### PR TITLE
MosekSolver supports QuadraticConstraint

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -620,6 +620,20 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "quadratic_constrained_program_examples",
+    testonly = 1,
+    srcs = ["test/quadratic_constrained_program_examples.cc"],
+    hdrs = ["test/quadratic_constrained_program_examples.h"],
+    deps = [
+        ":mathematical_program",
+        ":mosek_solver",
+        ":solve",
+        "//common/test_utilities:eigen_matrix_compare",
+        "@gtest//:without_main",
+    ],
+)
+
+drake_cc_library(
     name = "second_order_cone_program_examples",
     testonly = 1,
     srcs = ["test/second_order_cone_program_examples.cc"],
@@ -1382,6 +1396,7 @@ drake_cc_googletest(
         ":mathematical_program_test_util",
         ":mixed_integer_optimization_util",
         ":mosek_solver",
+        ":quadratic_constrained_program_examples",
         ":quadratic_program_examples",
         ":second_order_cone_program_examples",
         ":semidefinite_program_examples",

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1887,6 +1887,11 @@ class MathematicalProgram {
    lb ≤ .5 xᵀQx + bᵀx ≤ ub
    where `x` might be a subset of the decision variables in this
    MathematicalProgram.
+   Notice that if your quadratic constraint is convex, and you intend to solve
+   the problem with a convex solver (like Mosek), then it is better to
+   reformulate it with a second order cone constraint. See
+   https://docs.mosek.com/10.0/capi/prob-def-quadratic.html#a-recommendation for
+   an explanation.
    @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   Binding<QuadraticConstraint> AddConstraint(
@@ -1894,6 +1899,11 @@ class MathematicalProgram {
 
   /** Adds quadratic constraint
    lb ≤ .5 xᵀQx + bᵀx ≤ ub
+   Notice that if your quadratic constraint is convex, and you intend to solve
+   the problem with a convex solver (like Mosek), then it is better to
+   reformulate it with a second order cone constraint. See
+   https://docs.mosek.com/10.0/capi/prob-def-quadratic.html#a-recommendation for
+   an explanation.
    @param vars x in the documentation above.
    @param hessian_type Whether the Hessian is positive semidefinite, negative
    semidefinite or indefinite. Drake will check the type if
@@ -1911,6 +1921,11 @@ class MathematicalProgram {
 
   /** Adds quadratic constraint
    lb ≤ .5 xᵀQx + bᵀx ≤ ub
+   Notice that if your quadratic constraint is convex, and you intend to solve
+   the problem with a convex solver (like Mosek), then it is better to
+   reformulate it with a second order cone constraint. See
+   https://docs.mosek.com/10.0/capi/prob-def-quadratic.html#a-recommendation for
+   an explanation.
    @param vars x in the documentation above.
    @param hessian_type Whether the Hessian is positive semidefinite, negative
    semidefinite or indefinite. Drake will check the type if
@@ -1928,6 +1943,11 @@ class MathematicalProgram {
 
   /** Overloads AddQuadraticConstraint, impose lb <= e <= ub where `e` is a
    quadratic expression.
+   Notice that if your quadratic constraint is convex, and you intend to solve
+   the problem with a convex solver (like Mosek), then it is better to
+   reformulate it with a second order cone constraint. See
+   https://docs.mosek.com/10.0/capi/prob-def-quadratic.html#a-recommendation for
+   an explanation.
    */
   Binding<QuadraticConstraint> AddQuadraticConstraint(
       const symbolic::Expression& e, double lb, double ub,

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -186,6 +186,14 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
                                 &rotated_lorentz_cone_acc_indices);
   }
 
+  // Add quadratic constraints.
+  std::unordered_map<Binding<QuadraticConstraint>, MSKint64t>
+      quadratic_constraint_dual_indices;
+  if (rescode == MSK_RES_OK) {
+    rescode =
+        impl.AddQuadraticConstraints(prog, &quadratic_constraint_dual_indices);
+  }
+
   // Add linear matrix inequality constraints.
   if (rescode == MSK_RES_OK) {
     rescode = impl.AddLinearMatrixInequalityConstraint(prog);
@@ -204,6 +212,7 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
   if (with_integer_or_binary_variable) {
     solution_type = MSK_SOL_ITG;
   } else if (prog.quadratic_costs().empty() &&
+             prog.quadratic_constraints().empty() &&
              prog.lorentz_cone_constraints().empty() &&
              prog.rotated_lorentz_cone_constraints().empty() &&
              prog.positive_semidefinite_constraints().empty() &&
@@ -332,9 +341,9 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
     }
     rescode = impl.SetDualSolution(
         solution_type, prog, bb_con_dual_indices, linear_con_dual_indices,
-        lin_eq_con_dual_indices, lorentz_cone_acc_indices,
-        rotated_lorentz_cone_acc_indices, exp_cone_acc_indices,
-        psd_barvar_indices, result);
+        lin_eq_con_dual_indices, quadratic_constraint_dual_indices,
+        lorentz_cone_acc_indices, rotated_lorentz_cone_acc_indices,
+        exp_cone_acc_indices, psd_barvar_indices, result);
     DRAKE_ASSERT(rescode == MSK_RES_OK);
   }
 

--- a/solvers/mosek_solver_common.cc
+++ b/solvers/mosek_solver_common.cc
@@ -39,6 +39,7 @@ bool CheckAttributes(const MathematicalProgram& prog,
       std::initializer_list<ProgramAttribute>{
           ProgramAttribute::kLinearEqualityConstraint,
           ProgramAttribute::kLinearConstraint,
+          ProgramAttribute::kQuadraticConstraint,
           ProgramAttribute::kLorentzConeConstraint,
           ProgramAttribute::kRotatedLorentzConeConstraint,
           ProgramAttribute::kPositiveSemidefiniteConstraint,

--- a/solvers/mosek_solver_internal.h
+++ b/solvers/mosek_solver_internal.h
@@ -238,6 +238,14 @@ class MosekSolverProgram {
                          std::pair<ConstraintDualIndices,
                                    ConstraintDualIndices>>* dual_indices);
 
+  // Add the quadratic constraints in @p prog.
+  // @param[out] dual_indices Map each quadratic constraint to its dual variable
+  // index.
+  MSKrescodee AddQuadraticConstraints(
+      const MathematicalProgram& prog,
+      std::unordered_map<Binding<QuadraticConstraint>, MSKint64t>*
+          dual_indices);
+
   /**
    Adds the constraint that A * decision_vars + B * slack_vars + c is in an
    affine cone.
@@ -325,6 +333,8 @@ class MosekSolverProgram {
           bb_con_dual_indices,
       const DualMap<LinearConstraint>& linear_con_dual_indices,
       const DualMap<LinearEqualityConstraint>& lin_eq_con_dual_indices,
+      const std::unordered_map<Binding<QuadraticConstraint>, MSKint64t>&
+          quadratic_constraint_dual_indices,
       const std::unordered_map<Binding<LorentzConeConstraint>, MSKint64t>&
           lorentz_cone_acc_indices,
       const std::unordered_map<Binding<RotatedLorentzConeConstraint>,
@@ -529,6 +539,19 @@ void SetLinearConstraintDualSolution(
     result->set_dual_solution(binding, dual_sol);
   }
 }
+
+// @param slc Mosek dual variables for linear and quadratic constraint lower
+// bound. See
+// https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getslc
+// @param suc Mosek dual variables for linear and quadratic constraint upper
+// bound. See
+// https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getsuc
+void SetQuadraticConstraintDualSolution(
+    const std::vector<Binding<QuadraticConstraint>>& constraints,
+    const std::vector<MSKrealt>& slc, const std::vector<MSKrealt>& suc,
+    const std::unordered_map<Binding<QuadraticConstraint>, MSKint64t>&
+        quadratic_constraint_dual_indices,
+    MathematicalProgramResult* result);
 
 /*
  * Sets the dual solution for the affine cone constraints.

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -10,6 +10,7 @@
 #include "drake/solvers/mixed_integer_optimization_util.h"
 #include "drake/solvers/test/exponential_cone_program_examples.h"
 #include "drake/solvers/test/linear_program_examples.h"
+#include "drake/solvers/test/quadratic_constrained_program_examples.h"
 #include "drake/solvers/test/quadratic_program_examples.h"
 #include "drake/solvers/test/second_order_cone_program_examples.h"
 #include "drake/solvers/test/semidefinite_program_examples.h"
@@ -552,6 +553,22 @@ GTEST_TEST(MosekTest, SDPDualSolution1) {
   MosekSolver solver;
   if (solver.available()) {
     TestSDPDualSolution1(solver, 3E-6);
+  }
+}
+
+GTEST_TEST(MosekTest, TestEllipsoid1) {
+  // Test quadratically constrained program.
+  MosekSolver solver;
+  if (solver.available()) {
+    TestEllipsoid1(solver, std::nullopt, 1E-6);
+  }
+}
+
+GTEST_TEST(MosekTest, TestEllipsoid2) {
+  // Test quadratically constrained program.
+  MosekSolver solver;
+  if (solver.available()) {
+    TestEllipsoid2(solver, std::nullopt, 1E-5);
   }
 }
 

--- a/solvers/test/quadratic_constrained_program_examples.cc
+++ b/solvers/test/quadratic_constrained_program_examples.cc
@@ -1,0 +1,65 @@
+#include "drake/solvers/test/quadratic_constrained_program_examples.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace solvers {
+namespace test {
+const double kInf = std::numeric_limits<double>::infinity();
+
+void TestEllipsoid1(const SolverInterface& solver,
+                    const std::optional<SolverOptions>& solver_options,
+                    double tol) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>("x");
+  const Eigen::Matrix2d Q = Eigen::Vector2d(8, 18).asDiagonal();
+  auto quadratic_con =
+      prog.AddQuadraticConstraint(Q, Eigen::Vector2d::Zero(), -kInf, 1, x);
+  prog.AddLinearCost(Eigen::Vector2d(1, 1), x);
+  MathematicalProgramResult result;
+  solver.Solve(prog, std::nullopt, solver_options, &result);
+  EXPECT_TRUE(result.is_success());
+  const Eigen::Vector2d x_sol = result.GetSolution(x);
+  EXPECT_NEAR(result.get_optimal_cost(), -std::sqrt(13) / 6, tol);
+  const Eigen::Vector2d x_expected(-3 * std::sqrt(13) / 26,
+                                   -4 * std::sqrt(13) / 78);
+  EXPECT_TRUE(CompareMatrices(x_sol, x_expected, tol));
+  EXPECT_TRUE(CompareMatrices(result.GetDualSolution(quadratic_con),
+                              -Vector1d(std::sqrt(13) / 12), tol));
+}
+
+void TestEllipsoid2(const SolverInterface& solver,
+                    const std::optional<SolverOptions>& solver_options,
+                    double tol) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+  // We intentially wirte this constraint as -x0² - x0*x1 - x1² >= -1 to test
+  // the quadratic constraint with a lower bound.
+  const auto quadratic_constraint1 = prog.AddQuadraticConstraint(
+      -x(0) * x(0) - x(0) * x(1) - x(1) * x(1), -1, kInf);
+  const auto quadratic_constraint2 = prog.AddQuadraticConstraint(
+      x(0) * x(0) + 2 * x(0) * x(1) + 4 * x(1) * x(1), -kInf, 9);
+  const auto linear_constraint = prog.AddLinearConstraint(x(0) + x(1) <= 0);
+  prog.AddLinearCost(x(0) + x(1));
+  MathematicalProgramResult result;
+  solver.Solve(prog, std::nullopt, solver_options, &result);
+  EXPECT_TRUE(result.is_success());
+  const Eigen::Vector2d x_sol = result.GetSolution(x);
+  EXPECT_TRUE(CompareMatrices(
+      x_sol, Eigen::Vector2d(-std::sqrt(3) / 3, -std::sqrt(3) / 3), tol));
+  EXPECT_NEAR(result.get_optimal_cost(), -2 * std::sqrt(3) / 3, tol);
+  EXPECT_TRUE(CompareMatrices(result.GetDualSolution(quadratic_constraint1),
+                              Vector1d(std::sqrt(3) / 3), tol));
+  EXPECT_TRUE(CompareMatrices(result.GetDualSolution(quadratic_constraint2),
+                              Vector1d(0), tol));
+  EXPECT_TRUE(CompareMatrices(result.GetDualSolution(linear_constraint),
+                              Vector1d(0), tol));
+}
+
+}  // namespace test
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/quadratic_constrained_program_examples.h
+++ b/solvers/test/quadratic_constrained_program_examples.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/solver_interface.h"
+#include "drake/solvers/solver_options.h"
+
+namespace drake {
+namespace solvers {
+namespace test {
+// min x0 + x1
+// s.t 4x0²+9x1² ≤ 1
+void TestEllipsoid1(const SolverInterface& solver,
+                    const std::optional<SolverOptions>& solver_options,
+                    double tol);
+
+// min x0 + x1
+// s.t x0²+ x0*x1 + x1² ≤ 1
+//     x0²+ 2*x0*x1 + 4x1² ≤ 9
+//     x0 +x1 <= 0
+void TestEllipsoid2(const SolverInterface& solver,
+                    const std::optional<SolverOptions>& solver_options,
+                    double tol);
+
+}  // namespace test
+}  // namespace solvers
+}  // namespace drake


### PR DESCRIPTION
MosekSolver now takes in convex QuadraticConstraint. We still recommended the users to formulate the convex QuadraticConstraint
 as Lorentz cone constraint to get best solver performance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19705)
<!-- Reviewable:end -->
