### PR TITLE
[multibody] Implements SapCouplerConstraint

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":sap_constraint_bundle",
         ":sap_constraint_jacobian",
         ":sap_contact_problem",
+        ":sap_coupler_constraint",
         ":sap_distance_constraint",
         ":sap_friction_cone_constraint",
         ":sap_holonomic_constraint",
@@ -103,6 +104,19 @@ drake_cc_library(
         "//common:essential",
         "//multibody/contact_solvers:block_sparse_matrix",
         "//multibody/plant:slicing_and_indexing",
+    ],
+)
+
+drake_cc_library(
+    name = "sap_coupler_constraint",
+    srcs = ["sap_coupler_constraint.cc"],
+    hdrs = ["sap_coupler_constraint.h"],
+    deps = [
+        ":sap_constraint",
+        ":sap_constraint_jacobian",
+        ":sap_holonomic_constraint",
+        "//common:default_scalars",
+        "//common:essential",
     ],
 )
 
@@ -248,6 +262,16 @@ drake_cc_googletest(
         ":sap_contact_problem",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sap_coupler_constraint_test",
+    deps = [
+        ":sap_coupler_constraint",
+        ":validate_constraint_gradients",
+        "//common:pointer_cast",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/contact_solvers/sap/sap_coupler_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_coupler_constraint.cc
@@ -1,0 +1,95 @@
+#include "drake/multibody/contact_solvers/sap/sap_coupler_constraint.h"
+
+#include <limits>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+template <typename T>
+SapCouplerConstraint<T>::SapCouplerConstraint(Kinematics kinematics)
+    : SapHolonomicConstraint<T>(
+          MakeSapHolonomicConstraintKinematics(kinematics),
+          MakeSapHolonomicConstraintParameters(), {}),
+      kinematics_(std::move(kinematics)) {}
+
+template <typename T>
+typename SapHolonomicConstraint<T>::Parameters
+SapCouplerConstraint<T>::MakeSapHolonomicConstraintParameters() {
+  // "Near-rigid" regime parameter, see [Castro et al., 2022].
+  // TODO(amcastro-tri): consider exposing this parameter.
+  constexpr double kBeta = 0.1;
+
+  // Coupler constraints do not have impulse limits, they are bi-lateral
+  // constraints. Each coupler constraint introduces a single constraint
+  // equation.
+  //
+  // N.B. `stiffness` is set to infinity to model this constraint in the
+  // "near-rigid" regime. `relaxation_time` is set arbitrarily to 0.0.
+  // SapHolonomicConstraint will use the time step as the relaxation time when
+  // it detects this constraint is "near-rigid". See
+  // SapHolonomicConstraint::DoMakeData().
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  return typename SapHolonomicConstraint<T>::Parameters{
+      Vector1<T>(-kInf), Vector1<T>(kInf), Vector1<T>(kInf), Vector1<T>(0.0),
+      kBeta};
+}
+
+template <typename T>
+typename SapHolonomicConstraint<T>::Kinematics
+SapCouplerConstraint<T>::MakeSapHolonomicConstraintKinematics(
+    const Kinematics& kinematics) {
+  Vector1<T> g(kinematics.q0 - kinematics.gear_ratio * kinematics.q1 -
+               kinematics.offset);    // Constraint function.
+  Vector1<T> b = Vector1<T>::Zero();  // Bias term.
+
+  // Determine the single clique or two clique case.
+  if (kinematics.clique0 == kinematics.clique1) {
+    MatrixX<T> J0 = MatrixX<T>::Zero(1, kinematics.clique_nv0);
+    J0(0, kinematics.clique_dof0) = 1.0;
+    J0(0, kinematics.clique_dof1) = -kinematics.gear_ratio;
+
+    return typename SapHolonomicConstraint<T>::Kinematics(
+        std::move(g),
+        SapConstraintJacobian<T>(kinematics.clique0, std::move(J0)),
+        std::move(b));
+  } else {
+    MatrixX<T> J0 = MatrixX<T>::Zero(1, kinematics.clique_nv0);
+    MatrixX<T> J1 = MatrixX<T>::Zero(1, kinematics.clique_nv1);
+    J0(0, kinematics.clique_dof0) = 1.0;
+    J1(0, kinematics.clique_dof1) = -kinematics.gear_ratio;
+
+    return typename SapHolonomicConstraint<T>::Kinematics(
+        std::move(g),
+        SapConstraintJacobian<T>(kinematics.clique0, std::move(J0),
+                                 kinematics.clique1, std::move(J1)),
+        std::move(b));
+  }
+}
+
+template <typename T>
+void SapCouplerConstraint<T>::DoAccumulateGeneralizedImpulses(
+    int c, const Eigen::Ref<const VectorX<T>>& gamma,
+    EigenPtr<VectorX<T>> tau) const {
+  // τ = Jᵀ⋅γ
+  if (c == 0) {
+    (*tau)(kinematics().clique_dof0) += gamma(0);
+  }
+
+  if (this->num_cliques() == 1 || c == 1) {
+    (*tau)(kinematics().clique_dof1) -= kinematics().gear_ratio * gamma(0);
+  }
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::internal::SapCouplerConstraint)

--- a/multibody/contact_solvers/sap/sap_coupler_constraint.h
+++ b/multibody/contact_solvers/sap/sap_coupler_constraint.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+/* Implements a SAP (compliant) coupler constraint between two dofs.
+ Given positions of dof 0 and 1 as q₀ and q₁, respectively, this constraint
+ enforces:
+   q₀ = ρ⋅q₁ + Δq
+ where ρ is the gear ratio and Δq is a fixed offset.
+
+ More precisely, this constraint enforces a single holonomic constraint
+ equation:
+   g = q₀ - ρ⋅q₁ - Δq = 0
+ which produces a constraint impulse γ ∈ ℝ.
+
+ The resulting generalized impulse on dof 0 is:
+   j₀ = γ
+ And the generalized impulse on dof 1 is:
+   j₁ = −ργ
+
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class SapCouplerConstraint final : public SapHolonomicConstraint<T> {
+ public:
+  /* We do not allow copy, move, or assignment generally to avoid slicing. */
+  //@{
+  SapCouplerConstraint& operator=(const SapCouplerConstraint&) = delete;
+  SapCouplerConstraint(SapCouplerConstraint&&) = delete;
+  SapCouplerConstraint& operator=(SapCouplerConstraint&&) = delete;
+  //@}
+
+  /* Struct to store the kinematics of the the constraint in its current
+   configuration, when it gets constructed. */
+  struct Kinematics {
+    /* Index of clique 0. */
+    int clique0;
+    /* Clique local index of dof 0. */
+    int clique_dof0;
+    /* Clique 0 number of velocities. */
+    int clique_nv0;
+    /* Position of dof 0. */
+    T q0;
+    /* Index of clique 1. */
+    int clique1;
+    /* Clique local index of dof 1. */
+    int clique_dof1;
+    /* Clique 1 number of velocities. */
+    int clique_nv1;
+    /* Position of dof 1. */
+    T q1;
+    /* Gear ratio ρ. */
+    T gear_ratio;
+    /* Constraint function bias Δq. */
+    T offset;
+  };
+
+  /* Constructs a coupler constraint given its kinematics in a particular
+   configuration. */
+  explicit SapCouplerConstraint(Kinematics kinematics);
+
+  const Kinematics& kinematics() const { return kinematics_; }
+
+ private:
+  /* Private copy construction is enabled to use in the implementation of
+     DoClone(). */
+  SapCouplerConstraint(const SapCouplerConstraint&) = default;
+
+  /* Accumulates generalized impulses applied by this constraint on the c-th
+   clique.
+   @param[in] c The c-th clique of index clique(c).
+   @param[in] gamma Impulses for this constraint, of size
+   num_constraint_equations().
+   @param[out] tau On output this function will accumulate the generalized
+   impulses applied by this constraint on the c-th clique.
+  */
+  void DoAccumulateGeneralizedImpulses(
+      int c, const Eigen::Ref<const VectorX<T>>& gamma,
+      EigenPtr<VectorX<T>> tau) const final;
+
+  /* No-op for this constraint. */
+  void DoAccumulateSpatialImpulses(int, const Eigen::Ref<const VectorX<T>>&,
+                                   SpatialForce<T>*) const final {}
+
+  /* Helper used at construction. This method makes the parameters needed by the
+   base class SapHolonomicConstraint. */
+  static typename SapHolonomicConstraint<T>::Parameters
+  MakeSapHolonomicConstraintParameters();
+
+  /* Helper used at construction. Makes the constraint function and Jacobian
+   needed to initialize the base class SapHolonomicConstraint.
+   @returns Holonomic constraint kinematics needed at construction of the
+   parent SapHolonomicConstraint. */
+  static typename SapHolonomicConstraint<T>::Kinematics
+  MakeSapHolonomicConstraintKinematics(const Kinematics& kinematics);
+
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<SapCouplerConstraint<T>>(
+        new SapCouplerConstraint<T>(*this));
+  }
+
+  Kinematics kinematics_;
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/test/sap_coupler_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_coupler_constraint_test.cc
@@ -1,0 +1,252 @@
+#include "drake/multibody/contact_solvers/sap/sap_coupler_constraint.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/pointer_cast.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/contact_solvers/sap/validate_constraint_gradients.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+template <typename T = double>
+typename SapCouplerConstraint<T>::Kinematics MakeArbitraryKinematics(
+    int num_cliques) {
+  const int clique0 = 4;
+  const int clique_dof0 = 2;
+  const int clique_nv0 = 5;
+  const T q0 = 0.5;
+  const int clique1 = (num_cliques == 1 ? clique0 : 9);
+  const int clique_dof1 = 3;
+  const int clique_nv1 = (num_cliques == 1 ? clique_nv0 : 7);
+  const T q1 = 2.3;
+  const T gear_ratio = 1.2;
+  const T offset = 0.7;
+
+  return typename SapCouplerConstraint<T>::Kinematics{
+      clique0,     clique_dof0, clique_nv0, q0,         clique1,
+      clique_dof1, clique_nv1,  q1,         gear_ratio, offset};
+}
+
+GTEST_TEST(SapCouplerConstraint, SingleCliqueConstraint) {
+  const int num_cliques = 1;
+  const SapCouplerConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapCouplerConstraint<double> c(kinematics);
+
+  EXPECT_EQ(c.num_objects(), 0);
+  EXPECT_EQ(c.num_constraint_equations(), 1);
+  EXPECT_EQ(c.num_cliques(), 1);
+  EXPECT_EQ(c.first_clique(), kinematics.clique0);
+  EXPECT_EQ(c.num_velocities(0), kinematics.clique_nv0);
+  EXPECT_THROW(c.second_clique(), std::exception);
+
+  const MatrixX<double> J0 = c.first_clique_jacobian().MakeDenseMatrix();
+
+  // The Jacobian should contain only two entries corresponding to the
+  // constraints two dofs.
+  EXPECT_EQ(J0(kinematics.clique_dof0), 1.0);
+  EXPECT_EQ(J0(kinematics.clique_dof1), -kinematics.gear_ratio);
+  EXPECT_EQ(J0.sum(), 1.0 - kinematics.gear_ratio);
+
+  EXPECT_THROW(c.second_clique_jacobian(), std::exception);
+}
+
+GTEST_TEST(SapCouplerConstraint, TwoCliquesConstraint) {
+  const int num_cliques = 2;
+  const SapCouplerConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapCouplerConstraint<double> c(kinematics);
+
+  EXPECT_EQ(c.num_objects(), 0);
+  EXPECT_EQ(c.num_constraint_equations(), 1);
+  EXPECT_EQ(c.num_cliques(), 2);
+  EXPECT_EQ(c.first_clique(), kinematics.clique0);
+  EXPECT_EQ(c.second_clique(), kinematics.clique1);
+  EXPECT_EQ(c.num_velocities(0), kinematics.clique_nv0);
+  EXPECT_EQ(c.num_velocities(1), kinematics.clique_nv1);
+
+  const MatrixX<double> J0 = c.first_clique_jacobian().MakeDenseMatrix();
+  const MatrixX<double> J1 = c.second_clique_jacobian().MakeDenseMatrix();
+
+  // J0 and J1 should each contain exactly one entry corresponding to dof 0 or
+  // dof 1, respectively.
+  EXPECT_EQ(J0(kinematics.clique_dof0), 1.0);
+  EXPECT_EQ(J0.sum(), 1.0);
+  EXPECT_EQ(J1(kinematics.clique_dof1), -kinematics.gear_ratio);
+  EXPECT_EQ(J1.sum(), -kinematics.gear_ratio);
+}
+
+// This method validates analytical gradients implemented by
+// SapCouplerConstraint using automatic differentiation.
+void ValidateProjection(const Vector1d& vc) {
+  // Arbitrary kinematic values.
+  const int num_cliques = 1;
+  const SapCouplerConstraint<AutoDiffXd>::Kinematics kin_ad =
+      MakeArbitraryKinematics<AutoDiffXd>(num_cliques);
+
+  // Instantiate constraint on AutoDiffXd for automatic differentiation.
+  SapCouplerConstraint<AutoDiffXd> c(kin_ad);
+
+  // Verify cost gradients using AutoDiffXd.
+  ValidateConstraintGradients(c, vc);
+}
+
+GTEST_TEST(SapCouplerConstraint, Gradients) {
+  // Arbitrary set of vc values.
+  {
+    const Vector1d vc(-1.4);
+    ValidateProjection(vc);
+  }
+  {
+    const Vector1d vc(2.3);
+    ValidateProjection(vc);
+  }
+  {
+    const Vector1d vc(6.2);
+    ValidateProjection(vc);
+  }
+}
+
+GTEST_TEST(SapCouplerConstraint, SingleCliqueConstraintClone) {
+  const int num_cliques = 1;
+  const SapCouplerConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapCouplerConstraint<double> c(kinematics);
+
+  // N.B. Here we dynamic cast to the derived type so that we can test that the
+  // clone is a deep-copy of the original constraint.
+  auto clone = dynamic_pointer_cast<SapCouplerConstraint<double>>(c.Clone());
+  ASSERT_NE(clone, nullptr);
+  EXPECT_EQ(clone->num_objects(), 0);
+  EXPECT_EQ(clone->num_constraint_equations(), 1);
+  EXPECT_EQ(clone->num_cliques(), 1);
+  EXPECT_EQ(clone->first_clique(), kinematics.clique0);
+  EXPECT_EQ(clone->num_velocities(0), kinematics.clique_nv0);
+  EXPECT_THROW(clone->second_clique(), std::exception);
+
+  const MatrixX<double> J0 = clone->first_clique_jacobian().MakeDenseMatrix();
+
+  // The Jacobian should contain only two entries corresponding to the
+  // constraints two dofs.
+  EXPECT_EQ(J0(kinematics.clique_dof0), 1.0);
+  EXPECT_EQ(J0(kinematics.clique_dof1), -kinematics.gear_ratio);
+  EXPECT_EQ(J0.sum(), 1.0 - kinematics.gear_ratio);
+
+  EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
+}
+
+GTEST_TEST(SapCouplerConstraint, TwoCliquesConstraintClone) {
+  const int num_cliques = 2;
+  const SapCouplerConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapCouplerConstraint<double> c(kinematics);
+
+  auto clone = dynamic_pointer_cast<SapCouplerConstraint<double>>(c.Clone());
+  ASSERT_NE(clone, nullptr);
+  EXPECT_EQ(clone->num_objects(), 0);
+  EXPECT_EQ(clone->num_constraint_equations(), 1);
+  EXPECT_EQ(clone->num_cliques(), 2);
+  EXPECT_EQ(clone->first_clique(), kinematics.clique0);
+  EXPECT_EQ(clone->second_clique(), kinematics.clique1);
+  EXPECT_EQ(clone->num_velocities(0), kinematics.clique_nv0);
+  EXPECT_EQ(clone->num_velocities(1), kinematics.clique_nv1);
+
+  const MatrixX<double> J0 = clone->first_clique_jacobian().MakeDenseMatrix();
+  const MatrixX<double> J1 = clone->second_clique_jacobian().MakeDenseMatrix();
+
+  // J0 and J1 should each contain exactly one entry corresponding to dof 0 or
+  // dof 1, respectively.
+  EXPECT_EQ(J0(kinematics.clique_dof0), 1.0);
+  EXPECT_EQ(J0.sum(), 1.0);
+  EXPECT_EQ(J1(kinematics.clique_dof1), -kinematics.gear_ratio);
+  EXPECT_EQ(J1.sum(), -kinematics.gear_ratio);
+}
+
+GTEST_TEST(SapCouplerConstraint, SingleCliqueAccumulateGeneralizedImpulses) {
+  // Make a coupler constraint with an arbitrary kinamtics state, irrelevant for
+  // this test but needed at construction.
+  const int num_cliques = 1;
+  const SapCouplerConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapCouplerConstraint<double> c(kinematics);
+
+  // Arbitrary value of the impulse.
+  const Vector1d gamma(1.2345);
+
+  // Expected generalized impulse on clique 0.
+  VectorXd tau_clique0 = VectorXd::Zero(kinematics.clique_nv0);
+  tau_clique0(kinematics.clique_dof0) = gamma(0);
+
+  // Expected generalized impulse on clique 1.
+  VectorXd tau_clique1 = VectorXd::Zero(kinematics.clique_nv1);
+  tau_clique1(kinematics.clique_dof1) = -kinematics.gear_ratio * gamma(0);
+
+  const VectorXd tau_0 =
+      VectorXd::LinSpaced(kinematics.clique_nv0, 1, kinematics.clique_nv0);
+
+  VectorXd tau_accumulated = tau_0;  // Initialize to non-zero value.
+  const VectorXd tau_expected = tau_0 + tau_clique0 + tau_clique1;
+  c.AccumulateGeneralizedImpulses(0, gamma, &tau_accumulated);
+  EXPECT_TRUE(CompareMatrices(tau_accumulated, tau_expected,
+                              std::numeric_limits<double>::epsilon(),
+                              MatrixCompareType::relative));
+
+  // Calling on clique one when num_cliques() == 1 should throw an exception.
+  EXPECT_THROW(c.AccumulateGeneralizedImpulses(1, gamma, &tau_accumulated),
+               std::exception);
+}
+
+GTEST_TEST(SapCouplerConstraint, TwoCliquesAccumulateGeneralizedImpulses) {
+  // Make a coupler constraint with an arbitrary kinamtics state, irrelevant for
+  // this test but needed at construction.
+  const int num_cliques = 2;
+  const SapCouplerConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapCouplerConstraint<double> c(kinematics);
+
+  // Arbitrary value of the impulse.
+  const Vector1d gamma(1.2345);
+
+  // Expected generalized impulse on clique 0.
+  VectorXd tau_clique0 = VectorXd::Zero(kinematics.clique_nv0);
+  tau_clique0(kinematics.clique_dof0) = gamma(0);
+
+  // Expected generalized impulse on clique 1.
+  VectorXd tau_clique1 = VectorXd::Zero(kinematics.clique_nv1);
+  tau_clique1(kinematics.clique_dof1) = -kinematics.gear_ratio * gamma(0);
+
+  const VectorXd tau_0 =
+      VectorXd::LinSpaced(kinematics.clique_nv0, 1, kinematics.clique_nv0);
+
+  VectorXd tau_accumulated = tau_0;  // Initialize to non-zero value.
+  VectorXd tau_expected = tau_0 + tau_clique0;
+  c.AccumulateGeneralizedImpulses(0, gamma, &tau_accumulated);
+  EXPECT_TRUE(CompareMatrices(tau_accumulated, tau_expected,
+                              std::numeric_limits<double>::epsilon(),
+                              MatrixCompareType::relative));
+
+  const VectorXd tau_1 =
+      VectorXd::LinSpaced(kinematics.clique_nv1, 1, kinematics.clique_nv1);
+
+  tau_accumulated = tau_1;  // Initialize to non-zero value.
+  tau_expected = tau_1 + tau_clique1;
+  c.AccumulateGeneralizedImpulses(1, gamma, &tau_accumulated);
+  EXPECT_TRUE(CompareMatrices(tau_accumulated, tau_expected,
+                              std::numeric_limits<double>::epsilon(),
+                              MatrixCompareType::relative));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -13,6 +13,7 @@
 #include "drake/multibody/contact_solvers/contact_configuration.h"
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_coupler_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_distance_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
@@ -33,6 +34,7 @@ using drake::multibody::contact_solvers::internal::MatrixBlock;
 using drake::multibody::contact_solvers::internal::SapConstraint;
 using drake::multibody::contact_solvers::internal::SapConstraintJacobian;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapCouplerConstraint;
 using drake::multibody::contact_solvers::internal::SapDistanceConstraint;
 using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
 using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
@@ -335,20 +337,6 @@ void SapDriver<T>::AddCouplerConstraints(const systems::Context<T>& context,
                                          SapContactProblem<T>* problem) const {
   DRAKE_DEMAND(problem != nullptr);
 
-  // Previous time step positions.
-  const VectorX<T> q0 = plant().GetPositions(context);
-
-  // Couplers do not have impulse limits, they are bi-lateral constraints. Each
-  // coupler constraint introduces a single constraint equation.
-  constexpr double kInfinity = std::numeric_limits<double>::infinity();
-  const Vector1<T> gamma_lower(-kInfinity);
-  const Vector1<T> gamma_upper(kInfinity);
-
-  // Stiffness and dissipation are set so that the constraint is in the
-  // "near-rigid" regime, [Castro et al., 2022].
-  const Vector1<T> stiffness(kInfinity);
-  const Vector1<T> relaxation_time(plant().time_step());
-
   const std::map<MultibodyConstraintId, bool>& constraint_active_status =
       manager().GetConstraintActiveStatus(context);
 
@@ -369,36 +357,16 @@ void SapDriver<T>::AddCouplerConstraints(const systems::Context<T>& context,
     const int tree_dof0 = dof0 - tree_topology().tree_velocities_start(tree0);
     const int tree_dof1 = dof1 - tree_topology().tree_velocities_start(tree1);
 
-    // Constraint function defined as g = q₀ - ρ⋅q₁ - Δq, with ρ the gear ratio
-    // and Δq a fixed position offset.
-    Vector1<T> g0(q0[dof0] - info.gear_ratio * q0[dof1] - info.offset);
+    const int tree_nv0 = tree_topology().num_tree_velocities(tree0);
+    const int tree_nv1 = tree_topology().num_tree_velocities(tree1);
 
-    // TODO(amcastro-tri): consider exposing this parameter.
-    const double beta = 0.1;
+    const typename SapCouplerConstraint<T>::Kinematics kinematics{
+        tree0,           tree_dof0,  tree_nv0, joint0.GetOnePosition(context),
+        tree1,           tree_dof1,  tree_nv1, joint1.GetOnePosition(context),
+        info.gear_ratio, info.offset};
 
-    const typename SapHolonomicConstraint<T>::Parameters parameters{
-        gamma_lower, gamma_upper, stiffness, relaxation_time, beta};
-
-    if (tree0 == tree1) {
-      const int nv = tree_topology().num_tree_velocities(tree0);
-      MatrixX<T> J0 = MatrixX<T>::Zero(1, nv);
-      // J = dg/dv
-      J0(0, tree_dof0) = 1.0;
-      J0(0, tree_dof1) = -info.gear_ratio;
-      SapConstraintJacobian<T> J(tree0, std::move(J0));
-      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
-          std::move(g0), std::move(J), parameters));
-    } else {
-      const int nv0 = tree_topology().num_tree_velocities(tree0);
-      const int nv1 = tree_topology().num_tree_velocities(tree1);
-      MatrixX<T> J0 = MatrixX<T>::Zero(1, nv0);
-      MatrixX<T> J1 = MatrixX<T>::Zero(1, nv1);
-      J0(0, tree_dof0) = 1.0;
-      J1(0, tree_dof1) = -info.gear_ratio;
-      SapConstraintJacobian<T> J(tree0, std::move(J0), tree1, std::move(J1));
-      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
-          std::move(g0), std::move(J), parameters));
-    }
+    problem->AddConstraint(
+        std::make_unique<SapCouplerConstraint<T>>(std::move(kinematics)));
   }
 }
 

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -674,8 +674,7 @@ TEST_F(KukaIiwaArmTests, CouplerConstraints) {
     EXPECT_EQ(params.impulse_lower_limits(), -kInfinity);
     EXPECT_EQ(params.impulse_upper_limits(), kInfinity);
     EXPECT_EQ(params.stiffnesses(), kInfinity);
-    EXPECT_EQ(params.relaxation_times(),
-              Vector1d::Constant(plant_.time_step()));
+    EXPECT_EQ(params.relaxation_times(), Vector1d::Zero());
     EXPECT_EQ(params.beta(), 0.1);
   }
 }


### PR DESCRIPTION
Makes `SapCouplerConstraint` a first class citizen of the sap constraints family. Refactors `SapDriver` to use the new constraint. Implements reporting forces for coupler constraints. 

Note: Coupler constraints are already tested in `compliant_contact_manager_test`, but these test should probably moved and refactored to match the testing strategy already adopted by `sap_driver_ball_constraints_test`, `sap_driver_distance_constraints_test`, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19902)
<!-- Reviewable:end -->
