### PR TITLE
[controllers] Add InverseDynamicsController deprecation annotation

### DIFF
--- a/systems/controllers/inverse_dynamics_controller.cc
+++ b/systems/controllers/inverse_dynamics_controller.cc
@@ -121,10 +121,21 @@ joints modeled with quaternions.)""", num_positions, num_velocities));
 
   // The output port name 'force' is deprecated and will be removed from Drake
   // on or after 2024-01-01. Use the name 'generalized_force' instead.
-  builder.ExportOutput(inverse_dynamics->get_output_port_generalized_force(),
-                       "force");
+  const OutputPortIndex deprecated_index = builder.ExportOutput(
+      inverse_dynamics->get_output_port_generalized_force(), "force");
 
+  // Finalize ourself.
   builder.BuildInto(this);
+
+  // Now we can label the deprecated port as such. (There is no DiagramBuilder
+  // API available to do it earlier.)
+  const OutputPort<T>& deprecated_output =
+      this->get_output_port(deprecated_index);
+  const_cast<OutputPort<T>&>(deprecated_output)
+      .set_deprecation(
+          "The output port name 'force' is deprecated and will be removed from "
+          "Drake on or after 2024-01-01. Use the name 'generalized_force' "
+          "instead.");
 }
 
 template <typename T>

--- a/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -28,6 +28,8 @@ class InverseDynamicsControllerTest : public ::testing::Test {
   void ConfigTestAndCheck(InverseDynamicsController<double>* test_sys,
                           const VectorX<double>& kp, const VectorX<double>& ki,
                           const VectorX<double>& kd) {
+    EXPECT_EQ(test_sys->get_output_port().get_index(), 0);
+
     auto inverse_dynamics_context = test_sys->CreateDefaultContext();
     auto output = test_sys->AllocateOutput();
     const MultibodyPlant<double>& robot_plant =


### PR DESCRIPTION
Amends #20079 so that `get_output_port()` still works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20167)
<!-- Reviewable:end -->
