### PR TITLE
[tools] Nerf the symbol visibility test when Clarabel is enabled

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -242,12 +242,23 @@ drake_cc_googletest(
     ],
 )
 
+# The exported_symbols_test is skipped in some build configurations.
+selects.config_setting_group(
+    name = "skip_exported_symbols_test",
+    match_any = [
+        # Debug builds have a lot more symbols (no dead code elimination) so
+        # are too much work to tidy up.
+        "//tools/cc_toolchain:debug",
+        # Rust symbols (from Clarabel) have the wrong visibility; this is a
+        # known issue with a TODO in the Clarabel BUILD file.
+        "//tools:with_clarabel",
+    ],
+)
+
 drake_py_unittest(
     name = "exported_symbols_test",
-    args = select({
-        # Don't run the test on Debug builds. They have a lot more symbols
-        # (no dead code elimination) so are too much work to tidy up.
-        "//tools/cc_toolchain:debug": ["--help"],
+    args = selects.with_or({
+        ":skip_exported_symbols_test": ["--help"],
         "//conditions:default": [],
     }),
     data = [

--- a/tools/workspace/clarabel_cpp_internal/package.BUILD.bazel
+++ b/tools/workspace/clarabel_cpp_internal/package.BUILD.bazel
@@ -40,3 +40,7 @@ cc_library(
 
 # TODO(jwnimmer-tri) Prior to using Clarabel as part of libdrake.so, we'll need
 # to add the license-install rule here.
+
+# TODO(jwnimmer-tri) Prior to using Clarabel as part of libdrake.so, we'll need
+# to un-nerf exported_symbols_test when Clarabel is enabled (and figure out how
+# to set Rust code to use hidden visibility).


### PR DESCRIPTION
\CC @hongkai-dai per https://github.com/RobotLocomotion/drake/pull/20314#pullrequestreview-1660255664.

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20318)
<!-- Reviewable:end -->
