### PR TITLE
Implement Change of Coordinates Functionality for AffineSubspace.

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -95,6 +95,14 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.basis.doc)
         .def("translation", &AffineSubspace::translation,
             py_rvp::reference_internal, cls_doc.translation.doc)
+        .def("AffineDimension", &AffineSubspace::AffineDimension,
+            cls_doc.AffineDimension.doc)
+        .def("Project", &AffineSubspace::Project, py::arg("x"),
+            cls_doc.Project.doc)
+        .def("ToLocalCoordinates", &AffineSubspace::ToLocalCoordinates,
+            py::arg("x"), cls_doc.ToLocalCoordinates.doc)
+        .def("ToGlobalCoordinates", &AffineSubspace::ToGlobalCoordinates,
+            py::arg("y"), cls_doc.ToGlobalCoordinates.doc)
         .def("ContainedIn", &AffineSubspace::ContainedIn, py::arg("other"),
             py::arg("tol") = 1e-15, cls_doc.ContainedIn.doc)
         .def("IsNearlyEqualTo", &AffineSubspace::IsNearlyEqualTo,

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -69,6 +69,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertTrue(dut.IsBounded())
         self.assertTrue(dut.PointInSet(dut.MaybeGetFeasiblePoint()))
         self.assertTrue(dut.IntersectsWith(dut))
+        self.assertTrue(dut.PointInSet(dut.Project([])))
+        self.assertEqual(dut.AffineDimension(), 0)
         self.assertTrue(dut.ContainedIn(mut.AffineSubspace()))
         self.assertTrue(dut.IsNearlyEqualTo(mut.AffineSubspace()))
 
@@ -84,6 +86,30 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertFalse(dut.IsBounded())
         self.assertTrue(dut.PointInSet(dut.MaybeGetFeasiblePoint()))
         self.assertTrue(dut.IntersectsWith(dut))
+        self.assertEqual(dut.AffineDimension(), 2)
+
+        test_point = np.array([43, 43, 0])
+        self.assertFalse(dut.PointInSet(test_point))
+        self.assertTrue(dut.PointInSet(dut.Project(test_point)))
+
+        np.testing.assert_array_equal(dut.ToGlobalCoordinates(
+            dut.ToLocalCoordinates(test_point)), dut.Project(test_point))
+        local_coords = np.array([1, -1])
+        np.testing.assert_array_equal(dut.ToLocalCoordinates(
+            dut.ToGlobalCoordinates(local_coords)),
+            local_coords.reshape(-1, 1))
+        np.testing.assert_array_equal(dut.ToLocalCoordinates(
+            dut.ToGlobalCoordinates(local_coords.reshape(-1, 1))),
+            local_coords.reshape(-1, 1))
+
+        test_point_batch = np.zeros((3, 5))
+        self.assertEqual(dut.ToLocalCoordinates(x=test_point_batch).shape,
+                         (2, 5))
+        self.assertEqual(dut.Project(x=test_point_batch).shape, (3, 5))
+        local_coords_batch = np.zeros((2, 5))
+        self.assertEqual(dut.ToGlobalCoordinates(y=local_coords_batch).shape,
+                         (3, 5))
+
         self.assertTrue(dut.ContainedIn(other=mut.AffineSubspace(
             basis, translation), tol=0))
         self.assertTrue(dut.IsNearlyEqualTo(other=mut.AffineSubspace(

--- a/geometry/optimization/affine_subspace.h
+++ b/geometry/optimization/affine_subspace.h
@@ -59,6 +59,44 @@ class AffineSubspace final : public ConvexSet {
     a->Visit(MakeNameValue("translation", &translation_));
   }
 
+  /** Returns the affine dimension of this set. For an affine subspace,
+  this is simply the number of columns in the basis_ matrix. A point will
+  have affine dimension zero. */
+  int AffineDimension() const { return basis_.cols(); }
+
+  /** Computes the orthogonal projection of x onto the AffineSubspace. This
+  is achieved by finding the least squares solution y for y to x = translation_
+  + basis_*y, and returning translation_ + basis_*y. Each column of the input
+  should be a vector in the ambient space, and the corresponding column of the
+  output will be its projection onto the affine subspace.
+  @pre x.rows() == ambient_dimension() */
+  Eigen::MatrixXd Project(const Eigen::Ref<const Eigen::MatrixXd>& x) const;
+
+  /** Given a point x in the standard basis of the ambient space, returns the
+  coordinates of x in the basis of the AffineSubspace, with the zero point at
+  translation_. The component of x that is orthogonal to the AffineSubspace (if
+  it exists) is discarded, so ToGlobalCoordinates(ToLocalCoordinates(x)) is
+  equivalent to Project(x). Note that if the AffineSubspace is a point, the
+  basis is empty, so the local coordinates will also be empty (and returned as a
+  length-zero vector). Each column of the input should be a vector in the
+  ambient space, and the corresponding column of the output will be its
+  representation in the local coordinates of the affine subspace.
+  @pre x.rows() == ambient_dimension() */
+  Eigen::MatrixXd ToLocalCoordinates(
+      const Eigen::Ref<const Eigen::MatrixXd>& x) const;
+
+  /** Given a point y in the basis of the AffineSubspace, with the zero point
+  at translation_, returns the coordinates of y in the standard basis of the
+  ambient space. If the AffineSubspace is a point, it has an empty basis, so the
+  only possible local coordinates are also empty (and should be passed in as a
+  length-zero vector). Each column of the input should be a vector in the
+  affine subspace, represented in its local coordinates, and the corresponding
+  column of the output will be its representation in the coordinate system of
+  the ambient space.
+  @pre y.rows() == AffineDimension() */
+  Eigen::MatrixXd ToGlobalCoordinates(
+      const Eigen::Ref<const Eigen::MatrixXd>& y) const;
+
   /** Returns `true` if `this` AffineSubspace is contained in `other`. This is
   computed by checking if `translation()` is in `other` and then checking if
   each basis vector is in the span of the basis of `other`. The latter step

--- a/geometry/optimization/test/affine_subspace_test.cc
+++ b/geometry/optimization/test/affine_subspace_test.cc
@@ -24,6 +24,14 @@ GTEST_TEST(AffineSubspaceTest, DefaultCtor) {
   EXPECT_TRUE(dut.PointInSet(dut.MaybeGetFeasiblePoint().value()));
   EXPECT_TRUE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
   EXPECT_TRUE(dut.IntersectsWith(dut));
+  EXPECT_NO_THROW(dut.Project(Eigen::VectorXd::Zero(0)));
+  EXPECT_EQ(dut.AffineDimension(), 0);
+  Eigen::VectorXd test_point(0);
+  EXPECT_EQ(dut.ToLocalCoordinates(test_point).size(), 0);
+  EXPECT_TRUE(CompareMatrices(dut.ToLocalCoordinates(test_point), test_point));
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToGlobalCoordinates(dut.ToLocalCoordinates(test_point)),
+      dut.Project(test_point)));
   EXPECT_TRUE(dut.ContainedIn(AffineSubspace()));
   EXPECT_TRUE(dut.IsNearlyEqualTo(AffineSubspace()));
 }
@@ -47,14 +55,34 @@ GTEST_TEST(AffineSubspaceTest, Point) {
   EXPECT_TRUE(as.PointInSet(translation));
   EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3)));
   EXPECT_TRUE(as.IntersectsWith(as));
+  EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3))));
+
+  // Should throw because the ambient dimension is wrong.
+  EXPECT_THROW(as.Project(Eigen::VectorXd::Zero(1)), std::exception);
+
+  // Test local coordinates
+  EXPECT_EQ(as.AffineDimension(), 0);
+  Eigen::VectorXd test_point(3);
+  test_point << 42, 27, 0;
+  EXPECT_EQ(as.ToLocalCoordinates(test_point).size(), 0);
+  EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point),
+                              Eigen::VectorXd::Zero(0)));
+  EXPECT_TRUE(
+      CompareMatrices(as.ToGlobalCoordinates(as.ToLocalCoordinates(test_point)),
+                      as.Project(test_point)));
+  EXPECT_TRUE(CompareMatrices(
+      as.ToLocalCoordinates(as.ToGlobalCoordinates(Eigen::VectorXd::Zero(0))),
+      Eigen::VectorXd::Zero(0)));
 }
 
 GTEST_TEST(AffineSubspaceTest, Line) {
   Eigen::Matrix<double, 3, 1> basis;
-  basis << 1, 1, 1;
+  basis << 1, 1, 0;
   Eigen::VectorXd translation(3);
   translation << 1, 0, 0;
   const AffineSubspace as(basis, translation);
+
+  const double kTol = 1e-15;
 
   EXPECT_EQ(as.basis().cols(), 1);
   EXPECT_EQ(as.basis().rows(), 3);
@@ -68,10 +96,29 @@ GTEST_TEST(AffineSubspaceTest, Line) {
   EXPECT_TRUE(as.PointInSet(as.MaybeGetFeasiblePoint().value()));
   EXPECT_TRUE(as.PointInSet(translation));
   Eigen::VectorXd test_point(3);
-  test_point << 2, 1, 1;
-  EXPECT_TRUE(as.PointInSet(test_point));
-  EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3)));
+  test_point << 2, 1, 0;
+  EXPECT_TRUE(as.PointInSet(test_point, kTol));
+  EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3), kTol));
   EXPECT_TRUE(as.IntersectsWith(as));
+  EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3)), kTol));
+
+  // Test local coordinates
+  EXPECT_EQ(as.AffineDimension(), 1);
+  Eigen::VectorXd test_point2(3);
+  test_point2 << 2, 1, 1;
+  Eigen::VectorXd expected_project(3);
+  expected_project << 2, 1, 0;
+  Eigen::VectorXd expected_local_coords(1);
+  expected_local_coords << 1;
+  EXPECT_EQ(as.ToLocalCoordinates(test_point2).size(), 1);
+  EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point2),
+                              expected_local_coords, kTol));
+  EXPECT_TRUE(CompareMatrices(
+      as.ToGlobalCoordinates(as.ToLocalCoordinates(test_point2)),
+      as.Project(test_point2), kTol));
+  EXPECT_TRUE(CompareMatrices(
+      as.ToLocalCoordinates(as.ToGlobalCoordinates(expected_local_coords)),
+      expected_local_coords, kTol));
 }
 
 GTEST_TEST(AffineSubspaceTest, Plane) {
@@ -84,6 +131,8 @@ GTEST_TEST(AffineSubspaceTest, Plane) {
   Eigen::VectorXd translation(3);
   translation << 0, 0, 1;
   const AffineSubspace as(basis, translation);
+
+  const double kTol = 1e-15;
 
   EXPECT_EQ(as.basis().cols(), 2);
   EXPECT_EQ(as.basis().rows(), 3);
@@ -101,6 +150,25 @@ GTEST_TEST(AffineSubspaceTest, Plane) {
   EXPECT_TRUE(as.PointInSet(test_point));
   EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3)));
   EXPECT_TRUE(as.IntersectsWith(as));
+  EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3))));
+
+  // Test local coordinates
+  EXPECT_EQ(as.AffineDimension(), 2);
+  Eigen::VectorXd test_point2(3);
+  test_point2 << 42, 27, 0;
+  Eigen::VectorXd expected_project(3);
+  expected_project << 42, 27, 1;
+  Eigen::VectorXd expected_local_coords(2);
+  expected_local_coords << 42, 27;
+  EXPECT_EQ(as.ToLocalCoordinates(test_point2).size(), 2);
+  EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point2),
+                              expected_local_coords, kTol));
+  EXPECT_TRUE(CompareMatrices(
+      as.ToGlobalCoordinates(as.ToLocalCoordinates(test_point2)),
+      as.Project(test_point2), kTol));
+  EXPECT_TRUE(CompareMatrices(
+      as.ToLocalCoordinates(as.ToGlobalCoordinates(expected_local_coords)),
+      expected_local_coords, kTol));
 }
 
 GTEST_TEST(AffineSubspaceTest, VolumeInR3) {
@@ -113,6 +181,8 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR3) {
   Eigen::VectorXd translation(3);
   translation << 0, 0, 1;
   const AffineSubspace as(basis, translation);
+
+  const double kTol = 1e-15;
 
   EXPECT_EQ(as.basis().cols(), 3);
   EXPECT_EQ(as.basis().rows(), 3);
@@ -130,6 +200,25 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR3) {
   EXPECT_TRUE(as.PointInSet(test_point));
   EXPECT_TRUE(as.PointInSet(Eigen::VectorXd::Zero(3)));
   EXPECT_TRUE(as.IntersectsWith(as));
+  EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3))));
+
+  // Test local coordinates
+  EXPECT_EQ(as.AffineDimension(), 3);
+  Eigen::VectorXd test_point2(3);
+  test_point2 << 42, 27, 1;
+  Eigen::VectorXd expected_project(3);
+  expected_project << 42, 27, 1;
+  Eigen::VectorXd expected_local_coords(3);
+  expected_local_coords << 42, 27, 0;
+  EXPECT_EQ(as.ToLocalCoordinates(test_point2).size(), 3);
+  EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point2),
+                              expected_local_coords, kTol));
+  EXPECT_TRUE(CompareMatrices(
+      as.ToGlobalCoordinates(as.ToLocalCoordinates(test_point2)),
+      as.Project(test_point2), kTol));
+  EXPECT_TRUE(CompareMatrices(
+      as.ToLocalCoordinates(as.ToGlobalCoordinates(expected_local_coords)),
+      expected_local_coords, kTol));
 }
 
 GTEST_TEST(AffineSubspaceTest, VolumeInR4) {
@@ -143,6 +232,8 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR4) {
   Eigen::VectorXd translation(4);
   translation << 0, 0, 0, 1;
   const AffineSubspace as(basis, translation);
+
+  const double kTol = 1e-15;
 
   EXPECT_EQ(as.basis().cols(), 3);
   EXPECT_EQ(as.basis().rows(), 4);
@@ -160,6 +251,25 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR4) {
   EXPECT_TRUE(as.PointInSet(test_point));
   EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(4)));
   EXPECT_TRUE(as.IntersectsWith(as));
+  EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(4))));
+
+  // Test local coordinates
+  EXPECT_EQ(as.AffineDimension(), 3);
+  Eigen::VectorXd test_point2(4);
+  test_point2 << 42, 27, -7, 0;
+  Eigen::VectorXd expected_project(4);
+  expected_project << 42, 27, -7, 1;
+  Eigen::VectorXd expected_local_coords(3);
+  expected_local_coords << 42, 27, -7;
+  EXPECT_EQ(as.ToLocalCoordinates(test_point2).size(), 3);
+  EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point2),
+                              expected_local_coords, kTol));
+  EXPECT_TRUE(CompareMatrices(
+      as.ToGlobalCoordinates(as.ToLocalCoordinates(test_point2)),
+      as.Project(test_point2), kTol));
+  EXPECT_TRUE(CompareMatrices(
+      as.ToLocalCoordinates(as.ToGlobalCoordinates(expected_local_coords)),
+      expected_local_coords, kTol));
 }
 
 GTEST_TEST(AffineSubspaceTest, NotABasis1) {
@@ -279,6 +389,50 @@ GTEST_TEST(AffineSubspaceTest, PointInSetConstraints) {
   EXPECT_TRUE(as.PointInSet(x_val, kTol));
   EXPECT_TRUE(
       CompareMatrices(x_val, as.basis() * new_vars_val + translation, kTol));
+}
+
+GTEST_TEST(AffineSubspaceTest, BatchChangeOfCoordinates) {
+  // Test that the projection and transforms to and from local coordinates can
+  // handle batches of points.
+  Eigen::Matrix<double, 3, 2> basis;
+  // clang-format off
+  basis << 1, 0,
+           0, 1,
+           0, 0;
+  // clang-format on
+  Eigen::VectorXd translation(3);
+  translation << 0, 0, 1;
+  const AffineSubspace as(basis, translation);
+
+  Eigen::Matrix<double, 3, 5> points;
+  // clang-format off
+  points << 1, 2, 3, 4, 5,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0;
+  // clang-format on
+
+  Eigen::MatrixXd projected = as.Project(points);
+  EXPECT_EQ(projected.rows(), 3);
+  EXPECT_EQ(projected.cols(), 5);
+  for (int i = 0; i < points.cols(); ++i) {
+    EXPECT_TRUE(CompareMatrices(projected.col(i), as.Project(points.col(i))));
+  }
+
+  Eigen::MatrixXd local = as.ToLocalCoordinates(points);
+  EXPECT_EQ(local.rows(), 2);
+  EXPECT_EQ(local.cols(), 5);
+  for (int i = 0; i < points.cols(); ++i) {
+    EXPECT_TRUE(
+        CompareMatrices(local.col(i), as.ToLocalCoordinates(points.col(i))));
+  }
+
+  Eigen::MatrixXd global = as.ToGlobalCoordinates(local);
+  EXPECT_EQ(global.rows(), 3);
+  EXPECT_EQ(global.cols(), 5);
+  for (int i = 0; i < local.cols(); ++i) {
+    EXPECT_TRUE(
+        CompareMatrices(global.col(i), as.ToGlobalCoordinates(local.col(i))));
+  }
 }
 
 GTEST_TEST(AffineSubspaceTest, ContainmentTest) {


### PR DESCRIPTION
This PR implements new functionality for the AffineSubspace class:

- `AffineDimension()`, which returns the affine dimension of this AffineSubspace. For this class of sets, it's simply the number of columns in the basis.
- `Project(x)`, which computes the orthogonal projection of x onto the AffineSubspace
- `ToLocalCoordinates(x)`, which yields local coordinates of the projection onto AffineSubspace, with respect to its own basis (and zero point)
- `ToGlobalCoordinates(x)`, which lifts a point from local coordinate along AffineSubspace into the ambient space

Once #19828 lands, I'll rebase and look for a reviewer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19851)
<!-- Reviewable:end -->
