### PR TITLE
Update camera_config doc/test based on yaml fix

### DIFF
--- a/systems/sensors/camera_config.h
+++ b/systems/sensors/camera_config.h
@@ -337,6 +337,11 @@ struct CameraConfig {
      cleanup: false
    @endcode
 
+   6. Explicitly request Drake's default render engine.
+   @code{yaml}
+   renderer_class: ""
+   @endcode
+
    Things to note:
 
      - When providing the _parameters_ for the engine, the declaration must
@@ -344,13 +349,6 @@ struct CameraConfig {
      - A defaulted set of parameters must have a trailing `{}` (example 2).
      - Two engine parameter sets may have the same semantic parameter but spell
        it differently (`default_clear_color` in examples 3 and 4).
-
-   <!-- TODO(SeanCurtis-TRI): Figure out why this doesn't work.
-   ?. Explicitly default to Drake's default render engine.
-   @code{yaml}
-   renderer_class: ""
-   @endcode
-   -->
 
    @pre `renderer_class` is a string and either empty or one of
         `"RenderEngineVtk"`, `"RenderEngineGl"`, or `"RenderEngineGltfClient"`,

--- a/systems/sensors/test/camera_config_test.cc
+++ b/systems/sensors/test/camera_config_test.cc
@@ -319,6 +319,9 @@ GTEST_TEST(CameraConfigTest, DeserializingRendererClass) {
                                                .render_endpoint = "server",
                                                .verbose = true,
                                                .cleanup = false}));
+
+  const CameraConfig config_6 = parse("renderer_class: \"\"");
+  EXPECT_THAT(config_6.renderer_class, testing::VariantWith<std::string>(""));
 }
 
 // Helper functions for validating a render camera.


### PR DESCRIPTION
Recently, the yaml parsing was fixed so that a variant with a string could be passed the empty string. This resolved a TODO in the CameraConfig documentation (allowing the set of documented examples to be expanded and the corresponding tests to cover it).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19957)
<!-- Reviewable:end -->
