### PR TITLE
Add Reset functions for realtime rate calculation

### DIFF
--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -63,15 +63,18 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   explicit MeshcatVisualizer(std::shared_ptr<Meshcat> meshcat,
                              MeshcatVisualizerParams params = {});
 
-  /** Resets the realtime rate calculator so that realtime rate is accurate
-   * after simulator is resumed from a paused state. */
-  void ResetRealtimeRateCalculator() const { realtime_rate_calculator_.Reset(); }
-
   /** Scalar-converting copy constructor. See @ref system_scalar_conversion.
    It should only be used to convert _from_ double _to_ other scalar types.
    */
   template <typename U>
   explicit MeshcatVisualizer(const MeshcatVisualizer<U>& other);
+
+  /** Resets the realtime rate calculator. Calculation will resume on the next
+   periodic publish event. This is useful for correcting the realtime rate after
+   simulation is resumed from a paused state, etc. */
+  void ResetRealtimeRateCalculator() const {
+      realtime_rate_calculator_.Reset();
+  }
 
   /** Calls Meshcat::Delete(std::string path), with the path set to
    MeshcatVisualizerParams::prefix.  Since this visualizer will only ever add
@@ -162,6 +165,10 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    data. */
   template <typename>
   friend class MeshcatVisualizer;
+
+  /* Friend declaration so that internal states can be checked in unit
+  tests. */
+  friend class MeshcatVisualizerTester;
 
   /* The periodic event handler. It tests to see if the last scene description
    is valid (if not, sends the objects) and then sends the transforms.  */

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -63,6 +63,10 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   explicit MeshcatVisualizer(std::shared_ptr<Meshcat> meshcat,
                              MeshcatVisualizerParams params = {});
 
+  /** Resets the realtime rate calculator so that realtime rate is accurate
+   * after simulator is resumed from a paused state. */
+  void ResetRealtimeRateCalculator() const { realtime_rate_calculator_.Reset(); }
+
   /** Scalar-converting copy constructor. See @ref system_scalar_conversion.
    It should only be used to convert _from_ double _to_ other scalar types.
    */

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -1118,7 +1118,7 @@ GTEST_TEST(MeshcatTest, StaticHtml) {
   EXPECT_THAT(html, ::testing::Not(HasSubstr("CONNECTION BLOCK")));
 }
 
-// Check MeshcatParams.hide_stats_plot sends a hide_realtime_rate message
+// Check MeshcatParams.show_stats_plot sends a show_realtime_rate message
 GTEST_TEST(MeshcatTest, RealtimeRatePlot) {
   MeshcatParams params;
   params.show_stats_plot = true;

--- a/systems/analysis/instantaneous_realtime_rate_calculator.h
+++ b/systems/analysis/instantaneous_realtime_rate_calculator.h
@@ -24,6 +24,13 @@ class InstantaneousRealtimeRateCalculator {
    */
   std::optional<double> UpdateAndRecalculate(double current_sim_time);
 
+  /* If the simulator was paused, prev_sim_time_ should be set to nullopt
+   * so that the timer is not used in the calculation of realtime rate on
+   * the first call after the simulator is resumed. Otherwise the realtime
+   * rate value would be inaccurate since the timer was not paused.
+   */
+  void Reset() { prev_sim_time_ = std::nullopt; }
+
   /* (Internal use for unit testing only) Used to mock the monotonic wall time
      source to control time during unit testing.  */
 #ifndef DRAKE_DOXYGEN_CXX

--- a/systems/analysis/instantaneous_realtime_rate_calculator.h
+++ b/systems/analysis/instantaneous_realtime_rate_calculator.h
@@ -24,10 +24,9 @@ class InstantaneousRealtimeRateCalculator {
    */
   std::optional<double> UpdateAndRecalculate(double current_sim_time);
 
-  /* If the simulator was paused, prev_sim_time_ should be set to nullopt
-   * so that the timer is not used in the calculation of realtime rate on
-   * the first call after the simulator is resumed. Otherwise the realtime
-   * rate value would be inaccurate since the timer was not paused.
+  /* Resets the internal state of `this` rate calculator. After a call, the next
+   call to UpdateAndRecalculate() will re-seed the rate calculation as if it was
+   the first call.
    */
   void Reset() { prev_sim_time_ = std::nullopt; }
 

--- a/systems/analysis/test/instantaneous_realtime_rate_calculator_test.cc
+++ b/systems/analysis/test/instantaneous_realtime_rate_calculator_test.cc
@@ -32,11 +32,12 @@ GTEST_TEST(InstantaneousRealtimeRateCalculatorTest, BasicTest) {
   EXPECT_FALSE(calculator.UpdateAndRecalculate(0.0).has_value());
   EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 1.0);
 
-  // Pause simulator and RTR should be zero. Note that in practice meshcat
-  // still shows the RTR before pause since the simulation is paused and
-  // meshcat system is not publishing updated RTRs anymore.
+  // Calling UpdateAndRecalcuate() again with the same sim time will
+  // return 0.0 RTR.
   EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 0.0);
 
+  // InstantaneousRealtimeRatecalculator should reset properly on call
+  // to Reset().
   calculator.Reset();
 
   // First call to UpdateAndRecalculate() after Reset() returns nullopt

--- a/systems/analysis/test/instantaneous_realtime_rate_calculator_test.cc
+++ b/systems/analysis/test/instantaneous_realtime_rate_calculator_test.cc
@@ -18,11 +18,9 @@ class MockTimer final : public Timer {
 // Tests that the InstantaneousRealtimeRateCalculator calculates the correct
 // results including startup and rewinding time.
 GTEST_TEST(InstantaneousRealtimeRateCalculatorTest, BasicTest) {
-  auto timer = std::make_unique<MockTimer>();
-
   InstantaneousRealtimeRateCalculator calculator{};
-  calculator.InjectMockTimer(std::move(timer));
-  // First call is seed and gives nullopt result.
+  calculator.InjectMockTimer(std::make_unique<MockTimer>());
+  // First (seed) call returns nullopt.
   EXPECT_FALSE(calculator.UpdateAndRecalculate(0.0).has_value());
 
   // Next calls return correct value.
@@ -33,30 +31,18 @@ GTEST_TEST(InstantaneousRealtimeRateCalculatorTest, BasicTest) {
   // Reset time and observe another nullopt result.
   EXPECT_FALSE(calculator.UpdateAndRecalculate(0.0).has_value());
   EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 1.0);
-}
 
-// Tests that the InstantaneousRealtimeRateCalculator resets properly
-// after simulation is paused.
-GTEST_TEST(InstantaneousRealtimeRateCalculatorTest, UnpausedSimTest) {
-  auto timer = std::make_unique<MockTimer>();
+  // Pause simulator and RTR should be zero. Note that in practice meshcat
+  // still shows the RTR before pause since the simulation is paused and
+  // meshcat system is not publishing updated RTRs anymore.
+  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 0.0);
 
-  InstantaneousRealtimeRateCalculator calculator{};
-  calculator.InjectMockTimer(std::move(timer));
-  // First call is seed and gives nullopt result.
-  EXPECT_FALSE(calculator.UpdateAndRecalculate(0.0).has_value());
-
-  // Next calls return correct value.
-  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 1.0);
-  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.2).value(), 1.0);
-  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.4).value(), 2.0);
-
-  // Pause simulation for 2.0 seconds, then unpausing will reset the 
-  // prev_sim_time_ to nullopt, so the next calculation will be correct.
   calculator.Reset();
 
-  // Reset time and observe another nullopt result.
-  EXPECT_FALSE(calculator.UpdateAndRecalculate(2.5).has_value());
-  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(2.6).value(), 1.0);
+  // First call to UpdateAndRecalculate() after Reset() returns nullopt
+  // and calculation resumes on the next call.
+  EXPECT_FALSE(calculator.UpdateAndRecalculate(0.2).has_value());
+  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.3).value(), 1.0);
 }
 }  // namespace
 }  // namespace systems

--- a/systems/analysis/test/instantaneous_realtime_rate_calculator_test.cc
+++ b/systems/analysis/test/instantaneous_realtime_rate_calculator_test.cc
@@ -34,6 +34,30 @@ GTEST_TEST(InstantaneousRealtimeRateCalculatorTest, BasicTest) {
   EXPECT_FALSE(calculator.UpdateAndRecalculate(0.0).has_value());
   EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 1.0);
 }
+
+// Tests that the InstantaneousRealtimeRateCalculator resets properly
+// after simulation is paused.
+GTEST_TEST(InstantaneousRealtimeRateCalculatorTest, UnpausedSimTest) {
+  auto timer = std::make_unique<MockTimer>();
+
+  InstantaneousRealtimeRateCalculator calculator{};
+  calculator.InjectMockTimer(std::move(timer));
+  // First call is seed and gives nullopt result.
+  EXPECT_FALSE(calculator.UpdateAndRecalculate(0.0).has_value());
+
+  // Next calls return correct value.
+  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 1.0);
+  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.2).value(), 1.0);
+  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.4).value(), 2.0);
+
+  // Pause simulation for 2.0 seconds, then unpausing will reset the 
+  // prev_sim_time_ to nullopt, so the next calculation will be correct.
+  calculator.Reset();
+
+  // Reset time and observe another nullopt result.
+  EXPECT_FALSE(calculator.UpdateAndRecalculate(2.5).has_value());
+  EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(2.6).value(), 1.0);
+}
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Previously when resuming simulator from a paused state, the realtime rate (RTR) calculator will use a wrong prev_sim_time_, resulting in a sudden drop of RTR in meshcat. This adds a new API ResetRealtimeRateCalculator() to meshcat visualizer which should be called upon simulation resuming to fix the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19667)
<!-- Reviewable:end -->
