### PR TITLE
[multibody] Change ConstraintIndex into ConstraintId

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -106,6 +106,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_geometry_pybind",
         "//bindings/pydrake/common:eigen_pybind",
+        "//bindings/pydrake/common:identifier_pybind",
         "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:type_safe_index_pybind",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -22,7 +22,7 @@ from pydrake.multibody.tree import (
     Body_,
     BodyIndex,
     CalcSpatialInertia,
-    ConstraintIndex,
+    MultibodyConstraintId,
     DoorHinge_,
     DoorHingeConfig,
     FixedOffsetFrame_,
@@ -2288,12 +2288,9 @@ class TestPlant(unittest.TestCase):
         # Add coupler constraint.
         left_slider = plant.GetJointByName("left_finger_sliding_joint")
         right_slider = plant.GetJointByName("right_finger_sliding_joint")
-        coupler_index = plant.AddCouplerConstraint(
+        plant.AddCouplerConstraint(
             joint0=left_slider, joint1=right_slider,
             gear_ratio=1.2, offset=3.4)
-
-        # Constraint indexes are assigned in increasing order starting at zero.
-        self.assertEqual(coupler_index, ConstraintIndex(0))
 
         # We are done creating the model.
         plant.Finalize()
@@ -2313,11 +2310,8 @@ class TestPlant(unittest.TestCase):
         body_B = plant.AddRigidBody(name="B", M_BBo_B=M_BBo_B)
         p_AP = [0.0, 0.0, 0.0]
         p_BQ = [0.0, 0.0, 0.0]
-        index = plant.AddDistanceConstraint(
+        plant.AddDistanceConstraint(
             body_A=body_A, p_AP=p_AP, body_B=body_B, p_BQ=p_BQ, distance=0.01)
-
-        # Constraint indexes are assigned in increasing order starting at zero.
-        self.assertEqual(index, ConstraintIndex(0))
 
         # We are done creating the model.
         plant.Finalize()
@@ -2337,11 +2331,8 @@ class TestPlant(unittest.TestCase):
         body_B = plant.AddRigidBody(name="B", M_BBo_B=M_BBo_B)
         p_AP = [0.0, 0.0, 0.0]
         p_BQ = [0.0, 0.0, 0.0]
-        index = plant.AddBallConstraint(
+        plant.AddBallConstraint(
             body_A=body_A, p_AP=p_AP, body_B=body_B, p_BQ=p_BQ)
-
-        # Constraint indexes are assigned in increasing order starting at zero.
-        self.assertEqual(index, ConstraintIndex(0))
 
         # We are done creating the model.
         plant.Finalize()

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -4,6 +4,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
+#include "drake/bindings/pydrake/common/identifier_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/type_safe_index_pybind.h"
@@ -104,8 +105,8 @@ void DoScalarIndependentDefinitions(py::module m) {
       m, "JointActuatorIndex", doc.JointActuatorIndex.doc);
   BindTypeSafeIndex<ModelInstanceIndex>(
       m, "ModelInstanceIndex", doc.ModelInstanceIndex.doc);
-  BindTypeSafeIndex<ConstraintIndex>(
-      m, "ConstraintIndex", doc.ConstraintIndex.doc);
+  BindIdentifier<MultibodyConstraintId>(
+      m, "MultibodyConstraintId", doc.MultibodyConstraintId.doc);
   m.def("world_index", &world_index, doc.world_index.doc);
   m.def("world_frame_index", &world_frame_index, doc.world_frame_index.doc);
   m.def("world_model_instance", &world_model_instance,

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -124,6 +124,7 @@ drake_cc_library(
         ":tamsi_solver",
         "//common:default_scalars",
         "//common:essential",
+        "//common:unused",
         "//geometry:geometry_ids",
         "//geometry:geometry_roles",
         "//geometry:scene_graph",
@@ -466,6 +467,7 @@ drake_cc_googletest(
         ":compliant_contact_manager_tester",
         ":plant",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/plant/constraint_specs.h
+++ b/multibody/plant/constraint_specs.h
@@ -18,7 +18,7 @@ namespace internal {
 // ρ⋅q₁ + Δq, where q₀ and q₁ are the positions of two one-DOF joints, ρ the
 // gear ratio and Δq a fixed offset. Per equation above, ρ has units of q₀/q₁
 // and Δq has units of q₀.
-struct CouplerConstraintSpecs {
+struct CouplerConstraintSpec {
   // First joint with position q₀.
   JointIndex joint0_index;
   // Second joint with position q₁.
@@ -47,7 +47,7 @@ struct CouplerConstraintSpecs {
 // be strictly positive.
 //
 // @pre d₀ > 0, k >= 0, c >= 0. @see IsValid().
-struct DistanceConstraintSpecs {
+struct DistanceConstraintSpec {
   // Returns `true` iff `this` specification is valid to define a distance
   // constraint. A distance constraint specification is considered to be valid
   // iff distance > 0, stiffness >= 0 and damping >= 0.
@@ -76,7 +76,7 @@ struct DistanceConstraintSpecs {
 // does not restrict the rotational degrees of freedom.
 //
 // @pre body_A != body_B. @see IsValid().
-struct BallConstraintSpecs {
+struct BallConstraintSpec {
   // Returns `true` iff `this` specification is valid to define a ball
   // constraint. A ball constraint specification is considered to be valid iff:
   //   body_A != body_B.

--- a/multibody/plant/constraint_specs.h
+++ b/multibody/plant/constraint_specs.h
@@ -27,6 +27,8 @@ struct CouplerConstraintSpec {
   double gear_ratio{1.0};
   // Offset Δq.
   double offset{0.0};
+  // Id of this constraint in the plant.
+  MultibodyConstraintId id;
 };
 
 // Struct to store the specification for a distance constraint. A distance
@@ -46,13 +48,14 @@ struct CouplerConstraintSpec {
 // is singular in this case. Therefore we require the distance parameter to
 // be strictly positive.
 //
-// @pre d₀ > 0, k >= 0, c >= 0. @see IsValid().
+// @pre body_A != body_B, d₀ > 0, k >= 0, c >= 0. @see IsValid().
 struct DistanceConstraintSpec {
   // Returns `true` iff `this` specification is valid to define a distance
   // constraint. A distance constraint specification is considered to be valid
-  // iff distance > 0, stiffness >= 0 and damping >= 0.
+  // iff body_A != body_B, distance > 0, stiffness >= 0 and damping >= 0.
   bool IsValid() {
-    return distance > 0.0 && stiffness >= 0.0 && damping >= 0.0;
+    return body_A != body_B && distance > 0.0 && stiffness >= 0.0 &&
+           damping >= 0.0;
   }
 
   BodyIndex body_A;      // Index of body A.
@@ -63,7 +66,8 @@ struct DistanceConstraintSpec {
   double stiffness{
       std::numeric_limits<double>::infinity()};  // Constraint stiffness
                                                  // k in N/m.
-  double damping{0.0};  // Constraint damping c in N⋅s/m.
+  double damping{0.0};   // Constraint damping c in N⋅s/m.
+  MultibodyConstraintId id;       // Id of this constraint in the plant.
 };
 
 // Struct to store the specification for a ball constraint. A ball
@@ -86,6 +90,7 @@ struct BallConstraintSpec {
   Vector3<double> p_AP;  // Position of point P in body frame A.
   BodyIndex body_B;      // Index of body B.
   Vector3<double> p_BQ;  // Position of point Q in body frame B.
+  MultibodyConstraintId id;       // Id of this constraint in the plant.
 };
 
 }  // namespace internal

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -195,7 +195,7 @@ void DiscreteUpdateManager<T>::CalcForceElementsContribution(
 }
 
 template <typename T>
-const std::vector<internal::CouplerConstraintSpecs>&
+const std::vector<internal::CouplerConstraintSpec>&
 DiscreteUpdateManager<T>::coupler_constraints_specs() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<
       T>::coupler_constraints_specs(*plant_);
@@ -210,14 +210,14 @@ DiscreteUpdateManager<T>::EvalJointLockingCache(
 }
 
 template <typename T>
-const std::vector<internal::DistanceConstraintSpecs>&
+const std::vector<internal::DistanceConstraintSpec>&
 DiscreteUpdateManager<T>::distance_constraints_specs() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<
       T>::distance_constraints_specs(*plant_);
 }
 
 template <typename T>
-const std::vector<internal::BallConstraintSpecs>&
+const std::vector<internal::BallConstraintSpec>&
 DiscreteUpdateManager<T>::ball_constraints_specs() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::ball_constraints_specs(
       *plant_);

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -195,13 +195,6 @@ void DiscreteUpdateManager<T>::CalcForceElementsContribution(
 }
 
 template <typename T>
-const std::vector<internal::CouplerConstraintSpec>&
-DiscreteUpdateManager<T>::coupler_constraints_specs() const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::coupler_constraints_specs(*plant_);
-}
-
-template <typename T>
 const internal::JointLockingCacheData<T>&
 DiscreteUpdateManager<T>::EvalJointLockingCache(
     const systems::Context<T>& context) const {
@@ -210,14 +203,21 @@ DiscreteUpdateManager<T>::EvalJointLockingCache(
 }
 
 template <typename T>
-const std::vector<internal::DistanceConstraintSpec>&
+const std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>&
+DiscreteUpdateManager<T>::coupler_constraints_specs() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::coupler_constraints_specs(*plant_);
+}
+
+template <typename T>
+const std::map<MultibodyConstraintId, internal::DistanceConstraintSpec>&
 DiscreteUpdateManager<T>::distance_constraints_specs() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<
       T>::distance_constraints_specs(*plant_);
 }
 
 template <typename T>
-const std::vector<internal::BallConstraintSpec>&
+const std::map<MultibodyConstraintId, internal::BallConstraintSpec>&
 DiscreteUpdateManager<T>::ball_constraints_specs() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::ball_constraints_specs(
       *plant_);

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -245,17 +245,17 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   void CalcForceElementsContribution(const drake::systems::Context<T>& context,
                                      MultibodyForces<T>* forces) const;
 
-  const std::vector<internal::CouplerConstraintSpecs>&
+  const std::vector<internal::CouplerConstraintSpec>&
   coupler_constraints_specs() const;
 
   const internal::JointLockingCacheData<T>&
   EvalJointLockingCache(
       const systems::Context<T>& context) const;
 
-  const std::vector<internal::DistanceConstraintSpecs>&
+  const std::vector<internal::DistanceConstraintSpec>&
   distance_constraints_specs() const;
 
-  const std::vector<internal::BallConstraintSpecs>& ball_constraints_specs()
+  const std::vector<internal::BallConstraintSpec>& ball_constraints_specs()
       const;
 
   BodyIndex FindBodyByGeometryId(geometry::GeometryId geometry_id) const;

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -245,18 +246,18 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   void CalcForceElementsContribution(const drake::systems::Context<T>& context,
                                      MultibodyForces<T>* forces) const;
 
-  const std::vector<internal::CouplerConstraintSpec>&
-  coupler_constraints_specs() const;
-
   const internal::JointLockingCacheData<T>&
   EvalJointLockingCache(
       const systems::Context<T>& context) const;
 
-  const std::vector<internal::DistanceConstraintSpec>&
+  const std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>&
+  coupler_constraints_specs() const;
+
+  const std::map<MultibodyConstraintId, internal::DistanceConstraintSpec>&
   distance_constraints_specs() const;
 
-  const std::vector<internal::BallConstraintSpec>& ball_constraints_specs()
-      const;
+  const std::map<MultibodyConstraintId, internal::BallConstraintSpec>&
+  ball_constraints_specs() const;
 
   BodyIndex FindBodyByGeometryId(geometry::GeometryId geometry_id) const;
   /* @} */

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -420,10 +420,9 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
 }
 
 template <typename T>
-ConstraintIndex MultibodyPlant<T>::AddCouplerConstraint(const Joint<T>& joint0,
-                                                        const Joint<T>& joint1,
-                                                        double gear_ratio,
-                                                        double offset) {
+MultibodyConstraintId MultibodyPlant<T>::AddCouplerConstraint(
+    const Joint<T>& joint0, const Joint<T>& joint1, double gear_ratio,
+    double offset) {
   // N.B. The manager is setup at Finalize() and therefore we must require
   // constraints to be added pre-finalize.
   DRAKE_MBP_THROW_IF_FINALIZED();
@@ -453,16 +452,17 @@ ConstraintIndex MultibodyPlant<T>::AddCouplerConstraint(const Joint<T>& joint0,
     throw std::runtime_error(message);
   }
 
-  const ConstraintIndex constraint_index(num_constraints());
+  const MultibodyConstraintId constraint_id =
+      MultibodyConstraintId::get_new_id();
 
-  coupler_constraints_specs_.push_back(internal::CouplerConstraintSpec{
-      joint0.index(), joint1.index(), gear_ratio, offset});
+  coupler_constraints_specs_[constraint_id] = internal::CouplerConstraintSpec{
+      joint0.index(), joint1.index(), gear_ratio, offset, constraint_id};
 
-  return constraint_index;
+  return constraint_id;
 }
 
 template <typename T>
-ConstraintIndex MultibodyPlant<T>::AddDistanceConstraint(
+MultibodyConstraintId MultibodyPlant<T>::AddDistanceConstraint(
     const Body<T>& body_A, const Vector3<double>& p_AP, const Body<T>& body_B,
     const Vector3<double>& p_BQ, double distance, double stiffness,
     double damping) {
@@ -487,10 +487,12 @@ ConstraintIndex MultibodyPlant<T>::AddDistanceConstraint(
         "DiscreteContactSolver.");
   }
 
-  DRAKE_THROW_UNLESS(body_A.index() != body_B.index());
+  const MultibodyConstraintId constraint_id =
+      MultibodyConstraintId::get_new_id();
 
-  internal::DistanceConstraintSpec spec{body_A.index(), p_AP, body_B.index(),
-                                         p_BQ, distance, stiffness, damping};
+  internal::DistanceConstraintSpec spec{
+      body_A.index(), p_AP,      body_B.index(), p_BQ,
+      distance,       stiffness, damping,        constraint_id};
   if (!spec.IsValid()) {
     const std::string msg = fmt::format(
         "Invalid set of parameters for constraint between bodies '{}' and "
@@ -499,15 +501,15 @@ ConstraintIndex MultibodyPlant<T>::AddDistanceConstraint(
     throw std::runtime_error(msg);
   }
 
-  const ConstraintIndex constraint_index(num_constraints());
 
-  distance_constraints_specs_.push_back(spec);
 
-  return constraint_index;
+  distance_constraints_specs_[constraint_id] = spec;
+
+  return constraint_id;
 }
 
 template <typename T>
-ConstraintIndex MultibodyPlant<T>::AddBallConstraint(
+MultibodyConstraintId MultibodyPlant<T>::AddBallConstraint(
     const Body<T>& body_A, const Vector3<double>& p_AP, const Body<T>& body_B,
     const Vector3<double>& p_BQ) {
   // N.B. The manager is set up at Finalize() and therefore we must require
@@ -531,8 +533,11 @@ ConstraintIndex MultibodyPlant<T>::AddBallConstraint(
         "DiscreteContactSolver.");
   }
 
-  internal::BallConstraintSpec spec{body_A.index(), p_AP, body_B.index(),
-                                     p_BQ};
+  const MultibodyConstraintId constraint_id =
+      MultibodyConstraintId::get_new_id();
+
+  internal::BallConstraintSpec spec{body_A.index(), p_AP, body_B.index(), p_BQ,
+                                     constraint_id};
   if (!spec.IsValid()) {
     const std::string msg = fmt::format(
         "Invalid set of parameters for constraint between bodies '{}' and "
@@ -542,11 +547,9 @@ ConstraintIndex MultibodyPlant<T>::AddBallConstraint(
     throw std::logic_error(msg);
   }
 
-  const ConstraintIndex constraint_index(num_constraints());
+  ball_constraints_specs_[constraint_id] = spec;
 
-  ball_constraints_specs_.push_back(spec);
-
-  return constraint_index;
+  return constraint_id;
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -455,7 +455,7 @@ ConstraintIndex MultibodyPlant<T>::AddCouplerConstraint(const Joint<T>& joint0,
 
   const ConstraintIndex constraint_index(num_constraints());
 
-  coupler_constraints_specs_.push_back(internal::CouplerConstraintSpecs{
+  coupler_constraints_specs_.push_back(internal::CouplerConstraintSpec{
       joint0.index(), joint1.index(), gear_ratio, offset});
 
   return constraint_index;
@@ -489,7 +489,7 @@ ConstraintIndex MultibodyPlant<T>::AddDistanceConstraint(
 
   DRAKE_THROW_UNLESS(body_A.index() != body_B.index());
 
-  internal::DistanceConstraintSpecs spec{body_A.index(), p_AP, body_B.index(),
+  internal::DistanceConstraintSpec spec{body_A.index(), p_AP, body_B.index(),
                                          p_BQ, distance, stiffness, damping};
   if (!spec.IsValid()) {
     const std::string msg = fmt::format(
@@ -531,7 +531,7 @@ ConstraintIndex MultibodyPlant<T>::AddBallConstraint(
         "DiscreteContactSolver.");
   }
 
-  internal::BallConstraintSpecs spec{body_A.index(), p_AP, body_B.index(),
+  internal::BallConstraintSpec spec{body_A.index(), p_AP, body_B.index(),
                                      p_BQ};
   if (!spec.IsValid()) {
     const std::string msg = fmt::format(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -5385,13 +5385,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   std::vector<std::unique_ptr<PhysicalModel<T>>> physical_models_;
 
   // Vector of coupler constraints specifications.
-  std::vector<internal::CouplerConstraintSpecs> coupler_constraints_specs_;
+  std::vector<internal::CouplerConstraintSpec> coupler_constraints_specs_;
 
   // Vector of distance constraints specifications.
-  std::vector<internal::DistanceConstraintSpecs> distance_constraints_specs_;
+  std::vector<internal::DistanceConstraintSpec> distance_constraints_specs_;
 
   // Vector of ball constraint specifications.
-  std::vector<internal::BallConstraintSpecs> ball_constraints_specs_;
+  std::vector<internal::BallConstraintSpec> ball_constraints_specs_;
 
   // All MultibodyPlant cache indexes are stored in cache_indexes_.
   CacheIndexes cache_indexes_;

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1211,9 +1211,47 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns the total number of constraints specified by the user.
   int num_constraints() const {
-    return static_cast<int>(coupler_constraints_specs_.size() +
-                            distance_constraints_specs_.size() +
-                            ball_constraints_specs_.size());
+    return num_coupler_constraints() + num_distance_constraints() +
+           num_ball_constraints();
+  }
+
+  /// Returns the total number of coupler constraints specified by the user.
+  int num_coupler_constraints() const {
+    return ssize(coupler_constraints_specs_);
+  }
+
+  /// Returns the total number of distance constraints specified by the user.
+  int num_distance_constraints() const {
+    return ssize(distance_constraints_specs_);
+  }
+
+  /// Returns the total number of ball constraints specified by the user.
+  int num_ball_constraints() const {
+    return ssize(ball_constraints_specs_);
+  }
+
+  /// Returns the coupler constraint specification corresponding to `id`
+  /// @throws if `id` is not a valid identifier for a coupler constraint.
+  const internal::CouplerConstraintSpec& get_coupler_constraint_specs(
+      MultibodyConstraintId id) const {
+    DRAKE_THROW_UNLESS(coupler_constraints_specs_.count(id) > 0);
+    return coupler_constraints_specs_.at(id);
+  }
+
+  /// Returns the distance constraint specification corresponding to `id`
+  /// @throws if `id` is not a valid identifier for a distance constraint.
+  const internal::DistanceConstraintSpec& get_distance_constraint_specs(
+      MultibodyConstraintId id) const {
+    DRAKE_THROW_UNLESS(distance_constraints_specs_.count(id) > 0);
+    return distance_constraints_specs_.at(id);
+  }
+
+  /// Returns the ball constraint specification corresponding to `id`
+  /// @throws if `id` is not a valid identifier for a ball constraint.
+  const internal::BallConstraintSpec& get_ball_constraint_specs(
+      MultibodyConstraintId id) const {
+    DRAKE_THROW_UNLESS(ball_constraints_specs_.count(id) > 0);
+    return ball_constraints_specs_.at(id);
   }
 
   /// Defines a holonomic constraint between two single-dof joints `joint0`
@@ -1234,7 +1272,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///
   /// @throws if joint0 and joint1 are not both single-dof joints.
   /// @throws std::exception if the %MultibodyPlant has already been finalized.
-  ConstraintIndex AddCouplerConstraint(const Joint<T>& joint0,
+  MultibodyConstraintId AddCouplerConstraint(const Joint<T>& joint0,
                                        const Joint<T>& joint1,
                                        double gear_ratio, double offset = 0.0);
 
@@ -1261,7 +1299,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] damping For modeling a spring with free length equal to
   /// `distance`, damping parameter in N⋅s/m. Optional, with its default value
   /// being zero for a non-dissipative constraint.
-  /// @returns the index to the newly added constraint.
+  /// @returns the id of the newly added constraint.
   ///
   /// @warning Currently, it is the user's responsibility to initialize the
   /// model's context in a configuration compatible with the newly added
@@ -1278,7 +1316,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if `stiffness` is not positive or zero.
   /// @throws std::exception if `damping` is not positive or zero.
   /// @throws std::exception if the %MultibodyPlant has already been finalized.
-  ConstraintIndex AddDistanceConstraint(
+  MultibodyConstraintId AddDistanceConstraint(
       const Body<T>& body_A, const Vector3<double>& p_AP, const Body<T>& body_B,
       const Vector3<double>& p_BQ, double distance,
       double stiffness = std::numeric_limits<double>::infinity(),
@@ -1292,11 +1330,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] p_AP Position of point P in body A's frame.
   /// @param[in] body_B Body to which point Q is rigidly attached.
   /// @param[in] p_BQ Position of point Q in body B's frame.
-  /// @returns the index to the newly added constraint.
+  /// @returns the id of the newly added constraint.
   ///
   /// @throws std::exception if bodies A and B are the same body.
   /// @throws std::exception if the %MultibodyPlant has already been finalized.
-  ConstraintIndex AddBallConstraint(const Body<T>& body_A,
+  MultibodyConstraintId AddBallConstraint(const Body<T>& body_A,
                                     const Vector3<double>& p_AP,
                                     const Body<T>& body_B,
                                     const Vector3<double>& p_BQ);
@@ -5384,14 +5422,17 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // (Experimental) The vector of physical models owned by MultibodyPlant.
   std::vector<std::unique_ptr<PhysicalModel<T>>> physical_models_;
 
-  // Vector of coupler constraints specifications.
-  std::vector<internal::CouplerConstraintSpec> coupler_constraints_specs_;
+  // Map of coupler constraints specifications.
+  std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>
+      coupler_constraints_specs_;
 
-  // Vector of distance constraints specifications.
-  std::vector<internal::DistanceConstraintSpec> distance_constraints_specs_;
+  // Map of distance constraints specifications.
+  std::map<MultibodyConstraintId, internal::DistanceConstraintSpec>
+      distance_constraints_specs_;
 
-  // Vector of ball constraint specifications.
-  std::vector<internal::BallConstraintSpec> ball_constraints_specs_;
+  // Map of ball constraint specifications.
+  std::map<MultibodyConstraintId, internal::BallConstraintSpec>
+      ball_constraints_specs_;
 
   // All MultibodyPlant cache indexes are stored in cache_indexes_.
   CacheIndexes cache_indexes_;

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -87,7 +87,7 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.geometry_id_to_body_index_;
   }
 
-  static const std::vector<internal::CouplerConstraintSpecs>&
+  static const std::vector<internal::CouplerConstraintSpec>&
   coupler_constraints_specs(const MultibodyPlant<T>& plant) {
     return plant.coupler_constraints_specs_;
   }
@@ -98,12 +98,12 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.EvalJointLockingCache(context);
   }
 
-  static const std::vector<internal::DistanceConstraintSpecs>&
+  static const std::vector<internal::DistanceConstraintSpec>&
   distance_constraints_specs(const MultibodyPlant<T>& plant) {
     return plant.distance_constraints_specs_;
   }
 
-  static const std::vector<internal::BallConstraintSpecs>&
+  static const std::vector<internal::BallConstraintSpec>&
   ball_constraints_specs(const MultibodyPlant<T>& plant) {
     return plant.ball_constraints_specs_;
   }

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -87,23 +88,24 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.geometry_id_to_body_index_;
   }
 
-  static const std::vector<internal::CouplerConstraintSpec>&
-  coupler_constraints_specs(const MultibodyPlant<T>& plant) {
-    return plant.coupler_constraints_specs_;
-  }
-
   static const internal::JointLockingCacheData<T>&
   EvalJointLockingCache(const MultibodyPlant<T>& plant,
                                        const systems::Context<T>& context) {
     return plant.EvalJointLockingCache(context);
   }
 
-  static const std::vector<internal::DistanceConstraintSpec>&
+  static const std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>&
+  coupler_constraints_specs(const MultibodyPlant<T>& plant) {
+    return plant.coupler_constraints_specs_;
+  }
+
+  static const std::map<MultibodyConstraintId,
+                        internal::DistanceConstraintSpec>&
   distance_constraints_specs(const MultibodyPlant<T>& plant) {
     return plant.distance_constraints_specs_;
   }
 
-  static const std::vector<internal::BallConstraintSpec>&
+  static const std::map<MultibodyConstraintId, internal::BallConstraintSpec>&
   ball_constraints_specs(const MultibodyPlant<T>& plant) {
     return plant.ball_constraints_specs_;
   }

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -345,7 +345,7 @@ void SapDriver<T>::AddCouplerConstraints(const systems::Context<T>& context,
   const Vector1<T> stiffness(kInfinity);
   const Vector1<T> relaxation_time(plant().time_step());
 
-  for (const CouplerConstraintSpecs& info :
+  for (const CouplerConstraintSpec& info :
        manager().coupler_constraints_specs()) {
     const Joint<T>& joint0 = plant().get_joint(info.joint0_index);
     const Joint<T>& joint1 = plant().get_joint(info.joint1_index);
@@ -412,7 +412,7 @@ void SapDriver<T>::AddDistanceConstraints(const systems::Context<T>& context,
   MatrixX<T> Jdistance = MatrixX<T>::Zero(1, nv);
 
   const Frame<T>& frame_W = plant().world_frame();
-  for (const DistanceConstraintSpecs& specs :
+  for (const DistanceConstraintSpec& specs :
        manager().distance_constraints_specs()) {
     const Body<T>& body_A = plant().get_body(specs.body_A);
     const Body<T>& body_B = plant().get_body(specs.body_B);
@@ -524,7 +524,7 @@ void SapDriver<T>::AddBallConstraints(
   MatrixX<T> Jv_ApBq_W = MatrixX<T>::Zero(3, nv);
 
   const Frame<T>& frame_W = plant().world_frame();
-  for (const BallConstraintSpecs& specs : manager().ball_constraints_specs()) {
+  for (const BallConstraintSpec& specs : manager().ball_constraints_specs()) {
     const Body<T>& body_A = plant().get_body(specs.body_A);
     const Body<T>& body_B = plant().get_body(specs.body_B);
 

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/unused.h"
 #include "drake/multibody/contact_solvers/contact_configuration.h"
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
@@ -345,8 +346,8 @@ void SapDriver<T>::AddCouplerConstraints(const systems::Context<T>& context,
   const Vector1<T> stiffness(kInfinity);
   const Vector1<T> relaxation_time(plant().time_step());
 
-  for (const CouplerConstraintSpec& info :
-       manager().coupler_constraints_specs()) {
+  for (const auto& [id, info] : manager().coupler_constraints_specs()) {
+    unused(id);
     const Joint<T>& joint0 = plant().get_joint(info.joint0_index);
     const Joint<T>& joint1 = plant().get_joint(info.joint1_index);
     const int dof0 = joint0.velocity_start();
@@ -412,17 +413,18 @@ void SapDriver<T>::AddDistanceConstraints(const systems::Context<T>& context,
   MatrixX<T> Jdistance = MatrixX<T>::Zero(1, nv);
 
   const Frame<T>& frame_W = plant().world_frame();
-  for (const DistanceConstraintSpec& specs :
-       manager().distance_constraints_specs()) {
-    const Body<T>& body_A = plant().get_body(specs.body_A);
-    const Body<T>& body_B = plant().get_body(specs.body_B);
+
+  for (const auto& [id, spec] : manager().distance_constraints_specs()) {
+    unused(id);
+    const Body<T>& body_A = plant().get_body(spec.body_A);
+    const Body<T>& body_B = plant().get_body(spec.body_B);
 
     const math::RigidTransform<T>& X_WA =
         plant().EvalBodyPoseInWorld(context, body_A);
     const math::RigidTransform<T>& X_WB =
         plant().EvalBodyPoseInWorld(context, body_B);
-    const Vector3<T>& p_WP = X_WA * specs.p_AP.cast<T>();
-    const Vector3<T>& p_WQ = X_WB * specs.p_BQ.cast<T>();
+    const Vector3<T>& p_WP = X_WA * spec.p_AP.template cast<T>();
+    const Vector3<T>& p_WQ = X_WB * spec.p_BQ.template cast<T>();
 
     // Distance as the norm of p_PQ_W = p_WQ - p_WP
     const Vector3<T> p_PQ_W = p_WQ - p_WP;
@@ -431,12 +433,12 @@ void SapDriver<T>::AddDistanceConstraints(const systems::Context<T>& context,
     // user-specified distance as a reference.
     constexpr double kMinimumDistance = 1.0e-7;
     constexpr double kRelativeDistance = 1.0e-2;
-    if (d0 < kMinimumDistance + kRelativeDistance * specs.distance) {
+    if (d0 < kMinimumDistance + kRelativeDistance * spec.distance) {
       const std::string msg = fmt::format(
           "The distance between bodies '{}' and '{}' is: {}. This is "
           "nonphysically small when compared to the free length of the "
           "constraint, {}. ",
-          body_A.name(), body_B.name(), d0, specs.distance);
+          body_A.name(), body_B.name(), d0, spec.distance);
       throw std::logic_error(msg);
     }
     const Vector3<T> p_hat_W = p_PQ_W / d0;
@@ -453,18 +455,18 @@ void SapDriver<T>::AddDistanceConstraints(const systems::Context<T>& context,
         frame_W, frame_W, &Jv_WBq_W);
     Jdistance = p_hat_W.transpose() * (Jv_WBq_W - Jv_WAp_W);
 
-    const T dissipation_time_scale = specs.damping / specs.stiffness;
+    const T dissipation_time_scale = spec.damping / spec.stiffness;
 
     // TODO(amcastro-tri): consider exposing this parameter.
     const double beta = 0.1;
     const typename SapHolonomicConstraint<T>::Parameters parameters{
-        gamma_lower, gamma_upper, Vector1<T>(specs.stiffness),
+        gamma_lower, gamma_upper, Vector1<T>(spec.stiffness),
         Vector1<T>(dissipation_time_scale), beta};
 
     const TreeIndex treeA_index =
-        tree_topology().body_to_tree_index(specs.body_A);
+        tree_topology().body_to_tree_index(spec.body_A);
     const TreeIndex treeB_index =
-        tree_topology().body_to_tree_index(specs.body_B);
+        tree_topology().body_to_tree_index(spec.body_B);
 
     // Sanity check at least one body is not the world.
     DRAKE_DEMAND(treeA_index.is_valid() || treeB_index.is_valid());
@@ -475,7 +477,7 @@ void SapDriver<T>::AddDistanceConstraints(const systems::Context<T>& context,
                              treeA_index == treeB_index;
 
     // Constraint function at current time step.
-    const Vector1<T> g0(d0 - specs.distance);
+    const Vector1<T> g0(d0 - spec.distance);
     if (single_tree) {
       const TreeIndex tree_index =
           treeA_index.is_valid() ? treeA_index : treeB_index;
@@ -524,16 +526,17 @@ void SapDriver<T>::AddBallConstraints(
   MatrixX<T> Jv_ApBq_W = MatrixX<T>::Zero(3, nv);
 
   const Frame<T>& frame_W = plant().world_frame();
-  for (const BallConstraintSpec& specs : manager().ball_constraints_specs()) {
-    const Body<T>& body_A = plant().get_body(specs.body_A);
-    const Body<T>& body_B = plant().get_body(specs.body_B);
+  for (const auto& [id, spec] : manager().ball_constraints_specs()) {
+    unused(id);
+    const Body<T>& body_A = plant().get_body(spec.body_A);
+    const Body<T>& body_B = plant().get_body(spec.body_B);
 
     const math::RigidTransform<T>& X_WA =
         plant().EvalBodyPoseInWorld(context, body_A);
     const math::RigidTransform<T>& X_WB =
         plant().EvalBodyPoseInWorld(context, body_B);
-    const Vector3<T> p_WP = X_WA * specs.p_AP.cast<T>();
-    const Vector3<T> p_WQ = X_WB * specs.p_BQ.cast<T>();
+    const Vector3<T> p_WP = X_WA * spec.p_AP.template cast<T>();
+    const Vector3<T> p_WQ = X_WB * spec.p_BQ.template cast<T>();
 
     const Vector3<T> p_PQ_W = p_WQ - p_WP;
 
@@ -553,9 +556,9 @@ void SapDriver<T>::AddBallConstraints(
         gamma_lower, gamma_upper, stiffness, relaxation_time, beta};
 
     const TreeIndex treeA_index =
-        tree_topology().body_to_tree_index(specs.body_A);
+        tree_topology().body_to_tree_index(spec.body_A);
     const TreeIndex treeB_index =
-        tree_topology().body_to_tree_index(specs.body_B);
+        tree_topology().body_to_tree_index(spec.body_B);
 
     // TODO(joemasterjohn): Move this exception up to the plant level so that it
     // fails as fast as possible. Currently, the earliest this can happen is

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -235,7 +235,7 @@ GTEST_TEST(ScalarConversionTest, ExternalComponent) {
 class MultibodyPlantTester {
  public:
   template <typename T>
-  static std::vector<internal::CouplerConstraintSpecs>& get_mutable_specs(
+  static std::vector<internal::CouplerConstraintSpec>& get_mutable_specs(
       MultibodyPlant<T>* plant) {
     return plant->coupler_constraints_specs_;
   }
@@ -247,14 +247,14 @@ namespace {
 // that the number of constraints before and aftter scalar conversion are the
 // same. The correctness of the scalar copying semantics for the constraints are
 // tested in their own unit tests.
-GTEST_TEST(ScalarConversionTest, CouplerConstraintSpecs) {
+GTEST_TEST(ScalarConversionTest, CouplerConstraintSpec) {
   MultibodyPlant<double> plant_double(0.1);
 
   const JointIndex j0(3);
   const JointIndex j1(5);
   constexpr double kGearRatio = 1.2;
   constexpr double kOffset = 0.3;
-  const internal::CouplerConstraintSpecs reference_spec{j0, j1, kGearRatio,
+  const internal::CouplerConstraintSpec reference_spec{j0, j1, kGearRatio,
                                                         kOffset};
 
   // Directly add dummy constraint specs through the tester so that we don't

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -235,8 +235,8 @@ GTEST_TEST(ScalarConversionTest, ExternalComponent) {
 class MultibodyPlantTester {
  public:
   template <typename T>
-  static std::vector<internal::CouplerConstraintSpec>& get_mutable_specs(
-      MultibodyPlant<T>* plant) {
+  static std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>&
+  get_mutable_specs(MultibodyPlant<T>* plant) {
     return plant->coupler_constraints_specs_;
   }
 };
@@ -259,8 +259,8 @@ GTEST_TEST(ScalarConversionTest, CouplerConstraintSpec) {
 
   // Directly add dummy constraint specs through the tester so that we don't
   // need to actually add any joints.
-  MultibodyPlantTester::get_mutable_specs(&plant_double)
-      .emplace_back(reference_spec);
+  MultibodyPlantTester::get_mutable_specs(
+      &plant_double)[MultibodyConstraintId::get_new_id()] = reference_spec;
   plant_double.Finalize();
   // double -> AutoDiffXd.
   std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant_double_to_autodiff =

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -506,6 +506,9 @@ GTEST_TEST(MultibodyPlant, EmptyWorldElements) {
   EXPECT_EQ(plant.num_joints(), 0);
   EXPECT_EQ(plant.num_actuators(), 0);
   EXPECT_EQ(plant.num_constraints(), 0);
+  EXPECT_EQ(plant.num_coupler_constraints(), 0);
+  EXPECT_EQ(plant.num_distance_constraints(), 0);
+  EXPECT_EQ(plant.num_ball_constraints(), 0);
   EXPECT_EQ(plant.num_force_elements(), 1);
 }
 

--- a/multibody/plant/test/sap_driver_ball_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_ball_constraints_test.cc
@@ -228,6 +228,30 @@ INSTANTIATE_TEST_SUITE_P(SapBallConstraintTests, TwoBodiesTest,
                          testing::ValuesIn(MakeTestCases()),
                          testing::PrintToStringParamName());
 
+GTEST_TEST(BallConstraintsTests, VerifyIdMapping) {
+  MultibodyPlant<double> plant{0.1};
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  const RigidBody<double>& bodyA =
+      plant.AddRigidBody("A", SpatialInertia<double>{});
+  const RigidBody<double>& bodyB =
+      plant.AddRigidBody("B", SpatialInertia<double>{});
+  const Vector3d p_AP(1, 2, 3);
+  const Vector3d p_BQ(4, 5, 6);
+  MultibodyConstraintId ball_id =
+      plant.AddBallConstraint(bodyA, p_AP, bodyB, p_BQ);
+  const BallConstraintSpec& ball_spec =
+      plant.get_ball_constraint_specs(ball_id);
+  EXPECT_EQ(ball_spec.id, ball_id);
+  EXPECT_EQ(ball_spec.body_A, bodyA.index());
+  EXPECT_EQ(ball_spec.body_B, bodyB.index());
+  EXPECT_EQ(ball_spec.p_AP, p_AP);
+  EXPECT_EQ(ball_spec.p_BQ, p_BQ);
+
+  // Throw on id to wrong constraint specs type.
+  EXPECT_THROW(plant.get_coupler_constraint_specs(ball_id), std::exception);
+  EXPECT_THROW(plant.get_distance_constraint_specs(ball_id), std::exception);
+}
+
 GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
   MultibodyPlant<double> plant{0.1};
   plant.set_discrete_contact_solver(DiscreteContactSolver::kTamsi);

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -126,11 +126,9 @@ class KukaIiwaArmTests : public ::testing::Test {
     // offset is zero, here we use an arbitrary set of values to verify later on
     // in the test that the manager created a constraint consistent with these
     // numbers.
-    const ConstraintIndex next_constraint_index(plant->num_constraints());
-    ConstraintIndex constraint_index =
-        plant->AddCouplerConstraint(left_finger_slider, right_finger_slider,
-                                    kCouplerGearRatio, kCouplerOffset);
-    EXPECT_EQ(constraint_index, next_constraint_index);
+    plant->AddCouplerConstraint(left_finger_slider, right_finger_slider,
+                                kCouplerGearRatio, kCouplerOffset);
+
     return models;
   }
 
@@ -547,9 +545,8 @@ TEST_F(KukaIiwaArmTests, CouplerConstraints) {
       plant_.GetJointByName("iiwa_joint_3", arm_gripper1[0]);
   const Joint<double>& arm2_joint6 =
       plant_.GetJointByName("iiwa_joint_6", arm_gripper2[0]);
-  ConstraintIndex constraint_index = plant_.AddCouplerConstraint(
-      arm1_joint3, arm2_joint6, kCouplerGearRatio, kCouplerOffset);
-  EXPECT_EQ(constraint_index, ConstraintIndex(2));
+  plant_.AddCouplerConstraint(arm1_joint3, arm2_joint6, kCouplerGearRatio,
+                              kCouplerOffset);
 
   plant_.Finalize();
 

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_library(
         "multibody_tree_indexes.h",
     ],
     deps = [
+        "//common:identifier",
         "//common:type_safe_index",
     ],
 )

--- a/multibody/tree/multibody_tree_indexes.h
+++ b/multibody/tree/multibody_tree_indexes.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/identifier.h"
 #include "drake/common/type_safe_index.h"
 
 namespace drake {
@@ -38,8 +39,8 @@ using JointIndex = TypeSafeIndex<class JointElementTag>;
 /// Type used to identify actuators by index within a multibody tree system.
 using JointActuatorIndex = TypeSafeIndex<class JointActuatorElementTag>;
 
-/// Type used to identify constraints by index within a multibody system.
-using ConstraintIndex = TypeSafeIndex<class ConstraintTag>;
+/// Type used to identify constraint by id within a multibody system.
+using MultibodyConstraintId = Identifier<class ConstraintTag>;
 
 /// Type used to identify model instances by index within a multibody
 /// tree system.


### PR DESCRIPTION
Changes the internal indexing of SAP constraints from a TypeSafeIndex into an Identifier. This will more easily enable the workflow of adding/removing or enabling/disabling constraints.

Currently `ConstraintIndex` is only exposed through the return value of:
- `AddCouplerConstraint()`
- `AddDistanceConstraint()`
- `AddBallConstraint()`

It is not used in any public API for access or introspection to constraints in the plant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19698)
<!-- Reviewable:end -->
