### PR TITLE
Remove beta testing tag from RenderEngineGltf doxygen

### DIFF
--- a/geometry/render_gltf_client/render_gltf_client_doxygen.h
+++ b/geometry/render_gltf_client/render_gltf_client_doxygen.h
@@ -8,9 +8,6 @@ namespace render_gltf_client {
 /** @defgroup render_engine_gltf_client_server_api glTF Render Client-Server API
     @ingroup render_engines
 
-@warning This feature is currently in "beta testing" and may change without any
-deprecation notice ahead of time.
-
 <h2 id="overview">Overview</h2>
 
 Drake offers built-in renderers (RenderEngineVtk, RenderEngineGl), but in some


### PR DESCRIPTION
I browsed through the documentation, and I think this is the only place mentioning `beta-testing` or `experimental`. I also built the Doxygen locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/19997)
<!-- Reviewable:end -->
