### PR TITLE
[py optimization] Add missing repr and docs for polytope options

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -6,6 +6,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/identifier_pybind.h"
+#include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/sorted_pair_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -872,10 +873,16 @@ void DefineGeometryOptimization(py::module m) {
             base_cls_doc.separating_planes.doc)
         .def("y_slack", &BaseClass::y_slack, base_cls_doc.y_slack.doc);
 
-    py::class_<BaseClass::Options>(
-        cspace_free_polytope_base_cls, "Options", base_cls_doc.Options.doc)
-        .def(py::init<>())
-        .def_readwrite("with_cross_y", &BaseClass::Options::with_cross_y);
+    {
+      const auto& options_cls_doc = base_cls_doc.Options;
+      py::class_<BaseClass::Options> options_cls(
+          cspace_free_polytope_base_cls, "Options", options_cls_doc.doc);
+      options_cls  // BR
+          .def(py::init<>(), options_cls_doc.ctor.doc)
+          .def_readwrite("with_cross_y", &BaseClass::Options::with_cross_y,
+              options_cls_doc.with_cross_y.doc);
+      DefReprUsingSerialize(&options_cls);
+    }
 
     using Class = CspaceFreePolytope;
     const auto& cls_doc = doc.CspaceFreePolytope;

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -949,6 +949,8 @@ class TestCspaceFreePolytope(unittest.TestCase):
         self.assertFalse(options.with_cross_y)
         options.with_cross_y = True
         self.assertTrue(options.with_cross_y)
+        self.assertIn("with_cross_y", repr(options))
+        self.assertNotIn("object at 0x", repr(options))
 
     def test_CspaceFreePolytope_getters_and_auxillary_structs(self):
         dut = self.cspace_free_polytope

--- a/geometry/optimization/cspace_free_polytope_base.h
+++ b/geometry/optimization/cspace_free_polytope_base.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/name_value.h"
 #include "drake/geometry/optimization/c_iris_collision_geometry.h"
 #include "drake/geometry/optimization/cspace_free_structs.h"
 #include "drake/geometry/optimization/cspace_separating_plane.h"
@@ -38,6 +39,13 @@ class CspaceFreePolytopeBase {
   /** Optional argument for constructing CspaceFreePolytopeBase */
   struct Options {
     Options() {}
+
+    /** Passes this object to an Archive.
+     Refer to @ref yaml_serialization "YAML Serialization" for background. */
+    template <typename Archive>
+    void Serialize(Archive* a) {
+      a->Visit(DRAKE_NVP(with_cross_y));
+    }
 
     /**
      For non-polytopic collision geometries, we will impose a matrix-sos


### PR DESCRIPTION
The lack of a `repr()` leads to [hex spam](https://drake.mit.edu/pydrake/pydrake.geometry.optimization.html#pydrake.geometry.optimization.CspaceFreePolytope) in the website API reference.

Amends #19574.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20181)
<!-- Reviewable:end -->
