### PR TITLE
Implement MaybeGetFeasiblePoint for ConvexSet

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -48,6 +48,8 @@ void DefineGeometryOptimization(py::module m) {
         .def("IsEmpty", &ConvexSet::IsEmpty, cls_doc.IsEmpty.doc)
         .def("MaybeGetPoint", &ConvexSet::MaybeGetPoint,
             cls_doc.MaybeGetPoint.doc)
+        .def("MaybeGetFeasiblePoint", &ConvexSet::MaybeGetFeasiblePoint,
+            cls_doc.MaybeGetFeasiblePoint.doc)
         .def("PointInSet", &ConvexSet::PointInSet, py::arg("x"),
             py::arg("tol") = 1e-8, cls_doc.PointInSet.doc)
         .def("AddPointInSetConstraints", &ConvexSet::AddPointInSetConstraints,

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -47,6 +47,7 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(point.ambient_dimension(), 3)
         np.testing.assert_array_equal(point.x(), p)
         np.testing.assert_array_equal(point.MaybeGetPoint(), p)
+        np.testing.assert_array_equal(point.MaybeGetFeasiblePoint(), p)
         point.set_x(x=2*p)
         np.testing.assert_array_equal(point.x(), 2*p)
         point.set_x(x=p)
@@ -63,6 +64,8 @@ class TestGeometryOptimization(unittest.TestCase):
         np.testing.assert_array_equal(hpoly.b(), self.b)
         self.assertTrue(hpoly.PointInSet(x=[0, 0, 0], tol=0.0))
         self.assertFalse(hpoly.IsEmpty())
+        self.assertFalse(hpoly.MaybeGetFeasiblePoint() is None)
+        self.assertTrue(hpoly.PointInSet(hpoly.MaybeGetFeasiblePoint()))
         self.assertFalse(hpoly.IsBounded())
         new_vars, new_constraints = hpoly.AddPointInSetConstraints(
             self.prog, self.x)
@@ -173,6 +176,9 @@ class TestGeometryOptimization(unittest.TestCase):
         ellipsoid = mut.Hyperellipsoid(A=self.A, center=self.b)
         self.assertEqual(ellipsoid.ambient_dimension(), 3)
         self.assertFalse(ellipsoid.IsEmpty())
+        self.assertFalse(ellipsoid.MaybeGetFeasiblePoint() is None)
+        self.assertTrue(ellipsoid.PointInSet(
+            ellipsoid.MaybeGetFeasiblePoint()))
         np.testing.assert_array_equal(ellipsoid.A(), self.A)
         np.testing.assert_array_equal(ellipsoid.center(), self.b)
         self.assertTrue(ellipsoid.PointInSet(x=self.b, tol=0.0))
@@ -223,6 +229,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(sum2.num_terms(), 2)
         self.assertIsInstance(sum2.term(0), mut.Point)
         self.assertFalse(sum.IsEmpty())
+        self.assertFalse(sum.MaybeGetFeasiblePoint() is None)
+        self.assertTrue(sum.PointInSet(sum.MaybeGetFeasiblePoint()))
 
     def test_spectrahedron(self):
         s = mut.Spectrahedron()
@@ -232,12 +240,17 @@ class TestGeometryOptimization(unittest.TestCase):
         prog.AddLinearEqualityConstraint(X[0, 0] + X[1, 1] + X[2, 2], 1)
         s = mut.Spectrahedron(prog=prog)
         self.assertEqual(s.ambient_dimension(), 6)
+        self.assertFalse(s.IsEmpty())
+        self.assertFalse(s.MaybeGetFeasiblePoint() is None)
+        self.assertTrue(s.PointInSet(s.MaybeGetFeasiblePoint()))
 
     def test_v_polytope(self):
         mut.VPolytope()
         vertices = np.array([[0.0, 1.0, 2.0], [3.0, 7.0, 5.0]])
         vpoly = mut.VPolytope(vertices=vertices)
         self.assertFalse(vpoly.IsEmpty())
+        self.assertFalse(vpoly.MaybeGetFeasiblePoint() is None)
+        self.assertTrue(vpoly.PointInSet(vpoly.MaybeGetFeasiblePoint()))
         self.assertEqual(vpoly.ambient_dimension(), 2)
         np.testing.assert_array_equal(vpoly.vertices(), vertices)
         self.assertTrue(vpoly.PointInSet(x=[1.0, 5.0], tol=1e-8))
@@ -317,6 +330,8 @@ class TestGeometryOptimization(unittest.TestCase):
             lb=[-1, -1, -1], ub=[1, 1, 1])
         sum = mut.CartesianProduct(setA=point, setB=h_box)
         self.assertFalse(sum.IsEmpty())
+        self.assertFalse(sum.MaybeGetFeasiblePoint() is None)
+        self.assertTrue(sum.PointInSet(sum.MaybeGetFeasiblePoint()))
         self.assertEqual(sum.ambient_dimension(), 6)
         self.assertEqual(sum.num_factors(), 2)
         sum2 = mut.CartesianProduct(sets=[point, h_box])
@@ -336,6 +351,9 @@ class TestGeometryOptimization(unittest.TestCase):
             lb=[-1, -1, -1], ub=[1, 1, 1])
         intersect = mut.Intersection(setA=point, setB=h_box)
         self.assertFalse(intersect.IsEmpty())
+        self.assertFalse(intersect.MaybeGetFeasiblePoint() is None)
+        self.assertTrue(intersect.PointInSet(
+            intersect.MaybeGetFeasiblePoint()))
         self.assertEqual(intersect.ambient_dimension(), 3)
         self.assertEqual(intersect.num_elements(), 2)
         intersect2 = mut.Intersection(sets=[point, h_box])

--- a/geometry/optimization/cartesian_product.cc
+++ b/geometry/optimization/cartesian_product.cc
@@ -89,8 +89,7 @@ CartesianProduct::CartesianProduct(const QueryObject<double>& query_object,
 
   A_ = X_GF.rotation().matrix();
   b_ = X_GF.translation();
-  // N.B. We leave A_decomp_ unset here. It's only used by MaybeGetPoint and
-  // there it's irrelevant because a cylinder is never a point anyway.
+  A_decomp_ = Eigen::ColPivHouseholderQR<Eigen::MatrixXd>(*A_);
 }
 
 CartesianProduct::~CartesianProduct() = default;

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -56,6 +56,20 @@ std::optional<Eigen::VectorXd> ConvexSet::DoMaybeGetPoint() const {
   return std::nullopt;
 }
 
+std::optional<Eigen::VectorXd> ConvexSet::DoMaybeGetFeasiblePoint() const {
+  DRAKE_DEMAND(ambient_dimension() > 0);
+  solvers::MathematicalProgram prog;
+  auto point = prog.NewContinuousVariables(ambient_dimension());
+  AddPointInSetConstraints(&prog, point);
+  auto result = solvers::Solve(prog);
+  auto status = result.get_solution_result();
+  if (status == solvers::SolutionResult::kSolutionFound) {
+    return result.GetSolution(point);
+  } else {
+    return std::nullopt;
+  }
+}
+
 std::pair<VectorX<symbolic::Variable>,
           std::vector<solvers::Binding<solvers::Constraint>>>
 ConvexSet::AddPointInSetConstraints(

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -112,6 +112,18 @@ class ConvexSet : public ShapeReifier {
     return DoMaybeGetPoint();
   }
 
+  /** Returns a feasible point within this convex set if it is nonempty,
+  and nullopt otherwise. When ambient_dimension is zero, returns nullopt. */
+  std::optional<Eigen::VectorXd> MaybeGetFeasiblePoint() const {
+    if (ambient_dimension() == 0) {
+      return std::nullopt;
+    } else if (MaybeGetPoint().has_value()) {
+      return MaybeGetPoint();
+    } else {
+      return DoMaybeGetFeasiblePoint();
+    }
+  }
+
   /** Returns true iff the point x is contained in the set.  When
   ambient_dimension is zero, returns false. */
   bool PointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -232,6 +244,11 @@ class ConvexSet : public ShapeReifier {
   override with a custom implementation.
   @pre ambient_dimension() > 0 */
   virtual std::optional<Eigen::VectorXd> DoMaybeGetPoint() const;
+
+  /** Non-virtual interface implementation for MaybeGetFeasiblePoint(). The
+  default implementation solves a feasibility optimization problem, but
+  derived classes can override with a custom (more efficient) implementation. */
+  virtual std::optional<Eigen::VectorXd> DoMaybeGetFeasiblePoint() const;
 
   /** Non-virtual interface implementation for PointInSet().
   @pre x.size() == ambient_dimension()

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -48,6 +48,7 @@ GTEST_TEST(HPolyhedronTest, DefaultConstructor) {
   EXPECT_FALSE(H.IntersectsWith(H));
   EXPECT_TRUE(H.IsBounded());
   EXPECT_THROW(H.IsEmpty(), std::exception);
+  EXPECT_FALSE(H.MaybeGetFeasiblePoint().has_value());
   EXPECT_FALSE(H.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 
@@ -71,6 +72,10 @@ GTEST_TEST(HPolyhedronTest, UnitBoxTest) {
   // Test MaybeGetPoint.
   EXPECT_FALSE(H.MaybeGetPoint().has_value());
 
+  // Test MaybeGetFeasiblePoint.
+  ASSERT_TRUE(H.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H.PointInSet(H.MaybeGetFeasiblePoint().value()));
+
   // Test PointInSet.
   EXPECT_TRUE(H.PointInSet(Vector3d(.8, .3, -.9)));
   EXPECT_TRUE(H.PointInSet(Vector3d(-1.0, 1.0, 1.0)));
@@ -91,6 +96,10 @@ GTEST_TEST(HPolyhedronTest, UnitBoxTest) {
   HPolyhedron H_scene_graph(query, geom_id);
   EXPECT_TRUE(CompareMatrices(A, H_scene_graph.A()));
   EXPECT_TRUE(CompareMatrices(b, H_scene_graph.b()));
+
+  ASSERT_TRUE(H_scene_graph.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(
+      H_scene_graph.PointInSet(H_scene_graph.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HPolyhedronTest, Move) {
@@ -141,6 +150,11 @@ GTEST_TEST(HPolyhedronTest, ConstructorFromVPolytope) {
   EXPECT_TRUE(hpoly2.PointInSet(Eigen::Vector3d(1.99, -1.99, 3.99)));
   EXPECT_FALSE(hpoly2.PointInSet(Eigen::Vector3d(0, 3.01, 0)));
   EXPECT_FALSE(hpoly2.PointInSet(Eigen::Vector3d(-1.01, 0, 0)));
+
+  ASSERT_TRUE(hpoly1.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(hpoly1.PointInSet(hpoly1.MaybeGetFeasiblePoint().value()));
+  ASSERT_TRUE(hpoly2.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(hpoly2.PointInSet(hpoly2.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HPolyhedronTest, L1BallTest) {
@@ -162,6 +176,9 @@ GTEST_TEST(HPolyhedronTest, L1BallTest) {
   EXPECT_EQ(H_L1_box.ambient_dimension(), 3);
   EXPECT_TRUE(CompareMatrices(A, H_L1_box.A()));
   EXPECT_TRUE(CompareMatrices(b, H_L1_box.b()));
+
+  ASSERT_TRUE(H_L1_box.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H_L1_box.PointInSet(H_L1_box.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HPolyhedronTest, ArbitraryBoxTest) {
@@ -189,6 +206,9 @@ GTEST_TEST(HPolyhedronTest, ArbitraryBoxTest) {
   EXPECT_FALSE(H.PointInSet(out1_W));
   EXPECT_FALSE(H.PointInSet(out2_W));
 
+  ASSERT_TRUE(H.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H.PointInSet(H.MaybeGetFeasiblePoint().value()));
+
   EXPECT_TRUE(CheckAddPointInSetConstraints(H, in1_W));
   EXPECT_TRUE(CheckAddPointInSetConstraints(H, in2_W));
   EXPECT_FALSE(CheckAddPointInSetConstraints(H, out1_W));
@@ -212,6 +232,10 @@ GTEST_TEST(HPolyhedronTest, ArbitraryBoxTest) {
   EXPECT_TRUE(H_F.PointInSet(X_FW * in2_W));
   EXPECT_FALSE(H_F.PointInSet(X_FW * out1_W));
   EXPECT_FALSE(H_F.PointInSet(X_FW * out2_W));
+
+  const double kTol = 1e-14;
+  ASSERT_TRUE(H_F.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H_F.PointInSet(H_F.MaybeGetFeasiblePoint().value(), kTol));
 }
 
 GTEST_TEST(HPolyhedronTest, HalfSpaceTest) {
@@ -238,6 +262,9 @@ GTEST_TEST(HPolyhedronTest, HalfSpaceTest) {
   EXPECT_TRUE(H.PointInSet(in2_W));
   EXPECT_FALSE(H.PointInSet(out1_W));
   EXPECT_FALSE(H.PointInSet(out2_W));
+
+  ASSERT_TRUE(H.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H.PointInSet(H.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HPolyhedronTest, UnitBox6DTest) {
@@ -251,6 +278,9 @@ GTEST_TEST(HPolyhedronTest, UnitBox6DTest) {
   EXPECT_TRUE(H.PointInSet(in2_W));
   EXPECT_FALSE(H.PointInSet(out1_W));
   EXPECT_FALSE(H.PointInSet(out2_W));
+
+  ASSERT_TRUE(H.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H.PointInSet(H.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HPolyhedronTest, InscribedEllipsoidTest) {
@@ -358,6 +388,9 @@ GTEST_TEST(HpolyhedronTest, Scale) {
   EXPECT_TRUE(H_scaled.PointInSet(Vector3d::Constant(-0.99)));
   EXPECT_FALSE(H_scaled.PointInSet(Vector3d::Constant(-1.01)));
 
+  ASSERT_TRUE(H_scaled.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H_scaled.PointInSet(H_scaled.MaybeGetFeasiblePoint().value()));
+
   // Shrink to a point.
   const Vector3d kPoint = Vector3d::Constant(-1.0);
   H_scaled = H.Scale(0, kPoint);
@@ -415,6 +448,9 @@ GTEST_TEST(HPolyhedronTest, Scale3) {
   H_scaled = H.Scale(kScale, Vector3d{2, 0, 0});
   EXPECT_FALSE(H_scaled.PointInSet(Vector3d{1, 0, 0}));
   EXPECT_TRUE(H_scaled.PointInSet(Vector3d{-1, 0, 0}));
+
+  ASSERT_TRUE(H_scaled.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H_scaled.PointInSet(H_scaled.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HPolyhedronTest, CloneTest) {
@@ -576,6 +612,7 @@ GTEST_TEST(HPolyhedronTest, IsBoundedEmptyPolyhedron) {
   // clang-format on
   HPolyhedron H(A_infeasible, -Vector3d::Ones());
   EXPECT_TRUE(H.IsEmpty());
+  EXPECT_FALSE(H.MaybeGetFeasiblePoint().has_value());
 }
 
 GTEST_TEST(HPolyhedronTest, CartesianPowerTest) {
@@ -633,6 +670,9 @@ GTEST_TEST(HPolyhedronTest, CartesianProductTest) {
   VectorXd x_C{x_A.size() + x_B.size()};
   x_C << x_A, x_B;
   EXPECT_TRUE(H_C.PointInSet(x_C));
+
+  ASSERT_TRUE(H_C.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H_C.PointInSet(H_C.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HPolyhedronTest, AxisAlignedContainment) {
@@ -772,6 +812,8 @@ GTEST_TEST(HPolyhedronTest, ReduceToInfeasibleSet) {
 
   EXPECT_TRUE(H.IsEmpty());
   EXPECT_TRUE(H_reduced.IsEmpty());
+  EXPECT_FALSE(H.MaybeGetFeasiblePoint().has_value());
+  EXPECT_FALSE(H_reduced.MaybeGetFeasiblePoint().has_value());
 }
 
 GTEST_TEST(HPolyhedronTest, IsEmptyMinimalInequalitySet) {
@@ -839,6 +881,9 @@ GTEST_TEST(HPolyhedronTest, IntersectionTest) {
   EXPECT_FALSE(H_A.PointInSet(x_B));
   EXPECT_TRUE(H_B.PointInSet(x_B));
   EXPECT_FALSE(H_C.PointInSet(x_B));
+
+  ASSERT_TRUE(H_C.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H_C.PointInSet(H_C.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HPolyhedronTest, PontryaginDifferenceTestAxisAligned) {
@@ -850,6 +895,9 @@ GTEST_TEST(HPolyhedronTest, PontryaginDifferenceTestAxisAligned) {
 
   EXPECT_TRUE(CompareMatrices(H_C.A(), H_C_expected.A(), 1e-8));
   EXPECT_TRUE(CompareMatrices(H_C.b(), H_C_expected.b(), 1e-8));
+
+  ASSERT_TRUE(H_C.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(H_C.PointInSet(H_C.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HPolyhedronTest, PontryaginDifferenceTestSquareTriangle) {

--- a/geometry/optimization/test/hyperellipsoid_test.cc
+++ b/geometry/optimization/test/hyperellipsoid_test.cc
@@ -62,6 +62,10 @@ GTEST_TEST(HyperellipsoidTest, UnitSphereTest) {
   // Test IsEmpty (which is trivially false for Hyperellipsoid).
   EXPECT_FALSE(E.IsEmpty());
 
+  // Test MaybeGetFeasiblePoint
+  ASSERT_TRUE(E.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(E.PointInSet(E.MaybeGetFeasiblePoint().value()));
+
   // Test PointInSet.
   const Vector3d in1_W{.99, 0, 0}, in2_W{.5, .5, .5}, out1_W{1.01, 0, 0},
       out2_W{1.0, 1.0, 1.0};
@@ -105,6 +109,7 @@ GTEST_TEST(HyperellipsoidTest, DefaultCtor) {
   EXPECT_FALSE(dut.IntersectsWith(dut));
   EXPECT_TRUE(dut.IsBounded());
   EXPECT_THROW(dut.IsEmpty(), std::exception);
+  EXPECT_FALSE(dut.MaybeGetFeasiblePoint().has_value());
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 
@@ -196,6 +201,9 @@ GTEST_TEST(HyperellipsoidTest, ArbitraryEllipsoidTest) {
   EXPECT_FALSE(CheckAddPointInSetConstraints(E, out1_W));
   EXPECT_FALSE(CheckAddPointInSetConstraints(E, out2_W));
 
+  ASSERT_TRUE(E.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(E.PointInSet(E.MaybeGetFeasiblePoint().value()));
+
   // Test reference_frame frame.
   SourceId source_id = scene_graph->RegisterSource("F");
   FrameId frame_id = scene_graph->RegisterFrame(source_id, GeometryFrame("F"));
@@ -214,6 +222,9 @@ GTEST_TEST(HyperellipsoidTest, ArbitraryEllipsoidTest) {
   EXPECT_TRUE(E_F.PointInSet(X_FW * in2_W));
   EXPECT_FALSE(E_F.PointInSet(X_FW * out1_W));
   EXPECT_FALSE(E_F.PointInSet(X_FW * out2_W));
+
+  ASSERT_TRUE(E_F.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(E_F.PointInSet(E_F.MaybeGetFeasiblePoint().value()));
 
   // Test ToShapeWithPose.
   auto [shape, X_WG] = E.ToShapeWithPose();
@@ -250,6 +261,9 @@ GTEST_TEST(HyperellipsoidTest, UnitBall6DTest) {
   EXPECT_TRUE(E.PointInSet(in2_W));
   EXPECT_FALSE(E.PointInSet(out1_W));
   EXPECT_FALSE(E.PointInSet(out2_W));
+
+  ASSERT_TRUE(E.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(E.PointInSet(E.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(HyperellipsoidTest, CloneTest) {

--- a/geometry/optimization/test/intersection_test.cc
+++ b/geometry/optimization/test/intersection_test.cc
@@ -62,6 +62,10 @@ GTEST_TEST(IntersectionTest, BasicTest) {
   // Test IsEmpty
   EXPECT_FALSE(S.IsEmpty());
 
+  // Test MaybeGetFeasiblePoint.
+  ASSERT_TRUE(S.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(S.PointInSet(S.MaybeGetFeasiblePoint().value()));
+
   // Test ConvexSets constructor.
   ConvexSets sets;
   sets.emplace_back(P1);
@@ -81,6 +85,8 @@ GTEST_TEST(IntersectionTest, TwoIdenticalPoints) {
   EXPECT_TRUE(CompareMatrices(S.MaybeGetPoint().value(), P1.x()));
   EXPECT_TRUE(S.PointInSet(P1.x()));
   EXPECT_FALSE(S.IsEmpty());
+  ASSERT_TRUE(S.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(S.PointInSet(S.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(IntersectionTest, DefaultCtor) {
@@ -92,6 +98,7 @@ GTEST_TEST(IntersectionTest, DefaultCtor) {
   EXPECT_TRUE(dut.IsBounded());
   EXPECT_THROW(dut.IsEmpty(), std::exception);
   EXPECT_FALSE(dut.MaybeGetPoint().has_value());
+  EXPECT_FALSE(dut.MaybeGetFeasiblePoint().has_value());
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 
@@ -122,6 +129,8 @@ GTEST_TEST(IntersectionTest, TwoBoxes) {
   EXPECT_FALSE(S.PointInSet(Vector2d{2.1, 0.9}));
   EXPECT_FALSE(S.MaybeGetPoint().has_value());
   EXPECT_FALSE(S.IsEmpty());
+  ASSERT_TRUE(S.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(S.PointInSet(S.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(IntersectionTest, BoundedTest) {
@@ -261,6 +270,7 @@ GTEST_TEST(IntersectionTest, EmptyIntersectionTest2) {
   Intersection S(P1, P2);
 
   EXPECT_TRUE(S.IsEmpty());
+  EXPECT_FALSE(S.MaybeGetFeasiblePoint().has_value());
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/minkowski_sum_test.cc
+++ b/geometry/optimization/test/minkowski_sum_test.cc
@@ -63,6 +63,10 @@ GTEST_TEST(MinkowskiSumTest, BasicTest) {
   // Test IsEmpty.
   EXPECT_FALSE(S.IsEmpty());
 
+  // Test MaybeGetFeasiblePoint.
+  ASSERT_TRUE(S.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(S.PointInSet(S.MaybeGetFeasiblePoint().value()));
+
   // Test ConvexSets constructor.
   ConvexSets sets;
   sets.emplace_back(P1);
@@ -72,6 +76,8 @@ GTEST_TEST(MinkowskiSumTest, BasicTest) {
   EXPECT_EQ(S2.ambient_dimension(), 2);
   EXPECT_TRUE(S2.PointInSet(in));
   EXPECT_FALSE(S2.PointInSet(out));
+  ASSERT_TRUE(S2.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(S2.PointInSet(S2.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(MinkowskiSumTest, DefaultCtor) {
@@ -83,6 +89,7 @@ GTEST_TEST(MinkowskiSumTest, DefaultCtor) {
   EXPECT_TRUE(dut.IsBounded());
   EXPECT_THROW(dut.IsEmpty(), std::exception);
   EXPECT_FALSE(dut.MaybeGetPoint().has_value());
+  EXPECT_FALSE(dut.MaybeGetFeasiblePoint().has_value());
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 }
 
@@ -137,6 +144,8 @@ GTEST_TEST(MinkowskiSumTest, FromSceneGraph) {
     EXPECT_TRUE(S.PointInSet(in_W.col(i)));
     EXPECT_FALSE(S.PointInSet(out_W.col(i)));
   }
+  ASSERT_TRUE(S.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(S.PointInSet(S.MaybeGetFeasiblePoint().value()));
 
   // Test reference_frame frame.
   SourceId source_id = scene_graph->RegisterSource("F");
@@ -157,6 +166,8 @@ GTEST_TEST(MinkowskiSumTest, FromSceneGraph) {
     EXPECT_TRUE(S2.PointInSet(in_F.col(i)));
     EXPECT_FALSE(S2.PointInSet(out_F.col(i)));
   }
+  ASSERT_TRUE(S2.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(S2.PointInSet(S2.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(MinkowskiSumTest, TwoBoxes) {
@@ -167,6 +178,8 @@ GTEST_TEST(MinkowskiSumTest, TwoBoxes) {
   EXPECT_FALSE(S.PointInSet(Vector2d{-1, 2.9}));
   EXPECT_FALSE(S.PointInSet(Vector2d{-1.01, 3}));
   EXPECT_FALSE(S.MaybeGetPoint().has_value());
+  ASSERT_TRUE(S.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(S.PointInSet(S.MaybeGetFeasiblePoint().value()));
 }
 
 GTEST_TEST(MinkowskiSumTest, CloneTest) {
@@ -289,6 +302,7 @@ GTEST_TEST(MinkowskiSumTest, EmptyMinkowskiSumTest) {
   const MinkowskiSum S(P1, H1);
 
   EXPECT_TRUE(S.IsEmpty());
+  EXPECT_FALSE(S.MaybeGetFeasiblePoint().has_value());
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/point_test.cc
+++ b/geometry/optimization/test/point_test.cc
@@ -59,6 +59,10 @@ GTEST_TEST(PointTest, BasicTest) {
   // Test IsEmpty (which is trivially false for Point).
   EXPECT_FALSE(P.IsEmpty());
 
+  // Test MaybeGetFeasiblePoint.
+  ASSERT_TRUE(P.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(P.PointInSet(P.MaybeGetFeasiblePoint().value()));
+
   // Test set_x().
   const Vector3d p2_W{6.2, -.23, -8.2};
   P.set_x(p2_W);
@@ -75,6 +79,7 @@ GTEST_TEST(PointTest, DefaultCtor) {
   EXPECT_TRUE(dut.IsBounded());
   EXPECT_THROW(dut.IsEmpty(), std::exception);
   EXPECT_FALSE(dut.MaybeGetPoint().has_value());
+  EXPECT_FALSE(dut.MaybeGetFeasiblePoint().has_value());
   EXPECT_FALSE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
 
   Point P;

--- a/geometry/optimization/test/spectrahedron_test.cc
+++ b/geometry/optimization/test/spectrahedron_test.cc
@@ -24,6 +24,7 @@ GTEST_TEST(SpectrahedronTest, DefaultCtor) {
   Spectrahedron spect;
   EXPECT_EQ(spect.ambient_dimension(), 0);
   EXPECT_THROW(spect.IsEmpty(), std::exception);
+  EXPECT_FALSE(spect.MaybeGetFeasiblePoint().has_value());
 }
 
 GTEST_TEST(SpectrahedronTest, Attributes) {
@@ -70,6 +71,8 @@ GTEST_TEST(SpectrahedronTest, TrivialSdp1) {
   EXPECT_TRUE(spect.PointInSet(x_star, kTol));
   EXPECT_FALSE(spect.PointInSet(x_bad, kTol));
   EXPECT_FALSE(spect.MaybeGetPoint().has_value());
+  ASSERT_TRUE(spect.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(spect.PointInSet(spect.MaybeGetFeasiblePoint().value(), kTol));
 
   MathematicalProgram prog2;
   auto x2 = prog2.NewContinuousVariables<6>("x");
@@ -257,6 +260,7 @@ GTEST_TEST(SpectrahedronTest, NontriviallyEmpty) {
 
   Spectrahedron spect(prog);
   EXPECT_TRUE(spect.IsEmpty());
+  EXPECT_FALSE(spect.MaybeGetFeasiblePoint().has_value());
 }
 
 }  // namespace


### PR DESCRIPTION
Towards #19717.

This method simply computes and returns a point within a convex set. If the set is empty or has ambient dimension zero, it instead returns nullopt. In this PR, I provide a base class implementation, that tries MaybeGetPoint, and otherwise just solves a simple optimization problem. I also added test cases for all derived classes. Once this PR lands, I'll go through and start adding more efficient implementations for certain subclasses.

+@hongkai-dai for feature review

EDIT: Sorry about the repeated updates. I had to mess with the tolerances a bit to get it to work on the default solvers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19804)
<!-- Reviewable:end -->
