### PR TITLE
Fix HPolyhedronTest.

### DIFF
--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -880,14 +880,15 @@ GTEST_TEST(HPolyhedronTest, ReduceL1LInfBallIntersection) {
   A_int.bottomRows(Linfty_ball.A().rows()) = Linfty_ball.A();
   b_int.bottomRows(Linfty_ball.b().rows()) = Linfty_ball.b();
   HPolyhedron polyhedron_to_reduce(A_int, b_int);
-  const auto redundant_indices = polyhedron_to_reduce.FindRedundant();
+  const double tol = 1E-7;
+  const auto redundant_indices = polyhedron_to_reduce.FindRedundant(tol);
   // Removed Linfty_ball.
   std::set<int> redundant_indices_expected;
   for (int i = 0; i < Linfty_ball.A().rows(); ++i) {
     redundant_indices_expected.emplace(i + L1_ball.A().rows());
   }
   EXPECT_EQ(redundant_indices, redundant_indices_expected);
-  HPolyhedron reduced_polyhedron = polyhedron_to_reduce.ReduceInequalities();
+  HPolyhedron reduced_polyhedron = polyhedron_to_reduce.ReduceInequalities(tol);
 
   EXPECT_TRUE(CompareMatrices(reduced_polyhedron.A(), L1_ball.A()));
   EXPECT_TRUE(CompareMatrices(reduced_polyhedron.b(), L1_ball.b()));


### PR DESCRIPTION
Relax the tolerance for finding redundant faces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20201)
<!-- Reviewable:end -->
