### PR TITLE
[hardware_sim] Add option to output Graphviz

### DIFF
--- a/examples/hardware_sim/BUILD.bazel
+++ b/examples/hardware_sim/BUILD.bazel
@@ -102,7 +102,7 @@ drake_py_unittest(
         "test/test_scenarios.yaml",
         ":demo_cc",
     ],
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         ":hardware_sim_test_common",
     ],
@@ -144,7 +144,7 @@ drake_py_unittest(
     env = {
         "_DRAKE_DEPRECATION_IS_ERROR": "1",
     },
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         ":hardware_sim_test_common",
     ],

--- a/examples/hardware_sim/hardware_sim.cc
+++ b/examples/hardware_sim/hardware_sim.cc
@@ -15,6 +15,8 @@ the robot, without extra hassle.
 
 Drake maintainers should keep this file in sync with hardware_sim.py. */
 
+#include <fstream>
+
 #include <gflags/gflags.h>
 
 #include "drake/common/unused.h"
@@ -43,6 +45,9 @@ DEFINE_string(scenario_name, "",
 DEFINE_string(scenario_text, "{}",
     "Additional YAML scenario text to load, in order to override values "
     "in the scenario_file, e.g., timeouts");
+DEFINE_string(graphviz, "",
+    "Dump the Simulator's Diagram to this file in Graphviz format as a "
+    "debugging aid");
 
 namespace drake {
 namespace {
@@ -72,6 +77,9 @@ class Simulation {
 
   /* Runs the main loop of the simulation until completion criteria are met. */
   void Simulate();
+
+  /* Provides read-only access to the diagram. */
+  const Diagram<double>& diagram() { return *diagram_; }
 
  private:
   // The scenario passed into the ctor.
@@ -131,6 +139,11 @@ int main() {
       FLAGS_scenario_file, FLAGS_scenario_name, FLAGS_scenario_text);
   Simulation sim(scenario);
   sim.Setup();
+  if (!FLAGS_graphviz.empty()) {
+    std::ofstream out(FLAGS_graphviz);
+    out << sim.diagram().GetGraphvizString();
+    DRAKE_THROW_UNLESS(out.good());
+  }
   sim.Simulate();
   return 0;
 }

--- a/examples/hardware_sim/hardware_sim.py
+++ b/examples/hardware_sim/hardware_sim.py
@@ -123,7 +123,7 @@ def _load_scenario(*, filename, scenario_name, scenario_text):
     return result
 
 
-def run(*, scenario):
+def run(*, scenario, graphviz=None):
     """Runs a simulation of the given scenario.
     """
     builder = DiagramBuilder()
@@ -174,6 +174,11 @@ def run(*, scenario):
     random = RandomGenerator(scenario.random_seed)
     diagram.SetRandomContext(simulator.get_mutable_context(), random)
 
+    # Visualize the diagram, when requested.
+    if graphviz is not None:
+        with open(graphviz, "w", encoding="utf-8") as f:
+            f.write(diagram.GetGraphvizString())
+
     # Simulate.
     simulator.AdvanceTo(scenario.simulation_duration)
 
@@ -193,12 +198,16 @@ def main():
         "--scenario_text", default="{}",
         help="Additional YAML scenario text to load, in order to override "
              "values in the scenario_file, e.g., timeouts")
+    parser.add_argument(
+        "--graphviz", metavar="FILENAME",
+        help="Dump the Simulator's Diagram to this file in Graphviz format "
+             "as a debugging aid")
     args = parser.parse_args()
     scenario = _load_scenario(
         filename=args.scenario_file,
         scenario_name=args.scenario_name,
         scenario_text=args.scenario_text)
-    run(scenario=scenario)
+    run(scenario=scenario, graphviz=args.graphviz)
 
 
 if __name__ == "__main__":

--- a/examples/hardware_sim/test/hardware_sim_test_common.py
+++ b/examples/hardware_sim/test/hardware_sim_test_common.py
@@ -51,7 +51,7 @@ class HardwareSimTest:
         result = re.sub(r"  *", " ", result)
         return result
 
-    def _run(self, scenario_file, scenario_name, extra=None):
+    def _run(self, scenario_file, scenario_name, extra=None, graphviz=None):
         """Runs the given scenario for 1 second, checking that it does not
         crash. Allows overriding scenario options using the optional `extra`
         dictionary"""
@@ -64,6 +64,8 @@ class HardwareSimTest:
             f"--scenario_name={scenario_name}",
             f"--scenario_text={scenario_text}",
         ]
+        if graphviz is not None:
+            args.append(f"--graphviz={graphviz}")
         printable_args = " ".join([
             shlex.quote(re.sub(r"[^=]*\.runfiles/", "", x))
             for x in args
@@ -82,3 +84,9 @@ class HardwareSimTest:
     def test_Demo(self):
         """Tests the Demo example."""
         self._run(self._example_scenarios, "Demo")
+
+    def test_graphviz(self):
+        out_file = f"{os.environ['TEST_TMPDIR']}/graph.dot"
+        self.assertFalse(os.path.exists(out_file))
+        self._run(self._test_scenarios, "Defaults", graphviz=out_file)
+        self.assertTrue(os.path.exists(out_file))


### PR DESCRIPTION
In support of #20182, and also other future work to improve our Graphviz output.

For example:

```
bazel run //examples/hardware_sim:demo_cc -- \
  --scenario_text='{simulation_duration: 0}' \
  --graphviz=$(pwd)/example.dot &&
  dot -Tpng example.dot > example.png
```

![image](https://github.com/RobotLocomotion/drake/assets/17596505/357f84ee-ae23-4880-9cc1-364ea09c3694)

I looked into adding some text to the `README.md` to demonstrate this option, but it seemed like it might be more confusing than helpful.  If anything, I want to make our graphviz output better before we advertise this too much.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20198)
<!-- Reviewable:end -->
