### PR TITLE
[workspace] Deprecate the conex external

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -226,7 +226,7 @@ drake_cc_library(
         "//common:essential",
     ],
     deps = [
-        "@conex//conex:supernodal_solver",
+        "@conex_internal//conex:supernodal_solver",
     ],
 )
 

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -111,7 +111,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "yaml_cpp_internal",
 ]] + ["//tools/workspace/%s:install" % p for p in [
     "abseil_cpp_internal",
-    "conex",
+    "conex_internal",
     "drake_visualizer",
     "gflags",
     "optitrack_driver",

--- a/tools/workspace/conex/BUILD.bazel
+++ b/tools/workspace/conex/BUILD.bazel
@@ -1,16 +1,3 @@
-load("@drake//tools/install:install.bzl", "install_files")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-
-install_files(
-    name = "install",
-    dest = "share/doc/conex",
-    files = [
-        "@conex//:LICENSE",
-    ],
-    allowed_externals = [
-        "@conex//:LICENSE",
-    ],
-    visibility = ["//tools/workspace:__pkg__"],
-)
 
 add_lint_tests()

--- a/tools/workspace/conex/patches/deprecation.patch
+++ b/tools/workspace/conex/patches/deprecation.patch
@@ -1,0 +1,106 @@
+[conex] Add deprecation messages
+
+--- conex/BUILD
++++ conex/BUILD
+@@ -1,3 +1,5 @@
++_DEPRECATION = "DRAKE_DEPRECATED: The @conex external is deprecated in Drake's WORKSPACE and will be removed on or after 2023-11-01."
++
+ cc_library(
+     name = "test_util",
+     srcs = glob(["test/test_util.cc"]),
+@@ -111,6 +111,7 @@
+     srcs = ["approximate_eigenvalues.cc"],
+     hdrs = ["approximate_eigenvalues.h"],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = ["@eigen"],
+ )
+ 
+@@ -133,6 +134,7 @@
+     ],
+     hdrs = ["exponential_map_pade.h"],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = ["@eigen"],
+ )
+ 
+@@ -144,6 +146,7 @@
+     ],
+     hdrs = ["jordan_matrix_algebra.h"],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = [
+         "@eigen",
+     ],
+@@ -175,6 +178,7 @@
+     srcs = ["exponential_map.cc"],
+     hdrs = ["exponential_map.h"],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = [
+         "jordan_matrix_algebra",
+         "@eigen",
+@@ -241,6 +245,7 @@
+         "tree_utils.h",
+     ],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = ["@eigen"],
+ )
+ 
+@@ -277,6 +282,7 @@
+         "workspace.h",
+     ],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = [
+         "tree_utils",
+         "@eigen",
+@@ -304,6 +310,7 @@
+         "workspace.h",
+     ],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = [
+         "divergence",
+         ":supernodal_solver",
+@@ -321,6 +328,7 @@
+         "linear_workspace.h",
+     ],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = [
+         "core",
+         "@eigen",
+@@ -340,6 +348,7 @@
+         "psd_constraint.h",
+     ],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = [
+         "approximate_eigenvalues",
+         "core",
+@@ -362,6 +371,7 @@
+         "newton_step.h",
+     ],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = ["@eigen"],
+ )
+ 
+@@ -378,6 +388,7 @@
+         "soc_constraint.h",
+     ],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = [
+         "core",
+         "@eigen",
+@@ -397,6 +408,7 @@
+         "workspace.h",
+     ],
+     visibility = ["//visibility:public"],
++    deprecation = _DEPRECATION,
+     deps = [
+         "approximate_eigenvalues",
+         "core",

--- a/tools/workspace/conex_internal/BUILD.bazel
+++ b/tools/workspace/conex_internal/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@drake//tools/install:install.bzl", "install_files")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+install_files(
+    name = "install",
+    dest = "share/doc/conex",
+    files = [
+        "@conex_internal//:LICENSE",
+    ],
+    allowed_externals = [
+        "@conex_internal//:LICENSE",
+    ],
+    visibility = ["//tools/workspace:__pkg__"],
+)
+
+add_lint_tests()

--- a/tools/workspace/conex_internal/package.BUILD.bazel
+++ b/tools/workspace/conex_internal/package.BUILD.bazel
@@ -1,0 +1,3 @@
+# -*- bazel -*-
+
+exports_files(["LICENSE"])

--- a/tools/workspace/conex_internal/patches/debug_macros.patch
+++ b/tools/workspace/conex_internal/patches/debug_macros.patch
@@ -1,4 +1,4 @@
-Add a missing #include statements
+[conex] Add a missing #include statements
 
 See https://github.com/ToyotaResearchInstitute/conex/pull/4
 

--- a/tools/workspace/conex_internal/patches/no_eigen_io.patch
+++ b/tools/workspace/conex_internal/patches/no_eigen_io.patch
@@ -1,4 +1,4 @@
-Nerf the DUMP() macro to elide the dumped value
+[conex] Nerf the DUMP() macro to elide the dumped value
 
 Drake builds using EIGEN_NO_IO, so Conex can't use it either.
 

--- a/tools/workspace/conex_internal/repository.bzl
+++ b/tools/workspace/conex_internal/repository.bzl
@@ -1,11 +1,8 @@
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def conex_repository(
+def conex_internal_repository(
         name,
         mirrors = None):
-    """The @conex external is deprecated in Drake's WORKSPACE and will be
-    removed on or after 2023-11-01.
-    """
     github_archive(
         name = name,
         repository = "ToyotaResearchInstitute/conex",
@@ -13,9 +10,8 @@ def conex_repository(
         sha256 = "3f88f45276a1b474946b67e7c650fefd6d7c9dcb48f0c0a11393be3e6adc5ba7",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
-            ":patches/deprecation.patch",
-            "//tools/workspace/conex_internal:patches/debug_macros.patch",
-            "//tools/workspace/conex_internal:patches/no_eigen_io.patch",
+            ":patches/debug_macros.patch",
+            ":patches/no_eigen_io.patch",
         ],
         mirrors = mirrors,
     )

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -12,6 +12,7 @@ load("@drake//tools/workspace/com_jidesoft_jide_oss:repository.bzl", "com_jideso
 load("@drake//tools/workspace/common_robotics_utilities:repository.bzl", "common_robotics_utilities_repository")  # noqa
 load("@drake//tools/workspace/commons_io:repository.bzl", "commons_io_repository")  # noqa
 load("@drake//tools/workspace/conex:repository.bzl", "conex_repository")
+load("@drake//tools/workspace/conex_internal:repository.bzl", "conex_internal_repository")  # noqa
 load("@drake//tools/workspace/csdp:repository.bzl", "csdp_repository")
 load("@drake//tools/workspace/curl_internal:repository.bzl", "curl_internal_repository")  # noqa
 load("@drake//tools/workspace/double_conversion:repository.bzl", "double_conversion_repository")  # noqa
@@ -133,7 +134,11 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
     if "commons_io" not in excludes:
         commons_io_repository(name = "commons_io", mirrors = mirrors)
     if "conex" not in excludes:
+        # The @conex external is deprecated in Drake's WORKSPACE and will be
+        # removed on or after 2023-11-01.
         conex_repository(name = "conex", mirrors = mirrors)
+    if "conex_internal" not in excludes:
+        conex_internal_repository(name = "conex_internal", mirrors = mirrors)
     if "csdp" not in excludes:
         csdp_repository(name = "csdp", mirrors = mirrors)
     if "curl_internal" not in excludes:


### PR DESCRIPTION
We are already applying custom patches to our copy of conex, and will be applying more in the future (for C++ ODR).  As such, it needs to be badged as "internal".

Towards #17231.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19883)
<!-- Reviewable:end -->
