### PR TITLE
Don't install drake_models from manipulation_station

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -16,24 +16,30 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 models_filegroup(
-    name = "models",
-    extra_srcs = [
-        "@drake_models//:manipulation_station/bin.mtl",
-        "@drake_models//:manipulation_station/bin.obj",
-        "@drake_models//:manipulation_station/bin.png",
-        "@drake_models//:manipulation_station/table_wide.mtl",
-        "@drake_models//:manipulation_station/table_wide.obj",
-        "@drake_models//:manipulation_station/table_wide.png",
-        "@drake_models//:manipulation_station/shelves.mtl",
-        "@drake_models//:manipulation_station/shelves.obj",
-        "@drake_models//:manipulation_station/shelves.png",
-    ],
+    name = "installed_models",
     visibility = ["//visibility:public"],
 )
 
 install_data(
     name = "install_data",
-    data = [":models"],
+    data = [":installed_models"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "models",
+    srcs = [
+        ":installed_models",
+        "@drake_models//:manipulation_station/bin.mtl",
+        "@drake_models//:manipulation_station/bin.obj",
+        "@drake_models//:manipulation_station/bin.png",
+        "@drake_models//:manipulation_station/shelves.mtl",
+        "@drake_models//:manipulation_station/shelves.obj",
+        "@drake_models//:manipulation_station/shelves.png",
+        "@drake_models//:manipulation_station/table_wide.mtl",
+        "@drake_models//:manipulation_station/table_wide.obj",
+        "@drake_models//:manipulation_station/table_wide.png",
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Follow-up to #19771. Related to #19822.

The workflow for drake_models has changed. I should not have installed them.

+@rpoyner-tri for both reviews, please.
Thanks @adeeb10abbas for the help!

Relevant slack thread: https://drakedevelopers.slack.com/archives/C2PMBJVAN/p1690124580155169

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19836)
<!-- Reviewable:end -->
