### PR TITLE
Fix memcheck failure in internal_merge_gltf_test.cc

### DIFF
--- a/geometry/render_gltf_client/test/internal_merge_gltf_test.cc
+++ b/geometry/render_gltf_client/test/internal_merge_gltf_test.cc
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -39,6 +40,12 @@ struct MergeCase {
   string description;
   /* The merge function that should be called. */
   std::function<void(json*, json&&)> merge{};
+
+  friend std::ostream& operator<<(std::ostream& out,
+                                  const MergeCase& merge_case) {
+    out << merge_case.description;
+    return out;
+  }
 };
 
 /* Evaluates a test case, confirming the merged result is as expected. */
@@ -47,7 +54,7 @@ void Evaluate(const MergeCase& test_case) {
   json source = json::parse(test_case.source);
   test_case.merge(&target, std::move(source));
   const json expected = json::parse(test_case.expected);
-  EXPECT_EQ(target[test_case.array_name], expected) << test_case.description;
+  EXPECT_EQ(target[test_case.array_name], expected) << test_case;
 }
 
 /* The test harness for the various merge functions. This includes families of


### PR DESCRIPTION
Adding the `operator<<` in `MergeCase` resolves the memcheck failure.

```
$ bazel test --config=memcheck //geometry/render_gltf_client:internal_merge_gltf_test
INFO: Invocation ID: a0286ef3-256f-49ec-bb9a-ac4972b31824
INFO: Analyzed target //geometry/render_gltf_client:internal_merge_gltf_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //geometry/render_gltf_client:internal_merge_gltf_test up-to-date:
  bazel-bin/geometry/render_gltf_client/internal_merge_gltf_test
INFO: Elapsed time: 10.844s, Critical Path: 10.62s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

Executed 1 out of 1 test: 1 test passes.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19686)
<!-- Reviewable:end -->
