### PR TITLE
[py visualization] Split flaky camera_test into its own file

### DIFF
--- a/bindings/pydrake/visualization/BUILD.bazel
+++ b/bindings/pydrake/visualization/BUILD.bazel
@@ -173,6 +173,14 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
+    name = "model_visualizer_camera_test",
+    flaky = True,
+    deps = [
+        ":model_visualizer",
+    ],
+)
+
+drake_py_unittest(
     name = "plotting_test",
     deps = [
         ":visualization",

--- a/bindings/pydrake/visualization/test/model_visualizer_camera_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_camera_test.py
@@ -1,0 +1,32 @@
+import unittest
+
+import pydrake.visualization as mut
+
+
+class TestModelVisualizerCamera(unittest.TestCase):
+    """
+    Tests the camera feature of the ModelVisualizer class.
+
+    The camera testing is carved into a separate file vs model_visualizer_test
+    because our camera code tends to be flaky when run using the emulated video
+    driver on our continuous integration builds.
+    """
+
+    def test_camera(self):
+        """
+        Checks that the rgbd sensor code does not crash.
+        """
+        # N.B. We don't need perception geometry in the scene -- we'll rely on
+        # the RgbdSensor unit tests to check that cameras work as advertised.
+        # Our only goal here is to achieve statement-level code coverage of the
+        # ModelVisualizer code when show_rgbd_sensor=True.
+        model = """<?xml version="1.0"?>
+          <sdf version="1.9">
+            <model name="sample">
+              <link name="base"/>
+            </model>
+          </sdf>
+        """
+        dut = mut.ModelVisualizer(show_rgbd_sensor=True)
+        dut.parser().AddModelsFromString(model, "sdf")
+        dut.Run(loop_once=True)

--- a/bindings/pydrake/visualization/test/model_visualizer_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_test.py
@@ -72,7 +72,11 @@ class TestModelVisualizerSubprocess(unittest.TestCase):
 
 
 class TestModelVisualizer(unittest.TestCase):
-    """Tests the ModelVisualizer class."""
+    """
+    Tests the ModelVisualizer class.
+
+    Note that camera tests are split into the model_visualizer_camera_test.
+    """
 
     SAMPLE_OBJ = textwrap.dedent("""<?xml version="1.0"?>
     <sdf version="1.7">
@@ -193,14 +197,6 @@ class TestModelVisualizer(unittest.TestCase):
             dut.parser()
         with self.assertRaisesRegex(ValueError, "already been"):
             dut.AddModels("ignored.urdf")
-
-    def test_camera(self):
-        """
-        Checks that the rgbd sensor code does not crash.
-        """
-        dut = mut.ModelVisualizer(show_rgbd_sensor=True)
-        dut.parser().AddModelsFromString(self.SAMPLE_OBJ, "sdf")
-        dut.Run(loop_once=True)
 
     def test_reload(self):
         """


### PR DESCRIPTION
Closes #19415.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19687)
<!-- Reviewable:end -->
