### PR TITLE
Implement AffineSubspace Methods to Check Containment and Equivalence

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -94,7 +94,11 @@ void DefineGeometryOptimization(py::module m) {
         .def("basis", &AffineSubspace::basis, py_rvp::reference_internal,
             cls_doc.basis.doc)
         .def("translation", &AffineSubspace::translation,
-            py_rvp::reference_internal, cls_doc.translation.doc);
+            py_rvp::reference_internal, cls_doc.translation.doc)
+        .def("ContainedIn", &AffineSubspace::ContainedIn, py::arg("other"),
+            py::arg("tol") = 1e-15, cls_doc.ContainedIn.doc)
+        .def("IsNearlyEqualTo", &AffineSubspace::IsNearlyEqualTo,
+            py::arg("other"), py::arg("tol") = 1e-15, cls_doc.ContainedIn.doc);
     DefClone(&cls);
   }
 

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -69,6 +69,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertTrue(dut.IsBounded())
         self.assertTrue(dut.PointInSet(dut.MaybeGetFeasiblePoint()))
         self.assertTrue(dut.IntersectsWith(dut))
+        self.assertTrue(dut.ContainedIn(mut.AffineSubspace()))
+        self.assertTrue(dut.IsNearlyEqualTo(mut.AffineSubspace()))
 
         basis = np.array([[1, 0, 0], [0, 1, 0]]).T
         translation = np.array([0, 0, 1])
@@ -82,6 +84,14 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertFalse(dut.IsBounded())
         self.assertTrue(dut.PointInSet(dut.MaybeGetFeasiblePoint()))
         self.assertTrue(dut.IntersectsWith(dut))
+        self.assertTrue(dut.ContainedIn(other=mut.AffineSubspace(
+            basis, translation), tol=0))
+        self.assertTrue(dut.IsNearlyEqualTo(other=mut.AffineSubspace(
+            basis, translation), tol=0))
+        self.assertFalse(dut.ContainedIn(other=mut.AffineSubspace(), tol=0))
+        self.assertFalse(mut.AffineSubspace().ContainedIn(other=dut, tol=0))
+        self.assertFalse(dut.IsNearlyEqualTo(other=mut.AffineSubspace(),
+                                             tol=0))
 
         self.assertIsNot(dut.Clone(), dut)
         self.assertIsNot(copy.deepcopy(dut), dut)

--- a/geometry/optimization/affine_subspace.cc
+++ b/geometry/optimization/affine_subspace.cc
@@ -121,6 +121,32 @@ AffineSubspace::DoToShapeWithPose() const {
       "ToShapeWithPose is not supported by AffineSubspace.");
 }
 
+bool AffineSubspace::ContainedIn(const AffineSubspace& other,
+                                 double tol) const {
+  // For this AffineSubspace to be contained in other, their ambient
+  // dimensions must be the same, its translation_ must be in other,
+  // and its subspace must be contained in the subspace of other.
+  if (ambient_dimension() != other.ambient_dimension()) {
+    return false;
+  }
+  if (!other.PointInSet(translation_, tol)) {
+    return false;
+  }
+  // Check that this basis is contained in other. If the basis vectors
+  // are all contained in other, than the whole set is.
+  for (int i = 0; i < basis_.cols(); ++i) {
+    if (!other.PointInSet(basis_.col(i) + translation_, tol)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool AffineSubspace::IsNearlyEqualTo(const AffineSubspace& other,
+                                     double tol) const {
+  return ContainedIn(other, tol) && other.ContainedIn(*this, tol);
+}
+
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/affine_subspace.h
+++ b/geometry/optimization/affine_subspace.h
@@ -59,6 +59,19 @@ class AffineSubspace final : public ConvexSet {
     a->Visit(MakeNameValue("translation", &translation_));
   }
 
+  /** Returns `true` if `this` AffineSubspace is contained in `other`. This is
+  computed by checking if `translation()` is in `other` and then checking if
+  each basis vector is in the span of the basis of `other`. The latter step
+  requires finding a least-squares solution, so a nonzero tolerance (`tol`) is
+  almost always necessary. (You may have to adjust the default tolerance
+  depending on the dimension of your space and the scale of your basis vectors.)
+  */
+  bool ContainedIn(const AffineSubspace& other, double tol = 1e-15) const;
+
+  /** Returns true if the two AffineSubspaces describe the same set, by checking
+   * that each set is contained in the other. */
+  bool IsNearlyEqualTo(const AffineSubspace& other, double tol = 1e-15) const;
+
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 

--- a/geometry/optimization/test/affine_subspace_test.cc
+++ b/geometry/optimization/test/affine_subspace_test.cc
@@ -24,6 +24,8 @@ GTEST_TEST(AffineSubspaceTest, DefaultCtor) {
   EXPECT_TRUE(dut.PointInSet(dut.MaybeGetFeasiblePoint().value()));
   EXPECT_TRUE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
   EXPECT_TRUE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.ContainedIn(AffineSubspace()));
+  EXPECT_TRUE(dut.IsNearlyEqualTo(AffineSubspace()));
 }
 
 GTEST_TEST(AffineSubspaceTest, Point) {
@@ -277,6 +279,156 @@ GTEST_TEST(AffineSubspaceTest, PointInSetConstraints) {
   EXPECT_TRUE(as.PointInSet(x_val, kTol));
   EXPECT_TRUE(
       CompareMatrices(x_val, as.basis() * new_vars_val + translation, kTol));
+}
+
+GTEST_TEST(AffineSubspaceTest, ContainmentTest) {
+  Eigen::Matrix<double, 3, 1> basis1;
+  // clang-format off
+  basis1 << 1,
+            1,
+            0;
+  // clang-format on
+  Eigen::VectorXd translation1(3);
+  translation1 << 0, 0, 1;
+  const AffineSubspace as1(basis1, translation1);
+
+  Eigen::Matrix<double, 3, 2> basis2;
+  // clang-format off
+  basis2 << 1, 0,
+            0, 1,
+            0, 0;
+  // clang-format on
+  Eigen::VectorXd translation2(3);
+  translation2 << 1, 1, 1;
+  const AffineSubspace as2(basis2, translation2);
+
+  EXPECT_TRUE(as1.ContainedIn(as2));
+  EXPECT_FALSE(as2.ContainedIn(as1));
+  EXPECT_FALSE(as1.IsNearlyEqualTo(as2));
+}
+
+GTEST_TEST(AffineSubspaceTest, CompareDifferentDimensions) {
+  // The containment, equality, and inequality methods must handle
+  // the case where the AffineSubspaces are of differing ambient
+  // dimension.
+  Eigen::Matrix<double, 2, 1> basis1;
+  // clang-format off
+  basis1 << 1,
+            0;
+  // clang-format on
+  Eigen::VectorXd translation1(2);
+  translation1 << 0, 1;
+  const AffineSubspace as1(basis1, translation1);
+
+  Eigen::Matrix<double, 3, 2> basis2;
+  // clang-format off
+  basis2 << 1, 0,
+            0, 1,
+            0, 0;
+  // clang-format on
+  Eigen::VectorXd translation2(3);
+  translation2 << 0, 0, 1;
+  const AffineSubspace as2(basis2, translation2);
+
+  EXPECT_FALSE(as1.ContainedIn(as2));
+  EXPECT_FALSE(as2.ContainedIn(as1));
+  EXPECT_FALSE(as1.IsNearlyEqualTo(as2));
+}
+
+GTEST_TEST(AffineSubspaceTest, EqualityTest) {
+  // An affine subspace is invariant under change of basis, and any choice of
+  // point in the affine subspace can be used as the translation. This test
+  // verifies that these properties hold.
+  Eigen::Matrix<double, 3, 2> basis1;
+  // clang-format off
+  basis1 << 1, 0,
+            0, 1,
+            0, 0;
+  // clang- format on
+  Eigen::VectorXd translation1(3);
+  translation1 << 0, 0, 1;
+
+  Eigen::Matrix<double, 3, 2> basis2;
+  // clang-format off
+  basis2 << 1, 1,
+            1, -1,
+            0, 0;
+  // clang-format on
+  Eigen::VectorXd translation2(3);
+  translation2 << 1, 1, 1;
+
+  const AffineSubspace as1(basis1, translation1);
+  const AffineSubspace as2(basis1, translation1);
+  const AffineSubspace as3(basis1, translation2);
+  const AffineSubspace as4(basis2, translation1);
+  const AffineSubspace as5(basis2, translation2);
+
+  const double kTol = 1e-15;
+
+  EXPECT_TRUE(as1.IsNearlyEqualTo(as2, kTol));
+  EXPECT_TRUE(as2.IsNearlyEqualTo(as3, kTol));
+  EXPECT_TRUE(as3.IsNearlyEqualTo(as4, kTol));
+  EXPECT_TRUE(as4.IsNearlyEqualTo(as5, kTol));
+}
+
+GTEST_TEST(AffineSubspaceTest, EqualityTest2) {
+  // This test checks to make sure that IsNearlyEqualTo still works when the
+  // translations are clearly different, and the AffineSubspaces aren't
+  // axis-aligned. This subspace is the plane passing through the points
+  // (1, 0, 0); (0, 1, 0); and (0, 0, 1). We give two different bases and two
+  // different translations -- note that the basis vectors are always orthogonal
+  // to the vector (1, 1, 1).
+  Eigen::Matrix<double, 3, 2> basis1;
+  // clang-format off
+  basis1 << -1,  0.5,
+            0.5, -1,
+            0.5, 0.5;
+  // clang- format on
+  Eigen::Matrix<double, 3, 2> basis2;
+  // clang-format off
+  basis2 << 1,  0,
+            -1, 1,
+            0, -1;
+  // clang- format on
+  Eigen::VectorXd translation1(3);
+  translation1 << 0, 0, 1;
+  Eigen::VectorXd translation2(3);
+  translation2 << 0, 1, 0;
+
+  const AffineSubspace as1(basis1, translation1);
+  const AffineSubspace as2(basis1, translation2);
+  const AffineSubspace as3(basis2, translation1);
+  const AffineSubspace as4(basis2, translation2);
+
+  const double kTol = 1e-15;
+
+  EXPECT_TRUE(as1.IsNearlyEqualTo(as2, kTol));
+  EXPECT_TRUE(as2.IsNearlyEqualTo(as3, kTol));
+  EXPECT_TRUE(as3.IsNearlyEqualTo(as4, kTol));
+}
+
+GTEST_TEST(AffineSubspaceTest, DeliberatelyLooseTolerance) {
+  // Verify that we can set the tolerance very high, and make it look like two
+  // affine subspaces are equivalent (when they aren't).
+  Eigen::Matrix<double, 2, 1> basis1;
+  basis1 << 1, 0;
+  Eigen::Matrix<double, 2, 1> basis2;
+  basis2 << 0, 1;
+  Eigen::VectorXd translation(2);
+  translation << 0, 0;
+
+  const AffineSubspace as1(basis1, translation);
+  const AffineSubspace as2(basis2, translation);
+
+  const double almost_too_high_tol = 1. - 1e-12;
+  const double too_high_tol = 1. + 1e-12;
+
+  EXPECT_FALSE(as1.ContainedIn(as2, almost_too_high_tol));
+  EXPECT_TRUE(as1.ContainedIn(as2, too_high_tol));
+  EXPECT_FALSE(as2.ContainedIn(as1, almost_too_high_tol));
+  EXPECT_TRUE(as2.ContainedIn(as1, too_high_tol));
+  EXPECT_FALSE(as1.IsNearlyEqualTo(as2, almost_too_high_tol));
+  EXPECT_TRUE(as1.IsNearlyEqualTo(as2, too_high_tol));
 }
 
 }  // namespace optimization


### PR DESCRIPTION
These methods allow the comparison of two AffineSubspaces, to check if one is contained in the other, and to check if they're equivalent.

Once #19828 lands, I'll rebase and look for a reviewer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19850)
<!-- Reviewable:end -->
