### PR TITLE
Add InCollisionConstraint.

### DIFF
--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -69,6 +69,7 @@ drake_cc_library(
         "distance_constraint.cc",
         "distance_constraint_utilities.cc",
         "gaze_target_constraint.cc",
+        "in_collision_constraint.cc",
         "kinematic_evaluator_utilities.cc",
         "minimum_distance_constraint.cc",
         "orientation_constraint.cc",
@@ -88,6 +89,7 @@ drake_cc_library(
         "distance_constraint.h",
         "distance_constraint_utilities.h",
         "gaze_target_constraint.h",
+        "in_collision_constraint.h",
         "kinematic_evaluator_utilities.h",
         "minimum_distance_constraint.h",
         "orientation_constraint.h",
@@ -287,6 +289,17 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "in_collision_constraint_test",
+    deps = [
+        ":inverse_kinematics_test_utilities",
+        ":kinematic_evaluators",
+        "//common/test_utilities:expect_throws_message",
+        "//planning:scene_graph_collision_checker",
+        "//solvers/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
     name = "minimum_distance_constraint_test",
     deps = [
         ":inverse_kinematics_test_utilities",
@@ -294,6 +307,18 @@ drake_cc_googletest(
         "//common/test_utilities:expect_throws_message",
         "//planning:scene_graph_collision_checker",
         "//solvers/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "in_collision_constraint_nlp_test",
+    deps = [
+        ":inverse_kinematics_core",
+        ":inverse_kinematics_test_utilities",
+        ":kinematic_evaluators",
+        "//solvers:ipopt_solver",
+        "//solvers:snopt_solver",
+        "//solvers:solve",
     ],
 )
 

--- a/multibody/inverse_kinematics/distance_constraint_utilities.cc
+++ b/multibody/inverse_kinematics/distance_constraint_utilities.cc
@@ -1,6 +1,9 @@
 #include "drake/multibody/inverse_kinematics/distance_constraint_utilities.h"
 
+#include <vector>
+
 #include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/inverse_kinematics/kinematic_evaluator_utilities.h"
 
 namespace drake {
 namespace multibody {
@@ -61,6 +64,88 @@ void CalcDistanceDerivatives(const MultibodyPlant<double>&,
                              double* distance_out) {
   *distance_out = distance_in;
 }
+
+template <typename T, typename S>
+VectorX<S> Distances(const MultibodyPlant<T>& plant,
+                     systems::Context<T>* context,
+                     const Eigen::Ref<const VectorX<S>>& q,
+                     double influence_distance) {
+  UpdateContextConfiguration(context, plant, q);
+  const auto& query_port = plant.get_geometry_query_input_port();
+  if (!query_port.HasValue(*context)) {
+    throw std::invalid_argument(
+        "MinimumDistanceConstraint: Cannot get a valid geometry::QueryObject. "
+        "Either the plant geometry_query_input_port() is not properly "
+        "connected to the SceneGraph's output port, or the plant_context_ is "
+        "incorrect. Please refer to AddMultibodyPlantSceneGraph on connecting "
+        "MultibodyPlant to SceneGraph.");
+  }
+  const auto& query_object =
+      query_port.template Eval<geometry::QueryObject<T>>(*context);
+
+  const std::vector<geometry::SignedDistancePair<T>> signed_distance_pairs =
+      query_object.ComputeSignedDistancePairwiseClosestPoints(
+          influence_distance);
+  VectorX<S> distances(signed_distance_pairs.size());
+  for (int i = 0; i < static_cast<int>(signed_distance_pairs.size()); ++i) {
+    const geometry::SceneGraphInspector<T>& inspector =
+        query_object.inspector();
+    const geometry::FrameId frame_A_id =
+        inspector.GetFrameId(signed_distance_pairs[i].id_A);
+    const geometry::FrameId frame_B_id =
+        inspector.GetFrameId(signed_distance_pairs[i].id_B);
+    const Frame<T>& frameA = plant.GetBodyFromFrameId(frame_A_id)->body_frame();
+    const Frame<T>& frameB = plant.GetBodyFromFrameId(frame_B_id)->body_frame();
+    internal::CalcDistanceDerivatives(
+        plant, *context, frameA, frameB,
+        // GetPoseInFrame() returns RigidTransform<double> -- we can't
+        // multiply across heterogeneous scalar types; so we cast the double
+        // to T.
+        inspector.GetPoseInFrame(signed_distance_pairs[i].id_A)
+                .template cast<T>() *
+            signed_distance_pairs[i].p_ACa,
+        signed_distance_pairs[i].distance, signed_distance_pairs[i].nhat_BA_W,
+        q, &distances(i));
+  }
+  return distances;
+}
+
+Eigen::VectorXd Distances(
+    const planning::CollisionChecker& collision_checker,
+    planning::CollisionCheckerContext* collision_checker_context,
+    const Eigen::Ref<const Eigen::VectorXd>& x, double influence_distance_val) {
+  return collision_checker
+      .CalcContextRobotClearance(collision_checker_context, x,
+                                 influence_distance_val)
+      .distances();
+}
+
+AutoDiffVecXd Distances(
+    const planning::CollisionChecker& collision_checker,
+    planning::CollisionCheckerContext* collision_checker_context,
+    const Eigen::Ref<const AutoDiffVecXd>& x, double influence_distance_val) {
+  const planning::RobotClearance robot_clearance =
+      collision_checker.CalcContextRobotClearance(collision_checker_context,
+                                                  math::ExtractValue(x),
+                                                  influence_distance_val);
+  return math::InitializeAutoDiff(
+      robot_clearance.distances(),
+      robot_clearance.jacobians() * math::ExtractGradient(x));
+}
+
+// Explicit instantiation
+template VectorX<double> Distances<double, double>(
+    const MultibodyPlant<double>&, systems::Context<double>*,
+    const Eigen::Ref<const VectorX<double>>&, double);
+template VectorX<AutoDiffXd> Distances<double, AutoDiffXd>(
+    const MultibodyPlant<double>&, systems::Context<double>*,
+    const Eigen::Ref<const VectorX<AutoDiffXd>>&, double);
+template VectorX<double> Distances<AutoDiffXd, double>(
+    const MultibodyPlant<AutoDiffXd>&, systems::Context<AutoDiffXd>*,
+    const Eigen::Ref<const VectorX<double>>&, double);
+template VectorX<AutoDiffXd> Distances<AutoDiffXd, AutoDiffXd>(
+    const MultibodyPlant<AutoDiffXd>&, systems::Context<AutoDiffXd>*,
+    const Eigen::Ref<const VectorX<AutoDiffXd>>&, double);
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/distance_constraint_utilities.h
+++ b/multibody/inverse_kinematics/distance_constraint_utilities.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/planning/collision_checker.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
@@ -83,6 +84,23 @@ void CheckPlantIsConnectedToSceneGraph(
         "SceneGraph.");
   }
 }
+
+// Compute all distances for the posture `q`.
+template <typename T, typename S>
+VectorX<S> Distances(const MultibodyPlant<T>& plant,
+                     systems::Context<T>* context,
+                     const Eigen::Ref<const VectorX<S>>& q,
+                     double influence_distance);
+
+Eigen::VectorXd Distances(
+    const planning::CollisionChecker& collision_checker,
+    planning::CollisionCheckerContext* collision_checker_context,
+    const Eigen::Ref<const Eigen::VectorXd>& x, double influence_distance_val);
+
+AutoDiffVecXd Distances(
+    const planning::CollisionChecker& collision_checker,
+    planning::CollisionCheckerContext* collision_checker_context,
+    const Eigen::Ref<const AutoDiffVecXd>& x, double influence_distance_val);
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/in_collision_constraint.cc
+++ b/multibody/inverse_kinematics/in_collision_constraint.cc
@@ -1,0 +1,85 @@
+#include "drake/multibody/inverse_kinematics/in_collision_constraint.h"
+
+#include <limits>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/inverse_kinematics/distance_constraint_utilities.h"
+#include "drake/multibody/inverse_kinematics/kinematic_evaluator_utilities.h"
+namespace drake {
+namespace multibody {
+namespace {
+const double kInf = std::numeric_limits<double>::infinity();
+}  // namespace
+
+InCollisionConstraint::InCollisionConstraint(
+    const multibody::MultibodyPlant<double>* const plant,
+    double minimum_distance_upper, double normalizer,
+    systems::Context<double>* plant_context)
+    : solvers::Constraint(1, internal::RefFromPtrOrThrow(plant).num_positions(),
+                          Vector1d(0), Vector1d(0)),
+      plant_double_{plant},
+      plant_context_double_{plant_context},
+      plant_autodiff_{nullptr},
+      plant_context_autodiff_{nullptr} {
+  Initialize<double>(*plant_double_, plant_context_double_,
+                     minimum_distance_upper, normalizer);
+}
+
+InCollisionConstraint::InCollisionConstraint(
+    const multibody::MultibodyPlant<AutoDiffXd>* const plant,
+    double minimum_distance_upper, double normalizer,
+    systems::Context<AutoDiffXd>* plant_context)
+    : solvers::Constraint(1, RefFromPtrOrThrow(plant).num_positions(),
+                          Vector1d(0), Vector1d(0)),
+      plant_double_{nullptr},
+      plant_context_double_{nullptr},
+      plant_autodiff_{plant},
+      plant_context_autodiff_{plant_context} {
+  Initialize<AutoDiffXd>(*plant_autodiff_, plant_context_autodiff_,
+                         minimum_distance_upper, normalizer);
+}
+
+template <typename T>
+void InCollisionConstraint::Initialize(const MultibodyPlant<T>& plant,
+                                       systems::Context<T>* plant_context,
+                                       double minimum_distance_upper,
+                                       double normalizer) {
+  internal::CheckPlantIsConnectedToSceneGraph(plant, *plant_context);
+  minimum_distance_upper_ = minimum_distance_upper;
+  normalizer_ = normalizer;
+  DRAKE_DEMAND(normalizer > 0);
+  minimum_value_constraint_ =
+      std::make_unique<solvers::MinimumValueUpperBoundConstraint>(
+          plant.num_positions(), minimum_distance_upper, normalizer,
+          [&plant, plant_context](const auto& x) {
+            return internal::Distances<T, AutoDiffXd>(plant, plant_context, x,
+                                                      kInf);
+          },
+          [&plant, plant_context](const auto& x) {
+            return internal::Distances<T, double>(plant, plant_context, x,
+                                                  kInf);
+          });
+  this->set_bounds(minimum_value_constraint_->lower_bound(),
+                   minimum_value_constraint_->upper_bound());
+}
+
+template <typename T>
+void InCollisionConstraint::DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
+                                          VectorX<T>* y) const {
+  minimum_value_constraint_->Eval(x, y);
+}
+
+void InCollisionConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                                   Eigen::VectorXd* y) const {
+  DoEvalGeneric<double>(x, y);
+}
+
+void InCollisionConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                                   AutoDiffVecXd* y) const {
+  DoEvalGeneric<AutoDiffXd>(x, y);
+}
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/inverse_kinematics/in_collision_constraint.h
+++ b/multibody/inverse_kinematics/in_collision_constraint.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/solvers/constraint.h"
+#include "drake/solvers/minimum_value_constraint.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+/** Constraint min(d) <= ub. Namely at least one of the signed distance between
+ all candidate pairs of geometries is below ub. When ub=0, it means the robot
+ is in collision.
+ */
+class InCollisionConstraint final : public solvers::Constraint {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InCollisionConstraint);
+
+  /**
+   @param minimum_distance_upper The upper bound on the minimum distance.
+   @param normalizer A positive scalar. This normalizer should be roughly in the
+   same magnitude as the range of distances between all pairs of geometries. It
+   doesn't need to be precise.
+   */
+  InCollisionConstraint(const multibody::MultibodyPlant<double>* const plant,
+                        double minimum_distance_upper, double normalizer,
+                        systems::Context<double>* plant_context);
+
+  /** Overloaded constructor with AutoDiff scalar. */
+  InCollisionConstraint(
+      const multibody::MultibodyPlant<AutoDiffXd>* const plant,
+      double minimum_distance_upper, double normalizer,
+      systems::Context<AutoDiffXd>* plant_context);
+
+  ~InCollisionConstraint() override {}
+
+  [[nodiscard]] double minimum_distance_upper() const {
+    return minimum_distance_upper_;
+  }
+
+  [[nodiscard]] double normalizer() const { return normalizer_; }
+
+ private:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const override;
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
+              VectorX<symbolic::Expression>*) const override {
+    throw std::logic_error(
+        "InCollisionConstraint::DoEval() does not work for symbolic "
+        "variables.");
+  }
+
+  template <typename T>
+  void DoEvalGeneric(const Eigen::Ref<const VectorX<T>>& x,
+                     VectorX<T>* y) const;
+
+  template <typename T>
+  void Initialize(const MultibodyPlant<T>& plant,
+                  systems::Context<T>* plant_context,
+                  double minimum_distance_upper, double nomalizer);
+
+  const multibody::MultibodyPlant<double>* const plant_double_;
+  systems::Context<double>* const plant_context_double_;
+  std::unique_ptr<solvers::MinimumValueUpperBoundConstraint>
+      minimum_value_constraint_;
+
+  const multibody::MultibodyPlant<AutoDiffXd>* const plant_autodiff_;
+  systems::Context<AutoDiffXd>* const plant_context_autodiff_;
+
+  double minimum_distance_upper_;
+  double normalizer_;
+};
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -5,6 +5,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/inverse_kinematics/distance_constraint_utilities.h"
 #include "drake/multibody/inverse_kinematics/kinematic_evaluator_utilities.h"
 
@@ -21,74 +22,6 @@ int NumConstraints(double minimum_distance_lower,
          static_cast<int>(std::isfinite(minimum_distance_upper));
 }
 }  // namespace
-
-template <typename T, typename S>
-VectorX<S> Distances(const MultibodyPlant<T>& plant,
-                     systems::Context<T>* context,
-                     const Eigen::Ref<const VectorX<S>>& q,
-                     double influence_distance) {
-  internal::UpdateContextConfiguration(context, plant, q);
-  const auto& query_port = plant.get_geometry_query_input_port();
-  if (!query_port.HasValue(*context)) {
-    throw std::invalid_argument(
-        "MinimumDistanceConstraint: Cannot get a valid geometry::QueryObject. "
-        "Either the plant geometry_query_input_port() is not properly "
-        "connected to the SceneGraph's output port, or the plant_context_ is "
-        "incorrect. Please refer to AddMultibodyPlantSceneGraph on connecting "
-        "MultibodyPlant to SceneGraph.");
-  }
-  const auto& query_object =
-      query_port.template Eval<geometry::QueryObject<T>>(*context);
-
-  const std::vector<geometry::SignedDistancePair<T>> signed_distance_pairs =
-      query_object.ComputeSignedDistancePairwiseClosestPoints(
-          influence_distance);
-  VectorX<S> distances(signed_distance_pairs.size());
-  for (int i = 0; i < static_cast<int>(signed_distance_pairs.size()); ++i) {
-    const geometry::SceneGraphInspector<T>& inspector =
-        query_object.inspector();
-    const geometry::FrameId frame_A_id =
-        inspector.GetFrameId(signed_distance_pairs[i].id_A);
-    const geometry::FrameId frame_B_id =
-        inspector.GetFrameId(signed_distance_pairs[i].id_B);
-    const Frame<T>& frameA = plant.GetBodyFromFrameId(frame_A_id)->body_frame();
-    const Frame<T>& frameB = plant.GetBodyFromFrameId(frame_B_id)->body_frame();
-    internal::CalcDistanceDerivatives(
-        plant, *context, frameA, frameB,
-        // GetPoseInFrame() returns RigidTransform<double> -- we can't
-        // multiply across heterogeneous scalar types; so we cast the double
-        // to T.
-        inspector.GetPoseInFrame(signed_distance_pairs[i].id_A)
-                .template cast<T>() *
-            signed_distance_pairs[i].p_ACa,
-        signed_distance_pairs[i].distance, signed_distance_pairs[i].nhat_BA_W,
-        q, &distances(i));
-  }
-  return distances;
-}
-
-Eigen::VectorXd Distances(
-    const planning::CollisionChecker& collision_checker,
-    planning::CollisionCheckerContext* collision_checker_context,
-    const Eigen::Ref<const Eigen::VectorXd>& x, double influence_distance_val) {
-  return collision_checker
-      .CalcContextRobotClearance(collision_checker_context, x,
-                                 influence_distance_val)
-      .distances();
-}
-
-AutoDiffVecXd Distances(
-    const planning::CollisionChecker& collision_checker,
-    planning::CollisionCheckerContext* collision_checker_context,
-    const Eigen::Ref<const AutoDiffVecXd>& x, double influence_distance_val) {
-  const planning::RobotClearance robot_clearance =
-      collision_checker.CalcContextRobotClearance(collision_checker_context,
-                                                  math::ExtractValue(x),
-                                                  influence_distance_val);
-  return math::InitializeAutoDiff(
-      robot_clearance.distances(),
-      robot_clearance.jacobians() * math::ExtractGradient(x));
-}
 
 void MinimumDistanceConstraint::CheckMinimumDistanceBounds(
     double minimum_distance_lower, double minimum_distance_upper,
@@ -136,12 +69,12 @@ void MinimumDistanceConstraint::Initialize(
       this->num_vars(), minimum_distance_lower, minimum_distance_upper,
       influence_distance, num_collision_candidates,
       [&plant, plant_context](const auto& x, double influence_distance_val) {
-        return Distances<T, AutoDiffXd>(plant, plant_context, x,
-                                        influence_distance_val);
+        return internal::Distances<T, AutoDiffXd>(plant, plant_context, x,
+                                                  influence_distance_val);
       },
       [&plant, plant_context](const auto& x, double influence_distance_val) {
-        return Distances<T, double>(plant, plant_context, x,
-                                    influence_distance_val);
+        return internal::Distances<T, double>(plant, plant_context, x,
+                                              influence_distance_val);
       });
   this->set_bounds(minimum_value_constraint_->lower_bound(),
                    minimum_value_constraint_->upper_bound());
@@ -164,15 +97,15 @@ void MinimumDistanceConstraint::Initialize(
       collision_checker.MaxContextNumDistances(*collision_checker_context),
       [this](const Eigen::Ref<const AutoDiffVecXd>& x,
              double influence_distance_val) {
-        return Distances(*(this->collision_checker_),
-                         this->collision_checker_context_, x,
-                         influence_distance_val);
+        return internal::Distances(*(this->collision_checker_),
+                                   this->collision_checker_context_, x,
+                                   influence_distance_val);
       },
       [this](const Eigen::Ref<const Eigen::VectorXd>& x,
              double influence_distance_val) {
-        return Distances(*(this->collision_checker_),
-                         this->collision_checker_context_, x,
-                         influence_distance_val);
+        return internal::Distances(*(this->collision_checker_),
+                                   this->collision_checker_context_, x,
+                                   influence_distance_val);
       });
   this->set_bounds(minimum_value_constraint_->lower_bound(),
                    minimum_value_constraint_->upper_bound());
@@ -195,8 +128,7 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
     const multibody::MultibodyPlant<double>* const plant,
     double minimum_distance_lower, double minimum_distance_upper,
     systems::Context<double>* plant_context,
-    MinimumDistancePenaltyFunction penalty_function,
-    double influence_distance_offset)
+    MinimumDistancePenaltyFunction penalty_function, double influence_distance)
     : solvers::Constraint(
           NumConstraints(minimum_distance_lower, minimum_distance_upper),
           RefFromPtrOrThrow(plant).num_positions(),
@@ -210,10 +142,10 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
       plant_context_double_{plant_context},
       plant_autodiff_{nullptr},
       plant_context_autodiff_{nullptr},
-      collision_checker_{nullptr} {
+      collision_checker_{nullptr},
+      collision_checker_context_{nullptr} {
   Initialize(*plant_double_, plant_context_double_, minimum_distance_lower,
-             minimum_distance_upper, influence_distance_offset,
-             penalty_function);
+             minimum_distance_upper, influence_distance, penalty_function);
 }
 
 MinimumDistanceConstraint::MinimumDistanceConstraint(
@@ -242,7 +174,8 @@ MinimumDistanceConstraint::MinimumDistanceConstraint(
       plant_context_double_{nullptr},
       plant_autodiff_{plant},
       plant_context_autodiff_{plant_context},
-      collision_checker_{nullptr} {
+      collision_checker_{nullptr},
+      collision_checker_context_{nullptr} {
   Initialize(*plant_autodiff_, plant_context_autodiff_, minimum_distance_lower,
              minimum_distance_upper, influence_distance, penalty_function);
 }
@@ -301,5 +234,6 @@ void MinimumDistanceConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
                                        AutoDiffVecXd* y) const {
   DoEvalGeneric(x, y);
 }
+
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -205,6 +205,10 @@ class MinimumDistanceConstraint final : public solvers::Constraint {
     return minimum_value_constraint_->influence_value();
   }
 
+  const solvers::MinimumValueConstraint& minimum_value_constraint() const {
+    return *minimum_value_constraint_;
+  }
+
  private:
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
               Eigen::VectorXd* y) const override;

--- a/multibody/inverse_kinematics/test/in_collision_constraint_nlp_test.cc
+++ b/multibody/inverse_kinematics/test/in_collision_constraint_nlp_test.cc
@@ -1,0 +1,196 @@
+/**
+Solves optimization programs with InCollisionConstraint. We want to make
+sure that our formulation of the InCollisionConstraint is suitable for the
+nonlinear optimization solvers.
+*/
+#include <limits>
+
+#include "drake/multibody/inverse_kinematics/in_collision_constraint.h"
+#include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
+#include "drake/multibody/inverse_kinematics/minimum_distance_constraint.h"
+#include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
+#include "drake/solvers/ipopt_solver.h"
+#include "drake/solvers/snopt_solver.h"
+#include "drake/solvers/solve.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+const double kInf = std::numeric_limits<double>::infinity();
+
+TEST_F(TwoFreeSpheresTest, NoCollisionTest) {
+  auto diagram_context = diagram_double_->CreateDefaultContext();
+  systems::Context<double>* plant_context =
+      &(plant_double_->GetMyMutableContextFromRoot(diagram_context.get()));
+  InverseKinematics ik(*plant_double_, plant_context);
+  MinimumDistancePenaltyFunction penalty_function{};
+  double influence_distance = 0.01;
+  auto no_collision_constraint = std::make_shared<MinimumDistanceConstraint>(
+      plant_double_, 0, kInf, plant_context, penalty_function,
+      influence_distance);
+  ik.get_mutable_prog()->AddConstraint(no_collision_constraint, ik.q());
+
+  Eigen::VectorXd q_guess(ik.q().rows());
+  q_guess.setZero();
+  q_guess.head<4>() << 1, 0, 0, 0;
+  q_guess.segment<4>(7) << 1, 0, 0, 0;
+  Eigen::VectorXd sphere2_position_x = Eigen::VectorXd::LinSpaced(
+      10, 0.01, radius1_ + radius2_ + influence_distance + 1);
+  for (int i = 0; i < sphere2_position_x.rows(); ++i) {
+    q_guess(11) = sphere2_position_x(i);
+    const auto result = solvers::Solve(ik.prog(), q_guess);
+    EXPECT_TRUE(result.is_success());
+  }
+}
+
+TEST_F(TwoFreeSpheresTest, InCollisionTest) {
+  auto diagram_context = diagram_double_->CreateDefaultContext();
+  systems::Context<double>* plant_context =
+      &(plant_double_->GetMyMutableContextFromRoot(diagram_context.get()));
+  InverseKinematics ik(*plant_double_, plant_context);
+  MinimumDistancePenaltyFunction penalty_function{};
+  auto in_collision_constraint = std::make_shared<InCollisionConstraint>(
+      plant_double_, 0, 10, plant_context);
+  ik.get_mutable_prog()->AddConstraint(in_collision_constraint, ik.q());
+
+  Eigen::VectorXd q_guess(ik.q().rows());
+  q_guess.setZero();
+  q_guess.head<4>() << 1, 0, 0, 0;
+  q_guess.segment<4>(7) << 1, 0, 0, 0;
+  Eigen::VectorXd sphere2_position_x =
+      Eigen::VectorXd::LinSpaced(10, 0.01, radius1_ + radius2_ + 100 - 0.01);
+  solvers::SolverOptions solver_options;
+  solver_options.SetOption(solvers::IpoptSolver::id(), "max_iter", 1000);
+  if (solvers::SnoptSolver::is_available() &&
+      solvers::SnoptSolver::is_enabled()) {
+    // TODO(hongkai.dai): For some reasons IPOPT often fails to solve the
+    // problem and exceeds the maximal iteration. I will look into this later.
+    for (int i = 0; i < sphere2_position_x.rows(); ++i) {
+      q_guess(11) = sphere2_position_x(i);
+      Eigen::VectorXd y_guess;
+      in_collision_constraint->Eval(q_guess, &y_guess);
+      const auto result = solvers::Solve(ik.prog(), q_guess, solver_options);
+      EXPECT_TRUE(result.is_success());
+      if (!result.is_success()) {
+        drake::log()->info(result.get_solution_result());
+        const Eigen::VectorXd q_sol = result.GetSolution(ik.q());
+        drake::log()->info("q_sol: {}", fmt_eigen(q_sol.transpose()));
+        Eigen::VectorXd in_collision_constraint_val;
+        auto q_sol_ad = math::InitializeAutoDiff(q_sol);
+        AutoDiffVecXd y_sol_ad;
+        in_collision_constraint->Eval(q_sol_ad, &y_sol_ad);
+        drake::log()->info("y_sol value {}, derivatives {}",
+                           y_sol_ad(0).value(),
+                           fmt_eigen(y_sol_ad(0).derivatives().transpose()));
+      }
+    }
+  }
+}
+
+TEST_F(SpheresAndWallsTest, InCollisionTest) {
+  auto diagram = builder_.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  systems::Context<double>* plant_context =
+      &(diagram->mutable_plant_context(diagram_context.get()));
+  auto in_collision_constraint = std::make_shared<InCollisionConstraint>(
+      &(diagram->plant()), 0, 2, plant_context);
+
+  InverseKinematics ik(diagram->plant(), plant_context);
+  ik.get_mutable_prog()->AddConstraint(in_collision_constraint, ik.q());
+
+  Eigen::VectorXd sphere_position_x = Eigen::VectorXd::LinSpaced(
+      10, -wall_length_ / 2 - 0.2, wall_length_ / 2 + 0.2);
+  Eigen::VectorXd q_guess = Eigen::VectorXd::Zero(ik.q().rows());
+  q_guess.head<4>() << 1, 0, 0, 0;
+  q_guess.segment<4>(7) << 1, 0, 0, 0;
+  solvers::SolverOptions solver_options;
+  solver_options.SetOption(solvers::IpoptSolver::id(), "max_iter", 1000);
+  for (int i = 0; i < sphere_position_x.rows(); ++i) {
+    q_guess(11) = sphere_position_x(i);
+    const auto result = solvers::Solve(ik.prog(), q_guess, solver_options);
+    EXPECT_TRUE(result.is_success());
+    if (!result.is_success()) {
+      if (result.get_solver_id() == solvers::IpoptSolver::id()) {
+        drake::log()->info(
+            "ipopt status: {}, {}",
+            result.get_solver_details<solvers::IpoptSolver>().status,
+            result.get_solver_details<solvers::IpoptSolver>()
+                .ConvertStatusToString());
+      }
+      drake::log()->info(result.get_solution_result());
+      const Eigen::VectorXd q_sol = result.GetSolution(ik.q());
+      drake::log()->info("q_sol: {}\n", fmt_eigen(q_sol.transpose()));
+      const auto q_sol_ad = math::InitializeAutoDiff(q_sol);
+      AutoDiffVecXd y_sol_ad;
+      in_collision_constraint->Eval(q_sol_ad, &y_sol_ad);
+      drake::log()->info("y_sol value {}, derivatives {}\n",
+                         y_sol_ad(0).value(),
+                         fmt_eigen(y_sol_ad(0).derivatives().transpose()));
+    }
+  }
+}
+
+TEST_F(Planar2DofTest, InCollisionTest) {
+  auto diagram = builder_.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  systems::Context<double>* plant_context =
+      &(diagram->mutable_plant_context(diagram_context.get()));
+  const double normalizer = 1;
+  auto in_collision_constraint = std::make_shared<InCollisionConstraint>(
+      &(diagram->plant()), 0, normalizer, plant_context);
+
+  InverseKinematics ik(diagram->plant(), plant_context);
+  ik.get_mutable_prog()->AddConstraint(in_collision_constraint, ik.q());
+
+  const Eigen::Vector2d q_joint_lower_limit =
+      diagram->plant().GetPositionLowerLimits();
+  const Eigen::Vector2d q_joint_upper_limit =
+      diagram->plant().GetPositionUpperLimits();
+
+  Eigen::VectorXd q0_values =
+      Eigen::VectorXd::LinSpaced(10, -M_PI / 2, M_PI / 2);
+  Eigen::VectorXd q1_values = Eigen::VectorXd::LinSpaced(
+      10, q_joint_lower_limit(1), q_joint_upper_limit(1));
+  Eigen::VectorXd q_guess = Eigen::VectorXd::Zero(ik.q().rows());
+  solvers::SolverOptions solver_options;
+  solver_options.SetOption(solvers::IpoptSolver::id(), "max_iter", 1000);
+  if (solvers::SnoptSolver::is_available() &&
+      solvers::SnoptSolver::is_enabled()) {
+    // TODO(hongkai.dai): For some reasons IPOPT often fails to solve the
+    // problem and exceeds the maximal iteration. I will look into this later.
+    for (int i = 0; i < q0_values.rows(); ++i) {
+      q_guess(0) = q0_values(i);
+      for (int j = 0; j < q1_values.rows(); ++j) {
+        q_guess(1) = q1_values(j);
+        const auto result = solvers::Solve(ik.prog(), q_guess, solver_options);
+        EXPECT_TRUE(result.is_success());
+        if (!result.is_success()) {
+          if (result.get_solver_id() == solvers::IpoptSolver::id()) {
+            drake::log()->info(
+                "ipopt status: {}, {}",
+                result.get_solver_details<solvers::IpoptSolver>().status,
+                result.get_solver_details<solvers::IpoptSolver>()
+                    .ConvertStatusToString());
+          } else if (result.get_solver_id() == solvers::SnoptSolver::id()) {
+            drake::log()->info(
+                "snopt info: {}",
+                result.get_solver_details<solvers::SnoptSolver>().info);
+          }
+          drake::log()->info(result.get_solution_result());
+          const Eigen::VectorXd q_sol = result.GetSolution(ik.q());
+          drake::log()->info("q_sol: {}", fmt_eigen(q_sol.transpose()));
+          const auto q_sol_ad = math::InitializeAutoDiff(q_sol);
+          AutoDiffVecXd y_sol_ad;
+          in_collision_constraint->Eval(q_sol_ad, &y_sol_ad);
+          drake::log()->info("y_sol value {}, derivatives {}\n",
+                             y_sol_ad(0).value(),
+                             fmt_eigen(y_sol_ad(0).derivatives().transpose()));
+        }
+      }
+    }
+  }
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/inverse_kinematics/test/in_collision_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/in_collision_constraint_test.cc
@@ -1,0 +1,71 @@
+#include "drake/multibody/inverse_kinematics/in_collision_constraint.h"
+
+#include <limits>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/compute_numerical_gradient.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"
+#include "drake/solvers/minimum_value_constraint.h"
+#include "drake/solvers/test_utilities/check_constraint_eval_nonsymbolic.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+TEST_F(TwoFreeSpheresTest, InCollisionConstraint) {
+  // Test InCollision constraint with MBP.
+  double minimum_distance_upper = 0.5;
+  double normalizer = 1;
+  auto diagram_context_double = diagram_double_->CreateDefaultContext();
+  auto plant_context_double = &(
+      plant_double_->GetMyMutableContextFromRoot(diagram_context_double.get()));
+  InCollisionConstraint dut_double(plant_double_, minimum_distance_upper,
+                                   normalizer, plant_context_double);
+  Eigen::VectorXd q_double_good = Eigen::VectorXd::Zero(14);
+  q_double_good.head<4>() << 1, 0, 0, 0;
+  q_double_good.segment<4>(7) << 1, 0, 0, 0;
+  q_double_good.tail<3>() << radius1_ + radius2_ + minimum_distance_upper - 0.1,
+      0, 0;
+
+  EXPECT_TRUE(dut_double.CheckSatisfied(q_double_good));
+
+  Eigen::VectorXd q_double_bad = q_double_good;
+  q_double_bad.tail<3>() << radius1_ + radius2_ + minimum_distance_upper + 0.1,
+      0, 0;
+  EXPECT_FALSE(dut_double.CheckSatisfied(q_double_bad));
+
+  // Now construct InCollisionConstraint with AutoDiffXd. Make sure the
+  // evaluation is the same as the constraint constructed with double.
+  auto diagram_context_autodiff = diagram_autodiff_->CreateDefaultContext();
+  auto plant_context_ad = &(plant_autodiff_->GetMyMutableContextFromRoot(
+      diagram_context_autodiff.get()));
+  InCollisionConstraint dut_ad(plant_autodiff_, minimum_distance_upper,
+                               normalizer, plant_context_ad);
+
+  // Use arbitrary gradient.
+  Eigen::MatrixXd q_gradient =
+      Eigen::MatrixXd(plant_double_->num_positions(), 2);
+  q_gradient.col(0) = Eigen::VectorXd::LinSpaced(q_gradient.rows(), 0, 2);
+  q_gradient.col(1) = Eigen::VectorXd::LinSpaced(q_gradient.rows(), 3, -1);
+  const auto q_ad_good = math::InitializeAutoDiff(q_double_good, q_gradient);
+  const auto q_ad_bad = math::InitializeAutoDiff(q_double_bad, q_gradient);
+
+  Eigen::VectorXd y_double;
+  Eigen::VectorXd y_double_expected;
+  dut_double.Eval(q_double_good, &y_double);
+  dut_ad.Eval(q_double_good, &y_double_expected);
+  EXPECT_TRUE(CompareMatrices(y_double, y_double_expected));
+  AutoDiffVecXd y_ad;
+  AutoDiffVecXd y_ad_expected;
+  dut_double.Eval(q_ad_good, &y_ad);
+  dut_ad.Eval(q_ad_good, &y_ad_expected);
+  const double tol = 1E-12;
+  EXPECT_TRUE(CompareMatrices(math::ExtractValue(y_ad), y_double));
+  EXPECT_TRUE(CompareMatrices(math::ExtractValue(y_ad),
+                              math::ExtractValue(y_ad_expected), tol));
+  EXPECT_TRUE(CompareMatrices(math::ExtractGradient(y_ad),
+                              math::ExtractGradient(y_ad_expected), tol));
+}
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -157,6 +157,19 @@ class SpheresAndWallsTest : public ::testing::Test {
   std::array<geometry::GeometryId, 2> spheres_;
 };
 
+// We put a 2-dof planar robot (with two revolute joints and some obstacles in
+// the environment.
+class Planar2DofTest : public ::testing::Test {
+ public:
+  Planar2DofTest();
+
+ public:
+  planning::RobotDiagramBuilder<double> builder_;
+  std::array<multibody::BodyIndex, 3> body_indices_;
+  std::array<geometry::GeometryId, 3> body_box_ids_;
+  std::array<geometry::GeometryId, 4> world_sphere_ids_;
+};
+
 /**
  * Compute the signed distance between a box and a sphere.
  * @param box_size The size of the box.

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -604,5 +604,6 @@ TEST_F(SpheresAndWallsTest, TestWithCollisionChecker) {
         Eigen::Vector3d(1.1 * minimum_distance + 2 * radius_, 0, 0), true);
   }
 }
+
 }  // namespace multibody
 }  // namespace drake

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1117,6 +1117,8 @@ drake_cc_googletest(
     name = "minimum_value_constraint_test",
     deps = [
         ":minimum_value_constraint",
+        "//solvers:mathematical_program",
+        "//solvers:solve",
         "//solvers/test_utilities",
     ],
 )

--- a/solvers/test/minimum_value_constraint_test.cc
+++ b/solvers/test/minimum_value_constraint_test.cc
@@ -7,6 +7,8 @@
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/autodiff_gradient.h"
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/solve.h"
 #include "drake/solvers/test_utilities/check_constraint_eval_nonsymbolic.h"
 
 namespace drake {
@@ -340,6 +342,26 @@ GTEST_TEST(MinimumValueConstraintTests, EvalSymbolicTest) {
   VectorX<symbolic::Expression> y;
   EXPECT_THROW(dut.Eval(x, &y), std::logic_error);
 }
+
+template <typename T>
+VectorX<T> Square(const Eigen::Ref<const VectorX<T>>& x) {
+  return x.array().square().matrix();
+}
+
+GTEST_TEST(MinimumValueUpperBoundConstraintTests, Test) {
+  int num_vars = 4;
+  const double minimum_value_upper = 0.5;
+  const double normalizer = 1;
+  MinimumValueUpperBoundConstraint dut(num_vars, minimum_value_upper,
+                                       normalizer, Square<AutoDiffXd>,
+                                       Square<double>);
+
+  Eigen::Vector4d x_good(0.1, 1.5, -0.2, 2.1);
+  EXPECT_TRUE(dut.CheckSatisfied(x_good));
+  Eigen::Vector4d x_bad(0.9, 2.1, -0.8, 1.5);
+  EXPECT_FALSE(dut.CheckSatisfied(x_bad));
+}
+
 }  // namespace
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
As mentioned in #20109, currently when we want to find an in-collision posture, we use the MinimumDistanceConstraint which impose `minimum_distance_upper`. The formulation of this constraint isn't correct. It ignores any distance that is larger than `influence_distance`, which is good if we want to impose not-in-collision constraint because a pair of geometry with distance larger than `influence_distance` automatically satisfies the not-in-collision constraint, and hence can be safely ignored. On the other hand, if we want to find an in-collision posture, then we should consider the pair of geometry if the distance is larger than `influence_distance`.

This PR introduces InCollisionConstraint. I also tested it in some nonlinear optimization problem and it performs better than the old MinimumDistanceConstraint when I want to find in-collision posture.

I will deprecate the old `MinimumDistanceConstraint` with `minimum_distance_upper` in a separate PR.

Relates to #18830

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20120)
<!-- Reviewable:end -->
