### PR TITLE
[common] Add WarnDeprecated sugar for console deprecation logs

### DIFF
--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -308,6 +308,8 @@ def _forward_callables_as_deprecated(var_dict, m_new, date):
 
 if os.environ.get("_DRAKE_DEPRECATION_IS_ERROR") == "1":
     # This is used for testing Jupyter notebooks in `jupyter_bazel`.
+    # Note that the same literal string name for the environment variable is
+    # used for both C++ code and Python code, so keep the two in sync.
     warnings.simplefilter('error', DrakeDeprecationWarning)
 else:
     warnings.simplefilter('once', DrakeDeprecationWarning)

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -84,6 +84,7 @@ drake_cc_library(
     name = "essential",
     srcs = [
         "drake_assert_and_throw.cc",
+        "drake_deprecated.cc",
         "text_logging.cc",
     ],
     hdrs = [
@@ -805,6 +806,7 @@ drake_cc_googletest(
     copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":essential",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/common/drake_deprecated.cc
+++ b/common/drake_deprecated.cc
@@ -1,0 +1,48 @@
+#include "drake/common/drake_deprecated.h"
+
+#include <cstdlib>
+#include <stdexcept>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace internal {
+namespace {
+
+// TODO(jwnimmer-tri) Teach pybind11 to map this to Python's DeprecationWarning.
+class DeprecationWarning final : public std::runtime_error {
+ public:
+  using runtime_error::runtime_error;
+};
+
+// Drake's regression tests use this to fail-fast in case Drake is spuriously
+// using deprecated self-calls. Note that the same literal string name for the
+// environment variable is used for both C++ code and Python code, so keep the
+// two in sync.
+constexpr char kEnvDrakeDeprecationIsError[] = "_DRAKE_DEPRECATION_IS_ERROR";
+
+}  // namespace
+
+WarnDeprecated::WarnDeprecated(std::string_view removal_date,
+                               std::string_view message) {
+  const bool missing_period = message.empty() || message.back() != '.';
+  const std::string full_message = fmt::format(
+      "DRAKE DEPRECATED: {}{} "
+      "The deprecated code will be removed from Drake on or after {}.",
+      message, missing_period ? "." : "", removal_date);
+  const char* const is_error = std::getenv(kEnvDrakeDeprecationIsError);
+  if (is_error != nullptr && std::string_view(is_error) == "1") {
+    throw DeprecationWarning(full_message);
+  } else {
+    log()->warn(full_message);
+  }
+
+  // If a Drake developer made a mistake, we need to fail-fast but it's better
+  // to have at least printed the warning first.
+  DRAKE_THROW_UNLESS(removal_date.size() == 10);
+  DRAKE_THROW_UNLESS(!message.empty());
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/drake_deprecated.h
+++ b/common/drake_deprecated.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <string_view>
+
 /** @file
 Provides a portable macro for use in generating compile-time warnings for
 use of code that is permitted but discouraged. */
@@ -62,3 +65,29 @@ Sample uses: @code
                " on or after " removal_date ".")]]
 
 #endif  // DRAKE_DOXYGEN_CXX
+
+namespace drake {
+namespace internal {
+
+/* When constructed, logs a deprecation message; the destructor is guaranteed
+to be trivial. This is useful for declaring an instance of this class as a
+function-static global, so that a warning is logged the first time the program
+encounters some code, but does not repeat the warning on subsequent encounters
+within the same process.
+
+For example:
+<pre>
+void OldCalc(double data) {
+  static const drake::internal::WarnDeprecated warn_once(
+      "2038-01-19", "The method OldCalc() has been renamed to NewCalc().");
+  return NewCalc(data);
+}
+</pre> */
+class[[maybe_unused]] WarnDeprecated {
+ public:
+  /* The removal_date must be in the form YYYY-MM-DD. */
+  WarnDeprecated(std::string_view removal_date, std::string_view message);
+};
+
+}  // namespace internal
+}  // namespace drake

--- a/common/test/drake_deprecated_test.cc
+++ b/common/test/drake_deprecated_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/expect_throws_message.h"
+
 // This test verifies that the Drake build still succeeds if a deprecated class
 // or function is in use.
 
@@ -31,6 +33,23 @@ GTEST_TEST(DrakeDeprecatedTest, FunctionTest) {
   int not_obsolete = NewMethod(1);
   (void)obsolete;
   (void)not_obsolete;
+}
+
+// Check that the "warn once" idiom compiles and doesn't crash at runtime.
+GTEST_TEST(DrakeDeprecatedTest, WarnOnceTest) {
+  static const drake::internal::WarnDeprecated warn_once(
+      "2038-01-19", "The method OldCalc() has been renamed to NewCalc().");
+}
+
+// When the magic environment variable is set, warnings become errors.
+GTEST_TEST(DrakeDeprecatedTest, WarnThrowsTest) {
+  constexpr char kEnvName[] = "_DRAKE_DEPRECATION_IS_ERROR";
+  ASSERT_EQ(::setenv(kEnvName, "1", 1), 0);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      drake::internal::WarnDeprecated("2038-01-19", "Hello"),
+      "DRAKE DEPRECATED: Hello. The deprecated code will be removed from Drake "
+      "on or after 2038-01-19.");
+  ASSERT_EQ(::unsetenv(kEnvName), 0);
 }
 
 }  // namespace

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -9,6 +9,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/diagnostic_policy.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/pointer_cast.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/ssize.h"
@@ -708,9 +709,9 @@ RenderEngineGl::RenderEngineGl(RenderEngineGlParams params)
       texture_library_(make_shared<TextureLibrary>()),
       parameters_(CleanupLights(std::move(params))) {
   if (params.default_label != RenderLabel::kDontCare) {
-    static const logging::Warn log_once(
-        "RenderEngineGl(): the default_label configuration option is "
-        "deprecated and will be removed from Drake on or after 2023-12-01.");
+    static const drake::internal::WarnDeprecated warn_once(
+        "2023-12-01",
+        "RenderEngineGl(): the default_label option is deprecated.");
   }
 
   // The default light parameters have been crafted to create the default

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
@@ -15,6 +15,7 @@
 #include <vtkMatrix4x4.h>      // vtkCommonMath
 #include <vtkVersionMacros.h>  // vtkCommonCore
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"
@@ -316,9 +317,9 @@ RenderEngineGltfClient::RenderEngineGltfClient(
     : RenderEngineVtk({.default_label = parameters.default_label}),
       render_client_{std::make_unique<RenderClient>(parameters)} {
   if (parameters.default_label.has_value()) {
-    static const logging::Warn log_once(
-        "RenderEngineGltfClient(): the default_label configuration option is "
-        "deprecated and will be removed from Drake on or after 2023-12-01.");
+    static const drake::internal::WarnDeprecated warn_once(
+        "2023-12-01",
+        "RenderEngineGltfClient(): the default_label option is deprecated.");
   }
 }
 

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -111,9 +111,9 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtkParams& parameters)
                   make_unique<RenderingPipeline>(),
                   make_unique<RenderingPipeline>()}} {
   if (parameters.default_label.has_value()) {
-    static const logging::Warn log_once(
-        "RenderEngineVtk(): the default_label configuration option is "
-        "deprecated and will be removed from Drake on or after 2023-12-01.");
+    static const drake::internal::WarnDeprecated warn_once(
+        "2023-12-01",
+        "RenderEngineVtk(): the default_label option is deprecated.");
   }
   if (parameters.default_diffuse) {
     default_diffuse_.set(*parameters.default_diffuse);

--- a/multibody/tree/unit_inertia.cc
+++ b/multibody/tree/unit_inertia.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/tree/unit_inertia.h"
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/text_logging.h"
 
@@ -82,10 +83,9 @@ T WarnUnlessVectorIsMagnitudeOne(const Vector3<T>& unit_vector,
   auto [result, error_message] =
       CheckVectorIsMagnitudeOne(unit_vector, function_name);
   if (!error_message.empty()) {
-    static const logging::Warn log_once(
-        "{} Implicit normalization is deprecated; on or after 2023-12-01 this "
-        "will become an exception.",
-        error_message);
+    static const internal::WarnDeprecated warn_once(
+        "2023-12-01",
+        fmt::format("{} Implicit normalization is deprecated.", error_message));
   }
   return result;
 }

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -5,6 +5,7 @@
 
 #include "absl/container/inlined_vector.h"
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/pointer_cast.h"
 #include "drake/systems/framework/system_symbolic_inspector.h"
 #include "drake/systems/framework/value_checker.h"
@@ -857,9 +858,9 @@ EventStatus LeafSystem<T>::DispatchPublishHandler(
   this->DoPublish(context, leaf_events.get_events());
 #pragma GCC diagnostic pop
   if (!context.get_use_default_implementation()) {
-    static const logging::Warn log_once(
-        "Overriding LeafSystem::DoPublish is deprecated "
-        "and will be removed from Drake on or after 2024-02-01.");
+    static const drake::internal::WarnDeprecated warn_once(
+        "2024-02-01",
+        "Overriding LeafSystem::DoPublish is deprecated.");
     // Derived system overrode the dispatcher and did not invoke the base class
     // implementation so there is nothing else to do.
     return EventStatus::Succeeded();
@@ -901,9 +902,9 @@ EventStatus LeafSystem<T>::DispatchDiscreteVariableUpdateHandler(
       discrete_state);  // in/out
 #pragma GCC diagnostic pop
   if (!context.get_use_default_implementation()) {
-    static const logging::Warn log_once(
-        "Overriding LeafSystem::DoCalcDiscreteVariableUpdates is deprecated "
-        "and will be removed from Drake on or after 2024-02-01.");
+    static const drake::internal::WarnDeprecated warn_once(
+        "2024-02-01",
+        "Overriding LeafSystem::DoCalcDiscreteVariableUpdates is deprecated.");
     // Derived system overrode the dispatcher and did not invoke the base class
     // implementation so there is nothing else to do.
     return EventStatus::Succeeded();
@@ -956,9 +957,9 @@ EventStatus LeafSystem<T>::DispatchUnrestrictedUpdateHandler(
                                         state);  // in/out
 #pragma GCC diagnostic pop
   if (!context.get_use_default_implementation()) {
-    static const logging::Warn log_once(
-        "Overriding LeafSystem::DoCalcUnrestrictedUpdate is deprecated "
-        "and will be removed from Drake on or after 2024-02-01.");
+    static const drake::internal::WarnDeprecated warn_once(
+        "2024-02-01",
+        "Overriding LeafSystem::DoCalcUnrestrictedUpdate is deprecated.");
     // Derived system overrode the dispatcher and did not invoke the base class
     // implementation so there is nothing else to do.
     return EventStatus::Succeeded();

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -6,6 +6,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/unused.h"
 #include "drake/systems/framework/system_visitor.h"
 
@@ -965,13 +966,14 @@ VectorX<T> System<T>::CopyContinuousStateVector(
 // Remove this stanza on 2024-01-01.
 namespace {
 void WarnGraphvizDeprecation() {
-  static const logging::Warn log_once(
+  static const drake::internal::WarnDeprecated warn_once(
+      "2024-02-01",
       "The member functions "
       "System<T>::GetGraphvizFragment(), "
       "System<T>::GetGraphvizInputPortToken(), "
       "System<T>::GetGraphvizOutputPortToken(), and "
       "System<T>::GetGraphvizId() "
-      "are deprecated and will be removed from Drake on or after 2024-01-01. "
+      "are deprecated. "
       "Instead, either call GetGraphvizFragment() or "
       "override DoGetGraphvizFragment().");
 }


### PR DESCRIPTION
Example output:

```
[ RUN      ] DrakeDeprecatedTest.WarnOnceTest
[2023-10-13 06:56:48.867] [console] [warning] DRAKE DEPRECATED: The method OldCalc() has been renamed to NewCalc(). The deprecated code will be removed from Drake on or after 2038-01-19.
[       OK ] DrakeDeprecatedTest.WarnOnceTest (0 ms)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20365)
<!-- Reviewable:end -->
