### PR TITLE
DeformableDriver uses the new FemSolver

### DIFF
--- a/multibody/fem/fem_model.cc
+++ b/multibody/fem/fem_model.cc
@@ -110,7 +110,7 @@ FemModel<T>::FemModel()
 template <typename T>
 void FemModel<T>::ThrowIfModelStateIncompatible(
     const char* func, const FemState<T>& fem_state) const {
-  if (!fem_state.is_created_from_system(*fem_state_system_)) {
+  if (!is_compatible_with(fem_state)) {
     throw std::logic_error(std::string(func) +
                            "(): The FEM model and state are not compatible.");
   }

--- a/multibody/fem/fem_model.h
+++ b/multibody/fem/fem_model.h
@@ -241,6 +241,12 @@ class FemModel {
    corresponding to this %FemModel is linear. */
   bool is_linear() const { return do_is_linear(); }
 
+  /** Returns true if the given FEM state is compatible with `this` FEM model.
+   */
+  bool is_compatible_with(const FemState<T>& state) const {
+    return state.is_created_from_system(*fem_state_system_);
+  }
+
   /** (Internal use only) Throws std::exception to report a mismatch between
   the FEM model and state that were passed to API method `func`. */
   void ThrowIfModelStateIncompatible(const char* func,

--- a/multibody/fem/test/fem_solver_test.cc
+++ b/multibody/fem/test/fem_solver_test.cc
@@ -11,7 +11,6 @@ namespace drake {
 namespace multibody {
 namespace fem {
 namespace internal {
-namespace {
 
 using Eigen::MatrixXd;
 constexpr double kTolerance = 16 * std::numeric_limits<double>::epsilon();
@@ -33,13 +32,17 @@ struct BoolWrapper {
 template <typename T>
 class FemSolverTest : public ::testing::Test {
  protected:
+  void set_max_newton_iterations(int max_iterations) {
+    solver_.max_iterations_ = max_iterations;
+  }
   DummyModel<T::value> model_{};
   AccelerationNewmarkScheme<double> integrator_{kDt, kGamma, kBeta};
   FemSolver<double> solver_{&model_, &integrator_};
 };
 
-TYPED_TEST_SUITE_P(FemSolverTest);
+namespace {
 
+TYPED_TEST_SUITE_P(FemSolverTest);
 TYPED_TEST_P(FemSolverTest, Tolerance) {
   /* Default values. */
   EXPECT_EQ(this->solver_.relative_tolerance(), 1e-4);
@@ -66,11 +69,9 @@ TYPED_TEST_P(FemSolverTest, AdvanceOneTimeStep) {
   builder.AddTwoElementsWithSharedNodes();
   builder.Build();
   std::unique_ptr<FemState<double>> state0 = this->model_.MakeFemState();
-  std::unique_ptr<FemState<double>> state = this->model_.MakeFemState();
-  FemSolverData<double> data(this->model_);
-  data.set_nonparticipating_vertices({0, 1});
+  const std::unordered_set<int> nonparticipating_vertices = {0, 1};
   const int num_iterations =
-      this->solver_.AdvanceOneTimeStep(*state0, state.get(), &data);
+      this->solver_.AdvanceOneTimeStep(*state0, nonparticipating_vertices);
   EXPECT_EQ(num_iterations, 1);
 
   /* Compute the expected result from AdvanceOneTimeStep(). */
@@ -88,31 +89,68 @@ TYPED_TEST_P(FemSolverTest, AdvanceOneTimeStep) {
   llt.compute(A0);
   const VectorX<double> dz = llt.solve(-b0);
   this->integrator_.UpdateStateFromChangeInUnknowns(dz, expected_state.get());
+  const FemState<double>& computed_state = this->solver_.next_fem_state();
   EXPECT_TRUE(CompareMatrices(expected_state->GetPositions(),
-                              state->GetPositions(), kTolerance));
+                              computed_state.GetPositions(), kTolerance));
   EXPECT_TRUE(CompareMatrices(expected_state->GetAccelerations(),
-                              state->GetAccelerations(), kTolerance));
+                              computed_state.GetAccelerations(), kTolerance));
   EXPECT_TRUE(CompareMatrices(expected_state->GetVelocities(),
-                              state->GetVelocities(), kTolerance));
+                              computed_state.GetVelocities(), kTolerance));
 
   /* Check the Schur complement is as expected. */
   auto tangent_matrix = this->model_.MakeTangentMatrix();
-  this->model_.CalcTangentMatrix(*state, this->integrator_.GetWeights(),
+  this->model_.CalcTangentMatrix(computed_state, this->integrator_.GetWeights(),
                                  tangent_matrix.get());
   contact_solvers::internal::SchurComplement
-      force_balance_tangent_matrix_schur_complement(
-          *tangent_matrix, data.nonparticipating_vertices());
-  /* Multiply by dt to get the schur complement of the tangent matrix of the
-   momentum balance. */
+      force_balance_tangent_matrix_schur_complement(*tangent_matrix,
+                                                    nonparticipating_vertices);
   const MatrixXd expected_schur_complement =
       force_balance_tangent_matrix_schur_complement.get_D_complement();
+  const contact_solvers::internal::SchurComplement& computed_schur_complement =
+      this->solver_.next_schur_complement();
   EXPECT_TRUE(CompareMatrices(expected_schur_complement,
-                              data.schur_complement().get_D_complement(),
+                              computed_schur_complement.get_D_complement(),
                               kTolerance, MatrixCompareType::relative));
 }
 
+/* Tests that AdvanceOneTimeStep for nonlinear models throws an error message if
+ * the Newton solver doesn't converge within the max number of iterations. */
+TYPED_TEST_P(FemSolverTest, Nonconvergence) {
+  constexpr bool is_linear = TypeParam::value;
+  if (!is_linear) {
+    typename DummyModel<is_linear>::DummyBuilder builder(&this->model_);
+    builder.AddTwoElementsWithSharedNodes();
+    builder.Build();
+    std::unique_ptr<FemState<double>> state0 = this->model_.MakeFemState();
+    const std::unordered_set<int> nonparticipating_vertices = {0, 1};
+    /* We set up the model so that nonlinear solves takes exactly one iteration
+     to converge. */
+    this->set_max_newton_iterations(0);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        this->solver_.AdvanceOneTimeStep(*state0, nonparticipating_vertices),
+        ".*failed.*");
+  }
+}
+
+TYPED_TEST_P(FemSolverTest, DefaultStateAndSchurComplement) {
+  std::unique_ptr<FemState<double>> default_state = this->model_.MakeFemState();
+  const FemState<double>& next_state = this->solver_.next_fem_state();
+
+  EXPECT_TRUE(CompareMatrices(default_state->GetPositions(),
+                              next_state.GetPositions()));
+  EXPECT_TRUE(CompareMatrices(default_state->GetAccelerations(),
+                              next_state.GetAccelerations()));
+  EXPECT_TRUE(CompareMatrices(default_state->GetVelocities(),
+                              next_state.GetVelocities()));
+  const contact_solvers::internal::SchurComplement next_schur_complement =
+      this->solver_.next_schur_complement();
+  EXPECT_EQ(next_schur_complement.get_D_complement().rows(), 0);
+  EXPECT_EQ(next_schur_complement.get_D_complement().cols(), 0);
+}
+
 using AllTypes = ::testing::Types<BoolWrapper<true>, BoolWrapper<false>>;
-REGISTER_TYPED_TEST_SUITE_P(FemSolverTest, Tolerance, AdvanceOneTimeStep);
+REGISTER_TYPED_TEST_SUITE_P(FemSolverTest, Tolerance, AdvanceOneTimeStep,
+                            Nonconvergence, DefaultStateAndSchurComplement);
 INSTANTIATE_TYPED_TEST_SUITE_P(LinearAndNonLinear, FemSolverTest, AllTypes);
 
 }  // namespace

--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -12,7 +12,6 @@
 #include "drake/multibody/contact_solvers/contact_configuration.h"
 #include "drake/multibody/fem/dirichlet_boundary_condition.h"
 #include "drake/multibody/fem/fem_model.h"
-#include "drake/multibody/fem/fem_solver.h"
 #include "drake/multibody/fem/velocity_newmark_scheme.h"
 #include "drake/multibody/plant/contact_properties.h"
 #include "drake/systems/framework/context.h"
@@ -26,13 +25,11 @@ using drake::multibody::contact_solvers::internal::ContactConfiguration;
 using drake::multibody::contact_solvers::internal::ContactSolverResults;
 using drake::multibody::contact_solvers::internal::MatrixBlock;
 using drake::multibody::contact_solvers::internal::PartialPermutation;
+using drake::multibody::contact_solvers::internal::SchurComplement;
 using drake::multibody::fem::FemModel;
 using drake::multibody::fem::FemState;
 using drake::multibody::fem::internal::DirichletBoundaryCondition;
 using drake::multibody::fem::internal::FemSolver;
-using drake::multibody::fem::internal::FemSolverData;
-using drake::multibody::fem::internal::PetscSymmetricBlockSparseMatrix;
-using drake::multibody::fem::internal::SchurComplement;
 using drake::systems::Context;
 
 namespace drake {
@@ -112,94 +109,6 @@ void DeformableDriver<T>::DeclareCacheEntries(
         {systems::System<T>::xd_ticket()});
     cache_indexes_.fem_states.emplace_back(fem_state_cache_entry.cache_index());
 
-    /* Cache entry for free motion FEM state. */
-    const auto& free_motion_fem_state_cache_entry = manager->DeclareCacheEntry(
-        fmt::format("free motion FEM state for body with index {}", i),
-        systems::ValueProducer(
-            *model_state,
-            std::function<void(const systems::Context<T>&, fem::FemState<T>*)>{
-                [this, i](const systems::Context<T>& context,
-                          fem::FemState<T>* free_motion_state) {
-                  this->CalcFreeMotionFemState(context, i, free_motion_state);
-                }}),
-        {fem_state_cache_entry.ticket()});
-    cache_indexes_.free_motion_fem_states.emplace_back(
-        free_motion_fem_state_cache_entry.cache_index());
-
-    /* Cache entry for FEM state at next time step. */
-    const auto& next_fem_state_cache_entry = manager->DeclareCacheEntry(
-        fmt::format("FEM state for body with index {} at next time step", i),
-        systems::ValueProducer(
-            *model_state,
-            std::function<void(const systems::Context<T>&, fem::FemState<T>*)>{
-                [this, i](const systems::Context<T>& context,
-                          fem::FemState<T>* next_fem_state) {
-                  this->CalcNextFemState(context, i, next_fem_state);
-                }}),
-        {systems::SystemBase::all_sources_ticket()});
-    cache_indexes_.next_fem_states.emplace_back(
-        next_fem_state_cache_entry.cache_index());
-
-    /* Solver data for each FEM model. */
-    FemSolverData solver_data(fem_model);
-    const auto& solver_data_entry = manager->DeclareCacheEntry(
-        fmt::format("FEM solver data for body with index {}", i),
-        systems::ValueProducer(solver_data, &systems::ValueProducer::NoopCalc),
-        {systems::SystemBase::nothing_ticket()});
-    cache_indexes_.fem_solver_data.emplace_back(
-        solver_data_entry.cache_index());
-
-    /* Cache entry for the tangent matrix at free motion state. */
-    std::unique_ptr<PetscSymmetricBlockSparseMatrix> model_tangent_matrix =
-        fem_model.MakePetscSymmetricBlockSparseTangentMatrix();
-    model_tangent_matrix->AssembleIfNecessary();
-    const auto& free_motion_tangent_matrix_cache_entry =
-        manager->DeclareCacheEntry(
-            fmt::format("free motion tangent matrix for body with index {}", i),
-            systems::ValueProducer(
-                *model_tangent_matrix,
-                std::function<void(const systems::Context<T>&,
-                                   PetscSymmetricBlockSparseMatrix*)>{
-                    [this, i](const systems::Context<T>& context,
-                              PetscSymmetricBlockSparseMatrix* tangent_matrix) {
-                      this->CalcFreeMotionTangentMatrix(context, i,
-                                                        tangent_matrix);
-                    }}),
-            {free_motion_fem_state_cache_entry.ticket()});
-    cache_indexes_.free_motion_tangent_matrices.emplace_back(
-        free_motion_tangent_matrix_cache_entry.cache_index());
-
-    const auto& schur_complement_cache_entry = manager->DeclareCacheEntry(
-        fmt::format("free motion tangent matrix Schur complement for body "
-                    "with index {}",
-                    i),
-        systems::ValueProducer(std::function<void(const systems::Context<T>&,
-                                                  SchurComplement<T>*)>{
-            [this, i](const systems::Context<T>& context,
-                      SchurComplement<T>* schur_complement) {
-              this->CalcFreeMotionTangentMatrixSchurComplement(
-                  context, i, schur_complement);
-            }}),
-        {free_motion_tangent_matrix_cache_entry.ticket(),
-         deformable_contact_cache_entry.ticket()});
-    cache_indexes_.free_motion_tangent_matrix_schur_complements.emplace_back(
-        schur_complement_cache_entry.cache_index());
-
-    /* Permutation for participating dofs for each body. */
-    const auto& dof_permutation_cache_entry = manager->DeclareCacheEntry(
-        fmt::format("partial permutation for dofs of body {} based on "
-                    "participation in contact",
-                    i),
-        systems::ValueProducer(
-            std::function<void(const Context<T>&, PartialPermutation*)>{
-                [this, i](const Context<T>& context,
-                          PartialPermutation* result) {
-                  this->CalcDofPermutation(context, i, result);
-                }}),
-        {deformable_contact_cache_entry.ticket()});
-    cache_indexes_.dof_permutations.emplace_back(
-        dof_permutation_cache_entry.cache_index());
-
     /* Permutation for participating vertices for each body. */
     const GeometryId g_id =
         deformable_model_->GetGeometryId(deformable_model_->GetBodyId(i));
@@ -216,6 +125,51 @@ void DeformableDriver<T>::DeclareCacheEntries(
         {deformable_contact_cache_entry.ticket()});
     cache_indexes_.vertex_permutations.emplace(
         g_id, vertex_permutation_cache_entry.cache_index());
+
+    FemSolver<T> model_fem_solver(&fem_model, integrator_.get());
+    /* Cache entry for free motion FEM state and data. */
+    const auto& fem_solver_cache_entry = manager->DeclareCacheEntry(
+        fmt::format("FEM solver and data for body with index {}", i),
+        systems::ValueProducer(
+            model_fem_solver,
+            std::function<void(const systems::Context<T>&, FemSolver<T>*)>{
+                [this, i](const systems::Context<T>& context,
+                          FemSolver<T>* fem_solver) {
+                  this->CalcFreeMotionFemSolver(context, i, fem_solver);
+                }}),
+        {fem_state_cache_entry.ticket(),
+         vertex_permutation_cache_entry.ticket()});
+    cache_indexes_.fem_solvers.emplace_back(
+        fem_solver_cache_entry.cache_index());
+
+    /* Cache entry for FEM state at next time step. */
+    const auto& next_fem_state_cache_entry = manager->DeclareCacheEntry(
+        fmt::format("FEM state for body with index {} at next time step", i),
+        systems::ValueProducer(
+            *model_state,
+            std::function<void(const systems::Context<T>&, fem::FemState<T>*)>{
+                [this, i](const systems::Context<T>& context,
+                          fem::FemState<T>* next_fem_state) {
+                  this->CalcNextFemState(context, i, next_fem_state);
+                }}),
+        {systems::SystemBase::all_sources_ticket()});
+    cache_indexes_.next_fem_states.emplace_back(
+        next_fem_state_cache_entry.cache_index());
+
+    /* Permutation for participating dofs for each body. */
+    const auto& dof_permutation_cache_entry = manager->DeclareCacheEntry(
+        fmt::format("partial permutation for dofs of body {} based on "
+                    "participation in contact",
+                    i),
+        systems::ValueProducer(
+            std::function<void(const Context<T>&, PartialPermutation*)>{
+                [this, i](const Context<T>& context,
+                          PartialPermutation* result) {
+                  this->CalcDofPermutation(context, i, result);
+                }}),
+        {deformable_contact_cache_entry.ticket()});
+    cache_indexes_.dof_permutations.emplace_back(
+        dof_permutation_cache_entry.cache_index());
   }
 }
 
@@ -225,9 +179,13 @@ void DeformableDriver<T>::AppendLinearDynamicsMatrix(
   DRAKE_DEMAND(A != nullptr);
   const int num_bodies = deformable_model_->num_bodies();
   for (DeformableBodyIndex index(0); index < num_bodies; ++index) {
-    const SchurComplement<T>& schur_complement =
+    const SchurComplement& schur_complement =
         EvalFreeMotionTangentMatrixSchurComplement(context, index);
-    A->emplace_back(schur_complement.get_D_complement());
+    /* The schur complement is of the tangent matrix of the force balance
+     * whereas the linear dyanmics matrix requires the tangnet matrix of the
+     * momentum balance. Hence, we scale by dt here. */
+    A->push_back(schur_complement.get_D_complement() *
+                 manager_->plant().time_step());
   }
 }
 
@@ -524,27 +482,46 @@ const FemState<T>& DeformableDriver<T>::EvalFemState(
 }
 
 template <typename T>
-void DeformableDriver<T>::CalcFreeMotionFemState(
+void DeformableDriver<T>::CalcFreeMotionFemSolver(
     const systems::Context<T>& context, DeformableBodyIndex index,
-    FemState<T>* fem_state_star) const {
+    FemSolver<T>* fem_solver) const {
+  const DeformableBodyId body_id = deformable_model_->GetBodyId(index);
+  const GeometryId geometry_id = deformable_model_->GetGeometryId(body_id);
   const FemState<T>& fem_state = EvalFemState(context, index);
-  const DeformableBodyId id = deformable_model_->GetBodyId(index);
-  const FemModel<T>& model = deformable_model_->GetFemModel(id);
-  const FemSolver<T> solver(&model, integrator_.get());
-  FemSolverData<T>& solver_data =
-      manager_->plant()
-          .get_cache_entry(cache_indexes_.fem_solver_data.at(index))
-          .get_mutable_cache_entry_value(context)
-          .template GetMutableValueOrThrow<FemSolverData<T>>();
-  solver.AdvanceOneTimeStep(fem_state, fem_state_star, &solver_data);
+  /* Write the non-participating vertices. */
+  std::unordered_set<int> nonparticipating_vertices;
+  const PartialPermutation& permutation =
+      EvalVertexPermutation(context, geometry_id);
+  DRAKE_DEMAND(3 * permutation.domain_size() == fem_state.num_dofs());
+  for (int v = 0; v < permutation.domain_size(); ++v) {
+    if (!permutation.participates(v)) {
+      nonparticipating_vertices.insert(v);
+    }
+  }
+  fem_solver->AdvanceOneTimeStep(fem_state, nonparticipating_vertices);
+}
+
+template <typename T>
+const FemSolver<T>& DeformableDriver<T>::EvalFreeMotionFemSolver(
+    const systems::Context<T>& context, DeformableBodyIndex index) const {
+  return manager_->plant()
+      .get_cache_entry(cache_indexes_.fem_solvers.at(index))
+      .template Eval<FemSolver<T>>(context);
 }
 
 template <typename T>
 const FemState<T>& DeformableDriver<T>::EvalFreeMotionFemState(
     const systems::Context<T>& context, DeformableBodyIndex index) const {
-  return manager_->plant()
-      .get_cache_entry(cache_indexes_.free_motion_fem_states.at(index))
-      .template Eval<FemState<T>>(context);
+  const FemSolver<T>& fem_solver = EvalFreeMotionFemSolver(context, index);
+  return fem_solver.next_fem_state();
+}
+
+template <typename T>
+const SchurComplement&
+DeformableDriver<T>::EvalFreeMotionTangentMatrixSchurComplement(
+    const systems::Context<T>& context, DeformableBodyIndex index) const {
+  const FemSolver<T>& fem_solver = EvalFreeMotionFemSolver(context, index);
+  return fem_solver.next_schur_complement();
 }
 
 template <typename T>
@@ -557,7 +534,6 @@ void DeformableDriver<T>::CalcNextFemState(const systems::Context<T>& context,
   const ContactParticipation& participation =
       contact_data.contact_participation(g_id);
   if (participation.num_vertices_in_contact() == 0) {
-    // TODO(xuchenhan-tri): Account for constraints when we support them.
     /* The next states are the free motion states if no vertex of the
      deformable body participates in contact. */
     const FemState<T>& free_motion_state =
@@ -587,10 +563,10 @@ void DeformableDriver<T>::CalcNextFemState(const systems::Context<T>& context,
         body_participating_v_next - body_participating_v_star;
     /* Compute the value of the post-constraint non-participating
      velocities using Schur complement. */
-    const SchurComplement<T>& schur_complement =
+    const SchurComplement& schur_complement =
         EvalFreeMotionTangentMatrixSchurComplement(context, index);
     const VectorX<T> body_nonparticipating_dv =
-        schur_complement.SolveForY(body_participating_dv);
+        schur_complement.SolveForX(body_participating_dv);
     /* Concatenate the participating and non-participating velocities and
      then apply the inverse permutation to put the dofs in their original
      order. */
@@ -738,75 +714,6 @@ const VectorX<T>& DeformableDriver<T>::EvalParticipatingFreeMotionVelocities(
   return manager_->plant()
       .get_cache_entry(cache_indexes_.participating_free_motion_velocities)
       .template Eval<VectorX<T>>(context);
-}
-
-template <typename T>
-void DeformableDriver<T>::CalcFreeMotionTangentMatrix(
-    const systems::Context<T>& context, DeformableBodyIndex index,
-    PetscSymmetricBlockSparseMatrix* tangent_matrix) const {
-  DRAKE_DEMAND(tangent_matrix != nullptr);
-  const DeformableBodyId id = deformable_model_->GetBodyId(index);
-  const FemModel<T>& fem_model = deformable_model_->GetFemModel(id);
-  const FemState<T>& fem_state_star = EvalFreeMotionFemState(context, index);
-  /* Multiply by dt because we need the tangent matrix of the momentum balance
-   instead of the force balance. */
-  fem_model.CalcTangentMatrix(
-      fem_state_star, manager_->plant().time_step() * integrator_->GetWeights(),
-      tangent_matrix);
-  tangent_matrix->AssembleIfNecessary();
-}
-
-template <typename T>
-const PetscSymmetricBlockSparseMatrix&
-DeformableDriver<T>::EvalFreeMotionTangentMatrix(
-    const systems::Context<T>& context, DeformableBodyIndex index) const {
-  return manager_->plant()
-      .get_cache_entry(cache_indexes_.free_motion_tangent_matrices.at(index))
-      .template Eval<PetscSymmetricBlockSparseMatrix>(context);
-}
-
-template <typename T>
-void DeformableDriver<T>::CalcFreeMotionTangentMatrixSchurComplement(
-    const systems::Context<T>& context, DeformableBodyIndex index,
-    SchurComplement<T>* result) const {
-  DRAKE_DEMAND(result != nullptr);
-  const DeformableContact<T>& contact_data = EvalDeformableContact(context);
-  const DeformableBodyId body_id = deformable_model_->GetBodyId(index);
-  const GeometryId geometry_id = deformable_model_->GetGeometryId(body_id);
-  /* Avoid the expensive tangent matrix and Schur complement calculation if
-   there's no contact at all. */
-  const ContactParticipation& body_contact_participation =
-      contact_data.contact_participation(geometry_id);
-  if (body_contact_participation.num_vertices_in_contact() == 0) {
-    *result = SchurComplement<T>();
-    return;
-  }
-  const PetscSymmetricBlockSparseMatrix& tangent_matrix =
-      EvalFreeMotionTangentMatrix(context, index);
-  std::vector<int> participating_vertices;
-  std::vector<int> non_participating_vertices;
-  const PartialPermutation& permutation =
-      EvalVertexPermutation(context, geometry_id);
-  DRAKE_DEMAND(3 * permutation.domain_size() == tangent_matrix.cols());
-  for (int v = 0; v < permutation.domain_size(); ++v) {
-    if (permutation.participates(v)) {
-      participating_vertices.emplace_back(v);
-    } else {
-      non_participating_vertices.emplace_back(v);
-    }
-  }
-  *result = tangent_matrix.CalcSchurComplement(non_participating_vertices,
-                                               participating_vertices);
-}
-
-template <typename T>
-const SchurComplement<T>&
-DeformableDriver<T>::EvalFreeMotionTangentMatrixSchurComplement(
-    const systems::Context<T>& context, DeformableBodyIndex index) const {
-  return manager_->plant()
-      .get_cache_entry(
-          cache_indexes_.free_motion_tangent_matrix_schur_complements.at(index))
-      .template Eval<SchurComplement<T>>(context);
 }
 
 template class DeformableDriver<double>;


### PR DESCRIPTION
FemSolver stores the scratch data and the solution as data members to ensure compatibility of with the FEM model being solved for.
As a result, `FemSolver::AdvanceOneTimeStep()` only takes the previous FEM state and the set of non-participating vertices as input and FemSolver offers a `next_state_and_schur_complement()` function to inspect the solution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20086)
<!-- Reviewable:end -->
