### PR TITLE
Follow-up fix for IrisInConfigurationSpace mac test

### DIFF
--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -669,7 +669,7 @@ GTEST_TEST(IrisInConfigurationSpaceTest, ConvexConfigurationSpace) {
   // With num_collision_infeasible_samples == 1, we found that SNOPT misses this
   // point (on some platforms with some random seeds).
 
-  options.num_collision_infeasible_samples = 5;
+  options.num_collision_infeasible_samples = 15;
   HPolyhedron region = IrisFromUrdf(convex_urdf, sample, options);
   EXPECT_FALSE(region.PointInSet(Vector2d{z_test, theta_test}));
 


### PR DESCRIPTION
After #19728, mac w/ SNOPT was failing with the default random seed. This PR increases the number of samples to verify the region.

Closes #19749.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19751)
<!-- Reviewable:end -->
