### PR TITLE
[symbolic] Give the default Variable a name

### DIFF
--- a/common/symbolic/expression/BUILD.bazel
+++ b/common/symbolic/expression/BUILD.bazel
@@ -50,6 +50,7 @@ drake_cc_library(
         "//common:essential",
         "//common:hash",
         "//common:random",
+        "//common:reset_after_move",
     ],
     deps = [
         "@abseil_cpp_internal//absl/container:flat_hash_set",

--- a/common/symbolic/expression/environment.cc
+++ b/common/symbolic/expression/environment.cc
@@ -25,15 +25,6 @@ using std::runtime_error;
 using std::string;
 
 namespace {
-void throw_if_dummy(const Variable& var) {
-  if (var.is_dummy()) {
-    ostringstream oss;
-    oss << "Dummy variable (ID = 0) is detected"
-        << "in the initialization of an environment.";
-    throw runtime_error(oss.str());
-  }
-}
-
 void throw_if_nan(const double v) {
   if (std::isnan(v)) {
     ostringstream oss;
@@ -62,13 +53,11 @@ Environment::Environment(const std::initializer_list<key_type> vars)
 
 Environment::Environment(map m) : map_{std::move(m)} {
   for (const auto& p : map_) {
-    throw_if_dummy(p.first);
     throw_if_nan(p.second);
   }
 }
 
 void Environment::insert(const key_type& key, const mapped_type& elem) {
-  throw_if_dummy(key);
   throw_if_nan(elem);
   map_.emplace(key, elem);
 }
@@ -105,21 +94,11 @@ string Environment::to_string() const {
 }
 
 Environment::mapped_type& Environment::operator[](const key_type& key) {
-  if (key.is_dummy()) {
-    ostringstream oss;
-    oss << "Environment::operator[] is called with a dummy variable.";
-    throw runtime_error(oss.str());
-  }
   return map_[key];
 }
 
 const Environment::mapped_type& Environment::operator[](
     const key_type& key) const {
-  if (key.is_dummy()) {
-    ostringstream oss;
-    oss << "Environment::operator[] is called with a dummy variable.";
-    throw runtime_error(oss.str());
-  }
   if (map_.count(key) == 0) {
     ostringstream oss;
     oss << "Environment::operator[] was called on a const Environment "

--- a/common/symbolic/expression/environment.h
+++ b/common/symbolic/expression/environment.h
@@ -37,22 +37,6 @@ namespace symbolic {
  *   const double res2 = e2.Evaluate(env);  // x - y => 2.0 - 3.0 => -1.0
  *   const bool res = f.Evaluate(env);  // x + y > x - y => 5.0 >= -1.0 => True
  * \endcode
- *
- * Note that it is not allowed to have a dummy variable in an environment. It
- * throws std::exception for the attempts to create an environment with a
- * dummy variable, to insert a dummy variable to an existing environment, or to
- * take a reference to a value mapped to a dummy variable. See the following
- * examples.
- *
- * \code{.cpp}
- *   Variable    var_dummy{};           // OK to have a dummy variable
- *   Environment e1{var_dummy};         // throws exception
- *   Environment e2{{var_dummy, 1.0}};  // throws exception
- *   Environment e{};
- *   e.insert(var_dummy, 1.0);          // throws exception
- *   e[var_dummy] = 3.0;                // throws exception
- * \endcode
- *
  */
 class Environment {
  public:

--- a/common/symbolic/expression/expression.h
+++ b/common/symbolic/expression/expression.h
@@ -180,7 +180,7 @@ class Expression {
   }
 
   /** Constructs an expression from @p var.
-   * @pre @p var is neither a dummy nor a BOOLEAN variable.
+   * @pre @p var is not a BOOLEAN variable.
    */
   // NOLINTNEXTLINE(runtime/explicit): This conversion is desirable.
   Expression(const Variable& var);

--- a/common/symbolic/expression/expression_cell.cc
+++ b/common/symbolic/expression/expression_cell.cc
@@ -323,9 +323,6 @@ double BinaryExpressionCell::Evaluate(const Environment& env) const {
 
 ExpressionVar::ExpressionVar(Variable v)
     : ExpressionCell{ExpressionKind::Var, true, true}, var_{std::move(v)} {
-  // Dummy symbolic variable (ID = 0) should not be used in constructing
-  // symbolic expressions.
-  DRAKE_DEMAND(!var_.is_dummy());
   // Boolean symbolic variable should not be used in constructing symbolic
   // expressions.
   DRAKE_DEMAND(var_.get_type() != Variable::Type::BOOLEAN);

--- a/common/symbolic/expression/expression_cell.h
+++ b/common/symbolic/expression/expression_cell.h
@@ -177,7 +177,7 @@ class BinaryExpressionCell : public ExpressionCell {
 class ExpressionVar : public ExpressionCell {
  public:
   /** Constructs an expression from @p var.
-   * @pre @p var is neither a dummy nor a BOOLEAN variable.
+   * @pre @p var is not a BOOLEAN variable.
    */
   void HashAppendDetail(DelegatingHasher*) const override;
   explicit ExpressionVar(Variable v);

--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -128,7 +128,7 @@ class Formula {
   explicit Formula(std::shared_ptr<const FormulaCell> ptr);
 
   /** Constructs a formula from @p var.
-   * @pre @p var is of BOOLEAN type and not a dummy variable.
+   * @pre @p var is of BOOLEAN type.
    */
   explicit Formula(const Variable& var);
 

--- a/common/symbolic/expression/formula_cell.cc
+++ b/common/symbolic/expression/formula_cell.cc
@@ -190,9 +190,6 @@ ostream& FormulaFalse::Display(ostream& os) const {
 
 FormulaVar::FormulaVar(Variable v)
     : FormulaCell{FormulaKind::Var}, var_{std::move(v)} {
-  // Dummy symbolic variable (ID = 0) should not be used in constructing
-  // symbolic formulas.
-  DRAKE_DEMAND(!var_.is_dummy());
   DRAKE_DEMAND(var_.get_type() == Variable::Type::BOOLEAN);
 }
 

--- a/common/symbolic/expression/formula_cell.h
+++ b/common/symbolic/expression/formula_cell.h
@@ -172,7 +172,7 @@ class FormulaFalse : public FormulaCell {
 class FormulaVar : public FormulaCell {
  public:
   /** Constructs a formula from @p var.
-   * @pre @p var is of BOOLEAN type and not a dummy variable.
+   * @pre @p var is of BOOLEAN type.
    */
   explicit FormulaVar(Variable v);
   void HashAppendDetail(DelegatingHasher*) const override;

--- a/common/symbolic/expression/test/environment_test.cc
+++ b/common/symbolic/expression/test/environment_test.cc
@@ -18,7 +18,6 @@ using std::string;
 // Provides common variables that are used by the following tests.
 class EnvironmentTest : public ::testing::Test {
  protected:
-  const Variable var_dummy_{};
   const Variable var_x_{"x"};
   const Variable var_y_{"y"};
   const Variable var_z_{"z"};
@@ -53,13 +52,6 @@ TEST_F(EnvironmentTest, InitWithMap) {
   m.emplace(var_y_, 4.0);
   const Expression e{var_x_ + var_y_};
   EXPECT_EQ(e.Evaluate(Environment{m}), 7.0);
-}
-
-TEST_F(EnvironmentTest, InitWithMapExceptionDummyVariable) {
-  Environment::map m;
-  const Variable dummy;
-  m.emplace(dummy, 3.0);
-  EXPECT_THROW(Environment{m}, runtime_error);
 }
 
 TEST_F(EnvironmentTest, InitWithMapExceptionNan) {
@@ -130,16 +122,6 @@ TEST_F(EnvironmentTest, ToString) {
   EXPECT_TRUE(out.find("z -> 3") != string::npos);
 }
 
-TEST_F(EnvironmentTest, DummyVariable1) {
-  EXPECT_THROW(Environment({var_dummy_, var_x_}), runtime_error);
-  EXPECT_THROW(Environment({{var_dummy_, 1.0}, {var_x_, 2}}), runtime_error);
-}
-
-TEST_F(EnvironmentTest, DummyVariable2) {
-  Environment env{{var_x_, 2}, {var_y_, 3}, {var_z_, 3}};
-  EXPECT_THROW(env.insert(var_dummy_, 0.0), runtime_error);
-}
-
 TEST_F(EnvironmentTest, LookupOperator) {
   Environment env{{var_x_, 2}};
   const Environment const_env{{var_x_, 2}};
@@ -149,8 +131,6 @@ TEST_F(EnvironmentTest, LookupOperator) {
   EXPECT_THROW(const_env[var_y_], runtime_error);
   EXPECT_EQ(env.size(), 2u);
   EXPECT_EQ(const_env.size(), 1u);
-  EXPECT_THROW(env[var_dummy_], runtime_error);
-  EXPECT_THROW(const_env[var_dummy_], runtime_error);
 }
 
 TEST_F(EnvironmentTest, PopulateRandomVariables) {

--- a/common/symbolic/expression/test/variable_test.cc
+++ b/common/symbolic/expression/test/variable_test.cc
@@ -59,6 +59,18 @@ TEST_F(VariableTest, DefaultConstructors) {
   const Variable v_zero(0);
   EXPECT_TRUE(v_default.is_dummy());
   EXPECT_TRUE(v_zero.is_dummy());
+
+  // We don't especially care exactly what the name is, just that its non-empty.
+  // For clarity, we'll check for an exact name here but it's OK for us to
+  // change the name as we develop; the API doesn't promise any particular name.
+  EXPECT_EQ(v_default.get_name(), "𝑥");
+  EXPECT_EQ(v_default.get_type(), Variable::Type::CONTINUOUS);
+  EXPECT_EQ(v_default.get_id(), 0);
+
+  const Variable copy(v_default);
+  EXPECT_EQ(copy.get_name(), "𝑥");
+  EXPECT_EQ(copy.get_type(), Variable::Type::CONTINUOUS);
+  EXPECT_EQ(copy.get_id(), 0);
 }
 
 TEST_F(VariableTest, GetId) {
@@ -75,16 +87,36 @@ TEST_F(VariableTest, GetName) {
   EXPECT_EQ(x_.get_name(), x_prime.get_name());
 }
 
-TEST_F(VariableTest, MoveCopyPreserveId) {
+TEST_F(VariableTest, Copy) {
+  const Variable x{"x"};
+  const size_t x_id{x.get_id()};
+  const size_t x_hash{get_std_hash(x)};
+  const std::string x_name{x.get_name()};
+
+  // The copied object has the same value.
+  const Variable x_copied{x};
+  EXPECT_EQ(x_copied.get_id(), x_id);
+  EXPECT_EQ(get_std_hash(x_copied), x_hash);
+  EXPECT_EQ(x_copied.get_name(), x_name);
+}
+
+TEST_F(VariableTest, Move) {
   Variable x{"x"};
   const size_t x_id{x.get_id()};
   const size_t x_hash{get_std_hash(x)};
-  const Variable x_copied{x};
+  const std::string x_name{x.get_name()};
+
+  // The moved-to object has the same value.
   const Variable x_moved{std::move(x)};
-  EXPECT_EQ(x_id, x_copied.get_id());
-  EXPECT_EQ(x_hash, get_std_hash(x_copied));
-  EXPECT_EQ(x_id, x_moved.get_id());
-  EXPECT_EQ(x_hash, get_std_hash(x_moved));
+  EXPECT_EQ(x_moved.get_id(), x_id);
+  EXPECT_EQ(get_std_hash(x_moved), x_hash);
+  EXPECT_EQ(x_moved.get_name(), x_name);
+
+  // The moved-from object matches a default-constructed Variable.
+  const Variable expected;
+  EXPECT_EQ(x.get_id(), expected.get_id());
+  EXPECT_EQ(get_std_hash(x), get_std_hash(expected));
+  EXPECT_EQ(x.get_name(), expected.get_name());
 }
 
 TEST_F(VariableTest, Less) {

--- a/common/symbolic/expression/variable.cc
+++ b/common/symbolic/expression/variable.cc
@@ -44,9 +44,11 @@ Variable::Variable(string name, const Type type)
       name_{make_shared<const string>(std::move(name))} {
   DRAKE_ASSERT(id_ > 0);
 }
+
 string Variable::get_name() const {
-  return *name_;
+  return name_ != nullptr ? *name_ : string{"𝑥"};
 }
+
 string Variable::to_string() const {
   ostringstream oss;
   oss << *this;

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -167,10 +167,6 @@ void MathematicalProgram::AddDecisionVariables(
   for (int i = 0; i < decision_variables.rows(); ++i) {
     for (int j = 0; j < decision_variables.cols(); ++j) {
       const auto& var = decision_variables(i, j);
-      if (var.is_dummy()) {
-        throw std::runtime_error(fmt::format(
-            "decision_variables({}, {}) should not be a dummy variable", i, j));
-      }
       if (decision_variable_index_.find(var.get_id()) !=
           decision_variable_index_.end()) {
         continue;
@@ -400,10 +396,6 @@ MatrixXIndeterminate MathematicalProgram::NewIndeterminates(
 
 int MathematicalProgram::AddIndeterminate(
     const symbolic::Variable& new_indeterminate) {
-  if (new_indeterminate.is_dummy()) {
-    throw std::runtime_error(
-        fmt::format("{} should not be a dummy variable.", new_indeterminate));
-  }
   if (decision_variable_index_.find(new_indeterminate.get_id()) !=
       decision_variable_index_.end()) {
     throw std::runtime_error(

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -436,7 +436,6 @@ class MathematicalProgram {
    * @param decision_variables The newly added decision_variables.
    * @pre `decision_variables` should not intersect with the existing
    * indeterminates in the optimization program.
-   * @pre Each entry in `decision_variables` should not be a dummy variable.
    * @throws std::exception if the preconditions are not satisfied.
    */
   void AddDecisionVariables(
@@ -837,7 +836,6 @@ class MathematicalProgram {
    * new_indeterminate.
    * @pre `new_indeterminate` should not intersect with the program's
    * decision variables.
-   * @pre new_indeterminate should not be dummy.
    * @pre new_indeterminate should be of CONTINUOUS type.
    */
   int AddIndeterminate(const symbolic::Variable& new_indeterminate);
@@ -849,7 +847,6 @@ class MathematicalProgram {
    * program's old indeterminates.
    * @pre `new_indeterminates` should not intersect with the program's old
    * decision variables.
-   * @pre Each entry in new_indeterminates should not be dummy.
    * @pre Each entry in new_indeterminates should be of CONTINUOUS type.
    */
   void AddIndeterminates(
@@ -862,7 +859,6 @@ class MathematicalProgram {
    * program's old indeterminates.
    * @pre `new_indeterminates` should not intersect with the program's old
    * decision variables.
-   * @pre Each entry in new_indeterminates should not be dummy.
    * @pre Each entry in new_indeterminates should be of CONTINUOUS type.
    */
   void AddIndeterminates(
@@ -2610,7 +2606,7 @@ class MathematicalProgram {
    * dominant.
    * @return M For i < j M[i][j] contains the slack variables, mentioned in
    * @ref addsdd "scaled diagonally dominant matrix constraint". For i >= j,
-   * M[i][j] contains dummy variables.
+   * M[i][j] contains default-constructed variables (with get_id() == 0).
    *
    * @pydrake_mkdoc_identifier{variable}
    */

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -446,19 +446,10 @@ GTEST_TEST(TestAddDecisionVariables, AddVariable3) {
 GTEST_TEST(TestAddDecisionVariables, AddVariableError) {
   // Test the error inputs.
   MathematicalProgram prog;
-  auto y = prog.NewContinuousVariables<3>("y");
-  const Variable x0("x0", Variable::Type::CONTINUOUS);
-  const Variable x1("x1", Variable::Type::CONTINUOUS);
-  // The newly added variables contain a dummy variable.
-  Variable dummy;
-  EXPECT_TRUE(dummy.is_dummy());
-  EXPECT_THROW(
-      prog.AddDecisionVariables(VectorDecisionVariable<3>(x0, x1, dummy)),
-      std::runtime_error);
   auto z = prog.NewIndeterminates<2>("z");
   // Call AddDecisionVariables on a program that has some indeterminates, and
-  // the new
-  // variables intersects with the indeterminates.
+  // the new variables intersects with the indeterminates.
+  const Variable x0("x0", Variable::Type::CONTINUOUS);
   EXPECT_THROW(prog.AddDecisionVariables(VectorDecisionVariable<2>(x0, z(0))),
                std::runtime_error);
 
@@ -601,10 +592,6 @@ GTEST_TEST(TestAddIndeterminate, AddIndeterminateError) {
   // Call AddIndeterminate with an input of type BINARY.
   DRAKE_EXPECT_THROWS_MESSAGE(prog.AddIndeterminate(z),
                               ".*should be of type CONTINUOUS.*");
-  // Call AddIndeterminate with a dummy variable.
-  Variable dummy;
-  DRAKE_EXPECT_THROWS_MESSAGE(prog.AddIndeterminate(dummy),
-                              ".*should not be a dummy variable.*");
 }
 
 GTEST_TEST(TestAddIndeterminates, AddIndeterminatesVec1) {
@@ -683,11 +670,6 @@ GTEST_TEST(TestAddIndeterminates, AddIndeterminatesVecError) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       prog.AddIndeterminates(VectorIndeterminate<2>(x1, x0)),
       ".*should be of type CONTINUOUS.*");
-  // Call AddIndeterminates with a dummy variable.
-  Variable dummy;
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      prog.AddIndeterminates(VectorIndeterminate<2>(dummy, x0)),
-      ".*should not be a dummy variable.*");
 }
 
 GTEST_TEST(TestAddIndeterminates, AddIndeterminatesVars1) {
@@ -774,11 +756,6 @@ GTEST_TEST(TestAddIndeterminates, AddIndeterminatesVarsError) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       prog.AddIndeterminates(symbolic::Variables({x0, x1})),
       ".*should be of type CONTINUOUS.*");
-  // Call AddIndeterminates with a dummy variable.
-  Variable dummy;
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      prog.AddIndeterminates(symbolic::Variables({x0, dummy})),
-      ".*should not be a dummy variable.*");
 }
 
 GTEST_TEST(TestAddIndeterminates, MatrixInput) {


### PR DESCRIPTION
Remove various restriction on using the default Variable in an Expression, Environment, Formula, etc.

This will be useful for univariate monomials and polynomials, where the variable name doesn't matter but shouldn't be empty.

This is also probably a tiny speed-up to not hit the heap during the default constructor (to allocate an empty reference-counted string).

Towards #7576 and #20159.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20164)
<!-- Reviewable:end -->
