### PR TITLE
SpatialInertia::MakeFromCentralInertia() immediately checks physical validity

### DIFF
--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -590,17 +590,16 @@ class RotationalInertia {
   ///         calculated (eigenvalue solver) or if scalar type T cannot be
   ///         converted to a double.
   boolean<T> CouldBePhysicallyValid() const {
-    // To check the validity of rotational inertia use an epsilon value that is
-    // a number related to machine precision multiplied by the largest possible
-    // element that can appear in a valid `this` rotational inertia.  Note: The
+    // To check the validity of `this` rotational inertia, use an epsilon value
+    // related to machine precision multiplied by the largest possible element
+    // that can appear in a valid `this` rotational inertia.  Note: The
     // largest product of inertia is at most half the largest moment of inertia.
     using std::max;
-    const double precision = 10 * std::numeric_limits<double>::epsilon();
+    const double precision = 16 * std::numeric_limits<double>::epsilon();
     const T max_possible_inertia_moment = CalcMaximumPossibleMomentOfInertia();
 
-    // In order to avoid false negatives for inertias close to zero we use, in
-    // addition to a relative tolerance of "precision", an absolute tolerance
-    // equal to "precision" as well.
+    // To avoid false negatives for inertias close to zero we use, we also use
+    // an absolute tolerance equal to "1.0 * precision".
     const T epsilon = precision * max(1.0, max_possible_inertia_moment);
 
     // Calculate principal moments of inertia p and then test these principal

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -598,7 +598,7 @@ class RotationalInertia {
     const double precision = 16 * std::numeric_limits<double>::epsilon();
     const T max_possible_inertia_moment = CalcMaximumPossibleMomentOfInertia();
 
-    // To avoid false negatives for inertias close to zero we use, we also use
+    // To avoid false negatives for inertias close to zero, we also use
     // an absolute tolerance equal to "1.0 * precision".
     const T epsilon = precision * max(1.0, max_possible_inertia_moment);
 

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -14,16 +14,21 @@ const boolean<T> is_positive_finite(const T& value) {
   using std::isfinite;
   return isfinite(value) && value > 0;
 }
+
+template <typename T>
+const boolean<T> is_nonnegative_finite(const T& value) {
+  using std::isfinite;
+  return isfinite(value) && value >= 0;
+}
 }  // namespace
 
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::MakeFromCentralInertia(const T& mass,
     const Vector3<T>& p_PScm_E, const RotationalInertia<T>& I_SScm_E) {
-  const RotationalInertia<T> I_SP_E =
-      I_SScm_E.ShiftFromCenterOfMass(mass, p_PScm_E);
-  UnitInertia<T> G_SP_E;
-  G_SP_E.SetFromRotationalInertia(I_SP_E, mass);
-  return SpatialInertia(mass, p_PScm_E, G_SP_E);
+  UnitInertia<T> G_SScm_E;
+  G_SScm_E.SetFromRotationalInertia(I_SScm_E, mass);
+  const SpatialInertia<T> M_SScm_E(mass, Vector3<T>::Zero(), G_SScm_E);
+  return M_SScm_E.Shift(-p_PScm_E);  // Shift from Scm to point P.
 }
 
 template <typename T>
@@ -437,7 +442,7 @@ template <typename T>
 boolean<T> SpatialInertia<T>::IsPhysicallyValid() const {
   // This spatial inertia is not physically valid if the mass is NaN or if the
   // center of mass or unit inertia matrix have NaN elements.
-  boolean<T> ret_value = !IsNaN() && mass_ >= T(0);
+  boolean<T> ret_value = is_nonnegative_finite(mass_);
   if (ret_value) {
     // Form a rotational inertia about the body's center of mass and then use
     // the well-documented tests in RotationalInertia to test validity.
@@ -454,9 +459,9 @@ void SpatialInertia<T>::ThrowNotPhysicallyValid() const {
   std::string error_message = fmt::format(
           "Spatial inertia fails SpatialInertia::IsPhysicallyValid().");
   const T& mass = get_mass();
-  if (!is_positive_finite(mass)) {
+  if (!is_nonnegative_finite(mass)) {
       error_message += fmt::format(
-          "\nmass = {} is not positive and finite.\n", mass);
+          "\nmass = {} is negative or not finite.\n", mass);
   } else {
     error_message += fmt::format("{}", *this);
     WriteExtraCentralInertiaProperties(&error_message);

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -459,9 +459,9 @@ void SpatialInertia<T>::ThrowNotPhysicallyValid() const {
   std::string error_message = fmt::format(
           "Spatial inertia fails SpatialInertia::IsPhysicallyValid().");
   const T& mass = get_mass();
-  if (!is_nonnegative_finite(mass)) {
+  if (!is_positive_finite(mass)) {
       error_message += fmt::format(
-          "\nmass = {} is negative or not finite.\n", mass);
+          "\nmass = {} is not positive and finite.\n", mass);
   } else {
     error_message += fmt::format("{}", *this);
     WriteExtraCentralInertiaProperties(&error_message);

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -440,8 +440,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutVertexWithDensity(
 
 template <typename T>
 boolean<T> SpatialInertia<T>::IsPhysicallyValid() const {
-  // This spatial inertia is not physically valid if the mass is NaN or if the
-  // center of mass or unit inertia matrix have NaN elements.
+  // This spatial inertia is not physically valid if the mass is negative or
+  // non-finite or the center of mass or unit inertia matrix have NaN elements.
   boolean<T> ret_value = is_nonnegative_finite(mass_);
   if (ret_value) {
     // Form a rotational inertia about the body's center of mass and then use

--- a/multibody/tree/unit_inertia.h
+++ b/multibody/tree/unit_inertia.h
@@ -133,8 +133,8 @@ class UnitInertia : public RotationalInertia<T> {
   ///                     inertia is expressed.
   /// @returns A reference to `this` unit inertia, which has now been taken
   ///          about point Q so can be written as `G_BQ_E`.
-  UnitInertia<T>& ShiftFromCenterOfMassInPlace(const Vector3<T>& p_BcQ_E) {
-    RotationalInertia<T>::operator+=(PointMass(p_BcQ_E));
+  UnitInertia<T>& ShiftFromCenterOfMassInPlace(const Vector3<T>& p_BcmQ_E) {
+    RotationalInertia<T>::operator+=(PointMass(p_BcmQ_E));
     return *this;
   }
 
@@ -146,8 +146,8 @@ class UnitInertia : public RotationalInertia<T> {
   /// @retval G_BQ_E This same unit inertia taken about a point Q instead of
   ///                the centroid `Bcm`.
   UnitInertia<T> ShiftFromCenterOfMass(
-      const Vector3<T>& p_BcQ_E) const __attribute__((warn_unused_result)) {
-    return UnitInertia<T>(*this).ShiftFromCenterOfMassInPlace(p_BcQ_E);
+      const Vector3<T>& p_BcmQ_E) const __attribute__((warn_unused_result)) {
+    return UnitInertia<T>(*this).ShiftFromCenterOfMassInPlace(p_BcmQ_E);
   }
 
   /// For the unit inertia `G_BQ_E` of a body or composite body B computed about

--- a/visualization/test/inertia_visualizer_test.cc
+++ b/visualization/test/inertia_visualizer_test.cc
@@ -275,12 +275,6 @@ TEST_P(InertiaVisualizerGeometryTest, BoxTest) {
 // TODO(trowell-tri) Add rotation to the test when supported.
 TEST_P(InertiaVisualizerGeometryTest, ThinRodTest) {
   const Vector3d pose = GetParam().transpose();
-  // TODO(jwnimmer-tri) Our SDFormat parser erroneously rejects rods that are
-  // posed too far away.  We need to skip those test cases for now.
-  if (pose.maxCoeff() > 5) {
-    drake::log()->info("Skipping test case due to SDFormat parser bug");
-    return;
-  }
   constexpr double length = 5.0;
   const auto M =
       SpatialInertia<double>::ThinRodWithMass(10, length, Vector3d(0, 0, 1));


### PR DESCRIPTION
Closes #19544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19581)
<!-- Reviewable:end -->
