### PR TITLE
Removes VertexId and EdgeId overloads from GraphOfConvexSets API

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -622,33 +622,19 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("name") = "", py_rvp::reference_internal,
             cls_doc.AddVertex.doc)
         .def("AddEdge",
-            py::overload_cast<GraphOfConvexSets::VertexId,
-                GraphOfConvexSets::VertexId, std::string>(
-                &GraphOfConvexSets::AddEdge),
-            py::arg("u_id"), py::arg("v_id"), py::arg("name") = "",
-            py_rvp::reference_internal, cls_doc.AddEdge.doc_by_id)
-        .def("AddEdge",
-            py::overload_cast<const GraphOfConvexSets::Vertex&,
-                const GraphOfConvexSets::Vertex&, std::string>(
+            py::overload_cast<GraphOfConvexSets::Vertex*,
+                GraphOfConvexSets::Vertex*, std::string>(
                 &GraphOfConvexSets::AddEdge),
             py::arg("u"), py::arg("v"), py::arg("name") = "",
-            py_rvp::reference_internal, cls_doc.AddEdge.doc_by_reference)
+            py_rvp::reference_internal, cls_doc.AddEdge.doc)
         .def("RemoveVertex",
-            py::overload_cast<GraphOfConvexSets::VertexId>(
+            py::overload_cast<GraphOfConvexSets::Vertex*>(
                 &GraphOfConvexSets::RemoveVertex),
-            py::arg("vertex_id"), cls_doc.RemoveVertex.doc_by_id)
-        .def("RemoveVertex",
-            py::overload_cast<const GraphOfConvexSets::Vertex&>(
-                &GraphOfConvexSets::RemoveVertex),
-            py::arg("vertex"), cls_doc.RemoveVertex.doc_by_reference)
+            py::arg("vertex"), cls_doc.RemoveVertex.doc)
         .def("RemoveEdge",
-            py::overload_cast<GraphOfConvexSets::EdgeId>(
+            py::overload_cast<GraphOfConvexSets::Edge*>(
                 &GraphOfConvexSets::RemoveEdge),
-            py::arg("edge_id"), cls_doc.RemoveEdge.doc_by_id)
-        .def("RemoveEdge",
-            py::overload_cast<const GraphOfConvexSets::Edge&>(
-                &GraphOfConvexSets::RemoveEdge),
-            py::arg("edge"), cls_doc.RemoveEdge.doc_by_reference)
+            py::arg("edge"), cls_doc.RemoveEdge.doc)
         .def("Vertices",
             overload_cast_explicit<std::vector<GraphOfConvexSets::Vertex*>>(
                 &GraphOfConvexSets::Vertices),
@@ -666,21 +652,13 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.GetGraphvizString.doc)
         .def("SolveShortestPath",
             overload_cast_explicit<solvers::MathematicalProgramResult,
-                GraphOfConvexSets::VertexId, GraphOfConvexSets::VertexId,
-                const GraphOfConvexSetsOptions&>(
-                &GraphOfConvexSets::SolveShortestPath),
-            py::arg("source_id"), py::arg("target_id"),
-            py::arg("options") = GraphOfConvexSetsOptions(),
-            cls_doc.SolveShortestPath.doc_by_id)
-        .def("SolveShortestPath",
-            overload_cast_explicit<solvers::MathematicalProgramResult,
                 const GraphOfConvexSets::Vertex&,
                 const GraphOfConvexSets::Vertex&,
                 const GraphOfConvexSetsOptions&>(
                 &GraphOfConvexSets::SolveShortestPath),
             py::arg("source"), py::arg("target"),
             py::arg("options") = GraphOfConvexSetsOptions(),
-            cls_doc.SolveShortestPath.doc_by_reference)
+            cls_doc.SolveShortestPath.doc)
         .def("GetSolutionPath", &GraphOfConvexSets::GetSolutionPath,
             py::arg("source"), py::arg("target"), py::arg("result"),
             py::arg("tolerance") = 1e-3, cls_doc.GetSolutionPath.doc)
@@ -688,6 +666,37 @@ void DefineGeometryOptimization(py::module m) {
             &GraphOfConvexSets::SolveConvexRestriction, py::arg("active_edges"),
             py::arg("options") = GraphOfConvexSetsOptions(),
             cls_doc.SolveConvexRestriction.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    graph_of_convex_sets
+        .def("AddEdge",
+            WrapDeprecated(cls_doc.AddEdge.doc_deprecated,
+                py::overload_cast<GraphOfConvexSets::VertexId,
+                    GraphOfConvexSets::VertexId, std::string>(
+                    &GraphOfConvexSets::AddEdge)),
+            py::arg("u_id"), py::arg("v_id"), py::arg("name") = "",
+            py_rvp::reference_internal, cls_doc.AddEdge.doc_deprecated)
+        .def("RemoveVertex",
+            WrapDeprecated(cls_doc.RemoveVertex.doc_deprecated,
+                py::overload_cast<GraphOfConvexSets::VertexId>(
+                    &GraphOfConvexSets::RemoveVertex)),
+            py::arg("vertex_id"), cls_doc.RemoveVertex.doc_deprecated)
+        .def("RemoveEdge",
+            WrapDeprecated(cls_doc.RemoveEdge.doc_deprecated,
+                py::overload_cast<GraphOfConvexSets::EdgeId>(
+                    &GraphOfConvexSets::RemoveEdge)),
+            py::arg("edge_id"), cls_doc.RemoveEdge.doc_deprecated)
+        .def("SolveShortestPath",
+            WrapDeprecated(cls_doc.SolveShortestPath.doc_deprecated,
+                overload_cast_explicit<solvers::MathematicalProgramResult,
+                    GraphOfConvexSets::VertexId, GraphOfConvexSets::VertexId,
+                    const GraphOfConvexSetsOptions&>(
+                    &GraphOfConvexSets::SolveShortestPath)),
+            py::arg("source_id"), py::arg("target_id"),
+            py::arg("options") = GraphOfConvexSetsOptions(),
+            cls_doc.SolveShortestPath.doc_deprecated);
+#pragma GCC diagnostic pop
   }
 
   // NOLINTNEXTLINE(readability/fn_size)

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -259,31 +259,33 @@ Vertex* GraphOfConvexSets::AddVertex(const ConvexSet& set, std::string name) {
 
 Edge* GraphOfConvexSets::AddEdge(VertexId u_id, VertexId v_id,
                                  std::string name) {
-  auto u_iter = vertices_.find(u_id);
-  DRAKE_DEMAND(u_iter != vertices_.end());
-  auto v_iter = vertices_.find(v_id);
-  DRAKE_DEMAND(v_iter != vertices_.end());
+  return AddEdge(vertices_.at(u_id).get(), vertices_.at(v_id).get(),
+                 std::move(name));
+}
 
+Edge* GraphOfConvexSets::AddEdge(Vertex* u, Vertex* v, std::string name) {
+  DRAKE_DEMAND(u != nullptr);
+  DRAKE_DEMAND(v != nullptr);
   if (name.empty()) {
     name = fmt::format("e{}", edges_.size());
   }
   EdgeId id = EdgeId::get_new_id();
-  auto [iter, success] = edges_.try_emplace(
-      id, new Edge(id, u_iter->second.get(), v_iter->second.get(), name));
+  auto [iter, success] = edges_.try_emplace(id, new Edge(id, u, v, name));
   DRAKE_DEMAND(success);
   Edge* e = iter->second.get();
-  u_iter->second->AddOutgoingEdge(e);
-  v_iter->second->AddIncomingEdge(e);
+  u->AddOutgoingEdge(e);
+  v->AddIncomingEdge(e);
   return e;
 }
 
-Edge* GraphOfConvexSets::AddEdge(const Vertex& u, const Vertex& v,
-                                 std::string name) {
-  return AddEdge(u.id(), v.id(), std::move(name));
+void GraphOfConvexSets::RemoveVertex(VertexId vertex_id) {
+  RemoveVertex(vertices_.at(vertex_id).get());
 }
 
-void GraphOfConvexSets::RemoveVertex(VertexId vertex_id) {
-  DRAKE_DEMAND(vertices_.find(vertex_id) != vertices_.end());
+void GraphOfConvexSets::RemoveVertex(Vertex* vertex) {
+  DRAKE_THROW_UNLESS(vertex != nullptr);
+  VertexId vertex_id = vertex->id();
+  DRAKE_THROW_UNLESS(vertices_.count(vertex_id) > 0);
   for (auto it = edges_.begin(); it != edges_.end();) {
     if (it->second->u().id() == vertex_id ||
         it->second->v().id() == vertex_id) {
@@ -295,20 +297,16 @@ void GraphOfConvexSets::RemoveVertex(VertexId vertex_id) {
   vertices_.erase(vertex_id);
 }
 
-void GraphOfConvexSets::RemoveVertex(const Vertex& vertex) {
-  RemoveVertex(vertex.id());
-}
-
 void GraphOfConvexSets::RemoveEdge(EdgeId edge_id) {
-  DRAKE_DEMAND(edges_.find(edge_id) != edges_.end());
-  Edge* e = edges_.at(edge_id).get();
-  e->u().RemoveOutgoingEdge(e);
-  e->v().RemoveIncomingEdge(e);
-  edges_.erase(edge_id);
+  RemoveEdge(edges_.at(edge_id).get());
 }
 
-void GraphOfConvexSets::RemoveEdge(const Edge& edge) {
-  RemoveEdge(edge.id());
+void GraphOfConvexSets::RemoveEdge(Edge* edge) {
+  DRAKE_THROW_UNLESS(edge != nullptr);
+  DRAKE_THROW_UNLESS(edges_.count(edge->id()) > 0);
+  edge->u().RemoveOutgoingEdge(edge);
+  edge->v().RemoveIncomingEdge(edge);
+  edges_.erase(edge->id());
 }
 
 std::vector<Vertex*> GraphOfConvexSets::Vertices() {
@@ -727,7 +725,16 @@ void GraphOfConvexSets::AddPerspectiveConstraint(
 
 MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     VertexId source_id, VertexId target_id,
+    const GraphOfConvexSetsOptions& options) const {
+  return SolveShortestPath(*vertices_.at(source_id), *vertices_.at(target_id),
+                           options);
+}
+
+MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
+    const Vertex& source, const Vertex& target,
     const GraphOfConvexSetsOptions& specified_options) const {
+  VertexId source_id = source.id();
+  VertexId target_id = target.id();
   if (vertices_.find(source_id) == vertices_.end()) {
     throw std::runtime_error(fmt::format(
         "Source vertex {} is not a vertex in this GraphOfConvexSets.",
@@ -1219,12 +1226,6 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
   }
 
   return result;
-}
-
-MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
-    const Vertex& source, const Vertex& target,
-    const GraphOfConvexSetsOptions& options) const {
-  return SolveShortestPath(source.id(), target.id(), options);
 }
 
 std::vector<const Edge*> GraphOfConvexSets::GetSolutionPath(

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -420,42 +420,39 @@ class GraphOfConvexSets {
   /** Adds an edge to the graph from VertexId @p u_id to VertexId @p v_id.  The
   ids must refer to valid vertices in this graph. If @p name is empty then a
   default name will be provided.
-  @pydrake_mkdoc_identifier{by_id}
   */
+  DRAKE_DEPRECATED("2023-11-01", "Use the overload that takes Vertex* instead.")
   Edge* AddEdge(VertexId u_id, VertexId v_id, std::string name = "");
 
   /** Adds an edge to the graph from Vertex @p u to Vertex @p v.  The
   vertex references must refer to valid vertices in this graph. If @p name is
   empty then a default name will be provided.
-  @pydrake_mkdoc_identifier{by_reference}
   */
-  Edge* AddEdge(const Vertex& u, const Vertex& v, std::string name = "");
+  Edge* AddEdge(Vertex* u, Vertex* v, std::string name = "");
 
   /** Removes vertex @p vertex_id from the graph as well as any edges from or to
   the vertex. Runtime is O(nₑ) where nₑ is the number of edges in the graph.
   @pre The vertex must be part of the graph.
-  @pydrake_mkdoc_identifier{by_id}
   */
+  DRAKE_DEPRECATED("2023-11-01", "Use the overload that takes Vertex* instead.")
   void RemoveVertex(VertexId vertex_id);
 
   /** Removes vertex @p vertex from the graph as well as any edges from or to
   the vertex. Runtime is O(nₑ) where nₑ is the number of edges in the graph.
   @pre The vertex must be part of the graph.
-  @pydrake_mkdoc_identifier{by_reference}
   */
-  void RemoveVertex(const Vertex& vertex);
+  void RemoveVertex(Vertex* vertex);
 
   /** Removes edge @p edge_id from the graph.
   @pre The edge must be part of the graph.
-  @pydrake_mkdoc_identifier{by_id}
   */
+  DRAKE_DEPRECATED("2023-11-01", "Use the overload that takes Vertex* instead.")
   void RemoveEdge(EdgeId edge_id);
 
   /** Removes edge @p edge from the graph.
   @pre The edge must be part of the graph.
-  @pydrake_mkdoc_identifier{by_reference}
   */
-  void RemoveEdge(const Edge& edge);
+  void RemoveEdge(Edge* edge);
 
   /** Returns mutable pointers to the vertices stored in the graph. */
   std::vector<Vertex*> Vertices();
@@ -511,20 +508,15 @@ class GraphOfConvexSets {
   @throws std::exception if any of the costs or constraints in the graph are
   incompatible with the shortest path formulation or otherwise unsupported. All
   costs must be non-negative for all values of the continuous variables.
-
-  @pydrake_mkdoc_identifier{by_id}
-  */
-  solvers::MathematicalProgramResult SolveShortestPath(
-      VertexId source_id, VertexId target_id,
-      const GraphOfConvexSetsOptions& options =
-          GraphOfConvexSetsOptions()) const;
-
-  /** Convenience overload that takes const reference arguments for source and
-  target.
-  @pydrake_mkdoc_identifier{by_reference}
   */
   solvers::MathematicalProgramResult SolveShortestPath(
       const Vertex& source, const Vertex& target,
+      const GraphOfConvexSetsOptions& options =
+          GraphOfConvexSetsOptions()) const;
+
+  DRAKE_DEPRECATED("2023-11-01", "Use the overload that takes Vertex& instead.")
+  solvers::MathematicalProgramResult SolveShortestPath(
+      VertexId source_id, VertexId target_id,
       const GraphOfConvexSetsOptions& options =
           GraphOfConvexSetsOptions()) const;
 
@@ -589,8 +581,6 @@ class GraphOfConvexSets {
       solvers::MathematicalProgram* prog,
       const solvers::Binding<solvers::Constraint>& binding,
       const solvers::VectorXDecisionVariable& vars) const;
-
-  // TODO(russt): remove VertexId and EdgeId from the public API.
 
   // Note: we use VertexId and EdgeId (vs e.g. Vertex* and Edge*) here to
   // provide consistent ordering of the vertices/edges. This is important for

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -401,8 +401,8 @@ class GcsTrajectoryOptimization final {
 
   // Adds a Edge to gcs_ with the name "{u.name} -> {v.name}".
   geometry::optimization::GraphOfConvexSets::Edge* AddEdge(
-      const geometry::optimization::GraphOfConvexSets::Vertex& u,
-      const geometry::optimization::GraphOfConvexSets::Vertex& v);
+      geometry::optimization::GraphOfConvexSets::Vertex* u,
+      geometry::optimization::GraphOfConvexSets::Vertex* v);
 
   geometry::optimization::GraphOfConvexSets gcs_;
 


### PR DESCRIPTION
BREAKING CHANGE.

The class is marked experimental, so some changes are made without deprecation.

- Deprecated the VertexId and EdgeId overloads. In particular, python users should get a useful message telling them to use the other overload.

- AddEdge, RemoveVertex, and RemoveEdge have changed (without deprecation) from taking `const Vertex&` to `Vertex*`. The previous constness was a lie. This change will not impact python users.

+@wrangelvid for feature review, and confirmation that we like the changes.
+@jwnimmer-tri for super platform review, and approval of my decisions and half-deprecation strategy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19825)
<!-- Reviewable:end -->
