### PR TITLE
[framework] Propagate EventStatus through Event handlers

### DIFF
--- a/manipulation/kinova_jaco/jaco_command_receiver.cc
+++ b/manipulation/kinova_jaco/jaco_command_receiver.cc
@@ -107,10 +107,11 @@ void JacoCommandReceiver::DoCalcNextUpdateTime(
   *time = context.get_time();
   auto& discrete_events = events->get_mutable_discrete_update_events();
   discrete_events.AddEvent(DiscreteUpdateEvent<double>(
-      [this](const Context<double>& event_context,
+      [this](const System<double>&, const Context<double>& event_context,
              const DiscreteUpdateEvent<double>&,
              DiscreteValues<double>* next_values) {
         LatchInitialPosition(event_context, next_values);
+        return systems::EventStatus::Succeeded();
       }));
 }
 

--- a/manipulation/kuka_iiwa/iiwa_command_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.cc
@@ -118,10 +118,11 @@ void IiwaCommandReceiver::DoCalcNextUpdateTime(
   *time = context.get_time();
   auto& discrete_events = events->get_mutable_discrete_update_events();
   discrete_events.AddEvent(DiscreteUpdateEvent<double>(
-      [this](const Context<double>& event_context,
+      [this](const System<double>&, const Context<double>& event_context,
              const DiscreteUpdateEvent<double>&,
              DiscreteValues<double>* next_values) {
         LatchInitialPosition(event_context, next_values);
+        return systems::EventStatus::Succeeded();
       }));
 }
 

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -862,6 +862,15 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "event_deprecated_test",
+    copts = ["-Wno-deprecated-declarations"],
+    deps = [
+        ":event_collection",
+        "//systems/primitives:pass_through",
+    ],
+)
+
+drake_cc_googletest(
     name = "leaf_context_test",
     deps = [
         ":leaf_context",

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -7,6 +7,7 @@
 #include <variant>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/value.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/continuous_state.h"
@@ -401,29 +402,30 @@ enum class TriggerType {
  */
 using TriggerTypeSet = std::unordered_set<TriggerType, DefaultHash>;
 
-/**
- * Abstract base class that represents an event. The base event contains two
- * main pieces of information: an enum trigger type and an optional attribute
- * that can be used to explain why the event is triggered.
- * Derived classes should contain a function pointer to an optional callback
- * function that handles the event. See @ref event_callbacks for detail.
- * No-op is the default handling behavior.  Currently, the System framework
- * supports three concrete event types: PublishEvent, DiscreteUpdateEvent,
- * and UnrestrictedUpdateEvent distinguished by their callback functions' write
- * access level to the State.
- *
- * Event handling occurs during a simulation of a system. The logic that
- * describes when particular event types are handled is described in the
- * class documentation for Simulator.
- */
+/** Abstract base class that represents an event. The base event contains two
+main pieces of information: an enum trigger type and an optional attribute
+that can be used to explain why the event is triggered.
+
+Concrete derived classes contain a function pointer to an optional callback that
+handles the event. No-op is the default handling behavior.  The System framework
+supports three concrete event types: PublishEvent, DiscreteUpdateEvent, and
+UnrestrictedUpdateEvent distinguished by their callback functions' write access
+level to the State.
+
+The most common and convenient use of events and callbacks will happen via the
+LeafSystem Declare*Event() methods. To that end, the callback signature always
+passes the `const %System<T>&` as the first argument, so that %LeafSystem does
+not need to capture `this` into the lambda; typically only a pointer-to-member-
+function is captured. Capturing any more than that would defeat std::function's
+small buffer optimization and cause heap allocations when scheduling events.
+
+%Event handling occurs during a simulation of a system. The logic that describes
+when particular event types are handled is described in the class documentation
+for Simulator. */
 template <typename T>
 class Event {
  public:
-  #ifndef DRAKE_DOXYGEN_CXX
-  // Constructs an Event with no trigger type and no event data.
-  Event() { trigger_type_ = TriggerType::kUnknown; }
-  virtual ~Event() {}
-  #endif
+  virtual ~Event() = default;
 
   // TODO(eric.cousineau): Deprecate and remove this alias.
   using TriggerType = systems::TriggerType;
@@ -481,18 +483,17 @@ class Event {
     return std::get_if<EventDataType>(&event_data_);
   }
 
-  // Note: Users should not be calling these.
-  #if !defined(DRAKE_DOXYGEN_CXX)
-  // Sets the trigger type.
+#if !defined(DRAKE_DOXYGEN_CXX)
+  /* (Internal use only) Sets the trigger type. */
   void set_trigger_type(const TriggerType trigger_type) {
     trigger_type_ = trigger_type; }
 
-  // Sets data to one of the available variants.
+  /* (Internal use only) Sets data to one of the available variants. */
   template <typename EventDataType>
   void set_event_data(EventDataType data) {
     event_data_ = std::move(data);
   }
-  #endif
+#endif
 
   /**
    * Adds a clone of `this` event to the event collection `events`, with
@@ -524,11 +525,13 @@ class Event {
  protected:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Event);
 
-  // Note: Users should not be calling this.
-  #if !defined(DRAKE_DOXYGEN_CXX)
-  // Constructs an Event with the specified @p trigger.
+  /** Constructs an empty Event. */
+  Event() = default;
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+  /* (Internal use only) */
   explicit Event(const TriggerType& trigger) : trigger_type_(trigger) {}
-  #endif
+#endif
 
   /**
    * Derived classes must implement this to add a clone of this Event to
@@ -563,39 +566,11 @@ struct PeriodicEventDataComparator {
   }
 };
 
-/** @defgroup event_callbacks Event Callbacks
-    @ingroup technical_notes
-
- The derived subclasses of Event<T> support two different type signatures for
- callbacks. They differ by whether a System<T>& argument is present. For this
- discussion, call them legacy (no system) callbacks and system callbacks.
-
- One goal of offering both signatures is to support the possibility of
- simulation without heap transactions after initialization. The motivation is
- to enable certain kinds of soft real-time applications of Drake; see #14543
- for more detail. Even with careful support within Drake, implementers of such
- systems need to analyze and test carefully to see the heap proscription is
- maintained.
-
- The most common and convenient use of events and callbacks will be indirect,
- via the LeafSystem Declare*Event() methods. The system callbacks permit those
- methods to avoid heap usage induced in std::function by lambdas with captures
- of a certain size. Empirically, the capture of an ordinary pointer and a
- (wider) pointer-to-member-function are enough to induce heap allocations.
-
- Direct clients of the event callbacks here may prefer the legacy callback,
- together with a lambda capture of a pointer of the exact type needed. This
- technique avoids a down-cast within the callback body. However, if other
- captures are also necessary, the system callback (with a down-cast) may help
- avoid heap use.
-*/
-// TODO(rpoyner-tri): extend the support described above to all subclasses.
-
 /**
  * This class represents a publish event. It has an optional callback function
- * (two forms are supported) to do custom handling of this event. @see
- * System::Publish for more details. @see LeafSystem for more convenient
- * interfaces to publish events via the Declare*PublishEvent() methods.
+ * to do custom handling of this event. @see System::Publish for more details.
+ * @see LeafSystem for more convenient interfaces to publish events via the
+ * Declare*PublishEvent() methods.
  */
 template <typename T>
 class PublishEvent final : public Event<T> {
@@ -603,76 +578,115 @@ class PublishEvent final : public Event<T> {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PublishEvent);
   bool is_discrete_update() const override { return false; }
 
-  /** @name Publish Callbacks
-   *
-   * Two callback signatures are supported. See @ref event_callbacks for a
-   * complete discussion. Both callback types receive a const reference to the
-   * context and this publish event. They differ in whether a const reference
-   * to the owning system is also provided.
-   */
-  ///@{
-  /**
-   * Callback without system reference.
-   */
-  typedef std::function<void(const Context<T>&, const PublishEvent<T>&)>
-      PublishCallback;
+  /** (Deprecated.) */
+  using PublishCallback DRAKE_DEPRECATED(
+      "2023-12-01",
+      "Callbacks must accept a `const System<T>&` as their first argument "
+      "and return an EventStatus, not void.") =
+      std::function<void(const Context<T>&, const PublishEvent<T>&)>;
 
-  /**
-   * Callback with const system reference.
-   */
-  typedef std::function<void(const System<T>&, const Context<T>&,
-                             const PublishEvent<T>&)> SystemCallback;
-  ///@}
+  /** (Deprecated.) */
+  using SystemCallback DRAKE_DEPRECATED(
+      "2023-12-01", "Callbacks must return an EventStatus, not void.") =
+      std::function<void(const System<T>&, const Context<T>&,
+                         const PublishEvent<T>&)>;
 
-  /// Makes a PublishEvent with no trigger type, no event data, and
-  /// no specified callback function.
-  PublishEvent() : Event<T>() {}
+  /** Constructs an empty PublishEvent. */
+  PublishEvent() = default;
 
-  /// Makes a PublishEvent with no trigger type, no event data, and
-  /// the specified callback function.
-  explicit PublishEvent(const PublishCallback& callback)
-      : Event<T>(), callback_(callback) {}
+  /** Constructs a PublishEvent with the given callback function.
 
-  /// Makes a PublishEvent with no trigger type, no event data, and
-  /// the specified system callback function.
-  explicit PublishEvent(const SystemCallback& system_callback)
-      : Event<T>(), system_callback_(system_callback) {}
+  The following three callback signatures are supported:
+  - `(const System<T>& const Context<T>&,
+      const PublishEvent<T>&) -> EventStatus`
+  - `(const System<T>& const Context<T>&,
+     const PublishEvent<T>&) -> void`
+  - `(const Context<T>&,
+      const PublishEvent<T>&) -> void`
 
-  // Note: Users should not be calling these.
-  #if !defined(DRAKE_DOXYGEN_CXX)
-  // Makes a PublishEvent with `trigger_type`, no event data, and
-  // callback function `callback`, which can be null.
-  PublishEvent(const TriggerType& trigger_type,
-               const PublishCallback& callback)
-      : Event<T>(trigger_type), callback_(callback) {}
+  @warning All signatures except the first one are deprecated and will be
+  removed from Drake on or after 2023-12-01. */
+  template <typename Function>
+  explicit PublishEvent(const Function& callback) {
+    set_callback(callback);
+  }
 
-  // Makes a PublishEvent with `trigger_type`, no event data, and
-  // system callback function `system_callback`, which can be null.
-  PublishEvent(const TriggerType& trigger_type,
-               const SystemCallback& system_callback)
-      : Event<T>(trigger_type), system_callback_(system_callback) {}
+#if !defined(DRAKE_DOXYGEN_CXX)
+  /* (Internal use only) */
+  explicit PublishEvent(const TriggerType& trigger_type) {
+    this->set_trigger_type(trigger_type);
+  }
+  /* (Internal use only) */
+  template <typename Function>
+  PublishEvent(const TriggerType& trigger_type, const Function& callback) {
+    this->set_trigger_type(trigger_type);
+    this->set_callback(callback);
+  }
+#endif
 
-  // Makes a PublishEvent with `trigger_type`, no event data, and
-  // no specified callback function.
-  explicit PublishEvent(const TriggerType& trigger_type)
-      : Event<T>(trigger_type) {}
-  #endif
-
+  // TODO(jwnimmer-tri) Annotate [[nodiscard]] on the return value.
+  // Possibly fix CamelCase at the same time, e.g., InvokeCallback().
   /**
    * Calls the optional callback or system callback function, if one exists,
    * with @p system, @p context, and `this`.
    */
-  void handle(const System<T>& system, const Context<T>& context) const {
-    // At most one callback can be set.
-    DRAKE_ASSERT(!(callback_ && system_callback_));
-    if (callback_ != nullptr) {
-      callback_(context, *this);
-    } else if (system_callback_ != nullptr) {
-      system_callback_(system, context, *this);
-    }
+  EventStatus handle(const System<T>& system, const Context<T>& context) const {
+    return (callback_ != nullptr) ? callback_(system, context, *this)
+                                  : EventStatus::DidNothing();
   }
 
  private:
+  // This overload matches SFINAE iff the given Function uses the "modern"
+  // spelling of the callback signature (i.e., returns an EventStatus). On
+  // 2023-12-01 once the other overloads disappear, we can nix the SFINAE.
+  template <typename Function,
+            // When SFINAE matches, this argument will be `void* = nullptr`.
+            std::enable_if_t<std::is_same_v<
+                EventStatus, std::invoke_result_t<
+                                 Function, const System<T>&, const Context<T>&,
+                                 const PublishEvent<T>&>>>* = nullptr>
+  void set_callback(const Function& callback) {
+    callback_ = callback;
+  }
+
+  // This overload matches SFINAE iff the given Function uses the legacy
+  // PublishCallback spelling of the callback signature.
+  template <typename Function,
+            // When SFINAE matches, this argument will be `void* = nullptr`.
+            std::enable_if_t<std::is_same_v<
+                void, std::invoke_result_t<Function, const Context<T>&,
+                                           const PublishEvent<T>&>>>* = nullptr>
+  DRAKE_DEPRECATED(
+      "2023-12-01",
+      "Callbacks must accept a `const System<T>&` as their first argument "
+      "and return an EventStatus, not void.")
+  void set_callback(const Function& legacy_callback) {
+    callback_ = [legacy_callback](const System<T>&, const Context<T>& context,
+                                  const PublishEvent<T>& event) {
+      legacy_callback(context, event);
+      return EventStatus::Succeeded();
+    };
+  }
+
+  // This overload matches SFINAE iff the given Function uses the legacy
+  // SystemCallback spelling of the callback signature.
+  template <typename Function,
+            // When SFINAE matches, this argument will be `void* = nullptr`.
+            std::enable_if_t<std::is_same_v<
+                void, std::invoke_result_t<Function, const System<T>&,
+                                           const Context<T>&,
+                                           const PublishEvent<T>&>>>* = nullptr>
+  DRAKE_DEPRECATED("2023-12-01",
+                   "Callbacks must return an EventStatus, not void.")
+  void set_callback(const Function& legacy_callback) {
+    callback_ = [legacy_callback](const System<T>& system,
+                                  const Context<T>& context,
+                                  const PublishEvent<T>& event) {
+      legacy_callback(system, context, event);
+      return EventStatus::Succeeded();
+    };
+  }
+
   void DoAddToComposite(TriggerType trigger_type,
                         CompositeEventCollection<T>* events) const final {
     PublishEvent event(*this);
@@ -685,19 +699,19 @@ class PublishEvent final : public Event<T> {
     return new PublishEvent(*this);
   }
 
-  // Optional callback functions that handle this publish event. At most one
-  // callback can be set; whichever one is set will be invoked. It is valid for
-  // no callback to be set.
-  PublishCallback callback_{nullptr};
-  SystemCallback system_callback_{nullptr};
+  // Optional callback function that handles this event.
+  // It is valid for no callback to be set.
+  std::function<EventStatus(const System<T>&, const Context<T>&,
+                            const PublishEvent<T>&)>
+      callback_;
 };
 
 /**
  * This class represents a discrete update event. It has an optional callback
- * function (two forms are supported) to do custom handling of this event, and
- * that can write updates to a mutable, non-null DiscreteValues object.  @see
- * LeafSystem for more convenient interfaces to discrete update events via the
- * Declare*DiscreteUpdateEvent() methods.
+ * function to do custom handling of this event, and that can write updates to a
+ * mutable, non-null DiscreteValues object.  @see LeafSystem for more convenient
+ * interfaces to discrete update events via the Declare*DiscreteUpdateEvent()
+ * methods.
  */
 template <typename T>
 class DiscreteUpdateEvent final : public Event<T> {
@@ -705,82 +719,124 @@ class DiscreteUpdateEvent final : public Event<T> {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DiscreteUpdateEvent);
   bool is_discrete_update() const override { return true; }
 
-  /** @name Discrete Update Callbacks
-   *
-   * Two callback signatures are supported. See @ref event_callbacks for a
-   * complete discussion. Both callback types receive a const reference to the
-   * context and this discrete update event, and a writable non-null pointer to
-   * discrete state which the callback may write to. They differ in whether a
-   * const reference to the owning system is also provided.
-   */
-  ///@{
-  /**
-   * Callback without system reference.
-   */
-  typedef std::function<void(const Context<T>&, const DiscreteUpdateEvent<T>&,
-                             DiscreteValues<T>*)>
-      DiscreteUpdateCallback;
+  /** (Deprecated.) */
+  using DiscreteUpdateCallback DRAKE_DEPRECATED(
+      "2023-12-01",
+      "Callbacks must accept a `const System<T>&` as their first argument "
+      "and return an EventStatus, not void.") =
+      std::function<void(const Context<T>&, const DiscreteUpdateEvent<T>&,
+                         DiscreteValues<T>*)>;
 
-  /**
-   * Callback with const system reference.
-   */
-  typedef std::function<void(const System<T>&, const Context<T>&,
-                             const DiscreteUpdateEvent<T>&, DiscreteValues<T>*)>
-      SystemCallback;
-  ///@}
+  /** (Deprecated.) */
+  using SystemCallback DRAKE_DEPRECATED(
+      "2023-12-01", "Callbacks must return an EventStatus, not void.") =
+      std::function<void(const System<T>&, const Context<T>&,
+                         const DiscreteUpdateEvent<T>&, DiscreteValues<T>*)>;
 
-  /// Makes a DiscreteUpdateEvent with no trigger type, no event data, and
-  /// no specified callback function.
-  DiscreteUpdateEvent() : Event<T>() {}
+  /** Constructs an empty DiscreteUpdateEvent. */
+  DiscreteUpdateEvent() = default;
 
-  /// Makes a DiscreteUpdateEvent with no trigger type, no event data, and
-  /// the specified callback function.
-  explicit DiscreteUpdateEvent(const DiscreteUpdateCallback& callback)
-      : Event<T>(), callback_(callback) {}
+  /** Constructs a DiscreteUpdateEvent with the given callback function.
 
-  /// Makes a DiscreteUpdateEvent with no trigger type, no event data, and
-  /// the specified system callback function.
-  explicit DiscreteUpdateEvent(const SystemCallback& system_callback)
-      : Event<T>(), system_callback_(system_callback) {}
+  The following three callback signatures are supported:
+  - `(const System<T>& const Context<T>&,
+      const DiscreteUpdateEvent<T>&, DiscreteValues<T>*) -> EventStatus`
+  - `(const System<T>& const Context<T>&,
+      const DiscreteUpdateEvent<T>&, DiscreteValues<T>*) -> void`
+  - `(const Context<T>&,
+      const DiscreteUpdateEvent<T>&, DiscreteValues<T>*) -> void`
 
-  // Note: Users should not be calling these.
-  #if !defined(DRAKE_DOXYGEN_CXX)
-  // Makes a DiscreteUpdateEvent with `trigger_type` with no event data and
-  // the callback function `callback`.
-  // `callback` can be null.
+  @warning All signatures except the first one are deprecated and will be
+  removed from Drake on or after 2023-12-01. */
+  template <typename Function>
+  explicit DiscreteUpdateEvent(const Function& callback) {
+    set_callback(callback);
+  }
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+  /* (Internal use only) */
+  explicit DiscreteUpdateEvent(const TriggerType& trigger_type) {
+    this->set_trigger_type(trigger_type);
+  }
+  /* (Internal use only) */
+  template <typename Function>
   DiscreteUpdateEvent(const TriggerType& trigger_type,
-                      const DiscreteUpdateCallback& callback)
-      : Event<T>(trigger_type), callback_(callback) {}
+                      const Function& callback) {
+    this->set_trigger_type(trigger_type);
+    this->set_callback(callback);
+  }
+#endif
 
-  // Makes a DiscreteUpdateEvent with `trigger_type` with no event data and
-  // the system callback function `system_callback`.
-  // `system_callback` can be null.
-  DiscreteUpdateEvent(const TriggerType& trigger_type,
-                      const SystemCallback& system_callback)
-      : Event<T>(trigger_type), system_callback_(system_callback) {}
-
-  // Makes a DiscreteUpdateEvent with @p trigger_type with no event data and
-  // no specified callback function.
-  explicit DiscreteUpdateEvent(const TriggerType& trigger_type)
-      : Event<T>(trigger_type) {}
-  #endif
-
+  // TODO(jwnimmer-tri) Annotate [[nodiscard]] on the return value.
+  // Possibly fix CamelCase at the same time, e.g., InvokeCallback().
   /**
    * Calls the optional callback function, if one exists, with @p system, @p
    * context, `this` and @p discrete_state.
    */
-  void handle(const System<T>& system, const Context<T>& context,
-              DiscreteValues<T>* discrete_state) const {
-    // At most one callback can be set.
-    DRAKE_ASSERT(!(callback_ && system_callback_));
-    if (callback_ != nullptr) {
-      callback_(context, *this, discrete_state);
-    } else if (system_callback_ != nullptr) {
-      system_callback_(system, context, *this, discrete_state);
-    }
+  EventStatus handle(const System<T>& system, const Context<T>& context,
+                     DiscreteValues<T>* discrete_state) const {
+    return (callback_ != nullptr)
+               ? callback_(system, context, *this, discrete_state)
+               : EventStatus::DidNothing();
   }
 
  private:
+  // This overload matches SFINAE iff the given Function uses the "modern"
+  // spelling of the callback signature (i.e., returns an EventStatus).
+  template <typename Function,
+            // When SFINAE matches, this argument will be `void* = nullptr`.
+            std::enable_if_t<std::is_same_v<
+                EventStatus, std::invoke_result_t<
+                                 Function, const System<T>&, const Context<T>&,
+                                 const DiscreteUpdateEvent<T>&,
+                                 DiscreteValues<T>*>>>* = nullptr>
+  void set_callback(const Function& callback) {
+    callback_ = callback;
+  }
+
+  // This overload matches iff the given Function uses the legacy
+  // DiscreteUpdateCallback spelling of the callback signature.
+  template <typename Function,
+            // When SFINAE matches, this argument will be `void* = nullptr`.
+            std::enable_if_t<std::is_same_v<
+                void, std::invoke_result_t<Function, const Context<T>&,
+                                           const DiscreteUpdateEvent<T>&,
+                                           DiscreteValues<T>*>>>* = nullptr>
+  DRAKE_DEPRECATED(
+      "2023-12-01",
+      "Callbacks must accept a `const System<T>&` as their first argument "
+      "and return an EventStatus, not void.")
+  void set_callback(const Function& legacy_callback) {
+    callback_ = [legacy_callback](const System<T>&, const Context<T>& context,
+                                  const DiscreteUpdateEvent<T>& event,
+                                  DiscreteValues<T>* discrete_state) {
+      legacy_callback(context, event, discrete_state);
+      return EventStatus::Succeeded();
+    };
+  }
+
+  // This overload matches iff the given Function uses the legacy
+  // SystemCallback spelling of the callback signature.
+  template <
+      typename Function,
+      // When SFINAE matches, this argument will be `void* = nullptr`.
+      std::enable_if_t<std::is_same_v<
+          void, std::invoke_result_t<
+                    Function, const System<T>&, const Context<T>&,
+                    const DiscreteUpdateEvent<T>&, DiscreteValues<T>*>>>* =
+          nullptr>
+  DRAKE_DEPRECATED("2023-12-01",
+                   "Callbacks must return an EventStatus, not void.")
+  void set_callback(const Function& legacy_callback) {
+    callback_ = [legacy_callback](const System<T>& system,
+                                  const Context<T>& context,
+                                  const DiscreteUpdateEvent<T>& event,
+                                  DiscreteValues<T>* discrete_state) {
+      legacy_callback(system, context, event, discrete_state);
+      return EventStatus::Succeeded();
+    };
+  }
+
   void DoAddToComposite(TriggerType trigger_type,
                         CompositeEventCollection<T>* events) const final {
     DiscreteUpdateEvent<T> event(*this);
@@ -793,19 +849,19 @@ class DiscreteUpdateEvent final : public Event<T> {
     return new DiscreteUpdateEvent(*this);
   }
 
-  // Optional callback functions that handle this discrete update event. At
-  // most one callback can be set; whichever one is set will be invoked. It is
-  // valid for no callback to be set.
-  DiscreteUpdateCallback callback_{nullptr};
-  SystemCallback system_callback_{nullptr};
+  // Optional callback functions that handle this event.
+  // It is valid for no callback to be set.
+  std::function<EventStatus(const System<T>&, const Context<T>&,
+                            const DiscreteUpdateEvent<T>&, DiscreteValues<T>*)>
+      callback_;
 };
 
 /**
  * This class represents an unrestricted update event. It has an optional
- * callback function (two forms are supported) to do custom handling of this
- * event, and that can write updates to a mutable, non-null State object. @see
- * LeafSystem for more convenient interfaces to unrestricted update events via
- * the Declare*UnrestrictedUpdateEvent() methods.
+ * callback function to do custom handling of this event, and that can write
+ * updates to a mutable, non-null State object. @see LeafSystem for more
+ * convenient interfaces to unrestricted update events via the
+ * Declare*UnrestrictedUpdateEvent() methods.
  */
 template <typename T>
 class UnrestrictedUpdateEvent final : public Event<T> {
@@ -813,82 +869,121 @@ class UnrestrictedUpdateEvent final : public Event<T> {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(UnrestrictedUpdateEvent);
   bool is_discrete_update() const override { return false; }
 
-  /** @name Unrestricted Update Callbacks
-   *
-   * Two callback signatures are supported. See @ref event_callbacks for a
-   * complete discussion. Both callback types receive a const reference to the
-   * context and this unrestricted update event, and a writable non-null
-   * pointer to state which the callback may write to. They differ in whether a
-   * const reference to the owning system is also provided.
-   */
-  ///@{
-  /**
-   * Callback without system reference.
-   */
-  typedef std::function<void(const Context<T>&,
-                             const UnrestrictedUpdateEvent<T>&, State<T>*)>
-      UnrestrictedUpdateCallback;
+  /** (Deprecated.) */
+  using UnrestrictedUpdateCallback DRAKE_DEPRECATED(
+      "2023-12-01",
+      "Callbacks must accept a `const System<T>&` as their first argument "
+      "and return an EventStatus, not void.") =
+      std::function<void(const Context<T>&, const UnrestrictedUpdateEvent<T>&,
+                         State<T>*)>;
 
-  /**
-   * Callback with const system reference.
-   */
-  typedef std::function<void(const System<T>&, const Context<T>&,
-                             const UnrestrictedUpdateEvent<T>&, State<T>*)>
-      SystemCallback;
-  ///@}
+  /** (Deprecated.) */
+  using SystemCallback DRAKE_DEPRECATED(
+      "2023-12-01", "Callbacks must return an EventStatus, not void.") =
+      std::function<void(const System<T>&, const Context<T>&,
+                         const UnrestrictedUpdateEvent<T>&, State<T>*)>;
 
-  /// Makes an UnrestrictedUpdateEvent with no trigger type, no event data, and
-  /// no specified callback function.
-  UnrestrictedUpdateEvent() : Event<T>() {}
+  /** Constructs an empty UnrestrictedUpdateEvent. */
+  UnrestrictedUpdateEvent() = default;
 
-  /// Makes a UnrestrictedUpdateEvent with no trigger type, no event data, and
-  /// the specified callback function.
-  explicit UnrestrictedUpdateEvent(const UnrestrictedUpdateCallback& callback)
-      : Event<T>(), callback_(callback) {}
+  /** Constructs an UnrestrictedUpdateEvent with the given callback function.
 
-  /// Makes a UnrestrictedUpdateEvent with no trigger type, no event data, and
-  /// the specified system callback function.
-  explicit UnrestrictedUpdateEvent(
-      const SystemCallback& system_callback)
-      : Event<T>(), system_callback_(system_callback) {}
+  The following three callback signatures are supported:
+  - `(const System<T>& const Context<T>&,
+      const UnrestrictedUpdateEvent<T>&, State<T>*) -> EventStatus`
+  - `(const System<T>& const Context<T>&,
+      const UnrestrictedUpdateEvent<T>&, State<T>*) -> void`
+  - `(const Context<T>&,
+      const UnrestrictedUpdateEvent<T>&, State<T>*) -> void`
 
-  // Note: Users should not be calling these.
-  #if !defined(DRAKE_DOXYGEN_CXX)
-  // Makes an UnrestrictedUpdateEvent with `trigger_type` and callback function
-  // `callback`. `callback` can be null.
+  @warning All signatures except the first one are deprecated and will be
+  removed from Drake on or after 2023-12-01. */
+  template <typename Function>
+  explicit UnrestrictedUpdateEvent(const Function& callback) {
+    set_callback(callback);
+  }
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+  /* (Internal use only) */
+  explicit UnrestrictedUpdateEvent(const TriggerType& trigger_type) {
+    this->set_trigger_type(trigger_type);
+  }
+  /* (Internal use only) */
+  template <typename Function>
   UnrestrictedUpdateEvent(const TriggerType& trigger_type,
-                          const UnrestrictedUpdateCallback& callback)
-      : Event<T>(trigger_type), callback_(callback) {}
+                          const Function& callback) {
+    this->set_trigger_type(trigger_type);
+    this->set_callback(callback);
+  }
+#endif
 
-  // Makes an UnrestrictedUpdateEvent with `trigger_type` and system callback
-  // function `system_callback`. `system_callback` can be null.
-  UnrestrictedUpdateEvent(const TriggerType& trigger_type,
-                          const SystemCallback& system_callback)
-      : Event<T>(trigger_type), system_callback_(system_callback) {}
-
-  // Makes an UnrestrictedUpateEvent with @p trigger_type, no optional data, and
-  // no callback function.
-  explicit UnrestrictedUpdateEvent(
-      const TriggerType& trigger_type)
-      : Event<T>(trigger_type) {}
-  #endif
-
+  // TODO(jwnimmer-tri) Annotate [[nodiscard]] on the return value.
+  // Possibly fix CamelCase at the same time, e.g., InvokeCallback().
   /**
    * Calls the optional callback function, if one exists, with @p system, @p
    * context, `this` and @p state.
    */
-  void handle(const System<T>& system, const Context<T>& context,
-              State<T>* state) const {
-    // At most one callback can be set.
-    DRAKE_ASSERT(!(callback_ && system_callback_));
-    if (callback_ != nullptr) {
-      callback_(context, *this, state);
-    } else if (system_callback_ != nullptr) {
-      system_callback_(system, context, *this, state);
-    }
+  EventStatus handle(const System<T>& system, const Context<T>& context,
+                     State<T>* state) const {
+    return (callback_ != nullptr) ? callback_(system, context, *this, state)
+                                  : EventStatus::DidNothing();
   }
 
  private:
+  // This overload matches SFINAE iff the given Function uses the "modern"
+  // spelling of the callback signature (i.e., returns an EventStatus).
+  template <typename Function,
+            // When SFINAE matches, this argument will be `void* = nullptr`.
+            std::enable_if_t<std::is_same_v<
+                EventStatus,
+                std::invoke_result_t<
+                    Function, const System<T>&, const Context<T>&,
+                    const UnrestrictedUpdateEvent<T>&, State<T>*>>>* = nullptr>
+  void set_callback(const Function& callback) {
+    callback_ = callback;
+  }
+
+  // This overload matches SFINAE iff the given Function uses the legacy
+  // UnrestrictedUpdateCallback spelling of the callback signature.
+  template <typename Function,
+            // When SFINAE matches, this argument will be `void* = nullptr`.
+            std::enable_if_t<std::is_same_v<
+                void, std::invoke_result_t<Function, const Context<T>&,
+                                           const UnrestrictedUpdateEvent<T>&,
+                                           State<T>*>>>* = nullptr>
+  DRAKE_DEPRECATED(
+      "2023-12-01",
+      "Callbacks must accept a `const System<T>&` as their first argument "
+      "and return an EventStatus, not void.")
+  void set_callback(const Function& legacy_callback) {
+    callback_ = [legacy_callback](const System<T>&, const Context<T>& context,
+                                  const UnrestrictedUpdateEvent<T>& event,
+                                  State<T>* state) {
+      legacy_callback(context, event, state);
+      return EventStatus::Succeeded();
+    };
+  }
+
+  // This overload matches SFINAE iff the given Function uses the legacy
+  // SystemCallback spelling of the callback signature.
+  template <
+      typename Function,
+      // When SFINAE matches, this argument will be `void* = nullptr`.
+      std::enable_if_t<std::is_same_v<
+          void, std::invoke_result_t<
+                    Function, const System<T>&, const Context<T>&,
+                    const UnrestrictedUpdateEvent<T>&, State<T>*>>>* = nullptr>
+  DRAKE_DEPRECATED("2023-12-01",
+                   "Callbacks must return an EventStatus, not void.")
+  void set_callback(const Function& legacy_callback) {
+    callback_ = [legacy_callback](
+                    const System<T>& system, const Context<T>& context,
+                    const UnrestrictedUpdateEvent<T>& event, State<T>* state) {
+      legacy_callback(system, context, event, state);
+      return EventStatus::Succeeded();
+    };
+  }
+
   void DoAddToComposite(TriggerType trigger_type,
                         CompositeEventCollection<T>* events) const final {
     UnrestrictedUpdateEvent<T> event(*this);
@@ -901,11 +996,11 @@ class UnrestrictedUpdateEvent final : public Event<T> {
     return new UnrestrictedUpdateEvent(*this);
   }
 
-  // Optional callback functions that handle this unrestricted update event. At
-  // most one callback can be set; whichever one is set will be invoked. It is
-  // valid for no callback to be set.
-  UnrestrictedUpdateCallback callback_{nullptr};
-  SystemCallback system_callback_{nullptr};
+  // Optional callback function that handles this event.
+  // It is valid for no callback to be set.
+  std::function<EventStatus(const System<T>&, const Context<T>&,
+                            const UnrestrictedUpdateEvent<T>&, State<T>*)>
+      callback_;
 };
 
 }  // namespace systems

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -305,8 +305,7 @@ class LeafSystem : public System<T> {
                             const Context<T>& context,
                             const PublishEvent<T>&) {
           const auto& sys = dynamic_cast<const MySystem&>(system);
-          // TODO(sherm1) Forward the return status.
-          (sys.*publish)(context);  // Ignore return status for now.
+          return (sys.*publish)(context);
         }));
   }
 
@@ -334,7 +333,7 @@ class LeafSystem : public System<T> {
                       const PublishEvent<T>&) {
               const auto& sys = dynamic_cast<const MySystem&>(system);
               (sys.*publish)(context);
-              // TODO(sherm1) return EventStatus::Succeeded()
+              return EventStatus::Succeeded();
             }));
   }
 
@@ -375,8 +374,7 @@ class LeafSystem : public System<T> {
                      const DiscreteUpdateEvent<T>&,
                      DiscreteValues<T>* xd) {
               const auto& sys = dynamic_cast<const MySystem&>(system);
-              // TODO(sherm1) Forward the return status.
-              (sys.*update)(context, &*xd);  // Ignore return status for now.
+              return (sys.*update)(context, &*xd);
             }));
   }
 
@@ -406,7 +404,7 @@ class LeafSystem : public System<T> {
                      DiscreteValues<T>* xd) {
               const auto& sys = dynamic_cast<const MySystem&>(system);
               (sys.*update)(context, &*xd);
-              // TODO(sherm1) return EventStatus::Succeeded()
+              return EventStatus::Succeeded();
             }));
   }
 
@@ -444,8 +442,7 @@ class LeafSystem : public System<T> {
                      const Context<T>& context,
                      const UnrestrictedUpdateEvent<T>&, State<T>* x) {
               const auto& sys = dynamic_cast<const MySystem&>(system);
-              // TODO(sherm1) Forward the return status.
-              (sys.*update)(context, &*x);  // Ignore return status for now.
+              return (sys.*update)(context, &*x);
             }));
   }
 
@@ -472,7 +469,7 @@ class LeafSystem : public System<T> {
                      const UnrestrictedUpdateEvent<T>&, State<T>* x) {
               const auto& sys = dynamic_cast<const MySystem&>(system);
               (sys.*update)(context, &*x);
-              // TODO(sherm1) return EventStatus::Succeeded()
+              return EventStatus::Succeeded();
             }));
   }
 
@@ -624,8 +621,7 @@ class LeafSystem : public System<T> {
         [publish](const System<T>& system, const Context<T>& context,
                   const PublishEvent<T>&) {
           const auto& sys = dynamic_cast<const MySystem&>(system);
-          // TODO(sherm1) Forward the return status.
-          (sys.*publish)(context);  // Ignore return status for now.
+          return (sys.*publish)(context);
         }));
   }
 
@@ -662,8 +658,7 @@ class LeafSystem : public System<T> {
             [update](const System<T>& system, const Context<T>& context,
                      const DiscreteUpdateEvent<T>&, DiscreteValues<T>* xd) {
               const auto& sys = dynamic_cast<const MySystem&>(system);
-              // TODO(sherm1) Forward the return status.
-              (sys.*update)(context, &*xd);  // Ignore return status for now.
+              return (sys.*update)(context, &*xd);
             }));
   }
 
@@ -699,8 +694,7 @@ class LeafSystem : public System<T> {
         [update](const System<T>& system, const Context<T>& context,
                  const UnrestrictedUpdateEvent<T>&, State<T>* x) {
           const auto& sys = dynamic_cast<const MySystem&>(system);
-          // TODO(sherm1) Forward the return status.
-          (sys.*update)(context, &*x);  // Ignore return status for now.
+          return (sys.*update)(context, &*x);
         }));
   }
 
@@ -786,10 +780,10 @@ class LeafSystem : public System<T> {
 
     DeclareInitializationEvent<PublishEvent<T>>(PublishEvent<T>(
         TriggerType::kInitialization,
-        [this_ptr, publish](const Context<T>& context,
-                            const PublishEvent<T>&) {
-          // TODO(sherm1) Forward the return status.
-          (this_ptr->*publish)(context);  // Ignore return status for now.
+        [publish](const System<T>& system, const Context<T>& context,
+                  const PublishEvent<T>&) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
+          return (sys.*publish)(context);
         }));
   }
 
@@ -824,12 +818,10 @@ class LeafSystem : public System<T> {
 
     DeclareInitializationEvent(DiscreteUpdateEvent<T>(
         TriggerType::kInitialization,
-        [this_ptr, update](const Context<T>& context,
-                           const DiscreteUpdateEvent<T>&,
-                           DiscreteValues<T>* xd) {
-          // TODO(sherm1) Forward the return status.
-          (this_ptr->*update)(context,
-                              &*xd);  // Ignore return status for now.
+        [update](const System<T>& system, const Context<T>& context,
+                 const DiscreteUpdateEvent<T>&, DiscreteValues<T>* xd) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
+          return (sys.*update)(context, &*xd);
         }));
   }
 
@@ -864,11 +856,10 @@ class LeafSystem : public System<T> {
 
     DeclareInitializationEvent(UnrestrictedUpdateEvent<T>(
         TriggerType::kInitialization,
-        [this_ptr, update](const Context<T>& context,
-                           const UnrestrictedUpdateEvent<T>&, State<T>* x) {
-          // TODO(sherm1) Forward the return status.
-          (this_ptr->*update)(context,
-                              &*x);  // Ignore return status for now.
+        [update](const System<T>& system, const Context<T>& context,
+                 const UnrestrictedUpdateEvent<T>&, State<T>* x) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
+          return (sys.*update)(context, &*x);
         }));
   }
 
@@ -959,9 +950,10 @@ class LeafSystem : public System<T> {
     // Instantiate the event.
     PublishEvent<T> forced(
         TriggerType::kForced,
-        [this_ptr, publish](const Context<T>& context, const PublishEvent<T>&) {
-          // TODO(sherm1) Forward the return status.
-          (this_ptr->*publish)(context);  // Ignore return status for now.
+        [publish](const System<T>& system, const Context<T>& context,
+                  const PublishEvent<T>&) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
+          return (sys.*publish)(context);
         });
 
     // Add the event to the collection of forced publish events.
@@ -997,12 +989,11 @@ class LeafSystem : public System<T> {
     // Instantiate the event.
     DiscreteUpdateEvent<T> forced(
         TriggerType::kForced,
-        [this_ptr, update](const Context<T>& context,
-                           const DiscreteUpdateEvent<T>&,
-                           DiscreteValues<T>* discrete_state) {
-          // TODO(sherm1) Forward the return status.
-          (this_ptr->*update)(
-              context, discrete_state);  // Ignore return status for now.
+        [update](const System<T>& system, const Context<T>& context,
+                 const DiscreteUpdateEvent<T>&,
+                 DiscreteValues<T>* discrete_state) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
+          return (sys.*update)(context, discrete_state);
         });
 
     // Add the event to the collection of forced discrete update events.
@@ -1039,10 +1030,10 @@ class LeafSystem : public System<T> {
     // Instantiate the event.
     UnrestrictedUpdateEvent<T> forced(
         TriggerType::kForced,
-        [this_ptr, update](const Context<T>& context,
-                           const UnrestrictedUpdateEvent<T>&, State<T>* state) {
-          // TODO(sherm1) Forward the return status.
-          (this_ptr->*update)(context, state);  // Ignore return status for now.
+        [update](const System<T>& system, const Context<T>& context,
+                 const UnrestrictedUpdateEvent<T>&, State<T>* state) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
+          return (sys.*update)(context, state);
         });
 
     // Add the event to the collection of forced unrestricted update events.
@@ -1625,16 +1616,16 @@ class LeafSystem : public System<T> {
           const Context<T>&, const PublishEvent<T>&) const) const {
     static_assert(std::is_base_of_v<LeafSystem<T>, MySystem>,
                   "Expected to be invoked from a LeafSystem-derived system.");
-    auto fn = [this, publish_callback](
-        const Context<T>& context, const PublishEvent<T>& publish_event) {
-      auto system_ptr = dynamic_cast<const MySystem*>(this);
-      DRAKE_DEMAND(system_ptr != nullptr);
-      return (system_ptr->*publish_callback)(context, publish_event);
-    };
-    PublishEvent<T> publish_event(fn);
-    publish_event.set_trigger_type(TriggerType::kWitness);
+    PublishEvent<T> event(
+        TriggerType::kWitness,
+        [publish_callback](const System<T>& system, const Context<T>& context,
+                           const PublishEvent<T>& callback_event) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
+          (sys.*publish_callback)(context, callback_event);
+          return EventStatus::Succeeded();
+        });
     return std::make_unique<WitnessFunction<T>>(
-        this, this, description, direction_type, calc, publish_event.Clone());
+        this, this, description, direction_type, calc, event.Clone());
   }
 
   /** Constructs the witness function with the given description (used primarily
@@ -1653,16 +1644,17 @@ class LeafSystem : public System<T> {
           const DiscreteUpdateEvent<T>&, DiscreteValues<T>*) const) const {
     static_assert(std::is_base_of_v<LeafSystem<T>, MySystem>,
                   "Expected to be invoked from a LeafSystem-derived system.");
-    auto fn = [this, du_callback](const Context<T>& context,
-        const DiscreteUpdateEvent<T>& du_event, DiscreteValues<T>* values) {
-      auto system_ptr = dynamic_cast<const MySystem*>(this);
-      DRAKE_DEMAND(system_ptr != nullptr);
-      return (system_ptr->*du_callback)(context, du_event, values);
-    };
-    DiscreteUpdateEvent<T> du_event(fn);
-    du_event.set_trigger_type(TriggerType::kWitness);
+    DiscreteUpdateEvent<T> event(
+        TriggerType::kWitness,
+        [du_callback](const System<T>& system, const Context<T>& context,
+                      const DiscreteUpdateEvent<T>& callback_event,
+                      DiscreteValues<T>* values) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
+          (sys.*du_callback)(context, callback_event, values);
+          return EventStatus::Succeeded();
+        });
     return std::make_unique<WitnessFunction<T>>(
-        this, this, description, direction_type, calc, du_event.Clone());
+        this, this, description, direction_type, calc, event.Clone());
   }
 
   /** Constructs the witness function with the given description (used primarily
@@ -1681,16 +1673,17 @@ class LeafSystem : public System<T> {
           const UnrestrictedUpdateEvent<T>&, State<T>*) const) const {
     static_assert(std::is_base_of_v<LeafSystem<T>, MySystem>,
                   "Expected to be invoked from a LeafSystem-derived system.");
-    auto fn = [this, uu_callback](const Context<T>& context,
-        const UnrestrictedUpdateEvent<T>& uu_event, State<T>* state) {
-      auto system_ptr = dynamic_cast<const MySystem*>(this);
-      DRAKE_DEMAND(system_ptr != nullptr);
-      return (system_ptr->*uu_callback)(context, uu_event, state);
-    };
-    UnrestrictedUpdateEvent<T> uu_event(fn);
-    uu_event.set_trigger_type(TriggerType::kWitness);
+    UnrestrictedUpdateEvent<T> event(
+        TriggerType::kWitness,
+        [uu_callback](const System<T>& system, const Context<T>& context,
+                      const UnrestrictedUpdateEvent<T>& callback_event,
+                      State<T>* state) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
+          (sys.*uu_callback)(context, callback_event, state);
+          return EventStatus::Succeeded();
+        });
     return std::make_unique<WitnessFunction<T>>(
-        this, this, description, direction_type, calc, uu_event.Clone());
+        this, this, description, direction_type, calc, event.Clone());
   }
 
   /** Constructs the witness function with the given description (used primarily

--- a/systems/framework/test/event_deprecated_test.cc
+++ b/systems/framework/test/event_deprecated_test.cc
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include "drake/systems/framework/event.h"
+#include "drake/systems/primitives/pass_through.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+class EventDeprecatedTest : public ::testing::Test {
+ protected:
+  const PassThrough<double> system_{1};
+  std::unique_ptr<Context<double>> context_ptr_ =
+      system_.CreateDefaultContext();
+  const Context<double>& context_ = *context_ptr_;
+};
+
+TEST_F(EventDeprecatedTest, PublishCallback) {
+  bool called = false;
+  PublishEvent<double>::PublishCallback callback =
+      [&called](const Context<double>&, const PublishEvent<double>&) {
+        called = true;
+      };
+  PublishEvent<double> event(callback);
+  EventStatus result = event.handle(system_, context_);
+  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(called);
+}
+
+TEST_F(EventDeprecatedTest, PublishSystemCallback) {
+  bool called = false;
+  PublishEvent<double>::SystemCallback callback =
+      [&called](const System<double>&, const Context<double>&,
+                const PublishEvent<double>&) {
+        called = true;
+      };
+  PublishEvent<double> event(callback);
+  EventStatus result = event.handle(system_, context_);
+  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(called);
+}
+
+TEST_F(EventDeprecatedTest, DiscreteUpdateCallback) {
+  bool called = false;
+  DiscreteUpdateEvent<double>::DiscreteUpdateCallback callback =
+      [&called](const Context<double>&, const DiscreteUpdateEvent<double>&,
+                DiscreteValues<double>*) {
+        called = true;
+      };
+  DiscreteUpdateEvent<double> event(callback);
+  DiscreteValues<double> out;
+  EventStatus result = event.handle(system_, context_, &out);
+  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(called);
+}
+
+TEST_F(EventDeprecatedTest, DiscreteUpdateSystemCallback) {
+  bool called = false;
+  DiscreteUpdateEvent<double>::SystemCallback callback =
+      [&called](const System<double>&, const Context<double>&,
+                const DiscreteUpdateEvent<double>&, DiscreteValues<double>*) {
+        called = true;
+      };
+  DiscreteUpdateEvent<double> event(callback);
+  DiscreteValues<double> out;
+  EventStatus result = event.handle(system_, context_, &out);
+  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(called);
+}
+
+TEST_F(EventDeprecatedTest, UnrestrictedUpdateCallback) {
+  bool called = false;
+  UnrestrictedUpdateEvent<double>::UnrestrictedUpdateCallback callback =
+      [&called](const Context<double>&, const UnrestrictedUpdateEvent<double>&,
+                State<double>*) {
+        called = true;
+      };
+  UnrestrictedUpdateEvent<double> event(callback);
+  State<double> out;
+  EventStatus result = event.handle(system_, context_, &out);
+  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(called);
+}
+
+TEST_F(EventDeprecatedTest, UnrestrictedUpdateSystemCallback) {
+  bool called = false;
+  UnrestrictedUpdateEvent<double>::SystemCallback callback =
+      [&called](const System<double>&, const Context<double>&,
+                const UnrestrictedUpdateEvent<double>&,
+                State<double>*) {
+        called = true;
+      };
+  UnrestrictedUpdateEvent<double> event(callback);
+  State<double> out;
+  EventStatus result = event.handle(system_, context_, &out);
+  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(called);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1721,12 +1721,13 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
   // Create an unrestricted update callback that just copies the state.
   LeafCompositeEventCollection<double> leaf_events;
   {
-    UnrestrictedUpdateEvent<double>::UnrestrictedUpdateCallback callback = [](
-        const Context<double>& c, const Event<double>&, State<double>* s) {
-      s->SetFrom(*c.CloneState());
-    };
-
-    UnrestrictedUpdateEvent<double> event(TriggerType::kPeriodic, callback);
+    UnrestrictedUpdateEvent<double> event(
+        TriggerType::kPeriodic,
+        [](const System<double>&, const Context<double>& c,
+           const Event<double>&, State<double>* s) {
+          s->SetFrom(*c.CloneState());
+          return EventStatus::Succeeded();
+        });
     event.AddToComposite(&leaf_events);
   }
 
@@ -1739,14 +1740,15 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
   // exception is thrown.
   leaf_events.Clear();
   {
-    UnrestrictedUpdateEvent<double>::UnrestrictedUpdateCallback callback = [](
-        const Context<double>& c, const Event<double>&, State<double>* s) {
-      s->SetFrom(*c.CloneState());
-      s->set_continuous_state(std::make_unique<ContinuousState<double>>(
-          std::make_unique<BasicVector<double>>(4), 4, 0, 0));
-    };
-
-    UnrestrictedUpdateEvent<double> event(TriggerType::kPeriodic, callback);
+    UnrestrictedUpdateEvent<double> event(
+        TriggerType::kPeriodic,
+        [](const System<double>&, const Context<double>& c,
+           const Event<double>&, State<double>* s) {
+          s->SetFrom(*c.CloneState());
+          s->set_continuous_state(std::make_unique<ContinuousState<double>>(
+              std::make_unique<BasicVector<double>>(4), 4, 0, 0));
+          return EventStatus::Succeeded();
+        });
     event.AddToComposite(&leaf_events);
   }
 
@@ -1764,17 +1766,18 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
   // Change the event to indicate to change the discrete state dimension.
   leaf_events.Clear();
   {
-    UnrestrictedUpdateEvent<double>::UnrestrictedUpdateCallback callback = [](
-        const Context<double>& c, const Event<double>&, State<double>* s) {
-      std::vector<std::unique_ptr<BasicVector<double>>> disc_data;
-      s->SetFrom(*c.CloneState());
-      disc_data.push_back(std::make_unique<BasicVector<double>>(1));
-      disc_data.push_back(std::make_unique<BasicVector<double>>(1));
-      s->set_discrete_state(
-          std::make_unique<DiscreteValues<double>>(std::move(disc_data)));
-    };
-
-    UnrestrictedUpdateEvent<double> event(TriggerType::kPeriodic, callback);
+    UnrestrictedUpdateEvent<double> event(
+        TriggerType::kPeriodic,
+        [](const System<double>&, const Context<double>& c,
+           const Event<double>&, State<double>* s) {
+          std::vector<std::unique_ptr<BasicVector<double>>> disc_data;
+          s->SetFrom(*c.CloneState());
+          disc_data.push_back(std::make_unique<BasicVector<double>>(1));
+          disc_data.push_back(std::make_unique<BasicVector<double>>(1));
+          s->set_discrete_state(
+              std::make_unique<DiscreteValues<double>>(std::move(disc_data)));
+          return EventStatus::Succeeded();
+        });
     event.AddToComposite(&leaf_events);
   }
 
@@ -1792,13 +1795,14 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
   // Change the event to indicate to change the abstract state dimension.
   leaf_events.Clear();
   {
-    UnrestrictedUpdateEvent<double>::UnrestrictedUpdateCallback callback = [](
-        const Context<double>& c, const Event<double>&, State<double>* s) {
-      s->SetFrom(*c.CloneState());
-      s->set_abstract_state(std::make_unique<AbstractValues>());
-    };
-
-    UnrestrictedUpdateEvent<double> event(TriggerType::kPeriodic, callback);
+    UnrestrictedUpdateEvent<double> event(
+        TriggerType::kPeriodic,
+        [](const System<double>&, const Context<double>& c,
+           const Event<double>&, State<double>* s) {
+          s->SetFrom(*c.CloneState());
+          s->set_abstract_state(std::make_unique<AbstractValues>());
+          return EventStatus::Succeeded();
+        });
     event.AddToComposite(&leaf_events);
   }
 

--- a/systems/framework/test_utilities/initialization_test_system.h
+++ b/systems/framework/test_utilities/initialization_test_system.h
@@ -16,8 +16,11 @@ class InitializationTestSystem : public LeafSystem<double> {
   InitializationTestSystem() {
     PublishEvent<double> pub_event(
         TriggerType::kInitialization,
-        std::bind(&InitializationTestSystem::InitPublish, this,
-                  std::placeholders::_1, std::placeholders::_2));
+        [this](const System<double>&, const Context<double>&,
+               const PublishEvent<double>& event) {
+          this->InitPublish(event);
+          return EventStatus::Succeeded();
+        });
     DeclareInitializationEvent(pub_event);
 
     DeclareDiscreteState(1);
@@ -34,8 +37,7 @@ class InitializationTestSystem : public LeafSystem<double> {
   bool get_unres_update_init() const { return unres_update_init_; }
 
  private:
-  void InitPublish(const Context<double>&,
-                   const PublishEvent<double>& event) const {
+  void InitPublish(const PublishEvent<double>& event) const {
     EXPECT_EQ(event.get_trigger_type(), TriggerType::kInitialization);
     pub_init_ = true;
   }

--- a/systems/lcm/lcm_log_playback_system.cc
+++ b/systems/lcm/lcm_log_playback_system.cc
@@ -33,12 +33,14 @@ void LcmLogPlaybackSystem::DoCalcNextUpdateTime(
   DRAKE_THROW_UNLESS(next_message_time > context.get_time());
 
   // Prepare a callback that dispatches message(s) to all the subscribers.
-  PublishEvent<double>::PublishCallback callback = [log = log_](
-      const Context<double>& callback_context, const PublishEvent<double>&) {
+  auto callback = [log = log_](const System<double>&,
+                               const Context<double>& callback_context,
+                               const PublishEvent<double>&) {
     // Use a loop to publish all messages that occur at the exact same time.
     while (log->GetNextMessageTime() == callback_context.get_time()) {
       log->DispatchMessageAndAdvanceLog(callback_context.get_time());
     }
+    return EventStatus::Succeeded();
   };
 
   // Schedule a publish event at the next message time.

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -255,6 +255,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
   double get_publish_offset() const;
 
  private:
+  EventStatus Initialize(const Context<double>& context) const;
   EventStatus PublishInputAsLcmMessage(const Context<double>& context) const;
 
   // The channel on which to publish LCM messages.

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -110,12 +110,14 @@ void LcmSubscriberSystem::DoCalcNextUpdateTime(
 
   // Create a unrestricted event and tie the handler to the corresponding
   // function.
-  systems::UnrestrictedUpdateEvent<double>::UnrestrictedUpdateCallback
-      callback = [this](const Context<double>& c,
-                        const systems::UnrestrictedUpdateEvent<double>&,
-                        State<double>* s) {
-        this->ProcessMessageAndStoreToAbstractState(c, s);
-      };
+  auto callback = [](const System<double>& system,
+                     const Context<double>& callback_context,
+                     const systems::UnrestrictedUpdateEvent<double>&,
+                     State<double>* callback_state) {
+    const auto& self = dynamic_cast<const LcmSubscriberSystem&>(system);
+    return self.ProcessMessageAndStoreToAbstractState(callback_context,
+                                                      callback_state);
+  };
 
   // Schedule an update event at the current time.
   *time = context.get_time();

--- a/systems/primitives/vector_log_sink.cc
+++ b/systems/primitives/vector_log_sink.cc
@@ -66,10 +66,7 @@ VectorLogSink<T>::VectorLogSink(int input_size,
   }
 
   if (publish_triggers.find(TriggerType::kPerStep) != publish_triggers.end()) {
-    this->DeclarePerStepEvent(PublishEvent<T>(
-        [this](const Context<T>& context, const PublishEvent<T>&) {
-          this->WriteToLog(context);
-        }));
+    this->DeclarePerStepPublishEvent(&VectorLogSink::WriteToLog);
   }
 }
 


### PR DESCRIPTION
Towards #19980.  This only updates the Event classes.  It does not yet propagate through Diagram, Simulator, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19989)
<!-- Reviewable:end -->
