### PR TITLE
[parsing] Deprecate some parser methods

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -157,6 +157,7 @@ drake_pybind_library(
     name = "parsing_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:serialize_pybind",
     ],
     cc_srcs = ["parsing_py.cc"],

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -1,3 +1,4 @@
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -92,9 +93,6 @@ PYBIND11_MODULE(parsing, m) {
             cls_doc.plant.doc)
         .def("package_map", &Class::package_map, py_rvp::reference_internal,
             cls_doc.package_map.doc)
-        // TODO(rpoyner-tri): deprecate on or after 2023-01.
-        .def("AddAllModelsFromFile", &Class::AddAllModelsFromFile,
-            py::arg("file_name"), cls_doc.AddAllModelsFromFile.doc)
         .def(
             "AddModels",
             // Pybind11 won't implicitly convert strings to
@@ -116,14 +114,25 @@ PYBIND11_MODULE(parsing, m) {
         .def("AddModels", &Class::AddModelsFromString, py::kw_only(),
             py::arg("file_contents"), py::arg("file_type"),
             cls_doc.AddModelsFromString.doc)
-        .def("AddModelFromFile", &Class::AddModelFromFile, py::arg("file_name"),
-            py::arg("model_name") = "", cls_doc.AddModelFromFile.doc)
         .def("SetStrictParsing", &Class::SetStrictParsing,
             cls_doc.SetStrictParsing.doc)
         .def("SetAutoRenaming", &Class::SetAutoRenaming, py::arg("value"),
             cls_doc.SetAutoRenaming.doc)
         .def("GetAutoRenaming", &Class::GetAutoRenaming,
             cls_doc.GetAutoRenaming.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("AddAllModelsFromFile",
+            WrapDeprecated(cls_doc.AddAllModelsFromFile.doc_deprecated,
+                &Class::AddAllModelsFromFile),
+            py::arg("file_name"))
+        .def("AddModelFromFile",
+            WrapDeprecated(cls_doc.AddModelFromFile.doc_deprecated,
+                &Class::AddModelFromFile),
+            py::arg("file_name"), py::arg("model_name") = "");
+#pragma GCC diagnostic pop
   }
 
   // Model Directives

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -214,8 +214,8 @@ class Parser final {
   std::vector<ModelInstanceIndex> AddModelsFromUrl(
       const std::string& url);
 
-  // TODO(rpoyner-tri): deprecate on or after 2023-01.
   /// Legacy spelling of AddModels.
+  DRAKE_DEPRECATED("2023-12-01", "Use AddModels() instead.")
   std::vector<ModelInstanceIndex> AddAllModelsFromFile(
       const std::string& file_name);
 
@@ -244,6 +244,10 @@ class Parser final {
   ///
   /// @sa http://sdformat.org/tutorials?tut=composition&ver=1.7 for details on
   /// nesting in SDFormat.
+  DRAKE_DEPRECATED("2023-12-01", "Use parser.AddModels() instead. To port the"
+                   " 2-argument form, rename models using"
+                   " parser.SetAutoRenaming() and plant.RenameModelInstance()."
+                   " See PR #19978 for more details.")
   ModelInstanceIndex AddModelFromFile(
       const std::string& file_name,
       const std::string& model_name = {});

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -36,84 +36,57 @@ GTEST_TEST(FileParserTest, BasicTest) {
   const std::string obj_name = FindResourceOrThrow(
       "drake/multibody/parsing/test/box_package/meshes/box.obj");
 
-  // Load from SDF using plural method.
-  // Add a second one with an overridden model_name.
-  // Add one with a name prefix.
+  // Load from SDFormat.
+  // Load the same model again with a name prefix.
   {
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     EXPECT_EQ(&dut.plant(), &plant);
     EXPECT_EQ(dut.AddModels(sdf_name).size(), 1);
-    dut.AddModelFromFile(sdf_name, "foo");
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(sdf_name);
     EXPECT_EQ(prefix_ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(prefix_ids[0]), "prefix::acrobot");
   }
 
-  // Load from URDF using plural method.
-  // Add a second one with an overridden model_name.
-  // Add one with a name prefix.
+  // Load from URDF.
+  // Load the same model again with a name prefix.
   {
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     EXPECT_EQ(dut.AddModels(urdf_name).size(), 1);
-    dut.AddModelFromFile(urdf_name, "foo");
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(urdf_name);
     EXPECT_EQ(prefix_ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(prefix_ids[0]), "prefix::acrobot");
   }
 
-  // Load an SDF then a URDF.
-  // Load an SDF then a URDF with name prefixes.
-  {
-    MultibodyPlant<double> plant(0.0);
-    Parser dut(&plant);
-    dut.AddModelFromFile(sdf_name, "foo");
-    dut.AddModelFromFile(urdf_name, "bar");
-    const auto foo_ids = Parser(&plant, "foo").AddModels(sdf_name);
-    EXPECT_EQ(foo_ids.size(), 1);
-    EXPECT_EQ(plant.GetModelInstanceName(foo_ids[0]), "foo::acrobot");
-    const auto bar_ids = Parser(&plant, "bar").AddModels(urdf_name);
-    EXPECT_EQ(bar_ids.size(), 1);
-    EXPECT_EQ(plant.GetModelInstanceName(bar_ids[0]), "bar::acrobot");
-  }
-
-  // Load from XML using plural method.
-  // Add a second one with an overridden model_name.
-  // Add one with a name prefix.
+  // Load from Mujoco XML.
+  // Load the same model again with a name prefix.
   {
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     const std::vector<ModelInstanceIndex> ids = dut.AddModels(xml_name);
     EXPECT_EQ(ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(ids[0]), "acrobot");
-    const ModelInstanceIndex id = dut.AddModelFromFile(xml_name, "foo");
-    EXPECT_EQ(plant.GetModelInstanceName(id), "foo");
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(xml_name);
     EXPECT_EQ(prefix_ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(prefix_ids[0]), "prefix::acrobot");
   }
 
-  // Load from DMD using plural method.
-  // Using the singular method is always an error.
-  // Add one with a name prefix.
+  // Load from DMD.
+  // Load the same model again with a name prefix.
   {
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     const std::vector<ModelInstanceIndex> ids = dut.AddModels(dmd_name);
     EXPECT_EQ(ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(ids[0]), "acrobot");
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        dut.AddModelFromFile(dmd_name, "foo"),
-        ".* always an error.*");
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(dmd_name);
     EXPECT_EQ(prefix_ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(prefix_ids[0]), "prefix::acrobot");
   }
 
-  // Load from OBJ using plural method.
-  // Add a second one with an overridden model_name.
-  // Add one with a name prefix.
+  // Load from OBJ.
+  // Load the same model again with a name prefix.
   {
     // TODO(SeanCurtis-TRI): Break this "basic test" up into each extension
     // type. The shared infrastructure is negligible, but the cost of adding
@@ -124,8 +97,6 @@ GTEST_TEST(FileParserTest, BasicTest) {
     const std::vector<ModelInstanceIndex> ids = dut.AddModels(obj_name);
     EXPECT_EQ(ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(ids[0]), "box");
-    const ModelInstanceIndex id = dut.AddModelFromFile(obj_name, "foo");
-    EXPECT_EQ(plant.GetModelInstanceName(id), "foo");
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(obj_name);
     EXPECT_EQ(prefix_ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(prefix_ids[0]), "prefix::box");
@@ -147,15 +118,38 @@ GTEST_TEST(FileParserTest, UrlTest) {
       ".*unsupported scheme.*");
 }
 
-GTEST_TEST(FileParserTest, LegacyFunctionTest) {
-  // Just make sure the legacy spelling "AddAllModelsFromFile" still
-  // works. This test can go away when the function is deprecated.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(FileParserTest, DeprecatedSingularFunctionTest) {
+  // Just make sure the deprecated function still works until removal.
+  // Load an SDF then a URDF.
+  // Load an SDF then a URDF with name prefixes.
+  const std::string sdf_name = FindResourceOrThrow(
+      "drake/multibody/benchmarks/acrobot/acrobot.sdf");
+  const std::string urdf_name = FindResourceOrThrow(
+      "drake/multibody/benchmarks/acrobot/acrobot.urdf");
+  MultibodyPlant<double> plant(0.0);
+  Parser dut(&plant);
+  dut.AddModelFromFile(sdf_name, "foo");
+  dut.AddModelFromFile(urdf_name, "bar");
+  const auto foo_ids = Parser(&plant, "foo").AddModels(sdf_name);
+  EXPECT_EQ(foo_ids.size(), 1);
+  EXPECT_EQ(plant.GetModelInstanceName(foo_ids[0]), "foo::acrobot");
+  const auto bar_ids = Parser(&plant, "bar").AddModels(urdf_name);
+  EXPECT_EQ(bar_ids.size(), 1);
+  EXPECT_EQ(plant.GetModelInstanceName(bar_ids[0]), "bar::acrobot");
+}
+
+GTEST_TEST(FileParserTest, DeprecatedFunctionTest) {
+  // Just make sure the deprecated spelling "AddAllModelsFromFile" still
+  // works. This test can go away when the function is removed.
   const std::string sdf_name = FindResourceOrThrow(
       "drake/multibody/benchmarks/acrobot/acrobot.sdf");
   MultibodyPlant<double> plant(0.0);
   Parser dut(&plant);
   EXPECT_EQ(dut.AddAllModelsFromFile(sdf_name).size(), 1);
 }
+#pragma GCC diagnostic push
 
 GTEST_TEST(FileParserTest, BasicStringTest) {
   const std::string sdf_name = FindResourceOrThrow(


### PR DESCRIPTION
This patch deprecates the legacy spelling AddAllModelsFromFile() and the singular method AddModelFromFile(), and reorganizes tests around those deprecations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19978)
<!-- Reviewable:end -->
