### PR TITLE
[multibody] Implements MultibodyTreeSystem::SetDefaultParameters

### DIFF
--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -478,6 +478,14 @@ class Body : public MultibodyElement<T> {
         name_(internal::DeprecateWhenEmptyName(name, "Body")),
         body_frame_(*this) {}
 
+  /// Called by DoDeclareParameters(). Derived classes may choose to override
+  /// to declare their sub-class specific parameters.
+  virtual void DoDeclareBodyParameters(internal::MultibodyTreeSystem<T>*) {}
+
+  /// Called by DoSetDefaultParameters(). Derived classes may choose to override
+  /// to set their sub-class specific parameters.
+  virtual void DoSetDefaultBodyParameters(systems::Parameters<T>*) const {}
+
   /// @name Methods to make a clone templated on different scalar types.
   ///
   /// These methods are meant to be called by MultibodyTree::CloneToScalar()
@@ -531,6 +539,17 @@ class Body : public MultibodyElement<T> {
       const internal::MultibodyTreeTopology& tree_topology) final {
     topology_ = tree_topology.get_body(this->index());
     body_frame_.SetTopology(tree_topology);
+  }
+
+  // Implementation for MultibodyElement::DoDeclareParameters().
+  void DoDeclareParameters(
+      internal::MultibodyTreeSystem<T>* tree_system) final {
+    DoDeclareBodyParameters(tree_system);
+  }
+
+  // Implementation for MultibodyElement::DoSetDefaultParameters().
+  void DoSetDefaultParameters(systems::Parameters<T>* parameters) const final {
+    DoSetDefaultBodyParameters(parameters);
   }
 
   // MultibodyTree has access to the mutable BodyFrame through BodyAttorney.

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -147,16 +147,26 @@ class FixedOffsetFrame final : public Frame<T> {
   /// @}
 
  private:
-  // Implementation for MultibodyElement::DoDeclareParameters().
+  // Implementation for Frame::DoDeclareFrameParameters().
   // FixedOffsetFrame declares a single parameter for its RigidTransform.
-  void DoDeclareParameters(
+  void DoDeclareFrameParameters(
       internal::MultibodyTreeSystem<T>* tree_system) final {
-    // Declare parent classes' parameters
-    Frame<T>::DoDeclareParameters(tree_system);
-    X_PF_parameter_index_ = this->DeclareNumericParameter(
-        tree_system,
-        systems::BasicVector<T>(Eigen::Map<const VectorX<T>>(
-            X_PF_.template cast<T>().GetAsMatrix34().data(), 12, 1)));
+    // Model value of this transform is set to a dummy value to indicate that
+    // the model value is not used. This class stores the default value and
+    // sets it in DoSetDefaultFrameParameters().
+    X_PF_parameter_index_ =
+        this->DeclareNumericParameter(tree_system, systems::BasicVector<T>(12));
+  }
+
+  // Implementation for Frame::DoSetDefaultFrameParameters().
+  // FixedOffsetFrame sets a single parameter for its RigidTransform.
+  void DoSetDefaultFrameParameters(
+      systems::Parameters<T>* parameters) const final {
+    // Set default rigid transform between P and F.
+    systems::BasicVector<T>& X_PF_parameter =
+        parameters->get_mutable_numeric_parameter(X_PF_parameter_index_);
+    X_PF_parameter.set_value(Eigen::Map<const VectorX<T>>(
+        X_PF_.template cast<T>().GetAsMatrix34().data(), 12, 1));
   }
 
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/force_element.h
+++ b/multibody/tree/force_element.h
@@ -183,6 +183,16 @@ class ForceElement : public MultibodyElement<T> {
       const internal::VelocityKinematicsCache<T>& vc,
       MultibodyForces<T>* forces) const = 0;
 
+  /// Called by DoDeclareParameters(). Derived classes may choose to override
+  /// to declare their sub-class specific parameters.
+  virtual void DoDeclareForceElementParameters(
+      internal::MultibodyTreeSystem<T>*) {}
+
+  /// Called by DoSetDefaultParameters(). Derived classes may choose to override
+  /// to set their sub-class specific parameters.
+  virtual void DoSetDefaultForceElementParameters(
+      systems::Parameters<T>*) const {}
+
   /// @name Methods to make a clone templated on different scalar types.
   ///
   /// Specific force element subclasses must implement these to support scalar
@@ -252,6 +262,17 @@ class ForceElement : public MultibodyElement<T> {
   // At MultibodyTree::Finalize() time, each force element retrieves its
   // topology from the parent MultibodyTree.
   void DoSetTopology(const internal::MultibodyTreeTopology&) final {}
+
+  // Implementation for MultibodyElement::DoDeclareParameters().
+  void DoDeclareParameters(
+      internal::MultibodyTreeSystem<T>* tree_system) final {
+    DoDeclareForceElementParameters(tree_system);
+  }
+
+  // Implementation for MultibodyElement::DoSetDefaultParameters().
+  void DoSetDefaultParameters(systems::Parameters<T>* parameters) const final {
+    DoSetDefaultForceElementParameters(parameters);
+  }
 };
 
 }  // namespace multibody

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -601,6 +601,14 @@ class Frame : public FrameBase<T> {
         name_(internal::DeprecateWhenEmptyName(name, "Frame")),
         body_(body) {}
 
+  /// Called by DoDeclareParameters(). Derived classes may choose to override
+  /// to declare their sub-class specific parameters.
+  virtual void DoDeclareFrameParameters(internal::MultibodyTreeSystem<T>*) {}
+
+  /// Called by DoSetDefaultParameters(). Derived classes may choose to override
+  /// to set their sub-class specific parameters.
+  virtual void DoSetDefaultFrameParameters(systems::Parameters<T>*) const {}
+
   /// @name Methods to make a clone templated on different scalar types.
   ///
   /// These methods are meant to be called by MultibodyTree::CloneToScalar()
@@ -631,6 +639,17 @@ class Frame : public FrameBase<T> {
   final {
     topology_ = tree_topology.get_frame(this->index());
     DRAKE_ASSERT(topology_.index == this->index());
+  }
+
+  // Implementation for MultibodyElement::DoDeclareParameters().
+  void DoDeclareParameters(
+      internal::MultibodyTreeSystem<T>* tree_system) final {
+    DoDeclareFrameParameters(tree_system);
+  }
+
+  // Implementation for MultibodyElement::DoSetDefaultParameters().
+  void DoSetDefaultParameters(systems::Parameters<T>* parameters) const final {
+    DoSetDefaultFrameParameters(parameters);
   }
 
   const std::string name_;

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -348,13 +348,25 @@ class JointActuator final : public MultibodyElement<T> {
   // Implementation for MultibodyElement::DoDeclareParameters().
   void DoDeclareParameters(
       internal::MultibodyTreeSystem<T>* tree_system) final {
-    // Declare parent classes' parameters
-    MultibodyElement<T>::DoDeclareParameters(tree_system);
-    rotor_inertia_parameter_index_ = this->DeclareNumericParameter(
-        tree_system,
-        systems::BasicVector<T>(Vector1<T>(default_rotor_inertia_)));
-    gear_ratio_parameter_index_ = this->DeclareNumericParameter(
-        tree_system, systems::BasicVector<T>(Vector1<T>(default_gear_ratio_)));
+    // Sets model values to dummy values to indicate that the model values are
+    // not used. This class stores the the default values of the parameters.
+    rotor_inertia_parameter_index_ =
+        this->DeclareNumericParameter(tree_system, systems::BasicVector<T>(1));
+    gear_ratio_parameter_index_ =
+        this->DeclareNumericParameter(tree_system, systems::BasicVector<T>(1));
+  }
+
+  // Implementation for MultibodyElement::DoSetDefaultParameters().
+  void DoSetDefaultParameters(systems::Parameters<T>* parameters) const final {
+    // Set the default rotor inertia.
+    systems::BasicVector<T>& rotor_inertia_parameter =
+        parameters->get_mutable_numeric_parameter(
+            rotor_inertia_parameter_index_);
+    rotor_inertia_parameter.set_value(Vector1<T>(default_rotor_inertia_));
+    // Set the default gear ratio.
+    systems::BasicVector<T>& gear_ratio_parameter =
+        parameters->get_mutable_numeric_parameter(gear_ratio_parameter_index_);
+    gear_ratio_parameter.set_value(Vector1<T>(default_gear_ratio_));
   }
 
   // The actuator's unique name in the MultibodyTree model

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.h
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.h
@@ -503,31 +503,49 @@ class LinearBushingRollPitchYaw final : public ForceElement<T> {
   SpatialForce<T> CalcBushingSpatialForceOnFrameC(
       const systems::Context<T>& context) const;
 
- protected:
-  // Implementation for MultibodyElement::DoDeclareParameters().
-  void DoDeclareParameters(
-      internal::MultibodyTreeSystem<T>* tree_system) override {
-    // Declare parent classes' parameters
-    ForceElement<T>::DoDeclareParameters(tree_system);
-
-    torque_stiffness_parameter_index_ = this->DeclareNumericParameter(
-        tree_system, systems::BasicVector<T>(
-                         torque_stiffness_constants_.template cast<T>()));
-
-    torque_damping_parameter_index_ = this->DeclareNumericParameter(
-        tree_system,
-        systems::BasicVector<T>(torque_damping_constants_.template cast<T>()));
-
-    force_stiffness_parameter_index_ = this->DeclareNumericParameter(
-        tree_system,
-        systems::BasicVector<T>(force_stiffness_constants_.template cast<T>()));
-
-    force_damping_parameter_index_ = this->DeclareNumericParameter(
-        tree_system,
-        systems::BasicVector<T>(force_damping_constants_.template cast<T>()));
+ private:
+  // Implementation for ForceElement::DoDeclareForceElementParameters().
+  void DoDeclareForceElementParameters(
+      internal::MultibodyTreeSystem<T>* tree_system) final {
+    // Sets model values to dummy values to indicate that the model values are
+    // not used. This class stores the the default values of the parameters.
+    torque_stiffness_parameter_index_ =
+        this->DeclareNumericParameter(tree_system, systems::BasicVector<T>(3));
+    torque_damping_parameter_index_ =
+        this->DeclareNumericParameter(tree_system, systems::BasicVector<T>(3));
+    force_stiffness_parameter_index_ =
+        this->DeclareNumericParameter(tree_system, systems::BasicVector<T>(3));
+    force_damping_parameter_index_ =
+        this->DeclareNumericParameter(tree_system, systems::BasicVector<T>(3));
   }
 
- private:
+  // Implementation for ForceElement::DoSetDefaultForceElementParameters().
+  void DoSetDefaultForceElementParameters(
+      systems::Parameters<T>* parameters) const final {
+    // Set the default stiffness and damping parameters.
+    systems::BasicVector<T>& torque_stiffness_parameter =
+        parameters->get_mutable_numeric_parameter(
+            torque_stiffness_parameter_index_);
+    systems::BasicVector<T>& torque_damping_parameter_ =
+        parameters->get_mutable_numeric_parameter(
+            torque_damping_parameter_index_);
+    systems::BasicVector<T>& force_stiffness_parameter_ =
+        parameters->get_mutable_numeric_parameter(
+            force_stiffness_parameter_index_);
+    systems::BasicVector<T>& force_damping_parameter_ =
+        parameters->get_mutable_numeric_parameter(
+            force_damping_parameter_index_);
+
+    torque_stiffness_parameter.set_value(
+        torque_stiffness_constants_.template cast<T>());
+    torque_damping_parameter_.set_value(
+        torque_damping_constants_.template cast<T>());
+    force_stiffness_parameter_.set_value(
+        force_stiffness_constants_.template cast<T>());
+    force_damping_parameter_.set_value(
+        force_damping_constants_.template cast<T>());
+  }
+
   // Friend class for accessing protected/private internals of this class.
   friend class BushingTester;
 

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -704,12 +704,16 @@ class Mobilizer : public MultibodyElement<T> {
 
   // Implementation for MultibodyElement::DoDeclareParameters().
   void DoDeclareParameters(
-      internal::MultibodyTreeSystem<T>* tree_system) override {
-    // Declare parent class's parameters
-    MultibodyElement<T>::DoDeclareParameters(tree_system);
-
+      internal::MultibodyTreeSystem<T>* tree_system) final {
     is_locked_parameter_index_ =
         this->DeclareAbstractParameter(tree_system, Value<bool>(false));
+  }
+
+  // Implementation for MultibodyElement::DoDeclareParameters().
+  void DoSetDefaultParameters(systems::Parameters<T>* parameters) const final {
+    // TODO(joemasterjonh): Consider exposing a default locked model value.
+    parameters->template get_mutable_abstract_parameter<bool>(
+        is_locked_parameter_index_) = false;
   }
 
  private:

--- a/multibody/tree/multibody_element.cc
+++ b/multibody/tree/multibody_element.cc
@@ -4,6 +4,7 @@ namespace drake {
 namespace multibody {
 
 using internal::MultibodyTreeSystem;
+using systems::Parameters;
 
 template <typename T>
 MultibodyElement<T>::~MultibodyElement() {}
@@ -16,6 +17,13 @@ void MultibodyElement<T>::DeclareParameters(
 }
 
 template <typename T>
+void MultibodyElement<T>::SetDefaultParameters(
+    systems::Parameters<T>* parameters) const {
+  DRAKE_DEMAND(parameters != nullptr);
+  DoSetDefaultParameters(parameters);
+}
+
+template <typename T>
 MultibodyElement<T>::MultibodyElement() {}
 
 template <typename T>
@@ -24,6 +32,9 @@ MultibodyElement<T>::MultibodyElement(ModelInstanceIndex model_instance)
 
 template <typename T>
 void MultibodyElement<T>::DoDeclareParameters(MultibodyTreeSystem<T>*) {}
+
+template <typename T>
+void MultibodyElement<T>::DoSetDefaultParameters(Parameters<T>*) const {}
 
 template <typename T>
 systems::NumericParameterIndex MultibodyElement<T>::DeclareNumericParameter(

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -68,6 +68,12 @@ class MultibodyElement {
   /// returned from GetParentTreeSystem()).
   void DeclareParameters(internal::MultibodyTreeSystem<T>* tree_system);
 
+  /// Sets default values of parameters belonging to each %MultibodyElement in
+  /// `parameters` at a call to MultibodyTreeSystem::SetDefaultParameters().
+  /// @param[out] parameters A mutable collections of parameters in a context.
+  /// @pre parameters != nullptr
+  void SetDefaultParameters(systems::Parameters<T>* parameters) const;
+
  protected:
   /// Default constructor made protected so that sub-classes can still declare
   /// their default constructors if they need to.
@@ -109,10 +115,12 @@ class MultibodyElement {
   virtual void DoSetTopology(const internal::MultibodyTreeTopology& tree) = 0;
 
   /// Implementation of the NVI DeclareParameters(). MultibodyElement-derived
-  /// objects must override to declare their specific parameters. If an object
-  /// is not a direct descendent of MultibodyElement, it must invoke its parent
-  /// classes' DoDeclareParameters() before declaring its own parameters.
+  /// objects may override to declare their specific parameters.
   virtual void DoDeclareParameters(internal::MultibodyTreeSystem<T>*);
+
+  /// Implementation of the NVI SetDefaultParameters(). MultibodyElement-derived
+  /// objects may override to set default values of their specific parameters.
+  virtual void DoSetDefaultParameters(systems::Parameters<T>*) const;
 
   /// To be used by MultibodyElement-derived objects when declaring parameters
   /// in their implementation of DoDeclareParameters(). For an example, see

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -11,6 +11,7 @@ namespace drake {
 using systems::BasicVector;
 using systems::Context;
 using systems::LeafSystem;
+using systems::Parameters;
 using systems::State;
 
 namespace multibody {
@@ -79,6 +80,56 @@ void MultibodyTreeSystem<T>::SetDefaultState(const Context<T>& context,
                                              State<T>* state) const {
   LeafSystem<T>::SetDefaultState(context, state);
   tree_->SetDefaultState(context, state);
+}
+
+template <typename T>
+void MultibodyTreeSystem<T>::SetDefaultParameters(
+    const Context<T>& context, Parameters<T>* parameters) const {
+  LeafSystem<T>::SetDefaultParameters(context, parameters);
+
+  // Mobilizers.
+  for (MobilizerIndex mobilizer_index(0);
+       mobilizer_index < tree_->num_mobilizers(); ++mobilizer_index) {
+    mutable_tree()
+        .get_mutable_mobilizer(mobilizer_index)
+        .SetDefaultParameters(parameters);
+  }
+  // Joints.
+  for (JointIndex joint_index(0); joint_index < tree_->num_joints();
+       ++joint_index) {
+    mutable_tree()
+        .get_mutable_joint(joint_index)
+        .SetDefaultParameters(parameters);
+  }
+  // JointActuators.
+  for (JointActuatorIndex joint_actuator_index(0);
+       joint_actuator_index < tree_->num_actuators(); ++joint_actuator_index) {
+    mutable_tree()
+        .get_mutable_joint_actuator(joint_actuator_index)
+        .SetDefaultParameters(parameters);
+  }
+  // Bodies.
+  for (BodyIndex body_index(0); body_index < tree_->num_bodies();
+       ++body_index) {
+    mutable_tree()
+        .get_mutable_body(body_index)
+        .SetDefaultParameters(parameters);
+  }
+  // Frames.
+  for (FrameIndex frame_index(0); frame_index < tree_->num_frames();
+       ++frame_index) {
+    mutable_tree()
+        .get_mutable_frame(frame_index)
+        .SetDefaultParameters(parameters);
+  }
+  // Force Elements.
+  for (ForceElementIndex force_element_index(0);
+       force_element_index < tree_->num_force_elements();
+       ++force_element_index) {
+    mutable_tree()
+        .get_mutable_force_element(force_element_index)
+        .SetDefaultParameters(parameters);
+  }
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -329,6 +329,12 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override;
 
+  // Override of LeafSystem::SetDefaultParameters. For all parameters declared
+  // by various MultibodyElement subclasses, sets numeric and abstract
+  // parameters to default values stored in their class members.
+  void SetDefaultParameters(const systems::Context<T>& context,
+                            systems::Parameters<T>* parameters) const final;
+
  private:
   // This is only meaningful in continuous mode.
   void DoCalcTimeDerivatives(


### PR DESCRIPTION
Sets up a framework within MultibodyTree/MultibodyPlant to have all MultibodyElements fill in their default model parameter values upon default context creation. This change means that model default values can now change post-Finalize, and those changes will be reflected in new default contexts.

Note: The member fields of all MultibodyElements will be the source of truth for default model parameter values. Model values for system parameters are set to dummy values to reflect that they are not used. When a default context is created (i.e. `MultibodyPlantSystem::SetDefaultContext()` is called) each `MultibodyElement` instance in the plant has the chance to write default values for its system level parameters through the NVI `MultibodyElement::SetDefaultParameters()`.

The current list of multibody elements storing parameters in the context is:
- `FixedOffsetFrame`
- `JointActuator`
- `LinearBushingRollPitchYaw`
- `Mobilizer`
- `RigidBody`

Of those, `JointActuator` is currently the only class that exposes mutation of default parameters, thus the new regression test to show that changes to these default parameters end up in default contexts. Because the other classes do not support mutation of their default parameters and their model values are set to dummy values, the changes to these classes are already covered by tests that use context dependent accessors of these parameters. Were their implementations of `SetDefaultParameters()` be wrong, the context dependent accessors would report wrong values.

Closes: #14841.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20307)
<!-- Reviewable:end -->
