### PR TITLE
[geometry] Indicate Meshcat connections in System graphviz output

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -36,6 +36,7 @@ drake_cc_package_library(
         ":make_mesh_for_deformable",
         ":meshcat",
         ":meshcat_animation",
+        ":meshcat_graphviz",
         ":meshcat_point_cloud_visualizer",
         ":meshcat_visualizer",
         ":meshcat_visualizer_params",
@@ -543,6 +544,7 @@ drake_cc_library(
     hdrs = ["meshcat_point_cloud_visualizer.h"],
     deps = [
         ":meshcat",
+        ":meshcat_graphviz",
         ":rgba",
         ":utilities",
         "//perception:point_cloud",
@@ -558,6 +560,22 @@ drake_cc_googletest(
         "//systems/analysis:simulator",
         "//systems/framework:diagram_builder",
         "//systems/primitives:constant_value_source",
+    ],
+)
+
+drake_cc_library(
+    name = "meshcat_graphviz",
+    srcs = ["meshcat_graphviz.cc"],
+    hdrs = ["meshcat_graphviz.h"],
+    deps = [
+        "//systems/framework:system_base",
+    ],
+)
+
+drake_cc_googletest(
+    name = "meshcat_graphviz_test",
+    deps = [
+        ":meshcat_graphviz",
     ],
 )
 
@@ -578,6 +596,7 @@ drake_cc_library(
     deps = [
         ":geometry_roles",
         ":meshcat",
+        ":meshcat_graphviz",
         ":meshcat_visualizer_params",
         ":rgba",
         ":scene_graph",

--- a/geometry/meshcat_graphviz.cc
+++ b/geometry/meshcat_graphviz.cc
@@ -1,0 +1,60 @@
+#include "drake/geometry/meshcat_graphviz.h"
+
+#include <utility>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Params = systems::SystemBase::GraphvizFragmentParams;
+using Result = systems::SystemBase::GraphvizFragment;
+
+namespace {
+/* Resolves a possibly-relative path, per the policy of the Meshcat class. */
+std::string ResolvePath(std::string_view path) {
+  if (path.substr(0, 1) == "/") {
+    return std::string{path};
+  }
+  if (path.empty()) {
+    return "/drake";
+  }
+  return fmt::format("/drake/{}", path);
+}
+}  // namespace
+
+MeshcatGraphviz::MeshcatGraphviz(std::optional<std::string_view> path,
+                                 bool subscribe)
+    : path_(ResolvePath(path.value_or(""))),
+      publish_(path.has_value()),
+      subscribe_(subscribe) {}
+
+Params MeshcatGraphviz::DecorateParams(const Params& params) {
+  node_id_ = params.node_id;
+  Params new_params{params};
+  if (publish_) {
+    new_params.header_lines.push_back(fmt::format("path={}", path_));
+  }
+  return new_params;
+}
+
+Result MeshcatGraphviz::DecorateResult(Result&& result) {
+  Result new_result = std::move(result);
+  DRAKE_THROW_UNLESS(!node_id_.empty());
+  if (publish_) {
+    new_result.fragments.push_back(
+        fmt::format("meshcat_in [label=Meshcat, color=magenta];\n"
+                    "{}:e -> meshcat_in [style=dashed, color=magenta]\n",
+                    node_id_));
+  }
+  if (subscribe_) {
+    new_result.fragments.push_back(
+        fmt::format("meshcat_out [label=Meshcat, color=magenta];\n"
+                    "meshcat_out -> {}:w [style=dashed, color=magenta]\n",
+                    node_id_));
+  }
+  return new_result;
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/meshcat_graphviz.h
+++ b/geometry/meshcat_graphviz.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "drake/systems/framework/system_base.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* Encapsulates how to annotate use of Meshcat in a System's Graphviz.
+
+Use this class within the implementation of DoGetGraphvizFragment, e.g.:
+
+```c++
+// Overrides the Parent::DoGetGraphvizFragment member function.
+Parent::GraphvizFragment MySystem::DoGetGraphvizFragment(
+    const Parent::GraphvizFragmentParams& params) const override {
+  MeshcatGraphviz helper(...);
+  return helper.DecorateResult(
+      Parent::DoGetGraphvizFragment(helper.DecorateParams(paraams)));
+}
+```
+
+Grep for existing uses of this class to find other examples. */
+class MeshcatGraphviz {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MeshcatGraphviz);
+
+  /* Specifies how to customize the Graphviz for a Meshcat-using System.
+  @param path When the system publishes messages to Meshcat, provide the
+   (non-null) meshcat path in this parameter. This draws a Graphviz arrow from
+   the system to meshcat. See "Meshcat paths and the scene tree" in Drake's
+   meshcat class overview docs for the semantics of `path`. When this system is
+   subscribe-only, pass nullopt instead.
+  @param subscribe True iff the system receives messages from meshcat (e.g.,
+   uses buttons or sliders from control panel). This draws a Graphviz arrow
+   from meshcat to the system. */
+  MeshcatGraphviz(std::optional<std::string_view> path, bool subscribe);
+
+  /* Rewrites the `params` to customize for Meshcat, by returning a possibly-
+  edited copy. Intended for use alongside DecorateResult(). */
+  systems::SystemBase::GraphvizFragmentParams DecorateParams(
+      const systems::SystemBase::GraphvizFragmentParams& params);
+
+  /* Rewrites the `result` to customize for Meshcat.
+  @pre DecorateParams has already been called. */
+  systems::SystemBase::GraphvizFragment DecorateResult(
+      systems::SystemBase::GraphvizFragment&& result);
+
+ private:
+  const std::string path_;
+  const bool publish_;
+  const bool subscribe_;
+
+  std::string node_id_;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/meshcat_point_cloud_visualizer.cc
+++ b/geometry/meshcat_point_cloud_visualizer.cc
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/extract_double.h"
+#include "drake/geometry/meshcat_graphviz.h"
 #include "drake/geometry/utilities.h"
 #include "drake/perception/point_cloud.h"
 
@@ -70,6 +71,17 @@ systems::EventStatus MeshcatPointCloudVisualizer<T>::UpdateMeshcat(
   meshcat_->SetTransform(path_, X_ParentCloud);
 
   return systems::EventStatus::Succeeded();
+}
+
+template <typename T>
+typename systems::LeafSystem<T>::GraphvizFragment
+MeshcatPointCloudVisualizer<T>::DoGetGraphvizFragment(
+    const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+    const {
+  internal::MeshcatGraphviz meshcat_graphviz(path_, /* subscribe = */ false);
+  return meshcat_graphviz.DecorateResult(
+      systems::LeafSystem<T>::DoGetGraphvizFragment(
+          meshcat_graphviz.DecorateParams(params)));
 }
 
 }  // namespace geometry

--- a/geometry/meshcat_point_cloud_visualizer.h
+++ b/geometry/meshcat_point_cloud_visualizer.h
@@ -85,6 +85,10 @@ class MeshcatPointCloudVisualizer final : public systems::LeafSystem<T> {
   /* The periodic event handler which publishes the cloud to Meshcat.  */
   systems::EventStatus UpdateMeshcat(const systems::Context<T>& context) const;
 
+  typename systems::LeafSystem<T>::GraphvizFragment DoGetGraphvizFragment(
+      const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+      const final;
+
   /* Input ports. */
   int cloud_input_port_{};
   int pose_input_port_{};

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -9,6 +9,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/extract_double.h"
+#include "drake/geometry/meshcat_graphviz.h"
 #include "drake/geometry/proximity/volume_to_surface_mesh.h"
 #include "drake/geometry/utilities.h"
 
@@ -283,6 +284,18 @@ systems::EventStatus MeshcatVisualizer<T>::OnInitialization(
     const systems::Context<T>&) const {
   Delete();
   return systems::EventStatus::Succeeded();
+}
+
+template <typename T>
+typename systems::LeafSystem<T>::GraphvizFragment
+MeshcatVisualizer<T>::DoGetGraphvizFragment(
+    const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+    const {
+  internal::MeshcatGraphviz meshcat_graphviz(params_.prefix,
+                                             /* subscribe = */ false);
+  return meshcat_graphviz.DecorateResult(
+      systems::LeafSystem<T>::DoGetGraphvizFragment(
+          meshcat_graphviz.DecorateParams(params)));
 }
 
 }  // namespace geometry

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -187,6 +187,10 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   /* Handles the initialization event. */
   systems::EventStatus OnInitialization(const systems::Context<T>&) const;
 
+  typename systems::LeafSystem<T>::GraphvizFragment DoGetGraphvizFragment(
+      const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+      const final;
+
   /* The index of this System's QueryObject-valued input port. */
   int query_object_input_port_{};
 

--- a/geometry/test/meshcat_graphviz_test.cc
+++ b/geometry/test/meshcat_graphviz_test.cc
@@ -1,0 +1,69 @@
+#include "drake/geometry/meshcat_graphviz.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Params = systems::SystemBase::GraphvizFragmentParams;
+using Result = systems::SystemBase::GraphvizFragment;
+
+GTEST_TEST(MeshcatGraphvizTest, Publish) {
+  MeshcatGraphviz dut("path_foo", /* subscribe = */ false);
+
+  const Params params_orig{.node_id = "node_bar",
+                           .header_lines = {"existing header"}};
+  const Params params = dut.DecorateParams(params_orig);
+  EXPECT_EQ(params.node_id, "node_bar");
+  EXPECT_THAT(params.header_lines,
+              testing::ElementsAre("existing header", "path=/drake/path_foo"));
+
+  const Result result_orig{.input_ports = {"node_bar:u0"},
+                           .output_ports = {"node_bar:y0"},
+                           .fragments = {"existing fragment"}};
+  const Result result = dut.DecorateResult(Result{result_orig});
+  EXPECT_EQ(result.input_ports, result_orig.input_ports);
+  EXPECT_EQ(result.output_ports, result_orig.output_ports);
+  ASSERT_GE(result.fragments.size(), 2);
+  EXPECT_EQ(result.fragments.front(), "existing fragment");
+  EXPECT_THAT(result.fragments.back(), testing::HasSubstr("meshcat_in"));
+  EXPECT_THAT(result.fragments.back(),
+              testing::Not(testing::HasSubstr("meshcat_out")));
+}
+
+GTEST_TEST(MeshcatGraphvizTest, PublishAbsolutePath) {
+  MeshcatGraphviz dut("/absolute", /* subscribe = */ false);
+
+  const Params params = dut.DecorateParams(Params{});
+  EXPECT_THAT(params.header_lines, testing::ElementsAre("path=/absolute"));
+}
+
+GTEST_TEST(MeshcatGraphvizTest, Subscribe) {
+  MeshcatGraphviz dut(/* path = */ std::nullopt, /* subscribe = */ true);
+
+  const Params params_orig{.node_id = "node_bar",
+                           .header_lines = {"existing header"}};
+  const Params params = dut.DecorateParams(params_orig);
+  EXPECT_EQ(params.node_id, "node_bar");
+  EXPECT_THAT(params.header_lines, testing::ElementsAre("existing header"));
+
+  const Result result_orig{.input_ports = {"node_bar:u0"},
+                           .output_ports = {"node_bar:y0"},
+                           .fragments = {"existing fragment"}};
+  const Result result = dut.DecorateResult(Result{result_orig});
+  EXPECT_EQ(result.input_ports, result_orig.input_ports);
+  EXPECT_EQ(result.output_ports, result_orig.output_ports);
+  ASSERT_GE(result.fragments.size(), 2);
+  EXPECT_EQ(result.fragments.front(), "existing fragment");
+  EXPECT_THAT(result.fragments.back(), testing::HasSubstr("meshcat_out"));
+  EXPECT_THAT(result.fragments.back(),
+              testing::Not(testing::HasSubstr("meshcat_in")));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/meshcat_point_cloud_visualizer_test.cc
+++ b/geometry/test/meshcat_point_cloud_visualizer_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/meshcat_point_cloud_visualizer.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -118,7 +119,11 @@ TEST_F(MeshcatPointCloudVisualizerTest, ScalarConversion) {
   ad_diagram->ForcedPublish(*ad_context);
 }
 
-
+TEST_F(MeshcatPointCloudVisualizerTest, Graphviz) {
+  SetUpDiagram();
+  EXPECT_THAT(visualizer_->GetGraphvizString(),
+              testing::HasSubstr("-> meshcat_in"));
+}
 
 }  // namespace
 }  // namespace geometry

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -2,6 +2,7 @@
 
 #include <thread>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <msgpack.hpp>
 
@@ -620,6 +621,12 @@ GTEST_TEST(MeshcatVisualizerTest, RealtimeRate) {
   // kernel's details of process scheduling, or else we could be flaky.)
   simulator.AdvanceTo(0.005);
   EXPECT_NE(meshcat->GetRealtimeRate(), slow_rate);
+}
+
+TEST_F(MeshcatVisualizerWithIiwaTest, Graphviz) {
+  SetUpDiagram();
+  EXPECT_THAT(visualizer_->GetGraphvizString(),
+              testing::HasSubstr("-> meshcat_in"));
 }
 
 }  // namespace

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -37,6 +37,7 @@ drake_cc_library(
         ":point_contact_visualizer",
         "//common:essential",
         "//geometry:meshcat",
+        "//geometry:meshcat_graphviz",
         "//math:geometric_transform",
         "//multibody/plant",
         "//systems/framework:context",
@@ -85,6 +86,7 @@ drake_cc_library(
     deps = [
         "//common:scope_exit",
         "//geometry:meshcat",
+        "//geometry:meshcat_graphviz",
         "//multibody/plant",
     ],
 )

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -6,6 +6,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/extract_double.h"
+#include "drake/geometry/meshcat_graphviz.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
 #include "drake/multibody/meshcat/point_contact_visualizer.h"
@@ -322,6 +323,18 @@ template <typename T>
 EventStatus ContactVisualizer<T>::OnInitialization(const Context<T>&) const {
   Delete();
   return EventStatus::Succeeded();
+}
+
+template <typename T>
+typename systems::LeafSystem<T>::GraphvizFragment
+ContactVisualizer<T>::DoGetGraphvizFragment(
+    const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+    const {
+  geometry::internal::MeshcatGraphviz meshcat_graphviz(params_.prefix,
+                                                       /* subscribe = */ false);
+  return meshcat_graphviz.DecorateResult(
+      systems::LeafSystem<T>::DoGetGraphvizFragment(
+          meshcat_graphviz.DecorateParams(params)));
 }
 
 }  // namespace meshcat

--- a/multibody/meshcat/contact_visualizer.h
+++ b/multibody/meshcat/contact_visualizer.h
@@ -152,6 +152,10 @@ class ContactVisualizer final : public systems::LeafSystem<T> {
   /* Handles the initialization event. */
   systems::EventStatus OnInitialization(const systems::Context<T>&) const;
 
+  typename systems::LeafSystem<T>::GraphvizFragment DoGetGraphvizFragment(
+      const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+      const final;
+
   /* Meshcat is mutable because we must send messages (a non-const operation)
   from a const System (e.g., during simulation). We use shared_ptr instead of
   unique_ptr to facilitate sharing ownership through scalar conversion;

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -11,6 +11,7 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/unused.h"
+#include "drake/geometry/meshcat_graphviz.h"
 
 namespace {
 // Boilerplate for std::visit.
@@ -246,6 +247,19 @@ void JointSliders<T>::CalcOutput(
       (*output)[position_index] = meshcat_->GetSliderValue(slider_name);
     }
   }
+}
+
+template <typename T>
+typename systems::LeafSystem<T>::GraphvizFragment
+JointSliders<T>::DoGetGraphvizFragment(
+    const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+    const {
+  geometry::internal::MeshcatGraphviz meshcat_graphviz(
+      /* path = */ std::nullopt,
+      /* subscribe = */ true);
+  return meshcat_graphviz.DecorateResult(
+      systems::LeafSystem<T>::DoGetGraphvizFragment(
+          meshcat_graphviz.DecorateParams(params)));
 }
 
 template <typename T>

--- a/multibody/meshcat/joint_sliders.h
+++ b/multibody/meshcat/joint_sliders.h
@@ -146,6 +146,10 @@ class JointSliders final : public systems::LeafSystem<T> {
  private:
   void CalcOutput(const systems::Context<T>&, systems::BasicVector<T>*) const;
 
+  typename systems::LeafSystem<T>::GraphvizFragment DoGetGraphvizFragment(
+      const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+      const final;
+
   std::shared_ptr<geometry::Meshcat> meshcat_;
   const MultibodyPlant<T>* const plant_;
   const std::map<int, std::string> position_names_;

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/meshcat/contact_visualizer.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
@@ -244,6 +245,12 @@ TEST_F(ContactVisualizerTest, ScalarConversion) {
   // Call publish to provide code coverage for the AutoDiffXd version of
   // UpdateMeshcat.  We simply confirm that the code doesn't blow up.
   ad_diagram->ForcedPublish(*ad_context);
+}
+
+TEST_F(ContactVisualizerTest, Graphviz) {
+  SetUpDiagram();
+  EXPECT_THAT(visualizer_->GetGraphvizString(),
+              testing::HasSubstr("-> meshcat_in"));
 }
 
 }  // namespace

--- a/multibody/meshcat/test/joint_sliders_test.cc
+++ b/multibody/meshcat/test/joint_sliders_test.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/meshcat/joint_sliders.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
@@ -428,6 +429,13 @@ TEST_F(JointSlidersTest, SetPositionsKukaIiwaRobot) {
   EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint5), std::exception);
   EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint6), std::exception);
   EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint7), std::exception);
+}
+
+TEST_F(JointSlidersTest, Graphviz) {
+  AddAcrobot();
+  const JointSliders<double> dut(meshcat_, &plant_);
+  EXPECT_THAT(dut.GetGraphvizString(),
+              testing::HasSubstr("meshcat_out ->"));
 }
 
 }  // namespace

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -198,6 +198,28 @@ class SystemBase : public internal::SystemMessageInterface {
       const std::map<std::string, std::string>& options = {}) const;
   //@}
 
+  /** (Advanced) The arguments to the protected method DoGetGraphvizFragment().
+  This struct typically is only used by subclasses of LeafSystem that need to
+  customize their Graphviz representation. These parameters constitute a polite
+  request; a user's %System's implementation of DoGetGraphvizFragment() is not
+  strictly required to honor any of these parameters, but generally should
+  attempt to honor as many as possible. */
+  struct GraphvizFragmentParams {
+    /** As per GetGraphvizString(). */
+    int max_depth{};
+
+    /** As per GetGraphvizString(). */
+    std::map<std::string, std::string> options;
+
+    /** The Graphviz ID to use for this node. */
+    std::string node_id;
+
+    /** The header line(s) to use for this Graphviz node's table. The strings in
+    `header_lines` should not contain newlines; those are added automatically,
+    along with `<BR/>` breaks between lines. */
+    std::vector<std::string> header_lines;
+  };
+
   //----------------------------------------------------------------------------
   /** @name            Input port evaluation (deprecated)
   These _deprecated_ methods provide scalar type-independent evaluation of a
@@ -1267,26 +1289,6 @@ class SystemBase : public internal::SystemMessageInterface {
   /** (Internal) Gets the id used to tag context data as being created by this
   system. See @ref system_compatibility. */
   internal::SystemId get_system_id() const { return system_id_; }
-
-  /** The arguments to DoGetGraphvizFragment(). These parameters constitute a
-  polite request; a user's %System's implementation of DoGetGraphvizFragment()
-  is not strictly required to honor any of these parameters, but generally
-  should attempt to honor as many as possible. */
-  struct GraphvizFragmentParams {
-    /** As per GetGraphvizString(). */
-    int max_depth{};
-
-    /** As per GetGraphvizString(). */
-    std::map<std::string, std::string> options;
-
-    /** The Graphviz ID to use for this node. */
-    std::string node_id;
-
-    /** The header line(s) to use for this Graphviz node's table. The strings in
-    `header_lines` should not contain newlines; those are added automatically,
-    along with `<BR/>` breaks between lines. */
-    std::vector<std::string> header_lines;
-  };
 
   /** The NVI implementation of GetGraphvizFragment() for subclasses to override
   if desired. The default behavior should be sufficient in most cases. */

--- a/visualization/BUILD.bazel
+++ b/visualization/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_library(
     deps = [
         "//common:scope_exit",
         "//geometry:meshcat",
+        "//geometry:meshcat_graphviz",
         "//systems/framework",
     ],
 )

--- a/visualization/meshcat_pose_sliders.cc
+++ b/visualization/meshcat_pose_sliders.cc
@@ -10,6 +10,7 @@
 
 #include "drake/common/scope_exit.h"
 #include "drake/common/unused.h"
+#include "drake/geometry/meshcat_graphviz.h"
 
 namespace drake {
 namespace visualization {
@@ -183,6 +184,19 @@ systems::EventStatus MeshcatPoseSliders<T>::OnInitialization(
     return systems::EventStatus::Succeeded();
   }
   return systems::EventStatus::DidNothing();
+}
+
+template <typename T>
+typename systems::LeafSystem<T>::GraphvizFragment
+MeshcatPoseSliders<T>::DoGetGraphvizFragment(
+    const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+    const {
+  geometry::internal::MeshcatGraphviz meshcat_graphviz(
+      /* path = */ std::nullopt,
+      /* subscribe = */ true);
+  return meshcat_graphviz.DecorateResult(
+      systems::LeafSystem<T>::DoGetGraphvizFragment(
+          meshcat_graphviz.DecorateParams(params)));
 }
 
 template <typename T>

--- a/visualization/meshcat_pose_sliders.h
+++ b/visualization/meshcat_pose_sliders.h
@@ -162,6 +162,10 @@ class MeshcatPoseSliders final : public systems::LeafSystem<T> {
   /* Handles the initialization event. */
   systems::EventStatus OnInitialization(const systems::Context<T>&) const;
 
+  typename systems::LeafSystem<T>::GraphvizFragment DoGetGraphvizFragment(
+      const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+      const final;
+
   std::shared_ptr<geometry::Meshcat> meshcat_;
   mutable math::RigidTransform<double> nominal_pose_;
   std::atomic<bool> is_registered_;

--- a/visualization/test/meshcat_pose_sliders_test.cc
+++ b/visualization/test/meshcat_pose_sliders_test.cc
@@ -1,5 +1,6 @@
 #include "drake/visualization/meshcat_pose_sliders.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
@@ -287,6 +288,12 @@ GTEST_TEST(MeshcatPoseSlidersTest, RunWithFixedInputPort) {
       dut.get_output_port().Eval<RigidTransformd>(*context).IsExactlyEqualTo(
           X));
   EXPECT_TRUE(X_out.IsExactlyEqualTo(X));
+}
+
+GTEST_TEST(MeshcatPoseSlidersTest, Graphviz) {
+  auto meshcat = geometry::GetTestEnvironmentMeshcat();
+  MeshcatPoseSliders<double> dut(meshcat);
+  EXPECT_THAT(dut.GetGraphvizString(), testing::HasSubstr("meshcat_out ->"));
 }
 
 }  // namespace


### PR DESCRIPTION
Towards #20203.

As an example, here's what `//tools:model_visualizer` looks like in r1:

![image](https://github.com/RobotLocomotion/drake/assets/17596505/24bb142a-ecfa-4912-897d-2131702e9f29)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20270)
<!-- Reviewable:end -->
