### PR TITLE
Bug fix in actuation inputs ordering

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2005,8 +2005,11 @@ class TestPlant(unittest.TestCase):
                 u = np.array([0.1])
                 numpy_compare.assert_float_equal(
                     actuator.get_actuation_vector(u=u), [0.1])
+                with catch_drake_warnings(expected_count=1):
+                    actuator.set_actuation_vector(
+                        u_instance=np.array([0.2]), u=u)
                 actuator.set_actuation_vector(
-                    u_instance=np.array([0.2]), u=u)
+                    u_actuator=np.array([0.2]), u=u)
                 numpy_compare.assert_float_equal(u, [0.2])
                 self.assertIsInstance(actuator.rotor_inertia(context), float)
                 self.assertIsInstance(actuator.gear_ratio(context), float)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -825,7 +825,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("u"), cls_doc.get_actuation_vector.doc)
         .def("set_actuation_vector", &Class::set_actuation_vector,
-            py::arg("u_instance"), py::arg("u"),
+            py::arg("u_actuator"), py::arg("u"),
             cls_doc.set_actuation_vector.doc)
         .def("input_start", &Class::input_start, cls_doc.input_start.doc)
         .def("num_inputs", &Class::num_inputs, cls_doc.num_inputs.doc)
@@ -856,6 +856,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("gains"), cls_doc.set_controller_gains.doc)
         .def("has_controller", &Class::has_controller,
             cls_doc.has_controller.doc);
+    constexpr char doc_deprecated_set_actuation_vector[] =
+        "The kwarg name 'u_instance' is deprecated and will be removed on "
+        "2024-02-01. Spell the argument name as 'u_actuator' instead.";
+    cls.def("set_actuation_vector",
+        WrapDeprecated(
+            doc_deprecated_set_actuation_vector, &Class::set_actuation_vector),
+        py::arg("u_instance"), py::arg("u"),
+        doc_deprecated_set_actuation_vector);
   }
 
   // Force Elements.

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -475,6 +475,7 @@ drake_cc_googletest(
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
         "//multibody:models",
+        "//multibody/benchmarks/acrobot:models",
     ],
     deps = [
         ":plant",

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -325,17 +325,57 @@ externally applied body forces, constraint forces, and contact forces.
                 ### Actuation
 
 In a %MultibodyPlant model an actuator can be added as a JointActuator, see
-AddJointActuator(). For models with actuators, the plant will declare an
-actuation input port to provide feedforward actuation, see
-get_actuation_input_port(). Actuation ports can be requested for each individual
-@ref model_instances "model instance" in the %MultibodyPlant.
+AddJointActuator(). The plant declares actuation input ports to provide
+feedforward actuation, both for the %MultibodyPlant as a whole (see
+get_actuation_input_port()) and for each individual @ref model_instances
+"model instance" in the %MultibodyPlant (see
+@ref get_actuation_input_port(ModelInstanceIndex)const
+"get_actuation_input_port(ModelInstanceIndex)").
+Any actuation input ports not connected are assumed to be zero. Actuation values
+from the full %MultibodyPlant model port (get_actuation_input_port()) and from
+the per model-instance ports (
+@ref get_actuation_input_port(ModelInstanceIndex)const
+"get_actuation_input_port(ModelInstanceIndex)") are summed up.
 
-Unless PD controllers are defined
-(see @ref pd_controllers "PD controlled actuators" next), actuation input ports
-are required to be connected.
+@note The vector data supplied to %MultibodyPlant's actuation input ports should
+be ordered by @ref JointActuatorIndex. For the get_actuation_input_port() that
+covers all actuators, the iᵗʰ vector element corresponds to
+`JointActuatorIndex(i)`. For the
+@ref get_actuation_input_port(ModelInstanceIndex)const
+"get_actuation_input_port(ModelInstanceIndex)" specific to a model index, the
+vector data is ordered by monotonically increasing @ref JointActuatorIndex for
+the actuators within that model instance: the 0ᵗʰ vector element
+corresponds to the lowest-numbered %JointActuatorIndex of that instance, the 1ˢᵗ
+vector element corresponds to the second-lowest-numbered %JointActuatorIndex of
+that instance, etc.
+
+@note The following snippet shows how per model instance actuation can be set:
+```
+ModelInstanceIndex model_instance_index = ...;
+VectorX<T> u_instance(plant.num_actuated_dofs(model_instance_index));
+int offset = 0;
+for (JointActuatorIndex joint_actuator_index :
+         plant.GetJointActuatorIndices(model_instance_index)) {
+  const JointActuator<T>& actuator = plant.get_joint_actuator(
+      joint_actuator_index);
+  const Joint<T>& joint = actuator.joint();
+  VectorX<T> u_joint = ... my_actuation_logic_for(joint) ...;
+  ASSERT(u_joint.size() == joint_actuator.num_inputs());
+  u_instance.segment(offset, u_joint.size()) = u_joint;
+  offset += u_joint.size();
+}
+plant.get_actuation_input_port(model_instance_index).FixValue(
+    plant_context, u_instance);
+```
+
+@note To inter-operate between the whole plant actuation vector and sets of
+per-model instance actuation vectors, see SetActuationInArray() to gather the
+model instance vectors into a whole plant vector and GetActuationFromArray() to
+scatter the whole plant vector into per-model instance vectors.
 
 @warning Effort limits (JointActuator::effort_limit()) are not enforced, unless
-PD controllers are defined. See @ref pd_controllers "PD controlled actuators".
+PD controllers are defined.
+See @ref pd_controllers "Using PD controlled actuators".
 
 <!-- TODO(amcastro-tri): Consider enforcing effort limits whether PD controllers
      are defined or not. -->
@@ -531,7 +571,6 @@ the following properties for point contact modeling:
 |material|point_contact_stiffness|no²|T| Penalty method stiffness.|
 |material|hunt_crossley_dissipation |no²⁴|T| Penalty method dissipation.|
 |material|relaxation_time|yes³⁴|T|Linear Kelvin–Voigt model parameter.|
-
 
 ¹ Collision geometry is required to be registered with a
   geometry::ProximityProperties object that contains the
@@ -790,40 +829,25 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_body_spatial_accelerations_output_port()
       const;
 
-  /// Returns a constant reference to the input port for external actuations for
-  /// all actuated dofs regardless the number of model instances that have
-  /// actuated dofs. The input actuation is assumed to be ordered according to
-  /// model instances. This input port is a vector valued port, which can be set
-  /// with JointActuator::set_actuation_vector().
+  /// Returns a constant reference to the input port for external actuation for
+  /// all actuated dofs. This input port is a vector valued port indexed by
+  /// @ref JointActuatorIndex, see JointActuator::index(), and can be set with
+  /// JointActuator::set_actuation_vector().
   /// Refer to @ref mbp_actuation "Actuation" for further details.
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize().
-  /// @throws std::exception if individual actuation ports are connected.
   const systems::InputPort<T>& get_actuation_input_port() const;
 
   /// Returns a constant reference to the input port for external actuation for
-  /// a specific model instance.  This input port is a vector valued port, which
-  /// can be set with JointActuator::set_actuation_vector().
-  /// Refer to @ref mbp_actuation "Actuation" for further details.
+  /// a specific model instance. This is a vector valued port with entries
+  /// ordered by monotonically increasing @ref JointActuatorIndex within
+  /// `model_instance`. Refer to @ref mbp_actuation "Actuation" for further
+  /// details.
   ///
-  /// Each model instance in `this` plant model has an actuation input port,
-  /// even if zero sized (for model instance with no actuators.)
+  /// Every model instance in `this` plant model has an actuation input port,
+  /// even if zero sized (for model instance with no actuators).
   ///
   /// @see GetJointActuatorIndices(), GetActuatedJointIndices().
-  ///
-  /// @note This is a vector valued port of size num_actuators(model_instance)
-  /// (where we assume only 1-DOF joints are actuated.)
-  ///
-  /// @warning It is required to connect this input port unless the model
-  /// instance has PD controllers defined, see get_desired_state_input_port(),
-  /// or if the full multibody version of this port is connected. For models
-  /// with PD controllers, actuation defaults to zero. This allows the modeler
-  /// to use PD controllers only, without the need to provide feed-forward
-  /// torques.
-  ///
-  /// @warning This port cannot be used together with get_actuation_input_port()
-  /// for the full multibody system. Either use the port for the full multibody
-  /// system or the port per model instance, never both.
   ///
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize().
@@ -2778,25 +2802,33 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       ModelInstanceIndex model_instance,
       bool add_model_instance_prefix = false) const;
 
-  /// Returns a vector of actuation values for `model_instance` from a
-  /// vector `u` of actuation values for the entire model. This method throws an
-  /// exception if `u` is not of size MultibodyPlant::num_actuated_dofs().
+  /// Returns a vector of actuation values for `model_instance` from a vector
+  /// `u` of actuation values for the entire plant model. Refer to @ref
+  /// mbp_actuation "Actuation" for further details.
+  /// @param[in] u Actuation values for the entire model, indexed by
+  /// @ref JointActuatorIndex.
+  /// @returns Actuation values for `model_instance`, ordered by monotonically
+  /// increasing @ref JointActuatorIndex.
+  /// @throws std::exception if `u` is not of size
+  /// MultibodyPlant::num_actuated_dofs().
   VectorX<T> GetActuationFromArray(
       ModelInstanceIndex model_instance,
       const Eigen::Ref<const VectorX<T>>& u) const {
     return internal_tree().GetActuationFromArray(model_instance, u);
   }
 
-  /// Given the actuation values `u_instance` for all actuators in
-  /// `model_instance`, this method sets the actuation vector u for the entire
-  /// model to which this actuator belongs to. This method throws
-  /// an exception if the size of `u_instance` is not equal to the number of
-  /// degrees of freedom of all of the actuated joints in `model_instance`.
-  /// @param[in] u_instance Actuation values for the actuators. It must be of
-  ///   size equal to the number of degrees of freedom of all of the actuated
-  ///   joints in `model_instance`.
-  /// @param[out] u
-  ///   The vector containing the actuation values for the entire model.
+  /// Given actuation values `u_instance` for the actuators in `model_instance`,
+  /// this function updates the actuation vector u for the entire plant model to
+  /// which this actuator belongs to. Refer to @ref mbp_actuation "Actuation"
+  /// for further details.
+  /// @param[in] u_instance Actuation values for the model instance. Values are
+  ///   ordered by monotonically increasing @ref JointActuatorIndex within the
+  ///   model instance.
+  /// @param[in,out] u Actuation values for the entire plant model, indexed by
+  ///   @ref JointActuatorIndex. Only values corresponding to `model_instance`
+  ///   are changed.
+  /// @throws std::exception if the size of `u_instance` is not equal to the
+  ///   number of actuation inputs for the joints of `model_instance`.
   void SetActuationInArray(ModelInstanceIndex model_instance,
                            const Eigen::Ref<const VectorX<T>>& u_instance,
                            EigenPtr<VectorX<T>> u) const {
@@ -4495,6 +4527,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Returns a list of joint actuator indices associated with `model_instance`.
+  /// The vector is ordered by monotonically increasing @ref JointActuatorIndex.
   /// @throws std::exception if called pre-finalize.
   std::vector<JointActuatorIndex> GetJointActuatorIndices(
       ModelInstanceIndex model_instance) const {
@@ -4852,18 +4885,23 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().GetAccelerationUpperLimits();
   }
 
-  /// Returns a vector of size `num_actuators()` containing the lower effort
+  /// Returns a vector of size `num_actuated_dofs()` containing the lower effort
   /// limits for every actuator. Any unbounded or unspecified limits will be
-  /// -infinity.
+  /// -∞. The returned vector is indexed by @ref JointActuatorIndex, see
+  /// JointActuator::index().
+  /// @see GetEffortUpperLimits()
   /// @throws std::exception if called pre-finalize.
   VectorX<double> GetEffortLowerLimits() const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     return internal_tree().GetEffortLowerLimits();
   }
 
-  /// Upper limit analog of GetAccelerationsLowerLimits(), where any unbounded
-  /// or unspecified limits will be +infinity.
-  /// @see GetEffortLowerLimits() for more information.
+  /// Returns a vector of size `num_actuated_dofs()` containing the upper effort
+  /// limits for every actuator. Any unbounded or unspecified limits will be
+  /// +∞. The returned vector is indexed by @ref JointActuatorIndex, see
+  /// JointActuator::index().
+  /// @see GetEffortLowerLimits()
+  /// @throws std::exception if called pre-finalize.
   VectorX<double> GetEffortUpperLimits() const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     return internal_tree().GetEffortUpperLimits();
@@ -5095,12 +5133,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void EstimatePointContactParameters(double penetration_allowance);
 
   // Helper method to assemble actuation input vector from the appropriate
-  // ports.
+  // ports. The return value is indexed by JointActuatorIndex.
   VectorX<T> AssembleActuationInput(const systems::Context<T>& context) const;
 
   // For models with joint actuators with PD control, this method helps to
   // assemble desired states for the full model from the input ports for
   // individual model instances.
+  // The return stacks desired state as xd = [qd, vd], with both qd and vd
+  // indexed by JointActuatorIndex (it is assumed that qd.size() == vd.size()).
   VectorX<T> AssembleDesiredStateInput(
       const systems::Context<T>& context) const;
 

--- a/multibody/plant/test/actuated_models_test.cc
+++ b/multibody/plant/test/actuated_models_test.cc
@@ -43,6 +43,8 @@ namespace {
 // gripper.
 class ActuatedIiiwaArmTest : public ::testing::Test {
  public:
+  // Enum to control the PD model for ther kuka arm and its gripper.
+  // This does not affect the acrobot model, which has no PD controllers.
   enum class ModelConfiguration {
     kArmIsControlled,
     kArmIsNotControlled,
@@ -74,6 +76,12 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
 
     // Add the arm.
     arm_model_ = parser.AddModels(FindResourceOrThrow(kArmSdfPath)).at(0);
+
+    // A model of an underactuated robot.
+    acrobot_model_ = parser
+                         .AddModels(FindResourceOrThrow(
+                             "drake/multibody/benchmarks/acrobot/acrobot.sdf"))
+                         .at(0);
 
     // Add the gripper.
     gripper_model_ = parser.AddModels(FindResourceOrThrow(kWsg50SdfPath)).at(0);
@@ -121,11 +129,22 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
            actuator_index < plant_->num_actuators(); ++actuator_index) {
         JointActuator<double>& actuator =
             plant_->get_mutable_joint_actuator(actuator_index);
+        // We do not add PD controllers to the acrobot.
+        if (actuator.model_instance() == acrobot_model_) continue;
         // N.B. Proportional gains must be strictly positive, so we choose a
         // small positive number to approximate zero.
         actuator.set_controller_gains({1.0e-10, 0.0});
       }
     }
+
+    // We make the acrobot fully actuated.
+    const Joint<double>& acrobot_shoulder =
+        plant_->GetJointByName("ShoulderJoint", acrobot_model_);
+    plant_->AddJointActuator("ShoulderActuator", acrobot_shoulder);
+    // N.B. Notice that this actuator is added at a later state long after other
+    // model instances were added to the plant. This will allow testing that
+    // actuation input is assembled as documented by monotonically
+    // increasing JointActuatorIndex, regardless of model instance index.
 
     plant_->Finalize();
 
@@ -149,6 +168,7 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
   const double kProportionalGain_{10000.0};
   const double kDerivativeGain_{100.0};
   std::unique_ptr<MultibodyPlant<double>> plant_;
+  ModelInstanceIndex acrobot_model_;
   ModelInstanceIndex arm_model_;
   ModelInstanceIndex gripper_model_;
   ModelInstanceIndex box_model_;
@@ -207,54 +227,28 @@ TEST_F(ActuatedIiiwaArmTest, GetDesiredStatePort) {
       "num_model_instances\\(\\)' failed.");
 }
 
-// Verify that MultibodyPlant::AssembleActuationInput() throws an exception if
-// the actuation input port for a model instance without PD controllers is not
-// connected.
-TEST_F(ActuatedIiiwaArmTest, AssembleActuationInput_ActuationInputRequired) {
-  SetUpModel();
-
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MultibodyPlantTester::AssembleActuationInput(*plant_, *context_),
-      "Actuation input port for model instance iiwa7 must be connected or PD "
-      "gains must be specified for each actuator.");
-}
-
-// Verify that actuation port is not required to be connected if the model is PD
-// controlled.
-TEST_F(ActuatedIiiwaArmTest, AssembleActuationInput_NotRequiredIfPdControlled) {
-  SetUpModel();
-
-  // The actuation input port for the arm is required to be connected.
-  plant_->get_actuation_input_port(arm_model_)
-      .FixValue(context_.get(), VectorXd::Zero(kKukaNumPositions_));
-
-  // The actuation input port for the gripper is not required to be connected
-  // since its actuators are PD controlled.
-  EXPECT_NO_THROW(
-      MultibodyPlantTester::AssembleActuationInput(*plant_, *context_));
-}
-
-// Verify the assembly of actuation input ports defaults to zero actuation when
-// a model instance input port is not connected.
-TEST_F(ActuatedIiiwaArmTest,
-       AssembleActuationInput_DisconnectedPortHasZeroValues) {
-  // We set up a PD controlled arm so that we can test the feed-forward term
-  // defaults to zero values when not connected.
-  SetUpModel(ModelConfiguration::kArmIsControlled);
+// Verify the assembly of actuation input ports. In particular, we verify this
+// assembly is performed in the order of JointActuatorIndex and that
+// disconnected ports default to zero values.
+TEST_F(ActuatedIiiwaArmTest, AssembleActuationInput) {
+  // We setup a model with one PD controlled model instance (the gripper) and a
+  // model instance without PD control (the arm).
+  SetUpModel(ModelConfiguration::kArmIsNotControlled);
 
   // Desired state is required to be connected, even if values are not relevant
   // for this test.
   const VectorXd gripper_xd = (VectorXd(4) << 1.0, 2.0, 3.0, 4.0).finished();
   plant_->get_desired_state_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_xd);
-  const VectorXd arm_xd = VectorXd::LinSpaced(14, 1.0, 14.0);
-  plant_->get_desired_state_input_port(arm_model_)
-      .FixValue(context_.get(), arm_xd);
 
   // Fix input input ports to known values.
   const VectorXd gripper_u = (VectorXd(2) << 1.0, 2.0).finished();
   plant_->get_actuation_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_u);
+
+  const VectorXd acrobot_u = (VectorXd(2) << 3.0, 4.0).finished();
+  plant_->get_actuation_input_port(acrobot_model_)
+      .FixValue(context_.get(), acrobot_u);
 
   const VectorXd full_u =
       MultibodyPlantTester::AssembleActuationInput(*plant_, *context_);
@@ -264,8 +258,11 @@ TEST_F(ActuatedIiiwaArmTest,
   // entries to zero. In this case, entries corresponding to the arm are
   // expected to be zero.
   const int arm_nu = plant_->num_actuated_dofs(arm_model_);
-  VectorXd expected_u =
-      (VectorXd(nu) << VectorXd::Zero(arm_nu), gripper_u).finished();
+  // Values are assembled in order of JointActuatorIndex, regardless of model
+  // instance index. Therefore we expect the shoulder actuator value to be last.
+  VectorXd expected_u = (VectorXd(nu) << VectorXd::Zero(arm_nu), acrobot_u(0),
+                         gripper_u, acrobot_u(1))
+                            .finished();
 
   EXPECT_EQ(full_u, expected_u);
 }
@@ -314,14 +311,24 @@ TEST_F(ActuatedIiiwaArmTest,
 
   const int nu = plant_->num_actuated_dofs();
   // AssembleDesiredStateInput will always return a vector of size 2 * nu. It
-  // fill in values for those models with PD control and set all other entries
+  // fills in values for those models with PD control and set all other entries
   // to zero. In this case, entries corresponding to the arm are expected to be
   // zero. All qd values go first, followed by vd values.
   const int arm_nu = plant_->num_actuated_dofs(arm_model_);
+  // clang-format off
   VectorXd expected_xd =
-      (VectorXd(2 * nu) << VectorXd::Zero(arm_nu), gripper_xd.head<2>(),
-       VectorXd::Zero(arm_nu), gripper_xd.tail<2>())
-          .finished();
+      (VectorXd(2 * nu) <<
+        // Desired positions.
+        VectorXd::Zero(arm_nu),
+        0.0, /* Acrobot shoulder */
+        gripper_xd.head<2>(),
+        0.0, /* Acrobot elbow */
+        // Desired velocities.
+        VectorXd::Zero(arm_nu),
+        0.0, /* Acrobot shoulder */
+        gripper_xd.tail<2>(),
+        0.0 /* Acrobot elbow */).finished();
+  // clang-format on
 
   EXPECT_EQ(full_xd, expected_xd);
 }
@@ -347,10 +354,20 @@ TEST_F(ActuatedIiiwaArmTest,
   // therefore in this case arm first followed by gripper. All qd values go
   // first, followed by vd values.
   const int nu = plant_->num_actuated_dofs();
+  // clang-format off
   const VectorXd expected_xd =
-      (VectorXd(2 * nu) << arm_xd.head<7>(), gripper_xd.head<2>(),
-       arm_xd.tail<7>(), gripper_xd.tail<2>())
-          .finished();
+      (VectorXd(2 * nu) <<
+        // Desired positions.
+        arm_xd.head<7>(),
+        0.0, /* Acrobot shoulder */
+        gripper_xd.head<2>(),
+        0.0, /* Acrobot elbow */
+        // Desired velocities.
+        arm_xd.tail<7>(),
+        0.0, /* Acrobot shoulder */
+        gripper_xd.tail<2>(),
+        0.0 /* Acrobot elbow */).finished();
+  // clang-format on
 
   EXPECT_EQ(full_xd, expected_xd);
 }
@@ -395,9 +412,16 @@ TEST_F(ActuatedIiiwaArmTest,
   // N.B. These values of actuation are well within effort limits, for both arm
   // and gripper.
   const VectorXd arm_u = VectorXd::LinSpaced(7, 1.0, 7.0);
+  const VectorXd acrobot_u = VectorXd::Zero(2);
   const VectorXd gripper_u = VectorXd::LinSpaced(2, 1.0, 2.0);
-  const VectorXd free_box = VectorXd::Zero(6);
-  const VectorXd tau = (VectorXd(15) << arm_u, gripper_u, free_box).finished();
+  const VectorXd free_box_u = VectorXd::Zero(6);
+  VectorXd tau = VectorXd::Zero(plant_->num_velocities());
+  // N.B. We are setting a vector tau of generalized forces, ordered by velocity
+  // indexes and therefore we use SetVelocitiesInArray().
+  plant_->SetVelocitiesInArray(arm_model_, arm_u, &tau);
+  plant_->SetVelocitiesInArray(acrobot_model_, acrobot_u, &tau);
+  plant_->SetVelocitiesInArray(gripper_model_, gripper_u, &tau);
+  plant_->SetVelocitiesInArray(box_model_, free_box_u, &tau);
 
   auto updates = plant_->AllocateDiscreteVariables();
 
@@ -409,7 +433,7 @@ TEST_F(ActuatedIiiwaArmTest,
 
   // Input through actuation. Zero generalized forces first.
   plant_->get_applied_generalized_force_input_port().FixValue(
-      context_.get(), VectorXd::Zero(15));
+      context_.get(), VectorXd::Zero(17));
   plant_->get_actuation_input_port(arm_model_).FixValue(context_.get(), arm_u);
   plant_->get_actuation_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_u);
@@ -454,13 +478,19 @@ TEST_F(ActuatedIiiwaArmTest,
   // values to be outside this limit.
   const VectorXd arm_u =
       (VectorXd(7) << 350, 400, 55, -350, -400, -450, -40).finished();
+  const VectorXd acrobot_u = VectorXd::Zero(2);
   const VectorXd gripper_u = VectorXd::LinSpaced(2, 1.0, 2.0);
-  const VectorXd free_box = VectorXd::Zero(6);
+  const VectorXd free_box_u = VectorXd::Zero(6);
   // To obtain the same actuation with generalized forces, we clamp u to be
   // within effort limits.
   const VectorXd arm_u_clamped = arm_u.array().min(300).max(-300);
-  const VectorXd tau =
-      (VectorXd(15) << arm_u_clamped, gripper_u, free_box).finished();
+  VectorXd tau = VectorXd::Zero(plant_->num_velocities());
+  // N.B. We are setting a vector tau of generalized forces, ordered by velocity
+  // indexes and therefore we use SetVelocitiesInArray().
+  plant_->SetVelocitiesInArray(arm_model_, arm_u_clamped, &tau);
+  plant_->SetVelocitiesInArray(acrobot_model_, acrobot_u, &tau);
+  plant_->SetVelocitiesInArray(gripper_model_, gripper_u, &tau);
+  plant_->SetVelocitiesInArray(box_model_, free_box_u, &tau);
 
   auto updates = plant_->AllocateDiscreteVariables();
 
@@ -472,7 +502,7 @@ TEST_F(ActuatedIiiwaArmTest,
 
   // Input through actuation. Zero generalized forces first.
   plant_->get_applied_generalized_force_input_port().FixValue(
-      context_.get(), VectorXd::Zero(15));
+      context_.get(), VectorXd::Zero(17));
   plant_->get_actuation_input_port(arm_model_).FixValue(context_.get(), arm_u);
   plant_->get_actuation_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_u);

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -42,20 +42,20 @@ void JointActuator<T>::AddInOneForce(
     const T& joint_tau,
     MultibodyForces<T>* forces) const {
   DRAKE_DEMAND(forces != nullptr);
-  DRAKE_DEMAND(0 <= joint_dof && joint_dof < joint().num_velocities());
+  DRAKE_DEMAND(0 <= joint_dof && joint_dof < num_inputs());
   DRAKE_DEMAND(forces->CheckHasRightSizeForModel(this->get_parent_tree()));
   joint().AddInOneForce(context, joint_dof, joint_tau, forces);
 }
 
 template <typename T>
 void JointActuator<T>::set_actuation_vector(
-    const Eigen::Ref<const VectorX<T>>& u_instance,
+    const Eigen::Ref<const VectorX<T>>& u_actuator,
     EigenPtr<VectorX<T>> u) const {
-  DRAKE_DEMAND(u != nullptr);
-  DRAKE_DEMAND(u->size() == this->get_parent_tree().num_actuated_dofs());
-  DRAKE_DEMAND(u_instance.size() == joint().num_velocities());
-  u->segment(topology_.actuator_index_start, joint().num_velocities()) =
-      u_instance;
+  DRAKE_THROW_UNLESS(u != nullptr);
+  DRAKE_THROW_UNLESS(u->size() == this->get_parent_tree().num_actuated_dofs());
+  DRAKE_THROW_UNLESS(u_actuator.size() == num_inputs());
+  u->segment(topology_.actuator_index_start, num_inputs()) =
+      u_actuator;
 }
 
 template <typename T>

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -84,7 +84,7 @@ class JointActuator final : public MultibodyElement<T> {
   ///   `this` joint belongs.
   /// @param[in] joint_dof
   ///   Index specifying one of the degrees of freedom for this joint. The index
-  ///   must be in the range `0 <= joint_dof < num_velocities()` or otherwise
+  ///   must be in the range `0 <= joint_dof < num_inputs()` or otherwise
   ///   this method will throw an exception.
   /// @param[in] joint_tau
   ///   Generalized force corresponding to the degree of freedom indicated by
@@ -104,7 +104,7 @@ class JointActuator final : public MultibodyElement<T> {
       MultibodyForces<T>* forces) const;
 
   /// Gets the actuation values for `this` actuator from the actuation vector u
-  /// for the entire model.
+  /// for the entire plant model.
   /// @return a reference to a nv-dimensional vector, where nv is the number
   ///         of velocity variables of joint().
   const Eigen::Ref<const VectorX<T>> get_actuation_vector(
@@ -113,24 +113,24 @@ class JointActuator final : public MultibodyElement<T> {
     return u.segment(topology_.actuator_index_start, joint().num_velocities());
   }
 
-  /// Given the actuation values u_instance for `this` actuator, this method
-  /// sets the actuation vector u for the entire MultibodyTree model
-  /// to which this actuator belongs to.
-  /// @param[in] u_instance
-  ///   Actuation values for `this` actuator. It must be of size equal to the
-  ///   number of degrees of freedom of the actuated Joint, see
-  ///   Joint::num_velocities(). For units and sign conventions refer to the
-  ///   specific Joint sub-class documentation.
-  /// @param[out] u
-  ///   The vector containing the actuation values for the entire MultibodyTree
-  ///   model to which `this` actuator belongs to.
+  /// Given the actuation values `u_actuator` for `this` actuator, updates the
+  /// actuation vector `u` for the entire multibody model to which this actuator
+  /// belongs to.
+  /// @param[in] u_actuator
+  ///   Actuation values for `this` actuator. It must be of size equal to
+  ///   num_inputs(). For units and sign conventions refer to the specific Joint
+  ///   sub-class documentation.
+  /// @param[in,out] u
+  ///   Actuation values for the entire plant model to which `this` actuator
+  ///   belongs to, indexed by JointActuatorIndex. Only values corresponding to
+  ///   this actuator are changed.
   /// @throws std::exception if
-  ///   `u_instance.size() != this->joint().num_velocities()`.
+  ///   `u_actuator.size() != this->num_inputs()`.
   /// @throws std::exception if u is nullptr.
   /// @throws std::exception if
-  ///   `u.size() != this->get_parent_tree().num_actuated_dofs()`.
+  ///   `u.size() != this->GetParentPlant().num_actuated_dofs()`.
   void set_actuation_vector(
-      const Eigen::Ref<const VectorX<T>>& u_instance,
+      const Eigen::Ref<const VectorX<T>>& u_actuator,
       EigenPtr<VectorX<T>> u) const;
 
   /// Returns the index to the first element for this joint actuator / within

--- a/multibody/tree/model_instance.h
+++ b/multibody/tree/model_instance.h
@@ -79,39 +79,51 @@ class ModelInstance : public MultibodyElement<T> {
     mobilizers_.push_back(mobilizer);
   }
 
+  // Adds an actuator to this model instance. Actuators must be added in
+  // monotonically increasing order of JointActuatorIndex (or else throws).
   void add_joint_actuator(const JointActuator<T>* joint_actuator) {
+    DRAKE_THROW_UNLESS(joint_actuator != nullptr);
     num_actuated_dofs_ += joint_actuator->joint().num_velocities();
+    // Verify the documented requirement.
+    DRAKE_THROW_UNLESS(joint_actuators_.empty() ||
+                       joint_actuators_.back()->index() <
+                           joint_actuator->index());
     joint_actuators_.push_back(joint_actuator);
   }
 
+  // Returns a vector of JointActuatorIndex for this model instance. Within the
+  // returned vector, actuator indexes are sorted in ascending order.
   std::vector<JointActuatorIndex> GetJointActuatorIndices() const;
 
   std::vector<JointIndex> GetActuatedJointIndices() const;
 
-  // Returns an Eigen vector of the actuation for `this` model instance from a
-  // vector `u` of actuator forces for the entire model.
+  // Returns the actuation for `this` model instance extracted from `u`.
+  // @param[in] u Actuation for the full plant model, indexed by
+  // JointActuatorIndex.
+  // @returns the per model instance actuation, order by monotonically
+  // increasing JointActuatorIndex within this model instance.
   // @throws std::exception if `u` is not of size
   //         MultibodyTree::num_actuators().
   VectorX<T> GetActuationFromArray(
       const Eigen::Ref<const VectorX<T>>& u) const;
 
   // Given the actuation values `u_instance` for all actuators in `this` model
-  // instance, this method sets the portion of the actuation vector `u` (which
-  // is the actuation vector for the entire MultibodyTree) corresponding to the
-  // actuators for this model instance.
-  // @param[in] u_instance Actuation values for the actuators. It must be of
+  // instance, updates the portion of the actuation vector `u` corresponding to
+  // the actuators for this model instance.
+  // @param[in] u_instance Actuation values for this model instance. It must be
+  //   of size equal to the number of degrees of freedom of all of the actuated
+  //   joints in this model instance. It is ordered by monotonically increasing
+  //   JointActuatorIndex within this model instance.
+  // @param[in,out] u Actuation values for the entire plant model to which
+  //   `this` actuator belongs, indexed by JointActuatorIndex. It must be of
   //   size equal to the number of degrees of freedom of all of the actuated
-  //   joints in this model instance.
-  // @param[out] u
-  //   The vector containing the actuation values for the entire MultibodyTree
-  //   model to which `this` actuator belongs to. It must be of size equal to
-  //   the number of degrees of freedom of all of the actuated joints in the
-  //   entire MultibodyTree model.
-  // @throws std::exception if `u_instance` is not of size equal to the
-  //         number of degrees of freedom of all of the actuated joints in this
-  //         model or `u` is not of size equal to the number of degrees of
-  //         freedom of all of the actuated joints in the entire MultibodyTree
-  //         model to which `this` actuator belongs to.
+  //   joints in the entire MultibodyTree model. Only values corresponding to
+  //   this model instance are updated.
+  // @throws std::exception if `u_instance` is not of size equal to the number
+  //   of degrees of freedom of all of the actuated joints in this model or `u`
+  //   is not of size equal to the number of degrees of freedom of all of the
+  //   actuated joints in the entire MultibodyTree model to which `this`
+  //   actuator belongs to.
   void SetActuationInArray(
       const Eigen::Ref<const VectorX<T>>& u_instance,
       EigenPtr<VectorX<T>> u) const;

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -843,6 +843,9 @@ void MultibodyTree<T>::CreateModelInstances() {
     }
   }
 
+  // N.B. The result of the code below is that actuators are sorted by
+  // JointActuatorIndex within each model instance. If this was not true,
+  // ModelInstance::add_joint_actuator() would throw.
   for (const auto& joint_actuator : owned_actuators_) {
     model_instances_.at(joint_actuator->model_instance())->add_joint_actuator(
         joint_actuator.get());

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -308,7 +308,8 @@ struct JointActuatorTopology {
   JointActuatorIndex index{0};
   // For an actuator in a MultibodyTree model, this index corresponds to the
   // first entry in the global array u containing all actuation values for the
-  // entire model.
+  // entire model. Actuator indexes are assigned in the order actuators are
+  // added to the model, that is, in the order of JointActuatorIndex.
   int actuator_index_start{-1};
   // The number of dofs actuated by this actuator.
   int num_dofs{-1};


### PR DESCRIPTION
Per [conversation in Slack](https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1695068480697379).

This PR ensure that we properly documented and verify the indexing of input ports according to:
1. Actuation input ordered by JointActuatorIndex for the full actuation port.
2. For per-instance ports, inputs are ordered by JointActuatorIndex within that model instance.

And a bug fix for when joint actuators are not added in the same order model instances are. This seldom happens as we usually load models with our parsers, which add all actuators one model instance at a time. But users could choose to add actuators programatically in arbitrary oder of model instance. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20212)
<!-- Reviewable:end -->
