### PR TITLE
HPolyhedron::FindRedundant() performance improved by using a single mathematical program

### DIFF
--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -622,7 +622,7 @@ std::set<int> HPolyhedron::FindRedundant(double tol) const {
     const auto result = Solve(prog);
     if ((result.is_success() && -result.get_optimal_cost() > b_[i] + tol) ||
         !result.is_success()) {
-      // bring back the constraint, it is not redundant
+      // Bring back the constraint, it is not redundant.
       prog.AddConstraint(bindings_vec.at(i));
     } else {
       redundant_indices.insert(i);


### PR DESCRIPTION
`FindRedundant` is used to detect the redundant hyperplanes in a `HPolyedron`. The current implementation is slow because at every iteration it builds a Mathematical Program object from scratch. @hongkai-dai actually had a ToDo comment to fix this. This PR is an implementation of it.

Some benchmarks with polytopes that I work with (_not_ included in the PR)

| # | n_original | n_new | time_new(ms) | n_old | time_old(ms) |
|---|-------------|--------|--------------|--------|--------------|
| 1 | 631         | 500    | 5261         | 500    | 16914        |
| 2 | 532         | 434    | 3565         | 434    | 11684        |
| 3 | 705         | 558    | 6459         | 558    | 20687        |
| 4 | 137         | 87     | 233          | 87     | 733          |
| 5 | 97          | 58     | 109          | 58     | 352          |

cc @rhjiang @AlexandreAmice as you are the expert on this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20188)
<!-- Reviewable:end -->
