### PR TITLE
Clarify MultibodyPlant::CalcGeneralizedForces()

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3592,7 +3592,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// Computes the generalized forces result of a set of MultibodyForces applied
   /// to this model.
   ///
-  /// MultibodyForces stores applied forces as both generalized forces τₐₚₚ and
+  /// MultibodyForces stores applied forces as both generalized forces τ and
   /// spatial forces F on each body, refer to documentation in MultibodyForces
   /// for details. Users of MultibodyForces will use
   /// MultibodyForces::mutable_generalized_forces() to mutate the stored
@@ -3603,7 +3603,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// compute the total generalized forces on this model. More precisely, if
   /// J_WBo is the Jacobian (with respect to velocities) for this model,
   /// including all bodies, then this method computes: <pre>
-  ///   τ = τₐₚₚ + J_WBo⋅F
+  ///   τᵣₑₛᵤₗₜ = τ + J_WBo⋅F
   /// </pre>
   ///
   /// @param[in] context Context that stores the state of the model.

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1563,12 +1563,6 @@ class MultibodyTree {
   //
   // @param[in] context
   //   The context containing the state of the %MultibodyTree model.
-  // @param[in] pc
-  //   A position kinematics cache object already updated to be in sync with
-  //   `context`.
-  // @param[in] vc
-  //   A velocity kinematics cache object already updated to be in sync with
-  //   `context`.
   // @param[in] known_vdot
   //   A vector with the known generalized accelerations `vdot` for the full
   //   %MultibodyTree model. Use Mobilizer::get_accelerations_from_array() to
@@ -1637,11 +1631,6 @@ class MultibodyTree {
   // allocations. However the information in `Fapplied_Bo_W_array`
   // (`tau_applied_array`) would be overwritten through `F_BMo_W_array`
   // (`tau_array`). Make a copy if data must be preserved.
-  //
-  // @pre The position kinematics `pc` must have been previously updated with a
-  // call to CalcPositionKinematicsCache().
-  // @pre The velocity kinematics `vc` must have been previously updated with a
-  // call to CalcVelocityKinematicsCache().
   void CalcInverseDynamics(
       const systems::Context<T>& context, const VectorX<T>& known_vdot,
       const std::vector<SpatialForce<T>>& Fapplied_Bo_W_array,


### PR DESCRIPTION
Closes #20244

Steer away from using `tau_app` because it sometimes is used to denote externally applied forces excluding gravity.

Also update the stale documentation of the related MbT function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20426)
<!-- Reviewable:end -->
