### PR TITLE
[math] Rewrite the DARE solver to use a faster algorithm

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -109,9 +109,11 @@ drake_cc_library(
     srcs = ["discrete_algebraic_riccati_equation.cc"],
     hdrs = ["discrete_algebraic_riccati_equation.h"],
     deps = [
-        ":autodiff",
         "//common:essential",
         "//common:is_approx_equal_abstol",
+        # TODO(jwnimmer-tri) Move this code into //math to avoid the circular
+        # dependency.
+        "//systems/primitives:linear_system_internal",
     ],
 )
 

--- a/math/discrete_algebraic_riccati_equation.cc
+++ b/math/discrete_algebraic_riccati_equation.cc
@@ -1,455 +1,169 @@
 #include "drake/math/discrete_algebraic_riccati_equation.h"
 
+#include <Eigen/Cholesky>
+#include <Eigen/Eigenvalues>
+#include <Eigen/LU>
+#include <Eigen/QR>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/is_approx_equal_abstol.h"
 
-namespace drake {
-namespace math {
+namespace drake::math {
+
 namespace {
-/* helper functions */
-template <typename T>
-int sgn(T val) {
-  return (T(0) < val) - (val < T(0));
-}
-void check_stabilizable(const Eigen::Ref<const Eigen::MatrixXd>& A,
-                        const Eigen::Ref<const Eigen::MatrixXd>& B) {
-  // This function checks if (A,B) is a stabilizable pair.
-  // (A,B) is stabilizable if and only if the uncontrollable eigenvalues of
-  // A, if any, have absolute values less than one, where an eigenvalue is
-  // uncontrollable if Rank[lambda * I - A, B] < n.
-  int n = B.rows(), m = B.cols();
-  Eigen::EigenSolver<Eigen::MatrixXd> es(A);
-  for (int i = 0; i < n; i++) {
-    if (es.eigenvalues()[i].real() * es.eigenvalues()[i].real() +
-            es.eigenvalues()[i].imag() * es.eigenvalues()[i].imag() <
-        1)
-      continue;
-    Eigen::MatrixXcd E(n, n + m);
-    E << es.eigenvalues()[i] * Eigen::MatrixXcd::Identity(n, n) - A, B;
-    Eigen::ColPivHouseholderQR<Eigen::MatrixXcd> qr(E);
-    DRAKE_THROW_UNLESS(qr.rank() == n);
-  }
-}
-void check_detectable(const Eigen::Ref<const Eigen::MatrixXd>& A,
-                      const Eigen::Ref<const Eigen::MatrixXd>& Q) {
-  // This function check if (A,C) is a detectable pair, where Q = C' * C.
-  // (A,C) is detectable if and only if the unobservable eigenvalues of A,
-  // if any, have absolute values less than one, where an eigenvalue is
-  // unobservable if Rank[lambda * I - A; C] < n.
-  // Also, (A,C) is detectable if and only if (A',C') is stabilizable.
-  int n = A.rows();
-  Eigen::LDLT<Eigen::MatrixXd> ldlt(Q);
-  Eigen::MatrixXd L = ldlt.matrixL();
-  Eigen::MatrixXd D = ldlt.vectorD();
-  Eigen::MatrixXd D_sqrt = Eigen::MatrixXd::Zero(n, n);
-  for (int i = 0; i < n; i++) {
-    D_sqrt(i, i) = sqrt(D(i));
-  }
-  Eigen::MatrixXd C = L * D_sqrt;
-  check_stabilizable(A.transpose(), C.transpose());
-}
-
-// "Givens rotation" computes an orthogonal 2x2 matrix R such that
-// it eliminates the 2nd coordinate of the vector [a,b]', i.e.,
-// R * [ a ] = [ a_hat ]
-//     [ b ]   [   0   ]
-// The implementation is based on
-// https://en.wikipedia.org/wiki/Givens_rotation#Stable_calculation
-void Givens_rotation(double a, double b, Eigen::Ref<Eigen::Matrix2d> R,
-                     double eps = 1e-10) {
-  double c, s;
-  if (fabs(b) < eps) {
-    c = (a < -eps ? -1 : 1);
-    s = 0;
-  } else if (fabs(a) < eps) {
-    c = 0;
-    s = -sgn(b);
-  } else if (fabs(a) > fabs(b)) {
-    double t = b / a;
-    double u = sgn(a) * fabs(sqrt(1 + t * t));
-    c = 1 / u;
-    s = -c * t;
-  } else {
-    double t = a / b;
-    double u = sgn(b) * fabs(sqrt(1 + t * t));
-    s = -1 / u;
-    c = -s * t;
-  }
-  R(0, 0) = c, R(0, 1) = -s, R(1, 0) = s, R(1, 1) = c;
-}
-
-// The arguments S, T, and Z will be changed.
-void swap_block_11(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
-                   Eigen::Ref<Eigen::MatrixXd> Z, int p) {
-  // Dooren, Case I, p124-125.
-  int n2 = S.rows();
-  Eigen::Matrix2d A = S.block<2, 2>(p, p);
-  Eigen::Matrix2d B = T.block<2, 2>(p, p);
-  Eigen::MatrixXd Z1 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::Matrix2d H = A(1, 1) * B - B(1, 1) * A;
-  Givens_rotation(H(0, 1), H(0, 0), Z1.block<2, 2>(p, p));
-  S = (S * Z1).eval();
-  T = (T * Z1).eval();
-  Z = (Z * Z1).eval();
-  Eigen::MatrixXd Q = Eigen::MatrixXd::Identity(n2, n2);
-  Givens_rotation(T(p, p), T(p + 1, p), Q.block<2, 2>(p, p));
-  S = (Q * S).eval();
-  T = (Q * T).eval();
-  S(p + 1, p) = 0;
-  T(p + 1, p) = 0;
-}
-
-// The arguments S, T, and Z will be changed.
-void swap_block_21(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
-                   Eigen::Ref<Eigen::MatrixXd> Z, int p) {
-  // Dooren, Case II, p126-127.
-  int n2 = S.rows();
-  Eigen::Matrix3d A = S.block<3, 3>(p, p);
-  Eigen::Matrix3d B = T.block<3, 3>(p, p);
-  // Compute H and eliminate H(1,0) by row operation.
-  Eigen::Matrix3d H = A(2, 2) * B - B(2, 2) * A;
-  Eigen::Matrix3d R = Eigen::MatrixXd::Identity(3, 3);
-  Givens_rotation(H(0, 0), H(1, 0), R.block<2, 2>(0, 0));
-  H = (R * H).eval();
-  Eigen::MatrixXd Z1 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::MatrixXd Z2 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::MatrixXd Q1 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::MatrixXd Q2 = Eigen::MatrixXd::Identity(n2, n2);
-  // Compute Z1, Z2, Q1, Q2.
-  Givens_rotation(H(1, 2), H(1, 1), Z1.block<2, 2>(p + 1, p + 1));
-  H = (H * Z1.block<3, 3>(p, p)).eval();
-  Givens_rotation(H(0, 1), H(0, 0), Z2.block<2, 2>(p, p));
-  S = (S * Z1).eval();
-  T = (T * Z1).eval();
-  Z = (Z * Z1 * Z2).eval();
-  Givens_rotation(T(p + 1, p + 1), T(p + 2, p + 1),
-                  Q1.block<2, 2>(p + 1, p + 1));
-  S = (Q1 * S * Z2).eval();
-  T = (Q1 * T * Z2).eval();
-  Givens_rotation(T(p, p), T(p + 1, p), Q2.block<2, 2>(p, p));
-  S = (Q2 * S).eval();
-  T = (Q2 * T).eval();
-  S(p + 1, p) = 0;
-  S(p + 2, p) = 0;
-  T(p + 1, p) = 0;
-  T(p + 2, p) = 0;
-  T(p + 2, p + 1) = 0;
-}
-
-// The arguments S, T, and Z will be changed.
-void swap_block_12(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
-                   Eigen::Ref<Eigen::MatrixXd> Z, int p) {
-  int n2 = S.rows();
-  // Swap the role of S and T.
-  Eigen::MatrixXd Z1 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::MatrixXd Z2 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::MatrixXd Q0 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::MatrixXd Q1 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::MatrixXd Q2 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::MatrixXd Q3 = Eigen::MatrixXd::Identity(n2, n2);
-  Givens_rotation(S(p + 1, p + 1), S(p + 2, p + 1),
-                  Q0.block<2, 2>(p + 1, p + 1));
-  S = (Q0 * S).eval();
-  T = (Q0 * T).eval();
-  Eigen::Matrix3d A = S.block<3, 3>(p, p);
-  Eigen::Matrix3d B = T.block<3, 3>(p, p);
-  // Compute H and eliminate H(2,1) by column operation.
-  Eigen::Matrix3d H = B(0, 0) * A - A(0, 0) * B;
-  Eigen::Matrix3d R = Eigen::MatrixXd::Identity(3, 3);
-  Givens_rotation(H(2, 2), H(2, 1), R.block<2, 2>(1, 1));
-  H = (H * R).eval();
-  // Compute Q1, Q2, Z1, Z2.
-  Givens_rotation(H(0, 1), H(1, 1), Q1.block<2, 2>(p, p));
-  H = (Q1.block<3, 3>(p, p) * H).eval();
-  Givens_rotation(H(1, 2), H(2, 2), Q2.block<2, 2>(p + 1, p + 1));
-  S = (Q1 * S).eval();
-  T = (Q1 * T).eval();
-  Givens_rotation(S(p + 1, p + 1), S(p + 1, p), Z1.block<2, 2>(p, p));
-  S = (Q2 * S * Z1).eval();
-  T = (Q2 * T * Z1).eval();
-  Givens_rotation(S(p + 2, p + 2), S(p + 2, p + 1),
-                  Z2.block<2, 2>(p + 1, p + 1));
-  S = (S * Z2).eval();
-  T = (T * Z2).eval();
-  Z = (Z * Z1 * Z2).eval();
-  // Swap back the role of S and T.
-  Givens_rotation(T(p, p), T(p + 1, p), Q3.block<2, 2>(p, p));
-  S = (Q3 * S).eval();
-  T = (Q3 * T).eval();
-  S(p + 2, p) = 0;
-  S(p + 2, p + 1) = 0;
-  T(p + 1, p) = 0;
-  T(p + 2, p) = 0;
-  T(p + 2, p + 1) = 0;
-}
-
-// The arguments S, T, and Z will be changed.
-void swap_block_22(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
-                   Eigen::Ref<Eigen::MatrixXd> Z, int p) {
-  // Direct Swapping Algorithm based on
-  // "Numerical Methods for General and Structured Eigenvalue Problems" by
-  // Daniel Kressner, p108-111.
-  // ( http://sma.epfl.ch/~anchpcommon/publications/kressner_eigenvalues.pdf ).
-  // Also relevant but not applicable here:
-  // "On Swapping Diagonal Blocks in Real Schur Form" by Zhaojun Bai and James
-  // W. Demmelt;
-  int n2 = S.rows();
-  Eigen::MatrixXd A = S.block<4, 4>(p, p);
-  Eigen::MatrixXd B = T.block<4, 4>(p, p);
-  // Solve
-  // A11 * X - Y A22 = A12
-  // B11 * X - Y B22 = B12
-  // Reduce to solve Cx=D, where x=[x1;...;x4;y1;...;y4].
-  Eigen::Matrix<double, 8, 8> C = Eigen::Matrix<double, 8, 8>::Zero();
-  Eigen::Matrix<double, 8, 1> D;
-  // clang-format off
-  C << A(0, 0), 0, A(0, 1), 0, -A(2, 2), -A(3, 2), 0, 0,
-       0, A(0, 0), 0, A(0, 1), -A(2, 3), -A(3, 3), 0, 0,
-       A(1, 0), 0, A(1, 1), 0, 0, 0, -A(2, 2), -A(3, 2),
-       0, A(1, 0), 0, A(1, 1), 0, 0, -A(2, 3), -A(3, 3),
-       B(0, 0), 0, B(0, 1), 0, -B(2, 2), -B(3, 2), 0, 0,
-       0, B(0, 0), 0, B(0, 1), -B(2, 3), -B(3, 3), 0, 0,
-       B(1, 0), 0, B(1, 1), 0, 0, 0, -B(2, 2), -B(3, 2),
-       0, B(1, 0), 0, B(1, 1), 0, 0, -B(2, 3), -B(3, 3);
-  // clang-format on
-  D << A(0, 2), A(0, 3), A(1, 2), A(1, 3), B(0, 2), B(0, 3), B(1, 2), B(1, 3);
-  Eigen::MatrixXd x = C.colPivHouseholderQr().solve(D);
-  // Q * [ -Y ] = [ R_Y ] ,  Z' * [ -X ] = [ R_X ] .
-  //     [ I  ]   [  0  ]         [ I  ] = [  0  ]
-  Eigen::Matrix<double, 4, 2> X, Y;
-  X << -x(0, 0), -x(1, 0), -x(2, 0), -x(3, 0), Eigen::Matrix2d::Identity();
-  Y << -x(4, 0), -x(5, 0), -x(6, 0), -x(7, 0), Eigen::Matrix2d::Identity();
-  Eigen::MatrixXd Q1 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::MatrixXd Z1 = Eigen::MatrixXd::Identity(n2, n2);
-  Eigen::ColPivHouseholderQR<Eigen::Matrix<double, 4, 2> > qr1(X);
-  Z1.block<4, 4>(p, p) = qr1.householderQ();
-  Eigen::ColPivHouseholderQR<Eigen::Matrix<double, 4, 2> > qr2(Y);
-  Q1.block<4, 4>(p, p) = qr2.householderQ().adjoint();
-  // Apply transform Q1 * (S,T) * Z1.
-  S = (Q1 * S * Z1).eval();
-  T = (Q1 * T * Z1).eval();
-  Z = (Z * Z1).eval();
-  // Eliminate the T(p+3,p+2) entry.
-  Eigen::MatrixXd Q2 = Eigen::MatrixXd::Identity(n2, n2);
-  Givens_rotation(T(p + 2, p + 2), T(p + 3, p + 2),
-                  Q2.block<2, 2>(p + 2, p + 2));
-  S = (Q2 * S).eval();
-  T = (Q2 * T).eval();
-  // Eliminate the T(p+1,p) entry.
-  Eigen::MatrixXd Q3 = Eigen::MatrixXd::Identity(n2, n2);
-  Givens_rotation(T(p, p), T(p + 1, p), Q3.block<2, 2>(p, p));
-  S = (Q3 * S).eval();
-  T = (Q3 * T).eval();
-  S(p + 2, p) = 0;
-  S(p + 2, p + 1) = 0;
-  S(p + 3, p) = 0;
-  S(p + 3, p + 1) = 0;
-  T(p + 1, p) = 0;
-  T(p + 2, p) = 0;
-  T(p + 2, p + 1) = 0;
-  T(p + 3, p) = 0;
-  T(p + 3, p + 1) = 0;
-  T(p + 3, p + 2) = 0;
-}
-
-// Functionality of "swap_block" function:
-// swap the 1x1 or 2x2 blocks pointed by p and q.
-// There are four cases: swapping 1x1 and 1x1 matrices, swapping 2x2 and 1x1
-// matrices, swapping 1x1 and 2x2 matrices, and swapping 2x2 and 2x2 matrices.
-// Algorithms are described in the papers
-// "A generalized eigenvalue approach for solving Riccati equations" by P. Van
-// Dooren, 1981 ( http://epubs.siam.org/doi/pdf/10.1137/0902010 ), and
-// "Numerical Methods for General and Structured Eigenvalue Problems" by
-// Daniel Kressner, 2005.
-void swap_block(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
-                Eigen::Ref<Eigen::MatrixXd> Z, int p, int q, int q_block_size,
-                double eps = 1e-10) {
-  int p_tmp = q, p_block_size;
-  while (p_tmp-- > p) {
-    p_block_size = 1;
-    if (p_tmp >= 1 && fabs(S(p_tmp, p_tmp - 1)) > eps) {
-      p_block_size = 2;
-      p_tmp--;
-    }
-    switch (p_block_size * 10 + q_block_size) {
-      case 11:
-        swap_block_11(S, T, Z, p_tmp);
-        break;
-      case 21:
-        swap_block_21(S, T, Z, p_tmp);
-        break;
-      case 12:
-        swap_block_12(S, T, Z, p_tmp);
-        break;
-      case 22:
-        swap_block_22(S, T, Z, p_tmp);
-        break;
-    }
-  }
-}
-
-// Functionality of "reorder_eigen" function:
-// Reorder the eigenvalues of (S,T) such that the top-left n by n matrix has
-// stable eigenvalues by multiplying Q's and Z's on the left and the right,
-// respectively.
-// Stable eigenvalues are inside the unit disk.
-//
-// Algorithm:
-// Go along the diagonals of (S,T) from the top left to the bottom right.
-// Once find a stable eigenvalue, push it to top left.
-// In implementation, use two pointers, p and q.
-// p points to the current block (1x1 or 2x2) and q points to the block with the
-// stable eigenvalue(s).
-// Push the block pointed by q to the position pointed by p.
-// Finish when n stable eigenvalues are placed at the top-left n by n matrix.
-// The algorithm for swapping blocks is described in the papers
-// "A generalized eigenvalue approach for solving Riccati equations" by P. Van
-// Dooren, 1981, and "Numerical Methods for General and Structured Eigenvalue
-// Problems" by Daniel Kressner, 2005.
-void reorder_eigen(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
-                   Eigen::Ref<Eigen::MatrixXd> Z, double eps = 1e-10) {
-  // abs(a) < eps => a = 0
-  int n2 = S.rows();
-  int n = n2 / 2, p = 0, q = 0;
-
-  // Find the first unstable p block.
-  while (p < n) {
-    if (fabs(S(p + 1, p)) < eps) {  // p block size = 1
-      if (fabs(T(p, p)) > eps && fabs(S(p, p)) <= fabs(T(p, p))) {  // stable
-        p++;
-        continue;
-      }
-    } else {  // p block size = 2
-      const double det_T =
-          T(p, p) * T(p + 1, p + 1) - T(p + 1, p) * T(p, p + 1);
-      if (fabs(det_T) > eps) {
-        const double det_S =
-            S(p, p) * S(p + 1, p + 1) - S(p + 1, p) * S(p, p + 1);
-        if (fabs(det_S) <= fabs(det_T)) {  // stable
-          p += 2;
-          continue;
-        }
-      }
-    }
-    break;
-  }
-  q = p;
-
-  // Make the first n generalized eigenvalues stable.
-  while (p < n && q < n2) {
-    // Update q.
-    int q_block_size = 0;
-    while (q < n2) {
-      if (q == n2 - 1 || fabs(S(q + 1, q)) < eps) {  // block size = 1
-        if (fabs(T(q, q)) > eps && fabs(S(q, q)) <= fabs(T(q, q))) {
-          q_block_size = 1;
-          break;
-        }
-        q++;
-      } else {  // block size = 2
-        const double det_T =
-            T(q, q) * T(q + 1, q + 1) - T(q + 1, q) * T(q, q + 1);
-        if (fabs(det_T) > eps) {
-          const double det_S =
-              S(q, q) * S(q + 1, q + 1) - S(q + 1, q) * S(q, q + 1);
-          if (fabs(det_S) <= fabs(det_T)) {
-            q_block_size = 2;
-            break;
-          }
-        }
-        q += 2;
-      }
-    }
-    if (q >= n2)
-      throw std::runtime_error("fail to find enough stable eigenvalues");
-    // Swap blocks pointed by p and q.
-    if (p != q) {
-      swap_block(S, T, Z, p, q, q_block_size);
-      p += q_block_size;
-      q += q_block_size;
-    }
-  }
-  if (p < n && q >= n2)
-    throw std::runtime_error("fail to find enough stable eigenvalues");
-}
-}  // namespace
 
 /**
- * DiscreteAlgebraicRiccatiEquation function
- * computes the unique stabilizing solution X to the discrete-time algebraic
- * Riccati equation:
+ * Returns true if (A, B) is a stabilizable pair.
  *
- * AᵀXA − X − AᵀXB(BᵀXB + R)⁻¹BᵀXA + Q = 0
- *
- * @throws std::exception if Q is not positive semi-definite.
- * @throws std::exception if R is not positive definite.
- *
- * Based on the Schur Vector approach outlined in this paper:
- * "On the Numerical Solution of the Discrete-Time Algebraic Riccati Equation"
- * by Thrasyvoulos Pappas, Alan J. Laub, and Nils R. Sandell, in TAC, 1980,
- * http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=1102434
- *
- * Note: When, for example, n = 100, m = 80, and entries of A, B, Q_half,
- * R_half are sampled from standard normal distributions, where
- * Q = Q_halfᵀ Q_half and similar for R, the absolute error of the solution
- * is 10⁻⁶, while the absolute error of the solution computed by Matlab is
- * 10⁻⁸.
- *
- * TODO(weiqiao.han): I may overwrite the RealQZ function to improve the
- * accuracy, together with more thorough tests.
+ * (A,B) is stabilizable if and only if the uncontrollable eigenvalues of A, if
+ * any, have absolute values less than one, where an eigenvalue is
+ * uncontrollable if rank([λI - A, B]) < n where n is the number of states.
  */
+bool IsStabilizable(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                    const Eigen::Ref<const Eigen::MatrixXd>& B) {
+  int states = B.rows();
+  int inputs = B.cols();
+
+  Eigen::EigenSolver<Eigen::MatrixXd> es{A, false};
+  for (int i = 0; i < states; ++i) {
+    if (es.eigenvalues()[i].real() * es.eigenvalues()[i].real() +
+            es.eigenvalues()[i].imag() * es.eigenvalues()[i].imag() <
+        1) {
+      continue;
+    }
+
+    Eigen::MatrixXcd E{states, states + inputs};
+    E << es.eigenvalues()[i] * Eigen::MatrixXcd::Identity(states, states) - A,
+        B;
+
+    Eigen::ColPivHouseholderQR<Eigen::MatrixXcd> qr{E};
+    if (qr.rank() < states) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Returns true if (A, C) is a detectable pair.
+ *
+ * (A, C) is detectable if and only if the unobservable eigenvalues of A, if
+ * any, have absolute values less than one, where an eigenvalue is unobservable
+ * if rank([λI - A; C]) < n where n is the number of states.
+ */
+bool IsDetectable(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                  const Eigen::Ref<const Eigen::MatrixXd>& C) {
+  return IsStabilizable(A.transpose(), C.transpose());
+}
+
+}  // namespace
 
 Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
     const Eigen::Ref<const Eigen::MatrixXd>& B,
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::MatrixXd>& R) {
-  int n = B.rows(), m = B.cols();
+  int states = B.rows();
+  int inputs = B.cols();
 
-  DRAKE_DEMAND(m <= n);
-  DRAKE_DEMAND(A.rows() == n && A.cols() == n);
-  DRAKE_DEMAND(Q.rows() == n && Q.cols() == n);
-  DRAKE_DEMAND(R.rows() == m && R.cols() == m);
-  DRAKE_DEMAND(is_approx_equal_abstol(Q, Q.transpose(), 1e-10));
-  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(Q);
-  for (int i = 0; i < n; i++) {
-    DRAKE_THROW_UNLESS(es.eigenvalues()[i] >= 0);
-  }
-  DRAKE_DEMAND(is_approx_equal_abstol(R, R.transpose(), 1e-10));
-  Eigen::LLT<Eigen::MatrixXd> R_cholesky(R);
-  DRAKE_THROW_UNLESS(R_cholesky.info() == Eigen::Success);
-  check_stabilizable(A, B);
-  check_detectable(A, Q);
+  DRAKE_DEMAND(A.rows() == states && A.cols() == states);
+  DRAKE_DEMAND(Q.rows() == states && Q.cols() == states);
+  DRAKE_DEMAND(R.rows() == inputs && R.cols() == inputs);
 
-  Eigen::MatrixXd M(2 * n, 2 * n), L(2 * n, 2 * n);
-  M << A, Eigen::MatrixXd::Zero(n, n), -Q, Eigen::MatrixXd::Identity(n, n);
-  L << Eigen::MatrixXd::Identity(n, n), B * R.inverse() * B.transpose(),
-      Eigen::MatrixXd::Zero(n, n), A.transpose();
+  // Ensure Q is symmetric
+  DRAKE_THROW_UNLESS(is_approx_equal_abstol(Q, Q.transpose(), 1e-10));
 
-  // QZ decomposition of M and L
-  // QMZ = S, QLZ = T
-  // where Q and Z are real orthogonal matrixes
-  // T is upper-triangular matrix, and S is upper quasi-triangular matrix
-  Eigen::RealQZ<Eigen::MatrixXd> qz(2 * n);
-  qz.compute(M, L);  // M = Q S Z,  L = Q T Z (Q and Z computed by Eigen package
-                     // are adjoints of Q and Z above)
-  Eigen::MatrixXd S = qz.matrixS(), T = qz.matrixT(),
-                  Z = qz.matrixZ().adjoint();
+  // Ensure Q is positive semidefinite
+  //
+  // If Q is a symmetric matrix with a decomposition LDLᵀ, the number of
+  // positive, negative, and zero diagonal entries in D equals the number of
+  // positive, negative, and zero eigenvalues respectively in Q (see
+  // https://en.wikipedia.org/wiki/Sylvester's_law_of_inertia).
+  //
+  // Therefore, D having no negative diagonal entries is sufficient to prove Q
+  // is positive semidefinite.
+  auto Q_ldlt = Q.ldlt();
+  DRAKE_THROW_UNLESS(Q_ldlt.info() == Eigen::Success &&
+                     (Q_ldlt.vectorD().array() >= 0.0).all());
 
-  // Reorder the generalized eigenvalues of (S,T).
-  Eigen::MatrixXd Z2 = Eigen::MatrixXd::Identity(2 * n, 2 * n);
-  reorder_eigen(S, T, Z2);
-  Z = (Z * Z2).eval();
+  // Ensure R is symmetric
+  DRAKE_THROW_UNLESS(is_approx_equal_abstol(R, R.transpose(), 1e-10));
 
-  // The first n columns of Z is ( U1 ) .
-  //                             ( U2 )
-  //            -1
-  // X = U2 * U1   is a solution of the discrete time Riccati equation.
-  Eigen::MatrixXd U1 = Z.block(0, 0, n, n), U2 = Z.block(n, 0, n, n);
-  Eigen::MatrixXd X = U2 * U1.inverse();
-  X = (X + X.adjoint().eval()) / 2.0;
-  return X;
+  // Ensure R is positive definite (LLT decomposition fails if not)
+  Eigen::LLT<Eigen::MatrixXd> R_llt{R};
+  DRAKE_THROW_UNLESS(R_llt.info() == Eigen::Success);
+
+  // Ensure (A, B) pair is stabilizable
+  DRAKE_THROW_UNLESS(IsStabilizable(A, B));
+
+  // Ensure (A, C) pair where Q = CᵀC is detectable
+  Eigen::MatrixXd C = Eigen::MatrixXd{Q_ldlt.matrixL()} *
+                      Q_ldlt.vectorD().cwiseSqrt().asDiagonal();
+  DRAKE_THROW_UNLESS(IsDetectable(A, C));
+
+  // Implements the SDA algorithm on page 5 of [1].
+  //
+  // [1] E. K.-W. Chu, H.-Y. Fan, W.-W. Lin & C.-S. Wang "Structure-Preserving
+  //     Algorithms for Periodic Discrete-Time Algebraic Riccati Equations",
+  //     International Journal of Control, 77:8, 767-788, 2004.
+  //     DOI: 10.1080/00207170410001714988
+
+  // A₀ = A
+  Eigen::MatrixXd A_k = A;
+
+  // G₀ = BR⁻¹Bᵀ
+  //
+  // See equation (4) of [1].
+  Eigen::MatrixXd G_k = B * R_llt.solve(B.transpose());
+
+  // H₀ = Q
+  //
+  // See equation (4) of [1].
+  Eigen::MatrixXd H_k;
+  Eigen::MatrixXd H_k1 = Q;
+
+  do {
+    H_k = H_k1;
+
+    // W = I + GₖHₖ
+    Eigen::MatrixXd W =
+        Eigen::MatrixXd::Identity(H_k.rows(), H_k.cols()) + G_k * H_k;
+
+    auto W_solver = W.lu();
+
+    // Solve WV₁ = Aₖ for V₁
+    Eigen::MatrixXd V_1 = W_solver.solve(A_k);
+
+    // Solve V₂Wᵀ = Gₖ for V₂
+    //
+    // We want to put V₂Wᵀ = Gₖ into Ax = b form so we can solve it more
+    // efficiently.
+    //
+    // V₂Wᵀ = Gₖ
+    // (V₂Wᵀ)ᵀ = Gₖᵀ
+    // WV₂ᵀ = Gₖᵀ
+    //
+    // The solution of Ax = b can be found via x = A.solve(b).
+    //
+    // V₂ᵀ = W.solve(Gₖᵀ)
+    // V₂ = W.solve(Gₖᵀ)ᵀ
+    Eigen::MatrixXd V_2 = W_solver.solve(G_k.transpose()).transpose();
+
+    // Gₖ₊₁ = Gₖ + AₖV₂Aₖᵀ
+    G_k += A_k * V_2 * A_k.transpose();
+
+    // Hₖ₊₁ = Hₖ + V₁ᵀHₖAₖ
+    H_k1 = H_k + V_1.transpose() * H_k * A_k;
+
+    // Aₖ₊₁ = AₖV₁
+    A_k *= V_1;
+
+    // while |Hₖ₊₁ − Hₖ| > ε |Hₖ₊₁|
+  } while ((H_k1 - H_k).norm() > 1e-10 * H_k1.norm());
+
+  return H_k1;
 }
 
 Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
@@ -458,15 +172,20 @@ Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::MatrixXd>& R,
     const Eigen::Ref<const Eigen::MatrixXd>& N) {
-    DRAKE_DEMAND(N.rows() == B.rows() && N.cols() == B.cols());
+  int states = B.rows();
+  int inputs = B.cols();
+  DRAKE_DEMAND(N.rows() == states && N.cols() == inputs);
 
-    // This is a change of variables to make the DARE that includes Q, R, and N
-    // cost matrices fit the form of the DARE that includes only Q and R cost
-    // matrices.
-    Eigen::MatrixXd A2 = A - B * R.llt().solve(N.transpose());
-    Eigen::MatrixXd Q2 = Q - N * R.llt().solve(N.transpose());
-    return DiscreteAlgebraicRiccatiEquation(A2, B, Q2, R);
+  // Ensure R is positive definite (LLT decomposition fails if not)
+  auto R_llt = R.llt();
+  DRAKE_THROW_UNLESS(R_llt.info() == Eigen::Success);
+
+  // This is a change of variables to make the DARE that includes Q, R, and N
+  // cost matrices fit the form of the DARE that includes only Q and R cost
+  // matrices.
+  Eigen::MatrixXd A_2 = A - B * R_llt.solve(N.transpose());
+  Eigen::MatrixXd Q_2 = Q - N * R_llt.solve(N.transpose());
+  return DiscreteAlgebraicRiccatiEquation(A_2, B, Q_2, R);
 }
 
-}  // namespace math
-}  // namespace drake
+}  // namespace drake::math

--- a/math/discrete_algebraic_riccati_equation.cc
+++ b/math/discrete_algebraic_riccati_equation.cc
@@ -50,9 +50,12 @@ Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
       drake::systems::internal::IsStabilizable(A, B, false, std::nullopt));
 
   // Ensure (A, C) pair where Q = CᵀC is detectable
-  // NOLINTNEXTLINE(whitespace/braces)
-  Eigen::MatrixXd C = Eigen::MatrixXd{Q_ldlt.matrixL()} *
-                      Q_ldlt.vectorD().cwiseSqrt().asDiagonal();
+  //
+  // Q = CᵀC = LDLᵀ
+  // C = √(D)Lᵀ
+  Eigen::MatrixXd C = Q_ldlt.vectorD().cwiseSqrt().asDiagonal() *
+                      // NOLINTNEXTLINE(whitespace/braces)
+                      Eigen::MatrixXd{Q_ldlt.matrixL().transpose()};
   DRAKE_THROW_UNLESS(
       drake::systems::internal::IsDetectable(A, C, false, std::nullopt));
 

--- a/math/discrete_algebraic_riccati_equation.cc
+++ b/math/discrete_algebraic_riccati_equation.cc
@@ -8,7 +8,8 @@
 #include "drake/common/is_approx_equal_abstol.h"
 #include "drake/systems/primitives/linear_system_internal.h"
 
-namespace drake::math {
+namespace drake {
+namespace math {
 
 Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
@@ -147,4 +148,5 @@ Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
   return DiscreteAlgebraicRiccatiEquation(A_2, B, Q_2, R);
 }
 
-}  // namespace drake::math
+}  // namespace math
+}  // namespace drake

--- a/math/discrete_algebraic_riccati_equation.cc
+++ b/math/discrete_algebraic_riccati_equation.cc
@@ -51,11 +51,14 @@ Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
 
   // Ensure (A, C) pair where Q = CᵀC is detectable
   //
-  // Q = CᵀC = LDLᵀ
-  // C = √(D)Lᵀ
-  Eigen::MatrixXd C = Q_ldlt.vectorD().cwiseSqrt().asDiagonal() *
-                      // NOLINTNEXTLINE(whitespace/braces)
-                      Eigen::MatrixXd{Q_ldlt.matrixL().transpose()};
+  // Q = CᵀC = PᵀLDLᵀP
+  // Cᵀ = PᵀL√(D)
+  // C = (PᵀL√(D))ᵀ
+  Eigen::MatrixXd C = (Q_ldlt.transpositionsP().transpose() *
+                       // NOLINTNEXTLINE(whitespace/braces)
+                       Eigen::MatrixXd{Q_ldlt.matrixL()} *
+                       Q_ldlt.vectorD().cwiseSqrt().asDiagonal())
+                          .transpose();
   DRAKE_THROW_UNLESS(
       drake::systems::internal::IsDetectable(A, C, false, std::nullopt));
 

--- a/math/discrete_algebraic_riccati_equation.cc
+++ b/math/discrete_algebraic_riccati_equation.cc
@@ -99,6 +99,7 @@ Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
   DRAKE_THROW_UNLESS(IsStabilizable(A, B));
 
   // Ensure (A, C) pair where Q = CᵀC is detectable
+  // NOLINTNEXTLINE(whitespace/braces)
   Eigen::MatrixXd C = Eigen::MatrixXd{Q_ldlt.matrixL()} *
                       Q_ldlt.vectorD().cwiseSqrt().asDiagonal();
   DRAKE_THROW_UNLESS(IsDetectable(A, C));

--- a/math/discrete_algebraic_riccati_equation.h
+++ b/math/discrete_algebraic_riccati_equation.h
@@ -1,12 +1,8 @@
 #pragma once
 
-#include <cmath>
-#include <cstdlib>
+#include <Eigen/Core>
 
-#include <Eigen/Dense>
-
-namespace drake {
-namespace math {
+namespace drake::math {
 
 /**
 Computes the unique stabilizing solution X to the discrete-time algebraic
@@ -14,12 +10,10 @@ Riccati equation:
 
 AᵀXA − X − AᵀXB(BᵀXB + R)⁻¹BᵀXA + Q = 0
 
-@throws std::exception if Q is not positive semi-definite.
-@throws std::exception if R is not positive definite.
-
-Based on the Schur Vector approach outlined in this paper:
-"On the Numerical Solution of the Discrete-Time Algebraic Riccati Equation"
-by Thrasyvoulos Pappas, Alan J. Laub, and Nils R. Sandell
+@throws std::runtime_error if Q is not symmetric positive semidefinite.
+@throws std::runtime_error if R is not symmetric positive definite.
+@throws std::runtime_error if (A, B) isn't a stabilizable pair.
+@throws std::runtime_error if (A, C) isn't a detectable pair where Q = CᵀC.
 */
 Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
@@ -68,8 +62,10 @@ J = Σ [uₖ] [0 R][uₖ] ΔT
    k=0
 @endverbatim
 
-@throws std::runtime_error if Q − NR⁻¹Nᵀ is not positive semi-definite.
-@throws std::runtime_error if R is not positive definite.
+@throws std::runtime_error if Q₂ is not symmetric positive semidefinite.
+@throws std::runtime_error if R is not symmetric positive definite.
+@throws std::runtime_error if (A₂, B) isn't a stabilizable pair.
+@throws std::runtime_error if (A₂, C) isn't a detectable pair where Q₂ = CᵀC.
 */
 Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
@@ -77,6 +73,5 @@ Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::MatrixXd>& R,
     const Eigen::Ref<const Eigen::MatrixXd>& N);
-}  // namespace math
-}  // namespace drake
 
+}  // namespace drake::math

--- a/math/discrete_algebraic_riccati_equation.h
+++ b/math/discrete_algebraic_riccati_equation.h
@@ -2,7 +2,8 @@
 
 #include <Eigen/Core>
 
-namespace drake::math {
+namespace drake {
+namespace math {
 
 /**
 Computes the unique stabilizing solution X to the discrete-time algebraic
@@ -10,10 +11,10 @@ Riccati equation:
 
 AᵀXA − X − AᵀXB(BᵀXB + R)⁻¹BᵀXA + Q = 0
 
-@throws std::runtime_error if Q is not symmetric positive semidefinite.
-@throws std::runtime_error if R is not symmetric positive definite.
-@throws std::runtime_error if (A, B) isn't a stabilizable pair.
-@throws std::runtime_error if (A, C) isn't a detectable pair where Q = CᵀC.
+@throws std::exception if Q is not symmetric positive semidefinite.
+@throws std::exception if R is not symmetric positive definite.
+@throws std::exception if (A, B) isn't a stabilizable pair.
+@throws std::exception if (A, C) isn't a detectable pair where Q = CᵀC.
 */
 Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
@@ -62,10 +63,10 @@ J = Σ [uₖ] [0 R][uₖ] ΔT
    k=0
 @endverbatim
 
-@throws std::runtime_error if Q₂ is not symmetric positive semidefinite.
-@throws std::runtime_error if R is not symmetric positive definite.
-@throws std::runtime_error if (A₂, B) isn't a stabilizable pair.
-@throws std::runtime_error if (A₂, C) isn't a detectable pair where Q₂ = CᵀC.
+@throws std::exception if Q₂ is not symmetric positive semidefinite.
+@throws std::exception if R is not symmetric positive definite.
+@throws std::exception if (A₂, B) isn't a stabilizable pair.
+@throws std::exception if (A₂, C) isn't a detectable pair where Q₂ = CᵀC.
 */
 Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
@@ -74,4 +75,5 @@ Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& R,
     const Eigen::Ref<const Eigen::MatrixXd>& N);
 
-}  // namespace drake::math
+}  // namespace math
+}  // namespace drake

--- a/math/test/discrete_algebraic_riccati_equation_test.cc
+++ b/math/test/discrete_algebraic_riccati_equation_test.cc
@@ -236,6 +236,24 @@ GTEST_TEST(DARETest, ACNotDetectable_ABQRN) {
   EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::runtime_error);
 }
 
+GTEST_TEST(DARETest, QDecomposition) {
+  // Ensures the decomposition of Q into CᵀC is correct
+
+  const Eigen::Matrix2d A{{1.0, 0.0}, {0.0, 0.0}};
+  const Eigen::Matrix2d B{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
+
+  // (A, C₁) should be detectable pair
+  const Eigen::Matrix2d C_1{{0.0, 0.0}, {1.0, 0.0}};
+  const Eigen::Matrix2d Q_1 = C_1.transpose() * C_1;
+  EXPECT_NO_THROW(SolveDAREandVerify(A, B, Q_1, R));
+
+  // (A, C₂) shouldn't be detectable pair
+  const Eigen::Matrix2d C_2 = C_1.transpose();
+  const Eigen::Matrix2d Q_2 = C_2.transpose() * C_2;
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q_2, R), std::runtime_error);
+}
+
 }  // namespace
 
 }  // namespace drake::math

--- a/math/test/discrete_algebraic_riccati_equation_test.cc
+++ b/math/test/discrete_algebraic_riccati_equation_test.cc
@@ -76,40 +76,54 @@ GTEST_TEST(DARE, NonInvertibleA) {
   // Test 1: non-invertible A
   // Example 2 of "On the Numerical Solution of the Discrete-Time Algebraic
   // Riccati Equation"
-  Eigen::MatrixXd A{{0.5, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {0, 0, 0, 0}};
-  Eigen::MatrixXd B{{0}, {0}, {0}, {1}};
-  Eigen::MatrixXd Q{{1, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}};
-  Eigen::MatrixXd R{{0.25}};
+  Eigen::MatrixXd A{4, 4};
+  A << 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0;
+  Eigen::MatrixXd B{4, 1};
+  B << 0, 0, 0, 1;
+  Eigen::MatrixXd Q{4, 4};
+  Q << 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+  Eigen::MatrixXd R{1, 1};
+  R << 0.25;
   SolveDAREandVerify(A, B, Q, R);
 
-  Eigen::MatrixXd Aref{
-      {0.25, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {0, 0, 0, 0}};
+  Eigen::MatrixXd Aref{4, 4};
+  Aref << 0.25, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0;
   SolveDAREandVerify(A, B, (A - Aref).transpose() * Q * (A - Aref),
                      B.transpose() * Q * B + R, (A - Aref).transpose() * Q * B);
 }
 
 GTEST_TEST(DARE, InvertibleA) {
   // Test 2: invertible A
-  Eigen::MatrixXd A{{1, 1}, {0, 1}};
-  Eigen::MatrixXd B{{0}, {1}};
-  Eigen::MatrixXd Q{{1, 0}, {0, 0}};
-  Eigen::MatrixXd R{{0.3}};
+  Eigen::MatrixXd A{2, 2};
+  A << 1, 1, 0, 1;
+  Eigen::MatrixXd B{2, 1};
+  B << 0, 1;
+  Eigen::MatrixXd Q{2, 2};
+  Q << 1, 0, 0, 0;
+  Eigen::MatrixXd R{1, 1};
+  R << 0.3;
   SolveDAREandVerify(A, B, Q, R);
 
-  Eigen::MatrixXd Aref{{0.5, 1}, {0, 1}};
+  Eigen::MatrixXd Aref{2, 2};
+  Aref << 0.5, 1, 0, 1;
   SolveDAREandVerify(A, B, (A - Aref).transpose() * Q * (A - Aref),
                      B.transpose() * Q * B + R, (A - Aref).transpose() * Q * B);
 }
 
 GTEST_TEST(DARE, FirstGeneralizedEigenvalueOfSTIsStable) {
   // Test 3: the first generalized eigenvalue of (S, T) is stable
-  Eigen::MatrixXd A{{0, 1}, {0, 0}};
-  Eigen::MatrixXd B{{0}, {1}};
-  Eigen::MatrixXd Q{{1, 0}, {0, 1}};
-  Eigen::MatrixXd R{{1}};
+  Eigen::MatrixXd A{2, 2};
+  A << 0, 1, 0, 0;
+  Eigen::MatrixXd B{2, 1};
+  B << 0, 1;
+  Eigen::MatrixXd Q{2, 2};
+  Q << 1, 0, 0, 1;
+  Eigen::MatrixXd R{1, 1};
+  R << 1;
   SolveDAREandVerify(A, B, Q, R);
 
-  Eigen::MatrixXd Aref{{0, 0.5}, {0, 0}};
+  Eigen::MatrixXd Aref{2, 2};
+  Aref << 0, 0.5, 0, 0;
   SolveDAREandVerify(A, B, (A - Aref).transpose() * Q * (A - Aref),
                      B.transpose() * Q * B + R, (A - Aref).transpose() * Q * B);
 }
@@ -129,12 +143,14 @@ GTEST_TEST(DARE, IdentitySystem) {
 GTEST_TEST(DARE, MoreInputsThanStates) {
   // Test 5: More inputs than states
   const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
-  const Eigen::MatrixXd B{{1, 0, 0}, {0, 0.5, 0.3}};
+  Eigen::MatrixXd B{2, 3};
+  B << 1, 0, 0, 0, 0.5, 0.3;
   const Eigen::Matrix2d Q{Eigen::Matrix2d::Identity()};
   const Eigen::Matrix3d R{Eigen::Matrix3d::Identity()};
   SolveDAREandVerify(A, B, Q, R);
 
-  const Eigen::MatrixXd N{{1, 0, 0}, {0, 1, 0}};
+  Eigen::MatrixXd N{2, 3};
+  N << 1, 0, 0, 0, 1, 0;
   SolveDAREandVerify(A, B, Q, R, N);
 }
 

--- a/math/test/discrete_algebraic_riccati_equation_test.cc
+++ b/math/test/discrete_algebraic_riccati_equation_test.cc
@@ -1,12 +1,14 @@
 #include "drake/math/discrete_algebraic_riccati_equation.h"
 
+#include <exception>
+
 #include <Eigen/LU>  // for inverse()
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
-namespace drake::math {
-
+namespace drake {
+namespace math {
 namespace {
 
 void SolveDAREandVerify(const Eigen::Ref<const Eigen::MatrixXd>& A,
@@ -160,7 +162,7 @@ GTEST_TEST(DARE, QNotSymmetricPositiveSemidefinite_ABQR) {
   const Eigen::Matrix2d Q{-Eigen::Matrix2d::Identity()};
   const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
 
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R), std::exception);
 }
 
 GTEST_TEST(DARE, QNotSymmetricPositiveSemidefinite_ABQRN) {
@@ -170,7 +172,7 @@ GTEST_TEST(DARE, QNotSymmetricPositiveSemidefinite_ABQRN) {
   const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
   const Eigen::Matrix2d N{2.0 * Eigen::Matrix2d::Identity()};
 
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::exception);
 }
 
 GTEST_TEST(DARE, RNotSymmetricPositiveDefinite_ABQR) {
@@ -179,10 +181,10 @@ GTEST_TEST(DARE, RNotSymmetricPositiveDefinite_ABQR) {
   const Eigen::Matrix2d Q{Eigen::Matrix2d::Identity()};
 
   const Eigen::Matrix2d R1{Eigen::Matrix2d::Zero()};
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R1), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R1), std::exception);
 
   const Eigen::Matrix2d R2{-Eigen::Matrix2d::Identity()};
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R2), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R2), std::exception);
 }
 
 GTEST_TEST(DARE, RNotSymmetricPositiveDefinite_ABQRN) {
@@ -192,10 +194,10 @@ GTEST_TEST(DARE, RNotSymmetricPositiveDefinite_ABQRN) {
   const Eigen::Matrix2d N{Eigen::Matrix2d::Identity()};
 
   const Eigen::Matrix2d R1{Eigen::Matrix2d::Zero()};
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R1, N), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R1, N), std::exception);
 
   const Eigen::Matrix2d R2{-Eigen::Matrix2d::Identity()};
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R2, N), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R2, N), std::exception);
 }
 
 GTEST_TEST(DARE, ABNotStabilizable_ABQR) {
@@ -204,7 +206,7 @@ GTEST_TEST(DARE, ABNotStabilizable_ABQR) {
   const Eigen::Matrix2d Q{Eigen::Matrix2d::Identity()};
   const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
 
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R), std::exception);
 }
 
 GTEST_TEST(DARETest, ABNotStabilizable_ABQRN) {
@@ -214,7 +216,7 @@ GTEST_TEST(DARETest, ABNotStabilizable_ABQRN) {
   const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
   const Eigen::Matrix2d N{Eigen::Matrix2d::Identity()};
 
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::exception);
 }
 
 GTEST_TEST(DARETest, ACNotDetectable_ABQR) {
@@ -223,7 +225,7 @@ GTEST_TEST(DARETest, ACNotDetectable_ABQR) {
   const Eigen::Matrix2d Q{Eigen::Matrix2d::Zero()};
   const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
 
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R), std::exception);
 }
 
 GTEST_TEST(DARETest, ACNotDetectable_ABQRN) {
@@ -233,7 +235,7 @@ GTEST_TEST(DARETest, ACNotDetectable_ABQRN) {
   const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
   const Eigen::Matrix2d N{Eigen::Matrix2d::Zero()};
 
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::exception);
 }
 
 GTEST_TEST(DARETest, QDecomposition) {
@@ -253,9 +255,9 @@ GTEST_TEST(DARETest, QDecomposition) {
   // (A, C₂) shouldn't be detectable pair
   const Eigen::Matrix2d C_2 = C_1.transpose();
   const Eigen::Matrix2d Q_2 = C_2.transpose() * C_2;
-  EXPECT_THROW(SolveDAREandVerify(A, B, Q_2, R), std::runtime_error);
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q_2, R), std::exception);
 }
 
 }  // namespace
-
-}  // namespace drake::math
+}  // namespace math
+}  // namespace drake

--- a/math/test/discrete_algebraic_riccati_equation_test.cc
+++ b/math/test/discrete_algebraic_riccati_equation_test.cc
@@ -1,123 +1,225 @@
 #include "drake/math/discrete_algebraic_riccati_equation.h"
 
+#include <Eigen/LU>  // for inverse()
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
-#include "drake/math/autodiff.h"
 
-using Eigen::MatrixXd;
+namespace drake::math {
 
-namespace drake {
-namespace math {
 namespace {
-void SolveDAREandVerify(const Eigen::Ref<const MatrixXd>& A,
-                        const Eigen::Ref<const MatrixXd>& B,
-                        const Eigen::Ref<const MatrixXd>& Q,
-                        const Eigen::Ref<const MatrixXd>& R) {
-  MatrixXd X = DiscreteAlgebraicRiccatiEquation(A, B, Q, R);
-  // Check that X is positive semi-definite.
+
+void SolveDAREandVerify(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                        const Eigen::Ref<const Eigen::MatrixXd>& B,
+                        const Eigen::Ref<const Eigen::MatrixXd>& Q,
+                        const Eigen::Ref<const Eigen::MatrixXd>& R) {
+  int states = A.rows();
+
+  Eigen::MatrixXd X = DiscreteAlgebraicRiccatiEquation(A, B, Q, R);
+
+  // Check that X is symmetric
   EXPECT_TRUE(
-      CompareMatrices(X, X.transpose(), 1E-10, MatrixCompareType::absolute));
-  int n = X.rows();
-  Eigen::SelfAdjointEigenSolver<MatrixXd> es(X);
-  for (int i = 0; i < n; i++) {
+      CompareMatrices(X, X.transpose(), 1e-10, MatrixCompareType::absolute));
+
+  // Check that X is positive semidefinite
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es{X, Eigen::EigenvaluesOnly};
+  for (int i = 0; i < states; ++i) {
     EXPECT_GE(es.eigenvalues()[i], 0);
   }
-  // Check that X is the solution to the discrete time ARE.
+
+  // Check that X is the solution to the discrete time ARE
   // clang-format off
-  MatrixXd Y =
+  Eigen::MatrixXd Y =
       A.transpose() * X * A
       - X
       - (A.transpose() * X * B * (B.transpose() * X * B + R).inverse()
         * B.transpose() * X * A)
       + Q;
   // clang-format on
-  EXPECT_TRUE(CompareMatrices(Y, MatrixXd::Zero(n, n), 1E-10,
+  EXPECT_TRUE(CompareMatrices(Y, Eigen::MatrixXd::Zero(states, states), 1e-10,
                               MatrixCompareType::absolute));
 }
 
-void SolveDAREandVerify(const Eigen::Ref<const MatrixXd>& A,
-                        const Eigen::Ref<const MatrixXd>& B,
-                        const Eigen::Ref<const MatrixXd>& Q,
-                        const Eigen::Ref<const MatrixXd>& R,
-                        const Eigen::Ref<const MatrixXd>& N) {
-  MatrixXd X = DiscreteAlgebraicRiccatiEquation(A, B, Q, R, N);
-  // Check that X is positive semi-definite.
+void SolveDAREandVerify(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                        const Eigen::Ref<const Eigen::MatrixXd>& B,
+                        const Eigen::Ref<const Eigen::MatrixXd>& Q,
+                        const Eigen::Ref<const Eigen::MatrixXd>& R,
+                        const Eigen::Ref<const Eigen::MatrixXd>& N) {
+  int states = A.rows();
+
+  Eigen::MatrixXd X = DiscreteAlgebraicRiccatiEquation(A, B, Q, R, N);
+
+  // Check that X is symmetric
   EXPECT_TRUE(
-      CompareMatrices(X, X.transpose(), 1E-10, MatrixCompareType::absolute));
-  int n = X.rows();
-  Eigen::SelfAdjointEigenSolver<MatrixXd> es(X);
-  for (int i = 0; i < n; i++) {
+      CompareMatrices(X, X.transpose(), 1e-10, MatrixCompareType::absolute));
+
+  // Check that X is positive semidefinite
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es{X, Eigen::EigenvaluesOnly};
+  for (int i = 0; i < states; ++i) {
     EXPECT_GE(es.eigenvalues()[i], 0);
   }
-  // Check that X is the solution to the discrete time ARE.
+
+  // Check that X is the solution to the discrete time ARE
   // clang-format off
-  MatrixXd Y =
+  Eigen::MatrixXd Y =
       A.transpose() * X * A
       - X
       - ((A.transpose() * X * B + N) * (B.transpose() * X * B + R).inverse()
         * (B.transpose() * X * A + N.transpose()))
       + Q;
   // clang-format on
-  EXPECT_TRUE(CompareMatrices(Y, MatrixXd::Zero(n, n), 1E-10,
+  EXPECT_TRUE(CompareMatrices(Y, Eigen::MatrixXd::Zero(states, states), 1e-10,
                               MatrixCompareType::absolute));
 }
 
-GTEST_TEST(DARE, SolveDAREandVerify) {
+GTEST_TEST(DARE, NonInvertibleA) {
   // Test 1: non-invertible A
   // Example 2 of "On the Numerical Solution of the Discrete-Time Algebraic
   // Riccati Equation"
-  int n1 = 4, m1 = 1;
-  MatrixXd A1(n1, n1), B1(n1, m1), Q1(n1, n1), R1(m1, m1);
-  A1 << 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0;
-  B1 << 0, 0, 0, 1;
-  Q1 << 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
-  R1 << 0.25;
-  SolveDAREandVerify(A1, B1, Q1, R1);
+  Eigen::MatrixXd A{{0.5, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {0, 0, 0, 0}};
+  Eigen::MatrixXd B{{0}, {0}, {0}, {1}};
+  Eigen::MatrixXd Q{{1, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}};
+  Eigen::MatrixXd R{{0.25}};
+  SolveDAREandVerify(A, B, Q, R);
 
-  MatrixXd Aref1(n1, n1);
-  Aref1 << 0.25, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0;
-  SolveDAREandVerify(A1, B1, (A1 - Aref1).transpose() * Q1 * (A1 - Aref1),
-      B1.transpose() * Q1 * B1 + R1, (A1 - Aref1).transpose() * Q1 * B1);
-
-  // Test 2: invertible A
-  int n2 = 2, m2 = 1;
-  MatrixXd A2(n2, n2), B2(n2, m2), Q2(n2, n2), R2(m2, m2);
-  A2 << 1, 1, 0, 1;
-  B2 << 0, 1;
-  Q2 << 1, 0, 0, 0;
-  R2 << 0.3;
-  SolveDAREandVerify(A2, B2, Q2, R2);
-
-  MatrixXd Aref2(n2, n2);
-  Aref2 << 0.5, 1, 0, 1;
-  SolveDAREandVerify(A2, B2, (A2 - Aref2).transpose() * Q2 * (A2 - Aref2),
-      B2.transpose() * Q2 * B2 + R2, (A2 - Aref2).transpose() * Q2 * B2);
-
-  // Test 3: the first generalized eigenvalue of (S,T) is stable
-  int n3 = 2, m3 = 1;
-  MatrixXd A3(n3, n3), B3(n3, m3), Q3(n3, n3), R3(m3, m3);
-  A3 << 0, 1, 0, 0;
-  B3 << 0, 1;
-  Q3 << 1, 0, 0, 1;
-  R3 << 1;
-  SolveDAREandVerify(A3, B3, Q3, R3);
-
-  MatrixXd Aref3(n3, n3);
-  Aref3 << 0, 0.5, 0, 0;
-  SolveDAREandVerify(A3, B3, (A3 - Aref3).transpose() * Q3 * (A3 - Aref3),
-      B3.transpose() * Q3 * B3 + R3, (A3 - Aref3).transpose() * Q3 * B3);
-
-  // Test 4: A = B = Q = R = I_2 (2-by-2 identity matrix)
-  const Eigen::MatrixXd A4{Eigen::Matrix2d::Identity()};
-  const Eigen::MatrixXd B4{Eigen::Matrix2d::Identity()};
-  const Eigen::MatrixXd Q4{Eigen::Matrix2d::Identity()};
-  const Eigen::MatrixXd R4{Eigen::Matrix2d::Identity()};
-  SolveDAREandVerify(A4, B4, Q4, R4);
-
-  const Eigen::MatrixXd N4{Eigen::Matrix2d::Identity()};
-  SolveDAREandVerify(A4, B4, Q4, R4, N4);
+  Eigen::MatrixXd Aref{
+      {0.25, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {0, 0, 0, 0}};
+  SolveDAREandVerify(A, B, (A - Aref).transpose() * Q * (A - Aref),
+                     B.transpose() * Q * B + R, (A - Aref).transpose() * Q * B);
 }
+
+GTEST_TEST(DARE, InvertibleA) {
+  // Test 2: invertible A
+  Eigen::MatrixXd A{{1, 1}, {0, 1}};
+  Eigen::MatrixXd B{{0}, {1}};
+  Eigen::MatrixXd Q{{1, 0}, {0, 0}};
+  Eigen::MatrixXd R{{0.3}};
+  SolveDAREandVerify(A, B, Q, R);
+
+  Eigen::MatrixXd Aref{{0.5, 1}, {0, 1}};
+  SolveDAREandVerify(A, B, (A - Aref).transpose() * Q * (A - Aref),
+                     B.transpose() * Q * B + R, (A - Aref).transpose() * Q * B);
+}
+
+GTEST_TEST(DARE, FirstGeneralizedEigenvalueOfSTIsStable) {
+  // Test 3: the first generalized eigenvalue of (S, T) is stable
+  Eigen::MatrixXd A{{0, 1}, {0, 0}};
+  Eigen::MatrixXd B{{0}, {1}};
+  Eigen::MatrixXd Q{{1, 0}, {0, 1}};
+  Eigen::MatrixXd R{{1}};
+  SolveDAREandVerify(A, B, Q, R);
+
+  Eigen::MatrixXd Aref{{0, 0.5}, {0, 0}};
+  SolveDAREandVerify(A, B, (A - Aref).transpose() * Q * (A - Aref),
+                     B.transpose() * Q * B + R, (A - Aref).transpose() * Q * B);
+}
+
+GTEST_TEST(DARE, IdentitySystem) {
+  // Test 4: A = B = Q = R = I₂ₓ₂
+  const Eigen::MatrixXd A{Eigen::Matrix2d::Identity()};
+  const Eigen::MatrixXd B{Eigen::Matrix2d::Identity()};
+  const Eigen::MatrixXd Q{Eigen::Matrix2d::Identity()};
+  const Eigen::MatrixXd R{Eigen::Matrix2d::Identity()};
+  SolveDAREandVerify(A, B, Q, R);
+
+  const Eigen::MatrixXd N{Eigen::Matrix2d::Identity()};
+  SolveDAREandVerify(A, B, Q, R, N);
+}
+
+GTEST_TEST(DARE, MoreInputsThanStates) {
+  // Test 5: More inputs than states
+  const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
+  const Eigen::MatrixXd B{{1, 0, 0}, {0, 0.5, 0.3}};
+  const Eigen::Matrix2d Q{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix3d R{Eigen::Matrix3d::Identity()};
+  SolveDAREandVerify(A, B, Q, R);
+
+  const Eigen::MatrixXd N{{1, 0, 0}, {0, 1, 0}};
+  SolveDAREandVerify(A, B, Q, R, N);
+}
+
+GTEST_TEST(DARE, QNotSymmetricPositiveSemidefinite_ABQR) {
+  const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d B{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d Q{-Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
+
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R), std::runtime_error);
+}
+
+GTEST_TEST(DARE, QNotSymmetricPositiveSemidefinite_ABQRN) {
+  const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d B{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d Q{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d N{2.0 * Eigen::Matrix2d::Identity()};
+
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::runtime_error);
+}
+
+GTEST_TEST(DARE, RNotSymmetricPositiveDefinite_ABQR) {
+  const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d B{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d Q{Eigen::Matrix2d::Identity()};
+
+  const Eigen::Matrix2d R1{Eigen::Matrix2d::Zero()};
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R1), std::runtime_error);
+
+  const Eigen::Matrix2d R2{-Eigen::Matrix2d::Identity()};
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R2), std::runtime_error);
+}
+
+GTEST_TEST(DARE, RNotSymmetricPositiveDefinite_ABQRN) {
+  const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d B{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d Q{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d N{Eigen::Matrix2d::Identity()};
+
+  const Eigen::Matrix2d R1{Eigen::Matrix2d::Zero()};
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R1, N), std::runtime_error);
+
+  const Eigen::Matrix2d R2{-Eigen::Matrix2d::Identity()};
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R2, N), std::runtime_error);
+}
+
+GTEST_TEST(DARE, ABNotStabilizable_ABQR) {
+  const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d B{Eigen::Matrix2d::Zero()};
+  const Eigen::Matrix2d Q{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
+
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R), std::runtime_error);
+}
+
+GTEST_TEST(DARETest, ABNotStabilizable_ABQRN) {
+  const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d B{Eigen::Matrix2d::Zero()};
+  const Eigen::Matrix2d Q{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d N{Eigen::Matrix2d::Identity()};
+
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::runtime_error);
+}
+
+GTEST_TEST(DARETest, ACNotDetectable_ABQR) {
+  const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d B{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d Q{Eigen::Matrix2d::Zero()};
+  const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
+
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R), std::runtime_error);
+}
+
+GTEST_TEST(DARETest, ACNotDetectable_ABQRN) {
+  const Eigen::Matrix2d A{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d B{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d Q{Eigen::Matrix2d::Zero()};
+  const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
+  const Eigen::Matrix2d N{Eigen::Matrix2d::Zero()};
+
+  EXPECT_THROW(SolveDAREandVerify(A, B, Q, R, N), std::runtime_error);
+}
+
 }  // namespace
-}  // namespace math
-}  // namespace drake
+
+}  // namespace drake::math

--- a/math/test/discrete_algebraic_riccati_equation_test.cc
+++ b/math/test/discrete_algebraic_riccati_equation_test.cc
@@ -239,12 +239,14 @@ GTEST_TEST(DARETest, ACNotDetectable_ABQRN) {
 GTEST_TEST(DARETest, QDecomposition) {
   // Ensures the decomposition of Q into CᵀC is correct
 
-  const Eigen::Matrix2d A{{1.0, 0.0}, {0.0, 0.0}};
+  Eigen::Matrix2d A{2, 2};
+  A << 1.0, 0.0, 0.0, 0.0;
   const Eigen::Matrix2d B{Eigen::Matrix2d::Identity()};
   const Eigen::Matrix2d R{Eigen::Matrix2d::Identity()};
 
   // (A, C₁) should be detectable pair
-  const Eigen::Matrix2d C_1{{0.0, 0.0}, {1.0, 0.0}};
+  Eigen::Matrix2d C_1{2, 2};
+  C_1 << 0.0, 0.0, 1.0, 0.0;
   const Eigen::Matrix2d Q_1 = C_1.transpose() * C_1;
   EXPECT_NO_THROW(SolveDAREandVerify(A, B, Q_1, R));
 

--- a/systems/primitives/linear_system_internal.cc
+++ b/systems/primitives/linear_system_internal.cc
@@ -66,7 +66,7 @@ bool IsStabilizable(const Ref<const MatrixXd>& A, const Ref<const MatrixXd>& B,
   // eigenvalues.
   DRAKE_DEMAND(A.rows() == A.cols());
   DRAKE_DEMAND(A.rows() == B.rows());
-  Eigen::EigenSolver<MatrixXd> es(A);
+  Eigen::EigenSolver<MatrixXd> es(A, false);
   DRAKE_DEMAND(es.info() == Eigen::Success);
   for (int i = 0; i < es.eigenvalues().size(); ++i) {
     bool stable_mode = false;


### PR DESCRIPTION
Implements the SDA algorithm on page 5 of the following paper:

  E. K.-W. Chu, H.-Y. Fan, W.-W. Lin & C.-S. Wang "Structure-Preserving
  Algorithms for Periodic Discrete-Time Algebraic Riccati Equations",
  International Journal of Control, 77:8, 767-788, 2004.
  DOI: 10.1080/00207170410001714988

Here's Google Benchmark results for the old DARE solver using https://github.com/calcmogul/DAREBench/:
```
Running ./build/DAREBench
Run on (8 X 3595.49 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 1.59, 4.28, 3.08
-------------------------------------------------------------------------------
Benchmark                                     Time             CPU   Iterations
-------------------------------------------------------------------------------
DARE_WPIMath_Dynamic                       28.2 us         28.1 us        24704
DARE_WPIMath_NoPrecondChecks_Dynamic       21.3 us         21.1 us        33349
DARE_WPIMath_Static                        13.1 us         13.1 us        52985
DARE_WPIMath_NoPrecondChecks_Static        8.78 us         8.77 us        79851
DARE_SLICOT                                41.4 us         41.3 us        16967
DARE_Drake                                 95.6 us         95.3 us         7597
```

Here's Google Benchmark results for the new DARE solver using https://github.com/calcmogul/DAREBench/tree/new-drake-dare-solver:
```
Running ./build/DAREBench
Run on (8 X 3600.03 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 0.65, 0.41, 0.42
-------------------------------------------------------------------------------
Benchmark                                     Time             CPU   Iterations
-------------------------------------------------------------------------------
DARE_WPIMath_Dynamic                       28.1 us         28.1 us        25070
DARE_WPIMath_NoPrecondChecks_Dynamic       21.2 us         21.2 us        32991
DARE_WPIMath_Static                        13.1 us         13.1 us        52666
DARE_WPIMath_NoPrecondChecks_Static        8.79 us         8.79 us        79544
DARE_SLICOT                                41.3 us         41.3 us        16893
DARE_Drake                                 28.1 us         28.1 us        25109
```

"WPIMath" is a previous implementation I wrote of the new algorithm. Benchmarking has shown that using statically sized matrices is twice as fast as dynamically sized matrices, and the precondition checks are very expensive relative to the main solve.

WPIMath refactored the precondition checks out so users could opt out of precondition checking via separate DARE overloads, and so the ABQRN overload doesn't do an extra LLT decomposition of R. I decided to leave Drake's API as is though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20104)
<!-- Reviewable:end -->
