### PR TITLE
MathematicalProgram::AddConstraint parses QuadraticConstraint

### DIFF
--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -543,8 +543,10 @@ class EvaluatorConstraint : public Constraint {
 /**
  * A constraint on the values of multivariate polynomials.
  *
- *  lb[i] <= P[i](x, y...) <= ub[i], where each P[i] is a multivariate
- *  polynomial in x, y...
+ * @verbatim
+ * lb[i] ≤ P[i](x, y...) ≤ ub[i],
+ * @endverbatim
+ * where each P[i] is a multivariate polynomial in x, y...
  *
  * The Polynomial class uses a different variable naming scheme; thus the
  * caller must provide a list of Polynomial::VarType variables that correspond

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -38,6 +38,14 @@ Binding<Constraint> ParseConstraint(
   DRAKE_ASSERT(v.rows() == lb.rows() && v.rows() == ub.rows());
 
   if (!IsAffine(v)) {
+    // Quadratic constraints.
+    if (v.size() == 1 && v[0].is_polynomial()) {
+      const symbolic::Polynomial poly{v[0]};
+      if (poly.TotalDegree() == 2) {
+        return ParseQuadraticConstraint(v[0], lb[0], ub[0]);
+      }
+    }
+
     auto constraint = make_shared<ExpressionConstraint>(v, lb, ub);
     return CreateBinding(constraint, constraint->vars());
   }  // else, continue on to linear-specific version below.

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1305,9 +1305,9 @@ class MathematicalProgram {
    * @param ub A scalar, the upper bound.
    *
    * The resulting constraint may be a BoundingBoxConstraint, LinearConstraint,
-   * LinearEqualityConstraint, or ExpressionConstraint, depending on the
-   * arguments.  Constraints of the form x == 1 (which could be created as a
-   * BoundingBoxConstraint or LinearEqualityConstraint) will be
+   * LinearEqualityConstraint, QuadraticConstraint, or ExpressionConstraint,
+   * depending on the arguments.  Constraints of the form x == 1 (which could
+   * be created as a BoundingBoxConstraint or LinearEqualityConstraint) will be
    * constructed as a LinearEqualityConstraint.
    */
   Binding<Constraint> AddConstraint(const symbolic::Expression& e, double lb,


### PR DESCRIPTION
Previously, a quadratic constraint passes to AddConstraint would default to an ExpressionConstraint.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19633)
<!-- Reviewable:end -->
