### PR TITLE
[multibody] Add SapBallConstraint

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -16,6 +16,7 @@ drake_cc_package_library(
     deps = [
         ":contact_problem_graph",
         ":partial_permutation",
+        ":sap_ball_constraint",
         ":sap_constraint",
         ":sap_constraint_bundle",
         ":sap_constraint_jacobian",
@@ -104,6 +105,19 @@ drake_cc_library(
         "//common:essential",
         "//multibody/contact_solvers:block_sparse_matrix",
         "//multibody/plant:slicing_and_indexing",
+    ],
+)
+
+drake_cc_library(
+    name = "sap_ball_constraint",
+    srcs = ["sap_ball_constraint.cc"],
+    hdrs = ["sap_ball_constraint.h"],
+    deps = [
+        ":sap_constraint",
+        ":sap_constraint_jacobian",
+        ":sap_holonomic_constraint",
+        "//common:default_scalars",
+        "//common:essential",
     ],
 )
 
@@ -262,6 +276,16 @@ drake_cc_googletest(
         ":sap_contact_problem",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sap_ball_constraint_test",
+    deps = [
+        ":sap_ball_constraint",
+        ":validate_constraint_gradients",
+        "//common:pointer_cast",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/contact_solvers/sap/sap_ball_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_ball_constraint.cc
@@ -1,0 +1,102 @@
+#include "drake/multibody/contact_solvers/sap/sap_ball_constraint.h"
+
+#include <limits>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+template <typename T>
+SapBallConstraint<T>::SapBallConstraint(Kinematics kinematics)
+    : SapHolonomicConstraint<T>(
+          MakeSapHolonomicConstraintKinematics(kinematics),
+          MakeSapHolonomicConstraintParameters(),
+          {kinematics.objectA(), kinematics.objectB()}),
+      kinematics_(std::move(kinematics)) {}
+
+template <typename T>
+typename SapHolonomicConstraint<T>::Parameters
+SapBallConstraint<T>::MakeSapHolonomicConstraintParameters() {
+  // "Near-rigid" regime parameter, see [Castro et al., 2022].
+  // TODO(amcastro-tri): consider exposing this parameter.
+  constexpr double kBeta = 0.1;
+
+  // Ball constraints do not have impulse limits, they are bi-lateral
+  // constraints. Each ball constraint introduces 3 constraint
+  // equations. We set stiffness to infinity to indicate that this
+  // constraint is modeled as near-rigid. Relaxation time is set to 0.
+  // The time step will be used as an effective relaxation time when
+  // SapHolonomicConstriant detects the near-rigid condition in DoMakeData().
+  const Vector3<T> kInf =
+      std::numeric_limits<double>::infinity() * Vector3<T>::Ones();
+  return typename SapHolonomicConstraint<T>::Parameters{
+      -kInf, kInf, kInf, Vector3<T>::Zero(), kBeta};
+}
+
+template <typename T>
+typename SapHolonomicConstraint<T>::Kinematics
+SapBallConstraint<T>::MakeSapHolonomicConstraintKinematics(
+    const Kinematics& kinematics) {
+  Vector3<T> g(kinematics.p_WQ() - kinematics.p_WP());  // Constraint function.
+  Vector3<T> b = Vector3<T>::Zero();                    // Bias term.
+
+  return typename SapHolonomicConstraint<T>::Kinematics(
+      std::move(g), kinematics.jacobian(), std::move(b));
+}
+
+template <typename T>
+void SapBallConstraint<T>::DoAccumulateSpatialImpulses(
+    int i, const Eigen::Ref<const VectorX<T>>& gamma,
+    SpatialForce<T>* F) const {
+  // To interpret γ as a spatial impulse and determine the point of application
+  // for this formulation, let's consider the case where both A and B are free
+  // bodies for simplicity. In this case the generalized velocities v are just
+  // the spatial velocities of each body in the world frame stacked:
+  //   v = [w_WA, v_WA, w_WB, v_WB]
+  // We know that J⋅v = v_W_PQ = v_WQ - v_WP. Thus J is just the operator that
+  // takes the difference of the body's translational velocities shifted to P
+  // and Q:
+  //   J = [[p_AP]ₓ -[I] -[p_BQ]ₓ [I]]
+  // We also know from the optimality condition of the SAP formulation
+  // (essentially the balance of momentum condition):
+  //   A⋅(v - v*) - Jᵀ⋅γ = 0
+  // Therefore the generalized impulse Jᵀ⋅γ corresponds to a spatial impulse on
+  // body A and a spatial impulse on body B stacked:
+  //   Jᵀ⋅γ = [Γ_Ao_W, Γ_Bo_W]
+  // Where:
+  //   Γ_Ao_W = (-[p_PA]ₓ⋅-γ, -γ) and Γ_Bo_W = (-[p_QB]ₓ⋅γ, γ)
+  // Therefore Jᵀ can be understood as the operator that shifts a spatial
+  // impulse (0, -γ) applied at P to Ao and shifts the equal and opposite
+  // spatial impulse (0, γ) applied at Q to Bo. Thus, this constraint can be
+  // interpreted as applying an impulse γ at point Q on B and an impulse -γ
+  // at point P on A. As a consequence the constraint satisfies Newton's 3rd
+  // law, but does introduce a small moment of order O(‖γ‖⋅‖p_PQ‖) when P and Q
+  // are not coincident.
+  if (i == 0) {
+    // Object A.
+    // -gamma = gamma_Ap_W
+    // Shift gamma_Ap_W = to Ao and add in.
+    const SpatialForce<T> gamma_Ap_W(Vector3<T>::Zero(), -gamma);
+    *F += gamma_Ap_W.Shift(-kinematics().p_AP_W());
+  } else {
+    // Object B.
+    // gamma = gamma_Bq_W
+    // Shift gamma_Bq_W to Bo and add in.
+    const SpatialForce<T> gamma_Bq_W(Vector3<T>::Zero(), gamma);
+    *F += gamma_Bq_W.Shift(-kinematics().p_BQ_W());
+    return;
+  }
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::internal::SapBallConstraint)

--- a/multibody/contact_solvers/sap/sap_ball_constraint.h
+++ b/multibody/contact_solvers/sap/sap_ball_constraint.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+/* Implements a SAP (compliant) ball constraint between two points.
+
+ To be more precise, consider a point P on an object A and point Q on an object
+ B. Working in the world frame W, this constraint penalizes non-coincident P and
+ Q with the constraint function:
+   g = p_WQ - p_WP = 0
+ with corresponding constraint velocity:
+   ġ = vc(v) = v_W_PQ
+
+ N.B. Only when P and Q are coincident is their relative velocity independent
+ of which frame it is measured in. This means that the way we model this
+ constraint lacks frame-invariance. It is unclear at this time if choosing a
+ particular frame leads to a better approximation, conditioning, etc. We choose
+ the world frame for convenience.
+
+ This leads to 3 holonomic constraint equations, producing a constraint
+ impulse, γ ∈ ℝ³. The impulse on B applied at Q is:
+   γ_Bq_W = γ
+ and the reaction force on A applied at Q is:
+   γ_Ap_W = -γ
+
+ N.B. See DoAccumulateSpatialImpulses() for a discussion of where this
+ interpretation of γ comes from. In general when P and Q are not coincident this
+ formulation does NOT conserve angular momentum, introducing a small moment of
+ order O(‖γ‖⋅‖p_PQ‖).
+
+ DoAccumulateSpatialImpulses() shifts these impulses to the body frame origins,
+ reporting spatial impulses Γ_Bo_W and Γ_Ao_W, respectively.
+
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class SapBallConstraint final : public SapHolonomicConstraint<T> {
+ public:
+  /* We do not allow copy, move, or assignment generally to avoid slicing. */
+  //@{
+  SapBallConstraint& operator=(const SapBallConstraint&) = delete;
+  SapBallConstraint(SapBallConstraint&&) = delete;
+  SapBallConstraint& operator=(SapBallConstraint&&) = delete;
+  //@}
+
+  /* Class to store the kinematics of the the constraint in its current
+   configuration, when it gets constructed. */
+  class Kinematics {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Kinematics);
+
+    /* @param[in] objectA
+         Index of the physical object A on which point P attaches.
+       @param[in] p_WP Position of point P in the world frame.
+       @param[in] p_AP_W Position of point P in A, expressed in the world frame.
+       @param[in] objectB
+         Index of the physical object B on which point Q attaches.
+       @param[in] p_WQ Position of point Q in the world frame.
+       @param[in] p_BQ_W Position of point Q in B, expressed in the world frame.
+       @param[in] J_ApBq_W Jacobian for the relative velocity v_ApBq_W. */
+    Kinematics(int objectA, Vector3<T> p_WP, Vector3<T> p_AP_W, int objectB,
+               Vector3<T> p_WQ, Vector3<T> p_BQ_W,
+               SapConstraintJacobian<T> J_ApBq_W)
+        : objectA_(objectA),
+          p_WP_(std::move(p_WP)),
+          p_AP_W_(std::move(p_AP_W)),
+          objectB_(objectB),
+          p_WQ_(std::move(p_WQ)),
+          p_BQ_W_(std::move(p_BQ_W)),
+          J_(std::move(J_ApBq_W)) {
+      // Thus far only dense Jacobian blocks are supported, i.e. rigid body
+      // applications in mind.
+      DRAKE_THROW_UNLESS(J_.blocks_are_dense());
+    }
+
+    int objectA() const { return objectA_; }
+    const Vector3<T>& p_WP() const { return p_WP_; }
+    const Vector3<T>& p_AP_W() const { return p_AP_W_; }
+    int objectB() const { return objectB_; }
+    const Vector3<T>& p_WQ() const { return p_WQ_; }
+    const Vector3<T>& p_BQ_W() const { return p_BQ_W_; }
+    const SapConstraintJacobian<T>& jacobian() const { return J_; }
+
+   private:
+    /* Index to a physical object A. */
+    int objectA_;
+
+    /* Position of point P in world. */
+    Vector3<T> p_WP_;
+
+    /* Position of point P in A, expressed in the world. */
+    Vector3<T> p_AP_W_;
+
+    /* Index to a physical object B. */
+    int objectB_;
+
+    /* Position of point Q in world. */
+    Vector3<T> p_WQ_;
+
+    /* Position of point Q in B, expressed in the world. */
+    Vector3<T> p_BQ_W_;
+
+    /* Jacobian that defines the velocity v_ApBq_W of point P relative to point
+     Q, expressed in the world frame. That is, v_ApBq_W = J⋅v. */
+    SapConstraintJacobian<T> J_;
+  };
+
+  /* Constructs a ball constraint given its kinematics in a particular
+   configuration. */
+  explicit SapBallConstraint(Kinematics kinematics);
+
+  const Kinematics& kinematics() const { return kinematics_; }
+
+ private:
+  /* Private copy construction is enabled to use in the implementation of
+     DoClone(). */
+  SapBallConstraint(const SapBallConstraint&) = default;
+
+  // no-op for this constraint.
+  void DoAccumulateGeneralizedImpulses(int, const Eigen::Ref<const VectorX<T>>&,
+                                       EigenPtr<VectorX<T>>) const final {}
+
+  /* Accumulates generalized forces applied by this constraint on the i-th
+   object.
+   @param[in] i Object index. As defined at construction i = 0 corresponds to
+   object A and i = 1 corresponds to object B.
+   @param[in] gamma A vector of size 3, with the constraint impulse.
+   @param[out] F On output, this method accumulates the total spatial impulse
+   applied by this constraint on the i-th object.
+   @pre 0 ≤ i < 2.
+   @pre gamma is a vector of size 3.
+   @pre F is not nullptr. */
+  void DoAccumulateSpatialImpulses(int i,
+                                   const Eigen::Ref<const VectorX<T>>& gamma,
+                                   SpatialForce<T>* F) const final;
+
+  /* Helper used at construction. This method makes the parameters needed by the
+   base class SapHolonomicConstraint. */
+  static typename SapHolonomicConstraint<T>::Parameters
+  MakeSapHolonomicConstraintParameters();
+
+  /* Helper used at construction. Makes the constraint function and Jacobian
+   needed to initialize the base class SapHolonomicConstraint.
+   @returns Holonomic constraint kinematics needed at construction of the
+   parent SapHolonomicConstraint. */
+  static typename SapHolonomicConstraint<T>::Kinematics
+  MakeSapHolonomicConstraintKinematics(const Kinematics& kinematics);
+
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<SapBallConstraint<T>>(
+        new SapBallConstraint<T>(*this));
+  }
+
+  Kinematics kinematics_;
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/test/sap_ball_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_ball_constraint_test.cc
@@ -1,0 +1,198 @@
+#include "drake/multibody/contact_solvers/sap/sap_ball_constraint.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/pointer_cast.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/contact_solvers/sap/validate_constraint_gradients.h"
+
+using drake::math::RotationMatrix;
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+// These Jacobian matrices have arbitrary values for testing. We specify the
+// size of the matrix in the name, e.g. J32 is of size 3x2.
+// clang-format off
+const MatrixXd J32 =
+    (MatrixXd(3, 2) << 2, 1,
+                       1, 2,
+                       1, 2).finished();
+
+const MatrixXd J34 =
+    (MatrixXd(3, 4) << 7, 1, 2, 3,
+                       1, 8, 4, 5,
+                       2, 4, 9, 6).finished();
+// clang-format on
+
+template <typename T = double>
+typename SapBallConstraint<T>::Kinematics MakeArbitraryKinematics(
+    int num_cliques) {
+  const int objectA = 12;
+  Vector3<T> p_WP(1., 2., 3.);
+  Vector3<T> p_AP_W(4., 5., 6.);
+  const int objectB = 5;
+  Vector3<T> p_WQ(7., 8., 9.);
+  Vector3<T> p_BQ_W(10., 11., 12.);
+  const int clique0 = 3;
+  const int clique1 = 12;
+  auto J_PQ_W = (num_cliques == 1)
+                    ? SapConstraintJacobian<T>(clique0, J32)
+                    : SapConstraintJacobian<T>(clique0, J32, clique1, J34);
+  return typename SapBallConstraint<T>::Kinematics{
+      objectA, p_WP, p_AP_W, objectB, p_WQ, p_BQ_W, J_PQ_W};
+}
+
+GTEST_TEST(SapBallConstraint, SingleCliqueConstraint) {
+  const int num_cliques = 1;
+  const SapBallConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapBallConstraint<double> c(kinematics);
+
+  EXPECT_EQ(c.num_objects(), 2);
+  EXPECT_EQ(c.num_constraint_equations(), 3);
+  EXPECT_EQ(c.num_cliques(), 1);
+  EXPECT_EQ(c.first_clique(), kinematics.jacobian().clique(0));
+  EXPECT_THROW(c.second_clique(), std::exception);
+  EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(), J32);
+  EXPECT_THROW(c.second_clique_jacobian(), std::exception);
+}
+
+GTEST_TEST(SapBallConstraint, TwoCliquesConstraint) {
+  const int num_cliques = 2;
+  const SapBallConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapBallConstraint<double> c(kinematics);
+
+  EXPECT_EQ(c.num_objects(), 2);
+  EXPECT_EQ(c.num_constraint_equations(), 3);
+  EXPECT_EQ(c.num_cliques(), 2);
+  EXPECT_EQ(c.first_clique(), kinematics.jacobian().clique(0));
+  EXPECT_EQ(c.second_clique(), kinematics.jacobian().clique(1));
+  EXPECT_EQ(c.first_clique_jacobian().MakeDenseMatrix(), J32);
+  EXPECT_EQ(c.second_clique_jacobian().MakeDenseMatrix(), J34);
+}
+
+// This method validates analytical gradients implemented by
+// SapBallConstraint using automatic differentiation.
+void ValidateProjection(const Vector3d& vc) {
+  // Arbitrary kinematic values.
+  const int num_cliques = 1;
+  const SapBallConstraint<AutoDiffXd>::Kinematics kin_ad =
+      MakeArbitraryKinematics<AutoDiffXd>(num_cliques);
+
+  // Instantiate constraint on AutoDiffXd for automatic differentiation.
+  SapBallConstraint<AutoDiffXd> c(kin_ad);
+
+  // Verify cost gradients using AutoDiffXd.
+  ValidateConstraintGradients(c, vc);
+}
+
+GTEST_TEST(SapBallConstraint, Gradients) {
+  // Arbitrary set of vc values.
+  {
+    const Vector3d vc(-1.4, 9.3, -4.5);
+    ValidateProjection(vc);
+  }
+  {
+    const Vector3d vc(2.3, -1.7, 3.4);
+    ValidateProjection(vc);
+  }
+  {
+    const Vector3d vc(6.2, 0.5, -4.9);
+    ValidateProjection(vc);
+  }
+}
+
+GTEST_TEST(SapBallConstraint, SingleCliqueConstraintClone) {
+  const int num_cliques = 1;
+  const SapBallConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapBallConstraint<double> c(kinematics);
+
+  // N.B. Here we dynamic cast to the derived type so that we can test that the
+  // clone is a deep-copy of the original constraint.
+  auto clone = dynamic_pointer_cast<SapBallConstraint<double>>(c.Clone());
+  ASSERT_NE(clone, nullptr);
+  EXPECT_EQ(clone->num_objects(), 2);
+  EXPECT_EQ(clone->num_constraint_equations(), 3);
+  EXPECT_EQ(clone->num_cliques(), 1);
+  EXPECT_EQ(clone->first_clique(), kinematics.jacobian().clique(0));
+  EXPECT_THROW(clone->second_clique(), std::exception);
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
+  EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
+}
+
+GTEST_TEST(SapBallConstraint, TwoCliquesConstraintClone) {
+  const int num_cliques = 2;
+  const SapBallConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapBallConstraint<double> c(kinematics);
+
+  auto clone = dynamic_pointer_cast<SapBallConstraint<double>>(c.Clone());
+  ASSERT_NE(clone, nullptr);
+  EXPECT_EQ(clone->num_objects(), 2);
+  EXPECT_EQ(clone->num_constraint_equations(), 3);
+  EXPECT_EQ(clone->num_cliques(), 2);
+  EXPECT_EQ(clone->first_clique(), kinematics.jacobian().clique(0));
+  EXPECT_EQ(clone->second_clique(), kinematics.jacobian().clique(1));
+  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
+  EXPECT_EQ(clone->second_clique_jacobian().MakeDenseMatrix(), J34);
+}
+
+GTEST_TEST(SapBallConstraint, AccumulateSpatialImpulses) {
+  // Make a ball constraint with an arbitrary kinematics state, irrelevant for
+  // this test but needed at construction.
+  const int num_cliques = 1;
+  const SapBallConstraint<double>::Kinematics kinematics =
+      MakeArbitraryKinematics(num_cliques);
+  SapBallConstraint<double> c(kinematics);
+
+  EXPECT_EQ(c.num_objects(), 2);
+  EXPECT_EQ(c.object(0), kinematics.objectA());
+  EXPECT_EQ(c.object(1), kinematics.objectB());
+
+  // Arbitrary value of the impulse.
+  const Vector3d gamma(1.2, 3.4, 5.6);
+
+  // Expected spatial impulse on B.
+  const SpatialForce<double> F_Bo_W =
+      (SpatialForce<double>(Vector3d::Zero(), gamma))
+          .ShiftInPlace(-kinematics.p_BQ_W());
+
+  // Expected spatial impulse on A.
+  const SpatialForce<double> F_Ao_W =
+      (SpatialForce<double>(Vector3d::Zero(), -gamma))
+          .ShiftInPlace(-kinematics.p_AP_W());
+
+  const SpatialForce<double> F0(Vector3d(1., 2., 3), Vector3d(4., 5., 6));
+  SpatialForce<double> Faccumulated = F0;  // Initialize to non-zero value.
+  SpatialForce<double> F_Bo_W_expected = F0 + F_Bo_W;
+  c.AccumulateSpatialImpulses(1, gamma, &Faccumulated);
+  EXPECT_TRUE(CompareMatrices(
+      Faccumulated.get_coeffs(), F_Bo_W_expected.get_coeffs(),
+      std::numeric_limits<double>::epsilon(), MatrixCompareType::relative));
+
+  Faccumulated = F0;  // Initialize to non-zero value.
+  SpatialForce<double> F_Ao_W_expected = F0 + F_Ao_W;
+  c.AccumulateSpatialImpulses(0, gamma, &Faccumulated);
+  EXPECT_TRUE(CompareMatrices(
+      Faccumulated.get_coeffs(), F_Ao_W_expected.get_coeffs(),
+      std::numeric_limits<double>::epsilon(), MatrixCompareType::relative));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -12,6 +12,7 @@
 #include "drake/common/unused.h"
 #include "drake/multibody/contact_solvers/contact_configuration.h"
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
+#include "drake/multibody/contact_solvers/sap/sap_ball_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
 #include "drake/multibody/contact_solvers/sap/sap_coupler_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_distance_constraint.h"
@@ -31,6 +32,7 @@ using drake::multibody::contact_solvers::internal::ContactSolverResults;
 using drake::multibody::contact_solvers::internal::ExtractNormal;
 using drake::multibody::contact_solvers::internal::ExtractTangent;
 using drake::multibody::contact_solvers::internal::MatrixBlock;
+using drake::multibody::contact_solvers::internal::SapBallConstraint;
 using drake::multibody::contact_solvers::internal::SapConstraint;
 using drake::multibody::contact_solvers::internal::SapConstraintJacobian;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
@@ -464,22 +466,10 @@ void SapDriver<T>::AddBallConstraints(
     contact_solvers::internal::SapContactProblem<T>* problem) const {
   DRAKE_DEMAND(problem != nullptr);
 
-  // Ball constraints do not have impulse limits, they are bi-lateral
-  // constraints. Each ball constraint introduces three constraint
-  // equations.
-  constexpr double kInfinity = std::numeric_limits<double>::infinity();
-  const Vector3<T> gamma_lower(-kInfinity, -kInfinity, -kInfinity);
-  const Vector3<T> gamma_upper(kInfinity, kInfinity, kInfinity);
-
-  // Stiffness and dissipation are set so that the constraint is in the
-  // "near-rigid" regime, [Castro et al., 2022].
-  const Vector3<T> stiffness(kInfinity, kInfinity, kInfinity);
-  const Vector3<T> relaxation_time = plant().time_step() * Vector3<T>::Ones();
-
   const int nv = plant().num_velocities();
   Matrix3X<T> Jv_WAp_W(3, nv);
   Matrix3X<T> Jv_WBq_W(3, nv);
-  MatrixX<T> Jv_ApBq_W = MatrixX<T>::Zero(3, nv);
+  Matrix3X<T> Jv_ApBq_W(3, nv);
 
   const Frame<T>& frame_W = plant().world_frame();
 
@@ -498,9 +488,9 @@ void SapDriver<T>::AddBallConstraints(
     const math::RigidTransform<T>& X_WB =
         plant().EvalBodyPoseInWorld(context, body_B);
     const Vector3<T> p_WP = X_WA * spec.p_AP.template cast<T>();
+    const Vector3<T> p_AP_W = X_WA.rotation() * spec.p_AP.template cast<T>();
     const Vector3<T> p_WQ = X_WB * spec.p_BQ.template cast<T>();
-
-    const Vector3<T> p_PQ_W = p_WQ - p_WP;
+    const Vector3<T> p_BQ_W = X_WB.rotation() * spec.p_BQ.template cast<T>();
 
     // Dense Jacobian.
     // d(p_PQ_W)/dt = Jv_ApBq_W * v.
@@ -512,55 +502,56 @@ void SapDriver<T>::AddBallConstraints(
         frame_W, frame_W, &Jv_WBq_W);
     Jv_ApBq_W = (Jv_WBq_W - Jv_WAp_W);
 
-    // TODO(amcastro-tri): consider exposing this parameter.
-    const double beta = 0.1;
-    const typename SapHolonomicConstraint<T>::Parameters parameters{
-        gamma_lower, gamma_upper, stiffness, relaxation_time, beta};
+    // Jacobian for the relative velocity v_PQ_W, as required by
+    // SapDistanceConstraint.
+    auto make_constraint_jacobian = [this, &Jv_ApBq_W, &body_A, &body_B]() {
+      const TreeIndex treeA_index =
+          tree_topology().body_to_tree_index(body_A.index());
+      const TreeIndex treeB_index =
+          tree_topology().body_to_tree_index(body_B.index());
 
-    const TreeIndex treeA_index =
-        tree_topology().body_to_tree_index(spec.body_A);
-    const TreeIndex treeB_index =
-        tree_topology().body_to_tree_index(spec.body_B);
+      // TODO(joemasterjohn): Move this exception up to the plant level so that
+      // it fails as fast as possible. Currently, the earliest this can happen
+      // is in MbP::Finalize() after the topology has been finalized.
+      if (!treeA_index.is_valid() && !treeB_index.is_valid()) {
+        const std::string msg = fmt::format(
+            "Creating a ball Constraint between bodies '{}' and '{}' where "
+            "both are welded to the world is not allowed.",
+            body_A.name(), body_B.name());
+        throw std::runtime_error(msg);
+      }
 
-    // TODO(joemasterjohn): Move this exception up to the plant level so that it
-    // fails as fast as possible. Currently, the earliest this can happen is
-    // in MbP::Finalize() after the topology has been finalized.
-    if (!treeA_index.is_valid() && !treeB_index.is_valid()) {
-      const std::string msg = fmt::format(
-          "Creating a ball Constraint between bodies '{}' and '{}' where both "
-          "are welded to the world is not allowed.",
-          body_A.name(), body_B.name());
-      throw std::runtime_error(msg);
-    }
+      // Both bodies A and B belong to the same tree or one of them is the
+      // world.
+      const bool single_tree = !treeA_index.is_valid() ||
+                               !treeB_index.is_valid() ||
+                               treeA_index == treeB_index;
 
-    // Both bodies A and B belong to the same tree or one of them is the world.
-    const bool single_tree = !treeA_index.is_valid() ||
-                             !treeB_index.is_valid() ||
-                             treeA_index == treeB_index;
+      if (single_tree) {
+        const TreeIndex tree_index =
+            treeA_index.is_valid() ? treeA_index : treeB_index;
+        MatrixX<T> Jtree = Jv_ApBq_W.middleCols(
+            tree_topology().tree_velocities_start(tree_index),
+            tree_topology().num_tree_velocities(tree_index));
+        return SapConstraintJacobian<T>(tree_index, std::move(Jtree));
+      } else {
+        MatrixX<T> JA = Jv_ApBq_W.middleCols(
+            tree_topology().tree_velocities_start(treeA_index),
+            tree_topology().num_tree_velocities(treeA_index));
+        MatrixX<T> JB = Jv_ApBq_W.middleCols(
+            tree_topology().tree_velocities_start(treeB_index),
+            tree_topology().num_tree_velocities(treeB_index));
+        return SapConstraintJacobian<T>(treeA_index, std::move(JA), treeB_index,
+                                        std::move(JB));
+      }
+    };
 
-    // Constraint function at current time step.
-    const Vector3<T> g0 = p_PQ_W;
-    if (single_tree) {
-      const TreeIndex tree_index =
-          treeA_index.is_valid() ? treeA_index : treeB_index;
-      MatrixX<T> Jtree = Jv_ApBq_W.middleCols(
-          tree_topology().tree_velocities_start(tree_index),
-          tree_topology().num_tree_velocities(tree_index));
-      SapConstraintJacobian<T> J(tree_index, std::move(Jtree));
-      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
-          g0, std::move(J), parameters));
-    } else {
-      MatrixX<T> JA = Jv_ApBq_W.middleCols(
-          tree_topology().tree_velocities_start(treeA_index),
-          tree_topology().num_tree_velocities(treeA_index));
-      MatrixX<T> JB = Jv_ApBq_W.middleCols(
-          tree_topology().tree_velocities_start(treeB_index),
-          tree_topology().num_tree_velocities(treeB_index));
-      SapConstraintJacobian<T> J(treeA_index, std::move(JA), treeB_index,
-                                 std::move(JB));
-      problem->AddConstraint(std::make_unique<SapHolonomicConstraint<T>>(
-          g0, std::move(J), parameters));
-    }
+    const typename SapBallConstraint<T>::Kinematics kinematics(
+        spec.body_A, p_WP, p_AP_W, spec.body_B, p_WQ, p_BQ_W,
+        make_constraint_jacobian());
+
+    problem->AddConstraint(
+        std::make_unique<SapBallConstraint<T>>(std::move(kinematics)));
   }
 }
 

--- a/multibody/plant/test/sap_driver_ball_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_ball_constraints_test.cc
@@ -157,7 +157,7 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
             Vector3d(kInfinity, kInfinity, kInfinity));
 
   EXPECT_EQ(p.stiffnesses(), Vector3d(kInfinity, kInfinity, kInfinity));
-  EXPECT_EQ(p.relaxation_times(), plant_.time_step() * Vector3d::Ones());
+  EXPECT_EQ(p.relaxation_times(), Vector3d::Zero());
 
   // This value is hard-coded in the source. This test serves as a brake to
   // prevent the value changing without notification. Changing this value


### PR DESCRIPTION
Makes SapBallConstraint a first class citizen of the sap constraints family. Refactors SapDriver to use the new constraint. Implements reporting forces for ball constraints.

Note: Ball constraints are already tested in `sap_driver_ball_constraints_test`, the new tests just verify that data flows through the new class correctly and expected spatial impulses are accumulated correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19940)
<!-- Reviewable:end -->
