### PR TITLE
Handle bounding box constraints in MakeSemidefiniteRelaxation

### DIFF
--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -21,6 +21,10 @@ namespace solvers {
  See https://underactuated.mit.edu/optimization.html#sdp_relaxation for
  references and examples.
 
+ Note: Currently, programs using LinearEqualityConstraint will give tighter
+ relaxations than programs using LinearConstraint or BoundingBoxConstraint,
+ even if lower_bound == upper_bound. Prefer LinearEqualityConstraint.
+
  @throws std::exception if `prog` has costs and constraints which are not
  linear nor quadratic.
  */


### PR DESCRIPTION
Fixes the issue described in #19783.

On [this](https://github.com/bernhardpg/drake/blob/sdp_relaxation_bounding_box_constraints/solvers/semidefinite_relaxation.cc#L164) (and [this](https://github.com/bernhardpg/drake/blob/sdp_relaxation_bounding_box_constraints/solvers/semidefinite_relaxation.cc#L174)) line, we know that the value should be `-1.0` (and `1.0`). Do we prefer to keep it the way it is, which may be more readable, or should we rather use the constant values?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19795)
<!-- Reviewable:end -->
