### PR TITLE
Remove outdated TODO from MeshcatVisualizer

### DIFF
--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -222,16 +222,6 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   /* The parameters for the visualizer.  */
   MeshcatVisualizerParams params_;
 
-  /* TODO(russt): Consider moving the MeshcatAnimation into the Context.
-  Full-fledged support for multi-threaded recording requires some additional
-  design thinking and may require either moving the prefix into the Context as
-  well (e.g. multiple copies of the MeshcatVisualizer publish to the same
-  Meshcat, but on different prefixes) or support for SetObject in
-  MeshcatAnimation (each animation keeps track of the objects, instead of the
-  shared Meshcat instance keeping track).  We may also want to allow users to
-  disable the default publishing behavior (to record without visualizing
-  immediately). */
-
   /* TODO(#16486): ideally this mutable state will go away once it is safe to
   run Meshcat multithreaded */
   mutable systems::internal::InstantaneousRealtimeRateCalculator


### PR DESCRIPTION
In PR #18433, we moved MeshcatAnimation into Meshcat (instead of the Context). The comments about multithreading are moot -- our current stance is that one should not try to publish to visualizers from multiple threads.

+@jwnimmer-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19767)
<!-- Reviewable:end -->
