### PR TITLE
[tools] Avoid --force_pic on macOS

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -5,7 +5,6 @@ build --incompatible_load_python_rules_from_bzl=yes
 build -c opt
 
 # Default build options.
-build --force_pic
 build --strip=never
 build --strict_system_includes
 

--- a/tools/ubuntu.bazelrc
+++ b/tools/ubuntu.bazelrc
@@ -1,5 +1,6 @@
 # Common options for Ubuntu, no matter the version.
 
+build --force_pic
 build --fission=dbg
 build --features=per_object_debug_info
 


### PR DESCRIPTION
This is unnecessary in the first place, and makes objc_library not work (https://github.com/bazelbuild/bazel/issues/12439).

Towards #19945.