### PR TITLE
Fix caching for autodiff in direct collocation

### DIFF
--- a/planning/trajectory_optimization/direct_collocation.h
+++ b/planning/trajectory_optimization/direct_collocation.h
@@ -175,9 +175,9 @@ class DirectCollocationConstraint : public solvers::Constraint {
               VectorX<symbolic::Expression>* y) const override;
 
  private:
-  void dynamics(const AutoDiffVecXd& state, const AutoDiffVecXd& input,
-                systems::Context<AutoDiffXd>* context,
-                AutoDiffVecXd* xdot) const;
+  void CalcDynamics(const AutoDiffVecXd& state, const AutoDiffVecXd& input,
+                    systems::Context<AutoDiffXd>* context,
+                    AutoDiffVecXd* xdot) const;
 
   // Note: owned_system_ and owned_context_ can be nullptr.
   std::unique_ptr<systems::System<AutoDiffXd>> owned_system_;


### PR DESCRIPTION
My previous attempt at caching failed to address the fact that the autodiff gradients would be different when the status/inputs were passed in different places inside the variable list for the constraint. Now we implement the chain rule locally so that the cache is kept warm with gradients only with respect to the current variables.

Resolves #19396.

+@sammy-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19468)
<!-- Reviewable:end -->
