### PR TITLE
[workspace] Deprecate the rules_pkg external

### DIFF
--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -263,6 +263,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
     if "ros_xacro_internal" not in excludes:
         ros_xacro_internal_repository(name = "ros_xacro_internal", mirrors = mirrors)  # noqa
     if "rules_pkg" not in excludes:
+        # The @rules_pkg external is deprecated in Drake's WORKSPACE and will
+        # be removed on or after 2023-11-01.
         rules_pkg_repository(name = "rules_pkg", mirrors = mirrors)
     if "rules_python" not in excludes:
         rules_python_repository(name = "rules_python", mirrors = mirrors)

--- a/tools/workspace/metadata.py
+++ b/tools/workspace/metadata.py
@@ -37,7 +37,6 @@ def read_repository_metadata(repositories=None):
 
         # These are starlark deps, so don't show up in the query.
         repositories.add("bazel_skylib")
-        repositories.add("rules_pkg")
 
     # Make sure all of the repository_rule results are up-to-date.
     subprocess.check_call(["bazel", "fetch", "//..."])

--- a/tools/workspace/rules_pkg/repository.bzl
+++ b/tools/workspace/rules_pkg/repository.bzl
@@ -6,6 +6,9 @@ load("@drake//tools/workspace:github.bzl", "github_archive")
 def rules_pkg_repository(
         name,
         mirrors = None):
+    """The @rules_pkg external is deprecated in Drake's WORKSPACE and will be
+    removed on or after 2023-11-01.
+    """
     github_archive(
         name = name,
         repository = "bazelbuild/rules_pkg",  # License: Apache-2.0


### PR DESCRIPTION
This has been unused within Drake for a while now.

Note that in this case it's impractical to add build-system warnings to announce the deprecation.  The only place the deprecation will be announced is in the new source file comments and the release notes.

Closes #19781.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19872)
<!-- Reviewable:end -->
