### PR TITLE
Avoid false self collisions in iiwa_primitive_collision.urdf

### DIFF
--- a/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf
@@ -295,7 +295,9 @@
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://drake_models/iiwa_description/meshes/iiwa14/collision/link_7_polytope.obj"/>
+        <mesh filename="package://drake_models/iiwa_description/meshes/iiwa14/collision/link_7_polytope.obj">
+          <drake:declare_convex/>
+        </mesh>
       </geometry>
       <material name="Grey"/>
     </collision>
@@ -316,6 +318,12 @@
   <link name="left_iiwa_link_ee">
     </link>
   <frame link="left_iiwa_link_ee" name="left_iiwa_frame_ee" rpy="3.141592653589793 0 1.570796326794897" xyz="0.09 0 0"/>
+  <drake:collision_filter_group name="left_iiwa_wrist">
+    <drake:member link="left_iiwa_link_5"/>
+    <drake:member link="left_iiwa_link_6"/>
+    <drake:member link="left_iiwa_link_7"/>
+    <drake:ignored_collision_filter_group name="left_iiwa_wrist"/>
+  </drake:collision_filter_group>
   <!-- Load Gazebo lib and set the robot namespace -->
   <gazebo>
     <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_controller">
@@ -711,7 +719,9 @@
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://drake_models/iiwa_description/meshes/iiwa14/collision/link_7_polytope.obj"/>
+        <mesh filename="package://drake_models/iiwa_description/meshes/iiwa14/collision/link_7_polytope.obj">
+          <drake:declare_convex/>
+        </mesh>
       </geometry>
       <material name="Grey"/>
     </collision>
@@ -732,6 +742,12 @@
   <link name="right_iiwa_link_ee">
     </link>
   <frame link="right_iiwa_link_ee" name="right_iiwa_frame_ee" rpy="3.141592653589793 0 1.570796326794897" xyz="0.09 0 0"/>
+  <drake:collision_filter_group name="right_iiwa_wrist">
+    <drake:member link="right_iiwa_link_5"/>
+    <drake:member link="right_iiwa_link_6"/>
+    <drake:member link="right_iiwa_link_7"/>
+    <drake:ignored_collision_filter_group name="right_iiwa_wrist"/>
+  </drake:collision_filter_group>
   <!-- Load Gazebo lib and set the robot namespace -->
   <gazebo>
     <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_controller">

--- a/manipulation/models/iiwa_description/urdf/iiwa14.xacro
+++ b/manipulation/models/iiwa_description/urdf/iiwa14.xacro
@@ -442,7 +442,9 @@
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0"/>
           <geometry>
-            <mesh filename="package://drake_models/iiwa_description/meshes/iiwa14/collision/link_7_polytope.obj"/>
+            <mesh filename="package://drake_models/iiwa_description/meshes/iiwa14/collision/link_7_polytope.obj">
+              <drake:declare_convex/>
+            </mesh>
           </geometry>
           <material name="Grey"/>
         </collision>
@@ -464,6 +466,12 @@
     <link name="${robot_name}_link_ee">
     </link>
     <frame name="${robot_name}_frame_ee" link="${robot_name}_link_ee" xyz="0.09 0 0" rpy="3.141592653589793 0 1.570796326794897"/>
+    <drake:collision_filter_group name="${robot_name}_wrist">
+      <drake:member link="${robot_name}_link_5"/>
+      <drake:member link="${robot_name}_link_6"/>
+      <drake:member link="${robot_name}_link_7"/>
+      <drake:ignored_collision_filter_group name="${robot_name}_wrist"/>
+    </drake:collision_filter_group>
     <!--Extensions -->
     <xacro:iiwa_gazebo robot_name="${robot_name}"/>
     <xacro:iiwa_transmission hardware_interface="${hardware_interface}" robot_name="${robot_name}"/>

--- a/manipulation/models/iiwa_description/urdf/iiwa14_polytope_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_polytope_collision.urdf
@@ -290,8 +290,10 @@
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://drake_models/iiwa_description/meshes/iiwa14/collision/link_7_polytope.obj"/>
-      </geometry>
+        <mesh filename="package://drake_models/iiwa_description/meshes/iiwa14/collision/link_7_polytope.obj">
+          <drake:declare_convex/>
+        </mesh>
+       </geometry>
       <material name="Grey"/>
     </collision>
   </link>
@@ -311,6 +313,12 @@
   <link name="iiwa_link_ee">
     </link>
   <frame link="iiwa_link_ee" name="iiwa_frame_ee" rpy="3.141592653589793 0 1.570796326794897" xyz="0.09 0 0"/>
+  <drake:collision_filter_group name="iiwa_wrist">
+    <drake:member link="iiwa_link_5"/>
+    <drake:member link="iiwa_link_6"/>
+    <drake:member link="iiwa_link_7"/>
+    <drake:ignored_collision_filter_group name="iiwa_wrist"/>
+  </drake:collision_filter_group>
   <!-- Load Gazebo lib and set the robot namespace -->
   <gazebo>
     <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_controller">

--- a/manipulation/models/iiwa_description/urdf/iiwa14_primitive_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_primitive_collision.urdf
@@ -366,6 +366,12 @@
   <link name="iiwa_link_ee">
     </link>
   <frame link="iiwa_link_ee" name="iiwa_frame_ee" rpy="3.141592653589793 0 1.570796326794897" xyz="0.09 0 0"/>
+  <drake:collision_filter_group name="iiwa_wrist">
+    <drake:member link="iiwa_link_5"/>
+    <drake:member link="iiwa_link_6"/>
+    <drake:member link="iiwa_link_7"/>
+    <drake:ignored_collision_filter_group name="iiwa_wrist"/>
+  </drake:collision_filter_group>
   <!-- Load Gazebo lib and set the robot namespace -->
   <gazebo>
     <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_controller">


### PR DESCRIPTION
Adds a collision filter group to all iiwa models to avoid self collisions between links 5 through 7.

To see the change, one can run
```
from pydrake.visualization import ModelVisualizer

v = ModelVisualizer()
v.AddModels(url="package://drake/manipulation/models/iiwa_description/urdf/iiwa14_primitive_collision.urdf")
plant = v.parser().plant()
plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"))
v.Finalize()
v.Run(position=[0, 0.3, 0, -1.8, 0, 1, 1.57])
```
Before the change, the visualizer will show the self collision. After the change there is no collision.

This PR also adds a missing declare_convex tag to the polytopic geometry.

![meshcat](https://github.com/RobotLocomotion/drake/assets/6442292/7521d67a-3db9-4671-a924-c851d8279d4b)


+@rcory for feature review, please.
Towards #19514.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19674)
<!-- Reviewable:end -->
