### PR TITLE
Implements MultibodyPlant::IsVelocityEqualToQDot

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -652,6 +652,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("MakeStateSelectorMatrix", &Class::MakeStateSelectorMatrix,
             py::arg("user_to_joint_index_map"),
             cls_doc.MakeStateSelectorMatrix.doc)
+        .def("IsVelocityEqualToQDot", &Class::IsVelocityEqualToQDot,
+            cls_doc.IsVelocityEqualToQDot.doc)
         .def(
             "MapVelocityToQDot",
             [](const Class* self, const Context<T>& context,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1755,6 +1755,7 @@ class TestPlant(unittest.TestCase):
         self.assertNotEqual(link0.floating_positions_start(), -1)
         self.assertNotEqual(link0.floating_velocities_start(), -1)
         v_expected = np.linspace(start=-1.0, stop=-nv, num=nv)
+        self.assertFalse(plant.IsVelocityEqualToQDot())
         qdot = plant.MapVelocityToQDot(context, v_expected)
         v_remap = plant.MapQDotToVelocity(context, qdot)
         numpy_compare.assert_float_allclose(v_remap, v_expected)

--- a/manipulation/util/robot_plan_interpolator.cc
+++ b/manipulation/util/robot_plan_interpolator.cc
@@ -76,7 +76,7 @@ RobotPlanInterpolator::RobotPlanInterpolator(
   // TODO(sammy-tri) This implementation doesn't know how to
   // calculate velocities/accelerations for differing numbers of
   // positions and velocities.
-  DRAKE_DEMAND(plant_.num_positions() == plant_.num_velocities());
+  DRAKE_DEMAND(plant_.IsVelocityEqualToQDot());
   const int num_pv = plant_.num_positions() + plant_.num_velocities();
 
   state_output_port_ =

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3303,6 +3303,15 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                              const MultibodyForces<T>& forces,
                              VectorX<T>* generalized_forces) const;
 
+  /// Returns true iff the generalized velocity v is exactly the time
+  /// derivative q̇ of the generalized coordinates q. In this case
+  /// MapQDotToVelocity() and MapVelocityToQDot() implement the identity map.
+  /// This method is, in the worst case, O(n), where n is the number of joints.
+  bool IsVelocityEqualToQDot() const {
+    // TODO(sherm1): Consider caching this value.
+    return internal_tree().IsVelocityEqualToQDot();
+  }
+
   // Preserve access to base overload from this class.
   using systems::System<T>::MapVelocityToQDot;
 

--- a/multibody/plant/test/floating_body_test.cc
+++ b/multibody/plant/test/floating_body_test.cc
@@ -208,6 +208,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
   // The generalized velocity computed last at time = kEndTime.
   const VectorX<double> v =
       context.get_continuous_state().get_generalized_velocity().CopyToVector();
+  EXPECT_FALSE(model.IsVelocityEqualToQDot());
   model.MapVelocityToQDot(context, v, &qdot_from_v);
   // MultibodyTree computes the time derivatives in the inboard frame which in
   // this case happens to be the world frame W. Thus we use DtW to denote the
@@ -297,6 +298,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, MapVelocityToQDotAndBack) {
           free_body_plant.body(), {w_WB, v_WB}, context.get()));
 
   // Map generalized velocities to time derivatives of generalized positions.
+  EXPECT_FALSE(model.IsVelocityEqualToQDot());
   VectorX<double> qdot_from_v(model.num_positions());
   const VectorX<double> v =
       context->get_continuous_state().get_generalized_velocity().CopyToVector();

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -2175,6 +2175,8 @@ GTEST_TEST(MultibodyPlantTest, MapVelocityToQDotAndBackFixedWorld) {
   plant.Finalize();
   unique_ptr<Context<double>> context = plant.CreateDefaultContext();
 
+  EXPECT_TRUE(plant.IsVelocityEqualToQDot());
+
   // Make sure that the mapping functions do not throw.
   BasicVector<double> qdot(0), v(0);
   ASSERT_NO_THROW(plant.MapVelocityToQDot(*context, v, &qdot));
@@ -2185,6 +2187,8 @@ GTEST_TEST(MultibodyPlantTest, MapVelocityToQDotAndBackContinuous) {
   MultibodyPlant<double> plant(0.0);
   unique_ptr<Context<double>> context;
   InitializePlantAndContextForVelocityToQDotMapping(&plant, &context);
+
+  EXPECT_FALSE(plant.IsVelocityEqualToQDot());
 
   // Use of MultibodyPlant's mapping to convert generalized velocities to time
   // derivatives of generalized coordinates.
@@ -2210,6 +2214,8 @@ GTEST_TEST(MultibodyPlantTest, MapVelocityToQDotAndBackDiscrete) {
   MultibodyPlant<double> plant(time_step);
   unique_ptr<Context<double>> context;
   InitializePlantAndContextForVelocityToQDotMapping(&plant, &context);
+
+  EXPECT_FALSE(plant.IsVelocityEqualToQDot());
 
   // Use of MultibodyPlant's mapping to convert generalized velocities to time
   // derivatives of generalized coordinates.

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -527,6 +527,8 @@ class Mobilizer : public MultibodyElement<T> {
     DoCalcNplusMatrix(context, Nplus);
   }
 
+  virtual bool is_velocity_equal_to_qdot() const = 0;
+
   // Computes the kinematic mapping `q̇ = N(q)⋅v` between generalized
   // velocities v and time derivatives of the generalized positions `qdot`.
   // The generalized positions vector is stored in `context`.

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1520,6 +1520,19 @@ void MultibodyTree<T>::AddJointDampingForces(
 }
 
 template <typename T>
+bool MultibodyTree<T>::IsVelocityEqualToQDot() const {
+  if (num_positions() != num_velocities()) {
+    return false;
+  }
+  for (const auto& mobilizer : owned_mobilizers_) {
+    if (!mobilizer->is_velocity_equal_to_qdot()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T>
 void MultibodyTree<T>::MapQDotToVelocity(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& qdot,

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1689,6 +1689,9 @@ class MultibodyTree {
       const systems::Context<T>& context) const;
 
   // See MultibodyPlant method.
+  bool IsVelocityEqualToQDot() const;
+
+  // See MultibodyPlant method.
   void MapVelocityToQDot(
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& v,

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -164,6 +164,8 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
                            const SpatialForce<T>& F_Mo_F,
                            Eigen::Ref<VectorX<T>> tau) const override;
 
+  bool is_velocity_equal_to_qdot() const override { return true; }
+
   /* Performs the identity mapping from v to qdot since, for this mobilizer,
    v = q̇. */
   void MapVelocityToQDot(const systems::Context<T>& context,

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -146,6 +146,8 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
       const SpatialForce<T>& F_Mo_F,
       Eigen::Ref<VectorX<T>> tau) const final;
 
+  bool is_velocity_equal_to_qdot() const override { return true; }
+
   // Computes the kinematic mapping from generalized velocities v to time
   // derivatives of the generalized positions `q̇`. For this mobilizer `q̇ = v`.
   void MapVelocityToQDot(

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -214,6 +214,8 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
       const SpatialForce<T>& F_Mo_F,
       Eigen::Ref<VectorX<T>> tau) const override;
 
+  bool is_velocity_equal_to_qdot() const override { return false; }
+
   void MapVelocityToQDot(
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& v,

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -147,6 +147,8 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
       const SpatialForce<T>& F_Mo_F,
       Eigen::Ref<VectorX<T>> tau) const override;
 
+  bool is_velocity_equal_to_qdot() const override { return true; }
+
   void MapVelocityToQDot(
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& v,

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -198,6 +198,8 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
                            const SpatialForce<T>& F_Mo_F,
                            Eigen::Ref<VectorX<T>> tau) const final;
 
+  bool is_velocity_equal_to_qdot() const override { return true; }
+
   /* Performs the identity mapping from v to qdot since, for this mobilizer,
    v = q̇. */
   void MapVelocityToQDot(const systems::Context<T>& context,

--- a/multibody/tree/space_xyz_floating_mobilizer.h
+++ b/multibody/tree/space_xyz_floating_mobilizer.h
@@ -232,6 +232,8 @@ class SpaceXYZFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
                            const SpatialForce<T>& F_Mo_F,
                            Eigen::Ref<VectorX<T>> tau) const override;
 
+  bool is_velocity_equal_to_qdot() const override { return false; }
+
   // Maps the generalized velocity v to time derivatives of configuration
   // `qdot`.
   //

--- a/multibody/tree/space_xyz_mobilizer.h
+++ b/multibody/tree/space_xyz_mobilizer.h
@@ -200,6 +200,8 @@ class SpaceXYZMobilizer final : public MobilizerImpl<T, 3, 3> {
       const SpatialForce<T>& F_Mo_F,
       Eigen::Ref<VectorX<T>> tau) const override;
 
+  bool is_velocity_equal_to_qdot() const override { return false; }
+
   // Maps the generalized velocity v, which corresponds to the angular velocity
   // `w_FM`, to time derivatives of space x-y-z angles θ₁, θ₂, θ₃ in `qdot`.
   //

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -91,6 +91,8 @@ class FeatherstoneMobilizer final : public MobilizerImpl<T, 2, 2> {
     tau = H_FM_.transpose() * F_Mo_F.get_coeffs();
   }
 
+  bool is_velocity_equal_to_qdot() const override { return true; }
+
   void MapVelocityToQDot(
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& v,

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -252,6 +252,8 @@ TEST_F(PlanarMobilizerTest, ProjectSpatialForce) {
 }
 
 TEST_F(PlanarMobilizerTest, MapVelocityToQDotAndBack) {
+  EXPECT_TRUE(mobilizer_->is_velocity_equal_to_qdot());
+
   Vector3d v(1.5, 2.5, 3.5);
   Vector3d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -146,6 +146,8 @@ TEST_F(PrismaticMobilizerTest, ProjectSpatialForce) {
 }
 
 TEST_F(PrismaticMobilizerTest, MapVelocityToQDotAndBack) {
+  EXPECT_TRUE(slider_->is_velocity_equal_to_qdot());
+
   Vector1d v(1.5);
   Vector1d qdot;
   slider_->MapVelocityToQDot(*context_, v, &qdot);

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -188,6 +188,8 @@ TEST_F(QuaternionFloatingMobilizerTest, MapUsesN) {
   const Vector3d p_WB(1.0, 2.0, 3.0);
   mobilizer_->set_position(context_.get(), p_WB);
 
+  EXPECT_FALSE(mobilizer_->is_velocity_equal_to_qdot());
+
   // Set arbitrary v and MapVelocityToQDot
   const Vector6<double> v =
       (Vector6<double>() << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0).finished();

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -195,6 +195,8 @@ TEST_F(RevoluteMobilizerTest, ProjectSpatialForce) {
 }
 
 TEST_F(RevoluteMobilizerTest, MapVelocityToQDotAndBack) {
+  EXPECT_TRUE(mobilizer_->is_velocity_equal_to_qdot());
+
   Vector1d v(1.5);
   Vector1d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -278,6 +278,8 @@ TEST_F(ScrewMobilizerTest, ProjectSpatialForce) {
 }
 
 TEST_F(ScrewMobilizerTest, MapVelocityToQDotAndBack) {
+  EXPECT_TRUE(mobilizer_->is_velocity_equal_to_qdot());
+
   Vector1d v(1.5);
   Vector1d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);

--- a/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
@@ -147,6 +147,8 @@ TEST_F(SpaceXYZFloatingMobilizerTest, CalcAcrossMobilizer) {
 }
 
 TEST_F(SpaceXYZFloatingMobilizerTest, MapVelocityToQdotAndBack) {
+  EXPECT_FALSE(mobilizer_->is_velocity_equal_to_qdot());
+
   SetArbitraryNonZeroState();
   const Vector6<double> v = (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
   Vector6<double> qdot;

--- a/multibody/tree/test/space_xyz_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_mobilizer_test.cc
@@ -111,6 +111,8 @@ TEST_F(SpaceXYZMobilizerTest, MapUsesN) {
   const Vector3d rpy_value(M_PI / 3, -M_PI / 3, M_PI / 5);
   mobilizer_->set_angles(context_.get(), rpy_value);
 
+  EXPECT_FALSE(mobilizer_->is_velocity_equal_to_qdot());
+
   // Set arbitrary v and MapVelocityToQDot.
   const Vector3<double> v = (Vector3<double>() << 1, 2, 3).finished();
   Vector3<double> qdot;

--- a/multibody/tree/test/universal_mobilizer_test.cc
+++ b/multibody/tree/test/universal_mobilizer_test.cc
@@ -225,6 +225,8 @@ TEST_F(UniversalMobilizerTest, ProjectSpatialForce) {
 }
 
 TEST_F(UniversalMobilizerTest, MapVelocityToQDotAndBack) {
+  EXPECT_TRUE(mobilizer_->is_velocity_equal_to_qdot());
+
   Vector2d v(1.5, 2.5);
   Vector2d qdot;
   mobilizer_->MapVelocityToQDot(*context_, v, &qdot);

--- a/multibody/tree/test/weld_mobilizer_test.cc
+++ b/multibody/tree/test/weld_mobilizer_test.cc
@@ -83,6 +83,8 @@ TEST_F(WeldMobilizerTest, ProjectSpatialForce) {
 }
 
 TEST_F(WeldMobilizerTest, MapVelocityToQDotAndBack) {
+  EXPECT_TRUE(weld_body_to_world_->is_velocity_equal_to_qdot());
+
   VectorXd zero_sized_vector(0);
   // These methods are no-ops, just test we can call them with zero sized
   // vectors.

--- a/multibody/tree/universal_mobilizer.h
+++ b/multibody/tree/universal_mobilizer.h
@@ -140,6 +140,8 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
                            const SpatialForce<T>& F_Mo_F,
                            Eigen::Ref<VectorX<T>> tau) const override;
 
+  bool is_velocity_equal_to_qdot() const override { return true; }
+
   // Performs the identity mapping from v to qdot since, for this mobilizer,
   // v = q̇.
   void MapVelocityToQDot(const systems::Context<T>& context,

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -61,6 +61,8 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
       const SpatialForce<T>& F_Mo_F,
       Eigen::Ref<VectorX<T>> tau) const final;
 
+  bool is_velocity_equal_to_qdot() const override { return true; }
+
   // This override is a no-op since this mobilizer has no generalized
   // velocities associated with it.
   void MapVelocityToQDot(

--- a/systems/controllers/joint_stiffness_controller.cc
+++ b/systems/controllers/joint_stiffness_controller.cc
@@ -31,6 +31,7 @@ JointStiffnessController<T>::JointStiffnessController(
   const int num_q = plant_->num_positions();
   DRAKE_DEMAND(num_q == plant_->num_velocities());
   DRAKE_DEMAND(num_q == plant_->num_actuated_dofs());
+  DRAKE_DEMAND(plant_->IsVelocityEqualToQDot());
 
   DRAKE_DEMAND(kp.size() == num_q);
   DRAKE_DEMAND(kd.size() == num_q);

--- a/systems/controllers/joint_stiffness_controller.h
+++ b/systems/controllers/joint_stiffness_controller.h
@@ -39,14 +39,13 @@ namespace controllers {
  * contact forces.
  *
  * The controller currently requires that plant.num_positions() ==
- * plant.num_velocities() == plant.num_actuated_dofs().
+ * plant.num_velocities() == plant.num_actuated_dofs() and that
+ * plant.IsVelocityEqualToQDot() is true.
  *
  * @system
- * name: JointStiffnessController
- * input_ports:
+ * name: JointStiffnessController input_ports:
  * - estimated_state
- * - desired_state
- * output_ports:
+ * - desired_state output_ports:
  * - generalized_force
  * @endsystem
  *
@@ -72,6 +71,7 @@ class JointStiffnessController final : public LeafSystem<T> {
    * `true`).
    * @pre plant.num_positions() == plant.num_velocities() ==
    * plant.num_actuated_dofs() == kp.size() == kd.size()
+   * @pre plant.IsVelocityEqualToQDot() is true.
    */
   JointStiffnessController(const multibody::MultibodyPlant<T>& plant,
                            const Eigen::Ref<const Eigen::VectorXd>& kp,
@@ -84,6 +84,7 @@ class JointStiffnessController final : public LeafSystem<T> {
    * `true`).
    * @pre plant.num_positions() == plant.num_velocities() ==
    * plant.num_actuated_dofs() == kp.size() == kd.size()
+   * @pre plant.IsVelocityEqualToQDot() is true.
    *
    * @exclude_from_pydrake_mkdoc{This overload is not bound.}
    */

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -126,7 +126,7 @@ class DiscreteDerivative final : public LeafSystem<T> {
 /// Supports the common pattern of combining a (feed-through) position with
 /// a velocity estimated with the DiscreteDerivative into a single output
 /// vector with positions and velocities stacked.  This assumes that the
-/// number of positions == the number of velocities.
+/// velocities are equal to the time derivative of the positions.
 ///
 /// ```
 ///                                  ┌─────┐


### PR DESCRIPTION
We had several methods that which assumed the v==q̇, but only checked that assumption by testing that num_positions() == num_velocities(). But the SpaceXYZMobilizer (and it's floating equivalent) have num_positions==num_velocities, but not v==q̇. This PR introduces the proper check.

+@sherm1 for feature review, please.
This will be used to resolve the discussion in #19522 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19563)
<!-- Reviewable:end -->
