### PR TITLE
OpenGlInstance now references OpenGlGeometry in preparation for cloning

### DIFF
--- a/geometry/render_gl/internal_opengl_geometry.h
+++ b/geometry/render_gl/internal_opengl_geometry.h
@@ -47,15 +47,22 @@ struct OpenGlGeometry {
    @param index_buffer_in       The handle to the OpenGl index buffer defining a
                                 set of triangles.
    @param index_buffer_size_in  The number of indices in the index buffer.
+   @param has_tex_coord_in      If true, the vertex buffer contains *meaningful*
+                                texture coordinates.
+   @param v_count_in            The number of vertices in this mesh (and, by
+                                implication, the number of normals and texture
+                                coordinates).
    @pre `index_buffer_size_in >= 0`.  */
-  OpenGlGeometry(GLuint vertex_array_in, GLuint vertex_buffer_in,
-                 GLuint index_buffer_in, int index_buffer_size_in,
-                 bool has_tex_coord_in)
+  OpenGlGeometry(GLuint vertex_array_in,
+                 GLuint vertex_buffer_in, GLuint index_buffer_in,
+                 int index_buffer_size_in, bool has_tex_coord_in,
+                 int v_count_in)
       : vertex_array{vertex_array_in},
         vertex_buffer{vertex_buffer_in},
         index_buffer{index_buffer_in},
         index_buffer_size{index_buffer_size_in},
-        has_tex_coord{has_tex_coord_in} {
+        has_tex_coord{has_tex_coord_in},
+        v_count(v_count_in) {
     if (index_buffer_size < 0) {
       throw std::logic_error("Index buffer size must be non-negative");
     }
@@ -77,33 +84,42 @@ struct OpenGlGeometry {
     if (!is_defined()) throw std::logic_error(message);
   }
 
+  // TODO(SeanCurtis-TRI): This can't really be a struct; there are invariants
+  // that need to be maintained: vertex_buffer is sized according to v_count,
+  // vertex_array depends on vertex_buffer, has_tex_coord needs to reflect
+  // the uv data in vertex_buffer, and index_buffer_size needs to be the actual
+  // size of index_buffer (in triangles).
   GLuint vertex_array{kInvalid};
   GLuint vertex_buffer{kInvalid};
   GLuint index_buffer{kInvalid};
   int index_buffer_size{0};
+
   /* True indicates that this has texture coordinates to support texture
    maps. See MeshData::has_tex_coord for detail.  */
   bool has_tex_coord{};
+
+  // The number of vertices encoded in `vertex_buffer`.
+  int v_count{};
 
   /* The value of an object (array, buffer) that should be considered invalid.
    */
   static constexpr GLuint kInvalid = std::numeric_limits<GLuint>::max();
 };
 
-/* An instance of a geometry in the renderer - the underlying OpenGl geometry
- definition in Frame G, its pose in the world frame W, and scale factors. The
- scale factors are not required to be uniform. They _can_ be negative, but that
- is not recommended; in addition to mirroring the geometry it will also turn
- the geometry "inside out".
+/* An instance of a geometry in the renderer - a reference to the underlying
+ OpenGl geometry definition in Frame G, its pose in the world frame W, and scale
+ factors. The scale factors are not required to be uniform. They _can_ be
+ negative, but that is not recommended; in addition to mirroring the geometry it
+ will also turn the geometry "inside out".
 
  When rendering, the visual geometry will be scaled around G's origin and
  subsequently posed relative to W.  */
 struct OpenGlInstance {
   /* Constructs an instance from a geometry definition, a pose, a scale factor
    and the instance's shader data for depth and label shaders.
-   @pre `g_in.is_defined()` reports `true`.
+   @pre g_in references a defined OpenGlGeometry.
    @pre The shader program data has valid shader ids.  */
-  OpenGlInstance(const OpenGlGeometry& g_in,
+  OpenGlInstance(int g_in,
                  const math::RigidTransformd& pose_in,
                  const Vector3<double>& scale_in, ShaderProgramData color_data,
                  ShaderProgramData depth_data, ShaderProgramData label_data)
@@ -114,12 +130,13 @@ struct OpenGlInstance {
     shader_data[RenderType::kColor] = std::move(color_data);
     shader_data[RenderType::kDepth] = std::move(depth_data);
     shader_data[RenderType::kLabel] = std::move(label_data);
-    DRAKE_DEMAND(geometry.is_defined());
+    DRAKE_DEMAND(geometry >= 0);
   }
 
+  // This is the index to the OpenGlGeometry stored by RenderEngineGl.
+  int geometry{};
   // TODO(SeanCurtis-TRI) Change these quantities to be float-valued so they
   //  can go directly into the shader without casting.
-  OpenGlGeometry geometry;
   math::RigidTransformd X_WG;
   Vector3<double> scale;
   std::array<ShaderProgramData, RenderType::kTypeCount> shader_data;

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -7,6 +7,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 
@@ -40,6 +41,8 @@ using systems::sensors::ImageTraits;
 using systems::sensors::PixelType;
 
 namespace {
+
+namespace fs = std::filesystem;
 
 constexpr char kInternalGroup[] = "render_engine_gl_internal";
 constexpr char kHasTexCoordProperty[] = "has_tex_coord";
@@ -508,9 +511,9 @@ void RenderEngineGl::UpdateViewpoint(const RigidTransformd& X_WR) {
 }
 
 void RenderEngineGl::ImplementGeometry(const Box& box, void* user_data) {
-  OpenGlGeometry geometry = GetBox();
-  ImplementGeometry(geometry, user_data,
-                    Vector3d(box.width(), box.depth(), box.height()));
+  const int geometry = GetBox();
+  AddGeometryInstance(geometry, user_data,
+                      Vector3d(box.width(), box.depth(), box.height()));
 }
 
 void RenderEngineGl::ImplementGeometry(const Capsule& capsule,
@@ -519,57 +522,57 @@ void RenderEngineGl::ImplementGeometry(const Capsule& capsule,
   RenderMesh mesh_data =
       MakeCapsule(resolution, capsule.radius(), capsule.length());
 
-  OpenGlGeometry geometry = CreateGlGeometry(mesh_data);
-  capsules_.push_back(geometry);
+  const int geometry = CreateGlGeometry(mesh_data);
 
-  ImplementGeometry(geometry, user_data, Vector3d::Ones());
+  AddGeometryInstance(geometry, user_data, Vector3d::Ones());
 }
 
 void RenderEngineGl::ImplementGeometry(const Convex& convex, void* user_data) {
-  OpenGlGeometry geometry = GetMesh(convex.filename());
+  const int geometry = GetMesh(convex.filename());
   ImplementMesh(geometry, user_data, Vector3d(1, 1, 1) * convex.scale(),
                 convex.filename());
 }
 
 void RenderEngineGl::ImplementGeometry(const Cylinder& cylinder,
                                        void* user_data) {
-  OpenGlGeometry geometry = GetCylinder();
+  const int geometry = GetCylinder();
   const double r = cylinder.radius();
   const double l = cylinder.length();
-  ImplementGeometry(geometry, user_data, Vector3d(r, r, l));
+  AddGeometryInstance(geometry, user_data, Vector3d(r, r, l));
 }
 
 void RenderEngineGl::ImplementGeometry(const Ellipsoid& ellipsoid,
                                        void* user_data) {
-  OpenGlGeometry geometry = GetSphere();
-  ImplementGeometry(geometry, user_data,
-                    Vector3d(ellipsoid.a(), ellipsoid.b(), ellipsoid.c()));
+  const int geometry = GetSphere();
+  AddGeometryInstance(geometry, user_data,
+                      Vector3d(ellipsoid.a(), ellipsoid.b(), ellipsoid.c()));
 }
 
 void RenderEngineGl::ImplementGeometry(const HalfSpace&, void* user_data) {
-  OpenGlGeometry geometry = GetHalfSpace();
-  ImplementGeometry(geometry, user_data, Vector3d(1, 1, 1));
+  const int geometry = GetHalfSpace();
+  AddGeometryInstance(geometry, user_data, Vector3d(1, 1, 1));
 }
 
 void RenderEngineGl::ImplementGeometry(const Mesh& mesh, void* user_data) {
-  OpenGlGeometry geometry = GetMesh(mesh.filename());
+  const int geometry = GetMesh(mesh.filename());
   ImplementMesh(geometry, user_data, Vector3d(1, 1, 1) * mesh.scale(),
                 mesh.filename());
 }
 
 void RenderEngineGl::ImplementGeometry(const Sphere& sphere, void* user_data) {
-  OpenGlGeometry geometry = GetSphere();
+  const int geometry = GetSphere();
   const double r = sphere.radius();
-  ImplementGeometry(geometry, user_data, Vector3d(r, r, r));
+  AddGeometryInstance(geometry, user_data, Vector3d(r, r, r));
 }
 
-void RenderEngineGl::ImplementMesh(const OpenGlGeometry& geometry,
+void RenderEngineGl::ImplementMesh(int geometry_index,
                                    void* user_data,
                                    const Vector3<double>& scale,
                                    const std::string& file_name) {
   const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
   PerceptionProperties temp_props(data.properties);
 
+  const OpenGlGeometry& geometry = geometries_[geometry_index];
   temp_props.AddProperty(
       kInternalGroup, kHasTexCoordProperty, geometry.has_tex_coord);
 
@@ -588,7 +591,7 @@ void RenderEngineGl::ImplementMesh(const OpenGlGeometry& geometry,
   }
 
   RegistrationData temp_data{data.id, data.X_WG, temp_props};
-  ImplementGeometry(geometry, &temp_data, scale);
+  AddGeometryInstance(geometry_index, &temp_data, scale);
 }
 
 bool RenderEngineGl::DoRegisterVisual(GeometryId id, const Shape& shape,
@@ -650,7 +653,8 @@ void RenderEngineGl::RenderAt(const ShaderProgram& shader_program,
   for (const GeometryId& g_id :
        shader_families_.at(render_type).at(shader_program.shader_id())) {
     const OpenGlInstance& instance = visuals_.at(g_id);
-    glBindVertexArray(instance.geometry.vertex_array);
+    const OpenGlGeometry& geometry = geometries_[instance.geometry];
+    glBindVertexArray(geometry.vertex_array);
 
     shader_program.SetInstanceParameters(instance.shader_data[render_type]);
     // TODO(SeanCurtis-TRI): Consider storing the float-valued pose in the
@@ -661,7 +665,7 @@ void RenderEngineGl::RenderAt(const ShaderProgram& shader_program,
     shader_program.SetModelViewMatrix(
         X_CW * instance.X_WG.GetAsMatrix4().cast<float>(), instance.scale);
 
-    glDrawElements(GL_TRIANGLES, instance.geometry.index_buffer_size,
+    glDrawElements(GL_TRIANGLES, geometry.index_buffer_size,
                    GL_UNSIGNED_INT, 0);
   }
   // Unbind the vertex array back to the default of 0.
@@ -681,14 +685,10 @@ void RenderEngineGl::DoRenderColorImage(const ColorRenderCamera& camera,
 
   const RenderTarget render_target =
       GetRenderTarget(camera.core(), RenderType::kColor);
-  // TODO(SeanCurtis-TRI) Consider converting Rgba to float[4] as a method on
-  //  Rgba.
-  const Rgba& clear = parameters_.default_clear_color;
-  float clear_color[4] = {
-      static_cast<float>(clear.r()), static_cast<float>(clear.g()),
-      static_cast<float>(clear.b()), static_cast<float>(clear.a())};
+  const Vector4<float> clear_color =
+      parameters_.default_clear_color.rgba().cast<float>();
   glClearNamedFramebufferfv(render_target.frame_buffer, GL_COLOR, 0,
-                            &clear_color[0]);
+                            clear_color.data());
   glClear(GL_DEPTH_BUFFER_BIT);
   // We only want blending for color; not for label or depth.
   glEnable(GL_BLEND);
@@ -698,9 +698,7 @@ void RenderEngineGl::DoRenderColorImage(const ColorRenderCamera& camera,
   const Eigen::Matrix4f T_DC =
       camera.core().CalcProjectionMatrix().cast<float>();
 
-  for (const auto& [shader_id, shader_ptr] :
-       shader_programs_[RenderType::kColor]) {
-    unused(shader_id);
+  for (const auto& [_, shader_ptr] : shader_programs_[RenderType::kColor]) {
     const ShaderProgram& shader_program = *shader_ptr;
     shader_program.Use();
 
@@ -741,8 +739,8 @@ void RenderEngineGl::DoRenderDepthImage(const DepthRenderCamera& camera,
   const Eigen::Matrix4f T_DC =
       camera.core().CalcProjectionMatrix().cast<float>();
 
-  for (const auto& id_shader_pair : shader_programs_[RenderType::kDepth]) {
-    const ShaderProgram& shader_program = *(id_shader_pair.second);
+  for (const auto& [_, shader_ptr] : shader_programs_[RenderType::kDepth]) {
+    const ShaderProgram& shader_program = *shader_ptr;
     shader_program.Use();
 
     shader_program.SetProjectionMatrix(T_DC);
@@ -778,8 +776,8 @@ void RenderEngineGl::DoRenderLabelImage(const ColorRenderCamera& camera,
   const Eigen::Matrix4f T_DC =
       camera.core().CalcProjectionMatrix().cast<float>();
 
-  for (const auto& id_shader_pair : shader_programs_[RenderType::kLabel]) {
-    const ShaderProgram& shader_program = *(id_shader_pair.second);
+  for (const auto& [_, shader_ptr] : shader_programs_[RenderType::kLabel]) {
+    const ShaderProgram& shader_program = *shader_ptr;
     shader_program.Use();
 
     shader_program.SetProjectionMatrix(T_DC);
@@ -800,8 +798,8 @@ void RenderEngineGl::DoRenderLabelImage(const ColorRenderCamera& camera,
   GetLabelImage(label_image_out, render_target);
 }
 
-void RenderEngineGl::ImplementGeometry(const OpenGlGeometry& geometry,
-                                       void* user_data, const Vector3d& scale) {
+void RenderEngineGl::AddGeometryInstance(int geometry_index, void* user_data,
+                                         const Vector3d& scale) {
   const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
   std::optional<ShaderProgramData> color_data =
       GetShaderProgram(data.properties, RenderType::kColor);
@@ -813,7 +811,7 @@ void RenderEngineGl::ImplementGeometry(const OpenGlGeometry& geometry,
                label_data.has_value());
 
   visuals_.emplace(data.id,
-                   OpenGlInstance(geometry, data.X_WG, scale, *color_data,
+                   OpenGlInstance(geometry_index, data.X_WG, scale, *color_data,
                                   *depth_data, *label_data));
 
   shader_families_[RenderType::kColor][color_data->shader_id()].push_back(
@@ -824,8 +822,8 @@ void RenderEngineGl::ImplementGeometry(const OpenGlGeometry& geometry,
       data.id);
 }
 
-OpenGlGeometry RenderEngineGl::GetSphere() {
-  if (!sphere_.is_defined()) {
+int RenderEngineGl::GetSphere() {
+  if (sphere_ < 0) {
     const int kLatitudeBands = 50;
     const int kLongitudeBands = 50;
 
@@ -835,13 +833,14 @@ OpenGlGeometry RenderEngineGl::GetSphere() {
     sphere_ = CreateGlGeometry(mesh_data);
   }
 
-  sphere_.throw_if_undefined("Built-in sphere has some invalid objects");
+  geometries_[sphere_].throw_if_undefined(
+      "Built-in sphere has some invalid objects");
 
   return sphere_;
 }
 
-OpenGlGeometry RenderEngineGl::GetCylinder() {
-  if (!cylinder_.is_defined()) {
+int RenderEngineGl::GetCylinder() {
+  if (cylinder_ < 0) {
     const int kLongitudeBands = 50;
 
     // For long skinny cylinders, it would be better to offer some subdivisions
@@ -850,13 +849,14 @@ OpenGlGeometry RenderEngineGl::GetCylinder() {
     cylinder_ = CreateGlGeometry(mesh_data);
   }
 
-  cylinder_.throw_if_undefined("Built-in cylinder has some invalid objects");
+  geometries_[cylinder_].throw_if_undefined(
+      "Built-in cylinder has some invalid objects");
 
   return cylinder_;
 }
 
-OpenGlGeometry RenderEngineGl::GetHalfSpace() {
-  if (!half_space_.is_defined()) {
+int RenderEngineGl::GetHalfSpace() {
+  if (half_space_ < 0) {
     // This matches the RenderEngineVtk half space size. Keep them matching
     // so that the common "horizon" unit test passes.
     const GLfloat kMeasure = 100.f;
@@ -867,39 +867,45 @@ OpenGlGeometry RenderEngineGl::GetHalfSpace() {
     half_space_ = CreateGlGeometry(mesh_data);
   }
 
-  half_space_.throw_if_undefined(
+  geometries_[half_space_].throw_if_undefined(
       "Built-in half space has some invalid objects");
 
   return half_space_;
 }
 
-OpenGlGeometry RenderEngineGl::GetBox() {
-  if (!box_.is_defined()) {
+int RenderEngineGl::GetBox() {
+  if (box_ < 0) {
     RenderMesh mesh_data = MakeUnitBox();
     box_ = CreateGlGeometry(mesh_data);
   }
 
-  box_.throw_if_undefined("Built-in box has some invalid objects");
+  geometries_[box_].throw_if_undefined("Built-in box has some invalid objects");
 
   return box_;
 }
 
-OpenGlGeometry RenderEngineGl::GetMesh(const string& filename) {
-  OpenGlGeometry mesh;
+int RenderEngineGl::GetMesh(const string& filename_in) {
+  int mesh = -1;
+  // Handle the case where filename_in is a symlink.
+  const fs::path path_in(filename_in);
+  const fs::path file_path =
+      fs::is_symlink(path_in) ? fs::read_symlink(path_in) : path_in;
+  const std::string filename = file_path.string();
+
   if (meshes_.count(filename) == 0) {
     // TODO(SeanCurtis-TRI): We're ignoring the declared perception properties
     //  for the mesh. We need to pass it in and return a mesh *and* the
     //  resulting material properties.
     RenderMesh mesh_data = LoadRenderMeshFromObj(
-        filename, PerceptionProperties(), parameters_.default_diffuse);
+        filename_in, PerceptionProperties(), parameters_.default_diffuse);
     mesh = CreateGlGeometry(mesh_data);
     meshes_.insert({filename, mesh});
   } else {
     mesh = meshes_[filename];
   }
 
-  mesh.throw_if_undefined(
-      fmt::format("Error creating object for mesh {}", filename).c_str());
+  geometries_[mesh].throw_if_undefined(
+      fmt::format("Error creating object for mesh {}", filename_in).c_str());
 
   return mesh;
 }
@@ -1008,10 +1014,8 @@ RenderTarget RenderEngineGl::GetRenderTarget(const RenderCameraCore& camera,
   return target;
 }
 
-OpenGlGeometry RenderEngineGl::CreateGlGeometry(const RenderMesh& mesh_data) {
+int RenderEngineGl::CreateGlGeometry(const RenderMesh& mesh_data) {
   OpenGlGeometry geometry;
-  // Create the vertex array object (VAO).
-  glCreateVertexArrays(1, &geometry.vertex_array);
 
   // Create the vertex buffer object (VBO).
   glCreateBuffers(1, &geometry.vertex_buffer);
@@ -1041,37 +1045,6 @@ OpenGlGeometry RenderEngineGl::CreateGlGeometry(const RenderMesh& mesh_data) {
                        vertex_data.size() * sizeof(GLfloat),
                        vertex_data.data(), 0);
 
-  std::size_t vbo_offset = 0;
-
-  const int position_attrib = 0;
-  glVertexArrayVertexBuffer(geometry.vertex_array, position_attrib,
-                            geometry.vertex_buffer, vbo_offset,
-                            kFloatsPerPosition * sizeof(GLfloat));
-  glVertexArrayAttribFormat(geometry.vertex_array, position_attrib,
-                            kFloatsPerPosition, GL_FLOAT, GL_FALSE, 0);
-  glEnableVertexArrayAttrib(geometry.vertex_array, position_attrib);
-  vbo_offset += v_count * kFloatsPerPosition * sizeof(GLfloat);
-
-  const int normal_attrib = 1;
-  glVertexArrayVertexBuffer(
-      geometry.vertex_array, normal_attrib, geometry.vertex_buffer,
-      vbo_offset, kFloatsPerNormal * sizeof(GLfloat));
-  glVertexArrayAttribFormat(geometry.vertex_array, normal_attrib,
-                            kFloatsPerNormal, GL_FLOAT, GL_FALSE, 0);
-  glEnableVertexArrayAttrib(geometry.vertex_array, normal_attrib);
-  vbo_offset += v_count * kFloatsPerNormal * sizeof(GLfloat);
-
-  const int uv_attrib = 2;
-  glVertexArrayVertexBuffer(
-      geometry.vertex_array, uv_attrib, geometry.vertex_buffer,
-      vbo_offset, kFloatsPerUv * sizeof(GLfloat));
-  glVertexArrayAttribFormat(geometry.vertex_array, uv_attrib,
-                            kFloatsPerUv, GL_FLOAT,
-                            GL_FALSE, 0);
-  glEnableVertexArrayAttrib(geometry.vertex_array, uv_attrib);
-  vbo_offset += v_count * kFloatsPerUv * sizeof(GLfloat);
-  DRAKE_DEMAND(vbo_offset == vertex_data.size() * sizeof(GLfloat));
-
   // Create the index buffer object (IBO).
   using indices_uint_t = decltype(mesh_data.indices)::Scalar;
   static_assert(sizeof(GLuint) == sizeof(indices_uint_t),
@@ -1080,19 +1053,69 @@ OpenGlGeometry RenderEngineGl::CreateGlGeometry(const RenderMesh& mesh_data) {
   glNamedBufferStorage(geometry.index_buffer,
                        mesh_data.indices.size() * sizeof(GLuint),
                        mesh_data.indices.data(), 0);
-  // Bind IBO with the VAO.
-  glVertexArrayElementBuffer(geometry.vertex_array, geometry.index_buffer);
 
   geometry.index_buffer_size = mesh_data.indices.size();
 
   geometry.has_tex_coord = mesh_data.has_tex_coord;
+
+  geometry.v_count = v_count;
+  CreateVertexArray(&geometry);
 
   // Note: We won't need to call the corresponding glDeleteVertexArrays or
   // glDeleteBuffers. The meshes we store are "canonical" meshes. Even if a
   // particular GeometryId is removed, it was only referencing its corresponding
   // canonical mesh. We keep all canonical meshes alive for the lifetime of the
   // OpenGL context for convenient reuse.
-  return geometry;
+  const int index = ssize(geometries_);
+  geometries_.push_back(geometry);
+  return index;
+}
+
+void RenderEngineGl::CreateVertexArray(OpenGlGeometry* geometry) const {
+  glCreateVertexArrays(1, &geometry->vertex_array);
+
+  // 3 floats each for position and normal, 2 for texture coordinates.
+  const int kFloatsPerPosition = 3;
+  const int kFloatsPerNormal = 3;
+  const int kFloatsPerUv = 2;
+
+  std::size_t vbo_offset = 0;
+
+  const int position_attrib = 0;
+  glVertexArrayVertexBuffer(geometry->vertex_array, position_attrib,
+                            geometry->vertex_buffer, vbo_offset,
+                            kFloatsPerPosition * sizeof(GLfloat));
+  glVertexArrayAttribFormat(geometry->vertex_array, position_attrib,
+                            kFloatsPerPosition, GL_FLOAT, GL_FALSE, 0);
+  glEnableVertexArrayAttrib(geometry->vertex_array, position_attrib);
+  vbo_offset += geometry->v_count * kFloatsPerPosition * sizeof(GLfloat);
+
+  const int normal_attrib = 1;
+  glVertexArrayVertexBuffer(
+      geometry->vertex_array, normal_attrib, geometry->vertex_buffer,
+      vbo_offset, kFloatsPerNormal * sizeof(GLfloat));
+  glVertexArrayAttribFormat(geometry->vertex_array, normal_attrib,
+                            kFloatsPerNormal, GL_FLOAT, GL_FALSE, 0);
+  glEnableVertexArrayAttrib(geometry->vertex_array, normal_attrib);
+  vbo_offset += geometry->v_count * kFloatsPerNormal * sizeof(GLfloat);
+
+  const int uv_attrib = 2;
+  glVertexArrayVertexBuffer(
+      geometry->vertex_array, uv_attrib, geometry->vertex_buffer,
+      vbo_offset, kFloatsPerUv * sizeof(GLfloat));
+  glVertexArrayAttribFormat(geometry->vertex_array, uv_attrib,
+                            kFloatsPerUv, GL_FLOAT,
+                            GL_FALSE, 0);
+  glEnableVertexArrayAttrib(geometry->vertex_array, uv_attrib);
+  vbo_offset += geometry->v_count * kFloatsPerUv * sizeof(GLfloat);
+
+  const float float_count =
+      geometry->v_count *
+      (kFloatsPerPosition + kFloatsPerNormal + kFloatsPerUv);
+  DRAKE_DEMAND(vbo_offset == float_count * sizeof(GLfloat));
+
+  // Bind index buffer object (IBO) with the vertex array object (VAO).
+  glVertexArrayElementBuffer(geometry->vertex_array, geometry->index_buffer);
 }
 
 void RenderEngineGl::SetWindowVisibility(const RenderCameraCore& camera,
@@ -1131,12 +1154,13 @@ ShaderProgramData RenderEngineGl::GetShaderProgram(
   std::optional<ShaderProgramData> data{std::nullopt};
   for (const auto& id_shader_pair : shader_programs_[render_type]) {
     const ShaderProgram& program = *(id_shader_pair.second);
+
+    // We prioritize the shader by id; higher ids will always win.
+    if (data.has_value() && program.shader_id() < data->shader_id()) continue;
+
     std::optional<ShaderProgramData> candidate_data =
         program.CreateProgramData(properties);
     if (candidate_data.has_value()) {
-      if (data.has_value()) {
-        if (candidate_data->shader_id() < data->shader_id()) continue;
-      }
       data = std::move(candidate_data);
     }
   }

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -72,7 +72,10 @@ class RenderEngineGl final : public render::RenderEngine {
   // legacy behavior of mapping mesh.obj -> mesh.png, applying it as a diffuse
   // texture, if found. When we eliminate that behavior, we can eliminate this
   // method.
-  void ImplementMesh(const OpenGlGeometry& geometry, void* user_data,
+  //
+  // @param geometry_index   The index into geometries_ of the mesh's
+  //                         OpenGlGeometry.
+  void ImplementMesh(int geometry_index, void* user_data,
                      const Vector3<double>& scale,
                      const std::string& file_name);
 
@@ -114,19 +117,32 @@ class RenderEngineGl final : public render::RenderEngine {
   void RenderAt(const ShaderProgram& shader_program,
                 RenderType render_type) const;
 
-  // Performs the common setup for all shape types.
-  void ImplementGeometry(const OpenGlGeometry& geometry,
-                         void* user_data, const Vector3<double>& scale);
+  // Creates a geometry instance from the referenced geometry data, scale, and
+  // user data (e.g., GeometryId, perception properties). The instance is added
+  // to visuals_.
+  //
+  // @param geometry_index   The index into geometries_ of the geometry used by
+  //                         this instance.
+  void AddGeometryInstance(int geometry_index, void* user_data,
+                           const Vector3<double>& scale);
 
+  // The set of all geometries. These are the geometries that have the
+  // identifiers for the OpenGl geometries on the GPU.
+  std::vector<OpenGlGeometry> geometries_;
+
+  // TODO(SeanCurtis-TRI): Make these threadsafe. Particularly, w.r.t. the
+  // underlying OpenGl context where multiple RenderEngineGl clones share the
+  // same GPU memory objects.
   // Provides triangle mesh definitions of the various canonical geometries
   // supported by this renderer: sphere, cylinder, half space, box, and mesh.
-  // These update the stored OpenGlGeometry members of this class. They are
-  // *not* threadsafe.
-  OpenGlGeometry GetSphere();
-  OpenGlGeometry GetCylinder();
-  OpenGlGeometry GetHalfSpace();
-  OpenGlGeometry GetBox();
-  OpenGlGeometry GetMesh(const std::string& filename);
+  // The returned value is an index into geometries_.
+  // If the canonical mesh has not been defined yet, it will be defined.
+  // These are *not* threadsafe.
+  int GetSphere();
+  int GetCylinder();
+  int GetHalfSpace();
+  int GetBox();
+  int GetMesh(const std::string& filename);
 
   // Given the render type, returns the texture configuration for that render
   // type. These are the key arguments for glTexImage2D based on the render
@@ -159,8 +175,14 @@ class RenderEngineGl final : public render::RenderEngine {
                                RenderType render_type) const;
 
   // Creates an OpenGlGeometry from the mesh defined by the given `mesh_data`.
-  static OpenGlGeometry CreateGlGeometry(
+  // The geometry is added to geometries_ and its index is returned.
+  // This is *not* threadsafe.
+  int CreateGlGeometry(
       const geometry::internal::RenderMesh& mesh_data);
+
+  // Given a geometry that has its buffers (and vertex counts assigned), ties
+  // all of the buffer data into the vertex array attributes.
+  void CreateVertexArray(OpenGlGeometry* geometry) const;
 
   // Sets the display window visibility and populates it with the _last_ image
   // rendered, if visible.
@@ -184,9 +206,8 @@ class RenderEngineGl final : public render::RenderEngine {
   // we exploit the behind-the-scenes knowledge that Identifiers are
   // monotonically increasing. So, the shader that is added last implicitly is
   // more preferred than the earlier shader.
-  ShaderProgramData GetShaderProgram(
-      const PerceptionProperties& properties,
-      RenderType render_type) const;
+  ShaderProgramData GetShaderProgram(const PerceptionProperties& properties,
+                                     RenderType render_type) const;
 
   void SetDefaultLightPosition(const Vector3<double>& light_dir_C) override {
     light_dir_C_ = light_dir_C.normalized().cast<float>();
@@ -226,22 +247,28 @@ class RenderEngineGl final : public render::RenderEngine {
              RenderType::kTypeCount>
       shader_programs_;
 
-  // One OpenGlGeometry per primitive type. They represent a canonical, "unit"
-  // version of the primitive type. Each instance scales and poses the
-  // corresponding primitive to create arbitrarily sized geometries.
-  OpenGlGeometry sphere_;
-  OpenGlGeometry cylinder_;
-  OpenGlGeometry half_space_;
-  OpenGlGeometry box_;
+  // For each primitive type, we create a single OpenGlGeometry. Each represents
+  // a canonical, "unit" version of the primitive type. Each OpenGlInstance
+  // scales and poses the corresponding primitive to create arbitrarily sized
+  // geometries. These members are the indices into geometries_ of the primitive
+  // geometry. A negative value means the primitive shape hasn't been created
+  // in the OpenGlContext yet.
+  //
+  // There is no capsule_ because each capsule is unique. Generally, one capsule
+  // cannot be realized from another capsule via a linear transformation (i.e.,
+  // translation, rotation, and non-uniform scale).
+  int sphere_{-1};
+  int cylinder_{-1};
+  int half_space_{-1};
+  int box_{-1};
   // TODO(SeanCurtis-TRI): Figure out how to re-use capsules - if two capsules
   // have the same dimensions (or are related by a *uniform* scale*), we can
-  // re-use the same geometry.
-  // Each capsule is unique; they cannot generally be related by a linear
-  // transform (i.e., translation, rotation, and non-uniform scale).
-  std::vector<OpenGlGeometry> capsules_;
+  // re-use the same geometry. For example, if we tracked them by "aspect ratio"
+  // and allowed deviation within a small tolerance, then we could reuse them.
 
-  // Mapping from obj filename to the mesh loaded into an OpenGlGeometry.
-  std::unordered_map<std::string, OpenGlGeometry> meshes_;
+  // Mapping from obj filename to the index into geometries_ containing the
+  // OpenGlGeometry representation of the mesh.
+  std::unordered_map<std::string, int> meshes_;
 
   // These are caches of reusable RenderTargets. There is a unique render target
   // for each unique image size (BufferDim) and output image type. The

--- a/geometry/render_gl/test/internal_opengl_geometry_test.cc
+++ b/geometry/render_gl/test/internal_opengl_geometry_test.cc
@@ -28,35 +28,37 @@ GTEST_TEST(OpenGlGeometryTest, Construction) {
   EXPECT_EQ(default_geometry.index_buffer, OpenGlGeometry::kInvalid);
   EXPECT_EQ(default_geometry.index_buffer_size, 0);
   EXPECT_EQ(default_geometry.has_tex_coord, false);
+  EXPECT_EQ(default_geometry.v_count, 0);
 
-  const OpenGlGeometry geometry{1, 2, 3, 4, true};
+  const OpenGlGeometry geometry{1, 2, 3, 4, true, 7};
   EXPECT_EQ(geometry.vertex_array, 1);
   EXPECT_EQ(geometry.vertex_buffer, 2);
   EXPECT_EQ(geometry.index_buffer, 3);
   EXPECT_EQ(geometry.index_buffer_size, 4);
   EXPECT_EQ(geometry.has_tex_coord, true);
+  EXPECT_EQ(geometry.v_count, 7);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      OpenGlGeometry(1, 2, 3, -1, false),
+      OpenGlGeometry(1, 2, 3, -1, false, 1),
       "Index buffer size must be non-negative");
 }
 
 GTEST_TEST(OpenGlGeometryTest, IsDefined) {
   const GLuint kInvalid = OpenGlGeometry::kInvalid;
 
-  EXPECT_TRUE(OpenGlGeometry(1, 2, 3, 4, false).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, 3, 4, false).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, 3, 4, false).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(1, 2, kInvalid, 4, false).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, kInvalid, 3, 4, false).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, kInvalid, 4, false).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, kInvalid, 4, false).is_defined());
+  EXPECT_TRUE(OpenGlGeometry(1, 2, 3, 4, false, 1).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, 3, 4, false, 1).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, 3, 4, false, 1).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(1, 2, kInvalid, 4, false, 1).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(kInvalid, kInvalid, 3, 4, false, 1).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, kInvalid, 4, false, 1).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, kInvalid, 4, false, 1).is_defined());
   EXPECT_FALSE(
-      OpenGlGeometry(kInvalid, kInvalid, kInvalid, 4, false).is_defined());
+      OpenGlGeometry(kInvalid, kInvalid, kInvalid, 4, false, 1).is_defined());
 }
 
 GTEST_TEST(OpenGlGeometryTest, ThrowIfUndefined) {
-  const OpenGlGeometry valid{1, 2, 3, 4, false};
+  const OpenGlGeometry valid{1, 2, 3, 4, false, 1};
   EXPECT_NO_THROW(valid.throw_if_undefined("test message"));
   DRAKE_EXPECT_THROWS_MESSAGE(
       OpenGlGeometry().throw_if_undefined("default is undefined"),
@@ -64,7 +66,8 @@ GTEST_TEST(OpenGlGeometryTest, ThrowIfUndefined) {
 }
 
 GTEST_TEST(OpenGlInstanceTest, Construction) {
-  const OpenGlGeometry geometry(1, 2, 3, 4, true);
+  // This is a dummy index that doesn't reference into any particular geometry.
+  const int geometry_index = 2;
   const RigidTransformd X_WG{Vector3d{-1, -2, 3}};
   const Vector3d scale{0.25, 0.5, 0.75};
   // We'll create a pretend block of depth data; simply a double value with no
@@ -76,13 +79,10 @@ GTEST_TEST(OpenGlInstanceTest, Construction) {
   const ShaderProgramData color_data(
       ShaderId::get_new_id(), AbstractValue::Make(33));
 
-  const OpenGlInstance instance{geometry,   X_WG,       scale,
-                                color_data, depth_data, label_data};
+  const OpenGlInstance instance{geometry_index, X_WG,       scale,
+                                color_data,     depth_data, label_data};
 
-  EXPECT_EQ(instance.geometry.vertex_array, geometry.vertex_array);
-  EXPECT_EQ(instance.geometry.vertex_buffer, geometry.vertex_buffer);
-  EXPECT_EQ(instance.geometry.index_buffer, geometry.index_buffer);
-  EXPECT_EQ(instance.geometry.index_buffer_size, geometry.index_buffer_size);
+  EXPECT_EQ(instance.geometry, geometry_index);
   EXPECT_TRUE(
       CompareMatrices(instance.X_WG.GetAsMatrix34(), X_WG.GetAsMatrix34()));
   EXPECT_TRUE(CompareMatrices(instance.scale, scale));

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -48,7 +48,8 @@ class RenderEngineGlTester {
   }
 
   const internal::OpenGlGeometry GetMesh(const std::string& filename) const {
-    return const_cast<RenderEngineGl&>(engine_).GetMesh(filename);
+    const int index = const_cast<RenderEngineGl&>(engine_).GetMesh(filename);
+    return engine_.geometries_[index];
   }
 
  private:


### PR DESCRIPTION
Previously, each `OpenGlInstance` contained a *copy* of the `OpenGlGeometry` that it instantiated. While the cost of a few ints isn't overly burdensome, this will be an obstacle in future efforts to clone the OpenGl context.

`RenderEngineGl` now maintains a vector of `OpenGlGeometry` and each instance merely gets an index into that vector. These indices are amenable to copying without requiring changing the references.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19508)
<!-- Reviewable:end -->
