### PR TITLE
[wheel] Save time by not compressing drake-src

### DIFF
--- a/tools/wheel/Dockerfile
+++ b/tools/wheel/Dockerfile
@@ -44,7 +44,7 @@ RUN /image/provision-python.sh ${PYTHON} ${PYTHON_SHA}
 
 ADD image/build-drake.sh /image/
 ADD image/pip-drake.patch /image/
-ADD image/drake-src.tar.xz /opt/drake-wheel-build/drake/
+ADD image/drake-src.tar /opt/drake-wheel-build/drake/
 
 # -----------------------------------------------------------------------------
 # Build the Drake wheel.

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -139,7 +139,7 @@ def _create_source_tar(path):
     Creates a tarball of the repository working tree.
     """
     print('[-] Creating source archive', end='', flush=True)
-    out = tarfile.open(path, 'w:xz')
+    out = tarfile.open(path, 'w')
 
     # Add an rcfile that's compatible with our Dockerfile base.
     rc_lines = [
@@ -337,7 +337,7 @@ def build(options):
     identifier = f'{time}-{salt}'
 
     # Generate the repository source archive.
-    source_tar = os.path.join(resource_root, 'image', 'drake-src.tar.xz')
+    source_tar = os.path.join(resource_root, 'image', 'drake-src.tar')
     _files_to_remove.append(source_tar)
     _create_source_tar(source_tar)
 


### PR DESCRIPTION
It wastes about 15 seconds to compress the source tree every time, but the compression cannot be reused from one run to the next. Iterative local testing is much more pleasant without compressing, and there's no downside even for Jenkins builds.

+@mwoehlke-kitware for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20315)
<!-- Reviewable:end -->
