### PR TITLE
Adds some text logging to IrisInConfigurationSpace

### DIFF
--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -428,7 +428,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
   // Check the inputs.
   plant.ValidateContext(context);
   const int nq = plant.num_positions();
-  const Eigen::VectorXd sample = plant.GetPositions(context);
+  const Eigen::VectorXd seed = plant.GetPositions(context);
   const int nc = static_cast<int>(options.configuration_obstacles.size());
   // Note: We require finite joint limits to define the bounding box for the
   // IRIS algorithm.
@@ -437,7 +437,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
   DRAKE_DEMAND(options.num_collision_infeasible_samples >= 0);
   for (int i = 0; i < nc; ++i) {
     DRAKE_DEMAND(options.configuration_obstacles[i]->ambient_dimension() == nq);
-    if (options.configuration_obstacles[i]->PointInSet(sample)) {
+    if (options.configuration_obstacles[i]->PointInSet(seed)) {
       throw std::runtime_error(
           fmt::format("The seed point is in configuration obstacle {}", i));
     }
@@ -454,7 +454,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
   DRAKE_DEMAND(P.A().rows() == 2 * nq);
   const double kEpsilonEllipsoid = 1e-2;
   Hyperellipsoid E = options.starting_ellipse.value_or(
-      Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample));
+      Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, seed));
 
   // Make all of the convex sets and supporting quantities.
   auto query_object =
@@ -482,7 +482,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
       std::make_shared<internal::SamePointConstraint>(&plant, context);
 
   // As a surrogate for the true objective, the pairs are sorted by the distance
-  // between each collision pair from the sample point configuration. This could
+  // between each collision pair from the seed point configuration. This could
   // improve computation times and produce regions with fewer faces.
   std::vector<GeometryPairWithDistance> sorted_pairs;
   for (const auto& [geomA, geomB] : pairs) {
@@ -520,10 +520,10 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
     // Fail fast if the seed point is infeasible.
     {
       if (!options.prog_with_additional_constraints->CheckSatisfied(
-              additional_constraint_bindings, sample)) {
+              additional_constraint_bindings, seed)) {
         throw std::runtime_error(
             "options.prog_with_additional_constraints is infeasible at the "
-            "sample point. The seed point must be feasible.");
+            "seed point. The seed point must be feasible.");
       }
     }
     // Handle bounding box and linear constraints as a special case (extracting
@@ -572,7 +572,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
                     b.head(num_initial_constraints));
   }
 
-  DRAKE_THROW_UNLESS(P.PointInSet(sample, 1e-12));
+  DRAKE_THROW_UNLESS(P.PointInSet(seed, 1e-12));
 
   double best_volume = E.Volume();
   int iteration = 0;
@@ -585,9 +585,10 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
       {solvers::SnoptSolver::id(), solvers::IpoptSolver::id()});
 
   while (true) {
+    log()->info("IrisInConfigurationSpace iteration {}", iteration);
     int num_constraints = num_initial_constraints;
-    bool sample_point_requirement = true;
-    VectorXd guess = sample;
+    VectorXd guess = seed;
+    bool seed_point_requirement = true;
     HPolyhedron P_candidate = P;
     DRAKE_ASSERT(best_volume > 0);
     // Find separating hyperplanes
@@ -615,14 +616,13 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
       }
 
       if (options.require_sample_point_is_contained) {
-        sample_point_requirement =
-            ((A.topRows(num_constraints) * sample).array() <=
-             b.head(num_constraints).array())
-                .any();
+        seed_point_requirement = ((A.topRows(num_constraints) * seed).array() <=
+                                  b.head(num_constraints).array())
+                                     .any();
       }
     }
 
-    if (!sample_point_requirement) break;
+    if (!seed_point_requirement) break;
 
     // Use the fast nonlinear optimizer until it fails
     // num_collision_infeasible_samples consecutive times.
@@ -632,8 +632,9 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
           same_point_constraint, *frames.at(pair.geomA), *frames.at(pair.geomB),
           *sets.at(pair.geomA), *sets.at(pair.geomB), E,
           A.topRows(num_constraints), b.head(num_constraints));
-      while (sample_point_requirement &&
-             consecutive_failures < options.num_collision_infeasible_samples) {
+      int counter_example_searches_for_this_pair = 0;
+      bool warned_many_searches = false;
+      while (consecutive_failures < options.num_collision_infeasible_samples) {
         if (prog.Solve(*solver, guess, &closest)) {
           consecutive_failures = 0;
           AddTangentToPolytope(E, closest, options.configuration_space_margin,
@@ -642,9 +643,9 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
               HPolyhedron(A.topRows(num_constraints), b.head(num_constraints));
           MakeGuessFeasible(P_candidate, options, closest, &guess);
           if (options.require_sample_point_is_contained) {
-            sample_point_requirement =
-                A.row(num_constraints - 1) * sample <= b(num_constraints - 1);
-            if (!sample_point_requirement) break;
+            seed_point_requirement =
+                A.row(num_constraints - 1) * seed <= b(num_constraints - 1);
+            if (!seed_point_requirement) break;
           }
           prog.UpdatePolytope(A.topRows(num_constraints),
                               b.head(num_constraints));
@@ -652,10 +653,28 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
           ++consecutive_failures;
         }
         guess = P_candidate.UniformSample(&generator, guess);
+        if (!warned_many_searches &&
+            counter_example_searches_for_this_pair >=
+                10 * options.num_collision_infeasible_samples) {
+          warned_many_searches = true;
+          log()->info(
+              " Checking {} against {} has already required {} counter-example "
+              "searches; still searching...",
+              inspector.GetName(pair.geomA), inspector.GetName(pair.geomB),
+              counter_example_searches_for_this_pair);
+        }
       }
+      if (warned_many_searches) {
+        log()->info(
+            " Finished checking {} against {} after {} counter-example "
+            "searches.",
+            inspector.GetName(pair.geomA), inspector.GetName(pair.geomB),
+            counter_example_searches_for_this_pair);
+      }
+      if (!seed_point_requirement) break;
     }
 
-    if (!sample_point_requirement) break;
+    if (!seed_point_requirement) break;
 
     if (options.prog_with_additional_constraints) {
       counter_example_prog->UpdatePolytope(A.topRows(num_constraints),
@@ -686,10 +705,9 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
                                           b.head(num_constraints));
                 MakeGuessFeasible(P_candidate, options, closest, &guess);
                 if (options.require_sample_point_is_contained) {
-                  sample_point_requirement =
-                      A.row(num_constraints - 1) * sample <=
-                      b(num_constraints - 1);
-                  if (!sample_point_requirement) break;
+                  seed_point_requirement = A.row(num_constraints - 1) * seed <=
+                                           b(num_constraints - 1);
+                  if (!seed_point_requirement) break;
                 }
                 counter_example_prog->UpdatePolytope(A.topRows(num_constraints),
                                                      b.head(num_constraints));
@@ -703,7 +721,7 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
       }
     }
 
-    if (!sample_point_requirement) break;
+    if (!seed_point_requirement) break;
 
     P = HPolyhedron(A.topRows(num_constraints), b.head(num_constraints));
 


### PR DESCRIPTION
For long-running calls to IRIS, this gives some much needed feedback. It also can give some insights on if/where IRIS is getting bogged down.

This PR also clarifies the usage of the term "seed" vs "samples" vs "searches", which got even more confusing when we start reporting excessive numbers of searches.

The code does not change the computation (and therefore does not change the tests).

+@cohnt for feature review, please?
cc @rhjiang

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19673)
<!-- Reviewable:end -->
