### PR TITLE
Adjust value in GraphOfConvexSets::GetGraphvizString test

### DIFF
--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1986,7 +1986,7 @@ GTEST_TEST(ShortestPathTest, Figure9) {
 GTEST_TEST(ShortestPathTest, Graphviz) {
   GraphOfConvexSets g;
   auto source = g.AddVertex(Point(Vector2d{1.0, 2.}), "source");
-  auto target = g.AddVertex(Point(Vector1d{1e-6}), "target");
+  auto target = g.AddVertex(Point(Vector1d{1e-5}), "target");
   g.AddEdge(*source, *target, "edge");
 
   GraphOfConvexSetsOptions options;
@@ -2011,7 +2011,7 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   EXPECT_THAT(g.GetGraphvizString(result, false, 2, false),
               AllOf(HasSubstr("x = [1.00 2.00]"), HasSubstr("x = [0.00]")));
   EXPECT_THAT(g.GetGraphvizString(result, false, 2, true),
-              AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-06]")));
+              AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-05]")));
 }
 
 }  // namespace optimization


### PR DESCRIPTION
@Xining-Du reported that building drake with slightly different dependencies caused this test to fail -- 1e-6 was being rounded down to 0. 1e-5 is just as good for this test, but resolves that issue.

+@Xining-Du for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19818)
<!-- Reviewable:end -->
