### PR TITLE
Introduce SapConstraintJacobian

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_package_library(
         ":partial_permutation",
         ":sap_constraint",
         ":sap_constraint_bundle",
+        ":sap_constraint_jacobian",
         ":sap_contact_problem",
         ":sap_friction_cone_constraint",
         ":sap_holonomic_constraint",
@@ -53,6 +54,7 @@ drake_cc_library(
     srcs = ["sap_constraint.cc"],
     hdrs = ["sap_constraint.h"],
     deps = [
+        ":sap_constraint_jacobian",
         "//common:default_scalars",
         "//common:essential",
         "//common:unused",
@@ -75,6 +77,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "sap_constraint_jacobian",
+    srcs = ["sap_constraint_jacobian.cc"],
+    hdrs = ["sap_constraint_jacobian.h"],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+        "//multibody/contact_solvers:matrix_block",
+    ],
+)
+
+drake_cc_library(
     name = "sap_contact_problem",
     srcs = ["sap_contact_problem.cc"],
     hdrs = ["sap_contact_problem.h"],
@@ -92,6 +105,7 @@ drake_cc_library(
     hdrs = ["sap_holonomic_constraint.h"],
     deps = [
         ":sap_constraint",
+        ":sap_constraint_jacobian",
         "//common:default_scalars",
         "//common:essential",
     ],
@@ -103,6 +117,7 @@ drake_cc_library(
     hdrs = ["sap_limit_constraint.h"],
     deps = [
         ":sap_constraint",
+        ":sap_constraint_jacobian",
         "//common:default_scalars",
         "//common:essential",
     ],
@@ -114,6 +129,7 @@ drake_cc_library(
     hdrs = ["sap_friction_cone_constraint.h"],
     deps = [
         ":sap_constraint",
+        ":sap_constraint_jacobian",
         "//common:default_scalars",
         "//common:essential",
     ],

--- a/multibody/contact_solvers/sap/sap_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_constraint.cc
@@ -11,33 +11,8 @@ namespace contact_solvers {
 namespace internal {
 
 template <typename T>
-SapConstraint<T>::SapConstraint(int clique, VectorX<T> g, MatrixBlock<T> J)
-    : first_clique_(clique),
-      g_(std::move(g)),
-      first_clique_jacobian_(std::move(J)) {
-  DRAKE_THROW_UNLESS(clique >= 0);
-  DRAKE_THROW_UNLESS(constraint_function().size() >= 0);
-  DRAKE_THROW_UNLESS(first_clique_jacobian().rows() ==
-                     constraint_function().size());
-}
-
-template <typename T>
-SapConstraint<T>::SapConstraint(int first_clique, int second_clique,
-                                VectorX<T> g, MatrixBlock<T> J_first_clique,
-                                MatrixBlock<T> J_second_clique)
-    : first_clique_(first_clique),
-      second_clique_(second_clique),
-      g_(std::move(g)),
-      first_clique_jacobian_(std::move(J_first_clique)),
-      second_clique_jacobian_(std::move(J_second_clique)) {
-  DRAKE_THROW_UNLESS(first_clique >= 0);
-  DRAKE_THROW_UNLESS(second_clique >= 0);
-  DRAKE_THROW_UNLESS(first_clique != second_clique);
-  DRAKE_THROW_UNLESS(constraint_function().size() >= 0);
-  DRAKE_THROW_UNLESS(first_clique_jacobian().rows() ==
-                     second_clique_jacobian().rows());
-  DRAKE_THROW_UNLESS(constraint_function().size() ==
-                     first_clique_jacobian().rows());
+SapConstraint<T>::SapConstraint(SapConstraintJacobian<T> J) : J_(std::move(J)) {
+  DRAKE_THROW_UNLESS(J_.rows() > 0);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/sap/sap_constraint.h
+++ b/multibody/contact_solvers/sap/sap_constraint.h
@@ -8,6 +8,7 @@
 #include "drake/common/unused.h"
 #include "drake/common/value.h"
 #include "drake/multibody/contact_solvers/matrix_block.h"
+#include "drake/multibody/contact_solvers/sap/sap_constraint_jacobian.h"
 
 namespace drake {
 namespace multibody {
@@ -80,150 +81,79 @@ class SapConstraintData {
 /* This class serves to represent constraints supported by the SapSolver as
 described in [Castro et al., 2021].
 
-All SAP constraints are compliant. That is, SAP does not impose the hard
-constraint g(q, v, t) = 0 but rather applies a compliant force that drives the
-state towards g(q, v, t) = 0. More specifically, the impulse γ applied by a
-constraint in the SAP formulation admits the analytical form:
-  γ/δt = P(−k⋅g−cġ)                                                         (1)
-where δt is the discrete time step used in the formulation, k is the
-constraint's stiffness, c is its linear dissipation and P is a projection
-operator. For instance, for contact constraints, P projects the compliant
-impulse y = −k⋅g−cġ onto the friction cone, see the documentation of
-SapConstraint::Project() for details. We parameterize the linear dissipation c
-in terms of a "dissipation time scale" τ (in seconds) as c=τ⋅k.
+All SAP constraints are described by a convex cost function ℓ(vc), where vc is
+the constraint velocity. The constraint velocity (along with sign conventions
+used by specific constraints) is defined at construction given the constraint
+Jacobian J such that vc = J⋅v, where v are the generalized velocities of the
+SapContactProblem. The size of vc defines a fixed number nₑ of constraint
+equations, see num_constraint_equations() (E.g. 3 for contact constraints, 1 for
+a distance constraint).
 
-A particular constraint defines a fixed number nᵢ of constraint equations, see
-num_constraint_equations() (E.g. 3 for contact constraints, 1 for a distance
-constraint). Then γ, g, ġ in Eq. (1) are all vectors of size nᵢ and stiffness k
-and damping c are positive diagonal matrices of size nᵢ×nᵢ. Then the projection
-P projects vectors in the real nᵢ-space into vectors in the same space. Refer to
-Project()'s documentation for further details.
+In this formulation, constraint impulses are simply defined by:
+  γ(vc) = −∂ℓ/∂vc
+where γ is also a vector of size nₑ. The Hessian of the constraint is then
+given by:
+  G(vc) = −∂γ/∂vc = ∂²ℓ/∂vc²
+of size nₑ×nₑ, it is positive semi-definite given the cost function ℓ(vc) is
+convex.
 
-The constraint's Jacobian J is defined such that ġ = J⋅v + b where v are the
-generalized velocities of the system and b is the bias term b = ∂g/∂t. When a
-constraint is instantiated, constraint function g and Jacobian J are provided at
-construction for the state of the mechanical system at the previous (current)
-time step. Therefore an instance of this class is a function of the state of the
-dynamical system.
-
-In general a constraint will couple the degrees of freedom of two cliques
-(please refer to SapContactProblem's documentation for a definition of
-cliques). Therefore ġ = J⋅v = J₁⋅v₁ + J₂⋅v₂ where v₁ and v₂ correspond to the
-vector of generalized velocities for the first and second clique respectively
-(which clique is designated as first or second is arbitrary). Similarly, J₁ and
-J₂ are the non-zero blocks of the full Jacobian J that correspond to
-contributions from the first and second cliques respectively. A constraint can
-also involve only a single clique. Examples include a coupler constraint between
-DOFs in a single clique or a contact constraint with the world (the world has no
-DOFs and therefore has no clique.) For the case of a single clique constraint,
-only one clique and a single block J₁ needs to be provided at construction. For
-details, refer to the documentation for this class's constructors.
-
-TODO(amcastro-tri): consider extension to support constraints among more than
-two cliques, see issue #16575.
+Specific constraint types will provide a definition for ℓ(vc), γ(vc) and G(vc)
+with the implementation of DoCalcCost(), DoCalcImpulse(), and DoCalcHessian(),
+respectively.
 
 @tparam_nonsymbolic_scalar */
 template <typename T>
 class SapConstraint {
  public:
   /* We do not allow copy, move, or assignment generally to avoid slicing.
-    Protected copy construction is enabled for sub-classes to use in their
-    implementation of DoClone(). */
+   Protected copy construction is enabled for sub-classes to use in their
+   implementation of DoClone(). */
   //@{
   SapConstraint& operator=(const SapConstraint&) = delete;
   SapConstraint(SapConstraint&&) = delete;
   SapConstraint& operator=(SapConstraint&&) = delete;
   //@}
 
-  /* Constructor for a constraint among DOFs within a single `clique`.
-   @param[in] clique
-     Index of a clique in the SapContactProblem where this constraint will be
-     added. It must be non-negative or an exception is thrown.
-   @param[in] g
-     Value of the constraint function (see this class's documentation) evaluated
-     at the previous time step state of the mechanical system. g.size()
-     corresponds to the number of constraint equations, see
-     num_constraint_equations(). The size must be strictly positive or an
-     exception is thrown.
-   @param[in] J
-     Jacobian of g with respect to the DOFs for `clique` only. J.rows() must
-     equal g.size() or an exception is thrown. J.cols() must match the number of
-     generalized velocities for `clique`, see
-     SapContactProblem::num_velocities(). This condition is enforced when the
-     constraint is added to the contact problem instead of during construction
-     here, see SapContactProblem::AddConstraint(). */
-  SapConstraint(int clique, VectorX<T> g, MatrixBlock<T> J);
+  /* Constructor for a SAP constraint given its Jacobian J.
+   SAP constraints are defined by their convex cost ℓ(vc) function of the
+   constraint velocity vc. The constraint velocity in turn is defined by the
+   constraint's Jacobian J such that vc = J⋅v, where v are the generalized
+   velocities of the contact problem.
 
-  /* Alternative signature for the constructor for a constraint within a single
-   clique. that takes a dense Jacobian. */
-  SapConstraint(int clique, VectorX<T> g, MatrixX<T> J)
-      : SapConstraint(clique, std::move(g), MatrixBlock<T>(std::move(J))) {}
-
-  /* Constructor for a constraint among DOFs between two cliques.
-   @param[in] first_clique
-     Index of a clique in the SapContactProblem where this constraint will be
-     added. It must be non-negative or an exception is thrown.
-   @param[in] second_clique
-     Index of a clique in the SapContactProblem where this constraint will be
-     added. It must be non-negative and different from first_clique or an
-     exception is thrown.
-   @param[in] g
-     Value of the constraint function (see this class's documentation) evaluated
-     at the previous time step state of the mechanical system. g.size()
-     corresponds to the number of constraint equations, see
-     num_constraint_equations(). The size must be strictly positive or an
-     exception is thrown.
-   @param[in] J_first_clique
-     Jacobian of g with respect to the DOFs of the first clique only.
-     J_first_clique.rows() must equal g.size() or an exception is thrown.
-     J_first_clique.cols() must match the number of generalized velocities for
-     `first_clique`, see SapContactProblem::num_velocities(). This condition is
-     enforced when the constraint is added to the contact problem instead of
-     during construction here, see SapContactProblem::AddConstraint()
-   @param[in] J_second_clique
-     Jacobian of g with respect to the DOFs of the second clique only.
-     J_second_clique.rows() must equal g.size() or an exception is thrown.
-     J_second_clique.cols() must match the number of generalized velocities for
-     `second_clique`, see SapContactProblem::num_velocities(), though this
-     condition is not enforced at construction but when the constraint is added
-     to the contact problem, see SapContactProblem::AddConstraint(). */
-  SapConstraint(int first_clique, int second_clique, VectorX<T> g,
-                MatrixBlock<T> J_first_clique, MatrixBlock<T> J_second_clique);
-
-  /* Alternative signature for the constructor for constraint between two
-   cliques that takes dense Jacobians. */
-  SapConstraint(int first_clique, int second_clique, VectorX<T> g,
-                MatrixX<T> J_first_clique, MatrixX<T> J_second_clique)
-      : SapConstraint(first_clique, second_clique, std::move(g),
-                      MatrixBlock<T>(std::move(J_first_clique)),
-                      MatrixBlock<T>(std::move(J_second_clique))) {}
+   @throws if J.rows() equals zero. */
+  explicit SapConstraint(SapConstraintJacobian<T> J);
 
   virtual ~SapConstraint() = default;
 
   /* Number of constraint equations. */
-  int num_constraint_equations() const { return g_.size(); }
+  int num_constraint_equations() const { return J_.rows(); }
 
   /* Number of participating cliques. It will always return either one (1) or
    two (2). */
-  int num_cliques() const { return second_clique_ < 0 ? 1 : 2; }
+  int num_cliques() const { return J_.num_cliques(); }
+
+  int num_velocities(int clique) const {
+    DRAKE_THROW_UNLESS(0 <= clique && clique < num_cliques());
+    return J_.clique_jacobian(clique).cols();
+  }
 
   /* Index of the first (and maybe only) participating clique. Always a
    non-negative number. */
-  int first_clique() const { return first_clique_; }
+  int first_clique() const { return J_.clique(0); }
 
   /* Index of the second participating clique. It throws an exception if
    num_cliques() == 1. */
   int second_clique() const {
     if (num_cliques() == 1)
       throw std::logic_error("This constraint only involves a single clique.");
-    return second_clique_;
+    return J_.clique(1);
   }
 
-  const VectorX<T>& constraint_function() const { return g_; }
+  const SapConstraintJacobian<T>& jacobian() const { return J_; }
 
   /* Returns the Jacobian with respect to the DOFs of the first clique. */
   const MatrixBlock<T>& first_clique_jacobian() const {
-    return first_clique_jacobian_;
+    return J_.clique_jacobian(0);
   }
 
   /* Returns the Jacobian with respect to the DOFs of the second clique.
@@ -231,7 +161,7 @@ class SapConstraint {
   const MatrixBlock<T>& second_clique_jacobian() const {
     if (num_cliques() == 1)
       throw std::logic_error("This constraint only involves a single clique.");
-    return second_clique_jacobian_;
+    return J_.clique_jacobian(1);
   }
 
   /* Makes data used by this constraint to perform computations. Different
@@ -388,11 +318,7 @@ class SapConstraint {
   }
 
  private:
-  int first_clique_{-1};
-  int second_clique_{-1};
-  VectorX<T> g_;
-  MatrixBlock<T> first_clique_jacobian_;
-  MatrixBlock<T> second_clique_jacobian_;
+  SapConstraintJacobian<T> J_;
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_constraint_jacobian.cc
+++ b/multibody/contact_solvers/sap/sap_constraint_jacobian.cc
@@ -1,0 +1,46 @@
+#include "drake/multibody/contact_solvers/sap/sap_constraint_jacobian.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+template <typename T>
+SapConstraintJacobian<T>::SapConstraintJacobian(int clique, MatrixBlock<T> J) {
+  DRAKE_THROW_UNLESS(clique >= 0);
+  clique_jacobians_.emplace_back(clique, std::move(J));
+}
+
+template <typename T>
+SapConstraintJacobian<T>::SapConstraintJacobian(int clique, MatrixX<T> J)
+    : SapConstraintJacobian(clique, MatrixBlock<T>(std::move(J))) {}
+
+template <typename T>
+SapConstraintJacobian<T>::SapConstraintJacobian(
+    int first_clique, MatrixBlock<T> J_first_clique, int second_clique,
+    MatrixBlock<T> J_second_clique) {
+  DRAKE_THROW_UNLESS(first_clique >= 0);
+  DRAKE_THROW_UNLESS(second_clique >= 0);
+  DRAKE_THROW_UNLESS(first_clique != second_clique);
+  DRAKE_THROW_UNLESS(J_first_clique.rows() == J_second_clique.rows());
+  clique_jacobians_.reserve(2);
+  clique_jacobians_.emplace_back(first_clique, std::move(J_first_clique));
+  clique_jacobians_.emplace_back(second_clique, std::move(J_second_clique));
+}
+
+template <typename T>
+SapConstraintJacobian<T>::SapConstraintJacobian(int first_clique,
+                                                MatrixX<T> J_first_clique,
+                                                int second_clique,
+                                                MatrixX<T> J_second_clique)
+    : SapConstraintJacobian(
+          first_clique, MatrixBlock<T>(std::move(J_first_clique)),
+          second_clique, MatrixBlock<T>(std::move(J_second_clique))) {}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::internal::SapConstraintJacobian)

--- a/multibody/contact_solvers/sap/sap_constraint_jacobian.h
+++ b/multibody/contact_solvers/sap/sap_constraint_jacobian.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/matrix_block.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+template <typename T>
+struct CliqueJacobian {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CliqueJacobian);
+  CliqueJacobian(int c, MatrixBlock<T>&& b) : clique(c), block(std::move(b)) {}
+  int clique;
+  MatrixBlock<T> block;
+};
+
+// TODO(amcastro-tri): consider extension to support constraints among more than
+// two cliques, see issue #16575.
+
+/* Class to abstract the specific structure of Jacobian matrices for SAP
+ constraints.
+
+ In general, the constraint velocity vc is given as vc = J⋅v = ∑ᵢ₌₁ᴺJᵢ⋅vᵢ where
+ vᵢ is the subvector in the vector of generalized velocities for the i-th clique
+ (the ordering of the cliques is arbitrary) and Jᵢ is the non-zero block of the
+ full constraint Jacobian J that correspond to contributions from the i-th
+ clique. A constraint can only involve a single clique or two cliques, so N = 1
+ or 2.
+
+ This class exploits the sparsity in the constraint Jacobian by only storing the
+ (at most 2) nonzero Jacobian blocks (as MatrixBlock). Further sparsity
+ structure may exist within a single Jacobian block. See MatrixBlock for
+ details.
+
+ Therefore, the Jacobian matrix for a SAP constraint encodes sparsity at two
+ levels:
+  1. Per clique: This class stores a matrix (a MatrixBlock) per each clique that
+     participates in the constraint. As explained above, only up to two cliques
+     can participate in a given constraint.
+  2. Within the clique: The MatrixBlock for a given clique might in turn have
+     its own sparsity structure within the clique. See MatrixBlock for details.
+
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class SapConstraintJacobian {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SapConstraintJacobian);
+
+  /* Constraint Jacobian involving a single clique.
+   @throws if `clique` is negative. */
+  SapConstraintJacobian(int clique, MatrixBlock<T> J);
+
+  /* Constraint Jacobian involving a single clique.
+   Alternative signature taking a dense matrix block. */
+  SapConstraintJacobian(int clique, MatrixX<T> J);
+
+  /* Constraint Jacobian involving two cliques.
+   @throws if `first_clique` is negative.
+   @throws if `second_clique` is negative.
+   @throws first_clique and second_clique are equal.
+   @throws if J_first_clique and J_second_clique have different number of rows.
+  */
+  SapConstraintJacobian(int first_clique, MatrixBlock<T> J_first_clique,
+                        int second_clique, MatrixBlock<T> J_second_clique);
+
+  /* Constraint Jacobian involving two cliques.
+   Alternative signature taking dense matrix blocks. */
+  SapConstraintJacobian(int first_clique, MatrixX<T> J_first_clique,
+                        int second_clique, MatrixX<T> J_second_clique);
+
+  /* Returns the number of rows in the constraint Jacobian. Each clique block
+   has the same number of rows. */
+  int rows() const {
+    // N.B. Constructions guarantees both blocks have the same number of rows.
+    // Moreover, the first block always exists.
+    return clique_jacobians_[0].block.rows();
+  }
+
+  /* Returns the number of cliques, either one or two. */
+  int num_cliques() const { return clique_jacobians_.size(); }
+
+  /* Returns the clique index for the first clique (local_index = 0) or the
+   second clique (local_index = 1). Refer to the constructor's documentation for
+   details. */
+  int clique(int local_clique) const {
+    DRAKE_DEMAND(0 <= local_clique && local_clique < num_cliques());
+    return clique_jacobians_[local_clique].clique;
+  }
+
+  /* Returns the Jacobian block for the first clique (local_index = 0) or the
+   second clique (local_index = 1). */
+  const MatrixBlock<T>& clique_jacobian(int local_clique) const {
+    DRAKE_DEMAND(local_clique < num_cliques());
+    return clique_jacobians_[local_clique].block;
+  }
+
+ private:
+  // Blocks for each block. Up to two entries only.
+  std::vector<CliqueJacobian<T>> clique_jacobians_;
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
@@ -12,39 +12,15 @@ namespace contact_solvers {
 namespace internal {
 
 template <typename T>
-SapFrictionConeConstraint<T>::SapFrictionConeConstraint(int clique,
-                                                        MatrixBlock<T> J,
-                                                        const T& phi0,
-                                                        const Parameters& p)
-    : SapConstraint<T>(clique, Vector3<T>(0.0, 0.0, phi0), std::move(J)),
-      parameters_(p),
-      phi0_(phi0) {
-  DRAKE_DEMAND(clique >= 0);
-  DRAKE_DEMAND(p.mu >= 0.0);
-  DRAKE_DEMAND(p.stiffness > 0.0);
-  DRAKE_DEMAND(p.dissipation_time_scale >= 0.0);
-  DRAKE_DEMAND(p.beta >= 0.0);
-  DRAKE_DEMAND(p.sigma > 0.0);
-  DRAKE_DEMAND(this->first_clique_jacobian().rows() == 3);
-}
-
-template <typename T>
 SapFrictionConeConstraint<T>::SapFrictionConeConstraint(
-    int clique0, int clique1, MatrixBlock<T> J0, MatrixBlock<T> J1,
-    const T& phi0, const Parameters& p)
-    : SapConstraint<T>(clique0, clique1, Vector3<T>(0.0, 0.0, phi0),
-                       std::move(J0), std::move(J1)),
-      parameters_(p),
-      phi0_(phi0) {
-  DRAKE_DEMAND(clique0 >= 0);
-  DRAKE_DEMAND(clique1 >= 0);
+    SapConstraintJacobian<T> J, const T& phi0, const Parameters& p)
+    : SapConstraint<T>(std::move(J)), parameters_(p), phi0_(phi0) {
   DRAKE_DEMAND(p.mu >= 0.0);
   DRAKE_DEMAND(p.stiffness > 0.0);
   DRAKE_DEMAND(p.dissipation_time_scale >= 0.0);
   DRAKE_DEMAND(p.beta >= 0.0);
   DRAKE_DEMAND(p.sigma > 0.0);
-  DRAKE_DEMAND(this->first_clique_jacobian().rows() == 3);
-  DRAKE_DEMAND(this->second_clique_jacobian().rows() == 3);
+  DRAKE_DEMAND(this->jacobian().rows() == 3);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
@@ -6,6 +6,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/sap/sap_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_constraint_jacobian.h"
 
 namespace drake {
 namespace multibody {
@@ -182,47 +183,16 @@ class SapFrictionConeConstraint final : public SapConstraint<T> {
     double sigma{1.0e-3};
   };
 
-  /* Constructs a contact constraint for the case in which only a single clique
-   is involved. E.g. contact with the world or self-contact.
-   @param[in] clique The clique involved in the contact. Must be non-negative.
-   @param[in] J The Jacobian, such that vc = J⋅v. It must have three rows or an
-   exception is thrown.
-   @param[in] phi0 The value of the signed distance at the previous time step.
-   @param[in] parameters Constraint parameters. See Parameters for details. */
-  SapFrictionConeConstraint(int clique, MatrixBlock<T> J, const T& phi0,
+  /* Constructs a contact constraint given its Jacobian and signed distance at
+   the current configuration.
+   @param[in] J The contact Jacobian, which defines the contact velocity `vc` as
+   vc = J⋅v.
+   @param[in] phi0 The value of the signed distance at the current
+   configuration.
+   @param[in] parameters Constraint parameters. See Parameters for details.
+   @pre J has three rows. */
+  SapFrictionConeConstraint(SapConstraintJacobian<T> J, const T& phi0,
                             const Parameters& parameters);
-
-  /* Alternative constructor for a contact constraint involving a single clique
-   that takes a dense Jacobian. */
-  SapFrictionConeConstraint(int clique, MatrixX<T> J, const T& phi0,
-                            const Parameters& parameters)
-      : SapFrictionConeConstraint(clique, MatrixBlock<T>(std::move(J)), phi0,
-                                  parameters) {}
-
-  /* Constructs a contact constraint for the case in which two cliques
-   are involved.
-   @param[in] clique0 First clique involved in the contact. Must be
-   non-negative.
-   @param[in] clique1 Second clique involved in the contact. Must be
-   non-negative.
-   @param[in] J0 The Jacobian w.r.t. to the first clique's generalized
-   velocities. It must have three rows or an exception is thrown.
-   @param[in] J1 The Jacobian w.r.t. to the second clique's generalized
-   velocities. It must have three rows or an exception is thrown.
-   @param[in] phi0 The value of the signed distance at the previous time step.
-   @param[in] parameters Constraint parameters. See Parameters for details. */
-  SapFrictionConeConstraint(int clique0, int clique1, MatrixBlock<T> J0,
-                            MatrixBlock<T> J1, const T& phi0,
-                            const Parameters& parameters);
-
-  /* Alternative constructor for a contact constraint involving two cliques
-   that takes a dense Jacobian. */
-  SapFrictionConeConstraint(int clique0, int clique1, MatrixX<T> J0,
-                            MatrixX<T> J1, const T& phi0,
-                            const Parameters& parameters)
-      : SapFrictionConeConstraint(
-            clique0, clique1, MatrixBlock<T>(std::move(J0)),
-            MatrixBlock<T>(std::move(J1)), phi0, parameters) {}
 
   /* Returns the coefficient of friction for this constraint. */
   const T& mu() const { return parameters_.mu; }

--- a/multibody/contact_solvers/sap/sap_holonomic_constraint.h
+++ b/multibody/contact_solvers/sap/sap_holonomic_constraint.h
@@ -123,74 +123,32 @@ class SapHolonomicConstraint final : public SapConstraint<T> {
     double beta_{0.1};
   };
 
-  /* Constructs a holonomic constraint involving a single clique. The bias term
-   b is zero.
-   @param[in] clique The clique involved in the constraint.
+  /* Constructs a holonomic constraint with zero bias term.
    @param[in] g The value of the constraint function.
    @param[in] J The Jacobian w.r.t. to the clique's generalized velocities.
    @param[in] parameters Constraint parameters. See Parameters for details.
 
    @pre clique is non-negative.
    @pre g.size() == J.rows() == parameters.num_constraint_equations(). */
-  SapHolonomicConstraint(int clique, VectorX<T> g, MatrixBlock<T> J,
+  SapHolonomicConstraint(VectorX<T> g, SapConstraintJacobian<T> J,
                          Parameters parameters);
 
-  /* Alternative holonomic constraint constructor for a single clique that takes
-   a dense Jacobian and zero bias. */
-  SapHolonomicConstraint(int clique, VectorX<T> g, MatrixX<T> J,
-                         Parameters parameters)
-      : SapHolonomicConstraint(clique, std::move(g),
-                               MatrixBlock<T>(std::move(J)), parameters) {}
-
-  /* Constructs a holonomic constraint involving two cliques. The bias term b is
-   zero.
-   @param[in] first_clique First clique involved in the constraint.
-   @param[in] second_clique Second clique involved in the constraint.
-   @param[in] g The value of the constraint function.
-   @param[in] J_first_clique The Jacobian w.r.t. to the first clique's
-   generalized velocities.
-   @param[in] J_second_clique The Jacobian w.r.t. to the second clique's
-   generalized velocities.
-   @param[in] parameters Constraint parameters. See Parameters for details.
-
-   @pre first_clique and second_clique are non-negative.
-   @pre g.size() == J_first_clique.rows() == J_second_clique.rows() ==
-   parameters.num_constraint_equations(). */
-  SapHolonomicConstraint(int first_clique, int second_clique, VectorX<T> g,
-                         MatrixBlock<T> J_first_clique,
-                         MatrixBlock<T> J_second_clique, Parameters parameters);
-
-  /* Alternative holonomic constraint constructor for two cliques that takes
-   dense Jacobians and zero bias. */
-  SapHolonomicConstraint(int first_clique, int second_clique, VectorX<T> g,
-                         MatrixX<T> J_first_clique, MatrixX<T> J_second_clique,
-                         Parameters parameters)
-      : SapHolonomicConstraint(first_clique, second_clique, std::move(g),
-                               MatrixBlock<T>(std::move(J_first_clique)),
-                               MatrixBlock<T>(std::move(J_second_clique)),
-                               parameters) {}
-
-  /* Single clique holonomic constraints with non-zero bias.
-   @param[in] clique The clique involved in the constraint.
+  /* Constructs a holonomic constraint with a non-zero bias b.
    @param[in] g The value of the constraint function.
    @param[in] J The Jacobian w.r.t. to the clique's generalized velocities.
    @param[in] b The bias term, such that ġ = J⋅v + b.
    @param[in] parameters Constraint parameters. See Parameters for details.
 
    @pre clique is non-negative.
-   @pre g.size() == J.rows() == parameters.num_constraint_equations(). */
-  SapHolonomicConstraint(int clique, VectorX<T> g, MatrixBlock<T> J,
-                         VectorX<T> b, Parameters parameters);
-
-  /* Alternative holonomic constraint constructor for single clique that takes
-   a dense Jacobian and non-zero bias. */
-  SapHolonomicConstraint(int clique, VectorX<T> g, MatrixX<T> J, VectorX<T> b,
-                         Parameters parameters)
-      : SapHolonomicConstraint(clique, std::move(g),
-                               MatrixBlock<T>(std::move(J)), std::move(b),
-                               parameters) {}
+   @pre g.size() == J.rows() == b.size() ==
+   parameters.num_constraint_equations(). */
+  SapHolonomicConstraint(VectorX<T> g, SapConstraintJacobian<T> J, VectorX<T> b,
+                         Parameters parameters);
 
   const Parameters& parameters() const { return parameters_; }
+
+  /* Returns the constraint function provided at construction. */
+  const VectorX<T>& constraint_function() const { return g_; }
 
   /* Returns the holonomic constraint bias b. */
   const VectorX<T>& bias() const { return bias_; }
@@ -220,8 +178,9 @@ class SapHolonomicConstraint final : public SapConstraint<T> {
         new SapHolonomicConstraint<T>(*this));
   }
 
-  Parameters parameters_;
+  VectorX<T> g_;
   VectorX<T> bias_;
+  Parameters parameters_;
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_limit_constraint.h
+++ b/multibody/contact_solvers/sap/sap_limit_constraint.h
@@ -204,8 +204,8 @@ class SapLimitConstraint final : public SapConstraint<T> {
 
   /* Computes the constraint Jacobian, independent of the configuration for this
    constraint. */
-  static MatrixX<T> CalcConstraintJacobian(int clique_dof, int clique_nv,
-                                           const T& ql, const T& qu);
+  static SapConstraintJacobian<T> CalcConstraintJacobian(
+      int clique, int clique_dof, int clique_nv, const T& ql, const T& qu);
 
   /* Implementations of SapConstraint NVI functions. */
   std::unique_ptr<AbstractValue> DoMakeData(
@@ -226,6 +226,7 @@ class SapLimitConstraint final : public SapConstraint<T> {
   Parameters parameters_;
   int clique_dof_{-1};  // Initialized to an invalid value.
   T q0_{};              // position at the configuration from construction.
+  VectorX<T> g_;        // Constraint function g. See CalcConstraintFunction().
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
@@ -44,14 +44,12 @@ template <typename T>
 class TestConstraint final : public SapConstraint<T> {
  public:
   TestConstraint(int clique, int size, T param)
-      : SapConstraint<T>(clique, VectorX<T>::Zero(size),
-                         MakeJacobian(size, clique + 1)),
+      : SapConstraint<T>({clique, MakeJacobian(size, clique + 1)}),
         param_(param) {}
 
   TestConstraint(int clique0, int clique1, int size, T param)
-      : SapConstraint<T>(clique0, clique1, VectorX<T>::Zero(size),
-                         MakeJacobian(size, clique0 + 1),
-                         MakeJacobian(size, clique1 + 1)),
+      : SapConstraint<T>({clique0, MakeJacobian(size, clique0 + 1), clique1,
+                          MakeJacobian(size, clique1 + 1)}),
         param_(param) {}
 
   // Implements a fake projection operation where the result is given by:

--- a/multibody/contact_solvers/sap/test/sap_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_test.cc
@@ -32,14 +32,13 @@ const MatrixXd J34 =
 class TestConstraint final : public SapConstraint<double> {
  public:
   // These constructor set up an arbitrary constraint for one and two cliques.
-  TestConstraint(int clique, VectorXd g, MatrixXd J)
-      : SapConstraint<double>(clique, std::move(g), std::move(J)) {}
+  TestConstraint(int clique, MatrixXd J)
+      : SapConstraint<double>({clique, std::move(J)}) {}
 
-  TestConstraint(int first_clique, int second_clique, VectorXd g,
-                 MatrixXd J_first_clique, MatrixXd J_second_clique)
-      : SapConstraint<double>(first_clique, second_clique, std::move(g),
-                              std::move(J_first_clique),
-                              std::move(J_second_clique)) {}
+  TestConstraint(int first_clique, int second_clique, MatrixXd J_first_clique,
+                 MatrixXd J_second_clique)
+      : SapConstraint<double>({first_clique, std::move(J_first_clique),
+                               second_clique, std::move(J_second_clique)}) {}
 
   // N.B no-op overloads to allow us compile this testing constraint. These
   // methods are only tested for specific derived classes, not in this file.
@@ -63,80 +62,62 @@ class TestConstraint final : public SapConstraint<double> {
 };
 
 GTEST_TEST(SapConstraint, SingleCliqueConstraint) {
-  TestConstraint c(12, Vector3d(1., 2., 3), J32);
+  TestConstraint c(12, J32);
   EXPECT_EQ(c.num_constraint_equations(), 3);
   EXPECT_EQ(c.num_cliques(), 1);
   EXPECT_EQ(c.first_clique(), 12);
   EXPECT_THROW(c.second_clique(), std::exception);
-  EXPECT_EQ(c.constraint_function(), Vector3d(1., 2., 3));
   EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(), J32);
   EXPECT_THROW(c.second_clique_jacobian(), std::exception);
 }
 
 GTEST_TEST(SapConstraint, TwoCliquesConstraint) {
-  TestConstraint c(11, 7, Vector3d(1., 2., 3), J32, J34);
+  TestConstraint c(11, 7, J32, J34);
   EXPECT_EQ(c.num_constraint_equations(), 3);
   EXPECT_EQ(c.num_cliques(), 2);
   EXPECT_EQ(c.first_clique(), 11);
   EXPECT_EQ(c.second_clique(), 7);
-  EXPECT_EQ(c.constraint_function(), Vector3d(1., 2., 3));
   EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(), J32);
   EXPECT_EQ(c.second_clique_jacobian().MakeDenseMatrix(), J34);
 }
 
 GTEST_TEST(SapConstraint, SingleCliqueConstraintWrongArguments) {
   // Negative clique.
-  EXPECT_THROW(TestConstraint c(-1, Vector2d(1., 2.), J32), std::exception);
-  // g.size() != J.rows().
-  EXPECT_THROW(TestConstraint c(12, Vector2d(1., 2.), J32), std::exception);
-  // g.size() = 0.
-  EXPECT_THROW(TestConstraint c(12, VectorXd(), J32), std::exception);
+  EXPECT_THROW(TestConstraint c(-1, J32), std::exception);
   // J.size() = 0.
-  EXPECT_THROW(TestConstraint c(12, Vector2d(1., 2.), MatrixXd()),
-               std::exception);
+  EXPECT_THROW(TestConstraint c(12, MatrixXd()), std::exception);
 }
 
 GTEST_TEST(SapConstraint, TwoCliquesConstraintWrongArguments) {
   // Negative first clique.
-  EXPECT_THROW(TestConstraint c(-1, 7, Vector3d(1., 2., 3), J32, J34),
-               std::exception);
+  EXPECT_THROW(TestConstraint c(-1, 7, J32, J34), std::exception);
   // Negative second clique.
-  EXPECT_THROW(TestConstraint c(1, -1, Vector3d(1., 2., 3), J32, J34),
-               std::exception);
+  EXPECT_THROW(TestConstraint c(1, -1, J32, J34), std::exception);
   // Equal cliques.
-  EXPECT_THROW(TestConstraint c(5, 5, Vector3d(1., 2., 3), J32, J34),
-               std::exception);
-  // g.size() != J.rows().
-  EXPECT_THROW(TestConstraint c(11, 7, Vector2d(1., 2.), J32, J34),
-               std::exception);
-  // g.size() = 0.
-  EXPECT_THROW(TestConstraint c(11, 7, VectorXd(), J32, J34), std::exception);
+  EXPECT_THROW(TestConstraint c(5, 5, J32, J34), std::exception);
   // J_first.rows() != J_second.rows().
-  EXPECT_THROW(
-      TestConstraint c(11, 7, Vector3d(1., 2., 3), J32, MatrixXd::Zero(1, 4)),
-      std::exception);
+  EXPECT_THROW(TestConstraint c(11, 7, J32, MatrixXd::Zero(1, 4)),
+               std::exception);
 }
 
 GTEST_TEST(SapConstraint, SingleCliqueConstraintClone) {
-  TestConstraint c(12, Vector3d(1., 2., 3), J32);
+  TestConstraint c(12, J32);
   std::unique_ptr<SapConstraint<double>> clone = c.Clone();
   EXPECT_EQ(clone->num_constraint_equations(), 3);
   EXPECT_EQ(clone->num_cliques(), 1);
   EXPECT_EQ(clone->first_clique(), 12);
   EXPECT_THROW(clone->second_clique(), std::exception);
-  EXPECT_EQ(clone->constraint_function(), Vector3d(1., 2., 3));
   EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
   EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
 }
 
 GTEST_TEST(SapConstraint, TwoCliquesConstraintClone) {
-  TestConstraint c(11, 7, Vector3d(1., 2., 3), J32, J34);
+  TestConstraint c(11, 7, J32, J34);
   std::unique_ptr<SapConstraint<double>> clone = c.Clone();
   EXPECT_EQ(clone->num_constraint_equations(), 3);
   EXPECT_EQ(clone->num_cliques(), 2);
   EXPECT_EQ(clone->first_clique(), 11);
   EXPECT_EQ(clone->second_clique(), 7);
-  EXPECT_EQ(clone->constraint_function(), Vector3d(1., 2., 3));
   EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
   EXPECT_EQ(clone->second_clique_jacobian().MakeDenseMatrix(), J34);
 }

--- a/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
@@ -39,17 +39,16 @@ class TestConstraint final : public SapConstraint<double> {
   // Constructor for a constraint on a single clique.
   TestConstraint(int num_constraint_equations, int clique, int clique_nv)
       : SapConstraint<double>(
-            clique, VectorXd::Zero(num_constraint_equations),
-            MatrixXd::Zero(num_constraint_equations, clique_nv)) {}
+            {clique, MatrixXd::Zero(num_constraint_equations, clique_nv)}) {}
 
   // Constructor for a constraint between two cliques.
   TestConstraint(int num_constraint_equations, int first_clique,
                  int first_clique_nv, int second_clique, int second_clique_nv)
       : SapConstraint<double>(
-            first_clique, second_clique,
-            VectorXd::Zero(num_constraint_equations),
-            MatrixXd::Zero(num_constraint_equations, first_clique_nv),
-            MatrixXd::Zero(num_constraint_equations, second_clique_nv)) {}
+            {first_clique,
+             MatrixXd::Zero(num_constraint_equations, first_clique_nv),
+             second_clique,
+             MatrixXd::Zero(num_constraint_equations, second_clique_nv)}) {}
 
   // N.B no-op overloads to allow us compile this testing constraint. These
   // methods are only tested for specific derived classes, not in this file.

--- a/multibody/contact_solvers/sap/test/sap_limit_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_limit_constraint_test.cc
@@ -117,7 +117,6 @@ TEST_P(SapLimitConstraintTest, Construction) {
   EXPECT_EQ(dut_->num_cliques(), 1);
   EXPECT_EQ(dut_->first_clique(), clique_);
   EXPECT_THROW(dut_->second_clique(), std::exception);
-  EXPECT_EQ(dut_->constraint_function(), MakeExpectedConstraintFunction());
   EXPECT_EQ(dut_->first_clique_jacobian().MakeDenseMatrix(),
             MakeExpectedJacobian());
   EXPECT_THROW(dut_->second_clique_jacobian(), std::exception);
@@ -139,9 +138,8 @@ TEST_P(SapLimitConstraintTest, CalcBias) {
   std::unique_ptr<AbstractValue> abstract_data =
       dut_->MakeData(time_step, delassus_approximation);
   const auto& data = abstract_data->get_value<SapLimitConstraintData<double>>();
-
   const VectorXd v_hat_expected =
-      -dut_->constraint_function() / (time_step + dissipation_time_scale);
+      -MakeExpectedConstraintFunction() / (time_step + dissipation_time_scale);
   EXPECT_TRUE(CompareMatrices(data.v_hat(), v_hat_expected,
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::relative));
@@ -292,7 +290,6 @@ TEST_P(SapLimitConstraintTest, Clone) {
   EXPECT_EQ(clone->num_cliques(), 1);
   EXPECT_EQ(clone->first_clique(), clique_);
   EXPECT_THROW(clone->second_clique(), std::exception);
-  EXPECT_EQ(clone->constraint_function(), dut_->constraint_function());
   EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(),
             dut_->first_clique_jacobian().MakeDenseMatrix());
   EXPECT_THROW(clone->second_clique_jacobian(), std::exception);

--- a/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
@@ -45,13 +45,14 @@ GTEST_TEST(SapAutoDiffTest, SolveWithGuess) {
   constexpr double kPhi0 = 0.1;
   SapFrictionConeConstraint<AutoDiffXd>::Parameters parameters;
   parameters.stiffness = 1.0;
-  MatrixX<AutoDiffXd> J =
-      MatrixX<AutoDiffXd>::Ones(kNumConstraintEquations, kNumDofs);
+  SapConstraintJacobian<AutoDiffXd> J(
+      kCliqueIndex,
+      MatrixX<AutoDiffXd>::Ones(kNumConstraintEquations, kNumDofs));
   SapContactProblem<AutoDiffXd> contact_problem_with_constraint(
       std::move(contact_problem_without_constraint));
   contact_problem_with_constraint.AddConstraint(
       std::make_unique<SapFrictionConeConstraint<AutoDiffXd>>(
-          kCliqueIndex, std::move(J), kPhi0, parameters));
+          std::move(J), kPhi0, parameters));
   DRAKE_EXPECT_THROWS_MESSAGE(
       sap.SolveWithGuess(contact_problem_with_constraint, v_guess, &result),
       ".*Only.*double is supported.*");

--- a/multibody/contact_solvers/sap/test/sap_solver_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_test.cc
@@ -189,11 +189,14 @@ class PizzaSaverProblem {
     MatrixXd J;  // Full system Jacobian for the three contacts.
     CalcContactJacobian(q0(3), &J);
     problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<double>>(
-        0, J.middleRows(0, 3), phi0, parameters));
+        SapConstraintJacobian<double>{0, J.middleRows(0, 3)}, phi0,
+        parameters));
     problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<double>>(
-        0, J.middleRows(3, 3), phi0, parameters));
+        SapConstraintJacobian<double>{0, J.middleRows(3, 3)}, phi0,
+        parameters));
     problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<double>>(
-        0, J.middleRows(6, 3), phi0, parameters));
+        SapConstraintJacobian<double>{0, J.middleRows(6, 3)}, phi0,
+        parameters));
 
     return problem;
   }
@@ -679,10 +682,7 @@ class LimitConstraint final : public SapConstraint<T> {
   // limit vu and regularization R.
   LimitConstraint(int clique, const VectorX<T>& vl, const VectorX<T>& vu,
                   VectorX<T> R)
-      : SapConstraint<T>(
-            clique,
-            ConcatenateVectors(vl, vu) /* Dummy vector of the right size. */,
-            CalcConstraintJacobian(vl.size())),
+      : SapConstraint<T>({clique, CalcConstraintJacobian(vl.size())}),
         R_(std::move(R)),
         vhat_(ConcatenateVectors(vl, -vu)) {
     DRAKE_DEMAND(vl.size() == vu.size());

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -170,8 +170,6 @@ TEST_F(SpheresStackTest, EvalContactProblemCache) {
             &problem.get_constraint(i));
     // In this test we do know all constraints are contact constraints.
     ASSERT_NE(constraint, nullptr);
-    EXPECT_EQ(constraint->constraint_function(),
-              Vector3d(0., 0., pair_kinematics.phi));
     EXPECT_EQ(constraint->num_cliques(), pair_kinematics.jacobian.size());
     EXPECT_EQ(constraint->first_clique(), pair_kinematics.jacobian[0].tree);
     EXPECT_EQ(constraint->first_clique_jacobian().MakeDenseMatrix(),


### PR DESCRIPTION
Towards #19434.

In this PR:
 1. Docs of `SapConstraint` are updated according to #19434.
 2. `SapConstraint::constraint_function()` is removed, since no longer fits this abstraction. 
 3. `SapConstraintJacobian` is introduced to defined the contraint velocity `vc` in a compact manner.
 4. Refactoring of call sites to use new APIs in terms of `SapConstraintJacobian` (most of the bulk).
 
The compact set of arguments in a constraint is important for #19435, which introduces additional semantics for constraints to understand forces (i.e. more arguments).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19462)
<!-- Reviewable:end -->
