### PR TITLE
 Handle converting HPolyhedron to VPolytope if it is not full dimensional.

### DIFF
--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -163,7 +163,7 @@ HPolyhedron::HPolyhedron(const VPolytope& vpoly)
     Eigen::MatrixXd points_local =
         affine_hull.ToLocalCoordinates(vpoly.vertices());
 
-    // Note QHull will not function in zero or one dimensional spaces, so
+    // Note that QHull will not function in zero or one dimensional spaces, so
     // we handle these separately here.
     Eigen::MatrixXd global_A;
     Eigen::VectorXd global_b;

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -465,6 +465,104 @@ GTEST_TEST(VPolytopeTest, FromUnboundedHPolytopeTest) {
   DRAKE_EXPECT_THROWS_MESSAGE(VPolytope{H}, ".*hpoly.IsBounded().*");
 }
 
+GTEST_TEST(VPolytopeTest, ConstructorFromHPolyhedronQHullProblems) {
+  // Test cases of HPolyhedra that QHull cannot handle on its own.
+  // Code logic in the constructor should handle these cases without any
+  // QHull errors.
+
+  // Empty case.
+  Eigen::Matrix<double, 2, 1> A0;
+  // clang-format off
+  A0 << 1,   // x  <= 0
+        -1;  // -x <= -1 (equivalently, x >= 1)
+  // clang-format on
+  Eigen::VectorXd b0 = Eigen::VectorXd::Zero(2);
+  b0[1] = -1;
+  HPolyhedron hpoly0(A0, b0);
+  EXPECT_TRUE(hpoly0.IsEmpty());
+  EXPECT_NO_THROW(VPolytope{hpoly0});
+  const VPolytope vpoly0(hpoly0);
+  EXPECT_TRUE(vpoly0.IsEmpty());
+
+  // Zero-dimensional case (singleton point).
+  Eigen::Matrix<double, 6, 3> A1;
+  // clang-format off
+  A1 << 1,  0,  0,  // x  <= 0
+        -1, 0,  0,  // -x <= 0 (equivalently, x >= 0)
+        0,  1,  0,  // y  <= 0
+        0, -1,  0,  // -y <= 0 (equivalently, y >= 0)
+        0,  0,  1,  // z  <= 0
+        0,  0, -1;  // -z <= 0 (equivalently, z >= 0)
+  // clang-format on
+  Eigen::VectorXd b1 = Eigen::VectorXd::Zero(6);
+  HPolyhedron hpoly1(A1, b1);
+  EXPECT_NO_THROW(VPolytope{hpoly1});
+  const VPolytope vpoly1(hpoly1);
+  EXPECT_TRUE(vpoly1.PointInSet(Eigen::Vector3d(0, 0, 0)));
+  EXPECT_FALSE(vpoly1.PointInSet(Eigen::Vector3d(1, 0, 0)));
+  EXPECT_FALSE(vpoly1.PointInSet(Eigen::Vector3d(-1, 0, 0)));
+  EXPECT_FALSE(vpoly1.PointInSet(Eigen::Vector3d(0, 1, 0)));
+  EXPECT_FALSE(vpoly1.PointInSet(Eigen::Vector3d(0, -1, 0)));
+  EXPECT_FALSE(vpoly1.PointInSet(Eigen::Vector3d(0, 0, 1)));
+  EXPECT_FALSE(vpoly1.PointInSet(Eigen::Vector3d(0, 0, -1)));
+
+  // Due to poor numerics, a surprisingly loose tolerance is needed for
+  // PointInSet queries with VPolytope. This bug is tracked in Github issue
+  // #17197.
+  const double vpolyTol = 1e-8;
+
+  // One-dimensional case (line segment).
+  Eigen::Matrix<double, 6, 3> A2;
+  // clang-format off
+  A2 << 1,  0,  0,  // x  <= 1
+        -1, 0,  0,  // -x <= 0 (equivalently, x >= 0)
+        0,  1,  0,  // y  <= 0
+        0, -1,  0,  // -y <= 0 (equivalently, y >= 0)
+        0,  0,  1,  // z  <= 0
+        0,  0, -1;  // -z <= 0 (equivalently, z >= 0)
+  // clang-format on
+  Eigen::VectorXd b2 = Eigen::VectorXd::Zero(6);
+  b2[0] = 1;
+  HPolyhedron hpoly2(A2, b2);
+  EXPECT_NO_THROW(VPolytope{hpoly2});
+  const VPolytope vpoly2(hpoly2);
+  EXPECT_TRUE(vpoly2.PointInSet(Eigen::Vector3d(0, 0, 0), vpolyTol));
+  EXPECT_TRUE(vpoly2.PointInSet(Eigen::Vector3d(1, 0, 0), vpolyTol));
+  EXPECT_FALSE(vpoly2.PointInSet(Eigen::Vector3d(2, 0, 0), vpolyTol));
+  EXPECT_FALSE(vpoly2.PointInSet(Eigen::Vector3d(-1, 0, 0), vpolyTol));
+  EXPECT_FALSE(vpoly2.PointInSet(Eigen::Vector3d(0, 1, 0), vpolyTol));
+  EXPECT_FALSE(vpoly2.PointInSet(Eigen::Vector3d(0, -1, 0), vpolyTol));
+  EXPECT_FALSE(vpoly2.PointInSet(Eigen::Vector3d(0, 0, 1), vpolyTol));
+  EXPECT_FALSE(vpoly2.PointInSet(Eigen::Vector3d(0, 0, -1), vpolyTol));
+
+  // Two-dimensional case (square).
+  Eigen::Matrix<double, 6, 3> A3;
+  // clang-format off
+  A3 << 1,  0,  0,  // x  <= 0
+        -1, 0,  0,  // -x <= 0 (equivalently, x >= 0)
+        0,  1,  0,  // y  <= 1
+        0, -1,  0,  // -y <= 0 (equivalently, y >= 0)
+        0,  0,  1,  // z  <= 1
+        0,  0, -1;  // -z <= 0 (equivalently, z >= 0)
+  // clang-format on
+  Eigen::VectorXd b3 = Eigen::VectorXd::Zero(6);
+  b3[2] = 1;
+  b3[4] = 1;
+  HPolyhedron hpoly3(A3, b3);
+  EXPECT_NO_THROW(VPolytope{hpoly3});
+  const VPolytope vpoly3(hpoly3);
+  EXPECT_TRUE(vpoly3.PointInSet(Eigen::Vector3d(0, 0, 0), vpolyTol));
+  EXPECT_TRUE(vpoly3.PointInSet(Eigen::Vector3d(0, 1, 0), vpolyTol));
+  EXPECT_TRUE(vpoly3.PointInSet(Eigen::Vector3d(0, 0, 1), vpolyTol));
+  EXPECT_TRUE(vpoly3.PointInSet(Eigen::Vector3d(0, 1, 1), vpolyTol));
+  EXPECT_FALSE(vpoly3.PointInSet(Eigen::Vector3d(1, 0, 0), vpolyTol));
+  EXPECT_FALSE(vpoly3.PointInSet(Eigen::Vector3d(-1, 0, 0), vpolyTol));
+  EXPECT_FALSE(vpoly3.PointInSet(Eigen::Vector3d(0, -1, 0), vpolyTol));
+  EXPECT_FALSE(vpoly3.PointInSet(Eigen::Vector3d(0, 2, 0), vpolyTol));
+  EXPECT_FALSE(vpoly3.PointInSet(Eigen::Vector3d(0, 0, -1), vpolyTol));
+  EXPECT_FALSE(vpoly3.PointInSet(Eigen::Vector3d(0, 0, 2), vpolyTol));
+}
+
 GTEST_TEST(VPolytopeTest, CloneTest) {
   VPolytope V = VPolytope::MakeBox(Vector3d{-3, -4, -5}, Vector3d{6, 7, 8});
   std::unique_ptr<ConvexSet> clone = V.Clone();

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/geometry/optimization/affine_subspace.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/math/rigid_transform.h"
@@ -44,11 +45,16 @@ class VPolytope final : public ConvexSet {
   @pydrake_mkdoc_identifier{vertices} */
   explicit VPolytope(const Eigen::Ref<const Eigen::MatrixXd>& vertices);
 
-  /** Constructs the polytope from a bounded polyhedron (using Qhull).
+  /** Constructs the polytope from a bounded polyhedron (using Qhull). If the
+  HPolyhedron is not full-dimensional, we perform computations in a coordinate
+  system of its affine hull. `tol` specifies the numerical tolerance used in the
+  computation of the affine hull. See the documentation of AffineSubspace for
+  more details. A loose tolerance is necessary for the built-in solvers, but a
+  tighter tolerance can be used with commercial solvers (e.g. Gurobi and Mosek).
   @throws std::runtime_error if H is unbounded or if Qhull terminates with an
   error.
   @pydrake_mkdoc_identifier{hpolyhedron} */
-  explicit VPolytope(const HPolyhedron& H);
+  explicit VPolytope(const HPolyhedron& H, const double tol = 1e-9);
 
   /** Constructs the polytope from a SceneGraph geometry.
   @pydrake_mkdoc_identifier{scenegraph} */


### PR DESCRIPTION
The last steps to complete #19717. This allows the conversion of a HPolyhedron to a VPolytope even if the HPolyhedron is not full dimensional.

+@hongkai-dai for feature review, please

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20001)
<!-- Reviewable:end -->
