### PR TITLE
Disconnected actuation input ports evaluate to zero actuation

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2298,7 +2298,7 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
 
   // Assemble the vector from the model instance input ports.
   // TODO(sherm1) Heap allocation here. Get rid of it.
-  VectorX<T> actuation_input(num_actuated_dofs());
+  VectorX<T> actuation_input = VectorX<T>::Zero(num_actuated_dofs());
 
   const auto& actuation_port = this->get_input_port(actuation_port_);
   if (actuation_port.HasValue(context)) {

--- a/multibody/plant/test/actuated_models_test.cc
+++ b/multibody/plant/test/actuated_models_test.cc
@@ -225,6 +225,42 @@ TEST_F(ActuatedIiiwaArmTest, AssembleActuationInput_NotRequiredIfPdControlled) {
       MultibodyPlantTester::AssembleActuationInput(*plant_, *context_));
 }
 
+// Verify the assembly of actuation input ports defaults to zero actuation when
+// a model instance input port is not connected.
+TEST_F(ActuatedIiiwaArmTest,
+       AssembleActuationInput_DisconnectedPortHasZeroValues) {
+  // We set up a PD controlled arm so that we can test the feed-forward term
+  // defaults to zero values when not connected.
+  SetUpModel(ModelConfiguration::kArmIsControlled);
+
+  // Desired state is required to be connected, even if values are not relevant
+  // for this test.
+  const VectorXd gripper_xd = (VectorXd(4) << 1.0, 2.0, 3.0, 4.0).finished();
+  plant_->get_desired_state_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_xd);
+  const VectorXd arm_xd = VectorXd::LinSpaced(14, 1.0, 14.0);
+  plant_->get_desired_state_input_port(arm_model_)
+      .FixValue(context_.get(), arm_xd);
+
+  // Fix input input ports to known values.
+  const VectorXd gripper_u = (VectorXd(2) << 1.0, 2.0).finished();
+  plant_->get_actuation_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_u);
+
+  const VectorXd full_u =
+      MultibodyPlantTester::AssembleActuationInput(*plant_, *context_);
+  const int nu = plant_->num_actuated_dofs();
+  // AssembleActuationInput() will always return a vector of size nu. It fills
+  // in values for those models with feed-forward actuation and set all other
+  // entries to zero. In this case, entries corresponding to the arm are
+  // expected to be zero.
+  const int arm_nu = plant_->num_actuated_dofs(arm_model_);
+  VectorXd expected_u =
+      (VectorXd(nu) << VectorXd::Zero(arm_nu), gripper_u).finished();
+
+  EXPECT_EQ(full_u, expected_u);
+}
+
 // Verify that MultibodyPlant::AssembleDesiredStateInput() throws an exception
 // when not all actuators in a model instance are PD controlled. Once a PD
 // controller is defined in a model instance, all actuators must use PD control.
@@ -261,7 +297,7 @@ TEST_F(ActuatedIiiwaArmTest,
        AssembleDesiredStateInput_VerifyAssemblyWithOneModel) {
   SetUpModel();
 
-  const VectorXd gripper_xd = (VectorXd(4) << 1., 2., 3, 4.).finished();
+  const VectorXd gripper_xd = (VectorXd(4) << 1.0, 2.0, 3.0, 4.0).finished();
   plant_->get_desired_state_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_xd);
   const VectorXd full_xd =
@@ -289,7 +325,7 @@ TEST_F(ActuatedIiiwaArmTest,
 
   // Fixed desired state input ports to known values.
   // Both arm and gripper are required to be connected.
-  const VectorXd gripper_xd = (VectorXd(4) << 1., 2., 3, 4.).finished();
+  const VectorXd gripper_xd = (VectorXd(4) << 1.0, 2.0, 3.0, 4.0).finished();
   plant_->get_desired_state_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_xd);
   const VectorXd arm_xd = VectorXd::LinSpaced(14, 1.0, 14.0);


### PR DESCRIPTION
This was already identified in this [Slack conversation](https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1695068480697379) by @jwnimmer-tri. 

It turns out the problem shows quickly as users start excercising the implicit PD controllers recently merged, when their models do not connect feed-forward terms (expecing these ports to evaluate to zero by default).

cc'ing @JoseBarreiros-TRI 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20215)
<!-- Reviewable:end -->
