### PR TITLE
MultibodyPlant no longer assigned perception color

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -715,10 +715,11 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
   //  and illustration in favor of a protocol that allows definition.
   geometry::PerceptionProperties perception_props;
   perception_props.AddProperty("label", "id", RenderLabel(body.index()));
-  perception_props.AddProperty(
-      "phong", "diffuse",
-      properties.GetPropertyOrDefault(
-          "phong", "diffuse", Vector4<double>(0.9, 0.9, 0.9, 1.0)));
+  if (properties.HasProperty("phong", "diffuse")) {
+    perception_props.AddProperty(
+        "phong", "diffuse",
+        properties.GetProperty<geometry::Rgba>("phong", "diffuse"));
+  }
   if (properties.HasProperty("phong", "diffuse_map")) {
     perception_props.AddProperty(
         "phong", "diffuse_map",


### PR DESCRIPTION
Geometry with perception roles, if they have no definition of color, should defer to the `RenderEngine`'s logic and default values to pick up a color. MultibodyPlant shouldn't be playing a role in that regard.

In this case, MultibodyPlant is assuming that if the illustration properties have a color defined, the perception role should pick up the same. This is correct so far as our parsing cannot yet distinguish between illustration and perception roles (they're all just "visual").

This *can* affect an end user who never specified a color -- i.e., the default may change from MultibodyPlant's default color to their render engine or visualizer's default color.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19533)
<!-- Reviewable:end -->
