### PR TITLE
Implements ApplyMultibodyPlantConfig

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1257,7 +1257,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         doc.AddMultibodyPlantSceneGraph
             .doc_3args_systemsDiagramBuilder_double_stduniqueptr);
 
-    // In C++ this function is only defined for double, not AutoDiffXd.
+    // In C++ these functions are only defined for double, not AutoDiffXd.
     if constexpr (std::is_same_v<T, double>) {
       m.def(
           "AddMultibodyPlant",
@@ -1267,6 +1267,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             return result_to_tuple(builder, pair);
           },
           py::arg("config"), py::arg("builder"), doc.AddMultibodyPlant.doc);
+      m.def("ApplyMultibodyPlantConfig", &ApplyMultibodyPlantConfig,
+          py::arg("config"), py::arg("plant"),
+          doc.ApplyMultibodyPlantConfig.doc);
     }
   }
 

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -69,6 +69,7 @@ from pydrake.multibody.math import (
 from pydrake.multibody.plant import (
     AddMultibodyPlant,
     AddMultibodyPlantSceneGraph,
+    ApplyMultibodyPlantConfig,
     CalcContactFrictionFromSurfaceProperties,
     ConnectContactResultsToDrakeVisualizer,
     ContactModel,
@@ -264,9 +265,16 @@ class TestPlant(unittest.TestCase):
         copy.copy(config)
 
         builder = DiagramBuilder_[float]()
-        plant, scene_graph = AddMultibodyPlant(config, builder)
+        plant, scene_graph = AddMultibodyPlant(config=config, builder=builder)
         self.assertIsNotNone(plant)
         self.assertIsNotNone(scene_graph)
+
+        self.assertNotEqual(plant.get_contact_model(),
+                            ContactModel.kHydroelasticsOnly)
+        config.contact_model = "hydroelastic"
+        ApplyMultibodyPlantConfig(config=config, plant=plant)
+        self.assertEqual(plant.get_contact_model(),
+                         ContactModel.kHydroelasticsOnly)
 
     @numpy_compare.check_all_types
     def test_get_bodies_welded_to_keep_alive(self, T):

--- a/multibody/plant/multibody_plant_config_functions.cc
+++ b/multibody/plant/multibody_plant_config_functions.cc
@@ -15,20 +15,25 @@ AddResult AddMultibodyPlant(
     const MultibodyPlantConfig& config,
     systems::DiagramBuilder<double>* builder) {
   AddResult result = AddMultibodyPlantSceneGraph(builder, config.time_step);
-  result.plant.set_penetration_allowance(config.penetration_allowance);
-  result.plant.set_stiction_tolerance(config.stiction_tolerance);
-  result.plant.set_contact_model(
+  ApplyMultibodyPlantConfig(config, &result.plant);
+  return result;
+}
+
+void ApplyMultibodyPlantConfig(const MultibodyPlantConfig& config,
+                               MultibodyPlant<double>* plant) {
+  plant->set_penetration_allowance(config.penetration_allowance);
+  plant->set_stiction_tolerance(config.stiction_tolerance);
+  plant->set_contact_model(
       internal::GetContactModelFromString(config.contact_model));
-  result.plant.set_discrete_contact_solver(
+  plant->set_discrete_contact_solver(
       internal::GetDiscreteContactSolverFromString(
           config.discrete_contact_solver));
-  result.plant.set_sap_near_rigid_threshold(config.sap_near_rigid_threshold);
-  result.plant.set_contact_surface_representation(
+  plant->set_sap_near_rigid_threshold(config.sap_near_rigid_threshold);
+  plant->set_contact_surface_representation(
       internal::GetContactSurfaceRepresentationFromString(
           config.contact_surface_representation));
-  result.plant.set_adjacent_bodies_collision_filters(
+  plant->set_adjacent_bodies_collision_filters(
       config.adjacent_bodies_collision_filters);
-  return result;
 }
 
 namespace internal {

--- a/multibody/plant/multibody_plant_config_functions.h
+++ b/multibody/plant/multibody_plant_config_functions.h
@@ -16,6 +16,13 @@ AddMultibodyPlantSceneGraphResult<double> AddMultibodyPlant(
     const MultibodyPlantConfig& config,
     systems::DiagramBuilder<double>* builder);
 
+/// Applies settings given in `config` to an existing `plant`. The `time_step`
+/// is the one value in `config` that is not set -- it can only be set in the
+/// MultibodyPlant constructor. Consider using AddMultibodyPlant() or manually
+/// passing `config.time_step` when you construct the MultibodyPlant.
+void ApplyMultibodyPlantConfig(const MultibodyPlantConfig& config,
+                               MultibodyPlant<double>* plant);
+
 namespace internal {
 
 // (Exposed for unit testing only.)

--- a/multibody/plant/test/multibody_plant_config_functions_test.cc
+++ b/multibody/plant/test/multibody_plant_config_functions_test.cc
@@ -12,7 +12,7 @@ namespace {
 
 using yaml::LoadYamlString;
 
-GTEST_TEST(MultibodyPlantConfigFunctionsTest, BasicTest) {
+GTEST_TEST(MultibodyPlantConfigFunctionsTest, AddMultibodyBasicTest) {
   MultibodyPlantConfig config;
   config.time_step = 0.002;
   config.penetration_allowance = 0.003;
@@ -30,6 +30,29 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, BasicTest) {
   EXPECT_EQ(result.plant.get_contact_surface_representation(),
             geometry::HydroelasticContactRepresentation::kPolygon);
   EXPECT_EQ(result.plant.get_adjacent_bodies_collision_filters(), false);
+  // There is no getter for penetration_allowance nor stiction_tolerance, so we
+  // can't test them.
+}
+
+GTEST_TEST(MultibodyPlantConfigFunctionsTest,
+           ApplyMultibodyPlantConfigBasicTest) {
+  MultibodyPlantConfig config;
+  config.time_step = 0.002;
+  config.penetration_allowance = 0.003;
+  config.stiction_tolerance = 0.004;
+  config.sap_near_rigid_threshold = 0.1;
+  config.contact_model = "hydroelastic";
+  config.contact_surface_representation = "polygon";
+  config.adjacent_bodies_collision_filters = false;
+
+  MultibodyPlant<double> plant(0.0);
+  ApplyMultibodyPlantConfig(config, &plant);
+  // The times_step is not set.
+  EXPECT_EQ(plant.get_sap_near_rigid_threshold(), 0.1);
+  EXPECT_EQ(plant.get_contact_model(), ContactModel::kHydroelasticsOnly);
+  EXPECT_EQ(plant.get_contact_surface_representation(),
+            geometry::HydroelasticContactRepresentation::kPolygon);
+  EXPECT_EQ(plant.get_adjacent_bodies_collision_filters(), false);
   // There is no getter for penetration_allowance nor stiction_tolerance, so we
   // can't test them.
 }


### PR DESCRIPTION
Previously, support for MultibodyPlantConfig was only through AddMultibodyPlant; which requires a builder, and also makes a SceneGraph. The new method supports applying the config to an existing plant (no builder nor SceneGraph required).

+@jwnimmer for feature review, please.