### PR TITLE
[osqp_solver] Allow for primal-only warm-start

### DIFF
--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -183,6 +183,7 @@ drake_cc_googletest(
         ":kinematic_trajectory_optimization",
         "//common/test_utilities:eigen_matrix_compare",
         "//solvers:constraint",
+        "//solvers:osqp_solver",
         "//solvers:solve",
     ],
 )


### PR DESCRIPTION
Partial solution to #10048
Extracting primal-only warm starting from #19498

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19499)
<!-- Reviewable:end -->
