### PR TITLE
[geometry] Deprecate RenderEngineVtk's default_label option

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -357,6 +357,16 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
     DefCopyAndDeepCopy(&cls);
+    // Shim in the vestigial (deprecated) attribute; it's not part of Serialize.
+    // Remove this on 2023-12-01.
+    cls.def_property("default_label",
+        WrapDeprecated(cls_doc.default_label.doc,
+            [](const Class& self) { return self.default_label; }),
+        WrapDeprecated(cls_doc.default_label.doc,
+            [](Class& self, const RenderLabel& value) {
+              self.default_label = value;
+            }),
+        cls_doc.default_label.doc);
   }
 
   m.def("MakeRenderEngineVtk", &MakeRenderEngineVtk, py::arg("params"),

--- a/bindings/pydrake/geometry/test/render_test.py
+++ b/bindings/pydrake/geometry/test/render_test.py
@@ -52,18 +52,27 @@ class TestGeometryRender(unittest.TestCase):
     def test_render_engine_vtk_params(self):
         # Confirm default construction of params.
         params = mut.RenderEngineVtkParams()
-        self.assertEqual(params.default_label, None)
         self.assertEqual(params.default_diffuse, None)
 
-        label = mut.RenderLabel(10)
         diffuse = np.array((1.0, 0.0, 0.0, 0.0))
-        params = mut.RenderEngineVtkParams(
-            default_label=label, default_diffuse=diffuse)
-        self.assertEqual(params.default_label, label)
+        params = mut.RenderEngineVtkParams(default_diffuse=diffuse)
         self.assertTrue((params.default_diffuse == diffuse).all())
 
-        self.assertIn("default_label", repr(params))
+        self.assertIn("default_diffuse", repr(params))
         copy.copy(params)
+
+    def test_render_engine_vtk_params_deprecated(self):
+        """The default_label attribute is deprecated; make sure it still works,
+        for now.
+        """
+        params = mut.RenderEngineVtkParams()
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(params.default_label, None)
+        label = mut.RenderLabel(10)
+        with catch_drake_warnings(expected_count=1):
+            params = mut.RenderEngineVtkParams(default_label=label)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(params.default_label, label)
 
     def test_render_engine_gl_params(self):
         # A default constructor exists.

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
@@ -309,11 +309,7 @@ void ChangeToLabelMaterials(nlohmann::json* gltf, const ColorD& color) {
 
 RenderEngineGltfClient::RenderEngineGltfClient(
     const RenderEngineGltfClientParams& parameters)
-    : RenderEngineVtk({// TODO(jwnimmer-tri) Upon deprecation removal of the
-                       // default_label on 2023-12-01, we should hard-code the
-                       // kDontCare here, instead of using value_or().
-                       .default_label = parameters.default_label.value_or(
-                           render::RenderLabel::kDontCare)}),
+    : RenderEngineVtk({.default_label = parameters.default_label}),
       render_client_{std::make_unique<RenderClient>(parameters)} {
   if (parameters.default_label.has_value()) {
     static const logging::Warn log_once(

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -151,4 +151,12 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "render_engine_vtk_params_test",
+    deps = [
+        ":render_engine_vtk_params",
+        "//common/yaml",
+    ],
+)
+
 add_lint_tests(enable_clang_format_lint = False)

--- a/geometry/render_vtk/factory.h
+++ b/geometry/render_vtk/factory.h
@@ -57,14 +57,10 @@ namespace geometry {
 
  | Group name | Property Name |   Required    |  Property Type  | Property Description |
  | :--------: | :-----------: | :-----------: | :-------------: | :------------------- |
- |   label    | id            | configurable⁵ |  RenderLabel    | The label to render into the image. |
+ |   label    | id            | no⁵           |  RenderLabel    | The label to render into the image. |
 
- ⁵ %RenderEngineVtk has a default render label value that is applied to any
- geometry that doesn't have a (label, id) property at registration. If a value
- is not explicitly specified, %RenderEngineVtk uses RenderLabel::kUnspecified
- as this default value. It can be explicitly set upon construction. The possible
- values for this default label and the ramifications of that choice are
- documented @ref render_engine_default_label "here".
+ ⁵ When the label property is not set, %RenderEngineVtk uses a default render
+ label of RenderLabel::kDontCare.
 
  <h3>Geometries accepted by %RenderEngineVtk</h3>
 

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -93,11 +93,18 @@ ShaderCallback::ShaderCallback() :
 vtkNew<ShaderCallback> RenderEngineVtk::uniform_setting_callback_;
 
 RenderEngineVtk::RenderEngineVtk(const RenderEngineVtkParams& parameters)
-    : RenderEngine(parameters.default_label ? *parameters.default_label
-                                            : RenderLabel::kUnspecified),
+    : RenderEngine(  // TODO(jwnimmer-tri) Upon deprecation removal of the
+                     // default_label on 2023-12-01, we should hard-code the
+                     // kDontCare here, instead of using value_or().
+          parameters.default_label.value_or(RenderLabel::kDontCare)),
       pipelines_{{make_unique<RenderingPipeline>(),
                   make_unique<RenderingPipeline>(),
                   make_unique<RenderingPipeline>()}} {
+  if (parameters.default_label.has_value()) {
+    static const logging::Warn log_once(
+        "RenderEngineVtk(): the default_label configuration option is "
+        "deprecated and will be removed from Drake on or after 2023-12-01.");
+  }
   if (parameters.default_diffuse) {
     default_diffuse_.set(*parameters.default_diffuse);
   }

--- a/geometry/render_vtk/render_engine_vtk_params.h
+++ b/geometry/render_vtk/render_engine_vtk_params.h
@@ -15,13 +15,13 @@ struct RenderEngineVtkParams  {
   Refer to @ref yaml_serialization "YAML Serialization" for background. */
   template <typename Archive>
   void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(default_label));
     a->Visit(DRAKE_NVP(default_diffuse));
     a->Visit(DRAKE_NVP(default_clear_color));
   }
 
-  /** The (optional) label to apply when none is otherwise specified.  */
-  std::optional<render::RenderLabel> default_label{};
+  /** (Deprecated.) The default_label is no longer configurable. <br>
+   This will be removed from Drake on or after 2023-12-01. */
+  std::optional<render::RenderLabel> default_label;
 
   /** The (optional) rgba color to apply to the (phong, diffuse) property when
     none is otherwise specified. Note: currently the alpha channel is unused

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -991,7 +991,7 @@ TEST_F(RenderEngineVtkTest, NonUcharChannelTextures) {
   ImageRgba8U color_uchar_texture(intrinsics.width(), intrinsics.height());
   {
     RenderEngineVtk renderer;
-    InitializeRenderer(X_WC_, false /* add terrain */, &renderer);
+    InitializeRenderer(X_WC_, false /* no terrain */, &renderer);
 
     const GeometryId id = GeometryId::get_new_id();
     PerceptionProperties props = simple_material(true);
@@ -1003,7 +1003,7 @@ TEST_F(RenderEngineVtkTest, NonUcharChannelTextures) {
   ImageRgba8U color_uint16_texture(intrinsics.width(), intrinsics.height());
   {
     RenderEngineVtk renderer;
-    InitializeRenderer(X_WC_, false /* add terrain */, &renderer);
+    InitializeRenderer(X_WC_, false /* no terrain */, &renderer);
 
     const GeometryId id = GeometryId::get_new_id();
     PerceptionProperties props = simple_material(true);
@@ -1266,14 +1266,18 @@ TEST_F(RenderEngineVtkTest, DefaultProperties_RenderLabel) {
     engine->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
   };
 
-  // Case: No change to render engine's default must throw.
+  // Case: The engine's default is "don't care".
   {
+    ResetExpectations();
     RenderEngineVtk renderer;
-    InitializeRenderer(X_WC_, false /* no terrain */, &renderer);
+    InitializeRenderer(X_WC_, true /* add terrain */, &renderer);
 
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        populate_default_sphere(&renderer),
-        ".* geometry with the 'unspecified' or 'empty' render labels.*");
+    DRAKE_EXPECT_NO_THROW(populate_default_sphere(&renderer));
+    expected_label_ = RenderLabel::kDontCare;
+    expected_color_ = RgbaColor(renderer.default_diffuse());
+
+    PerformCenterShapeTest(&renderer,
+                           "Default properties; don't care label");
   }
 
   // Case: Change render engine's default to explicitly be unspecified; must
@@ -1292,7 +1296,7 @@ TEST_F(RenderEngineVtkTest, DefaultProperties_RenderLabel) {
   {
     ResetExpectations();
     RenderEngineVtk renderer{{RenderLabel::kDontCare, {}}};
-    InitializeRenderer(X_WC_, true /* no terrain */, &renderer);
+    InitializeRenderer(X_WC_, true /* add terrain */, &renderer);
 
     DRAKE_EXPECT_NO_THROW(populate_default_sphere(&renderer));
     expected_label_ = RenderLabel::kDontCare;

--- a/geometry/render_vtk/test/render_engine_vtk_params_test.cc
+++ b/geometry/render_vtk/test/render_engine_vtk_params_test.cc
@@ -1,0 +1,25 @@
+#include "drake/geometry/render_vtk/render_engine_vtk_params.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/yaml/yaml_io.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+GTEST_TEST(RenderEngineVtkParams, Serialization) {
+  using Params = RenderEngineVtkParams;
+  const Params original{
+      .default_diffuse = Eigen::Vector4d{1.0, 0.5, 0.25, 1.0},
+      .default_clear_color = Eigen::Vector3d{0.25, 0.5, 1.0},
+  };
+  const std::string yaml = yaml::SaveYamlString<Params>(original);
+  const Params dut = yaml::LoadYamlString<Params>(yaml);
+  EXPECT_EQ(dut.default_diffuse, original.default_diffuse);
+  EXPECT_EQ(dut.default_clear_color, original.default_clear_color);
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
See #19906 for discussion.

To avoid some merge conflict awkwardness, I plan to wait for that PR to merge first before we start reviewing this one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19911)
<!-- Reviewable:end -->
