### PR TITLE
Actuators with PD control implicitly integrated with SAP

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -714,6 +714,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_joint_actuator", &Class::get_joint_actuator,
             py::arg("actuator_index"), py_rvp::reference_internal,
             cls_doc.get_joint_actuator.doc)
+        .def("get_mutable_joint_actuator", &Class::get_mutable_joint_actuator,
+            py::arg("actuator_index"), py_rvp::reference_internal,
+            cls_doc.get_mutable_joint_actuator.doc)
         .def("get_frame", &Class::get_frame, py::arg("frame_index"),
             py_rvp::reference_internal, cls_doc.get_frame.doc)
         .def("gravity_field", &Class::gravity_field, py_rvp::reference_internal,
@@ -904,6 +907,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 ModelInstanceIndex>(&Class::get_actuation_input_port),
             py::arg("model_instance"), py_rvp::reference_internal,
             cls_doc.get_actuation_input_port.doc_1args)
+        .def("get_desired_state_input_port",
+            overload_cast_explicit<const systems::InputPort<T>&,
+                multibody::ModelInstanceIndex>(
+                &Class::get_desired_state_input_port),
+            py::arg("model_instance"), py_rvp::reference_internal,
+            cls_doc.get_desired_state_input_port.doc)
         .def("get_applied_generalized_force_input_port",
             overload_cast_explicit<const systems::InputPort<T>&>(
                 &Class::get_applied_generalized_force_input_port),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -39,6 +39,7 @@ from pydrake.multibody.tree import (
     LinearSpringDamper_,
     ModelInstanceIndex,
     MultibodyForces_,
+    PdControllerGains,
     PlanarJoint_,
     PrismaticJoint_,
     PrismaticSpring_,
@@ -2481,11 +2482,21 @@ class TestPlant(unittest.TestCase):
         file_name = FindResourceOrThrow(
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         # N.B. `Parser` only supports `MultibodyPlant_[float]`.
-        plant_f = MultibodyPlant_[float](0.0)
+        # N.B. PD controllers below are only supported by discrete models.
+        plant_f = MultibodyPlant_[float](0.01)
         Parser(plant_f).AddModels(file_name)
         # Getting ready for when we set foot on Mars :-).
         gravity_vector = np.array([0.0, 0.0, -3.71])
         plant_f.mutable_gravity_field().set_gravity_vector(gravity_vector)
+
+        # Smoke test PD controllers APIs.
+        elbow = plant_f.GetJointActuatorByName("ElbowJoint")
+        mutable_elbow = plant_f.get_mutable_joint_actuator(elbow.index())
+        gains = PdControllerGains(p=2000.0, d=100.0)
+        mutable_elbow.set_controller_gains(gains)
+        self.assertTrue(mutable_elbow.has_controller())
+        mutable_elbow.get_controller_gains()
+
         plant_f.Finalize()
         plant = to_type(plant_f, T)
         context = plant.CreateDefaultContext()

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -179,6 +179,18 @@ void DoScalarIndependentDefinitions(py::module m) {
         });
     DefCopyAndDeepCopy(&cls);
   }
+
+  {
+    using Class = PdControllerGains;
+    constexpr auto& cls_doc = doc.PdControllerGains;
+    py::class_<Class> cls(m, "PdControllerGains", cls_doc.doc);
+    cls  // BR
+        .def(ParamInit<Class>());
+    cls  // BR
+        .def_readwrite("p", &Class::p, cls_doc.p.doc)
+        .def_readwrite("d", &Class::d, cls_doc.d.doc);
+    DefCopyAndDeepCopy(&cls);
+  }
 }
 
 /**
@@ -837,7 +849,13 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("SetGearRatio", &Class::SetGearRatio, py::arg("context"),
             py::arg("gear_ratio"), cls_doc.SetGearRatio.doc)
         .def("calc_reflected_inertia", &Class::calc_reflected_inertia,
-            py::arg("context"), cls_doc.calc_reflected_inertia.doc);
+            py::arg("context"), cls_doc.calc_reflected_inertia.doc)
+        .def("get_controller_gains", &Class::get_controller_gains,
+            cls_doc.get_controller_gains.doc)
+        .def("set_controller_gains", &Class::set_controller_gains,
+            py::arg("gains"), cls_doc.set_controller_gains.doc)
+        .def("has_controller", &Class::has_controller,
+            cls_doc.has_controller.doc);
   }
 
   // Force Elements.

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -426,6 +426,22 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
+    name = "actuated_models_test",
+    data = [
+        "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/wsg_50_description:models",
+        "//multibody:models",
+    ],
+    deps = [
+        ":plant",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/parsing",
+    ],
+)
+
+drake_cc_googletest(
     name = "compliant_contact_manager_scalar_conversion_test",
     deps = [
         ":plant",
@@ -1130,6 +1146,20 @@ drake_cc_googletest(
         ":multibody_plant_core",
         "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:is_dynamic_castable",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sap_driver_pd_controller_constraints_test",
+    data = [
+        "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/wsg_50_description:models",
+    ],
+    deps = [
+        ":compliant_contact_manager_tester",
+        ":plant",
+        "//common:find_resource",
+        "//multibody/parsing",
     ],
 )
 

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -218,8 +218,22 @@ template <typename T>
 const internal::JointLockingCacheData<T>&
 DiscreteUpdateManager<T>::EvalJointLockingCache(
     const systems::Context<T>& context) const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalJointLockingCache(
+      plant(), context);
+}
+
+template <typename T>
+VectorX<T> DiscreteUpdateManager<T>::AssembleActuationInput(
+    const systems::Context<T>& context) const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::AssembleActuationInput(
+      plant(), context);
+}
+
+template <typename T>
+VectorX<T> DiscreteUpdateManager<T>::AssembleDesiredStateInput(
+    const systems::Context<T>& context) const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::EvalJointLockingCache(plant(), context);
+      T>::AssembleDesiredStateInput(plant(), context);
 }
 
 template <typename T>

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -250,8 +250,12 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   void CalcForceElementsContribution(const drake::systems::Context<T>& context,
                                      MultibodyForces<T>* forces) const;
 
-  const internal::JointLockingCacheData<T>&
-  EvalJointLockingCache(
+  const internal::JointLockingCacheData<T>& EvalJointLockingCache(
+      const systems::Context<T>& context) const;
+
+  VectorX<T> AssembleActuationInput(const systems::Context<T>& context) const;
+
+  VectorX<T> AssembleDesiredStateInput(
       const systems::Context<T>& context) const;
 
   const std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>&

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -262,6 +262,45 @@ std::string GetScopedName(
   }
 }
 
+// Helper that returns `true` when all actuators in `model_instance` have PD
+// gains defined.
+template <typename T>
+bool AllActuatorsHavePdControl(const MultibodyPlant<T>& plant,
+                               ModelInstanceIndex model_instance) {
+  for (JointActuatorIndex actuator_index :
+       plant.GetJointActuatorIndices(model_instance)) {
+    if (!plant.get_joint_actuator(actuator_index).has_controller())
+      return false;
+  }
+  return true;
+}
+
+// Helper that returns `true` iff any joint actuator in the model is PD
+// controlled.
+template <typename T>
+bool AnyActuatorHasPdControl(const MultibodyPlant<T>& plant) {
+  for (JointActuatorIndex a(0); a < plant.num_actuators(); ++a) {
+    if (plant.get_joint_actuator(a).has_controller()) return true;
+  }
+  return false;
+}
+
+// Helper that computes the number of PD controlled actuators in a given model
+// instance.
+template <typename T>
+int NumOfPdControlledActuators(const MultibodyPlant<T>& plant,
+                               ModelInstanceIndex model_instance) {
+  int num_actuators = 0;
+  for (JointActuatorIndex a(0); a < plant.num_actuators(); ++a) {
+    const JointActuator<T>& actuator = plant.get_joint_actuator(a);
+    if (actuator.model_instance() == model_instance &&
+        actuator.has_controller()) {
+      ++num_actuators;
+    }
+  }
+  return num_actuators;
+}
+
 }  // namespace
 
 template <typename T>
@@ -1039,6 +1078,13 @@ void MultibodyPlant<T>::Finalize() {
     if (manager) {
       SetDiscreteUpdateManager(std::move(manager));
     }
+  }
+
+  if (!is_discrete() && AnyActuatorHasPdControl(*this)) {
+    throw std::logic_error(
+        "Continuous model with PD controlled joint actuators. This feature is "
+        "only supported for discrete models. Refer to MultibodyPlant's "
+        "documentation for further details.");
   }
 }
 
@@ -2255,11 +2301,10 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
   VectorX<T> actuation_input(num_actuated_dofs());
 
   const auto& actuation_port = this->get_input_port(actuation_port_);
-  const ModelInstanceIndex first_non_world_index(1);
   if (actuation_port.HasValue(context)) {
     // The port for all instances and the actuation ports for individual
     // instances should not be connected at the same time.
-    for (ModelInstanceIndex model_instance_index(first_non_world_index);
+    for (ModelInstanceIndex model_instance_index(0);
          model_instance_index < num_model_instances(); ++model_instance_index) {
       const auto& per_instance_actuation_port =
           this->get_input_port(instance_actuation_ports_[model_instance_index]);
@@ -2271,7 +2316,7 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
             GetModelInstanceName(model_instance_index)));
       }
     }
-    // TODO(xuchenhan-tri): It'd be nice to avoid the copy here.
+    // TODO(amcastro-tri): It'd be nice to avoid the copy here.
     actuation_input = actuation_port.Eval(context);
     if (actuation_input.hasNaN()) {
       throw std::runtime_error(
@@ -2280,33 +2325,111 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
     DRAKE_ASSERT(actuation_input.size() == num_actuated_dofs());
   } else {
     int u_offset = 0;
-    for (ModelInstanceIndex model_instance_index(first_non_world_index);
+    for (ModelInstanceIndex model_instance_index(0);
          model_instance_index < num_model_instances(); ++model_instance_index) {
       // Ignore the port if the model instance has no actuated DoFs.
       const int instance_num_dofs = num_actuated_dofs(model_instance_index);
       if (instance_num_dofs == 0) continue;
 
+      // The user can apply an external feed-forward torque using an actuator.
       const auto& input_port =
           this->get_input_port(instance_actuation_ports_[model_instance_index]);
-      if (!input_port.HasValue(context)) {
-        throw std::logic_error(fmt::format("Actuation input port for model "
-            "instance {} must be connected.",
-            GetModelInstanceName(model_instance_index)));
-      }
-      const auto& u_instance = input_port.Eval(context);
 
-      if (u_instance.hasNaN()) {
-        throw std::runtime_error(
-            fmt::format("Actuation input port for model "
-                        "instance {} contains NaN.",
-                        GetModelInstanceName(model_instance_index)));
+      if (input_port.HasValue(context)) {
+        const auto& u_instance = input_port.Eval(context);
+        if (u_instance.hasNaN()) {
+          throw std::runtime_error(
+              fmt::format("Actuation input port for model "
+                          "instance {} contains NaN.",
+                          GetModelInstanceName(model_instance_index)));
+        }
+        actuation_input.segment(u_offset, instance_num_dofs) = u_instance;
+      } else {
+        // If there is PD control we do not require this actuation to be
+        // connected and we assume a zero feed-forward torque.
+        // However, if there is no PD controller, we require the actuation input
+        // port to be connected.
+        if (!AllActuatorsHavePdControl(*this, model_instance_index)) {
+          throw std::logic_error(
+              fmt::format("Actuation input port for model instance {} must "
+                          "be connected or PD gains must be specified for "
+                          "each actuator.",
+                          GetModelInstanceName(model_instance_index)));
+        }
       }
-      actuation_input.segment(u_offset, instance_num_dofs) = u_instance;
+
       u_offset += instance_num_dofs;
     }
     DRAKE_ASSERT(u_offset == num_actuated_dofs());
   }
+
   return actuation_input;
+}
+
+template <typename T>
+VectorX<T> MultibodyPlant<T>::AssembleDesiredStateInput(
+    const systems::Context<T>& context) const {
+  this->ValidateContext(context);
+
+  // Assemble the vector from the model instance input ports.
+  // TODO(amcastro-tri): Heap allocation here. Get rid of it. Make it EvalFoo().
+  // Desired states of size 2 * num_actuators() for the full model packed as xd
+  // = [qd, vd].
+  VectorX<T> xd = VectorX<T>::Zero(2 * num_actuated_dofs());
+
+  int qd_offset = 0;
+  int vd_offset = num_actuators();
+  for (ModelInstanceIndex model_instance_index(0);
+       model_instance_index < num_model_instances(); ++model_instance_index) {
+    // Ignore the port if the model instance has no actuated DoFs.
+    const int instance_num_u = num_actuated_dofs(model_instance_index);
+    const int instance_num_xd = 2 * instance_num_u;
+
+    // N.B. The desired state port is always declared, though it is zero sized
+    // for models with no PD controllers.
+    if (instance_num_xd == 0) continue;
+
+    const auto& xd_input_port =
+        this->get_desired_state_input_port(model_instance_index);
+
+    const int num_pd_controlled_actuators =
+        NumOfPdControlledActuators(*this, model_instance_index);
+
+    // Desired states input port is ignored for models without PD controllers.
+    if (num_pd_controlled_actuators == instance_num_u) {
+      if (xd_input_port.HasValue(context)) {
+        const auto& xd_instance = xd_input_port.Eval(context);
+        if (xd_instance.hasNaN()) {
+          throw std::runtime_error(
+              fmt::format("Desired state input port for model "
+                          "instance {} contains NaN.",
+                          GetModelInstanceName(model_instance_index)));
+        }
+        xd.segment(qd_offset, instance_num_u) =
+            xd_instance.head(instance_num_u);
+        xd.segment(vd_offset, instance_num_u) =
+            xd_instance.tail(instance_num_u);
+      } else {
+        throw std::runtime_error(
+            fmt::format("Desired state input port for model "
+                        "instance {} not connected.",
+                        GetModelInstanceName(model_instance_index)));
+      }
+    } else if (0 < num_pd_controlled_actuators &&
+               num_pd_controlled_actuators < instance_num_u) {
+      // Partially controlled model. Not supported.
+      throw std::runtime_error(fmt::format(
+          "Model {} is partially PD controlled. For PD controlling a model "
+          "instance, all of its actuators must have gains defined.",
+          GetModelInstanceName(model_instance_index)));
+    }
+    qd_offset += instance_num_u;
+    vd_offset += instance_num_u;
+  }
+  DRAKE_ASSERT(qd_offset == num_actuators());
+  DRAKE_ASSERT(vd_offset == 2 * num_actuators());
+
+  return xd;
 }
 
 template <typename T>
@@ -2646,14 +2769,10 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
   DeclareParameters();
 
   // Declare per model instance actuation ports.
-  ModelInstanceIndex last_actuated_instance;
   instance_actuation_ports_.resize(num_model_instances());
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     const int instance_num_dofs = num_actuated_dofs(model_instance_index);
-    if (instance_num_dofs > 0) {
-      last_actuated_instance = model_instance_index;
-    }
     instance_actuation_ports_[model_instance_index] =
         this->DeclareVectorInputPort(
                 GetModelInstanceName(model_instance_index) + "_actuation",
@@ -2663,6 +2782,22 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
   actuation_port_ =
       this->DeclareVectorInputPort("actuation", num_actuated_dofs())
           .get_index();
+
+  // Declare per model instance desired states input ports.
+  instance_desired_state_ports_.resize(num_model_instances());
+  for (ModelInstanceIndex model_instance_index(0);
+       model_instance_index < num_model_instances(); ++model_instance_index) {
+    const int instance_num_u =
+        NumOfPdControlledActuators(*this, model_instance_index);
+    // Actuators can only be defined on single-dof joints. Therefore the number
+    // of desired states per instance is twice the number of actuators.
+    const int instance_num_xd = 2 * instance_num_u;
+    instance_desired_state_ports_[model_instance_index] =
+        this->DeclareVectorInputPort(
+                GetModelInstanceName(model_instance_index) + "_desired_state",
+                instance_num_xd)
+            .get_index();
+  }
 
   // Declare the generalized force input port.
   applied_generalized_force_input_port_ =
@@ -3039,6 +3174,17 @@ const systems::InputPort<T>& MultibodyPlant<T>::get_actuation_input_port()
     const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   return systems::System<T>::get_input_port(actuation_port_);
+}
+
+template <typename T>
+const systems::InputPort<T>&
+MultibodyPlant<T>::get_desired_state_input_port(
+    ModelInstanceIndex model_instance) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_THROW_UNLESS(model_instance.is_valid());
+  DRAKE_THROW_UNLESS(model_instance < num_model_instances());
+  return systems::System<T>::get_input_port(
+      instance_desired_state_ports_.at(model_instance));
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -198,6 +198,7 @@ input_ports:
 - applied_generalized_force
 - applied_spatial_force
 - <em style="color:gray">model_instance_name[i]</em>_actuation
+- <em style="color:gray">model_instance_name[i]</em>_desired_state
 - <span style="color:green">geometry_query</span>
 output_ports:
 - state
@@ -319,6 +320,91 @@ velocities v, [Seth 2010]. `N(q)` is an `nq x nv` matrix.
 The vector `τ ∈ ℝⁿᵛ` on the right hand side of Eq. (1) is
 the system's generalized forces. These incorporate gravity, springs,
 externally applied body forces, constraint forces, and contact forces.
+
+@anchor mbp_actuation
+                ### Actuation
+
+In a %MultibodyPlant model an actuator can be added as a JointActuator, see
+AddJointActuator(). For models with actuators, the plant will declare an
+actuation input port to provide feedforward actuation, see
+get_actuation_input_port(). Actuation ports can be requested for each individual
+@ref model_instances "model instance" in the %MultibodyPlant.
+
+Unless PD controllers are defined
+(see @ref pd_controllers "PD controlled actuators" next), actuation input ports
+are required to be connected.
+
+@warning Effort limits (JointActuator::effort_limit()) are not enforced, unless
+PD controllers are defined. See @ref pd_controllers "PD controlled actuators".
+
+<!-- TODO(amcastro-tri): Consider enforcing effort limits whether PD controllers
+     are defined or not. -->
+
+@anchor pd_controllers
+  #### Using PD controlled actuators
+
+While PD controllers can be modeled externally and be connected to the
+%MultibodyPlant model via the get_actuation_input_port(), simulation stability
+at discrete time steps can be compromised for high controller gains. For such
+cases, simulation stability and robustness can be improved significantly by
+moving your PD controller into the plant where the discrete solver can strongly
+couple controller and model dynamics.
+
+@warning Currently, this feature is only supported for discrete models
+(is_discrete() is true) using the SAP solver (get_discrete_contact_solver()
+returns DiscreteContactSolver::kSap.)
+
+PD controlled joint actuators can be defined by setting PD gains for each joint
+actuator, see JointActuator::set_controller_gains(). Unless these gains are
+specified, joint actuators will not be PD controlled and
+JointActuator::has_controller() will return `false`.
+
+@warning For PD controlled models, all joint actuators in a model instance are
+required to have PD controllers defined. That is, partially PD controlled model
+instances are not supported. An exception will be thrown when evaluating the
+actuation input ports if only a subset of the actuators in a model instance is
+PD controlled.
+
+For models with PD controllers, the actuation torque per actuator is computed
+according to: <pre>
+  ũ = -Kp⋅(q − qd) - Kd⋅(v − vd) + u_ff
+  u = max(−e, min(e, ũ))
+</pre>
+where qd and vd are desired configuration and velocity (see
+get_desired_state_input_port()) for the actuated joint (see
+JointActuator::joint()), Kp and Kd are the proportional and derivative gains of
+the actuator (see JointActuator::get_controller_gains()), `u_ff` is the
+feed-forward actuation specified with get_actuation_input_port(), and `e`
+corresponds to effort limit (see JointActuator::effort_limit()).
+
+Notice that actuation through get_actuation_input_port() and PD control are not
+mutually exclusive, and they can be used together. This is better explained
+through examples:
+  1. **PD controlled gripper**. In this case, only PD control is used to drive
+     the opening and closing of the fingers. The feed-forward term is assumed to
+     be zero and the actuation input port is not required to be connected.
+  2. **Robot arm**. A typical configuration consists on applying gravity
+     compensation in the feed-forward term plus PD control to drive the robot to
+     a given desired state.
+
+@anchor pd_controllers_and_ports
+  #### Actuation input ports requirements
+
+The following table specifies whether actuation ports are required to be
+connected or not:
+
+|               Port               |   without PD control  | with PD control |
+| :------------------------------: | :-------------------: | :-------------: |
+|  get_actuation_input_port()      |          yes          |       no¹       |
+|  get_desired_state_input_port()  |          no²          |       yes       |
+
+¹ Feed-forward actuation is not required for models with PD controlled
+  actuators. This simplifies the diagram wiring for models that only rely on PD
+  controllers.
+
+² This port is always declared, though it will be zero sized for model instances
+  with no PD controllers.
+
 
 @anchor sdf_loading
                  ### Loading models from SDFormat files
@@ -704,24 +790,72 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_body_spatial_accelerations_output_port()
       const;
 
+  /// Returns a constant reference to the input port for external actuations for
+  /// all actuated dofs regardless the number of model instances that have
+  /// actuated dofs. The input actuation is assumed to be ordered according to
+  /// model instances. This input port is a vector valued port, which can be set
+  /// with JointActuator::set_actuation_vector().
+  /// Refer to @ref mbp_actuation "Actuation" for further details.
+  /// @pre Finalize() was already called on `this` plant.
+  /// @throws std::exception if called before Finalize().
+  /// @throws std::exception if individual actuation ports are connected.
+  const systems::InputPort<T>& get_actuation_input_port() const;
+
   /// Returns a constant reference to the input port for external actuation for
   /// a specific model instance.  This input port is a vector valued port, which
   /// can be set with JointActuator::set_actuation_vector().
+  /// Refer to @ref mbp_actuation "Actuation" for further details.
+  ///
+  /// Each model instance in `this` plant model has an actuation input port,
+  /// even if zero sized (for model instance with no actuators.)
+  ///
+  /// @see GetJointActuatorIndices(), GetActuatedJointIndices().
+  ///
+  /// @note This is a vector valued port of size num_actuators(model_instance)
+  /// (where we assume only 1-DOF joints are actuated.)
+  ///
+  /// @warning It is required to connect this input port unless the model
+  /// instance has PD controllers defined, see get_desired_state_input_port(),
+  /// or if the full multibody version of this port is connected. For models
+  /// with PD controllers, actuation defaults to zero. This allows the modeler
+  /// to use PD controllers only, without the need to provide feed-forward
+  /// torques.
+  ///
+  /// @warning This port cannot be used together with get_actuation_input_port()
+  /// for the full multibody system. Either use the port for the full multibody
+  /// system or the port per model instance, never both.
+  ///
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize().
   /// @throws std::exception if the model instance does not exist.
   const systems::InputPort<T>& get_actuation_input_port(
       ModelInstanceIndex model_instance) const;
 
-  /// Returns a constant reference to the input port for external actuations for
-  /// all actuated dofs regardless the number of model instances that have
-  /// actuated dofs. The input actuation is assumed to be ordered according to
-  /// model instances. This input port is a vector valued port, which can be set
-  /// with JointActuator::set_actuation_vector().
-  /// @pre Finalize() was already called on `this` plant.
-  /// @throws std::exception if called before Finalize().
-  /// @throws std::exception if individual actuation ports are connected.
-  const systems::InputPort<T>& get_actuation_input_port() const;
+  /// For models with PD controlled joint actuators, returns the port to provide
+  /// the desired state for the full `model_instance`.
+  /// Refer to @ref mbp_actuation "Actuation" for further details.
+  ///
+  /// For consistency with get_actuation_input_port(), each model instance in
+  /// `this` plant model has a desired states input port, even if zero sized
+  /// (for model instance with no actuators.)
+  ///
+  /// @note This is a vector valued port of size
+  /// 2*num_actuators(model_instance), where we assumed 1-DOF actuated joints.
+  /// This is true even for unactuated models, for which this port is zero
+  /// sized. This port must provide one desired position and one desired
+  /// velocity per joint actuator. Desired state is assumed to be packed as xd =
+  /// [qd, vd] that is, configurations first followed by velocities.
+  /// Configurations in qd are ordered by JointActuatorIndex, see
+  /// JointActuator::set_actuation_vector(). Similarly for velocities in vd.
+  ///
+  /// @warning If a user specifies a PD controller for an actuator from a given
+  /// model instance, then all actuators of that model instance are required to
+  /// be PD controlled.
+  ///
+  /// @warning It is required to connect this port for PD controlled model
+  /// instances.
+  const systems::InputPort<T>& get_desired_state_input_port(
+      ModelInstanceIndex model_instance) const;
 
   /// Returns a constant reference to the vector-valued input port for applied
   /// generalized forces, and the vector will be added directly into `tau` (see
@@ -4958,6 +5092,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   VectorX<T> AssembleActuationInput(
       const systems::Context<T>& context) const;
 
+  // For models with joint actuators with PD control, this method helps to
+  // assemble desired states for the full model from the input ports for
+  // individual model instances.
+  VectorX<T> AssembleDesiredStateInput(
+      const systems::Context<T>& context) const;
+
   // Computes all non-contact applied forces including:
   //  - Force elements.
   //  - Joint actuation.
@@ -5444,6 +5584,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // The actuation port for all actuated dofs.
   systems::InputPortIndex actuation_port_;
+
+  std::vector<systems::InputPortIndex> instance_desired_state_ports_;
 
   // A port for externally applied generalized forces u.
   systems::InputPortIndex applied_generalized_force_input_port_;

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -66,6 +66,18 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.CalcForceElementsContribution(context, forces);
   }
 
+  static VectorX<T> AssembleActuationInput(
+      const MultibodyPlant<T>& plant,
+      const systems::Context<T>& context) {
+    return plant.AssembleActuationInput(context);
+  }
+
+  static VectorX<T> AssembleDesiredStateInput(
+      const MultibodyPlant<T>& plant,
+      const systems::Context<T>& context) {
+    return plant.AssembleDesiredStateInput(context);
+  }
+
   // TODO(xuchenhan-tri): Remove this when SceneGraph takes control of all
   //  geometries.
   /* Returns the per-body arrays of collision geometries indexed by BodyIndex

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -19,6 +19,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_limit_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_pd_controller_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver_results.h"
 #include "drake/multibody/plant/compliant_contact_manager.h"
@@ -41,6 +42,7 @@ using drake::multibody::contact_solvers::internal::SapDistanceConstraint;
 using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
 using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
 using drake::multibody::contact_solvers::internal::SapLimitConstraint;
+using drake::multibody::contact_solvers::internal::SapPdControllerConstraint;
 using drake::multibody::contact_solvers::internal::SapSolver;
 using drake::multibody::contact_solvers::internal::SapSolverResults;
 using drake::multibody::contact_solvers::internal::SapSolverStatus;
@@ -571,6 +573,57 @@ void SapDriver<T>::AddBallConstraints(
 }
 
 template <typename T>
+void SapDriver<T>::AddPdControllerConstraints(
+    const systems::Context<T>& context, SapContactProblem<T>* problem) const {
+  DRAKE_DEMAND(problem != nullptr);
+
+  // Do nothing if not PD controllers were specified.
+  if (plant().num_actuators() == 0) return;
+
+  // Previous time step positions.
+  const VectorX<T> q0 = plant().GetPositions(context);
+
+  // Desired positions & velocities.
+  const int num_actuators = plant().num_actuators();
+  // TODO(amcastro-tri): makes these EvalFoo() instead to avoid heap
+  // allocations.
+  const VectorX<T> desired_state = manager_->AssembleDesiredStateInput(context);
+  const VectorX<T> feed_forward_actuation =
+      manager_->AssembleActuationInput(context);
+
+  for (JointActuatorIndex actuator_index(0);
+       actuator_index < plant().num_actuators(); ++actuator_index) {
+    const JointActuator<T>& actuator =
+        plant().get_joint_actuator(actuator_index);
+    if (actuator.has_controller()) {
+      const Joint<T>& joint = actuator.joint();
+      const double effort_limit = actuator.effort_limit();
+      const T& qd = desired_state[actuator.index()];
+      const T& vd = desired_state[num_actuators + actuator.index()];
+      const T& u0 = feed_forward_actuation[actuator.index()];
+
+      const int dof = joint.velocity_start();
+      const TreeIndex tree = tree_topology().velocity_to_tree_index(dof);
+      const int tree_dof = dof - tree_topology().tree_velocities_start(tree);
+      const int tree_nv = tree_topology().num_tree_velocities(tree);
+
+      // Controller gains.
+      const PdControllerGains& gains = actuator.get_controller_gains();
+      const T& Kp = gains.p;
+      const T& Kd = gains.d;
+
+      typename SapPdControllerConstraint<T>::Parameters parameters{
+          Kp, Kd, effort_limit};
+      typename SapPdControllerConstraint<T>::Configuration configuration{
+          tree, tree_dof, tree_nv, q0[dof], qd, vd, u0};
+
+      problem->AddConstraint(std::make_unique<SapPdControllerConstraint<T>>(
+          std::move(configuration), std::move(parameters)));
+    }
+  }
+}
+
+template <typename T>
 void SapDriver<T>::CalcContactProblemCache(
     const systems::Context<T>& context, ContactProblemCache<T>* cache) const {
   std::vector<MatrixX<T>> A;
@@ -596,6 +649,7 @@ void SapDriver<T>::CalcContactProblemCache(
   AddCouplerConstraints(context, &problem);
   AddDistanceConstraints(context, &problem);
   AddBallConstraints(context, &problem);
+  AddPdControllerConstraints(context, &problem);
 
   // Make a reduced version of the original contact problem using joint locking
   // data.

--- a/multibody/plant/sap_driver.h
+++ b/multibody/plant/sap_driver.h
@@ -179,6 +179,10 @@ class SapDriver {
       const systems::Context<T>& context,
       contact_solvers::internal::SapContactProblem<T>* problem) const;
 
+  void AddPdControllerConstraints(
+      const systems::Context<T>& context,
+      contact_solvers::internal::SapContactProblem<T>* problem) const;
+
   // This method takes SAP results for a given `problem` and loads forces due to
   // contact only into `contact_results`. `contact_results` is properly resized
   // on output.

--- a/multibody/plant/test/actuated_models_test.cc
+++ b/multibody/plant/test/actuated_models_test.cc
@@ -1,0 +1,324 @@
+#include <limits>
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/multibody_plant_config.h"
+#include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/multibody/tree/revolute_joint.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+
+using Eigen::VectorXd;
+using multibody::Parser;
+using systems::Context;
+
+namespace multibody {
+
+// MultibodyPlant friend class used to provide access to private methods for
+// testing purposes.
+class MultibodyPlantTester {
+ public:
+  static VectorXd AssembleActuationInput(const MultibodyPlant<double>& plant,
+                                         const Context<double>& context) {
+    return plant.AssembleActuationInput(context);
+  }
+
+  static VectorXd AssembleDesiredStateInput(const MultibodyPlant<double>& plant,
+                                            const Context<double>& context) {
+    return plant.AssembleDesiredStateInput(context);
+  }
+};
+
+namespace {
+
+// This fixture loads a MultibodyPlant model of a KUKA Iiiwa arm with a Schunk
+// gripper.
+class ActuatedIiiwaArmTest : public ::testing::Test {
+ public:
+  enum class ModelConfiguration {
+    kArmIsControlled,
+    kArmIsNotControlled,
+    kArmIsPartiallyControlled,
+  };
+
+  // - arm not controlled
+  // - arm controlled
+  // - arm partially controlled
+  void SetUpModel(
+      ModelConfiguration model_config = ModelConfiguration::kArmIsNotControlled,
+      bool is_discrete = true) {
+    const char kArmSdfPath[] =
+        "drake/manipulation/models/iiwa_description/sdf/"
+        "iiwa14_no_collision.sdf";
+
+    const char kWsg50SdfPath[] =
+        "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf";
+
+    // Make a discrete model.
+    const double update_period = is_discrete ? 0.01 : 0.0;
+    plant_ = std::make_unique<MultibodyPlant<double>>(update_period);
+    // Use the SAP solver. Thus far only SAP support the modeling of PD
+    // controllers.
+    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+    Parser parser(plant_.get());
+
+    // Add the arm.
+    arm_model_ = parser.AddModels(FindResourceOrThrow(kArmSdfPath)).at(0);
+
+    // Add the gripper.
+    gripper_model_ = parser.AddModels(FindResourceOrThrow(kWsg50SdfPath)).at(0);
+
+    // A model of a (non-actuated) plate.
+    box_model_ = parser
+                       .AddModels(FindResourceOrThrow(
+                           "drake/multibody/models/box.urdf"))
+                       .at(0);
+
+    const auto& base_body = plant_->GetBodyByName("iiwa_link_0", arm_model_);
+    const auto& end_effector = plant_->GetBodyByName("iiwa_link_7", arm_model_);
+    const auto& gripper_body = plant_->GetBodyByName("body", gripper_model_);
+    plant_->WeldFrames(plant_->world_frame(), base_body.body_frame());
+    plant_->WeldFrames(end_effector.body_frame(), gripper_body.body_frame());
+
+    // Set PD controllers for the gripper.
+    SetGripperModel();
+
+    // Arm actuators.
+    std::vector<JointActuatorIndex> arm_actuators;
+    for (JointActuatorIndex actuator_index(0);
+         actuator_index < plant_->num_actuators(); ++actuator_index) {
+      if (plant_->get_joint_actuator(actuator_index).model_instance() ==
+          arm_model_) {
+        arm_actuators.push_back(actuator_index);
+      }
+    }
+
+    // Set PD controllers for the arm, depending on the desired configuration.
+    if (model_config == ModelConfiguration::kArmIsControlled) {
+      // Define PD controllers for the arm.
+      for (JointActuatorIndex actuator_index : arm_actuators) {
+        JointActuator<double>& actuator =
+            plant_->get_mutable_joint_actuator(actuator_index);
+        actuator.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+      }
+    } else if (model_config == ModelConfiguration::kArmIsPartiallyControlled) {
+      // Add PD control only on a subset of actuators.
+      auto& actuator1 = plant_->get_mutable_joint_actuator(arm_actuators[1]);
+      actuator1.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+      auto& actuator3 = plant_->get_mutable_joint_actuator(arm_actuators[3]);
+      actuator3.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+    }
+
+    plant_->Finalize();
+
+    context_ = plant_->CreateDefaultContext();
+  }
+
+  void SetGripperModel() {
+    for (JointActuatorIndex actuator_index(0);
+         actuator_index < plant_->num_actuators(); ++actuator_index) {
+      JointActuator<double>& actuator =
+          plant_->get_mutable_joint_actuator(actuator_index);
+      if (actuator.model_instance() == gripper_model_) {
+        actuator.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+      }
+    }
+  }
+
+ protected:
+  const int kKukaNumPositions_{7};
+  const int kGripperNumPositions_{2};
+  const double kProportionalGain_{10000.0};
+  const double kDerivativeGain_{100.0};
+  std::unique_ptr<MultibodyPlant<double>> plant_;
+  ModelInstanceIndex arm_model_;
+  ModelInstanceIndex gripper_model_;
+  ModelInstanceIndex box_model_;
+  std::unique_ptr<Context<double>> context_;
+};
+
+TEST_F(ActuatedIiiwaArmTest, JointActuatorApis) {
+  SetUpModel();
+  for (JointActuatorIndex actuator_index :
+       plant_->GetJointActuatorIndices(gripper_model_)) {
+    const auto& actuator = plant_->get_joint_actuator(actuator_index);
+    ASSERT_TRUE(actuator.has_controller());
+    const PdControllerGains& gains = actuator.get_controller_gains();
+    EXPECT_EQ(gains.p, kProportionalGain_);
+    EXPECT_EQ(gains.d, kDerivativeGain_);
+  }
+}
+
+TEST_F(ActuatedIiiwaArmTest, GetActuationInputPort) {
+  SetUpModel();
+
+  EXPECT_NO_THROW(plant_->get_actuation_input_port(arm_model_));
+  EXPECT_NO_THROW(plant_->get_actuation_input_port(gripper_model_));
+
+  // We always have an actuation input port, even for unactuated models. In this
+  // case the port is zero sized.
+  EXPECT_EQ(plant_->get_actuation_input_port(box_model_).size(), 0);
+
+  // Invalid model index throws.
+  const ModelInstanceIndex invalid_index(plant_->num_model_instances() + 10);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_->get_actuation_input_port(invalid_index),
+      ".* get_actuation_input_port\\(\\): condition 'model_instance < "
+      "num_model_instances\\(\\)' failed.");
+}
+
+TEST_F(ActuatedIiiwaArmTest, GetDesiredStatePort) {
+  SetUpModel(ModelConfiguration::kArmIsNotControlled);
+
+  EXPECT_NO_THROW(plant_->get_desired_state_input_port(arm_model_));
+  EXPECT_NO_THROW(plant_->get_desired_state_input_port(gripper_model_));
+
+  // For consistency with actuation input ports, all model instances have a
+  // desired state input port. If the model instance has no PD controllers, this
+  // port will have zero size.
+  EXPECT_EQ(plant_->get_desired_state_input_port(arm_model_).size(),
+            0);  // The arm is not PD controlled.
+  EXPECT_EQ(plant_->get_desired_state_input_port(box_model_).size(),
+            0);  // The free floating box has no actuators.
+
+  // Invalid model index throws.
+  const ModelInstanceIndex invalid_index(plant_->num_model_instances() + 10);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_->get_desired_state_input_port(invalid_index),
+      ".* get_desired_state_input_port\\(\\): condition 'model_instance < "
+      "num_model_instances\\(\\)' failed.");
+}
+
+// Verify that MultibodyPlant::AssembleActuationInput() throws an exception if
+// the actuation input port for a model instance without PD controllers is not
+// connected.
+TEST_F(ActuatedIiiwaArmTest, AssembleActuationInput_ActuationInputRequired) {
+  SetUpModel();
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MultibodyPlantTester::AssembleActuationInput(*plant_, *context_),
+      "Actuation input port for model instance iiwa14 must be connected or PD "
+      "gains must be specified for each actuator.");
+}
+
+// Verify that actuation port is not required to be connected if the model is PD
+// controlled.
+TEST_F(ActuatedIiiwaArmTest, AssembleActuationInput_NotRequiredIfPdControlled) {
+  SetUpModel();
+
+  // The actuation input port for the arm is required to be connected.
+  plant_->get_actuation_input_port(arm_model_)
+      .FixValue(context_.get(), VectorXd::Zero(kKukaNumPositions_));
+
+  // The actuation input port for the gripper is not required to be connected
+  // since its actuators are PD controlled.
+  EXPECT_NO_THROW(
+      MultibodyPlantTester::AssembleActuationInput(*plant_, *context_));
+}
+
+// Verify that MultibodyPlant::AssembleDesiredStateInput() throws an exception
+// when not all actuators in a model instance are PD controlled. Once a PD
+// controller is defined in a model instance, all actuators must use PD control.
+TEST_F(ActuatedIiiwaArmTest,
+       AssembleDesiredStateInput_ThrowsIfPartiallyPDControlled) {
+  SetUpModel(ModelConfiguration::kArmIsPartiallyControlled);
+
+  // The gripper has controllers in all of its actuators and thus it is required
+  // to be connected.
+  plant_->get_desired_state_input_port(gripper_model_)
+      .FixValue(context_.get(), VectorXd::Zero(2 * kGripperNumPositions_));
+
+  // We now verify AssembleDesiredStateInput() throws for the right reason.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_),
+      "Model iiwa14 is partially PD controlled. .*");
+}
+
+TEST_F(ActuatedIiiwaArmTest,
+       AssembleDesiredStateInput_ThrowsIfDesiredStateNotConnected) {
+  SetUpModel();
+
+  // The input port for desired states for the gripper is required to be
+  // connected.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_),
+      "Desired state input port for model instance Schunk_Gripper not "
+      "connected.");
+}
+
+// Verify the assembly of desired states for a plant with a single PD controlled
+// model instance.
+TEST_F(ActuatedIiiwaArmTest,
+       AssembleDesiredStateInput_VerifyAssemblyWithOneModel) {
+  SetUpModel();
+
+  const VectorXd gripper_xd = (VectorXd(4) << 1., 2., 3, 4.).finished();
+  plant_->get_desired_state_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_xd);
+  const VectorXd full_xd =
+      MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_);
+
+  const int nu = plant_->num_actuated_dofs();
+  // AssembleDesiredStateInput will always return a vector of size 2 * nu. It
+  // fill in values for those models with PD control and set all other entries
+  // to zero. In this case, entries corresponding to the arm are expected to be
+  // zero. All qd values go first, followed by vd values.
+  const int arm_nu = plant_->num_actuated_dofs(arm_model_);
+  VectorXd expected_xd =
+      (VectorXd(2 * nu) << VectorXd::Zero(arm_nu), gripper_xd.head<2>(),
+       VectorXd::Zero(arm_nu), gripper_xd.tail<2>())
+          .finished();
+
+  EXPECT_EQ(full_xd, expected_xd);
+}
+
+// Verify the assembly of desired states for a plant with two PD controlled
+// model instances.
+TEST_F(ActuatedIiiwaArmTest,
+       AssembleDesiredStateInput_VerifyAssemblyWithTwoModels) {
+  SetUpModel(ModelConfiguration::kArmIsControlled);
+
+  // Fixed desired state input ports to known values.
+  // Both arm and gripper are required to be connected.
+  const VectorXd gripper_xd = (VectorXd(4) << 1., 2., 3, 4.).finished();
+  plant_->get_desired_state_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_xd);
+  const VectorXd arm_xd = VectorXd::LinSpaced(14, 1.0, 14.0);
+  plant_->get_desired_state_input_port(arm_model_)
+      .FixValue(context_.get(), arm_xd);
+
+  const VectorXd full_xd =
+      MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_);
+  // Desired states must be assembled according to model instance order,
+  // therefore in this case arm first followed by gripper. All qd values go
+  // first, followed by vd values.
+  const int nu = plant_->num_actuated_dofs();
+  const VectorXd expected_xd =
+      (VectorXd(2 * nu) << arm_xd.head<7>(), gripper_xd.head<2>(),
+       arm_xd.tail<7>(), gripper_xd.tail<2>())
+          .finished();
+
+  EXPECT_EQ(full_xd, expected_xd);
+}
+
+TEST_F(ActuatedIiiwaArmTest,
+       PdControlledActuatorsOnlySupportedForDiscreteModels) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SetUpModel(ModelConfiguration::kArmIsControlled, false),
+      "Continuous model with PD controlled joint actuators. This feature is "
+      "only supported for discrete models. Refer to MultibodyPlant's "
+      "documentation for further details.");
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -604,7 +604,7 @@ GTEST_TEST(ActuationPortsTest, CheckActuation) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.CalcTimeDerivatives(*context, continuous_state.get()),
       "Actuation input port for model instance .* must "
-          "be connected.");
+      "be connected or PD gains must be specified for each actuator.");
 
   // Verify that derivatives can be computed after fixing the acrobot actuation
   // input port.

--- a/multibody/plant/test/sap_driver_pd_controller_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_pd_controller_constraints_test.cc
@@ -1,0 +1,228 @@
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_pd_controller_constraint.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/sap_driver.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+
+/* @file This file tests SapDriver's support for PD controller constraints. */
+
+using drake::math::RigidTransformd;
+using drake::multibody::Parser;
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapPdControllerConstraint;
+using drake::systems::Context;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using Configuration = SapPdControllerConstraint<double>::Configuration;
+
+namespace drake {
+namespace multibody {
+
+namespace contact_solvers {
+namespace internal {
+// N.B. What namespace this operator is in is important for ADL.
+bool operator==(const Configuration& a, const Configuration& b) {
+  if (a.clique != b.clique) return false;
+  if (a.clique_dof != b.clique_dof) return false;
+  if (a.clique_nv != b.clique_nv) return false;
+  if (a.q0 != b.q0) return false;
+  if (a.qd != b.qd) return false;
+  if (a.vd != b.vd) return false;
+  if (a.u0 != b.u0) return false;
+  return true;
+}
+}  // namespace internal
+}  // namespace contact_solvers
+
+namespace internal {
+
+// Friend class used to provide access to a selection of private functions in
+// SapDriver for testing purposes.
+class SapDriverTest {
+ public:
+  static const ContactProblemCache<double>& EvalContactProblemCache(
+      const SapDriver<double>& driver, const Context<double>& context) {
+    return driver.EvalContactProblemCache(context);
+  }
+};
+
+// Test fixture that sets up a model of an IIWA arm with PD controlled gripper.
+// Its purpose is to verify that the SAP driver defines constraints
+// appropriately to model the PD controllers on the gripper.
+class ActuatedIiiwaArmTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    const char kArmSdfPath[] =
+        "drake/manipulation/models/iiwa_description/sdf/"
+        "iiwa14_no_collision.sdf";
+
+    const char kWsg50SdfPath[] =
+        "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf";
+
+    // Make a discrete model.
+    plant_ = std::make_unique<MultibodyPlant<double>>(0.01 /* update period */);
+    // Use the SAP solver. Thus far only SAP support the modeling of PD
+    // controllers.
+    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+    Parser parser(plant_.get());
+
+    // Add the arm.
+    arm_model_ = parser.AddModels(FindResourceOrThrow(kArmSdfPath)).at(0);
+
+    // Add the gripper.
+    gripper_model_ = parser.AddModels(FindResourceOrThrow(kWsg50SdfPath)).at(0);
+
+    const auto& base_body = plant_->GetBodyByName("iiwa_link_0", arm_model_);
+    const auto& end_effector = plant_->GetBodyByName("iiwa_link_7", arm_model_);
+    const auto& gripper_body = plant_->GetBodyByName("body", gripper_model_);
+    plant_->WeldFrames(plant_->world_frame(), base_body.body_frame());
+    plant_->WeldFrames(end_effector.body_frame(), gripper_body.body_frame());
+
+    // Set PD controllers for the gripper.
+    SetGripperModel();
+
+    plant_->Finalize();
+
+    // We set the manager programmatically in order to have access to its
+    // instance.
+    auto owned_contact_manager =
+        std::make_unique<CompliantContactManager<double>>();
+    manager_ = owned_contact_manager.get();
+    plant_->SetDiscreteUpdateManager(std::move(owned_contact_manager));
+
+    context_ = plant_->CreateDefaultContext();
+  }
+
+  void SetGripperModel() {
+    for (JointActuatorIndex actuator_index(0);
+         actuator_index < plant_->num_actuators(); ++actuator_index) {
+      JointActuator<double>& actuator =
+          plant_->get_mutable_joint_actuator(actuator_index);
+      if (actuator.model_instance() == gripper_model_) {
+        actuator.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+      }
+    }
+  }
+
+  const SapDriver<double>& sap_driver() const {
+    return CompliantContactManagerTester::sap_driver(*manager_);
+  }
+
+ protected:
+  const int kKukaNumPositions_{7};
+  const int kGripperNumPositions_{2};
+  const double kProportionalGain_{10000.0};
+  const double kDerivativeGain_{100.0};
+  const double kEffortLimit_{80.0};  // Defined in schunk_wsg_50.sdf
+  std::unique_ptr<MultibodyPlant<double>> plant_;
+  ModelInstanceIndex arm_model_;
+  ModelInstanceIndex gripper_model_;
+  CompliantContactManager<double>* manager_{nullptr};
+  std::unique_ptr<Context<double>> context_;
+};
+
+// We verify that the SAP driver properly defined constraints to model the PD
+// controllers in the gripper fingers.
+TEST_F(ActuatedIiiwaArmTest, VerifyConstraints) {
+  // We expect each of the 1-DOF joints to be actuated.
+  EXPECT_EQ(plant_->num_actuators(), plant_->num_velocities());
+
+  // Sanity check we only defined PD controllers for the grippers DOFs.
+  int num_controlled_actuators = 0;
+  for (JointActuatorIndex a(0); a < plant_->num_actuators(); ++a) {
+    const JointActuator<double>& actuator = plant_->get_joint_actuator(a);
+    if (actuator.has_controller()) ++num_controlled_actuators;
+  }
+  EXPECT_EQ(num_controlled_actuators, 2);
+
+  // The actuation input port for the arm is required to be connected.
+  const VectorXd arm_u =
+      VectorXd::LinSpaced(kKukaNumPositions_, 1.0, kKukaNumPositions_);
+  plant_->get_actuation_input_port(arm_model_).FixValue(context_.get(), arm_u);
+
+  // Since the gripper has controllers, the desired state input port must be
+  // connected.
+  const VectorXd gripper_xd = (VectorXd(4) << 1., 2., 3, 4.).finished();
+  plant_->get_desired_state_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_xd);
+
+  // Arbitrary feed-forward term for testing.
+  const VectorXd gripper_ff = (VectorXd(2) << 5., 6.).finished();
+  plant_->get_actuation_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_ff);
+
+  const ContactProblemCache<double>& problem_cache =
+      SapDriverTest::EvalContactProblemCache(sap_driver(), *context_);
+  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+  // We should at least have two constraints to model the controllers.
+  // Additional constraints will correspond to joint limits.
+  EXPECT_GE(problem.num_constraints(), 2);
+  EXPECT_GE(problem.num_constraint_equations(), 2);
+
+  auto make_finger_config = [&](const std::string& name) {
+    const int dof = plant_->GetJointByName(name).velocity_start();
+    const int gripper_dof = dof - kKukaNumPositions_;
+    const int clique = 0;  // Only one kinematic tree in this model.
+    const int clique_dof = dof;
+    const int clique_nv = 9;  // 7 Kuka DOFs + 2 gripper DOFs.
+    const VectorXd q = plant_->GetPositions(*context_);
+    const double q0 = q[dof];  // For this model nq = nv.
+    const double qd = gripper_xd(gripper_dof);
+    const double vd = gripper_xd(2 + gripper_dof);
+    const double u_ff = gripper_ff(gripper_dof);
+    SapPdControllerConstraint<double>::Configuration config{
+        clique, clique_dof, clique_nv, q0, qd, vd, u_ff};
+    return config;
+  };
+
+  const SapPdControllerConstraint<double>::Configuration left_finger_config =
+      make_finger_config("left_finger_sliding_joint");
+  const SapPdControllerConstraint<double>::Configuration right_finger_config =
+      make_finger_config("right_finger_sliding_joint");
+
+  for (int k = 0; k < problem.num_constraints(); ++k) {
+    const auto* constraint =
+        dynamic_cast<const SapPdControllerConstraint<double>*>(
+            &problem.get_constraint(k));
+    if (constraint != nullptr) {
+      const auto& p = constraint->parameters();
+      EXPECT_EQ(p.Kp(), kProportionalGain_);
+      EXPECT_EQ(p.Kd(), kDerivativeGain_);
+      EXPECT_EQ(p.effort_limit(), kEffortLimit_);
+
+      // Always one clique for PD controllers.
+      EXPECT_EQ(constraint->num_cliques(), 1);
+      // There is only one kinematic tree in this model, thus the driver will
+      // only define a single clique.
+      EXPECT_EQ(constraint->first_clique(), 0);
+      EXPECT_THROW(constraint->second_clique(), std::exception);
+
+      const auto& c = constraint->configuration();
+      EXPECT_EQ(c.clique, 0);  // There is only one clique.
+      // Either of the two gripper DOFs.
+      EXPECT_TRUE(c.clique_dof == 7 || c.clique_dof == 8);
+      EXPECT_EQ(c.clique_nv, 9);  // 7 Kuka DOFs + 2 gripper DOFs.
+
+      if (c.clique_dof == left_finger_config.clique_dof) {
+        EXPECT_EQ(c, left_finger_config);
+      } else {
+        EXPECT_EQ(c, right_finger_config);
+      }
+    }
+  }
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -19,6 +19,18 @@ JointActuator<T>::JointActuator(const std::string& name, const Joint<T>& joint,
 }
 
 template <typename T>
+void JointActuator<T>::set_controller_gains(PdControllerGains gains) {
+  if (topology_.actuator_index_start >= 0) {
+    throw std::runtime_error(
+        "JointActuator::set_controller_gains() must be called before "
+        "MultibodyPlant::Finalize(). ");
+  }
+  DRAKE_THROW_UNLESS(gains.p > 0);
+  DRAKE_THROW_UNLESS(gains.d >= 0);
+  pd_controller_gains_ = gains;
+}
+
+template <typename T>
 const Joint<T>& JointActuator<T>::joint() const {
   return this->get_parent_tree().get_joint(joint_index_);
 }

--- a/multibody/tree/test/joint_actuator_test.cc
+++ b/multibody/tree/test/joint_actuator_test.cc
@@ -43,6 +43,14 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
   const auto& actuator1 = tree.GetJointActuatorByName("act1");
   EXPECT_EQ(actuator1.effort_limit(), kPositiveEffortLimit);
 
+  // Unit test PD controller APIs.
+  EXPECT_FALSE(actuator1.has_controller());
+  JointActuator<double>& mutable_actuator1 =
+      tree.get_mutable_joint_actuator(actuator1.index());
+  PdControllerGains gains{.p = 1000, .d = 100};
+  mutable_actuator1.set_controller_gains(gains);
+  EXPECT_TRUE(actuator1.has_controller());
+
   // Throw if the effort limit is set to 0.
   const Joint<double>& body2_body1 =
       tree.AddJoint(std::make_unique<PrismaticJoint<double>>(


### PR DESCRIPTION
New feature to define PD controlled actuators (with effort limits).
The model is integrated in SAP for stable simulation even with high gains.

Closes #19067

Below is a screenshot of the new MbP docs in this PR on PD controlled actuators:
![pd_control_docs](https://github.com/RobotLocomotion/drake/assets/17601461/afb4a59f-a025-4a3a-a24f-a4e56f5f409d)


cc'ing @joemasterjohn and @JoseBarreiros-TRI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20111)
<!-- Reviewable:end -->
