### PR TITLE
Add SchurComplement

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -30,6 +30,7 @@ drake_cc_package_library(
         ":newton_with_bisection",
         ":pgs_solver",
         ":point_contact_data",
+        ":schur_complement",
         ":sparse_linear_operator",
         ":supernodal_solver",
         ":system_dynamics_data",
@@ -196,6 +197,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "schur_complement",
+    srcs = ["schur_complement.cc"],
+    hdrs = ["schur_complement.h"],
+    deps = [
+        ":block_sparse_cholesky_solver",
+        ":block_sparse_lower_triangular_or_symmetric_matrix",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "sparse_linear_operator",
     srcs = ["sparse_linear_operator.cc"],
     hdrs = ["sparse_linear_operator.h"],
@@ -336,6 +348,15 @@ drake_cc_googletest(
         ":pgs_solver",
         ":sparse_linear_operator",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "schur_complement_test",
+    deps = [
+        ":schur_complement",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/contact_solvers/schur_complement.cc
+++ b/multibody/contact_solvers/schur_complement.cc
@@ -1,0 +1,110 @@
+#include "drake/multibody/contact_solvers/schur_complement.h"
+
+#include <algorithm>
+#include <optional>
+#include <utility>
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+SchurComplement::SchurComplement() = default;
+
+SchurComplement::~SchurComplement() = default;
+
+SchurComplement::SchurComplement(const Block3x3SparseSymmetricMatrix& A,
+                                 const std::unordered_set<int>& D_indices)
+    : D_indices_(D_indices.begin(), D_indices.end()) {
+  /* Keep D_indices_ sorted. */
+  DRAKE_THROW_UNLESS(ssize(D_indices) <= A.block_cols());
+  std::sort(D_indices_.begin(), D_indices_.end());
+  /* If a block index doesn't belong to the D blocks, it belongs to the C
+   blocks. We step through `D_indices_` to detect the gaps in order to fill in
+   `C_indices`. */
+  /* Starting point for each potential missing segment in D_indices_. */
+  int start = 0;
+  for (int D_index : D_indices_) {
+    while (start < D_index) {
+      C_indices_.push_back(start++);
+    }
+    start = D_index + 1;
+  }
+  /* Add the remaining indices (if any) after the last D index. */
+  while (start < A.block_cols()) {
+    C_indices_.push_back(start++);
+  }
+
+  const int block_cols = C_indices_.size() + D_indices_.size();
+  DRAKE_DEMAND(block_cols * 3 == A.cols());
+  std::optional<MatrixX<double>> S =
+      A_solver_.FactorAndCalcSchurComplement(A, D_indices);
+  if (!S) {
+    throw std::runtime_error(
+        "Factorization failed when computing Schur complement. Make sure the "
+        "matrix is symmetric positive definite and not ill-conditioned.");
+  }
+  DRAKE_DEMAND(
+      A_solver_.solver_mode() ==
+      BlockSparseCholeskySolver<Matrix3<double>>::SolverMode::kFactored);
+  S_ = std::move(*S);
+}
+
+/* TODO(xuchenhan-tri): In the following implementation, we construct `a`, the
+ segment in the right-hand side corresponding to participating dofs with
+ `a = S*y`. From `a`, we construct the full right-hand side `b`, then solve the
+ entire system for `z`, and finally extract `x` from `z`. Alternatively, we
+ could directly compute `x` from the equation Dx + By = 0. This would require
+   1. a representation of `B`, and
+   2. the ability to solve the linear system `D`.
+ Both of these is avaiable, just not conveniently so:
+ We had access to `A` at construction, and we could have saved a sparse
+ representation of `B` and use it to efficiently compute `By`. From the
+ factorization of `A`, we get a factorization of D as a by-product. So far, our
+ profiling in the common case where size(D) is much smaller than size(A) shows
+ that the current implementation is not a performance issue, so we have opted
+ for simplicity in the implementation. */
+VectorX<double> SchurComplement::SolveForX(
+    const Eigen::Ref<const VectorX<double>>& y) const {
+  DRAKE_THROW_UNLESS(y.size() == 3 * ssize(C_indices_));
+  DRAKE_DEMAND(
+      A_solver_.solver_mode() ==
+      BlockSparseCholeskySolver<Matrix3<double>>::SolverMode::kFactored);
+  if (D_indices_.empty()) {
+    return VectorX<double>::Zero(0);
+  }
+  if (C_indices_.empty()) {
+    return VectorX<double>::Zero(D_indices_.size());
+  }
+
+  /* Build `a`, the rhs corrsponding to variable y. */
+  const VectorX<double> a = S_ * y;
+  /* Build the full rhs. */
+  const int block_cols = C_indices_.size() + D_indices_.size();
+  VectorX<double> b(VectorX<double>::Zero(3 * block_cols));
+  for (int i = 0; i < ssize(C_indices_); ++i) {
+    b.segment<3>(3 * C_indices_[i]) = a.segment<3>(3 * i);
+  }
+  VectorX<double>& z = b;
+  A_solver_.SolveInPlace(&z);
+  /* Extract x from the z. */
+  VectorX<double> x(3 * D_indices_.size());
+  for (int i = 0; i < ssize(D_indices_); ++i) {
+    x.segment<3>(3 * i) = z.segment<3>(3 * D_indices_[i]);
+  }
+  return x;
+}
+
+VectorX<double> SchurComplement::Solve(
+    const Eigen::Ref<const VectorX<double>>& c) const {
+  DRAKE_THROW_UNLESS(3 * (ssize(C_indices_) + ssize(D_indices_)) == c.size());
+  DRAKE_DEMAND(
+      A_solver_.solver_mode() ==
+      BlockSparseCholeskySolver<Matrix3<double>>::SolverMode::kFactored);
+  return A_solver_.Solve(c);
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/schur_complement.h
+++ b/multibody/contact_solvers/schur_complement.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <unordered_set>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/block_sparse_cholesky_solver.h"
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+/* Given a symmetric linear system of equations Az = b in block form as:
+
+     Dx  + By = 0     (1)
+     Bᵀx + Cy = a     (2)
+
+ where A = [D B; Bᵀ C], z = [x; y], b = [0; a]. If C (size p-by-p),
+ D (size q-by-q) and A (size p+q-by-p+q) are positive definite, one can solve
+ the system using Schur complement. Specifically, using equation (1), we get
+
+     x = -D⁻¹By       (3)
+
+ Plugging (3) in (1), we get
+
+    (C - BᵀD⁻¹B)y = a.
+
+ After a solution for y is obtained, we can use (3) to recover the solution for
+ x. The matrix S = C - BᵀD⁻¹B is the Schur complement of the block D of the
+ matrix A. Since A is positive definite, so is S.
+
+ The decomposition of A into [D, B; Bᵀ, C] is defined by the block indices of D.
+ (See the two-argument constructor for more detail.) Given the symmetric matrix
+ A and its decomposition [D, B; Bᵀ, C], this class computes the Schur complement
+ of the block D of A. The matrix is factorized in the process and consequently,
+ one can solve the system Az = b efficiently once the Schur complement is
+ computed. */
+class SchurComplement {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SchurComplement);
+
+  /* Constructs an empty SchurComplement, i.e one that corresponds
+   corresponds to a linear system with no equations.*/
+  SchurComplement();
+
+  ~SchurComplement();
+
+  /* Constructs a SchurComplement for the block sparse matrix A of size
+   3*N-by-3*N consisting of blocks of size 3x3. `D_indices` determine which
+   block rows/columns make up the D diagonal blocks. The remaining block
+   rows/columns make up the C diagonal blocks. For example, if matrix A is given
+   by
+
+     x x x | u u u | w w w
+     x x x | u u u | w w w
+     x x x | u u u | w w w
+     ------+-------+------
+     u u u | y y y | v v v
+     u u u | y y y | v v v
+     u u u | y y y | v v v
+     ------+-------+------
+     w w w | v v v | z z z
+     w w w | v v v | z z z
+     w w w | v v v | z z z
+
+   and D_indices = {0, 2},  then submatrix D is given by
+
+     x x x | w w w
+     x x x | w w w
+     x x x | w w w
+     ------+------
+     w w w | z z z
+     w w w | z z z
+     w w w | z z z
+
+   submatrix C is given by
+
+     y y y
+     y y y
+     y y y
+
+   submatrix B is given by
+
+     u u u
+     u u u
+     u u u
+     -----
+     v v v
+     v v v
+     v v v
+
+   @pre D_indices is a subset of {0, ..., A.block_cols()-1}. */
+  SchurComplement(const Block3x3SparseSymmetricMatrix& A,
+                  const std::unordered_set<int>& D_indices);
+
+  /* Returns the Schur complement for the block D of the matrix A,
+   S = C - BᵀD⁻¹B. */
+  const MatrixX<double>& get_D_complement() const { return S_; }
+
+  /* Given a value of y, solves for x in the equation Dx + By = 0.
+   @pre The size of y is equal to the number of columns of B */
+  VectorX<double> SolveForX(const Eigen::Ref<const VectorX<double>>& y) const;
+
+  // TODO(xuchenhan-tri): Consider adding a SolveForY() function for
+  // completeness.
+
+  /* Given a right-hand side vector b with the same dimension as the input
+   matrix A provided at construction, solve solves for A*z = b.
+   @pre The size of b is compatible with the input matrix A provided at
+   construction. */
+  VectorX<double> Solve(const Eigen::Ref<const VectorX<double>>& b) const;
+
+ private:
+  /* Sorted block row/column indices for 3x3 blocks that belong to submatrix D.
+   */
+  std::vector<int> D_indices_;
+  /* Sorted block row/column indices for 3x3 blocks that belong to submatrix C.
+   */
+  std::vector<int> C_indices_;
+  /* Cholesky solver that factorizes the matrix and stores the factorization. */
+  BlockSparseCholeskySolver<Matrix3<double>> A_solver_;
+  /* The Schur complement of block D: S = C - BᵀD⁻¹B. */
+  MatrixX<double> S_;
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/test/schur_complement_test.cc
+++ b/multibody/contact_solvers/test/schur_complement_test.cc
@@ -1,0 +1,134 @@
+#include "drake/multibody/contact_solvers/schur_complement.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+constexpr double kTolerance = 4.0 * std::numeric_limits<double>::epsilon();
+
+// clang-format off
+Matrix3d A00() {
+  return (Eigen::Matrix3d() << 11, 2, 3,
+                               2, 50, 6,
+                               3, 6, 190).finished();
+}
+Matrix3d A10() {
+  return (Eigen::Matrix3d() << 1.1, 1.0, 0.9,
+                               1.2, 1.5, 1.6,
+                               1.3, 1.8, 1.9).finished();
+}
+Matrix3d A11() {
+    return (Eigen::Matrix3d() << 110, 12, 13,
+                                 12, 150, 16,
+                                 13, 16, 190).finished();
+}
+Matrix3d A20() {
+    return (Eigen::Matrix3d() << 11, 12, 13,
+                                 14, 21, 16,
+                                 17, 18, 29).finished();
+}
+Matrix3d A22() {
+    return (Eigen::Matrix3d() << 210, 22, 23,
+                                 22, 205, 26,
+                                 23, 26, 290).finished();
+}
+// clang-format on
+
+/* Makes a block sparse symmetric matrix with 3x3 dense blocks that looks like
+   A =   A00 | A01 | A02
+        -----------------
+         A10 | A11 |  0
+        -----------------
+         A20 |  0  | A22
+ where A02 = A20.transpose(). We choose values so that A is diagonally dominant
+ and thus SPD. */
+Block3x3SparseSymmetricMatrix MakeBlockSparseMatrix() {
+  std::vector<std::vector<int>> sparsity_pattern;
+  sparsity_pattern.emplace_back(std::vector<int>{0, 1, 2});
+  sparsity_pattern.emplace_back(std::vector<int>{1});
+  sparsity_pattern.emplace_back(std::vector<int>{2});
+  BlockSparsityPattern block_pattern({{3, 3, 3}}, std::move(sparsity_pattern));
+  Block3x3SparseSymmetricMatrix A(std::move(block_pattern));
+  A.SetBlock(0, 0, A00());
+  A.SetBlock(1, 0, A10());
+  A.SetBlock(2, 0, A20());
+  A.SetBlock(1, 1, A11());
+  A.SetBlock(2, 2, A22());
+  return A;
+}
+
+/* Constructs an arbitrary block sparse matrix (see MakeBlockSparseMatrix())
+
+   A =   A00 | A01 | A02
+        -----------------
+         A10 | A11 |  0
+        -----------------
+         A20 |  0  | A22
+
+and returns the Schur complement of the A11 block. */
+SchurComplement MakeSchurComplement() {
+  Block3x3SparseSymmetricMatrix block_sparse_matrix = MakeBlockSparseMatrix();
+  const std::unordered_set<int> eliminated_blocks = {1};
+  return SchurComplement(block_sparse_matrix, eliminated_blocks);
+}
+
+GTEST_TEST(SchurComplementTest, GetDComplement) {
+  const SchurComplement schur_complement = MakeSchurComplement();
+  const MatrixXd S = schur_complement.get_D_complement();
+
+  MatrixXd C = MatrixXd(6, 6);
+  C.topLeftCorner<3, 3>() = A00();
+  C.bottomLeftCorner<3, 3>() = A20();
+  C.topRightCorner<3, 3>() = A20().transpose();
+  C.bottomRightCorner<3, 3>() = A22();
+  MatrixXd D = A11();
+  MatrixXd B = MatrixXd::Zero(3, 6);
+  B.topLeftCorner<3, 3>() = A10();
+
+  const MatrixXd expected = C - B.transpose() * D.llt().solve(B);
+  EXPECT_TRUE(CompareMatrices(S, expected, kTolerance));
+}
+
+GTEST_TEST(SchurComplementTest, SolveForX) {
+  const SchurComplement schur_complement = MakeSchurComplement();
+  const VectorXd y = VectorXd::LinSpaced(6, 0.0, 12.0);
+  const VectorXd x = schur_complement.SolveForX(y);
+
+  MatrixXd D = A11();
+  MatrixXd B = MatrixXd::Zero(3, 6);
+  B.topLeftCorner<3, 3>() = A10();
+  /* The system of equation reads
+       Dx  + By = 0 (1)
+       Bᵀx + Ay = a (2)
+     Using equation (1), we get
+       x = -D⁻¹By */
+  const VectorXd expected_x = D.llt().solve(-B * y);
+  EXPECT_TRUE(CompareMatrices(x, expected_x, kTolerance));
+}
+
+GTEST_TEST(SchurComplementTest, Solve) {
+  const SchurComplement schur_complement = MakeSchurComplement();
+  const VectorXd b = VectorXd::LinSpaced(9, 0.0, 12.0);
+  const VectorXd z = schur_complement.Solve(b);
+
+  const MatrixXd A = MakeBlockSparseMatrix().MakeDenseMatrix();
+  const VectorXd expected_z = A.llt().solve(b);
+  EXPECT_TRUE(CompareMatrices(z, expected_z, kTolerance));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
The SchurComplement class computes the Schur complement of a given 3x3 block sparse symmetric matrix `A` based on the block indices to be eliminated. It also supports solving the linear system Az = b by leveraging the Cholesky factorization obtained in the process of computing the Schur complement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19924)
<!-- Reviewable:end -->
