### PR TITLE
[sensors] Deprecate symbolic expression images

### DIFF
--- a/systems/sensors/image.h
+++ b/systems/sensors/image.h
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/reset_after_move.h"
 #include "drake/systems/sensors/pixel_types.h"
@@ -42,9 +43,20 @@ using ImageLabel16I = Image<PixelType::kLabel16I>;
 /// The type for greyscale image where the channel has the type of uint8_t.
 using ImageGrey8U = Image<PixelType::kGrey8U>;
 
+#ifndef DRAKE_DOXYGEN_CXX
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+constexpr auto kInternalPixelTypeExpr = PixelType::kExpr;
+#pragma GCC diagnostic pop
+#endif
+
 /// The type for symbolic image where the channel has the type of
 /// symbolic::Expression.
-using ImageExpr = Image<PixelType::kExpr>;
+using ImageExpr DRAKE_DEPRECATED(
+    "2023-12-01",
+    "ImageExpr is deprecated because kExpr is no longer a supported PixelType."
+    "There is no direct replacement available, but Eigen::Array<Expression> "
+    "might be a suitable alternative.") = Image<kInternalPixelTypeExpr>;
 
 /// Simple data format for Image. For the complex calculation with the image,
 /// consider converting this to other libaries' Matrix data format, i.e.,

--- a/systems/sensors/image_to_lcm_image_array_t.cc
+++ b/systems/sensors/image_to_lcm_image_array_t.cc
@@ -122,8 +122,11 @@ void PackImageToLcmImageT(const AbstractValue& untyped_image,
       PackImageToLcmImageT(image_value, msg, do_compress);
       break;
     }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     case PixelType::kExpr:
       throw std::domain_error("PixelType::kExpr is not supported.");
+#pragma GCC diagnostic pop
   }
 }
 

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -216,8 +216,11 @@ const InputPort<double>& ImageWriter::DeclareImageInputPort(
           std::move(port_name), std::move(file_name_format), publish_period,
           start_time);
     }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     case PixelType::kExpr:
       break;
+#pragma GCC diagnostic pop
   }
   throw std::logic_error(fmt::format(
       "ImageWriter::DeclareImageInputPort does not support pixel_type={}",

--- a/systems/sensors/pixel_types.cc
+++ b/systems/sensors/pixel_types.cc
@@ -24,8 +24,11 @@ std::string to_string(PixelType x) {
       return "Depth32F";
     case PixelType::kLabel16I:
       return "Label16I";
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     case PixelType::kExpr:
       return "Expr";
+#pragma GCC diagnostic pop
   }
   DRAKE_UNREACHABLE();
 }
@@ -46,8 +49,11 @@ std::string to_string(PixelFormat x) {
       return "Depth";
     case PixelFormat::kLabel:
       return "Label";
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     case PixelFormat::kExpr:
       return "Expr";
+#pragma GCC diagnostic pop
   }
   DRAKE_UNREACHABLE();
 }

--- a/systems/sensors/pixel_types.h
+++ b/systems/sensors/pixel_types.h
@@ -4,6 +4,7 @@
 #include <limits>
 #include <string>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/expression.h"
@@ -38,7 +39,8 @@ enum class PixelType {
   /// The pixel format used by ImageLabel16I.
   kLabel16I,
   /// The pixel format representing symbolic::Expression.
-  kExpr,
+  kExpr DRAKE_DEPRECATED("2023-12-01",
+                         "kExpr is no longer a supported PixelType"),
 };
 
 std::string to_string(PixelType);
@@ -62,7 +64,8 @@ enum class PixelFormat {
   /// The pixel format used for all the labe images.
   kLabel,
   /// The pixel format used for all the symbolic images.
-  kExpr,
+  kExpr DRAKE_DEPRECATED("2023-12-01",
+                         "kExpr is no longer a supported PixelType"),
 };
 
 std::string to_string(PixelFormat);
@@ -171,12 +174,17 @@ struct ImageTraits<PixelType::kGrey8U> {
   static constexpr PixelFormat kPixelFormat = PixelFormat::kGrey;
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// (Deprecated) kExpr is no longer a supported PixelType; these traits will be
+// removed on or after 2023-12-01.
 template <>
 struct ImageTraits<PixelType::kExpr> {
   typedef symbolic::Expression ChannelType;
   static constexpr int kNumChannels = 1;
   static constexpr PixelFormat kPixelFormat = PixelFormat::kExpr;
 };
+#pragma GCC diagnostic pop
 
 }  // namespace sensors
 }  // namespace systems


### PR DESCRIPTION
Reverts #8055.

Their only effect is to clutter up our switch-case statements with an extra condition that always throws an exception.

Eigen should be a sufficient alternative for users who actually need a two-dimensional array of expressions. The only advantages of `Image<>` over `Array<>` are semantic labeling of the pixels (color, depth, label) and multi-channel pixels (rgb) -- neither of which apply here anyway.  (The `u,v` vs `x,y` indexing is another difference, but not too difficult to manage.)

This came up during #19945 when trying to improved our image reading and writing infrastructure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20023)
<!-- Reviewable:end -->
