### PR TITLE
[tutorials] Highlight inertia visualization in multibody tutorial

### DIFF
--- a/tutorials/authoring_multibody_simulation.ipynb
+++ b/tutorials/authoring_multibody_simulation.ipynb
@@ -53,18 +53,13 @@
     "import os\n",
     "\n",
     "from pydrake.common import temp_directory\n",
-    "from pydrake.geometry import (\n",
-    "    MeshcatVisualizer,\n",
-    "    MeshcatVisualizerParams,\n",
-    "    Role,\n",
-    "    StartMeshcat,\n",
-    ")\n",
+    "from pydrake.geometry import StartMeshcat\n",
     "from pydrake.math import RigidTransform, RollPitchYaw\n",
     "from pydrake.multibody.parsing import Parser\n",
     "from pydrake.multibody.plant import AddMultibodyPlantSceneGraph\n",
     "from pydrake.systems.analysis import Simulator\n",
     "from pydrake.systems.framework import DiagramBuilder\n",
-    "from pydrake.visualization import ModelVisualizer"
+    "from pydrake.visualization import AddDefaultVisualization, ModelVisualizer"
    ]
   },
   {
@@ -88,7 +83,9 @@
     "\n",
     "Drake provides a `ModelVisualizer` class to visualize models interactively. This class will help as we start to produce our own robot description files, or port description files over from another simulator. We'll show examples in the cells below, using a couple of pre-existing models provided by Drake.\n",
     "\n",
-    "After running each of the two example cells, switch to the MeshCat tab to see the robot. Be sure to check out both the \"illustration\" and \"proximity\" geometries (the Drake names for visual and collision) using the MeshCat control panel. Click **Open Controls** to unfold the control panel.  The geometry checkboxes are under the **Scene / drake** menu. Try adjusting the sliding bars to observe the kinematics of the robot."
+    "After running each of the two example cells, switch to the MeshCat tab to see the robot. Click **Open Controls** to unfold the control panel. Try adjusting the sliding bars to observe the kinematics of the robot.\n",
+    "\n",
+    "In the control panel, unfold the **▶ Scene / ▶ drake** menu. By default, only the \"illustration\" geomtry is displayed (the Drake name for visual geometry). Toggle the \"proximity\" checkbox to also show the collision geometry (in red), or the \"inertia\" checkbox to also show each body's equivalent inertia ellipsoid (in blue). Use the α sliders to adjust the transparancy of the geometry. When debugging a simulation, it's important to keep these extra views in mind; usually, the illustration geometry does not tell the full story of simulated dynamics."
    ]
   },
   {
@@ -430,13 +427,11 @@
     "    X_WorldSugar = X_WorldTable.multiply(X_TableSugar)\n",
     "    plant.SetDefaultFreeBodyPose(sugar_box, X_WorldSugar)\n",
     "    \n",
-    "    # Add visualizer to visualize the geometries.\n",
-    "    visualizer = MeshcatVisualizer.AddToBuilder(\n",
-    "        builder, scene_graph, meshcat,\n",
-    "        MeshcatVisualizerParams(role=Role.kPerception, prefix=\"visual\"))\n",
+    "    # Add visualization to see the geometries.\n",
+    "    AddDefaultVisualization(builder=builder, meshcat=meshcat)\n",
     "\n",
     "    diagram = builder.Build()\n",
-    "    return diagram, visualizer"
+    "    return diagram"
    ]
   },
   {
@@ -465,12 +460,12 @@
     "    return simulator\n",
     "\n",
     "def run_simulation(sim_time_step):\n",
-    "    diagram, visualizer = create_scene(sim_time_step)\n",
+    "    diagram = create_scene(sim_time_step)\n",
     "    simulator = initialize_simulation(diagram)\n",
-    "    visualizer.StartRecording()\n",
+    "    meshcat.StartRecording()\n",
     "    finish_time = 0.1 if test_mode else 2.0\n",
     "    simulator.AdvanceTo(finish_time)\n",
-    "    visualizer.PublishRecording()\n",
+    "    meshcat.PublishRecording()\n",
     "\n",
     "# Run the simulation with a small time step. Try gradually increasing it!\n",
     "run_simulation(sim_time_step=0.0001)"


### PR DESCRIPTION
Add text telling users how to unfold and see the inertia geometry.

Update the simple simulation to use default visualization and record the proximity geometry and contact forces as well.

(Note that meshcat-recorded animations won't show the inertia ellipsoids until #19813 lands.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19812)
<!-- Reviewable:end -->
