### PR TITLE
[py systems] Simulator.AdvanceTo is interruptible by default

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -107,6 +107,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:wrap_pybind",
+        "//systems/analysis:simulator_python_internal_header",
     ],
     cc_srcs = ["analysis_py.cc"],
     package_info = PACKAGE_INFO,

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -158,8 +158,9 @@ class TestAnalysis(unittest.TestCase):
         copy.copy(initialize_params)
         simulator.Initialize(params=initialize_params)
 
-        simulator.AdvanceTo(boundary_time=0.0)
+        simulator.AdvanceTo(boundary_time=0.0, interruptible=False)
         simulator.AdvancePendingEvents()
+        simulator.AdvanceTo(boundary_time=0.1, interruptible=True)
 
         monitor_called_count = 0
 

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -408,6 +408,18 @@ drake_cc_library(
     ],
 )
 
+# N.B. This library does not have all of its dependencies declared. Instead,
+# it defines only the headers such that it can be used by `pydrake` without
+# installing the file. (If we just used `install_hdrs_exclude`, the header
+# would not make it into `//:drake_shared_library`.)
+drake_cc_library(
+    name = "simulator_python_internal_header",
+    hdrs = ["simulator_python_internal.h"],
+    install_hdrs_exclude = ["simulator_python_internal.h"],
+    tags = ["exclude_from_package"],
+    visibility = ["//bindings/pydrake/systems:__pkg__"],
+)
+
 drake_cc_library(
     name = "simulator",
     srcs = ["simulator.cc"],
@@ -423,6 +435,7 @@ drake_cc_library(
     ],
     deps = [
         ":runge_kutta3_integrator",
+        ":simulator_python_internal_header",
     ],
 )
 
@@ -492,6 +505,15 @@ drake_cc_googletest(
     name = "simulator_print_stats_test",
     deps = [
         ":simulator_print_stats",
+        "//systems/primitives:constant_vector_source",
+    ],
+)
+
+drake_cc_googletest(
+    name = "simulator_python_internal_test",
+    deps = [
+        ":simulator",
+        ":simulator_python_internal_header",
         "//systems/primitives:constant_vector_source",
     ],
 )

--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -5,6 +5,7 @@
 #include "drake/common/extract_double.h"
 #include "drake/common/text_logging.h"
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
+#include "drake/systems/analysis/simulator_python_internal.h"
 
 namespace drake {
 namespace systems {
@@ -723,8 +724,19 @@ void Simulator<T>::ResetStatistics() {
   initial_realtime_ = Clock::now();
 }
 
+namespace internal {
+template <typename T>
+void SimulatorPythonInternal<T>::set_python_monitor(
+    Simulator<T>* simulator, void (*monitor)()) {
+  DRAKE_DEMAND(simulator != nullptr);
+  simulator->python_monitor_ = monitor;
+}
+}  // namespace internal
+
 }  // namespace systems
 }  // namespace drake
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class drake::systems::Simulator)
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::systems::internal::SimulatorPythonInternal)

--- a/systems/analysis/simulator_python_internal.h
+++ b/systems/analysis/simulator_python_internal.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace drake {
+namespace systems {
+namespace internal {
+
+/* Offers a pydrake-specific private interface to the simulator.
+The implementation of this header lives in `simulator.cc`.
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class SimulatorPythonInternal {
+ public:
+  SimulatorPythonInternal() = delete;
+
+  /* Sets a python-specific `monitor` function callback for AdvanceTo(). The
+  `monitor` is a plain function function (not std::function) for performance.
+  Setting to nullptr removes the monitor. */
+  static void set_python_monitor(Simulator<T>* simulator, void (*monitor)());
+};
+
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/test/simulator_python_internal_test.cc
+++ b/systems/analysis/test/simulator_python_internal_test.cc
@@ -1,0 +1,46 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/analysis/simulator_python_internal.h"
+/* clang-format on */
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/primitives/constant_vector_source.h"
+
+namespace drake {
+namespace systems {
+namespace internal {
+namespace {
+
+// The python_monitor will increment this mutable, global counter.
+int global_counter = 0;
+
+GTEST_TEST(SimulatorPythonInternalTest, BasicTest) {
+  ConstantVectorSource<double> source(1.0);
+  Simulator<double> simulator(source);
+
+  // Add a monitor. Initializing or advancing should update the counter.
+  global_counter = 0;
+  auto python_monitor = []() {
+    ++global_counter;
+  };
+  SimulatorPythonInternal<double>::set_python_monitor(&simulator,
+                                                      python_monitor);
+  simulator.Initialize();
+  EXPECT_EQ(global_counter, 1);
+  simulator.AdvanceTo(0.2);
+  EXPECT_EQ(global_counter, 2);
+  simulator.AdvanceTo(0.3);
+  EXPECT_EQ(global_counter, 3);
+
+  // Clearing the monitor means no more counter updates.
+  SimulatorPythonInternal<double>::set_python_monitor(&simulator, nullptr);
+  simulator.Initialize();
+  simulator.AdvanceTo(0.4);
+  EXPECT_EQ(global_counter, 3);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -117,6 +117,7 @@ def _check_cc_deps(*, cc_deps, testonly):
         # The dep is a header-only library with no dependencies (unless those
         # dependencies are also header-only).
         "//common:nice_type_name_override_header",
+        "//systems/analysis:simulator_python_internal_header",
     ]
     if testonly:
         allowed_prefix.extend([


### PR DESCRIPTION
Closes #20053.

(Aside: This will probably make a bunch of Anzu simulations happier in CI.  As it stands, IIRC out CI has trouble killing simulator jobs and tends to time them out rather then interrupt them.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20130)
<!-- Reviewable:end -->
