### PR TITLE
[geometry] Fix a benchmarking doc typo

### DIFF
--- a/geometry/benchmarking/render_benchmark_doxygen.h
+++ b/geometry/benchmarking/render_benchmark_doxygen.h
@@ -118,7 +118,7 @@ namespace render {
  For example:
  ```
  bazel run //geometry/benchmarking:render_experiment -- \
-    --output_dir=trial2 --save_image_path="/tmp" --show_window=true
+    --output_dir=trial2 -- -save_image_path="/tmp" -show_window=true
  ```
 
  <h4>Interpreting the benchmark</h4>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20039)
<!-- Reviewable:end -->
