### PR TITLE
Implements multibody::RigidTransformSelector

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -26,6 +26,7 @@
 #include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/multibody/plant/point_pair_contact_info.h"
 #include "drake/multibody/plant/propeller.h"
+#include "drake/multibody/plant/rigid_transform_selector.h"
 #include "drake/multibody/plant/wing.h"
 #include "drake/multibody/tree/spatial_inertia.h"
 
@@ -1310,6 +1311,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_spatial_forces_output_port",
             &Class::get_spatial_forces_output_port, py_rvp::reference_internal,
             cls_doc.get_spatial_forces_output_port.doc);
+  }
+
+  // RigidTransformSelector
+  {
+    using Class = RigidTransformSelector<T>;
+    constexpr auto& cls_doc = doc.RigidTransformSelector;
+    auto cls = DefineTemplateClassWithDefault<Class, systems::LeafSystem<T>>(
+        m, "RigidTransformSelector", param, cls_doc.doc);
+    cls  // BR
+        .def(py::init<int>(), py::arg("index"), cls_doc.ctor.doc)
+        .def("index", &Class::index, cls_doc.index.doc);
   }
 
   // Wing

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -83,6 +83,7 @@ from pydrake.multibody.plant import (
     PointPairContactInfo_,
     PropellerInfo,
     Propeller_,
+    RigidTransformSelector_,
     Wing,
 )
 from pydrake.multibody.parsing import Parser
@@ -2662,6 +2663,11 @@ class TestPlant(unittest.TestCase):
 
         prop2 = Propeller_[float]([info, info])
         self.assertEqual(prop2.num_propellers(), 2)
+
+    @numpy_compare.check_all_types
+    def test_rigid_transform_selector(self, T):
+        system = RigidTransformSelector_[T](index=2)
+        self.assertIsInstance(system, LeafSystem_[T])
 
     def test_wing(self):
         builder = DiagramBuilder()

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -33,6 +33,7 @@ drake_cc_package_library(
         ":multibody_plant_core",
         ":point_pair_contact_info",
         ":propeller",
+        ":rigid_transform_selector",
         ":slicing_and_indexing",
         ":tamsi_solver",
         ":wing",
@@ -355,6 +356,17 @@ drake_cc_library(
     hdrs = ["propeller.h"],
     deps = [
         ":multibody_plant_core",
+    ],
+)
+
+drake_cc_library(
+    name = "rigid_transform_selector",
+    srcs = ["rigid_transform_selector.cc"],
+    hdrs = ["rigid_transform_selector.h"],
+    deps = [
+        "//common:default_scalars",
+        "//math:geometric_transform",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -1052,6 +1064,15 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//systems/framework",
+    ],
+)
+
+drake_cc_googletest(
+    name = "rigid_transform_selector_test",
+    deps = [
+        ":rigid_transform_selector",
+        "//common/test_utilities:expect_throws_message",
+        "//systems/framework/test_utilities",
     ],
 )
 

--- a/multibody/plant/externally_applied_spatial_force_multiplexer.h
+++ b/multibody/plant/externally_applied_spatial_force_multiplexer.h
@@ -23,6 +23,7 @@ output_ports:
 @endsystem
 
 @tparam_default_scalar
+@ingroup multibody_systems
 */
 template <typename T>
 class ExternallyAppliedSpatialForceMultiplexer final

--- a/multibody/plant/rigid_transform_selector.cc
+++ b/multibody/plant/rigid_transform_selector.cc
@@ -1,0 +1,44 @@
+#include "drake/multibody/plant/rigid_transform_selector.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+RigidTransformSelector<T>::RigidTransformSelector(int index)
+    : systems::LeafSystem<T>(systems::SystemTypeTag<RigidTransformSelector>{}),
+      index_(index) {
+  DRAKE_DEMAND(index >= 0);
+  this->DeclareAbstractInputPort("vector", Value<ListType>());
+  this->DeclareAbstractOutputPort("element",
+                                  &RigidTransformSelector<T>::CalcOutput);
+}
+
+template <typename T>
+template <typename U>
+RigidTransformSelector<T>::
+RigidTransformSelector(
+    const RigidTransformSelector<U>& other)
+    : RigidTransformSelector(other.index()) { }
+
+template <typename T>
+void RigidTransformSelector<T>::CalcOutput(
+    const systems::Context<T>& context,
+    ValueType* output) const {
+  const ListType& vector =
+      this->get_input_port().template Eval<ListType>(context);
+  if (index_ >= static_cast<int>(vector.size())) {
+    throw std::runtime_error(fmt::format(
+        "RigidTransformSelector cannot select index {} from a vector of size "
+        "{}.",
+        index_, vector.size()));
+  }
+  *output = vector[index_];
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::RigidTransformSelector)

--- a/multibody/plant/rigid_transform_selector.h
+++ b/multibody/plant/rigid_transform_selector.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+
+// TODO(russt): We should also provide SpatialVelocitySelector, and
+// SpatialAccelerationSelector, to carve up the other std::vector output ports
+// from MultibodyPlant.  While it is tempting to template<template> this class,
+// or use type erasure, that gets into the "sharp corners" discussed in
+// https://github.com/RobotLocomotion/drake/issues/16923 .
+
+/**
+Makes a single element from a std::vector<RigidTransform<T>> available on the
+single output port. This can be used, for instance, to extract a single pose
+from the `body_poses` output port of MultibodyPlant.
+
+@system
+name: RigidTransformSelector
+input_ports:
+- vector
+output_ports:
+- element
+@endsystem
+
+Note: In Drake parlance, a "multiplexer" combines multiple input ports into a
+single output port, a "demultiplexer" extracts a single input port into multiple
+output ports, and a "selector" extracts a portion of the input port into a
+single output port.
+
+@tparam_default_scalar
+@ingroup multibody_systems
+*/
+template <typename T>
+class RigidTransformSelector final
+    : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RigidTransformSelector)
+
+  /**
+  Constructor.
+  @param num_inputs Number of input ports to be added.
+  */
+  explicit RigidTransformSelector(int index);
+
+  /** Returns the index into the input vector that will be selected. */
+  int index() const { return index_; }
+
+  /**
+  Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  */
+  template <typename U>
+  explicit RigidTransformSelector(
+      const RigidTransformSelector<U>& other);
+
+ private:
+  using ValueType = math::RigidTransform<T>;
+  using ListType = std::vector<ValueType>;
+
+  // This is the calculator for the output port.
+  void CalcOutput(
+      const systems::Context<T>& context, ValueType* output) const;
+
+  int index_;
+};
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::multibody::RigidTransformSelector)

--- a/multibody/plant/test/rigid_transform_selector_test.cc
+++ b/multibody/plant/test/rigid_transform_selector_test.cc
@@ -1,0 +1,45 @@
+#include "drake/multibody/plant/rigid_transform_selector.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/framework/fixed_input_port_value.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransform;
+using ListType = std::vector<RigidTransform<double>>;
+
+GTEST_TEST(RigidTransformSelectorTest, BasicTest) {
+  const int kIndex = 1;
+  RigidTransformSelector<double> dut(kIndex);
+  EXPECT_EQ(dut.num_input_ports(), 1);
+  EXPECT_EQ(dut.num_output_ports(), 1);
+  EXPECT_TRUE(dut.HasDirectFeedthrough(0, 0));
+
+  ListType vector(2);
+  vector[kIndex] = RigidTransform<double>(Vector3d(0.1, 0.2, 0.3));
+
+  auto context = dut.CreateDefaultContext();
+  dut.get_input_port().FixValue(context.get(), vector);
+  auto X =
+      dut.get_output_port().template Eval<RigidTransform<double>>(*context);
+  EXPECT_TRUE(X.IsExactlyEqualTo(vector[kIndex]));
+
+  ListType empty_vector;
+  dut.get_input_port().FixValue(context.get(), empty_vector);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.get_output_port().template Eval<RigidTransform<double>>(*context),
+      ".*cannot select index.*");
+
+  EXPECT_TRUE(systems::is_autodiffxd_convertible(dut));
+  EXPECT_TRUE(systems::is_symbolic_convertible(dut));
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
The MultibodyPlant body_poses output port provides a vector of all body poses, but often a downstream system just wants to take a single pose on the input port. This system provides that capability.

While RigidTransform lives in drake::math, I felt that this system should live in drake::multibody since it is likely to have SpatialVector and SpatialAcceleration equivalents alongside it soon.

+@jwnimmer-tri for both reviews(?), please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19520)
<!-- Reviewable:end -->
