### PR TITLE
Adds MathematicalProgramResult::SetSolution()

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -572,6 +572,9 @@ void BindMathematicalProgram(py::module m) {
             return self.GetSolution(var);
           },
           doc.MathematicalProgramResult.GetSolution.doc_1args_var)
+      .def("SetSolution", &MathematicalProgramResult::SetSolution,
+          py::arg("var"), py::arg("value"),
+          doc.MathematicalProgramResult.SetSolution.doc)
       .def(
           "GetSolution",
           [](const MathematicalProgramResult& self,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -227,6 +227,9 @@ class TestMathematicalProgram(unittest.TestCase):
         result.set_x_val(x_val_new)
         np.testing.assert_array_equal(x_val_new, result.get_x_val())
 
+        result.SetSolution(var=qp.x[0], value=1.5)
+        self.assertEqual(result.GetSolution(qp.x[0]), 1.5)
+
     def test_str(self):
         qp = TestQP()
         s = str(qp.prog)

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -66,6 +66,11 @@ double MathematicalProgramResult::GetSolution(
   return GetVariableValue(var, decision_variable_index_, x_val_);
 }
 
+void MathematicalProgramResult::SetSolution(const symbolic::Variable& var,
+                                            double value) {
+  x_val_(decision_variable_index_->at(var.get_id())) = value;
+}
+
 symbolic::Expression MathematicalProgramResult::GetSolution(
     const symbolic::Expression& e) const {
   DRAKE_ASSERT(decision_variable_index_.has_value());

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -198,6 +198,13 @@ class MathematicalProgramResult final {
    */
   [[nodiscard]] double GetSolution(const symbolic::Variable& var) const;
 
+  /** Resets the solution of a single decision variable that is already
+  registered with this result.
+  @throws std::exception if `var` is not captured in the mapping @p
+  decision_variable_index, as the input argument of
+  set_decision_variable_index(). */
+  void SetSolution(const symbolic::Variable& var, double value);
+
   /**
    * Substitutes the value of all decision variables into the Expression.
    * @param e The decision variable.

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -64,6 +64,11 @@ TEST_F(MathematicalProgramResultTest, Setters) {
   EXPECT_EQ(result.get_optimal_cost(), cost);
   EXPECT_EQ(result.get_solver_id().name(), "foo");
   EXPECT_TRUE(CompareMatrices(result.GetSolution(), x_val));
+
+  result.SetSolution(x0_, 0.123);
+  EXPECT_EQ(result.GetSolution(x0_), 0.123);
+  symbolic::Variable unregistered("unregistered");
+  EXPECT_THROW(result.SetSolution(unregistered, 0.456), std::exception);
 }
 
 TEST_F(MathematicalProgramResultTest, GetSolution) {


### PR DESCRIPTION
This only supports the narrow case where the decision variable indices do not change. But it is very helpful for, e.g., writing test cases for methods that must extract context from a
MathematicalProgramResult. Previously, the only alternative was to set the entire vector each time.

+@hongkai-dai for feature review, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19790)
<!-- Reviewable:end -->
