### PR TITLE
[manipulation_station] Use applied spatial force in MbP

### DIFF
--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -59,7 +59,7 @@ namespace internal {
 namespace {
 
 // This system computes the generalized forces on the IIWA arm of the
-// manipulation resulting from externally applied spatial forces.
+// manipulation station resulting from externally applied spatial forces.
 //
 // @system
 // name: ExternalGeneralizedForcesComputer
@@ -796,6 +796,10 @@ void ManipulationStation<T>::Finalize(
                   computer->GetInputPort("multibody_state"));
   builder.ExportInput(computer->GetInputPort("applied_spatial_force"),
                       "applied_spatial_force");
+  // Connect the exported input to the plant's applied spatial force input as
+  // well.
+  builder.ConnectToSame(computer->GetInputPort("applied_spatial_force"),
+                        plant_->get_applied_spatial_force_input_port());
 
   // Adder to compute τ_external = τ_applied_spatial_force + τ_contact
   systems::Adder<double>* external_forces_adder =

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -355,9 +355,6 @@ GTEST_TEST(ManipulationStationTest, CheckDynamics) {
 //  - Case 2: zero spatial forces and feedforward torques equal to the
 //    generalized forces equivalent to the spatial forces from Case 1.
 GTEST_TEST(ManipulationStationTest, CheckDynamicsUnderExternallyAppliedForce) {
-  // TODO(xuchenhan-tri): Re-enable this test after fixing the wiring of
-  // manipulation station as a follow up to #19225.
-  GTEST_SKIP();
   const double kTimeStep = 0.002;
   ManipulationStation<double> station(kTimeStep);
   station.SetupManipulationClassStation();


### PR DESCRIPTION
#18268 introduced the `applied_spatial_force` input port in `ManipulationStation`; however, the input applied spatial force value is not used by MbP at all but instead only flows through the force computer.

Some context: #18268 has a unit test that's supposed to reveal this issue but it was short circuited by #12786. Partially resolving #12786, #19225 allows the unit test to reveal the problem again.

I believe the fix is as simple as porting `applied_spatial_force` into MbP, but I'm not overly familiar with manipulation station so reviewers be aware.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19548)
<!-- Reviewable:end -->
