### PR TITLE
Add lights to RenderEngineVtkParams

### DIFF
--- a/geometry/benchmarking/render_benchmark.cc
+++ b/geometry/benchmarking/render_benchmark.cc
@@ -1,3 +1,5 @@
+/* See render_benchmark_doxygen.h for discussion of this benchmark.  */
+
 #include <unistd.h>
 
 #include <filesystem>
@@ -12,23 +14,6 @@
 
 namespace drake {
 namespace geometry {
-namespace render {
-
-/* See render_benchmark_doxygen.h for discussion of this benchmark.  */
-
-/* Friend class for accessing RenderEngine's protected/private functionality. */
-class RenderEngineTester {
- public:
-  RenderEngineTester() = delete;
-
-  static void SetDefaultLightPosition(const Vector3<double>& X_DL,
-                                      RenderEngine* renderer) {
-    renderer->SetDefaultLightPosition(X_DL);
-  }
-};
-
-}  // namespace render
-
 namespace {
 
 using Eigen::Vector3d;
@@ -39,7 +24,6 @@ using render::DepthRange;
 using render::DepthRenderCamera;
 using render::RenderCameraCore;
 using render::RenderEngine;
-using render::RenderEngineTester;
 using render::RenderLabel;
 using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
@@ -66,13 +50,19 @@ enum class EngineType { Vtk, Gl };
 /* Creates a render engine of the given type with the given background color. */
 template <EngineType engine_type>
 std::unique_ptr<RenderEngine> MakeEngine(const Vector3d& bg_rgb) {
+  // Offset the light from its default position (coincident with the camera)
+  // so that shadows can be seen in the render.
   if constexpr (engine_type == EngineType::Vtk) {
-    RenderEngineVtkParams params{{}, {}, bg_rgb};
+    const RenderEngineVtkParams params{
+      .default_clear_color = bg_rgb,
+      .lights = {{.type = "point", .position = {0.5, 0.5, 0}}}};
     return MakeRenderEngineVtk(params);
   }
   if constexpr (engine_type == EngineType::Gl) {
-    RenderEngineGlParams params;
-    params.default_clear_color.set(bg_rgb[0], bg_rgb[1], bg_rgb[2], 1.0);
+    const Rgba bg(bg_rgb[0], bg_rgb[1], bg_rgb[2]);
+    const RenderEngineGlParams params{
+        .default_clear_color = bg,
+        .lights = {{.type = "point", .position = {0.5, 0.5, 0}}}};
     return MakeRenderEngineGl(params);
   }
 }
@@ -308,14 +298,6 @@ class RenderBenchmark : public benchmark::Fixture {
                                   DepthRange{kZNear, kZFar});
     }
     AddSphereArray(sphere_count, depth_cameras_[0].core(), engine);
-
-    // Offset the light from its default position shared with the camera, i.e.
-    // (0, 0, 1), so that shadows can be seen in the render.
-    // TODO(SeanCurtis-TRI) This is using a stop-gap mechanism for configuring
-    // light position. Swap it to use a light declaration API when it is
-    // introduced.
-    RenderEngineTester::SetDefaultLightPosition(Vector3d{0.5, 0.5, 1},
-                                                engine);
   }
 
   std::vector<DepthRenderCamera> depth_cameras_;

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:name_value",
+        "//geometry/render:light_parameter",
         "//geometry/render:render_label",
     ],
 )
@@ -118,6 +119,7 @@ drake_cc_googletest(
                 "RenderEngineVtkTest.DefaultProperties_RenderLabel",
                 "RenderEngineVtkTest.DifferentCameras",
                 "RenderEngineVtkTest.EllipsoidTest",
+                "RenderEngineVtkTest.FallbackLight",
                 "RenderEngineVtkTest.GltfSupport",
                 "RenderEngineVtkTest.HorizonTest",
                 "RenderEngineVtkTest.IntrinsicsAndRenderProperties",

--- a/geometry/render_vtk/render_engine_vtk_params.h
+++ b/geometry/render_vtk/render_engine_vtk_params.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <optional>
+#include <vector>
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/name_value.h"
+#include "drake/geometry/render/light_parameter.h"
 #include "drake/geometry/render/render_label.h"
 
 namespace drake {
@@ -17,6 +19,7 @@ struct RenderEngineVtkParams  {
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(default_diffuse));
     a->Visit(DRAKE_NVP(default_clear_color));
+    a->Visit(DRAKE_NVP(lights));
   }
 
   /** (Deprecated.) The default_label is no longer configurable. <br>
@@ -32,6 +35,14 @@ struct RenderEngineVtkParams  {
    channel in the range [0, 1]). The default value (in byte values) would be
    [204, 229, 255].  */
   Eigen::Vector3d default_clear_color{204 / 255., 229 / 255., 255 / 255.};
+
+  /** Lights in the scene. If no lights are defined, a single directional light,
+   fixed to the camera frame, is used.
+
+   Note: RenderEngineVtk does not have a hard-coded limit on the number of
+         lights; but more lights increases rendering cost.
+   Note: the attenuation values have no effect on VTK *directional* lights. */
+  std::vector<render::LightParameter> lights;
 };
 
 }  // namespace geometry

--- a/geometry/render_vtk/test/render_engine_vtk_params_test.cc
+++ b/geometry/render_vtk/test/render_engine_vtk_params_test.cc
@@ -13,11 +13,14 @@ GTEST_TEST(RenderEngineVtkParams, Serialization) {
   const Params original{
       .default_diffuse = Eigen::Vector4d{1.0, 0.5, 0.25, 1.0},
       .default_clear_color = Eigen::Vector3d{0.25, 0.5, 1.0},
+      .lights = {{.type = "point"}},
   };
   const std::string yaml = yaml::SaveYamlString<Params>(original);
   const Params dut = yaml::LoadYamlString<Params>(yaml);
   EXPECT_EQ(dut.default_diffuse, original.default_diffuse);
   EXPECT_EQ(dut.default_clear_color, original.default_clear_color);
+  ASSERT_EQ(dut.lights.size(), 1);
+  EXPECT_EQ(dut.lights.at(0).type, "point");
 }
 
 }  // namespace


### PR DESCRIPTION
This allows lights to be configured in `RenderEngineVtk` like they are in `RenderEngineGl`.

Calling the `SetDefaultLightPosition()` now spews a warning and does little else. `render_benchmark.cc` was the only code in Drake that exercised this API. It is not part of `RenderEngine`'s public API, just part of its protected API. This is a precursor to removing it.

The light tests are basically copied from `RenderEngineGl`'s tests (with small tweaks to make them applicable to VTK).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19948)
<!-- Reviewable:end -->
