### PR TITLE
Fix build failure for `iris_test`

### DIFF
--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -205,7 +205,7 @@ GTEST_TEST(IrisTest, BoundingRegion) {
   EXPECT_TRUE(region_w_bounding.PointInSet(Vector2d(0.99, 0)));
 
   // Points inside obstacles should be excluded from both regions.
-  EXPECT_FALSE(region.PointInSet(Vector2d(0.1, 0.5)));
+  EXPECT_FALSE(region.PointInSet(Vector2d(0.11, 0.51)));
   EXPECT_FALSE(region_w_bounding.PointInSet(Vector2d(0.11, 0.51)));
 }
 


### PR DESCRIPTION
Fix iris_test failure
    
Use a point more deeply embedded in the obstacle when checking that obstacles are removed from iris regions

Closes #20507.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20512)
<!-- Reviewable:end -->
