### PR TITLE
Cleanup GcsTrajectoryOptimization::EdgesBetweenSubgraphs

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -104,7 +104,7 @@ class TestTrajectories(unittest.TestCase):
         numpy_compare.assert_float_equal(curve.control_points(), points)
 
         M = curve.AsLinearInControlPoints(derivative_order=1)
-        self.assertEqual(M.shape, (1, 2))
+        self.assertEqual(M.shape, (2, 1))
         self.assertIsInstance(M, scipy.sparse.csc_matrix)
 
         curve_expression = curve.GetExpression(time=Variable("t"))

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -298,6 +298,7 @@ drake_cc_googletest(
         "//common/symbolic:polynomial",
         "//common/test_utilities",
         "//geometry/optimization:convex_set",
+        "//solvers:mathematical_program",
     ],
 )
 

--- a/common/trajectories/test/bezier_curve_test.cc
+++ b/common/trajectories/test/bezier_curve_test.cc
@@ -6,12 +6,18 @@
 #include "drake/common/symbolic/polynomial.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/geometry/optimization/vpolytope.h"
+#include "drake/solvers/mathematical_program.h"
 
 namespace drake {
 namespace trajectories {
 namespace {
 
+using Eigen::Map;
 using Eigen::Matrix2d;
+using Eigen::MatrixXd;
+using Eigen::SparseMatrix;
+using Eigen::Vector2d;
+using Eigen::VectorXd;
 
 // Tests the default constructor.
 GTEST_TEST(BezierCurveTest, DefaultConstructor) {
@@ -43,8 +49,8 @@ GTEST_TEST(BezierCurveTest, Constant) {
   EXPECT_TRUE(CompareMatrices(curve.value(0.5), kValue));
 
   auto M = curve.AsLinearInControlPoints(1);
-  EXPECT_EQ(M.rows(), 0);
-  EXPECT_EQ(M.cols(), 1);
+  EXPECT_EQ(M.rows(), 1);
+  EXPECT_EQ(M.cols(), 0);
 
   curve.ElevateOrder();
   EXPECT_EQ(curve.order(), 1);
@@ -128,18 +134,15 @@ GTEST_TEST(BezierCurveTest, Linear) {
   CheckConvexHullProperty(deriv_bezier, num_samples);
 
   auto M = curve.AsLinearInControlPoints(1);
-  EXPECT_EQ(M.rows(), 1);
-  EXPECT_EQ(M.cols(), 2);
-  for (int i = 0; i < curve.rows(); ++i) {
-    EXPECT_TRUE(
-        CompareMatrices(deriv_bezier.control_points().row(i).transpose(),
-                        M * curve.control_points().row(i).transpose(), 1e-14));
-  }
+  EXPECT_EQ(M.rows(), 2);
+  EXPECT_EQ(M.cols(), 1);
+  EXPECT_TRUE(CompareMatrices(deriv_bezier.control_points(),
+                              curve.control_points() * M, 1e-14));
   M = curve.AsLinearInControlPoints(0);
   EXPECT_TRUE(CompareMatrices(M.toDense(), Matrix2d::Identity()));
   M = curve.AsLinearInControlPoints(2);
-  EXPECT_EQ(M.rows(), 0);
-  EXPECT_EQ(M.cols(), 2);
+  EXPECT_EQ(M.rows(), 2);
+  EXPECT_EQ(M.cols(), 0);
 
   curve.ElevateOrder();
   EXPECT_EQ(curve.order(), 2);
@@ -171,13 +174,10 @@ GTEST_TEST(BezierCurveTest, Quadratic) {
   EXPECT_EQ(deriv->end_time(), 1.0);
 
   auto M = curve.AsLinearInControlPoints(1);
-  EXPECT_EQ(M.rows(), 2);
-  EXPECT_EQ(M.cols(), 3);
-  for (int i = 0; i < curve.rows(); ++i) {
-    EXPECT_TRUE(
-        CompareMatrices(deriv_bezier.control_points().row(i).transpose(),
-                        M * curve.control_points().row(i).transpose(), 1e-14));
-  }
+  EXPECT_EQ(M.rows(), 3);
+  EXPECT_EQ(M.cols(), 2);
+  EXPECT_TRUE(CompareMatrices(deriv_bezier.control_points(),
+                              curve.control_points() * M, 1e-14));
 
   // second derivative is [ 2; 2 ]
   auto second_deriv = curve.MakeDerivative(2);
@@ -211,13 +211,10 @@ GTEST_TEST(BezierCurveTest, Quadratic) {
   }
 
   M = curve.AsLinearInControlPoints(2);
-  EXPECT_EQ(M.rows(), 1);
-  EXPECT_EQ(M.cols(), 3);
-  for (int i = 0; i < curve.rows(); ++i) {
-    EXPECT_TRUE(
-        CompareMatrices(second_deriv_bezier.control_points().row(i).transpose(),
-                        M * curve.control_points().row(i).transpose(), 1e-14));
-  }
+  EXPECT_EQ(M.rows(), 3);
+  EXPECT_EQ(M.cols(), 1);
+  EXPECT_TRUE(CompareMatrices(second_deriv_bezier.control_points(),
+                              curve.control_points() * M, 1e-14));
 
   // Extract the symbolic expression for the bezier curve.
   VectorX<symbolic::Expression> curve_expression{
@@ -239,6 +236,61 @@ GTEST_TEST(BezierCurveTest, Quadratic) {
                                 Eigen::Vector2d((1 - t) * (1 - t), t * t),
                                 1e-14));
   }
+}
+
+// Test the example from the AsLinearInControlPoints doc string.
+GTEST_TEST(BezierCurve, ConstraintDerivativeControlPoint) {
+  Eigen::Matrix<double, 2, 3> points;
+  // clang-format off
+  points << 1, 0, 0,
+            0, 0, 1;
+  // clang-format on
+  BezierCurve<double> curve(0, 1, points);
+  auto deriv = curve.MakeDerivative();
+  BezierCurve<double>& deriv_bezier =
+      dynamic_cast<BezierCurve<double>&>(*deriv);
+
+  solvers::MathematicalProgram prog;
+  auto p = prog.NewContinuousVariables<2, 3>("p");
+  prog.SetInitialGuess(p, points);
+
+  SparseMatrix<double> M = curve.AsLinearInControlPoints(1);
+  const Vector2d lb(-0.1, -0.2);
+  const Vector2d ub(0.1, 0.2);
+  const int k = 1;
+  // Test the code sample.
+  for (int i = 0; i < curve.rows(); ++i) {
+    auto constraint = std::make_shared<solvers::LinearConstraint>(
+        M.col(k).transpose(), Vector1d(lb(i)), Vector1d(ub(i)));
+    auto b = prog.AddConstraint(constraint, p.row(i).transpose());
+    EXPECT_NEAR(prog.EvalBindingAtInitialGuess(b)[0],
+                deriv_bezier.control_points()(i, k), 1e-12);
+  }
+
+  // TODO(russt): Implement blkdiag for SparseMatrix and switch this example to
+  // use it instead of converting to dense matrices.
+
+  /* Test the block matrix documentation:
+   vec(derivative.control_points().T) = blockMT * vec(this.control_points().T),
+   blockMT = [ M.T,   0, .... 0 ]
+             [   0, M.T, 0, ... ]
+             [      ...         ]
+             [  ...    , 0, M.T ].
+  */
+  const int m = M.rows();
+  const int n = M.cols();
+  MatrixXd blockMT = MatrixXd::Zero(n * curve.rows(), m * curve.rows());
+  for (int i = 0; i < curve.rows(); ++i) {
+    blockMT.block(i * n, i * m, n, m) = M.transpose().toDense();
+  }
+  Map<const VectorXd> vec_curve_points(
+      curve.control_points().transpose().data(),
+      curve.rows() * (curve.order() + 1));
+  Map<const VectorXd> vec_deriv_points(
+      deriv_bezier.control_points().transpose().data(),
+      curve.rows() * (deriv_bezier.order() + 1));
+  EXPECT_TRUE(
+      CompareMatrices(vec_deriv_points, blockMT * vec_curve_points, 1e-12));
 }
 
 GTEST_TEST(BezierCurve, Clone) {

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -200,21 +200,30 @@ class GcsTrajectoryOptimization final {
         const geometry::optimization::ConvexSet& B,
         const geometry::optimization::ConvexSet& subspace);
 
+    /* Extracts the control points variables from an edge. */
+    Eigen::Map<const MatrixX<symbolic::Variable>> GetControlPointsU(
+        const geometry::optimization::GraphOfConvexSets::Edge& e) const;
+
+    /* Extracts the control points variables from an edge. */
+    Eigen::Map<const MatrixX<symbolic::Variable>> GetControlPointsV(
+        const geometry::optimization::GraphOfConvexSets::Edge& e) const;
+
+    /* Extracts the time scaling variable from a edge. */
+    symbolic::Variable GetTimeScalingU(
+        const geometry::optimization::GraphOfConvexSets::Edge& e) const;
+
+    /* Extracts the time scaling variable from a edge. */
+    symbolic::Variable GetTimeScalingV(
+        const geometry::optimization::GraphOfConvexSets::Edge& e) const;
+
     GcsTrajectoryOptimization& traj_opt_;
     const int from_subgraph_order_;
     const int to_subgraph_order_;
 
+    trajectories::BezierCurve<double> ur_trajectory_;
+    trajectories::BezierCurve<double> vr_trajectory_;
+
     std::vector<geometry::optimization::GraphOfConvexSets::Edge*> edges_;
-
-    // We keep track of the edge variables and trajectory since other
-    // constraints and costs will use these.
-    VectorX<symbolic::Variable> u_h_;
-    VectorX<symbolic::Variable> u_vars_;
-    trajectories::BezierCurve<symbolic::Expression> u_r_trajectory_;
-
-    VectorX<symbolic::Variable> v_h_;
-    VectorX<symbolic::Variable> v_vars_;
-    trajectories::BezierCurve<symbolic::Expression> v_r_trajectory_;
 
     friend class GcsTrajectoryOptimization;
   };

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -351,7 +351,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, VelocityBoundsOnEdges) {
   gcs.AddTimeCost();
 
   // Nonregression bound on the complexity of the underlying GCS MICP.
-  EXPECT_LT(gcs.EstimateComplexity(), 1e2);
+  EXPECT_LT(gcs.EstimateComplexity(), 125);
 
   if (!GurobiOrMosekSolverAvailable()) {
     return;
@@ -927,7 +927,7 @@ TEST_F(SimpleEnv2D, IntermediatePoint) {
   main2.AddPathLengthCost(weight_matrix);
 
   // Nonregression bound on the complexity of the underlying GCS MICP.
-  EXPECT_LT(gcs.EstimateComplexity(), 1e3);
+  EXPECT_LT(gcs.EstimateComplexity(), 1100);
 
   if (!GurobiOrMosekSolverAvailable()) {
     return;


### PR DESCRIPTION
To use less placeholder variables, and make use of the new BezierCurve::AsLinearInControlPoints() to avoid symbolic expressions.

+wrangelvid for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19907)
<!-- Reviewable:end -->
