### PR TITLE
Parsing an .obj file can produce multiple RenderMesh instances

### DIFF
--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -3,16 +3,16 @@
 #include <algorithm>
 #include <fstream>
 #include <map>
-#include <set>
 #include <string>
 #include <tuple>
-#include <vector>
+#include <utility>
 
 #include <fmt/format.h>
 #include <tiny_obj_loader.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {
@@ -92,10 +92,9 @@ RenderMaterial MakeMaterialFromMtl(const tinyobj::material_t& mat,
 // TODO(SeanCurtis-TRI): Add troubleshooting entry on OBJ support and
 // reference it in these errors/warnings.
 
-RenderMesh LoadRenderMeshFromObj(const std::filesystem::path& obj_path,
-                                 const GeometryProperties& properties,
-                                 const Rgba& default_diffuse,
-                                 const DiagnosticPolicy& policy) {
+vector<RenderMesh> LoadRenderMeshesFromObj(
+    const std::filesystem::path& obj_path, const GeometryProperties& properties,
+    const Rgba& default_diffuse, const DiagnosticPolicy& policy) {
   tinyobj::ObjReaderConfig config;
   config.triangulate = true;
   config.vertex_color = false;
@@ -129,9 +128,6 @@ RenderMesh LoadRenderMeshFromObj(const std::filesystem::path& obj_path,
   }
 
   const tinyobj::attrib_t& attrib = reader.GetAttrib();
-
-  // All of the materials referenced by faces.
-  std::set<int> referenced_materials;
 
   /* The parsed product needs to be further processed. The RenderMesh assumes
    that all vertex quantities (positions, normals, texture coordinates) are
@@ -175,6 +171,11 @@ RenderMesh LoadRenderMeshFromObj(const std::filesystem::path& obj_path,
   vector<Vector2d> uvs;
   vector<Vector3<int>> triangles;
 
+  /* A map from the index of a material that was referenced to the indices of
+   the faces to which it is applied. The face indices are not indices into
+   the original obj, but into the `triangles` data. */
+  map<int, vector<int>> material_triangles;
+
   // TODO(SeanCurtis-TRI) Revisit how we handle normals:
   //   1. If normals are absent, generate normals so that we get faceted meshes.
   //   2. Make use of smoothing groups.
@@ -183,7 +184,21 @@ RenderMesh LoadRenderMeshFromObj(const std::filesystem::path& obj_path,
         fmt::format("OBJ has no normals: {}", obj_path.string()));
   }
 
-  bool has_tex_coord{attrib.texcoords.size() > 0};
+  /* Each triangle consists of three vertices. Any of those vertices may be
+   associated with a corresponding UV value. For each material, we'll count the
+   number of vertices with associated UVs. If the value is zero, no UVs were
+   assigned at all. If it is equal to 3T (T = num triangles), UVs are assigned
+   to all vertices. Any number in between means incomplete assignment. This
+   will result in the following behavior:
+
+     - fewer than 3T UVs: if the material references texture maps
+                            - the map will be omitted,
+                            - a warning will be dispatched.
+                            - the RenderMesh will report no UVs (although it
+                              will hold a full complement of zero-valued UVs).
+     - 3T UVs: The RenderMesh will report it has UVs and the material will not
+               be hampered in any way. */
+  map<int, int> material_uvs;
 
   for (const auto& shape : shapes) {
     /* Each face is a sequence of indices. All of the face indices are
@@ -198,6 +213,7 @@ RenderMesh LoadRenderMeshFromObj(const std::filesystem::path& obj_path,
     const int num_faces = static_cast<int>(shape_mesh.num_face_vertices.size());
     for (int f = 0; f < num_faces; ++f) {
       DRAKE_DEMAND(shape_mesh.num_face_vertices[f] == 3);
+      const int mat_index = shape_mesh.material_ids[f];
       /* Captures the [i0, i1, i2] new index values for the face.  */
       int face_vertices[3] = {-1, -1, -1};
       for (int i = 0; i < 3; ++i) {
@@ -208,17 +224,15 @@ RenderMesh LoadRenderMeshFromObj(const std::filesystem::path& obj_path,
           throw std::runtime_error(fmt::format(
               "Not all faces reference normals: {}", obj_path.string()));
         }
-        if (has_tex_coord) {
-          if (uv_index < 0) {
-            throw std::runtime_error(
-                fmt::format("Not all faces reference texture coordinates: {}",
-                            obj_path.string()));
-          }
-        } else {
-          DRAKE_DEMAND(uv_index < 0);
-        }
         const auto obj_indices =
             make_tuple(position_index, norm_index, uv_index);
+        if (uv_index >= 0) {
+          // If this vertex has a UV coordinate, we need to count it, even if
+          // the "meta" vertex isn't unique.
+          // Note: the map's value gets zero initialized so we can blindly
+          // increment it without worry.
+          ++material_uvs[mat_index];
+        }
         if (obj_vertex_to_new_vertex.count(obj_indices) == 0) {
           obj_vertex_to_new_vertex[obj_indices] =
               static_cast<int>(positions.size());
@@ -231,7 +245,7 @@ RenderMesh LoadRenderMeshFromObj(const std::filesystem::path& obj_path,
           normals.emplace_back(attrib.normals[3 * norm_index],
                                attrib.normals[3 * norm_index + 1],
                                attrib.normals[3 * norm_index + 2]);
-          if (has_tex_coord) {
+          if (uv_index >= 0) {
             uvs.emplace_back(attrib.texcoords[2 * uv_index],
                              attrib.texcoords[2 * uv_index + 1]);
           } else {
@@ -241,64 +255,141 @@ RenderMesh LoadRenderMeshFromObj(const std::filesystem::path& obj_path,
         face_vertices[i] = obj_vertex_to_new_vertex[obj_indices];
         ++v_index;
       }
+      material_triangles[mat_index].push_back(ssize(triangles));
       triangles.emplace_back(&face_vertices[0]);
-      referenced_materials.insert(shape_mesh.material_ids[f]);
     }
   }
 
   DRAKE_DEMAND(positions.size() == normals.size());
   DRAKE_DEMAND(positions.size() == uvs.size());
 
-  RenderMesh mesh_data;
-  using indices_uint_t = decltype(mesh_data.indices)::Scalar;
-  mesh_data.indices.resize(triangles.size(), 3);
-  for (int t = 0; t < mesh_data.indices.rows(); ++t) {
-    mesh_data.indices.row(t) = triangles[t].cast<indices_uint_t>();
-  }
-  mesh_data.positions.resize(positions.size(), 3);
-  for (int v = 0; v < mesh_data.positions.rows(); ++v) {
-    mesh_data.positions.row(v) = positions[v];
-  }
-  mesh_data.normals.resize(normals.size(), 3);
-  for (int n = 0; n < mesh_data.normals.rows(); ++n) {
-    mesh_data.normals.row(n) = normals[n];
-  }
-  mesh_data.uvs.resize(uvs.size(), 2);
-  for (int uv = 0; uv < mesh_data.uvs.rows(); ++uv) {
-    mesh_data.uvs.row(uv) = uvs[uv];
+  /* Now we need to partition the prepped geometry data. Each material used
+   will lead to a unique `RenderMesh` and `RenderMaterial`. Note: the obj may
+   have declared distinct *objects*. We are erasing that distinction as
+   irrelevant for rendering the mesh as a rigid structure. */
+  vector<RenderMesh> meshes;
+  for (const auto& [mat_index, tri_indices] : material_triangles) {
+    RenderMesh mesh_data;
+
+    /* Create the material for set of triangles. */
+    mesh_data.uv_state = material_uvs[mat_index] == 0 ? UvState::kNone
+                         : material_uvs[mat_index] == ssize(tri_indices) * 3
+                             ? UvState::kFull
+                             : UvState::kPartial;
+    if (mat_index == -1) {
+      /* This is the default material. No material was assigned to the faces.
+       We'll apply the fallback logic. */
+      mesh_data.material = MakeMeshFallbackMaterial(
+          properties, obj_path, default_diffuse, policy, mesh_data.uv_state);
+    } else {
+      mesh_data.material =
+          MakeMaterialFromMtl(reader.GetMaterials().at(mat_index), obj_path,
+                              properties, policy, mesh_data.uv_state);
+    }
+
+    /* Partition the data into distinct RenderMeshes. The triangles in one
+     render mesh can reference vertex indices from all over the original vertex
+     buffer. However, in the new render mesh, they must be compactly enumerated
+     from [0, N-1]. This map provides the mapping from the original index value
+     in the full buffer, to the vertex buffer in this RenderMesh. At the same
+     time, convert them to the unsigned type required by RenderMesh. */
+    using indices_uint_t = decltype(mesh_data.indices)::Scalar;
+    map<int, indices_uint_t> vertex_index_full_to_part;
+    for (const auto& t : tri_indices) {
+      const auto& tri = triangles[t];
+      for (int i = 0; i < 3; ++i) {
+        if (vertex_index_full_to_part.count(tri[i]) == 0) {
+          vertex_index_full_to_part[tri(i)] =
+              static_cast<indices_uint_t>(vertex_index_full_to_part.size());
+        }
+      }
+    }
+    mesh_data.indices.resize(ssize(tri_indices), 3);
+    int row = -1;
+    for (const int t : tri_indices) {
+      const Vector3<int>& source_tri = triangles[t];
+      auto mapped_tri = mesh_data.indices.row(++row);
+      /* Each vertex maps independently. */
+      for (int i = 0; i < 3; ++i) {
+        mapped_tri[i] = vertex_index_full_to_part[source_tri[i]];
+      }
+    }
+
+    const int vertex_count = ssize(vertex_index_full_to_part);
+    mesh_data.positions.resize(vertex_count, 3);
+    mesh_data.normals.resize(vertex_count, 3);
+    mesh_data.uvs.resize(vertex_count, 2);
+    for (const auto [full_index, part_index] : vertex_index_full_to_part) {
+      mesh_data.positions.row(part_index) = positions[full_index];
+      mesh_data.normals.row(part_index) = normals[full_index];
+      mesh_data.uvs.row(part_index) = uvs[full_index];
+    }
+    meshes.push_back(std::move(mesh_data));
   }
 
-  // If we've only used a single material in the OBJ, use it. If the only
-  // referenced material is "-1", it means there is no material.
-  mesh_data.uv_state = has_tex_coord ? UvState::kFull : UvState::kNone;
-  if (referenced_materials.size() == 1 && referenced_materials.count(-1) == 0) {
-    mesh_data.material =
-        MakeMaterialFromMtl(reader.GetMaterials().front(), obj_path, properties,
-                            policy, mesh_data.uv_state);
-  } else {
-    // We'll need to use the material fallback logic for meshes.
-    if (referenced_materials.size() > 1) {
-      vector<std::string> mat_names;
-      // If the referenced material is < 0 (typically -1), it represents the
-      // *unnamed* default material. We need to detect it and provide *some*
-      // name for the error. We choose __default__ as being conspicuous but with
-      // a low probability that it was actually chosen by the user.
-      std::transform(
-          referenced_materials.begin(), referenced_materials.end(),
-          std::back_inserter(mat_names), [&reader](int i) {
-            return i < 0 ? std::string("__default__")
-                         : fmt::format("'{}'", reader.GetMaterials()[i].name);
-          });
-      log()->debug(
-          "Drake currently only supports OBJs that use a single material "
-          "across the whole mesh; for {}, {} materials were used: {}. The "
-          "parsed materials will not be used.",
-          obj_path.string(), referenced_materials.size(),
-          fmt::join(mat_names, ", "));
-    }
-    mesh_data.material = MakeMeshFallbackMaterial(
-        properties, obj_path, default_diffuse, policy, mesh_data.uv_state);
+  return meshes;
+}
+
+RenderMesh LoadRenderMeshFromObj(
+    const std::filesystem::path& obj_path, const GeometryProperties& properties,
+    const Rgba& default_diffuse,
+    const drake::internal::DiagnosticPolicy& policy) {
+  vector<RenderMesh> meshes =
+      LoadRenderMeshesFromObj(obj_path, properties, default_diffuse, policy);
+
+  if (meshes.size() == 1) {
+    return std::move(meshes[0]);
   }
+
+  log()->debug(
+      "Drake currently only supports OBJs that use a single material across "
+      "the whole mesh; for {}, {} materials were used. The parsed materials "
+      "will not be used.",
+      obj_path.string(), meshes.size());
+
+  RenderMesh mesh_data;
+
+  // Merge the geometry.
+  int vert_count = 0;
+  int tri_count = 0;
+  int encoded_uv_count = 0;  // Add 1 for partial and 2 for full.
+  for (const auto& mesh : meshes) {
+    vert_count += mesh.positions.rows();
+    tri_count += mesh.indices.rows();
+    encoded_uv_count += mesh.uv_state == UvState::kFull      ? 2
+                        : mesh.uv_state == UvState::kPartial ? 1
+                                                             : 0;
+  }
+  mesh_data.uv_state = encoded_uv_count == ssize(meshes) * 2 ? UvState::kFull
+                       : encoded_uv_count > 0                ? UvState::kPartial
+                                                             : UvState::kNone;
+  mesh_data.indices.resize(tri_count, 3);
+  mesh_data.positions.resize(vert_count, 3);
+  mesh_data.normals.resize(vert_count, 3);
+  mesh_data.uvs.resize(vert_count, 2);
+  int tri_row = -1;  // Always pre-increment.
+  int vert_row = 0;  // We'll increment in blocks.
+  for (const auto& mesh : meshes) {
+    // Vertex data.
+    const int local_v_count = mesh.positions.rows();
+    mesh_data.positions.block(vert_row, 0, local_v_count, 3) = mesh.positions;
+    mesh_data.normals.block(vert_row, 0, local_v_count, 3) = mesh.normals;
+    mesh_data.uvs.block(vert_row, 0, local_v_count, 2) = mesh.uvs;
+    vert_row += local_v_count;
+
+    // Triangles.
+    using indices_uint_t = decltype(mesh_data.indices)::Scalar;
+    Vector3<indices_uint_t> v_offset =
+        Vector3<indices_uint_t>::Constant(vert_row);
+    for (int t = 0; t < mesh.indices.rows(); ++t) {
+      mesh_data.indices.row(++tri_row) =
+          mesh.indices.row(t) + v_offset.transpose();
+    }
+  }
+
+  // More than one material means we replace it with the fallback.
+  mesh_data.material = MakeMeshFallbackMaterial(
+      properties, obj_path, default_diffuse, policy, mesh_data.uv_state);
 
   return mesh_data;
 }

--- a/geometry/render/render_mesh.h
+++ b/geometry/render/render_mesh.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <vector>
 
 #include <Eigen/Dense>
 
@@ -22,7 +23,7 @@ namespace internal {
 
  For now, all vertex quantities (`positions`, `normals` and `uvs`) are
  guaranteed (as well as the `indices` data). In the future, `uvs` may become
- optional.  */
+ optional. */
 struct RenderMesh {
   Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> positions;
   Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> normals;
@@ -42,22 +43,15 @@ struct RenderMesh {
 // TODO(SeanCurtis-TRI): All of this explanation, and general guidance for what
 // meshes (and which features) are supported, needs to go into the trouble-
 // shooting guide.
-// TODO(SeanCurtis-TRI): Modify the API to return a *set* of RenderMesh, each
-// with a unique material.
-/* Returns a single instance of RenderMesh from the indicated obj file.
+/* Returns a set of RenderMesh instances based on the objects and materials
+ defined in the indicated obj file.
 
- The material definition will come from the obj's mtl file iff a single material
- is applied to all faces in the obj. Otherwise, it applies the fallback material
- protocol documented in MakeMeshFallbackMaterial() (the only time in which the
- `properties` and `default_diffuse` parameters are used).
-
- As long as there is a single material applied to all faces in the obj file,
- the material will be derived from the material library, even if the material
- specification is flawed. The derivation does its best to provide the "best"
- approximation of the declared material. But the fact it was declared and
- applied is respected. For example, the following are specification defects
- that nevertheless result in a RenderMaterial _based_ on the mtl material and
- _not_ on the fallback logic:
+ For each unique material referenced in the obj file, a RenderMesh will be
+ created. Even if there are errors in the material specification, the algorithm
+ does its best to provide the "best" approximation of the declared material. The
+ fact that it was declared and applied is respected. For example, the following
+ are specification defects that nevertheless result in a RenderMaterial _based_
+ on the mtl material and _not_ on the fallback logic:
 
    - Referencing a non-existent or unavailable texture.
    - Failing to specify *any* material properties at all beyond its name.
@@ -72,6 +66,10 @@ struct RenderMesh {
     - Material semantics.
     - The geometric data is reconditioned to be compatible with "geometry
       buffer" applications. (See RenderMesh for details.)
+    - It supports multiple objects in the file. In fact, there may be more
+      RenderMesh instances than objects defined because a single object with
+      multiple materials will likewise be partitioned into separate RenderMesh
+      instances.
 
  If texture coordinates are assigned to vertices, it will be indicated in
  the returned RenderMesh. See RenderMesh::uv_state for more detail.
@@ -88,7 +86,15 @@ struct RenderMesh {
  @throws std::exception if a) tinyobj::LoadObj() fails, (b) there are no faces
                            or normals, c) faces fail to reference normals, or d)
                            faces fail to reference the texture coordinates if
-                           they are present.  */
+                           they are present. */
+std::vector<RenderMesh> LoadRenderMeshesFromObj(
+    const std::filesystem::path& obj_path, const GeometryProperties& properties,
+    const Rgba& default_diffuse,
+    const drake::internal::DiagnosticPolicy& policy = {});
+
+/* Legacy stub. Multiple RenderMeshes get merged together with the fallback
+ material applied (spewing a debug message). We'll remove this in follow up
+ PRs as the RenderEngines change to accommodate multiple RenderMeshes. */
 RenderMesh LoadRenderMeshFromObj(
     const std::filesystem::path& obj_path, const GeometryProperties& properties,
     const Rgba& default_diffuse,

--- a/geometry/render/test/render_mesh_test.cc
+++ b/geometry/render/test/render_mesh_test.cc
@@ -28,14 +28,14 @@ using std::vector;
 
 namespace fs = std::filesystem;
 
-/* The tests for the function LoadRenderMeshFromObj are partitioned into two
+/* The tests for the function LoadRenderMeshesFromObj are partitioned into two
  broad categories indicated by prefix:
 
    - Geometry: evaluation of the geometry produced.
      - The tests confirm that the data gets processed as expected, including
        expected error conditions.
    - Material: evaluation of the material generation logic.
-     - LoadRenderMeshFromObj is responsible for defining a material from a
+     - LoadRenderMeshesFromObj is responsible for defining a material from a
        material library where possible and, failing that, creating a fallback
        material using the RenderMaterial functions.
      - There are many ways in which the library has problems, but we still get
@@ -127,8 +127,8 @@ TEST_F(LoadRenderMeshFromObjTest, GeometryErrorModes) {
     // is simply for the file to not exist. Any other conditions that tinyobj
     // considers a parse failure will get treated the same.
     DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadRenderMeshFromObj("__garbage_doesn't_exist__.obj", empty_props(),
-                              kDefaultDiffuse, diagnostic_policy_),
+        LoadRenderMeshesFromObj("__garbage_doesn't_exist__.obj", empty_props(),
+                                kDefaultDiffuse, diagnostic_policy_),
         "Failed parsing the obj file[^]*");
   }
   {
@@ -136,8 +136,8 @@ TEST_F(LoadRenderMeshFromObjTest, GeometryErrorModes) {
     const fs::path obj_path =
         WriteFile("v 1 2 3", fmt::format("error{}.obj", ++error));
     DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
-                              diagnostic_policy_),
+        LoadRenderMeshesFromObj(obj_path, empty_props(), kDefaultDiffuse,
+                                diagnostic_policy_),
         "The OBJ data appears to have no faces.*");
   }
   {
@@ -146,8 +146,8 @@ TEST_F(LoadRenderMeshFromObjTest, GeometryErrorModes) {
         WriteFile("Not an obj\njust some\nmeaningles text.\n",
                   fmt::format("error{}.obj", ++error));
     DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
-                              diagnostic_policy_),
+        LoadRenderMeshesFromObj(obj_path, empty_props(), kDefaultDiffuse,
+                                diagnostic_policy_),
         "The OBJ data appears to have no faces.* might not be an OBJ file.+");
   }
   {
@@ -155,8 +155,8 @@ TEST_F(LoadRenderMeshFromObjTest, GeometryErrorModes) {
     const fs::path obj_path =
         WriteFile("v 1 2 3\nf 1 1 1\n", fmt::format("error{}.obj", ++error));
     DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
-                              diagnostic_policy_),
+        LoadRenderMeshesFromObj(obj_path, empty_props(), kDefaultDiffuse,
+                                diagnostic_policy_),
         "OBJ has no normals.+");
   }
   {
@@ -170,29 +170,15 @@ f 1//1 1//1 1//1
 )""",
                                         fmt::format("error{}.obj", ++error));
     DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
-                              diagnostic_policy_),
+        LoadRenderMeshesFromObj(obj_path, empty_props(), kDefaultDiffuse,
+                                diagnostic_policy_),
         "Not all faces reference normals.+");
-  }
-  {
-    // Case: Not all faces reference uvs.
-    const fs::path obj_path = WriteFile(R"""(
-v 1 2 3
-vn 0 0 1
-vt 0 0
-f 1//1 1//1 1//1
-)""",
-                                        fmt::format("error{}.obj", ++error));
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadRenderMeshFromObj(obj_path, empty_props(), kDefaultDiffuse,
-                              diagnostic_policy_),
-        "Not all faces reference texture.+");
   }
 }
 
-// Confirms that non-triangular faces get triangulated. This also confirms that
-// duplication occurs due to associations of vertex positions with multiple
-// normals or texture coordinates.
+/* Confirms that non-triangular faces get triangulated. This also confirms that
+ duplication occurs due to associations of vertex positions with multiple
+ normals or texture coordinates. */
 TEST_F(LoadRenderMeshFromObjTest, GeometryTriangulatePolygons) {
   /*
              o 4
@@ -268,8 +254,8 @@ TEST_F(LoadRenderMeshFromObjTest, GeometryTriangulatePolygons) {
     SCOPED_TRACE(params.name);
     const fs::path obj_path = WriteFile(
         fmt::format("{}{}", positions, params.obj_spec), params.name + ".obj");
-    const RenderMesh mesh_data = LoadRenderMeshFromObj(
-        obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+    const RenderMesh mesh_data = LoadRenderMeshesFromObj(
+        obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_)[0];
     EXPECT_EQ(mesh_data.positions.rows(), params.position_count);
     EXPECT_EQ(mesh_data.normals.rows(), params.position_count);
     EXPECT_EQ(mesh_data.uvs.rows(), params.position_count);
@@ -301,9 +287,9 @@ TEST_F(LoadRenderMeshFromObjTest, GeometryTriangulatePolygons) {
   }
 }
 
-// Geometry already triangulated gets preserved. This doesn't do variations on
-// whether vertex positions need copying due to associations with multiple
-// normals/uvs. It relies on `TriangulatePolygons` to handle that.
+/* Geometry already triangulated gets preserved. This doesn't do variations on
+ whether vertex positions need copying due to associations with multiple
+ normals/uvs. It relies on `TriangulatePolygons` to handle that. */
 TEST_F(LoadRenderMeshFromObjTest, GeometryPreserveTriangulation) {
   /*
              o 4
@@ -338,17 +324,17 @@ TEST_F(LoadRenderMeshFromObjTest, GeometryPreserveTriangulation) {
   )""",
                                       "preserve_triangulation.obj");
 
-  const RenderMesh mesh_data = LoadRenderMeshFromObj(
-      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  const RenderMesh mesh_data = LoadRenderMeshesFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_)[0];
   EXPECT_EQ(mesh_data.positions.rows(), 7);
   EXPECT_EQ(mesh_data.normals.rows(), 7);
   EXPECT_EQ(mesh_data.uvs.rows(), 7);
   EXPECT_EQ(mesh_data.indices.rows(), 5);
 }
 
-// The RenderMesh produces *new* vertices from what was in the OBJ based on what
-// vertex gets referenced by which faces. A vertex that doesn't get referenced
-// gets omitted.
+/* The RenderMesh produces *new* vertices from what was in the OBJ based on what
+ vertex gets referenced by which faces. A vertex that doesn't get referenced
+ gets omitted. */
 TEST_F(LoadRenderMeshFromObjTest, GeometryRemoveUnreferencedVertices) {
   /*
 
@@ -372,16 +358,16 @@ TEST_F(LoadRenderMeshFromObjTest, GeometryRemoveUnreferencedVertices) {
   f 6/1/1 3/1/1 4/1/1
   )""",
                                       "unreferenced_vertices.obj");
-  const RenderMesh mesh_data = LoadRenderMeshFromObj(
-      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  const RenderMesh mesh_data = LoadRenderMeshesFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_)[0];
   EXPECT_EQ(mesh_data.positions.rows(), 5);
   EXPECT_EQ(mesh_data.normals.rows(), 5);
   EXPECT_EQ(mesh_data.uvs.rows(), 5);
   EXPECT_EQ(mesh_data.indices.rows(), 2);
 }
 
-/* The OBJ has a single intrinsic material which only defines diffuse color. The
- resulting material is the defined color. */
+/* The OBJ has a single intrinsic material which only defines diffuse color.
+ Only a single mesh is created and its material is the defined color. */
 TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorOnly) {
   const fs::path obj_path = WriteFile(fmt::format(R"""(
         mtllib {}
@@ -393,15 +379,17 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorOnly) {
         f 1//1 2//1 3//1)""",
                                                   basic_mtl),
                                       "intrinsic_color_mat.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, Rgba(0.5, 1, 1));
   EXPECT_EQ(mesh.material.diffuse_map, "");
 }
 
 /* The OBJ has a single intrinsic material which only defines diffuse texture.
- The texture is in the same directory as the .mtl file. The resulting material
- has a white diffuse color and the named texture. */
+ The texture is in the same directory as the .mtl file. Only a single mesh is
+ created and its material has a white diffuse color and the named texture. */
 TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureOnly) {
   const fs::path obj_path = WriteFile(fmt::format(R"""(
         mtllib {}
@@ -414,15 +402,17 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureOnly) {
         f 1/1/1 2/1/1 3/1/1)""",
                                                   texture_only_mtl),
                                       "intrinsic_texture_mat.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 1));
   EXPECT_THAT(mesh.material.diffuse_map,
               testing::EndsWith("diag_gradient.png"));
 }
 
-/* The OBJ has a single intrinsic material which defines color and texture. The
- resulting material includes both color and texture. */
+/* The OBJ has a single intrinsic material which defines color and texture. Only
+ a single mesh is created and its material includes both color and texture. */
 TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorAndTexture) {
   const fs::path obj_path = WriteFile(fmt::format(R"""(
         mtllib {}
@@ -435,8 +425,10 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorAndTexture) {
         f 1/1/1 2/1/1 3/1/1)""",
                                                   texture_mtl),
                                       "intrinsic_full_diffuse_mat.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 0));
   EXPECT_THAT(mesh.material.diffuse_map,
               testing::EndsWith("diag_gradient.png"));
@@ -444,8 +436,9 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorAndTexture) {
 
 /* The OBJ has a single intrinsic material which defines a diffuse texture.
  The texture is in a *different* directory from the mtl file. But the mtl must
- be in the same directory as the obj. (See notes in implementation.)
- The resulting material has a *white* diffuse color and the named texture. */
+ be in the same directory as the obj. (See notes in implementation.)  Only a
+ single mesh is created and its material has a *white* diffuse color and the
+ named texture. */
 TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryDislocatedTexture) {
   const fs::path obj_dir = temp_dir() / "dis_texture";
   fs::create_directory(obj_dir);
@@ -465,8 +458,10 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryDislocatedTexture) {
     d 1
     map_Kd ../diag_gradient.png)""",
             "my.mtl", obj_dir);
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 1));
   EXPECT_EQ(mesh.material.diffuse_map, (temp_dir() / "diag_gradient.png"));
 }
@@ -485,8 +480,10 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryMultipleDefinedIntrinsic) {
         f 1/1/1 2/1/1 3/1/1)""",
                                                   multi_mtl),
                                       "use_only_one_material.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, Rgba(1, 0, 1));
   EXPECT_EQ(mesh.material.diffuse_map, "");
 }
@@ -506,8 +503,10 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorAndBadTexture) {
         usemtl test_material
         f 1/1/1 2/1/1 3/1/1)""",
                                       "missing_texture.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, Rgba(1, 0.5, 1));
   EXPECT_EQ(mesh.material.diffuse_map, "");
   EXPECT_THAT(
@@ -528,11 +527,39 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureButNoUvs) {
         f 1//1 2//1 3//1)""",
                                                   texture_mtl),
                                       "no_uvs_with_texture.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_THAT(TakeWarning(),
               testing::MatchesRegex(".*requested a diffuse texture.*doesn't "
                                     "define any texture coordinates.*"));
+  EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 0));
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+}
+
+/* The OBJ has a single intrinsic material with a texture but no uvs. The
+ resulting material has *only* the color value (and a warning is dispatched). */
+TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureButPartialUvs) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material
+        f 1/1/1 2/1/1 3//1)""",  // Note: final vertex has no uv index.
+                                                  texture_mtl),
+                                      "partial_uvs_with_texture.obj");
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
+      obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
+  EXPECT_THAT(
+      TakeWarning(),
+      testing::MatchesRegex(".*requested a diffuse texture.*doesn't define a "
+                            "complete set of texture coordinates.*"));
   EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 0));
   EXPECT_EQ(mesh.material.diffuse_map, "");
 }
@@ -557,8 +584,10 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryObjMtlDislocation) {
         f 1/1/1 2/1/1 3/1/1)""",
                                                   texture_mtl),
                                       "mtl_elsewhere.obj", obj_dir);
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 0));
   EXPECT_EQ(mesh.material.diffuse_map, "");
   // Because of our limited access to parsing information, this will look like
@@ -568,10 +597,12 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryObjMtlDislocation) {
       testing::HasSubstr("requested an unavailable diffuse texture image"));
 }
 
-/* The OBJ has multiple intrinsic materials *applied* to the mesh. The material
- should be the fallback material and should be accompanied by a warning. When
- we expand material support, this test can and should change. */
-TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackMultipleAppliedIntrinsic) {
+/* The OBJ has multiple intrinsic materials *applied* to the mesh. It leads to
+ multiple RenderMesh instances with the various materials. We'll confirm the
+ partitioning of the geometry and the resulting materials. This test provides
+ token coverage of the partitioning -- it only considers the number of triangles
+ in each partition -- real bugs would be obvious in the rendered results. */
+TEST_F(LoadRenderMeshFromObjTest, MultipleValidIntrinsicMaterials) {
   const fs::path obj_path = WriteFile(fmt::format(R"""(
         mtllib {}
         v 0 0 0
@@ -581,15 +612,53 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackMultipleAppliedIntrinsic) {
         usemtl test_material_1
         f 1//1 2//1 3//1
         usemtl test_material_2
-        f 1//1 2//1 3//1)""",
+        f 2//1 3//1 1//1
+        f 3//1 1//1 2//1)""",  // Distinguish meshes by triangle count.
                                                   multi_mtl),
                                       "too_many_usemtl.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> meshes = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(meshes.size(), 2);
+  for (const auto& mesh : meshes) {
+    if (mesh.indices.rows() == 1) {
+      // test_material_1 applied to a single triangle.
+      EXPECT_EQ(mesh.material.diffuse, Rgba(1, 0, 1));
+      EXPECT_EQ(mesh.material.diffuse_map, "");
+    } else if (mesh.indices.rows() == 2) {
+      // test_material_2 applied to two triangles.
+      EXPECT_EQ(mesh.material.diffuse, Rgba(1, 0, 0));
+      EXPECT_EQ(mesh.material.diffuse_map, "");
+    } else {
+      DRAKE_UNREACHABLE();
+    }
+  }
+}
+
+/* The OBJ has multiple intrinsic materials *applied* to the mesh. It leads to
+ multiple RenderMesh instances with the various materials. The legacy API will
+ merge those into a single mesh with fallback material. */
+TEST_F(LoadRenderMeshFromObjTest, MultipleValidIntrinsicMaterialsLegacy) {
+  const fs::path obj_path = WriteFile(fmt::format(R"""(
+        mtllib {}
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        usemtl test_material_1
+        f 1/1/1 2/1/1 3/1/1
+        usemtl test_material_2
+        f 2//1 3//1 1//1
+        f 3//1 1//1 2//1)""",  // Distinguish meshes by triangle count.
+                                                  multi_mtl),
+                                      "too_many_usemtl.obj");
+  RenderMesh mesh = LoadRenderMeshFromObj(obj_path, empty_props(),
+                                          kDefaultDiffuse, diagnostic_policy_);
   EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
   EXPECT_EQ(mesh.material.diffuse_map, "");
-  // N.B. We do not test the `log()->debug()` message output for correctness.
-  // Checking for the diffuse material is enough to prove that the code was run.
+  EXPECT_EQ(mesh.indices.rows(), 3);
+  // The vertices get mindlessly duplicated.
+  EXPECT_EQ(mesh.positions.rows(), 6);
 }
 
 /* If the obj references the mtl file with an absolute path, there will be a
@@ -611,16 +680,19 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackObjMtlDislocationAbsolute) {
         f 1/1/1 2/1/1 3/1/1)""",
                                                   mtl_path.string()),
                                       "mtl_elsewhere.obj", obj_dir);
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
   EXPECT_EQ(mesh.material.diffuse_map, "");
   // The tinyobj warning that the material library can't be found.
   EXPECT_THAT(TakeWarning(), testing::HasSubstr("not found in a path"));
 }
 
-/* The obj explicitly applies a material to *some* of the faces. The material
- gets defaulted and a warning given. */
+/* The obj explicitly applies a material to *some* of the faces. This is
+ implicitly two materials (the default material being applied to the otherwise
+ unspecified faces). Two meshes are created. */
 TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackDefaultedFaces) {
   const fs::path obj_path = WriteFile(fmt::format(R"""(
         mtllib {}
@@ -630,15 +702,26 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackDefaultedFaces) {
         vn 0 1 0
         f 1//1 2//1 3//1
         usemtl test_material
-        f 1//1 2//1 3//1)""",
+        f 1//1 2//1 3//1
+        f 1//1 2//1 3//1)""",  // Distinguish meshes by triangle count.
                                                   basic_mtl),
                                       "default_material_faces.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> meshes = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
-  EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
-  EXPECT_EQ(mesh.material.diffuse_map, "");
-  // N.B. We do not test the `log()->debug()` message output for correctness.
-  // Checking for the diffuse material is enough to prove that the code was run.
+  ASSERT_EQ(meshes.size(), 2);
+  for (const auto& mesh : meshes) {
+    if (mesh.indices.rows() == 1) {
+      // default material applied to a single triangle.
+      EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
+      EXPECT_EQ(mesh.material.diffuse_map, "");
+    } else if (mesh.indices.rows() == 2) {
+      // test_material applied to two triangles.
+      EXPECT_EQ(mesh.material.diffuse, Rgba(0.5, 1, 1));
+      EXPECT_EQ(mesh.material.diffuse_map, "");
+    } else {
+      DRAKE_UNREACHABLE();
+    }
+  }
 }
 
 /* If the obj references an invalid material name, there will be a warning and
@@ -654,8 +737,10 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackBadMaterialName) {
         f 1//1 2//1 3//1)""",
                                                   texture_mtl),
                                       "bad_material_name.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
   EXPECT_EQ(mesh.material.diffuse_map, "");
   EXPECT_THAT(TakeWarning(),
@@ -674,8 +759,10 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackMissingMtl) {
         usemtl test_material
         f 1//1 2//1 3//1)""",
                                       "non_existent_mtl.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
   EXPECT_EQ(mesh.material.diffuse_map, "");
   EXPECT_THAT(
@@ -695,8 +782,10 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackNoAppliedMaterial) {
         f 1//1 2//1 3//1)""",
                                                   basic_mtl),
                                       "no_usemtl.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
   EXPECT_EQ(mesh.material.diffuse_map, "");
 }
@@ -711,8 +800,10 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackNoMaterialLibrary) {
         vn 0 1 0
         f 1//1 2//1 3//1)""",
                                       "no_mtllib.obj");
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   EXPECT_EQ(mesh.material.diffuse, kDefaultDiffuse);
   EXPECT_EQ(mesh.material.diffuse_map, "");
 }
@@ -737,14 +828,46 @@ TEST_F(LoadRenderMeshFromObjTest, RedundantMaterialWarnings) {
 
   PerceptionProperties props;
   props.AddProperty("phong", "diffuse", Rgba(0.1, 0.2, 0.3, 0.4));
-  const RenderMesh mesh = LoadRenderMeshFromObj(
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
       obj_path, props, kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
   // We still get the intrinsic material.
   EXPECT_EQ(mesh.material.diffuse, Rgba(0.5, 1, 1));
   EXPECT_EQ(mesh.material.diffuse_map, "");
   EXPECT_THAT(
       TakeWarning(),
       testing::MatchesRegex(".*has its own materials.*'phong', 'diffuse'.*"));
+}
+
+/* We need evidence that the uv state is passed to the fallback material. So,
+ we'll create an obj with partial UVs and a valid ("phong", "diffuse_map"). We
+ should get the RenderMaterial warning. */
+TEST_F(LoadRenderMeshFromObjTest, UvStatePassedToFallback) {
+  // We just need an obj with *any* intrinsic material; we'll do color only.
+  const fs::path obj_path = WriteFile(R"""(
+        v 0 0 0
+        v 1 1 1
+        v 2 2 2
+        vn 0 1 0
+        vt 0 1
+        f 1/1/1 2/1/1 3//1)""",
+                                      "partial_uvs_fallback_texture.obj");
+
+  PerceptionProperties props;
+  const std::string tex_name =
+      FindResourceOrThrow("drake/geometry/render/test/diag_gradient.png");
+  props.AddProperty("phong", "diffuse_map", tex_name);
+  vector<RenderMesh> result = LoadRenderMeshesFromObj(
+      obj_path, props, kDefaultDiffuse, diagnostic_policy_);
+  ASSERT_EQ(result.size(), 1);
+  const RenderMesh& mesh = result[0];
+  // Inability to apply a valid texture leaves the material flat white.
+  EXPECT_EQ(mesh.material.diffuse, Rgba(1, 1, 1));
+  EXPECT_EQ(mesh.material.diffuse_map, "");
+  EXPECT_THAT(TakeWarning(),
+              testing::MatchesRegex(
+                  ".*'diffuse_map'.* doesn't define a complete set of.*"));
 }
 
 /* Tests if the `from_mesh_file` flag is correctly propagated. */
@@ -758,8 +881,8 @@ TEST_F(LoadRenderMeshFromObjTest, PropagateFromMeshFileFlag) {
             : FindResourceOrThrow(
                   "drake/geometry/render/test/meshes/box_no_mtl.obj");
 
-    const RenderMesh mesh_data = LoadRenderMeshFromObj(
-        filename, empty_props(), kDefaultDiffuse, diagnostic_policy_);
+    const RenderMesh mesh_data = LoadRenderMeshesFromObj(
+        filename, empty_props(), kDefaultDiffuse, diagnostic_policy_)[0];
     const RenderMaterial material = mesh_data.material;
     EXPECT_EQ(from_mesh_file, material.from_mesh_file);
   }


### PR DESCRIPTION
Obj files have several mechanisms that would conceptually lead to creating disjoint "meshes" (i.e., putting them in different groups, different objects, or assigning different materials). For the purpose of rendering, the only important distinction is material. Because we render the whole mesh as a rigid object, we just need to partition based on the material assigned to a triangle. LoadRenderMeshesFromObj can now return multiple RenderMeshes.

We've introduced a shim for the old API (LoadRenderMeshFromObj()). This allows us to update RenderEngineVtk and RenderEngineGl in a follow up PR. The shim is *mostly* the same as the old. It has two differences which are acceptable for a short horizon.

  - The debug message no longer prints out the material names.
  - The resultant RenderMesh can easily have an increased number of vertex data (as shown in the legacy test). This increase is representative of how things will work for the forseeable future.

This is the second PR in a train relating to https://github.com/RobotLocomotion/drake/issues/17266. The full PR train can be seen in https://github.com/RobotLocomotion/drake/pull/20235. This PR corresponds to the __*second*__ commit in that PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20250)
<!-- Reviewable:end -->
