### PR TITLE
Increase timeout for internal_render_engine_vtk_test

### DIFF
--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -114,6 +114,7 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "internal_render_engine_vtk_test",
+    timeout = "moderate",
     args = select({
         # Most test cases do not render correctly on macOS arm64 CI. Instead of
         # trying to select the few that randomly happen to pass, we'll skip all


### PR DESCRIPTION
Although the tests are excluded from mac arm, this test now times out on mac x86 monterey.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20434)
<!-- Reviewable:end -->
