### PR TITLE
Fix divide by norm bug in RotationMatrix::NormalizeOrThrow().

### DIFF
--- a/math/rotation_matrix.cc
+++ b/math/rotation_matrix.cc
@@ -397,10 +397,11 @@ Vector3<T> RotationMatrix<T>::NormalizeOrThrow(const Vector3<T>& v,
     // an expected small physical dimensions in a robotic systems.  Numbers
     // smaller than this are probably user or developer errors.
     constexpr double kMinMagnitude = 1e-10;
-    const double norm = ExtractDoubleOrThrow(v.norm());
+    const T norm = v.norm();
+    const double norm_as_double = ExtractDoubleOrThrow(norm);
     // Normalize the vector v if norm is finite and sufficiently large.
     // Throw an exception if norm is non-finite (NaN or infinity) or too small.
-    if (std::isfinite(norm) && norm >= kMinMagnitude) {
+    if (std::isfinite(norm_as_double) && norm_as_double >= kMinMagnitude) {
       u = v / norm;
     } else {
       const double vx = ExtractDoubleOrThrow(v.x());
@@ -414,7 +415,7 @@ Vector3<T> RotationMatrix<T>::NormalizeOrThrow(const Vector3<T>& v,
           " magnitude of at least {} to automatically normalize. If"
           " you are confident that v's direction is meaningful, pass"
           " v.normalized() in place of v.",
-          function_name, vx, vy, vz, norm, kMinMagnitude));
+          function_name, vx, vy, vz, norm_as_double, kMinMagnitude));
     }
   } else {
     // Do not use u = v.normalized() with an underlying symbolic type since

--- a/math/rotation_matrix.cc
+++ b/math/rotation_matrix.cc
@@ -394,7 +394,6 @@ Vector3<T> RotationMatrix<T>::NormalizeOrThrow(const Vector3<T>& v,
                                                const char* function_name) {
   DRAKE_DEMAND(function_name != nullptr);
   const T norm = v.norm();
-  // Throw an exception if norm is non-finite (NaN or infinity) or too small.
   if constexpr (scalar_predicate<T>::is_bool) {
     // Throw an exception if norm is non-finite (NaN or infinity) or too small.
     // The threshold for "too small" is a heuristic (rule of thumb) guided by an

--- a/math/rotation_matrix.cc
+++ b/math/rotation_matrix.cc
@@ -4,6 +4,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/unused.h"
 #include "drake/math/autodiff.h"
 
@@ -391,39 +392,29 @@ double ProjectMatToRotMatWithAxis(const Eigen::Matrix3d& M,
 template <typename T>
 Vector3<T> RotationMatrix<T>::NormalizeOrThrow(const Vector3<T>& v,
                                                const char* function_name) {
-  Vector3<T> u;
+  DRAKE_DEMAND(function_name != nullptr);
+  const T norm = v.norm();
+  // Throw an exception if norm is non-finite (NaN or infinity) or too small.
   if constexpr (scalar_predicate<T>::is_bool) {
-    // The number 1.0E-10 is a heuristic (rule of thumb) that is guided by
-    // an expected small physical dimensions in a robotic systems.  Numbers
-    // smaller than this are probably user or developer errors.
-    constexpr double kMinMagnitude = 1e-10;
-    const T norm = v.norm();
-    const double norm_as_double = ExtractDoubleOrThrow(norm);
-    // Normalize the vector v if norm is finite and sufficiently large.
     // Throw an exception if norm is non-finite (NaN or infinity) or too small.
-    if (std::isfinite(norm_as_double) && norm_as_double >= kMinMagnitude) {
-      u = v / norm;
-    } else {
-      const double vx = ExtractDoubleOrThrow(v.x());
-      const double vy = ExtractDoubleOrThrow(v.y());
-      const double vz = ExtractDoubleOrThrow(v.z());
+    // The threshold for "too small" is a heuristic (rule of thumb) guided by an
+    // expected small physical dimensions in a robotic systems. Numbers smaller
+    // than this are probably user or developer errors.
+    constexpr double kMinMagnitude = 1e-10;
+    using std::isfinite;
+    if (!(isfinite(norm) && norm >= kMinMagnitude)) {
       throw std::logic_error(fmt::format(
           "RotationMatrix::{}() cannot normalize the given vector.\n"
-          "   v: {} {} {}\n"
+          "   v: {}\n"
           " |v|: {}\n"
-          " The measures must be finite and the vector must have a"
-          " magnitude of at least {} to automatically normalize. If"
-          " you are confident that v's direction is meaningful, pass"
-          " v.normalized() in place of v.",
-          function_name, vx, vy, vz, norm_as_double, kMinMagnitude));
+          " The measures must be finite and the vector must have a magnitude of"
+          " at least {} to normalize. If you are confident that v's direction"
+          " is meaningful, pass v.normalized() in place of v.",
+          function_name, fmt_eigen(DiscardGradient(v).transpose()),
+          ExtractDoubleOrThrow(norm), kMinMagnitude));
     }
-  } else {
-    // Do not use u = v.normalized() with an underlying symbolic type since
-    // normalized() is incompatible with symbolic::Expression.
-    u = v / v.norm();
-    unused(function_name);
   }
-  return u;
+  return v / norm;
 }
 
 template <typename T>

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -1312,8 +1312,10 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneVectorExceptions) {
       RotationMatrix<double>::MakeFromOneVector(Vector3<double>(NAN, 1, NAN),
                                                 axis_index),
       "RotationMatrix::MakeFromOneVector.* cannot normalize the given vector"
-      "[^]+ nan 1.* nan[^]+ If you are confident that v's direction is "
-      "meaningful, pass v.normalized.. in place of v.");
+      "[^]+ nan[^]+ 1.* nan[^]+ |v|[^]+ nan[^]+ The measures must be finite "
+      "and the vector must have a magnitude of at least [^]+ to normalize. "
+      "If you are confident that v's direction is meaningful, "
+      "pass v.normalized..* in place of v.");
 
   // Verify vector with infinity throws an exception.
   constexpr double kInfinity = std::numeric_limits<double>::infinity();
@@ -1321,17 +1323,20 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneVectorExceptions) {
       RotationMatrix<double>::MakeFromOneVector(
           Vector3<double>(kInfinity, 1, 0), axis_index),
       "RotationMatrix::MakeFromOneVector.* cannot normalize the given vector"
-      "[^]+ inf 1.* 0[^]+ If you are confident that v's direction is "
-      "meaningful, pass v.normalized.. in place of v.");
+      "[^]+ inf[^]+ 1.* 0[^]+ |v|[^]+ inf[^]+ The measures must be finite "
+      "and the vector must have a magnitude of at least [^]+ to normalize. "
+      "If you are confident that v's direction is meaningful, "
+      "pass v.normalized..* in place of v.");
 
   // Verify that a vector that is slightly too small throws.
   constexpr double kTolerance = 2 * std::numeric_limits<double>::epsilon();
   const Vector3<double> too_small_vector(1.0E-10 - kTolerance, 0, 0);
   DRAKE_EXPECT_THROWS_MESSAGE(
       RotationMatrix<double>::MakeFromOneVector(too_small_vector, axis_index),
-      "RotationMatrix::MakeFromOneVector.* cannot normalize the given vector"
-      "[^]+ If you are confident that v's direction is meaningful, pass "
-      "v.normalized.. in place of v.");
+      "RotationMatrix::MakeFromOneVector.* cannot normalize the given vector."
+      "[^]+ 0[^]+ 0[^]+ The measures must be finite and the vector must have a "
+      "magnitude of at least [^]+ to normalize. If you are confident that v's "
+      "direction is meaningful, pass v.normalized..* in place of v.");
 
   // Verify a vector with a magnitude that is barely over tolerance works.
   const Vector3<double> ok_small_vector(1.0E-10 + kTolerance, 0, 0);


### PR DESCRIPTION
Helps address issue #20405.
To fully close this issue, this piece of code needs to move to unit_vector.cc and there needs more complete test coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20406)
<!-- Reviewable:end -->
