### PR TITLE
[geometry] Clean up meshcat tests for maintainability

### DIFF
--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -33,72 +33,79 @@ using math::RotationMatrixd;
 int do_main() {
   auto meshcat = std::make_shared<Meshcat>();
 
-  Vector3d sphere_home{-4, 0, 0};
-  meshcat->SetObject("sphere", Sphere(.25), Rgba(1.0, 0, 0, 1));
+  // For every two items we add to the initial array, decrement start_x by one
+  // to keep things centered.
+  // Use ++x as the x-position of new items.
+  const double start_x = -8;
+  double x = start_x;
+
+  Vector3d sphere_home{++x, 0, 0};
+  meshcat->SetObject("sphere", Sphere(0.25), Rgba(1.0, 0, 0, 1));
   meshcat->SetTransform("sphere", RigidTransformd(sphere_home));
 
-  meshcat->SetObject("cylinder", Cylinder(.25, .5), Rgba(0.0, 1.0, 0, 1));
-  meshcat->SetTransform("cylinder", RigidTransformd(Vector3d{-3, 0, 0}));
+  meshcat->SetObject("cylinder", Cylinder(0.25, 0.5), Rgba(0.0, 1.0, 0, 1));
+  meshcat->SetTransform("cylinder", RigidTransformd(Vector3d{++x, 0, 0}));
 
-  meshcat->SetObject("ellipsoid", Ellipsoid(.25, .25, .5), Rgba(1., 0, 1, .5));
-  meshcat->SetTransform("ellipsoid", RigidTransformd(Vector3d{-2, 0, 0}));
+  meshcat->SetObject("ellipsoid", Ellipsoid(0.25, 0.25, 0.5),
+                     Rgba(1.0, 0, 1, 0.5));
+  meshcat->SetTransform("ellipsoid", RigidTransformd(Vector3d{++x, 0, 0}));
 
-  Vector3d box_home{-1, 0, 0};
-  meshcat->SetObject("box", Box(.25, .25, .5), Rgba(0, 0, 1, 1));
+  Vector3d box_home{++x, 0, 0};
+  meshcat->SetObject("box", Box(0.25, 0.25, 0.5), Rgba(0, 0, 1, 1));
   meshcat->SetTransform("box", RigidTransformd(box_home));
 
-  meshcat->SetObject("capsule", Capsule(.25, .5), Rgba(0, 1, 1, 1));
-  meshcat->SetTransform("capsule", RigidTransformd(Vector3d{0, 0, 0}));
+  meshcat->SetObject("capsule", Capsule(0.25, 0.5), Rgba(0, 1, 1, 1));
+  meshcat->SetTransform("capsule", RigidTransformd(Vector3d{++x, 0, 0}));
 
   // Note that height (in z) is the first argument.
-  meshcat->SetObject("cone", MeshcatCone(.5, .25, .5), Rgba(1, 0, 0, 1));
-  meshcat->SetTransform("cone", RigidTransformd(Vector3d{1, 0, 0}));
+  meshcat->SetObject("cone", MeshcatCone(0.5, 0.25, 0.5), Rgba(1, 0, 0, 1));
+  meshcat->SetTransform("cone", RigidTransformd(Vector3d{++x, 0, 0}));
 
   // The green color of this cube comes from the texture map.
   meshcat->SetObject(
       "obj", Mesh(FindResourceOrThrow(
                       "drake/geometry/render/test/meshes/box.obj"),
-                  .25));
-  meshcat->SetTransform("obj", RigidTransformd(Vector3d{2, 0, 0}));
+                  0.25));
+  meshcat->SetTransform("obj", RigidTransformd(Vector3d{++x, 0, 0}));
 
   auto mustard_obj =
       FindRunfile("drake_models/ycb/meshes/006_mustard_bottle_textured.obj")
           .abspath;
   meshcat->SetObject("mustard", Mesh(mustard_obj, 3.0));
-  meshcat->SetTransform("mustard", RigidTransformd(Vector3d{3, 0, 0}));
+  meshcat->SetTransform("mustard", RigidTransformd(Vector3d{++x, 0, 0}));
 
   {
     const int kPoints = 100000;
     perception::PointCloud cloud(
         kPoints, perception::pc_flags::kXYZs | perception::pc_flags::kRGBs);
     Eigen::Matrix3Xf m = Eigen::Matrix3Xf::Random(3, kPoints);
-    cloud.mutable_xyzs() = Eigen::DiagonalMatrix<float, 3>{.25, .25, .5} * m;
+    cloud.mutable_xyzs() = Eigen::DiagonalMatrix<float, 3>{0.25, 0.25, 0.5} * m;
     cloud.mutable_rgbs() = (255.0 * (m.array() + 1.0) / 2.0).cast<uint8_t>();
     meshcat->SetObject("point_cloud", cloud, 0.01);
-    meshcat->SetTransform("point_cloud", RigidTransformd(Vector3d{4, 0, 0}));
+    meshcat->SetTransform("point_cloud", RigidTransformd(Vector3d{++x, 0, 0}));
   }
 
   {
     Eigen::Matrix3Xd vertices(3, 200);
     Eigen::RowVectorXd t = Eigen::RowVectorXd::LinSpaced(200, 0, 10 * M_PI);
-    vertices << .25 * t.array().sin(), .25 * t.array().cos(), t / (10 * M_PI);
+    vertices << 0.25 * t.array().sin(), 0.25 * t.array().cos(), t / (10 * M_PI);
     meshcat->SetLine("line", vertices, 3.0, Rgba(0, 0, 1, 1));
-    meshcat->SetTransform("line", RigidTransformd(Vector3d{5, 0, -.5}));
+    meshcat->SetTransform("line", RigidTransformd(Vector3d{++x, 0, -0.5}));
   }
 
   {
     Eigen::Matrix3Xd start(3, 4), end(3, 4);
     // clang-format off
-    start << -.1, -.1,  .1, .1,
-            -.1,  .1, -.1, .1,
-            0, 0, 0, 0;
+    start << -0.1, -0.1,  0.1,  0.1,
+             -0.1,  0.1, -0.1,  0.1,
+                0,    0,    0,    0;
     // clang-format on
     end = start;
     end.row(2) = Eigen::RowVector4d::Ones();
     meshcat->SetLineSegments("line_segments", start, end, 5.0,
                              Rgba(0, 1, 0, 1));
     meshcat->SetTransform("line_segments",
-                          RigidTransformd(Vector3d{6, 0, -.5}));
+                          RigidTransformd(Vector3d{++x, 0, -0.5}));
   }
 
   // The TriangleSurfaceMesh variant of SetObject calls SetTriangleMesh(), so
@@ -113,14 +120,14 @@ int do_main() {
     for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
     TriangleSurfaceMesh<double> surface_mesh(
         std::move(faces), std::move(vertices));
-    meshcat->SetObject("triangle_mesh", surface_mesh, Rgba(.9, 0, .9, 1.0));
+    meshcat->SetObject("triangle_mesh", surface_mesh, Rgba(0.9, 0, 0.9, 1.0));
     meshcat->SetTransform("triangle_mesh",
-                          RigidTransformd(Vector3d{6.75, -.25, 0}));
+                          RigidTransformd(Vector3d{++x, -0.25, 0}));
 
     meshcat->SetObject("triangle_mesh_wireframe", surface_mesh,
-                       Rgba(.9, 0, .9, 1.0), true, 5.0);
+                       Rgba(0.9, 0, 0.9, 1.0), true, 5.0);
     meshcat->SetTransform("triangle_mesh_wireframe",
-                          RigidTransformd(Vector3d{7.75, -.25, 0}));
+                          RigidTransformd(Vector3d{++x, -0.25, 0}));
   }
 
   // SetTriangleColorMesh.
@@ -145,7 +152,7 @@ int do_main() {
     meshcat->SetTriangleColorMesh("triangle_color_mesh", vertices, faces,
                                   colors);
     meshcat->SetTransform("triangle_color_mesh",
-                          RigidTransformd(Vector3d{8.75, -.25, 0}));
+                          RigidTransformd(Vector3d{++x, -0.25, 0}));
   }
 
   // PlotSurface.
@@ -157,9 +164,9 @@ int do_main() {
     // z = y*sin(5*x)
     Eigen::MatrixXd Z = (Y.array() * (5 * X.array()).sin()).matrix();
 
-    meshcat->PlotSurface("plot_surface", X, Y, Z, Rgba(0, 0, .9, 1.0), true);
+    meshcat->PlotSurface("plot_surface", X, Y, Z, Rgba(0, 0, 0.9, 1.0), true);
     meshcat->SetTransform("plot_surface",
-                          RigidTransformd(Vector3d{9.75, -.25, 0}));
+                          RigidTransformd(Vector3d{++x, -0.25, 0}));
   }
 
   std::cout << R"""(
@@ -334,7 +341,7 @@ Open up your browser to the URL above.
         "extra_heavy_duty_table_surface_only_collision.sdf"));
     const double table_height = 0.7645;
     plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("link"),
-                     RigidTransformd(Vector3d{0, 0, -table_height - .01}));
+                     RigidTransformd(Vector3d{0, 0, -table_height - 0.01}));
     plant.Finalize();
 
     builder.ExportInput(plant.get_actuation_input_port(), "actuation_input");

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -276,28 +276,29 @@ GTEST_TEST(MeshcatTest, NumActive) {
 GTEST_TEST(MeshcatTest, SetObjectWithShape) {
   Meshcat meshcat;
   EXPECT_TRUE(meshcat.GetPackedObject("sphere").empty());
-  meshcat.SetObject("sphere", Sphere(.25), Rgba(1.0, 0, 0, 1));
+  meshcat.SetObject("sphere", Sphere(0.25), Rgba(1.0, 0, 0, 1));
   EXPECT_FALSE(meshcat.GetPackedObject("sphere").empty());
-  meshcat.SetObject("cylinder", Cylinder(.25, .5), Rgba(0.0, 1.0, 0, 1));
+  meshcat.SetObject("cylinder", Cylinder(0.25, 0.5), Rgba(0.0, 1.0, 0, 1));
   EXPECT_FALSE(meshcat.GetPackedObject("cylinder").empty());
   // HalfSpaces are not supported yet; this should only log a warning.
   meshcat.SetObject("halfspace", HalfSpace());
   EXPECT_TRUE(meshcat.GetPackedObject("halfspace").empty());
-  meshcat.SetObject("box", Box(.25, .25, .5), Rgba(0, 0, 1, 1));
+  meshcat.SetObject("box", Box(0.25, 0.25, 0.5), Rgba(0, 0, 1, 1));
   EXPECT_FALSE(meshcat.GetPackedObject("box").empty());
-  meshcat.SetObject("ellipsoid", Ellipsoid(.25, .25, .5), Rgba(1., 0, 1, 1));
+  meshcat.SetObject("ellipsoid", Ellipsoid(0.25, 0.25, 0.5),
+                    Rgba(1.0, 0, 1, 1));
   EXPECT_FALSE(meshcat.GetPackedObject("ellipsoid").empty());
-  meshcat.SetObject("capsule", Capsule(.25, .5));
+  meshcat.SetObject("capsule", Capsule(0.25, 0.5));
   EXPECT_FALSE(meshcat.GetPackedObject("capsule").empty());
   meshcat.SetObject(
       "mesh", Mesh(FindResourceOrThrow(
                        "drake/geometry/render/test/meshes/box.obj"),
-                   .25));
+                   0.25));
   EXPECT_FALSE(meshcat.GetPackedObject("mesh").empty());
   meshcat.SetObject(
       "convex", Convex(FindResourceOrThrow(
                            "drake/geometry/render/test/meshes/box.obj"),
-                       .25));
+                       0.25));
   EXPECT_FALSE(meshcat.GetPackedObject("convex").empty());
   // Bad filename (no extension).  Should only log a warning.
   meshcat.SetObject("bad", Mesh("test"));
@@ -349,11 +350,11 @@ GTEST_TEST(MeshcatTest, SetObjectWithTriangleSurfaceMesh) {
   for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
   TriangleSurfaceMesh<double> surface_mesh(
       std::move(faces), std::move(vertices));
-  meshcat.SetObject("triangle_mesh", surface_mesh, Rgba(.9, 0, .9, 1.0));
+  meshcat.SetObject("triangle_mesh", surface_mesh, Rgba(0.9, 0, 0.9, 1.0));
   EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh").empty());
 
   meshcat.SetObject("triangle_mesh_wireframe", surface_mesh,
-                    Rgba(.9, 0, .9, 1.0), true, 5.0);
+                    Rgba(0.9, 0, 0.9, 1.0), true, 5.0);
   EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh_wireframe").empty());
 }
 
@@ -369,11 +370,11 @@ GTEST_TEST(MeshcatTest, PlotSurface) {
   Eigen::MatrixXd Z = (Y.array() * (5*X.array()).sin()).matrix();
 
   // Wireframe = false.
-  meshcat.PlotSurface("plot_surface", X, Y, Z, Rgba(0, 0, .9, 1.0), false);
+  meshcat.PlotSurface("plot_surface", X, Y, Z, Rgba(0, 0, 0.9, 1.0), false);
   EXPECT_FALSE(meshcat.GetPackedObject("plot_surface").empty());
 
   // Wireframe = true.
-  meshcat.PlotSurface("plot_surface_wireframe", X, Y, Z, Rgba(0, 0, .9, 1.0),
+  meshcat.PlotSurface("plot_surface_wireframe", X, Y, Z, Rgba(0, 0, 0.9, 1.0),
                       true);
   EXPECT_FALSE(meshcat.GetPackedObject("plot_surface_wireframe").empty());
 }
@@ -383,15 +384,15 @@ GTEST_TEST(MeshcatTest, SetLine) {
 
   Eigen::Matrix3Xd vertices(3, 200);
   Eigen::RowVectorXd t = Eigen::RowVectorXd::LinSpaced(200, 0, 10 * M_PI);
-  vertices << .25 * t.array().sin(), .25 * t.array().cos(), t / (10 * M_PI);
+  vertices << 0.25 * t.array().sin(), 0.25 * t.array().cos(), t / (10 * M_PI);
   meshcat.SetLine("line", vertices, 3.0, Rgba(0, 0, 1, 1));
   EXPECT_FALSE(meshcat.GetPackedObject("line").empty());
 
   Eigen::Matrix3Xd start(3, 4), end(3, 4);
   // clang-format off
-  start << -.1, -.1,  .1, .1,
-           -.1,  .1, -.1, .1,
-           0, 0, 0, 0;
+  start << -0.1, -0.1,  0.1,  0.1,
+           -0.1,  0.1, -0.1,  0.1,
+              0,    0,    0,    0;
   // clang-format on
   end = start;
   end.row(2) = Eigen::RowVector4d::Ones();
@@ -429,8 +430,8 @@ GTEST_TEST(MeshcatTest, SetTransform) {
   Meshcat meshcat;
   EXPECT_FALSE(meshcat.HasPath("frame"));
   EXPECT_TRUE(meshcat.GetPackedTransform("frame").empty());
-  const RigidTransformd X_ParentPath{math::RollPitchYawd(.5, .26, -3),
-                                     Vector3d{.9, -2., .12}};
+  const RigidTransformd X_ParentPath{math::RollPitchYawd(0.5, 0.26, -3),
+                                     Vector3d{0.9, -2.0, 0.12}};
   meshcat.SetTransform("frame", X_ParentPath);
 
   std::string transform = meshcat.GetPackedTransform("frame");
@@ -672,7 +673,7 @@ GTEST_TEST(MeshcatTest, Sliders) {
   meshcat.SetSliderValue("slider", 0.7);
   EXPECT_NEAR(meshcat.GetSliderValue("slider"), 0.7, 1e-14);
   meshcat.SetSliderValue("slider", -2.0);
-  EXPECT_NEAR(meshcat.GetSliderValue("slider"), .2, 1e-14);
+  EXPECT_NEAR(meshcat.GetSliderValue("slider"), 0.2, 1e-14);
   meshcat.SetSliderValue("slider", 2.0);
   EXPECT_NEAR(meshcat.GetSliderValue("slider"), 1.5, 1e-14);
   meshcat.SetSliderValue("slider", 1.245);
@@ -812,7 +813,7 @@ GTEST_TEST(MeshcatTest, SetOrthographicCamera) {
   Meshcat meshcat;
   Meshcat::OrthographicCamera ortho;
   ortho.left = -1.23;
-  ortho.bottom = .84;
+  ortho.bottom = 0.84;
   meshcat.SetCamera(ortho, "/my/camera");
   CheckWebsocketCommand(meshcat, {}, 1, R"""({
       "type": "set_object",
@@ -952,8 +953,8 @@ GTEST_TEST(MeshcatTest, Recording) {
   DRAKE_EXPECT_THROWS_MESSAGE(meshcat.get_mutable_recording(),
                               ".*You must create a recording.*");
 
-  const RigidTransformd X_ParentPath{math::RollPitchYawd(.5, .26, -3),
-                                     Vector3d{.9, -2., .12}};
+  const RigidTransformd X_ParentPath{math::RollPitchYawd(0.5, 0.26, -3),
+                                     Vector3d{0.9, -2.0, 0.12}};
   meshcat.SetTransform("frame", X_ParentPath, 0);
   meshcat.StartRecording();
   MeshcatAnimation* animation = &meshcat.get_mutable_recording();
@@ -1028,9 +1029,9 @@ GTEST_TEST(MeshcatTest, Recording) {
 GTEST_TEST(MeshcatTest, RecordingWithoutSetTransform) {
   Meshcat meshcat;
 
-  const RigidTransformd X_0{math::RollPitchYawd(.5, .26, -3),
-                            Vector3d{.9, -2., .12}};
-  const RigidTransformd X_1{math::RollPitchYawd(.75, .21, 2.4),
+  const RigidTransformd X_0{math::RollPitchYawd(0.5, 0.26, -3),
+                            Vector3d{0.9, -2.0, 0.12}};
+  const RigidTransformd X_1{math::RollPitchYawd(0.75, 0.21, 2.4),
                             Vector3d{6.9, -2.2, 1.12}};
 
   const double kFrameRate = 64.0;
@@ -1095,7 +1096,7 @@ GTEST_TEST(MeshcatTest, StaticHtml) {
   Meshcat meshcat;
 
   // Call each command that will be saved (at least) once.
-  meshcat.SetObject("box", Box(.25, .25, .5), Rgba(0, 0, 1, 1));
+  meshcat.SetObject("box", Box(0.25, 0.25, 0.5), Rgba(0, 0, 1, 1));
   meshcat.SetTransform("box", RigidTransformd(Vector3d{0, 0, 0}));
   meshcat.SetProperty("/Background", "visible", false);
 


### PR DESCRIPTION
Use a variable to more easily space out the x-axis offsets.
Obey GSG's formatting rule for floating point literals.

Inspired by #19635.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19645)
<!-- Reviewable:end -->
