### PR TITLE
Fix a bug in FiniteHorizonLinearQuadraticRegulator

### DIFF
--- a/systems/controllers/finite_horizon_linear_quadratic_regulator.cc
+++ b/systems/controllers/finite_horizon_linear_quadratic_regulator.cc
@@ -372,7 +372,9 @@ FiniteHorizonLinearQuadraticRegulator(
       Eigen::VectorBlock<Eigen::VectorXd> sx =
           S_vectorized.segment(num_states * num_states, num_states);
       double& s0 = S_vectorized[S_vectorized.size() - 1];
-      const Eigen::VectorXd xd0 = options.xd->value(tf) - x0->value(tf);
+      const Eigen::VectorXd xd0 =
+          options.xd->value(tf) -
+          (options.x0 ? options.x0->value(tf) : x0->value(tf));
       sx = -(*options.Qf) * xd0;
       s0 = xd0.dot((*options.Qf) * xd0);
     }

--- a/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
@@ -132,6 +132,7 @@ GTEST_TEST(FiniteHorizonLQRTest, NominalTrajectoryTest) {
     options.Qf = lqr_result.S;
     trajectories::PiecewisePolynomial<double> x0_traj(x0v);
     options.x0 = &x0_traj;
+    options.xd = &x0_traj;
     trajectories::PiecewisePolynomial<double> u0_traj(u0v);
     options.u0 = &u0_traj;
     FiniteHorizonLinearQuadraticRegulatorResult result =


### PR DESCRIPTION
When both x0 and xd are set, it caused segfault.

Resolves #19419 