### PR TITLE
[geometry] Add SceneGraphInspector::GetAllSourceIds

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -52,9 +52,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
          // Scene-graph wide data.
         .def("num_sources", &Class::num_sources, cls_doc.num_sources.doc)
-        .def("num_frames", &Class::num_frames, cls_doc.num_frames.doc);
-
-    cls  // BR
+        .def("num_frames", &Class::num_frames, cls_doc.num_frames.doc)
+        .def("GetAllSourceIds", &Class::GetAllSourceIds,
+            cls_doc.GetAllSourceIds.doc)
         .def("GetAllFrameIds", &Class::GetAllFrameIds,
             cls_doc.GetAllFrameIds.doc)
         .def("world_frame_id", &Class::world_frame_id,

--- a/bindings/pydrake/geometry/test/scene_graph_test.py
+++ b/bindings/pydrake/geometry/test/scene_graph_test.py
@@ -85,6 +85,7 @@ class TestGeometrySceneGraph(unittest.TestCase):
         inspector = scene_graph.model_inspector()
         self.assertEqual(inspector.num_sources(), 2)
         self.assertEqual(inspector.num_frames(), 3)
+        self.assertEqual(len(inspector.GetAllSourceIds()), 2)
         self.assertEqual(len(inspector.GetAllFrameIds()), 3)
         self.assertTrue(inspector.world_frame_id()
                         in inspector.GetAllFrameIds())

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -320,6 +320,20 @@ GeometryState<T>::GetCollisionCandidates() const {
 }
 
 template <typename T>
+std::vector<SourceId> GeometryState<T>::GetAllSourceIds() const {
+  std::vector<SourceId> result;
+  result.reserve(source_frame_id_map_.size());
+  result.push_back(self_source_);
+  for (const auto& [source_id, _] : source_names_) {
+    if (source_id != self_source_) {
+      result.push_back(source_id);
+    }
+  }
+  std::sort(result.begin() + 1, result.end());
+  return result;
+}
+
+template <typename T>
 bool GeometryState<T>::SourceIsRegistered(SourceId source_id) const {
   return source_frame_id_map_.find(source_id) != source_frame_id_map_.end();
 }

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -195,6 +195,11 @@ class GeometryState {
   /** @name          Sources and source-related data  */
   //@{
 
+  /** Returns all of the source ids in the scene graph. The order is guaranteed
+   to be stable and consistent. The first element is the SceneGraph-internal
+   source.  */
+  std::vector<SourceId> GetAllSourceIds() const;
+
   /** Implementation of SceneGraphInspector::SourceIsRegistered().  */
   bool SourceIsRegistered(SourceId source_id) const;
 

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -143,17 +143,15 @@ class QueryObject;
  registered with %SceneGraph as producers (a.k.a. _geometry sources_). They
  do this by acquiring a SourceId (via SceneGraph::RegisterSource()). The
  SourceId serves as a unique handle through which the producer's identity is
- validated and its ownership of its registered geometry is maintained.
+ validated.
 
  _Registering Geometry_
 
  %SceneGraph cannot know what geometry _should_ be part of the shared world.
  Other systems are responsible for introducing geometry into the world. This
  process (defining geometry and informing %SceneGraph) is called
- _registering_ the geometry. The source that registers the geometry "owns" the
- geometry; the source's unique SourceId is required to perform any operations
- on the geometry registered with that SourceId. Geometry can be registered as
- _anchored_ or _dynamic_.
+ _registering_ the geometry. Geometry can be registered as  _anchored_ or
+ _dynamic_, and is always registered to (associated with) a SourceId.
 
  Dynamic geometry can move; more specifically, its kinematics (e.g., pose)
  depends on a system's Context. Particularly, a non-deformable dynamic geometry
@@ -396,19 +394,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
      geometries can be registered via calls to the (experimental)
      RegisterDeformableGeometry() methods.
 
-   %SceneGraph has a concept of "ownership" that is separate from the C++
-   notion of ownership. In this case, %SceneGraph protects geometry and frames
-   registered by one source from being modified by another source. All methods
-   that change the world are associated with the SourceId of the geometry source
-   requesting the change. One source cannot "hang" geometry onto a frame (or
-   geometry) that belongs to another source. However, all sources have read
-   access to all geometries in the world. For example, queries will return
-   GeometryId values that span all sources and the properties of the associated
-   geometries can be queried by arbitrary sources.
-
-   That said, if one source _chooses_ to share its SourceId externally, then
-   arbitrary code can use that SourceId to modify the geometry resources that
-   are associated with that SourceId.
+   %SceneGraph has a concept of "ownership" that is separate from the C++ notion
+   of ownership. All methods that *change* the world require passing the
+   SourceId that was originally used to register that geometry. However,
+   read-only operations on geometries do not require the SourceId, e.g., queries
+   will return GeometryId values that span all sources and the properties of the
+   associated geometries can be queried by arbitrary sources.
 
    @note There are no Context-modifying variants for source or frame
    registration yet, as these methods modify the port semantics.  */
@@ -455,6 +446,8 @@ class SceneGraph final : public systems::LeafSystem<T> {
   FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
                         const GeometryFrame& frame);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument, instead using
+  // the source_id associated with the given `frame_id`.
   /** Registers a new rigid geometry G for this source. This hangs geometry G on
    a previously registered frame F (indicated by `frame_id`). The pose of the
    geometry is defined in a fixed pose relative to F (i.e., `X_FG`).
@@ -481,6 +474,8 @@ class SceneGraph final : public systems::LeafSystem<T> {
   GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument, instead using
+  // the source_id associated with the given `frame_id`.
   /** systems::Context-modifying variant of RegisterGeometry(). Rather than
    modifying %SceneGraph's model, it modifies the copy of the model stored in
    the provided context.  */
@@ -488,6 +483,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
                               FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry) const;
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** Registers a new _anchored_ geometry G for this source. This hangs geometry
    G from the world frame (W). Its pose is defined in that frame (i.e., `X_WG`).
    Returns the corresponding unique geometry id.
@@ -510,6 +506,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id, std::unique_ptr<GeometryInstance> geometry);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   // TODO(xuchenhan-tri): Consider allowing registering deformable geometries to
   // non-world frames.
   /** Registers a new deformable geometry G for this source. This registers
@@ -547,6 +544,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
       SourceId source_id, FrameId frame_id,
       std::unique_ptr<GeometryInstance> geometry, double resolution_hint);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** systems::Context-modifying variant of RegisterDeformableGeometry(). Rather
    than modifying %SceneGraph's model, it modifies the copy of the model stored
    in the provided context.
@@ -555,6 +553,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
       systems::Context<T>* context, SourceId source_id, FrameId frame_id,
       std::unique_ptr<GeometryInstance> geometry, double resolution_hint) const;
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** Changes the `shape` of the geometry indicated by the given `geometry_id`.
 
    The geometry is otherwise unchanged -- same geometry_id, same assigned roles,
@@ -584,6 +583,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
       SourceId source_id, GeometryId geometry_id, const Shape& shape,
       std::optional<math::RigidTransform<double>> X_FG = std::nullopt);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** systems::Context-modifying variant of ChangeShape(). Rather than modifying
    %SceneGraph's model, it modifies the copy of the model stored in the provided
    context.
@@ -593,6 +593,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
       const Shape& shape,
       std::optional<math::RigidTransform<double>> X_FG = std::nullopt);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** Removes the given geometry G (indicated by `geometry_id`) from the given
    source's registered geometries. All registered geometries hanging from
    this geometry will also be removed.
@@ -613,6 +614,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
                            not belong to the indicated source.  */
   void RemoveGeometry(SourceId source_id, GeometryId geometry_id);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** systems::Context-modifying variant of RemoveGeometry(). Rather than
    modifying %SceneGraph's model, it modifies the copy of the model stored in
    the provided context.  */
@@ -754,6 +756,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    These methods include the model- and context-modifying variants.    */
   //@{
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** Assigns the proximity role to the geometry indicated by `geometry_id`.
    Modifies the proximity version (see @ref scene_graph_versioning).
    @pydrake_mkdoc_identifier{proximity_direct}
@@ -762,6 +765,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
                   ProximityProperties properties,
                   RoleAssign assign = RoleAssign::kNew);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** systems::Context-modifying variant of
    @ref AssignRole(SourceId,GeometryId,ProximityProperties) "AssignRole()" for
    proximity properties. Rather than modifying %SceneGraph's model, it modifies
@@ -772,6 +776,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
                   GeometryId geometry_id, ProximityProperties properties,
                   RoleAssign assign = RoleAssign::kNew) const;
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** Assigns the perception role to the geometry indicated by `geometry_id`.
 
    By default, a geometry with a perception role will be reified by all
@@ -789,6 +794,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
                   PerceptionProperties properties,
                   RoleAssign assign = RoleAssign::kNew);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** systems::Context-modifying variant of
    @ref AssignRole(SourceId,GeometryId,PerceptionProperties) "AssignRole()" for
    perception properties. Rather than modifying %SceneGraph's model, it modifies
@@ -799,6 +805,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
                   GeometryId geometry_id, PerceptionProperties properties,
                   RoleAssign assign = RoleAssign::kNew) const;
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** Assigns the illustration role to the geometry indicated by `geometry_id`.
    Modifies the illustration version (see @ref scene_graph_versioning).
 
@@ -814,6 +821,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
                   IllustrationProperties properties,
                   RoleAssign assign = RoleAssign::kNew);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** systems::Context-modifying variant of
    @ref AssignRole(SourceId,GeometryId,IllustrationProperties) "AssignRole()"
    for illustration properties. Rather than modifying %SceneGraph's model, it
@@ -837,6 +845,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
                   GeometryId geometry_id, IllustrationProperties properties,
                   RoleAssign assign = RoleAssign::kNew) const;
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** Removes the indicated `role` from any geometry directly registered to the
    frame indicated by `frame_id` (if the geometry has the role).
    Potentially modifies the proximity, perception, or illustration version based
@@ -852,6 +861,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @pydrake_mkdoc_identifier{frame_direct}  */
   int RemoveRole(SourceId source_id, FrameId frame_id, Role role);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** systems::Context-modifying variant of
    @ref RemoveRole(SourceId,FrameId,Role) "RemoveRole()" for frames.
    Rather than modifying %SceneGraph's model, it modifies the copy of the model
@@ -860,6 +870,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   int RemoveRole(systems::Context<T>* context, SourceId source_id,
                  FrameId frame_id, Role role) const;
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** Removes the indicated `role` from the geometry indicated by `geometry_id`.
    Potentially modifies the proximity, perception, or illustration version based
    on the role being removed from the geometry (see @ref
@@ -875,6 +886,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @pydrake_mkdoc_identifier{geometry_direct}  */
   int RemoveRole(SourceId source_id, GeometryId geometry_id, Role role);
 
+  // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
   /** systems::Context-modifying variant of
    @ref RemoveRole(SourceId,GeometryId,Role) "RemoveRole()" for individual
    geometries. Rather than modifying %SceneGraph's model, it modifies the copy

--- a/geometry/scene_graph_inspector.cc
+++ b/geometry/scene_graph_inspector.cc
@@ -21,6 +21,12 @@ int SceneGraphInspector<T>::num_frames() const {
 }
 
 template <typename T>
+std::vector<SourceId> SceneGraphInspector<T>::GetAllSourceIds() const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetAllSourceIds();
+}
+
+template <typename T>
 std::vector<FrameId> SceneGraphInspector<T>::GetAllFrameIds() const {
   DRAKE_DEMAND(state_ != nullptr);
   typename GeometryState<T>::FrameIdRange range = state_->get_frame_ids();

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -87,6 +87,11 @@ class SceneGraphInspector {
    (including the world frame).  */
   int num_frames() const;
 
+  /** Returns all of the source ids in the scene graph. The order is guaranteed
+   to be stable and consistent. The first element is the SceneGraph-internal
+   source.  */
+  std::vector<SourceId> GetAllSourceIds() const;
+
   /** Returns all of the frame ids in the scene graph. The order is guaranteed
    to be stable and consistent. The ids include the world frame's id.  */
   std::vector<FrameId> GetAllFrameIds() const;

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
@@ -854,6 +855,15 @@ TEST_F(GeometryStateTest, SourceRegistrationWithNames) {
   DRAKE_EXPECT_NO_THROW((s_id = geometry_state_.RegisterNewSource(name)));
   EXPECT_TRUE(geometry_state_.SourceIsRegistered(s_id));
   EXPECT_EQ(geometry_state_.GetName(s_id), name);
+
+  // The first source id is the internal source.
+  ASSERT_EQ(geometry_state_.GetAllSourceIds().size(), 2);
+  const SourceId world_source = geometry_state_.GetAllSourceIds().front();
+  EXPECT_THAT(geometry_state_.FramesForSource(world_source),
+              testing::ElementsAre(gs_tester_.get_world_frame()));
+
+  // The second source id is the one we added.
+  EXPECT_EQ(geometry_state_.GetAllSourceIds().back(), s_id);
 
   // Case: User-specified name duplicates previously registered name.
   DRAKE_EXPECT_THROWS_MESSAGE(

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -45,6 +45,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
 
   // Scene-graph wide data methods.
   inspector.num_sources();
+  inspector.GetAllSourceIds();
 
   inspector.num_frames();
   inspector.num_geometries();


### PR DESCRIPTION
This enables downstream code to know which input ports and frame kinematics to provide to (or expect from) a SceneGraph.

Towards #19437.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19525)
<!-- Reviewable:end -->
