### PR TITLE
Implement IsEmpty for ConvexSet and derived classes

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -45,6 +45,7 @@ void DefineGeometryOptimization(py::module m) {
         .def("IntersectsWith", &ConvexSet::IntersectsWith, py::arg("other"),
             cls_doc.IntersectsWith.doc)
         .def("IsBounded", &ConvexSet::IsBounded, cls_doc.IsBounded.doc)
+        .def("IsEmpty", &ConvexSet::IsEmpty, cls_doc.IsEmpty.doc)
         .def("MaybeGetPoint", &ConvexSet::MaybeGetPoint,
             cls_doc.MaybeGetPoint.doc)
         .def("PointInSet", &ConvexSet::PointInSet, py::arg("x"),
@@ -133,7 +134,6 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("tol") = 1E-9, cls_doc.ReduceInequalities.doc)
         .def("FindRedundant", &HPolyhedron::FindRedundant,
             py::arg("tol") = 1E-9, cls_doc.FindRedundant.doc)
-        .def("IsEmpty", &HPolyhedron::IsEmpty, cls_doc.IsEmpty.doc)
         .def("MaximumVolumeInscribedEllipsoid",
             &HPolyhedron::MaximumVolumeInscribedEllipsoid,
             cls_doc.MaximumVolumeInscribedEllipsoid.doc)

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -43,6 +43,7 @@ class TestGeometryOptimization(unittest.TestCase):
         mut.Point()
         p = np.array([11.1, 12.2, 13.3])
         point = mut.Point(p)
+        self.assertFalse(point.IsEmpty())
         self.assertEqual(point.ambient_dimension(), 3)
         np.testing.assert_array_equal(point.x(), p)
         np.testing.assert_array_equal(point.MaybeGetPoint(), p)
@@ -61,6 +62,7 @@ class TestGeometryOptimization(unittest.TestCase):
         np.testing.assert_array_equal(hpoly.A(), self.A)
         np.testing.assert_array_equal(hpoly.b(), self.b)
         self.assertTrue(hpoly.PointInSet(x=[0, 0, 0], tol=0.0))
+        self.assertFalse(hpoly.IsEmpty())
         self.assertFalse(hpoly.IsBounded())
         new_vars, new_constraints = hpoly.AddPointInSetConstraints(
             self.prog, self.x)
@@ -166,6 +168,7 @@ class TestGeometryOptimization(unittest.TestCase):
         mut.Hyperellipsoid()
         ellipsoid = mut.Hyperellipsoid(A=self.A, center=self.b)
         self.assertEqual(ellipsoid.ambient_dimension(), 3)
+        self.assertFalse(ellipsoid.IsEmpty())
         np.testing.assert_array_equal(ellipsoid.A(), self.A)
         np.testing.assert_array_equal(ellipsoid.center(), self.b)
         self.assertTrue(ellipsoid.PointInSet(x=self.b, tol=0.0))
@@ -215,6 +218,7 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(sum2.ambient_dimension(), 3)
         self.assertEqual(sum2.num_terms(), 2)
         self.assertIsInstance(sum2.term(0), mut.Point)
+        self.assertFalse(sum.IsEmpty())
 
     def test_spectrahedron(self):
         s = mut.Spectrahedron()
@@ -229,6 +233,7 @@ class TestGeometryOptimization(unittest.TestCase):
         mut.VPolytope()
         vertices = np.array([[0.0, 1.0, 2.0], [3.0, 7.0, 5.0]])
         vpoly = mut.VPolytope(vertices=vertices)
+        self.assertFalse(vpoly.IsEmpty())
         self.assertEqual(vpoly.ambient_dimension(), 2)
         np.testing.assert_array_equal(vpoly.vertices(), vertices)
         self.assertTrue(vpoly.PointInSet(x=[1.0, 5.0], tol=1e-8))
@@ -307,6 +312,7 @@ class TestGeometryOptimization(unittest.TestCase):
         h_box = mut.HPolyhedron.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])
         sum = mut.CartesianProduct(setA=point, setB=h_box)
+        self.assertFalse(sum.IsEmpty())
         self.assertEqual(sum.ambient_dimension(), 6)
         self.assertEqual(sum.num_factors(), 2)
         sum2 = mut.CartesianProduct(sets=[point, h_box])
@@ -325,6 +331,7 @@ class TestGeometryOptimization(unittest.TestCase):
         h_box = mut.HPolyhedron.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])
         intersect = mut.Intersection(setA=point, setB=h_box)
+        self.assertFalse(intersect.IsEmpty())
         self.assertEqual(intersect.ambient_dimension(), 3)
         self.assertEqual(intersect.num_elements(), 2)
         intersect2 = mut.Intersection(sets=[point, h_box])

--- a/geometry/optimization/cartesian_product.cc
+++ b/geometry/optimization/cartesian_product.cc
@@ -114,6 +114,18 @@ bool CartesianProduct::DoIsBounded() const {
   return true;
 }
 
+bool CartesianProduct::DoIsEmpty() const {
+  if (sets_.size() == 0) {
+    return true;
+  }
+  for (const auto& s : sets_) {
+    if (s->IsEmpty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::optional<VectorXd> CartesianProduct::DoMaybeGetPoint() const {
   // Check if all sets are points.
   std::vector<VectorXd> points;

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -77,6 +77,8 @@ class CartesianProduct final : public ConvexSet {
 
   bool DoIsBounded() const final;
 
+  bool DoIsEmpty() const final;
+
   std::optional<Eigen::VectorXd> DoMaybeGetPoint() const final;
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -90,6 +90,15 @@ class ConvexSet : public ShapeReifier {
     return DoIsBounded();
   }
 
+  /** Returns true iff the set is empty. Note: for some derived classes, this
+  check is trivial, but for others, it can require solving a (typically small)
+  optimization problem. Check the derived class documentation for any notes.
+  @throws std::exception if ambient_dimension() == 0 */
+  bool IsEmpty() const {
+    DRAKE_THROW_UNLESS(ambient_dimension() > 0);
+    return DoIsEmpty();
+  }
+
   /** If this set trivially contains exactly one point, returns the value of
   that point. Otherwise, returns nullopt. When ambient_dimension is zero,
   returns nullopt. By "trivially", we mean that representation of the set
@@ -212,6 +221,11 @@ class ConvexSet : public ShapeReifier {
   /** Non-virtual interface implementation for IsBounded().
   @pre ambient_dimension() > 0 */
   virtual bool DoIsBounded() const = 0;
+
+  /** Non-virtual interface implementation for IsEmpty(). The default
+  implementation solves a feasibility optimization problem, but derived
+  classes can override with a custom (more efficient) implementation. */
+  virtual bool DoIsEmpty() const;
 
   /** Non-virtual interface implementation for MaybeGetPoint(). The default
   implementation returns nullopt. Sets that can model a single point should

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -54,16 +54,6 @@ std::tuple<bool, solvers::MathematicalProgramResult> IsInfeasible(
           result};
 }
 
-// Checks if Ax ≤ b defines an empty set.
-bool DoIsEmpty(const Eigen::Ref<const MatrixXd>& A,
-               const Eigen::Ref<const VectorXd>& b) {
-  solvers::MathematicalProgram prog;
-  solvers::VectorXDecisionVariable x =
-      prog.NewContinuousVariables(A.cols(), "x");
-  prog.AddLinearConstraint(A, VectorXd::Constant(b.rows(), -kInf), b, x);
-  return std::get<0>(IsInfeasible(prog));
-}
-
 /* Checks whether the constraint cᵀ x ≤ d is already implied by the linear
  constraints in prog. This is done by solving a small linear program
  and modifying the coefficients of  `new_constraint` binding. This method may
@@ -363,11 +353,19 @@ bool HPolyhedron::DoIsBounded() const {
   return result.is_success();
 }
 
+bool HPolyhedron::DoIsEmpty() const {
+  solvers::MathematicalProgram prog;
+  solvers::VectorXDecisionVariable x =
+      prog.NewContinuousVariables(A_.cols(), "x");
+  prog.AddLinearConstraint(A_, VectorXd::Constant(b_.rows(), -kInf), b_, x);
+  return std::get<0>(IsInfeasible(prog));
+}
+
 bool HPolyhedron::ContainedIn(const HPolyhedron& other, double tol) const {
   DRAKE_THROW_UNLESS(other.A().cols() == A_.cols());
   // `this` defines an empty set and therefore is contained in any `other`
   // HPolyhedron.
-  if (DoIsEmpty(A_, b_)) {
+  if (DoIsEmpty()) {
     return true;
   }
 
@@ -439,8 +437,9 @@ HPolyhedron HPolyhedron::DoIntersectionWithChecks(const HPolyhedron& other,
       A.row(num_kept) = other.A().row(i);
       b.row(num_kept) = other.b().row(i);
       ++num_kept;
-      if (DoIsEmpty(A.topRows(num_kept), b.topRows(num_kept))) {
-        return {A.topRows(num_kept), b.topRows(num_kept)};
+      HPolyhedron maybe_empty(A.topRows(num_kept), b.topRows(num_kept));
+      if (maybe_empty.IsEmpty()) {
+        return maybe_empty;
       }
     }
   }
@@ -520,10 +519,6 @@ std::set<int> HPolyhedron::FindRedundant(double tol) const {
     }
   }
   return redundant_indices;
-}
-
-bool HPolyhedron::IsEmpty() const {
-  return DoIsEmpty(A_, b_);
 }
 
 std::unique_ptr<ConvexSet> HPolyhedron::DoClone() const {

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -103,9 +103,6 @@ class HPolyhedron final : public ConvexSet {
   negative tol means it is less likely to remote a constraint.  */
   [[nodiscard]] HPolyhedron ReduceInequalities(double tol = 1E-9) const;
 
-  /** Checks if this HPolyhedron defines an empty set.  */
-  [[nodiscard]] bool IsEmpty() const;
-
   /** Solves a semi-definite program to compute the inscribed ellipsoid.
   From Section 8.4.2 in Boyd and Vandenberghe, 2004, we solve
   @verbatim
@@ -211,6 +208,8 @@ class HPolyhedron final : public ConvexSet {
   std::unique_ptr<ConvexSet> DoClone() const final;
 
   bool DoIsBounded() const final;
+
+  bool DoIsEmpty() const final;
 
   // N.B. No need to override DoMaybeGetPoint here.
 

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -180,6 +180,10 @@ bool Hyperellipsoid::DoIsBounded() const {
   return qr.dimensionOfKernel() == 0;
 }
 
+bool Hyperellipsoid::DoIsEmpty() const {
+  return false;
+}
+
 bool Hyperellipsoid::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
                                   double tol) const {
   DRAKE_DEMAND(A_.cols() == x.size());

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -109,6 +109,8 @@ class Hyperellipsoid final : public ConvexSet {
 
   bool DoIsBounded() const final;
 
+  bool DoIsEmpty() const final;
+
   // N.B. No need to override DoMaybeGetPoint here.
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -103,6 +103,19 @@ bool MinkowskiSum::DoIsBounded() const {
   return true;
 }
 
+bool MinkowskiSum::DoIsEmpty() const {
+  if (sets_.size() == 0) {
+    return true;
+  }
+  // The empty set is annihilatory in Minkowski addition.
+  for (const auto& s : sets_) {
+    if (s->IsEmpty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::optional<VectorXd> MinkowskiSum::DoMaybeGetPoint() const {
   std::optional<VectorXd> result;
   for (const auto& s : sets_) {

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -64,6 +64,8 @@ class MinkowskiSum final : public ConvexSet {
 
   bool DoIsBounded() const final;
 
+  bool DoIsEmpty() const final;
+
   std::optional<Eigen::VectorXd> DoMaybeGetPoint() const final;
 
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/geometry/optimization/point.cc
+++ b/geometry/optimization/point.cc
@@ -57,6 +57,14 @@ std::unique_ptr<ConvexSet> Point::DoClone() const {
   return std::make_unique<Point>(*this);
 }
 
+bool Point::DoIsBounded() const {
+  return true;
+}
+
+bool Point::DoIsEmpty() const {
+  return false;
+}
+
 std::optional<VectorXd> Point::DoMaybeGetPoint() const {
   return x_;
 }

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -49,7 +49,9 @@ class Point final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final { return true; }
+  bool DoIsBounded() const final;
+
+  bool DoIsEmpty() const final;
 
   std::optional<Eigen::VectorXd> DoMaybeGetPoint() const final;
 

--- a/geometry/optimization/test/cartesian_product_test.cc
+++ b/geometry/optimization/test/cartesian_product_test.cc
@@ -58,6 +58,9 @@ GTEST_TEST(CartesianProductTest, BasicTest) {
   // Test IsBounded.
   EXPECT_TRUE(S.IsBounded());
 
+  // Test IsEmpty
+  EXPECT_FALSE(S.IsEmpty());
+
   // Test ConvexSets constructor.
   ConvexSets sets;
   sets.emplace_back(P1);
@@ -76,6 +79,7 @@ GTEST_TEST(CartesianProductTest, DefaultCtor) {
   EXPECT_EQ(dut.ambient_dimension(), 0);
   EXPECT_FALSE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
+  EXPECT_THROW(dut.IsEmpty(), std::exception);
   EXPECT_FALSE(dut.MaybeGetPoint().has_value());
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
@@ -411,6 +415,26 @@ GTEST_TEST(CartesianProductTest, Rotated) {
   prog.RemoveConstraint(x_constraint);
   prog.AddBoundingBoxConstraint(.5 * out_S, .5 * out_S, x);
   EXPECT_FALSE(Solve(prog).is_success());
+}
+
+GTEST_TEST(CartesianProductTest, EmptyCartesianProductTest) {
+  Eigen::MatrixXd A{5, 3};
+  Eigen::VectorXd b{5};
+  // Rows 1-3 define an infeasible set of inequalities.
+  // clang-format off
+  A << 1, 0, 0,
+       1, -1, 0,
+       -1, 0, 1,
+       0, 1, -1,
+       0, 0, -1;
+  b << 1, -1, -1, -1, 0;
+  // clang-format off
+
+  const HPolyhedron H1{A, b};
+  const Point P1(Vector3d{0.1, 1.2, 0.3});
+  const CartesianProduct S(P1, H1);
+
+  EXPECT_TRUE(S.IsEmpty());
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -47,6 +47,7 @@ GTEST_TEST(HPolyhedronTest, DefaultConstructor) {
   EXPECT_NO_THROW(H.Clone());
   EXPECT_FALSE(H.IntersectsWith(H));
   EXPECT_TRUE(H.IsBounded());
+  EXPECT_THROW(H.IsEmpty(), std::exception);
   EXPECT_FALSE(H.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 

--- a/geometry/optimization/test/hyperellipsoid_test.cc
+++ b/geometry/optimization/test/hyperellipsoid_test.cc
@@ -57,6 +57,9 @@ GTEST_TEST(HyperellipsoidTest, UnitSphereTest) {
   // Test MaybeGetPoint.
   EXPECT_FALSE(E.MaybeGetPoint().has_value());
 
+  // Test IsEmpty (which is trivially false for Hyperellipsoid).
+  EXPECT_FALSE(E.IsEmpty());
+
   // Test PointInSet.
   const Vector3d in1_W{.99, 0, 0}, in2_W{.5, .5, .5}, out1_W{1.01, 0, 0},
       out2_W{1.0, 1.0, 1.0};
@@ -99,6 +102,7 @@ GTEST_TEST(HyperellipsoidTest, DefaultCtor) {
   EXPECT_EQ(dut.ambient_dimension(), 0);
   EXPECT_FALSE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
+  EXPECT_THROW(dut.IsEmpty(), std::exception);
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 

--- a/geometry/optimization/test/minkowski_sum_test.cc
+++ b/geometry/optimization/test/minkowski_sum_test.cc
@@ -60,6 +60,9 @@ GTEST_TEST(MinkowskiSumTest, BasicTest) {
   // Test IsBounded.
   EXPECT_TRUE(S.IsBounded());
 
+  // Test IsEmpty.
+  EXPECT_FALSE(S.IsEmpty());
+
   // Test ConvexSets constructor.
   ConvexSets sets;
   sets.emplace_back(P1);
@@ -78,6 +81,7 @@ GTEST_TEST(MinkowskiSumTest, DefaultCtor) {
   EXPECT_EQ(dut.ambient_dimension(), 0);
   EXPECT_FALSE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
+  EXPECT_THROW(dut.IsEmpty(), std::exception);
   EXPECT_FALSE(dut.MaybeGetPoint().has_value());
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
@@ -265,6 +269,26 @@ GTEST_TEST(MinkowskiSumTest, NonnegativeScalingTest2) {
       PointInScaledSet(x, t, x_solution, Eigen::Vector2d(0, 1), &prog));
   EXPECT_FALSE(
       PointInScaledSet(x, t, x_solution, Eigen::Vector2d(-1, 0), &prog));
+}
+
+GTEST_TEST(MinkowskiSumTest, EmptyMinkowskiSumTest) {
+  Eigen::MatrixXd A{5, 3};
+  Eigen::VectorXd b{5};
+  // Rows 1-3 define an infeasible set of inequalities.
+  // clang-format off
+  A << 1, 0, 0,
+       1, -1, 0,
+       -1, 0, 1,
+       0, 1, -1,
+       0, 0, -1;
+  b << 1, -1, -1, -1, 0;
+  // clang-format off
+
+  const HPolyhedron H1{A, b};
+  const Point P1(Vector3d{0.1, 1.2, 0.3});
+  const MinkowskiSum S(P1, H1);
+
+  EXPECT_TRUE(S.IsEmpty());
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/point_test.cc
+++ b/geometry/optimization/test/point_test.cc
@@ -56,6 +56,9 @@ GTEST_TEST(PointTest, BasicTest) {
   // Test IsBounded (which is trivially true for Point).
   EXPECT_TRUE(P.IsBounded());
 
+  // Test IsEmpty (which is trivially false for Point).
+  EXPECT_FALSE(P.IsEmpty());
+
   // Test set_x().
   const Vector3d p2_W{6.2, -.23, -8.2};
   P.set_x(p2_W);
@@ -70,6 +73,7 @@ GTEST_TEST(PointTest, DefaultCtor) {
   EXPECT_EQ(dut.ambient_dimension(), 0);
   EXPECT_FALSE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
+  EXPECT_THROW(dut.IsEmpty(), std::exception);
   EXPECT_FALSE(dut.MaybeGetPoint().has_value());
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -48,6 +48,9 @@ GTEST_TEST(VPolytopeTest, TriangleTest) {
   // Check IsBounded (which is trivially true for V Polytopes).
   EXPECT_TRUE(V.IsBounded());
 
+  // Test IsEmpty.
+  EXPECT_FALSE(V.IsEmpty());
+
   const Eigen::Vector2d center = triangle.rowwise().mean();
   // Mosek worked with 1e-15.
   // Gurobi worked with 1e-15 (see the note about alpha_sol in the method).
@@ -83,6 +86,7 @@ GTEST_TEST(VPolytopeTest, DefaultCtor) {
   EXPECT_EQ(dut.ambient_dimension(), 0);
   EXPECT_FALSE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
+  EXPECT_THROW(dut.IsEmpty(), std::exception);
   EXPECT_FALSE(dut.MaybeGetPoint().has_value());
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
@@ -637,6 +641,15 @@ GTEST_TEST(VPolytopeTest, WriteObjTest) {
 
   VPolytope V_scene_graph(query, geom_id);
   CheckVertices(V.vertices(), V_scene_graph.vertices(), 1e-6);
+}
+
+// If a VPolytope is constructed over an empty vertex list, it is considered
+// to be empty.
+GTEST_TEST(VPolytopeTest, EmptyTest) {
+  Eigen::Matrix<double, 3, 0> vertices;
+  auto V = VPolytope(vertices);
+  EXPECT_EQ(V.ambient_dimension(), 3);
+  ASSERT_TRUE(V.IsEmpty());
 }
 
 }  // namespace optimization

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -328,6 +328,14 @@ std::unique_ptr<ConvexSet> VPolytope::DoClone() const {
   return std::make_unique<VPolytope>(*this);
 }
 
+bool VPolytope::DoIsBounded() const {
+  return true;
+}
+
+bool VPolytope::DoIsEmpty() const {
+  return vertices_.size() == 0;
+}
+
 std::optional<VectorXd> VPolytope::DoMaybeGetPoint() const {
   if (vertices_.cols() == 1) {
     return vertices_.col(0);

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -87,7 +87,9 @@ class VPolytope final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final { return true; }
+  bool DoIsBounded() const final;
+
+  bool DoIsEmpty() const final;
 
   std::optional<Eigen::VectorXd> DoMaybeGetPoint() const final;
 


### PR DESCRIPTION
This function already existed for HPolyedron, but this adds it to the base ConvexSet class, and implements it for all derived classes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19716)
<!-- Reviewable:end -->
