### PR TITLE
SAP contact constraint reports multibody forces

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -17,6 +17,7 @@ drake_cc_package_library(
         ":block_3x3_sparse_matrix",
         ":block_sparse_lower_triangular_or_symmetric_matrix",
         ":block_sparse_matrix",
+        ":contact_configuration",
         ":contact_solver",
         ":contact_solver_results",
         ":contact_solver_utils",
@@ -50,6 +51,16 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:essential",
         "//common:unused",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_configuration",
+    srcs = ["contact_configuration.cc"],
+    hdrs = ["contact_configuration.h"],
+    deps = [
+        "//common:essential",
+        "//math:geometric_transform",
     ],
 )
 

--- a/multibody/contact_solvers/contact_configuration.cc
+++ b/multibody/contact_solvers/contact_configuration.cc
@@ -1,0 +1,4 @@
+#include "drake/multibody/contact_solvers/contact_configuration.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    struct ::drake::multibody::contact_solvers::internal::ContactConfiguration)

--- a/multibody/contact_solvers/contact_configuration.h
+++ b/multibody/contact_solvers/contact_configuration.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "drake/common/eigen_types.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+// Struct used to store the contact configuration between two objects A and B.
+// The configuration is given by a contact point C, its position relative to
+// objects A and B, and the contact frame, also denoted with C, defined by its
+// orientation in the world frame W.
+template <typename T>
+struct ContactConfiguration {
+  // Index to a physical object A.
+  int objectA;
+
+  // Position of contact point C relative to a point P on A, expressed in the
+  // world frame W. Point P will usually be defined by convention and/or
+  // convenience. Typical choices might be the object's center of mass or its
+  // body frame, though other choices might exist.
+  Vector3<T> p_ApC_W;
+
+  // Index to a physical object B.
+  int objectB;
+
+  // Position of contact point C relative to a point Q on B, expressed in the
+  // world frame W. Point Q will usually be defined by convention and/or
+  // convenience. Typical choices might be the object's center of mass or its
+  // body frame, though other choices might exist.
+  Vector3<T> p_BqC_W;
+
+  // Signed distance. Positive if bodies do not overlap and negative otherwise.
+  T phi;
+
+  // Orientation of contact frame C in the world frame W.
+  // Rz_WC = R_WC.col(2) corresponds to the normal from object A into object B.
+  math::RotationMatrix<T> R_WC;
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -136,6 +136,7 @@ drake_cc_library(
         ":sap_constraint_jacobian",
         "//common:default_scalars",
         "//common:essential",
+        "//multibody/contact_solvers:contact_configuration",
     ],
 )
 

--- a/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
@@ -50,9 +50,19 @@ GTEST_TEST(SapAutoDiffTest, SolveWithGuess) {
       MatrixX<AutoDiffXd>::Ones(kNumConstraintEquations, kNumDofs));
   SapContactProblem<AutoDiffXd> contact_problem_with_constraint(
       std::move(contact_problem_without_constraint));
+  // Since a contact constraint is involved, there must be at least one object
+  // with a valid index, equal to zero.
+  contact_problem_with_constraint.set_num_objects(1);
+  // For this test, only the signed distance phi is relevant.
+  // Object indices must be valid, even though not used in these tests. Every
+  // other configuration will be left uninitialized.
+  ContactConfiguration<AutoDiffXd> configuration{
+      .objectA = 0 /* valid, though not used */,
+      .objectB = 0 /* valid, though not used */,
+      .phi = kPhi0};
   contact_problem_with_constraint.AddConstraint(
       std::make_unique<SapFrictionConeConstraint<AutoDiffXd>>(
-          std::move(J), kPhi0, parameters));
+          std::move(configuration), std::move(J), std::move(parameters)));
   DRAKE_EXPECT_THROWS_MESSAGE(
       sap.SolveWithGuess(contact_problem_with_constraint, v_guess, &result),
       ".*Only.*double is supported.*");

--- a/multibody/contact_solvers/sap/test/sap_solver_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_test.cc
@@ -181,21 +181,33 @@ class PizzaSaverProblem {
       double sigma) const {
     std::unique_ptr<SapContactProblem<double>> problem =
         MakeContactProblemWithoutConstraints(q0, v0, tau);
+    // Since contact constraints are involved, there must be at least one object
+    // with a valid index, equal to zero.
+    problem->set_num_objects(1);
 
     // Add contact constraints.
     const double phi0 = q0(2);
     const SapFrictionConeConstraint<double>::Parameters parameters{
         mu_, stiffness_, taud_, beta, 1.0e-3};
+
+    // For these tests, only the signed distance phi is relevant.
+    // Object indices must be valid, even though not used in these tests. Every
+    // other configuration will be left uninitialized.
+    const ContactConfiguration<double> configuration{
+        .objectA = 0 /* valid, though not used */,
+        .objectB = 0 /* valid, though not used */,
+        .phi = phi0};
+
     MatrixXd J;  // Full system Jacobian for the three contacts.
     CalcContactJacobian(q0(3), &J);
     problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<double>>(
-        SapConstraintJacobian<double>{0, J.middleRows(0, 3)}, phi0,
+        configuration, SapConstraintJacobian<double>{0, J.middleRows(0, 3)},
         parameters));
     problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<double>>(
-        SapConstraintJacobian<double>{0, J.middleRows(3, 3)}, phi0,
+        configuration, SapConstraintJacobian<double>{0, J.middleRows(3, 3)},
         parameters));
     problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<double>>(
-        SapConstraintJacobian<double>{0, J.middleRows(6, 3)}, phi0,
+        configuration, SapConstraintJacobian<double>{0, J.middleRows(6, 3)},
         parameters));
 
     return problem;

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -177,6 +177,7 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//math:geometric_transform",
+        "//multibody/contact_solvers:contact_configuration",
         "//multibody/contact_solvers:matrix_block",
         "//multibody/tree:multibody_tree_indexes",
     ],

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -20,9 +20,11 @@
 #include "drake/multibody/triangle_quadrature/gaussian_triangle_quadrature_rule.h"
 #include "drake/systems/framework/context.h"
 
+using drake::multibody::contact_solvers::internal::ContactConfiguration;
 using drake::geometry::ContactSurface;
 using drake::geometry::GeometryId;
 using drake::geometry::PenetrationAsPointPair;
+using drake::math::RigidTransform;
 using drake::math::RotationMatrix;
 using drake::multibody::contact_solvers::internal::ContactSolverResults;
 using drake::multibody::contact_solvers::internal::MatrixBlock;
@@ -197,6 +199,14 @@ CompliantContactManager<T>::CalcContactKinematics(
     const Vector3<T>& nhat_W = -point_pair.nhat_BA_W;
     const Vector3<T>& p_WC = point_pair.p_WC;
 
+    // Contact point position relative to each body.
+    const RigidTransform<T>& X_WA = plant().EvalBodyPoseInWorld(context, bodyA);
+    const Vector3<T>& p_WA = X_WA.translation();
+    const Vector3<T> p_AC_W = p_WC - p_WA;
+    const RigidTransform<T>& X_WB = plant().EvalBodyPoseInWorld(context, bodyB);
+    const Vector3<T>& p_WB = X_WB.translation();
+    const Vector3<T> p_BC_W = p_WC - p_WB;
+
     // Since v_AcBc_W = v_WBc - v_WAc the relative velocity Jacobian will be:
     //   J_AcBc_W = Jv_WBc_W - Jv_WAc_W.
     // That is the relative velocity at C is v_AcBc_W = J_AcBc_W * v.
@@ -246,8 +256,15 @@ CompliantContactManager<T>::CalcContactKinematics(
       jacobian_blocks.emplace_back(treeB_index, MatrixBlock<T>(std::move(J)));
     }
 
-    contact_kinematics.emplace_back(point_pair.phi0, std::move(jacobian_blocks),
-                                    std::move(R_WC));
+    ContactConfiguration<T> configuration{.objectA = bodyA_index,
+                                          .p_ApC_W = p_AC_W,
+                                          .objectB = bodyB_index,
+                                          .p_BqC_W = p_BC_W,
+                                          .phi = point_pair.phi0,
+                                          .R_WC = R_WC};
+
+    contact_kinematics.emplace_back(std::move(jacobian_blocks),
+                                    std::move(configuration));
   }
   if constexpr (std::is_same_v<T, double>) {
     if (deformable_driver_ != nullptr) {
@@ -762,7 +779,8 @@ void CompliantContactManager<T>::AppendContactResultsForPointContact(
     const BodyIndex bodyA_index = this->FindBodyByGeometryId(geometryA_id);
     const BodyIndex bodyB_index = this->FindBodyByGeometryId(geometryB_id);
 
-    const RotationMatrix<T>& R_WC = contact_kinematics[icontact].R_WC;
+    const RotationMatrix<T>& R_WC =
+        contact_kinematics[icontact].configuration.R_WC;
 
     // Contact forces applied on B at contact point C.
     const Vector3<T> f_Bc_C(ft(2 * icontact), ft(2 * icontact + 1),
@@ -858,7 +876,8 @@ void CompliantContactManager<T>::CalcHydroelasticContactInfo(
     const auto& pair = discrete_pairs[icontact];
     // Quadrature point Q.
     const Vector3<T>& p_WQ = pair.p_WC;
-    const RotationMatrix<T>& R_WC = contact_kinematics[icontact].R_WC;
+    const RotationMatrix<T>& R_WC =
+        contact_kinematics[icontact].configuration.R_WC;
 
     // Contact forces applied on B at quadrature point Q expressed in the
     // contact frame.

--- a/multibody/plant/contact_pair_kinematics.h
+++ b/multibody/plant/contact_pair_kinematics.h
@@ -6,6 +6,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/contact_solvers/contact_configuration.h"
 #include "drake/multibody/contact_solvers/matrix_block.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 
@@ -38,15 +39,11 @@ struct ContactPairKinematics {
     contact_solvers::internal::MatrixBlock<T> J;
   };
 
-  ContactPairKinematics(T phi_in, std::vector<JacobianTreeBlock> jacobian_in,
-                        math::RotationMatrix<T> R_WC_in)
-      : phi(std::move(phi_in)),
-        jacobian(std::move(jacobian_in)),
-        R_WC(std::move(R_WC_in)) {}
-
-  // Signed distance for the given pair. Defined negative for overlapping
-  // bodies.
-  T phi{};
+  ContactPairKinematics(
+      std::vector<JacobianTreeBlock> jacobian_in,
+      contact_solvers::internal::ContactConfiguration<T> configuration_in)
+      : jacobian(std::move(jacobian_in)),
+        configuration(std::move(configuration_in)) {}
 
   // TODO(amcastro-tri): consider using absl::InlinedVector since here we know
   // this has a size of at most 2.
@@ -55,8 +52,9 @@ struct ContactPairKinematics {
   // participate in a given contact.
   std::vector<JacobianTreeBlock> jacobian;
 
-  // Rotation matrix to re-express between contact frame C and world frame W.
-  math::RotationMatrix<T> R_WC;
+  // Contact configuration specifying objects in contact, contact point
+  // position, depth and contact frame.
+  contact_solvers::internal::ContactConfiguration<T> configuration;
 };
 
 }  // namespace internal

--- a/multibody/plant/deformable_driver.h
+++ b/multibody/plant/deformable_driver.h
@@ -101,6 +101,8 @@ class DeformableDriver : public ScalarConvertibleComponent<T> {
 
   ~DeformableDriver();
 
+  int num_deformable_bodies() const { return deformable_model_->num_bodies(); }
+
   // TODO(xuchenhan-tri): Implement CloneToDouble() and allow cloning to double.
   bool is_cloneable_to_double() const final { return false; }
   bool is_cloneable_to_autodiff() const final { return false; }

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -189,8 +189,15 @@ TEST_F(SpheresStackTest, EvalContactProblemCache) {
     // Here we simply test they are consistent with those hard-coded values.
     EXPECT_EQ(constraint->parameters().sigma, 1.0e-3);
 
-    // Verify contact frame orientation matrix R_WC.
-    EXPECT_EQ(R_WC[i].matrix(), pair_kinematics.R_WC.matrix());
+    // Verify contact configuration.
+    const contact_solvers::internal::ContactConfiguration<double>&
+        configuration = pair_kinematics.configuration;
+    EXPECT_EQ(constraint->configuration().objectA, configuration.objectA);
+    EXPECT_EQ(constraint->configuration().objectB, configuration.objectB);
+    EXPECT_EQ(constraint->configuration().p_ApC_W, configuration.p_ApC_W);
+    EXPECT_EQ(constraint->configuration().p_BqC_W, configuration.p_BqC_W);
+    EXPECT_EQ(constraint->configuration().phi, configuration.phi);
+    EXPECT_EQ(constraint->configuration().R_WC.matrix(), R_WC[i].matrix());
   }
 }
 


### PR DESCRIPTION
Towards #19435. Follow up to #19557.

This PR implements `SapFrictionConeConstraint::DoAccumulateSpatialImpulses()` so that the constraint can report forces.
Notice however this new functionality is not yet used.
Updates in manager and drivers are only due to an updated constructor signature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19596)
<!-- Reviewable:end -->
