### PR TITLE
[py solvers] Add more MixedIntegerBranchAndBound::Options bindings

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -45,6 +45,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_pybind",
+        "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:value_pybind",
     ],
     cc_so_name = "__init__",

--- a/bindings/pydrake/solvers/solvers_py_branch_and_bound.cc
+++ b/bindings/pydrake/solvers/solvers_py_branch_and_bound.cc
@@ -1,3 +1,4 @@
+#include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
@@ -17,12 +18,15 @@ void DefineSolversBranchAndBound(py::module m) {
     constexpr auto& cls_doc = doc.MixedIntegerBranchAndBound;
     py::class_<Class> bnb_cls(m, "MixedIntegerBranchAndBound", cls_doc.doc);
 
-    py::class_<MixedIntegerBranchAndBound::Options>(
-        bnb_cls, "Options", cls_doc.Options.doc)
-        .def(py::init<>(), cls_doc.Options.ctor.doc)
-        .def_readwrite("max_explored_nodes",
-            &MixedIntegerBranchAndBound::Options::max_explored_nodes,
-            cls_doc.Options.max_explored_nodes.doc);
+    {
+      using Nested = MixedIntegerBranchAndBound::Options;
+      constexpr auto& options_doc = cls_doc.Options;
+      py::class_<Nested> options_cls(bnb_cls, "Options", options_doc.doc);
+      options_cls.def(ParamInit<Nested>());
+      DefAttributesUsingSerialize(&options_cls, options_doc);
+      DefReprUsingSerialize(&options_cls);
+      DefCopyAndDeepCopy(&options_cls);
+    }
 
     bnb_cls
         .def(py::init<const MathematicalProgram&, const SolverId&,

--- a/bindings/pydrake/solvers/test/branch_and_bound_test.py
+++ b/bindings/pydrake/solvers/test/branch_and_bound_test.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 import numpy as np
@@ -45,8 +46,13 @@ class TestMixedIntegerBranchAndBound(unittest.TestCase):
         self.assertAlmostEqual(x1_solutions[0], 0.0)
         self.assertAlmostEqual(x1_solutions[1], 0.5)
 
-        options = MixedIntegerBranchAndBound.Options()
+        MixedIntegerBranchAndBound.Options()
+        options = MixedIntegerBranchAndBound.Options(max_explored_nodes=22)
         options.max_explored_nodes = 1
+        self.assertEqual(options.max_explored_nodes, 1)
+        self.assertIn("max_explored_nodes=", repr(options))
+        copy.copy(options)
+
         dut2 = MixedIntegerBranchAndBound(
             prog=prog, solver_id=OsqpSolver().solver_id(), options=options)
         solution_result = dut2.Solve()

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -418,6 +418,7 @@ drake_cc_library(
     interface_deps = [
         ":mathematical_program",
         ":mathematical_program_result",
+        "//common:name_value",
     ],
     deps = [
         ":choose_best_solver",

--- a/solvers/branch_and_bound.h
+++ b/solvers/branch_and_bound.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "drake/common/name_value.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mathematical_program_result.h"
 
@@ -279,12 +280,21 @@ class MixedIntegerBranchAndBound {
     kMinLowerBound,  ///< Pick the node with the smallest optimal cost.
   };
 
+  /** Configuration settings for the MixedIntegerBranchAndBound constructor. */
   struct Options {
     Options() {}
-    // The maximal number of explored nodes in the tree. The branch and bound
-    // process will terminate if the tree has explored this number of nodes.
-    // max_explored_nodes <= 0 means that we don't put an upper bound on
-    // the number of explored nodes.
+
+    /** Passes this object to an Archive.
+    Refer to @ref yaml_serialization "YAML Serialization" for background. */
+    template <typename Archive>
+    void Serialize(Archive* a) {
+      a->Visit(DRAKE_NVP(max_explored_nodes));
+    }
+
+    /** The maximal number of explored nodes in the tree. The branch and bound
+     * process will terminate if the tree has explored this number of nodes.
+     * max_explored_nodes <= 0 means that we don't put an upper bound on the
+     * number of explored nodes. */
     int max_explored_nodes{-1};
   };
 
@@ -653,7 +663,7 @@ class MixedIntegerBranchAndBound {
   // The root node of the tree.
   std::unique_ptr<MixedIntegerBranchAndBoundNode> root_;
 
-  MixedIntegerBranchAndBound::Options options_;
+  Options options_;
 
   // We re-created the decision variables in the optimization program in the
   // branch-and-bound. All nodes uses the same new set of decision variables,


### PR DESCRIPTION
In particular, we need `repr()` to remove hex spam from our API reference:
https://drake.mit.edu/pydrake/pydrake.solvers.html#pydrake.solvers.MixedIntegerBranchAndBound

Before: 
![image](https://github.com/RobotLocomotion/drake/assets/17596505/8ea2ead2-63fa-4725-8437-91e4045fc35a)

After:
![image](https://github.com/RobotLocomotion/drake/assets/17596505/0700c1b6-7d1b-4259-814c-06c667cdd884)

Amends #19366.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19639)
<!-- Reviewable:end -->
