### PR TITLE
[workspace] Fail-fast in miscofigured VTK build on macOS

### DIFF
--- a/doc/_release-notes/v1.21.0.md
+++ b/doc/_release-notes/v1.21.0.md
@@ -22,6 +22,8 @@ released: 2023-09-14
   * During manual testing on macOS, we found that RenderEngineVtk sometimes does
     not obey ``show_window=true``. It is not clear whether this is a new bug due
     to the upgrade. Refer to [#20144][_#20144] for further discussion.
+  * On macOS, when building Drake from source as a bazel external, you must not
+    have ``build --force_pic`` in your ``.bazelrc`` file ([#20217][_#20217]).
 * CMake users no longer need to install Bazel when building Drake from source
   ([#20064][_#20064]).
 
@@ -281,6 +283,7 @@ Philip E. Gill and Elizabeth Wong for their kind support.
 [_#20179]: https://github.com/RobotLocomotion/drake/pull/20179
 [_#20181]: https://github.com/RobotLocomotion/drake/pull/20181
 [_#20183]: https://github.com/RobotLocomotion/drake/pull/20183
+[_#20217]: https://github.com/RobotLocomotion/drake/pull/20217
 <!-- <end issue links> -->
 
 <!--

--- a/tools/workspace/vtk_internal/package.BUILD.bazel
+++ b/tools/workspace/vtk_internal/package.BUILD.bazel
@@ -18,6 +18,15 @@ config_setting(
     constraint_values = ["@platforms//os:osx"],
 )
 
+# When the rules.bzl needs to declare an objc_library, it adds this to `deps`
+# to improve the error messages in case of a mis-configured build.
+cc_library(
+    name = "_on_macos_you_must_not_have_forcepic_in_your_bazelrc_file_see_drake_issue_20217",  # noqa
+    linkstatic = True,
+    features = ["-supports_pic"],
+    tags = ["manual"],
+)
+
 # Generate some source files on the fly, using Bazel re-implementations of
 # various CMake scripts.
 

--- a/tools/workspace/vtk_internal/rules.bzl
+++ b/tools/workspace/vtk_internal/rules.bzl
@@ -150,7 +150,9 @@ def _vtk_cc_module_impl(
             defines = defines_extra,
             copts = copts,
             linkopts = linkopts,
-            deps = deps,
+            deps = deps + [
+                "//:_on_macos_you_must_not_have_forcepic_in_your_bazelrc_file_see_drake_issue_20217",  # noqa
+            ],
         )
         deps = deps + [objc_lib_name]
 


### PR DESCRIPTION
Here's the improved error message:

```console
jeremynimmer@macsim-m1-1 drake % bazel build --force_pic @vtk_internal//:all
ERROR: /.../external/vtk_internal/BUILD.bazel:21:11: in cc_library rule @vtk_internal//:_on_macos_you_must_not_have_forcepic_in_your_bazelrc_file_see_drake_issue_20217: 
Traceback (most recent call last):
	File "/virtual_builtins_bzl/common/cc/cc_library.bzl", line 32, column 57, in _cc_library_impl
Error in configure_features: PIC compilation is requested but the toolchain does not support it (feature named 'supports_pic' is not enabled)
ERROR: /.../external/vtk_internal/BUILD.bazel:21:11: Analysis of target '@vtk_internal//:_on_macos_you_must_not_have_forcepic_in_your_bazelrc_file_see_drake_issue_20217' failed
WARNING: errors encountered while analyzing target '@vtk_internal//:_VTK__RenderingOpenGL2_objc': it will not be built
WARNING: errors encountered while analyzing target '@vtk_internal//:vtkRenderingOpenGL2': it will not be built
WARNING: errors encountered while analyzing target '@vtk_internal//:VTK__RenderingOpenGL2': it will not be built
INFO: Analysis succeeded for only 208 of 211 top-level targets
INFO: Analyzed 211 targets (0 packages loaded, 0 targets configured).
INFO: Found 208 targets...
ERROR: command succeeded, but not all targets were analyzed
INFO: Elapsed time: 0.207s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
FAILED: Build did NOT complete successfully
```

Towards #20217.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20219)
<!-- Reviewable:end -->
