### PR TITLE
Implements SapDistanceConstraint

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":sap_constraint_bundle",
         ":sap_constraint_jacobian",
         ":sap_contact_problem",
+        ":sap_distance_constraint",
         ":sap_friction_cone_constraint",
         ":sap_holonomic_constraint",
         ":sap_limit_constraint",
@@ -102,6 +103,19 @@ drake_cc_library(
         "//common:essential",
         "//multibody/contact_solvers:block_sparse_matrix",
         "//multibody/plant:slicing_and_indexing",
+    ],
+)
+
+drake_cc_library(
+    name = "sap_distance_constraint",
+    srcs = ["sap_distance_constraint.cc"],
+    hdrs = ["sap_distance_constraint.h"],
+    deps = [
+        ":sap_constraint",
+        ":sap_constraint_jacobian",
+        ":sap_holonomic_constraint",
+        "//common:default_scalars",
+        "//common:essential",
     ],
 )
 
@@ -234,6 +248,16 @@ drake_cc_googletest(
         ":sap_contact_problem",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sap_distance_constraint_test",
+    deps = [
+        ":sap_distance_constraint",
+        ":validate_constraint_gradients",
+        "//common:pointer_cast",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/contact_solvers/sap/sap_constraint_jacobian.h
+++ b/multibody/contact_solvers/sap/sap_constraint_jacobian.h
@@ -100,6 +100,15 @@ class SapConstraintJacobian {
     return clique_jacobians_[local_clique].block;
   }
 
+  /* Returns `true` iff both clique blocks of this Jacobian are dense. */
+  bool blocks_are_dense() const;
+
+  // TODO(amcastro-tri): extend this method to support non-dense blocks.
+  /* Returns Y = Aᵀ⋅J, with J being `this` Jacobian matrix.
+   @pre blocks_are_dense() is true. */
+  SapConstraintJacobian<T> LeftMultiplyByTranspose(
+      const Eigen::Ref<const MatrixX<T>>& A) const;
+
  private:
   // Blocks for each block. Up to two entries only.
   std::vector<CliqueJacobian<T>> clique_jacobians_;

--- a/multibody/contact_solvers/sap/sap_distance_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_distance_constraint.cc
@@ -1,0 +1,93 @@
+#include "drake/multibody/contact_solvers/sap/sap_distance_constraint.h"
+
+#include <limits>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+template <typename T>
+SapDistanceConstraint<T>::ComplianceParameters::ComplianceParameters(
+    T stiffness, T damping)
+    : stiffness_(std::move(stiffness)), damping_(std::move(damping)) {
+  DRAKE_DEMAND(stiffness_ > 0.0);
+  DRAKE_DEMAND(damping_ >= 0.0);
+}
+
+template <typename T>
+SapDistanceConstraint<T>::SapDistanceConstraint(Kinematics kinematics,
+                                                ComplianceParameters parameters)
+    : SapHolonomicConstraint<T>(
+          MakeSapHolonomicConstraintKinematics(kinematics),
+          MakeSapHolonomicConstraintParameters(parameters),
+          {kinematics.objectA(), kinematics.objectB()}),
+      kinematics_(std::move(kinematics)),
+      parameters_(std::move(parameters)) {}
+
+template <typename T>
+typename SapHolonomicConstraint<T>::Parameters
+SapDistanceConstraint<T>::MakeSapHolonomicConstraintParameters(
+    const ComplianceParameters& p) {
+  // "Near-rigid" regime parameter, see [Castro et al., 2022].
+  // TODO(amcastro-tri): consider exposing this parameter.
+  constexpr double kBeta = 0.1;
+
+  // Distance constraints do not have impulse limits, they are bi-lateral
+  // constraints. Each distance constraint introduces a single constraint
+  // equation.
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  return typename SapHolonomicConstraint<T>::Parameters{
+      Vector1<T>(-kInf), Vector1<T>(kInf), Vector1<T>(p.stiffness()),
+      Vector1<T>(p.damping() / p.stiffness()), kBeta};
+}
+
+template <typename T>
+typename SapHolonomicConstraint<T>::Kinematics
+SapDistanceConstraint<T>::MakeSapHolonomicConstraintKinematics(
+    const Kinematics& kinematics) {
+  Vector1<T> g(kinematics.distance() -
+               kinematics.length());  // Constraint function.
+  Vector1<T> b = Vector1<T>::Zero();  // Bias term.
+
+  // The constraint Jacobian is the projection of the relative velocity between
+  // P and Q on p_hat. That is ḋ = p̂⋅v_PQ_W = p̂⋅(J_WBq - J_WAp)⋅v.
+  // Therefore the distance constraint Jacobian is Jdist = p̂⋅J.
+  SapConstraintJacobian<T> Jdist =
+      kinematics.jacobian().LeftMultiplyByTranspose(kinematics.p_hat_W());
+
+  return typename SapHolonomicConstraint<T>::Kinematics(
+      std::move(g), std::move(Jdist), std::move(b));
+}
+
+template <typename T>
+void SapDistanceConstraint<T>::DoAccumulateSpatialImpulses(
+    int i, const Eigen::Ref<const VectorX<T>>& gamma,
+    SpatialForce<T>* F) const {
+  if (i == 0) {
+    // Object A.
+    const Vector3<T> f_Ap_W = -gamma(0) * kinematics_.p_hat_W();
+    const Vector3<T> t_A_W = kinematics_.p_AP_W().cross(f_Ap_W);
+    const SpatialForce<T> F_Ao_W(t_A_W, f_Ap_W);
+    *F += F_Ao_W;
+  } else {
+    // Object B.
+    const Vector3<T> f_Bq_W = gamma(0) * kinematics_.p_hat_W();
+    const Vector3<T> t_B_W = kinematics_.p_BQ_W().cross(f_Bq_W);
+    const SpatialForce<T> F_Bo_W(t_B_W, f_Bq_W);
+    *F += F_Bo_W;
+    return;
+  }
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::internal::SapDistanceConstraint)

--- a/multibody/contact_solvers/sap/sap_distance_constraint.h
+++ b/multibody/contact_solvers/sap/sap_distance_constraint.h
@@ -1,0 +1,209 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+/* Implements a SAP (compliant) distance constraint between two points. With
+ finite compliance, this constraint can be used to model a linear spring between
+ two points.
+
+ To be more precise, consider a point P on an object A and point Q on an object
+ B. With d the distance between points P and Q and ḋ its rate of change, this
+ SAP constraint models the constraint impulse as γ ∈ ℝ:
+   γ = −k⋅(d−ℓ) − c⋅ḋ
+ where ℓ is the "free length" of the constraint, and k and c are the stiffness
+ and damping coefficients respectively.
+
+ With p̂ the unit vector from P to Q, the force vector on B applied at Q is:
+   f_Bq = γ⋅p̂
+ and the reaction force on A applied at P is:
+   f_Ap = -γ⋅p̂
+
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class SapDistanceConstraint final : public SapHolonomicConstraint<T> {
+ public:
+  /* We do not allow copy, move, or assignment generally to avoid slicing. */
+  //@{
+  SapDistanceConstraint& operator=(const SapDistanceConstraint&) = delete;
+  SapDistanceConstraint(SapDistanceConstraint&&) = delete;
+  SapDistanceConstraint& operator=(SapDistanceConstraint&&) = delete;
+  //@}
+
+  /* ComplianceParameters that define the constraint's compliance. */
+  class ComplianceParameters {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ComplianceParameters);
+
+    /* Stiffness k and damping c. */
+    ComplianceParameters(T stiffness, T damping);
+
+    const T& stiffness() const { return stiffness_; }
+
+    const T& damping() const { return damping_; }
+
+   private:
+    T stiffness_;
+    T damping_;
+  };
+
+  /* Class to store the kinematics of the the constraint in its current
+   configuration, when it gets constructed. */
+  class Kinematics {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Kinematics);
+
+    /* @param[in] objectA
+         Index of the physical object A on which point P attaches.
+       @param[in] p_WP_W Position of point P in the world frame.
+       @param[in] p_AP_W Position of point P in A, expressed in the world frame.
+       @param[in] objectB
+         Index of the physical object B on which point Q attaches.
+       @param[in] p_WQ_W Position of point Q in the world frame.
+       @param[in] p_BQ_W Position of point Q in B, expressed in the world frame.
+       @param[in] length The constraint's length.
+       @param[in] J_ApBq_W Jacobian for the relative velocity v_ApBq_W. */
+    Kinematics(int objectA, Vector3<T> p_WP_W, Vector3<T> p_AP_W, int objectB,
+               Vector3<T> p_WQ_W, Vector3<T> p_BQ_W, T length,
+               SapConstraintJacobian<T> J_ApBq_W)
+        : objectA_(objectA),
+          p_WP_(std::move(p_WP_W)),
+          p_AP_W_(std::move(p_AP_W)),
+          objectB_(objectB),
+          p_WQ_(std::move(p_WQ_W)),
+          p_BQ_W_(std::move(p_BQ_W)),
+          length_(std::move(length)),
+          J_(std::move(J_ApBq_W)) {
+      // Thus far only dense Jacobian blocks are supported, i.e. rigid body
+      // applications in mind.
+      DRAKE_THROW_UNLESS(J_.blocks_are_dense());
+
+      const Vector3<T> p_PQ_W = p_WQ_ - p_WP_;
+      distance_ = p_PQ_W.norm();
+      // Verify the distance did not become ridiculously small. We use the
+      // constraint's fixed length as a reference.
+      constexpr double kMinimumDistance = 1.0e-7;
+      constexpr double kRelativeDistance = 1.0e-2;
+      if (distance_ < kMinimumDistance + kRelativeDistance * length_) {
+        throw std::logic_error(
+            fmt::format("The distance is {}. This is nonphysically small when "
+                        "compared to the free length of the constraint, {}. ",
+                        distance_, length_));
+      }
+      p_hat_W_ = p_PQ_W / distance_;
+    }
+
+    int objectA() const { return objectA_; }
+    const Vector3<T>& p_WP() const { return p_WP_; }
+    const Vector3<T>& p_AP_W() const { return p_AP_W_; }
+    int objectB() const { return objectB_; }
+    const Vector3<T>& p_WQ() const { return p_WQ_; }
+    const Vector3<T>& p_BQ_W() const { return p_BQ_W_; }
+    const T& length() const { return length_; }
+    const T& distance() const { return distance_; }
+    const SapConstraintJacobian<T>& jacobian() const { return J_; }
+    const Vector3<T>& p_hat_W() const { return p_hat_W_; }
+
+   private:
+    /* Index to a physical object A. */
+    int objectA_;
+
+    /* Position of point P in the world. */
+    Vector3<T> p_WP_;
+
+    /* Position of point P relative to A. */
+    Vector3<T> p_AP_W_;
+
+    /* Index to a physical object B. */
+    int objectB_;
+
+    /* Position of point Q in the world. */
+    Vector3<T> p_WQ_;
+
+    /* Position of point Q relative to B. */
+    Vector3<T> p_BQ_W_;
+
+    /* Fixed length of the constraint. */
+    T length_;
+
+    /* Jacobian that defines the velocity v_ApBq_W of point P relative to point
+     Q, expressed in the world frame. That is, v_ApBq_W = J⋅v. */
+    SapConstraintJacobian<T> J_;
+
+    /* Distance between point P and Q. */
+    T distance_;
+
+    /* Versor pointing from point P to point Q, expressed in the world frame W.
+     */
+    Vector3<T> p_hat_W_;
+  };
+
+  /* Constructs a distance constraint given its kinematics in a particular
+   configuration and the set of parameters that define the constraint. */
+  SapDistanceConstraint(Kinematics kinematics, ComplianceParameters parameters);
+
+  /* The constraint's length. */
+  const T& length() const { return kinematics_.length(); }
+
+  const ComplianceParameters& compliance_parameters() const {
+    return parameters_;
+  }
+
+ private:
+  /* Private copy construction is enabled to use in the implementation of
+     DoClone(). */
+  SapDistanceConstraint(const SapDistanceConstraint&) = default;
+
+  // no-op for this constraint.
+  void DoAccumulateGeneralizedImpulses(int, const Eigen::Ref<const VectorX<T>>&,
+                                       EigenPtr<VectorX<T>>) const final {}
+
+  /* Accumulates generalized forces applied by this constraint on the i-th
+   object.
+   @param[in] i Object index. As defined at construction i = 0 corresponds to
+   object A and i = 1 corresponds to object B.
+   @param[in] gamma A vector of size 1, with the (scalar) constraint impulse.
+   @param[out] F On output, this method accumulates the total spatial impulse
+   applied by this constraint on the i-th object.
+   @pre 0 ≤ i < 2.
+   @pre gamma is a vector of size one.
+   @pre F is not nullptr. */
+  void DoAccumulateSpatialImpulses(int i,
+                                   const Eigen::Ref<const VectorX<T>>& gamma,
+                                   SpatialForce<T>* F) const final;
+
+  /* Helper used at construction. Given parameters `p` for a
+   SapDistanceConstraint, this method makes the parameters needed by the base
+   class SapHolonomicConstraint. */
+  static typename SapHolonomicConstraint<T>::Parameters
+  MakeSapHolonomicConstraintParameters(const ComplianceParameters& p);
+
+  /* Helper used at construction. Makes the constraint function and Jacobian
+   needed to initialize the base class SapHolonomicConstraint.
+   @returns Holonomic constraint kinematics needed at construction of the
+   parent SapHolonomicConstraint. */
+  static typename SapHolonomicConstraint<T>::Kinematics
+  MakeSapHolonomicConstraintKinematics(const Kinematics& kinematics);
+
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<SapDistanceConstraint<T>>(
+        new SapDistanceConstraint<T>(*this));
+  }
+
+  Kinematics kinematics_;
+  ComplianceParameters parameters_;
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
@@ -34,6 +34,15 @@ SapHolonomicConstraint<T>::Parameters::Parameters(
 }
 
 template <typename T>
+SapHolonomicConstraint<T>::SapHolonomicConstraint(Kinematics kinematics,
+                                                  Parameters parameters,
+                                                  std::vector<int> objects)
+    : SapConstraint<T>(std::move(kinematics.J), std::move(objects)),
+      g_(std::move(kinematics.g)),
+      bias_(std::move(kinematics.b)),
+      parameters_(std::move(parameters)) {}
+
+template <typename T>
 SapHolonomicConstraint<T>::SapHolonomicConstraint(VectorX<T> g,
                                                   SapConstraintJacobian<T> J,
                                                   Parameters parameters)

--- a/multibody/contact_solvers/sap/test/sap_distance_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_distance_constraint_test.cc
@@ -1,0 +1,260 @@
+#include "drake/multibody/contact_solvers/sap/sap_distance_constraint.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/pointer_cast.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/contact_solvers/sap/validate_constraint_gradients.h"
+
+using drake::math::RotationMatrix;
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+// These Jacobian matrices have arbitrary values for testing. We specify the
+// size of the matrix in the name, e.g. J32 is of size 3x2.
+// clang-format off
+const MatrixXd J32 =
+    (MatrixXd(3, 2) << 2, 1,
+                       1, 2,
+                       1, 2).finished();
+
+const MatrixXd J34 =
+    (MatrixXd(3, 4) << 7, 1, 2, 3,
+                       1, 8, 4, 5,
+                       2, 4, 9, 6).finished();
+// clang-format on
+
+template <typename T = double>
+typename SapDistanceConstraint<T>::ComplianceParameters
+MakeArbitraryParameters() {
+  const T stiffness = 1.0e5;
+  const T damping = 1.0e3;
+  return typename SapDistanceConstraint<T>::ComplianceParameters{stiffness,
+                                                                 damping};
+}
+
+template <typename T = double>
+typename SapDistanceConstraint<T>::Kinematics MakeArbitraryKinematics(
+    int num_cliques) {
+  const int objectA = 12;
+  Vector3<T> p_WP(1., 2., 3.);
+  Vector3<T> p_AP_W(4., 5., 6.);
+  const int objectB = 5;
+  Vector3<T> p_WQ(7., 8., 9.);
+  Vector3<T> p_BQ_W(10., 11., 12.);
+  const int clique0 = 3;
+  const int clique1 = 12;
+  const T length = 0.35;
+  auto J_PQ_W = (num_cliques == 1)
+                    ? SapConstraintJacobian<T>(clique0, J32)
+                    : SapConstraintJacobian<T>(clique0, J32, clique1, J34);
+  return typename SapDistanceConstraint<T>::Kinematics{
+      objectA, p_WP, p_AP_W, objectB, p_WQ, p_BQ_W, length, J_PQ_W};
+}
+
+GTEST_TEST(SapDistanceConstraint, SingleCliqueConstraint) {
+  const int num_cliques = 1;
+  const SapDistanceConstraint<double>::ComplianceParameters parameters =
+      MakeArbitraryParameters();
+  const SapDistanceConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapDistanceConstraint<double> c(kinematics, parameters);
+
+  const Vector3d p = kinematics.p_WQ() - kinematics.p_WP();
+  const Vector3d p_hat = p.normalized();
+
+  EXPECT_EQ(c.num_objects(), 2);
+  EXPECT_EQ(c.num_constraint_equations(), 1);
+  EXPECT_EQ(c.num_cliques(), 1);
+  EXPECT_EQ(c.first_clique(), kinematics.jacobian().clique(0));
+  EXPECT_THROW(c.second_clique(), std::exception);
+  EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(),
+            p_hat.transpose() * J32);
+  EXPECT_THROW(c.second_clique_jacobian(), std::exception);
+  EXPECT_EQ(c.length(), kinematics.length());
+  EXPECT_EQ(c.compliance_parameters().stiffness(), parameters.stiffness());
+  EXPECT_EQ(c.compliance_parameters().damping(), parameters.damping());
+}
+
+GTEST_TEST(SapDistanceConstraint, TwoCliquesConstraint) {
+  const int num_cliques = 2;
+  const SapDistanceConstraint<double>::ComplianceParameters parameters =
+      MakeArbitraryParameters();
+  const SapDistanceConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapDistanceConstraint<double> c(kinematics, parameters);
+
+  const Vector3d p = kinematics.p_WQ() - kinematics.p_WP();
+  const Vector3d p_hat = p.normalized();
+
+  EXPECT_EQ(c.num_objects(), 2);
+  EXPECT_EQ(c.num_constraint_equations(), 1);
+  EXPECT_EQ(c.num_cliques(), 2);
+  EXPECT_EQ(c.first_clique(), kinematics.jacobian().clique(0));
+  EXPECT_EQ(c.second_clique(), kinematics.jacobian().clique(1));
+  EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(),
+            p_hat.transpose() * J32);
+  EXPECT_EQ(c.second_clique_jacobian().MakeDenseMatrix(),
+            p_hat.transpose() * J34);
+  EXPECT_EQ(c.length(), kinematics.length());
+  EXPECT_EQ(c.compliance_parameters().stiffness(), parameters.stiffness());
+  EXPECT_EQ(c.compliance_parameters().damping(), parameters.damping());
+}
+
+// This method validates analytical gradients implemented by
+// SapDistanceConstraint using automatic differentiation.
+void ValidateProjection(
+    const SapDistanceConstraint<double>::ComplianceParameters& p,
+    const Vector1d& vc) {
+  SapDistanceConstraint<AutoDiffXd>::ComplianceParameters p_ad(p.stiffness(),
+                                                               p.damping());
+
+  // Arbitrary kinematic values.
+  const int num_cliques = 1;
+  const SapDistanceConstraint<AutoDiffXd>::Kinematics kin_ad =
+      MakeArbitraryKinematics<AutoDiffXd>(num_cliques);
+
+  // Instantiate constraint on AutoDiffXd for automatic differentiation.
+  SapDistanceConstraint<AutoDiffXd> c(kin_ad, p_ad);
+
+  // Verify cost gradients using AutoDiffXd.
+  ValidateConstraintGradients(c, vc);
+}
+
+GTEST_TEST(SapDistanceConstraint, Gradients) {
+  // An arbitrary set of parameters.
+  SapDistanceConstraint<double>::ComplianceParameters p(1.0e3, 1.0e2);
+
+  // Arbitrary set of vc values.
+  {
+    const Vector1d vc(-1.4);
+    ValidateProjection(p, vc);
+  }
+  {
+    const Vector1d vc(2.3);
+    ValidateProjection(p, vc);
+  }
+  {
+    const Vector1d vc(6.2);
+    ValidateProjection(p, vc);
+  }
+}
+
+GTEST_TEST(SapDistanceConstraint, SingleCliqueConstraintClone) {
+  const int num_cliques = 1;
+  const SapDistanceConstraint<double>::ComplianceParameters parameters =
+      MakeArbitraryParameters();
+  const SapDistanceConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapDistanceConstraint<double> c(kinematics, parameters);
+
+  const Vector3d p = kinematics.p_WQ() - kinematics.p_WP();
+  const Vector3d p_hat = p.normalized();
+
+  // N.B. Here we dynamic cast to the derived type so that we can test that the
+  // clone is a deep-copy of the original constraint.
+  auto clone = dynamic_pointer_cast<SapDistanceConstraint<double>>(c.Clone());
+  ASSERT_NE(clone, nullptr);
+  EXPECT_EQ(clone->num_objects(), 2);
+  EXPECT_EQ(clone->num_constraint_equations(), 1);
+  EXPECT_EQ(clone->num_cliques(), 1);
+  EXPECT_EQ(clone->first_clique(), kinematics.jacobian().clique(0));
+  EXPECT_THROW(clone->second_clique(), std::exception);
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(),
+            p_hat.transpose() * J32);
+  EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
+  EXPECT_EQ(clone->length(), kinematics.length());
+  EXPECT_EQ(clone->compliance_parameters().stiffness(), parameters.stiffness());
+  EXPECT_EQ(clone->compliance_parameters().damping(), parameters.damping());
+}
+
+GTEST_TEST(SapDistanceConstraint, TwoCliquesConstraintClone) {
+  const int num_cliques = 2;
+  const SapDistanceConstraint<double>::ComplianceParameters parameters =
+      MakeArbitraryParameters();
+  const SapDistanceConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapDistanceConstraint<double> c(kinematics, parameters);
+
+  const Vector3d p = kinematics.p_WQ() - kinematics.p_WP();
+  const Vector3d p_hat = p.normalized();
+
+  auto clone = dynamic_pointer_cast<SapDistanceConstraint<double>>(c.Clone());
+  ASSERT_NE(clone, nullptr);
+  EXPECT_EQ(clone->num_objects(), 2);
+  EXPECT_EQ(clone->num_constraint_equations(), 1);
+  EXPECT_EQ(clone->num_cliques(), 2);
+  EXPECT_EQ(clone->first_clique(), kinematics.jacobian().clique(0));
+  EXPECT_EQ(clone->second_clique(), kinematics.jacobian().clique(1));
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(),
+            p_hat.transpose() * J32);
+  EXPECT_EQ(clone->second_clique_jacobian().MakeDenseMatrix(),
+            p_hat.transpose() * J34);
+  EXPECT_EQ(clone->length(), kinematics.length());
+  EXPECT_EQ(clone->compliance_parameters().stiffness(), parameters.stiffness());
+  EXPECT_EQ(clone->compliance_parameters().damping(), parameters.damping());
+}
+
+GTEST_TEST(SapDistanceConstraint, AccumulateSpatialImpulses) {
+  // Make a distance constraint with an arbitrary kinematics state and set of
+  // parameters, irrelevant for this test but needed at construction.
+  const int num_cliques = 1;
+  const SapDistanceConstraint<double>::ComplianceParameters parameters =
+      MakeArbitraryParameters();
+  const SapDistanceConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapDistanceConstraint<double> c(kinematics, parameters);
+
+  // Vector from P to Q, and its normalized versor.
+  const Vector3d p_PQ_W = kinematics.p_WQ() - kinematics.p_WP();
+  const Vector3d p_hat_W = p_PQ_W.normalized();
+
+  EXPECT_EQ(c.num_objects(), 2);
+  EXPECT_EQ(c.object(0), kinematics.objectA());
+  EXPECT_EQ(c.object(1), kinematics.objectB());
+
+  // Arbitrary value of the impulse.
+  const Vector1d gamma(1.2345);
+
+  // Expected spatial impulse on B.
+  const Vector3d f_B_W = gamma(0) * p_hat_W;
+  const Vector3d t_Bo_W = kinematics.p_BQ_W().cross(f_B_W);
+  const SpatialForce<double> F_Bo_W(t_Bo_W, f_B_W);
+
+  // Expected spatial impulse on A.
+  const Vector3d f_A_W = -f_B_W;
+  const Vector3d t_Ao_W = kinematics.p_AP_W().cross(f_A_W);
+  const SpatialForce<double> F_Ao_W(t_Ao_W, f_A_W);
+
+  const SpatialForce<double> F0(Vector3d(1., 2., 3), Vector3d(4., 5., 6));
+  SpatialForce<double> Faccumulated = F0;  // Initialize to non-zero value.
+  SpatialForce<double> F_Bo_W_expected = F0 + F_Bo_W;
+  c.AccumulateSpatialImpulses(1, gamma, &Faccumulated);
+  EXPECT_TRUE(CompareMatrices(
+      Faccumulated.get_coeffs(), F_Bo_W_expected.get_coeffs(),
+      std::numeric_limits<double>::epsilon(), MatrixCompareType::relative));
+
+  Faccumulated = F0;  // Initialize to non-zero value.
+  SpatialForce<double> F_Ao_W_expected = F0 + F_Ao_W;
+  c.AccumulateSpatialImpulses(0, gamma, &Faccumulated);
+  EXPECT_TRUE(CompareMatrices(
+      Faccumulated.get_coeffs(), F_Ao_W_expected.get_coeffs(),
+      std::numeric_limits<double>::epsilon(), MatrixCompareType::relative));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
This PR makes `SapDistanceConstraint` a first class citizen of the constraints family and it also implements the reporting of forces.
The `SapDriver` is refactored to use this constraint. Notice that `sap_drive_test.cc` already provides test coverage for distance constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19846)
<!-- Reviewable:end -->
