### PR TITLE
Adds solvers::GetVariableInSemidefiniteRelaxation()

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -14,6 +14,11 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
 
   m.def("MakeSemidefiniteRelaxation", &solvers::MakeSemidefiniteRelaxation,
       py::arg("prog"), doc.MakeSemidefiniteRelaxation.doc);
+  
+  m.def("GetVariableInSemidefiniteRelaxation",
+      &solvers::GetVariableInSemidefiniteRelaxation,
+      py::arg("prog"), py::arg("relaxation"), py::arg("vars_in_prog"),
+      doc.GetVariableInSemidefiniteRelaxation.doc);
 }
 
 }  // namespace internal

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -31,5 +31,21 @@ namespace solvers {
 std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     const MathematicalProgram& prog);
 
+/** Combinations of variables in the original program are "linearized" into
+ additional decision variables in the relaxation. For instance, if the original
+ `prog` contained the variables, `x` and `y`, and then the relaxed program will
+ have `x` and `y`, but also `x²`, `xy`, and `y²` as new decision variables. To
+ find the decision variable associated with `xy` in the new program, pass in
+ `vars_in_prog = [x, y]`. 
+
+ @pre `relaxation` was constructed by calling `MakeSemidefiniteRelaxation` on
+ `prog` and no additional semidefinite constraints have been added.
+ @throws std::exception if `vars_in_prog` does not describe a variable in
+ `relaxation`.
+ */
+symbolic::Variable GetVariableInSemidefiniteRelaxation(
+    const MathematicalProgram& prog, const MathematicalProgram& relaxation,
+    std::vector<symbolic::Variable> vars_in_prog);
+
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
@hongkai-dai , @bernhardpg , @lujieyang  -- WDYT of this as a generalizable solution to the SDP relaxation variable idea?

I toyed with returning e.g. a `std::map<std::pair<Variable, Variable>, Variable>` from the `MakeSemidefiniteRelaxation` method, but this feels unscalable to more complicated settings (e.g. higher moment relaxations).  We could imagine other implementations of this -- for instance we could assign unique variable names in the relaxation and look things up by name.  We might need to pass more information between the two methods in the future. But I think as an API this is close to what we want?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19886)
<!-- Reviewable:end -->
