### PR TITLE
[math] Add soft min and max function

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -31,6 +31,7 @@ drake_cc_package_library(
         ":linear_solve",
         ":matrix_util",
         ":quadratic_form",
+        ":soft_min_max",
         ":vector3_util",
         ":wrap_to",
     ],
@@ -261,6 +262,17 @@ drake_cc_library(
         ":matrix_util",
         "//common:essential",
         "@eigen",
+    ],
+)
+
+drake_cc_library(
+    name = "soft_min_max",
+    srcs = ["soft_min_max.cc"],
+    hdrs = ["soft_min_max.h"],
+    deps = [
+        "//common:autodiff",
+        "//common:default_scalars",
+        "//common:essential",
     ],
 )
 
@@ -551,6 +563,15 @@ drake_cc_googletest(
         ":autodiff",
         ":geometric_transform",
         "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "soft_min_max_test",
+    deps = [
+        ":soft_min_max",
+        "//common/test_utilities:eigen_matrix_compare",
+        "@eigen",
     ],
 )
 

--- a/math/soft_min_max.cc
+++ b/math/soft_min_max.cc
@@ -1,108 +1,88 @@
 #include "drake/math/soft_min_max.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include "drake/common/default_scalars.h"
+#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace math {
 namespace {
-/** Computes log(∑exp(xᵢ)). Exploits the shift invariance of log-sum-exp to
-avoid overflow. */
+using std::exp;
+using std::isfinite;
+using std::log;
+
+/* We use tare_x to exploit the shift invariance of log-sum-exp to avoid
+overflow. It should be set to the extremum of x (i.e., max when alpha > 0,
+min when alpha < 0). */
 template <typename T>
-T LogSumExp(const std::vector<T>& x) {
-  DRAKE_ASSERT(x.size() > 0);
-  using std::exp;
-  using std::log;
-  const T x_max = *std::max_element(x.begin(), x.end());
-  T sum_exp{0.0};
+T SoftOverMaxImpl(const std::vector<T>& x, double tare_x, double alpha) {
+  T sum_exp{0};
   for (const T& xi : x) {
-    sum_exp += exp(xi - x_max);
+    sum_exp += exp(alpha * (xi - tare_x));
   }
-  return x_max + log(sum_exp);
+  return log(sum_exp) / alpha + tare_x;
+}
+
+/* We use tare_x to avoid overflow. It should be set to the extremum of x
+(i.e., max when alpha > 0, min when alpha < 0). */
+template <typename T>
+T SoftUnderMaxImpl(const std::vector<T>& x, double tare_x, double alpha) {
+  T soft_max{0};
+  T sum_exp{0};
+  for (const T& xi : x) {
+    T exp_xi = exp(alpha * (xi - tare_x));
+    sum_exp += exp_xi;
+    exp_xi *= xi;
+    soft_max += exp_xi;
+  }
+  return soft_max / sum_exp;
 }
 }  // namespace
 
-/**
- Computes a smooth over approximation of max function, namely SoftOverMax(x) >=
- max(x).
- Mathematically we compute this as (log (∑ᵢ exp(αxᵢ))) / α.
- @param x The vector we want to compute its soft max.
- @param alpha α in the documentation above. Larger α makes the soft max more
- similar to max, with a sharper corner.
- @throws std::exception if α <= 0.
- */
 template <typename T>
-[[nodiscard]] T SoftOverMax(const std::vector<T>& x, double alpha) {
-  DRAKE_ASSERT(x.size() > 0);
+T SoftOverMax(const std::vector<T>& x, double alpha) {
+  DRAKE_THROW_UNLESS(x.size() > 0);
   DRAKE_THROW_UNLESS(alpha > 0);
-  if (alpha == 1.0) {
-    return LogSumExp(x);
-  }
-  std::vector<T> x_scaled{x};
-  for (T& xi_scaled : x_scaled) {
-    xi_scaled *= alpha;
-  }
-  return LogSumExp(x_scaled) / alpha;
+  DRAKE_THROW_UNLESS(std::isfinite(alpha));
+  const double max_x =
+      ExtractDoubleOrThrow(*std::max_element(x.begin(), x.end()));
+  return SoftOverMaxImpl(x, max_x, alpha);
 }
 
-/**
- Computes a smooth under approximation of max function, namely SoftUnderMax(x)
- <= max(x). Mathematically we compute this as ∑ᵢ exp(αxᵢ)*xᵢ) / d, where d = ∑ⱼ
- exp(αxⱼ)
- @param x The vector we want to compute its soft max.
- @param alpha α in the documentation above. Larger α makes the soft max more
- similar to max, with a sharper corner.
- @throws std::exception if α <= 0.
- */
 template <typename T>
-[[nodiscard]] T SoftUnderMax(const std::vector<T>& x, double alpha) {
-  DRAKE_ASSERT(x.size() > 0);
+T SoftUnderMax(const std::vector<T>& x, double alpha) {
+  DRAKE_THROW_UNLESS(x.size() > 0);
   DRAKE_THROW_UNLESS(alpha > 0);
-  std::vector<T> x_scaled{x};
-  for (auto& xi_scaled : x_scaled) {
-    xi_scaled *= alpha;
-  }
-  // To avoid overflow, we subtract x_scaled_max.
-  const T x_scaled_max = *std::max_element(x_scaled.begin(), x_scaled.end());
-  T soft_max{0};
-  T d{0};
-  for (int i = 0; i < static_cast<int>(x.size()); ++i) {
-    using std::exp;
-    const T exp_xi = exp(x_scaled[i] - x_scaled_max);
-    soft_max += exp_xi * x[i];
-    d += exp_xi;
-  }
-  return soft_max / d;
-}
-
-/**
- Computes a smooth over approximation of max function, namely SoftOverMin(x) >=
- min(x).
- Mathematically we compute this as ∑ᵢ exp(-αxᵢ)*xᵢ) / d, where d = ∑ⱼ
- exp(-αxⱼ)
- @param x The vector we want to compute its soft min.
- @param alpha α in the documentation above. Larger α makes the soft min more
- similar to min, with a sharper corner.
- @throws std::exception if α <= 0.
- */
-template <typename T>
-[[nodiscard]] T SoftOverMin(const std::vector<T>& x, double alpha) {
-  // min(x) = -max(-x)
-  std::vector<T> x_negate{x};
-  for (auto& xi : x_negate) {
-    xi *= -1;
-  }
-  return -SoftUnderMax(x_negate, alpha);
+  DRAKE_THROW_UNLESS(std::isfinite(alpha));
+  const double max_x =
+      ExtractDoubleOrThrow(*std::max_element(x.begin(), x.end()));
+  return SoftUnderMaxImpl(x, max_x, alpha);
 }
 
 template <typename T>
-[[nodiscard]] T SoftUnderMin(const std::vector<T>& x, double alpha) {
+T SoftOverMin(const std::vector<T>& x, double alpha) {
+  DRAKE_THROW_UNLESS(x.size() > 0);
+  DRAKE_THROW_UNLESS(alpha > 0);
+  DRAKE_THROW_UNLESS(std::isfinite(alpha));
   // min(x) = -max(-x)
-  std::vector<T> x_negate{x};
-  for (auto& xi : x_negate) {
-    xi *= -1;
-  }
-  return -SoftOverMax(x_negate, alpha);
+  const double min_x =
+      ExtractDoubleOrThrow(*std::min_element(x.begin(), x.end()));
+  return SoftUnderMaxImpl(x, min_x, -alpha);
 }
+
+template <typename T>
+T SoftUnderMin(const std::vector<T>& x, double alpha) {
+  DRAKE_THROW_UNLESS(x.size() > 0);
+  DRAKE_THROW_UNLESS(alpha > 0);
+  DRAKE_THROW_UNLESS(std::isfinite(alpha));
+  // min(x) = -max(-x)
+  const double min_x =
+      ExtractDoubleOrThrow(*std::min_element(x.begin(), x.end()));
+  return SoftOverMaxImpl(x, min_x, -alpha);
+}
+
 // Explicit instantiation
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     (&SoftOverMax<T>, &SoftUnderMax<T>, &SoftOverMin<T>, &SoftUnderMin<T>))

--- a/math/soft_min_max.cc
+++ b/math/soft_min_max.cc
@@ -1,0 +1,110 @@
+#include "drake/math/soft_min_max.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace math {
+namespace {
+/** Computes log(∑exp(xᵢ)). Exploits the shift invariance of log-sum-exp to
+avoid overflow. */
+template <typename T>
+T LogSumExp(const std::vector<T>& x) {
+  DRAKE_ASSERT(x.size() > 0);
+  using std::exp;
+  using std::log;
+  const T x_max = *std::max_element(x.begin(), x.end());
+  T sum_exp{0.0};
+  for (const T& xi : x) {
+    sum_exp += exp(xi - x_max);
+  }
+  return x_max + log(sum_exp);
+}
+}  // namespace
+
+/**
+ Computes a smooth over approximation of max function, namely SoftOverMax(x) >=
+ max(x).
+ Mathematically we compute this as (log (∑ᵢ exp(αxᵢ))) / α.
+ @param x The vector we want to compute its soft max.
+ @param alpha α in the documentation above. Larger α makes the soft max more
+ similar to max, with a sharper corner.
+ @throws std::exception if α <= 0.
+ */
+template <typename T>
+[[nodiscard]] T SoftOverMax(const std::vector<T>& x, double alpha) {
+  DRAKE_ASSERT(x.size() > 0);
+  DRAKE_THROW_UNLESS(alpha > 0);
+  if (alpha == 1.0) {
+    return LogSumExp(x);
+  }
+  std::vector<T> x_scaled{x};
+  for (T& xi_scaled : x_scaled) {
+    xi_scaled *= alpha;
+  }
+  return LogSumExp(x_scaled) / alpha;
+}
+
+/**
+ Computes a smooth under approximation of max function, namely SoftUnderMax(x)
+ <= max(x). Mathematically we compute this as ∑ᵢ exp(αxᵢ)*xᵢ) / d, where d = ∑ⱼ
+ exp(αxⱼ)
+ @param x The vector we want to compute its soft max.
+ @param alpha α in the documentation above. Larger α makes the soft max more
+ similar to max, with a sharper corner.
+ @throws std::exception if α <= 0.
+ */
+template <typename T>
+[[nodiscard]] T SoftUnderMax(const std::vector<T>& x, double alpha) {
+  DRAKE_ASSERT(x.size() > 0);
+  DRAKE_THROW_UNLESS(alpha > 0);
+  std::vector<T> x_scaled{x};
+  for (auto& xi_scaled : x_scaled) {
+    xi_scaled *= alpha;
+  }
+  // To avoid overflow, we subtract x_scaled_max.
+  const T x_scaled_max = *std::max_element(x_scaled.begin(), x_scaled.end());
+  T soft_max{0};
+  T d{0};
+  for (int i = 0; i < static_cast<int>(x.size()); ++i) {
+    using std::exp;
+    const T exp_xi = exp(x_scaled[i] - x_scaled_max);
+    soft_max += exp_xi * x[i];
+    d += exp_xi;
+  }
+  return soft_max / d;
+}
+
+/**
+ Computes a smooth over approximation of max function, namely SoftOverMin(x) >=
+ min(x).
+ Mathematically we compute this as ∑ᵢ exp(-αxᵢ)*xᵢ) / d, where d = ∑ⱼ
+ exp(-αxⱼ)
+ @param x The vector we want to compute its soft min.
+ @param alpha α in the documentation above. Larger α makes the soft min more
+ similar to min, with a sharper corner.
+ @throws std::exception if α <= 0.
+ */
+template <typename T>
+[[nodiscard]] T SoftOverMin(const std::vector<T>& x, double alpha) {
+  // min(x) = -max(-x)
+  std::vector<T> x_negate{x};
+  for (auto& xi : x_negate) {
+    xi *= -1;
+  }
+  return -SoftUnderMax(x_negate, alpha);
+}
+
+template <typename T>
+[[nodiscard]] T SoftUnderMin(const std::vector<T>& x, double alpha) {
+  // min(x) = -max(-x)
+  std::vector<T> x_negate{x};
+  for (auto& xi : x_negate) {
+    xi *= -1;
+  }
+  return -SoftOverMax(x_negate, alpha);
+}
+// Explicit instantiation
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&SoftOverMax<T>, &SoftUnderMax<T>, &SoftOverMin<T>, &SoftUnderMin<T>))
+}  // namespace math
+}  // namespace drake

--- a/math/soft_min_max.cc
+++ b/math/soft_min_max.cc
@@ -14,35 +14,41 @@ using std::isfinite;
 using std::log;
 
 /* We use tare_x to exploit the shift invariance of log-sum-exp to avoid
-overflow. It should be set to the extremum of x (i.e., max when alpha > 0,
-min when alpha < 0). */
+overflow. It should be set to the extremum of x (i.e., max when alpha_prime > 0,
+min when alpha_prime < 0). */
 template <typename T>
-T SoftOverMaxImpl(const std::vector<T>& x, double tare_x, double alpha) {
+T SoftOverMaxImpl(const std::vector<T>& x, double tare_x, double alpha_prime) {
+  // Note that the function
+  // f(x) = log(∑ᵢ exp(αxᵢ)) /α satisfies f(x) = f(x - m) + m for any arbitrary
+  // m. Here we use m = tare_x.
   T sum_exp{0};
   for (const T& xi : x) {
-    sum_exp += exp(alpha * (xi - tare_x));
+    sum_exp += exp(alpha_prime * (xi - tare_x));
   }
-  return log(sum_exp) / alpha + tare_x;
+  return log(sum_exp) / alpha_prime + tare_x;
 }
 
 /* We use tare_x to avoid overflow. It should be set to the extremum of x
-(i.e., max when alpha > 0, min when alpha < 0). */
+(i.e., max when alpha_prime > 0, min when alpha_prime < 0). */
 template <typename T>
-T SoftUnderMaxImpl(const std::vector<T>& x, double tare_x, double alpha) {
+T SoftUnderMaxImpl(const std::vector<T>& x, double tare_x, double alpha_prime) {
+  // Note that the function
+  // f(x) = ∑ᵢ exp(αxᵢ)*xᵢ / ∑ⱼ exp(αxⱼ) satisfies
+  // f(x) = ∑ᵢ exp(α(xᵢ-m))*xᵢ / ∑ⱼ exp(α(xⱼ-m)) for any arbitrary m, by
+  // multiplying exp(-αm) on both the numerator and denominator.
   T soft_max{0};
   T sum_exp{0};
   for (const T& xi : x) {
-    T exp_xi = exp(alpha * (xi - tare_x));
+    const T exp_xi = exp(alpha_prime * (xi - tare_x));
     sum_exp += exp_xi;
-    exp_xi *= xi;
-    soft_max += exp_xi;
+    soft_max += exp_xi * xi;
   }
   return soft_max / sum_exp;
 }
 }  // namespace
 
 template <typename T>
-T SoftOverMax(const std::vector<T>& x, double alpha) {
+T SoftOverMax(const std::vector<T>& x, const double alpha) {
   DRAKE_THROW_UNLESS(x.size() > 0);
   DRAKE_THROW_UNLESS(alpha > 0);
   DRAKE_THROW_UNLESS(std::isfinite(alpha));
@@ -52,7 +58,7 @@ T SoftOverMax(const std::vector<T>& x, double alpha) {
 }
 
 template <typename T>
-T SoftUnderMax(const std::vector<T>& x, double alpha) {
+T SoftUnderMax(const std::vector<T>& x, const double alpha) {
   DRAKE_THROW_UNLESS(x.size() > 0);
   DRAKE_THROW_UNLESS(alpha > 0);
   DRAKE_THROW_UNLESS(std::isfinite(alpha));
@@ -62,7 +68,7 @@ T SoftUnderMax(const std::vector<T>& x, double alpha) {
 }
 
 template <typename T>
-T SoftOverMin(const std::vector<T>& x, double alpha) {
+T SoftOverMin(const std::vector<T>& x, const double alpha) {
   DRAKE_THROW_UNLESS(x.size() > 0);
   DRAKE_THROW_UNLESS(alpha > 0);
   DRAKE_THROW_UNLESS(std::isfinite(alpha));
@@ -73,7 +79,7 @@ T SoftOverMin(const std::vector<T>& x, double alpha) {
 }
 
 template <typename T>
-T SoftUnderMin(const std::vector<T>& x, double alpha) {
+T SoftUnderMin(const std::vector<T>& x, const double alpha) {
   DRAKE_THROW_UNLESS(x.size() > 0);
   DRAKE_THROW_UNLESS(alpha > 0);
   DRAKE_THROW_UNLESS(std::isfinite(alpha));

--- a/math/soft_min_max.h
+++ b/math/soft_min_max.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#include <algorithm>
-#include <cmath>
 #include <vector>
-
-#include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace math {
@@ -17,34 +12,34 @@ namespace math {
  @param alpha α in the documentation above. Larger α makes the soft max more
  similar to max, with a sharper corner.
  @throws std::exception if α <= 0.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
 [[nodiscard]] T SoftOverMax(const std::vector<T>& x, double alpha = 1.0);
 
 /**
  Computes a smooth under approximation of max function, namely SoftUnderMax(x)
- <= max(x). Mathematically we compute this as ∑ᵢ exp(αxᵢ)*xᵢ) / d, where d = ∑ⱼ
+ <= max(x). Mathematically we compute this as ∑ᵢ exp(αxᵢ)*xᵢ / d, where d = ∑ⱼ
  exp(αxⱼ)
  @param x The vector we want to compute its soft max.
  @param alpha α in the documentation above. Larger α makes the soft max more
  similar to max, with a sharper corner.
  @throws std::exception if α <= 0.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
-[[nodiscard]] T SoftUnderMax(const std::vector<T>& x, double alpha = 1);
+[[nodiscard]] T SoftUnderMax(const std::vector<T>& x, double alpha = 1.0);
 
 /**
  Computes a smooth over approximation of min function, namely SoftOverMin(x) >=
  min(x).
- Mathematically we compute this as ∑ᵢ exp(-αxᵢ)*xᵢ) / d, where d = ∑ⱼ
+ Mathematically we compute this as ∑ᵢ exp(-αxᵢ)*xᵢ / d, where d = ∑ⱼ
  exp(-αxⱼ)
  @param x The vector we want to compute its soft min.
  @param alpha α in the documentation above. Larger α makes the soft min more
  similar to min, with a sharper corner.
  @throws std::exception if α <= 0.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
-[[nodiscard]] T SoftOverMin(const std::vector<T>& x, double alpha = 1);
+[[nodiscard]] T SoftOverMin(const std::vector<T>& x, double alpha = 1.0);
 
 /**
  Computes a smooth under approximation of max function, namely SoftUnderMin(x)
@@ -53,8 +48,8 @@ template <typename T>
  @param alpha α in the documentation above. Larger α makes the soft min more
  similar to min, with a sharper corner.
  @throws std::exception if α <= 0.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
-[[nodiscard]] T SoftUnderMin(const std::vector<T>& x, double alpha = 1);
+[[nodiscard]] T SoftUnderMin(const std::vector<T>& x, double alpha = 1.0);
 }  // namespace math
 }  // namespace drake

--- a/math/soft_min_max.h
+++ b/math/soft_min_max.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace math {
+/**
+ Computes a smooth over approximation of max function, namely SoftOverMax(x) >=
+ max(x).
+ Mathematically we compute this as (log (∑ᵢ exp(αxᵢ))) / α.
+ @param x The vector we want to compute its soft max.
+ @param alpha α in the documentation above. Larger α makes the soft max more
+ similar to max, with a sharper corner.
+ @throws std::exception if α <= 0.
+ */
+template <typename T>
+[[nodiscard]] T SoftOverMax(const std::vector<T>& x, double alpha = 1.0);
+
+/**
+ Computes a smooth under approximation of max function, namely SoftUnderMax(x)
+ <= max(x). Mathematically we compute this as ∑ᵢ exp(αxᵢ)*xᵢ) / d, where d = ∑ⱼ
+ exp(αxⱼ)
+ @param x The vector we want to compute its soft max.
+ @param alpha α in the documentation above. Larger α makes the soft max more
+ similar to max, with a sharper corner.
+ @throws std::exception if α <= 0.
+ */
+template <typename T>
+[[nodiscard]] T SoftUnderMax(const std::vector<T>& x, double alpha = 1);
+
+/**
+ Computes a smooth over approximation of min function, namely SoftOverMin(x) >=
+ min(x).
+ Mathematically we compute this as ∑ᵢ exp(-αxᵢ)*xᵢ) / d, where d = ∑ⱼ
+ exp(-αxⱼ)
+ @param x The vector we want to compute its soft min.
+ @param alpha α in the documentation above. Larger α makes the soft min more
+ similar to min, with a sharper corner.
+ @throws std::exception if α <= 0.
+ */
+template <typename T>
+[[nodiscard]] T SoftOverMin(const std::vector<T>& x, double alpha = 1);
+
+/**
+ Computes a smooth under approximation of max function, namely SoftUnderMin(x)
+ <= min(x). Mathematically we compute this as -(log (∑ᵢ exp(-αxᵢ))) / α
+ @param x The vector we want to compute its soft min.
+ @param alpha α in the documentation above. Larger α makes the soft min more
+ similar to min, with a sharper corner.
+ @throws std::exception if α <= 0.
+ */
+template <typename T>
+[[nodiscard]] T SoftUnderMin(const std::vector<T>& x, double alpha = 1);
+}  // namespace math
+}  // namespace drake

--- a/math/soft_min_max.h
+++ b/math/soft_min_max.h
@@ -8,10 +8,12 @@ namespace math {
  Computes a smooth over approximation of max function, namely SoftOverMax(x) >=
  max(x).
  Mathematically we compute this as (log (∑ᵢ exp(αxᵢ))) / α.
- @param x The vector we want to compute its soft max.
+ @param x The vector for which we want to compute its soft max.
  @param alpha α in the documentation above. Larger α makes the soft max more
- similar to max, with a sharper corner.
+ similar to max, with a sharper corner. Must be strictly positive and finite.
+ @default is 1.
  @throws std::exception if α <= 0.
+ @throws std::exception if α is non-finite.
  @tparam_nonsymbolic_scalar */
 template <typename T>
 [[nodiscard]] T SoftOverMax(const std::vector<T>& x, double alpha = 1.0);
@@ -20,10 +22,12 @@ template <typename T>
  Computes a smooth under approximation of max function, namely SoftUnderMax(x)
  <= max(x). Mathematically we compute this as ∑ᵢ exp(αxᵢ)*xᵢ / d, where d = ∑ⱼ
  exp(αxⱼ)
- @param x The vector we want to compute its soft max.
+ @param x The vector for which we want to compute its soft max.
  @param alpha α in the documentation above. Larger α makes the soft max more
- similar to max, with a sharper corner.
+ similar to max, with a sharper corner. Must be strictly positive and finite.
+ @default is 1.
  @throws std::exception if α <= 0.
+ @throws std::exception if α is non-finite.
  @tparam_nonsymbolic_scalar */
 template <typename T>
 [[nodiscard]] T SoftUnderMax(const std::vector<T>& x, double alpha = 1.0);
@@ -33,21 +37,25 @@ template <typename T>
  min(x).
  Mathematically we compute this as ∑ᵢ exp(-αxᵢ)*xᵢ / d, where d = ∑ⱼ
  exp(-αxⱼ)
- @param x The vector we want to compute its soft min.
+ @param x The vector for which we want to compute its soft min.
  @param alpha α in the documentation above. Larger α makes the soft min more
- similar to min, with a sharper corner.
+ similar to min, with a sharper corner. Must be strictly positive and finite.
+ @default is 1.
  @throws std::exception if α <= 0.
+ @throws std::exception if α is non-finite.
  @tparam_nonsymbolic_scalar */
 template <typename T>
 [[nodiscard]] T SoftOverMin(const std::vector<T>& x, double alpha = 1.0);
 
 /**
- Computes a smooth under approximation of max function, namely SoftUnderMin(x)
+ Computes a smooth under approximation of min function, namely SoftUnderMin(x)
  <= min(x). Mathematically we compute this as -(log (∑ᵢ exp(-αxᵢ))) / α
- @param x The vector we want to compute its soft min.
+ @param x The vector for which we want to compute its soft min.
  @param alpha α in the documentation above. Larger α makes the soft min more
- similar to min, with a sharper corner.
+ similar to min, with a sharper corner. Must be strictly positive and finite.
+ @default is 1.
  @throws std::exception if α <= 0.
+ @throws std::exception if α is non-finite.
  @tparam_nonsymbolic_scalar */
 template <typename T>
 [[nodiscard]] T SoftUnderMin(const std::vector<T>& x, double alpha = 1.0);

--- a/math/test/soft_min_max_test.cc
+++ b/math/test/soft_min_max_test.cc
@@ -8,7 +8,7 @@
 namespace drake {
 namespace math {
 GTEST_TEST(SoftOverMax, TestDouble) {
-  const std::vector<double> x{{1., 2., 3., 1.5, 2.9, 2.99}};
+  const std::vector<double> x{{1.0, 2.0, 3.0, 1.5, 2.9, 2.99}};
   double alpha = 1;
   const double x_max1 = SoftOverMax(x, alpha);
   EXPECT_GT(x_max1, 3);
@@ -35,7 +35,7 @@ GTEST_TEST(SoftOverMax, TestAutodiff) {
   EXPECT_GT(x_max.value(), 3);
   EXPECT_NEAR(x_max.value(), 3, 0.01);
   EXPECT_TRUE(
-      CompareMatrices(x_max.derivatives(), Eigen::Vector2d(0, -1), 1e-3));
+      CompareMatrices(x_max.derivatives(), Eigen::Vector2d(0, -1), 1E-3));
 }
 
 GTEST_TEST(SoftUnderMax, TestDouble) {
@@ -48,6 +48,7 @@ GTEST_TEST(SoftUnderMax, TestDouble) {
   const double x_max10 = SoftUnderMax(x, alpha);
   EXPECT_LT(x_max10, 3);
   EXPECT_LT(x_max1, x_max10);
+  EXPECT_NEAR(x_max10, 3, 0.1);
 
   alpha = 100;
   const double x_max100 = SoftUnderMax(x, alpha);
@@ -78,6 +79,7 @@ GTEST_TEST(SoftOverMin, TestDouble) {
   const double x_min10 = SoftOverMin(x, alpha);
   EXPECT_GT(x_min10, 1);
   EXPECT_LT(x_min10, x_min1);
+  EXPECT_NEAR(x_min10, 1, 0.1);
 
   alpha = 100;
   const double x_min100 = SoftOverMin(x, alpha);
@@ -108,6 +110,7 @@ GTEST_TEST(SoftUnderMin, TestDouble) {
   const double x_min10 = SoftUnderMin(x, alpha);
   EXPECT_LT(x_min10, 1);
   EXPECT_GT(x_min10, x_min1);
+  EXPECT_NEAR(x_min10, 1, 0.1);
 
   alpha = 100;
   const double x_min100 = SoftUnderMin(x, alpha);

--- a/math/test/soft_min_max_test.cc
+++ b/math/test/soft_min_max_test.cc
@@ -1,0 +1,131 @@
+#include "drake/math/soft_min_max.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace math {
+GTEST_TEST(SoftOverMax, TestDouble) {
+  const std::vector<double> x{{1., 2., 3., 1.5, 2.9, 2.99}};
+  double alpha = 1;
+  const double x_max1 = SoftOverMax(x, alpha);
+  EXPECT_GT(x_max1, 3);
+
+  alpha = 10;
+  const double x_max10 = SoftOverMax(x, alpha);
+  EXPECT_GT(x_max10, 3);
+  EXPECT_LT(x_max10, x_max1);
+  EXPECT_NEAR(x_max10, 3, 0.1);
+
+  alpha = 100;
+  const double x_max100 = SoftOverMax(x, alpha);
+  EXPECT_GT(x_max100, 3);
+  EXPECT_LT(x_max100, x_max10);
+  EXPECT_NEAR(x_max100, 3, 0.01);
+}
+
+GTEST_TEST(SoftOverMax, TestAutodiff) {
+  std::vector<AutoDiffXd> x;
+  x.emplace_back(1, Eigen::Vector2d(1, 3));
+  x.emplace_back(2, Eigen::Vector2d(0, 1));
+  x.emplace_back(3, Eigen::Vector2d(0, -1));
+  const AutoDiffXd x_max = SoftOverMax(x, 10);
+  EXPECT_GT(x_max.value(), 3);
+  EXPECT_NEAR(x_max.value(), 3, 0.01);
+  EXPECT_TRUE(
+      CompareMatrices(x_max.derivatives(), Eigen::Vector2d(0, -1), 1e-3));
+}
+
+GTEST_TEST(SoftUnderMax, TestDouble) {
+  const std::vector<double> x{{0, 1, 2, 3, 0.5, 2.5, 2.9}};
+  double alpha = 1;
+  const double x_max1 = SoftUnderMax(x, alpha);
+  EXPECT_LT(x_max1, 3);
+
+  alpha = 10;
+  const double x_max10 = SoftUnderMax(x, alpha);
+  EXPECT_LT(x_max10, 3);
+  EXPECT_LT(x_max1, x_max10);
+
+  alpha = 100;
+  const double x_max100 = SoftUnderMax(x, alpha);
+  EXPECT_LT(x_max100, 3);
+  EXPECT_LT(x_max10, x_max100);
+  EXPECT_NEAR(x_max100, 3, 1E-5);
+}
+
+GTEST_TEST(SoftUnderMax, TestAutoDiff) {
+  std::vector<AutoDiffXd> x;
+  x.emplace_back(0, Eigen::Vector2d(3, 4));
+  x.emplace_back(1, Eigen::Vector2d(1, 2));
+  x.emplace_back(2, Eigen::Vector2d(0, -1));
+  const AutoDiffXd x_max = SoftUnderMax(x, 10 /* alpha */);
+  EXPECT_LT(x_max.value(), 2);
+  EXPECT_NEAR(x_max.value(), 2, 1E-2);
+  EXPECT_TRUE(
+      CompareMatrices(x_max.derivatives(), Eigen::Vector2d(0, -1), 1E-2));
+}
+
+GTEST_TEST(SoftOverMin, TestDouble) {
+  const std::vector<double> x{{1, 1.2, 1.5, 2, 3, 4}};
+  double alpha = 1;
+  const double x_min1 = SoftOverMin(x, alpha);
+  EXPECT_GT(x_min1, 1);
+
+  alpha = 10;
+  const double x_min10 = SoftOverMin(x, alpha);
+  EXPECT_GT(x_min10, 1);
+  EXPECT_LT(x_min10, x_min1);
+
+  alpha = 100;
+  const double x_min100 = SoftOverMin(x, alpha);
+  EXPECT_GT(x_min100, 1);
+  EXPECT_LT(x_min100, x_min10);
+  EXPECT_NEAR(x_min100, 1, 1E-3);
+}
+
+GTEST_TEST(SoftOverMin, TestAutoDiff) {
+  std::vector<AutoDiffXd> x;
+  x.emplace_back(0, Eigen::Vector2d(3, 4));
+  x.emplace_back(1, Eigen::Vector2d(1, 2));
+  x.emplace_back(2, Eigen::Vector2d(0, -1));
+  const AutoDiffXd x_min = SoftOverMin(x, 10 /* alpha */);
+  EXPECT_GT(x_min.value(), 0);
+  EXPECT_NEAR(x_min.value(), 0, 1E-2);
+  EXPECT_TRUE(
+      CompareMatrices(x_min.derivatives(), Eigen::Vector2d(3, 4), 1E-2));
+}
+
+GTEST_TEST(SoftUnderMin, TestDouble) {
+  std::vector<double> x{{1, 1.2, 1.5, 2, 3, 4, 5}};
+  double alpha = 1;
+  const double x_min1 = SoftUnderMin(x, alpha);
+  EXPECT_LT(x_min1, 1);
+
+  alpha = 10;
+  const double x_min10 = SoftUnderMin(x, alpha);
+  EXPECT_LT(x_min10, 1);
+  EXPECT_GT(x_min10, x_min1);
+
+  alpha = 100;
+  const double x_min100 = SoftUnderMin(x, alpha);
+  EXPECT_LT(x_min100, 1);
+  EXPECT_GT(x_min100, x_min10);
+  EXPECT_NEAR(x_min100, 1, 1E-3);
+}
+
+GTEST_TEST(SoftUnderMin, TestAutoDiff) {
+  std::vector<AutoDiffXd> x;
+  x.emplace_back(0, Eigen::Vector2d(3, 4));
+  x.emplace_back(1, Eigen::Vector2d(1, 2));
+  x.emplace_back(2, Eigen::Vector2d(0, -1));
+  const AutoDiffXd x_min = SoftUnderMin(x, 10 /* alpha */);
+  EXPECT_LT(x_min.value(), 0);
+  EXPECT_NEAR(x_min.value(), 0, 1E-2);
+  EXPECT_TRUE(
+      CompareMatrices(x_min.derivatives(), Eigen::Vector2d(3, 4), 1E-2));
+}
+}  // namespace math
+}  // namespace drake

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -195,6 +195,7 @@ drake_cc_library(
     ],
     deps = [
         "//math:gradient",
+        "//math:soft_min_max",
     ],
 )
 


### PR DESCRIPTION
Support soft min or max being either the under or over approximation of min/max.

This will be used later when I impose the minimum distance constraint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19591)
<!-- Reviewable:end -->
