### PR TITLE
[py manipulation] Deprecate three vestigial sub-modules

### DIFF
--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -41,8 +41,8 @@ drake_pybind_library(
     ],
     py_srcs = [
         "_manipulation_extra.py",
-        # TODO(jwnimmer-tri) On 2023-06-01 add deprecation for these modules.
-        # See #18683 for an example of what to do.
+        # TODO(jwnimmer-tri) On 2023-11-01 upon completion of deprecation,
+        # remove these files.
         "kuka_iiwa.py",
         "schunk_wsg.py",
         "util.py",

--- a/bindings/pydrake/manipulation/kuka_iiwa.py
+++ b/bindings/pydrake/manipulation/kuka_iiwa.py
@@ -2,9 +2,9 @@
 
 Prefer not to use this import path in new code; all of the code in
 this module can be imported from pydrake.manipulation directly.
-
-This module will be deprecated at some point in the future.
 """
+
+from pydrake.common.deprecation import _warn_deprecated
 
 from pydrake.manipulation import (
     ApplyDriverConfig,
@@ -22,3 +22,8 @@ from pydrake.manipulation import (
     position_enabled,
     torque_enabled,
 )
+
+_warn_deprecated(
+    "Please import from the pydrake.manipulation module directly, instead of "
+    f"the deprecated {__name__} submodule.",
+    date="2023-11-01", stacklevel=3)

--- a/bindings/pydrake/manipulation/schunk_wsg.py
+++ b/bindings/pydrake/manipulation/schunk_wsg.py
@@ -2,9 +2,9 @@
 
 Prefer not to use this import path in new code; all of the code in
 this module can be imported from pydrake.manipulation directly.
-
-This module will be deprecated at some point in the future.
 """
+
+from pydrake.common.deprecation import _warn_deprecated
 
 from pydrake.manipulation import (
     ApplyDriverConfig,
@@ -20,3 +20,8 @@ from pydrake.manipulation import (
     SchunkWsgStatusReceiver,
     SchunkWsgStatusSender,
 )
+
+_warn_deprecated(
+    "Please import from the pydrake.manipulation module directly, instead of "
+    f"the deprecated {__name__} submodule.",
+    date="2023-11-01", stacklevel=3)

--- a/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
+++ b/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import pydrake.manipulation.kuka_iiwa as mut
+import pydrake.manipulation as mut
 
 import unittest
 import numpy as np

--- a/bindings/pydrake/manipulation/test/schunk_wsg_test.py
+++ b/bindings/pydrake/manipulation/test/schunk_wsg_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import pydrake.manipulation.schunk_wsg as mut
+import pydrake.manipulation as mut
 
 import unittest
 import numpy as np

--- a/bindings/pydrake/manipulation/test/util_test.py
+++ b/bindings/pydrake/manipulation/test/util_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import pydrake.manipulation.util as mut
+import pydrake.manipulation as mut
 
 import unittest
 

--- a/bindings/pydrake/manipulation/util.py
+++ b/bindings/pydrake/manipulation/util.py
@@ -2,11 +2,16 @@
 
 Prefer not to use this import path in new code; all of the code in
 this module can be imported from pydrake.manipulation directly.
-
-This module will be deprecated at some point in the future.
 """
+
+from pydrake.common.deprecation import _warn_deprecated
 
 from pydrake.manipulation import (
     ApplyDriverConfig,
     ZeroForceDriver,
 )
+
+_warn_deprecated(
+    "Please import from the pydrake.manipulation module directly, instead of "
+    f"the deprecated {__name__} submodule.",
+    date="2023-11-01", stacklevel=3)


### PR DESCRIPTION
Follow-up from #18973.

Manually tested:
```console
>>> from pydrake.all import *
>>> import pydrake.manipulation
>>> import pydrake.manipulation.kuka_iiwa
<stdin>:1: DrakeDeprecationWarning: Please import from the pydrake.manipulation module directly, instead of the deprecated pydrake.manipulation.kuka_iiwa submodule. The deprecated code will be removed from Drake on or after 2023-11-01.

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19869)
<!-- Reviewable:end -->
