### PR TITLE
[framework] Move GetMemoryObjectName to SystemBase

### DIFF
--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -1,8 +1,5 @@
 #include "drake/systems/framework/system.h"
 
-#include <iomanip>
-#include <ios>
-#include <regex>
 #include <set>
 #include <string_view>
 #include <vector>
@@ -723,28 +720,6 @@ System<T>::DoGetTargetSystemCompositeEventCollection(
     const CompositeEventCollection<T>* events) const {
   if (&target_system == this) return events;
   return nullptr;
-}
-
-template <typename T>
-std::string System<T>::GetMemoryObjectName() const {
-  using std::setfill;
-  using std::setw;
-  using std::hex;
-
-  // Remove the template parameter(s).
-  const std::string type_name_without_templates = std::regex_replace(
-      NiceTypeName::Get(*this), std::regex("<.*>$"), std::string());
-
-  // Replace "::" with "/" because ":" is System::GetSystemPathname's separator.
-  // TODO(sherm1) Change the separator to "/" and avoid this!
-  const std::string default_name = std::regex_replace(
-      type_name_without_templates, std::regex(":+"), std::string("/"));
-
-  // Append the address spelled like "@0123456789abcdef".
-  const int64_t address = GetGraphvizId();
-  std::ostringstream result;
-  result << default_name << '@' << setfill('0') << setw(16) << hex << address;
-  return result.str();
 }
 
 template <typename T>

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1070,14 +1070,8 @@ class System : public SystemBase {
   /** @name                      Utility methods */
   //@{
 
-  /** Returns a name for this %System based on a stringification of its type
-  name and memory address.  This is intended for use in diagnostic output
-  and should not be used for behavioral logic, because the stringification
-  of the type name may produce differing results across platforms and
-  because the address can vary from run to run. */
-  std::string GetMemoryObjectName() const;
-
-  // So we don't have to keep writing this->num_input_ports().
+  // Avoid `this->` boilerplate for these member functions.
+  using SystemBase::GetMemoryObjectName;
   using SystemBase::num_input_ports;
   using SystemBase::num_output_ports;
 

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <regex>
 #include <stdexcept>
 #include <unordered_set>
 
@@ -27,6 +28,21 @@ SystemBase::~SystemBase() {}
 
 internal::SystemId SystemBase::get_next_id() {
   return internal::SystemId::get_new_id();
+}
+
+std::string SystemBase::GetMemoryObjectName() const {
+  // Remove the template parameter(s).
+  const std::string type_name_without_templates = std::regex_replace(
+      NiceTypeName::Get(*this), std::regex("<.*>$"), std::string());
+
+  // Replace "::" with "/" because ":" is System::GetSystemPathname's separator.
+  // TODO(sherm1) Change the separator to "/" and avoid this!
+  const std::string default_name = std::regex_replace(
+      type_name_without_templates, std::regex(":+"), std::string("/"));
+
+  // Append the address spelled like "@0123456789abcdef".
+  const uintptr_t address = reinterpret_cast<uintptr_t>(this);
+  return fmt::format("{}@{:0>16x}", default_name, address);
 }
 
 std::string SystemBase::GetSystemPathname() const {

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -64,6 +64,13 @@ class SystemBase : public internal::SystemMessageInterface {
   // intent that the label could be used programmatically.
   const std::string& get_name() const { return name_; }
 
+  /** Returns a name for this %System based on a stringification of its type
+  name and memory address.  This is intended for use in diagnostic output
+  and should not be used for behavioral logic, because the stringification
+  of the type name may produce differing results across platforms and
+  because the address can vary from run to run. */
+  std::string GetMemoryObjectName() const;
+
   /** Returns a human-readable name for this system, for use in messages and
   logging. This will be the same as returned by get_name(), unless that would
   be an empty string. In that case we return a non-unique placeholder name,

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_no_throw.h"
@@ -118,6 +119,18 @@ GTEST_TEST(SystemBaseTest, NameAndMessageSupport) {
       system.ValidateCreatedForThisSystem(disconnected_context),
       ".*MyContextBase.*was not associated.*should have been "
       "created for.*MySystemBase.*any_name_will_do.*");
+}
+
+// Tests GetMemoryObjectName.
+GTEST_TEST(SystemBaseTest, GetMemoryObjectName) {
+  const MySystemBase system;
+  const std::string name = system.GetMemoryObjectName();
+
+  // The nominal value for 'name' is something like:
+  //   drake/systems/(anonymous namespace)/MySystemBase@0123456789abcdef
+  // We check only some platform-agnostic portions of that.
+  EXPECT_THAT(name, ::testing::HasSubstr("drake/systems/"));
+  EXPECT_THAT(name, ::testing::ContainsRegex("/MySystemBase@[0-9a-fA-F]{16}$"));
 }
 
 }  // namespace system_base_test_internal

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -597,17 +597,6 @@ TEST_F(SystemTest, SystemConstraintTest) {
   EXPECT_FALSE(system_.CheckSystemConstraintsSatisfied(*context_, tol));
 }
 
-// Tests GetMemoryObjectName.
-TEST_F(SystemTest, GetMemoryObjectName) {
-  const std::string name = system_.GetMemoryObjectName();
-
-  // The nominal value for 'name' is something like:
-  //   drake/systems/(anonymous namespace)/TestSystem@0123456789abcdef
-  // We check only some platform-agnostic portions of that.
-  EXPECT_THAT(name, ::testing::HasSubstr("drake/systems/"));
-  EXPECT_THAT(name, ::testing::ContainsRegex("/TestSystem@[0-9a-fA-F]{16}$"));
-}
-
 // Tests that by default, transmogrification fails appropriately.
 // (For testing transmogrification success, we rely on leaf_system_test.)
 TEST_F(SystemTest, TransmogrifyNotSupported) {


### PR DESCRIPTION
Nothing about this function needs scalar-type templating.

While we're here, fix it to use `fmt` (instead of `<iomanip>` :scream_cat:) and `uintptr_t`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20200)
<!-- Reviewable:end -->
