### PR TITLE
Adds GraphOfConvexSets::GetSolutionPath() and supporting introspection methods.

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -548,7 +548,11 @@ void DefineGeometryOptimization(py::module m) {
         .def("GetSolutionCost", &GraphOfConvexSets::Vertex::GetSolutionCost,
             py::arg("result"), vertex_doc.GetSolutionCost.doc)
         .def("GetSolution", &GraphOfConvexSets::Vertex::GetSolution,
-            py::arg("result"), vertex_doc.GetSolution.doc);
+            py::arg("result"), vertex_doc.GetSolution.doc)
+        .def("incoming_edges", &GraphOfConvexSets::Vertex::incoming_edges,
+            py_rvp::reference_internal, vertex_doc.incoming_edges.doc)
+        .def("outgoing_edges", &GraphOfConvexSets::Vertex::outgoing_edges,
+            py_rvp::reference_internal, vertex_doc.outgoing_edges.doc);
 
     // Edge
     const auto& edge_doc = doc.GraphOfConvexSets.Edge;
@@ -556,10 +560,14 @@ void DefineGeometryOptimization(py::module m) {
         graph_of_convex_sets, "Edge", edge_doc.doc)
         .def("id", &GraphOfConvexSets::Edge::id, edge_doc.id.doc)
         .def("name", &GraphOfConvexSets::Edge::name, edge_doc.name.doc)
-        .def("u", &GraphOfConvexSets::Edge::u, py_rvp::reference_internal,
-            edge_doc.u.doc)
-        .def("v", &GraphOfConvexSets::Edge::v, py_rvp::reference_internal,
-            edge_doc.v.doc)
+        .def("u",
+            overload_cast_explicit<GraphOfConvexSets::Vertex&>(
+                &GraphOfConvexSets::Edge::u),
+            py_rvp::reference_internal, edge_doc.u.doc_0args_nonconst)
+        .def("v",
+            overload_cast_explicit<GraphOfConvexSets::Vertex&>(
+                &GraphOfConvexSets::Edge::v),
+            py_rvp::reference_internal, edge_doc.v.doc_0args_nonconst)
         .def("phi", &GraphOfConvexSets::Edge::phi, py_rvp::reference_internal,
             edge_doc.phi.doc)
         .def(
@@ -671,6 +679,9 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("source"), py::arg("target"),
             py::arg("options") = GraphOfConvexSetsOptions(),
             cls_doc.SolveShortestPath.doc_by_reference)
+        .def("GetSolutionPath", &GraphOfConvexSets::GetSolutionPath,
+            py::arg("source"), py::arg("target"), py::arg("result"),
+            py::arg("tolerance") = 1e-3, cls_doc.GetSolutionPath.doc)
         .def("SolveConvexRestriction",
             &GraphOfConvexSets::SolveConvexRestriction, py::arg("active_edges"),
             py::arg("options") = GraphOfConvexSetsOptions(),

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -542,10 +542,15 @@ class TestGeometryOptimization(unittest.TestCase):
             source=source, target=target, options=options),
             MathematicalProgramResult)
         self.assertIsInstance(
-            spp.SolveConvexRestriction(active_edges={edge0.id(),
-                                                     edge1.id()},
+            spp.SolveConvexRestriction(active_edges=[edge0, edge1],
                                        options=options),
             MathematicalProgramResult)
+        self.assertEqual(
+            len(
+                spp.GetSolutionPath(source=source,
+                                    target=target,
+                                    result=result,
+                                    tolerance=0.1)), 1)
 
         self.assertIn("source", spp.GetGraphvizString(
             result=result, show_slacks=True, precision=2, scientific=False))
@@ -572,6 +577,10 @@ class TestGeometryOptimization(unittest.TestCase):
         binding = source.AddConstraint(binding=binding)
         self.assertIsInstance(binding, Binding[Constraint])
         self.assertEqual(len(source.GetConstraints()), 2)
+        self.assertEqual(len(source.incoming_edges()), 0)
+        self.assertEqual(len(source.outgoing_edges()), 2)
+        self.assertEqual(len(target.incoming_edges()), 2)
+        self.assertEqual(len(target.outgoing_edges()), 0)
 
         # Edge
         self.assertAlmostEqual(edge0.GetSolutionCost(result=result), 0.0, 1e-6)

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -215,9 +215,17 @@ class GraphOfConvexSets {
     Eigen::VectorXd GetSolution(
         const solvers::MathematicalProgramResult& result) const;
 
+    const std::vector<Edge*>& incoming_edges() const { return incoming_edges_; }
+    const std::vector<Edge*>& outgoing_edges() const { return outgoing_edges_; }
+
    private:
     // Constructs a new vertex.
     Vertex(VertexId id, const ConvexSet& set, std::string name);
+
+    void AddIncomingEdge(Edge* e);
+    void AddOutgoingEdge(Edge* e);
+    void RemoveIncomingEdge(Edge* e);
+    void RemoveOutgoingEdge(Edge* e);
 
     const VertexId id_{};
     const std::unique_ptr<const ConvexSet> set_;
@@ -227,6 +235,9 @@ class GraphOfConvexSets {
     solvers::VectorXDecisionVariable ell_{};
     std::vector<solvers::Binding<solvers::Cost>> costs_{};
     std::vector<solvers::Binding<solvers::Constraint>> constraints_{};
+
+    std::vector<Edge*> incoming_edges_{};
+    std::vector<Edge*> outgoing_edges_{};
 
     friend class GraphOfConvexSets;
   };
@@ -252,9 +263,17 @@ class GraphOfConvexSets {
     to. */
     const Vertex& u() const { return *u_; }
 
+    /** Returns a mutable reference to the "left" Vertex that this edge connects
+    to. */
+    Vertex& u() { return *u_; }
+
     /** Returns a const reference to the "right" Vertex that this edge connects
     to. */
     const Vertex& v() const { return *v_; }
+
+    /** Returns a mutable reference to the "right" Vertex that this edge
+    connects to. */
+    Vertex& v() { return *v_; }
 
     /** Returns the binary variable associated with this edge. It can be used
     to determine whether this edge was active in the solution to an
@@ -366,11 +385,11 @@ class GraphOfConvexSets {
 
    private:
     // Constructs a new edge.
-    Edge(const EdgeId& id, const Vertex* u, const Vertex* v, std::string name);
+    Edge(const EdgeId& id, Vertex* u, Vertex* v, std::string name);
 
     const EdgeId id_{};
-    const Vertex* const u_{};
-    const Vertex* const v_{};
+    Vertex* const u_{};
+    Vertex* const v_{};
     symbolic::Variables allowed_vars_{};
     symbolic::Variable phi_{};
     const std::string name_{};
@@ -509,6 +528,22 @@ class GraphOfConvexSets {
       const GraphOfConvexSetsOptions& options =
           GraphOfConvexSetsOptions()) const;
 
+  /** Extracts a path from `source` to `target` described by the `result`
+  returned by SolveShortestPath(), via depth-first search following the largest
+  values of the edge binary variables.
+  @param tolerance defines the threshold for checking the integrality
+  conditions of the binary variables for each edge. `tolerance` = 0 would
+  demand that the binary variables are exactly 1 for the edges on the path.
+  `tolerance` = 1 would allow the binary variables to be any value in [0, 1].
+  The default value is 1e-3.
+  @throws std::exception if !result.is_success() or no path from `source` to
+  `target` can be found in the solution.
+  */
+  std::vector<const Edge*> GetSolutionPath(
+      const Vertex& source, const Vertex& target,
+      const solvers::MathematicalProgramResult& result,
+      double tolerance = 1e-3) const;
+
   /** The non-convexity in a GCS problem comes from the binary variables (phi)
   associated with the edges being active or inactive in the solution. If those
   binary variables are fixed, then the problem is convex -- this is a so-called
@@ -518,9 +553,10 @@ class GraphOfConvexSets {
   the full GCS problem with additional constraints to fix the binaries; it can
   be written using less decision variables, and needs only to include the
   vertices associated with at least one of the active edges. Decision variables
-  for all other convex sets will be set to NaN. */
+  for all other convex sets will be set to NaN.
+  */
   solvers::MathematicalProgramResult SolveConvexRestriction(
-      const std::set<EdgeId>& active_edge_ids,
+      const std::vector<const Edge*>& active_edges,
       const GraphOfConvexSetsOptions& options =
           GraphOfConvexSetsOptions()) const;
 
@@ -553,6 +589,14 @@ class GraphOfConvexSets {
       const solvers::Binding<solvers::Constraint>& binding,
       const solvers::VectorXDecisionVariable& vars) const;
 
+  // TODO(russt): remove VertexId and EdgeId from the public API.
+
+  // Note: we use VertexId and EdgeId (vs e.g. Vertex* and Edge*) here to
+  // provide consistent ordering of the vertices/edges. This is important for
+  // producing consistent MathematicalPrograms (the order of costs and
+  // constraints can change the behavior). But prefer using Vertex* and Edge*
+  // over VertexId and EdgeId in the public API; this means avoiding any sorted
+  // containers (like std::set or std::map) using their default ordering.
   std::map<VertexId, std::unique_ptr<Vertex>> vertices_{};
   std::map<EdgeId, std::unique_ptr<Edge>> edges_{};
 };

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -154,13 +154,32 @@ GTEST_TEST(GraphOfConvexSetsTest, RemoveEdge) {
 
   EXPECT_EQ(g.Edges().size(), 2);
 
+  EXPECT_EQ(u->incoming_edges().size(), 1);
+  EXPECT_EQ(u->incoming_edges()[0], e2);
+  EXPECT_EQ(u->outgoing_edges().size(), 1);
+  EXPECT_EQ(u->outgoing_edges()[0], e1);
+  EXPECT_EQ(v->incoming_edges().size(), 1);
+  EXPECT_EQ(v->incoming_edges()[0], e1);
+  EXPECT_EQ(v->outgoing_edges().size(), 1);
+  EXPECT_EQ(v->outgoing_edges()[0], e2);
+
   g.RemoveEdge(e1->id());
   auto edges = g.Edges();
   EXPECT_EQ(edges.size(), 1);
   EXPECT_EQ(edges.at(0), e2);
+  EXPECT_EQ(u->incoming_edges().size(), 1);
+  EXPECT_EQ(u->incoming_edges()[0], e2);
+  EXPECT_EQ(u->outgoing_edges().size(), 0);
+  EXPECT_EQ(v->incoming_edges().size(), 0);
+  EXPECT_EQ(v->outgoing_edges().size(), 1);
+  EXPECT_EQ(v->outgoing_edges()[0], e2);
 
   g.RemoveEdge(*e2);
   EXPECT_EQ(g.Edges().size(), 0);
+  EXPECT_EQ(u->incoming_edges().size(), 0);
+  EXPECT_EQ(u->outgoing_edges().size(), 0);
+  EXPECT_EQ(v->incoming_edges().size(), 0);
+  EXPECT_EQ(v->outgoing_edges().size(), 0);
 }
 
 GTEST_TEST(GraphOfConvexSetsTest, RemoveVertex) {
@@ -858,6 +877,29 @@ TEST_F(ThreePoints, PerspectiveQuadraticCost) {
   EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
 }
 
+TEST_F(ThreePoints, GetSolutionPath) {
+  auto result = g_.SolveShortestPath(*source_, *target_, options_);
+  ASSERT_TRUE(result.is_success());
+  const auto path = g_.GetSolutionPath(*source_, *target_, result);
+  ASSERT_EQ(path.size(), 1);
+  EXPECT_EQ(path[0], e_on_);
+
+  GraphOfConvexSets other;
+  Vertex* v = other.AddVertex(HPolyhedron::MakeUnitBox(2), "other");
+
+  // Bad source.
+  DRAKE_EXPECT_THROWS_MESSAGE(g_.GetSolutionPath(*v, *target_, result),
+                              ".*Source.*is not a vertex.*");
+  // Bad target.
+  DRAKE_EXPECT_THROWS_MESSAGE(g_.GetSolutionPath(*source_, *v, result),
+                              ".*Target.*is not a vertex.*");
+
+  // is_success is false.
+  result.set_solution_result(solvers::SolutionResult::kInfeasibleConstraints);
+  DRAKE_EXPECT_THROWS_MESSAGE(g_.GetSolutionPath(*source_, *target_, result),
+                              ".*Cannot extract a solution.*");
+}
+
 // Like the ThreePoints, but with boxes for each vertex instead of points.
 class ThreeBoxes : public ::testing::Test {
  protected:
@@ -1023,59 +1065,72 @@ TEST_F(ThreeBoxes, SolveConvexRestriction) {
   auto result = g_.SolveShortestPath(*source_, *target_, options_);
   ASSERT_TRUE(result.is_success());
 
-  auto active_edges_result =
-      g_.SolveConvexRestriction(std::set<EdgeId>{e_on_->id()}, options_);
-  ASSERT_TRUE(active_edges_result.is_success());
+  auto restriction_result =
+      g_.SolveConvexRestriction(std::vector<const Edge*>{e_on_}, options_);
+  ASSERT_TRUE(restriction_result.is_success());
 
-  EXPECT_NEAR(result.get_optimal_cost(), active_edges_result.get_optimal_cost(),
+  EXPECT_NEAR(result.get_optimal_cost(), restriction_result.get_optimal_cost(),
               1e-6);
   for (const auto* v : g_.Vertices()) {
     EXPECT_TRUE(CompareMatrices(result.GetSolution(v->x()),
-                                active_edges_result.GetSolution(v->x()), 1e-6));
+                                restriction_result.GetSolution(v->x()), 1e-6));
   }
 }
 
-// A simple shortest-path problem where the continuous variables do not effect
+// A simple shortest-path problem where the continuous variables do not affect
 // the problem (they are all equality constrained).  The GraphOfConvexSets class
 // should still solve the problem, and the convex relaxation should be optimal.
 GTEST_TEST(ShortestPathTest, ClassicalShortestPath) {
   GraphOfConvexSets spp;
 
-  std::vector<VertexId> vid(5);
+  std::vector<Vertex*> v(5);
   for (int i = 0; i < 5; ++i) {
-    vid[i] = spp.AddVertex(Point(Vector1d{0.0}))->id();
+    v[i] = spp.AddVertex(Point(Vector1d{0.0}));
   }
 
-  spp.AddEdge(vid[0], vid[1])->AddCost(3.0);
-  spp.AddEdge(vid[1], vid[0])->AddCost(1.0);
-  spp.AddEdge(vid[0], vid[2])->AddCost(4.0);
-  spp.AddEdge(vid[1], vid[2])->AddCost(1.0);
-  spp.AddEdge(vid[0], vid[3])->AddCost(1.0);
-  spp.AddEdge(vid[3], vid[2])->AddCost(1.0);
-  spp.AddEdge(vid[1], vid[4])
+  Edge* v0_to_v1 = spp.AddEdge(*v[0], *v[1]);
+  v0_to_v1->AddCost(3.0);
+  spp.AddEdge(*v[1], *v[0])->AddCost(1.0);
+  spp.AddEdge(*v[0], *v[2])->AddCost(4.0);
+  spp.AddEdge(*v[1], *v[2])->AddCost(1.0);
+  Edge* v0_to_v3 = spp.AddEdge(*v[0], *v[3]);
+  v0_to_v3->AddCost(1.0);
+  Edge* v3_to_v2 = spp.AddEdge(*v[3], *v[2]);
+  v3_to_v2->AddCost(1.0);
+  spp.AddEdge(*v[1], *v[4])
       ->AddCost(2.5);  // Updated from original to break symmetry.
-  spp.AddEdge(vid[2], vid[4])->AddCost(3.0);
-  spp.AddEdge(vid[0], vid[4])->AddCost(6.0);
+  Edge* v2_to_v4 = spp.AddEdge(*v[2], *v[4]);
+  v2_to_v4->AddCost(3.0);
+  spp.AddEdge(*v[0], *v[4])->AddCost(6.0);
 
   GraphOfConvexSetsOptions options;
   options.convex_relaxation = true;
   options.preprocessing = false;
 
-  auto result = spp.SolveShortestPath(vid[0], vid[4], options);
+  auto result = spp.SolveShortestPath(*v[0], *v[4], options);
   ASSERT_TRUE(result.is_success());
 
-  for (const auto& e : spp.Edges()) {
+  EXPECT_EQ(spp.GetSolutionPath(*v[0], *v[4], result),
+            std::vector<const Edge*>({v0_to_v3, v3_to_v2, v2_to_v4}));
+  for (const auto* e : spp.Edges()) {
     double expected_cost = 0.0;
     // Only expect non-zero costs on the shortest path.
-    if (e->u().id() == vid[0] && e->v().id() == vid[3]) {
+    if (e == v0_to_v3) {
       expected_cost = 1.0;
-    } else if (e->u().id() == vid[3] && e->v().id() == vid[2]) {
+    } else if (e == v3_to_v2) {
       expected_cost = 1.0;
-    } else if (e->u().id() == vid[2] && e->v().id() == vid[4]) {
+    } else if (e == v2_to_v4) {
       expected_cost = 3.0;
     }
     EXPECT_NEAR(e->GetSolutionCost(result), expected_cost, 1e-6);
   }
+
+  // Now we artificially change the binaries in the result to cause
+  // GetSolutionPath to backtrack.
+  result.SetSolution(v0_to_v3->phi(), 0.8);
+  result.SetSolution(v0_to_v1->phi(), 1.0);
+  EXPECT_EQ(spp.GetSolutionPath(*v[0], *v[4], result, 0.2 /* tolerance */),
+            std::vector<const Edge*>({v0_to_v3, v3_to_v2, v2_to_v4}));
 }
 
 GTEST_TEST(ShortestPathTest, InfeasibleProblem) {
@@ -1109,6 +1164,9 @@ GTEST_TEST(ShortestPathTest, InfeasibleProblem) {
   options.convex_relaxation = false;
   result = spp.SolveShortestPath(*source, *target, options);
   ASSERT_FALSE(result.is_success());
+
+  DRAKE_EXPECT_THROWS_MESSAGE(spp.GetSolutionPath(*source, *target, result),
+                              ".*is_success.*");
 }
 
 GTEST_TEST(ShortestPathTest, TwoStepLoopConstraint) {
@@ -1425,6 +1483,14 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
       spp.SolveShortestPath(source->id(), target->id(), options);
   ASSERT_TRUE(relaxed_result.is_success());
 
+  // We do not expect to find a path in the solution with zero tolerance.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      spp.GetSolutionPath(*source, *target, relaxed_result, 0 /* tolerance*/),
+      ".*No path.*");
+  // However, relaxing the tolerance (significantly) will find a path.
+  EXPECT_NO_THROW(spp.GetSolutionPath(*source, *target, relaxed_result,
+                                      0.9 /* tolerance*/));
+
   options.preprocessing = true;
   options.max_rounded_paths = 10;
   auto rounded_result =
@@ -1594,6 +1660,9 @@ GTEST_TEST(ShortestPathTest, NoPath) {
   EXPECT_EQ(result.get_solution_result(),
             SolutionResult::kInfeasibleConstraints);
 
+  DRAKE_EXPECT_THROWS_MESSAGE(spp.GetSolutionPath(*source, *target, result),
+                              ".*is_success.*");
+
   if (!MixedIntegerSolverAvailable()) {
     return;
   }
@@ -1754,6 +1823,9 @@ GTEST_TEST(ShortestPathTest, TobiasToyExample) {
   options.preprocessing = false;
   auto result = spp.SolveShortestPath(source->id(), target->id(), options);
   ASSERT_TRUE(result.is_success());
+  EXPECT_EQ(spp.GetSolutionPath(*source, *target, result),
+            std::vector<const Edge*>(
+                {source_to_p3, p3_to_e1, e1_to_p4, p4_to_p5, p5_to_target}));
 
   const std::forward_list<Vertex*> shortest_path{source, p3, e1,
                                                  p4,     p5, target};
@@ -1769,9 +1841,7 @@ GTEST_TEST(ShortestPathTest, TobiasToyExample) {
 
   // Test that solving with the known shortest path returns the same results.
   auto active_edges_result = spp.SolveConvexRestriction(
-      std::set<EdgeId>{source_to_p3->id(), p3_to_e1->id(), e1_to_p4->id(),
-                       p4_to_p5->id(), p5_to_target->id()},
-      options);
+      spp.GetSolutionPath(*source, *target, result), options);
   ASSERT_TRUE(active_edges_result.is_success());
   // The optimal costs should match.
   EXPECT_NEAR(result.get_optimal_cost(), active_edges_result.get_optimal_cost(),

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -665,91 +665,49 @@ GcsTrajectoryOptimization::SolvePath(
 
   const VectorXd empty_vector;
 
-  VertexId source_id = source.vertices_[0]->id();
+  Vertex* source_vertex = source.vertices_[0];
   Vertex* dummy_source = nullptr;
 
-  VertexId target_id = target.vertices_[0]->id();
+  Vertex* target_vertex = target.vertices_[0];
   Vertex* dummy_target = nullptr;
 
   if (source.size() != 1) {
     // Source subgraph has more than one region. Add a dummy source vertex.
     dummy_source = gcs_.AddVertex(Point(empty_vector), "Dummy source");
-    source_id = dummy_source->id();
+    source_vertex = dummy_source;
     for (const Vertex* v : source.vertices_) {
       AddEdge(*dummy_source, *v);
     }
   }
   const ScopeExit cleanup_dummy_source_before_returning([&]() {
     if (dummy_source != nullptr) {
-      gcs_.RemoveVertex(dummy_source->id());
+      gcs_.RemoveVertex(*dummy_source);
     }
   });
 
   if (target.size() != 1) {
     // Target subgraph has more than one region. Add a dummy target vertex.
     dummy_target = gcs_.AddVertex(Point(empty_vector), "Dummy target");
-    target_id = dummy_target->id();
+    target_vertex = dummy_target;
     for (const Vertex* v : target.vertices_) {
       AddEdge(*v, *dummy_target);
     }
   }
   const ScopeExit cleanup_dummy_target_before_returning([&]() {
     if (dummy_target != nullptr) {
-      gcs_.RemoveVertex(dummy_target->id());
+      gcs_.RemoveVertex(*dummy_target);
     }
   });
 
   solvers::MathematicalProgramResult result =
-      gcs_.SolveShortestPath(source_id, target_id, options);
+      gcs_.SolveShortestPath(*source_vertex, *target_vertex, options);
   if (!result.is_success()) {
     return {CompositeTrajectory<double>({}), result};
   }
 
-  // Extract the flow from the solution.
-  std::unordered_map<VertexId, std::vector<Edge*>> outgoing_edges;
-  std::unordered_map<EdgeId, double> flows;
-  for (Edge* edge : gcs_.Edges()) {
-    outgoing_edges[edge->u().id()].push_back(edge);
-    flows[edge->id()] = result.GetSolution(edge->phi());
-  }
-
-  // Extract the path by traversing the graph with a depth first search.
-  std::unordered_set<VertexId> visited_vertex_ids{source_id};
-  std::vector<VertexId> path_vertex_ids{source_id};
-  std::vector<Edge*> path_edges;
-  while (path_vertex_ids.back() != target_id) {
-    // Find the edge with the maximum flow from the current node.
-    double maximum_flow = 0;
-    VertexId max_flow_vertex_id;
-    Edge* max_flow_edge = nullptr;
-    for (Edge* e : outgoing_edges[path_vertex_ids.back()]) {
-      const double next_flow = flows[e->id()];
-      const VertexId next_vertex_id = e->v().id();
-
-      // If the edge has not been visited and has a flow greater than the
-      // current maximum, update the maximum flow and the vertex id.
-      if (visited_vertex_ids.count(e->v().id()) == 0 &&
-          next_flow > maximum_flow && next_flow > options.flow_tolerance) {
-        maximum_flow = next_flow;
-        max_flow_vertex_id = next_vertex_id;
-        max_flow_edge = e;
-      }
-    }
-
-    if (max_flow_edge == nullptr) {
-      // If no candidate edges are found, backtrack to the previous node and
-      // continue the search.
-      path_vertex_ids.pop_back();
-      DRAKE_DEMAND(!path_vertex_ids.empty());
-      continue;
-    } else {
-      // If the maximum flow is non-zero, add the vertex to the path and
-      // continue the search.
-      visited_vertex_ids.insert(max_flow_vertex_id);
-      path_vertex_ids.push_back(max_flow_vertex_id);
-      path_edges.push_back(max_flow_edge);
-    }
-  }
+  const double kTolerance = 1.0;  // take any path we can get.
+  std::vector<const Edge*> path_edges =
+      gcs_.GetSolutionPath(*source_vertex, *target_vertex, result, kTolerance);
 
   // Remove the dummy edges from the path.
   if (dummy_source != nullptr) {
@@ -763,19 +721,19 @@ GcsTrajectoryOptimization::SolvePath(
 
   // Extract the path from the edges.
   std::vector<copyable_unique_ptr<Trajectory<double>>> bezier_curves;
-  for (Edge* edge : path_edges) {
+  for (const Edge* e : path_edges) {
     // Extract phi from the solution to rescale the control points and duration
     // in case we get the relaxed solution.
-    const double phi_inv = 1 / result.GetSolution(edge->phi());
+    const double phi_inv = 1 / result.GetSolution(e->phi());
     // Extract the control points from the solution.
-    const int num_control_points = vertex_to_subgraph_[&edge->u()]->order() + 1;
+    const int num_control_points = vertex_to_subgraph_[&e->u()]->order() + 1;
     const MatrixX<double> edge_path_points =
         phi_inv *
-        Eigen::Map<MatrixX<double>>(result.GetSolution(edge->xu()).data(),
+        Eigen::Map<MatrixX<double>>(result.GetSolution(e->xu()).data(),
                                     num_positions(), num_control_points);
 
     // Extract the duration from the solution.
-    double h = phi_inv * result.GetSolution(edge->xu()).tail<1>().value();
+    double h = phi_inv * result.GetSolution(e->xu()).tail<1>().value();
     const double start_time =
         bezier_curves.empty() ? 0 : bezier_curves.back()->end_time();
 
@@ -784,30 +742,30 @@ GcsTrajectoryOptimization::SolvePath(
     // would result in a discontinuous trajectory for velocities and higher
     // derivatives.
     if (!(num_control_points == 1 &&
-          vertex_to_subgraph_[&edge->u()]->h_min_ == 0)) {
+          vertex_to_subgraph_[&e->u()]->h_min_ == 0)) {
       bezier_curves.emplace_back(std::make_unique<BezierCurve<double>>(
           start_time, start_time + h, edge_path_points));
     }
   }
 
   // Get the final control points from the solution.
-  const double phi_inv = 1 / result.GetSolution(path_edges.back()->phi());
+  const Edge& last_edge = *path_edges.back();
+  const double phi_inv = 1 / result.GetSolution(last_edge.phi());
   const int num_control_points =
-      vertex_to_subgraph_[&path_edges.back()->v()]->order() + 1;
+      vertex_to_subgraph_[&last_edge.v()]->order() + 1;
   const MatrixX<double> edge_path_points =
-      phi_inv * Eigen::Map<MatrixX<double>>(
-                    result.GetSolution(path_edges.back()->xv()).data(),
-                    num_positions(), num_control_points);
+      phi_inv *
+      Eigen::Map<MatrixX<double>>(result.GetSolution(last_edge.xv()).data(),
+                                  num_positions(), num_control_points);
 
-  double h =
-      phi_inv * result.GetSolution(path_edges.back()->xv()).tail<1>().value();
+  double h = phi_inv * result.GetSolution(last_edge.xv()).tail<1>().value();
   const double start_time =
       bezier_curves.empty() ? 0 : bezier_curves.back()->end_time();
 
   // Skip edges with a single control point that spend near zero time in the
   // region, since zero order continuity constraint is sufficient.
   if (!(num_control_points == 1 &&
-        vertex_to_subgraph_[&path_edges.back()->v()]->h_min_ == 0)) {
+        vertex_to_subgraph_[&last_edge.v()]->h_min_ == 0)) {
     bezier_curves.emplace_back(std::make_unique<BezierCurve<double>>(
         start_time, start_time + h, edge_path_points));
   }


### PR DESCRIPTION
... and use it in GcsTrajectoryOptimization.
Also adds introspection methods that curate the incoming and outgoing edges from a vertex.

+@wrangelvid for feature review, please.
cc @TobiaMarcucci 
(note that one test will fail until #19790 lands, but I'd like to start the review process here)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19792)
<!-- Reviewable:end -->
