### PR TITLE
Implements actuation output port for MultibodyPlant

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -915,6 +915,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 ModelInstanceIndex>(&Class::get_actuation_input_port),
             py::arg("model_instance"), py_rvp::reference_internal,
             cls_doc.get_actuation_input_port.doc_1args)
+        .def("get_net_actuation_output_port",
+            &Class::get_net_actuation_output_port, py_rvp::reference_internal,
+            cls_doc.get_net_actuation_output_port.doc)
         .def("get_desired_state_input_port",
             overload_cast_explicit<const systems::InputPort<T>&,
                 multibody::ModelInstanceIndex>(

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -433,6 +433,8 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(
             plant.get_actuation_input_port(), InputPort)
         self.assertIsInstance(
+            plant.get_net_actuation_output_port(), OutputPort)
+        self.assertIsInstance(
             plant.get_state_output_port(), OutputPort)
         self.assertIsInstance(
             plant.get_generalized_acceleration_output_port(), OutputPort)

--- a/multibody/contact_solvers/sap/sap_contact_problem.h
+++ b/multibody/contact_solvers/sap/sap_contact_problem.h
@@ -271,6 +271,26 @@ class SapContactProblem {
       const VectorX<T>& gamma, VectorX<T>* generalized_forces,
       std::vector<SpatialForce<T>>* spatial_forces) const;
 
+  /* Computes the generalized forces given a known vector of impulses `gamma`,
+   for constraints with index i in the inclusive range constraint_start <= i &&
+   i <= constraint_end.
+
+   @param[in] gamma Constraint impulses for this full problem. Of size
+   num_constraint_equations().
+   @param[out] generalized_forces On output, the set of generalized forces
+   result of the combined action of all constraints in `this` problem given the
+   known impulses `gamma`.
+
+   @throws if gamma.size() != num_constraint_equations().
+   @throws if constraint_start is not in [0, num_constraints()).
+   @throws if constraint_end is not in [0, num_constraints()).
+   @throws if constraint_end < constraint_start.
+   @throws if generalized_forces is nullptr.
+   @throws if generalized_forces.size() != num_velocities(). */
+  void CalcConstraintGeneralizedForces(const VectorX<T>& gamma,
+                                       int constraint_start, int constraint_end,
+                                       VectorX<T>* generalized_forces) const;
+
  private:
   int nv_{0};           // Total number of generalized velocities.
   T time_step_{0.0};    // Discrete time step.

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -158,6 +158,8 @@ class CompliantContactManager final : public DiscreteUpdateManager<T> {
   void DoCalcDiscreteUpdateMultibodyForces(
       const systems::Context<T>& context,
       MultibodyForces<T>* forces) const final;
+  void DoCalcActuation(const systems::Context<T>& context,
+                       VectorX<T>* forces) const final;
 
   // Computes non-constraint forces and the accelerations they induce.
   void CalcAccelerationsDueToNonConstraintForcesCache(

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -194,6 +194,11 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   const MultibodyForces<T>& EvalDiscreteUpdateMultibodyForces(
       const systems::Context<T>& context) const;
 
+  /* Evaluate the actuation applied through actuators during the discrete
+   update. This will include actuation input as well as controller models.
+   The returned vector is indexed by JointActuatorIndex. */
+  const VectorX<T>& EvalActuation(const systems::Context<T>& context) const;
+
   /* Evaluates sparse kinematics information for each contact pair at
    the given configuration stored in `context`. */
   const DiscreteContactData<ContactPairKinematics<T>>& EvalContactKinematics(
@@ -354,6 +359,13 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   virtual void DoCalcDiscreteUpdateMultibodyForces(
       const systems::Context<T>& context, MultibodyForces<T>* forces) const = 0;
 
+  /* Concrete managers must implement this method to compute the total actuation
+   applied during a discrete update.
+   For instance, managers that implement implicit controllers must override this
+   method to include these terms. */
+  virtual void DoCalcActuation(const systems::Context<T>& context,
+                               VectorX<T>* actuation) const = 0;
+
   /* Performs discrete updates for rigid DoFs in the system. Defaults to
    symplectic Euler updates. Derived classes may choose to override the
    implemention to provide a different update scheme. */
@@ -399,6 +411,7 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
     systems::CacheIndex contact_kinematics;
     systems::CacheIndex discrete_contact_pairs;
     systems::CacheIndex hydroelastic_contact_info;
+    systems::CacheIndex actuation;
   };
 
   /* Exposes indices for the cache entries declared by this class for derived
@@ -441,6 +454,10 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
    DoCalcDiscreteUpdateMultibodyForces. */
   void CalcDiscreteUpdateMultibodyForces(const systems::Context<T>& context,
                                          MultibodyForces<T>* forces) const;
+
+  /* Calc version of EvalActuation, NVI to DoCalcActuation. */
+  void CalcActuation(const systems::Context<T>& context,
+                     VectorX<T>* forces) const;
 
   /* Calc version of EvalContactKinematics(). */
   void CalcContactKinematics(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -206,6 +206,7 @@ output_ports:
 - body_spatial_velocities
 - body_spatial_accelerations
 - generalized_acceleration
+- net_actuation
 - reaction_forces
 - contact_results
 - <em style="color:gray">model_instance_name[i]</em>_state
@@ -445,6 +446,15 @@ connected or not:
 ² This port is always declared, though it will be zero sized for model instances
   with no PD controllers.
 
+  #### Net actuation
+
+The total joint actuation applied via the actuation input port
+(get_actuation_input_port()) and applied by the PD controllers is reported by
+the net actuation port (get_net_actuation_output_port()). That is, the net
+actuation port reports the total actuation applied by a given actuator.
+
+@note PD controllers are ignored when a joint is locked (see Joint::Lock()), and
+thus they have no effect on the actuation output.
 
 @anchor sdf_loading
                  ### Loading models from SDFormat files
@@ -837,6 +847,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize().
   const systems::InputPort<T>& get_actuation_input_port() const;
+
+  /// Returns a constant reference to the output port that reports actuation
+  /// values applied through joint actuators. This output port is a vector
+  /// valued port indexed by @ref JointActuatorIndex, see
+  /// JointActuator::index(). Models that include PD controllers will include
+  /// their contribution in this port, refer to @ref mbp_actuation "Actuation"
+  /// for further details.
+  /// @note PD controllers are not considered for actuators on locked joints,
+  /// see Joint::Lock(). Therefore they do not contribute to this port.
+  /// @pre Finalize() was already called on `this` plant.
+  /// @throws std::exception if called before Finalize().
+  const systems::OutputPort<T>& get_net_actuation_output_port() const;
 
   /// Returns a constant reference to the input port for external actuation for
   /// a specific model instance. This is a vector valued port with entries
@@ -5136,6 +5158,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // ports. The return value is indexed by JointActuatorIndex.
   VectorX<T> AssembleActuationInput(const systems::Context<T>& context) const;
 
+  // Computes the total applied actuation through actuators. For continuous
+  // models (thus far) this only inludes values coming from the
+  // actuation_input_port. For discrete models, it includes actuator
+  // controllers, see @ref mbp_actuation. Similarly to AssembleActuationInput(),
+  // this function assembles actuation values indexed by JointActuatorIndex.
+  void CalcActuationOutput(const systems::Context<T>& context,
+                           systems::BasicVector<T>* actuation) const;
+
   // For models with joint actuators with PD control, this method helps to
   // assemble desired states for the full model from the input ports for
   // individual model instances.
@@ -5624,8 +5654,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // if that instance has no actuators.
   std::vector<systems::InputPortIndex> instance_actuation_ports_;
 
-  // The actuation port for all actuated dofs.
+  // The actuation input port for all actuated dofs.
   systems::InputPortIndex actuation_port_;
+
+  // Net actuation applied through actuators.
+  systems::OutputPortIndex net_actuation_port_;
 
   std::vector<systems::InputPortIndex> instance_desired_state_ports_;
 

--- a/multibody/plant/sap_driver.h
+++ b/multibody/plant/sap_driver.h
@@ -49,6 +49,9 @@ struct ContactProblemCache {
   }
   copyable_unique_ptr<contact_solvers::internal::SapContactProblem<T>>
       sap_problem;
+  // Start/end constraint index for PD controller constraints in sap_problem.
+  int pd_controller_constraints_start{0};
+  int num_pd_controller_constraints{0};
 
   copyable_unique_ptr<contact_solvers::internal::SapContactProblem<T>>
       sap_problem_locked;
@@ -103,6 +106,12 @@ class SapDriver {
   // forces.
   void CalcDiscreteUpdateMultibodyForces(const systems::Context<T>& context,
                                          MultibodyForces<T>* forces) const;
+
+  // Computes the actuation applied to the multibody system when stepping the
+  // discrete dynamics from the state stored in `context`. This includes the
+  // actuation from implicit PD controllers.
+  void CalcActuation(const systems::Context<T>& context,
+                     VectorX<T>* actuation) const;
 
  private:
   // Provide private access for unit testing only.

--- a/multibody/plant/test/actuated_models_test.cc
+++ b/multibody/plant/test/actuated_models_test.cc
@@ -1,5 +1,6 @@
 #include <limits>
 #include <memory>
+#include <tuple>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -10,12 +11,14 @@
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/plant/multibody_plant_config.h"
+#include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
 
+using Eigen::MatrixXd;
 using Eigen::VectorXd;
 using multibody::Parser;
 using systems::Context;
@@ -46,18 +49,21 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
   // Enum to control the PD model for ther kuka arm and its gripper.
   // This does not affect the acrobot model, which has no PD controllers.
   enum class ModelConfiguration {
+    // None of the models have PD controllers.
+    kNoPdControl,
     kArmIsControlled,
     kArmIsNotControlled,
     kArmIsPartiallyControlled,
     kModelWithZeroGains,
   };
 
-  // - arm not controlled
-  // - arm controlled
-  // - arm partially controlled
+  // Sets a model with PD controllers as specified by `model_config`. The
+  // MultibodyPlant model is discrete and uses the SAP solver by default, but
+  // this can be changed with `config`.
   void SetUpModel(
       ModelConfiguration model_config = ModelConfiguration::kArmIsNotControlled,
-      bool is_discrete = true) {
+      const MultibodyPlantConfig& config = MultibodyPlantConfig{
+          .time_step = 0.01, .discrete_contact_solver = "sap"}) {
     const char kArmSdfPath[] =
         "drake/manipulation/models/iiwa_description/iiwa7/"
         "iiwa7_no_collision.sdf";
@@ -66,11 +72,8 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
         "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf";
 
     // Make a discrete model.
-    const double update_period = is_discrete ? 0.01 : 0.0;
-    plant_ = std::make_unique<MultibodyPlant<double>>(update_period);
-    // Use the SAP solver. Thus far only SAP support the modeling of PD
-    // controllers.
-    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    plant_ = std::make_unique<MultibodyPlant<double>>(config.time_step);
+    ApplyMultibodyPlantConfig(config, plant_.get());
 
     Parser parser(plant_.get());
 
@@ -97,43 +100,46 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
     plant_->WeldFrames(plant_->world_frame(), base_body.body_frame());
     plant_->WeldFrames(end_effector.body_frame(), gripper_body.body_frame());
 
-    // Set PD controllers for the gripper.
-    SetGripperModel();
+    if (model_config != ModelConfiguration::kNoPdControl) {
+      // Set PD controllers for the gripper.
+      SetGripperModel();
 
-    // Arm actuators.
-    std::vector<JointActuatorIndex> arm_actuators;
-    for (JointActuatorIndex actuator_index(0);
-         actuator_index < plant_->num_actuators(); ++actuator_index) {
-      if (plant_->get_joint_actuator(actuator_index).model_instance() ==
-          arm_model_) {
-        arm_actuators.push_back(actuator_index);
-      }
-    }
-
-    // Set PD controllers for the arm, depending on the desired configuration.
-    if (model_config == ModelConfiguration::kArmIsControlled) {
-      // Define PD controllers for the arm.
-      for (JointActuatorIndex actuator_index : arm_actuators) {
-        JointActuator<double>& actuator =
-            plant_->get_mutable_joint_actuator(actuator_index);
-        actuator.set_controller_gains({kProportionalGain_, kDerivativeGain_});
-      }
-    } else if (model_config == ModelConfiguration::kArmIsPartiallyControlled) {
-      // Add PD control only on a subset of actuators.
-      auto& actuator1 = plant_->get_mutable_joint_actuator(arm_actuators[1]);
-      actuator1.set_controller_gains({kProportionalGain_, kDerivativeGain_});
-      auto& actuator3 = plant_->get_mutable_joint_actuator(arm_actuators[3]);
-      actuator3.set_controller_gains({kProportionalGain_, kDerivativeGain_});
-    } else if (model_config == ModelConfiguration::kModelWithZeroGains) {
+      // Arm actuators.
+      std::vector<JointActuatorIndex> arm_actuators;
       for (JointActuatorIndex actuator_index(0);
            actuator_index < plant_->num_actuators(); ++actuator_index) {
-        JointActuator<double>& actuator =
-            plant_->get_mutable_joint_actuator(actuator_index);
-        // We do not add PD controllers to the acrobot.
-        if (actuator.model_instance() == acrobot_model_) continue;
-        // N.B. Proportional gains must be strictly positive, so we choose a
-        // small positive number to approximate zero.
-        actuator.set_controller_gains({1.0e-10, 0.0});
+        if (plant_->get_joint_actuator(actuator_index).model_instance() ==
+            arm_model_) {
+          arm_actuators.push_back(actuator_index);
+        }
+      }
+
+      // Set PD controllers for the arm, depending on the desired configuration.
+      if (model_config == ModelConfiguration::kArmIsControlled) {
+        // Define PD controllers for the arm.
+        for (JointActuatorIndex actuator_index : arm_actuators) {
+          JointActuator<double>& actuator =
+              plant_->get_mutable_joint_actuator(actuator_index);
+          actuator.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+        }
+      } else if (model_config ==
+                 ModelConfiguration::kArmIsPartiallyControlled) {
+        // Add PD control only on a subset of actuators.
+        auto& actuator1 = plant_->get_mutable_joint_actuator(arm_actuators[1]);
+        actuator1.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+        auto& actuator3 = plant_->get_mutable_joint_actuator(arm_actuators[3]);
+        actuator3.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+      } else if (model_config == ModelConfiguration::kModelWithZeroGains) {
+        for (JointActuatorIndex actuator_index(0);
+             actuator_index < plant_->num_actuators(); ++actuator_index) {
+          JointActuator<double>& actuator =
+              plant_->get_mutable_joint_actuator(actuator_index);
+          // We do not add PD controllers to the acrobot.
+          if (actuator.model_instance() == acrobot_model_) continue;
+          // N.B. Proportional gains must be strictly positive, so we choose a
+          // small positive number to approximate zero.
+          actuator.set_controller_gains({1.0e-10, 0.0});
+        }
       }
     }
 
@@ -160,6 +166,86 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
         actuator.set_controller_gains({kProportionalGain_, kDerivativeGain_});
       }
     }
+  }
+
+  // Makes a set of actuation values for each model instance. Values are
+  // arbitrary, though non-zero.
+  // If iiwa_within_limits is false, the actuation vector for the iiwa arm will
+  // be above effort limits (300 Nm) for joints 1 and 2 and below effort limits
+  // (-300 Nm) for joints 4, 5, and 6. The returned tuple packs each model's
+  // actuation as {arm, acrobot, gripper, box}.
+  static std::tuple<VectorXd, VectorXd, VectorXd> MakeActuationForEachModel(
+      bool iiwa_within_limits) {
+    // N.B. Per SDFormat model, effort limits are 300 Nm. We set some of the
+    // actuation values to be outside this limit.
+    const VectorXd arm_u =
+        iiwa_within_limits
+            ? (VectorXd(7) << 50, 40, 55, -35, -40, -45, -40).finished()
+            : (VectorXd(7) << 350, 400, 55, -350, -400, -450, -40).finished();
+    const VectorXd gripper_u = VectorXd::LinSpaced(2, 1.0, 2.0);
+    const VectorXd acrobot_u = VectorXd::LinSpaced(2, 3.0, 4.0);
+    return std::make_tuple(arm_u, acrobot_u, gripper_u);
+  }
+
+  // Given the actuation for each model instance separately, this function
+  // assembles the actuation vector for the full MultibodyPlant model. This is
+  // the actuation vector consumed by
+  // MultibodyPlant::get_actuation_input_port(), ordered by JointActuatorIndex,
+  // regardless of model instance.
+  VectorXd AssembleFullModelActuation(const VectorXd& arm_u,
+                                      const VectorXd& acrobot_u,
+                                      const VectorXd& gripper_u) {
+    // Reported actuation values are indexed by JointActuatorIndex. That is, in
+    // the order actuators were added to the model. For this test, recall that
+    // the acrobot shoulder is added last programmatically.
+    const int nu = plant_->num_actuated_dofs();
+    // clang-format off
+    const VectorXd full_model_u =
+      (VectorXd(nu) <<
+        arm_u,
+        acrobot_u(0), /* Acrobot elbow */
+        gripper_u,
+        acrobot_u(1)  /* Acrobot shoulder */).finished();
+    // clang-format on
+    return full_model_u;
+  }
+
+  // This method sets arm and gripper actuation inputs with
+  // MakeActuationForEachModel(false) (iiwa outside effort limits) and verifies
+  // the actuation output port copies them to the output.
+  // Note: Since the arm actuation is outside effort limits, for SAP this will
+  // only be true in the absence of PD controllers.
+  void VerifyActuationOutputFeedsThroughActuationInputs() {
+    auto [arm_u, acrobot_u, gripper_u] =
+        MakeActuationForEachModel(false /* iiwa outside limits */);
+
+    // Set arbitrary actuation values.
+    plant_->get_actuation_input_port(arm_model_)
+        .FixValue(context_.get(), arm_u);
+    plant_->get_actuation_input_port(gripper_model_)
+        .FixValue(context_.get(), gripper_u);
+    plant_->get_actuation_input_port(acrobot_model_)
+        .FixValue(context_.get(), acrobot_u);
+
+    // Reported actuation values are indexed by JointActuatorIndex. That is, in
+    // the order actuators were added to the model. For this test, recall that
+    // the acrobot elbow is added last programmatically. For continuous models,
+    // we do not expect the actuators to enforce limits, see section @ref
+    // mbp_actuation, in the MultibodyPlant documentation.
+    const int nu = plant_->num_actuated_dofs();
+    // clang-format off
+    const VectorXd expected_u =
+      (VectorXd(nu) <<
+        arm_u,
+        acrobot_u(0), /* Acrobot shoulder */
+        gripper_u,
+        acrobot_u(1) /* Acrobot elbow */).finished();
+    // clang-format on
+
+    // Verify that actuation output is an exact copy of the inputs.
+    const VectorXd actuation_output =
+        plant_->get_net_actuation_output_port().Eval(*context_);
+    EXPECT_EQ(actuation_output, expected_u);
   }
 
  protected:
@@ -242,27 +328,21 @@ TEST_F(ActuatedIiiwaArmTest, AssembleActuationInput) {
       .FixValue(context_.get(), gripper_xd);
 
   // Fix input input ports to known values.
-  const VectorXd gripper_u = (VectorXd(2) << 1.0, 2.0).finished();
+  // We leave the arm's port disconnected to verify it's value defaults to zero
+  // actuation.
+  auto [arm_u, acrobot_u, gripper_u] =
+      MakeActuationForEachModel(false /* irrelevant for this test */);
   plant_->get_actuation_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_u);
-
-  const VectorXd acrobot_u = (VectorXd(2) << 3.0, 4.0).finished();
   plant_->get_actuation_input_port(acrobot_model_)
       .FixValue(context_.get(), acrobot_u);
 
   const VectorXd full_u =
       MultibodyPlantTester::AssembleActuationInput(*plant_, *context_);
-  const int nu = plant_->num_actuated_dofs();
-  // AssembleActuationInput() will always return a vector of size nu. It fills
-  // in values for those models with feed-forward actuation and set all other
-  // entries to zero. In this case, entries corresponding to the arm are
-  // expected to be zero.
+
   const int arm_nu = plant_->num_actuated_dofs(arm_model_);
-  // Values are assembled in order of JointActuatorIndex, regardless of model
-  // instance index. Therefore we expect the shoulder actuator value to be last.
-  VectorXd expected_u = (VectorXd(nu) << VectorXd::Zero(arm_nu), acrobot_u(0),
-                         gripper_u, acrobot_u(1))
-                            .finished();
+  VectorXd expected_u =
+      AssembleFullModelActuation(VectorXd::Zero(arm_nu), acrobot_u, gripper_u);
 
   EXPECT_EQ(full_u, expected_u);
 }
@@ -375,7 +455,8 @@ TEST_F(ActuatedIiiwaArmTest,
 TEST_F(ActuatedIiiwaArmTest,
        PdControlledActuatorsOnlySupportedForDiscreteModels) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SetUpModel(ModelConfiguration::kArmIsControlled, false),
+      SetUpModel(ModelConfiguration::kArmIsControlled,
+                 MultibodyPlantConfig{.time_step = 0.0}),
       "Continuous model with PD controlled joint actuators. This feature is "
       "only supported for discrete models. Refer to MultibodyPlant's "
       "documentation for further details.");
@@ -411,17 +492,14 @@ TEST_F(ActuatedIiiwaArmTest,
 
   // N.B. These values of actuation are well within effort limits, for both arm
   // and gripper.
-  const VectorXd arm_u = VectorXd::LinSpaced(7, 1.0, 7.0);
-  const VectorXd acrobot_u = VectorXd::Zero(2);
-  const VectorXd gripper_u = VectorXd::LinSpaced(2, 1.0, 2.0);
-  const VectorXd free_box_u = VectorXd::Zero(6);
-  VectorXd tau = VectorXd::Zero(plant_->num_velocities());
-  // N.B. We are setting a vector tau of generalized forces, ordered by velocity
-  // indexes and therefore we use SetVelocitiesInArray().
-  plant_->SetVelocitiesInArray(arm_model_, arm_u, &tau);
-  plant_->SetVelocitiesInArray(acrobot_model_, acrobot_u, &tau);
-  plant_->SetVelocitiesInArray(gripper_model_, gripper_u, &tau);
-  plant_->SetVelocitiesInArray(box_model_, free_box_u, &tau);
+  auto [arm_u, acrobot_u, gripper_u] =
+      MakeActuationForEachModel(true /* iiwa inside limits */);
+  const VectorXd expected_u =
+      AssembleFullModelActuation(arm_u, acrobot_u, gripper_u);
+
+  // Map actuation to generalized forces.
+  const MatrixXd B = plant_->MakeActuationMatrix();
+  VectorXd tau = B * expected_u;
 
   auto updates = plant_->AllocateDiscreteVariables();
 
@@ -435,6 +513,8 @@ TEST_F(ActuatedIiiwaArmTest,
   plant_->get_applied_generalized_force_input_port().FixValue(
       context_.get(), VectorXd::Zero(17));
   plant_->get_actuation_input_port(arm_model_).FixValue(context_.get(), arm_u);
+  plant_->get_actuation_input_port(acrobot_model_)
+      .FixValue(context_.get(), acrobot_u);
   plant_->get_actuation_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_u);
   plant_->CalcForcedDiscreteVariableUpdate(*context_, updates.get());
@@ -445,6 +525,12 @@ TEST_F(ActuatedIiiwaArmTest,
   // therefore the accuracy of the solution is affected by solver tolerances.
   const double kTolerance = 1.0e-12;
   EXPECT_TRUE(CompareMatrices(x_actuation, x_tau, kTolerance,
+                              MatrixCompareType::relative));
+
+  // Verify the actuation values reported by the plant.
+  const VectorXd actuation_output =
+      plant_->get_net_actuation_output_port().Eval(*context_);
+  EXPECT_TRUE(CompareMatrices(actuation_output, expected_u, kTolerance,
                               MatrixCompareType::relative));
 }
 
@@ -474,23 +560,18 @@ TEST_F(ActuatedIiiwaArmTest,
   plant_->get_desired_state_input_port(arm_model_)
       .FixValue(context_.get(), arm_x0);
 
-  // N.B. Per SDF model, effort limits are 300 Nm. We set some of the actuation
-  // values to be outside this limit.
-  const VectorXd arm_u =
-      (VectorXd(7) << 350, 400, 55, -350, -400, -450, -40).finished();
-  const VectorXd acrobot_u = VectorXd::Zero(2);
-  const VectorXd gripper_u = VectorXd::LinSpaced(2, 1.0, 2.0);
-  const VectorXd free_box_u = VectorXd::Zero(6);
-  // To obtain the same actuation with generalized forces, we clamp u to be
-  // within effort limits.
+  auto [arm_u, acrobot_u, gripper_u] =
+      MakeActuationForEachModel(false /* iiwa outside limits */);
+
+  // We clamp u to be within the iiwa effort limits so that we can make an
+  // equivalent vector or generalized forces below.
   const VectorXd arm_u_clamped = arm_u.array().min(300).max(-300);
-  VectorXd tau = VectorXd::Zero(plant_->num_velocities());
-  // N.B. We are setting a vector tau of generalized forces, ordered by velocity
-  // indexes and therefore we use SetVelocitiesInArray().
-  plant_->SetVelocitiesInArray(arm_model_, arm_u_clamped, &tau);
-  plant_->SetVelocitiesInArray(acrobot_model_, acrobot_u, &tau);
-  plant_->SetVelocitiesInArray(gripper_model_, gripper_u, &tau);
-  plant_->SetVelocitiesInArray(box_model_, free_box_u, &tau);
+  const VectorXd expected_u =
+      AssembleFullModelActuation(arm_u_clamped, acrobot_u, gripper_u);
+
+  // Map actuation to generalized forces.
+  const MatrixXd B = plant_->MakeActuationMatrix();
+  VectorXd tau = B * expected_u;
 
   auto updates = plant_->AllocateDiscreteVariables();
 
@@ -506,15 +587,68 @@ TEST_F(ActuatedIiiwaArmTest,
   plant_->get_actuation_input_port(arm_model_).FixValue(context_.get(), arm_u);
   plant_->get_actuation_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_u);
+  plant_->get_actuation_input_port(acrobot_model_)
+      .FixValue(context_.get(), acrobot_u);
   plant_->CalcForcedDiscreteVariableUpdate(*context_, updates.get());
   const VectorXd x_actuation = updates->get_vector().CopyToVector();
 
   // N.B. Generalized forces inputs and actuation inputs feed into the result in
   // very different ways. Actuation input goes through the SAP solver and
   // therefore the accuracy of the solution is affected by solver tolerances.
-  const double kTolerance = 1.0e-12;
+  const double kTolerance = 1.0e-10;
   EXPECT_TRUE(CompareMatrices(x_actuation, x_tau, kTolerance,
                               MatrixCompareType::relative));
+
+  // Verify the actuation values reported by the plant.
+  const VectorXd actuation_output =
+      plant_->get_net_actuation_output_port().Eval(*context_);
+  EXPECT_TRUE(CompareMatrices(actuation_output, expected_u, kTolerance,
+                              MatrixCompareType::relative));
+
+  // Joint 4 is actuated beyond its effort limits. Here we verify that when the
+  // joint is locked (and only for this joint), it's PD controller is ignored
+  // and only the input actuation (through the actuation input port) is reported
+  // in the actuation output.
+  plant_->GetJointByName("iiwa_joint_4").Lock(context_.get());
+  const VectorXd arm_u_when_joint4_is_locked =
+      (VectorXd(7) << 300, 300, 55, -350, -300, -300, -40).finished();
+  const VectorXd expected_u_when_joint4_is_locked = AssembleFullModelActuation(
+      arm_u_when_joint4_is_locked, acrobot_u, gripper_u);
+
+  const VectorXd actuation_output_when_joint4_is_locked =
+      plant_->get_net_actuation_output_port().Eval(*context_);
+  EXPECT_TRUE(CompareMatrices(actuation_output_when_joint4_is_locked,
+                              expected_u_when_joint4_is_locked, kTolerance,
+                              MatrixCompareType::relative));
+}
+
+// This test verifies that for continuous models the actuation output port
+// simply feeds through the actuation inputs.
+TEST_F(ActuatedIiiwaArmTest,
+       ActuationOutputForContinuousModelsFeedsThroughActuationInput) {
+  SetUpModel(ModelConfiguration::kNoPdControl,
+             MultibodyPlantConfig{.time_step = 0.0});
+  VerifyActuationOutputFeedsThroughActuationInputs();
+}
+
+// This test verifies that discrete models using a solver other than SAP, simply
+// feed through the actuation inputs.
+TEST_F(ActuatedIiiwaArmTest,
+       ActuationOutputForDiscreteNonSapModelsFeedsThroughActuationInput) {
+  SetUpModel(ModelConfiguration::kNoPdControl,
+             MultibodyPlantConfig{.time_step = 0.01,
+                                  .discrete_contact_solver = "tamsi"});
+  VerifyActuationOutputFeedsThroughActuationInputs();
+}
+
+// This test verifies that SAP models without PD controllers also feed through
+// the actuation input to the actuation output.
+TEST_F(ActuatedIiiwaArmTest,
+       ActuationOutputForDiscreteSapModelsFeedsThroughActuationInput) {
+  SetUpModel(ModelConfiguration::kNoPdControl,
+             MultibodyPlantConfig{.time_step = 0.01,
+                                  .discrete_contact_solver = "sap"});
+  VerifyActuationOutputFeedsThroughActuationInputs();
 }
 
 }  // namespace

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -161,6 +161,10 @@ class DummyDiscreteUpdateManager final : public DiscreteUpdateManager<T> {
     throw std::logic_error("Must implement if needed for these tests.");
   }
 
+  void DoCalcActuation(const systems::Context<T>&, VectorX<T>*) const final {
+    throw std::logic_error("Must implement if needed for these tests.");
+  }
+
  private:
   systems::DiscreteStateIndex additional_state_index_;
   systems::CacheIndex cache_index_;

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -191,6 +191,8 @@ class DoubleOnlyDiscreteUpdateManager final
   void DoCalcDiscreteUpdateMultibodyForces(
       const systems::Context<T>& context,
       MultibodyForces<T>* forces) const final {}
+
+  void DoCalcActuation(const systems::Context<T>&, VectorX<T>*) const final {}
 };
 
 // This test verifies that adding external components that do not support some

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1721,6 +1721,7 @@ GTEST_TEST(MultibodyPlantTest, ReversedWeldError) {
 bool VerifyFeedthroughPorts(const MultibodyPlant<double>& plant) {
   // Create a set of the indices of all ports that can be feedthrough.
   std::set<int> ok_to_feedthrough;
+  ok_to_feedthrough.insert(plant.get_net_actuation_output_port().get_index());
   ok_to_feedthrough.insert(plant.get_reaction_forces_output_port().get_index());
   ok_to_feedthrough.insert(
       plant.get_generalized_acceleration_output_port().get_index());


### PR DESCRIPTION
Adds output port to MultibodyPlant to report the total actuation applied by the actuators in the model, including PD controllers added to the plant.

cc'ing @JoseBarreiros-TRI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20421)
<!-- Reviewable:end -->
