### PR TITLE
[geometry] Fix clang warning in render_mesh

### DIFF
--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -319,7 +319,7 @@ vector<RenderMesh> LoadRenderMeshesFromObj(
     mesh_data.positions.resize(vertex_count, 3);
     mesh_data.normals.resize(vertex_count, 3);
     mesh_data.uvs.resize(vertex_count, 2);
-    for (const auto [full_index, part_index] : vertex_index_full_to_part) {
+    for (const auto& [full_index, part_index] : vertex_index_full_to_part) {
       mesh_data.positions.row(part_index) = positions[full_index];
       mesh_data.normals.row(part_index) = normals[full_index];
       mesh_data.uvs.row(part_index) = uvs[full_index];


### PR DESCRIPTION
`error: loop variable '[full_index, part_index]' creates a copy from type 'std::pair<const int, unsigned int> const' [-Werror,-Wrange-loop-construct]`

+@SeanCurtis-TRI for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20332)
<!-- Reviewable:end -->
