### PR TITLE
[tools] Switch ASan back to using ld.gold and fission

### DIFF
--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -43,11 +43,6 @@ build:asan --copt=-O0
 build:asan --copt=-fno-omit-frame-pointer
 build:asan --linkopt=-fsanitize=address
 build:asan --linkopt=-fsanitize-address-use-after-scope
-# ld.gold: warning: Cannot export local symbol __asan_extra_spill_area
-build:asan --linkopt=-fuse-ld=ld
-build:asan --start_end_lib=no
-# --fission requires gold; remove if -fuse-ld=ld above is removed.
-build:asan --fission=no
 build:asan --run_under=//tools/dynamic_analysis:asan
 build:asan --test_env=ASAN_OPTIONS
 build:asan --test_env=LSAN_OPTIONS
@@ -60,6 +55,11 @@ build:asan --test_lang_filters=-sh,-py
 # See https://clang.llvm.org/docs/AddressSanitizer.html
 build:asan --test_timeout=150,750,2250,9000  # 2.5x
 build:asan --define=USING_SANITIZER=ON
+# Due to https://sourceware.org/bugzilla/show_bug.cgi?id=25975, we see ...
+#  ld.gold: warning: Cannot export local symbol __asan_extra_spill_area
+# ... spammed millions of times in ASan builds. The only way to silence that
+# warning is to silence ALL WARNINGS AT ALL EVER in ASan builds.
+build:asan --auto_output_filter=all
 
 ### ASan everything build. Clang only. ###
 build:asan_everything --build_tests_only
@@ -76,11 +76,6 @@ build:asan_everything --copt=-O0
 build:asan_everything --copt=-fno-omit-frame-pointer
 build:asan_everything --linkopt=-fsanitize=address
 build:asan_everything --linkopt=-fsanitize-address-use-after-scope
-# ld.gold: warning: Cannot export local symbol __asan_extra_spill_area
-build:asan_everything --linkopt=-fuse-ld=ld
-build:asan_everything --start_end_lib=no
-# --fission requires gold; remove if -fuse-ld=ld above is removed.
-build:asan_everything --fission=no
 # LSan is run with ASan by default
 build:asan_everything --test_tag_filters=-no_asan,-no_lsan
 build:asan_everything --run_under=//tools/dynamic_analysis:asan
@@ -93,6 +88,11 @@ build:asan_everything --test_lang_filters=-sh,-py
 # See https://clang.llvm.org/docs/AddressSanitizer.html
 build:asan_everything --test_timeout=150,750,2250,9000  # 2.5x
 build:asan_everything --define=USING_SANITIZER=ON
+# Due to https://sourceware.org/bugzilla/show_bug.cgi?id=25975, we see ...
+# ld.gold: warning: Cannot export local symbol __asan_extra_spill_area
+# ... spammed millions of times in ASan builds. The only way to silence that
+# warning is to silence ALL WARNINGS AT ALL EVER in ASan builds.
+build:asan_everything --auto_output_filter=all
 
 ### LSan build. Clang only. ###
 build:lsan --build_tests_only


### PR DESCRIPTION
Switch ASan back to using ld.gold and fission because the non-fission builds are way too big.

This means that the buggy [console spam from ld.gold](https://github.com/RobotLocomotion/drake/pull/13650#issuecomment-656316040) comes back (see [binutils bug tracker](https://sourceware.org/bugzilla/show_bug.cgi?id=25975)), which means we need to globally disable all console warnings in ASan builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20156)
<!-- Reviewable:end -->
