### PR TITLE
Modernize articulated body algorithm test

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -546,6 +546,7 @@ drake_cc_googletest(
     name = "articulated_body_algorithm_test",
     deps = [
         ":tree",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 


### PR DESCRIPTION
(This is a yak shave for #18442.)

In the near future Mobilizers won't be independently definable like Joints, they will instead be created already in depth-first order from the computed SpanningForestModel. MultibodyTree's articulated body algorithm test is the only one that defined its own Mobilizer and then used it like a Joint, so can't be easily converted to the new paradigm. 

This PR removes the bespoke Mobilizer, adds a massless body to provide the desired mobility, and models the system using only Joints (corresponding Mobilizers get created under the covers). Recalculated the ABIs, added some comments and a little cleanup.

+@amcastro-tri for feature review, please

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19832)
<!-- Reviewable:end -->
