### PR TITLE
fix names shown off-by-one in RationalForwardKinematics var names

### DIFF
--- a/multibody/rational/rational_forward_kinematics.cc
+++ b/multibody/rational/rational_forward_kinematics.cc
@@ -76,9 +76,9 @@ RationalForwardKinematics::RationalForwardKinematics(
       s_.push_back(s_angle);
       s_angles_.push_back(s_angle);
       cos_delta_.emplace_back(
-          fmt::format("cos_delta[{}]", cos_delta_.size() - 1));
+          fmt::format("cos_delta[{}]", cos_delta_.size()));
       sin_delta_.emplace_back(
-          fmt::format("sin_delta[{}]", cos_delta_.size() - 1));
+          fmt::format("sin_delta[{}]", sin_delta_.size()));
       sin_cos_.emplace_back(sin_delta_.back(), cos_delta_.back());
       sin_cos_set_.insert(sin_delta_.back());
       sin_cos_set_.insert(cos_delta_.back());


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19797)
<!-- Reviewable:end -->
