### PR TITLE
[pydrake] Factor out DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE helper

### DIFF
--- a/bindings/pydrake/autodiff_types_pybind.h
+++ b/bindings/pydrake/autodiff_types_pybind.h
@@ -3,9 +3,8 @@
 #include "pybind11/eigen.h"
 #include "pybind11/numpy.h"
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/autodiff.h"
 
-// The macro `PYBIND11_NUMPY_OBJECT_DTYPE` place symbols into the namespace
-// `pybind11::detail`, so we should not place these in `drake::pydrake`.
-
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::AutoDiffXd);
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::AutoDiffXd)

--- a/bindings/pydrake/polynomial_types_pybind.h
+++ b/bindings/pydrake/polynomial_types_pybind.h
@@ -6,9 +6,9 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/polynomial.h"
 
-// The macro `PYBIND11_NUMPY_OBJECT_DTYPE` places symbols into the namespace
-// `pybind11::detail`, so we should not place these in `drake::pydrake`.
-
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::Polynomial<double>);
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::Polynomial<drake::AutoDiffXd>);
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::Polynomial<drake::symbolic::Expression>);
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::Polynomial<double>)
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::Polynomial<drake::AutoDiffXd>)
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::Polynomial<drake::symbolic::Expression>)

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -158,3 +158,6 @@ inline void ExecuteExtraPythonCode(py::module m, bool use_subdir = false) {
 
 }  // namespace pydrake
 }  // namespace drake
+
+#define DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(Type) \
+  PYBIND11_NUMPY_OBJECT_DTYPE(Type)

--- a/bindings/pydrake/symbolic_types_pybind.h
+++ b/bindings/pydrake/symbolic_types_pybind.h
@@ -3,19 +3,23 @@
 #include "pybind11/eigen.h"
 #include "pybind11/numpy.h"
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/symbolic/polynomial.h"
 #include "drake/common/symbolic/rational_function.h"
 
-// The macro `PYBIND11_NUMPY_OBJECT_DTYPE` place symbols into the namespace
-// `pybind11::detail`, so we should not place these in `drake::pydrake`.
-
-// Whenever we want to cast any array / matrix type of `T` in C++
-// (e.g. `Eigen::MatrixX<T>`) to a NumPy array, we should have it in the
-// following list.
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Expression);
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Formula);
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Monomial);
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Polynomial);
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::RationalFunction);
-PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Variable);
+// Whenever we want to cast any array / matrix type of `T` in C++ (e.g.,
+// `Eigen::MatrixX<T>`) to a NumPy array, we should have it in the following
+// list.
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::symbolic::Expression)
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::symbolic::Formula)
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::symbolic::Monomial)
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::symbolic::Polynomial)
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::symbolic::RationalFunction)
+DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
+    drake::symbolic::Variable)


### PR DESCRIPTION
This provides a single point of control for our custom dtypes, in preparation for dropping our forked version of pybind11.

Towards #19250.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19572)
<!-- Reviewable:end -->
