### PR TITLE
SapContactProblem reports multibody forces.

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -60,6 +60,7 @@ drake_cc_library(
         "//common:unused",
         "//common:value",
         "//multibody/contact_solvers:matrix_block",
+        "//multibody/math:spatial_algebra",
     ],
 )
 
@@ -223,6 +224,7 @@ drake_cc_googletest(
     deps = [
         ":sap_constraint",
         ":sap_contact_problem",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/multibody/contact_solvers/sap/sap_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_constraint.cc
@@ -52,6 +52,27 @@ void SapConstraint<T>::CalcCostHessian(const AbstractValue& data,
   DoCalcCostHessian(data, G);
 }
 
+template <typename T>
+void SapConstraint<T>::AccumulateGeneralizedImpulses(
+    int c, const Eigen::Ref<const VectorX<T>>& gamma,
+    EigenPtr<VectorX<T>> tau) const {
+  DRAKE_THROW_UNLESS(0 <= c && c < num_cliques());
+  DRAKE_THROW_UNLESS(gamma.size() == num_constraint_equations());
+  DRAKE_THROW_UNLESS(tau != nullptr);
+  DRAKE_THROW_UNLESS(tau->size() == num_velocities(c));
+  DoAccumulateGeneralizedImpulses(c, gamma, tau);
+}
+
+template <typename T>
+void SapConstraint<T>::AccumulateSpatialImpulses(
+    int o, const Eigen::Ref<const VectorX<T>>& gamma,
+    SpatialForce<T>* F) const {
+  DRAKE_THROW_UNLESS(o < num_objects());
+  DRAKE_THROW_UNLESS(gamma.size() == num_constraint_equations());
+  DRAKE_THROW_UNLESS(F != nullptr);
+  DoAccumulateSpatialImpulses(o, gamma, F);
+}
+
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody

--- a/multibody/contact_solvers/sap/sap_constraint.h
+++ b/multibody/contact_solvers/sap/sap_constraint.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
@@ -9,6 +10,7 @@
 #include "drake/common/value.h"
 #include "drake/multibody/contact_solvers/matrix_block.h"
 #include "drake/multibody/contact_solvers/sap/sap_constraint_jacobian.h"
+#include "drake/multibody/math/spatial_algebra.h"
 
 namespace drake {
 namespace multibody {
@@ -68,6 +70,14 @@ class SapConstraint {
   /* Number of participating cliques. It will always return either one (1) or
    two (2). */
   int num_cliques() const { return J_.num_cliques(); }
+
+  /* Returns the clique index for the first clique (c = 0) or for the
+   second clique (c = 1).
+   @throws if c < 0 or c >= num_cliques().*/
+  int clique(int c) const {
+    DRAKE_THROW_UNLESS(0 <= c && c < num_cliques());
+    return J_.clique(c);
+  }
 
   int num_velocities(int clique) const {
     DRAKE_THROW_UNLESS(0 <= clique && clique < num_cliques());
@@ -154,6 +164,71 @@ class SapConstraint {
   */
   void CalcCostHessian(const AbstractValue& abstract_data, MatrixX<T>* G) const;
 
+  /* @name Physical forces
+   @anchor sap_physical_forces
+   Each SAP constraint leads to a set of impulses in the solution to their
+   corresponding SapContactProblem. These impulses map to physical generalized
+   and/or spatial forces on the physical objects being constrained. As an
+   example, a distance constraint leads to a single scalar impulse value,
+   however the actual physical forces are vectors that act along the direction
+   of the two points being constrained. These forces are applied on the objects
+   being constrained, e.g. a rigid body, deformable body or particle. It is the
+   specify constraint type that knows how to map these impulses to physical
+   generalized and/or spatial forces.
+   Constraints will register indexes associated with physical objects at
+   construction with RegisterObjects(). These indexes can then be used to
+   request spatial forces on each object via AccumulateSpatialImpulses().
+   Generalized impulses are reported on a per-clique basis via
+   AccumulateGeneralizedImpulses(). */
+  //@{
+
+  /* Number of physical objects constrained by `this` constraint.
+   At construction, specific constraints must call RegisterObjects() in order to
+   register indexes that correspond to these physical objects. */
+  int num_objects() const { return objects_.size(); }
+
+  /* Returns the vector of object indexes register with RegisterObjects(). */
+  const std::vector<int>& objects() const { return objects_; }
+
+  /* Returns the index for the o-the object constrained by `this` constraint.
+   @throws if o < 0 > or if o >= num_objects(). */
+  int object(int o) const {
+    DRAKE_THROW_UNLESS(0 <= o && o < num_objects());
+    return objects_[o];
+  }
+  //@}
+
+  /* Accumulates generalized impulses applied by this constraint on the c-th
+   clique.
+   @param[in] c The c-th clique of index clique(c).
+   @param[in] gamma Impulses for this constraint, of size
+   num_constraint_equations().
+   @param[out] tau On output this function will accumulate the generalized
+   impulses applied by this constraint on the c-th clique.
+
+   @throws if c < 0 or if c >= num_cliques().
+   @throws if gamma.size() != num_constraint_equations().
+   @throws if tau is the nullptr.
+   @throws if tau.size() != num_velocities(c). */
+  void AccumulateGeneralizedImpulses(int c,
+                                     const Eigen::Ref<const VectorX<T>>& gamma,
+                                     EigenPtr<VectorX<T>> tau) const;
+
+  /* Accumulates generalized impulses applied by this constraint the o-th
+   object.
+   @param[in] o The o-th object of index object(o).
+   @param[in] gamma Impulses for this constraint, of size
+   num_constraint_equations().
+   @param[out] tau On output this function will accumulate the spatial
+   impulse applied by this constraint on the o-th object.
+
+   @throws if c < 0 or if c >= num_cliques().
+   @throws if gamma.size() != num_constraint_equations().
+   @throws if F is the nullptr. */
+  void AccumulateSpatialImpulses(int o,
+                                 const Eigen::Ref<const VectorX<T>>& gamma,
+                                 SpatialForce<T>* F) const;
+
   /* Polymorphic deep-copy into a new instance. */
   std::unique_ptr<SapConstraint<T>> Clone() const { return DoClone(); }
 
@@ -162,8 +237,18 @@ class SapConstraint {
    implementation of DoClone(). */
   SapConstraint(const SapConstraint&) = default;
 
+  /* Derived constraints must register the indexes of the objects they
+   constraint. After this call, num_objects() will equal objects.size(). See
+   @ref sap_physical_forces.
+   @throws if called more than once. */
+  void RegisterObjects(std::vector<int> objects) {
+    DRAKE_THROW_UNLESS(num_objects() == 0);
+    objects_ = std::move(objects);
+  }
+
   /* Helper to pack `data` of type `U` into an AbstractValue.
-   Derived constraint classes can use this helper to implement DoMakeData(). */
+   Derived constraint classes can use thisAccumulateSpatialForces helper to
+   implement DoMakeData(). */
   template <typename U>
   static std::unique_ptr<AbstractValue> MoveAndMakeAbstractValue(U&& data) {
     auto owned_data = std::make_unique<U>(std::move(data));
@@ -185,7 +270,23 @@ class SapConstraint {
                              EigenPtr<VectorX<T>> gamma) const = 0;
   virtual void DoCalcCostHessian(const AbstractValue& data,
                                  MatrixX<T>* G) const = 0;
-
+  virtual void DoAccumulateGeneralizedImpulses(
+      int, const Eigen::Ref<const VectorX<T>>&, EigenPtr<VectorX<T>>) const {
+    // TODO(amcastro-tri): Temporarily, the default implementation is a no-op
+    // until the full resolution of #19435. Once all constraints report forces,
+    // this function will be pure virtual.
+    throw std::logic_error(
+        "Constraints must implement this function. See #19435. ");
+  }
+  virtual void DoAccumulateSpatialImpulses(int,
+                                           const Eigen::Ref<const VectorX<T>>&,
+                                           SpatialForce<T>*) const {
+    // TODO(amcastro-tri): Temporarily, the default implementation is a no-op
+    // until the full resolution of #19435. Once all constraints report forces,
+    // this function will be pure virtual.
+    throw std::logic_error(
+        "Constraints must implement this function. See #19435. ");
+  }
   /* Clone() implementation. Derived classes must override to provide
    polymorphic deep-copy into a new instance. */
   virtual std::unique_ptr<SapConstraint<T>> DoClone() const = 0;
@@ -193,6 +294,7 @@ class SapConstraint {
 
  private:
   SapConstraintJacobian<T> J_;
+  std::vector<int> objects_;
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_constraint_jacobian.h
+++ b/multibody/contact_solvers/sap/sap_constraint_jacobian.h
@@ -88,16 +88,16 @@ class SapConstraintJacobian {
   /* Returns the clique index for the first clique (local_index = 0) or the
    second clique (local_index = 1). Refer to the constructor's documentation for
    details. */
-  int clique(int local_clique) const {
-    DRAKE_DEMAND(0 <= local_clique && local_clique < num_cliques());
-    return clique_jacobians_[local_clique].clique;
+  int clique(int local_index) const {
+    DRAKE_DEMAND(0 <= local_index && local_index < num_cliques());
+    return clique_jacobians_[local_index].clique;
   }
 
   /* Returns the Jacobian block for the first clique (local_index = 0) or the
    second clique (local_index = 1). */
-  const MatrixBlock<T>& clique_jacobian(int local_clique) const {
-    DRAKE_DEMAND(local_clique < num_cliques());
-    return clique_jacobians_[local_clique].block;
+  const MatrixBlock<T>& clique_jacobian(int local_index) const {
+    DRAKE_DEMAND(local_index < num_cliques());
+    return clique_jacobians_[local_index].block;
   }
 
  private:

--- a/multibody/contact_solvers/sap/sap_contact_problem.cc
+++ b/multibody/contact_solvers/sap/sap_contact_problem.cc
@@ -5,6 +5,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/ssize.h"
 #include "drake/multibody/contact_solvers/sap/contact_problem_graph.h"
 
 namespace drake {
@@ -21,30 +22,38 @@ SapContactProblem<T>::SapContactProblem(const T& time_step)
 template <typename T>
 SapContactProblem<T>::SapContactProblem(const T& time_step,
                                         std::vector<MatrixX<T>> A,
-                                        VectorX<T> v_star)
+                                        VectorX<T> v_star, int num_objects)
     : time_step_(time_step),
       A_(std::move(A)),
       v_star_(std::move(v_star)),
       graph_(num_cliques()) {
   DRAKE_THROW_UNLESS(time_step > 0.0);
+  num_objects_ = num_objects;
+  velocities_start_.resize(A_.size(), 0);
   nv_ = 0;
-  for (const auto& Ac : A_) {
-    DRAKE_THROW_UNLESS(Ac.size() >= 0);
+  for (int i = 0; i < ssize(A_); ++i) {
+    const auto& Ac = A_[i];
     DRAKE_THROW_UNLESS(Ac.rows() == Ac.cols());
+    const int clique_nv = Ac.rows();
+    if (i > 0) velocities_start_[i] = velocities_start_[i - 1] + clique_nv;
     nv_ += Ac.rows();
   }
   DRAKE_THROW_UNLESS(v_star_.size() == nv_);
 }
 
 template <typename T>
-void SapContactProblem<T>::Reset(std::vector<MatrixX<T>> A, VectorX<T> v_star) {
+void SapContactProblem<T>::Reset(std::vector<MatrixX<T>> A, VectorX<T> v_star,
+                                 int num_objects) {
+  num_objects_ = num_objects;
   A_ = std::move(A);
   v_star_ = std::move(v_star);
   graph_.ResetNumCliques(num_cliques());
+  velocities_start_.reserve(A_.size());
   nv_ = 0;
   for (const auto& Ac : A_) {
     DRAKE_THROW_UNLESS(Ac.size() >= 0);
     DRAKE_THROW_UNLESS(Ac.rows() == Ac.cols());
+    velocities_start_.push_back(Ac.rows());
     nv_ += Ac.rows();
   }
   DRAKE_THROW_UNLESS(v_star_.size() == nv_);
@@ -53,7 +62,8 @@ void SapContactProblem<T>::Reset(std::vector<MatrixX<T>> A, VectorX<T> v_star) {
 
 template <typename T>
 std::unique_ptr<SapContactProblem<T>> SapContactProblem<T>::Clone() const {
-  auto clone = std::make_unique<SapContactProblem<T>>(time_step_, A_, v_star_);
+  auto clone = std::make_unique<SapContactProblem<T>>(time_step_, A_, v_star_,
+                                                      num_objects_);
   for (int i = 0; i < num_constraints(); ++i) {
     const SapConstraint<T>& c = get_constraint(i);
     clone->AddConstraint(c.Clone());
@@ -90,6 +100,12 @@ int SapContactProblem<T>::AddConstraint(std::unique_ptr<SapConstraint<T>> c) {
         "Adding constraint to a clique with zero number of velocities is not "
         "allowed.");
   }
+  for (int object_index : c->objects()) {
+    DRAKE_THROW_UNLESS(0 <= object_index && object_index < num_objects());
+  }
+
+  // Register objects.
+  objects_.insert(c->objects().begin(), c->objects().end());
 
   // Update graph.
   const int ni = c->num_constraint_equations();
@@ -101,6 +117,47 @@ int SapContactProblem<T>::AddConstraint(std::unique_ptr<SapConstraint<T>> c) {
   constraints_.push_back(std::move(c));
 
   return constraint_index;
+}
+
+template <typename T>
+void SapContactProblem<T>::CalcConstraintMultibodyForces(
+    const VectorX<T>& gamma, VectorX<T>* generalized_forces,
+    std::vector<SpatialForce<T>>* spatial_forces) const {
+  DRAKE_THROW_UNLESS(gamma.size() == num_constraint_equations());
+  DRAKE_THROW_UNLESS(generalized_forces != nullptr);
+  DRAKE_THROW_UNLESS(generalized_forces->size() == num_velocities());
+  DRAKE_THROW_UNLESS(spatial_forces != nullptr);
+  DRAKE_THROW_UNLESS(ssize(*spatial_forces) == num_objects());
+  int offset = 0;
+  for (int i = 0; i < num_constraints(); ++i) {
+    const SapConstraint<T>& constraint = get_constraint(i);
+    const int ne = constraint.num_constraint_equations();
+    const auto constraint_gamma = gamma.segment(offset, ne);
+
+    // Compute generalized forces per clique.
+    for (int c = 0; c < constraint.num_cliques(); ++c) {
+      const int clique = constraint.clique(c);
+      auto clique_forces = generalized_forces->segment(velocities_start(clique),
+                                                       num_velocities(clique));
+      constraint.AccumulateGeneralizedImpulses(c, constraint_gamma,
+                                               &clique_forces);
+    }
+
+    // Accumulate spatial forces per object.
+    for (int o = 0; o < constraint.num_objects(); ++o) {
+      const int object = constraint.object(o);
+      SpatialForce<T>& F = (*spatial_forces)[object];
+      constraint.AccumulateSpatialImpulses(o, constraint_gamma, &F);
+    }
+
+    offset += ne;
+  }
+
+  // Conversion of impulses into forces.
+  (*generalized_forces) /= time_step();
+  for (SpatialForce<T>& F : *spatial_forces) {
+    F.get_coeffs() /= time_step();
+  }
 }
 
 }  // namespace internal


### PR DESCRIPTION
Towards fixing #18748 , #18749 and #19068.
Design in #19435.

Only specific constraint types know how to compute forces given a set of impulses. 
This PR adds the needed minimum infrastructure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19555)
<!-- Reviewable:end -->
