### PR TITLE
[common] Provide fmt helper for consistent floating point output

### DIFF
--- a/common/fmt.h
+++ b/common/fmt.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <string_view>
 
 #include <fmt/format.h>
@@ -27,6 +28,18 @@ inline auto fmt_runtime(std::string_view s) {
 }
 #define DRAKE_FMT8_CONST
 #endif  // FMT_VERSION
+
+/** Returns `fmt::to_string(x)` but always with at least one digit after the
+decimal point. Different versions of fmt disagree on whether to omit the
+trailing ".0" when formatting integer-valued floating-point numbers. */
+template <typename T>
+std::string fmt_floating_point(T x) {
+  std::string result = fmt::format("{:#}", x);
+  if (result.back() == '.') {
+    result.push_back('0');
+  }
+  return result;
+}
 
 namespace internal::formatter_as {
 

--- a/common/test/fmt_test.cc
+++ b/common/test/fmt_test.cc
@@ -39,7 +39,7 @@ DRAKE_FORMATTER_AS(typename... Ts, sample, Pair<Ts...>, x, std::pair(x.t, x.u))
 namespace drake {
 namespace {
 
-// Spot check the for "format as" formatter.
+// Spot check for the "format as" formatter.
 GTEST_TEST(FmtTest, FormatAsFormatter) {
   const sample::Int plain{1};
   EXPECT_EQ(fmt::format("{}", plain), "1");
@@ -65,6 +65,17 @@ GTEST_TEST(FmtTest, TestPrinter) {
 
   const sample::Pair<int, int> pear{1, 2};
   EXPECT_EQ(testing::PrintToString(pear), "(1, 2)");
+}
+
+// Spot check for the floating point formatter.
+GTEST_TEST(FmtTest, FloatingPoint) {
+  EXPECT_EQ(fmt_floating_point(1.11), "1.11");
+  EXPECT_EQ(fmt_floating_point(1.1), "1.1");
+  EXPECT_EQ(fmt_floating_point(1.0), "1.0");
+
+  EXPECT_EQ(fmt_floating_point(1.11f), "1.11");
+  EXPECT_EQ(fmt_floating_point(1.1f), "1.1");
+  EXPECT_EQ(fmt_floating_point(1.0f), "1.0");
 }
 
 }  // namespace

--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -55,7 +55,7 @@ GTEST_TEST(TextLoggingTest, SmokeTestFormattable) {
 // Check that floating point values format sensibly.  We'll just test fmt
 // directly, since we know that spdlog uses it internally.
 GTEST_TEST(TextLoggingTest, FloatingPoint) {
-  EXPECT_EQ(fmt::format("{:#}", 1.0), "1.0");
+  EXPECT_EQ(fmt::format("{}", 1.1), "1.1");
   // This number is particularly challenging.
   EXPECT_EQ(fmt::format("{}", 0.009), "0.009");
 }

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -219,12 +219,9 @@ class YamlWriteArchive final {
     using T = typename NVP::value_type;
     const T& value = *nvp.value();
     if constexpr (std::is_floating_point_v<T>) {
-      // Different versions of fmt disagree on whether to omit the trailing
-      // ".0" when formatting integer-valued floating-point numbers.  Force
-      // the ".0" in all cases by using the "#" option for floats.  Also be
-      // sure to add the required leading period for special values.
-      auto scalar = internal::Node::MakeScalar(
-          fmt::format("{}{:#}", std::isfinite(value) ? "" : ".", value));
+      // We must be sure to add the required leading period for special values.
+      auto scalar = internal::Node::MakeScalar(fmt::format(
+          "{}{}", std::isfinite(value) ? "" : ".", fmt_floating_point(value)));
       scalar.SetTag(internal::JsonSchemaTag::kFloat);
       root_.Add(nvp.name(), std::move(scalar));
       return;

--- a/solvers/sdpa_free_format.cc
+++ b/solvers/sdpa_free_format.cc
@@ -887,11 +887,10 @@ bool GenerateSdpaImpl(const std::vector<BlockInX>& X_blocks,
       if (i > 0) {
         sdpa_file << " ";
       }
-      // Different versions of fmt disagree on whether to omit the trailing
-      // ".0" when formatting integer-valued floating-point numbers. Force
-      // the ".0" in all cases by using the "#" option for floats, so that
-      // our output is consistent on all platforms.
-      sdpa_file << fmt::format("{:#}", g[i]);
+      // Different versions of fmt disagree on whether to omit the trailing ".0"
+      // when formatting integer-valued floating-point numbers, so we must paper
+      // over it using a helper function.
+      sdpa_file << fmt_floating_point(g[i]);
     }
     sdpa_file << "\n";
     // block_start_rows[i] records the starting row index of the i'th block in
@@ -921,7 +920,7 @@ bool GenerateSdpaImpl(const std::vector<BlockInX>& X_blocks,
                     << " "
                     << i - block_start_row +
                            1 /* block column index, starts from 1*/
-                    << " " << fmt::format("{:#}", it.value()) << "\n";
+                    << " " << fmt_floating_point(it.value()) << "\n";
         }
       }
     }
@@ -937,7 +936,7 @@ bool GenerateSdpaImpl(const std::vector<BlockInX>& X_blocks,
                              1 /* block number, starts from 1 */
                       << " " << it.row() - block_start_row + 1 << " "
                       << j - block_start_row + 1 << " "
-                      << fmt::format("{:#}", it.value()) << "\n";
+                      << fmt_floating_point(it.value()) << "\n";
           }
         }
       }


### PR DESCRIPTION
Towards #19446.

See also https://github.com/fmtlib/fmt/issues/3456.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19454)
<!-- Reviewable:end -->
