### PR TITLE
geometry/render_vtk opts into clang format

### DIFF
--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -163,4 +163,4 @@ drake_cc_googletest(
     ],
 )
 
-add_lint_tests(enable_clang_format_lint = False)
+add_lint_tests()

--- a/geometry/render_vtk/factory.h
+++ b/geometry/render_vtk/factory.h
@@ -8,6 +8,9 @@
 
 namespace drake {
 namespace geometry {
+// We need to get clang-format to ignore the long table lines so they get
+// rendered properly in doxygen.
+// clang-format off
 
 /** Constructs a RenderEngine implementation which uses a VTK-based OpenGL
  renderer.
@@ -74,6 +77,7 @@ namespace geometry {
  */
 std::unique_ptr<render::RenderEngine> MakeRenderEngineVtk(
     const RenderEngineVtkParams& params);
+// clang-format on
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -89,11 +89,11 @@ float CheckRangeAndConvertToMeters(float z_buffer_value, double z_near,
 
 }  // namespace
 
-ShaderCallback::ShaderCallback() :
-    // These values are arbitrary "reasonable" values, but we expect them to
-    // *both* be overwritten upon every usage.
-    z_near_(0.01),
-    z_far_(100.0) {}
+ShaderCallback::ShaderCallback()
+    :  // These values are arbitrary "reasonable" values, but we expect them to
+       // *both* be overwritten upon every usage.
+      z_near_(0.01),
+      z_far_(100.0) {}
 
 vtkNew<ShaderCallback> RenderEngineVtk::uniform_setting_callback_;
 
@@ -190,9 +190,9 @@ void RenderEngineVtk::ImplementGeometry(const Sphere& sphere, void* user_data) {
                     DefineMaterial(data.properties, default_diffuse_), data);
 }
 
-bool RenderEngineVtk::DoRegisterVisual(
-    GeometryId id, const Shape& shape, const PerceptionProperties& properties,
-    const RigidTransformd& X_WG) {
+bool RenderEngineVtk::DoRegisterVisual(GeometryId id, const Shape& shape,
+                                       const PerceptionProperties& properties,
+                                       const RigidTransformd& X_WG) {
   // Note: the user_data interface on reification requires a non-const pointer.
   RegistrationData data{properties, X_WG, id};
   shape.Reify(this, &data);
@@ -229,9 +229,8 @@ std::unique_ptr<RenderEngine> RenderEngineVtk::DoClone() const {
   return std::unique_ptr<RenderEngineVtk>(new RenderEngineVtk(*this));
 }
 
-void RenderEngineVtk::DoRenderColorImage(
-    const ColorRenderCamera& camera,
-    ImageRgba8U* color_image_out) const {
+void RenderEngineVtk::DoRenderColorImage(const ColorRenderCamera& camera,
+                                         ImageRgba8U* color_image_out) const {
   UpdateWindow(camera.core(), camera.show_window(),
                *pipelines_[ImageType::kColor], "Color Image");
   PerformVtkUpdate(*pipelines_[ImageType::kColor]);
@@ -241,9 +240,8 @@ void RenderEngineVtk::DoRenderColorImage(
   pipelines_[ImageType::kColor]->exporter->Export(color_image_out->at(0, 0));
 }
 
-void RenderEngineVtk::DoRenderDepthImage(
-    const DepthRenderCamera& camera,
-      ImageDepth32F* depth_image_out) const {
+void RenderEngineVtk::DoRenderDepthImage(const DepthRenderCamera& camera,
+                                         ImageDepth32F* depth_image_out) const {
   UpdateWindow(camera, *pipelines_[ImageType::kDepth]);
   PerformVtkUpdate(*pipelines_[ImageType::kDepth]);
 
@@ -274,16 +272,15 @@ void RenderEngineVtk::DoRenderDepthImage(
         // Dividing by 255 so that the range gets to be [0, 1].
         shader_value /= 255.f;
         // TODO(kunimatsu-tri) Calculate this in a vertex shader.
-        depth_image_out->at(u, v)[0] = CheckRangeAndConvertToMeters(
-            shader_value, min_depth, max_depth);
+        depth_image_out->at(u, v)[0] =
+            CheckRangeAndConvertToMeters(shader_value, min_depth, max_depth);
       }
     }
   }
 }
 
-void RenderEngineVtk::DoRenderLabelImage(
-    const ColorRenderCamera& camera,
-    ImageLabel16I* label_image_out) const {
+void RenderEngineVtk::DoRenderLabelImage(const ColorRenderCamera& camera,
+                                         ImageLabel16I* label_image_out) const {
   UpdateWindow(camera.core(), camera.show_window(),
                *pipelines_[ImageType::kLabel], "Label Image");
   PerformVtkUpdate(*pipelines_[ImageType::kLabel]);
@@ -641,8 +638,8 @@ void RenderEngineVtk::ImplementPolyData(vtkPolyDataAlgorithm* source,
   DRAKE_DEMAND(shader_prop != nullptr);
   shader_prop->SetVertexShaderCode(render::shaders::kDepthVS);
   shader_prop->SetFragmentShaderCode(render::shaders::kDepthFS);
-  mappers[ImageType::kDepth]->AddObserver(
-      vtkCommand::UpdateShaderEvent, uniform_setting_callback_.Get());
+  mappers[ImageType::kDepth]->AddObserver(vtkCommand::UpdateShaderEvent,
+                                          uniform_setting_callback_.Get());
 
   for (auto& mapper : mappers) {
     mapper->SetInputConnection(source->GetOutputPort());

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -40,7 +40,7 @@ namespace internal {
 
 #ifndef DRAKE_DOXYGEN_CXX
 struct ModuleInitVtkRenderingOpenGL2 {
-  ModuleInitVtkRenderingOpenGL2(){
+  ModuleInitVtkRenderingOpenGL2() {
     VTK_AUTOINIT_CONSTRUCT(vtkRenderingOpenGL2)
   }
 };
@@ -67,13 +67,9 @@ class DRAKE_NO_EXPORT ShaderCallback : public vtkCommand {
     program->SetUniformf("z_far", z_far_);
   }
 
-  void set_z_near(float z_near) {
-    z_near_ = z_near;
-  }
+  void set_z_near(float z_near) { z_near_ = z_near; }
 
-  void set_z_far(float z_far) {
-    z_far_ = z_far;
-  }
+  void set_z_far(float z_far) { z_far_ = z_far; }
 
  private:
   float z_near_{0.f};
@@ -132,9 +128,7 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
    using. These values must be set at construction.  */
   //@{
 
-  Eigen::Vector4d default_diffuse() const {
-    return default_diffuse_.rgba();
-  }
+  Eigen::Vector4d default_diffuse() const { return default_diffuse_.rgba(); }
 
   using render::RenderEngine::default_render_label;
   //@}

--- a/geometry/render_vtk/internal_render_engine_vtk_base.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk_base.cc
@@ -27,9 +27,9 @@ namespace render_vtk {
 namespace internal {
 namespace {
 
-using geometry::internal::RenderMesh;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
+using geometry::internal::RenderMesh;
 
 // TODO(SeanCurtis-TRI): The semantics of this textured box needs to be
 //  explained *somewhere* in the documentation. The layout of the texture on the
@@ -104,7 +104,7 @@ class DrakeCubeSource : public vtkPolyDataAlgorithm {
     vtkFloatArray* newTCoords = vtkFloatArray::New();
     vtkCellArray* newPolys = vtkCellArray::New();
 
-    ScopeExit guard([newPoints, newNormals, newTCoords, newPolys](){
+    ScopeExit guard([newPoints, newNormals, newTCoords, newPolys]() {
       newPoints->Delete();
       newNormals->Delete();
       newTCoords->Delete();
@@ -286,8 +286,7 @@ class DrakeObjSource : public vtkPolyDataAlgorithm {
     newPolys->Allocate(newPolys->EstimateSize(num_tris, 3));
 
     for (int p = 0; p < num_points; ++p) {
-      newPoints->InsertNextPoint(mesh_.positions(p, 0),
-                                 mesh_.positions(p, 1),
+      newPoints->InsertNextPoint(mesh_.positions(p, 0), mesh_.positions(p, 1),
                                  mesh_.positions(p, 2));
       const double n[] = {mesh_.normals(p, 0), mesh_.normals(p, 1),
                           mesh_.normals(p, 2)};
@@ -346,8 +345,8 @@ vtkSmartPointer<vtkPolyDataAlgorithm> CreateVtkBox(
   vtkSmartPointer<DrakeCubeSource> vtk_box =
       vtkSmartPointer<DrakeCubeSource>::New();
   vtk_box->set_size({box.width(), box.depth(), box.height()});
-  const Vector2d& uv_scale = properties.GetPropertyOrDefault(
-      "phong", "diffuse_scale", Vector2d{1, 1});
+  const Vector2d& uv_scale =
+      properties.GetPropertyOrDefault("phong", "diffuse_scale", Vector2d{1, 1});
   vtk_box->set_uv_scale(uv_scale);
   return vtk_box;
 }

--- a/geometry/render_vtk/internal_vtk_util.h
+++ b/geometry/render_vtk/internal_vtk_util.h
@@ -40,11 +40,10 @@ vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
 //
 // @tparam transform The transform to convert into a `vtkTransform`.
 template <typename T, typename... Ts, size_t N = 1 + sizeof...(Ts)>
-const vtkPointerArray<T, N> MakeVtkPointerArray(
-    const vtkNew<T>& element, const vtkNew<Ts>&... elements) {
-  return vtkPointerArray<T, N>{{
-      vtkSmartPointer<T>(element.GetPointer()),
-      vtkSmartPointer<Ts>(elements.GetPointer())...}};
+const vtkPointerArray<T, N> MakeVtkPointerArray(const vtkNew<T>& element,
+                                                const vtkNew<Ts>&... elements) {
+  return vtkPointerArray<T, N>{{vtkSmartPointer<T>(element.GetPointer()),
+                                vtkSmartPointer<Ts>(elements.GetPointer())...}};
 }
 
 }  // namespace internal

--- a/geometry/render_vtk/render_engine_vtk_params.h
+++ b/geometry/render_vtk/render_engine_vtk_params.h
@@ -12,7 +12,7 @@ namespace drake {
 namespace geometry {
 
 /** Construction parameters for the RenderEngineVtk.  */
-struct RenderEngineVtkParams  {
+struct RenderEngineVtkParams {
   /** Passes this object to an Archive.
   Refer to @ref yaml_serialization "YAML Serialization" for background. */
   template <typename Archive>

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -167,14 +167,13 @@ std::ostream& operator<<(std::ostream& out, const RgbaColor& c) {
 }
 
 // Tests color within tolerance.
-bool IsColorNear(
-    const RgbaColor& expected, const RgbaColor& tested,
-    double tolerance = kColorPixelTolerance) {
+bool IsColorNear(const RgbaColor& expected, const RgbaColor& tested,
+                 double tolerance = kColorPixelTolerance) {
   using std::abs;
   return (abs(expected.r - tested.r) < tolerance &&
-      abs(expected.g - tested.g) < tolerance &&
-      abs(expected.b - tested.b) < tolerance &&
-      abs(expected.a - tested.a) < tolerance);
+          abs(expected.g - tested.g) < tolerance &&
+          abs(expected.b - tested.b) < tolerance &&
+          abs(expected.a - tested.a) < tolerance);
 }
 
 // Tests that the color in the given `image` located at screen coordinate `p`
@@ -186,10 +185,9 @@ bool IsColorNear(
   if (IsColorNear(expected, tested, tolerance)) {
     return ::testing::AssertionSuccess();
   }
-  return ::testing::AssertionFailure() << "Expected: " << expected
-                                       << " at " << p
-                                       << ", tested: " << tested
-                                       << " with tolerance: " << tolerance;
+  return ::testing::AssertionFailure()
+         << "Expected: " << expected << " at " << p << ", tested: " << tested
+         << " with tolerance: " << tolerance;
 }
 
 // This test suite facilitates a test with a ground plane and floating shape.
@@ -260,7 +258,7 @@ class RenderEngineVtkTest : public ::testing::Test {
     for (int y = 0; y < label->height(); ++y) {
       for (int x = 0; x < label->width(); ++x) {
         ASSERT_EQ(label->at(x, y)[0], value)
-                      << "At pixel (" << x << ", " << y << ")";
+            << "At pixel (" << x << ", " << y << ")";
       }
     }
   }
@@ -310,8 +308,8 @@ class RenderEngineVtkTest : public ::testing::Test {
         return ::testing::AssertionSuccess();
       } else {
         return ::testing::AssertionFailure()
-               << "Expected depth at " << coord << " to be infinity. Found: "
-               << actual_depth;
+               << "Expected depth at " << coord
+               << " to be infinity. Found: " << actual_depth;
       }
     } else {
       float delta = std::abs(expected_depth - actual_depth);
@@ -330,8 +328,7 @@ class RenderEngineVtkTest : public ::testing::Test {
   // plane. If images are provided, the given images will be tested, otherwise
   // the member images will be tested.
   void VerifyOutliers(const RenderEngineVtk& renderer,
-                      const DepthRenderCamera& camera,
-                      const char* name,
+                      const DepthRenderCamera& camera, const char* name,
                       const ImageRgba8U* color_in = nullptr,
                       const ImageDepth32F* depth_in = nullptr,
                       const ImageLabel16I* label_in = nullptr) const {
@@ -343,30 +340,27 @@ class RenderEngineVtkTest : public ::testing::Test {
       const int x = screen_coord.x;
       const int y = screen_coord.y;
       EXPECT_TRUE(CompareColor(expected_outlier_color_, color, screen_coord))
-                << "Color at: " << screen_coord << " for test: " << name;
+          << "Color at: " << screen_coord << " for test: " << name;
       EXPECT_TRUE(IsExpectedDepth(depth, screen_coord, expected_outlier_depth_,
                                   kDepthTolerance))
-                << "Depth at: " << screen_coord << " for test: " << name;
+          << "Depth at: " << screen_coord << " for test: " << name;
       EXPECT_EQ(label.at(x, y)[0], expected_outlier_label_)
-                << "Label at: " << screen_coord << " for test: " << name;
+          << "Label at: " << screen_coord << " for test: " << name;
     }
   }
 
-  void SetUp() override {
-    ResetExpectations();
-  }
+  void SetUp() override { ResetExpectations(); }
 
   // Tests that don't instantiate their own renderers should invoke this.
   void Init(const RigidTransformd& X_WR, bool add_terrain = false) {
-    const Vector3d bg_rgb{
-        kBgColor.r / 255., kBgColor.g / 255., kBgColor.b / 255.};
+    const Vector3d bg_rgb{kBgColor.r / 255., kBgColor.g / 255.,
+                          kBgColor.b / 255.};
     RenderEngineVtkParams params{{}, {}, bg_rgb};
     renderer_ = make_unique<RenderEngineVtk>(params);
     InitializeRenderer(X_WR, add_terrain, renderer_.get());
     // Ensure that we truly have a non-default color.
-    EXPECT_FALSE(IsColorNear(
-        RgbaColor(kDefaultVisualColor, 1.),
-        RgbaColor(renderer_->default_diffuse())));
+    EXPECT_FALSE(IsColorNear(RgbaColor(kDefaultVisualColor, 1.),
+                             RgbaColor(renderer_->default_diffuse())));
   }
 
   // Tests that instantiate their own renderers can initialize their renderers
@@ -458,8 +452,7 @@ class RenderEngineVtkTest : public ::testing::Test {
   // Performs the work to test the rendering with a shape centered in the
   // image. To pass, the renderer will have to have been populated with a
   // compatible shape and camera configuration (e.g., PopulateSphereTest()).
-  void PerformCenterShapeTest(RenderEngineVtk* renderer,
-                              const char* name,
+  void PerformCenterShapeTest(RenderEngineVtk* renderer, const char* name,
                               const DepthRenderCamera* camera = nullptr) {
     const DepthRenderCamera& cam = camera ? *camera : depth_camera_;
     const int w = cam.core().intrinsics().width();
@@ -474,12 +467,11 @@ class RenderEngineVtkTest : public ::testing::Test {
     VerifyCenterShapeTest(*renderer, name, cam, color, depth, label);
   }
 
-  void VerifyCenterShapeTest(const RenderEngineVtk& renderer,
-                              const char* name,
-                              const DepthRenderCamera& camera,
-                              const ImageRgba8U& color,
-                              const ImageDepth32F& depth,
-                              const ImageLabel16I& label) const {
+  void VerifyCenterShapeTest(const RenderEngineVtk& renderer, const char* name,
+                             const DepthRenderCamera& camera,
+                             const ImageRgba8U& color,
+                             const ImageDepth32F& depth,
+                             const ImageLabel16I& label) const {
     VerifyOutliers(renderer, camera, name, &color, &depth, &label);
 
     // Verifies inside the sphere.
@@ -487,12 +479,12 @@ class RenderEngineVtkTest : public ::testing::Test {
     const int x = inlier.x;
     const int y = inlier.y;
     EXPECT_TRUE(CompareColor(expected_color_, color, inlier))
-              << "Color at: " << inlier << " for test: " << name;
-    EXPECT_TRUE(IsExpectedDepth(depth, inlier, expected_object_depth_,
-                                kDepthTolerance))
-              << "Depth at: " << inlier << " for test: " << name;
+        << "Color at: " << inlier << " for test: " << name;
+    EXPECT_TRUE(
+        IsExpectedDepth(depth, inlier, expected_object_depth_, kDepthTolerance))
+        << "Depth at: " << inlier << " for test: " << name;
     EXPECT_EQ(label.at(x, y)[0], static_cast<int>(expected_label_))
-              << "Label at: " << inlier << " for test: " << name;
+        << "Label at: " << inlier << " for test: " << name;
   }
 
   RgbaColor expected_color_{kDefaultVisualColor, 255};
@@ -585,7 +577,7 @@ TEST_F(RenderEngineVtkTest, TerrainTest) {
 TEST_F(RenderEngineVtkTest, HorizonTest) {
   // Camera at the origin, pointing in a direction parallel to the ground.
   RigidTransformd X_WR{RotationMatrixd{AngleAxisd(-M_PI_2, Vector3d::UnitX()) *
-      AngleAxisd(M_PI_2, Vector3d::UnitY())}};
+                                       AngleAxisd(M_PI_2, Vector3d::UnitY())}};
   Init(X_WR, true);
 
   const ColorRenderCamera camera(depth_camera_.core(), kShowWindow);
@@ -669,8 +661,7 @@ TEST_F(RenderEngineVtkTest, BoxTest) {
                             Vector2d{texture_scale, texture_scale});
         }
       }
-      renderer_->RegisterVisual(id, box, props,
-                                RigidTransformd::Identity(),
+      renderer_->RegisterVisual(id, box, props, RigidTransformd::Identity(),
                                 true /* needs update */);
       // We want to position the box so that one corner of the box exactly
       // covers the pixel used for the "inlier test" (w/2, h/2). We can't put
@@ -713,9 +704,9 @@ TEST_F(RenderEngineVtkTest, BoxTest) {
       PerformCenterShapeTest(
           renderer_.get(),
           fmt::format("Box test - {}",
-                      use_texture ?
-                      (texture_scaled ? "scaled texture" : "unscaled texture") :
-                      "diffuse color")
+                      use_texture ? (texture_scaled ? "scaled texture"
+                                                    : "unscaled texture")
+                                  : "diffuse color")
               .c_str());
     }
   }
@@ -1198,9 +1189,9 @@ TEST_F(RenderEngineVtkTest, RemoveVisual) {
 // Optimizers on some platforms break code and cause test failures. Worse
 // still, there is no agreement on attribute spelling.
 #ifdef __clang__
-__attribute__((optnone))
+      __attribute__((optnone))
 #else
-__attribute__((optimize("-O0")))
+      __attribute__((optimize("-O0")))
 #endif
   {
     expected_color_ = color;
@@ -1352,12 +1343,11 @@ TEST_F(RenderEngineVtkTest, DifferentCameras) {
     // NOTE: Need to restored expected outlier depth for next test.
     expected_outlier_depth_ = old_outlier_depth;
 
-      const DepthRenderCamera clipping_near_plane{
+    const DepthRenderCamera clipping_near_plane{
         depth_camera_.core(),
         {expected_object_depth_ + 0.1, depth_range.max_depth()}};
     expected_object_depth_ = 0;
-    PerformCenterShapeTest(renderer_.get(),
-                           "Camera change - z near clips mesh",
+    PerformCenterShapeTest(renderer_.get(), "Camera change - z near clips mesh",
                            &clipping_near_plane);
   }
 }
@@ -1386,8 +1376,7 @@ TEST_F(RenderEngineVtkTest, DefaultProperties_RenderLabel) {
     expected_label_ = RenderLabel::kDontCare;
     expected_color_ = RgbaColor(renderer.default_diffuse());
 
-    PerformCenterShapeTest(&renderer,
-                           "Default properties; don't care label");
+    PerformCenterShapeTest(&renderer, "Default properties; don't care label");
   }
 
   // Case: Change render engine's default to explicitly be unspecified; must
@@ -1412,14 +1401,13 @@ TEST_F(RenderEngineVtkTest, DefaultProperties_RenderLabel) {
     expected_label_ = RenderLabel::kDontCare;
     expected_color_ = RgbaColor(renderer.default_diffuse());
 
-    PerformCenterShapeTest(&renderer,
-                           "Default properties; don't care label");
+    PerformCenterShapeTest(&renderer, "Default properties; don't care label");
   }
 
   // Case: Change render engine's default to invalid default value; must throw.
   {
     for (RenderLabel label :
-        {RenderLabel::kEmpty, RenderLabel(1), RenderLabel::kDoNotRender}) {
+         {RenderLabel::kEmpty, RenderLabel(1), RenderLabel::kDoNotRender}) {
       DRAKE_EXPECT_THROWS_MESSAGE(
           RenderEngineVtk({label, {}}),
           ".* default render label .* either 'kUnspecified' or 'kDontCare'.*");
@@ -1685,35 +1673,28 @@ TEST_F(RenderEngineVtkTest, SingleLight) {
        .expected_color = Rgba(0, 0, 0),
        // The lights are positioned badly to illuminate anything.
        .description = "World coordinates in the camera frame - nothing lit!"},
-      {.light = {.color = light_color,
-                 .cone_angle = 22.5},
+      {.light = {.color = light_color, .cone_angle = 22.5},
        .expected_color = modulated_color,
        .description = "Non-white light color"},
-      {.light = {.intensity = 0.1,
-                 .cone_angle = 22.5},
+      {.light = {.intensity = 0.1, .cone_angle = 22.5},
        .expected_color = kTerrainRgba.scale_rgb(0.1),
        .description = "Low intensity"},
-      {.light = {.intensity = 3.0,
-                 .cone_angle = 22.5},
+      {.light = {.intensity = 3.0, .cone_angle = 22.5},
        .expected_color = kTerrainRgba.scale_rgb(3),
        .description = "High intensity"},
-      {.light = {.attenuation_values = {2, 0, 0},
-                 .cone_angle = 22.5},
+      {.light = {.attenuation_values = {2, 0, 0}, .cone_angle = 22.5},
        .expected_color = kTerrainRgba.scale_rgb(0.5),
        .description = "Non-unit constant attenuation"},
-      {.light = {.attenuation_values = {0, 1, 0},
-                 .cone_angle = 22.5},
+      {.light = {.attenuation_values = {0, 1, 0}, .cone_angle = 22.5},
        .expected_color = kTerrainRgba.scale_rgb(1 / dist),
        .description = "Linear attenuation"},
-      {.light = {.attenuation_values = {0, 0, 1},
-                 .cone_angle = 22.5},
+      {.light = {.attenuation_values = {0, 0, 1}, .cone_angle = 22.5},
        .expected_color = kTerrainRgba.scale_rgb(1 / (dist * dist)),
        .description = "Quadratic attenuation"},
       {.light = {.cone_angle = 0},
        .expected_color = Rgba(0, 0, 0),
        .description = "Zero cone angle",
-       .target_type = "spot"}
-      };
+       .target_type = "spot"}};
 
   for (const auto& config : configs) {
     for (const auto& l_type : {"point", "spot", "directional"}) {
@@ -1756,7 +1737,7 @@ TEST_F(RenderEngineVtkTest, SingleLight) {
 TEST_F(RenderEngineVtkTest, MultiLights) {
   const ColorRenderCamera camera(depth_camera_.core(), kShowWindow);
   const RigidTransformd X_WR(RotationMatrixd::MakeXRotation(M_PI),
-                              Vector3d(0, 0, 3));
+                             Vector3d(0, 0, 3));
   ImageRgba8U image(camera.core().intrinsics().width(),
                     camera.core().intrinsics().height());
   const int cx = image.width() / 2;
@@ -1767,20 +1748,12 @@ TEST_F(RenderEngineVtkTest, MultiLights) {
   // should get 75% of the diffuse color. To test the non-limits on the number
   // of lights, we'll duplicate each light with half the intensity.
   const RenderEngineVtkParams params{
-      .lights = {{.type = "point",
-                  .intensity = 0.25 * 0.5},
-                  {.type = "point",
-                  .intensity = 0.25 * 0.5},
-                  {.type = "spot",
-                  .intensity = 0.25 * 0.5,
-                  .cone_angle = 45},
-                  {.type = "spot",
-                  .intensity = 0.25 * 0.5,
-                  .cone_angle = 45},
-                  {.type = "directional",
-                  .intensity = 0.25 * 0.5},
-                  {.type = "directional",
-                  .intensity = 0.25 * 0.5}}};
+      .lights = {{.type = "point", .intensity = 0.25 * 0.5},
+                 {.type = "point", .intensity = 0.25 * 0.5},
+                 {.type = "spot", .intensity = 0.25 * 0.5, .cone_angle = 45},
+                 {.type = "spot", .intensity = 0.25 * 0.5, .cone_angle = 45},
+                 {.type = "directional", .intensity = 0.25 * 0.5},
+                 {.type = "directional", .intensity = 0.25 * 0.5}}};
   RenderEngineVtk renderer(params);
 
   InitializeRenderer(X_WR, true /* add terrain */, &renderer);
@@ -1855,8 +1828,7 @@ Vector4<int> FindBoxEdges(const ImageType& image) {
 
       // Look for edge between current pixel and pixel below.
       const T* bottom_pixel = image.at(x, y + 1);
-      const AdjacentPixel bottom_result =
-          Compare(curr_pixel, bottom_pixel);
+      const AdjacentPixel bottom_result = Compare(curr_pixel, bottom_pixel);
       if (bottom_result == GroundToBox) {
         // Current lies on the ground, next lies on the box; bottom edge.
         DRAKE_DEMAND(edges(3) == -1 || edges(3) == y + 1);
@@ -1869,8 +1841,7 @@ Vector4<int> FindBoxEdges(const ImageType& image) {
 
       // Look for edge between current pixel and pixel to the right.
       const T* right_pixel = image.at(x + 1, y);
-      const AdjacentPixel right_result =
-          Compare(curr_pixel, right_pixel);
+      const AdjacentPixel right_result = Compare(curr_pixel, right_pixel);
       if (right_result == GroundToBox) {
         // Current lies on the ground, next lies on the box; left edge.
         DRAKE_DEMAND(edges(0) == -1 || edges(0) == x + 1);
@@ -1884,7 +1855,7 @@ Vector4<int> FindBoxEdges(const ImageType& image) {
   }
 
   return edges;
-  }
+}
 
 }  // namespace
 
@@ -2081,12 +2052,12 @@ TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
     renderer_->RenderDepthImage(depth_camera, &depth);
 
     // Confirm pixel in corner (ground) and pixel in center (box).
-    EXPECT_TRUE(
-        IsExpectedDepth(depth, ScreenCoord{w / 2, h / 2},
-            ImageTraits<PixelType::kDepth32F>::kTooClose, 0.0));
-    EXPECT_TRUE(
-        IsExpectedDepth(depth, ScreenCoord{0, 0},
-            ImageTraits<PixelType::kDepth32F>::kTooFar, 0.0));
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{w / 2, h / 2},
+                                ImageTraits<PixelType::kDepth32F>::kTooClose,
+                                0.0));
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{0, 0},
+                                ImageTraits<PixelType::kDepth32F>::kTooFar,
+                                0.0));
   }
 
   {
@@ -2100,12 +2071,12 @@ TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
     renderer_->RenderDepthImage(depth_camera, &depth);
 
     // Confirm pixel in corner (ground) and pixel in center (box).
-    EXPECT_TRUE(
-        IsExpectedDepth(depth, ScreenCoord{w / 2, h / 2},
-            ImageTraits<PixelType::kDepth32F>::kTooFar, 0.0));
-    EXPECT_TRUE(
-        IsExpectedDepth(depth, ScreenCoord{0, 0},
-            ImageTraits<PixelType::kDepth32F>::kTooFar, 0.0));
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{w / 2, h / 2},
+                                ImageTraits<PixelType::kDepth32F>::kTooFar,
+                                0.0));
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{0, 0},
+                                ImageTraits<PixelType::kDepth32F>::kTooFar,
+                                0.0));
   }
 
   {
@@ -2122,12 +2093,12 @@ TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
     renderer_->RenderDepthImage(depth_camera, &depth);
 
     // Confirm pixel in corner (ground) and pixel in center (box).
-    EXPECT_TRUE(
-        IsExpectedDepth(depth, ScreenCoord{w / 2, h / 2},
-            ImageTraits<PixelType::kDepth32F>::kTooClose, 0.0));
-    EXPECT_TRUE(
-        IsExpectedDepth(depth, ScreenCoord{0, 0},
-            ImageTraits<PixelType::kDepth32F>::kTooClose, 0.0));
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{w / 2, h / 2},
+                                ImageTraits<PixelType::kDepth32F>::kTooClose,
+                                0.0));
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{0, 0},
+                                ImageTraits<PixelType::kDepth32F>::kTooClose,
+                                0.0));
   }
 }
 

--- a/geometry/render_vtk/test/internal_vtk_util_test.cc
+++ b/geometry/render_vtk/test/internal_vtk_util_test.cc
@@ -27,16 +27,17 @@ struct Point {
   double z;
 };
 
+// clang-format off
 const Point kExpectedPointSet[kNumPoints] = {
   Point{ kHalfSize, -kHalfSize, 0.},
   Point{ kHalfSize,  kHalfSize, 0.},
   Point{-kHalfSize, -kHalfSize, 0.},
   Point{-kHalfSize,  kHalfSize, 0.}
 };
+// clang-format on
 
 GTEST_TEST(PointsCorrespondenceTest, PlaneCreationTest) {
-  vtkSmartPointer<vtkPlaneSource> dut =
-      CreateSquarePlane(kSize);
+  vtkSmartPointer<vtkPlaneSource> dut = CreateSquarePlane(kSize);
 
   EXPECT_EQ(kNumPoints, dut->GetOutput()->GetPoints()->GetNumberOfPoints());
   for (int i = 0; i < kNumPoints; ++i) {
@@ -52,18 +53,17 @@ GTEST_TEST(PointsCorrespondenceTest, PlaneCreationTest) {
 // Verifies whether the conversion is correct.
 GTEST_TEST(ConvertToVtkTransformTest, ConversionTest) {
   const math::RigidTransformd expected(
-       Eigen::AngleAxisd(1., Eigen::Vector3d(1. / std::sqrt(3.),
-                                             1. / std::sqrt(3.),
-                                             1. / std::sqrt(3.))),
-       Eigen::Vector3d(1., 2., 3.));
+      Eigen::AngleAxisd(1.,
+                        Eigen::Vector3d(1. / std::sqrt(3.), 1. / std::sqrt(3.),
+                                        1. / std::sqrt(3.))),
+      Eigen::Vector3d(1., 2., 3.));
 
   auto dut = ConvertToVtkTransform(expected);
 
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
       EXPECT_NEAR(expected.GetAsMatrix4()(i, j),
-                  dut->GetMatrix()->GetElement(i, j),
-                  kTolerance);
+                  dut->GetMatrix()->GetElement(i, j), kTolerance);
     }
   }
 }


### PR DESCRIPTION
Updates formatting to pass lint tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20007)
<!-- Reviewable:end -->
