### PR TITLE
[pydrake] Centralize pybind11 includes for ODR safety

### DIFF
--- a/bindings/pydrake/autodiff_types_pybind.h
+++ b/bindings/pydrake/autodiff_types_pybind.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "pybind11/eigen.h"
-#include "pybind11/numpy.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/autodiff.h"
 

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -1,7 +1,4 @@
-#include "pybind11/eigen.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
+#include <Eigen/Core>
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"

--- a/bindings/pydrake/common/cpp_param_pybind.h
+++ b/bindings/pydrake/common/cpp_param_pybind.h
@@ -7,9 +7,6 @@
 #include <typeinfo>
 #include <vector>
 
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/common/cpp_template_pybind.h
+++ b/bindings/pydrake/common/cpp_template_pybind.h
@@ -3,10 +3,6 @@
 #include <string>
 #include <utility>
 
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 // `GetPyTypes` is implemented specifically for `cpp_template`; to simplify
 // dependencies, this is included transitively.
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"

--- a/bindings/pydrake/common/deprecation_pybind.h
+++ b/bindings/pydrake/common/deprecation_pybind.h
@@ -9,9 +9,6 @@
 #include <string>
 #include <utility>
 
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/wrap_function.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 

--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -1,8 +1,6 @@
 #include <cmath>
 #include <stdexcept>
 
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"

--- a/bindings/pydrake/common/eigen_geometry_pybind.h
+++ b/bindings/pydrake/common/eigen_geometry_pybind.h
@@ -10,7 +10,6 @@
 #include <string>
 #include <utility>
 
-#include "pybind11/eigen.h"
 #include <Eigen/Dense>
 
 #include "drake/bindings/pydrake/common/wrap_pybind.h"

--- a/bindings/pydrake/common/eigen_pybind.h
+++ b/bindings/pydrake/common/eigen_pybind.h
@@ -2,7 +2,6 @@
 
 #include <utility>
 
-#include "pybind11/eigen.h"
 #include <Eigen/Dense>
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/common/identifier_pybind.h
+++ b/bindings/pydrake/common/identifier_pybind.h
@@ -2,9 +2,6 @@
 
 #include <string>
 
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/identifier.h"

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/text_logging_pybind.h"

--- a/bindings/pydrake/common/schema_py.cc
+++ b/bindings/pydrake/common/schema_py.cc
@@ -1,10 +1,7 @@
 #include <memory>
 #include <vector>
 
-#include "pybind11/eigen.h"
 #include "pybind11/eval.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"

--- a/bindings/pydrake/common/serialize_pybind.h
+++ b/bindings/pydrake/common/serialize_pybind.h
@@ -10,13 +10,10 @@
 #include <variant>
 #include <vector>
 
-#include "bindings/pydrake/common/cpp_template_pybind.h"
-#include "bindings/pydrake/pydrake_pybind.h"
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
 #include <fmt/format.h>
 
+#include "drake/bindings/pydrake/common/cpp_template_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"

--- a/bindings/pydrake/common/sorted_pair_pybind.h
+++ b/bindings/pydrake/common/sorted_pair_pybind.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/sorted_pair.h"
 

--- a/bindings/pydrake/common/test/compatibility_test_util_py.cc
+++ b/bindings/pydrake/common/test/compatibility_test_util_py.cc
@@ -1,6 +1,3 @@
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 
 namespace drake {

--- a/bindings/pydrake/common/test/cpp_param_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_param_pybind_test.cc
@@ -8,7 +8,6 @@
 
 #include "pybind11/embed.h"
 #include "pybind11/eval.h"
-#include "pybind11/pybind11.h"
 #include <gtest/gtest.h>
 
 #include "drake/bindings/pydrake/test/test_util_pybind.h"

--- a/bindings/pydrake/common/test/cpp_template_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_template_pybind_test.cc
@@ -10,7 +10,6 @@
 
 #include "pybind11/embed.h"
 #include "pybind11/eval.h"
-#include "pybind11/pybind11.h"
 #include <gtest/gtest.h>
 
 #include "drake/bindings/pydrake/test/test_util_pybind.h"

--- a/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
+++ b/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
@@ -6,8 +6,6 @@ Please review this file and the corresponding test,
 `deprecation_utility_test.py`.
 */
 
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/test/deprecation_example/example_class.h"  // NOLINT
 #include "drake/bindings/pydrake/common/test/deprecation_example/example_class_documentation.h"  // NOLINT

--- a/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
+++ b/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
@@ -1,4 +1,3 @@
-#include "pybind11/pybind11.h"
 #include <Eigen/Dense>
 
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"

--- a/bindings/pydrake/common/test/serialize_test_bar_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_bar_py.cc
@@ -1,5 +1,3 @@
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/test/serialize_test_foo_py.h"
 #include "drake/common/name_value.h"

--- a/bindings/pydrake/common/test/serialize_test_foo_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_foo_py.cc
@@ -1,7 +1,5 @@
 #include "drake/bindings/pydrake/common/test/serialize_test_foo_py.h"
 
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 
 namespace drake {

--- a/bindings/pydrake/common/test/serialize_test_util_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_util_py.cc
@@ -1,9 +1,6 @@
 #include <array>
 #include <utility>
 
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
@@ -8,7 +8,6 @@
 
 #include "pybind11/embed.h"
 #include "pybind11/eval.h"
-#include "pybind11/pybind11.h"
 #include <gtest/gtest.h>
 
 #include "drake/bindings/pydrake/test/test_util_pybind.h"

--- a/bindings/pydrake/common/test/value_test_util_py.cc
+++ b/bindings/pydrake/common/test/value_test_util_py.cc
@@ -1,6 +1,3 @@
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 

--- a/bindings/pydrake/common/test/wrap_test_util_py.cc
+++ b/bindings/pydrake/common/test/wrap_test_util_py.cc
@@ -1,5 +1,3 @@
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/copyable_unique_ptr.h"

--- a/bindings/pydrake/common/type_safe_index_pybind.h
+++ b/bindings/pydrake/common/type_safe_index_pybind.h
@@ -2,9 +2,6 @@
 
 #include <string>
 
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -1,7 +1,6 @@
 #include <string>
 
 #include "pybind11/eval.h"
-#include "pybind11/pybind11.h"
 
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"

--- a/bindings/pydrake/common/wrap_pybind.h
+++ b/bindings/pydrake/common/wrap_pybind.h
@@ -8,8 +8,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/wrap_function.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/copyable_unique_ptr.h"

--- a/bindings/pydrake/examples/examples_py_acrobot.cc
+++ b/bindings/pydrake/examples/examples_py_acrobot.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/examples/examples_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/examples/examples_py_compass_gait.cc
+++ b/bindings/pydrake/examples/examples_py_compass_gait.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/examples/examples_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/examples/examples_py_manipulation_station.cc
+++ b/bindings/pydrake/examples/examples_py_manipulation_station.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/examples/examples_py.h"

--- a/bindings/pydrake/examples/examples_py_pendulum.cc
+++ b/bindings/pydrake/examples/examples_py_pendulum.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/examples/examples_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/examples/examples_py_quadrotor.cc
+++ b/bindings/pydrake/examples/examples_py_quadrotor.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/examples/examples_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/examples/examples_py_rimless_wheel.cc
+++ b/bindings/pydrake/examples/examples_py_rimless_wheel.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/examples/examples_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/examples/examples_py_van_der_pol.cc
+++ b/bindings/pydrake/examples/examples_py_van_der_pol.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/examples/examples_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -4,8 +4,6 @@
  represent the input values to all of those computations. They can be found in
  the pydrake.geometry module. */
 
-#include "pybind11/operators.h"
-
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/identifier_pybind.h"

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -2,8 +2,6 @@
  drake::geometry::optimization namespace. They can be found in the
  pydrake.geometry.optimization module. */
 
-#include "pybind11/stl/filesystem.h"
-
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/identifier_pybind.h"

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -2,8 +2,6 @@
  and drake/geometry/render* directories. They can be found in the
  pydrake.geometry module. */
 
-#include "pybind11/operators.h"
-
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"

--- a/bindings/pydrake/geometry/optimization_pybind.h
+++ b/bindings/pydrake/geometry/optimization_pybind.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <utility>
 #include <vector>
-
-#include "pybind11/stl.h"
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/geometry/optimization/convex_set.h"

--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -1,9 +1,5 @@
 #include <cstring>
 
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/manipulation/manipulation_py_util.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_util.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/math_operators_pybind.h
+++ b/bindings/pydrake/math_operators_pybind.h
@@ -4,9 +4,6 @@
 #include <cmath>
 #include <type_traits>
 
-#include "pybind11/eigen.h"
-#include "pybind11/numpy.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/drake_bool.h"
 

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -1,10 +1,5 @@
 #include <cmath>
 
-#include "pybind11/eigen.h"
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"

--- a/bindings/pydrake/multibody/benchmarks_py.cc
+++ b/bindings/pydrake/multibody/benchmarks_py.cc
@@ -1,5 +1,4 @@
 #include "pybind11/eval.h"
-#include "pybind11/pybind11.h"
 
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/multibody/fem_py.cc
+++ b/bindings/pydrake/multibody/fem_py.cc
@@ -1,6 +1,3 @@
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -1,8 +1,5 @@
 #include "drake/bindings/pydrake/multibody/inverse_kinematics_py.h"
 
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/sorted_pair_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/inverse_kinematics/differential_inverse_kinematics.h"

--- a/bindings/pydrake/multibody/math_py.cc
+++ b/bindings/pydrake/multibody/math_py.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"

--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -1,6 +1,3 @@
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/monostate_pybind.h"

--- a/bindings/pydrake/multibody/optimization_py.cc
+++ b/bindings/pydrake/multibody/optimization_py.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/sorted_pair_pybind.h"

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -1,6 +1,3 @@
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"

--- a/bindings/pydrake/multibody/rational_py.cc
+++ b/bindings/pydrake/multibody/rational_py.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/sorted_pair_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1,8 +1,4 @@
-#include "pybind11/eigen.h"
 #include "pybind11/eval.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"

--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -1,8 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
@@ -1,8 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/planning/planning_py_robot_diagram.cc
+++ b/bindings/pydrake/planning/planning_py_robot_diagram.cc
@@ -1,5 +1,3 @@
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -1,8 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/geometry/optimization_pybind.h"

--- a/bindings/pydrake/polynomial_py.cc
+++ b/bindings/pydrake/polynomial_py.cc
@@ -1,8 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/polynomial_types_pybind.h"

--- a/bindings/pydrake/polynomial_types_pybind.h
+++ b/bindings/pydrake/polynomial_types_pybind.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/polynomial.h"
 

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -2,11 +2,20 @@
 
 #include <utility>
 
+// Here we include a lot of the pybind11 API, to ensure that all code in pydrake
+// sees the same definitions ("One Definition Rule") for template types intended
+// for specialization. Any pybind11 headers with `type_caster<>` specializations
+// must be included here (e.g., eigen.h, functional.h, numpy.h, stl.h) as well
+// as ADL headers (e.g., operators.h). Headers that are unused by pydrake
+// (e.g., complex.h) are omitted, as are headers that do not specialize anything
+// (e.g., eval.h).
+#include "pybind11/eigen.h"
+#include "pybind11/functional.h"
+#include "pybind11/numpy.h"
+#include "pybind11/operators.h"
 #include "pybind11/pybind11.h"
-
-// N.B. Avoid including other headers, such as `pybind11/eigen.sh` or
-// `pybind11/functional.sh`, such that modules can opt-in to (and pay the cost
-// for) these binding capabilities.
+#include "pybind11/stl.h"
+#include "pybind11/stl/filesystem.h"
 
 namespace drake {
 

--- a/bindings/pydrake/solvers/solvers_py_augmented_lagrangian.cc
+++ b/bindings/pydrake/solvers/solvers_py_augmented_lagrangian.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_branch_and_bound.cc
+++ b/bindings/pydrake/solvers/solvers_py_branch_and_bound.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_clp.cc
+++ b/bindings/pydrake/solvers/solvers_py_clp.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_csdp.cc
+++ b/bindings/pydrake/solvers/solvers_py_csdp.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_gurobi.cc
+++ b/bindings/pydrake/solvers/solvers_py_gurobi.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_ipopt.cc
+++ b/bindings/pydrake/solvers/solvers_py_ipopt.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1,12 +1,6 @@
 #include <cstddef>
 #include <memory>
 
-#include "pybind11/eigen.h"
-#include "pybind11/functional.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_mixed_integer_optimization_util.cc
+++ b/bindings/pydrake/solvers/solvers_py_mixed_integer_optimization_util.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_py.h"

--- a/bindings/pydrake/solvers/solvers_py_mixed_integer_rotation_constraint.cc
+++ b/bindings/pydrake/solvers/solvers_py_mixed_integer_rotation_constraint.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_py.h"

--- a/bindings/pydrake/solvers/solvers_py_mobylcp.cc
+++ b/bindings/pydrake/solvers/solvers_py_mobylcp.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_mosek.cc
+++ b/bindings/pydrake/solvers/solvers_py_mosek.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_nlopt.cc
+++ b/bindings/pydrake/solvers/solvers_py_nlopt.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_osqp.cc
+++ b/bindings/pydrake/solvers/solvers_py_osqp.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_scs.cc
+++ b/bindings/pydrake/solvers/solvers_py_scs.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_sdpa_free_format.cc
+++ b/bindings/pydrake/solvers/solvers_py_sdpa_free_format.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_py.h"

--- a/bindings/pydrake/solvers/solvers_py_snopt.cc
+++ b/bindings/pydrake/solvers/solvers_py_snopt.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_unrevised_lemke.cc
+++ b/bindings/pydrake/solvers/solvers_py_unrevised_lemke.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -1,10 +1,6 @@
 #include <map>
 #include <string>
 
-#include "pybind11/eigen.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
 #include <fmt/format.h>
 
 #include "drake/bindings/pydrake/common/eigen_pybind.h"

--- a/bindings/pydrake/symbolic_py_unapply.cc
+++ b/bindings/pydrake/symbolic_py_unapply.cc
@@ -1,6 +1,5 @@
 #include "drake/bindings/pydrake/symbolic_py_unapply.h"
 
-#include "pybind11/stl.h"
 #include <fmt/format.h>
 
 namespace drake {

--- a/bindings/pydrake/symbolic_py_unapply.h
+++ b/bindings/pydrake/symbolic_py_unapply.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 

--- a/bindings/pydrake/symbolic_types_pybind.h
+++ b/bindings/pydrake/symbolic_types_pybind.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "pybind11/eigen.h"
-#include "pybind11/numpy.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/symbolic/polynomial.h"

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -1,5 +1,3 @@
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -1,8 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -1,9 +1,5 @@
 #include "drake/bindings/pydrake/systems/framework_py_semantics.h"
 
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -1,10 +1,6 @@
 #include "drake/bindings/pydrake/systems/framework_py_systems.h"
 
-#include "pybind11/eigen.h"
 #include "pybind11/eval.h"
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -2,9 +2,6 @@
 
 #include <sstream>
 
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -1,7 +1,6 @@
 #include <cstring>
 
 #include "pybind11/eval.h"
-#include "pybind11/pybind11.h"
 
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -1,5 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
 #include <Eigen/Dense>
 
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -2,10 +2,6 @@
 #include <string>
 #include <vector>
 
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -1,7 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/functional.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/systems/analysis/simulator.h"

--- a/bindings/pydrake/test/autodiffutils_test_util_py.cc
+++ b/bindings/pydrake/test/autodiffutils_test_util_py.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/math/roll_pitch_yaw.h"

--- a/bindings/pydrake/test/odr_test_module_py.cc
+++ b/bindings/pydrake/test/odr_test_module_py.cc
@@ -1,5 +1,3 @@
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 

--- a/bindings/pydrake/test/pydrake_pybind_test.cc
+++ b/bindings/pydrake/test/pydrake_pybind_test.cc
@@ -8,9 +8,6 @@
 
 #include "pybind11/embed.h"
 #include "pybind11/eval.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
 #include <gtest/gtest.h>
 
 #include "drake/bindings/pydrake/test/test_util_pybind.h"

--- a/bindings/pydrake/test/test_util_pybind.h
+++ b/bindings/pydrake/test/test_util_pybind.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 
 namespace drake {

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -1,9 +1,4 @@
-#include "pybind11/eigen.h"
 #include "pybind11/eval.h"
-#include "pybind11/numpy.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/visualization/visualization_py_config.cc
+++ b/bindings/pydrake/visualization/visualization_py_config.cc
@@ -1,6 +1,3 @@
-#include "pybind11/eigen.h"
-#include "pybind11/pybind11.h"
-
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"


### PR DESCRIPTION
For convenience and easier ODR-safety, consolidate the common pybind11 includes (especially the includes that specialize trait structs) into our central `pydrake_pybind.h` header. This avoids hazards where some modules forget to include the proper headers and experience compile-time or runtime failures as a result.

Towards #19250.

Tested locally for possible performance regressions (see below).

---

Checking for performance regression of a full rebuild:

Build time on **master**:
* `git checkout master`
* `bazel build //bindings/...`
* patch `pybind11/package.BUILD.bazel` to force a bindings rebuild [1]
* `time bazel build //bindings/...`

Result:
```
INFO: Elapsed time: 170.486s, Critical Path: 135.65s
INFO: 99 processes: 1 internal, 98 linux-sandbox.
```

Build time on **pull request**:
* `git checkout pydrake-canonical-includes`
* `bazel build //bindings/...`
* patch `pybind11/package.BUILD.bazel` to force a bindings rebuild [1]
* `time bazel build //bindings/...`

Result:
```
INFO: Elapsed time: 151.502s, Critical Path: 150.37s
INFO: 99 processes: 1 internal, 98 linux-sandbox.
```

I believe the critical path changes are just the luck of when `multibody_tree_py.cc` starts compiling.

[1] the patch:
```patch
--- a/tools/workspace/pybind11/package.BUILD.bazel
+++ b/tools/workspace/pybind11/package.BUILD.bazel
@@ -43,6 +43,7 @@ cc_library(
         "include/pybind11/stl_bind.h",
     ],
     includes = ["include"],
+    defines = ["TRIGGER_REBUILD=YES_PLEASE_master"],
     deps = [
         "@eigen",
         "@python",
```

---

Checking performance of a single-file incremental rebuild:

Neither of these two targets show any performance slow-down of a rebuild with the extra included headers:

```
bazel build //bindings/pydrake/common:schema_py
bazel build //bindings/pydrake/common:eigen_geometry_py
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19571)
<!-- Reviewable:end -->
