### PR TITLE
[doc] Minor updates to Docker/Apt/S3 release documentation

### DIFF
--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -186,7 +186,7 @@ the main body of the document:
    2. Click "Publish release"
    3. Notify `@BetsyMcPhail` by creating a GitHub issue asking her to manually 
       tag docker images and upload the releases to S3. Be sure to provide her 
-      with the binary date and release tag in the same ping.
+      with the release tag in the same ping.
    4. Announce on Drake Slack, ``#general``.
    5. Party on, Wayne.
 

--- a/tools/release_engineering/dev/README.md
+++ b/tools/release_engineering/dev/README.md
@@ -75,24 +75,6 @@ use `v` on the version string. For example:
 
     bazel run //tools/release_engineering/dev:push_release -- 1.0.0
 
-## Run script for apt
-
-(Before proceeding, refer to the sections below if you need to add a new
-configuration or package.)
-
-Once your machine is set-up, run the `push_release` script as described below:
-
-    cd tools/release_engineering/dev
-    ./push_release <version>
-
-The release creator will provide the version. Again, don’t use `v` on the
-version string. For example:
-
-    ./push_release 0.32.0 20210714 --apt
-
-The script may prompt for the GPG passphrase, which may be found in the AWS
-Secrets Manager. The script may prompt for this multiple times.
-
 ### Verification
 
 Verify that:
@@ -106,6 +88,24 @@ has `<version>` tags for each supported configuration (e.g. Focal and Jammy).
 
 1. The `*.deb` files are in AWS
 `S3/Buckets/drake-packages/drake/release/<configuration>/drake-dev_<version>-1_amd64.deb` for each supported configuration (e.g. focal and jammy)
+
+## Run script for apt
+
+(Before proceeding, refer to the sections below if you need to add a new
+configuration or package.)
+
+Once your machine is set-up, run the `push_release` script as described below:
+
+    cd tools/release_engineering/dev
+    ./push_release <version>
+
+The release creator will provide the version. Again, don’t use `v` on the
+version string. For example:
+
+    ./push_release 0.32.0
+
+The script may prompt for the GPG passphrase, which may be found in the AWS
+Secrets Manager. The script may prompt for this multiple times.
 
 ### [Optional] Add a new configuration
 


### PR DESCRIPTION
The updated `push_release` scripts only require the release tag, we no longer need the date or SHA.

Also, move the verification step to after running the script to push docker images and S3 artifacts. That is the step that we are verifying.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19787)
<!-- Reviewable:end -->
