### PR TITLE
GraphOfConvexSets: don't try to display costs for convex restriction solutions

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -377,7 +377,15 @@ std::string GraphOfConvexSets::GetGraphvizString(
     graphviz << " [label=\"" << e->name();
     if (result) {
       graphviz << "\n";
-      graphviz << "cost = " << e->GetSolutionCost(*result);
+      if (e->ell_.size() > 0) {
+        // SolveConvexRestriction does not yet return the rewritten costs.
+        if (result->get_decision_variable_index()->count(e->ell_[0].get_id()) !=
+            0) {
+          graphviz << "cost = " << e->GetSolutionCost(*result);
+        }
+      } else {
+        graphviz << "cost = 0";
+      }
       if (show_slacks) {
         graphviz << ",\n";
         graphviz << "ϕ = " << result->GetSolution(e->phi()) << ",\n";


### PR DESCRIPTION
Resolves #20113.

The ultimate solution will be to write the costs into the MathematicalProgramResult when solving the convex restriction. This is already listed with a TODO in SolveConvexRestriction; but will require some effort. For now, we shouldn't throw errors; we simply don't offer the cost display for that case.

+@richardrl for feature review.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20118)
<!-- Reviewable:end -->
