### PR TITLE
Clearly document the drake_visualizer program as legacy code

### DIFF
--- a/bindings/pydrake/multibody/examples/jupyter_widgets_examples.ipynb
+++ b/bindings/pydrake/multibody/examples/jupyter_widgets_examples.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "This version of the sliders is intended for use as a System in a Diagram.\n",
     "\n",
-    "Running this cell should allow you to control the joints of the IIWA in drake visualizer.  You must set `running_as_notebook` to `True` in the cell above."
+    "Running this cell should allow you to control the joints of the IIWA in Meldis.  You must set `running_as_notebook` to `True` in the cell above."
    ]
   },
   {
@@ -83,7 +83,7 @@
     "\n",
     "This version of the sliders uses callback on the widget events to call Publish.  It does not provide a System and does not use Simulator.  While it doesn't work for as many applications, it has the advantage that one does not have to `AdvanceTo` in a loop to have a meaningful interaction.\n",
     "\n",
-    "Running this cell should allow you to control the joints of the IIWA in drake visualizer.  This time, it is without a simulator and relying solely on callbacks.\n",
+    "Running this cell should allow you to control the joints of the IIWA in Meldis.  This time, it is without a simulator and relying solely on callbacks.\n",
     "\n",
     "You should see the output in the textbox below the sliders update with the number of times the callback is called; it should report that it was called once immediately, before you even move the sliders."
    ]

--- a/bindings/pydrake/systems/jupyter_widgets_examples.ipynb
+++ b/bindings/pydrake/systems/jupyter_widgets_examples.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "# PoseSliders\n",
     "\n",
-    "Running this cell should allow you to control the 6 DOF pose of a mustard bottle in drake visualizer."
+    "Running this cell should allow you to control the 6 DOF pose of a mustard bottle in Meldis."
    ]
   },
   {

--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -40,8 +40,8 @@ from pydrake.visualization._triad import (
 
 class ModelVisualizer:
     """
-    Visualizes models from a file or string buffer in Drake Visualizer,
-    meldis, or MeshCat.
+    Visualizes models from a file or string buffer in MeshCat, Meldis,
+    or the legacy ``drake_visualizer`` application of days past.
 
     To use this class to visualize model(s), create an instance with
     any desired options, add any models, and then call Run()::

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -4,7 +4,7 @@ MeshCat LCM Display Server (MeLDiS)
 A standalone program that can display Drake visualizations in MeshCat
 by listening for LCM messages that are broadcast by the simulation.
 
-This can stand in for the legacy ``drake-visualizer`` application of
+This can stand in for the legacy ``drake_visualizer`` application of
 days past.
 
 From a Drake source build, run this as::

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -33,7 +33,7 @@ drake_cc_binary(
 )
 
 # The :models in these packages are installed as part of the Drake release
-# process, and loaded into drake_visualizer's model database by default.
+# process and loaded into //tools:drake_visualizer's model database by default.
 INSTALLED_MODEL_PACKAGES = [
     "//examples/acrobot",
     "//examples/hydroelastic/spatula_slip_control",

--- a/examples/hardware_sim/hardware_sim.cc
+++ b/examples/hardware_sim/hardware_sim.cc
@@ -9,8 +9,9 @@ listens for command messages.
 It is intended to operate in the "no ground truth" regime, i.e, the only LCM
 messages it knows about are the ones used by the actual hardware. The one
 messaging difference from real life is that we emit visualization messages (for
-meldis or drake-visualizer) so that you can watch a simulation on your screen
-while some (separate) controller operates the robot, without extra hassle.
+Meldis, or the legacy `drake_visualizer` application of days past) so that you
+can watch a simulation on your screen while some (separate) controller operates
+the robot, without extra hassle.
 
 Drake maintainers should keep this file in sync with hardware_sim.py. */
 

--- a/examples/hardware_sim/hardware_sim.py
+++ b/examples/hardware_sim/hardware_sim.py
@@ -10,8 +10,9 @@ listens for command messages.
 It is intended to operate in the "no ground truth" regime, i.e, the only LCM
 messages it knows about are the ones used by the actual hardware. The one
 messaging difference from real life is that we emit visualization messages (for
-meldis or drake-visualizer) so that you can watch a simulation on your screen
-while some (separate) controller operates the robot, without extra hassle.
+Meldis, or the legacy ``drake-visualizer`` application of days past) so that
+you can watch a simulation on your screen while some (separate) controller
+operates the robot, without extra hassle.
 
 Drake maintainers should keep this file in sync with both hardware_sim.cc and
 scenario.h.

--- a/examples/hydroelastic/ball_plate/README.md
+++ b/examples/hydroelastic/ball_plate/README.md
@@ -13,7 +13,7 @@ files and also calling C++ APIs.
 
 ![ball_plate](images/ball_plate.jpg)
 
-<h2> Preliminary Step: drake_visualizer </h2>
+<h2> Preliminary Step: the legacy drake_visualizer application of days past </h2>
 
 ```
 bazel run //tools:drake_visualizer &

--- a/examples/hydroelastic/ball_plate/ball_plate_run_dynamics.cc
+++ b/examples/hydroelastic/ball_plate/ball_plate_run_dynamics.cc
@@ -134,7 +134,7 @@ int main(int argc, char* argv[]) {
       "and plate-floor contacts are rigid-compliant, compliant-compliant,\n"
       "and rigid-compliant. The hydroelastic contact model can work with\n"
       "non-convex shapes accurately without resorting to their convex\n"
-      "hulls. Launch drake-visualizer before running this example.\n"
+      "hulls. Launch drake_visualizer before running this example.\n"
       "See the README.md file for more information.\n");
   FLAGS_simulator_publish_every_time_step = true;
   FLAGS_simulator_target_realtime_rate = 0.1;

--- a/examples/hydroelastic/python_ball_paddle/README.md
+++ b/examples/hydroelastic/python_ball_paddle/README.md
@@ -11,7 +11,7 @@ World's X-Y plane. The center of its top surface is at World origin.
 The compliant ball has radius of 2 cm. By default, it is dropped 4 cm above
 the paddle.
 
-## Run Drake Visualizer
+## Run the legacy Drake Visualizer application of days past
 
 ```
 bazel run //tools:drake_visualizer &

--- a/examples/hydroelastic/python_nonconvex_mesh/README.md
+++ b/examples/hydroelastic/python_nonconvex_mesh/README.md
@@ -8,7 +8,7 @@ The bell pepper is a non-convex compliant mesh.
 The bowl is a non-convex rigid mesh.
 The table is a compliant box primitive.
 
-## Run Drake Visualizer
+## Run the legacy Drake Visualizer application of days past
 ```
 bazel run //tools:drake_visualizer &
 ```

--- a/examples/hydroelastic/spatula_slip_control/README.md
+++ b/examples/hydroelastic/spatula_slip_control/README.md
@@ -80,8 +80,8 @@ bazel run //examples/hydroelastic/spatula_slip_control:spatula_slip_control \
 
 **WARNING**: According to issue
 [17681](https://github.com/RobotLocomotion/drake/issues/17681),
-only `//tools:drake_visualizer`, not MeshCat, not meldis,
-can draw wireframe of the contact surfaces.
+only the legacy `//tools:drake_visualizer` application of days past, not
+MeshCat nor meldis, can draw wireframe of the contact surfaces.
 As a result, you will need `//tools:drake_visualizer` to visualize the 
 difference between the `triangle` option and the default `polygon` option.
 However, `//tools:drake_visualizer` is only available in the older

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -252,7 +252,7 @@ int main(int argc, char* argv[]) {
       "The example poses the spatula in the closed grip of the gripper and\n"
       "uses an open loop square wave controller to perform a controlled\n"
       "rotational slip of the spatula while maintaining the spatula in\n"
-      "the gripper's grasp. Launch drake-visualizer before running this\n"
+      "the gripper's grasp. Launch drake_visualizer before running this\n"
       "example. See the README.md file for more information.\n");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::spatula_slip_control::DoMain();

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -235,7 +235,7 @@ def main():
         station.Finalize()
 
         # If using meshcat, don't render the cameras, since RgbdCamera
-        # rendering only works with drake-visualizer. Without this check,
+        # rendering only works with Meldis (modulo #18862). Without this check,
         # running this code in a docker container produces libGL errors.
         geometry_query_port = station.GetOutputPort("geometry_query")
 
@@ -249,7 +249,7 @@ def main():
         if args.setup == 'planar':
             meshcat.Set2dRenderMode()
 
-        # Connect and publish to drake visualizer.
+        # Connect LCM visualization.
         DrakeVisualizer.AddToBuilder(builder, geometry_query_port)
         image_to_lcm_image_array = builder.AddSystem(
             ImageToLcmImageArrayT())

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -18,8 +18,8 @@ namespace examples {
 namespace manipulation_station {
 namespace {
 
-// Simple example which simulates the manipulation station (and visualizes it
-// with drake visualizer).
+// Simple example which simulates the manipulation station (and transmits
+// visualization data for Meldis to display).
 // TODO(russt): Replace this with a slightly more interesting minimal example
 // (e.g. picking up an object) and perhaps a slightly more descriptive name.
 

--- a/examples/multibody/inclined_plane_with_body/README.md
+++ b/examples/multibody/inclined_plane_with_body/README.md
@@ -22,15 +22,10 @@ finite box (if a finite box, the block can fall off the inclined plane).
 
 Open a terminal in the `drake` workspace, and type commands as shown below.
 
-Build the example like so:
-```
-bazel build //tools:drake_visualizer //examples/multibody/inclined_plane_with_body
-```
-
 Run the example like so:
 ```
-bazel-bin/tools/drake_visualizer &
-bazel-bin/examples/multibody/inclined_plane_with_body/inclined_plane_with_body
+bazel run //tools:meldis -- --open-window &
+bazel run //examples/multibody/inclined_plane_with_body:inclined_plane_with_body
 ```
 
 Alternatively,
@@ -38,10 +33,10 @@ to simulate body B as a block that has 4 contacting spheres welded to its
 lowest four corners on a 30 degree inclined plane A (modeled as a half-space), 
 pass command line arguments to the executable by typing:
 ```
-bazel-bin/examples/multibody/inclined_plane_with_body/inclined_plane_with_body -inclined_plane_angle_degrees=30 -bodyB_type=block_with_4Spheres
+bazel run //examples/multibody/inclined_plane_with_body:inclined_plane_with_body -- -inclined_plane_angle_degrees=30 -bodyB_type=block_with_4Spheres
 ```
 
 To see a list of all possible command-line arguments:
 ```
-bazel-bin/examples/multibody/inclined_plane_with_body/inclined_plane_with_body -help
+bazel run //examples/multibody/inclined_plane_with_body:inclined_plane_with_body -- -help
 ```

--- a/examples/multibody/rolling_sphere/README.md
+++ b/examples/multibody/rolling_sphere/README.md
@@ -127,21 +127,11 @@ workspace directory.
 cd drake
 ```
 
-Ensure that you have built the Drake visualizer with
-```
-bazel build //tools:drake_visualizer
-```
-
-Build the example in this directory
-```
-bazel build //examples/multibody/rolling_sphere/...
-```
-
 ## Visualizer
 
-Before running the example, launch the visualizer (building it as necessary):
+Before running the example, launch the visualizer:
 ```
-bazel-bin/tools/drake_visualizer
+bazel run //tools:meldis -- --open-window &
 ```
 
 ## Example
@@ -154,44 +144,44 @@ can make.
 The command below runs the default configuration using a continuous modeling of
 the dynamics.
 ```
-bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics
+bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics
 ```
 
 ##### Default behavior, discrete solver
 Run the same configuration as above, but this time using a discrete
 approximation of the dynamics with an update period of one millisecond.
 ```
-bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --mbp_dt=1.0e-3
+bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics -- --mbp_dt=1.0e-3
 ```
 The discrete solver supports all other configurations below, including hybrid
 contact.
 
 ##### Default behavior with hydroelastic contact with default compliance type; rigid ground, compliant ball
 ```
-bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hydroelastic
+bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics -- --contact_model=hydroelastic
 ```
 
 ##### Default behavior with hydroelastic contact with reversed compliance; compliant ground, rigid ball
 ```
-bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hydroelastic --rigid_ball=1 --soft_ground=1
+bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics -- --contact_model=hydroelastic --rigid_ball=1 --soft_ground=1
 ```
 
 ##### Default behavior with hybrid contact
 ```
-bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hybrid
+bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics -- --contact_model=hybrid
 ```
 
 ##### Add the wall with hydroelastic contact -- throw when sphere hits the wall
 ```
-bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hydroelastic --add_wall=1
+bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics -- --contact_model=hydroelastic --add_wall=1
 ```
 
 ##### Add the wall with hybrid contact
 ```
-bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hybrid --add_wall=1
+bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics -- --contact_model=hybrid --add_wall=1
 ```
 
 ##### Add the wall, make the sphere rigid with hybrid contact
 ```
-bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hybrid --add_wall=1 --rigid_ball=1
+bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics -- --contact_model=hybrid --add_wall=1 --rigid_ball=1
 ```

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -229,7 +229,7 @@ int main(int argc, char* argv[]) {
       "A rolling sphere demo using Drake's MultibodyPlant, "
       "with SceneGraph visualization. This demo allows to switch between "
       "different contact models and integrators to evaluate performance."
-      "Launch drake-visualizer before running this example.");
+      "Launch meldis before running this example.");
   // We slow down the default realtime rate to 0.2, so that we can appreciate
   // the motion. Users can still change it on command-line, e.g.
   // --simulator_target_realtime_rate=0.5.

--- a/examples/planar_gripper/planar_gripper_simulation.cc
+++ b/examples/planar_gripper/planar_gripper_simulation.cc
@@ -107,7 +107,7 @@ DEFINE_string(orientation, "vertical",
               "The orientation of the planar gripper. Options are {vertical, "
               "horizontal}.");
 DEFINE_bool(visualize_contacts, false,
-            "Visualize contacts in Drake visualizer.");
+            "Visualize contacts in Meldis.");
 DEFINE_bool(
     use_position_control, true,
     "If true (default) we simulate position control via inverse dynamics "

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -136,8 +136,7 @@ int do_main() {
     builder.Connect(scene_graph->get_query_output_port(),
                     camera->query_object_input_port());
 
-    // Broadcast the images.
-    // Publishing images to drake visualizer
+    // Broadcast the images to Meldis (available after #18862 is finished).
     auto image_to_lcm_image_array =
         builder.template AddSystem<systems::sensors::ImageToLcmImageArrayT>();
     image_to_lcm_image_array->set_name("converter");

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -468,8 +468,8 @@ std::string MakeLcmChannelNameForRole(const std::string& channel,
   DRAKE_DEMAND(params.role != Role::kUnassigned);
 
   // These channel name transformations must be kept in sync with message
-  // consumers (meldis, drake_visualizer) in order for visualization of all
-  // roles to work.
+  // consumers (Meldis, or the legacy ``drake_visualizer`` application of days
+  // past) in order for visualization of all roles to work.
   switch (params.role) {
     case Role::kIllustration:
       return channel + "_ILLUSTRATION";

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -59,9 +59,13 @@ std::string MakeLcmChannelNameForRole(const std::string& channel,
 
 }  // namespace internal
 
-/** A system that publishes LCM messages compatible with the `drake_visualizer`
- application representing the current state of a SceneGraph instance (whose
- QueryObject-valued output port is connected to this system's input port).
+/** A system that publishes LCM messages representing the current state of a
+ SceneGraph instance (whose QueryObject-valued output port is connected to this
+ system's input port).
+
+ The messages are compatible with the legacy `drake_visualizer` application of
+ days past, or its modern re-implementation
+ <a href="/pydrake/pydrake.visualization.meldis.html">Meldis</a>.
 
  @system
  name: DrakeVisualizer
@@ -88,7 +92,7 @@ std::string MakeLcmChannelNameForRole(const std::string& channel,
 
  The system uses the versioning mechanism provided by SceneGraph to detect
  changes to the geometry so that a change in SceneGraph's data will propagate
- to `drake_visualizer`.
+ to the message receiver.
 
  @anchor drake_visualizer_role_consumer
  <h3>Visualization by Role</h3>
@@ -117,8 +121,8 @@ std::string MakeLcmChannelNameForRole(const std::string& channel,
  <h4>Appearance of OBJ files</h4>
 
  Meshes represented by OBJ are special. The OBJ file can reference a material
- file (.mtl). If found by `drake_visualizer`, the values in the .mtl will take
- precedence over the ("phong", "diffuse") geometry property.
+ file (.mtl). If the mtl file is found by the receiving application, values in
+ the .mtl will take precedence over the ("phong", "diffuse") geometry property.
 
  It's worth emphasizing that these rules permits control over the appearance of
  collision geometry on a per-geometry basis by assigning an explicit Rgba value
@@ -324,11 +328,11 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
       const systems::Context<T>& context) const;
 
   /* DrakeVisualizer stores a "model" of what it thinks is registered in the
-   drake_visualizer application. Because drake_visualizer is not part of the
+   receiving application. Because that application is not part of the
    Drake state, this model is likewise not part of the Drake state. It is a
    property of the system. This allows arbitrary changes to the context but
    DrakeVisualizer can still make its *best effort* to ensure that
-   drake_visualizer state is consistent with the messages it is about to send.
+   the remote state is consistent with the messages it is about to send.
    Because of the nature of lcm messages, it cannot make guarantees; lcm
    messages can arrive in a different order than they were broadcast.
 

--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -107,7 +107,8 @@
     }
 
     requestAnimationFrame( animate );
-    // Set background to match Drake Visualizer.
+    // Set background to match the legacy ``drake_visualizer`` application of
+    // days past.
     viewer.set_property(['Background'], "top_color", [.95, .95, 1.0])
     viewer.set_property(['Background'], "bottom_color", [.32, .32, .35])
     // Set the initial view looking up the y-axis.

--- a/geometry/profiling/README.md
+++ b/geometry/profiling/README.md
@@ -14,8 +14,9 @@ ball. The rigid bowl is a realistic non-convex object, and the compliant
 ball uses a coarse tetrahedral mesh, which is typical in hydroelastic 
 contact model.
 
-To visualize the contact surface and pressure, run drake_visualizer and
-configure Hydroelastic Contact Visualization plugin as follows:
+To visualize the contact surface and pressure, run the legacy
+``drake_visualizer`` application of days past and configure Hydroelastic
+Contact Visualization plugin as follows:
 1. From the top menu, click on: `Plugins > Contacts > Configure Hydroelastic
  Contact Visualization.`
 2. Change `Maximum pressure` to a reasonably large number (for example, 4e7).

--- a/geometry/render_gltf_client/test/README.md
+++ b/geometry/render_gltf_client/test/README.md
@@ -17,7 +17,7 @@ it before proceeding.
 
 ## Run the Client-Server Testing Suite
 There are three commands to run to launch the client, the server, and optionally
-Drake Visualizer for displaying rendered images.
+Meldis to observe what's happening.
 
 ### Run the Server
 A single threaded / single worker flask development server on host `127.0.0.1`
@@ -53,12 +53,12 @@ Note that if you ran your server on an alternate `--host` or `--port`, you will
 need to specify that in `--server_base_url` when running `client_demo`
 executable as well.
 
-### (Optional) Run Drake Visualizer
+### (Optional) Run Meldis
 
-In a separate terminal, launch drake_visualizer.
+In a separate terminal, launch Meldis.
 
 ```
-$ bazel run //tools:drake_visualizer
+$ bazel run //tools:meldis
 ```
 
 ## Testing of the client-server RPC pipeline

--- a/geometry/render_gltf_client/test/client_demo.cc
+++ b/geometry/render_gltf_client/test/client_demo.cc
@@ -220,7 +220,7 @@ int DoMain() {
   builder.Connect(scene_graph.get_query_output_port(),
                   camera->query_object_input_port());
 
-  // Broadcast images via LCM for visualization (via drake visualizer).
+  // Broadcast images via LCM for visualization (requires #18862 to see them).
   const double image_publish_period = 1. / FLAGS_render_fps;
   ImageToLcmImageArrayT* image_to_lcm_image_array =
       builder.template AddSystem<ImageToLcmImageArrayT>();

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -323,8 +323,9 @@ void SceneGraph<T>::AssignRole(Context<T>* context, SourceId source_id,
   static const logging::Warn one_time(
       "Due to a bug (see issue #13597), changing the illustration roles or "
       "properties in the context will not have any apparent effect in, at "
-      "least, drake_visualizer. Please change the illustration role in the "
-      "model prior to allocating the Context.");
+      "least, the legacy `drake_visualizer` application of days past. Please "
+      "change the illustration role in the model prior to allocating the "
+      "Context.");
   auto& g_state = mutable_geometry_state(context);
   g_state.AssignRole(source_id, geometry_id, std::move(properties), assign);
 }

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -837,8 +837,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @warning Due to a bug (see issue
    <a href="https://github.com/RobotLocomotion/drake/issues/13597">#13597</a>),
    changing the illustration roles or properties in a systems::Context will not
-   have any apparent effect in, at least, drake_visualizer. Please change the
-   illustration role in the model prior to allocating the context.
+   have any apparent effect in, at least, the legacy `drake_visualizer`
+   application of days past. Please change the illustration role in the model
+   prior to allocating the context.
    @pydrake_mkdoc_identifier{illustration_context}
    */
   void AssignRole(systems::Context<T>* context, SourceId source_id,

--- a/manipulation/models/realsense2_description/BUILD.bazel
+++ b/manipulation/models/realsense2_description/BUILD.bazel
@@ -66,7 +66,6 @@ drake_cc_googletest(
     data = [":models"],
     deps = [
         "//common:find_resource",
-        "//geometry:drake_visualizer",
         "//geometry:scene_graph",
         "//multibody/parsing",
         "//systems/analysis:simulator",

--- a/manipulation/models/realsense2_description/test/realsense_parse_test.cc
+++ b/manipulation/models/realsense2_description/test/realsense_parse_test.cc
@@ -1,19 +1,3 @@
-/*
-@file
-Parses and visualizes Realsense d415.
-
-If you wish to visualize this mesh, in its own terminal run:
-
- $ bazel-bin/tools/drake_visualizer
-
-In a new terminal, run example of showing a Realsense d415:
-
- $ bazel run \
-   //manipulation/models/realsense2_description:realsense_parse_test -- \
-   --visualize=true
-
-*/
-
 #include <string>
 
 #include <fmt/format.h>
@@ -21,19 +5,15 @@ In a new terminal, run example of showing a Realsense d415:
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
-#include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 
-DEFINE_bool(visualize, false, "Publish model to Drake Visualizer.");
-
 namespace drake {
 namespace manipulation {
 namespace {
 
-using geometry::DrakeVisualizerd;
 using geometry::SceneGraph;
 using multibody::AddMultibodyPlantSceneGraph;
 using multibody::Parser;
@@ -42,7 +22,7 @@ using systems::Simulator;
 
 class ParseTest : public testing::TestWithParam<std::string> {};
 
-TEST_P(ParseTest, ParsesUrdfAndVisualizes) {
+TEST_P(ParseTest, ParsesUrdf) {
   const std::string object_name = GetParam();
   const std::string filename = FindResourceOrThrow(fmt::format(
       "drake/manipulation/models/realsense2_description/urdf/{}.urdf",
@@ -59,17 +39,6 @@ TEST_P(ParseTest, ParsesUrdfAndVisualizes) {
 
   // Ensure there was exactly one model instance added for the new model.
   EXPECT_EQ(plant.num_model_instances() - default_num_models, 1);
-
-  // Visualize via publishing, if requested.
-  if (FLAGS_visualize) {
-    DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
-    plant.Finalize();
-    auto diagram = builder.Build();
-    drake::log()->info("Visualize: {}", object_name);
-    Simulator<double> simulator(*diagram);
-    simulator.Initialize();
-    diagram->ForcedPublish(simulator.get_context());
-  }
 }
 
 // Note: We use a test suite here, even if currently for only one value, to

--- a/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
+++ b/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
@@ -326,9 +326,9 @@ modulus value.
 
 @subsection hug_visualizing Visualizing hydroelastic contact
 
-Currently we can visualize the contact surface using Drake Visualizer; however,
-it will be replaced by [MeshCat](https://github.com/rdeits/meshcat) in the
-future.
+Currently we can only visualize the contact surface using the legacy
+``drake_visualizer`` application of days past; however, it will be replaced by
+[MeshCat](https://github.com/rdeits/meshcat) in the future.
 
 Start Drake Visualizer by:
 

--- a/multibody/plant/contact_results_to_lcm.h
+++ b/multibody/plant/contact_results_to_lcm.h
@@ -190,9 +190,9 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
  @anchor contact_result_vis_creation
 
  These functions extend a Diagram with the required components to publish
- contact results (as reported by MultibodyPlant) to a visualizer (either meldis
- or drake_visualizer). We recommend using these functions instead of assembling
- the requisite components by hand.
+ contact results (as reported by MultibodyPlant) to a visualizer (either Meldis
+ or the legacy ``drake_visualizer`` application of days past). We recommend
+ using these functions instead of assembling the requisite components by hand.
 
  These must be called _during_ Diagram building. Each function makes
  modifications to the diagram being constructed by `builder` including the

--- a/systems/sensors/lcm_image_array_receive_example.cc
+++ b/systems/sensors/lcm_image_array_receive_example.cc
@@ -2,7 +2,7 @@
 /// ImageToLcmImageArrayT systems.  It receives an incoming stream of
 /// lcmt_image_array messages, unpacks and repacks the color and
 /// depth frames, and retransmits the images.  The output can be viewed in
-/// drake_visualizer.
+/// Meldis once #18862 is finished.
 
 #include <gflags/gflags.h>
 

--- a/tools/workspace/drake_visualizer/README.md
+++ b/tools/workspace/drake_visualizer/README.md
@@ -1,3 +1,10 @@
+# Deprecation
+
+The legacy `drake_visualizer` application is deprecated for removal and is only
+maintained on the Ubuntu 20.04 ("Focal") operating system.  When Drake drops
+support for that platform (ETA spring of 2024), the `drake_visualizer` program
+will also be dropped.
+
 # drake_visualizer
 
 The files in this directory should by and large be ignored by consumers.

--- a/tutorials/mathematical_program_multibody_plant.ipynb
+++ b/tutorials/mathematical_program_multibody_plant.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "***To be added***:\n",
     "* Using `pydrake.multibody.inverse_kinematics`.\n",
-    "* Visualizing with Drake Visualizer.\n",
+    "* Visualizing with Meshcat.\n",
     "\n",
     "### Important Note\n",
     "\n",

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -12,8 +12,8 @@ namespace visualization {
 
 // TODO(jwnimmer-tri or trowell-tri) Add an option to disable LCM entirely.
 
-/** Settings for what MultibodyPlant and SceneGraph should send to meldis,
-Meshcat, and/or drake_visualizer.
+/** Settings for what MultibodyPlant and SceneGraph should send to Meshcat,
+Meldis, and/or the legacy ``drake_visualizer`` application of days past.
 
 See ApplyVisualizationConfig() for how to enact this configuration. */
 struct VisualizationConfig {

--- a/visualization/visualization_config_functions.h
+++ b/visualization/visualization_config_functions.h
@@ -18,8 +18,8 @@
 namespace drake {
 namespace visualization {
 
-/** Adds LCM visualization publishers to communicate to drake_visualizer
-and/or meldis.
+/** Adds LCM visualization publishers to communicate to Meshcat, Meldis, and/or
+the legacy ``drake_visualizer`` application of days past.
 
 <dl><dt>Example</dt><dd>
 @code
@@ -124,9 +124,9 @@ void ApplyVisualizationConfig(
     std::shared_ptr<geometry::Meshcat> meshcat = nullptr,
     lcm::DrakeLcmInterface* lcm = nullptr);
 
-/** Adds LCM visualization publishers to communicate to Meshcat,
-drake_visualizer and/or meldis, using all of the default configuration
-settings.
+/** Adds LCM visualization publishers to communicate to Meshcat, Meldis, and/or
+the legacy ``drake_visualizer`` application of days past, using all of the
+default configuration settings.
 
 @param meshcat An optional existing Meshcat instance. (If nullptr, then a
 meshcat instance will be created.)


### PR DESCRIPTION
- Anywhere we mention `drake_visualizer` refer to it as "legacy ... of days past".
- Replace ipynb mentions of `drake_visualizer` with Meldis.
- Remove visualization from realsense parsing test; that's what `//tools:model_visualizer` is for.

Closes #16216.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19871)
<!-- Reviewable:end -->
