### PR TITLE
[bazel] Remove irrelevant rcfile flag

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,6 +1,3 @@
-# Disable native Python rules in Bazel versions before 4.0.
-build --incompatible_load_python_rules_from_bzl=yes
-
 # Default to an optimized build.
 build -c opt
 


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/9006.  This flag doesn't do anything.

https://github.com/RobotLocomotion/drake-external-examples/pull/270 tracks its removal from `drake-external-examples` as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20242)
<!-- Reviewable:end -->
