### PR TITLE
Add DiscreteContactData

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -22,6 +22,7 @@ drake_cc_package_library(
         ":contact_results",
         ":coulomb_friction",
         ":deformable_ids",
+        ":discrete_contact_data",
         ":discrete_contact_pair",
         ":externally_applied_spatial_force",
         ":externally_applied_spatial_force_multiplexer",
@@ -48,6 +49,15 @@ drake_cc_library(
     deps = [
         ":deformable_ids",
         "//multibody/tree:multibody_tree_indexes",
+    ],
+)
+
+drake_cc_library(
+    name = "discrete_contact_data",
+    srcs = [],
+    hdrs = ["discrete_contact_data.h"],
+    deps = [
+        "//common:essential",
     ],
 )
 
@@ -120,6 +130,7 @@ drake_cc_library(
         ":contact_results",
         ":coulomb_friction",
         ":deformable_ids",
+        ":discrete_contact_data",
         ":discrete_contact_pair",
         ":externally_applied_spatial_force",
         ":hydroelastic_traction",
@@ -930,6 +941,14 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "deformable_contact_results_test",
+    deps = [
+        ":plant",
+        "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_googletest(
     name = "deformable_driver_test",
     deps = [
         ":compliant_contact_manager_tester",
@@ -983,6 +1002,14 @@ drake_cc_googletest(
         ":multibody_plant_core",
         "//common/test_utilities:expect_throws_message",
         "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_googletest(
+    name = "discrete_contact_data_test",
+    deps = [
+        ":discrete_contact_data",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -154,23 +154,39 @@ void CompliantContactManager<T>::DoDeclareCacheEntries() {
 }
 
 template <typename T>
-std::vector<ContactPairKinematics<T>>
+DiscreteContactData<ContactPairKinematics<T>>
 CompliantContactManager<T>::CalcContactKinematics(
     const systems::Context<T>& context) const {
-  const std::vector<DiscreteContactPair<T>>& contact_pairs =
+  const DiscreteContactData<DiscreteContactPair<T>>& contact_pairs =
       this->EvalDiscreteContactPairs(context);
+  DiscreteContactData<ContactPairKinematics<T>> contact_kinematics;
   const int num_contacts = contact_pairs.size();
-  std::vector<ContactPairKinematics<T>> contact_kinematics;
-  contact_kinematics.reserve(num_contacts);
 
   // Quick no-op exit.
   if (num_contacts == 0) return contact_kinematics;
 
-  const geometry::QueryObject<T>& query_object =
-      this->plant()
-          .get_geometry_query_input_port()
-          .template Eval<geometry::QueryObject<T>>(context);
-  const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
+  contact_kinematics.Reserve(contact_pairs.num_point_contacts(),
+                             contact_pairs.num_hydro_contacts(),
+                             contact_pairs.num_deformable_contacts());
+  AppendContactKinematics(context, contact_pairs.point_contact_data(),
+                          DiscreteContactType::kPoint, &contact_kinematics);
+  AppendContactKinematics(context, contact_pairs.hydro_contact_data(),
+                          DiscreteContactType::kHydroelastic,
+                          &contact_kinematics);
+  if constexpr (std::is_same_v<T, double>) {
+    if (deformable_driver_ != nullptr) {
+      deformable_driver_->AppendContactKinematics(context, &contact_kinematics);
+    }
+  }
+  return contact_kinematics;
+}
+
+template <typename T>
+void CompliantContactManager<T>::AppendContactKinematics(
+    const systems::Context<T>& context,
+    const std::vector<DiscreteContactPair<T>>& contact_pairs,
+    DiscreteContactType type,
+    DiscreteContactData<ContactPairKinematics<T>>* contact_kinematics) const {
   // Scratch workspace variables.
   const int nv = plant().num_velocities();
   Matrix3X<T> Jv_WAc_W(3, nv);
@@ -178,16 +194,10 @@ CompliantContactManager<T>::CalcContactKinematics(
   Matrix3X<T> Jv_AcBc_W(3, nv);
 
   const Frame<T>& frame_W = plant().world_frame();
-  for (int icontact = 0; icontact < num_contacts; ++icontact) {
+  for (int icontact = 0; icontact < ssize(contact_pairs); ++icontact) {
     const auto& point_pair = contact_pairs[icontact];
 
     const GeometryId geometryA_id = point_pair.id_A;
-    // All contact pairs involving deformable bodies come after pairs involving
-    // only rigid bodies. Once we reach a deformable body, we know that there
-    // are no rigid-only pairs left.
-    if (inspector.IsDeformableGeometry(geometryA_id)) {
-      break;
-    }
     const GeometryId geometryB_id = point_pair.id_B;
 
     BodyIndex bodyA_index = this->geometry_id_to_body_index().at(geometryA_id);
@@ -262,32 +272,39 @@ CompliantContactManager<T>::CalcContactKinematics(
                                           .p_BqC_W = p_BC_W,
                                           .phi = point_pair.phi0,
                                           .R_WC = R_WC};
-
-    contact_kinematics.emplace_back(std::move(jacobian_blocks),
-                                    std::move(configuration));
-  }
-  if constexpr (std::is_same_v<T, double>) {
-    if (deformable_driver_ != nullptr) {
-      deformable_driver_->AppendContactKinematics(context, &contact_kinematics);
+    switch (type) {
+      case DiscreteContactType::kPoint: {
+        contact_kinematics->AppendPointData(ContactPairKinematics<T>{
+            std::move(jacobian_blocks), std::move(configuration)});
+        break;
+      }
+      case DiscreteContactType::kHydroelastic: {
+        contact_kinematics->AppendHydroData(ContactPairKinematics<T>{
+            std::move(jacobian_blocks), std::move(configuration)});
+        break;
+      }
+      case DiscreteContactType::kDeformable: {
+        throw std::logic_error(
+            "Call DeformableDriver::AppendContactKinematics() to compute "
+            "contact kinematics for deformable contact instead.");
+      }
     }
   }
-
-  return contact_kinematics;
 }
 
 template <typename T>
-const std::vector<ContactPairKinematics<T>>&
+const DiscreteContactData<ContactPairKinematics<T>>&
 CompliantContactManager<T>::EvalContactKinematics(
     const systems::Context<T>& context) const {
   return plant()
       .get_cache_entry(cache_indexes_.contact_kinematics)
-      .template Eval<std::vector<ContactPairKinematics<T>>>(context);
+      .template Eval<DiscreteContactData<ContactPairKinematics<T>>>(context);
 }
 
 template <>
 void CompliantContactManager<symbolic::Expression>::CalcDiscreteContactPairs(
     const drake::systems::Context<symbolic::Expression>&,
-    std::vector<DiscreteContactPair<symbolic::Expression>>*) const {
+    DiscreteContactData<DiscreteContactPair<symbolic::Expression>>*) const {
   // Currently, the computation of contact pairs is not supported when T =
   // symbolic::Expression.
   throw std::domain_error(
@@ -298,11 +315,11 @@ void CompliantContactManager<symbolic::Expression>::CalcDiscreteContactPairs(
 template <typename T>
 void CompliantContactManager<T>::CalcDiscreteContactPairs(
     const systems::Context<T>& context,
-    std::vector<DiscreteContactPair<T>>* contact_pairs) const {
+    DiscreteContactData<DiscreteContactPair<T>>* contact_pairs) const {
   plant().ValidateContext(context);
   DRAKE_DEMAND(contact_pairs != nullptr);
 
-  contact_pairs->clear();
+  contact_pairs->Clear();
   if (plant().num_collision_geometries() == 0) return;
 
   const auto contact_model = plant().get_contact_model();
@@ -335,8 +352,7 @@ void CompliantContactManager<T>::CalcDiscreteContactPairs(
       num_quadrature_pairs += s.num_faces();
     }
   }
-  const int num_contact_pairs = num_point_pairs + num_quadrature_pairs;
-  contact_pairs->reserve(num_contact_pairs);
+  contact_pairs->Reserve(num_point_pairs, num_quadrature_pairs, 0);
 
   if (contact_model == ContactModel::kPoint ||
       contact_model == ContactModel::kHydroelasticWithFallback) {
@@ -356,8 +372,8 @@ void CompliantContactManager<T>::CalcDiscreteContactPairs(
 template <typename T>
 void CompliantContactManager<T>::AppendDiscreteContactPairsForPointContact(
     const systems::Context<T>& context,
-    std::vector<DiscreteContactPair<T>>* result) const {
-  std::vector<DiscreteContactPair<T>>& contact_pairs = *result;
+    DiscreteContactData<DiscreteContactPair<T>>* result) const {
+  DiscreteContactData<DiscreteContactPair<T>>& contact_pairs = *result;
 
   const geometry::QueryObject<T>& query_object =
       this->plant()
@@ -421,18 +437,19 @@ void CompliantContactManager<T>::AppendDiscreteContactPairsForPointContact(
       const T phi0 = -pair.depth;
       const T fn0 = k * pair.depth;  // Used by TAMSI, ignored by SAP.
 
-      contact_pairs.push_back({pair.id_A,
-                               pair.id_B,
-                               p_WC,
-                               pair.nhat_BA_W,
-                               phi0,
-                               fn0,
-                               k,
-                               d,
-                               tau,
-                               mu,
-                               {} /* no surface index */,
-                               {} /* no face index */});
+      contact_pairs.AppendPointData(
+          DiscreteContactPair<T>{pair.id_A,
+                                 pair.id_B,
+                                 p_WC,
+                                 pair.nhat_BA_W,
+                                 phi0,
+                                 fn0,
+                                 k,
+                                 d,
+                                 tau,
+                                 mu,
+                                 {} /* no surface index */,
+                                 {} /* no face index */});
     }
   }
 }
@@ -441,7 +458,7 @@ template <>
 void CompliantContactManager<symbolic::Expression>::
     AppendDiscreteContactPairsForHydroelasticContact(
         const drake::systems::Context<symbolic::Expression>&,
-        std::vector<DiscreteContactPair<symbolic::Expression>>*) const {
+        DiscreteContactData<DiscreteContactPair<symbolic::Expression>>*) const {
   throw std::domain_error(
       fmt::format("This method doesn't support T = {}.",
                   NiceTypeName::Get<symbolic::Expression>()));
@@ -451,8 +468,8 @@ template <typename T>
 void CompliantContactManager<T>::
     AppendDiscreteContactPairsForHydroelasticContact(
         const systems::Context<T>& context,
-        std::vector<DiscreteContactPair<T>>* result) const {
-  std::vector<DiscreteContactPair<T>>& contact_pairs = *result;
+        DiscreteContactData<DiscreteContactPair<T>>* result) const {
+  DiscreteContactData<DiscreteContactPair<T>>& contact_pairs = *result;
 
   // N.B. For discrete hydro we use a first order quadrature rule. As such,
   // the per-face quadrature point is the face's centroid and the weight is 1.
@@ -598,8 +615,9 @@ void CompliantContactManager<T>::
           const T phi0 = -p0 / g;
 
           if (k > 0) {
-            contact_pairs.push_back({s.id_M(), s.id_N(), p_WQ, nhat_W, phi0,
-                                     fn0, k, d, tau, mu, surface_index, face});
+            contact_pairs.AppendHydroData(DiscreteContactPair<T>{
+                s.id_M(), s.id_N(), p_WQ, nhat_W, phi0, fn0, k, d, tau, mu,
+                surface_index, face});
           }
         }
       }
@@ -674,12 +692,12 @@ void CompliantContactManager<T>::CalcAccelerationsDueToNonConstraintForcesCache(
 }
 
 template <typename T>
-const std::vector<DiscreteContactPair<T>>&
+const DiscreteContactData<DiscreteContactPair<T>>&
 CompliantContactManager<T>::EvalDiscreteContactPairs(
     const systems::Context<T>& context) const {
   return plant()
       .get_cache_entry(cache_indexes_.discrete_contact_pairs)
-      .template Eval<std::vector<DiscreteContactPair<T>>>(context);
+      .template Eval<DiscreteContactData<DiscreteContactPair<T>>>(context);
 }
 
 template <typename T>
@@ -753,9 +771,9 @@ void CompliantContactManager<T>::AppendContactResultsForPointContact(
 
   const std::vector<PenetrationAsPointPair<T>>& point_pairs =
       plant().EvalPointPairPenetrations(context);
-  const std::vector<internal::DiscreteContactPair<T>>& discrete_pairs =
+  const DiscreteContactData<DiscreteContactPair<T>>& discrete_pairs =
       this->EvalDiscreteContactPairs(context);
-  const std::vector<ContactPairKinematics<T>>& contact_kinematics =
+  const DiscreteContactData<ContactPairKinematics<T>>& contact_kinematics =
       this->EvalContactKinematics(context);
   const contact_solvers::internal::ContactSolverResults<T>& solver_results =
       this->EvalContactSolverResults(context);
@@ -765,26 +783,13 @@ void CompliantContactManager<T>::AppendContactResultsForPointContact(
   const VectorX<T>& vt = solver_results.vt;
   const VectorX<T>& vn = solver_results.vn;
 
-  // N.B. Contact between two fully locked trees are filtered out of discrete
-  // pairs, therefore for purely point contact:
-  //   num_point_contacts != plant().EvalPointPairPenetrations(context).size()
-  // We find the index of the first non-point contact, whose value corresponds
-  // to num_point_contacts.
-  auto itr = std::find_if(discrete_pairs.begin(), discrete_pairs.end(),
-                          [](const auto& pair) {
-                            return pair.surface_index.has_value();
-                          });
-  const int num_point_contacts = std::distance(discrete_pairs.begin(), itr);
+  const int num_point_contacts = discrete_pairs.num_point_contacts();
 
   DRAKE_DEMAND(fn.size() >= num_point_contacts);
   DRAKE_DEMAND(ft.size() >= 2 * num_point_contacts);
   DRAKE_DEMAND(vn.size() >= num_point_contacts);
   DRAKE_DEMAND(vt.size() >= 2 * num_point_contacts);
 
-  // The correspondence between `discrete_pairs` and `point_pairs` depends on
-  // strict ordering of CompliantContactManager::CalcDiscreteContactPairs.
-  // All point contacts must come first and their order in discrete_pairs
-  // corresponds to their order in point_pairs.
   for (int icontact = 0; icontact < num_point_contacts; ++icontact) {
     const auto& discrete_pair = discrete_pairs[icontact];
     const auto& point_pair = point_pairs[icontact];
@@ -846,9 +851,9 @@ void CompliantContactManager<T>::CalcHydroelasticContactInfo(
   contact_info->clear();
   contact_info->reserve(all_surfaces.size());
 
-  const std::vector<internal::DiscreteContactPair<T>>& discrete_pairs =
+  const DiscreteContactData<DiscreteContactPair<T>>& discrete_pairs =
       this->EvalDiscreteContactPairs(context);
-  const std::vector<ContactPairKinematics<T>>& contact_kinematics =
+  const DiscreteContactData<ContactPairKinematics<T>>& contact_kinematics =
       this->EvalContactKinematics(context);
 
   const contact_solvers::internal::ContactSolverResults<T>& solver_results =
@@ -866,14 +871,8 @@ void CompliantContactManager<T>::CalcHydroelasticContactInfo(
   DRAKE_DEMAND(vn.size() == num_contacts);
   DRAKE_DEMAND(vt.size() == 2 * num_contacts);
 
-  // If the point contact model is used, hydroelastic contact pairs are appended
-  // after point contact pairs. The index of the first discrete pair with a
-  // valid surface index is the first non-point contact pair.
-  auto itr = std::find_if(discrete_pairs.begin(), discrete_pairs.end(),
-                          [](const auto& pair) {
-                            return pair.surface_index.has_value();
-                          });
-  const int num_point_contacts = std::distance(discrete_pairs.begin(), itr);
+  const int num_point_contacts = discrete_pairs.num_point_contacts();
+  const int num_hydro_contacts = discrete_pairs.num_hydro_contacts();
   const int num_surfaces = all_surfaces.size();
 
   std::vector<SpatialForce<T>> F_Ao_W_per_surface(num_surfaces,
@@ -888,7 +887,8 @@ void CompliantContactManager<T>::CalcHydroelasticContactInfo(
   // We only scan discrete pairs corresponding to hydroelastic quadrature
   // points. These are appended by CalcDiscreteContactPairs() at the end of the
   // point contact forces.
-  for (int icontact = num_point_contacts; icontact < num_contacts; ++icontact) {
+  for (int icontact = num_point_contacts;
+       icontact < num_point_contacts + num_hydro_contacts; ++icontact) {
     const auto& pair = discrete_pairs[icontact];
     // Quadrature point Q.
     const Vector3<T>& p_WQ = pair.p_WC;

--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -222,9 +222,8 @@ void DeformableDriver<T>::AppendLinearDynamicsMatrix(
 template <typename T>
 void DeformableDriver<T>::AppendDiscreteContactPairs(
     const systems::Context<T>& context,
-    std::vector<DiscreteContactPair<T>>* result) const {
+    DiscreteContactData<DiscreteContactPair<T>>* result) const {
   DRAKE_DEMAND(result != nullptr);
-  std::vector<DiscreteContactPair<T>>& contact_pairs = *result;
 
   const geometry::QueryObject<T>& query_object =
       manager_->plant()
@@ -269,8 +268,9 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
       const T& phi0 = surface.signed_distances()[i];
       const T fn0 = NAN;  // not used.
       const T d = NAN;    // not used.
-      contact_pairs.push_back({surface.id_A(), surface.id_B(), p_WC, nhat_BA_W,
-                               phi0, fn0, k, d, tau, mu});
+      result->AppendDeformableData(
+          DiscreteContactPair<T>{surface.id_A(), surface.id_B(), p_WC,
+                                 nhat_BA_W, phi0, fn0, k, d, tau, mu});
     }
   }
 }
@@ -278,7 +278,7 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
 template <typename T>
 void DeformableDriver<T>::AppendContactKinematics(
     const systems::Context<T>& context,
-    std::vector<ContactPairKinematics<T>>* result) const {
+    DiscreteContactData<ContactPairKinematics<T>>* result) const {
   DRAKE_DEMAND(result != nullptr);
   /* Since v_AcBc_W = v_WBc - v_WAc the relative velocity Jacobian will be:
      Jv_v_AcBc_W = Jv_v_WBc_W - Jv_v_WAc_W.
@@ -411,8 +411,8 @@ void DeformableDriver<T>::AppendContactKinematics(
           .p_BqC_W = p_BC_W,
           .phi = surface.signed_distances()[i],
           .R_WC = R_WC};
-      result->emplace_back(std::move(jacobian_blocks),
-                           std::move(configuration));
+      result->AppendDeformableData(ContactPairKinematics<T>(
+          std::move(jacobian_blocks), std::move(configuration)));
     }
   }
 }

--- a/multibody/plant/deformable_driver.h
+++ b/multibody/plant/deformable_driver.h
@@ -14,6 +14,7 @@
 #include "drake/multibody/fem/fem_solver.h"
 #include "drake/multibody/plant/contact_pair_kinematics.h"
 #include "drake/multibody/plant/deformable_model.h"
+#include "drake/multibody/plant/discrete_contact_data.h"
 #include "drake/multibody/plant/discrete_update_manager.h"
 #include "drake/systems/framework/context.h"
 
@@ -140,14 +141,14 @@ class DeformableDriver : public ScalarConvertibleComponent<T> {
    @pre pairs != nullptr. */
   void AppendDiscreteContactPairs(
       const systems::Context<T>& context,
-      std::vector<DiscreteContactPair<T>>* pairs) const;
+      DiscreteContactData<DiscreteContactPair<T>>* pairs) const;
 
   /* Appends the contact kinematics information for each contact pair where at
    least one of the body in contact is deformable.
    @pre result != nullptr. */
   void AppendContactKinematics(
       const systems::Context<T>& context,
-      std::vector<ContactPairKinematics<T>>* result) const;
+      DiscreteContactData<ContactPairKinematics<T>>* result) const;
 
   /* Appends the constraint kinematics information for each deformable rigid
    fixed constraint.

--- a/multibody/plant/discrete_contact_data.h
+++ b/multibody/plant/discrete_contact_data.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* Types of discrete contact supported in Drake. */
+enum class DiscreteContactType {
+  kPoint,
+  kHydroelastic,
+  kDeformable,
+};
+
+/**
+ Container to store results from discrete contact. Categorized by the contact
+ type: point, hydroelastic, and deformable contact.
+ @tparam Data The type of contact data shared by both point, hydroelastic, and
+ deformable contact.
+*/
+template <typename Data>
+class DiscreteContactData {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DiscreteContactData);
+
+  /* Constructs an empty contact data. */
+  DiscreteContactData() = default;
+
+  /* The total number of contact data, including all of point, hydroelastic, and
+   deformable contacts. */
+  int size() const {
+    return num_point_contacts() + num_hydro_contacts() +
+           num_deformable_contacts();
+  }
+
+  /* Increases the capacity of the containers for point, hydroelastic, and
+   deformable contact data to values greater than or equal to the given
+   capacities. If the given capacities are greater than the current capacities,
+   new storage is allocated, otherwise the function does nothing. Reserve() does
+   not change `size()` or `num_point/hydro/deformable_contacts()`. */
+  void Reserve(int point_cap, int hydro_cap, int deformable_cap) {
+    DRAKE_THROW_UNLESS(point_cap >= 0);
+    DRAKE_THROW_UNLESS(hydro_cap >= 0);
+    DRAKE_THROW_UNLESS(deformable_cap >= 0);
+    point_.reserve(point_cap);
+    hydro_.reserve(hydro_cap);
+    deformable_.reserve(deformable_cap);
+  }
+
+  int num_point_contacts() const { return point_.size(); }
+  int num_hydro_contacts() const { return hydro_.size(); }
+  int num_deformable_contacts() const { return deformable_.size(); }
+
+  const std::vector<Data>& point_contact_data() const { return point_; }
+  const std::vector<Data>& hydro_contact_data() const { return hydro_; }
+  const std::vector<Data>& deformable_contact_data() const {
+    return deformable_;
+  }
+
+  /* Returns the i-th contact data, where the index is assigned as if contact
+   data was stacked with point contact coming first, followed by hydroelastic
+   contact data and then deformable contact data. That is, this operator will
+   return:
+    1. Point contact data, for 0 <= i < num_point_contacts(),
+    2. Hydroelastic contact data, for
+       num_point_contacts() <= i < num_point_contacts() + num_hydro_contacts(),
+    3. Deformable contact data, for
+       num_point_contacts() + num_hydro_contacts() <= i < size(). */
+  const Data& operator[](int i) const {
+    DRAKE_THROW_UNLESS(0 <= i && i < size());
+    if (i < hydro_contact_start()) {
+      return point_[i];
+    } else if (i < deformable_contact_start()) {
+      return hydro_[i - hydro_contact_start()];
+    } else {
+      return deformable_[i - deformable_contact_start()];
+    }
+    DRAKE_UNREACHABLE();
+  }
+
+  void AppendPointData(Data&& data) {
+    point_.push_back(std::forward<Data>(data));
+  }
+  void AppendHydroData(Data&& data) {
+    hydro_.push_back(std::forward<Data>(data));
+  }
+  void AppendDeformableData(Data&& data) {
+    deformable_.push_back(std::forward<Data>(data));
+  }
+
+  /* Removes all data from the container, leaving the container with a `size()`
+   of 0. */
+  void Clear() {
+    point_.clear();
+    hydro_.clear();
+    deformable_.clear();
+  }
+
+ private:
+  /* The starting index of point, hydroelastic, and deformable contact data when
+   stacked in that order. */
+  int point_contact_start() const { return 0; }
+  int hydro_contact_start() const { return num_point_contacts(); }
+  int deformable_contact_start() const {
+    return num_point_contacts() + num_hydro_contacts();
+  }
+  std::vector<Data> point_;
+  std::vector<Data> hydro_;
+  std::vector<Data> deformable_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -198,14 +198,14 @@ std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
   // TODO(amcastro-tri): consider exposing these parameters.
   constexpr double sigma = 1.0e-3;
 
-  const std::vector<DiscreteContactPair<T>>& contact_pairs =
+  const DiscreteContactData<DiscreteContactPair<T>>& contact_pairs =
       manager().EvalDiscreteContactPairs(context);
   const int num_contacts = contact_pairs.size();
 
   // Quick no-op exit.
   if (num_contacts == 0) return std::vector<RotationMatrix<T>>();
 
-  const std::vector<ContactPairKinematics<T>>& contact_kinematics =
+  const DiscreteContactData<ContactPairKinematics<T>>& contact_kinematics =
       manager().EvalContactKinematics(context);
 
   std::vector<RotationMatrix<T>> R_WC;
@@ -933,7 +933,7 @@ void SapDriver<T>::CalcContactSolverResults(
       EvalContactProblemCache(context);
   const SapContactProblem<T>& sap_problem = *contact_problem_cache.sap_problem;
   const SapSolverResults<T>& sap_results = EvalSapSolverResults(context);
-  const std::vector<DiscreteContactPair<T>>& discrete_pairs =
+  const DiscreteContactData<DiscreteContactPair<T>>& discrete_pairs =
       manager().EvalDiscreteContactPairs(context);
   const int num_contacts = discrete_pairs.size();
   PackContactSolverResults(context, sap_problem, num_contacts, sap_results,

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -29,7 +29,7 @@ TamsiDriver<T>::TamsiDriver(const CompliantContactManager<T>* manager)
 template <typename T>
 internal::ContactJacobians<T> TamsiDriver<T>::CalcContactJacobians(
     const systems::Context<T>& context) const {
-  const std::vector<ContactPairKinematics<T>>& contact_kinematics =
+  const DiscreteContactData<ContactPairKinematics<T>>& contact_kinematics =
       manager().EvalContactKinematics(context);
 
   const int nc = contact_kinematics.size();
@@ -109,7 +109,7 @@ void TamsiDriver<T>::CalcContactSolverResults(
 
   // Compute all contact pairs, including both penetration pairs and quadrature
   // pairs for discrete hydroelastic.
-  const std::vector<internal::DiscreteContactPair<T>>& contact_pairs =
+  const DiscreteContactData<DiscreteContactPair<T>>& contact_pairs =
       manager().EvalDiscreteContactPairs(context);
   const int num_contacts = contact_pairs.size();
 
@@ -119,10 +119,9 @@ void TamsiDriver<T>::CalcContactSolverResults(
 
   // Get friction coefficient into a single vector.
   VectorX<T> mu(num_contacts);
-  std::transform(contact_pairs.begin(), contact_pairs.end(), mu.data(),
-                 [](const internal::DiscreteContactPair<T>& pair) {
-                   return pair.friction_coefficient;
-                 });
+  for (int i = 0; i < num_contacts; ++i) {
+    mu[i] = contact_pairs[i].friction_coefficient;
+  }
 
   // Fill in data as required by our discrete solver.
   VectorX<T> fn0(num_contacts);

--- a/multibody/plant/test/compliant_contact_manager_tester.h
+++ b/multibody/plant/test/compliant_contact_manager_tester.h
@@ -32,7 +32,7 @@ class CompliantContactManagerTester {
     return manager.EvalContactSurfaces(context);
   }
 
-  static const std::vector<DiscreteContactPair<double>>&
+  static const DiscreteContactData<DiscreteContactPair<double>>&
   EvalDiscreteContactPairs(const CompliantContactManager<double>& manager,
                            const drake::systems::Context<double>& context) {
     return manager.EvalDiscreteContactPairs(context);
@@ -47,9 +47,9 @@ class CompliantContactManagerTester {
                                  forces);
   }
 
-  static std::vector<ContactPairKinematics<double>> CalcContactKinematics(
-      const CompliantContactManager<double>& manager,
-      const drake::systems::Context<double>& context) {
+  static DiscreteContactData<ContactPairKinematics<double>>
+  CalcContactKinematics(const CompliantContactManager<double>& manager,
+                        const drake::systems::Context<double>& context) {
     return manager.CalcContactKinematics(context);
   }
 
@@ -82,7 +82,8 @@ class CompliantContactManagerTester {
   // Jacobian matrix.
   static Eigen::MatrixXd CalcDenseJacobianMatrixInContactFrame(
       const CompliantContactManager<double>& manager,
-      const std::vector<ContactPairKinematics<double>>& contact_kinematics) {
+      const DiscreteContactData<ContactPairKinematics<double>>&
+          contact_kinematics) {
     const int nc = contact_kinematics.size();
     Eigen::MatrixXd J_AcBc_C(3 * nc, manager.plant().num_velocities());
     J_AcBc_C.setZero();

--- a/multibody/plant/test/deformable_contact_results_test.cc
+++ b/multibody/plant/test/deformable_contact_results_test.cc
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+
+#include "drake/geometry/proximity_properties.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/multibody_plant_config_functions.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+using drake::geometry::GeometryInstance;
+using drake::geometry::ProximityProperties;
+using drake::geometry::Sphere;
+using drake::math::RigidTransformd;
+using drake::systems::Context;
+using Eigen::Vector3d;
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Tests that querying contact results in the presence of deformable contact
+// doesn't throw. See #20187.
+GTEST_TEST(CompliantContactManagerTest, ContactResultsWithDeformable) {
+  systems::DiagramBuilder<double> builder;
+
+  MultibodyPlantConfig plant_config;
+  plant_config.time_step = 1.0e-3;
+  plant_config.discrete_contact_solver = "sap";
+  auto [plant, scene_graph] = AddMultibodyPlant(plant_config, &builder);
+
+  /* Add a hydro ground weld to the world*/
+  ProximityProperties hydro_proximity_properties;
+  geometry::AddCompliantHydroelasticProperties(
+      /* resolution_hint */ 1.0, 1e6, &hydro_proximity_properties);
+  geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
+                               &hydro_proximity_properties);
+  plant.RegisterCollisionGeometry(plant.world_body(), RigidTransformd(),
+                                  geometry::Box(10, 10, 10), "ground_collision",
+                                  hydro_proximity_properties);
+  /* Add a rigid box that has compliant hydro proximity properties and collide
+   with the ground. */
+  const auto M = SpatialInertia<double>::SolidCubeWithMass(1.0, 0.1);
+  const auto& body1 = plant.AddRigidBody("hydro body", M);
+  plant.RegisterCollisionGeometry(body1, RigidTransformd(Vector3d(5, 5, 5)),
+                                  geometry::Box(1, 1, 1), "hydro box",
+                                  hydro_proximity_properties);
+
+  /* Add a rigid box that has point contact proximity properties and collide
+   with the ground (but not with the other body1). */
+  ProximityProperties point_proximity_properties;
+  const auto& body2 = plant.AddRigidBody("point contact body", M);
+  geometry::AddContactMaterial(1e6, 1.0, CoulombFriction<double>(1.0, 1.0),
+                               &point_proximity_properties);
+  plant.RegisterCollisionGeometry(body2, RigidTransformd(Vector3d(-5, -5, 5)),
+                                  geometry::Box(1, 1, 1), "point contact box",
+                                  point_proximity_properties);
+
+  auto deformable_model = std::make_unique<DeformableModel<double>>(&plant);
+  const DeformableModel<double>* model = deformable_model.get();
+  /* Add a deformable sphere that collides with the ground but not with any
+   other rigid bodies. */
+  auto deformable_geometry = std::make_unique<GeometryInstance>(
+      RigidTransformd(Vector3d(0, 0, 5)), std::make_unique<Sphere>(1.0),
+      "sphere");
+  ProximityProperties deformable_proximity_props;
+  geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
+                               &deformable_proximity_props);
+  deformable_geometry->set_proximity_properties(
+      std::move(deformable_proximity_props));
+  multibody::fem::DeformableBodyConfig<double> body_config;
+  constexpr double kRezHint = 10.0;
+  deformable_model->RegisterDeformableBody(std::move(deformable_geometry),
+                                           body_config, kRezHint);
+  plant.AddPhysicalModel(std::move(deformable_model));
+  plant.Finalize();
+  builder.Connect(
+      model->vertex_positions_port(),
+      scene_graph.get_source_configuration_port(plant.get_source_id().value()));
+
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+  const auto& plant_context = plant.GetMyContextFromRoot(*context);
+
+  const auto& contact_results =
+      plant.get_contact_results_output_port().Eval<ContactResults<double>>(
+          plant_context);
+  EXPECT_EQ(contact_results.num_point_pair_contacts(), 1);
+  EXPECT_EQ(contact_results.num_hydroelastic_contacts(), 1);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
@@ -202,7 +202,7 @@ class DeformableDriverContactKinematicsTest
     /* Each discrete contact pair should create a contact kinematics pair. */
     const Context<double>& plant_context =
         plant_->GetMyContextFromRoot(*context_);
-    std::vector<ContactPairKinematics<double>> contact_kinematics;
+    DiscreteContactData<ContactPairKinematics<double>> contact_kinematics;
     driver_->AppendContactKinematics(plant_context, &contact_kinematics);
     const int num_contact_points = GetNumContactPoints(plant_context);
     ASSERT_EQ(contact_kinematics.size(), num_contact_points);
@@ -453,7 +453,7 @@ GTEST_TEST(DeformableDriverContactKinematicsWithBcTest,
   auto context = diagram->CreateDefaultContext();
 
   const Context<double>& plant_context = plant.GetMyContextFromRoot(*context);
-  std::vector<ContactPairKinematics<double>> contact_kinematics;
+  DiscreteContactData<ContactPairKinematics<double>> contact_kinematics;
   driver->AppendContactKinematics(plant_context, &contact_kinematics);
   /* The set of contact points is not empty. */
   EXPECT_GT(contact_kinematics.size(), 0);

--- a/multibody/plant/test/deformable_driver_contact_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_test.cc
@@ -372,7 +372,7 @@ TEST_F(DeformableDriverContactTest, AppendLinearDynamicsMatrix) {
 TEST_F(DeformableDriverContactTest, AppendDiscreteContactPairs) {
   const Context<double>& plant_context =
       plant_->GetMyContextFromRoot(*context_);
-  std::vector<DiscreteContactPair<double>> contact_pairs;
+  DiscreteContactData<DiscreteContactPair<double>> contact_pairs;
   driver_->AppendDiscreteContactPairs(plant_context, &contact_pairs);
 
   const DeformableContact<double>& contact_data =
@@ -392,7 +392,8 @@ TEST_F(DeformableDriverContactTest, AppendDiscreteContactPairs) {
   GeometryId id0 = model_->GetGeometryId(body_id0_);
   GeometryId id1 = model_->GetGeometryId(body_id1_);
 
-  for (const DiscreteContactPair<double>& pair : contact_pairs) {
+  for (int i = 0; i < contact_pairs.size(); ++i) {
+    const DiscreteContactPair<double>& pair = contact_pairs[i];
     EXPECT_TRUE(pair.id_A == id0 || pair.id_A == id1);
     EXPECT_EQ(pair.id_B, rigid_geometry_id_);
     /* The contact point is on the z = -0.25 plane, the top surface of the rigid

--- a/multibody/plant/test/discrete_contact_data_test.cc
+++ b/multibody/plant/test/discrete_contact_data_test.cc
@@ -1,0 +1,94 @@
+#include "drake/multibody/plant/discrete_contact_data.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/limit_malloc.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+struct DummyData {
+  int value;
+};
+
+GTEST_TEST(DiscreteContactData, Constructor) {
+  DiscreteContactData<DummyData> dut;
+  EXPECT_EQ(dut.size(), 0);
+  EXPECT_EQ(dut.num_point_contacts(), 0);
+  EXPECT_EQ(dut.num_hydro_contacts(), 0);
+  EXPECT_EQ(dut.num_deformable_contacts(), 0);
+  EXPECT_EQ(dut.point_contact_data().size(), 0);
+  EXPECT_EQ(dut.hydro_contact_data().size(), 0);
+  EXPECT_EQ(dut.deformable_contact_data().size(), 0);
+  EXPECT_THROW(dut[0], std::exception);
+}
+
+GTEST_TEST(DiscreteContactData, Size) {
+  DiscreteContactData<DummyData> dut;
+
+  dut.AppendPointData(DummyData{100});
+
+  dut.AppendHydroData(DummyData{0});
+  dut.AppendHydroData(DummyData{1});
+
+  dut.AppendDeformableData(DummyData{1});
+  dut.AppendDeformableData(DummyData{2});
+  dut.AppendDeformableData(DummyData{3});
+
+  EXPECT_EQ(dut.num_point_contacts(), 1);
+  EXPECT_EQ(dut.num_hydro_contacts(), 2);
+  EXPECT_EQ(dut.num_deformable_contacts(), 3);
+  EXPECT_EQ(dut.size(), 6);
+}
+
+GTEST_TEST(DiscreteContactData, AppendAndAccessAndClear) {
+  DiscreteContactData<DummyData> dut;
+
+  dut.AppendPointData(DummyData{1});
+  dut.AppendHydroData(DummyData{2});
+  dut.AppendDeformableData(DummyData{3});
+
+  /* Access via operator[]. */
+  EXPECT_EQ(dut[0].value, 1);
+  EXPECT_EQ(dut[1].value, 2);
+  EXPECT_EQ(dut[2].value, 3);
+
+  /* Access by group. */
+  ASSERT_EQ(dut.point_contact_data().size(), 1);
+  EXPECT_EQ(dut.point_contact_data()[0].value, 1);
+
+  ASSERT_EQ(dut.hydro_contact_data().size(), 1);
+  EXPECT_EQ(dut.hydro_contact_data()[0].value, 2);
+
+  ASSERT_EQ(dut.deformable_contact_data().size(), 1);
+  EXPECT_EQ(dut.deformable_contact_data()[0].value, 3);
+
+  /* Clear */
+  dut.Clear();
+  EXPECT_EQ(dut.num_point_contacts(), 0);
+  EXPECT_EQ(dut.num_hydro_contacts(), 0);
+  EXPECT_EQ(dut.num_deformable_contacts(), 0);
+  EXPECT_EQ(dut.size(), 0);
+}
+
+GTEST_TEST(DiscreteContactData, Reserve) {
+  using drake::test::LimitMalloc;
+  DiscreteContactData<DummyData> dut;
+  dut.Reserve(1, 2, 3);
+  /* We should be able to add 1, 2, and 3 point, hydroelastic, and deformable
+   data respectively without allocation. */
+  LimitMalloc guard;
+  dut.AppendPointData(DummyData{0});
+  dut.AppendHydroData(DummyData{0});
+  dut.AppendHydroData(DummyData{0});
+  dut.AppendDeformableData(DummyData{0});
+  dut.AppendDeformableData(DummyData{0});
+  dut.AppendDeformableData(DummyData{0});
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -434,7 +434,7 @@ TEST_F(KukaIiwaArmTests, LimitConstraints) {
   SetArbitraryStateWithLimitsSpecification(plant_, limits_specification,
                                            context_.get());
 
-  const std::vector<DiscreteContactPair<double>>& discrete_pairs =
+  const DiscreteContactData<DiscreteContactPair<double>>& discrete_pairs =
       CompliantContactManagerTester::EvalDiscreteContactPairs(*manager_,
                                                               *context_);
   const int num_contacts = discrete_pairs.size();
@@ -574,7 +574,7 @@ TEST_F(KukaIiwaArmTests, CouplerConstraints) {
                                            context_.get());
 
   // We are assuming there is no contact. Assert this.
-  const std::vector<DiscreteContactPair<double>>& discrete_pairs =
+  const DiscreteContactData<DiscreteContactPair<double>>& discrete_pairs =
       CompliantContactManagerTester::EvalDiscreteContactPairs(*manager_,
                                                               *context_);
   const int num_contacts = discrete_pairs.size();

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -123,13 +123,13 @@ class SpheresStackTest : public SpheresStack, public ::testing::Test {
     return CompliantContactManagerTester::topology(*contact_manager_);
   }
 
-  const std::vector<DiscreteContactPair<double>>& EvalDiscreteContactPairs(
-      const Context<double>& context) const {
+  const DiscreteContactData<DiscreteContactPair<double>>&
+  EvalDiscreteContactPairs(const Context<double>& context) const {
     return CompliantContactManagerTester::EvalDiscreteContactPairs(
         *contact_manager_, context);
   }
 
-  std::vector<ContactPairKinematics<double>> CalcContactKinematics(
+  DiscreteContactData<ContactPairKinematics<double>> CalcContactKinematics(
       const Context<double>& context) const {
     return CompliantContactManagerTester::CalcContactKinematics(
         *contact_manager_, context);
@@ -146,7 +146,7 @@ TEST_F(SpheresStackTest, EvalContactProblemCache) {
   const std::vector<drake::math::RotationMatrix<double>>& R_WC =
       problem_cache.R_WC;
 
-  const std::vector<DiscreteContactPair<double>>& pairs =
+  const DiscreteContactData<DiscreteContactPair<double>>& pairs =
       EvalDiscreteContactPairs(*plant_context_);
   const int num_contacts = pairs.size();
 
@@ -165,9 +165,9 @@ TEST_F(SpheresStackTest, EvalContactProblemCache) {
   EXPECT_EQ(problem.dynamics_matrix(), A);
 
   // Verify each of the contact constraints.
-  const std::vector<ContactPairKinematics<double>> contact_kinematics =
+  const DiscreteContactData<ContactPairKinematics<double>> contact_kinematics =
       CalcContactKinematics(*plant_context_);
-  for (size_t i = 0; i < contact_kinematics.size(); ++i) {
+  for (int i = 0; i < contact_kinematics.size(); ++i) {
     const DiscreteContactPair<double>& discrete_pair = pairs[i];
     const ContactPairKinematics<double>& pair_kinematics =
         contact_kinematics[i];
@@ -305,7 +305,7 @@ TEST_F(SpheresStackTest, PackContactSolverResults) {
 
   // We form an arbitrary set of SAP results consistent with the contact
   // kinematics for the configuration of our model.
-  const std::vector<ContactPairKinematics<double>> contact_kinematics =
+  const DiscreteContactData<ContactPairKinematics<double>> contact_kinematics =
       CalcContactKinematics(*plant_context_);
   const int num_contacts = contact_kinematics.size();
   const int nv = plant_->num_velocities();


### PR DESCRIPTION
Closes #20187 

We have three types of contact: point, hydroelastic, and deformable that share similar contact data like  DiscreteContactPair and ContactPairKinematics. Currently, we store them all in a std::vector with an ordering convention that is inconsistent across various classes that produce and consume these data.

We introduce DiscreteContactData to help enforce ordering conventions across the board and ensure the correct contact data is retrieved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20209)
<!-- Reviewable:end -->
