### PR TITLE
[render] RenderMaterial offers more nuanced and complete warnings

### DIFF
--- a/geometry/render/render_material.h
+++ b/geometry/render/render_material.h
@@ -10,6 +10,10 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+/* Reports how UVs have been assigned to the mesh receiving a material. Textures
+ should only be applied to meshes with *fully* assigned UVs. */
+enum class UvState { kNone, kFull, kPartial };
+
 /* Specifies a mesh material as currently supported by Drake. We expect this
  definition to grow with time. */
 struct RenderMaterial {
@@ -47,14 +51,15 @@ void MaybeWarnForRedundantMaterial(
    - Finally, a diffuse material is created with the given default_diffuse
      color value.
 
- References to textures will be included in the material iff they can be read.
+ References to textures will be included in the material iff they can be read
+ and the `uv_state` is full. Otherwise, a warning will be dispatched.
 
  @pre The mesh (named by `mesh_filename`) is a valid mesh and did not have an
       acceptable material definition). */
 RenderMaterial MakeMeshFallbackMaterial(
     const GeometryProperties& props, const std::filesystem::path& mesh_path,
     const Rgba& default_diffuse,
-    const drake::internal::DiagnosticPolicy& policy);
+    const drake::internal::DiagnosticPolicy& policy, UvState uv_state);
 
 /* Creates a RenderMaterial from the given set of geometry properties. If no
  material properties exist, a material with the given default diffuse color is
@@ -69,7 +74,8 @@ RenderMaterial MakeMeshFallbackMaterial(
 RenderMaterial DefineMaterial(
     const GeometryProperties& props,
     const Rgba& default_diffuse = Rgba(1, 1, 1),
-    const drake::internal::DiagnosticPolicy& policy = {});
+    const drake::internal::DiagnosticPolicy& policy = {},
+    UvState uv_state = UvState::kFull);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/render/render_mesh.h
+++ b/geometry/render/render_mesh.h
@@ -29,22 +29,11 @@ struct RenderMesh {
   Eigen::Matrix<double, Eigen::Dynamic, 2, Eigen::RowMajor> uvs;
   Eigen::Matrix<unsigned int, Eigen::Dynamic, 3, Eigen::RowMajor> indices;
 
-  /* See docs for `has_tex_coord` below.  */
-  static constexpr bool kHasTexCoordDefault{true};
-
-  // TODO(SeanCurtis-TRI): this flag was necessary when materials and meshes
-  // were resolved separately. Now that we resolve materials at the same time,
-  // we should maintain the invariants that the presence of a texture map
-  // implies the presence of texture coordinates. We make no guarantees about
-  // the opposite direction -- that should only be relevant to efforts to add a
-  // texture material to a RenderMesh that didn't originally parse into having
-  // a texture material. It may or may not work. It also means that this
-  // cannot be a struct; structs don't get to maintain invariants.
-  /* This flag indicates that this mesh has texture coordinates to support maps.
-   If True, the values of `uvs` will be nontrivial.
-   If False, the values of `uvs` will be all zeros, but will still have the
-   correct size.  */
-  bool has_tex_coord{kHasTexCoordDefault};
+  /* Indicates the degree that UV coordinates have been assigned to the mesh.
+   Only UvState::kFull supports texture images. No matter what, the `uvs` matrix
+   will be appropriately sized. But only for kFull will the values be
+   meaningful. */
+  UvState uv_state{UvState::kNone};
 
   /* The specification of the material associated with this mesh data. */
   RenderMaterial material;
@@ -84,8 +73,8 @@ struct RenderMesh {
     - The geometric data is reconditioned to be compatible with "geometry
       buffer" applications. (See RenderMesh for details.)
 
- If no texture coordinates are specified by the file, it will be indicated in
- the returned RenderMesh. See RenderMesh::has_tex_coord for more detail.
+ If texture coordinates are assigned to vertices, it will be indicated in
+ the returned RenderMesh. See RenderMesh::uv_state for more detail.
 
  If the material includes texture paths, they will have been confirmed to both
  exist and be accessible.

--- a/geometry/render/test/render_mesh_test.cc
+++ b/geometry/render/test/render_mesh_test.cc
@@ -532,7 +532,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureButNoUvs) {
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
   EXPECT_THAT(TakeWarning(),
               testing::MatchesRegex(".*requested a diffuse texture.*doesn't "
-                                    "define texture coordinates.*"));
+                                    "define any texture coordinates.*"));
   EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 0));
   EXPECT_EQ(mesh.material.diffuse_map, "");
 }

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -58,6 +58,7 @@ drake_cc_library_ubuntu_only(
         ":internal_opengl_context",
         ":internal_shader_program_data",
         "//geometry/render:render_label",
+        "//geometry/render:render_material",
         "//math:geometric_transform",
     ],
 )

--- a/geometry/render_gl/internal_opengl_geometry.h
+++ b/geometry/render_gl/internal_opengl_geometry.h
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "drake/geometry/render/render_label.h"
+#include "drake/geometry/render/render_material.h"
 #include "drake/geometry/render_gl/internal_opengl_includes.h"
 #include "drake/geometry/render_gl/internal_shader_program_data.h"
 #include "drake/math/rigid_transform.h"
@@ -48,20 +49,19 @@ struct OpenGlGeometry {
    @param index_buffer_in       The handle to the OpenGl index buffer defining a
                                 set of triangles.
    @param index_buffer_size_in  The number of indices in the index buffer.
-   @param has_tex_coord_in      If true, the vertex buffer contains *meaningful*
-                                texture coordinates.
+   @param uv_state_in           The state of UVs assigned to the geometry.
    @param v_count_in            The number of vertices in this mesh (and, by
                                 implication, the number of normals and texture
                                 coordinates).
    @pre `index_buffer_size_in >= 0`.  */
   OpenGlGeometry(GLuint vertex_array_in, GLuint vertex_buffer_in,
                  GLuint index_buffer_in, int index_buffer_size_in,
-                 bool has_tex_coord_in, int v_count_in)
+                 geometry::internal::UvState uv_state_in, int v_count_in)
       : vertex_array{vertex_array_in},
         vertex_buffer{vertex_buffer_in},
         index_buffer{index_buffer_in},
         index_buffer_size{index_buffer_size_in},
-        has_tex_coord{has_tex_coord_in},
+        uv_state{uv_state_in},
         v_count(v_count_in) {
     if (index_buffer_size < 0) {
       throw std::logic_error("Index buffer size must be non-negative");
@@ -86,17 +86,16 @@ struct OpenGlGeometry {
 
   // TODO(SeanCurtis-TRI): This can't really be a struct; there are invariants
   // that need to be maintained: vertex_buffer is sized according to v_count,
-  // vertex_array depends on vertex_buffer, has_tex_coord needs to reflect
-  // the uv data in vertex_buffer, and index_buffer_size needs to be the actual
-  // size of index_buffer (in triangles).
+  // vertex_array depends on vertex_buffer, uv_state needs to reflect the uv
+  // data in vertex_buffer, and index_buffer_size needs to be the actual size of
+  // index_buffer (in triangles).
   GLuint vertex_array{kInvalid};
   GLuint vertex_buffer{kInvalid};
   GLuint index_buffer{kInvalid};
   int index_buffer_size{0};
 
-  /* True indicates that this has texture coordinates to support texture
-   maps. See MeshData::has_tex_coord for detail.  */
-  bool has_tex_coord{};
+  /* Reports the state of the UV data stored in the vertex buffer. */
+  geometry::internal::UvState uv_state{geometry::internal::UvState::kNone};
 
   // The number of vertices encoded in `vertex_buffer`.
   int v_count{};

--- a/geometry/render_gl/test/internal_opengl_geometry_test.cc
+++ b/geometry/render_gl/test/internal_opengl_geometry_test.cc
@@ -13,6 +13,7 @@ namespace internal {
 namespace {
 
 using Eigen::Vector3d;
+using geometry::internal::UvState;
 using math::RigidTransformd;
 using render::RenderLabel;
 
@@ -27,37 +28,44 @@ GTEST_TEST(OpenGlGeometryTest, Construction) {
   EXPECT_EQ(default_geometry.vertex_buffer, OpenGlGeometry::kInvalid);
   EXPECT_EQ(default_geometry.index_buffer, OpenGlGeometry::kInvalid);
   EXPECT_EQ(default_geometry.index_buffer_size, 0);
-  EXPECT_EQ(default_geometry.has_tex_coord, false);
+  EXPECT_EQ(default_geometry.uv_state, UvState::kNone);
   EXPECT_EQ(default_geometry.v_count, 0);
 
-  const OpenGlGeometry geometry{1, 2, 3, 4, true, 7};
+  const OpenGlGeometry geometry{1, 2, 3, 4, UvState::kPartial, 7};
   EXPECT_EQ(geometry.vertex_array, 1);
   EXPECT_EQ(geometry.vertex_buffer, 2);
   EXPECT_EQ(geometry.index_buffer, 3);
   EXPECT_EQ(geometry.index_buffer_size, 4);
-  EXPECT_EQ(geometry.has_tex_coord, true);
+  EXPECT_EQ(geometry.uv_state, UvState::kPartial);
   EXPECT_EQ(geometry.v_count, 7);
 
-  DRAKE_EXPECT_THROWS_MESSAGE(OpenGlGeometry(1, 2, 3, -1, false, 1),
+  DRAKE_EXPECT_THROWS_MESSAGE(OpenGlGeometry(1, 2, 3, -1, UvState::kNone, 1),
                               "Index buffer size must be non-negative");
 }
 
 GTEST_TEST(OpenGlGeometryTest, IsDefined) {
   const GLuint kInvalid = OpenGlGeometry::kInvalid;
 
-  EXPECT_TRUE(OpenGlGeometry(1, 2, 3, 4, false, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, 3, 4, false, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, 3, 4, false, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(1, 2, kInvalid, 4, false, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, kInvalid, 3, 4, false, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, kInvalid, 4, false, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, kInvalid, 4, false, 1).is_defined());
+  EXPECT_TRUE(OpenGlGeometry(1, 2, 3, 4, UvState::kNone, 1).is_defined());
   EXPECT_FALSE(
-      OpenGlGeometry(kInvalid, kInvalid, kInvalid, 4, false, 1).is_defined());
+      OpenGlGeometry(kInvalid, 2, 3, 4, UvState::kNone, 1).is_defined());
+  EXPECT_FALSE(
+      OpenGlGeometry(1, kInvalid, 3, 4, UvState::kNone, 1).is_defined());
+  EXPECT_FALSE(
+      OpenGlGeometry(1, 2, kInvalid, 4, UvState::kNone, 1).is_defined());
+  EXPECT_FALSE(
+      OpenGlGeometry(kInvalid, kInvalid, 3, 4, UvState::kNone, 1).is_defined());
+  EXPECT_FALSE(
+      OpenGlGeometry(kInvalid, 2, kInvalid, 4, UvState::kNone, 1).is_defined());
+  EXPECT_FALSE(
+      OpenGlGeometry(1, kInvalid, kInvalid, 4, UvState::kNone, 1).is_defined());
+  EXPECT_FALSE(
+      OpenGlGeometry(kInvalid, kInvalid, kInvalid, 4, UvState::kNone, 1)
+          .is_defined());
 }
 
 GTEST_TEST(OpenGlGeometryTest, ThrowIfUndefined) {
-  const OpenGlGeometry valid{1, 2, 3, 4, false, 1};
+  const OpenGlGeometry valid{1, 2, 3, 4, UvState::kNone, 1};
   EXPECT_NO_THROW(valid.throw_if_undefined("test message"));
   DRAKE_EXPECT_THROWS_MESSAGE(
       OpenGlGeometry().throw_if_undefined("default is undefined"),

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -143,8 +143,12 @@ void RenderEngineVtk::ImplementGeometry(const Box& box, void* user_data) {
 void RenderEngineVtk::ImplementGeometry(const Capsule& capsule,
                                         void* user_data) {
   const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  // TODO(18296): When the capsule has texture coordinates, remove the UvState
+  // and let it default to UvState::kFull.
   ImplementPolyData(CreateVtkCapsule(capsule).GetPointer(),
-                    DefineMaterial(data.properties, default_diffuse_), data);
+                    DefineMaterial(data.properties, default_diffuse_, {},
+                                   geometry::internal::UvState::kNone),
+                    data);
 }
 
 void RenderEngineVtk::ImplementGeometry(const Convex& convex, void* user_data) {


### PR DESCRIPTION
The fallback materials would use the ('phong', 'diffuse_map') or matching foo.png images as diffuse texture map, even if the underlying mesh could not support it. This is because they were given no information about whether a texture could be applied or not.

Now, it is provided information as to the support of texture coordinates and will *also* omit a texture if the underlying geometry lacks sufficient texture coordinate support.

Note: This leads to a very subtle, but non-destructive behavior change. If a diffuse map was specified for a capsule in RenderEngineVtk, the image will not appear (as it did before), but now there's a warning emitted.

This is the first PR in a train relating to #17266. The full PR train can be seen in #20235. This PR corresponds to the first commit  in that PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20236)
<!-- Reviewable:end -->
