### PR TITLE
[symbolic] Fix integer overflow in ToLatex

### DIFF
--- a/common/symbolic/test/latex_test.cc
+++ b/common/symbolic/test/latex_test.cc
@@ -24,6 +24,7 @@ GTEST_TEST(SymbolicLatex, BasicTest) {
   EXPECT_EQ(ToLatex(1.0, 1), "1");
   EXPECT_EQ(ToLatex(1.01), "1.010");
   EXPECT_EQ(ToLatex(1.01, 1), "1.0");
+  EXPECT_EQ(ToLatex(4e9), "4000000000");
   EXPECT_EQ(ToLatex(kInf - kInf), "\\text{NaN}");
   EXPECT_EQ(ToLatex(kInf), "\\infty");
   EXPECT_EQ(ToLatex(-kInf), "-\\infty");


### PR DESCRIPTION
Also some nearby cleanups:
- Prefer "optional" over "bool success + output argument".
  - Remove unused precision; ints never have decimals anyway.
- Prefer "isinf" over "== numeric_limits::infinity".

Amends #19941.

+@RussTedrake for feature review, please.
+@sherm1 for platform review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19951)
<!-- Reviewable:end -->
