### PR TITLE
Implements MakeSemidefiniteRelaxation

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -68,6 +68,7 @@ drake_pybind_library(
         "solvers_py_osqp.cc",
         "solvers_py_scs.cc",
         "solvers_py_sdpa_free_format.cc",
+        "solvers_py_semidefinite_relaxation.cc",
         "solvers_py_snopt.cc",
         "solvers_py_unrevised_lemke.cc",
     ],
@@ -261,6 +262,14 @@ drake_py_unittest(
 
 drake_py_unittest(
     name = "sdpa_free_format_test",
+    deps = [
+        ":solvers",
+        "//bindings/pydrake/common/test_utilities",
+    ],
+)
+
+drake_py_unittest(
+    name = "semidefinite_relaxation_test",
     deps = [
         ":solvers",
         "//bindings/pydrake/common/test_utilities",

--- a/bindings/pydrake/solvers/solvers_py.cc
+++ b/bindings/pydrake/solvers/solvers_py.cc
@@ -24,6 +24,7 @@ top-level documentation for :py:mod:`pydrake.math`.
   internal::DefineSolversMixedIntegerOptimizationUtil(m);
   internal::DefineSolversMixedIntegerRotationConstraint(m);
   internal::DefineSolversSdpaFreeFormat(m);
+  internal::DefineSolversSemidefiniteRelaxation(m);
   internal::DefineSolversClp(m);
   internal::DefineSolversCsdp(m);
   internal::DefineSolversGurobi(m);

--- a/bindings/pydrake/solvers/solvers_py.h
+++ b/bindings/pydrake/solvers/solvers_py.h
@@ -60,6 +60,9 @@ void DefineSolversScs(py::module m);
 /* Defines bindings per solvers_py_sdpa_free_format.cc. */
 void DefineSolversSdpaFreeFormat(py::module m);
 
+/* Defines bindings per solvers_py_semidefinite_relaxation.cc. */
+void DefineSolversSemidefiniteRelaxation(py::module m);
+
 /* Defines the SNOPT bindings. See solvers_py_snopt.cc. */
 void DefineSolversSnopt(py::module m);
 

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1471,6 +1471,14 @@ for every column of ``prog_var_vals``. )""")
           py::arg("binding"), py::arg("prog_var_vals"),
           doc.MathematicalProgram.EvalBinding.doc)
       .def(
+          "EvalBindingAtInitialGuess",
+          [](const MathematicalProgram& prog,
+              const Binding<EvaluatorBase>& binding) {
+            return prog.EvalBindingAtInitialGuess(binding);
+          },
+          py::arg("binding"),
+          doc.MathematicalProgram.EvalBindingAtInitialGuess.doc)
+      .def(
           "EvalBindings",
           [](const MathematicalProgram& prog,
               const std::vector<Binding<EvaluatorBase>>& binding,

--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -1,0 +1,21 @@
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/solvers/solvers_py.h"
+#include "drake/solvers/semidefinite_relaxation.h"
+
+namespace drake {
+namespace pydrake {
+namespace internal {
+
+void DefineSolversSemidefiniteRelaxation(py::module m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::solvers;
+  constexpr auto& doc = pydrake_doc.drake.solvers;
+
+  m.def("MakeSemidefiniteRelaxation", &solvers::MakeSemidefiniteRelaxation,
+      py::arg("prog"), doc.MakeSemidefiniteRelaxation.doc);
+}
+
+}  // namespace internal
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -1,0 +1,24 @@
+import numpy as np
+import unittest
+
+from pydrake.solvers import (
+    MakeSemidefiniteRelaxation,
+    MathematicalProgram,
+)
+
+
+class TestSemidefiniteRelaxation(unittest.TestCase):
+    def test_MakeSemidefiniteRelaxation(self):
+        prog = MathematicalProgram()
+        y = prog.NewContinuousVariables(2, "y")
+        A = np.array([[0.5, 0.7], [-.2, 0.4], [-2.3, -4.5]])
+        lb = np.array([1.3, -.24, 0.25])
+        ub = np.array([5.6, 0.1, 1.4])
+        prog.AddLinearConstraint(A, lb, ub, y)
+        relaxation = MakeSemidefiniteRelaxation(prog)
+
+        self.assertEqual(relaxation.num_vars(), 6)
+        self.assertEqual(len(relaxation.positive_semidefinite_constraints()),
+                         1)
+        self.assertEqual(len(relaxation.bounding_box_constraints()), 1)
+        self.assertEqual(len(relaxation.linear_constraints()), 2)

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -61,6 +61,7 @@ drake_cc_package_library(
         ":rotation_constraint",
         ":scs_solver",
         ":sdpa_free_format",
+        ":semidefinite_relaxation",
         ":snopt_solver",
         ":solution_result",
         ":solve",
@@ -961,6 +962,16 @@ drake_cc_library(
     deps = [],
 )
 
+drake_cc_library(
+    name = "semidefinite_relaxation",
+    srcs = ["semidefinite_relaxation.cc"],
+    hdrs = ["semidefinite_relaxation.h"],
+    interface_deps = [
+        ":mathematical_program",
+    ],
+    deps = [],
+)
+
 drake_cc_optional_library(
     name = "csdp_solver_error_handling",
     opt_out_condition = "//tools:no_csdp",
@@ -1137,6 +1148,15 @@ drake_cc_googletest(
         ":csdp_test_examples",
         ":sdpa_free_format",
         "//common:temp_directory",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "semidefinite_relaxation_test",
+    deps = [
+        ":semidefinite_relaxation",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
     ],

--- a/solvers/semidefinite_relaxation.cc
+++ b/solvers/semidefinite_relaxation.cc
@@ -1,0 +1,224 @@
+#include "drake/solvers/semidefinite_relaxation.h"
+
+#include <initializer_list>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/ssize.h"
+#include "drake/common/text_logging.h"
+#include "drake/solvers/program_attribute.h"
+
+namespace drake {
+namespace solvers {
+
+using Eigen::MatrixXd;
+using Eigen::SparseMatrix;
+using Eigen::Triplet;
+using Eigen::VectorXd;
+using symbolic::Expression;
+using symbolic::Variable;
+
+namespace {
+
+const double kInf = std::numeric_limits<double>::infinity();
+
+}  // namespace
+
+std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
+    const MathematicalProgram& prog) {
+  std::string unsupported_message{};
+  const ProgramAttributes supported_attributes(
+      std::initializer_list<ProgramAttribute>{
+          ProgramAttribute::kLinearCost, ProgramAttribute::kQuadraticCost,
+          ProgramAttribute::kLinearConstraint,
+          ProgramAttribute::kLinearEqualityConstraint,
+          ProgramAttribute::kQuadraticConstraint});
+  if (!AreRequiredAttributesSupported(prog.required_capabilities(),
+                                      supported_attributes,
+                                      &unsupported_message)) {
+    throw std::runtime_error(fmt::format(
+        "MakeSemidefiniteRelaxation() does not (yet) support this program: {}.",
+        unsupported_message));
+  }
+
+  auto relaxation = std::make_unique<MathematicalProgram>();
+
+  // Build a symmetric matrix X of decision variables using the original
+  // program variables (so that GetSolution, etc, works using the original
+  // variables).
+  relaxation->AddDecisionVariables(prog.decision_variables());
+  MatrixX<Variable> X(prog.num_vars() + 1, prog.num_vars() + 1);
+  // X = xxᵀ; x = [prog.decision_vars(); 1].
+  X.topLeftCorner(prog.num_vars(), prog.num_vars()) =
+      relaxation->NewSymmetricContinuousVariables(prog.num_vars(), "Y");
+  X.topRightCorner(prog.num_vars(), 1) = prog.decision_variables();
+  X.bottomLeftCorner(1, prog.num_vars()) =
+      prog.decision_variables().transpose();
+  // X(-1,-1) = 1.
+  Variable one("one");
+  X(prog.num_vars(), prog.num_vars()) = one;
+  relaxation->AddDecisionVariables(Vector1<Variable>(one));
+  relaxation->AddBoundingBoxConstraint(1, 1,
+                                       X(prog.num_vars(), prog.num_vars()));
+  // X ≽ 0.
+  relaxation->AddPositiveSemidefiniteConstraint(X);
+
+  auto x = X.col(prog.num_vars());
+
+  // Returns the {a, vars} in relaxation, such that a' vars = 0.5*tr(QY). This
+  // assumes Q=Q', which is ensured by QuadraticCost and QuadraticConstraint.
+  auto half_trace_QY = [&X, &prog](const Eigen::MatrixXd& Q,
+                                   const VectorXDecisionVariable& prog_vars)
+      -> std::pair<VectorXd, VectorX<Variable>> {
+    const int N = prog_vars.size();
+    const int num_vars = N * (N + 1) / 2;
+    const std::vector<int> indices =
+        prog.FindDecisionVariableIndices(prog_vars);
+    VectorXd a = VectorXd::Zero(num_vars);
+    VectorX<Variable> y(num_vars);
+    int count = 0;
+    for (int i = 0; i < N; ++i) {
+      for (int j = 0; j <= i; ++j) {
+        // tr(QY) = ∑ᵢ ∑ⱼ Qᵢⱼ Yⱼᵢ.
+        a[count] = ((i == j) ? 0.5 : 1.0) * Q(i, j);
+        y[count] = X(indices[i], indices[j]);
+        ++count;
+      }
+    }
+    return {a, y};
+  };
+
+  // Linear costs => Linear costs.
+  for (const auto& binding : prog.linear_costs()) {
+    relaxation->AddCost(binding);
+  }
+  // Quadratic costs.
+  // 0.5 y'Qy + b'y + c => 0.5 tr(QY) + b'y + c
+  for (const auto& binding : prog.quadratic_costs()) {
+    const int N = binding.variables().size();
+    const int num_vars = N + (N * (N + 1) / 2);
+    std::pair<VectorXd, VectorX<Variable>> quadratic_terms =
+        half_trace_QY(binding.evaluator()->Q(), binding.variables());
+    VectorXd a(num_vars);
+    VectorX<Variable> vars(num_vars);
+    a << quadratic_terms.first, binding.evaluator()->b();
+    vars << quadratic_terms.second, binding.variables();
+    relaxation->AddLinearCost(a, binding.evaluator()->c(), vars);
+  }
+
+  {  // Linear constraints.
+    // lb ≤ Ay ≤ ub => lb ≤ Ay ≤ ub
+    for (const auto& binding : prog.linear_constraints()) {
+      relaxation->AddConstraint(binding);
+    }
+
+    // Now assemble one big Ay <= b matrix.
+    int num_constraints = 0;
+    int nnz = 0;
+    for (const auto& binding : prog.linear_constraints()) {
+      for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
+        if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
+          ++num_constraints;
+        }
+        if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
+          ++num_constraints;
+        }
+      }
+      nnz += binding.evaluator()->get_sparse_A().nonZeros();
+    }
+    std::vector<Triplet<double>> triplet_list;
+    triplet_list.reserve(nnz);
+    SparseMatrix<double> A(num_constraints, prog.num_vars());
+    VectorXd b(num_constraints);
+    int constraint = 0;
+    for (const auto& binding : prog.linear_constraints()) {
+      const std::vector<int> indices =
+          prog.FindDecisionVariableIndices(binding.variables());
+      // TODO(hongkai-dai): Consider using the SparseMatrix iterators.
+      for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
+        if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
+          for (int j = 0; j < binding.evaluator()->num_vars(); ++j) {
+            if (binding.evaluator()->get_sparse_A().coeff(i, j) != 0) {
+              triplet_list.push_back(Triplet<double>(
+                  constraint, indices[j],
+                  -binding.evaluator()->get_sparse_A().coeff(i, j)));
+            }
+          }
+          b(constraint++) = -binding.evaluator()->lower_bound()[i];
+        }
+        if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
+          for (int j = 0; j < binding.evaluator()->num_vars(); ++j) {
+            if (binding.evaluator()->get_sparse_A().coeff(i, j) != 0) {
+              triplet_list.push_back(Triplet<double>(
+                  constraint, indices[j],
+                  binding.evaluator()->get_sparse_A().coeff(i, j)));
+            }
+          }
+          b(constraint++) = binding.evaluator()->upper_bound()[i];
+        }
+      }
+    }
+    A.setFromTriplets(triplet_list.begin(), triplet_list.end());
+
+    // 0 ≤ (Ay-b)(Ay-b)ᵀ, implemented with
+    // -bbᵀ ≤ AYAᵀ - b(Ay)ᵀ - (Ay)bᵀ.
+    // TODO(russt): Avoid the symbolic computation here.
+    // TODO(russt): Avoid the dense matrix.
+    // TODO(russt): Only add the lower triangular constraints
+    // (MathematicalProgram::AddLinearEqualityConstraint has this option, but
+    // AddLinearConstraint does not yet).
+    const MatrixX<Expression> AYAT =
+        A * X.topLeftCorner(prog.num_vars(), prog.num_vars()) * A.transpose();
+    const VectorX<Variable> y = x.head(prog.num_vars());
+    relaxation->AddLinearConstraint(
+        AYAT - b * (A * y).transpose() - A * y * b.transpose(),
+        -b * b.transpose(),
+        MatrixXd::Constant(num_constraints, num_constraints, kInf));
+  }
+
+  // Linear equality constraints.
+  // Ay = b => (Ay-b)xᵀ = Ayxᵀ - bxᵀ = 0.
+  // Note that this contains Ay=b since x contains 1.
+  for (const auto& binding : prog.linear_equality_constraints()) {
+    const int N = binding.variables().size();
+    const std::vector<int> indices =
+        prog.FindDecisionVariableIndices(binding.variables());
+    VectorX<Variable> vars(N + 1);
+    // Add the constraints one column at a time:
+    // Ayx_j - bx_j = 0.
+    MatrixX<double> Ab(binding.evaluator()->num_constraints(), N + 1);
+    Ab.leftCols(N) = binding.evaluator()->GetDenseA();
+    Ab.col(N) = -binding.evaluator()->lower_bound();
+    for (int j = 0; j < static_cast<int>(x.size()); ++j) {
+      for (int i = 0; i < N; ++i) {
+        vars[i] = X(indices[i], j);
+      }
+      vars[N] = x[j];
+      relaxation->AddLinearEqualityConstraint(
+          Ab, VectorXd::Zero(binding.evaluator()->num_constraints()), vars);
+    }
+  }
+
+  // Quadratic constraints.
+  // lb ≤ 0.5 y'Qy + b'y ≤ ub => lb ≤ 0.5 tr(QY) + b'y ≤ ub
+  for (const auto& binding : prog.quadratic_constraints()) {
+    const int N = binding.variables().size();
+    const int num_vars = N + (N * (N + 1) / 2);
+    std::pair<VectorXd, VectorX<Variable>> quadratic_terms =
+        half_trace_QY(binding.evaluator()->Q(), binding.variables());
+    VectorXd a(num_vars);
+    VectorX<Variable> vars(num_vars);
+    a << quadratic_terms.first, binding.evaluator()->b();
+    vars << quadratic_terms.second, binding.variables();
+    relaxation->AddLinearConstraint(a.transpose(),
+                                    binding.evaluator()->lower_bound(),
+                                    binding.evaluator()->upper_bound(), vars);
+  }
+
+  return relaxation;
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+
+// TODO(russt): Add an option for using diagonal dominance and/or
+// scaled-diagonal dominance instead of the PSD constraint.
+
+// TODO(russt): Consider adding Y as an optional argument return value, to help
+// users know the decision variables associated with Y.
+
+/** Constructs a new MathematicalProgram which represents the semidefinite
+ programming convex relaxation of the (likely nonconvex) program `prog`. This
+ method currently supports only linear and quadratic costs and constraints, but
+ may be extended in the future with broader support.
+
+ See https://underactuated.mit.edu/optimization.html#sdp_relaxation for
+ references and examples.
+
+ @throws std::exception if `prog` has costs and constraints which are not
+ linear nor quadratic.
+ */
+std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
+    const MathematicalProgram& prog);
+
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -1,0 +1,258 @@
+#include "drake/solvers/semidefinite_relaxation.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace solvers {
+namespace internal {
+
+using Eigen::Matrix2d;
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using symbolic::Variable;
+
+void SetRelaxationInitialGuess(const Eigen::Ref<const VectorXd>& y_expected,
+                               MathematicalProgram* relaxation) {
+  const int N = y_expected.size() + 1;
+  MatrixX<Variable> X = Eigen::Map<const MatrixX<Variable>>(
+      relaxation->positive_semidefinite_constraints()[0].variables().data(), N,
+      N);
+  VectorXd x_expected(N);
+  x_expected << y_expected, 1;
+  const MatrixXd X_expected = x_expected * x_expected.transpose();
+  relaxation->SetInitialGuess(X, X_expected);
+}
+
+GTEST_TEST(MakeSemidefiniteRelaxationTest, NoCostsNorConstraints) {
+  MathematicalProgram prog;
+  const auto y = prog.NewContinuousVariables<2>("y");
+  const auto relaxation = MakeSemidefiniteRelaxation(prog);
+
+  // X is 3x3 symmetric.
+  EXPECT_EQ(relaxation->num_vars(), 6);
+  // X ≽ 0.
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  // X(-1,-1) = 1.
+  EXPECT_EQ(relaxation->bounding_box_constraints().size(), 1);
+}
+
+GTEST_TEST(MakeSemidefiniteRelaxationTest, UnsupportedCost) {
+  MathematicalProgram prog;
+  const auto y = prog.NewContinuousVariables<2>("y");
+  prog.AddCost(sin(y[0]));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MakeSemidefiniteRelaxation(prog),
+      ".*GenericCost was declared but is not supported.");
+}
+
+GTEST_TEST(MakeSemidefiniteRelaxationTest, UnsupportedConstraint) {
+  MathematicalProgram prog;
+  const auto y = prog.NewContinuousVariables<2>("y");
+  prog.AddConstraint(sin(y[0]) >= 0.2);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MakeSemidefiniteRelaxation(prog),
+      ".*GenericConstraint was declared but is not supported.");
+}
+
+GTEST_TEST(MakeSemidefiniteRelaxationTest, LinearCost) {
+  MathematicalProgram prog;
+  const auto y = prog.NewContinuousVariables<2>("y");
+  const Vector2d a(0.5, 0.7);
+  const double b = 1.3;
+  prog.AddLinearCost(a, b, y);
+  auto relaxation = MakeSemidefiniteRelaxation(prog);
+
+  EXPECT_EQ(relaxation->num_vars(), 6);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(relaxation->bounding_box_constraints().size(), 1);
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+
+  const Vector2d y_test(1.3, 0.24);
+  SetRelaxationInitialGuess(y_test, relaxation.get());
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(relaxation->linear_costs()[0])[0],
+      a.transpose() * y_test + b, 1e-12);
+
+  // Confirm that the decision variables of prog are also decision variables of
+  // the relaxation.
+  std::vector<int> indices = relaxation->FindDecisionVariableIndices(y);
+  EXPECT_EQ(indices.size(), 2);
+}
+
+GTEST_TEST(MakeSemidefiniteRelaxationTest, QuadraticCost) {
+  MathematicalProgram prog;
+  const auto y = prog.NewContinuousVariables<2>("y");
+  const Vector2d yd(0.5, 0.7);
+  prog.AddQuadraticErrorCost(Matrix2d::Identity(), yd, y);
+  auto relaxation = MakeSemidefiniteRelaxation(prog);
+
+  EXPECT_EQ(relaxation->num_vars(), 6);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(relaxation->bounding_box_constraints().size(), 1);
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+
+  SetRelaxationInitialGuess(yd, relaxation.get());
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(relaxation->linear_costs()[0])[0],
+      0, 1e-12);
+}
+
+GTEST_TEST(MakeSemidefiniteRelaxationTest, LinearConstraint) {
+  MathematicalProgram prog;
+  const auto y = prog.NewContinuousVariables<2>("y");
+  MatrixXd A0(3, 2);
+  A0 << 0.5, 0.7, -0.2, 0.4, -2.3, -4.5;
+  const double kInf = std::numeric_limits<double>::infinity();
+  const Vector3d lb0(1.3, -kInf, 0.25);
+  const Vector3d ub0(5.6, 0.1, kInf);
+  prog.AddLinearConstraint(A0, lb0, ub0, y);
+  Matrix2d A1;
+  A1 << 0.2, 1.2, 0.24, -0.1;
+  const Vector2d lb1(-0.74, -0.3);
+  const Vector2d ub1(-0.75, 0.9);
+  prog.AddLinearConstraint(A1, lb1, ub1, Vector2<Variable>(y[1], y[0]));
+  Matrix2d A1_reordered;
+  A1_reordered.col(0) = A1.col(1);
+  A1_reordered.col(1) = A1.col(0);
+
+  auto relaxation = MakeSemidefiniteRelaxation(prog);
+
+  EXPECT_EQ(relaxation->num_vars(), 6);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(relaxation->bounding_box_constraints().size(), 1);
+  EXPECT_EQ(relaxation->linear_constraints().size(), 3);
+
+  const Vector2d y_test(1.3, 0.24);
+  SetRelaxationInitialGuess(y_test, relaxation.get());
+
+  // First linear constraint is lb0 ≤ A0y ≤ ub0.
+  EXPECT_TRUE(CompareMatrices(
+      A0, relaxation->linear_constraints()[0].evaluator()->GetDenseA()));
+  EXPECT_TRUE(CompareMatrices(
+      lb0, relaxation->linear_constraints()[0].evaluator()->lower_bound()));
+  EXPECT_TRUE(CompareMatrices(
+      ub0, relaxation->linear_constraints()[0].evaluator()->upper_bound()));
+
+  // Second linear constraint is lb1 ≤ A1 y ≤ ub1.
+  EXPECT_TRUE(CompareMatrices(
+      A1, relaxation->linear_constraints()[1].evaluator()->GetDenseA()));
+  EXPECT_TRUE(CompareMatrices(
+      lb1, relaxation->linear_constraints()[1].evaluator()->lower_bound()));
+  EXPECT_TRUE(CompareMatrices(
+      ub1, relaxation->linear_constraints()[1].evaluator()->upper_bound()));
+
+  // Third linear (in the new decision variables) constraint is 0 ≤
+  // (Ay-b)(Ay-b)ᵀ, where A and b represent all of the constraints stacked.
+  VectorXd b(8);  // all of the finite lower/upper bounds.
+  b << -lb0[0], ub0[0], ub0[1], -lb0[2], -lb1[0], ub1[0], -lb1[1], ub1[1];
+  MatrixXd A(8, 2);
+  A << -A0.row(0), A0.row(0), A0.row(1), -A0.row(2), -A1_reordered.row(0),
+      A1_reordered.row(0), -A1_reordered.row(1), A1_reordered.row(1);
+  EXPECT_EQ(relaxation->linear_constraints()[2].evaluator()->num_constraints(),
+            b.size() * b.size());
+  VectorXd value = relaxation->EvalBindingAtInitialGuess(
+      relaxation->linear_constraints()[2]);
+  MatrixXd expected = (A * y_test - b) * (A * y_test - b).transpose() -
+                      b * b.transpose();
+  EXPECT_TRUE(CompareMatrices(Eigen::Map<MatrixXd>(value.data(), 8, 8),
+                              expected, 1e-12));
+  value = relaxation->linear_constraints()[2].evaluator()->lower_bound();
+  expected = -b * b.transpose();
+  EXPECT_TRUE(CompareMatrices(Eigen::Map<MatrixXd>(value.data(), 8, 8),
+                              expected, 1e-12));
+}
+
+GTEST_TEST(MakeSemidefiniteRelaxationTest, LinearEqualityConstraint) {
+  MathematicalProgram prog;
+  const auto y = prog.NewContinuousVariables<2>("y");
+  MatrixXd A(3, 2);
+  A << 0.5, 0.7, -0.2, 0.4, -2.3, -4.5;
+  const Vector3d b(1.3, -0.24, 0.25);
+  prog.AddLinearEqualityConstraint(A, b, y);
+  auto relaxation = MakeSemidefiniteRelaxation(prog);
+
+  EXPECT_EQ(relaxation->num_vars(), 6);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(relaxation->bounding_box_constraints().size(), 1);
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 3);
+
+  const Vector2d y_test(1.3, 0.24);
+  SetRelaxationInitialGuess(y_test, relaxation.get());
+
+  for (int i = 0; i < 2; ++i) {
+    // Linear constraints are (Ay - b)*y_i = 0.
+    MatrixXd expected = (A * y_test - b) * y_test[i];
+    VectorXd value = relaxation->EvalBindingAtInitialGuess(
+        relaxation->linear_equality_constraints()[i]);
+    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  }
+  // Last constraint is (Ay-b)=0.
+  MatrixXd expected = A * y_test - b;
+  VectorXd value = relaxation->EvalBindingAtInitialGuess(
+      relaxation->linear_equality_constraints()[2]);
+  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+}
+
+GTEST_TEST(MakeSemidefiniteRelaxationTest, QuadraticConstraint) {
+  MathematicalProgram prog;
+  const auto y = prog.NewContinuousVariables<2>("y");
+  Matrix2d Q;
+  Q << 1, 2, 3, 4;
+  const Vector2d b(0.2, 0.4);
+  const double lb = -.4, ub = 0.5;
+  prog.AddQuadraticConstraint(Q, b, lb, ub, y);
+  auto relaxation = MakeSemidefiniteRelaxation(prog);
+
+  EXPECT_EQ(relaxation->num_vars(), 6);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(relaxation->bounding_box_constraints().size(), 1);
+  EXPECT_EQ(relaxation->linear_constraints().size(), 1);
+
+  const Vector2d y_test(1.3, 0.24);
+  SetRelaxationInitialGuess(y_test, relaxation.get());
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(
+          relaxation->linear_constraints()[0])[0],
+      (0.5 * y_test.transpose() * Q * y_test + b.transpose() * y_test)[0],
+      1e-12);
+
+  EXPECT_EQ(relaxation->linear_constraints()[0].evaluator()->lower_bound()[0],
+            lb);
+  EXPECT_EQ(relaxation->linear_constraints()[0].evaluator()->upper_bound()[0],
+            ub);
+}
+
+// This test checks that repeated variables in a quadratic constraint are
+// handled correctly.
+GTEST_TEST(MakeSemidefiniteRelaxationTest, QuadraticConstraint2) {
+  MathematicalProgram prog;
+  const auto y = prog.NewContinuousVariables<1>("y");
+  prog.AddQuadraticConstraint(Eigen::Matrix2d::Ones(), Eigen::Vector2d::Zero(),
+                              0, 1, Vector2<Variable>(y(0), y(0)));
+  auto relaxation = MakeSemidefiniteRelaxation(prog);
+
+  EXPECT_EQ(relaxation->num_vars(), 3);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(relaxation->bounding_box_constraints().size(), 1);
+  EXPECT_EQ(relaxation->linear_constraints().size(), 1);
+
+  const Vector1d y_test(1.3);
+  SetRelaxationInitialGuess(y_test, relaxation.get());
+  EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
+                  relaxation->linear_constraints()[0])[0],
+              2 * y_test(0) * y_test(0), 1e-12);
+  EXPECT_EQ(relaxation->linear_constraints()[0].evaluator()->lower_bound()[0],
+            0.0);
+  EXPECT_EQ(relaxation->linear_constraints()[0].evaluator()->upper_bound()[0],
+            1.0);
+}
+
+}  // namespace internal
+}  // namespace solvers
+}  // namespace drake


### PR DESCRIPTION
Given a (typically nonconvex) MathematicalProgram, this method constructs a new MathematicalProgram which implements the SDP relaxation of the original program.

This initial implementation supports the case of quadratic objectives and constraints; it's an extremely important (and quite general) case.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19632)
<!-- Reviewable:end -->
