### PR TITLE
Work around test error in coverage builds (kcov 339)

### DIFF
--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -15,6 +15,7 @@ namespace drake {
 namespace examples {
 namespace multibody {
 namespace cylinder_with_multicontact {
+inline namespace kcov339_avoidance_magic {
 namespace {
 
 DEFINE_double(target_realtime_rate, 0.5,
@@ -114,6 +115,7 @@ int do_main() {
 }
 
 }  // namespace
+}  // inline namespace kcov339_avoidance_magic
 }  // namespace cylinder_with_multicontact
 }  // namespace multibody
 }  // namespace examples


### PR DESCRIPTION
Add a dummy namespace to perturb the elf header.

Failing builds:
https://drake-jenkins.csail.mit.edu/view/Production/job/linux-focal-gcc-bazel-nightly-coverage/1235/
https://drake-jenkins.csail.mit.edu/view/Production/job/linux-focal-gcc-bazel-weekly-everything-coverage/76/
https://drake-jenkins.csail.mit.edu/view/Production/job/linux-focal-gcc-bazel-weekly-gurobi-coverage/132/
https://drake-jenkins.csail.mit.edu/view/Production/job/linux-focal-gcc-bazel-weekly-mosek-coverage/131/
https://drake-jenkins.csail.mit.edu/view/Production/job/linux-focal-gcc-bazel-weekly-snopt-coverage/132/

Prior examples: https://github.com/RobotLocomotion/drake/issues/17978#issuecomment-1258200209

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20328)
<!-- Reviewable:end -->
