### PR TITLE
[math] Add hash_append to RollPitchYaw/RotationMatrix/RigidTransform

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -159,6 +159,7 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:drake_bool",
         "//common:essential",
+        "//common:hash",
         "//common:is_approx_equal_abstol",
         "//common:unused",
         "//math:gradient",

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_ostream.h"
+#include "drake/common/hash.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/math/rotation_matrix.h"
 
@@ -617,6 +618,19 @@ class RigidTransform {
       p_AoQ_A.col(i) = translation() + p_BoQ_A.col(i);
 
     return p_AoQ_A;
+  }
+
+  /// Implements the @ref hash_append concept.
+  /// @pre T implements the hash_append concept.
+  template <class HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher,
+                          const RigidTransform& X) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, X.R_AB_);
+    const T* begin = X.p_AoBo_A_.data();
+    const T* end = X.p_AoBo_A_.data() + X.p_AoBo_A_.size();
+    using drake::hash_append_range;
+    hash_append_range(hasher, begin, end);
   }
 
  private:

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_ostream.h"
+#include "drake/common/hash.h"
 
 namespace drake {
 namespace math {
@@ -411,6 +412,17 @@ class RollPitchYaw {
   /// of these pitch angles, i.e., when `cos(p) ≈ 0`.
   Vector3<T> CalcRpyDDtFromAngularAccelInChild(
       const Vector3<T>& rpyDt, const Vector3<T>& alpha_AD_D) const;
+
+  /// Implements the @ref hash_append concept.
+  /// @pre T implements the hash_append concept.
+  template <class HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher,
+                          const RollPitchYaw& rpy) noexcept {
+    const T* begin = rpy.roll_pitch_yaw_.data();
+    const T* end = rpy.roll_pitch_yaw_.data() + rpy.roll_pitch_yaw_.size();
+    using drake::hash_append_range;
+    hash_append_range(hasher, begin, end);
+  }
 
  private:
   // Throws an exception if rpy is not a valid %RollPitchYaw.

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -14,6 +14,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/hash.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/math/fast_pose_composition_functions.h"
 #include "drake/math/roll_pitch_yaw.h"
@@ -670,6 +671,17 @@ class RotationMatrix {
   /// (Internal use only) Constructs a RotationMatrix without initializing the
   /// underlying 3x3 matrix. For use by RigidTransform and RotationMatrix only.
   explicit RotationMatrix(internal::DoNotInitializeMemberFields) {}
+
+  /// Implements the @ref hash_append concept.
+  /// @pre T implements the hash_append concept.
+  template <class HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher,
+                          const RotationMatrix& R) noexcept {
+    const T* begin = R.R_AB_.data();
+    const T* end = R.R_AB_.data() + R.R_AB_.size();
+    using drake::hash_append_range;
+    hash_append_range(hasher, begin, end);
+  }
 
  private:
   // Make RotationMatrix<U> templatized on any typename U be a friend of a

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -813,6 +813,15 @@ GTEST_TEST(RigidTransform, TestMemoryLayoutOfRigidTransformDouble) {
   EXPECT_EQ(sizeof(X), 12 * sizeof(double));
 }
 
+GTEST_TEST(RigidTransform, Hash) {
+  RigidTransform<double> X_AB(Vector3d{0.0, 0.5, 1.0});
+  RigidTransform<double> X_CD = X_AB;
+  const DefaultHash hash_func;
+  EXPECT_EQ(hash_func(X_AB), hash_func(X_CD));
+  X_CD.set_translation(Vector3d{1.0, 0.0, 0.0});
+  EXPECT_NE(hash_func(X_AB), hash_func(X_CD));
+}
+
 // This utility function helps verify the output string from RigidTransform's
 // stream insertion operator <<.  Specifically, it does the following:
 // 1. Verifies the output string has form: "rpy = 0.125 0.25 0.5 xyz = 7 6 5";

--- a/math/test/roll_pitch_yaw_test.cc
+++ b/math/test/roll_pitch_yaw_test.cc
@@ -479,6 +479,15 @@ GTEST_TEST(RollPitchYaw, CalcRpyDDtFromAngularAccel) {
   }
 }
 
+GTEST_TEST(RollPitchYaw, Hash) {
+  RollPitchYaw<double> R_AB(Vector3d{0.0, 0.5, 1.0});
+  RollPitchYaw<double> R_CD = R_AB;
+  const DefaultHash hash_func;
+  EXPECT_EQ(hash_func(R_AB), hash_func(R_CD));
+  R_CD.set_roll_angle(1.0);
+  EXPECT_NE(hash_func(R_AB), hash_func(R_CD));
+}
+
 // Verify the constructor and a few key operations are compatible with
 // symbolic::Expression.  We focus only on methods that required tweaks in
 // order to compile against Expression.

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -1310,6 +1310,15 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneVectorExceptions) {
   VerifyMakeFromOneUnitVector(R_AB, huge_vector.normalized(), axis_index);
 }
 
+GTEST_TEST(RotationMatrixTest, Hash) {
+  RotationMatrix<double> R_AB = RotationMatrix<double>::MakeXRotation(1.0);
+  RotationMatrix<double> R_CD = R_AB;
+  const DefaultHash hash_func;
+  EXPECT_EQ(hash_func(R_AB), hash_func(R_CD));
+  R_CD = RotationMatrix<double>::MakeXRotation(0.5);
+  EXPECT_NE(hash_func(R_AB), hash_func(R_CD));
+}
+
 class MakeClosestRotationToIdentityFromUnitZTest
     : public ::testing::TestWithParam<Vector3d> {};
 


### PR DESCRIPTION
This can be useful for a part of an architecture for checking whether a pre-computed planning model for a robot or scene might have changed.

Closes #20207.

+@sadraddini for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20252)
<!-- Reviewable:end -->
