### PR TITLE
Remove vtkAssembly from RenderEngineVtk

### DIFF
--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.h
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.h
@@ -106,17 +106,11 @@ class DRAKE_NO_EXPORT RenderEngineGltfClient
    Returns true if added, false if ignored (for whatever reason).
 
    Note: Even though RenderEngineVtk supports consuming and rendering glTF
-   files, GltfClient handles glTF files in its own way for the following
-   reasons:
-
-      1. vtkGLTFExporter doesn't handle assemblies correctly yet. So, the
-         vtkAssembly at the root of each loaded glTF file *renders* correctly
-         but won't export correctly. See:
-         https://discourse.vtk.org/t/bug-in-vtkgltfexporter/12052.
-      2. vtkGLTFExporter has limited support for glTF extensions. Useful, common
-         extensions. So, by injecting the files directly into the exported
-         glTF file, we maintain whatever declarations the source glTF had
-         without the lossy filter implied by VTK. */
+   files, GltfClient handles glTF files in its own way because vtkGLTFImporter
+   and vtkGLTFExporter have limited support for glTF extensions -- useful,
+   common extensions. So, by injecting the files directly into the exported glTF
+   file, we maintain whatever declarations the source glTF had without the lossy
+   filter provided by VTK. */
   bool ImplementGltf(const std::filesystem::path& gltf_path, double scale,
                      const RenderEngineVtk::RegistrationData& data);
 

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -8,7 +8,6 @@
 
 // To ease build system upkeep, we annotate VTK includes with their deps.
 #include <vtkActor.h>                    // vtkRenderingCore
-#include <vtkAssembly.h>                 // vtkRenderingCore
 #include <vtkCamera.h>                   // vtkRenderingCore
 #include <vtkCylinderSource.h>           // vtkFiltersSources
 #include <vtkGLTFImporter.h>             // vtkIOImport
@@ -31,6 +30,7 @@
 #include "drake/geometry/render/shaders/depth_shaders.h"
 #include "drake/geometry/render_vtk/internal_render_engine_vtk_base.h"
 #include "drake/geometry/render_vtk/internal_vtk_util.h"
+#include "drake/math/rotation_matrix.h"
 #include "drake/systems/sensors/color_palette.h"
 
 namespace drake {
@@ -46,6 +46,7 @@ using geometry::internal::LoadRenderMeshFromObj;
 using geometry::internal::RenderMaterial;
 using geometry::internal::RenderMesh;
 using math::RigidTransformd;
+using math::RotationMatrixd;
 using render::ColorRenderCamera;
 using render::DepthRenderCamera;
 using render::LightParameter;
@@ -208,7 +209,19 @@ void RenderEngineVtk::DoUpdateVisualPose(GeometryId id,
   // TODO(SeanCurtis-TRI): Perhaps provide the ability to specify which pipeline
   //  is being updated and only update the pose of the prop for that pipeline.
   for (const auto& prop : props_.at(id)) {
-    prop->SetUserTransform(vtk_X_WG);
+    for (const auto& part : prop.parts) {
+      if (part.T_GA != nullptr) {
+        // The goal is to update the actor's pose without allocating new
+        // transforms or matrices. Using part.actor->GetUserMatrix() as the
+        // result of the matrix product is unreliable. Instead, write to the
+        // matrix from the user transform.
+        vtkMatrix4x4* T_WA = part.actor->GetUserTransform()->GetMatrix();
+        vtkMatrix4x4::Multiply4x4(vtk_X_WG->GetMatrix(), part.T_GA, T_WA);
+        part.actor->Modified();
+      } else {
+        part.actor->SetUserTransform(vtk_X_WG);
+      }
+    }
   }
 }
 
@@ -218,8 +231,9 @@ bool RenderEngineVtk::DoRemoveGeometry(GeometryId id) {
   if (iter != props_.end()) {
     PropArray& pipe_props = iter->second;
     for (int i = 0; i < kNumPipelines; ++i) {
-      // Note: the misnamed `RemoveActor()` actually removes vtkProps.
-      pipelines_[i]->renderer->RemoveActor(pipe_props[i]);
+      for (const auto& part : pipe_props[i].parts) {
+        pipelines_[i]->renderer->RemoveActor(part.actor);
+      }
     }
     props_.erase(iter);
     return true;
@@ -307,31 +321,6 @@ void RenderEngineVtk::DoRenderLabelImage(const ColorRenderCamera& camera,
   }
 }
 
-namespace {
-
-// Clones an array of props into a new, equivalent array. The new array is a
-// *shallow* copy of the source. VTK requires us to know the most derived type
-// of the object we're cloning (because we have to copy *into* an existing
-// object of that type).
-template <typename VtkType, std::size_t N>
-std::array<vtkSmartPointer<vtkProp3D>, N> CloneProps(
-    const std::array<vtkSmartPointer<vtkProp3D>, N>& source_props) {
-  static_assert(std::is_base_of_v<vtkProp3D, VtkType>,
-                "Geometries should all be derived from vtkProp3D.");
-  std::array<vtkSmartPointer<vtkProp3D>, N> target_props;
-  for (std::size_t i = 0; i < N; ++i) {
-    // NOTE: source *should* be const; but none of the getters on the
-    // source are const-compatible.
-    DRAKE_DEMAND(source_props[i]);
-    vtkNew<VtkType> clone;
-    clone->ShallowCopy(source_props[i]);
-    target_props[i] = std::move(clone);
-  }
-  return target_props;
-}
-
-}  // namespace
-
 RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
     : RenderEngine(other),
       parameters_(other.parameters_),
@@ -344,15 +333,17 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
 
   for (const auto& [id, source_props] : other.props_) {
     PropArray target_props;
-    if (vtkActor::SafeDownCast(source_props[0]) != nullptr) {
-      target_props = CloneProps<vtkActor>(source_props);
-    } else if (vtkAssembly::SafeDownCast(source_props[0]) != nullptr) {
-      target_props = CloneProps<vtkAssembly>(source_props);
-    }
     for (int i = 0; i < kNumPipelines; ++i) {
-      // We should have copied *something*, either actors or assemblies.
-      DRAKE_DEMAND(target_props[i].Get() != nullptr);
-      pipelines_.at(i)->renderer.Get()->AddActor(target_props[i]);
+      auto& renderer = *pipelines_.at(i)->renderer;
+      const Prop& source_prop = source_props[i];
+      Prop& target_prop = target_props[i];
+      for (const auto& source_part : source_prop.parts) {
+        vtkNew<vtkActor> target_actor;
+        target_actor->ShallowCopy(source_part.actor);
+        renderer.AddActor(target_actor);
+        target_prop.parts.push_back(
+            Part{.actor = std::move(target_actor), .T_GA = source_part.T_GA});
+      }
     }
     props_.insert({id, std::move(target_props)});
   }
@@ -412,42 +403,6 @@ bool RenderEngineVtk::ImplementObj(const std::string& file_name, double scale,
   return true;
 }
 
-namespace {
-
-/* It has been shown that when we import glTF files and place the resultant
- vtkActors under a vtkAssembly, that the glTF's texture images get inverted
- vertically. See
- https://discourse.vtk.org/t/vtkgltfimporter-loads-textures-upside-down/12113
- This is a simple hack that allows us to keep the vtkAssembly.
- This function simply iterates through an actor's glTF textures and flips
- them in the y direction.
-
- Once vtkAssembly is better behaved, this can be removed. When we remove it,
- we can also remove the test GltfTextureOrientation in
- internal_render_engine_vtk_test.cc */
-void FlipGltfTextures(vtkActor* actor) {
-  // Set up a small, reusable graph for flipping a texture's image data.
-  vtkNew<vtkImageFlip> flip_y;
-  flip_y->SetFilteredAxis(1);
-  flip_y->SetOutputDimensionality(2);
-  vtkNew<vtkImageData> image_data;
-  flip_y->SetInputData(image_data);
-
-  vtkProperty* property = actor->GetProperty();
-  // The four "special textures with reserved names" (vtkProperty.h) that get
-  // used during glTF parsing.
-  for (const char* tex_name :
-       {"albedoTex", "materialTex", "emissiveTex", "normalTex"}) {
-    if (vtkTexture* texture = property->GetTexture(tex_name)) {
-      image_data->ShallowCopy(texture->GetImageDataInput(0));
-      flip_y->SetOutput(texture->GetImageDataInput(0));
-      flip_y->Update();
-    }
-  }
-}
-
-}  // namespace
-
 bool RenderEngineVtk::ImplementGltf(const std::string& file_name, double scale,
                                     const RegistrationData& data) {
   vtkNew<vtkGLTFImporter> importer;
@@ -462,17 +417,16 @@ bool RenderEngineVtk::ImplementGltf(const std::string& file_name, double scale,
     return false;
   }
 
-  auto make_file_assembly = [scale]() {
-    vtkNew<vtkAssembly> file_assembly;
-    file_assembly->SetScale(scale);
-    file_assembly->RotateX(90);
-    return file_assembly;
-  };
-
-  // The final assemblies associated with the GeometryId.
-  PropArray props;
-
+  // The pose of the geometry in Drake's world. This is a component of the final
+  // UserMatrix value.
   vtkSmartPointer<vtkTransform> vtk_X_WG = ConvertToVtkTransform(data.X_WG);
+
+  // The relative transform from the file's frame F to the geometry's frame G.
+  // This includes the rotation from y-up to z-up and the requested scale.
+  const RigidTransformd X_GF(RotationMatrixd::MakeXRotation(M_PI / 2));
+  vtkSmartPointer<vtkTransform> T_GF_transform =
+      ConvertToVtkTransform(X_GF, scale);
+  vtkMatrix4x4* T_GF = T_GF_transform->GetMatrix();
 
   // Color.
   if (data.properties.HasProperty("phong", "diffuse") ||
@@ -487,60 +441,69 @@ bool RenderEngineVtk::ImplementGltf(const std::string& file_name, double scale,
   const RenderLabel label = GetRenderLabelOrThrow(data.properties);
   const ColorD label_color = RenderEngine::GetColorDFromLabel(label);
 
+  // The final assemblies associated with the GeometryId.
+  PropArray prop_array;
+
   for (int i = 0; i < kNumPipelines; ++i) {
-    // VTK imports a collection of visible parts. Whatever the glTF hierarchy
-    // was, VTK brings in actors that all have their poses defined w.r.t. the
-    // file's world frame.
+    // VTK imports a collection of visible parts (nee vtkActors), regardless
+    // what the glTF hierarchy was, The actor poses are all measured and
+    // expressed w.r.t. the file's frame F.
     //
-    // We'll place all these actors in a new assembly. We'll use this "file"
-    // assembly to account for scale, and the rotation necessary to re-express
-    // the y-up glTF world frame to Drake's z-up world frame. This will
-    // ultimately become the child of the geometry assembly which gets posed
-    // with the drake pose X_WG associated with the geometry id.
-    vtkNew<vtkAssembly> file_root_node(make_file_assembly());
+    // We'll store each actor from the glTF file in a single Part, storing the
+    // transform of the actor frame A to the *geometry* frame G (see below).
+    auto& prop = prop_array[i];
     auto* actors = renderer->GetActors();
     actors->InitTraversal();
     // For each source_actor, create a color, depth, and label actor.
     while (vtkActor* source_actor = actors->GetNextActor()) {
+      vtkSmartPointer<vtkActor> part_actor;
       if (i == ImageType::kColor) {
         // Color rendering can use the source_actor without changes.
-        FlipGltfTextures(source_actor);
-        file_root_node->AddPart(source_actor);
+        part_actor = source_actor;
       } else {
         // Depth and label images require new actors, based on the source, but
         // with changes to their materials (aka "mapper").
-        vtkNew<vtkActor> actor;
+        part_actor = vtkNew<vtkActor>();
         vtkNew<vtkOpenGLPolyDataMapper> mapper;
-        actor->SetMapper(mapper);
-        actor->SetUserTransform(source_actor->GetUserTransform());
+        part_actor->SetMapper(mapper);
         mapper->SetInputConnection(
             source_actor->GetMapper()->GetInputAlgorithm()->GetOutputPort());
         if (i == ImageType::kLabel) {
           // Label requires a mapper with the encoded RenderLabel color.
-          actor->GetProperty()->LightingOff();
-          actor->GetProperty()->SetColor(label_color.r, label_color.g,
-                                         label_color.b);
+          part_actor->GetProperty()->LightingOff();
+          part_actor->GetProperty()->SetColor(label_color.r, label_color.g,
+                                              label_color.b);
         } else if (i == ImageType::kDepth) {
           // Depth requires a mapper with the depth shader.
           vtkOpenGLShaderProperty* shader_prop =
-              vtkOpenGLShaderProperty::SafeDownCast(actor->GetShaderProperty());
+              vtkOpenGLShaderProperty::SafeDownCast(
+                  part_actor->GetShaderProperty());
           DRAKE_DEMAND(shader_prop != nullptr);
           shader_prop->SetVertexShaderCode(render::shaders::kDepthVS);
           shader_prop->SetFragmentShaderCode(render::shaders::kDepthFS);
           mapper->AddObserver(vtkCommand::UpdateShaderEvent,
                               uniform_setting_callback_.Get());
         }
-        file_root_node->AddPart(actor);
       }
+      // vtkGLTFImporter uses the actor's UserTransform property to define the
+      // actor's transform in the file frame (T_FA). We also have to use the
+      // UserTransform to pose the geometry in Drake's world (T_WG). So, we will
+      // interpret UserTransform as T_WA = X_WG * T_GA = X_WG * T_GF * T_FA.
+      // We save T_GA with the actor in the part so we can keep computing T_WA
+      // as X_WG changes.
+      vtkNew<vtkMatrix4x4> T_GA;
+      vtkMatrix4x4* T_FA = source_actor->GetUserMatrix();
+      vtkMatrix4x4::Multiply4x4(T_GF, T_FA, T_GA);
+      vtkNew<vtkMatrix4x4> T_WA;
+      vtkMatrix4x4::Multiply4x4(vtk_X_WG->GetMatrix(), T_GA, T_WA);
+      part_actor->SetUserMatrix(T_WA);
+      pipelines_.at(i)->renderer->AddActor(part_actor);
+      prop.parts.push_back(
+          {.actor = std::move(part_actor), .T_GA = std::move(T_GA)});
     }
-    vtkNew<vtkAssembly> geometry_root;
-    geometry_root->AddPart(file_root_node.Get());
-    geometry_root->SetUserTransform(vtk_X_WG);
-    pipelines_.at(i)->renderer.Get()->AddActor(geometry_root);
-    props[i] = std::move(geometry_root);
   }
 
-  props_.insert({data.id, std::move(props)});
+  props_.insert({data.id, std::move(prop_array)});
 
   // We've successfully processed the .gltf. Report it as accepted.
   return true;
@@ -691,11 +654,11 @@ void RenderEngineVtk::ImplementPolyData(vtkPolyDataAlgorithm* source,
   PropArray props;
   auto connect_actor = [this, &actors, &mappers, &props,
                         &vtk_X_WG](ImageType image_type) {
-    vtkActor* actor = actors[image_type].Get();
+    vtkSmartPointer<vtkActor>& actor = actors[image_type];
     actor->SetMapper(mappers[image_type].Get());
     actor->SetUserTransform(vtk_X_WG);
     pipelines_[image_type]->renderer->AddActor(actor);
-    props[image_type] = actor;
+    props[image_type].parts.push_back({.actor = actor, .T_GA = nullptr});
   };
 
   // Label actor.

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -7,13 +7,13 @@
 #include <vector>
 
 // To ease build system upkeep, we annotate VTK includes with their deps.
+#include <vtkActor.h>                // vtkRenderingCore
 #include <vtkAutoInit.h>             // vtkCommonCore
 #include <vtkCommand.h>              // vtkCommonCore
 #include <vtkImageExport.h>          // vtkIOImage
 #include <vtkLight.h>                // vtkRenderingCore
 #include <vtkNew.h>                  // vtkCommonCore
 #include <vtkPolyDataAlgorithm.h>    // vtkCommonExecutionModel
-#include <vtkProp3D.h>               // vtkRenderingCore
 #include <vtkRenderWindow.h>         // vtkRenderingCore
 #include <vtkRenderer.h>             // vtkRenderingCore
 #include <vtkShaderProgram.h>        // vtkRenderingOpenGL2
@@ -135,15 +135,6 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
   //@}
 
  protected:
-  /* Returns all props registered with the engine, keyed by the SceneGraph
-   GeometryId. Each GeometryId maps to a triple of props: color, depth, and
-   label. The prop will either be a `vtkActor` or `vtkAssembly`. */
-  const std::unordered_map<GeometryId,
-                           std::array<vtkSmartPointer<vtkProp3D>, 3>>&
-  props() const {
-    return props_;
-  }
-
   /* Copy constructor for the purpose of cloning. */
   RenderEngineVtk(const RenderEngineVtk& other);
 
@@ -232,6 +223,8 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
                      const RegistrationData& data);
 
  private:
+  friend class RenderEngineVtkTester;
+
   // Initializes the VTK pipelines.
   void InitializePipelines();
 
@@ -241,6 +234,37 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
                          const RegistrationData& data);
 
   void SetDefaultLightPosition(const Vector3<double>& p_DL) override;
+
+  // A geometry is modeled with one or more "parts". A part maps to the actor
+  // representing it in VTK and an optional transform mapping the actor's frame
+  // A to the Drake geometry frame G. This mapping can include scaling terms.
+  // If T_GA = I, then `T_GA` is set to nullptr. Otherwise, posing the actor
+  // using geometry's world pose X_WG should set the transform to
+  // T_WA = X_WG * T_GA.
+  struct Part {
+    vtkSmartPointer<vtkActor> actor;
+    vtkSmartPointer<vtkMatrix4x4> T_GA;
+  };
+
+  // Some geometries are represented by multiple parts (such as when importing
+  // a complex glTF file). A "prop" is the collection of parts which constitute
+  // one visual geometry associated with a GeometryId.
+  //
+  // For simple Drake primitives, there will be a single "part".
+  //
+  // Note: this is conceptually similar to vtkAssembly. But do *not* use
+  // vtkAssembly. It is incredibly buggy and causes rendering problems. See:
+  // https://discourse.vtk.org/t/vtkgltfimporter-loads-textures-upside-down/12113
+  // https://discourse.vtk.org/t/bug-in-vtkgltfexporter/12052
+  struct Prop {
+    std::vector<Part> parts;
+  };
+
+  // Three pipelines: rgb, depth, and label.
+  static constexpr int kNumPipelines = 3;
+
+  // Each geometry is represented by one "prop" per pipeline.
+  using PropArray = std::array<Prop, kNumPipelines>;
 
   // Handles the logic for using the lights defined in the construction
   // parameters vs the built-in fallback light. The implementation should only
@@ -253,9 +277,6 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
     DRAKE_DEMAND(!fallback_lights_.empty());
     return fallback_lights_;
   }
-
-  // Three pipelines: rgb, depth, and label.
-  static constexpr int kNumPipelines = 3;
 
   // The engine's configuration parameters.
   const RenderEngineVtkParams parameters_;
@@ -284,23 +305,9 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
   // The color to clear the color buffer to.
   systems::sensors::ColorD default_clear_color_;
 
-  // TODO(SeanCurtis-TRI): when vtkGLTFExporter handles vtkAssembly correctly,
-  // then we can just make everything an assembly and not have to worry about
-  // heterogeneity and the base class of vtkProp3D.
-
-  // Each geometry is represented by one "3D property" per pipeline. That
-  // property (or "prop") can be either an actor or an assembly. But it will be
-  // the same type in all entries of the array.
-  using PropArray = std::array<vtkSmartPointer<vtkProp3D>, kNumPipelines>;
-
   // The collection of per-geometry actors -- one actor per pipeline (color,
   // depth, and label) -- keyed by the geometry's GeometryId.
   std::unordered_map<GeometryId, PropArray> props_;
-
-  // The collection of per-geometry actors (one actor per pipeline (color,
-  // depth, and label) keyed by the geometry's GeometryId.
-  std::unordered_map<GeometryId, std::array<vtkSmartPointer<vtkActor>, 3>>
-      actors_;
 
   // Lights can be defined in the engine parameters. If no lights are defined,
   // we use the fallback_lights. Otherwise, we use the parameter lights.

--- a/geometry/render_vtk/internal_vtk_util.cc
+++ b/geometry/render_vtk/internal_vtk_util.cc
@@ -29,12 +29,12 @@ vtkSmartPointer<vtkPlaneSource> CreateSquarePlane(double size) {
 }
 
 vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
-    const math::RigidTransformd& transform) {
+    const math::RigidTransformd& transform, double scale) {
   vtkNew<vtkMatrix4x4> vtk_mat;
   for (int i = 0; i < 3; ++i) {
     const auto& row = transform.rotation().row(i);
     for (int j = 0; j < 3; ++j) {
-      vtk_mat->SetElement(i, j, row(j));
+      vtk_mat->SetElement(i, j, row(j) * scale);
     }
     vtk_mat->SetElement(i, 3, transform.translation()(i));
   }

--- a/geometry/render_vtk/internal_vtk_util.h
+++ b/geometry/render_vtk/internal_vtk_util.h
@@ -33,9 +33,14 @@ using vtkPointerArray = std::array<vtkSmartPointer<T>, N>;
 // @param size The size of the plane.
 vtkSmartPointer<vtkPlaneSource> CreateSquarePlane(double size);
 
-// Converts the provided `transform` to a vtkTransform.
+// Converts the provided `transform` to a vtkTransform. The rigid transform is
+// the concatenation of a translation operation T and rotation operation R
+// (X = T * R). We turn it into a general transform by also concatenating a
+// scale matrix: T * R * S, where where S is I * `scale` (i.e., a diagonal
+// matrix with `scale` on the diagonal). This is the standard transform matrix
+// for graphics.
 vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
-    const math::RigidTransformd& transform);
+    const math::RigidTransformd& transform, double scale = 1.0);
 
 // Makes vtkPointerArray from one or multiple pointer(s) for VTK objects
 // wrapped by vtkNew.

--- a/geometry/render_vtk/test/internal_vtk_util_test.cc
+++ b/geometry/render_vtk/test/internal_vtk_util_test.cc
@@ -19,7 +19,7 @@ namespace internal {
 namespace {
 
 const double kTolerance = 1e-15;
-const double kSize = 10.;
+const double kSize = 10.0;
 const double kHalfSize = kSize * 0.5;
 const int kNumPoints = 4;
 
@@ -31,10 +31,10 @@ struct Point {
 
 // clang-format off
 const Point kExpectedPointSet[kNumPoints] = {
-  Point{ kHalfSize, -kHalfSize, 0.},
-  Point{ kHalfSize,  kHalfSize, 0.},
-  Point{-kHalfSize, -kHalfSize, 0.},
-  Point{-kHalfSize,  kHalfSize, 0.}
+  Point{ kHalfSize, -kHalfSize, 0.0},
+  Point{ kHalfSize,  kHalfSize, 0.0},
+  Point{-kHalfSize, -kHalfSize, 0.0},
+  Point{-kHalfSize,  kHalfSize, 0.0}
 };
 // clang-format on
 
@@ -54,18 +54,28 @@ GTEST_TEST(PointsCorrespondenceTest, PlaneCreationTest) {
 
 // Verifies whether the conversion is correct.
 GTEST_TEST(ConvertToVtkTransformTest, ConversionTest) {
-  const math::RigidTransformd expected(
-      Eigen::AngleAxisd(1.,
-                        Eigen::Vector3d(1. / std::sqrt(3.), 1. / std::sqrt(3.),
-                                        1. / std::sqrt(3.))),
-      Eigen::Vector3d(1., 2., 3.));
+  const math::RigidTransformd X_AB(
+      Eigen::AngleAxisd(1.0, Eigen::Vector3d::Constant(1.0 / std::sqrt(3.0))),
+      Eigen::Vector3d(1.0, 2.0, 3.0));
 
-  auto dut = ConvertToVtkTransform(expected);
+  auto dut_X_AB = ConvertToVtkTransform(X_AB);
 
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
-      EXPECT_NEAR(expected.GetAsMatrix4()(i, j),
-                  dut->GetMatrix()->GetElement(i, j), kTolerance);
+      EXPECT_NEAR(X_AB.GetAsMatrix4()(i, j),
+                  dut_X_AB->GetMatrix()->GetElement(i, j), kTolerance);
+    }
+  }
+
+  const double scale = 1.5;
+  auto dut_T_AB = ConvertToVtkTransform(X_AB, scale);
+  Eigen::Matrix4d T_AB_expected = X_AB.GetAsMatrix4();
+  T_AB_expected.block<3, 3>(0, 0) *= scale;
+
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_NEAR(T_AB_expected(i, j), dut_T_AB->GetMatrix()->GetElement(i, j),
+                  kTolerance);
     }
   }
 }


### PR DESCRIPTION
vtkAssembly is a poorly supported class in VTK. It has already been shown to be ignored when exporting to glTF. It has also been shown to cause textures from glTF files to render upside down. Therefore, it causes more troubles than it solves.

RenderEngineVtk now provides its own assembly-like struct: a "prop", comprised of one or more "parts".

The glTF import, pose update, and cloning has been updated to reflect the change from assembly to "prop" and all references to the old assemblies have been removed (except for "here-be-dragons" warnings).

Furthermore, we evolve the internal VTK utilities to produce a VTK-compatible *general* transform instead of just a rigid transform.

The existing tests should serve as sufficient proof against regression.

(Incidental clean up in `internal_vtk_util_test.cc` where doubles of the form 1. have been upgraded to 1.0.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20169)
<!-- Reviewable:end -->
