### PR TITLE
Disable TSan on stl2obj

### DIFF
--- a/examples/pr2/BUILD.bazel
+++ b/examples/pr2/BUILD.bazel
@@ -38,6 +38,7 @@ _OBJS = [x[:-3] + "obj" for x in _STLS]
         srcs = [stl] + ["//manipulation/util:stl2obj"],
         outs = [obj],
         cmd = " ".join([
+            "env TSAN_OPTIONS=report_bugs=0",
             "$(location //manipulation/util:stl2obj)",
             "--input=$(location {})".format(stl),
             "--output=$@",

--- a/manipulation/models/realsense2_description/BUILD.bazel
+++ b/manipulation/models/realsense2_description/BUILD.bazel
@@ -50,6 +50,7 @@ _OBJS = [x[:-3] + "obj" for x in _STLS]
         srcs = [stl] + ["//manipulation/util:stl2obj"],
         outs = [obj],
         cmd = " ".join([
+            "env TSAN_OPTIONS=report_bugs=0",
             "$(location //manipulation/util:stl2obj)",
             "--input=$(location {})".format(stl),
             "--output=$@",


### PR DESCRIPTION
Genrules don't obey --run_under, so miss out on the suppression file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19990)
<!-- Reviewable:end -->
