### PR TITLE
[multibody] Deprecate confusing Body::floating_velocities_start() method

### DIFF
--- a/bindings/pydrake/examples/gym/named_view_helpers.py
+++ b/bindings/pydrake/examples/gym/named_view_helpers.py
@@ -55,7 +55,7 @@ def MakeNamedViewVelocities(plant,
                     f"{joint.name()}_{joint.velocity_suffix(i)}"
     for ind in plant.GetFloatingBaseBodies():
         body = plant.get_body(ind)
-        start = body.floating_velocities_start() - plant.num_positions()
+        start = body.floating_velocities_start_in_v()
         for i in range(6):
             names[start
                   + i] = f"{body.name()}_{body.floating_velocity_suffix(i)}"

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1849,7 +1849,9 @@ class TestPlant(unittest.TestCase):
             plant.GetFreeBodyPose(context, link0).translation(),
             [0.4, 0.5, 0.6])
         self.assertNotEqual(link0.floating_positions_start(), -1)
-        self.assertNotEqual(link0.floating_velocities_start(), -1)
+        self.assertNotEqual(link0.floating_velocities_start_in_v(), -1)
+        with catch_drake_warnings(expected_count=1):
+            self.assertNotEqual(link0.floating_velocities_start(), -1)
         self.assertFalse(plant.IsVelocityEqualToQDot())
         v_expected = np.linspace(start=-1.0, stop=-nv, num=nv)
         qdot = plant.MapVelocityToQDot(context, v_expected)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -334,8 +334,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.has_quaternion_dofs.doc)
         .def("floating_positions_start", &Class::floating_positions_start,
             cls_doc.floating_positions_start.doc)
-        .def("floating_velocities_start", &Class::floating_velocities_start,
-            cls_doc.floating_velocities_start.doc)
+        .def("floating_velocities_start_in_v",
+            &Class::floating_velocities_start_in_v,
+            cls_doc.floating_velocities_start_in_v.doc)
         .def("floating_position_suffix", &Class::floating_position_suffix,
             cls_doc.floating_position_suffix.doc)
         .def("floating_velocity_suffix", &Class::floating_velocity_suffix,
@@ -366,6 +367,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("Unlock", &Class::Unlock, py::arg("context"), cls_doc.Unlock.doc)
         .def("is_locked", &Class::is_locked, py::arg("context"),
             cls_doc.is_locked.doc);
+
+// TODO(sherm1) Remove as of 2024-02-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("floating_velocities_start",
+            WrapDeprecated(cls_doc.floating_velocities_start.doc_deprecated,
+                &Class::floating_velocities_start),
+            cls_doc.floating_velocities_start.doc_deprecated);
+#pragma GCC diagnostic pop
   }
 
   {

--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -88,9 +88,8 @@ int do_main() {
   // lie first in the state vector.
   DRAKE_DEMAND(pelvis.floating_positions_start() == 0);
   // Similarly for velocities. The velocities for this floating pelvis are the
-  // first set of velocities after all model positions, since the state vector
-  // is stacked as x = [q; v].
-  DRAKE_DEMAND(pelvis.floating_velocities_start() == plant.num_positions());
+  // first set of velocities and should start at the beginning of v.
+  DRAKE_DEMAND(pelvis.floating_velocities_start_in_v() == 0);
 
   visualization::AddDefaultVisualization(&builder);
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2919,8 +2919,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// free (floating) or not with Body::is_floating().
   /// For many applications, a user might need to work with indexes in the
   /// multibody state vector. For such applications,
-  /// Body::floating_positions_start() and Body::floating_velocities_start()
-  /// offer the additional level of introspection needed.
+  /// Body::floating_positions_start() and
+  /// Body::floating_velocities_start_in_v() offer the additional level of
+  /// introspection needed.
   ///
   /// It is sometimes convenient for users to perform operations on Bodies
   /// ubiquitously through the APIs of the Joint class. For that reason we

--- a/multibody/plant/test/calc_distance_and_time_derivative_test.cc
+++ b/multibody/plant/test/calc_distance_and_time_derivative_test.cc
@@ -16,18 +16,30 @@ void CheckDistanceAndTimeDerivative(
     const Eigen::Vector3d& v_WS, const Eigen::Vector3d& omega_WS,
     double distance_expected, double distance_time_derivative_expected,
     systems::Context<double>* plant_context) {
-  Eigen::Matrix<double, 26, 1> q_v;
+  EXPECT_EQ(plant.num_positions(), 14);
+  EXPECT_EQ(plant.num_velocities(), 12);
+  Eigen::Matrix<double, 14, 1> q;
+  Eigen::Matrix<double, 12, 1> v;
   const auto& sphere_body = plant.get_frame(sphere_frame_index).body();
   const auto& box_body = plant.get_frame(box_frame_index).body();
-  q_v.segment<4>(box_body.floating_positions_start()) = quat_WB;
-  q_v.segment<3>(box_body.floating_positions_start() + 4) = p_WB;
-  q_v.segment<4>(sphere_body.floating_positions_start()) = quat_WS;
-  q_v.segment<3>(sphere_body.floating_positions_start() + 4) = p_WS;
-  q_v.segment<3>(box_body.floating_velocities_start()) = omega_WB;
-  q_v.segment<3>(box_body.floating_velocities_start() + 3) = v_WB;
-  q_v.segment<3>(sphere_body.floating_velocities_start()) = omega_WS;
-  q_v.segment<3>(sphere_body.floating_velocities_start() + 3) = v_WS;
-  plant.SetPositionsAndVelocities(plant_context, q_v);
+  q.segment<4>(box_body.floating_positions_start()) = quat_WB;
+  q.segment<3>(box_body.floating_positions_start() + 4) = p_WB;
+  q.segment<4>(sphere_body.floating_positions_start()) = quat_WS;
+  q.segment<3>(sphere_body.floating_positions_start() + 4) = p_WS;
+  v.segment<3>(box_body.floating_velocities_start_in_v()) = omega_WB;
+  v.segment<3>(box_body.floating_velocities_start_in_v() + 3) = v_WB;
+  v.segment<3>(sphere_body.floating_velocities_start_in_v()) = omega_WS;
+  v.segment<3>(sphere_body.floating_velocities_start_in_v() + 3) = v_WS;
+
+  // TODO(sherm1) Remove as of 2024-02-01
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(box_body.floating_velocities_start(),
+            14 + box_body.floating_velocities_start_in_v());
+#pragma GCC diagnostic push
+
+  plant.SetPositions(plant_context, q);
+  plant.SetVelocities(plant_context, v);
   const SignedDistanceWithTimeDerivative result =
       CalcDistanceAndTimeDerivative(plant, box_sphere_pair, *plant_context);
   EXPECT_NEAR(result.distance, distance_expected, 1e-12);

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -119,8 +119,7 @@ TEST_P(JointLockingTest, JointLockingIndicesTest) {
   RevoluteJoint<double>& body3_body4 =
       plant_->GetMutableJointByName<RevoluteJoint>("body3_body4");
 
-  const int body1_velocity_start =
-      body1.floating_velocities_start() - plant_->num_positions();
+  const int body1_velocity_start = body1.floating_velocities_start_in_v();
 
   // No joints/bodies are locked, all joint/body velocity indices should exist.
   {

--- a/multibody/plant/test/multibody_plant_introspection_test.cc
+++ b/multibody/plant/test/multibody_plant_introspection_test.cc
@@ -146,14 +146,15 @@ GTEST_TEST(MultibodyPlantIntrospection, FloatingBodies) {
        mug.floating_positions_start()});
   EXPECT_EQ(floating_positions_start, expected_floating_positions_start);
 
-  const int nq = plant.num_positions();
   const int atlas_nv = plant.num_velocities(atlas_model1);
-  const std::unordered_set<int> expected_floating_velocities_start(
-      {nq, nq + atlas_nv, nq + 2 * atlas_nv});
-  const std::unordered_set<int> floating_velocities_start(
-      {pelvis1.floating_velocities_start(), pelvis2.floating_velocities_start(),
-       mug.floating_velocities_start()});
-  EXPECT_EQ(floating_velocities_start, expected_floating_velocities_start);
+  const std::unordered_set<int> expected_floating_velocities_start_in_v(
+      {0, atlas_nv, 2 * atlas_nv});
+  const std::unordered_set<int> floating_velocities_start_in_v(
+      {pelvis1.floating_velocities_start_in_v(),
+       pelvis2.floating_velocities_start_in_v(),
+       mug.floating_velocities_start_in_v()});
+  EXPECT_EQ(floating_velocities_start_in_v,
+            expected_floating_velocities_start_in_v);
 }
 
 GTEST_TEST(MultibodyPlantIntrospection, NonUniqueBaseBody) {

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -259,12 +259,12 @@ class Body : public MultibodyElement<T> {
   }
 
   /// (Advanced) For floating bodies (see is_floating()) this method returns the
-  /// index of the first generalized position in the state vector for a
-  /// MultibodyPlant model.
-  /// Positions for this body are then contiguous starting at this index.
-  /// When a floating body is modeled with a quaternion mobilizer (see
+  /// index of this %Body's first generalized position in the vector q of
+  /// generalized position coordinates for a MultibodyPlant model.
+  /// Positions q for this %Body are then contiguous starting at this index.
+  /// When a floating %Body is modeled with quaternion coordinates (see
   /// has_quaternion_dofs()), the four consecutive entries in the state starting
-  /// at this index correspond to the quaternion that parametrizes this body's
+  /// at this index correspond to the quaternion that parametrizes this %Body's
   /// orientation.
   /// @throws std::exception if called pre-finalize
   /// @pre `this` is a floating body
@@ -275,17 +275,36 @@ class Body : public MultibodyElement<T> {
     return topology_.floating_positions_start;
   }
 
-  /// (Advanced) For floating bodies (see is_floating()) this method returns the
-  /// index of the first generalized velocity in the state vector for a
-  /// MultibodyPlant model.
+  /// (Advanced, Deprecated) For floating bodies (see is_floating()) this
+  /// method returns the index of this %Body's first generalized velocity in the
+  /// _full state vector_ for a MultibodyPlant model, under the dubious
+  /// assumption that the state consists of [q v] concatenated.
   /// Velocities for this body are then contiguous starting at this index.
   /// @throws std::exception if called pre-finalize
   /// @pre `this` is a floating body
-  /// @see is_floating(), MultibodyPlant::Finalize()
+  /// @see floating_velocities_start_in_v()
+  DRAKE_DEPRECATED("2024-02-01",
+                   "Convert to floating_velocities_start_in_v(). In a state "
+                   "with [q v] concatenated, offset by num_positions() to "
+                   "get to the start of v.")
   int floating_velocities_start() const {
     DRAKE_BODY_THROW_IF_NOT_FINALIZED();
     DRAKE_DEMAND(is_floating());
-    return topology_.floating_velocities_start_in_state;
+    return this->get_parent_tree().num_positions() +
+           topology_.floating_velocities_start_in_v;
+  }
+
+  /// (Advanced) For floating bodies (see is_floating()) this method returns the
+  /// index of this %Body's first generalized velocity in the vector v of
+  /// generalized velocities for a MultibodyPlant model.
+  /// Velocities v for this %Body are then contiguous starting at this index.
+  /// @throws std::exception if called pre-finalize
+  /// @pre `this` is a floating body
+  /// @see is_floating(), MultibodyPlant::Finalize()
+  int floating_velocities_start_in_v() const {
+    DRAKE_BODY_THROW_IF_NOT_FINALIZED();
+    DRAKE_DEMAND(is_floating());
+    return topology_.floating_velocities_start_in_v;
   }
 
   /// Returns a string suffix (e.g. to be appended to the name()) to identify

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -57,13 +57,14 @@ struct BodyTopology {
   // members of `other`.
   bool operator==(const BodyTopology& other) const {
     if (index != other.index) return false;
-    if (inboard_mobilizer.is_valid() !=
-        other.inboard_mobilizer.is_valid()) return false;
+    if (inboard_mobilizer.is_valid() != other.inboard_mobilizer.is_valid())
+      return false;
     if (inboard_mobilizer.is_valid() &&
-        inboard_mobilizer != other.inboard_mobilizer) return false;
+        inboard_mobilizer != other.inboard_mobilizer)
+      return false;
     if (parent_body.is_valid() != other.parent_body.is_valid()) return false;
-    if (parent_body.is_valid() &&
-        parent_body != other.parent_body) return false;
+    if (parent_body.is_valid() && parent_body != other.parent_body)
+      return false;
     if (child_bodies != other.child_bodies) return false;
     if (body_frame != other.body_frame) return false;
     if (level != other.level) return false;
@@ -72,8 +73,7 @@ struct BodyTopology {
     if (has_quaternion_dofs != other.has_quaternion_dofs) return false;
     if (floating_positions_start != other.floating_positions_start)
       return false;
-    if (floating_velocities_start_in_state !=
-        other.floating_velocities_start_in_state)
+    if (floating_velocities_start_in_v != other.floating_velocities_start_in_v)
       return false;
     return true;
   }
@@ -119,7 +119,7 @@ struct BodyTopology {
   bool has_quaternion_dofs{false};
 
   int floating_positions_start{-1};
-  int floating_velocities_start_in_state{-1};
+  int floating_velocities_start_in_v{-1};
 };
 
 // Data structure to store the topological information associated with a
@@ -923,8 +923,8 @@ class MultibodyTreeTopology {
         const MobilizerTopology& mobilizer =
             get_mobilizer(body.inboard_mobilizer);
         body.floating_positions_start = mobilizer.positions_start;
-        body.floating_velocities_start_in_state =
-            mobilizer.velocities_start_in_state;
+        body.floating_velocities_start_in_v =
+            mobilizer.velocities_start_in_v;
       }
     }
 

--- a/tutorials/multibody_plant_autodiff_mass.ipynb
+++ b/tutorials/multibody_plant_autodiff_mass.ipynb
@@ -119,10 +119,8 @@
    "source": [
     "def get_z_component(plant, body, v):\n",
     "    assert body.is_floating()\n",
-    "    # N.B. This method returns position w.r.t. *state* [q; v]. We only have v (or vdot).\n",
-    "    x_start = body.floating_velocities_start()\n",
     "    # Floating-base velocity dofs are organized as [angular velocity; translation velocity].\n",
-    "    v_start = x_start - plant.num_positions()\n",
+    "    v_start = body.floating_velocities_start_in_v()\n",
     "    nv_pose = 6\n",
     "    rxyz_txyz = v[v_start:v_start + nv_pose]\n",
     "    assert len(rxyz_txyz) == nv_pose\n",


### PR DESCRIPTION
In MbP Joint and in MbP/MbT internals, `velocity_start()` means "start index in v" while in MbP Body, `floating_velocities_start()` means "start index in state qv" so adds num_positions() to skip over q. This has been an endless source of confusion, as first noted by @amcastro-tri in #12757. The "within state" indexing also bakes in an assumption that we store q and v concatenated, something we may want to change for performance reasons later.

This PR deprecates  `Body::floating_velocities_start()` and replaces it with `floating_velocities_start_in_v()`, with deprecation instructions noting that it has to be offset by num_positions() to be equivalent. This brings the floating API (marked as "Advanced") in line with the Joint API.

Resolves #12757

cc @drewhamiltonasdf

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20454)
<!-- Reviewable:end -->
