### PR TITLE
[multibody] Reject duplicated frame names

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -965,13 +965,15 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// This method adds a Joint of type `JointType` between two bodies.
   /// For more information, see the below overload of `AddJoint<>`.
-  template <template<typename Scalar> class JointType>
+  template <template <typename Scalar> class JointType>
   const JointType<T>& AddJoint(std::unique_ptr<JointType<T>> joint) {
-    DRAKE_MBP_THROW_IF_FINALIZED();
     static_assert(std::is_convertible_v<JointType<T>*, Joint<T>*>,
                   "JointType must be a sub-class of Joint<T>.");
-    RegisterJointInGraph(*joint);
-    return this->mutable_tree().AddJoint(std::move(joint));
+    DRAKE_MBP_THROW_IF_FINALIZED();
+    const JointType<T>& result =
+        this->mutable_tree().AddJoint(std::move(joint));
+    RegisterJointInGraph(result);
+    return result;
   }
 
   /// This method adds a Joint of type `JointType` between two bodies.
@@ -1059,31 +1061,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     //  consider changing frame F to frame Jp and changing frame M to frame Jc.
     static_assert(std::is_base_of_v<Joint<T>, JointType<T>>,
                   "JointType<T> must be a sub-class of Joint<T>.");
-
-    const Frame<T>* frame_on_parent{nullptr};
-    if (X_PF) {
-      frame_on_parent = &this->AddFrame(
-          std::make_unique<FixedOffsetFrame<T>>(
-              name + "_parent", parent, *X_PF));
-    } else {
-      frame_on_parent = &parent.body_frame();
-    }
-
-    const Frame<T>* frame_on_child{nullptr};
-    if (X_BM) {
-      frame_on_child = &this->AddFrame(
-          std::make_unique<FixedOffsetFrame<T>>(
-              name + "_child", child, *X_BM));
-    } else {
-      frame_on_child = &child.body_frame();
-    }
-
-    const JointType<T>& joint = AddJoint(
-        std::make_unique<JointType<T>>(
-            name,
-            *frame_on_parent, *frame_on_child,
-            std::forward<Args>(args)...));
-    return joint;
+    DRAKE_MBP_THROW_IF_FINALIZED();
+    const JointType<T>& result =
+        this->mutable_tree().template AddJoint<JointType>(
+            name, parent, X_PF, child, X_BM, std::forward<Args>(args)...);
+    RegisterJointInGraph(result);
+    return result;
   }
 
   /// Welds `frame_on_parent_F` and `frame_on_child_M` with relative pose

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -138,6 +138,12 @@ const FrameType<T>& MultibodyTree<T>::AddFrame(
   if (frame == nullptr) {
     throw std::logic_error("Input frame is a nullptr.");
   }
+  if (HasFrameNamed(frame->name(), frame->model_instance())) {
+    throw std::logic_error(fmt::format(
+        "Model instance '{}' already contains a frame named '{}'. "
+        "Frame names must be unique within a given model.",
+        instance_index_to_name_.at(frame->model_instance()), frame->name()));
+  }
   FrameIndex frame_index = topology_.add_frame(frame->body().index());
   // This test MUST be performed BEFORE frames_.push_back() and
   // owned_frames_.push_back() below. Do not move it around!
@@ -324,29 +330,19 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
     Args&&... args) {
   static_assert(std::is_base_of_v<Joint<T>, JointType<T>>,
                 "JointType<T> must be a sub-class of Joint<T>.");
-
-  const Frame<T>* frame_on_parent{nullptr};
-  if (X_PF) {
-    frame_on_parent = &this->AddFrame<FixedOffsetFrame>(
-       name + "_parent", parent, *X_PF);
-  } else {
-    frame_on_parent = &parent.body_frame();
-  }
-
-  const Frame<T>* frame_on_child{nullptr};
-  if (X_BM) {
-    frame_on_child = &this->AddFrame<FixedOffsetFrame>(
-        name + "_child", child, *X_BM);
-  } else {
-    frame_on_child = &child.body_frame();
-  }
-
-  const JointType<T>& joint = AddJoint(
-      std::make_unique<JointType<T>>(
-          name,
-          *frame_on_parent, *frame_on_child,
-          std::forward<Args>(args)...));
-  return joint;
+  // The Joint constructor promises that the Joint's model instance will be the
+  // same as the child body's model instance. We'll assume that for now, and
+  // then cross-check it at the bottom of this function. We need to use the same
+  // model instance when creating any offset frames needed for the joint.
+  const ModelInstanceIndex joint_instance = child.model_instance();
+  const Frame<T>& frame_on_parent =
+      this->AddOrGetJointFrame(parent, X_PF, joint_instance, name, "parent");
+  const Frame<T>& frame_on_child =
+      this->AddOrGetJointFrame(child, X_BM, joint_instance, name, "child");
+  const JointType<T>& result = AddJoint(std::make_unique<JointType<T>>(
+      name, frame_on_parent, frame_on_child, std::forward<Args>(args)...));
+  DRAKE_DEMAND(result.model_instance() == joint_instance);
+  return result;
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -677,6 +677,21 @@ MultibodyTree<T>::GetFreeBodyMobilizerOrThrow(
 }
 
 template <typename T>
+const Frame<T>& MultibodyTree<T>::AddOrGetJointFrame(
+    const Body<T>& body,
+    const std::optional<math::RigidTransform<double>>& X_BF,
+    ModelInstanceIndex joint_instance, std::string_view joint_name,
+    std::string_view frame_suffix) {
+  if (X_BF.has_value()) {
+    return this->AddFrame<FixedOffsetFrame>(
+        fmt::format("{}_{}", joint_name, frame_suffix), body.body_frame(),
+        *X_BF, joint_instance);
+  } else {
+    return body.body_frame();
+  }
+}
+
+template <typename T>
 void MultibodyTree<T>::FinalizeTopology() {
   // If the topology is valid it means that this MultibodyTree was already
   // finalized. Re-compilation is not allowed.

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2632,6 +2632,15 @@ class MultibodyTree {
   [[noreturn]] void ThrowJointSubtypeMismatch(
       const Joint<T>&, std::string_view) const;
 
+  // If X_BF is nullopt, returns the body frame of `body`. Otherwise, adds a
+  // FixedOffsetFrame (named based on the joint_name and frame_suffix) to `body`
+  // and returns it.
+  const Frame<T>& AddOrGetJointFrame(
+      const Body<T>& body,
+      const std::optional<math::RigidTransform<double>>& X_BF,
+      ModelInstanceIndex joint_instance, std::string_view joint_name,
+      std::string_view frame_suffix);
+
   // Finalizes the MultibodyTreeTopology of this tree.
   void FinalizeTopology();
 

--- a/multibody/tree/test/model_instance_test.cc
+++ b/multibody/tree/test/model_instance_test.cc
@@ -26,10 +26,12 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
   const RigidBody<double>& body3 =
       tree.AddRigidBody("Body3", instance1, SpatialInertia<double>());
 
-  tree.AddJoint<WeldJoint>(
+  const auto& weld1 = tree.AddJoint<WeldJoint>(
       "weld1", tree.world_body(), math::RigidTransformd::Identity(),
       body1, math::RigidTransformd::Identity(),
       math::RigidTransformd::Identity());
+  EXPECT_EQ(weld1.frame_on_parent().model_instance(), instance1);
+  EXPECT_EQ(weld1.frame_on_child().model_instance(), instance1);
   // Test minimal `AddJoint` overload.
   const Joint<double>& body1_body2 =
       tree.AddJoint(

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -237,9 +237,17 @@ GTEST_TEST(MultibodyTree, VerifyModelBasics) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       model->AddRigidBody("iiwa_link_5", default_model_instance(),
                           SpatialInertia<double>()),
-      /* Verify this method is throwing for the right reasons. */
       ".* already contains a body named 'iiwa_link_5'. "
       "Body names must be unique within a given model.");
+
+  // Attempt to add a frame having the same name as a frame already part of the
+  // model. This is not allowed and an exception should be thrown.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model->AddFrame<FixedOffsetFrame>("iiwa_link_5",
+                                        model->GetBodyByName("iiwa_link_1"),
+                                        RigidTransform<double>()),
+      ".* already contains a frame named 'iiwa_link_5'. "
+      "Frame names must be unique within a given model.");
 
   // Attempt to add a joint having the same name as a joint already part of the
   // model. This is not allowed and an exception should be thrown.
@@ -249,17 +257,15 @@ GTEST_TEST(MultibodyTree, VerifyModelBasics) {
           model->world_body(), std::nullopt,
           model->GetBodyByName("iiwa_link_5"), std::nullopt,
           Vector3<double>::UnitZ()),
-      /* Verify this method is throwing for the right reasons. */
       ".* already contains a joint named 'iiwa_joint_4'. "
       "Joint names must be unique within a given model.");
 
-  // Attempt to add a joint having the same name as a joint already part of the
-  // model. This is not allowed and an exception should be thrown.
+  // Attempt to add an actuator having the same name as an actuator already part
+  // of the model. This is not allowed and an exception should be thrown.
   DRAKE_EXPECT_THROWS_MESSAGE(
       model->AddJointActuator(
           "iiwa_actuator_4",
           model->GetJointByName("iiwa_joint_4")),
-      /* Verify this method is throwing for the right reasons. */
       ".* already contains a joint actuator named 'iiwa_actuator_4'. "
           "Joint actuator names must be unique within a given model.");
 


### PR DESCRIPTION
Unwind some code duplication between the plant and the tree, so that we only need to fix the logic one place. (Amends #11344 to remove its copy-pasta.)

To avoid name conflicts for a joint's parent body's offset frame, register the offset frame using the child body's model instance instead of the parent's model instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19724)
<!-- Reviewable:end -->
