### PR TITLE
[multibody] Allow zero-dof trees in the multibody forest

### DIFF
--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -442,18 +442,19 @@ void SapDriver<T>::AddDistanceConstraints(const systems::Context<T>& context,
                                                        BodyIndex bodyB) {
       const TreeIndex treeA_index = tree_topology().body_to_tree_index(bodyA);
       const TreeIndex treeB_index = tree_topology().body_to_tree_index(bodyB);
-      // Sanity check at least one body is not the world.
-      DRAKE_DEMAND(treeA_index.is_valid() || treeB_index.is_valid());
+      const bool treeA_has_dofs = tree_topology().tree_has_dofs(treeA_index);
+      const bool treeB_has_dofs = tree_topology().tree_has_dofs(treeB_index);
+
+      // Sanity check at least one body is not World or anchored to World.
+      DRAKE_DEMAND(treeA_has_dofs || treeB_has_dofs);
 
       // Both bodies A and B belong to the same tree or one of them is the
       // world.
-      const bool single_tree = !treeA_index.is_valid() ||
-                               !treeB_index.is_valid() ||
-                               treeA_index == treeB_index;
+      const bool single_tree =
+          !treeA_has_dofs || !treeB_has_dofs || treeA_index == treeB_index;
 
       if (single_tree) {
-        const TreeIndex tree_index =
-            treeA_index.is_valid() ? treeA_index : treeB_index;
+        const TreeIndex tree_index = treeA_has_dofs ? treeA_index : treeB_index;
         MatrixX<T> Jtree = Jv_ApBq_W.middleCols(
             tree_topology().tree_velocities_start(tree_index),
             tree_topology().num_tree_velocities(tree_index));
@@ -531,11 +532,13 @@ void SapDriver<T>::AddBallConstraints(
           tree_topology().body_to_tree_index(body_A.index());
       const TreeIndex treeB_index =
           tree_topology().body_to_tree_index(body_B.index());
+      const bool treeA_has_dofs = tree_topology().tree_has_dofs(treeA_index);
+      const bool treeB_has_dofs = tree_topology().tree_has_dofs(treeB_index);
 
       // TODO(joemasterjohn): Move this exception up to the plant level so that
       // it fails as fast as possible. Currently, the earliest this can happen
       // is in MbP::Finalize() after the topology has been finalized.
-      if (!treeA_index.is_valid() && !treeB_index.is_valid()) {
+      if (!treeA_has_dofs && !treeB_has_dofs) {
         const std::string msg = fmt::format(
             "Creating a ball Constraint between bodies '{}' and '{}' where "
             "both are welded to the world is not allowed.",
@@ -545,13 +548,11 @@ void SapDriver<T>::AddBallConstraints(
 
       // Both bodies A and B belong to the same tree or one of them is the
       // world.
-      const bool single_tree = !treeA_index.is_valid() ||
-                               !treeB_index.is_valid() ||
-                               treeA_index == treeB_index;
+      const bool single_tree =
+          !treeA_has_dofs || !treeB_has_dofs || treeA_index == treeB_index;
 
       if (single_tree) {
-        const TreeIndex tree_index =
-            treeA_index.is_valid() ? treeA_index : treeB_index;
+        const TreeIndex tree_index = treeA_has_dofs ? treeA_index : treeB_index;
         MatrixX<T> Jtree = Jv_ApBq_W.middleCols(
             tree_topology().tree_velocities_start(tree_index),
             tree_topology().num_tree_velocities(tree_index));
@@ -625,11 +626,13 @@ void SapDriver<T>::AddWeldConstraints(
           tree_topology().body_to_tree_index(bodyA.index());
       const TreeIndex treeB_index =
           tree_topology().body_to_tree_index(bodyB.index());
+      const bool treeA_has_dofs = tree_topology().tree_has_dofs(treeA_index);
+      const bool treeB_has_dofs = tree_topology().tree_has_dofs(treeB_index);
 
       // TODO(joemasterjohn): Move this exception up to the plant level so
       // that it fails as fast as possible. Currently, the earliest this can
       // happen is in MbP::Finalize() after the topology has been finalized.
-      if (!treeA_index.is_valid() && !treeB_index.is_valid()) {
+      if (!treeA_has_dofs && !treeB_has_dofs) {
         const std::string msg = fmt::format(
             "Creating a weld constraint between bodies '{}' and '{}' where "
             "both are welded to the world is not allowed.",
@@ -639,13 +642,11 @@ void SapDriver<T>::AddWeldConstraints(
 
       // Both bodies A and B belong to the same tree or one of them is the
       // world.
-      const bool single_tree = !treeA_index.is_valid() ||
-                               !treeB_index.is_valid() ||
-                               treeA_index == treeB_index;
+      const bool single_tree =
+          !treeA_has_dofs || !treeB_has_dofs || treeA_index == treeB_index;
 
       if (single_tree) {
-        const TreeIndex tree_index =
-            treeA_index.is_valid() ? treeA_index : treeB_index;
+        const TreeIndex tree_index = treeA_has_dofs ? treeA_index : treeB_index;
         MatrixX<T> Jtree_W = J_W_AmBm.middleCols(
             tree_topology().tree_velocities_start(tree_index),
             tree_topology().num_tree_velocities(tree_index));

--- a/multibody/plant/test/sap_driver_ball_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_ball_constraints_test.cc
@@ -140,10 +140,11 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
   // One clique if body A is anchored, two if not.
   const int expected_num_cliques = config.bodyA_anchored ? 1 : 2;
   EXPECT_EQ(constraint->num_cliques(), expected_num_cliques);
-  EXPECT_EQ(constraint->first_clique(), 0);
   if (expected_num_cliques == 1) {
+    EXPECT_EQ(constraint->first_clique(), 1);  // i.e., bodyB's tree
     EXPECT_THROW(constraint->second_clique(), std::exception);
   } else {
+    EXPECT_EQ(constraint->first_clique(), 0);
     EXPECT_EQ(constraint->second_clique(), 1);
   }
 

--- a/multibody/plant/test/sap_driver_distance_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_distance_constraints_test.cc
@@ -154,10 +154,11 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
   // One clique if body A is anchored, two if not.
   const int expected_num_cliques = config.bodyA_anchored ? 1 : 2;
   EXPECT_EQ(constraint->num_cliques(), expected_num_cliques);
-  EXPECT_EQ(constraint->first_clique(), 0);
   if (expected_num_cliques == 1) {
+    EXPECT_EQ(constraint->first_clique(), 1);  // i.e. body B's tree
     EXPECT_THROW(constraint->second_clique(), std::exception);
   } else {
+    EXPECT_EQ(constraint->first_clique(), 0);
     EXPECT_EQ(constraint->second_clique(), 1);
   }
 

--- a/multibody/plant/test/sap_driver_weld_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_weld_constraints_test.cc
@@ -149,10 +149,11 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
   // One clique if body A is anchored, two if not.
   const int expected_num_cliques = config.bodyA_anchored ? 1 : 2;
   EXPECT_EQ(constraint->num_cliques(), expected_num_cliques);
-  EXPECT_EQ(constraint->first_clique(), 0);
   if (expected_num_cliques == 1) {
+    EXPECT_EQ(constraint->first_clique(), 1);  // i.e., bodyB's tree
     EXPECT_THROW(constraint->second_clique(), std::exception);
   } else {
+    EXPECT_EQ(constraint->first_clique(), 0);
     EXPECT_EQ(constraint->second_clique(), 1);
   }
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -729,7 +729,7 @@ void MultibodyTree<T>::FinalizeInternals() {
     actuator->SetTopology(topology_);
   }
 
-  body_node_levels_.resize(topology_.tree_height());
+  body_node_levels_.resize(topology_.forest_height());
   for (BodyNodeIndex body_node_index(1);
        body_node_index < topology_.get_num_body_nodes(); ++body_node_index) {
     const BodyNodeTopology& node_topology =

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -648,7 +648,7 @@ class MultibodyTree {
   // frames. Therefore, this method does not count kinematic cycles, which
   // could only be considered in the model using constraints.
   int tree_height() const {
-    return topology_.tree_height();
+    return topology_.forest_height();
   }
 
   // Returns a constant reference to the *world* body.

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -450,7 +450,7 @@ class MultibodyTreeTopology {
   // members of `other`.
   bool operator==(const MultibodyTreeTopology& other) const {
     if (is_valid_ != other.is_valid_) return false;
-    if (tree_height_ != other.tree_height_) return false;
+    if (forest_height_ != other.forest_height_) return false;
 
     if (num_positions_ != other.num_positions_) return false;
     if (num_velocities_ != other.num_velocities_) return false;
@@ -498,9 +498,9 @@ class MultibodyTreeTopology {
     return ssize(joint_actuators_);
   }
 
-  // Returns the number of tree levels in the topology.
-  int tree_height() const {
-    return tree_height_;
+  // Returns the number of levels in the forest topology.
+  int forest_height() const {
+    return forest_height_;
   }
 
   // Returns a constant reference to the corresponding FrameTopology given the
@@ -587,6 +587,14 @@ class MultibodyTreeTopology {
   TreeIndex velocity_to_tree_index(int v) const {
     DRAKE_ASSERT(0 <= v && v < num_velocities());
     return velocity_to_tree_index_[v];
+  }
+
+  // Given a tree index, returns `true` if that tree has any degrees of freedom
+  // (ignoring joint locking). An invalid tree index is treated as World's
+  // "tree", which has no dofs.
+  bool tree_has_dofs(TreeIndex tree_index) const {
+    if (!tree_index.is_valid()) return false;  // World doesn't have a Tree.
+    return num_tree_velocities(tree_index) > 0;
   }
 
   // Creates and adds a new BodyTopology to this MultibodyTreeTopology.
@@ -791,7 +799,7 @@ class MultibodyTreeTopology {
     // For each body, assign a body node in a depth first traversal order.
     std::stack<BodyIndex> stack;
     stack.push(BodyIndex(0));  // Starts at the root.
-    tree_height_ = 1;  // At least one level with the world body at the root.
+    forest_height_ = 1;  // At least one level with the world body at the root.
     body_nodes_.reserve(num_bodies());
     while (!stack.empty()) {
       const BodyNodeIndex node(get_num_body_nodes());
@@ -810,7 +818,7 @@ class MultibodyTreeTopology {
       // Updates body levels.
       bodies_[current].level = level;
       // Keep track of the number of levels, the deepest (i.e. max) level.
-      tree_height_ = std::max(tree_height_, level + 1);
+      forest_height_ = std::max(forest_height_, level + 1);
 
       // Since we are doing a DFT, it is valid to ask for the parent node,
       // unless we are at the root.
@@ -1194,20 +1202,18 @@ class MultibodyTreeTopology {
     for (const BodyNodeIndex& root_child_index : root.child_nodes) {
       const BodyNodeTopology& root_child = get_body_node(root_child_index);
       const int nt = CalcNumberOfOutboardVelocities(root_child);
-      if (nt > 0) {
-        const TreeIndex tree_index(num_trees());
-        num_tree_velocities_.push_back(nt);
-        TraverseOutboardNodes(root_child, [&](const BodyNodeTopology& node) {
-          // We recurse all bodies in this tree (with tree_index) to fill in the
-          // maps from body index to tree index and from velocity index to tree
-          // index.
-          body_to_tree_index_[node.body] = tree_index;
-          for (int i = 0; i < node.num_mobilizer_velocities; ++i) {
-            const int v = node.mobilizer_velocities_start_in_v + i;
-            velocity_to_tree_index_[v] = tree_index;
-          }
-        });
-      }
+      const TreeIndex tree_index(num_trees());
+      num_tree_velocities_.push_back(nt);
+      TraverseOutboardNodes(root_child, [&](const BodyNodeTopology& node) {
+        // We recurse all bodies in this tree (with tree_index) to fill in the
+        // maps from body index to tree index and from velocity index to tree
+        // index.
+        body_to_tree_index_[node.body] = tree_index;
+        for (int i = 0; i < node.num_mobilizer_velocities; ++i) {
+          const int v = node.mobilizer_velocities_start_in_v + i;
+          velocity_to_tree_index_[v] = tree_index;
+        }
+      });
     }
 
     // N.B. For trees with no generalized velocities, this code sets
@@ -1235,9 +1241,9 @@ class MultibodyTreeTopology {
 
   // is_valid is set to `true` after a successful Finalize().
   bool is_valid_{false};
-  // Number of levels (or generations) in the tree topology. After Finalize()
+  // Number of levels (or generations) in the forest topology. After Finalize()
   // there will be at least one level (level = 0) with the world body.
-  int tree_height_{-1};
+  int forest_height_{-1};
 
   // Topological elements:
   std::vector<FrameTopology> frames_;


### PR DESCRIPTION
This internal-only change brings the definition of a "tree" in line with the upcoming SpanningForest, and with standard graph terminology. Previously zero-dof trees didn't count, now they do. This required some minor changes to a few unit tests and to how constraints decide whether they have 1 clique or 2. (Consequences cleared f2f w/Alejandro)

Also renamed `MultibodyTreeTopology::tree_height()` to `::forest_height()` to avoid missing the forest for the trees.

This is a yak shave for the new MbP topology in #20225.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20386)
<!-- Reviewable:end -->
