### PR TITLE
[systems/lcm] Indicate LCM connections in System graphviz output

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -130,6 +130,7 @@ drake_cc_library(
     deps = [
         "//lcm:drake_lcm",
         "//lcmtypes:viewer",
+        "//systems/lcm:lcm_system_graphviz",
     ],
 )
 

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -327,6 +327,10 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
   const std::vector<internal::DeformableMeshData>& EvalDeformableMeshData(
       const systems::Context<T>& context) const;
 
+  typename systems::LeafSystem<T>::GraphvizFragment DoGetGraphvizFragment(
+      const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
+      const final;
+
   /* DrakeVisualizer stores a "model" of what it thinks is registered in the
    receiving application. Because that application is not part of the
    Drake state, this model is likewise not part of the Drake state. It is a

--- a/geometry/meshcat_graphviz.h
+++ b/geometry/meshcat_graphviz.h
@@ -20,7 +20,7 @@ Parent::GraphvizFragment MySystem::DoGetGraphvizFragment(
     const Parent::GraphvizFragmentParams& params) const override {
   MeshcatGraphviz helper(...);
   return helper.DecorateResult(
-      Parent::DoGetGraphvizFragment(helper.DecorateParams(paraams)));
+      Parent::DoGetGraphvizFragment(helper.DecorateParams(params)));
 }
 ```
 

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
@@ -1201,6 +1202,13 @@ GTEST_TEST(DrakeVisualizerdTest, Transmogrify) {
       "DrakeVisualizer can only be scalar converted if it owns its "
       "DrakeLcmInterface instance.");
 }
+
+// The Graphviz should have an arrow pointing to the DrakeLcmInterface.
+GTEST_TEST(DrakeVisualizerdTest, Graphviz) {
+  DrakeVisualizerd dut;
+  EXPECT_THAT(dut.GetGraphvizString(), testing::HasSubstr(" -> drakelcm"));
+}
+
 }  // namespace
 }  // namespace geometry
 }  // namespace drake

--- a/manipulation/kuka_iiwa/test/iiwa_driver_functions_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_driver_functions_test.cc
@@ -124,7 +124,7 @@ GTEST_TEST(IiwaDriverFunctionsTest, ApplyDriverConfigNoLcm) {
       // This one SharedPtrSystem is the only remnant of LCM that gets added.
       // It is a DrakeLcmInterface that is never pumped (note that there is
       // no LcmInterfaceSystem anywhere in this list of `expected` systems.
-      "DrakeLcm(bus_name=default, lcm_url=memq://null)",
+      "DrakeLcm(bus_name=default)",
   };
   EXPECT_THAT(names, testing::UnorderedElementsAreArray(expected));
 }

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":lcm_pubsub_system",
         ":lcm_scope_system",
         ":lcm_subscriber_system",
+        ":lcm_system_graphviz",
         ":serializer",
     ],
 )
@@ -35,6 +36,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "lcm_system_graphviz",
+    srcs = ["lcm_system_graphviz.cc"],
+    hdrs = ["lcm_system_graphviz.h"],
+    deps = [
+        "//lcm:interface",
+        "//systems/framework:system_base",
+    ],
+)
+
+drake_cc_library(
     name = "lcm_publisher_system",
     srcs = ["lcm_publisher_system.cc"],
     hdrs = ["lcm_publisher_system.h"],
@@ -44,6 +55,7 @@ drake_cc_library(
         "//systems/framework:leaf_system",
     ],
     deps = [
+        ":lcm_system_graphviz",
         "//lcm:drake_lcm",
     ],
 )
@@ -71,6 +83,7 @@ drake_cc_library(
         "//systems/framework:leaf_system",
     ],
     deps = [
+        ":lcm_system_graphviz",
         "//lcm:drake_lcm",
     ],
 )
@@ -84,6 +97,7 @@ drake_cc_library(
         "//systems/framework:leaf_system",
     ],
     deps = [
+        ":lcm_system_graphviz",
         "//lcm:drake_lcm",
     ],
 )
@@ -203,6 +217,16 @@ drake_cc_googletest(
         "//systems/framework:diagram",
         "//systems/framework:diagram_builder",
         "//systems/primitives:sine",
+    ],
+)
+
+drake_cc_googletest(
+    name = "lcm_system_graphviz_test",
+    deps = [
+        ":lcm_system_graphviz",
+        "//lcm:drake_lcm",
+        "//lcmtypes:drake_signal",
+        "@abseil_cpp_internal//absl/strings",
     ],
 )
 

--- a/systems/lcm/lcm_config_functions.cc
+++ b/systems/lcm/lcm_config_functions.cc
@@ -81,8 +81,7 @@ LcmBuses ApplyLcmBusConfig(
     // of the eventual Diagram).
     auto* owner_system =
         builder->AddSystem<SharedPointerSystem<double>>(drake_lcm);
-    owner_system->set_name(fmt::format("DrakeLcm(bus_name={}, lcm_url={})",
-                                       bus_name, canonical_url));
+    owner_system->set_name(fmt::format("DrakeLcm(bus_name={})", bus_name));
 
     // We should not pump a null LCM, so we should return early now.
     if (is_noop) {
@@ -97,8 +96,7 @@ LcmBuses ApplyLcmBusConfig(
     auto* pumper_system =
         builder->AddSystem<LcmInterfaceSystem>(drake_lcm.get());
     pumper_system->set_name(
-        fmt::format("LcmInterfaceSystem(bus_name={}, lcm_url={})", bus_name,
-                    canonical_url));
+        fmt::format("LcmInterfaceSystem(bus_name={})", bus_name));
 
     // Display an update; provide the interface pointer to our caller.
     drake::log()->info("LCM bus '{}' created for URL {}", bus_name,

--- a/systems/lcm/lcm_interface_system.cc
+++ b/systems/lcm/lcm_interface_system.cc
@@ -6,6 +6,7 @@
 #include <fmt/format.h>
 
 #include "drake/lcm/drake_lcm.h"
+#include "drake/systems/lcm/lcm_system_graphviz.h"
 
 namespace drake {
 namespace systems {
@@ -93,6 +94,24 @@ void LcmInterfaceSystem::DoCalcNextUpdateTime(
   } else {
     *time = std::numeric_limits<double>::infinity();
   }
+}
+
+LeafSystem<double>::GraphvizFragment LcmInterfaceSystem::DoGetGraphvizFragment(
+    const GraphvizFragmentParams& params) const {
+  const std::string node_id = internal::LcmSystemGraphviz::get_node_id(*this);
+
+  // Set the well-known ID, enable twaining, and tack on the URL.
+  GraphvizFragmentParams new_params{params};
+  new_params.node_id = node_id;
+  new_params.options.emplace("split", "I/O");
+  new_params.header_lines.push_back(fmt::format("lcm_url={}", get_lcm_url()));
+  GraphvizFragment result =
+      LeafSystem<double>::DoGetGraphvizFragment(new_params);
+  result.fragments.push_back(fmt::format(
+      "{}in [color={}];", node_id, internal::LcmSystemGraphviz::get_color()));
+  result.fragments.push_back(fmt::format(
+      "{}out [color={}];", node_id, internal::LcmSystemGraphviz::get_color()));
+  return result;
 }
 
 }  // namespace lcm

--- a/systems/lcm/lcm_interface_system.h
+++ b/systems/lcm/lcm_interface_system.h
@@ -81,6 +81,10 @@ class LcmInterfaceSystem final : public LeafSystem<double>,
                             systems::CompositeEventCollection<double>*,
                             double*) const final;
 
+  typename LeafSystem<double>::GraphvizFragment DoGetGraphvizFragment(
+      const typename LeafSystem<double>::GraphvizFragmentParams& params)
+      const final;
+
   std::unique_ptr<drake::lcm::DrakeLcmInterface> owned_lcm_;
   drake::lcm::DrakeLcmInterface* const lcm_{};
 };

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -4,9 +4,11 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/nice_type_name.h"
 #include "drake/common/text_logging.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcm/drake_lcm_interface.h"
+#include "drake/systems/lcm/lcm_system_graphviz.h"
 
 namespace drake {
 namespace systems {
@@ -136,6 +138,17 @@ EventStatus LcmPublisherSystem::PublishInputAsLcmMessage(
                 context.get_time());
 
   return EventStatus::Succeeded();
+}
+
+LeafSystem<double>::GraphvizFragment LcmPublisherSystem::DoGetGraphvizFragment(
+    const GraphvizFragmentParams& params) const {
+  internal::LcmSystemGraphviz lcm_system_graphviz(
+      *lcm_, channel_, &serializer_->CreateDefaultValue()->static_type_info(),
+      /* publish = */ true,
+      /* subscribe = */ false);
+  return lcm_system_graphviz.DecorateResult(
+      LeafSystem<double>::DoGetGraphvizFragment(
+          lcm_system_graphviz.DecorateParams(params)));
 }
 
 }  // namespace lcm

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -252,6 +252,10 @@ class LcmPublisherSystem : public LeafSystem<double> {
   EventStatus Initialize(const Context<double>& context) const;
   EventStatus PublishInputAsLcmMessage(const Context<double>& context) const;
 
+  typename LeafSystem<double>::GraphvizFragment DoGetGraphvizFragment(
+      const typename LeafSystem<double>::GraphvizFragmentParams& params)
+      const final;
+
   // The channel on which to publish LCM messages.
   const std::string channel_;
 

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -18,6 +18,12 @@ namespace drake {
 namespace systems {
 namespace lcm {
 
+#ifndef DRAKE_DOXYGEN_CXX
+namespace internal {
+class LcmSystemGraphviz;
+}  // namespace internal
+#endif
+
 /**
  * Receives LCM messages from a given channel and outputs them to a
  * System<double>'s port. This class stores the most recently processed LCM
@@ -156,6 +162,10 @@ class LcmSubscriberSystem : public LeafSystem<double> {
 
   EventStatus Initialize(const Context<double>&, State<double>* state) const;
 
+  typename LeafSystem<double>::GraphvizFragment DoGetGraphvizFragment(
+      const typename LeafSystem<double>::GraphvizFragmentParams& params)
+      const final;
+
   // The channel on which to receive LCM messages.
   const std::string channel_;
 
@@ -188,6 +198,9 @@ class LcmSubscriberSystem : public LeafSystem<double> {
 
   // A timeout in seconds.
   const double wait_for_message_on_initialization_timeout_;
+
+  // Graphviz support (for DoGetGraphvizFragment).
+  const std::unique_ptr<internal::LcmSystemGraphviz> graphviz_;
 };
 
 }  // namespace lcm

--- a/systems/lcm/lcm_system_graphviz.cc
+++ b/systems/lcm/lcm_system_graphviz.cc
@@ -1,0 +1,69 @@
+#include "drake/systems/lcm/lcm_system_graphviz.h"
+
+#include <utility>
+
+namespace drake {
+namespace systems {
+namespace lcm {
+namespace internal {
+
+using drake::lcm::DrakeLcmInterface;
+
+using Params = systems::SystemBase::GraphvizFragmentParams;
+using Result = systems::SystemBase::GraphvizFragment;
+
+LcmSystemGraphviz::LcmSystemGraphviz(const DrakeLcmInterface& lcm,
+                                     std::string_view channel,
+                                     const std::type_info* message_type,
+                                     bool publish, bool subscribe)
+    : lcm_interface_node_id_{get_node_id(lcm)},
+      channel_line_{fmt::format("channel={}", channel)},
+      type_line_{message_type != nullptr
+                     ? std::optional<std::string>{fmt::format(
+                           "type={}", NiceTypeName::RemoveNamespaces(
+                                          NiceTypeName::Get(*message_type)))}
+                     : std::nullopt},
+      publish_{publish},
+      subscribe_{subscribe} {}
+
+Params LcmSystemGraphviz::DecorateParams(const Params& params) {
+  node_id_ = params.node_id;
+  Params new_params{params};
+  if (publish_ || subscribe_) {
+    new_params.header_lines.push_back(channel_line_);
+  }
+  if (type_line_.has_value()) {
+    new_params.header_lines.push_back(*type_line_);
+  }
+  return new_params;
+}
+
+Result LcmSystemGraphviz::DecorateResult(Result&& result) {
+  Result new_result = std::move(result);
+  DRAKE_THROW_UNLESS(!node_id_.empty());
+  if (publish_) {
+    new_result.fragments.push_back(
+        fmt::format("{}:e -> {}in [style=\"dashed\", color=\"{}\"];\n",
+                    node_id_, lcm_interface_node_id_, get_color()));
+  }
+  if (subscribe_) {
+    new_result.fragments.push_back(
+        fmt::format("{}out -> {}:w [style=\"dashed\", color=\"{}\"];\n",
+                    lcm_interface_node_id_, node_id_, get_color()));
+  }
+  return new_result;
+}
+
+std::string LcmSystemGraphviz::get_node_id(
+    const drake::lcm::DrakeLcmInterface& lcm) {
+  return fmt::format("drakelcminterface{}", reinterpret_cast<uintptr_t>(&lcm));
+}
+
+std::string_view LcmSystemGraphviz::get_color() {
+  return "webpurple";
+}
+
+}  // namespace internal
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/systems/lcm/lcm_system_graphviz.h
+++ b/systems/lcm/lcm_system_graphviz.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "drake/lcm/drake_lcm_interface.h"
+#include "drake/systems/framework/system_base.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+namespace internal {
+
+/* Encapsulates how to annotate use of LCM in a System's Graphviz.
+
+Use this class within the implementation of DoGetGraphvizFragment, e.g.:
+
+```c++
+// Overrides the Parent::DoGetGraphvizFragment member function.
+Parent::GraphvizFragment MySystem::DoGetGraphvizFragment(
+    const Parent::GraphvizFragmentParams& params) const override {
+  LcmSystemGraphviz helper(...);
+  return helper.DecorateResult(
+      Parent::DoGetGraphvizFragment(helper.DecorateParams(params)));
+}
+```
+
+Grep for existing uses of this class to find other examples. */
+class LcmSystemGraphviz {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LcmSystemGraphviz);
+
+  /* Specifies how to customize the Graphviz for a LCM-using System.
+  @param lcm The interface the system communicates with.
+  @param channel The channel name the system publishes to (or receives from).
+  @param message_type (Optional) The `typeid(lcmt_foo_bar)` type the system
+   publishes (or receives).
+  @param publish True iff the system transmits messages.
+   This draws a Graphviz arrow from the system to `lcm`.
+  @param subscribe True iff the system receives messages.
+   This draws a Graphviz arrow from `lcm` to the system. */
+  LcmSystemGraphviz(const drake::lcm::DrakeLcmInterface& lcm,
+                    std::string_view channel,
+                    const std::type_info* message_type, bool publish,
+                    bool subscribe);
+
+  /* Rewrites the `params` to customize for LCM, by returning a possibly-
+  edited copy. Intended for use alongside DecorateResult(). */
+  SystemBase::GraphvizFragmentParams DecorateParams(
+      const SystemBase::GraphvizFragmentParams& params);
+
+  /* Rewrites the `result` to customize for LCM.
+  @pre DecorateParams has already been called. */
+  SystemBase::GraphvizFragment DecorateResult(
+      SystemBase::GraphvizFragment&& result);
+
+  /* Returns the Graphviz node ID for the given `lcm` interface. */
+  static std::string get_node_id(const drake::lcm::DrakeLcmInterface& lcm);
+
+  /* Returns the color for LCM nodes and edges. */
+  static std::string_view get_color();
+
+ private:
+  const std::string lcm_interface_node_id_;
+  const std::string channel_line_;
+  const std::optional<std::string> type_line_;
+  const bool publish_;
+  const bool subscribe_;
+
+  std::string node_id_;
+};
+
+}  // namespace internal
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/systems/lcm/test/lcm_config_functions_test.cc
+++ b/systems/lcm/test/lcm_config_functions_test.cc
@@ -142,6 +142,8 @@ GTEST_TEST(LcmConfigFunctionsTest, Nulls) {
   DrakeLcmInterface* interface2 = name_to_interface.Find("Nulls test", "bar");
   ASSERT_NE(interface1, nullptr);
   ASSERT_NE(interface2, nullptr);
+  EXPECT_EQ(interface1->get_lcm_url(), "memq://null");
+  EXPECT_EQ(interface2->get_lcm_url(), "memq://null");
 
   // Check that no unwanted systems were added.
   std::vector<std::string> names;
@@ -151,8 +153,8 @@ GTEST_TEST(LcmConfigFunctionsTest, Nulls) {
   const std::vector<std::string> expected{
       // The two `SharedPtrSystem`s are the only things that get added.
       // Note that there are no `LcmInterfaceSystem`s anywhere here.
-      "DrakeLcm(bus_name=foo, lcm_url=memq://null)",
-      "DrakeLcm(bus_name=bar, lcm_url=memq://null)",
+      "DrakeLcm(bus_name=foo)",
+      "DrakeLcm(bus_name=bar)",
   };
   EXPECT_THAT(names, testing::UnorderedElementsAreArray(expected));
 

--- a/systems/lcm/test/lcm_interface_system_test.cc
+++ b/systems/lcm/test/lcm_interface_system_test.cc
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <thread>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/text_logging.h"
@@ -135,6 +136,14 @@ TEST_F(LcmInterfaceSystemTest, NameCollisionTest) {
   builder.AddSystem<LcmInterfaceSystem>();
   builder.AddSystem<LcmInterfaceSystem>();
   builder.Build();
+}
+
+// The Graphviz should have split nodes (sub vs pub) show some useful metadata.
+TEST_F(LcmInterfaceSystemTest, Graphviz) {
+  LcmInterfaceSystem dut;
+  EXPECT_THAT(dut.GetGraphvizString(), testing::HasSubstr("in [shape"));
+  EXPECT_THAT(dut.GetGraphvizString(), testing::HasSubstr("out [shape"));
+  EXPECT_THAT(dut.GetGraphvizString(), testing::HasSubstr("lcm_url=memq://"));
 }
 
 INSTANTIATE_TEST_SUITE_P(test, LcmInterfaceSystemTest,

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <memory>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/is_dynamic_castable.h"
@@ -335,6 +336,15 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishOffset) {
 
   // Check that we didn't get any redundant (duplicate) messages.
   EXPECT_EQ(sub.count(), 3);
+}
+
+// The Graphviz should have an arrow pointing to the DrakeLcmInterface, plus
+// some extra metadata.
+GTEST_TEST(LcmPublisherSystemTest, Graphviz) {
+  DrakeLcm interface;
+  auto dut = LcmPublisherSystem::Make<lcmt_drake_signal>("SIGNAL", &interface);
+  EXPECT_THAT(dut->GetGraphvizString(), testing::HasSubstr(" -> drakelcm"));
+  EXPECT_THAT(dut->GetGraphvizString(), testing::HasSubstr("channel=SIGNAL"));
 }
 
 }  // namespace

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -3,6 +3,7 @@
 #include <array>
 #include <future>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -259,6 +260,16 @@ GTEST_TEST(LcmSubscriberSystemTest, WaitTest) {
   wait();
   sample_data.PublishAndHandle(&lcm, channel_name);
   EXPECT_GE(second_timeout_count.get(), old_count + 1);
+}
+
+// The Graphviz should have an arrow pointing from DrakeLcmInterface to our
+// system, plus some extra metadata.
+GTEST_TEST(LcmSubscriberSystemTest, Graphviz) {
+  drake::lcm::DrakeLcm interface;
+  auto dut = LcmSubscriberSystem::Make<lcmt_drake_signal>("SIGNAL", &interface);
+  EXPECT_THAT(dut->GetGraphvizString(),
+              testing::ContainsRegex("drakelcm[a-z0-9]* -> "));
+  EXPECT_THAT(dut->GetGraphvizString(), testing::HasSubstr("channel=SIGNAL"));
 }
 
 }  // namespace

--- a/systems/lcm/test/lcm_system_graphviz_test.cc
+++ b/systems/lcm/test/lcm_system_graphviz_test.cc
@@ -1,0 +1,142 @@
+#include "drake/systems/lcm/lcm_system_graphviz.h"
+
+#include "absl/strings/str_split.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_drake_signal.hpp"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+namespace internal {
+namespace {
+
+using drake::lcm::DrakeLcm;
+
+using Params = systems::SystemBase::GraphvizFragmentParams;
+using Result = systems::SystemBase::GraphvizFragment;
+
+GTEST_TEST(LcmSystemGraphvizTest, Publish) {
+  const DrakeLcm lcm;
+  const std::string channel = "SIGNAL";
+  const std::type_info& message_type = typeid(lcmt_drake_signal);
+  const bool publish = true;
+  const bool subscribe = false;
+  LcmSystemGraphviz dut(lcm, channel, &message_type, publish, subscribe);
+
+  const Params params_orig{.node_id = "foo",
+                           .header_lines = {"existing header"}};
+  const Params params = dut.DecorateParams(params_orig);
+  EXPECT_EQ(params.node_id, "foo");
+  EXPECT_THAT(params.header_lines,
+              testing::ElementsAre(
+                  // Prior item.
+                  "existing header",
+                  // Newly-added items.
+                  "channel=SIGNAL", "type=lcmt_drake_signal"));
+
+  const Result result_orig{.input_ports = {"foo:u0"},
+                           .output_ports = {"foo:y0"},
+                           .fragments = {"existing fragment"}};
+  const Result result = dut.DecorateResult(Result{result_orig});
+  EXPECT_EQ(result.input_ports, result_orig.input_ports);
+  EXPECT_EQ(result.output_ports, result_orig.output_ports);
+  ASSERT_GE(result.fragments.size(), 2);
+  EXPECT_EQ(result.fragments.front(), "existing fragment");
+  EXPECT_THAT(result.fragments.back(), testing::HasSubstr("-> drakelcm"));
+  EXPECT_THAT(result.fragments.back(),
+              testing::Not(testing::HasSubstr("out ->")));
+}
+
+GTEST_TEST(LcmSystemGraphvizTest, Subscribe) {
+  const DrakeLcm lcm;
+  const std::string channel = "SIGNAL";
+  const std::type_info& message_type = typeid(lcmt_drake_signal);
+  const bool publish = false;
+  const bool subscribe = true;
+  LcmSystemGraphviz dut(lcm, channel, &message_type, publish, subscribe);
+
+  const Params params_orig{.node_id = "foo",
+                           .header_lines = {"existing header"}};
+  const Params params = dut.DecorateParams(params_orig);
+  EXPECT_EQ(params.node_id, "foo");
+  EXPECT_THAT(params.header_lines,
+              testing::ElementsAre(
+                  // Prior item.
+                  "existing header",
+                  // Newly-added items.
+                  "channel=SIGNAL", "type=lcmt_drake_signal"));
+
+  const Result result_orig{.input_ports = {"foo:u0"},
+                           .output_ports = {"foo:y0"},
+                           .fragments = {"existing fragment"}};
+  const Result result = dut.DecorateResult(Result{result_orig});
+  EXPECT_EQ(result.input_ports, result_orig.input_ports);
+  EXPECT_EQ(result.output_ports, result_orig.output_ports);
+  ASSERT_GE(result.fragments.size(), 2);
+  EXPECT_EQ(result.fragments.front(), "existing fragment");
+  EXPECT_THAT(result.fragments.back(), testing::HasSubstr("out ->"));
+  EXPECT_THAT(result.fragments.back(),
+              testing::Not(testing::HasSubstr("-> drakelcm")));
+}
+
+GTEST_TEST(LcmSystemGraphvizTest, Neither) {
+  const DrakeLcm lcm;
+  const std::string channel;
+  const std::type_info* message_type = nullptr;
+  const bool publish = false;
+  const bool subscribe = false;
+  LcmSystemGraphviz dut(lcm, channel, message_type, publish, subscribe);
+
+  const Params params_orig{.node_id = "foo",
+                           .header_lines = {"existing header"}};
+  const Params params = dut.DecorateParams(params_orig);
+  EXPECT_EQ(params.node_id, "foo");
+  EXPECT_EQ(params.header_lines, params_orig.header_lines);
+
+  const Result result_orig{.input_ports = {"foo:u0"},
+                           .output_ports = {"foo:y0"},
+                           .fragments = {"existing fragment"}};
+  const Result result = dut.DecorateResult(Result{result_orig});
+  EXPECT_EQ(result.input_ports, result_orig.input_ports);
+  EXPECT_EQ(result.output_ports, result_orig.output_ports);
+  EXPECT_EQ(result.fragments, result_orig.fragments);
+}
+
+GTEST_TEST(LcmSystemGraphvizTest, TwoDifferentPublish) {
+  const DrakeLcm alpha;
+  const DrakeLcm bravo;
+  std::vector<std::string> alpha_graphviz;
+  std::vector<std::string> bravo_graphviz;
+  {
+    LcmSystemGraphviz dut(alpha, "CHANNEL", nullptr, true, false);
+    dut.DecorateParams(Params{.node_id = "alpha"});
+    const Result result = dut.DecorateResult(Result{});
+    alpha_graphviz =
+        absl::StrSplit(fmt::format("{}", fmt::join(result.fragments, "")), " ");
+  }
+  {
+    LcmSystemGraphviz dut(bravo, "CHANNEL", nullptr, true, false);
+    dut.DecorateParams(Params{.node_id = "bravo"});
+    const Result result = dut.DecorateResult(Result{});
+    bravo_graphviz =
+        absl::StrSplit(fmt::format("{}", fmt::join(result.fragments, "")), " ");
+  }
+  // Confirm that the destination node (after the "->") differs for the two
+  // edges, since each one should be pointing to a different interface.
+  EXPECT_EQ(alpha_graphviz.at(0), "alpha:e");
+  EXPECT_EQ(bravo_graphviz.at(0), "bravo:e");
+  EXPECT_EQ(alpha_graphviz.at(1), "->");
+  EXPECT_EQ(bravo_graphviz.at(1), "->");
+  EXPECT_THAT(alpha_graphviz.at(2), testing::StartsWith("drakelcm"));
+  EXPECT_THAT(bravo_graphviz.at(2), testing::StartsWith("drakelcm"));
+  EXPECT_NE(alpha_graphviz.at(2), bravo_graphviz.at(2));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Closes #20203.  Here's a demo using the command line given in #20198.  See also #20270 for related Meshcat change.

![image](https://github.com/RobotLocomotion/drake/assets/17596505/7a97c709-97d6-42cf-8bf8-cf897784f512)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20310)
<!-- Reviewable:end -->
