### PR TITLE
[py visualization] Meldis supports inertia visualization

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -339,9 +339,29 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.DeleteRecording.doc)
         .def("get_mutable_recording", &Class::get_mutable_recording,
             py_rvp::reference_internal, cls_doc.get_mutable_recording.doc)
-        .def("HasPath", &Class::HasPath, py::arg("path"), cls_doc.HasPath.doc);
-    // Note: we intentionally do not bind the advanced methods (GetPacked...)
-    // which were intended primarily for testing in C++.
+        .def("HasPath", &Class::HasPath, py::arg("path"), cls_doc.HasPath.doc)
+        // These methods are intended to primarily for testing. Because they
+        // are excluded from C++ Doxygen, we bind them privately here.
+        .def(
+            "_GetPackedObject",
+            [](const Class& self, std::string_view path) {
+              return py::bytes(self.GetPackedObject(path));
+            },
+            py::arg("path"))
+        .def(
+            "_GetPackedTransform",
+            [](const Class& self, std::string_view path) {
+              return py::bytes(self.GetPackedTransform(path));
+            },
+            py::arg("path"))
+        .def(
+            "_GetPackedProperty",
+            [](const Class& self, std::string_view path,
+                std::string_view property) {
+              return py::bytes(
+                  self.GetPackedProperty(path, std::string{property}));
+            },
+            py::arg("path"), py::arg("property"));
 
     const auto& perspective_camera_doc = doc.Meshcat.PerspectiveCamera;
     py::class_<Meshcat::PerspectiveCamera> perspective_camera_cls(

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -238,6 +238,14 @@ class TestGeometryVisualizers(unittest.TestCase):
         copy.copy(camera)
         meshcat.SetCamera(camera=camera, path="mypath")
 
+        packed = meshcat._GetPackedObject(path="/test/box")
+        self.assertGreater(len(packed), 0)
+        packed = meshcat._GetPackedTransform(path="/test/box")
+        self.assertGreater(len(packed), 0)
+        packed = meshcat._GetPackedProperty(path="/Background",
+                                            property="visible")
+        self.assertGreater(len(packed), 0)
+
     def test_meshcat_animation(self):
         animation = mut.MeshcatAnimation(frames_per_second=64)
         self.assertEqual(animation.frames_per_second(), 64)


### PR DESCRIPTION
Towards #17662.

For local testing, use this patch to enable inertia visualization:

```patch
--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -317,6 +317,7 @@ class ModelVisualizer:
         ApplyVisualizationConfig(
             config=VisualizationConfig(
                 publish_contacts=self._publish_contacts,
+                publish_inertia=True,
                 enable_alpha_sliders=True),
             plant=self._builder.plant(),
             scene_graph=self._builder.scene_graph(),
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19677)
<!-- Reviewable:end -->
