### PR TITLE
[bindings] Test broken return value logic of plant.GetBodiesWeldedTo()

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -393,6 +393,7 @@ drake_py_unittest(
     name = "plant_test",
     data = [
         ":models",
+        "//examples/acrobot:models",
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
         "//multibody:models",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -261,6 +261,19 @@ class TestPlant(unittest.TestCase):
         self.assertIsNotNone(plant)
         self.assertIsNotNone(scene_graph)
 
+    def test_get_bodies_welded_to(self):
+        # Test some tedious return-type logic. The model has a link welded to
+        # the world.
+        plant_f = MultibodyPlant_[float](time_step=0.01)
+        model_instance, = Parser(plant_f).AddModels(
+            url='package://drake/examples/acrobot/Acrobot.urdf')
+
+        # Prior implementations would inadvertently attempt to copy Body
+        # objects, leading to run-time errors.
+        self.assertEqual(plant_f.GetBodiesWeldedTo(plant_f.world_body()),
+                         [plant_f.world_body(),
+                          plant_f.get_body(BodyIndex(1))])
+
     @numpy_compare.check_all_types
     def test_multibody_plant_api_via_parsing(self, T):
         MultibodyPlant = MultibodyPlant_[T]


### PR DESCRIPTION
Prior implementations would inadvertently copy un-copyable Body<T> objects, leading to run-time errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19615)
<!-- Reviewable:end -->
