### PR TITLE
CameraConfig can use RenderEngineParams

### DIFF
--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -96,6 +96,7 @@ drake_cc_library(
     hdrs = [
         "factory.h",
     ],
+    visibility = ["//visibility:public"],
     interface_deps = [
         ":render_engine_gl_params",
         "//geometry/render:render_engine",
@@ -132,6 +133,7 @@ drake_cc_library(
     hdrs = [
         "render_engine_gl_params.h",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//common:name_value",
         "//geometry:rgba",

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -83,6 +83,9 @@ drake_cc_library(
         "//common/schema:transform",
         "//geometry:rgba",
         "//geometry/render:render_camera",
+        "//geometry/render_gl:render_engine_gl_params",
+        "//geometry/render_gltf_client:render_engine_gltf_client_params",
+        "//geometry/render_vtk:render_engine_vtk_params",
     ],
 )
 
@@ -104,6 +107,7 @@ drake_cc_library(
         ":rgbd_sensor_async",
         ":sim_rgbd_sensor",
         "//geometry/render_gl",
+        "//geometry/render_gltf_client",
         "//geometry/render_vtk",
         "//math:geometric_transform",
         "//multibody/parsing:scoped_names",
@@ -358,13 +362,14 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//common/yaml:yaml_io",
-        "//geometry/render_gl",
+        "//geometry/render_vtk",
         "@fmt",
     ],
 )
 
 drake_cc_googletest(
     name = "camera_config_functions_test",
+    allow_network = ["render_gltf_client"],
     tags = vtk_test_tags(),
     deps = [
         ":camera_config_functions",
@@ -374,6 +379,8 @@ drake_cc_googletest(
         "//common/test_utilities:expect_throws_message",
         "//common/yaml:yaml_io",
         "//geometry/render_gl",
+        "//geometry/render_gltf_client",
+        "//geometry/render_vtk",
         "//lcm:drake_lcm",
         "//systems/lcm:lcm_publisher_system",
     ],

--- a/systems/sensors/camera_config.cc
+++ b/systems/sensors/camera_config.cc
@@ -130,13 +130,20 @@ void CameraConfig::ValidateOrThrow() const {
       },
       focal);
 
-  if (!renderer_class.empty() && !(renderer_class == "RenderEngineVtk" ||
-                                   renderer_class == "RenderEngineGl")) {
-    throw std::logic_error(fmt::format(
-        "Invalid camera configuration; the given renderer_class value '{}' "
-        "must be empty (to use the default) or be one of 'RenderEngineVtk' or "
-        "'RenderEngineGl'.",
-        renderer_class));
+  // We don't worry about the other variant alternatives; if we're here, we've
+  // constructed a set of parameters, and we'll defer to the RenderEngine to
+  // determine if the values are valid.
+  if (std::holds_alternative<std::string>(renderer_class)) {
+    const auto& class_name = std::get<std::string>(renderer_class);
+    if (!class_name.empty() &&
+        !(class_name == "RenderEngineVtk" || class_name == "RenderEngineGl" ||
+          class_name == "RenderEngineGltfClient")) {
+      throw std::logic_error(fmt::format(
+          "Invalid camera configuration; the given renderer_class value '{}' "
+          "must be empty (to use the default) or be one of 'RenderEngineVtk', "
+          "'RenderEngineGl', or 'RenderEngineGltfClient'.",
+          class_name));
+    }
   }
 
   // This throws for us if we have bad bad numerical camera values (or an empty

--- a/systems/sensors/camera_config_functions.cc
+++ b/systems/sensors/camera_config_functions.cc
@@ -13,6 +13,7 @@
 #include "drake/common/nice_type_name.h"
 #include "drake/geometry/render/render_camera.h"
 #include "drake/geometry/render_gl/factory.h"
+#include "drake/geometry/render_gltf_client/factory.h"
 #include "drake/geometry/render_vtk/factory.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/parsing/scoped_names.h"
@@ -29,8 +30,10 @@ using drake::lcm::DrakeLcmInterface;
 using drake::systems::lcm::LcmBuses;
 using Eigen::Vector3d;
 using geometry::MakeRenderEngineGl;
+using geometry::MakeRenderEngineGltfClient;
 using geometry::MakeRenderEngineVtk;
 using geometry::RenderEngineGlParams;
+using geometry::RenderEngineGltfClientParams;
 using geometry::RenderEngineVtkParams;
 using geometry::SceneGraph;
 using geometry::render::ColorRenderCamera;
@@ -45,21 +48,82 @@ using multibody::parsing::GetScopedFrameByName;
 
 namespace {
 
+// Boilerplate for std::visit.
+template <class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+// Given a valid string containing a supported RenderEngine class name, returns
+// the full name as would be returned by SceneGraph::GetRendererTypeName().
+// @pre We already know that `class_name` is a "supported" value.
+const std::string& LookupEngineType(const std::string& class_name) {
+  using Dict = std::map<std::string, std::string>;
+  static const never_destroyed<Dict> type_lookup(
+      std::initializer_list<Dict::value_type>{
+          {"",  // Empty string defaults to RenderEngineVtk.
+           "drake::geometry::render_vtk::internal::RenderEngineVtk"},
+          {"RenderEngineVtk",
+           "drake::geometry::render_vtk::internal::RenderEngineVtk"},
+          {"RenderEngineGl",
+           "drake::geometry::render_gl::internal::RenderEngineGl"},
+          {"RenderEngineGltfClient",
+           "drake::geometry::render_gltf_client::internal::"
+           "RenderEngineGltfClient"}});
+  return type_lookup.access().at(class_name);
+}
+
+template <typename ParamsType>
+const char* GetEngineName(const ParamsType&) {
+  if constexpr (std::is_same_v<ParamsType, RenderEngineVtkParams>) {
+    return "RenderEngineVtk";
+  } else if constexpr (std::is_same_v<ParamsType, RenderEngineGlParams>) {
+    return "RenderEngineGl";
+    // NOLINTNEXTLINE(readability/braces) The line break confuses the linter.
+  } else if constexpr (std::is_same_v<ParamsType,
+                                      RenderEngineGltfClientParams>) {
+    return "RenderEngineGltfClient";
+  }
+}
+
+void MakeEngineByClassName(const std::string& class_name,
+                           const CameraConfig& config,
+                           SceneGraph<double>* scene_graph) {
+  if (class_name == "RenderEngineGl") {
+    if (!geometry::kHasRenderEngineGl) {
+      throw std::logic_error(
+          "Invalid camera configuration; renderer_class = 'RenderEngineGl' "
+          "is not supported in current build.");
+    }
+    RenderEngineGlParams params{.default_clear_color = config.background};
+    scene_graph->AddRenderer(config.renderer_name, MakeRenderEngineGl(params));
+    return;
+  } else if (class_name == "RenderEngineGltfClient") {
+    scene_graph->AddRenderer(config.renderer_name,
+                             MakeRenderEngineGltfClient({}));
+    return;
+  }
+  // Note: if we add *other* supported render engine implementations, add the
+  // logic for detecting and instantiating those types here.
+
+  // Fall through to the default render engine type (name is either empty or
+  // the only remaining possible value: "RenderEngineVtk").
+  DRAKE_DEMAND(class_name.empty() || class_name == "RenderEngineVtk");
+  RenderEngineVtkParams params;
+  const geometry::Rgba& rgba = config.background;
+  params.default_clear_color = Vector3d{rgba.r(), rgba.g(), rgba.b()};
+  scene_graph->AddRenderer(config.renderer_name, MakeRenderEngineVtk(params));
+}
+
 // Validates the render engine specification in `config`. If the specification
 // is valid, upon return, the specified RenderEngine is defined in `scene_graph`
 // (this may require creating the RenderEngine instance). Throws if the
 // specification is invalid.
-// @pre we already know that config.renderer_class has a "supported" value.
+// @pre If config.renderer_class *names* a class, it is a "supported" value.
 void ValidateEngineAndMaybeAdd(const CameraConfig& config,
                                SceneGraph<double>* scene_graph) {
-  using Dict = std::map<std::string, std::string>;
-  static const never_destroyed<Dict> type_lookup(
-      std::initializer_list<Dict::value_type>{
-          {"RenderEngineVtk",
-           "drake::geometry::render_vtk::internal::RenderEngineVtk"},
-          {"RenderEngineGl",
-           "drake::geometry::render_gl::internal::RenderEngineGl"}});
-
   DRAKE_DEMAND(scene_graph != nullptr);
 
   // Querying for the type_name of the named renderer will simultaneously tell
@@ -70,40 +134,56 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
 
   // Non-empty type name says that it already exists.
   bool already_exists = !type_name.empty();
-  if (already_exists && !config.renderer_class.empty()) {
-    if (type_lookup.access().at(config.renderer_class) != type_name) {
-      throw std::logic_error(
-          fmt::format("Invalid camera configuration; requested "
-                      "renderer_name = '{}' and renderer_class = '{}'. The "
-                      "name is already used with a different type: {}.",
-                      config.renderer_name, config.renderer_class, type_name));
-    }
+
+  if (already_exists) {
+    std::visit(
+        overloaded{
+            [&type_name, &config](const std::string& class_name) -> void {
+              if (LookupEngineType(class_name) != type_name) {
+                throw std::logic_error(fmt::format(
+                    "Invalid camera configuration; requested renderer_name "
+                    "= '{}' and renderer_class = '{}'. The name is already "
+                    "used with a different type: {}.",
+                    config.renderer_name, class_name, type_name));
+              }
+            },
+            [&config](auto&&) -> void {
+              throw std::logic_error(
+                  fmt::format("Invalid camera configuration; requested "
+                              "renderer_name = '{}' with renderer parameters, "
+                              "but the named renderer already exists. Only the "
+                              "first instance of the named renderer can use "
+                              "parameters.",
+                              config.renderer_name));
+            }},
+        config.renderer_class);
   }
 
   if (already_exists) return;
 
-  // Now we know we need to add one. Confirm we can add the specified class.
-  if (config.renderer_class == "RenderEngineGl") {
-    if (!geometry::kHasRenderEngineGl) {
-      throw std::logic_error(
-          "Invalid camera configuration; renderer_class = 'RenderEngineGl' "
-          "is not supported in current build.");
-    }
-    RenderEngineGlParams params{.default_clear_color = config.background};
-    scene_graph->AddRenderer(config.renderer_name, MakeRenderEngineGl(params));
-    return;
-  }
-  // Note: if we add *other* supported render engine implementations, add the
-  // logic for detecting and instantiating those types here.
-
-  // Fall through to the default render engine type (name is either empty or
-  // the only remaining possible value: "RenderEngineVtk").
-  DRAKE_DEMAND(config.renderer_class.empty() ||
-               config.renderer_class == "RenderEngineVtk");
-  RenderEngineVtkParams params;
-  const geometry::Rgba& rgba = config.background;
-  params.default_clear_color = Vector3d{rgba.r(), rgba.g(), rgba.b()};
-  scene_graph->AddRenderer(config.renderer_name, MakeRenderEngineVtk(params));
+  std::visit(
+      overloaded{
+          [&config, scene_graph](const std::string& class_name) {
+            MakeEngineByClassName(class_name, config, scene_graph);
+          },
+          [&config, scene_graph](const RenderEngineVtkParams& params) {
+            scene_graph->AddRenderer(config.renderer_name,
+                                     MakeRenderEngineVtk(params));
+          },
+          [&config, scene_graph](const RenderEngineGlParams& params) {
+            if (!geometry::kHasRenderEngineGl) {
+              throw std::logic_error(
+                  "Invalid camera configuration; renderer_class = "
+                  "'RenderEngineGl' is not supported in current build.");
+            }
+            scene_graph->AddRenderer(config.renderer_name,
+                                     MakeRenderEngineGl(params));
+          },
+          [&config, scene_graph](const RenderEngineGltfClientParams& params) {
+            scene_graph->AddRenderer(config.renderer_name,
+                                     MakeRenderEngineGltfClient(params));
+          }},
+      config.renderer_class);
 }
 
 }  // namespace

--- a/systems/sensors/test/camera_config_functions_test.cc
+++ b/systems/sensors/test/camera_config_functions_test.cc
@@ -9,6 +9,8 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/render_gl/factory.h"
+#include "drake/geometry/render_gltf_client/factory.h"
+#include "drake/geometry/render_vtk/factory.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/sensors/image_to_lcm_image_array_t.h"
@@ -21,6 +23,9 @@ namespace sensors {
 namespace {
 
 using drake::geometry::FrameId;
+using drake::geometry::RenderEngineGlParams;
+using drake::geometry::RenderEngineGltfClientParams;
+using drake::geometry::RenderEngineVtkParams;
 using drake::geometry::Rgba;
 using drake::geometry::SceneGraph;
 using drake::geometry::render::ColorRenderCamera;
@@ -57,7 +62,7 @@ CameraConfig MakeConfig() {
                       .X_BC = Transform{RigidTransformd{Vector3d::UnitX()}},
                       .X_BD = Transform{RigidTransformd{Vector3d::UnitX()}},
                       .renderer_name = "test_renderer",
-                      .renderer_class = "RenderEngineVtk",
+                      .renderer_class = "RenderEngineGltfClient",
                       .background = Rgba(0.25, 0.5, 0.75),
                       .name = "test_camera",
                       .fps = 17,
@@ -129,8 +134,8 @@ TEST_F(CameraConfigFunctionsTest, EarlyExit) {
   EXPECT_EQ(builder_.GetSystems().size(), system_count);
 }
 
-// The tests below require that the default CameraConfig renders at least one
-// image. This test puts a guard on that property.
+/* The tests below require that the default CameraConfig renders at least one
+ image. This test puts a guard on that property. */
 GTEST_TEST(CameraConfigFunctionsTestAux, DefaultConfigRenders) {
   const CameraConfig config;
   EXPECT_TRUE(config.rgb || config.depth);
@@ -176,13 +181,16 @@ TEST_F(CameraConfigFunctionsTest, InvalidParentBaseFrame) {
                               ".*invalid_frame.*");
 }
 
-/* Confirms that render engine is handled correctly.
+/* Confirms that renderer_name is handled correctly.
   - If a render engine is named that hasn't been previously created, a new
     engine is added and the sensor is assigned to it.
   - If a previously existing engine is named, no new engine is created and
     the existing engine is shared.
+    - The error case where the same name is used with a different class is
+      dealt with in RendererNameReuse.
+  - The provided renderer_name and config.name is piped into the sensor.
   This is independent of image type, so, we'll use rgb. */
-TEST_F(CameraConfigFunctionsTest, RenderEngine) {
+TEST_F(CameraConfigFunctionsTest, RendererClassBasic) {
   ASSERT_EQ(scene_graph_->RendererCount(), 0);
 
   CameraConfig config;
@@ -200,7 +208,7 @@ TEST_F(CameraConfigFunctionsTest, RenderEngine) {
   // Now add second camera which uses the same name.
   size_t previous_system_count = builder_.GetSystems().size();
   config.name = config.name + "_the_other_one";
-  ApplyCameraConfig(config, &builder_);
+  EXPECT_NO_THROW(ApplyCameraConfig(config, &builder_));
 
   // No new render engine added.
   ASSERT_EQ(scene_graph_->RendererCount(), 1);
@@ -218,7 +226,7 @@ TEST_F(CameraConfigFunctionsTest, RenderEngine) {
   // Third camera uses a unique name creates a unique render engine.
   config.name = "just_for_test";
   config.renderer_name = "just_for_test";
-  ApplyCameraConfig(config, &builder_);
+  EXPECT_NO_THROW(ApplyCameraConfig(config, &builder_));
   ASSERT_EQ(scene_graph_->RendererCount(), 2);
   // New RgbdSensor added.
   EXPECT_GT(builder_.GetSystems().size(), previous_system_count);
@@ -230,6 +238,137 @@ TEST_F(CameraConfigFunctionsTest, RenderEngine) {
   EXPECT_EQ(sensor3->depth_render_camera().core().renderer_name(),
             config.renderer_name);
 }
+
+/* Exercises the various ways to specify the various RenderEngine classes - via
+ class name or parameters. Simply a regression test to make sure the spellings
+ work. */
+TEST_F(CameraConfigFunctionsTest, RendererClassVariant) {
+  int renderer_count = 0;
+
+  // Add VTK by name.
+  {
+    const CameraConfig config{.renderer_name = "vtk_name",
+                              .renderer_class = "RenderEngineVtk"};
+    ApplyCameraConfig(config, &builder_);
+    EXPECT_EQ(scene_graph_->RendererCount(), ++renderer_count);
+    EXPECT_THAT(scene_graph_->GetRendererTypeName(config.renderer_name),
+                testing::EndsWith("RenderEngineVtk"));
+  }
+  // Add VTK by parameters.
+  {
+    const CameraConfig config{.renderer_name = "vtk_params",
+                              .renderer_class = RenderEngineVtkParams{}};
+    ApplyCameraConfig(config, &builder_);
+    EXPECT_EQ(scene_graph_->RendererCount(), ++renderer_count);
+    EXPECT_THAT(scene_graph_->GetRendererTypeName(config.renderer_name),
+                testing::EndsWith("RenderEngineVtk"));
+  }
+
+  // Add glTF client by name.
+  {
+    const CameraConfig config{.renderer_name = "gltf_client_name",
+                              .renderer_class = "RenderEngineGltfClient"};
+    ApplyCameraConfig(config, &builder_);
+    EXPECT_EQ(scene_graph_->RendererCount(), ++renderer_count);
+    EXPECT_THAT(scene_graph_->GetRendererTypeName(config.renderer_name),
+                testing::EndsWith("RenderEngineGltfClient"));
+  }
+  // Add glTF client by parameters.
+  {
+    const CameraConfig config{.renderer_name = "gltf_client_params",
+                              .renderer_class = RenderEngineGltfClientParams{}};
+    ApplyCameraConfig(config, &builder_);
+    EXPECT_EQ(scene_graph_->RendererCount(), ++renderer_count);
+    EXPECT_THAT(scene_graph_->GetRendererTypeName(config.renderer_name),
+                testing::EndsWith("RenderEngineGltfClient"));
+  }
+
+  if (geometry::kHasRenderEngineGl) {
+    // Add GL by name.
+    {
+      const CameraConfig config{.renderer_name = "gl_name",
+                                .renderer_class = "RenderEngineGl"};
+      ApplyCameraConfig(config, &builder_);
+      EXPECT_EQ(scene_graph_->RendererCount(), ++renderer_count);
+      EXPECT_THAT(scene_graph_->GetRendererTypeName(config.renderer_name),
+                  testing::EndsWith("RenderEngineGl"));
+    }
+    // Add GL by parameters.
+    {
+      const CameraConfig config{.renderer_name = "gl_params",
+                                .renderer_class = RenderEngineGlParams{}};
+      ApplyCameraConfig(config, &builder_);
+      EXPECT_EQ(scene_graph_->RendererCount(), ++renderer_count);
+      EXPECT_THAT(scene_graph_->GetRendererTypeName(config.renderer_name),
+                  testing::EndsWith("RenderEngineGl"));
+    }
+  }
+}
+
+/* Confirms the logic for when a renderer name is successfully used several
+ times.
+
+  - If a name is reused and the class is specified via parameters, the
+    parameterized spec must come first.
+ */
+TEST_F(CameraConfigFunctionsTest, RendererNameReuse) {
+  int renderer_count = 0;
+
+  auto perform_test = [this, &renderer_count](const auto& parameters,
+                                              const std::string& name) {
+    CameraConfig config{.renderer_name = name + "_renderer",
+                        .renderer_class = parameters,
+                        .name = name + "_initial_params_succeeds"};
+    ApplyCameraConfig(config, &builder_);
+    EXPECT_EQ(scene_graph_->RendererCount(), ++renderer_count);
+    EXPECT_THAT(scene_graph_->GetRendererTypeName(config.renderer_name),
+                testing::EndsWith(name));
+
+    // Another camera config using parameters should throw.
+    config.name = name + "_second_params_throws";
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        ApplyCameraConfig(config, &builder_),
+        ".*Only the first instance of the named renderer can use parameters.");
+
+    // However, camera config using the same class name is happy.
+    config.name = name + "_class_name_succeeds";
+    config.renderer_class = name;
+    EXPECT_NO_THROW(ApplyCameraConfig(config, &builder_));
+    EXPECT_EQ(scene_graph_->RendererCount(), renderer_count);
+
+    // Camera config using the name of a different class is angry.
+    config.name = name + "_wrong_class_name_throws";
+    config.renderer_class = name == "RenderEngineVtk" ? "RenderEngineGltfClient"
+                                                      : "RenderEngineVtk";
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        ApplyCameraConfig(config, &builder_),
+        ".*The name is already used with a different type.*.");
+  };
+
+  {
+    SCOPED_TRACE("Vtk");
+    perform_test(RenderEngineVtkParams(), "RenderEngineVtk");
+  }
+
+  {
+    SCOPED_TRACE("GltfClient");
+    perform_test(RenderEngineGltfClientParams(), "RenderEngineGltfClient");
+  }
+
+  if (geometry::kHasRenderEngineGl) {
+    SCOPED_TRACE("Gl");
+    perform_test(RenderEngineGlParams(), "RenderEngineGl");
+  }
+}
+
+// TODO(SeanCurtis-TRI): We'd like to verify that the .background value is used
+// when RenderEngineVtk or RenderEngineGl are specified by class name. However,
+// we don't have any straightforward way to introspect a SceneGraph model
+// RenderEngine. We can get one from a QueryObject, but that's quite cumbersome.
+// Solving this problem also empowers solving the problem where we detect that
+// a set of engine parameters matches the parameters of a previously
+// instantiated engine, allowing us to relax our "parameters must come only on
+// the first shared renderer name" rule.
 
 // Confirms that all of the parameters in CameraConfig are present in the final
 // configuration. This excludes the following parameters:


### PR DESCRIPTION
Previously, the nature of the render engine was given by a single string: naming the render engine class to use. It makes the `RenderEngine` impossible to configure.

This extends the `renderer_class` field to also take instances of the various `RenderEngine*Params` structs. Now the engines can be fully specified in yaml.

This also extends the set of renderer classes to include GltfCLient.

Updated the documentation on `CameraConfig::background` to clarify its scope in the new world.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19863)
<!-- Reviewable:end -->
