### PR TITLE
Fix visualization of contact_surface_rigid_bowl_soft_ball

### DIFF
--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -278,10 +278,18 @@ class ContactResultMaker final : public LeafSystem<double> {
       const ContactSurface<double>& surface = contacts[i];
 
       // TODO(SeanCurtis-TRI): This currently skips the full naming and doesn't
-      //  report any dynamics (e.g., force, moment, or quadrature data).
+      //  report quadrature data.
 
       surface_message.body1_name = "Id_" + to_string(surface.id_M());
       surface_message.body2_name = "Id_" + to_string(surface.id_N());
+
+      std::copy(surface.centroid().data(), surface.centroid().data() + 3,
+                surface_message.centroid_W);
+      const std::array<double, 3> fake_force{1e-2, 0, 0};
+      std::copy(fake_force.begin(), fake_force.end(),
+                surface_message.force_C_W);
+      const std::array<double, 3> moment{0, 0, 0};
+      std::copy(moment.begin(), moment.end(), surface_message.moment_C_W);
 
       const int num_vertices = surface.num_vertices();
       surface_message.num_vertices = num_vertices;


### PR DESCRIPTION
Fix #19504
- #19504 

Related to:
- #19494 

Test it by:
```
bazel run //tools:meldis -- -w &
bazel run //geometry/profiling:contact_surface_rigid_bowl_soft_ball
```
You should see contact surfaces like this:

![image](https://github.com/RobotLocomotion/drake/assets/42557859/597ec0af-e3fd-49be-af18-3acf970a9084)

Diagnosis of #19504:
1. contact_surface_rigid_bowl_soft_ball uses SceneGraph without MultibodyPlant.
2. It didn't calculate force and moment, so it sent the default zero force and moment to LCM  via lcmt_hydroelastic_contact_surface_for_viz message.
3. Meldis passes zero force and moment from LCM to Meshcat
4. Meshcat passes zero force and moment to HydroelasticContactVisualizer
5. [This code in HydroelasticContactVisualizer](https://github.com/RobotLocomotion/drake/blob/7417c146d434934fdced26449449b003040ec0f2/multibody/meshcat/hydroelastic_contact_visualizer.cc#L56-L63) skips any contact patch with both force and moment below certain thresholds.

This PR fixes it by adding a fake force of 1e-2 Newtons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19505)
<!-- Reviewable:end -->
