### PR TITLE
Adds a test and an improved docstring for getting GCS Edge solutions.

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -283,12 +283,20 @@ class GraphOfConvexSets {
 
     /** Returns the continuous decision variables associated with vertex `u`.
     This can be used for constructing symbolic::Expression costs and
-    constraints.*/
+    constraints.
+
+    See also GetSolutionPhiXu(); using `result.GetSolution(xu())` may not
+    be what you want.
+    */
     const VectorX<symbolic::Variable>& xu() const { return u_->x(); }
 
     /** Returns the continuous decision variables associated with vertex `v`.
     This can be used for constructing symbolic::Expression costs and
-    constraints.*/
+    constraints.
+
+    See also GetSolutionPhiXv(); using `result.GetSolution(xv())` may not
+    be what you want.
+    */
     const VectorX<symbolic::Variable>& xv() const { return v_->x(); }
 
     /** Adds a cost to this edge, described by a symbolic::Expression @p e
@@ -373,13 +381,17 @@ class GraphOfConvexSets {
     double GetSolutionCost(
         const solvers::MathematicalProgramResult& result) const;
 
-    /** Returns the vector value of the slack variables associated with ϕxᵤ in a
-    solvers::MathematicalProgramResult. */
+    /** Returns the vector value of the slack variables associated with ϕxᵤ in
+    a solvers::MathematicalProgramResult. This can obtain a different value
+    than `result.GetSolution(edge->xu())`, which is equivalent to
+    `result.GetSolution(edge->u()->x())`; in the case of a loose convex
+    relaxation `result.GetSolution(edge->xu())` will be the *averaged* value of
+    the edge slacks for all non-zero-flow edges. */
     Eigen::VectorXd GetSolutionPhiXu(
         const solvers::MathematicalProgramResult& result) const;
 
     /** Returns the vector value of the slack variables associated with ϕxᵥ in
-    a solvers::MathematicalProgramResult. */
+    a solvers::MathematicalProgramResult. See GetSolutionPhiXu(). */
     Eigen::VectorXd GetSolutionPhiXv(
         const solvers::MathematicalProgramResult& result) const;
 

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -2039,6 +2039,80 @@ GTEST_TEST(ShortestPathTest, Figure9) {
   }
 }
 
+// A simple path planning example, where the environment is in the box (0,0)
+// to (6,6), and there is an obstacle in the box (2,2) to (4,4).
+GTEST_TEST(ShortestPathTest, SavvaBoxExample) {
+  auto add_edge_and_constraints = [](GraphOfConvexSets* gcs, Vertex* v_left,
+                                     Vertex* v_right) {
+    Edge* edge =
+        gcs->AddEdge(v_left, v_right, v_left->name() + "-" + v_right->name());
+    // Second point of left vertex is equal to first point of right vertex.
+    edge->AddConstraint(edge->xu().tail<2>() == edge->xv().head<2>());
+    return edge;
+  };
+
+  auto add_quadratic_cost_between_consecutive_points = [](Vertex* v) {
+    auto x = v->x();
+    v->AddCost((x[2] - x[0]) * (x[2] - x[0]) + (x[3] - x[1]) * (x[3] - x[1]));
+  };
+
+  // Construct a GCS.
+  GraphOfConvexSets gcs;
+
+  // Define vertices.
+  Vertex* start = gcs.AddVertex(Point(Vector2d{4, 5}), "start");
+  Vertex* target = gcs.AddVertex(Point(Vector2d{3, 0}), "target");
+
+  Vertex* v_left = gcs.AddVertex(
+      HPolyhedron::MakeBox(Vector4d{0, 0, 0, 0}, Vector4d{2, 6, 2, 6}), "left");
+  Vertex* v_above = gcs.AddVertex(
+      HPolyhedron::MakeBox(Vector4d{0, 4, 0, 4}, Vector4d{6, 6, 6, 6}),
+      "above");
+  Vertex* v_right = gcs.AddVertex(
+      HPolyhedron::MakeBox(Vector4d{4, 0, 4, 0}, Vector4d{6, 6, 6, 6}),
+      "right");
+  Vertex* v_below = gcs.AddVertex(
+      HPolyhedron::MakeBox(Vector4d{0, 0, 0, 0}, Vector4d{6, 2, 6, 2}),
+      "below");
+
+  // Add costs and constraints.
+  add_quadratic_cost_between_consecutive_points(v_left);
+  add_quadratic_cost_between_consecutive_points(v_above);
+  add_quadratic_cost_between_consecutive_points(v_right);
+  add_quadratic_cost_between_consecutive_points(v_below);
+
+  // From above you can go left or right,
+  // from left or right you can go below.
+  add_edge_and_constraints(&gcs, start, v_above);
+  add_edge_and_constraints(&gcs, v_above, v_right);
+  add_edge_and_constraints(&gcs, v_above, v_left);
+  add_edge_and_constraints(&gcs, v_right, v_below);
+  add_edge_and_constraints(&gcs, v_left, v_below);
+  add_edge_and_constraints(&gcs, v_below, target);
+
+  // Solve convex relaxation so that the flows are split.
+  GraphOfConvexSetsOptions options;
+  options.convex_relaxation = true;
+
+  auto result = gcs.SolveShortestPath(*start, *target, options);
+  ASSERT_TRUE(result.is_success());
+
+  for (auto* e : gcs.Edges()) {
+    if (e->name().find("start") == std::string::npos &&
+        e->name().find("target") == std::string::npos) {
+      // The flows are split, so recovering the solution via e->xu() does not
+      // return the expected result (it looks like the equality constraint was
+      // not enforced).
+      EXPECT_FALSE(CompareMatrices(result.GetSolution(e->xu()).tail<2>(),
+                                   result.GetSolution(e->xv()).head<2>(),
+                                   1e-4));
+      // But the underlying edge decision variables *are* equal.
+      EXPECT_TRUE(CompareMatrices(e->GetSolutionPhiXu(result).tail<2>(),
+                                  e->GetSolutionPhiXv(result).head<2>(), 1e-4));
+    }
+  }
+}
+
 GTEST_TEST(ShortestPathTest, Graphviz) {
   GraphOfConvexSets g;
   auto source = g.AddVertex(Point(Vector2d{1.0, 2.}), "source");


### PR DESCRIPTION
GraphOfConvexSets::Edge::xu() returns the placeholder variables for the vertices. This can be potentially confusing when one is inspecting the MathematicalProgramResult for a solution where the convex relaxation is loose. I've captured the confusion in an example, and tried to improve the most relevant docstring.

+@iamsavva for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20042)
<!-- Reviewable:end -->
