### PR TITLE
[py common] Improve error message for un-imported Value<> binding

### DIFF
--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -54,10 +54,13 @@ PYBIND11_MODULE(value, m) {
   auto abstract_stub = [](const std::string& method) {
     return [method](const AbstractValue* self, py::args, py::kwargs) {
       std::string type_name = NiceTypeName::Get(*self);
-      throw std::runtime_error(
-          "This derived class of `AbstractValue`, `" + type_name + "`, " +
-          "is not exposed to pybind11, so `" + method + "` cannot be " +
-          "called. See `AddValueInstantiation` for how to bind it.");
+      throw std::runtime_error(fmt::format(
+          "This C++ derived class of `AbstractValue`, `{}`, is not known to "
+          "Python, so `AbstractValue.{}` cannot be called. One likely source "
+          "of this problem is a missing `import` statement. Or, if the binding "
+          "truly doesn't exist in any module, see `AddValueInstantiation` for "
+          "how to bind it.",
+          type_name, method));
     };
   };
 


### PR DESCRIPTION
A better message for problems like #19985.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19984)
<!-- Reviewable:end -->
