### PR TITLE
RenderEngineGltfClient changes how input glTFs are handled

### DIFF
--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -138,6 +138,7 @@ drake_cc_library(
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
+        "//common:drake_export",
         "//common:essential",
         "@nlohmann_internal//:nlohmann",
     ],
@@ -361,6 +362,7 @@ drake_cc_googletest(
         ":internal_merge_gltf",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "@nlohmann_internal//:nlohmann",
     ],
 )

--- a/geometry/render_gltf_client/internal_merge_gltf.cc
+++ b/geometry/render_gltf_client/internal_merge_gltf.cc
@@ -1,16 +1,17 @@
 #include "drake/geometry/render_gltf_client/internal_merge_gltf.h"
 
+#include <algorithm>
 #include <fstream>
-#include <map>
+#include <functional>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/common/ssize.h"
+#include "drake/common/text_logging.h"
 
 // For more explanation of the glTF fun and games:
 // https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html
@@ -35,8 +36,8 @@ int ArraySize(const json& j, std::string_view array_name) {
 }
 
 // If the json pointed to by `j_ptr` has a child with the given `name`, its
-// integer value incremented by `offset`.
-// @pre If present (*j_ptr)[name] is an integer value.
+// integer value gets incremented by `offset`.
+// @pre If present, (*j_ptr)[name] is an integer value.
 void MaybeOffsetNamedIndex(json* j_ptr, std::string_view name, int offset) {
   json& j = *j_ptr;
   if (j.contains(name)) {
@@ -46,7 +47,7 @@ void MaybeOffsetNamedIndex(json* j_ptr, std::string_view name, int offset) {
 }
 
 // Same as MaybeOffsetNamedIndex(), but the child is an array of integers.
-// @pre If present (*j_ptr)[array_name] is an array of integers.
+// @pre If present, (*j_ptr)[array_name] is an array of integers.
 void MaybeOffsetIndexArray(json* j_ptr, std::string_view array_name,
                            int offset) {
   json& j = *j_ptr;
@@ -72,7 +73,159 @@ void MaybeOffsetNamedIndexInTree(json* j_ptr, std::string_view name,
   }
 }
 
+// Merges *names* of extensions from j2 into j1 (preventing duplicates). This
+// should not be used for merging an "extensions" property which contains
+// arbitrary objects.
+void MergeExtensionNames(json* j1, json&& j2, const std::string& array_name) {
+  if (j2.contains(array_name)) {
+    json& extensions1 = (*j1)[array_name];
+    for (auto& extension2 : j2[array_name]) {
+      if (std::any_of(extensions1.begin(), extensions1.end(),
+                      [&extension2](const auto& value) {
+                        return value == extension2;
+                      })) {
+        // Don't duplicate extension names.
+        continue;
+      }
+      extensions1.push_back(std::move(extension2));
+    }
+  }
+}
+
+// Provides information about the scope for extra/extensions merging. It
+// indicates the element that "contains" the extras/extensions being merged.
+// Used to craft exception messages.
+enum class ContainerType {
+  // The root of the glTF data.
+  kGltf,
+  // The "asset" node under the root.
+  kAsset,
+  // The item in the "scenes" array being treated as the default scene.
+  kDefaultScene,
+};
+std::string_view to_string(ContainerType x) {
+  switch (x) {
+    case ContainerType::kGltf:
+      return "glTF";
+    case ContainerType::kAsset:
+      return "asset";
+    case ContainerType::kDefaultScene:
+      return "default_scene";
+  }
+  DRAKE_UNREACHABLE();
+}
+
+// Attempts to merge the key-value pairs from j2 into j1. To merge successfully,
+// all every key in j2 that appears in j1 must have the same value. If
+// successful, every key-value pair in j2 is in j1 upon return.
+//
+// Note: a "successful" merge could still leave j1 unchanged, because either
+// there was nothing in j2, or j2's contents were already present in j1.
+//
+// @throws if merge was not successful.
+// @pre j1->is_object() && j2.is_object().
+void MergeTrees(json* j1, json&& j2, const std::string& blob_name,
+                ContainerType container_type,
+                const std::filesystem::path& j2_path, MergeRecord* record) {
+  DRAKE_DEMAND(j1->is_object() && j2.is_object());
+  // First confirm there are no collisions.
+  for (auto& [key, value] : j2.items()) {
+    if (j1->contains(key)) {
+      if ((*j1)[key] != value) {
+        const std::string& j1_name = record->FindSourcePath(*j1);
+        throw std::runtime_error(fmt::format(
+            "Error in merging '{}.{}.{}'; two glTF files have different "
+            "values. '{}' defines it as {}, but '{}' defines it as {}.",
+            to_string(container_type), blob_name, key, j1_name,
+            fmt_streamed((*j1)[key]), j2_path, fmt_streamed(value)));
+      }
+    }
+  }
+  // There were no collisions, merging will now proceed and be successful by
+  // default.
+  for (auto& [key, value] : j2.items()) {
+    if (j1->contains(key)) continue;
+    (*j1)[key] = std::move(value);
+    record->AddElementTree((*j1)[key], j2_path);
+  }
+}
+
+// Merge user data. This can be used for merging the arbitrary collection of
+// objects contained in either "extras" or "extensions". As documented, if there
+// is a collision between the two json trees, we will throw with helpful info.
+void MergeBlobs(json* j1, json&& j2, const std::string& blob_name,
+                ContainerType container_type,
+                const std::filesystem::path& j2_path, MergeRecord* record) {
+  if (j2.contains(blob_name)) {
+    json& blob2 = j2[blob_name];
+    if (blob2.is_null()) {
+      // The "blob" key existed, but nothing was stored. We do nothing.
+      return;
+    }
+    json& blob1 = (*j1)[blob_name];
+    // Merging logic. There are a limited number of cases where we can merge:
+    //  1. blobs 1 and 2 are both objects with no colliding key-value pairs.
+    //     We can simply merge 2 into 1.
+    //  2. blob1 is null
+    //     We can simply take blob2 verbatim (whether object or primitive).
+    //  3. In all other cases, merging is not possible.
+    if (blob1.is_object() && blob2.is_object()) {
+      MergeTrees(&blob1, std::move(blob2), blob_name, container_type, j2_path,
+                 record);
+    } else if (blob1.is_null()) {
+      // j1 doesn't have the blob, go ahead and replace it with j2's.
+      blob1 = std::move(blob2);
+      record->AddElementTree(blob1, j2_path);
+    } else {
+      const std::string& j1_name = record->FindSourcePath(blob1);
+      throw std::runtime_error(fmt::format(
+          "Error in merging '{}.{}'. To merge, the must both be objects. "
+          "'{}' has {} and '{}' has {}.",
+          to_string(container_type), blob_name, j1_name,
+          blob1.is_object() ? "an object" : "a primitive", j2_path,
+          blob2.is_object() ? "an object" : "a primitive"));
+    }
+  }
+}
+
+// Attempts to merge the "extras" and "extensions" object blocks from j2 to to
+// j1. This only needs to be called where we're attempting to merge nodes:
+// the root glTF node and Scene nodes. All other nodes simply get concatenated
+// to lists.
+void MergeExtrasAndExtensions(json* j1, json&& j2, ContainerType container_type,
+                              const std::filesystem::path& j2_path,
+                              MergeRecord* record) {
+  MergeBlobs(j1, std::move(j2), "extras", container_type, j2_path, record);
+  MergeBlobs(j1, std::move(j2), "extensions", container_type, j2_path, record);
+}
+
 }  // namespace
+
+MergeRecord::MergeRecord(std::filesystem::path initial_path) {
+  source_paths_.push_back(std::move(initial_path));
+}
+
+const std::filesystem::path& MergeRecord::FindSourcePath(
+    const json& element) const {
+  const auto iter = merged_trees_.find(&element);
+  DRAKE_DEMAND(iter != merged_trees_.end());
+  return source_paths_.at(iter->second);
+}
+
+void MergeRecord::AddElementTree(const json& root,
+                                 const std::filesystem::path& source_path) {
+  const int source_index = ssize(source_paths_);
+  source_paths_.push_back(source_path);
+  std::function<void(const json&)> add_tree = [&](const json& tree_root) {
+    this->merged_trees_[&tree_root] = source_index;
+    if (tree_root.is_object() || tree_root.is_array()) {
+      for (const auto& child : tree_root) {
+        add_tree(child);
+      }
+    }
+  };
+  add_tree(root);
+}
 
 json ReadJsonFile(const std::filesystem::path& json_path) {
   std::ifstream f(json_path);
@@ -102,51 +255,25 @@ Matrix4<double> EigenMatrixFromGltfMatrix(const json& matrix_json) {
   return T;
 }
 
-void MergeScenes(json* j1, json&& j2) {
-  std::map<string, int> names_in_1;
-  json& j1_scenes = (*j1)["scenes"];
-  // Identify all of the named scenes in j1. Names are optional.
-  for (int s = 0; s < ssize(j1_scenes); ++s) {
-    const json& scene = j1_scenes[s];
-    if (scene.contains("name")) {
-      names_in_1.insert({scene["name"].get<string>(), s});
-    }
-  }
-
-  // For each scene in j2, update its node values and either merge scenes or
-  // append scenes.
-  if (j2.contains("scenes")) {
+void MergeDefaultScenes(json* j1, json&& j2,
+                        const std::filesystem::path& j2_path,
+                        MergeRecord* record) {
+  int index_1 = j1->contains("scene") ? (*j1)["scene"].get<int>() : 0;
+  int index_2 = j2.contains("scene") ? j2["scene"].get<int>() : 0;
+  json& scene_1 = (*j1)["scenes"][index_1];
+  json& scene_2 = j2["scenes"][index_2];
+  if (scene_2.contains("nodes")) {
     const int node_offset = ArraySize(*j1, "nodes");
-    for (auto& scene : j2["scenes"]) {
-      // Offset all node indices in this scene.
-      MaybeOffsetIndexArray(&scene, "nodes", node_offset);
-
-      // If the scene needs to be merged, merge it.
-      if (scene.contains("name")) {
-        const string& name = scene["name"].get<string>();
-        if (names_in_1.count(name) > 0) {
-          if (scene.contains("nodes")) {
-            // Merge this scene's nodes into the named scene.
-            json& nodes = j1_scenes[names_in_1[name]]["nodes"];
-            for (auto& n : scene["nodes"]) {
-              nodes.push_back(std::move(n));
-            }
-            // TODO(SeanCurtis-TRI): This omits the extensions and extras that
-            // may be stored with j2's scene. Consider merging them as well.
-            // It's unclear what to do if two identically named scenes have the
-            // same extras property, but different values. Probably just throw.
-            // Note: where j2's scene doesn't require merging, those properties
-            // are copied automatically.
-          }
-          // We've merged; no further required for this scene.
-          continue;
-        }
-      }
-
-      // We didn't merge the scenes, so we just need to append.
-      j1_scenes.push_back(std::move(scene));
+    // Offset all node indices in j2's scene.
+    MaybeOffsetIndexArray(&scene_2, "nodes", node_offset);
+    // Merge j2's scene's nodes into the j1's scene's nodes.
+    json& nodes_1 = scene_1["nodes"];
+    for (auto& n : scene_2["nodes"]) {
+      nodes_1.push_back(std::move(n));
     }
   }
+  MergeExtrasAndExtensions(&scene_1, std::move(scene_2),
+                           ContainerType::kDefaultScene, j2_path, record);
 }
 
 void MergeNodes(json* j1, json&& j2) {
@@ -166,6 +293,14 @@ void MergeNodes(json* j1, json&& j2) {
       nodes.push_back(std::move(node));
     }
   }
+}
+
+void MergeExtensionsUsed(json* j1, json&& j2) {
+  MergeExtensionNames(j1, std::move(j2), "extensionsUsed");
+}
+
+void MergeExtensionsRequired(json* j1, json&& j2) {
+  MergeExtensionNames(j1, std::move(j2), "extensionsRequired");
 }
 
 void MergeMeshes(json* j1, json&& j2) {
@@ -294,16 +429,26 @@ void MergeSamplers(json* j1, json&& j2) {
   }
 }
 
-void MergeGltf(json* j1, json&& j2) {
-  (*j1)["asset"]["generator"] = "Drake glTF merger";
-  DRAKE_DEMAND((*j1)["asset"]["version"].get<string>() == "2.0");
-  DRAKE_DEMAND(j2["asset"]["version"].get<string>() == "2.0");
+void MergeGltf(json* j1, json&& j2, const std::filesystem::path& j2_path,
+               MergeRecord* record) {
+  json& asset1 = (*j1)["asset"];
+  json& asset2 = j2["asset"];
+  DRAKE_DEMAND(!(asset1.is_null() || asset2.is_null()));
+
+  asset1["generator"] = "Drake glTF merger";
+  // TODO(SeanCurtis-TRI): We're not doing anything to the copyright. Should we?
+  DRAKE_DEMAND(asset1["version"].get<string>() == "2.0");
+  DRAKE_DEMAND(asset2["version"].get<string>() == "2.0");
+  MergeExtrasAndExtensions(j1, std::move(j2), ContainerType::kGltf, j2_path,
+                           record);
+  MergeExtrasAndExtensions(&asset1, std::move(asset2), ContainerType::kAsset,
+                           j2_path, record);
 
   // Don't change the order. Because we mutate j1 as we go, we need to make sure
   // we only mutate something after we've processed everything that depends on
   // it.
   // https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_002_BasicGltfStructure.md
-  MergeScenes(j1, std::move(j2));
+  MergeDefaultScenes(j1, std::move(j2), j2_path, record);
   MergeNodes(j1, std::move(j2));
   MergeMeshes(j1, std::move(j2));
   MergeMaterials(j1, std::move(j2));
@@ -314,6 +459,8 @@ void MergeGltf(json* j1, json&& j2) {
   MergeSamplers(j1, std::move(j2));
   MergeBufferViews(j1, std::move(j2));
   MergeBuffers(j1, std::move(j2));
+  MergeExtensionsUsed(j1, std::move(j2));
+  MergeExtensionsRequired(j1, std::move(j2));
 
   // NOTE: For now we're omitting skins, animations and morphs.
 }

--- a/geometry/render_gltf_client/internal_merge_gltf.h
+++ b/geometry/render_gltf_client/internal_merge_gltf.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <filesystem>
+#include <unordered_map>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
+#include "drake/common/drake_export.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
@@ -28,15 +31,61 @@ Matrix4<double> EigenMatrixFromGltfMatrix(const nlohmann::json& matrix_json);
  get incremented by the size of the target array before merging.
 */
 
-/* Merges the "scenes" array from j2 into j1.
+/* We attempt to merge extensions and extras for the glTF, scene, and asset
+ elements. If there is a conflict in the values, we report the conflict. This
+ struct provides a record of where merged extras and extensions come from so
+ we can effectively report the source of the conflict. */
+class DRAKE_NO_EXPORT MergeRecord {
+ public:
+  /* The initial merge record should be created with the path of the initial
+   target glTF's source; it need not be a path to an existing file. */
+  explicit MergeRecord(std::filesystem::path initial_path);
 
- Upon return, j1 will contain the following scenes:
+  /* Finds the source path for the given element.
+   @pre element is part of this merge record. */
+  const std::filesystem::path& FindSourcePath(
+      const nlohmann::json& element) const;
 
-   - Each scene from j1 and j2 whose name only appears in one of the files.
-   - For scenes in j1 and j2 with the same name, the node list of j2's scene
-     appended to the scene in j1. Any extras or extensions in j2's scene will
-     be lost. */
-void MergeScenes(nlohmann::json* j1, nlohmann::json&& j2);
+  /* Adds the json tree with the given `root` to the record associated with the
+   given `source_name`.
+   @pre `source_name` is not in the record already. */
+  void AddElementTree(const nlohmann::json& root,
+                      const std::filesystem::path& source_path);
+
+ private:
+  /* A map from a json pointer in the target glTF structure to the index of the
+   source path from which it came. The mapped values should all be valid
+   indices into `source_paths_`.
+
+   Note: This works because nlohmann::json is linked-list-esque. Each node is
+   allocated on the heap and they don't move just because additional children
+   get included. */
+  std::unordered_map<const nlohmann::json*, int> merged_trees_;
+
+  /* The paths of all sources contributing to the composition of j1. */
+  std::vector<std::filesystem::path> source_paths_;
+};
+
+/* Merges the default scene from j2 into j1's default scene.
+
+ For each glTF source, the default scene is defined by the optional "scenes"
+ property. If undefined, it is interpreted as zero. It will also attempt to
+ merge the extras and extensions between the two scenes.
+
+ @param j1  The glTF root element.
+ @param j2  The glTF root element.
+ @pre Both j1 and j2 have a valid default scene.
+ @throws if there are merge conflicts between the scenes' "extra" or
+ "extensions" data. */
+void MergeDefaultScenes(nlohmann::json* j1, nlohmann::json&& j2,
+                        const std::filesystem::path& j2_path,
+                        MergeRecord* record);
+
+/* Merges the "extensionsUsed" array from j2 into j1. */
+void MergeExtensionsUsed(nlohmann::json* j1, nlohmann::json&& j2);
+
+/* Merges the "extensionsRequired" array from j2 into j1. */
+void MergeExtensionsRequired(nlohmann::json* j1, nlohmann::json&& j2);
 
 /* Merges the "nodes" array from j2 into j1. */
 void MergeNodes(nlohmann::json* j1, nlohmann::json&& j2);
@@ -75,17 +124,41 @@ void MergeSamplers(nlohmann::json* j1, nlohmann::json&& j2);
 //    to bytes and back again).
 //  b. All bufferViews that reference the buffer at higher byte addresses need
 //     to be identified and offset.
+//
+// With the fact that we only merge the default scenes, this means we could be
+// merging all sorts of unused data. Nodes not referenced by the default scene
+// are wasted. Any meshes referenced *only* by those nodes are likewise wasted.
+// This can be pushed down to all images, textures, samplers, etc., not just
+// the data embedded in buffers.
+//
+// To make a truly minimal merged result, we'd have to walk the tree once to
+// find out what we'll actually need based on default scene merging and then
+// merge only that. However, at this point our informal (hopefully soon to
+// become formal) advice is to use glTF files with a single scene (the normal
+// result of simply exporting geometry from a tool like blender). So, this
+// extra work would probably be premature. When we change to not just allow but
+// exploit multiple scenes, we'll have to be more targeted here.
 
 /* Merges the glTF data stored in the json j2 into j1.
+
+ Generally, merging consists of concatenating the elements of the arrays in
+ j2 into the corresponding arrays in j1. Indices in j2 referencing those
+ elements get offset to reflect their new positions in j1's arrays. However,
+ there are some special rules for merging:
+
+ 1. Only the default scenes get merged. If either glTF hasn't specified the
+    "scene" property, it is assumed to be the 0th scene.
+    - The scene *name* is never modified.
+ 2. We attempt to merge the "extras" and "extensions" at the glTF level, and in
+    the "asset" and merged Scene properties. If there is any problem in merging,
+    we throw an exception detailing the problem.
 
  This explicitly excludes skin data, animation, and morph target elements
  (although the underlying data contained in buffers remains).
 
- All index references in j2's elements are updated based on the number of
- indices already used by j1.
-
  @pre Both j1 and j2 indicate version 2.0 glTF files. */
-void MergeGltf(nlohmann::json* j1, nlohmann::json&& j2);
+void MergeGltf(nlohmann::json* j1, nlohmann::json&& j2,
+               const std::filesystem::path& j2_path, MergeRecord* record);
 
 }  // namespace internal
 }  // namespace render_gltf_client

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.h
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.h
@@ -117,6 +117,8 @@ class DRAKE_NO_EXPORT RenderEngineGltfClient
   std::unique_ptr<RenderClient> render_client_;
 
   struct GltfRecord {
+    // The path for the .gltf file.
+    std::filesystem::path path;
     // The contents of a glTF file registered as Mesh or Convex.
     nlohmann::json contents;
     // The root nodes of the gltf file represented as a mapping from the node's

--- a/geometry/render_gltf_client/test/internal_merge_gltf_test.cc
+++ b/geometry/render_gltf_client/test/internal_merge_gltf_test.cc
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <functional>
 #include <ostream>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -12,6 +13,7 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace drake {
 namespace geometry {
@@ -27,7 +29,7 @@ using std::vector;
 // 4x4 matrix and make sure that translating in and out of json is idempotent.
 GTEST_TEST(GltfMergeTest, JsonEigenConversion) {
   Matrix4<double> M;
-  M << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16;
+  M << 1.1, 2, 3.5, 4, 5, 6, 7, 8, 9.8, 10, 11, 12, 13, 14, 15, 16;
   const json M_json = GltfMatrixFromEigenMatrix(M);
   const Matrix4<double> M_return = EigenMatrixFromGltfMatrix(M_json);
   EXPECT_TRUE(CompareMatrices(M_return, M));
@@ -37,8 +39,16 @@ using MergeFunction = std::function<void(json*, json&&)>;
 
 /* Specification of a test case. Because each function under test is responsible
  for merging a particular array, each test case examines only the targeted
- array (see array_name). */
+ array (see array_name).
+
+ To make the test case instantiation more compact, we write json using ' instead
+ of ". This allows us to use simple string literals: "'key':'value'" instead of
+ raw literals: ""key":"value"". The single quotes are swapped for double
+ quotes in the Evaluate() test function. This applies to `target`, `source`, and
+ `expected`. */
 struct MergeCase {
+  /* A description of what is being tested -- displayed for test failure. */
+  string description;
   /* A string representation of the json for a glTF file. This glTF will be
    modified. */
   string target;
@@ -49,8 +59,6 @@ struct MergeCase {
   string array_name;
   /* A string representation of the expected json produced by merging. */
   string expected;
-  /* A description of what is being tested -- displayed for test failure. */
-  string description;
   /* The merge function that should be called. */
   MergeFunction merge{};
 
@@ -60,15 +68,6 @@ struct MergeCase {
     return out;
   }
 };
-
-/* Evaluates a test case, confirming the merged result is as expected. */
-void Evaluate(const MergeCase& test_case) {
-  json target = json::parse(test_case.target);
-  json source = json::parse(test_case.source);
-  test_case.merge(&target, std::move(source));
-  const json expected = json::parse(test_case.expected);
-  EXPECT_EQ(target[test_case.array_name], expected) << test_case;
-}
 
 /* The test harness for the various merge functions. This includes families of
  static functions that generate test cases.
@@ -114,47 +113,49 @@ class MergeTest : public testing::TestWithParam<MergeCase> {
                         MergeFunction merge) {
     DRAKE_DEMAND(cases != nullptr);
     cases->push_back(
-        {.target = fmt::format(R"""({{"{}":[10, 20], "{}":[0, 1]}})""", array,
-                               independent),
-         .source = fmt::format(R"""({{"{0}":[{{"{1}":10}}, {{"{1}":20}}]}})""",
-                               array, index),
-         .array_name = array,
-         .expected =
-             fmt::format(R"""([10, 20, {{"{0}":12}}, {{"{0}":22}}])""", index),
-         .description = fmt::format(
+        {.description = fmt::format(
              "The {} {} indices get bumped - array in both.", array, index),
+         .target =
+             fmt::format("{{'{}':[10, 20], '{}':[0, 1]}}", array, independent),
+         .source = fmt::format("{{'{0}':[{{'{1}':10}}, {{'{1}':20}}]}}", array,
+                               index),
+         .array_name = array,
+         .expected = fmt::format("[10, 20, {{'{0}':12}}, {{'{0}':22}}]", index),
          .merge = merge});
     cases->push_back(
-        {.target = fmt::format(R"""({{"{}":[10, 20], "{}":[0, 1]}})""", array,
-                               independent),
+        {.description = fmt::format(
+             "The {} {} indices get bumped - array in target.", array, index),
+         .target =
+             fmt::format("{{'{}':[10, 20], '{}':[0, 1]}}", array, independent),
          .source = "{}",
          .array_name = array,
          .expected = "[10, 20]",
-         .description = fmt::format(
-             "The {} {} indices get bumped - array in target.", array, index),
          .merge = merge});
     cases->push_back(
-        {.target = fmt::format(R"""({{"{}":[0, 1]}})""", independent),
-         .source = fmt::format(R"""({{"{0}":[{{"{1}":10}}, {{"{1}":20}}]}})""",
-                               array, index),
-         .array_name = array,
-         .expected = fmt::format(R"""([{{"{0}":12}}, {{"{0}":22}}])""", index),
-         .description = fmt::format(
+        {.description = fmt::format(
              "The {} {} indices get bumped - array in source.", array, index),
+         .target = fmt::format("{{'{}':[0, 1]}}", independent),
+         .source = fmt::format("{{'{0}':[{{'{1}':10}}, {{'{1}':20}}]}}", array,
+                               index),
+         .array_name = array,
+         .expected = fmt::format("[{{'{0}':12}}, {{'{0}':22}}]", index),
          .merge = merge});
     cases->push_back(
-        {.target = fmt::format(R"""({{"{}":[0, 1]}})""", independent),
+        {.description = fmt::format(
+             "The {} {} indices get bumped - array in neither.", array, index),
+         .target = fmt::format("{{'{}':[0, 1]}}", independent),
          .source = "{}",
          .array_name = array,
          .expected = "null",
-         .description = fmt::format(
-             "The {} {} indices get bumped - array in neither.", array, index),
          .merge = merge});
   }
 
   /* Creates a test case where the elements of the array in question are copied
    verbatim. We don't inspect or modify the contents in any way. So, we put some
    unique garbage into the arrays to confirm that the dut really doesn't care.
+   Note: passing this test implies that esoteric tags like "extensions" or
+   "extras" will propagate through for those entities that simply get appended
+   to arrays instead of getting merged together.
 
    We make sure that the source array has multiple elements to confirm that
    we iterate through its contents.
@@ -177,104 +178,263 @@ class MergeTest : public testing::TestWithParam<MergeCase> {
                            MergeFunction merge) {
     DRAKE_DEMAND(cases != nullptr);
     cases->push_back(
-        {.target = fmt::format("{{\"{}\":[0, 1]}}", array),
+        {.description = fmt::format(
+             "The {} array contents copied verbatim - array in both.", array),
+         .target = fmt::format("{{'{}':[0, 1]}}", array),
          .source = fmt::format(
-             R"""({{"{}":[{{"one":1}},
-                       {{"two":{{"arabic":2, "roman":"II"}}}}]}})""",
+             "{{'{}':[{{'one':1}}, {{'two':{{'arabic':2, 'roman':'II'}}}}]}}",
              array),
          .array_name = array,
-         .expected = R"""([0, 1, {"one":1},
-                           {"two":{"arabic":2, "roman":"II"}}])""",
-         .description = fmt::format(
-             "The {} array contents copied verbatim - array in both.", array),
+         .expected = "[0, 1, {'one':1}, {'two':{'arabic':2, 'roman':'II'}}]",
          .merge = merge});
     cases->push_back(
-        {.target = fmt::format("{{\"{}\":[0, 1]}}", array),
+        {.description = fmt::format(
+             "The {} array contents copied verbatim - array in target.", array),
+         .target = fmt::format("{{'{}':[0, 1]}}", array),
          .source = "{}",
          .array_name = array,
          .expected = "[0, 1]",
-         .description = fmt::format(
-             "The {} array contents copied verbatim - array in target.", array),
          .merge = merge});
     cases->push_back(
-        {.target = "{}",
+        {.description = fmt::format(
+             "The {} array contents copied verbatim - array in source.", array),
+         .target = "{}",
          .source = fmt::format(
-             R"""({{"{}":[{{"one":1}},
-                          {{"two":{{"arabic":2, "roman":"II"}}}}]}})""",
+             "{{'{}':[{{'one':1}}, {{'two':{{'arabic':2, 'roman':'II'}}}}]}}",
              array),
          .array_name = array,
-         .expected = R"""([{"one":1}, {"two":{"arabic":2, "roman":"II"}}])""",
-         .description = fmt::format(
-             "The {} array contents copied verbatim - array in source.", array),
+         .expected = "[{'one':1}, {'two':{'arabic':2, 'roman':'II'}}]",
          .merge = merge});
     cases->push_back(
-        {.target = "{}",
+        {.description = fmt::format(
+             "The {} array contents copied verbatim - array in neither.",
+             array),
+         .target = "{}",
          .source = "{}",
          .array_name = array,
          .expected = "null",
-         .description = fmt::format(
-             "The {} array contents copied verbatim - array in neither.",
-             array),
          .merge = merge});
   }
 
-  static vector<MergeCase> MergeScenesCases() {
-    /* Merging scenes does extra work. A scene in the source may simply be
-     concatenated to the target's "scenes" array (with the scene's node indices
-     bumped appropriately). But where the two glTF files have scenes with
-     matching names, those scenes get merged. The merging logic requires a
-     bespoke test.
+  static vector<MergeCase> MergeExtensionsAndExtrasCases() {
+    /* Drake attempts to merge sets of "extensions" and "extras" blobs in only
+     three cases: the root glTF file, the assets, and scenes that get merged.
+     These test cases primarily use the root glTF to test the merging logic but
+     also include a few token tests to confirm that the logic is applied to the
+     extensions and extras in "asset". The scene merging is handled in the scene
+     test.
 
-     We can't use the test case APIs to test bumping node indices because the
-     nodes are not direct children of a "scene" element. */
-
-    MergeFunction merge = MergeScenes;
+     Failure to merge is handled in its own test harness (MergeFailureTest). */
+    auto merge = [](json* j1, json&& j2) {
+      MergeRecord record("test_target");
+      MergeGltf(j1, std::move(j2), "test_source", &record);
+    };
+    // Note: "asset" must exist for MergeGltf to work.
+    const string asset_prefix = "{'asset':{'version':'2.0'}";
     return vector<MergeCase>{
-        {.target = R"""({"scenes":[{"name":"Scene", "nodes":[0],
-                                    "extras":{"v":2}}],
-                         "nodes":[0]})""",
+        // Successful merges on extensions.
+        {.description = "Target only extensions are preserved",
+         .target = asset_prefix + ", 'extensions':{'one':1}}",
+         .source = asset_prefix + "}",
+         .array_name = "extensions",
+         .expected = "{'one':1}",
+         .merge = merge},
+        {.description = "Source only extensions are preserved",
+         .target = asset_prefix + "}",
+         .source = asset_prefix + ", 'extensions':{'one':1}}",
+         .array_name = "extensions",
+         .expected = "{'one':1}",
+         .merge = merge},
+        {.description = "Non-colliding data merges",
+         .target = asset_prefix + ", 'extensions':{'two':2}}",
+         .source = asset_prefix + ", 'extensions':{'one':1}}",
+         .array_name = "extensions",
+         .expected = "{'one':1, 'two':2}",
+         .merge = merge},
+        {.description = "Target has no extensions, source is non-object",
+         .target = asset_prefix + "}",
+         .source = asset_prefix + ", 'extensions':2}",
+         .array_name = "extensions",
+         .expected = "2",
+         .merge = merge},
+        {.description = "Source has non-object extensions, target has none",
+         .target = asset_prefix + ", 'extensions':1}",
+         .source = asset_prefix + "}",
+         .array_name = "extensions",
+         .expected = "1",
+         .merge = merge},
+        {.description = "Source and object have shallow, non-colliding "
+                        "duplications in extensions",
+         .target = asset_prefix + ", 'extensions':{'one':1}}",
+         .source = asset_prefix + ", 'extensions':{'one':1, 'two':2}}",
+         .array_name = "extensions",
+         .expected = "{'one':1, 'two':2}",
+         .merge = merge},
+        {.description = "Source and object have deep, non-colliding "
+                        "duplications in extensions",
+         .target = asset_prefix + ", 'extensions':{'one':{'a':1}}}",
+         .source = asset_prefix + ", 'extensions':{'one':{'a':1}, 'b':2}}",
+         .array_name = "extensions",
+         .expected = "{'one':{'a':1}, 'b':2}",
+         .merge = merge},
+        // Evidence that extras are being merged; complex successful and
+        // unsuccessful case.
+        {.description = "glTFs have deep, non-colliding duplications in extras",
+         .target = asset_prefix + ", 'extras':{'one':{'a':1}}}",
+         .source = asset_prefix + ", 'extras':{'one':{'a':1}, 'b':2}}",
+         .array_name = "extras",
+         .expected = "{'one':{'a':1}, 'b':2}",
+         .merge = merge},
+        // Evidence that extras and extensions are being merged in "assets".
+        {.description =
+             "glTFs have deep, non-colliding duplications in assets[extras]",
+         .target = "{'asset':{'version':'2.0', 'extras':{'one':{'a':1}}}}",
+         .source =
+             "{'asset':{'version':'2.0', 'extras':{'one':{'a':1}, 'b':2}}}",
+         .array_name = "asset",
+         .expected = "{'generator':'Drake glTF merger', 'version':'2.0', "
+                     "'extras':{'one':{'a':1}, 'b':2}}",
+         .merge = merge},
+        {.description = "glTFs have deep, non-colliding duplications in "
+                        "assets[extensions]",
+         .target = "{'asset':{'version':'2.0', 'extensions':{'one':{'a':1}}}}",
+         .source =
+             "{'asset':{'version':'2.0', 'extensions':{'one':{'a':1}, 'b':2}}}",
+         .array_name = "asset",
+         .expected = "{'generator':'Drake glTF merger', 'version':'2.0', "
+                     "'extensions':{'one':{'a':1}, 'b':2}}",
+         .merge = merge},
+    };
+  }
+
+  static vector<MergeCase> MergeExtensionsDeclarationCases() {
+    /* Both the "extensionsUsed" and "extensionsRequired" arrays use the same
+     code. We'll rigorously test one of those arrays and then provide a token
+     test for the other to make sure it gets processed correctly. */
+    return vector<MergeCase>{
+        {.description = "Target only is passed through",
+         .target = "{'extensionsUsed':['A', 'B']}",
          .source = "{}",
+         .array_name = "extensionsUsed",
+         .expected = "['A', 'B']",
+         .merge = MergeExtensionsUsed},
+        {.description = "Source only is preserved",
+         .target = "{}",
+         .source = "{'extensionsUsed':['A', 'B']}",
+         .array_name = "extensionsUsed",
+         .expected = "['A', 'B']",
+         .merge = MergeExtensionsUsed},
+        {.description = "Source and target are merged without duplication",
+         .target = "{'extensionsUsed':['A', 'B']}",
+         .source = "{'extensionsUsed':['C', 'B', 'D']}",
+         .array_name = "extensionsUsed",
+         .expected = "['A', 'B', 'C', 'D']",
+         .merge = MergeExtensionsUsed},
+        {.description = "Source and target are merged without duplication - "
+                        "extensionsRequired",
+         .target = "{'extensionsRequired':['B', 'A']}",
+         .source = "{'extensionsRequired':['C', 'B', 'D']}",
+         .array_name = "extensionsRequired",
+         .expected = "['B', 'A', 'C', 'D']",
+         .merge = MergeExtensionsRequired},
+    };
+  }
+
+  static vector<MergeCase> MergeScenesCases() {
+    /* In merging scenes, we need to test the following aspects:
+       - only default scenes get merged
+         - both explicit declaration and default definition of "default".
+       - When merging the target nodes get appended to the source node with
+         offset values.
+       - Extras and extensions get merged (where appropriate). Cases where
+         merging fails uses the MergeFailureTest infrastructure.
+    */
+    MergeFunction merge = [](json* j1, json&& j2) {
+      MergeRecord record("test_target");
+      MergeDefaultScenes(j1, std::move(j2), "test_source", &record);
+    };
+    return vector<MergeCase>{
+        // Cases that cover respect for the default scene *and* confirm that
+        // merged nodes get appended and offset appropriately.
+        //
+        // Recognizing that the "right" source scene got merged is a bit
+        // subtle. Below, we have source scenes S0 and S1 which reference source
+        // nodes 0 and 1, respectively. Both of those nodes get merged, changing
+        // their indices to 2 and 3. So, if the expected scene has node 2, it
+        // means we merged S0. If it has index 3, we merged S1.
+        //
+        // When we become more strategic about what assets get merged, we'll
+        // have to be equally more strategic in detecting success (i.e., by
+        // giving the nodes unique names and confirming the nodes we've merged
+        // have the expected names).
+        {.description = "Target and source default scenes inferred as zero.",
+         .target = "{'scenes':[{'name':'T0', 'nodes':[0]}, "
+                   "           {'name':'T1', 'nodes':[1]}], "
+                   "'nodes':[0, 1]}",  // We need nodes in target to get offset.
+         .source = "{'scenes':[{'name':'S0', 'nodes':[0]}, "
+                   "           {'name':'S1', 'nodes':[1]}]}",
          .array_name = "scenes",
-         .expected = R"""([{"name":"Scene", "nodes":[0], "extras":{"v":2}}])""",
-         .description = "Only target has scenes.",
+         .expected = "[{'name':'T0', 'nodes':[0, 2]}, "
+                     " {'name':'T1', 'nodes':[1]}]",
          .merge = merge},
-        {.target = R"""({"nodes":[0,1]})""",
-         .source = R"""({"scenes":[{"name":"Scene", "nodes":[0],
-                                    "extras":{"v":1}}]})""",
+        {.description = "Target and source default scenes explicitly zero.",
+         .target = "{'scenes':[{'name':'T0', 'nodes':[0]}, "
+                   "           {'name':'T1', 'nodes':[1]}], "
+                   "'scene':0, "
+                   "'nodes':[0, 1]}",  // We need nodes in target to get offset.
+         .source = "{'scenes':[{'name':'S0', 'nodes':[0]}, "
+                   "           {'name':'S1', 'nodes':[1]}], "
+                   "'scene':0}",
          .array_name = "scenes",
-         .expected = R"""([{"name":"Scene", "nodes":[2], "extras":{"v":1}}])""",
-         .description = "Only source has scenes, nodes in both.",
+         .expected = "[{'name':'T0', 'nodes':[0, 2]}, "
+                     " {'name':'T1', 'nodes':[1]}]",
          .merge = merge},
-        {.target = R"""({"scenes":[{"name":"Scene", "nodes":[0]}],
-                         "nodes":[0, 1]})""",
-         .source = R"""({"scenes":[{"name":"Scene", "nodes":[0]}],
-                         "nodes":[0]})""",
+        {.description = "Target scene is 0, source is non-zero.",
+         .target = "{'scenes':[{'name':'T0', 'nodes':[0]}, "
+                   "           {'name':'T1', 'nodes':[1]}], "
+                   "'scene':0, "
+                   "'nodes':[0, 1]}",  // We need nodes in target to get offset.
+         .source = "{'scenes':[{'name':'S0', 'nodes':[0]}, "
+                   "           {'name':'S1', 'nodes':[1]}], "
+                   "'scene':1}",
          .array_name = "scenes",
-         .expected = R"""([{"name":"Scene", "nodes":[0, 2]}])""",
-         .description = "Scene names match.",
+         .expected = "[{'name':'T0', 'nodes':[0, 3]}, "
+                     " {'name':'T1', 'nodes':[1]}]",
          .merge = merge},
-        {.target = R"""({"scenes":[{"name":"SceneA", "nodes":[0]}],
-                         "nodes":[0, 1]})""",
-         .source = R"""({"scenes":[{"name":"SceneB", "nodes":[0, 2]}],
-                         "nodes":[0,1,2]})""",
+        {.description = "Target scene is non-zero, source is zero.",
+         .target = "{'scenes':[{'name':'T0', 'nodes':[0]}, "
+                   "           {'name':'T1', 'nodes':[1]}], "
+                   "'scene':1, "
+                   "'nodes':[0, 1]}",  // We need nodes in target to get offset.
+         .source = "{'scenes':[{'name':'S0', 'nodes':[0]}, "
+                   "           {'name':'S1', 'nodes':[1]}], "
+                   "'scene':0}",
          .array_name = "scenes",
-         .expected = R"""([{"name":"SceneA", "nodes":[0]},
-                           {"name":"SceneB", "nodes":[2, 4]}])""",
-         .description = "Scene names don't match.",
+         .expected = "[{'name':'T0', 'nodes':[0]}, "
+                     " {'name':'T1', 'nodes':[1, 2]}]",
          .merge = merge},
-        {.target = R"""({"scenes":[{"nodes":[0]}], "nodes":[0, 1]})""",
-         .source = R"""({"scenes":[{"nodes":[0, 2]}], "nodes":[0, 1, 2]})""",
+        // Successful merging of extensions and extras.
+        {.description = "Merged scenes with non-colliding extras merge.",
+         .target = "{'scenes':[{'name':'S0', 'nodes':[0], "
+                   "            'extras':{'one':{'a':1}}}],"
+                   " 'nodes':[0, 1]}",
+         .source = "{'scenes':[{'name':'T0', 'nodes':[0], "
+                   "            'extras':{'v':1}}], "
+                   " 'nodes':[0]}",
          .array_name = "scenes",
-         .expected = R"""([{"nodes":[0]}, {"nodes":[2, 4]}])""",
-         .description = "Scenes with no names are both present.",
+         .expected = "[{'name':'S0', 'nodes':[0, 2], "
+                     "  'extras':{'v':1, 'one':{'a':1}}}]",
          .merge = merge},
-        {.target = R"""({"scenes":[{"name":"Scene", "nodes":[0]}],
-                         "nodes":[0, 1]})""",
-         .source = R"""({"scenes":[{"name":"Scene", "nodes":[0], 
-                                    "extras":{"v":1}}], "nodes":[0]})""",
+        {.description = "Merged scenes with non-colliding extensions merge.",
+         .target = "{'scenes':[{'name':'S0', 'nodes':[0], "
+                   "            'extensions':{'one':{'a':1}}}], "
+                   " 'nodes':[0, 1]}",
+         .source = "{'scenes':[{'name':'T0', 'nodes':[0], "
+                   "            'extensions':{'v':1}}], "
+                   " 'nodes':[0]}",
          .array_name = "scenes",
-         .expected = R"""([{"name":"Scene", "nodes":[0, 2]}])""",
-         .description = "Merged scenes lose extras.",
+         .expected = "[{'name':'S0', 'nodes':[0, 2], "
+                     "  'extensions':{'v':1, 'one':{'a':1}}}]",
          .merge = merge},
     };
   }
@@ -287,21 +447,19 @@ class MergeTest : public testing::TestWithParam<MergeCase> {
 
      Furthermore, we explicitly confirm removal of the "skin" element. */
     vector<MergeCase> cases{
-        {.target = R"""({"nodes":[{"name":"A","children":[1]},
-                                  {"name":"B","mesh":0}],
-                         "meshes":[0, 1]})""",
-         .source = R"""({"nodes":[{"name":"C","children":[0, 1]},
-                                  {"name":"D"}]})""",
+        {.description = "Nodes in target cause children in 2 to offset.",
+         .target = "{'nodes':[{'name':'A','children':[1]}, "
+                   "{'name':'B','mesh':0}], 'meshes':[0, 1]}",
+         .source = "{'nodes':[{'name':'C','children':[0, 1]}, {'name':'D'}]}",
          .array_name = "nodes",
-         .expected = R"""([{"name":"A","children":[1]}, {"name":"B","mesh":0},
-                           {"name":"C","children":[2,3]}, {"name":"D"}])""",
-         .description = "Nodes in target cause children in 2 to offset.",
+         .expected = "[{'name':'A','children':[1]}, {'name':'B','mesh':0}, "
+                     "{'name':'C','children':[2,3]}, {'name':'D'}]",
          .merge = merge},
-        {.target = "{}",
-         .source = R"""({"nodes":[{"name":"C","skin":1}]})""",
+        {.description = "Remove 'skin' child.",
+         .target = "{}",
+         .source = "{'nodes':[{'name':'C','skin':1}]}",
          .array_name = "nodes",
-         .expected = R"""([{"name":"C"}])""",
-         .description = R"""(Remove "skin" child.)""",
+         .expected = "[{'name':'C'}]",
          .merge = merge},
     };
 
@@ -322,54 +480,46 @@ class MergeTest : public testing::TestWithParam<MergeCase> {
          bumped.
      So, these test cases get spelled out explicitly. */
     vector<MergeCase> cases{
-        {.target = R"""({"materials":[0, 1]})""",
-         .source = R"""({"meshes":[{"name":"A",
-                                    "primitives":[{"material":2}]}]})""",
+        {.description = "Material index gets bumped.",
+         .target = "{'materials':[0, 1]}",
+         .source = "{'meshes':[{'name':'A', 'primitives':[{'material':2}]}]}",
          .array_name = "meshes",
-         .expected = R"""([{"name":"A", "primitives":[{"material":4}]}])""",
-         .description = "Material index gets bumped.",
+         .expected = "[{'name':'A', 'primitives':[{'material':4}]}]",
          .merge = merge},
-        {.target = R"""({"accessors":[0, 1]})""",
-         .source = R"""({"meshes":[{"name":"A",
-                                    "primitives":[{"indices":2}]}]})""",
+        {.description = "Vertex accessor gets bumped.",
+         .target = "{'accessors':[0, 1]}",
+         .source = "{'meshes':[{'name':'A', 'primitives':[{'indices':2}]}]}",
          .array_name = "meshes",
-         .expected = R"""([{"name":"A", "primitives":[{"indices":4}]}])""",
-         .description = "Vertex accessor gets bumped.",
+         .expected = "[{'name':'A', 'primitives':[{'indices':4}]}]",
          .merge = merge},
-        {.target = R"""({"accessors":[0, 1]})""",
-         .source = R"""({"meshes":[{"name":"A",
-                                    "primitives":[
-                                       {"attributes":{"key1":1}},
-                                       {"attributes":{"key2":3, "key4":5}}
-                                     ]}]})""",
+        {.description = "Primitives attributes get bumped.",
+         .target = "{'accessors':[0, 1]}",
+         .source =
+             "{'meshes':[{'name':'A', 'primitives':[{'attributes':{'key1':1}}, "
+             "{'attributes':{'key2':3, 'key4':5}}]}]}",
          .array_name = "meshes",
-         .expected = R"""([{"name":"A",
-                            "primitives":[
-                               {"attributes":{"key1":3}},
-                               {"attributes":{"key2":5, "key4":7}}
-                             ]}])""",
-         .description = "Primitives attributes get bumped.",
+         .expected = "[{'name':'A', 'primitives':[{'attributes':{'key1':3}}, "
+                     "{'attributes':{'key2':5, 'key4':7}}]}]",
          .merge = merge},
-        {.target = R"""({"accessors":[0, 1]})""",
-         .source = R"""({"meshes":[{"primitives":[{"mode":17,
-                                                   "extras":{"v":2}}]}]})""",
+        {.description = "Non-index primitive fields propagate.",
+         .target = "{'accessors':[0, 1]}",
+         .source =
+             "{'meshes':[{'primitives':[{'mode':17, 'extras':{'v':2}}]}]}",
          .array_name = "meshes",
-         .expected = R"""([{"primitives":[{"mode":17,
-                                           "extras":{"v":2}}]}])""",
-         .description = "Non-index primitive fields propagate.",
+         .expected = "[{'primitives':[{'mode':17, 'extras':{'v':2}}]}]",
          .merge = merge},
-        {.target = R"""({})""",
-         .source = R"""({"meshes":[{"primitives":[{"mode":17,
-                                                   "targets":{"v":2}}]}]})""",
+        {.description = "Targets get removed from primitives.",
+         .target = "{}",
+         .source =
+             "{'meshes':[{'primitives':[{'mode':17, 'targets':{'v':2}}]}]}",
          .array_name = "meshes",
-         .expected = R"""([{"primitives":[{"mode":17}]}])""",
-         .description = "Targets get removed from primitives.",
+         .expected = "[{'primitives':[{'mode':17}]}]",
          .merge = merge},
-        {.target = R"""({"meshes":[{"name":"A"}]})""",
-         .source = R"""({"meshes":[{"name":"B", "weights":[0, 1]}]})""",
+        {.description = "Weights get stripped.",
+         .target = "{'meshes':[{'name':'A'}]}",
+         .source = "{'meshes':[{'name':'B', 'weights':[0, 1]}]}",
          .array_name = "meshes",
-         .expected = R"""([{"name":"A"}, {"name":"B"}])""",
-         .description = "Weights get stripped.",
+         .expected = "[{'name':'A'}, {'name':'B'}]",
          .merge = merge},
     };
     VerbatimCopy(&cases, "meshes", merge);
@@ -382,27 +532,21 @@ class MergeTest : public testing::TestWithParam<MergeCase> {
      indices to bump are not directly children of the "material" element. So,
      we test the bump logic directly. */
     vector<MergeCase> cases{
-        {.target = R"""({"textures":[0, 1]})""",
-         .source = R"""({"materials":[
-                           {"normalTexture":{"index":2},
-                            "occlusionTexture":{"index":3},
-                            "emissiveTexture":{"index":4},
-                            "pbrMetallicRoughness":{
-                              "baseColorTexture":{"index":5},
-                              "metallicRoughnessTexture":{"index":6}
-                            }},
-                           {"normalTexture":{"index":17}}
-                           ]})""",
+        {.description = "Texture indices get bumped on all materials.",
+         .target = "{'textures':[0, 1]}",
+         .source =
+             "{'materials':[{'normalTexture':{'index':2}, "
+             "'occlusionTexture':{'index':3}, 'emissiveTexture':{'index':4}, "
+             "'pbrMetallicRoughness':{'baseColorTexture':{'index':5}, "
+             "'metallicRoughnessTexture':{'index':6}}}, "
+             "{'normalTexture':{'index':17}}]}",
          .array_name = "materials",
-         .expected = R"""([{"normalTexture":{"index":4},
-                            "occlusionTexture":{"index":5},
-                            "emissiveTexture":{"index":6},
-                            "pbrMetallicRoughness":{
-                              "baseColorTexture":{"index":7},
-                              "metallicRoughnessTexture":{"index":8}
-                            }},
-                            {"normalTexture":{"index":19}}])""",
-         .description = "Texture indices get bumped on all materials.",
+         .expected =
+             "[{'normalTexture':{'index':4}, 'occlusionTexture':{'index':5}, "
+             "'emissiveTexture':{'index':6}, "
+             "'pbrMetallicRoughness':{'baseColorTexture':{'index':7}, "
+             "'metallicRoughnessTexture':{'index':8}}}, "
+             "{'normalTexture':{'index':19}}]",
          .merge = merge},
     };
     VerbatimCopy(&cases, "materials", merge);
@@ -458,9 +602,23 @@ class MergeTest : public testing::TestWithParam<MergeCase> {
 };
 
 TEST_P(MergeTest, Evaluate) {
-  Evaluate(GetParam());
+  const MergeCase& test_case = GetParam();
+  auto swap_quotes = [](const string& in) {
+    return std::regex_replace(in, std::regex("'"), string("\""));
+  };
+  json target = json::parse(swap_quotes(test_case.target));
+  json source = json::parse(swap_quotes(test_case.source));
+  test_case.merge(&target, std::move(source));
+  const json expected = json::parse(swap_quotes(test_case.expected));
+  EXPECT_EQ(target[test_case.array_name], expected) << test_case;
 }
 
+INSTANTIATE_TEST_SUITE_P(
+    ExtensionsAndExtras, MergeTest,
+    testing::ValuesIn(MergeTest::MergeExtensionsAndExtrasCases()));
+INSTANTIATE_TEST_SUITE_P(
+    ExtensionDeclarations, MergeTest,
+    testing::ValuesIn(MergeTest::MergeExtensionsDeclarationCases()));
 INSTANTIATE_TEST_SUITE_P(Scenes, MergeTest,
                          testing::ValuesIn(MergeTest::MergeScenesCases()));
 INSTANTIATE_TEST_SUITE_P(Nodes, MergeTest,
@@ -484,6 +642,177 @@ INSTANTIATE_TEST_SUITE_P(Images, MergeTest,
 INSTANTIATE_TEST_SUITE_P(Samplers, MergeTest,
                          testing::ValuesIn(MergeTest::MergeSamplersCases()));
 
+/* Specification of a failure test case. Merging only fails if there is a
+ collision in merging "extras" or "extensions" in the glTF, "Scene", or "asset"
+ elements. These test cases are simpler.
+
+ To make the test case instantiation more compact, we write json using ' instead
+ of ". This allows us to use simple string literals: "'key':'value'" instead of
+ raw literals: ""key":"value"". The single quotes are swapped for double
+ quotes in the Evaluate() test function. This applies to `target`, `source`, and
+ `expected`. */
+struct MergeFailureCase {
+  /* A description of what is being tested -- displayed for test failure. */
+  string description;
+  /* A string representation of the json for a glTF file. This glTF will be
+   modified. */
+  string target;
+  /* A string representation of the json for a glTF file. This glTF will be
+   merged into target. */
+  string source;
+  /* A regular expression string to match against the expected exception
+   message. */
+  string expected_error;
+  /* The merge function that should be called. */
+  std::function<void(json*, json&&, const string&, MergeRecord*)> merge{};
+
+  friend std::ostream& operator<<(std::ostream& out,
+                                  const MergeFailureCase& merge_case) {
+    out << merge_case.description;
+    return out;
+  }
+};
+
+/* The test harness for the merge failure due to collisions in "extras" or
+ "extensions". This includes families of static functions that generate test
+ cases. See MergeTest documentation for further elaboration on testing strategy.
+ */
+class MergeFailureTest : public testing::TestWithParam<MergeFailureCase> {
+ public:
+  /* The minutiae of the collision logic are tested through these test cases.
+   Specifically, we test it via the "extensions" blob. We'll provide a token
+   test for "extras" for evidence that it is calling the same API.
+
+   Token tests are likewise provided in their own groups for merging scenes
+   and assets. Just enough test to show that it's exercising the same API. */
+  static vector<MergeFailureCase> MergeGltfCases() {
+    /* Note: "asset" must exist for MergeGltf to work (note the fact that we
+     have ended with the closing bracket; so extensions and extras are
+     *siblings* of "asset", and children of glTF). */
+    const string asset_prefix = "{'asset':{'version':'2.0'}";
+    return vector<MergeFailureCase>{
+        // Robust tests on extensions.
+        {.description = "Target and source have non-object extensions",
+         .target = asset_prefix + ", 'extensions':1}",
+         .source = asset_prefix + ", 'extensions':2}",
+         .expected_error =
+             ".*glTF.extensions.*has a primitive.*has a primitive.",
+         .merge = MergeGltf},
+        {.description = "Target has primitive, source has object in extensions",
+         .target = asset_prefix + ", 'extensions':1}",
+         .source = asset_prefix + ", 'extensions':{'a':1}}",
+         .expected_error = ".*glTF.extensions.*has a primitive.*has an object.",
+         .merge = MergeGltf},
+        {.description = "Target has object, source has primitive in extensions",
+         .target = asset_prefix + ", 'extensions':{'b':2}}",
+         .source = asset_prefix + ", 'extensions':1}",
+         .expected_error = ".*glTF.extensions.*has an object.*has a primitive.",
+         .merge = MergeGltf},
+        {.description = "Shallow collision between extensions",
+         .target = asset_prefix + ", 'extensions':{'b':2}}",
+         .source = asset_prefix + ", 'extensions':{'b':3}}",
+         .expected_error =
+             ".*glTF.extensions.b.*defines it as 2.*defines it as 3.",
+         .merge = MergeGltf},
+        {.description = "Deep collision between extensions",
+         .target = asset_prefix + ", 'extensions':{'b':{'a':1}}}",
+         .source = asset_prefix + ", 'extensions':{'b':{'a':2}}}",
+         .expected_error = ".*glTF.extensions.b.*defines it as "
+                           ".\"a\":1.*defines it as .\"a\":2.*",
+         .merge = MergeGltf},
+        // Token test on extras.
+        {.description = "Deep collision between extras",
+         .target = asset_prefix + ", 'extras':{'b':{'a':1}}}",
+         .source = asset_prefix + ", 'extras':{'b':{'a':2}}}",
+         .expected_error = ".*glTF.extras.b.*defines it as "
+                           ".\"a\":1.*defines it as .\"a\":2.*",
+         .merge = MergeGltf},
+    };
+  }
+
+  /* Minimum set of tests to provide evidence that merging extensions/extras in
+   the "asset" element is using the same API as tested for merging glTF. */
+  static vector<MergeFailureCase> MergeAssetCases() {
+    /* Note: "asset" must exist for MergeGltf to work (note the fact that we
+     haven't provided the closing bracket; so extensions and extras are
+     *children* of "asset"). */
+    const string asset_prefix = "{'asset':{'version':'2.0'";
+    return vector<MergeFailureCase>{
+        {.description = "Deep collision between asset.extras",
+         .target = asset_prefix + ", 'extras':{'b':{'a':1}}}}",
+         .source = asset_prefix + ", 'extras':{'b':{'a':2}}}}",
+         .expected_error = ".*asset.extras.b.*defines it as "
+                           ".\"a\":1.*defines it as .\"a\":2.*",
+         .merge = MergeGltf},
+        {.description = "Deep collision between asset.extensions",
+         .target = asset_prefix + ", 'extensions':{'b':{'a':1}}}}",
+         .source = asset_prefix + ", 'extensions':{'b':{'a':2}}}}",
+         .expected_error = ".*asset.extensions.b.*defines it as "
+                           ".\"a\":1.*defines it as .\"a\":2.*",
+         .merge = MergeGltf},
+    };
+  }
+
+  /* Minimum set of tests to provide evidence that merging extensions/extras in
+   a Scene element is using the same API as tested for merging glTF. */
+  static vector<MergeFailureCase> MergeSceneCases() {
+    return vector<MergeFailureCase>{
+        {.description = "Merged scenes with colliding extras.",
+         .target = "{'scenes':[{'name':'T0', 'nodes':[0], "
+                   "            'extras':{'one':{'a':1}}}], "
+                   " 'nodes':[0, 1]}",
+         .source = "{'scenes':[{'name':'S0', 'nodes':[0], "
+                   "            'extras':{'one':2, 'v':1}}], "
+                   " 'nodes':[0]}",
+         .expected_error = ".*default_scene.extras.one.*defines it as "
+                           ".\"a\":1.*defines it as 2.*",
+         .merge = MergeDefaultScenes},
+        {.description = "Merged scenes with colliding extensions.",
+         .target = "{'scenes':[{'name':'T0', 'nodes':[0], "
+                   "            'extensions':{'one':{'a':1}}}], "
+                   " 'nodes':[0, 1]}",
+         .source = "{'scenes':[{'name':'S0', 'nodes':[0], "
+                   "            'extensions':{'one':2, 'v':1}}], "
+                   " 'nodes':[0]}",
+         .expected_error = ".*default_scene.extensions.one.*defines it as "
+                           ".\"a\":1.*defines it as 2.*",
+         .merge = MergeDefaultScenes},
+    };
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(Gltf, MergeFailureTest,
+                         testing::ValuesIn(MergeFailureTest::MergeGltfCases()));
+INSTANTIATE_TEST_SUITE_P(
+    Asset, MergeFailureTest,
+    testing::ValuesIn(MergeFailureTest::MergeAssetCases()));
+INSTANTIATE_TEST_SUITE_P(
+    Scene, MergeFailureTest,
+    testing::ValuesIn(MergeFailureTest::MergeSceneCases()));
+
+TEST_P(MergeFailureTest, Evaluate) {
+  const MergeFailureCase& test_case = GetParam();
+  auto swap_quotes = [](const string& in) {
+    return std::regex_replace(in, std::regex("'"), string("\""));
+  };
+  json target = json::parse(swap_quotes(test_case.target));
+  json source = json::parse(swap_quotes(test_case.source));
+  const string target_name = "target_name";
+  const string source_name = "source_name";
+  // Before merging source into target, we need to register all of the target
+  // extension/extra elements with the merge record. We'll merge it into a
+  // minimal glTF and let the merging functionality record the data for us. This
+  // will allow the subsequent collisions with source to be able to author
+  // the exceptions properly.
+  MergeRecord record("from empty");
+  json merged_target{{"asset", {{"version", "2.0"}}}};
+  test_case.merge(&merged_target, std::move(target), target_name, &record);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      test_case.merge(&merged_target, std::move(source), source_name, &record),
+      test_case.expected_error);
+}
+
 /* Simply call MergeGltf on real glTF files and makes sure it doesn't throw. */
 GTEST_TEST(MergeGltf, Smoke) {
   json target = ReadJsonFile(FindResourceOrThrow(
@@ -492,7 +821,9 @@ GTEST_TEST(MergeGltf, Smoke) {
   json source = ReadJsonFile(FindResourceOrThrow(
       "drake/geometry/render_gltf_client/test/textured_green_box.gltf"));
 
-  EXPECT_NO_THROW(MergeGltf(&target, std::move(source)));
+  MergeRecord record("test_target");
+  EXPECT_NO_THROW(
+      MergeGltf(&target, std::move(source), "test_source", &record));
 
   /* Save the merged glTF for inspection.
    bazel-testlogs/geometry/render_gltf_client/internal_merge_gltf_test/test.outputs/output.zip.


### PR DESCRIPTION
There are two significant behavioral changes -- that *could* affect a user. However, given the newness of the underlying code and the fact that this touches distant corners of glTF-dom, the odds that anyone *actually* gets affected is small.

Scene merging.
- Previously, all input scenes were included and scenes with the same name were merged. Now only default scenes are merged, regardless of names.

Extras and extensions are properly handled.
- We now include two root arrays that were previously skipped: "extensionsUsed" and "extensionsRequired". These are now merged (without duplicates). The previous omission of "extensionsUsed" and "extensionsRequired" wasn't *obviously* a defect before because some glTF parsers are more forgiving than others in terms of *applying* extensions without having declared them as "used" or "required". This simply shores up the hole to make the final glTF as compliant as the input glTFs.
 - When it is necessary to merge extras or extensions, if there is ambiguity, we throw an exception with enough information to help the users address the conflict in their data. If we had been previously consuming glTF files that met the error conditions, they will now start throwing. This is, however, highly unlikely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20184)
<!-- Reviewable:end -->
