### PR TITLE
[RenderEngineVtk] Throw exceptions rather than abort() in vtkXOpenGLRenderWindow.cxx

### DIFF
--- a/tools/workspace/vtk_internal/patches/rendering_opengl2_throw_rather_than_abort.patch
+++ b/tools/workspace/vtk_internal/patches/rendering_opengl2_throw_rather_than_abort.patch
@@ -1,0 +1,170 @@
+[vtk] Throw exceptions rather than abort() in vtkXOpenGLRenderWindow.cxx
+
+This patch is being added to drake to bypass inconsistent error reporting
+mechanisms in VTK that result in jupyter kernels restarting without any output
+to the user as to what went wrong (e.g., DISPLAY is not set but they are trying
+to use graphics functions).  See drake issue 18445 for more information.
+
+TODO(#20455) VTK cannot accept patches with exceptions, so we intend to upstream
+a different patch that makes the error mechanisms consistent and install a
+signal handler for drake to catch the abort() statements and error slightly
+more gracefully.
+
+
+--- Rendering/OpenGL2/vtkXOpenGLRenderWindow.cxx
++++ Rendering/OpenGL2/vtkXOpenGLRenderWindow.cxx
+@@ -61,6 +61,8 @@ typedef ptrdiff_t GLsizeiptr;
+ #include "vtkRendererCollection.h"
+ #include "vtkStringOutputWindow.h"
+
++#include <exception>
++#include <string>
+ #include <sstream>
+
+ #include <X11/Xatom.h>
+@@ -77,6 +79,14 @@ typedef ptrdiff_t GLsizeiptr;
+  * it populates the global namespace.
+  */
+ VTK_ABI_NAMESPACE_BEGIN
++
++namespace {
++std::string SummarizeDisplayEnv() {
++  const char* const display = vtksys::SystemTools::GetEnv("DISPLAY");
++  return display == nullptr ? std::string("DISPLAY is not set") : std::string("DISPLAY=") + display;
++}
++}  // namespace
++
+ struct vtkXVisualInfo : public XVisualInfo
+ {
+ };
+@@ -251,9 +261,9 @@ vtkXVisualInfo* vtkXOpenGLRenderWindow::GetDesiredVisualInfo()
+
+     if (this->DisplayId == nullptr)
+     {
+-      vtkErrorMacro(<< "bad X server connection. DISPLAY=" << vtksys::SystemTools::GetEnv("DISPLAY")
+-                    << ". Aborting.\n");
+-      abort();
++      throw std::runtime_error(
++        "VTK OpenGL2 error: bad X server connection. DISPLAY=" +
++        SummarizeDisplayEnv() + ".");
+     }
+
+     this->OwnDisplay = 1;
+@@ -264,14 +274,16 @@ vtkXVisualInfo* vtkXOpenGLRenderWindow::GetDesiredVisualInfo()
+
+   if (!this->Internal->FBConfig)
+   {
+-    vtkErrorMacro(<< "Could not find a decent config\n");
++    throw std::runtime_error(
++      "VTK OpenGL2 error: could not obtain GLX frame buffer configurations.");
+   }
+   else
+   {
+     v = glXGetVisualFromFBConfig(this->DisplayId, this->Internal->FBConfig);
+     if (!v)
+     {
+-      vtkErrorMacro(<< "Could not find a decent visual\n");
++      throw std::runtime_error(
++        "VTK OpenGL2 error: could not obtain GLX XVisualInfo.");
+     }
+   }
+   return reinterpret_cast<vtkXVisualInfo*>(v);
+@@ -462,9 +474,9 @@ void vtkXOpenGLRenderWindow::CreateAWindow()
+     this->DisplayId = XOpenDisplay(static_cast<char*>(nullptr));
+     if (this->DisplayId == nullptr)
+     {
+-      vtkErrorMacro(<< "bad X server connection. DISPLAY=" << vtksys::SystemTools::GetEnv("DISPLAY")
+-                    << ". Aborting.\n");
+-      abort();
++      throw std::runtime_error(
++        "VTK OpenGL2 error: bad X server connection. DISPLAY=" +
++        SummarizeDisplayEnv() + ".");
+     }
+     this->OwnDisplay = 1;
+   }
+@@ -482,8 +494,8 @@ void vtkXOpenGLRenderWindow::CreateAWindow()
+     v = this->GetDesiredVisualInfo();
+     if (!v)
+     {
+-      vtkErrorMacro(<< "Could not find a decent visual\n");
+-      abort();
++      throw std::runtime_error(
++        "VTK OpenGL2 error: could not obtain GLX XVisualInfo.");
+     }
+     this->ColorMap = XCreateColormap(
+       this->DisplayId, XRootWindow(this->DisplayId, v->screen), v->visual, AllocNone);
+@@ -555,16 +567,7 @@ void vtkXOpenGLRenderWindow::CreateAWindow()
+   // is GLX extension is supported?
+   if (!glXQueryExtension(this->DisplayId, nullptr, nullptr))
+   {
+-    vtkErrorMacro("GLX not found.  Aborting.");
+-    if (this->HasObserver(vtkCommand::ExitEvent))
+-    {
+-      this->InvokeEvent(vtkCommand::ExitEvent, nullptr);
+-      return;
+-    }
+-    else
+-    {
+-      abort();
+-    }
++    throw std::runtime_error("VTK OpenGL2 error: GLX not found.");
+   }
+
+   // try for 32 context
+@@ -649,16 +652,7 @@ void vtkXOpenGLRenderWindow::CreateAWindow()
+
+   if (!this->Internal->ContextId)
+   {
+-    vtkErrorMacro("Cannot create GLX context.  Aborting.");
+-    if (this->HasObserver(vtkCommand::ExitEvent))
+-    {
+-      this->InvokeEvent(vtkCommand::ExitEvent, nullptr);
+-      return;
+-    }
+-    else
+-    {
+-      abort();
+-    }
++    throw std::runtime_error("VTK OpenGL2 error: cannot create GLX context.");
+   }
+
+   if (this->OwnWindow && this->ShowWindow)
+@@ -1215,9 +1209,9 @@ int* vtkXOpenGLRenderWindow::GetScreenSize()
+     this->DisplayId = XOpenDisplay(static_cast<char*>(nullptr));
+     if (this->DisplayId == nullptr)
+     {
+-      vtkErrorMacro(<< "bad X server connection. DISPLAY=" << vtksys::SystemTools::GetEnv("DISPLAY")
+-                    << ". Aborting.\n");
+-      abort();
++      throw std::runtime_error(
++        "VTK OpenGL2 error: bad X server connection. DISPLAY=" +
++        SummarizeDisplayEnv() + ".");
+     }
+     else
+     {
+@@ -1335,9 +1329,9 @@ void vtkXOpenGLRenderWindow::SetWindowInfo(const char* info)
+     this->DisplayId = XOpenDisplay(static_cast<char*>(nullptr));
+     if (this->DisplayId == nullptr)
+     {
+-      vtkErrorMacro(<< "bad X server connection. DISPLAY=" << vtksys::SystemTools::GetEnv("DISPLAY")
+-                    << ". Aborting.\n");
+-      abort();
++      throw std::runtime_error(
++        "VTK OpenGL2 error: bad X server connection. DISPLAY=" +
++        SummarizeDisplayEnv() + ".");
+     }
+     else
+     {
+@@ -1370,9 +1364,9 @@ void vtkXOpenGLRenderWindow::SetParentInfo(const char* info)
+     this->DisplayId = XOpenDisplay(static_cast<char*>(nullptr));
+     if (this->DisplayId == nullptr)
+     {
+-      vtkErrorMacro(<< "bad X server connection. DISPLAY=" << vtksys::SystemTools::GetEnv("DISPLAY")
+-                    << ". Aborting.\n");
+-      abort();
++      throw std::runtime_error(
++        "VTK OpenGL2 error: bad X server connection. DISPLAY=" +
++        SummarizeDisplayEnv() + ".");
+     }
+     else
+     {

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -152,6 +152,7 @@ vtk_internal_repository = repository_rule(
                 "@drake//tools/workspace/vtk_internal:patches/io_image_png_messages.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/io_legacy_data_reader_uninit.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/rendering_opengl2_nobacktrace.patch",  # noqa
+                "@drake//tools/workspace/vtk_internal:patches/rendering_opengl2_throw_rather_than_abort.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/vtkdoubleconversion_hidden.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/vtkglew_hidden.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/vtkpugixml_hidden.patch",  # noqa


### PR DESCRIPTION
Fixes #18445.

The vtkXOpenGLRenderWindow.cxx initialization code aborts when a DISPLAY cannot be found.  We are transforming this into an exception because in a headless jupyter kernel (e.g., deepnote), the abort() call makes the kernel restart without any helpful information to the user as to _why_ it restarted.  With exceptions, the kernel will continue to run but provide the exception message instead.

Final testing for feature reviewer can be done as:

1. First build this Dockerfile:

    ```console
    docker build -t drake-18445:latest .
    ```
2. Now run it and allow the ports for jupyter to forward.  While this is not the full setup to get a valid DISPLAY in docker, that's not what we're testing here, we're testing that the error messages are useful / exist rather than a kernel restart:

    ```console
    docker run --rm -it -p 8888:8888 drake-18445:latest
    ```
3. Now in the container:

    ```
    cd /opt/tutorials/broken/
    ./venv_broken/bin/jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
    ```

    It will launch jupyter and spit out a token, like:

    ```
    To access the notebook, open this file in a browser:
        file:///root/.local/share/jupyter/runtime/nbserver-14-open.html
    Or copy and paste one of these URLs:
        http://315f5c18710b:8888/?token=9199cfe591f5c6c809d4b93ed588b4050ee4fc320e8730bc
     or http://127.0.0.1:8888/?token=9199cfe591f5c6c809d4b93ed588b4050ee4fc320e8730bc
    ```

    Visit the 127.0.0.1:8888 url in your host OS browser, select Open and choose `rendering_multibody_plant.ipynb`, then select Run -> Run All Cells.  The browser will tell you the Kernel is Restarting, and the console output will show the same.
4. Go ahead and close the browser windows, and ctrl+c the docker jupyter kernel so we can launch the fixed one.
5. Launch the fixed one:

    ```console
    cd /opt/tutorials/fixed
    ./venv_fixed/bin/jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
    ```

    Like before, you'll get a 127.0.0.1 URL with a new token, paste that into your browser, and run all the cells in the notebook.

    ```py
    RuntimeError                              Traceback (most recent call last)
    Cell In[18], line 1
    ----> 1 color = sensor.color_image_output_port().Eval(
          2     sensor.GetMyContextFromRoot(diagram_context)).data
          3 depth = colorize_depth.get_output_port().Eval(
          4     colorize_depth.GetMyContextFromRoot(diagram_context)).data
          5 label = colorize_label.get_output_port().Eval(
          6     colorize_label.GetMyContextFromRoot(diagram_context)).data
    RuntimeError: basic_string::_M_construct null not valid
    ```
-----

The hacky `Dockerfile`:

```docker
# -*- mode: dockerfile -*-
# vi: set ft=dockerfile :

FROM ubuntu:jammy

RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y git

WORKDIR /opt
RUN git clone https://github.com/RobotLocomotion/drake.git
RUN DEBIAN_FRONTEND=noninteractive \
  TZ=America/New_York \
  ./drake/setup/ubuntu/install_prereqs.sh -y

# Putting in different folders so that checkpoints between the two do not
# end up conflicting with each other (.ipynb_checkpoints folder created when
# running the notebook).
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3.10-venv

# Experimental job from https://github.com/RobotLocomotion/drake/pull/20433
# (which will be deleted fairly soon)
WORKDIR /opt/tutorials/fixed
RUN cp /opt/drake/tutorials/rendering_multibody_plant.ipynb .
RUN python3 -m venv venv_fixed
RUN ./venv_fixed/bin/pip3 install \
  jupyter \
  https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.2023.10.27.0.9.27%2Bgite85f1c9a-cp310-cp310-manylinux_2_31_x86_64.whl

# Install one that we know is broken for confirmation
WORKDIR /opt/tutorials/broken
RUN cp /opt/drake/tutorials/rendering_multibody_plant.ipynb .
RUN python3 -m venv venv_broken
RUN ./venv_broken/bin/pip3 install \
  jupyter \
  drake
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20433)
<!-- Reviewable:end -->
