### PR TITLE
[setup] Change clang-format to a testonly dependency

### DIFF
--- a/setup/mac/source_distribution/Brewfile
+++ b/setup/mac/source_distribution/Brewfile
@@ -1,7 +1,4 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-tap 'robotlocomotion/director'
-
 brew 'bazelisk'
-brew 'robotlocomotion/director/clang-format@12'

--- a/setup/mac/source_distribution/Brewfile-test-only
+++ b/setup/mac/source_distribution/Brewfile-test-only
@@ -1,0 +1,6 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+tap 'robotlocomotion/director'
+
+brew 'robotlocomotion/director/clang-format@12'

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -45,6 +45,10 @@ fi
 
 brew bundle --file="${BASH_SOURCE%/*}/Brewfile" --no-lock
 
+if [[ "${with_test_only}" -eq 1 ]]; then
+  brew bundle --file="${BASH_SOURCE%/*}/Brewfile-test-only" --no-lock
+fi
+
 if ! command -v pip3.11 &>/dev/null; then
   echo 'ERROR: pip3.11 is NOT installed. The post-install step for the python@3.11 formula may have failed.' >&2
   exit 2

--- a/setup/ubuntu/source_distribution/packages-focal-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-test-only.txt
@@ -1,3 +1,4 @@
+clang-format-12
 curl
 kcov
 libstdc++6-10-dbg

--- a/setup/ubuntu/source_distribution/packages-focal.txt
+++ b/setup/ubuntu/source_distribution/packages-focal.txt
@@ -1,4 +1,3 @@
-clang-format-12
 coinor-libcoinutils-dev
 default-jdk
 file

--- a/setup/ubuntu/source_distribution/packages-jammy-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy-test-only.txt
@@ -1,3 +1,4 @@
+clang-format-12
 curl
 kcov
 libstdc++6-10-dbg

--- a/setup/ubuntu/source_distribution/packages-jammy.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy.txt
@@ -1,4 +1,3 @@
-clang-format-12
 coinor-libcoinutils-dev
 default-jdk
 file

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -43,12 +43,14 @@ drake_py_binary(
 
 drake_py_library(
     name = "clang_format",
+    testonly = 1,
     srcs = ["clang_format.py"],
     data = ["//:.clang-format"],
 )
 
 drake_py_binary(
     name = "clang_format_lint",
+    testonly = 1,
     srcs = ["clang_format_lint.py"],
     deps = [
         ":clang_format",
@@ -57,6 +59,7 @@ drake_py_binary(
 
 drake_py_binary(
     name = "drakelint",
+    testonly = 1,
     srcs = ["drakelint.py"],
     deps = [":formatter"],
 )
@@ -70,12 +73,14 @@ drake_py_binary(
 
 drake_py_library(
     name = "formatter",
+    testonly = 1,
     srcs = ["formatter.py"],
     deps = [":clang_format"],
 )
 
 drake_py_binary(
     name = "clang-format-includes",
+    testonly = 1,
     srcs = ["clang_format_includes.py"],
     main = "clang_format_includes.py",
     deps = [

--- a/tools/vector_gen/BUILD.bazel
+++ b/tools/vector_gen/BUILD.bazel
@@ -25,7 +25,6 @@ drake_py_binary(
     name = "lcm_vector_gen",
     srcs = ["lcm_vector_gen.py"],
     deps = [
-        "//tools/lint:clang_format",
         "//tools/lint:find_data",
     ],
 )

--- a/tools/vector_gen/test/goal/lcmt_sample_t.lcm
+++ b/tools/vector_gen/test/goal/lcmt_sample_t.lcm
@@ -8,7 +8,7 @@ struct lcmt_sample_t {
   int64_t timestamp;
 
   double x;  // Some coordinate
-  double two_word;  // A very long documentation string that will certainly flow across multiple lines of C++
+  double two_word;  // A very long documentation string that exceeds the typical C++ line length of 80 characters
   double absone;  // A signed, normalized value
   double unset;  // A value that is unset by default
 }

--- a/tools/vector_gen/test/goal/sample.cc
+++ b/tools/vector_gen/test/goal/sample.cc
@@ -16,10 +16,10 @@ const int SampleIndices::kUnset;
 const std::vector<std::string>& SampleIndices::GetCoordinateNames() {
   static const drake::never_destroyed<std::vector<std::string>> coordinates(
       std::vector<std::string>{
-          "x",         // BR
-          "two_word",  // BR
-          "absone",    // BR
-          "unset",     // BR
+          "x",
+          "two_word",
+          "absone",
+          "unset",
       });
   return coordinates.access();
 }

--- a/tools/vector_gen/test/goal/sample.h
+++ b/tools/vector_gen/test/goal/sample.h
@@ -91,7 +91,9 @@ class Sample final : public drake::systems::BasicVector<T> {
     this->set_unset(symbolic::Variable("unset"));
   }
 
-  [[nodiscard]] Sample<T>* DoClone() const final { return new Sample; }
+  [[nodiscard]] Sample<T>* DoClone() const final {
+    return new Sample;
+  }
 
   /// @name Getters and Setters
   //@{
@@ -114,8 +116,7 @@ class Sample final : public drake::systems::BasicVector<T> {
     result.set_x(x);
     return result;
   }
-  /// A very long documentation string that will certainly flow across multiple
-  /// lines of C++
+  /// A very long documentation string that exceeds the typical C++ line length of 80 characters
   /// @note @c two_word has a limited domain of [-Inf, 2.0].
   const T& two_word() const {
     ThrowIfEmpty();

--- a/tools/vector_gen/test/sample_named_vector.yaml
+++ b/tools/vector_gen/test/sample_named_vector.yaml
@@ -8,7 +8,7 @@ elements:
     default_value: 42.0
   -
     name: two_word
-    doc: A very long documentation string that will certainly flow across multiple lines of C++
+    doc: A very long documentation string that exceeds the typical C++ line length of 80 characters
     max_value: 2.0
     default_value: 0.0
   -

--- a/tools/vector_gen/vector_gen.bzl
+++ b/tools/vector_gen/vector_gen.bzl
@@ -152,6 +152,7 @@ def cc_vector_gen(
 def drake_cc_vector_gen_library(
         name,
         srcs = [],
+        tags = [],
         deps = [],
         **kwargs):
     """Given *_named_vector.yaml files in `srcs`, declare a drake_cc_library
@@ -165,6 +166,7 @@ def drake_cc_vector_gen_library(
     generated = cc_vector_gen(
         name = name + "_codegen",
         srcs = srcs,
+        tags = tags,
         include_prefix = "drake",
         drake_workspace_name = "",
         visibility = [],
@@ -173,6 +175,7 @@ def drake_cc_vector_gen_library(
         name = name,
         srcs = generated.srcs,
         hdrs = generated.hdrs,
+        tags = tags + ["nolint"],
         deps = deps + generated.deps,
         **kwargs
     )

--- a/tools/wheel/image/packages-focal
+++ b/tools/wheel/image/packages-focal
@@ -11,9 +11,8 @@ g++
 gfortran
 libgfortran-7-dev
 yasm
-# Clang (for clang-format).
+# Clang (for mkdoc).
 libclang-12-dev
-clang-format-12
 # Other code tools.
 cmake
 git


### PR DESCRIPTION
This should allow users to rebuild from source with fewer headaches.

On macOS, it removes 1 of 2 remaining build-time dependencies on the custom RobotLocomotion homebrew tap. We anticipate dropping the other item (VTK) from the custom tap soon, as well.

On Ubuntu, it avoids a hard-coded clang-format version. This should be more portable for users who build on a non-Ubuntu distribution.

Developers who want to run Drake's full test suite will still need this dependency; this is only a change for *users* who build from source.

With this change, the build-time vector_gen can no longer autoformat its generated code. With a few minor edits to the tool, the output still looks passable without the autoformat.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20028)
<!-- Reviewable:end -->
