### PR TITLE
Provide add_planar_joint in model directives

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -147,6 +147,16 @@ PYBIND11_MODULE(parsing, m) {
   }
 
   {
+    using Class = parsing::AddPlanarJoint;
+    constexpr auto& cls_doc = doc.parsing.AddPlanarJoint;
+    py::class_<Class> cls(m, "AddPlanarJoint", cls_doc.doc);
+    cls.def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  {
     using Class = parsing::AddModel;
     constexpr auto& cls_doc = doc.parsing.AddModel;
     py::class_<Class> cls(m, "AddModel", cls_doc.doc);

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -6,6 +6,7 @@ from pydrake.multibody.parsing import (
     AddFrame,
     AddModel,
     AddModelInstance,
+    AddPlanarJoint,
     AddWeld,
     GetScopedFrameByName,
     LoadModelDirectives,
@@ -320,6 +321,13 @@ directives:
     def test_add_weld_struct(self):
         """Checks the bindings of the AddWeld helper struct."""
         dut = AddWeld(parent="foo")
+        self.assertIn("foo", repr(dut))
+        copy.copy(dut)
+        copy.deepcopy(dut)
+
+    def test_add_planar_joint_struct(self):
+        """Checks the bindings of the AddPlanarJoint helper struct."""
+        dut = AddPlanarJoint(name="foo")
         self.assertIn("foo", repr(dut))
         copy.copy(dut)
         copy.deepcopy(dut)

--- a/multibody/parsing/test/process_model_directives_test/add_planar_joint.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/add_planar_joint.dmd.yaml
@@ -1,0 +1,29 @@
+# This file is for testing the add_planar_joint directive.
+directives:
+
+- add_model:
+    name: xy_model
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_planar_joint:
+    name: xy_planar
+    parent: world
+    child: xy_model::base
+    default_translation: [-1, -2]
+    default_rotation_deg: 90 
+
+- add_model:
+    name: xz_model
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_frame:
+    name: xz_frame
+    X_PF:
+      base_frame: world
+      rotation: !Rpy { deg: [90, 0, 0] }
+
+- add_planar_joint:
+    name: xz_planar
+    parent: xz_frame
+    child: xz_model::base
+    damping: [0.1, 0.2, 0.3]


### PR DESCRIPTION
I have many examples in the manipulation notes that restrict the dynamics to the plane. Without this, I do not have a reasonable way to construct the 2D scenes from yaml (e.g. for use in hardware_sim). It is not viable to have to add a planar joint to every model that needs to be inserted.

+@jwnimmer-tri for feature review, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20122)
<!-- Reviewable:end -->
