### PR TITLE
[sensors] Hotfix for async test vs TSan

### DIFF
--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -445,7 +445,11 @@ drake_cc_googletest(
         ":test/rgbd_sensor_async_gl_test.dmd.yaml",
         "//examples/manipulation_station:models",
     ],
-    tags = vtk_test_tags(),
+    tags = vtk_test_tags() + [
+        # Similar to #7520, the GL vendor's libraries are not sufficiently
+        # instrumented for compatibility with TSan.
+        "no_tsan",
+    ],
     deps = [
         ":image_writer",
         ":rgbd_sensor",


### PR DESCRIPTION
Similar to #7520, the GL vendor's libraries are not sufficiently instrumented for compatibility with TSan.

Possibly this should be part of `vtk_test_tags()` in the first place, but for now I'll be conservative and just change one spot.

Here's an example of the errors we'll be ignoring now:
```
==================
WARNING: ThreadSanitizer: data race (pid=596042)
  Write of size 8 at 0x7b5400018d80 by thread T1 (mutexes: write M0):
    #0 free <null> (rgbd_sensor_async_gl_test+0x273914) (BuildId: d89053b7261f5ad5c666c45513ee3f4d23641657)
    #1 <null> <null> (libnvidia-glcore.so.525.105.17+0x146eaf5) (BuildId: 5bdffe680592c7195d8beb3e9a87fcb951d4c64f)
    #2 drake::geometry::render_gl::internal::OpenGlContext::MakeCurrent() const geometry/render_gl/internal_opengl_context.cc:324:50 (rgbd_sensor_async_gl_test+0x5b68cd) (BuildId: d89053b7261f5ad5c666c45513ee3f4d23641657)
    #3 drake::geometry::render_gl::internal::RenderEngineGl::DoRenderColorImage(drake::geometry::render::ColorRenderCamera const&, drake::systems::sensors::Image<(drake::systems::sensors::PixelType)2>*) const geometry/render_gl/internal_render_engine_gl.cc:751:20 (rgbd_sensor_async_gl_test+0x52ca28) (BuildId: d89053b7261f5ad5c666c45513ee3f4d23641657)

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19613)
<!-- Reviewable:end -->
