### PR TITLE
[workspace] Remove drake_vendor prefix from our include paths

### DIFF
--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -3,9 +3,9 @@
 #include <algorithm>
 #include <cstring>
 
-#include <drake_vendor/yaml-cpp/yaml.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <yaml-cpp/yaml.h>
 
 #include "drake/common/nice_type_name.h"
 

--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -5,8 +5,8 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/yaml-cpp/emitfromevents.h>
-#include <drake_vendor/yaml-cpp/yaml.h>
+#include <yaml-cpp/emitfromevents.h>
+#include <yaml-cpp/yaml.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/unused.h"

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -19,9 +19,9 @@
 
 #include <App.h>
 #include <common_robotics_utilities/base64_helpers.hpp>
-#include <drake_vendor/msgpack.hpp>
-#include <drake_vendor/uuid.h>
 #include <fmt/format.h>
+#include <msgpack.hpp>
+#include <uuid.h>
 
 #include "drake/common/drake_export.h"
 #include "drake/common/drake_throw.h"

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -8,7 +8,7 @@
 #include <variant>
 #include <vector>
 
-#include <drake_vendor/msgpack.hpp>
+#include <msgpack.hpp>
 
 #include "drake/common/nice_type_name.h"
 #include "drake/geometry/meshcat.h"

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -10,11 +10,11 @@
 #include <tuple>
 
 #include <Eigen/Eigenvalues>
-#include <drake_vendor/libqhullcpp/Coordinates.h>
-#include <drake_vendor/libqhullcpp/Qhull.h>
-#include <drake_vendor/libqhullcpp/QhullFacet.h>
-#include <drake_vendor/libqhullcpp/QhullFacetList.h>
 #include <fmt/format.h>
+#include <libqhullcpp/Coordinates.h>
+#include <libqhullcpp/Qhull.h>
+#include <libqhullcpp/QhullFacet.h>
+#include <libqhullcpp/QhullFacetList.h>
 
 #include "drake/geometry/optimization/vpolytope.h"
 #include "drake/math/matrix_util.h"

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -9,9 +9,9 @@
 #include <numeric>
 #include <string>
 
-#include <drake_vendor/libqhullcpp/Qhull.h>
-#include <drake_vendor/libqhullcpp/QhullVertexSet.h>
 #include <fmt/format.h>
+#include <libqhullcpp/Qhull.h>
+#include <libqhullcpp/QhullVertexSet.h>
 
 #include "drake/common/is_approx_equal_abstol.h"
 #include "drake/geometry/read_obj.h"

--- a/geometry/proximity/collisions_exist_callback.h
+++ b/geometry/proximity/collisions_exist_callback.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_export.h"

--- a/geometry/proximity/distance_to_point_callback.h
+++ b/geometry/proximity/distance_to_point_callback.h
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_export.h"

--- a/geometry/proximity/distance_to_shape_callback.h
+++ b/geometry/proximity/distance_to_shape_callback.h
@@ -3,7 +3,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 
 #include "drake/common/drake_export.h"
 #include "drake/common/eigen_types.h"

--- a/geometry/proximity/find_collision_candidates_callback.h
+++ b/geometry/proximity/find_collision_candidates_callback.h
@@ -4,7 +4,7 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <fmt/format.h>
 
 #include "drake/common/drake_export.h"

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <fmt/format.h>
 
 #include "drake/common/drake_export.h"

--- a/geometry/proximity/penetration_as_point_pair_callback.h
+++ b/geometry/proximity/penetration_as_point_pair_callback.h
@@ -3,7 +3,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 
 #include "drake/common/drake_export.h"
 #include "drake/geometry/proximity/collision_filter.h"

--- a/geometry/proximity/proximity_utilities.h
+++ b/geometry/proximity/proximity_utilities.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <fmt/format.h>
 
 #include "drake/common/drake_export.h"

--- a/geometry/proximity/test/characterization_utilities.h
+++ b/geometry/proximity/test/characterization_utilities.h
@@ -15,7 +15,7 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/default_scalars.h"

--- a/geometry/proximity/test/collisions_exist_callback_test.cc
+++ b/geometry/proximity/test/collisions_exist_callback_test.cc
@@ -2,7 +2,7 @@
 
 #include <utility>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/geometry/proximity/proximity_utilities.h"

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -4,7 +4,7 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -1,6 +1,6 @@
 #include "drake/geometry/proximity/distance_to_point_callback.h"
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/fmt_eigen.h"

--- a/geometry/proximity/test/find_collision_candidates_callback_test.cc
+++ b/geometry/proximity/test/find_collision_candidates_callback_test.cc
@@ -3,7 +3,7 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/geometry/proximity/proximity_utilities.h"

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_no_throw.h"

--- a/geometry/proximity/test/proximity_utilities_test.cc
+++ b/geometry/proximity/test/proximity_utilities_test.cc
@@ -3,7 +3,7 @@
 #include <memory>
 #include <sstream>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <fmt/format.h>
 
 #include "drake/common/default_scalars.h"

--- a/geometry/render_gltf_client/internal_merge_gltf.h
+++ b/geometry/render_gltf_client/internal_merge_gltf.h
@@ -2,7 +2,7 @@
 
 #include <filesystem>
 
-#include <drake_vendor/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "drake/common/eigen_types.h"
 

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.h
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <string>
 
-#include <drake_vendor/nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "drake/common/drake_export.h"
 #include "drake/geometry/render/render_camera.h"

--- a/geometry/render_gltf_client/test/internal_merge_gltf_test.cc
+++ b/geometry/render_gltf_client/test/internal_merge_gltf_test.cc
@@ -7,8 +7,8 @@
 #include <string>
 #include <vector>
 
-#include <drake_vendor/nlohmann/json.hpp>
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -5,8 +5,8 @@
 #include <set>
 #include <vector>
 
-#include <drake_vendor/nlohmann/json.hpp>
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 #include <vtkCamera.h>
 #include <vtkMatrix4x4.h>
 

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -4,10 +4,10 @@
 #include <filesystem>
 #include <thread>
 
-#include <drake_vendor/msgpack.hpp>
 #include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <msgpack.hpp>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -2,8 +2,8 @@
 
 #include <thread>
 
-#include <drake_vendor/msgpack.hpp>
 #include <gtest/gtest.h>
+#include <msgpack.hpp>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -7,7 +7,7 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/fcl/fcl.h>
+#include <fcl/fcl.h>
 #include <fmt/ostream.h>
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -6,8 +6,8 @@
 #include <string>
 #include <variant>
 
-#include <drake_vendor/sdf/Element.hh>
-#include <drake_vendor/tinyxml2.h>
+#include <sdf/Element.hh>
+#include <tinyxml2.h>
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/common/drake_copyable.h"

--- a/multibody/parsing/detail_ignition.h
+++ b/multibody/parsing/detail_ignition.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <drake_vendor/gz/math/Pose3.hh>
+#include <gz/math/Pose3.hh>
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/rigid_transform.h"

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -10,8 +10,8 @@
 #include <utility>
 #include <vector>
 
-#include <drake_vendor/tinyxml2.h>
 #include <fmt/format.h>
+#include <tinyxml2.h>
 
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"

--- a/multibody/parsing/detail_sdf_diagnostic.h
+++ b/multibody/parsing/detail_sdf_diagnostic.h
@@ -3,7 +3,7 @@
 #include <set>
 #include <string>
 
-#include <drake_vendor/sdf/Element.hh>
+#include <sdf/Element.hh>
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/multibody/parsing/detail_common.h"

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -7,13 +7,13 @@
 #include <string>
 #include <utility>
 
-#include <drake_vendor/sdf/Box.hh>
-#include <drake_vendor/sdf/Capsule.hh>
-#include <drake_vendor/sdf/Cylinder.hh>
-#include <drake_vendor/sdf/Element.hh>
-#include <drake_vendor/sdf/Ellipsoid.hh>
-#include <drake_vendor/sdf/Plane.hh>
-#include <drake_vendor/sdf/Sphere.hh>
+#include <sdf/Box.hh>
+#include <sdf/Capsule.hh>
+#include <sdf/Cylinder.hh>
+#include <sdf/Element.hh>
+#include <sdf/Ellipsoid.hh>
+#include <sdf/Plane.hh>
+#include <sdf/Sphere.hh>
 
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/proximity_properties.h"

--- a/multibody/parsing/detail_sdf_geometry.h
+++ b/multibody/parsing/detail_sdf_geometry.h
@@ -4,9 +4,9 @@
 #include <optional>
 #include <string>
 
-#include <drake_vendor/sdf/Collision.hh>
-#include <drake_vendor/sdf/Geometry.hh>
-#include <drake_vendor/sdf/Visual.hh>
+#include <sdf/Collision.hh>
+#include <sdf/Geometry.hh>
+#include <sdf/Visual.hh>
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/geometry_instance.h"

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -10,15 +10,15 @@
 #include <variant>
 #include <vector>
 
-#include <drake_vendor/sdf/Error.hh>
-#include <drake_vendor/sdf/Frame.hh>
-#include <drake_vendor/sdf/Joint.hh>
-#include <drake_vendor/sdf/JointAxis.hh>
-#include <drake_vendor/sdf/Link.hh>
-#include <drake_vendor/sdf/Model.hh>
-#include <drake_vendor/sdf/ParserConfig.hh>
-#include <drake_vendor/sdf/Root.hh>
-#include <drake_vendor/sdf/World.hh>
+#include <sdf/Error.hh>
+#include <sdf/Frame.hh>
+#include <sdf/Joint.hh>
+#include <sdf/JointAxis.hh>
+#include <sdf/Link.hh>
+#include <sdf/Model.hh>
+#include <sdf/ParserConfig.hh>
+#include <sdf/Root.hh>
+#include <sdf/World.hh>
 
 #include "drake/geometry/geometry_instance.h"
 #include "drake/math/rigid_transform.h"

--- a/multibody/parsing/detail_tinyxml.h
+++ b/multibody/parsing/detail_tinyxml.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include <Eigen/Dense>
-#include <drake_vendor/tinyxml2.h>
+#include <tinyxml2.h>
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/math/rigid_transform.h"

--- a/multibody/parsing/detail_tinyxml2_diagnostic.h
+++ b/multibody/parsing/detail_tinyxml2_diagnostic.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include <drake_vendor/tinyxml2.h>
+#include <tinyxml2.h>
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/multibody/parsing/detail_common.h"

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -8,7 +8,7 @@
 #include <utility>
 
 #include <Eigen/Dense>
-#include <drake_vendor/tinyxml2.h>
+#include <tinyxml2.h>
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/geometry_instance.h"

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -13,8 +13,8 @@
 #include <vector>
 
 #include <Eigen/Dense>
-#include <drake_vendor/tinyxml2.h>
 #include <fmt/format.h>
+#include <tinyxml2.h>
 
 #include "drake/common/sorted_pair.h"
 #include "drake/math/rotation_matrix.h"

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -16,8 +16,8 @@
 #include <tuple>
 #include <utility>
 
-#include <drake_vendor/tinyxml2.h>
 #include <picosha2.h>
+#include <tinyxml2.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"

--- a/multibody/parsing/test/detail_sdf_diagnostic_test.cc
+++ b/multibody/parsing/test/detail_sdf_diagnostic_test.cc
@@ -1,8 +1,8 @@
 #include "drake/multibody/parsing/detail_sdf_diagnostic.h"
 
-#include <drake_vendor/sdf/Root.hh>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <sdf/Root.hh>
 
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/diagnostic_policy_test_base.h"

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -7,10 +7,10 @@
 #include <sstream>
 #include <vector>
 
-#include <drake_vendor/sdf/Root.hh>
-#include <drake_vendor/sdf/parser.hh>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <sdf/Root.hh>
+#include <sdf/parser.hh>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/fmt_eigen.h"

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -6,9 +6,9 @@
 #include <sstream>
 #include <stdexcept>
 
-#include <drake_vendor/sdf/parser.hh>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <sdf/parser.hh>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/never_destroyed.h"

--- a/perception/point_cloud.cc
+++ b/perception/point_cloud.cc
@@ -10,8 +10,8 @@
 #include <common_robotics_utilities/dynamic_spatial_hashed_voxel_grid.hpp>
 #include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/voxel_grid.hpp>
-#include <drake_vendor/nanoflann.hpp>
 #include <fmt/format.h>
+#include <nanoflann.hpp>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"

--- a/tools/workspace/fcl_internal/package.BUILD.bazel
+++ b/tools/workspace/fcl_internal/package.BUILD.bazel
@@ -126,17 +126,14 @@ cc_library_vendored(
     ],
     hdrs = _HDRS,
     hdrs_vendored = [
-        x.replace("include/fcl/", "drake_src/drake_vendor/fcl/")
+        x.replace("include/fcl/", "drake_hdr/fcl/")
         for x in _HDRS
     ],
-    edit_include = {
-        "fcl/": "drake_vendor/fcl/",
-    },
     copts = ["-fvisibility=hidden"],
     defines = [
         "FCL_STATIC_DEFINE",
     ],
-    includes = ["drake_src"],
+    includes = ["drake_hdr"],
     linkstatic = True,
     deps = [
         "@ccd_internal//:ccd",

--- a/tools/workspace/gz_math_internal/package.BUILD.bazel
+++ b/tools/workspace/gz_math_internal/package.BUILD.bazel
@@ -249,15 +249,12 @@ cc_library_vendored(
     ],
     hdrs = _HDRS,
     hdrs_vendored = [
-        x.replace("include/gz/", "drake_src/drake_vendor/gz/")
+        x.replace("include/gz/", "drake_hdr/gz/")
         for x in _HDRS
     ],
-    edit_include = {
-        "gz/": "drake_vendor/gz/",
-    },
     copts = ["-w"],
     linkstatic = True,
-    includes = ["drake_src"],
+    includes = ["drake_hdr"],
     visibility = ["//visibility:public"],
     deps = [
         "@gz_utils_internal//:gz_utils",

--- a/tools/workspace/gz_utils_internal/package.BUILD.bazel
+++ b/tools/workspace/gz_utils_internal/package.BUILD.bazel
@@ -99,7 +99,7 @@ cc_library_vendored(
     name = "gz_utils",
     hdrs = _HDRS,
     hdrs_vendored = [
-        x.replace("include/gz/", "drake_src/drake_vendor/gz/")
+        x.replace("include/gz/", "drake_hdr/gz/")
         for x in _HDRS
     ],
     srcs = _SRCS,
@@ -107,12 +107,9 @@ cc_library_vendored(
         x.replace("src/", "drake_src/")
         for x in _SRCS
     ],
-    edit_include = {
-        "gz/": "drake_vendor/gz/",
-    },
     copts = ["-w"],
     linkstatic = True,
-    includes = ["drake_src"],
+    includes = ["drake_hdr"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/msgpack_internal/package.BUILD.bazel
+++ b/tools/workspace/msgpack_internal/package.BUILD.bazel
@@ -22,7 +22,6 @@ cc_library(
     name = "hdrs_no_vendor",
     hdrs = _HDRS_NO_VENDOR,
     strip_include_prefix = "include",
-    include_prefix = "drake_vendor",
 )
 
 # The upstream headers that we'll use.
@@ -38,13 +37,10 @@ cc_library_vendored(
     hdrs = _HDRS,
     defines = ["MSGPACK_NO_BOOST"],
     hdrs_vendored = [
-        x.replace("include/", "drake_src/drake_vendor/")
+        x.replace("include/", "drake_hdr/")
         for x in _HDRS
     ],
-    edit_include = {
-        "msgpack/": "drake_vendor/msgpack/",
-    },
-    includes = ["drake_src"],
+    includes = ["drake_hdr"],
     linkstatic = 1,
     deps = [":hdrs_no_vendor"],
     visibility = ["//visibility:public"],

--- a/tools/workspace/msgpack_internal/patches/vendor.patch
+++ b/tools/workspace/msgpack_internal/patches/vendor.patch
@@ -1,25 +1,9 @@
-Fix various vendor_cxx compatibility problems.
-
-For sysdep.hpp, the contents are too complicated to try to feed
-through vendor_cxx, so we've excluded in from the auto-vendoring
-tool. The only thing we need to do here is patch one #include.
+[msgpack] Fix various vendor_cxx compatibility problems.
 
 For cpp_config_decl.hpp, vendor_cxx gets a bit too greedy and tries to
 span its namespace changes across #ifdef branches. We can avoid that
 outcome by adding a redundant #include statement to help guide it.
 
-
---- include/msgpack/sysdep.hpp.orig
-+++ include/msgpack/sysdep.hpp
-@@ -97,7 +97,7 @@
- #if !defined(MSGPACK_ENDIAN_LITTLE_BYTE) && !defined(MSGPACK_ENDIAN_BIG_BYTE)
- 
- #if defined(MSGPACK_NO_BOOST)
--#include <msgpack/predef/other/endian.h>
-+#include <drake_vendor/msgpack/predef/other/endian.h>
- #else  // defined(MSGPACK_NO_BOOST)
- #include <boost/predef/other/endian.h>
- 
 
 --- include/msgpack/v2/cpp_config_decl.hpp.orig
 +++ include/msgpack/v2/cpp_config_decl.hpp

--- a/tools/workspace/nanoflann_internal/package.BUILD.bazel
+++ b/tools/workspace/nanoflann_internal/package.BUILD.bazel
@@ -12,7 +12,6 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "nanoflann",
     hdrs = ["include/nanoflann.hpp"],
-    include_prefix = "drake_vendor",
     strip_include_prefix = "include",
     linkstatic = 1,
 )

--- a/tools/workspace/nlohmann_internal/package.BUILD.bazel
+++ b/tools/workspace/nlohmann_internal/package.BUILD.bazel
@@ -13,7 +13,6 @@ cc_library(
     name = "nlohmann",
     hdrs = ["single_include/nlohmann/json.hpp"],
     strip_include_prefix = "single_include",
-    include_prefix = "drake_vendor",
     linkstatic = 1,
 )
 

--- a/tools/workspace/qhull_internal/package.BUILD.bazel
+++ b/tools/workspace/qhull_internal/package.BUILD.bazel
@@ -71,16 +71,13 @@ cc_library_vendored(
     name = "qhull",
     hdrs = _HDRS_CPP,
     hdrs_vendored = [
-        x.replace("src/libqhullcpp/", "drake_src/drake_vendor/libqhullcpp/")
+        x.replace("src/libqhullcpp/", "drake_hdr/libqhullcpp/")
         for x in _HDRS_CPP
     ],
-    includes = ["drake_src"],
-    edit_include = {
-        "libqhullcpp/": "drake_vendor/libqhullcpp/",
-    },
+    includes = ["drake_hdr"],
     srcs = _SRCS_CPP,
     srcs_vendored = [
-        x.replace("src/", "drake_src/drake_vendor/")
+        x.replace("src/", "drake_src/")
         for x in _SRCS_CPP
     ],
     copts = ["-w"],

--- a/tools/workspace/sdformat_internal/embed_sdf.py
+++ b/tools/workspace/sdformat_internal/embed_sdf.py
@@ -28,7 +28,7 @@ filenames = sorted(sys.argv[1:])
 print("""
 #include "EmbeddedSdf.hh"
 #include <array>
-#include "drake_vendor/gz/utils/NeverDestroyed.hh"
+#include "gz/utils/NeverDestroyed.hh"
 namespace sdf { inline namespace SDF_VERSION_NAMESPACE {
 const std::map<std::string, std::string>& GetEmbeddedSdf() {
   using Result = std::map<std::string, std::string>;

--- a/tools/workspace/sdformat_internal/package.BUILD.bazel
+++ b/tools/workspace/sdformat_internal/package.BUILD.bazel
@@ -257,16 +257,10 @@ cc_library_vendored(
     ],
     hdrs = _HDRS,
     hdrs_vendored = [
-        x.replace("include/sdf/", "drake_src/drake_vendor/sdf/")
+        x.replace("include/sdf/", "drake_hdr/sdf/")
         for x in _HDRS
     ],
-    edit_include = {
-        "sdf/": "drake_vendor/sdf/",
-        "gz/math/": "drake_vendor/gz/math/",
-        "gz/utils/": "drake_vendor/gz/utils/",
-        "tinyxml2": "drake_vendor/tinyxml2",
-    },
-    includes = ["drake_src"],
+    includes = ["drake_hdr"],
     copts = ["-w"],
     defines = ["SDFORMAT_STATIC_DEFINE", "SDFORMAT_DISABLE_CONSOLE_LOGFILE"],
     linkstatic = 1,
@@ -294,10 +288,6 @@ cc_library_vendored(
         x.replace("src/", "drake_src/src/")
         for x in _IGN_CMDLINE_SRCS
     ],
-    edit_include = {
-        "sdf/": "drake_vendor/sdf/",
-        "gz/math/": "drake_vendor/gz/math/",
-    },
     copts = ["-w"],
     linkstatic = 1,
     visibility = ["@drake//tools/workspace/sdformat_internal:__pkg__"],

--- a/tools/workspace/stduuid_internal/package.BUILD.bazel
+++ b/tools/workspace/stduuid_internal/package.BUILD.bazel
@@ -22,7 +22,6 @@ cc_library(
     name = "stduuid",
     hdrs = ["include/uuid.h"],
     strip_include_prefix = "include",
-    include_prefix = "drake_vendor",
     linkstatic = 1,
     deps = [":gsl"],
 )

--- a/tools/workspace/tinyxml2_internal/package.BUILD.bazel
+++ b/tools/workspace/tinyxml2_internal/package.BUILD.bazel
@@ -13,7 +13,7 @@ cc_library(
     name = "tinyxml2",
     hdrs = ["tinyxml2.h"],
     srcs = ["tinyxml2.cpp"],
-    include_prefix = "drake_vendor",
+    strip_include_prefix = "/",
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )

--- a/tools/workspace/yaml_cpp_internal/package.BUILD.bazel
+++ b/tools/workspace/yaml_cpp_internal/package.BUILD.bazel
@@ -33,13 +33,10 @@ cc_library_vendored(
     ],
     hdrs = _HDRS,
     hdrs_vendored = [
-        x.replace("include/yaml-cpp/", "drake_src/drake_vendor/yaml-cpp/")
+        x.replace("include/yaml-cpp/", "drake_hdr/yaml-cpp/")
         for x in _HDRS
     ],
-    edit_include = {
-        "yaml-cpp/": "drake_vendor/yaml-cpp/",
-    },
-    includes = ["drake_src"],
+    includes = ["drake_hdr"],
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The purpose of the non-traditional include path within Drake (e.g., including `<drake_vendor/tinyxml2.h>` instead of just `<tinyxml2.h>`) was to avoid the hazard of accidentally picking up the OS copy of the header (e.g., `/usr/include/tinyxml2.h`).

When all of the BUILD files are correct, there is no hazard -- Bazel will always place the Drake-internal copy earlier on include path and that will always win out over the OS copy. Instead, the hazard happens during local development, while build system maintainers are iterating adding or updating externals. This had some moderate benefit as we've been iterating to build more and more externals from source. The ongoing benefit is more limited.

It also has some drawbacks. Downstream users of Drake who use our build system without modifications are fine, but more advanced users who want to substitute these dependencies with their own builds of the libraries suffer: they either need to provide their copy of the library with a weird `drake_vendor` include path, or patch Drake to switch the `#include` statements in the source code back to normal. There is an ongoing cost here for them, to keep up-to-date with regular updates and Drake churns.

On balance, the path switcheroo does not seem worth it anymore. Here, we undo all of the `drake_vendor` additions to the include paths. The ODR-safe addition of `namespace drake_vendor { ... }` in our own source builds of externals remains unchanged. The users users with their own builds can keep that intact or skip it, at their discretion.

Related to #17231.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19936)
<!-- Reviewable:end -->
