### PR TITLE
[meshcat] Set Content-Type for HTML pages

### DIFF
--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -2,6 +2,7 @@ import pydrake.geometry as mut
 
 import copy
 import unittest
+import urllib.request
 
 import numpy as np
 
@@ -340,6 +341,13 @@ class TestGeometryVisualizers(unittest.TestCase):
 
     def test_start_meshcat(self):
         # StartMeshcat only performs interesting work on cloud notebook hosts.
-        # Here we simply ensure that it runs.
+        # Here we simply ensure that it runs and is available.
         meshcat = mut.StartMeshcat()
         self.assertIsInstance(meshcat, mut.Meshcat)
+        with urllib.request.urlopen(meshcat.web_url()) as response:
+            content_type = response.getheader("Content-Type")
+            some_data = response.read(4096)
+        # This also serves as a regresion test of the C++ code, where parsing
+        # the Content-Type is difficult within its unit test infrastructure.
+        self.assertIn("text/html", content_type)
+        self.assertIn("DOCTYPE html", some_data.decode("utf-8"))

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1795,7 +1795,12 @@ class Meshcat::Impl {
             .get("/*",
                  [&](uWS::HttpResponse<kSsl>* res, uWS::HttpRequest* req) {
                    DRAKE_DEMAND(IsThread(websocket_thread_id_));
-                   res->end(GetUrlContent(req->getUrl()));
+                   const std::string& content = GetUrlContent(req->getUrl());
+                   if (content.substr(0, 15) == "<!DOCTYPE html>") {
+                     res->writeHeader("Content-Type",
+                                      "text/html; charset=utf-8");
+                   }
+                   res->end(content);
                  })
             .ws<PerSocketData>("/*", std::move(behavior));
     app_ = &app;

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -95,6 +95,9 @@ GTEST_TEST(MeshcatTest, TestHttp) {
   EXPECT_EQ(SystemCall({"/usr/bin/curl", "-o", "/dev/null", "--silent",
                         meshcat.web_url() + "/no-such-file"}),
             0);
+  // Note that the pydrake visualizers_test.py case test_start_meshcat() also
+  // checks the http Content-Type and page data. It's too awkward to try to
+  // do that here.
 }
 
 GTEST_TEST(MeshcatTest, ConstructMultiple) {


### PR DESCRIPTION
It's not clear to me why or whether this matters, but we have [anecdotal reports](https://stackoverflow.com/questions/77137333/meshcat-port-forwarding-with-vs-code) that it might.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20237)
<!-- Reviewable:end -->
