### PR TITLE
Deformable geometries support collision filtering.

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -256,11 +256,6 @@ int GeometryState<T>::NumGeometriesWithRole(Role role) const {
 
 template <typename T>
 int GeometryState<T>::NumDynamicGeometries() const {
-  return NumDeformableGeometries() + NumDynamicNonDeformableGeometries();
-}
-
-template <typename T>
-int GeometryState<T>::NumDynamicNonDeformableGeometries() const {
   int count = 0;
   for (const auto& pair : frames_) {
     const InternalFrame& frame = pair.second;
@@ -826,9 +821,10 @@ GeometryId GeometryState<T>::RegisterDeformableGeometry(
   }
 
   const GeometryId geometry_id = geometry->id();
-  if (frame_id != InternalFrame::world_frame_id()) {
+  if (frame_id == InternalFrame::world_frame_id()) {
     throw std::logic_error("Registering deformable geometry with id " +
-                           to_string(geometry_id) + " to a non-world frame");
+                           to_string(geometry_id) +
+                           " to the world frame is not allowed.");
   }
 
   ValidateRegistrationAndSetTopology(source_id, frame_id, geometry_id);

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -173,10 +173,6 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::NumDynamicGeometries().  */
   int NumDynamicGeometries() const;
 
-  /** Returns the total number of registered dynamic non-deformable geometries.
-   */
-  int NumDynamicNonDeformableGeometries() const;
-
   /** Returns the total number of registered deformable geometries. All
    deformable geometries are dynamic and _not_ anchored.  */
   int NumDeformableGeometries() const;

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -183,6 +183,7 @@ drake_cc_library(
     srcs = ["deformable_contact_internal.cc"],
     hdrs = ["deformable_contact_internal.h"],
     deps = [
+        ":collision_filter",
         ":deformable_mesh_intersection",
         "//common:essential",
         "//geometry:geometry_ids",

--- a/geometry/proximity/deformable_contact_internal.cc
+++ b/geometry/proximity/deformable_contact_internal.cc
@@ -53,7 +53,8 @@ void Geometries::UpdateDeformableVertexPositions(
   }
 }
 
-DeformableContact<double> Geometries::ComputeDeformableContact() const {
+DeformableContact<double> Geometries::ComputeDeformableContact(
+    const CollisionFilter& collision_filter) const {
   DeformableContact<double> result;
   for (const auto& [deformable_id, deformable_geometry] :
        deformable_geometries_) {
@@ -61,13 +62,18 @@ DeformableContact<double> Geometries::ComputeDeformableContact() const {
         deformable_geometry.deformable_mesh().mesh();
     result.RegisterDeformableGeometry(
         deformable_id, deformable_mesh.num_vertices());
+    DRAKE_DEMAND(collision_filter.HasGeometry(deformable_id));
     for (const auto& [rigid_id, rigid_geometry] : rigid_geometries_) {
-      const math::RigidTransform<double>& X_WR = rigid_geometry.pose_in_world();
-      const auto& rigid_bvh = rigid_geometry.rigid_mesh().bvh();
-      const auto& rigid_tri_mesh = rigid_geometry.rigid_mesh().mesh();
-      AddDeformableRigidContactSurface(deformable_geometry, deformable_id,
-                                       rigid_id, rigid_tri_mesh, rigid_bvh,
-                                       X_WR, &result);
+      DRAKE_DEMAND(collision_filter.HasGeometry(rigid_id));
+      if (collision_filter.CanCollideWith(deformable_id, rigid_id)) {
+        const math::RigidTransform<double>& X_WR =
+            rigid_geometry.pose_in_world();
+        const auto& rigid_bvh = rigid_geometry.rigid_mesh().bvh();
+        const auto& rigid_tri_mesh = rigid_geometry.rigid_mesh().mesh();
+        AddDeformableRigidContactSurface(deformable_geometry, deformable_id,
+                                         rigid_id, rigid_tri_mesh, rigid_bvh,
+                                         X_WR, &result);
+      }
     }
   }
   return result;

--- a/geometry/proximity/deformable_contact_internal.h
+++ b/geometry/proximity/deformable_contact_internal.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/collision_filter.h"
 #include "drake/geometry/proximity/deformable_contact_geometries.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/query_results/deformable_contact.h"
@@ -103,7 +104,8 @@ class Geometries final : public ShapeReifier {
    with respect to all registered rigid geometries. Assumes the vertex positions
    and poses of all registered deformable and rigid geometries are up to date.
   */
-  DeformableContact<double> ComputeDeformableContact() const;
+  DeformableContact<double> ComputeDeformableContact(
+      const CollisionFilter& collision_filter) const;
 
  private:
   friend class GeometriesTester;

--- a/geometry/proximity/test/deformable_contact_internal_test.cc
+++ b/geometry/proximity/test/deformable_contact_internal_test.cc
@@ -12,6 +12,16 @@
 
 namespace drake {
 namespace geometry {
+
+/* Use GeometrySetTester's friend status with GeometrySet to leak its geometry
+ ids to support the tests below. */
+class GeometrySetTester {
+ public:
+  static std::unordered_set<GeometryId> geometries(const GeometrySet& s) {
+    return s.geometries();
+  }
+};
+
 namespace internal {
 namespace deformable {
 
@@ -60,6 +70,11 @@ ProximityProperties MakeProximityPropsWithRezHint(double resolution_hint) {
 math::RigidTransformd default_pose() {
   return math::RigidTransformd(math::RollPitchYaw<double>(1, 2, 3),
                                Vector3d(4, 5, 6));
+}
+
+/* Returns a value for the collision filter id extraction functor. */
+static CollisionFilter::ExtractIds get_extract_ids_functor() {
+  return &GeometrySetTester::geometries;
 }
 
 GTEST_TEST(GeometriesTest, AddRigidGeometry) {
@@ -309,9 +324,10 @@ GTEST_TEST(GeometriesTest, UpdateDeformableVertexPositions) {
 
 GTEST_TEST(GeometriesTest, ComputeDeformableContact) {
   Geometries geometries;
+  CollisionFilter collision_filter;
   /* The contact data is empty when there is no deformable geometry. */
   DeformableContact<double> contact_data =
-      geometries.ComputeDeformableContact();
+      geometries.ComputeDeformableContact(collision_filter);
   EXPECT_EQ(contact_data.contact_surfaces().size(), 0);
 
   /* Add a deformable unit cube. */
@@ -320,9 +336,10 @@ GTEST_TEST(GeometriesTest, ComputeDeformableContact) {
       MakeBoxVolumeMesh<double>(Box::MakeCube(1.0), 1.0);
   const int num_vertices = deformable_mesh.num_vertices();
   geometries.AddDeformableGeometry(deformable_id, std::move(deformable_mesh));
+  collision_filter.AddGeometry(deformable_id);
 
   /* There is no geometry to collide with the deformable geometry yet. */
-  contact_data = geometries.ComputeDeformableContact();
+  contact_data = geometries.ComputeDeformableContact(collision_filter);
   ASSERT_EQ(contact_data.contact_surfaces().size(), 0);
   /* Add a rigid unit cube. */
   GeometryId rigid_id = GeometryId::get_new_id();
@@ -330,9 +347,10 @@ GTEST_TEST(GeometriesTest, ComputeDeformableContact) {
   math::RigidTransform<double> X_WR(Vector3d(0, -2.0, 0));
   geometries.MaybeAddRigidGeometry(Box::MakeCube(1.0), rigid_id,
                                    rigid_properties, X_WR);
+  collision_filter.AddGeometry(rigid_id);
 
   /* The deformable box and the rigid box are not in contact yet. */
-  contact_data = geometries.ComputeDeformableContact();
+  contact_data = geometries.ComputeDeformableContact(collision_filter);
   ASSERT_EQ(contact_data.contact_surfaces().size(), 0);
 
   /* Now shift the rigid geometry closer to the deformable geometry.
@@ -356,7 +374,7 @@ GTEST_TEST(GeometriesTest, ComputeDeformableContact) {
   geometries.UpdateRigidWorldPose(rigid_id, X_WR);
 
   /* Now there should be exactly one contact data. */
-  contact_data = geometries.ComputeDeformableContact();
+  contact_data = geometries.ComputeDeformableContact(collision_filter);
   ASSERT_EQ(contact_data.contact_surfaces().size(), 1);
 
   /* Verify that the contact surface is as expected. */
@@ -389,6 +407,14 @@ GTEST_TEST(GeometriesTest, ComputeDeformableContact) {
             expected_contact_surface.num_contact_points());
   EXPECT_TRUE(contact_surface.contact_mesh_W().Equal(
       expected_contact_surface.contact_mesh_W()));
+
+  /* No contact is reported if the the pair of rigid and deformable geometries
+   are filtered. */
+  collision_filter.Apply(CollisionFilterDeclaration().ExcludeBetween(
+                             GeometrySet(deformable_id), GeometrySet(rigid_id)),
+                         get_extract_ids_functor());
+  contact_data = geometries.ComputeDeformableContact(collision_filter);
+  EXPECT_EQ(contact_data.contact_surfaces().size(), 0);
 }
 
 }  // namespace

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -776,7 +776,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   void ComputeDeformableContact(
       DeformableContact<double>* deformable_contact) const {
     *deformable_contact =
-        geometries_for_deformable_contact_.ComputeDeformableContact();
+        geometries_for_deformable_contact_.ComputeDeformableContact(
+            collision_filter_);
   }
 
   // Testing utilities

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -507,8 +507,6 @@ class SceneGraph final : public systems::LeafSystem<T> {
       SourceId source_id, std::unique_ptr<GeometryInstance> geometry);
 
   // TODO(jwnimmer-tri) Deprecate and remove `source_id` argument.
-  // TODO(xuchenhan-tri): Consider allowing registering deformable geometries to
-  // non-world frames.
   /** Registers a new deformable geometry G for this source. This registers
    geometry G on a frame F (indicated by `frame_id`). The registered geometry
    has a meshed representation. The positions of the vertices of this mesh
@@ -536,7 +534,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @pre resolution_hint > 0.
    @throws std::exception  if a) the `source_id` does _not_ map to a
                            registered source,
-                           b) frame_id != world_frame_id(),
+                           b) frame_id == world_frame_id(),
                            c) the `geometry` is equal to `nullptr`,
                            d) the geometry's name doesn't satisfy the
                            requirements outlined in GeometryInstance.  */

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -866,9 +866,11 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeDeformableGeometry) {
   constexpr double kRadius = 1.0;
   auto geometry_instance = make_unique<GeometryInstance>(
       RigidTransformd::Identity(), make_unique<Sphere>(kRadius), "sphere");
+  FrameId f_id = this->scene_graph_->RegisterFrame(
+      this->configuration_source_id_, GeometryFrame("frame"));
   GeometryId g_id = this->scene_graph_->RegisterDeformableGeometry(
-      this->configuration_source_id_, this->scene_graph_->world_frame_id(),
-      std::move(geometry_instance), kRezHint);
+      this->configuration_source_id_, f_id, std::move(geometry_instance),
+      kRezHint);
   const auto& inspector = this->scene_graph_->model_inspector();
   const VolumeMesh<double>* mesh = inspector.GetReferenceMesh(g_id);
   ASSERT_NE(mesh, nullptr);

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -244,15 +244,17 @@ TEST_F(QueryObjectTest, BakedCopyHasFullUpdate) {
 
   auto deformable_geometry = make_unique<GeometryInstance>(
       RigidTransformd::Identity(), make_unique<Sphere>(1.0), "deformable");
+  FrameId deformable_frame_id =
+      scene_graph_.RegisterFrame(s_id, GeometryFrame("deformable's frame"));
   // Make sure the resolution hint is large enough so that we know that the
   // volume mesh is a octahedron.
   GeometryId g_id = scene_graph_.RegisterDeformableGeometry(
-      s_id, internal::InternalFrame::world_frame_id(),
-      std::move(deformable_geometry), 10.0);
+      s_id, deformable_frame_id, std::move(deformable_geometry), 10.0);
   unique_ptr<Context<double>> context = scene_graph_.CreateDefaultContext();
 
   RigidTransformd X_WF{Vector3d{1, 2, 3}};
-  FramePoseVector<double> poses{{frame_id, X_WF}};
+  FramePoseVector<double> poses{
+      {frame_id, X_WF}, {deformable_frame_id, RigidTransformd::Identity()}};
   scene_graph_.get_source_pose_port(s_id).FixValue(context.get(), poses);
 
   const int kNumVertices = 7;

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -149,8 +150,7 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
   }
 
  private:
-  PhysicalModelPointerVariant<T> DoToPhysicalModelPointerVariant()
-      const final {
+  PhysicalModelPointerVariant<T> DoToPhysicalModelPointerVariant() const final {
     return PhysicalModelPointerVariant<T>(this);
   }
 
@@ -178,6 +178,11 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
   void CopyVertexPositions(const systems::Context<T>& context,
                            AbstractValue* output) const;
 
+  /* Sets the poses (in world frame) of all frames associated with the
+   deformable bodies to identity. */
+  void DoCalcFramePoseOutput(const systems::Context<T>& context,
+                             geometry::FramePoseVector<T>* poses) const final;
+
   /* Helper to throw a useful message if a deformable body with the given `id`
    doesn't exist. */
   void ThrowUnlessRegistered(const char* source_method,
@@ -199,6 +204,7 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
       fem_models_;
   std::vector<DeformableBodyId> body_ids_;
   std::unordered_map<DeformableBodyId, DeformableBodyIndex> body_id_to_index_;
+  std::map<DeformableBodyId, geometry::FrameId> body_id_to_frame_id_;
   systems::OutputPortIndex vertex_positions_port_index_;
 };
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -3120,6 +3120,9 @@ void MultibodyPlant<T>::CalcFramePoseOutput(
     poses->set_value(body_index_to_frame_id_.at(body_index),
                      pc.get_X_WB(body.node_index()));
   }
+  for (const auto& model : physical_models_) {
+    model->CalcFramePoseOutput(context, poses);
+  }
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -5151,6 +5151,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // with a SceneGraph.
   void DeclareSceneGraphPorts();
 
+  // Computes the poses of all frames registered with SceneGraph through `this`
+  // MultibodyPlant and its owned components.
   void CalcFramePoseOutput(const systems::Context<T>& context,
                            geometry::FramePoseVector<T>* poses) const;
 

--- a/multibody/plant/physical_model.h
+++ b/multibody/plant/physical_model.h
@@ -108,6 +108,13 @@ class PhysicalModel : public internal::ScalarConvertibleComponent<T> {
     return DoToPhysicalModelPointerVariant();
   }
 
+  /* Computes the poses of all frames registered with SceneGraph through `this`
+   physical model. */
+  void CalcFramePoseOutput(const systems::Context<T>& context,
+                           geometry::FramePoseVector<T>* poses) const {
+    DoCalcFramePoseOutput(context, poses);
+  }
+
  protected:
   /* Derived classes must override this function to return their specific model
    variant. */
@@ -136,6 +143,9 @@ class PhysicalModel : public internal::ScalarConvertibleComponent<T> {
   /* Derived class must override this to declare system resources for its
    specific model. */
   virtual void DoDeclareSystemResources(MultibodyPlant<T>* plant) = 0;
+
+  virtual void DoCalcFramePoseOutput(const systems::Context<T>&,
+                                     geometry::FramePoseVector<T>*) const {}
 
   /* Helper method for throwing an exception within public methods that should
    not be called after system resources are declared. The invoking method should


### PR DESCRIPTION
To enable collision filtering for deformable geometries, we need to modify the convention that deformable geometries are always registered to the world frame. This is because collision among geometries registered with the same frame is automatically filtered and as a result, collision between deformable geometries and anchored rigid geometries are filtered, which is usually not what we want.

This commit changes the convention so that deformable geomtries are never registered with the world frame, and it enables collision filtering for deformable bodies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19854)
<!-- Reviewable:end -->
