### PR TITLE
[rendering] TextureLibrary upgraded to prepare for cloning

### DIFF
--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -306,6 +306,31 @@ drake_cc_googletest_ubuntu_only(
     ],
 )
 
+drake_cc_googletest_ubuntu_only(
+    name = "multithread_safety_test",
+    data = [
+        "//geometry/render:test_models",
+    ],
+    tags = vtk_test_tags() + ["cpu:4"],
+    deps = [
+        ":internal_texture_library",
+        "//common:find_resource",
+    ],
+)
+
+drake_cc_googletest_ubuntu_only(
+    name = "internal_texture_library_test",
+    data = [
+        "//geometry/render:test_models",
+    ],
+    tags = vtk_test_tags(),
+    deps = [
+        ":internal_texture_library",
+        "//common:find_resource",
+        "//common:temp_directory",
+    ],
+)
+
 add_lint_tests(
     cpplint_extra_srcs = [
         "no_factory.cc",

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -22,6 +22,7 @@ using geometry::internal::LoadRenderMeshFromObj;
 using math::RigidTransformd;
 using std::make_shared;
 using std::make_unique;
+using std::shared_ptr;
 using std::string;
 using std::unique_ptr;
 using std::unordered_map;
@@ -164,10 +165,16 @@ class DefaultTextureColorShader final : public ShaderProgram {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DefaultTextureColorShader)
 
   /* Constructs the texture shader with the given library. The library will be
-   used to access OpenGl textures.  */
-  explicit DefaultTextureColorShader(TextureLibrary* library)
-      : ShaderProgram(), library_(library) {
-    DRAKE_DEMAND(library != nullptr);
+   used to access OpenGl textures.
+
+   When the RenderEngineGl is cloned, instances of this shader program are
+   likewise cloned, each with a shared ptr to the *same* texture library. This
+   is alright, because the owning RenderEngineGl instances share that library
+   as well -- so the shader program instances are consistent with the render
+   engine instances. */
+  explicit DefaultTextureColorShader(shared_ptr<TextureLibrary> library)
+      : ShaderProgram(), library_(std::move(library)) {
+    DRAKE_DEMAND(library_ != nullptr);
     LoadFromSources(kVertexShader, kFragmentShader);
     diffuse_map_loc_ = GetUniformLocation("diffuse_map");
     diffuse_scale_loc_ = GetUniformLocation("diffuse_map_scale");
@@ -241,7 +248,7 @@ class DefaultTextureColorShader final : public ShaderProgram {
     glUniformMatrix3fv(normal_mat_loc_, 1, GL_FALSE, normal_mat.data());
   }
 
-  TextureLibrary* library_{};
+  std::shared_ptr<TextureLibrary> library_{};
 
   // The location of the "diffuse_map" uniform in the shader.
   GLint diffuse_map_loc_{};
@@ -462,7 +469,7 @@ void main() {
 RenderEngineGl::RenderEngineGl(RenderEngineGlParams params)
     : RenderEngine(params.default_label),
       opengl_context_(make_shared<OpenGlContext>()),
-      texture_library_(make_shared<TextureLibrary>(opengl_context_.get())),
+      texture_library_(make_shared<TextureLibrary>()),
       parameters_(std::move(params)) {
   // Configuration of basic OpenGl state.
   opengl_context_->MakeCurrent();
@@ -483,7 +490,7 @@ RenderEngineGl::RenderEngineGl(RenderEngineGlParams params)
   // texture color shader *after* the rgba color shader.
   AddShader(make_unique<DefaultRgbaColorShader>(params.default_diffuse),
             RenderType::kColor);
-  AddShader(make_unique<DefaultTextureColorShader>(texture_library_.get()),
+  AddShader(make_unique<DefaultTextureColorShader>(texture_library_),
             RenderType::kColor);
 
   // Depth shaders -- a single shader that accepts all geometry.

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -207,6 +207,10 @@ class RenderEngineGl final : public render::RenderEngine {
   // or are stashed in a shared pointer.
   std::shared_ptr<OpenGlContext> opengl_context_;
 
+  // This texture library is coupled with the OpenGlContext. The texture
+  // identifiers in the library are instantiated in that context. Operations
+  // on this library must be invoked with the context bound. Both context and
+  // library are shared between a RenderEngineGl instance and all of its clones.
   std::shared_ptr<TextureLibrary> texture_library_;
 
   // The engine's configuration parameters.

--- a/geometry/render_gl/internal_shader_program.h
+++ b/geometry/render_gl/internal_shader_program.h
@@ -102,7 +102,8 @@ class ShaderProgram {
    The derived classes define the details in DoCreateProgramData.
 
    @returns The validated and packaged shader program properties, `nullopt` if
-            `this` shader program cannot be applied for the given properties. */
+            `this` shader program cannot be applied for the given properties.
+   @pre The OpenGl context to which this program belongs has been bound. */
   std::optional<ShaderProgramData> CreateProgramData(
       const PerceptionProperties& properties) const {
     return DoCreateProgramData(properties);

--- a/geometry/render_gl/internal_texture_library.cc
+++ b/geometry/render_gl/internal_texture_library.cc
@@ -19,31 +19,25 @@ namespace geometry {
 namespace render_gl {
 namespace internal {
 
-TextureLibrary::TextureLibrary(const OpenGlContext* context)
-    : context_(context) {
-  DRAKE_DEMAND(context_ != nullptr);
-}
+namespace fs = std::filesystem;
 
 std::optional<GLuint> TextureLibrary::GetTextureId(
-    const std::string& file_name) {
+    const std::string& file_name_in) {
+  const std::string file_name = GetTextureKey(file_name_in);
+
+  // We'll simply serialize all calls to GetTextureId(). As this act is purely
+  // an initialization operation (i.e., we get the texture id when *adding*
+  // an object with a texture), simple serialization isn't harmful.
+  std::lock_guard<std::mutex> lock(mutex_);
   const auto iter = textures_.find(file_name);
-  if (iter != textures_.end()) return iter->second;
-  // If it's not a string from which we can even *consider* finding an
-  // extension, simply bail out.
-  if (file_name.size() < 4) return std::nullopt;
+  if (iter != textures_.end()) {
+    return iter->second;
+  }
 
-  context_->MakeCurrent();
-  // Otherwise load the texture, register the texture.
-  std::string ext = file_name.substr(file_name.size() - 4, 4);
-  std::transform(ext.begin(), ext.end(), ext.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-  // TODO(SeanCurtis-TRI) Support other image types.
-  if (ext != ".png") return std::nullopt;
-
-  // Exit quickly if the file doesn't exist or is a directory.
-  // Otherwise, vtkPNGReader spams stdout.
-  if (!std::filesystem::exists(file_name) ||
-      std::filesystem::is_directory(file_name)) {
+  // Technically, if this fails, file_name won't be a valid key, so this test
+  // could be outside the lock. But as it touches the filesystem, we'll defer
+  // the test until we know we have to do it.
+  if (!IsSupportedImage(file_name)) {
     return std::nullopt;
   }
 
@@ -54,7 +48,7 @@ std::optional<GLuint> TextureLibrary::GetTextureId(
     log()->warn(
         "Texture map '{}' has an unsupported bit depth, casting it to uchar "
         "channels.",
-        file_name);
+        file_name_in);
   }
 
   vtkNew<vtkImageCast> caster;
@@ -77,11 +71,15 @@ std::optional<GLuint> TextureLibrary::GetTextureId(
   const GLint internal_format =
       num_channels == 4 ? GL_RGBA : (num_channels == 3 ? GL_RGB : 0);
   if (internal_format == 0) {
-      return std::nullopt;
+    return std::nullopt;
   }
 
   GLuint texture_id;
   glGenTextures(1, &texture_id);
+  // This will catch the problem that an OpenGl context is not bound; we have no
+  // way to tell if the *wrong* context is bound and we create the texture in
+  // the wrong place.
+  DRAKE_ASSERT(glGetError() == GL_NO_ERROR);
   glBindTexture(GL_TEXTURE_2D, texture_id);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
@@ -98,6 +96,41 @@ std::optional<GLuint> TextureLibrary::GetTextureId(
   textures_[file_name] = texture_id;
 
   return texture_id;
+}
+
+std::string TextureLibrary::GetTextureKey(const std::string& file_name) {
+  const fs::path path_in(file_name);
+  const fs::path file_path =
+      fs::is_symlink(path_in) ? fs::read_symlink(path_in) : path_in;
+  return file_path.string();
+}
+
+bool TextureLibrary::IsSupportedImage(const std::string& file_name) {
+  // TODO(SeanCurtis-TRI): We should dispatch warnings if a `file_name` is not
+  // "supported" (and why) instead of silently ignoring it.
+
+  // If it's not a string from which we can even *consider* finding an
+  // extension, simply bail out.
+  if (file_name.size() < 4) {
+    return false;
+  }
+
+  // Test for supported extension.
+  std::string ext = file_name.substr(file_name.size() - 4, 4);
+  std::transform(ext.begin(), ext.end(), ext.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  // TODO(SeanCurtis-TRI) Support other image types.
+  if (ext != ".png") {
+    return false;
+  }
+
+  // Exit quickly if the file doesn't exist or is a directory.
+  const fs::path file_path(file_name);
+  if (!fs::exists(file_path) || fs::is_directory(file_path)) {
+    return false;
+  }
+
+  return true;
 }
 
 }  // namespace internal

--- a/geometry/render_gl/internal_texture_library.h
+++ b/geometry/render_gl/internal_texture_library.h
@@ -1,43 +1,88 @@
 #pragma once
 
 #include <map>
+#include <mutex>
 #include <optional>
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/geometry/render_gl/internal_opengl_context.h"
+#include "drake/geometry/render_gl/internal_opengl_includes.h"
 
 namespace drake {
 namespace geometry {
 namespace render_gl {
 namespace internal {
 
+/* Note to developers: Using file paths as unique identifiers prevents a texture
+ library instance from recognizing changes to images on disk. This doesn't seem
+ like much of a risk. In order for this failing to affect a user, the user would
+ would have to:
+
+   1. Load a mesh referencing a texture.
+   2. Update the texture in another program (while holding Drake initialization
+      in abeyance).
+   3. Load another mesh referencing the same texture path.
+
+ TextureLibrary doesn't regularly poll the file system to detect changes and
+ only loading a mesh would cause it to consider the filesystem again. As this
+ workflow seems unlikely, we'll defer this question til later.
+
+ We can't use a sha256 of the file's contents as the key because we'd never
+ recognize if a texture we already loaded had changed. We'd end up with a system
+ containing *both* versions of the texture (one on the old mesh, one on the
+ new). Instead, we'd use the same file path as key, but store the texture data
+ *and* the sha so that we only store one version of the image. */
+
 /* Stores a set of OpenGl textures objects, keyed by their in-filesystem name.
  Its purpose is to guarantee that an image in the file system is only stored
  once in an OpenGl context. As such, a %TextureLibrary instance is associated
- with an instance of OpenGlContext.  */
+ with an instance of OpenGlContext by RenderEngineGl.
+
+ By design, a single texture library is shared by a "family" of RenderEngineGl
+ instances -- the original and all instances *cloned* from it. The library
+ is threadsafe for adding new textures to the OpenGl context such that if one
+ instance loads a texture, the others will benefit from it instead of blindly
+ duplicating the texture in memory. This works because the OpenGlContext is
+ also shared across a family of RenderEngineGl instances. */
 class TextureLibrary {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TextureLibrary)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TextureLibrary);
 
-  explicit TextureLibrary(const OpenGlContext* context);
+  TextureLibrary() = default;
 
   /* Returns the unique OpenGl identifier for the texture with the given name.
+   A new OpenGl identifier will be created if one doesn't already exist.
    Errors in loading the texture are processed *silently*. This will attempt
    to load the image if a texture hasn't already been added with the given
    `file_name`.
 
+   The caller (typically the owner of the %TextureLibrary instance) is
+   responsible for partnering the %TextureLibrary with an OpenGl context. The
+   texture's identifier will be created within that context (assuming it has
+   been bound).
+
    @param file_name  The absolute path to the file containing the texture data.
    @returns A valid OpenGl identifier if the texture has been successfully
-            added to the library, std::nullopt if not.  */
+            added to the library, std::nullopt if not.
+   @pre The OpenGl context "partnered" to this library has been bound. */
   std::optional<GLuint> GetTextureId(const std::string& file_name);
 
+  /* Reports the key to use for the texture with the given file_name.
+   This resolves symlinks to prevent redundant texture definitions. */
+  static std::string GetTextureKey(const std::string& file_name);
+
+  /* Reports if the file_name references an image type that is supported. */
+  static bool IsSupportedImage(const std::string& file_name);
+
  private:
-  const OpenGlContext* context_{};
+  friend class TextureLibraryTester;
 
   /* The mapping from requested texture file name to its OpenGl id (as existing
    in context_).  */
   std::map<std::string, GLuint> textures_;
+
+  /* Mutex to control access to textures_. */
+  std::mutex mutex_;
 };
 
 }  // namespace internal

--- a/geometry/render_gl/test/internal_texture_library_test.cc
+++ b/geometry/render_gl/test/internal_texture_library_test.cc
@@ -1,0 +1,88 @@
+#include "drake/geometry/render_gl/internal_texture_library.h"
+
+#include <filesystem>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/temp_directory.h"
+
+namespace drake {
+namespace geometry {
+namespace render_gl {
+namespace internal {
+namespace {
+
+namespace fs = std::filesystem;
+
+/* This test doesn't test the following:
+
+ - Thread safety of calling GetTextureId() - see multithread_safety_test.cc
+   for that test.
+ - Doesn't test the image parsing and OpenGl texture loading logic of
+   GetTextureId(). If that failed, it would be apparent in the RenderEngineGl
+   tests -- texture would not get loaded properly. */
+
+/* Confirms that the texture key is generated as expected, handling symlinks
+ and actual paths. */
+GTEST_TEST(TextureLibraryTest, TextureKey) {
+  const std::string image_link =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
+  // In the bazel ecosystem, all of our resources are symlinks.
+  ASSERT_TRUE(fs::is_symlink(image_link));
+  const std::string real_image = fs::read_symlink(image_link).string();
+  ASSERT_NE(image_link, real_image);
+
+  // A hard path to the file is its own key.
+  EXPECT_EQ(TextureLibrary::GetTextureKey(real_image), real_image);
+
+  // The symlink gets resolved.
+  EXPECT_EQ(TextureLibrary::GetTextureKey(image_link), real_image);
+
+  // Non-existent is its own key.
+  const std::string bad_path("/not/a/path/to/stuff");
+  EXPECT_EQ(TextureLibrary::GetTextureKey(bad_path), bad_path);
+}
+
+/* Confirms the logic for deciding if an image is supported. */
+GTEST_TEST(TextureLibraryTest, SupportedImage) {
+  const std::string image_link =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
+  const fs::path dir = temp_directory();
+
+  // Lower case.
+  const fs::path f1 = dir / "local.png";
+  fs::copy_file(image_link, f1);
+  EXPECT_TRUE(TextureLibrary::IsSupportedImage(f1.string()));
+
+  // Upper case.
+  const fs::path f2 = dir / "local.PNG";
+  fs::rename(f1, f2);
+  EXPECT_TRUE(TextureLibrary::IsSupportedImage(f2.string()));
+
+  // Unsupported extension.
+  const fs::path f3 = dir / "local.jpg";
+  fs::rename(f2, f3);
+  EXPECT_FALSE(TextureLibrary::IsSupportedImage(f3.string()));
+
+  // Almost supported extension.
+  const fs::path f4 = dir / "localpng";
+  fs::rename(f3, f4);
+  EXPECT_FALSE(TextureLibrary::IsSupportedImage(f4.string()));
+
+  // Non-existent file.
+  EXPECT_FALSE(
+      TextureLibrary::IsSupportedImage((dir / "not_real.png").string()));
+
+  // Badly named directory.
+  const fs::path local_dir = dir / "dir.png";
+  fs::create_directory(local_dir);
+  EXPECT_FALSE(TextureLibrary::IsSupportedImage(local_dir.string()));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace render_gl
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render_gl/test/multithread_safety_test.cc
+++ b/geometry/render_gl/test/multithread_safety_test.cc
@@ -1,0 +1,71 @@
+#include <future>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/ssize.h"
+#include "drake/common/text_logging.h"
+#include "drake/geometry/render_gl/internal_texture_library.h"
+
+namespace drake {
+namespace geometry {
+namespace render_gl {
+namespace internal {
+
+class TextureLibraryTester {
+ public:
+  static int NumTextures(const TextureLibrary& library) {
+    return ssize(library.textures_);
+  }
+};
+
+}  // namespace internal
+}  // namespace render_gl
+
+namespace {
+
+using render_gl::internal::TextureLibrary;
+using render_gl::internal::TextureLibraryTester;
+
+/* We should be able to safely call GetTextureId in multiple threads. */
+GTEST_TEST(ThreadSafetyTest, TextureLibrary) {
+  TextureLibrary library;
+  ASSERT_EQ(TextureLibraryTester::NumTextures(library), 0);
+
+  const std::string image_name =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
+
+  std::atomic<int> num_errors{0};
+  auto work = [&library, &image_name, &num_errors] (int i) {
+    try {
+      std::optional<GLuint> id = library.GetTextureId(image_name);
+      if (!id.has_value()) {
+        throw std::runtime_error("no valid texture id returned.");
+      }
+    } catch (std::exception& e) {
+      log()->error("Worker {} unexpected error: {}", i, e.what());
+      ++num_errors;
+    }
+  };
+
+  std::vector<std::future<void>> futures;
+  futures.push_back(std::async(std::launch::async, work, 0));
+  futures.push_back(std::async(std::launch::async, work, 1));
+  futures.push_back(std::async(std::launch::async, work, 2));
+
+  for (auto& future : futures) {
+    future.get();
+  }
+
+  /* All invocations successfully returned an id. */
+  ASSERT_EQ(num_errors, 0);
+  /* There is still only a single texture in the library. */
+  EXPECT_EQ(TextureLibraryTester::NumTextures(library), 1);
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
1. `TextureLibrary` no longer stores a pointer to `OpenGlContext`. It simply declares that the `OpenGlContext` must be bound. This will aid in cloning contexts across render engine families.
2. It handles look up of texture id in a thread-safe way. This was missing before and has now been corrected.
3. Tests have been added.
4. The texture library now handles symlink files so that a single file, aliased in different ways, doesn't lead to multiple textures on the GPU.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19507)
<!-- Reviewable:end -->
