### PR TITLE
[py autodiff] Handle empty derivatives in pydrake.forwarddiff.jacobian.

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -441,6 +441,7 @@ drake_py_unittest(
     name = "forward_diff_test",
     deps = [
         ":autodiffutils_py",
+        ":math_py",
         "//bindings/pydrake/common/test_utilities",
     ],
 )

--- a/bindings/pydrake/forwarddiff.py
+++ b/bindings/pydrake/forwarddiff.py
@@ -53,8 +53,13 @@ def jacobian(function, x):
         der[i] = 1
         x_ad.flat[i] = AutoDiffXd(x.flat[i], der)
     y_ad = np.asarray(function(x_ad))
+    # An AutoDiffXd variable with empty derivatives should be treated as
+    # having all zero derivatives. Checking the length of the derivatives
+    # vector, and replacing it with all zeros ensures np.vstack doesn't
+    # throw an error when the shapes don't line up.
     return np.vstack(
-        [y.derivatives() for y in y_ad.flat]).reshape(y_ad.shape + (-1,))
+        [y.derivatives() if len(y.derivatives()) > 0 else np.zeros(x.size)
+            for y in y_ad.flat]).reshape(y_ad.shape + (-1,))
 
 
 # Method overloads:

--- a/bindings/pydrake/test/forward_diff_test.py
+++ b/bindings/pydrake/test/forward_diff_test.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 from pydrake.forwarddiff import sin, cos, derivative, gradient, jacobian
 from pydrake.common.test_utilities import numpy_compare
+import pydrake.math as drake_math
 
 
 class TestForwardDiff(unittest.TestCase):
@@ -83,6 +84,21 @@ class TestForwardDiff(unittest.TestCase):
         numpy_compare.assert_equal(jacobian(f, x), df(x))
         numpy_compare.assert_equal(jacobian(g_vector, x), dg_vector(x))
         numpy_compare.assert_equal(jacobian(g_matrix, x), dg_matrix(x))
+
+    def test_jacobian_derivative_shape(self):
+        # Test that jacobian can handle AutoDiffXd entries with
+        # empty derivative vectors.
+
+        x = [0., 2.]
+
+        def f(q):
+            # The math.min function will have empty derivatives when
+            # it promotes the constant.
+            return np.array([q[0], drake_math.min(q[1], 1), q[1]])
+
+        expected_jacobian = np.array([[1., 0.], [0., 0.], [0., 1.]])
+
+        numpy_compare.assert_equal(jacobian(f, x), expected_jacobian)
 
     def test_gradient_api_negative(self):
         def f_good(x):


### PR DESCRIPTION
Resolves #19584

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19638)
<!-- Reviewable:end -->
