### PR TITLE
[multibody] Adds active/inactive parameter for SAP constraints.

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -258,6 +258,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("force_element"), py_rvp::reference_internal,
             cls_doc.AddForceElement.doc)
+        .def("SetConstraintActiveStatus", &Class::SetConstraintActiveStatus,
+            py::arg("context"), py::arg("id"), py::arg("status"),
+            cls_doc.SetConstraintActiveStatus.doc)
+        .def("GetConstraintActiveStatus",
+            overload_cast_explicit<bool, const Context<T>&,
+                MultibodyConstraintId>(&Class::GetConstraintActiveStatus),
+            py::arg("context"), py::arg("id"),
+            cls_doc.GetConstraintActiveStatus.doc)
         .def("AddCouplerConstraint", &Class::AddCouplerConstraint,
             py::arg("joint0"), py::arg("joint1"), py::arg("gear_ratio"),
             py::arg("offset") = 0.0, py_rvp::reference_internal,

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -224,6 +224,14 @@ DiscreteUpdateManager<T>::ball_constraints_specs() const {
 }
 
 template <typename T>
+const std::map<MultibodyConstraintId, bool>&
+DiscreteUpdateManager<T>::GetConstraintActiveStatus(
+    const systems::Context<T>& context) const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::GetConstraintActiveStatus(context, *plant_);
+}
+
+template <typename T>
 BodyIndex DiscreteUpdateManager<T>::FindBodyByGeometryId(
     geometry::GeometryId geometry_id) const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::FindBodyByGeometryId(

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -259,6 +259,9 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   const std::map<MultibodyConstraintId, internal::BallConstraintSpec>&
   ball_constraints_specs() const;
 
+  const std::map<MultibodyConstraintId, bool>& GetConstraintActiveStatus(
+      const systems::Context<T>& context) const;
+
   BodyIndex FindBodyByGeometryId(geometry::GeometryId geometry_id) const;
   /* @} */
 

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -110,6 +110,12 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.ball_constraints_specs_;
   }
 
+  static const std::map<MultibodyConstraintId, bool>&
+  GetConstraintActiveStatus(const systems::Context<T>& context,
+                               const MultibodyPlant<T>& plant) {
+    return plant.GetConstraintActiveStatus(context);
+  }
+
   static BodyIndex FindBodyByGeometryId(const MultibodyPlant<T>& plant,
                                         geometry::GeometryId geometry_id) {
     return plant.FindBodyByGeometryId(geometry_id);

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -346,8 +347,12 @@ void SapDriver<T>::AddCouplerConstraints(const systems::Context<T>& context,
   const Vector1<T> stiffness(kInfinity);
   const Vector1<T> relaxation_time(plant().time_step());
 
+  const std::map<MultibodyConstraintId, bool>& constraint_active_status =
+      manager().GetConstraintActiveStatus(context);
+
   for (const auto& [id, info] : manager().coupler_constraints_specs()) {
-    unused(id);
+    // Skip this constraint if it is not active.
+    if (!constraint_active_status.at(id)) continue;
     const Joint<T>& joint0 = plant().get_joint(info.joint0_index);
     const Joint<T>& joint1 = plant().get_joint(info.joint1_index);
     const int dof0 = joint0.velocity_start();
@@ -414,8 +419,13 @@ void SapDriver<T>::AddDistanceConstraints(const systems::Context<T>& context,
 
   const Frame<T>& frame_W = plant().world_frame();
 
+  const std::map<MultibodyConstraintId, bool>& constraint_active_status =
+      manager().GetConstraintActiveStatus(context);
+
   for (const auto& [id, spec] : manager().distance_constraints_specs()) {
-    unused(id);
+    // skip this constraint if it is not active.
+    if (!constraint_active_status.at(id)) continue;
+
     const Body<T>& body_A = plant().get_body(spec.body_A);
     const Body<T>& body_B = plant().get_body(spec.body_B);
 
@@ -526,8 +536,14 @@ void SapDriver<T>::AddBallConstraints(
   MatrixX<T> Jv_ApBq_W = MatrixX<T>::Zero(3, nv);
 
   const Frame<T>& frame_W = plant().world_frame();
+
+  const std::map<MultibodyConstraintId, bool>& constraint_active_status =
+      manager().GetConstraintActiveStatus(context);
+
   for (const auto& [id, spec] : manager().ball_constraints_specs()) {
-    unused(id);
+    // skip this constraint if it is not active.
+    if (!constraint_active_status.at(id)) continue;
+
     const Body<T>& body_A = plant().get_body(spec.body_A);
     const Body<T>& body_B = plant().get_body(spec.body_B);
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3840,6 +3840,56 @@ GTEST_TEST(MultibodyPlantTest, AutoDiffAcrobotParameters) {
                               MatrixCompareType::relative));
 }
 
+GTEST_TEST(MultibodyPlantTests, ConstraintActiveStatus) {
+  // Set up a plant with 3 constraints with arbitrary parameters.
+  MultibodyPlant<double> plant(0.01);
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  const Body<double>& body_A =
+      plant.AddRigidBody("body_A", SpatialInertia<double>{});
+  const Body<double>& body_B =
+      plant.AddRigidBody("body_B", SpatialInertia<double>{});
+  const RevoluteJoint<double>& world_A =
+      plant.AddJoint<RevoluteJoint>("world_A", plant.world_body(), std::nullopt,
+                                    body_A, std::nullopt, Vector3d::UnitZ());
+  const RevoluteJoint<double>& A_B = plant.AddJoint<RevoluteJoint>(
+      "A_B", body_A, std::nullopt, body_B, std::nullopt, Vector3d::UnitZ());
+  MultibodyConstraintId coupler_id =
+      plant.AddCouplerConstraint(world_A, A_B, 2.3);
+  MultibodyConstraintId distance_id = plant.AddDistanceConstraint(
+      body_A, Vector3d(1.0, 2.0, 3.0), body_B, Vector3d(4.0, 5.0, 6.0), 2.0);
+  MultibodyConstraintId ball_id = plant.AddBallConstraint(
+      body_A, Vector3d(-1.0, -2.0, -3.0), body_B, Vector3d(-4.0, -5.0, -6.0));
+
+  plant.Finalize();
+
+  std::unique_ptr<Context<double>> context = plant.CreateDefaultContext();
+
+  // Verify all constraints are active in a default context.
+  EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, coupler_id));
+  EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, distance_id));
+  EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, ball_id));
+
+  // Set all constraints to inactive.
+  plant.SetConstraintActiveStatus(context.get(), coupler_id, false);
+  plant.SetConstraintActiveStatus(context.get(), distance_id, false);
+  plant.SetConstraintActiveStatus(context.get(), ball_id, false);
+
+  // Verify all constraints are inactive in the context.
+  EXPECT_FALSE(plant.GetConstraintActiveStatus(*context, coupler_id));
+  EXPECT_FALSE(plant.GetConstraintActiveStatus(*context, distance_id));
+  EXPECT_FALSE(plant.GetConstraintActiveStatus(*context, ball_id));
+
+  // Set all constraints to back to active.
+  plant.SetConstraintActiveStatus(context.get(), coupler_id, true);
+  plant.SetConstraintActiveStatus(context.get(), distance_id, true);
+  plant.SetConstraintActiveStatus(context.get(), ball_id, true);
+
+  // Verify all constraints are active in the context.
+  EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, coupler_id));
+  EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, distance_id));
+  EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, ball_id));
+}
+
 GTEST_TEST(MultibodyPlantTests, FixedOffsetFrameFunctions) {
   MultibodyPlant<double> plant(0.0);
   const Body<double>& body_B = plant.AddRigidBody("body_B",

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
@@ -14,7 +15,12 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
 #include "drake/multibody/plant/test/spheres_stack.h"
+#include "drake/multibody/tree/body.h"
+#include "drake/multibody/tree/revolute_joint.h"
 
+using drake::math::RigidTransformd;
+using drake::multibody::Body;
+using drake::multibody::RevoluteJoint;
 using drake::multibody::contact_solvers::internal::ContactSolverResults;
 using drake::multibody::contact_solvers::internal::MergeNormalAndTangent;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
@@ -350,6 +356,130 @@ TEST_F(SpheresStackTest, SapFailureException) {
   DRAKE_EXPECT_THROWS_MESSAGE(contact_manager_->CalcContactSolverResults(
                                   *plant_context_, &contact_results),
                               "The SAP solver failed to converge(.|\n)*");
+}
+
+// Unit test that the manager is forwarded the active status of each constraint
+// and produces a SapContactProblem with only the active constraints and
+// recalculates the cached SapContactProblem with constraint parameters change.
+GTEST_TEST(SapDriverTest, ConstraintActiveStatus) {
+  MultibodyPlant<double> plant(0.01);
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+  // Add two bodies and two joints in order to cover all constraint types.
+  // We aren't doing any physics in this test, just checking that constraint
+  // active status is forwarded through to the driver. So bodies, joints, and
+  // constraints have arbitrary non-physical parameters for ease of setup.
+  const Body<double>& body_A =
+      plant.AddRigidBody("body_A", SpatialInertia<double>::MakeUnitary());
+  const Body<double>& body_B =
+      plant.AddRigidBody("body_B", SpatialInertia<double>::MakeUnitary());
+  const RevoluteJoint<double>& world_A = plant.AddJoint<RevoluteJoint>(
+      "world_A", plant.world_body(), RigidTransformd::Identity(), body_A,
+      RigidTransformd::Identity(), Vector3d::UnitZ());
+  const RevoluteJoint<double>& A_B = plant.AddJoint<RevoluteJoint>(
+      "A_B", body_A, RigidTransformd::Identity(), body_B,
+      RigidTransformd::Identity(), Vector3d::UnitZ());
+
+  // Add one coupler constraint, one distance constraint, and one ball
+  // constraint.
+  MultibodyConstraintId coupler_constraint_id =
+      plant.AddCouplerConstraint(world_A, A_B, 1.2);
+  MultibodyConstraintId distance_constraint_id = plant.AddDistanceConstraint(
+      body_A, Vector3d::Zero(), body_B, Vector3d(1.0, 2.0, 3.0), 1.0);
+  MultibodyConstraintId ball_constraint_id = plant.AddBallConstraint(
+      body_A, Vector3d::Zero(), body_B, Vector3d::Zero());
+
+  // Finalize and set the manager/driver.
+  plant.Finalize();
+
+  auto owned_contact_manager =
+      std::make_unique<CompliantContactManager<double>>();
+  const CompliantContactManager<double>* contact_manager =
+      owned_contact_manager.get();
+  plant.SetDiscreteUpdateManager(std::move(owned_contact_manager));
+  const SapDriver<double>& sap_driver =
+      CompliantContactManagerTester::sap_driver(*contact_manager);
+
+  std::unique_ptr<Context<double>> context = plant.CreateDefaultContext();
+
+  // All constraints active.
+  {
+    const ContactProblemCache<double>& problem_cache =
+        SapDriverTest::EvalContactProblemCache(sap_driver, *context);
+    const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+    // Verify number of constraints when all are active. There is no contact
+    // so we expect one coupler constraint, one distance constraint and one
+    // ball constraint.
+    EXPECT_EQ(problem.num_constraints(), 3);
+    EXPECT_EQ(problem.num_constraint_equations(),
+              1 /* coupler constraint */ + 1 /* distance constraint */ +
+                  3 /* ball constraint */);
+    // TODO(joemasterjohn): When these constraints become first class citizens,
+    // verify the constraints via type casts rather than just looking at the
+    // number of constraint equations as a proxy.
+    EXPECT_EQ(problem.get_constraint(0).num_constraint_equations(), 1);
+    EXPECT_EQ(problem.get_constraint(1).num_constraint_equations(), 1);
+    EXPECT_EQ(problem.get_constraint(2).num_constraint_equations(), 3);
+  }
+
+  // Set the distance and ball constraint to inactive and verify that only the
+  // coupler constraint shows up in the problem.
+  {
+    plant.SetConstraintActiveStatus(context.get(), distance_constraint_id,
+                                    false);
+    plant.SetConstraintActiveStatus(context.get(), ball_constraint_id, false);
+
+    const ContactProblemCache<double>& problem_cache =
+        SapDriverTest::EvalContactProblemCache(sap_driver, *context);
+    const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+    // Verify number of constraints when only the coupler constraint is active.
+    EXPECT_EQ(problem.num_constraints(), 1);
+    EXPECT_EQ(problem.num_constraint_equations(), 1 /* coupler constraint */);
+    EXPECT_EQ(problem.get_constraint(0).num_constraint_equations(), 1);
+  }
+
+  // Now disable the coupler constraint and verify that the problem has 0
+  // constraints.
+  {
+    plant.SetConstraintActiveStatus(context.get(), coupler_constraint_id,
+                                    false);
+
+    const ContactProblemCache<double>& problem_cache =
+        SapDriverTest::EvalContactProblemCache(sap_driver, *context);
+    const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+    // Verify number of constraints when all are inactive.
+    EXPECT_EQ(problem.num_constraints(), 0);
+    EXPECT_EQ(problem.num_constraint_equations(), 0);
+  }
+
+  // Reactivate all constraints and verify they show up in the problem.
+  {
+    plant.SetConstraintActiveStatus(context.get(), distance_constraint_id,
+                                    true);
+    plant.SetConstraintActiveStatus(context.get(), ball_constraint_id, true);
+    plant.SetConstraintActiveStatus(context.get(), coupler_constraint_id, true);
+
+    const ContactProblemCache<double>& problem_cache =
+        SapDriverTest::EvalContactProblemCache(sap_driver, *context);
+    const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+    // Verify number of constraints when all are active. There is no contact
+    // so we expect one coupler constraint, one distance constraint and one
+    // ball constraint.
+    EXPECT_EQ(problem.num_constraints(), 3);
+    EXPECT_EQ(problem.num_constraint_equations(),
+              1 /* coupler constraint */ + 1 /* distance constraint */ +
+                  3 /* ball constraint */);
+    // TODO(joemasterjohn): When these constraints become first class citizens,
+    // verify the constraints via type casts rather than just looking at the
+    // number of constraint equations as a proxy.
+    EXPECT_EQ(problem.get_constraint(0).num_constraint_equations(), 1);
+    EXPECT_EQ(problem.get_constraint(1).num_constraint_equations(), 1);
+    EXPECT_EQ(problem.get_constraint(2).num_constraint_equations(), 3);
+  }
 }
 
 }  // namespace internal


### PR DESCRIPTION
Adds a parameter to `MultibodyPlant` that stores an "active" status for each constraint added to the plant. The active status is forwarded to `SapDriver` which in turn only adds "active" constraints to the `SapContactProblem` computed by `EvalContactProblemCache`. This allows a user to dynamically turn off/on constraints in a context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19884)
<!-- Reviewable:end -->
