### PR TITLE
[multibody] Make coordinate numbering for Weld mobilizers consistent with others

### DIFF
--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -559,24 +559,15 @@ TEST_F(TreeTopologyTests, SizesAndIndexing) {
     }
 
     // Verify positions and velocity indexes.
-    if (mobilizer_topology.num_velocities == 0) {
-      // MultibodyTreeTopology sets start indexes to zero when there are no
-      // mobilities associated to a node.
-      EXPECT_EQ(node.mobilizer_positions_start, 0);
-      EXPECT_EQ(mobilizer_topology.positions_start, 0);
-      EXPECT_EQ(node.mobilizer_velocities_start, 0);
-      EXPECT_EQ(mobilizer_topology.velocities_start, 0);
-    } else {
-      EXPECT_EQ(positions_index, node.mobilizer_positions_start);
-      EXPECT_EQ(positions_index, mobilizer_topology.positions_start);
-      EXPECT_EQ(velocities_index, node.mobilizer_velocities_start);
-      EXPECT_EQ(velocities_index, mobilizer_topology.velocities_start);
+    EXPECT_EQ(positions_index, node.mobilizer_positions_start);
+    EXPECT_EQ(positions_index, mobilizer_topology.positions_start);
+    EXPECT_EQ(velocities_index, node.mobilizer_velocities_start);
+    EXPECT_EQ(velocities_index, mobilizer_topology.velocities_start);
 
-      // Mobilizers 5 and 8 are weld joints, with no velocities. All other
-      // mobilizers introduce one position and one velocity.
-      positions_index += 1;
-      velocities_index += 1;
-    }
+    // Mobilizers 5 and 8 are weld joints, with no velocities. All other
+    // mobilizers introduce one position and one velocity.
+    positions_index += mobilizer_topology.num_positions;
+    velocities_index += mobilizer_topology.num_velocities;
   }
   EXPECT_EQ(positions_index, topology.num_positions());
   EXPECT_EQ(velocities_index, topology.num_states());


### PR DESCRIPTION
Removes some special cases for Weld coordinate numbering by making it consistent with other mobilizer types.

The consistent approach is to assign q_start and v_start for Welds to be where they _would_ put coordinates if they had any. Then because nq==nv==0 for Welds, the next mobilizer starts at the same place. This consistent numbering scheme was already being used for trees with 0 dofs; it is definitely the nicer approach!

This is an internal-only change with no visible consequences. (This PR is a yak shave for the new MbP topology code which uses consistent numbering for all mobilized body types.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20428)
<!-- Reviewable:end -->
