### PR TITLE
[vis] MeshcatVisualizer and Meldis rely on meshcat APIs to handle alpha sliders

### DIFF
--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -385,12 +385,15 @@ class TestMeldis(unittest.TestCase):
         meshcat.SetSliderValue("Viewer α", new_alpha)
         dut._invoke_poll()
 
-        # Confirm the new color of the box.
-        path = "/DRAKE_VIEWER/2/plant/box/box/0"
+        # Confirm the new (modulated) opacity of the box. Note: this doesn't
+        # actually test the resulting opacity of the box, merely that we
+        # called set_property("/DRAKE_VIEWER", "modulated_opacity", new_alpha).
+        # We rely on meshcat to do the "right" thing in response.
+        path = "/DRAKE_VIEWER"
         self.assertEqual(meshcat.HasPath(path), True)
-        message = meshcat._GetPackedProperty(path, "color")
+        message = meshcat._GetPackedProperty(path, "modulated_opacity")
         parsed = umsgpack.unpackb(message)
-        self.assertListEqual(parsed['value'], rgb + [new_alpha])
+        self.assertEqual(parsed['value'], new_alpha)
 
     def test_inertia_geometry(self):
         url = "package://drake/examples/manipulation_station/models/sphere.sdf"

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -135,7 +135,7 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
   if (!version_.has_value() ||
       !version_->IsSameAs(current_version, params_.role)) {
     SetObjects(query_object.inspector());
-    SetColorAlphas(/* is_first_call = */ true);
+    SetAlphas(/* initializing = */ true);
     version_ = current_version;
   }
   SetTransforms(context, query_object);
@@ -143,7 +143,7 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
     double new_alpha_value = meshcat_->GetSliderValue(alpha_slider_name_);
     if (new_alpha_value != alpha_value_) {
       alpha_value_ = new_alpha_value;
-      SetColorAlphas(/* is_first_call = */ false);
+      SetAlphas(/* initializing = */ false);
     }
   }
   std::optional<double> rate = realtime_rate_calculator_.UpdateAndRecalculate(
@@ -158,8 +158,6 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
 template <typename T>
 void MeshcatVisualizer<T>::SetObjects(
     const SceneGraphInspector<T>& inspector) const {
-  colors_.clear();
-
   // Frames registered previously that are not set again here should be deleted.
   std::map <FrameId, std::string> frames_to_delete{};
   dynamic_frames_.swap(frames_to_delete);
@@ -231,7 +229,6 @@ void MeshcatVisualizer<T>::SetObjects(
       }
       meshcat_->SetTransform(path, inspector.GetPoseInFrame(geom_id));
       geometries_[geom_id] = path;
-      colors_[geom_id] = rgba;
       geometries_to_delete.erase(geom_id);  // Don't delete this one.
       frame_has_any_geometry = true;
     }
@@ -265,26 +262,19 @@ void MeshcatVisualizer<T>::SetTransforms(
 }
 
 template <typename T>
-void MeshcatVisualizer<T>::SetColorAlphas(bool is_first_call) const {
-  double max_alpha = 0.0;
-  for (const auto& [geom_id, path] : geometries_) {
-    max_alpha = std::max(max_alpha, colors_[geom_id].a());
-  }
-
-  if (is_first_call && alpha_value_ == 1.0 && max_alpha > 0.0) {
-    // We can skip all of the no-op calls to SetProperty.
-    return;
-  }
-
-  for (const auto& [geom_id, path] : geometries_) {
-    Rgba color = colors_[geom_id];
-    if (max_alpha == 0.0) {
-      color.update({}, {}, {}, alpha_value_);
-    } else {
-      color.update({}, {}, {}, alpha_value_ * color.a());
+void MeshcatVisualizer<T>::SetAlphas(bool initializing) const {
+  if (initializing) {
+    for (const auto& [_, geo_path] : geometries_) {
+      meshcat_->SetProperty(geo_path, "modulated_opacity", alpha_value_);
     }
-    meshcat_->SetProperty(path, "color",
-                          {color.r(), color.g(), color.b(), color.a()});
+  } else {
+    // The geometries visualized by this visualizer (stored in geometries_) all
+    // have a common prefix and for a well-configured visualizer, it is a
+    // *unique* prefix. So, we can rely on meshcat's behavior to update all
+    // materials in a tree with a single invocation on the root path. This
+    // requires that all object instantiations are complete in the visualizer
+    // instance.
+    meshcat_->SetProperty(params_.prefix, "modulated_opacity", alpha_value_);
   }
 }
 

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -178,8 +178,11 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   void SetTransforms(const systems::Context<T>& context,
                      const QueryObject<T>& query_object) const;
 
-  /* Makes calls to Meshcat::SetProperty to update color alphas. */
-  void SetColorAlphas(bool is_first_call) const;
+  /* Makes calls to Meshcat::SetProperty to update geometry alphas. During
+   initialization, it is necessary to explicitly configure each geometry
+   individually due to race conditions between declaring the geometry and
+   configuring it. Once the geometry is loaded, they can be updated en masse. */
+  void SetAlphas(bool initializing) const;
 
   /* Handles the initialization event. */
   systems::EventStatus OnInitialization(const systems::Context<T>&) const;
@@ -212,11 +215,8 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    new geometry version appears that does not contain them. */
   mutable std::map<GeometryId, std::string> geometries_{};
 
-  /* A store of the original colors for the objects in geometries_. */
-  mutable std::map<GeometryId, Rgba> colors_{};
-
   /* The last alpha value applied to the objects in geometries_; used to avoid
-   * unnecessary updates to geometry colors. */
+   unnecessary updates to geometry opacities. */
   mutable double alpha_value_{1.0};
 
   /* The parameters for the visualizer.  */

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -497,121 +497,84 @@ TEST_F(MeshcatVisualizerWithIiwaTest, AlphaSlidersSystemCheck) {
   diagram_->ForcedPublish(*context_);
 }
 
-// Checks whether the given path has been set to a new color beyond it's initial
-// color. If so, returns the new color; otherwise, returns nullopt.
-std::optional<Rgba> GetColorProperty(const Meshcat& meshcat,
-                                     const std::string& path) {
-  std::string bytes = meshcat.GetPackedProperty(path, "color");
+// Tests to see if the given meshcat instance has had the "modulated_opacity"
+// set for the given path. Returns the value if so, nullopt otherwise.
+std::optional<double> GetOpacityProperty(const Meshcat& meshcat,
+                                         const std::string& path) {
+  const std::string bytes =
+      meshcat.GetPackedProperty(path, "modulated_opacity");
   if (bytes.empty()) {
     return {};
   }
   msgpack::object_handle oh = msgpack::unpack(bytes.data(), bytes.size());
-  auto decoded = oh.get().as<internal::SetPropertyData<std::vector<double>>>();
-  EXPECT_EQ(decoded.property, "color");
-  EXPECT_EQ(decoded.value.size(), 4);
-  if (decoded.value.size() != 4) {
-    return {};
-  }
-  return Rgba(decoded.value[0], decoded.value[1], decoded.value[2],
-              decoded.value[3]);
+  auto decoded = oh.get().as<internal::SetPropertyData<double>>();
+  return decoded.value;
 }
 
-// Check the effect that changing alpha sliders has on geometry color.
+// Check the effect that changing alpha sliders has on geometry opacity.
+// MeshcatVisualizer now has limited logic for controlling alpha based on slider
+// value -- the majority of the heavy lifting is done by meshcat.js.
+// MeshcatVisualizer is responsible for initializing all of the initial alphas
+// and efficiently updating after the fact. We'll be checking that the expected
+// messages have been sent.
 GTEST_TEST(MeshcatVisualizerTest, AlphaSliderCheckResults) {
-  struct Scenario {
-    double geometry_alpha{};
-    double slider_value{};
-    double expected_value{};
-  };
+  // Load a simple model with one geometry.
+  auto meshcat = std::make_shared<Meshcat>();
+  systems::DiagramBuilder<double> builder;
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.001);
+  multibody::Parser(&plant).AddModelsFromUrl(
+      "package://drake/geometry/render/test/box.sdf");
+  plant.Finalize();
 
-  std::vector<Scenario> scenarios{
-    // For geometry that is not fully transparent, the alpha set by the slider
-    // is geometry alpha * slider value.
-    {1.0, 0.6, 0.6},
-    {1.0, 1.0, 1.0},
-    {0.5, 0.6, 0.6 * 0.5},
-    {0.5, 1.0, 0.5},
+  // Get the geometry id so we can create the path for the geometry.
+  auto& inspector = scene_graph.model_inspector();
+  const FrameId body_frame =
+      plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("box").index());
+  const auto geom_ids =
+      inspector.GetGeometries(body_frame, Role::kIllustration);
+  DRAKE_DEMAND(geom_ids.size() == 1);
+  const GeometryId geom_id = *geom_ids.begin();
+  const std::string geom_path =
+      fmt::format("visualizer/box/box/{}", geom_id.get_value());
 
-    // For fully-transparent geometry, the alpha set by the slider is the
-    // slider's value.
-    {0.0, 0.6, 0.6},
-    {0.0, 1.0, 1.0},
+  // Create the visualizer.
+  MeshcatVisualizerParams params;
+  params.prefix = "visualizer";
+  params.enable_alpha_slider = true;
+  MeshcatVisualizer<double>::AddToBuilder(&builder, scene_graph, meshcat,
+                                          params);
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
 
-    // Note that we do not test setting sliders to 0.0 because that's outside
-    // the slider range and is also orthogonal to the logic we're testing.
-  };
+  // After instantiation, the first publish should initialize the modulated
+  // opacity for each geometry individually with the initial value of 1.
+  diagram->ForcedPublish(*context);
+  const std::optional<double> init_alpha =
+      GetOpacityProperty(*meshcat, geom_path);
+  ASSERT_TRUE(init_alpha.has_value());
+  EXPECT_EQ(*init_alpha, 1.0);
 
-  for (auto scenario : scenarios) {
-    // Load a simple model with one geometry.
-    auto meshcat = std::make_shared<Meshcat>();
-    systems::DiagramBuilder<double> builder;
-    auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.001);
-    multibody::Parser(&plant).AddModelsFromUrl(
-        "package://drake/geometry/render/test/box.sdf");
-    plant.Finalize();
+  // The opacity value started as one, attempting to redundantly "change" it to
+  // the same value will do nothing.
+  meshcat->SetSliderValue("visualizer α", 1.0);
+  diagram->ForcedPublish(*context);
+  ASSERT_FALSE(GetOpacityProperty(*meshcat, params.prefix).has_value());
 
-    // Update the single geometry's alpha to scenario.geometry_alpha.
-    auto& inspector = scene_graph.model_inspector();
-    const FrameId body_frame =
-        plant.GetBodyFrameIdOrThrow(plant.GetBodyByName("box").index());
-    const auto geom_ids =
-        inspector.GetGeometries(body_frame, Role::kIllustration);
-    DRAKE_DEMAND(geom_ids.size() == 1);
-    const GeometryId geom_id = *geom_ids.begin();
-    const IllustrationProperties* old_props =
-        scene_graph.model_inspector().GetIllustrationProperties(geom_id);
-    DRAKE_DEMAND(old_props != nullptr);
-    IllustrationProperties new_props(*old_props);
-    new_props.UpdateProperty("phong", "diffuse", Rgba{1.0, 1.0, 1.0,
-                             scenario.geometry_alpha});
-    scene_graph.AssignRole(*plant.get_source_id(), geom_id, new_props,
-                           RoleAssign::kReplace);
-
-    // Create the visualizer.
-    MeshcatVisualizerParams params;
-    params.prefix = "visualizer";
-    params.enable_alpha_slider = true;
-    MeshcatVisualizer<double>::AddToBuilder(&builder, scene_graph, meshcat,
-                                            params);
-    auto diagram = builder.Build();
-    auto context = diagram->CreateDefaultContext();
-
-    // Publish the initial geometry. The alpha slider remains at its default
-    // value of 100%.
-    const std::string geom_path =
-        fmt::format("visualizer/box/box/{}", geom_id.get_value());
+  // For a somewhat arbitrary sequence of opacity values, we're confirming that
+  // the slider value is always set to the "modulating_opacity" property.
+  // These values must be integer multiples of 0.02 between 0.02 and 1 -- this
+  // is how the slider is configured -- and 1 must not come first -- because
+  // the slider value started as one, and setting it redundantly is ignored.
+  for (const double slider_value : {0.2, 0.76, 1.0, 0.02}) {
+    meshcat->SetSliderValue("visualizer α", slider_value);
     diagram->ForcedPublish(*context);
 
-    // If the geometry had a zero alpha, it's promoted to the default (100%).
-    // If the geometry already had a non-zero alpha, it remains unchanged.
-    const std::optional<Rgba> init_color =
-        GetColorProperty(*meshcat, geom_path);
-    if (scenario.geometry_alpha == 0.0) {
-      EXPECT_TRUE(init_color.has_value());
-      EXPECT_EQ(init_color.value_or(Rgba{}).a(), 1.0);
-    } else {
-      EXPECT_FALSE(init_color.has_value());
-    }
-
-    // If the test case specifies a <100% alpha, move the slider and republish.
-    if (scenario.slider_value != 1.0) {
-      meshcat->SetSliderValue("visualizer α", scenario.slider_value);
-      diagram->ForcedPublish(*context);
-    }
-
-    // Check to see whether the visualizer adjusted the alpha value with a
-    // SetProperty call subsequent to the original SetObject call.
-    const bool requires_alpha_update =
-        scenario.geometry_alpha != scenario.expected_value;
-    const std::optional<Rgba> final_color =
-        GetColorProperty(*meshcat, geom_path);
-    EXPECT_EQ(final_color.has_value(), requires_alpha_update);
-    if (final_color.has_value()) {
-      EXPECT_EQ(final_color->r(), 1.0);
-      EXPECT_EQ(final_color->g(), 1.0);
-      EXPECT_EQ(final_color->b(), 1.0);
-      EXPECT_EQ(final_color->a(), scenario.expected_value);
-    }
+    // We should have dispatched a set property on the *visualizer root* with
+    // the given slider value.
+    const std::optional<double> mod_opacity_value =
+        GetOpacityProperty(*meshcat, params.prefix);
+    ASSERT_TRUE(mod_opacity_value.has_value());
+    EXPECT_EQ(*mod_opacity_value, slider_value);
   }
 }
 

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -10,8 +10,8 @@ def meshcat_repository(
         Updating this commit requires local testing; see
         drake/tools/workspace/meshcat/README.md for details.
         """,
-        commit = "7b233bc98717d82212312af37ff7d0ce9f51a1ba",
-        sha256 = "49b1a985d847e67de0efdb32f268e704c4fc1c2c1fc4769715cd3d87601d1aa6",  # noqa
+        commit = "44eac463725f048c47debfe34d3f935d01aa6bac",
+        sha256 = "7ac5e9fdcc407abb4770bad1cee849de939f1dc856ef38d601a1982abec68ac3",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/visualization/inertia_visualizer.cc
+++ b/visualization/inertia_visualizer.cc
@@ -63,10 +63,13 @@ InertiaVisualizer<T>::InertiaVisualizer(
     IllustrationProperties props;
     props.AddProperty("meshcat", "accepting", "inertia");
     // TODO(trowell-tri) This color is a placeholder until texturing is added.
-    // We set alpha to 0.0 here to support visualizers without alpha sliders.
-    // MeshcatVisualizer will update the alpha of this geometry based on the
-    // alpha slider's value.
-    props.AddProperty("phong", "diffuse", Rgba{0.0, 0.0, 1.0, 0.0});
+
+    // We set inherent opacity (alpha) to 1. This means if InertiaVisualizer is
+    // used in a viewer without a slider control for opacity, the inertia
+    // geometry will be permanently visible (but does allow us to use
+    // meshcat.js's "modulated_opacity" property to manage its opacity
+    // in a manner consistent with MeshcatVisualizer).
+    props.AddProperty("phong", "diffuse", Rgba{0.0, 0.0, 1.0, 1.0});
     geom->set_illustration_properties(std::move(props));
     item.geometry = scene_graph->RegisterGeometry(source_id_, item.Bcm_frame,
                                                   std::move(geom));


### PR DESCRIPTION
Previously, meshcat visualizer was trying to modulate the opacity of geometries by storing the underlying color/opacity and subsequently setting it by setting the "color" property. This works for primtive shapes but breaks down for complex geometries (e.g., obj with mtl files and glTF files).
    
Instead, MeshcatVisualizer makes use of the new affordances in meshcat. With meshcat, one can set the "opacity" or "modulated_opacity" property. As with setting the "color" property, meshcat will update all of the materials in a tree. Meshcat and meldis now exploit this to reduce the number of meshcat calls (making a single API invocation for the entire path tree that the instance owns).

Resolves #19820

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20140)
<!-- Reviewable:end -->
