### PR TITLE
[framework] Make GetDowncastSubsystemByName() work with non-templatized System

### DIFF
--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -163,8 +163,23 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   /// @see System<T>::get_name()
   template <template <typename> class MySystem>
   const MySystem<T>& GetDowncastSubsystemByName(std::string_view name) const {
+    return GetDowncastSubsystemByName<MySystem<T>>(name);
+  }
+
+  /// Alternate signature for a subsystem that has the Diagram's scalar type T
+  /// but is not explicitly templatized on T. This can happen if the
+  /// subsystem class declaration inherits, for example, from a `LeafSystem<T>`.
+  /// @pre The Scalar type of MyUntemplatizedSystem matches the %Diagram
+  ///      Scalar type T (will fail to compile if not).
+  template <class MyUntemplatizedSystem>
+  const MyUntemplatizedSystem& GetDowncastSubsystemByName(std::string_view name)
+      const {
+    static_assert(std::is_same_v<
+        typename MyUntemplatizedSystem::Scalar, T>,
+        "Scalar type of untemplatized System doesn't match the Diagram's.");
     const System<T>& subsystem = this->GetSubsystemByName(name);
-    return *dynamic_pointer_cast_or_throw<const MySystem<T>>(&subsystem);
+    return *dynamic_pointer_cast_or_throw<const MyUntemplatizedSystem>
+        (&subsystem);
   }
 
   /// Retrieves the state derivatives for a particular subsystem from the

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -46,6 +46,9 @@ class System : public SystemBase {
   // System objects are neither copyable nor moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(System)
 
+  /// The scalar type with which this %System was instantiated.
+  using Scalar = T;
+
   ~System() override;
 
   /// Implements a visitor pattern.  @see SystemVisitor<T>.

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -999,6 +999,17 @@ TEST_F(DiagramTest, GetDowncastSubsystemByName) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       diagram_->GetDowncastSubsystemByName<StatelessSystem>("not_a_subsystem"),
       "System .* does not have a subsystem named not_a_subsystem");
+
+  // Now downcast a non-templatized system (invokes a different overload).
+  // This will only compile if the subsystem's scalar type matches the
+  // Diagram's scalar type.
+  const StatelessSystem<double>& also_stateless =
+      diagram_->GetDowncastSubsystemByName<StatelessSystem<double>>
+          ("stateless");
+  EXPECT_EQ(also_stateless.get_name(), "stateless");
+
+  // Both overloads use the same implementation and depend on
+  // GetSubsystemByName() for the error checking tested above.
 }
 
 // Tests that ContextBase methods for affecting cache behavior propagate


### PR DESCRIPTION
Diagram::GetDowncastSubsystemByName() required a template template type for the subsystem so wouldn't work with a subsystem that had been instantiated with a particular scalar type, even if that scalar type is the correct one for the Diagram.

This adds a template overload to permit either specification for the subsystem type.

Resolves #19752

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19755)
<!-- Reviewable:end -->
