### PR TITLE
Add bounding_region to IrisOptions

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -451,8 +451,8 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.configuration_obstacles.doc)
         .def_readwrite("starting_ellipse", &IrisOptions::starting_ellipse,
             cls_doc.starting_ellipse.doc)
-        .def_readwrite("domain", &IrisOptions::domain,
-            cls_doc.domain.doc)
+        .def_readwrite("bounding_region", &IrisOptions::bounding_region,
+            cls_doc.bounding_region.doc)
         .def_readwrite("num_additional_constraint_infeasible_samples",
             &IrisOptions::num_additional_constraint_infeasible_samples,
             cls_doc.num_additional_constraint_infeasible_samples.doc)

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -451,8 +451,8 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.configuration_obstacles.doc)
         .def_readwrite("starting_ellipse", &IrisOptions::starting_ellipse,
             cls_doc.starting_ellipse.doc)
-        .def_readwrite("starting_polytope", &IrisOptions::starting_polytope,
-            cls_doc.starting_polytope.doc)
+        .def_readwrite("domain", &IrisOptions::domain,
+            cls_doc.domain.doc)
         .def_readwrite("num_additional_constraint_infeasible_samples",
             &IrisOptions::num_additional_constraint_infeasible_samples,
             cls_doc.num_additional_constraint_infeasible_samples.doc)

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -451,6 +451,8 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.configuration_obstacles.doc)
         .def_readwrite("starting_ellipse", &IrisOptions::starting_ellipse,
             cls_doc.starting_ellipse.doc)
+        .def_readwrite("starting_polytope", &IrisOptions::starting_polytope,
+            cls_doc.starting_polytope.doc)
         .def_readwrite("num_additional_constraint_infeasible_samples",
             &IrisOptions::num_additional_constraint_infeasible_samples,
             cls_doc.num_additional_constraint_infeasible_samples.doc)

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -552,7 +552,8 @@ class TestGeometryOptimization(unittest.TestCase):
         options.relative_termination_threshold = 0.01
         options.random_seed = 1314
         options.starting_ellipse = mut.Hyperellipsoid.MakeUnitBall(3)
-        options.domain = mut.HPolyhedron.MakeBox(lb=[-6, -6, -6], ub=[6, 6, 6])
+        options.bounding_region = mut.HPolyhedron.MakeBox(
+            lb=[-6, -6, -6], ub=[6, 6, 6])
         self.assertNotIn("object at 0x", repr(options))
         region = mut.Iris(
             obstacles=obstacles, sample=[2, 3.4, 5],

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -552,6 +552,7 @@ class TestGeometryOptimization(unittest.TestCase):
         options.relative_termination_threshold = 0.01
         options.random_seed = 1314
         options.starting_ellipse = mut.Hyperellipsoid.MakeUnitBall(3)
+        options.domain = mut.HPolyhedron.MakeBox(lb=[-6, -6, -6], ub=[6, 6, 6])
         self.assertNotIn("object at 0x", repr(options))
         region = mut.Iris(
             obstacles=obstacles, sample=[2, 3.4, 5],

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -54,13 +54,18 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
       Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample));
   HPolyhedron P = domain;
 
+  if (options.starting_polytope) {
+    DRAKE_DEMAND(options.starting_polytope->ContainedIn(domain));
+    P = options.starting_polytope;
+  }
+
   // On each iteration, we will build the collision-free polytope represented as
   // {x | A * x <= b}.  Here we pre-allocate matrices of the maximum size.
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A(
-      domain.A().rows() + N, dim);
-  VectorXd b(domain.A().rows() + N);
-  A.topRows(domain.A().rows()) = domain.A();
-  b.head(domain.A().rows()) = domain.b();
+      P.A().rows() + N, dim);
+  VectorXd b(P.A().rows() + N);
+  A.topRows(P.A().rows()) = P.A();
+  b.head(P.A().rows()) = P.b();
   // Use pairs {scale, index}, so that I can back out the indices after a sort.
   std::vector<std::pair<double, int>> scaling(N);
   MatrixXd closest_points(dim, N);
@@ -464,6 +469,12 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
   HPolyhedron P = HPolyhedron::MakeBox(plant.GetPositionLowerLimits(),
                                        plant.GetPositionUpperLimits());
   DRAKE_DEMAND(P.A().rows() == 2 * nq);
+
+  if (options.starting_polytope) {
+    DRAKE_DEMAND(options.starting_polytope->ContainedIn(P));
+    P = options.starting_polytope;
+  }
+
   const double kEpsilonEllipsoid = 1e-2;
   Hyperellipsoid E = options.starting_ellipse.value_or(
       Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, seed));

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -54,9 +54,9 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
       Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample));
   HPolyhedron P = domain;
 
-  if (options.domain) {
-    DRAKE_DEMAND(options.domain->ambient_dimension() == dim);
-    P = P.Intersection(*options.domain);
+  if (options.bounding_region) {
+    DRAKE_DEMAND(options.bounding_region->ambient_dimension() == dim);
+    P = P.Intersection(*options.bounding_region);
     return P;
   }
 
@@ -473,9 +473,9 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
                                        plant.GetPositionUpperLimits());
   DRAKE_DEMAND(P.A().rows() == 2 * nq);
 
-  if (options.domain) {
-    DRAKE_DEMAND(options.domain->ambient_dimension() == nq);
-    P = P.Intersection(*options.domain);
+  if (options.bounding_region) {
+    DRAKE_DEMAND(options.bounding_region->ambient_dimension() == nq);
+    P = P.Intersection(*options.bounding_region);
   }
 
   const double kEpsilonEllipsoid = 1e-2;

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -59,7 +59,7 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
     P = P.Intersection(*options.bounding_region);
   }
 
-  const int initial_constraints = P.A().rows();
+  const int num_initial_constraints = P.A().rows();
 
   // On each iteration, we will build the collision-free polytope represented as
   // {x | A * x <= b}.  Here we pre-allocate matrices of the maximum size.
@@ -87,7 +87,7 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
     }
     std::sort(scaling.begin(), scaling.end());
 
-    int num_constraints = initial_constraints;
+    int num_constraints = num_initial_constraints;
     tangent_matrix = 2.0 * E.A().transpose() * E.A();
     for (int i = 0; i < N; ++i) {
       // Only add a constraint if this obstacle still has overlap with the set

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -57,7 +57,6 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
   if (options.bounding_region) {
     DRAKE_DEMAND(options.bounding_region->ambient_dimension() == dim);
     P = P.Intersection(*options.bounding_region);
-    return P;
   }
 
   const int initial_constraints = P.A().rows();

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -86,10 +86,12 @@ struct IrisOptions {
   centered at the given sample will be used. */
   std::optional<Hyperellipsoid> starting_ellipse{};
 
-  /** The initial polytope that IRIS will search within for collisions in
-  the first iteration. If no polytope is provided, Iris will use the input
-  domain, IrisInConfigurationSpace will use the joint limits of the plant */
-  std::optional<HPolyhedron> starting_polytope{};
+  /** Optionally allows the caller to override the default domain used by IRIS;
+  which is defined as the `domain` argument in the case of `Iris` or the joint
+  limits  of the input `plant` in the case of `IrisInConfigurationSpace`. If
+  specified, the effective domain used by IRIS will be the intersection of its
+  default domain and `options.domain`. */
+  std::optional<HPolyhedron> domain{};
 
   /** By default, IRIS in configuration space certifies regions for collision
   avoidance constraints and joint limits. This option can be used to pass

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -91,7 +91,7 @@ struct IrisOptions {
   `domain` argument in the case of `Iris` or the joint limits of the input
   `plant` in the case of `IrisInConfigurationSpace`. If this option is
   specified, IRIS regions will be confined to the intersection between the
-  domain and `boundary_region` */
+  domain and `bounding_region` */
   std::optional<HPolyhedron> bounding_region{};
 
   /** By default, IRIS in configuration space certifies regions for collision

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -86,6 +86,11 @@ struct IrisOptions {
   centered at the given sample will be used. */
   std::optional<Hyperellipsoid> starting_ellipse{};
 
+  /** The initial polytope that IRIS will search within for collisions in
+  the first iteration. If no polytope is provided, Iris will use the input
+  domain, IrisInConfigurationSpace will use the joint limits of the plant */
+  std::optional<HPolyhedron> starting_polytope{};
+
   /** By default, IRIS in configuration space certifies regions for collision
   avoidance constraints and joint limits. This option can be used to pass
   additional constraints that should be satisfied by the IRIS region. We accept

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -86,12 +86,13 @@ struct IrisOptions {
   centered at the given sample will be used. */
   std::optional<Hyperellipsoid> starting_ellipse{};
 
-  /** Optionally allows the caller to override the default domain used by IRIS;
-  which is defined as the `domain` argument in the case of `Iris` or the joint
-  limits  of the input `plant` in the case of `IrisInConfigurationSpace`. If
-  specified, the effective domain used by IRIS will be the intersection of its
-  default domain and `options.domain`. */
-  std::optional<HPolyhedron> domain{};
+  /** Optionally allows the caller to restrict the space within which IRIS
+  regions are allowed to grow. By default, IRIS regions are bounded by the
+  `domain` argument in the case of `Iris` or the joint limits of the input
+  `plant` in the case of `IrisInConfigurationSpace`. If this option is
+  specified, IRIS regions will be confined to the intersection between the
+  domain and `boundary_region` */
+  std::optional<HPolyhedron> bounding_region{};
 
   /** By default, IRIS in configuration space certifies regions for collision
   avoidance constraints and joint limits. This option can be used to pass

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -366,7 +366,7 @@ GTEST_TEST(IrisInConfigurationSpaceTest, StartingEllipse) {
               1e-6);
 }
 
-GTEST_TEST(IrisInConfigurationSpaceTest, StartingPolytope) {
+GTEST_TEST(IrisInConfigurationSpaceTest, Domain) {
   const Vector2d sample{0.0, 0.0};
   IrisOptions options;
   options.iteration_limit = 1;
@@ -377,25 +377,24 @@ GTEST_TEST(IrisInConfigurationSpaceTest, StartingPolytope) {
   HPolyhedron region = IrisFromUrdf(boxes_in_2d_urdf, sample, options);
 
   // Add a starting polytope that halves the plant's joint limits.
-  options.starting_polytope =
-      HPolyhedron::MakeBox(Vector2d(-1, -0.5), Vector2d(1, 0.5));
-  HPolyhedron region_w_polytope =
-      IrisFromUrdf(boxes_in_2d_urdf, sample, options);
+  options.domain = HPolyhedron::MakeBox(Vector2d(-1, -0.5), Vector2d(1, 0.5));
+  HPolyhedron region_w_domain = IrisFromUrdf(boxes_in_2d_urdf, sample, options);
 
-  // Regions should have only one additional half space beyond the inital
-  // polytope.
+  // `region` should have only one additional half space beyond the initial
+  // polytope. `region_w_domain` should have a further four half spaces since
+  // its domain will have been intersected with `options.domain`.
   EXPECT_EQ(region.b().size(), 5);
-  EXPECT_EQ(region_w_polytope.b().size(), 5);
+  EXPECT_EQ(region_w_domain.b().size(), 9);
 
   // The point (-1.5, -0.5) is within the plant's joint limits but outside the
-  // starting_polytope. It should be contained region but not in
-  // region_w_polytope.
+  // domain. It should be contained in region but not in
+  // region_w_domain.
   EXPECT_TRUE(region.PointInSet(Vector2d(-1.5, -0.5)));
-  EXPECT_FALSE(region_w_polytope.PointInSet(Vector2d(-1.5, -0.5)));
+  EXPECT_FALSE(region_w_domain.PointInSet(Vector2d(-1.5, -0.5)));
 
   // A point closer to the origin should be in both regions.
   EXPECT_TRUE(region.PointInSet(Vector2d(-0.5, -0.25)));
-  EXPECT_TRUE(region_w_polytope.PointInSet(Vector2d(-0.5, -0.25)));
+  EXPECT_TRUE(region_w_domain.PointInSet(Vector2d(-0.5, -0.25)));
 }
 
 // Three spheres.  Two on the outside are fixed.  One in the middle on a

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -377,24 +377,27 @@ GTEST_TEST(IrisInConfigurationSpaceTest, Domain) {
   HPolyhedron region = IrisFromUrdf(boxes_in_2d_urdf, sample, options);
 
   // Add a starting polytope that halves the plant's joint limits.
-  options.domain = HPolyhedron::MakeBox(Vector2d(-1, -0.5), Vector2d(1, 0.5));
-  HPolyhedron region_w_domain = IrisFromUrdf(boxes_in_2d_urdf, sample, options);
+  options.bounding_region =
+      HPolyhedron::MakeBox(Vector2d(-1, -0.5), Vector2d(1, 0.5));
+  HPolyhedron region_w_bounding =
+      IrisFromUrdf(boxes_in_2d_urdf, sample, options);
 
   // `region` should have only one additional half space beyond the initial
-  // polytope. `region_w_domain` should have a further four half spaces since
-  // its domain will have been intersected with `options.domain`.
+  // polytope. `region_w_bounding` should have a further four half spaces since
+  // its initial polytope will have been intersected with
+  // `options.bounding_region`.
   EXPECT_EQ(region.b().size(), 5);
-  EXPECT_EQ(region_w_domain.b().size(), 9);
+  EXPECT_EQ(region_w_bounding.b().size(), 9);
 
   // The point (-1.5, -0.5) is within the plant's joint limits but outside the
   // domain. It should be contained in region but not in
-  // region_w_domain.
+  // region_w_bounding.
   EXPECT_TRUE(region.PointInSet(Vector2d(-1.5, -0.5)));
-  EXPECT_FALSE(region_w_domain.PointInSet(Vector2d(-1.5, -0.5)));
+  EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(-1.5, -0.5)));
 
   // A point closer to the origin should be in both regions.
   EXPECT_TRUE(region.PointInSet(Vector2d(-0.5, -0.25)));
-  EXPECT_TRUE(region_w_domain.PointInSet(Vector2d(-0.5, -0.25)));
+  EXPECT_TRUE(region_w_bounding.PointInSet(Vector2d(-0.5, -0.25)));
 }
 
 // Three spheres.  Two on the outside are fixed.  One in the middle on a

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -366,17 +366,18 @@ GTEST_TEST(IrisInConfigurationSpaceTest, StartingEllipse) {
               1e-6);
 }
 
-GTEST_TEST(IrisInConfigurationSpaceTest, Domain) {
+GTEST_TEST(IrisInConfigurationSpaceTest, BoundingRegion) {
   const Vector2d sample{0.0, 0.0};
   IrisOptions options;
   options.iteration_limit = 1;
   options.num_collision_infeasible_samples = 0;
   ConvexSets obstacles;
-  obstacles.emplace_back(VPolytope::MakeBox(Vector2d(.2, .2), Vector2d(1, 1)));
+  obstacles.emplace_back(
+      VPolytope::MakeBox(Vector2d(0.2, 0.2), Vector2d(1, 1)));
   options.configuration_obstacles = obstacles;
   HPolyhedron region = IrisFromUrdf(boxes_in_2d_urdf, sample, options);
 
-  // Add a starting polytope that halves the plant's joint limits.
+  // Add a bounding region that halves the plant's joint limits.
   options.bounding_region =
       HPolyhedron::MakeBox(Vector2d(-1, -0.5), Vector2d(1, 0.5));
   HPolyhedron region_w_bounding =
@@ -390,7 +391,7 @@ GTEST_TEST(IrisInConfigurationSpaceTest, Domain) {
   EXPECT_EQ(region_w_bounding.b().size(), 9);
 
   // The point (-1.5, -0.5) is within the plant's joint limits but outside the
-  // domain. It should be contained in region but not in
+  // bounding region. It should be contained in region but not in
   // region_w_bounding.
   EXPECT_TRUE(region.PointInSet(Vector2d(-1.5, -0.5)));
   EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(-1.5, -0.5)));

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -180,14 +180,15 @@ GTEST_TEST(IrisTest, Domain) {
   IrisOptions options;
 
   // Use a domain that omits the obstacles entirely.
-  options.domain =
+  options.bounding_region =
       HPolyhedron::MakeBox(Vector2d(-0.25, -0.25), Vector2d(0.25, 0.25));
   const HPolyhedron region = Iris(obstacles, sample, domain, options);
-  EXPECT_EQ(region.b().size(),
-            8);  // 4 from `domain`, 4 more from `options.domain` (obstacles
-                 // aren't considered since they're outside the domain).
+  EXPECT_EQ(
+      region.b().size(),
+      8);  // 4 from `domain`, 4 more from `options.bounding_region` (obstacles
+           // aren't considered since they're outside the bounding_region).
 
-  // The initial polytope eliminates all points outside a box of size 0.25.
+  // The bounding region eliminates all points outside a box of size 0.25.
   EXPECT_TRUE(region.PointInSet(Vector2d(0.0, .24)));
   EXPECT_TRUE(region.PointInSet(Vector2d(0.0, -.24)));
   EXPECT_FALSE(region.PointInSet(Vector2d(.49, 0.0)));

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -15,6 +15,7 @@ namespace optimization {
 namespace {
 
 using Eigen::Matrix;
+using Eigen::RowVector2d;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
@@ -183,16 +184,15 @@ GTEST_TEST(IrisTest, BoundingRegion) {
   const HPolyhedron region = Iris(obstacles, sample, domain, options);
 
   // Use a bounding_region that omits the obstacles to the left of the x-axis.
-  options.bounding_region =
-      HPolyhedron::MakeBox(Vector2d(-0.05, -1), Vector2d(1, 1));
+  options.bounding_region = HPolyhedron(RowVector2d(-1, 0), Vector1d(0.05));
 
   const HPolyhedron region_w_bounding =
       Iris(obstacles, sample, domain, options);
 
   EXPECT_EQ(region.b().size(), 8);  // 4 from `domain` and 1 from each obstacle.
   EXPECT_EQ(region_w_bounding.b().size(),
-            10);  // 4 from `domain`, 4 from `options.bounding_region` and 2
-                  // more from the right obstacles.
+            7);  // 4 from `domain`, 1 from `options.bounding_region` and 2
+                 // more from the right obstacles.
 
   // `region_w_bounding` should not contain points of y ≤ -0.05 since they're
   // outside its bounding region.
@@ -206,7 +206,7 @@ GTEST_TEST(IrisTest, BoundingRegion) {
 
   // Points inside obstacles should be excluded from both regions.
   EXPECT_FALSE(region.PointInSet(Vector2d(0.1, 0.5)));
-  EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(0.1, 0.5)));
+  EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(0.11, 0.51)));
 }
 
 GTEST_TEST(IrisTest, TerminationConditions) {

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -165,15 +165,16 @@ GTEST_TEST(IrisTest, StartingEllipse) {
   EXPECT_FALSE(region.PointInSet(Vector2d(-.99, 0.0)));
 }
 
-GTEST_TEST(IrisTest, Domain) {
+GTEST_TEST(IrisTest, BoundingRegion) {
   ConvexSets obstacles;
-  obstacles.emplace_back(VPolytope::MakeBox(Vector2d(.1, .5), Vector2d(1, 1)));
   obstacles.emplace_back(
-      VPolytope::MakeBox(Vector2d(-1, -1), Vector2d(-.1, -.5)));
+      VPolytope::MakeBox(Vector2d(0.1, 0.5), Vector2d(1, 1)));
   obstacles.emplace_back(
-      HPolyhedron::MakeBox(Vector2d(.1, -1), Vector2d(1, -.5)));
+      VPolytope::MakeBox(Vector2d(-1, -1), Vector2d(-0.1, -0.5)));
   obstacles.emplace_back(
-      HPolyhedron::MakeBox(Vector2d(-1, .5), Vector2d(-.1, 1)));
+      HPolyhedron::MakeBox(Vector2d(.1, -1), Vector2d(1, -0.5)));
+  obstacles.emplace_back(
+      HPolyhedron::MakeBox(Vector2d(-1, 0.5), Vector2d(-0.1, 1)));
   const HPolyhedron domain = HPolyhedron::MakeUnitBox(2);
 
   const Vector2d sample{0, 0};  // center of the bounding box.
@@ -204,8 +205,8 @@ GTEST_TEST(IrisTest, Domain) {
   EXPECT_TRUE(region_w_bounding.PointInSet(Vector2d(0.99, 0)));
 
   // Points inside obstacles should be excluded from both regions.
-  EXPECT_FALSE(region.PointInSet(Vector2d(.1, 0.5)));
-  EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(.1, 0.5)));
+  EXPECT_FALSE(region.PointInSet(Vector2d(0.1, 0.5)));
+  EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(0.1, 0.5)));
 }
 
 GTEST_TEST(IrisTest, TerminationConditions) {

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -165,7 +165,7 @@ GTEST_TEST(IrisTest, StartingEllipse) {
   EXPECT_FALSE(region.PointInSet(Vector2d(-.99, 0.0)));
 }
 
-GTEST_TEST(IrisTest, StartingPolytope) {
+GTEST_TEST(IrisTest, Domain) {
   ConvexSets obstacles;
   obstacles.emplace_back(VPolytope::MakeBox(Vector2d(.1, .5), Vector2d(1, 1)));
   obstacles.emplace_back(
@@ -179,13 +179,13 @@ GTEST_TEST(IrisTest, StartingPolytope) {
   const Vector2d sample{0, 0};  // center of the bounding box.
   IrisOptions options;
 
-  // Use a starting_polytope that omits the obstacles entirely.
-  options.starting_polytope =
+  // Use a domain that omits the obstacles entirely.
+  options.domain =
       HPolyhedron::MakeBox(Vector2d(-0.25, -0.25), Vector2d(0.25, 0.25));
   const HPolyhedron region = Iris(obstacles, sample, domain, options);
   EXPECT_EQ(region.b().size(),
-            4);  // 4 from bbox (obstacles aren't considered since they're
-                 // outside the starting_polytope).
+            8);  // 4 from `domain`, 4 more from `options.domain` (obstacles
+                 // aren't considered since they're outside the domain).
 
   // The initial polytope eliminates all points outside a box of size 0.25.
   EXPECT_TRUE(region.PointInSet(Vector2d(0.0, .24)));

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -165,6 +165,35 @@ GTEST_TEST(IrisTest, StartingEllipse) {
   EXPECT_FALSE(region.PointInSet(Vector2d(-.99, 0.0)));
 }
 
+GTEST_TEST(IrisTest, StartingPolytope) {
+  ConvexSets obstacles;
+  obstacles.emplace_back(VPolytope::MakeBox(Vector2d(.1, .5), Vector2d(1, 1)));
+  obstacles.emplace_back(
+      VPolytope::MakeBox(Vector2d(-1, -1), Vector2d(-.1, -.5)));
+  obstacles.emplace_back(
+      HPolyhedron::MakeBox(Vector2d(.1, -1), Vector2d(1, -.5)));
+  obstacles.emplace_back(
+      HPolyhedron::MakeBox(Vector2d(-1, .5), Vector2d(-.1, 1)));
+  const HPolyhedron domain = HPolyhedron::MakeUnitBox(2);
+
+  const Vector2d sample{0, 0};  // center of the bounding box.
+  IrisOptions options;
+
+  // Use a starting_polytope that omits the obstacles entirely.
+  options.starting_polytope =
+      HPolyhedron::MakeBox(Vector2d(-0.25, -0.25), Vector2d(0.25, 0.25));
+  const HPolyhedron region = Iris(obstacles, sample, domain, options);
+  EXPECT_EQ(region.b().size(),
+            4);  // 4 from bbox (obstacles aren't considered since they're
+                 // outside the starting_polytope).
+
+  // The initial polytope eliminates all points outside a box of size 0.25.
+  EXPECT_TRUE(region.PointInSet(Vector2d(0.0, .24)));
+  EXPECT_TRUE(region.PointInSet(Vector2d(0.0, -.24)));
+  EXPECT_FALSE(region.PointInSet(Vector2d(.49, 0.0)));
+  EXPECT_FALSE(region.PointInSet(Vector2d(-.49, 0.0)));
+}
+
 GTEST_TEST(IrisTest, TerminationConditions) {
   ConvexSets obstacles;
   obstacles.emplace_back(VPolytope::MakeBox(Vector2d(.1, .5), Vector2d(1, 1)));


### PR DESCRIPTION
This PR addresses https://github.com/RobotLocomotion/drake/issues/20268 by adding a ~`starting_polytope`~ _`bounding_region`_ member to the `IrisOptions` struct. 

@RussTedrake when you have a chance could I bother you for a feature review on this one?

P.S this is be my first PR into drake. I've been through the contributing guidelines but let me know if I missed anything!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20417)
<!-- Reviewable:end -->
