### PR TITLE
[systems] Don't render SharedPointerSystem in Graphviz

### DIFF
--- a/systems/primitives/shared_pointer_system.cc
+++ b/systems/primitives/shared_pointer_system.cc
@@ -18,6 +18,14 @@ SharedPointerSystem<T>::SharedPointerSystem(const SharedPointerSystem<U>& other)
 template <typename T>
 SharedPointerSystem<T>::~SharedPointerSystem() = default;
 
+template <typename T>
+typename LeafSystem<T>::GraphvizFragment
+SharedPointerSystem<T>::DoGetGraphvizFragment(
+    const typename LeafSystem<T>::GraphvizFragmentParams&) const {
+  // Do not show anything in Graphviz for this system.
+  return {};
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/primitives/shared_pointer_system.h
+++ b/systems/primitives/shared_pointer_system.h
@@ -106,6 +106,9 @@ class SharedPointerSystem final : public LeafSystem<T> {
 
   SharedPointerSystem(std::shared_ptr<void> held, std::type_index held_type);
 
+  typename LeafSystem<T>::GraphvizFragment DoGetGraphvizFragment(
+      const typename LeafSystem<T>::GraphvizFragmentParams&) const final;
+
   const std::shared_ptr<void> held_;
   const std::type_index held_type_;
 };

--- a/systems/primitives/test/shared_pointer_system_test.cc
+++ b/systems/primitives/test/shared_pointer_system_test.cc
@@ -72,6 +72,13 @@ GTEST_TEST(SharedPointerSystemTest, Null) {
   auto diagram = builder->Build();
 }
 
+// Just make sure nothing crashes.
+GTEST_TEST(SharedPointerSystemTest, Graphviz) {
+  auto held = std::make_shared<std::string>("held");
+  auto dut = std::make_unique<SharedPointerSystem<double>>(std::move(held));
+  EXPECT_NO_THROW(dut->GetGraphvizString());
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Towards #20203.

It never has any ports or connections.  The only thing it could add as a clue to the output is something like it's name?

My premise, however, it that users looking at graphviz are seeking information about control and/or information flow, not details about heap reference counting.

To compare the before/after output, you can use the command line given in #20198.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20228)
<!-- Reviewable:end -->
