### PR TITLE
[geometry] Add Meshcat::GetRealtimeRate

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -109,6 +109,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("meshcat"), py::arg("params") = MeshcatVisualizerParams{},
             // `meshcat` is a shared_ptr, so does not need a keep_alive.
             cls_doc.ctor.doc)
+        .def("ResetRealtimeRateCalculator", &Class::ResetRealtimeRateCalculator,
+            cls_doc.ResetRealtimeRateCalculator.doc)
         .def("Delete", &Class::Delete, cls_doc.Delete.doc)
         .def("StartRecording", &Class::StartRecording,
             py::arg("set_transforms_while_recording") = true,
@@ -281,6 +283,8 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("Delete", &Class::Delete, py::arg("path") = "", cls_doc.Delete.doc)
         .def("SetRealtimeRate", &Class::SetRealtimeRate, py::arg("rate"),
             cls_doc.SetRealtimeRate.doc)
+        .def("GetRealtimeRate", &Class::GetRealtimeRate,
+            cls_doc.GetRealtimeRate.doc)
         .def("SetProperty",
             py::overload_cast<std::string_view, std::string, bool,
                 const std::optional<double>&>(&Class::SetProperty),

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -193,6 +193,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         self.assertEqual(len(gamepad.button_values), 0)
         self.assertEqual(len(gamepad.axes), 0)
         meshcat.SetRealtimeRate(1.0)
+        meshcat.GetRealtimeRate()
         meshcat.Flush()
 
         meshcat.StartRecording(frames_per_second=64.0,
@@ -277,6 +278,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         self.assertIn("publish_period", repr(params))
         copy.copy(params)
         vis = mut.MeshcatVisualizer_[T](meshcat=meshcat, params=params)
+        vis.ResetRealtimeRateCalculator()
         vis.Delete()
         self.assertIsInstance(vis.query_object_input_port(), InputPort_[T])
         animation = vis.StartRecording(set_transforms_while_recording=True)

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -654,6 +654,7 @@ class Meshcat::Impl {
   // This function is public via the PIMPL.
   void SetRealtimeRate(double rate) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
+    realtime_rate_ = rate;
     internal::RealtimeRateData data;
     data.rate = rate;
     Defer([this, data = std::move(data)]() {
@@ -664,6 +665,12 @@ class Meshcat::Impl {
       std::string message = message_stream.str();
       app_->publish("all", message, uWS::OpCode::BINARY, false);
     });
+  }
+
+  // This function is public via the PIMPL.
+  double GetRealtimeRate() const {
+    DRAKE_DEMAND(IsThread(main_thread_id_));
+    return realtime_rate_;
   }
 
   // This function is public via the PIMPL.
@@ -1937,6 +1944,7 @@ class Meshcat::Impl {
   const MeshcatParams params_;
   int port_{};
   std::mt19937 generator_{};
+  double realtime_rate_{0.0};
 
   // These variables should only be accessed in the websocket thread.
   std::thread::id websocket_thread_id_{};
@@ -2230,6 +2238,10 @@ void Meshcat::Delete(std::string_view path) {
 
 void Meshcat::SetRealtimeRate(double rate) {
   impl().SetRealtimeRate(rate);
+}
+
+double Meshcat::GetRealtimeRate() const {
+  return impl().GetRealtimeRate();
 }
 
 void Meshcat::SetProperty(std::string_view path, std::string property,

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -484,6 +484,12 @@ class Meshcat {
   percentage (multiplied by 100) */
   void SetRealtimeRate(double rate);
 
+  /** Gets the realtime rate that is displayed in the meshcat visualizer stats
+   strip chart. See SetRealtimeRate(). Note that this value might be a smoothing
+   function across multiple calls to SetRealtimeRate() rather than the most
+   recent argument value, in case this class ever adds smoothing capability. */
+  double GetRealtimeRate() const;
+
   /** Sets a single named property of the object at the given path. For example,
   @verbatim
   meshcat.SetProperty("/Background", "visible", false);

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -73,7 +73,7 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    periodic publish event. This is useful for correcting the realtime rate after
    simulation is resumed from a paused state, etc. */
   void ResetRealtimeRateCalculator() const {
-      realtime_rate_calculator_.Reset();
+    realtime_rate_calculator_.Reset();
   }
 
   /** Calls Meshcat::Delete(std::string path), with the path set to
@@ -165,10 +165,6 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    data. */
   template <typename>
   friend class MeshcatVisualizer;
-
-  /* Friend declaration so that internal states can be checked in unit
-  tests. */
-  friend class MeshcatVisualizerTester;
 
   /* The periodic event handler. It tests to see if the last scene description
    is valid (if not, sends the objects) and then sends the transforms.  */

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -1119,8 +1119,8 @@ GTEST_TEST(MeshcatTest, StaticHtml) {
   EXPECT_THAT(html, ::testing::Not(HasSubstr("CONNECTION BLOCK")));
 }
 
-// Check MeshcatParams.show_stats_plot sends a show_realtime_rate message
-GTEST_TEST(MeshcatTest, RealtimeRatePlot) {
+// Check that MeshcatParams.show_stats_plot sends a show_realtime_rate message.
+GTEST_TEST(MeshcatTest, ShowStatsPlot) {
   MeshcatParams params;
   params.show_stats_plot = true;
   Meshcat meshcat(params);
@@ -1128,6 +1128,12 @@ GTEST_TEST(MeshcatTest, RealtimeRatePlot) {
       "type": "show_realtime_rate",
       "show": true
     })""");
+}
+
+GTEST_TEST(MeshcatTest, RealtimeRate) {
+  Meshcat meshcat;
+  meshcat.SetRealtimeRate(2.2);
+  EXPECT_EQ(meshcat.GetRealtimeRate(), 2.2);
 }
 
 }  // namespace

--- a/systems/analysis/test/instantaneous_realtime_rate_calculator_test.cc
+++ b/systems/analysis/test/instantaneous_realtime_rate_calculator_test.cc
@@ -33,10 +33,10 @@ GTEST_TEST(InstantaneousRealtimeRateCalculatorTest, BasicTest) {
   EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 1.0);
 
   // Calling UpdateAndRecalcuate() again with the same sim time will
-  // return 0.0 RTR.
+  // return 0.0 realtime rate.
   EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 0.0);
 
-  // InstantaneousRealtimeRatecalculator should reset properly on call
+  // InstantaneousRealtimeRateCalculator should reset properly on call
   // to Reset().
   calculator.Reset();
 


### PR DESCRIPTION
Tidy up recent Meshcat changes (amends #19667):
- Add missing pydrake bindings.
- Strongly prefer testing the public API (eschew test-friendship hacks). We want to guard against regressions in the end-user experience; using private API goes against that goal.
- Fix indentation, typos, and eschew abbreviation.

+@joemasterjohn for feature review, please.

\CC @Xining-Du @EricCousineau-TRI FYI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19700)
<!-- Reviewable:end -->
