### PR TITLE
Disallow partial Dirichlet BC for an FEM node

### DIFF
--- a/multibody/fem/dirichlet_boundary_condition.cc
+++ b/multibody/fem/dirichlet_boundary_condition.cc
@@ -7,8 +7,8 @@ namespace internal {
 
 template <typename T>
 void DirichletBoundaryCondition<T>::AddBoundaryCondition(
-    int dof_index, const Eigen::Ref<const Vector3<T>>& boundary_state) {
-  index_to_boundary_state_[dof_index] = boundary_state;
+    FemNodeIndex index, const NodeState<T>& boundary_state) {
+  index_to_boundary_state_[index] = boundary_state;
 }
 
 template <typename T>
@@ -16,16 +16,16 @@ void DirichletBoundaryCondition<T>::ApplyBoundaryConditionToState(
     FemState<T>* fem_state) const {
   DRAKE_DEMAND(fem_state != nullptr);
   if (index_to_boundary_state_.empty()) return;
-  VerifyIndexes(fem_state->num_dofs());
+  VerifyIndices(fem_state->num_nodes());
 
   // TODO(xuchenhan-tri): Consider avoiding this copy.
   VectorX<T> q = fem_state->GetPositions();
   VectorX<T> v = fem_state->GetVelocities();
   VectorX<T> a = fem_state->GetAccelerations();
-  for (const auto& [dof_index, boundary_state] : index_to_boundary_state_) {
-    q(dof_index) = boundary_state(0);
-    v(dof_index) = boundary_state(1);
-    a(dof_index) = boundary_state(2);
+  for (const auto& [node_index, boundary_state] : index_to_boundary_state_) {
+    q.template segment<3>(3 * node_index) = boundary_state.q;
+    v.template segment<3>(3 * node_index) = boundary_state.v;
+    a.template segment<3>(3 * node_index) = boundary_state.a;
   }
   fem_state->SetPositions(q);
   fem_state->SetVelocities(v);
@@ -38,16 +38,18 @@ void DirichletBoundaryCondition<T>::ApplyBoundaryConditionToTangentMatrix(
   DRAKE_DEMAND(tangent_matrix != nullptr);
   DRAKE_DEMAND(tangent_matrix->rows() == tangent_matrix->cols());
   if (index_to_boundary_state_.empty()) return;
-  VerifyIndexes(tangent_matrix->cols());
+  VerifyIndices(tangent_matrix->cols() / 3);
 
   /* Zero out all rows and columns of the tangent matrix corresponding to
-   dofs under the BC (except the diagonal entry which is set to 1). */
-  std::vector<int> indexes(index_to_boundary_state_.size());
+   DoFs under the BC (except the diagonal entry which is set to 1). */
+  std::vector<int> dof_indices(3 * index_to_boundary_state_.size());
   int i = 0;
   for (const auto& it : index_to_boundary_state_) {
-    indexes[i++] = it.first;
+    dof_indices[i++] = 3 * it.first;
+    dof_indices[i++] = 3 * it.first + 1;
+    dof_indices[i++] = 3 * it.first + 2;
   }
-  tangent_matrix->ZeroRowsAndColumns(indexes, /* diagonal entry */ 1.0);
+  tangent_matrix->ZeroRowsAndColumns(dof_indices, /* diagonal entry */ 1.0);
 }
 
 template <typename T>
@@ -55,17 +57,17 @@ void DirichletBoundaryCondition<T>::ApplyHomogeneousBoundaryCondition(
     EigenPtr<VectorX<T>> v) const {
   DRAKE_DEMAND(v != nullptr);
   if (index_to_boundary_state_.empty()) return;
-  VerifyIndexes(v->size());
+  VerifyIndices(v->size() / 3);
 
   /* Zero out all entries of `v` corresponding to dofs under the BC. */
   for (const auto& it : index_to_boundary_state_) {
-    const int dof_index = it.first;
-    (*v)(dof_index) = 0.0;
+    const int node_index = it.first;
+    v->template segment<3>(3 * node_index).setZero();
   }
 }
 
 template <typename T>
-void DirichletBoundaryCondition<T>::VerifyIndexes(int size) const {
+void DirichletBoundaryCondition<T>::VerifyIndices(int size) const {
   const auto& last_bc = index_to_boundary_state_.crbegin();
   if (last_bc->first >= size) {
     throw std::out_of_range(

--- a/multibody/fem/dirichlet_boundary_condition.h
+++ b/multibody/fem/dirichlet_boundary_condition.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/fem_indexes.h"
 #include "drake/multibody/fem/fem_state.h"
 #include "drake/multibody/fem/petsc_symmetric_block_sparse_matrix.h"
 
@@ -11,6 +12,15 @@ namespace drake {
 namespace multibody {
 namespace fem {
 namespace internal {
+
+/* The position, velocity, and acceleration of an FEM node.
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+struct NodeState {
+  Vector3<T> q;
+  Vector3<T> v;
+  Vector3<T> a;
+};
 
 /* DirichletBoundaryCondition provides functionalities related to Dirichlet
  boundary conditions (BC) on FEM models [Zienkiewicz et al. Sec 1.4]. In
@@ -20,6 +30,11 @@ namespace internal {
  3. modifying a given tangent matrix/residual that arises from the FEM model
  without BC and transform it into the tangent matrix/residual for the same
  model under the stored BC.
+
+ We only allow specifying BCs at the node level. That means that either all
+ degrees of freedom (DoFs) of a node are subject to BCs or none of the DoFs of
+ the node is subject to BCs. For example, we don't allow specifying BCs for
+ just the x-components of the states while leaving the y and z components free.
 
  Zienkiewicz, Olek C., Robert L. Taylor, and Jian Z. Zhu. The finite element
  method: its basis and fundamentals. Elsevier, 2005.
@@ -33,59 +48,54 @@ class DirichletBoundaryCondition {
   /* Constructs an empty boundary condition. */
   DirichletBoundaryCondition() {}
 
-  /* Sets the degree of freemdom (dof) with index `dof_index` to be subject to
-   the prescribed `boundary_state`.
-   @param[in] dof_index       The index of the degree of freedom to which the
-                              boundary condition is applied.
-   @param[in] boundary_state  The position, velocity, and acceleration at
-                              `dof_index` prescribed by this boundary condition.
-  */
-  void AddBoundaryCondition(int dof_index,
-                            const Eigen::Ref<const Vector3<T>>& boundary_state);
+  /* Sets the node with the given `index` to be subject to the prescribed
+   `boundary_state`.
+   @pre index.is_valid() and values provided in `boundary_state` are finite. */
+  void AddBoundaryCondition(FemNodeIndex index,
+                            const NodeState<T>& boundary_state);
 
-  /* Returns the boundary conditions as an `std::map` with dof indexes as keys
+  /* Returns the boundary conditions as an `std::map` with node indices as keys
    and the prescribed boundary states as values. */
-  const std::map<int, Vector3<T>>& index_to_boundary_state() const {
+  const std::map<FemNodeIndex, NodeState<T>>& index_to_boundary_state() const {
     return index_to_boundary_state_;
   }
 
   /* Modifies the given `fem_state` to comply with this boundary condition.
    @pre fem_state != nullptr.
    @pre fem_state is an "owned" FEM state (see FemState).
-   @throw std::exception if any dof index specified by `this` boundary
-   condition is greater than or equal to the `fem_state->num_dofs()`. */
+   @throw std::exception if any node index specified by `this` boundary
+   condition is greater than or equal to the `fem_state->num_nodes()`. */
   void ApplyBoundaryConditionToState(FemState<T>* fem_state) const;
 
   /* Modifies the given tangent matrix that arises from an FEM model into the
    tangent matrix for the same model subject to this BC. More specifically,
-   the rows and columns corresponding to dofs under this BC will be zeroed out
-   with the exception of the diagonal entries for those dofs which will be set
+   the rows and columns corresponding to DoFs under this BC will be zeroed out
+   with the exception of the diagonal entries for those DoFs which will be set
    to 1.
    @pre tangent_matrix != nullptr.
    @pre tangent_matrix->rows() == tangent_matrix->cols().
-   @throw std::exception if any dof index specified by `this` boundary
-   condition is greater than or equal to the `tangent_matrix->cols()`. */
+   @throw std::exception if the index of any DoF associated with nodes subject
+   to `this` BC is greater than or equal to the `tangent_matrix->cols()`. */
   void ApplyBoundaryConditionToTangentMatrix(
       PetscSymmetricBlockSparseMatrix* tangent_matrix) const;
 
   /* Modifies the given vector `v` (e.g, the residual of the system or the
    velocities/positions) that arises from an FEM model without BC into the a
    vector for the same model subject to `this` BC. More specifically, the
-   entries corresponding to dofs under the BC will be zeroed out.
+   entries corresponding to nodes under the BC will be zeroed out.
    @pre v != nullptr.
-   @throw std::exception if any dof index specified by `this` boundary
-   condition is greater than or equal to the `v->size()`. */
+   @throw std::exception if the index of any DoF associated with nodes subject
+   to `this` BC is greater than or equal to the `v->size()`. */
   void ApplyHomogeneousBoundaryCondition(EigenPtr<VectorX<T>> v) const;
 
  private:
-  /* Throws an exception if the largest dof index specified by this BC is larger
-   than or equal to the given `size`. */
-  void VerifyIndexes(int size) const;
+  /* Throws an exception if the largest node index specified by this BC is
+   larger than or equal to the given `size`. */
+  void VerifyIndices(int size) const;
 
-  /* We sort the boundary conditions according to dof indexes for better
-   cache consistency when applying the BC. The value stored is q, v, and a (in
-   that order) of the dof under BC. */
-  std::map<int, Vector3<T>> index_to_boundary_state_{};
+  /* We sort the boundary conditions according to node indices for better
+   cache consistency when applying the BC. */
+  std::map<FemNodeIndex, NodeState<T>> index_to_boundary_state_{};
 };
 
 }  // namespace internal

--- a/multibody/fem/fem_state.h
+++ b/multibody/fem/fem_state.h
@@ -81,6 +81,9 @@ class FemState {
         .size();
   }
 
+  /** Returns the number of nodes in the FEM model. */
+  int num_nodes() const { return num_dofs() / 3; }
+
   /** Returns true if this FemState is constructed from the given system. */
   bool is_created_from_system(const internal::FemStateSystem<T>& system) const {
     return &system == system_;

--- a/multibody/fem/test/fem_model_test.cc
+++ b/multibody/fem/test/fem_model_test.cc
@@ -177,7 +177,9 @@ GTEST_TEST(FemModelTest, DirichletBoundaryCondition) {
 
   /* Create a BC and add it to the model. */
   DirichletBoundaryCondition<double> bc;
-  bc.AddBoundaryCondition(0, Vector3<double>(3, 2, 1));
+  bc.AddBoundaryCondition(FemNodeIndex(0),
+                          {Vector3<double>(1, 1, 1), Vector3<double>(2, 2, 2),
+                           Vector3<double>(3, 3, 3)});
   model.SetDirichletBoundaryCondition(bc);
   /* Verify that BC is applied to the state, but it doesn't matter whether BC is
    applied from the model or directly from the BC.*/

--- a/multibody/fem/test/fem_state_test.cc
+++ b/multibody/fem/test/fem_state_test.cc
@@ -12,7 +12,8 @@ namespace {
 
 using Eigen::VectorXd;
 constexpr int kNumElements = 2;
-constexpr int kNumDofs = 12;
+constexpr int kNumNodes = 4;
+constexpr int kNumDofs = 3 * kNumNodes;
 
 /* Dummy values for the states. */
 template <typename T>
@@ -96,6 +97,7 @@ TYPED_TEST(FemStateTest, SharedFemState) {
   auto context = this->fem_state_system_->CreateDefaultContext();
   FemState<T> state(this->fem_state_system_.get(), context.get());
   EXPECT_EQ(state.num_dofs(), kNumDofs);
+  EXPECT_EQ(state.num_nodes(), kNumNodes);
   EXPECT_EQ(state.GetPositions(), q<T>());
   EXPECT_EQ(state.GetVelocities(), v<T>());
   EXPECT_EQ(state.GetAccelerations(), a<T>());
@@ -111,6 +113,7 @@ TYPED_TEST(FemStateTest, GetStates) {
   using T = TypeParam;
   const FemState<T> state(this->fem_state_system_.get());
   EXPECT_EQ(state.num_dofs(), kNumDofs);
+  EXPECT_EQ(state.num_nodes(), kNumNodes);
   EXPECT_EQ(state.GetPositions(), q<T>());
   EXPECT_EQ(state.GetVelocities(), v<T>());
   EXPECT_EQ(state.GetAccelerations(), a<T>());

--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -329,17 +329,10 @@ void DeformableDriver<T>::AppendContactKinematics(
     std::vector<int> num_bcs(fem_model.num_nodes(), 0);
     for (const auto& it : bc.index_to_boundary_state()) {
       /* Note that we currently only allow zero boundary conditions. */
-      DRAKE_DEMAND(it.second.y() == 0);
-      DRAKE_DEMAND(it.second.z() == 0);
-      const int dof_index = it.first;
-      const int vertex_index = dof_index / 3;
+      DRAKE_DEMAND(it.second.v == Vector3<T>::Zero());
+      DRAKE_DEMAND(it.second.a == Vector3<T>::Zero());
+      const int vertex_index = it.first;
       ++num_bcs[vertex_index];
-    }
-    /* Note that we currently do not allow partial boundary condition; i.e.,
-     if any dof of a vertex is under bc, then all three dofs associated with the
-     vertex are under bc. */
-    for (int n : num_bcs) {
-      DRAKE_ASSERT(n % 3 == 0);
     }
 
     for (int i = 0; i < surface.num_contact_points(); ++i) {

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -87,11 +87,9 @@ void DeformableModel<T>::SetWallBoundaryCondition(DeformableBodyId id,
     const int dof_index = kDim * n;
     const auto p_WV = p_WVs.template segment<kDim>(dof_index);
     if (is_inside_wall(p_WV)) {
-      /* Set all kDim dofs associated with this node to be subject to zero
-       Dirichlet BC. */
-      for (int d = 0; d < kDim; ++d) {
-        bc.AddBoundaryCondition(dof_index + d, Vector3<T>(p_WV(d), 0, 0));
-      }
+      /* Set this node to be subject to zero Dirichlet BC. */
+      bc.AddBoundaryCondition(fem::FemNodeIndex(n),
+                              {p_WV, Vector3<T>::Zero(), Vector3<T>::Zero()});
     }
   }
   fem_model.SetDirichletBoundaryCondition(std::move(bc));


### PR DESCRIPTION
Instead, we require the full state (3 DoFs) of a vertex is specified when a vertex is put under a Dirichlet boundary condition.

The flexibility of putting individual DoFs of a vertex under BC turns out to be rather useless in practice as our public APIs only allow users to describes BCs at the level of vertices.

This also paves the way for transitioning to the new data structure of storing FEM tangent matrix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19545)
<!-- Reviewable:end -->
