### PR TITLE
Adds an initialization event to LcmSubscriberSystem

### DIFF
--- a/bindings/pydrake/systems/_lcm_extra.py
+++ b/bindings/pydrake/systems/_lcm_extra.py
@@ -39,7 +39,12 @@ class PySerializer(SerializerInterface):
 
 
 @staticmethod
-def _make_lcm_subscriber(channel, lcm_type, lcm, use_cpp_serializer=False):
+def _make_lcm_subscriber(channel,
+                         lcm_type,
+                         lcm,
+                         use_cpp_serializer=False,
+                         *,
+                         wait_for_message_on_initialization_timeout=0.0):
     """Convenience to create an LCM subscriber system with a concrete type.
 
     Args:
@@ -48,7 +53,16 @@ def _make_lcm_subscriber(channel, lcm_type, lcm, use_cpp_serializer=False):
         lcm: LCM service instance.
         use_cpp_serializer: Use C++ serializer to interface with LCM converter
             systems that are implemented in C++. LCM types must be registered
-            in C++ via `BindCppSerializer`.
+            in C++ via ``BindCppSerializer``.
+        wait_for_message_on_initialization_timeout: Configures the behavior of
+            initialization events (see ``System.ExecuteInitializationEvents``
+            and ``Simulator.Initialize``) by specifying the number of seconds
+            (wall-clock elapsed time) to wait for a new message. If this
+            timeout is <= 0, initialization will copy any already-received
+            messages into the Context but will not process any new messages.
+            If this timeout is > 0, initialization will call
+            ``lcm.HandleSubscriptions()`` until at least one message is
+            received or until the timeout. Pass ∞ to wait indefinitely.
     """
     # TODO(eric.cousineau): Make `use_cpp_serializer` be kwarg-only.
     # N.B. This documentation is actually public, as it is assigned to classes
@@ -57,7 +71,8 @@ def _make_lcm_subscriber(channel, lcm_type, lcm, use_cpp_serializer=False):
         serializer = PySerializer(lcm_type)
     else:
         serializer = _Serializer_[lcm_type]()
-    return LcmSubscriberSystem(channel, serializer, lcm)
+    return LcmSubscriberSystem(channel, serializer, lcm,
+                               wait_for_message_on_initialization_timeout)
 
 
 @staticmethod

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -230,14 +230,16 @@ PYBIND11_MODULE(lcm, m) {
     py::class_<Class, LeafSystem<double>>(m, "LcmSubscriberSystem")
         .def(py::init<const std::string&,
                  std::shared_ptr<const SerializerInterface>,
-                 LcmInterfaceSystem*>(),
+                 LcmInterfaceSystem*, double>(),
             py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
+            py::arg("wait_for_message_on_initialization_timeout") = 0.0,
             // Keep alive, reference: `self` keeps `lcm` alive.
             py::keep_alive<1, 4>(), doc.LcmSubscriberSystem.ctor.doc)
         .def(py::init<const std::string&,
-                 std::shared_ptr<const SerializerInterface>,
-                 DrakeLcmInterface*>(),
+                 std::shared_ptr<const SerializerInterface>, DrakeLcmInterface*,
+                 double>(),
             py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
+            py::arg("wait_for_message_on_initialization_timeout") = 0.0,
             // Keep alive, reference: `self` keeps `lcm` alive.
             py::keep_alive<1, 4>(), doc.LcmSubscriberSystem.ctor.doc)
         .def("WaitForMessage", &Class::WaitForMessage,

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -151,7 +151,8 @@ class TestSystemsLcm(unittest.TestCase):
     def test_subscriber(self):
         lcm = DrakeLcm()
         dut = mut.LcmSubscriberSystem.Make(
-            channel="TEST_CHANNEL", lcm_type=lcmt_quaternion, lcm=lcm)
+            channel="TEST_CHANNEL", lcm_type=lcmt_quaternion, lcm=lcm,
+            wait_for_message_on_initialization_timeout=0.0)
         model_message = self._model_message()
         lcm.Publish(channel="TEST_CHANNEL", buffer=model_message.encode())
         lcm.HandleSubscriptions(0)
@@ -172,7 +173,8 @@ class TestSystemsLcm(unittest.TestCase):
         lcm = DrakeLcm()
         dut = mut.LcmSubscriberSystem.Make(
             channel="TEST_CHANNEL", lcm_type=lcmt_quaternion, lcm=lcm,
-            use_cpp_serializer=True)
+            use_cpp_serializer=True,
+            wait_for_message_on_initialization_timeout=0.0)
         model_message = self._model_message()
         lcm.Publish(channel="TEST_CHANNEL", buffer=model_message.encode())
         lcm.HandleSubscriptions(0)

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -203,6 +203,7 @@ drake_cc_googletest(
     name = "lcm_subscriber_system_test",
     deps = [
         ":lcm_subscriber_system",
+        "//common/test_utilities:expect_throws_message",
         "//lcm:drake_lcm",
         "//lcm:lcmt_drake_signal_utils",
     ],

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -57,30 +57,55 @@ class LcmSubscriberSystem : public LeafSystem<double> {
    *
    * @param[in] channel The LCM channel on which to subscribe.
    *
-   * @param lcm A non-null pointer to the LCM subsystem to subscribe on.
+   * @param lcm A non-null pointer to the LCM subsystem to subscribe on. If
+   * `wait_for_message_on_initialization_timeout > 0`, then the pointer must
+   * remain valid for the lifetime of the returned system.
+   *
+   * @param wait_for_message_on_initialization_timeout Configures the behavior
+   * of initialization events (see System::ExecuteInitializationEvents() and
+   * Simulator::Initialize()) by specifying the number of seconds (wall-clock
+   * elapsed time) to wait for a new message. If this timeout is <= 0,
+   * initialization will copy any already-received messages into the Context but
+   * will not process any new messages. If this timeout is > 0, initialization
+   * will call lcm->HandleSubscriptions() until at least one message is received
+   * or until the timeout. Pass ∞ to wait indefinitely.
    */
   template <typename LcmMessage>
   static std::unique_ptr<LcmSubscriberSystem> Make(
-      const std::string& channel, drake::lcm::DrakeLcmInterface* lcm) {
+      const std::string& channel, drake::lcm::DrakeLcmInterface* lcm,
+      double wait_for_message_on_initialization_timeout = 0.0) {
     return std::make_unique<LcmSubscriberSystem>(
-        channel, std::make_unique<Serializer<LcmMessage>>(), lcm);
+        channel, std::make_unique<Serializer<LcmMessage>>(), lcm,
+        wait_for_message_on_initialization_timeout);
   }
 
   /**
    * Constructor that returns a subscriber System that provides message objects
-   * on its sole abstract-valued output port.  The type of the message object is
-   * determined by the @p serializer.
+   * on its sole abstract-valued output port.  The type of the message object
+   * is determined by the @p serializer.
    *
    * @param[in] channel The LCM channel on which to subscribe.
    *
    * @param[in] serializer The serializer that converts between byte vectors
    * and LCM message objects. Cannot be null.
    *
-   * @param lcm A non-null pointer to the LCM subsystem to subscribe on.
+   * @param lcm A non-null pointer to the LCM subsystem to subscribe on. If
+   * `wait_for_message_on_initialization_timeout > 0`, then the pointer must
+   * remain valid for the lifetime of the returned system.
+   *
+   * @param wait_for_message_on_initialization_timeout Configures the behavior
+   * of initialization events (see System::ExecuteInitializationEvents() and
+   * Simulator::Initialize()) by specifying the number of seconds (wall-clock
+   * elapsed time) to wait for a new message. If this timeout is <= 0,
+   * initialization will copy any already-received messages into the Context but
+   * will not process any new messages. If this timeout is > 0, initialization
+   * will call lcm->HandleSubscriptions() until at least one message is received
+   * or until the timeout. Pass ∞ to wait indefinitely.
    */
   LcmSubscriberSystem(const std::string& channel,
                       std::shared_ptr<const SerializerInterface> serializer,
-                      drake::lcm::DrakeLcmInterface* lcm);
+                      drake::lcm::DrakeLcmInterface* lcm,
+                      double wait_for_message_on_initialization_timeout = 0.0);
 
   ~LcmSubscriberSystem() override;
 
@@ -126,8 +151,10 @@ class LcmSubscriberSystem : public LeafSystem<double> {
                             systems::CompositeEventCollection<double>* events,
                             double* time) const final;
 
-  systems::EventStatus ProcessMessageAndStoreToAbstractState(
-      const Context<double>&, State<double>* state) const;
+  EventStatus ProcessMessageAndStoreToAbstractState(const Context<double>&,
+                                                    State<double>* state) const;
+
+  EventStatus Initialize(const Context<double>&, State<double>* state) const;
 
   // The channel on which to receive LCM messages.
   const std::string channel_;
@@ -154,6 +181,13 @@ class LcmSubscriberSystem : public LeafSystem<double> {
 
   // A little hint to help catch use-after-free.
   int magic_number_{};
+
+  // The lcm interface is (maybe) used to handle subscriptions during
+  // Initialization.
+  drake::lcm::DrakeLcmInterface* const lcm_;
+
+  // A timeout in seconds.
+  const double wait_for_message_on_initialization_timeout_;
 };
 
 }  // namespace lcm


### PR DESCRIPTION
Also supports a new opt-in ability to wait for at least one message to be received during initialization.

+@jwnimmer-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20072)
<!-- Reviewable:end -->
