### PR TITLE
Modify MultibodyTree tests to use AddJoint() rather than AddMobilizer()

### DIFF
--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -43,7 +43,7 @@ class RotationMatrix;
 /// rotate relative to frame B, A by a pitch angle `p` about `Cy = By`.
 /// Note: C and B are no longer aligned.
 /// @li 3rd rotation R_AB: Frames D, C, B (collectively -- as if welded)
-/// rotate relative to frame A by a roll angle `y` about `Bz = Az`.
+/// rotate relative to frame A by a yaw angle `y` about `Bz = Az`.
 /// Note: B and A are no longer aligned.
 /// The monogram notation for the rotation matrix relating A to D is `R_AD`.
 ///

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -133,7 +133,6 @@ drake_cc_library(
         "//multibody/contact_solvers/sap",
         "//multibody/fem",
         "//multibody/hydroelastics:hydroelastic_engine",
-        "//multibody/topology:multibody_graph",
         "//multibody/tree",
         "//systems/framework:diagram_builder",
         "//systems/framework:leaf_system",

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -287,8 +287,7 @@ MultibodyPlant<T>::MultibodyPlant(
   // it less brittle.
   visual_geometries_.emplace_back();  // Entries for the "world" body.
   collision_geometries_.emplace_back();
-  // Add the world body to the graph.
-  multibody_graph_.AddBody(world_body().name(), world_body().model_instance());
+
   DeclareSceneGraphPorts();
 }
 
@@ -358,17 +357,6 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
     //   -reaction_forces_port_
     //   -instance_generalized_contact_forces_output_ports_
 
-    // Partially copy multibody_graph_. The looped calls to RegisterJointInGraph
-    // below copy the second half.
-    // TODO(xuchenhan-tri) MultibodyGraph should offer a public function (or
-    // constructor) for scalar conversion, so that MbP can just delegate the
-    // copying to MbG, instead of leaking knowledge of what kind of data MbG
-    // holds into MbP's converting constructor here.
-    for (BodyIndex index(0); index < num_bodies(); ++index) {
-      const Body<T>& body = get_body(index);
-      multibody_graph_.AddBody(body.name(), body.model_instance());
-    }
-
     time_step_ = other.time_step_;
     // discrete_update_manager_ is copied below after FinalizePlantOnly().
 
@@ -401,10 +389,6 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
   }
 
   DeclareSceneGraphPorts();
-
-  for (JointIndex index(0); index < num_joints(); ++index) {
-    RegisterJointInGraph(get_joint(index));
-  }
 
   // MultibodyTree::CloneToScalar() already called MultibodyTree::Finalize()
   // on the new MultibodyTree on U. Therefore we only Finalize the plant's
@@ -830,7 +814,7 @@ template <typename T>
 std::vector<const Body<T>*> MultibodyPlant<T>::GetBodiesWeldedTo(
     const Body<T>& body) const {
   const std::set<BodyIndex> island =
-      multibody_graph_.FindBodiesWeldedTo(body.index());
+      internal_tree().multibody_graph().FindBodiesWeldedTo(body.index());
   // Map body indices to pointers.
   std::vector<const Body<T>*> sub_graph_bodies;
   for (BodyIndex body_index : island) {
@@ -988,16 +972,6 @@ template<typename T>
 void MultibodyPlant<T>::Finalize() {
   // After finalizing the base class, tree is read-only.
   internal::MultibodyTreeSystem<T>::Finalize();
-
-  // Add free joints created by tree's finalize to the multibody graph.
-  // Until the call to Finalize(), all joints are added through calls to
-  // MultibodyPlant APIs and therefore registered in the graph. This accounts
-  // for the QuaternionFloatingJoint added for each free body that was not
-  // explicitly given a parent joint. It is important that this loop happens
-  // AFTER finalizing the internal tree.
-  for (JointIndex i{multibody_graph_.num_joints()}; i < num_joints(); ++i) {
-    RegisterJointInGraph(get_joint(i));
-  }
 
   if (geometry_source_is_registered()) {
     ApplyDefaultCollisionFilters();
@@ -1234,7 +1208,7 @@ void MultibodyPlant<T>::ApplyDefaultCollisionFilters() {
   }
   // We explicitly exclude collisions within welded subgraphs.
   std::vector<std::set<BodyIndex>> subgraphs =
-      multibody_graph_.FindSubgraphsOfWeldedBodies();
+      internal_tree().multibody_graph().FindSubgraphsOfWeldedBodies();
   for (const auto& subgraph : subgraphs) {
     // Only operate on non-trivial weld subgraphs.
     if (subgraph.size() <= 1) { continue; }
@@ -3351,7 +3325,7 @@ void MultibodyPlant<T>::RemoveUnsupportedScalars(
 template <typename T>
 std::vector<std::set<BodyIndex>>
 MultibodyPlant<T>::FindSubgraphsOfWeldedBodies() const {
-  return multibody_graph_.FindSubgraphsOfWeldedBodies();
+  return internal_tree().multibody_graph().FindSubgraphsOfWeldedBodies();
 }
 
 template <typename T>

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1711,9 +1711,7 @@ GTEST_TEST(MultibodyPlantTest, ReversedWeldError) {
   // reflect that.
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.Finalize(),
-      "This multibody tree already has a mobilizer connecting "
-      "inboard frame \\(index=0\\) and outboard frame \\(index=\\d*\\). "
-      "More than one mobilizer between two frames is not allowed.");
+      ".*already has a joint.*extra_welds_to_world.*joint.*not allowed.*");
 }
 
 // Utility to verify that the only ports of MultibodyPlant that are feedthrough

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -185,6 +185,7 @@ drake_cc_library(
         "//common:nice_type_name",
         "//common:unused",
         "//math:geometric_transform",
+        "//multibody/topology:multibody_graph",
         "//systems/framework:leaf_system",
     ],
 )

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -214,7 +214,7 @@ class Body : public MultibodyElement<T> {
   /// @throws std::exception if this body is not a floating body.
   void Lock(systems::Context<T>* context) const {
     // TODO(rpoyner-tri): consider extending the design to allow locking on
-    // non-floating bodies.
+    //  non-floating bodies.
     if (!is_floating()) {
       throw std::logic_error(fmt::format(
           "Attempted to call Lock() on non-floating body {}", name()));
@@ -228,7 +228,7 @@ class Body : public MultibodyElement<T> {
   /// @throws std::exception if this body is not a floating body.
   void Unlock(systems::Context<T>* context) const {
     // TODO(rpoyner-tri): consider extending the design to allow locking on
-    // non-floating bodies.
+    //  non-floating bodies.
     if (!is_floating()) {
       throw std::logic_error(fmt::format(
           "Attempted to call Unlock() on non-floating body {}", name()));

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -504,6 +504,12 @@ class Joint : public MultibodyElement<T> {
 
     return joint_clone;
   }
+
+  const internal::Mobilizer<T>& GetMobilizerInUse() const {
+    // This implementation should only have one mobilizer.
+    DRAKE_DEMAND(get_implementation().num_mobilizers() == 1);
+    return *get_implementation().mobilizers_[0];
+  }
 #endif
   // End of hidden Doxygen section.
 

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -13,7 +13,7 @@
 #include "drake/multibody/tree/fixed_offset_frame.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
-#include "drake/multibody/tree/revolute_mobilizer.h"
+#include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/systems/framework/context.h"
 
@@ -51,11 +51,9 @@ class FrameTests : public ::testing::Test {
     bodyB_ = &model->AddBody<RigidBody>("B", M_Bo_B);
     frameB_ = &bodyB_->body_frame();
 
-    // Mobilizer connecting bodyB to the world.
-    // The mobilizer is only needed because it is a requirement of MultibodyTree
-    // that all bodies in the model must have an inboard mobilizer.
-    model->AddMobilizer<RevoluteMobilizer>(
-        model->world_frame(), bodyB_->body_frame(),
+    // Joint connecting bodyB to the world.
+    model->AddJoint<RevoluteJoint>("joint0",
+        model->world_body(), {}, *bodyB_, {},
         Vector3d::UnitZ() /*revolute axis*/);
 
     // Some arbitrary pose of frame P in the body frame B.

--- a/multibody/tree/test/free_rotating_body_plant.cc
+++ b/multibody/tree/test/free_rotating_body_plant.cc
@@ -34,9 +34,8 @@ void FreeRotatingBodyPlant<T>::BuildMultibodyTreeModel() {
   SpatialInertia<double> M_Bcm(kMass, Vector3<double>::Zero(), G_Bcm);
 
   body_ = &this->mutable_tree().template AddBody<RigidBody>("B", M_Bcm);
-  mobilizer_ = &this->mutable_tree().template AddMobilizer<
-      internal::SpaceXYZMobilizer>(
-          tree().world_frame(), body_->body_frame());
+  joint_ = &this->mutable_tree().template AddJoint<BallRpyJoint>(
+          "ball_rpy_joint", tree().world_body(), {}, *body_, {});
 
   internal::MultibodyTreeSystem<T>::Finalize();
 }
@@ -47,26 +46,31 @@ FreeRotatingBodyPlant<T>::get_default_initial_angular_velocity() const {
   return Vector3d::UnitX() + Vector3d::UnitY() + Vector3d::UnitZ();
 }
 
-template<typename T>
+template <typename T>
 void FreeRotatingBodyPlant<T>::SetDefaultState(
     const systems::Context<T>& context, systems::State<T>* state) const {
   DRAKE_DEMAND(state != nullptr);
   internal::MultibodyTreeSystem<T>::SetDefaultState(context, state);
 
-  mobilizer_->set_angular_velocity(
+  const internal::Mobilizer<T>& mobilizer = joint_->GetMobilizerInUse();
+  const auto* xyz_mobilizer =
+      dynamic_cast<const internal::SpaceXYZMobilizer<T>*>(&mobilizer);
+  DRAKE_DEMAND(xyz_mobilizer != nullptr);
+
+  xyz_mobilizer->set_angular_velocity(
       context, get_default_initial_angular_velocity(), state);
 }
 
 template<typename T>
 Vector3<T> FreeRotatingBodyPlant<T>::get_angular_velocity(
     const systems::Context<T>& context) const {
-  return mobilizer_->get_angular_velocity(context);
+  return joint_->get_angular_velocity(context);
 }
 
 template<typename T>
 void FreeRotatingBodyPlant<T>::set_angular_velocity(
     systems::Context<T>* context, const Vector3<T>& w_WB) const {
-  mobilizer_->set_angular_velocity(context, w_WB);
+  joint_->set_angular_velocity(context, w_WB);
 }
 
 template<typename T>

--- a/multibody/tree/test/free_rotating_body_plant.h
+++ b/multibody/tree/test/free_rotating_body_plant.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "drake/math/rigid_transform.h"
+#include "drake/multibody/tree/ball_rpy_joint.h"
 #include "drake/multibody/tree/multibody_tree.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
 #include "drake/multibody/tree/rigid_body.h"
@@ -83,7 +84,7 @@ class FreeRotatingBodyPlant final : public internal::MultibodyTreeSystem<T> {
   double J_{0};
 
   const RigidBody<T>* body_{nullptr};
-  const internal::SpaceXYZMobilizer<T>* mobilizer_{nullptr};
+  const BallRpyJoint<T>* joint_{nullptr};
 };
 
 }  // namespace test

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -7,6 +7,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
+#include "drake/multibody/tree/planar_joint.h"
 #include "drake/multibody/tree/test/mobilizer_tester.h"
 #include "drake/systems/framework/context.h"
 
@@ -30,9 +31,10 @@ class PlanarMobilizerTest : public MobilizerTester {
   // Creates a simple model consisting of a single body with a planar
   // mobilizer connecting it to the world.
   void SetUp() override {
-    mobilizer_ =
-        &AddMobilizerAndFinalize(std::make_unique<PlanarMobilizer<double>>(
-            tree().world_body().body_frame(), body_->body_frame()));
+    mobilizer_ = &AddJointAndFinalize<PlanarJoint, PlanarMobilizer>(
+        std::make_unique<PlanarJoint<double>>(
+            "joint0", tree().world_body().body_frame(), body_->body_frame(),
+            Vector3d::Zero()));
   }
 
  protected:

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -7,6 +7,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
+#include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/test/mobilizer_tester.h"
 #include "drake/systems/framework/context.h"
 
@@ -27,9 +28,10 @@ constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 class PrismaticMobilizerTest : public MobilizerTester {
  public:
   void SetUp() override {
-    slider_ = &AddMobilizerAndFinalize(
-        std::make_unique<PrismaticMobilizer<double>>(
-        tree().world_body().body_frame(), body_->body_frame(), axis_F_));
+    slider_ = &AddJointAndFinalize<PrismaticJoint, PrismaticMobilizer>(
+        std::make_unique<PrismaticJoint<double>>(
+            "joint0", tree().world_body().body_frame(), body_->body_frame(),
+            axis_F_));
   }
 
  protected:

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -9,8 +9,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
-#include "drake/multibody/tree/multibody_tree_system.h"
-#include "drake/multibody/tree/rigid_body.h"
+#include "drake/multibody/tree/quaternion_floating_joint.h"
 #include "drake/multibody/tree/test/mobilizer_tester.h"
 #include "drake/systems/framework/context.h"
 
@@ -34,9 +33,10 @@ constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 class QuaternionFloatingMobilizerTest : public MobilizerTester {
  public:
   void SetUp() override {
-    mobilizer_ = &AddMobilizerAndFinalize(
-        std::make_unique<QuaternionFloatingMobilizer<double>>(
-            tree().world_body().body_frame(), body_->body_frame()));
+    mobilizer_ = &AddJointAndFinalize<QuaternionFloatingJoint,
+                                          QuaternionFloatingMobilizer>(
+        std::make_unique<QuaternionFloatingJoint<double>>(
+            "joint0", tree().world_body().body_frame(), body_->body_frame()));
   }
 
  protected:

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -7,6 +7,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
+#include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/test/mobilizer_tester.h"
 #include "drake/systems/framework/context.h"
 
@@ -29,9 +30,10 @@ constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 class RevoluteMobilizerTest : public MobilizerTester {
  public:
   void SetUp() override {
-    mobilizer_ = &AddMobilizerAndFinalize(
-        std::make_unique<RevoluteMobilizer<double>>(
-            tree().world_body().body_frame(), body_->body_frame(), axis_F_));
+    mobilizer_ = &AddJointAndFinalize<RevoluteJoint, RevoluteMobilizer>(
+        std::make_unique<RevoluteJoint<double>>(
+            "joint0", tree().world_body().body_frame(), body_->body_frame(),
+            axis_F_));
   }
 
  protected:

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -9,8 +9,8 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
+#include "drake/multibody/tree/screw_joint.h"
 #include "drake/multibody/tree/test/mobilizer_tester.h"
-#include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace multibody {
@@ -33,10 +33,10 @@ class ScrewMobilizerTest : public MobilizerTester {
   // Creates a simple model consisting of a single body with a screw
   // mobilizer connecting it to the world.
   void SetUp() override {
-    mobilizer_ =
-        &AddMobilizerAndFinalize(std::make_unique<ScrewMobilizer<double>>(
-            tree().world_body().body_frame(),
-            body_->body_frame(), kScrewAxis, kScrewPitch));
+    mobilizer_ = &AddJointAndFinalize<ScrewJoint, ScrewMobilizer>(
+        std::make_unique<ScrewJoint<double>>(
+            "joint0", tree().world_body().body_frame(), body_->body_frame(),
+            kScrewAxis, kScrewPitch, 0.0));
   }
 
  protected:

--- a/multibody/tree/test/space_xyz_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_mobilizer_test.cc
@@ -7,8 +7,8 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/tree/ball_rpy_joint.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
-#include "drake/multibody/tree/multibody_tree_system.h"
 #include "drake/multibody/tree/test/mobilizer_tester.h"
 #include "drake/systems/framework/context.h"
 
@@ -34,8 +34,8 @@ class SpaceXYZMobilizerTest :  public MobilizerTester {
   // Creates a simple model consisting of a single body with a space xyz
   // mobilizer connecting it to the world.
   void SetUp() override {
-    mobilizer_ = &AddMobilizerAndFinalize(
-        std::make_unique<SpaceXYZMobilizer<double>>(
+    mobilizer_ = &AddJointAndFinalize<BallRpyJoint, SpaceXYZMobilizer>(
+        std::make_unique<BallRpyJoint<double>>("joint0",
             tree().world_body().body_frame(), body_->body_frame()));
   }
 

--- a/multibody/tree/test/universal_mobilizer_test.cc
+++ b/multibody/tree/test/universal_mobilizer_test.cc
@@ -9,6 +9,7 @@
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
 #include "drake/multibody/tree/test/mobilizer_tester.h"
+#include "drake/multibody/tree/universal_joint.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
@@ -32,9 +33,9 @@ class UniversalMobilizerTest : public MobilizerTester {
   // Creates a simple model consisting of a single body with a universal
   // mobilizer connecting it to the world.
   void SetUp() override {
-    mobilizer_ =
-        &AddMobilizerAndFinalize(std::make_unique<UniversalMobilizer<double>>(
-            tree().world_body().body_frame(), body_->body_frame()));
+    mobilizer_ = &AddJointAndFinalize<UniversalJoint, UniversalMobilizer>(
+        std::make_unique<UniversalJoint<double>>(
+            "joint0", tree().world_body().body_frame(), body_->body_frame()));
   }
 
   MatrixXd CalcHMatrix(const Vector2d angles) {

--- a/multibody/tree/test/weld_mobilizer_test.cc
+++ b/multibody/tree/test/weld_mobilizer_test.cc
@@ -7,8 +7,8 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
-#include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/test/mobilizer_tester.h"
+#include "drake/multibody/tree/weld_joint.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
@@ -28,8 +28,8 @@ constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 class WeldMobilizerTest :  public MobilizerTester {
  public:
   void SetUp() override {
-    weld_body_to_world_ = &AddMobilizerAndFinalize(
-        std::make_unique<WeldMobilizer<double>>(
+    weld_body_to_world_ = &AddJointAndFinalize<WeldJoint, WeldMobilizer>(
+        std::make_unique<WeldJoint<double>>("joint0",
             tree().world_body().body_frame(), body_->body_frame(), X_WB_));
   }
 


### PR DESCRIPTION
(This is another #18442 yak shave)

This PR modifies all the direct MultibodyTree tests to use AddJoint() rather than a raw AddMobilizer(). This will allow these tests to keep working after changes to graphing, where Mobilizers are created under the covers already in depth-first order so can't be treated like Joints.

The existing MultibodyGraph is moved from MultibodyPlant to MultibodyTree (to be called "MultibodyPlantImpl" later) but the functionality is unchanged.

+@amcastro-tri for feature review, please (no rush)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19841)
<!-- Reviewable:end -->
