### PR TITLE
[tools] Fix a typo in googlebench command line

### DIFF
--- a/tools/performance/defs.bzl
+++ b/tools/performance/defs.bzl
@@ -53,7 +53,7 @@ def drake_cc_googlebench_binary(
                 # When running as a unit test, run each function only once to
                 # save time. (Once should be sufficient to prove the lack of
                 # runtime errors.)
-                "--benchmark_min_time=0",
+                "--benchmark_min_time=0s",
             ] + (test_args or []),
             tags = test_tags,
         )


### PR DESCRIPTION
Otherwise, all benchmark programs warn about units every time we test them.

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19744)
<!-- Reviewable:end -->
