### PR TITLE
[manipulation_station] Assign missing texture colors

### DIFF
--- a/examples/manipulation_station/models/bin.sdf
+++ b/examples/manipulation_station/models/bin.sdf
@@ -28,6 +28,9 @@
             <size>0.05 0.63 0.21</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <collision name="front">
         <pose>0.22 0 0.105 0 0 0</pose>
@@ -36,6 +39,9 @@
             <size>0.05 0.63 0.21</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </collision>
       <visual name="slope">
         <pose>0.182 0 0.102 0 0.35 0</pose>
@@ -44,6 +50,9 @@
             <size>0.05 0.63 0.21</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <collision name="slope">
         <pose>0.182 0 0.102 0 0.35 0</pose>
@@ -60,6 +69,9 @@
             <size>0.05 0.63 0.21</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <collision name="back">
         <pose>-0.22 0 0.105 0 0 0</pose>
@@ -76,6 +88,9 @@
             <size>0.49 0.05 0.21</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <collision name="left">
         <pose>0 0.29 0.105 0 0 0</pose>
@@ -92,6 +107,9 @@
             <size>0.49 0.05 0.21</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <collision name="right">
         <pose>0 -0.29 0.105 0 0 0</pose>
@@ -100,6 +118,9 @@
             <size>0.49 0.05 0.21</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </collision>
       <visual name="bottom">
         <pose>0.0 0.0 0.0075 0 0 0</pose>
@@ -108,6 +129,9 @@
             <size>0.49 0.63 0.015</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <collision name="bottom">
         <pose>0.0 0.0 0.0075 0 0 0</pose>

--- a/examples/manipulation_station/models/cupboard.sdf
+++ b/examples/manipulation_station/models/cupboard.sdf
@@ -9,6 +9,9 @@
             <size>0.3 0.016 0.783</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <visual name="left_wall">
         <pose> 0 -0.292 0 0 0 0</pose>
@@ -17,6 +20,9 @@
             <size>0.3 0.016 0.783</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <collision name="right_wall">
         <pose> 0 0.292 0 0 0 0</pose>
@@ -43,6 +49,9 @@
             <size>0.3 0.6 0.016</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <visual name="top">
         <pose> 0 0 0.3995 0 0 0</pose>
@@ -51,6 +60,9 @@
             <size>0.3 0.6 0.016</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <visual name="shelf_lower">
         <pose> 0 0 -0.13115 0 0 0</pose>
@@ -59,6 +71,9 @@
             <size>0.3 0.6 0.016</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <visual name="shelf_upper">
         <pose> 0 0 0.13115 0 0 0</pose>
@@ -67,6 +82,9 @@
             <size>0.3 0.6 0.016</size>
           </box>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <collision name="bottom">
         <pose> 0 0 -0.3995 0 0 0</pose>
@@ -142,6 +160,9 @@
             <radius>0.005</radius>
           </cylinder>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <visual name="slab">
         <geometry>
@@ -206,6 +227,9 @@
             <radius>0.005</radius>
           </cylinder>
         </geometry>
+        <material>
+          <diffuse>0.9 0.9 0.9 1.0</diffuse>
+        </material>
       </visual>
       <visual name="slab">
         <geometry>


### PR DESCRIPTION
Some primitive surfaces had no color assigned, so they would show up as orange with VTK render engine.