### PR TITLE
[workspace] Cull some unwanted ClpSolver code

### DIFF
--- a/tools/install/libdrake/test/exported_symbols_test.py
+++ b/tools/install/libdrake/test/exported_symbols_test.py
@@ -87,7 +87,6 @@ _KNOWN_BAD_SYMBOLS_SUBSTR = [
     "setupForSolve",
     "slack_value",
     "sortOnOther",
-    "usage",
     "wrapper",
     # This fix is pending a deprecation removal (#20115) 2024-01-01.
     "N3lcm",

--- a/tools/workspace/clp_internal/package.BUILD.bazel
+++ b/tools/workspace/clp_internal/package.BUILD.bazel
@@ -32,7 +32,15 @@ _SRCS = glob(
         "Clp/src/*.cpp",
     ],
     exclude = [
+        # We only want libClp, not libClpSolver nor the main program.
+        "**/MyEventHandler*",
+        "**/MyMessageHandler*",
+        "**/CbcOrClpParam*",
         "**/ClpMain*",
+        "**/ClpSolver*",
+        "**/Clp_C_Interface*",
+        "**/Clp_ampl*",
+        "**/unitTest*",
         # We treat COIN_HAS_ABC as OFF.
         "**/Abc*",
         "**/CoinAbc*",


### PR DESCRIPTION
Towards #17231.  (More broadly Clp still leaks a bajillion global symbols that we don't want, but that remains as future work.)

+@sammy-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20358)
<!-- Reviewable:end -->
