### PR TITLE
Add log(det(X)) >= lower to MathematicalProgram.

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -823,6 +823,10 @@ void BindMathematicalProgram(py::module m) {
               &MathematicalProgram::AddMaximizeLogDeterminantCost),
           py::arg("X"),
           doc.MathematicalProgram.AddMaximizeLogDeterminantCost.doc)
+      .def("AddLogDeterminantLowerBoundConstraint",
+          &MathematicalProgram::AddLogDeterminantLowerBoundConstraint,
+          py::arg("X"), py::arg("lower"),
+          doc.MathematicalProgram.AddLogDeterminantLowerBoundConstraint.doc)
       .def("AddMaximizeGeometricMeanCost",
           overload_cast_explicit<Binding<LinearCost>,
               const Eigen::Ref<const Eigen::MatrixXd>&,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -709,7 +709,7 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertAlmostEqual(a_val[0], 1)
         self.assertAlmostEqual(a_val[1], 2)
 
-    def test_log_determinant(self):
+    def test_log_determinant_cost(self):
         # Find the minimal ellipsoid that covers some given points.
         prog = mp.MathematicalProgram()
         X = prog.NewSymmetricContinuousVariables(2)
@@ -723,6 +723,14 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(log_det_Z.shape, (2, 2))
         result = mp.Solve(prog)
         self.assertTrue(result.is_success())
+
+    def test_log_determinant_lower(self):
+        prog = mp.MathematicalProgram()
+        X = prog.NewSymmetricContinuousVariables(2)
+        linear_constraint, t, Z = prog.AddLogDeterminantLowerBoundConstraint(
+            X=X, lower=1)
+        self.assertEqual(t.shape, (2,))
+        self.assertEqual(Z.shape, (2, 2))
 
     def test_maximize_geometric_mean(self):
         # Find the smallest axis-algined ellipsoid that covers some given

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1210,27 +1210,22 @@ class MathematicalProgram {
   Binding<Cost> AddCost(const symbolic::Expression& e);
 
   /**
-   * Adds the cost to maximize the log determinant of symmetric matrix X.
-   * log(det(X)) is a concave function of X, so we can maximize it through
-   * convex optimization. In order to do that, we introduce slack variables t,
-   * and a lower triangular matrix Z, with the constraints
+   * @anchor log_determinant
+   * @name Matrix log determinant
+   * Represents the log-determinant of `X` by introducing slack variables t, and
+   * a lower triangular matrix Z and imposing the constraints
    *
-   *     ⌈X         Z⌉ is positive semidifinite.
-   *     ⌊Zᵀ  diag(Z)⌋
+   *    ⌈X         Z⌉ is positive semidifinite.
+   *    ⌊Zᵀ  diag(Z)⌋
    *
-   *     log(Z(i, i)) >= t(i)
+   *    log(Z(i, i)) >= t(i)
    *
-   * and we will minimize -∑ᵢt(i).
-   * @param X A symmetric positive semidefinite matrix X, whose log(det(X)) will
-   * be maximized.
-   * @return (cost, t, Z) cost is -∑ᵢt(i), we also return the newly created
-   * slack variables t and the lower triangular matrix Z. Note that Z is not a
-   * matrix of symbolic::Variable but symbolic::Expression, because the
-   * upper-diagonal entries of Z are not variable, but expression 0.
-   * @pre X is a symmetric matrix.
+   * Since log(det(X)) is a concave function of X, we can either lower bound
+   * it's value by imposing the constraint `∑ᵢt(i) >= lower` or maximize its
+   * value by adding the cost -∑ᵢt(i) using convex optimization.
    * @note The constraint log(Z(i, i)) >= t(i) is imposed as an exponential cone
    * constraint. Please make sure your have a solver that supports exponential
-   * cone constraint (currently SCS does).
+   * cone constraint (currently SCS and Mosek do).
    * @note The constraint that
    *
    *     ⌈X         Z⌉ is positive semidifinite.
@@ -1243,10 +1238,42 @@ class MathematicalProgram {
    * https://docs.mosek.com/modeling-cookbook/sdo.html#log-determinant for more
    * details.
    */
+  //@{
+  /**
+   * Maximize the log determinant. See @ref log_determinant for more details.
+   * @param X A symmetric positive semidefinite matrix X, whose log(det(X)) will
+   * be maximized.
+   * @return (cost, t, Z) cost is -∑ᵢt(i), we also return the newly created
+   * slack variables t and the lower triangular matrix Z. Note that Z is not a
+   * matrix of symbolic::Variable but symbolic::Expression, because the
+   * upper-diagonal entries of Z are not variable, but expression 0.
+   * @pre X is a symmetric matrix.
+   */
+  // TODO(hongkai.dai): return the lower-triangular of Z as
+  // VectorX<symbolic::Variable>.
   std::tuple<Binding<LinearCost>, VectorX<symbolic::Variable>,
              MatrixX<symbolic::Expression>>
   AddMaximizeLogDeterminantCost(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& X);
+
+  /**
+   * Impose the constraint log(det(X)) >= lower. See @ref log_determinant for
+   * more details.
+   * @param X A symmetric positive semidefinite matrix X.
+   * @param lower The lower bound of log(det(X))
+   * @return (constraint, t, Z) constraint is ∑ᵢt(i) >= lower, we also return
+   * the newly created slack variables t and the lower triangular matrix Z. Note
+   * that Z is not a matrix of symbolic::Variable but symbolic::Expression,
+   * because the upper-diagonal entries of Z are not variable, but expression 0.
+   * @pre X is a symmetric matrix.
+   */
+  // TODO(hongkai.dai): return the lower-triangular of Z as
+  // VectorX<symbolic::Variable>.
+  std::tuple<Binding<LinearConstraint>, VectorX<symbolic::Variable>,
+             MatrixX<symbolic::Expression>>
+  AddLogDeterminantLowerBoundConstraint(
+      const Eigen::Ref<const MatrixX<symbolic::Expression>>& X, double lower);
+  //@}
 
   /**
    * @anchor maximize_geometric_mean

--- a/solvers/test/exponential_cone_program_examples.h
+++ b/solvers/test/exponential_cone_program_examples.h
@@ -36,6 +36,12 @@ void MinimizeKLDivergence(const SolverInterface& solver, double tol);
  */
 void MinimalEllipsoidCoveringPoints(const SolverInterface& solver, double tol);
 
+/* Impose the constraint log(det(X)) >= 1
+ * Note that this requires both exponential cone and positive semidefinite
+ * constraint.
+ */
+void MatrixLogDeterminantLower(const SolverInterface& solver, double tol);
+
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -4663,6 +4663,26 @@ GTEST_TEST(RelaxPsdConstraintToSddDualCone, NoConstraintToReplace) {
   EXPECT_EQ(ssize(prog.rotated_lorentz_cone_constraints()), 3);
 }
 
+GTEST_TEST(MathematicalProgramTest, AddLogDeterminantLowerBoundConstraint) {
+  MathematicalProgram prog;
+  auto X = prog.NewSymmetricContinuousVariables<3>("X");
+  auto ret = prog.AddLogDeterminantLowerBoundConstraint(
+      X.cast<symbolic::Expression>(), 1);
+  const auto& constraint = std::get<0>(ret);
+  const auto& t = std::get<1>(ret);
+  EXPECT_TRUE(CompareMatrices(constraint.evaluator()->GetDenseA(),
+                              Eigen::RowVector3d::Ones()));
+  EXPECT_TRUE(
+      CompareMatrices(constraint.evaluator()->lower_bound(), Vector1d(1)));
+  EXPECT_TRUE(
+      CompareMatrices(constraint.evaluator()->upper_bound(), Vector1d(kInf)));
+  EXPECT_EQ(constraint.variables().size(), 3);
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_TRUE(constraint.variables()(i).equal_to(t(i)));
+  }
+  EXPECT_EQ(prog.exponential_cone_constraints().size(), 3);
+  EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1);
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -233,6 +233,13 @@ GTEST_TEST(TestExponentialConeProgram, MinimalEllipsoidConveringPoints) {
   }
 }
 
+GTEST_TEST(TestExponentialConeProgram, MatrixLogDeterminantLower) {
+  MosekSolver mosek_solver;
+  if (mosek_solver.available()) {
+    MatrixLogDeterminantLower(mosek_solver, 1E-6);
+  }
+}
+
 GTEST_TEST(MosekTest, TestLogging) {
   // Test if we can print the logging info to a log file.
   MathematicalProgram prog;

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -402,6 +402,13 @@ GTEST_TEST(TestExponentialConeProgram, MinimalEllipsoidConveringPoints) {
   }
 }
 
+GTEST_TEST(TestExponentialConeProgram, MatrixLogDeterminantLower) {
+  ScsSolver scs_solver;
+  if (scs_solver.available()) {
+    MatrixLogDeterminantLower(scs_solver, kTol);
+  }
+}
+
 GTEST_TEST(TestScs, SetOptions) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();


### PR DESCRIPTION
MathematicalProgram.AddLogDeterminantLowerConstraint imposes log(det(X)) >= lower as convex constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20411)
<!-- Reviewable:end -->
