### PR TITLE
Revert "Add bounding_region to IrisOptions"

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -455,8 +455,6 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.configuration_obstacles.doc)
         .def_readwrite("starting_ellipse", &IrisOptions::starting_ellipse,
             cls_doc.starting_ellipse.doc)
-        .def_readwrite("bounding_region", &IrisOptions::bounding_region,
-            cls_doc.bounding_region.doc)
         .def_readwrite("num_additional_constraint_infeasible_samples",
             &IrisOptions::num_additional_constraint_infeasible_samples,
             cls_doc.num_additional_constraint_infeasible_samples.doc)

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -557,8 +557,6 @@ class TestGeometryOptimization(unittest.TestCase):
         options.relative_termination_threshold = 0.01
         options.random_seed = 1314
         options.starting_ellipse = mut.Hyperellipsoid.MakeUnitBall(3)
-        options.bounding_region = mut.HPolyhedron.MakeBox(
-            lb=[-6, -6, -6], ub=[6, 6, 6])
         self.assertNotIn("object at 0x", repr(options))
         region = mut.Iris(
             obstacles=obstacles, sample=[2, 3.4, 5],

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -54,20 +54,13 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
       Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample));
   HPolyhedron P = domain;
 
-  if (options.bounding_region) {
-    DRAKE_DEMAND(options.bounding_region->ambient_dimension() == dim);
-    P = P.Intersection(*options.bounding_region);
-  }
-
-  const int num_initial_constraints = P.A().rows();
-
   // On each iteration, we will build the collision-free polytope represented as
   // {x | A * x <= b}.  Here we pre-allocate matrices of the maximum size.
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A(
-      P.A().rows() + N, dim);
-  VectorXd b(P.A().rows() + N);
-  A.topRows(P.A().rows()) = P.A();
-  b.head(P.A().rows()) = P.b();
+      domain.A().rows() + N, dim);
+  VectorXd b(domain.A().rows() + N);
+  A.topRows(domain.A().rows()) = domain.A();
+  b.head(domain.A().rows()) = domain.b();
   // Use pairs {scale, index}, so that I can back out the indices after a sort.
   std::vector<std::pair<double, int>> scaling(N);
   MatrixXd closest_points(dim, N);
@@ -87,7 +80,7 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
     }
     std::sort(scaling.begin(), scaling.end());
 
-    int num_constraints = num_initial_constraints;
+    int num_constraints = domain.A().rows();
     tangent_matrix = 2.0 * E.A().transpose() * E.A();
     for (int i = 0; i < N; ++i) {
       // Only add a constraint if this obstacle still has overlap with the set
@@ -471,12 +464,6 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
   HPolyhedron P = HPolyhedron::MakeBox(plant.GetPositionLowerLimits(),
                                        plant.GetPositionUpperLimits());
   DRAKE_DEMAND(P.A().rows() == 2 * nq);
-
-  if (options.bounding_region) {
-    DRAKE_DEMAND(options.bounding_region->ambient_dimension() == nq);
-    P = P.Intersection(*options.bounding_region);
-  }
-
   const double kEpsilonEllipsoid = 1e-2;
   Hyperellipsoid E = options.starting_ellipse.value_or(
       Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, seed));

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -86,14 +86,6 @@ struct IrisOptions {
   centered at the given sample will be used. */
   std::optional<Hyperellipsoid> starting_ellipse{};
 
-  /** Optionally allows the caller to restrict the space within which IRIS
-  regions are allowed to grow. By default, IRIS regions are bounded by the
-  `domain` argument in the case of `Iris` or the joint limits of the input
-  `plant` in the case of `IrisInConfigurationSpace`. If this option is
-  specified, IRIS regions will be confined to the intersection between the
-  domain and `bounding_region` */
-  std::optional<HPolyhedron> bounding_region{};
-
   /** By default, IRIS in configuration space certifies regions for collision
   avoidance constraints and joint limits. This option can be used to pass
   additional constraints that should be satisfied by the IRIS region. We accept

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -366,41 +366,6 @@ GTEST_TEST(IrisInConfigurationSpaceTest, StartingEllipse) {
               1e-6);
 }
 
-GTEST_TEST(IrisInConfigurationSpaceTest, BoundingRegion) {
-  const Vector2d sample{0.0, 0.0};
-  IrisOptions options;
-  options.iteration_limit = 1;
-  options.num_collision_infeasible_samples = 0;
-  ConvexSets obstacles;
-  obstacles.emplace_back(
-      VPolytope::MakeBox(Vector2d(0.2, 0.2), Vector2d(1, 1)));
-  options.configuration_obstacles = obstacles;
-  HPolyhedron region = IrisFromUrdf(boxes_in_2d_urdf, sample, options);
-
-  // Add a bounding region that halves the plant's joint limits.
-  options.bounding_region =
-      HPolyhedron::MakeBox(Vector2d(-1, -0.5), Vector2d(1, 0.5));
-  HPolyhedron region_w_bounding =
-      IrisFromUrdf(boxes_in_2d_urdf, sample, options);
-
-  // `region` should have only one additional half space beyond the initial
-  // polytope. `region_w_bounding` should have a further four half spaces since
-  // its initial polytope will have been intersected with
-  // `options.bounding_region`.
-  EXPECT_EQ(region.b().size(), 5);
-  EXPECT_EQ(region_w_bounding.b().size(), 9);
-
-  // The point (-1.5, -0.5) is within the plant's joint limits but outside the
-  // bounding region. It should be contained in region but not in
-  // region_w_bounding.
-  EXPECT_TRUE(region.PointInSet(Vector2d(-1.5, -0.5)));
-  EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(-1.5, -0.5)));
-
-  // A point closer to the origin should be in both regions.
-  EXPECT_TRUE(region.PointInSet(Vector2d(-0.5, -0.25)));
-  EXPECT_TRUE(region_w_bounding.PointInSet(Vector2d(-0.5, -0.25)));
-}
-
 // Three spheres.  Two on the outside are fixed.  One in the middle on a
 // prismatic joint.  The configuration space is a (convex) line segment q ∈
 // (−1,1).

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -15,7 +15,6 @@ namespace optimization {
 namespace {
 
 using Eigen::Matrix;
-using Eigen::RowVector2d;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
@@ -164,49 +163,6 @@ GTEST_TEST(IrisTest, StartingEllipse) {
   EXPECT_TRUE(region.PointInSet(Vector2d(0.0, -.99)));
   EXPECT_FALSE(region.PointInSet(Vector2d(.99, 0.0)));
   EXPECT_FALSE(region.PointInSet(Vector2d(-.99, 0.0)));
-}
-
-GTEST_TEST(IrisTest, BoundingRegion) {
-  ConvexSets obstacles;
-  obstacles.emplace_back(
-      VPolytope::MakeBox(Vector2d(0.1, 0.5), Vector2d(1, 1)));
-  obstacles.emplace_back(
-      VPolytope::MakeBox(Vector2d(-1, -1), Vector2d(-0.1, -0.5)));
-  obstacles.emplace_back(
-      HPolyhedron::MakeBox(Vector2d(.1, -1), Vector2d(1, -0.5)));
-  obstacles.emplace_back(
-      HPolyhedron::MakeBox(Vector2d(-1, 0.5), Vector2d(-0.1, 1)));
-  const HPolyhedron domain = HPolyhedron::MakeUnitBox(2);
-
-  const Vector2d sample{0, 0};  // center of the bounding box.
-  IrisOptions options;
-
-  const HPolyhedron region = Iris(obstacles, sample, domain, options);
-
-  // Use a bounding_region that omits the obstacles to the left of the x-axis.
-  options.bounding_region = HPolyhedron(RowVector2d(-1, 0), Vector1d(0.05));
-
-  const HPolyhedron region_w_bounding =
-      Iris(obstacles, sample, domain, options);
-
-  EXPECT_EQ(region.b().size(), 8);  // 4 from `domain` and 1 from each obstacle.
-  EXPECT_EQ(region_w_bounding.b().size(),
-            7);  // 4 from `domain`, 1 from `options.bounding_region` and 2
-                 // more from the right obstacles.
-
-  // `region_w_bounding` should not contain points of y ≤ -0.05 since they're
-  // outside its bounding region.
-  EXPECT_TRUE(region.PointInSet(Vector2d(-0.1, 0)));
-  EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(-0.1, 0)));
-
-  // Points inside the bounding region and outside obstacles should be members
-  // of both regions
-  EXPECT_TRUE(region.PointInSet(Vector2d(0.99, 0)));
-  EXPECT_TRUE(region_w_bounding.PointInSet(Vector2d(0.99, 0)));
-
-  // Points inside obstacles should be excluded from both regions.
-  EXPECT_FALSE(region.PointInSet(Vector2d(0.1, 0.5)));
-  EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(0.11, 0.51)));
 }
 
 GTEST_TEST(IrisTest, TerminationConditions) {


### PR DESCRIPTION
Dear @tomstewart-woven ,

 The on-call build cop, @BetsyMcPhail, believes that your PR #20417 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Production/job/linux-focal-clang-bazel-nightly-gurobi-release/420/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20507)
<!-- Reviewable:end -->
