### PR TITLE
Cleanup GcsTrajectoryOptimization Subgraph costs and constraints

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -490,7 +490,9 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py::arg("target"),
             py::arg("options") =
                 geometry::optimization::GraphOfConvexSetsOptions(),
-            cls_doc.SolvePath.doc);
+            cls_doc.SolvePath.doc)
+        .def("graph_of_convex_sets", &Class::graph_of_convex_sets,
+            py_rvp::reference_internal, cls_doc.graph_of_convex_sets.doc);
   }
 }
 

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -17,6 +17,7 @@ from pydrake.planning import (
 )
 from pydrake.geometry.optimization import (
     GraphOfConvexSetsOptions,
+    GraphOfConvexSets,
     HPolyhedron,
     Point,
     VPolytope,
@@ -632,6 +633,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
 
         # Add tighter velocity bounds to the main2 subgraph.
         main2.AddVelocityBounds(lb=-0.5*max_vel, ub=0.5*max_vel)
+
+        self.assertIsInstance(gcs.graph_of_convex_sets(), GraphOfConvexSets)
 
         options = GraphOfConvexSetsOptions()
         options.convex_relaxation = True


### PR DESCRIPTION
- Simplifies AddPathLengthCost.
- Uses the new BezierCurve method to avoid Expression parsing in
  AddVelocityBounds (and uses SparseMatrix).
- Avoids extraneous placeholder variable manipulation.
- Fixes some missing default names.

+@wrangelvid for feature review, please.
Note: this has #19867 as a first commit.  You can ignore those files in this review; I will merge that PR first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19873)
<!-- Reviewable:end -->
