### PR TITLE
[framework] Add EventStatus to Event callbacks and propagate upwards

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -123,8 +123,8 @@ struct Impl {
     // Trampoline virtual methods.
 
     // TODO(sherm): This overload should be deprecated and removed; the
-    // preferred workflow is to register callbacks with Declare*PublishEvent.
-    void DoPublish(const Context<T>& context,
+    //  preferred workflow is to register callbacks with Declare*PublishEvent.
+    EventStatus DoPublish(const Context<T>& context,
         const vector<const PublishEvent<T>*>& events) const override {
       // Yuck! We have to dig in and use internals :(
       // We must ensure that pybind only sees pointers, since this method may
@@ -132,9 +132,10 @@ struct Impl {
       // @see https://github.com/pybind/pybind11/issues/1241
       // TODO(eric.cousineau): Figure out how to supply different behavior,
       // possibly using function wrapping.
-      PYBIND11_OVERLOAD_INT(void, LeafSystem<T>, "DoPublish", &context, events);
+      PYBIND11_OVERLOAD_INT(
+          EventStatus, LeafSystem<T>, "DoPublish", &context, events);
       // If the macro did not return, use default functionality.
-      Base::DoPublish(context, events);
+      return Base::DoPublish(context, events);
     }
 
     void DoCalcTimeDerivatives(const Context<T>& context,
@@ -222,15 +223,15 @@ struct Impl {
     using Base::Base;
 
     // Trampoline virtual methods.
-    void DoPublish(const Context<T>& context,
+    EventStatus DoPublish(const Context<T>& context,
         const vector<const PublishEvent<T>*>& events) const override {
       // Copied from above, since we cannot use `PyLeafSystemBase` due to final
       // overrides of some methods.
       // TODO(eric.cousineau): Make this more granular?
       PYBIND11_OVERLOAD_INT(
-          void, VectorSystem<T>, "DoPublish", &context, events);
+          EventStatus, VectorSystem<T>, "DoPublish", &context, events);
       // If the macro did not return, use default functionality.
-      Base::DoPublish(context, events);
+      return Base::DoPublish(context, events);
     }
 
     void DoCalcVectorOutput(const Context<T>& context,

--- a/bindings/pydrake/systems/pyplot_visualizer.py
+++ b/bindings/pydrake/systems/pyplot_visualizer.py
@@ -97,7 +97,7 @@ class PyPlotVisualizer(LeafSystem):
         # simulate it.
         # We need to bind a mechanism for declaring forced events so we don't
         # have to resort to overriding the dispatcher.
-        LeafSystem.DoPublish(self, context, event)
+        status = LeafSystem.DoPublish(self, context, event)
         if self._show:
             self.draw(context)
             self.fig.canvas.draw()
@@ -107,6 +107,7 @@ class PyPlotVisualizer(LeafSystem):
             snapshot.SetTimeStateAndParametersFrom(context)
             self.FixInputPortsFrom(self, context, snapshot)
             self._recorded_contexts.append(snapshot)
+        return status
 
     def draw(self, context):
         """Draws a single frame.

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -423,7 +423,7 @@ class TestCustom(unittest.TestCase):
 
             def DoPublish(self, context, events):
                 # Call base method to ensure we do not get recursion.
-                LeafSystem.DoPublish(self, context, events)
+                status = LeafSystem.DoPublish(self, context, events)
                 # N.B. We do not test for a singular call to `DoPublish`
                 # (checking `assertFalse(self.called_publish)` first) because
                 # the above `_DeclareInitializationEvent` will call both its
@@ -431,6 +431,7 @@ class TestCustom(unittest.TestCase):
                 # `Simulator::Initialize` from `call_leaf_system_overrides`,
                 # even when we explicitly say not to publish at initialize.
                 self.called_publish = True
+                return status
 
             def DoCalcTimeDerivatives(self, context, derivatives):
                 # Note:  Don't call base method here; it would abort because

--- a/bindings/pydrake/systems/test/pyplot_visualizer_test.py
+++ b/bindings/pydrake/systems/test/pyplot_visualizer_test.py
@@ -111,7 +111,7 @@ class TestPyplotVisualizer(unittest.TestCase):
         context = visualizer.AllocateContext()
         for time in times:
             context.SetTime(time)
-            visualizer.ForcedPublish(context)
+            status = visualizer.ForcedPublish(context)
 
         # Check that there are now recorded contexts with matching times.
         visualizer.stop_recording()

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -93,7 +93,8 @@ PYBIND11_MODULE(test_util, m) {
       // Call `Publish` to test `DoPublish`.
       auto events =
           LeafEventCollection<PublishEvent<T>>::MakeForcedEventCollection();
-      system.Publish(*context, *events);
+      const EventStatus status = system.Publish(*context, *events);
+      DRAKE_DEMAND(status.is_good());
     }
     {
       // Call `HasDirectFeedthrough` to test `DoHasDirectFeedthrough`.

--- a/examples/kinova_jaco_arm/jaco_controller.cc
+++ b/examples/kinova_jaco_arm/jaco_controller.cc
@@ -189,7 +189,8 @@ int DoMain() {
     simulator.AdvanceTo(time);
     // Force-publish the lcmt_jaco_command (via the command_pub system within
     // the diagram).
-    diagram->ForcedPublish(diagram_context);
+    const systems::EventStatus status = diagram->ForcedPublish(diagram_context);
+    DRAKE_DEMAND(status.is_good());
   }
 
   // We should never reach here.

--- a/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -140,7 +140,8 @@ int DoMain() {
     simulator.AdvanceTo(time);
     // Force-publish the lcmt_iiwa_command (via the command_pub system within
     // the diagram).
-    diagram.ForcedPublish(diagram_context);
+    const systems::EventStatus status = diagram.ForcedPublish(diagram_context);
+    DRAKE_DEMAND(status.is_good());
   }
 
   // We should never reach here.

--- a/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
+++ b/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
@@ -150,7 +150,8 @@ int DoMain() {
     simulator.AdvanceTo(time);
     // Force-publish the lcmt_planar_gripper_command (via the command_pub system
     // within the diagram).
-    diagram->ForcedPublish(diagram_context);
+    const systems::EventStatus status = diagram->ForcedPublish(diagram_context);
+    DRAKE_DEMAND(status.is_good());
   }
 
   // We should never reach here.

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -677,7 +677,7 @@ TYPED_TEST(DrakeVisualizerTest, ForcePublish) {
   this->PopulateScene();
   auto context = this->diagram_->CreateDefaultContext();
   const auto& vis_context = this->visualizer_->GetMyContextFromRoot(*context);
-  this->visualizer_->ForcedPublish(vis_context);
+  EXPECT_TRUE(this->visualizer_->ForcedPublish(vis_context).is_good());
 
   /* Confirm that messages were sent.  */
   MessageResults results = this->ProcessMessages();
@@ -878,7 +878,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeDeformableGeometry) {
   /* Dispatch a load message. */
   auto context = this->diagram_->CreateDefaultContext();
   const auto& vis_context = this->visualizer_->GetMyContextFromRoot(*context);
-  this->visualizer_->ForcedPublish(vis_context);
+  EXPECT_TRUE(this->visualizer_->ForcedPublish(vis_context).is_good());
 
   /* Confirm that messages were sent.  */
   MessageResults results = this->ProcessMessages();
@@ -988,7 +988,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeHydroGeometry) {
   /* Dispatch a load message. */
   auto context = this->diagram_->CreateDefaultContext();
   const auto& vis_context = this->visualizer_->GetMyContextFromRoot(*context);
-  this->visualizer_->ForcedPublish(vis_context);
+  EXPECT_TRUE(this->visualizer_->ForcedPublish(vis_context).is_good());
 
   /* Confirm that messages were sent.  */
   MessageResults results = this->ProcessMessages(params.role);

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -330,7 +330,7 @@ Open up your browser to the URL above.
 
     plant.SetPositions(&plant.GetMyMutableContextFromRoot(context.get()),
                        Eigen::Vector2d{0.1, 0.3});
-    diagram->ForcedPublish(*context);
+    (void)diagram->ForcedPublish(*context);
     std::cout << "- Now you should see three colliding hydroelastic spheres."
               << std::endl;
     MaybePauseForUser();
@@ -371,7 +371,7 @@ Open up your browser to the URL above.
     auto context = diagram->CreateDefaultContext();
     diagram->get_input_port().FixValue(context.get(), Eigen::VectorXd::Zero(7));
 
-    diagram->ForcedPublish(*context);
+    (void)diagram->ForcedPublish(*context);
     std::cout
         << "- Now you should see a kuka model (from MultibodyPlant/SceneGraph)"
         << std::endl;

--- a/geometry/test/meshcat_point_cloud_visualizer_test.cc
+++ b/geometry/test/meshcat_point_cloud_visualizer_test.cc
@@ -60,7 +60,7 @@ TEST_F(MeshcatPointCloudVisualizerTest, Publish) {
 
   EXPECT_TRUE(meshcat_->GetPackedObject("cloud").empty());
   EXPECT_TRUE(meshcat_->GetPackedTransform("cloud").empty());
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_FALSE(meshcat_->GetPackedObject("cloud").empty());
   EXPECT_FALSE(meshcat_->GetPackedTransform("cloud").empty());
 }
@@ -70,7 +70,7 @@ TEST_F(MeshcatPointCloudVisualizerTest, NoPose) {
 
   EXPECT_TRUE(meshcat_->GetPackedObject("cloud").empty());
   EXPECT_TRUE(meshcat_->GetPackedTransform("cloud").empty());
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_FALSE(meshcat_->GetPackedObject("cloud").empty());
   // It still publishes a transform; but it publishes the identity.
   EXPECT_FALSE(meshcat_->GetPackedTransform("cloud").empty());
@@ -91,7 +91,7 @@ TEST_F(MeshcatPointCloudVisualizerTest, PublishPeriod) {
 TEST_F(MeshcatPointCloudVisualizerTest, Delete) {
   SetUpDiagram();
 
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_FALSE(meshcat_->GetPackedObject("cloud").empty());
 
   visualizer_->Delete();
@@ -115,7 +115,7 @@ TEST_F(MeshcatPointCloudVisualizerTest, ScalarConversion) {
 
   // Call publish to provide code coverage for the AutoDiffXd version of
   // UpdateMeshcat.  We simply confirm that the code doesn't blow up.
-  ad_diagram->ForcedPublish(*ad_context);
+  EXPECT_TRUE(ad_diagram->ForcedPublish(*ad_context).is_good());
 }
 
 

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -92,7 +92,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, BasicTest) {
             0);
 
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer/iiwa14"));
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_TRUE(meshcat_->HasPath("/drake/visualizer/iiwa14"));
   for (int link = 0; link < 8; link++) {
     EXPECT_NE(meshcat_->GetPackedTransform(
@@ -132,7 +132,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Roles) {
     params.role = role;
     SetUpDiagram(params);
     EXPECT_FALSE(meshcat_->HasPath("visualizer/iiwa14/iiwa_link_7"));
-    diagram_->ForcedPublish(*context_);
+    EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
     EXPECT_TRUE(meshcat_->HasPath("visualizer/iiwa14/iiwa_link_7"));
     auto& inspector = scene_graph_->model_inspector();
     FrameId iiwa_link_7 = plant_->GetBodyFrameIdOrThrow(
@@ -166,7 +166,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Prefix) {
   SetUpDiagram(params);
   EXPECT_EQ(visualizer_->get_name(), "meshcat_visualizer(/foo)");
   EXPECT_FALSE(meshcat_->HasPath("/foo/iiwa14"));
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_TRUE(meshcat_->HasPath("/foo/iiwa14"));
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer"));
 
@@ -175,7 +175,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Prefix) {
   EXPECT_FALSE(meshcat_->HasPath("/drake/foo/iiwa14"));
   SetUpDiagram(params);
   EXPECT_EQ(visualizer_->get_name(), "meshcat_visualizer(foo)");
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_TRUE(meshcat_->HasPath("/drake/foo/iiwa14"));
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer"));
 }
@@ -206,7 +206,8 @@ TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
   {  // Send an initialization event.
     auto events = diagram_->AllocateCompositeEventCollection();
     diagram_->GetInitializationEvents(*context_, events.get());
-    diagram_->Publish(*context_, events->get_publish_events());
+    EXPECT_TRUE(
+        diagram_->Publish(*context_, events->get_publish_events()).is_good());
   }
   // Confirm that my scribble was deleted.
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer/my_random_path"));
@@ -219,7 +220,8 @@ TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
   {  // Send an initialization event.
     auto events = diagram_->AllocateCompositeEventCollection();
     diagram_->GetInitializationEvents(*context_, events.get());
-    diagram_->Publish(*context_, events->get_publish_events());
+    EXPECT_TRUE(
+        diagram_->Publish(*context_, events->get_publish_events()).is_good());
   }
   // Confirm that my scribble remains.
   EXPECT_TRUE(meshcat_->HasPath("/drake/visualizer/my_random_path"));
@@ -227,7 +229,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
 
 TEST_F(MeshcatVisualizerWithIiwaTest, Delete) {
   SetUpDiagram();
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_TRUE(meshcat_->HasPath("/drake/visualizer"));
   visualizer_->Delete();
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer"));
@@ -251,13 +253,13 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
 
   // Publish once without recording and confirm that we don't have the iiwa
   // frame.
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   visualizer_->StartRecording();
   auto animation = visualizer_->get_mutable_recording();
   EXPECT_FALSE(has_iiwa_frame(*animation, 0));
 
   // Publish again *with* recording and confirm that we do now have the frame.
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_TRUE(has_iiwa_frame(*animation, 0));
 
   // Deleting the recording removes that frame.
@@ -266,7 +268,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
   EXPECT_FALSE(has_iiwa_frame(*animation, 0));
 
   // We are still recording, so publish *will* add it.
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_TRUE(has_iiwa_frame(*animation, 0));
 
   // But if we stop recording, then it's not added.
@@ -274,14 +276,14 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
   visualizer_->DeleteRecording();
   animation = visualizer_->get_mutable_recording();
   EXPECT_FALSE(has_iiwa_frame(*animation, 0));
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_FALSE(has_iiwa_frame(*animation, 0));
 
   // Now publish a time 0.0 and time = 1.0 and confirm we have the frames.
   animation = visualizer_->StartRecording();
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   context_->SetTime(1.0);
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_TRUE(has_iiwa_frame(*animation, 0));
   EXPECT_TRUE(
       has_iiwa_frame(*animation, std::floor(1.0 / params.publish_period)));
@@ -293,7 +295,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
 
 TEST_F(MeshcatVisualizerWithIiwaTest, RecordingWithoutSetTransform) {
   SetUpDiagram();
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   std::string X_7_message =
       meshcat_->GetPackedTransform("/drake/visualizer/iiwa14/iiwa_link_7");
 
@@ -304,7 +306,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, RecordingWithoutSetTransform) {
   bool set_transforms_while_recording = false;
   visualizer_->StartRecording(set_transforms_while_recording);
   // This publish should *not* change the transform in the Meshcat scene tree.
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_EQ(
       meshcat_->GetPackedTransform("/drake/visualizer/iiwa14/iiwa_link_7"),
       X_7_message);
@@ -312,7 +314,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, RecordingWithoutSetTransform) {
   set_transforms_while_recording = true;
   visualizer_->StartRecording(set_transforms_while_recording);
   // This publish *should* change the transform in the Meshcat scene tree.
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_NE(
       meshcat_->GetPackedTransform("/drake/visualizer/iiwa14/iiwa_link_7"),
       X_7_message);
@@ -327,7 +329,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, ScalarConversion) {
   // Call publish to provide code coverage for the AutoDiffXd version of
   // UpdateMeshcat / SetObjects SetTransforms.  We simply confirm that the code
   // doesn't blow up.
-  ad_diagram->ForcedPublish(*ad_context);
+  EXPECT_TRUE(ad_diagram->ForcedPublish(*ad_context).is_good());
 }
 
 // When opted-in by the user, we should display the hydroelastic tessellation
@@ -361,7 +363,7 @@ GTEST_TEST(MeshcatVisualizerTest, HydroGeometry) {
     // Send the geometry to Meshcat.
     auto diagram = builder.Build();
     auto context = diagram->CreateDefaultContext();
-    diagram->ForcedPublish(*context);
+    EXPECT_TRUE(diagram->ForcedPublish(*context).is_good());
 
     // Read back the mesh for a hydroelastic shape. Its size (in bytes) will
     // tell us whether or not hydro was used -- the normal representation is
@@ -410,7 +412,7 @@ GTEST_TEST(MeshcatVisualizerTest, MultipleModels) {
   EXPECT_FALSE(meshcat->HasPath("/drake/visualizer/iiwa14"));
   EXPECT_FALSE(meshcat->HasPath("/drake/visualizer/second/iiwa14"));
 
-  diagram->ForcedPublish(*context);
+  EXPECT_TRUE(diagram->ForcedPublish(*context).is_good());
 
   EXPECT_TRUE(meshcat->HasPath("/drake/visualizer/iiwa14"));
   EXPECT_TRUE(meshcat->HasPath("/drake/visualizer/second/iiwa14"));
@@ -473,7 +475,7 @@ GTEST_TEST(MeshcatVisualizerTest, AcceptingProperty) {
       const bool should_show =
           (accepting == "prefix") ||
           (include_unspecified_accepting && accepting.empty());
-      diagram->ForcedPublish(*context);
+      EXPECT_TRUE(diagram->ForcedPublish(*context).is_good());
       EXPECT_EQ(meshcat->HasPath(geom_path), should_show);
     }
   }
@@ -488,13 +490,13 @@ TEST_F(MeshcatVisualizerWithIiwaTest, AlphaSlidersSystemCheck) {
 
   // Simulate for a moment and publish to populate the visualizer.
   simulator.AdvanceTo(0.1);
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
 
   meshcat_->SetSliderValue("visualizer α", 0.5);
 
   // Simulate and publish again to cause an update.
   simulator.AdvanceTo(0.1);
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
 }
 
 // Checks whether the given path has been set to a new color beyond it's initial
@@ -580,7 +582,7 @@ GTEST_TEST(MeshcatVisualizerTest, AlphaSliderCheckResults) {
     // value of 100%.
     const std::string geom_path =
         fmt::format("visualizer/box/box/{}", geom_id.get_value());
-    diagram->ForcedPublish(*context);
+    EXPECT_TRUE(diagram->ForcedPublish(*context).is_good());
 
     // If the geometry had a zero alpha, it's promoted to the default (100%).
     // If the geometry already had a non-zero alpha, it remains unchanged.
@@ -596,7 +598,7 @@ GTEST_TEST(MeshcatVisualizerTest, AlphaSliderCheckResults) {
     // If the test case specifies a <100% alpha, move the slider and republish.
     if (scenario.slider_value != 1.0) {
       meshcat->SetSliderValue("visualizer α", scenario.slider_value);
-      diagram->ForcedPublish(*context);
+      EXPECT_TRUE(diagram->ForcedPublish(*context).is_good());
     }
 
     // Check to see whether the visualizer adjusted the alpha value with a

--- a/manipulation/models/ycb/test/parse_test.cc
+++ b/manipulation/models/ycb/test/parse_test.cc
@@ -91,7 +91,7 @@ TEST_P(ParseTest, Quantities) {
   // Display the object; optionally wait for user input.
   drake::log()->info("Visualize: {}", object_name);
   auto context = diagram->CreateDefaultContext();
-  diagram->ForcedPublish(*context);
+  EXPECT_TRUE(diagram->ForcedPublish(*context).is_good());
   if (FLAGS_pause) {
     WaitForNextButtonClick();
   }

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -110,7 +110,7 @@ class ContactVisualizerTest : public ::testing::Test {
   void PublishAndCheck(
       bool expect_geometry_names = false) {
     EXPECT_EQ(visualizer_->get_name(), "meshcat_contact_visualizer");
-    diagram_->ForcedPublish(*context_);
+    EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
     if (expect_geometry_names) {
       EXPECT_TRUE(meshcat_->HasPath(
           "contact_forces/point/sphere1::sphere.base_link+"
@@ -195,7 +195,7 @@ TEST_F(ContactVisualizerTest, Parameters) {
   // visualization; they are partially covered by meshcat_manual_test.
   SetUpDiagram(0, false, params);
 
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_FALSE(meshcat_->HasPath("contact_forces"));
   EXPECT_TRUE(meshcat_->HasPath("test_prefix"));
 
@@ -210,13 +210,13 @@ TEST_F(ContactVisualizerTest, Parameters) {
 TEST_F(ContactVisualizerTest, Delete) {
   SetUpDiagram();
 
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_TRUE(meshcat_->HasPath("contact_forces"));
 
   visualizer_->Delete();
   EXPECT_FALSE(meshcat_->HasPath("contact_forces"));
 
-  diagram_->ForcedPublish(*context_);
+  EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   EXPECT_TRUE(meshcat_->HasPath("contact_forces"));
 }
 
@@ -243,7 +243,7 @@ TEST_F(ContactVisualizerTest, ScalarConversion) {
 
   // Call publish to provide code coverage for the AutoDiffXd version of
   // UpdateMeshcat.  We simply confirm that the code doesn't blow up.
-  ad_diagram->ForcedPublish(*ad_context);
+  EXPECT_TRUE(ad_diagram->ForcedPublish(*ad_context).is_good());
 }
 
 }  // namespace

--- a/multibody/optimization/test/static_equilibrium_problem_test.cc
+++ b/multibody/optimization/test/static_equilibrium_problem_test.cc
@@ -175,8 +175,10 @@ GTEST_TEST(TestStaticEquilibriumProblem, TwoSpheresWithinBin) {
 
           free_spheres_double.plant().SetPositions(
               free_spheres_double.get_mutable_plant_context(), q_sol);
-          free_spheres_double.get_mutable_diagram()->ForcedPublish(
-              free_spheres_double.diagram_context());
+          const systems::EventStatus status =
+              free_spheres_double.get_mutable_diagram()->ForcedPublish(
+                  free_spheres_double.diagram_context());
+          EXPECT_TRUE(status.is_good());
           const double tol = 2E-5;
           EXPECT_NEAR(q_sol.head<4>().squaredNorm(), 1, tol);
           EXPECT_NEAR(q_sol.segment<4>(7).squaredNorm(), 1, tol);

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -205,7 +205,7 @@ class HydroelasticModelTests : public ::testing::Test {
     // Set initial condition.
     const RigidTransformd X_WB(Vector3d(0.0, 0.0, kSphereRadius));
     plant_->SetFreeBodyPose(&plant_context, *body_, X_WB);
-    diagram_->ForcedPublish(diagram_context);
+    EXPECT_TRUE(diagram_->ForcedPublish(diagram_context).is_good());
 
     // Run simulation for long enough to reach the steady state.
     simulator.AdvanceTo(0.5);

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -2098,8 +2098,10 @@ GTEST_TEST(SimulatorTest, Initialization) {
     InitializationTestSystem() {
       PublishEvent<double> pub_event(
           TriggerType::kInitialization,
-          std::bind(&InitializationTestSystem::InitPublish, this,
-                    std::placeholders::_1, std::placeholders::_2));
+          [this](const Context<double>& context,
+                 const PublishEvent<double>& event) {
+            this->InitPublish(context, event);
+          });
       DeclareInitializationEvent(pub_event);
 
       DeclareInitializationEvent(DiscreteUpdateEvent<double>(

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -425,7 +425,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // For each subsystem, if there is a publish event in its corresponding
   // subevent collection, calls its Publish method with the appropriate
   // subcontext and subevent collection.
-  void DispatchPublishHandler(
+  [[nodiscard]] EventStatus DispatchPublishHandler(
       const Context<T>& context,
       const EventCollection<PublishEvent<T>>& event_info) const final;
 

--- a/systems/framework/event_status.h
+++ b/systems/framework/event_status.h
@@ -44,6 +44,9 @@ class EventStatus {
     kFailed = 3
   };
 
+  /** Constructs an %EventStatus indicating nothing happened. */
+  EventStatus() : EventStatus(kDidNothing) {}
+
   /** Returns "did nothing" status, with no message. */
   static EventStatus DidNothing() { return EventStatus(kDidNothing); }
 
@@ -60,6 +63,15 @@ class EventStatus {
   static EventStatus Failed(const SystemBase* system, std::string message) {
     return EventStatus(kFailed, system, std::move(message));
   }
+
+  /** Returns `true` if the status is DidNothing or Succeeded. */
+  bool is_good() const { return severity() <= kSucceeded; }
+
+  /** Returns `true` if the status is Failed. */
+  bool failed() const { return severity() == kFailed; }
+
+  /** Returns `true` if the status is DidNothing. */
+  bool did_nothing() const { return severity() == kDidNothing; }
 
   /** Returns the severity of the current status. */
   Severity severity() const { return severity_; }
@@ -79,7 +91,7 @@ class EventStatus {
   `candidate` severity is less than or equal to `this` severity. This method is
   for use in event dispatchers for accumulating status returns from a series of
   event handlers for a set of simultaneous events. */
-  EventStatus& KeepMoreSevere(EventStatus candidate) {
+  EventStatus& KeepMoreSevere(const EventStatus& candidate) {
     if (candidate.severity() > severity()) *this = candidate;
     return *this;
   }

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -252,8 +252,10 @@ class System : public SystemBase {
   so that a step begins exactly at the next publication time. In the latter
   case the change in step size may affect the numerical result somewhat
   since a smaller integrator step produces a more accurate solution. */
-  void Publish(const Context<T>& context,
-               const EventCollection<PublishEvent<T>>& events) const;
+  // TODO(sherm1) Remove the nodiscard before merging.
+  [[nodiscard]] EventStatus Publish(
+      const Context<T>& context,
+      const EventCollection<PublishEvent<T>>& events) const;
 
   /** (Advanced) Manually triggers any PublishEvent that has trigger
   type kForced. Invokes the publish event dispatcher on this %System with the
@@ -273,7 +275,8 @@ class System : public SystemBase {
 
   @see Publish(), CalcForcedDiscreteVariableUpdate(),
        CalcForcedUnrestrictedUpdate() */
-  void ForcedPublish(const Context<T>& context) const;
+  // TODO(sherm1) Remove the nodiscard before merging.
+  [[nodiscard]] EventStatus ForcedPublish(const Context<T>& context) const;
   //@}
 
   //----------------------------------------------------------------------------
@@ -738,7 +741,9 @@ class System : public SystemBase {
   Note that this is not fully equivalent to Simulator::Initialize() because
   _only_ initialization events are handled here, while Simulator::Initialize()
   also processes other events associated with time zero. */
-  void ExecuteInitializationEvents(Context<T>* context) const;
+  // TODO(sherm1) Remove the nodiscard before merging.
+  [[nodiscard]] EventStatus ExecuteInitializationEvents(
+      Context<T>* context) const;
 
   /** Determines whether there exists a unique periodic timing (offset and
   period) that triggers one or more discrete update events (and, if so, returns
@@ -1531,7 +1536,7 @@ class System : public SystemBase {
 
   /** This function dispatches all publish events to the appropriate
   handlers. */
-  virtual void DispatchPublishHandler(
+  [[nodiscard]] virtual EventStatus DispatchPublishHandler(
       const Context<T>& context,
       const EventCollection<PublishEvent<T>>& events) const = 0;
 

--- a/systems/framework/test_utilities/initialization_test_system.h
+++ b/systems/framework/test_utilities/initialization_test_system.h
@@ -14,10 +14,11 @@ namespace systems {
 class InitializationTestSystem : public LeafSystem<double> {
  public:
   InitializationTestSystem() {
-    PublishEvent<double> pub_event(
-        TriggerType::kInitialization,
-        std::bind(&InitializationTestSystem::InitPublish, this,
-                  std::placeholders::_1, std::placeholders::_2));
+    PublishEvent<double> pub_event(TriggerType::kInitialization,
+                                   [this](const Context<double>& context,
+                                          const PublishEvent<double>& event) {
+                                     this->InitPublish(context, event);
+                                   });
     DeclareInitializationEvent(pub_event);
 
     DeclareDiscreteState(1);

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -93,26 +93,26 @@ void GenerateLog() {
   auto context1 = pub1->CreateDefaultContext();
 
   SetInput(0.1, "Ch0", 1, pub0->get_input_port(), context0.get());
-  pub0->ForcedPublish(*context0);
+  EXPECT_TRUE(pub0->ForcedPublish(*context0).is_good());
 
   SetInput(0.22, "Ch1", 2, pub1->get_input_port(), context1.get());
-  pub1->ForcedPublish(*context1);
+  EXPECT_TRUE(pub1->ForcedPublish(*context1).is_good());
 
   // Testing multiple messages sent to the same channel at the same time.
   // Only the last one should be visible from the Subscriber's point of view.
   SetInput(0.3, "Ch0", 3, pub0->get_input_port(), context0.get());
-  pub0->ForcedPublish(*context0);
+  EXPECT_TRUE(pub0->ForcedPublish(*context0).is_good());
   SetInput(0.3, "Ch0", 4, pub0->get_input_port(), context0.get());
-  pub0->ForcedPublish(*context0);
+  EXPECT_TRUE(pub0->ForcedPublish(*context0).is_good());
   SetInput(0.3, "Ch0", 5, pub0->get_input_port(), context0.get());
-  pub0->ForcedPublish(*context0);
+  EXPECT_TRUE(pub0->ForcedPublish(*context0).is_good());
 
   // Testing sending a message to a different channel at the same time.
   SetInput(0.3, "Ch1", 6, pub1->get_input_port(), context1.get());
-  pub1->ForcedPublish(*context1);
+  EXPECT_TRUE(pub1->ForcedPublish(*context1).is_good());
 
   SetInput(0.4, "Ch1", 7, pub1->get_input_port(), context1.get());
-  pub1->ForcedPublish(*context1);
+  EXPECT_TRUE(pub1->ForcedPublish(*context1).is_good());
 }
 
 void CheckLog(const std::vector<double>& expected_times,

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -72,8 +72,8 @@ GTEST_TEST(LcmPublisherSystemTest, TestInitializationEvent) {
   // Simulator::Initialize() behavior.
   auto init_events = dut1->AllocateCompositeEventCollection();
   dut1->GetInitializationEvents(*context, &*init_events);
-  dut1->Publish(*context, init_events->get_publish_events());
-
+  EXPECT_TRUE(
+      dut1->Publish(*context, init_events->get_publish_events()).is_good());
   EXPECT_TRUE(init_was_called);
 
   // Nothing should have been published to this channel.
@@ -101,7 +101,7 @@ GTEST_TEST(LcmPublisherSystemTest, SerializerTest) {
 
   // Verifies that a correct message is published.
   Subscriber sub(&interface, channel_name);
-  dut->ForcedPublish(*context.get());
+  EXPECT_TRUE(dut->ForcedPublish(*context.get()).is_good());
   interface.HandleSubscriptions(0);
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(sub.message(), sample_data));
 }
@@ -186,7 +186,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestForcedPublishTrigger) {
   dut->get_input_port().FixValue(context.get(), lcmt_drake_signal{});
 
   for (int i = 0; i < force_publish_count; i++) {
-    dut->ForcedPublish(*context);
+    EXPECT_TRUE(dut->ForcedPublish(*context).is_good());
     interface.HandleSubscriptions(0);
   }
 

--- a/systems/primitives/test/vector_log_sink_test.cc
+++ b/systems/primitives/test/vector_log_sink_test.cc
@@ -164,7 +164,7 @@ GTEST_TEST(TestVectorLogSink, ForcedPublishOnly) {
 
   EXPECT_EQ(log.num_samples(), 0);
 
-  diagram->ForcedPublish(*context);
+  EXPECT_TRUE(diagram->ForcedPublish(*context).is_good());
   EXPECT_EQ(log.num_samples(), 1);
 }
 
@@ -182,7 +182,7 @@ GTEST_TEST(TestVectorLogSink, NoForcedPublish) {
 
   EXPECT_EQ(log.num_samples(), 0);
 
-  diagram->ForcedPublish(*context);
+  EXPECT_TRUE(diagram->ForcedPublish(*context).is_good());
   EXPECT_EQ(log.num_samples(), 0);
 }
 

--- a/systems/sensors/test/image_writer_test.cc
+++ b/systems/sensors/test/image_writer_test.cc
@@ -300,7 +300,8 @@ class ImageWriterTest : public ::testing::Test {
         port_name, tester.port_count(port.get_index()));
     fs::path expected_file(expected_name);
     EXPECT_FALSE(fs::exists(expected_file));
-    writer.Publish(*context, events->get_publish_events());
+    EXPECT_TRUE(
+        writer.Publish(*context, events->get_publish_events()).is_good());
     EXPECT_TRUE(fs::exists(expected_file));
     EXPECT_EQ(1, tester.port_count(port.get_index()));
     add_file_for_cleanup(expected_file.string());
@@ -660,7 +661,8 @@ TEST_F(ImageWriterTest, SingleConfiguredPort) {
           port_name, tester.port_count(port.get_index()));
       fs::path expected_file(expected_name);
       EXPECT_FALSE(fs::exists(expected_file));
-      writer.Publish(*context, events->get_publish_events());
+      EXPECT_TRUE(
+          writer.Publish(*context, events->get_publish_events()).is_good());
       EXPECT_TRUE(fs::exists(expected_file));
       EXPECT_EQ(1, tester.port_count(port.get_index()));
       add_file_for_cleanup(expected_file.string());

--- a/visualization/meshcat_pose_sliders.cc
+++ b/visualization/meshcat_pose_sliders.cc
@@ -210,12 +210,15 @@ RigidTransformd MeshcatPoseSliders<T>::Run(
   using Duration = std::chrono::duration<double>;
   const auto start_time = Clock::now();
 
-  system.ExecuteInitializationEvents(root_context.get());
+  systems::EventStatus status =
+      system.ExecuteInitializationEvents(root_context.get());
+  DRAKE_DEMAND(status.is_good());
 
   RigidTransformd pose = nominal_pose_;
 
   // Loop until the button is clicked, or the timeout (when given) is reached.
-  system.ForcedPublish(system_context);
+  status = system.ForcedPublish(system_context);
+  DRAKE_DEMAND(status.is_good());
   while (meshcat_->GetButtonClicks(kButtonName) < 1) {
     if (timeout.has_value()) {
       const auto elapsed = Duration(Clock::now() - start_time).count();
@@ -233,7 +236,8 @@ RigidTransformd MeshcatPoseSliders<T>::Run(
     }
 
     pose = new_pose;
-    system.ForcedPublish(system_context);
+    status = system.ForcedPublish(system_context);
+    DRAKE_DEMAND(status.is_good());
   }
 
   return pose;

--- a/visualization/test/inertia_visualizer_test.cc
+++ b/visualization/test/inertia_visualizer_test.cc
@@ -60,7 +60,7 @@ class InertiaVisualizerConfigTest : public ::testing::Test {
 
     diagram_ = builder_.Build();
     context_ = diagram_->CreateDefaultContext();
-    diagram_->ForcedPublish(*context_);
+    EXPECT_TRUE(diagram_->ForcedPublish(*context_).is_good());
   }
 
  protected:


### PR DESCRIPTION
[WIP, design review only please]

This is a first cut at getting the EventStatus plumbing hooked up so failures bubble up through the Simulator. So far:
- Adds EventStatus returns to Event callbacks. Backwards compatible via overloads that wrap status-free callbacks with a lambda that assumes EventStatus::Succeeded().
- Modified just the Publish event pathway to include EventStatus. If the approach seems good I'll add Discrete and Unrestricted events also.
- Currently I put [[nodiscard]] on the status-returning Publish APIs so I can find all the Drake usages and check status there. I'll take nodiscard off before merging so most existing call sites won't need to change.

As written this will be a breaking change only for overrides of the LeafSystem::DoPublish() event dispatcher. Those overrides will now have to have an EventStatus return type rather than void. Those who follow the modern Event callback technique won't need to make a change unless they actually want to return status.

WDYT @jwnimmer-tri ?

Resolves #13799 (eventually)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19980)
<!-- Reviewable:end -->
