### PR TITLE
Implements MultibodyPlant::DeclareBodyPoseOutputPort

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -893,6 +893,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_body_poses_output_port),
             py_rvp::reference_internal, cls_doc.get_body_poses_output_port.doc)
+        .def("DeclareBodyPoseOutputPort",
+            overload_cast_explicit<const systems::OutputPort<T>&,
+                const Body<T>&>(&Class::DeclareBodyPoseOutputPort),
+            py::arg("body"), py_rvp::reference_internal,
+            cls_doc.DeclareBodyPoseOutputPort.doc)
+        .def("get_body_pose_output_port",
+            overload_cast_explicit<const systems::OutputPort<T>&, BodyIndex>(
+                &Class::get_body_pose_output_port),
+            py::arg("body_index"), py_rvp::reference_internal,
+            cls_doc.get_body_pose_output_port.doc)
         .def("get_body_spatial_velocities_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_body_spatial_velocities_output_port),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1322,6 +1322,9 @@ class TestPlant(unittest.TestCase):
         plant_f.Finalize()
         plant = to_type(plant_f, T)
         models = [iiwa_model, gripper_model]
+        gripper_body = plant.GetBodyByName("body")
+        self.assertIsInstance(
+            plant.DeclareBodyPoseOutputPort(body=gripper_body), OutputPort)
 
         # Fix inputs.
         context = plant.CreateDefaultContext()
@@ -1354,9 +1357,16 @@ class TestPlant(unittest.TestCase):
             self.assertGreater(len(value), 0)
             return value[0]
 
+        def extract_value(port):
+            self.assertIsInstance(port, OutputPort)
+            return port.Eval(context)
+
         self.assertIsInstance(
             extract_list_value(plant.get_body_poses_output_port()),
             RigidTransform_[T])
+        self.assertIsInstance(
+            extract_value(plant.get_body_pose_output_port(
+                gripper_body.index())), RigidTransform_[T])
         self.assertIsInstance(
             extract_list_value(
                 plant.get_body_spatial_velocities_output_port()),

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -802,6 +802,7 @@ drake_cc_googletest(
         ":plant",
         "//common:autodiff",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//math:geometric_transform",
         "//math:gradient",
         "//multibody/test_utilities:add_fixed_objects_to_plant",

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -94,6 +94,9 @@ void CompareMultibodyPlantPortIndices(const MultibodyPlant<T>& plant_t,
             plant_u.get_body_spatial_velocities_output_port().get_index());
   EXPECT_EQ(plant_t.get_body_spatial_accelerations_output_port().get_index(),
             plant_u.get_body_spatial_accelerations_output_port().get_index());
+  BodyIndex body_index = plant_t.GetBodyByName("Body").index();
+  EXPECT_EQ(plant_t.get_body_pose_output_port(body_index).get_index(),
+            plant_u.get_body_pose_output_port(body_index).get_index());
   EXPECT_EQ(plant_t.get_state_output_port().get_index(),
             plant_u.get_state_output_port().get_index());
   EXPECT_EQ(plant_t.get_generalized_acceleration_output_port().get_index(),
@@ -128,7 +131,12 @@ TYPED_TEST_P(MultibodyPlantDefaultScalarsTest, PortIndexOrdering) {
 
   systems::DiagramBuilder<double> builder;
   MultibodyPlant<double>& plant = AddMultibodyPlantSceneGraph(&builder, 0.0);
+  const RigidBody<double>& body =
+      plant.AddRigidBody("Body", SpatialInertia<double>::MakeUnitary());
+  plant.AddJoint<RevoluteJoint>("Pin", plant.world_body(), std::nullopt, body,
+                                std::nullopt, Vector3<double>::UnitZ());
   plant.Finalize();
+  plant.DeclareBodyPoseOutputPort(body);
   std::unique_ptr<Diagram<double>> diagram = builder.Build();
 
   std::unique_ptr<Diagram<U>> diagram_u =

--- a/systems/framework/leaf_output_port.cc
+++ b/systems/framework/leaf_output_port.cc
@@ -18,6 +18,18 @@ void LeafOutputPort<T>::ThrowIfInvalidPortValueType(
   }
 }
 
+template <typename T>
+const AbstractValue& LeafOutputPort<T>::DoEval(
+    const Context<T>& context) const {
+  if (!context.get_cache().has_cache_entry_value(cache_entry().cache_index())) {
+    throw std::runtime_error(fmt::format(
+        "This Context does not have a cache entry for {}. Make sure that the "
+        "context is created *after* declaring any output ports.",
+        cache_entry().description()));
+  }
+  return cache_entry().EvalAbstract(context);
+}
+
 }  // namespace drake::systems
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -101,9 +101,7 @@ class LeafOutputPort final : public OutputPort<T> {
   }
 
   // Invokes the cache entry's Eval() function.
-  const AbstractValue& DoEval(const Context<T>& context) const final {
-    return cache_entry().EvalAbstract(context);
-  }
+  const AbstractValue& DoEval(const Context<T>& context) const final;
 
   // Returns the cache entry's ticket and no subsystem.
   internal::OutputPortPrerequisite DoGetPrerequisite() const final {


### PR DESCRIPTION
This allows a user of MultibodyPlant to declare a new output port that contains just a single body pose, instead of using the vector of poses from the existing body_poses output port.  This design was discussed in #19520.

Towards #19514.

+@joemasterjohn for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19602)
<!-- Reviewable:end -->
