### PR TITLE
[osqp_solver] Allow for warm-starting

### DIFF
--- a/solvers/osqp_solver.cc
+++ b/solvers/osqp_solver.cc
@@ -319,6 +319,20 @@ void SetDualSolution(
                                    constraint.evaluator()->num_constraints()));
   }
 }
+
+template <typename T>
+T GetOptionOrDefault(
+    const SolverOptions& merged_options,
+    const std::string& key,
+    T default_value) {
+  const auto& options = merged_options.GetOptions<T>(OsqpSolver::id());
+  auto iter = options.find(key);
+  if (iter != options.end()) {
+    return iter->second;
+  } else {
+    return default_value;
+  }
+}
 }  // namespace
 
 bool OsqpSolver::is_available() {
@@ -331,6 +345,17 @@ void OsqpSolver::DoSolve(const MathematicalProgram& prog,
                          MathematicalProgramResult* result) const {
   OsqpSolverDetails& solver_details =
       result->SetSolverDetailsType<OsqpSolverDetails>();
+
+  const bool warm_start_dual = GetOptionOrDefault<int>(
+      merged_options, "drake_warm_start_dual", 0);
+  // Retrieve information from prior solution.
+  const Eigen::VectorXd warm_dual = solver_details.y;
+  if (warm_start_dual) {
+    // Manually clear details when warm-starting.
+    // TODO(eric.cousineau): Add something like `result->Reset()` to keep
+    // "pre-solve" data (solver id, etc) and reset "post-solve" data?
+    solver_details = {};
+  }
 
   // OSQP solves a convex quadratic programming problem
   // min 0.5 xᵀPx + qᵀx
@@ -389,10 +414,18 @@ void OsqpSolver::DoSolve(const MathematicalProgram& prog,
   }
 
   if (!solution_result && initial_guess.array().isFinite().all()) {
-    const c_int osqp_warm_err = osqp_warm_start_x(
-        work, initial_guess.data());
-    if (osqp_warm_err != 0) {
-      solution_result = SolutionResult::kInvalidInput;
+    if (warm_start_dual && warm_dual.size() > 0) {
+      const c_int osqp_warm_err = osqp_warm_start(
+          work, initial_guess.data(), warm_dual.data());
+      if (osqp_warm_err != 0) {
+        solution_result = SolutionResult::kInvalidInput;
+      }
+    } else {
+      const c_int osqp_warm_err = osqp_warm_start_x(
+          work, initial_guess.data());
+      if (osqp_warm_err != 0) {
+        solution_result = SolutionResult::kInvalidInput;
+      }
     }
   }
 

--- a/solvers/solver_base.cc
+++ b/solvers/solver_base.cc
@@ -37,13 +37,40 @@ namespace {
 std::string ShortName(const SolverInterface& solver) {
   return NiceTypeName::RemoveNamespaces(NiceTypeName::Get(solver));
 }
+
+template <typename T>
+T GetOptionOrDefault(
+    SolverId solver_id,
+    const std::optional<SolverOptions>& merged_options,
+    const std::string& key,
+    T default_value) {
+  if (!merged_options) {
+    return default_value;
+  }
+  const auto& options = merged_options->GetOptions<T>(solver_id);
+  auto iter = options.find(key);
+  if (iter != options.end()) {
+    return iter->second;
+  } else {
+    return default_value;
+  }
+}
 }  // namespace
 
 void SolverBase::Solve(const MathematicalProgram& prog,
                        const std::optional<Eigen::VectorXd>& initial_guess,
                        const std::optional<SolverOptions>& solver_options,
                        MathematicalProgramResult* result) const {
-  *result = {};
+  const bool warm_start_dual = GetOptionOrDefault<int>(
+      solver_id(), solver_options, "drake_warm_start_dual", 0);
+  if (!warm_start_dual) {
+    // If we are warm starting via dual, we will rely on the solver itself to
+    // keep relevant data from the the prior result.
+    // Note: Solvers that are warm-starting should take care to retrieve the
+    // results they need and then clear out prior results.
+    *result = {};
+  }
+
   if (!available()) {
     const std::string name = ShortName(*this);
     throw std::invalid_argument(fmt::format(


### PR DESCRIPTION
Loosely drawing from
https://github.com/DAIRLab/dairlib/blob/0da42bc/solvers/fast_osqp_solver.cc#L402-L414

Resolves #10048 - but does not attempt to reuse the solver workspace
Relates #16811

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19498)
<!-- Reviewable:end -->
