### PR TITLE
Update ConvexSet logic to properly handle zero-dimensional sets

### DIFF
--- a/geometry/optimization/cartesian_product.cc
+++ b/geometry/optimization/cartesian_product.cc
@@ -41,10 +41,16 @@ int SumAmbientDimensions(const ConvexSets& sets) {
 CartesianProduct::CartesianProduct() : CartesianProduct(ConvexSets{}) {}
 
 CartesianProduct::CartesianProduct(const ConvexSets& sets)
-    : ConvexSet(SumAmbientDimensions(sets)), sets_(sets) {}
+    : ConvexSet(SumAmbientDimensions(sets)), sets_(sets) {
+  for (const auto& s : sets_) {
+    DRAKE_THROW_UNLESS(s->ambient_dimension() > 0);
+  }
+}
 
 CartesianProduct::CartesianProduct(const ConvexSet& setA, const ConvexSet& setB)
     : ConvexSet(setA.ambient_dimension() + setB.ambient_dimension()) {
+  DRAKE_THROW_UNLESS(setA.ambient_dimension() > 0);
+  DRAKE_THROW_UNLESS(setB.ambient_dimension() > 0);
   sets_.emplace_back(setA.Clone());
   sets_.emplace_back(setB.Clone());
 }
@@ -116,7 +122,9 @@ bool CartesianProduct::DoIsBounded() const {
 
 bool CartesianProduct::DoIsEmpty() const {
   if (sets_.size() == 0) {
-    return true;
+    // By convention, the empty cartesian product is considered nonempty.
+    // See https://en.wikipedia.org/wiki/Empty_product#Nullary_Cartesian_product
+    return false;
   }
   for (const auto& s : sets_) {
     if (s->IsEmpty()) {

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -27,13 +27,15 @@ class CartesianProduct final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CartesianProduct)
 
-  /** Constructs a default (zero-dimensional) set. */
+  /** Constructs a default (zero-dimensional, nonempty) set. */
   CartesianProduct();
 
-  /** Constructs the product from a vector of convex sets. */
+  /** Constructs the product from a vector of convex sets. Each set must have
+  ambient_dimension greater than 0 and be nonempty.*/
   explicit CartesianProduct(const ConvexSets& sets);
 
-  /** Constructs the product from a pair of convex sets. */
+  /** Constructs the product from a pair of convex sets. Each set must have
+  ambient_dimension greater than 0 and be nonempty.*/
   CartesianProduct(const ConvexSet& setA, const ConvexSet& setB);
 
   /** Constructs the product of convex sets in the transformed coordinates:

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -21,7 +21,7 @@ ConvexSet::~ConvexSet() = default;
 bool ConvexSet::IntersectsWith(const ConvexSet& other) const {
   DRAKE_THROW_UNLESS(other.ambient_dimension() == this->ambient_dimension());
   if (ambient_dimension() == 0) {
-    return false;
+    return !other.IsEmpty() && !this->IsEmpty();
   }
   solvers::MathematicalProgram prog{};
   const auto& x = prog.NewContinuousVariables(this->ambient_dimension(), "x");
@@ -32,6 +32,9 @@ bool ConvexSet::IntersectsWith(const ConvexSet& other) const {
 }
 
 bool ConvexSet::DoIsEmpty() const {
+  if (ambient_dimension() == 0) {
+    return false;
+  }
   solvers::MathematicalProgram prog;
   auto point = prog.NewContinuousVariables(ambient_dimension());
   AddPointInSetConstraints(&prog, point);

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -354,6 +354,10 @@ bool HPolyhedron::DoIsBounded() const {
 }
 
 bool HPolyhedron::DoIsEmpty() const {
+  if (ambient_dimension() == 0) {
+    // By convention, a zero-dimensional HPolyhedron is considered nonempty.
+    return false;
+  }
   solvers::MathematicalProgram prog;
   solvers::VectorXDecisionVariable x =
       prog.NewContinuousVariables(A_.cols(), "x");

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -23,7 +23,7 @@ class HPolyhedron final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HPolyhedron)
 
-  /** Constructs a default (zero-dimensional) polyhedron. */
+  /** Constructs a default (zero-dimensional, nonempty) polyhedron. */
   HPolyhedron();
 
   /** Constructs the polyhedron.

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -29,7 +29,7 @@ class Hyperellipsoid final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Hyperellipsoid)
 
-  /** Constructs a default (zero-dimensional) set. */
+  /** Constructs a default (zero-dimensional, nonempty) set. */
   Hyperellipsoid();
 
   /** Constructs the ellipsoid.

--- a/geometry/optimization/intersection.h
+++ b/geometry/optimization/intersection.h
@@ -20,13 +20,15 @@ class Intersection final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Intersection)
 
-  /** Constructs a default (zero-dimensional) set. */
+  /** Constructs a default (zero-dimensional, nonempty) set. */
   Intersection();
 
-  /** Constructs the intersection from a vector of convex sets. */
+  /** Constructs the intersection from a vector of convex sets. Each set must
+  have ambient_dimension greater than 0 and be nonempty. */
   explicit Intersection(const ConvexSets& sets);
 
-  /** Constructs the intersection from a pair of convex sets. */
+  /** Constructs the intersection from a pair of convex sets. Each set must have
+  ambient_dimension greater than 0 and be nonempty. */
   Intersection(const ConvexSet& setA, const ConvexSet& setB);
 
   ~Intersection() final;
@@ -42,6 +44,8 @@ class Intersection final : public ConvexSet {
   std::unique_ptr<ConvexSet> DoClone() const final;
 
   bool DoIsBounded() const final;
+
+  bool DoIsEmpty() const final;
 
   std::optional<Eigen::VectorXd> DoMaybeGetPoint() const final;
 

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -45,11 +45,16 @@ int GetAmbientDimension(const ConvexSets& sets) {
 MinkowskiSum::MinkowskiSum() : MinkowskiSum(ConvexSets{}) {}
 
 MinkowskiSum::MinkowskiSum(const ConvexSets& sets)
-    : ConvexSet(GetAmbientDimension(sets)), sets_(sets) {}
+    : ConvexSet(GetAmbientDimension(sets)), sets_(sets) {
+  for (const auto& s : sets_) {
+    DRAKE_THROW_UNLESS(s->ambient_dimension() > 0);
+  }
+}
 
 MinkowskiSum::MinkowskiSum(const ConvexSet& setA, const ConvexSet& setB)
     : ConvexSet(setA.ambient_dimension()) {
   DRAKE_THROW_UNLESS(setB.ambient_dimension() == setA.ambient_dimension());
+  DRAKE_THROW_UNLESS(setB.ambient_dimension() > 0);
   sets_.emplace_back(setA.Clone());
   sets_.emplace_back(setB.Clone());
 }
@@ -105,7 +110,9 @@ bool MinkowskiSum::DoIsBounded() const {
 
 bool MinkowskiSum::DoIsEmpty() const {
   if (sets_.size() == 0) {
-    return true;
+    // When we have sets_.size() == 0, we treat the Minkowski sum as being
+    // {0}, the unique zero-dimensional vector space, which is nonempty.
+    return false;
   }
   // The empty set is annihilatory in Minkowski addition.
   for (const auto& s : sets_) {

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -21,13 +21,15 @@ class MinkowskiSum final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MinkowskiSum)
 
-  /** Constructs a default (zero-dimensional) set. */
+  /** Constructs a default (zero-dimensional, nonempty) set. */
   MinkowskiSum();
 
-  /** Constructs the sum from a vector of convex sets. */
+  /** Constructs the sum from a vector of convex sets. Each set must have
+  ambient_dimension greater than 0 and be nonempty.*/
   explicit MinkowskiSum(const ConvexSets& sets);
 
-  /** Constructs the sum from a pair of convex sets. */
+  /** Constructs the sum from a pair of convex sets. Each set must have
+  ambient_dimension greater than 0 and be nonempty. */
   MinkowskiSum(const ConvexSet& setA, const ConvexSet& setB);
 
   /** Constructs a MinkowskiSum from a SceneGraph geometry and pose in the

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -19,7 +19,7 @@ class Point final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Point)
 
-  /** Constructs a default (zero-dimensional) set. */
+  /** Constructs a default (zero-dimensional, nonempty) set. */
   Point();
 
   /** Constructs a Point. */

--- a/geometry/optimization/spectrahedron.h
+++ b/geometry/optimization/spectrahedron.h
@@ -21,7 +21,7 @@ class Spectrahedron final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Spectrahedron)
 
-  /** Default constructor (which constructs the empty set). */
+  /** Default constructor (yields the zero-dimensional nonempty set). */
   Spectrahedron();
 
   /** Constructs the spectrahedron from a MathematicalProgram.

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -45,10 +45,10 @@ GTEST_TEST(HPolyhedronTest, DefaultConstructor) {
   EXPECT_EQ(H.A().size(), 0);
   EXPECT_EQ(H.b().size(), 0);
   EXPECT_NO_THROW(H.Clone());
-  EXPECT_FALSE(H.IntersectsWith(H));
+  EXPECT_TRUE(H.IntersectsWith(H));
   EXPECT_TRUE(H.IsBounded());
-  EXPECT_THROW(H.IsEmpty(), std::exception);
-  EXPECT_FALSE(H.PointInSet(Eigen::VectorXd::Zero(0)));
+  EXPECT_FALSE(H.IsEmpty());
+  EXPECT_TRUE(H.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 
 GTEST_TEST(HPolyhedronTest, UnitBoxTest) {

--- a/geometry/optimization/test/hyperellipsoid_test.cc
+++ b/geometry/optimization/test/hyperellipsoid_test.cc
@@ -102,10 +102,10 @@ GTEST_TEST(HyperellipsoidTest, DefaultCtor) {
   EXPECT_THROW(dut.MinimumUniformScalingToTouch(dut), std::exception);
   EXPECT_NO_THROW(dut.Clone());
   EXPECT_EQ(dut.ambient_dimension(), 0);
-  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
-  EXPECT_THROW(dut.IsEmpty(), std::exception);
-  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+  EXPECT_FALSE(dut.IsEmpty());
+  EXPECT_TRUE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 
 GTEST_TEST(HyperellipsoidTest, Move) {

--- a/geometry/optimization/test/intersection_test.cc
+++ b/geometry/optimization/test/intersection_test.cc
@@ -88,11 +88,11 @@ GTEST_TEST(IntersectionTest, DefaultCtor) {
   EXPECT_EQ(dut.num_elements(), 0);
   EXPECT_NO_THROW(dut.Clone());
   EXPECT_EQ(dut.ambient_dimension(), 0);
-  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
-  EXPECT_THROW(dut.IsEmpty(), std::exception);
-  EXPECT_FALSE(dut.MaybeGetPoint().has_value());
-  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+  EXPECT_FALSE(dut.IsEmpty());
+  EXPECT_TRUE(dut.MaybeGetPoint().has_value());
+  EXPECT_TRUE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 
 GTEST_TEST(IntersectionTest, Move) {
@@ -260,6 +260,27 @@ GTEST_TEST(IntersectionTest, EmptyIntersectionTest2) {
   const Point P2(Vector2d{0.1, 4.3});
   Intersection S(P1, P2);
 
+  EXPECT_TRUE(S.IsEmpty());
+}
+
+GTEST_TEST(IntersectionTest, ZeroDimensionalInput) {
+  // If any of the inputs are zero dimensional, it should throw an error.
+  const Point P1(Vector2d{1.2, 3.4});
+  const Point P2(Eigen::VectorXd::Zero(0));
+  EXPECT_THROW(Intersection(P1, P2), std::exception);
+
+  ConvexSets sets;
+  sets.emplace_back(P1);
+  sets.emplace_back(P2);
+  EXPECT_THROW((Intersection(sets)), std::exception);
+}
+
+GTEST_TEST(IntersectionTest, EmptyInput) {
+  const Point P(Vector2d{1.2, 3.4});
+  // A VPolytope constructed from an empty list of vertices is empty.
+  Eigen::Matrix<double, 2, 0> vertices;
+  const VPolytope V = VPolytope(vertices);
+  Intersection S(P, V);
   EXPECT_TRUE(S.IsEmpty());
 }
 

--- a/geometry/optimization/test/minkowski_sum_test.cc
+++ b/geometry/optimization/test/minkowski_sum_test.cc
@@ -79,11 +79,11 @@ GTEST_TEST(MinkowskiSumTest, DefaultCtor) {
   EXPECT_EQ(dut.num_terms(), 0);
   EXPECT_NO_THROW(dut.Clone());
   EXPECT_EQ(dut.ambient_dimension(), 0);
-  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
-  EXPECT_THROW(dut.IsEmpty(), std::exception);
-  EXPECT_FALSE(dut.MaybeGetPoint().has_value());
-  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+  EXPECT_FALSE(dut.IsEmpty());
+  EXPECT_TRUE(dut.MaybeGetPoint().has_value());
+  EXPECT_TRUE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 
 GTEST_TEST(MinkowskiSumTest, Move) {
@@ -271,23 +271,24 @@ GTEST_TEST(MinkowskiSumTest, NonnegativeScalingTest2) {
       PointInScaledSet(x, t, x_solution, Eigen::Vector2d(-1, 0), &prog));
 }
 
-GTEST_TEST(MinkowskiSumTest, EmptyMinkowskiSumTest) {
-  Eigen::MatrixXd A{5, 3};
-  Eigen::VectorXd b{5};
-  // Rows 1-3 define an infeasible set of inequalities.
-  // clang-format off
-  A << 1, 0, 0,
-       1, -1, 0,
-       -1, 0, 1,
-       0, 1, -1,
-       0, 0, -1;
-  b << 1, -1, -1, -1, 0;
-  // clang-format off
+GTEST_TEST(MinkowskiSumTest, ZeroDimensionalInput) {
+  // If any of the inputs are zero dimensional, it should throw an error.
+  const Point P1(Vector2d{1.2, 3.4});
+  const Point P2(Eigen::VectorXd::Zero(0));
+  EXPECT_THROW(MinkowskiSum(P1, P2), std::exception);
 
-  const HPolyhedron H1{A, b};
-  const Point P1(Vector3d{0.1, 1.2, 0.3});
-  const MinkowskiSum S(P1, H1);
+  ConvexSets sets;
+  sets.emplace_back(P1);
+  sets.emplace_back(P2);
+  EXPECT_THROW((MinkowskiSum(sets)), std::exception);
+}
 
+GTEST_TEST(MinkowskiSumTest, EmptyInput) {
+  const Point P(Vector2d{1.2, 3.4});
+  // A VPolytope constructed from an empty list of vertices is empty.
+  Eigen::Matrix<double, 2, 0> vertices;
+  const VPolytope V = VPolytope(vertices);
+  MinkowskiSum S(P, V);
   EXPECT_TRUE(S.IsEmpty());
 }
 

--- a/geometry/optimization/test/point_test.cc
+++ b/geometry/optimization/test/point_test.cc
@@ -71,11 +71,11 @@ GTEST_TEST(PointTest, DefaultCtor) {
   EXPECT_EQ(dut.x().size(), 0);
   EXPECT_NO_THROW(dut.Clone());
   EXPECT_EQ(dut.ambient_dimension(), 0);
-  EXPECT_FALSE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
-  EXPECT_THROW(dut.IsEmpty(), std::exception);
-  EXPECT_FALSE(dut.MaybeGetPoint().has_value());
-  EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+  EXPECT_TRUE(dut.MaybeGetPoint().has_value());
+  EXPECT_TRUE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+  EXPECT_FALSE(dut.IsEmpty());
 
   Point P;
   EXPECT_NO_THROW(P.set_x(Eigen::VectorXd::Zero(0)));

--- a/geometry/optimization/test/spectrahedron_test.cc
+++ b/geometry/optimization/test/spectrahedron_test.cc
@@ -23,7 +23,7 @@ using solvers::Solve;
 GTEST_TEST(SpectrahedronTest, DefaultCtor) {
   Spectrahedron spect;
   EXPECT_EQ(spect.ambient_dimension(), 0);
-  EXPECT_THROW(spect.IsEmpty(), std::exception);
+  EXPECT_FALSE(spect.IsEmpty());
 }
 
 GTEST_TEST(SpectrahedronTest, Attributes) {

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -84,11 +84,13 @@ GTEST_TEST(VPolytopeTest, DefaultCtor) {
   EXPECT_EQ(dut.CalcVolume(), 0.0);
   EXPECT_NO_THROW(dut.Clone());
   EXPECT_EQ(dut.ambient_dimension(), 0);
-  EXPECT_FALSE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
-  EXPECT_THROW(dut.IsEmpty(), std::exception);
+  EXPECT_TRUE(dut.IsEmpty());
   EXPECT_FALSE(dut.MaybeGetPoint().has_value());
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+
+  // The intersection of {} and {} is {}, so this should be false
+  EXPECT_FALSE(dut.IntersectsWith(dut));
 }
 
 GTEST_TEST(VPolytopeTest, Move) {
@@ -648,8 +650,11 @@ GTEST_TEST(VPolytopeTest, WriteObjTest) {
 GTEST_TEST(VPolytopeTest, EmptyTest) {
   Eigen::Matrix<double, 3, 0> vertices;
   auto V = VPolytope(vertices);
-  EXPECT_EQ(V.ambient_dimension(), 3);
   ASSERT_TRUE(V.IsEmpty());
+  ASSERT_EQ(V.ambient_dimension(), 3);
+  ASSERT_FALSE(V.IntersectsWith(V));
+  EXPECT_FALSE(V.MaybeGetPoint().has_value());
+  EXPECT_FALSE(V.PointInSet(Eigen::VectorXd::Zero(3)));
 }
 
 }  // namespace optimization

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -345,6 +345,11 @@ std::optional<VectorXd> VPolytope::DoMaybeGetPoint() const {
 
 bool VPolytope::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
                              double tol) const {
+  if (vertices_.size() == 0) {
+    return false;
+  } else if (ambient_dimension() == 0) {
+    return true;
+  }
   const int n = ambient_dimension();
   const int m = vertices_.cols();
   const double inf = std::numeric_limits<double>::infinity();

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -26,7 +26,7 @@ class VPolytope final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VPolytope)
 
-  /** Constructs a default (zero-dimensional) set. */
+  /** Constructs a default (zero-dimensional, empty) set. */
   VPolytope();
 
   /** Constructs the polytope from a d-by-n matrix, where d is the ambient


### PR DESCRIPTION
Fixes #19723, towards the long term goal of #19717.

Aside from documenting and clarifying the behavior of the IsEmpty method when the set has an ambient dimension of zero (previously, it would throw an error), this also adds an error if you try to construct a CartesianProduct, Intersection, or MinkowskiSum with a set whose ambient dimension is zero. Not sure if that qualifies as a breaking change -- you technically could do so before, but I imagine it would have led to errors of some sort.

+@hongkai-dai for feature review