### PR TITLE
[lcm] Deprecate direct access to the native LCM library

### DIFF
--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -105,7 +105,7 @@ std::string DrakeLcm::get_lcm_url() const {
   return impl_->lcm_url_;
 }
 
-::lcm::LCM* DrakeLcm::get_lcm_instance() {
+::lcm::LCM* DrakeLcm::get_native() {
   if (impl_->lcm_cpp_ == nullptr) {
     // Create the C++ wrapper only when requested by the user or our unit test.
     impl_->lcm_cpp_ = std::make_unique<::lcm::LCM>(impl_->lcm_);

--- a/lcm/drake_lcm.h
+++ b/lcm/drake_lcm.h
@@ -6,6 +6,7 @@
 #include <string_view>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcm/drake_lcm_params.h"
 
@@ -13,7 +14,7 @@
 namespace lcm {
 // We don't want to pollute our Drake headers with the include paths for either
 // @lcm or @glib, so we forward-declare the `class ::lcm::LCM` for use only by
-// DrakeLcm::get_lcm_instance() -- an advanced function that is rarely used.
+// DrakeLcm::get_native() -- an unit-test-only private function.
 class LCM;
 }  // namespace lcm
 #endif
@@ -53,12 +54,15 @@ class DrakeLcm : public DrakeLcmInterface {
    */
   ~DrakeLcm() override;
 
+  DRAKE_DEPRECATED(
+      "2024-01-01",
+      "Drake will no longer provide access to the underlying lcm::LCM object.")
   /**
    * (Advanced.) An accessor to the underlying LCM instance. The returned
    * pointer is guaranteed to be valid for the duration of this object's
    * lifetime.
    */
-  ::lcm::LCM* get_lcm_instance();
+  ::lcm::LCM* get_lcm_instance() { return get_native(); }
 
   void Publish(const std::string&, const void*, int,
                std::optional<double>) override;
@@ -72,7 +76,11 @@ class DrakeLcm : public DrakeLcmInterface {
   int HandleSubscriptions(int) override;
 
  private:
+  friend class DrakeLcmTester;
+
   void OnHandleSubscriptionsError(const std::string&) override;
+
+  ::lcm::LCM* get_native();
 
   class Impl;
   std::unique_ptr<Impl> impl_;

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -13,6 +13,15 @@
 
 namespace drake {
 namespace lcm {
+// Provides friend access to the underlying LCM object.
+class DrakeLcmTester {
+ public:
+  DrakeLcmTester() = delete;
+  static ::lcm::LCM* get_native(DrakeLcm* dut) {
+    DRAKE_DEMAND(dut != nullptr);
+    return dut->get_native();
+  }
+};
 namespace {
 
 // A udpm URL that is not the default.  We'll transmit here in our tests.
@@ -49,6 +58,8 @@ class DrakeLcmTest : public ::testing::Test {
     }
     EXPECT_TRUE(message_was_received);
   }
+
+  ::lcm::LCM* get_native() { return DrakeLcmTester::get_native(dut_.get()); }
 
   // The device under test.
   std::unique_ptr<DrakeLcm> dut_ = std::make_unique<DrakeLcm>();
@@ -88,7 +99,7 @@ TEST_F(DrakeLcmTest, EmptyChannelTest) {
 // Tests DrakeLcm's ability to publish an LCM message.
 // We subscribe using the native LCM APIs.
 TEST_F(DrakeLcmTest, PublishTest) {
-  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  ::lcm::LCM* const native_lcm = get_native();
   const std::string channel_name = "DrakeLcmTest.PublishTest";
 
   lcmt_drake_signal received{};
@@ -109,7 +120,7 @@ TEST_F(DrakeLcmTest, PublishTest) {
 // Tests DrakeLcm's ability to subscribe to an LCM message.
 // We publish using the native LCM APIs.
 TEST_F(DrakeLcmTest, SubscribeTest) {
-  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  ::lcm::LCM* const native_lcm = get_native();
   const std::string channel_name = "DrakeLcmTest.SubscribeTest";
 
   lcmt_drake_signal received{};
@@ -129,7 +140,7 @@ TEST_F(DrakeLcmTest, SubscribeTest) {
 
 // Repeats the above test, but with explicit opt-out of unsubscribe.
 TEST_F(DrakeLcmTest, SubscribeTest2) {
-  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  ::lcm::LCM* const native_lcm = get_native();
   const std::string channel_name = "DrakeLcmTest.SubscribeTest2";
 
   lcmt_drake_signal received{};
@@ -150,7 +161,7 @@ TEST_F(DrakeLcmTest, SubscribeTest2) {
 
 // Repeat SubscribeTest for SubscribeAllChannels.
 TEST_F(DrakeLcmTest, SubscribeAllTest) {
-  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  ::lcm::LCM* const native_lcm = get_native();
   const std::string channel_name = "DrakeLcmTest.SubscribeAllTest";
 
   lcmt_drake_signal received{};
@@ -172,7 +183,7 @@ TEST_F(DrakeLcmTest, SubscribeAllTest) {
 
 // Repeat SubscribeTest2 for SubscribeAllChannels.
 TEST_F(DrakeLcmTest, SubscribeAllTest2) {
-  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  ::lcm::LCM* const native_lcm = get_native();
   const std::string channel_name = "DrakeLcmTest.SubscribeAllTest2";
 
   lcmt_drake_signal received{};
@@ -352,7 +363,7 @@ TEST_F(DrakeLcmTest, Suffix) {
   DrakeLcmParams params;
   params.channel_suffix = "_SUFFIX";
   dut_ = std::make_unique<DrakeLcm>(params);
-  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  ::lcm::LCM* const native_lcm = get_native();
 
   // Subscribe using native LCM (with the fully-qualified channel name).
   lcmt_drake_signal received_native{};
@@ -422,7 +433,7 @@ TEST_F(DrakeLcmTest, SuffixInSubscribeAllChannels) {
 
 // Confirm that SubscribeMultichannel ignores mismatched channel names.
 TEST_F(DrakeLcmTest, SubscribeMultiTest) {
-  ::lcm::LCM* const native_lcm = dut_->get_lcm_instance();
+  ::lcm::LCM* const native_lcm = get_native();
   const std::string channel_name = "DrakeLcmTest.SubscribeMultiTest";
 
   lcmt_drake_signal received{};
@@ -443,6 +454,16 @@ TEST_F(DrakeLcmTest, SubscribeMultiTest) {
   });
   EXPECT_EQ(total, 1);
 }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+TEST_F(DrakeLcmTest, DeprecatedGetter) {
+  ::lcm::LCM* const deprecated = dut_->get_lcm_instance();
+  EXPECT_TRUE(deprecated != nullptr);
+  ::lcm::LCM* native = get_native();
+  EXPECT_TRUE(native == deprecated);
+}
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace lcm


### PR DESCRIPTION
It's not sufficiently ABI-stable to offer as Drake ABI, and because its LGPL we are required to expose its ABI if we use it.

This function is used nowhere in Drake or Anzu currently.  (It was last used in Anzu in May, 2022.)

Towards #17231.
See also #20116.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20115)
<!-- Reviewable:end -->
