### PR TITLE
[examples] Strandbeest with constraints

### DIFF
--- a/examples/multibody/strandbeest/BUILD.bazel
+++ b/examples/multibody/strandbeest/BUILD.bazel
@@ -1,22 +1,26 @@
 load("@drake//tools/skylark:drake_cc.bzl", "drake_cc_binary")
 load("@drake//tools/skylark:drake_py.bzl", "drake_py_unittest")
-load("@drake//tools/workspace/ros_xacro_internal:defs.bzl", "xacro_file")
+load("@drake//tools/workspace/ros_xacro_internal:defs.bzl", "xacro_filegroup")
 load("@drake//tools/lint:lint.bzl", "add_lint_tests")
 
-xacro_file(
-    name = "Strandbeest.urdf",
-    src = "model/Strandbeest.xacro",
+xacro_filegroup(
+    name = "StrandbeestModels",
+    srcs = [
+        "model/StrandbeestBushings.urdf.xacro",
+        "model/StrandbeestConstraints.urdf.xacro",
+    ],
     data = [
         "model/LegAssembly.xacro",
         "model/LegPair.xacro",
         "model/Macros.xacro",
+        "model/Strandbeest.xacro",
     ],
 )
 
 drake_cc_binary(
     name = "run_with_motor",
     srcs = ["run_with_motor.cc"],
-    data = [":Strandbeest.urdf"],
+    data = [":StrandbeestModels"],
     deps = [
         "//common:add_text_logging_gflags",
         "//multibody/inverse_kinematics",

--- a/examples/multibody/strandbeest/model/LegAssembly.xacro
+++ b/examples/multibody/strandbeest/model/LegAssembly.xacro
@@ -4,12 +4,12 @@
 
      These files are an adaptation of the original Strandbeest example in
      Drake, written by Robin Deits:
-       
+
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
 <robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="http://drake.mit.edu ../../doc/drakeURDF.xsd" name="LegAssembly">
   <xacro:include filename="Macros.xacro"/>
-  <xacro:macro name="strandbeest_leg" params="prefix">
+  <xacro:macro name="strandbeest_leg" params="prefix with_constraints">
     <!-- Links -->
     <link name="${prefix}_bar_j">
       <xacro:strandbeest_cylinder xyz="0 0 0.25" rpy="0 0 0" length="0.50" radius="0.01" material="tri_grey"/>
@@ -114,26 +114,44 @@
       <origin rpy="0 0 0" xyz="0 0 0.558"/>
       <limit lower="-1.7" upper="0.4" effort="0" velocity="1000"/>
     </joint>
-    <!-- Custom Bushing Elements -->
-    <frame name="${prefix}_loop_f_g_bushing_frameA" link="${prefix}_bar_f" rpy="${-pi/2} 0 0" xyz="0 0 0.394"/>
-    <frame name="${prefix}_loop_f_g_bushing_frameC" link="${prefix}_bar_g" rpy="${-pi/2} 0 0" xyz="0.3624 0 -0.0582"/>
-    <drake:linear_bushing_rpy>
-      <drake:bushing_frameA name="${prefix}_loop_f_g_bushing_frameA"/>
-      <drake:bushing_frameC name="${prefix}_loop_f_g_bushing_frameC"/>
-      <drake:bushing_torque_stiffness value="${torque_stiffness} ${torque_stiffness} 0"/>
-      <drake:bushing_torque_damping value="${torque_damping} ${torque_damping} 0"/>
-      <drake:bushing_force_stiffness value="${force_stiffness} ${force_stiffness} ${force_stiffness}"/>
-      <drake:bushing_force_damping value="${force_damping} ${force_damping} ${force_damping}"/>
-    </drake:linear_bushing_rpy>
-    <frame name="${prefix}_loop_b_c_bushing_frameA" link="${prefix}_bar_b" rpy="${-pi/2} 0 0" xyz="-0.2978 0 0.2892"/>
-    <frame name="${prefix}_loop_b_c_bushing_frameC" link="${prefix}_bar_c" rpy="${-pi/2} 0 0" xyz="0 0 0.393"/>
-    <drake:linear_bushing_rpy>
-      <drake:bushing_frameA name="${prefix}_loop_b_c_bushing_frameA"/>
-      <drake:bushing_frameC name="${prefix}_loop_b_c_bushing_frameC"/>
-      <drake:bushing_torque_stiffness value="${torque_stiffness} ${torque_stiffness} 0"/>
-      <drake:bushing_torque_damping value="${torque_damping} ${torque_damping} 0"/>
-      <drake:bushing_force_stiffness value="${force_stiffness} ${force_stiffness} ${force_stiffness}"/>
-      <drake:bushing_force_damping value="${force_damping} ${force_damping} ${force_damping}"/>
-    </drake:linear_bushing_rpy>
+
+    <xacro:if value="${with_constraints}">
+      <!-- Custom Ball Constraint Elements -->
+      <drake:ball_constraint>
+        <drake:ball_constraint_body_A name="${prefix}_bar_f"/>
+        <drake:ball_constraint_p_AP value="0 0 0.394"/>
+        <drake:ball_constraint_body_B name="${prefix}_bar_g"/>
+        <drake:ball_constraint_p_BQ value="0.3624 0 -0.0582"/>
+      </drake:ball_constraint>
+      <drake:ball_constraint>
+        <drake:ball_constraint_body_A name="${prefix}_bar_b"/>
+        <drake:ball_constraint_p_AP value="-0.2978 0 0.2892"/>
+        <drake:ball_constraint_body_B name="${prefix}_bar_c"/>
+        <drake:ball_constraint_p_BQ value="0 0 0.393"/>
+      </drake:ball_constraint>
+    </xacro:if>
+    <xacro:unless value="${with_constraints}">
+      <!-- Custom Bushing Elements -->
+      <frame name="${prefix}_loop_f_g_bushing_frameA" link="${prefix}_bar_f" rpy="${-pi/2} 0 0" xyz="0 0 0.394"/>
+      <frame name="${prefix}_loop_f_g_bushing_frameC" link="${prefix}_bar_g" rpy="${-pi/2} 0 0" xyz="0.3624 0 -0.0582"/>
+      <drake:linear_bushing_rpy>
+        <drake:bushing_frameA name="${prefix}_loop_f_g_bushing_frameA"/>
+        <drake:bushing_frameC name="${prefix}_loop_f_g_bushing_frameC"/>
+        <drake:bushing_torque_stiffness value="${torque_stiffness} ${torque_stiffness} 0"/>
+        <drake:bushing_torque_damping value="${torque_damping} ${torque_damping} 0"/>
+        <drake:bushing_force_stiffness value="${force_stiffness} ${force_stiffness} ${force_stiffness}"/>
+        <drake:bushing_force_damping value="${force_damping} ${force_damping} ${force_damping}"/>
+      </drake:linear_bushing_rpy>
+      <frame name="${prefix}_loop_b_c_bushing_frameA" link="${prefix}_bar_b" rpy="${-pi/2} 0 0" xyz="-0.2978 0 0.2892"/>
+      <frame name="${prefix}_loop_b_c_bushing_frameC" link="${prefix}_bar_c" rpy="${-pi/2} 0 0" xyz="0 0 0.393"/>
+      <drake:linear_bushing_rpy>
+        <drake:bushing_frameA name="${prefix}_loop_b_c_bushing_frameA"/>
+        <drake:bushing_frameC name="${prefix}_loop_b_c_bushing_frameC"/>
+        <drake:bushing_torque_stiffness value="${torque_stiffness} ${torque_stiffness} 0"/>
+        <drake:bushing_torque_damping value="${torque_damping} ${torque_damping} 0"/>
+        <drake:bushing_force_stiffness value="${force_stiffness} ${force_stiffness} ${force_stiffness}"/>
+        <drake:bushing_force_damping value="${force_damping} ${force_damping} ${force_damping}"/>
+      </drake:linear_bushing_rpy>
+    </xacro:unless>
   </xacro:macro>
 </robot>

--- a/examples/multibody/strandbeest/model/LegPair.xacro
+++ b/examples/multibody/strandbeest/model/LegPair.xacro
@@ -4,16 +4,16 @@
 
      These files are an adaptation of the original Strandbeest example in
      Drake, written by Robin Deits:
-       
+
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
 <robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="http://drake.mit.edu ../../doc/drakeURDF.xsd" name="LegPair">
   <xacro:include filename="Macros.xacro"/>
   <xacro:include filename="LegAssembly.xacro"/>
-  <xacro:macro name="strandbeest_leg_pair" params="prefix">
+  <xacro:macro name="strandbeest_leg_pair" params="prefix with_constraints">
     <!-- Create the two legs -->
-    <xacro:strandbeest_leg prefix="${prefix}_leg1"/>
-    <xacro:strandbeest_leg prefix="${prefix}_leg2"/>
+    <xacro:strandbeest_leg prefix="${prefix}_leg1" with_constraints="${with_constraints}"/>
+    <xacro:strandbeest_leg prefix="${prefix}_leg2" with_constraints="${with_constraints}"/>
     <!-- Links -->
     <link name="${prefix}_bar_l">
       <xacro:strandbeest_cylinder xyz="0 0 0.039" rpy="0 0 0" length="0.078" radius="0.01" material="tri_black"/>
@@ -43,26 +43,44 @@
       <child link="${prefix}_leg2_bar_j"/>
       <origin rpy="0 0 ${pi}" xyz="0 0 0.15"/>
     </joint>
-    <!-- Custom Bushing Elements -->
-    <frame name="${prefix}_leg1_loop_a_c_bushing_frameA" link="${prefix}_bar_a" rpy="${-pi/2} 0 0" xyz="0 0 0.38"/>
-    <frame name="${prefix}_leg1_loop_a_c_bushing_frameC" link="${prefix}_leg1_bar_c" rpy="${-pi/2} 0 0" xyz="0 0 0.393"/>
-    <drake:linear_bushing_rpy>
-      <drake:bushing_frameA name="${prefix}_leg1_loop_a_c_bushing_frameA"/>
-      <drake:bushing_frameC name="${prefix}_leg1_loop_a_c_bushing_frameC"/>
-      <drake:bushing_torque_stiffness value="${torque_stiffness} ${torque_stiffness} 0"/>
-      <drake:bushing_torque_damping value="${torque_damping} ${torque_damping} 0"/>
-      <drake:bushing_force_stiffness value="${force_stiffness} ${force_stiffness} ${force_stiffness}"/>
-      <drake:bushing_force_damping value="${force_damping} ${force_damping} ${force_damping}"/>
-    </drake:linear_bushing_rpy>
-    <frame name="${prefix}_leg2_loop_a_c_bushing_frameA" link="${prefix}_bar_a" rpy="${-pi/2} 0 ${pi}" xyz="0 0 -0.38"/>
-    <frame name="${prefix}_leg2_loop_a_c_bushing_frameC" link="${prefix}_leg2_bar_c" rpy="${-pi/2} 0 0" xyz="0 0 0.393"/>
-    <drake:linear_bushing_rpy>
-      <drake:bushing_frameA name="${prefix}_leg2_loop_a_c_bushing_frameA"/>
-      <drake:bushing_frameC name="${prefix}_leg2_loop_a_c_bushing_frameC"/>
-      <drake:bushing_torque_stiffness value="${torque_stiffness} ${torque_stiffness} 0"/>
-      <drake:bushing_torque_damping value="${torque_damping} ${torque_damping} 0"/>
-      <drake:bushing_force_stiffness value="${force_stiffness} ${force_stiffness} ${force_stiffness}"/>
-      <drake:bushing_force_damping value="${force_damping} ${force_damping} ${force_damping}"/>
-    </drake:linear_bushing_rpy>
+
+    <xacro:if value="${with_constraints}">
+      <!-- Custom Ball Constraint Elements -->
+      <drake:ball_constraint>
+        <drake:ball_constraint_body_A name="${prefix}_bar_a"/>
+        <drake:ball_constraint_p_AP value="0 0 0.38"/>
+        <drake:ball_constraint_body_B name="${prefix}_leg1_bar_c"/>
+        <drake:ball_constraint_p_BQ value="0 0 0.393"/>
+      </drake:ball_constraint>
+      <drake:ball_constraint>
+        <drake:ball_constraint_body_A name="${prefix}_bar_a"/>
+        <drake:ball_constraint_p_AP value="0 0 -0.38"/>
+        <drake:ball_constraint_body_B name="${prefix}_leg2_bar_c"/>
+        <drake:ball_constraint_p_BQ value="0 0 0.393"/>
+      </drake:ball_constraint>
+    </xacro:if>
+    <xacro:unless value="${with_constraints}">
+      <!-- Custom Bushing Elements -->
+      <frame name="${prefix}_leg1_loop_a_c_bushing_frameA" link="${prefix}_bar_a" rpy="${-pi/2} 0 0" xyz="0 0 0.38"/>
+      <frame name="${prefix}_leg1_loop_a_c_bushing_frameC" link="${prefix}_leg1_bar_c" rpy="${-pi/2} 0 0" xyz="0 0 0.393"/>
+      <drake:linear_bushing_rpy>
+        <drake:bushing_frameA name="${prefix}_leg1_loop_a_c_bushing_frameA"/>
+        <drake:bushing_frameC name="${prefix}_leg1_loop_a_c_bushing_frameC"/>
+        <drake:bushing_torque_stiffness value="${torque_stiffness} ${torque_stiffness} 0"/>
+        <drake:bushing_torque_damping value="${torque_damping} ${torque_damping} 0"/>
+        <drake:bushing_force_stiffness value="${force_stiffness} ${force_stiffness} ${force_stiffness}"/>
+        <drake:bushing_force_damping value="${force_damping} ${force_damping} ${force_damping}"/>
+      </drake:linear_bushing_rpy>
+      <frame name="${prefix}_leg2_loop_a_c_bushing_frameA" link="${prefix}_bar_a" rpy="${-pi/2} 0 ${pi}" xyz="0 0 -0.38"/>
+      <frame name="${prefix}_leg2_loop_a_c_bushing_frameC" link="${prefix}_leg2_bar_c" rpy="${-pi/2} 0 0" xyz="0 0 0.393"/>
+      <drake:linear_bushing_rpy>
+        <drake:bushing_frameA name="${prefix}_leg2_loop_a_c_bushing_frameA"/>
+        <drake:bushing_frameC name="${prefix}_leg2_loop_a_c_bushing_frameC"/>
+        <drake:bushing_torque_stiffness value="${torque_stiffness} ${torque_stiffness} 0"/>
+        <drake:bushing_torque_damping value="${torque_damping} ${torque_damping} 0"/>
+        <drake:bushing_force_stiffness value="${force_stiffness} ${force_stiffness} ${force_stiffness}"/>
+        <drake:bushing_force_damping value="${force_damping} ${force_damping} ${force_damping}"/>
+      </drake:linear_bushing_rpy>
+    </xacro:unless>
   </xacro:macro>
 </robot>

--- a/examples/multibody/strandbeest/model/Macros.xacro
+++ b/examples/multibody/strandbeest/model/Macros.xacro
@@ -4,7 +4,7 @@
 
      These files are an adaptation of the original Strandbeest example in
      Drake, written by Robin Deits:
-       
+
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
 <robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="http://drake.mit.edu ../../doc/drakeURDF.xsd" name="Macros">

--- a/examples/multibody/strandbeest/model/Strandbeest.xacro
+++ b/examples/multibody/strandbeest/model/Strandbeest.xacro
@@ -2,102 +2,109 @@
 <!-- @author: Joseph Masterjohn (github: @joemasterjohn)
      @author: Robin Deits (github: @rdeits)
 
+     Strandbeest.xacro is not intended to be invoked directly.
+     Instead, use the 'strandbeest' macro contained here in a separate
+     file after including Strandbeest.xacro.
+
      These files are an adaptation of the original Strandbeest example in
      Drake, written by Robin Deits:
-       
+
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
 <robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="../../doc/drakeURDF.xsd" name="Strandbeest">
-  <xacro:include filename="Macros.xacro"/>
-  <xacro:include filename="LegPair.xacro"/>
-  <!-- Materials -->
-  <material name="tri_red">
-    <color rgba="0.8 0 0 1"/>
-  </material>
-  <material name="tri_black">
-    <color rgba="0 0 0 1"/>
-  </material>
-  <material name="tri_grey">
-    <color rgba="0.6 0.6 0.6 1"/>
-  </material>
-  <!-- Fixed floor link for collision and walking -->
-  <link name="floor">
-    <inertial>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <mass value="1"/>
-      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
-    </inertial>
-    <visual>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="10 10 1"/>
-      </geometry>
-      <material name="gray">
-        <color rgba=".4 .4 .4 1"/>
-      </material>
-    </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="10 10 1"/>
-      </geometry>
-      <drake:proximity_properties>
-        <drake:mu_static value="1"/>
-        <drake:mu_dynamic value="0.6"/>
-      </drake:proximity_properties>
-    </collision>
-  </link>
-  <joint name="floor_weld" type="fixed">
-    <origin rpy="0 0 0" xyz="0 0 0.0"/>
-    <parent link="world"/>
-    <child link="floor"/>
-  </joint>
-  <!-- Links -->
-  <link name="crossbar">
-    <xacro:strandbeest_cylinder xyz="0 0 0" rpy="${pi/2} 0 0" length="1.2" radius="0.01" material="tri_black"/>
-  </link>
-  <link name="crank_axle">
-    <xacro:strandbeest_cylinder xyz="0 0 0" rpy="${pi/2} 0 0" length="1.2" radius="0.02" material="tri_red"/>
-  </link>
-  <!-- Joints -->
-  <joint name="joint_crossbar_crank" type="continuous">
-    <axis xyz="0 1 0"/>
-    <parent link="crossbar"/>
-    <child link="crank_axle"/>
-    <origin rpy="0 0 0" xyz="0 0 0.078"/>
-  </joint>
-  <transmission name="crossbar_crank_transmission" type="pr2_mechanism_model/SimpleTransmission">
-    <joint name="joint_crossbar_crank"/>
-    <actuator name="crossbar_crank_motor"/>
-    <mechanicalReduction>1</mechanicalReduction>
-  </transmission>
-  <!-- Macro to define a pair of legs at an offset along the crank shaft -->
-  <xacro:macro name="positioned_leg_pair" params="name offset angle">
-    <xacro:strandbeest_leg_pair prefix="${name}"/>
-    <joint name="${name}_joint_crossbar_l" type="fixed">
+  <xacro:macro name="strandbeest" params="with_constraints">
+    <xacro:include filename="Macros.xacro"/>
+    <xacro:include filename="LegPair.xacro"/>
+
+    <!-- Materials -->
+    <material name="tri_red">
+      <color rgba="0.8 0 0 1"/>
+    </material>
+    <material name="tri_black">
+      <color rgba="0 0 0 1"/>
+    </material>
+    <material name="tri_grey">
+      <color rgba="0.6 0.6 0.6 1"/>
+    </material>
+    <!-- Fixed floor link for collision and walking -->
+    <link name="floor">
+      <inertial>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="1"/>
+        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+      </inertial>
+      <visual>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <box size="10 10 1"/>
+        </geometry>
+        <material name="gray">
+          <color rgba=".4 .4 .4 1"/>
+        </material>
+      </visual>
+      <collision>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <box size="10 10 1"/>
+        </geometry>
+        <drake:proximity_properties>
+          <drake:mu_static value="1"/>
+          <drake:mu_dynamic value="0.6"/>
+        </drake:proximity_properties>
+      </collision>
+    </link>
+    <joint name="floor_weld" type="fixed">
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <parent link="world"/>
+      <child link="floor"/>
+    </joint>
+    <!-- Links -->
+    <link name="crossbar">
+      <xacro:strandbeest_cylinder xyz="0 0 0" rpy="${pi/2} 0 0" length="1.2" radius="0.01" material="tri_black"/>
+    </link>
+    <link name="crank_axle">
+      <xacro:strandbeest_cylinder xyz="0 0 0" rpy="${pi/2} 0 0" length="1.2" radius="0.02" material="tri_red"/>
+    </link>
+    <!-- Joints -->
+    <joint name="joint_crossbar_crank" type="continuous">
       <axis xyz="0 1 0"/>
       <parent link="crossbar"/>
-      <child link="${name}_bar_l"/>
-      <origin rpy="0 0 0" xyz="0 ${offset} 0"/>
+      <child link="crank_axle"/>
+      <origin rpy="0 0 0" xyz="0 0 0.078"/>
     </joint>
-    <joint name="${name}_joint_crank_axle_m" type="fixed">
-      <axis xyz="0 1 0"/>
-      <parent link="crank_axle"/>
-      <child link="${name}_bar_m"/>
-      <origin rpy="0 ${angle} 0" xyz="0 ${offset} 0"/>
-    </joint>
+    <transmission name="crossbar_crank_transmission" type="pr2_mechanism_model/SimpleTransmission">
+      <joint name="joint_crossbar_crank"/>
+      <actuator name="crossbar_crank_motor"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <!-- Macro to define a pair of legs at an offset along the crank shaft -->
+    <xacro:macro name="positioned_leg_pair" params="name offset angle">
+      <xacro:strandbeest_leg_pair prefix="${name}" with_constraints="${with_constraints}"/>
+      <joint name="${name}_joint_crossbar_l" type="fixed">
+        <axis xyz="0 1 0"/>
+        <parent link="crossbar"/>
+        <child link="${name}_bar_l"/>
+        <origin rpy="0 0 0" xyz="0 ${offset} 0"/>
+      </joint>
+      <joint name="${name}_joint_crank_axle_m" type="fixed">
+        <axis xyz="0 1 0"/>
+        <parent link="crank_axle"/>
+        <child link="${name}_bar_m"/>
+        <origin rpy="0 ${angle} 0" xyz="0 ${offset} 0"/>
+      </joint>
+    </xacro:macro>
+    <!-- Define the legs -->
+    <xacro:positioned_leg_pair name="pair01" offset="0.6" angle="0">
+    </xacro:positioned_leg_pair>
+    <xacro:positioned_leg_pair name="pair02" offset="0.36" angle="${2*pi/3}">
+    </xacro:positioned_leg_pair>
+    <xacro:positioned_leg_pair name="pair03" offset="0.12" angle="${4*pi/3}">
+    </xacro:positioned_leg_pair>
+    <xacro:positioned_leg_pair name="pair04" offset="-0.12" angle="${pi/3}">
+    </xacro:positioned_leg_pair>
+    <xacro:positioned_leg_pair name="pair05" offset="-0.36" angle="${3*pi/3}">
+    </xacro:positioned_leg_pair>
+    <xacro:positioned_leg_pair name="pair06" offset="-0.6" angle="${5*pi/3}">
+    </xacro:positioned_leg_pair>
   </xacro:macro>
-  <!-- Define the legs -->
-  <xacro:positioned_leg_pair name="pair01" offset="0.6" angle="0">
-  </xacro:positioned_leg_pair>
-  <xacro:positioned_leg_pair name="pair02" offset="0.36" angle="${2*pi/3}">
-  </xacro:positioned_leg_pair>
-  <xacro:positioned_leg_pair name="pair03" offset="0.12" angle="${4*pi/3}">
-  </xacro:positioned_leg_pair>
-  <xacro:positioned_leg_pair name="pair04" offset="-0.12" angle="${pi/3}">
-  </xacro:positioned_leg_pair>
-  <xacro:positioned_leg_pair name="pair05" offset="-0.36" angle="${3*pi/3}">
-  </xacro:positioned_leg_pair>
-  <xacro:positioned_leg_pair name="pair06" offset="-0.6" angle="${5*pi/3}">
-  </xacro:positioned_leg_pair>
 </robot>

--- a/examples/multibody/strandbeest/model/StrandbeestBushings.urdf.xacro
+++ b/examples/multibody/strandbeest/model/StrandbeestBushings.urdf.xacro
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!-- @author: Joseph Masterjohn (github: @joemasterjohn)
+     @author: Robin Deits (github: @rdeits)
+
+     These files are an adaptation of the original Strandbeest example in
+     Drake, written by Robin Deits:
+
+     https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
+-->
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="../../doc/drakeURDF.xsd" name="Strandbeest">
+  <xacro:include filename="Strandbeest.xacro"/>
+  <xacro:strandbeest with_constraints="false" />
+</robot>

--- a/examples/multibody/strandbeest/model/StrandbeestConstraints.urdf.xacro
+++ b/examples/multibody/strandbeest/model/StrandbeestConstraints.urdf.xacro
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!-- @author: Joseph Masterjohn (github: @joemasterjohn)
+     @author: Robin Deits (github: @rdeits)
+
+     These files are an adaptation of the original Strandbeest example in
+     Drake, written by Robin Deits:
+
+     https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
+-->
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="../../doc/drakeURDF.xsd" name="Strandbeest">
+  <xacro:include filename="Strandbeest.xacro"/>
+  <xacro:strandbeest with_constraints="true" />
+</robot>


### PR DESCRIPTION
Modifies the Strandbeest example to have an option to close loops with ball constraints rather than with bushing force elements. Currently runs only with SAP when using ball constraints.

This PR depends on #19780 and cannot be merged until it has been merged. The PR is split into two commits, the first containing all of the ball constraint parsing code from #19780 which can be ignored in this review. The second contains all of the relevant code for this review.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19782)
<!-- Reviewable:end -->
