### PR TITLE
Bug fix for deformable fixed constraints

### DIFF
--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -147,6 +147,14 @@ MultibodyConstraintId DeformableModel<T>::AddFixedConstraint(
     }
     ++vertex_index;
   }
+  // TODO(xuchenhan-tri): consider adding an option to allow empty constraint.
+  if (spec.vertices.size() == 0) {
+    throw std::runtime_error(
+        fmt::format("No constraint has been added between deformable body with "
+                    "id {} and rigid body with name {}. Remove the call to "
+                    "AddFixedConstraint() if this is intended.",
+                    body_A_id, body_B.name()));
+  }
   body_id_to_constraint_ids_[body_A_id].push_back(constraint_id);
   fixed_constraint_specs_[constraint_id] = std::move(spec);
   return constraint_id;

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -124,7 +124,9 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
            shapes include Box, Capsule, Cylinder, Ellipsoid, HalfSpace, and
            Sphere.
    @throws std::exception if Finalize() has been called on the multibody plant
-           owning this deformable model. */
+           owning this deformable model.
+   @throws std::exception if no constraint is added (i.e. no vertex of the
+           deformable body is inside the given `shape` with the given poses). */
   MultibodyConstraintId AddFixedConstraint(
       DeformableBodyId body_A_id, const Body<T>& body_B,
       const math::RigidTransform<double>& X_BA, const geometry::Shape& shape,

--- a/multibody/plant/test/deformable_fixed_constraint_test.cc
+++ b/multibody/plant/test/deformable_fixed_constraint_test.cc
@@ -48,16 +48,13 @@ constexpr double kDt = 1e-2;
                              |              |
                              -------/|\------
                                    / | \
-                                  /  |  \
-                                 /___|___\  deformable
-                                 \   |   /
-                                  \  |  /
-                                   \ | /
-                             -------\|/------
-                             |              |
-                             |              |
+                             -----/--|--\----
+                             |   /___|___\  | deformable
+                             |   \   |   /  |
+                             |    \  |  /   |
+                             |     \ | /    |
+                             |      \|/     |
                              | dynamic rigid|
-                             |              |
                              |              |
                              ----------------
 
@@ -100,9 +97,9 @@ class DeformableFixedConstraintTest : public ::testing::Test {
     plant_->RegisterVisualGeometry(box_body, RigidTransformd::Identity(), box,
                                    "box_visual", illustration_props);
 
-    /* Pose the deformable body in the rigid body's frame so that the bottom
-     vertex is under fixed constraint. */
-    const RigidTransformd X_RD(Vector3d(0, 0, 0.19));
+    /* Pose the deformable body in the rigid body's frame so that all vertices
+     except the top vertex are under fixed constraint. */
+    const RigidTransformd X_RD(Vector3d(0, 0, 0.09));
     model_->AddFixedConstraint(deformable_body_id_, box_body, X_RD, box,
                                RigidTransformd::Identity());
 

--- a/multibody/plant/test/deformable_model_test.cc
+++ b/multibody/plant/test/deformable_model_test.cc
@@ -278,9 +278,8 @@ TEST_F(DeformableModelTest, AddFixedConstraint) {
                                                 box, X_BG);
 
   EXPECT_TRUE(deformable_model_ptr_->HasConstraint(deformable_id));
-  EXPECT_EQ(
-      deformable_model_ptr_->fixed_constraint_ids(deformable_id).size(),
-      1);
+  EXPECT_EQ(deformable_model_ptr_->fixed_constraint_ids(deformable_id).size(),
+            1);
   const DeformableRigidFixedConstraintSpec& spec =
       deformable_model_ptr_->fixed_constraint_spec(constraint_id);
   EXPECT_EQ(spec.body_A, deformable_id);
@@ -318,6 +317,11 @@ TEST_F(DeformableModelTest, AddFixedConstraint) {
   EXPECT_THROW(deformable_model_ptr_->AddFixedConstraint(
                    deformable_id, rigid_body, X_BA, mesh, X_BG),
                std::exception);
+  /* No constraint is added . */
+  DRAKE_EXPECT_THROWS_MESSAGE(deformable_model_ptr_->AddFixedConstraint(
+                                  deformable_id, rigid_body, X_BA, box,
+                                  RigidTransformd(Vector3d(100, 100, 100))),
+                              "No constraint has been added.*box.*");
   /* Adding constraint after finalize. */
   plant_->Finalize();
   EXPECT_THROW(deformable_model_ptr_->AddFixedConstraint(


### PR DESCRIPTION
1. The Jacobian of the rigid dofs when computing the kinematics for fixed constraints now have the correct number of rows.
2. Fail fast when no constraints are added in DeformableModel::AddFixedConstraint().
3. Use dense algebra for computing `G*J` for the Jacobians of the deformable dofs for fixed constraints because `G*J` for non-3x3 G and block sparse J is not yet supported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20297)
<!-- Reviewable:end -->
