### PR TITLE
[workspace] Nerf new_release for rust crates

### DIFF
--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -205,6 +205,10 @@ def _check_for_upgrades(gh, args, metadata):
         key = data["repository_rule_type"]
         if key == "github":
             old_commit, new_commit = _handle_github(workspace_name, gh, data)
+        elif key == "crate_universe":
+            # For details, see drake/tools/workspace/crate_universe/README.md.
+            print(f"Ignoring {workspace_name} from rules_rust")
+            continue
         elif key in ["pypi", "pypi_wheel"]:
             # TODO(jwnimmer-tri) Implement for real.
             print("{} version {} needs manual inspection".format(


### PR DESCRIPTION
Sample output as of this morning:
```
Checking for new releases...
abseil_cpp_internal needs upgrade from 1981cf8c0206657a16f73f48d43a313c65485d5e to 302d851a06072a581961970c1e120c2af7b70482
build_bazel_apple_support needs upgrade from 1.8.1 to 1.10.1
Ignoring crate__amd-0.2.2 from rules_rust
Ignoring crate__autocfg-1.1.0 from rules_rust
Ignoring crate__cfg-if-1.0.0 from rules_rust
Ignoring crate__clarabel-0.6.0 from rules_rust
Ignoring crate__darling-0.14.4 from rules_rust
Ignoring crate__darling_core-0.14.4 from rules_rust
Ignoring crate__darling_macro-0.14.4 from rules_rust
Ignoring crate__derive_builder-0.11.2 from rules_rust
Ignoring crate__derive_builder_core-0.11.2 from rules_rust
Ignoring crate__derive_builder_macro-0.11.2 from rules_rust
Ignoring crate__either-1.9.0 from rules_rust
Ignoring crate__enum_dispatch-0.3.12 from rules_rust
Ignoring crate__fnv-1.0.7 from rules_rust
Ignoring crate__ident_case-1.0.1 from rules_rust
Ignoring crate__itertools-0.11.0 from rules_rust
Ignoring crate__lazy_static-1.4.0 from rules_rust
Ignoring crate__num-traits-0.2.16 from rules_rust
Ignoring crate__once_cell-1.18.0 from rules_rust
Ignoring crate__proc-macro2-1.0.67 from rules_rust
Ignoring crate__quote-1.0.33 from rules_rust
Ignoring crate__strsim-0.10.0 from rules_rust
Ignoring crate__syn-1.0.109 from rules_rust
Ignoring crate__syn-2.0.37 from rules_rust
Ignoring crate__thiserror-1.0.48 from rules_rust
Ignoring crate__thiserror-impl-1.0.48 from rules_rust
Ignoring crate__unicode-ident-1.0.12 from rules_rust
curl_internal needs upgrade from curl-8_2_1 to curl-8_3_0
dm_control_internal needs upgrade from d6f9cb4e4a616d1e1d3bd8944bc89541434f1d49 to af46387b0c571d5a4f871d99b266001550a1377a
gz_utils_internal needs upgrade from gz-utils2_2.0.0 to gz-utils2_2.1.0
rules_rust needs upgrade from 0.27.0 to 0.28.0
Skipping prerelease sdformat-prerelease_2.0.3 for sdformat_internal
Skipping prerelease sdformat-prerelease_2.0.2 for sdformat_internal
Skipping prerelease sdformat-prerelease_2.0.1 for sdformat_internal
Skipping prerelease sdformat-prerelease_2.0.0 for sdformat_internal
Skipping prerelease sdformat-prerelease_1.5.0 for sdformat_internal
Skipping prerelease sdformat-prerelease_1.4.9 for sdformat_internal
sdformat_internal needs upgrade from sdformat13_13.6.0 to sdformat14_14.0.0
suitesparse_internal needs upgrade from v7.1.0 to v7.2.0
typing_extensions_internal needs upgrade from 4.7.0 to 4.8.0
yaml_cpp_internal needs upgrade from yaml-cpp-0.7.0 to 0.8.0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20292)
<!-- Reviewable:end -->
