### PR TITLE
[math] Narrow the circular dependency on systems/primitives

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -93,10 +93,13 @@ drake_cc_library(
     name = "continuous_algebraic_riccati_equation",
     srcs = ["continuous_algebraic_riccati_equation.cc"],
     hdrs = ["continuous_algebraic_riccati_equation.h"],
+    interface_deps = [],
     deps = [
         "//common:essential",
         "//common:is_approx_equal_abstol",
-        "//systems/primitives:linear_system",
+        # TODO(jwnimmer-tri) Move this code into //math to avoid the circular
+        # dependency.
+        "//systems/primitives:linear_system_internal",
     ],
 )
 

--- a/math/continuous_algebraic_riccati_equation.cc
+++ b/math/continuous_algebraic_riccati_equation.cc
@@ -1,8 +1,10 @@
 #include "drake/math/continuous_algebraic_riccati_equation.h"
 
+#include <optional>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/is_approx_equal_abstol.h"
-#include "drake/systems/primitives/linear_system.h"
+#include "drake/systems/primitives/linear_system_internal.h"
 
 namespace drake {
 namespace math {
@@ -43,14 +45,15 @@ Eigen::MatrixXd ContinuousAlgebraicRiccatiEquation(
         "detectable.");
   }
   // Now we actually check if the system is stabilizable and detectable.
-  const systems::LinearSystem<double> sys(
-      A, B, Q, Eigen::MatrixXd::Zero(Q.rows(), 0), 0 /* time_period=0.*/);
-  if (!systems::IsStabilizable(sys)) {
+  constexpr bool continuous_time = true;
+  constexpr std::optional<double> threshold = std::nullopt;
+  if (!systems::internal::IsStabilizable(A, B, continuous_time, threshold)) {
     throw std::runtime_error(
         "ContinuousAlgebraicRiccatiEquation fails. The system is not "
         "stabilizable.");
   }
-  if (!systems::IsDetectable(sys)) {
+  if (!systems::internal::IsDetectable(A, /* C = */ Q, continuous_time,
+                                       threshold)) {
     throw std::runtime_error(
         "ContinuousAlgebraicRiccatiEquation fails. The system is not "
         "detectable.");

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -171,11 +171,24 @@ drake_cc_library(
         "//common/symbolic:expression",
     ],
     deps = [
+        ":linear_system_internal",
         "//common/symbolic:polynomial",
         "//math:autodiff",
         "//math:gradient",
         "//systems/framework",
     ],
+)
+
+drake_cc_library(
+    name = "linear_system_internal",
+    srcs = ["linear_system_internal.cc"],
+    hdrs = ["linear_system_internal.h"],
+    internal = True,
+    visibility = ["//:__subpackages__"],
+    interface_deps = [
+        "//common:essential",
+    ],
+    deps = [],
 )
 
 drake_cc_library(

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -14,6 +14,7 @@
 #include "drake/math/autodiff_gradient.h"
 #include "drake/systems/framework/event.h"
 #include "drake/systems/framework/event_collection.h"
+#include "drake/systems/primitives/linear_system_internal.h"
 
 namespace drake {
 namespace systems {
@@ -253,99 +254,34 @@ std::unique_ptr<AffineSystem<double>> FirstOrderTaylorApproximation(
                                          std::move(output_port_index));
 }
 
-/// Returns the controllability matrix:  R = [B, AB, ..., A^{n-1}B].
 Eigen::MatrixXd ControllabilityMatrix(const LinearSystem<double>& sys) {
-  const int num_states = sys.B().rows(), num_inputs = sys.B().cols();
-  Eigen::MatrixXd R(num_states, num_states * num_inputs);
-  R.leftCols(num_inputs) = sys.B();
-  for (int i = 1; i < num_states; i++) {
-    R.middleCols(num_inputs * i, num_inputs) =
-        sys.A() * R.middleCols(num_inputs * (i - 1), num_inputs);
-  }
-  return R;
+  return internal::ControllabilityMatrix(sys.A(), sys.B());
 }
 
-/// Returns true iff the controllability matrix is full row rank.
 bool IsControllable(const LinearSystem<double>& sys,
                     std::optional<double> threshold) {
-  const auto R = ControllabilityMatrix(sys);
-  Eigen::ColPivHouseholderQR<Eigen::MatrixXd> lu_decomp(R);
-  if (threshold) {
-    lu_decomp.setThreshold(threshold.value());
-  }
-  return lu_decomp.rank() == sys.A().rows();
+  return internal::IsControllable(sys.A(), sys.B(), threshold);
 }
 
-/// Returns the observability matrix: O = [ C; CA; ...; CA^{n-1} ].
 Eigen::MatrixXd ObservabilityMatrix(const LinearSystem<double>& sys) {
-  const int num_states = sys.C().cols(), num_outputs = sys.C().rows();
-  Eigen::MatrixXd O(num_states * num_outputs, num_states);
-  O.topRows(num_outputs) = sys.C();
-  for (int i = 1; i < num_states; i++) {
-    O.middleRows(num_outputs * i, num_outputs) =
-        O.middleRows(num_outputs * (i - 1), num_outputs) * sys.A();
-  }
-  return O;
+  return internal::ObservabilityMatrix(sys.A(), sys.C());
 }
 
-/// Returns true iff the observability matrix is full column rank.
 bool IsObservable(const LinearSystem<double>& sys,
                   std::optional<double> threshold) {
-  const auto O = ObservabilityMatrix(sys);
-  Eigen::ColPivHouseholderQR<Eigen::MatrixXd> lu_decomp(O);
-  if (threshold) {
-    lu_decomp.setThreshold(threshold.value());
-  }
-  return lu_decomp.rank() == sys.A().rows();
+  return internal::IsObservable(sys.A(), sys.C(), threshold);
 }
-
-namespace {
-bool IsStabilizable(const Eigen::Ref<const Eigen::MatrixXd>& A,
-                    const Eigen::Ref<const Eigen::MatrixXd>& B,
-                    bool continuous_time, std::optional<double> threshold) {
-  // (A, B) is stabilizable if [(λI - A) B] is full rank for all unstable
-  // eigenvalues.
-  DRAKE_DEMAND(A.rows() == A.cols());
-  DRAKE_DEMAND(A.rows() == B.rows());
-  Eigen::EigenSolver<Eigen::MatrixXd> es(A);
-  DRAKE_DEMAND(es.info() == Eigen::Success);
-  for (int i = 0; i < es.eigenvalues().size(); ++i) {
-    bool stable_mode = false;
-    if (continuous_time) {
-      stable_mode = es.eigenvalues()(i).real() < 0;
-    } else {
-      stable_mode = std::norm(es.eigenvalues()(i)) < 1;
-    }
-    if (!stable_mode) {
-      Eigen::MatrixXcd mat(A.rows(), A.cols() + B.cols());
-      mat.leftCols(A.cols()) =
-          es.eigenvalues()(i) * Eigen::MatrixXd::Identity(A.rows(), A.cols()) -
-          A;
-      mat.rightCols(B.cols()) = B;
-      Eigen::ColPivHouseholderQR<Eigen::MatrixXcd> qr(mat);
-      if (threshold) {
-        qr.setThreshold(*threshold);
-      }
-      DRAKE_DEMAND(qr.info() == Eigen::Success);
-      if (qr.rank() < A.rows()) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-}  // namespace
 
 bool IsStabilizable(const LinearSystem<double>& sys,
                     std::optional<double> threshold) {
-  return IsStabilizable(sys.A(), sys.B(), sys.time_period() <= 0, threshold);
+  const bool continuous_time = sys.time_period() <= 0;
+  return internal::IsStabilizable(sys.A(), sys.B(), continuous_time, threshold);
 }
 
 bool IsDetectable(const LinearSystem<double>& sys,
                   std::optional<double> threshold) {
-  // The system (C, A) is detectable iff (A', C') is stabilizable.;
-  return IsStabilizable(sys.A().transpose(), sys.C().transpose(),
-                        sys.time_period() <= 0, threshold);
+  const bool continuous_time = sys.time_period() <= 0;
+  return internal::IsDetectable(sys.A(), sys.C(), continuous_time, threshold);
 }
 
 }  // namespace systems

--- a/systems/primitives/linear_system_internal.cc
+++ b/systems/primitives/linear_system_internal.cc
@@ -1,0 +1,105 @@
+#include "drake/systems/primitives/linear_system_internal.h"
+
+namespace drake {
+namespace systems {
+namespace internal {
+
+using Eigen::MatrixXd;
+using Eigen::Ref;
+
+// Note that unit testing of this code happens via its use in linear_system.h
+// via the linear_system_test program.
+
+MatrixXd ControllabilityMatrix(const Ref<const MatrixXd>& A,
+                               const Ref<const MatrixXd>& B) {
+  const int num_states = B.rows();
+  const int num_inputs = B.cols();
+  DRAKE_DEMAND(A.rows() == num_states);
+  DRAKE_DEMAND(A.cols() == num_states);
+  MatrixXd R(num_states, num_states * num_inputs);
+  R.leftCols(num_inputs) = B;
+  for (int i = 1; i < num_states; ++i) {
+    R.middleCols(num_inputs * i, num_inputs) =
+        A * R.middleCols(num_inputs * (i - 1), num_inputs);
+  }
+  return R;
+}
+
+bool IsControllable(const Ref<const MatrixXd>& A, const Ref<const MatrixXd>& B,
+                    std::optional<double> threshold) {
+  const MatrixXd R = ControllabilityMatrix(A, B);
+  Eigen::ColPivHouseholderQR<MatrixXd> lu_decomp(R);
+  if (threshold) {
+    lu_decomp.setThreshold(threshold.value());
+  }
+  return lu_decomp.rank() == A.rows();
+}
+
+MatrixXd ObservabilityMatrix(const Ref<const MatrixXd>& A,
+                             const Ref<const MatrixXd>& C) {
+  const int num_states = C.cols();
+  const int num_outputs = C.rows();
+  DRAKE_DEMAND(A.rows() == num_states);
+  DRAKE_DEMAND(A.cols() == num_states);
+  MatrixXd O(num_states * num_outputs, num_states);
+  O.topRows(num_outputs) = C;
+  for (int i = 1; i < num_states; ++i) {
+    O.middleRows(num_outputs * i, num_outputs) =
+        O.middleRows(num_outputs * (i - 1), num_outputs) * A;
+  }
+  return O;
+}
+
+bool IsObservable(const Ref<const MatrixXd>& A, const Ref<const MatrixXd>& C,
+                  std::optional<double> threshold) {
+  const MatrixXd O = ObservabilityMatrix(A, C);
+  Eigen::ColPivHouseholderQR<MatrixXd> lu_decomp(O);
+  if (threshold) {
+    lu_decomp.setThreshold(threshold.value());
+  }
+  return lu_decomp.rank() == A.rows();
+}
+
+bool IsStabilizable(const Ref<const MatrixXd>& A, const Ref<const MatrixXd>& B,
+                    bool continuous_time, std::optional<double> threshold) {
+  // (A, B) is stabilizable if [(λI - A) B] is full rank for all unstable
+  // eigenvalues.
+  DRAKE_DEMAND(A.rows() == A.cols());
+  DRAKE_DEMAND(A.rows() == B.rows());
+  Eigen::EigenSolver<MatrixXd> es(A);
+  DRAKE_DEMAND(es.info() == Eigen::Success);
+  for (int i = 0; i < es.eigenvalues().size(); ++i) {
+    bool stable_mode = false;
+    if (continuous_time) {
+      stable_mode = es.eigenvalues()(i).real() < 0;
+    } else {
+      stable_mode = std::norm(es.eigenvalues()(i)) < 1;
+    }
+    if (!stable_mode) {
+      Eigen::MatrixXcd mat(A.rows(), A.cols() + B.cols());
+      mat.leftCols(A.cols()) =
+          es.eigenvalues()(i) * MatrixXd::Identity(A.rows(), A.cols()) - A;
+      mat.rightCols(B.cols()) = B;
+      Eigen::ColPivHouseholderQR<Eigen::MatrixXcd> qr(mat);
+      if (threshold) {
+        qr.setThreshold(*threshold);
+      }
+      DRAKE_DEMAND(qr.info() == Eigen::Success);
+      if (qr.rank() < A.rows()) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool IsDetectable(const Ref<const MatrixXd>& A, const Ref<const MatrixXd>& C,
+                  bool continuous_time, std::optional<double> threshold) {
+  // The system (C, A) is detectable iff (A', C') is stabilizable.
+  return IsStabilizable(A.transpose(), C.transpose(), continuous_time,
+                        threshold);
+}
+
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/linear_system_internal.h
+++ b/systems/primitives/linear_system_internal.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <optional>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace systems {
+namespace internal {
+
+/* Returns the controllability matrix:  R = [B, AB, ..., A^{n-1}B].
+@pre The coefficient matrices must obey the following dimensions:
+ | Matrix  | Num Rows    | Num Columns |
+ | A       | num states  | num states  |
+ | B       | num states  | num inputs  | */
+Eigen::MatrixXd ControllabilityMatrix(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::MatrixXd>& B);
+
+/* Returns true iff the controllability matrix is full row rank.
+@pre The coefficient matrices must obey the following dimensions:
+ | Matrix  | Num Rows    | Num Columns |
+ | A       | num states  | num states  |
+ | B       | num states  | num inputs  | */
+bool IsControllable(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                    const Eigen::Ref<const Eigen::MatrixXd>& B,
+                    std::optional<double> threshold);
+
+/* Returns the observability matrix: O = [ C; CA; ...; CA^{n-1} ].
+@pre The coefficient matrices must obey the following dimensions:
+ | Matrix  | Num Rows    | Num Columns |
+ | A       | num states  | num states  |
+ | C       | num outputs | num states  | */
+Eigen::MatrixXd ObservabilityMatrix(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                                    const Eigen::Ref<const Eigen::MatrixXd>& C);
+
+/* Returns true iff the observability matrix is full column rank.
+@pre The coefficient matrices must obey the following dimensions:
+ | Matrix  | Num Rows    | Num Columns |
+ | A       | num states  | num states  |
+ | C       | num outputs | num states  | */
+bool IsObservable(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                  const Eigen::Ref<const Eigen::MatrixXd>& C,
+                  std::optional<double> threshold);
+
+/* Returns true iff the system is stabilizable.
+@pre The coefficient matrices must obey the following dimensions:
+ | Matrix  | Num Rows    | Num Columns |
+ | A       | num states  | num states  |
+ | B       | num states  | num inputs  | */
+bool IsStabilizable(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                    const Eigen::Ref<const Eigen::MatrixXd>& B,
+                    bool continuous_time, std::optional<double> threshold);
+
+/* Returns true iff the system is detectable.
+@pre The coefficient matrices must obey the following dimensions:
+ | Matrix  | Num Rows    | Num Columns |
+ | A       | num states  | num states  |
+ | C       | num outputs | num states  | */
+bool IsDetectable(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                  const Eigen::Ref<const Eigen::MatrixXd>& C,
+                  bool continuous_time, std::optional<double> threshold);
+
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
The only edits to the moved code are the function arguments (now passed directly as matrices, instead of a `LinearSystem`), more `DRAKE_DEMAND` cross-checks, namespaces, clang formatting, and https://drake.mit.edu/styleguide/cppguide.html#Preincrement_and_Predecrement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19529)
<!-- Reviewable:end -->
