### PR TITLE
[vtk] Dispatch vtkPNGReader errors correctly

### DIFF
--- a/tools/workspace/vtk_internal/patches/io_image_png_messages.patch
+++ b/tools/workspace/vtk_internal/patches/io_image_png_messages.patch
@@ -1,0 +1,78 @@
+[vtk] Fix PNG reader error reporting
+
+Dumping errors to the global output window when unable to parse a PNG
+file header is completely unacceptable. We should send all errors to a
+relevant vtkObject so that they are dispatched appropriately.
+
+We should upstream this patch.
+
+--- IO/Image/vtkPNGReader.cxx
++++ IO/Image/vtkPNGReader.cxx
+@@ -91,6 +91,7 @@
+ class vtkPNGReader::vtkInternals
+ {
+ public:
++  vtkPNGReader* parent = nullptr;
+   std::vector<std::pair<std::string, std::string>> TextKeyValue;
+   typedef std::vector<std::pair<std::string, std::string>>::iterator TextKeyValueIterator;
+   void ReadTextChunks(png_structp png_ptr, png_infop info_ptr)
+@@ -129,7 +130,7 @@
+     bool is_png = !png_sig_cmp(header, 0, 8);
+     if (!is_png)
+     {
+-      vtkErrorWithObjectMacro(nullptr, << "Unknown file type! Not a PNG file!");
++      vtkErrorWithObjectMacro(parent, << "Unknown file type! Not a PNG file!");
+     }
+     return is_png;
+   }
+@@ -140,7 +141,7 @@
+     unsigned char header[8];
+     if (fread(header, 1, 8, fp) != 8)
+     {
+-      vtkErrorWithObjectMacro(nullptr,
++      vtkErrorWithObjectMacro(parent,
+         "PNGReader error reading file."
+           << " Premature EOF while reading header.");
+       return false;
+@@ -154,7 +155,7 @@
+     unsigned char header[8];
+     if (length < 8)
+     {
+-      vtkErrorWithObjectMacro(nullptr, "MemoryBuffer is too short, could not read the header");
++      vtkErrorWithObjectMacro(parent, "MemoryBuffer is too short, could not read the header");
+       return false;
+     }
+     std::copy(buffer, buffer + 8, header);
+@@ -166,21 +167,21 @@
+     pngPtr = png_create_read_struct(PNG_LIBPNG_VER_STRING, (png_voidp) nullptr, nullptr, nullptr);
+     if (!pngPtr)
+     {
+-      vtkErrorWithObjectMacro(nullptr, "Out of memory.");
++      vtkErrorWithObjectMacro(parent, "Out of memory.");
+       return false;
+     }
+     infoPtr = png_create_info_struct(pngPtr);
+     if (!infoPtr)
+     {
+       png_destroy_read_struct(&pngPtr, (png_infopp) nullptr, (png_infopp) nullptr);
+-      vtkErrorWithObjectMacro(nullptr, "Out of memory.");
++      vtkErrorWithObjectMacro(parent, "Out of memory.");
+       return false;
+     }
+     endInfo = png_create_info_struct(pngPtr);
+     if (!endInfo)
+     {
+       png_destroy_read_struct(&pngPtr, &infoPtr, (png_infopp) nullptr);
+-      vtkErrorWithObjectMacro(nullptr, "Unable to read PNG file!");
++      vtkErrorWithObjectMacro(parent, "Unable to read PNG file!");
+       return false;
+     }
+     return true;
+@@ -224,6 +225,7 @@
+ vtkPNGReader::vtkPNGReader()
+ {
+   this->Internals = new vtkInternals();
++  this->Internals->parent = this;
+   this->ReadSpacingFromFile = false;
+ }
+ 

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -149,6 +149,7 @@ vtk_internal_repository = repository_rule(
                 "@drake//tools/workspace/vtk_internal:patches/common_core_warnings.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/common_data_model_warnings.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/io_image_formats.patch",  # noqa
+                "@drake//tools/workspace/vtk_internal:patches/io_image_png_messages.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/io_legacy_data_reader_uninit.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/rendering_opengl2_nobacktrace.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/vtkdoubleconversion_hidden.patch",  # noqa


### PR DESCRIPTION
We don't yet have enough plumbing hooked up to add regression testing for this, but I hope that the patch is obviously correct on its own.  At least, it doesn't cause any _new_ test failures.

+@svenevs for feature review or delegation, please.

Towards #20447.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20445)
<!-- Reviewable:end -->
