### PR TITLE
[workspace] Upgrade gtest to latest release v1.14.0

### DIFF
--- a/tools/workspace/gtest/patches/add_printers.patch
+++ b/tools/workspace/gtest/patches/add_printers.patch
@@ -1,4 +1,4 @@
-Adds more printer options for displaying values under test
+[googletest] Adds more printer options for displaying values under test
 
 The EigenPrinter knows how to print Eigen matrices. We need to inject
 it prior to the ContainerPrinter because Eigen vectors offer container
@@ -20,7 +20,7 @@ prefer fmt over ostream anytime fmt is offered.
  namespace testing {
  
  // Definitions in the internal* namespaces are subject to change without notice.
-@@ -306,6 +308,9 @@
+@@ -306,4 +308,7 @@
  void PrintWithFallback(const T& value, ::std::ostream* os) {
    using Printer = typename FindFirstPrinter<
 -      T, void, ContainerPrinter, FunctionPointerPrinter, PointerPrinter,
@@ -28,6 +28,4 @@ prefer fmt over ostream anytime fmt is offered.
 +      drake::internal::EigenPrinter,
 +      ContainerPrinter, FunctionPointerPrinter, PointerPrinter,
 +      drake::internal::FmtFormatPrinter,
-       internal_stream_operator_without_lexical_name_lookup::StreamPrinter,
-       ProtobufPrinter, ConvertibleToIntegerPrinter,
-       ConvertibleToStringViewPrinter, RawBytesPrinter, FallbackPrinter>::type;
+       ProtobufPrinter,

--- a/tools/workspace/gtest/repository.bzl
+++ b/tools/workspace/gtest/repository.bzl
@@ -6,8 +6,8 @@ def gtest_repository(
     github_archive(
         name = name,
         repository = "google/googletest",
-        commit = "v1.13.0",
-        sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",  # noqa
+        commit = "v1.14.0",
+        sha256 = "8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             ":patches/add_printers.patch",


### PR DESCRIPTION
Towards #19865

The auto-update failed:

```
Error in fail: Error applying patch @//tools/workspace/gtest:patches/add_printers.patch:
patching file googletest/include/gtest/gtest-printers.h
Hunk #1 succeeded at 122 (offset 7 lines).
Hunk #2 FAILED at 309.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19932)
<!-- Reviewable:end -->
