### PR TITLE
Fix EqualityConstrainedQPSolver.

### DIFF
--- a/solvers/equality_constrained_qp_solver.cc
+++ b/solvers/equality_constrained_qp_solver.cc
@@ -50,10 +50,14 @@ SolutionResult SolveUnconstrainedQP(const Eigen::Ref<const Eigen::MatrixXd>& G,
 
     // We first check if G is positive semidefinite, by doing an LDLT
     // decomposition.
-    Eigen::LDLT<Eigen::MatrixXd> ldlt(G);
-    if (ldlt.info() == Eigen::Success && ldlt.isPositive()) {
+    // I do not use LDLT to check the positive semidefiniteness. I found LDLT
+    // not very reliable.
+    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(G);
+    if (es.info() == Eigen::Success &&
+        (es.eigenvalues().array() >= -feasibility_tol).all()) {
       // G is positive semidefinite.
-      *x = ldlt.solve(-c);
+      Eigen::HouseholderQR<Eigen::MatrixXd> qr(G);
+      *x = qr.solve(-c);
       if ((G * (*x)).isApprox(-c, feasibility_tol)) {
         return SolutionResult::kSolutionFound;
       }

--- a/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/solvers/test/equality_constrained_qp_solver_test.cc
@@ -404,6 +404,11 @@ TEST_F(EqualityConstrainedQPSolverTest, WrongSolverOptions2) {
       "FeasibilityTol should be a non-negative number.");
 }
 
+GTEST_TEST(TestEqualityConstrainedQP1, Test) {
+  EqualityConstrainedQPSolver solver;
+  TestEqualityConstrainedQP1(solver);
+}
+
 GTEST_TEST(EqualityConstrainedQPSolverDualSolutionTest, DualSolution1) {
   EqualityConstrainedQPSolver solver;
   TestEqualityConstrainedQPDualSolution1(solver);
@@ -413,7 +418,6 @@ GTEST_TEST(EqualityConstrainedQPSolverDualSolutionTest, DualSolution2) {
   EqualityConstrainedQPSolver solver;
   TestEqualityConstrainedQPDualSolution2(solver);
 }
-
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -575,6 +575,11 @@ GTEST_TEST(GurobiTest, QPDualSolution3) {
   TestQPDualSolution3(solver);
 }
 
+GTEST_TEST(GurobiTest, TestEqualityConstrainedQP1) {
+  GurobiSolver solver;
+  TestEqualityConstrainedQP1(solver);
+}
+
 GTEST_TEST(GurobiTest, EqualityConstrainedQPDualSolution1) {
   GurobiSolver solver;
   TestEqualityConstrainedQPDualSolution1(solver);

--- a/solvers/test/quadratic_program_examples.cc
+++ b/solvers/test/quadratic_program_examples.cc
@@ -761,6 +761,29 @@ void TestDuplicatedVariableQuadraticProgram(const SolverInterface& solver,
   }
 }
 
+void TestEqualityConstrainedQP1(const SolverInterface& solver, double tol) {
+  MathematicalProgram prog{};
+  auto x = prog.NewContinuousVariables<2, 6>();
+  prog.AddQuadraticCost(0.5 * x(0, 5) * x(0, 5));
+  prog.AddLinearEqualityConstraint(x(0, 0) + 3 * x(0, 1) + 9 * x(0, 2) +
+                                       27 * x(0, 3) + 81 * x(0, 4) +
+                                       243 * x(0, 5) - x(1, 0),
+                                   0);
+  prog.AddLinearEqualityConstraint(x(0, 1) + 6 * x(0, 2) + 27 * x(0, 3) +
+                                       108 * x(0, 4) + 405 * x(0, 5) - x(1, 1),
+                                   0);
+  prog.AddLinearEqualityConstraint(x(0, 0), 0);
+  prog.AddLinearEqualityConstraint(x(0, 1), 0);
+  prog.AddLinearEqualityConstraint(x(1, 0), 6);
+  prog.AddLinearEqualityConstraint(x(1, 1), 0);
+
+  MathematicalProgramResult result;
+  solver.Solve(prog, std::nullopt, std::nullopt, &result);
+  EXPECT_TRUE(result.is_success());
+  const auto x_sol = result.GetSolution(x);
+  EXPECT_NEAR(x_sol(0, 5), 0, tol);
+}
+
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/quadratic_program_examples.h
+++ b/solvers/test/quadratic_program_examples.h
@@ -200,6 +200,14 @@ will have repeated entries for given variables.
  */
 void TestDuplicatedVariableQuadraticProgram(const SolverInterface& solver,
                                             double tol = 1E-7);
+
+/**
+ This program is reported in
+ https://github.com/RobotLocomotion/drake/issues/19524
+ This program has infinitely equally good optimal solution.
+ */
+void TestEqualityConstrainedQP1(const SolverInterface& solver,
+                                double tol = 1E-7);
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Resolves #19524 
Use SelfAdjointEigenSolver instead of LDLT solver to determine if the Hessian matrix is psd. LDLT reports info != Eigen::Success for a matrix that is positive semidefinite (up to a numerical precision) but not strictly positive definite.