### PR TITLE
[py autodiff] Bind constructor overload for unit derivatives vector

### DIFF
--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -35,8 +35,15 @@ PYBIND11_MODULE(autodiffutils, m) {
   // TODO(m-chaturvedi) Add Pybind11 documentation.
   py::class_<AutoDiffXd> autodiff(m, "AutoDiffXd");
   autodiff  // BR
-      .def(py::init<double>())
-      .def(py::init<const double&, const VectorXd&>())
+      .def(py::init<double>(), py::arg("value"),
+          "Constructs a value with empty derivatives.")
+      .def(py::init<const double&, const VectorXd&>(), py::arg("value"),
+          py::arg("derivatives"),
+          "Constructs a value with the given derivatives.")
+      .def(py::init<double, Eigen::Index, Eigen::Index>(), py::arg("value"),
+          py::arg("size"), py::arg("offset"),
+          "Constructs a value with a single partial derivative of 1.0 at the "
+          "given `offset` in a vector of `size` otherwise-zero derivatives.")
       .def("value", [](const AutoDiffXd& self) { return self.value(); })
       .def("derivatives",
           [](const AutoDiffXd& self) { return self.derivatives(); })

--- a/bindings/pydrake/forwarddiff.py
+++ b/bindings/pydrake/forwarddiff.py
@@ -9,7 +9,7 @@ def derivative(function, x):
 
     The function should be scalar-input and scalar-output.
     """
-    x_ad = AutoDiffXd(x, np.ones(1))
+    x_ad = AutoDiffXd(value=x, size=1, offset=0)
     y_ad = function(x_ad)
     return y_ad.derivatives()[0]
 
@@ -25,9 +25,7 @@ def gradient(function, x):
     assert x.ndim == 1, "x must be a vector"
     x_ad = np.empty(x.shape, dtype=AutoDiffXd)
     for i in range(x.size):
-        der = np.zeros(x.size)
-        der[i] = 1
-        x_ad.flat[i] = AutoDiffXd(x.flat[i], der)
+        x_ad.flat[i] = AutoDiffXd(value=x.flat[i], size=x.size, offset=i)
     y_ad = np.asarray(function(x_ad))
     # TODO(eric.cousineau): Consider restricting this in the future to only be
     # a scalar.
@@ -49,9 +47,7 @@ def jacobian(function, x):
     assert x.ndim == 1, "x must be a vector"
     x_ad = np.empty(x.shape, dtype=object)
     for i in range(x.size):
-        der = np.zeros(x.size)
-        der[i] = 1
-        x_ad.flat[i] = AutoDiffXd(x.flat[i], der)
+        x_ad.flat[i] = AutoDiffXd(value=x.flat[i], size=x.size, offset=i)
     y_ad = np.asarray(function(x_ad))
     return np.vstack(
         [y.derivatives() for y in y_ad.flat]).reshape(y_ad.shape + (-1,))

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -44,9 +44,14 @@ def check_logical(func, a, b, expected):
 
 class TestAutoDiffXd(unittest.TestCase):
     def test_scalar_api(self):
-        a = AD(1, [1., 0])
-        self.assertEqual(a.value(), 1.)
-        numpy_compare.assert_equal(a.derivatives(), [1., 0])
+        # Test the unit vector constructor.
+        a = AD(value=1, size=2, offset=1)
+        self.assertEqual(a.value(), 1.0)
+        numpy_compare.assert_equal(a.derivatives(), [0.0, 1.0])
+        # Test the dense derivatives vector constructor.
+        a = AD(value=1, derivatives=[1.0, 2.0])
+        self.assertEqual(a.value(), 1.0)
+        numpy_compare.assert_equal(a.derivatives(), [1.0, 2.0])
         self.assertEqual(str(a), "AD{1.0, nderiv=2}")
         self.assertEqual(repr(a), "<AutoDiffXd 1.0 nderiv=2>")
         numpy_compare.assert_equal(a, a)


### PR DESCRIPTION
Add docs and kwarg names for all overloads, matching the naming choices of the forthcoming `drake::ad::AutoDiff`.

Port a few existing call sites to use the more efficient constructor.

Towards #17492.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19623)
<!-- Reviewable:end -->
