### PR TITLE
[sensors] Encapsulate VTK image readers and writers

### DIFF
--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -98,6 +98,7 @@ drake_cc_library(
         "//geometry/render:render_camera",
         "//geometry/render:render_engine",
         "//systems/sensors:image",
+        "//systems/sensors:vtk_image_reader_writer",
         "@picosha2_internal//:picosha2",
         "@vtk//:vtkCommonCore",
         "@vtk//:vtkCommonDataModel",

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -31,6 +31,7 @@ drake_cc_package_library(
         ":color_palette",
         ":gyroscope",
         ":image",
+        ":image_file_format",
         ":image_to_lcm_image_array_t",
         ":image_writer",
         ":lcm_image_array_to_images",
@@ -159,6 +160,15 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "image_file_format",
+    srcs = ["image_file_format.cc"],
+    hdrs = ["image_file_format.h"],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "lcm_image_traits",
     srcs = [
         "lcm_image_traits.cc",
@@ -204,8 +214,8 @@ drake_cc_library(
     ],
     deps = [
         ":lcm_image_traits",
+        ":vtk_image_reader_writer",
         "//lcmtypes:image_array",
-        "@libpng",
         "@vtk//:vtkCommonCore",
         "@vtk//:vtkIOImage",
         "@zlib",
@@ -307,9 +317,12 @@ drake_cc_library(
     interface_deps = [
         ":image",
         "//common:essential",
-        "//systems/framework",
+        "//systems/framework:leaf_system",
     ],
     deps = [
+        ":vtk_image_reader_writer",
+        "@vtk//:vtkCommonCore",
+        "@vtk//:vtkCommonDataModel",
         "@vtk//:vtkIOImage",
     ],
 )
@@ -325,6 +338,20 @@ drake_cc_library(
         "//multibody/plant",
         "//systems/framework:diagram_builder",
         "//systems/lcm:lcm_publisher_system",
+    ],
+)
+
+drake_cc_library(
+    name = "vtk_image_reader_writer",
+    srcs = ["vtk_image_reader_writer.cc"],
+    hdrs = ["vtk_image_reader_writer.h"],
+    internal = True,
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":image_file_format",
+        "//common:unused",
+        "@vtk//:vtkCommonCore",
+        "@vtk//:vtkIOImage",
     ],
 )
 
@@ -393,6 +420,13 @@ drake_cc_googletest(
         ":camera_info",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "image_file_format_test",
+    deps = [
+        ":image_file_format",
     ],
 )
 
@@ -564,6 +598,18 @@ drake_cc_googletest(
         "//systems/framework:diagram_builder",
         "//systems/lcm:lcm_publisher_system",
         "@fmt",
+    ],
+)
+
+drake_cc_googletest(
+    name = "vtk_image_reader_writer_test",
+    deps = [
+        ":vtk_image_reader_writer",
+        "//common:temp_directory",
+        "//common/test_utilities:expect_throws_message",
+        "@vtk//:vtkCommonCore",
+        "@vtk//:vtkCommonDataModel",
+        "@vtk//:vtkIOImage",
     ],
 )
 

--- a/systems/sensors/image_file_format.cc
+++ b/systems/sensors/image_file_format.cc
@@ -1,0 +1,23 @@
+#include "drake/systems/sensors/image_file_format.h"
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+std::string to_string(ImageFileFormat format) {
+  switch (format) {
+    case ImageFileFormat::kJpeg:
+      return "jpeg";
+    case ImageFileFormat::kPng:
+      return "png";
+    case ImageFileFormat::kTiff:
+      return "tiff";
+  }
+  DRAKE_UNREACHABLE();
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/image_file_format.h
+++ b/systems/sensors/image_file_format.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+
+#include "drake/common/fmt.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/** The image file formats known to Drake. */
+enum class ImageFileFormat {
+  /** mime-type: image/jpeg. */
+  kJpeg,
+  /** mime-type: image/png. */
+  kPng,
+  /** mime-type: image/tiff. */
+  kTiff,
+};
+
+std::string to_string(ImageFileFormat);
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake::systems::sensors, ImageFileFormat, x,
+                   drake::systems::sensors::to_string(x))

--- a/systems/sensors/lcm_image_array_to_images.cc
+++ b/systems/sensors/lcm_image_array_to_images.cc
@@ -2,19 +2,19 @@
 
 #include <vector>
 
-#include <png.h>
 #include <zlib.h>
 
 // To ease build system upkeep, we annotate VTK includes with their deps.
-#include <vtkImageExport.h>  // vtkIOImage
-#include <vtkJPEGReader.h>   // vtkIOImage
-#include <vtkNew.h>          // vtkCommonCore
+#include <vtkImageExport.h>   // vtkIOImage
+#include <vtkImageReader2.h>  // vtkIOImage
+#include <vtkNew.h>           // vtkCommonCore
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/lcmt_image_array.hpp"
 #include "drake/systems/sensors/lcm_image_traits.h"
+#include "drake/systems/sensors/vtk_image_reader_writer.h"
 
 namespace drake {
 namespace systems {
@@ -49,105 +49,22 @@ bool image_has_alpha(int8_t type) {
   return false;
 }
 
-struct PngDecodeData {
-  const unsigned char* data{nullptr};
-  int size{0};
-  int pos{0};
-  std::string error_msg;
-};
-
-void CopyNextPngBytes(png_structp png_ptr, png_bytep data, size_t length) {
-  DRAKE_DEMAND(png_ptr != nullptr);
-  PngDecodeData* decode_data =
-      reinterpret_cast<PngDecodeData*>(png_get_io_ptr(png_ptr));
-  DRAKE_DEMAND(decode_data != nullptr);
-
-  if (decode_data->pos + static_cast<int>(length) > decode_data->size) {
-    png_error(png_ptr, "Attempt to read past end of PNG input buffer");
-  }
-
-  memcpy(data, decode_data->data + decode_data->pos, length);
-  decode_data->pos += length;
-}
-
 template <PixelType kPixelType>
-bool DecompressPng(const lcmt_image* lcm_image, Image<kPixelType>* image) {
-  PngDecodeData decode_data;
-  decode_data.data = lcm_image->data.data();
-  decode_data.size = lcm_image->size;
-
-  png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, 0, 0, 0);
-  DRAKE_DEMAND(png_ptr != nullptr);
-
-  png_infop info_ptr = png_create_info_struct(png_ptr);
-  DRAKE_DEMAND(info_ptr != nullptr);
-
-  if (setjmp(png_jmpbuf(png_ptr)) == 0) {
-    png_set_read_fn(png_ptr, &decode_data, CopyNextPngBytes);
-    png_read_info(png_ptr, info_ptr);
-    if ((static_cast<int>(png_get_image_width(png_ptr, info_ptr)) !=
-         lcm_image->width) ||
-        (static_cast<int>(png_get_image_height(png_ptr, info_ptr)) !=
-         lcm_image->height)) {
-      drake::log()->error("Decoded PNG parameter mismatch");
-      goto out;
-    }
-
-    if (png_get_bit_depth(png_ptr, info_ptr) !=
-        sizeof(typename ImageTraits<kPixelType>::ChannelType) * 8) {
-      drake::log()->error("Decoded PNG bit depth mismatch");
-      goto out;
-    }
-
-    if (png_get_channels(png_ptr, info_ptr) != image->kNumChannels) {
-      drake::log()->error("Decoded PNG bit channel mismatch");
-      goto out;
-    }
-
-    if (png_get_color_type(png_ptr, info_ptr) == PNG_COLOR_TYPE_PALETTE) {
-      png_set_palette_to_rgb(png_ptr);
-    }
-
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    png_set_swap(png_ptr);
-#endif
-
-    png_read_update_info(png_ptr, info_ptr);
-
-    std::vector<png_bytep> row_pointers(lcm_image->height);
-    for (int i = 0; i < lcm_image->height; ++i) {
-      row_pointers[i] = reinterpret_cast<png_bytep>(image->at(0, i));
-    }
-
-    png_read_image(png_ptr, row_pointers.data());
-    png_destroy_read_struct(&png_ptr, &info_ptr, 0);
-    return true;
-
-  } else {
-    drake::log()->error("Error during PNG decoding");
-  }
-
-out:
-  png_destroy_read_struct(&png_ptr, &info_ptr, 0);
-  return false;
-}
-
-template <PixelType kPixelType>
-bool DecompressJpeg(const lcmt_image* lcm_image, Image<kPixelType>* image) {
-  vtkNew<vtkJPEGReader> jpg_reader;
-  jpg_reader->SetMemoryBuffer(
-      const_cast<unsigned char*>(lcm_image->data.data()));
-  jpg_reader->SetMemoryBufferLength(lcm_image->size);
-  jpg_reader->Update();
+bool DecompressVtk(ImageFileFormat format, const lcmt_image* lcm_image,
+                   Image<kPixelType>* image) {
+  vtkSmartPointer<vtkImageReader2> reader = internal::MakeReader(
+      format, lcm_image->data.data(), lcm_image->data.size());
+  reader->Update();
 
   vtkNew<vtkImageExport> exporter;
-  exporter->SetInputConnection(jpg_reader->GetOutputPort(0));
+  exporter->SetInputConnection(reader->GetOutputPort(0));
   exporter->ImageLowerLeftOff();
   exporter->Update();
 
   if (exporter->GetDataMemorySize() !=
       image->width() * image->height() * image->kPixelSize) {
-    drake::log()->error("Malformed output decoding incoming LCM JPEG image");
+    drake::log()->error("Malformed output decoding incoming LCM {} image",
+                        format);
     return false;
   }
   exporter->Export(image->at(0, 0));
@@ -188,10 +105,10 @@ bool UnpackLcmImage(const lcmt_image* lcm_image, Image<kPixelType>* image) {
       return DecompressZlib(lcm_image, image);
     }
     case lcmt_image::COMPRESSION_METHOD_JPEG: {
-      return DecompressJpeg(lcm_image, image);
+      return DecompressVtk(ImageFileFormat::kJpeg, lcm_image, image);
     }
     case lcmt_image::COMPRESSION_METHOD_PNG: {
-      return DecompressPng(lcm_image, image);
+      return DecompressVtk(ImageFileFormat::kPng, lcm_image, image);
     }
     default: {
       break;
@@ -306,13 +223,7 @@ void LcmImageArrayToImages::CalcDepthImage(const Context<double>& context,
   } else {
     ImageDepth16U image_16u;
     if (UnpackLcmImage(lcm_image, &image_16u)) {
-      depth_image->resize(lcm_image->width, lcm_image->height);
-      for (int x = 0; x < lcm_image->width; x++) {
-        for (int y = 0; y < lcm_image->height; y++) {
-          depth_image->at(x, y)[0] =
-              static_cast<float>(image_16u.at(x, y)[0]) / 1e3;
-        }
-      }
+      ConvertDepth16UTo32F(image_16u, depth_image);
     } else {
       *depth_image = ImageDepth32F();
     }

--- a/systems/sensors/test/image_file_format_test.cc
+++ b/systems/sensors/test/image_file_format_test.cc
@@ -1,0 +1,16 @@
+#include "drake/systems/sensors/image_file_format.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+// Checks for fmt capability. A spot-check of just one enum value is sufficient.
+GTEST_TEST(ImageFileFormatTest, ToString) {
+  EXPECT_EQ(fmt::to_string(ImageFileFormat::kPng), "png");
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/vtk_image_reader_writer_test.cc
+++ b/systems/sensors/test/vtk_image_reader_writer_test.cc
@@ -1,0 +1,191 @@
+#include <numeric>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+// To ease build system upkeep, we annotate VTK includes with their deps.
+#include <vtkImageData.h>    // vtkCommonDataModel
+#include <vtkImageExport.h>  // vtkIOImage
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/sensors/vtk_image_reader_writer.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace internal {
+namespace {
+
+namespace fs = std::filesystem;
+
+// TestParams provides a grouping for value-parameterized test params.
+struct TestParams {
+  ImageFileFormat format{ImageFileFormat::kJpeg};
+
+  // Whether to use files or memory buffers.
+  bool write_to_file{false};
+
+  // Whether to use uint16_t (instead of the natural type).
+  bool force_16u{false};
+
+  friend std::ostream& operator<<(std::ostream& os, const TestParams& self) {
+    os << fmt::format("[format = {}; write_to_file = {}; force_16u = {}]",
+                      self.format, self.write_to_file, self.force_16u);
+    return os;
+  }
+};
+
+class VtkImageReaderWriterTest : public testing::TestWithParam<TestParams> {
+ public:
+  VtkImageReaderWriterTest() = default;
+};
+
+// Checks MakeWriter() and MakeReader() back-to-back. This provides a simple
+// sanity check for these low-level helper functions.
+TEST_P(VtkImageReaderWriterTest, RoundTrip) {
+  const ImageFileFormat format = GetParam().format;
+  const bool write_to_file = GetParam().write_to_file;
+  const bool force_16u = GetParam().force_16u;
+
+  // Create a sample image in memory. The image data will be filled with
+  // incrementing numbers, starting from 1 for the first datum.
+  const int width = 3;
+  const int height = 2;
+  const int depth = 1;
+  const int channels = (format == ImageFileFormat::kTiff) ? 1 : 3;
+  const int total_storage = width * height * depth * channels;
+  const int vtk_scalar = force_16u                            ? VTK_TYPE_UINT16
+                         : (format == ImageFileFormat::kTiff) ? VTK_TYPE_FLOAT32
+                                                              : VTK_TYPE_UINT8;
+  vtkNew<vtkImageData> image;
+  image->SetDimensions(width, height, depth);
+  image->AllocateScalars(vtk_scalar, channels);
+  if (vtk_scalar == VTK_TYPE_UINT8) {
+    auto* dest = reinterpret_cast<uint8_t*>(image->GetScalarPointer());
+    std::iota(dest, dest + total_storage, uint8_t{0x01});
+  } else if (vtk_scalar == VTK_TYPE_UINT16) {
+    auto* dest = reinterpret_cast<uint16_t*>(image->GetScalarPointer());
+    std::iota(dest, dest + total_storage, uint16_t{0x0001});
+  } else {
+    auto* dest = reinterpret_cast<float*>(image->GetScalarPointer());
+    std::iota(dest, dest + total_storage, 1.0f);
+  }
+
+  // Check MakeWriter() construction.
+  // Set it up to write either to `filename` xor `writer_output`.
+  fs::path filename;
+  std::vector<uint8_t> writer_output;
+  vtkSmartPointer<vtkImageWriter> writer;
+  if (write_to_file) {
+    filename =
+        fs::path(temp_directory()) / fmt::format("RoundTrip_{}.image", format);
+    writer = MakeWriter(format, filename);
+  } else {
+    writer = MakeWriter(format, &writer_output);
+  }
+  ASSERT_TRUE(writer != nullptr);
+
+  // Ask MakeWriter() to write out the image.
+  writer->SetInputData(image.Get());
+  writer->Write();
+
+  // Check MakeReader().
+  vtkSmartPointer<vtkImageReader2> reader;
+  if (write_to_file) {
+    reader = MakeReader(format, filename);
+  } else {
+    reader = MakeReader(format, writer_output.data(), writer_output.size());
+  }
+  ASSERT_TRUE(reader != nullptr);
+  reader->Update();
+
+  // Check the image metadata. We'll use ASSERT not EXPECT because momentarily
+  // we'll also compare the image data buffers, which we don't want to do when
+  // the sizes were wrong.
+  vtkNew<vtkImageExport> loader;
+  loader->SetInputConnection(reader->GetOutputPort(0));
+  loader->Update();
+  const int* const dims = loader->GetDataDimensions();
+  ASSERT_EQ(dims[0], width);
+  ASSERT_EQ(dims[1], height);
+  ASSERT_EQ(dims[2], depth);
+  ASSERT_EQ(loader->GetDataNumberOfScalarComponents(), channels);
+  ASSERT_EQ(loader->GetDataScalarType(), vtk_scalar);
+
+  // For JPEG images, we can't exactly compare the pixels because the lossy
+  // compression algorithm will have adjusted them slightly.
+  if (format == ImageFileFormat::kJpeg) {
+    // Instead, we'll check that the data is still monotonically increasing
+    // (within some tolerance). This is sufficient to notice if any data was
+    // mistakenly transposed.
+    DRAKE_DEMAND(vtk_scalar == VTK_TYPE_UINT8);
+    auto* loaded = reinterpret_cast<const uint8_t*>(loader->GetPointerToData());
+    Eigen::Map<const MatrixX<uint8_t>> head(loaded, 1, total_storage - 1);
+    Eigen::Map<const MatrixX<uint8_t>> tail(loaded + 1, 1, total_storage - 1);
+    const Eigen::Array<int, 1, Eigen::Dynamic> increments =
+        tail.cast<int>().array() - head.cast<int>().array();
+    const int max_increment = 2;
+    EXPECT_LE(increments.abs().maxCoeff(), max_increment)
+        << fmt::to_string(fmt_eigen(increments.matrix()));
+    return;
+  }
+
+  // Compare the loaded pixels to the original image. We'll compare using
+  // an Eigen::Map wrapper over the image data, to get a better printout.
+  if (vtk_scalar == VTK_TYPE_UINT8) {
+    auto* orig = reinterpret_cast<const uint8_t*>(image->GetScalarPointer());
+    auto* loaded = reinterpret_cast<const uint8_t*>(loader->GetPointerToData());
+    Eigen::Map<const MatrixX<uint8_t>> orig_map(orig, 1, total_storage);
+    Eigen::Map<const MatrixX<uint8_t>> loaded_map(loaded, 1, total_storage);
+    EXPECT_EQ(orig_map.template cast<int>(), loaded_map.template cast<int>());
+  } else if (vtk_scalar == VTK_TYPE_UINT16) {
+    auto* orig = reinterpret_cast<const uint16_t*>(image->GetScalarPointer());
+    auto* loaded =
+        reinterpret_cast<const uint16_t*>(loader->GetPointerToData());
+    Eigen::Map<const MatrixX<uint16_t>> orig_map(orig, 1, total_storage);
+    Eigen::Map<const MatrixX<uint16_t>> loaded_map(loaded, 1, total_storage);
+    EXPECT_EQ(orig_map, loaded_map);
+  } else {
+    auto* orig = reinterpret_cast<const float*>(image->GetScalarPointer());
+    auto* loaded = reinterpret_cast<const float*>(loader->GetPointerToData());
+    Eigen::Map<const MatrixX<float>> orig_map(orig, 1, total_storage);
+    Eigen::Map<const MatrixX<float>> loaded_map(loaded, 1, total_storage);
+    EXPECT_EQ(orig_map, loaded_map);
+  }
+}
+
+// These abbreviations help make the test matrix below easier to read.
+constexpr ImageFileFormat kJpeg = ImageFileFormat::kJpeg;
+constexpr ImageFileFormat kPng = ImageFileFormat::kPng;
+constexpr ImageFileFormat kTiff = ImageFileFormat::kTiff;
+
+INSTANTIATE_TEST_SUITE_P(
+    All, VtkImageReaderWriterTest,
+    testing::Values(
+        // VTK JPEG only supports 8-bit channels, so no 16u here.
+        TestParams{.format = kJpeg, .write_to_file = true},
+        TestParams{.format = kJpeg, .write_to_file = false},
+        // VTK PNG supports both 8-bit and 16-bit channels.
+        TestParams{.format = kPng, .write_to_file = true},
+        TestParams{.format = kPng, .write_to_file = false},
+        TestParams{.format = kPng, .write_to_file = true, .force_16u = true},
+        TestParams{.format = kPng, .write_to_file = false, .force_16u = true},
+        // VTK TIFF doesn't support writing to memory. We have a expect-throws
+        // test immediately below to cover that.
+        TestParams{.format = kTiff, .write_to_file = true},
+        TestParams{.format = kTiff, .write_to_file = true, .force_16u = true}));
+
+// Checks that an unsupported operation produces an error.
+GTEST_TEST(UnparameterizedVtkImageReaderWriterTest, TiffWriteToMemoryThrow) {
+  std::vector<uint8_t> output;
+  DRAKE_EXPECT_THROWS_MESSAGE(MakeWriter(kTiff, &output),
+                              ".*TIFF.*memory buffer.*");
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/vtk_image_reader_writer.cc
+++ b/systems/sensors/vtk_image_reader_writer.cc
@@ -1,0 +1,164 @@
+#include "drake/systems/sensors/vtk_image_reader_writer.h"
+
+#include <utility>
+#include <variant>
+
+// To ease build system upkeep, we annotate VTK includes with their deps.
+#include <vtkCommand.h>            // vtkCommonCore
+#include <vtkJPEGReader.h>         // vtkIOImage
+#include <vtkJPEGWriter.h>         // vtkIOImage
+#include <vtkPNGReader.h>          // vtkIOImage
+#include <vtkPNGWriter.h>          // vtkIOImage
+#include <vtkTIFFReader.h>         // vtkIOImage
+#include <vtkTIFFWriter.h>         // vtkIOImage
+#include <vtkUnsignedCharArray.h>  // vtkCommonCore
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace internal {
+namespace {
+
+namespace fs = std::filesystem;
+
+vtkSmartPointer<vtkImageReader2> MakeReaderObject(ImageFileFormat format) {
+  switch (format) {
+    case ImageFileFormat::kJpeg:
+      return vtkSmartPointer<vtkJPEGReader>::New();
+    case ImageFileFormat::kPng:
+      return vtkSmartPointer<vtkPNGReader>::New();
+    case ImageFileFormat::kTiff: {
+      auto result = vtkSmartPointer<vtkTIFFReader>::New();
+      // VTK's TIFF reader doesn't use VTK's default coordinate conventions
+      // unless we specifically tell it to.
+      result->SetOrientationType(4 /* ORIENTATION_BOTLEFT */);
+      return result;
+    }
+  }
+  DRAKE_UNREACHABLE();
+}
+
+}  // namespace
+
+vtkSmartPointer<vtkImageReader2> MakeReader(ImageFileFormat format,
+                                            const fs::path& filename) {
+  vtkSmartPointer<vtkImageReader2> reader = MakeReaderObject(format);
+  reader->SetFileName(filename.c_str());
+  return reader;
+}
+
+vtkSmartPointer<vtkImageReader2> MakeReader(ImageFileFormat format,
+                                            const void* input, size_t size) {
+  vtkSmartPointer<vtkImageReader2> reader = MakeReaderObject(format);
+  reader->SetMemoryBuffer(input);
+  reader->SetMemoryBufferLength(size);
+  return reader;
+}
+
+namespace {
+
+vtkSmartPointer<vtkImageWriter> MakeWriterObject(ImageFileFormat format) {
+  switch (format) {
+    case ImageFileFormat::kJpeg:
+      return vtkSmartPointer<vtkJPEGWriter>::New();
+    case ImageFileFormat::kPng:
+      return vtkSmartPointer<vtkPNGWriter>::New();
+    case ImageFileFormat::kTiff:
+      return vtkSmartPointer<vtkTIFFWriter>::New();
+  }
+  DRAKE_UNREACHABLE();
+}
+
+/* Trampolines VTK progress events into a Drake-specific callback. */
+class VtkProgressObserver final : public vtkCommand {
+ public:
+  VtkProgressObserver() = default;
+  void set_progress_callback(std::function<void(double)> callback) {
+    callback_ = std::move(callback);
+  }
+  // Boilerplate for VTK smart pointers.
+  static VtkProgressObserver* New() { return new VtkProgressObserver; }
+
+ private:
+  // NOLINTNEXTLINE(runtime/int) To match the VTK signature.
+  void Execute(vtkObject*, unsigned long event, void* calldata) final {
+    if (event == vtkCommand::ProgressEvent) {
+      const double amount = *static_cast<const double*>(calldata);
+      if (callback_ != nullptr) {
+        callback_(amount);
+      }
+    }
+  }
+  std::function<void(double)> callback_;
+};
+
+}  // namespace
+
+vtkSmartPointer<vtkImageWriter> MakeWriter(ImageFileFormat format,
+                                           const fs::path& filename) {
+  vtkSmartPointer<vtkImageWriter> writer = MakeWriterObject(format);
+  writer->SetFileName(filename.c_str());
+  return writer;
+}
+
+vtkSmartPointer<vtkImageWriter> MakeWriter(ImageFileFormat format,
+                                           std::vector<uint8_t>* output) {
+  DRAKE_DEMAND(output != nullptr);
+  if (format == ImageFileFormat::kTiff) {
+    throw std::logic_error("Cannot save TIFF images to a memory buffer");
+  }
+  vtkSmartPointer<vtkImageWriter> writer = MakeWriterObject(format);
+
+  // The "write to memory" API is only available on the concrete subclasses,
+  // so we'll always need to call it with a visitor, instead of virtually.
+  std::variant<vtkJPEGWriter*, vtkPNGWriter*> writer_variant;
+  switch (format) {
+    case ImageFileFormat::kJpeg:
+      writer_variant = static_cast<vtkJPEGWriter*>(writer.Get());
+      break;
+    case ImageFileFormat::kPng:
+      writer_variant = static_cast<vtkPNGWriter*>(writer.Get());
+      break;
+    case ImageFileFormat::kTiff:
+      DRAKE_UNREACHABLE();
+  }
+  std::visit(
+      [](auto* typed_writer) {
+        typed_writer->WriteToMemoryOn();
+      },
+      writer_variant);
+
+  // Add an observer to the writer that copies the encoded image into the
+  // `output` buffer.
+  vtkNew<VtkProgressObserver> observer;
+  observer->set_progress_callback([output, writer_variant](double amount) {
+    // TODO(jwnimmer) Use the `amount` to decide when the writing is finished.
+    // At the moment, VTK mistakenly posts 0% progress both when it starts and
+    // when it finishes, so we can't use 100% to know when its time to copy.
+    unused(amount);
+    std::visit(
+        [output](auto* typed_writer) {
+          vtkUnsignedCharArray* range = typed_writer->GetResult();
+          // The result pointer `range` only exists after writing is complete.
+          // Use that to know when we're actually done.
+          if (range != nullptr) {
+            output->clear();
+            const size_t size = range->GetNumberOfTuples();
+            const uint8_t* const data = range->GetPointer(0);
+            output->insert(output->begin(), data, data + size);
+          }
+        },
+        writer_variant);
+  });
+  writer->AddObserver(vtkCommand::ProgressEvent, observer);
+
+  return writer;
+}
+
+}  // namespace internal
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/vtk_image_reader_writer.h
+++ b/systems/sensors/vtk_image_reader_writer.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+// To ease build system upkeep, we annotate VTK includes with their deps.
+#include <vtkImageReader2.h>  // vtkIOImage
+#include <vtkImageWriter.h>   // vtkIOImage
+#include <vtkSmartPointer.h>  // vtkCommonCore
+
+#include "drake/systems/sensors/image_file_format.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace internal {
+
+// This file provides internal helper functions that encapsulate VTK's reader
+// and writer classes for the file formats Drake cares about.
+
+/* Constructs a VTK image reader for a specific file format, already connected
+to read the data from the given filename. */
+vtkSmartPointer<vtkImageReader2> MakeReader(
+    ImageFileFormat format, const std::filesystem::path& filename);
+
+/* Constructs a VTK image reader for a specific file format, already connected
+to read the data from the given memory buffer of `size` bytes.
+@warning The reader retains a pointer to the `input`, so it can read from it
+when requested to. The `input` buffer must outlive the returned reader. */
+vtkSmartPointer<vtkImageReader2> MakeReader(ImageFileFormat format,
+                                            const void* input, size_t size);
+
+/* Constructs a VTK image writer for a specific file format, already connected
+to write the data to the given destination filename. */
+vtkSmartPointer<vtkImageWriter> MakeWriter(
+    ImageFileFormat format, const std::filesystem::path& filename);
+
+/* Constructs a VTK image writer for a specific file format, already connected
+to write the data to the given memory
+@warning The TIFF file format cannot currently be written to a memory buffer,
+rather only to a file. Passing `format == kTiff` will throw an exception.
+@warning The writer retains a pointer to the `output`, so it can set it during
+the Write() operation.  The `output` buffer must outlive the returned writer. */
+vtkSmartPointer<vtkImageWriter> MakeWriter(ImageFileFormat format,
+                                           std::vector<uint8_t>* output);
+
+}  // namespace internal
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/pull/19945 and https://github.com/RobotLocomotion/drake/issues/16502.  In particular, the new unit test here will serve as a backstop against regressions in the reader/writer code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20026)
<!-- Reviewable:end -->
