### PR TITLE
Deprecate all optitrack-related code for removal

### DIFF
--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -508,6 +508,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "optitrack_receiver_test",
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":optitrack_receiver",
         "//common/test_utilities:eigen_matrix_compare",
@@ -518,6 +519,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "optitrack_sender_test",
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":optitrack_sender",
         "@optitrack_driver//lcmtypes:optitrack_lcmtypes",

--- a/systems/sensors/optitrack_receiver.h
+++ b/systems/sensors/optitrack_receiver.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -23,7 +24,12 @@ output_ports:
 - <em style="color:gray">...</em>
 @endsystem
 */
-class OptitrackReceiver : public systems::LeafSystem<double> {
+class DRAKE_DEPRECATED(
+    "2023-11-01",
+    "The OptitrackReceiver will be removed from Drake. If you still need to "
+    "use this class, feel free to copy its source code to your own project "
+    "and customize it to your needs.")  // BR
+    OptitrackReceiver : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptitrackReceiver)
 

--- a/systems/sensors/optitrack_sender.h
+++ b/systems/sensors/optitrack_sender.h
@@ -1,10 +1,5 @@
 #pragma once
 
-/// @file This file implements a system which populates optitrack_frame_t
-/// messages for publishing over a message passing system. Currently we support
-/// publishing over LCM, and may support other messaging protocols in the
-/// future.
-
 #include <map>
 #include <string>
 #include <utility>
@@ -12,6 +7,7 @@
 #include "optitrack/optitrack_frame_t.hpp"
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -34,7 +30,12 @@ namespace sensors {
 /// output_ports:
 /// - y0
 /// @endsystem
-class OptitrackLcmFrameSender : public systems::LeafSystem<double> {
+class DRAKE_DEPRECATED(
+    "2023-11-01",
+    "The OptitrackLcmFrameSender will be removed from Drake. If you still need "
+    "to use this class, feel free to copy its source code to your own project "
+    "and customize it to your needs.")  // BR
+    OptitrackLcmFrameSender : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptitrackLcmFrameSender)
 

--- a/tools/install/libdrake/drake-config.cmake.in
+++ b/tools/install/libdrake/drake-config.cmake.in
@@ -20,6 +20,9 @@ if(${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX STREQUAL "/")
   set(${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX)
 endif()
 
+# TODO(jwnimmer-tri) On 2023-11-01 upon completion of deprecation removal,
+# also remove all mentions of optitrack from this file.
+
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules;${CMAKE_MODULE_PATH}")
 find_dependency(Eigen3 3.3.4 CONFIG)
 find_dependency(fmt 6.0 CONFIG HINTS "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/cmake/fmt")

--- a/tools/install/libdrake/header_lint.bzl
+++ b/tools/install/libdrake/header_lint.bzl
@@ -10,11 +10,14 @@ _ALLOWED_EXTERNALS = [
     "eigen",
     "fmt",
     "lcm",
-    "optitrack",
     "spdlog",
 
     # The entries that follow are defects; we should work to remove them.
     "zlib",
+
+    # TODO(jwnimmer-tri) On 2023-11-01 upon completion of deprecation removal,
+    # also remove this item from this list.
+    "optitrack",
 ]
 
 # Drake's allowed list of public preprocessor definitions. The only things

--- a/tools/install/libdrake/test/header_dependency_test.py
+++ b/tools/install/libdrake/test/header_dependency_test.py
@@ -24,6 +24,9 @@ class HeaderDependencyTest(unittest.TestCase):
         re_thirds = [
             re.compile(r'^(Eigen|unsupported/Eigen)/.*$'),
             re.compile(r'^(fmt|spdlog)/.*$'),
+
+            # TODO(jwnimmer-tri) On 2023-11-01 upon completion of deprecation
+            # removal, also remove this item from this list.
             re.compile(r'^optitrack/.*$'),
         ]
 

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -239,6 +239,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
     if "opengl" not in excludes:
         opengl_repository(name = "opengl")
     if "optitrack_driver" not in excludes:
+        # The @optitrack_driver external is deprecated and will be removed on
+        # or after 2023-11-01.
         optitrack_driver_repository(name = "optitrack_driver", mirrors = mirrors)  # noqa
     if "org_apache_xmlgraphics_commons" not in excludes:
         org_apache_xmlgraphics_commons_repository(name = "org_apache_xmlgraphics_commons", mirrors = mirrors)  # noqa

--- a/tools/workspace/optitrack_driver/optitrack_client
+++ b/tools/workspace/optitrack_driver/optitrack_client
@@ -5,6 +5,12 @@ import sys
 
 
 def main():
+    print("""
+Drake's installed optitrack_client script is deprecated and will be removed
+from future releases on or after 2023-11-01. As a replacement, use the wheel
+packages provided by https://github.com/RobotLocomotion/optitrack-driver.
+""")
+
     prefix = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     sys.path.insert(0, os.path.join(
         prefix, 'lib',

--- a/tools/workspace/optitrack_driver/repository.bzl
+++ b/tools/workspace/optitrack_driver/repository.bzl
@@ -3,6 +3,9 @@ load("@drake//tools/workspace:github.bzl", "github_archive")
 def optitrack_driver_repository(
         name,
         mirrors = None):
+    """The @optitrack_driver external is deprecated and will be removed on or
+    after 2023-11-01.
+    """
     github_archive(
         name = name,
         repository = "RobotLocomotion/optitrack-driver",


### PR DESCRIPTION
The following code will be removed in ~3 months:

- `drake::systems::sensors::OptitrackLcmFrameSender`
- `drake::systems::sensors::OptitrackReceiver`
- The `@optitrack_driver` external
- The installed `optitrack_client` program

Note that this does not add Bazel deprecation markers anywhere (doing so ends up being extra trouble for downstreams).

Closes #19600.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19866)
<!-- Reviewable:end -->
