### PR TITLE
[doc] Improve code block formatting in API docs

### DIFF
--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -112,3 +112,56 @@ the latter.
 
 Each build command has a corresponding test defined as part of the
 ``//doc:manual_tests`` test suite.
+
+# Custom markup
+
+Drake has a few local conventions for adding markup to documentation strings.
+
+## @experimental
+
+The ``@experimental`` command generates a documentation paragraph that opts-out
+of the [Stable API](/stable.html).
+
+## @python_detail_...
+
+In Drake Doxygen, we can collapse Python example code under an "accordion", so
+that it only appears when the user clicks to expand it. Use the Drake-specific
+custom commands ``@python_details_begin`` and ``@python_details_end``.
+Here's an example:
+
+```
+/** Some overview.
+
+A code example in C++:
+@code{.cpp}
+int foo = 123;
+fmt:print("foo={}", foo);
+@endcode
+
+A code example in Python:
+@python_details_begin
+@code{.py}
+foo = 123
+print(f"foo={foo}")
+@endcode
+@python_details_end
+
+See also https://fmt.dev/.
+*/
+```
+
+## @tparam_...
+
+``@tparam`` is a built-in Doxygen command to describe a template argument. In
+Drake, for code templated on the "scalar type", writing out the description of
+the scalar type template in every class would be onerous boilerplate. Instead,
+we have a few custom abbreviations for the common cases:
+
+```
+@tparam_default_scalar
+@tparam_nonsymbolic_scalar
+@tparam_double_only
+```
+
+See the [C++ API documentation](/doxygen_cxx/group__default__scalars.html)
+for a full description.

--- a/doc/doxygen_cxx/Doxyfile_CXX.in
+++ b/doc/doxygen_cxx/Doxyfile_CXX.in
@@ -45,7 +45,9 @@ ALIASES                = "default=@n @a Default: " \
                          "tparam_double_only=@tparam T The scalar type, which must be `double`. " \
                          "experimental=@warning This feature is considered to be **experimental** and may change or be removed at any time, without any deprecation notice ahead of time. " \
                          "pydrake_mkdoc_identifier{1}= " \
-                         "exclude_from_pydrake_mkdoc{1}= "
+                         "exclude_from_pydrake_mkdoc{1}= " \
+                         "python_details_begin=<p><span class='_python_details_begin'></span>" \
+                         "python_details_end=<span class='_python_details_end'></span></p>"
 OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO

--- a/doc/doxygen_cxx/build.py
+++ b/doc/doxygen_cxx/build.py
@@ -252,12 +252,29 @@ def _build(*, out_dir, temp_dir, modules, quick):
         ]
     _postprocess_doxygen_log(lines, check_for_errors)
 
-    # Fix the formatting of deprecation text (see drake#15619 for an example).
     extra_perl_statements = [
-        # Remove quotes around the removal date.
+        # The next stanza forms the second half of the handling for the Python
+        # "▶ Details" block (i.e., the @python_details_{begin,end} markup).
+        #
+        # Here's how it works:
+        #
+        # Our current version of Doxygen doesn't know that <details> is a valid
+        # HTML element, so if we try to put that element in a comment, it would
+        # get escaped rather than passed through. Instead, our Doxyfile macros
+        # for @python_details_begin and @python_details_end convert the markup
+        # to a <span>, which *is* passed through as raw HTML by Doxygen. Then,
+        # with the following regular expressions, we transform the two <span>s
+        # to <detail> and </detail>.
+        (r's#<p><span class="_python_details_begin"></span> </p>#'
+         r'<p><details><summary>Click to expand Python code...</summary>#;'),
+        (r's#<p> <span class="_python_details_end"></span></p>$#'
+         r'</details></p>#;'),
+
+        # Fix the formatting of deprecation text (see #15619 for an example).
+        # (1) Remove quotes around the removal date.
         r's#(removed from Drake on or after) "(....-..-..)" *\.#\1 \2.#;',
-        # Remove all quotes within the explanation text, i.e., the initial and
-        # final quotes, as well as internal quotes that might be due to C++
+        # (2) Remove all quotes within the explanation text, i.e., the initial
+        # and final quotes, as well as internal quotes that might be due to C++
         # multi-line string literals.
         # - The quotes must appear after a "_deprecatedNNNNNN" anchor.
         # - The quotes must appear before a "<br />" end-of-line.

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -243,6 +243,7 @@ class QueryObject;
  that affects geometry with one of those roles will modify the corresponding
  version. For example:
 
+ In C++:
  @code
  // Does *not* modify any version; no roles have been assigned.
  const GeometryId geometry_id = scene_graph.RegisterGeometry(
@@ -260,6 +261,27 @@ class QueryObject;
  // registered with any renderer.
  scene_graph.RemoveGeometry(source_id, geometry_id);
  @endcode
+
+ In Python:
+ @python_details_begin
+ @code{.py}
+ # Does *not* modify any version; no roles have been assigned.
+ geometry_id = scene_graph.RegisterGeometry(
+     source_id, frame_id, GeometryInstance(...))
+ # Modifies the proximity version.
+ scene_graph.AssignRole(source_id, geometry_id, ProximityProperties())
+ # Modifies the illustration version.
+ scene_graph.AssignRole(source_id, geometry_id, IllustrationProperties())
+ # Modifies the perception version if there exists a renderer that accepts the
+ # geometry.
+ scene_graph.AssignRole(source_id, geometry_id, PerceptionProperties())
+ # Modifies the illustration version.
+ scene_graph.RemoveRole(source_id, geometry_id, Role.kIllustration)
+ # Modifies proximity version and perception version if the geometry is
+ # registered with any renderer.
+ scene_graph.RemoveGeometry(source_id, geometry_id)
+ @endcode
+ @python_details_end
 
  Each copy of geometry data maintains its own set of versions.
  %SceneGraph's model has its own version, and that version is the same as the

--- a/tools/workspace/pybind11/test/mkdoc_comment_test.py
+++ b/tools/workspace/pybind11/test/mkdoc_comment_test.py
@@ -316,7 +316,7 @@ eu non diam phasellus vestibulum.
         self.assertEqual(process_comment("/// @brief Static method"),
                          "Static method")
 
-    def test_code(self):
+    def test_code_cpp(self):
         input = """\
 /// @code{.cpp}
 /// Class class();
@@ -324,10 +324,37 @@ eu non diam phasellus vestibulum.
 /// @endcode
 """.rstrip()
         output = """\
-::
+.. raw:: html
+
+    <details><summary>Click to expand C++ code...</summary>
+
+.. code-block:: c++
 
     Class class();
     class.PublicMethod();
+
+.. raw:: html
+
+    </details>
+""".rstrip()
+        self.assertEqual(process_comment(input), output)
+
+    def test_code_py(self):
+        input = """\
+/// @python_details_begin
+/// @code{.py}
+/// # This is a Python comment.
+/// foo = dict()
+/// print(foo)
+/// @endcode
+/// @python_details_end
+""".rstrip()
+        output = """\
+.. code-block:: python
+
+    # This is a Python comment.
+    foo = dict()
+    print(foo)
 """.rstrip()
         self.assertEqual(process_comment(input), output)
 


### PR DESCRIPTION
For my sense of style, this presentation layout is still a bit rough, but it seems like enough of an improvement to land now, and let others improve upon over time.  At least this solves the tricky build system parts; the rest is just html & css fu.

---

C++ sample:

<img width="50%" src="https://github.com/RobotLocomotion/drake/assets/17596505/393bbe4b-94c0-412c-83df-510662464859"/>

---

Python sample:

<img width="50%" src="https://github.com/RobotLocomotion/drake/assets/17596505/48d05218-125f-4344-a464-382156bb7cb1"/>

---

Towards #12591.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20083)
<!-- Reviewable:end -->
