### PR TITLE
Hyperellipsoid::MinimumUniformScalingToTouch handles the empty case.

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -387,6 +387,7 @@ drake_cc_googletest(
         ":convex_set",
         ":test_utilities",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//common/yaml",
     ],
 )

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -138,11 +138,20 @@ std::pair<double, VectorXd> Hyperellipsoid::MinimumUniformScalingToTouch(
   solvers::MathematicalProgramResult result;
   solver->Solve(prog, std::nullopt, std::nullopt, &result);
   if (!result.is_success()) {
-    throw std::runtime_error(fmt::format(
-        "Solver {} failed to solve the `minimum uniform scaling to touch' "
-        "problem; it terminated with SolutionResult {}). This should not "
-        "happen.",
-        result.get_solver_id().name(), result.get_solution_result()));
+    // Check if `other` is empty.
+    MathematicalProgram prog2;
+    auto x2 = prog2.NewContinuousVariables(ambient_dimension());
+    other.AddPointInSetConstraints(&prog2, x2);
+    auto result2 = Solve(prog2);
+    if (!result2.is_success()) {
+      throw std::runtime_error("The set `other` is empty.");
+    } else {
+      throw std::runtime_error(fmt::format(
+          "Solver {} failed to solve the `minimum uniform scaling to touch' "
+          "problem; it terminated with SolutionResult {}). The solver likely "
+          "ran into numerical issues.",
+          result.get_solver_id().name(), result.get_solution_result()));
+    }
   }
   return std::pair<double, VectorXd>(std::sqrt(result.get_optimal_cost()),
                                      result.GetSolution(x));

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -63,6 +63,7 @@ class Hyperellipsoid final : public ConvexSet {
   precision).
   @pre `other` must have the same ambient_dimension as this.
   @returns the minimal scaling and the witness point, x, on other.
+  @throws std::exception if `other` is empty.
   @throws std::exception if ambient_dimension() == 0 */
   std::pair<double, Eigen::VectorXd> MinimumUniformScalingToTouch(
       const ConvexSet& other) const;

--- a/geometry/optimization/test/hyperellipsoid_test.cc
+++ b/geometry/optimization/test/hyperellipsoid_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
@@ -19,6 +20,7 @@ namespace drake {
 namespace geometry {
 namespace optimization {
 
+using Eigen::Matrix2d;
 using Eigen::Matrix3d;
 using Eigen::MatrixXd;
 using Eigen::RowVector2d;
@@ -500,6 +502,20 @@ GTEST_TEST(HyperellipsoidTest, MinimumUniformScaling4) {
   auto [sigma, x] = E.MinimumUniformScalingToTouch(E2);
   EXPECT_NEAR(sigma, 3.0, kTol);
   EXPECT_TRUE(CompareMatrices(x, Vector2d{3.0, 0.0}, kTol));
+}
+
+// Check the case when `other` has no interior.
+GTEST_TEST(HyperellipsoidTest, MinimumUniformScaling5) {
+  const Hyperellipsoid E = Hyperellipsoid::MakeUnitBall(2);
+  // x₀ ≤ -1, x₀ ≥ 1.
+  Matrix2d A;
+  // clang-format off
+  A <<  1, 0,
+       -1, 0;
+  // clang-format on
+  const HPolyhedron H(A, Vector2d(-1, -1));
+  DRAKE_EXPECT_THROWS_MESSAGE(E.MinimumUniformScalingToTouch(H),
+                              ".*is empty.*");
 }
 
 GTEST_TEST(HyperellipsoidTest, Serialize) {


### PR DESCRIPTION
Previously, if the set `other` had no interior, the solver would fail the method would throw a confusing error message. Now it handles this case explicitly.

This PR also resolves a TODO to return to ChooseBestSolver in the MinimumUniformScalingToTouch now that #15320 is resolved.

+@cohnt for feature review, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19671)
<!-- Reviewable:end -->
