### PR TITLE
[sensors] Improve RgbdSensorDiscrete and RgbdSensorAsync

### DIFF
--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -197,7 +197,9 @@ PYBIND11_MODULE(sensors, m) {
             py_rvp::reference_internal, cls_doc.label_image_output_port.doc)
         .def("body_pose_in_world_output_port",
             &Class::body_pose_in_world_output_port, py_rvp::reference_internal,
-            cls_doc.body_pose_in_world_output_port.doc);
+            cls_doc.body_pose_in_world_output_port.doc)
+        .def("image_time_output_port", &Class::image_time_output_port,
+            py_rvp::reference_internal, cls_doc.image_time_output_port.doc);
   };
 
   py::class_<RgbdSensor, LeafSystem<T>> rgbd_sensor(
@@ -272,7 +274,9 @@ PYBIND11_MODULE(sensors, m) {
             py_rvp::reference_internal, cls_doc.label_image_output_port.doc)
         .def("body_pose_in_world_output_port",
             &Class::body_pose_in_world_output_port, py_rvp::reference_internal,
-            cls_doc.body_pose_in_world_output_port.doc);
+            cls_doc.body_pose_in_world_output_port.doc)
+        .def("image_time_output_port", &Class::image_time_output_port,
+            py_rvp::reference_internal, cls_doc.image_time_output_port.doc);
   }
 
   {

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -400,6 +400,7 @@ class TestSensors(unittest.TestCase):
             self.assertIsInstance(system.label_image_output_port(), OutputPort)
             self.assertIsInstance(system.body_pose_in_world_output_port(),
                                   OutputPort)
+            self.assertIsInstance(system.image_time_output_port(), OutputPort)
 
         # Use HDTV size.
         width = 1280
@@ -495,6 +496,7 @@ class TestSensors(unittest.TestCase):
         dut.depth_image_16U_output_port()
         dut.label_image_output_port()
         dut.body_pose_in_world_output_port()
+        dut.image_time_output_port()
 
     def test_image_writer(self):
         writer = mut.ImageWriter()

--- a/systems/sensors/rgbd_sensor.cc
+++ b/systems/sensors/rgbd_sensor.cc
@@ -57,6 +57,9 @@ RgbdSensor::RgbdSensor(FrameId parent_id, const RigidTransformd& X_PB,
   body_pose_in_world_output_port_ = &this->DeclareAbstractOutputPort(
       "body_pose_in_world", &RgbdSensor::CalcX_WB);
 
+  image_time_output_port_ = &this->DeclareVectorOutputPort(
+      "image_time", 1, &RgbdSensor::CalcImageTime, {this->time_ticket()});
+
   // The depth_16U represents depth in *millimeters*. With 16 bits there is
   // an absolute limit on the farthest distance it can register. This tests to
   // see if the user has specified a maximum depth value that exceeds that
@@ -94,6 +97,10 @@ const OutputPort<double>& RgbdSensor::label_image_output_port() const {
 
 const OutputPort<double>& RgbdSensor::body_pose_in_world_output_port() const {
   return *body_pose_in_world_output_port_;
+}
+
+const OutputPort<double>& RgbdSensor::image_time_output_port() const {
+  return *image_time_output_port_;
 }
 
 void RgbdSensor::CalcColorImage(const Context<double>& context,
@@ -136,6 +143,11 @@ void RgbdSensor::CalcX_WB(const Context<double>& context,
     const QueryObject<double>& query_object = get_query_object(context);
     *X_WB = query_object.GetPoseInWorld(parent_frame_id_) * X_PB_;
   }
+}
+
+void RgbdSensor::CalcImageTime(const Context<double>& context,
+                               BasicVector<double>* output) const {
+  output->SetFromVector(Vector1d{context.get_time()});
 }
 
 }  // namespace sensors

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -26,6 +26,7 @@ namespace sensors {
  - depth_image_16u
  - label_image
  - body_pose_in_world
+ - image_time
  @endsystem
 
  This system models a continuous sensor, where the output ports reflect the
@@ -168,6 +169,12 @@ class RgbdSensor final : public LeafSystem<double> {
    which reports the pose of the body in the world frame (X_WB).  */
   const OutputPort<double>& body_pose_in_world_output_port() const;
 
+  /** Returns the vector-valued output port (with size == 1) that reports the
+   current simulation time, in seconds. This is provided for consistency with
+   RgbdSensorDiscrete and RgbdSensorAsync (where the image time is not always
+   the current time). */
+  const OutputPort<double>& image_time_output_port() const;
+
  private:
   // The calculator methods for the four output ports.
   void CalcColorImage(const Context<double>& context,
@@ -180,6 +187,7 @@ class RgbdSensor final : public LeafSystem<double> {
                       ImageLabel16I* label_image) const;
   void CalcX_WB(const Context<double>& context,
                 math::RigidTransformd* X_WB) const;
+  void CalcImageTime(const Context<double>&, BasicVector<double>*) const;
 
   // Extract the query object from the given context (via the appropriate input
   // port.
@@ -195,6 +203,7 @@ class RgbdSensor final : public LeafSystem<double> {
   const OutputPort<double>* depth_image_16U_port_{};
   const OutputPort<double>* label_image_port_{};
   const OutputPort<double>* body_pose_in_world_output_port_{};
+  const OutputPort<double>* image_time_output_port_{};
 
   // The identifier for the parent frame `P`.
   const geometry::FrameId parent_frame_id_;

--- a/systems/sensors/rgbd_sensor_discrete.h
+++ b/systems/sensors/rgbd_sensor_discrete.h
@@ -27,6 +27,7 @@ output_ports:
 - depth_image_16u
 - label_image
 - body_pose_in_world
+- image_time
 @endsystem
 
 See also RgbdSensorAsync for a slightly different discrete sensor model.
@@ -40,11 +41,11 @@ type, eschew this system in favor of adding your own zero-order hold on just
 the one RgbdSensor output port that you need.
 
 @ingroup sensor_systems  */
-class RgbdSensorDiscrete final : public systems::Diagram<double> {
+class RgbdSensorDiscrete final : public Diagram<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RgbdSensorDiscrete);
 
-  static constexpr double kDefaultPeriod = 1. / 30;
+  static constexpr double kDefaultPeriod = 1.0 / 30;
 
   /** Constructs a diagram containing a (non-registered) RgbdSensor that will
   update at a given rate.
@@ -59,35 +60,35 @@ class RgbdSensorDiscrete final : public systems::Diagram<double> {
                      double period = kDefaultPeriod,
                      bool render_label_image = true);
 
-  /** Returns reference to RgbdSensor instance. */
+  /** Returns a reference to the underlying RgbdSensor object. */
   const RgbdSensor& sensor() const { return *camera_; }
 
-  /** Returns update period for discrete camera. */
+  /** Returns the update period for the discrete camera. */
   double period() const { return period_; }
 
   /** @see RgbdSensor::query_object_input_port(). */
   const InputPort<double>& query_object_input_port() const {
-    return get_input_port(query_object_port_);
+    return get_input_port(query_object_input_port_);
   }
 
   /** @see RgbdSensor::color_image_output_port(). */
   const systems::OutputPort<double>& color_image_output_port() const {
-    return get_output_port(output_port_color_image_);
+    return get_output_port(color_image_output_port_);
   }
 
   /** @see RgbdSensor::depth_image_32F_output_port(). */
   const systems::OutputPort<double>& depth_image_32F_output_port() const {
-    return get_output_port(output_port_depth_image_32F_);
+    return get_output_port(depth_image_32F_output_port_);
   }
 
   /** @see RgbdSensor::depth_image_16U_output_port(). */
   const systems::OutputPort<double>& depth_image_16U_output_port() const {
-    return get_output_port(output_port_depth_image_16U_);
+    return get_output_port(depth_image_16U_output_port_);
   }
 
   /** @see RgbdSensor::label_image_output_port(). */
   const systems::OutputPort<double>& label_image_output_port() const {
-    return get_output_port(output_port_label_image_);
+    return get_output_port(label_image_output_port_);
   }
 
   /** @see RgbdSensor::body_pose_in_world_output_port(). */
@@ -95,16 +96,24 @@ class RgbdSensorDiscrete final : public systems::Diagram<double> {
     return get_output_port(body_pose_in_world_output_port_);
   }
 
+  /** Returns the vector-valued output port (with size == 1) which reports the
+  simulation time when the image outputs were captured, in seconds (i.e., the
+  time of the most recent zero-order hold discrete update). */
+  const OutputPort<double>& image_time_output_port() const {
+    return get_output_port(image_time_output_port_);
+  }
+
  private:
   RgbdSensor* const camera_{};
   const double period_{};
 
-  int query_object_port_{-1};
-  int output_port_color_image_{-1};
-  int output_port_depth_image_32F_{-1};
-  int output_port_depth_image_16U_{-1};
-  int output_port_label_image_{-1};
+  int query_object_input_port_{-1};
+  int color_image_output_port_{-1};
+  int depth_image_32F_output_port_{-1};
+  int depth_image_16U_output_port_{-1};
+  int label_image_output_port_{-1};
   int body_pose_in_world_output_port_{-1};
+  int image_time_output_port_{-1};
 };
 
 }  // namespace sensors

--- a/systems/sensors/test/rgbd_sensor_discrete_test.cc
+++ b/systems/sensors/test/rgbd_sensor_discrete_test.cc
@@ -36,6 +36,7 @@ GTEST_TEST(RgbdSensorDiscrete, Construction) {
   EXPECT_EQ(sensor.label_image_output_port().get_name(), "label_image");
   EXPECT_EQ(sensor.body_pose_in_world_output_port().get_name(),
             "body_pose_in_world");
+  EXPECT_EQ(sensor.image_time_output_port().get_name(), "image_time");
 
   // Confirm that the period was passed into the ZOH correctly. If the ZOH
   // reports the expected period, we rely on it to do the right thing.
@@ -53,38 +54,39 @@ GTEST_TEST(RgbdSensorDiscrete, ImageHold) {
       make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(),
                               RigidTransformd::Identity(), depth_camera);
   RgbdSensor* sensor_raw = sensor.get();
+  const int num_outputs = sensor_raw->num_output_ports();
   const double kPeriod = 0.1;
   const bool include_render_port = true;
   RgbdSensorDiscrete discrete_sensor(std::move(sensor), kPeriod,
                                      include_render_port);
+  EXPECT_EQ(discrete_sensor.num_output_ports(), num_outputs);
 
   // This tests very *explicit* knowledge of what the wiring should be. As such,
   // it's a bit brittle, but this is the most efficient way to affect this test.
   // We assume these systems are reported in the order they were added.
   vector<const System<double>*> sub_systems = discrete_sensor.GetSystems();
 
-  // Five sub-systems: the sensor and one hold per image type.
-  ASSERT_EQ(sub_systems.size(), 5);
+  // For our diagram's sub-systems, we expect to have the sensor and then one
+  // zero-order hold per output port.
+  ASSERT_EQ(sub_systems.size(), 1 + num_outputs);
   ASSERT_EQ(sub_systems[0], sensor_raw);
 
-  // For each image output port, we want to make sure it's connected to the
-  // expected ZOH and that the hold's period is kPeriod. This proves that
+  // For each output port, we want to make sure it's connected to the expected
+  // zero-order hold and that the hold's period is kPeriod. This proves that
   // RgbdSensorDiscrete has wired things up properly.
-  auto confirm_hold = [&sub_systems, &kPeriod, &discrete_sensor](
-                          int hold_index,
-                          const OutputPort<double>& image_port) {
-    const ZeroOrderHold<double>* zoh =
-        dynamic_cast<const ZeroOrderHold<double>*>(sub_systems[hold_index]);
+  auto confirm_hold = [&sensor_raw, &sub_systems, &kPeriod,
+                       &discrete_sensor](int port_index) {
+    const auto* zoh = dynamic_cast<const ZeroOrderHold<double>*>(
+        sub_systems.at(1 + port_index));
     ASSERT_NE(zoh, nullptr);
     EXPECT_EQ(zoh->period(), kPeriod);
-    EXPECT_TRUE(
-        discrete_sensor.AreConnected(image_port, zoh->get_input_port()));
+    EXPECT_TRUE(discrete_sensor.AreConnected(
+        sensor_raw->get_output_port(port_index), zoh->get_input_port()));
   };
-
-  confirm_hold(1, sensor_raw->color_image_output_port());
-  confirm_hold(2, sensor_raw->depth_image_32F_output_port());
-  confirm_hold(3, sensor_raw->depth_image_16U_output_port());
-  confirm_hold(4, sensor_raw->label_image_output_port());
+  for (int i = 0; i < num_outputs; ++i) {
+    SCOPED_TRACE(fmt::format("i = {}", i));
+    confirm_hold(i);
+  }
 
   // TODO(SeanCurtis-TRI): Consider confirming that the exported ports map to
   //  the expected sub-system ports.

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -194,6 +194,7 @@ class RgbdSensorTest : public ::testing::Test {
                     sensor_->query_object_input_port());
     diagram_ = builder.Build();
     context_ = diagram_->CreateDefaultContext();
+    context_->SetTime(22.2);  // An arbitrary non-zero value.
     context_->DisableCaching();
     scene_graph_context_ =
         &diagram_->GetMutableSubsystemContext(*scene_graph_, context_.get());
@@ -279,6 +280,7 @@ TEST_F(RgbdSensorTest, PortNames) {
   EXPECT_EQ(sensor.label_image_output_port().get_name(), "label_image");
   EXPECT_EQ(sensor.body_pose_in_world_output_port().get_name(),
             "body_pose_in_world");
+  EXPECT_EQ(sensor.image_time_output_port().get_name(), "image_time");
 }
 
 // Tests that the anchored camera reports the correct parent frame and has the
@@ -298,6 +300,8 @@ TEST_F(RgbdSensorTest, ConstructAnchoredCamera) {
   const RigidTransformd X_WC_expected = X_WB * X_BC;
   EXPECT_TRUE(
       ValidateConstruction(scene_graph_->world_frame_id(), X_WC_expected));
+  EXPECT_EQ(sensor_->image_time_output_port().Eval(*sensor_context_),
+            Vector1d{22.2});
 }
 
 // Similar to the AnchoredCamera test -- but, in this case, the reported pose


### PR DESCRIPTION
Towards #19604 and #19437.
Closes #19198.

Feature:
- Add an image_time output port to all three RGBD sensors.

Fixes:
- Fix the missing ZOH on the discrete sensor's body pose output port.
- Async sensor: the systems framework does not allow negative event trigger times, so we need to forbid that.
- Async sensor: Change the port getters to throw instead of nullptr. This is better for return-type consistency with the other sensors.

Tweak some style guide typos and related inconsistencies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19696)
<!-- Reviewable:end -->
