### PR TITLE
[workspace] Remove vestigial meshcat files from the install

### DIFF
--- a/tools/workspace/meshcat/package.BUILD.bazel
+++ b/tools/workspace/meshcat/package.BUILD.bazel
@@ -1,6 +1,6 @@
 # -*- bazel -*-
 
-load("@drake//tools/install:install.bzl", "install", "install_files")
+load("@drake//tools/install:install.bzl", "install")
 
 licenses(["notice"])  # MIT
 
@@ -14,13 +14,6 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
-# This installation is for meshcat-python.
-install_files(
-    name = "install_viewer",
-    dest = "@PYTHON_SITE_PACKAGES@/meshcat/viewer",
-    files = VIEWER_FILES,
-)
-
 install(
     name = "install",
     docs = [
@@ -29,5 +22,4 @@ install(
     ],
     doc_strip_prefix = ["dist"],
     visibility = ["//visibility:public"],
-    deps = [":install_viewer"],
 )


### PR DESCRIPTION
I believe these were used by `meshcat-python`, but are now unused.

+@RussTedrake for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19877)
<!-- Reviewable:end -->
