### PR TITLE
Adds HPolyhedron::Scale()

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -139,6 +139,8 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.MaximumVolumeInscribedEllipsoid.doc)
         .def("ChebyshevCenter", &HPolyhedron::ChebyshevCenter,
             cls_doc.ChebyshevCenter.doc)
+        .def("Scale", &HPolyhedron::Scale, py::arg("scale"),
+            py::arg("center") = std::nullopt, cls_doc.Scale.doc)
         .def("CartesianProduct", &HPolyhedron::CartesianProduct,
             py::arg("other"), cls_doc.CartesianProduct.doc)
         .def("CartesianPower", &HPolyhedron::CartesianPower, py::arg("n"),

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -102,6 +102,10 @@ class TestGeometryOptimization(unittest.TestCase):
             mut.Hyperellipsoid)
         np.testing.assert_array_almost_equal(
             h_box.ChebyshevCenter(), [0, 0, 0])
+        h_scaled = h_box.Scale(scale=2.0, center=[1, 2, 3])
+        self.assertIsInstance(h_scaled, mut.HPolyhedron)
+        h_scaled = h_box.Scale(scale=2.0)
+        self.assertIsInstance(h_scaled, mut.HPolyhedron)
         h2 = h_box.CartesianProduct(other=h_unit_box)
         self.assertIsInstance(h2, mut.HPolyhedron)
         self.assertEqual(h2.ambient_dimension(), 6)

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -232,6 +232,19 @@ VectorXd HPolyhedron::ChebyshevCenter() const {
   return result.GetSolution(x);
 }
 
+HPolyhedron HPolyhedron::Scale(double scale,
+                               std::optional<Eigen::VectorXd> center) const {
+  DRAKE_THROW_UNLESS(scale >= 0.0);
+  if (center) {
+    DRAKE_THROW_UNLESS(center->size() == ambient_dimension());
+  } else {
+    center = ChebyshevCenter();
+  }
+  return HPolyhedron(
+      A_, std::pow(scale, 1.0 / ambient_dimension()) * (b_ - A_ * *center) +
+              A_ * *center);
+}
+
 HPolyhedron HPolyhedron::CartesianProduct(const HPolyhedron& other) const {
   MatrixXd A_product = MatrixXd::Zero(A_.rows() + other.A().rows(),
                                       A_.cols() + other.A().cols());

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -119,7 +119,7 @@ class HPolyhedron final : public ConvexSet {
   @pre the HPolyhedron is bounded.
   @throws std::exception if the solver fails to solve the problem.
   */
-  Hyperellipsoid MaximumVolumeInscribedEllipsoid() const;
+  [[nodiscard]] Hyperellipsoid MaximumVolumeInscribedEllipsoid() const;
 
   /** Solves a linear program to compute the center of the largest inscribed
   ball in the polyhedron.  This is often the recommended way to find some
@@ -142,21 +142,41 @@ class HPolyhedron final : public ConvexSet {
   MaximumVolumeInscribedEllipsoid() method, and then taking the center of the
   returned Hyperellipsoid.
   @throws std::exception if the solver fails to solve the problem. */
-  Eigen::VectorXd ChebyshevCenter() const;
+  [[nodiscard]] Eigen::VectorXd ChebyshevCenter() const;
+
+  /** Results a new HPolyhedron that is a scaled version of `this`, by scaling
+  the distance from each face to the `center` by a factor of
+  `pow(scale, 1/ambient_dimension())`, to have units of volume:
+    - `scale = 0` will result in a point,
+    - `0 < scale < 1` shrinks the region,
+    - `scale = 1` returns a copy of the `this`, and
+    - `1 < scale` grows the region.
+
+  If `center` is not provided, then the value returned by ChebyshevCenter()
+  will be used.
+
+  `this` does not need to be bounded, nor have volume. `center` does not need
+  to be in the set.
+  @pre `scale` >= 0.
+  @pre `center` has size equal to the ambient dimension.
+  */
+  [[nodiscard]] HPolyhedron Scale(
+      double scale, std::optional<Eigen::VectorXd> center = std::nullopt) const;
 
   /** Returns the Cartesian product of `this` and `other`. */
-  HPolyhedron CartesianProduct(const HPolyhedron& other) const;
+  [[nodiscard]] HPolyhedron CartesianProduct(const HPolyhedron& other) const;
 
   /** Returns the `n`-ary Cartesian power of `this`. The n-ary Cartesian power
   of a set H is the set H ⨉ H ⨉ ... ⨉ H, where H is repeated n times. */
-  HPolyhedron CartesianPower(int n) const;
+  [[nodiscard]] HPolyhedron CartesianPower(int n) const;
 
   /** Returns the Pontryagin (Minkowski) Difference of `this` and `other`.
   This is the set A ⊖ B = { a|a+ B ⊆ A }. The result is an HPolyhedron with the
   same number of inequalities as A. Requires that `this` and `other` both
   be bounded and have the same ambient dimension. This method may throw a
   runtime error if `this` or `other` are ill-conditioned. */
-  HPolyhedron PontryaginDifference(const HPolyhedron& other) const;
+  [[nodiscard]] HPolyhedron PontryaginDifference(
+      const HPolyhedron& other) const;
 
   /** Draw an (approximately) uniform sample from the set using the hit and run
   Markov-chain Monte-Carlo strategy described at

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -325,6 +325,97 @@ GTEST_TEST(HPolyhedronTest, ChebyshevCenter2) {
   EXPECT_GE(distance[3], 1.0 - 1e-6);
 }
 
+GTEST_TEST(HpolyhedronTest, Scale) {
+  const double kTol = 1e-12;
+  const HPolyhedron H = HPolyhedron::MakeUnitBox(3);
+  const double kScale = 2.0;
+
+  // The original volume is 2x2x2 = 8.
+  // The new volume should be 16.
+  HPolyhedron H_scaled = H.Scale(kScale);
+  VPolytope V(H_scaled);
+  EXPECT_NEAR(V.CalcVolume(), 16.0, kTol);
+  // The vertices should be pow(16,1/3)/2.
+  const double kVertexValue = std::pow(16.0, 1.0 / 3.0) / 2.0;
+  for (int i = 0; i < V.vertices().rows(); ++i) {
+    for (int j = 0; j < V.vertices().cols(); ++j) {
+      EXPECT_NEAR(std::abs(V.vertices()(i, j)), kVertexValue, kTol);
+    }
+  }
+
+  // Again with the center specified explicitly.
+  H_scaled = H.Scale(kScale, Vector3d::Zero());
+  V = VPolytope(H_scaled);
+  EXPECT_NEAR(V.CalcVolume(), 16.0, kTol);
+
+  // Again with the center in the bottom corner.
+  H_scaled = H.Scale(1.0 / 8.0, Vector3d::Constant(-1.0));
+  V = VPolytope(H_scaled);
+  EXPECT_NEAR(V.CalcVolume(), 1.0, kTol);
+  EXPECT_TRUE(H_scaled.PointInSet(Vector3d::Constant(-0.01)));
+  EXPECT_FALSE(H_scaled.PointInSet(Vector3d::Constant(0.01)));
+  EXPECT_TRUE(H_scaled.PointInSet(Vector3d::Constant(-0.99)));
+  EXPECT_FALSE(H_scaled.PointInSet(Vector3d::Constant(-1.01)));
+
+  // Shrink to a point.
+  const Vector3d kPoint = Vector3d::Constant(-1.0);
+  H_scaled = H.Scale(0, kPoint);
+  // A*point == b.
+  EXPECT_TRUE(CompareMatrices(H_scaled.A() * kPoint, H_scaled.b(), kTol));
+}
+
+// Scale supports unbounded sets.
+GTEST_TEST(HPolyhedronTest, Scale2) {
+  const double kTol = 1e-14;
+  // The ice cream cone in 2d. y>=x, y>=-x.
+  Eigen::Matrix2d A;
+  A << 1, -1, 1, 1;
+  HPolyhedron H(A, Vector2d::Zero());
+
+  const double kScale = 0.25;
+  // Scaling about the origin should have no effect.
+  HPolyhedron H_scaled = H.Scale(kScale, Vector2d::Zero());
+  EXPECT_TRUE(CompareMatrices(H.A(), H_scaled.A(), kTol));
+  EXPECT_TRUE(CompareMatrices(H.b(), H_scaled.b(), kTol));
+
+  // Scaling about the point (0,1) will move the cone up, to
+  // y >= x + 0.5, y >= -x - 0.5.
+  H_scaled = H.Scale(kScale, Vector2d{0, 1});
+  EXPECT_TRUE(CompareMatrices(H_scaled.A(), H.A(), kTol));
+  EXPECT_TRUE(CompareMatrices(H_scaled.b(), Vector2d{-0.5, 0.5}, kTol));
+}
+
+// The original set has no volume.
+GTEST_TEST(HPolyhedronTest, Scale3) {
+  // Make a square in the xz plane, with y=0.
+  Eigen::MatrixXd A(6, 3);
+  // clang-format off
+  A <<  1,  0,  0,  // x <= 1
+       -1,  0,  0,  // x >= -1
+        0,  1,  0,  // y <= 0
+        0, -1,  0,  // y >= 0
+        0,  0,  1,  // z <= 1
+        0,  0, -1;  // z >= -1
+  // clang-format on
+  VectorXd b(6);
+  b << 1, 1, 0, 0, 1, 1;
+  HPolyhedron H(A, b);
+
+  const double kScale = 2.0;
+  const double kOffset = 1e-6;
+  HPolyhedron H_scaled = H.Scale(kScale, Vector3d::Zero());
+  const double kVertexValue = std::pow(16.0, 1.0 / 3.0) / 2.0;
+  EXPECT_TRUE(H_scaled.PointInSet(
+      Vector3d{kVertexValue - kOffset, 0, kVertexValue - kOffset}));
+  EXPECT_FALSE(H_scaled.PointInSet(
+      Vector3d{kVertexValue + kOffset, 0, kVertexValue + kOffset}));
+
+  // center does not need to be in the set.
+  H_scaled = H.Scale(kScale, Vector3d{2, 0, 0});
+  EXPECT_FALSE(H_scaled.PointInSet(Vector3d{1, 0, 0}));
+  EXPECT_TRUE(H_scaled.PointInSet(Vector3d{-1, 0, 0}));
+}
+
 GTEST_TEST(HPolyhedronTest, CloneTest) {
   HPolyhedron H = HPolyhedron::MakeBox(Vector3d{-3, -4, -5}, Vector3d{6, 7, 8});
   std::unique_ptr<ConvexSet> clone = H.Clone();


### PR DESCRIPTION
This method returns a scaled version of the HPolyhedron (about some center point). It is useful in our IRIS workflows.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19733)
<!-- Reviewable:end -->
