### PR TITLE
refactor scs_solver.cc

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -418,7 +418,9 @@ drake_cc_library(
         ":binding",
         ":mathematical_program",
     ],
-    deps = [],
+    deps = [
+        "//math:eigen_sparse_triplet",
+    ],
 )
 
 drake_cc_library(

--- a/solvers/aggregate_costs_constraints.cc
+++ b/solvers/aggregate_costs_constraints.cc
@@ -6,6 +6,8 @@
 
 #include <fmt/format.h>
 
+#include "drake/math/eigen_sparse_triplet.h"
+
 namespace drake {
 namespace solvers {
 namespace {
@@ -112,6 +114,7 @@ void AggregateLinearCostsHelper(
     *constant_cost += cost.evaluator()->b();
   }
 }
+
 }  // namespace
 
 void AggregateLinearCosts(const std::vector<Binding<LinearCost>>& linear_costs,
@@ -303,6 +306,341 @@ bool CheckConvexSolverAttributes(const MathematicalProgram& prog,
   }
   return true;
 }
+
+void ParseLinearCosts(const MathematicalProgram& prog, std::vector<double>* c,
+                      double* constant) {
+  DRAKE_DEMAND(static_cast<int>(c->size()) >= prog.num_vars());
+  for (const auto& linear_cost : prog.linear_costs()) {
+    // Each linear cost is in the form of aᵀx + b
+    const auto& a = linear_cost.evaluator()->a();
+    const VectorXDecisionVariable& x = linear_cost.variables();
+    for (int i = 0; i < a.rows(); ++i) {
+      (*c)[prog.FindDecisionVariableIndex(x(i))] += a(i);
+    }
+    (*constant) += linear_cost.evaluator()->b();
+  }
+}
+
+void ParseLinearEqualityConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* linear_eq_y_start_indices,
+    int* num_linear_equality_constraints_rows) {
+  DRAKE_ASSERT(linear_eq_y_start_indices->empty());
+  DRAKE_ASSERT(static_cast<int>(b->size()) == *A_row_count);
+  *num_linear_equality_constraints_rows = 0;
+  linear_eq_y_start_indices->reserve(prog.linear_equality_constraints().size());
+  // The linear equality constraint A x = b is converted to
+  // A x + s = b. s in zero cone.
+  for (const auto& linear_equality_constraint :
+       prog.linear_equality_constraints()) {
+    const Eigen::SparseMatrix<double>& Ai =
+        linear_equality_constraint.evaluator()->get_sparse_A();
+    const std::vector<Eigen::Triplet<double>> Ai_triplets =
+        math::SparseMatrixToTriplets(Ai);
+    A_triplets->reserve(A_triplets->size() + Ai_triplets.size());
+    const solvers::VectorXDecisionVariable& x =
+        linear_equality_constraint.variables();
+    // x_indices[i] is the index of x(i)
+    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
+    for (const auto& Ai_triplet : Ai_triplets) {
+      A_triplets->emplace_back(Ai_triplet.row() + *A_row_count,
+                               x_indices[Ai_triplet.col()], Ai_triplet.value());
+    }
+    const int num_Ai_rows =
+        linear_equality_constraint.evaluator()->num_constraints();
+    b->reserve(b->size() + num_Ai_rows);
+    for (int i = 0; i < num_Ai_rows; ++i) {
+      b->push_back(linear_equality_constraint.evaluator()->lower_bound()(i));
+    }
+    linear_eq_y_start_indices->push_back(*A_row_count);
+    *A_row_count += num_Ai_rows;
+    *num_linear_equality_constraints_rows += num_Ai_rows;
+  }
+}
+
+void ParseLinearConstraints(const solvers::MathematicalProgram& prog,
+                            std::vector<Eigen::Triplet<double>>* A_triplets,
+                            std::vector<double>* b, int* A_row_count,
+                            std::vector<std::vector<std::pair<int, int>>>*
+                                linear_constraint_dual_indices,
+                            int* num_linear_constraint_rows) {
+  // The linear constraint lb ≤ aᵀx ≤ ub is converted to
+  // -aᵀx + s1 = lb,
+  //  aᵀx + s2 = ub
+  // s1, s2 in the positive cone.
+  // The special cases are when ub = ∞ or lb = -∞.
+  // When ub = ∞, then we only add the constraint
+  // -aᵀx + s = lb, s in the positive cone.
+  // When lb = -∞, then we only add the constraint
+  // aᵀx + s = ub, s in the positive cone.
+  *num_linear_constraint_rows = 0;
+  linear_constraint_dual_indices->reserve(prog.linear_constraints().size());
+  for (const auto& linear_constraint : prog.linear_constraints()) {
+    linear_constraint_dual_indices->emplace_back(
+        linear_constraint.evaluator()->num_constraints());
+    const Eigen::VectorXd& ub = linear_constraint.evaluator()->upper_bound();
+    const Eigen::VectorXd& lb = linear_constraint.evaluator()->lower_bound();
+    const VectorXDecisionVariable& x = linear_constraint.variables();
+    const Eigen::SparseMatrix<double>& Ai =
+        linear_constraint.evaluator()->get_sparse_A();
+    // We store the starting row index in A_triplets for each row of
+    // linear_constraint. Namely the constraint lb(i) <= A.row(i)*x <= ub(i) is
+    // stored in A_triplets with starting_row_indices[i] (or
+    // starting_row_indices[i]+1 if both lb(i) and ub(i) are finite).
+    std::vector<int> starting_row_indices(
+        linear_constraint.evaluator()->num_constraints());
+    for (int i = 0; i < linear_constraint.evaluator()->num_constraints(); ++i) {
+      const bool needs_ub{!std::isinf(ub(i))};
+      const bool needs_lb{!std::isinf(lb(i))};
+      auto& dual_index = linear_constraint_dual_indices->back()[i];
+      // Use -1 to indicate the constraint bound is infinity.
+      dual_index.first = -1;
+      dual_index.second = -1;
+      if (!needs_ub && !needs_lb) {
+        // We use -1 to indicate that we won't add linear constraint when both
+        // bounds are infinity.
+        starting_row_indices[i] = -1;
+      } else {
+        starting_row_indices[i] = *A_row_count + *num_linear_constraint_rows;
+        // We first add the constraint for lower bound, and then add the
+        // constraint for upper bound. This is consistent with the loop below
+        // when we modify A_triplets.
+        if (needs_lb) {
+          b->push_back(-lb(i));
+          dual_index.first = *A_row_count + *num_linear_constraint_rows;
+          (*num_linear_constraint_rows)++;
+        }
+        if (needs_ub) {
+          b->push_back(ub(i));
+          dual_index.second = *A_row_count + *num_linear_constraint_rows;
+          (*num_linear_constraint_rows)++;
+        }
+      }
+    }
+    for (int j = 0; j < Ai.cols(); ++j) {
+      const int xj_index = prog.FindDecisionVariableIndex(x(j));
+      for (Eigen::SparseMatrix<double>::InnerIterator it(Ai, j); it; ++it) {
+        const int Ai_row_count = it.row();
+        const bool needs_ub{!std::isinf(ub(Ai_row_count))};
+        const bool needs_lb{!std::isinf(lb(Ai_row_count))};
+        if (!needs_lb && !needs_ub) {
+          continue;
+        }
+        int row_index = starting_row_indices[Ai_row_count];
+        if (needs_lb) {
+          // If lb != -∞, then the constraint -aᵀx + s = lb will be added to
+          // the matrix A, in the row row_index.
+          A_triplets->emplace_back(row_index, xj_index, -it.value());
+          ++row_index;
+        }
+        if (needs_ub) {
+          // If ub != ∞, then the constraint aᵀx + s = ub will be added to the
+          // matrix A, in the row row_index.
+          A_triplets->emplace_back(row_index, xj_index, it.value());
+        }
+      }
+    }
+  }
+  *A_row_count += *num_linear_constraint_rows;
+}
+
+void ParseQuadraticCosts(const MathematicalProgram& prog,
+                         std::vector<Eigen::Triplet<double>>* P_upper_triplets,
+                         std::vector<double>* c, double* constant) {
+  for (const auto& cost : prog.quadratic_costs()) {
+    const auto var_indices = prog.FindDecisionVariableIndices(cost.variables());
+    for (int j = 0; j < cost.evaluator()->Q().cols(); ++j) {
+      for (int i = 0; i <= j; ++i) {
+        if (cost.evaluator()->Q()(i, j) != 0) {
+          // Since we allow duplicated variables in a quadratic cost, we need to
+          // handle this more carefully. If i != j but var_indices[i] ==
+          // var_indices[j], then it means that the cost is a diagonal term
+          // (Q(i, j) + Q(j, i)) * x[var_indices[i]]² = 2 * Q(i, j)*
+          // x[var_indices[i]]², not a cross term (Q(i, j) + Q(j, i)) *
+          // x[var_indices[i]] * x[var_indices[j]]. Hence we need a factor of 2
+          // for this special case.
+          const double factor =
+              (i != j && var_indices[i] == var_indices[j]) ? 2 : 1;
+          // Since we only add the upper diagonal entries, we need to branch
+          // based on whether var_indices[i] > var_indices[j]
+          int row_index = var_indices[i];
+          int col_index = var_indices[j];
+          if (var_indices[i] > var_indices[j]) {
+            row_index = var_indices[j];
+            col_index = var_indices[i];
+          }
+          P_upper_triplets->emplace_back(row_index, col_index,
+                                         factor * cost.evaluator()->Q()(i, j));
+        }
+      }
+      (*c)[var_indices[j]] += cost.evaluator()->b()(j);
+    }
+    *constant += cost.evaluator()->c();
+  }
+}
+
+// Add a rotated Lorentz cone constraint that A_cone * x + b_cone is in the
+// rotated Lorentz cone.
+// @param A_cone_triplets The triplets of non-zero entries in A_cone.
+// @param b_cone A_cone * x + b_cone is in the rotated Lorentz cone.
+// @param x_indices The index of the variable in SCS.
+// @param A_triplets[in/out] The non-zero entry triplet in A before and after
+// adding the Lorentz cone.
+// @param b[in/out] The right-hand side vector b before and after adding the
+// Lorentz cone.
+// @param A_row_count[in/out] The number of rows in A before and after adding
+// the Lorentz cone.
+// @param second_order_cone_length[in/out] The length of each Lorentz cone
+// before and after adding the Lorentz cone constraint.
+// @param rotated_lorentz_cone_y_start_indices[in/out] The starting index of y
+// corresponds to this rotated Lorentz cone. If set to nullopt, then we don't
+// modify rotated_lorentz_cone_y_start_indices.
+void ParseRotatedLorentzConeConstraint(
+    const std::vector<Eigen::Triplet<double>>& A_cone_triplets,
+    const Eigen::Ref<const Eigen::VectorXd>& b_cone,
+    const std::vector<int>& x_indices,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* second_order_cone_length,
+    std::optional<std::vector<int>*> rotated_lorentz_cone_y_start_indices) {
+  // Our RotatedLorentzConeConstraint encodes that Ax + b is in the rotated
+  // Lorentz cone, namely
+  //  (a₀ᵀx + b₀) (a₁ᵀx + b₁) ≥ (a₂ᵀx + b₂)² + ... + (aₙ₋₁ᵀx + bₙ₋₁)²
+  //  (a₀ᵀx + b₀) ≥ 0
+  //  (a₁ᵀx + b₁) ≥ 0
+  // , where aᵢᵀ is the i'th row of A, bᵢ is the i'th row of b. Equivalently the
+  // vector
+  // [ 0.5(a₀ + a₁)ᵀx + 0.5(b₀ + b₁) ]
+  // [ 0.5(a₀ - a₁)ᵀx + 0.5(b₀ - b₁) ]
+  // [           a₂ᵀx +           b₂ ]
+  //             ...
+  // [         aₙ₋₁ᵀx +         bₙ₋₁ ]
+  // is in the Lorentz cone. We convert this to the SCS form, that
+  //  Cx + s = d
+  //  s in Lorentz cone,
+  // where C = [ -0.5(a₀ + a₁)ᵀ ]   d = [ 0.5(b₀ + b₁) ]
+  //           [ -0.5(a₀ - a₁)ᵀ ]       [ 0.5(b₀ - b₁) ]
+  //           [           -a₂ᵀ ]       [           b₂ ]
+  //                 ...                      ...
+  //           [         -aₙ₋₁ᵀ ]       [          bₙ₋₁]
+  for (const auto& Ai_triplet : A_cone_triplets) {
+    const int x_index = x_indices[Ai_triplet.col()];
+    if (Ai_triplet.row() == 0) {
+      A_triplets->emplace_back(*A_row_count, x_index,
+                               -0.5 * Ai_triplet.value());
+      A_triplets->emplace_back(*A_row_count + 1, x_index,
+                               -0.5 * Ai_triplet.value());
+    } else if (Ai_triplet.row() == 1) {
+      A_triplets->emplace_back(*A_row_count, x_index,
+                               -0.5 * Ai_triplet.value());
+      A_triplets->emplace_back(*A_row_count + 1, x_index,
+                               0.5 * Ai_triplet.value());
+    } else {
+      A_triplets->emplace_back(*A_row_count + Ai_triplet.row(), x_index,
+                               -Ai_triplet.value());
+    }
+  }
+  b->push_back(0.5 * (b_cone(0) + b_cone(1)));
+  b->push_back(0.5 * (b_cone(0) - b_cone(1)));
+  for (int i = 2; i < b_cone.rows(); ++i) {
+    b->push_back(b_cone(i));
+  }
+  if (rotated_lorentz_cone_y_start_indices.has_value()) {
+    rotated_lorentz_cone_y_start_indices.value()->push_back(*A_row_count);
+  }
+  *A_row_count += b_cone.rows();
+  second_order_cone_length->push_back(b_cone.rows());
+}
+
+void ParseSecondOrderConeConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* second_order_cone_length,
+    std::vector<int>* lorentz_cone_y_start_indices,
+    std::vector<int>* rotated_lorentz_cone_y_start_indices) {
+  // Our LorentzConeConstraint encodes that Ax + b is in Lorentz cone. We
+  // convert this to SCS form, as -Ax + s = b, s in Lorentz cone.
+  second_order_cone_length->reserve(
+      prog.lorentz_cone_constraints().size() +
+      prog.rotated_lorentz_cone_constraints().size());
+  lorentz_cone_y_start_indices->reserve(prog.lorentz_cone_constraints().size());
+  rotated_lorentz_cone_y_start_indices->reserve(
+      prog.rotated_lorentz_cone_constraints().size());
+  for (const auto& lorentz_cone_constraint : prog.lorentz_cone_constraints()) {
+    // x_indices[i] is the index of x(i)
+    const VectorXDecisionVariable& x = lorentz_cone_constraint.variables();
+    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
+    const Eigen::SparseMatrix<double> Ai =
+        lorentz_cone_constraint.evaluator()->A();
+    const std::vector<Eigen::Triplet<double>> Ai_triplets =
+        math::SparseMatrixToTriplets(Ai);
+    for (const auto& Ai_triplet : Ai_triplets) {
+      A_triplets->emplace_back(Ai_triplet.row() + *A_row_count,
+                               x_indices[Ai_triplet.col()],
+                               -Ai_triplet.value());
+    }
+    const int num_Ai_rows = lorentz_cone_constraint.evaluator()->A().rows();
+    for (int i = 0; i < num_Ai_rows; ++i) {
+      b->push_back(lorentz_cone_constraint.evaluator()->b()(i));
+    }
+    second_order_cone_length->push_back(num_Ai_rows);
+    lorentz_cone_y_start_indices->push_back(*A_row_count);
+    *A_row_count += num_Ai_rows;
+  }
+
+  for (const auto& rotated_lorentz_cone :
+       prog.rotated_lorentz_cone_constraints()) {
+    const VectorXDecisionVariable& x = rotated_lorentz_cone.variables();
+    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
+    const Eigen::SparseMatrix<double> Ai =
+        rotated_lorentz_cone.evaluator()->A();
+    const Eigen::VectorXd& bi = rotated_lorentz_cone.evaluator()->b();
+    const std::vector<Eigen::Triplet<double>> Ai_triplets =
+        math::SparseMatrixToTriplets(Ai);
+    ParseRotatedLorentzConeConstraint(Ai_triplets, bi, x_indices, A_triplets, b,
+                                      A_row_count, second_order_cone_length,
+                                      rotated_lorentz_cone_y_start_indices);
+  }
+}
+
+void ParseExponentialConeConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count) {
+  for (const auto& binding : prog.exponential_cone_constraints()) {
+    // drake::solvers::ExponentialConstraint enforces that z = A * x + b is in
+    // the exponential cone (z₀ ≥ z₁*exp(z₂ / z₁)). This is different from the
+    // exponential cone used in SCS. In SCS, a vector s is in the exponential
+    // cone, if s₂≥ s₁*exp(s₀ / s₁). To transform drake's Exponential cone to
+    // SCS's exponential cone, we use
+    // -[A.row(2); A.row(1); A.row(0)] * x + s = [b(2); b(1); b(0)], and s is
+    // in SCS's exponential cone, where A = binding.evaluator()->A(), b =
+    // binding.evaluator()->b().
+    const int num_bound_variables = binding.variables().rows();
+    for (int i = 0; i < num_bound_variables; ++i) {
+      A_triplets->reserve(A_triplets->size() +
+                          binding.evaluator()->A().nonZeros());
+      const int decision_variable_index =
+          prog.FindDecisionVariableIndex(binding.variables()(i));
+      for (Eigen::SparseMatrix<double>::InnerIterator it(
+               binding.evaluator()->A(), i);
+           it; ++it) {
+        // 2 - it.row() is used for reverse the row order, as mentioned in the
+        // function documentation above.
+        A_triplets->emplace_back(*A_row_count + 2 - it.row(),
+                                 decision_variable_index, -it.value());
+      }
+    }
+    // The exponential cone constraint is on a 3 x 1 vector, hence for each
+    // ExponentialConeConstraint, we append 3 rows to A and b.
+    b->reserve(b->size() + 3);
+    for (int i = 0; i < 3; ++i) {
+      b->push_back(binding.evaluator()->b()(2 - i));
+    }
+    *A_row_count += 3;
+  }
+}
+
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/aggregate_costs_constraints.h
+++ b/solvers/aggregate_costs_constraints.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -121,6 +122,161 @@ bool CheckConvexSolverAttributes(const MathematicalProgram& prog,
                                  const ProgramAttributes& solver_capabilities,
                                  std::string_view solver_name,
                                  std::string* explanation);
+
+// Aggregates all prog.linear_costs(), such that the aggregated linear cost is
+// ∑ᵢ (*c)[i] * prog.decision_variable(i) + *constant
+// @note c and constant might not be zero. This function adds
+// prog.linear_costs() to the coefficient c and constant.
+// @pre c->size() >= prog.num_vars();
+void ParseLinearCosts(const MathematicalProgram& prog, std::vector<double>* c,
+                      double* constant);
+
+// Parses all prog.linear_equality_constraints() to
+// A*x = b
+// Some convex solvers (like SCS and Clarabel) aggregates all constraints in the
+// form of
+// A*x + s = b
+// s in K
+// This function appends all prog.linear_equality_constraints() to the existing
+// A*x+s=b.
+// @param[in/out] A_triplets The triplets on the non-zero entries in A.
+// prog.linear_equality_constraints() will be appended to A_triplets.
+// @param[in/out] b The righthand side of A*x=b.
+// prog.linear_equality_constraints() will be appended to b.
+// @param[in/out] A_row_count The number of rows in A before and after calling
+// this function.
+// @param[out] linear_eq_y_start_indices linear_eq_y_start_indices[i] is the
+// starting index of the dual variable for the constraint
+// prog.linear_equality_constraints()[i]. Namely y[linear_eq_y_start_indices[i]:
+// linear_eq_y_start_indices[i] +
+// prog.linear_equality_constraints()[i].evaluator()->num_constraints] are the
+// dual variables for  the linear equality constraint
+// prog.linear_equality_constraint()(i), where y is the vector containing all
+// dual variables.
+// @param[out] num_linear_equality_constraints_rows The number of new rows
+// appended to A*x+s=b in all prog.linear_equality_constraints()
+void ParseLinearEqualityConstraints(
+    const solvers::MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* linear_eq_y_start_indices,
+    int* num_linear_equality_constraints_rows);
+
+// Parses all prog.linear_constraints() to
+// A*x + s = b
+// s in the nonnegative orthant cone.
+// Some convex solvers (like SCS and Clarabel) aggregates all constraints in the
+// form of
+// A*x + s = b
+// s in K
+// This function appends all prog.linear_constraints() to the existing
+// A*x+s=b.
+// @param[in/out] A_triplets The triplets on the non-zero entries in A.
+// prog.linear_constraints() will be appended to A_triplets.
+// @param[in/out] b The righthand side of A*x+s=b.
+// prog.linear_equality_constraints() will be appended to b.
+// @param[in/out] A_row_count The number of rows in A before and after calling
+// this function.
+// @param[out] linear_constraint_dual_indices
+// linear_constraint_dual_indices[i][j].first/linear_constraint_dual_indices[i][j].second
+// is the dual variable for the lower/upper bound of the j'th row in the
+// linear constraint prog.linear_constraint()[i], we use -1 to indicate that
+// the lower or upper bound is infinity.
+// @param[out] num_linear_constraint_rows The number of new rows appended to
+// A*x+s = b in all
+// prog.linear_equality_constraints()
+void ParseLinearConstraints(const solvers::MathematicalProgram& prog,
+                            std::vector<Eigen::Triplet<double>>* A_triplets,
+                            std::vector<double>* b, int* A_row_count,
+                            std::vector<std::vector<std::pair<int, int>>>*
+                                linear_constraint_dual_indices,
+                            int* num_linear_constraint_rows);
+
+// Aggregates all quadratic prog.quadratic_costs() and add the aggregated cost
+// to 0.5*x'P*x + c'*x + constant. where x is prog.decision_variables().
+void ParseQuadraticCosts(const MathematicalProgram& prog,
+                         std::vector<Eigen::Triplet<double>>* P_upper_triplets,
+                         std::vector<double>* c, double* constant);
+
+// Parse all second order cone constraints (including both Lorentz cone and
+// rotated Lorentz cone constraint) to the form A*x+s=b, s in K where K is the
+// Cartesian product of Lorentz cone {s | sqrt(s₁²+...+sₙ₋₁²) ≤ s₀}
+// @param[in/out] A_triplets We append the second order cone constraints to
+// A_triplets.
+// @param[in/out] b We append the second order cone constraints to b.
+// @param[in/out] The number of rows in A before/after appending the second
+// order cone constraints.
+// @param[out] second_order_cone_length The lengths of each second order cone s
+// in K in the Cartesian product K.
+// @param[out] lorentz_cone_y_start_indices y[lorentz_cone_y_start_indices[i]:
+// lorentz_cone_y_start_indices[i] + second_order_cone_length[i]]
+// are the dual variables for prog.lorentz_cone_constraints()[i].
+// @param[out] rotated_lorentz_cone_y_start_indices
+// y[rotated_lorentz_cone_y_start_indices[i]:
+// rotated_lorentz_cone_y_start_indices[i] +
+// prog.rotate_lorentz_cone()[i].evaluator().A().rows] are the y variables for
+// prog.rotated_lorentz_cone_constraints()[i]. Note that we assume the Cartesian
+// product K doesn't contain a
+// rotated Lorentz cone constraint, instead we convert the rotated Lorentz
+// cone constraint to the Lorentz cone constraint through a linear
+// transformation. Hence we need to apply the transpose of that linear
+// transformation on the y variable to get the dual variable in the dual cone
+// of rotated Lorentz cone.
+void ParseSecondOrderConeConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* second_order_cone_length,
+    std::vector<int>* lorentz_cone_y_start_indices,
+    std::vector<int>* rotated_lorentz_cone_y_start_indices);
+
+// Add a rotated Lorentz cone constraint that A_cone * x + b_cone is in the
+// rotated Lorentz cone.
+//
+// We add these rotated Lorentz cones in the form A*x+s=b and s in K, where K is
+// the Cartesian product of Lorentz cones.
+// @param A_cone_triplets The triplets of non-zero entries in A_cone.
+// @param b_cone A_cone * x + b_cone is in the rotated Lorentz cone.
+// @param x_indices The index of the variables.
+// @param A_triplets[in/out] The non-zero entry triplet in A before and after
+// adding the Lorentz cone.
+// @param b[in/out] The right-hand side vector b before and after adding the
+// Lorentz cone.
+// @param A_row_count[in/out] The number of rows in A before and after adding
+// the Lorentz cone.
+// @param second_order_cone_length[in/out] The length of each Lorentz cone
+// before and after adding the Lorentz cone constraint.
+// @param rotated_lorentz_cone_y_start_indices[in/out] The starting index of y
+// corresponds to this rotated Lorentz cone. If set to nullopt, then we don't
+// modify rotated_lorentz_cone_y_start_indices.
+void ParseRotatedLorentzConeConstraint(
+    const std::vector<Eigen::Triplet<double>>& A_cone_triplets,
+    const Eigen::Ref<const Eigen::VectorXd>& b_cone,
+    const std::vector<int>& x_indices,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count, std::vector<int>* second_order_cone_length,
+    std::optional<std::vector<int>*> rotated_lorentz_cone_y_start_indices);
+
+// Parses all prog.exponential_cone_constraints() to
+// A*x + s = b
+// s in the exponential cone.
+// Some convex solvers (like SCS and Clarabel) aggregates all constraints in the
+// form of
+// A*x + s = b
+// s in K
+// Note that the definition of SCS/Clarabel's exponential cone is different from
+// Drake's definition. In SCS/Clarabel, a vector s is in the exponential cone if
+// s₂≥ s₁*exp(s₀ / s₁). In Drake, a vector z is in the exponential cone if z₀ ≥
+// z₁ * exp(z₂ / z₁). Note that the index 0 and 2 is swapped. This function
+// appends all prog.exponential_cone_constraints() to the existing A*x+s=b.
+// @param[in/out] A_triplets The triplets on the non-zero entries in A.
+// prog.exponential_cone_constraints() will be appended to A_triplets.
+// @param[in/out] b The righthand side of A*x+s=b.
+// prog.exponential_cone_constraints() will be appended to b.
+// @param[in/out] A_row_count The number of rows in A before and after calling
+// this function.
+void ParseExponentialConeConstraints(
+    const MathematicalProgram& prog,
+    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
+    int* A_row_count);
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/scs_solver.cc
+++ b/solvers/scs_solver.cc
@@ -19,114 +19,13 @@
 #include "drake/common/text_logging.h"
 #include "drake/math/eigen_sparse_triplet.h"
 #include "drake/math/quadratic_form.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mathematical_program_result.h"
 
 namespace drake {
 namespace solvers {
 namespace {
-void ParseLinearCost(const MathematicalProgram& prog, std::vector<double>* c,
-                     double* constant) {
-  for (const auto& linear_cost : prog.linear_costs()) {
-    // Each linear cost is in the form of aᵀx + b
-    const auto& a = linear_cost.evaluator()->a();
-    const VectorXDecisionVariable& x = linear_cost.variables();
-    for (int i = 0; i < a.rows(); ++i) {
-      (*c)[prog.FindDecisionVariableIndex(x(i))] += a(i);
-    }
-    (*constant) += linear_cost.evaluator()->b();
-  }
-}
-
-// Add a rotated Lorentz cone constraint that A_cone * x + b_cone is in the
-// rotated Lorentz cone.
-// @param A_cone_triplets The triplets of non-zero entries in A_cone.
-// @param b_cone A_cone * x + b_cone is in the rotated Lorentz cone.
-// @param x_indices The index of the variable in SCS.
-// @param A_triplets[in/out] The non-zero entry triplet in A before and after
-// adding the Lorentz cone.
-// @param b[in/out] The right-hand side vector b before and after adding the
-// Lorentz cone.
-// @param A_row_count[in/out] The number of rows in A before and after adding
-// the Lorentz cone.
-// @param second_order_cone_length[in/out] The length of each Lorentz cone
-// before and after adding the Lorentz cone constraint.
-// @param rotated_lorentz_cone_y_start_indices[in/out] The starting index of y
-// corresponds to this rotated Lorentz cone. If set to nullopt, then we don't
-// modify rotated_lorentz_cone_y_start_indices.
-void ParseRotatedLorentzConeConstraint(
-    const std::vector<Eigen::Triplet<double>>& A_cone_triplets,
-    const Eigen::Ref<const Eigen::VectorXd>& b_cone,
-    const std::vector<int>& x_indices,
-    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
-    int* A_row_count, std::vector<int>* second_order_cone_length,
-    std::optional<std::vector<int>*> rotated_lorentz_cone_y_start_indices) {
-  // Our RotatedLorentzConeConstraint encodes that Ax + b is in the rotated
-  // Lorentz cone, namely
-  //  (a₀ᵀx + b₀) (a₁ᵀx + b₁) ≥ (a₂ᵀx + b₂)² + ... + (aₙ₋₁ᵀx + bₙ₋₁)²
-  //  (a₀ᵀx + b₀) ≥ 0
-  //  (a₁ᵀx + b₁) ≥ 0
-  // , where aᵢᵀ is the i'th row of A, bᵢ is the i'th row of b. Equivalently the
-  // vector
-  // [ 0.5(a₀ + a₁)ᵀx + 0.5(b₀ + b₁) ]
-  // [ 0.5(a₀ - a₁)ᵀx + 0.5(b₀ - b₁) ]
-  // [           a₂ᵀx +           b₂ ]
-  //             ...
-  // [         aₙ₋₁ᵀx +         bₙ₋₁ ]
-  // is in the Lorentz cone. We convert this to the SCS form, that
-  //  Cx + s = d
-  //  s in Lorentz cone,
-  // where C = [ -0.5(a₀ + a₁)ᵀ ]   d = [ 0.5(b₀ + b₁) ]
-  //           [ -0.5(a₀ - a₁)ᵀ ]       [ 0.5(b₀ - b₁) ]
-  //           [           -a₂ᵀ ]       [           b₂ ]
-  //                 ...                      ...
-  //           [         -aₙ₋₁ᵀ ]       [          bₙ₋₁]
-  for (const auto& Ai_triplet : A_cone_triplets) {
-    const int x_index = x_indices[Ai_triplet.col()];
-    if (Ai_triplet.row() == 0) {
-      A_triplets->emplace_back(*A_row_count, x_index,
-                               -0.5 * Ai_triplet.value());
-      A_triplets->emplace_back(*A_row_count + 1, x_index,
-                               -0.5 * Ai_triplet.value());
-    } else if (Ai_triplet.row() == 1) {
-      A_triplets->emplace_back(*A_row_count, x_index,
-                               -0.5 * Ai_triplet.value());
-      A_triplets->emplace_back(*A_row_count + 1, x_index,
-                               0.5 * Ai_triplet.value());
-    } else {
-      A_triplets->emplace_back(*A_row_count + Ai_triplet.row(), x_index,
-                               -Ai_triplet.value());
-    }
-  }
-  b->push_back(0.5 * (b_cone(0) + b_cone(1)));
-  b->push_back(0.5 * (b_cone(0) - b_cone(1)));
-  for (int i = 2; i < b_cone.rows(); ++i) {
-    b->push_back(b_cone(i));
-  }
-  if (rotated_lorentz_cone_y_start_indices.has_value()) {
-    rotated_lorentz_cone_y_start_indices.value()->push_back(*A_row_count);
-  }
-  *A_row_count += b_cone.rows();
-  second_order_cone_length->push_back(b_cone.rows());
-}
-
-void ParseQuadraticCost(const MathematicalProgram& prog,
-                        std::vector<Eigen::Triplet<double>>* P_upper_triplets,
-                        std::vector<double>* c, double* constant) {
-  for (const auto& cost : prog.quadratic_costs()) {
-    const auto var_indices = prog.FindDecisionVariableIndices(cost.variables());
-    for (int j = 0; j < cost.evaluator()->Q().cols(); ++j) {
-      for (int i = 0; i <= j; ++i) {
-        if (cost.evaluator()->Q()(i, j) != 0) {
-          P_upper_triplets->emplace_back(var_indices[i], var_indices[j],
-                                         cost.evaluator()->Q()(i, j));
-        }
-      }
-      (*c)[var_indices[j]] += cost.evaluator()->b()(j);
-    }
-    *constant += cost.evaluator()->c();
-  }
-}
 
 void ParseQuadraticCostWithRotatedLorentzCone(
     const MathematicalProgram& prog, std::vector<double>* c,
@@ -174,136 +73,12 @@ void ParseQuadraticCostWithRotatedLorentzCone(
     b_cone(0) = -cost.evaluator()->c();
     b_cone(1) = 2;
     // Add the rotated Lorentz cone constraint
-    ParseRotatedLorentzConeConstraint(Ai_triplets, b_cone, Ai_var_indices,
-                                      A_triplets, b, A_row_count,
-                                      second_order_cone_length, std::nullopt);
+    internal::ParseRotatedLorentzConeConstraint(
+        Ai_triplets, b_cone, Ai_var_indices, A_triplets, b, A_row_count,
+        second_order_cone_length, std::nullopt);
     // Add the cost y.
     c->push_back(1);
   }
-}
-
-void ParseLinearConstraint(const MathematicalProgram& prog,
-                           std::vector<Eigen::Triplet<double>>* A_triplets,
-                           std::vector<double>* b, int* A_row_count,
-                           ScsCone* cone,
-                           std::vector<std::vector<std::pair<int, int>>>*
-                               linear_constraint_dual_indices) {
-  // The linear constraint lb ≤ aᵀx ≤ ub is converted to
-  // -aᵀx + s1 = lb,
-  //  aᵀx + s2 = ub
-  // s1, s2 in the positive cone.
-  // The special cases are when ub = ∞ or lb = -∞.
-  // When ub = ∞, then we only add the constraint
-  // -aᵀx + s = lb, s in the positive cone.
-  // When lb = -∞, then we only add the constraint
-  // aᵀx + s = ub, s in the positive cone.
-  int num_linear_constraint_rows = 0;
-  linear_constraint_dual_indices->reserve(prog.linear_constraints().size());
-  for (const auto& linear_constraint : prog.linear_constraints()) {
-    linear_constraint_dual_indices->emplace_back(
-        linear_constraint.evaluator()->num_constraints());
-    const Eigen::VectorXd& ub = linear_constraint.evaluator()->upper_bound();
-    const Eigen::VectorXd& lb = linear_constraint.evaluator()->lower_bound();
-    const VectorXDecisionVariable& x = linear_constraint.variables();
-    const Eigen::SparseMatrix<double>& Ai =
-        linear_constraint.evaluator()->get_sparse_A();
-    // We store the starting row index in A_triplets for each row of
-    // linear_constraint. Namely the constraint lb(i) <= A.row(i)*x <= ub(i) is
-    // stored in A_triplets with starting_row_indices[i] (or
-    // starting_row_indices[i]+1 if both lb(i) and ub(i) are finite).
-    std::vector<int> starting_row_indices(
-        linear_constraint.evaluator()->num_constraints());
-    for (int i = 0; i < linear_constraint.evaluator()->num_constraints(); ++i) {
-      const bool needs_ub{!std::isinf(ub(i))};
-      const bool needs_lb{!std::isinf(lb(i))};
-      auto& dual_index = linear_constraint_dual_indices->back()[i];
-      // Use -1 to indicate the constraint bound is infinity.
-      dual_index.first = -1;
-      dual_index.second = -1;
-      if (!needs_ub && !needs_lb) {
-        // We use -1 to indicate that we won't add linear constraint when both
-        // bounds are infinity.
-        starting_row_indices[i] = -1;
-      } else {
-        starting_row_indices[i] = *A_row_count + num_linear_constraint_rows;
-        // We first add the constraint for lower bound, and then add the
-        // constraint for upper bound. This is consistent with the loop below
-        // when we modify A_triplets.
-        if (needs_lb) {
-          b->push_back(-lb(i));
-          dual_index.first = *A_row_count + num_linear_constraint_rows;
-          num_linear_constraint_rows++;
-        }
-        if (needs_ub) {
-          b->push_back(ub(i));
-          dual_index.second = *A_row_count + num_linear_constraint_rows;
-          num_linear_constraint_rows++;
-        }
-      }
-    }
-    for (int j = 0; j < Ai.cols(); ++j) {
-      const int xj_index = prog.FindDecisionVariableIndex(x(j));
-      for (Eigen::SparseMatrix<double>::InnerIterator it(Ai, j); it; ++it) {
-        const int Ai_row_count = it.row();
-        const bool needs_ub{!std::isinf(ub(Ai_row_count))};
-        const bool needs_lb{!std::isinf(lb(Ai_row_count))};
-        if (!needs_lb && !needs_ub) {
-          continue;
-        }
-        int row_index = starting_row_indices[Ai_row_count];
-        if (needs_lb) {
-          // If lb != -∞, then the constraint -aᵀx + s = lb will be added to
-          // the matrix A, in the row row_index.
-          A_triplets->emplace_back(row_index, xj_index, -it.value());
-          ++row_index;
-        }
-        if (needs_ub) {
-          // If ub != ∞, then the constraint aᵀx + s = ub will be added to the
-          // matrix A, in the row row_index.
-          A_triplets->emplace_back(row_index, xj_index, it.value());
-        }
-      }
-    }
-  }
-  *A_row_count += num_linear_constraint_rows;
-  cone->l += num_linear_constraint_rows;
-}
-
-void ParseLinearEqualityConstraint(
-    const MathematicalProgram& prog,
-    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
-    int* A_row_count, ScsCone* cone,
-    std::vector<int>* linear_eq_y_start_indices) {
-  int num_linear_equality_constraints_rows = 0;
-  linear_eq_y_start_indices->reserve(prog.linear_equality_constraints().size());
-  // The linear equality constraint A x = b is converted to
-  // A x + s = b. s in zero cone.
-  for (const auto& linear_equality_constraint :
-       prog.linear_equality_constraints()) {
-    const Eigen::SparseMatrix<double>& Ai =
-        linear_equality_constraint.evaluator()->get_sparse_A();
-    const std::vector<Eigen::Triplet<double>> Ai_triplets =
-        math::SparseMatrixToTriplets(Ai);
-    A_triplets->reserve(A_triplets->size() + Ai_triplets.size());
-    const solvers::VectorXDecisionVariable& x =
-        linear_equality_constraint.variables();
-    // x_indices[i] is the index of x(i)
-    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
-    for (const auto& Ai_triplet : Ai_triplets) {
-      A_triplets->emplace_back(Ai_triplet.row() + *A_row_count,
-                               x_indices[Ai_triplet.col()], Ai_triplet.value());
-    }
-    const int num_Ai_rows =
-        linear_equality_constraint.evaluator()->num_constraints();
-    b->reserve(b->size() + num_Ai_rows);
-    for (int i = 0; i < num_Ai_rows; ++i) {
-      b->push_back(linear_equality_constraint.evaluator()->lower_bound()(i));
-    }
-    linear_eq_y_start_indices->push_back(*A_row_count);
-    *A_row_count += num_Ai_rows;
-    num_linear_equality_constraints_rows += num_Ai_rows;
-  }
-  cone->z += num_linear_equality_constraints_rows;
 }
 
 void ParseBoundingBoxConstraint(
@@ -350,57 +125,6 @@ void ParseBoundingBoxConstraint(
     num_bounding_box_constraint_rows += num_scs_new_constraint;
   }
   cone->l += num_bounding_box_constraint_rows;
-}
-
-void ParseSecondOrderConeConstraints(
-    const MathematicalProgram& prog,
-    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
-    int* A_row_count, std::vector<int>* second_order_cone_length,
-    std::vector<int>* lorentz_cone_y_start_indices,
-    std::vector<int>* rotated_lorentz_cone_y_start_indices) {
-  // Our LorentzConeConstraint encodes that Ax + b is in Lorentz cone. We
-  // convert this to SCS form, as -Ax + s = b, s in Lorentz cone.
-  second_order_cone_length->reserve(
-      prog.lorentz_cone_constraints().size() +
-      prog.rotated_lorentz_cone_constraints().size());
-  lorentz_cone_y_start_indices->reserve(prog.lorentz_cone_constraints().size());
-  rotated_lorentz_cone_y_start_indices->reserve(
-      prog.rotated_lorentz_cone_constraints().size());
-  for (const auto& lorentz_cone_constraint : prog.lorentz_cone_constraints()) {
-    // x_indices[i] is the index of x(i)
-    const VectorXDecisionVariable& x = lorentz_cone_constraint.variables();
-    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
-    const Eigen::SparseMatrix<double> Ai =
-        lorentz_cone_constraint.evaluator()->A();
-    const std::vector<Eigen::Triplet<double>> Ai_triplets =
-        math::SparseMatrixToTriplets(Ai);
-    for (const auto& Ai_triplet : Ai_triplets) {
-      A_triplets->emplace_back(Ai_triplet.row() + *A_row_count,
-                               x_indices[Ai_triplet.col()],
-                               -Ai_triplet.value());
-    }
-    const int num_Ai_rows = lorentz_cone_constraint.evaluator()->A().rows();
-    for (int i = 0; i < num_Ai_rows; ++i) {
-      b->push_back(lorentz_cone_constraint.evaluator()->b()(i));
-    }
-    second_order_cone_length->push_back(num_Ai_rows);
-    lorentz_cone_y_start_indices->push_back(*A_row_count);
-    *A_row_count += num_Ai_rows;
-  }
-
-  for (const auto& rotated_lorentz_cone :
-       prog.rotated_lorentz_cone_constraints()) {
-    const VectorXDecisionVariable& x = rotated_lorentz_cone.variables();
-    const std::vector<int> x_indices = prog.FindDecisionVariableIndices(x);
-    const Eigen::SparseMatrix<double> Ai =
-        rotated_lorentz_cone.evaluator()->A();
-    const Eigen::VectorXd& bi = rotated_lorentz_cone.evaluator()->b();
-    const std::vector<Eigen::Triplet<double>> Ai_triplets =
-        math::SparseMatrixToTriplets(Ai);
-    ParseRotatedLorentzConeConstraint(Ai_triplets, bi, x_indices, A_triplets, b,
-                                      A_row_count, second_order_cone_length,
-                                      rotated_lorentz_cone_y_start_indices);
-  }
 }
 
 // This function parses both PositiveSemidefinite and
@@ -500,45 +224,6 @@ void ParsePositiveSemidefiniteConstraint(
   cone->s = static_cast<scs_int*>(scs_calloc(cone->ssize, sizeof(scs_int)));
   for (int i = 0; i < cone->ssize; ++i) {
     cone->s[i] = psd_cone_length[i];
-  }
-}
-
-void ParseExponentialConeConstraint(
-    const MathematicalProgram& prog,
-    std::vector<Eigen::Triplet<double>>* A_triplets, std::vector<double>* b,
-    int* A_row_count, ScsCone* cone) {
-  cone->ep = static_cast<int>(prog.exponential_cone_constraints().size());
-  for (const auto& binding : prog.exponential_cone_constraints()) {
-    // drake::solvers::ExponentialConstraint enforces that z = A * x + b is in
-    // the exponential cone (z₀ ≥ z₁*exp(z₂ / z₁)). This is different from the
-    // exponential cone used in SCS. In SCS, a vector s is in the exponential
-    // cone, if s₂≥ s₁*exp(s₀ / s₁). To transform drake's Exponential cone to
-    // SCS's exponential cone, we use
-    // -[A.row(2); A.row(1); A.row(0)] * x + s = [b(2); b(1); b(0)], and s is
-    // in SCS's exponential cone, where A = binding.evaluator()->A(), b =
-    // binding.evaluator()->b().
-    const int num_bound_variables = binding.variables().rows();
-    for (int i = 0; i < num_bound_variables; ++i) {
-      A_triplets->reserve(A_triplets->size() +
-                          binding.evaluator()->A().nonZeros());
-      const int decision_variable_index =
-          prog.FindDecisionVariableIndex(binding.variables()(i));
-      for (Eigen::SparseMatrix<double>::InnerIterator it(
-               binding.evaluator()->A(), i);
-           it; ++it) {
-        // 2 - it.row() is used for reverse the row order, as mentioned in the
-        // function documentation above.
-        A_triplets->emplace_back(*A_row_count + 2 - it.row(),
-                                 decision_variable_index, -it.value());
-      }
-    }
-    // The exponential cone constraint is on a 3 x 1 vector, hence for each
-    // ExponentialConeConstraint, we append 3 rows to A and b.
-    b->reserve(b->size() + 3);
-    for (int i = 0; i < 3; ++i) {
-      b->push_back(binding.evaluator()->b()(2 - i));
-    }
-    *A_row_count += 3;
   }
 }
 
@@ -972,7 +657,7 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
   double cost_constant{0};
 
   // Parse linear cost
-  ParseLinearCost(prog, &c, &cost_constant);
+  internal::ParseLinearCosts(prog, &c, &cost_constant);
 
   // Parse linear equality constraint
   // linear_eq_y_start_indices[i] is the starting index of the dual
@@ -984,8 +669,11 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
   // prog.linear_equality_constraint()(i), where y is the vector containing all
   // dual variables.
   std::vector<int> linear_eq_y_start_indices;
-  ParseLinearEqualityConstraint(prog, &A_triplets, &b, &A_row_count, cone,
-                                &linear_eq_y_start_indices);
+  int num_linear_equality_constraints_rows;
+  internal::ParseLinearEqualityConstraints(
+      prog, &A_triplets, &b, &A_row_count, &linear_eq_y_start_indices,
+      &num_linear_equality_constraints_rows);
+  cone->z += num_linear_equality_constraints_rows;
 
   // Parse bounding box constraint
   // bbcon_dual_indices[i][j][0]/bbcon_dual_indices[i][j][1] is the dual
@@ -1002,8 +690,11 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
   // linear constraint prog.linear_constraint()[i], we use -1 to indicate that
   // the lower or upper bound is infinity.
   std::vector<std::vector<std::pair<int, int>>> linear_constraint_dual_indices;
-  ParseLinearConstraint(prog, &A_triplets, &b, &A_row_count, cone,
-                        &linear_constraint_dual_indices);
+  int num_linear_constraint_rows = 0;
+  internal::ParseLinearConstraints(prog, &A_triplets, &b, &A_row_count,
+                                   &linear_constraint_dual_indices,
+                                   &num_linear_constraint_rows);
+  cone->l += num_linear_constraint_rows;
 
   // Parse Lorentz cone and rotated Lorentz cone constraint
   std::vector<int> second_order_cone_length;
@@ -1021,7 +712,7 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
   // transformation on the y variable to get the dual variable in the dual cone
   // of rotated Lorentz cone.
   std::vector<int> rotated_lorentz_cone_y_start_indices;
-  ParseSecondOrderConeConstraints(
+  internal::ParseSecondOrderConeConstraints(
       prog, &A_triplets, &b, &A_row_count, &second_order_cone_length,
       &lorentz_cone_y_start_indices, &rotated_lorentz_cone_y_start_indices);
 
@@ -1043,7 +734,7 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
                                              &A_row_count,
                                              &second_order_cone_length, &num_x);
   } else {
-    ParseQuadraticCost(prog, &P_upper_triplets, &c, &cost_constant);
+    internal::ParseQuadraticCosts(prog, &P_upper_triplets, &c, &cost_constant);
   }
 
   // Set the lorentz cone length in the SCS cone.
@@ -1058,7 +749,9 @@ void ScsSolver::DoSolve(const MathematicalProgram& prog,
                                       cone);
 
   // Parse ExponentialConeConstraint.
-  ParseExponentialConeConstraint(prog, &A_triplets, &b, &A_row_count, cone);
+  internal::ParseExponentialConeConstraints(prog, &A_triplets, &b,
+                                            &A_row_count);
+  cone->ep = static_cast<int>(prog.exponential_cone_constraints().size());
 
   Eigen::SparseMatrix<double> A(A_row_count, num_x);
   A.setFromTriplets(A_triplets.begin(), A_triplets.end());

--- a/solvers/test/aggregate_costs_constraints_test.cc
+++ b/solvers/test/aggregate_costs_constraints_test.cc
@@ -455,6 +455,279 @@ GTEST_TEST(CheckConvexSolverAttributes, Test) {
   EXPECT_THAT(explanation,
               HasSubstr(nonconvex_quadratic_constraint_description));
 }
+
+GTEST_TEST(ParseLinearCosts, Test) {
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<2>();
+  const auto y = prog.NewContinuousVariables<3>();
+  prog.AddLinearCost(x[0] + 2 * y[0] + 1);
+  prog.AddLinearCost(x[1] - 2 * x[0] + 3 * y[1] - y[0] + 2);
+  std::vector<double> c(prog.num_vars(), 0);
+  double constant = 0;
+  ParseLinearCosts(prog, &c, &constant);
+  // The aggregated costs are -x[0] + x[1] + y[0] + 3y[1] + 3
+  Eigen::Matrix<double, 5, 1> coeff =
+      (Eigen::Matrix<double, 5, 1>() << -1, 1, 1, 3, 0).finished();
+  EXPECT_TRUE(CompareMatrices(Eigen::Map<Eigen::Matrix<double, 5, 1>>(c.data()),
+                              coeff));
+  EXPECT_EQ(constant, 3);
+  // Now start with a non-zero c and constant.
+  c = {1, 2, 3, 4, 5};
+  constant = 2;
+  Eigen::Matrix<double, 5, 1> c_expected =
+      coeff + Eigen::Map<Eigen::Matrix<double, 5, 1>>(c.data());
+  double constant_expected = constant + 3;
+  ParseLinearCosts(prog, &c, &constant);
+  EXPECT_TRUE(CompareMatrices(Eigen::Map<Eigen::Matrix<double, 5, 1>>(c.data()),
+                              c_expected));
+  EXPECT_EQ(constant, constant_expected);
+}
+
+GTEST_TEST(ParseLinearEqualityConstraints, Test) {
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<2>();
+  const auto y = prog.NewContinuousVariables<2>();
+  prog.AddLinearEqualityConstraint(
+      Eigen::RowVector3d(1, 2, 4), 1,
+      Vector3<symbolic::Variable>(x(0), x(0), y(1)));
+  prog.AddLinearEqualityConstraint((Eigen::Matrix2d() << 1, 2, 3, 4).finished(),
+                                   Eigen::Vector2d(2, 3),
+                                   Vector2<symbolic::Variable>(x(1), y(0)));
+  std::vector<Eigen::Triplet<double>> A_triplets;
+  std::vector<double> b;
+  int A_row_count = 0;
+  std::vector<int> linear_eq_y_start_indices;
+  int num_linear_equality_constraints_rows = 0;
+  ParseLinearEqualityConstraints(prog, &A_triplets, &b, &A_row_count,
+                                 &linear_eq_y_start_indices,
+                                 &num_linear_equality_constraints_rows);
+  Eigen::SparseMatrix<double> A(3, prog.num_vars());
+  A.setFromTriplets(A_triplets.begin(), A_triplets.end());
+  Eigen::MatrixXd A_expected(3, prog.num_vars());
+  // clang-format off
+  A_expected << 3, 0, 0, 4,
+                0, 1, 2, 0,
+                0, 3, 4, 0;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(A.toDense(), A_expected));
+  EXPECT_TRUE(CompareMatrices(Eigen::Map<Eigen::Vector3d>(b.data()),
+                              Eigen::Vector3d(1, 2, 3)));
+  EXPECT_EQ(A_row_count, 3);
+  std::vector<int> linear_eq_y_start_indices_expected{0, 1};
+  EXPECT_EQ(linear_eq_y_start_indices, linear_eq_y_start_indices_expected);
+  EXPECT_EQ(num_linear_equality_constraints_rows, 3);
+
+  // Use a non-zero A_row_count. The row indices should be offset by the initial
+  // A_row_count.
+  const int A_rows_offset = 2;
+  A_row_count = A_rows_offset;
+  A_triplets.clear();
+  b = std::vector<double>{0, 0};
+  linear_eq_y_start_indices.clear();
+  ParseLinearEqualityConstraints(prog, &A_triplets, &b, &A_row_count,
+                                 &linear_eq_y_start_indices,
+                                 &num_linear_equality_constraints_rows);
+  Eigen::SparseMatrix<double> A2(A_rows_offset + 3, prog.num_vars());
+  A2.setFromTriplets(A_triplets.begin(), A_triplets.end());
+  EXPECT_TRUE(CompareMatrices(A2.toDense().bottomRows(3), A_expected));
+  EXPECT_TRUE(
+      CompareMatrices(Eigen::Map<Eigen::Vector3d>(b.data() + A_rows_offset),
+                      Eigen::Vector3d(1, 2, 3)));
+  EXPECT_EQ(A_row_count, A_rows_offset + 3);
+  linear_eq_y_start_indices_expected =
+      std::vector<int>{A_rows_offset, A_rows_offset + 1};
+  EXPECT_EQ(linear_eq_y_start_indices, linear_eq_y_start_indices_expected);
+  EXPECT_EQ(num_linear_equality_constraints_rows, 3);
+}
+
+GTEST_TEST(ParseLinearConstraints, Test) {
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<2>();
+  const auto y = prog.NewContinuousVariables<2>();
+  prog.AddLinearConstraint(
+      (Eigen::Matrix3d() << 1, 2, 3, 4, 5, 6, 7, 8, 9).finished(),
+      Eigen::Vector3d(-kInf, 3, 2), Eigen::Vector3d(1, kInf, 4),
+      Vector3<symbolic::Variable>(x(0), y(0), x(0)));
+  prog.AddLinearConstraint(Eigen::RowVector3d(1, 2, 3), -1, 3,
+                           Vector3<symbolic::Variable>(y(0), y(1), x(1)));
+  std::vector<Eigen::Triplet<double>> A_triplets;
+  std::vector<double> b;
+  int A_row_count = 0;
+  std::vector<std::vector<std::pair<int, int>>> linear_constraint_dual_indices;
+  int num_linear_constraint_rows;
+  ParseLinearConstraints(prog, &A_triplets, &b, &A_row_count,
+                         &linear_constraint_dual_indices,
+                         &num_linear_constraint_rows);
+  EXPECT_EQ(num_linear_constraint_rows, 6);
+  Eigen::SparseMatrix<double> A(6, prog.num_vars());
+  A.setFromTriplets(A_triplets.begin(), A_triplets.end());
+  Eigen::MatrixXd A_expected(6, prog.num_vars());
+  // clang-format off
+  A_expected << 4, 0, 2, 0,
+                -10, 0, -5, 0,
+                -16, 0, -8, 0,
+                16, 0, 8, 0,
+                0, -3, -1, -2,
+                0, 3, 1, 2;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(A.toDense(), A_expected));
+  EXPECT_TRUE(CompareMatrices(Eigen::Map<Vector6d>(b.data()),
+                              (Vector6d() << 1, -3, -2, 4, 1, 3).finished()));
+  EXPECT_EQ(A_row_count, 6);
+  std::vector<std::vector<std::pair<int, int>>>
+      linear_constraint_dual_indices_expected;
+  linear_constraint_dual_indices_expected.push_back({{-1, 0}, {1, -1}, {2, 3}});
+  linear_constraint_dual_indices_expected.push_back({{4, 5}});
+  EXPECT_EQ(linear_constraint_dual_indices,
+            linear_constraint_dual_indices_expected);
+  EXPECT_EQ(num_linear_constraint_rows, 6);
+}
+
+GTEST_TEST(ParseQuadraticCosts, Test) {
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<3>();
+  prog.AddQuadraticCost((Eigen::Matrix2d() << 1, 3, 2, 4).finished(),
+                        Eigen::Vector2d(1, 2), 1, x.tail<2>());
+  prog.AddQuadraticCost(
+      (Eigen::Matrix3d() << 1, 2, 3, 4, 5, 6, 7, 8, 9).finished(),
+      Eigen::Vector3d(2, 3, 4), 2,
+      Vector3<symbolic::Variable>(x(0), x(1), x(0)));
+  std::vector<Eigen::Triplet<double>> P_upper_triplets;
+  std::vector<double> c(prog.num_vars(), 0);
+  double constant;
+  ParseQuadraticCosts(prog, &P_upper_triplets, &c, &constant);
+  // The total cost is 0.5 * (20*x0^2 + 6*x1^2 + 4*x2^2 + 5*x1*x2 + 20*x0*x1) +
+  // 6*x0 + 4*x1 + 2*x(2) + 3
+  Eigen::SparseMatrix<double> P_upper(prog.num_vars(), prog.num_vars());
+  P_upper.setFromTriplets(P_upper_triplets.begin(), P_upper_triplets.end());
+  Eigen::Matrix3d P_upper_expected;
+  // clang-format off
+  P_upper_expected << 20, 10, 0,
+                       0,  6, 2.5,
+                       0,  0, 4;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(P_upper.toDense(), P_upper_expected));
+}
+
+GTEST_TEST(ParseSecondOrderConeConstraints, LorentzCone) {
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<3>();
+
+  prog.AddLorentzConeConstraint(
+      (Eigen::Matrix<double, 4, 3>() << 1, 0, 2, -1, 2, 3, 1, 2, 4, -2, 1, 2)
+          .finished(),
+      Eigen::Vector4d(1, 2, 3, 4),
+      Vector3<symbolic::Variable>(x(1), x(0), x(1)));
+
+  prog.AddLorentzConeConstraint(
+      (Eigen::Matrix<double, 4, 2>() << 1, 2, 3, 4, 5, 6, 7, 8).finished(),
+      Eigen::Vector4d(-1, -2, -3, -4), Vector2<symbolic::Variable>(x(2), x(0)));
+  std::vector<Eigen::Triplet<double>> A_triplets;
+  std::vector<double> b;
+  int A_row_count{0};
+  std::vector<int> second_order_cone_length;
+  std::vector<int> lorentz_cone_y_start_indices;
+  std::vector<int> rotated_lorentz_cone_y_start_indices;
+  ParseSecondOrderConeConstraints(
+      prog, &A_triplets, &b, &A_row_count, &second_order_cone_length,
+      &lorentz_cone_y_start_indices, &rotated_lorentz_cone_y_start_indices);
+  EXPECT_EQ(A_row_count, 8);
+  Eigen::SparseMatrix<double> A(8, prog.num_vars());
+  A.setFromTriplets(A_triplets.begin(), A_triplets.end());
+  Eigen::MatrixXd A_expected(8, prog.num_vars());
+  // clang-format off
+  A_expected << 0, -3, 0,
+                -2, -2, 0,
+                -2, -5, 0,
+                -1, 0, 0,
+                 -2, 0, -1,
+                 -4, 0, -3,
+                 -6, 0, -5,
+                 -8, 0, -7;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(A.toDense(), A_expected));
+  Eigen::Matrix<double, 8, 1> b_expected;
+  b_expected << 1, 2, 3, 4, -1, -2, -3, -4;
+  EXPECT_TRUE(CompareMatrices(Eigen::Map<Eigen::Matrix<double, 8, 1>>(b.data()),
+                              b_expected));
+  EXPECT_EQ(second_order_cone_length, std::vector<int>({4, 4}));
+  EXPECT_EQ(lorentz_cone_y_start_indices, std::vector<int>({0, 4}));
+  EXPECT_EQ(rotated_lorentz_cone_y_start_indices, std::vector<int>());
+}
+
+GTEST_TEST(ParseSecondOrderConeConstraints, RotatedLorentzConeConstraint) {
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<3>();
+  prog.AddRotatedLorentzConeConstraint(
+      (Eigen::Matrix<double, 4, 3>() << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+          .finished(),
+      Eigen::Vector4d(0, 1, 2, 3),
+      Vector3<symbolic::Variable>(x(1), x(0), x(1)));
+  prog.AddRotatedLorentzConeConstraint(
+      (Eigen::Matrix<double, 3, 4>() << -1, -2, -3, -4, -5, -6, -7, -8, -9, -10,
+       -11, -12)
+          .finished(),
+      Eigen::Vector3d(5, 6, 7),
+      Vector4<symbolic::Variable>(x(1), x(0), x(0), x(2)));
+  std::vector<Eigen::Triplet<double>> A_triplets;
+  std::vector<double> b;
+  int A_row_count{0};
+  std::vector<int> second_order_cone_length;
+  std::vector<int> lorentz_cone_y_start_indices;
+  std::vector<int> rotated_lorentz_cone_y_start_indices;
+  ParseSecondOrderConeConstraints(
+      prog, &A_triplets, &b, &A_row_count, &second_order_cone_length,
+      &lorentz_cone_y_start_indices, &rotated_lorentz_cone_y_start_indices);
+  EXPECT_EQ(A_row_count, 7);
+  Eigen::SparseMatrix<double> A(7, prog.num_vars());
+  A.setFromTriplets(A_triplets.begin(), A_triplets.end());
+  Eigen::MatrixXd A_expected(7, prog.num_vars());
+  // clang-format off
+  A_expected << -3.5, -7, 0,
+                 1.5, 3, 0,
+                 -8, -16, 0,
+                 -11, -22, 0,
+                 9, 3, 6,
+                 -4, -2, -2,
+                 21, 9, 12;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(A.toDense(), A_expected));
+  Eigen::Matrix<double, 7, 1> b_expected;
+  b_expected << 0.5, -0.5, 2, 3, 5.5, -0.5, 7;
+  EXPECT_TRUE(CompareMatrices(Eigen::Map<Eigen::Matrix<double, 7, 1>>(b.data()),
+                              b_expected));
+  EXPECT_EQ(second_order_cone_length, std::vector<int>({4, 3}));
+  EXPECT_EQ(lorentz_cone_y_start_indices, std::vector<int>());
+  EXPECT_EQ(rotated_lorentz_cone_y_start_indices, std::vector<int>({0, 4}));
+}
+
+GTEST_TEST(ParseExponentialConeConstraints, Test) {
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<3>();
+  prog.AddExponentialConeConstraint(
+      (Eigen::Matrix<double, 3, 4>() << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+          .finished()
+          .sparseView(),
+      Eigen::Vector3d(1, 2, 3),
+      Vector4<symbolic::Variable>(x(1), x(0), x(2), x(0)));
+  std::vector<Eigen::Triplet<double>> A_triplets;
+  std::vector<double> b;
+  int A_row_count = 0;
+  ParseExponentialConeConstraints(prog, &A_triplets, &b, &A_row_count);
+  EXPECT_EQ(A_row_count, 3);
+  Eigen::SparseMatrix<double> A(3, prog.num_vars());
+  A.setFromTriplets(A_triplets.begin(), A_triplets.end());
+  Eigen::Matrix3d A_expected;
+  // clang-format off
+  A_expected << -22, -9, -11,
+                -14, -5, -7,
+                -6, -1, -3;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(A.toDense(), A_expected));
+  EXPECT_EQ(b.size(), 3);
+  EXPECT_TRUE(CompareMatrices(Eigen::Map<Eigen::Vector3d>(b.data()),
+                              Eigen::Vector3d(3, 2, 1)));
+}
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Move the functions that convert MathematicalProgram costs/constraints to SCS format to aggregate_costs_constraints.h/cc, as these functions will be re-used for Clarabel.