### PR TITLE
[parsing] Parse custom ball constraint elements.

### DIFF
--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -155,6 +155,21 @@ const LinearBushingRollPitchYaw<double>* ParseLinearBushingRollPitchYaw(
       bushing_force_stiffness, bushing_force_damping);
 }
 
+std::optional<MultibodyConstraintId> ParseBallConstraint(
+    const std::function<Eigen::Vector3d(const char*)>& read_vector,
+    const std::function<const Body<double>*(const char*)>& read_body,
+    MultibodyPlant<double>* plant) {
+  const Body<double>* body_A = read_body("drake:ball_constraint_body_A");
+  if (!body_A) { return {}; }
+  const Body<double>* body_B = read_body("drake:ball_constraint_body_B");
+  if (!body_B) { return {}; }
+
+  const Eigen::Vector3d p_AP = read_vector("drake:ball_constraint_p_AP");
+  const Eigen::Vector3d p_BQ = read_vector("drake:ball_constraint_p_BQ");
+
+  return plant->AddBallConstraint(*body_A, p_AP, *body_B, p_BQ);
+}
+
 // See ParseCollisionFilterGroupCommon at header for documentation
 void CollectCollisionFilterGroup(
     const DiagnosticPolicy& diagnostic,

--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -163,6 +163,40 @@ const LinearBushingRollPitchYaw<double>* ParseLinearBushingRollPitchYaw(
     const std::function<const Frame<double>*(const char*)>& read_frame,
     MultibodyPlant<double>* plant);
 
+// Adds a ball constraint to `plant` from a reading interface in a URDF/SDF
+// agnostic manner. This function does no semantic parsing and leaves the
+// responsibility of handling errors or missing values to the individual
+// parsers. All values are expected to exist and be well formed. Through this,
+// the API to specify the ball_constraint tag in both SDF and URDF can be
+// controlled/modified in a single function.
+//
+// __SDF__:
+//
+// <drake:ball_constraint>
+//   <drake:ball_constraint_body_A>body_A</drake:ball_constraint_body_A>
+//   <drake:ball_constraint_body_B>body_B</drake:ball_constraint_body_B>
+//   <drake:ball_constraint_p_AP>0 0 0</drake:ball_constraint_p_AP>
+//   <drake:ball_constraint_p_BQ>0 0 0</drake:ball_constraint_p_BQ>
+// </drake:ball_constraint>
+//
+// __URDF__:
+//
+// <drake:ball_constraint>
+//   <drake:ball_constraint_body_A name="body_A"/>
+//   <drake:ball_constraint_body_B name="body_B"/>
+//   <drake:ball_constraint_p_AP value="0 0 0"/>
+//   <drake:ball_constraint_p_BQ value="0 0 0"/>
+// </drake:ball_constraint>
+//
+// The @p read_body functor may (at its option) throw std:exception, or return
+// nullptr when body parsing fails. Similarly,
+// ParseBallConstraint() may return nullopt when read_body has
+// returned nullptr.
+std::optional<MultibodyConstraintId> ParseBallConstraint(
+    const std::function<Eigen::Vector3d(const char*)>& read_vector,
+    const std::function<const Body<double>*(const char*)>& read_body,
+    MultibodyPlant<double>* plant);
+
 // TODO(@SeanCurtis-TRI): The real solution here is to create a wrapper
 // class that provides a consistent interface to either representation.
 // Then instantiate on the caller side and express the code here in terms of

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -151,6 +151,11 @@ For URDF, declare the namespace prefix like this:
 Here is the full list of custom elements:
 - @ref tag_drake_acceleration
 - @ref tag_drake_accepting_renderer
+- @ref tag_drake_ball_constraint
+- @ref tag_drake_ball_constraint_body_A
+- @ref tag_drake_ball_constraint_body_B
+- @ref tag_drake_ball_constraint_p_AP
+- @ref tag_drake_ball_constraint_p_BQ
 - @ref tag_drake_bushing_force_damping
 - @ref tag_drake_bushing_force_stiffness
 - @ref tag_drake_bushing_frameA
@@ -214,6 +219,79 @@ The tag serves as a list of renderers for which this visual is targeted.
     the list of targeted renderers.
 
 This feature is one way to provide multiple visual representations of a body.
+
+@subsection tag_drake_ball_constraint drake:ball_constraint
+
+- SDFormat path: `//model/drake:ball_constraint`
+- URDF path: `/robot/drake:ball_constraint`
+- Syntax: Nested elements @ref tag_drake_ball_constraint_body_A, @ref
+tag_drake_ball_constraint_body_B, @ref tag_drake_ball_constraint_p_AP, and @ref
+tag_drake_ball_constraint_p_BQ
+
+@subsection tag_drake_ball_constraint_semantics Semantics
+
+The element adds a ball constraint to the model via
+drake::multibody::MultibodyPlant::AddBallConstraint().
+
+@subsection tag_drake_ball_constraint_body_A drake:ball_constraint_body_A
+
+- SDFormat path: `//model/drake:ball_constraint/drake:ball_constraint_body_A`
+- URDF path: `/robot/drake:ball_constraint/drake:ball_constraint_body_A/@value`
+- Syntax: String.
+
+@subsection tag_drake_ball_constraint_body_A_semantics Semantics
+
+The string names a body (expected to already be defined by this model) that
+will be passed to drake::multibody::MultibodyPlant::AddBallConstraint()
+as the `body_A` parameter.
+
+@see @ref tag_drake_ball_constraint,
+drake::multibody::MultibodyPlant::AddBallConstraint()
+
+@subsection tag_drake_ball_constraint_body_B drake:ball_constraint_body_B
+
+- SDFormat path: `//model/drake:ball_constraint/drake:ball_constraint_body_B`
+- URDF path: `/robot/drake:ball_constraint/drake:ball_constraint_body_B/@value`
+- Syntax: String.
+
+@subsection tag_drake_ball_constraint_body_B_semantics Semantics
+
+The string names a body (expected to already be defined by this model) that
+will be passed to drake::multibody::MultibodyPlant::AddBallConstraint()
+as the `body_B` parameter.
+
+@see @ref tag_drake_ball_constraint,
+drake::multibody::MultibodyPlant::AddBallConstraint()
+
+@subsection tag_drake_ball_constraint_p_AP drake:ball_constraint_p_AP
+
+- SDFormat path: `//model/drake:ball_constraint/drake:ball_constraint_p_AP`
+- URDF path: `/robot/drake:ball_constraint/drake:ball_constraint_p_AP/@value`
+- Syntax: Three floating point values.
+
+@subsection tag_drake_ball_constraint_p_AP_semantics Semantics
+
+The three floating point values (units of meters) are formed into a
+vector and passed into drake::multibody::MultibodyPlant::AddBallConstraint() as
+the `p_AP` parameter.
+
+@see @ref tag_drake_ball_constraint,
+drake::multibody::MultibodyPlant::AddBallConstraint()
+
+@subsection tag_drake_ball_constraint_p_BQ drake:ball_constraint_p_BQ
+
+- SDFormat path: `//model/drake:ball_constraint/drake:ball_constraint_p_BQ`
+- URDF path: `/robot/drake:ball_constraint/drake:ball_constraint_p_BQ/@value`
+- Syntax: Three floating point values.
+
+@subsection tag_drake_ball_constraint_p_BQ_semantics Semantics
+
+The three floating point values (units of meters) are formed into a
+vector and passed into drake::multibody::MultibodyPlant::AddBallConstraint() as
+the `p_BQ` parameter.
+
+@see @ref tag_drake_ball_constraint,
+drake::multibody::MultibodyPlant::AddBallConstraint()
 
 @subsection tag_drake_bushing_force_damping drake:bushing_force_damping
 

--- a/multibody/plant/constraint_specs.h
+++ b/multibody/plant/constraint_specs.h
@@ -53,7 +53,7 @@ struct DistanceConstraintSpec {
   // Returns `true` iff `this` specification is valid to define a distance
   // constraint. A distance constraint specification is considered to be valid
   // iff body_A != body_B, distance > 0, stiffness >= 0 and damping >= 0.
-  bool IsValid() {
+  bool IsValid() const {
     return body_A != body_B && distance > 0.0 && stiffness >= 0.0 &&
            damping >= 0.0;
   }
@@ -84,7 +84,7 @@ struct BallConstraintSpec {
   // Returns `true` iff `this` specification is valid to define a ball
   // constraint. A ball constraint specification is considered to be valid iff:
   //   body_A != body_B.
-  bool IsValid() { return body_A != body_B; }
+  bool IsValid() const { return body_A != body_B; }
 
   BodyIndex body_A;      // Index of body A.
   Vector3<double> p_AP;  // Position of point P in body frame A.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1213,7 +1213,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return ssize(ball_constraints_specs_);
   }
 
-  /// Returns the coupler constraint specification corresponding to `id`
+  /// (Internal use only) Returns the coupler constraint specification
+  /// corresponding to `id`
   /// @throws if `id` is not a valid identifier for a coupler constraint.
   const internal::CouplerConstraintSpec& get_coupler_constraint_specs(
       MultibodyConstraintId id) const {
@@ -1221,7 +1222,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return coupler_constraints_specs_.at(id);
   }
 
-  /// Returns the distance constraint specification corresponding to `id`
+  /// (Internal use only) Returns the distance constraint specification
+  /// corresponding to `id`
   /// @throws if `id` is not a valid identifier for a distance constraint.
   const internal::DistanceConstraintSpec& get_distance_constraint_specs(
       MultibodyConstraintId id) const {
@@ -1229,12 +1231,36 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return distance_constraints_specs_.at(id);
   }
 
-  /// Returns the ball constraint specification corresponding to `id`
+  /// (Internal use only)  Returns the ball constraint specification
+  /// corresponding to `id`
   /// @throws if `id` is not a valid identifier for a ball constraint.
   const internal::BallConstraintSpec& get_ball_constraint_specs(
       MultibodyConstraintId id) const {
     DRAKE_THROW_UNLESS(ball_constraints_specs_.count(id) > 0);
     return ball_constraints_specs_.at(id);
+  }
+
+  /// (Internal use only)  Returns a reference to the all of the coupler
+  /// constraints in this plant as a map from MultibodyConstraintId to
+  /// CouplerConstraintSpec.
+  const std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>&
+  get_coupler_constraint_specs() const {
+    return coupler_constraints_specs_;
+  }
+
+  /// (Internal use only) Returns a reference to the all of the distance
+  /// constraints in this plant as a map from MultibodyConstraintId to
+  /// DistanceConstraintSpec.
+  const std::map<MultibodyConstraintId, internal::DistanceConstraintSpec>&
+  get_distance_constraint_specs() const {
+    return distance_constraints_specs_;
+  }
+
+  /// (Internal use only) Returns a reference to the all of the ball constraints
+  /// in this plant as a map from MultibodyConstraintId to BallConstraintSpec.
+  const std::map<MultibodyConstraintId, internal::BallConstraintSpec>&
+  get_ball_constraint_specs() const {
+    return ball_constraints_specs_;
   }
 
   /// Defines a holonomic constraint between two single-dof joints `joint0`

--- a/multibody/plant/test/sap_driver_ball_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_ball_constraints_test.cc
@@ -247,6 +247,23 @@ GTEST_TEST(BallConstraintsTests, VerifyIdMapping) {
   EXPECT_EQ(ball_spec.p_AP, p_AP);
   EXPECT_EQ(ball_spec.p_BQ, p_BQ);
 
+  const std::map<MultibodyConstraintId, BallConstraintSpec>& ball_specs =
+      plant.get_ball_constraint_specs();
+  ASSERT_EQ(ssize(ball_specs), 1);
+
+  const MultibodyConstraintId ball_id_from_map = ball_specs.begin()->first;
+  const BallConstraintSpec& ball_spec_from_map = ball_specs.begin()->second;
+
+  // Check the id in the map matches the one returned.
+  EXPECT_EQ(ball_id, ball_id_from_map);
+
+  // Check that the one spec in the map is equal to `ball_spec`.
+  EXPECT_EQ(ball_spec.id, ball_spec_from_map.id);
+  EXPECT_EQ(ball_spec.body_A, ball_spec_from_map.body_A);
+  EXPECT_EQ(ball_spec.body_B, ball_spec_from_map.body_B);
+  EXPECT_EQ(ball_spec.p_AP, ball_spec_from_map.p_AP);
+  EXPECT_EQ(ball_spec.p_BQ, ball_spec_from_map.p_BQ);
+
   // Throw on id to wrong constraint specs type.
   EXPECT_THROW(plant.get_coupler_constraint_specs(ball_id), std::exception);
   EXPECT_THROW(plant.get_distance_constraint_specs(ball_id), std::exception);

--- a/multibody/plant/test/sap_driver_distance_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_distance_constraints_test.cc
@@ -258,6 +258,25 @@ GTEST_TEST(DistanceConstraintsTests, VerifyIdMapping) {
   EXPECT_EQ(distance_spec.p_BQ, p_BQ);
   EXPECT_EQ(distance_spec.distance, distance);
 
+  const std::map<MultibodyConstraintId, DistanceConstraintSpec>&
+      distance_specs = plant.get_distance_constraint_specs();
+  ASSERT_EQ(ssize(distance_specs), 1);
+
+  const MultibodyConstraintId distance_id_from_map =
+      distance_specs.begin()->first;
+  const DistanceConstraintSpec& distance_spec_from_map =
+      distance_specs.begin()->second;
+
+  // Check the id in the map matches the one returned.
+  EXPECT_EQ(distance_id, distance_id_from_map);
+
+  // Check that the one spec in the map is equal to `distance_spec`.
+  EXPECT_EQ(distance_spec.id, distance_spec_from_map.id);
+  EXPECT_EQ(distance_spec.body_A, distance_spec_from_map.body_A);
+  EXPECT_EQ(distance_spec.body_B, distance_spec_from_map.body_B);
+  EXPECT_EQ(distance_spec.p_AP, distance_spec_from_map.p_AP);
+  EXPECT_EQ(distance_spec.p_BQ, distance_spec_from_map.p_BQ);
+
   // Throw on id to wrong constraint specs type.
   EXPECT_THROW(plant.get_coupler_constraint_specs(distance_id), std::exception);
   EXPECT_THROW(plant.get_ball_constraint_specs(distance_id), std::exception);


### PR DESCRIPTION
Adds parsing for SAP ball constraints in SDF and URDF. In addition a few small APIs for constraint introspection are introduced. They give const access to all constraint specs in the plant. These are necessary to give access to constraints when an associated `MultibodyConstraintId` is not present (e.g. silently thrown away by the Parser).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19780)
<!-- Reviewable:end -->
