### PR TITLE
[wrap_function] Allow for empty std::function objects

### DIFF
--- a/bindings/pydrake/common/wrap_function.h
+++ b/bindings/pydrake/common/wrap_function.h
@@ -137,6 +137,9 @@ struct wrap_function_impl {
         std::function<wrap_type_t<Return>(wrap_type_t<Args>...)>;
 
     static WrappedFunc wrap(const Func& func) {
+      if (!func) {
+        return {};
+      }
       return wrap_function_impl::run(infer_function_info(func));
     }
 
@@ -146,6 +149,9 @@ struct wrap_function_impl {
     static Func unwrap(  // BR
         const WrappedFunc& func_wrapped,
         std::enable_if_t<enable_wrap_output<Defer>, void*> = {}) {
+      if (!func_wrapped) {
+        return {};
+      }
       return [func_wrapped](Args... args) -> Return {
         return wrap_arg_functions<Return>::unwrap(func_wrapped(
             wrap_arg_functions<Args>::wrap(std::forward<Args>(args))...));
@@ -156,6 +162,9 @@ struct wrap_function_impl {
     template <typename Defer = Return>
     static Func unwrap(const WrappedFunc& func_wrapped,
         std::enable_if_t<!enable_wrap_output<Defer>, void*> = {}) {
+      if (!func_wrapped) {
+        return {};
+      }
       return [func_wrapped](Args... args) {
         func_wrapped(
             wrap_arg_functions<Args>::wrap(std::forward<Args>(args))...);


### PR DESCRIPTION
Ran into this in some Anzu code (PR 10614) using `WrapCalbacks()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19697)
<!-- Reviewable:end -->
