### PR TITLE
Use bullet point rather than number list in MosekSolver doxygen.

### DIFF
--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -60,7 +60,9 @@ struct MosekSolverDetails {
  * parameters in
  * https://docs.mosek.com/10.0/capi/param-groups.html#doc-param-groups. On top
  * of these parameters, we also provide the following additional parameters
- * 1. "writedata", set to a file name so that MOSEK™ solver will write the
+ *
+ * - "writedata"
+ *    set to a file name so that MOSEK™ solver will write the
  *    optimization model to this file. check
  *    https://docs.mosek.com/10.0/capi/solver-io.html#saving-a-problem-to-a-file
  *    for more details. The supported file extensions are listed in


### PR DESCRIPTION
The numbered list is ignored in pydrake doxygen.

Now the rendering looks like this in pydrake doc
![Screenshot from 2023-09-15 18-48-05](https://github.com/RobotLocomotion/drake/assets/6314000/6bef7ed2-2c6b-4a95-ab52-f095a458a17c)

and in C++ doxygen

![Screenshot from 2023-09-15 18-47-28](https://github.com/RobotLocomotion/drake/assets/6314000/2526d6be-a8e3-4210-98fd-28c617018b03)



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20199)
<!-- Reviewable:end -->
