### PR TITLE
[hardware_sim] Add Schunk wsg desired state controller

### DIFF
--- a/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
@@ -53,6 +53,14 @@ void DefineManipulationSchunkWsg(py::module m) {
   }
 
   {
+    using Class = manipulation::schunk_wsg::SchunkWsgDesiredStateController;
+    constexpr auto& cls_doc = doc.SchunkWsgDesiredStateController;
+    py::class_<Class, Diagram<double>>(
+        m, "SchunkWsgDesiredStateController", cls_doc.doc)
+        .def(py::init(), cls_doc.ctor.doc);
+  }
+
+  {
     using Class = manipulation::schunk_wsg::SchunkWsgCommandReceiver;
     constexpr auto& cls_doc = doc.SchunkWsgCommandReceiver;
     py::class_<Class, LeafSystem<double>>(

--- a/bindings/pydrake/test/parse_models_test.py
+++ b/bindings/pydrake/test/parse_models_test.py
@@ -11,6 +11,7 @@ import unittest
 from pydrake.common import FindResourceOrThrow
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
+from pydrake.multibody.plant import DiscreteContactSolver
 from pydrake.systems.framework import DiagramBuilder
 
 
@@ -24,7 +25,8 @@ def parse_model_and_create_context(file):
     """Tests a model by loading parsing it with a SceneGraph connected,
     building the relevant diagram, and allocating its default context."""
     builder = DiagramBuilder()
-    plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+    plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.1)
+    plant.set_discrete_contact_solver(DiscreteContactSolver.kSap)
     Parser(plant).AddModels(file)
     plant.Finalize()
     diagram = builder.Build()

--- a/examples/hardware_sim/example_scenarios.yaml
+++ b/examples/hardware_sim/example_scenarios.yaml
@@ -3,6 +3,9 @@
 
 # This demo simulation shows an IIWA arm with an attached WSG gripper.
 Demo:
+  plant_config:
+    time_step: 1e-2
+    discrete_contact_solver: sap
   directives:
   - add_model:
       name: amazon_table
@@ -32,7 +35,7 @@ Demo:
       child: iiwa::base
   - add_model:
       name: wsg
-      file: package://drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+      file: package://drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_mimic_and_tip.sdf
       default_joint_positions:
         left_finger_sliding_joint: [-0.02]
         right_finger_sliding_joint: [0.02]

--- a/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_mimic_and_tip.sdf
+++ b/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_mimic_and_tip.sdf
@@ -309,6 +309,8 @@
     <joint name="left_finger_sliding_joint" type="prismatic">
       <parent>body</parent>
       <child>left_finger</child>
+      <!-- Use MultibodyPlant's PD controller interface. -->
+      <drake:controller_gains p="100000" d="1000" />
       <axis>
         <xyz>-1 0 0</xyz>
         <!-- Drake attaches an actuator to all and only joints with a nonzero
@@ -330,14 +332,15 @@
     <joint name="right_finger_sliding_joint" type="prismatic">
       <parent>body</parent>
       <child>right_finger</child>
+      <!-- Folow the left finger joint position. -->
+      <drake:mimic joint="left_finger_sliding_joint" multiplier="-1" offset="0" />
       <axis>
         <xyz>1 0 0</xyz>
-        <!-- Drake attaches an actuator to all and only joints with a nonzero
-             effort limit. -->
+        <!-- Set effort limit to 0 so no actuator is created for this joint. -->
         <limit>
           <lower>0</lower>
           <upper>0.055</upper>
-          <effort>80</effort>
+          <effort>0</effort>
           <stiffness>15000</stiffness>
         </limit>
         <dynamics>

--- a/manipulation/schunk_wsg/schunk_wsg_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_controller.cc
@@ -5,6 +5,7 @@
 #include "drake/manipulation/schunk_wsg/schunk_wsg_plain_controller.h"
 #include "drake/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h"
 #include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/gain.h"
 
 namespace drake {
 namespace manipulation {
@@ -39,6 +40,35 @@ SchunkWsgController::SchunkWsgController(double kp, double ki, double kd) {
                   wsg_controller->get_input_port_max_force());
 
   builder.ExportOutput(wsg_controller->get_output_port_control(), "force");
+  builder.BuildInto(this);
+}
+
+SchunkWsgDesiredStateController::SchunkWsgDesiredStateController() {
+  systems::DiagramBuilder<double> builder;
+
+  auto wsg_trajectory_generator =
+      builder.AddSystem<SchunkWsgTrajectoryGenerator>(
+          kSchunkWsgNumPositions + kSchunkWsgNumVelocities,
+          kSchunkWsgPositionIndex);
+  builder.ExportInput(wsg_trajectory_generator->get_state_input_port(),
+                      "state");
+
+  auto command_receiver = builder.AddSystem<SchunkWsgCommandReceiver>();
+  builder.ExportInput(command_receiver->GetInputPort("command_message"),
+                      "command_message");
+  builder.Connect(command_receiver->get_position_output_port(),
+                  wsg_trajectory_generator->get_desired_position_input_port());
+  builder.Connect(command_receiver->get_force_limit_output_port(),
+                  wsg_trajectory_generator->get_force_limit_input_port());
+
+  // SchunkWsgTrajectoryGenerator outputs the negation of the desired
+  // distance between the gripper fingers and the desired velocity of that
+  // quantity. Transform this into the state of the actuated finger.
+  auto half_gain = builder.AddSystem<systems::Gain>(0.5, 2);
+  builder.Connect(wsg_trajectory_generator->get_target_output_port(),
+                  half_gain->get_input_port());
+  builder.ExportOutput(half_gain->get_output_port(), "desired_state");
+
   builder.BuildInto(this);
 }
 

--- a/manipulation/schunk_wsg/schunk_wsg_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_controller.h
@@ -37,6 +37,39 @@ class SchunkWsgController : public systems::Diagram<double> {
                                double kd = 5.0);
 };
 
+/// This class implements a desired state controller for a Schunk WSG gripper.
+/// It has two input ports: lcmt_schunk_wsg_command message and the current
+/// state, and an output port which emits the desired state for the actuated
+/// finger. The desired state output port is designed to be connect to the
+/// desired state input port of MultibodyPlant for the model instance
+/// corresponding to the controlled Schunk gripper. This controller is intended
+/// for a Schunk gripper modeled with 1 actuated dof and 1 unactuated dof.
+/// The unactuated dof constrained to follow the actuated DoF with a coupler
+/// constraint, either added programmatically with
+/// MultibodyPlant::AddCouplerConstraint() or in URDF through the use of the
+/// <mimic> tag.
+/// @see drake::multibody::MultibodyPlant::get_desired_state_input_port().
+///
+/// Note: This controller is intended only for position control, and will
+///       thus ignore the `force` component of the command message.
+///
+/// @system
+/// name: SchunkWsgDesiredStateController
+/// input_ports:
+/// - state
+/// - command_message
+/// output_ports:
+/// - desired_state
+/// @endsystem
+///
+/// @ingroup manipulation_systems
+class SchunkWsgDesiredStateController : public systems::Diagram<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SchunkWsgDesiredStateController)
+
+  SchunkWsgDesiredStateController();
+};
+
 }  // namespace schunk_wsg
 }  // namespace manipulation
 }  // namespace drake

--- a/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
@@ -63,6 +63,71 @@ GTEST_TEST(SchunkWsgControllerTest, SchunkWsgControllerTest) {
   EXPECT_NEAR(commanded_force.second, 0, 1);
 }
 
+/// Runs the controller for a brief period with the specified initial conditions
+/// and returns the desired state on the gripper's actuated finger (left
+/// finger).
+std::pair<double, double> RunWsgDesiredStateControllerTestStep(
+    const lcmt_schunk_wsg_command& wsg_command, double wsg_position,
+    double sim_time) {
+  SchunkWsgDesiredStateController dut;
+  std::unique_ptr<systems::Context<double>> context =
+      dut.CreateDefaultContext();
+  std::unique_ptr<systems::SystemOutput<double>> output = dut.AllocateOutput();
+  dut.GetInputPort("command_message").FixValue(context.get(), wsg_command);
+  Eigen::VectorXd wsg_state_vec =
+      Eigen::VectorXd::Zero(kSchunkWsgNumPositions + kSchunkWsgNumVelocities);
+  wsg_state_vec(0) = -(wsg_position / 1e3) / 2.;
+  wsg_state_vec(1) = (wsg_position / 1e3) / 2.;
+  dut.GetInputPort("state").FixValue(context.get(), wsg_state_vec);
+  systems::Simulator<double> simulator(dut, std::move(context));
+  simulator.AdvanceTo(sim_time);
+  dut.CalcOutput(simulator.get_context(), output.get());
+  return {output->get_vector_data(0)->GetAtIndex(0),
+          output->get_vector_data(0)->GetAtIndex(1)};
+}
+
+GTEST_TEST(SchunkWsgControllerTest, SchunkWsgDesiredStateControllerTest) {
+  // Some constants from SchunkWsgTrajectoryGenerator.
+  const double kMaxVelocity = 0.42;  // m/s
+  const double kMaxAccel = 5.;       // m/s^2
+  const double kTimeToMaxVelocity = kMaxVelocity / kMaxAccel;
+
+  // Commanded position is the distance between the grippers in mm.
+  // q0 is the position of the left finger in m.
+  auto wsg_position_to_q0 = [](const double wsg_position) {
+    return -5e-4 * wsg_position;
+  };
+
+  // Start off with the gripper closed (zero) and a command to open to
+  // 100mm. Observe the desired state along the generated trajectory.
+  lcmt_schunk_wsg_command wsg_command{};
+  wsg_command.utime = 1;
+  wsg_command.target_position_mm = 300;
+  wsg_command.force = 0;
+
+  // At t = 0 the desired position should be 0.
+  std::pair<double, double> desired_state =
+      RunWsgDesiredStateControllerTestStep(wsg_command, 0, 0);
+  EXPECT_FLOAT_EQ(desired_state.first, 0);
+  EXPECT_FLOAT_EQ(desired_state.second, 0);
+
+  // At t = kTimeToMaxVelocity, the position should be between 0 and the target.
+  // The velocity of the gripper should be maximum.
+  desired_state =
+      RunWsgDesiredStateControllerTestStep(wsg_command, 0, kTimeToMaxVelocity);
+  EXPECT_LT(desired_state.first, 0);
+  EXPECT_GT(desired_state.first,
+            wsg_position_to_q0(wsg_command.target_position_mm));
+  // Convert gripper distance velocity to v0.
+  EXPECT_FLOAT_EQ(desired_state.second, -kMaxVelocity / 2);
+
+  // After enough time, the desired position should be the commanded position.
+  desired_state = RunWsgDesiredStateControllerTestStep(wsg_command, 0, 2);
+  EXPECT_FLOAT_EQ(desired_state.first,
+                  wsg_position_to_q0(wsg_command.target_position_mm));
+  EXPECT_FLOAT_EQ(desired_state.second, 0);
+}
+
 }  // namespace
 }  // namespace schunk_wsg
 }  // namespace manipulation

--- a/manipulation/schunk_wsg/test/schunk_wsg_driver_functions_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_driver_functions_test.cc
@@ -26,13 +26,11 @@ using systems::DiagramBuilder;
 using systems::Simulator;
 using systems::lcm::LcmBuses;
 
-/* A smoke test to apply simulated wsg driver with default driver config. */
-GTEST_TEST(SchunkWsgDriverFunctionsTest, ApplyDriverConfig) {
+void ApplyDriverConfigHelper(std::string model_file) {
   DiagramBuilder<double> builder;
-  MultibodyPlant<double>& plant =
-      AddMultibodyPlant(MultibodyPlantConfig{}, &builder);
-  const std::string filename = FindResourceOrThrow(
-      "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf");
+  MultibodyPlant<double>& plant = AddMultibodyPlant(
+      MultibodyPlantConfig{.discrete_contact_solver = "sap"}, &builder);
+  const std::string filename = FindResourceOrThrow(model_file);
   const ModelInstanceIndex schunk_wsg =
       Parser(&plant).AddModels(filename).at(0);
   plant.WeldFrames(plant.world_frame(),
@@ -52,8 +50,17 @@ GTEST_TEST(SchunkWsgDriverFunctionsTest, ApplyDriverConfig) {
   // Prove that simulation does not crash.
   Simulator<double> simulator(builder.Build());
   simulator.AdvanceTo(0.1);
-}
+}  // namespace
 
+/* A smoke test to apply simulated wsg driver with default driver config. */
+GTEST_TEST(SchunkWsgDriverFunctionsTest, ApplyDriverConfig) {
+  // Test both Schunk models.
+  ApplyDriverConfigHelper(
+      "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf");
+  ApplyDriverConfigHelper(
+      "drake/manipulation/models/wsg_50_description/sdf/"
+      "schunk_wsg_50_with_mimic_and_tip.sdf");
+}
 }  // namespace
 }  // namespace schunk_wsg
 }  // namespace manipulation

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -241,6 +241,7 @@ filegroup(
     testonly = True,
     srcs = [
         ":test/iiwa7_wsg.dmd.yaml",
+        ":test/iiwa7_wsg_with_mimic.dmd.yaml",
     ],
 )
 

--- a/manipulation/util/test/iiwa7_wsg_with_mimic.dmd.yaml
+++ b/manipulation/util/test/iiwa7_wsg_with_mimic.dmd.yaml
@@ -1,0 +1,28 @@
+directives:
+- add_model:
+    name: iiwa7
+    file: package://drake/manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf
+- add_model:
+    name: schunk_wsg
+    file: package://drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_mimic_and_tip.sdf
+# Weld iiwa7 to the world frame.
+- add_weld:
+    parent: world
+    child: iiwa7::iiwa_link_0
+# Weld schunk_wsg to iiwa7.
+- add_frame:
+    name: schunk_wsg_on_iiwa
+    X_PF:
+      base_frame: iiwa_link_7
+      translation: [0, 0, 0.114]
+      rotation: !Rpy { deg: [90, 0, 90] }
+- add_weld:
+    parent: schunk_wsg_on_iiwa
+    child: schunk_wsg::body
+# Add `grasp_frame` to schunk_wsg model.
+- add_frame:
+    name: schunk_wsg::grasp_frame
+    X_PF:
+      base_frame: schunk_wsg::body_frame
+      translation: [0.0, 0.11, 0.0]
+      rotation: !Rpy { deg: [0, 0, 0] }


### PR DESCRIPTION
Provides an alternative `SchunkWsgDesiredStateController` that makes use of SAP's implicit PD controllers and coupler constraint. The controller input port interface remains identical to `SchunkWsgController` taking in the current state and an lcm command message, but exports a `desired_state` output port to be connected to MultibodyPlant's `desired_state_input_port`, rather than a `force` output port to be connected to the `actuation_input_port`.

For backwards compatability, the controller still makes use of the `SchunkWsgTrajectoryGenerator` that takes a desired position from the Schunk's lcm command message and outputs a desired state. Thus the expected trajectories with using plant's implicit PD should be nearly identical to those using the current explicit PD controller.

The added models show how to model using the new features with custom SDF tags (or equivalent URDF tags). Note: this PR depends on parsing of `<mimic>` and `<controller_gains>` (in flight PRs #20503 and #20497). The first two commits in this PR can be ignored as they will be eventually removed with a rebase.

The hardware sim example is modified to observe the new controller. Switching controllers can be achieved by changing the specified schunk model between `schunk_wsg_50_with_tip.sdf` and `schunk_wsg_50_with_mimic_and_tip.sdf`.

CC: @dmcconachie-tri @rcory

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20506)
<!-- Reviewable:end -->
