### PR TITLE
[doc] Remove macOS Monterey arm64 support

### DIFF
--- a/doc/_pages/buildcop.md
+++ b/doc/_pages/buildcop.md
@@ -173,7 +173,7 @@ servers that need to be confirmed.  Open each of the following jobs and search
 for ``REMOTE_CACHE_KEY`` and confirm it has a value:
 
 - [https://drake-jenkins.csail.mit.edu/job/linux-focal-clang-bazel-continuous-release/lastBuild/consoleFull](https://drake-jenkins.csail.mit.edu/job/linux-focal-clang-bazel-continuous-release/lastBuild/consoleFull)
-- [https://drake-jenkins.csail.mit.edu/job/mac-arm-monterey-clang-bazel-continuous-release/lastBuild/consoleFull](https://drake-jenkins.csail.mit.edu/job/mac-arm-monterey-clang-bazel-continuous-release/lastBuild/consoleFull)
+- [https://drake-jenkins.csail.mit.edu/job/mac-arm-ventura-clang-bazel-continuous-release/lastBuild/consoleFull](https://drake-jenkins.csail.mit.edu/job/mac-arm-ventura-clang-bazel-continuous-release/lastBuild/consoleFull)
 
 Message indicating a problem:
 

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -17,7 +17,6 @@ officially supports:
 | Ubuntu 20.04 LTS (Focal Fossa)     | x86_64       | 3.8        | 6.4   | 3.16  | GCC 9 (default) or Clang 12  | OpenJDK 11                    |
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 6.4   | 3.22  | GCC 11 (default) or Clang 12 | OpenJDK 11                    |
 | macOS Monterey (12)                | x86_64       | 3.11       | 6.4   | 3.25  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
-| macOS Monterey (12)                | arm64        | 3.11       | 6.4   | 3.25  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
 | macOS Ventura (13)                 | arm64        | 3.11       | 6.4   | 3.26  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
 
 "Official support" means that we have Continuous Integration test coverage to

--- a/doc/_pages/getting_help.md
+++ b/doc/_pages/getting_help.md
@@ -39,7 +39,7 @@ If you wish to contribute a patch, please see how to [submit a pull request](/de
 When reporting an issue, please consider providing the following information
 (``helper command in monospace``):
 
-* Operating system (e.g., Ubuntu Focal 20.04 or macOS Monterey)
+* Operating system (e.g., Ubuntu Focal 20.04 or macOS Ventura)
 * Installation method (e.g., pip, apt, binary tar.gz, docker image, or
   rebuilding from source)
 * Language you are using (C++ or [Python](/python_bindings.html))

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -19,7 +19,6 @@ officially supports:
 | Ubuntu 20.04 LTS (Focal Fossa)     | x86_64       | 3.8 ⁽³⁾    | March 2024      |
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10 ⁽³⁾   | March 2026      |
 | macOS Monterey (12)                | x86_64       | 3.11       | October 2023    |
-| macOS Monterey (12)                | arm64        | 3.11       | October 2023    |
 | macOS Ventura (13)                 | arm64        | 3.11       | October 2024    |
 
 "Official support" means that we have Continuous Integration test coverage to

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -128,7 +128,7 @@ more of these commands:
 
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-bazel-experimental-packaging please``
 * ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-bazel-experimental-packaging please``
-* ``@drake-jenkins-bot mac-arm-monterey-unprovisioned-clang-bazel-experimental-packaging please``
+* ``@drake-jenkins-bot mac-arm-ventura-unprovisioned-clang-bazel-experimental-packaging please``
 * ``@drake-jenkins-bot mac-x86-monterey-unprovisioned-clang-bazel-experimental-packaging please``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
@@ -153,7 +153,7 @@ To schedule an "experimental" build of a [wheel package](/pip.html),
 comment on an open pull request using one or more of these commands:
 
 * ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-wheel-experimental-release``
-* ``@drake-jenkins-bot mac-arm-monterey-unprovisioned-clang-wheel-experimental-release``
+* ``@drake-jenkins-bot mac-arm-ventura-unprovisioned-clang-wheel-experimental-release``
 * ``@drake-jenkins-bot mac-x86-monterey-unprovisioned-clang-wheel-experimental-release``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -110,7 +110,7 @@ the main body of the document:
       1. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-packaging/>
       2. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-jammy-unprovisioned-gcc-bazel-nightly-packaging/>
       3. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-x86-monterey-unprovisioned-clang-bazel-nightly-packaging/>
-      4. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-arm-monterey-unprovisioned-clang-bazel-nightly-packaging/>
+      4. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-arm-ventura-unprovisioned-clang-bazel-nightly-packaging/>
    4. Check the logs for those packaging builds and find the URLs they posted
       to (open the latest build, go to "View as plain text", and search for
       ``drake/nightly/drake-20``), and find the date.  It will be ``YYYYMMDD``
@@ -127,7 +127,7 @@ the main body of the document:
       new browser tab):
       - [Linux Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-focal-unprovisioned-gcc-wheel-staging-release/)
       - [macOS x86 Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-x86-monterey-unprovisioned-clang-wheel-staging-release/)
-      - [macOS arm Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-monterey-unprovisioned-clang-wheel-staging-release/)
+      - [macOS arm Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-ventura-unprovisioned-clang-wheel-staging-release/)
       - [Focal Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-focal-unprovisioned-gcc-bazel-staging-packaging/)
       - [Jammy Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-bazel-staging-packaging/)
    2. In the upper right, click "log in" (unless you're already logged in). This
@@ -190,8 +190,8 @@ the main body of the document:
    1. Check that the link to drake.mit.edu docs from the GitHub release draft
       page actually works.
    2. Click "Publish release"
-   3. Notify `@BetsyMcPhail` by creating a GitHub issue asking her to manually 
-      tag docker images and upload the releases to S3. Be sure to provide her 
+   3. Notify `@BetsyMcPhail` by creating a GitHub issue asking her to manually
+      tag docker images and upload the releases to S3. Be sure to provide her
       with the release tag in the same ping.
    4. Create a GitHub issue on the [drake-ros](https://github.com/RobotLocomotion/drake-ros/issues)
       repository, requesting an update of the `DRAKE_SUGGESTED_VERSION`


### PR DESCRIPTION
Drake v1.22.0 was the last release with macOS Monterey arm64 support.

Relates: #20339.  CC @BetsyMcPhail

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20511)
<!-- Reviewable:end -->
