### PR TITLE
[py tools] Add back some missing pydrake.common stubgen output

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -421,6 +421,7 @@ drake_py_binary(
 # out of date.
 PYI_FILES = [
     "pydrake/autodiffutils.pyi",
+    "pydrake/common/_module_py.pyi",
     "pydrake/common/eigen_geometry.pyi",
     "pydrake/common/schema.pyi",
     "pydrake/common/value.pyi",

--- a/bindings/pydrake/stubgen.py
+++ b/bindings/pydrake/stubgen.py
@@ -111,6 +111,14 @@ def _actual_main():
         source = getattr(sys.modules[name], "__file__", "")
         if source.endswith(".py"):
             native_modules.remove(name)
+    native_modules.extend([
+        # The "pydrake.common" module is unique in that seems to be a pure
+        # Python module (with an __init__.py) but then tacks on some native
+        # code imported from a private helper (pydrake.common._module_py).
+        # To get those native classes into the type stubs, we must manually
+        # add one private module to the stubgen manifest.
+        "pydrake.common._module_py",
+    ])
 
     # Run stubgen. It writes junk in the current directory, so we need to run
     # it from a safe place.


### PR DESCRIPTION
Amends #20403.

Without this fix, VSCode users are missing tab-completion for things like `pydrake.common.Parallelism`.

+@xuchenhan-tri for both reviews, please.

+(release notes: none) because 20403 has not yet been released.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20466)
<!-- Reviewable:end -->
