### PR TITLE
Enable Boundedness Checks for Spectrahedra and Intersections with Unbounded Components

### DIFF
--- a/geometry/optimization/affine_subspace.cc
+++ b/geometry/optimization/affine_subspace.cc
@@ -36,7 +36,7 @@ std::unique_ptr<ConvexSet> AffineSubspace::DoClone() const {
   return std::make_unique<AffineSubspace>(*this);
 }
 
-bool AffineSubspace::DoIsBounded() const {
+std::optional<bool> AffineSubspace::DoIsBoundedShortcut() const {
   return basis_.cols() == 0;
 }
 

--- a/geometry/optimization/affine_subspace.h
+++ b/geometry/optimization/affine_subspace.h
@@ -62,7 +62,7 @@ class AffineSubspace final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/cartesian_product.cc
+++ b/geometry/optimization/cartesian_product.cc
@@ -103,7 +103,7 @@ std::unique_ptr<ConvexSet> CartesianProduct::DoClone() const {
   return std::make_unique<CartesianProduct>(*this);
 }
 
-bool CartesianProduct::DoIsBounded() const {
+std::optional<bool> CartesianProduct::DoIsBoundedShortcut() const {
   // Note: The constructor enforces that A_ is full column rank.
   for (const auto& s : sets_) {
     if (!s->IsBounded()) {

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -81,7 +81,7 @@ class CartesianProduct final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -341,7 +341,7 @@ HPolyhedron HPolyhedron::MakeL1Ball(const int dim) {
   return {A, b};
 }
 
-bool HPolyhedron::DoIsBounded() const {
+std::optional<bool> HPolyhedron::DoIsBoundedShortcut() const {
   if (A_.rows() < A_.cols()) {
     return false;
   }

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -231,7 +231,7 @@ class HPolyhedron final : public ConvexSet {
 
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -256,7 +256,7 @@ std::unique_ptr<ConvexSet> Hyperellipsoid::DoClone() const {
   return std::make_unique<Hyperellipsoid>(*this);
 }
 
-bool Hyperellipsoid::DoIsBounded() const {
+std::optional<bool> Hyperellipsoid::DoIsBoundedShortcut() const {
   if (A_.rows() < A_.cols()) {
     return false;
   }

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -132,7 +132,7 @@ class Hyperellipsoid final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/intersection.cc
+++ b/geometry/optimization/intersection.cc
@@ -55,17 +55,13 @@ std::unique_ptr<ConvexSet> Intersection::DoClone() const {
   return std::make_unique<Intersection>(*this);
 }
 
-bool Intersection::DoIsBounded() const {
+std::optional<bool> Intersection::DoIsBoundedShortcut() const {
   for (const auto& s : sets_) {
     if (s->IsBounded()) {
       return true;
     }
   }
-  // TODO(mpetersen94): Cover case where sets are unbounded but intersection is
-  // bounded.
-  throw std::runtime_error(
-      "Determining the boundedness of an Intersection made up of unbounded "
-      "elements is not currently supported.");
+  return std::nullopt;
 }
 
 bool Intersection::DoIsEmpty() const {

--- a/geometry/optimization/intersection.h
+++ b/geometry/optimization/intersection.h
@@ -45,7 +45,7 @@ class Intersection final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -94,7 +94,7 @@ std::unique_ptr<ConvexSet> MinkowskiSum::DoClone() const {
   return std::make_unique<MinkowskiSum>(*this);
 }
 
-bool MinkowskiSum::DoIsBounded() const {
+std::optional<bool> MinkowskiSum::DoIsBoundedShortcut() const {
   for (const auto& s : sets_) {
     if (!s->IsBounded()) {
       return false;

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -66,7 +66,7 @@ class MinkowskiSum final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/point.cc
+++ b/geometry/optimization/point.cc
@@ -57,7 +57,7 @@ std::unique_ptr<ConvexSet> Point::DoClone() const {
   return std::make_unique<Point>(*this);
 }
 
-bool Point::DoIsBounded() const {
+std::optional<bool> Point::DoIsBoundedShortcut() const {
   return true;
 }
 

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -51,7 +51,7 @@ class Point final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   /** A Point is always nonempty, even in the zero-dimensional case. */
   bool DoIsEmpty() const final;

--- a/geometry/optimization/spectrahedron.h
+++ b/geometry/optimization/spectrahedron.h
@@ -43,7 +43,7 @@ class Spectrahedron final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   // N.B. No need to override DoMaybeGetPoint here.
 

--- a/geometry/optimization/test/intersection_test.cc
+++ b/geometry/optimization/test/intersection_test.cc
@@ -137,14 +137,14 @@ GTEST_TEST(IntersectionTest, TwoBoxes) {
 GTEST_TEST(IntersectionTest, BoundedTest) {
   HPolyhedron H1 = HPolyhedron(Matrix2d::Identity(), Vector2d{1, 1});
   HPolyhedron H2 = HPolyhedron(-Matrix2d::Identity(), Vector2d{1, 1});
-  Intersection S(H1, H2);
+  Intersection S1(H1, H2);
 
   EXPECT_FALSE(H1.IsBounded());
   EXPECT_FALSE(H2.IsBounded());
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      S.IsBounded(),
-      "Determining the boundedness of an Intersection made up of unbounded "
-      "elements is not currently supported.");
+  EXPECT_TRUE(S1.IsBounded());
+
+  Intersection S2(H1, H1);
+  EXPECT_FALSE(S2.IsBounded());
 }
 
 GTEST_TEST(IntersectionTest, CloneTest) {

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -336,7 +336,7 @@ std::unique_ptr<ConvexSet> VPolytope::DoClone() const {
   return std::make_unique<VPolytope>(*this);
 }
 
-bool VPolytope::DoIsBounded() const {
+std::optional<bool> VPolytope::DoIsBoundedShortcut() const {
   return true;
 }
 

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -96,7 +96,7 @@ class VPolytope final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 


### PR DESCRIPTION
This implements `DoIsBoundedShortcut()` for `ConvexSet`, and also modifies the implementations for `Intersection` and `Spectahedron` to use the generic base class method (after checking some edge cases).

Fixes #16663 (although potentially not in the most efficient way). +@russtedrake for feature review.

The implementation is slightly different than what I suggested in [this comment](https://github.com/RobotLocomotion/drake/issues/16663#issuecomment-1619017030) -- instead of maximizing and minimizing each dimension, I maximize the displacement between two feasible points along each dimension. This doubles the number of decision variables, but halves the number of optimization problems solved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19888)
<!-- Reviewable:end -->
