### PR TITLE
Adds SaveIrisRegionsYamlFile and LoadIrisRegionsYamlFile to pydrake

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/geometry/geometry_py.h"
 #include "drake/bindings/pydrake/geometry/optimization_pybind.h"
+#include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/optimization/cartesian_product.h"
 #include "drake/geometry/optimization/graph_of_convex_sets.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
@@ -402,6 +403,27 @@ void DefineGeometryOptimization(py::module m) {
           &IrisInConfigurationSpace),
       py::arg("plant"), py::arg("context"), py::arg("options") = IrisOptions(),
       doc.IrisInConfigurationSpace.doc);
+
+  // TODO(#19597) Deprecate and remove these functions once Python
+  // can natively handle the file I/O.
+  m.def(
+      "SaveIrisRegionsYamlFile",
+      [](const std::filesystem::path& filename, const IrisRegions& regions,
+          const std::optional<std::string>& child_name) {
+        yaml::SaveYamlFile(filename, regions, child_name);
+      },
+      py::arg("filename"), py::arg("regions"),
+      py::arg("child_name") = std::nullopt,
+      "Calls SaveYamlFile() to serialize an IrisRegions object.");
+
+  m.def(
+      "LoadIrisRegionsYamlFile",
+      [](const std::filesystem::path& filename,
+          const std::optional<std::string>& child_name) {
+        return yaml::LoadYamlFile<IrisRegions>(filename, child_name);
+      },
+      py::arg("filename"), py::arg("child_name") = std::nullopt,
+      "Calls LoadYamlFile() to deserialize an IrisRegions object.");
 
   // GraphOfConvexSetsOptions
   {

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -468,6 +468,26 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertTrue(region.PointInSet([1.0]))
         self.assertFalse(region.PointInSet([-1.0]))
 
+    def test_serialize_iris_regions(self):
+        iris_regions = {
+            "box1":
+            mut.HPolyhedron.MakeBox(lb=[-1, -2, -3], ub=[1, 2, 3]),
+            "box2":
+            mut.HPolyhedron.MakeBox(lb=[-4.1, -5.2, -6.3], ub=[4.1, 4.2, 6.3])
+        }
+        temp_file_name = f"{temp_directory()}/iris.yaml"
+        mut.SaveIrisRegionsYamlFile(filename=temp_file_name,
+                                    regions=iris_regions,
+                                    child_name="test")
+        loaded_regions = mut.LoadIrisRegionsYamlFile(filename=temp_file_name,
+                                                     child_name="test")
+        self.assertEqual(iris_regions.keys(), loaded_regions.keys())
+        for k in iris_regions.keys():
+            np.testing.assert_array_equal(iris_regions[k].A(),
+                                          loaded_regions[k].A())
+            np.testing.assert_array_equal(iris_regions[k].b(),
+                                          loaded_regions[k].b())
+
     def test_graph_of_convex_sets(self):
         options = mut.GraphOfConvexSetsOptions()
         options.convex_relaxation = True

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "drake/common/name_value.h"
@@ -193,6 +195,10 @@ HPolyhedron IrisInConfigurationSpace(
     const multibody::MultibodyPlant<double>& plant,
     const systems::Context<double>& context,
     const IrisOptions& options = IrisOptions());
+
+/** Defines a standardized representation for (named) IrisRegions, which can be
+serialized in both C++ and Python. */
+typedef std::map<std::string, HPolyhedron> IrisRegions;
 
 }  // namespace optimization
 }  // namespace geometry


### PR DESCRIPTION
In order to serialize a dictionary of Iris regions in both C++ and Python, this PR defines the type and adds the bespoke serialization wrapper for pydrake.

Towards #19514.
Related to #19597.  If that lands, we can deprecate this shim.

+@jwnimmer-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19612)
<!-- Reviewable:end -->
