### PR TITLE
[framework] Propagate EventStatus through the API

### DIFF
--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -93,7 +93,8 @@ PYBIND11_MODULE(test_util, m) {
       // Call `Publish` to test `DoPublish`.
       auto events =
           LeafEventCollection<PublishEvent<T>>::MakeForcedEventCollection();
-      system.Publish(*context, *events);
+      const EventStatus status = system.Publish(*context, *events);
+      DRAKE_DEMAND(status.did_nothing());
     }
     {
       // Call `HasDirectFeedthrough` to test `DoHasDirectFeedthrough`.

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -207,7 +207,9 @@ TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
   {  // Send an initialization event.
     auto events = diagram_->AllocateCompositeEventCollection();
     diagram_->GetInitializationEvents(*context_, events.get());
-    diagram_->Publish(*context_, events->get_publish_events());
+    const systems::EventStatus status =
+        diagram_->Publish(*context_, events->get_publish_events());
+    EXPECT_TRUE(status.succeeded());
   }
   // Confirm that my scribble was deleted.
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer/my_random_path"));
@@ -220,7 +222,9 @@ TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
   {  // Send an initialization event.
     auto events = diagram_->AllocateCompositeEventCollection();
     diagram_->GetInitializationEvents(*context_, events.get());
-    diagram_->Publish(*context_, events->get_publish_events());
+    const systems::EventStatus status =
+        diagram_->Publish(*context_, events->get_publish_events());
+    EXPECT_TRUE(status.did_nothing());
   }
   // Confirm that my scribble remains.
   EXPECT_TRUE(meshcat_->HasPath("/drake/visualizer/my_random_path"));

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -122,8 +122,27 @@ priori and is determined by the Step() algorithm. Each step consists of zero or
 more unrestricted updates, followed by zero or more discrete updates, followed
 by (possibly zero-length) continuous time and state advancement, followed by
 zero or more publishes, and then a call to the monitor() function if one has
-been defined. Updates, publishes, and the monitor can report errors or detect a
-termination condition; that is not shown in the pseudocode below.
+been defined.
+
+Updates, publishes, and the monitor can report errors or detect a
+termination condition; that is not shown in the pseudocode below. We follow
+this policy:
+ - If any unrestricted update event fails, we leave the state unchanged and
+   report failure. We leave unspecified whether the handlers for other
+   simultaneous unrestricted update events are executed or skipped in this case.
+   (That could affect behavior if they have side effects but in any case the
+   state will not be modified.)
+ - Next, if any discrete update event fails, we report failure. In this case
+   the state may have been partially updated; don't assume it has been left
+   unchanged. We leave unspecified whether the handlers for other simultaneous
+   discrete events are executed.
+ - Next, if any publish event fails, we _continue_ executing the handlers for
+   all simultaneous publish events, and report failure after they have all been
+   executed. The state is returned as updated since publish events can have
+   external consequences based on that updated state.
+ - A "reached termination" status from any event handler permits continued
+   processing of simultaneous events, but doesn't permit time to advance
+   any further.
 
 The pseudocode will clarify the effects on time and state of each of the update
 stages above. This algorithm is given a starting Context value `{tₛ, x⁻(tₛ)}`
@@ -257,20 +276,18 @@ class Simulator {
   // TODO(sherm1) Make Initialize() attempt to satisfy constraints.
 
   /// Prepares the %Simulator for a simulation. In order, the sequence of
-  /// actions taken here are:
+  /// actions taken here is:
   /// - The active integrator's Initialize() method is invoked.
   /// - Statistics are reset.
   /// - By default, initialization update events are triggered and handled to
   ///   produce the initial trajectory value `{t₀, x(t₀)}`. If initialization
   ///   events are suppressed, it is the caller's responsibility to ensure the
   ///   desired initial state.
-
   /// - Then that initial value is provided to the handlers for any publish
   ///   events that have triggered, including initialization events if any, and
   ///   per-step publish events, periodic or other time-triggered publish
   ///   events that are scheduled for the initial time t₀, and finally a call
   ///   to the monitor() function if one has been defined.
-
   ///
   /// See the class documentation for more information. We recommend calling
   /// Initialize() explicitly prior to beginning a simulation so that error
@@ -290,7 +307,8 @@ class Simulator {
   /// Initialize() call is missing.
   ///
   /// @note The only way to suppress initialization events is by calling
-  /// Initialize() explicitly. The most common scenario for this is when
+  /// Initialize() explicitly with the `suppress_initialization_events`
+  /// parameter set. The most common scenario for this is when
   /// reusing a Simulator object. In this case, the caller is responsible for
   /// ensuring the correctness of the initial state.
   ///
@@ -298,9 +316,9 @@ class Simulator {
   /// constraints -- it is up to you to make sure that constraints are
   /// satisfied by the initial conditions.
   ///
-  /// This method will throw `std::exception` if the combination of options
-  /// doesn't make sense. Other failures are possible from the System and
-  /// integrator in use.
+  /// @throws std::exception if the combination of options doesn't make sense
+  /// or if any handled event reports failure. Other error conditions are
+  /// possible from the System and integrator in use.
   ///
   /// @param params (optional) a parameter structure (@see InitializeParams).
   ///
@@ -311,11 +329,7 @@ class Simulator {
   SimulatorStatus Initialize(const InitializeParams& params = {});
 
   /// Advances the System's trajectory until `boundary_time` is reached in
-  /// the context or some other termination condition occurs. A variety of
-  /// `std::runtime_error` conditions are possible here, as well as error
-  /// conditions that may be thrown by the System when it is asked to perform
-  /// computations. Be sure to enclose your simulation in a `try-catch` block
-  /// and display the `what()` message.
+  /// the Context or some other termination condition occurs.
   ///
   /// We recommend that you call Initialize() prior to making the first call
   /// to AdvanceTo(). However, if you don't it will be called for you the first
@@ -329,6 +343,9 @@ class Simulator {
   ///
   /// @note You can track simulation progress to terminate on arbitrary
   /// conditions using a _monitor_ function; see set_monitor().
+  ///
+  /// @throws std::exception if any handled event reports failure. Other error
+  /// conditions are possible from the System and integrator in use.
   ///
   /// @param boundary_time The maximum time to which the trajectory will be
   ///     advanced by this call to %AdvanceTo(). The method may return earlier
@@ -360,6 +377,8 @@ class Simulator {
   /// pending events, nothing happens except possibly a final per-step publish
   /// call (if enabled) followed by a call to the monitor() function (if one
   /// has been provided).
+  ///
+  /// @throws std::exception if any handled event reports failure.
   ///
   /// @retval status A SimulatorStatus object indicating success, termination,
   ///                or an error condition as reported by event handlers or
@@ -432,7 +451,7 @@ class Simulator {
   /// });
   /// @endcode
   /// In the above case the Simulator's AdvanceTo() method will throw an
-  /// std::runtime_error containing a human-readable message including
+  /// std::exception containing a human-readable message including
   /// the text provided in the monitor.
   ///
   /// @note monitor() is called every time the trajectory is advanced by a step,
@@ -457,7 +476,8 @@ class Simulator {
   }
 
   // TODO(sherm1): Provide options for issuing a warning or aborting the
-  // simulation if the desired rate cannot be achieved.
+  //  simulation if the desired rate cannot be achieved.
+
   /// Slow the simulation down to *approximately* synchronize with real time
   /// when it would otherwise run too fast. Normally the %Simulator takes steps
   /// as quickly as it can. You can request that it slow down to synchronize
@@ -513,6 +533,8 @@ class Simulator {
   /// @see set_target_realtime_rate()
   double get_actual_realtime_rate() const;
 
+  /// (To be deprecated) Prefer using per-step publish events instead.
+  ///
   /// Sets whether the simulation should trigger a forced-Publish event on the
   /// System under simulation at the end of every trajectory-advancing step.
   /// Specifically, that means the System::Publish() event dispatcher will be
@@ -527,14 +549,22 @@ class Simulator {
   /// end of every step, you will usually also want one at the end of
   /// initialization, requiring both options to be enabled.
   ///
+  /// @see LeafSystem::DeclarePerStepPublishEvent()
   /// @see LeafSystem::DeclareForcedPublishEvent()
   void set_publish_every_time_step(bool publish) {
     publish_every_time_step_ = publish;
   }
 
+  /// (To be deprecated) Prefer using initialization or per-step publish
+  /// events instead.
+  ///
   /// Sets whether the simulation should trigger a forced-Publish at the end
   /// of Initialize(). See set_publish_every_time_step() documentation for
   /// more information.
+  ///
+  /// @see LeafSystem::DeclareInitializationPublishEvent()
+  /// @see LeafSystem::DeclarePerStepPublishEvent()
+  /// @see LeafSystem::DeclareForcedPublishEvent()
   void set_publish_at_initialization(bool publish) {
     publish_at_initialization_ = publish;
   }
@@ -593,21 +623,30 @@ class Simulator {
   /// have post construction or immediately after `Initialize()`.
   void ResetStatistics();
 
-  /// Gets the number of publishes made since the last Initialize() or
-  /// ResetStatistics() call.
-  int64_t get_num_publishes() const { return num_publishes_; }
-
-  /// Gets the number of steps since the last Initialize() call. (We're
-  /// not counting the Initialize() 0-length "step".) Note that every
-  /// AdvanceTo() call can potentially take many steps.
+  /// Gets the number of steps since the last Initialize() or ResetStatistics()
+  /// call. (We're not counting the Initialize() 0-length "step".) Note that
+  /// every AdvanceTo() call can potentially take many steps.
   int64_t get_num_steps_taken() const { return num_steps_taken_; }
 
-  /// Gets the number of discrete variable updates performed since the last
-  /// Initialize() call.
+  /// Gets the number of effective publish dispatcher calls made since the last
+  /// Initialize() or ResetStatistics() call. A dispatch is ineffective (not
+  /// counted) if _any_ of the publish events fails or _all_ the publish events
+  /// return "did nothing". A single dispatcher call may handle multiple publish
+  /// events.
+  int64_t get_num_publishes() const { return num_publishes_; }
+
+  /// Gets the number of effective discrete variable update dispatcher calls
+  /// since the last Initialize() or ResetStatistics() call. A dispatch is
+  /// ineffective (not counted) if _any_ of the discrete update events fails or
+  /// _all_ the discrete update events return "did nothing". A single dispatcher
+  /// call may handle multiple discrete update events.
   int64_t get_num_discrete_updates() const { return num_discrete_updates_; }
 
-  /// Gets the number of "unrestricted" updates performed since the last
-  /// Initialize() call.
+  /// Gets the number of effective unrestricted update dispatcher calls since
+  /// the last Initialize() or ResetStatistics() call. A dispatch is ineffective
+  /// (not counted) if _any_ of the unrestricted update events fails or _all_
+  /// the unrestricted update events return "did nothing". A single dispatcher
+  /// call may handle multiple unrestricted update events.
   int64_t get_num_unrestricted_updates() const {
     return num_unrestricted_updates_; }
 
@@ -717,38 +756,22 @@ class Simulator {
       std::unique_ptr<const System<T>> owned_system,
       std::unique_ptr<Context<T>> context);
 
-  void HandleUnrestrictedUpdate(
+  [[nodiscard]] EventStatus HandleUnrestrictedUpdate(
       const EventCollection<UnrestrictedUpdateEvent<T>>& events);
 
-  void HandleDiscreteUpdate(
+  [[nodiscard]] EventStatus HandleDiscreteUpdate(
       const EventCollection<DiscreteUpdateEvent<T>>& events);
 
-  void HandlePublish(const EventCollection<PublishEvent<T>>& events);
+  [[nodiscard]] EventStatus HandlePublish(
+      const EventCollection<PublishEvent<T>>& events);
 
-  // Invoke the monitor() if there is one. If it wants termination we'll
-  // update the Simulator status accordingly. If it reports failure,
-  // currently we just throw.
-  // TODO(sherm1) Add an option where the Simulator returns failed status
-  // rather than throwing.
-  void CallMonitorUpdateStatusAndMaybeThrow(SimulatorStatus* status) {
-    DRAKE_DEMAND(status != nullptr);
-    if (python_monitor_ != nullptr) python_monitor_();
-    if (!get_monitor()) return;
-    const EventStatus monitor_status = get_monitor()(*context_);
-    if (monitor_status.severity() == EventStatus::kReachedTermination) {
-      status->SetReachedTermination(ExtractDoubleOrThrow(context_->get_time()),
-                                    monitor_status.system(),
-                                    monitor_status.message());
-      return;
-    }
-    if (monitor_status.severity() == EventStatus::kFailed) {
-      status->SetEventHandlerFailed(ExtractDoubleOrThrow(context_->get_time()),
-                                    monitor_status.system(),
-                                    monitor_status.message());
-      throw std::runtime_error(status->FormatMessage());
-    }
-    // For any other condition, leave the status unchanged.
-  }
+  // If an event handler failed, we have to interrupt the simulation.
+  // In that case, updates the SimulatorStatus to explain what happened and
+  // then optionally throws or returns true. Returns false and does nothing
+  // if no failure.
+  bool HasEventFailureOrMaybeThrow(
+      const EventStatus& event_status, bool throw_on_failure,
+      SimulatorStatus* simulator_status);
 
   TimeOrWitnessTriggered IntegrateContinuousState(
       const T& next_publish_time,
@@ -912,7 +935,7 @@ T GetPreviousNormalizedValue(const T& value) {
   // There are three distinct cases to be handled:
   //     -∞        -10⁻³⁰⁸  0      10⁻³⁰⁸      ∞
   //     |-----------|------|------|----------|
-  // (a) ^           ^              ^         ^   [-∞, 10⁻³⁰⁸] ∪ (10³⁰⁸, ∞]
+  // (a) ^           ^              ^         ^   [-∞, 10⁻³⁰⁸] ∪ (10⁻³⁰⁸, ∞]
   // (b)              ^           ^               (-10⁻³⁰⁸, 10⁻³⁰⁸)
   // (c)                           ^              10⁻³⁰⁸
 

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -40,6 +40,8 @@ using StatelessSystem = drake::systems::analysis_test::StatelessSystem<double>;
 using Eigen::AutoDiffScalar;
 using Eigen::NumTraits;
 using std::complex;
+using testing::ElementsAre;
+using testing::ElementsAreArray;
 
 // N.B. internal::GetPreviousNormalizedValue() is tested separately in
 // simulator_denorm_test.cc.
@@ -2329,6 +2331,547 @@ GTEST_TEST(SimulatorTest, MonitorFunctionAndStatusReturn) {
       ".*Simulator stopped at time 6.*because.*"
       "SpringMassSystem.*my_spring_mass.*"
       "failed with message.*Something terrible happened.*");
+}
+
+/* A System that has a complete set of simultaneous events (unrestricted,
+discrete, publish) with both initialization and periodic triggers for the
+purpose of testing that event status handling is done properly. We also define
+per-step publish events so we can ensure we're working with the steps we
+expect. */
+class EventStatusTestSystem : public LeafSystem<double> {
+ public:
+  enum class UpdateType {
+    kUnrestricted,
+    kDiscrete,
+    kPublish,
+  };
+  using Summary = std::tuple<TriggerType, UpdateType, int /* which */>;
+
+  EventStatusTestSystem() {
+    // Declare pairs (0 and 1) of identically-triggered events so that we have
+    // simultaneous events of each handler type.
+    MakeOneOfEach<0>();
+    MakeOneOfEach<1>();
+
+    DRAKE_DEMAND(event_severities_.size() == 14);
+  }
+
+  template <TriggerType trigger_type, UpdateType update_type, int which,
+            typename... Args>
+  EventStatus GenericHandler(const Context<double>& context, Args...) const {
+    return MakeStatus(trigger_type, update_type, which, context.get_time());
+  }
+
+  void SetSeverity(TriggerType trigger_type, UpdateType update_type, int which,
+                   EventStatus::Severity severity) {
+    event_severities_.at(Summary{trigger_type, update_type, which}) = severity;
+  }
+
+  void SetAllSeverities(EventStatus::Severity severity) {
+    for (auto& [_, map_entry_severity] : event_severities_) {
+      map_entry_severity = severity;
+    }
+  }
+
+  // Returns the list of events handled by all EventStatusTestSystem instances,
+  // and clears the list back to empty.
+  static std::vector<std::string> take_static_events() {
+    std::vector<std::string> result = events_singleton();
+    events_singleton().clear();
+    return result;
+  }
+
+ private:
+  static std::vector<std::string>& events_singleton() {
+    static never_destroyed<std::vector<std::string>> global(
+        std::vector<std::string>{});
+    return global.access();
+  }
+
+  EventStatus MakeStatus(TriggerType trigger_type, UpdateType update_type,
+                         int which, double context_time) const {
+    DRAKE_DEMAND(which == 0 || which == 1);
+    const std::string description = fmt::format(
+        "{} {} event {} at {}",
+        trigger_type == TriggerType::kInitialization ? "initialization"
+        : trigger_type == TriggerType::kPerStep      ? "per-step"
+        : trigger_type == TriggerType::kPeriodic     ? "periodic"
+                                                     : "???",
+        update_type == UpdateType::kUnrestricted ? "unrestricted update"
+        : update_type == UpdateType::kDiscrete   ? "discrete update"
+        : update_type == UpdateType::kPublish    ? "publish"
+                                                 : "???",
+        which, context_time);
+    events_singleton().push_back(description);
+    switch (event_severities_.at(Summary{trigger_type, update_type, which})) {
+      case EventStatus::kDidNothing:
+        return EventStatus::DidNothing();
+      case EventStatus::kSucceeded:
+        return EventStatus::Succeeded();
+      case EventStatus::kReachedTermination:
+        return EventStatus::ReachedTermination(
+            this, fmt::format("{} terminated", description));
+      case EventStatus::kFailed:
+        return EventStatus::Failed(this, fmt::format("{} failed", description));
+    }
+    DRAKE_UNREACHABLE();
+  }
+
+  template <int which>
+  void MakeOneOfEach() {
+    DeclareInitializationUnrestrictedUpdateEvent(
+        &EventStatusTestSystem::template GenericHandler<
+            TriggerType::kInitialization, UpdateType::kUnrestricted, which,
+            State<double>*>);
+    DeclareInitializationDiscreteUpdateEvent(
+        &EventStatusTestSystem::template GenericHandler<
+            TriggerType::kInitialization, UpdateType::kDiscrete, which,
+            DiscreteValues<double>*>);
+    DeclareInitializationPublishEvent(
+        &EventStatusTestSystem::template GenericHandler<
+            TriggerType::kInitialization, UpdateType::kPublish, which>);
+
+    DeclarePerStepPublishEvent(&EventStatusTestSystem::template GenericHandler<
+        TriggerType::kPerStep, UpdateType::kPublish, which>);
+
+    const double period = 0.5;
+    const double offset = 0.0;
+    DeclarePeriodicUnrestrictedUpdateEvent(
+        period, offset,
+        &EventStatusTestSystem::template GenericHandler<
+            TriggerType::kPeriodic, UpdateType::kUnrestricted, which,
+            State<double>*>);
+    DeclarePeriodicDiscreteUpdateEvent(
+        period, offset,
+        &EventStatusTestSystem::template GenericHandler<
+            TriggerType::kPeriodic, UpdateType::kDiscrete, which,
+            DiscreteValues<double>*>);
+    DeclarePeriodicPublishEvent(
+        period, offset,
+        &EventStatusTestSystem::template GenericHandler<
+            TriggerType::kPeriodic, UpdateType::kPublish, which>);
+
+    // Set return status to "succeeded" initially.
+    for (auto trigger_type : {TriggerType::kInitialization,
+                              TriggerType::kPerStep, TriggerType::kPeriodic}) {
+      for (auto update_type : {UpdateType::kUnrestricted, UpdateType::kDiscrete,
+                               UpdateType::kPublish}) {
+        if (trigger_type == TriggerType::kPerStep &&
+            update_type != UpdateType::kPublish) {
+          continue;
+        }
+        event_severities_[Summary{trigger_type, update_type, which}] =
+            EventStatus::kSucceeded;
+      }
+    }
+  }
+
+  // The prescribed return value for each GenericHandler.
+  std::map<Summary, EventStatus::Severity> event_severities_;
+};
+
+// Verify that the Simulator handles EventStatus from event handlers correctly
+// (monitor status returns tested above). The Simulator-affecting statuses are
+// ReachedTermination (which should cause AdvanceTo to stop advancing and
+// report the reason) and Failure (which should cause an immediate halt to
+// event processing and throw an exception). In case of simultaneous
+// ReachedTermination and Failure, the Failure should win.
+// Simulator::Initialize() and ::AdvanceTo() process events similarly but differ
+// in details.
+GTEST_TEST(SimulatorTest, EventStatusReturnHandlingForInitialize) {
+  using UpdateType = EventStatusTestSystem::UpdateType;
+
+  EventStatusTestSystem system;
+  system.set_name("my_event_system");
+  Simulator<double> sim(system);
+
+  const double start_time = 0.125;  // Note: not t=0, periodic won't trigger.
+
+  sim.get_mutable_context().SetTime(start_time);
+
+  auto reset = [&]() {
+    system.SetAllSeverities(EventStatus::kSucceeded);
+    sim.ResetStatistics();  // Clear the Simulator's counts.
+  };
+
+  // Baseline: all events execute and return "succeeded". The Simulator should
+  // count _dispatcher_ calls which cover multiple events.
+  reset();
+  SimulatorStatus status = sim.Initialize();
+  const std::string all_events[] = {
+      "initialization unrestricted update event 0 at 0.125",
+      "initialization unrestricted update event 1 at 0.125",
+      "initialization discrete update event 0 at 0.125",
+      "initialization discrete update event 1 at 0.125",
+      "initialization publish event 0 at 0.125",
+      "initialization publish event 1 at 0.125",
+      "per-step publish event 0 at 0.125",
+      "per-step publish event 1 at 0.125"};
+  EXPECT_THAT(system.take_static_events(), ElementsAreArray(all_events));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 1);
+  EXPECT_EQ(sim.get_num_publishes(), 1);  // initialize & per-step together
+  EXPECT_TRUE(status.succeeded());
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedBoundaryTime);
+  EXPECT_EQ(sim.get_context().get_time(), start_time);
+
+  // Same test but now everything returns "did nothing" so the Simulator
+  // shouldn't count them.
+  reset();
+  system.SetAllSeverities(EventStatus::kDidNothing);
+  status = sim.Initialize();
+  EXPECT_THAT(system.take_static_events(), ElementsAreArray(all_events));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 0);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 0);
+  EXPECT_EQ(sim.get_num_publishes(), 0);
+  EXPECT_TRUE(status.succeeded());
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedBoundaryTime);
+  EXPECT_EQ(sim.get_context().get_time(), start_time);
+
+  // 2nd unrestricted update reports failure. Discrete and publish events
+  // should not get executed. The dispatch should not be counted since it
+  // failed.
+  reset();
+  system.SetSeverity(TriggerType::kInitialization, UpdateType::kUnrestricted, 1,
+                     EventStatus::kFailed);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      sim.Initialize(), fmt::format("Simulator stopped.*"
+                                    "unrestricted update event 1.*failed.*"));
+  EXPECT_THAT(
+      system.take_static_events(),
+      ElementsAre("initialization unrestricted update event 0 at 0.125",
+                  "initialization unrestricted update event 1 at 0.125"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 0);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 0);
+  EXPECT_EQ(sim.get_num_publishes(), 0);
+  EXPECT_EQ(sim.get_context().get_time(), start_time);
+
+  // 2nd unrestricted update reports termination. Discrete events should still
+  // be processed but then we return early without handling end-of-step publish
+  // events.
+  reset();
+  system.SetSeverity(TriggerType::kInitialization, UpdateType::kUnrestricted, 1,
+                     EventStatus::kReachedTermination);
+  status = sim.Initialize();
+  EXPECT_THAT(system.take_static_events(),
+              ElementsAre("initialization unrestricted update event 0 at 0.125",
+                          "initialization unrestricted update event 1 at 0.125",
+                          "initialization discrete update event 0 at 0.125",
+                          "initialization discrete update event 1 at 0.125"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 1);
+  EXPECT_EQ(sim.get_num_publishes(), 0);
+  EXPECT_FALSE(status.succeeded());
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedTerminationCondition);
+  EXPECT_EQ(status.system(), &system);
+  EXPECT_THAT(status.FormatMessage(),
+              ::testing::MatchesRegex(
+                  fmt::format("Simulator returned early.*"
+                              "unrestricted update event 1.*terminated.*")));
+  EXPECT_EQ(sim.get_context().get_time(), start_time);
+
+  // 2nd unrestricted update still reports termination, but later the 1st
+  // discrete update fails, which trumps. Should stop executing at that point
+  // and throw. Simulator shouldn't count the failed discrete update.
+  reset();
+  system.SetSeverity(TriggerType::kInitialization, UpdateType::kUnrestricted, 1,
+                     EventStatus::kReachedTermination);
+  system.SetSeverity(TriggerType::kInitialization, UpdateType::kDiscrete, 0,
+                     EventStatus::kFailed);
+  DRAKE_EXPECT_THROWS_MESSAGE(sim.Initialize(),
+                              fmt::format("Simulator stopped.*"
+                                          "discrete update event 0.*failed.*"));
+  EXPECT_THAT(system.take_static_events(),
+              ElementsAre("initialization unrestricted update event 0 at 0.125",
+                          "initialization unrestricted update event 1 at 0.125",
+                          "initialization discrete update event 0 at 0.125"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 0);
+  EXPECT_EQ(sim.get_num_publishes(), 0);
+  EXPECT_EQ(sim.get_context().get_time(), start_time);
+
+  // 1st publish event reports termination. All events should still execute
+  // but return status should indicate termination.
+  reset();
+  system.SetSeverity(TriggerType::kInitialization, UpdateType::kPublish, 0,
+                     EventStatus::kReachedTermination);
+  status = sim.Initialize();
+  EXPECT_THAT(system.take_static_events(), ElementsAreArray(all_events));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 1);
+  EXPECT_EQ(sim.get_num_publishes(), 1);
+  EXPECT_FALSE(status.succeeded());
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedTerminationCondition);
+  EXPECT_EQ(status.system(), &system);
+  EXPECT_THAT(status.FormatMessage(), ::testing::MatchesRegex(fmt::format(
+                                          "Simulator returned early.*"
+                                          "publish event 0.*terminated.*")));
+  EXPECT_EQ(sim.get_context().get_time(), start_time);
+
+  // 1st publish event reports failure. All events should still execute but an
+  // error should be thrown.
+  reset();
+  system.SetSeverity(TriggerType::kInitialization, UpdateType::kPublish, 0,
+                     EventStatus::kFailed);
+  DRAKE_EXPECT_THROWS_MESSAGE(sim.Initialize(),
+                              fmt::format("Simulator stopped.*"
+                                          "publish event 0.*failed.*"));
+  EXPECT_THAT(system.take_static_events(), ElementsAreArray(all_events));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 1);
+  EXPECT_EQ(sim.get_num_publishes(), 0);  // Shouldn't count failed dispatch.
+  EXPECT_EQ(sim.get_context().get_time(), start_time);
+
+  // Both publish events fail. All events should still execute but an error
+  // should be thrown reporting the _first_ publish event's failure.
+  reset();
+  system.SetSeverity(TriggerType::kInitialization, UpdateType::kPublish, 0,
+                     EventStatus::kFailed);
+  system.SetSeverity(TriggerType::kInitialization, UpdateType::kPublish, 1,
+                     EventStatus::kFailed);
+  DRAKE_EXPECT_THROWS_MESSAGE(sim.Initialize(),
+                              fmt::format("Simulator stopped.*"
+                                          "publish event 0.*failed.*"));
+  EXPECT_THAT(system.take_static_events(), ElementsAreArray(all_events));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 1);
+  EXPECT_EQ(sim.get_num_publishes(), 0);  // Shouldn't count failed dispatch.
+  EXPECT_EQ(sim.get_context().get_time(), start_time);
+}
+
+GTEST_TEST(SimulatorTest, EventStatusReturnHandlingForAdvanceTo) {
+  using UpdateType = EventStatusTestSystem::UpdateType;
+
+  EventStatusTestSystem system;
+  system.set_name("my_event_system");
+  Simulator<double> sim(system);
+  sim.reset_integrator<RungeKutta2Integrator<double>>(0.5);  // Fixed step size.
+
+  // We're starting at t=0.125 and advancing to t=0.75 with a step size of
+  // h=0.5. If there were no events, the two steps taken would have been:
+  //   t=.125  (h=.5)  t=.625 (h=.125) t=.75
+  // But with periodic events occurring at t=0.5, the steps will be:
+  //   t=.125 (h=.375) t=.5   (h=.25)  t=.75
+  // Note that the per-step publishes will occur with each step regardless of
+  // the step size.
+
+  const double start_time = 0.125;
+  const double early_return_time = 0.5;  // Periodic events trigger here.
+  const double boundary_time = 0.75;
+
+  auto reset = [&]() {
+    sim.get_mutable_context().SetTime(start_time);
+    system.SetAllSeverities(EventStatus::kSucceeded);
+    sim.Initialize();
+    system.take_static_events();  // Clear the System's event log.
+    sim.ResetStatistics();        // Clear the Simulator's counts.
+  };
+
+  // Baseline: advance to 0.75 with no notable status returns. Should take two
+  // steps, executing the per-step publishes twice and each of the periodic
+  // events once.
+  reset();
+  SimulatorStatus status = sim.AdvanceTo(boundary_time);
+  const std::string all_events[] = {
+      "per-step publish event 0 at 0.5",
+      "per-step publish event 1 at 0.5",
+      "periodic publish event 0 at 0.5",
+      "periodic publish event 1 at 0.5",
+      "periodic unrestricted update event 0 at 0.5",
+      "periodic unrestricted update event 1 at 0.5",
+      "periodic discrete update event 0 at 0.5",
+      "periodic discrete update event 1 at 0.5",
+      "per-step publish event 0 at 0.75",
+      "per-step publish event 1 at 0.75"};
+  EXPECT_THAT(system.take_static_events(), ElementsAreArray(all_events));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 1);
+  EXPECT_EQ(sim.get_num_publishes(), 2);  // step+periodic dispatched together
+  EXPECT_TRUE(status.succeeded());
+  EXPECT_EQ(sim.get_context().get_time(), boundary_time);
+  EXPECT_EQ(sim.get_num_steps_taken(), 2);
+
+  // Same, but everyone reports "did nothing" so the Simulator should not count
+  // those dispatches.
+  reset();
+  system.SetAllSeverities(EventStatus::kDidNothing);
+  status = sim.AdvanceTo(boundary_time);
+  EXPECT_THAT(system.take_static_events(), ElementsAreArray(all_events));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 0);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 0);
+  EXPECT_EQ(sim.get_num_publishes(), 0);
+  EXPECT_TRUE(status.succeeded());
+  EXPECT_EQ(sim.get_context().get_time(), boundary_time);
+  EXPECT_EQ(sim.get_num_steps_taken(), 2);
+
+  // When we attempt to advance to t=0.75 we'll trigger events at t=0.5. Publish
+  // events are handled at the _end_ of the step that reached 0.5; unrestricted
+  // and discrete events are handled at the _start_ of the next step.
+
+  // 2nd unrestricted update fails (at start of 2nd step). Should stop executing
+  // at that point (t=0.5) and throw. Discrete updates and final publishes
+  // should _not_ be handled. Simulator should not count the unrestricted
+  // update since it failed. Per-step and periodic publishes occur at the end
+  // of the first step (also t=0.5).
+  reset();
+  system.SetSeverity(TriggerType::kPeriodic, UpdateType::kUnrestricted, 1,
+                     EventStatus::kFailed);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      status = sim.AdvanceTo(boundary_time),
+      fmt::format("Simulator stopped.*"
+                  "periodic unrestricted update event 1.*failed.*"));
+  EXPECT_THAT(system.take_static_events(),
+              ElementsAre("per-step publish event 0 at 0.5",
+                          "per-step publish event 1 at 0.5",
+                          "periodic publish event 0 at 0.5",
+                          "periodic publish event 1 at 0.5",
+                          "periodic unrestricted update event 0 at 0.5",
+                          "periodic unrestricted update event 1 at 0.5"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 0);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 0);
+  EXPECT_EQ(sim.get_num_publishes(), 1);  // the one at 0.5 (end of 1st step)
+
+  // The periodic publish occurring at the end of the step that reaches 0.5
+  // reports termination. That should not stop both per-step and periodic
+  // publishes from being handled then and allows the periodic updates to be
+  // scheduled, though not handled.
+  reset();
+  system.SetSeverity(TriggerType::kPeriodic, UpdateType::kPublish, 0,
+                     EventStatus::kReachedTermination);
+  status = sim.AdvanceTo(boundary_time);
+  EXPECT_THAT(system.take_static_events(),
+              ElementsAre("per-step publish event 0 at 0.5",
+                          "per-step publish event 1 at 0.5",
+                          "periodic publish event 0 at 0.5",
+                          "periodic publish event 1 at 0.5"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 0);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 0);
+  EXPECT_EQ(sim.get_num_publishes(), 1);  // dispatched together
+  EXPECT_FALSE(status.succeeded());
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedTerminationCondition);
+  EXPECT_EQ(status.return_time(), 0.5);
+  EXPECT_EQ(status.system(), &system);
+  EXPECT_THAT(status.FormatMessage(),
+              ::testing::MatchesRegex(
+                  fmt::format("Simulator returned early.*"
+                              "periodic publish event 0.*terminated.*")));
+  EXPECT_EQ(sim.get_context().get_time(), early_return_time);
+  EXPECT_EQ(sim.get_num_steps_taken(), 1);
+  // Handle the periodic events we left dangling. This counts as a final
+  // zero-length step so will bump the step count and trigger per-step events.
+  status = sim.AdvancePendingEvents();
+  EXPECT_THAT(system.take_static_events(),
+              ElementsAre("periodic unrestricted update event 0 at 0.5",
+                          "periodic unrestricted update event 1 at 0.5",
+                          "periodic discrete update event 0 at 0.5",
+                          "periodic discrete update event 1 at 0.5",
+                          "per-step publish event 0 at 0.5",
+                          "per-step publish event 1 at 0.5"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 1);
+  EXPECT_EQ(sim.get_num_publishes(), 2);
+  EXPECT_EQ(sim.get_num_steps_taken(), 2);
+
+  // 2nd unrestricted event reports termination at 0.5 (_start_ of 2nd step).
+  // Periodic and per-step publish events will trigger at end of 1st step, but
+  // not at end of 2nd step since that will be cut short. However, both the
+  // discrete update events should still trigger at start of 2nd since the
+  // termination return doesn't halt execution of simultaneous updates.
+  reset();
+  system.SetSeverity(TriggerType::kPeriodic, UpdateType::kUnrestricted, 1,
+                     EventStatus::kReachedTermination);
+  status = sim.AdvanceTo(boundary_time);
+  EXPECT_THAT(system.take_static_events(),
+              ElementsAre("per-step publish event 0 at 0.5",
+                          "per-step publish event 1 at 0.5",
+                          "periodic publish event 0 at 0.5",
+                          "periodic publish event 1 at 0.5",
+                          "periodic unrestricted update event 0 at 0.5",
+                          "periodic unrestricted update event 1 at 0.5",
+                          "periodic discrete update event 0 at 0.5",
+                          "periodic discrete update event 1 at 0.5"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 1);
+  EXPECT_EQ(sim.get_num_publishes(), 1);
+  EXPECT_FALSE(status.succeeded());
+  EXPECT_EQ(status.reason(), SimulatorStatus::kReachedTerminationCondition);
+  EXPECT_EQ(status.system(), &system);
+  EXPECT_THAT(status.FormatMessage(),
+              ::testing::MatchesRegex(fmt::format(
+                  "Simulator returned early.*"
+                  "periodic unrestricted update event 1.*terminated.*")));
+  EXPECT_EQ(sim.get_context().get_time(), early_return_time);
+  EXPECT_EQ(sim.get_num_steps_taken(), 1);
+
+  // 2nd unrestricted update still reports termination, but later the 1st
+  // discrete update fails, which trumps. Should stop executing at that point
+  // (t=0.5) and throw. 2nd discrete update and final publishes should _not_ be
+  // handled. Simulator should not count the discrete update since it failed.
+  // Per-step and periodic publishes occur at the end of the first step (at
+  // t=0.5).
+  reset();
+  system.SetSeverity(TriggerType::kPeriodic, UpdateType::kUnrestricted, 1,
+                     EventStatus::kReachedTermination);
+  system.SetSeverity(TriggerType::kPeriodic, UpdateType::kDiscrete, 0,
+                     EventStatus::kFailed);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      status = sim.AdvanceTo(boundary_time),
+      fmt::format("Simulator stopped.*"
+                  "periodic discrete update event 0.*failed.*"));
+  EXPECT_THAT(system.take_static_events(),
+              ElementsAre("per-step publish event 0 at 0.5",
+                          "per-step publish event 1 at 0.5",
+                          "periodic publish event 0 at 0.5",
+                          "periodic publish event 1 at 0.5",
+                          "periodic unrestricted update event 0 at 0.5",
+                          "periodic unrestricted update event 1 at 0.5",
+                          "periodic discrete update event 0 at 0.5"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 1);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 0);
+  EXPECT_EQ(sim.get_num_publishes(), 1);  // the one at 0.5 (end of 1st step)
+
+  // First publish event fails. The second one should still be handled, then
+  // AdvanceTo() should throw reporting the failure. That's at the end of the
+  // first step (that ended at 0.5s) so we won't get to the unrestricted and
+  // discrete updates that would have occurred at the start of the 2nd step.
+  reset();
+  system.SetSeverity(TriggerType::kPeriodic, UpdateType::kPublish, 0,
+                     EventStatus::kFailed);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      status = sim.AdvanceTo(boundary_time),
+      fmt::format("Simulator stopped.*"
+                  "periodic publish event 0.*failed.*"));
+  EXPECT_THAT(system.take_static_events(),
+              ElementsAre("per-step publish event 0 at 0.5",
+                          "per-step publish event 1 at 0.5",
+                          "periodic publish event 0 at 0.5",
+                          "periodic publish event 1 at 0.5"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 0);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 0);
+  EXPECT_EQ(sim.get_num_publishes(), 0);  // Shouldn't count failed dispatch.
+
+  // Same, but now both publishes failed. We should still report the failure of
+  // the first one that failed, i.e., publish0. Note that per-step and periodic
+  // publish handlers are all invoked (at end of 1st step) but we don't go any
+  // futher because of the failure (so none of the updates that would have
+  // occurred at the beginning of the next step occur).
+  reset();
+  system.SetSeverity(TriggerType::kPeriodic, UpdateType::kPublish, 0,
+                     EventStatus::kFailed);
+  system.SetSeverity(TriggerType::kPeriodic, UpdateType::kPublish, 1,
+                     EventStatus::kFailed);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      status = sim.AdvanceTo(boundary_time),
+      fmt::format("Simulator stopped.*"
+                  "periodic publish event 0.*failed.*"));
+  EXPECT_THAT(system.take_static_events(),
+              ElementsAre("per-step publish event 0 at 0.5",
+                          "per-step publish event 1 at 0.5",
+                          "periodic publish event 0 at 0.5",
+                          "periodic publish event 1 at 0.5"));
+  EXPECT_EQ(sim.get_num_unrestricted_updates(), 0);
+  EXPECT_EQ(sim.get_num_discrete_updates(), 0);
+  EXPECT_EQ(sim.get_num_publishes(), 0);  // Shouldn't count failed dispatch.
 }
 
 // Simulator::Initialize() called at time t temporarily moves time back to

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -177,6 +177,7 @@ drake_cc_library(
     name = "event_collection",
     srcs = [
         "event_collection.cc",
+        "event_status.cc",
     ],
     hdrs = [
         "event.h",
@@ -186,6 +187,7 @@ drake_cc_library(
     deps = [
         ":abstract_values",
         ":context",
+        ":system_base",
         "//common:default_scalars",
         "//common:essential",
         "//common:value",
@@ -848,6 +850,8 @@ drake_cc_googletest(
     name = "event_status_test",
     deps = [
         ":event_collection",
+        ":leaf_system",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -256,6 +256,19 @@ class ContextBase : public internal::ContextMessageInterface {
   /** Returns true if this context has no parent. */
   bool is_root_context() const { return parent_ == nullptr; }
 
+#ifndef DRAKE_DOXYGEN_CXX
+  // (Internal use only) Provides a mutable flag for use in deprecating
+  // user-overrideable virtuals in Drake code that only has access to a const
+  // Context. There is no explicit thread safety provided, but this can be used
+  // in a thread-safe manner as long as Contexts are not shared among threads.
+  void set_use_default_implementation(bool value) const {
+    use_default_implementation_ = value;
+  }
+  bool get_use_default_implementation() const {
+    return use_default_implementation_;
+  }
+#endif
+
  protected:
   /** Default constructor creates an empty ContextBase but initializes all the
   built-in dependency trackers that are the same in every System (like time,
@@ -653,6 +666,9 @@ class ContextBase : public internal::ContextMessageInterface {
   // const Context.
   // Note that it does *not* get reset when copied.
   mutable int64_t current_change_event_{0};
+
+  // A writable flag for use in deprecating user-overrideable virtuals.
+  mutable bool use_default_implementation_{false};
 
   // This is the dependency graph for values within this subcontext.
   DependencyGraph graph_;

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1215,28 +1215,34 @@ Diagram<T>::AllocateForcedEventCollection(
 }
 
 template <typename T>
-void Diagram<T>::DispatchPublishHandler(
+EventStatus Diagram<T>::DispatchPublishHandler(
     const Context<T>& context,
     const EventCollection<PublishEvent<T>>& event_info) const {
   auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
   DRAKE_DEMAND(diagram_context != nullptr);
   const DiagramEventCollection<PublishEvent<T>>& info =
-      dynamic_cast<const DiagramEventCollection<PublishEvent<T>>&>(
-          event_info);
+      dynamic_cast<const DiagramEventCollection<PublishEvent<T>>&>(event_info);
 
+  EventStatus overall_status = EventStatus::DidNothing();
   for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
     const EventCollection<PublishEvent<T>>& subinfo =
         info.get_subevent_collection(i);
 
     if (subinfo.HasEvents()) {
       const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
-      registered_systems_[i]->Publish(subcontext, subinfo);
+      const EventStatus per_subsystem_status =
+          registered_systems_[i]->Publish(subcontext, subinfo);
+      overall_status.KeepMoreSevere(per_subsystem_status);
+      // Unlike the discrete & unrestricted event policy, we don't stop handling
+      // publish events when one fails; we just report the first failure after
+      // all the publishes are done.
     }
   }
+  return overall_status;
 }
 
 template <typename T>
-void Diagram<T>::DispatchDiscreteVariableUpdateHandler(
+EventStatus Diagram<T>::DispatchDiscreteVariableUpdateHandler(
     const Context<T>& context,
     const EventCollection<DiscreteUpdateEvent<T>>& events,
     DiscreteValues<T>* discrete_state) const {
@@ -1250,6 +1256,7 @@ void Diagram<T>::DispatchDiscreteVariableUpdateHandler(
       dynamic_cast<const DiagramEventCollection<DiscreteUpdateEvent<T>>&>(
           events);
 
+  EventStatus overall_status = EventStatus::DidNothing();
   for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
     const EventCollection<DiscreteUpdateEvent<T>>& subevents =
         diagram_events.get_subevent_collection(i);
@@ -1259,10 +1266,14 @@ void Diagram<T>::DispatchDiscreteVariableUpdateHandler(
       DiscreteValues<T>& subdiscrete =
           diagram_discrete->get_mutable_subdiscrete(i);
 
-      registered_systems_[i]->CalcDiscreteVariableUpdate(
+      const EventStatus per_subsystem_status =
+          registered_systems_[i]->CalcDiscreteVariableUpdate(
           subcontext, subevents, &subdiscrete);
+      overall_status.KeepMoreSevere(per_subsystem_status);
+      if (overall_status.failed()) break;  // Stop at the first disaster.
     }
   }
+  return overall_status;
 }
 
 template <typename T>
@@ -1293,7 +1304,7 @@ void Diagram<T>::DoApplyDiscreteVariableUpdate(
 }
 
 template <typename T>
-void Diagram<T>::DispatchUnrestrictedUpdateHandler(
+EventStatus Diagram<T>::DispatchUnrestrictedUpdateHandler(
     const Context<T>& context,
     const EventCollection<UnrestrictedUpdateEvent<T>>& events,
     State<T>* state) const {
@@ -1306,6 +1317,7 @@ void Diagram<T>::DispatchUnrestrictedUpdateHandler(
       dynamic_cast<const DiagramEventCollection<UnrestrictedUpdateEvent<T>>&>(
           events);
 
+  EventStatus overall_status = EventStatus::DidNothing();
   for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
     const EventCollection<UnrestrictedUpdateEvent<T>>& subevents =
         diagram_events.get_subevent_collection(i);
@@ -1314,10 +1326,14 @@ void Diagram<T>::DispatchUnrestrictedUpdateHandler(
       const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
       State<T>& substate = diagram_state->get_mutable_substate(i);
 
-      registered_systems_[i]->CalcUnrestrictedUpdate(subcontext, subevents,
-                                                     &substate);
+      const EventStatus per_subsystem_status =
+          registered_systems_[i]->CalcUnrestrictedUpdate(subcontext, subevents,
+                                                         &substate);
+      overall_status.KeepMoreSevere(per_subsystem_status);
+      if (overall_status.failed()) break;  // Stop at the first disaster.
     }
   }
+  return overall_status;
 }
 
 template <typename T>

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -433,7 +433,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // For each subsystem, if there is a publish event in its corresponding
   // subevent collection, calls its Publish method with the appropriate
   // subcontext and subevent collection.
-  void DispatchPublishHandler(
+  [[nodiscard]] EventStatus DispatchPublishHandler(
       const Context<T>& context,
       const EventCollection<PublishEvent<T>>& event_info) const final;
 
@@ -441,7 +441,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // corresponding subevent collection, calls its CalcDiscreteVariableUpdate()
   // method with the appropriate subcontext, subevent collection and
   // substate.
-  void DispatchDiscreteVariableUpdateHandler(
+  [[nodiscard]] EventStatus DispatchDiscreteVariableUpdateHandler(
       const Context<T>& context,
       const EventCollection<DiscreteUpdateEvent<T>>& events,
       DiscreteValues<T>* discrete_state) const final;
@@ -453,7 +453,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // For each subsystem, if there is an unrestricted update event in its
   // corresponding subevent collection, calls its CalcUnrestrictedUpdate
   // method with the appropriate subcontext, subevent collection and substate.
-  void DispatchUnrestrictedUpdateHandler(
+  [[nodiscard]] EventStatus DispatchUnrestrictedUpdateHandler(
       const Context<T>& context,
       const EventCollection<UnrestrictedUpdateEvent<T>>& events,
       State<T>* state) const final;

--- a/systems/framework/event_status.cc
+++ b/systems/framework/event_status.cc
@@ -1,0 +1,33 @@
+#include "drake/systems/framework/event_status.h"
+
+#include <stdexcept>
+
+#include <fmt/format.h>
+
+#include "drake/common/nice_type_name.h"
+#include "drake/systems/framework/system_base.h"
+
+namespace drake {
+namespace systems {
+
+void EventStatus::ThrowOnFailure(const char* function_name) const {
+  if (!failed()) return;
+  DRAKE_THROW_UNLESS(function_name != nullptr);
+
+  /* Attempt to identify the relevant subsystem in human-readable terms. If no
+  subsystem was provided we just call it "System". Otherwise, we obtain its
+  type and its name and call it "type system 'name'", e.g.
+  "MultibodyPlant<double> system 'my_plant'". */
+  const std::string system_id =
+      system() == nullptr
+          ? "System"
+          : fmt::format("{} system '{}'", system()->GetSystemType(),
+                        system()->GetSystemPathname());
+
+  throw std::runtime_error(
+      fmt::format("{}(): An event handler in {} failed with message: \"{}\".",
+                  function_name, system_id, message()));
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -766,30 +766,32 @@ SystemConstraintIndex LeafSystem<T>::DeclareInequalityConstraint(
 template <typename T>
 void LeafSystem<T>::DoPublish(
     const Context<T>& context,
-    const std::vector<const PublishEvent<T>*>& events) const {
-  for (const PublishEvent<T>* event : events) {
-    event->handle(*this, context);
-  }
+    const std::vector<const PublishEvent<T>*>&) const {
+  // Sets this flag to indicate that the derived System did not override
+  // our default method. See DispatchPublishHandler() for how this is used.
+  context.set_use_default_implementation(true);
 }
 
 template <typename T>
 void LeafSystem<T>::DoCalcDiscreteVariableUpdates(
     const Context<T>& context,
-    const std::vector<const DiscreteUpdateEvent<T>*>& events,
-    DiscreteValues<T>* discrete_state) const {
-  for (const DiscreteUpdateEvent<T>* event : events) {
-    event->handle(*this, context, discrete_state);
-  }
+    const std::vector<const DiscreteUpdateEvent<T>*>&,
+    DiscreteValues<T>*) const {
+  // Sets this flag to indicate that the derived System did not override
+  // our default method. See DispatchDiscreteVariableUpdateHandler() for how
+  // this is used.
+  context.set_use_default_implementation(true);
 }
 
 template <typename T>
 void LeafSystem<T>::DoCalcUnrestrictedUpdate(
     const Context<T>& context,
-    const std::vector<const UnrestrictedUpdateEvent<T>*>& events,
-    State<T>* state) const {
-  for (const UnrestrictedUpdateEvent<T>* event : events) {
-    event->handle(*this, context, state);
-  }
+    const std::vector<const UnrestrictedUpdateEvent<T>*>&,
+    State<T>*) const {
+  // Sets this flag to indicate that the derived System did not override
+  // our default method. See DispatchUnrestrictedUpdateHandler() for how
+  // this is used.
+  context.set_use_default_implementation(true);
 }
 
 template <typename T>
@@ -839,31 +841,71 @@ LeafSystem<T>::DoMapPeriodicEventsByTiming(const Context<T>&) const {
 }
 
 template <typename T>
-void LeafSystem<T>::DispatchPublishHandler(
+EventStatus LeafSystem<T>::DispatchPublishHandler(
     const Context<T>& context,
     const EventCollection<PublishEvent<T>>& events) const {
   const LeafEventCollection<PublishEvent<T>>& leaf_events =
      dynamic_cast<const LeafEventCollection<PublishEvent<T>>&>(events);
-  // Only call DoPublish if there are publish events.
+  // This function shouldn't have been called if no publish events.
   DRAKE_DEMAND(leaf_events.HasEvents());
+
+  // Determine whether the derived System overloaded DoPublish(). If so, this
+  // flag will remain false; the default implementation sets it to true.
+  context.set_use_default_implementation(false);
   this->DoPublish(context, leaf_events.get_events());
+  if (!context.get_use_default_implementation()) {
+    // Derived system overrode the dispatcher and did not invoke the base class
+    // implementation so there is nothing else to do.
+    return EventStatus::Succeeded();
+  }
+
+  // Use our default dispatch policy.
+  EventStatus overall_status = EventStatus::DidNothing();
+  for (const PublishEvent<T>* event : leaf_events.get_events()) {
+    const EventStatus per_event_status = event->handle(*this, context);
+    overall_status.KeepMoreSevere(per_event_status);
+    // Unlike the discrete & unrestricted event policy, we don't stop
+    // handling publish events when one fails; we just report the first failure
+    // after all the publishes are done.
+  }
+  return overall_status;
 }
 
 template <typename T>
-void LeafSystem<T>::DispatchDiscreteVariableUpdateHandler(
+EventStatus LeafSystem<T>::DispatchDiscreteVariableUpdateHandler(
     const Context<T>& context,
     const EventCollection<DiscreteUpdateEvent<T>>& events,
     DiscreteValues<T>* discrete_state) const {
   const LeafEventCollection<DiscreteUpdateEvent<T>>& leaf_events =
       dynamic_cast<const LeafEventCollection<DiscreteUpdateEvent<T>>&>(
           events);
+  // This function shouldn't have been called if no discrete update events.
   DRAKE_DEMAND(leaf_events.HasEvents());
 
-  // Must initialize the output argument with the current contents of the
-  // discrete state.
+  // Must initialize the output argument with current discrete state contents.
   discrete_state->SetFrom(context.get_discrete_state());
+
+  // Determine whether the derived System overloaded
+  // DoCalcDiscreteVariableUpdates(). If so, this flag will remain false; the
+  // default implementation sets it to true.
+  context.set_use_default_implementation(false);
   this->DoCalcDiscreteVariableUpdates(context, leaf_events.get_events(),
       discrete_state);  // in/out
+  if (!context.get_use_default_implementation()) {
+    // Derived system overrode the dispatcher and did not invoke the base class
+    // implementation so there is nothing else to do.
+    return EventStatus::Succeeded();
+  }
+
+  // Use our default dispatch policy.
+  EventStatus overall_status = EventStatus::DidNothing();
+  for (const DiscreteUpdateEvent<T>* event : leaf_events.get_events()) {
+    const EventStatus per_event_status =
+        event->handle(*this, context, discrete_state);
+    overall_status.KeepMoreSevere(per_event_status);
+    if (overall_status.failed()) break;  // Stop at the first disaster.
+  }
+  return overall_status;
 }
 
 template <typename T>
@@ -879,20 +921,39 @@ void LeafSystem<T>::DoApplyDiscreteVariableUpdate(
 }
 
 template <typename T>
-void LeafSystem<T>::DispatchUnrestrictedUpdateHandler(
+EventStatus LeafSystem<T>::DispatchUnrestrictedUpdateHandler(
     const Context<T>& context,
     const EventCollection<UnrestrictedUpdateEvent<T>>& events,
     State<T>* state) const {
   const LeafEventCollection<UnrestrictedUpdateEvent<T>>& leaf_events =
       dynamic_cast<const LeafEventCollection<UnrestrictedUpdateEvent<T>>&>(
           events);
+  // This function shouldn't have been called if no unrestricted update events.
   DRAKE_DEMAND(leaf_events.HasEvents());
 
-  // Must initialize the output argument with the current contents of the
-  // state.
+  // Must initialize the output argument with current state contents.
   state->SetFrom(context.get_state());
+
+  // Determine whether the derived System overloaded
+  // DoCalcUnrestrictedUpdate(). If so, this flag will remain false; the
+  // default implementation sets it to true.
+  context.set_use_default_implementation(false);
   this->DoCalcUnrestrictedUpdate(context, leaf_events.get_events(),
-      state);  // in/out
+                                        state);  // in/out
+  if (!context.get_use_default_implementation()) {
+    // Derived system overrode the dispatcher and did not invoke the base class
+    // implementation so there is nothing else to do.
+    return EventStatus::Succeeded();
+  }
+
+  // Use our default dispatch policy.
+  EventStatus overall_status = EventStatus::DidNothing();
+  for (const UnrestrictedUpdateEvent<T>* event : leaf_events.get_events()) {
+    const EventStatus per_event_status = event->handle(*this, context, state);
+    overall_status.KeepMoreSevere(per_event_status);
+    if (overall_status.failed()) break;  // Stop at the first disaster.
+  }
+  return overall_status;
 }
 
 template <typename T>

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1823,6 +1823,10 @@ class LeafSystem : public System<T> {
   is only called from the public non-virtual Publish(), which will have
   already error-checked @p context so you may assume that it is valid.
 
+  @note There is no provision for returning EventStatus from DoPublish() as
+  there is if you use the default dispatcher. Instead, your DoPublish() will be
+  assumed to return EventStatus::Succeeded() regardless of what happened.
+
   @param[in] context Const current context.
   @param[in] events All the publish events that need handling. */
   virtual void DoPublish(
@@ -1853,6 +1857,11 @@ class LeafSystem : public System<T> {
   implementations may assume that @p context is valid; that
   @p discrete_state is non-null, and that the referenced object has the
   same constituent structure as was produced by AllocateDiscreteVariables().
+
+  @note There is no provision for returning EventStatus from
+  DoCalcDiscreteVariableUpdates() as there is if you use the default
+  dispatcher. Instead, your DoCalcDiscreteVariableUpdates() will be assumed to
+  return EventStatus::Succeeded() regardless of what happened.
 
   @param[in] context The "before" state.
   @param[in] events All the discrete update events that need handling.
@@ -1887,6 +1896,11 @@ class LeafSystem : public System<T> {
   implementations may assume that the @p context is valid; that @p state
   is non-null, and that the referenced object has the same constituent
   structure as the state in @p context.
+
+  @note There is no provision for returning EventStatus from
+  DoCalcUnrestrictedUpdate() as there is if you use the default dispatcher.
+  Instead, your DoCalcUnrestrictedUpdate() will be assumed to return
+  EventStatus::Succeeded() regardless of what happened.
 
   @param[in]     context The "before" state that is to be used to calculate
                          the returned state update.
@@ -1924,7 +1938,7 @@ class LeafSystem : public System<T> {
   // Assumes @param events is an instance of LeafEventCollection, throws
   // std::bad_cast otherwise.
   // Assumes @param events is not empty. Aborts otherwise.
-  void DispatchPublishHandler(
+  [[nodiscard]] EventStatus DispatchPublishHandler(
       const Context<T>& context,
       const EventCollection<PublishEvent<T>>& events) const final;
 
@@ -1932,7 +1946,7 @@ class LeafSystem : public System<T> {
   // Assumes @p events is an instance of LeafEventCollection, throws
   // std::bad_cast otherwise.
   // Assumes @p events is not empty. Aborts otherwise.
-  void DispatchDiscreteVariableUpdateHandler(
+  [[nodiscard]] EventStatus DispatchDiscreteVariableUpdateHandler(
       const Context<T>& context,
       const EventCollection<DiscreteUpdateEvent<T>>& events,
       DiscreteValues<T>* discrete_state) const final;
@@ -1948,7 +1962,7 @@ class LeafSystem : public System<T> {
   // Assumes @p events is an instance of LeafEventCollection, throws
   // std::bad_cast otherwise.
   // Assumes @p events is not empty. Aborts otherwise.
-  void DispatchUnrestrictedUpdateHandler(
+  [[nodiscard]] EventStatus DispatchUnrestrictedUpdateHandler(
       const Context<T>& context,
       const EventCollection<UnrestrictedUpdateEvent<T>>& events,
       State<T>* state) const final;

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -255,8 +255,9 @@ class System : public SystemBase {
   so that a step begins exactly at the next publication time. In the latter
   case the change in step size may affect the numerical result somewhat
   since a smaller integrator step produces a more accurate solution. */
-  void Publish(const Context<T>& context,
-               const EventCollection<PublishEvent<T>>& events) const;
+  [[nodiscard]] EventStatus Publish(
+      const Context<T>& context,
+      const EventCollection<PublishEvent<T>>& events) const;
 
   /** (Advanced) Manually triggers any PublishEvent that has trigger
   type kForced. Invokes the publish event dispatcher on this %System with the
@@ -273,6 +274,9 @@ class System : public SystemBase {
   The Simulator can be configured to call this in Simulator::Initialize() and at
   the start of each continuous integration step. See the Simulator API for more
   details.
+
+  @throws std::exception if it invokes an event handler that returns status
+                         indicating failure.
 
   @see Publish(), CalcForcedDiscreteVariableUpdate(),
        CalcForcedUnrestrictedUpdate() */
@@ -586,7 +590,7 @@ class System : public SystemBase {
   variables `xd(n)` in @p context and outputs the results to @p
   discrete_state. See documentation for
   DispatchDiscreteVariableUpdateHandler() for more details. */
-  void CalcDiscreteVariableUpdate(
+  [[nodiscard]] EventStatus CalcDiscreteVariableUpdate(
       const Context<T>& context,
       const EventCollection<DiscreteUpdateEvent<T>>& events,
       DiscreteValues<T>* discrete_state) const;
@@ -625,6 +629,9 @@ class System : public SystemBase {
   associated handler. By default that will do nothing when triggered, but that
   behavior can be changed by overriding the dispatcher (not recommended).
 
+  @throws std::exception if it invokes an event handler that returns status
+                         indicating failure.
+
   @see CalcDiscreteVariableUpdate(), CalcForcedUnrestrictedUpdate() */
   void CalcForcedDiscreteVariableUpdate(
       const Context<T>& context, DiscreteValues<T>* discrete_state) const;
@@ -638,7 +645,7 @@ class System : public SystemBase {
 
   @throws std::exception if the dimensionality of the state variables
           changes in the callback. */
-  void CalcUnrestrictedUpdate(
+  [[nodiscard]] EventStatus CalcUnrestrictedUpdate(
       const Context<T>& context,
       const EventCollection<UnrestrictedUpdateEvent<T>>& events,
       State<T>* state) const;
@@ -675,6 +682,9 @@ class System : public SystemBase {
   @note There will always be at least one force-triggered event, though with no
   associated handler. By default that will do nothing when triggered, but that
   behavior can be changed by overriding the dispatcher (not recommended).
+
+  @throws std::exception if it invokes an event handler that returns status
+                         indicating failure.
 
   @see CalcUnrestrictedUpdate() */
   void CalcForcedUnrestrictedUpdate(const Context<T>& context,
@@ -740,7 +750,11 @@ class System : public SystemBase {
 
   Note that this is not fully equivalent to Simulator::Initialize() because
   _only_ initialization events are handled here, while Simulator::Initialize()
-  also processes other events associated with time zero. */
+  also processes other events associated with time zero. Also, "reached
+  termination" returns are ignored here.
+
+  @throws std::exception if it invokes an event handler that returns status
+                         indicating failure. */
   void ExecuteInitializationEvents(Context<T>* context) const;
 
   /** Determines whether there exists a unique periodic timing (offset and
@@ -813,6 +827,9 @@ class System : public SystemBase {
 
   @throws std::exception if there is not exactly one periodic timing in this
   %System (which may be a Diagram) that triggers discrete update events.
+
+  @throws std::exception if it invokes an event handler that returns status
+  indicating failure.
 
   @par Implementation
   If recalculation is needed, copies the current discrete state values into
@@ -1455,6 +1472,19 @@ class System : public SystemBase {
 
   // Don't promote output_port_ticket() since it is for internal use only.
 
+#ifndef DRAKE_DOXYGEN_CXX
+  // For unfortunate historical reasons the Drake Simulator needs access to
+  // forced publish events to implement its optional publish_every_time_step
+  // feature. Now we have PerStep events that serve the same purpose.
+  // Move this to protected with the other forced events when the Simulator
+  // feature is removed.
+  const EventCollection<PublishEvent<T>>&
+  get_forced_publish_events() const {
+    DRAKE_DEMAND(forced_publish_events_ != nullptr);
+    return *forced_publish_events_;
+  }
+#endif
+
  protected:
   // Promote these frequently-used methods so users (and tutorial examples)
   // don't need "this->" everywhere when in templated derived classes.
@@ -1488,14 +1518,17 @@ class System : public SystemBase {
       std::vector<const WitnessFunction<T>*>*) const;
 
   //----------------------------------------------------------------------------
-  /** @name                 Event handler dispatch mechanism
-  For a LeafSystem (or user implemented equivalent classes), these functions
-  need to call the appropriate LeafSystem::DoX event handler. E.g.
-  LeafSystem::DispatchPublishHandler() calls LeafSystem::DoPublish(). User
-  supplied custom event callbacks embedded in each individual event need to
-  be further dispatched in the LeafSystem::DoX handlers if desired. For a
-  LeafSystem, the pseudo code of the complete default publish event handler
-  dispatching is roughly:
+  /** @name  (Internal use only) Event handler dispatch mechanism
+  The pure virtuals declared here are intended to be implemented only by
+  Drake's LeafSystem and Diagram (plus a few unit tests) and those
+  implementations must be `final`.
+
+  For a LeafSystem, these functions need to call the appropriate LeafSystem::DoX
+  event dispatcher. E.g. LeafSystem::DispatchPublishHandler() calls
+  LeafSystem::DoPublish(). User supplied custom event callbacks embedded in each
+  individual event need to be invoked in the LeafSystem::DoX handlers if
+  desired. For a LeafSystem, the pseudo code of the complete default publish
+  event handler dispatching is roughly:
   <pre>
     leaf_sys.Publish(context, event_collection)
     -> leaf_sys.DispatchPublishHandler(context, event_collection)
@@ -1505,46 +1538,57 @@ class System : public SystemBase {
                  event.handler(context)
   </pre>
   Discrete update events and unrestricted update events are dispatched
-  similarly for a LeafSystem.
+  similarly for a LeafSystem. EventStatus is propagated upwards from the
+  individual event handlers with the first worst retained.
 
-  For a Diagram (or user implemented equivalent classes), these functions
-  must iterate through all subsystems, extract their corresponding
-  subcontext and subevent collections from @p context and @p events,
-  and pass those to the subsystems' public non-virtual event handlers if
-  the subevent collection is nonempty (e.g. System::Publish() for publish
-  events).
+  For a Diagram, these functions must iterate through all subsystems, extract
+  their corresponding subcontext and subevent collections from `context` and
+  `events`, and pass those to the subsystems' public non-virtual event
+  dispatchers if the subevent collection is nonempty (e.g. System::Publish()
+  for publish events).
 
   All of these functions are only called from their corresponding public
-  non-virtual event dispatchers, where @p context is error checked. The
-  derived implementations can assume that @p context is valid. See, e.g.,
+  non-virtual event dispatchers, where `context` is error checked. The
+  derived implementations can assume that `context` is valid. See, e.g.,
   LeafSystem::DispatchPublishHandler() and Diagram::DispatchPublishHandler()
   for more details. */
   //@{
 
-  /** This function dispatches all publish events to the appropriate
-  handlers. */
-  virtual void DispatchPublishHandler(
+  /** (Internal use only) This function dispatches all publish events to the
+  appropriate handlers. Only LeafSystem and Diagram (and some unit test code)
+  provide implementations and those must be `final`. */
+  [[nodiscard]] virtual EventStatus DispatchPublishHandler(
       const Context<T>& context,
       const EventCollection<PublishEvent<T>>& events) const = 0;
 
-  /** This function dispatches all discrete update events to the appropriate
-  handlers. @p discrete_state cannot be null. */
-  virtual void DispatchDiscreteVariableUpdateHandler(
+  /** (Internal use only) This function dispatches all discrete update events to
+  the appropriate handlers. @p discrete_state cannot be null. Only LeafSystem
+  and Diagram (and some unit test code) provide implementations and those
+  must be `final`. */
+  [[nodiscard]] virtual EventStatus DispatchDiscreteVariableUpdateHandler(
       const Context<T>& context,
       const EventCollection<DiscreteUpdateEvent<T>>& events,
       DiscreteValues<T>* discrete_state) const = 0;
 
+  /** (Internal use only) Updates the given `context` with the results returned
+  from a previous call to DispatchDiscreteVariableUpdateHandler() that handled
+  the given `events`. */
   virtual void DoApplyDiscreteVariableUpdate(
       const EventCollection<DiscreteUpdateEvent<T>>& events,
       DiscreteValues<T>* discrete_state, Context<T>* context) const = 0;
 
-  /** This function dispatches all unrestricted update events to the appropriate
-  handlers. @p state cannot be null. */
-  virtual void DispatchUnrestrictedUpdateHandler(
+  /** (Internal use only) This function dispatches all unrestricted update
+  events to the appropriate handlers. @p state cannot be null. Only LeafSystem
+  and Diagram (and some unit test code) provide implementations and those must
+  be `final`. */
+  [[nodiscard]] virtual EventStatus DispatchUnrestrictedUpdateHandler(
       const Context<T>& context,
       const EventCollection<UnrestrictedUpdateEvent<T>>& events,
       State<T>* state) const = 0;
 
+  /** (Internal use only) Updates the given `context` with the results returned
+  from a previous call to DispatchUnrestrictedUpdateHandler() that handled
+  the given `events`. */
   virtual void DoApplyUnrestrictedUpdate(
       const EventCollection<UnrestrictedUpdateEvent<T>>& events,
       State<T>* state, Context<T>* context) const = 0;
@@ -1673,6 +1717,11 @@ class System : public SystemBase {
   virtual std::map<PeriodicEventData, std::vector<const Event<T>*>,
                    PeriodicEventDataComparator>
   DoMapPeriodicEventsByTiming(const Context<T>& context) const = 0;
+
+  // TODO(sherm1) Move these three functions adjacent to the event
+  //  dispatching functions and note that they are to be implemented only
+  //  in Diagram and LeafSystem with `final` implementations. Make corresponding
+  //  changes in Diagram and LeafSystem.
 
   /** Implement this method to return any periodic events. @p events is cleared
   in the public non-virtual GetPeriodicEvents(). You may assume that
@@ -1843,12 +1892,6 @@ class System : public SystemBase {
     return *forced_unrestricted_update_events_;
   }
 
-  const EventCollection<PublishEvent<T>>&
-  get_forced_publish_events() const {
-    DRAKE_DEMAND(forced_publish_events_ != nullptr);
-    return *forced_publish_events_;
-  }
-
   const EventCollection<DiscreteUpdateEvent<T>>&
   get_forced_discrete_update_events() const {
     DRAKE_DEMAND(forced_discrete_update_events_ != nullptr);
@@ -1964,7 +2007,7 @@ class System : public SystemBase {
       const std::vector<ExternalSystemConstraint>& constraints);
 
   // This is the computation function for EvalUniquePeriodicDiscreteUpdate()'s
-  // cache entry.
+  // cache entry. Throws if an event handler fails.
   void CalcUniquePeriodicDiscreteUpdate(
       const Context<T>& context, DiscreteValues<T>* updated) const;
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -30,6 +30,7 @@ using Eigen::Vector3d;
 using Eigen::Vector4d;
 using Eigen::VectorXd;
 using drake::systems::analysis_test::StatelessSystem;
+using testing::ElementsAreArray;
 
 namespace drake {
 namespace systems {
@@ -2075,8 +2076,9 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
 
   // Fast forward to 9.0 sec and do the update.
   context_->SetTime(9.0);
-  diagram_.CalcDiscreteVariableUpdate(
+  EventStatus status = diagram_.CalcDiscreteVariableUpdate(
       *context_, events->get_discrete_update_events(), updates.get());
+  EXPECT_TRUE(status.succeeded());
 
   // Note that non-participating hold1's state should not have been
   // copied (if it had been it would be 1001.0).
@@ -2100,8 +2102,9 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
 
   // Fast forward to 12.0 sec and do the update again.
   context_->SetTime(12.0);
-  diagram_.CalcDiscreteVariableUpdate(
+  status = diagram_.CalcDiscreteVariableUpdate(
       *context_, events->get_discrete_update_events(), updates.get());
+  EXPECT_TRUE(status.succeeded());
   EXPECT_EQ(17.0, updates1[0]);
   EXPECT_EQ(23.0, updates2[0]);
 }
@@ -2145,8 +2148,9 @@ TEST_F(DiscreteStateTest, DiscreteUpdateNotificationsAreLocalized) {
 
   // Fast forward to 2.0 sec and collect the update.
   context_->SetTime(2.0);
-  diagram_.CalcDiscreteVariableUpdate(
+  const EventStatus status = diagram_.CalcDiscreteVariableUpdate(
       *context_, discrete_events, updates.get());
+  EXPECT_TRUE(status.succeeded());
 
   // Of course nothing should have been notified since nothing's changed yet.
   EXPECT_EQ(num_notifications(ctx1), notifications_1);
@@ -2311,8 +2315,9 @@ GTEST_TEST(DiscreteStateDiagramTest, CalcDiscreteVariableUpdate) {
   // Fast forward to the event time, and record it for the test below.
   double time = 2.0;
   context->SetTime(time);
-  diagram.CalcDiscreteVariableUpdate(
+  EventStatus status = diagram.CalcDiscreteVariableUpdate(
       *context, events->get_discrete_update_events(), x_buf.get());
+  EXPECT_TRUE(status.succeeded());
 
   // The non-participating sys2 state shouldn't have been copied (if it had
   // it would now be 2). sys1's state should have been copied, replacing the
@@ -2340,8 +2345,9 @@ GTEST_TEST(DiscreteStateDiagramTest, CalcDiscreteVariableUpdate) {
   // Fast forward to the new event time, and record it for the tests below.
   time = 6.0;
   context->SetTime(time);
-  diagram.CalcDiscreteVariableUpdate(
+  status = diagram.CalcDiscreteVariableUpdate(
       *context, events->get_discrete_update_events(), x_buf.get());
+  EXPECT_TRUE(status.succeeded());
   // Both sys1 and sys2's discrete data should be updated.
   diagram.ApplyDiscreteVariableUpdate(events->get_discrete_update_events(),
                                       x_buf.get(), context.get());
@@ -2423,7 +2429,10 @@ TEST_F(DiscreteStateTest, Publish) {
   // Fast forward to 19.0 sec and do the publish.
   EXPECT_EQ(false, diagram_.publisher()->published());
   context_->SetTime(19.0);
-  diagram_.Publish(*context_, events->get_publish_events());
+  const EventStatus status =
+      diagram_.Publish(*context_, events->get_publish_events());
+  EXPECT_TRUE(status.succeeded());
+
   // Check that publication occurred.
   EXPECT_EQ(true, diagram_.publisher()->published());
 }
@@ -2573,8 +2582,9 @@ TEST_F(AbstractStateDiagramTest, CalcUnrestrictedUpdate) {
 
   double time = 2.0;
   context_->SetTime(time);
-  diagram_.CalcUnrestrictedUpdate(
+  EventStatus status = diagram_.CalcUnrestrictedUpdate(
       *context_, events->get_unrestricted_update_events(), x_buf.get());
+  EXPECT_TRUE(status.succeeded());
 
   // The non-participating sys2 state shouldn't have been copied (if it had
   // it would now be kSys2Id). sys1's state should have been copied, replacing
@@ -2606,8 +2616,9 @@ TEST_F(AbstractStateDiagramTest, CalcUnrestrictedUpdate) {
 
   time = 6.0;
   context_->SetTime(time);
-  diagram_.CalcUnrestrictedUpdate(
+  status = diagram_.CalcUnrestrictedUpdate(
       *context_, events->get_unrestricted_update_events(), x_buf.get());
+  EXPECT_TRUE(status.succeeded());
   // Both sys1 and sys2's abstract data should be updated.
   diagram_.ApplyUnrestrictedUpdate(events->get_unrestricted_update_events(),
                                    x_buf.get(), context_.get());
@@ -2661,8 +2672,9 @@ TEST_F(AbstractStateDiagramTest, UnrestrictedUpdateNotificationsAreLocalized) {
 
   // Fast forward to 2.0 sec and collect the update.
   context_->SetTime(next_time);
-  diagram_.CalcUnrestrictedUpdate(
+  const EventStatus status = diagram_.CalcUnrestrictedUpdate(
       *context_, unrestricted_events, updates.get());
+  EXPECT_TRUE(status.succeeded());
 
   // Of course nothing should have been notified since nothing's changed yet.
   EXPECT_EQ(num_notifications(ctx1), notifications_1);
@@ -3239,9 +3251,9 @@ class PerStepActionTestSystem : public LeafSystem<double> {
 // trigger doesn't matter.
 GTEST_TEST(DiagramEventEvaluation, Propagation) {
   std::unique_ptr<Diagram<double>> sub_diagram;
-  PerStepActionTestSystem* sys0;
-  PerStepActionTestSystem* sys1;
-  PerStepActionTestSystem* sys2;
+  PerStepActionTestSystem* sys0{};
+  PerStepActionTestSystem* sys1{};
+  PerStepActionTestSystem* sys2{};
 
   // Sub diagram. Has sys0, and sys1.
   // sys0 does not have any per step actions.
@@ -3279,18 +3291,20 @@ GTEST_TEST(DiagramEventEvaluation, Propagation) {
   ASSERT_TRUE(events->HasEvents());
 
   // Does unrestricted update first.
-  diagram->CalcUnrestrictedUpdate(
+  EventStatus status = diagram->CalcUnrestrictedUpdate(
       *context, events->get_unrestricted_update_events(), tmp_state.get());
+  EXPECT_TRUE(status.succeeded());
   context->get_mutable_state().SetFrom(*tmp_state);
 
   // Does discrete updates second.
-  diagram->CalcDiscreteVariableUpdate(*context,
-                                      events->get_discrete_update_events(),
-                                      tmp_discrete_state.get());
+  status = diagram->CalcDiscreteVariableUpdate(
+      *context, events->get_discrete_update_events(), tmp_discrete_state.get());
+  EXPECT_TRUE(status.succeeded());
   context->get_mutable_discrete_state().SetFrom(*tmp_discrete_state);
 
   // Publishes last.
-  diagram->Publish(*context, events->get_publish_events());
+  status = diagram->Publish(*context, events->get_publish_events());
+  EXPECT_TRUE(status.succeeded());
 
   // Only sys2 published once.
   EXPECT_EQ(sys0->publish_count(), 0);
@@ -3314,6 +3328,252 @@ GTEST_TEST(DiagramEventEvaluation, Propagation) {
   EXPECT_EQ(sys2_context.get_discrete_state(0)[0], 0);
   EXPECT_EQ(sys2_context.get_abstract_state<std::string>(0), "wow0");
   EXPECT_EQ(sys2->publish_count(), 1);
+}
+
+// A System that has one of each kind of event, with independently settable
+// return statuses. We'll use this to test whether Diagrams properly
+// implement our policy for handling error returns for simultaneous events.
+class EventStatusTestSystem : public LeafSystem<double> {
+ public:
+  EventStatusTestSystem() {
+    DeclareForcedUnrestrictedUpdateEvent(
+        &EventStatusTestSystem::UnrestrictedHandler);
+    DeclareForcedDiscreteUpdateEvent(&EventStatusTestSystem::DiscreteHandler);
+    DeclareForcedPublishEvent(&EventStatusTestSystem::PublishHandler);
+  }
+
+  void set_unrestricted_severity(EventStatus::Severity severity) {
+    unrestricted_severity_ = severity;
+  }
+  void set_discrete_severity(EventStatus::Severity severity) {
+    discrete_severity_ = severity;
+  }
+  void set_publish_severity(EventStatus::Severity severity) {
+    publish_severity_ = severity;
+  }
+
+  // Returns the list of events handled by all EventStatusTestSystem instances,
+  // and clears the list back to empty.
+  static std::vector<std::string> take_static_events() {
+    std::vector<std::string> result = events_singleton();
+    events_singleton().clear();
+    return result;
+  }
+
+ private:
+  static std::vector<std::string>& events_singleton() {
+    static never_destroyed<std::vector<std::string>> global(
+        std::vector<std::string>{});
+    return global.access();
+  }
+
+  EventStatus MakeStatus(std::string id, EventStatus::Severity severity) const {
+    events_singleton().push_back(fmt::format("{} {}", this->get_name(), id));
+    switch (severity) {
+      case EventStatus::kDidNothing:
+        return EventStatus::DidNothing();
+      case EventStatus::kSucceeded:
+        return EventStatus::Succeeded();
+      case EventStatus::kReachedTermination:
+        return EventStatus::ReachedTermination(
+            this, fmt::format("{} terminated", id));
+      case EventStatus::kFailed:
+        return EventStatus::Failed(this, fmt::format("{} failed", id));
+    }
+    DRAKE_UNREACHABLE();
+  }
+
+  EventStatus UnrestrictedHandler(const Context<double>&,
+                                  State<double>*) const {
+    return MakeStatus("unrestricted", unrestricted_severity_);
+  }
+  EventStatus DiscreteHandler(const Context<double>&,
+                              DiscreteValues<double>*) const {
+    return MakeStatus("discrete", discrete_severity_);
+  }
+  EventStatus PublishHandler(const Context<double>&) const {
+    return MakeStatus("publish", publish_severity_);
+  }
+
+  // The corresponding handlers return whatever status is set here.
+  EventStatus::Severity unrestricted_severity_{EventStatus::kSucceeded};
+  EventStatus::Severity discrete_severity_{EventStatus::kSucceeded};
+  EventStatus::Severity publish_severity_{EventStatus::kSucceeded};
+};
+
+// Policy to verify:
+//   1 events are handled in the order the subsystems were added
+//   2 if all events succeed, all get executed and return succeeded
+// 3ab if all events do nothing (a), all get executed and we return did_nothing;
+//     a mix of succeeded & did nothing (b) returns succeeded
+// 4ab if an unrestricted (a) or discrete (b) update fails, we fail immediately
+//     and return a message attributing the error to the right subsystem
+//   5 if a publish event fails, we continue to handle remaining publish events
+//     and then finally report the correct message for the first failure
+// 6ab a reached_termination status doesn't prevent execution but reports
+//     the first detection (a), but is superseded by a later failure (b)
+GTEST_TEST(DiagramEventEvaluation, EventStatusHandling) {
+  std::unique_ptr<Diagram<double>> sub_diagram0;
+  std::unique_ptr<Diagram<double>> sub_diagram1;
+  EventStatusTestSystem* sys[5] = {};
+
+  {  // Sub diagram 0 has sys0 & sys1.
+    DiagramBuilder<double> builder;
+    sys[0] = builder.AddSystem<EventStatusTestSystem>();
+    sys[0]->set_name("sys0");
+    sys[1] = builder.AddSystem<EventStatusTestSystem>();
+    sys[1]->set_name("sys1");
+    sub_diagram0 = builder.Build();
+    sub_diagram0->set_name("sub_diagram0");
+  }
+
+  {  // Sub diagram 1 has sys3 & sys4.
+    DiagramBuilder<double> builder;
+    sys[3] = builder.AddSystem<EventStatusTestSystem>();
+    sys[3]->set_name("sys3");
+    sys[4] = builder.AddSystem<EventStatusTestSystem>();
+    sys[4]->set_name("sys4");
+    sub_diagram1 = builder.Build();
+    sub_diagram1->set_name("sub_diagram1");
+  }
+
+  // Now build the diagram consisting of the two subdiagrams separated by
+  // one more leaf system:
+  //                                diagram
+  //                   sub_diagram0  sys2  sub_diagram1
+  //                    sys0  sys1          sys3  sys4
+  //
+  DiagramBuilder<double> builder;
+  builder.AddSystem(std::move(sub_diagram0));
+  sys[2] = builder.AddSystem<EventStatusTestSystem>();
+  sys[2]->set_name("sys2");
+  builder.AddSystem(std::move(sub_diagram1));
+  auto diagram = builder.Build();
+  diagram->set_name("diagram");
+
+  // We aren't looking for state updates; we just need a place to put the
+  // (ignored) outputs. We just need to know who got called when.
+  auto context = diagram->CreateDefaultContext();
+  State<double>& state = context->get_mutable_state();
+  DiscreteValues<double>& discrete_state = state.get_mutable_discrete_state();
+
+  auto calc_unrestricted_update = [&context, &state](const auto& dut) {
+    return dut->CalcUnrestrictedUpdate(
+        *context, *dut->AllocateForcedUnrestrictedUpdateEventCollection(),
+        &state);
+  };
+  auto calc_discrete_variable_update = [&context,
+                                        &discrete_state](const auto& dut) {
+    return dut->CalcDiscreteVariableUpdate(
+        *context, *dut->AllocateForcedDiscreteUpdateEventCollection(),
+        &discrete_state);
+  };
+  auto publish = [&context](const auto& dut) {
+    return dut->Publish(*context, *dut->AllocateForcedPublishEventCollection());
+  };
+
+  // The event logs should have these strings in this order, when everything
+  // succeeds. When failure cuts execution short, we still expect to see a
+  // prefix of the full arrays.
+  const std::string all_unrestricted[] = {
+      "sys0 unrestricted", "sys1 unrestricted", "sys2 unrestricted",
+      "sys3 unrestricted", "sys4 unrestricted"};
+  const std::string all_discrete[] = {
+      "sys0 discrete", "sys1 discrete", "sys2 discrete",
+      "sys3 discrete", "sys4 discrete"};
+  const std::string all_publish[] = {
+      "sys0 publish", "sys1 publish", "sys2 publish",
+      "sys3 publish", "sys4 publish"};
+
+  // Sets all events in all systems to the same severity.
+  auto reset_severity = [sys](EventStatus::Severity severity) {
+    for (EventStatusTestSystem* item : sys) {
+      item->set_unrestricted_severity(severity);
+      item->set_discrete_severity(severity);
+      item->set_publish_severity(severity);
+    }
+  };
+  auto take_static_events = &EventStatusTestSystem::take_static_events;
+
+  // Policy 1 & 2: Every handler returns success and should be invoked in order.
+  EventStatus unrestricted_status = calc_unrestricted_update(diagram);
+  EXPECT_TRUE(unrestricted_status.succeeded());
+  EXPECT_THAT(take_static_events(), ElementsAreArray(all_unrestricted));
+  EventStatus discrete_status = calc_discrete_variable_update(diagram);
+  EXPECT_TRUE(discrete_status.succeeded());
+  EXPECT_THAT(take_static_events(), ElementsAreArray(all_discrete));
+  EventStatus publish_status = publish(diagram);
+  EXPECT_TRUE(publish_status.succeeded());
+  EXPECT_THAT(take_static_events(), ElementsAreArray(all_publish));
+
+  // Policy 3ab: Unrestricted & publish handlers all return did_nothing, so
+  // their final status should be did_nothing. One of the discrete handlers
+  // succeeds so its final status should be succeeded. Order unchanged from
+  // above.
+  reset_severity(EventStatus::kDidNothing);
+  sys[3]->set_discrete_severity(EventStatus::kSucceeded);
+  unrestricted_status = calc_unrestricted_update(diagram);
+  EXPECT_TRUE(unrestricted_status.did_nothing());
+  EXPECT_THAT(take_static_events(), ElementsAreArray(all_unrestricted));
+  discrete_status = calc_discrete_variable_update(diagram);
+  EXPECT_TRUE(discrete_status.succeeded());
+  EXPECT_THAT(take_static_events(), ElementsAreArray(all_discrete));
+  publish_status = publish(diagram);
+  EXPECT_TRUE(publish_status.did_nothing());
+  EXPECT_THAT(take_static_events(), ElementsAreArray(all_publish));
+
+  // Policy 4a: sys[1] unrestricted fails. Nothing after should execute.
+  reset_severity(EventStatus::kSucceeded);
+  sys[1]->set_unrestricted_severity(EventStatus::kFailed);
+  unrestricted_status = calc_unrestricted_update(diagram);
+  EXPECT_TRUE(unrestricted_status.failed());
+  EXPECT_EQ(unrestricted_status.system(), sys[1]);
+  EXPECT_EQ(unrestricted_status.message(), "unrestricted failed");
+  EXPECT_THAT(take_static_events(),
+              ElementsAreArray(all_unrestricted, /* count = */ 2));
+
+  // Policy 4b: sys[2] discrete fails. Nothing after should execute.
+  reset_severity(EventStatus::kSucceeded);
+  sys[2]->set_discrete_severity(EventStatus::kFailed);
+  discrete_status = calc_discrete_variable_update(diagram);
+  EXPECT_TRUE(discrete_status.failed());
+  EXPECT_EQ(discrete_status.system(), sys[2]);
+  EXPECT_EQ(discrete_status.message(), "discrete failed");
+  EXPECT_THAT(take_static_events(),
+              ElementsAreArray(all_discrete, /* count = */ 3));
+
+  // Policy 5: sys[0] publish fails. All other publishes should execute
+  // but then the returned status is the sys[0] failure.
+  reset_severity(EventStatus::kSucceeded);
+  sys[0]->set_publish_severity(EventStatus::kFailed);
+  publish_status = publish(diagram);
+  EXPECT_TRUE(publish_status.failed());
+  EXPECT_EQ(publish_status.system(), sys[0]);
+  EXPECT_EQ(publish_status.message(), "publish failed");
+  EXPECT_THAT(take_static_events(), ElementsAreArray(all_publish));
+
+  // Policy 6a: sys[1] unrestricted and sys[3] unrestricted report termination.
+  // Everything executes and the sys[1] termination return is reported.
+  reset_severity(EventStatus::kSucceeded);
+  sys[1]->set_unrestricted_severity(EventStatus::kReachedTermination);
+  sys[3]->set_unrestricted_severity(EventStatus::kReachedTermination);
+  unrestricted_status = calc_unrestricted_update(diagram);
+  EXPECT_TRUE(unrestricted_status.reached_termination());
+  EXPECT_EQ(unrestricted_status.system(), sys[1]);
+  EXPECT_EQ(unrestricted_status.message(), "unrestricted terminated");
+  EXPECT_THAT(take_static_events(), ElementsAreArray(all_unrestricted));
+
+  // Policy 6b: sys[1] discrete reports termination, sys[3] fails.
+  // sys[4] is not executed, and the sys[3] failure is reported.
+  reset_severity(EventStatus::kSucceeded);
+  sys[1]->set_discrete_severity(EventStatus::kReachedTermination);
+  sys[3]->set_discrete_severity(EventStatus::kFailed);
+  discrete_status = calc_discrete_variable_update(diagram);
+  EXPECT_TRUE(discrete_status.failed());
+  EXPECT_EQ(discrete_status.system(), sys[3]);
+  EXPECT_EQ(discrete_status.message(), "discrete failed");
+  EXPECT_THAT(take_static_events(),
+              ElementsAreArray(all_discrete, /* count = */ 4));
 }
 
 class MyEventTestSystem : public LeafSystem<double> {
@@ -3369,7 +3629,9 @@ GTEST_TEST(MyEventTest, MyEventTestLeaf) {
     dut.GetPerStepEvents(*context, per_step_events.get());
     events->AddToEnd(*periodic_events);
     events->AddToEnd(*per_step_events);
-    dut.Publish(*context, events->get_publish_events());
+    const EventStatus status =
+        dut.Publish(*context, events->get_publish_events());
+    EXPECT_TRUE(status.succeeded());
 
     EXPECT_EQ(dut.get_periodic_count(), period > 0 ? 1 : 0);
     EXPECT_EQ(dut.get_per_step_count(), period > 0 ? 0 : 1);
@@ -3417,7 +3679,8 @@ GTEST_TEST(MyEventTest, MyEventTestDiagram) {
 
   // FYI time not actually needed here; events to handle already selected.
   context->SetTime(time);
-  dut->Publish(*context, events->get_publish_events());
+  EventStatus status = dut->Publish(*context, events->get_publish_events());
+  EXPECT_TRUE(status.succeeded());
 
   // Sys0's period is larger, so it doesn't get evaluated.
   EXPECT_EQ(sys[0]->get_periodic_count(), 0);
@@ -3443,7 +3706,8 @@ GTEST_TEST(MyEventTest, MyEventTestDiagram) {
   // it doesn't contain the ones leftover from the CalcNextUpdateTime() call.
   // (If it doesn't get cleared some of the counts will be incremented twice.)
   dut->GetPeriodicEvents(*context, periodic_events.get());
-  dut->Publish(*context, periodic_events->get_publish_events());
+  status = dut->Publish(*context, periodic_events->get_publish_events());
+  EXPECT_TRUE(status.succeeded());
 
   EXPECT_EQ(sys[0]->get_periodic_count(), 1);
   EXPECT_EQ(sys[0]->get_per_step_count(), 0);

--- a/systems/framework/test/event_deprecated_test.cc
+++ b/systems/framework/test/event_deprecated_test.cc
@@ -23,7 +23,7 @@ TEST_F(EventDeprecatedTest, PublishCallback) {
       };
   PublishEvent<double> event(callback);
   EventStatus result = event.handle(system_, context_);
-  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(result.succeeded());
   EXPECT_TRUE(called);
 }
 
@@ -36,7 +36,7 @@ TEST_F(EventDeprecatedTest, PublishSystemCallback) {
       };
   PublishEvent<double> event(callback);
   EventStatus result = event.handle(system_, context_);
-  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(result.succeeded());
   EXPECT_TRUE(called);
 }
 
@@ -50,7 +50,7 @@ TEST_F(EventDeprecatedTest, DiscreteUpdateCallback) {
   DiscreteUpdateEvent<double> event(callback);
   DiscreteValues<double> out;
   EventStatus result = event.handle(system_, context_, &out);
-  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(result.succeeded());
   EXPECT_TRUE(called);
 }
 
@@ -64,7 +64,7 @@ TEST_F(EventDeprecatedTest, DiscreteUpdateSystemCallback) {
   DiscreteUpdateEvent<double> event(callback);
   DiscreteValues<double> out;
   EventStatus result = event.handle(system_, context_, &out);
-  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(result.succeeded());
   EXPECT_TRUE(called);
 }
 
@@ -78,7 +78,7 @@ TEST_F(EventDeprecatedTest, UnrestrictedUpdateCallback) {
   UnrestrictedUpdateEvent<double> event(callback);
   State<double> out;
   EventStatus result = event.handle(system_, context_, &out);
-  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(result.succeeded());
   EXPECT_TRUE(called);
 }
 
@@ -93,7 +93,7 @@ TEST_F(EventDeprecatedTest, UnrestrictedUpdateSystemCallback) {
   UnrestrictedUpdateEvent<double> event(callback);
   State<double> out;
   EventStatus result = event.handle(system_, context_, &out);
-  EXPECT_EQ(result.severity(), EventStatus::Severity::kSucceeded);
+  EXPECT_TRUE(result.succeeded());
   EXPECT_TRUE(called);
 }
 

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -931,6 +931,18 @@ TEST_F(LeafContextTest, PerturbTime) {
   EXPECT_FALSE(context_.get_true_time());
 }
 
+// Check that the hidden mutable "utility flag" in the Context can be set
+// even in a const Context.
+TEST_F(LeafContextTest, UtilityFlag) {
+  auto set_flag = [](const Context<double>& context) {
+    context.set_use_default_implementation(true);
+  };
+
+  EXPECT_FALSE(context_.get_use_default_implementation());
+  set_flag(context_);
+  EXPECT_TRUE(context_.get_use_default_implementation());
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1731,9 +1731,9 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
     event.AddToComposite(&leaf_events);
   }
 
-  // Verify no exception is thrown.
-  DRAKE_EXPECT_NO_THROW(system_.CalcUnrestrictedUpdate(
-      *context, leaf_events.get_unrestricted_update_events(), x.get()));
+  const EventStatus status = system_.CalcUnrestrictedUpdate(
+      *context, leaf_events.get_unrestricted_update_events(), x.get());
+  EXPECT_TRUE(status.succeeded());
 
   // Change the function to change the continuous state dimension.
   // Call the unrestricted update function again, now verifying that an
@@ -1754,10 +1754,10 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
 
   // Call the unrestricted update function, verifying that an exception
   // is thrown.
-  EXPECT_THROW(
+  DRAKE_EXPECT_THROWS_MESSAGE(
       system_.CalcUnrestrictedUpdate(
           *context, leaf_events.get_unrestricted_update_events(), x.get()),
-      std::logic_error);
+      ".*dimensions cannot be changed.*");
 
   // Restore the continuous state (size).
   x->set_continuous_state(std::make_unique<ContinuousState<double>>(
@@ -1783,10 +1783,10 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
 
   // Call the unrestricted update function again, again verifying that an
   // exception is thrown.
-  EXPECT_THROW(
+  DRAKE_EXPECT_THROWS_MESSAGE(
       system_.CalcUnrestrictedUpdate(
           *context, leaf_events.get_unrestricted_update_events(), x.get()),
-      std::logic_error);
+      ".*dimensions cannot be changed.*");
 
   // Restore the discrete state (size).
   x->set_discrete_state(std::make_unique<DiscreteValues<double>>(
@@ -1808,10 +1808,10 @@ TEST_F(LeafSystemTest, CallbackAndInvalidUpdates) {
 
   // Call the unrestricted update function again, again verifying that an
   // exception is thrown.
-  EXPECT_THROW(
+  DRAKE_EXPECT_THROWS_MESSAGE(
       system_.CalcUnrestrictedUpdate(
           *context, leaf_events.get_unrestricted_update_events(), x.get()),
-      std::logic_error);
+      ".*dimensions cannot be changed.*");
 }
 
 // Tests that the next update time is computed correctly for LeafSystems
@@ -2487,7 +2487,8 @@ class DoPublishOverrideSystem : public LeafSystem<double> {
       const Context<double>& context,
       const std::vector<const PublishEvent<double>*>& events) const override {
     ++do_publish_count_;
-    if (!ignore_events_) LeafSystem<double>::DoPublish(context, events);
+    if (!ignore_events_)
+      LeafSystem<double>::DoPublish(context, events);
   }
 
   // If true, DoPublish ignores events, calls LeafSystem::DoPublish() if false.
@@ -2519,7 +2520,8 @@ GTEST_TEST(DoPublishOverrideTest, ConfirmOverride) {
   system.ForcedPublish(*context);
   EXPECT_EQ(system.do_publish_count(), 1);
   EXPECT_EQ(system.event_handle_count(), 1);
-  system.Publish(*context, events);
+  EventStatus status = system.Publish(*context, events);
+  EXPECT_TRUE(status.succeeded());
   EXPECT_EQ(system.do_publish_count(), 2);
   EXPECT_EQ(system.event_handle_count(), 2);
 
@@ -2531,7 +2533,8 @@ GTEST_TEST(DoPublishOverrideTest, ConfirmOverride) {
   system.ForcedPublish(*context);
   EXPECT_EQ(system.do_publish_count(), 3);
   EXPECT_EQ(system.event_handle_count(), 2);
-  system.Publish(*context, events);
+  status = system.Publish(*context, events);
+  EXPECT_TRUE(status.succeeded());
   EXPECT_EQ(system.do_publish_count(), 4);
   EXPECT_EQ(system.event_handle_count(), 2);
 }
@@ -2895,12 +2898,15 @@ GTEST_TEST(InitializationTest, ManualEventProcessing) {
   EXPECT_EQ(init_events->get_system_id(), context->get_system_id());
   dut.GetInitializationEvents(*context, init_events.get());
 
-  dut.Publish(*context, init_events->get_publish_events());
-  dut.CalcDiscreteVariableUpdate(*context,
+  EventStatus status = dut.Publish(*context, init_events->get_publish_events());
+  EXPECT_TRUE(status.succeeded());
+  status = dut.CalcDiscreteVariableUpdate(*context,
                                  init_events->get_discrete_update_events(),
                                  discrete_updates.get());
-  dut.CalcUnrestrictedUpdate(
+  EXPECT_TRUE(status.succeeded());
+  status = dut.CalcUnrestrictedUpdate(
       *context, init_events->get_unrestricted_update_events(), state.get());
+  EXPECT_TRUE(status.succeeded());
 
   EXPECT_TRUE(dut.get_pub_init());
   EXPECT_TRUE(dut.get_dis_update_init());
@@ -2928,7 +2934,9 @@ GTEST_TEST(InitializationTest, DefaultEventProcessing) {
 // is a set of sugar methods to facilitate that; this class uses them all.
 class EventSugarTestSystem : public LeafSystem<double> {
  public:
-  EventSugarTestSystem() {
+  explicit EventSugarTestSystem(EventStatus::Severity desired_status =
+      EventStatus::kSucceeded)
+      : desired_status_(desired_status) {
     DeclareInitializationPublishEvent(
         &EventSugarTestSystem::MyPublishHandler);
     DeclareInitializationDiscreteUpdateEvent(
@@ -2994,38 +3002,38 @@ class EventSugarTestSystem : public LeafSystem<double> {
  private:
   EventStatus MyPublishHandler(const Context<double>& context) const {
     MySuccessfulPublishHandler(context);
-    return EventStatus::Succeeded();
+    return MakeStatus();
   }
 
   EventStatus MySecondPublishHandler(const Context<double>& context) const {
     ++num_second_publish_handler_publishes_;
-    return EventStatus::Succeeded();
+    return MakeStatus();
   }
 
   EventStatus MyDiscreteUpdateHandler(
       const Context<double>& context,
       DiscreteValues<double>* discrete_state) const {
     MySuccessfulDiscreteUpdateHandler(context, &*discrete_state);
-    return EventStatus::Succeeded();
+    return MakeStatus();
   }
 
   EventStatus MySecondDiscreteUpdateHandler(
       const Context<double>& context,
       DiscreteValues<double>* discrete_state) const {
     ++num_second_discrete_update_;
-    return EventStatus::Succeeded();
+    return MakeStatus();
   }
 
   EventStatus MyUnrestrictedUpdateHandler(const Context<double>& context,
                                           State<double>* state) const {
     MySuccessfulUnrestrictedUpdateHandler(context, &*state);
-    return EventStatus::Succeeded();
+    return MakeStatus();
   }
 
   EventStatus MySecondUnrestrictedUpdateHandler(const Context<double>& context,
                                                 State<double>* state) const {
     ++num_second_unrestricted_update_;
-    return EventStatus::Succeeded();
+    return MakeStatus();
   }
 
   void MySuccessfulPublishHandler(const Context<double>&) const {
@@ -3041,6 +3049,22 @@ class EventSugarTestSystem : public LeafSystem<double> {
                                              State<double>*) const {
     ++num_unrestricted_update_;
   }
+
+  EventStatus MakeStatus() const {
+    switch (desired_status_) {
+      case EventStatus::kDidNothing:
+        return EventStatus::DidNothing();
+      case EventStatus::kSucceeded:
+        return EventStatus::Succeeded();
+      case EventStatus::kReachedTermination:
+        return EventStatus::ReachedTermination(this, "Terminated");
+      case EventStatus::kFailed:
+        return EventStatus::Failed(this, "Something bad happened");
+    }
+    DRAKE_UNREACHABLE();
+  }
+
+  const EventStatus::Severity desired_status_;
 
   mutable int num_publish_{0};
   mutable int num_second_publish_handler_publishes_{0};
@@ -3097,13 +3121,16 @@ GTEST_TEST(EventSugarTest, HandlersGetCalled) {
   dut.GetPeriodicEvents(*context, &*periodic_events);
   all_events->AddToEnd(*periodic_events);
 
-  dut.CalcUnrestrictedUpdate(
+  EventStatus status = dut.CalcUnrestrictedUpdate(
       *context, all_events->get_unrestricted_update_events(), &*state);
+  EXPECT_TRUE(status.succeeded());
   dut.CalcForcedUnrestrictedUpdate(*context, &*state);
-  dut.CalcDiscreteVariableUpdate(
+  status = dut.CalcDiscreteVariableUpdate(
       *context, all_events->get_discrete_update_events(), &*discrete_state);
+  EXPECT_TRUE(status.succeeded());
   dut.CalcForcedDiscreteVariableUpdate(*context, &*discrete_state);
-  dut.Publish(*context, all_events->get_publish_events());
+  status = dut.Publish(*context, all_events->get_publish_events());
+  EXPECT_TRUE(status.succeeded());
   dut.ForcedPublish(*context);
 
   EXPECT_EQ(dut.num_publish(), 5);
@@ -3112,6 +3139,65 @@ GTEST_TEST(EventSugarTest, HandlersGetCalled) {
   EXPECT_EQ(dut.num_second_discrete_update(), 1);
   EXPECT_EQ(dut.num_unrestricted_update(), 5);
   EXPECT_EQ(dut.num_second_unrestricted_update(), 1);
+}
+
+// Verify that user-initiated event APIs throw on handler failure.
+GTEST_TEST(EventSugarTest, ForcedEventsThrowOnFailure) {
+  EventSugarTestSystem dut(EventStatus::kFailed);
+  dut.set_name("dut");
+  auto context = dut.CreateDefaultContext();
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.ForcedPublish(*context),
+      "ForcedPublish.*event handler.*"
+      "EventSugarTestSystem.*dut.*failed.*Something bad happened.*");
+
+  auto discrete_state = dut.AllocateDiscreteVariables();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.CalcForcedDiscreteVariableUpdate(*context, &*discrete_state),
+      "CalcForcedDiscreteVariableUpdate.*event handler.*"
+      "EventSugarTestSystem.*dut.*failed.*Something bad happened.*");
+
+  auto state = context->CloneState();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.CalcForcedUnrestrictedUpdate(*context, &*state),
+      "CalcForcedUnrestrictedUpdate.*event handler.*"
+      "EventSugarTestSystem.*dut.*failed.*Something bad happened.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.ExecuteInitializationEvents(&*context),
+      "ExecuteInitializationEvents.*event handler.*"
+      "EventSugarTestSystem.*dut.*failed.*Something bad happened.*");
+}
+
+// Verify that user-initiated event APIs don't throw for any status less
+// than failure (including "reached termination").
+GTEST_TEST(EventSugarTest, ForcedEventsDontThrowWhenNoFailure) {
+  EventSugarTestSystem successful(EventStatus::kSucceeded);
+  EventSugarTestSystem terminating(EventStatus::kReachedTermination);
+  auto successful_context = successful.CreateDefaultContext();
+  auto terminating_context = terminating.CreateDefaultContext();
+
+  EXPECT_NO_THROW(successful.ForcedPublish(*successful_context));
+  EXPECT_NO_THROW(terminating.ForcedPublish(*terminating_context));
+
+  auto successful_discrete_state = successful.AllocateDiscreteVariables();
+  auto terminating_discrete_state = terminating.AllocateDiscreteVariables();
+  EXPECT_NO_THROW(successful.CalcForcedDiscreteVariableUpdate(
+      *successful_context, &*successful_discrete_state));
+  EXPECT_NO_THROW(terminating.CalcForcedDiscreteVariableUpdate(
+      *terminating_context, &*terminating_discrete_state));
+
+  auto successful_state = successful_context->CloneState();
+  auto terminating_state = terminating_context->CloneState();
+  EXPECT_NO_THROW(successful.CalcForcedUnrestrictedUpdate(*successful_context,
+                                                          &*successful_state));
+  EXPECT_NO_THROW(terminating.CalcForcedUnrestrictedUpdate(
+      *terminating_context, &*terminating_state));
+
+  EXPECT_NO_THROW(successful.ExecuteInitializationEvents(&*successful_context));
+  EXPECT_NO_THROW(
+      terminating.ExecuteInitializationEvents(&*terminating_context));
 }
 
 // A System that does not override the default implicit time derivatives

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -105,10 +105,11 @@ class TestSystemBase : public System<T> {
     ADD_FAILURE() << "A test called a method that was expected to be unused.";
   }
 
-  void DispatchUnrestrictedUpdateHandler(
+  EventStatus DispatchUnrestrictedUpdateHandler(
       const Context<T>&, const EventCollection<UnrestrictedUpdateEvent<T>>&,
       State<T>*) const final {
     ADD_FAILURE() << "A test called a method that was expected to be unused.";
+    return EventStatus::DidNothing();
   }
 
   void DoApplyUnrestrictedUpdate(
@@ -140,17 +141,19 @@ class TestSystemBase : public System<T> {
     ADD_FAILURE() << "A test called a method that was expected to be unused.";
   }
 
-  void DispatchPublishHandler(
+  EventStatus DispatchPublishHandler(
       const Context<T>& context,
       const EventCollection<PublishEvent<T>>& event_info) const override {
     ADD_FAILURE() << "A test called a method that was expected to be unused.";
+    return EventStatus::DidNothing();
   }
 
-  void DispatchDiscreteVariableUpdateHandler(
+  EventStatus DispatchDiscreteVariableUpdateHandler(
       const Context<T>& context,
       const EventCollection<DiscreteUpdateEvent<T>>& event_info,
       DiscreteValues<T>* discrete_state) const override {
     ADD_FAILURE() << "A test called a method that was expected to be unused.";
+    return EventStatus::DidNothing();
   }
 
   std::multimap<int, int> GetDirectFeedthroughs() const override {
@@ -228,17 +231,19 @@ class TestSystem : public TestSystemBase<double> {
   }
 
  protected:
-  void DispatchPublishHandler(
+  EventStatus DispatchPublishHandler(
       const Context<double>& context,
       const EventCollection<PublishEvent<double>>& events) const final {
     const LeafEventCollection<PublishEvent<double>>& leaf_events =
        dynamic_cast<const LeafEventCollection<PublishEvent<double>>&>(events);
     if (leaf_events.HasEvents()) {
       this->MyPublish(context, leaf_events.get_events());
+      return EventStatus::Succeeded();
     }
+    return EventStatus::DidNothing();
   }
 
-  void DispatchDiscreteVariableUpdateHandler(
+  EventStatus DispatchDiscreteVariableUpdateHandler(
       const Context<double>& context,
       const EventCollection<DiscreteUpdateEvent<double>>& events,
       DiscreteValues<double>* discrete_state) const final {
@@ -248,7 +253,9 @@ class TestSystem : public TestSystemBase<double> {
     if (leaf_events.HasEvents()) {
       this->MyCalcDiscreteVariableUpdates(context, leaf_events.get_events(),
           discrete_state);
+      return EventStatus::Succeeded();
     }
+    return EventStatus::DidNothing();
   }
 
   // Sets up an arbitrary mapping from the current time to the next discrete
@@ -362,7 +369,9 @@ TEST_F(SystemTest, DiscretePublish) {
   EXPECT_EQ(events.front()->get_trigger_type(),
             TriggerType::kPeriodic);
 
-  system_.Publish(*context_, event_info->get_publish_events());
+  const EventStatus status =
+      system_.Publish(*context_, event_info->get_publish_events());
+  EXPECT_TRUE(status.succeeded());
   EXPECT_EQ(1, system_.get_publish_count());
 }
 
@@ -376,8 +385,9 @@ TEST_F(SystemTest, DiscreteUpdate) {
 
   std::unique_ptr<DiscreteValues<double>> update =
       system_.AllocateDiscreteVariables();
-  system_.CalcDiscreteVariableUpdate(
+  const EventStatus status = system_.CalcDiscreteVariableUpdate(
       *context_, event_info->get_discrete_update_events(), update.get());
+  EXPECT_TRUE(status.succeeded());
   EXPECT_EQ(1, system_.get_update_count());
 }
 

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -73,7 +73,9 @@ GTEST_TEST(LcmPublisherSystemTest, TestInitializationEvent) {
   // Simulator::Initialize() behavior.
   auto init_events = dut1->AllocateCompositeEventCollection();
   dut1->GetInitializationEvents(*context, &*init_events);
-  dut1->Publish(*context, init_events->get_publish_events());
+  const EventStatus status =
+      dut1->Publish(*context, init_events->get_publish_events());
+  EXPECT_TRUE(status.succeeded());
 
   EXPECT_TRUE(init_was_called);
 

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -25,13 +25,15 @@ void EvalOutputHelper(const LcmSubscriberSystem& sub, Context<double>* context,
   if (event_info->HasEvents()) {
     std::unique_ptr<State<double>> tmp_state = context->CloneState();
     if (event_info->HasDiscreteUpdateEvents()) {
-      sub.CalcDiscreteVariableUpdate(*context,
-                                     event_info->get_discrete_update_events(),
-                                     &tmp_state->get_mutable_discrete_state());
+      const EventStatus status = sub.CalcDiscreteVariableUpdate(
+          *context, event_info->get_discrete_update_events(),
+          &tmp_state->get_mutable_discrete_state());
+      EXPECT_TRUE(status.succeeded());
     } else if (event_info->HasUnrestrictedUpdateEvents()) {
-      sub.CalcUnrestrictedUpdate(*context,
-                                 event_info->get_unrestricted_update_events(),
-                                 tmp_state.get());
+      const EventStatus status = sub.CalcUnrestrictedUpdate(
+          *context, event_info->get_unrestricted_update_events(),
+          tmp_state.get());
+      EXPECT_TRUE(status.succeeded());
     } else {
       DRAKE_DEMAND(false);
     }

--- a/systems/sensors/test/image_writer_test.cc
+++ b/systems/sensors/test/image_writer_test.cc
@@ -227,7 +227,9 @@ class ImageWriterTest : public ::testing::Test {
         port_name, tester.port_count(port.get_index()));
     fs::path expected_file(expected_name);
     EXPECT_FALSE(fs::exists(expected_file));
-    writer.Publish(*context, events->get_publish_events());
+    const EventStatus status =
+        writer.Publish(*context, events->get_publish_events());
+    EXPECT_TRUE(status.succeeded());
     EXPECT_TRUE(fs::exists(expected_file));
     EXPECT_EQ(1, tester.port_count(port.get_index()));
     add_file_for_cleanup(expected_file.string());
@@ -589,7 +591,9 @@ TEST_F(ImageWriterTest, SingleConfiguredPort) {
           port_name, tester.port_count(port.get_index()));
       fs::path expected_file(expected_name);
       EXPECT_FALSE(fs::exists(expected_file));
-      writer.Publish(*context, events->get_publish_events());
+      const EventStatus status =
+          writer.Publish(*context, events->get_publish_events());
+      EXPECT_TRUE(status.succeeded());
       EXPECT_TRUE(fs::exists(expected_file));
       EXPECT_EQ(1, tester.port_count(port.get_index()));
       add_file_for_cleanup(expected_file.string());

--- a/systems/sensors/test/rgbd_sensor_async_test.cc
+++ b/systems/sensors/test/rgbd_sensor_async_test.cc
@@ -406,8 +406,10 @@ TEST_F(RgbdSensorAsyncTest, RenderBackgroundColor) {
       events->get_unrestricted_update_events();
   EXPECT_TRUE(update_events.HasEvents());
   auto next_state_out = simulator.get_context().CloneState();
-  EXPECT_NO_THROW(simulator.get_system().CalcUnrestrictedUpdate(
-      simulator.get_context(), update_events, next_state_out.get()));
+  EXPECT_TRUE(simulator.get_system()
+                  .CalcUnrestrictedUpdate(simulator.get_context(),
+                                          update_events, next_state_out.get())
+                  .succeeded());
 }
 
 }  // namespace


### PR DESCRIPTION
Replaces Draft PR #19980

PR #19989 added `EventStatus` returns to the callbacks stored with Event objects. This PR propagates those upwards through the Drake API and deals with Event status returns in the Simulator. Caveat: code that overrides the default dispatchers (DoPublish(), DoCalcDiscreteVariableUpdates(), DoCalcUnrestrictedUpdate()) will still be assumed to return success since those virtuals have no way to return a status.

This is potentially (but not likely) a breaking change for these reasons:
- The default dispatchers listed above now execute handlers _after_ the overridable dispatchers return, _if_ the override invoked the default implementation. Previously, default dispatch would occur immediately when invoked.
- We now officially disallow user extension of class `System`; the only direct descendants are `LeafSystem` and `Diagram`. Users should derive from those classes rather than directly from `System`. Likely this won't affect anyone.

Handling event status in the Simulator requires obscure policy choices for Initialize() and AdvanceTo() because those handle a sequence of unrestricted, discrete, and publish events any one of which can fail or detect early termination. A rough summary of the implemented policy is:
- any state-updating event handler (i.e., discrete or unrestricted) that fails causes Initialize() or AdvanceTo() to throw immediately. Later we will make throwing optional so that those methods can return a failed status that higher level code can deal with. However, state-updating handler failure will always prevent any further processing in a call to Initialize() or AdvanceTo().
- OTOH, if a publish event handler fails, we will still execute the rest of the publish events prior to throwing the error message produced by the first-failing publish event.
- an event handler that reports termination still allows other simultaneous events to execute. If one of those fails, that failure is reported, otherwise we return "early termination" status from the first handler that reported it. Time will not advance after a termination condition is reported.
- unit tests attempt to capture this policy in systems/analysis/simulator_test.cc.

User-invoked event APIs such as ForcedPublish() and ExecuteInitializationEvents() throw if a failure is encountered.

Resolves #13799
Resolves #13794

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20035)
<!-- Reviewable:end -->
