### PR TITLE
Update primitives and examples to use modern event API

### DIFF
--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -30,7 +30,8 @@ Rod2D<T>::Rod2D(SystemType system_type, double dt)
 
     // Discretization approach requires three position variables and
     // three velocity variables, all discrete, and periodic update.
-    this->DeclarePeriodicDiscreteUpdateNoHandler(dt);
+    this->DeclarePeriodicDiscreteUpdateEvent(dt, 0.0,
+                                             &Rod2D<T>::CalcDiscreteUpdate);
     auto state_index = this->DeclareDiscreteState(6);
     state_output_port_ = &this->DeclareStateOutputPort(
         "state_output", state_index);
@@ -481,9 +482,8 @@ void Rod2D<T>::CalcImpactProblemData(
 /// Integrates the Rod 2D example forward in time using a
 /// half-explicit discretization scheme.
 template <class T>
-void Rod2D<T>::DoCalcDiscreteVariableUpdates(
+void Rod2D<T>::CalcDiscreteUpdate(
     const systems::Context<T>& context,
-    const std::vector<const systems::DiscreteUpdateEvent<T>*>&,
     systems::DiscreteValues<T>* discrete_state) const {
   using std::sin;
   using std::cos;

--- a/examples/rod2d/rod2d.h
+++ b/examples/rod2d/rod2d.h
@@ -504,10 +504,9 @@ class Rod2D : public systems::LeafSystem<T> {
   void DoCalcTimeDerivatives(const systems::Context<T>& context,
                              systems::ContinuousState<T>* derivatives)
                                const override;
-  void DoCalcDiscreteVariableUpdates(
+  void CalcDiscreteUpdate(
       const systems::Context<T>& context,
-      const std::vector<const systems::DiscreteUpdateEvent<T>*>& events,
-      systems::DiscreteValues<T>* discrete_state) const override;
+      systems::DiscreteValues<T>* discrete_state) const;
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override;
 

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -10,6 +10,7 @@ namespace schunk_wsg {
 using systems::BasicVector;
 using systems::Context;
 using systems::DiscreteValues;
+using systems::EventStatus;
 
 SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(int input_size,
                                                            int position_index)
@@ -33,7 +34,10 @@ SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(int input_size,
       SchunkWsgTrajectoryGeneratorStateVector<double>());
   // The update period below matches the polling rate from
   // drake-schunk-driver.
-  this->DeclarePeriodicDiscreteUpdateNoHandler(0.05);
+  this->DeclarePeriodicDiscreteUpdateEvent(
+      0.05, 0.0, &SchunkWsgTrajectoryGenerator::CalcDiscreteUpdate);
+  this->DeclareForcedDiscreteUpdateEvent(
+      &SchunkWsgTrajectoryGenerator::CalcDiscreteUpdate);
 }
 
 void SchunkWsgTrajectoryGenerator::OutputTarget(
@@ -59,9 +63,8 @@ void SchunkWsgTrajectoryGenerator::OutputForce(
   output->get_mutable_value() = Vector1d(traj_state->max_force());
 }
 
-void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
+EventStatus SchunkWsgTrajectoryGenerator::CalcDiscreteUpdate(
     const Context<double>& context,
-    const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
     DiscreteValues<double>* discrete_state) const {
   const double desired_position =
       get_desired_position_input_port().Eval(context)[0];
@@ -97,6 +100,8 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
     new_traj_state->set_trajectory_start_time(
         last_traj_state->trajectory_start_time());
   }
+
+  return EventStatus::Succeeded();
 }
 
 void SchunkWsgTrajectoryGenerator::UpdateTrajectory(

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
@@ -78,10 +78,9 @@ class SchunkWsgTrajectoryGenerator : public systems::LeafSystem<double> {
                    systems::BasicVector<double>* output) const;
 
   /// Latches the input port into the discrete state.
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventStatus CalcDiscreteUpdate(
       const systems::Context<double>& context,
-      const std::vector<const systems::DiscreteUpdateEvent<double>*>& events,
-      systems::DiscreteValues<double>* discrete_state) const override;
+      systems::DiscreteValues<double>* discrete_state) const;
 
   void UpdateTrajectory(double cur_position, double target_position) const;
 

--- a/planning/trajectory_optimization/test/direct_transcription_test.cc
+++ b/planning/trajectory_optimization/test/direct_transcription_test.cc
@@ -52,7 +52,8 @@ class CubicPolynomialSystem final : public systems::LeafSystem<T> {
         time_step_(time_step) {
     // Zero inputs, zero outputs.
     this->DeclareDiscreteState(1);  // One state variable.
-    this->DeclarePeriodicDiscreteUpdateNoHandler(time_step);
+    this->DeclarePeriodicDiscreteUpdateEvent(
+        time_step, 0.0, &CubicPolynomialSystem<T>::CalcDiscreteUpdate);
   }
 
   // Scalar-converting copy constructor.
@@ -64,10 +65,8 @@ class CubicPolynomialSystem final : public systems::LeafSystem<T> {
 
  private:
   // x[n+1] = x³[n]
-  void DoCalcDiscreteVariableUpdates(
-      const Context<T>& context,
-      const std::vector<const DiscreteUpdateEvent<T>*>&,
-      DiscreteValues<T>* discrete_state) const final {
+  void CalcDiscreteUpdate(const Context<T>& context,
+                          DiscreteValues<T>* discrete_state) const {
     using std::pow;
     (*discrete_state)[0] =
         pow(context.get_discrete_state(0).GetAtIndex(0), 3.0);
@@ -86,7 +85,8 @@ class LinearSystemWParams final : public systems::LeafSystem<T> {
     // Zero inputs, zero outputs.
     this->DeclareDiscreteState(1);                     // One state variable.
     this->DeclareNumericParameter(BasicVector<T>(1));  // One parameter.
-    this->DeclarePeriodicDiscreteUpdateNoHandler(1.0);
+    this->DeclarePeriodicDiscreteUpdateEvent(
+        1.0, 0.0, &LinearSystemWParams<T>::CalcDiscreteUpdate);
   }
 
   // Scalar-converting copy constructor.
@@ -96,10 +96,8 @@ class LinearSystemWParams final : public systems::LeafSystem<T> {
 
  private:
   // x[n+1] = p0 * x[n]
-  void DoCalcDiscreteVariableUpdates(
-      const Context<T>& context,
-      const std::vector<const DiscreteUpdateEvent<T>*>&,
-      DiscreteValues<T>* discrete_state) const final {
+  void CalcDiscreteUpdate(const Context<T>& context,
+                          DiscreteValues<T>* discrete_state) const {
     (*discrete_state)[0] = context.get_numeric_parameter(0).GetAtIndex(0) *
                            context.get_discrete_state(0).GetAtIndex(0);
   }

--- a/systems/controllers/linear_model_predictive_controller.h
+++ b/systems/controllers/linear_model_predictive_controller.h
@@ -84,6 +84,9 @@ class LinearModelPredictiveController : public LeafSystem<T> {
  private:
   void CalcControl(const Context<T>& context, BasicVector<T>* control) const;
 
+  EventStatus DoNothingButPretendItWasSomething(const Context<T>&,
+                                                DiscreteValues<T>*) const;
+
   // Sets up a DirectTranscription problem and solves for the current control
   // input.
   VectorX<T> SetupAndSolveQp(const Context<T>& base_context,

--- a/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -95,7 +95,8 @@ class CubicPolynomialSystem final : public LeafSystem<T> {
                                   &CubicPolynomialSystem::OutputState,
                                   {this->all_state_ticket()});
     this->DeclareDiscreteState(2);
-    this->DeclarePeriodicDiscreteUpdateNoHandler(time_step);
+    this->DeclarePeriodicDiscreteUpdateEvent(
+        time_step, 0.0, &CubicPolynomialSystem<T>::CalcDiscreteUpdate);
   }
 
   template <typename U>
@@ -107,10 +108,9 @@ class CubicPolynomialSystem final : public LeafSystem<T> {
 
   // x1(k+1) = u(k)
   // x2(k+1) = -x1³(k)
-  void DoCalcDiscreteVariableUpdates(
+  void CalcDiscreteUpdate(
       const Context<T>& context,
-      const std::vector<const DiscreteUpdateEvent<T>*>&,
-      DiscreteValues<T>* next_state) const final {
+      DiscreteValues<T>* next_state) const {
     using std::pow;
     const T& x1 = context.get_discrete_state(0).get_value()[0];
     const T& u = this->get_input_port(0).Eval(context)[0];

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -51,13 +51,18 @@ class EmptySystem : public LeafSystem<T> {
   void AddPeriodicDiscreteUpdate() {
     const double default_period = 1.125;
     const double default_offset = 2.25;
-    this->DeclarePeriodicDiscreteUpdateNoHandler(default_period,
-                                                 default_offset);
+    this->DeclarePeriodicDiscreteUpdateEvent(default_period, default_offset,
+                                             &EmptySystem::Noop);
   }
 
   // Adds a specific periodic discrete update.
   void AddPeriodicDiscreteUpdate(double period, double offset) {
-    this->DeclarePeriodicDiscreteUpdateNoHandler(period, offset);
+    this->DeclarePeriodicDiscreteUpdateEvent(period, offset,
+                                             &EmptySystem::Noop);
+  }
+
+  EventStatus Noop(const Context<T>&, DiscreteValues<T>*) const {
+    return EventStatus::DidNothing();
   }
 };
 

--- a/systems/framework/test_utilities/initialization_test_system.h
+++ b/systems/framework/test_utilities/initialization_test_system.h
@@ -14,22 +14,47 @@ namespace systems {
 class InitializationTestSystem : public LeafSystem<double> {
  public:
   InitializationTestSystem() {
+    // N.B. In the code below, we call the DeclareInitializationEvent() internal
+    // API to declare events, so that we can carefully inspect the contents
+    // during unit testing. Users should NOT use this event API, but instead the
+    // DeclareInitializationPublishEvent(), etc.
+
+    // Publish event.
     PublishEvent<double> pub_event(
         TriggerType::kInitialization,
         [this](const System<double>&, const Context<double>&,
                const PublishEvent<double>& event) {
-          this->InitPublish(event);
+          EXPECT_EQ(event.get_trigger_type(), TriggerType::kInitialization);
+          this->InitPublish();
           return EventStatus::Succeeded();
         });
     DeclareInitializationEvent(pub_event);
 
+    // Discrete state and update event.
     DeclareDiscreteState(1);
-    DeclareAbstractState(Value<bool>(false));
+    DiscreteUpdateEvent<double> discrete_update_event(
+        TriggerType::kInitialization,
+        [this](const System<double>&, const Context<double>&,
+               const DiscreteUpdateEvent<double>& event,
+               DiscreteValues<double>* discrete_state) {
+          EXPECT_EQ(event.get_trigger_type(), TriggerType::kInitialization);
+          this->InitDiscreteUpdate(discrete_state);
+          return EventStatus::Succeeded();
+        });
+    DeclareInitializationEvent(discrete_update_event);
 
-    DeclareInitializationEvent(
-        DiscreteUpdateEvent<double>(TriggerType::kInitialization));
-    DeclareInitializationEvent(
-        UnrestrictedUpdateEvent<double>(TriggerType::kInitialization));
+    // Abstract state and update event.
+    DeclareAbstractState(Value<bool>(false));
+    UnrestrictedUpdateEvent<double> unrestricted_update_event(
+        TriggerType::kInitialization,
+        [this](const System<double>&, const Context<double>&,
+               const UnrestrictedUpdateEvent<double>& event,
+               State<double>* state) {
+          EXPECT_EQ(event.get_trigger_type(), TriggerType::kInitialization);
+          this->InitUnrestrictedUpdate(state);
+          return EventStatus::Succeeded();
+        });
+    DeclareInitializationEvent(unrestricted_update_event);
   }
 
   bool get_pub_init() const { return pub_init_; }
@@ -37,27 +62,16 @@ class InitializationTestSystem : public LeafSystem<double> {
   bool get_unres_update_init() const { return unres_update_init_; }
 
  private:
-  void InitPublish(const PublishEvent<double>& event) const {
-    EXPECT_EQ(event.get_trigger_type(), TriggerType::kInitialization);
+  void InitPublish() const {
     pub_init_ = true;
   }
 
-  void DoCalcDiscreteVariableUpdates(
-      const Context<double>&,
-      const std::vector<const DiscreteUpdateEvent<double>*>& events,
-      DiscreteValues<double>* discrete_state) const final {
-    EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kInitialization);
+  void InitDiscreteUpdate(DiscreteValues<double>* discrete_state) const {
     dis_update_init_ = true;
     discrete_state->set_value(Vector1d(1.23));
   }
 
-  void DoCalcUnrestrictedUpdate(
-      const Context<double>&,
-      const std::vector<const UnrestrictedUpdateEvent<double>*>& events,
-      State<double>* state) const final {
-    EXPECT_EQ(events.size(), 1);
-    EXPECT_EQ(events.front()->get_trigger_type(), TriggerType::kInitialization);
+  void InitUnrestrictedUpdate(State<double>* state) const {
     unres_update_init_ = true;
     state->get_mutable_abstract_state<bool>(0) = true;
   }

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -32,7 +32,10 @@ DiscreteDerivative<T>::DiscreteDerivative(int num_inputs, double time_step,
     // at time == 0.0.
     this->DeclareDiscreteState(1);
   }
-  this->DeclarePeriodicDiscreteUpdateNoHandler(time_step_);
+  this->DeclarePeriodicDiscreteUpdateEvent(
+      time_step_, 0.0, &DiscreteDerivative<T>::CalcDiscreteUpdate);
+  this->DeclareForcedDiscreteUpdateEvent(
+      &DiscreteDerivative<T>::CalcDiscreteUpdate);
 }
 
 template <typename T>
@@ -57,9 +60,8 @@ void DiscreteDerivative<T>::set_input_history(
 }
 
 template <typename T>
-void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
+EventStatus DiscreteDerivative<T>::CalcDiscreteUpdate(
     const drake::systems::Context<T>& context,
-    const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
     drake::systems::DiscreteValues<T>* state) const {
   // x₀[n+1] = u[n].
   state->set_value(0, this->get_input_port().Eval(context));
@@ -71,6 +73,8 @@ void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
   if (suppress_initial_transient_) {
     state->get_mutable_vector(2)[0] = context.get_discrete_state(2)[0] + 1.0;
   }
+
+  return EventStatus::Succeeded();
 }
 
 template <typename T>

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -108,10 +108,8 @@ class DiscreteDerivative final : public LeafSystem<T> {
   bool suppress_initial_transient() const;
 
  private:
-  void DoCalcDiscreteVariableUpdates(
-      const Context<T>& context,
-      const std::vector<const DiscreteUpdateEvent<T>*>&,
-      DiscreteValues<T>* discrete_state) const final;
+  EventStatus CalcDiscreteUpdate(const Context<T>& context,
+                                 DiscreteValues<T>* discrete_state) const;
 
   void CalcOutput(const Context<T>& context,
                   BasicVector<T>* output_vector) const;

--- a/systems/primitives/symbolic_vector_system.cc
+++ b/systems/primitives/symbolic_vector_system.cc
@@ -130,7 +130,10 @@ SymbolicVectorSystem<T>::SymbolicVectorSystem(
       this->DeclareContinuousState(state_vars_.size());
     } else {
       this->DeclareDiscreteState(state_vars_.size());
-      this->DeclarePeriodicDiscreteUpdateNoHandler(time_period_, 0.0);
+      this->DeclarePeriodicDiscreteUpdateEvent(
+          time_period_, 0.0, &SymbolicVectorSystem<T>::CalcDiscreteUpdate);
+      this->DeclareForcedDiscreteUpdateEvent(
+          &SymbolicVectorSystem<T>::CalcDiscreteUpdate);
     }
   }
   if (parameter_vars_.size() > 0) {
@@ -351,15 +354,14 @@ void SymbolicVectorSystem<T>::DoCalcTimeDerivatives(
 }
 
 template <typename T>
-void SymbolicVectorSystem<T>::DoCalcDiscreteVariableUpdates(
+EventStatus SymbolicVectorSystem<T>::CalcDiscreteUpdate(
     const drake::systems::Context<T>& context,
-    const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>& events,
     drake::systems::DiscreteValues<T>* updates) const {
-  unused(events);
   DRAKE_DEMAND(time_period_ > 0.0);
   DRAKE_DEMAND(dynamics_.size() > 0);
   EvaluateWithContext(context, dynamics_, dynamics_jacobian_,
                       dynamics_needs_inputs_, &updates->get_mutable_vector());
+  return EventStatus::Succeeded();
 }
 
 }  // namespace systems

--- a/systems/primitives/symbolic_vector_system.h
+++ b/systems/primitives/symbolic_vector_system.h
@@ -196,10 +196,9 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const final;
 
-  void DoCalcDiscreteVariableUpdates(
+  EventStatus CalcDiscreteUpdate(
       const drake::systems::Context<T>& context,
-      const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>& events,
-      drake::systems::DiscreteValues<T>* updates) const final;
+      drake::systems::DiscreteValues<T>* updates) const;
 
   const std::optional<symbolic::Variable> time_var_{std::nullopt};
   const VectorX<symbolic::Variable> state_vars_{};

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -355,15 +355,10 @@ TEST_F(TestLinearizeFromAffine, DiscreteAtNonEquilibrium) {
 class TestNonPeriodicSystem : public LeafSystem<double> {
  public:
   TestNonPeriodicSystem() {
-    this->DeclareDiscreteState(1);
     this->DeclarePerStepEvent(PublishEvent<double>());
-  }
 
-  void DoCalcDiscreteVariableUpdates(
-      const Context<double>& context,
-      const std::vector<const DiscreteUpdateEvent<double>*>&,
-      DiscreteValues<double>* discrete_state) const override {
-    (*discrete_state)[0] = context.get_discrete_state(0).GetAtIndex(0) + 1;
+    // State with no update event is sufficient to be non-periodic.
+    this->DeclareDiscreteState(1);
   }
 };
 
@@ -803,7 +798,8 @@ class MimoSystem final : public LeafSystem<T> {
 
     if (is_discrete) {
       this->DeclareDiscreteState(2);
-      this->DeclarePeriodicDiscreteUpdateNoHandler(0.1, 0.0);
+      this->DeclarePeriodicDiscreteUpdateEvent(0.1, 0.0,
+                                               &MimoSystem::CalcDiscreteUpdate);
     } else {
       this->DeclareContinuousState(2);
     }
@@ -841,10 +837,8 @@ class MimoSystem final : public LeafSystem<T> {
     derivatives->SetFromVector(A_ * x + B0_ * u0 + B1_ * u1);
   }
 
-  void DoCalcDiscreteVariableUpdates(
-      const Context<T>& context,
-      const std::vector<const DiscreteUpdateEvent<T>*>&,
-      DiscreteValues<T>* discrete_state) const final {
+  void CalcDiscreteUpdate(const Context<T>& context,
+                          DiscreteValues<T>* discrete_state) const {
     Vector1<T> u0 = this->get_input_port(0).Eval(context);
     Vector3<T> u1 = this->get_input_port(1).Eval(context);
     Vector2<T> x = get_state_vector(context);


### PR DESCRIPTION
Overriding the event dispatching will soon be deprecated.

Towards #13799.

+@sherm1 for feature review, please.

For testonly systems, I've only made the minimal adjustments.  For systems available to users, I tried to ensure the behavior remains the same by declaring both periodic and forced triggers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20114)
<!-- Reviewable:end -->
