### PR TITLE
[workspace] Upgrade meshcat to latest commit

### DIFF
--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -10,8 +10,8 @@ def meshcat_repository(
         Updating this commit requires local testing; see
         drake/tools/workspace/meshcat/README.md for details.
         """,
-        commit = "4b4f8ffbaa5f609352ea6227bd5ae8207b579c70",
-        sha256 = "2f7131aa47c38d21f7904ecc07344bb12538d495668682117e0e7fbd28ad893b",  # noqa
+        commit = "120cbc1f57b10a15efac2b79f38f19b8bdd44722",
+        sha256 = "f8a63d3453470d19fd2667c551ae2bde99c9afacd3091c73f960eeff211273fa",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Meshcat has had a bugfix that allows glTF files to cast/receive shadows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19817)
<!-- Reviewable:end -->
