### PR TITLE
Add MathematicalProgramResult::get_decision_variable_index()

### DIFF
--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -101,6 +101,12 @@ class MathematicalProgramResult final {
                                   std::numeric_limits<double>::quiet_NaN());
   }
 
+  /** Gets decision_variable_index. */
+  const std::optional<std::unordered_map<symbolic::Variable::Id, int>>&
+  get_decision_variable_index() const {
+    return decision_variable_index_;
+  }
+
   /** Sets SolutionResult. */
   void set_solution_result(SolutionResult solution_result) {
     solution_result_ = solution_result;

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -41,6 +41,7 @@ TEST_F(MathematicalProgramResultTest, DefaultConstructor) {
 TEST_F(MathematicalProgramResultTest, Setters) {
   MathematicalProgramResult result;
   result.set_decision_variable_index(decision_variable_index_);
+  EXPECT_EQ(result.get_decision_variable_index(), decision_variable_index_);
   EXPECT_TRUE(CompareMatrices(
       result.get_x_val(),
       Eigen::VectorXd::Constant(decision_variable_index_.size(),


### PR DESCRIPTION
This enables, for instance, callers that want to add new variables to an existing `MathematicalProgramResult` (who can get the current index, add to it, and then `set_decision_variable_index()`).

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19814)
<!-- Reviewable:end -->
