### PR TITLE
[workspace] Use hidden symbols for our build of vtksys

### DIFF
--- a/tools/workspace/vtk_internal/patches/vtksys_hidden.patch
+++ b/tools/workspace/vtk_internal/patches/vtksys_hidden.patch
@@ -1,0 +1,92 @@
+[vtk] Set vtksys to hidden visibility
+
+The vtksys library doesn't obey the VTK_ABI_NAMESPACE macros, so it's
+an ODR hazard versus other non-Drake builds of VTK. Switch it to use
+hidden visibility to help mitigate the risk.
+
+--- Utilities/KWSys/vtksys/Configure.h.in
++++ Utilities/KWSys/vtksys/Configure.h.in
+@@ -39,7 +39,7 @@
+ #    define @KWSYS_NAMESPACE@_EXPORT
+ #  endif
+ #else
+-#  define @KWSYS_NAMESPACE@_EXPORT
++#  define @KWSYS_NAMESPACE@_EXPORT __attribute__((visibility("hidden")))
+ #endif
+ 
+ /* Enable warnings that are off by default but are useful.  */
+
+--- Utilities/KWSys/vtksys/Directory.cxx
++++ Utilities/KWSys/vtksys/Directory.cxx
+@@ -36,7 +36,7 @@
+ 
+ namespace KWSYS_NAMESPACE {
+ 
+-class DirectoryInternals
++class __attribute__((visibility("hidden"))) DirectoryInternals
+ {
+ public:
+   struct FileData
+
+--- Utilities/KWSys/vtksys/RegularExpression.cxx
++++ Utilities/KWSys/vtksys/RegularExpression.cxx
+@@ -290,7 +290,7 @@ static char* const regdummyptr = &regdummy;
+ /*
+  * Utility class for RegularExpression::compile().
+  */
+-class RegExpCompile
++class __attribute__((visibility("hidden"))) RegExpCompile
+ {
+ public:
+   const char* regparse; // Input-scan pointer.
+@@ -841,7 +841,7 @@ void RegExpCompile::regoptail(char* p, const char* val)
+ /*
+  * Utility class for RegularExpression::find().
+  */
+-class RegExpFind
++class __attribute__((visibility("hidden"))) RegExpFind
+ {
+ public:
+   const char* reginput;   // String-input pointer.
+
+--- Utilities/KWSys/vtksys/SystemInformation.cxx
++++ Utilities/KWSys/vtksys/SystemInformation.cxx
+@@ -266,7 +266,7 @@ using SigAction = void (*)(int, siginfo_t*, void*);
+ //  Define SystemInformationImplementation class
+ using DELAY_FUNC = void (*)(unsigned int);
+ 
+-class SystemInformationImplementation
++class __attribute__((visibility("hidden"))) SystemInformationImplementation
+ {
+ public:
+   SystemInformationImplementation();
+@@ -1202,7 +1202,7 @@ void StacktraceSignalHandler(int sigNo, siginfo_t* sigInfo,
+ // Description:
+ // A container for symbol properties. Each instance
+ // must be Initialized.
+-class SymbolProperties
++class __attribute__((visibility("hidden"))) SymbolProperties
+ {
+ public:
+   SymbolProperties();
+
+--- Utilities/KWSys/vtksys/SystemTools.cxx
++++ Utilities/KWSys/vtksys/SystemTools.cxx
+@@ -475,7 +475,7 @@ struct kwsysEnvCompare
+   }
+ };
+ 
+-class kwsysEnvSet : public std::set<const envchar*, kwsysEnvCompare>
++class __attribute__((visibility("hidden"))) kwsysEnvSet : public std::set<const envchar*, kwsysEnvCompare>
+ {
+ public:
+   class Free
+@@ -524,7 +524,7 @@ struct SystemToolsPathCaseCmp
+ /**
+  * SystemTools static variables singleton class.
+  */
+-class SystemToolsStatic
++class __attribute__((visibility("hidden"))) SystemToolsStatic
+ {
+ public:
+   using StringMap = std::map<std::string, std::string>;

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -10,6 +10,9 @@ load(
 def parse_module(repo_ctx, subdir):
     """Parses and returns a vtk.module file as a dict.
 
+    For an overview of VTK modules, see:
+    https://github.com/Kitware/VTK/blob/v9.2.6/Documentation/Doxygen/ModuleSystem.md#modules
+
     An upstream `Foo/Bar/vtk.module` file is formatted like this:
     NAME
       VTK::FooBar
@@ -145,6 +148,7 @@ vtk_internal_repository = repository_rule(
                 "@drake//tools/workspace/vtk_internal:patches/common_core_warnings.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/common_data_model_warnings.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/io_image_formats.patch",  # noqa
+                "@drake//tools/workspace/vtk_internal:patches/vtksys_hidden.patch",  # noqa
             ],
         ),
         "extra_strip_prefix": attr.string(),

--- a/tools/workspace/vtk_internal/settings.bzl
+++ b/tools/workspace/vtk_internal/settings.bzl
@@ -29,17 +29,18 @@ MODULE_SETTINGS = {
         # Upstream, this module has opt-in flags for each small feature within
         # the module. The VTK CMake script chooses which features to enable. To
         # match that logic here, we'll opt-out the default srcs glob and opt-in
-        # to specific files that match how upstream VTK configures KWSys.
+        # to specific files that match how upstream VTK configures KWSys (with
+        # exceptions noted inline below).
         "srcs_glob_exclude": ["**"],
         "srcs_extra": [
             "Utilities/KWSys/vtksys/Base64.c",
-            "Utilities/KWSys/vtksys/CommandLineArguments.cxx",
+            # CommandLineArguments.cxx is unused in Drake, so is omitted here.
             "Utilities/KWSys/vtksys/Directory.cxx",
             "Utilities/KWSys/vtksys/DynamicLoader.cxx",
             "Utilities/KWSys/vtksys/EncodingC.c",
             "Utilities/KWSys/vtksys/EncodingCXX.cxx",
             "Utilities/KWSys/vtksys/FStream.cxx",
-            "Utilities/KWSys/vtksys/Glob.cxx",
+            # Glob.cxx is unused in Drake, so is omitted here.
             "Utilities/KWSys/vtksys/MD5.c",
             "Utilities/KWSys/vtksys/ProcessUNIX.c",
             "Utilities/KWSys/vtksys/RegularExpression.cxx",
@@ -243,6 +244,7 @@ MODULE_SETTINGS = {
         "srcs_glob_exclude": [
             # Skip code we don't need.
             "**/*Codec*",
+            "**/*Glob*",
             "**/*Particle*",
             "**/*Java*",
             "**/*UTF*",


### PR DESCRIPTION
Towards #19945.
Amends #20068.
See also #19965.

+@rpoyner-tri for both reviews, please.

FYI In local testing (of the full PR 19945), this is the command I used to look for problems:
```console
nm -a bazel-bin/tools/install/libdrake/libdrake.so |
  grep vtksys |
  sed -e 's#^................ ##' |
  grep -E '[A-Z] ' |
  sort -u |
  less
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20097)
<!-- Reviewable:end -->
