### PR TITLE
Handle converting VPolytope to HPolyhedron if it is not full dimensional.

### DIFF
--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -16,6 +16,7 @@
 #include <libqhullcpp/QhullFacet.h>
 #include <libqhullcpp/QhullFacetList.h>
 
+#include "drake/geometry/optimization/affine_subspace.h"
 #include "drake/geometry/optimization/vpolytope.h"
 #include "drake/math/matrix_util.h"
 #include "drake/math/rotation_matrix.h"
@@ -128,12 +129,126 @@ HPolyhedron::HPolyhedron(const QueryObject<double>& query_object,
 
 HPolyhedron::HPolyhedron(const VPolytope& vpoly)
     : ConvexSet(vpoly.ambient_dimension()) {
+  // First, handle the case where the VPolytope is empty.
+  if (vpoly.IsEmpty()) {
+    if (vpoly.ambient_dimension() == 0) {
+      throw std::runtime_error(
+          "Cannot convert an empty VPolytope with ambient dimension zero into "
+          "a HPolyhedron.");
+    } else {
+      // Just create an infeasible HPolyhedron.
+      Eigen::MatrixXd A = Eigen::MatrixXd::Zero(2, vpoly.ambient_dimension());
+      Eigen::VectorXd b = Eigen::VectorXd::Zero(2);
+      // x <= 1
+      A(0, 0) = 1;
+      b[0] = 1;
+      // -x <= -2, equivalent to x >= 2
+      A(1, 0) = -1;
+      b[1] = -2;
+      *this = HPolyhedron(A, b);
+      return;
+    }
+  }
+  // Next, handle the case where the VPolytope is not full dimensional.
+  const AffineSubspace affine_hull(vpoly);
+  if (affine_hull.AffineDimension() < affine_hull.ambient_dimension()) {
+    // This special case avoids two QHull errors: QH6214 and QH6154.
+    // QH6214 is due to the VPolytope not having enough vertices to make a
+    // full dimensional simplex, and QH6154 is due to the VPolytope not being
+    // full-dimensional, because all the vertices lie along a proper affine
+    // subspace. We can handle both of these cases by projecting onto the
+    // affine hull and doing the computations there. Then, we lift back to the
+    // original space, and add hyperplanes to require the point lie on the
+    // affine subspace.
+    Eigen::MatrixXd points_local =
+        affine_hull.ToLocalCoordinates(vpoly.vertices());
+
+    // Note QHull will not function in zero or one dimensional spaces, so
+    // we handle these separately here.
+    Eigen::MatrixXd global_A;
+    Eigen::VectorXd global_b;
+    if (affine_hull.AffineDimension() == 0) {
+      // If it's just a point, then the orthogonal complement constraints
+      // will do all the work, and we can set global_A and global_b to empty.
+      global_A = Eigen::MatrixXd::Zero(0, ambient_dimension());
+      global_b = Eigen::VectorXd::Zero(0);
+    } else if (affine_hull.AffineDimension() == 1) {
+      // In this case, we have a line, so we just pick the highest and lowest
+      // points on that line (w.r.t. the direction of the one vector in the
+      // affine basis) and put hyperplanes there.
+      int min_idx, max_idx;
+      Eigen::VectorXd point_local_vector = points_local.row(0);
+
+      point_local_vector.minCoeff(&min_idx);
+      point_local_vector.maxCoeff(&max_idx);
+      Eigen::VectorXd lower_point = vpoly.vertices().col(min_idx);
+      Eigen::VectorXd upper_point = vpoly.vertices().col(max_idx);
+      Eigen::VectorXd direction = affine_hull.basis();
+
+      global_A = Eigen::MatrixXd::Zero(2, ambient_dimension());
+      global_A.row(0) = -direction;
+      global_A.row(1) = direction;
+      global_b = Eigen::VectorXd::Zero(2);
+      global_b[0] = -lower_point.dot(direction);
+      global_b[1] = upper_point.dot(direction);
+    } else {
+      // Construct a new VPolytope in the local coordinates, and then try
+      // converting it to an HPolyhedron. This VPolytope is full dimensional
+      // and has enough points for QHull, so in the subsequent call of the
+      // VPolytope -> HPolyhedron constructor, none of this conditional block
+      // is considered, and it goes directly to QHull. If QHull has additional
+      // errors besides the dimension ones, they will be caught there.
+      HPolyhedron hpoly_subspace(VPolytope{points_local});
+
+      // Now, lift the HPolyhedron to the original ambient space. A point x in
+      // R^n is projected to P(x-d), where d is the AffineSubspace translation,
+      // and P is the projection matrix associated with the basis B (so that PB
+      // is the identity matrix, mapping points in the local coordinates of the
+      // AffineSubspace to themselves, where B is the matrix whose columns are
+      // the basis vectors). Thus, an HPolyhedron in local coordinates
+      // {Ay <= b : y in R^m} can be lifted to an HPolyhedron in global
+      // coordinates by substituting P(x-d) for y. After simplification, we have
+      // {APx <= b + APd : x in R^n}.
+
+      // First, we obtain the matrix P. Because it's a linear operator, we can
+      // compute its matrix by passing in the standard basis vectors (centered
+      // at the translation of the AffineSubspace).
+      Eigen::MatrixXd P_in =
+          Eigen::MatrixXd::Identity(ambient_dimension(), ambient_dimension());
+      Eigen::MatrixXd P = affine_hull.ToLocalCoordinates(
+          P_in.colwise() + affine_hull.translation());
+
+      // Now, we construct the global versions of A and b.
+      global_A = hpoly_subspace.A() * P;
+      global_b = hpoly_subspace.b() +
+                 hpoly_subspace.A() * P * affine_hull.translation();
+    }
+
+    // Finally, we add additional constraints from the perpendicular basis. This
+    // ensures that the points in the new HPolyhedron lie along the affine hull
+    // of the VPolytope.
+    Eigen::MatrixXd perpendicular_basis =
+        affine_hull.OrthogonalComplementBasis();
+    Eigen::MatrixXd perp_A(2 * perpendicular_basis.cols(), ambient_dimension());
+    perp_A << perpendicular_basis.transpose(), -perpendicular_basis.transpose();
+    Eigen::VectorXd perp_b = perp_A * affine_hull.translation();
+
+    Eigen::MatrixXd full_A(global_A.rows() + perp_A.rows(),
+                           ambient_dimension());
+    full_A << global_A, perp_A;
+    Eigen::VectorXd full_b(global_b.size() + perp_b.size());
+    full_b << global_b, perp_b;
+    *this = HPolyhedron(full_A, full_b);
+    return;
+  }
+
+  // Now that we know that the VPolytope is full dimensional, we can call QHull.
   orgQhull::Qhull qhull;
   qhull.runQhull("", vpoly.ambient_dimension(), vpoly.vertices().cols(),
                  vpoly.vertices().data(), "");
   if (qhull.qhullStatus() != 0) {
     throw std::runtime_error(
-        fmt::format("Qhull terminated with status {} and  message:\n{}",
+        fmt::format("Qhull exited with status {} and  message:\n{}",
                     qhull.qhullStatus(), qhull.qhullMessage()));
   }
   A_.resize(qhull.facetCount(), ambient_dimension());

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -42,7 +42,8 @@ class HPolyhedron final : public ConvexSet {
               std::optional<FrameId> reference_frame = std::nullopt);
 
   /** Constructs a new HPolyedron from a VPolytope object.  This function will
-  use qhull. */
+  use qhull. If the VPolytope is empty, then the HPolyhedron will also be empty.
+  @throws std::exception if vpoly is empty and zero dimensional. */
   explicit HPolyhedron(const VPolytope& vpoly);
 
   // TODO(russt): Add a method/constructor that would create the geometry using

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -159,6 +159,102 @@ GTEST_TEST(HPolyhedronTest, ConstructorFromVPolytope) {
   EXPECT_TRUE(hpoly2.PointInSet(hpoly2.MaybeGetFeasiblePoint().value()));
 }
 
+void CheckHPolyhedronContainsVPolyhedron(const HPolyhedron& h,
+                                         const VPolytope& v, double tol = 0) {
+  for (int i = 0; i < v.vertices().cols(); ++i) {
+    EXPECT_TRUE(h.PointInSet(v.vertices().col(i)));
+  }
+}
+
+GTEST_TEST(HPolyhedronTest, ConstructorFromVPolytopeQHullProblems) {
+  // Test cases of VPolytopes that QHull cannot handle on its own.
+  // Code logic in the constructor should handle these cases without any
+  // QHull errors.
+
+  // Case 1: Not enough points (need at least n+1 points in R^n). This
+  // will throw QHull error QH6214.
+  Eigen::Matrix<double, 2, 1> vert1;
+  vert1 << 1, 0;
+  const VPolytope vpoly1(vert1);
+  EXPECT_NO_THROW(HPolyhedron{vpoly1});
+  const HPolyhedron hpoly1(vpoly1);
+  CheckHPolyhedronContainsVPolyhedron(hpoly1, vpoly1);
+  EXPECT_FALSE(hpoly1.PointInSet(Eigen::Vector2d(0, 0)));
+  EXPECT_FALSE(hpoly1.PointInSet(Eigen::Vector2d(2, 0)));
+  EXPECT_FALSE(hpoly1.PointInSet(Eigen::Vector2d(1, 1)));
+  EXPECT_FALSE(hpoly1.PointInSet(Eigen::Vector2d(1, -1)));
+
+  Eigen::Matrix<double, 2, 2> vert2;
+  // clang-format off
+  vert2 << 1, 0,
+           0, 1;
+  // clang-format on
+  const VPolytope vpoly2(vert2);
+  EXPECT_NO_THROW(HPolyhedron{vpoly2});
+  const HPolyhedron hpoly2(vpoly2);
+  CheckHPolyhedronContainsVPolyhedron(hpoly2, vpoly2);
+  EXPECT_FALSE(hpoly2.PointInSet(Eigen::Vector2d(0, 0)));
+  EXPECT_FALSE(hpoly2.PointInSet(Eigen::Vector2d(1, 1)));
+  EXPECT_FALSE(hpoly2.PointInSet(Eigen::Vector2d(2, -1)));
+  EXPECT_FALSE(hpoly2.PointInSet(Eigen::Vector2d(-1, 2)));
+
+  Eigen::Matrix<double, 3, 3> vert3;
+  // clang-format off
+  vert3 << 1, 0, 0,
+           0, 1, 0,
+           0, 0, 0;
+  // clang-format on
+  const VPolytope vpoly3(vert3);
+  EXPECT_NO_THROW(HPolyhedron{vpoly3});
+  const HPolyhedron hpoly3(vpoly3);
+  CheckHPolyhedronContainsVPolyhedron(hpoly3, vpoly3);
+  EXPECT_FALSE(hpoly3.PointInSet(Eigen::Vector3d(1, 1, 0)));
+  EXPECT_FALSE(hpoly3.PointInSet(Eigen::Vector3d(-1, 0, 0)));
+  EXPECT_FALSE(hpoly3.PointInSet(Eigen::Vector3d(0, -1, 0)));
+  EXPECT_FALSE(hpoly3.PointInSet(Eigen::Vector3d(0, 0, 1)));
+  EXPECT_FALSE(hpoly3.PointInSet(Eigen::Vector3d(0, 0, -1)));
+
+  // Case 2: VPolytope not full-dimensional (all points lie on a
+  // proper affine subspace). This will throw QHull error QH6154.
+  Eigen::Matrix<double, 2, 5> vert4;
+  // clang-format off
+  vert4 << 1, 2, 3, 4, 5,
+           0, 1, 2, 3, 4;
+  // clang-format on
+  const VPolytope vpoly4(vert4);
+  EXPECT_NO_THROW(HPolyhedron{vpoly4});
+  const HPolyhedron hpoly4(vpoly4);
+  CheckHPolyhedronContainsVPolyhedron(hpoly4, vpoly4);
+
+  Eigen::Matrix<double, 3, 4> vert5;
+  // clang-format off
+  vert5 << 0, 1, 0, 1,
+           0, 0, 1, 1,
+           0, 0, 0, 0;
+  // clang-format on
+  const VPolytope vpoly5(vert5);
+  EXPECT_NO_THROW(HPolyhedron{vpoly5});
+  const HPolyhedron hpoly5(vpoly5);
+  CheckHPolyhedronContainsVPolyhedron(hpoly5, vpoly5);
+
+  // Case 3: VPolytope is empty
+  Eigen::Matrix<double, 2, 0> vert6;
+  const VPolytope vpoly6(vert6);
+  EXPECT_TRUE(vpoly6.IsEmpty());
+  EXPECT_EQ(vpoly6.ambient_dimension(), 2);
+  EXPECT_NO_THROW(HPolyhedron{vpoly6});
+  const HPolyhedron hpoly6(vpoly6);
+  EXPECT_TRUE(hpoly6.IsEmpty());
+
+  Eigen::Matrix<double, 0, 0> vert7;
+  const VPolytope vpoly7(vert7);
+  EXPECT_TRUE(vpoly7.IsEmpty());
+  EXPECT_EQ(vpoly7.ambient_dimension(), 0);
+  // Should throw an error, because HPolyhedron can't
+  // handle an empty zero dimensional set.
+  EXPECT_THROW(HPolyhedron{vpoly7}, std::exception);
+}
+
 GTEST_TEST(HPolyhedronTest, L1BallTest) {
   Matrix<double, 8, 3> A;
   VectorXd b = VectorXd::Ones(8);


### PR DESCRIPTION
One of the last two major steps to complete #19717. This allows the conversion of a VPolytope to an HPolyhedron even if the VPolytope is not full dimensional, or has insufficient points for QHull. (QHull always needs n+1 points in R^n.)

+@hongkai-dai for feature review, please

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19979)
<!-- Reviewable:end -->
