### PR TITLE
[wheel] Update xz url to newly mirrored 5.2.5

### DIFF
--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -27,7 +27,7 @@ list(APPEND ALL_PROJECTS lz4)
 
 # xz
 set(xz_version 5.2.5)
-set(xz_url "https://tukaani.org/xz/xz-${xz_version}.tar.gz")
+set(xz_url "https://drake-mirror.csail.mit.edu/other/xz/xz-${xz_version}.tar.gz")
 set(xz_md5 "0d270c997aff29708c74d53f599ef717")
 list(APPEND ALL_PROJECTS xz)
 


### PR DESCRIPTION
The original archive link has a different md5sum now.  We have mirrored the original.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20142)
<!-- Reviewable:end -->
