### PR TITLE
Implements BezierCurve::ElevateOrder()

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -107,6 +107,9 @@ class TestTrajectories(unittest.TestCase):
         for expr in curve_expression:
             self.assertTrue(isinstance(expr, Expression))
 
+        curve.ElevateOrder()
+        self.assertEqual(curve.order(), 2)
+
     @numpy_compare.check_all_types
     def test_bspline_trajectory(self, T):
         BsplineBasis = BsplineBasis_[T]

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -269,7 +269,8 @@ struct Impl {
               cls_doc.control_points.doc)
           .def("GetExpression", &Class::GetExpression,
               py::arg("time") = symbolic::Variable("t"),
-              cls_doc.GetExpression.doc);
+              cls_doc.GetExpression.doc)
+          .def("ElevateOrder", &Class::ElevateOrder, cls_doc.ElevateOrder.doc);
       DefCopyAndDeepCopy(&cls);
     }
 

--- a/common/trajectories/bezier_curve.h
+++ b/common/trajectories/bezier_curve.h
@@ -71,6 +71,11 @@ class BezierCurve final : public trajectories::Trajectory<T> {
   VectorX<symbolic::Expression> GetExpression(
       symbolic::Variable time = symbolic::Variable("t")) const;
 
+  /** Increases the order of the curve by 1. A Bézier curve of order n can be
+   converted into a Bézier curve of order n + 1 with the same shape. The
+   control points of `this` are modified to obtain the equivalent curve. */
+  void ElevateOrder();
+
   Eigen::Index rows() const override { return control_points_.rows(); }
 
   Eigen::Index cols() const override { return 1; }

--- a/common/trajectories/test/bezier_curve_test.cc
+++ b/common/trajectories/test/bezier_curve_test.cc
@@ -11,6 +11,40 @@ namespace drake {
 namespace trajectories {
 namespace {
 
+// Tests the default constructor.
+GTEST_TEST(BezierCurveTest, DefaultConstructor) {
+  BezierCurve<double> curve;
+  EXPECT_EQ(curve.order(), -1);
+  EXPECT_EQ(curve.start_time(), 0);
+  EXPECT_EQ(curve.end_time(), 1);
+  EXPECT_EQ(curve.rows(), 0);
+  EXPECT_EQ(curve.cols(), 1);
+
+  EXPECT_EQ(curve.BernsteinBasis(0, 0), 0);
+  EXPECT_EQ(curve.control_points().size(), 0);
+  EXPECT_EQ(curve.Clone()->rows(), 0);
+  EXPECT_EQ(curve.value(0).size(), 0);
+  EXPECT_EQ(curve.GetExpression().size(), 0);
+  curve.ElevateOrder();
+  EXPECT_EQ(curve.order(), 0);
+  EXPECT_EQ(curve.control_points().size(), 0);
+}
+
+GTEST_TEST(BezierCurveTest, Constant) {
+  const Eigen::Vector2d kValue(1, 2);
+  BezierCurve<double> curve(0, 1, kValue);
+  EXPECT_EQ(curve.order(), 0);
+  EXPECT_EQ(curve.start_time(), 0);
+  EXPECT_EQ(curve.end_time(), 1);
+  EXPECT_EQ(curve.rows(), 2);
+  EXPECT_EQ(curve.cols(), 1);
+  EXPECT_TRUE(CompareMatrices(curve.value(0.5), kValue));
+
+  curve.ElevateOrder();
+  EXPECT_EQ(curve.order(), 1);
+  EXPECT_TRUE(CompareMatrices(curve.value(0.5), kValue));
+}
+
 using drake::geometry::optimization::VPolytope;
 void CheckConvexHullProperty(const BezierCurve<double>& curve,
                              int num_samples) {
@@ -54,6 +88,13 @@ GTEST_TEST(BezierCurveTest, Linear) {
   const int num_samples{100};
   CheckConvexHullProperty(curve, num_samples);
   CheckConvexHullProperty(deriv_bezier, num_samples);
+
+  curve.ElevateOrder();
+  EXPECT_EQ(curve.order(), 2);
+  EXPECT_TRUE(
+      CompareMatrices(curve.value(2.5), Eigen::Vector2d(1.5, 5), 1e-14));
+  EXPECT_TRUE(CompareMatrices(curve.value(0), Eigen::Vector2d(1, 3), 1e-14));
+  EXPECT_TRUE(CompareMatrices(curve.value(3.0), Eigen::Vector2d(2, 7), 1e-14));
 }
 
 // Quadratic curve: [ (1-t)²; t^2 ]
@@ -98,10 +139,6 @@ GTEST_TEST(BezierCurveTest, Quadratic) {
     EXPECT_TRUE(CompareMatrices(curve.value(sample_time),
                                 Eigen::Vector2d((1 - t) * (1 - t), t * t),
                                 1e-14));
-    EXPECT_TRUE(CompareMatrices(curve.value(sample_time),
-                                Eigen::Vector2d((1 - t) * (1 - t), t * t),
-                                1e-14));
-
     EXPECT_TRUE(CompareMatrices(deriv->value(sample_time),
                                 Eigen::Vector2d(-2 * (1 - t), 2 * t), 1e-14));
     EXPECT_TRUE(CompareMatrices(curve.EvalDerivative(sample_time),
@@ -123,6 +160,15 @@ GTEST_TEST(BezierCurveTest, Quadratic) {
   const int num_samples{100};
   CheckConvexHullProperty(curve, num_samples);
   CheckConvexHullProperty(deriv_bezier, num_samples);
+
+  curve.ElevateOrder();
+  EXPECT_EQ(curve.order(), 3);
+  for (double sample_time = -0.2; sample_time <= 1.2; sample_time += 0.1) {
+    const double t = std::clamp(sample_time, 0.0, 1.0);
+    EXPECT_TRUE(CompareMatrices(curve.value(sample_time),
+                                Eigen::Vector2d((1 - t) * (1 - t), t * t),
+                                1e-14));
+  }
 }
 
 GTEST_TEST(BezierCurve, Clone) {


### PR DESCRIPTION
A Bezier curve of degree n can be converted into a Bézier curve of degree n + 1 with the same shape. This method implements the degree/order elevation.

+@AlexandreAmice for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19620)
<!-- Reviewable:end -->
