### PR TITLE
[pydrake] Remove misleadingly long spellings in BUILD files

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -94,8 +94,8 @@ drake_pybind_library(
     name = "autodiffutils_py",
     cc_deps = [
         ":autodiff_types_pybind",
-        "//bindings/pydrake:documentation_pybind",
-        "//bindings/pydrake:math_operators_pybind",
+        ":documentation_pybind",
+        ":math_operators_pybind",
     ],
     cc_srcs = ["autodiffutils_py.cc"],
     package_info = PACKAGE_INFO,
@@ -112,7 +112,7 @@ drake_pybind_library(
 drake_pybind_library(
     name = "lcm_py",
     cc_deps = [
-        "//bindings/pydrake:documentation_pybind",
+        ":documentation_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:serialize_pybind",
     ],
@@ -134,10 +134,10 @@ drake_cc_library(
 drake_pybind_library(
     name = "math_py",
     cc_deps = [
-        "//bindings/pydrake:autodiff_types_pybind",
-        "//bindings/pydrake:documentation_pybind",
-        "//bindings/pydrake:math_operators_pybind",
-        "//bindings/pydrake:symbolic_types_pybind",
+        ":autodiff_types_pybind",
+        ":documentation_pybind",
+        ":math_operators_pybind",
+        ":symbolic_types_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:eigen_pybind",
@@ -148,8 +148,8 @@ drake_pybind_library(
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
-        "//bindings/pydrake:autodiffutils_py",
-        "//bindings/pydrake:symbolic_py",
+        ":autodiffutils_py",
+        ":symbolic_py",
         "//bindings/pydrake/common:eigen_geometry_py",
         "//bindings/pydrake/common:value_py",
     ],
@@ -159,7 +159,7 @@ drake_pybind_library(
 drake_pybind_library(
     name = "perception_py",
     cc_deps = [
-        "//bindings/pydrake:documentation_pybind",
+        ":documentation_pybind",
         "//bindings/pydrake/common:value_pybind",
     ],
     cc_srcs = ["perception_py.cc"],
@@ -182,16 +182,16 @@ drake_cc_library(
 drake_pybind_library(
     name = "polynomial_py",
     cc_deps = [
+        ":documentation_pybind",
         ":polynomial_types_pybind",
-        "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
     ],
     cc_srcs = ["polynomial_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
-        "//bindings/pydrake:autodiffutils_py",
-        "//bindings/pydrake:symbolic_py",
+        ":autodiffutils_py",
+        ":symbolic_py",
         "//bindings/pydrake/common:value_py",
     ],
 )
@@ -202,17 +202,17 @@ drake_cc_library(
     declare_installed_headers = 0,
     visibility = ["//visibility:public"],
     deps = [
+        ":documentation_pybind",
         "//:drake_shared_library",
-        "//bindings/pydrake:documentation_pybind",
     ],
 )
 
 drake_pybind_library(
     name = "symbolic_py",
     cc_deps = [
+        ":documentation_pybind",
+        ":math_operators_pybind",
         ":symbolic_types_pybind",
-        "//bindings/pydrake:documentation_pybind",
-        "//bindings/pydrake:math_operators_pybind",
         "//bindings/pydrake/common:eigen_pybind",
     ],
     cc_srcs = [
@@ -231,8 +231,8 @@ drake_pybind_library(
 drake_pybind_library(
     name = "trajectories_py",
     cc_deps = [
+        ":documentation_pybind",
         ":polynomial_types_pybind",
-        "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
     ],
@@ -240,9 +240,9 @@ drake_pybind_library(
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
-        "//bindings/pydrake:autodiffutils_py",
-        "//bindings/pydrake:polynomial_py",
-        "//bindings/pydrake:symbolic_py",
+        ":autodiffutils_py",
+        ":polynomial_py",
+        ":symbolic_py",
         "//bindings/pydrake/common:value_py",
     ],
     py_srcs = [
@@ -329,7 +329,7 @@ drake_cc_googletest(
 # decoupled test.
 drake_pybind_cc_googletest(
     name = "pydrake_pybind_test",
-    cc_deps = ["//bindings/pydrake:test_util_pybind"],
+    cc_deps = [":test_util_pybind"],
     py_deps = [":module_py"],
     py_srcs = ["test/_pydrake_pybind_test_extra.py"],
 )
@@ -379,7 +379,7 @@ drake_pybind_library(
     add_install = False,
     cc_deps = [
         ":autodiff_types_pybind",
-        "//bindings/pydrake:documentation_pybind",
+        ":documentation_pybind",
     ],
     cc_so_name = "test/autodiffutils_test_util",
     cc_srcs = ["test/autodiffutils_test_util_py.cc"],
@@ -406,8 +406,8 @@ drake_pybind_library(
     testonly = 1,
     add_install = False,
     cc_deps = [
+        ":documentation_pybind",
         ":symbolic_types_pybind",
-        "//bindings/pydrake:documentation_pybind",
     ],
     cc_so_name = "test/odr_test_module",
     cc_srcs = ["test/odr_test_module_py.cc"],
@@ -540,8 +540,8 @@ drake_py_unittest(
 drake_py_unittest(
     name = "dot_clang_format_test",
     data = [
+        ":.clang-format",
         "//:.clang-format",
-        "//bindings/pydrake:.clang-format",
     ],
     tags = ["lint"],
 )

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -40,9 +40,9 @@ PACKAGE_INFO = get_pybind_package_info("//bindings")
 drake_pybind_library(
     name = "_init_py",
     cc_deps = [
+        ":value_pybind",
         "//bindings/pydrake:autodiff_types_pybind",
         "//bindings/pydrake:documentation_pybind",
-        "//bindings/pydrake/common:value_pybind",
         "//common:nice_type_name_override_header",
     ],
     cc_so_name = "_module_py",
@@ -178,8 +178,8 @@ drake_cc_library(
     declare_installed_headers = 0,
     visibility = ["//visibility:public"],
     deps = [
+        ":cpp_template_pybind",
         "//:drake_shared_library",
-        "//bindings/pydrake/common:cpp_template_pybind",
     ],
 )
 
@@ -431,9 +431,9 @@ drake_pybind_library(
     name = "schema_py",
     cc_deps = [
         ":cpp_template_pybind",
+        ":serialize_pybind",
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake:symbolic_types_pybind",
-        "//bindings/pydrake/common:serialize_pybind",
     ],
     cc_srcs = ["schema_py.cc"],
     package_info = PACKAGE_INFO,
@@ -750,7 +750,7 @@ drake_pybind_cc_googletest(
         "//bindings/pydrake:test_util_pybind",
     ],
     py_deps = [
-        "//bindings/pydrake/common:value_py",
+        ":value_py",
     ],
 )
 

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -541,9 +541,9 @@ drake_py_unittest(
     ],
     deps = [
         ":mesh_model_maker_py",
+        ":parsing_py",
+        ":plant_py",
         "//bindings/pydrake/common",
-        "//bindings/pydrake/multibody:parsing_py",
-        "//bindings/pydrake/multibody:plant_py",
         "//bindings/pydrake/systems:framework_py",
     ],
 )
@@ -562,11 +562,11 @@ drake_py_unittest(
     ],
     deps = [
         ":inertia_fixer_py",
+        ":parsing_py",
+        ":plant_py",
         "//bindings/pydrake/common",
         "//bindings/pydrake/common/test_utilities:numpy_compare_py",
         "//bindings/pydrake/geometry",
-        "//bindings/pydrake/multibody:parsing_py",
-        "//bindings/pydrake/multibody:plant_py",
     ],
 )
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20382)
<!-- Reviewable:end -->
