### PR TITLE
Correct, test, and document `FlattenModelDirectives`

### DIFF
--- a/multibody/parsing/README_model_directives.md
+++ b/multibody/parsing/README_model_directives.md
@@ -81,6 +81,18 @@ Thus:
 - `top_level::my_model::my_frame`: The model instance is
   `top_level::my_model`, the frame is `my_frame`.
 
+Every use of `add_directives` with a `model_namespace` will append that
+namespace to the model instance name while parsing the referenced `file`.  All
+element names will be automatically prefixed with that model namespace, with
+the exception of `add_frame` names without a model instance.
+
+When `add_frame` has a model instance scope in its name, `add_frame` will
+use that as the prefix all element names like any other directive would; if
+no model instance is present, however, `add_frame` will check the associated
+`X_PF.base_frame` for a model instance prefix and, if it is present, use it
+as the prefix for the `name` element.
+
+
 ## Units
 
 We use SI units plus radians for all physical quantities.

--- a/multibody/parsing/process_model_directives.cc
+++ b/multibody/parsing/process_model_directives.cc
@@ -12,6 +12,7 @@
 #include "drake/multibody/parsing/detail_dmd_parser.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
 #include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/tree/scoped_name.h"
 
 namespace drake {
 namespace multibody {
@@ -36,6 +37,125 @@ std::unique_ptr<T> ConstructIfNullAndReassign(T** ptr, Args&&... args) {
   return out;
 }
 
+// This function must match the logic in
+// `detail_dmd_parser.cc`:`get_scoped_frame`, which applies the equivalent
+// construction operation in the building of the plant.
+std::string NamespaceJoin(const std::string& model_namespace,
+                          const std::string& name) {
+  // The world frame can never be namespaced, nor is any model permitted to
+  // itself be named or declare a frame named "world."
+  if (name == "world") return name;
+  return ScopedName::Join(model_namespace, name).to_string();
+}
+
+AddWeld ApplyDirectiveNamespace(const AddWeld& orig,
+                                const std::string& model_namespace) {
+  if (model_namespace.empty()) return orig;
+  AddWeld result = orig;
+  result.parent = NamespaceJoin(model_namespace, orig.parent);
+  result.child = NamespaceJoin(model_namespace, orig.child);
+  return result;
+}
+
+AddModel ApplyDirectiveNamespace(const AddModel& orig,
+                                 const std::string& model_namespace) {
+  if (model_namespace.empty()) return orig;
+  AddModel result = orig;
+  result.name = NamespaceJoin(model_namespace, orig.name);
+  return result;
+}
+
+AddModelInstance ApplyDirectiveNamespace(const AddModelInstance& orig,
+                                         const std::string& model_namespace) {
+  if (model_namespace.empty()) return orig;
+  AddModelInstance result = orig;
+  result.name = NamespaceJoin(model_namespace, orig.name);
+  return result;
+}
+
+AddFrame ApplyDirectiveNamespace(const AddFrame& orig,
+                                 const std::string& model_namespace) {
+  DRAKE_THROW_UNLESS(orig.IsValid());  // Ensures `base_frame` is present.
+  AddFrame result = orig;
+  // Handle the general case of prepending the model namespace.
+  if (!model_namespace.empty()) {
+    result.name = NamespaceJoin(model_namespace, orig.name);
+    result.X_PF.base_frame =
+        NamespaceJoin(model_namespace, orig.X_PF.base_frame.value());
+  }
+  // Handle the special case of an add_frame name with no namespace.
+  // Note that we don't need to update result.X_PF.base_frame -- it's already
+  // correct.
+  const ScopedName orig_scoped_name = ScopedName::Parse(orig.name);
+  if (orig_scoped_name.get_namespace().empty()) {
+    // If the original directive's name had no namespace, the flattened
+    // directive's name has to get both the model namespace and the
+    // base frame's namespace prepended.
+    const std::string base_frame_namespace(
+        ScopedName::Parse(orig.X_PF.base_frame.value()).get_namespace());
+    const std::string orig_element(orig_scoped_name.get_element());
+    result.name = NamespaceJoin(model_namespace,
+                      NamespaceJoin(base_frame_namespace,
+                                    orig_element));
+  }
+  return result;
+}
+
+AddCollisionFilterGroup ApplyDirectiveNamespace(
+    const AddCollisionFilterGroup& orig, const std::string& model_namespace) {
+  // Model_namespace is not supported here, as `AddCollisionFilterGroup::name`
+  // is documented to be model_namespace-free.
+  // TODO(ggould-tri) The rest of the structure could concievably be salvaged
+  // rather than failing outright, but I don't yet see a sound use case.
+  DRAKE_THROW_UNLESS(model_namespace.empty());
+  return orig;
+}
+
+void FlattenModelDirectivesInternal(const ModelDirectives& directives,
+                                    const PackageMap& package_map,
+                                    ModelDirectives* out,
+                                    const std::string& model_namespace) {
+  for (auto& directive : directives.directives) {
+    if (directive.add_directives) {
+      const AddDirectives& sub = *directive.add_directives;
+      const std::string sub_file =
+          ResolveModelDirectiveUri(sub.file, package_map);
+      FlattenModelDirectivesInternal(
+          LoadModelDirectives(sub_file), package_map, out,
+          (sub.model_namespace.has_value()
+               ? NamespaceJoin(model_namespace, *sub.model_namespace)
+               : model_namespace));
+    } else if (directive.add_weld) {
+      ModelDirective result;
+      result.add_weld =
+          ApplyDirectiveNamespace(*directive.add_weld, model_namespace);
+      out->directives.push_back(result);
+    } else if (directive.add_model) {
+      ModelDirective result;
+      result.add_model =
+          ApplyDirectiveNamespace(*directive.add_model, model_namespace);
+      out->directives.push_back(result);
+    } else if (directive.add_model_instance) {
+      ModelDirective result;
+      result.add_model_instance = ApplyDirectiveNamespace(
+          *directive.add_model_instance, model_namespace);
+      out->directives.push_back(result);
+    } else if (directive.add_frame) {
+      ModelDirective result;
+      result.add_frame =
+          ApplyDirectiveNamespace(*directive.add_frame, model_namespace);
+      out->directives.push_back(result);
+    } else if (directive.add_collision_filter_group) {
+      ModelDirective result;
+      result.add_collision_filter_group = ApplyDirectiveNamespace(
+          *directive.add_collision_filter_group, model_namespace);
+      out->directives.push_back(result);
+    } else {
+      DRAKE_UNREACHABLE();
+    }
+  }
+}
+
 }  // namespace
 
 std::string ResolveModelDirectiveUri(const std::string& uri,
@@ -44,24 +164,22 @@ std::string ResolveModelDirectiveUri(const std::string& uri,
   return ::drake::multibody::internal::ResolveUri(policy, uri, package_map, "");
 }
 
-void ProcessModelDirectives(
-    const ModelDirectives& directives,
-    MultibodyPlant<double>* plant,
-    std::vector<ModelInstanceInfo>* added_models,
-    Parser* parser) {
+void ProcessModelDirectives(const ModelDirectives& directives,
+                            MultibodyPlant<double>* plant,
+                            std::vector<ModelInstanceInfo>* added_models,
+                            Parser* parser) {
   auto tmp_parser = ConstructIfNullAndReassign<Parser>(&parser, plant);
   auto composite = CompositeParse::MakeCompositeParse(parser);
   std::vector<ModelInstanceInfo> models =
-      multibody::internal::ParseModelDirectives(
-          directives, "", composite->workspace());
+      multibody::internal::ParseModelDirectives(directives, "",
+                                                composite->workspace());
   if (added_models) {
     added_models->insert(added_models->end(), models.begin(), models.end());
   }
 }
 
 std::vector<ModelInstanceInfo> ProcessModelDirectives(
-    const ModelDirectives& directives,
-    Parser* parser) {
+    const ModelDirectives& directives, Parser* parser) {
   DRAKE_THROW_UNLESS(parser != nullptr);
   std::vector<ModelInstanceInfo> added_models;
   ProcessModelDirectives(directives, &parser->plant(), &added_models, parser);
@@ -79,20 +197,10 @@ ModelDirectives LoadModelDirectivesFromString(
       {DataSource::kContents, &model_directives});
 }
 
-void FlattenModelDirectives(
-    const ModelDirectives& directives,
-    const PackageMap& package_map,
-    ModelDirectives* out) {
-  // NOTE: Does not handle scoping!
-  for (auto& directive : directives.directives) {
-    if (directive.add_directives) {
-      auto& sub = *directive.add_directives;
-      const auto sub_file = ResolveModelDirectiveUri(sub.file, package_map);
-      FlattenModelDirectives(LoadModelDirectives(sub_file), package_map, out);
-    } else {
-      out->directives.push_back(directive);
-    }
-  }
+void FlattenModelDirectives(const ModelDirectives& directives,
+                            const PackageMap& package_map,
+                            ModelDirectives* out) {
+  FlattenModelDirectivesInternal(directives, package_map, out, "");
 }
 
 }  // namespace parsing

--- a/multibody/parsing/process_model_directives.h
+++ b/multibody/parsing/process_model_directives.h
@@ -27,7 +27,19 @@ std::string ResolveModelDirectiveUri(
     const std::string& uri,
     const drake::multibody::PackageMap& package_map);
 
-/// Flatten model directives.
+/// Flatten model directives into a single object.
+///
+/// This function removes all AddDirectives directives from the given
+/// `directives`, locating the file via the given `package_map`, parsing it,
+/// and updating the names of its items to add any namespace prefix
+/// requested by the `model_namespace` of the directive.  The resulting
+/// directives are appended to `out`.
+///
+/// The results of FlattenModelDirectives are semantically identical to
+/// `directives`.  FlattenModelDirectives is therefore also idempotent.
+///
+/// This flattening is intended to assist with creating reproducible
+/// simulation scenarios and with hashing; it can also be useful in debugging.
 void FlattenModelDirectives(const ModelDirectives& directives,
                             const drake::multibody::PackageMap& package_map,
                             ModelDirectives* out);

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -398,6 +398,86 @@ GTEST_TEST(ProcessModelDirectivesTest, DeepNestedChildFrameWelds) {
         R"(.*Failure at .* in AddWeld\(\): condition 'found' failed.*)");
 }
 
+// Test that flattening is idempotent and semantically a no-op.
+GTEST_TEST(ProcessModelDirectivesTest, Flatten) {
+  std::vector<ModelInstanceInfo> deep_models;
+  {
+    const ModelDirectives directives = LoadModelDirectives(FindResourceOrThrow(
+        std::string(kTestDir) + "/add_scoped_top.dmd.yaml"));
+    MultibodyPlant<double> plant(0.0);
+    std::unique_ptr<Parser> parser = make_parser(&plant);
+    deep_models = ProcessModelDirectives(directives, make_parser(&plant).get());
+  }
+
+  std::vector<ModelInstanceInfo> flat_models;
+  {
+    const ModelDirectives directives = LoadModelDirectives(FindResourceOrThrow(
+        std::string(kTestDir) + "/add_scoped_top.dmd.yaml"));
+    MultibodyPlant<double> plant(0.0);
+    std::unique_ptr<Parser> parser = make_parser(&plant);
+    ModelDirectives flat_directives;
+    FlattenModelDirectives(directives, parser->package_map(), &flat_directives);
+    flat_models = ProcessModelDirectives(flat_directives, parser.get());
+  }
+
+  std::vector<ModelInstanceInfo> reflattened_models;
+  {
+    const ModelDirectives directives = LoadModelDirectives(FindResourceOrThrow(
+        std::string(kTestDir) + "/add_scoped_top.dmd.yaml"));
+    MultibodyPlant<double> plant(0.0);
+    std::unique_ptr<Parser> parser = make_parser(&plant);
+    ModelDirectives flat_directives;
+    ModelDirectives reflattened_directives;  // To test idempotency.
+    FlattenModelDirectives(directives, parser->package_map(), &flat_directives);
+    FlattenModelDirectives(flat_directives, parser->package_map(),
+                           &reflattened_directives);
+    reflattened_models =
+        ProcessModelDirectives(reflattened_directives, parser.get());
+  }
+
+  // If there were inconsistencies in the scoped names between directives,
+  // e.g. frame names referring to nonexistent model scopes, then the
+  // `ProcessModelDirectives` call above would have failed.  So we only need
+  // to ensure that the models are present with identical names and we can be
+  // reasonably sure the other named elements must have been correct.
+
+  // Models from flattened directives have the same names as the originals.
+  std::set<std::string> deep_names;
+  for (const auto& info : deep_models) {
+    deep_names.insert(info.model_name);
+  }
+  std::set<std::string> flat_names;
+  for (const auto& info : flat_models) {
+    flat_names.insert(info.model_name);
+  }
+  EXPECT_EQ(deep_names, flat_names);
+
+  // Repeated flattening makes no difference (idempotency).
+  std::set<std::string> reflattened_names;
+  for (const auto& info : reflattened_models) {
+    reflattened_names.insert(info.model_name);
+  }
+  EXPECT_EQ(flat_names, reflattened_names);
+}
+
+GTEST_TEST(ProcessModelDirectivesTest, FlattenWithWorld) {
+  // Test that frames named "world" are unaffected by the model namespace.
+  const std::string kDirectives = R"(
+directives:
+  - add_directives:
+      file: package://process_model_directives_test/add_frame_without_model_namespace.dmd.yaml
+      model_namespace: nested
+)";
+  const ModelDirectives directives = LoadModelDirectivesFromString(kDirectives);
+  MultibodyPlant<double> plant(0.0);
+  std::unique_ptr<Parser> parser = make_parser(&plant);
+  ModelDirectives flat_directives;
+  FlattenModelDirectives(directives, parser->package_map(), &flat_directives);
+  EXPECT_EQ(
+      flat_directives.directives[1].add_frame.value().X_PF.base_frame.value(),
+      "world" /* Not "nested::world" */);
+}
+
 }  // namespace
 }  // namespace parsing
 }  // namespace multibody

--- a/multibody/parsing/test/process_model_directives_test/add_scoped_top.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/add_scoped_top.dmd.yaml
@@ -4,8 +4,6 @@
 
 directives:
 
-# N.B. The namespacing features are only available for RBT.
-
 # No namespace.
 - add_directives:
     file: package://process_model_directives_test/add_scoped_sub.dmd.yaml
@@ -14,9 +12,6 @@ directives:
     X_PF:
       base_frame: simple_model::sub_added_frame
       translation: [5, 10, 15]
-# N.B. If this were added after the namespaced instances,
-# `simple_model_test_frame` would cause a failure because it appears in multiple
-# model instances.
 - add_frame:
     name: simple_model_test_frame
     X_PF:


### PR DESCRIPTION
FlattenModelDirectives did not handle scoped names, which made it difficult to use in scenarios with multiple instances of the same model.

It was also undocumented and untested.

This change adds correct namespace handling; it also adds documentation and a minimal test (minimal because any naming-related errors are caught during the assembly of the MultibodyTree, and because the scoped test fixtures were designed to exercise naming).

 * Fixes #20425.
 * Removes misleading comments (including a mention of RigidBodyTree!).
 * Documents FlattenModelDirectives.
 * Documents the special-case naming semantics in add_frame directives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20438)
<!-- Reviewable:end -->
