### PR TITLE
[multibody] Eliminate mention of flexible body support from MultibodyTree

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -515,8 +515,6 @@ class TestPlant(unittest.TestCase):
         self._test_multibody_tree_element_mixin(T, body)
         self.assertIsInstance(body.name(), str)
         self.assertIsInstance(body.scoped_name(), ScopedName)
-        self.assertIsInstance(body.get_num_flexible_positions(), int)
-        self.assertIsInstance(body.get_num_flexible_velocities(), int)
         self.assertIsInstance(body.is_floating(), bool)
         self.assertIsInstance(body.has_quaternion_dofs(), bool)
         self.assertIsInstance(body.default_mass(), float)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -327,10 +327,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
         .def("scoped_name", &Class::scoped_name, cls_doc.scoped_name.doc)
-        .def("get_num_flexible_positions", &Class::get_num_flexible_positions,
-            cls_doc.get_num_flexible_positions.doc)
-        .def("get_num_flexible_velocities", &Class::get_num_flexible_velocities,
-            cls_doc.get_num_flexible_velocities.doc)
         .def("body_frame", &Class::body_frame, py_rvp::reference_internal,
             cls_doc.body_frame.doc)
         .def("is_floating", &Class::is_floating, cls_doc.is_floating.doc)

--- a/multibody/multibody_doxygen.h
+++ b/multibody/multibody_doxygen.h
@@ -223,7 +223,6 @@ from Bo to Bcm.  Bcm is not necessarily coincident with Bo and body B's
 translational and spatial properties (e.g., position, velocity, acceleration)
 are measured using Bo (not Bcm).  If an additional frame is fixed to a rigid
 body, its position is located from the body frame.
-For a flexible body, deformations are measured with respect to the body frame.
 
 When a user initially specifies a body, such as in a `<link>` tag of an `.sdf`
 or `.urdf` file, there is a link frame L that may differ from Drake's body frame

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -630,8 +630,8 @@ void SapDriver<T>::AddWeldConstraints(
       const bool treeB_has_dofs = tree_topology().tree_has_dofs(treeB_index);
 
       // TODO(joemasterjohn): Move this exception up to the plant level so
-      // that it fails as fast as possible. Currently, the earliest this can
-      // happen is in MbP::Finalize() after the topology has been finalized.
+      //  that it fails as fast as possible. Currently, the earliest this can
+      //  happen is in MbP::Finalize() after the topology has been finalized.
       if (!treeA_has_dofs && !treeB_has_dofs) {
         const std::string msg = fmt::format(
             "Creating a weld constraint between bodies '{}' and '{}' where "

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -32,11 +32,8 @@ template<typename T> class Body;
 /// A %BodyFrame is a material Frame that serves as the unique reference frame
 /// for a Body.
 ///
-/// Each Body B, regardless of whether it represents a rigid body or a
-/// flexible body, has a unique body frame for which we use the same symbol B
-/// (with meaning clear from context). The body frame is also referred to as
-/// a _reference frame_ in the literature for flexible body mechanics modeling
-/// using the Finite Element Method. All properties of a body are defined with
+/// Each Body B, has a unique body frame for which we use the same symbol B
+/// (with meaning clear from context). All properties of a body are defined with
 /// respect to its body frame, including its mass properties and attachment
 /// locations for joints, constraints, actuators, geometry and so on. Run time
 /// motion of the body is defined with respect to the motion of its body frame.
@@ -46,12 +43,6 @@ template<typename T> class Body;
 /// Note that the %BodyFrame associated with a body does not necessarily need to
 /// be located at its center of mass nor does it need to be aligned with the
 /// body's principal axes, although, in practice, it frequently is.
-/// For flexible bodies, %BodyFrame provides a representation for the body's
-/// reference frame. The flexible degrees of freedom associated with a flexible
-/// body describe the body's deformation in this frame. Therefore, the motion of
-/// a flexible body is defined by the motion of its %BodyFrame, or reference
-/// frame, plus the motion of the material points on the body with respect to
-/// its %BodyFrame.
 ///
 /// A %BodyFrame and Body are tightly coupled concepts; neither makes sense
 /// without the other. Therefore, a %BodyFrame instance is constructed in
@@ -193,16 +184,6 @@ class Body : public MultibodyElement<T> {
   /// Returns scoped name of this frame. Neither of the two pieces of the name
   /// will be empty (the scope name and the element name).
   ScopedName scoped_name() const;
-
-  /// (Not implemented) Returns the number of generalized positions q describing
-  /// flexible deformations for this body. A rigid body will therefore return
-  /// zero.
-  virtual int get_num_flexible_positions() const = 0;
-
-  /// (Not implemented) Returns the number of generalized velocities v
-  /// describing flexible deformations for this body. A rigid body will
-  /// therefore return zero.
-  virtual int get_num_flexible_velocities() const = 0;
 
   /// Returns a const reference to the associated BodyFrame.
   const BodyFrame<T>& body_frame() const {
@@ -370,12 +351,8 @@ class Body : public MultibodyElement<T> {
 
   /// (Advanced) Computes the SpatialInertia `I_BBo_B` of `this` body about its
   /// frame origin `Bo` (not necessarily its center of mass) and expressed in
-  /// its body frame `B`.
-  /// In general, the spatial inertia of a body is a function of state.
-  /// Consider for instance the case of a flexible body for which its spatial
-  /// inertia in the body frame depends on the generalized coordinates
-  /// describing its state of deformation. As a particular case, the spatial
-  /// inertia of a RigidBody in its body frame is constant.
+  /// its body frame `B`. The spatial inertia of a RigidBody in its body frame
+  /// is constant, but may need to be calculated from Parameters.
   virtual SpatialInertia<T> CalcSpatialInertiaInBodyFrame(
       const systems::Context<T>& context) const = 0;
 

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -47,14 +47,6 @@ namespace internal {
 // `X_FM` as a function of the generalized coordinates associated with that
 // mobilizer.
 //
-// In addition, body B could be a flexible body, in which case the pose of each
-// frame attached to B would in general be a function of a number of
-// generalized positions associated with body B. In particular, the pose
-// `X_BM` of the outboard frame M will be a function of body B's generalized
-// positions while the pose `X_PF` of the inboard frame F will be a function of
-// parent body P's generalized positions. A RigidBody has no generalized
-// positions associated with it (see RigidBody::get_num_flexible_positions()).
-//
 // In summary, there will a %BodyNode for each Body in the MultibodyTree which
 // encompasses:
 //
@@ -70,27 +62,9 @@ namespace internal {
 // generalized positions of body B and of its inboard mobilizer.
 //
 // The relationship between frames F and M is dictated by the body B's inboard
-// mobilizer providing the pose `X_FM(qm_B)` as a function of the generalized
-// coordinates `qm_B` (where `m` refers to "mobilizer" and `_B` refers to the
-// fact this is the unique inboard mobilizer of body B.)
-//
-// In addition, body B could be a flexible body, in which case the pose of each
-// frame attached to B would in general be a function of the generalized
-// positions `qb_B` for body B (where `b` refers to "body" and `_B` refers to
-// body B in particular.) In particular, the pose `X_BM(qb_B)` of the outboard
-// frame M will be a function of body B's generalized positions `qb_B` while
-// the pose `X_PF(qb_P)` of the inboard frame F will be a function of parent
-// body P's generalized positions `qb_P`.
-//
-// Therefore, the generalized positions associated with a given body node
-// correspond to the concatenation `qn_B = [qm_B, qb_B]`. Similarly,
-// mobilizer's generalized velocities `vm_B` and body generalized velocities
-// `vb_B` are grouped into `vn_B = [vm_B, vb_B]`. [Jain 2010] uses a similar
-// grouping of generalized coordinates when flexible bodies are considered,
-// see Chapter 13.
-//
-// - [Jain 2010]  Jain, A., 2010. Robot and multibody dynamics: analysis and
-//                algorithms. Springer Science & Business Media.
+// mobilizer providing the pose `X_FM(q_B)` as a function of the generalized
+// coordinates `q_B` (where `_B` means these are the q's for just the unique
+// inboard mobilizer of body B.)
 //
 // @tparam_default_scalar
 template <typename T>
@@ -115,6 +89,10 @@ class BodyNode : public MultibodyElement<T> {
   //
   // @note %BodyNode keeps a reference to the parent body, body and mobilizer
   // for this node, which must outlive `this` BodyNode.
+  //
+  // Reference used below:
+  // - [Jain 2010]  Jain, A., 2010. Robot and multibody dynamics: analysis and
+  //                algorithms. Springer Science & Business Media.
   BodyNode(const BodyNode<T>* parent_node,
            const Body<T>* body, const Mobilizer<T>* mobilizer)
       : MultibodyElement<T>(body->model_instance()),
@@ -191,9 +169,7 @@ class BodyNode : public MultibodyElement<T> {
   int velocity_start() const {
     return topology_.mobilizer_velocities_start_in_v;
   }
-
   //@}
-
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
   // this node's kinematics that only depend on generalized positions.
@@ -219,18 +195,12 @@ class BodyNode : public MultibodyElement<T> {
     CalcAcrossMobilizerPositionKinematicsCache(context, pc);
 
     // This computes into the PositionKinematicsCache:
-    // - X_PB(qb_P, qm_B, qb_B)
-    // - X_WB(q(W:P), qb_P, qm_B, qb_B)
-    // where qb_P are the generalized coordinates associated with body P, qm_B
-    // the generalized coordinates associated with this node's mobilizer and
-    // qb_B the generalized coordinates associated with body B. q(W:P) denotes
-    // all generalized positions in the kinematics path between the world and
-    // the parent body P.
-    // It assumes:
-    // - Body B already updated the pose `X_BM(qb_B)` of the inboard
-    //   mobilizer M.
-    // - We are in a base-to-tip recursion and therefore `X_PF(qb_P)` and `X_WP`
-    //   have already been updated.
+    // - X_PB(q_B)
+    // - X_WB(q(W:P), q_B)
+    // where q_B is the generalized coordinates associated with this node's
+    // mobilizer. q(W:P) denotes all generalized positions in the kinematics
+    // path between World and the parent body P. It assumes we are in a
+    // base-to-tip recursion and therefore `X_WP` has already been updated.
     CalcAcrossMobilizerBodyPoses_BaseToTip(context, pc);
 
     // TODO(amcastro-tri):
@@ -240,10 +210,10 @@ class BodyNode : public MultibodyElement<T> {
     // - M_Bo_W: Spatial inertia.
 
     // TODO(amcastro-tri):
-    // With H_FM(qm) already in the cache (computed by
-    // Mobilizer::UpdatePositionKinematicsCache()) update the cache
-    // entries for H_PB_W, the hinge matrix for the SpatialVelocity jump between
-    // body B and its parent body P expressed in the world frame W.
+    // With H_FM(q) already in the cache (computed by
+    // Mobilizer::UpdatePositionKinematicsCache()) update the cache entries for
+    // H_PB_W, the hinge matrix for the SpatialVelocity jump between body B and
+    // its parent body P expressed in the world frame W.
   }
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
@@ -301,15 +271,11 @@ class BodyNode : public MultibodyElement<T> {
     // terms (V_WPb and V_PB_W) in Eq. (1).
     //
     // Computation of V_PB_W:
-    // This can be split as:
-    //   V_PB_W = V_PFb_W + V_FMb_W + V_MB_W                                (2)
-    // where Fb and Mb are frames aligned rigidly with F and M but with their
-    // origins at Bo. Assuming body P a rigid body V_PFb_W = 0 and assuming B
-    // a rigid body V_MB_W = 0, but that won't be true for flexible bodies.
-    // TODO(amcastro-tri): incorporate terms for flexible bodies below.
-    // Therefore for rigid bodies V_PB_W = V_FMb_W, which can be computed from
-    // the spatial velocity measured in frame F (as provided by mobilizer's
-    // methods)
+    // Let Mb be a frame aligned rigidly with M but with its origin at Bo.
+    // For rigid bodies (which we always have here)
+    //   V_PB_W = V_FMb_W                                                   (2)
+    // which can be computed from the spatial velocity measured in frame F (as
+    // provided by mobilizer's methods)
     //   V_FMb_W = R_WF * V_FMb = R_WF * V_FM.Shift(p_MoBo_F)               (3)
     // arriving to the desired result:
     //   V_PB_W = R_WF * V_FM.Shift(p_MoBo_F)                               (4)
@@ -326,9 +292,7 @@ class BodyNode : public MultibodyElement<T> {
     // It is very common to find treatments in which the body frame B is
     // coincident with the outboard frame M, that is B ≡ M, leading to slightly
     // simpler recursive relations (for instance, see Section 3.3.2 in
-    // Jain (2010).) where p_MoBo_F = 0 and thus V_PB_W = V_FM_W. Here we relax
-    // this restriction in preparation of the more general case considering
-    // flexible bodies.
+    // Jain (2010)) where p_MoBo_F = 0 and thus V_PB_W = V_FM_W.
 
     // Generalized velocities local to this node's mobilizer.
     const auto& vm = this->get_mobilizer_velocities(context);
@@ -490,8 +454,8 @@ class BodyNode : public MultibodyElement<T> {
     // =========================================================================
     // Computation of A_PB = DtP(V_PB), Eq. (4).
 
-    // TODO(amcastro-tri): consider caching these. Especially true if bodies are
-    // flexible. Also used in velocity kinematics.
+    // TODO(amcastro-tri): consider caching these. Also used in velocity
+    //  kinematics.
     const math::RotationMatrix<T> R_PF =
         frame_F.CalcRotationMatrixInBodyFrame(context);
     const math::RigidTransform<T> X_MB =
@@ -503,12 +467,12 @@ class BodyNode : public MultibodyElement<T> {
 
     // Orientation (rotation) of frame F with respect to the world frame W.
     // TODO(amcastro-tri): consider caching X_WF since it is also used to
-    // compute H_PB_W.
+    //  compute H_PB_W.
     const math::RotationMatrix<T> R_WF = R_WP * R_PF;
 
     // Vector from Mo to Bo expressed in frame F as needed below:
     // TODO(amcastro-tri): consider caching this since it is also used to
-    // compute H_PB_W.
+    //  compute H_PB_W.
     const math::RotationMatrix<T>& R_FM = get_X_FM(pc).rotation();
     const Vector3<T>& p_MB_M = X_MB.translation();
     const Vector3<T> p_MB_F = R_FM * p_MB_M;
@@ -770,7 +734,7 @@ class BodyNode : public MultibodyElement<T> {
         inboard_frame().CalcRotationMatrixInBodyFrame(context);
     const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
     // TODO(amcastro-tri): consider caching R_WF since also used in position and
-    // velocity kinematics.
+    //  velocity kinematics.
     const math::RotationMatrix<T> R_WF = R_WP * R_PF;
     const SpatialForce<T> F_BMo_F = R_WF.inverse() * F_BMo_W;
 
@@ -929,11 +893,11 @@ class BodyNode : public MultibodyElement<T> {
   // @throws if diagonal_inertias.size() does not much the number of generalized
   // velocities in the model.
   // TODO(amcastro-tri): Consider specialized BodyNodeImpl implementations that
-  // exploit the sparsity pattern of H_PB_W even at compile time. Most common
-  // cases are:
-  // - Revolute: [x y z 0 0 0]
-  // - Prismatic: [0 0 0 x y z]
-  // - Ball: 3x3 blocks of zeroes.
+  //  exploit the sparsity pattern of H_PB_W even at compile time. Most common
+  //  cases are:
+  //  - Revolute: [x y z 0 0 0]
+  //  - Prismatic: [0 0 0 x y z]
+  //  - Ball: 3x3 blocks of zeroes.
   void CalcArticulatedBodyInertiaCache_TipToBase(
       const systems::Context<T>& context,
       const PositionKinematicsCache<T>& pc,
@@ -1076,11 +1040,11 @@ class BodyNode : public MultibodyElement<T> {
       // inertia of this body B as felt by body P and expressed in frame W.
       // Symmetrize the computation to reduce floating point errors.
       // TODO(amcastro-tri): Notice that the line below makes the implicit
-      // assumption that g_PB_W * U_B_W is SPD and only the lower triangular
-      // portion is used, see the documentation for ArticulatedBodyInertia's
-      // constructor. This assumption is only asserted during debug builds. This
-      // *might* result in the accumulation of floating point round off errors
-      // for long kinematic chains. Further investigation is required.
+      //  assumption that g_PB_W * U_B_W is SPD and only the lower triangular
+      //  portion is used, see the documentation for ArticulatedBodyInertia's
+      //  constructor (checked only during Debug builds). This
+      //  *might* result in the accumulation of floating point round off errors
+      //  for long kinematic chains. Further investigation is required.
       Pplus_PB_W -= ArticulatedBodyInertia<T>(g_PB_W * U_B_W);
     }
   }
@@ -1756,18 +1720,12 @@ class BodyNode : public MultibodyElement<T> {
 
   // Helper method to be called within a base-to-tip recursion that computes
   // into the PositionKinematicsCache:
-  // - X_PB(qb_P, qm_B, qb_B)
-  // - X_WB(q(W:P), qb_P, qm_B, qb_B)
-  // where qb_P are the generalized coordinates associated with body P, qm_B
-  // the generalized coordinates associated with this node's mobilizer, and
-  // qb_B the generalized coordinates associated with body B. q(W:P) denotes
-  // all generalized positions in the kinematics path between the world and
-  // the parent body P.
-  // It assumes:
-  // - Body B already updated the pose `X_BM(qb_B)` of the inboard
-  //   mobilizer M.
-  // - We are in a base-to-tip recursion and therefore `X_PF(qb_P)` and `X_WP`
-  //   have already been updated.
+  // - X_PB(q_B)
+  // - X_WB(q(W:P), q_B)
+  // where q_B is the generalized coordinates associated with this node's
+  // mobilizer. q(W:P) denotes all generalized positions in the kinematics path
+  // between the world and the parent body P. It assumes we are in a base-to-tip
+  // recursion and therefore `X_WP` has already been updated.
   void CalcAcrossMobilizerBodyPoses_BaseToTip(
       const systems::Context<T>& context,
       PositionKinematicsCache<T>* pc) const {
@@ -1784,9 +1742,9 @@ class BodyNode : public MultibodyElement<T> {
     DRAKE_ASSERT(frame_M.body().index() == body_B.index());
 
     // Input (const):
-    // - X_PF(qb_P)
-    // - X_MB(qb_B)
-    // - X_FM(qm_B)
+    // - X_PF
+    // - X_MB
+    // - X_FM(q_B)
     // - X_WP(q(W:B)), where q(W:B) includes all positions in the kinematics
     //                 path from body B to the world W.
     const math::RigidTransform<T> X_MB =
@@ -1797,22 +1755,20 @@ class BodyNode : public MultibodyElement<T> {
         get_X_WP(*pc);  // body_P.EvalPoseInWorld(ctx)
 
     // Output (updating a cache entry):
-    // - X_PB(qf_P, qr_B, qf_B)
-    // - X_WB(q(W:P), qf_P, qr_B, qf_B)
+    // - X_PB(q_B)
+    // - X_WB(q(W:P), q_B)
     math::RigidTransform<T>& X_PB = get_mutable_X_PB(pc);
     math::RigidTransform<T>& X_WB =
         get_mutable_X_WB(pc);  // body_B.EvalPoseInWorld(ctx)
 
     // TODO(amcastro-tri): Consider logic for the common case B = M.
-    // In that case X_FB = X_FM as suggested by setting X_MB = Id.
+    //  In that case X_FB = X_FM as suggested by setting X_MB = Identity.
     const math::RigidTransform<T> X_FB = X_FM * X_MB;
 
     // Given the pose X_FB of body frame B measured in the mobilizer inboard
     // frame F, we can ask frame F (who's parent body is P) for the pose of body
     // B measured in the frame of the parent body P.
     // In the particular case F = B, this method directly returns X_FB.
-    // For flexible bodies this gives the chance to frame F to pull its pose
-    // from the context.
     X_PB = frame_F.CalcOffsetPoseInBody(context, X_FB);
 
     X_WB = X_WP * X_PB;
@@ -1860,7 +1816,7 @@ class BodyNode : public MultibodyElement<T> {
   //   1. Ftot_BBo = b_Bo when A_WB = 0.
   //   2. b_Bo = 0 when w_WB = 0.
   //   3. b_Bo.translational() = 0 when Bo = Bcm (p_BoBcm = 0).
-  //      When Fb_Bo_W_cache is nullptr velocites are considered to be zero.
+  //      When Fb_Bo_W_cache is nullptr velocities are considered to be zero.
   //      Therefore, from (2), the bias term is assumed to be zero and is not
   //      computed.
   void CalcBodySpatialForceGivenItsSpatialAcceleration(
@@ -1869,8 +1825,6 @@ class BodyNode : public MultibodyElement<T> {
       const SpatialAcceleration<T>& A_WB, SpatialForce<T>* Ftot_BBo_W_ptr)
   const {
     DRAKE_DEMAND(Ftot_BBo_W_ptr != nullptr);
-    // TODO(amcastro-tri): add argument for flexible body generalized
-    // accelerations and generalized forces.
 
     // Output spatial force applied on Body B, at Bo, measured in W.
     SpatialForce<T>& Ftot_BBo_W = *Ftot_BBo_W_ptr;

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1089,12 +1089,6 @@ void MultibodyTree<T>::CalcPositionKinematicsCache(
     PositionKinematicsCache<T>* pc) const {
   DRAKE_DEMAND(pc != nullptr);
 
-  // TODO(amcastro-tri): Loop over bodies to update their position dependent
-  // kinematics. This gives the chance to flexible bodies to update the pose
-  // X_BQ(qb_B) of each frame Q that is attached to the body.
-  // Notice this loop can be performed in any order and each X_BQ(qf_B) is
-  // independent of all others. This could even be performed in parallel.
-
   // With the kinematics information across mobilizer's and the kinematics
   // information for each body, we are now in position to perform a base-to-tip
   // recursion to update world positions and parent to child body transforms.
@@ -1118,9 +1112,6 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
     const PositionKinematicsCache<T>& pc,
     VelocityKinematicsCache<T>* vc) const {
   DRAKE_DEMAND(vc != nullptr);
-
-  // TODO(amcastro-tri): Loop over bodies to compute velocity kinematics updates
-  // corresponding to flexible bodies.
 
   // If the model has zero dofs we simply set all spatial velocities to zero and
   // return since there is no work to be done.
@@ -1167,7 +1158,7 @@ void MultibodyTree<T>::CalcSpatialInertiasInWorld(
 
   // Skip the world.
   // TODO(joemasterjohn): Consider an optimization to avoid calculating spatial
-  // inertias for locked floating bodies.
+  //  inertias for locked floating bodies.
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
     const RigidTransform<T>& X_WB = pc.get_X_WB(body.node_index());
@@ -1240,7 +1231,7 @@ void MultibodyTree<T>::CalcSpatialAccelerationBias(
   // an accidental usage (most likely indicating unnecessary math) in code would
   // immediately trigger a trail of NaNs that we can track to the source.
   // TODO(joemasterjohn): Consider an optimization where we avoid computing
-  // `Ab_WB` for locked floating bodies.
+  //  `Ab_WB` for locked floating bodies.
   (*Ab_WB_all)[world_index()].SetNaN();
   for (BodyNodeIndex body_node_index(1); body_node_index < num_bodies();
        ++body_node_index) {
@@ -1265,7 +1256,7 @@ void MultibodyTree<T>::CalcArticulatedBodyForceBias(
   // an accidental usage (most likely indicating unnecessary math) in code would
   // immediately trigger a trail of NaNs that we can track to the source.
   // TODO(joemasterjohn): Consider an optimization to avoid computing `Zb_Bo_W`
-  // for locked floating bodies.
+  //  for locked floating bodies.
   (*Zb_Bo_W_all)[world_index()].SetNaN();
   for (BodyNodeIndex body_node_index(1); body_node_index < num_bodies();
        ++body_node_index) {
@@ -1351,9 +1342,6 @@ void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
   const VelocityKinematicsCache<T>* vc =
       ignore_velocities ? nullptr : &EvalVelocityKinematics(context);
 
-  // TODO(amcastro-tri): Loop over bodies to compute acceleration kinematics
-  // updates corresponding to flexible bodies.
-
   // The world's spatial acceleration is always zero.
   A_WB_array->at(world_index()) = SpatialAcceleration<T>::Zero();
 
@@ -1382,9 +1370,6 @@ void MultibodyTree<T>::CalcAccelerationKinematicsCache(
     AccelerationKinematicsCache<T>* ac) const {
   DRAKE_DEMAND(ac != nullptr);
   DRAKE_DEMAND(known_vdot.size() == topology_.num_velocities());
-
-  // TODO(amcastro-tri): Loop over bodies to compute velocity kinematics updates
-  // corresponding to flexible bodies.
 
   std::vector<SpatialAcceleration<T>>& A_WB_array = ac->get_mutable_A_WB_pool();
 
@@ -1531,7 +1516,7 @@ void MultibodyTree<T>::CalcForceElementsContribution(
   }
 
   // TODO(amcastro-tri): Remove this call once damping is implemented in terms
-  // of force elements.
+  //  of force elements.
   AddJointDampingForces(context, forces);
 }
 
@@ -1606,10 +1591,10 @@ Eigen::SparseMatrix<T> MultibodyTree<T>::MakeVelocityToQDotMap(
   }
 
   // TODO(russt): Consider updating Mobilizer::CalcNMatrix to populate the
-  // SparseMatrix directly. But SparseMatrix does not support block writing
-  // operations, so we will likely need to pass the entire matrix, and each
-  // mobilizer will need to populate according to position_start_in_q() and
-  // velocity_start_in_v().
+  //  SparseMatrix directly. But SparseMatrix does not support block writing
+  //  operations, so we will likely need to pass the entire matrix, and each
+  //  mobilizer will need to populate according to position_start_in_q() and
+  //  velocity_start_in_v().
   std::vector<Eigen::Triplet<T>> triplet_list;
   // Note: We don't reserve storage for the triplet_list, because we don't have
   // a useful estimate of the size in general.

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -381,14 +381,8 @@ struct BodyNodeTopology {
       return false;
     if (mobilizer_velocities_start != other.mobilizer_velocities_start)
       return false;
-
-    if (num_flexible_positions != other.num_flexible_positions)
-      return false;
-    if (flexible_positions_start != other.flexible_positions_start)
-      return false;
-    if (num_flexible_velocities != other.num_flexible_velocities)
-      return false;
-    if (flexible_velocities_start != other.flexible_velocities_start)
+    if (mobilizer_velocities_start_in_v !=
+        other.mobilizer_velocities_start_in_v)
       return false;
 
     return true;
@@ -425,12 +419,6 @@ struct BodyNodeTopology {
   // It is also a valid index into a vector of generalized accelerations (which
   // are the time derivatives of the generalized velocities).
   int mobilizer_velocities_start_in_v{0};
-
-  // Start and number of dofs for this node's body (flexible dofs).
-  int num_flexible_positions{0};
-  int flexible_positions_start{0};
-  int num_flexible_velocities{0};
-  int flexible_velocities_start{0};
 };
 
 // Data structure to store the topological information associated with an
@@ -870,8 +858,6 @@ class MultibodyTreeTopology {
     // Compile information regarding the size of the system:
     // - Number of degrees of freedom (generalized positions and velocities).
     // - Start/end indexes for each node.
-    //
-    // TODO(amcastro-tri): count body dofs (i.e. for flexible dofs).
     //
     // Base-to-Tip loop in DFT order, skipping the world (node = 0).
 

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -20,6 +20,10 @@
 namespace drake {
 namespace multibody {
 
+// TODO(sherm1) Since there are now only rigid bodies, this functionality should
+//  move to the Body base class with RigidBody removed or left as an alias for
+//  Body.
+
 /// The term **rigid body** implies that the deformations of the body under
 /// consideration are so small that they have no significant effect on the
 /// overall motions of the body and therefore deformations can be neglected.
@@ -75,16 +79,6 @@ class RigidBody : public Body<T> {
   RigidBody(const std::string& body_name,
             ModelInstanceIndex model_instance,
             const SpatialInertia<double>& M_BBo_B);
-
-  /// There are no flexible degrees of freedom associated with a rigid body and
-  /// therefore this method returns zero. By definition, a rigid body has no
-  /// state associated with flexible deformations.
-  int get_num_flexible_positions() const final { return 0; }
-
-  /// There are no flexible degrees of freedom associated with a rigid body and
-  /// therefore this method returns zero. By definition, a rigid body has no
-  /// state associated with flexible deformations.
-  int get_num_flexible_velocities() const final { return 0; }
 
   /// Returns this rigid body's default mass, which is initially supplied at
   /// construction when specifying this rigid body's SpatialInertia.
@@ -173,7 +167,7 @@ class RigidBody : public Body<T> {
   }
 
   // TODO(joemasterjohn): Speed this up when we can store a reference to a
-  // SpatialInertia<T> as an abstract parameter.
+  //  SpatialInertia<T> as an abstract parameter.
 
   /// Gets this body's spatial inertia about its origin from the given context.
   /// @param[in] context contains the state of the multibody system.
@@ -271,9 +265,6 @@ class RigidBody : public Body<T> {
   /// kinematics).
   /// @param[in] pc position kinematics cache.
   /// @retval X_WB pose of rigid body B in world frame W.
-  // TODO(amcastro-tri) When cache entries are in the context, replace this
-  // method by Body<T>::get_pose_in_world(const Context<T>&).
-  //----------------------------------------------------------------------------
   const math::RigidTransform<T>& get_pose_in_world(
       const internal::PositionKinematicsCache<T>& pc) const {
     return pc.get_X_WB(this->node_index());
@@ -309,9 +300,6 @@ class RigidBody : public Body<T> {
   /// @param[in] vc velocity kinematics cache.
   /// @retval V_WB_W `this` rigid body B's spatial velocity in the world
   /// frame W, expressed in W (for point Bo, the body frame's origin).
-  // TODO(amcastro-tri) When cache entries are in the context, replace this
-  //  method by Body<T>::get_spatial_velocity_in_world(const Context<T>&).
-  //----------------------------------------------------------------------------
   const SpatialVelocity<T>& get_spatial_velocity_in_world(
       const internal::VelocityKinematicsCache<T>& vc) const {
     return vc.get_V_WB(this->node_index());
@@ -346,9 +334,6 @@ class RigidBody : public Body<T> {
   /// @param[in] ac acceleration kinematics cache.
   /// @retval A_WB_W `this` rigid body B's spatial acceleration in the world
   /// frame W, expressed in W (for point Bo, the body frame's origin).
-  // TODO(amcastro-tri) When cache entries are in the context, replace this
-  // method by Body<T>::get_spatial_acceleration_in_world(const Context<T>&).
-  //----------------------------------------------------------------------------
   const SpatialAcceleration<T>& get_spatial_acceleration_in_world(
       const internal::AccelerationKinematicsCache<T>& ac) const {
     return ac.get_A_WB(this->node_index());

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -57,8 +57,7 @@ class DummyBody : public Body<double> {
     // We need a body index for the body node test to be happy.
     MultibodyElementTester::set_index(this, index);
   }
-  int get_num_flexible_positions() const override { return 0; }
-  int get_num_flexible_velocities() const override { return 0; }
+
   double default_mass() const override { return 0; }
   RotationalInertia<double> default_rotational_inertia() const override {
     return {};

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -128,10 +128,6 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
   EXPECT_EQ(model->get_body(BodyIndex(1)).index(), pendulum.index());
   EXPECT_EQ(model->get_body(BodyIndex(2)).index(), pendulum2.index());
 
-  // Rigid bodies have no generalized coordinates.
-  EXPECT_EQ(pendulum.get_num_flexible_positions(), 0);
-  EXPECT_EQ(pendulum.get_num_flexible_velocities(), 0);
-
   // Verifies that an exception is throw if a call to Finalize() is attempted to
   // an already finalized MultibodyTree.
   EXPECT_THROW(model->Finalize(), std::exception);


### PR DESCRIPTION
At one time we thought we'd support flexible bodies in MultibodyTree. Now we support deformable bodies via a different mechanism. This PR removes anachronistic mention of flexible bodies and internal body states.

Two methods are removed from Body (`get_num_flexible_positions/velocities()`). Since these were documented as "not implemented" I'm proposing to remove them without further deprecation.

Since I had to wade through lots of comments to find everything, there are a few opportunistic comment fixes and removal of expired TODOs also.

In addition to general tech debt cleanup, this is a yak shave for the new MbP topology code which does not deal in body-internal coordinates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20427)
<!-- Reviewable:end -->
