### PR TITLE
[C-IRIS] Compute s on the kinematics chain between each body.

### DIFF
--- a/geometry/optimization/cspace_free_box.cc
+++ b/geometry/optimization/cspace_free_box.cc
@@ -13,7 +13,9 @@ CspaceFreeBox::CspaceFreeBox(const multibody::MultibodyPlant<double>* plant,
                              const geometry::SceneGraph<double>* scene_graph,
                              SeparatingPlaneOrder plane_order,
                              const Options& options)
-    : CspaceFreePolytopeBase(plant, scene_graph, plane_order, options) {}
+    : CspaceFreePolytopeBase(plant, scene_graph, plane_order,
+                             CspaceFreePolytopeBase::SForPlane::kOnChain,
+                             options) {}
 
 CspaceFreeBox::~CspaceFreeBox() {}
 

--- a/geometry/optimization/cspace_free_polytope.cc
+++ b/geometry/optimization/cspace_free_polytope.cc
@@ -243,7 +243,8 @@ CspaceFreePolytope::CspaceFreePolytope(
     SeparatingPlaneOrder plane_order,
     const Eigen::Ref<const Eigen::VectorXd>& q_star,
     const CspaceFreePolytope::Options& options)
-    : CspaceFreePolytopeBase(plant, scene_graph, plane_order, options),
+    : CspaceFreePolytopeBase(plant, scene_graph, plane_order,
+                             CspaceFreePolytopeBase::SForPlane::kAll, options),
       q_star_{q_star} {
   s_lower_ = rational_forward_kin().ComputeSValue(
       rational_forward_kin().plant().GetPositionLowerLimits(), q_star_);


### PR DESCRIPTION
For CspaceFreeBox, for the separating plane between a pair of geometries, the a(s) and b(s) of that plane only need to depend on the subset of s on the kinematics chain between the pair of geometries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19609)
<!-- Reviewable:end -->
