### PR TITLE
[workspace] Remove spurious lcm-gen dependency

### DIFF
--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -150,6 +150,7 @@ cc_binary(
 cc_binary(
     name = "lcm-gen",
     srcs = [
+        "lcm/lcm_version.h",
         "lcmgen/emit_c.c",
         "lcmgen/emit_cpp.c",
         "lcmgen/emit_csharp.c",
@@ -168,7 +169,6 @@ cc_binary(
     copts = LCM_COPTS,
     includes = ["."],
     deps = [
-        ":lcm",
         "@glib",
     ],
 )


### PR DESCRIPTION
This removes unnecessary build steps during message codegen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19788)
<!-- Reviewable:end -->
