### PR TITLE
[pydrake] Mark systems lcm_test as flaky

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -447,8 +447,6 @@ drake_py_unittest(
 
 drake_py_unittest(
     name = "lcm_test",
-    # See #19394, this test fails frequently on Mac ARM CI
-    flaky = True,
     deps = [
         ":lcm_py",
         "//bindings/pydrake/common/test_utilities:deprecation_py",

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -221,6 +221,8 @@ drake_pybind_library(
 
 drake_py_unittest(
     name = "lcm_test",
+    # See #19394, this test fails frequently on Mac ARM CI
+    flaky = True,
     deps = [
         ":analysis_py",
         ":lcm_py",


### PR DESCRIPTION
Fix error in earlier commit where the wrong test was marked as flaky.

Resolves #19394

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19541)
<!-- Reviewable:end -->
