### PR TITLE
[multibody] Disambiguate use of "velocity_start" in MultibodyTree

### DIFF
--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -382,9 +382,10 @@ void DeformableDriver<T>::AppendContactKinematics(
             context, JacobianWrtVariable::kV, rigid_body.body_frame(), frame_W,
             p_WC, frame_W, frame_W, &Jv_v_WBc_W);
         Matrix3X<T> J =
-            R_CW.matrix() * Jv_v_WBc_W.middleCols(
-                                tree_topology.tree_velocities_start(tree_index),
-                                tree_topology.num_tree_velocities(tree_index));
+            R_CW.matrix() *
+            Jv_v_WBc_W.middleCols(
+                tree_topology.tree_velocities_start_in_v(tree_index),
+                tree_topology.num_tree_velocities(tree_index));
         jacobian_blocks.emplace_back(tree_index, MatrixBlock<T>(std::move(J)));
       }
 
@@ -530,9 +531,9 @@ void DeformableDriver<T>::AppendDeformableRigidFixedConstraintKinematics(
             context, JacobianWrtVariable::kV, rigid_body.body_frame(), frame_W,
             Eigen::Map<const Matrix3X<T>>(p_WQs.data(), 3, p_WQs.size() / 3),
             frame_W, frame_W, &Jv_v_WBq);
-        MatrixBlock<T> jacobian_block_B(
-            Jv_v_WBq.middleCols(tree_topology.tree_velocities_start(tree_index),
-                                tree_topology.num_tree_velocities(tree_index)));
+        MatrixBlock<T> jacobian_block_B(Jv_v_WBq.middleCols(
+            tree_topology.tree_velocities_start_in_v(tree_index),
+            tree_topology.num_tree_velocities(tree_index)));
         SapConstraintJacobian<T> J(clique_index_A, std::move(jacobian_block_A),
                                    clique_index_B, std::move(jacobian_block_B));
         result->emplace_back(object_A, std::move(p_WPs), object_B,

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -833,10 +833,11 @@ void DiscreteUpdateManager<T>::AppendContactKinematics(
 
     // Tree A contribution to contact Jacobian Jv_W_AcBc_C.
     if (treeA_has_dofs) {
-      Matrix3X<T> J = R_WC.matrix().transpose() *
-                      Jv_AcBc_W.middleCols(
-                          tree_topology().tree_velocities_start(treeA_index),
-                          tree_topology().num_tree_velocities(treeA_index));
+      Matrix3X<T> J =
+          R_WC.matrix().transpose() *
+          Jv_AcBc_W.middleCols(
+              tree_topology().tree_velocities_start_in_v(treeA_index),
+              tree_topology().num_tree_velocities(treeA_index));
       jacobian_blocks.emplace_back(treeA_index, MatrixBlock<T>(std::move(J)));
     }
 
@@ -844,10 +845,11 @@ void DiscreteUpdateManager<T>::AppendContactKinematics(
     // This contribution must be added only if B is different from A.
     if ((treeB_has_dofs && !treeA_has_dofs) ||
         (treeB_has_dofs && treeB_index != treeA_index)) {
-      Matrix3X<T> J = R_WC.matrix().transpose() *
-                      Jv_AcBc_W.middleCols(
-                          tree_topology().tree_velocities_start(treeB_index),
-                          tree_topology().num_tree_velocities(treeB_index));
+      Matrix3X<T> J =
+          R_WC.matrix().transpose() *
+          Jv_AcBc_W.middleCols(
+              tree_topology().tree_velocities_start_in_v(treeB_index),
+              tree_topology().num_tree_velocities(treeB_index));
       jacobian_blocks.emplace_back(treeB_index, MatrixBlock<T>(std::move(J)));
     }
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2510,13 +2510,13 @@ void MultibodyPlant<T>::CalcJointLockingCache(
 
   for (int dof : unlocked) {
     const internal::TreeIndex tree = topology.velocity_to_tree_index(dof);
-    const int tree_dof = dof - topology.tree_velocities_start(tree);
+    const int tree_dof = dof - topology.tree_velocities_start_in_v(tree);
     unlocked_per_tree[tree].push_back(tree_dof);
   }
 
   for (int dof : locked) {
     const internal::TreeIndex tree = topology.velocity_to_tree_index(dof);
-    const int tree_dof = dof - topology.tree_velocities_start(tree);
+    const int tree_dof = dof - topology.tree_velocities_start_in_v(tree);
     locked_per_tree[tree].push_back(tree_dof);
   }
 }

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -145,9 +145,9 @@ void SapDriver<T>::CalcLinearDynamicsMatrix(const systems::Context<T>& context,
   M.diagonal() += plant().time_step() * joint_damping_;
 
   for (TreeIndex t(0); t < tree_topology().num_trees(); ++t) {
-    const int tree_start = tree_topology().tree_velocities_start(t);
+    const int tree_start_in_v = tree_topology().tree_velocities_start_in_v(t);
     const int tree_nv = tree_topology().num_tree_velocities(t);
-    (*A)[t] = M.block(tree_start, tree_start, tree_nv, tree_nv);
+    (*A)[t] = M.block(tree_start_in_v, tree_start_in_v, tree_nv, tree_nv);
   }
 
   if constexpr (std::is_same_v<T, double>) {
@@ -300,7 +300,7 @@ void SapDriver<T>::AddLimitConstraints(const systems::Context<T>& context,
           tree_topology().velocity_to_tree_index(velocity_start);
       const int tree_nv = tree_topology().num_tree_velocities(tree_index);
       const int tree_velocity_start =
-          tree_topology().tree_velocities_start(tree_index);
+          tree_topology().tree_velocities_start_in_v(tree_index);
       const int tree_dof = velocity_start - tree_velocity_start;
 
       // Current configuration position.
@@ -378,8 +378,10 @@ void SapDriver<T>::AddCouplerConstraints(const systems::Context<T>& context,
     DRAKE_DEMAND(tree0.is_valid() && tree1.is_valid());
 
     // DOFs local to their tree.
-    const int tree_dof0 = dof0 - tree_topology().tree_velocities_start(tree0);
-    const int tree_dof1 = dof1 - tree_topology().tree_velocities_start(tree1);
+    const int tree_dof0 =
+        dof0 - tree_topology().tree_velocities_start_in_v(tree0);
+    const int tree_dof1 =
+        dof1 - tree_topology().tree_velocities_start_in_v(tree1);
 
     const int tree_nv0 = tree_topology().num_tree_velocities(tree0);
     const int tree_nv1 = tree_topology().num_tree_velocities(tree1);
@@ -456,15 +458,15 @@ void SapDriver<T>::AddDistanceConstraints(const systems::Context<T>& context,
       if (single_tree) {
         const TreeIndex tree_index = treeA_has_dofs ? treeA_index : treeB_index;
         MatrixX<T> Jtree = Jv_ApBq_W.middleCols(
-            tree_topology().tree_velocities_start(tree_index),
+            tree_topology().tree_velocities_start_in_v(tree_index),
             tree_topology().num_tree_velocities(tree_index));
         return SapConstraintJacobian<T>(tree_index, std::move(Jtree));
       } else {
         MatrixX<T> JA = Jv_ApBq_W.middleCols(
-            tree_topology().tree_velocities_start(treeA_index),
+            tree_topology().tree_velocities_start_in_v(treeA_index),
             tree_topology().num_tree_velocities(treeA_index));
         MatrixX<T> JB = Jv_ApBq_W.middleCols(
-            tree_topology().tree_velocities_start(treeB_index),
+            tree_topology().tree_velocities_start_in_v(treeB_index),
             tree_topology().num_tree_velocities(treeB_index));
         return SapConstraintJacobian<T>(treeA_index, std::move(JA), treeB_index,
                                         std::move(JB));
@@ -554,15 +556,15 @@ void SapDriver<T>::AddBallConstraints(
       if (single_tree) {
         const TreeIndex tree_index = treeA_has_dofs ? treeA_index : treeB_index;
         MatrixX<T> Jtree = Jv_ApBq_W.middleCols(
-            tree_topology().tree_velocities_start(tree_index),
+            tree_topology().tree_velocities_start_in_v(tree_index),
             tree_topology().num_tree_velocities(tree_index));
         return SapConstraintJacobian<T>(tree_index, std::move(Jtree));
       } else {
         MatrixX<T> JA = Jv_ApBq_W.middleCols(
-            tree_topology().tree_velocities_start(treeA_index),
+            tree_topology().tree_velocities_start_in_v(treeA_index),
             tree_topology().num_tree_velocities(treeA_index));
         MatrixX<T> JB = Jv_ApBq_W.middleCols(
-            tree_topology().tree_velocities_start(treeB_index),
+            tree_topology().tree_velocities_start_in_v(treeB_index),
             tree_topology().num_tree_velocities(treeB_index));
         return SapConstraintJacobian<T>(treeA_index, std::move(JA), treeB_index,
                                         std::move(JB));
@@ -648,15 +650,15 @@ void SapDriver<T>::AddWeldConstraints(
       if (single_tree) {
         const TreeIndex tree_index = treeA_has_dofs ? treeA_index : treeB_index;
         MatrixX<T> Jtree_W = J_W_AmBm.middleCols(
-            tree_topology().tree_velocities_start(tree_index),
+            tree_topology().tree_velocities_start_in_v(tree_index),
             tree_topology().num_tree_velocities(tree_index));
         return SapConstraintJacobian<T>(tree_index, std::move(Jtree_W));
       } else {
         MatrixX<T> JA_W = J_W_AmBm.middleCols(
-            tree_topology().tree_velocities_start(treeA_index),
+            tree_topology().tree_velocities_start_in_v(treeA_index),
             tree_topology().num_tree_velocities(treeA_index));
         MatrixX<T> JB_W = J_W_AmBm.middleCols(
-            tree_topology().tree_velocities_start(treeB_index),
+            tree_topology().tree_velocities_start_in_v(treeB_index),
             tree_topology().num_tree_velocities(treeB_index));
         return SapConstraintJacobian<T>(treeA_index, std::move(JA_W),
                                         treeB_index, std::move(JB_W));
@@ -702,7 +704,8 @@ void SapDriver<T>::AddPdControllerConstraints(
       const T& q0 = joint.GetOnePosition(context);
       const int dof = joint.velocity_start();
       const TreeIndex tree = tree_topology().velocity_to_tree_index(dof);
-      const int tree_dof = dof - tree_topology().tree_velocities_start(tree);
+      const int tree_dof =
+          dof - tree_topology().tree_velocities_start_in_v(tree);
       const int tree_nv = tree_topology().num_tree_velocities(tree);
 
       // Controller gains.
@@ -869,7 +872,7 @@ void SapDriver<T>::AddCliqueContribution(
     }
   } else {
     const TreeIndex t(clique);
-    const int v_start = tree_topology().tree_velocities_start(t);
+    const int v_start = tree_topology().tree_velocities_start_in_v(t);
     const int nv = tree_topology().num_tree_velocities(t);
     values->segment(v_start, nv) += clique_values;
   }

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -45,7 +45,8 @@ internal::ContactJacobians<T> TamsiDriver<T>::CalcContactJacobians(
     const ContactPairKinematics<T>& pair_kinematics = contact_kinematics[i];
     for (const typename ContactPairKinematics<T>::JacobianTreeBlock&
              tree_jacobian : pair_kinematics.jacobian) {
-      const int col_offset = topology.tree_velocities_start(tree_jacobian.tree);
+      const int col_offset =
+          topology.tree_velocities_start_in_v(tree_jacobian.tree);
       const int tree_nv = topology.num_tree_velocities(tree_jacobian.tree);
       contact_jacobians.Jc.block(row_offset, col_offset, 3, tree_nv) =
           tree_jacobian.J.MakeDenseMatrix();

--- a/multibody/plant/test/compliant_contact_manager_tester.h
+++ b/multibody/plant/test/compliant_contact_manager_tester.h
@@ -86,7 +86,7 @@ class CompliantContactManagerTester {
         // If added to the Jacobian, it must have a valid index.
         EXPECT_TRUE(tree_jacobian.tree.is_valid());
         const int col_offset =
-            topology.tree_velocities_start(tree_jacobian.tree);
+            topology.tree_velocities_start_in_v(tree_jacobian.tree);
         const int tree_nv = topology.num_tree_velocities(tree_jacobian.tree);
         J_AcBc_C.block(row_offset, col_offset, 3, tree_nv) =
             tree_jacobian.J.MakeDenseMatrix();

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -351,7 +351,7 @@ TEST_F(KukaIiwaArmTests, CalcLinearDynamicsMatrix) {
   const MultibodyTreeTopology& topology =
       CompliantContactManagerTester::topology(*manager_);
   for (TreeIndex t(0); t < topology.num_trees(); ++t) {
-    const int tree_start = topology.tree_velocities_start(t);
+    const int tree_start = topology.tree_velocities_start_in_v(t);
     const int tree_nv = topology.num_tree_velocities(t);
     Adense.block(tree_start, tree_start, tree_nv, tree_nv) = A[t];
   }

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -287,9 +287,9 @@ TEST_F(SpheresStackTest, CalcLinearDynamicsMatrix) {
   const int nv = plant_->num_velocities();
   MatrixXd Adense = MatrixXd::Zero(nv, nv);
   for (TreeIndex t(0); t < topology().num_trees(); ++t) {
-    const int tree_start = topology().tree_velocities_start(t);
+    const int tree_start_in_v = topology().tree_velocities_start_in_v(t);
     const int tree_nv = topology().num_tree_velocities(t);
-    Adense.block(tree_start, tree_start, tree_nv, tree_nv) = A[t];
+    Adense.block(tree_start_in_v, tree_start_in_v, tree_nv, tree_nv) = A[t];
   }
   MatrixXd Aexpected(nv, nv);
   plant_->CalcMassMatrix(*plant_context_, &Aexpected);

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -285,7 +285,7 @@ class Body : public MultibodyElement<T> {
   int floating_velocities_start() const {
     DRAKE_BODY_THROW_IF_NOT_FINALIZED();
     DRAKE_DEMAND(is_floating());
-    return topology_.floating_velocities_start;
+    return topology_.floating_velocities_start_in_state;
   }
 
   /// Returns a string suffix (e.g. to be appended to the name()) to identify

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -166,7 +166,7 @@ class BodyNode : public MultibodyElement<T> {
   // Returns the index to the first generalized velocity for this node
   // within the vector v of generalized velocities for the full multibody
   // system.
-  int velocity_start() const {
+  int velocity_start_in_v() const {
     return topology_.mobilizer_velocities_start_in_v;
   }
   //@}
@@ -1025,7 +1025,8 @@ class BodyNode : public MultibodyElement<T> {
 
       // Include the effect of additional diagonal inertias. See @ref
       // additional_diagonal_inertias.
-      D_B.diagonal() += diagonal_inertias.segment(this->velocity_start(), nv);
+      D_B.diagonal() +=
+          diagonal_inertias.segment(this->velocity_start_in_v(), nv);
 
       // Compute the LLT factorization of D_B as llt_D_B.
       math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& llt_D_B =
@@ -1407,7 +1408,7 @@ class BodyNode : public MultibodyElement<T> {
   Eigen::VectorBlock<const VectorX<T>> get_mobilizer_velocities(
       const systems::Context<T>& context) const {
     return this->get_parent_tree().get_state_segment(context,
-        topology_.mobilizer_velocities_start,
+        topology_.mobilizer_velocities_start_in_state,
         topology_.num_mobilizer_velocities);
   }
 

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -565,7 +565,8 @@ class Joint : public MultibodyElement<T> {
   };
 
   /// Implementation of the NVI velocity_start(), see velocity_start() for
-  /// details.
+  /// details. Note that this must be the offset within just the velocity
+  /// vector, _not_ within the composite state vector.
   /// @note Implementations must meet the styleguide requirements for snake_case
   /// accessor methods.
   virtual int do_get_velocity_start() const = 0;

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -200,7 +200,7 @@ class MobilizerImpl : public Mobilizer<T> {
   Eigen::VectorBlock<const VectorX<T>, kNv> get_velocities(
       const systems::Context<T>& context) const {
     return this->get_parent_tree().template get_state_segment<kNv>(context,
-        this->get_velocities_start());
+        this->get_velocities_start_in_state());
   }
 
   // Helper to return a mutable fixed-size Eigen::VectorBlock referencing the
@@ -210,7 +210,7 @@ class MobilizerImpl : public Mobilizer<T> {
   Eigen::VectorBlock<VectorX<T>, kNv> GetMutableVelocities(
       systems::Context<T>* context) const {
     return this->get_parent_tree().template GetMutableStateSegment<kNv>(
-        context, this->get_velocities_start());
+        context, this->get_velocities_start_in_state());
   }
 
   // Helper variant to return a const fixed-size Eigen::VectorBlock referencing
@@ -220,23 +220,23 @@ class MobilizerImpl : public Mobilizer<T> {
   Eigen::VectorBlock<VectorX<T>, kNv> get_mutable_velocities(
       systems::State<T>* state) const {
     return this->get_parent_tree().template get_mutable_state_segment<kNv>(
-        state, this->get_velocities_start());
+        state, this->get_velocities_start_in_state());
   }
   //@}
 
  private:
-  // Returns the index in the global array of generalized coordinates in the
-  // MultibodyTree model to the first component of the generalized coordinates
-  // vector that corresponds to this mobilizer.
+  // Returns the index in the global array of generalized coordinates and
+  // velocities [q v] in the MultibodyTree model to the first component of the
+  // generalized coordinates vector that corresponds to this mobilizer.
   int get_positions_start() const {
     return this->get_topology().positions_start;
   }
 
-  // Returns the index in the global array of generalized velocities in the
-  // MultibodyTree model to the first component of the generalized velocities
-  // vector that corresponds to this mobilizer.
-  int get_velocities_start() const {
-    return this->get_topology().velocities_start;
+  // Returns the index in the global array of generalized coordinates and
+  // velocities [q v] in the MultibodyTree model to the first component of the
+  // generalized velocities vector that corresponds to this mobilizer.
+  int get_velocities_start_in_state() const {
+    return this->get_topology().velocities_start_in_state;
   }
 
   std::optional<Vector<double, kNq>> default_position_{};

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -464,10 +464,10 @@ class TreeTopologyTests : public ::testing::Test {
     EXPECT_EQ(topology.num_tree_velocities(TreeIndex(1)), 2);
     EXPECT_EQ(topology.num_tree_velocities(TreeIndex(2)), 0);
     EXPECT_EQ(topology.num_tree_velocities(TreeIndex(3)), 4);
-    EXPECT_EQ(topology.tree_velocities_start(TreeIndex(0)), 0);
-    EXPECT_EQ(topology.tree_velocities_start(TreeIndex(1)), 1);
-    EXPECT_EQ(topology.tree_velocities_start(TreeIndex(2)), 3);
-    EXPECT_EQ(topology.tree_velocities_start(TreeIndex(3)), 3);
+    EXPECT_EQ(topology.tree_velocities_start_in_v(TreeIndex(0)), 0);
+    EXPECT_EQ(topology.tree_velocities_start_in_v(TreeIndex(1)), 1);
+    EXPECT_EQ(topology.tree_velocities_start_in_v(TreeIndex(2)), 3);
+    EXPECT_EQ(topology.tree_velocities_start_in_v(TreeIndex(3)), 3);
     // The world body does not belong to a tree. Therefore the returned index is
     // invalid.
     EXPECT_FALSE(topology.body_to_tree_index(world_index()).is_valid());
@@ -557,8 +557,8 @@ TEST_F(TreeTopologyTests, SizesAndIndexing) {
     // Verify positions and velocity indexes.
     EXPECT_EQ(positions_index, node.mobilizer_positions_start);
     EXPECT_EQ(positions_index, mobilizer_topology.positions_start);
-    EXPECT_EQ(velocities_index, node.mobilizer_velocities_start);
-    EXPECT_EQ(velocities_index, mobilizer_topology.velocities_start);
+    EXPECT_EQ(velocities_index, node.mobilizer_velocities_start_in_state);
+    EXPECT_EQ(velocities_index, mobilizer_topology.velocities_start_in_state);
 
     // Mobilizers 5 and 8 are weld joints, with no velocities. All other
     // mobilizers introduce one position and one velocity.


### PR DESCRIPTION
The terms "velocity_start" and "velocities_start" are used in MbP and MbT ambiguously. Either "start within v" or "start within state qv".

This internal-only PR renames variables to disambiguate using "_in_state" or "_in_v" to clarify. No changes are made to the public API which uses "velocity_start()" to mean "in v" but "floating_velocities_start()" to mean "in state". 

Ideally I'd like to have position_start() mean "in q" and velocity_start() mean "in v" always, and do away entirely with the odd concept of velocity indexes "in state" which assumes that q and v are contiguous (something we hope to change). However for now I'll just settle for disambiguating the internals.

This is both a tech debt cleanup and yak shave for substituting the new graph's coordinate assignments for the old ones.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20435)
<!-- Reviewable:end -->
