### PR TITLE
Set dev/cspace_free_path test to manual

### DIFF
--- a/geometry/optimization/dev/BUILD.bazel
+++ b/geometry/optimization/dev/BUILD.bazel
@@ -52,6 +52,7 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "cspace_free_path_test",
+    tags = ["manual"],
     deps = [
         ":c_iris_path_test_utilities",
         "//common/test_utilities:symbolic_test_util",


### PR DESCRIPTION
[//geometry/optimization/dev:cspace_free_path_test](https://drake-cdash.csail.mit.edu/viewTest.php?onlyfailed&buildid=1695935) has timed out twice in CI now:

- https://drake-jenkins.csail.mit.edu/view/Production/job/linux-focal-clang-bazel-weekly-gurobi-thread-sanitizer/66/
- https://drake-jenkins.csail.mit.edu/job/linux-focal-clang-bazel-continuous-everything-address-sanitizer/2079/

This test is in 'dev/' so the next step is to disable the test in CI by tagging it as "manual"