### PR TITLE
[tools] Switch stl2obj to use VTK built from source

### DIFF
--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -151,8 +151,8 @@ drake_cc_binary(
         "//common:add_text_logging_gflags",
         "//common:essential",
         "@gflags",
-        "@vtk//:vtkFiltersCore",
-        "@vtk//:vtkIOGeometry",
+        "@vtk_internal//:vtkFiltersCore",
+        "@vtk_internal//:vtkIOGeometry",
     ],
 )
 

--- a/tools/workspace/vtk_internal/settings.bzl
+++ b/tools/workspace/vtk_internal/settings.bzl
@@ -225,6 +225,54 @@ MODULE_SETTINGS = {
     "VTK::CommonTransforms": {
         # This isn't used directly by Drake, but is used by other VTK modules.
     },
+    "VTK::FiltersCore": {
+        "visibility": ["//visibility:public"],
+        # This module has a lot of code we don't need. We'll opt-out of the
+        # default srcs glob, and instead just specify what Drake needs.
+        "srcs_glob_exclude": ["**"],
+        "srcs_extra": [
+            "Filters/Core/vtkAppendPolyData.cxx",
+            "Filters/Core/vtkDecimatePro.cxx",
+            "Filters/Core/vtkGlyph3D.cxx",
+            "Filters/Core/vtkPolyDataNormals.cxx",
+            "Filters/Core/vtkPolyDataTangents.cxx",
+            "Filters/Core/vtkTriangleFilter.cxx",
+        ],
+    },
+    "VTK::IOCore": {
+        "srcs_glob_exclude": [
+            # Skip code we don't need.
+            "**/*Codec*",
+            "**/*Particle*",
+            "**/*Java*",
+            "**/*UTF*",
+            # Skip this to avoid a dependency on lz4.
+            "**/*LZ4*",
+            # Skip this to avoid a dependency on lzma.
+            "**/*LZMA*",
+        ],
+        "module_deps_ignore": [
+            "VTK::lz4",
+            "VTK::lzma",
+        ],
+    },
+    "VTK::IOGeometry": {
+        "visibility": ["//visibility:public"],
+        # This module has a lot of code we don't need. We'll opt-out of the
+        # default srcs glob, and instead just specify what Drake needs.
+        "srcs_glob_exclude": ["**"],
+        "srcs_extra": [
+            "IO/Geometry/vtkOBJWriter.cxx",
+            "IO/Geometry/vtkSTLReader.cxx",
+        ],
+        "module_deps_ignore": [
+            "VTK::IOLegacy",
+            "VTK::FiltersGeneral",
+            "VTK::FiltersHybrid",
+            "VTK::RenderingCore",
+            "VTK::nlohmannjson",
+        ],
+    },
     "VTK::IOImage": {
         "visibility": ["//visibility:public"],
         # This module has a lot of code we don't need. We'll opt-out of the
@@ -300,6 +348,20 @@ MODULE_SETTINGS = {
 
     # Fourth, we'll configure dependencies that we let VTK build and vendor on
     # its own, because nothing else in Drake needs these.
+    "VTK::doubleconversion": {
+        "cmake_undefines": [
+            "VTK_MODULE_USE_EXTERNAL_vtkdoubleconversion",
+        ],
+        "hdrs_content": {
+            "ThirdParty/doubleconversion/vtkdoubleconversion_export.h": """
+                #pragma once
+                #define VTKDOUBLECONVERSION_EXPORT
+            """,
+        },
+        "srcs_glob_extra": [
+            "ThirdParty/doubleconversion/**/*.cc",
+        ],
+    },
     "VTK::pugixml": {
         # TODO(jwnimmer-tri) The only user of pugixml is vtkDataAssembly.
         # Possibly there is some way to disable XML I/O support on that


### PR DESCRIPTION
Towards #19945 and #16502.
Requires #20068.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20084)
<!-- Reviewable:end -->
