### PR TITLE
[py visualization] De-flake TestModelVisualizer.test_reload

### DIFF
--- a/bindings/pydrake/visualization/test/model_visualizer_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_test.py
@@ -226,6 +226,12 @@ class TestModelVisualizer(unittest.TestCase):
             cli,
             f"--ws_url={meshcat.ws_url()}",
             f"--send_message={message}"])
+
+        # Wait up to 5 seconds for the button click to be processed.
+        for _ in range(500):
+            if meshcat.GetButtonClicks(button) > 0:
+                break
+            time.sleep(1 / 100)
         self.assertEqual(meshcat.GetButtonClicks(button), 1)
 
         # Run once. If a reload() happened, the diagram will have changed out.


### PR DESCRIPTION
Closes #19998.

I cannot reproduce the problem locally.  Hopefully it's the kind of thing that will be solved by a bit more sleeping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20129)
<!-- Reviewable:end -->
