### PR TITLE
[planning] Export ports from RobotDiagram by default

### DIFF
--- a/planning/robot_diagram.cc
+++ b/planning/robot_diagram.cc
@@ -46,8 +46,6 @@ RobotDiagram<T>::RobotDiagram(
       scene_graph_(DowncastSubsystem<T, SceneGraph>(diagram_builder.get(),
                                                     kSceneGraphIndex)) {
   diagram_builder->BuildInto(this);
-  // TODO(jeremy.nimmer) For convenience, we should probably re-export most (or
-  // all) of the the subsytems' input and output ports here.
 }
 
 template <typename T>

--- a/planning/robot_diagram.h
+++ b/planning/robot_diagram.h
@@ -21,6 +21,28 @@ should generally prefer to just use a Diagram, instead.
 
 Use RobotDiagramBuilder to construct a RobotDiagram.
 
+By default, the ports exposed by a %RobotDiagram are the set of all ports
+provided by the plant and scene graph (excluding the internal connections
+between the two). Refer to their individual overview figures for details
+(see multibody::MultibodyPlant and geometry::SceneGraph), or see the full
+list by viewing the robot_diagram.GetGraphvizString().
+
+@system
+name: RobotDiagram
+input_ports:
+- plant_actuation
+- plant_applied_generalized_force
+- ... etc ...
+output_ports:
+- plant_state
+- ... etc ...
+- scene_graph_query
+@endsystem
+
+However, if the RobotDiagramBuilder::builder() was used to change the diagram or
+if either the plant or scene graph were renamed, then no ports will be exported
+by default. In that case, you can use the builder to export any desired ports.
+
 @tparam_default_scalar
 
 @ingroup planning_infrastructure */

--- a/planning/robot_diagram_builder.cc
+++ b/planning/robot_diagram_builder.cc
@@ -11,6 +11,10 @@ namespace planning {
 using geometry::SceneGraph;
 using multibody::AddMultibodyPlantSceneGraph;
 using systems::DiagramBuilder;
+using systems::InputPort;
+using systems::InputPortIndex;
+using systems::OutputPort;
+using systems::OutputPortIndex;
 using systems::System;
 
 template <typename T>
@@ -29,6 +33,11 @@ std::unique_ptr<RobotDiagram<T>> RobotDiagramBuilder<T>::Build() {
   ThrowIfAlreadyBuiltOrCorrupted();
   if (!plant().is_finalized()) {
     plant().Finalize();
+  }
+  // Unless the user has customized anything, by default it's convenient to
+  // export everything.
+  if (ShouldExportDefaultPorts()) {
+    ExportDefaultPorts();
   }
   return std::unique_ptr<RobotDiagram<T>>(
       new RobotDiagram<T>(std::move(builder_)));
@@ -62,6 +71,43 @@ void RobotDiagramBuilder<T>::ThrowIfAlreadyBuiltOrCorrupted() const {
     throw std::logic_error(
         "RobotDiagramBuilder: The underlying DiagramBuilder has become "
         "corrupted. You must not remove the MultibodyPlant or SceneGraph.");
+  }
+}
+
+/* Checks for whether or not the user has customized anything that would impact
+the default counts or names of exported ports. */
+template <typename T>
+bool RobotDiagramBuilder<T>::ShouldExportDefaultPorts() const {
+  return plant().get_name() == "plant" &&
+         scene_graph().get_name() == "scene_graph" &&
+         builder_->GetSystems().size() == 2 &&
+         builder_->num_input_ports() == 0 && builder_->num_output_ports() == 0;
+}
+
+template <typename T>
+void RobotDiagramBuilder<T>::ExportDefaultPorts() const {
+  // Export ports per the contract in the RobotDiagram class overview.
+  for (const System<T>* system : builder_->GetSystems()) {
+    for (InputPortIndex i{0}; i < system->num_input_ports(); ++i) {
+      if (system == &this->scene_graph()) {
+        // Don't export any SceneGraph input ports. The fact that it has any
+        // disconnected input ports is a bug that we'll paper over here.
+        // TODO(jwnimmer-tri) We can (and should) remove this special case once
+        // the deformable code resolves its messy "the configuration input port
+        // is disconnected by default" status quo.
+        break;  // Skip all input ports.
+      }
+      const InputPort<T>& port = system->get_input_port(i);
+      if (builder_->IsConnectedOrExported(port)) {
+        // We can't export this input because it's internally-sourced already.
+        continue;  // Skip just this one input port.
+      }
+      builder_->ExportInput(port);
+    }
+    for (OutputPortIndex i{0}; i < system->num_output_ports(); ++i) {
+      const OutputPort<T>& port = system->get_output_port(i);
+      builder_->ExportOutput(port);
+    }
   }
 }
 

--- a/planning/robot_diagram_builder.h
+++ b/planning/robot_diagram_builder.h
@@ -107,6 +107,9 @@ class RobotDiagramBuilder {
  private:
   void ThrowIfAlreadyBuiltOrCorrupted() const;
 
+  bool ShouldExportDefaultPorts() const;
+  void ExportDefaultPorts() const;
+
   // Storage for the diagram and its plant and scene graph.
   // After Build(), the `builder_` is set to nullptr.
   std::unique_ptr<systems::DiagramBuilder<T>> builder_;

--- a/planning/test/robot_diagram_test.cc
+++ b/planning/test/robot_diagram_test.cc
@@ -1,5 +1,9 @@
 #include "drake/planning/robot_diagram.h"
 
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -58,6 +62,54 @@ GTEST_TEST(RobotDiagramBuilderTest, Getters) {
   EXPECT_EQ(&mutable_parser.plant(), &plant);
   EXPECT_THAT(builder.GetSystems(), ::testing::Contains(&plant));
   EXPECT_THAT(builder.GetSystems(), ::testing::Contains(&scene_graph));
+}
+
+// If the user has exported an input port, nothing else gets exported.
+GTEST_TEST(RobotDiagramBuilderTest, NoDefaultExportCustomInputPort) {
+  std::unique_ptr<RobotDiagramBuilder<double>> dut = MakeSampleDut();
+  dut->plant().Finalize();
+  dut->builder().ExportInput(dut->plant().GetInputPort("actuation"));
+  auto diagram = dut->Build();
+  EXPECT_EQ(diagram->num_input_ports(), 1);
+  EXPECT_EQ(diagram->num_output_ports(), 0);
+  EXPECT_NO_THROW(diagram->GetInputPort("plant_actuation"));
+}
+
+// If the user has exported an output port, nothing else gets exported.
+GTEST_TEST(RobotDiagramBuilderTest, NoDefaultExportCustomOutputPort) {
+  std::unique_ptr<RobotDiagramBuilder<double>> dut = MakeSampleDut();
+  dut->builder().ExportOutput(dut->scene_graph().GetOutputPort("query"));
+  auto diagram = dut->Build();
+  EXPECT_EQ(diagram->num_input_ports(), 0);
+  EXPECT_EQ(diagram->num_output_ports(), 1);
+  EXPECT_NO_THROW(diagram->GetOutputPort("scene_graph_query"));
+}
+
+// If the user has added an extra system or renamed any system then nothing gets
+// exported.
+GTEST_TEST(RobotDiagramBuilderTest, NoDefaultExportCustomSystems) {
+  std::unique_ptr<RobotDiagramBuilder<double>> dut;
+
+  std::array<std::function<void()>, 3> edits = {
+      [&dut]() {
+        dut->builder().AddSystem<SharedPointerSystem>(std::shared_ptr<void>());
+      },
+      [&dut]() {
+        dut->plant().set_name("foo");
+      },
+      [&dut]() {
+        dut->scene_graph().set_name("foo");
+      },
+  };
+
+  for (size_t i = 0; i < edits.size(); ++i) {
+    SCOPED_TRACE(fmt::format("i = {}", i));
+    dut = MakeSampleDut();
+    edits[i]();
+    auto diagram = dut->Build();
+    EXPECT_EQ(diagram->num_input_ports(), 0);
+    EXPECT_EQ(diagram->num_output_ports(), 0);
+  }
 }
 
 GTEST_TEST(RobotDiagramBuilderTest, Lifecycle) {
@@ -198,6 +250,29 @@ GTEST_TEST(RobotDiagramTest, Clone) {
 
   // The new plant is distinct from the old plant.
   EXPECT_NE(&copy->plant(), &dut->plant());
+}
+
+GTEST_TEST(RobotDiagramTest, PortNamesExist) {
+  std::unique_ptr<RobotDiagram<double>> dut = MakeSampleDut()->Build();
+
+  // Write the Graphviz output for offline debugging.
+  if (const char* dir = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR")) {
+    std::ofstream out(std::filesystem::path(dir) / "iiwa14.dot");
+    out << dut->GetGraphvizString();
+    EXPECT_TRUE(out.good());
+  }
+
+  // Check the names mentioned in the class overview comment.
+  EXPECT_NO_THROW(dut->GetInputPort("plant_actuation"));
+  EXPECT_NO_THROW(dut->GetInputPort("plant_applied_generalized_force"));
+  EXPECT_NO_THROW(dut->GetOutputPort("plant_state"));
+  EXPECT_NO_THROW(dut->GetOutputPort("scene_graph_query"));
+
+  // The scene graph should not export any inputs.
+  for (int i = 0; i < dut->num_input_ports(); ++i) {
+    EXPECT_THAT(dut->get_input_port(i).get_name(),
+                ::testing::StartsWith("plant_"));
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
As of r1:

![image](https://github.com/RobotLocomotion/drake/assets/17596505/593dff86-8687-449c-9de4-f5965019b7cd)

As of r2:

![image](https://github.com/RobotLocomotion/drake/assets/17596505/43b4cbb4-d867-412b-9036-20906c219dc5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20238)
<!-- Reviewable:end -->
