### PR TITLE
Compute MD ordering with priority nodes

### DIFF
--- a/multibody/contact_solvers/minimum_degree_ordering.h
+++ b/multibody/contact_solvers/minimum_degree_ordering.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <unordered_set>
 #include <vector>
 
 #include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
@@ -71,20 +72,20 @@ struct Node {
 };
 
 /* A simplified version of Node used in a minimum priority queue of that only
- contains index of the node and the degree. */
-struct IndexDegree {
+ contains the node's index, degree, and priority (see the 2-arg
+ ComputeMinimumDegreeOrdering). */
+struct SimplifiedNode {
   int degree{};
   int index{};
+  int priority{};  // smaller number means higher priority
 };
 
-inline bool operator<(const IndexDegree& a, const IndexDegree& b) {
-  if (a.degree != b.degree) {
-    return a.degree < b.degree;
-  } else {
-    /* Sort by node index when degrees are equal so that consecutive nodes with
-     the same degree are not permuted. */
-    return a.index < b.index;
-  }
+inline bool operator<(const SimplifiedNode& a, const SimplifiedNode& b) {
+  /* Sort by priority first, then by degree, then by index. When all else are
+   equal we sort by index so that consecutive nodes with the same degree are not
+   permuted. */
+  return std::make_tuple(a.priority, a.degree, a.index) <
+         std::make_tuple(b.priority, b.degree, b.index);
 }
 
 /* Computes the preferred elimination ordering of the matrix with the given
@@ -94,6 +95,17 @@ inline bool operator<(const IndexDegree& a, const IndexDegree& b) {
  to original block indices. */
 std::vector<int> ComputeMinimumDegreeOrdering(
     const BlockSparsityPattern& block_sparsity_pattern);
+
+/* Similar to the one argument overload but eliminates elements in
+`priority_elements` first.
+ Suppose the sparsity pattern has n nodes (which we denote as V) and m of those
+ are in `priority_elements` (which we denote as P). Let D(v) be the degree of
+ the node v. For k ∈ [0, m), the k-th eliminated node is argmin(D(v)) s.t.
+ v ∈ P. For k ∈ [m, n), the k-th eliminated node is argmin(D(v)) s.t. v ∈ V\P.
+ @pre all entries in `priority_elements` are in {0, 1, ..., n-1}. */
+std::vector<int> ComputeMinimumDegreeOrdering(
+    const BlockSparsityPattern& block_sparsity_pattern,
+    const std::unordered_set<int>& priority_elements);
 
 /* Given the block sparsity pattern of a symmetric block sparse matrix, computes
  the block sparsity pattern of the lower triangular matrix resulting from a

--- a/multibody/contact_solvers/test/minimum_degree_ordering_test.cc
+++ b/multibody/contact_solvers/test/minimum_degree_ordering_test.cc
@@ -104,13 +104,20 @@ GTEST_TEST(MinimumDegreeOrderingTest, UpdateExternalDegree) {
   EXPECT_EQ(n10.degree, 240);
 }
 
-GTEST_TEST(MinimumDegreeOrderingTest, IndexDegreeComparator) {
-  IndexDegree a = {.degree = 0, .index = 0};
-  IndexDegree b = {.degree = 0, .index = 1};
-  IndexDegree c = {.degree = 1, .index = 2};
+GTEST_TEST(MinimumDegreeOrderingTest, SimplifiedNodeComparator) {
+  const SimplifiedNode a = {.degree = 0, .index = 0, .priority = 1};
+  const SimplifiedNode b = {.degree = 0, .index = 1, .priority = 1};
+  const SimplifiedNode c = {.degree = 1, .index = 2, .priority = 1};
   EXPECT_LT(a, b);
   EXPECT_LT(a, c);
   EXPECT_LT(b, c);
+
+  /* Priority trumps everything else. */
+  const SimplifiedNode priority_c = {.degree = 1, .index = 2, .priority = 0};
+
+  EXPECT_LT(priority_c, a);
+  EXPECT_LT(priority_c, b);
+  EXPECT_LT(priority_c, c);
 }
 
 GTEST_TEST(MinimumDegreeOrderingTest, ComputeMinimumDegreeOrdering) {
@@ -168,6 +175,30 @@ GTEST_TEST(MinimumDegreeOrderingTest, ComputeMinimumDegreeOrdering2) {
   BlockSparsityPattern block_pattern(block_sizes, sparsity);
   std::vector<int> result = ComputeMinimumDegreeOrdering(block_pattern);
   EXPECT_EQ(result, std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+}
+
+/* Here we use the same initial sparsity pattern as the example from Figure 1 in
+ [Amestoy, 1996], but run Minimum Degree ordering with even nodes as priority
+ nodes. We compare the computed results with pen-and-paper results from
+ actually performing the chordal completion of the graph. */
+GTEST_TEST(MinimumDegreeOrderingTest,
+           ComputeMinimumDegreeOrderingWithPriority) {
+  std::vector<std::vector<int>> sparsity;
+  sparsity.emplace_back(std::vector<int>{0, 3, 5});
+  sparsity.emplace_back(std::vector<int>{1, 4, 5, 8});
+  sparsity.emplace_back(std::vector<int>{2, 4, 5, 6});
+  sparsity.emplace_back(std::vector<int>{3, 6, 7});
+  sparsity.emplace_back(std::vector<int>{4, 6, 8});
+  sparsity.emplace_back(std::vector<int>{5});
+  sparsity.emplace_back(std::vector<int>{6, 7, 8, 9});
+  sparsity.emplace_back(std::vector<int>{7, 8, 9});
+  sparsity.emplace_back(std::vector<int>{8, 9});
+  sparsity.emplace_back(std::vector<int>{9});
+  std::vector<int> block_sizes(10, 2);
+  BlockSparsityPattern block_pattern(block_sizes, sparsity);
+  const std::vector<int> result =
+      ComputeMinimumDegreeOrdering(block_pattern, {0, 2, 4, 6, 8});
+  EXPECT_EQ(result, std::vector<int>({0, 2, 4, 8, 6, 1, 3, 5, 7, 9}));
 }
 
 GTEST_TEST(MinimumDegreeOrderingTest, SymbolicCholeskyFactor) {


### PR DESCRIPTION
Compute the minimum degree ordering of a sparsity pattern under the constraint that certain nodes are eliminated before others. This is useful for computing Schur complement as a side effect of a right-looking Cholesky factorization as the variables w.r.t which the Schur complement is computed must be eliminated first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19762)
<!-- Reviewable:end -->
