### PR TITLE
Improve error message for Diagram::GetSubsystemByName()

### DIFF
--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -369,9 +369,16 @@ const System<T>& Diagram<T>::GetSubsystemByName(std::string_view name) const {
       return *child;
     }
   }
+  std::vector<std::string> subsystem_names;
+  subsystem_names.reserve(registered_systems_.size());
+  for (const auto& child : registered_systems_) {
+    subsystem_names.emplace_back(child->get_name());
+  }
+
   throw std::logic_error(fmt::format(
-      "System {} does not have a subsystem named {}",
-      this->GetSystemName(), name));
+      "System {} does not have a subsystem named {}. The existing subsystems "
+      "are named {{{}}}.",
+      this->GetSystemName(), name, fmt::join(subsystem_names, ", ")));
 }
 
 template <typename T>

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -984,7 +984,9 @@ TEST_F(DiagramTest, GetSubsystemByName) {
   EXPECT_FALSE(diagram_->HasSubsystemNamed("not_a_subsystem"));
   DRAKE_EXPECT_THROWS_MESSAGE(
       diagram_->GetSubsystemByName("not_a_subsystem"),
-      "System .* does not have a subsystem named not_a_subsystem");
+      "System .* does not have a subsystem named not_a_subsystem. The existing "
+      "subsystems are named \\{adder0, adder1, adder2, stateless, integrator0, "
+      "integrator1, sink, kitchen_sink\\}.");
 }
 
 TEST_F(DiagramTest, GetDowncastSubsystemByName) {
@@ -998,7 +1000,9 @@ TEST_F(DiagramTest, GetDowncastSubsystemByName) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       diagram_->GetDowncastSubsystemByName<StatelessSystem>("not_a_subsystem"),
-      "System .* does not have a subsystem named not_a_subsystem");
+      "System .* does not have a subsystem named not_a_subsystem. The existing "
+      "subsystems are named \\{adder0, adder1, adder2, stateless, integrator0, "
+      "integrator1, sink, kitchen_sink\\}.");
 
   // Now downcast a non-templatized system (invokes a different overload).
   // This will only compile if the subsystem's scalar type matches the


### PR DESCRIPTION
If the requested name isn't a match, print out the names that would have matched.

+@jwnimmer-tri for both reviews, please.