### PR TITLE
Convert between Hyperellipsoid and AffineBall

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -33,6 +33,7 @@ drake_cc_package_library(
 drake_cc_library(
     name = "convex_set",
     srcs = [
+        "affine_ball.cc",
         "affine_subspace.cc",
         "cartesian_product.cc",
         "convex_set.cc",
@@ -45,6 +46,7 @@ drake_cc_library(
         "vpolytope.cc",
     ],
     hdrs = [
+        "affine_ball.h",
         "affine_subspace.h",
         "cartesian_product.h",
         "convex_set.h",
@@ -216,6 +218,15 @@ drake_cc_library(
         "//solvers:mathematical_program",
         "//solvers:solve",
         "@gtest//:without_main",
+    ],
+)
+
+drake_cc_googletest(
+    name = "affine_ball_test",
+    deps = [
+        ":convex_set",
+        ":test_utilities",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/geometry/optimization/affine_ball.cc
+++ b/geometry/optimization/affine_ball.cc
@@ -1,0 +1,160 @@
+#include "drake/geometry/optimization/affine_ball.h"
+
+#include <vector>
+
+#include "drake/geometry/optimization/hyperellipsoid.h"
+#include "drake/solvers/solve.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+using solvers::Binding;
+using solvers::Constraint;
+using solvers::MathematicalProgram;
+using solvers::VectorXDecisionVariable;
+using symbolic::Variable;
+
+AffineBall::AffineBall() : AffineBall(MatrixXd(0, 0), VectorXd(0)) {}
+
+AffineBall::AffineBall(const Eigen::Ref<const MatrixXd>& B,
+                       const Eigen::Ref<const VectorXd>& center)
+    : ConvexSet(center.size()), B_(B), center_(center) {
+  CheckInvariants();
+}
+
+AffineBall::AffineBall(const Hyperellipsoid& ellipsoid)
+    : ConvexSet(ellipsoid.ambient_dimension()) {
+  DRAKE_THROW_UNLESS(ellipsoid.IsBounded());
+  B_ = ellipsoid.A().inverse();
+  center_ = ellipsoid.center();
+}
+
+AffineBall::~AffineBall() = default;
+
+namespace {
+
+double volume_of_unit_sphere(int dim) {
+  // Formula from https://en.wikipedia.org/wiki/Volume_of_an_n-ball .
+  // Note: special case n≤3 only because they are common and simple.
+  switch (dim) {
+    case 0:
+      return 1.0;
+    case 1:
+      return 2.0;
+    case 2:
+      return M_PI;
+    case 3:
+      return 4.0 * M_PI / 3.0;
+    default:
+      return std::pow(M_PI, dim / 2.0) / std::tgamma(dim / 2.0 + 1);
+  }
+}
+
+}  // namespace
+
+double AffineBall::Volume() const {
+  if (ambient_dimension() == 0) {
+    return 0.0;
+  }
+  return volume_of_unit_sphere(ambient_dimension()) * B_.determinant();
+}
+
+AffineBall AffineBall::MakeAxisAligned(
+    const Eigen::Ref<const VectorXd>& radius,
+    const Eigen::Ref<const VectorXd>& center) {
+  DRAKE_THROW_UNLESS(radius.size() == center.size());
+  DRAKE_THROW_UNLESS((radius.array() >= 0).all());
+  return AffineBall(MatrixXd(radius.asDiagonal()), center);
+}
+
+AffineBall AffineBall::MakeHypersphere(
+    double radius, const Eigen::Ref<const VectorXd>& center) {
+  DRAKE_THROW_UNLESS(radius >= 0);
+  const int dim = center.size();
+  return AffineBall(MatrixXd::Identity(dim, dim) * radius, center);
+}
+
+AffineBall AffineBall::MakeUnitBall(int dim) {
+  DRAKE_THROW_UNLESS(dim > 0);
+  return AffineBall(MatrixXd::Identity(dim, dim), VectorXd::Zero(dim));
+}
+
+std::unique_ptr<ConvexSet> AffineBall::DoClone() const {
+  return std::make_unique<AffineBall>(*this);
+}
+
+std::optional<VectorXd> AffineBall::DoMaybeGetPoint() const {
+  if (B_.isZero(0)) {
+    return center_;
+  }
+  return std::nullopt;
+}
+
+bool AffineBall::DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
+                              double tol) const {
+  // Check that x is in the column space of B_, then find a y such that By+d =
+  // x, and see if y
+  const auto B_QR = Eigen::ColPivHouseholderQR<MatrixXd>(B_);
+  VectorXd y = B_QR.solve(x - center_);
+  if ((B_ * y).isApprox(x - center_, tol)) {
+    return y.dot(y) <= 1;
+  }
+  return false;
+}
+
+std::pair<std::unique_ptr<Shape>, math::RigidTransformd>
+AffineBall::DoToShapeWithPose() const {
+  throw std::runtime_error("ToShapeWithPose is not supported by AffineBall.");
+}
+
+std::pair<VectorX<Variable>, std::vector<Binding<Constraint>>>
+AffineBall::DoAddPointInSetConstraints(
+    MathematicalProgram* prog,
+    const Eigen::Ref<const VectorXDecisionVariable>& x) const {
+  std::vector<Binding<Constraint>> new_constraints;
+  const int n = ambient_dimension();
+  VectorXDecisionVariable y = prog->NewContinuousVariables(n, "y");
+  // ||y||^2 <= 1, represented as 0.5yᵀIy + 0ᵀy + (-0.5) <= 0.
+  new_constraints.push_back(prog->AddQuadraticAsRotatedLorentzConeConstraint(
+      MatrixXd::Identity(n, n), VectorXd::Zero(n), -0.5, y));
+  // x = By + d, represented as [I, -B_] * [x; y] = center_
+  MatrixXd equality_constraint_A(n, 2 * n);
+  equality_constraint_A.leftCols(n) = MatrixXd::Identity(n, n);
+  equality_constraint_A.rightCols(n) = -B_;
+  new_constraints.push_back(prog->AddLinearEqualityConstraint(
+      equality_constraint_A, center_, {x, y}));
+  return {std::move(y), std::move(new_constraints)};
+}
+
+std::vector<Binding<Constraint>>
+AffineBall::DoAddPointInNonnegativeScalingConstraints(
+    MathematicalProgram*, const Eigen::Ref<const VectorXDecisionVariable>&,
+    const Variable&) const {
+  throw std::runtime_error(
+      "AffineBall::DoAddPointInNonnegativeScalingConstraints() is not "
+      "implemented yet.");
+}
+
+std::vector<Binding<Constraint>>
+AffineBall::DoAddPointInNonnegativeScalingConstraints(
+    MathematicalProgram*, const Eigen::Ref<const MatrixXd>&,
+    const Eigen::Ref<const VectorXd>&, const Eigen::Ref<const VectorXd>&,
+    double, const Eigen::Ref<const VectorXDecisionVariable>&,
+    const Eigen::Ref<const VectorXDecisionVariable>&) const {
+  throw std::runtime_error(
+      "AffineBall::DoAddPointInNonnegativeScalingConstraints() is not "
+      "implemented yet.");
+}
+
+void AffineBall::CheckInvariants() const {
+  DRAKE_THROW_UNLESS(this->ambient_dimension() == B_.cols());
+  DRAKE_THROW_UNLESS(B_.cols() == B_.rows());
+  DRAKE_THROW_UNLESS(B_.cols() == center_.size());
+}
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/affine_ball.h
+++ b/geometry/optimization/affine_ball.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/optimization/convex_set.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+// Forward-declare Hyperellipsoid.
+class Hyperellipsoid;
+
+/** Implements an ellipsoidal convex set represented as an affine scaling of the
+unit ball {Bu + center | |u|₂ ≤ 1}. B must be a square matrix.
+
+Compare this with an alternative parametrization of the ellipsoid: {x |
+(x-center)ᵀAᵀA(x-center) ≤ 1}, which utilizes a quadratic form. The two
+representations are related by B = A⁻¹ if A and B are invertible.
+
+The quadratic form parametrization is implemented in Hyperellipsoid. It can
+represent unbounded sets, but not sets along a lower-dimensional affine
+subspace. The AffineBall parametrization can represent sets along a
+lower-dimensional affine subspace, but not unbounded sets.
+
+An AffineBall can never be empty -- it always contains its center. This includes
+the zero-dimensional case.
+
+@ingroup geometry_optimization */
+class AffineBall final : public ConvexSet {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(AffineBall)
+
+  /** Constructs a default (zero-dimensional, nonempty) set. */
+  AffineBall();
+
+  /** Constructs the ellipsoid. Note that the IsPositiveDefinite check enforces
+  that B is symmetric, and only enforces positive semi-definiteness with the
+  default tolerance of 0.
+  @pre B.rows() == B.cols().
+  @pre B.cols() == center.size(). */
+  AffineBall(const Eigen::Ref<const Eigen::MatrixXd>& B,
+             const Eigen::Ref<const Eigen::VectorXd>& center);
+
+  /** Constructs an AffineBall from a Hyperellipsoid.
+  @pre ellipsoid.IsBounded(). */
+  explicit AffineBall(const Hyperellipsoid& ellipsoid);
+
+  ~AffineBall() final;
+
+  /** Returns the affine transformation matrix B. */
+  const Eigen::MatrixXd& B() const { return B_; }
+
+  /** Returns the center of the ellipsoid. */
+  const Eigen::VectorXd& center() const { return center_; }
+
+  /** Returns the volume of the AffineBall (in Euclidean space). */
+  double Volume() const;
+
+  /** Constructs the an axis-aligned AffineBall with the implicit form
+  (x₀-c₀)²/r₀² + (x₁-c₁)²/r₁² + ... + (x_N - c_N)²/r_N² ≤ 1, where c is
+  shorthand for `center` and r is shorthand for `radius`. */
+  static AffineBall MakeAxisAligned(
+      const Eigen::Ref<const Eigen::VectorXd>& radius,
+      const Eigen::Ref<const Eigen::VectorXd>& center);
+
+  /** Constructs a hypersphere with `radius` and `center`. */
+  static AffineBall MakeHypersphere(
+      double radius, const Eigen::Ref<const Eigen::VectorXd>& center);
+
+  /** Constructs the L₂-norm unit ball in `dim` dimensions, {x | |x|₂ <= 1 }. */
+  static AffineBall MakeUnitBall(int dim);
+
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    ConvexSet::Serialize(a);
+    a->Visit(MakeNameValue("B", &B_));
+    a->Visit(MakeNameValue("center", &center_));
+    CheckInvariants();
+  }
+
+ private:
+  std::unique_ptr<ConvexSet> DoClone() const final;
+
+  /* AffineBall can only represent bounded sets. */
+  std::optional<bool> DoIsBoundedShortcut() const final { return true; };
+
+  /* AffineBall can only represent nonempty sets. */
+  bool DoIsEmpty() const final { return false; };
+
+  /* DoMaybeGetPoint only succeeds if C is a matrix of all zeros. */
+  std::optional<Eigen::VectorXd> DoMaybeGetPoint() const final;
+
+  /* Returns the center, which is always feasible. */
+  std::optional<Eigen::VectorXd> DoMaybeGetFeasiblePoint() const final {
+    return center_;
+  };
+
+  bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
+                    double tol) const final;
+
+  std::pair<VectorX<symbolic::Variable>,
+            std::vector<solvers::Binding<solvers::Constraint>>>
+  DoAddPointInSetConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& vars)
+      const final;
+
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const symbolic::Variable& t) const final;
+
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const Eigen::MatrixXd>& A_x,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      const Eigen::Ref<const Eigen::VectorXd>& c, double d,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& t) const final;
+
+  std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
+      const final;
+
+  void CheckInvariants() const;
+
+  Eigen::MatrixXd B_{};
+  Eigen::VectorXd center_{};
+};
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -60,6 +60,14 @@ Hyperellipsoid::Hyperellipsoid(const QueryObject<double>& query_object,
   center_ = X_GE.inverse().translation();
 }
 
+Hyperellipsoid::Hyperellipsoid(const AffineBall& ellipsoid)
+    : ConvexSet(ellipsoid.ambient_dimension()) {
+  const auto B_QR = Eigen::ColPivHouseholderQR<MatrixXd>(ellipsoid.B());
+  DRAKE_THROW_UNLESS(B_QR.isInvertible());
+  center_ = ellipsoid.center();
+  A_ = B_QR.inverse();
+}
+
 Hyperellipsoid::~Hyperellipsoid() = default;
 
 namespace {

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/name_value.h"
+#include "drake/geometry/optimization/affine_ball.h"
 #include "drake/geometry/optimization/convex_set.h"
 
 namespace drake {
@@ -19,7 +20,8 @@ only that the matrix AᵀA is positive semi-definite.
 Compare this with an alternative (very useful) parameterization of the
 ellipsoid: `{Bu + center | |u|₂ ≤ 1}`, which is an affine scaling of the unit
 ball.  This is related to the quadratic form by `B = A⁻¹`, when `A` is
-invertible, but the quadratic form can also represent unbounded sets.
+invertible, but the quadratic form can also represent unbounded sets. This
+representation is implemented in AffineBall.
 
 Note: the name Hyperellipsoid was taken here to avoid conflicting with
 geometry::Ellipsoid and to distinguish that this class supports N dimensions.
@@ -48,6 +50,10 @@ class Hyperellipsoid final : public ConvexSet {
   Hyperellipsoid(const QueryObject<double>& query_object,
                  GeometryId geometry_id,
                  std::optional<FrameId> reference_frame = std::nullopt);
+
+  /** Constructs a Hyperellipsoid from an AffineBall.
+  @pre ellipsoid.B() is invertible.*/
+  explicit Hyperellipsoid(const AffineBall& ellipsoid);
 
   ~Hyperellipsoid() final;
 

--- a/geometry/optimization/test/affine_ball_test.cc
+++ b/geometry/optimization/test/affine_ball_test.cc
@@ -1,0 +1,224 @@
+#include "drake/geometry/optimization/affine_ball.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/optimization/affine_subspace.h"
+#include "drake/geometry/optimization/hyperellipsoid.h"
+#include "drake/geometry/optimization/test_utilities.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using Eigen::VectorXd;
+using internal::CheckAddPointInSetConstraints;
+
+GTEST_TEST(AffineBallTest, DefaultCtor) {
+  const AffineBall dut;
+  EXPECT_EQ(dut.B().rows(), 0);
+  EXPECT_EQ(dut.B().cols(), 0);
+  EXPECT_EQ(dut.center().size(), 0);
+  EXPECT_EQ(dut.Volume(), 0.0);
+  EXPECT_NO_THROW(dut.Clone());
+  EXPECT_EQ(dut.ambient_dimension(), 0);
+  EXPECT_TRUE(dut.IntersectsWith(dut));
+  EXPECT_TRUE(dut.IsBounded());
+  EXPECT_FALSE(dut.IsEmpty());
+  EXPECT_TRUE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+  ASSERT_TRUE(dut.MaybeGetPoint().has_value());
+  EXPECT_TRUE(dut.PointInSet(dut.MaybeGetPoint().value()));
+  ASSERT_TRUE(dut.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(dut.PointInSet(dut.MaybeGetFeasiblePoint().value()));
+}
+
+GTEST_TEST(AffineBallTest, UnitSphereTest) {
+  // Test constructor.
+  const Eigen::Matrix3d B = Eigen::Matrix3d::Identity();
+  const Vector3d center = Vector3d::Zero();
+  AffineBall ab(B, center);
+  EXPECT_EQ(ab.ambient_dimension(), 3);
+  EXPECT_TRUE(CompareMatrices(B, ab.B()));
+  EXPECT_TRUE(CompareMatrices(center, ab.center()));
+
+  // Test MaybeGetPoint.
+  EXPECT_FALSE(ab.MaybeGetPoint().has_value());
+
+  // Test IsEmpty (which is trivially false for Hyperellipsoid).
+  EXPECT_FALSE(ab.IsEmpty());
+
+  // Test MaybeGetFeasiblePoint.
+  ASSERT_TRUE(ab.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(ab.PointInSet(ab.MaybeGetFeasiblePoint().value()));
+
+  // Test PointInSet.
+  const Vector3d in1_W{.99, 0, 0}, in2_W{.5, .5, .5}, out1_W{1.01, 0, 0},
+      out2_W{1.0, 1.0, 1.0};
+
+  EXPECT_TRUE(ab.PointInSet(in1_W));
+  EXPECT_TRUE(ab.PointInSet(in2_W));
+  EXPECT_FALSE(ab.PointInSet(out1_W));
+  EXPECT_FALSE(ab.PointInSet(out2_W));
+
+  EXPECT_TRUE(CheckAddPointInSetConstraints(ab, in1_W));
+  EXPECT_TRUE(CheckAddPointInSetConstraints(ab, in2_W));
+  EXPECT_FALSE(CheckAddPointInSetConstraints(ab, out1_W));
+  EXPECT_FALSE(CheckAddPointInSetConstraints(ab, out2_W));
+}
+
+GTEST_TEST(AffineBallTest, Move) {
+  const Eigen::Matrix3d B = Eigen::Matrix3d::Identity();
+  const Vector3d center = Vector3d::Zero();
+  AffineBall orig(B, center);
+
+  // A move-constructed AffineBall takes over the original data.
+  AffineBall dut(std::move(orig));
+  EXPECT_EQ(dut.ambient_dimension(), 3);
+  EXPECT_TRUE(CompareMatrices(dut.B(), B));
+  EXPECT_TRUE(CompareMatrices(dut.center(), center));
+
+  // The old AffineBall is in a valid but unspecified state.
+  EXPECT_EQ(orig.B().cols(), orig.ambient_dimension());
+  EXPECT_EQ(orig.center().size(), orig.ambient_dimension());
+  EXPECT_NO_THROW(orig.Clone());
+}
+
+GTEST_TEST(AffineBallTest, UnitBall6DTest) {
+  AffineBall ab = AffineBall::MakeUnitBall(6);
+  EXPECT_EQ(ab.ambient_dimension(), 6);
+
+  const double kScale = sqrt(1.0 / 6.0);
+  Vector6d in1_W{Vector6d::Constant(-.99 * kScale)},
+      in2_W{Vector6d::Constant(.99 * kScale)},
+      out1_W{Vector6d::Constant(-1.01 * kScale)},
+      out2_W{Vector6d::Constant(1.01 * kScale)};
+
+  EXPECT_TRUE(ab.PointInSet(in1_W));
+  EXPECT_TRUE(ab.PointInSet(in2_W));
+  EXPECT_FALSE(ab.PointInSet(out1_W));
+  EXPECT_FALSE(ab.PointInSet(out2_W));
+
+  ASSERT_TRUE(ab.MaybeGetFeasiblePoint().has_value());
+  EXPECT_TRUE(ab.PointInSet(ab.MaybeGetFeasiblePoint().value()));
+
+  EXPECT_EQ(ab.Volume(), std::pow(M_PI, 3) / 6);
+}
+
+GTEST_TEST(AffineBallTest, CloneTest) {
+  AffineBall ab(Eigen::Matrix<double, 6, 6>::Identity(), Vector6d::Zero());
+  std::unique_ptr<ConvexSet> clone = ab.Clone();
+  EXPECT_EQ(clone->ambient_dimension(), ab.ambient_dimension());
+  AffineBall* pointer = dynamic_cast<AffineBall*>(clone.get());
+  ASSERT_NE(pointer, nullptr);
+  EXPECT_TRUE(CompareMatrices(ab.B(), pointer->B()));
+  EXPECT_TRUE(CompareMatrices(ab.center(), pointer->center()));
+}
+
+GTEST_TEST(AffineBallTest, MakeUnitBallTest) {
+  AffineBall ab = AffineBall::MakeUnitBall(4);
+  EXPECT_TRUE(CompareMatrices(ab.B(), MatrixXd::Identity(4, 4)));
+  EXPECT_TRUE(CompareMatrices(ab.center(), VectorXd::Zero(4)));
+  EXPECT_EQ(ab.Volume(), 0.5 * std::pow(M_PI, 2));
+}
+
+GTEST_TEST(AffineBallTest, MakeHypersphereTest) {
+  const double kRadius = 3.0;
+  Vector4d center;
+  center << 1.3, 1.4, 7.2, 9.1;
+  AffineBall ab = AffineBall::MakeHypersphere(kRadius, center);
+  EXPECT_TRUE(CompareMatrices(ab.B(), MatrixXd::Identity(4, 4) * kRadius));
+  EXPECT_TRUE(CompareMatrices(ab.center(), center));
+  const Vector4d xvec = Eigen::MatrixXd::Identity(4, 1);
+  EXPECT_TRUE(ab.PointInSet(center + kRadius * xvec, 1e-16));
+  EXPECT_FALSE(ab.PointInSet(center + 1.1 * kRadius * xvec, 1e-16));
+}
+
+GTEST_TEST(AffineBallTest, MakeAxisAlignedTest) {
+  const double a = 2.3, b = 4.5, c = 6.1;
+  const Vector3d center{3.4, -2.3, 7.4};
+  AffineBall ab = AffineBall::MakeAxisAligned(Vector3d{a, b, c}, center);
+  EXPECT_EQ(ab.ambient_dimension(), 3);
+
+  EXPECT_TRUE(ab.PointInSet(center + Vector3d(0, 0, 0)));
+  EXPECT_TRUE(ab.PointInSet(center + Vector3d(a, 0, 0)));
+  EXPECT_TRUE(ab.PointInSet(center + Vector3d(-a, 0, 0)));
+  EXPECT_TRUE(ab.PointInSet(center + Vector3d(0, b, 0)));
+  EXPECT_TRUE(ab.PointInSet(center + Vector3d(0, -b, 0)));
+  EXPECT_TRUE(ab.PointInSet(center + Vector3d(0, 0, c)));
+  EXPECT_TRUE(ab.PointInSet(center + Vector3d(0, 0, -c)));
+
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(a, b, 0)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(a, -b, 0)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(-a, b, 0)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(-a, -b, 0)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(a, 0, c)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(a, 0, -c)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(-a, 0, c)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(-a, 0, -c)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(0, b, c)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(0, -b, c)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(0, b, -c)));
+  EXPECT_FALSE(ab.PointInSet(center + Vector3d(0, -b, -c)));
+
+  EXPECT_EQ(ab.Volume(), a * b * c * 4 * M_PI / 3);
+}
+
+GTEST_TEST(AffineBallTest, LowerDimensionalEllipsoids) {
+  const double kAffineHullTol = 1e-12;
+
+  // Test the MakeAxisAligned constructor.
+  const Vector3d center{3.4, -2.3, 7.4};
+  const double a = 2.3, b = 4.5, c = 6.1;
+  AffineBall ab0 = AffineBall::MakeAxisAligned(Vector3d{0, 0, 0}, center);
+  AffineBall ab1 = AffineBall::MakeAxisAligned(Vector3d{0, 0, c}, center);
+  AffineBall ab2 = AffineBall::MakeAxisAligned(Vector3d{0, b, c}, center);
+  AffineBall ab3 = AffineBall::MakeAxisAligned(Vector3d{a, b, c}, center);
+
+  AffineSubspace as0(ab0, kAffineHullTol);
+  AffineSubspace as1(ab1, kAffineHullTol);
+  AffineSubspace as2(ab2, kAffineHullTol);
+  AffineSubspace as3(ab3, kAffineHullTol);
+
+  EXPECT_EQ(as0.AffineDimension(), 0);
+  EXPECT_EQ(as1.AffineDimension(), 1);
+  EXPECT_EQ(as2.AffineDimension(), 2);
+  EXPECT_EQ(as3.AffineDimension(), 3);
+
+  // Test the MakeHypersphere constructor.
+  AffineBall ab4 = AffineBall::MakeHypersphere(0, center);
+  AffineSubspace as4(ab4, kAffineHullTol);
+  EXPECT_EQ(as4.AffineDimension(), 0);
+
+  // Test the standard constructor.
+  Eigen::MatrixXd B = Eigen::MatrixXd::Zero(3, 3);
+  AffineBall ab5(B, center);
+  AffineSubspace as5(ab5, kAffineHullTol);
+  EXPECT_EQ(as5.AffineDimension(), 0);
+  B(0, 0) = 1;
+  AffineBall ab6(B, center);
+  AffineSubspace as6(ab6, kAffineHullTol);
+  EXPECT_EQ(as6.AffineDimension(), 1);
+  B(1, 1) = 1;
+  AffineBall ab7(B, center);
+  AffineSubspace as7(ab7, kAffineHullTol);
+  EXPECT_EQ(as7.AffineDimension(), 2);
+}
+
+GTEST_TEST(HyperellipsoidTest, FromHyperellipsoid) {
+  Hyperellipsoid E1(MatrixXd::Identity(3, 3), Vector3d::Zero());
+  EXPECT_TRUE(E1.IsBounded());
+  EXPECT_NO_THROW(AffineBall{E1});
+  Hyperellipsoid E2(MatrixXd::Identity(2, 3), Vector3d::Zero());
+  EXPECT_FALSE(E2.IsBounded());
+  EXPECT_THROW(AffineBall{E2}, std::exception);
+}
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/test/hyperellipsoid_test.cc
+++ b/geometry/optimization/test/hyperellipsoid_test.cc
@@ -9,6 +9,7 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/optimization/affine_ball.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/test_utilities.h"
 #include "drake/geometry/scene_graph.h"
@@ -656,6 +657,20 @@ GTEST_TEST(HyperellipsoidTest, Serialize) {
   EXPECT_EQ(E.ambient_dimension(), E2.ambient_dimension());
   EXPECT_TRUE(CompareMatrices(E.A(), E2.A()));
   EXPECT_TRUE(CompareMatrices(E.center(), E2.center()));
+}
+
+GTEST_TEST(HyperellipsoidTest, FromAffineBall) {
+  const double a = 2.3, b = 4.5, c = 6.1;
+  const Vector3d center{3.4, -2.3, 7.4};
+  AffineBall ab = AffineBall::MakeAxisAligned(Vector3d{a, b, c}, center);
+  EXPECT_NO_THROW(Hyperellipsoid{ab});
+  Hyperellipsoid h(ab);
+  EXPECT_TRUE(CompareMatrices(h.center(), ab.center()));
+  EXPECT_TRUE(CompareMatrices(h.A() * ab.B(), MatrixXd::Identity(3, 3)));
+
+  AffineBall ab_sub_dimensional =
+      AffineBall::MakeAxisAligned(Vector3d{a, b, 0}, center);
+  EXPECT_THROW(Hyperellipsoid{ab_sub_dimensional}, std::exception);
 }
 
 }  // namespace optimization


### PR DESCRIPTION
Towards #20037. This allows transforming between the two representations of ellipsoidal convex sets, so long as the set in one representation can be represented in the other form. (When going from Hyperellipsoid to AffineBall, we check that it's bounded. When going from AffineBall to Hyperellipsoid, we check that it's full-dimensional.)

Waiting for #20038 to land before seeking a reviewer.