### PR TITLE
[setup] Provide opt-in/opt-out flags for installing Bazel

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,5 +1,5 @@
 # Keep this version number in sync with the Ubuntu deb installed by
-# drake/setup/ubuntu/source_distribution/install_prereqs.sh.
+# drake/setup/ubuntu/source_distribution/install_bazel.sh.
 #
 # These files should also be updated:
 # drake/tools/workspace/drake_visualizer/image/provision.sh

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -35,6 +35,14 @@ while [ "${1:-}" != "" ]; do
     --with-doc-only)
       source_distribution_args+=(--with-doc-only)
       ;;
+    # Install Bazel from a deb package.
+    --with-bazel)
+      source_distribution_args+=(--with-bazel)
+      ;;
+    # Do NOT install bazel.
+    --without-bazel)
+      source_distribution_args+=(--without-bazel)
+      ;;
     # Install prerequisites that are only needed for --config clang, i.e.,
     # opts-in to the ability to compile Drake's C++ code using Clang.
     --with-clang)

--- a/setup/ubuntu/source_distribution/install_bazel.sh
+++ b/setup/ubuntu/source_distribution/install_bazel.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Install Bazel as /usr/bin/bazel on Ubuntu 20.04 (Focal) or 22.04 (Jammy).
+# This script does not accept any command line arguments.
+
+set -euo pipefail
+
+dpkg_install_from_wget() {
+  package="$1"
+  version="$2"
+  url="$3"
+  checksum="$4"
+
+  # Skip the install if we're already at the exact version.
+  installed=$(dpkg-query --showformat='${Version}\n' --show "${package}" 2>/dev/null || true)
+  if [[ "${installed}" == "${version}" ]]; then
+    echo "${package} is already at the desired version ${version}"
+    return
+  fi
+
+  # If installing our desired version would be a downgrade, ask the user first.
+  if dpkg --compare-versions "${installed}" gt "${version}"; then
+    echo "This system has ${package} version ${installed} installed."
+    echo "Drake suggests downgrading to version ${version}, our supported version."
+    read -r -p 'Do you want to downgrade? [Y/n] ' reply
+    if [[ ! "${reply}" =~ ^([yY][eE][sS]|[yY])*$ ]]; then
+      echo "Skipping ${package} ${version} installation."
+      return
+    fi
+  fi
+
+  # Download and verify.
+  tmpdeb="/tmp/${package}_${version}-amd64.deb"
+  wget -O "${tmpdeb}" "${url}"
+  if echo "${checksum} ${tmpdeb}" | sha256sum -c -; then
+    echo  # Blank line between checkout output and dpkg output.
+  else
+    echo "ERROR: The ${package} deb does NOT have the expected SHA256. Not installing." >&2
+    exit 2
+  fi
+
+  # Install.
+  dpkg -i "${tmpdeb}"
+  rm "${tmpdeb}"
+}
+
+# Install bazel package dependencies (these may duplicate dependencies of
+# drake).
+apt-get install ${maybe_yes} --no-install-recommends $(cat <<EOF
+g++
+unzip
+zlib1g-dev
+EOF
+)
+
+# Install bazel.
+# Keep this version number in sync with the drake/.bazeliskrc version number.
+if [[ $(arch) = "aarch64" ]]; then
+  # Check if bazel is already installed.
+  if [[ "$(which bazel)" ]]; then
+    echo "Bazel is already installed." >&2
+  else
+    echo "WARNING: On Ubuntu arm64 systems, Drake's install_prereqs does not" \
+    "automatically install Bazel on your behalf. You will need to install" \
+    "Bazel yourself. See https://bazel.build for instructions." >&2
+  fi
+else
+  dpkg_install_from_wget \
+    bazel 6.3.1 \
+    https://github.com/bazelbuild/bazel/releases/download/6.3.1/bazel_6.3.1-linux-x86_64.deb \
+    2772e6aad3f12f9ddce83032d4f52aac9da141ca4191ced1471a1b6d5adb6da7
+fi

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 with_doc_only=0
 with_maintainer_only=0
+with_bazel=1
 with_clang=1
 with_test_only=1
 with_update=1
@@ -23,6 +24,14 @@ while [ "${1:-}" != "" ]; do
     # i.e., those prerequisites that are dependencies of bazel run //doc:build.
     --with-doc-only)
       with_doc_only=1
+      ;;
+    # Install Bazel from a deb package.
+    --with-bazel)
+      with_bazel=1
+      ;;
+    # Do NOT install Bazel.
+    --without-bazel)
+      with_bazel=0
       ;;
     # Install prerequisites that are only needed for --config clang, i.e.,
     # opts-in to the ability to compile Drake's C++ code using Clang.
@@ -103,6 +112,10 @@ if [[ "${with_doc_only}" -eq 1 ]]; then
   apt-get install ${maybe_yes} --no-install-recommends ${packages}
 fi
 
+if [[ "${with_bazel}" -eq 1 ]]; then
+  source "${BASH_SOURCE%/*}/install_bazel.sh"
+fi
+
 if [[ "${with_clang}" -eq 1 ]]; then
   packages=$(cat "${BASH_SOURCE%/*}/packages-${codename}-clang.txt")
   apt-get install ${maybe_yes} --no-install-recommends ${packages}
@@ -132,70 +145,4 @@ if [[ "${codename}" == "jammy" ]]; then
       apt-get install ${maybe_yes} --no-install-recommends libgcc-12-dev libstdc++-12-dev libgfortran-12-dev
     fi
   fi
-fi
-
-dpkg_install_from_wget() {
-  package="$1"
-  version="$2"
-  url="$3"
-  checksum="$4"
-
-  # Skip the install if we're already at the exact version.
-  installed=$(dpkg-query --showformat='${Version}\n' --show "${package}" 2>/dev/null || true)
-  if [[ "${installed}" == "${version}" ]]; then
-    echo "${package} is already at the desired version ${version}"
-    return
-  fi
-
-  # If installing our desired version would be a downgrade, ask the user first.
-  if dpkg --compare-versions "${installed}" gt "${version}"; then
-    echo "This system has ${package} version ${installed} installed."
-    echo "Drake suggests downgrading to version ${version}, our supported version."
-    read -r -p 'Do you want to downgrade? [Y/n] ' reply
-    if [[ ! "${reply}" =~ ^([yY][eE][sS]|[yY])*$ ]]; then
-      echo "Skipping ${package} ${version} installation."
-      return
-    fi
-  fi
-
-  # Download and verify.
-  tmpdeb="/tmp/${package}_${version}-amd64.deb"
-  wget -O "${tmpdeb}" "${url}"
-  if echo "${checksum} ${tmpdeb}" | sha256sum -c -; then
-    echo  # Blank line between checkout output and dpkg output.
-  else
-    echo "ERROR: The ${package} deb does NOT have the expected SHA256. Not installing." >&2
-    exit 2
-  fi
-
-  # Install.
-  dpkg -i "${tmpdeb}"
-  rm "${tmpdeb}"
-}
-
-# Install bazel package dependencies (these may duplicate dependencies of
-# drake).
-apt-get install ${maybe_yes} --no-install-recommends $(cat <<EOF
-g++
-unzip
-zlib1g-dev
-EOF
-)
-
-# Install bazel.
-# Keep this version number in sync with the drake/.bazeliskrc version number.
-if [[ $(arch) = "aarch64" ]]; then
-  # Check if bazel is already installed.
-  if [[ "$(which bazel)" ]]; then
-    echo "Bazel is already installed." >&2
-  else
-    echo "WARNING: On Ubuntu arm64 systems, Drake's install_prereqs does not" \
-    "automatically install Bazel on your behalf. You will need to install" \
-    "Bazel yourself. See https://bazel.build for instructions." >&2
-  fi
-else
-  dpkg_install_from_wget \
-    bazel 6.3.1 \
-    https://github.com/bazelbuild/bazel/releases/download/6.3.1/bazel_6.3.1-linux-x86_64.deb \
-    2772e6aad3f12f9ddce83032d4f52aac9da141ca4191ced1471a1b6d5adb6da7
 fi


### PR DESCRIPTION
Towards #19923.  For CMake users who choose to auto-fetch Bazel instead of installing it system-side, they should be able to opt-out of the install step for it.