### PR TITLE
GraphOfConvexSets returns kInfeasibleConstraints when no path exists.

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -668,6 +668,10 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
   std::map<EdgeId, Variable> relaxed_phi;
   std::vector<Variable> excluded_phi;
 
+  // The flow constraints below assume that we have some edge out of the source
+  // and into the target, so we handle that case explicitly.
+  bool has_edges_out_of_source = false;
+  bool has_edges_into_target = false;
   for (const auto& [edge_id, e] : edges_) {
     // If an edge is turned off (ϕ = 0) or excluded by preprocessing, don't
     // include it in the optimization.
@@ -680,6 +684,12 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
         excluded_phi.push_back(phi);
       }
       continue;
+    }
+    if (e->u().id() == source_id) {
+      has_edges_out_of_source = true;
+    }
+    if (e->v().id() == target_id) {
+      has_edges_into_target = true;
     }
     outgoing_edges[e->u().id()].emplace_back(e.get());
     incoming_edges[e->v().id()].emplace_back(e.get());
@@ -743,6 +753,18 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
       // (on the vertices).
       AddPerspectiveConstraint(&prog, b, vars);
     }
+  }
+  if (!has_edges_out_of_source) {
+    MathematicalProgramResult result;
+    log()->info("Source vertex {} has no outgoing edges.", source_id);
+    result.set_solution_result(SolutionResult::kInfeasibleConstraints);
+    return result;
+  }
+  if (!has_edges_into_target) {
+    MathematicalProgramResult result;
+    log()->info("Target vertex {} has no incoming edges.", target_id);
+    result.set_solution_result(SolutionResult::kInfeasibleConstraints);
+    return result;
   }
 
   for (const std::pair<const VertexId, std::unique_ptr<Vertex>>& vpair :
@@ -929,7 +951,7 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
       ++num_trials;
 
       // Find candidate path by traversing the graph with a depth first search
-      // where edges are taken with prbability proportional to their flow.
+      // where edges are taken with probability proportional to their flow.
       std::vector<VertexId> visited_vertex_ids{source_id};
       std::vector<VertexId> path_vertex_ids{source_id};
       std::vector<const Edge*> new_path;
@@ -948,6 +970,9 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
         if (candidate_edges.size() == 0) {
           path_vertex_ids.pop_back();
           new_path.pop_back();
+          // Since this code requires result.is_success() to be true, we should
+          // always have a path. We assert that..
+          DRAKE_ASSERT(path_vertex_ids.size() > 0);
           continue;
         }
         Eigen::VectorXd candidate_flows(candidate_edges.size());

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1496,6 +1496,115 @@ GTEST_TEST(ShortestPathTest, RoundingBacktrack) {
   ASSERT_TRUE(result.is_success());
 }
 
+// Cover the case where there is no path from source to target.
+GTEST_TEST(ShortestPathTest, NoPath) {
+  GraphOfConvexSets spp;
+  auto source = spp.AddVertex(Point(Vector2d(0, 0)));
+  auto v1 = spp.AddVertex(Point(Vector2d(0, 1)));
+  auto v2 = spp.AddVertex(Point(Vector2d(1, 0)));
+  auto target = spp.AddVertex(Point(Vector2d(1, 1)));
+  spp.AddEdge(*source, *v1);
+  spp.AddEdge(*v2, *target);
+
+  GraphOfConvexSetsOptions options;
+  options.convex_relaxation = true;
+  options.preprocessing = false;
+  options.max_rounded_paths = 10;
+  auto result = spp.SolveShortestPath(*source, *target, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleConstraints);
+
+  options.preprocessing = true;
+  options.max_rounded_paths = 10;
+  result = spp.SolveShortestPath(*source, *target, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleConstraints);
+
+  if (!MixedIntegerSolverAvailable()) {
+    return;
+  }
+
+  options.convex_relaxation = false;
+  result = spp.SolveShortestPath(*source, *target, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleConstraints);
+}
+
+// Cover the special case of the source not having any outgoing edges.
+GTEST_TEST(ShortestPathTest, NoPathDetachedSource) {
+  GraphOfConvexSets spp;
+  auto source = spp.AddVertex(Point(Vector2d(0, 0)));
+  spp.AddVertex(Point(Vector2d(0, 1)));
+  auto v2 = spp.AddVertex(Point(Vector2d(1, 0)));
+  auto target = spp.AddVertex(Point(Vector2d(1, 1)));
+  spp.AddEdge(*v2, *target);
+
+  GraphOfConvexSetsOptions options;
+  options.convex_relaxation = true;
+  options.preprocessing = false;
+  options.max_rounded_paths = 10;
+  auto result = spp.SolveShortestPath(*source, *target, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleConstraints);
+
+  options.preprocessing = true;
+  options.max_rounded_paths = 10;
+  result = spp.SolveShortestPath(*source, *target, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleConstraints);
+
+  if (!MixedIntegerSolverAvailable()) {
+    return;
+  }
+
+  options.convex_relaxation = false;
+  result = spp.SolveShortestPath(*source, *target, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleConstraints);
+}
+
+// Cover the special case of the target not having any incoming edges.
+GTEST_TEST(ShortestPathTest, NoPathDetachedTarget) {
+  GraphOfConvexSets spp;
+  auto source = spp.AddVertex(Point(Vector2d(0, 0)));
+  auto v1 = spp.AddVertex(Point(Vector2d(0, 1)));
+  spp.AddVertex(Point(Vector2d(1, 0)));
+  auto target = spp.AddVertex(Point(Vector2d(1, 1)));
+  spp.AddEdge(*source, *v1);
+
+  GraphOfConvexSetsOptions options;
+  options.convex_relaxation = true;
+  options.preprocessing = false;
+  options.max_rounded_paths = 10;
+  auto result = spp.SolveShortestPath(*source, *target, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleConstraints);
+
+  options.preprocessing = true;
+  options.max_rounded_paths = 10;
+  result = spp.SolveShortestPath(*source, *target, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleConstraints);
+
+  if (!MixedIntegerSolverAvailable()) {
+    return;
+  }
+
+  options.convex_relaxation = false;
+  result = spp.SolveShortestPath(*source, *target, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solution_result(),
+            SolutionResult::kInfeasibleConstraints);
+}
+
 GTEST_TEST(ShortestPathTest, TobiasToyExample) {
   GraphOfConvexSets spp;
 


### PR DESCRIPTION
This fixes some small bugs in our handling of the case where no path exists.

+@TobiaMarcucci for feature review, please.
(I found this when toying with the default parameter changes, which I will PR once this lands).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19719)
<!-- Reviewable:end -->
