### PR TITLE
[controllers] Remove PidController's special Graphviz

### DIFF
--- a/systems/controllers/pid_controller.cc
+++ b/systems/controllers/pid_controller.cc
@@ -119,20 +119,6 @@ void PidController<T>::CalcControl(const Context<T>& context,
        (ki_.array() * state_vector.array()).matrix()));
 }
 
-// Adds a simple record-based representation of the PID controller to @p dot.
-template <typename T>
-void PidController<T>::GetGraphvizFragment(int max_depth,
-                                           std::stringstream* dot) const {
-  unused(max_depth);
-  std::string name = this->get_name();
-  if (name.empty()) {
-    name = "PID Controller";
-  }
-  *dot << this->GetGraphvizId() << " [shape=record, label=\"" << name;
-  *dot << " | { {<u0> x |<u1> x_d} |<y0> y}";
-  *dot << "\"];" << std::endl;
-}
-
 }  // namespace controllers
 }  // namespace systems
 }  // namespace drake

--- a/systems/controllers/pid_controller.h
+++ b/systems/controllers/pid_controller.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <sstream>
 #include <stdexcept>
 
 #include "drake/common/drake_copyable.h"
@@ -182,14 +181,6 @@ class PidController : public LeafSystem<T>,
   }
 
  protected:
-  /**
-   * Appends to @p dot a simplified Graphviz representation of the PID
-   * controller, since the internal wiring is unimportant and hard for human
-   * viewers to parse.
-   */
-  void GetGraphvizFragment(int max_depth,
-                           std::stringstream* dot) const override;
-
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const override;
 

--- a/systems/controllers/test/pid_controller_test.cc
+++ b/systems/controllers/test/pid_controller_test.cc
@@ -106,14 +106,6 @@ TEST_F(PidControllerTest, GetterVectorKd) {
   EXPECT_THROW(controller.get_Kd_singleton(), std::runtime_error);
 }
 
-TEST_F(PidControllerTest, Graphviz) {
-  const std::string dot = controller_.GetGraphvizString();
-  EXPECT_NE(
-      std::string::npos,
-      dot.find("label=\"PID Controller | { {<u0> x |<u1> x_d} |<y0> y}\""))
-      << dot;
-}
-
 // Evaluates the output and asserts correctness.
 TEST_F(PidControllerTest, CalcOutput) {
   ASSERT_NE(nullptr, context_);


### PR DESCRIPTION
The custom code was useful when PidController used to be a Diagram, but when it was refactored to be a LeafSystem in #6326 we forgot to undo it. As we improve our default Graphviz output for systems, the custom code becomes actively harmful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20196)
<!-- Reviewable:end -->
