### PR TITLE
[workspace] Fully qualify absolute paths to patch files

### DIFF
--- a/tools/workspace/conex/repository.bzl
+++ b/tools/workspace/conex/repository.bzl
@@ -14,8 +14,8 @@ def conex_repository(
         build_file = ":package.BUILD.bazel",
         patches = [
             ":patches/deprecation.patch",
-            "//tools/workspace/conex_internal:patches/debug_macros.patch",
-            "//tools/workspace/conex_internal:patches/no_eigen_io.patch",
+            "@drake//tools/workspace/conex_internal:patches/debug_macros.patch",  # noqa
+            "@drake//tools/workspace/conex_internal:patches/no_eigen_io.patch",
         ],
         mirrors = mirrors,
     )

--- a/tools/workspace/tinyobjloader/repository.bzl
+++ b/tools/workspace/tinyobjloader/repository.bzl
@@ -15,7 +15,7 @@ def tinyobjloader_repository(
         mirrors = mirrors,
         patches = [
             ":patches/double_precision.patch",
-            "//tools/workspace/tinyobjloader_internal:patches/faster_float_parsing.patch",  # noqa
-            "//tools/workspace/tinyobjloader_internal:patches/default_texture_color.patch",  # noqa
+            "@drake//tools/workspace/tinyobjloader_internal:patches/faster_float_parsing.patch",  # noqa
+            "@drake//tools/workspace/tinyobjloader_internal:patches/default_texture_color.patch",  # noqa
         ],
     )


### PR DESCRIPTION
Downstream projects using Bazel to build Drake need to resolve the paths against Drake, not their own WORKSPACE.

Amends #19880 and #19883.

+@rpoyner-tri for both review please (high priority).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19904)
<!-- Reviewable:end -->
