### PR TITLE
[py systems] Improve error message for missing witness functions

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -913,7 +913,7 @@ Note: The above is for the C++ documentation. For Python, use
                       // return anything.
                       throw py::type_error(
                           "The MakeWitnessFunction() calc callback must return "
-                          "a floating pointp value, not NoneType.");
+                          "a floating point value, not NoneType.");
                     }
                     return *result;
                   });

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -423,6 +423,12 @@ class TestCustom(unittest.TestCase):
                     "system reset", WitnessFunctionDirection.kCrossesZero,
                     self._guard, UnrestrictedUpdateEvent(
                         system_callback=self._system_reset))
+                self.witness_result = 1.0
+                self.getwitness_result = [
+                    self.witness,
+                    self.reset_witness,
+                    self.system_reset_witness,
+                ]
 
             def DoPublish(self, context, events):
                 # Call base method to ensure we do not get recursion.
@@ -450,8 +456,7 @@ class TestCustom(unittest.TestCase):
 
             def DoGetWitnessFunctions(self, context):
                 self.called_getwitness = True
-                return [self.witness, self.reset_witness,
-                        self.system_reset_witness]
+                return self.getwitness_result
 
             def _on_initialize(self, context, event):
                 test.assertIsInstance(context, Context)
@@ -550,7 +555,7 @@ class TestCustom(unittest.TestCase):
             def _witness(self, context):
                 test.assertIsInstance(context, Context)
                 self.called_witness = True
-                return 1.0
+                return self.witness_result
 
             def _guard(self, context):
                 test.assertIsInstance(context, Context)
@@ -673,6 +678,20 @@ class TestCustom(unittest.TestCase):
         self.assertFalse(system.called_guard)
         self.assertFalse(system.called_reset)
         self.assertFalse(system.called_system_reset)
+
+        # Test witness function error messages.
+        system = TrivialSystem()
+        system.getwitness_result = None
+        simulator = Simulator(system)
+        with self.assertRaisesRegex(TypeError, "NoneType"):
+            simulator.AdvanceTo(0.1)
+        self.assertTrue(system.called_getwitness)
+        system = TrivialSystem()
+        system.witness_result = None
+        simulator = Simulator(system)
+        with self.assertRaisesRegex(TypeError, "NoneType"):
+            simulator.AdvanceTo(0.1)
+        self.assertTrue(system.called_witness)
 
     def test_event_handler_returns_none(self):
         """Checks that a Python event handler callback function is allowed to


### PR DESCRIPTION
When the user accidentally forgets the `return` statement, the error message was very poor.

Closes #20032.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20106)
<!-- Reviewable:end -->
