### PR TITLE
Start refactoring push_release script

### DIFF
--- a/tools/release_engineering/dev/BUILD.bazel
+++ b/tools/release_engineering/dev/BUILD.bazel
@@ -1,0 +1,24 @@
+# -*- python -*-
+
+load(
+    "//tools/skylark:drake_py_per_os.bzl",
+    "drake_py_binary_ubuntu_only",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:private"])
+
+# This program is used by a small subset of Drake maintainers, all of whom
+# operate solely on Ubuntu, and furthermore relies on manual testing. Since we
+# never develop, use, or test this on macOS, we reflect that in the build
+# system by omitting the target entirely on macOS. Note that it also depends on
+# maintainer-only packages.
+drake_py_binary_ubuntu_only(
+    name = "push_release",
+    srcs = ["push_release.py"],
+    deps = [
+        "@github3_py_internal//:github3_py",
+    ],
+)
+
+add_lint_tests()

--- a/tools/release_engineering/dev/push_release
+++ b/tools/release_engineering/dev/push_release
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-readonly usage="Usage: $0 {{ source version x.y.z }} {{ binary version YYYYMMDD }} [--apt] [--no-docker] [--no-tar]"
+readonly usage="Usage: $0 {{ source version x.y.z }} {{ binary version YYYYMMDD }} [--apt] [--no-docker]"
 
 if [[ "$#" -lt 2 ]]; then
   echo "${usage}" >&2
@@ -31,7 +31,6 @@ shift 2;
 # Do not publish Debian packages by default as they need to be manually built.
 push_apt=0
 push_docker=1
-push_tar=1
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -40,9 +39,6 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --no-docker)
       push_docker=0
-      ;;
-    --no-tar)
-      push_tar=0
       ;;
     *)
       echo "${usage}" >&2
@@ -62,7 +58,7 @@ if [[ "${push_apt}" -ne 0 ]] && ! command -v aptly &>/dev/null; then
   exit 3
 fi
 
-if [[ "${push_apt}" -ne 0 || "${push_tar}" -ne 0 ]] && ! command -v aws &>/dev/null; then
+if [[ "${push_apt}" -ne 0 ]] && ! command -v aws &>/dev/null; then
   echo 'ERROR: aws(1) was NOT found. Fix with apt-get install awscli or brew install awscli.' >&2
   exit 4
 fi
@@ -85,13 +81,6 @@ fi
 if [[ "${push_apt}" -ne 0 ]] && ! command -v gpg &>/dev/null; then
   echo 'ERROR: gpg(1) was NOT found. Fix with apt-get install gnupg or brew install gnupg.' >&2
   exit 6
-fi
-
-# sha256sum and sha512sum are not available on macOS and unusually this is a
-# maintainer script that will usually be used on macOS.
-if [[ "${push_tar}" -ne 0 ]] && ! command -v shasum &>/dev/null; then
-  echo 'ERROR: shasum(1) was NOT found. Fix with apt-get install libdigest-sha-perl.' >&2
-  exit 7
 fi
 
 # Sanity check that the release for the source version exists and has been
@@ -183,8 +172,6 @@ readonly temp_dir="$(mktemp -u)"
 mkdir -p "${temp_dir}"
 pushd "${temp_dir}"
 
-algorithms=( 256 512 )
-
 if [[ "${push_apt}" -ne 0 ]]; then
   set -x
 
@@ -205,16 +192,6 @@ if [[ "${push_apt}" -ne 0 ]]; then
 
     curl --fail --location --remote-name \
       "https://drake-packages.csail.mit.edu/drake/release/${platform}/${filename}"
-
-    # Generate checksums of the downloaded Debian package and upload the
-    # checksums to S3.
-    for algorithm in "${algorithms[@]}"; do
-      sha_filename="${filename}.sha${algorithm}"
-
-      shasum --algorithm "${algorithm}" "${filename}" | tee "${sha_filename}"
-      aws s3 cp "${sha_filename}" \
-        "s3://drake-packages/drake/release/${platform}/${sha_filename}"
-    done
 
     # Add the Debian package to the aptly database.
     aptly repo add "drake-${platform}" "${filename}"
@@ -239,50 +216,6 @@ if [[ "${push_apt}" -ne 0 ]]; then
   # Upload the new version of the aptly database to S3.
   aws s3 sync --delete --exclude .DS_Store "${HOME}/.aptly" \
     s3://drake-infrastructure/aptly/.aptly
-
-  set +x
-fi
-
-platforms+=( mac )
-
-if [[ "${push_tar}" -ne 0 ]]; then
-  set -x
-
-  # Download the nightly binary release archives for focal, jammy, and mac from
-  # S3 via CloudFront and rename with the x.y.z version number.
-  for platform in "${platforms[@]}"; do
-    curl --fail --location --output "drake-${source_version}-${platform}.tar.gz" \
-      "https://drake-packages.csail.mit.edu/drake/nightly/drake-${binary_version}-${platform}.tar.gz"
-  done
-
-  # Download the source release archive from GitHub and rename with the x.y.z
-  # version number and the suffix src.
-  curl --fail --location --output "drake-${source_version}-src.tar.gz" \
-    "https://github.com/RobotLocomotion/drake/archive/v${source_version}.tar.gz"
-
-  platforms+=( src )
-
-  # You need write credentials to drake-packages bucket S3. The number of people
-  # or bots that have or need these are necessarily very small.
-  if [[ ! -s "${HOME}/.aws/credentials" ]]; then
-    aws configure
-  fi
-
-  # Generate checksums of the renamed binary and source release archives and
-  # upload each archive and checksum to S3.
-  for platform in "${platforms[@]}"; do
-    filename="drake-${source_version}-${platform}.tar.gz"
-
-    aws s3 cp "${filename}" "s3://drake-packages/drake/release/${filename}"
-
-    for algorithm in "${algorithms[@]}"; do
-      sha_filename="${filename}.sha${algorithm}"
-
-      shasum --algorithm "${algorithm}" "${filename}" | tee "${sha_filename}"
-      aws s3 cp "${sha_filename}" \
-        "s3://drake-packages/drake/release/${sha_filename}"
-    done
-  done
 
   set +x
 fi

--- a/tools/release_engineering/dev/push_release.py
+++ b/tools/release_engineering/dev/push_release.py
@@ -1,0 +1,373 @@
+"""
+Uploads Drake release artifacts.
+
+This is intended for use by Drake maintainers (only).
+This program is only supported on Ubuntu Jammy 22.04.
+"""
+
+import argparse
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+import boto3
+
+import github3
+from github3.repos.release import Asset, Release
+from github3.repos.repo import Repository
+
+
+_GITHUB_REPO_OWNER = 'RobotLocomotion'
+_GITHUB_REPO_NAME = 'drake'
+
+_ARCHIVE_HASHES = {'sha256', 'sha512'}
+
+_DOCKER_PLATFORMS = {'focal', 'jammy'}
+
+_AWS_BUCKET = 'drake-packages'
+
+
+@dataclass
+class _Artifact:
+    name: str
+    ext: str
+    asset: Asset
+    version: str
+    platform: str
+    arch: str = None
+    hashes: Dict[str, Asset] = field(default_factory=dict)
+
+
+class _Manifest:
+    """
+    Regex matching a tarball, e.g. 'drake-19990101-mac-arm64.tar.gz'.
+    """
+    RE_TAR = re.compile(
+        r'^drake-'
+        r'(?P<id>[0-9]{8})-'
+        r'(?P<platform>\w+)'
+        r'(-(?P<arch>\w+))?.'
+        r'(?P<ext>tar.[gx]z)$')
+    """
+    Regex matching a .deb package, e.g. 'drake-dev_0.1.0-1_amd64-jammy.deb'.
+    """
+    RE_DEB = re.compile(
+        r'^drake-dev_'
+        r'(?P<id>[^-]+-[0-9]+)_'
+        r'(?P<arch>\w+)-'
+        r'(?P<platform>\w+).'
+        r'(?P<ext>deb)$')
+
+    def __init__(self, release: Release):
+        self._assets = list(release.assets())
+
+    def _find_hashes(self, name) -> Dict[str, Asset]:
+        """
+        Finds hashes associated with an asset of the given name.
+        """
+        pre = f'{name}.sha'
+        result = {}
+
+        for a in self._assets:
+            if a.name.startswith(pre):
+                result[a.name[len(pre):]] = a
+
+        return result
+
+    def find_artifacts(self, regex: re.Pattern) -> List[_Artifact]:
+        """
+        Finds assets whose name matches the given regular expression.
+
+        The regular expression must be one of RE_TAR or RE_DEB members
+        of this class.
+        """
+        result = []
+
+        for a in self._assets:
+            m = regex.match(a.name)
+            if m is not None:
+                attrs = m.groupdict()
+                n = attrs.pop('id')
+
+                artifact = _Artifact(name=a.name, asset=a, version=n, **attrs)
+                artifact.hashes = self._find_hashes(a.name)
+                result.append(artifact)
+
+        return result
+
+
+@dataclass
+class _State:
+    options: Dict[str, Any]
+    release: Release
+    manifest: _Manifest
+
+    def __init__(self, options: Dict[str, Any], release: Release):
+        self.options = options
+        self.release = release
+        self.manifest = _Manifest(release)
+        self._scratch = tempfile.TemporaryDirectory()
+        self._s3 = boto3.client('s3')
+
+        self.find_artifacts = self.manifest.find_artifacts
+
+    def _push_asset(self, asset: Asset, bucket: str, path: str):
+        """
+        Pushes the specified asset to S3.
+
+        If --dry-run was given, rather than actually pushing files to S3,
+        prints what would be done.
+        """
+        if self.options.dry_run:
+            print(f'push {asset.name!r} to s3://{bucket}/{path}')
+        else:
+            local_path = os.path.join(self._scratch.name, asset.name)
+            assert asset.download(path=local_path) is not None
+
+            self._s3.upload_file(local_path, bucket, path)
+
+    def _compute_hash(self, path: str, algorithm: str):
+        """
+        Compute the specified hash for the specified file.
+        """
+        with open(path, 'rb') as f:
+            if hasattr(hashlib, 'file_digest'):
+                return hashlib.file_digest(f, algorithm)
+
+            else:
+                digest = hashlib.new(algorithm)
+                buf = bytearray(256 * 1024)
+                view = memoryview(buf)
+
+                while True:
+                    size = f.readinto(buf)
+                    if size == 0:
+                        break
+                    digest.update(view[:size])
+
+                return digest
+
+    def push_artifact(self, artifact: _Artifact, bucket: str,
+                      path: str, include_hashes: bool = True):
+        """
+        Pushes the specified artifact to S3, optionally including any
+        associated hashes.
+
+        If --dry-run was given, rather than actually pushing files to S3,
+        prints what would be done.
+        """
+        self._push_asset(artifact.asset, bucket, path)
+        if include_hashes:
+            for h, a in artifact.hashes.items():
+                self._push_asset(a, bucket, f'{path}.sha{h}')
+
+    def push_archive(self, bucket: str, path: str, name: str,
+                     archive_format: str = 'tarball'):
+        """
+        Pushes the release source archive to S3, along with computed hashes.
+
+        If --dry-run was given, rather than actually pushing files to S3,
+        prints what would be done.
+        """
+        local_path = os.path.join(self._scratch.name, name)
+        assert self.release.archive(archive_format, local_path)
+
+        if self.options.dry_run:
+            print(f'push {name!r} to s3://{bucket}/{path}/{name}')
+        else:
+            self._s3.upload_file(local_path, bucket, path)
+
+        # Calculate hashes and write hash files
+        for algorithm in _ARCHIVE_HASHES:
+            hashfile_name = f'{name}.{algorithm}'
+            hashfile_path = os.path.join(self._scratch.name, hashfile_name)
+            remote_path = f'{path}/{hashfile_name}'
+
+            digest = self._compute_hash(local_path, algorithm)
+
+            with open(hashfile_path, 'wt') as f:
+                f.write(f'{digest.hexdigest()}  {name}\n')
+
+            if self.options.dry_run:
+                print(f'{name!r} {algorithm}: {digest.hexdigest()}')
+                print(f'push {hashfile_name!r} to s3://{bucket}/{remote_path}')
+            else:
+                self._s3.upload_file(hashfile_path, bucket, remote_path)
+
+
+def _fatal(msg: str, result: int = 1):
+    width = shutil.get_terminal_size().columns
+    for line in msg.split('\n'):
+        print(textwrap.fill(line, width), file=sys.stderr)
+    sys.exit(result)
+
+
+def _assert_tty():
+    try:
+        subprocess.check_call(['tty', '-s'])
+    except subprocess.CalledProcessError:
+        _fatal('ERROR: tty was NOT detected. This script may need'
+               ' various login credentials to be entered interactively.')
+        sys.exit(1)
+
+
+def _assert_command_exists(name: str, package: str):
+    """
+    Asserts that an executable <name> exists,
+    or tells the user to install <package>.
+    """
+    if shutil.which(name) is None:
+        _fatal(f'ERROR: `{name}` was not found. '
+               f'Fix with `apt-get install {package}`.')
+
+
+def _test_non_empty(path):
+    """
+    Tests if the specified path exists and is a non-empty file.
+    """
+    if path is None:
+        return False
+
+    path = os.path.expanduser(path)
+    if not os.path.exists(path):
+        return False
+
+    return os.stat(path).st_size > 0
+
+
+def _check_version(version):
+    """
+    Returns True iff the given version string matches PEP 440.
+    """
+    return re.match(
+        r'^([1-9][0-9]*!)?(0|[1-9][0-9]*)'
+        r'(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?'
+        r'(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?'
+        r'([+][a-z0-9]+([-_\.][a-z0-9]+)*)?$',
+        version) is not None
+
+
+def _find_tag(repo: Repository, tag: str):
+    """
+    Finds the tag <tag> in the repository <repo>.
+    """
+    for t in repo.tags():
+        if t.name == tag:
+            return t
+    return None
+
+
+def _push_tar(state: _State):
+    """
+    Downloads .tar artifacts and push them to S3.
+    """
+    version = state.options.source_version
+    for tar in state.find_artifacts(_Manifest.RE_TAR):
+        # TODO(mwoehlke-kitware):
+        # Eventually, the tarballs should use the version number and not the
+        # build date in their name, and we won't need this renaming logic. At
+        # that time, the code below should become:
+        #   state.push_artifact(tar, _AWS_BUCKET, f'drake/release/{tar.name}')
+        if tar.arch is None:
+            variant = tar.platform
+        else:
+            variant = f'{tar.platform}-{tar.arch}'
+        dest_name = f'drake-{version}-{variant}.{tar.ext}'
+        state.push_artifact(tar, _AWS_BUCKET, f'drake/release/{dest_name}')
+
+    dest_name = f'drake-{version}-src.tar.gz'
+
+    # TODO(mwoehlke-kitware):
+    # Eventually, the source tarball should be a discrete asset of the GitHub
+    # release, including hash files.
+    state.push_archive(_AWS_BUCKET, 'drake/release', dest_name)
+
+
+def _push_deb(state: _State):
+    """
+    Downloads .deb artifacts and push them to S3.
+    """
+    for deb in state.find_artifacts(_Manifest.RE_DEB):
+        dest_name = f'drake-dev_{deb.version}_{deb.arch}.{deb.ext}'
+        dest_path = f'drake/release/{deb.platform}/{dest_name}'
+        state.push_artifact(deb, _AWS_BUCKET, dest_path)
+
+
+def main(args: List[str]):
+    parser = argparse.ArgumentParser(
+        prog='push_release', description=__doc__)
+    parser.add_argument(
+        '--deb', dest='push_deb', default=True,
+        action=argparse.BooleanOptionalAction,
+        help='Mirror .deb packages to S3.')
+    parser.add_argument(
+        '--tar', dest='push_tar', default=True,
+        action=argparse.BooleanOptionalAction,
+        help='Mirror .tar packages to S3.')
+    parser.add_argument(
+        '-n', '--dry-run', default=False,
+        action=argparse.BooleanOptionalAction,
+        help='Print what would be done without actually pushing anything.')
+    parser.add_argument(
+        '--token', default='~/.config/readonly_github_api_token.txt',
+        help='Use the GitHub an API token read from this path, if it exists.'
+             ' Otherwise, anonymous access will be used, which may run into'
+             ' rate limitations. (default: %(default)s)')
+    parser.add_argument(
+        'source_version',
+        help='Version tag (x.y.z) of the release to be pushed.')
+    options = parser.parse_args(args)
+
+    # Validate version arguments
+    if not _check_version(options.source_version):
+        _fatal(f'ERROR: source_version {options.source_version!r}'
+               ' is not a valid version number.')
+
+    # Ensure execution environment is suitable.
+    _assert_tty()
+    if options.push_tar or options.push_deb:
+        if not _test_non_empty('~/.aws/credentials'):
+            _fatal('ERROR: AWS credentials were not found.\n\n'
+                   'The --tar and/or --deb options require the ability'
+                   ' to push files to S3, which requires authentication'
+                   ' credentials to be provided.\n\n'
+                   'Fix this by running `aws configure`.')
+
+    # Get GitHub repository, release tag, and release object.
+    if _test_non_empty(options.token):
+        with open(os.path.expanduser(options.token), 'r') as f:
+            token = f.read().strip()
+        gh = github3.login(token=token)
+    else:
+        gh = github3.GitHub()
+    repo = gh.repository(_GITHUB_REPO_OWNER, _GITHUB_REPO_NAME)
+    release_tag = _find_tag(repo, f'v{options.source_version}')
+
+    if release_tag is None:
+        _fatal(f'ERROR: GitHub tag v{options.source_version}'
+               ' does NOT exist.')
+
+    release = repo.release_from_tag(release_tag)
+
+    if release_tag is None:
+        _fatal(f'ERROR: GitHub release {release_tag.name!r} does NOT exist.')
+
+    # Set up shared state
+    state = _State(options, release)
+
+    # Push the requested release artifacts.
+    if options.push_tar:
+        _push_tar(state)
+    if options.push_deb:
+        _push_deb(state)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
Create a new push_release script written in Python. This takes over mirroring the .tar and .deb artifacts (and their respective hashes) to S3; the latter in particular replaces what was formerly a manual process due to the names being different. This also removes local specification of the artifact set and local recalculation of the hashes; both now use whatever is associated with the GitHub release.

Also, remove the actions handled by the new script from the old script. Eventually we expect to move the docker and apt steps to this script as well.

_Edit: Towards #18659_.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19510)
<!-- Reviewable:end -->
