### PR TITLE
[sensors] Add to_string and PixelScalar

### DIFF
--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -62,6 +62,10 @@ PYBIND11_MODULE(sensors, m) {
   py::module::import("pydrake.geometry");
   py::module::import("pydrake.systems.framework");
 
+  // Note: for this module's C++ enums we choose not to bind the C++ `to_string`
+  // functions as `__str__` in Python. The `enum.Enum` class already provides a
+  // `__str__` that looks more Pythonic than our C++ `to_string`.
+
   // Expose only types that are used.
   py::enum_<PixelFormat>(m, "PixelFormat")
       .value("kRgba", PixelFormat::kRgba)
@@ -105,7 +109,8 @@ PYBIND11_MODULE(sensors, m) {
       pixel_type.value(pixel_type_name.c_str(), kPixelType);
       py::tuple py_param = GetPyParam(param);
 
-      // Add traits.
+      // Add traits. Note that we choose not to bind kPixelScalar because the
+      // ChannelType already makes the same information easily available.
       py::class_<ImageTraitsT> traits(
           m, TemporaryClassName<ImageTraitsT>().c_str());
       traits.attr("ChannelType") = GetPyParam<T>()[0];

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -426,6 +426,13 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "pixel_types_test",
+    deps = [
+        ":image",
+    ],
+)
+
+drake_cc_googletest(
     name = "rgbd_sensor_test",
     tags = vtk_test_tags(),
     deps = [

--- a/systems/sensors/pixel_types.cc
+++ b/systems/sensors/pixel_types.cc
@@ -1,4 +1,71 @@
 #include "drake/systems/sensors/pixel_types.h"
 
-// For now, this is an empty .cc file that only serves to confirm
-// pixel_types.h is a stand-alone header.
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+std::string to_string(PixelType x) {
+  switch (x) {
+    case PixelType::kRgb8U:
+      return "Rgb8U";
+    case PixelType::kBgr8U:
+      return "Bgr8U";
+    case PixelType::kRgba8U:
+      return "Rgba8U";
+    case PixelType::kBgra8U:
+      return "Bgra8U";
+    case PixelType::kGrey8U:
+      return "Grey8U";
+    case PixelType::kDepth16U:
+      return "Depth16U";
+    case PixelType::kDepth32F:
+      return "Depth32F";
+    case PixelType::kLabel16I:
+      return "Label16I";
+    case PixelType::kExpr:
+      return "Expr";
+  }
+  DRAKE_UNREACHABLE();
+}
+
+std::string to_string(PixelFormat x) {
+  switch (x) {
+    case PixelFormat::kRgb:
+      return "Rgb";
+    case PixelFormat::kBgr:
+      return "Bgr";
+    case PixelFormat::kRgba:
+      return "Rgba";
+    case PixelFormat::kBgra:
+      return "Bgra";
+    case PixelFormat::kGrey:
+      return "Grey";
+    case PixelFormat::kDepth:
+      return "Depth";
+    case PixelFormat::kLabel:
+      return "Label";
+    case PixelFormat::kExpr:
+      return "Expr";
+  }
+  DRAKE_UNREACHABLE();
+}
+
+std::string to_string(PixelScalar x) {
+  switch (x) {
+    case PixelScalar::k8U:
+      return "8U";
+    case PixelScalar::k16I:
+      return "16I";
+    case PixelScalar::k16U:
+      return "16U";
+    case PixelScalar::k32F:
+      return "32F";
+  }
+  DRAKE_UNREACHABLE();
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/pixel_types.h
+++ b/systems/sensors/pixel_types.h
@@ -2,7 +2,9 @@
 
 #include <cstdint>
 #include <limits>
+#include <string>
 
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/expression.h"
 
@@ -20,7 +22,7 @@ namespace sensors {
 /// - F: float
 enum class PixelType {
   /// The pixel format used by ImageRgb8U.
-  kRgb8U = 0,
+  kRgb8U,
   /// The pixel format used by ImageBgr8U.
   kBgr8U,
   /// The pixel format used by ImageRgba8U.
@@ -39,12 +41,14 @@ enum class PixelType {
   kExpr,
 };
 
+std::string to_string(PixelType);
+
 /// The enum class to be used to express semantic meaning of pixels.
 /// This also expresses the order of channels in a pixel if the pixel has
 /// multiple channels.
 enum class PixelFormat {
   /// The pixel format used for all the RGB images.
-  kRgb = 0,
+  kRgb,
   /// The pixel format used for all the BGR images.
   kBgr,
   /// The pixel format used for all the RGBA images.
@@ -60,6 +64,22 @@ enum class PixelFormat {
   /// The pixel format used for all the symbolic images.
   kExpr,
 };
+
+std::string to_string(PixelFormat);
+
+/// The enum class to be used to express channel type.
+enum class PixelScalar {
+  /// uint8_t
+  k8U,
+  /// int16_t
+  k16I,
+  /// uint16_t
+  k16U,
+  /// float (32-bit)
+  k32F,
+};
+
+std::string to_string(PixelScalar);
 
 /// Traits class for Image, specialized by PixelType.
 ///
@@ -85,6 +105,7 @@ template <>
 struct ImageTraits<PixelType::kRgb8U> {
   typedef uint8_t ChannelType;
   static constexpr int kNumChannels = 3;
+  static constexpr PixelScalar kPixelScalar = PixelScalar::k8U;
   static constexpr PixelFormat kPixelFormat = PixelFormat::kRgb;
 };
 
@@ -92,6 +113,7 @@ template <>
 struct ImageTraits<PixelType::kBgr8U> {
   typedef uint8_t ChannelType;
   static constexpr int kNumChannels = 3;
+  static constexpr PixelScalar kPixelScalar = PixelScalar::k8U;
   static constexpr PixelFormat kPixelFormat = PixelFormat::kBgr;
 };
 
@@ -99,6 +121,7 @@ template <>
 struct ImageTraits<PixelType::kRgba8U> {
   typedef uint8_t ChannelType;
   static constexpr int kNumChannels = 4;
+  static constexpr PixelScalar kPixelScalar = PixelScalar::k8U;
   static constexpr PixelFormat kPixelFormat = PixelFormat::kRgba;
 };
 
@@ -106,6 +129,7 @@ template <>
 struct ImageTraits<PixelType::kBgra8U> {
   typedef uint8_t ChannelType;
   static constexpr int kNumChannels = 4;
+  static constexpr PixelScalar kPixelScalar = PixelScalar::k8U;
   static constexpr PixelFormat kPixelFormat = PixelFormat::kBgra;
 };
 
@@ -113,6 +137,7 @@ template <>
 struct ImageTraits<PixelType::kDepth32F> {
   typedef float ChannelType;
   static constexpr int kNumChannels = 1;
+  static constexpr PixelScalar kPixelScalar = PixelScalar::k32F;
   static constexpr PixelFormat kPixelFormat = PixelFormat::kDepth;
   static constexpr ChannelType kTooClose = 0.0f;
   static constexpr ChannelType kTooFar =
@@ -123,6 +148,7 @@ template <>
 struct ImageTraits<PixelType::kDepth16U> {
   typedef uint16_t ChannelType;
   static constexpr int kNumChannels = 1;
+  static constexpr PixelScalar kPixelScalar = PixelScalar::k16U;
   static constexpr PixelFormat kPixelFormat = PixelFormat::kDepth;
   static constexpr ChannelType kTooClose = 0;
   static constexpr ChannelType kTooFar =
@@ -133,6 +159,7 @@ template <>
 struct ImageTraits<PixelType::kLabel16I> {
   typedef int16_t ChannelType;
   static constexpr int kNumChannels = 1;
+  static constexpr PixelScalar kPixelScalar = PixelScalar::k16I;
   static constexpr PixelFormat kPixelFormat = PixelFormat::kLabel;
 };
 
@@ -140,6 +167,7 @@ template <>
 struct ImageTraits<PixelType::kGrey8U> {
   typedef uint8_t ChannelType;
   static constexpr int kNumChannels = 1;
+  static constexpr PixelScalar kPixelScalar = PixelScalar::k8U;
   static constexpr PixelFormat kPixelFormat = PixelFormat::kGrey;
 };
 
@@ -159,3 +187,10 @@ namespace std {
 template <>
 struct hash<drake::systems::sensors::PixelType> : public drake::DefaultHash {};
 }  // namespace std
+
+DRAKE_FORMATTER_AS(, drake::systems::sensors, PixelType, x,
+                   drake::systems::sensors::to_string(x))
+DRAKE_FORMATTER_AS(, drake::systems::sensors, PixelFormat, x,
+                   drake::systems::sensors::to_string(x))
+DRAKE_FORMATTER_AS(, drake::systems::sensors, PixelScalar, x,
+                   drake::systems::sensors::to_string(x))

--- a/systems/sensors/test/pixel_types_test.cc
+++ b/systems/sensors/test/pixel_types_test.cc
@@ -1,0 +1,19 @@
+#include "drake/systems/sensors/pixel_types.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace {
+
+GTEST_TEST(PixelTypesTest, Formatters) {
+  EXPECT_EQ(fmt::to_string(PixelType::kRgba8U), "Rgba8U");
+  EXPECT_EQ(fmt::to_string(PixelFormat::kRgba), "Rgba");
+  EXPECT_EQ(fmt::to_string(PixelScalar::k8U), "8U");
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
The `PixelScalar` is useful to denote image scalar types as values, in contrast with the `ChannelType` typedef which is only usable for template programming.

Both of these features will be used soon as part of a new [consolidated image I/O feature](https://github.com/jwnimmer-tri/drake/commits/image-io).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20015)
<!-- Reviewable:end -->
