### PR TITLE
[bindings] Split pydrake.geometry.optimization into its own target

### DIFF
--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -50,7 +50,7 @@ from .trajectories import *
 
 # Submodules.
 from .common.all import *
-from .geometry.all import *
+from .geometry.all import *  # ORDER BREAKS PLANNING?!
 # - `examples` does not offer public Drake library symbols.
 from .multibody.all import *
 from .systems.all import *

--- a/bindings/pydrake/geometry/BUILD.bazel
+++ b/bindings/pydrake/geometry/BUILD.bazel
@@ -95,7 +95,7 @@ drake_pybind_library(
     package_info = PACKAGE_INFO,
     py_deps = [
         ":geometry_py",
-        "//bindings/pydrake/multibody:rational_py",
+        # "//bindings/pydrake/multibody:rational_py",
     ],
 )
 

--- a/bindings/pydrake/geometry/BUILD.bazel
+++ b/bindings/pydrake/geometry/BUILD.bazel
@@ -5,6 +5,7 @@ load(
 )
 load(
     "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_library",
     "drake_py_unittest",
 )
 load(
@@ -30,7 +31,7 @@ drake_cc_library(
 )
 
 drake_pybind_library(
-    name = "geometry",
+    name = "geometry_py",
     cc_deps = [
         ":optimization_pybind",
         "//bindings/pydrake:documentation_pybind",
@@ -49,7 +50,6 @@ drake_pybind_library(
         "geometry_py.h",
         "geometry_py_common.cc",
         "geometry_py_hydro.cc",
-        "geometry_py_optimization.cc",
         "geometry_py_render.cc",
         "geometry_py_scene_graph.cc",
         "geometry_py_visualizers.cc",
@@ -70,6 +70,49 @@ drake_pybind_library(
         # 2023-08-01 Remove this source file upon completion of deprecation.
         "render.py",
     ],
+)
+
+# This is broken out to avoid dependency cycles between this library and
+# multibody.
+drake_pybind_library(
+    name = "geometry_optimization_py",
+    cc_deps = [
+        ":optimization_pybind",
+        "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
+        "//bindings/pydrake/common:identifier_pybind",
+        "//bindings/pydrake/common:monostate_pybind",
+        "//bindings/pydrake/common:serialize_pybind",
+        "//bindings/pydrake/common:type_pack",
+        "//bindings/pydrake/common:type_safe_index_pybind",
+        "//bindings/pydrake/common:value_pybind",
+    ],
+    cc_so_name = "optimization",
+    cc_srcs = [
+        "geometry_py_optimization.cc",
+    ],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":geometry_py",
+        "//bindings/pydrake/multibody:rational_py",
+    ],
+)
+
+# Symbol roll-up (for user ease).
+drake_py_library(
+    name = "all_py",
+    srcs = ["all.py"],
+    deps = [
+        ":geometry_py",
+        ":geometry_optimization_py",
+    ],
+)
+
+# Package roll-up (for Bazel dependencies).
+drake_py_library(
+    name = "geometry",
+    deps = [":all_py"],
 )
 
 install(

--- a/bindings/pydrake/geometry/all.py
+++ b/bindings/pydrake/geometry/all.py
@@ -1,0 +1,2 @@
+from . import *
+from .optimization import *

--- a/bindings/pydrake/geometry/geometry_py.cc
+++ b/bindings/pydrake/geometry/geometry_py.cc
@@ -6,16 +6,6 @@
 
 namespace drake {
 namespace pydrake {
-namespace {
-
-void def_geometry_all(py::module m) {
-  py::dict vars = m.attr("__dict__");
-  py::exec(
-      "from pydrake.geometry import *\n"
-      "from pydrake.geometry.optimization import *\n",
-      py::globals(), vars);
-}
-}  // namespace
 
 PYBIND11_MODULE(geometry, m) {
   PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
@@ -27,12 +17,9 @@ PYBIND11_MODULE(geometry, m) {
   DefineGeometryHydro(m);
   DefineGeometryRender(m);
   DefineGeometrySceneGraph(m);
-  DefineGeometryOptimization(m.def_submodule("optimization"));
   DefineGeometryVisualizers(m);
 
   ExecuteExtraPythonCode(m, true);
-
-  def_geometry_all(m.def_submodule("all"));
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/geometry/geometry_py.h
+++ b/bindings/pydrake/geometry/geometry_py.h
@@ -18,10 +18,6 @@ void DefineGeometryCommon(py::module m);
  */
 void DefineGeometryHydro(py::module m);
 
-/** Defines all elements in the drake::geometry::optimization namespace.
- See geometry_py_optimization.cc. */
-void DefineGeometryOptimization(py::module m);
-
 /** Binds the public API of the drake/geometry/render and
  drake/geometry/render_* directories. See geometry_py_render.cc. */
 void DefineGeometryRender(py::module m);

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -704,8 +704,8 @@ void DefineGeometryOptimization(py::module m) {
 PYBIND11_MODULE(optimization, m) {
   PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
   py::module::import("pydrake.math");
-  py::module::import("pydrake.geometry");
-  py::module::import("pydrake.multibody.rational");
+//   py::module::import("pydrake.geometry");
+//   py::module::import("pydrake.multibody.rational");
 
   DefineGeometryOptimization(m);
 }

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -6,7 +6,6 @@
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/identifier_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
-#include "drake/bindings/pydrake/geometry/geometry_py.h"
 #include "drake/bindings/pydrake/geometry/optimization_pybind.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/optimization/cartesian_product.h"
@@ -700,6 +699,15 @@ void DefineGeometryOptimization(py::module m) {
   }
 
   // NOLINTNEXTLINE(readability/fn_size)
+}
+
+PYBIND11_MODULE(optimization, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
+  py::module::import("pydrake.math");
+  py::module::import("pydrake.geometry");
+  py::module::import("pydrake.multibody.rational");
+
+  DefineGeometryOptimization(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -145,7 +145,7 @@ drake_pybind_library(
         ":math_py",
         ":module_py",
         ":tree_py",
-        "//bindings/pydrake/geometry",
+        "//bindings/pydrake/geometry:geometry_py",
         "//bindings/pydrake/common:cpp_template_py",
     ],
     py_srcs = [


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/pull/19574

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19852)
<!-- Reviewable:end -->
