### PR TITLE
[multibody] Reduce SapContactProblem to selected/excluded dofs.

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -60,6 +60,8 @@ drake_cc_library(
         "//common:unused",
         "//common:value",
         "//multibody/contact_solvers:matrix_block",
+        "//multibody/contact_solvers/sap:partial_permutation",
+        "//multibody/plant:slicing_and_indexing",
     ],
 )
 
@@ -96,6 +98,7 @@ drake_cc_library(
         ":sap_constraint",
         "//common:default_scalars",
         "//common:essential",
+        "//multibody/plant:slicing_and_indexing",
     ],
 )
 

--- a/multibody/contact_solvers/sap/sap_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_constraint.cc
@@ -4,6 +4,8 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/ssize.h"
+#include "drake/multibody/plant/slicing_and_indexing.h"
 
 namespace drake {
 namespace multibody {
@@ -50,6 +52,52 @@ void SapConstraint<T>::CalcCostHessian(const AbstractValue& data,
   const int ne = num_constraint_equations();
   G->resize(ne, ne);
   DoCalcCostHessian(data, G);
+}
+
+template <typename T>
+std::unique_ptr<SapConstraint<T>> SapConstraint<T>::MakeReduced(
+    const PartialPermutation& clique_permutation,
+    const std::vector<std::vector<int>>& per_clique_known_dofs) const {
+  DRAKE_DEMAND(clique_permutation.domain_size() ==
+               ssize(per_clique_known_dofs));
+  DRAKE_DEMAND(first_clique() < clique_permutation.domain_size());
+  DRAKE_DEMAND(num_cliques() <= 1 ||
+               second_clique() < clique_permutation.domain_size());
+
+  const bool first_participates =
+      clique_permutation.participates(first_clique());
+  const bool second_participates =
+      num_cliques() > 1 && clique_permutation.participates(second_clique());
+
+  // Neither clique participates, no constraint made.
+  if (!first_participates && !second_participates) return nullptr;
+
+  std::unique_ptr<SapConstraint<T>> c = this->Clone();
+
+  if (first_participates && second_participates) {
+    // Permute both cliques.
+    c->J_ = SapConstraintJacobian<T>(
+        clique_permutation.permuted_index(first_clique()),
+        drake::multibody::internal::ExcludeCols(
+            first_clique_jacobian(), per_clique_known_dofs[first_clique()]),
+        clique_permutation.permuted_index(second_clique()),
+        drake::multibody::internal::ExcludeCols(
+            second_clique_jacobian(), per_clique_known_dofs[second_clique()]));
+  } else if (first_participates) {
+    // Single clique, permute the first clique.
+    c->J_ = SapConstraintJacobian<T>(
+        clique_permutation.permuted_index(first_clique()),
+        drake::multibody::internal::ExcludeCols(
+            first_clique_jacobian(), per_clique_known_dofs[first_clique()]));
+  } else {
+    // Single clique, permute the second clique.
+    c->J_ = SapConstraintJacobian<T>(
+        clique_permutation.permuted_index(second_clique()),
+        drake::multibody::internal::ExcludeCols(
+            second_clique_jacobian(), per_clique_known_dofs[second_clique()]));
+  }
+
+  return c;
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_contact_problem.cc
+++ b/multibody/contact_solvers/sap/sap_contact_problem.cc
@@ -6,6 +6,7 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/sap/contact_problem_graph.h"
+#include "drake/multibody/plant/slicing_and_indexing.h"
 
 namespace drake {
 namespace multibody {
@@ -59,6 +60,57 @@ std::unique_ptr<SapContactProblem<T>> SapContactProblem<T>::Clone() const {
     clone->AddConstraint(c.Clone());
   }
   return clone;
+}
+
+template <typename T>
+std::unique_ptr<SapContactProblem<T>> SapContactProblem<T>::MakeReduced(
+    const std::vector<int>& known_free_motion_dofs,
+    const std::vector<std::vector<int>>& per_clique_known_free_motion_dofs,
+    ReducedMapping* mapping) const {
+  DRAKE_ASSERT_VOID(drake::multibody::internal::DemandIndicesValid(
+      known_free_motion_dofs, num_velocities()));
+  DRAKE_DEMAND(ssize(per_clique_known_free_motion_dofs) == num_cliques());
+  for (int i = 0; i < num_cliques(); ++i) {
+    DRAKE_ASSERT_VOID(drake::multibody::internal::DemandIndicesValid(
+        per_clique_known_free_motion_dofs[i], num_velocities(i)));
+  }
+  DRAKE_DEMAND(mapping != nullptr);
+
+  mapping->clique_permutation = PartialPermutation(num_cliques());
+  mapping->constraint_permutation = PartialPermutation(num_constraints());
+
+  // Project v_star and A matrices to reduced DOFs.
+  VectorX<T> v_star_reduced =
+      drake::multibody::internal::ExcludeRows(v_star_, known_free_motion_dofs);
+
+  std::vector<MatrixX<T>> A_reduced;
+  A_reduced.reserve(A_.size());
+  for (int i = 0; i < num_cliques(); ++i) {
+    // Clique participates if at least one of its dofs is not locked.
+    if (ssize(per_clique_known_free_motion_dofs[i]) < num_velocities(i)) {
+      A_reduced.push_back(drake::multibody::internal::ExcludeRowsCols(
+          A_[i], per_clique_known_free_motion_dofs[i]));
+      mapping->clique_permutation.push(i);
+    }
+  }
+
+  // Construct a problem with reduced parameters.
+  std::unique_ptr<SapContactProblem> problem =
+      std::make_unique<SapContactProblem<T>>(time_step(), std::move(A_reduced),
+                                             std::move(v_star_reduced));
+
+  // Make reduced constraints.
+  for (int i = 0; i < num_constraints(); ++i) {
+    std::unique_ptr<SapConstraint<T>> c = get_constraint(i).MakeReduced(
+        mapping->clique_permutation, per_clique_known_free_motion_dofs);
+
+    if (c) {
+      mapping->constraint_permutation.push(i);
+      problem->AddConstraint(std::move(c));
+    }
+  }
+
+  return problem;
 }
 
 template <typename T>

--- a/multibody/contact_solvers/sap/sap_contact_problem.h
+++ b/multibody/contact_solvers/sap/sap_contact_problem.h
@@ -13,6 +13,13 @@ namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
+/* Struct returned by SapContactProblem::MakeReduced() which stores the mapping
+   between the original and reduced problems.*/
+struct ReducedMapping {
+  PartialPermutation clique_permutation;
+  PartialPermutation constraint_permutation;
+};
+
 /* In the SAP formulation of contact the state of a mechanical system is
 advanced from the previous state x₀ = [q₀,v₀] to the next state x = [q,v]. The
 SAP formulation linearizes the discrete time dynamics of the mechanical system
@@ -116,6 +123,39 @@ class SapContactProblem {
 
   /* Returns a deep-copy of `this` instance. */
   std::unique_ptr<SapContactProblem<T>> Clone() const;
+
+  /* Makes a "reduced" contact problem given the DOFs specified in
+    `known_free_motion_dofs` are known to equal the free-motion velocities.
+    That is, for an i-th DOF in `known_free_motion_dofs`, we know that vᵢ = vᵢ*.
+    `per_clique_known_free_motion_dofs` contains the same information stored in
+    `known_free_motion_dofs`, but expressed per-clique and in clique local
+    indices. e.g. If clique 0 corresponds to global velocity indices {5, 6, 7},
+    then its local velocity indices are {0, 1, 2}. If `known_free_motion_dofs` =
+    {6}, i.e. we know v₆ = v₆*, then `per_clique_known_free_motion_dofs[0] =
+    {1}` containing the known clique local index 1, corresponding to the known
+    global velocity index 6.
+
+    @param[in] known_free_motion_dofs Specifies known DOFs to be eliminated.
+    i ∈ known_free_motion_dofs specifies the i-th DOF.
+    @param[in] per_clique_known_free_motion_dofs Specifies known DOFs to be
+    eliminated, per clique. i ∈ per_clique_known_free_motion_dofs[c] specifies
+    the i-th DOF of the c-th clique. This parameter should contain the same
+    information in `known_free_motion_dofs`, but transformed to clique local
+    indices.
+    @param[out] mapping On output it will store information to map DOFs and
+    constraints between the original and reduced problems in a ReducedMapping.
+
+    @pre known_free_motion_dofs is a strict ordered subset of
+         [0, ..., num_velocities()-1].
+    @pre per_clique_known_free_motion_dofs.size() == num_cliques().
+    @pre per_clique_known_free_motion_dofs[c] is a strict ordered subset of
+         [0, ..., num_velocities(c)-1].
+    @pre mapping != nullptr.
+  */
+  std::unique_ptr<SapContactProblem<T>> MakeReduced(
+      const std::vector<int>& known_free_motion_dofs,
+      const std::vector<std::vector<int>>& per_clique_known_free_motion_dofs,
+      ReducedMapping* mapping) const;
 
   /* TODO(amcastro-tri): consider constructor API taking std::vector<VectorX<T>>
    for v_star. It could be useful for deformables. */

--- a/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
@@ -259,6 +259,174 @@ GTEST_TEST(ContactProblem, Clone) {
   EXPECT_EQ(graph.num_constraint_equations(), 17);
 }
 
+/* We test reducing the SapContactProblem. The graph setup sketched below
+(having the same semantics as the graph described in AddConstraints())
+corresponds to the graph of the contact problem that results from locking DoFs
+{0,1,2,3,4,9} in the contact problem produced by AddConstraints(). The indices
+in the graph below are the new mapped indices of the reduced problem. The
+following tables explain the mapping between original clique and constraint
+indices and their corresponding indices in the reduced problem:
+
+┌────────────┬────────────────────┐┌─────────────────────────────────────────┐
+│ clique idx │ reduced clique idx ││ constraint idx │ reduced constraint idx │
+├────────────│────────────────────┤├────────────────│────────────────────────┤
+│     0      │         N/A        ││       0        │           0            │
+│     1      │         N/A        ││       1        │          N/A           │
+│     2      │          0         ││       2        │           1            │
+│     3      │          1         ││       3        │           2            │
+└────────────┴────────────────────┘│       4        │           3            │
+                                   └────────────────┴────────────────────────┘
+
+Locking these DoFs has the effect of eliminating clique 0 and 1 from the
+problem. One constraint from the original problem will be completely removed.
+Other constraints that involved one of the eliminated clique now become single
+clique constraints:
+
+    0[0, 1, 2, 3](1, 6, 2, 5)
+             ┌─┐
+             │ │
+            ┌┴─┴┐     ┌───┐
+            │ 1 │     │ 0 │
+            └───┘     └───┘
+
+TODO(joemasterjohn): Make a fixture to consolidate the creation of this problem
+and its constraints.
+*/
+GTEST_TEST(ContactProblem, MakeReduced) {
+  const double time_step = 0.01;
+  const std::vector<MatrixXd> A{S22, S33, S44, S22};
+  const VectorXd v_star = VectorXd::LinSpaced(11, 1.0, 11.0);
+  SapContactProblem<double> problem(time_step, std::move(A), std::move(v_star));
+  AddConstraints(&problem);
+
+  // Lock all the dofs of clique 0 and 1. Lock velocity index 9, local index 1
+  // of clique 3.
+  const std::vector<int> locked_indices{0, 1, 2, 3, 4, 9};
+  const std::vector<std::vector<int>> clique_locked_indices{
+      {0, 1}, {0, 1, 2}, {}, {1}};
+  ReducedMapping mapping;
+  std::unique_ptr<SapContactProblem<double>> reduced_problem =
+      problem.MakeReduced(locked_indices, clique_locked_indices, &mapping);
+
+  EXPECT_EQ(reduced_problem->num_cliques(), 2);
+  EXPECT_EQ(reduced_problem->num_constraints(), 4);
+  EXPECT_EQ(reduced_problem->num_constraint_equations(), 14);
+  // Verify some expected data.
+  EXPECT_EQ(reduced_problem->v_star().size(), 5);
+  // Two cliques eliminated, so two remain.
+  EXPECT_EQ(reduced_problem->dynamics_matrix().size(), 2);
+  // Original clique 2 (reduced clique 0) is unaffected.
+  EXPECT_EQ(reduced_problem->dynamics_matrix()[0], S44);
+  // Original clique 3 (reduced clique 1) has only 1 dof now.
+  EXPECT_EQ(reduced_problem->dynamics_matrix()[1].size(), 1);
+  EXPECT_EQ(reduced_problem->dynamics_matrix()[1](0, 0), 2);
+
+  const ContactProblemGraph& graph = reduced_problem->graph();
+  EXPECT_EQ(graph.num_cliques(), 2);
+  EXPECT_EQ(graph.num_constraints(), 4);
+  EXPECT_EQ(graph.num_clusters(), 1);
+  EXPECT_EQ(graph.num_constraint_equations(), 14);
+
+  /* Clique permutation. We expect the first two cliques to be eliminated. */
+  EXPECT_EQ(mapping.clique_permutation.domain_size(), problem.num_cliques());
+  EXPECT_EQ(mapping.clique_permutation.permuted_domain_size(), 2);
+  EXPECT_FALSE(mapping.clique_permutation.participates(0));
+  EXPECT_FALSE(mapping.clique_permutation.participates(1));
+  EXPECT_TRUE(mapping.clique_permutation.participates(2));
+  EXPECT_TRUE(mapping.clique_permutation.participates(3));
+
+  EXPECT_EQ(mapping.clique_permutation.permuted_index(2), 0);
+  EXPECT_EQ(mapping.clique_permutation.permuted_index(3), 1);
+
+  /* Constraint permutation. We expect the second constraint between the two
+     eliminated cliques (0 and 1) to be eliminated. */
+  EXPECT_EQ(mapping.constraint_permutation.domain_size(),
+            problem.num_constraints());
+  EXPECT_EQ(mapping.constraint_permutation.permuted_domain_size(), 4);
+  EXPECT_TRUE(mapping.constraint_permutation.participates(0));
+  EXPECT_FALSE(mapping.constraint_permutation.participates(1));
+  EXPECT_TRUE(mapping.constraint_permutation.participates(2));
+  EXPECT_TRUE(mapping.constraint_permutation.participates(3));
+  EXPECT_TRUE(mapping.constraint_permutation.participates(4));
+
+  EXPECT_EQ(mapping.constraint_permutation.permuted_index(0), 0);
+  EXPECT_EQ(mapping.constraint_permutation.permuted_index(2), 1);
+  EXPECT_EQ(mapping.constraint_permutation.permuted_index(3), 2);
+  EXPECT_EQ(mapping.constraint_permutation.permuted_index(4), 3);
+
+  /* Verify that the each constraint's index mapping is as expected and
+     described by the graph. For each constraint, the table lists the original
+     problem constraint properties and the reduced problem properties.*/
+
+  /*
+    ┌──────────┬───────┬───────────────┬────────────────┬─────────────────┐
+    │ problem  │ index │ num_equations │ first_clique() │ second_clique() │
+    ├──────────│───────│───────────────│────────────────│─────────────────┤
+    │ original │   0   │      1        │       3        │      N/A        │
+    │ reduced  │   0   │      1        │       1        │      N/A        │
+    └──────────┴───────┴───────────────┴────────────────┴─────────────────┘
+  */
+  {
+    const SapConstraint<double>& c = reduced_problem->get_constraint(0);
+    EXPECT_EQ(c.num_cliques(), 1);
+    EXPECT_EQ(c.first_clique(), mapping.clique_permutation.permuted_index(3));
+    EXPECT_EQ(c.num_constraint_equations(), 1);
+    EXPECT_EQ(c.first_clique_jacobian().cols(),
+              reduced_problem->num_velocities(c.first_clique()));
+  }
+
+  /*
+    ┌──────────┬───────┬───────────────┬────────────────┬─────────────────┐
+    │ problem  │ index │ num_equations │ first_clique() │ second_clique() │
+    ├──────────│───────│───────────────│────────────────│─────────────────┤
+    │ original │   2   │      6        │       0        │       3         │
+    │ reduced  │   1   │      6        │       1        │      N/A        │
+    └──────────┴───────┴───────────────┴────────────────┴─────────────────┘
+  */
+  {
+    const SapConstraint<double>& c = reduced_problem->get_constraint(1);
+    EXPECT_EQ(c.num_cliques(), 1);
+    EXPECT_EQ(c.first_clique(), mapping.clique_permutation.permuted_index(3));
+    EXPECT_EQ(c.num_constraint_equations(), 6);
+    EXPECT_EQ(c.first_clique_jacobian().cols(),
+              reduced_problem->num_velocities(c.first_clique()));
+  }
+
+  /*
+    ┌──────────┬───────┬───────────────┬────────────────┬─────────────────┐
+    │ problem  │ index │ num_equations │ first_clique() │ second_clique() │
+    ├──────────│───────│───────────────│────────────────│─────────────────┤
+    │ original │   3   │      2        │       1        │       3         │
+    │ reduced  │   2   │      2        │       1        │      N/A        │
+    └──────────┴───────┴───────────────┴────────────────┴─────────────────┘
+  */
+  {
+    const SapConstraint<double>& c = reduced_problem->get_constraint(2);
+    EXPECT_EQ(c.num_cliques(), 1);
+    EXPECT_EQ(c.first_clique(), mapping.clique_permutation.permuted_index(3));
+    EXPECT_EQ(c.num_constraint_equations(), 2);
+    EXPECT_EQ(c.first_clique_jacobian().cols(),
+              reduced_problem->num_velocities(c.first_clique()));
+  }
+
+  /*
+    ┌──────────┬───────┬───────────────┬────────────────┬─────────────────┐
+    │ problem  │ index │ num_equations │ first_clique() │ second_clique() │
+    ├──────────│───────│───────────────│────────────────│─────────────────┤
+    │ original │   4   │      5        │       0        │       3         │
+    │ reduced  │   3   │      5        │       1        │      N/A        │
+    └──────────┴───────┴───────────────┴────────────────┴─────────────────┘
+  */
+  {
+    const SapConstraint<double>& c = reduced_problem->get_constraint(3);
+    EXPECT_EQ(c.num_cliques(), 1);
+    EXPECT_EQ(c.first_clique(), mapping.clique_permutation.permuted_index(3));
+    EXPECT_EQ(c.num_constraint_equations(), 5);
+    EXPECT_EQ(c.first_clique_jacobian().cols(),
+              reduced_problem->num_velocities(c.first_clique()));
+  }
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace contact_solvers

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -394,6 +394,7 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//common:essential",
+        "//multibody/contact_solvers:matrix_block",
     ],
 )
 
@@ -538,6 +539,7 @@ drake_cc_googletest(
     deps = [
         ":slicing_and_indexing",
         "//common:essential",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/plant/slicing_and_indexing.cc
+++ b/multibody/plant/slicing_and_indexing.cc
@@ -1,9 +1,11 @@
 #include "drake/multibody/plant/slicing_and_indexing.h"
 
 #include <set>
+#include <utility>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/ssize.h"
 
 // TODO(rpoyner-tri): the Select*() and Expand*() functions below can be
 // removed and replaced with arbitrary indexing once Eigen 3.4 is our minimum
@@ -47,6 +49,50 @@ MatrixX<T> SelectRowsCols(const MatrixX<T>& M,
 }
 
 template <typename T>
+MatrixX<T> ExcludeRowsCols(const MatrixX<T>& M,
+                           const std::vector<int>& indices) {
+  DRAKE_DEMAND(M.rows() == M.cols());
+  DRAKE_ASSERT_VOID(DemandIndicesValid(indices, M.rows()));
+  if (indices.size() == 0) {
+    return M;
+  }
+
+  MatrixX<T> result(M.rows() - indices.size(), M.cols() - indices.size());
+
+  int r_index = 0;          // Keeps track of the row of result being filled.
+  int r_exclude_index = 0;  // Index into indices of the next row to exclude.
+  for (int i = 0; i < M.rows(); ++i) {
+    // If we still have rows to exclude and are on the next row to exclude,
+    // skip this row.
+    if (r_exclude_index < ssize(indices) && i == indices[r_exclude_index]) {
+      ++r_exclude_index;
+      continue;
+    }
+    // Keeps track of the column of result being filled.
+    int c_index = 0;
+    // Index into indices of the next column to exclude.
+    int c_exclude_index = 0;
+    for (int j = 0; j < M.cols(); ++j) {
+      // If we still have columns to exclude and are on the next columns to
+      // exclude, skip this column.
+      if (c_exclude_index < ssize(indices) && j == indices[c_exclude_index]) {
+        ++c_exclude_index;
+        continue;
+      }
+      result(r_index, c_index) = M(i, j);
+      ++c_index;
+    }
+    DRAKE_ASSERT(c_index == result.cols());
+    DRAKE_ASSERT(c_exclude_index == ssize(indices));
+    ++r_index;
+  }
+
+  DRAKE_ASSERT(r_index == result.rows());
+  DRAKE_ASSERT(r_exclude_index == ssize(indices));
+  return result;
+}
+
+template <typename T>
 MatrixX<T> SelectCols(const MatrixX<T>& M, const std::vector<int>& indices) {
   DRAKE_ASSERT_VOID(DemandIndicesValid(indices, M.cols()));
   const int selected_count = indices.size();
@@ -62,6 +108,46 @@ MatrixX<T> SelectCols(const MatrixX<T>& M, const std::vector<int>& indices) {
 }
 
 template <typename T>
+MatrixX<T> ExcludeCols(const MatrixX<T>& M, const std::vector<int>& indices) {
+  DRAKE_ASSERT_VOID(DemandIndicesValid(indices, M.cols()));
+  if (indices.size() == 0) {
+    return M;
+  }
+
+  MatrixX<T> result(M.rows(), M.cols() - indices.size());
+
+  int c_index = 0;          // Keeps track of the column of result being filled.
+  int c_exclude_index = 0;  // Index into indices of the next column to exclude.
+  for (int j = 0; j < M.cols(); ++j) {
+    // If we've run out of columns to exclude or are not the next column to
+    // exclude, include this column.
+    if (c_exclude_index >= ssize(indices) || j < indices[c_exclude_index]) {
+      result.col(c_index) = M.col(j);
+      ++c_index;
+    } else {
+      ++c_exclude_index;
+    }
+  }
+
+  DRAKE_ASSERT(c_index == result.cols());
+  DRAKE_ASSERT(c_exclude_index == ssize(indices));
+  return result;
+}
+
+template <typename T>
+contact_solvers::internal::MatrixBlock<T> ExcludeCols(
+    const contact_solvers::internal::MatrixBlock<T>& M,
+    const std::vector<int>& indices) {
+  if (M.is_dense()) {
+    return contact_solvers::internal::MatrixBlock<T>(
+        std::move(ExcludeCols(M.MakeDenseMatrix(), indices)));
+  } else {
+    throw std::runtime_error(
+        "ExcludeCols only supports dense MatrixBlock arguments.");
+  }
+}
+
+template <typename T>
 VectorX<T> SelectRows(const VectorX<T>& v, const std::vector<int>& indices) {
   DRAKE_ASSERT_VOID(DemandIndicesValid(indices, v.size()));
   const int selected_count = indices.size();
@@ -72,6 +158,28 @@ VectorX<T> SelectRows(const VectorX<T>& v, const std::vector<int>& indices) {
 
   for (int i = 0; i < result.rows(); ++i) {
     result(i) = v(indices[i]);
+  }
+  return result;
+}
+
+template <typename T>
+VectorX<T> ExcludeRows(const VectorX<T>& v, const std::vector<int>& indices) {
+  DRAKE_ASSERT_VOID(DemandIndicesValid(indices, v.size()));
+  const int selected_count = indices.size();
+  if (selected_count == 0) {
+    return v;
+  }
+  VectorX<T> result(v.rows() - selected_count);
+
+  int r_index = 0;
+  int exclude_index = 0;
+  for (int i = 0; i < v.rows(); ++i) {
+    if (exclude_index >= ssize(indices) || i < indices[exclude_index]) {
+      result(r_index) = v(i);
+      ++r_index;
+    } else {
+      ++exclude_index;
+    }
   }
   return result;
 }
@@ -99,8 +207,41 @@ VectorX<T> ExpandRows(const VectorX<T>& v, int rows_out,
   return result;
 }
 
+template <typename T>
+VectorX<T> ExpandRows(const Eigen::VectorBlock<const VectorX<T>>& v,
+                      int rows_out, const std::vector<int>& indices) {
+  DRAKE_ASSERT(static_cast<int>(indices.size()) == v.rows());
+  DRAKE_ASSERT(rows_out >= v.rows());
+  DRAKE_ASSERT_VOID(DemandIndicesValid(indices, rows_out));
+  if (rows_out == v.rows()) {
+    return v;
+  }
+  VectorX<T> result(rows_out);
+
+  int index_cursor = 0;
+  for (int i = 0; i < result.rows(); ++i) {
+    if (index_cursor >= v.rows() || i < indices[index_cursor]) {
+      result(i) = 0.;
+    } else {
+      result(indices[index_cursor]) = v(index_cursor);
+      ++index_cursor;
+    }
+  }
+  return result;
+}
+
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    (&SelectRowsCols<T>, &SelectRows<T>, &SelectCols<T>, &ExpandRows<T>))
+    (&SelectRowsCols<T>, &ExcludeRowsCols<T>, &SelectRows<T>, &ExcludeRows<T>,
+     &SelectCols<T>,
+     static_cast<MatrixX<T> (*)(const MatrixX<T>&, const std::vector<int>&)>(
+         &ExcludeCols),
+     static_cast<contact_solvers::internal::MatrixBlock<T> (*)(
+         const contact_solvers::internal::MatrixBlock<T>&,
+         const std::vector<int>&)>(&ExcludeCols),
+     static_cast<VectorX<T> (*)(const Eigen::VectorBlock<const VectorX<T>>&,
+                                int, const std::vector<int>&)>(&ExpandRows),
+     static_cast<VectorX<T> (*)(const VectorX<T>&, int,
+                                const std::vector<int>&)>(&ExpandRows)))
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/slicing_and_indexing.h
+++ b/multibody/plant/slicing_and_indexing.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/matrix_block.h"
 
 // TODO(rpoyner-tri): the Select*() and Expand*() functions below can be
 // removed and replaced with arbitrary indexing once Eigen 3.4 is our minimum
@@ -23,6 +24,14 @@ void DemandIndicesValid(const std::vector<int>& indices, int max_size);
 template <typename T>
 MatrixX<T> SelectRowsCols(const MatrixX<T>& M, const std::vector<int>& indices);
 
+// Make a new, possibly smaller square matrix from square matrix @p M, by
+// excluding the rows and columns indexed by @p indices.
+// @pre indices.size() <= M.rows() (or M.cols() since M is a square matrix).
+// @pre indices argument is valid according to DemandIndicesValid().
+template <typename T>
+MatrixX<T> ExcludeRowsCols(const MatrixX<T>& M,
+                           const std::vector<int>& indices);
+
 // Make a new, possibly smaller matrix from matrix M, by selecting the columns
 // indexed by @p indices.
 // @pre indices.size() <= M.cols().
@@ -30,12 +39,37 @@ MatrixX<T> SelectRowsCols(const MatrixX<T>& M, const std::vector<int>& indices);
 template <typename T>
 MatrixX<T> SelectCols(const MatrixX<T>& M, const std::vector<int>& indices);
 
+// Make a new, possibly smaller matrix from matrix @p M, by excluding the
+// columns indexed by @p indices.
+// @pre indices.size() <= M.cols().
+// @pre indices argument is valid according to DemandIndicesValid().
+template <typename T>
+MatrixX<T> ExcludeCols(const MatrixX<T>& M, const std::vector<int>& indices);
+
+// If M.is_dense() == true, returns a new possibly smaller matrix from M, by
+// excluding the columns indexed by @p indices. Does not handle non-dense
+// MatrixBlock.
+// @throws std::exception if !M.is_dense()
+// @pre indices.size() <= M.cols().
+// @pre indices argument is valid according to DemandIndicesValid().
+template <typename T>
+contact_solvers::internal::MatrixBlock<T> ExcludeCols(
+    const contact_solvers::internal::MatrixBlock<T>& M,
+    const std::vector<int>& indices);
+
 // Make a new, possibly smaller vector from vector @p v, by selecting the rows
 // indexed by @p indices.
 // @pre indices.size() <= v.size().
 // @pre indices argument is valid according to DemandIndicesValid().
 template <typename T>
 VectorX<T> SelectRows(const VectorX<T>& v, const std::vector<int>& indices);
+
+// Make a new, possibly smaller vector from vector @p v, by excluding the rows
+// indexed by @p indices.
+// @pre indices.size() <= v.size().
+// @pre indices argument is valid according to DemandIndicesValid().
+template <typename T>
+VectorX<T> ExcludeRows(const VectorX<T>& v, const std::vector<int>& indices);
 
 // Make a new, possibly larger vector of size @p rows_out, by copying rows
 // of @p v to rows indexed by @p indices. New rows are filled with zeros.
@@ -46,6 +80,10 @@ VectorX<T> SelectRows(const VectorX<T>& v, const std::vector<int>& indices);
 template <typename T>
 VectorX<T> ExpandRows(const VectorX<T>& v, int rows_out,
                       const std::vector<int>& indices);
+
+template <typename T>
+VectorX<T> ExpandRows(const Eigen::VectorBlock<const VectorX<T>>& v,
+                      int rows_out, const std::vector<int>& indices);
 
 }  // namespace internal
 }  // namespace multibody


### PR DESCRIPTION
Towards #18983.

Adds functionality to reduce a `SapContactProblem` via `SapContactProblem::Reduce()` by providing a list of "locked" or non-participating dofs. This results in a permutation of the original cliques and constraints of the problem as well as the associated linear dynamics matrices, v_star, and constraint jacobians. The returned data structure `ReducedMapping` contains the information to map a `SapSolverResults` associated with the reduced dof problem to a corresponding `SapSolverResults` for the original problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19488)
<!-- Reviewable:end -->
