### PR TITLE
Add nlohmann as internal vendored library

### DIFF
--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -312,4 +312,11 @@ drake_py_unittest(
     ],
 )
 
+drake_cc_googletest(
+    name = "merge_gltf_test",
+    deps = [
+        "@nlohmann_internal//:nlohmann",
+    ],
+)
+
 add_lint_tests(enable_clang_format_lint = False)

--- a/geometry/render_gltf_client/test/merge_gltf_test.cc
+++ b/geometry/render_gltf_client/test/merge_gltf_test.cc
@@ -1,0 +1,28 @@
+#include <drake_vendor/nlohmann/json.hpp>
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace render_gltf_client {
+namespace internal {
+namespace {
+
+using nlohmann::json;
+
+// Temporary smoke test to show that json has been properly included. This will
+// be replaced when the gltf merging code has been implemented.
+GTEST_TEST(JsonTest, Smoke) {
+  json source;
+  EXPECT_FALSE(source.contains("data"));
+  json& data = source["data"];
+  data.push_back(10);
+  EXPECT_TRUE(data.is_array());
+  json& value = data.back();
+  EXPECT_TRUE(value.is_number());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace render_gltf_client
+}  // namespace geometry
+}  // namespace drake

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -92,6 +92,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "msgpack_internal",
     "net_sf_jchart2d",
     "nanoflann_internal",
+    "nlohmann_internal",
     "nlopt_internal",
     "org_apache_xmlgraphics_commons",
     "petsc",

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -58,6 +58,7 @@ load("@drake//tools/workspace/mypy_extensions_internal:repository.bzl", "mypy_ex
 load("@drake//tools/workspace/mypy_internal:repository.bzl", "mypy_internal_repository")  # noqa
 load("@drake//tools/workspace/nanoflann_internal:repository.bzl", "nanoflann_internal_repository")  # noqa
 load("@drake//tools/workspace/net_sf_jchart2d:repository.bzl", "net_sf_jchart2d_repository")  # noqa
+load("@drake//tools/workspace/nlohmann_internal:repository.bzl", "nlohmann_internal_repository")  # noqa
 load("@drake//tools/workspace/nlopt_internal:repository.bzl", "nlopt_internal_repository")  # noqa
 load("@drake//tools/workspace/openblas:repository.bzl", "openblas_repository")
 load("@drake//tools/workspace/opencl:repository.bzl", "opencl_repository")
@@ -227,6 +228,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         nanoflann_internal_repository(name = "nanoflann_internal", mirrors = mirrors)  # noqa
     if "net_sf_jchart2d" not in excludes:
         net_sf_jchart2d_repository(name = "net_sf_jchart2d", mirrors = mirrors)
+    if "nlohmann_internal" not in excludes:
+        nlohmann_internal_repository(name = "nlohmann_internal", mirrors = mirrors)  # noqa
     if "nlopt_internal" not in excludes:
         nlopt_internal_repository(name = "nlopt_internal", mirrors = mirrors)
     if "openblas" not in excludes:

--- a/tools/workspace/nlohmann_internal/BUILD.bazel
+++ b/tools/workspace/nlohmann_internal/BUILD.bazel
@@ -1,0 +1,6 @@
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/nlohmann_internal/package.BUILD.bazel
+++ b/tools/workspace/nlohmann_internal/package.BUILD.bazel
@@ -1,0 +1,24 @@
+# -*- bazel -*-
+
+load(
+    "@drake//tools/install:install.bzl",
+    "install",
+)
+
+licenses(["notice"])  # MIT
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "nlohmann",
+    hdrs = ["single_include/nlohmann/json.hpp"],
+    strip_include_prefix = "single_include",
+    include_prefix = "drake_vendor",
+    linkstatic = 1,
+)
+
+# Install the license file.
+install(
+    name = "install",
+    docs = ["LICENSE.MIT"],
+)

--- a/tools/workspace/nlohmann_internal/patches/vendor.patch
+++ b/tools/workspace/nlohmann_internal/patches/vendor.patch
@@ -1,0 +1,35 @@
+Add vendoring namespace.
+
+This prevents ODR violations in case downstream code also links to json.
+
+--- single_include/nlohmann/json.hpp
++++ single_include/nlohmann/json.hpp
+@@ -131,19 +131,21 @@
+ #endif
+
+ #ifndef NLOHMANN_JSON_NAMESPACE_BEGIN
+-#define NLOHMANN_JSON_NAMESPACE_BEGIN                \
+-    namespace nlohmann                               \
+-    {                                                \
+-    inline namespace NLOHMANN_JSON_NAMESPACE_CONCAT( \
+-                NLOHMANN_JSON_ABI_TAGS,              \
+-                NLOHMANN_JSON_NAMESPACE_VERSION)     \
++#define NLOHMANN_JSON_NAMESPACE_BEGIN                                       \
++    inline namespace drake_vendor __attribute__ ((visibility ("hidden"))) { \
++    namespace nlohmann                                                      \
++    {                                                                       \
++    inline namespace NLOHMANN_JSON_NAMESPACE_CONCAT(                        \
++                NLOHMANN_JSON_ABI_TAGS,                                     \
++                NLOHMANN_JSON_NAMESPACE_VERSION)                            \
+     {
+ #endif
+
+ #ifndef NLOHMANN_JSON_NAMESPACE_END
+ #define NLOHMANN_JSON_NAMESPACE_END                                     \
+     }  /* namespace (inline namespace) NOLINT(readability/namespace) */ \
+-    }  // namespace nlohmann
++    }  /* namespace nlohmann         */                                 \
++    }  // namespace drake_vendor
+ #endif
+
+ // #include <nlohmann/detail/conversions/from_json.hpp>

--- a/tools/workspace/nlohmann_internal/repository.bzl
+++ b/tools/workspace/nlohmann_internal/repository.bzl
@@ -1,0 +1,16 @@
+load("@drake//tools/workspace:github.bzl", "github_archive")
+
+def nlohmann_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "nlohmann/json",
+        commit = "v3.11.2",
+        sha256 = "d69f9deb6a75e2580465c6c4c5111b89c4dc2fa94e3a85fcd2ffcd9a143d9273",  # noqa
+        build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/vendor.patch",
+        ],
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
This adds the library as header only. It might be better to build it as a static library, but the header-only version was quick and dirty.

relates #19532

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19625)
<!-- Reviewable:end -->
