### PR TITLE
[render] RenderEngineVtk throws on errors

### DIFF
--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -61,6 +61,7 @@ drake_cc_library(
         "//geometry/render/shaders:depth_shaders",
         "//geometry/render_vtk:render_engine_vtk_params",
         "//systems/sensors:color_palette",
+        "//systems/sensors:vtk_diagnostic_event_observer",
         "@eigen",
         "@vtk_internal//:vtkCommonCore",
         "@vtk_internal//:vtkCommonExecutionModel",
@@ -139,6 +140,26 @@ drake_cc_googletest(
         "@vtk_internal//:vtkIOImage",
         "@vtk_internal//:vtkRenderingCore",
         "@vtk_internal//:vtkRenderingOpenGL2",
+    ],
+)
+
+config_setting(
+    name = "osx",
+    constraint_values = ["@platforms//os:osx"],
+)
+
+drake_cc_googletest(
+    name = "internal_render_engine_vtk_no_display_test",
+    args = select({
+        # This test only makes sense on Linux, because only Linux uses the
+        # DISPLAY environment variable to connect to the graphics system.
+        ":osx": ["--gtest_filter=-*"],
+        "//conditions:default": [],
+    }),
+    tags = vtk_test_tags(),
+    deps = [
+        ":factory",
+        "//common/test_utilities",
     ],
 )
 

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -20,6 +20,7 @@
 #include <vtkSmartPointer.h>         // vtkCommonCore
 #include <vtkWindowToImageFilter.h>  // vtkRenderingCore
 
+#include "drake/common/diagnostic_policy.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_export.h"
 #include "drake/common/reset_on_copy.h"
@@ -295,6 +296,9 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
 
   // The engine's configuration parameters.
   const RenderEngineVtkParams parameters_;
+
+  // VTK error and/or warning messages end up here.
+  drake::internal::DiagnosticPolicy diagnostic_;
 
   std::array<std::unique_ptr<RenderingPipeline>, kNumPipelines> pipelines_;
 

--- a/geometry/render_vtk/test/internal_render_engine_vtk_no_display_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_no_display_test.cc
@@ -1,0 +1,50 @@
+#include <stdlib.h>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/render_vtk/factory.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace {
+
+// Invoke RenderEngineVtk::RenderColorImage.
+void TryToRenderSomething() {
+  const RenderEngineVtkParams params;
+  std::unique_ptr<render::RenderEngine> dut = MakeRenderEngineVtk(params);
+  const int kWidth = 640;
+  const int kHeight = 480;
+  const double kClipNear = 0.1;
+  const double kClipFar = 100.0;
+  const double kFovY = M_PI_4;
+  const ColorRenderCamera color_camera(
+      {"unused", {kWidth, kHeight, kFovY}, {kClipNear, kClipFar}, {}});
+  systems::sensors::ImageRgba8U image(kWidth, kHeight);
+  dut->RenderColorImage(color_camera, &image);
+}
+
+// When DISPLAY is not set, we get a useful message.
+GTEST_TEST(RenderEngineVtkNoDisplayTest, MissingDisplay) {
+  // Clear the environment.
+  EXPECT_EQ(::unsetenv("DISPLAY"), 0);
+
+  // Rendering should throw.
+  DRAKE_EXPECT_THROWS_MESSAGE(TryToRenderSomething(), ".*bad X server.*");
+}
+
+// When DISPLAY is incorrectly set, we get a useful message.
+GTEST_TEST(RenderEngineVtkNoDisplayTest, BadDisplay) {
+  // Clear the environment.
+  EXPECT_EQ(::setenv("DISPLAY", "Hello", 1), 0);
+
+  // Rendering should throw.
+  DRAKE_EXPECT_THROWS_MESSAGE(TryToRenderSomething(),
+                              ".*bad X server.*DISPLAY=Hello.*");
+}
+
+}  // namespace
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -369,7 +369,9 @@ drake_cc_library(
     srcs = ["vtk_diagnostic_event_observer.cc"],
     hdrs = ["vtk_diagnostic_event_observer.h"],
     internal = True,
-    visibility = ["//visibility:private"],
+    visibility = [
+        "//geometry/render_vtk:__pkg__",
+    ],
     deps = [
         "//common:diagnostic_policy",
         "//common:drake_export",


### PR DESCRIPTION
Previously, it would print to stderr and then abort, which was less-than-helpful for Jupyter sessions.

Closes #18445.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20461)
<!-- Reviewable:end -->
