### PR TITLE
[multibody] Remove the unused provision for a Joint to be modeled with multiple Mobilizers

### DIFF
--- a/multibody/plant/test/sap_driver_multidof_joints_test.cc
+++ b/multibody/plant/test/sap_driver_multidof_joints_test.cc
@@ -93,7 +93,7 @@ class MultiDofJointWithLimits final : public Joint<T> {
     // consistent during MultibodyPlant::Finalize().
     auto revolute_mobilizer = std::make_unique<internal::SpaceXYZMobilizer<T>>(
         this->frame_on_parent(), this->frame_on_child());
-    blue_print->mobilizers_.push_back(std::move(revolute_mobilizer));
+    blue_print->mobilizer = std::move(revolute_mobilizer);
     return blue_print;
   }
 

--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -66,7 +66,7 @@ BallRpyJoint<T>::MakeImplementationBlueprint() const {
   auto ballrpy_mobilizer = std::make_unique<internal::SpaceXYZMobilizer<T>>(
       this->frame_on_parent(), this->frame_on_child());
   ballrpy_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizers_.push_back(std::move(ballrpy_mobilizer));
+  blue_print->mobilizer = std::move(ballrpy_mobilizer);
   return blue_print;
 }
 

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -259,20 +259,18 @@ class BallRpyJoint final : public Joint<T> {
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
   const internal::SpaceXYZMobilizer<T>* get_mobilizer() const {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     const internal::SpaceXYZMobilizer<T>* mobilizer =
         dynamic_cast<const internal::SpaceXYZMobilizer<T>*>(
-            this->get_implementation().mobilizers_[0]);
+            this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }
 
   internal::SpaceXYZMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     auto* mobilizer = dynamic_cast<internal::SpaceXYZMobilizer<T>*>(
-        this->get_implementation().mobilizers_[0]);
+        this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }

--- a/multibody/tree/joint.cc
+++ b/multibody/tree/joint.cc
@@ -5,22 +5,14 @@ namespace multibody {
 
 template <typename T>
 bool Joint<T>::can_rotate() const {
-  const std::vector<internal::Mobilizer<T>*>& mobilizers =
-      get_implementation().mobilizers_;
-  for (const internal::Mobilizer<T>* mobilizer : mobilizers) {
-    if (mobilizer->can_rotate()) return true;
-  }
-  return false;
+  DRAKE_DEMAND(this->get_implementation().has_mobilizer());
+  return get_implementation().mobilizer->can_rotate();
 }
 
 template <typename T>
 bool Joint<T>::can_translate() const {
-  const std::vector<internal::Mobilizer<T>*>& mobilizers =
-      get_implementation().mobilizers_;
-  for (const internal::Mobilizer<T>* mobilizer : mobilizers) {
-    if (mobilizer->can_translate()) return true;
-  }
-  return false;
+  DRAKE_DEMAND(this->get_implementation().has_mobilizer());
+  return get_implementation().mobilizer->can_translate();
 }
 
 }  // namespace multibody

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -231,13 +231,13 @@ class Joint : public MultibodyElement<T> {
     return do_get_num_positions();
   }
 
-  /// Returns true if this joint's mobilizers allow relative rotation of the
+  /// Returns true if this joint's mobility allows relative rotation of the
   /// two frames associated with this joint.
   /// @pre the MultibodyPlant must be finalized.
   /// @see can_translate()
   bool can_rotate() const;
 
-  /// Returns true if this joint's mobilizers allow relative translation of the
+  /// Returns true if this joint's mobility allows relative translation of the
   /// two frames associated with this joint.
   /// @pre the MultibodyPlant must be finalized.
   /// @see can_rotate()
@@ -341,25 +341,20 @@ class Joint : public MultibodyElement<T> {
   /// Lock the joint. Its generalized velocities will be 0 until it is
   /// unlocked.
   void Lock(systems::Context<T>* context) const {
-    for (internal::Mobilizer<T>* mobilizer : implementation_->mobilizers_) {
-      mobilizer->Lock(context);
-    }
+    DRAKE_DEMAND(implementation_->has_mobilizer());
+    implementation_->mobilizer->Lock(context);
   }
 
   /// Unlock the joint.
   void Unlock(systems::Context<T>* context) const {
-    for (internal::Mobilizer<T>* mobilizer : implementation_->mobilizers_) {
-      mobilizer->Unlock(context);
-    }
+    DRAKE_DEMAND(implementation_->has_mobilizer());
+    implementation_->mobilizer->Unlock(context);
   }
 
   /// @return true if the joint is locked, false otherwise.
   bool is_locked(const systems::Context<T>& context) const {
-    bool locked = false;
-    for (internal::Mobilizer<T>* mobilizer : implementation_->mobilizers_) {
-      locked |= mobilizer->is_locked(context);
-    }
-    return locked;
+    DRAKE_DEMAND(implementation_->has_mobilizer());
+    return implementation_->mobilizer->is_locked(context);
   }
 
   /// @name Methods to get and set the limits of `this` joint. For position
@@ -506,9 +501,9 @@ class Joint : public MultibodyElement<T> {
   }
 
   const internal::Mobilizer<T>& GetMobilizerInUse() const {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(get_implementation().num_mobilizers() == 1);
-    return *get_implementation().mobilizers_[0];
+    // Currently we model each joint with a mobilizer.
+    DRAKE_DEMAND(get_implementation().has_mobilizer());
+    return *get_implementation().mobilizer;
   }
 #endif
   // End of hidden Doxygen section.
@@ -519,16 +514,16 @@ class Joint : public MultibodyElement<T> {
   /// %Joint creates a BluePrint of its implementation with MakeModelBlueprint()
   /// so that MultibodyTree can build an implementation for it.
   struct BluePrint {
-    std::vector<std::unique_ptr<internal::Mobilizer<T>>> mobilizers_;
-    // TODO(amcastro-tri): add force elements, constraints, bodies.
+    std::unique_ptr<internal::Mobilizer<T>> mobilizer;
+    // TODO(sherm1): add constraints and force elements as needed.
   };
 
-  /// (Advanced) A Joint is implemented in terms of MultibodyTree elements such
-  /// as bodies, mobilizers, force elements and constraints. This object
-  /// contains the internal details of the MultibodyTree implementation for a
-  /// joint. The implementation does not own the MBT elements, it just keeps
-  /// references to them.
-  /// This is intentionally made a protected member so that derived classes have
+  /// (Advanced) A Joint is implemented in terms of MultibodyTree elements,
+  /// typically a Mobilizer. However, some Joints may be better modeled with
+  /// constraints or force elements. This object contains the internal details
+  /// of the MultibodyTree implementation for a joint. The implementation does
+  /// not own the MbT elements, it just keeps references to them. This is
+  /// intentionally made a protected member so that derived classes have
   /// access to its definition.
   struct JointImplementation {
     /// Default constructor to create an empty implementation. Used by
@@ -538,15 +533,13 @@ class Joint : public MultibodyElement<T> {
     /// This constructor creates an implementation for `this` joint from the
     /// blueprint provided.
     explicit JointImplementation(const BluePrint& blue_print) {
-      DRAKE_DEMAND(static_cast<int>(blue_print.mobilizers_.size()) != 0);
-      for (const auto& mobilizer : blue_print.mobilizers_) {
-        mobilizers_.push_back(mobilizer.get());
-      }
+      DRAKE_DEMAND(blue_print.mobilizer != nullptr);
+      mobilizer = blue_print.mobilizer.get();
     }
 
-    /// Returns the number of mobilizers in this implementation.
-    int num_mobilizers() const {
-      return static_cast<int>(mobilizers_.size());
+    /// Returns `true` if the implementation of this Joint uses a Mobilizer.
+    bool has_mobilizer() const {
+      return mobilizer != nullptr;
     }
 
     // Hide the following section from Doxygen.
@@ -558,20 +551,17 @@ class Joint : public MultibodyElement<T> {
     CloneToScalar(internal::MultibodyTree<ToScalar>* tree_clone) const {
       auto implementation_clone =
           std::make_unique<typename Joint<ToScalar>::JointImplementation>();
-      for (const internal::Mobilizer<T>* mobilizer : mobilizers_) {
-        internal::Mobilizer<ToScalar>* mobilizer_clone =
-            &tree_clone->get_mutable_variant(*mobilizer);
-        implementation_clone->mobilizers_.push_back(mobilizer_clone);
-      }
+      internal::Mobilizer<ToScalar>* mobilizer_clone =
+          &tree_clone->get_mutable_variant(*mobilizer);
+      implementation_clone->mobilizer = mobilizer_clone;
       return implementation_clone;
     }
 #endif
     // End of hidden Doxygen section.
 
-    /// References (raw pointers) to the mobilizers that make part of this
-    /// implementation.
-    std::vector<internal::Mobilizer<T>*> mobilizers_;
-    // TODO(amcastro-tri): add force elements, constraints, bodies, etc.
+    /// Reference (raw pointer) to the mobilizer implementing this Joint.
+    internal::Mobilizer<T>* mobilizer{};
+    // TODO(sherm1): add constraints and force elements as needed.
   };
 
   /// Implementation of the NVI velocity_start(), see velocity_start() for

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -214,7 +214,7 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
   }
 
   // TODO(amcastro-tri): consider not depending on setting this pointer at
-  // all. Consider also removing MultibodyElement altogether.
+  //  all. Consider also removing MultibodyElement altogether.
   mobilizer->set_parent_tree(this, mobilizer_index);
 
   // Mark free bodies as needed.

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -44,20 +44,18 @@ template <typename T>
 class JointImplementationBuilder {
  public:
   JointImplementationBuilder() = delete;
-  static std::vector<Mobilizer<T>*> Build(
+  static Mobilizer<T>* Build(
       Joint<T>* joint, MultibodyTree<T>* tree) {
-    std::vector<Mobilizer<T>*> mobilizers;
+    Mobilizer<T>* mobilizer;
     std::unique_ptr<JointBluePrint> blue_print =
         joint->MakeImplementationBlueprint();
     auto implementation = std::make_unique<JointImplementation>(*blue_print);
-    DRAKE_DEMAND(implementation->num_mobilizers() != 0);
-    for (auto& mobilizer : blue_print->mobilizers_) {
-      mobilizers.push_back(mobilizer.get());
-      tree->AddMobilizer(std::move(mobilizer));
-    }
+    DRAKE_DEMAND(implementation->has_mobilizer());
+    mobilizer = blue_print->mobilizer.get();
+    tree->AddMobilizer(std::move(blue_print->mobilizer));
     // TODO(amcastro-tri): add force elements, bodies, constraints, etc.
     joint->OwnImplementation(std::move(implementation));
-    return mobilizers;
+    return mobilizer;
   }
 
  private:
@@ -614,17 +612,11 @@ void MultibodyTree<T>::CreateJointImplementations() {
   joint_to_mobilizer_.resize(num_joints_pre_floating_joints);
   for (int i = 0; i < num_joints_pre_floating_joints; ++i) {
     auto& joint = owned_joints_[i];
-    std::vector<Mobilizer<T>*> mobilizers =
+    Mobilizer<T>* mobilizer =
         internal::JointImplementationBuilder<T>::Build(joint.get(), this);
-    // Below we assume a single mobilizer per joint, which is  true
-    // for all joint types currently implemented. This may change in the future
-    // when closed topologies are supported.
-    DRAKE_DEMAND(mobilizers.size() == 1);
-    for (Mobilizer<T>* mobilizer : mobilizers) {
-      mobilizer->set_model_instance(joint->model_instance());
-      // Record the joint to mobilizer map.
-      joint_to_mobilizer_[joint->index()] = mobilizer->index();
-    }
+    mobilizer->set_model_instance(joint->model_instance());
+    // Record the joint to mobilizer map.
+    joint_to_mobilizer_[joint->index()] = mobilizer->index();
   }
   // It is VERY important to add joints to free bodies only AFTER joints had a
   // chance to get implemented with mobilizers. This is because above added
@@ -656,17 +648,11 @@ void MultibodyTree<T>::CreateJointImplementations() {
   joint_to_mobilizer_.resize(num_joints());
   for (int i = num_joints_pre_floating_joints; i < num_joints(); ++i) {
     auto& joint = owned_joints_[i];
-    std::vector<Mobilizer<T>*> mobilizers =
+    Mobilizer<T>* mobilizer =
         internal::JointImplementationBuilder<T>::Build(joint.get(), this);
-    // Below we assume a single mobilizer per joint, which is  true
-    // for all joint types currently implemented. This may change in the future
-    // when closed topologies are supported.
-    DRAKE_DEMAND(mobilizers.size() == 1);
-    for (Mobilizer<T>* mobilizer : mobilizers) {
-      mobilizer->set_model_instance(joint->model_instance());
-      // Record the joint to mobilizer map.
-      joint_to_mobilizer_[joint->index()] = mobilizer->index();
-    }
+    mobilizer->set_model_instance(joint->model_instance());
+    // Record the joint to mobilizer map.
+    joint_to_mobilizer_[joint->index()] = mobilizer->index();
   }
 }
 

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -65,7 +65,7 @@ PlanarJoint<T>::MakeImplementationBlueprint() const {
   auto planar_mobilizer = std::make_unique<internal::PlanarMobilizer<T>>(
       this->frame_on_parent(), this->frame_on_child());
   planar_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizers_.push_back(std::move(planar_mobilizer));
+  blue_print->mobilizer = std::move(planar_mobilizer);
   return blue_print;
 }
 

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -338,20 +338,18 @@ class PlanarJoint final : public Joint<T> {
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
   const internal::PlanarMobilizer<T>* get_mobilizer() const {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     const internal::PlanarMobilizer<T>* mobilizer =
         dynamic_cast<const internal::PlanarMobilizer<T>*>(
-            this->get_implementation().mobilizers_[0]);
+            this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }
 
   internal::PlanarMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     auto* mobilizer = dynamic_cast<internal::PlanarMobilizer<T>*>(
-        this->get_implementation().mobilizers_[0]);
+        this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -288,7 +288,7 @@ class PrismaticJoint final : public Joint<T> {
         std::make_unique<internal::PrismaticMobilizer<T>>(
             this->frame_on_parent(), this->frame_on_child(), axis_);
     prismatic_mobilizer->set_default_position(this->default_positions());
-    blue_print->mobilizers_.push_back(std::move(prismatic_mobilizer));
+    blue_print->mobilizer = std::move(prismatic_mobilizer);
     return blue_print;
   }
 
@@ -310,20 +310,20 @@ class PrismaticJoint final : public Joint<T> {
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
   const internal::PrismaticMobilizer<T>* get_mobilizer() const {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    // This implementation should always use a mobilizer.
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     const internal::PrismaticMobilizer<T>* mobilizer =
         dynamic_cast<const internal::PrismaticMobilizer<T>*>(
-            this->get_implementation().mobilizers_[0]);
+            this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }
 
   internal::PrismaticMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    // This implementation should always use a mobilizer.
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     auto* mobilizer = dynamic_cast<internal::PrismaticMobilizer<T>*>(
-        this->get_implementation().mobilizers_[0]);
+        this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }

--- a/multibody/tree/quaternion_floating_joint.cc
+++ b/multibody/tree/quaternion_floating_joint.cc
@@ -64,7 +64,7 @@ QuaternionFloatingJoint<T>::MakeImplementationBlueprint() const {
           this->frame_on_parent(), this->frame_on_child());
   quaternion_floating_mobilizer->set_default_position(
       this->default_positions());
-  blue_print->mobilizers_.push_back(std::move(quaternion_floating_mobilizer));
+  blue_print->mobilizer = std::move(quaternion_floating_mobilizer);
   return blue_print;
 }
 

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -445,20 +445,18 @@ class QuaternionFloatingJoint final : public Joint<T> {
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
   const internal::QuaternionFloatingMobilizer<T>& get_mobilizer() const {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     const internal::QuaternionFloatingMobilizer<T>* mobilizer =
         dynamic_cast<const internal::QuaternionFloatingMobilizer<T>*>(
-            this->get_implementation().mobilizers_[0]);
+            this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return *mobilizer;
   }
 
   internal::QuaternionFloatingMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     auto* mobilizer = dynamic_cast<internal::QuaternionFloatingMobilizer<T>*>(
-        this->get_implementation().mobilizers_[0]);
+        this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -93,7 +93,7 @@ RevoluteJoint<T>::MakeImplementationBlueprint() const {
   auto revolute_mobilizer = std::make_unique<internal::RevoluteMobilizer<T>>(
       this->frame_on_parent(), this->frame_on_child(), axis_);
   revolute_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizers_.push_back(std::move(revolute_mobilizer));
+  blue_print->mobilizer = std::move(revolute_mobilizer);
   return blue_print;
 }
 

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -343,20 +343,20 @@ class RevoluteJoint final : public Joint<T> {
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
   const internal::RevoluteMobilizer<T>* get_mobilizer() const {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    // This implementation should always use a mobilizer.
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     const internal::RevoluteMobilizer<T>* mobilizer =
         dynamic_cast<const internal::RevoluteMobilizer<T>*>(
-            this->get_implementation().mobilizers_[0]);
+            this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }
 
   internal::RevoluteMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    // This implementation should always use a mobilizer.
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     auto* mobilizer = dynamic_cast<internal::RevoluteMobilizer<T>*>(
-        this->get_implementation().mobilizers_[0]);
+        this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -98,7 +98,7 @@ ScrewJoint<T>::MakeImplementationBlueprint() const {
       this->frame_on_parent(), this->frame_on_child(), this->screw_axis(),
       screw_pitch_);
   screw_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizers_.push_back(std::move(screw_mobilizer));
+  blue_print->mobilizer = std::move(screw_mobilizer);
   return blue_print;
 }
 

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -353,20 +353,18 @@ class ScrewJoint final : public Joint<T> {
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
   const internal::ScrewMobilizer<T>* get_mobilizer() const {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     const internal::ScrewMobilizer<T>* mobilizer =
         dynamic_cast<const internal::ScrewMobilizer<T>*>(
-            this->get_implementation().mobilizers_[0]);
+            this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }
 
   internal::ScrewMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     auto* mobilizer = dynamic_cast<internal::ScrewMobilizer<T>*>(
-        this->get_implementation().mobilizers_[0]);
+        this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -65,7 +65,7 @@ UniversalJoint<T>::MakeImplementationBlueprint() const {
   auto univeral_mobilizer = std::make_unique<internal::UniversalMobilizer<T>>(
       this->frame_on_parent(), this->frame_on_child());
   univeral_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizers_.push_back(std::move(univeral_mobilizer));
+  blue_print->mobilizer = std::move(univeral_mobilizer);
   return blue_print;
 }
 

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -259,20 +259,18 @@ class UniversalJoint final : public Joint<T> {
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
   const internal::UniversalMobilizer<T>* get_mobilizer() const {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     const internal::UniversalMobilizer<T>* mobilizer =
         dynamic_cast<const internal::UniversalMobilizer<T>*>(
-            this->get_implementation().mobilizers_[0]);
+            this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }
 
   internal::UniversalMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     auto* mobilizer = dynamic_cast<internal::UniversalMobilizer<T>*>(
-        this->get_implementation().mobilizers_[0]);
+        this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -56,9 +56,8 @@ template <typename T>
 std::unique_ptr<typename Joint<T>::BluePrint>
 WeldJoint<T>::MakeImplementationBlueprint() const {
   auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
-  blue_print->mobilizers_.push_back(
-      std::make_unique<internal::WeldMobilizer<T>>(
-          this->frame_on_parent(), this->frame_on_child(), X_FM_));
+  blue_print->mobilizer = std::make_unique<internal::WeldMobilizer<T>>(
+      this->frame_on_parent(), this->frame_on_child(), X_FM_);
   return blue_print;
 }
 

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -115,20 +115,18 @@ class WeldJoint final : public Joint<T> {
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
   const internal::WeldMobilizer<T>* get_mobilizer() const {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     const internal::WeldMobilizer<T>* mobilizer =
         dynamic_cast<const internal::WeldMobilizer<T>*>(
-            this->get_implementation().mobilizers_[0]);
+            this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }
 
   internal::WeldMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should only have one mobilizer.
-    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
     auto* mobilizer = dynamic_cast<internal::WeldMobilizer<T>*>(
-        this->get_implementation().mobilizers_[0]);
+        this->get_implementation().mobilizer);
     DRAKE_DEMAND(mobilizer != nullptr);
     return mobilizer;
   }


### PR DESCRIPTION
For reasons lost to history (and likely my fault) MultibodyTree joint implementations allowed for the possibility that a joint would get modeled with more than one Mobilizer. With no loss of functionality, that is never going to happen! This PR removes that provision and its associated mess.

Changes are internal and not user visible.

(This is a small yak shave for multibody topology changes in #20225).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20309)
<!-- Reviewable:end -->
