### PR TITLE
[examples/gym] Shorten running time of play_cart_pole_test

### DIFF
--- a/bindings/pydrake/examples/gym/play_cart_pole.py
+++ b/bindings/pydrake/examples/gym/play_cart_pole.py
@@ -34,8 +34,9 @@ def _run_playing(args):
     if args.test:
         check_env(env)
 
-    env.simulator.set_target_realtime_rate(1.0)
-    max_steps = 1e5 if not args.test else 5e2
+    rate = 1.0 if not args.test else 0.0
+    env.simulator.set_target_realtime_rate(rate)
+    max_steps = 1e5 if not args.test else 5e1
 
     if not args.test:
         assert "drake_internal" not in stable_baselines3.__version__


### PR DESCRIPTION
CI got repeatable timeout (60 seconds) for //bindings/pydrake/examples/gym:py/play_cart_pole_test in 

https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-jammy-gcc-bazel-continuous-release/2048/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-jammy-gcc-bazel-continuous-release/2049/

Increase test size to medium.  Previously it was using default (small).

Edit: Actually I can shorten the running time of the test to keep it small.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20422)
<!-- Reviewable:end -->
