### PR TITLE
Implements MultibodyPlant::MakeVelocityToQDotMap and MakeQDotToVelocityMap

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -407,6 +407,7 @@ drake_py_unittest(
         ":tree_py",
         "//bindings/pydrake/common/test_utilities:numpy_compare_py",
         "//bindings/pydrake/common/test_utilities:pickle_compare_py",
+        "//bindings/pydrake/common/test_utilities:scipy_stub_py",
         "//bindings/pydrake/systems:analysis_py",
         "//bindings/pydrake/systems:scalar_conversion_py",
     ],

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -671,6 +671,13 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("CalcRelativeTransform", &Class::CalcRelativeTransform,
             py::arg("context"), py::arg("frame_A"), py::arg("frame_B"),
             cls_doc.CalcRelativeTransform.doc);
+    if constexpr (std::is_same_v<T, double>) {
+      cls  // BR
+          .def("MakeVelocityToQDotMap", &Class::MakeVelocityToQDotMap,
+              py::arg("context"), cls_doc.MakeVelocityToQDotMap.doc)
+          .def("MakeQDotToVelocityMap", &Class::MakeQDotToVelocityMap,
+              py::arg("context"), cls_doc.MakeQDotToVelocityMap.doc);
+    }
     // Topology queries.
     cls  // BR
         .def("num_frames", &Class::num_frames, cls_doc.num_frames.doc)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -7,6 +7,7 @@ import pickle
 import unittest
 
 import numpy as np
+import scipy.sparse
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression, Variable
@@ -1754,11 +1755,18 @@ class TestPlant(unittest.TestCase):
             [0.4, 0.5, 0.6])
         self.assertNotEqual(link0.floating_positions_start(), -1)
         self.assertNotEqual(link0.floating_velocities_start(), -1)
-        v_expected = np.linspace(start=-1.0, stop=-nv, num=nv)
         self.assertFalse(plant.IsVelocityEqualToQDot())
+        v_expected = np.linspace(start=-1.0, stop=-nv, num=nv)
         qdot = plant.MapVelocityToQDot(context, v_expected)
         v_remap = plant.MapQDotToVelocity(context, qdot)
         numpy_compare.assert_float_allclose(v_remap, v_expected)
+        # Bindings for Eigen::SparseMatrix only support T=float for now.
+        if T == float:
+            N = plant.MakeVelocityToQDotMap(context)
+            numpy_compare.assert_float_allclose(qdot, N.todense() @ v_expected)
+            Nplus = plant.MakeQDotToVelocityMap(context)
+            numpy_compare.assert_float_allclose(v_expected,
+                                                Nplus.todense() @ qdot)
 
     @numpy_compare.check_all_types
     def test_multibody_add_joint(self, T):

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -857,7 +857,7 @@ class GeometryState {
   // sources (e.g., frames and geometries). This lives in the state to support
   // runtime topology changes. This data should only change at _discrete_
   // events where frames/geometries are introduced and removed. They do _not_
-  // depend on time-dependent input values (e.g., System::Context).
+  // depend on time-dependent input values (e.g., systems::Context).
 
   // The registered geometry sources and the frame ids that have been registered
   // on them.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3376,6 +3376,39 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     DRAKE_DEMAND(v != nullptr);
     internal_tree().MapQDotToVelocity(context, qdot, v);
   }
+
+  /// Returns the matrix `N(q)`, which maps `q̇ = N(q)⋅v`, as described in
+  /// MapVelocityToQDot(). Prefer calling MapVelocityToQDot() directly; this
+  /// entry point is provided to support callers that require the explicit
+  /// linear form (once q is given) of the relationship. Do not take the
+  /// (pseudo-)inverse of `N(q)`; call MakeQDotToVelocityMap instead. This
+  /// method is, in the worst case, O(n), where n is the number of joints.
+  ///
+  /// @param[in] context
+  ///   The context containing the state of the model.
+  ///
+  /// @see MapVelocityToQDot()
+  Eigen::SparseMatrix<T> MakeVelocityToQDotMap(
+      const systems::Context<T>& context) {
+    this->ValidateContext(context);
+    return internal_tree().MakeVelocityToQDotMap(context);
+  }
+
+  /// Returns the matrix `N⁺(q)`, which maps `v = N⁺(q)⋅q̇`, as described in
+  /// MapQDotToVelocity(). Prefer calling MapQDotToVelocity() directly; this
+  /// entry point is provided to support callers that require the explicit
+  /// linear form (once q is given) of the relationship. This method is, in the
+  /// worst case, O(n), where n is the number of joints.
+  ///
+  /// @param[in] context
+  ///   The context containing the state of the model.
+  ///
+  /// @see MapVelocityToQDot()
+  Eigen::SparseMatrix<T> MakeQDotToVelocityMap(
+      const systems::Context<T>& context) {
+    this->ValidateContext(context);
+    return internal_tree().MakeQDotToVelocityMap(context);
+  }
   /// @} <!-- Kinematic and dynamic computations -->
 
   /// @anchor mbp_system_matrix_computations

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -2181,6 +2181,8 @@ GTEST_TEST(MultibodyPlantTest, MapVelocityToQDotAndBackFixedWorld) {
   BasicVector<double> qdot(0), v(0);
   ASSERT_NO_THROW(plant.MapVelocityToQDot(*context, v, &qdot));
   ASSERT_NO_THROW(plant.MapQDotToVelocity(*context, qdot, &v));
+  ASSERT_NO_THROW(plant.MakeVelocityToQDotMap(*context));
+  ASSERT_NO_THROW(plant.MakeQDotToVelocityMap(*context));
 }
 
 GTEST_TEST(MultibodyPlantTest, MapVelocityToQDotAndBackContinuous) {
@@ -2207,6 +2209,11 @@ GTEST_TEST(MultibodyPlantTest, MapVelocityToQDotAndBackContinuous) {
   const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(
       CompareMatrices(v_back.CopyToVector(), v.CopyToVector(), kTolerance));
+
+  Eigen::SparseMatrix<double> N = plant.MakeVelocityToQDotMap(*context);
+  EXPECT_TRUE(CompareMatrices(qdot.value(), N * v.value(), kTolerance));
+  Eigen::SparseMatrix<double> Nplus = plant.MakeQDotToVelocityMap(*context);
+  EXPECT_TRUE(CompareMatrices(v.value(), Nplus * qdot.value(), kTolerance));
 }
 
 GTEST_TEST(MultibodyPlantTest, MapVelocityToQDotAndBackDiscrete) {
@@ -3403,6 +3410,21 @@ GTEST_TEST(StateSelection, FloatingBodies) {
       plant.SetFreeBodyPoseInAnchoredFrame(
           context.get(), end_effector_frame, mug, X_OM),
       "Frame 'iiwa_link_7' must be anchored to the world frame.");
+
+  // Check qdot to v mappings.
+  VectorXd q = Eigen::VectorXd::LinSpaced(plant.num_positions(), -1, 1);
+  VectorXd v = Eigen::VectorXd::LinSpaced(plant.num_velocities(), -2, 2);
+  VectorXd qdot(plant.num_positions());
+  VectorXd v_back(plant.num_velocities());
+  plant.SetPositions(context.get(), q);
+  plant.MapVelocityToQDot(*context, v, &qdot);
+  plant.MapQDotToVelocity(*context, qdot, &v_back);
+  EXPECT_TRUE(CompareMatrices(v, v_back, kTolerance));
+  const Eigen::SparseMatrix<double> N = plant.MakeVelocityToQDotMap(*context);
+  const Eigen::SparseMatrix<double> Nplus =
+      plant.MakeQDotToVelocityMap(*context);
+  EXPECT_TRUE(CompareMatrices(qdot, N*v, kTolerance));
+  EXPECT_TRUE(CompareMatrices(v, Nplus*qdot, kTolerance));
 }
 
 GTEST_TEST(SetRandomTest, FloatingBodies) {

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1572,6 +1572,70 @@ void MultibodyTree<T>::MapVelocityToQDot(
 }
 
 template <typename T>
+Eigen::SparseMatrix<T> MultibodyTree<T>::MakeVelocityToQDotMap(
+    const systems::Context<T>& context) const {
+  Eigen::SparseMatrix<T> N(num_positions(), num_velocities());
+  if (IsVelocityEqualToQDot()) {
+    N.setIdentity();
+    return N;
+  }
+
+  // TODO(russt): Consider updating Mobilizer::CalcNMatrix to populate the
+  // SparseMatrix directly. But SparseMatrix does not support block writing
+  // operations, so we will likely need to pass the entire matrix, and each
+  // mobilizer will need to populate according to position_start_in_q() and
+  // velocity_start_in_v().
+  std::vector<Eigen::Triplet<T>> triplet_list;
+  // Note: We don't reserve storage for the triplet_list, because we don't have
+  // a useful estimate of the size in general.
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, 0, 7, 6> N_mobilizer;
+  for (const auto& mobilizer : owned_mobilizers_) {
+    N_mobilizer.resize(mobilizer->num_positions(), mobilizer->num_velocities());
+    mobilizer->CalcNMatrix(context, &N_mobilizer);
+    for (int i = 0; i < mobilizer->num_positions(); ++i) {
+      for (int j = 0; j < mobilizer->num_velocities(); ++j) {
+        if (N_mobilizer(i, j) != 0) {
+          triplet_list.push_back(Eigen::Triplet<T>(
+              mobilizer->position_start_in_q() + i,
+              mobilizer->velocity_start_in_v() + j, N_mobilizer(i, j)));
+        }
+      }
+    }
+  }
+  N.setFromTriplets(triplet_list.begin(), triplet_list.end());
+  return N;
+}
+
+template <typename T>
+Eigen::SparseMatrix<T> MultibodyTree<T>::MakeQDotToVelocityMap(
+      const systems::Context<T>& context) const {
+  Eigen::SparseMatrix<T> Nplus(num_velocities(), num_positions());
+  if (IsVelocityEqualToQDot()) {
+    Nplus.setIdentity();
+    return Nplus;
+  }
+
+  std::vector<Eigen::Triplet<T>> triplet_list;
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, 0, 6, 7> Nplus_mobilizer;
+  for (const auto& mobilizer : owned_mobilizers_) {
+    Nplus_mobilizer.resize(mobilizer->num_velocities(),
+                           mobilizer->num_positions());
+    mobilizer->CalcNplusMatrix(context, &Nplus_mobilizer);
+    for (int i = 0; i < mobilizer->num_velocities(); ++i) {
+      for (int j = 0; j < mobilizer->num_positions(); ++j) {
+        if (Nplus_mobilizer(i, j) != 0) {
+          triplet_list.push_back(Eigen::Triplet<T>(
+              mobilizer->velocity_start_in_v() + i,
+              mobilizer->position_start_in_q() + j, Nplus_mobilizer(i, j)));
+        }
+      }
+    }
+  }
+  Nplus.setFromTriplets(triplet_list.begin(), triplet_list.end());
+  return Nplus;
+}
+
+template <typename T>
 void MultibodyTree<T>::CalcMassMatrixViaInverseDynamics(
     const systems::Context<T>& context, EigenPtr<MatrixX<T>> M) const {
   DRAKE_DEMAND(M != nullptr);

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1703,6 +1703,14 @@ class MultibodyTree {
       const Eigen::Ref<const VectorX<T>>& qdot,
       EigenPtr<VectorX<T>> v) const;
 
+  // See MultibodyPlant method.
+  Eigen::SparseMatrix<T> MakeVelocityToQDotMap(
+      const systems::Context<T>& context) const;
+
+  // See MultibodyPlant method.
+  Eigen::SparseMatrix<T> MakeQDotToVelocityMap(
+      const systems::Context<T>& context) const;
+
   /**
   @anchor internal_forward_dynamics
   @name Articulated Body Algorithm Forward Dynamics.


### PR DESCRIPTION
This was needed immediately for #19522, but is useful particularly for optimization algorithms which need to know the linear form (given q) of the map from velocity to qdot (and back).

+@sherm1 for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19675)
<!-- Reviewable:end -->
