### PR TITLE
Rewrite push_release logic for docker

### DIFF
--- a/tools/release_engineering/dev/README.md
+++ b/tools/release_engineering/dev/README.md
@@ -38,7 +38,6 @@ Replace all (3) instances of "awsAccessKeyID" and "awsSecretAccessKey" in
 Set `rootDir` in `.aptly.conf` to your local home directory
 (e.g. `/Users/<username>/.aptly`)
 
-
 ### Import the gpg key
 
 Download the public key from S3.
@@ -49,6 +48,13 @@ Using the passphrase from the AWS Secrets Manager, run:
 
 **Note:** It is not clear if `gpg` or `gpg1` is correct to use on Ubuntu
 
+### Log into Docker
+
+Log into Docker to ensure that you will be able to push the Docker images:
+
+    docker login
+
+The Docker ID and password may be found in the AWS Secrets Manager.
 
 ### Get the push_release scripts
 
@@ -57,22 +63,19 @@ Clone the drake repository:
     git clone https://github.com/RobotLocomotion/drake.git
     cd drake
 
-In `tools/release_engineering/dev/push_release`, replace the placeholder
-`gpg_key` with the value from the AWS Secrets Manager.
-
-## Run script to mirror the .tar and .deb artifacts to S3
+## Run script to push docker images and mirror the .tar/.deb artifacts to S3
 
 Once your machine is set-up, run the `push_release` script as described below:
 
     bazel run //tools/release_engineering/dev:push_release -- <version>
 
 
-The release creator will provide the version and date. Throughout this process,
-don’t use `v` on the version string. For example:
+The release creator will provide the version. Throughout this process, don’t
+use `v` on the version string. For example:
 
     bazel run //tools/release_engineering/dev:push_release -- 1.0.0
 
-## Run script for docker and apt
+## Run script for apt
 
 (Before proceeding, refer to the sections below if you need to add a new
 configuration or package.)
@@ -80,16 +83,15 @@ configuration or package.)
 Once your machine is set-up, run the `push_release` script as described below:
 
     cd tools/release_engineering/dev
-    ./push_release <version> <date> --apt
+    ./push_release <version>
 
-The release creator will provide the version and date. Again, don’t use `v` on
-the version string. For example:
+The release creator will provide the version. Again, don’t use `v` on the
+version string. For example:
 
     ./push_release 0.32.0 20210714 --apt
 
-The script may prompt for the GPG passphrase and/or the docker ID and password,
-all of which may be found in the AWS Secrets Manager. The script may prompt for
-these multiple times.
+The script may prompt for the GPG passphrase, which may be found in the AWS
+Secrets Manager. The script may prompt for this multiple times.
 
 ### Verification
 

--- a/tools/release_engineering/dev/push_release
+++ b/tools/release_engineering/dev/push_release
@@ -9,44 +9,19 @@
 
 set -euo pipefail
 
-readonly usage="Usage: $0 {{ source version x.y.z }} {{ binary version YYYYMMDD }} [--apt] [--no-docker]"
+readonly usage="Usage: $0 {{ source version x.y.z }}"
 
-if [[ "$#" -lt 2 ]]; then
+if [[ "$#" -lt 1 ]]; then
   echo "${usage}" >&2
   exit 1
 fi
 
 readonly source_version=$1
-readonly binary_version=$2
 
-# Sanity check that the nightly binary release version is 8 characters long.
-# Apologies to the maintainer of the January release in the year 10000.
-if [[ "${#binary_version}" -ne 8 ]]; then
-  echo "${usage}" >&2
-  exit 1
-fi
+shift 1;
 
-shift 2;
-
-# Do not publish Debian packages by default as they need to be manually built.
-push_apt=0
-push_docker=1
-
-while [[ "$#" -gt 0 ]]; do
-  case "$1" in
-    --apt)
-      push_apt=1
-      ;;
-    --no-docker)
-      push_docker=0
-      ;;
-    *)
-      echo "${usage}" >&2
-      exit 1
-      ;;
-    esac
-  shift
-done
+# The only thing this script still does is the apt push
+push_apt=1
 
 if ! tty -s; then
   echo 'ERROR: tty was NOT detected. This script may need various login credentials to be entered interactively.'  >&2
@@ -69,15 +44,6 @@ if ! command -v curl &>/dev/null; then
   exit 5
 fi
 
-# Docker is available both as a formula and a cask on macOS. Either is fine as
-# are any of the Docker CE packages from the Docker website for both Ubuntu and
-# macOS. The Docker package on Ubuntu really does have a strange name. An
-# unrelated docklet for KDE or GNOME claimed the obvious name long ago.
-if [[ "${push_docker}" -ne 0 ]] && ! command -v docker &>/dev/null; then
-  echo 'ERROR: docker(1) was NOT found. Fix with apt-get install docker.io or brew install [--cask] docker.' >&2
-  exit 6
-fi
-
 if [[ "${push_apt}" -ne 0 ]] && ! command -v gpg &>/dev/null; then
   echo 'ERROR: gpg(1) was NOT found. Fix with apt-get install gnupg or brew install gnupg.' >&2
   exit 6
@@ -89,14 +55,6 @@ if ! curl --fail --head --location --output /dev/null \
     "https://api.github.com/repos/RobotLocomotion/drake/releases/tags/v${source_version}"; then
   echo "ERROR: GitHub release v${source_version} does NOT exist." >&2
   exit 8
-fi
-
-# Sanity check that the nightly binary is likely to exist given the datestamp.
-# In an ideal world, we would query the GitHub API to get an exact mapping from
-# source version to nightly binary version.
-if [[ "$(date '+%Y%m%d')" < "${binary_version}" ]]; then
-  echo "ERROR: Binary release has a future date so probably does NOT exist." >&2
-  exit 9
 fi
 
 platforms=( focal jammy )
@@ -128,45 +86,6 @@ if [[ "${push_apt}" -ne 0 ]]; then
   fi
 fi
 
-if [[ "${push_docker}" -ne 0 ]]; then
-  set -x
-
-  # You need credentials to the robotlocomotion organization on Docker Hub. The
-  # number of people or bots that have or need these are necessarily very small.
-  docker login
-
-  # Keep the Docker images available locally on error for retrying and/or
-  # debugging.
-  trap 'echo "Not cleaning downloaded Docker images due to error. No files have been downloaded yet."' ERR
-
-  # Pull the nightly Docker images for focal and jammy from Docker Hub, tag
-  # them with the appropriate platform prefix and the x.y.z version number, and
-  # push the tag to Docker Hub.
-  for platform in "${platforms[@]}"; do
-    image="robotlocomotion/drake:${platform}-${binary_version}"
-    tag="robotlocomotion/drake:${platform}-${source_version}"
-
-    docker pull "${image}"
-    docker tag "${image}" "${tag}"
-    docker push "${tag}"
-  done
-
-  image="robotlocomotion/drake:${platform}-${binary_version}"
-  tag="robotlocomotion/drake:${source_version}"
-
-  # Tag the Docker image without a platform prefix them and push the tag to
-  # Docker Hub.
-  docker tag "${image}" "${tag}"
-  docker push "${tag}"
-
-  # Remove the pulled Docker images on success.
-  for platform in "${platforms[@]}"; do
-    docker rmi "robotlocomotion/drake:${platform}-${binary_version}"
-  done
-
-  set +x
-fi
-
 readonly temp_dir="$(mktemp -u)"
 
 mkdir -p "${temp_dir}"
@@ -195,16 +114,16 @@ if [[ "${push_apt}" -ne 0 ]]; then
 
     # Add the Debian package to the aptly database.
     aptly repo add "drake-${platform}" "${filename}"
-    aptly snapshot create "drake-${platform}-${binary_version}" \
+    aptly snapshot create "drake-${platform}-${source_version}" \
       from repo "drake-${platform}"
 
     # Publish the new apt repository to S3.
     aptly publish switch -gpg-key="${gpg_key: -8}" "${platform}" \
-      "s3:drake-apt.csail.mit.edu/${platform}:" "drake-${platform}-${binary_version}"
+      "s3:drake-apt.csail.mit.edu/${platform}:" "drake-${platform}-${source_version}"
 
     # The first time a repository is published use snapshot not switch
     # aptly publish snapshot -gpg-key="${gpg_key: -8}" -distribution="${platform}" \
-    #  "drake-${platform}-${binary_version}" "s3:drake-apt.csail.mit.edu/${platform}:"
+    #  "drake-${platform}-${source_version}" "s3:drake-apt.csail.mit.edu/${platform}:"
 
     # Invalidate the cached apt repository.
     aws cloudfront create-invalidation --distribution-id E2RAGJYS5GNIOS \

--- a/tools/release_engineering/dev/push_release.py
+++ b/tools/release_engineering/dev/push_release.py
@@ -7,6 +7,7 @@ This program is only supported on Ubuntu Jammy 22.04.
 
 import argparse
 import hashlib
+import json
 import os
 import re
 import shutil
@@ -14,10 +15,13 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import urllib.request
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
 import boto3
+
+import docker
 
 import github3
 from github3.repos.release import Asset, Release
@@ -29,7 +33,8 @@ _GITHUB_REPO_NAME = 'drake'
 
 _ARCHIVE_HASHES = {'sha256', 'sha512'}
 
-_DOCKER_PLATFORMS = {'focal', 'jammy'}
+_DOCKER_REGISTRY_API_URI = 'https://registry.hub.docker.com/v2/repositories'
+_DOCKER_REPOSITORY_NAME = 'robotlocomotion/drake'
 
 _AWS_BUCKET = 'drake-packages'
 
@@ -115,8 +120,23 @@ class _State:
         self.manifest = _Manifest(release)
         self._scratch = tempfile.TemporaryDirectory()
         self._s3 = boto3.client('s3')
+        self._docker = docker.APIClient()
 
         self.find_artifacts = self.manifest.find_artifacts
+
+    def _begin(self, action: str, src: str, dst: str = None):
+        """
+        Report the start of an action.
+        """
+        if dst is not None:
+            print(f'{action} {src!r} to {dst!r} ...', flush=True, end='')
+        else:
+            print(f'{action} {src!r} ...', flush=True, end='')
+
+    def _done(self):
+        """
+        Report the completion of an action.
+        """
 
     def _push_asset(self, asset: Asset, bucket: str, path: str):
         """
@@ -201,6 +221,24 @@ class _State:
             else:
                 self._s3.upload_file(hashfile_path, bucket, remote_path)
 
+    def push_docker_tag(self, old_tag_name: str, new_tag_name: str,
+                        repository: str = _DOCKER_REPOSITORY_NAME):
+        image = f'{repository}:{old_tag_name}'
+        if self.options.dry_run:
+            print(f'push {image!r} to {repository!r} as {new_tag_name!r}')
+        else:
+            self._begin('pulling', f'{repository}:{old_tag_name}')
+            self._docker.pull(repository, old_tag_name)
+            self._done()
+
+            self._docker.tag(image, repository, new_tag_name)
+
+            self._begin('pushing', f'{repository}:{new_tag_name}')
+            self._docker.push(repository, new_tag_name)
+            self._done()
+
+            self._docker.remove_image(image)
+
 
 def _fatal(msg: str, result: int = 1):
     width = shutil.get_terminal_size().columns
@@ -264,6 +302,22 @@ def _find_tag(repo: Repository, tag: str):
     return None
 
 
+def _list_docker_tags(repository=_DOCKER_REPOSITORY_NAME):
+    tags = []
+    uri = f'{_DOCKER_REGISTRY_API_URI}/{repository}/tags?page_size=1000'
+
+    while uri is not None:
+        with urllib.request.urlopen(uri) as response:
+            reply = json.load(response)
+
+        for t in reply['results']:
+            tags.append(t['name'])
+
+        uri = reply.get('next')
+
+    return tags
+
+
 def _push_tar(state: _State):
     """
     Downloads .tar artifacts and push them to S3.
@@ -300,6 +354,17 @@ def _push_deb(state: _State):
         state.push_artifact(deb, _AWS_BUCKET, dest_path)
 
 
+def _push_docker(state: _State):
+    """
+    Re-tags Docker staging images as release images.
+    """
+    tail = f'{state.options.source_version}-staging'
+    for tag_name in _list_docker_tags():
+        if tag_name.endswith(tail):
+            release_tag_name = tag_name.rsplit('-', 1)[0]
+            state.push_docker_tag(tag_name, release_tag_name)
+
+
 def main(args: List[str]):
     parser = argparse.ArgumentParser(
         prog='push_release', description=__doc__)
@@ -307,6 +372,10 @@ def main(args: List[str]):
         '--deb', dest='push_deb', default=True,
         action=argparse.BooleanOptionalAction,
         help='Mirror .deb packages to S3.')
+    parser.add_argument(
+        '--docker', dest='push_docker', default=True,
+        action=argparse.BooleanOptionalAction,
+        help='Publish docker images from staging images.')
     parser.add_argument(
         '--tar', dest='push_tar', default=True,
         action=argparse.BooleanOptionalAction,
@@ -367,6 +436,8 @@ def main(args: List[str]):
         _push_tar(state)
     if options.push_deb:
         _push_deb(state)
+    if options.push_docker:
+        _push_docker(state)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Rewrite logic to push the release docker tags in Python, and to rely on the staging tags we are newly creating. This hopefully makes the logic easier to follow, and allows for a dry-run. More importantly, it eliminates the need to associate a release with a nightly build, which we really shouldn't have been doing in the first place, and simplifies things for the release manager.

Also remove an outdated instruction from the README, and change the aptly snapshot to use the source version rather than the corresponding nightly date for the release's snapshot name.

Fixes #19564.

See also RobotLocomotion/drake-ci#227 which added the staging tags. (Also RobotLocomotion/drake-ci#228, RobotLocomotion/drake-ci#229 and RobotLocomotion/drake-ci#230 which fixed the ensuing fallout.)

+@BetsyMcPhail for review, please. (@jwnimmer-tri  may also want to take a look...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19631)
<!-- Reviewable:end -->
