### PR TITLE
Add python binding for AffineSubspace::OrthogonalComplementBasis.

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -154,7 +154,10 @@ void DefineGeometryOptimization(py::module m) {
         .def("ContainedIn", &AffineSubspace::ContainedIn, py::arg("other"),
             py::arg("tol") = 1e-15, cls_doc.ContainedIn.doc)
         .def("IsNearlyEqualTo", &AffineSubspace::IsNearlyEqualTo,
-            py::arg("other"), py::arg("tol") = 1e-15, cls_doc.ContainedIn.doc);
+            py::arg("other"), py::arg("tol") = 1e-15, cls_doc.ContainedIn.doc)
+        .def("OrthogonalComplementBasis",
+            &AffineSubspace::OrthogonalComplementBasis,
+            cls_doc.OrthogonalComplementBasis.doc);
     DefClone(&cls);
   }
 

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -89,6 +89,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertTrue(dut.PointInSet(dut.MaybeGetFeasiblePoint()))
         self.assertTrue(dut.IntersectsWith(dut))
         self.assertEqual(dut.AffineDimension(), 2)
+        complement_basis = dut.OrthogonalComplementBasis()
+        self.assertEqual(complement_basis.shape, (3, 1))
 
         test_point = np.array([43, 43, 0])
         self.assertFalse(dut.PointInSet(test_point))


### PR DESCRIPTION
I added this method in #19975, but realized today I hadn't made a python binding for it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20341)
<!-- Reviewable:end -->
