### PR TITLE
Update install python path in documentation

### DIFF
--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -152,19 +152,19 @@ You will also need to have your ``PYTHONPATH`` configured correctly.
 
 ```bash
 cd drake-build
-export PYTHONPATH=${PWD}/install/lib/python3.8/site-packages:${PYTHONPATH}
+export PYTHONPATH=${PWD}/lib/python3.8/site-packages:${PYTHONPATH}
 ```
 
 *Ubuntu 22.04 (Jammy):*
 
 ```bash
 cd drake-build
-export PYTHONPATH=${PWD}/install/lib/python3.10/site-packages:${PYTHONPATH}
+export PYTHONPATH=${PWD}/lib/python3.10/site-packages:${PYTHONPATH}
 ```
 
 *macOS:*
 
 ```bash
 cd drake-build
-export PYTHONPATH=${PWD}/install/lib/python3.9/site-packages:${PYTHONPATH}
+export PYTHONPATH=${PWD}/lib/python3.9/site-packages:${PYTHONPATH}
 ```


### PR DESCRIPTION
Documentation presented an invalid path.

Calling

`bazel run //:install /my/drake_install`

does *not* create `/my/drake_install/install/lib/...`

It creates `/my/drake_install/lib/...`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19554)
<!-- Reviewable:end -->
