### PR TITLE
Improve error message for integrator smaller step size

### DIFF
--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -1556,8 +1556,13 @@ class IntegratorBase {
           "size of {}; working minimum is ", new_step_size,
           get_working_minimum_step_size());
       std::ostringstream str;
-      str << "Error control wants to select step smaller than minimum" <<
-           " allowed (" << get_working_minimum_step_size() << ")";
+      // TODO(russt): Link to the "debugging dynamical systems" tutorial
+      // (#17249) once it exists.
+      str << "Error control wants to select step smaller than minimum"
+          << " allowed (" << get_working_minimum_step_size()
+          << "). This is typically an indication that some part of your system "
+             "*with continuous state* is going unstable and/or is producing "
+             "excessively large derivatives.";
       throw std::runtime_error(str.str());
     }
   }


### PR DESCRIPTION
I've found that even a little nudge to say "your system is probably unstable" and "no, the discrete-time multibodyplant is not (directly) to blame, look at the continuous-state parts of your system" can help them understand/resolve.

Related to #18452.

+@sherm1 for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19481)
<!-- Reviewable:end -->
