### PR TITLE
[sensors] Split RgbdSensorDiscrete into its own file

### DIFF
--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -22,6 +22,7 @@
 #include "drake/systems/sensors/pixel_types.h"
 #include "drake/systems/sensors/rgbd_sensor.h"
 #include "drake/systems/sensors/rgbd_sensor_async.h"
+#include "drake/systems/sensors/rgbd_sensor_discrete.h"
 
 using std::string;
 using std::unique_ptr;

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -229,8 +229,14 @@ drake_cc_library(
 
 drake_cc_library(
     name = "rgbd_sensor",
-    srcs = ["rgbd_sensor.cc"],
-    hdrs = ["rgbd_sensor.h"],
+    srcs = [
+        "rgbd_sensor.cc",
+        "rgbd_sensor_discrete.cc",
+    ],
+    hdrs = [
+        "rgbd_sensor.h",
+        "rgbd_sensor_discrete.h",
+    ],
     deps = [
         ":camera_info",
         ":image",
@@ -428,6 +434,16 @@ drake_cc_googletest(
         "//geometry/test_utilities:dummy_render_engine",
         "//multibody/plant",
         "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "rgbd_sensor_discrete_test",
+    tags = vtk_test_tags(),
+    deps = [
+        ":rgbd_sensor",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry/test_utilities:dummy_render_engine",
     ],
 )
 

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -1,21 +1,10 @@
 #pragma once
 
-#include <map>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
-
-#include <Eigen/Dense>
-
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/render/render_camera.h"
 #include "drake/math/rigid_transform.h"
-#include "drake/math/roll_pitch_yaw.h"
-#include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/sensors/camera_info.h"
 #include "drake/systems/sensors/image.h"
@@ -217,100 +206,10 @@ class RgbdSensor final : public LeafSystem<double> {
   const math::RigidTransformd X_PB_;
 };
 
-/**
- Wraps a continuous RgbdSensor with a zero-order hold to create a discrete
- sensor.
-
- @system
- name: RgbdSensorDiscrete
- input_ports:
- - geometry_query
- output_ports:
- - color_image
- - depth_image_32f
- - depth_image_16u
- - label_image
- - body_pose_in_world
- @endsystem
-
- See also RgbdSensorAsync for a slightly different discrete sensor model.
-
- @note Be mindful that the discrete dynamics of a zero-order hold mean that all
- three image types (color, depth, label) are rendered at the given `period`,
- even if nothing ends up using the images on the output ports; this might be
- computationally wasteful. If you only need color and depth, be sure to pass
- `render_label_image = false` to the constructor. If you only need one image
- type, eschew this system in favor of adding your own zero-order hold on just
- the one RgbdSensor output port that you need.
-
- @ingroup sensor_systems  */
-class RgbdSensorDiscrete final : public systems::Diagram<double> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RgbdSensorDiscrete);
-
-  static constexpr double kDefaultPeriod = 1. / 30;
-
-  /** Constructs a diagram containing a (non-registered) RgbdSensor that will
-   update at a given rate.
-   @param sensor               The continuous sensor used to generate periodic
-                               images.
-   @param period               Update period (sec).
-   @param render_label_image   If true, renders label image (which requires
-                               additional overhead). If false,
-                               `label_image_output_port` will raise an error if
-                               called.  */
-  RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> sensor,
-                     double period = kDefaultPeriod,
-                     bool render_label_image = true);
-
-  /** Returns reference to RgbdSensor instance.  */
-  const RgbdSensor& sensor() const { return *camera_; }
-
-  /** Returns update period for discrete camera.  */
-  double period() const { return period_; }
-
-  /** @see RgbdSensor::query_object_input_port().  */
-  const InputPort<double>& query_object_input_port() const {
-    return get_input_port(query_object_port_);
-  }
-
-  /** @see RgbdSensor::color_image_output_port().  */
-  const systems::OutputPort<double>& color_image_output_port() const {
-    return get_output_port(output_port_color_image_);
-  }
-
-  /** @see RgbdSensor::depth_image_32F_output_port().  */
-  const systems::OutputPort<double>& depth_image_32F_output_port() const {
-    return get_output_port(output_port_depth_image_32F_);
-  }
-
-  /** @see RgbdSensor::depth_image_16U_output_port().  */
-  const systems::OutputPort<double>& depth_image_16U_output_port() const {
-    return get_output_port(output_port_depth_image_16U_);
-  }
-
-  /** @see RgbdSensor::label_image_output_port().  */
-  const systems::OutputPort<double>& label_image_output_port() const {
-    return get_output_port(output_port_label_image_);
-  }
-
-  /** @see RgbdSensor::body_pose_in_world_output_port().  */
-  const OutputPort<double>& body_pose_in_world_output_port() const {
-    return get_output_port(body_pose_in_world_output_port_);
-  }
-
- private:
-  RgbdSensor* const camera_{};
-  const double period_{};
-
-  int query_object_port_{-1};
-  int output_port_color_image_{-1};
-  int output_port_depth_image_32F_{-1};
-  int output_port_depth_image_16U_{-1};
-  int output_port_label_image_{-1};
-  int body_pose_in_world_output_port_{-1};
-};
-
 }  // namespace sensors
 }  // namespace systems
 }  // namespace drake
+
+// This exists for backwards compatibility reasons. The discrete sensor class
+// was previously defined within this file.
+#include "drake/systems/sensors/rgbd_sensor_discrete.h"

--- a/systems/sensors/rgbd_sensor_discrete.cc
+++ b/systems/sensors/rgbd_sensor_discrete.cc
@@ -1,0 +1,74 @@
+#include "drake/systems/sensors/rgbd_sensor_discrete.h"
+
+#include <utility>
+
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/zero_order_hold.h"
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+RgbdSensorDiscrete::RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> camera,
+                                       double period, bool render_label_image)
+    : camera_(camera.get()), period_(period) {
+  const auto& color_camera_info = camera->color_camera_info();
+  const auto& depth_camera_info = camera->depth_camera_info();
+
+  DiagramBuilder<double> builder;
+  builder.AddSystem(std::move(camera));
+  query_object_port_ =
+      builder.ExportInput(camera_->query_object_input_port(), "geometry_query");
+
+  // Color image.
+  const Value<ImageRgba8U> image_color(color_camera_info.width(),
+                                       color_camera_info.height());
+  const auto* const zoh_color =
+      builder.AddSystem<ZeroOrderHold>(period_, image_color);
+  builder.Connect(camera_->color_image_output_port(),
+                  zoh_color->get_input_port());
+  output_port_color_image_ =
+      builder.ExportOutput(zoh_color->get_output_port(), "color_image");
+
+  // Depth images.
+  const Value<ImageDepth32F> image_depth_32F(depth_camera_info.width(),
+                                             depth_camera_info.height());
+  const auto* const zoh_depth_32F =
+      builder.AddSystem<ZeroOrderHold>(period_, image_depth_32F);
+  builder.Connect(camera_->depth_image_32F_output_port(),
+                  zoh_depth_32F->get_input_port());
+  output_port_depth_image_32F_ =
+      builder.ExportOutput(zoh_depth_32F->get_output_port(), "depth_image_32f");
+
+  // Depth images.
+  const Value<ImageDepth16U> image_depth_16U(depth_camera_info.width(),
+                                             depth_camera_info.height());
+  const auto* const zoh_depth_16U =
+      builder.AddSystem<ZeroOrderHold>(period_, image_depth_16U);
+  builder.Connect(camera_->depth_image_16U_output_port(),
+                  zoh_depth_16U->get_input_port());
+  output_port_depth_image_16U_ =
+      builder.ExportOutput(zoh_depth_16U->get_output_port(), "depth_image_16u");
+
+  // Label image.
+  if (render_label_image) {
+    const Value<ImageLabel16I> image_label(color_camera_info.width(),
+                                           color_camera_info.height());
+    const auto* const zoh_label =
+        builder.AddSystem<ZeroOrderHold>(period_, image_label);
+    builder.Connect(camera_->label_image_output_port(),
+                    zoh_label->get_input_port());
+    output_port_label_image_ =
+        builder.ExportOutput(zoh_label->get_output_port(), "label_image");
+  }
+
+  body_pose_in_world_output_port_ = builder.ExportOutput(
+      camera_->body_pose_in_world_output_port(), "body_pose_in_world");
+
+  builder.BuildInto(this);
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/rgbd_sensor_discrete.h
+++ b/systems/sensors/rgbd_sensor_discrete.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/sensors/rgbd_sensor.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+#ifndef DRAKE_DOXYGEN_CXX
+class RgbdSensor;
+#endif
+
+/** Wraps a continuous RgbdSensor with a zero-order hold to create a discrete
+sensor.
+
+@system
+name: RgbdSensorDiscrete
+input_ports:
+- geometry_query
+output_ports:
+- color_image
+- depth_image_32f
+- depth_image_16u
+- label_image
+- body_pose_in_world
+@endsystem
+
+See also RgbdSensorAsync for a slightly different discrete sensor model.
+
+@note Be mindful that the discrete dynamics of a zero-order hold mean that all
+three image types (color, depth, label) are rendered at the given `period`,
+even if nothing ends up using the images on the output ports; this might be
+computationally wasteful. If you only need color and depth, be sure to pass
+`render_label_image = false` to the constructor. If you only need one image
+type, eschew this system in favor of adding your own zero-order hold on just
+the one RgbdSensor output port that you need.
+
+@ingroup sensor_systems  */
+class RgbdSensorDiscrete final : public systems::Diagram<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RgbdSensorDiscrete);
+
+  static constexpr double kDefaultPeriod = 1. / 30;
+
+  /** Constructs a diagram containing a (non-registered) RgbdSensor that will
+  update at a given rate.
+  @param sensor               The continuous sensor used to generate periodic
+                              images.
+  @param period               Update period (sec).
+  @param render_label_image   If true, renders label image (which requires
+                              additional overhead). If false,
+                              `label_image_output_port` will raise an error if
+                              called. */
+  RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> sensor,
+                     double period = kDefaultPeriod,
+                     bool render_label_image = true);
+
+  /** Returns reference to RgbdSensor instance. */
+  const RgbdSensor& sensor() const { return *camera_; }
+
+  /** Returns update period for discrete camera. */
+  double period() const { return period_; }
+
+  /** @see RgbdSensor::query_object_input_port(). */
+  const InputPort<double>& query_object_input_port() const {
+    return get_input_port(query_object_port_);
+  }
+
+  /** @see RgbdSensor::color_image_output_port(). */
+  const systems::OutputPort<double>& color_image_output_port() const {
+    return get_output_port(output_port_color_image_);
+  }
+
+  /** @see RgbdSensor::depth_image_32F_output_port(). */
+  const systems::OutputPort<double>& depth_image_32F_output_port() const {
+    return get_output_port(output_port_depth_image_32F_);
+  }
+
+  /** @see RgbdSensor::depth_image_16U_output_port(). */
+  const systems::OutputPort<double>& depth_image_16U_output_port() const {
+    return get_output_port(output_port_depth_image_16U_);
+  }
+
+  /** @see RgbdSensor::label_image_output_port(). */
+  const systems::OutputPort<double>& label_image_output_port() const {
+    return get_output_port(output_port_label_image_);
+  }
+
+  /** @see RgbdSensor::body_pose_in_world_output_port(). */
+  const OutputPort<double>& body_pose_in_world_output_port() const {
+    return get_output_port(body_pose_in_world_output_port_);
+  }
+
+ private:
+  RgbdSensor* const camera_{};
+  const double period_{};
+
+  int query_object_port_{-1};
+  int output_port_color_image_{-1};
+  int output_port_depth_image_32F_{-1};
+  int output_port_depth_image_16U_{-1};
+  int output_port_label_image_{-1};
+  int body_pose_in_world_output_port_{-1};
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/rgbd_sensor_async_gl_test.cc
+++ b/systems/sensors/test/rgbd_sensor_async_gl_test.cc
@@ -12,6 +12,7 @@
 #include "drake/systems/sensors/image_writer.h"
 #include "drake/systems/sensors/rgbd_sensor.h"
 #include "drake/systems/sensors/rgbd_sensor_async.h"
+#include "drake/systems/sensors/rgbd_sensor_discrete.h"
 
 // This is an end-to-end acceptance test of the RgbdSensorAsync.
 //

--- a/systems/sensors/test/rgbd_sensor_discrete_test.cc
+++ b/systems/sensors/test/rgbd_sensor_discrete_test.cc
@@ -1,0 +1,96 @@
+#include "drake/systems/sensors/rgbd_sensor_discrete.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/systems/primitives/zero_order_hold.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace {
+
+using geometry::SceneGraph;
+using geometry::render::DepthRenderCamera;
+using math::RigidTransformd;
+using std::make_unique;
+using std::vector;
+
+// Tests that the discrete sensor is properly constructed.
+GTEST_TEST(RgbdSensorDiscrete, Construction) {
+  const DepthRenderCamera depth_camera(
+      {"render", {640, 480, M_PI / 4}, {0.1, 10.0}, {}}, {0.1, 10});
+  const double kPeriod = 0.1;
+
+  const bool include_render_port = true;
+  // N.B. In addition to testing a discrete sensor, this also tests
+  // the `RgbdSensor` constructor which takes only `DepthRenderCamera`.
+  RgbdSensorDiscrete sensor(
+      make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(),
+                              RigidTransformd::Identity(), depth_camera),
+      kPeriod, include_render_port);
+  EXPECT_EQ(sensor.query_object_input_port().get_name(), "geometry_query");
+  EXPECT_EQ(sensor.color_image_output_port().get_name(), "color_image");
+  EXPECT_EQ(sensor.depth_image_32F_output_port().get_name(), "depth_image_32f");
+  EXPECT_EQ(sensor.depth_image_16U_output_port().get_name(), "depth_image_16u");
+  EXPECT_EQ(sensor.label_image_output_port().get_name(), "label_image");
+  EXPECT_EQ(sensor.body_pose_in_world_output_port().get_name(),
+            "body_pose_in_world");
+
+  // Confirm that the period was passed into the ZOH correctly. If the ZOH
+  // reports the expected period, we rely on it to do the right thing.
+  EXPECT_EQ(sensor.period(), kPeriod);
+}
+
+// Test that the diagram's internal architecture is correct and, likewise,
+// wired correctly.
+GTEST_TEST(RgbdSensorDiscrete, ImageHold) {
+  const DepthRenderCamera depth_camera(
+      {"render", {640, 480, M_PI / 4}, {0.1, 10.0}, {}}, {0.1, 10});
+  // N.B. In addition to testing a discrete sensor, this also tests
+  // the `RgbdSensor` constructor which takes only `DepthRenderCamera`.
+  auto sensor =
+      make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(),
+                              RigidTransformd::Identity(), depth_camera);
+  RgbdSensor* sensor_raw = sensor.get();
+  const double kPeriod = 0.1;
+  const bool include_render_port = true;
+  RgbdSensorDiscrete discrete_sensor(std::move(sensor), kPeriod,
+                                     include_render_port);
+
+  // This tests very *explicit* knowledge of what the wiring should be. As such,
+  // it's a bit brittle, but this is the most efficient way to affect this test.
+  // We assume these systems are reported in the order they were added.
+  vector<const System<double>*> sub_systems = discrete_sensor.GetSystems();
+
+  // Five sub-systems: the sensor and one hold per image type.
+  ASSERT_EQ(sub_systems.size(), 5);
+  ASSERT_EQ(sub_systems[0], sensor_raw);
+
+  // For each image output port, we want to make sure it's connected to the
+  // expected ZOH and that the hold's period is kPeriod. This proves that
+  // RgbdSensorDiscrete has wired things up properly.
+  auto confirm_hold = [&sub_systems, &kPeriod, &discrete_sensor](
+                          int hold_index,
+                          const OutputPort<double>& image_port) {
+    const ZeroOrderHold<double>* zoh =
+        dynamic_cast<const ZeroOrderHold<double>*>(sub_systems[hold_index]);
+    ASSERT_NE(zoh, nullptr);
+    EXPECT_EQ(zoh->period(), kPeriod);
+    EXPECT_TRUE(
+        discrete_sensor.AreConnected(image_port, zoh->get_input_port()));
+  };
+
+  confirm_hold(1, sensor_raw->color_image_output_port());
+  confirm_hold(2, sensor_raw->depth_image_32F_output_port());
+  confirm_hold(3, sensor_raw->depth_image_16U_output_port());
+  confirm_hold(4, sensor_raw->label_image_output_port());
+
+  // TODO(SeanCurtis-TRI): Consider confirming that the exported ports map to
+  //  the expected sub-system ports.
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -14,7 +14,6 @@
 #include "drake/geometry/test_utilities/dummy_render_engine.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/primitives/zero_order_hold.h"
 
 namespace drake {
 namespace systems {
@@ -403,80 +402,6 @@ TEST_F(RgbdSensorTest, ConstructCameraWithNonTrivialOffsetsDeprecated) {
 // coverage of its output value, not just its name. It ends up being indirectly
 // tested in sim_rgbd_sensor_test.cc but it would be better to identify bugs in
 // the RgbdSensor directly instead of intermingled with the wrapper code.
-
-// Tests that the discrete sensor is properly constructed.
-GTEST_TEST(RgbdSensorDiscrete, Construction) {
-  const DepthRenderCamera depth_camera(
-      {"render", {640, 480, M_PI / 4}, {0.1, 10.0}, {}}, {0.1, 10});
-  const double kPeriod = 0.1;
-
-  const bool include_render_port = true;
-  // N.B. In addition to testing a discrete sensor, this also tests
-  // the `RgbdSensor` constructor which takes only `DepthRenderCamera`.
-  RgbdSensorDiscrete sensor(
-      make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(),
-                              RigidTransformd::Identity(), depth_camera),
-      kPeriod, include_render_port);
-  EXPECT_EQ(sensor.query_object_input_port().get_name(), "geometry_query");
-  EXPECT_EQ(sensor.color_image_output_port().get_name(), "color_image");
-  EXPECT_EQ(sensor.depth_image_32F_output_port().get_name(), "depth_image_32f");
-  EXPECT_EQ(sensor.depth_image_16U_output_port().get_name(), "depth_image_16u");
-  EXPECT_EQ(sensor.label_image_output_port().get_name(), "label_image");
-  EXPECT_EQ(sensor.body_pose_in_world_output_port().get_name(),
-            "body_pose_in_world");
-
-  // Confirm that the period was passed into the ZOH correctly. If the ZOH
-  // reports the expected period, we rely on it to do the right thing.
-  EXPECT_EQ(sensor.period(), kPeriod);
-}
-
-// Test that the diagram's internal architecture is correct and, likewise,
-// wired correctly.
-GTEST_TEST(RgbdSensorDiscrete, ImageHold) {
-  const DepthRenderCamera depth_camera(
-      {"render", {640, 480, M_PI / 4}, {0.1, 10.0}, {}}, {0.1, 10});
-  // N.B. In addition to testing a discrete sensor, this also tests
-  // the `RgbdSensor` constructor which takes only `DepthRenderCamera`.
-  auto sensor =
-      make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(),
-                              RigidTransformd::Identity(), depth_camera);
-  RgbdSensor* sensor_raw = sensor.get();
-  const double kPeriod = 0.1;
-  const bool include_render_port = true;
-  RgbdSensorDiscrete discrete_sensor(std::move(sensor), kPeriod,
-                                     include_render_port);
-
-  // This tests very *explicit* knowledge of what the wiring should be. As such,
-  // it's a bit brittle, but this is the most efficient way to affect this test.
-  // We assume these systems are reported in the order they were added.
-  vector<const System<double>*> sub_systems = discrete_sensor.GetSystems();
-
-  // Five sub-systems: the sensor and one hold per image type.
-  ASSERT_EQ(sub_systems.size(), 5);
-  ASSERT_EQ(sub_systems[0], sensor_raw);
-
-  // For each image output port, we want to make sure it's connected to the
-  // expected ZOH and that the hold's period is kPeriod. This proves that
-  // RgbdSensorDiscrete has wired things up properly.
-  auto confirm_hold = [&sub_systems, &kPeriod, &discrete_sensor](
-                          int hold_index,
-                          const OutputPort<double>& image_port) {
-    const ZeroOrderHold<double>* zoh =
-        dynamic_cast<const ZeroOrderHold<double>*>(sub_systems[hold_index]);
-    ASSERT_NE(zoh, nullptr);
-    EXPECT_EQ(zoh->period(), kPeriod);
-    EXPECT_TRUE(
-        discrete_sensor.AreConnected(image_port, zoh->get_input_port()));
-  };
-
-  confirm_hold(1, sensor_raw->color_image_output_port());
-  confirm_hold(2, sensor_raw->depth_image_32F_output_port());
-  confirm_hold(3, sensor_raw->depth_image_16U_output_port());
-  confirm_hold(4, sensor_raw->label_image_output_port());
-
-  // TODO(SeanCurtis-TRI): Consider confirming that the exported ports map to
-  //  the expected sub-system ports.
-}
 
 }  // namespace
 }  // namespace sensors


### PR DESCRIPTION
Unless classes need to bleed private implementation details between each other, generally we should place once class per h/cc file pair to de-clutter development and improve build speeds.

Towards #19604 and #19437.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19649)
<!-- Reviewable:end -->
