### PR TITLE
Fix bug in DoAddPointInNonnegativeScalingConstraints for Spectrahedron class

### DIFF
--- a/geometry/optimization/spectrahedron.cc
+++ b/geometry/optimization/spectrahedron.cc
@@ -128,7 +128,10 @@ Spectrahedron::DoAddPointInNonnegativeScalingConstraints(
     Ab.leftCols(binding.evaluator()->num_vars()) =
         binding.evaluator()->get_sparse_A();
     Ab.rightCols<1>() = -binding.evaluator()->lower_bound();
-    constraints.emplace_back(prog->AddLinearEqualityConstraint(Ab, 0, vars));
+
+    VectorXd zeros = VectorXd::Zero(binding.evaluator()->num_constraints());
+    constraints.emplace_back(
+        prog->AddLinearEqualityConstraint(Ab, zeros, vars));
   }
 
   std::vector<Binding<LinearConstraint>> linear_inequality_constraints =
@@ -146,11 +149,23 @@ Spectrahedron::DoAddPointInNonnegativeScalingConstraints(
         binding.evaluator()->get_sparse_A();
     if (binding.evaluator()->lower_bound().array().isFinite().any()) {
       Ab.rightCols<1>() = -binding.evaluator()->lower_bound();
-      constraints.emplace_back(prog->AddLinearConstraint(Ab, 0, kInf, vars));
+
+      VectorXd zeros = VectorXd::Zero(binding.evaluator()->num_constraints());
+      VectorXd infs =
+          VectorXd::Constant(binding.evaluator()->num_constraints(), kInf);
+
+      constraints.emplace_back(
+          prog->AddLinearConstraint(Ab, zeros, infs, vars));
     }
     if (binding.evaluator()->upper_bound().array().isFinite().any()) {
       Ab.rightCols<1>() = -binding.evaluator()->upper_bound();
-      constraints.emplace_back(prog->AddLinearConstraint(Ab, -kInf, 0, vars));
+
+      VectorXd zeros = VectorXd::Zero(binding.evaluator()->num_constraints());
+      VectorXd infs =
+          VectorXd::Constant(binding.evaluator()->num_constraints(), kInf);
+
+      constraints.emplace_back(
+          prog->AddLinearConstraint(Ab, -infs, zeros, vars));
     }
   }
 

--- a/geometry/optimization/test/spectrahedron_test.cc
+++ b/geometry/optimization/test/spectrahedron_test.cc
@@ -219,6 +219,64 @@ GTEST_TEST(SpectrahedronTest, TrivialSdp1) {
   }
 }
 
+GTEST_TEST(SpectrahedronTest, AddPointInNonnegativeScalingConstraintsLinEqs) {
+  MathematicalProgram prog;
+  auto X1 = prog.NewSymmetricContinuousVariables<2>();
+  prog.AddPositiveSemidefiniteConstraint(X1);
+
+  const int kNumVars = 3;         // 3 free vars with SDP matrix of size 2x2
+  const int kNumConstraints = 2;  // Test 2 constraints
+  MatrixXd A(kNumConstraints, kNumVars);
+  A << 0.2, 0.0, 1.7, -2.0, 2.3, 1.9;
+  VectorXd b(kNumConstraints);
+  b << 2.0, 1.0;
+
+  prog.AddLinearEqualityConstraint(A, b, prog.decision_variables());
+
+  auto result = Solve(prog);
+  ASSERT_TRUE(result.is_success());
+
+  auto spect = Spectrahedron(prog);
+
+  MathematicalProgram prog2;
+  auto x = prog2.NewContinuousVariables<kNumVars>("x");
+  auto t = prog2.NewContinuousVariables<1>("t");
+  spect.AddPointInNonnegativeScalingConstraints(&prog2, x, t[0]);
+
+  EXPECT_EQ(prog2.positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(prog2.linear_equality_constraints().size(), 1);
+  EXPECT_EQ(prog2.bounding_box_constraints().size(), 1);  // t >= 0
+}
+
+GTEST_TEST(SpectrahedronTest, AddPointInNonnegativeScalingConstraintsBBox) {
+  MathematicalProgram prog;
+  auto X1 = prog.NewSymmetricContinuousVariables<2>();
+  prog.AddPositiveSemidefiniteConstraint(X1);
+
+  const int kNumVars = 3;  // 3 free vars with SDP matrix of size 2x2
+  VectorXd lb(kNumVars);
+  lb << -0.1, -2.0, 2.0;
+  VectorXd ub(kNumVars);
+  ub << 1.0, 0.0, 4.0;
+
+  prog.AddBoundingBoxConstraint(lb, ub, prog.decision_variables());
+
+  auto result = Solve(prog);
+  ASSERT_TRUE(result.is_success());
+
+  auto spect = Spectrahedron(prog);
+
+  MathematicalProgram prog2;
+  auto x = prog2.NewContinuousVariables<kNumVars>("x");
+  auto t = prog2.NewContinuousVariables<1>("t");
+  spect.AddPointInNonnegativeScalingConstraints(&prog2, x, t[0]);
+
+  EXPECT_EQ(prog2.positive_semidefinite_constraints().size(), 1);
+  // bounding box constraints become two constraints, upper and lower bound
+  EXPECT_EQ(prog2.linear_constraints().size(), 2);
+  EXPECT_EQ(prog2.bounding_box_constraints().size(), 1);  // t >= 0
+}
+
 GTEST_TEST(SpectrahedronTest, Move) {
   auto make_sdp = []() {
     auto sdp = std::make_unique<MathematicalProgram>();


### PR DESCRIPTION
This PR fixes a bug in the `DoAddPointInNonnegativeScalingConstraints ` function of the `Spectrahedron` class.

The bug is triggered when a binding has multiple constraints, i.e. `num_constraints` is higher than 1. In [line 131](https://github.com/RobotLocomotion/drake/blob/3fdd74cae58f672fe16b1f305e5a606f7f85c2e3/geometry/optimization/spectrahedron.cc#L131) (and [line 149](https://github.com/RobotLocomotion/drake/blob/3fdd74cae58f672fe16b1f305e5a606f7f85c2e3/geometry/optimization/spectrahedron.cc#L149), the row vector version of `AddLinearEqualityConstraint` (and `AddLinearConstraint`) is called due to a `double` passed as the argument to `b`. When there are multiple constraints in the binding, a matrix is wrongly passed as the row vector, resulting in an error.

See the added unit tests for minimal examples that trigger the bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19838)
<!-- Reviewable:end -->
