### PR TITLE
[geometry] Deprecate RenderEngineGl's default_label option

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -3,6 +3,7 @@
  pydrake.geometry module. */
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -370,6 +371,16 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
     DefCopyAndDeepCopy(&cls);
+    // Shim in the vestigial (deprecated) attribute; it's not part of Serialize.
+    // Remove this on 2023-12-01.
+    cls.def_property("default_label",
+        WrapDeprecated(cls_doc.default_label.doc,
+            [](const Class& self) { return self.default_label; }),
+        WrapDeprecated(cls_doc.default_label.doc,
+            [](Class& self, const RenderLabel& value) {
+              self.default_label = value;
+            }),
+        cls_doc.default_label.doc);
   }
 
   m.def("MakeRenderEngineGl", &MakeRenderEngineGl,

--- a/bindings/pydrake/geometry/test/render_test.py
+++ b/bindings/pydrake/geometry/test/render_test.py
@@ -6,6 +6,7 @@ import unittest
 import numpy as np
 
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.value import Value
 from pydrake.math import RigidTransform
 from pydrake.systems.framework import (
@@ -69,19 +70,26 @@ class TestGeometryRender(unittest.TestCase):
         mut.RenderEngineGlParams()
 
         # The kwarg constructor also works.
-        label = mut.RenderLabel(10)
         diffuse = mut.Rgba(1.0, 0.0, 0.0, 0.0)
         params = mut.RenderEngineGlParams(
             default_clear_color=diffuse,
-            default_label=label,
             default_diffuse=diffuse,
         )
         self.assertEqual(params.default_clear_color, diffuse)
-        self.assertEqual(params.default_label, label)
         self.assertEqual(params.default_diffuse, diffuse)
 
-        self.assertIn("default_label", repr(params))
+        self.assertIn("default_clear_color", repr(params))
         copy.copy(params)
+
+    def test_render_engine_gl_params_deprecated(self):
+        """The default_label attribute is deprecated; make sure it still works,
+        for now.
+        """
+        label = mut.RenderLabel(10)
+        with catch_drake_warnings(expected_count=1):
+            params = mut.RenderEngineGlParams(default_label=label)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(params.default_label, label)
 
     def test_render_engine_gltf_client_params(self):
         # A default constructor exists.

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -335,6 +335,14 @@ drake_cc_googletest_ubuntu_only(
     ],
 )
 
+drake_cc_googletest(
+    name = "render_engine_gl_params_test",
+    deps = [
+        ":render_engine_gl_params",
+        "//common/yaml",
+    ],
+)
+
 add_lint_tests(
     cpplint_extra_srcs = [
         "no_factory.cc",

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -714,6 +714,12 @@ RenderEngineGl::RenderEngineGl(RenderEngineGlParams params)
       opengl_context_(make_unique<OpenGlContext>()),
       texture_library_(make_shared<TextureLibrary>()),
       parameters_(CleanupLights(std::move(params))) {
+  if (params.default_label != RenderLabel::kDontCare) {
+    static const logging::Warn log_once(
+        "RenderEngineGl(): the default_label configuration option is "
+        "deprecated and will be removed from Drake on or after 2023-12-01.");
+  }
+
   // The default light parameters have been crafted to create the default
   // "headlamp" camera.
   fallback_lights_.push_back({});

--- a/geometry/render_gl/render_engine_gl_params.h
+++ b/geometry/render_gl/render_engine_gl_params.h
@@ -16,15 +16,14 @@ struct RenderEngineGlParams {
   Refer to @ref yaml_serialization "YAML Serialization" for background. */
   template <typename Archive>
   void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(default_label));
     a->Visit(DRAKE_NVP(default_diffuse));
     a->Visit(DRAKE_NVP(default_clear_color));
     a->Visit(DRAKE_NVP(lights));
   }
 
-  /** Default render label to apply to a geometry when none is otherwise
-   specified.  */
-  render::RenderLabel default_label{render::RenderLabel::kUnspecified};
+  /** (Deprecated.) The default_label is no longer configurable. <br>
+   This will be removed from Drake on or after 2023-12-01. */
+  render::RenderLabel default_label{render::RenderLabel::kDontCare};
 
   /** Default diffuse color to apply to a geometry when none is otherwise
    specified in the (phong, diffuse) property.  */

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -1377,10 +1377,6 @@ TEST_F(RenderEngineGlTest, DefaultProperties) {
   // Sets up a box.
   Box box(1, 1, 1);
   const GeometryId id = GeometryId::get_new_id();
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      renderer_->RegisterVisual(id, box, PerceptionProperties(),
-                                RigidTransformd::Identity(), true),
-      ".* geometry with the 'unspecified' or 'empty' render labels.*");
   PerceptionProperties material;
   material.AddProperty("label", "id", RenderLabel::kDontCare);
   renderer_->RegisterVisual(id, box, material, RigidTransformd::Identity(),
@@ -1406,14 +1402,17 @@ TEST_F(RenderEngineGlTest, DefaultProperties_RenderLabel) {
     engine->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
   };
 
-  // Case: No change to render engine's default must throw.
+  // Case: The engine's default is "don't care".
   {
     RenderEngineGl renderer;
-    InitializeRenderer(X_WR_, false /* no terrain */, &renderer);
+    InitializeRenderer(X_WR_, true /* add terrain */, &renderer);
 
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        populate_default_sphere(&renderer),
-        ".* geometry with the 'unspecified' or 'empty' render labels.*");
+    DRAKE_EXPECT_NO_THROW(populate_default_sphere(&renderer));
+    expected_label_ = RenderLabel::kDontCare;
+    expected_color_ = RgbaColor(renderer.parameters().default_diffuse);
+
+    SCOPED_TRACE("Default properties; don't care label");
+    PerformCenterShapeTest(&renderer);
   }
 
   // Case: Change render engine's default to explicitly be unspecified; must

--- a/geometry/render_gl/test/render_engine_gl_params_test.cc
+++ b/geometry/render_gl/test/render_engine_gl_params_test.cc
@@ -1,0 +1,28 @@
+#include "drake/geometry/render_gl/render_engine_gl_params.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/yaml/yaml_io.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+GTEST_TEST(RenderEngineGlParams, Serialization) {
+  using Params = RenderEngineGlParams;
+  const Params original{
+      .default_diffuse = Rgba{1.0, 0.5, 0.25},
+      .default_clear_color = Rgba{0.25, 0.5, 1.0},
+      .lights = {{.type = "point"}},
+  };
+  const std::string yaml = yaml::SaveYamlString<Params>(original);
+  const Params dut = yaml::LoadYamlString<Params>(yaml);
+  EXPECT_EQ(dut.default_diffuse, original.default_diffuse);
+  EXPECT_EQ(dut.default_clear_color, original.default_clear_color);
+  ASSERT_EQ(dut.lights.size(), 1);
+  EXPECT_EQ(dut.lights.at(0).type, "point");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
See #19906 for discussion.

+@SeanCurtis-TRI for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19912)
<!-- Reviewable:end -->
