### PR TITLE
CompositeTrajectory binding isa PiecewiseTrajectory

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -481,6 +481,7 @@ class TestTrajectories(unittest.TestCase):
         pp1 = PiecewisePolynomial.FirstOrderHold([0.0, 1.0, 2.0], x)
         pp2 = PiecewisePolynomial.FirstOrderHold([2.0, 3.0, 4.0], x)
         traj = CompositeTrajectory(segments=[pp1, pp2])
+        self.assertEqual(traj.get_number_of_segments(), 2)
         self.assertEqual(traj.rows(), 1)
         self.assertEqual(traj.cols(), 1)
         numpy_compare.assert_float_equal(traj.start_time(), 0.0)

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -554,7 +554,7 @@ struct Impl {
     {
       using Class = CompositeTrajectory<T>;
       constexpr auto& cls_doc = doc.CompositeTrajectory;
-      auto cls = DefineTemplateClassWithDefault<Class, Trajectory<T>>(
+      auto cls = DefineTemplateClassWithDefault<Class, PiecewiseTrajectory<T>>(
           m, "CompositeTrajectory", param, cls_doc.doc);
       cls  // BR
           .def(py::init([](std::vector<const Trajectory<T>*> py_segments) {


### PR DESCRIPTION
CompositeTrajectory's binding should have derived from PiecewiseTrajectory, not Trajectory. Now we have access to methods like `get_number_of_segments()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20407)
<!-- Reviewable:end -->
