### PR TITLE
Avoid copying the mesh in distance queries

### DIFF
--- a/geometry/proximity/calc_distance_to_surface_mesh.cc
+++ b/geometry/proximity/calc_distance_to_surface_mesh.cc
@@ -118,7 +118,7 @@ double CalcSquaredDistanceToTriangle(const Vector3<double>& p_WQ,
 // of "Real Time Collision Detection" (Christer Ericson) with fewer flops if
 // performance is an issue.
 double CalcDistanceToSurfaceMesh(const Vector3<double>& p_WQ,
-                                 const TriangleSurfaceMesh<double> mesh_W) {
+                                 const TriangleSurfaceMesh<double>& mesh_W) {
   double distance_squared = std::numeric_limits<double>::infinity();
   const std::vector<Vector3<double>>& vertices = mesh_W.vertices();
   for (const SurfaceTriangle& t : mesh_W.triangles()) {

--- a/geometry/proximity/calc_distance_to_surface_mesh.h
+++ b/geometry/proximity/calc_distance_to_surface_mesh.h
@@ -12,7 +12,7 @@ namespace internal {
  on the surface mesh `mesh_W`. The returned valued is non-negative.
  @pre Each element in `mesh_W` has non-zero area. */
 double CalcDistanceToSurfaceMesh(const Vector3<double>& p_WQ,
-                                 const TriangleSurfaceMesh<double> mesh_W);
+                                 const TriangleSurfaceMesh<double>& mesh_W);
 
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
CalcDistanceToSurfaceMesh is called repeatedly for each vertex in a hydroelastic mesh when constructing its pressure field. Even though it's only done in the pre-processing phase, we shouldn't copy unnecessarily.
