### PR TITLE
Add ClarabelSolver.

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -34,6 +34,7 @@ drake_cc_package_library(
         ":binding",
         ":branch_and_bound",
         ":choose_best_solver",
+        ":clarabel_solver",
         ":clp_solver",
         ":constraint",
         ":cost",
@@ -418,7 +419,9 @@ drake_cc_library(
         ":binding",
         ":mathematical_program",
     ],
-    deps = [],
+    deps = [
+        "//math:eigen_sparse_triplet",
+    ],
 )
 
 drake_cc_library(
@@ -585,6 +588,7 @@ drake_cc_library(
     srcs = ["test/optimization_examples.cc"],
     hdrs = ["test/optimization_examples.h"],
     deps = [
+        ":clarabel_solver",
         ":clp_solver",
         ":gurobi_solver",
         ":ipopt_solver",
@@ -947,6 +951,28 @@ drake_cc_variant_library(
     deps_enabled = [
         "//math:eigen_sparse_triplet",
         "@osqp_internal//:osqp",
+    ],
+)
+
+drake_cc_variant_library(
+    name = "clarabel_solver",
+    opt_in_condition = "//tools:with_clarabel",
+    srcs_always = ["clarabel_solver_common.cc"],
+    srcs_enabled = ["clarabel_solver.cc"],
+    srcs_disabled = ["no_clarabel.cc"],
+    hdrs = ["clarabel_solver.h"],
+    interface_deps = [
+        ":solver_base",
+        "//common:essential",
+    ],
+    deps_always = [
+        ":aggregate_costs_constraints",
+        ":mathematical_program",
+        "//math:quadratic_form",
+    ],
+    deps_enabled = [
+        "//math:eigen_sparse_triplet",
+        "@clarabel_cpp_internal//:clarabel_cpp",
     ],
 )
 
@@ -1626,6 +1652,21 @@ drake_cc_googletest(
         ":mixed_integer_rotation_constraint",
         ":rotation_constraint",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "clarabel_solver_test",
+    deps = [
+        ":clarabel_solver",
+        ":exponential_cone_program_examples",
+        ":linear_program_examples",
+        ":mathematical_program",
+        ":mathematical_program_test_util",
+        ":quadratic_program_examples",
+        ":second_order_cone_program_examples",
+        ":semidefinite_program_examples",
+        ":sos_examples",
     ],
 )
 

--- a/solvers/aggregate_costs_constraints.cc
+++ b/solvers/aggregate_costs_constraints.cc
@@ -6,6 +6,8 @@
 
 #include <fmt/format.h>
 
+#include "drake/math/eigen_sparse_triplet.h"
+
 namespace drake {
 namespace solvers {
 namespace {
@@ -112,6 +114,7 @@ void AggregateLinearCostsHelper(
     *constant_cost += cost.evaluator()->b();
   }
 }
+
 }  // namespace
 
 void AggregateLinearCosts(const std::vector<Binding<LinearCost>>& linear_costs,
@@ -303,6 +306,323 @@ bool CheckConvexSolverAttributes(const MathematicalProgram& prog,
   }
   return true;
 }
+
+void ParseLinearCosts(const MathematicalProgram& prog, std::vector<double>* c,
+                      double* constant) {
+  DRAKE_DEMAND(static_cast<int>(c->size()) >= prog.num_vars());
+  for (const auto& linear_cost : prog.linear_costs()) {
+    // Each linear cost is in the form of aᵀx + b
+    const auto& a = linear_cost.evaluator()->a();
+    const VectorXDecisionVariable& x = linear_cost.variables();
+    for (int i = 0; i < a.rows(); ++i) {
+      (*c)[prog.FindDecisionVariableIndex(x(i))] += a(i);
+    }
+    (*constant) += linear_cost.evaluator()->b();
+  }
+}
+
+void ParseLinearEqualityConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* linear_eq_y_start_indices,
+    int* num_linear_equality_constraints_rows) {
+  DRAKE_ASSERT(static_cast<int>(b->size()) == *A_row_count);
+  *num_linear_equality_constraints_rows = 0;
+  linear_eq_y_start_indices->reserve(prog.linear_equality_constraints().size());
+  // The linear equality constraint A x = b is converted to
+  // A x + s = b. s in zero cone.
+  for (const auto& linear_equality_constraint :
+       prog.linear_equality_constraints()) {
+    const Eigen::SparseMatrix<double>& Ai =
+        linear_equality_constraint.evaluator()->get_sparse_A();
+    const std::vector<Eigen::Triplet<double>> Ai_triplets =
+        math::SparseMatrixToTriplets(Ai);
+    A_triplets->reserve(A_triplets->size() + Ai_triplets.size());
+    const solvers::VectorXDecisionVariable& x =
+        linear_equality_constraint.variables();
+    // x_indices[i] is the index of x(i)
+    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
+    for (const auto& Ai_triplet : Ai_triplets) {
+      A_triplets->emplace_back(Ai_triplet.row() + *A_row_count,
+                               x_indices[Ai_triplet.col()], Ai_triplet.value());
+    }
+    const int num_Ai_rows =
+        linear_equality_constraint.evaluator()->num_constraints();
+    b->reserve(b->size() + num_Ai_rows);
+    for (int i = 0; i < num_Ai_rows; ++i) {
+      b->push_back(linear_equality_constraint.evaluator()->lower_bound()(i));
+    }
+    linear_eq_y_start_indices->push_back(*A_row_count);
+    *A_row_count += num_Ai_rows;
+    *num_linear_equality_constraints_rows += num_Ai_rows;
+  }
+}
+
+void ParseLinearConstraints(const solvers::MathematicalProgram& prog,
+                            std::vector<Eigen::Triplet<double>>* A_triplets,
+                            std::vector<double>* b, int* A_row_count,
+                            std::vector<std::vector<std::pair<int, int>>>*
+                                linear_constraint_dual_indices,
+                            int* num_linear_constraint_rows) {
+  // The linear constraint lb ≤ aᵀx ≤ ub is converted to
+  // -aᵀx + s1 = lb,
+  //  aᵀx + s2 = ub
+  // s1, s2 in the positive cone.
+  // The special cases are when ub = ∞ or lb = -∞.
+  // When ub = ∞, then we only add the constraint
+  // -aᵀx + s = lb, s in the positive cone.
+  // When lb = -∞, then we only add the constraint
+  // aᵀx + s = ub, s in the positive cone.
+  *num_linear_constraint_rows = 0;
+  linear_constraint_dual_indices->reserve(prog.linear_constraints().size());
+  for (const auto& linear_constraint : prog.linear_constraints()) {
+    linear_constraint_dual_indices->emplace_back(
+        linear_constraint.evaluator()->num_constraints());
+    const Eigen::VectorXd& ub = linear_constraint.evaluator()->upper_bound();
+    const Eigen::VectorXd& lb = linear_constraint.evaluator()->lower_bound();
+    const VectorXDecisionVariable& x = linear_constraint.variables();
+    const Eigen::SparseMatrix<double>& Ai =
+        linear_constraint.evaluator()->get_sparse_A();
+    // We store the starting row index in A_triplets for each row of
+    // linear_constraint. Namely the constraint lb(i) <= A.row(i)*x <= ub(i) is
+    // stored in A_triplets with starting_row_indices[i] (or
+    // starting_row_indices[i]+1 if both lb(i) and ub(i) are finite).
+    std::vector<int> starting_row_indices(
+        linear_constraint.evaluator()->num_constraints());
+    for (int i = 0; i < linear_constraint.evaluator()->num_constraints(); ++i) {
+      const bool needs_ub{!std::isinf(ub(i))};
+      const bool needs_lb{!std::isinf(lb(i))};
+      auto& dual_index = linear_constraint_dual_indices->back()[i];
+      // Use -1 to indicate the constraint bound is infinity.
+      dual_index.first = -1;
+      dual_index.second = -1;
+      if (!needs_ub && !needs_lb) {
+        // We use -1 to indicate that we won't add linear constraint when both
+        // bounds are infinity.
+        starting_row_indices[i] = -1;
+      } else {
+        starting_row_indices[i] = *A_row_count + *num_linear_constraint_rows;
+        // We first add the constraint for lower bound, and then add the
+        // constraint for upper bound. This is consistent with the loop below
+        // when we modify A_triplets.
+        if (needs_lb) {
+          b->push_back(-lb(i));
+          dual_index.first = *A_row_count + *num_linear_constraint_rows;
+          (*num_linear_constraint_rows)++;
+        }
+        if (needs_ub) {
+          b->push_back(ub(i));
+          dual_index.second = *A_row_count + *num_linear_constraint_rows;
+          (*num_linear_constraint_rows)++;
+        }
+      }
+    }
+    for (int j = 0; j < Ai.cols(); ++j) {
+      const int xj_index = prog.FindDecisionVariableIndex(x(j));
+      for (Eigen::SparseMatrix<double>::InnerIterator it(Ai, j); it; ++it) {
+        const int Ai_row_count = it.row();
+        const bool needs_ub{!std::isinf(ub(Ai_row_count))};
+        const bool needs_lb{!std::isinf(lb(Ai_row_count))};
+        if (!needs_lb && !needs_ub) {
+          continue;
+        }
+        int row_index = starting_row_indices[Ai_row_count];
+        if (needs_lb) {
+          // If lb != -∞, then the constraint -aᵀx + s = lb will be added to
+          // the matrix A, in the row row_index.
+          A_triplets->emplace_back(row_index, xj_index, -it.value());
+          ++row_index;
+        }
+        if (needs_ub) {
+          // If ub != ∞, then the constraint aᵀx + s = ub will be added to the
+          // matrix A, in the row row_index.
+          A_triplets->emplace_back(row_index, xj_index, it.value());
+        }
+      }
+    }
+  }
+  *A_row_count += *num_linear_constraint_rows;
+}
+
+void ParseQuadraticCosts(const MathematicalProgram& prog,
+                         std::vector<Eigen::Triplet<double>>* P_upper_triplets,
+                         std::vector<double>* c, double* constant) {
+  for (const auto& cost : prog.quadratic_costs()) {
+    const auto var_indices = prog.FindDecisionVariableIndices(cost.variables());
+    for (int j = 0; j < cost.evaluator()->Q().cols(); ++j) {
+      for (int i = 0; i <= j; ++i) {
+        if (cost.evaluator()->Q()(i, j) != 0) {
+          P_upper_triplets->emplace_back(var_indices[i], var_indices[j],
+                                         cost.evaluator()->Q()(i, j));
+        }
+      }
+      (*c)[var_indices[j]] += cost.evaluator()->b()(j);
+    }
+    *constant += cost.evaluator()->c();
+  }
+}
+
+// Add a rotated Lorentz cone constraint that A_cone * x + b_cone is in the
+// rotated Lorentz cone.
+// @param A_cone_triplets The triplets of non-zero entries in A_cone.
+// @param b_cone A_cone * x + b_cone is in the rotated Lorentz cone.
+// @param x_indices The index of the variable in SCS.
+// @param A_triplets[in/out] The non-zero entry triplet in A before and after
+// adding the Lorentz cone.
+// @param b[in/out] The right-hand side vector b before and after adding the
+// Lorentz cone.
+// @param A_row_count[in/out] The number of rows in A before and after adding
+// the Lorentz cone.
+// @param second_order_cone_length[in/out] The length of each Lorentz cone
+// before and after adding the Lorentz cone constraint.
+// @param rotated_lorentz_cone_y_start_indices[in/out] The starting index of y
+// corresponds to this rotated Lorentz cone. If set to nullopt, then we don't
+// modify rotated_lorentz_cone_y_start_indices.
+void ParseRotatedLorentzConeConstraint(
+    const std::vector<Eigen::Triplet<double>>& A_cone_triplets,
+    const Eigen::Ref<const Eigen::VectorXd>& b_cone,
+    const std::vector<int>& x_indices,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* second_order_cone_length,
+    std::optional<std::vector<int>*> rotated_lorentz_cone_y_start_indices) {
+  // Our RotatedLorentzConeConstraint encodes that Ax + b is in the rotated
+  // Lorentz cone, namely
+  //  (a₀ᵀx + b₀) (a₁ᵀx + b₁) ≥ (a₂ᵀx + b₂)² + ... + (aₙ₋₁ᵀx + bₙ₋₁)²
+  //  (a₀ᵀx + b₀) ≥ 0
+  //  (a₁ᵀx + b₁) ≥ 0
+  // , where aᵢᵀ is the i'th row of A, bᵢ is the i'th row of b. Equivalently the
+  // vector
+  // [ 0.5(a₀ + a₁)ᵀx + 0.5(b₀ + b₁) ]
+  // [ 0.5(a₀ - a₁)ᵀx + 0.5(b₀ - b₁) ]
+  // [           a₂ᵀx +           b₂ ]
+  //             ...
+  // [         aₙ₋₁ᵀx +         bₙ₋₁ ]
+  // is in the Lorentz cone. We convert this to the SCS form, that
+  //  Cx + s = d
+  //  s in Lorentz cone,
+  // where C = [ -0.5(a₀ + a₁)ᵀ ]   d = [ 0.5(b₀ + b₁) ]
+  //           [ -0.5(a₀ - a₁)ᵀ ]       [ 0.5(b₀ - b₁) ]
+  //           [           -a₂ᵀ ]       [           b₂ ]
+  //                 ...                      ...
+  //           [         -aₙ₋₁ᵀ ]       [          bₙ₋₁]
+  for (const auto& Ai_triplet : A_cone_triplets) {
+    const int x_index = x_indices[Ai_triplet.col()];
+    if (Ai_triplet.row() == 0) {
+      A_triplets->emplace_back(*A_row_count, x_index,
+                               -0.5 * Ai_triplet.value());
+      A_triplets->emplace_back(*A_row_count + 1, x_index,
+                               -0.5 * Ai_triplet.value());
+    } else if (Ai_triplet.row() == 1) {
+      A_triplets->emplace_back(*A_row_count, x_index,
+                               -0.5 * Ai_triplet.value());
+      A_triplets->emplace_back(*A_row_count + 1, x_index,
+                               0.5 * Ai_triplet.value());
+    } else {
+      A_triplets->emplace_back(*A_row_count + Ai_triplet.row(), x_index,
+                               -Ai_triplet.value());
+    }
+  }
+  b->push_back(0.5 * (b_cone(0) + b_cone(1)));
+  b->push_back(0.5 * (b_cone(0) - b_cone(1)));
+  for (int i = 2; i < b_cone.rows(); ++i) {
+    b->push_back(b_cone(i));
+  }
+  if (rotated_lorentz_cone_y_start_indices.has_value()) {
+    rotated_lorentz_cone_y_start_indices.value()->push_back(*A_row_count);
+  }
+  *A_row_count += b_cone.rows();
+  second_order_cone_length->push_back(b_cone.rows());
+}
+
+void ParseSecondOrderConeConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* second_order_cone_length,
+    std::vector<int>* lorentz_cone_y_start_indices,
+    std::vector<int>* rotated_lorentz_cone_y_start_indices) {
+  // Our LorentzConeConstraint encodes that Ax + b is in Lorentz cone. We
+  // convert this to SCS form, as -Ax + s = b, s in Lorentz cone.
+  second_order_cone_length->reserve(
+      prog.lorentz_cone_constraints().size() +
+      prog.rotated_lorentz_cone_constraints().size());
+  lorentz_cone_y_start_indices->reserve(prog.lorentz_cone_constraints().size());
+  rotated_lorentz_cone_y_start_indices->reserve(
+      prog.rotated_lorentz_cone_constraints().size());
+  for (const auto& lorentz_cone_constraint : prog.lorentz_cone_constraints()) {
+    // x_indices[i] is the index of x(i)
+    const VectorXDecisionVariable& x = lorentz_cone_constraint.variables();
+    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
+    const Eigen::SparseMatrix<double> Ai =
+        lorentz_cone_constraint.evaluator()->A();
+    const std::vector<Eigen::Triplet<double>> Ai_triplets =
+        math::SparseMatrixToTriplets(Ai);
+    for (const auto& Ai_triplet : Ai_triplets) {
+      A_triplets->emplace_back(Ai_triplet.row() + *A_row_count,
+                               x_indices[Ai_triplet.col()],
+                               -Ai_triplet.value());
+    }
+    const int num_Ai_rows = lorentz_cone_constraint.evaluator()->A().rows();
+    for (int i = 0; i < num_Ai_rows; ++i) {
+      b->push_back(lorentz_cone_constraint.evaluator()->b()(i));
+    }
+    second_order_cone_length->push_back(num_Ai_rows);
+    lorentz_cone_y_start_indices->push_back(*A_row_count);
+    *A_row_count += num_Ai_rows;
+  }
+
+  for (const auto& rotated_lorentz_cone :
+       prog.rotated_lorentz_cone_constraints()) {
+    const VectorXDecisionVariable& x = rotated_lorentz_cone.variables();
+    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
+    const Eigen::SparseMatrix<double> Ai =
+        rotated_lorentz_cone.evaluator()->A();
+    const Eigen::VectorXd& bi = rotated_lorentz_cone.evaluator()->b();
+    const std::vector<Eigen::Triplet<double>> Ai_triplets =
+        math::SparseMatrixToTriplets(Ai);
+    ParseRotatedLorentzConeConstraint(Ai_triplets, bi, x_indices, A_triplets, b,
+                                      A_row_count, second_order_cone_length,
+                                      rotated_lorentz_cone_y_start_indices);
+  }
+}
+
+void ParseExponentialConeConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count) {
+  for (const auto& binding : prog.exponential_cone_constraints()) {
+    // drake::solvers::ExponentialConstraint enforces that z = A * x + b is in
+    // the exponential cone (z₀ ≥ z₁*exp(z₂ / z₁)). This is different from the
+    // exponential cone used in SCS. In SCS, a vector s is in the exponential
+    // cone, if s₂≥ s₁*exp(s₀ / s₁). To transform drake's Exponential cone to
+    // SCS's exponential cone, we use
+    // -[A.row(2); A.row(1); A.row(0)] * x + s = [b(2); b(1); b(0)], and s is
+    // in SCS's exponential cone, where A = binding.evaluator()->A(), b =
+    // binding.evaluator()->b().
+    const int num_bound_variables = binding.variables().rows();
+    for (int i = 0; i < num_bound_variables; ++i) {
+      A_triplets->reserve(A_triplets->size() +
+                          binding.evaluator()->A().nonZeros());
+      const int decision_variable_index =
+          prog.FindDecisionVariableIndex(binding.variables()(i));
+      for (Eigen::SparseMatrix<double>::InnerIterator it(
+               binding.evaluator()->A(), i);
+           it; ++it) {
+        // 2 - it.row() is used for reverse the row order, as mentioned in the
+        // function documentation above.
+        A_triplets->emplace_back(*A_row_count + 2 - it.row(),
+                                 decision_variable_index, -it.value());
+      }
+    }
+    // The exponential cone constraint is on a 3 x 1 vector, hence for each
+    // ExponentialConeConstraint, we append 3 rows to A and b.
+    b->reserve(b->size() + 3);
+    for (int i = 0; i < 3; ++i) {
+      b->push_back(binding.evaluator()->b()(2 - i));
+    }
+    *A_row_count += 3;
+  }
+}
+
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/aggregate_costs_constraints.h
+++ b/solvers/aggregate_costs_constraints.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -121,6 +122,141 @@ bool CheckConvexSolverAttributes(const MathematicalProgram& prog,
                                  const ProgramAttributes& solver_capabilities,
                                  std::string_view solver_name,
                                  std::string* explanation);
+
+// Aggregates all prog.linear_costs(), such that the aggregated linear cost is
+// ∑ᵢ (*c)[i] * prog.decision_variable(i) + *constant
+// @pre c->size() >= prog.num_vars();
+void ParseLinearCosts(const MathematicalProgram& prog, std::vector<double>* c,
+                      double* constant);
+
+// Parses all prog.linear_equality_constraints() to
+// A*x = b
+// Some convex solvers (like SCS and Clarabel) aggregates all constraints in the
+// form of
+// A*x + s = b
+// s in K
+// This function appends all prog.linear_equality_constraints() to the existing
+// A*x+s=b.
+// @param[in/out] A_triplets The triplets on the non-zero entries in A.
+// prog.linear_equality_constraints() will be appended to A_triplets.
+// @param[in/out] b The righthand side of A*x=b.
+// prog.linear_equality_constraints() will be appended to b.
+// @param[in/out] A_row_count The number of rows in A before and after calling
+// this function.
+// @param[out] linear_eq_y_start_indices linear_eq_y_start_indices[i] is the
+// starting index of the dual variable for the constraint
+// prog.linear_equality_constraints()[i]. Namely y[linear_eq_y_start_indices[i]:
+// linear_eq_y_start_indices[i] +
+// prog.linear_equality_constraints()[i].evaluator()->num_constraints] are the
+// dual variables for  the linear equality constraint
+// prog.linear_equality_constraint()(i), where y is the vector containing all
+// dual variables.
+// @param[out] num_linear_equality_constraints_rows The number of new rows
+// appended to A*x+s=b in all prog.linear_equality_constraints()
+void ParseLinearEqualityConstraints(
+    const solvers::MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* linear_eq_y_start_indices,
+    int* num_linear_equality_constraints_rows);
+
+// Parses all prog.linear_constraints() to
+// A*x + s = b
+// s in the nonnegative orthant cone.
+// Some convex solvers (like SCS and Clarabel) aggregates all constraints in the
+// form of
+// A*x + s = b
+// s in K
+// This function appends all prog.linear_constraints() to the existing
+// A*x+s=b.
+// @param[in/out] A_triplets The triplets on the non-zero entries in A.
+// prog.linear_constraints() will be appended to A_triplets.
+// @param[in/out] b The righthand side of A*x+s=b.
+// prog.linear_equality_constraints() will be appended to b.
+// @param[in/out] A_row_count The number of rows in A before and after calling
+// this function.
+// @param[out] linear_constraint_dual_indices
+// linear_constraint_dual_indices[i][j].first/linear_constraint_dual_indices[i][j].second
+// is the dual variable for the lower/upper bound of the j'th row in the
+// linear constraint prog.linear_constraint()[i], we use -1 to indicate that
+// the lower or upper bound is infinity.
+// @param[out] num_linear_constraint_rows The number of new rows appended to
+// A*x+s = b in all
+// prog.linear_equality_constraints()
+void ParseLinearConstraints(const solvers::MathematicalProgram& prog,
+                            std::vector<Eigen::Triplet<double>>* A_triplets,
+                            std::vector<double>* b, int* A_row_count,
+                            std::vector<std::vector<std::pair<int, int>>>*
+                                linear_constraint_dual_indices,
+                            int* num_linear_constraint_rows);
+
+// Aggregates all quadratic prog.quadratic_costs() and add the aggregated cost
+// to 0.5*x'P*x + c'*x + constant. where x is prog.decision_variables().
+void ParseQuadraticCosts(const MathematicalProgram& prog,
+                         std::vector<Eigen::Triplet<double>>* P_upper_triplets,
+                         std::vector<double>* c, double* constant);
+
+// Parse all second order cone constraints (including both Lorentz cone and
+// rotated Lorentz cone constraint) to the form A*x+s=b, s in K where K is the
+// Cartesian product of Lorentz cone {s | sqrt(s₁²+...+sₙ₋₁²) ≤ s₀}
+// @param[in/out] A_triplets We append the second order cone constraints to
+// A_triplets.
+// @param[in/out] b We append the second order cone constraints to b.
+// @param[in/out] The number of rows in A before/after appending the second
+// order cone constraints.
+// @param[out] second_order_cone_length The lengths of each second order cone s
+// in K in the Cartesian product K.
+// @param[out] lorentz_cone_y_start_indices y[lorentz_cone_y_start_indices[i]:
+// lorentz_cone_y_start_indices[i] + second_order_cone_length[i]]
+// are the dual variables for prog.lorentz_cone_constraints()[i].
+// @param[out] rotated_lorentz_cone_y_start_indices
+// y[rotated_lorentz_cone_y_start_indices[i]:
+// rotated_lorentz_cone_y_start_indices[i] +
+// prog.rotate_lorentz_cone()[i].evaluator().A().rows] are the y variables for
+// prog.rotated_lorentz_cone_constraints()[i]. Note that we assume the Cartesian
+// product K doesn't contain a
+// rotated Lorentz cone constraint, instead we convert the rotated Lorentz
+// cone constraint to the Lorentz cone constraint through a linear
+// transformation. Hence we need to apply the transpose of that linear
+// transformation on the y variable to get the dual variable in the dual cone
+// of rotated Lorentz cone.
+void ParseSecondOrderConeConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* second_order_cone_length,
+    std::vector<int>* lorentz_cone_y_start_indices,
+    std::vector<int>* rotated_lorentz_cone_y_start_indices);
+
+// Add a rotated Lorentz cone constraint that A_cone * x + b_cone is in the
+// rotated Lorentz cone.
+//
+// We add these rotated Lorentz cones in the form A*x+s=b and s in K, where K is
+// the Cartesian product of Lorentz cones.
+// @param A_cone_triplets The triplets of non-zero entries in A_cone.
+// @param b_cone A_cone * x + b_cone is in the rotated Lorentz cone.
+// @param x_indices The index of the variables.
+// @param A_triplets[in/out] The non-zero entry triplet in A before and after
+// adding the Lorentz cone.
+// @param b[in/out] The right-hand side vector b before and after adding the
+// Lorentz cone.
+// @param A_row_count[in/out] The number of rows in A before and after adding
+// the Lorentz cone.
+// @param second_order_cone_length[in/out] The length of each Lorentz cone
+// before and after adding the Lorentz cone constraint.
+// @param rotated_lorentz_cone_y_start_indices[in/out] The starting index of y
+// corresponds to this rotated Lorentz cone. If set to nullopt, then we don't
+// modify rotated_lorentz_cone_y_start_indices.
+void ParseRotatedLorentzConeConstraint(
+    const std::vector<Eigen::Triplet<double>>& A_cone_triplets,
+    const Eigen::Ref<const Eigen::VectorXd>& b_cone,
+    const std::vector<int>& x_indices,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* second_order_cone_length,
+    std::optional<std::vector<int>*> rotated_lorentz_cone_y_start_indices);
+
+void ParseExponentialConeConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count);
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/clarabel_solver.cc
+++ b/solvers/clarabel_solver.cc
@@ -1,0 +1,318 @@
+#include "drake/solvers/clarabel_solver.h"
+
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <Clarabel>
+#include <Eigen/Eigen>
+
+#include "drake/common/text_logging.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+void ParseBoundingBoxConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<clarabel::SupportedConeT<double>>* cones,
+    std::vector<std::vector<std::pair<int, int>>>* bbcon_dual_indices) {
+  const std::unordered_map<symbolic::Variable, Bound> variable_bounds =
+      AggregateBoundingBoxConstraints(prog.bounding_box_constraints());
+
+  // For each variable with lb <= x <= ub, we check the following
+  // 1. If lb == ub (and both are finite), then we add the constraint x + s = ub
+  // with s in the zero cone.
+  // 2. If ub is finite, then we add the constraint x + s = ub with s in the
+  // positive orthant cone.
+  // 3. If lb is finite, then we add the constraint -x + s = -lb with s in the
+  // positive orthant cone.
+  // Set the dual variable indices.
+  bbcon_dual_indices->reserve(std::ssize(prog.bounding_box_constraints()));
+  for (int i = 0; i < std::ssize(prog.bounding_box_constraints()); ++i) {
+    bbcon_dual_indices->emplace_back(
+        prog.bounding_box_constraints()[i].variables().rows(),
+        std::pair<int, int>(-1, -1));
+    for (int j = 0; j < prog.bounding_box_constraints()[i].variables().rows();
+         ++j) {
+      const int var_index = prog.FindDecisionVariableIndex(
+          prog.bounding_box_constraints()[i].variables()(j));
+      const Bound& var_bound =
+          variable_bounds.at(prog.bounding_box_constraints()[i].variables()(j));
+      // We use the lower bound of this constraint in the optimization
+      // program.
+      const bool use_lb =
+          var_bound.lower ==
+              prog.bounding_box_constraints()[i].evaluator()->lower_bound()(
+                  j) &&
+          std::isfinite(var_bound.lower);
+      const bool use_ub =
+          var_bound.upper ==
+              prog.bounding_box_constraints()[i].evaluator()->upper_bound()(
+                  j) &&
+          std::isfinite(var_bound.upper);
+      if (use_lb && use_ub && var_bound.lower == var_bound.upper) {
+        // This is an equality constraint x = ub.
+        // Add the constraint x + s = ub and s in the zero cone.
+        A_triplets->emplace_back(*A_row_count, var_index, 1);
+        b->push_back(var_bound.upper);
+        (*bbcon_dual_indices)[i][j].first = *A_row_count;
+        (*bbcon_dual_indices)[i][j].second = *A_row_count;
+        cones->push_back(clarabel::ZeroConeT<double>(1));
+        (*A_row_count)++;
+      } else {
+        if (use_ub) {
+          // Add the constraint x + s = ub and s in the nonnegative orthant
+          // cone.
+          A_triplets->emplace_back(*A_row_count, var_index, 1);
+          b->push_back(var_bound.upper);
+          (*bbcon_dual_indices)[i][j].second = *A_row_count;
+          cones->push_back(clarabel::NonnegativeConeT<double>(1));
+          (*A_row_count)++;
+        }
+        if (use_lb) {
+          // Add the constraint -x + s = -lb and s in the nonnegative orthant
+          // cone.
+          A_triplets->emplace_back(*A_row_count, var_index, -1);
+          b->push_back(-var_bound.lower);
+          (*bbcon_dual_indices)[i][j].first = *A_row_count;
+          cones->push_back(clarabel::NonnegativeConeT<double>(1));
+          (*A_row_count)++;
+        }
+      }
+    }
+  }
+}
+
+std::string SolverStatusToString(const clarabel::SolverStatus status) {
+  switch (status) {
+    case clarabel::SolverStatus::Unsolved:
+      return "Unsolved";
+    case clarabel::SolverStatus::Solved:
+      return "Solved";
+    case clarabel::SolverStatus::PrimalInfeasible:
+      return "PrimalInfeasible";
+    case clarabel::SolverStatus::DualInfeasible:
+      return "DualInfeasible";
+    case clarabel::SolverStatus::AlmostSolved:
+      return "AlmostSolved";
+    case clarabel::SolverStatus::AlmostPrimalInfeasible:
+      return "AlmostPrimalInfeasible";
+    case clarabel::SolverStatus::AlmostDualInfeasible:
+      return "AlmostDualInfeasible";
+    case clarabel::SolverStatus::MaxIterations:
+      return "MaxIterations";
+    case clarabel::SolverStatus::MaxTime:
+      return "MaxTime";
+    case clarabel::SolverStatus::NumericalError:
+      return "NumericalError";
+    case clarabel::SolverStatus::InsufficientProgress:
+      return "InsufficientProgress";
+  }
+  DRAKE_UNREACHABLE();
+}
+
+void SetSolverDetails(
+    const clarabel::DefaultSolution<double>& clarabel_solution,
+    ClarabelSolverDetails* solver_details) {
+  solver_details->iterations = clarabel_solution.iterations;
+  solver_details->solve_time = clarabel_solution.solve_time;
+  solver_details->status = SolverStatusToString(clarabel_solution.status);
+}
+
+clarabel::DefaultSettings<double> SetClarabelSettings(
+    const SolverOptions& solver_options) {
+  clarabel::DefaultSettings<double> settings =
+      clarabel::DefaultSettingsBuilder<double>::default_settings().build();
+  // Clarabel defaults to print to console. But that would create too much noise
+  // on the console. So we overwrite the default value with
+  // solver_options.get_print_to_console().
+  settings.verbose = solver_options.get_print_to_console();
+  // TODO(hongkai.dai): set more options.
+  return settings;
+}
+
+}  // namespace
+
+bool ClarabelSolver::is_available() {
+  return true;
+}
+
+void ClarabelSolver::DoSolve(const MathematicalProgram& prog,
+                             const Eigen::VectorXd& initial_guess,
+                             const SolverOptions& merged_options,
+                             MathematicalProgramResult* result) const {
+  if (!prog.GetVariableScaling().empty()) {
+    static const logging::Warn log_once(
+        "ClarabelSolver doesn't support the feature of variable scaling.");
+  }
+
+  // Clarabel doesn't have an API to provide the initial guess yet.
+  unused(initial_guess);
+
+  // Clarabel solves the problem in this form
+  // min 0.5xᵀPx + qᵀx
+  // s.t A x + s = b
+  //     s in K
+  // where K is a Cartesian product of some primitive cones.
+  // The cones have to be in this order
+  // Zero cone {x | x = 0 }
+  // Positive orthant {x | x ≥ 0 }
+  // Second-order cone {(t, x) | |x|₂ ≤ t }
+  // Positive semidefinite cone { X | min(eig(X)) ≥ 0, X = Xᵀ }
+  // Exponential cone {x,y,z): y>0, y*exp(x/y) <= z}
+  // Power cone {(x, y, z): pow(x, α)*pow(y, 1-α) >= |z|, x>=0, y>=0} with α in
+  // (0, 1)
+  // Notice that due to the special problem form supported by Clarabel, we need
+  // to convert our generic constraints to Clarabel form. For example, a linear
+  // inequality constraint
+  //   A x ≤ b
+  // will be converted as
+  //   A x + s = b
+  //   s in positive orthant cone.
+  // by introducing the slack variable s.
+
+  // num_x is the number of variables in A*x+s=b. It can contain more variables
+  // than in prog. For some constraint/cost, we need to append slack variables
+  // to convert the constraint/cost to the Clarabel form.
+  int num_x = prog.num_vars();
+
+  // We need to construct a sparse matrix in Column Compressed Storage (CCS)
+  // format. On the other hand, we add the constraint row by row, instead of
+  // column by column, as preferred by CCS. As a result, we use Eigen sparse
+  // matrix to construct a sparse matrix in column order first, and then
+  // compress it to get CCS.
+  std::vector<Eigen::Triplet<double>> A_triplets;
+  // We need to construct a sparse matrix in Column Compressed Storage (CCS)
+  // format. Since we add an array of quadratic cost, each cost has its own
+  // associated variables, we use Eigen sparse matrix to aggregate the quadratic
+  // cost Hessian matrices. SCS only takes the upper triangular entries of the
+  // symmetric Hessian.
+  std::vector<Eigen::Triplet<double>> P_upper_triplets;
+
+  // A_row_count will increment, when we add each constraint.
+  int A_row_count = 0;
+  std::vector<double> b;
+
+  std::vector<clarabel::SupportedConeT<double>> cones;
+
+  // `q` is the coefficient in the linear cost qᵀx
+  std::vector<double> q(num_x, 0.0);
+
+  // Our cost (LinearCost, QuadraticCost, etc) also allows a constant term, we
+  // add these constant terms to `cost_constant`.
+  double cost_constant{0};
+
+  internal::ParseLinearCosts(prog, &q, &cost_constant);
+
+  internal::ParseQuadraticCosts(prog, &P_upper_triplets, &q, &cost_constant);
+
+  // Parse linear equality constraint
+  // linear_eq_y_start_indices[i] is the starting index of the dual
+  // variable for the constraint prog.linear_equality_constraints()[i]. Namely
+  // y[linear_eq_y_start_indices[i]:
+  // linear_eq_y_start_indices[i] +
+  // prog.linear_equality_constraints()[i].evaluator()->num_constraints] are the
+  // dual variables for  the linear equality constraint
+  // prog.linear_equality_constraint()(i), where y is the vector containing all
+  // dual variables.
+  std::vector<int> linear_eq_y_start_indices;
+  int num_linear_equality_constraints_rows;
+  internal::ParseLinearEqualityConstraints(
+      prog, &A_triplets, &b, &A_row_count, &linear_eq_y_start_indices,
+      &num_linear_equality_constraints_rows);
+  cones.push_back(
+      clarabel::ZeroConeT<double>(num_linear_equality_constraints_rows));
+
+  // Parse bounding box constraints.
+  // bbcon_dual_indices[i][j][0]/bbcon_dual_indices[i][j][1] is the dual
+  // variable for the lower/upper bound of the j'th row in the bounding box
+  // constraint prog.bounding_box_constraint()[i], we use -1 to indicate that
+  // the lower or upper bound is infinity.
+  std::vector<std::vector<std::pair<int, int>>> bbcon_dual_indices;
+  ParseBoundingBoxConstraints(prog, &A_triplets, &b, &A_row_count, &cones,
+                              &bbcon_dual_indices);
+
+  // Parse linear constraint
+  // linear_constraint_dual_indices[i][j][0]/linear_constraint_dual_indices[i][j][1]
+  // is the dual variable for the lower/upper bound of the j'th row in the
+  // linear constraint prog.linear_constraint()[i], we use -1 to indicate that
+  // the lower or upper bound is infinity.
+  std::vector<std::vector<std::pair<int, int>>> linear_constraint_dual_indices;
+  int num_linear_constraint_rows = 0;
+  internal::ParseLinearConstraints(prog, &A_triplets, &b, &A_row_count,
+                                   &linear_constraint_dual_indices,
+                                   &num_linear_constraint_rows);
+  cones.push_back(
+      clarabel::NonnegativeConeT<double>(num_linear_constraint_rows));
+
+  // Parse Lorentz cone and rotated Lorentz cone constraint
+  std::vector<int> second_order_cone_length;
+  // y[lorentz_cone_y_start_indices[i]:
+  //   lorentz_cone_y_start_indices[i] + second_order_cone_length[i]]
+  // are the dual variables for prog.lorentz_cone_constraints()[i].
+  std::vector<int> lorentz_cone_y_start_indices;
+  std::vector<int> rotated_lorentz_cone_y_start_indices;
+  internal::ParseSecondOrderConeConstraints(
+      prog, &A_triplets, &b, &A_row_count, &second_order_cone_length,
+      &lorentz_cone_y_start_indices, &rotated_lorentz_cone_y_start_indices);
+  for (const int soc_length : second_order_cone_length) {
+    cones.push_back(clarabel::SecondOrderConeT<double>(soc_length));
+  }
+
+  internal::ParseExponentialConeConstraints(prog, &A_triplets, &b,
+                                            &A_row_count);
+  for (int i = 0; i < std::ssize(prog.exponential_cone_constraints()); ++i) {
+    cones.push_back(clarabel::ExponentialConeT<double>());
+  }
+
+  Eigen::SparseMatrix<double> P(num_x, num_x);
+  P.setFromTriplets(P_upper_triplets.begin(), P_upper_triplets.end());
+  Eigen::Map<Eigen::VectorXd> q_vec{q.data(), std::ssize(q)};
+  Eigen::SparseMatrix<double> A(A_row_count, num_x);
+  A.setFromTriplets(A_triplets.begin(), A_triplets.end());
+  const Eigen::Map<Eigen::VectorXd> b_vec{b.data(), std::ssize(b)};
+
+  clarabel::DefaultSettings<double> settings =
+      SetClarabelSettings(merged_options);
+
+  clarabel::DefaultSolver<double> solver(P, q_vec, A, b_vec, cones, settings);
+
+  solver.solve();
+  clarabel::DefaultSolution<double> solution = solver.solution();
+
+  // Now set the solution.
+  ClarabelSolverDetails& solver_details =
+      result->SetSolverDetailsType<ClarabelSolverDetails>();
+  SetSolverDetails(solution, &solver_details);
+
+  SolutionResult solution_result{SolutionResult::kSolutionResultNotSet};
+
+  result->set_x_val(
+      Eigen::Map<Eigen::VectorXd>(solution.x.data(), prog.num_vars()));
+  if (solution.status == clarabel::SolverStatus::Solved ||
+      solution.status == clarabel::SolverStatus::AlmostSolved) {
+    solution_result = SolutionResult::kSolutionFound;
+    result->set_optimal_cost(solution.obj_val + cost_constant);
+  } else if (solution.status == clarabel::SolverStatus::PrimalInfeasible ||
+             solution.status ==
+                 clarabel::SolverStatus::AlmostPrimalInfeasible) {
+    solution_result = SolutionResult::kInfeasibleConstraints;
+    result->set_optimal_cost(MathematicalProgram::kGlobalInfeasibleCost);
+  } else if (solution.status == clarabel::SolverStatus::DualInfeasible ||
+             solution.status == clarabel::SolverStatus::AlmostDualInfeasible) {
+    solution_result = SolutionResult::kDualInfeasible;
+    result->set_optimal_cost(MathematicalProgram::kUnboundedCost);
+  } else if (solution.status == clarabel::SolverStatus::MaxIterations) {
+    solution_result = SolutionResult::kIterationLimit;
+    result->set_optimal_cost(solution.obj_val + cost_constant);
+  } else {
+    drake::log()->info("Clarabel returns {}",
+                       SolverStatusToString(solution.status));
+    solution_result = SolutionResult::kSolverSpecificError;
+  }
+  result->set_solution_result(solution_result);
+}
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/clarabel_solver.h
+++ b/solvers/clarabel_solver.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/solvers/solver_base.h"
+
+namespace drake {
+namespace solvers {
+
+struct ClarabelSolverDetails {
+  /// The solve time inside Clarabel.
+  double solve_time;
+  /// Number of iterations in Clarabel.
+  int iterations;
+
+  // The status from Clarabel.
+  std::string status;
+};
+
+class ClarabelSolver final : public SolverBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ClarabelSolver)
+
+  /// Type of details stored in MathematicalProgramResult.
+  using Details = ClarabelSolverDetails;
+
+  ClarabelSolver();
+  ~ClarabelSolver() final;
+
+  /// @name Static versions of the instance methods with similar names.
+  //@{
+  static SolverId id();
+  static bool is_available();
+  static bool is_enabled();
+  static bool ProgramAttributesSatisfied(const MathematicalProgram&);
+  static std::string UnsatisfiedProgramAttributes(const MathematicalProgram&);
+  //@}
+
+  // A using-declaration adds these methods into our class's Doxygen.
+  using SolverBase::Solve;
+
+ private:
+  void DoSolve(const MathematicalProgram&, const Eigen::VectorXd&,
+               const SolverOptions&, MathematicalProgramResult*) const final;
+};
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/clarabel_solver_common.cc
+++ b/solvers/clarabel_solver_common.cc
@@ -1,0 +1,58 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/solvers/clarabel_solver.h"
+/* clang-format on */
+
+#include "drake/common/never_destroyed.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+ClarabelSolver::ClarabelSolver()
+    : SolverBase(id(), &is_available, &is_enabled, &ProgramAttributesSatisfied,
+                 &UnsatisfiedProgramAttributes) {}
+
+ClarabelSolver::~ClarabelSolver() = default;
+
+SolverId ClarabelSolver::id() {
+  static const never_destroyed<SolverId> singleton{"Clarabel"};
+  return singleton.access();
+}
+
+bool ClarabelSolver::is_enabled() {
+  return true;
+}
+
+namespace {
+// If the program is compatible with this solver, returns true and clears the
+// explanation.  Otherwise, returns false and sets the explanation.  In either
+// case, the explanation can be nullptr in which case it is ignored.
+bool CheckAttributes(const MathematicalProgram& prog,
+                     std::string* explanation) {
+  static const never_destroyed<ProgramAttributes> solver_capabilities(
+      std::initializer_list<ProgramAttribute>{
+          ProgramAttribute::kLinearEqualityConstraint,
+          ProgramAttribute::kLinearConstraint,
+          ProgramAttribute::kLorentzConeConstraint,
+          ProgramAttribute::kRotatedLorentzConeConstraint,
+          ProgramAttribute::kExponentialConeConstraint,
+          ProgramAttribute::kLinearCost, ProgramAttribute::kQuadraticCost});
+  return internal::CheckConvexSolverAttributes(
+      prog, solver_capabilities.access(), "ClarabelSolver", explanation);
+}
+}  // namespace
+
+bool ClarabelSolver::ProgramAttributesSatisfied(
+    const MathematicalProgram& prog) {
+  return CheckAttributes(prog, nullptr);
+}
+
+std::string ClarabelSolver::UnsatisfiedProgramAttributes(
+    const MathematicalProgram& prog) {
+  std::string explanation;
+  CheckAttributes(prog, &explanation);
+  return explanation;
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/no_clarabel.cc
+++ b/solvers/no_clarabel.cc
@@ -1,0 +1,21 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/solvers/clarabel_solver.h"
+/* clang-format on */
+
+#include <stdexcept>
+
+namespace drake {
+namespace solvers {
+bool ClarabelSolver::is_available() {
+  return false;
+}
+
+void ClarabelSolver::DoSolve(const MathematicalProgram&, const Eigen::VectorXd&,
+                             const SolverOptions&,
+                             MathematicalProgramResult*) const {
+  throw std::runtime_error(
+      "The Clarabel bindings were not compiled.  You'll need to use a "
+      "different solver.");
+}
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/scs_solver.cc
+++ b/solvers/scs_solver.cc
@@ -19,114 +19,13 @@
 #include "drake/common/text_logging.h"
 #include "drake/math/eigen_sparse_triplet.h"
 #include "drake/math/quadratic_form.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mathematical_program_result.h"
 
 namespace drake {
 namespace solvers {
 namespace {
-void ParseLinearCost(const MathematicalProgram& prog, std::vector<double>* c,
-                     double* constant) {
-  for (const auto& linear_cost : prog.linear_costs()) {
-    // Each linear cost is in the form of aᵀx + b
-    const auto& a = linear_cost.evaluator()->a();
-    const VectorXDecisionVariable& x = linear_cost.variables();
-    for (int i = 0; i < a.rows(); ++i) {
-      (*c)[prog.FindDecisionVariableIndex(x(i))] += a(i);
-    }
-    (*constant) += linear_cost.evaluator()->b();
-  }
-}
-
-// Add a rotated Lorentz cone constraint that A_cone * x + b_cone is in the
-// rotated Lorentz cone.
-// @param A_cone_triplets The triplets of non-zero entries in A_cone.
-// @param b_cone A_cone * x + b_cone is in the rotated Lorentz cone.
-// @param x_indices The index of the variable in SCS.
-// @param A_triplets[in/out] The non-zero entry triplet in A before and after
-// adding the Lorentz cone.
-// @param b[in/out] The right-hand side vector b before and after adding the
-// Lorentz cone.
-// @param A_row_count[in/out] The number of rows in A before and after adding
-// the Lorentz cone.
-// @param second_order_cone_length[in/out] The length of each Lorentz cone
-// before and after adding the Lorentz cone constraint.
-// @param rotated_lorentz_cone_y_start_indices[in/out] The starting index of y
-// corresponds to this rotated Lorentz cone. If set to nullopt, then we don't
-// modify rotated_lorentz_cone_y_start_indices.
-void ParseRotatedLorentzConeConstraint(
-    const std::vector<Eigen::Triplet<double>>& A_cone_triplets,
-    const Eigen::Ref<const Eigen::VectorXd>& b_cone,
-    const std::vector<int>& x_indices,
-    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
-    int* A_row_count, std::vector<int>* second_order_cone_length,
-    std::optional<std::vector<int>*> rotated_lorentz_cone_y_start_indices) {
-  // Our RotatedLorentzConeConstraint encodes that Ax + b is in the rotated
-  // Lorentz cone, namely
-  //  (a₀ᵀx + b₀) (a₁ᵀx + b₁) ≥ (a₂ᵀx + b₂)² + ... + (aₙ₋₁ᵀx + bₙ₋₁)²
-  //  (a₀ᵀx + b₀) ≥ 0
-  //  (a₁ᵀx + b₁) ≥ 0
-  // , where aᵢᵀ is the i'th row of A, bᵢ is the i'th row of b. Equivalently the
-  // vector
-  // [ 0.5(a₀ + a₁)ᵀx + 0.5(b₀ + b₁) ]
-  // [ 0.5(a₀ - a₁)ᵀx + 0.5(b₀ - b₁) ]
-  // [           a₂ᵀx +           b₂ ]
-  //             ...
-  // [         aₙ₋₁ᵀx +         bₙ₋₁ ]
-  // is in the Lorentz cone. We convert this to the SCS form, that
-  //  Cx + s = d
-  //  s in Lorentz cone,
-  // where C = [ -0.5(a₀ + a₁)ᵀ ]   d = [ 0.5(b₀ + b₁) ]
-  //           [ -0.5(a₀ - a₁)ᵀ ]       [ 0.5(b₀ - b₁) ]
-  //           [           -a₂ᵀ ]       [           b₂ ]
-  //                 ...                      ...
-  //           [         -aₙ₋₁ᵀ ]       [          bₙ₋₁]
-  for (const auto& Ai_triplet : A_cone_triplets) {
-    const int x_index = x_indices[Ai_triplet.col()];
-    if (Ai_triplet.row() == 0) {
-      A_triplets->emplace_back(*A_row_count, x_index,
-                               -0.5 * Ai_triplet.value());
-      A_triplets->emplace_back(*A_row_count + 1, x_index,
-                               -0.5 * Ai_triplet.value());
-    } else if (Ai_triplet.row() == 1) {
-      A_triplets->emplace_back(*A_row_count, x_index,
-                               -0.5 * Ai_triplet.value());
-      A_triplets->emplace_back(*A_row_count + 1, x_index,
-                               0.5 * Ai_triplet.value());
-    } else {
-      A_triplets->emplace_back(*A_row_count + Ai_triplet.row(), x_index,
-                               -Ai_triplet.value());
-    }
-  }
-  b->push_back(0.5 * (b_cone(0) + b_cone(1)));
-  b->push_back(0.5 * (b_cone(0) - b_cone(1)));
-  for (int i = 2; i < b_cone.rows(); ++i) {
-    b->push_back(b_cone(i));
-  }
-  if (rotated_lorentz_cone_y_start_indices.has_value()) {
-    rotated_lorentz_cone_y_start_indices.value()->push_back(*A_row_count);
-  }
-  *A_row_count += b_cone.rows();
-  second_order_cone_length->push_back(b_cone.rows());
-}
-
-void ParseQuadraticCost(const MathematicalProgram& prog,
-                        std::vector<Eigen::Triplet<double>>* P_upper_triplets,
-                        std::vector<double>* c, double* constant) {
-  for (const auto& cost : prog.quadratic_costs()) {
-    const auto var_indices = prog.FindDecisionVariableIndices(cost.variables());
-    for (int j = 0; j < cost.evaluator()->Q().cols(); ++j) {
-      for (int i = 0; i <= j; ++i) {
-        if (cost.evaluator()->Q()(i, j) != 0) {
-          P_upper_triplets->emplace_back(var_indices[i], var_indices[j],
-                                         cost.evaluator()->Q()(i, j));
-        }
-      }
-      (*c)[var_indices[j]] += cost.evaluator()->b()(j);
-    }
-    *constant += cost.evaluator()->c();
-  }
-}
 
 void ParseQuadraticCostWithRotatedLorentzCone(
     const MathematicalProgram& prog, std::vector<double>* c,
@@ -174,136 +73,12 @@ void ParseQuadraticCostWithRotatedLorentzCone(
     b_cone(0) = -cost.evaluator()->c();
     b_cone(1) = 2;
     // Add the rotated Lorentz cone constraint
-    ParseRotatedLorentzConeConstraint(Ai_triplets, b_cone, Ai_var_indices,
-                                      A_triplets, b, A_row_count,
-                                      second_order_cone_length, std::nullopt);
+    internal::ParseRotatedLorentzConeConstraint(
+        Ai_triplets, b_cone, Ai_var_indices, A_triplets, b, A_row_count,
+        second_order_cone_length, std::nullopt);
     // Add the cost y.
     c->push_back(1);
   }
-}
-
-void ParseLinearConstraint(const MathematicalProgram& prog,
-                           std::vector<Eigen::Triplet<double>>* A_triplets,
-                           std::vector<double>* b, int* A_row_count,
-                           ScsCone* cone,
-                           std::vector<std::vector<std::pair<int, int>>>*
-                               linear_constraint_dual_indices) {
-  // The linear constraint lb ≤ aᵀx ≤ ub is converted to
-  // -aᵀx + s1 = lb,
-  //  aᵀx + s2 = ub
-  // s1, s2 in the positive cone.
-  // The special cases are when ub = ∞ or lb = -∞.
-  // When ub = ∞, then we only add the constraint
-  // -aᵀx + s = lb, s in the positive cone.
-  // When lb = -∞, then we only add the constraint
-  // aᵀx + s = ub, s in the positive cone.
-  int num_linear_constraint_rows = 0;
-  linear_constraint_dual_indices->reserve(prog.linear_constraints().size());
-  for (const auto& linear_constraint : prog.linear_constraints()) {
-    linear_constraint_dual_indices->emplace_back(
-        linear_constraint.evaluator()->num_constraints());
-    const Eigen::VectorXd& ub = linear_constraint.evaluator()->upper_bound();
-    const Eigen::VectorXd& lb = linear_constraint.evaluator()->lower_bound();
-    const VectorXDecisionVariable& x = linear_constraint.variables();
-    const Eigen::SparseMatrix<double>& Ai =
-        linear_constraint.evaluator()->get_sparse_A();
-    // We store the starting row index in A_triplets for each row of
-    // linear_constraint. Namely the constraint lb(i) <= A.row(i)*x <= ub(i) is
-    // stored in A_triplets with starting_row_indices[i] (or
-    // starting_row_indices[i]+1 if both lb(i) and ub(i) are finite).
-    std::vector<int> starting_row_indices(
-        linear_constraint.evaluator()->num_constraints());
-    for (int i = 0; i < linear_constraint.evaluator()->num_constraints(); ++i) {
-      const bool needs_ub{!std::isinf(ub(i))};
-      const bool needs_lb{!std::isinf(lb(i))};
-      auto& dual_index = linear_constraint_dual_indices->back()[i];
-      // Use -1 to indicate the constraint bound is infinity.
-      dual_index.first = -1;
-      dual_index.second = -1;
-      if (!needs_ub && !needs_lb) {
-        // We use -1 to indicate that we won't add linear constraint when both
-        // bounds are infinity.
-        starting_row_indices[i] = -1;
-      } else {
-        starting_row_indices[i] = *A_row_count + num_linear_constraint_rows;
-        // We first add the constraint for lower bound, and then add the
-        // constraint for upper bound. This is consistent with the loop below
-        // when we modify A_triplets.
-        if (needs_lb) {
-          b->push_back(-lb(i));
-          dual_index.first = *A_row_count + num_linear_constraint_rows;
-          num_linear_constraint_rows++;
-        }
-        if (needs_ub) {
-          b->push_back(ub(i));
-          dual_index.second = *A_row_count + num_linear_constraint_rows;
-          num_linear_constraint_rows++;
-        }
-      }
-    }
-    for (int j = 0; j < Ai.cols(); ++j) {
-      const int xj_index = prog.FindDecisionVariableIndex(x(j));
-      for (Eigen::SparseMatrix<double>::InnerIterator it(Ai, j); it; ++it) {
-        const int Ai_row_count = it.row();
-        const bool needs_ub{!std::isinf(ub(Ai_row_count))};
-        const bool needs_lb{!std::isinf(lb(Ai_row_count))};
-        if (!needs_lb && !needs_ub) {
-          continue;
-        }
-        int row_index = starting_row_indices[Ai_row_count];
-        if (needs_lb) {
-          // If lb != -∞, then the constraint -aᵀx + s = lb will be added to
-          // the matrix A, in the row row_index.
-          A_triplets->emplace_back(row_index, xj_index, -it.value());
-          ++row_index;
-        }
-        if (needs_ub) {
-          // If ub != ∞, then the constraint aᵀx + s = ub will be added to the
-          // matrix A, in the row row_index.
-          A_triplets->emplace_back(row_index, xj_index, it.value());
-        }
-      }
-    }
-  }
-  *A_row_count += num_linear_constraint_rows;
-  cone->l += num_linear_constraint_rows;
-}
-
-void ParseLinearEqualityConstraint(
-    const MathematicalProgram& prog,
-    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
-    int* A_row_count, ScsCone* cone,
-    std::vector<int>* linear_eq_y_start_indices) {
-  int num_linear_equality_constraints_rows = 0;
-  linear_eq_y_start_indices->reserve(prog.linear_equality_constraints().size());
-  // The linear equality constraint A x = b is converted to
-  // A x + s = b. s in zero cone.
-  for (const auto& linear_equality_constraint :
-       prog.linear_equality_constraints()) {
-    const Eigen::SparseMatrix<double>& Ai =
-        linear_equality_constraint.evaluator()->get_sparse_A();
-    const std::vector<Eigen::Triplet<double>> Ai_triplets =
-        math::SparseMatrixToTriplets(Ai);
-    A_triplets->reserve(A_triplets->size() + Ai_triplets.size());
-    const solvers::VectorXDecisionVariable& x =
-        linear_equality_constraint.variables();
-    // x_indices[i] is the index of x(i)
-    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
-    for (const auto& Ai_triplet : Ai_triplets) {
-      A_triplets->emplace_back(Ai_triplet.row() + *A_row_count,
-                               x_indices[Ai_triplet.col()], Ai_triplet.value());
-    }
-    const int num_Ai_rows =
-        linear_equality_constraint.evaluator()->num_constraints();
-    b->reserve(b->size() + num_Ai_rows);
-    for (int i = 0; i < num_Ai_rows; ++i) {
-      b->push_back(linear_equality_constraint.evaluator()->lower_bound()(i));
-    }
-    linear_eq_y_start_indices->push_back(*A_row_count);
-    *A_row_count += num_Ai_rows;
-    num_linear_equality_constraints_rows += num_Ai_rows;
-  }
-  cone->z += num_linear_equality_constraints_rows;
 }
 
 void ParseBoundingBoxConstraint(
@@ -350,57 +125,6 @@ void ParseBoundingBoxConstraint(
     num_bounding_box_constraint_rows += num_scs_new_constraint;
   }
   cone->l += num_bounding_box_constraint_rows;
-}
-
-void ParseSecondOrderConeConstraints(
-    const MathematicalProgram& prog,
-    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
-    int* A_row_count, std::vector<int>* second_order_cone_length,
-    std::vector<int>* lorentz_cone_y_start_indices,
-    std::vector<int>* rotated_lorentz_cone_y_start_indices) {
-  // Our LorentzConeConstraint encodes that Ax + b is in Lorentz cone. We
-  // convert this to SCS form, as -Ax + s = b, s in Lorentz cone.
-  second_order_cone_length->reserve(
-      prog.lorentz_cone_constraints().size() +
-      prog.rotated_lorentz_cone_constraints().size());
-  lorentz_cone_y_start_indices->reserve(prog.lorentz_cone_constraints().size());
-  rotated_lorentz_cone_y_start_indices->reserve(
-      prog.rotated_lorentz_cone_constraints().size());
-  for (const auto& lorentz_cone_constraint : prog.lorentz_cone_constraints()) {
-    // x_indices[i] is the index of x(i)
-    const VectorXDecisionVariable& x = lorentz_cone_constraint.variables();
-    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
-    const Eigen::SparseMatrix<double> Ai =
-        lorentz_cone_constraint.evaluator()->A();
-    const std::vector<Eigen::Triplet<double>> Ai_triplets =
-        math::SparseMatrixToTriplets(Ai);
-    for (const auto& Ai_triplet : Ai_triplets) {
-      A_triplets->emplace_back(Ai_triplet.row() + *A_row_count,
-                               x_indices[Ai_triplet.col()],
-                               -Ai_triplet.value());
-    }
-    const int num_Ai_rows = lorentz_cone_constraint.evaluator()->A().rows();
-    for (int i = 0; i < num_Ai_rows; ++i) {
-      b->push_back(lorentz_cone_constraint.evaluator()->b()(i));
-    }
-    second_order_cone_length->push_back(num_Ai_rows);
-    lorentz_cone_y_start_indices->push_back(*A_row_count);
-    *A_row_count += num_Ai_rows;
-  }
-
-  for (const auto& rotated_lorentz_cone :
-       prog.rotated_lorentz_cone_constraints()) {
-    const VectorXDecisionVariable& x = rotated_lorentz_cone.variables();
-    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
-    const Eigen::SparseMatrix<double> Ai =
-        rotated_lorentz_cone.evaluator()->A();
-    const Eigen::VectorXd& bi = rotated_lorentz_cone.evaluator()->b();
-    const std::vector<Eigen::Triplet<double>> Ai_triplets =
-        math::SparseMatrixToTriplets(Ai);
-    ParseRotatedLorentzConeConstraint(Ai_triplets, bi, x_indices, A_triplets, b,
-                                      A_row_count, second_order_cone_length,
-                                      rotated_lorentz_cone_y_start_indices);
-  }
 }
 
 // This function parses both PositiveSemidefinite and
@@ -500,45 +224,6 @@ void ParsePositiveSemidefiniteConstraint(
   cone->s = static_cast<scs_int*>(scs_calloc(cone->ssize, sizeof(scs_int)));
   for (int i = 0; i < cone->ssize; ++i) {
     cone->s[i] = psd_cone_length[i];
-  }
-}
-
-void ParseExponentialConeConstraint(
-    const MathematicalProgram& prog,
-    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
-    int* A_row_count, ScsCone* cone) {
-  cone->ep = static_cast<int>(prog.exponential_cone_constraints().size());
-  for (const auto& binding : prog.exponential_cone_constraints()) {
-    // drake::solvers::ExponentialConstraint enforces that z = A * x + b is in
-    // the exponential cone (z₀ ≥ z₁*exp(z₂ / z₁)). This is different from the
-    // exponential cone used in SCS. In SCS, a vector s is in the exponential
-    // cone, if s₂≥ s₁*exp(s₀ / s₁). To transform drake's Exponential cone to
-    // SCS's exponential cone, we use
-    // -[A.row(2); A.row(1); A.row(0)] * x + s = [b(2); b(1); b(0)], and s is
-    // in SCS's exponential cone, where A = binding.evaluator()->A(), b =
-    // binding.evaluator()->b().
-    const int num_bound_variables = binding.variables().rows();
-    for (int i = 0; i < num_bound_variables; ++i) {
-      A_triplets->reserve(A_triplets->size() +
-                          binding.evaluator()->A().nonZeros());
-      const int decision_variable_index =
-          prog.FindDecisionVariableIndex(binding.variables()(i));
-      for (Eigen::SparseMatrix<double>::InnerIterator it(
-               binding.evaluator()->A(), i);
-           it; ++it) {
-        // 2 - it.row() is used for reverse the row order, as mentioned in the
-        // function documentation above.
-        A_triplets->emplace_back(*A_row_count + 2 - it.row(),
-                                 decision_variable_index, -it.value());
-      }
-    }
-    // The exponential cone constraint is on a 3 x 1 vector, hence for each
-    // ExponentialConeConstraint, we append 3 rows to A and b.
-    b->reserve(b->size() + 3);
-    for (int i = 0; i < 3; ++i) {
-      b->push_back(binding.evaluator()->b()(2 - i));
-    }
-    *A_row_count += 3;
   }
 }
 
@@ -972,7 +657,7 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
   double cost_constant{0};
 
   // Parse linear cost
-  ParseLinearCost(prog, &c, &cost_constant);
+  internal::ParseLinearCosts(prog, &c, &cost_constant);
 
   // Parse linear equality constraint
   // linear_eq_y_start_indices[i] is the starting index of the dual
@@ -984,8 +669,11 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
   // prog.linear_equality_constraint()(i), where y is the vector containing all
   // dual variables.
   std::vector<int> linear_eq_y_start_indices;
-  ParseLinearEqualityConstraint(prog, &A_triplets, &b, &A_row_count, cone,
-                                &linear_eq_y_start_indices);
+  int num_linear_equality_constraints_rows;
+  internal::ParseLinearEqualityConstraints(
+      prog, &A_triplets, &b, &A_row_count, &linear_eq_y_start_indices,
+      &num_linear_equality_constraints_rows);
+  cone->z += num_linear_equality_constraints_rows;
 
   // Parse bounding box constraint
   // bbcon_dual_indices[i][j][0]/bbcon_dual_indices[i][j][1] is the dual
@@ -1002,8 +690,11 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
   // linear constraint prog.linear_constraint()[i], we use -1 to indicate that
   // the lower or upper bound is infinity.
   std::vector<std::vector<std::pair<int, int>>> linear_constraint_dual_indices;
-  ParseLinearConstraint(prog, &A_triplets, &b, &A_row_count, cone,
-                        &linear_constraint_dual_indices);
+  int num_linear_constraint_rows = 0;
+  internal::ParseLinearConstraints(prog, &A_triplets, &b, &A_row_count,
+                                   &linear_constraint_dual_indices,
+                                   &num_linear_constraint_rows);
+  cone->l += num_linear_constraint_rows;
 
   // Parse Lorentz cone and rotated Lorentz cone constraint
   std::vector<int> second_order_cone_length;
@@ -1021,7 +712,7 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
   // transformation on the y variable to get the dual variable in the dual cone
   // of rotated Lorentz cone.
   std::vector<int> rotated_lorentz_cone_y_start_indices;
-  ParseSecondOrderConeConstraints(
+  internal::ParseSecondOrderConeConstraints(
       prog, &A_triplets, &b, &A_row_count, &second_order_cone_length,
       &lorentz_cone_y_start_indices, &rotated_lorentz_cone_y_start_indices);
 
@@ -1043,7 +734,7 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
                                              &A_row_count,
                                              &second_order_cone_length, &num_x);
   } else {
-    ParseQuadraticCost(prog, &P_upper_triplets, &c, &cost_constant);
+    internal::ParseQuadraticCosts(prog, &P_upper_triplets, &c, &cost_constant);
   }
 
   // Set the lorentz cone length in the SCS cone.
@@ -1058,7 +749,9 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
                                       cone);
 
   // Parse ExponentialConeConstraint.
-  ParseExponentialConeConstraint(prog, &A_triplets, &b, &A_row_count, cone);
+  internal::ParseExponentialConeConstraints(prog, &A_triplets, &b,
+                                            &A_row_count);
+  cone->ep = static_cast<int>(prog.exponential_cone_constraints().size());
 
   Eigen::SparseMatrix<double> A(A_row_count, num_x);
   A.setFromTriplets(A_triplets.begin(), A_triplets.end());

--- a/solvers/test/clarabel_solver_test.cc
+++ b/solvers/test/clarabel_solver_test.cc
@@ -1,0 +1,293 @@
+#include "drake/solvers/clarabel_solver.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/test/exponential_cone_program_examples.h"
+#include "drake/solvers/test/linear_program_examples.h"
+#include "drake/solvers/test/mathematical_program_test_util.h"
+#include "drake/solvers/test/quadratic_program_examples.h"
+#include "drake/solvers/test/second_order_cone_program_examples.h"
+#include "drake/solvers/test/semidefinite_program_examples.h"
+#include "drake/solvers/test/sos_examples.h"
+
+namespace drake {
+namespace solvers {
+namespace test {
+const double kTol = 1E-5;
+GTEST_TEST(LinearProgramTest, Test0) {
+  // Test a linear program with only equality constraint.
+  // min x(0) + 2 * x(1)
+  // s.t x(0) + x(1) = 2
+  // The problem is unbounded.
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<2>("x");
+  prog.AddLinearCost(x(0) + 2 * x(1));
+  prog.AddLinearConstraint(x(0) + x(1) == 2);
+  ClarabelSolver solver;
+  if (solver.available()) {
+    auto result = solver.Solve(prog, {}, {});
+    EXPECT_EQ(result.get_solution_result(), SolutionResult::kDualInfeasible);
+  }
+
+  // Now add the constraint x(1) <= 1. The problem is
+  // min x(0) + 2 * x(1)
+  // s.t x(0) + x(1) = 2
+  //     x(1) <= 1
+  // the problem should still be unbounded.
+  prog.AddBoundingBoxConstraint(-std::numeric_limits<double>::infinity(), 1,
+                                x(1));
+  if (solver.available()) {
+    auto result = solver.Solve(prog, {}, {});
+    EXPECT_EQ(result.get_solution_result(), SolutionResult::kDualInfeasible);
+  }
+
+  // Now add the constraint x(0) <= 5. The problem is
+  // min x(0) + 2x(1)
+  // s.t x(0) + x(1) = 2
+  //     x(1) <= 1
+  //     x(0) <= 5
+  // the problem should be feasible. The optimal cost is -1, with x = (5, -3)
+  prog.AddBoundingBoxConstraint(-std::numeric_limits<double>::infinity(), 5,
+                                x(0));
+  if (solver.available()) {
+    auto result = solver.Solve(prog, {}, {});
+    EXPECT_TRUE(result.is_success());
+    EXPECT_NEAR(result.get_optimal_cost(), -1, kTol);
+    const Eigen::Vector2d x_expected(5, -3);
+    EXPECT_TRUE(CompareMatrices(result.GetSolution(x), x_expected, kTol,
+                                MatrixCompareType::absolute));
+  }
+
+  // Now change the cost to 3x(0) - x(1) + 5, and add the constraint 2 <= x(0)
+  // The problem is
+  // min 3x(0) - x(1) + 5
+  // s.t x(0) + x(1) = 2
+  //     2 <= x(0) <= 5
+  //          x(1) <= 1
+  // The optimal cost is 11, the optimal solution is x = (2, 0)
+  prog.AddLinearCost(2 * x(0) - 3 * x(1) + 5);
+  prog.AddBoundingBoxConstraint(2, 6, x(0));
+  if (solver.available()) {
+    auto result = solver.Solve(prog, {}, {});
+    EXPECT_TRUE(result.is_success());
+    EXPECT_NEAR(result.get_optimal_cost(), 11, kTol);
+    const Eigen::Vector2d x_expected(2, 0);
+    EXPECT_TRUE(CompareMatrices(result.GetSolution(x), x_expected, kTol,
+                                MatrixCompareType::absolute));
+  }
+}
+
+GTEST_TEST(LinearProgramTest, Test1) {
+  // Test a linear program with only equality constraints
+  // min x(0) + 2 * x(1)
+  // s.t x(0) + x(1) = 1
+  //     2x(0) + x(1) = 2
+  //     x(0) - 2x(1) = 3
+  // This problem is infeasible.
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<2>("x");
+  prog.AddLinearCost(x(0) + 2 * x(1));
+  prog.AddLinearEqualityConstraint(x(0) + x(1) == 1 && 2 * x(0) + x(1) == 2);
+  prog.AddLinearEqualityConstraint(x(0) - 2 * x(1) == 3);
+  ClarabelSolver clarabel_solver;
+  if (clarabel_solver.available()) {
+    auto result = clarabel_solver.Solve(prog, {}, {});
+    EXPECT_EQ(result.get_solution_result(),
+              SolutionResult::kInfeasibleConstraints);
+  }
+}
+
+GTEST_TEST(LinearProgramTest, Test2) {
+  // Test a linear program with bounding box, linear equality and inequality
+  // constraints
+  // min x(0) + 2 * x(1) + 3 * x(2) + 2
+  // s.t  x(0) + x(1) = 2
+  //      x(0) + 2x(2) = 3
+  //      -2 <= x(0) + 4x(1) <= 10
+  //      -5 <= x(1) + 2x(2) <= 9
+  //      -x(0) + 2x(2) <= 7
+  //      -x(1) + 3x(2) >= -10
+  //       x(0) <= 10
+  //      1 <= x(2) <= 9
+  // The optimal cost is 8, with x = (1, 1, 1)
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<3>();
+  prog.AddLinearCost(x(0) + 2 * x(1) + 3 * x(2) + 2);
+  prog.AddLinearEqualityConstraint(x(0) + x(1) == 2 && x(0) + 2 * x(2) == 3);
+  Eigen::Matrix<double, 3, 3> A;
+  // clang-format off
+  A << 1, 4, 0,
+       0, 1, 2,
+       -1, 0, 2;
+  // clang-format on
+  prog.AddLinearConstraint(
+      A, Eigen::Vector3d(-2, -5, -std::numeric_limits<double>::infinity()),
+      Eigen::Vector3d(10, 9, 7), x);
+  prog.AddLinearConstraint(-x(1) + 3 * x(2) >= -10);
+  prog.AddBoundingBoxConstraint(-std::numeric_limits<double>::infinity(), 10,
+                                x(0));
+  prog.AddBoundingBoxConstraint(1, 9, x(2));
+
+  ClarabelSolver clarabel_solver;
+  if (clarabel_solver.available()) {
+    auto result = clarabel_solver.Solve(prog, {}, {});
+    EXPECT_TRUE(result.is_success());
+    EXPECT_NEAR(result.get_optimal_cost(), 8, kTol);
+    EXPECT_TRUE(CompareMatrices(result.GetSolution(x), Eigen::Vector3d(1, 1, 1),
+                                kTol, MatrixCompareType::absolute));
+  }
+}
+
+TEST_P(LinearProgramTest, TestLP) {
+  ClarabelSolver solver;
+  prob()->RunProblem(&solver);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ClarabelTest, LinearProgramTest,
+    ::testing::Combine(::testing::ValuesIn(linear_cost_form()),
+                       ::testing::ValuesIn(linear_constraint_form()),
+                       ::testing::ValuesIn(linear_problems())));
+
+TEST_F(InfeasibleLinearProgramTest0, TestInfeasible) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    auto result = solver.Solve(*prog_, {}, {});
+    EXPECT_EQ(result.get_solution_result(),
+              SolutionResult::kInfeasibleConstraints);
+    EXPECT_EQ(result.get_optimal_cost(),
+              MathematicalProgram::kGlobalInfeasibleCost);
+  }
+}
+
+TEST_F(UnboundedLinearProgramTest0, TestUnbounded) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    auto result = solver.Solve(*prog_, {}, {});
+    EXPECT_EQ(result.get_solution_result(), SolutionResult::kDualInfeasible);
+    EXPECT_EQ(result.get_optimal_cost(), MathematicalProgram::kUnboundedCost);
+    EXPECT_TRUE(result.GetSolution(prog_->decision_variables())
+                    .array()
+                    .isFinite()
+                    .all());
+  }
+}
+
+TEST_F(DuplicatedVariableLinearProgramTest1, Test) {
+  ClarabelSolver solver;
+  if (solver.is_available()) {
+    CheckSolution(solver, std::nullopt, kTol);
+  }
+}
+
+TEST_P(QuadraticProgramTest, TestQP) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    prob()->RunProblem(&solver);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ClarabelTest, QuadraticProgramTest,
+    ::testing::Combine(::testing::ValuesIn(quadratic_cost_form()),
+                       ::testing::ValuesIn(linear_constraint_form()),
+                       ::testing::ValuesIn(quadratic_problems())));
+
+GTEST_TEST(QPtest, TestUnitBallExample) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    TestQPonUnitBallExample(solver);
+  }
+}
+
+GTEST_TEST(TestDuplicatedVariableQuadraticProgram, Test) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    TestDuplicatedVariableQuadraticProgram(solver, 1E-5);
+  }
+}
+
+TEST_P(TestEllipsoidsSeparation, TestSOCP) {
+  ClarabelSolver clarabel_solver;
+  if (clarabel_solver.available()) {
+    SolveAndCheckSolution(clarabel_solver, {}, kTol);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ClarabelTest, TestEllipsoidsSeparation,
+    ::testing::ValuesIn(GetEllipsoidsSeparationProblems()));
+
+TEST_P(TestQPasSOCP, TestSOCP) {
+  ClarabelSolver clarabel_solver;
+  if (clarabel_solver.available()) {
+    SolveAndCheckSolution(clarabel_solver, kTol);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ClarabelTest, TestQPasSOCP,
+                         ::testing::ValuesIn(GetQPasSOCPProblems()));
+
+TEST_P(TestFindSpringEquilibrium, TestSOCP) {
+  ClarabelSolver clarabel_solver;
+  if (clarabel_solver.available()) {
+    SolveAndCheckSolution(clarabel_solver, {}, 3E-4);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ClarabelTest, TestFindSpringEquilibrium,
+    ::testing::ValuesIn(GetFindSpringEquilibriumProblems()));
+
+GTEST_TEST(TestSOCP, MaximizeGeometricMeanTrivialProblem1) {
+  MaximizeGeometricMeanTrivialProblem1 prob;
+  ClarabelSolver solver;
+  if (solver.available()) {
+    const auto result = solver.Solve(prob.prog(), {}, {});
+    // Practically I observe Clarabel requires looser tolerance for this test. I
+    // don't know why.
+    prob.CheckSolution(result, 3 * kTol);
+  }
+}
+
+GTEST_TEST(TestSOCP, MaximizeGeometricMeanTrivialProblem2) {
+  MaximizeGeometricMeanTrivialProblem2 prob;
+  ClarabelSolver solver;
+  if (solver.available()) {
+    const auto result = solver.Solve(prob.prog(), {}, {});
+    prob.CheckSolution(result, kTol);
+  }
+}
+
+GTEST_TEST(TestSOCP, SmallestEllipsoidCoveringProblem) {
+  ClarabelSolver solver;
+  SolveAndCheckSmallestEllipsoidCoveringProblems(solver, {}, kTol);
+}
+
+GTEST_TEST(TestExponentialConeProgram, ExponentialConeTrivialExample) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    // Currently we don't support retrieving dual solution from SCS yet.
+    ExponentialConeTrivialExample(solver, 2E-4, false);
+  }
+}
+
+GTEST_TEST(TestExponentialConeProgram, MinimizeKLDivengence) {
+  ClarabelSolver clarabel_solver;
+  if (clarabel_solver.available()) {
+    MinimizeKLDivergence(clarabel_solver, 1E-4);
+  }
+}
+
+// GTEST_TEST(TestExponentialConeProgram, MinimalEllipsoidConveringPoints) {
+//   ClarabelSolver clarabel_solver;
+//   if (clarabel_solver.available()) {
+//     MinimalEllipsoidCoveringPoints(clarabel_solver, 1E-4);
+//   }
+// }
+
+}  // namespace test
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/optimization_examples.cc
+++ b/solvers/test/optimization_examples.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/solvers/clarabel_solver.h"
 #include "drake/solvers/clp_solver.h"
 #include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/ipopt_solver.h"
@@ -151,6 +152,9 @@ double OptimizationProgram::GetSolverSolutionDefaultCompareTolerance(
   }
   if (solver_id == ScsSolver::id()) {
     return 1E-3;  // Scs is not very accurate.
+  }
+  if (solver_id == ClarabelSolver::id()) {
+    return 1E-5;
   }
   throw std::runtime_error("Unsupported solver type.");
 }


### PR DESCRIPTION
Currently ClarabelSolver can support LP, QP, SOCP, exponential cone constraints. It is not used in ChooseBestSolver yet, so the user will have to instantiate ClarabelSolver manually. Also we have not added the support on SDP yet. These will be included in the follow-up PRs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20314)
<!-- Reviewable:end -->
