### PR TITLE
[kuka_iiwa] Factor non-LCM iiwa driver into a separate Diagram

### DIFF
--- a/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
+++ b/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
@@ -120,13 +120,13 @@ class TestKukaIiwa(unittest.TestCase):
             controller_plant.GetFrameByName("iiwa_link_0"), RigidTransform())
         controller_plant.Finalize()
 
-        self.assertEqual(len(builder.GetSystems()), 1)
+        tare = len(builder.GetSystems())
         mut.BuildIiwaControl(
             plant=plant, iiwa_instance=plant.GetModelInstanceByName("iiwa7"),
             controller_plant=controller_plant, lcm=DrakeLcm(), builder=builder,
             ext_joint_filter_tau=0.12, desired_iiwa_kp_gains=np.arange(7),
             control_mode=mut.IiwaControlMode.kPositionAndTorque)
-        self.assertEqual(len(builder.GetSystems()), 12)
+        self.assertGreater(len(builder.GetSystems()), tare)
 
     def test_kuka_iiwa_driver(self):
         dut = mut.IiwaDriver()
@@ -148,9 +148,9 @@ class TestKukaIiwa(unittest.TestCase):
         lcm_bus = LcmBuses()
         lcm_bus.Add("test", DrakeLcm())
 
-        self.assertEqual(len(builder.GetSystems()), 1)
+        tare = len(builder.GetSystems())
         mut.ApplyDriverConfig(
             driver_config=dut, model_instance_name="iiwa7",
             sim_plant=plant, models_from_directives=model_dict, lcms=lcm_bus,
             builder=builder)
-        self.assertEqual(len(builder.GetSystems()), 13)
+        self.assertGreater(len(builder.GetSystems()), tare)

--- a/manipulation/kuka_iiwa/BUILD.bazel
+++ b/manipulation/kuka_iiwa/BUILD.bazel
@@ -22,6 +22,7 @@ drake_cc_package_library(
         ":iiwa_driver_functions",
         ":iiwa_status_receiver",
         ":iiwa_status_sender",
+        ":sim_iiwa_driver",
     ],
 )
 
@@ -114,6 +115,23 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "sim_iiwa_driver",
+    srcs = ["sim_iiwa_driver.cc"],
+    hdrs = ["sim_iiwa_driver.h"],
+    deps = [
+        ":iiwa_constants",
+        "//common:essential",
+        "//multibody/plant",
+        "//systems/controllers:inverse_dynamics_controller",
+        "//systems/framework:diagram_builder",
+        "//systems/primitives:adder",
+        "//systems/primitives:demultiplexer",
+        "//systems/primitives:discrete_derivative",
+        "//systems/primitives:first_order_low_pass_filter",
+    ],
+)
+
+drake_cc_library(
     name = "build_iiwa_control",
     srcs = ["build_iiwa_control.cc"],
     hdrs = ["build_iiwa_control.h"],
@@ -121,14 +139,11 @@ drake_cc_library(
         ":iiwa_command_receiver",
         ":iiwa_constants",
         ":iiwa_status_sender",
+        ":sim_iiwa_driver",
         "//multibody/plant",
-        "//systems/controllers:inverse_dynamics_controller",
         "//systems/framework:diagram_builder",
         "//systems/lcm",
-        "//systems/primitives:adder",
         "//systems/primitives:demultiplexer",
-        "//systems/primitives:discrete_derivative",
-        "//systems/primitives:first_order_low_pass_filter",
         "//systems/primitives:gain",
         "@eigen",
     ],
@@ -215,6 +230,20 @@ drake_cc_googletest(
         "//systems/analysis:simulator",
         "//systems/framework:diagram_builder",
         "//systems/lcm:lcm_config_functions",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sim_iiwa_driver_test",
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":iiwa_constants",
+        ":sim_iiwa_driver",
+        "//multibody/parsing",
+        "//multibody/plant",
+        "//systems/framework/test_utilities:scalar_conversion",
     ],
 )
 

--- a/manipulation/kuka_iiwa/build_iiwa_control.cc
+++ b/manipulation/kuka_iiwa/build_iiwa_control.cc
@@ -1,245 +1,154 @@
 #include "drake/manipulation/kuka_iiwa/build_iiwa_control.h"
 
-#include <limits>
-
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/manipulation/kuka_iiwa/iiwa_command_receiver.h"
-#include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
 #include "drake/manipulation/kuka_iiwa/iiwa_status_sender.h"
-#include "drake/systems/controllers/inverse_dynamics_controller.h"
+#include "drake/manipulation/kuka_iiwa/sim_iiwa_driver.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
-#include "drake/systems/primitives/adder.h"
 #include "drake/systems/primitives/demultiplexer.h"
-#include "drake/systems/primitives/discrete_derivative.h"
-#include "drake/systems/primitives/first_order_low_pass_filter.h"
 #include "drake/systems/primitives/gain.h"
-#include "drake/systems/primitives/pass_through.h"
 
 namespace drake {
 namespace manipulation {
 namespace kuka_iiwa {
 
 using drake::lcm::DrakeLcmInterface;
-using manipulation::kuka_iiwa::IiwaCommandReceiver;
-using manipulation::kuka_iiwa::IiwaStatusSender;
-using manipulation::kuka_iiwa::kIiwaLcmStatusPeriod;
+using kuka_iiwa::internal::SimIiwaDriver;
 using multibody::ModelInstanceIndex;
 using multibody::MultibodyPlant;
-using systems::Adder;
-using systems::Context;
 using systems::Demultiplexer;
+using systems::DiagramBuilder;
 using systems::Gain;
-using systems::PassThrough;
-using systems::StateInterpolatorWithDiscreteDerivative;
-using systems::System;
-using systems::controllers::InverseDynamics;
-using systems::controllers::InverseDynamicsController;
 using systems::lcm::LcmPublisherSystem;
 using systems::lcm::LcmSubscriberSystem;
 
-using InverseDynamicsMode = InverseDynamics<double>::InverseDynamicsMode;
-
 void BuildIiwaControl(const MultibodyPlant<double>& plant,
-                      const multibody::ModelInstanceIndex iiwa_instance,
+                      const ModelInstanceIndex iiwa_instance,
                       const MultibodyPlant<double>& controller_plant,
-                      DrakeLcmInterface* lcm,
-                      systems::DiagramBuilder<double>* builder,
+                      DrakeLcmInterface* lcm, DiagramBuilder<double>* builder,
                       double ext_joint_filter_tau,
                       const std::optional<Eigen::VectorXd>& desired_kp_gains,
                       IiwaControlMode control_mode) {
-  const IiwaControlPorts iiwa_control_ports = BuildSimplifiedIiwaControl(
+  const IiwaControlPorts sim_ports = BuildSimplifiedIiwaControl(
       plant, iiwa_instance, controller_plant, builder, ext_joint_filter_tau,
       desired_kp_gains, control_mode);
 
   const int num_iiwa_positions = controller_plant.num_positions();
+  const std::string model_name = plant.GetModelInstanceName(iiwa_instance);
 
-  // Create the Iiwa command subscriber to receive desired state commands.
-  auto iiwa_command_sub = builder->AddSystem(
+  // Create the Iiwa command receiver.
+  auto command_sub = builder->AddNamedSystem(
+      fmt::format("{}_iiwa_command_subscriber", model_name),
       LcmSubscriberSystem::Make<lcmt_iiwa_command>("IIWA_COMMAND", lcm));
-  iiwa_command_sub->set_name(plant.GetModelInstanceName(iiwa_instance) +
-                             "_iiwa_command_subscriber");
-  auto iiwa_command_receiver =
-      builder->AddSystem<IiwaCommandReceiver>(num_iiwa_positions, control_mode);
-  builder->Connect(iiwa_command_sub->get_output_port(),
-                   iiwa_command_receiver->get_message_input_port());
+  auto command_decode = builder->AddNamedSystem<IiwaCommandReceiver>(
+      fmt::format("{}_iiwa_command_receiver", model_name), num_iiwa_positions,
+      control_mode);
+  builder->Connect(command_sub->get_output_port(),
+                   command_decode->get_message_input_port());
 
-  const bool has_position = position_enabled(control_mode);
-  const bool has_torque = torque_enabled(control_mode);
-
-  // Connect desired positions.
-  if (has_position) {
-    builder->Connect(
-        iiwa_command_receiver->get_commanded_position_output_port(),
-        *iiwa_control_ports.commanded_positions);
-  }
-
-  // Connect desired torque.
-  if (has_torque) {
-    builder->Connect(iiwa_command_receiver->get_commanded_torque_output_port(),
-                     *iiwa_control_ports.commanded_torque);
-  }
-
-  // Create an Iiwa state sender.
-  auto iiwa_state_measured_demux = builder->AddSystem<Demultiplexer>(
+  // Use the current position until the first command is received. Note that we
+  // connect the position directly from the plant, not the (possibly sampled or
+  // delayed) `sim_port.position_measured` output of the driver.
+  auto state_demux = builder->template AddNamedSystem<Demultiplexer>(
+      fmt::format("{}_iiwa_state_demultiplexer", model_name),
       2 * num_iiwa_positions, num_iiwa_positions);
-  auto iiwa_status_pub =
-      builder->AddSystem(LcmPublisherSystem::Make<lcmt_iiwa_status>(
-          "IIWA_STATUS", lcm, kIiwaLcmStatusPeriod));
-  iiwa_status_pub->set_name(plant.GetModelInstanceName(iiwa_instance) +
-                            "_iiwa_status_publisher");
-  auto iiwa_status_sender =
-      builder->AddSystem<IiwaStatusSender>(num_iiwa_positions);
   builder->Connect(plant.get_state_output_port(iiwa_instance),
-                   iiwa_state_measured_demux->get_input_port(0));
-  builder->Connect(iiwa_state_measured_demux->get_output_port(0),
-                   iiwa_status_sender->get_position_measured_input_port());
-  builder->Connect(iiwa_state_measured_demux->get_output_port(1),
-                   iiwa_status_sender->get_velocity_estimated_input_port());
-  builder->Connect(iiwa_status_sender->get_output_port(),
-                   iiwa_status_pub->get_input_port());
+                   state_demux->get_input_port());
+  builder->Connect(state_demux->get_output_port(0),
+                   command_decode->get_position_measured_input_port());
 
-  // Use the current position until the first command is received.
-  builder->Connect(iiwa_state_measured_demux->get_output_port(0),
-                   iiwa_command_receiver->get_position_measured_input_port());
-
-  // Also send commanded state through the Iiwa status sender.
-  if (has_position) {
-    builder->Connect(
-        iiwa_command_receiver->get_commanded_position_output_port(),
-        iiwa_status_sender->get_position_commanded_input_port());
-  } else {
-    // If we don't supply positions, simply loopback the estimated states.
-    builder->Connect(iiwa_state_measured_demux->get_output_port(0),
-                     iiwa_status_sender->get_position_commanded_input_port());
+  // Connect receiver output to sim controller input.
+  if (position_enabled(control_mode)) {
+    builder->Connect(command_decode->get_commanded_position_output_port(),
+                     *sim_ports.commanded_positions);
+  }
+  if (torque_enabled(control_mode)) {
+    builder->Connect(command_decode->get_commanded_torque_output_port(),
+                     *sim_ports.commanded_torque);
   }
 
-  // Also send control torque through the Iiwa status sender.
-  builder->Connect(*iiwa_control_ports.joint_torque,
-                   iiwa_status_sender->get_torque_commanded_input_port());
+  // Create an Iiwa status sender.
+  auto status_pub = builder->AddNamedSystem(
+      fmt::format("{}_iiwa_status_publisher", model_name),
+      LcmPublisherSystem::Make<lcmt_iiwa_status>("IIWA_STATUS", lcm,
+                                                 kIiwaLcmStatusPeriod));
+  auto status_encode = builder->AddNamedSystem<IiwaStatusSender>(
+      fmt::format("{}_iiwa_status_sender", model_name), num_iiwa_positions);
+  builder->Connect(status_encode->get_output_port(),
+                   status_pub->get_input_port());
 
-  // TODO(amcastro-tri): is this what we want to send as the "measured
-  // torque"? why coming from the controllers instead of from the plant?
-  builder->Connect(*iiwa_control_ports.joint_torque,
-                   iiwa_status_sender->get_torque_measured_input_port());
-
-  builder->Connect(*iiwa_control_ports.external_torque,
-                   iiwa_status_sender->get_torque_external_input_port());
+  // Connect sim controller output to status input.
+  builder->Connect(*sim_ports.position_commanded,
+                   status_encode->get_position_commanded_input_port());
+  builder->Connect(*sim_ports.position_measured,
+                   status_encode->get_position_measured_input_port());
+  builder->Connect(*sim_ports.velocity_estimated,
+                   status_encode->get_velocity_estimated_input_port());
+  builder->Connect(*sim_ports.joint_torque,
+                   status_encode->get_torque_commanded_input_port());
+  builder->Connect(*sim_ports.torque_measured,
+                   status_encode->get_torque_measured_input_port());
+  builder->Connect(*sim_ports.external_torque,
+                   status_encode->get_torque_external_input_port());
 }
 
 IiwaControlPorts BuildSimplifiedIiwaControl(
-    const MultibodyPlant<double>& plant,
-    const multibody::ModelInstanceIndex iiwa_instance,
+    const MultibodyPlant<double>& plant, const ModelInstanceIndex iiwa_instance,
     const MultibodyPlant<double>& controller_plant,
-    systems::DiagramBuilder<double>* builder, double ext_joint_filter_tau,
+    DiagramBuilder<double>* builder, double ext_joint_filter_tau,
     const std::optional<Eigen::VectorXd>& desired_kp_gains,
     IiwaControlMode control_mode) {
-  IiwaControlPorts ports{};
-  const int num_iiwa_positions = controller_plant.num_positions();
-  DRAKE_THROW_UNLESS(num_iiwa_positions == 7);
+  const int num_positions = controller_plant.num_positions();
+  DRAKE_THROW_UNLESS(num_positions == 7);
 
-  // Intercept desired torque so we can also send it as measured torque.
-  const PassThrough<double>* torque_proxy =
-      builder->AddSystem<PassThrough>(num_iiwa_positions);
-  builder->Connect(torque_proxy->get_output_port(),
-                   plant.get_actuation_input_port(iiwa_instance));
-
-  if (position_enabled(control_mode)) {
-    VectorX<double> iiwa_kp, iiwa_kd, iiwa_ki;
-
-    // The default values are taken from the current FRI driver.
-    // TODO(EricCousineau-TRI): These seem like *very* high values for inverse
-    // dynamics on a simulated plant. Investigate overshoot from
-    // `robot_follow_joint_sequence`, see if it's just a timing issue.
-    iiwa_kp = desired_kp_gains.value_or(
-        (Eigen::VectorXd(7) << 2000, 1500, 1500, 1500, 1500, 500, 500)
-            .finished());
-    DRAKE_THROW_UNLESS(iiwa_kp.size() == 7);
-
-    iiwa_kd.resize(num_iiwa_positions);
-    for (int i = 0; i < num_iiwa_positions; ++i) {
-      // Critical damping gains.
-      iiwa_kd[i] = 2 * std::sqrt(iiwa_kp[i]);
-    }
-    iiwa_ki = VectorX<double>::Constant(num_iiwa_positions, 1);
-
-    auto iiwa_controller = builder->AddSystem<InverseDynamicsController>(
-        controller_plant, iiwa_kp, iiwa_ki, iiwa_kd,
-        false /* no feedforward acceleration */);
-
-    builder->Connect(plant.get_state_output_port(iiwa_instance),
-                     iiwa_controller->get_input_port_estimated_state());
-
-    auto iiwa_commanded_state_interpolator =
-        builder->AddSystem<StateInterpolatorWithDiscreteDerivative>(
-            num_iiwa_positions, kIiwaLcmStatusPeriod,
-            true /* suppress_initial_transient */);
-    builder->Connect(iiwa_commanded_state_interpolator->get_output_port(),
-                     iiwa_controller->get_input_port_desired_state());
-
-    ports.commanded_positions =
-        &iiwa_commanded_state_interpolator->get_input_port();
-    if (control_mode == IiwaControlMode::kPositionAndTorque) {
-      // Optional feedforward torque.
-      auto adder = builder->template AddSystem<Adder>(2, num_iiwa_positions);
-      builder->Connect(iiwa_controller->get_output_port_control(),
-                       adder->get_input_port(0));
-      builder->Connect(adder->get_output_port(),
-                       torque_proxy->get_input_port());
-      ports.commanded_torque = &adder->get_input_port(1);
-    } else {
-      builder->Connect(iiwa_controller->get_output_port_control(),
-                       torque_proxy->get_input_port());
-    }
-  } else if (control_mode == IiwaControlMode::kTorqueOnly) {
-    DRAKE_THROW_UNLESS(!desired_kp_gains.has_value());
-    // Torque alone, added to gravity compensation.
-    auto gravity_comp = builder->AddSystem<InverseDynamics>(
-        &controller_plant, InverseDynamicsMode::kGravityCompensation);
-    builder->Connect(plant.get_state_output_port(iiwa_instance),
-                     gravity_comp->get_input_port_estimated_state());
-    auto adder = builder->template AddSystem<Adder>(2, num_iiwa_positions);
-    builder->Connect(gravity_comp->get_output_port_generalized_force(),
-                     adder->get_input_port(0));
-    ports.commanded_torque = &adder->get_input_port(1);
-    builder->Connect(adder->get_output_port(), torque_proxy->get_input_port());
-  }
-
-  // Filter for simulated external torques. Unlike the real robot, external
-  // torques in sim are rather noisy (which propagates into the computed
-  // external wrench).
-  const double kFirstOrderTimeConstant = ext_joint_filter_tau;
-  auto external_torque_filter =
-      builder->AddSystem<systems::FirstOrderLowPassFilter<double>>(
-          kFirstOrderTimeConstant, num_iiwa_positions);
+  // Add the sim driver to the builder.
+  const std::string inner_name = fmt::format(
+      "SimIiwaDriver({})", plant.GetModelInstanceName(iiwa_instance));
+  auto system = builder->template AddNamedSystem<SimIiwaDriver>(
+      inner_name, control_mode, &controller_plant, ext_joint_filter_tau,
+      desired_kp_gains);
+  builder->Connect(plant.get_state_output_port(iiwa_instance),
+                   system->GetInputPort("state"));
   builder->Connect(
       plant.get_generalized_contact_forces_output_port(iiwa_instance),
-      external_torque_filter->get_input_port());
+      system->GetInputPort("generalized_contact_forces"));
+  builder->Connect(system->GetOutputPort("actuation"),
+                   plant.get_actuation_input_port(iiwa_instance));
 
-  // Create a running constraint on the external torque limit.  Values taken
-  // from a TRI Iiwa station.
-  Eigen::VectorXd external_torque_limit(num_iiwa_positions);
-  external_torque_limit.fill(std::numeric_limits<double>::infinity());
-  external_torque_limit << 100, 100, 100, 100, 50, 30, 30;
-  external_torque_filter->AddExternalConstraint(
-      systems::ExternalSystemConstraint(
-          "external torque limit",
-          systems::SystemConstraintBounds(external_torque_limit * -1,
-                                          external_torque_limit),
-          [](const System<double>& system, const Context<double>& context,
-             Eigen::VectorXd* value) {
-            // TODO(jwnimmer-tri) Add a unit test for this.
-            *value = system.get_output_port(0).Eval(context);
-          }));
-
-  // TODO(eric.cousineau): Why do we flip this?
-  auto torque_gain = builder->AddSystem<Gain>(-1, num_iiwa_positions);
-  builder->Connect(torque_proxy->get_output_port(),
-                   torque_gain->get_input_port());
-
-  ports.external_torque = &external_torque_filter->get_output_port();
-  ports.joint_torque = &torque_gain->get_output_port();
-  return ports;
+  // Return the necessary port pointers.
+  IiwaControlPorts result;
+  if (position_enabled(control_mode)) {
+    result.commanded_positions = &system->GetInputPort("position");
+  }
+  if (torque_enabled(control_mode)) {
+    result.commanded_torque = &system->GetInputPort("torque");
+  }
+  result.position_commanded = &system->GetOutputPort("position_commanded");
+  result.position_measured = &system->GetOutputPort("position_measured");
+  result.velocity_estimated = &system->GetOutputPort("velocity_estimated");
+  {
+    // TODO(eric.cousineau): Why do we flip this?
+    auto negate = builder->AddNamedSystem<Gain>(
+        fmt::format("sign_flip_{}_torque_commanded",
+                    plant.GetModelInstanceName(iiwa_instance)),
+        -1, num_positions);
+    builder->Connect(system->GetOutputPort("torque_commanded"),
+                     negate->get_input_port());
+    result.joint_torque = &negate->get_output_port();
+  }
+  {
+    // TODO(eric.cousineau): Why do we flip this?
+    auto negate = builder->AddNamedSystem<Gain>(
+        fmt::format("sign_flip_{}_torque_measured",
+                    plant.GetModelInstanceName(iiwa_instance)),
+        -1, num_positions);
+    builder->Connect(system->GetOutputPort("torque_measured"),
+                     negate->get_input_port());
+    result.torque_measured = &negate->get_output_port();
+  }
+  result.external_torque = &system->GetOutputPort("torque_external");
+  return result;
 }
 
 }  // namespace kuka_iiwa

--- a/manipulation/kuka_iiwa/build_iiwa_control.h
+++ b/manipulation/kuka_iiwa/build_iiwa_control.h
@@ -66,23 +66,26 @@ void BuildIiwaControl(
     const std::optional<Eigen::VectorXd>& desired_iiwa_kp_gains = std::nullopt,
     IiwaControlMode control_mode = IiwaControlMode::kPositionAndTorque);
 
-/// The return type of BuildSimplifiedIiwaControl().
+/// The return type of BuildSimplifiedIiwaControl(). Depending on the
+/// `control_mode`, some of the input ports might be null. The output ports are
+/// never null.
 struct IiwaControlPorts {
+  /// This will be non-null iff the control_mode denotes commanded positions.
   const systems::InputPort<double>* commanded_positions{};
+  /// This will be non-null iff the control_mode denotes commanded torques.
   const systems::InputPort<double>* commanded_torque{};
-  const systems::OutputPort<double>* joint_torque{};
-  const systems::OutputPort<double>* external_torque{};
+
+  const systems::OutputPort<double>* position_commanded{};
+  const systems::OutputPort<double>* position_measured{};
+  const systems::OutputPort<double>* velocity_estimated{};
+  const systems::OutputPort<double>* joint_torque{};  // aka torque_commanded
+  const systems::OutputPort<double>* torque_measured{};
+  const systems::OutputPort<double>* external_torque{};  // aka torque_external
 };
 
 /// A simplified Iiwa controller builder to construct an
-/// InverseDynamicsController without connecting with LCM I/O systems.
+/// InverseDynamicsController without adding LCM I/O systems.
 /// @sa BuildIiwaControl()
-///
-/// @return an IiwaControlPorts struct containing the commanded positions
-/// and/or commanded torques ports of the installed control, depending on
-/// @p control_mode, as well as output ports for the joint and external
-/// torques. If a port is not present due to specified @p control mode, its
-/// pointer will be nullptr.
 IiwaControlPorts BuildSimplifiedIiwaControl(
     const multibody::MultibodyPlant<double>& plant,
     const multibody::ModelInstanceIndex iiwa_instance,

--- a/manipulation/kuka_iiwa/sim_iiwa_driver.cc
+++ b/manipulation/kuka_iiwa/sim_iiwa_driver.cc
@@ -1,0 +1,167 @@
+#include "drake/manipulation/kuka_iiwa/sim_iiwa_driver.h"
+
+#include "drake/common/default_scalars.h"
+#include "drake/systems/controllers/inverse_dynamics_controller.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/adder.h"
+#include "drake/systems/primitives/demultiplexer.h"
+#include "drake/systems/primitives/discrete_derivative.h"
+#include "drake/systems/primitives/first_order_low_pass_filter.h"
+#include "drake/systems/primitives/pass_through.h"
+
+namespace drake {
+namespace manipulation {
+namespace kuka_iiwa {
+namespace internal {
+
+using multibody::MultibodyPlant;
+using systems::Adder;
+using systems::Context;
+using systems::Demultiplexer;
+using systems::Diagram;
+using systems::DiagramBuilder;
+using systems::FirstOrderLowPassFilter;
+using systems::PassThrough;
+using systems::StateInterpolatorWithDiscreteDerivative;
+using systems::System;
+using systems::controllers::InverseDynamics;
+using systems::controllers::InverseDynamicsController;
+
+namespace {
+
+/* The return type of MakeInverseDynamicsGains(), immediately below. */
+struct Gains {
+  VectorX<double> kp;
+  VectorX<double> ki;
+  VectorX<double> kd;
+};
+
+/* Given the user-provided `kp` gains (if any), return all PID gains. */
+Gains MakeInverseDynamicsGains(const std::optional<Eigen::VectorXd>& kp) {
+  Gains result;
+
+  // The default values are taken from the current FRI driver.
+  // TODO(EricCousineau-TRI): These seem like *very* high values for inverse
+  // dynamics on a simulated plant. Investigate overshoot from
+  // `robot_follow_joint_sequence`, see if it's just a timing issue.
+  result.kp =
+      kp.value_or((Eigen::VectorXd(7) << 2000, 1500, 1500, 1500, 1500, 500, 500)
+                      .finished());
+
+  // Critical damping gains.
+  result.kd = 2 * result.kp.array().sqrt();
+
+  result.ki = VectorX<double>::Constant(result.kp.size(), 1.0);
+
+  return result;
+}
+
+}  // namespace
+
+template <typename T>
+SimIiwaDriver<T>::SimIiwaDriver(
+    const IiwaControlMode control_mode,
+    const multibody::MultibodyPlant<T>* const controller_plant,
+    const double ext_joint_filter_tau,
+    const std::optional<Eigen::VectorXd>& kp_gains)
+    : Diagram<T>(systems::SystemTypeTag<SimIiwaDriver>{}) {
+  DRAKE_THROW_UNLESS(controller_plant != nullptr);
+  const int num_positions = controller_plant->num_positions();
+
+  DiagramBuilder<T> builder;
+
+  // Declare the `state` input port to accept MbP's {i'th}_state output port,
+  // and demux it into separate positions and velocities.
+  auto state_demux = builder.template AddNamedSystem<Demultiplexer>(
+      "demultiplexer", 2 * num_positions, num_positions);
+  builder.ExportInput(state_demux->get_input_port(), "state");
+
+  // Declare the `generalized_contact_forces` input port to accept the MbP's
+  // {i'th}_generalized_contact_forces output port. Filter this because unlike
+  // the real robot external torques in sim are rather noisy (which propagates
+  // into the computed external wrench).
+  auto contact_forces =
+      builder.template AddNamedSystem<FirstOrderLowPassFilter>(
+          "low_pass_filter", ext_joint_filter_tau, num_positions);
+  builder.ExportInput(contact_forces->get_input_port(),
+                      "generalized_contact_forces");
+
+  // When position control is enabled, declare the `position` input port,
+  // interpolate position commands into state commands, and then use a full
+  // inverse dynamics controller. Otherwise, use inverse dynamics only for
+  // gravity compensation.
+  const System<T>* inverse_dynamics{};
+  if (position_enabled(control_mode)) {
+    using StateInterpolator = StateInterpolatorWithDiscreteDerivative<T>;
+    auto interpolator = builder.template AddNamedSystem<StateInterpolator>(
+        "velocity_interpolator", num_positions, kIiwaLcmStatusPeriod,
+        true /* suppress initial transient */);
+    builder.ExportInput(interpolator->get_input_port(), "position");
+    const Gains inverse_dynamics_gains = MakeInverseDynamicsGains(kp_gains);
+    inverse_dynamics =
+        builder.template AddNamedSystem<InverseDynamicsController>(
+            "inverse_dynamics_controller", *controller_plant,
+            inverse_dynamics_gains.kp, inverse_dynamics_gains.ki,
+            inverse_dynamics_gains.kd, false /* no feedforward acceleration */);
+    builder.Connect(interpolator->GetOutputPort("state"),
+                    inverse_dynamics->GetInputPort("desired_state"));
+  } else {
+    inverse_dynamics = builder.template AddNamedSystem<InverseDynamics>(
+        "gravity_compensation", controller_plant,
+        InverseDynamics<T>::InverseDynamicsMode::kGravityCompensation);
+  }
+  builder.ConnectInput("state",
+                       inverse_dynamics->GetInputPort("estimated_state"));
+
+  // When torque control is enabled, declare the `torque` input port and add it
+  // to the inverse dynamics output. Otherwise, use the inverse dynamics output
+  // by itself.
+  const System<T>* actuation = nullptr;
+  if (torque_enabled(control_mode)) {
+    actuation = builder.template AddNamedSystem<Adder>("+", 2, num_positions);
+    builder.Connect(inverse_dynamics->GetOutputPort("generalized_force"),
+                    actuation->get_input_port(0));
+    builder.ExportInput(actuation->get_input_port(1), "torque");
+  } else {
+    actuation = inverse_dynamics;
+  }
+
+  // Declare the various output ports.
+  builder.ExportOutput(actuation->get_output_port(), "actuation");
+  if (position_enabled(control_mode)) {
+    auto pass = builder.template AddNamedSystem<PassThrough>(
+        "position_pass_through", num_positions);
+    builder.ConnectInput("position", pass->get_input_port());
+    builder.ExportOutput(pass->get_output_port(), "position_commanded");
+  } else {
+    builder.ExportOutput(state_demux->get_output_port(0), "position_commanded");
+  }
+  builder.ExportOutput(state_demux->get_output_port(0), "position_measured");
+  builder.ExportOutput(state_demux->get_output_port(1), "velocity_estimated");
+  {
+    auto pass = builder.template AddNamedSystem<PassThrough>(
+        "state_pass_through", 2 * num_positions);
+    builder.ConnectInput("state", pass->get_input_port());
+    builder.ExportOutput(pass->get_output_port(), "state_estimated");
+  }
+  builder.ExportOutput(actuation->get_output_port(), "torque_commanded");
+  // TODO(amcastro-tri): is this what we want to send as the "measured
+  // torque"? why coming from the controllers instead of from the plant?
+  builder.ExportOutput(actuation->get_output_port(), "torque_measured");
+  builder.ExportOutput(contact_forces->get_output_port(), "torque_external");
+
+  builder.BuildInto(this);
+}
+
+template <typename T>
+template <typename U>
+SimIiwaDriver<T>::SimIiwaDriver(const SimIiwaDriver<U>& other)
+    : Diagram<T>(systems::SystemTypeTag<SimIiwaDriver>{}, other) {}
+
+}  // namespace internal
+}  // namespace kuka_iiwa
+}  // namespace manipulation
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::manipulation::kuka_iiwa::internal::SimIiwaDriver)

--- a/manipulation/kuka_iiwa/sim_iiwa_driver.h
+++ b/manipulation/kuka_iiwa/sim_iiwa_driver.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <optional>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/manipulation/kuka_iiwa/iiwa_constants.h"  // IiwaControlMode
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram.h"
+
+namespace drake {
+namespace manipulation {
+namespace kuka_iiwa {
+namespace internal {
+
+/* SimIiwaDriver simulates the IIWA control and status interface using a
+MultibodyPlant.
+
+@system
+name: SimIiwaDriver
+input_ports:
+- <b style="color:orange">state</b>
+- <b style="color:orange">generalized_contact_forces</b>
+- position (in kPositionOnly or kPositionAndTorque mode)
+- torque (in kTorqueOnly or kPositionAndTorque mode)
+output_ports:
+- <b style="color:orange">actuation</b>
+- position_commanded
+- position_measured
+- velocity_estimated
+- state_estimated
+- torque_commanded
+- torque_measured
+- torque_external
+@endsystem
+
+Ports shown in <b style="color:orange">orange</b> are intended to connect to the
+MultibodyPlant's per-model-instance ports of the same name. All other ports are
+intended to mimic the LCM command and status message fields.
+
+@tparam_default_scalar */
+template <typename T>
+class SimIiwaDriver : public systems::Diagram<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimIiwaDriver);
+
+  /* Constructs a diagram with the given parameters. A reference to the
+  `controller_plant` is retained by this system, so the `controller_plant`
+  must outlive `this`. */
+  SimIiwaDriver(IiwaControlMode control_mode,
+                const multibody::MultibodyPlant<T>* controller_plant,
+                double ext_joint_filter_tau,
+                const std::optional<Eigen::VectorXd>& kp_gains);
+
+  /* Scalar-converting copy constructor. See @ref system_scalar_conversion. */
+  template <typename U>
+  explicit SimIiwaDriver(const SimIiwaDriver<U>&);
+};
+
+}  // namespace internal
+}  // namespace kuka_iiwa
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/kuka_iiwa/test/build_iiwa_control_test.cc
+++ b/manipulation/kuka_iiwa/test/build_iiwa_control_test.cc
@@ -120,13 +120,27 @@ TEST_F(BuildIiwaControlTest, PositionOnly) {
       0.01, {}, IiwaControlMode::kPositionOnly);
   const auto diagram = builder_.Build();
 
-  EXPECT_NE(control_ports.commanded_positions, nullptr);
+  // Expect position as input.
+  ASSERT_NE(control_ports.commanded_positions, nullptr);
   EXPECT_EQ(control_ports.commanded_positions->size(), N);
-  // Should be nullptr if enable_feedforward_torque is false.
+
+  // No torque input. Should be nullptr if enable_feedforward_torque is false.
   EXPECT_EQ(control_ports.commanded_torque, nullptr);
-  EXPECT_NE(control_ports.joint_torque, nullptr);
+
+  // Check that outputs are never null.
+  ASSERT_NE(control_ports.position_commanded, nullptr);
+  ASSERT_NE(control_ports.position_measured, nullptr);
+  ASSERT_NE(control_ports.velocity_estimated, nullptr);
+  ASSERT_NE(control_ports.joint_torque, nullptr);
+  ASSERT_NE(control_ports.torque_measured, nullptr);
+  ASSERT_NE(control_ports.external_torque, nullptr);
+
+  // Check output sizes.
+  EXPECT_EQ(control_ports.position_commanded->size(), N);
+  EXPECT_EQ(control_ports.position_measured->size(), N);
+  EXPECT_EQ(control_ports.velocity_estimated->size(), N);
   EXPECT_EQ(control_ports.joint_torque->size(), N);
-  EXPECT_NE(control_ports.external_torque, nullptr);
+  EXPECT_EQ(control_ports.torque_measured->size(), N);
   EXPECT_EQ(control_ports.external_torque->size(), N);
 }
 
@@ -137,12 +151,27 @@ TEST_F(BuildIiwaControlTest, TorqueOnly) {
       0.01, {}, IiwaControlMode::kTorqueOnly);
   const auto diagram = builder_.Build();
 
-  EXPECT_EQ(control_ports.commanded_positions, nullptr);
-  EXPECT_NE(control_ports.commanded_torque, nullptr);
+  // Expect torque as input.
+  ASSERT_NE(control_ports.commanded_torque, nullptr);
   EXPECT_EQ(control_ports.commanded_torque->size(), N);
-  EXPECT_NE(control_ports.joint_torque, nullptr);
+
+  // No position input.
+  EXPECT_EQ(control_ports.commanded_positions, nullptr);
+
+  // Check that outputs are never null.
+  ASSERT_NE(control_ports.position_commanded, nullptr);
+  ASSERT_NE(control_ports.position_measured, nullptr);
+  ASSERT_NE(control_ports.velocity_estimated, nullptr);
+  ASSERT_NE(control_ports.joint_torque, nullptr);
+  ASSERT_NE(control_ports.torque_measured, nullptr);
+  ASSERT_NE(control_ports.external_torque, nullptr);
+
+  // Check output sizes.
+  EXPECT_EQ(control_ports.position_commanded->size(), N);
+  EXPECT_EQ(control_ports.position_measured->size(), N);
+  EXPECT_EQ(control_ports.velocity_estimated->size(), N);
   EXPECT_EQ(control_ports.joint_torque->size(), N);
-  EXPECT_NE(control_ports.external_torque, nullptr);
+  EXPECT_EQ(control_ports.torque_measured->size(), N);
   EXPECT_EQ(control_ports.external_torque->size(), N);
 }
 
@@ -168,14 +197,26 @@ TEST_F(BuildIiwaControlTest, PositionAndTorque) {
                    *control_ports.commanded_torque);
   auto diagram = builder_.Build();
 
-  // Check all the ports of `control_ports` are set up properly.
-  EXPECT_NE(control_ports.commanded_positions, nullptr);
+  // Check that both inputs exist.
+  ASSERT_NE(control_ports.commanded_positions, nullptr);
+  ASSERT_NE(control_ports.commanded_torque, nullptr);
   EXPECT_EQ(control_ports.commanded_positions->size(), N);
-  EXPECT_NE(control_ports.commanded_torque, nullptr);
   EXPECT_EQ(control_ports.commanded_torque->size(), N);
-  EXPECT_NE(control_ports.joint_torque, nullptr);
+
+  // Check that outputs are never null.
+  ASSERT_NE(control_ports.position_commanded, nullptr);
+  ASSERT_NE(control_ports.position_measured, nullptr);
+  ASSERT_NE(control_ports.velocity_estimated, nullptr);
+  ASSERT_NE(control_ports.joint_torque, nullptr);
+  ASSERT_NE(control_ports.torque_measured, nullptr);
+  ASSERT_NE(control_ports.external_torque, nullptr);
+
+  // Check output sizes.
+  EXPECT_EQ(control_ports.position_commanded->size(), N);
+  EXPECT_EQ(control_ports.position_measured->size(), N);
+  EXPECT_EQ(control_ports.velocity_estimated->size(), N);
   EXPECT_EQ(control_ports.joint_torque->size(), N);
-  EXPECT_NE(control_ports.external_torque, nullptr);
+  EXPECT_EQ(control_ports.torque_measured->size(), N);
   EXPECT_EQ(control_ports.external_torque->size(), N);
 
   systems::Simulator<double> simulator(*diagram);

--- a/manipulation/kuka_iiwa/test/sim_iiwa_driver_test.cc
+++ b/manipulation/kuka_iiwa/test/sim_iiwa_driver_test.cc
@@ -1,0 +1,91 @@
+#include "drake/manipulation/kuka_iiwa/sim_iiwa_driver.h"
+
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+namespace drake {
+namespace manipulation {
+namespace kuka_iiwa {
+namespace internal {
+namespace {
+
+using multibody::MultibodyPlant;
+using multibody::Parser;
+using systems::InputPortIndex;
+using systems::OutputPortIndex;
+using systems::System;
+
+class SimIiwaDriverTest : public ::testing::Test {
+ public:
+  SimIiwaDriverTest() = default;
+
+ protected:
+  void SetUp() {
+    sim_plant_ = std::make_unique<MultibodyPlant<double>>(0.001);
+    Parser parser{sim_plant_.get()};
+    parser.AddModelsFromUrl(
+        "package://drake/manipulation/models/iiwa_description/iiwa7/"
+        "iiwa7_no_collision.sdf");
+    sim_plant_->WeldFrames(sim_plant_->world_frame(),
+                           sim_plant_->GetFrameByName("iiwa_link_0"));
+    sim_plant_->Finalize();
+    controller_plant_ = System<double>::Clone(*sim_plant_);
+  }
+
+  std::unique_ptr<MultibodyPlant<double>> sim_plant_;
+  std::unique_ptr<MultibodyPlant<double>> controller_plant_;
+  double ext_joint_filter_tau_{0.1};
+};
+
+TEST_F(SimIiwaDriverTest, SanityCheck) {
+  for (const auto& mode :
+       {IiwaControlMode::kPositionOnly, IiwaControlMode::kTorqueOnly,
+        IiwaControlMode::kPositionAndTorque}) {
+    SCOPED_TRACE(fmt::format("mode = {}", static_cast<int>(mode)));
+    const SimIiwaDriver<double> dut(mode, controller_plant_.get(),
+                                    ext_joint_filter_tau_, {});
+
+    // Check input port names.
+    std::vector<std::string> inputs;
+    for (InputPortIndex i{0}; i < dut.num_input_ports(); ++i) {
+      inputs.push_back(dut.get_input_port(i).get_name());
+    }
+    std::vector<std::string> expected_inputs{"state",
+                                             "generalized_contact_forces"};
+    if (position_enabled(mode)) {
+      expected_inputs.push_back("position");
+    }
+    if (torque_enabled(mode)) {
+      expected_inputs.push_back("torque");
+    }
+    EXPECT_THAT(inputs, testing::ElementsAreArray(expected_inputs));
+
+    // Check output port names.
+    std::vector<std::string> outputs;
+    for (OutputPortIndex i{0}; i < dut.num_output_ports(); ++i) {
+      outputs.push_back(dut.get_output_port(i).get_name());
+    }
+    std::vector<std::string> expected_outputs{
+        "actuation",          "position_commanded", "position_measured",
+        "velocity_estimated", "state_estimated",    "torque_commanded",
+        "torque_measured",    "torque_external"};
+    EXPECT_THAT(outputs, testing::ElementsAreArray(expected_outputs));
+
+    // Check scalar conversion.
+    EXPECT_TRUE(systems::is_autodiffxd_convertible(dut));
+    EXPECT_TRUE(systems::is_symbolic_convertible(dut));
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace kuka_iiwa
+}  // namespace manipulation
+}  // namespace drake


### PR DESCRIPTION
Towards #20055.  See the discussion here: https://github.com/RobotLocomotion/drake/issues/20055#issuecomment-1716196721.

For a visual representation of the change, we can use the new option #20198 to output Graphviz from the `hardware_sim` example:

Before:

![image](https://github.com/RobotLocomotion/drake/assets/17596505/1c697d0a-20bd-44d7-8cee-86429c00bd3e)

After (r2):

![image](https://github.com/RobotLocomotion/drake/assets/17596505/eadc3d9c-7672-4083-8767-9de6bb467b7e)

After (r3):

![image](https://github.com/RobotLocomotion/drake/assets/17596505/596aaee5-1095-4192-9c3e-fbf0eecd9c2a)

(FYI These images also contain some styling improvements that are not yet on `master`.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20182)
<!-- Reviewable:end -->
