### PR TITLE
[bindings] Use vanilla py::cast() for keep alive behavior

### DIFF
--- a/bindings/pydrake/common/eigen_pybind.h
+++ b/bindings/pydrake/common/eigen_pybind.h
@@ -23,21 +23,25 @@ auto ToEigenRef(Eigen::VectorBlock<Derived>* derived) {
 
 /** Converts a raw array to a numpy array. */
 template <typename T>
-py::object ToArray(T* ptr, int size, py::tuple shape) {
+py::object ToArray(T* ptr, int size, py::tuple shape,
+    py::return_value_policy policy = py_rvp::reference,
+    py::handle parent = py::handle()) {
   // Create flat array to be reshaped in numpy.
   using Vector = VectorX<T>;
   Eigen::Map<Vector> data(ptr, size);
-  return py::cast(Eigen::Ref<Vector>(data), py_rvp::reference)
+  return py::cast(Eigen::Ref<Vector>(data), policy, parent)
       .attr("reshape")(shape);
 }
 
 /** Converts a raw array to a numpy array (`const` variant). */
 template <typename T>
-py::object ToArray(const T* ptr, int size, py::tuple shape) {
+py::object ToArray(const T* ptr, int size, py::tuple shape,
+    py::return_value_policy policy = py_rvp::reference,
+    py::handle parent = py::handle()) {
   // Create flat array to be reshaped in numpy.
   using Vector = const VectorX<T>;
   Eigen::Map<Vector> data(ptr, size);
-  return py::cast(Eigen::Ref<Vector>(data), py_rvp::reference)
+  return py::cast(Eigen::Ref<Vector>(data), policy, parent)
       .attr("reshape")(shape);
 }
 

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -393,6 +393,7 @@ drake_py_unittest(
     name = "plant_test",
     data = [
         ":models",
+        "//examples/acrobot:models",
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
         "//multibody:models",

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -405,17 +405,14 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def(
             "regions",
             [](Class::Subgraph* self) {
-              py::list out;
-              py::object self_py = py::cast(self, py_rvp::reference);
+              std::vector<const geometry::optimization::ConvexSet*> regions;
               for (auto& region : self->regions()) {
-                const geometry::optimization::ConvexSet* region_raw =
-                    region.get();
-                py::object region_py = py::cast(region_raw, py_rvp::reference);
-                // Keep alive, ownership: `region` keeps `self` alive.
-                py_keep_alive(region_py, self_py);
-                out.append(region_py);
+                regions.push_back(region.get());
               }
-              return out;
+              py::object self_py = py::cast(self, py_rvp::reference);
+              // Keep alive, ownership: each item in `regions` keeps `self`
+              // alive.
+              return py::cast(regions, py_rvp::reference_internal, self_py);
             },
             subgraph_doc.regions.doc)
         .def("AddTimeCost", &Class::Subgraph::AddTimeCost,

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -41,26 +41,6 @@ namespace py = pybind11;
 /// the @ref PydrakeReturnValuePolicy "Return Value Policy" section.
 using py_rvp = py::return_value_policy;
 
-/// Use this when you must do manual casting - e.g. lists or tuples of nurses,
-/// where the container may get discarded but the items kept. Prefer this over
-/// `py::cast(obj, reference_internal, parent)` (pending full resolution of
-/// #11046).
-inline py::object py_keep_alive(py::object nurse, py::object patient) {
-  py::detail::keep_alive_impl(nurse, patient);
-  return nurse;
-}
-
-/// Use this to manually cast an iterable type (e.g. py::list, py::set). See
-/// pydrake_pybind_test for an example.
-/// N.B. This should *not* be used for `py::dict`.
-template <typename PyType>
-inline PyType py_keep_alive_iterable(PyType nurses, py::object patient) {
-  for (py::handle nurse : nurses) {
-    py_keep_alive(py::reinterpret_borrow<py::object>(nurse), patient);
-  }
-  return nurses;
-}
-
 // Implementation for `overload_cast_explicit`. We must use this structure so
 // that we can constrain what is inferred. Otherwise, the ambiguity confuses
 // the compiler.

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -564,34 +564,10 @@ void DoScalarDependentDefinitions(py::module m) {
       .def("empty", &DiagramBuilder<T>::empty, doc.DiagramBuilder.empty.doc)
       .def("already_built", &DiagramBuilder<T>::already_built,
           doc.DiagramBuilder.already_built.doc)
-      .def(
-          "GetSystems",
-          [](DiagramBuilder<T>* self) {
-            py::list out;
-            py::object self_py = py::cast(self, py_rvp::reference);
-            for (const auto* system : self->GetSystems()) {
-              py::object system_py = py::cast(system, py_rvp::reference);
-              // Keep alive, ownership: `system` keeps `self` alive.
-              py_keep_alive(system_py, self_py);
-              out.append(system_py);
-            }
-            return out;
-          },
-          doc.DiagramBuilder.GetSystems.doc)
-      .def(
-          "GetMutableSystems",
-          [](DiagramBuilder<T>* self) {
-            py::list out;
-            py::object self_py = py::cast(self, py_rvp::reference);
-            for (auto* system : self->GetMutableSystems()) {
-              py::object system_py = py::cast(system, py_rvp::reference);
-              // Keep alive, ownership: `system` keeps `self` alive.
-              py_keep_alive(system_py, self_py);
-              out.append(system_py);
-            }
-            return out;
-          },
-          doc.DiagramBuilder.GetMutableSystems.doc)
+      .def("GetSystems", &DiagramBuilder<T>::GetSystems,
+          py_rvp::reference_internal, doc.DiagramBuilder.GetSystems.doc)
+      .def("GetMutableSystems", &DiagramBuilder<T>::GetMutableSystems,
+          py_rvp::reference_internal, doc.DiagramBuilder.GetMutableSystems.doc)
       .def("HasSubsystemNamed", &DiagramBuilder<T>::HasSubsystemNamed,
           py::arg("name"), doc.DiagramBuilder.HasSubsystemNamed.doc)
       .def("GetSubsystemByName", &DiagramBuilder<T>::GetSubsystemByName,
@@ -611,20 +587,20 @@ void DoScalarDependentDefinitions(py::module m) {
             py::object self_py = py::cast(self, py_rvp::reference);
             for (auto& [input_locator, output_locator] :
                 self->connection_map()) {
-              py::object input_system_py =
-                  py::cast(input_locator.first, py_rvp::reference);
-              py::object input_port_index_py = py::cast(input_locator.second);
               // Keep alive, ownership: `input_system_py` keeps `self` alive.
-              py_keep_alive(input_system_py, self_py);
+              py::object input_system_py = py::cast(
+                  input_locator.first, py_rvp::reference_internal, self_py);
+              py::object input_port_index_py = py::cast(input_locator.second);
+
               py::tuple input_locator_py(2);
               input_locator_py[0] = input_system_py;
               input_locator_py[1] = input_port_index_py;
 
-              py::object output_system_py =
-                  py::cast(output_locator.first, py_rvp::reference);
-              py::object output_port_index_py = py::cast(output_locator.second);
               // Keep alive, ownership: `output_system_py` keeps `self` alive.
-              py_keep_alive(output_system_py, self_py);
+              py::object output_system_py = py::cast(
+                  output_locator.first, py_rvp::reference_internal, self_py);
+              py::object output_port_index_py = py::cast(output_locator.second);
+
               py::tuple output_locator_py(2);
               output_locator_py[0] = output_system_py;
               output_locator_py[1] = output_port_index_py;

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -972,21 +972,21 @@ Note: The above is for the C++ documentation. For Python, use
               py::object self_py = py::cast(self, py_rvp::reference);
               for (auto& [input_locator, output_locator] :
                   self->connection_map()) {
-                py::object input_system_py =
-                    py::cast(input_locator.first, py_rvp::reference);
-                py::object input_port_index_py = py::cast(input_locator.second);
                 // Keep alive, ownership: `input_system_py` keeps `self` alive.
-                py_keep_alive(input_system_py, self_py);
+                py::object input_system_py = py::cast(
+                    input_locator.first, py_rvp::reference_internal, self_py);
+                py::object input_port_index_py = py::cast(input_locator.second);
+
                 py::tuple input_locator_py(2);
                 input_locator_py[0] = input_system_py;
                 input_locator_py[1] = input_port_index_py;
 
-                py::object output_system_py =
-                    py::cast(output_locator.first, py_rvp::reference);
+                // Keep alive, ownership: `output_system_py` keeps `self` alive.
+                py::object output_system_py = py::cast(
+                    output_locator.first, py_rvp::reference_internal, self_py);
                 py::object output_port_index_py =
                     py::cast(output_locator.second);
-                // Keep alive, ownership: `output_system_py` keeps `self` alive.
-                py_keep_alive(output_system_py, self_py);
+
                 py::tuple output_locator_py(2);
                 output_locator_py[0] = output_system_py;
                 output_locator_py[1] = output_port_index_py;
@@ -1002,11 +1002,11 @@ Note: The above is for the C++ documentation. For Python, use
               py::list out;
               py::object self_py = py::cast(self, py_rvp::reference);
               for (auto& locator : self->GetInputPortLocators(port_index)) {
-                py::object system_py =
-                    py::cast(locator.first, py_rvp::reference);
-                py::object port_index_py = py::cast(locator.second);
                 // Keep alive, ownership: `system_py` keeps `self` alive.
-                py_keep_alive(system_py, self_py);
+                py::object system_py = py::cast(
+                    locator.first, py_rvp::reference_internal, self_py);
+                py::object port_index_py = py::cast(locator.second);
+
                 py::tuple locator_py(2);
                 locator_py[0] = system_py;
                 locator_py[1] = port_index_py;
@@ -1020,10 +1020,11 @@ Note: The above is for the C++ documentation. For Python, use
             [](Diagram<T>* self, OutputPortIndex port_index) {
               py::object self_py = py::cast(self, py_rvp::reference);
               const auto& locator = self->get_output_port_locator(port_index);
-              py::object system_py = py::cast(locator.first, py_rvp::reference);
-              py::object port_index_py = py::cast(locator.second);
               // Keep alive, ownership: `system_py` keeps `self` alive.
-              py_keep_alive(system_py, self_py);
+              py::object system_py =
+                  py::cast(locator.first, py_rvp::reference_internal, self_py);
+              py::object port_index_py = py::cast(locator.second);
+
               py::tuple locator_py(2);
               locator_py[0] = system_py;
               locator_py[1] = port_index_py;
@@ -1042,19 +1043,7 @@ Note: The above is for the C++ documentation. For Python, use
         .def("GetSubsystemByName", &Diagram<T>::GetSubsystemByName,
             py::arg("name"), py_rvp::reference_internal,
             doc.Diagram.GetSubsystemByName.doc)
-        .def(
-            "GetSystems",
-            [](Diagram<T>* self) {
-              py::list out;
-              py::object self_py = py::cast(self, py_rvp::reference);
-              for (auto* system : self->GetSystems()) {
-                py::object system_py = py::cast(system, py_rvp::reference);
-                // Keep alive, ownership: `system` keeps `self` alive.
-                py_keep_alive(system_py, self_py);
-                out.append(system_py);
-              }
-              return out;
-            },
+        .def("GetSystems", &Diagram<T>::GetSystems, py_rvp::reference_internal,
             doc.Diagram.GetSystems.doc);
 
     // N.B. This will effectively allow derived classes of `VectorSystem` to

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -129,15 +129,13 @@ PYBIND11_MODULE(sensors, m) {
             self->height(), self->width(), int{ImageTraitsT::kNumChannels});
       };
       auto get_data = [=](const ImageT* self) {
-        py::object array =
-            ToArray(self->at(0, 0), self->size(), get_shape(self));
-        py_keep_alive(array, py::cast(self));
+        py::object array = ToArray(self->at(0, 0), self->size(),
+            get_shape(self), py_rvp::reference_internal, py::cast(self));
         return array;
       };
       auto get_mutable_data = [=](ImageT* self) {
-        py::object array =
-            ToArray(self->at(0, 0), self->size(), get_shape(self));
-        py_keep_alive(array, py::cast(self));
+        py::object array = ToArray(self->at(0, 0), self->size(),
+            get_shape(self), py_rvp::reference_internal, py::cast(self));
         return array;
       };
 

--- a/bindings/pydrake/test/_pydrake_pybind_test_extra.py
+++ b/bindings/pydrake/test/_pydrake_pybind_test_extra.py
@@ -2,6 +2,7 @@
 # rationale.
 
 import copy
+import weakref
 
 
 def check_copy(copy_function, obj):
@@ -9,3 +10,21 @@ def check_copy(copy_function, obj):
     it is not the same instance."""
     obj_copy = copy_function(obj)
     return obj == obj_copy and obj is not obj_copy
+
+
+def check_reference_internal_list(cls):
+    """
+    Expicitly check behavior of `py_rvp::reference_internal` on a return list
+    of pointers given class definitions used in `pydrake_pybind_test.cc`.
+    """
+    container = cls()
+    ref = weakref.ref(container)
+    item = container.a_list()[0]
+    del container
+    # Show that `item` is effectively keeping `container` alive.
+    assert ref() is not None, "Container has been gc'd!"
+    # Show that removing refcount from `item` will cause `container` to get
+    # garbage collected.
+    del item
+    assert ref() is None, "Container has *not* been gc'd!"
+    return True

--- a/bindings/pydrake/test/pydrake_pybind_test.cc
+++ b/bindings/pydrake/test/pydrake_pybind_test.cc
@@ -25,48 +25,57 @@ GTEST_TEST(PydrakePybindTest, PyReturnValuePolicy) {
 // Expects that a given Python expression `expr` evaluates to true, using
 // globals and the variables available in `m`.
 void PyExpectTrue(py::module m, const char* expr) {
-  const bool value =
-      py::eval(expr, py::globals(), m.attr("__dict__")).cast<bool>();
+  py::object locals = m.attr("__dict__");
+  const bool value = py::eval(expr, py::globals(), locals).cast<bool>();
   EXPECT_TRUE(value) << expr;
 }
 
-class Nonce {};
+template <typename T>
+void PyExpectEq(py::module m, const std::string& expr, const T& expected) {
+  SCOPED_TRACE("Python expression:\n  " + expr);
+  py::object locals = m.attr("__dict__");
+  const T actual = py::eval(expr, py::globals(), locals).cast<T>();
+  EXPECT_EQ(actual, expected);
+}
+
+struct Item {
+  int value{};
+};
 
 class ExamplePyKeepAlive {
  public:
-  const Nonce* a() const { return &a_; }
-  std::vector<const Nonce*> a_list() const { return {&a_}; }
+  const Item* a() const { return &a_; }
+  std::vector<const Item*> a_list() const { return {&a_}; }
 
  private:
-  Nonce a_{};
+  Item a_{.value = 10};
 };
 
 GTEST_TEST(PydrakePybindTest, PyKeepAlive) {
   py::module m =
       py::module::create_extension_module("test", "", new PyModuleDef());
   {
-    using Class = Nonce;
-    py::class_<Class>(m, "Nonce");
+    using Class = Item;
+    py::class_<Class>(m, "Item").def_readonly("value", &Class::value);
   }
   {
     using Class = ExamplePyKeepAlive;
     py::class_<Class>(m, "ExamplePyKeepAlive")
         .def(py::init())
-        .def("a",
-            [](const Class& self) {
-              return py_keep_alive(py::cast(self.a()), py::cast(&self));
-            })
-        .def("a_list", [](const Class& self) {
-          return py_keep_alive_iterable<py::list>(
-              py::cast(self.a_list()), py::cast(&self));
-        });
+        .def("a", &Class::a, py_rvp::reference_internal)
+        .def("a_list", &Class::a_list, py_rvp::reference_internal);
   }
 
-  PyExpectTrue(m, "isinstance(ExamplePyKeepAlive().a(), Nonce)");
+  PyExpectTrue(m, "isinstance(ExamplePyKeepAlive().a(), Item)");
+  PyExpectEq(m, "ExamplePyKeepAlive().a().value", 10);
   PyExpectTrue(m,
       "isinstance(ExamplePyKeepAlive().a_list(), list) and "
       "len(ExamplePyKeepAlive().a_list()) == 1 and "
-      "isinstance(ExamplePyKeepAlive().a_list()[0], Nonce)");
+      "isinstance(ExamplePyKeepAlive().a_list()[0], Item)");
+  // Ensure we test the value to check for memory corruption.
+  PyExpectEq(m, "ExamplePyKeepAlive().a_list()[0].value", 10);
+  // Explicitly test keep alive behavior.
+  PyExpectTrue(m, "check_reference_internal_list(cls=ExamplePyKeepAlive)");
 }
 
 // Class which has a copy constructor, for testing `DefCopyAndDeepCopy`.


### PR DESCRIPTION
Resolves #19617, at least as far as the acute error goes. Using Rico's solution outright.
~Resolves~ Relates #11046 (core issue) - This narrows the use of `py::detail::keep_alive_impl()`

Closes #19615 (superseded)
Relates #19636 (attempt to make a `type_caster<>` for `copyable_unique_ptr<>`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19655)
<!-- Reviewable:end -->
