### PR TITLE
Bump VGT with workaround for macOS OpenCL and fixes for Intel OpenCL

### DIFF
--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -8,13 +8,13 @@ def voxelized_geometry_tools_repository(
         mirrors = None):
     github_archive(
         name = name,
-        repository = "calderpg/voxelized_geometry_tools",
+        repository = "ToyotaResearchInstitute/voxelized_geometry_tools",
         upgrade_advice = """
         When updating, ensure that any new unit tests are reflected in
         package.BUILD.bazel and BUILD.bazel in drake.
         """,
-        commit = "db163d2d2f88a80d482be7fc639eb27f289ac4e4",
-        sha256 = "5309e5a65ff3197c22842f339f7ddf0524f1d27517e2ad0f8eccdb394e066e1c",  # noqa
+        commit = "0b4f4bbaa3881929045cd9157cd8ce0d9d5911af",
+        sha256 = "113014eedde0ad032a5109592ea9b6f6683f7df52d6b150e3c6bbba2aa41b646",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -8,13 +8,13 @@ def voxelized_geometry_tools_repository(
         mirrors = None):
     github_archive(
         name = name,
-        repository = "ToyotaResearchInstitute/voxelized_geometry_tools",
+        repository = "calderpg/voxelized_geometry_tools",
         upgrade_advice = """
         When updating, ensure that any new unit tests are reflected in
         package.BUILD.bazel and BUILD.bazel in drake.
         """,
-        commit = "37122a2d1c7da410965ab0d800b1dbc1c3ffd5fa",
-        sha256 = "80046ffe33f6dea3f4dd1b107e1d76a9ed76d21fc18cc9f8337ce641e9dc20cf",  # noqa
+        commit = "db163d2d2f88a80d482be7fc639eb27f289ac4e4",
+        sha256 = "5309e5a65ff3197c22842f339f7ddf0524f1d27517e2ad0f8eccdb394e066e1c",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Changes in VGT:
- Workaround for what appears to be a broken `clEnqueueFillBuffer` on macOS (resolves #20133)
- Fixes for OpenCL kernel double->float conversions, which are now warnings using the latest Intel OpenCL (specifically necessary to support ADL-N and ARC GPUs)
- Updates to buffer memory flags and kernel build flags

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20163)
<!-- Reviewable:end -->
