### PR TITLE
push_release: get GPG fingerprint from public key

### DIFF
--- a/tools/release_engineering/dev/push_release
+++ b/tools/release_engineering/dev/push_release
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-################################################################################
-# NOTE: before running this script, you must set the value of `gpg_key` below! #
-################################################################################
-
 # This shell script is used to complete the manual steps at the end of the
 # release process.
 
@@ -101,16 +97,11 @@ fi
 
 platforms=( focal jammy )
 
-# Unfortunately, but necessarily, the secret key is not available over any
-# network, including VPC and the Internet. The public key is at
-# https://drake-apt.csail.mit.edu/drake.asc and
-# https://drake-packages.csail.mit.edu/drake/release/drake.asc
-################################################################################
-# TODO(svenevs): allow command line or environment variable to set this.
-# The value for this variable is currently saved in the AWS Secrets Manager
-# `push_release` key.
-readonly gpg_key=0000000000000000000000000000000000000000
-################################################################################
+readonly gpg_key="$(
+  curl --fail https://drake-apt.csail.mit.edu/drake.asc | \
+  gpg --with-colons --show-keys --fingerprint | \
+  grep -m1 -E '^fpr:' | cut -c 4- | tr -d :)"
+
 if ! [[ "${gpg_key}" =~ ^[a-fA-F0-9]{40}$ ]]; then
   echo "Error: gpg_key value expected to be a length 40 hexadecimal string." >&2
   exit 1


### PR DESCRIPTION
Modify the logic in push_release that expected the GPG key fingerprint to be manually entered. While preserving the security of the private key is good, the identifying fingerprint is part of the public key, and therefore there is no reason to not simply fetch the public key in order to obtain the fingerprint, thus removing a manual step.

+@BetsyMcPhail for review (both), please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19630)
<!-- Reviewable:end -->
