### PR TITLE
[install] Upgrade rules_python to latest release to match workspace

### DIFF
--- a/tools/install/bazel/test/drake_bazel_installed_test.py
+++ b/tools/install/bazel/test/drake_bazel_installed_test.py
@@ -27,12 +27,12 @@ def main():
 
     # The commit (version) here should be identical to the commit listed in
     # drake/tools/workspace/rules_python/repository.bzl.
-    rules_python_commit = "0.22.0"
+    rules_python_commit = "0.24.0"
     rules_python_urls = [
         f"https://github.com/bazelbuild/rules_python/archive/{rules_python_commit}.tar.gz",  # noqa
         f"https://drake-mirror.csail.mit.edu/github/bazelbuild/rules_python/{rules_python_commit}.tar.gz",  # noqa
     ]
-    rules_python_sha256 = "863ba0fa944319f7e3d695711427d9ad80ba92c6edd0b7c7443b84e904689539"  # noqa
+    rules_python_sha256 = "0a8003b044294d7840ac7d9d73eef05d6ceb682d7516781a4ec62eeb34702578"  # noqa
 
     with open(join(scratch_dir, "WORKSPACE"), "w") as f:
         f.write(f"""


### PR DESCRIPTION
Follow-up to #19715, this change should have been committed along with the upgrade to `drake/tools/workspace/rules_python/repository.bzl`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19784)
<!-- Reviewable:end -->
