### PR TITLE
[sensors] RgbdSensor can be constructed from color properties only

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -163,7 +163,9 @@ void DoScalarIndependentDefinitions(py::module m) {
     cls  // BR
         .def(py::init<Class const&>(), py::arg("other"), "Copy constructor")
         .def(py::init<RenderCameraCore, DepthRange>(), py::arg("core"),
-            py::arg("depth_range"), cls_doc.ctor.doc)
+            py::arg("depth_range"), cls_doc.ctor.doc_2args)
+        .def(py::init<RenderCameraCore>(), py::arg("core"),
+            cls_doc.ctor.doc_1args)
         .def("core",
             static_cast<RenderCameraCore const& (Class::*)() const>(
                 &Class::core),

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -206,8 +206,9 @@ PYBIND11_MODULE(sensors, m) {
       m, "RgbdSensor", doc.RgbdSensor.doc);
 
   rgbd_sensor
-      .def(py::init<FrameId, const RigidTransformd&, ColorRenderCamera,
-               DepthRenderCamera>(),
+      .def(py::init<FrameId, const RigidTransformd&,
+               const std::optional<ColorRenderCamera>&,
+               const std::optional<DepthRenderCamera>&>(),
           py::arg("parent_id"), py::arg("X_PB"), py::arg("color_camera"),
           py::arg("depth_camera"),
           doc.RgbdSensor.ctor.doc_individual_intrinsics)
@@ -250,8 +251,8 @@ PYBIND11_MODULE(sensors, m) {
     py::class_<Class, LeafSystem<T>>(m, "RgbdSensorAsync", cls_doc.doc)
         .def(py::init<const geometry::SceneGraph<double>*, FrameId,
                  const math::RigidTransformd&, double, double, double,
-                 std::optional<ColorRenderCamera>,
-                 std::optional<DepthRenderCamera>, bool>(),
+                 const std::optional<ColorRenderCamera>&,
+                 const std::optional<DepthRenderCamera>&, bool>(),
             py::arg("scene_graph"), py::arg("parent_id"), py::arg("X_PB"),
             py::arg("fps"), py::arg("capture_offset"), py::arg("output_delay"),
             py::arg("color_camera"), py::arg("depth_camera") = std::nullopt,

--- a/geometry/render/render_camera.h
+++ b/geometry/render/render_camera.h
@@ -207,6 +207,10 @@ class DepthRenderCamera {
                           the clipping range.  */
   DepthRenderCamera(RenderCameraCore core, DepthRange depth_range);
 
+  /** Constructs a depth camera with the given core render properties.
+   The DepthRange will be chosen by a heuristic based on the clipping range.  */
+  explicit DepthRenderCamera(const RenderCameraCore& core);
+
   /** This camera's core render properties.  */
   const RenderCameraCore& core() const { return core_; }
 

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -422,6 +422,7 @@ drake_cc_googletest(
     deps = [
         ":rgbd_sensor",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//geometry/test_utilities:dummy_render_engine",
     ],
 )

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/query_object.h"
@@ -91,18 +93,19 @@ class RgbdSensor final : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RgbdSensor)
 
-  /** Constructs an %RgbdSensor with fully specified render camera models for
-   both color/label and depth cameras.
+  /** Constructs an %RgbdSensor using the given camera model(s). If one of the
+   two models is not provided, it is inferred from the other model.
+   @throws std::exception when neither model is provided.
    @pydrake_mkdoc_identifier{individual_intrinsics}  */
-  RgbdSensor(geometry::FrameId parent_id, const math::RigidTransformd& X_PB,
-             geometry::render::ColorRenderCamera color_camera,
-             geometry::render::DepthRenderCamera depth_camera);
+  RgbdSensor(
+      geometry::FrameId parent_id, const math::RigidTransformd& X_PB,
+      const std::optional<geometry::render::ColorRenderCamera>& color_camera,
+      const std::optional<geometry::render::DepthRenderCamera>& depth_camera);
 
-  /** Constructs an %RgbdSensor with fully specified render camera models for
-   both the depth camera. The color camera in inferred from the `depth_camera`;
-   it shares the same geometry::render::RenderCameraCore and is configured to
-   show the window based on the value of `show_color_window`.
-   @pydrake_mkdoc_identifier{combined_intrinsics}  */
+  /** Constructs an %RgbdSensor using the given depth camera model; the color
+   model is inferred from the depth model and is configured to show the window
+   based on the value of `show_color_window`.
+   @pydrake_mkdoc_identifier{combined_intrinsics} */
   RgbdSensor(geometry::FrameId parent_id, const math::RigidTransformd& X_PB,
              const geometry::render::DepthRenderCamera& depth_camera,
              bool show_color_window = false);
@@ -169,6 +172,11 @@ class RgbdSensor final : public LeafSystem<double> {
   const OutputPort<double>& body_pose_in_world_output_port() const;
 
  private:
+  RgbdSensor(int, geometry::FrameId parent_id,
+             const math::RigidTransformd& X_PB,
+             const geometry::render::ColorRenderCamera& color_camera,
+             const geometry::render::DepthRenderCamera& depth_camera);
+
   // The calculator methods for the four output ports.
   void CalcColorImage(const Context<double>& context,
                       ImageRgba8U* color_image) const;

--- a/systems/sensors/rgbd_sensor_async.h
+++ b/systems/sensors/rgbd_sensor_async.h
@@ -119,8 +119,9 @@ class RgbdSensorAsync final : public LeafSystem<double> {
       const geometry::SceneGraph<double>* scene_graph,
       geometry::FrameId parent_id, const math::RigidTransformd& X_PB,
       double fps, double capture_offset, double output_delay,
-      std::optional<geometry::render::ColorRenderCamera> color_camera,
-      std::optional<geometry::render::DepthRenderCamera> depth_camera = {},
+      const std::optional<geometry::render::ColorRenderCamera>& color_camera,
+      const std::optional<geometry::render::DepthRenderCamera>& depth_camera =
+          {},
       bool render_label_image = false);
 
   /** Returns the `parent_id` passed to the constructor. */

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/scene_graph.h"
@@ -391,6 +392,12 @@ TEST_F(RgbdSensorTest, ConstructCameraWithNonTrivialOffsetsDeprecated) {
       CompareMatrices(sensor.X_BC().GetAsMatrix4(), X_BC.GetAsMatrix4()));
   EXPECT_TRUE(
       CompareMatrices(sensor.X_BD().GetAsMatrix4(), X_BD.GetAsMatrix4()));
+}
+
+TEST_F(RgbdSensorTest, ErrorMissingCameras) {
+  DRAKE_EXPECT_THROWS_MESSAGE(RgbdSensor(SceneGraph<double>::world_frame_id(),
+                                         {}, std::nullopt, std::nullopt),
+                              ".*color_camera.*depth_camera.*");
 }
 
 // We don't explicitly test any of the image outputs. The image outputs simply


### PR DESCRIPTION
Towards #19662 and https://github.com/RobotLocomotion/drake/issues/19604 and https://github.com/RobotLocomotion/drake/issues/19437.

This centralizes the logic for how to infer the color properties from depth properties (or vice versa), which will be shared between both the discrete and async sensors. (It's also more convenient for users.  The `{Color|Depth}RenderCamera` constructors don't have enough defaults, and this is a step in a better direction.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19664)
<!-- Reviewable:end -->
