### PR TITLE
Add Minimum Degree ordering

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -22,6 +22,7 @@ drake_cc_package_library(
         ":contact_solver_utils",
         ":linear_operator",
         ":matrix_block",
+        ":minimum_degree_ordering",
         ":newton_with_bisection",
         ":pgs_solver",
         ":point_contact_data",
@@ -117,6 +118,16 @@ drake_cc_library(
     deps = [
         ":block_3x3_sparse_matrix",
         "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "minimum_degree_ordering",
+    srcs = ["minimum_degree_ordering.cc"],
+    hdrs = ["minimum_degree_ordering.h"],
+    deps = [
+        ":block_sparse_lower_triangular_or_symmetric_matrix",
         "//common:essential",
     ],
 )
@@ -242,6 +253,13 @@ drake_cc_googletest(
     deps = [
         ":matrix_block",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "minimum_degree_ordering_test",
+    deps = [
+        ":minimum_degree_ordering",
     ],
 )
 

--- a/multibody/contact_solvers/minimum_degree_ordering.cc
+++ b/multibody/contact_solvers/minimum_degree_ordering.cc
@@ -1,0 +1,217 @@
+#include "drake/multibody/contact_solvers/minimum_degree_ordering.h"
+
+#include <algorithm>
+#include <functional>
+#include <set>
+#include <utility>
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+std::vector<int> Union(const std::vector<int>& a, const std::vector<int>& b) {
+  std::vector<int> result;
+  result.reserve(a.size() + b.size());
+  std::set_union(a.begin(), a.end(), b.begin(), b.end(),
+                 std::back_inserter(result));
+  return result;
+}
+
+std::vector<int> SetDifference(const std::vector<int>& a,
+                               const std::vector<int>& b) {
+  std::vector<int> result;
+  result.reserve(a.size());
+  std::set_difference(a.begin(), a.end(), b.begin(), b.end(),
+                      std::back_inserter(result));
+  return result;
+}
+
+void RemoveValueFromSortedVector(int value, std::vector<int>* sorted_vector) {
+  auto it =
+      std::lower_bound(sorted_vector->begin(), sorted_vector->end(), value);
+  /* Check if the value was found and remove it. */
+  while (it != sorted_vector->end() && *it == value) {
+    it = sorted_vector->erase(it);
+  }
+}
+
+void InsertValueInSortedVector(int value, std::vector<int>* sorted_vector) {
+  auto it =
+      std::lower_bound(sorted_vector->begin(), sorted_vector->end(), value);
+  /* Check if the value doesn't already exist and insert it. */
+  if (it == sorted_vector->end() || *it != value) {
+    sorted_vector->insert(it, value);
+  }
+}
+
+void Node::UpdateExternalDegree(const std::vector<Node>& nodes) {
+  degree = 0;
+
+  /* Add in |Aᵢ \ i| term. */
+  for (int a : A) {
+    degree += nodes[a].size;
+  }
+
+  /* Add in |L \ i| term where L = ∪ₑLₑ and e ∈ Eᵢ. */
+  std::vector<int> L_union;
+  // TODO(xuchenhan-tri): This can be quadratic in the worst case and can be
+  // made more efficient by doing a K-way union if needed.
+  for (int e : E) {
+    L_union = Union(L_union, nodes[e].L);
+  }
+  RemoveValueFromSortedVector(index, &L_union);
+  for (int l : L_union) {
+    degree += nodes[l].size;
+  }
+}
+
+std::vector<int> ComputeMinimumDegreeOrdering(
+    const BlockSparsityPattern& block_sparsity_pattern) {
+  /* Initialize for Minimum Degree: Populate index, size, and A, the list of
+   adjacent variables. E, L are empty initially. */
+  const std::vector<int>& block_sizes = block_sparsity_pattern.block_sizes();
+  const int num_nodes = block_sizes.size();
+  std::vector<Node> nodes(num_nodes);
+  for (int n = 0; n < num_nodes; ++n) {
+    nodes[n].index = n;
+    nodes[n].size = block_sizes[n];
+  }
+  for (int n = 0; n < num_nodes; ++n) {
+    Node& node = nodes[n];
+    const std::vector<int>& neighbors = block_sparsity_pattern.neighbors()[n];
+    for (int neighbor : neighbors) {
+      if (n != neighbor) {
+        /* We modify both `node` and `neighbor` here because for each ij-pair
+         only one of (i, j) and (j, i) is recorded in `sparsity pattern` but
+         we want j be part of Ai and i to be part of Aj. */
+        node.A.push_back(nodes[neighbor].index);
+        node.degree += nodes[neighbor].size;
+        nodes[neighbor].A.push_back(node.index);
+        nodes[neighbor].degree += node.size;
+      }
+    }
+  }
+  /* Maintain the invariance that A, E, L vectors in a node are all sorted. */
+  for (auto& node : nodes) {
+    std::vector<int>& A = node.A;
+    /* Only A is non-empty at this point. */
+    std::sort(A.begin(), A.end());
+  }
+
+  /* The ideal data structure to use here is a priority queue implemeneted by a
+   heap. However, the Minimum Degree algorithm requires updating neighboring
+   nodes when a node is eliminated and std::priority_queue doesn't support
+   modifying existing elements. There are ways to get around it by duplicating
+   nodes and ignoring out-of-date nodes, but for simplicity and readability, we
+   use an std::set here instead. */
+  std::set<IndexDegree> sorted_nodes;
+  /* Keep the nodes sorted by degrees and break ties with indices. We use a
+   striped down version of the node to keep only the necessary information
+   (degree and index). */
+  for (int n = 0; n < num_nodes; ++n) {
+    IndexDegree node = {.degree = nodes[n].degree, .index = nodes[n].index};
+    sorted_nodes.insert(node);
+  }
+
+  /* The resulting elimination ordering. */
+  std::vector<int> result(num_nodes);
+  /* Begin elimination. */
+  for (int k = 0; k < num_nodes; ++k) {
+    DRAKE_DEMAND(ssize(sorted_nodes) == num_nodes - k);
+    const IndexDegree min_node =
+        sorted_nodes.extract(sorted_nodes.begin()).value();
+    /* p is the variable to be eliminated next. */
+    const int p = min_node.index;
+    result[k] = p;
+    Node& node_p = nodes[p];
+
+    /* Turn node p from a variable to an element. */
+    node_p.L = node_p.A;
+    /* Absorb into Lp all variables adjacent to element e where e is adjacent to
+     p. Make sure to exclude p itself since p is turning from a variable into an
+     element. */
+    for (int e : node_p.E) {
+      node_p.L = Union(node_p.L, nodes[e].L);
+    }
+    RemoveValueFromSortedVector(p, &(node_p.L));
+    /* Update all neighboring variables of p. */
+    for (int i : node_p.L) {
+      Node& node_i = nodes[i];
+      const IndexDegree old_node = {.degree = node_i.degree,
+                                    .index = node_i.index};
+      /* Pruning. */
+      node_i.A = SetDifference(node_i.A, node_p.L);
+      /* Convert p from a variable to an element in node i. Note that Lp was
+       already updated prior to the loop, and therefore we can now safely
+       remove the absorbed elements in node i */
+      node_i.E = SetDifference(node_i.E, node_p.E);
+      RemoveValueFromSortedVector(p, &(node_i.A));
+      InsertValueInSortedVector(p, &(node_i.E));
+      /* Compute external degree. */
+      node_i.UpdateExternalDegree(nodes);
+      IndexDegree new_node = {.degree = node_i.degree, .index = node_i.index};
+      sorted_nodes.erase(old_node);
+      sorted_nodes.insert(new_node);
+    }
+    /* Convert node p from a supervariable to an element. */
+    node_p.A.clear();
+    node_p.E.clear();
+  }
+  return result;
+}
+
+/* The complexity of this symbolic factorization is O(|L|) where L is the
+ factorized matrix. */
+BlockSparsityPattern SymbolicCholeskyFactor(
+    const BlockSparsityPattern& block_sparsity) {
+  const std::vector<int>& block_sizes = block_sparsity.block_sizes();
+  /* sparsity pattern of the original symmetric matrix. */
+  const std::vector<std::vector<int>>& A_sparsity = block_sparsity.neighbors();
+  const int N = block_sizes.size();
+
+  /* children[p] stores the children of node p in the elimination tree, in
+   increasing order. See [Vandenberghe, 2015] Section 4.3 for the definition
+   of an elimination tree.
+
+   [Vandenberghe, 2015] Vandenberghe, Lieven, and Martin S. Andersen. "Chordal
+   graphs and semidefinite optimization." Foundations and Trends® in
+   Optimization 1.4 (2015): 241-433. */
+  std::vector<std::vector<int>> children(N);
+  /* L_sparsity[j] denotes the non-zero row blocks of column j. */
+  std::vector<std::vector<int>> L_sparsity(N);
+  for (int j = 0; j < N; ++j) {
+    /* The sparsity pattern for the j-th node in L is the union of the
+     neighbors of the j-th node in A and all neighbors of children of the j-th
+     node that are larger than j. We first take the union of all neighbors of
+     j and children of j and then delete all neighbors that are smaller than
+     j. This is the same as described in equation 4.3 in [Davis 2006].
+      Lⱼ = Aⱼ ∪ {j} ∪ ( ∪ Lₛ \ {s})
+     where the union over s is over all children of j. */
+    L_sparsity[j] = A_sparsity[j];
+    for (int c : children[j]) {
+      // TODO(xuchenhan-tri): Consider doing a k-way union instead of a loop
+      // for efficiency.
+      L_sparsity[j] = Union(L_sparsity[j], L_sparsity[c]);
+    }
+    /* Instead of union over Lₛ \ {s}, we union over Lₛ and remove all entries
+     smaller than j here in a single pass. */
+    L_sparsity[j] = std::vector<int>(
+        std::lower_bound(L_sparsity[j].begin(), L_sparsity[j].end(), j),
+        L_sparsity[j].end());
+
+    /* Record the parent of j if j isn't already the root. */
+    if (L_sparsity[j].size() > 1) {
+      /* The 0-th entry is j itself and the 1st entry is j-th parent. See
+       [Vandenberghe, 2015] Section 4.3. */
+      const int parent_of_j = L_sparsity[j][1];
+      children[parent_of_j].emplace_back(j);
+    }
+  }
+  return BlockSparsityPattern(block_sizes, L_sparsity);
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/minimum_degree_ordering.h
+++ b/multibody/contact_solvers/minimum_degree_ordering.h
@@ -1,0 +1,116 @@
+// @file
+// Utilities for computing the Minimum Degree ordering of a symmetric block
+// sparse matrix.
+
+#pragma once
+
+#include <vector>
+
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+/* Returns the union of a and b (a ∪ b) as a sorted vector.
+ @pre a and b are sorted in increasing order. */
+std::vector<int> Union(const std::vector<int>& a, const std::vector<int>& b);
+
+/* Returns the set difference of a and b (a \ b) as a sorted vector.
+ @pre a and b are sorted in increasing order. */
+std::vector<int> SetDifference(const std::vector<int>& a,
+                               const std::vector<int>& b);
+
+/* Removes `value` from `sorted_vector` if it exists.
+ @pre `sorted_vector` is sorted in increasing order. */
+void RemoveValueFromSortedVector(int value, std::vector<int>* sorted_vector);
+
+/* Inserts `value` into `sorted_vector` if it doesn't already exists while
+ preserving the order of `sorted_vector`.
+ @pre `sorted_vector` is sorted in increasing order. */
+void InsertValueInSortedVector(int value, std::vector<int>* sorted_vector);
+
+/* Data structure for a node in an elimination graph as described in Algorithm 1
+ in [Amestoy, 1996] and section 7.1 in [Davis 2006]. The algorithm is slightly
+ modified such that the supervariables are prescribed and stored in A and L (see
+ below) instead of detected using hash functions because the problem we are
+ solving already comes in block form. In addition, each node is already a
+ supervariable at the start of the elimination. Essentially we do not implement
+ the merging of nodes in the graph as explained in [Amestoy, 1996. §3.2].
+
+ [Amestoy 1996] Amestoy, Patrick R., Timothy A. Davis, and
+ Iain S. Duff. "An approximate minimum degree ordering algorithm." SIAM Journal
+ on Matrix Analysis and Applications 17.4 (1996): 886-905.
+ [Davis 2006] Davis, Timothy A. Direct methods for sparse linear systems.
+ Society for Industrial and Applied Mathematics, 2006. */
+struct Node {
+  /* Computes and updates the external degree of `this` node given all nodes in
+   the graph. */
+  void UpdateExternalDegree(const std::vector<Node>& nodes);
+
+  /* See [Amestoy 1996] and [Davis 2006] for definitions of "supervariable",
+   "element", "external degree", etc. */
+  int degree{0};  // The external degree of the supervaiable. Note that this is
+                  // not simply the number of neighboring nodes, but the
+                  // summation of block sizes on the neighbors because the
+                  // neighboring nodes are supervariables themselves.
+  int size{0};    // The number of simple variables in a supervariable.
+  int index{-1};  // The index of this node that can be used as an unique
+                  // identifier of the node.
+  /* Invariant: A, E, L are sorted. We opt for a std::vector over std::set for
+   slightly lower overhead when performing union operations for these sets. */
+  std::vector<int> A;  // Adjacent supervariables when `this` node is a
+                       // variable; empty when this node is an element.
+  std::vector<int> E;  // Adjacent elements when `this` node is a variable;
+                       // empty when this node is an element due to absorption.
+  // TODO(xuchenhan-tri): We can reuse the storage of A for L as only one is
+  // non-empty at a given time.
+  std::vector<int> L;  // Adjacent supervariables when `this` node is an
+                       // element, empty otherwise.
+};
+
+/* A simplified version of Node used in a minimum priority queue of that only
+ contains index of the node and the degree. */
+struct IndexDegree {
+  int degree{};
+  int index{};
+};
+
+inline bool operator<(const IndexDegree& a, const IndexDegree& b) {
+  if (a.degree != b.degree) {
+    return a.degree < b.degree;
+  } else {
+    /* Sort by node index when degrees are equal so that consecutive nodes with
+     the same degree are not permuted. */
+    return a.index < b.index;
+  }
+}
+
+/* Computes the preferred elimination ordering of the matrix with the given
+ `block_sparsity_pattern` according to the Minimum Degree algorithm. For
+ example, a return value of [1, 3, 0, 2] first eliminates block 1, then 3,
+ 0, and 2. In other words, this is a permutation mapping from new block indices
+ to original block indices. */
+std::vector<int> ComputeMinimumDegreeOrdering(
+    const BlockSparsityPattern& block_sparsity_pattern);
+
+/* Given the block sparsity pattern of a symmetric block sparse matrix, computes
+ the block sparsity pattern of the lower triangular matrix resulting from a
+ Cholesky factorization. Specifically, L(i, j) ≠ 0 if A(i, j) ≠ 0 or if there
+ exists k such that A(k, i) and A(k, j) is non-zero ( for k < j ≤ i) We
+ implement this efficiently with an elimination tree.
+ See section 4.1 in [Davis 2006] for discussion on practical implementation.
+
+ [Davis 2006] Davis, Timothy A. Direct methods for sparse linear systems.
+ Society for Industrial and Applied Mathematics, 2006.
+
+ @param[in] pattern The block sparsity pattern of a symmetric block sparse
+ matrix. */
+BlockSparsityPattern SymbolicCholeskyFactor(
+    const BlockSparsityPattern& block_sparsity);
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/test/minimum_degree_ordering_test.cc
+++ b/multibody/contact_solvers/test/minimum_degree_ordering_test.cc
@@ -1,0 +1,224 @@
+#include "drake/multibody/contact_solvers/minimum_degree_ordering.h"
+
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+GTEST_TEST(MinimumDegreeOrderingTest, Union) {
+  const std::vector<int> a = {1, 2, 5, 8, 9};
+  const std::vector<int> b = {1, 3, 5, 7, 9, 11};
+  const std::vector<int> result = Union(a, b);
+  const std::vector<int> expected = {1, 2, 3, 5, 7, 8, 9, 11};
+  EXPECT_EQ(result, expected);
+}
+
+GTEST_TEST(MinimumDegreeOrderingTest, SetDifference) {
+  const std::vector<int> a = {1, 2, 5, 8, 9};
+  const std::vector<int> b = {1, 3, 5, 7, 9, 11};
+  const std::vector<int> result = SetDifference(a, b);
+  const std::vector<int> expected = {2, 8};
+  EXPECT_EQ(result, expected);
+}
+
+GTEST_TEST(MinimumDegreeOrderingTest, RemoveValueFromSortedVector) {
+  const std::vector<int> input = {1, 2, 5, 8, 9};
+  std::vector<int> v = input;
+  RemoveValueFromSortedVector(3, &v);
+  EXPECT_EQ(input, v);
+  RemoveValueFromSortedVector(2, &v);
+  const std::vector<int> expected = {1, 5, 8, 9};
+  EXPECT_EQ(v, expected);
+}
+
+GTEST_TEST(MinimumDegreeOrderingTest, InsertValueInSortedVector) {
+  const std::vector<int> input = {1, 2, 5, 8, 9};
+  std::vector<int> v = input;
+  InsertValueInSortedVector(2, &v);
+  EXPECT_EQ(input, v);
+  InsertValueInSortedVector(3, &v);
+  const std::vector<int> expected = {1, 2, 3, 5, 8, 9};
+  EXPECT_EQ(v, expected);
+}
+
+/* This example is taken from G5 in figure 2 from [Amestoy 1996].
+ The quotient graph is set up such that
+
+       __ 5
+     /   /  \
+    9   7     6
+    | \   \   |
+    |  \    \ /
+   10---8----4
+
+  where nodes 4 and 5 are elements and all other nodes are variables. We call
+  update external degree on all variables to verify the results are as expected.
+
+  [Amestoy 1996] Amestoy, Patrick R., Timothy A. Davis, and Iain S. Duff. "An
+ approximate minimum degree ordering algorithm." SIAM Journal on Matrix Analysis
+ and Applications 17.4 (1996): 886-905. */
+GTEST_TEST(MinimumDegreeOrderingTest, UpdateExternalDegree) {
+  Node n4{
+      .degree = 0, .size = 40, .index = 4, .A = {}, .E = {}, .L = {6, 7, 8}};
+  Node n5{
+      .degree = 0, .size = 50, .index = 5, .A = {}, .E = {}, .L = {6, 7, 9}};
+  Node n6{.degree = 0, .size = 60, .index = 6, .A = {}, .E = {4, 5}, .L = {}};
+  Node n7{.degree = 0, .size = 70, .index = 7, .A = {10}, .E = {4, 5}, .L = {}};
+  Node n8{.degree = 0, .size = 80, .index = 8, .A = {9, 10}, .E = {4}, .L = {}};
+  Node n9{.degree = 0, .size = 90, .index = 9, .A = {8, 10}, .E = {5}, .L = {}};
+  Node n10{
+      .degree = 0, .size = 100, .index = 10, .A = {7, 8, 9}, .E = {}, .L = {}};
+  std::vector<Node> nodes;
+  /* Nodes 0-3 are already eliminated. */
+  for (int i = 0; i < 4; ++i) {
+    nodes.emplace_back();
+  }
+  nodes.push_back(n4);
+  nodes.push_back(n5);
+  nodes.push_back(n6);
+  nodes.push_back(n7);
+  nodes.push_back(n8);
+  nodes.push_back(n9);
+  nodes.push_back(n10);
+
+  n6.UpdateExternalDegree(nodes);
+  n7.UpdateExternalDegree(nodes);
+  n8.UpdateExternalDegree(nodes);
+  n9.UpdateExternalDegree(nodes);
+  n10.UpdateExternalDegree(nodes);
+  /* Fill-ins are 7,8,9. */
+  EXPECT_EQ(n6.degree, 240);
+  /* Fill-ins are 6,8,9,10. */
+  EXPECT_EQ(n7.degree, 330);
+  /* Fill-ins are 6,7,9,10. */
+  EXPECT_EQ(n8.degree, 320);
+  /* Fill-ins are 6,7,8,10. */
+  EXPECT_EQ(n9.degree, 310);
+  /* Fill-ins are 7,8,9. */
+  EXPECT_EQ(n10.degree, 240);
+}
+
+GTEST_TEST(MinimumDegreeOrderingTest, IndexDegreeComparator) {
+  IndexDegree a = {.degree = 0, .index = 0};
+  IndexDegree b = {.degree = 0, .index = 1};
+  IndexDegree c = {.degree = 1, .index = 2};
+  EXPECT_LT(a, b);
+  EXPECT_LT(a, c);
+  EXPECT_LT(b, c);
+}
+
+GTEST_TEST(MinimumDegreeOrderingTest, ComputeMinimumDegreeOrdering) {
+  /* The block sparsity pattern is
+    X X | O O O | O O O O | O O O
+    X X | O O O | O O O O | O O O
+    --- | ----- |---------| -----
+    O O | X X X | X X X X | O O O
+    O O | X X X | X X X X | O O O
+    O O | X X X | X X X X | O O O
+    --- | ----- |---------| -----
+    O O | X X X | X X X X | O O O
+    O O | X X X | X X X X | O O O
+    O O | X X X | X X X X | O O O
+    O O | X X X | X X X X | O O O
+    --- | ----- |---------| -----
+    O O | O O O | O O O O | X X X
+    O O | O O O | O O O O | X X X
+    O O | O O O | O O O O | X X X
+  The expected elimination ordering is 0, 3, 2, 1 from pen and paper
+  calculation. 2 is eliminated before 1 because when 0 and 3 are eliminated, the
+  degree of 2 is 3 and the degree of 1 is 4. */
+
+  std::vector<std::vector<int>> sparsity;
+  sparsity.emplace_back(std::vector<int>{0});
+  sparsity.emplace_back(std::vector<int>{1, 2});
+  sparsity.emplace_back(std::vector<int>{2});
+  sparsity.emplace_back(std::vector<int>{3});
+  std::vector<int> block_sizes = {2, 3, 4, 3};
+  BlockSparsityPattern block_pattern(block_sizes, sparsity);
+  std::vector<int> result = ComputeMinimumDegreeOrdering(block_pattern);
+  EXPECT_EQ(result, std::vector<int>({0, 3, 2, 1}));
+}
+
+/* Another test for minimum degree ordering. Here we take the example from
+Figure 1 and 2 in [Amestoy, 1996], where the minimum degree ordering is the
+natural ordering when the size of the blocks are the same for all nodes.
+
+[Amestoy 1996] Amestoy, Patrick R., Timothy A. Davis, and
+Iain S. Duff. "An approximate minimum degree ordering algorithm." SIAM Journal
+on Matrix Analysis and Applications 17.4 (1996): 886-905. */
+GTEST_TEST(MinimumDegreeOrderingTest, ComputeMinimumDegreeOrdering2) {
+  std::vector<std::vector<int>> sparsity;
+  sparsity.emplace_back(std::vector<int>{0, 3, 5});
+  sparsity.emplace_back(std::vector<int>{1, 4, 5, 8});
+  sparsity.emplace_back(std::vector<int>{2, 4, 5, 6});
+  sparsity.emplace_back(std::vector<int>{3, 6, 7});
+  sparsity.emplace_back(std::vector<int>{4, 6, 8});
+  sparsity.emplace_back(std::vector<int>{5});
+  sparsity.emplace_back(std::vector<int>{6, 7, 8, 9});
+  sparsity.emplace_back(std::vector<int>{7, 8, 9});
+  sparsity.emplace_back(std::vector<int>{8, 9});
+  sparsity.emplace_back(std::vector<int>{9});
+  std::vector<int> block_sizes(10, 2);
+  BlockSparsityPattern block_pattern(block_sizes, sparsity);
+  std::vector<int> result = ComputeMinimumDegreeOrdering(block_pattern);
+  EXPECT_EQ(result, std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+}
+
+GTEST_TEST(MinimumDegreeOrderingTest, SymbolicCholeskyFactor) {
+  /*
+  In this schematic (unlike the one in the previous test), an X corresponds to a
+  block with the sizes specified below.
+
+    X X O O O O
+    X X X X O X
+    O X X O O O
+    O X O X O O
+    O O O O X X
+    O X O O X X
+
+    Symbolic Cholesky factorization should produce the following lower
+    triangular sparsity pattern.
+
+    X O O O O O
+    X X O O O O
+    O X X O O O
+    O X X X O O
+    O O O O X O
+    O X X X X X  */
+  std::vector<std::vector<int>> A_sparsity;
+  A_sparsity.emplace_back(std::vector<int>{0, 1});
+  A_sparsity.emplace_back(std::vector<int>{1, 2, 3, 5});
+  A_sparsity.emplace_back(std::vector<int>{2});
+  A_sparsity.emplace_back(std::vector<int>{3});
+  A_sparsity.emplace_back(std::vector<int>{4, 5});
+  A_sparsity.emplace_back(std::vector<int>{5});
+  /* Set up arbitrary block sizes. */
+  std::vector<int> A_block_sizes = {8, 4, 7, 6, 4, 4};
+  BlockSparsityPattern A_block_pattern(A_block_sizes, A_sparsity);
+
+  const BlockSparsityPattern L_block_pattern =
+      SymbolicCholeskyFactor(A_block_pattern);
+  const std::vector<int>& L_block_sizes = L_block_pattern.block_sizes();
+  EXPECT_EQ(L_block_sizes, A_block_sizes);
+
+  const std::vector<std::vector<int>>& L_sparsity = L_block_pattern.neighbors();
+  ASSERT_EQ(L_sparsity.size(), 6);
+  EXPECT_EQ(L_sparsity[0], std::vector<int>({0, 1}));
+  EXPECT_EQ(L_sparsity[1], std::vector<int>({1, 2, 3, 5}));
+  EXPECT_EQ(L_sparsity[2], std::vector<int>({2, 3, 5}));
+  EXPECT_EQ(L_sparsity[3], std::vector<int>({3, 5}));
+  EXPECT_EQ(L_sparsity[4], std::vector<int>({4, 5}));
+  EXPECT_EQ(L_sparsity[5], std::vector<int>({5}));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Introduce a minimum degree ordering that is a slightly modified version of Algorithm 1 in [Amestoy 1996].
This ordering is intended to be used for the block sparse Cholesky solver that will serve as an alternative implementation to the Conex solver in the `contact_solvers::internal::SupernodalSolver`.

Towards #19466.

[Amestoy 1996] Amestoy, Patrick R., Timothy A. Davis, and  Iain S. Duff. "An approximate minimum degree ordering algorithm." SIAM Journal on Matrix Analysis and Applications 17.4 (1996): 886-905.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19535)
<!-- Reviewable:end -->
