### PR TITLE
Fix GraphOfConvexSets test tolerances

### DIFF
--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1775,10 +1775,10 @@ GTEST_TEST(ShortestPathTest, TobiasToyExample) {
   ASSERT_TRUE(active_edges_result.is_success());
   // The optimal costs should match.
   EXPECT_NEAR(result.get_optimal_cost(), active_edges_result.get_optimal_cost(),
-              1e-5);
+              2e-5);
   for (const auto* v : spp.Vertices()) {
     EXPECT_TRUE(CompareMatrices(result.GetSolution(v->x()),
-                                active_edges_result.GetSolution(v->x()), 1e-3));
+                                active_edges_result.GetSolution(v->x()), 2e-3));
   }
 
   // Test that forcing an edge not on the shortest path to be active yields a


### PR DESCRIPTION
Replaces #19793.

@drake-jenkins-bot linux-focal-clang-bazel-experimental-everything-valgrind-memcheck please
@drake-jenkins-bot linux-focal-clang-bazel-nightly-gurobi-release please

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19794)
<!-- Reviewable:end -->
