### PR TITLE
[doc] Add 1.18 release notes caveat for DockerHub

### DIFF
--- a/doc/_release-notes/v1.18.0.md
+++ b/doc/_release-notes/v1.18.0.md
@@ -121,6 +121,7 @@ Fixes
 <!-- <relnotes for cmake,doc,setup,third_party,tools go here> -->
 
 * Default clang_format_lint to be enabled in new packages ([#19547][_#19547])
+* By accident for this release only, the DockerHub tag ``1.18.0`` is based on Ubuntu 20.04 instead of Ubuntu 22.04.  Use the tag ``jammy-1.18.0`` instead if you want 22.04.
 
 ## Build dependencies
 


### PR DESCRIPTION
Amends #19534. Relates #19659.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19661)
<!-- Reviewable:end -->
