### PR TITLE
Pipes constraints forces through and fixes reaction forces computation

### DIFF
--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -165,6 +165,15 @@ class CompliantContactManager final
 
   void DoDeclareCacheEntries() final;
 
+  // Computes the effective damping matrix D̃ used in discrete schemes treating
+  // damping terms implicitly. This includes joint damping and reflected
+  // inertias. That is, if R is the diagonal matrix of reflected inertias and D
+  // is the diagonal matrix of joint damping coefficients, then the effective
+  // discrete damping term D̃ is: D̃ = R + δt⋅D.
+  // Since D̃ is diagonal this method returns a VectorX with the diagonal
+  // entries only.
+  VectorX<T> CalcEffectiveDamping(const systems::Context<T>& context) const;
+
   // TODO(amcastro-tri): implement these APIs according to #16955.
   // @throws For SAP if T = symbolic::Expression.
   // @throws For TAMSI if T = symbolic::Expression only if the model contains
@@ -177,9 +186,11 @@ class CompliantContactManager final
   void DoCalcAccelerationKinematicsCache(
       const systems::Context<T>&,
       multibody::internal::AccelerationKinematicsCache<T>*) const final;
-  void DoCalcContactResults(
-      const systems::Context<T>&,
-      ContactResults<T>* contact_results) const final;
+  void DoCalcContactResults(const systems::Context<T>&,
+                            ContactResults<T>* contact_results) const final;
+  void DoCalcDiscreteUpdateMultibodyForces(
+      const systems::Context<T>& context,
+      MultibodyForces<T>* forces) const final;
 
   // This method computes sparse kinematics information for each contact pair at
   // the given configuration stored in `context`.

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -56,13 +56,33 @@ void DiscreteUpdateManager<T>::DeclareCacheEntries() {
   // See ThrowIfNonContactForceInProgress().
   const auto& non_contact_forces_evaluation_in_progress =
       this->DeclareCacheEntry(
-          "Evaluation of non-contact forces and accelerations is in progress.",
+          "Evaluation of non-contact forces and accelerations is in progress",
           // N.B. This flag is set to true only when the computation is in
           // progress. Therefore its default value is `false`.
           systems::ValueProducer(false, &systems::ValueProducer::NoopCalc),
           {systems::System<T>::nothing_ticket()});
   cache_indexes_.non_contact_forces_evaluation_in_progress =
       non_contact_forces_evaluation_in_progress.cache_index();
+
+  MultibodyForces<T> model_forces(plant());
+  const auto& multibody_forces_cache_entry = DeclareCacheEntry(
+      "Discrete update multibody forces",
+      systems::ValueProducer(
+          this, model_forces,
+          &DiscreteUpdateManager<T>::CalcDiscreteUpdateMultibodyForces),
+      {systems::System<T>::xd_ticket(),
+       systems::System<T>::all_parameters_ticket()});
+  cache_indexes_.discrete_update_multibody_forces =
+      multibody_forces_cache_entry.cache_index();
+
+  const auto& contact_results_cache_entry = DeclareCacheEntry(
+      "Contact results (discrete)",
+      systems::ValueProducer(
+          this,
+          &DiscreteUpdateManager<T>::CalcContactResults),
+      {systems::System<T>::xd_ticket(),
+       systems::System<T>::all_parameters_ticket()});
+  cache_indexes_.contact_results = contact_results_cache_entry.cache_index();
 
   // Allow derived classes to declare their own cache entries.
   DoDeclareCacheEntries();
@@ -300,6 +320,41 @@ void DiscreteUpdateManager<T>::CopyForcesFromInputPorts(
   forces->SetZero();
   MultibodyPlantDiscreteUpdateManagerAttorney<T>::AddInForcesFromInputPorts(
       plant(), context, forces);
+}
+
+template <typename T>
+void DiscreteUpdateManager<T>::CalcContactResults(
+    const systems::Context<T>& context,
+    ContactResults<T>* contact_results) const {
+  DRAKE_DEMAND(contact_results != nullptr);
+  plant().ValidateContext(context);
+  DoCalcContactResults(context, contact_results);
+}
+
+template <typename T>
+void DiscreteUpdateManager<T>::CalcDiscreteUpdateMultibodyForces(
+    const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  plant().ValidateContext(context);
+  DRAKE_DEMAND(forces != nullptr);
+  DRAKE_DEMAND(forces->CheckHasRightSizeForModel(plant()));
+  DoCalcDiscreteUpdateMultibodyForces(context, forces);
+}
+
+template <typename T>
+const MultibodyForces<T>&
+DiscreteUpdateManager<T>::EvalDiscreteUpdateMultibodyForces(
+    const systems::Context<T>& context) const {
+  return plant()
+      .get_cache_entry(cache_indexes_.discrete_update_multibody_forces)
+      .template Eval<MultibodyForces<T>>(context);
+}
+
+template <typename T>
+const ContactResults<T>& DiscreteUpdateManager<T>::EvalContactResults(
+    const systems::Context<T>& context) const {
+  return plant()
+      .get_cache_entry(cache_indexes_.contact_results)
+      .template Eval<ContactResults<T>>(context);
 }
 
 }  // namespace internal

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -143,13 +143,10 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
     DoCalcDiscreteValues(context, updates);
   }
 
-  /* MultibodyPlant invokes this method to report contact results. */
-  void CalcContactResults(const systems::Context<T>& context,
-                          ContactResults<T>* contact_results) const {
-    DRAKE_DEMAND(contact_results != nullptr);
-    plant().ValidateContext(context);
-    DoCalcContactResults(context, contact_results);
-  }
+  /* Evaluates the contact results used in CalcDiscreteValues() to advance the
+   discrete update from the state stored in `context`. */
+  const ContactResults<T>& EvalContactResults(
+      const systems::Context<T>& context) const;
 
   // Computes all non-contact applied forces including:
   //  - Force elements.
@@ -165,6 +162,13 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   // constraints, rather than raw solver results.
   const contact_solvers::internal::ContactSolverResults<T>&
   EvalContactSolverResults(const systems::Context<T>& context) const;
+
+  /* When the discrete update is performed, see CalcDiscreteValues(), multibody
+   forces applied during that updated are cached. This method returns a
+   reference to the total multibody forces applied during the discrete update.
+   These forces include force elements, constraints and contact forces. */
+  const MultibodyForces<T>& EvalDiscreteUpdateMultibodyForces(
+      const systems::Context<T>& context) const;
 
   /* Publicly exposed MultibodyPlant private/protected methods.
    @{ */
@@ -211,8 +215,8 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
    information from the owning MultibodyPlant. */
   virtual void ExtractModelInfo() {}
 
-  /* Derived DiscreteUpdateManager should override this method to declare
-   cache entries in the owning MultibodyPlant. */
+  /* Derived classes can implement this method if they wish to declare their own
+   cache entries. It defaults to a no-op. */
   virtual void DoDeclareCacheEntries() {}
 
   /* Returns the discrete state index of the rigid position and velocity states
@@ -277,9 +281,20 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
       const systems::Context<T>& context,
       systems::DiscreteValues<T>* updates) const = 0;
 
+  /* Concrete managers must implement this method to compute contact results
+   according to the underlying formulation of contact. */
   virtual void DoCalcContactResults(
       const systems::Context<T>& context,
       ContactResults<T>* contact_results) const = 0;
+
+  /* Concrete managers must implement this method to compute the total multibody
+   forces applied during a discrete update. The particulars of the numerical
+   scheme matter. For instance, whether we use an explicit or implicit update.
+   Therefore only concrete managers know how to perform this computation in
+   accordance to the schemes they implement. See
+   EvalDiscreteUpdateMultibodyForces(). */
+  virtual void DoCalcDiscreteUpdateMultibodyForces(
+      const systems::Context<T>& context, MultibodyForces<T>* forces) const = 0;
 
   // Struct used to conglomerate the indexes of cache entries declared by the
   // manager.
@@ -297,6 +312,8 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
     systems::CacheIndex discrete_input_port_forces;
     systems::CacheIndex contact_solver_results;
     systems::CacheIndex non_contact_forces_evaluation_in_progress;
+    systems::CacheIndex contact_results;
+    systems::CacheIndex discrete_update_multibody_forces;
   };
 
   // Exposes indices for the cache entries declared by this class for derived
@@ -331,10 +348,19 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   // NVI to DoDeclareCacheEntries().
   void DeclareCacheEntries();
 
-  systems::DiscreteStateIndex multibody_state_index_;
-  CacheIndexes cache_indexes_;
+  /* Calc version of EvalContactResults(), NVI to DoCalcContactResults(). */
+  void CalcContactResults(const systems::Context<T>& context,
+                          ContactResults<T>* contact_results) const;
+
+  // Calc version of EvalDiscreteUpdateMultibodyForces, NVI to
+  // DoCalcDiscreteUpdateMultibodyForces.
+  void CalcDiscreteUpdateMultibodyForces(const systems::Context<T>& context,
+                                         MultibodyForces<T>* forces) const;
+
   const MultibodyPlant<T>* plant_{nullptr};
   MultibodyPlant<T>* mutable_plant_{nullptr};
+  systems::DiscreteStateIndex multibody_state_index_;
+  CacheIndexes cache_indexes_;
 };
 
 }  // namespace internal

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1683,6 +1683,7 @@ void MultibodyPlant<T>::CalcContactResultsContinuous(
     const systems::Context<T>& context,
     ContactResults<T>* contact_results) const {
   this->ValidateContext(context);
+  DRAKE_DEMAND(!is_discrete());
   DRAKE_DEMAND(contact_results != nullptr);
   contact_results->Clear();
   contact_results->set_plant(this);
@@ -1845,14 +1846,6 @@ void MultibodyPlant<T>::AppendContactResultsContinuousPointPair(
           {bodyA_index, bodyB_index, f_Bc_W, p_WC, vn, slip_velocity, pair});
     }
   }
-}
-
-template <typename T>
-void MultibodyPlant<T>::CalcContactResultsDiscrete(
-    const systems::Context<T>& context,
-    ContactResults<T>* contact_results) const {
-  DRAKE_DEMAND(contact_results != nullptr);
-  discrete_update_manager_->CalcContactResults(context, contact_results);
 }
 
 template <typename T>
@@ -2780,12 +2773,18 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
           .get_index();
 
   // Contact results output port.
-  const auto& contact_results_cache_entry =
-      this->get_cache_entry(cache_indexes_.contact_results);
+  const systems::DependencyTicket state_ticket =
+      is_discrete() ? this->xd_ticket() : this->kinematics_ticket();
+  std::set<systems::DependencyTicket> contact_results_prerequisites = {
+      state_ticket};
+  if (is_discrete()) {
+    contact_results_prerequisites.insert(this->all_input_ports_ticket());
+    contact_results_prerequisites.insert(this->all_parameters_ticket());
+  }
   contact_results_port_ = this->DeclareAbstractOutputPort(
                                   "contact_results", ContactResults<T>(),
                                   &MultibodyPlant<T>::CopyContactResultsOutput,
-                                  {contact_results_cache_entry.ticket()})
+                                  contact_results_prerequisites)
                               .get_index();
 
   // Let external model managers declare their state, cache and ports in
@@ -2845,34 +2844,25 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
         contact_info_and_body_spatial_forces_cache_entry.cache_index();
   }
 
-  // Cache contact results.
-  // In discrete mode contact forces computation requires to advance the system
-  // from step n to n+1. Therefore they are a function of state and input.
+  // Cache contact results, for continuous plant models.
   // In continuous mode contact forces are simply a function of state.
-  std::set<systems::DependencyTicket> dependency_ticket = [this,
-                                                           use_hydroelastic]() {
-    std::set<systems::DependencyTicket> tickets;
-    if (is_discrete()) {
-      tickets.insert(systems::System<T>::xd_ticket());
-      tickets.insert(systems::System<T>::all_parameters_ticket());
-    } else {
-      tickets.insert(this->kinematics_ticket());
-      if (use_hydroelastic) {
-        tickets.insert(this->cache_entry_ticket(
-            cache_indexes_.contact_info_and_body_spatial_forces));
-      }
-    }
-    tickets.insert(this->all_parameters_ticket());
-
-    return tickets;
-  }();
-  auto& contact_results_cache_entry = this->DeclareCacheEntry(
-      std::string("Contact results."),
-      is_discrete() ?
-          &MultibodyPlant<T>::CalcContactResultsDiscrete :
-          &MultibodyPlant<T>::CalcContactResultsContinuous,
-      {dependency_ticket});
-  cache_indexes_.contact_results = contact_results_cache_entry.cache_index();
+  if (!is_discrete()) {
+    std::set<systems::DependencyTicket> dependency_ticket =
+        [this, use_hydroelastic]() {
+          std::set<systems::DependencyTicket> tickets;
+          tickets.insert(this->kinematics_ticket());
+          if (use_hydroelastic) {
+            tickets.insert(this->cache_entry_ticket(
+                cache_indexes_.contact_info_and_body_spatial_forces));
+          }
+          tickets.insert(this->all_parameters_ticket());
+          return tickets;
+        }();
+    auto& contact_results_cache_entry = this->DeclareCacheEntry(
+        std::string("Contact results (continuous)"),
+        &MultibodyPlant<T>::CalcContactResultsContinuous, {dependency_ticket});
+    cache_indexes_.contact_results = contact_results_cache_entry.cache_index();
+  }
 
   // Cache spatial continuous contact forces.
   auto& spatial_contact_forces_continuous_cache_entry = this->DeclareCacheEntry(
@@ -3133,33 +3123,35 @@ void MultibodyPlant<T>::CalcReactionForces(
   // Guard against failure to acquire the geometry input deep in the call graph.
   ValidateGeometryInput(context, get_reaction_forces_output_port());
 
-  const VectorX<T>& vdot = this->EvalForwardDynamics(context).get_vdot();
-
-  // TODO(sherm1) EvalForwardDynamics() should record the forces it used
-  //              so that we don't have to attempt to reconstruct them
-  //              here (and this is broken, see #13888).
+  // Compute the multibody forces applied during the computation of forward
+  // dynamics, consistent with the value of vdot obtained below.
   MultibodyForces<T> applied_forces(*this);
-  CalcNonContactForces(context, is_discrete(), &applied_forces);
   auto& Fapplied_Bo_W_array = applied_forces.mutable_body_forces();
   auto& tau_applied = applied_forces.mutable_generalized_forces();
-
-  // Add in forces due to contact.
-  // Only add in hydroelastic contact forces for continuous mode for now as
-  // the forces computed by CalcHydroelasticContactForces() are wrong in
-  // discrete mode. See (#13888).
-  if (!is_discrete()) {
-    CalcAndAddSpatialContactForcesContinuous(context, &Fapplied_Bo_W_array);
+  if (is_discrete()) {
+    applied_forces =
+        discrete_update_manager_->EvalDiscreteUpdateMultibodyForces(context);
   } else {
-    CalcAndAddContactForcesByPenaltyMethod(context, &Fapplied_Bo_W_array);
+    CalcNonContactForces(context, is_discrete(), &applied_forces);
+    CalcAndAddSpatialContactForcesContinuous(context, &Fapplied_Bo_W_array);
   }
 
   // Compute reaction forces at each mobilizer.
+  // N.B. For discrete systems, this approach right now evaluates Coriolis terms
+  // at the state stored in the context (previous time step). This is correct
+  // for the discrete solvers we have today, though it might change for future
+  // solvers that prefer an implicit evaluation of these terms.
+  // TODO(amcastro-tri): Consider having a
+  // DiscreteUpdateManager::EvalReactionForces() to ensure the manager performs
+  // this computation consistently with its discrete update.
+  const VectorX<T>& vdot = this->EvalForwardDynamics(context).get_vdot();
   std::vector<SpatialAcceleration<T>> A_WB_vector(num_bodies());
   std::vector<SpatialForce<T>> F_BMo_W_vector(num_bodies());
   VectorX<T> tau_id(num_velocities());
   internal_tree().CalcInverseDynamics(context, vdot, Fapplied_Bo_W_array,
                                       tau_applied, &A_WB_vector,
                                       &F_BMo_W_vector, &tau_id);
+
   // Since vdot is the result of Fapplied and tau_applied we expect the result
   // from inverse dynamics to be zero.
   // TODO(amcastro-tri): find a better estimation for this bound. For instance,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1832,6 +1832,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void set_contact_model(ContactModel model);
 
   /// Sets the contact solver type used for discrete %MultibodyPlant models.
+  /// @warning This function is a no-op for continuous models (when
+  /// is_discrete() is false.)
   /// @throws std::exception iff called post-finalize.
   void set_discrete_contact_solver(DiscreteContactSolver contact_solver);
 
@@ -5001,17 +5003,15 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       ContactResults<T>* contact_results) const;
 
-  // This method accumulates both point and hydroelastic contact results into
-  // contact_results when the model is discrete.
-  // @param[out] contact_results is fully overwritten
-  void CalcContactResultsDiscrete(const systems::Context<T>& context,
-                                  ContactResults<T>* contact_results) const;
-
   // Evaluate contact results.
   const ContactResults<T>& EvalContactResults(
       const systems::Context<T>& context) const {
-    return this->get_cache_entry(cache_indexes_.contact_results)
-        .template Eval<ContactResults<T>>(context);
+    if (this->is_discrete()) {
+      return discrete_update_manager_->EvalContactResults(context);
+    } else {
+      return this->get_cache_entry(cache_indexes_.contact_results)
+          .template Eval<ContactResults<T>>(context);
+    }
   }
 
   // Calc method for the reaction forces output port.

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -85,6 +85,21 @@ void SapDriver<T>::DeclareCacheEntries(
                              &SapDriver<T>::CalcContactProblemCache),
       state_input_and_parameters);
   contact_problem_ = contact_problem_cache_entry.cache_index();
+
+  const auto& sap_solver_results_cache_entry =
+      mutable_manager->DeclareCacheEntry(
+          "SAP solver results",
+          systems::ValueProducer(this, &SapDriver<T>::CalcSapSolverResults),
+          state_input_and_parameters);
+  sap_results_ = sap_solver_results_cache_entry.cache_index();
+}
+
+template <typename T>
+const SapSolverResults<T>& SapDriver<T>::EvalSapSolverResults(
+    const systems::Context<T>& context) const {
+  return plant()
+      .get_cache_entry(sap_results_)
+      .template Eval<SapSolverResults<T>>(context);
 }
 
 template <typename T>
@@ -710,9 +725,9 @@ void SapDriver<T>::AddCliqueContribution(
 }
 
 template <typename T>
-void SapDriver<T>::CalcContactSolverResults(
+void SapDriver<T>::CalcSapSolverResults(
     const systems::Context<T>& context,
-    contact_solvers::internal::ContactSolverResults<T>* results) const {
+    SapSolverResults<T>* sap_results) const {
   const ContactProblemCache<T>& contact_problem_cache =
       EvalContactProblemCache(context);
   const SapContactProblem<T>& sap_problem = *contact_problem_cache.sap_problem;
@@ -745,14 +760,19 @@ void SapDriver<T>::CalcContactSolverResults(
   // Solve the reduced DOF locked problem.
   SapSolver<T> sap;
   sap.set_parameters(sap_parameters_);
-  SapSolverResults<T> sap_results;
 
-  // Solve the locked problem only when joint locking is present.
-  const SapSolverStatus status =
-      (has_locked_dofs
-           ? sap.SolveWithGuess(*contact_problem_cache.sap_problem_locked, v0,
-                                &sap_results)
-           : sap.SolveWithGuess(sap_problem, v0, &sap_results));
+  SapSolverStatus status;
+  if (has_locked_dofs) {
+    SapSolverResults<T> locked_sap_results;
+    status = sap.SolveWithGuess(*contact_problem_cache.sap_problem_locked, v0,
+                                &locked_sap_results);
+    if (status == SapSolverStatus::kSuccess) {
+      sap_problem.ExpandContactSolverResults(contact_problem_cache.mapping,
+                                             locked_sap_results, sap_results);
+    }
+  } else {
+    status = sap.SolveWithGuess(sap_problem, v0, sap_results);
+  }
 
   if (status != SapSolverStatus::kSuccess) {
     const std::string msg = fmt::format(
@@ -777,22 +797,81 @@ void SapDriver<T>::CalcContactSolverResults(
         context.get_time());
     throw std::runtime_error(msg);
   }
+}
 
+template <typename T>
+void SapDriver<T>::CalcContactSolverResults(
+    const systems::Context<T>& context,
+    contact_solvers::internal::ContactSolverResults<T>* results) const {
+  const ContactProblemCache<T>& contact_problem_cache =
+      EvalContactProblemCache(context);
+  const SapContactProblem<T>& sap_problem = *contact_problem_cache.sap_problem;
+  const SapSolverResults<T>& sap_results = EvalSapSolverResults(context);
   const std::vector<DiscreteContactPair<T>>& discrete_pairs =
       manager().EvalDiscreteContactPairs(context);
   const int num_contacts = discrete_pairs.size();
+  PackContactSolverResults(context, sap_problem, num_contacts, sap_results,
+                           results);
+}
 
-  if (has_locked_dofs) {
-    SapSolverResults<T> expanded_sap_results;
-    sap_problem.ExpandContactSolverResults(contact_problem_cache.mapping,
-                                           sap_results, &expanded_sap_results);
-    // Pack the expanded solver results.
-    PackContactSolverResults(context, sap_problem, num_contacts,
-                             expanded_sap_results, results);
-  } else {
-    // Pack the solver results.
-    PackContactSolverResults(context, sap_problem, num_contacts, sap_results,
-                             results);
+template <typename T>
+void SapDriver<T>::CalcDiscreteUpdateMultibodyForces(
+    const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  auto& generalized_forces = forces->mutable_generalized_forces();
+  auto& spatial_forces = forces->mutable_body_forces();
+
+  // Current state (previous time step).
+  const VectorX<T>& x0 =
+      context.get_discrete_state(manager().multibody_state_index()).value();
+  const auto v0 = x0.bottomRows(plant().num_velocities());
+
+  // Next time step state.
+  const contact_solvers::internal::SapContactProblem<T>& problem =
+      *EvalContactProblemCache(context).sap_problem;
+  const SapSolverResults<T>& sap_results = EvalSapSolverResults(context);
+  // Generalized velocities and accelerations.
+  const VectorX<T>& v = sap_results.v;
+  const VectorX<T> a = (v - v0) / plant().time_step();
+
+  // Include all state dependent forces (not constraints) evaluated at t₀
+  // (previous time step as stored in the context).
+  const bool include_joint_limit_penalty_forces = false;
+  manager().CalcNonContactForces(context, include_joint_limit_penalty_forces,
+                                 forces);
+
+  // SAP evaluates damping terms (joint damping and reflected inertia)
+  // implicitly. Therefore we must subtract the explicit term evaluated above
+  // and include the implicit term instead.
+  const VectorX<T> diagonal_inertia = manager().CalcEffectiveDamping(context);
+  generalized_forces -= diagonal_inertia.asDiagonal() * a;
+
+  // Include the contribution from constraints.
+  // TODO(amcastro-tri): Consider deformables.
+  if (manager().deformable_driver_ != nullptr) {
+    throw std::logic_error(
+        "The computation of MultibodyForces must be updated to include "
+        "deformable objects.");
+  }
+
+  VectorX<T> constraints_generalized_forces(plant().num_velocities());
+  std::vector<SpatialForce<T>> constraint_spatial_forces(plant().num_bodies());
+  const VectorX<T>& gamma = sap_results.gamma;
+
+  // N.B. When CompliantContactManager builds the problem, the "about point" for
+  // the reporting of multibody forces is defined to be at body origins and
+  // expressed in the world frame.
+  // Therefore aggregation of forces per-body makes sense in this call.
+  problem.CalcConstraintMultibodyForces(gamma, &constraints_generalized_forces,
+                                        &constraint_spatial_forces);
+  generalized_forces += constraints_generalized_forces;
+
+  // N.B. The CompliantContactManager indexes constraints objects with body
+  // indexes. Therefore using body indices on constraint_spatial_forces is
+  // correct. However MultibodyForce uses BodyNodeIndex, see below.
+  for (BodyIndex b(0); b < plant().num_bodies(); ++b) {
+    // MultibodyForce indexes spatial body forces by BodyNodeIndex.
+    const BodyNodeIndex node_index = plant().get_body(b).node_index();
+    spatial_forces[node_index] += constraint_spatial_forces[b];
   }
 }
 

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -5,11 +5,15 @@
 #include <vector>
 
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/compliant_contact_manager.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/plant/slicing_and_indexing.h"
 #include "drake/multibody/plant/tamsi_solver.h"
 
+using drake::geometry::GeometryId;
+using drake::math::RigidTransform;
 using drake::multibody::contact_solvers::internal::ContactSolverResults;
 
 namespace drake {
@@ -133,9 +137,8 @@ void TamsiDriver<T>::CalcContactSolverResults(
   }
 
   // Joint locking: quick exit if everything is locked.
-  const auto& indices = manager()
-                            .EvalJointLockingCache(context)
-                            .unlocked_velocity_indices;
+  const auto& indices =
+      manager().EvalJointLockingCache(context).unlocked_velocity_indices;
   if (indices.empty()) {
     // Everything is locked! Return a result that indicates no velocity, but
     // reports normal forces.
@@ -299,6 +302,83 @@ void TamsiDriver<T>::CallTamsiSolver(
   results->vn = tamsi_solver->get_normal_velocities();
   results->vt = tamsi_solver->get_tangential_velocities();
   results->tau_contact = tamsi_solver->get_generalized_contact_forces();
+}
+
+template <typename T>
+void TamsiDriver<T>::CalcAndAddSpatialContactForcesFromContactResults(
+    const systems::Context<T>& context,
+    const ContactResults<T>& contact_results,
+    std::vector<SpatialForce<T>>* spatial_contact_forces) const {
+  // Add contribution from point contact.
+  for (int i = 0; i < contact_results.num_point_pair_contacts(); ++i) {
+    const PointPairContactInfo<T>& pair =
+        contact_results.point_pair_contact_info(i);
+    const Body<T>& bodyA = plant().get_body(pair.bodyA_index());
+    const Body<T>& bodyB = plant().get_body(pair.bodyB_index());
+    const Vector3<T>& f_Bc_W = pair.contact_force();
+    const Vector3<T>& p_WC = pair.contact_point();
+    const SpatialForce<T> F_Bc_W(Vector3<T>::Zero(), f_Bc_W);
+
+    // Contact spatial force on body A.
+    const RigidTransform<T>& X_WA = plant().EvalBodyPoseInWorld(context, bodyA);
+    const Vector3<T>& p_WA = X_WA.translation();
+    const Vector3<T> p_CA_W = p_WA - p_WC;
+    const SpatialForce<T> F_Ao_W = -F_Bc_W.Shift(p_CA_W);
+
+    // Contact spatial force on body B.
+    const RigidTransform<T>& X_WB = plant().EvalBodyPoseInWorld(context, bodyB);
+    const Vector3<T>& p_WB = X_WB.translation();
+    const Vector3<T> p_CB_W = p_WB - p_WC;
+    const SpatialForce<T> F_Bo_W = F_Bc_W.Shift(p_CB_W);
+
+    spatial_contact_forces->at(bodyA.node_index()) += F_Ao_W;
+    spatial_contact_forces->at(bodyB.node_index()) += F_Bo_W;
+  }
+
+  // Add contribution from hydroelastic contact.
+  for (int i = 0; i < contact_results.num_hydroelastic_contacts(); ++i) {
+    const HydroelasticContactInfo<T>& info =
+        contact_results.hydroelastic_contact_info(i);
+
+    const GeometryId geometryM_id = info.contact_surface().id_M();
+    const GeometryId geometryN_id = info.contact_surface().id_N();
+    const BodyIndex bodyA_index = manager().FindBodyByGeometryId(geometryM_id);
+    const BodyIndex bodyB_index = manager().FindBodyByGeometryId(geometryN_id);
+    const Body<T>& bodyA = plant().get_body(bodyA_index);
+    const Body<T>& bodyB = plant().get_body(bodyB_index);
+
+    // Spatial contact force at the centroid of the contact surface.
+    const SpatialForce<T>& F_Ac_W = info.F_Ac_W();
+    const Vector3<T>& p_WC = info.contact_surface().centroid();
+
+    // Contact spatial force on body A.
+    const RigidTransform<T>& X_WA = plant().EvalBodyPoseInWorld(context, bodyA);
+    const Vector3<T>& p_WA = X_WA.translation();
+    const Vector3<T> p_CA_W = p_WA - p_WC;
+    const SpatialForce<T> F_Ao_W = F_Ac_W.Shift(p_CA_W);
+
+    // Contact spatial force on body B.
+    const RigidTransform<T>& X_WB = plant().EvalBodyPoseInWorld(context, bodyB);
+    const Vector3<T>& p_WB = X_WB.translation();
+    const Vector3<T> p_CB_W = p_WB - p_WC;
+    const SpatialForce<T> F_Bo_W = -F_Ac_W.Shift(p_CB_W);
+
+    spatial_contact_forces->at(bodyA.node_index()) += F_Ao_W;
+    spatial_contact_forces->at(bodyB.node_index()) += F_Bo_W;
+  }
+}
+
+template <typename T>
+void TamsiDriver<T>::CalcDiscreteUpdateMultibodyForces(
+    const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  const bool include_joint_limit_penalty_forces = true;
+  manager().CalcNonContactForces(context, include_joint_limit_penalty_forces,
+                                 forces);
+  const ContactResults<T>& contact_results =
+      manager().EvalContactResults(context);
+  auto& Fapplied_Bo_W_array = forces->mutable_body_forces();
+  CalcAndAddSpatialContactForcesFromContactResults(context, contact_results,
+                                                   &Fapplied_Bo_W_array);
 }
 
 }  // namespace internal

--- a/multibody/plant/tamsi_driver.h
+++ b/multibody/plant/tamsi_driver.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <vector>
+
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
 #include "drake/multibody/plant/contact_jacobians.h"
+#include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/tamsi_solver.h"
+#include "drake/multibody/tree/multibody_forces.h"
 #include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/systems/framework/context.h"
 
@@ -45,6 +49,12 @@ class TamsiDriver {
       const systems::Context<T>& context,
       contact_solvers::internal::ContactSolverResults<T>* results) const;
 
+  // Computes the aggregated multibody forces to step the discrete dynamics from
+  // the state in `context`. This includes force elements evaluated at
+  // `context`, joint limits penalty forces and contact forces.
+  void CalcDiscreteUpdateMultibodyForces(const systems::Context<T>& context,
+                                         MultibodyForces<T>* forces) const;
+
  private:
   // Returns a reference to the manager provided at construction.
   const CompliantContactManager<T>& manager() const { return *manager_; }
@@ -83,6 +93,13 @@ class TamsiDriver {
       const MatrixX<T>& Jn, const MatrixX<T>& Jt, const VectorX<T>& stiffness,
       const VectorX<T>& damping, const VectorX<T>& mu,
       contact_solvers::internal::ContactSolverResults<T>* results) const;
+
+  // Helper to aggregate per-body contact spatial forces, given we know the
+  // contact results.
+  void CalcAndAddSpatialContactForcesFromContactResults(
+      const systems::Context<T>& context,
+      const ContactResults<T>& contact_results,
+      std::vector<SpatialForce<T>>* spatial_contact_forces) const;
 
   // Const access to the manager.
   const CompliantContactManager<T>* const manager_{nullptr};

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -161,6 +161,12 @@ class DummyDiscreteUpdateManager final : public DiscreteUpdateManager<T> {
   void DoCalcContactResults(const systems::Context<T>& context,
                             ContactResults<T>* contact_results) const final {}
 
+  // Not used in these tests.
+  void DoCalcDiscreteUpdateMultibodyForces(const systems::Context<T>&,
+                                           MultibodyForces<T>*) const final {
+    throw std::logic_error("Must implement if needed for these tests.");
+  }
+
  private:
   systems::DiscreteStateIndex additional_state_index_;
   systems::CacheIndex cache_index_;

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -189,6 +189,10 @@ class DoubleOnlyDiscreteUpdateManager final
 
   void DoCalcContactResults(const systems::Context<T>&,
                             ContactResults<T>*) const final {}
+
+  void DoCalcDiscreteUpdateMultibodyForces(
+      const systems::Context<T>& context,
+      MultibodyForces<T>* forces) const final {}
 };
 
 // This test verifies that adding external components that do not support some

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1716,9 +1716,11 @@ GTEST_TEST(MultibodyPlantTest, ReversedWeldError) {
       "More than one mobilizer between two frames is not allowed.");
 }
 
-// Utility to verify that the only ports of MultibodyPlant that are feedthrough
-// are acceleration and reaction force ports.
-bool OnlyAccelerationAndReactionPortsFeedthrough(
+// Utility to verify the subset of output ports we expect to be direct a
+// feedthrough of the inputs.
+// @returns `true` iff only if a closed subset of the ports is direct
+// feedthrough.
+bool VerifyFeedthroughPorts(
     const MultibodyPlant<double>& plant) {
   // Create a set of the indices of all ports that can be feedthrough.
   std::set<int> ok_to_feedthrough;
@@ -1730,6 +1732,10 @@ bool OnlyAccelerationAndReactionPortsFeedthrough(
         plant.get_generalized_acceleration_output_port(i).get_index());
   ok_to_feedthrough.insert(
       plant.get_body_spatial_accelerations_output_port().get_index());
+  if (plant.is_discrete()) {
+    ok_to_feedthrough.insert(
+        plant.get_contact_results_output_port().get_index());
+  }
 
   // Now find all the feedthrough ports and make sure they are on the
   // list of expected feedthrough ports.
@@ -1824,7 +1830,7 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
 
   // Only accelerations and joint reaction forces feedthrough, even with the
   // new ports related to SceneGraph interaction.
-  EXPECT_TRUE(OnlyAccelerationAndReactionPortsFeedthrough(plant));
+  EXPECT_TRUE(VerifyFeedthroughPorts(plant));
 
   EXPECT_EQ(plant.num_visual_geometries(), 0);
   EXPECT_EQ(plant.num_collision_geometries(), 3);
@@ -2770,7 +2776,7 @@ class KukaArmTest : public ::testing::TestWithParam<double> {
 
     // Only accelerations and joint reaction forces feedthrough, for either
     // continuous or discrete plants.
-    EXPECT_TRUE(OnlyAccelerationAndReactionPortsFeedthrough(*plant_));
+    EXPECT_TRUE(VerifyFeedthroughPorts(*plant_));
 
     EXPECT_EQ(plant_->num_positions(), 7);
     EXPECT_EQ(plant_->num_velocities(), 7);


### PR DESCRIPTION
This PR closes #19435 and #19068
It makes use of the infrastructure at the SAP solver level to report constraint forces within SapDriver so that we can compute the aggregate multibody forces due to constraints. With this information, we can reliably compute reaction forces including all terms in the discrete update.

With this PR we include discrete hydro forces along with every other solver constraint in the computation of reaction forces, effectively resolving #19068.

In summary
 - Closes #18749
 - Closes #19068
 - Closes #19435
 - Closes #13888

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19920)
<!-- Reviewable:end -->
