### PR TITLE
Fix AffineSubspace tolerance for focal/mosek.

### DIFF
--- a/geometry/optimization/test/affine_subspace_test.cc
+++ b/geometry/optimization/test/affine_subspace_test.cc
@@ -596,7 +596,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   Intersection i1(point, line_segment);
   AffineSubspace as1(i1);
 
-  const double kTol1 = 1e-15;
+  const double kTol1 = 1e-6;
   EXPECT_TRUE(i1.PointInSet(Eigen::Vector3d(0.5, 0.5, 0.5), kTol1));
   EXPECT_TRUE(as1.PointInSet(Eigen::Vector3d(0.5, 0.5, 0.5), kTol1));
 
@@ -617,7 +617,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   Intersection i2(line_segment, triangle1);
   AffineSubspace as2(i2);
 
-  const double kTol2 = 1e-12;
+  const double kTol2 = 1e-6;
   const Eigen::Vector3d one_third(1. / 3., 1. / 3., 1. / 3.);
   EXPECT_TRUE(i2.PointInSet(one_third, kTol2));
   EXPECT_TRUE(as2.PointInSet(one_third, kTol2));
@@ -639,7 +639,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   Intersection i3(line_segment, triangle2);
   AffineSubspace as3(i3);
 
-  const double kTol3 = 1e-12;
+  const double kTol3 = 1e-6;
   EXPECT_TRUE(i3.PointInSet(Eigen::Vector3d(0, 0, 0), kTol3));
   EXPECT_TRUE(i3.PointInSet(Eigen::Vector3d(1, 1, 1), kTol3));
 
@@ -694,6 +694,8 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   Intersection i5(triangle2, triangle4);
   AffineSubspace as5(i5);
 
+  EXPECT_EQ(as5.basis().cols(), 2);
+
   const double kTol5 = 1e-6;
   EXPECT_TRUE(i5.PointInSet(Eigen::Vector3d(0, 0, 0), kTol5));
   EXPECT_TRUE(i5.PointInSet(Eigen::Vector3d(1, 1, 0), kTol5));
@@ -709,7 +711,13 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   EXPECT_EQ(as5.ambient_dimension(), 3);
 
   EXPECT_TRUE(CheckAffineSubspaceSetContainment(as5, i5, kTol5));
-  CheckAffineHullTightness(as5, i5, kTol5);
+
+  // For this test case, a tighter tolerance is needed to check
+  // that the affine hull is the miminmal affine set that
+  // contains the intersection. May be related to the tolerance
+  // issues for VPolytope described in issue #17197.
+  const double tightness_tol = 1e-15;
+  CheckAffineHullTightness(as5, i5, tightness_tol);
 }
 
 GTEST_TEST(AffineSubspaceTest, AffineHullMinkowskiSum) {

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -347,7 +347,7 @@ GTEST_TEST(VPolytopeTest, FromHUnitBoxTest) {
   Vector6d out3_W;
   out3_W << .99, 1.01, .99, 1.01, .99, 1.01;
 
-  const double kTol = 1e-11;
+  const double kTol = 1e-9;
   EXPECT_TRUE(V.PointInSet(in1_W, kTol));
   EXPECT_TRUE(V.PointInSet(in2_W, kTol));
   EXPECT_FALSE(V.PointInSet(out1_W, kTol));


### PR DESCRIPTION
Testing out tolerances and diagnosing the problem discussed in #19917. If it's not a quick fix, then I'll ask buildcop to revert #19864.

@drake-jenkins-bot linux-focal-clang-bazel-experimental-mosek-release

Doing this all in a PR because I'm on 22.04 locally, and the existing tolerances work on my 22.04 machine with and without Mosek.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19918)
<!-- Reviewable:end -->
