### PR TITLE
[lcm] Hotfix for "Eschew LCM C++ API"

### DIFF
--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -61,7 +61,10 @@ class DrakeLcm::Impl {
     // Create the native instance only after all other checks are finished.
     lcm_ = ::lcm_create(lcm_url_.c_str());
     if (lcm_ == nullptr) {
-      throw std::runtime_error("Failure on lcm_create()");
+      // The initialization failed and printed a console warning. Create
+      // a dummy object instead (to at least have something non-null).
+      lcm_ = ::lcm_create("memq://");
+      DRAKE_THROW_UNLESS(lcm_ != nullptr);
     }
   }
 

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -77,6 +77,12 @@ TEST_F(DrakeLcmTest, CustomUrlTest) {
   EXPECT_EQ(dut_->get_lcm_url(), kUdpmUrl);
 }
 
+TEST_F(DrakeLcmTest, BadUrlTest) {
+  // At the moment, invalid URLs print to the console but do not throw.
+  // We probably want to revisit this as some point (to fail-fast).
+  EXPECT_NO_THROW(DrakeLcm("no-such-scheme://foo"));
+}
+
 TEST_F(DrakeLcmTest, DeferThreadTest) {
   DrakeLcmParams params;
   params.lcm_url = kUdpmUrl;


### PR DESCRIPTION
Previously, when multicast was disabled all operations printed a warning to the console and then did nothing.  The prior commit changed that to throw an error instead, which was breaking.

Instead, let LCM still print the console warning but then instead of throwing provide an inert DrakeLcm instead.

Closes #20136.
Amends #20116.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20137)
<!-- Reviewable:end -->
