### PR TITLE
Prefer Eval over Calc in SapDriver

### DIFF
--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -184,8 +184,8 @@ std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
   // Quick no-op exit.
   if (num_contacts == 0) return std::vector<RotationMatrix<T>>();
 
-  std::vector<ContactPairKinematics<T>> contact_kinematics =
-      manager().CalcContactKinematics(context);
+  const std::vector<ContactPairKinematics<T>>& contact_kinematics =
+      manager().EvalContactKinematics(context);
 
   std::vector<RotationMatrix<T>> R_WC;
   R_WC.reserve(num_contacts);
@@ -195,7 +195,7 @@ std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
     const T stiffness = discrete_pair.stiffness;
     const T dissipation_time_scale = discrete_pair.dissipation_time_scale;
     const T friction = discrete_pair.friction_coefficient;
-    ContactConfiguration<T>& configuration =
+    const ContactConfiguration<T>& configuration =
         contact_kinematics[icontact].configuration;
     const auto& jacobian_blocks = contact_kinematics[icontact].jacobian;
 
@@ -217,13 +217,13 @@ std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
       SapConstraintJacobian<T> J(jacobian_blocks[0].tree,
                                  std::move(jacobian_blocks[0].J));
       problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
-          std::move(configuration), std::move(J), std::move(parameters)));
+          configuration, std::move(J), std::move(parameters)));
     } else {
       SapConstraintJacobian<T> J(
           jacobian_blocks[0].tree, std::move(jacobian_blocks[0].J),
           jacobian_blocks[1].tree, std::move(jacobian_blocks[1].J));
       problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
-          std::move(configuration), std::move(J), std::move(parameters)));
+          configuration, std::move(J), std::move(parameters)));
     }
   }
   return R_WC;

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -25,8 +25,8 @@ TamsiDriver<T>::TamsiDriver(const CompliantContactManager<T>* manager)
 template <typename T>
 internal::ContactJacobians<T> TamsiDriver<T>::CalcContactJacobians(
     const systems::Context<T>& context) const {
-  const std::vector<ContactPairKinematics<T>> contact_kinematics =
-      manager().CalcContactKinematics(context);
+  const std::vector<ContactPairKinematics<T>>& contact_kinematics =
+      manager().EvalContactKinematics(context);
 
   const int nc = contact_kinematics.size();
   const int nv = manager().plant().num_velocities();


### PR DESCRIPTION
We should use the EvalContactKinematics in SapDriver::AddContactConstraint as the value may have been pre-computed elsewhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19970)
<!-- Reviewable:end -->
