### PR TITLE
Fixup for #19765. Remove problematic doxygen ref.

### DIFF
--- a/systems/controllers/finite_horizon_linear_quadratic_regulator.h
+++ b/systems/controllers/finite_horizon_linear_quadratic_regulator.h
@@ -80,8 +80,7 @@ struct FiniteHorizonLinearQuadraticRegulatorOptions {
   /**
   For continuous-time dynamical systems, the Riccati equation is solved by the
   Simulator (running backwards in time). Use this parameter to configure the
-  simulator (e.g. choose non-default @ref Integrators or integrator
-  parameters). */
+  simulator (e.g. choose non-default integrator or integrator parameters). */
   SimulatorConfig simulator_config{};
 };
 


### PR DESCRIPTION
+@EricCousineau for both reviews, please.

The doxygen build server had failed with
```
[1:24:49 PM]  RuntimeError: Problems found by Doxygen:
[1:24:49 PM]  drake/systems/controllers/finite_horizon_linear_quadratic_regulator.h:81: error: unable to resolve reference to `Integrators' for \ref command
````

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19772)
<!-- Reviewable:end -->
