### PR TITLE
[py doc] Set a policy that modules must always be factored

### DIFF
--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -140,10 +140,6 @@ When testing the values of NumPy matrices, please review the documentation in
   - File Names: `*.py`, `*_py.cc`
     - Each `*_py.cc` file should only define one package (a module; optionally
     with multiple submodules under it).
-    - *Note*: If you need to split up a `{module}_py.cc` file for compilation
-    speed and clarity, use `{module}_py_{part}.cc` for source and
-    `{module}_py_{part}.h` for headers, and then include the headers into the
-    original module source file. `{part}` may not necessarily be a submodule.
 
 - `*_pybind`: A C++ library for adding pybind-specific utilities to be consumed
   by C++.
@@ -185,6 +181,21 @@ components being built.
 @anchor PydrakeModuleDefinitions
 ## pybind Module Definitions
 
+- Module bindings must always be split into parts (to avoid large files that
+  would bloat our compile times). The easiest way to understand this pattern is
+  probably to look at an existing module that follows the convention (e.g.,
+  `pydrake/geometry/**` or `pydrake/visualization/**`), but here's a summary of
+  the rules:
+  - foo_py.h: provides function signatures for the various "Define..." helper
+    functions that comprise the module. In general, splitting into more
+    (smaller) helper functions is better than fewer (larger) helper functions.
+  - foo_py.cc: uses PYBIND11_MODULE to define the package or module, by
+    importing other dependent modules, calling the "Define..." helper functions,
+    and possibly defining submodules.  Must not itself add bindings; it must
+    always call helpers that add them.
+  - foo_py_bar.cc: the definition for the "DefineBar" helper function.
+  - foo_py_quux.cc: the definition for the "DefineQuux" helper function.
+  - ... etc.
 - Modules should be defined within the drake::pydrake namespace. Please review
 this namespace for available helper methods / classes.
 - Any Drake pybind module should include `pydrake_pybind.h`.


### PR DESCRIPTION
Even modules that start small end up growing too big, so from day one we should always define modules in pieces.

The dependency tree is not always simple. By defining the pieces of a module one by one, it allows us to stagger imports vs definitions and/or more carefully bind things in the right order.

+@EricCousineau-TRI for SME feature review, please.
+@SeanCurtis-TRI for additional feature review, please.
+@sammy-tri for platform review per schedule, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20432)
<!-- Reviewable:end -->
