### PR TITLE
[sensors] Add image_compare test utility

### DIFF
--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -222,6 +222,7 @@ drake_cc_googletest(
         "//common:find_resource",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+        "//systems/sensors/test_utilities:image_compare",
     ],
 )
 
@@ -237,6 +238,7 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+        "//systems/sensors/test_utilities:image_compare",
         "@nlohmann_internal//:nlohmann",
     ],
 )

--- a/geometry/render_gltf_client/test/internal_render_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_client_test.cc
@@ -22,30 +22,9 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/render_gltf_client/internal_http_service.h"
 #include "drake/geometry/render_gltf_client/test/internal_sample_image_data.h"
+#include "drake/systems/sensors/test_utilities/image_compare.h"
 
 namespace drake {
-namespace systems {
-namespace sensors {
-// Add support for printing EXPECT_EQ(Image, Image) failures.
-template <PixelType kPixelType>
-void PrintTo(const Image<kPixelType>& image, std::ostream* os) {
-  using T = typename Image<kPixelType>::T;
-  using Promoted = std::conditional_t<std::is_integral_v<T>, int, T>;
-  constexpr int num_channels = Image<kPixelType>::kNumChannels;
-  const int width = image.width();
-  const int height = image.height();
-  *os << "\n";
-  for (int z = 0; z < num_channels; ++z) {
-    const T* const base = image.at(0, 0) + z;
-    using Stride = Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>;
-    Eigen::Map<const MatrixX<T>, 0, Stride> eigen(
-        base, height, width, Stride(num_channels, width * num_channels));
-    fmt::print(*os, "Channel {}:\n", z);
-    fmt::print(*os, "{}\n", fmt_eigen(eigen.template cast<Promoted>()));
-  }
-}
-}  // namespace sensors
-}  // namespace systems
 namespace geometry {
 namespace render_gltf_client {
 namespace internal {

--- a/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -22,6 +22,10 @@
 #include "drake/geometry/render_gltf_client/render_engine_gltf_client_params.h"
 #include "drake/geometry/render_gltf_client/test/internal_sample_image_data.h"
 
+// This might *seem* to be unused, but don't remove it! We rely on this to dump
+// images to the console when calling `EXPECT_EQ(Image<...>, Image<...>)`.
+#include "drake/systems/sensors/test_utilities/image_compare.h"
+
 namespace drake {
 namespace geometry {
 namespace render_gltf_client {

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -421,7 +421,16 @@ drake_cc_googletest(
         ":image_writer",
         "//common:temp_directory",
         "//common/test_utilities",
-        "@vtk//:vtkIOImage",
+        "//systems/sensors/test_utilities:image_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "image_writer_free_functions_test",
+    deps = [
+        ":image_writer",
+        "//common:temp_directory",
+        "//systems/sensors/test_utilities:image_compare",
     ],
 )
 

--- a/systems/sensors/test/image_writer_free_functions_test.cc
+++ b/systems/sensors/test/image_writer_free_functions_test.cc
@@ -1,0 +1,106 @@
+#include <filesystem>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/temp_directory.h"
+#include "drake/systems/sensors/image_writer.h"
+#include "drake/systems/sensors/test_utilities/image_compare.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+namespace fs = std::filesystem;
+
+namespace {
+
+class SaveImageTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    const std::string name =
+        testing::UnitTest::GetInstance()->current_test_info()->name();
+    filename_ =
+        (fs::path(temp_directory()) / fmt::format("{}.png", name)).string();
+  }
+
+  template <PixelType kPixelType>
+  void CheckReadback(const Image<kPixelType>& expected) {
+    Image<kPixelType> readback;
+    ASSERT_TRUE(LoadImage(filename_, &readback));
+    EXPECT_EQ(readback, expected);
+  }
+
+ protected:
+  std::string filename_;
+};
+
+// Saves a simple 4x1 image consisting of: [red][green][blue][white].
+TEST_F(SaveImageTest, SaveToPng_Color) {
+  Image<PixelType::kRgba8U> image(4, 1);
+  auto set_color = [&image](int x, int y, uint8_t r, uint8_t g, uint8_t b) {
+    image.at(x, y)[0] = r;
+    image.at(x, y)[1] = g;
+    image.at(x, y)[2] = b;
+    image.at(x, y)[3] = 255;
+  };
+  set_color(0, 0, 255, 0, 0);
+  set_color(1, 0, 0, 255, 0);
+  set_color(2, 0, 0, 0, 255);
+  set_color(3, 0, 255, 255, 255);
+  EXPECT_NO_THROW(SaveToPng(image, filename_));
+  CheckReadback(image);
+}
+
+// Saves a simple 4x1 image consisting of: 0, 0.25, 0.5, 0.75
+TEST_F(SaveImageTest, SaveToTiff_Depth) {
+  Image<PixelType::kDepth32F> image(4, 1);
+  *image.at(0, 0) = 0.0f;
+  *image.at(1, 0) = 0.25f;
+  *image.at(2, 0) = 0.5f;
+  *image.at(3, 0) = 1.0f;
+  EXPECT_NO_THROW(SaveToTiff(image, filename_));
+  CheckReadback(image);
+}
+
+// Saves a simple 4x1 image consisting of: 0, 100, 200, 300.
+// Note: value > 255 to make sure that values aren't being truncated/wrapped
+// to 8-bit values.
+TEST_F(SaveImageTest, SaveToPng_Label) {
+  Image<PixelType::kLabel16I> image(4, 1);
+  *image.at(0, 0) = 0;
+  *image.at(1, 0) = 100;
+  *image.at(2, 0) = 200;
+  *image.at(3, 0) = 300;
+  EXPECT_NO_THROW(SaveToPng(image, filename_));
+  CheckReadback(image);
+}
+
+// Saves a simple 4x1 image consisting of: 0, 100, 200, 300.
+// Note: value > 255 to make sure that values aren't being truncated/wrapped
+// to 8-bit values.
+TEST_F(SaveImageTest, SaveToPng_Depth16) {
+  Image<PixelType::kDepth16U> image(4, 1);
+  *image.at(0, 0) = 0;
+  *image.at(1, 0) = 100;
+  *image.at(2, 0) = 200;
+  *image.at(3, 0) = 300;
+  EXPECT_NO_THROW(SaveToPng(image, filename_));
+  CheckReadback(image);
+}
+
+// Saves a simple 4x1 image consisting of: 1, 2, 3, 4.
+TEST_F(SaveImageTest, SaveToPng_Grey) {
+  Image<PixelType::kGrey8U> image(4, 1);
+  *image.at(0, 0) = 1;
+  *image.at(1, 0) = 2;
+  *image.at(2, 0) = 3;
+  *image.at(3, 0) = 4;
+  EXPECT_NO_THROW(SaveToPng(image, filename_));
+  CheckReadback(image);
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/image_writer_test.cc
+++ b/systems/sensors/test/image_writer_test.cc
@@ -8,17 +8,12 @@
 #include <string>
 
 #include <gtest/gtest.h>
-#include <vtkImageData.h>
-#include <vtkImageExport.h>
-#include <vtkNew.h>
-#include <vtkPNGReader.h>
-#include <vtkSmartPointer.h>
-#include <vtkTIFFReader.h>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/systems/framework/event_collection.h"
+#include "drake/systems/sensors/test_utilities/image_compare.h"
 
 namespace drake {
 namespace systems {
@@ -207,74 +202,6 @@ class ImageWriterTest : public ::testing::Test {
   }
 
   template <PixelType kPixelType>
-  static ::testing::AssertionResult ReadImage(const std::string& image_name,
-                                              Image<kPixelType>* image) {
-    fs::path image_path(image_name);
-    if (fs::exists(image_path)) {
-      vtkSmartPointer<vtkImageReader2> reader;
-      switch (kPixelType) {
-        case PixelType::kRgba8U:
-        case PixelType::kGrey8U:
-        case PixelType::kDepth16U:
-        case PixelType::kLabel16I:
-          reader = vtkSmartPointer<vtkPNGReader>::New();
-          break;
-        case PixelType::kDepth32F:
-          reader = vtkSmartPointer<vtkTIFFReader>::New();
-          break;
-        default:
-          return ::testing::AssertionFailure()
-                 << "Trying to read an unknown image type";
-      }
-      reader->SetFileName(image_name.c_str());
-      vtkNew<vtkImageExport> exporter;
-      exporter->SetInputConnection(reader->GetOutputPort());
-      exporter->Update();
-      vtkImageData* image_data = exporter->GetInput();
-      // Assumes 1-dimensional data -- the 4x1 image.
-      if (image_data->GetDataDimension() == 1) {
-        int read_width;
-        image_data->GetDimensions(&read_width);
-        if (read_width == image->width()) {
-          exporter->Export(image->at(0, 0));
-          return ::testing::AssertionSuccess();
-        }
-      }
-      int dims[3];
-      exporter->GetDataDimensions(&dims[0]);
-      return ::testing::AssertionFailure()
-             << "Expected a " << image->width() << "x" << image->height()
-             << "image. Read an image of size: " << dims[0] << "x" << dims[1]
-             << "x" << dims[2];
-    } else {
-      return ::testing::AssertionFailure()
-             << "The image to be read does not exist: " << image_name;
-    }
-  }
-
-  template <PixelType kPixelType>
-  static ::testing::AssertionResult MatchesFileOnDisk(
-      const std::string& file_name, const Image<kPixelType>& expected) {
-    Image<kPixelType> read_image(expected.width(), expected.height());
-    auto result = ReadImage(file_name, &read_image);
-    if (result == ::testing::AssertionSuccess()) {
-      for (int u = 0; u < 4; ++u) {
-        for (int c = 0; c < ImageTraits<kPixelType>::kNumChannels; ++c) {
-          if (read_image.at(u, 0)[c] != expected.at(u, 0)[c]) {
-            if (result != ::testing::AssertionFailure()) {
-              result = ::testing::AssertionFailure();
-            }
-            result << "\nPixel (" << u << ", 0)[" << c << "] doesn't match. "
-                   << "From disk(" << read_image.at(u, 0)[0]
-                   << ", reference image: " << expected.at(u, 0)[0];
-          }
-        }
-      }
-    }
-    return result;
-  }
-
-  template <PixelType kPixelType>
   static void TestWritingImageOnPort() {
     ImageWriter writer;
     ImageWriterTester tester(writer);
@@ -305,7 +232,9 @@ class ImageWriterTest : public ::testing::Test {
     EXPECT_EQ(1, tester.port_count(port.get_index()));
     add_file_for_cleanup(expected_file.string());
 
-    EXPECT_TRUE(MatchesFileOnDisk(expected_name, image));
+    Image<kPixelType> readback;
+    ASSERT_TRUE(LoadImage(expected_name, &readback));
+    EXPECT_EQ(readback, image);
   }
 
  private:
@@ -697,56 +626,6 @@ TEST_F(ImageWriterTest, WritesDepthImage16U) {
 // This simply confirms that the color image gets written to the right format.
 TEST_F(ImageWriterTest, WritesGreyImage) {
   TestWritingImageOnPort<PixelType::kGrey8U>();
-}
-
-// Evaluate the stand-alone test for color images.
-TEST_F(ImageWriterTest, SaveToPng_Color) {
-  ImageRgba8U color_image = test_image<PixelType::kRgba8U>();
-
-  const std::string color_image_name = temp_name();
-  SaveToPng(color_image, color_image_name);
-
-  EXPECT_TRUE(MatchesFileOnDisk(color_image_name, color_image));
-}
-
-// Evaluate the stand-alone test for depth images.
-TEST_F(ImageWriterTest, SaveToTiff_Depth) {
-  ImageDepth32F depth_image = test_image<PixelType::kDepth32F>();
-
-  const std::string depth_image_name = temp_name();
-  SaveToTiff(depth_image, depth_image_name);
-
-  EXPECT_TRUE(MatchesFileOnDisk(depth_image_name, depth_image));
-}
-
-// Evaluate the stand-alone test for label images.
-TEST_F(ImageWriterTest, SaveToPng_Label) {
-  ImageLabel16I label_image = test_image<PixelType::kLabel16I>();
-
-  const std::string label_image_name = temp_name();
-  SaveToPng(label_image, label_image_name);
-
-  EXPECT_TRUE(MatchesFileOnDisk(label_image_name, label_image));
-}
-
-// Evaluate the stand-alone test for depth16 images.
-TEST_F(ImageWriterTest, SaveToPng_Depth16) {
-  ImageDepth16U image = test_image<PixelType::kDepth16U>();
-
-  const std::string image_name = temp_name();
-  SaveToPng(image, image_name);
-
-  EXPECT_TRUE(MatchesFileOnDisk(image_name, image));
-}
-
-// Evaluate the stand-alone test for grey images.
-TEST_F(ImageWriterTest, SaveToPng_Grey) {
-  ImageGrey8U image = test_image<PixelType::kGrey8U>();
-
-  const std::string image_name = temp_name();
-  SaveToPng(image, image_name);
-
-  EXPECT_TRUE(MatchesFileOnDisk(image_name, image));
 }
 
 }  // namespace

--- a/systems/sensors/test_utilities/BUILD.bazel
+++ b/systems/sensors/test_utilities/BUILD.bazel
@@ -1,0 +1,31 @@
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "test_utilities",
+    testonly = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":image_compare",
+    ],
+)
+
+drake_cc_library(
+    name = "image_compare",
+    testonly = 1,
+    srcs = ["image_compare.cc"],
+    hdrs = ["image_compare.h"],
+    deps = [
+        "//systems/sensors:image",
+        "@gtest//:without_main",
+        "@vtk//:vtkIOImage",
+    ],
+)
+
+add_lint_tests()

--- a/systems/sensors/test_utilities/image_compare.cc
+++ b/systems/sensors/test_utilities/image_compare.cc
@@ -1,0 +1,115 @@
+#include "drake/systems/sensors/test_utilities/image_compare.h"
+
+#include <string>
+
+#include <vtkImageExport.h>
+#include <vtkPNGReader.h>
+#include <vtkSmartPointer.h>
+#include <vtkTIFFReader.h>
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+namespace fs = std::filesystem;
+
+using ::testing::AssertionFailure;
+using ::testing::AssertionResult;
+using ::testing::AssertionSuccess;
+
+template <PixelType kPixelType>
+void PrintTo(const Image<kPixelType>& image, std::ostream* os) {
+  const int width = image.width();
+  const int height = image.height();
+  fmt::print(*os, "Image<k{}>(width={}, height={})", kPixelType, width, height);
+  const int size = width * height;
+  // When there are no pixels, don't bother printing the "Channel ..." titles.
+  // If there are way too many pixels (more than fit on one screen), omit all
+  // pixel data, leaving only the summary of the size.
+  if (size == 0 || size > 1000) {
+    return;
+  }
+  using T = typename Image<kPixelType>::T;
+  using Promoted = std::conditional_t<std::is_integral_v<T>, int, T>;
+  constexpr int num_channels = Image<kPixelType>::kNumChannels;
+  for (int c = 0; c < num_channels; ++c) {
+    *os << "\n";
+    const T* const base = image.at(0, 0) + c;
+    using Stride = Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>;
+    Eigen::Map<const MatrixX<T>, 0, Stride> eigen(
+        base, height, width, Stride(num_channels, width * num_channels));
+    if (num_channels > 1) {
+      fmt::print(*os, "Channel {}:\n", c);
+    }
+    fmt::print(*os, "{}", fmt_eigen(eigen.template cast<Promoted>()));
+  }
+}
+
+template <PixelType kPixelType>
+AssertionResult LoadImage(const fs::path& filename, Image<kPixelType>* image) {
+  if (!fs::exists(filename)) {
+    return AssertionFailure() << "File not found: " << filename;
+  }
+  vtkSmartPointer<vtkImageReader2> reader;
+  switch (kPixelType) {
+    case PixelType::kRgba8U:
+    case PixelType::kGrey8U:
+    case PixelType::kDepth16U:
+    case PixelType::kLabel16I:
+      reader = vtkSmartPointer<vtkPNGReader>::New();
+      break;
+    case PixelType::kDepth32F:
+      reader = vtkSmartPointer<vtkTIFFReader>::New();
+      break;
+    default:
+      // TODO(jwnimmer-tri) Add support for more pixel types.
+      return AssertionFailure() << "Called with unsupported PixelType";
+  }
+  reader->SetFileName(filename.string().c_str());
+  vtkNew<vtkImageExport> exporter;
+  exporter->ImageLowerLeftOff();
+  exporter->SetInputConnection(reader->GetOutputPort());
+  exporter->Update();
+  const int* const dims = exporter->GetDataDimensions();
+  const int width = dims[0];
+  const int height = dims[1];
+  const int depth = dims[2];
+  const int channels = exporter->GetDataNumberOfScalarComponents();
+  if (depth != 1) {
+    // Drake's Image<> class only supports a shape of (width, height). It can't
+    // denote a 3D image (width, height, depth).
+    return AssertionFailure() << "Found wrong depth=" << depth;
+  }
+  if (channels != ImageTraits<kPixelType>::kNumChannels) {
+    return AssertionFailure() << "Found wrong channels=" << channels;
+  }
+  image->resize(width, height);
+  exporter->Export(image->at(0, 0));
+  return AssertionSuccess();
+}
+
+// Explicit template instantiations.
+// clang-format off
+static constexpr auto kInstantiations __attribute__((used)) = std::make_tuple(
+  &PrintTo<PixelType::kRgb8U>,
+  &PrintTo<PixelType::kBgr8U>,
+  &PrintTo<PixelType::kRgba8U>,
+  &PrintTo<PixelType::kBgra8U>,
+  &PrintTo<PixelType::kGrey8U>,
+  &PrintTo<PixelType::kDepth16U>,
+  &PrintTo<PixelType::kDepth32F>,
+  &PrintTo<PixelType::kLabel16I>,
+  &LoadImage<PixelType::kRgb8U>,
+  &LoadImage<PixelType::kBgr8U>,
+  &LoadImage<PixelType::kRgba8U>,
+  &LoadImage<PixelType::kBgra8U>,
+  &LoadImage<PixelType::kGrey8U>,
+  &LoadImage<PixelType::kDepth16U>,
+  &LoadImage<PixelType::kDepth32F>,
+  &LoadImage<PixelType::kLabel16I>
+);
+// clang-format on
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test_utilities/image_compare.h
+++ b/systems/sensors/test_utilities/image_compare.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <filesystem>
+#include <ostream>
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/** Adds googletest support for printing EXPECT_EQ(Image, Image) failures.
+Small images print all pixel data. Large images only print a summary. */
+template <PixelType kPixelType>
+void PrintTo(const Image<kPixelType>& image, std::ostream* os);
+
+/** Loads the PNG or TIFF image from `filename` into the `image` output. */
+template <PixelType kPixelType>
+::testing::AssertionResult LoadImage(const std::filesystem::path& filename,
+                                     Image<kPixelType>* image);
+
+// TODO(jwnimmer-tri) Add a helper function to stash an image into the
+// $TEST_UNDECLARED_OUTPUTS_DIR for offline inspection.
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Split `image_writer_test` into separate files for the free functions versus the system logic. (We'll soon be deprecating the free functions, in lieu of a [more full-featured replacement class](https://github.com/jwnimmer-tri/drake/commits/image-io).)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20017)
<!-- Reviewable:end -->
