### PR TITLE
Revise documentation for PathParameterizedTrajectory

### DIFF
--- a/common/trajectories/path_parameterized_trajectory.h
+++ b/common/trajectories/path_parameterized_trajectory.h
@@ -15,8 +15,8 @@ namespace trajectories {
 /**
  * A trajectory defined by a path and timing trajectory.
  *
- * Using a path of form `q(s)` and a time_scaling of the form `s(t)`, a full
- * trajectory of form `q(t) = q(s(t))` is modeled.
+ * Using a path of form `r(s)` and a time_scaling of the form `s(t)`, a full
+ * trajectory of form `q(t) = r(s(t))` is modeled.
  *
  * @tparam_default_scalar
  */


### PR DESCRIPTION
The notation was a bit imprecise before. `q()` has the domain [t_0, t_f]. We need a different symbol for the path function, which has the domain [s_0, s_f].

This change makes the notation consistent with my notes: https://manipulation.csail.mit.edu/trajectories.html#topp .

+@xuchenhan-tri for both reviews, please.
cc @mpetersen94 