### PR TITLE
Upgrade meshcat to latest commit

### DIFF
--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -109,11 +109,31 @@
     requestAnimationFrame( animate );
     // Set background to match the legacy ``drake_visualizer`` application of
     // days past.
-    viewer.set_property(['Background'], "top_color", [.95, .95, 1.0])
-    viewer.set_property(['Background'], "bottom_color", [.32, .32, .35])
+    viewer.set_property(['Background', '<object>'], "top_color",
+                        [.95, .95, 1.0])
+    viewer.set_property(['Background', '<object>'], "bottom_color",
+                        [.32, .32, .35])
     // Set the initial view looking up the y-axis.
     viewer.set_property(['Cameras', 'default', 'rotated', '<object>'],
                         "position", [0.0, 1.0, 3.0])
+
+    // With meshcat's upgrade of three.js, the default lighting conditions are
+    // no longer appropriate. Meshcat has boosted them slightly to account for
+    // a hidden change in three.js's lighting math, but it's not enough. The
+    // ambient and directional lights don't decay with distance, but point and
+    // spotlight do. The default lighting is now dominated by the non-decaying
+    // light sources. So, we're going to significantly bump the decaying sources
+    // to give them illuminating power and increase image contrast. These values
+    // don't live in upstream meshcat because in some of meshcat's test/*.html
+    // files, these defaults look horrible..
+    viewer.set_property(["Lights", "SpotLight", "<object>"], "intensity", 30);
+    viewer.set_property(["Lights", "PointLightNegativeX", "<object>"],
+                        "intensity", 25);
+    viewer.set_property(["Lights", "PointLightPositiveX", "<object>"],
+                        "intensity", 25);
+    viewer.set_property(["Lights", "AmbientLight", "<object>"], "intensity",
+                        0.3);
+    viewer.set_property(["Lights", "FillLight", "<object>"], "intensity", 0.5);
 
     <!-- CONNECTION BLOCK BEGIN -->
     // The lifespan of the server may be much shorter than this visualizer

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -10,8 +10,8 @@ def meshcat_repository(
         Updating this commit requires local testing; see
         drake/tools/workspace/meshcat/README.md for details.
         """,
-        commit = "44eac463725f048c47debfe34d3f935d01aa6bac",
-        sha256 = "7ac5e9fdcc407abb4770bad1cee849de939f1dc856ef38d601a1982abec68ac3",  # noqa
+        commit = "fa29aecebd5f1712844c3b98967a7d21707df5a0",
+        sha256 = "bdd505e90ab4e46958714a909f0a45d42d905eee0fa87637b97092035a4df7a3",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Note: This qualitatively changes the output renderings. Meshcat's rendered result has moved from linear-srgb to srgb. Things are generally less saturated now as part of three.js's move towards more realistic lighting.

We've amended meshcat.html to accommodate some of the fundamental changes:
  - Silence a console warning.
  - Beef up the lighting so that it's more aesthetically pleasing.

TODO: After the meshcat PR has merged, update repository.bzl to refer to
      the correct upstream source.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20442)
<!-- Reviewable:end -->
