### PR TITLE
CollisionChecker validates distance/interpolation funcs with default config

### DIFF
--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -517,7 +517,7 @@ void CollisionChecker::SetConfigurationDistanceFunction(
     const ConfigurationDistanceFunction& distance_function) {
   DRAKE_THROW_UNLESS(distance_function != nullptr);
   const double test_distance =
-      distance_function(GetZeroConfiguration(), GetZeroConfiguration());
+      distance_function(GetDefaultConfiguration(), GetDefaultConfiguration());
   DRAKE_THROW_UNLESS(test_distance == 0.0);
   configuration_distance_function_ = distance_function;
 }
@@ -538,12 +538,12 @@ void CollisionChecker::SetConfigurationInterpolationFunction(
     return;
   }
   const Eigen::VectorXd test_interpolated_q = interpolation_function(
-      GetZeroConfiguration(), GetZeroConfiguration(), 0.0);
+      GetDefaultConfiguration(), GetDefaultConfiguration(), 0.0);
   DRAKE_THROW_UNLESS(test_interpolated_q.size() ==
-                     GetZeroConfiguration().size());
+                     GetDefaultConfiguration().size());
   for (int index = 0; index < test_interpolated_q.size(); ++index) {
     DRAKE_THROW_UNLESS(test_interpolated_q(index) ==
-                       GetZeroConfiguration()(index));
+                       GetDefaultConfiguration()(index));
   }
   configuration_interpolation_function_ = interpolation_function;
 }
@@ -803,6 +803,11 @@ CollisionChecker::CollisionChecker(CollisionCheckerParams params,
       supports_parallel_checking_(supports_parallel_checking) {
   // Initialize the zero configuration.
   zero_configuration_ = Eigen::VectorXd::Zero(plant().num_positions());
+  // Initialize the default configuration.
+  auto plant_context = plant().CreateDefaultContext();
+  default_configuration_ =
+      plant().GetPositions(*plant().CreateDefaultContext());
+
   // Initialize the collision padding matrix.
   collision_padding_ =
       Eigen::MatrixXd::Zero(plant().num_bodies(), plant().num_bodies());

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -804,7 +804,6 @@ CollisionChecker::CollisionChecker(CollisionCheckerParams params,
   // Initialize the zero configuration.
   zero_configuration_ = Eigen::VectorXd::Zero(plant().num_positions());
   // Initialize the default configuration.
-  auto plant_context = plant().CreateDefaultContext();
   default_configuration_ =
       plant().GetPositions(*plant().CreateDefaultContext());
 

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -1216,6 +1216,12 @@ class CollisionChecker {
   std::string CriticizePaddingMatrix(const Eigen::MatrixXd& padding,
                                      const char* func) const;
 
+  /* @returns a generalized position vector, sized according to the full model,
+   whose values come from the plant's default context. */
+  const Eigen::VectorXd& GetDefaultConfiguration() const {
+    return default_configuration_;
+  }
+
   /* This class allocates and maintains the contexts associated with OpenMP
    threads. When the CollisionChecker is evaluated in its implicit mode, the
    contexts used are drawn from this collection and each context is associated
@@ -1394,6 +1400,10 @@ class CollisionChecker {
 
   /* We maintain a "zero configuration" of the model. */
   Eigen::VectorXd zero_configuration_;
+
+  /* We maintain a "default configuration" of the model (based on the plant's
+   default allocated context). */
+  Eigen::VectorXd default_configuration_;
 
   /* Determines whether the checker reports support for parallel evaluation.
    This is defined upon construction by implementations. */

--- a/planning/collision_checker_params.h
+++ b/planning/collision_checker_params.h
@@ -19,7 +19,8 @@ as a double. The returned distance will be strictly non-negative.
 To be valid, the function must satisfy the following condition:
 
  - dist(q, q) ≡ 0
-*/
+
+for values of q that are valid for the CollisionChecker's plant. */
 using ConfigurationDistanceFunction =
     std::function<double(const Eigen::VectorXd&, const Eigen::VectorXd&)>;
 
@@ -34,7 +35,8 @@ To be valid, the function must satisfy the following conditions:
  - interpolate(q1, q2, 0) ≡ q1
  - interpolate(q1, q2, 1) ≡ q2
  - interpolate(q, q, r) ≡ q, for all r in [0, 1]
-*/
+
+for values of q, q1, and q2 that are valid for the CollisionChecker's plant. */
 using ConfigurationInterpolationFunction = std::function<Eigen::VectorXd(
     const Eigen::VectorXd&, const Eigen::VectorXd&, double)>;
 


### PR DESCRIPTION
Previously, when setting a distance (or interpolation) function, `CollisionChecker` would validate it by testing the distance between the zero configuration and itself (or by interpolating between the zero configuration and itself). It is perfectly reasonable that a distance or interpolation function (e.g., one with quaternions) would reject such an invalid configuration as being incalculable. By using the default configuration, we assume we're starting with a valid configuration and the distance/interpolation functions can use their most natural semantics.

The valid test now validates using the plant's default configuration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19736)
<!-- Reviewable:end -->
