### PR TITLE
Increase mypy timeout for CI machines to 720 secs

### DIFF
--- a/tools/workspace/mypy_internal/patches/timeout.patch
+++ b/tools/workspace/mypy_internal/patches/timeout.patch
@@ -7,7 +7,7 @@ Increase timeout from 30 seconds to 360 seconds
          Return the value read from the queue, or None if the process unexpectedly died.
          """
 -        max_iter = 600
-+        timeout_seconds = 360
++        timeout_seconds = 720
 +        timeout_increment = 0.05
 +        max_iter = int(timeout_seconds / timeout_increment)
          n = 0


### PR DESCRIPTION
Relates: https://github.com/RobotLocomotion/drake/issues/18119

[Slack discussion](https://drakedevelopers.slack.com/archives/C270MN28G/p1690974686728459).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19916)
<!-- Reviewable:end -->
