### PR TITLE
[sensors] Fix exception from empty renderer_class config

### DIFF
--- a/systems/sensors/camera_config_functions.cc
+++ b/systems/sensors/camera_config_functions.cc
@@ -63,8 +63,6 @@ const std::string& LookupEngineType(const std::string& class_name) {
   using Dict = std::map<std::string, std::string>;
   static const never_destroyed<Dict> type_lookup(
       std::initializer_list<Dict::value_type>{
-          {"",  // Empty string defaults to RenderEngineVtk.
-           "drake::geometry::render_vtk::internal::RenderEngineVtk"},
           {"RenderEngineVtk",
            "drake::geometry::render_vtk::internal::RenderEngineVtk"},
           {"RenderEngineGl",
@@ -139,7 +137,8 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
     std::visit(
         overloaded{
             [&type_name, &config](const std::string& class_name) -> void {
-              if (LookupEngineType(class_name) != type_name) {
+              if (!class_name.empty() &&
+                  LookupEngineType(class_name) != type_name) {
                 throw std::logic_error(fmt::format(
                     "Invalid camera configuration; requested renderer_name "
                     "= '{}' and renderer_class = '{}'. The name is already "
@@ -148,13 +147,12 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
               }
             },
             [&config](auto&&) -> void {
-              throw std::logic_error(
-                  fmt::format("Invalid camera configuration; requested "
-                              "renderer_name = '{}' with renderer parameters, "
-                              "but the named renderer already exists. Only the "
-                              "first instance of the named renderer can use "
-                              "parameters.",
-                              config.renderer_name));
+              throw std::logic_error(fmt::format(
+                  "Invalid camera configuration; requested renderer_name "
+                  " = '{}' with renderer parameters, but the named renderer "
+                  "already exists. Only the first instance of the named "
+                  "renderer can use parameters.",
+                  config.renderer_name));
             }},
         config.renderer_class);
   }

--- a/systems/sensors/test/camera_config_functions_test.cc
+++ b/systems/sensors/test/camera_config_functions_test.cc
@@ -317,7 +317,7 @@ TEST_F(CameraConfigFunctionsTest, RendererNameReuse) {
     EXPECT_NO_THROW(ApplyCameraConfig(config, &builder_));
     EXPECT_EQ(scene_graph_->RendererCount(), renderer_count);
 
-    // Using an empty class name means "don't care", so it also happy.
+    // Using an empty class name means "don't care", so is also happy.
     config.name = name + "_emtpy_class_name_succeeds";
     config.renderer_class = "";
     EXPECT_NO_THROW(ApplyCameraConfig(config, &builder_));

--- a/systems/sensors/test/camera_config_functions_test.cc
+++ b/systems/sensors/test/camera_config_functions_test.cc
@@ -317,6 +317,12 @@ TEST_F(CameraConfigFunctionsTest, RendererNameReuse) {
     EXPECT_NO_THROW(ApplyCameraConfig(config, &builder_));
     EXPECT_EQ(scene_graph_->RendererCount(), renderer_count);
 
+    // Using an empty class name means "don't care", so it also happy.
+    config.name = name + "_emtpy_class_name_succeeds";
+    config.renderer_class = "";
+    EXPECT_NO_THROW(ApplyCameraConfig(config, &builder_));
+    EXPECT_EQ(scene_graph_->RendererCount(), renderer_count);
+
     // Camera config using the name of a different class is angry.
     config.name = name + "_wrong_class_name_throws";
     config.renderer_class = name == "RenderEngineVtk" ? "RenderEngineGltfClient"
@@ -573,14 +579,6 @@ TEST_F(CameraConfigFunctionsTest, RenderEngineRequest) {
                        .renderer_class = "RenderEngineGl"},
           &builder_),
       ".*The name is already used with a different type.+");
-
-  // Using existing name but *no* render engine uses existing engine. Call to
-  // ApplyCameraConfig doesn't throw, and the renderer count doesn't change.
-  // This test assumes that this behavior doesn't depend on the type of the
-  // RenderEngine.
-  current_renderer_count = scene_graph_->RendererCount();
-  ApplyCameraConfig(CameraConfig{.renderer_name = "vtk_renderer"}, &builder_);
-  EXPECT_EQ(current_renderer_count, scene_graph_->RendererCount());
 
   // Now explicitly request a new RenderEngineGl -- whether it throws depends
   // on whether GL is available.


### PR DESCRIPTION
When the renderer_class is empty, no engine type cross-checks should be performed.

Amends #19863.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20087)
<!-- Reviewable:end -->
