### PR TITLE
Optimize diagram loop check by using direct feedthrough maps

### DIFF
--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -113,7 +113,9 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   const OutputPortLocator& get_output_port_locator(
       OutputPortIndex port_index) const;
 
-  std::multimap<int, int> GetDirectFeedthroughs() const final;
+  std::multimap<int, int> GetDirectFeedthroughs() const;
+
+  using typename SystemBase::DirectFeedThroughMap;
 
   void SetDefaultState(const Context<T>& context,
                        State<T>* state) const override;
@@ -386,7 +388,14 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   // Returns true if there might be direct feedthrough from the given
   // @p input_port of the Diagram to the given @p output_port of the Diagram.
-  bool DiagramHasDirectFeedthrough(int input_port, int output_port) const;
+  // An optional map @p directfeedthrough_map is used for caching previous
+  // direct feedthroughs results of systems. The map is updated in recursive
+  // calls to system->GetDirectFeedthroughs(). If the parameter @p
+  // directfeedthrough_map is not given or null, no cache will be used.
+  bool DiagramHasDirectFeedthrough(
+      int input_port,
+      int output_port,
+      DirectFeedThroughMap* directfeedthrough_map = nullptr) const;
 
   // Allocates a collection of homogeneous events (e.g., publish events) for
   // this Diagram.
@@ -563,6 +572,9 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   bool NamesAreUniqueAndNonEmpty() const;
 
   int num_subsystems() const;
+
+  std::multimap<int, int> GetDirectFeedthroughsImpl(DirectFeedThroughMap* map)
+      const final;
 
   // A map from the input ports of constituent systems, to the output ports of
   // the systems from which they get their values.

--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -560,6 +560,9 @@ void DiagramBuilder<T>::ThrowIfAlgebraicLoopsExist() const {
     edges[output].insert(input);
   }
 
+  using DirectFeedThroughMap = SystemBase::DirectFeedThroughMap;
+  DirectFeedThroughMap directfeedthrough_map{};
+
   // Add more edges (*not* nodes) based on each System's direct feedthrough.
   // An input port influences an output port iff there is direct feedthrough
   // from that input to that output.  If a feedthrough edge refers to a port
@@ -567,7 +570,8 @@ void DiagramBuilder<T>::ThrowIfAlgebraicLoopsExist() const {
   // diagram cannot participate in a cycle.
   for (const auto& system_ptr : registered_systems_) {
     const SystemBase* const system = system_ptr.get();
-    for (const auto& item : system->GetDirectFeedthroughs()) {
+    for (const auto& item : system->GetDirectFeedthroughs(
+                &directfeedthrough_map)) {
       const SubsystemIndex subsystem_index = system_to_index.at(system);
       const PortIdentifier input{
           subsystem_index, InputPortIndex{item.first}, system};

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -225,7 +225,8 @@ std::unique_ptr<SystemSymbolicInspector> MakeSystemSymbolicInspector(
 }  // namespace
 
 template <typename T>
-std::multimap<int, int> LeafSystem<T>::GetDirectFeedthroughs() const {
+std::multimap<int, int> LeafSystem<T>::GetDirectFeedthroughsImpl(
+        DirectFeedThroughMap* directfeedthrough_map) const {
   // The input -> output feedthrough result we'll return to the user.
   std::multimap<int, int> feedthrough;
 

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -87,7 +87,7 @@ class LeafSystem : public System<T> {
 
   std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const final;
 
-  std::multimap<int, int> GetDirectFeedthroughs() const final;
+  using typename SystemBase::DirectFeedThroughMap;
 
  protected:
   // Promote so we don't need "this->" in defaults which show up in Doxygen.
@@ -129,6 +129,9 @@ class LeafSystem : public System<T> {
       const LeafContext<T>& context) const {
     unused(context);
   }
+
+  std::multimap<int, int> GetDirectFeedthroughsImpl(
+    [[maybe_unused]] DirectFeedThroughMap*) const final;
 
   // =========================================================================
   // Implementations of System<T> methods.

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -32,6 +32,8 @@ namespace drake {
 namespace systems {
 namespace {
 
+using DirectFeedThroughMap = drake::systems::SystemBase::DirectFeedThroughMap;
+
 // Free functions suitable for defining cache entries.
 auto Alloc1 = []() { return AbstractValue::Make<int>(1); };
 auto Alloc3 = []() { return AbstractValue::Make<int>(3); };
@@ -165,7 +167,8 @@ class MySystemBase final : public SystemBase {
     return {};
   }
 
-  std::multimap<int, int> GetDirectFeedthroughs() const final {
+  std::multimap<int, int> GetDirectFeedthroughsImpl(DirectFeedThroughMap* map)
+      const final {
     throw std::logic_error("GetDirectFeedthroughs is not implemented");
   }
 

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -15,6 +15,8 @@
 namespace drake {
 namespace systems {
 
+using DirectFeedThroughMap = drake::systems::SystemBase::DirectFeedThroughMap;
+
 // Don't want anonymous here because the type name test would then depend on
 // exactly how anonymous namespaces are rendered by NiceTypeName, which is
 // a "don't care" here.
@@ -50,8 +52,10 @@ class MySystemBase final : public SystemBase {
     return {};
   }
 
-  std::multimap<int, int> GetDirectFeedthroughs() const final {
-    throw std::logic_error("GetDirectFeedthroughs is not implemented");
+  std::multimap<int, int> GetDirectFeedthroughsImpl(DirectFeedThroughMap* map)
+      const final {
+    throw std::logic_error(
+        "GetDirectFeedthroughs is not implemented");
   }
 };
 


### PR DESCRIPTION
Trying to save intermediate system direct-feedthrough results in a map when a diagram calls `ThrowIfAlgebraicLoopsExist()` to check algebraic loops during the diagram build process. This helps to avoid repeatedly checking system direct-feedthroughs in the recursive calls. We were able to reduce the build time from ~5 mins to ~5 secs for a large diagram.

Some thoughts on the PR:
1. I could make it optional to use direct feedthrough map in diagram builder, but chose not to do so since I will need to add optional parameters in several APIs like `DiagramBuilder::Compile()` and `DiagramBuilder::ThrowIfAlgebraicLoopsExist()` which I'm not sure if is a good idea. Instead, the direct-feedthrough map is *always* enabled in this PR.
2. No additional unit tests are added here, partially because I couldn't find a good way to test public APIs with the choice made above. Instead I'm relying on existing diagram loop unit checks to confirm the correctness of the algorithm.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19711)
<!-- Reviewable:end -->
