### PR TITLE
Implement a method to get the perpendicular basis for an AffineSubspace.

### DIFF
--- a/geometry/optimization/affine_subspace.cc
+++ b/geometry/optimization/affine_subspace.cc
@@ -267,6 +267,23 @@ bool AffineSubspace::IsNearlyEqualTo(const AffineSubspace& other,
   return ContainedIn(other, tol) && other.ContainedIn(*this, tol);
 }
 
+Eigen::MatrixXd AffineSubspace::OrthogonalComplementBasis() const {
+  // If we have a zero-dimensional AffineSubspace (i.e. a point), the
+  // basis_decomp_ isn't constructed, and we just return a basis of the whole
+  // space.
+  if (!basis_decomp_.has_value()) {
+    return MatrixXd::Identity(ambient_dimension(), ambient_dimension());
+  }
+  // The perpendicular space is equivalent to the kernel of the QR decomposition
+  // stored in this class. So we can simply access the rightmost columns of the
+  // Q matrix, as described here:
+  // https://stackoverflow.com/questions/54766392/eigen-obtain-the-kernel-of-a-sparse-matrix
+  int perpendicular_basis_dimension = ambient_dimension() - AffineDimension();
+  MatrixXd Q = basis_decomp_.value().householderQ() *
+               MatrixXd::Identity(ambient_dimension(), ambient_dimension());
+  return Q.rightCols(perpendicular_basis_dimension);
+}
+
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/affine_subspace.h
+++ b/geometry/optimization/affine_subspace.h
@@ -125,6 +125,10 @@ class AffineSubspace final : public ConvexSet {
    * that each set is contained in the other. */
   bool IsNearlyEqualTo(const AffineSubspace& other, double tol = 1e-15) const;
 
+  /** Returns an orthonormal basis of the vector subspace which is perpendicular
+   * to this AffineSubspace.*/
+  Eigen::MatrixXd OrthogonalComplementBasis() const;
+
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 

--- a/geometry/optimization/test/affine_subspace_test.cc
+++ b/geometry/optimization/test/affine_subspace_test.cc
@@ -19,6 +19,21 @@ namespace drake {
 namespace geometry {
 namespace optimization {
 
+void CheckOrthogonalComplementBasis(const AffineSubspace& as) {
+  Eigen::MatrixXd perpendicular_basis = as.OrthogonalComplementBasis();
+  EXPECT_EQ(perpendicular_basis.cols(),
+            as.ambient_dimension() - as.AffineDimension());
+  EXPECT_EQ(perpendicular_basis.rows(), as.ambient_dimension());
+  // Check that every perpendicular basis vector is orthogonal to
+  // every basis vector.
+  const double kTol = 1e-15;
+  for (int i = 0; i < perpendicular_basis.cols(); ++i) {
+    for (int j = 0; j < as.basis().cols(); ++j) {
+      EXPECT_NEAR(0, as.basis().col(j).dot(perpendicular_basis.col(i)), kTol);
+    }
+  }
+}
+
 GTEST_TEST(AffineSubspaceTest, DefaultCtor) {
   const AffineSubspace dut;
   EXPECT_EQ(dut.basis().cols(), 0);
@@ -43,6 +58,7 @@ GTEST_TEST(AffineSubspaceTest, DefaultCtor) {
       dut.Project(test_point)));
   EXPECT_TRUE(dut.ContainedIn(AffineSubspace()));
   EXPECT_TRUE(dut.IsNearlyEqualTo(AffineSubspace()));
+  CheckOrthogonalComplementBasis(dut);
 }
 
 GTEST_TEST(AffineSubspaceTest, Point) {
@@ -65,6 +81,7 @@ GTEST_TEST(AffineSubspaceTest, Point) {
   EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3)));
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3))));
+  CheckOrthogonalComplementBasis(as);
 
   // Should throw because the ambient dimension is wrong.
   EXPECT_THROW(as.Project(Eigen::VectorXd::Zero(1)), std::exception);
@@ -110,6 +127,7 @@ GTEST_TEST(AffineSubspaceTest, Line) {
   EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3), kTol));
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3)), kTol));
+  CheckOrthogonalComplementBasis(as);
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 1);
@@ -160,6 +178,7 @@ GTEST_TEST(AffineSubspaceTest, Plane) {
   EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3)));
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3))));
+  CheckOrthogonalComplementBasis(as);
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 2);
@@ -210,6 +229,7 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR3) {
   EXPECT_TRUE(as.PointInSet(Eigen::VectorXd::Zero(3)));
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3))));
+  CheckOrthogonalComplementBasis(as);
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 3);
@@ -261,6 +281,7 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR4) {
   EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(4)));
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(4))));
+  CheckOrthogonalComplementBasis(as);
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 3);


### PR DESCRIPTION
Towards #19717. This returns a basis of the orthogonal complement of the vector subspace describing an affine subspace. That is, all vectors in the span of this basis are orthogonal to all vectors in the affine subspace (if it is translated so as to pass through the origin).

+@hongkai-dai for feature review, please

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19975)
<!-- Reviewable:end -->
