### PR TITLE
[examples] Remove optitrack_test

### DIFF
--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -173,13 +173,6 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_googletest(
-    name = "optitrack_test",
-    deps = [
-        "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
-    ],
-)
-
 alias(
     name = "dual_iiwa14_polytope_collision.urdf",
     actual = "//manipulation/models/iiwa_description:urdf/dual_iiwa14_polytope_collision.urdf",  # noqa

--- a/examples/kuka_iiwa_arm/test/optitrack_test.cc
+++ b/examples/kuka_iiwa_arm/test/optitrack_test.cc
@@ -1,8 +1,0 @@
-#include "optitrack/optitrack_frame_t.hpp"
-#include <gtest/gtest.h>
-
-GTEST_TEST(OptitrackTest, OptitrackLcmTest) {
-  // Dummy test to make sure the library is pulled in correctly.
-  EXPECT_TRUE(true);
-}
-


### PR DESCRIPTION
This test is vestigial.

It as created as a bootstrapping tool while we were working on adding new dependencies to the build system.  Since then, we've grown our optitrack support, and we now have several tests that supersede it, e.g., the sender and receiver tests here:
https://github.com/RobotLocomotion/drake/blob/v1.17.0/systems/sensors/test/optitrack_sender_test.cc#L3
https://github.com/RobotLocomotion/drake/blob/v1.17.0/systems/sensors/test/optitrack_receiver_test.cc#L3

To prune some deadwood, we should remove the now-redundant test.

Towards #19600.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19616)
<!-- Reviewable:end -->
