### PR TITLE
[parsing] URDF planar joint uses canonical frame

### DIFF
--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -262,6 +262,31 @@ class RotationMatrix {
   static RotationMatrix<T> MakeFromOneUnitVector(const Vector3<T>& u_A,
                                                  int axis_index);
 
+  /// Creates a 3D right-handed orthonormal basis B from a given unit vector
+  /// u_A, returned as a rotation matrix R_AB. It consists of orthogonal unit
+  /// vectors [Bx, By, Bz] where Bz is u_A.
+  /// The angle-axis representation of the resulting rotation is the one with
+  /// the minimum rotation angle that rotates A to B. When u_A is not parallel
+  /// or antiparallel to [0, 0, 1], such rotation is unique.
+  /// @param[in] u_A unit vector expressed in frame A that represents Bz.
+  /// @throws std::exception if u_A is not a unit vector.
+  /// @retval R_AB the rotation matrix with properties as described above.
+  static RotationMatrix<T> MakeClosestRotationToIdentityFromUnitZ(
+      const Vector3<T>& u_A) {
+    ThrowIfNotUnitLength(u_A, __func__);
+    const Vector3<T>& Bz = u_A;
+    const Vector3<T> Az = Vector3<T>(0, 0, 1);
+    // The rotation axis of the Axis-Angle representation of the resulting
+    // rotation.
+    const Vector3<T> axis = Az.cross(Bz);
+    const T axis_norm = axis.norm();
+    const Vector3<T> normalized_axis =
+        axis_norm < 1e-10 ? Vector3<T>(1, 0, 0) : axis / axis_norm;
+    using std::atan2;
+    const T angle = atan2(axis_norm, Az.dot(Bz));
+    return RotationMatrix<T>(Eigen::AngleAxis<T>(angle, normalized_axis));
+  }
+
   /// Creates a %RotationMatrix templatized on a scalar type U from a
   /// %RotationMatrix templatized on scalar type T.  For example,
   /// ```

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -581,9 +581,13 @@ void UrdfParser::ParseJoint(
     // e.g., revolute joint.  Here, we still set F to be coincident with M at
     // the zero state of the joint, but they are not necessarily coincident with
     // B. Instead, we let Mz_B to be specified by the parsed axis, and we let M
-    // and B have the same origin.
-    const Vector3d& Mz_B = axis;
-    const RotationMatrixd R_BM = RotationMatrixd::MakeFromOneVector(Mz_B, 2);
+    // and B have the same origin. Note that, in addition, this does not
+    // uniquely determine M or F, we still have the freedom to choose the x (or
+    // the y) axis to uniquely characterize M and F. Here we choose the M so
+    // that it's as close to B as possible.
+    const RotationMatrixd R_BM =
+        RotationMatrixd::MakeClosestRotationToIdentityFromUnitZ(
+            axis);  // axis is normalized above.
     const RigidTransformd X_BM = RigidTransformd(R_BM, Vector3d::Zero());
     const RigidTransformd X_PM = X_PB * X_BM;
     const RigidTransformd& X_PF = X_PM;


### PR DESCRIPTION
Closes #20095 

Add RotationMatrix::MakeClosestRotationToIdentityFromUnitZ
    
In addition, use this new function when parsing planar joint in URDF. Even though URDF does not put requirement on x and y axes for planar joint, we should choose a canonical frame that's not surprising. In particular if Mz is chosen to be Bz, then we should choose M to be equal to B.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20107)
<!-- Reviewable:end -->
