### PR TITLE
[tools] Always set forward_files to manual

### DIFF
--- a/geometry/profiling/BUILD.bazel
+++ b/geometry/profiling/BUILD.bazel
@@ -9,6 +9,7 @@ _EVO_MESH = forward_files(
     srcs = ["@drake_models//:dishes/bowls/evo_bowl_no_mtl.obj"],
     dest_prefix = "",
     strip_prefix = "@drake_models//:dishes/bowls/",
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 )
 

--- a/manipulation/models/realsense2_description/BUILD.bazel
+++ b/manipulation/models/realsense2_description/BUILD.bazel
@@ -18,6 +18,7 @@ _REALSENSE2_DESCRIPTION_FILES = forward_files(
             x for x in realsense2_description_files()],
     dest_prefix = "",
     strip_prefix = "@intel_realsense_ros_internal//:realsense2_description/",
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 )
 

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -39,6 +39,7 @@ _DM_CONTROL_MUJOCO_FILES = forward_files(
     srcs = ["@dm_control_internal//:" + x for x in dm_control_mujoco_files()],
     dest_prefix = "",
     strip_prefix = "@dm_control_internal//:",
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 )
 

--- a/tools/workspace/forward_files.bzl
+++ b/tools/workspace/forward_files.bzl
@@ -17,9 +17,14 @@ def forward_files(
         String to be stripped from source files. Should include trailing slash.
     @param dest_prefix
         String to be prepended to target.
+    @param tags
+        Must always include "manual" at a minimum.
+        Files should only be copied when needed, not as part of `:all`.
     """
     if strip_prefix == None or dest_prefix == None:
         fail("Must supply `strip_prefix` and `dest_prefix`.")
+    if "manual" not in (tags or []):
+        fail("Must set `tags = [\"manual\"]`")
     outs = []
     for src in srcs:
         if not src.startswith(strip_prefix):


### PR DESCRIPTION
This helps mitigate spurious build errors when downstream developers use different versions of model files externals. For example, if they are skipping `detail_mujoco_parser_test` then we shouldn't try to copy the `dm_control` model files when building `//...`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19614)
<!-- Reviewable:end -->
