### PR TITLE
Tests for AffineSubspace::CalcVolume.

### DIFF
--- a/geometry/optimization/affine_subspace.cc
+++ b/geometry/optimization/affine_subspace.cc
@@ -204,10 +204,10 @@ AffineSubspace::DoToShapeWithPose() const {
 }
 
 double AffineSubspace::DoCalcVolume() const {
-  if (ambient_dimension() == 0 || AffineDimension() < ambient_dimension()) {
-    // An AffineSubspace has zero volume if it is zero dimensional or has a
-    // lower affine dimension than its ambient space. Otherwise, it represents
-    // the whole ambient space, and has infinite volume."
+  if (AffineDimension() < ambient_dimension()) {
+    // An AffineSubspace has zero volume if it has a lower affine dimension than
+    // its ambient space. Otherwise, it represents the whole ambient space, and
+    // has infinite volume."
     return 0;
   }
   return std::numeric_limits<double>::infinity();

--- a/geometry/optimization/test/affine_subspace_test.cc
+++ b/geometry/optimization/test/affine_subspace_test.cc
@@ -59,6 +59,8 @@ GTEST_TEST(AffineSubspaceTest, DefaultCtor) {
   EXPECT_TRUE(dut.ContainedIn(AffineSubspace()));
   EXPECT_TRUE(dut.IsNearlyEqualTo(AffineSubspace()));
   CheckOrthogonalComplementBasis(dut);
+  EXPECT_TRUE(dut.has_exact_volume());
+  EXPECT_THROW(dut.CalcVolume(), std::exception);
 }
 
 GTEST_TEST(AffineSubspaceTest, Point) {
@@ -82,6 +84,7 @@ GTEST_TEST(AffineSubspaceTest, Point) {
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3))));
   CheckOrthogonalComplementBasis(as);
+  EXPECT_EQ(as.CalcVolume(), 0);
 
   // Should throw because the ambient dimension is wrong.
   EXPECT_THROW(as.Project(Eigen::VectorXd::Zero(1)), std::exception);
@@ -128,6 +131,7 @@ GTEST_TEST(AffineSubspaceTest, Line) {
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3)), kTol));
   CheckOrthogonalComplementBasis(as);
+  EXPECT_EQ(as.CalcVolume(), 0);
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 1);
@@ -179,6 +183,7 @@ GTEST_TEST(AffineSubspaceTest, Plane) {
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3))));
   CheckOrthogonalComplementBasis(as);
+  EXPECT_EQ(as.CalcVolume(), 0);
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 2);
@@ -230,6 +235,7 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR3) {
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(3))));
   CheckOrthogonalComplementBasis(as);
+  EXPECT_EQ(as.CalcVolume(), std::numeric_limits<double>::infinity());
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 3);
@@ -282,6 +288,7 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR4) {
   EXPECT_TRUE(as.IntersectsWith(as));
   EXPECT_TRUE(as.PointInSet(as.Project(Eigen::VectorXd::Zero(4))));
   CheckOrthogonalComplementBasis(as);
+  EXPECT_EQ(as.CalcVolume(), 0);
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 3);


### PR DESCRIPTION
Functionality to compute the volume of convex sets was added in #19982, but AffineSubspace slipped through without having any test cases. This adds tests for CalcVolume and has_exact_volume.

This also updates the comment for DoCalcVolume, since it previously contradicted the base class documentation -- we throw an error if affine_dimension is zero.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20342)
<!-- Reviewable:end -->
