### PR TITLE
 [tutorials] Remove unsupported matplotlib argument

### DIFF
--- a/tutorials/dynamical_systems.ipynb
+++ b/tutorials/dynamical_systems.ipynb
@@ -258,7 +258,7 @@
     "# Plot the results.\n",
     "log = logger.FindLog(simulator.get_context())\n",
     "plt.figure()\n",
-    "plt.stem(log.sample_times(), log.data().transpose(), use_line_collection=True)\n",
+    "plt.stem(log.sample_times(), log.data().transpose())\n",
     "plt.xlabel('n')\n",
     "plt.ylabel('y[n]');"
    ]


### PR DESCRIPTION
As of matplotlib 3.8.0, `stem(..., use_line_collection=False)` is no longer supported ([reference here](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html#stem-use-line-collection-false)).

On 9/15, Mac Unprovisioned Nightlies upgraded to Matplotlib 3.8.0 and the `//tutorials:py/dynamical_systems_test` began to fail as it is using the now unsupported argument:

- [mac-arm-monterey-unprovisioned-clang-bazel-nightly-release](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-arm-monterey-unprovisioned-clang-bazel-nightly-release/352/)
- [mac-arm-ventura-unprovisioned-clang-bazel-nightly-release](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-arm-ventura-unprovisioned-clang-bazel-nightly-release/124/)
- [mac-x86-monterey-unprovisioned-clang-bazel-nightly-release](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-x86-monterey-unprovisioned-clang-bazel-nightly-release/317/)

Per [slack discussion](https://drakedevelopers.slack.com/archives/C270MN28G/p1694782851961199), the argument can simply be removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20194)
<!-- Reviewable:end -->
