### PR TITLE
Don't symlink patchelf (wheel)

### DIFF
--- a/tools/wheel/image/build-dependencies.sh
+++ b/tools/wheel/image/build-dependencies.sh
@@ -14,8 +14,6 @@ cmake -G Ninja \
 ninja
 
 if [[ "$(uname)" == "Linux" ]]; then
-    ln -s /opt/drake-dependencies/bin/patchelf /usr/local/bin/patchelf
-
     # Libraries we get from the distro that get bundled into the wheel need to
     # have their licenses bundled also.
     mkdir -p /opt/drake-dependencies/licenses/mumps


### PR DESCRIPTION
Remove symlink that was intended to make our build of patchelf visible without munging PATH. This was overlooked in 6db087ccee2b when we switched from building patchelf ourselves to obtaining it via PyPI. Our Python virtual environment is in /usr/local, which means PyPI tries to install /usr/local/bin/patchelf. This seems to have not caused breakage until recently (either the binary overwrote the symlink, or wrote through it to where the symlink pointed), but now it seems the installer is unhappy about the symlink existing where it's trying to install the patchelf binary.