### PR TITLE
Removes duplicated contribution of actuation when using PD controllers

### DIFF
--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -622,12 +622,12 @@ void CompliantContactManager<T>::CalcAccelerationsDueToNonConstraintForcesCache(
     AccelerationsDueNonConstraintForcesCache<T>* forward_dynamics_cache) const {
   DRAKE_DEMAND(forward_dynamics_cache != nullptr);
 
-  // We exclude joint limit penalties here as dictated by the contract of the
-  // function. This function is used for SAP (not TAMSI) which models joint
-  // limits as constraints.
-  this->CalcNonContactForces(context,
-                             /* include joint limit penalty forces */ false,
-                             &forward_dynamics_cache->forces);
+  // SAP models joint limits and actuation inputs (with effort limits) using
+  // constraints. Therefore these terms are not included here since they are
+  // included later as SAP constraints.
+  this->CalcNonContactForces(
+      context, /* include_joint_limit_penalty_forces */ false,
+      /* include_pd_controlled_input */ false, &forward_dynamics_cache->forces);
 
   // Our goal is to compute accelerations from the Newton-Euler equations:
   //   M⋅v̇ = k(x)

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -35,6 +35,33 @@ class AccelerationKinematicsCache;
 template <typename T>
 struct JointLockingCacheData;
 
+// Struct to store MultibodyPlant input forces.
+template <typename T>
+struct InputPortForces {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InputPortForces);
+  // Constructs an `InputPortForces` to store input port values for the given
+  // `plant`. Values are initialized to zero at construction.
+  explicit InputPortForces(const MultibodyPlant<T>& plant)
+      : externally_applied_forces(plant),
+        actuation_w_pd(plant.num_velocities()),
+        actuation_wo_pd(plant.num_velocities()) {
+    SetZero();
+  }
+  void SetZero() {
+    externally_applied_forces.SetZero();
+    actuation_w_pd.setZero();
+    actuation_wo_pd.setZero();
+  }
+  // Externally applied generalized and body spatial forces.
+  MultibodyForces<T> externally_applied_forces;
+  // Joint actuation, indexed by DOF. We split them into actuators with and
+  // without PD control. Both have size equal to the number of generalized
+  // velocities. Entries with no contribution are zero. In other words, the
+  // total actuation equals actuation_w_pd + actuation_wo_pd.
+  VectorX<T> actuation_w_pd;   // For actuated joints with PD control.
+  VectorX<T> actuation_wo_pd;  // For actuated joints without PD control.
+};
+
 /* This class is used to perform all calculations needed to advance state for a
  MultibodyPlant with discrete state.
 
@@ -155,6 +182,7 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   //  - (possibly) Joint limits.
   void CalcNonContactForces(const drake::systems::Context<T>& context,
                             bool include_joint_limit_penalty_forces,
+                            bool include_pd_controlled_input,
                             MultibodyForces<T>* forces) const;
 
   // TODO(amcastro-tri): Consider replacing with more specific APIs with the
@@ -225,14 +253,28 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
     return multibody_state_index_;
   }
 
+  /* Evaluates actuation input into two separate contributions: Actuation with
+   PD control and actuation without PD control. Entries with no contribution are
+   left initialized to zero.
+   @param[out] actuation_w_pd
+     Contribution for actuators with PD control. Indexed by velocity DOF.
+   @param[out] actuation_wo_pd
+     Contribution for actuators without PD control. Indexed by velocity DOF.
+   @pre The size of actuation_w_pd and actuation_wo_pd equals
+   plant().num_velocities().
+   */
+  void CalcJointActuationForces(const systems::Context<T>& context,
+                                VectorX<T>* actuation_w_pd,
+                                VectorX<T>* actuation_wo_pd) const;
+
   /* Evaluates the discretely sampled MultibodyPlant input port force values.
    This includes forces from externally applied spatial forces, externally
    applied generalized forces, and joint actuation forces.  */
-  const MultibodyForces<T>& EvalDiscreteInputPortForces(
+  const InputPortForces<T>& EvalInputPortForces(
       const drake::systems::Context<T>& context) const {
     return plant()
         .get_cache_entry(cache_indexes_.discrete_input_port_forces)
-        .template Eval<MultibodyForces<T>>(context);
+        .template Eval<InputPortForces<T>>(context);
   }
 
   /* Exposed MultibodyPlant private/protected methods.
@@ -352,8 +394,8 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
 
   // Collects the sum of all forces added to the owning MultibodyPlant and store
   // them in given `forces`. The existing values in `forces` is cleared.
-  void CopyForcesFromInputPorts(const systems::Context<T>& context,
-                                MultibodyForces<T>* forces) const;
+  void CalcInputPortForces(const systems::Context<T>& context,
+                           InputPortForces<T>* forces) const;
 
   // NVI to DoDeclareCacheEntries().
   void DeclareCacheEntries();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -5140,9 +5140,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   //  - Joint actuation.
   //  - Externally applied spatial forces.
   //  - Joint limits.
-  // May be different between continuous and discrete modes.
+  // @pre The plant is continuous.
   void CalcNonContactForces(const drake::systems::Context<T>& context,
-                            bool discrete,
                             MultibodyForces<T>* forces) const;
 
   // Collects up forces from input ports (actuator, generalized, and spatial
@@ -5284,7 +5283,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Add contribution of external actuation forces passed in through our
   // actuation input ports (there is a separate port for each model instance).
   void AddJointActuationForces(
-      const systems::Context<T>& context, MultibodyForces<T>* forces) const;
+      const systems::Context<T>& context, VectorX<T>* forces) const;
 
   // Helper method to register geometry for a given body, either visual or
   // collision. The registration includes:

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -54,10 +54,22 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     plant.AddJointLimitsPenaltyForces(context, forces);
   }
 
-  static void AddInForcesFromInputPorts(
+  static void AddAppliedExternalGeneralizedForces(
       const MultibodyPlant<T>& plant, const drake::systems::Context<T>& context,
       MultibodyForces<T>* forces) {
-    plant.AddInForcesFromInputPorts(context, forces);
+    plant.AddAppliedExternalGeneralizedForces(context, forces);
+  }
+
+  static void AddAppliedExternalSpatialForces(
+      const MultibodyPlant<T>& plant, const drake::systems::Context<T>& context,
+      MultibodyForces<T>* forces) {
+    plant.AddAppliedExternalSpatialForces(context, forces);
+  }
+
+  static void AddJointActuationForces(const MultibodyPlant<T>& plant,
+                                      const drake::systems::Context<T>& context,
+                                      VectorX<T>* forces) {
+    plant.AddJointActuationForces(context, forces);
   }
 
   static void CalcForceElementsContribution(

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -676,9 +676,6 @@ void SapDriver<T>::AddPdControllerConstraints(
   // Do nothing if not PD controllers were specified.
   if (plant().num_actuators() == 0) return;
 
-  // Previous time step positions.
-  const VectorX<T> q0 = plant().GetPositions(context);
-
   // Desired positions & velocities.
   const int num_actuators = plant().num_actuators();
   // TODO(amcastro-tri): makes these EvalFoo() instead to avoid heap
@@ -698,6 +695,7 @@ void SapDriver<T>::AddPdControllerConstraints(
       const T& vd = desired_state[num_actuators + actuator.index()];
       const T& u0 = feed_forward_actuation[actuator.index()];
 
+      const T& q0 = joint.GetOnePosition(context);
       const int dof = joint.velocity_start();
       const TreeIndex tree = tree_topology().velocity_to_tree_index(dof);
       const int tree_dof = dof - tree_topology().tree_velocities_start(tree);
@@ -711,7 +709,7 @@ void SapDriver<T>::AddPdControllerConstraints(
       typename SapPdControllerConstraint<T>::Parameters parameters{
           Kp, Kd, effort_limit};
       typename SapPdControllerConstraint<T>::Configuration configuration{
-          tree, tree_dof, tree_nv, q0[dof], qd, vd, u0};
+          tree, tree_dof, tree_nv, q0, qd, vd, u0};
 
       problem->AddConstraint(std::make_unique<SapPdControllerConstraint<T>>(
           std::move(configuration), std::move(parameters)));
@@ -961,8 +959,9 @@ void SapDriver<T>::CalcDiscreteUpdateMultibodyForces(
 
   // Include all state dependent forces (not constraints) evaluated at t₀
   // (previous time step as stored in the context).
-  const bool include_joint_limit_penalty_forces = false;
-  manager().CalcNonContactForces(context, include_joint_limit_penalty_forces,
+  manager().CalcNonContactForces(context,
+                                 /* include_joint_limit_penalty_forces */ false,
+                                 /* include_pd_controlled_input */ false,
                                  forces);
 
   // SAP evaluates damping terms (joint damping and reflected inertia)

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -73,7 +73,8 @@ void TamsiDriver<T>::CalcContactSolverResults(
   // there's no moving objects.
   MultibodyForces<T> forces0(plant());
   manager().CalcNonContactForces(
-      context, /* include joint limit penalty forces */ true, &forces0);
+      context, /* include_joint_limit_penalty_forces */ true,
+      /* include_pd_controlled_input */ true, &forces0);
 
   const int nq = plant().num_positions();
   const int nv = plant().num_velocities();
@@ -371,8 +372,9 @@ void TamsiDriver<T>::CalcAndAddSpatialContactForcesFromContactResults(
 template <typename T>
 void TamsiDriver<T>::CalcDiscreteUpdateMultibodyForces(
     const systems::Context<T>& context, MultibodyForces<T>* forces) const {
-  const bool include_joint_limit_penalty_forces = true;
-  manager().CalcNonContactForces(context, include_joint_limit_penalty_forces,
+  manager().CalcNonContactForces(context,
+                                 /* include_joint_limit_penalty_forces */ true,
+                                 /* include_pd_controlled_input */ true,
                                  forces);
   const ContactResults<T>& contact_results =
       manager().EvalContactResults(context);

--- a/multibody/plant/test/actuated_models_test.cc
+++ b/multibody/plant/test/actuated_models_test.cc
@@ -47,6 +47,7 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
     kArmIsControlled,
     kArmIsNotControlled,
     kArmIsPartiallyControlled,
+    kModelWithZeroGains,
   };
 
   // - arm not controlled
@@ -56,8 +57,8 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
       ModelConfiguration model_config = ModelConfiguration::kArmIsNotControlled,
       bool is_discrete = true) {
     const char kArmSdfPath[] =
-        "drake/manipulation/models/iiwa_description/sdf/"
-        "iiwa14_no_collision.sdf";
+        "drake/manipulation/models/iiwa_description/iiwa7/"
+        "iiwa7_no_collision.sdf";
 
     const char kWsg50SdfPath[] =
         "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf";
@@ -78,10 +79,9 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
     gripper_model_ = parser.AddModels(FindResourceOrThrow(kWsg50SdfPath)).at(0);
 
     // A model of a (non-actuated) plate.
-    box_model_ = parser
-                       .AddModels(FindResourceOrThrow(
-                           "drake/multibody/models/box.urdf"))
-                       .at(0);
+    box_model_ =
+        parser.AddModels(FindResourceOrThrow("drake/multibody/models/box.urdf"))
+            .at(0);
 
     const auto& base_body = plant_->GetBodyByName("iiwa_link_0", arm_model_);
     const auto& end_effector = plant_->GetBodyByName("iiwa_link_7", arm_model_);
@@ -116,6 +116,15 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
       actuator1.set_controller_gains({kProportionalGain_, kDerivativeGain_});
       auto& actuator3 = plant_->get_mutable_joint_actuator(arm_actuators[3]);
       actuator3.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+    } else if (model_config == ModelConfiguration::kModelWithZeroGains) {
+      for (JointActuatorIndex actuator_index(0);
+           actuator_index < plant_->num_actuators(); ++actuator_index) {
+        JointActuator<double>& actuator =
+            plant_->get_mutable_joint_actuator(actuator_index);
+        // N.B. Proportional gains must be strictly positive, so we choose a
+        // small positive number to approximate zero.
+        actuator.set_controller_gains({1.0e-10, 0.0});
+      }
     }
 
     plant_->Finalize();
@@ -206,7 +215,7 @@ TEST_F(ActuatedIiiwaArmTest, AssembleActuationInput_ActuationInputRequired) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       MultibodyPlantTester::AssembleActuationInput(*plant_, *context_),
-      "Actuation input port for model instance iiwa14 must be connected or PD "
+      "Actuation input port for model instance iiwa7 must be connected or PD "
       "gains must be specified for each actuator.");
 }
 
@@ -276,7 +285,7 @@ TEST_F(ActuatedIiiwaArmTest,
   // We now verify AssembleDesiredStateInput() throws for the right reason.
   DRAKE_EXPECT_THROWS_MESSAGE(
       MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_),
-      "Model iiwa14 is partially PD controlled. .*");
+      "Model iiwa7 is partially PD controlled. .*");
 }
 
 TEST_F(ActuatedIiiwaArmTest,
@@ -353,6 +362,129 @@ TEST_F(ActuatedIiiwaArmTest,
       "Continuous model with PD controlled joint actuators. This feature is "
       "only supported for discrete models. Refer to MultibodyPlant's "
       "documentation for further details.");
+}
+
+// This unit test verifies that, when within effort limits, forces applied
+// through the generalized forces input port has the same effect as applying the
+// same forces using the actuation input port.
+TEST_F(ActuatedIiiwaArmTest,
+       WithinEffortLimitsActuationMatchesAppliedGeneralizedForces) {
+  // We add PD controllers but set their gains to zero since for this test we
+  // are only interested on verifying that the effect of input actuation in the
+  // dynamics is handled properly.
+  SetUpModel(ModelConfiguration::kModelWithZeroGains);
+
+  const VectorXd arm_q0 = (VectorXd(7) << 0, 0, 0, -1.7, 0, 1.0, 0).finished();
+  const VectorXd arm_v0 = VectorXd::Zero(7);
+  const VectorXd arm_x0 = (VectorXd(14) << arm_q0, arm_v0).finished();
+  const VectorXd gripper_q0 = VectorXd::Zero(2);
+  const VectorXd gripper_v0 = VectorXd::Zero(2);
+  const VectorXd gripper_x0 =
+      (VectorXd(4) << gripper_q0, gripper_v0).finished();
+
+  plant_->SetPositionsAndVelocities(context_.get(), arm_model_, arm_x0);
+  plant_->SetPositionsAndVelocities(context_.get(), gripper_model_, gripper_x0);
+
+  // The desired state input ports are required to be connected, even when PD
+  // gains are zero in this test.
+  plant_->get_desired_state_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_x0);
+  plant_->get_desired_state_input_port(arm_model_)
+      .FixValue(context_.get(), arm_x0);
+
+  // N.B. These values of actuation are well within effort limits, for both arm
+  // and gripper.
+  const VectorXd arm_u = VectorXd::LinSpaced(7, 1.0, 7.0);
+  const VectorXd gripper_u = VectorXd::LinSpaced(2, 1.0, 2.0);
+  const VectorXd free_box = VectorXd::Zero(6);
+  const VectorXd tau = (VectorXd(15) << arm_u, gripper_u, free_box).finished();
+
+  auto updates = plant_->AllocateDiscreteVariables();
+
+  // Input through generalized forces.
+  plant_->get_applied_generalized_force_input_port().FixValue(context_.get(),
+                                                              tau);
+  plant_->CalcForcedDiscreteVariableUpdate(*context_, updates.get());
+  const VectorXd x_tau = updates->get_vector().CopyToVector();
+
+  // Input through actuation. Zero generalized forces first.
+  plant_->get_applied_generalized_force_input_port().FixValue(
+      context_.get(), VectorXd::Zero(15));
+  plant_->get_actuation_input_port(arm_model_).FixValue(context_.get(), arm_u);
+  plant_->get_actuation_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_u);
+  plant_->CalcForcedDiscreteVariableUpdate(*context_, updates.get());
+  const VectorXd x_actuation = updates->get_vector().CopyToVector();
+
+  // N.B. Generalized forces inputs and actuation inputs feed into the result in
+  // very different ways. Actuation input goes through the SAP solver and
+  // therefore the accuracy of the solution is affected by solver tolerances.
+  const double kTolerance = 1.0e-12;
+  EXPECT_TRUE(CompareMatrices(x_actuation, x_tau, kTolerance,
+                              MatrixCompareType::relative));
+}
+
+// We verify that the PD controlled actuators exert effort limits.
+TEST_F(ActuatedIiiwaArmTest,
+       OutsideEffortLimitsActuationMatchesAppliedGeneralizedForces) {
+  // We add PD controllers but set their gains to zero since for this test we
+  // are only interested on verifying that the effect of input actuation in the
+  // dynamics is handled properly.
+  SetUpModel(ModelConfiguration::kModelWithZeroGains);
+
+  const VectorXd arm_q0 = (VectorXd(7) << 0, 0, 0, -1.7, 0, 1.0, 0).finished();
+  const VectorXd arm_v0 = VectorXd::Zero(7);
+  const VectorXd arm_x0 = (VectorXd(14) << arm_q0, arm_v0).finished();
+  const VectorXd gripper_q0 = VectorXd::Zero(2);
+  const VectorXd gripper_v0 = VectorXd::Zero(2);
+  const VectorXd gripper_x0 =
+      (VectorXd(4) << gripper_q0, gripper_v0).finished();
+
+  plant_->SetPositionsAndVelocities(context_.get(), arm_model_, arm_x0);
+  plant_->SetPositionsAndVelocities(context_.get(), gripper_model_, gripper_x0);
+
+  // The desired state input ports are required to be connected, even when PD
+  // gains are zero in this test.
+  plant_->get_desired_state_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_x0);
+  plant_->get_desired_state_input_port(arm_model_)
+      .FixValue(context_.get(), arm_x0);
+
+  // N.B. Per SDF model, effort limits are 300 Nm. We set some of the actuation
+  // values to be outside this limit.
+  const VectorXd arm_u =
+      (VectorXd(7) << 350, 400, 55, -350, -400, -450, -40).finished();
+  const VectorXd gripper_u = VectorXd::LinSpaced(2, 1.0, 2.0);
+  const VectorXd free_box = VectorXd::Zero(6);
+  // To obtain the same actuation with generalized forces, we clamp u to be
+  // within effort limits.
+  const VectorXd arm_u_clamped = arm_u.array().min(300).max(-300);
+  const VectorXd tau =
+      (VectorXd(15) << arm_u_clamped, gripper_u, free_box).finished();
+
+  auto updates = plant_->AllocateDiscreteVariables();
+
+  // Input through generalized forces.
+  plant_->get_applied_generalized_force_input_port().FixValue(context_.get(),
+                                                              tau);
+  plant_->CalcForcedDiscreteVariableUpdate(*context_, updates.get());
+  const VectorXd x_tau = updates->get_vector().CopyToVector();
+
+  // Input through actuation. Zero generalized forces first.
+  plant_->get_applied_generalized_force_input_port().FixValue(
+      context_.get(), VectorXd::Zero(15));
+  plant_->get_actuation_input_port(arm_model_).FixValue(context_.get(), arm_u);
+  plant_->get_actuation_input_port(gripper_model_)
+      .FixValue(context_.get(), gripper_u);
+  plant_->CalcForcedDiscreteVariableUpdate(*context_, updates.get());
+  const VectorXd x_actuation = updates->get_vector().CopyToVector();
+
+  // N.B. Generalized forces inputs and actuation inputs feed into the result in
+  // very different ways. Actuation input goes through the SAP solver and
+  // therefore the accuracy of the solution is affected by solver tolerances.
+  const double kTolerance = 1.0e-12;
+  EXPECT_TRUE(CompareMatrices(x_actuation, x_tau, kTolerance,
+                              MatrixCompareType::relative));
 }
 
 }  // namespace

--- a/multibody/plant/test/compliant_contact_manager_tester.h
+++ b/multibody/plant/test/compliant_contact_manager_tester.h
@@ -38,13 +38,15 @@ class CompliantContactManagerTester {
     return manager.EvalDiscreteContactPairs(context);
   }
 
+  // N.B. Actuation input is always included, regardless of solver choice.
   static void CalcNonContactForces(
       const CompliantContactManager<double>& manager,
       const drake::systems::Context<double>& context,
       bool include_joint_limit_penalty_forces,
       MultibodyForces<double>* forces) {
+    const bool include_pd_controlled_input = true;
     manager.CalcNonContactForces(context, include_joint_limit_penalty_forces,
-                                 forces);
+                                 include_pd_controlled_input, forces);
   }
 
   static std::vector<ContactPairKinematics<double>> CalcContactKinematics(


### PR DESCRIPTION
Bug reported via the [SO](https://stackoverflow.com/questions/77169145/drifting-observed-when-controlling-a-robot-arm-with-implicit-pd-control-gravit).
Fix to bug introduced in #20111.

There are two types of force contributions: continuous forces (such as Coriolis, damping and force elements) and constraints. SAP incorporates continuous forces in the "free motion velocities" computation. 

Implicit PD controllers implemented in #20111 move actuation from a continuous contribution to a constraint contribution. However, #20111 failed to remove the contribution from the free motion velocities computation, and therefore this contribution is erroneously accounted for twice.

This PR removes actuation from the free motion velocities computation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20259)
<!-- Reviewable:end -->
