### PR TITLE
GurobiSolver acquires a local license at most once per process

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -7,6 +7,10 @@ load(
     "drake_cc_test",
 )
 load(
+    "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_unittest",
+)
+load(
     ":defs.bzl",
     "drake_cc_optional_googletest",
     "drake_cc_optional_library",
@@ -1246,6 +1250,24 @@ drake_cc_googletest(
         ":mathematical_program",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_py_unittest(
+    name = "gurobi_solver_license_retention_test",
+    data = [
+        ":gurobi_solver_license_retention_test_helper",
+    ],
+    tags = gurobi_test_tags(),
+)
+
+drake_cc_binary(
+    name = "gurobi_solver_license_retention_test_helper",
+    testonly = True,
+    srcs = ["test/gurobi_solver_license_retention_test_helper.cc"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":gurobi_solver",
     ],
 )
 

--- a/solvers/gurobi_solver.h
+++ b/solvers/gurobi_solver.h
@@ -163,13 +163,22 @@ class GurobiSolver final : public SolverBase {
 
   /**
    * This acquires a Gurobi license environment shared among all GurobiSolver
-   * instances; the environment will stay valid as long as at least one
-   * shared_ptr returned by this function is alive.
-   * Call this ONLY if you must use different MathematicalProgram
-   * instances at different instances in time, and repeatedly acquiring the
-   * license is costly (e.g., requires contacting a license server).
-   * @return A shared pointer to a license environment that will stay valid
-   * as long as any shared_ptr returned by this function is alive. If Gurobi
+   * instances. The environment will stay valid as long as at least one
+   * shared_ptr returned by this function is alive. GurobiSolver calls this
+   * method on each Solve().
+   *
+   * If the license file contains the string `HOSTID`, then we treat this as
+   * confirmation that the license is attached to the local host, and maintain
+   * an internal copy of the shared_ptr for the lifetime of the process.
+   * Otherwise the default behavior is to only hold the license while at least
+   * one GurobiSolver instance is alive.
+   *
+   * Call this method directly and maintain the shared_ptr ONLY if you must use
+   * different MathematicalProgram instances at different instances in time,
+   * and repeatedly acquiring the license is costly (e.g., requires contacting
+   * a license server).
+   * @return A shared pointer to a license environment that will stay valid as
+   * long as any shared_ptr returned by this function is alive. If Gurobi is
    * not available in your build, this will return a null (empty) shared_ptr.
    * @throws std::exception if Gurobi is available but a license cannot be
    * obtained.

--- a/solvers/test/gurobi_solver_license_retention_test.py
+++ b/solvers/test/gurobi_solver_license_retention_test.py
@@ -1,0 +1,43 @@
+import copy
+import os
+from pathlib import Path
+import subprocess
+import unittest
+
+
+class TestGurobiSolverLicenseRetention(unittest.TestCase):
+
+    def _subprocess_license_use_count(self, license_file_content):
+        """Sets GRB_LICENSE_FILE to a temp file with the given content, runs
+        our test helper, and then returns the license pointer use_count.
+        """
+        # Create a dummy license file. Note that the license filename is magic.
+        # The License code in gurobi_solver.cc treats this filename specially.
+        tmpdir = Path(os.environ["TEST_TMPDIR"])
+        license_file = tmpdir / "DRAKE_UNIT_TEST_NO_LICENSE.lic"
+        with open(license_file, "w", encoding="utf-8") as f:
+            f.write(license_file_content)
+
+        # Override the built-in license file.
+        env = copy.copy(os.environ)
+        env["GRB_LICENSE_FILE"] = str(license_file)
+
+        # Run the helper and return the pointer use_count.
+        output = subprocess.check_output(
+            ["solvers/gurobi_solver_license_retention_test_helper"])
+        return int(output)
+
+    def test_local_license(self):
+        """When the file named by GRB_LICENSE_FILE contains 'HOSTID', the
+        license object is held in two places: the test helper main(), and
+        a global variable within GurobiSolver::AcquireLicense.
+        """
+        content = "HOSTID=foobar\n"
+        self.assertEqual(self._subprocess_license_use_count(content), 2)
+
+    def test_nonlocal_license(self):
+        """When the file named by GRB_LICENSE_FILE doesn't contain 'HOSTID',
+        the license object is only held by main(), not any global variable.
+        """
+        content = "TOKENSERVER=foobar.invalid.\n"
+        self.assertEqual(self._subprocess_license_use_count(content), 1)

--- a/solvers/test/gurobi_solver_license_retention_test_helper.cc
+++ b/solvers/test/gurobi_solver_license_retention_test_helper.cc
@@ -1,0 +1,11 @@
+#include "drake/solvers/gurobi_solver.h"
+
+using drake::solvers::GurobiSolver;
+
+/* Acquire a license and report the overall use_count. */
+int main() {
+  std::shared_ptr<GurobiSolver::License> license =
+      GurobiSolver::AcquireLicense();
+  fmt::print("{}\n", license.use_count());
+  return 0;
+}


### PR DESCRIPTION
Iff the contents of the file identified in GRB_LICENSE_FILE contain the magic keywork HOSTID, then any license that is obtained will never be destroyed.

Resolves #19657.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19713)
<!-- Reviewable:end -->
