### PR TITLE
[geometry] Deprecate RenderEngineGltfClient's default_label option

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -3,6 +3,7 @@
  pydrake.geometry module. */
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -385,6 +386,16 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
     DefCopyAndDeepCopy(&cls);
+    // Shim in the vestigial (deprecated) attribute; it's not part of Serialize.
+    // Remove this on 2023-12-01.
+    cls.def_property("default_label",
+        WrapDeprecated(cls_doc.default_label.doc,
+            [](const Class& self) { return self.default_label; }),
+        WrapDeprecated(cls_doc.default_label.doc,
+            [](Class& self, const RenderLabel& value) {
+              self.default_label = value;
+            }),
+        cls_doc.default_label.doc);
   }
 
   m.def("MakeRenderEngineGltfClient", &MakeRenderEngineGltfClient,

--- a/bindings/pydrake/geometry/test/render_test.py
+++ b/bindings/pydrake/geometry/test/render_test.py
@@ -6,6 +6,7 @@ import unittest
 import numpy as np
 
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.value import Value
 from pydrake.math import RigidTransform
 from pydrake.systems.framework import (
@@ -88,20 +89,27 @@ class TestGeometryRender(unittest.TestCase):
         mut.RenderEngineGltfClientParams()
 
         # The kwarg constructor also works.
-        label = mut.RenderLabel(10)
         base_url = "http://127.0.0.1:8888"
         render_endpoint = "render"
         params = mut.RenderEngineGltfClientParams(
-            default_label=label,
             base_url=base_url,
             render_endpoint=render_endpoint,
         )
-        self.assertEqual(params.default_label, label)
         self.assertEqual(params.render_endpoint, render_endpoint)
         self.assertEqual(params.base_url, base_url)
 
-        self.assertIn("default_label", repr(params))
+        self.assertIn("render_endpoint", repr(params))
         copy.copy(params)
+
+    def test_render_engine_gltf_client_params_deprecated(self):
+        """The render_label attribute is deprecated; make sure it still works,
+        for now.
+        """
+        label = mut.RenderLabel(10)
+        with catch_drake_warnings(expected_count=1):
+            dut = mut.RenderEngineGltfClientParams(default_label=label)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.default_label, label)
 
     def test_render_label(self):
         RenderLabel = mut.RenderLabel

--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -163,6 +163,7 @@ drake_cc_googletest(
     name = "render_engine_gltf_client_params_test",
     deps = [
         ":render_engine_gltf_client_params",
+        "//common/yaml",
     ],
 )
 

--- a/geometry/render_gltf_client/internal_render_client.h
+++ b/geometry/render_gltf_client/internal_render_client.h
@@ -27,11 +27,7 @@ class RenderClient {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RenderClient);
 
-  /* Constructs the render engine from the given RenderEngineGltfClientParams.
-
-   @note
-     RenderEngineGltfClientParams.default_label struct member is not relevant
-     for the RenderClient construction. */
+  /* Constructs the render client from the given `params`. */
   explicit RenderClient(const RenderEngineGltfClientParams& params);
 
   ~RenderClient();
@@ -182,8 +178,7 @@ class RenderClient {
   //@{
 
   /* Returns a RenderEngineGltfClientParams struct for RenderClient
-   construction.  Note that `default_label` is not relevant for RenderClient
-   class. */
+   construction. */
   const RenderEngineGltfClientParams& get_params() const { return params_; }
 
   /* The temporary directory used for scratch space, including but not limited

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
@@ -309,8 +309,18 @@ void ChangeToLabelMaterials(nlohmann::json* gltf, const ColorD& color) {
 
 RenderEngineGltfClient::RenderEngineGltfClient(
     const RenderEngineGltfClientParams& parameters)
-    : RenderEngineVtk({.default_label = parameters.default_label}),
-      render_client_{std::make_unique<RenderClient>(parameters)} {}
+    : RenderEngineVtk({// TODO(jwnimmer-tri) Upon deprecation removal of the
+                       // default_label on 2023-12-01, we should hard-code the
+                       // kDontCare here, instead of using value_or().
+                       .default_label = parameters.default_label.value_or(
+                           render::RenderLabel::kDontCare)}),
+      render_client_{std::make_unique<RenderClient>(parameters)} {
+  if (parameters.default_label.has_value()) {
+    static const logging::Warn log_once(
+        "RenderEngineGltfClient(): the default_label configuration option is "
+        "deprecated and will be removed from Drake on or after 2023-12-01.");
+  }
+}
 
 RenderEngineGltfClient::RenderEngineGltfClient(
     const RenderEngineGltfClient& other)

--- a/geometry/render_gltf_client/render_engine_gltf_client_params.h
+++ b/geometry/render_gltf_client/render_engine_gltf_client_params.h
@@ -18,7 +18,6 @@ struct RenderEngineGltfClientParams {
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(base_url));
     a->Visit(DRAKE_NVP(render_endpoint));
-    a->Visit(DRAKE_NVP(default_label));
     a->Visit(DRAKE_NVP(verbose));
     a->Visit(DRAKE_NVP(cleanup));
   }
@@ -31,8 +30,9 @@ struct RenderEngineGltfClientParams {
    See GetUrl() for details. */
   std::string render_endpoint{"render"};
 
-  /** The (optional) label to apply when none is otherwise specified. */
-  std::optional<render::RenderLabel> default_label{};
+  /** (Deprecated.) The default_label is no longer configurable. <br>
+   This will be removed from Drake on or after 2023-12-01. */
+  std::optional<render::RenderLabel> default_label;
 
   /** Whether or not the client should log information about which files are
    being generated, as well as any information about HTTP communications between

--- a/geometry/render_gltf_client/test/internal_render_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_client_test.cc
@@ -138,8 +138,10 @@ TEST_F(RenderClientTest, Constructor) {
   const std::string render_endpoint{"testing"};
   const bool verbose = true;
   const bool cleanup = false;
-  const RenderClient client{
-      Params{base_url, render_endpoint, std::nullopt, verbose, cleanup}};
+  const RenderClient client{Params{.base_url = base_url,
+                                   .render_endpoint = render_endpoint,
+                                   .verbose = verbose,
+                                   .cleanup = cleanup}};
   EXPECT_EQ(client.get_params().GetUrl(), base_url + "/" + render_endpoint);
   EXPECT_EQ(client.get_params().verbose, verbose);
   EXPECT_EQ(client.get_params().cleanup, cleanup);

--- a/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -123,6 +123,13 @@ TEST_F(RenderEngineGltfClientTest, Constructor) {
   EXPECT_EQ(engine.get_params().cleanup, false);
 }
 
+// Confirms that the deprecated option doesn't crash anything.
+TEST_F(RenderEngineGltfClientTest, ConstructorDeprecation) {
+  Params test_params(params_);
+  test_params.default_label = render::RenderLabel::kUnspecified;
+  const RenderEngineGltfClient engine{test_params};
+}
+
 TEST_F(RenderEngineGltfClientTest, Clone) {
   const RenderEngineGltfClient engine{params_};
   const std::unique_ptr<RenderEngine> clone = engine.Clone();

--- a/geometry/render_gltf_client/test/render_engine_gltf_client_params_test.cc
+++ b/geometry/render_gltf_client/test/render_engine_gltf_client_params_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/yaml/yaml_io.h"
+
 namespace drake {
 namespace geometry {
 namespace {
@@ -44,6 +46,22 @@ GTEST_TEST(RenderEngineGltfClientParams, GetUrl) {
     dut.render_endpoint = one_case.render_endpoint;
     EXPECT_EQ(dut.GetUrl(), one_case.expected_full_url);
   }
+}
+
+GTEST_TEST(RenderEngineGltfClientParams, Serialization) {
+  using Params = RenderEngineGltfClientParams;
+  const Params original{
+      .base_url = "http://hello",
+      .render_endpoint = "world",
+      .verbose = true,
+      .cleanup = false,
+  };
+  const std::string yaml = yaml::SaveYamlString<Params>(original);
+  const Params dut = yaml::LoadYamlString<Params>(yaml);
+  EXPECT_EQ(dut.base_url, original.base_url);
+  EXPECT_EQ(dut.render_endpoint, original.render_endpoint);
+  EXPECT_EQ(dut.verbose, original.verbose);
+  EXPECT_EQ(dut.cleanup, original.cleanup);
 }
 
 }  // namespace


### PR DESCRIPTION
Towards #19863.

+@SeanCurtis-TRI for feature review, please.

For the glTF engine, I think the best path forward is to remove the problematic option, and therefore avoid serializing it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19906)
<!-- Reviewable:end -->
