### PR TITLE
Compute in-group Minimum Degree ordering

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -157,6 +157,7 @@ drake_cc_library(
     deps = [
         ":block_sparse_lower_triangular_or_symmetric_matrix",
         "//common:essential",
+        "//multibody/contact_solvers/sap:partial_permutation",
     ],
 )
 

--- a/multibody/contact_solvers/minimum_degree_ordering.h
+++ b/multibody/contact_solvers/minimum_degree_ordering.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <unordered_set>
 #include <vector>
 
 #include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
@@ -109,6 +110,21 @@ std::vector<int> ComputeMinimumDegreeOrdering(
  matrix. */
 BlockSparsityPattern SymbolicCholeskyFactor(
     const BlockSparsityPattern& block_sparsity);
+
+/* Given a block sparsity pattern G on vertices v = {0, 1, ..., n-1} and a
+ partition on v = v₁ ∪ v₂ (such that v₁ ∩ v₂ = ∅), computes an elimination
+ ordering on v in the following way:
+  1. Generate the v₁-induced subgraph G₁ and the v₂-induced subgraph G₂.
+  2. Compute the Minimum Degree ordering on G₁ and G₂ respectively.
+  3. Concatenate the orderings so that all vertices in v₁ come before vertices
+     in v₂.
+ @param[in] global_pattern  The block sparsity pattern G.
+ @param[in] v1              The vertices in the set v₁.
+ @returns  The elimination ordering obtained by following the algorithm
+ described above. */
+std::vector<int> CalcAndConcatenateMdOrderingWithinGroup(
+    const BlockSparsityPattern& global_pattern,
+    const std::unordered_set<int>& v1);
 
 }  // namespace internal
 }  // namespace contact_solvers


### PR DESCRIPTION
Given a block sparsity pattern G on vertices v = {0, 1, ..., n-1} and a partition on v = v₁ ∪ v₂ (such that v₁ ∩ v₂ = ∅), computes an elimination for v₁ and v₂ respectively using their induced graphs and concatenates them.

This is useful for computing Schur complement as a side effect of a right-looking Cholesky factorization as the variables w.r.t which the Schur complement is computed must be eliminated first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19764)
<!-- Reviewable:end -->
