### PR TITLE
Allow zero matrix on the diagonal for block sparse matrix

### DIFF
--- a/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.cc
+++ b/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.cc
@@ -6,6 +6,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/fmt_eigen.h"
 
 namespace drake {
 namespace multibody {
@@ -128,12 +129,17 @@ void BlockSparseLowerTriangularOrSymmetricMatrix<
     throw std::runtime_error(fmt::format(
         "{}: The requested {},{}-th block doesn't exist.", source, i, j));
   }
-  if (is_symmetric && i == j && Aij.has_value() &&
-      !((*Aij - Aij->transpose()).norm() < 1e-12 * Aij->norm())) {
+
+  auto is_block_symmetric = [](const MatrixType& M) {
+    /* Note that "<=" is critical to allow zero matrices to pass. */
+    return (M - M.transpose()).norm() <= 1e-12 * M.norm();
+  };
+
+  if (is_symmetric && i == j && Aij.has_value() && !is_block_symmetric(*Aij)) {
     throw std::runtime_error(
         fmt::format("{}: The {}-th diagonal block must be symmetric for a "
-                    "symmetric matrix.",
-                    source, i));
+                    "symmetric matrix. Instead, the block is:\n {}",
+                    source, i, fmt_eigen(*Aij)));
   }
 }
 

--- a/multibody/contact_solvers/test/block_sparse_lower_triangular_or_symmetric_matrix_test.cc
+++ b/multibody/contact_solvers/test/block_sparse_lower_triangular_or_symmetric_matrix_test.cc
@@ -229,7 +229,9 @@ GTEST_TEST(TriangularBlockSparseMatrixTest, InvalidOperations) {
     /* Non-symmetric diagonal block. */
     DRAKE_ASSERT_THROWS_MESSAGE_IF_ARMED(
         A_symmetric.AddToBlock(2, 2, non_symmetric_matrix),
-        ".*must be symmetric.*");
+        ".*must be symmetric[^]*");
+    /* No false error when zero matrix is added to the diagonal block. */
+    EXPECT_NO_THROW(A_symmetric.AddToBlock(2, 2, MatrixXd::Zero(4, 4)));
 
     /* Evidence that other functions do the same checks. */
     ASSERT_THROW(A_triangular.block(0, 1), std::exception);


### PR DESCRIPTION
Fix a bug that incorrectly rejects putting zero matrix on the diagonal block of a block sparse symmetric matrix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19647)
<!-- Reviewable:end -->
