### PR TITLE
Fix an asan bug in CspaceFreePolytope.

### DIFF
--- a/geometry/optimization/cspace_free_box.cc
+++ b/geometry/optimization/cspace_free_box.cc
@@ -304,7 +304,8 @@ CspaceFreeBox::FindSeparationCertificateGivenBox(
   // This lambda function formulates and solves a small SOS program for each
   // pair of geometries.
   auto solve_small_sos = [this, &polynomials_to_certify, &active_plane_indices,
-                          &options, &ret](int plane_count) -> bool {
+                          &options,
+                          &ret](int plane_count) -> std::pair<bool, int> {
     const int plane_index = active_plane_indices[plane_count];
     auto certificate_program = this->ConstructPlaneSearchProgram(
         polynomials_to_certify.plane_geometries[plane_count],
@@ -320,10 +321,10 @@ CspaceFreeBox::FindSeparationCertificateGivenBox(
           plane_index, separating_planes()[plane_index].a,
           separating_planes()[plane_index].b,
           separating_planes()[plane_index].decision_variables, result));
-      return true;
+      return std::make_pair(true, plane_count);
     } else {
       ret[plane_count].reset();
-      return false;
+      return std::make_pair(false, plane_count);
     }
   };
   this->SolveCertificationForEachPlaneInParallel(

--- a/geometry/optimization/cspace_free_polytope.cc
+++ b/geometry/optimization/cspace_free_polytope.cc
@@ -294,10 +294,10 @@ CspaceFreePolytope::FindSeparationCertificateGivenPolytope(
 
   // This lambda function formulates and solves a small SOS program for each
   // pair of geometries.
-  auto solve_small_sos = [this, &d_minus_Cs, &C_redundant_indices,
-                          &s_lower_redundant_indices,
-                          &s_upper_redundant_indices, &active_plane_indices,
-                          &options, &ret](int plane_count) -> bool {
+  auto solve_small_sos =
+      [this, &d_minus_Cs, &C_redundant_indices, &s_lower_redundant_indices,
+       &s_upper_redundant_indices, &active_plane_indices, &options,
+       &ret](int plane_count) -> std::pair<bool, int> {
     const int plane_index = active_plane_indices[plane_count];
     auto certificate_program = this->ConstructPlaneSearchProgram(
         this->plane_geometries_[plane_index], d_minus_Cs, C_redundant_indices,
@@ -311,10 +311,10 @@ CspaceFreePolytope::FindSeparationCertificateGivenPolytope(
           plane_index, separating_planes()[plane_index].a,
           separating_planes()[plane_index].b,
           separating_planes()[plane_index].decision_variables, result));
-      return true;
+      return std::make_pair(true, plane_count);
     } else {
       ret[plane_count].reset();
-      return false;
+      return std::make_pair(false, plane_count);
     }
   };
 

--- a/geometry/optimization/cspace_free_polytope_base.h
+++ b/geometry/optimization/cspace_free_polytope_base.h
@@ -8,6 +8,7 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "drake/geometry/optimization/c_iris_collision_geometry.h"
@@ -201,9 +202,13 @@ class CspaceFreePolytopeBase {
    separation plane in parallel.
    @param active_plane_indices We will search for the plane in
    this->separating_planes()[active_plane_indices[i]].
-   @param solve_plane_sos The solve_plane_sos(plane_count) returns the whether
-   the solve for this->separating_planes()[active_plane_indices[plane_count]] is
-   successful or not.
+   @param solve_plane_sos The solve_plane_sos(plane_count) returns the pair
+   (is_success, plane_count), where is_success indicates whether the solve for
+   this->separating_planes()[active_plane_indices[plane_count]] is successful or
+   not. This function returns the input plane_count as one of the output. This
+   is because when we access the return value of solve_small_sos, we need to
+   know the plane_count, and the return value and the input `plane_count` live
+   in different part of the code due to multi-threading.
    @param num_threads The number of threads in the parallel solve.
    @param verbose Whether to print out some messages during the parallel solve.
    @param terminate_at_failure If set to true, then terminate this function when
@@ -211,8 +216,8 @@ class CspaceFreePolytopeBase {
    */
   void SolveCertificationForEachPlaneInParallel(
       const std::vector<int>& active_plane_indices,
-      const std::function<bool(int)>& solve_plane_sos, int num_threads,
-      bool verbose, bool terminate_at_failure) const;
+      const std::function<std::pair<bool, int>(int)>& solve_plane_sos,
+      int num_threads, bool verbose, bool terminate_at_failure) const;
 
  private:
   // Forward declare the tester class to test the private members.


### PR DESCRIPTION
When finding the separating planes in parallel, the lambda function that actually solves the sos should return plane_count.

Resolves #19843

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19845)
<!-- Reviewable:end -->
