### PR TITLE
[doc] Bump Bazel minimum version to 5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ endif()
 
 # The version passed to find_package(Bazel) should match the
 # minimum_bazel_version value in the call to versions.check() in WORKSPACE.
-set(MINIMUM_BAZEL_VERSION 4.0)
+set(MINIMUM_BAZEL_VERSION 5.1)
 find_package(Bazel ${MINIMUM_BAZEL_VERSION} MODULE)
 if(NOT Bazel_FOUND)
   set(Bazel_EXECUTABLE "${PROJECT_SOURCE_DIR}/third_party/com_github_bazelbuild_bazelisk/bazelisk.py")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,7 +24,7 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 # This needs to be in WORKSPACE or a repository rule for native.bazel_version
 # to actually be defined. The minimum_bazel_version value should match the
 # version passed to the find_package(Bazel) call in the root CMakeLists.txt.
-versions.check(minimum_bazel_version = "4.0")
+versions.check(minimum_bazel_version = "5.1")
 
 # The cargo_universe programs are only used by Drake's new_release tooling, not
 # by any compilation rules. As such, we can put it directly into the WORKSPACE

--- a/doc/_release-notes/v1.21.0.md
+++ b/doc/_release-notes/v1.21.0.md
@@ -24,6 +24,7 @@ released: 2023-09-14
     to the upgrade. Refer to [#20144][_#20144] for further discussion.
   * On macOS, when building Drake from source as a bazel external, you must not
     have ``build --force_pic`` in your ``.bazelrc`` file ([#20217][_#20217]).
+  * Drake's minimum compatible Bazel verison has increased to ``bazel >= 5.1``.
 * CMake users no longer need to install Bazel when building Drake from source
   ([#20064][_#20064]).
 
@@ -153,6 +154,7 @@ Fixes
   * CMake users no longer need to install Bazel before building Drake from source.
   * Provide install_prereqs opt-in/opt-out flags for installing Bazel on Ubuntu ([#20046][_#20046])
 * Fix model_visualizer --show_rgbd_sensor ([#20112][_#20112])
+* Drake's minimum compatible Bazel verison has increased to ``bazel >= 5.1`` ([#19945][_#19945])
 
 ## Build dependencies
 


### PR DESCRIPTION
This was already true in practice; our docs just missed it.  The `@vtk_internal` rules use https://github.com/bazelbuild/bazel/pull/14835.

Amends #19945.

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20263)
<!-- Reviewable:end -->
