### PR TITLE
[planning] CollisionChecker parallelism updates

### DIFF
--- a/bindings/pydrake/planning/BUILD.bazel
+++ b/bindings/pydrake/planning/BUILD.bazel
@@ -67,6 +67,7 @@ drake_py_unittest(
         "//multibody:models",
         "//planning/test_utilities:collision_ground_plane.sdf",
     ],
+    num_threads = 2,
     deps = [
         ":planning",
         "//bindings/pydrake/common/test_utilities:deprecation_py",

--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -223,7 +223,8 @@ void DefinePlanningCollisionChecker(py::module m) {
             py::arg("q1"), py::arg("q2"))
         .def("CheckEdgeCollisionFreeParallel",
             &Class::CheckEdgeCollisionFreeParallel, py::arg("q1"),
-            py::arg("q2"), cls_doc.CheckEdgeCollisionFreeParallel.doc)
+            py::arg("q2"), py::arg("parallelism") = true,
+            cls_doc.CheckEdgeCollisionFreeParallel.doc)
         .def("CheckEdgesCollisionFree", &Class::CheckEdgesCollisionFree,
             py::arg("edges"), py::arg("parallelize") = true,
             cls_doc.CheckEdgesCollisionFree.doc)
@@ -235,7 +236,8 @@ void DefinePlanningCollisionChecker(py::module m) {
             cls_doc.MeasureContextEdgeCollisionFree.doc)
         .def("MeasureEdgeCollisionFreeParallel",
             &Class::MeasureEdgeCollisionFreeParallel, py::arg("q1"),
-            py::arg("q2"), cls_doc.MeasureEdgeCollisionFreeParallel.doc)
+            py::arg("q2"), py::arg("parallelism") = true,
+            cls_doc.MeasureEdgeCollisionFreeParallel.doc)
         .def("MeasureEdgesCollisionFree", &Class::MeasureEdgesCollisionFree,
             py::arg("edges"), py::arg("parallelize") = true,
             cls_doc.MeasureEdgesCollisionFree.doc)

--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -229,7 +229,7 @@ void DefinePlanningCollisionChecker(py::module m) {
             py::arg("q1"), py::arg("q2"))
         .def("CheckEdgeCollisionFreeParallel",
             &Class::CheckEdgeCollisionFreeParallel, py::arg("q1"),
-            py::arg("q2"), py::arg("parallelism") = true,
+            py::arg("q2"), py::arg("parallelize") = true,
             cls_doc.CheckEdgeCollisionFreeParallel.doc)
         .def("CheckEdgesCollisionFree", &Class::CheckEdgesCollisionFree,
             py::arg("edges"), py::arg("parallelize") = true,
@@ -244,7 +244,7 @@ void DefinePlanningCollisionChecker(py::module m) {
             cls_doc.MeasureContextEdgeCollisionFree.doc)
         .def("MeasureEdgeCollisionFreeParallel",
             &Class::MeasureEdgeCollisionFreeParallel, py::arg("q1"),
-            py::arg("q2"), py::arg("parallelism") = true,
+            py::arg("q2"), py::arg("parallelize") = true,
             cls_doc.MeasureEdgeCollisionFreeParallel.doc)
         .def("MeasureEdgesCollisionFree", &Class::MeasureEdgesCollisionFree,
             py::arg("edges"), py::arg("parallelize") = true,

--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -44,12 +44,15 @@ void DefinePlanningCollisionChecker(py::module m) {
             cls_doc.GetZeroConfiguration.doc)
         .def("num_allocated_contexts", &Class::num_allocated_contexts,
             cls_doc.num_allocated_contexts.doc)
-        .def("model_context", &Class::model_context, py_rvp::reference_internal,
-            cls_doc.model_context.doc)
-        .def("plant_context", &Class::plant_context, py_rvp::reference_internal,
-            cls_doc.plant_context.doc)
+        .def("model_context", &Class::model_context,
+            py::arg("context_number") = std::nullopt,
+            py_rvp::reference_internal, cls_doc.model_context.doc)
+        .def("plant_context", &Class::plant_context,
+            py::arg("context_number") = std::nullopt,
+            py_rvp::reference_internal, cls_doc.plant_context.doc)
         .def("UpdatePositions", &Class::UpdatePositions,
             py_rvp::reference_internal, py::arg("q"),
+            py::arg("context_number") = std::nullopt,
             cls_doc.UpdatePositions.doc)
         .def("UpdateContextPositions", &Class::UpdateContextPositions,
             py::arg("model_context"), py::arg("q"),
@@ -177,7 +180,8 @@ void DefinePlanningCollisionChecker(py::module m) {
             py::arg("body"),
             cls_doc.SetCollisionFilteredWithAllBodies.doc_1args_body)
         .def("CheckConfigCollisionFree", &Class::CheckConfigCollisionFree,
-            py::arg("q"), cls_doc.CheckConfigCollisionFree.doc)
+            py::arg("q"), py::arg("context_number") = std::nullopt,
+            cls_doc.CheckConfigCollisionFree.doc)
         .def("CheckContextConfigCollisionFree",
             &Class::CheckContextConfigCollisionFree, py::arg("model_context"),
             py::arg("q"), cls_doc.CheckContextConfigCollisionFree.doc)
@@ -217,7 +221,9 @@ void DefinePlanningCollisionChecker(py::module m) {
         .def("set_edge_step_size", &Class::set_edge_step_size,
             py::arg("edge_step_size"), cls_doc.set_edge_step_size.doc)
         .def("CheckEdgeCollisionFree", &Class::CheckEdgeCollisionFree,
-            py::arg("q1"), py::arg("q2"), cls_doc.CheckEdgeCollisionFree.doc)
+            py::arg("q1"), py::arg("q2"),
+            py::arg("context_number") = std::nullopt,
+            cls_doc.CheckEdgeCollisionFree.doc)
         .def("CheckContextEdgeCollisionFree",
             &Class::CheckContextEdgeCollisionFree, py::arg("model_context"),
             py::arg("q1"), py::arg("q2"))
@@ -229,7 +235,9 @@ void DefinePlanningCollisionChecker(py::module m) {
             py::arg("edges"), py::arg("parallelize") = true,
             cls_doc.CheckEdgesCollisionFree.doc)
         .def("MeasureEdgeCollisionFree", &Class::MeasureEdgeCollisionFree,
-            py::arg("q1"), py::arg("q2"), cls_doc.MeasureEdgeCollisionFree.doc)
+            py::arg("q1"), py::arg("q2"),
+            py::arg("context_number") = std::nullopt,
+            cls_doc.MeasureEdgeCollisionFree.doc)
         .def("MeasureContextEdgeCollisionFree",
             &Class::MeasureContextEdgeCollisionFree, py::arg("model_context"),
             py::arg("q1"), py::arg("q2"),
@@ -242,17 +250,21 @@ void DefinePlanningCollisionChecker(py::module m) {
             py::arg("edges"), py::arg("parallelize") = true,
             cls_doc.MeasureEdgesCollisionFree.doc)
         .def("CalcRobotClearance", &Class::CalcRobotClearance, py::arg("q"),
-            py::arg("influence_distance"), cls_doc.CalcRobotClearance.doc)
+            py::arg("influence_distance"),
+            py::arg("context_number") = std::nullopt,
+            cls_doc.CalcRobotClearance.doc)
         .def("CalcContextRobotClearance", &Class::CalcContextRobotClearance,
             py::arg("model_context"), py::arg("q"),
             py::arg("influence_distance"),
             cls_doc.CalcContextRobotClearance.doc)
         .def("MaxNumDistances", &Class::MaxNumDistances,
+            py::arg("context_number") = std::nullopt,
             cls_doc.MaxNumDistances.doc)
         .def("MaxContextNumDistances", &Class::MaxContextNumDistances,
             py::arg("model_context"), cls_doc.MaxContextNumDistances.doc)
         .def("ClassifyBodyCollisions", &Class::ClassifyBodyCollisions,
-            py::arg("q"), cls_doc.ClassifyBodyCollisions.doc)
+            py::arg("q"), py::arg("context_number") = std::nullopt,
+            cls_doc.ClassifyBodyCollisions.doc)
         .def("ClassifyContextBodyCollisions",
             &Class::ClassifyContextBodyCollisions, py::arg("model_context"),
             py::arg("q"), cls_doc.ClassifyContextBodyCollisions.doc)

--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -269,9 +269,7 @@ void DefinePlanningCollisionChecker(py::module m) {
             &Class::ClassifyContextBodyCollisions, py::arg("model_context"),
             py::arg("q"), cls_doc.ClassifyContextBodyCollisions.doc)
         .def("SupportsParallelChecking", &Class::SupportsParallelChecking,
-            cls_doc.SupportsParallelChecking.doc)
-        .def("GetNumberOfThreads", &Class::GetNumberOfThreads,
-            py::arg("parallelize"), cls_doc.GetNumberOfThreads.doc);
+            cls_doc.SupportsParallelChecking.doc);
     DefClone(&cls);
   }
 

--- a/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
@@ -130,7 +130,10 @@ void DefinePlanningCollisionCheckerInterfaceTypes(py::module m) {
         .def_readwrite("env_collision_padding", &Class::env_collision_padding,
             cls_doc.env_collision_padding.doc)
         .def_readwrite("self_collision_padding", &Class::self_collision_padding,
-            cls_doc.self_collision_padding.doc);
+            cls_doc.self_collision_padding.doc)
+        .def_readwrite("implicit_context_parallelism",
+            &Class::implicit_context_parallelism,
+            cls_doc.implicit_context_parallelism.doc);
     // N.B. Any time we bind new CollisionCheckerParams fields that have pointer
     // semantics (e.g., std::unique_ptr), we should revisit the CollisionChecker
     // constructor bindings (e.g., SceneGraphCollisionChecker) and fix up their

--- a/bindings/pydrake/planning/test/collision_checker_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_test.py
@@ -382,7 +382,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.CheckEdgeCollisionFree(q1=q, q2=q)
         dut.CheckEdgeCollisionFree(q1=q, q2=q, context_number=1)
         dut.CheckContextEdgeCollisionFree(model_context=ccc, q1=q, q2=q)
-        dut.CheckEdgeCollisionFreeParallel(q1=q, q2=q)
+        dut.CheckEdgeCollisionFreeParallel(q1=q, q2=q, parallelism=False)
         self.assertEqual(
             len(dut.CheckEdgesCollisionFree(
                 edges=[(q, q)]*4,
@@ -393,7 +393,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.MeasureEdgeCollisionFree(q1=q, q2=q)
         dut.MeasureEdgeCollisionFree(q1=q, q2=q, context_number=1)
         dut.MeasureContextEdgeCollisionFree(model_context=ccc, q1=q, q2=q)
-        dut.MeasureEdgeCollisionFreeParallel(q1=q, q2=q)
+        dut.MeasureEdgeCollisionFreeParallel(q1=q, q2=q, parallelism=False)
         measures = dut.MeasureEdgesCollisionFree(
             edges=[(q, q)]*4, parallelize=False)
         self.assertEqual(len(measures), 4)

--- a/bindings/pydrake/planning/test/collision_checker_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_test.py
@@ -417,11 +417,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.ClassifyBodyCollisions(q=q, context_number=1)
         dut.ClassifyContextBodyCollisions(model_context=ccc, q=q)
 
-        # Remove this assert if we ever need to test a collision checker that
-        # doesn't support parallel checking.
-        self.assertEqual(dut.SupportsParallelChecking(), True)
-        self.assertEqual(dut.GetNumberOfThreads(parallelize=False), 1)
-        self.assertGreaterEqual(dut.GetNumberOfThreads(parallelize=True), 1)
+        self.assertIsInstance(dut.SupportsParallelChecking(), bool)
 
         provider = dut.distance_and_interpolation_provider()
         self.assertIsInstance(provider, mut.DistanceAndInterpolationProvider)

--- a/bindings/pydrake/planning/test/collision_checker_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_test.py
@@ -272,9 +272,15 @@ class TestCollisionChecker(unittest.TestCase):
         self.assertGreater(dut.num_allocated_contexts(), 0)
         self.assertIsInstance(dut.model_context(), mut.CollisionCheckerContext)
         self.assertIsInstance(dut.plant_context(), Context)
+        self.assertIsInstance(
+            dut.model_context(context_number=1), mut.CollisionCheckerContext)
+        self.assertIsInstance(dut.plant_context(context_number=1), Context)
 
         q = np.array([0.25] * 7)
         self.assertIs(dut.UpdatePositions(q=q), dut.plant_context())
+        self.assertIs(
+            dut.UpdatePositions(q=q, context_number=1),
+            dut.plant_context(context_number=1))
         ccc = dut.MakeStandaloneModelContext()  # ... a CollisionCheckerContext
         self.assertIsInstance(dut.UpdateContextPositions(
             model_context=ccc, q=q), Context)
@@ -341,6 +347,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.SetCollisionFilteredWithAllBodies(body=body)
 
         dut.CheckConfigCollisionFree(q=q)
+        dut.CheckConfigCollisionFree(q=q, context_number=1)
         dut.CheckContextConfigCollisionFree(model_context=ccc, q=q)
         self.assertEqual(
             len(dut.CheckConfigsCollisionFree(
@@ -373,6 +380,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.edge_step_size()
         dut.set_edge_step_size(edge_step_size=0.2)
         dut.CheckEdgeCollisionFree(q1=q, q2=q)
+        dut.CheckEdgeCollisionFree(q1=q, q2=q, context_number=1)
         dut.CheckContextEdgeCollisionFree(model_context=ccc, q1=q, q2=q)
         dut.CheckEdgeCollisionFreeParallel(q1=q, q2=q)
         self.assertEqual(
@@ -383,6 +391,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.CheckEdgesCollisionFree([(q, q)])  # Omit the defaulted arg.
 
         dut.MeasureEdgeCollisionFree(q1=q, q2=q)
+        dut.MeasureEdgeCollisionFree(q1=q, q2=q, context_number=1)
         dut.MeasureContextEdgeCollisionFree(model_context=ccc, q1=q, q2=q)
         dut.MeasureEdgeCollisionFreeParallel(q1=q, q2=q)
         measures = dut.MeasureEdgesCollisionFree(
@@ -393,14 +402,19 @@ class TestCollisionChecker(unittest.TestCase):
 
         clearance = dut.CalcRobotClearance(q=q, influence_distance=10)
         self.assertIsInstance(clearance, mut.RobotClearance)
+        clearance = dut.CalcRobotClearance(
+            q=q, influence_distance=10, context_number=1)
+        self.assertIsInstance(clearance, mut.RobotClearance)
         clearance = dut.CalcContextRobotClearance(
             model_context=ccc, q=q, influence_distance=10)
         self.assertIsInstance(clearance, mut.RobotClearance)
 
         dut.MaxNumDistances()
+        dut.MaxNumDistances(context_number=1)
         dut.MaxContextNumDistances(model_context=ccc)
 
         dut.ClassifyBodyCollisions(q=q)
+        dut.ClassifyBodyCollisions(q=q, context_number=1)
         dut.ClassifyContextBodyCollisions(model_context=ccc, q=q)
 
         self.assertIsInstance(dut.SupportsParallelChecking(), bool)

--- a/bindings/pydrake/planning/test/collision_checker_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_test.py
@@ -417,8 +417,11 @@ class TestCollisionChecker(unittest.TestCase):
         dut.ClassifyBodyCollisions(q=q, context_number=1)
         dut.ClassifyContextBodyCollisions(model_context=ccc, q=q)
 
-        self.assertIsInstance(dut.SupportsParallelChecking(), bool)
-        self.assertEqual(dut.GetNumberOfThreads(parallelize=True), 1)
+        # Remove this assert if we ever need to test a collision checker that
+        # doesn't support parallel checking.
+        self.assertEqual(dut.SupportsParallelChecking(), True)
+        self.assertEqual(dut.GetNumberOfThreads(parallelize=False), 1)
+        self.assertGreaterEqual(dut.GetNumberOfThreads(parallelize=True), 1)
 
         provider = dut.distance_and_interpolation_provider()
         self.assertIsInstance(provider, mut.DistanceAndInterpolationProvider)

--- a/bindings/pydrake/planning/test/collision_checker_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_test.py
@@ -382,7 +382,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.CheckEdgeCollisionFree(q1=q, q2=q)
         dut.CheckEdgeCollisionFree(q1=q, q2=q, context_number=1)
         dut.CheckContextEdgeCollisionFree(model_context=ccc, q1=q, q2=q)
-        dut.CheckEdgeCollisionFreeParallel(q1=q, q2=q, parallelism=False)
+        dut.CheckEdgeCollisionFreeParallel(q1=q, q2=q, parallelize=False)
         self.assertEqual(
             len(dut.CheckEdgesCollisionFree(
                 edges=[(q, q)]*4,
@@ -393,7 +393,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.MeasureEdgeCollisionFree(q1=q, q2=q)
         dut.MeasureEdgeCollisionFree(q1=q, q2=q, context_number=1)
         dut.MeasureContextEdgeCollisionFree(model_context=ccc, q1=q, q2=q)
-        dut.MeasureEdgeCollisionFreeParallel(q1=q, q2=q, parallelism=False)
+        dut.MeasureEdgeCollisionFreeParallel(q1=q, q2=q, parallelize=False)
         measures = dut.MeasureEdgesCollisionFree(
             edges=[(q, q)]*4, parallelize=False)
         self.assertEqual(len(measures), 4)

--- a/planning/BUILD.bazel
+++ b/planning/BUILD.bazel
@@ -65,6 +65,7 @@ drake_cc_library(
         ":robot_collision_type",
         ":robot_diagram",
         "//common:essential",
+        "//common:parallelism",
         "//geometry",
         "//multibody/plant",
     ],

--- a/planning/BUILD.bazel
+++ b/planning/BUILD.bazel
@@ -91,6 +91,7 @@ drake_cc_library(
     deps = [
         ":distance_and_interpolation_provider",
         ":robot_diagram",
+        "//common:parallelism",
         "//multibody/tree:multibody_tree_indexes",
     ],
 )

--- a/planning/collision_avoidance.cc
+++ b/planning/collision_avoidance.cc
@@ -10,18 +10,19 @@ namespace internal {
 Eigen::VectorXd ComputeCollisionAvoidanceDisplacement(
     const CollisionChecker& checker, const Eigen::VectorXd& q,
     double max_penetration, double max_clearance,
-    CollisionCheckerContext* context) {
+    const std::optional<int> context_number, CollisionCheckerContext* context) {
   DRAKE_THROW_UNLESS(max_penetration <= 0.0);
   DRAKE_THROW_UNLESS(std::isfinite(max_penetration));
   DRAKE_THROW_UNLESS(max_clearance >= 0.0);
   DRAKE_THROW_UNLESS(std::isfinite(max_clearance));
   DRAKE_THROW_UNLESS(max_clearance > max_penetration);
+  DRAKE_THROW_UNLESS(context_number == std::nullopt || context == nullptr);
 
   const double penetration_range = max_clearance - max_penetration;
   // Collect the distances and Jacobians.
   const RobotClearance robot_clearance =
       context == nullptr
-          ? checker.CalcRobotClearance(q, max_clearance)
+          ? checker.CalcRobotClearance(q, max_clearance, context_number)
           : checker.CalcContextRobotClearance(context, q, max_clearance);
 
   const int num_measurements = robot_clearance.size();

--- a/planning/collision_avoidance.h
+++ b/planning/collision_avoidance.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "drake/planning/collision_checker.h"
 
 namespace drake {
@@ -34,19 +36,24 @@ namespace internal {
                             to zero will only consider collisions and not nearby
                             objects. As the value increases, more and more
                             distant objects will influence the calculation.
- @param context             An optional collision checker context. If none is
-                            provided, the checker's context for the current
-                            thread is used.
+ @param context_number      An optional context number to specify the implicit
+                            context to use.
+ @param context             An optional collision checker context.
+ @note Either a context, a context number, or neither may be provided. If
+       neither is provided, the implicit context corresponding to the current
+       OpenMP hread is used.
  @pre q.size() == checker.GetZeroConfiguration().size().
  @pre max_penetration <= 0.
  @pre max_clearance >= 0.
  @pre max_clearance > max_penetration.
  @pre if context != nullptr, it is a context managed by checker.
+ @pre context != nullptr and context_number != nullopt cannot be combined.
 
  @ingroup planning_collision_checker */
 Eigen::VectorXd ComputeCollisionAvoidanceDisplacement(
     const CollisionChecker& checker, const Eigen::VectorXd& q,
     double max_penetration, double max_clearance,
+    std::optional<int> context_number = std::nullopt,
     CollisionCheckerContext* context = nullptr);
 
 // TODO(jwnimmer-tri) Before we promote the above function out of the internal

--- a/planning/collision_avoidance.h
+++ b/planning/collision_avoidance.h
@@ -41,7 +41,7 @@ namespace internal {
  @param context             An optional collision checker context.
  @note Either a context, a context number, or neither may be provided. If
        neither is provided, the implicit context corresponding to the current
-       OpenMP hread is used.
+       OpenMP thread is used.
  @pre q.size() == checker.GetZeroConfiguration().size().
  @pre max_penetration <= 0.
  @pre max_clearance >= 0.

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -910,16 +910,6 @@ std::vector<RobotCollisionType> CollisionChecker::ClassifyContextBodyCollisions(
   return DoClassifyContextBodyCollisions(*model_context);
 }
 
-int CollisionChecker::GetNumberOfThreads(const Parallelism parallelize) const {
-  const bool check_in_parallel =
-      CanEvaluateInParallel() && parallelize.num_threads() > 1;
-  if (check_in_parallel) {
-    return std::min(num_allocated_contexts(), parallelize.num_threads());
-  } else {
-    return 1;
-  }
-}
-
 CollisionChecker::CollisionChecker(CollisionCheckerParams params,
                                    bool supports_parallel_checking)
     : setup_model_(std::move(params.model)),
@@ -1294,6 +1284,16 @@ std::string CollisionChecker::CriticizePaddingMatrix(
     }
   }
   return {};
+}
+
+int CollisionChecker::GetNumberOfThreads(const Parallelism parallelize) const {
+  const bool check_in_parallel =
+      CanEvaluateInParallel() && parallelize.num_threads() > 1;
+  if (check_in_parallel) {
+    return std::min(num_allocated_contexts(), parallelize.num_threads());
+  } else {
+    return 1;
+  }
 }
 
 CollisionChecker::OwnedContextKeeper::~OwnedContextKeeper() = default;

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -93,7 +93,7 @@ namespace planning {
  - no two or more threads simultaneously use the same context number
 
  Methods supporting implicit context parallelism are noted below by having a
- reference to this section; as a rule of thumb, any method that takes a
+ reference to this section; as a rule of thumb, any public method that takes a
  `context_number` argument uses implicit context parallelism.
 
  Users of this class (derived classes and others) can write their own parallel
@@ -132,7 +132,7 @@ namespace planning {
  contexts, whether explicit or implicit.
 
  Methods supporting explicit context parallelism are noted below by having a
- reference to this section; as a rule of thumb, any method that takes a
+ reference to this section; as a rule of thumb, any public method that takes a
  `model_context` first argument uses explicit context parallelism.
 
  In practice, multi-threaded collision checking with explicit contexts may look
@@ -268,7 +268,7 @@ class CollisionChecker {
    context pool owned by this collision checker.
    @param context_number Optional implicit context number.
    @returns a `const` reference to the multibody plant sub-context within
-   the context given  by the `context_number`, or when nullopt the context to be
+   the context given by the `context_number`, or when nullopt the context to be
    used with the current OpenMP thread.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
   const systems::Context<double>& plant_context(

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -1088,6 +1088,8 @@ class CollisionChecker {
       CollisionCheckerContext* model_context, const Eigen::VectorXd& q,
       double influence_distance) const;
 
+  // TODO(calderpg-tri) Improve MaxNumDistances to use the prototype context
+  // instead, and deprecate context-specific forms.
   /** Returns an upper bound on the number of distances returned by
    CalcRobotClearance(), using the current thread's associated context.
    @param context_number Optional implicit context number.

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/parallelism.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/planning/body_shape_description.h"
 #include "drake/planning/collision_checker_context.h"
@@ -692,7 +693,7 @@ class CollisionChecker {
    each configuration, 1 if collision free, 0 if in collision. */
   std::vector<uint8_t> CheckConfigsCollisionFree(
       const std::vector<Eigen::VectorXd>& configs,
-      bool parallelize = true) const;
+      Parallelism parallelize = Parallelism::Max()) const;
 
   //@}
 
@@ -933,8 +934,9 @@ class CollisionChecker {
    @param q1 Start configuration for edge.
    @param q2 End configuration for edge.
    @returns true if collision free, false if in collision. */
-  bool CheckEdgeCollisionFreeParallel(const Eigen::VectorXd& q1,
-                                      const Eigen::VectorXd& q2) const;
+  bool CheckEdgeCollisionFreeParallel(
+      const Eigen::VectorXd& q1, const Eigen::VectorXd& q2,
+      Parallelism parallelism = Parallelism::Max()) const;
 
   /** Checks multiple configuration-to-configuration edges for collision.
    Collision checks are parallelized via OpenMP when supported and enabled by
@@ -947,7 +949,7 @@ class CollisionChecker {
    if collision free, 0 if in collision. */
   std::vector<uint8_t> CheckEdgesCollisionFree(
       const std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& edges,
-      bool parallelize = true) const;
+      Parallelism parallelize = Parallelism::Max()) const;
 
   /** Checks a single configuration-to-configuration edge for collision, using
    the current thread's associated context.
@@ -972,8 +974,9 @@ class CollisionChecker {
    @param q1 Start configuration for edge.
    @param q2 End configuration for edge.
    @returns A measure of how much of the edge is collision free. */
-  EdgeMeasure MeasureEdgeCollisionFreeParallel(const Eigen::VectorXd& q1,
-                                               const Eigen::VectorXd& q2) const;
+  EdgeMeasure MeasureEdgeCollisionFreeParallel(
+      const Eigen::VectorXd& q1, const Eigen::VectorXd& q2,
+      Parallelism parallelism = Parallelism::Max()) const;
 
   /** Checks multiple configuration-to-configuration edge for collision.
    Collision checks are parallelized via OpenMP when supported and enabled by
@@ -986,7 +989,7 @@ class CollisionChecker {
             is the result for the iᵗʰ edge. */
   std::vector<EdgeMeasure> MeasureEdgesCollisionFree(
       const std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& edges,
-      bool parallelize = true) const;
+      Parallelism parallelize = Parallelism::Max()) const;
 
   //@}
 
@@ -1065,7 +1068,7 @@ class CollisionChecker {
 
   /** Gets the number of threads that may be used in an OpenMP-parallelized
    loop, if parallelize=true, or 1 if parallelize=false. */
-  int GetNumberOfThreads(bool parallelize) const;
+  int GetNumberOfThreads(Parallelism parallelize) const;
 
  protected:
   /** Derived classes declare upon construction whether they support parallel

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -76,8 +76,8 @@ namespace planning {
  context by using `model_context(optional<int> context_number)` and related
  methods. These methods may be called in two ways:
 
- - without a context number, the association between and thread and context uses
-   the OpenMP notion of thread number
+ - without a context number, the association between thread and context uses the
+   OpenMP notion of thread number
  - with a context number, the method uses the context corresponding to the
    provided number
 

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -1124,12 +1124,6 @@ class CollisionChecker {
    @returns true if parallel checking is supported. */
   bool SupportsParallelChecking() const { return supports_parallel_checking_; }
 
-  /** Gets the number of threads that may be used in an OpenMP-parallelized
-   loop, which is the lesser of (a) the number of implicit contexts or (b) the
-   number of threads specified by `parallelize`. If OpenMP is not available,
-   returns 1. */
-  int GetNumberOfThreads(Parallelism parallelize) const;
-
  protected:
   /** Derived classes declare upon construction whether they support parallel
    checking (see SupportsParallelChecking()). If a derived class does not
@@ -1313,6 +1307,12 @@ class CollisionChecker {
    found. */
   std::string CriticizePaddingMatrix(const Eigen::MatrixXd& padding,
                                      const char* func) const;
+
+  /* Gets the number of threads that may be used in an OpenMP-parallelized
+   loop, which is the lesser of (a) the number of implicit contexts or (b) the
+   number of threads specified by `parallelize`. If OpenMP is not available,
+   returns 1. */
+  int GetNumberOfThreads(Parallelism parallelize) const;
 
   /* @returns a generalized position vector, sized according to the full model,
    whose values come from the plant's default context. */

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -1441,6 +1441,11 @@ class CollisionChecker {
    This is defined upon construction by implementations. */
   bool supports_parallel_checking_{};
 
+  /* Specifies how much parallelism can be used in implicit context operations.
+  If the checker does not support parallel evaluation, this will specify no
+  parallelism. */
+  Parallelism implicit_context_parallelism_;
+
   /* The names of all groups with added geometries. */
   std::map<std::string, std::vector<AddedShape>> geometry_groups_;
 };

--- a/planning/collision_checker_params.h
+++ b/planning/collision_checker_params.h
@@ -101,7 +101,9 @@ struct CollisionCheckerParams {
   double self_collision_padding{};
 
   /** Specify how many contexts should be allocated to support collision checker
-  implicit context parallelism. Defaults to the maximum parallelism. */
+  implicit context parallelism. Defaults to the maximum parallelism. If the
+  specific collision checker type in use declares that it *does not* support
+  parallel queries, then implicit context parallelism is set to None(). */
   Parallelism implicit_context_parallelism = Parallelism::Max();
 };
 

--- a/planning/collision_checker_params.h
+++ b/planning/collision_checker_params.h
@@ -103,7 +103,8 @@ struct CollisionCheckerParams {
   /** Specify how many contexts should be allocated to support collision checker
   implicit context parallelism. Defaults to the maximum parallelism. If the
   specific collision checker type in use declares that it *does not* support
-  parallel queries, then implicit context parallelism is set to None(). */
+  parallel queries, then implicit context parallelism is set to None().
+  @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
   Parallelism implicit_context_parallelism = Parallelism::Max();
 };
 

--- a/planning/collision_checker_params.h
+++ b/planning/collision_checker_params.h
@@ -6,6 +6,7 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/parallelism.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/planning/distance_and_interpolation_provider.h"
 #include "drake/planning/robot_diagram.h"
@@ -98,6 +99,10 @@ struct CollisionCheckerParams {
   distance between robot and itself is less than padding, the checker reports a
   collision. */
   double self_collision_padding{};
+
+  /** Specify how many contexts should be allocated to support collision checker
+  implicit context parallelism. Defaults to the maximum parallelism. */
+  Parallelism implicit_context_parallelism = Parallelism::Max();
 };
 
 }  // namespace planning

--- a/planning/test/collision_avoidance_test.cc
+++ b/planning/test/collision_avoidance_test.cc
@@ -100,14 +100,28 @@ GTEST_TEST(ComputeCollisionAvoidanceDisplacementTest, ContextProvenance) {
   EXPECT_TRUE(CompareMatrices(
       checker.plant().GetPositions(checker.plant_context()), q1));
 
+  /* Implicit context using context number. */
+  const int context_number = 0;
+  EXPECT_FALSE(CompareMatrices(
+      checker.plant().GetPositions(checker.plant_context(context_number)), q2));
+  EXPECT_NO_THROW(
+      ComputeCollisionAvoidanceDisplacement(checker, q2, 0, 1, context_number));
+  EXPECT_TRUE(CompareMatrices(
+      checker.plant().GetPositions(checker.plant_context(context_number)), q2));
+
   /* Explicit context. */
   auto context = checker.MakeStandaloneModelContext();
   EXPECT_FALSE(CompareMatrices(
       checker.plant().GetPositions(context->plant_context()), q2));
-  EXPECT_NO_THROW(
-      ComputeCollisionAvoidanceDisplacement(checker, q2, 0, 1, context.get()));
+  EXPECT_NO_THROW(ComputeCollisionAvoidanceDisplacement(
+      checker, q2, 0, 1, std::nullopt, context.get()));
   EXPECT_TRUE(CompareMatrices(
       checker.plant().GetPositions(context->plant_context()), q2));
+
+  /* Combining implicit context number and explicit context throws. */
+  EXPECT_THROW(ComputeCollisionAvoidanceDisplacement(
+                   checker, q2, 0, 1, context_number, context.get()),
+               std::exception);
 }
 
 GTEST_TEST(ComputeCollisionAvoidanceDisplacementTest, NoDistanceMeasurements) {

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -1388,21 +1388,6 @@ TEST_F(TrivialCollisionCheckerTest, IsCollisionFilteredBetween) {
                                                dut_->get_body(BodyIndex(3))));
 }
 
-TEST_F(TrivialCollisionCheckerTest, GetNumberOfThreads) {
-  EXPECT_EQ(dut_->GetNumberOfThreads(false), 1);
-
-  const int num_omp_threads =
-      common_robotics_utilities::openmp_helpers::GetNumOmpThreads();
-  const int num_contexts = dut_->num_allocated_contexts();
-  const int expected_num_threads = std::min(num_omp_threads, num_contexts);
-
-  if (common_robotics_utilities::openmp_helpers::IsOmpEnabledInBuild()) {
-    EXPECT_GT(expected_num_threads, 1);
-  }
-
-  EXPECT_EQ(dut_->GetNumberOfThreads(true), expected_num_threads);
-}
-
 // Creates a checker on a plant with an N-link chain (optionally) welded to the
 // world. Part of the edge-checking API test infrastructure (see below).
 template <typename CheckerType>

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -106,8 +106,10 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
  public:
   explicit CollisionCheckerTester(CollisionCheckerParams params,
                                   bool supports_parallel_checking = false)
-      : UnimplementedCollisionChecker(std::move(params),
-                                      supports_parallel_checking) {}
+      : UnimplementedCollisionChecker(
+            MaybeNerfParamParallelism(std::move(params),
+                                      supports_parallel_checking),
+            supports_parallel_checking) {}
 
   //@{
   // Interesting virtual overrides.
@@ -229,6 +231,14 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
   //@}
 
  private:
+  static CollisionCheckerParams MaybeNerfParamParallelism(
+      CollisionCheckerParams params, bool supports_parallel_checking) {
+    if (!supports_parallel_checking) {
+      params.implicit_context_parallelism = Parallelism::None();
+    }
+    return params;
+  }
+
   bool collision_free_{false};
   optional<GeometryId> added_shape_id_;
   // Updated with every call to DoUpdateContextPositions().

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -437,17 +437,26 @@ GTEST_TEST(CollisionCheckerTest, CollisionCheckerEmpty) {
   // are required to allocate contexts during construction. This is proof that
   // such an erroneous implementation can't appear functional.
   EXPECT_THROW(dut.plant_context(), std::exception);
+  EXPECT_THROW(dut.plant_context(0), std::exception);
   EXPECT_THROW(dut.model_context(), std::exception);
+  EXPECT_THROW(dut.model_context(0), std::exception);
   EXPECT_THROW(dut.Clone(), std::exception);
   EXPECT_THROW(dut.MakeStandaloneModelContext(), std::exception);
   EXPECT_THROW(dut.PerformOperationAgainstAllModelContexts(op), std::exception);
 
   dut.AllocateContexts();
   EXPECT_NO_THROW(dut.plant_context());
+  EXPECT_NO_THROW(dut.plant_context(0));
   EXPECT_NO_THROW(dut.model_context());
+  EXPECT_NO_THROW(dut.model_context(0));
   EXPECT_NO_THROW(dut.Clone());
   EXPECT_NO_THROW(dut.MakeStandaloneModelContext());
   EXPECT_NO_THROW(dut.PerformOperationAgainstAllModelContexts(op));
+
+  // Asking for an out-of-range context number throws.
+  EXPECT_FALSE(dut.SupportsParallelChecking());
+  EXPECT_THROW(dut.plant_context(1), std::exception);
+  EXPECT_THROW(dut.model_context(1), std::exception);
 }
 
 // Test the robot model introspection APIs.

--- a/planning/test_utilities/collision_checker_abstract_test_suite.cc
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.cc
@@ -2,7 +2,6 @@
 
 #include <unordered_map>
 
-#include <common_robotics_utilities/openmp_helpers.hpp>
 #include <common_robotics_utilities/print.hpp>
 
 #include "drake/geometry/shape_specification.h"
@@ -145,7 +144,7 @@ TEST_P(CollisionCheckerAbstractTestSuite, AddObstacles) {
 }
 
 void CollisionCheckerAbstractTestSuite::TestParallelizeableDiscreteQueries(
-    const CollisionCheckerTestParams& params) {
+    const CollisionCheckerTestParams& params, const Parallelism parallelism) {
   auto& checker = *params.checker;
   // Check single queries Queries we know are collision-free, given the robot
   // that MakeCollisionCheckerTestScene loads and the qs_ in the text fixture.
@@ -165,11 +164,13 @@ void CollisionCheckerAbstractTestSuite::TestParallelizeableDiscreteQueries(
 
   // Edge we know is collision-free.
   EXPECT_TRUE(checker.CheckEdgeCollisionFree(qs_.q1, qs_.q2));
-  EXPECT_TRUE(checker.CheckEdgeCollisionFreeParallel(qs_.q1, qs_.q2));
+  EXPECT_TRUE(
+      checker.CheckEdgeCollisionFreeParallel(qs_.q1, qs_.q2, parallelism));
   EXPECT_TRUE(
       checker.MeasureEdgeCollisionFree(qs_.q1, qs_.q2).completely_free());
-  EXPECT_TRUE(checker.MeasureEdgeCollisionFreeParallel(qs_.q1, qs_.q2)
-                  .completely_free());
+  EXPECT_TRUE(
+      checker.MeasureEdgeCollisionFreeParallel(qs_.q1, qs_.q2, parallelism)
+          .completely_free());
 
   // Edge we know is partially in collision.
   EXPECT_FALSE(checker.CheckEdgeCollisionFree(qs_.q2, qs_.q3));
@@ -184,28 +185,33 @@ void CollisionCheckerAbstractTestSuite::TestParallelizeableDiscreteQueries(
       checker.MeasureEdgeCollisionFree(qs_.q3, qs_.q2).partially_free());
 
   // Now repeat for the same (q2, q3) and (q3, q2) edges, but in parallel.
-  EXPECT_FALSE(checker.CheckEdgeCollisionFreeParallel(qs_.q2, qs_.q3));
-  EXPECT_FALSE(checker.CheckEdgeCollisionFreeParallel(qs_.q3, qs_.q2));
+  EXPECT_FALSE(
+      checker.CheckEdgeCollisionFreeParallel(qs_.q2, qs_.q3, parallelism));
+  EXPECT_FALSE(
+      checker.CheckEdgeCollisionFreeParallel(qs_.q3, qs_.q2, parallelism));
   const EdgeMeasure forward_parallel =
-      checker.MeasureEdgeCollisionFreeParallel(qs_.q2, qs_.q3);
+      checker.MeasureEdgeCollisionFreeParallel(qs_.q2, qs_.q3, parallelism);
   ASSERT_TRUE(forward_parallel.partially_free());
   EXPECT_FLOAT_EQ(forward.alpha(), forward_parallel.alpha());
   EXPECT_GE(forward_parallel.alpha(), 0.0);
   EXPECT_LT(forward_parallel.alpha(), 1.0);
-  EXPECT_FALSE(checker.MeasureEdgeCollisionFreeParallel(qs_.q3, qs_.q2)
-                   .partially_free());
+  EXPECT_FALSE(
+      checker.MeasureEdgeCollisionFreeParallel(qs_.q3, qs_.q2, parallelism)
+          .partially_free());
 
   // Edge we know is entirely in collision.
   EXPECT_FALSE(checker.CheckEdgeCollisionFree(qs_.q3, qs_.q4));
-  EXPECT_FALSE(checker.CheckEdgeCollisionFreeParallel(qs_.q3, qs_.q4));
+  EXPECT_FALSE(
+      checker.CheckEdgeCollisionFreeParallel(qs_.q3, qs_.q4, parallelism));
   EXPECT_FALSE(
       checker.MeasureEdgeCollisionFree(qs_.q3, qs_.q4).partially_free());
-  EXPECT_FALSE(checker.MeasureEdgeCollisionFreeParallel(qs_.q3, qs_.q4)
-                   .partially_free());
+  EXPECT_FALSE(
+      checker.MeasureEdgeCollisionFreeParallel(qs_.q3, qs_.q4, parallelism)
+          .partially_free());
 
   // Check parallel queries.
   const std::vector<uint8_t> checks =
-      checker.CheckConfigsCollisionFree(qs_.configs);
+      checker.CheckConfigsCollisionFree(qs_.configs, parallelism);
   EXPECT_TRUE(checks.size() == qs_.configs.size());
   EXPECT_EQ(checks.at(0), 1);
   EXPECT_EQ(checks.at(1), 1);
@@ -213,7 +219,7 @@ void CollisionCheckerAbstractTestSuite::TestParallelizeableDiscreteQueries(
   EXPECT_EQ(checks.at(3), 0);
 
   const std::vector<uint8_t> edge_checks =
-      checker.CheckEdgesCollisionFree(qs_.edges);
+      checker.CheckEdgesCollisionFree(qs_.edges, parallelism);
   EXPECT_TRUE(edge_checks.size() == qs_.edges.size());
   EXPECT_EQ(edge_checks.at(0), 1);
   EXPECT_EQ(edge_checks.at(1), 0);
@@ -221,7 +227,7 @@ void CollisionCheckerAbstractTestSuite::TestParallelizeableDiscreteQueries(
   EXPECT_EQ(edge_checks.at(3), 0);
 
   const std::vector<EdgeMeasure> results =
-      checker.MeasureEdgesCollisionFree(qs_.edges);
+      checker.MeasureEdgesCollisionFree(qs_.edges, parallelism);
   EXPECT_EQ(results.size(), qs_.edges.size());
   EXPECT_FLOAT_EQ(results.at(0).alpha(), 1.0);
   EXPECT_FLOAT_EQ(results.at(1).alpha(), forward.alpha());
@@ -231,24 +237,32 @@ void CollisionCheckerAbstractTestSuite::TestParallelizeableDiscreteQueries(
 
 TEST_P(CollisionCheckerAbstractTestSuite, StressParallelDiscreteQueries) {
   auto params = GetParam();
+  const auto parallelism = Parallelism::Max();
   // Since there are parallel query options, we test repeatedly to ensure that
   // tests are not flaky.
   const int iterations = params.thread_stress_iterations;
   for (int iteration = 0; iteration < iterations; ++iteration) {
-    TestParallelizeableDiscreteQueries(params);
+    TestParallelizeableDiscreteQueries(params, parallelism);
   }
 }
 
 TEST_P(CollisionCheckerAbstractTestSuite, ForceSerializeDiscreteQueries) {
-  common_robotics_utilities::openmp_helpers::DisableOmpWrapper disable_openmp;
   auto params = GetParam();
-  ASSERT_EQ(common_robotics_utilities::openmp_helpers::GetNumOmpThreads(), 1);
-  TestParallelizeableDiscreteQueries(params);
+  const auto parallelism = Parallelism::None();
+  TestParallelizeableDiscreteQueries(params, parallelism);
 }
 
 void CollisionCheckerAbstractTestSuite::TestParallelizeableGradientQueries(
-    const CollisionCheckerTestParams& params) {
+    const CollisionCheckerTestParams& params, const Parallelism parallelism) {
   auto& checker = *params.checker;
+
+  // Test parallel calls to CalcRobotClearance.
+#if defined(_OPENMP)
+#pragma omp parallel for num_threads(parallelism.num_threads()) schedule(static)
+#endif
+  for (int thread = 0; thread < parallelism.num_threads(); ++thread) {
+    EXPECT_NO_THROW(checker.CalcRobotClearance(qs_.q1, 0.0));
+  }
 
   // Test collision gradient:
   // q1 is not in collision, so we should have a free-space only avoidance
@@ -306,19 +320,19 @@ void CollisionCheckerAbstractTestSuite::TestParallelizeableGradientQueries(
 
 TEST_P(CollisionCheckerAbstractTestSuite, StressParallelGradientQueries) {
   auto params = GetParam();
+  const auto parallelism = Parallelism::Max();
   // Since there are parallel query options, we test repeatedly to ensure that
   // tests are not flaky.
   const int iterations = params.thread_stress_iterations;
   for (int iteration = 0; iteration < iterations; ++iteration) {
-    TestParallelizeableGradientQueries(params);
+    TestParallelizeableGradientQueries(params, parallelism);
   }
 }
 
 TEST_P(CollisionCheckerAbstractTestSuite, ForceSerializeGradientQueries) {
-  common_robotics_utilities::openmp_helpers::DisableOmpWrapper disable_openmp;
   auto params = GetParam();
-  ASSERT_EQ(common_robotics_utilities::openmp_helpers::GetNumOmpThreads(), 1);
-  TestParallelizeableGradientQueries(params);
+  const auto parallelism = Parallelism::None();
+  TestParallelizeableGradientQueries(params, parallelism);
 }
 
 }  // namespace test

--- a/planning/test_utilities/collision_checker_abstract_test_suite.cc
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.cc
@@ -143,7 +143,10 @@ TEST_P(CollisionCheckerAbstractTestSuite, AddObstacles) {
   }
 }
 
-void CollisionCheckerAbstractTestSuite::TestParallelizeableDiscreteQueries(
+// Tests "discrete" configuration and edge collision check methods. Provided
+// `parallelism` controls parallelism of parallel check methods.
+// TODO(calderpg-tri) Improve so that parallelism is exercised on all queries.
+void CollisionCheckerAbstractTestSuite::TestDiscreteQueries(
     const CollisionCheckerTestParams& params, const Parallelism parallelism) {
   auto& checker = *params.checker;
   // Check single queries Queries we know are collision-free, given the robot
@@ -242,17 +245,20 @@ TEST_P(CollisionCheckerAbstractTestSuite, StressParallelDiscreteQueries) {
   // tests are not flaky.
   const int iterations = params.thread_stress_iterations;
   for (int iteration = 0; iteration < iterations; ++iteration) {
-    TestParallelizeableDiscreteQueries(params, parallelism);
+    TestDiscreteQueries(params, parallelism);
   }
 }
 
 TEST_P(CollisionCheckerAbstractTestSuite, ForceSerializeDiscreteQueries) {
   auto params = GetParam();
   const auto parallelism = Parallelism::None();
-  TestParallelizeableDiscreteQueries(params, parallelism);
+  TestDiscreteQueries(params, parallelism);
 }
 
-void CollisionCheckerAbstractTestSuite::TestParallelizeableGradientQueries(
+// Tests "distance" clearance and collision avoidance methods. Provided
+// `parallelism` controls parallelism of calls to `CalcRobotClearance` only.
+// TODO(calderpg-tri) Improve so that parallelism is exercised on all queries.
+void CollisionCheckerAbstractTestSuite::TestDistanceQueries(
     const CollisionCheckerTestParams& params, const Parallelism parallelism) {
   auto& checker = *params.checker;
 
@@ -325,14 +331,14 @@ TEST_P(CollisionCheckerAbstractTestSuite, StressParallelGradientQueries) {
   // tests are not flaky.
   const int iterations = params.thread_stress_iterations;
   for (int iteration = 0; iteration < iterations; ++iteration) {
-    TestParallelizeableGradientQueries(params, parallelism);
+    TestDistanceQueries(params, parallelism);
   }
 }
 
 TEST_P(CollisionCheckerAbstractTestSuite, ForceSerializeGradientQueries) {
   auto params = GetParam();
   const auto parallelism = Parallelism::None();
-  TestParallelizeableGradientQueries(params, parallelism);
+  TestDistanceQueries(params, parallelism);
 }
 
 }  // namespace test

--- a/planning/test_utilities/collision_checker_abstract_test_suite.h
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.h
@@ -67,10 +67,10 @@ std::ostream& operator<<(std::ostream& out,
 class CollisionCheckerAbstractTestSuite
     : public testing::TestWithParam<CollisionCheckerTestParams> {
  protected:
-  void TestParallelizeableDiscreteQueries(
-      const CollisionCheckerTestParams& params, Parallelism parallelism);
-  void TestParallelizeableGradientQueries(
-      const CollisionCheckerTestParams& params, Parallelism parallelism);
+  void TestDiscreteQueries(const CollisionCheckerTestParams& params,
+                           Parallelism parallelism);
+  void TestDistanceQueries(const CollisionCheckerTestParams& params,
+                           Parallelism parallelism);
   const CollisionCheckerTestConfigurationData qs_;
 };
 

--- a/planning/test_utilities/collision_checker_abstract_test_suite.h
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.h
@@ -67,8 +67,10 @@ std::ostream& operator<<(std::ostream& out,
 class CollisionCheckerAbstractTestSuite
     : public testing::TestWithParam<CollisionCheckerTestParams> {
  protected:
-  void TestParallelizeableDiscreteQueries(const CollisionCheckerTestParams&);
-  void TestParallelizeableGradientQueries(const CollisionCheckerTestParams&);
+  void TestParallelizeableDiscreteQueries(
+      const CollisionCheckerTestParams& params, Parallelism parallelism);
+  void TestParallelizeableGradientQueries(
+      const CollisionCheckerTestParams& params, Parallelism parallelism);
   const CollisionCheckerTestConfigurationData qs_;
 };
 

--- a/planning/visibility_graph.cc
+++ b/planning/visibility_graph.cc
@@ -10,6 +10,7 @@
 #endif
 
 using common_robotics_utilities::openmp_helpers::GetContextOmpThreadNum;
+using common_robotics_utilities::openmp_helpers::IsOmpEnabledInBuild;
 
 namespace drake {
 namespace planning {
@@ -113,7 +114,9 @@ Eigen::SparseMatrix<bool> VisibilityGraph(
   DRAKE_THROW_UNLESS(checker.plant().num_positions() == points.rows());
 
   const int num_points = points.cols();
-  const int num_threads_to_use = checker.GetNumberOfThreads(parallelize);
+  const int num_threads_to_use = (IsOmpEnabledInBuild() && parallelize)
+                                     ? checker.num_allocated_contexts()
+                                     : 1;
   drake::log()->debug("Generating VisibilityGraph using {} threads",
                       num_threads_to_use);
 

--- a/planning/visibility_graph.cc
+++ b/planning/visibility_graph.cc
@@ -3,16 +3,12 @@
 #include <iterator>
 #include <vector>
 
-#include <common_robotics_utilities/openmp_helpers.hpp>
 #if defined(_OPENMP)
 #include <omp.h>
 #endif
 
 namespace drake {
 namespace planning {
-
-using common_robotics_utilities::openmp_helpers::DegreeOfParallelism;
-
 namespace {
 
 /* A custom iterator that turns undirected edges encoded in the given
@@ -121,7 +117,7 @@ Eigen::SparseMatrix<bool> VisibilityGraph(
   // parallel evaluations.
   std::vector<uint8_t> points_free(num_points, 0x00);
 #if defined(_OPENMP)
-#pragma omp parallel for num_threads(num_threads_to_use)
+#pragma omp parallel for num_threads(num_threads_to_use) schedule(static)
 #endif
   for (int i = 0; i < num_points; ++i) {
     points_free[i] =


### PR DESCRIPTION
Changes:

- Removes uses of CRU parallelization macros to decrease Drake+anzu+CRU coupling
- Provides `Parallelism` control to all parallel/optionally-parallelized `CollisionChecker` methods (many of which previously took just a `bool parallelize`)
- Provides an `implicit_context_parallelism` member of `CollisionCheckerParams` to optionally specify a different number of implicit contexts (e.g. to effectively disable implicit context parallelism if unnecessary), resolves #18982 
- Provides optional `context_number` parameters to all `CollisionChecker` implicit context methods to support (among other uses) non-OpenMP parallel for loop implementations

+@jwnimmer-tri for feature review, thanks!

fyi @rpoyner-tri @sadraddini

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20138)
<!-- Reviewable:end -->
