### PR TITLE
Support arbitrary geometric continuity order for GcsTrajectoryOptimization

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -404,7 +404,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py_rvp::reference_internal, py::arg("regions"),
             py::arg("edges_between_regions"), py::arg("order"),
             py::arg("h_min") = 1e-6, py::arg("h_max") = 20,
-            py::arg("name") = "", cls_doc.AddRegions.doc_6args)
+            py::arg("name") = "", py::arg("geometric_continuity_order") = 0,
+            cls_doc.AddRegions.doc_7args)
         .def(
             "AddRegions",
             [](Class& self,
@@ -416,7 +417,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             },
             py_rvp::reference_internal, py::arg("regions"), py::arg("order"),
             py::arg("h_min") = 1e-6, py::arg("h_max") = 20,
-            py::arg("name") = "", cls_doc.AddRegions.doc_5args)
+            py::arg("name") = "", py::arg("geometric_continuity_order") = 0,
+            cls_doc.AddRegions.doc_6args)
         .def("AddEdges", &Class::AddEdges, py_rvp::reference_internal,
             py::arg("from_subgraph"), py::arg("to_subgraph"),
             py::arg("subspace") = py::none(), cls_doc.AddEdges.doc)

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -396,10 +396,11 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             [](Class& self,
                 const std::vector<geometry::optimization::ConvexSet*>& regions,
                 const std::vector<std::pair<int, int>>& edges_between_regions,
-                int order, double h_min, double h_max,
-                std::string name) -> Class::Subgraph& {
+                int order, double h_min, double h_max, std::string name,
+                int geometric_continuity_order) -> Class::Subgraph& {
               return self.AddRegions(CloneConvexSets(regions),
-                  edges_between_regions, order, h_min, h_max, std::move(name));
+                  edges_between_regions, order, h_min, h_max, std::move(name),
+                  geometric_continuity_order);
             },
             py_rvp::reference_internal, py::arg("regions"),
             py::arg("edges_between_regions"), py::arg("order"),
@@ -410,10 +411,10 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             "AddRegions",
             [](Class& self,
                 const std::vector<geometry::optimization::ConvexSet*>& regions,
-                int order, double h_min, double h_max,
-                std::string name) -> Class::Subgraph& {
+                int order, double h_min, double h_max, std::string name,
+                int geometric_continuity_order) -> Class::Subgraph& {
               return self.AddRegions(CloneConvexSets(regions), order, h_min,
-                  h_max, std::move(name));
+                  h_max, std::move(name), geometric_continuity_order);
             },
             py_rvp::reference_internal, py::arg("regions"), py::arg("order"),
             py::arg("h_min") = 1e-6, py::arg("h_max") = 20,

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -60,13 +60,13 @@ const double kInf = std::numeric_limits<double>::infinity();
 Subgraph::Subgraph(
     const ConvexSets& regions,
     const std::vector<std::pair<int, int>>& edges_between_regions, int order,
-    double h_min, double h_max, int geometric_continuity_order,
-    std::string name, GcsTrajectoryOptimization* traj_opt)
+    double h_min, double h_max, std::string name,
+    int geometric_continuity_order, GcsTrajectoryOptimization* traj_opt)
     : regions_(regions),
       order_(order),
       h_min_(h_min),
-      geometric_continuity_order_(geometric_continuity_order),
       name_(std::move(name)),
+      geometric_continuity_order_(geometric_continuity_order),
       traj_opt_(*traj_opt) {
   DRAKE_THROW_UNLESS(order >= 0);
   DRAKE_THROW_UNLESS(geometric_continuity_order_ >= 0);
@@ -467,14 +467,14 @@ GcsTrajectoryOptimization::~GcsTrajectoryOptimization() = default;
 Subgraph& GcsTrajectoryOptimization::AddRegions(
     const ConvexSets& regions,
     const std::vector<std::pair<int, int>>& edges_between_regions, int order,
-    double h_min, double h_max, int geometric_continuity_order,
-    std::string name) {
+    double h_min, double h_max, std::string name,
+    int geometric_continuity_order) {
   if (name.empty()) {
     name = fmt::format("Subgraph{}", subgraphs_.size());
   }
   Subgraph* subgraph =
       new Subgraph(regions, edges_between_regions, order, h_min, h_max,
-                   geometric_continuity_order, std::move(name), this);
+                   std::move(name), geometric_continuity_order, this);
 
   // Add global costs to the subgraph.
   for (double weight : global_time_costs_) {
@@ -493,11 +493,9 @@ Subgraph& GcsTrajectoryOptimization::AddRegions(
   return *subgraphs_.emplace_back(subgraph);
 }
 
-Subgraph& GcsTrajectoryOptimization::AddRegions(const ConvexSets& regions,
-                                                int order, double h_min,
-                                                double h_max,
-                                                int geometric_continuity_order,
-                                                std::string name) {
+Subgraph& GcsTrajectoryOptimization::AddRegions(
+    const ConvexSets& regions, int order, double h_min, double h_max,
+    std::string name, int geometric_continuity_order) {
   // TODO(wrangelvid): This is O(n^2) and can be improved.
   std::vector<std::pair<int, int>> edges_between_regions;
   for (size_t i = 0; i < regions.size(); ++i) {
@@ -511,8 +509,8 @@ Subgraph& GcsTrajectoryOptimization::AddRegions(const ConvexSets& regions,
   }
 
   return GcsTrajectoryOptimization::AddRegions(
-      regions, edges_between_regions, order, h_min, h_max,
-      geometric_continuity_order, std::move(name));
+      regions, edges_between_regions, order, h_min, h_max, std::move(name),
+      geometric_continuity_order);
 }
 
 EdgesBetweenSubgraphs& GcsTrajectoryOptimization::AddEdges(

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -1,5 +1,6 @@
 #include "drake/planning/trajectory_optimization/gcs_trajectory_optimization.h"
 
+#include <algorithm>
 #include <limits>
 #include <tuple>
 #include <unordered_map>

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -32,9 +32,12 @@ via a conservative formulation, it supports geometric continuity on the path for
 arbitrary degree. That means the path is geoemtrically continuous at the
 transition times between the regions, however it may not be time-continuous. See
 the paper for further details on difference between geometric and time
-continuity. https://www2.eecs.berkeley.edu/Pubs/TechRpts/1984/CSD-84-205.pdf The
-resulting trajectories can be post-processed with e.g. Toppra in order to smooth
-out the timing rescaling.
+continuity. https://www2.eecs.berkeley.edu/Pubs/TechRpts/1984/CSD-84-205.pdf
+The resulting trajectories can be post-processed with e.g. Toppra in order to
+smooth out the timing rescaling.
+It is recommended to use order > 1 + 2 * geometric_continuity_order.
+Otherwise the geometric continuity constraints will be infeasible unless
+the problem is degenerate (e.g. the whole path is one line segment.)
 
 The ith piece of the composite trajectory is defined as q(t) = r((t - tᵢ) /
 hᵢ). r : [0, 1] → ℝⁿ is a the path, parametrized as a Bézier curve with order
@@ -277,7 +280,8 @@ class GcsTrajectoryOptimization final {
   energy ||ṙ(s)||² / h becomes non-convex for h = 0. Otherwise h_min can be set
   to 0.
   @param geometric_continuity_order is the order of the geometric continuity
-    constraints imposed at the transitions between regions.
+    constraints imposed at the transitions between regions. Can not be greater
+    than order.
   @param name is the name of the subgraph. A default name will be provided.
   */
   Subgraph& AddRegions(
@@ -300,7 +304,8 @@ class GcsTrajectoryOptimization final {
   @param h_max is the maximum duration to spend in a region (seconds). Some
   solvers struggle numerically with large values.
   @param geometric_continuity_order is the order of the geometric continuity
-    constraints imposed at the transitions between regions.
+    constraints imposed at the transitions between regions. Can not be greater
+    than order.
   @param name is the name of the subgraph. A default name will be provided.
   */
   Subgraph& AddRegions(const geometry::optimization::ConvexSets& regions,

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -34,7 +34,9 @@ transition times between the regions, however it may not be time-continuous. See
 the paper for further details on difference between geometric and time
 continuity. https://www2.eecs.berkeley.edu/Pubs/TechRpts/1984/CSD-84-205.pdf
 The resulting trajectories can be post-processed with e.g. Toppra in order to
-smooth out the timing rescaling.
+smooth out the timing rescaling. Note that Toppra is not currently informed
+of the piecewise nature of its input. Therefore, it is recommended to use a
+C2 geometric continuity order before using Toppra.
 It is recommended to use order > 1 + 2 * geometric_continuity_order.
 Otherwise the geometric continuity constraints will be infeasible unless
 the problem is degenerate (e.g. the whole path is one line segment.)

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -143,8 +143,8 @@ class GcsTrajectoryOptimization final {
     /* Constructs a new subgraph and copies the regions. */
     Subgraph(const geometry::optimization::ConvexSets& regions,
              const std::vector<std::pair<int, int>>& regions_to_connect,
-             int order, double h_min, double h_max,
-             int geometric_continuity_order, std::string name,
+             int order, double h_min, double h_max, std::string name,
+             int geometric_continuity_order,
              GcsTrajectoryOptimization* traj_opt);
 
     /* Convenience accessor, for brevity. */
@@ -161,8 +161,8 @@ class GcsTrajectoryOptimization final {
     const geometry::optimization::ConvexSets regions_;
     const int order_;
     const double h_min_;
-    const int geometric_continuity_order_;
     const std::string name_;
+    const int geometric_continuity_order_;
     GcsTrajectoryOptimization& traj_opt_;
 
     std::vector<geometry::optimization::GraphOfConvexSets::Vertex*> vertices_;
@@ -281,16 +281,16 @@ class GcsTrajectoryOptimization final {
   convex for h > 0. For example the perspective quadratic cost of the path
   energy ||ṙ(s)||² / h becomes non-convex for h = 0. Otherwise h_min can be set
   to 0.
+  @param name is the name of the subgraph. A default name will be provided.
   @param geometric_continuity_order is the order of the geometric continuity
     constraints imposed at the transitions between regions. Can not be greater
     than order.
-  @param name is the name of the subgraph. A default name will be provided.
   */
   Subgraph& AddRegions(
       const geometry::optimization::ConvexSets& regions,
       const std::vector<std::pair<int, int>>& edges_between_regions, int order,
-      double h_min = 0, double h_max = 20, int geometric_continuity_order = 0,
-      std::string name = "");
+      double h_min = 0, double h_max = 20, std::string name = "",
+      int geometric_continuity_order = 0);
 
   /** Creates a Subgraph with the given regions.
   This function will compute the edges between the regions based on the set
@@ -305,15 +305,15 @@ class GcsTrajectoryOptimization final {
   to 0.
   @param h_max is the maximum duration to spend in a region (seconds). Some
   solvers struggle numerically with large values.
-  @param geometric_continuity_order is the order of the geometric continuity
-    constraints imposed at the transitions between regions. Can not be greater
-    than order.
   @param name is the name of the subgraph. A default name will be provided.
+  @param geometric_continuity_order is the order of the geometric continuity
+  constraints imposed at the transitions between regions. Can not be greater
+  than order.
   */
   Subgraph& AddRegions(const geometry::optimization::ConvexSets& regions,
                        int order, double h_min = 0, double h_max = 20,
-                       int geometric_continuity_order = 0,
-                       std::string name = "");
+                       std::string name = "",
+                       int geometric_continuity_order = 0);
 
   /** Connects two subgraphs with directed edges.
   @param from_subgraph is the subgraph to connect from. Must have been created

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -792,7 +792,7 @@ TEST_F(SimpleEnv2D, DurationDelay) {
   // New added regions will inherit this cost.
   gcs.AddPathLengthCost();
 
-  Vector2d start(0.2, 0.2), goal(0.3, 0.2);
+  Vector2d start(0.2, 0.2), goal(4.8, 4.8);
   auto& regions = gcs.AddRegions(regions_, 1, kMinimumDuration);
   // Setting h_min = h_max = kStartDelay seconds will force to stay a the start
   // of the trajectory for kStartDelay seconds.

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -170,7 +170,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, MinimumTimeVsPathLength) {
   auto& walking_regions =
       gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeBox(Vector2d(-0.5, -0.5),
                                                          Vector2d(0.5, 0.5))),
-                     3, 0, 20, 0, "walking");
+                     3, 0, 20, "walking");
   // Bob can walk at 1 m/s in x and y.
   walking_regions.AddVelocityBounds(Vector2d(-kWalkingSpeed, -kWalkingSpeed),
                                     Vector2d(kWalkingSpeed, kWalkingSpeed));
@@ -180,7 +180,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, MinimumTimeVsPathLength) {
           HPolyhedron::MakeBox(Vector2d(-0.5, -0.5), Vector2d(-0.2, 1)),
           HPolyhedron::MakeBox(Vector2d(-0.5, 1), Vector2d(0.5, 1.5)),
           HPolyhedron::MakeBox(Vector2d(0.2, -0.5), Vector2d(0.5, 1))),
-      3, 0, 20, 0, "scooter");
+      3, 0, 20, "scooter", 0);
   // Bob can ride an e-scooter at 10 m/s in x and y.
   scooter_regions.AddVelocityBounds(Vector2d(-kScooterSpeed, -kScooterSpeed),
                                     Vector2d(kScooterSpeed, kScooterSpeed));
@@ -714,8 +714,9 @@ TEST_F(SimpleEnv2D, GeometricContinuity) {
 
     Vector2d start(4.8, 0.2), goal(4.8, 4.8);
     int kOrder = 1 + 2 * kGeometricContinuityOrder;
-    auto& regions = gcs.AddRegions(regions_, kOrder, kMinimumDuration,
-                                   kMaximumDuration, kGeometricContinuityOrder);
+    auto& regions =
+        gcs.AddRegions(regions_, kOrder, kMinimumDuration, kMaximumDuration, "",
+                       kGeometricContinuityOrder);
     auto& source = gcs.AddRegions(MakeConvexSets(Point(start)), 0);
     auto& target = gcs.AddRegions(MakeConvexSets(Point(goal)), 0);
     gcs.AddEdges(source, regions);
@@ -766,14 +767,14 @@ TEST_F(SimpleEnv2D, InvalidGeometricContinuity) {
     // geometric continuity order can not be negative
     GcsTrajectoryOptimization gcs(kDimension);
     DRAKE_EXPECT_THROWS_MESSAGE(
-        gcs.AddRegions(regions_, 2, kMinimumDuration, kMaximumDuration, -1),
+        gcs.AddRegions(regions_, 2, kMinimumDuration, kMaximumDuration, "", -1),
         ".*order.*");
   }
   {
     // geometric continuity order not be greater than the order of the subgraph
     GcsTrajectoryOptimization gcs(kDimension);
     DRAKE_EXPECT_THROWS_MESSAGE(
-        gcs.AddRegions(regions_, 1, kMinimumDuration, kMaximumDuration, 2),
+        gcs.AddRegions(regions_, 1, kMinimumDuration, kMaximumDuration, "", 2),
         ".*order.*");
   }
 }
@@ -968,8 +969,8 @@ TEST_F(SimpleEnv2D, IntermediatePoint) {
   // We can have different order subgraphs.
   // The trajectory from start to either subspace or intermidiate point will be
   // of order 3 and the trajectory from intermediate to goal will be of order 2.
-  auto& main1 = gcs.AddRegions(regions_, 3, 1e-6, 20, 0, "main1");
-  auto& main2 = gcs.AddRegions(regions_, 2, 1e-6, 20, 0, "main2");
+  auto& main1 = gcs.AddRegions(regions_, 3, 1e-6, 20, "main1");
+  auto& main2 = gcs.AddRegions(regions_, 2, 1e-6, 20, "main2");
 
   auto& source = gcs.AddRegions(MakeConvexSets(Point(start)), 0);
   auto& target = gcs.AddRegions(MakeConvexSets(Point(goal)), 0);


### PR DESCRIPTION
It was mentioned in the documentation of `GcsTrajectoryOptimization` that it supports arbitrary degrees of path continuity whereas it did not. This PR adds the constraints for arbitrary geometric continuity order at the transitions between Gcs regions.

Some results on the `SimpleEnv2D` unittest (_the script for generation of the images is not included in the PR_):
<img src="https://github.com/RobotLocomotion/drake/assets/26656757/09f9683a-d554-407b-bdb3-f18cdc70a23a" width="400" height="400" />  <img src="https://github.com/RobotLocomotion/drake/assets/26656757/f0ea37b7-5e96-4ee1-8315-65484a2e9cda" width="400" height="400" />

**Note about Toppra notes** the documentation stated that "The resulting trajectories can be post-processed with e.g. Toppra in order to smooth out the timing rescaling.".  We found that this is very nuanced. Toppra does **not** know about the piecewise nature of its trajectory. Therefore, the output can be a timed trajectory that violates the dynamic limits by arbitrary wide margins.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20243)
<!-- Reviewable:end -->
