### PR TITLE
[pydrake] Adds `pydrake.systems.sensors` import to the examples 

### DIFF
--- a/bindings/pydrake/examples/examples_py.cc
+++ b/bindings/pydrake/examples/examples_py.cc
@@ -15,6 +15,7 @@ Python examples.
   py::module::import("pydrake.multibody.plant");
   py::module::import("pydrake.systems.framework");
   py::module::import("pydrake.systems.primitives");
+  py::module::import("pydrake.systems.sensors");
 
   // These are in alphabetical order; the modules do not depend on each other.
   internal::DefineExamplesAcrobot(m);


### PR DESCRIPTION
Enables downstream use of drake::sensors.

cc: @jwnimmer-tri for review, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19985)
<!-- Reviewable:end -->
