### PR TITLE
[meldis] Offer --browser selection on the command line

### DIFF
--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -63,7 +63,7 @@ from pydrake.systems.framework import (
 from pydrake.systems.lcm import (
     LcmPublisherSystem,
 )
-
+import pydrake.visualization.meldis
 
 # https://bugs.launchpad.net/ubuntu/+source/u-msgpack-python/+bug/1979549
 #
@@ -625,3 +625,10 @@ class TestMeldis(unittest.TestCase):
         dut._invoke_subscriptions()
         # After the handlers are called, we have the expected meshcat path.
         self.assertEqual(dut.meshcat.HasPath(meshcat_path), True)
+
+    def test_command_line_browser_names(self):
+        """Sanity checks our webbrowser names logic. The objective is to return
+        some kind of a list, without crashing.
+        """
+        names = pydrake.visualization.meldis._available_browsers()
+        self.assertIsInstance(names, list)


### PR DESCRIPTION
This is ever so slightly easier to use (and discover) than the $BROWSER env var.

Towards #20221.  When viewing images, I think we'll be recommending `chromium` instead of `firefox`.

Here's an example of using the new flag:

```
bazel run //tools:meldis -- --browser=chromium
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20257)
<!-- Reviewable:end -->
