### PR TITLE
[yaml] Fix round-trip bugs with variant<string,...>

### DIFF
--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -526,6 +526,9 @@ TEST_P(YamlReadArchiveTest, Variant) {
     EXPECT_EQ(x.value, expected) << doc;
   };
 
+  test("doc:\n  value: \"\"", "");
+  test("doc:\n  value: foo", "foo");
+  test("doc:\n  value: \"foo\"", "foo");
   test("doc:\n  value: !!str foo", "foo");
   test("doc:\n  value: !!float 1.0", 1.0);
   test("doc:\n  value: !DoubleStruct { value: 1.0 }", DoubleStruct{1.0});

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -204,6 +204,7 @@ TEST_F(YamlWriteArchiveTest, Variant) {
     EXPECT_EQ(Save(x), WrapDoc(expected));
   };
 
+  test(Variant4(std::string()), "\"\"");
   test(Variant4(std::string("foo")), "foo");
   test(Variant4(DoubleStruct{1.0}), "!DoubleStruct\n    value: 1.0");
   test(Variant4(EigenVecStruct{Eigen::Vector2d(1.0, 2.0)}),

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -311,7 +311,7 @@ class YamlReadArchive final {
                          Variant* storage) {
     // For the first type declared in the variant<> (I == 0), the tag can be
     // absent; otherwise, the tag must match one of the variant's types.
-    if (((I == 0) && (tag.empty() || (tag == "?"))) ||
+    if (((I == 0) && (tag.empty() || (tag == "?") || (tag == "!"))) ||
         IsTagMatch(drake::NiceTypeName::GetFromStorage<T>(), tag)) {
       T& typed_storage = storage->template emplace<I>();
       this->Visit(drake::MakeNameValue(name, &typed_storage));

--- a/systems/sensors/test/camera_config_test.cc
+++ b/systems/sensors/test/camera_config_test.cc
@@ -268,6 +268,12 @@ GTEST_TEST(CameraConfigTest, SerializeBackgroundRgba) {
   EXPECT_EQ(yaml, "background:\n  rgba: [0.1, 0.2, 0.3, 0.4]\n");
 }
 
+GTEST_TEST(CameraConfigTest, SerializationDefaultRoundTrip) {
+  const CameraConfig original;
+  const std::string yaml = SaveYamlString<CameraConfig>(original);
+  EXPECT_NO_THROW(LoadYamlString<CameraConfig>(yaml)) << "with yaml:\n" << yaml;
+}
+
 // Various tests to support the documented examples in the documentation. The
 // number of each parsed config should correspond to the number in the docs for
 // the renderer_class field.


### PR DESCRIPTION
This is required for the default `renderer_class` value in #19863 (the empty string) to round-trip correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19954)
<!-- Reviewable:end -->
