### PR TITLE
[tools] Remove --edit-include feature for vendoring

### DIFF
--- a/tools/workspace/conex_internal/vendor.bzl
+++ b/tools/workspace/conex_internal/vendor.bzl
@@ -48,7 +48,6 @@ def conex_cc_library(
         "drake_vendor/conex/" + x
         for x in srcs or []
     ]
-    edit_include = None
     strip_include_prefix = "drake_vendor"
 
     # Compile the static library.
@@ -58,7 +57,6 @@ def conex_cc_library(
         srcs_vendored = srcs_vendored,
         hdrs = hdrs,
         hdrs_vendored = hdrs_vendored,
-        edit_include = edit_include,
         strip_include_prefix = strip_include_prefix,
         copts = copts,
         deps = deps,

--- a/tools/workspace/vendor_cxx.bzl
+++ b/tools/workspace/vendor_cxx.bzl
@@ -5,7 +5,6 @@ def cc_library_vendored(
         name,
         hdrs = None,
         hdrs_vendored = None,
-        edit_include = None,
         srcs = None,
         srcs_vendored = None,
         vendor_tool_args = None,
@@ -21,14 +20,6 @@ def cc_library_vendored(
     hdrs_vendored gives the list of header file paths to use for Drake's
     vendored build. Typically we will prefix "drake_vendor/" to the path.
 
-    The edit_include mapping provides #include patterns that should be
-    rewritten in all of the source files (both hdrs and srcs). The patterns
-    are implicitly anchored at the start of the #include statements.
-    For example, {"yaml-cpp/": "drake_vendor/yaml-cpp/"} would edit this line:
-      #include <yaml-cpp/node.h>
-    into this line instead:
-      #include <drake_vendor/yaml-cpp/node.h>
-
     The lists of srcs and srcs_vendored paths must be equal in length and
     correspond as elementwise pairs. The srcs gives the list of library
     source file paths as found in the third-party source layout; the
@@ -37,7 +28,6 @@ def cc_library_vendored(
     """
     hdrs = hdrs or []
     hdrs_vendored = hdrs_vendored or []
-    edit_include = edit_include or {}
     srcs = srcs or []
     srcs_vendored = srcs_vendored or []
     if len(hdrs) != len(hdrs_vendored):
@@ -51,9 +41,6 @@ def cc_library_vendored(
         cmd = " ".join([
             "$(execpath @drake//tools/workspace:vendor_cxx)",
         ] + (vendor_tool_args or []) + [
-            "'--edit-include={}:{}'".format(k, v)
-            for k, v in edit_include.items()
-        ] + [
             "$(execpath {}):$(execpath {})".format(old, new)
             for old, new in (zip(hdrs, hdrs_vendored) +
                              zip(srcs, srcs_vendored))


### PR DESCRIPTION
We stopped using this feature a while ago (#19936). I left it available as unit-tested-dead-code in case we ever wanted to start using it again, but it seems like probably not, and it's getting in the way of forthcoming revisions to this file (for #17231).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20452)
<!-- Reviewable:end -->
