### PR TITLE
Rename fields in HPolyhedron::Serialize to match convention

### DIFF
--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -171,7 +171,7 @@ class ConvexSet : public ShapeReifier {
   /** Implements non-virtual base class serialization. */
   template <typename Archive>
   void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(ambient_dimension_));
+    a->Visit(MakeNameValue("ambient_dimension", &ambient_dimension_));
   }
 
   /** Non-virtual interface implementation for Clone(). */

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -194,8 +194,8 @@ class HPolyhedron final : public ConvexSet {
   template <typename Archive>
   void Serialize(Archive* a) {
     ConvexSet::Serialize(a);
-    a->Visit(DRAKE_NVP(A_));
-    a->Visit(DRAKE_NVP(b_));
+    a->Visit(MakeNameValue("A", &A_));
+    a->Visit(MakeNameValue("b", &b_));
     CheckInvariants();
   }
 


### PR DESCRIPTION
Resolves #19309.

+@jwnimmer-tri for both reviews, please.
I think we should just rip this bandaid off, as I don't think we actually have users of the `HPolyhedron::Serialize()` yet (but we're about to).

If need be, it would be easy to manually update the names in the yaml files to remove the trailing _ from the fields, and make them compatible again.

fyi @rcory , @mpetersen94 , @wrangelvid , @AlexandreAmice

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19469)
<!-- Reviewable:end -->
