### PR TITLE
Compute number of nonzeros in a sparsity pattern

### DIFF
--- a/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.cc
+++ b/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.cc
@@ -13,6 +13,19 @@ namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
+int BlockSparsityPattern::CalcNumNonzeros() const {
+  int result = 0;
+  for (int i = 0; i < ssize(block_sizes_); ++i) {
+    const std::vector<int>& neighbors_i = neighbors_[i];
+    int row_count = 0;
+    for (int n : neighbors_i) {
+      row_count += block_sizes_[n];
+    }
+    result += row_count * block_sizes_[i];
+  }
+  return result;
+}
+
 template <typename MatrixType, bool is_symmetric>
 BlockSparseLowerTriangularOrSymmetricMatrix<MatrixType, is_symmetric>::
     BlockSparseLowerTriangularOrSymmetricMatrix(

--- a/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h
+++ b/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h
@@ -65,6 +65,13 @@ class BlockSparsityPattern {
    are nonzero. */
   const std::vector<std::vector<int>>& neighbors() const { return neighbors_; }
 
+  /* Returns the number of "non-zero" (in the sense of eigen::SparseMatrix::nnz,
+   i.e., stored densely, not necessarily numerically zero
+   https://eigen.tuxfamily.org/dox/classEigen_1_1SparseMatrix.html#a03de8b3da2c142ce8698a76123b3e7d3)
+   scalar values in `this` block sparsity pattern. Note that only the non-zero
+   entries in the lower triangular part of the matrix are included. */
+  int CalcNumNonzeros() const;
+
  private:
   std::vector<int> block_sizes_;
   std::vector<std::vector<int>> neighbors_;

--- a/multibody/contact_solvers/test/block_sparse_lower_triangular_or_symmetric_matrix_test.cc
+++ b/multibody/contact_solvers/test/block_sparse_lower_triangular_or_symmetric_matrix_test.cc
@@ -110,6 +110,22 @@ BlockSparseSymmetricMatrix MakeSymmetricMatrix() {
   return A_blocks;
 }
 
+GTEST_TEST(BlockSparsityPatternTest, CalcNumNonzeros) {
+  std::vector<int> diag{2, 3, 4};
+  std::vector<std::vector<int>> sparsity;
+  sparsity.push_back(std::vector<int>{0});
+  sparsity.push_back(std::vector<int>{1, 2});
+  sparsity.push_back(std::vector<int>{2});
+  /* The sparsity pattern is
+         2x2 |  0  |  0
+        -----------------
+          0  | 3x3 |  0
+        -----------------
+          0  | 4x3 | 4x4  */
+  const BlockSparsityPattern pattern(diag, sparsity);
+  EXPECT_EQ(pattern.CalcNumNonzeros(), 41);
+}
+
 GTEST_TEST(TriangularBlockSparseMatrixTest, Construction) {
   const BlockSparseLowerTriangularMatrix A_triangular =
       MakeLowerTriangularMatrix();


### PR DESCRIPTION
The information about the number of nonzeros in a sparsity pattern helps evaluate the quality of the elimination ordering for a sparse system.

Towards #19466.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19678)
<!-- Reviewable:end -->
