### PR TITLE
[wheel] macOS arm64 staging builds use Ventura now

### DIFF
--- a/tools/release_engineering/download_release_candidate.py
+++ b/tools/release_engineering/download_release_candidate.py
@@ -137,7 +137,7 @@ def _download_binaries(*, timestamp, staging, version):
             f"drake-{version[1:]}-cp311-cp311-manylinux_2_31_x86_64.whl",
             f"drake-{version[1:]}-cp312-cp312-manylinux_2_31_x86_64.whl",
             f"drake-{version[1:]}-cp311-cp311-macosx_12_0_x86_64.whl",
-            f"drake-{version[1:]}-cp311-cp311-macosx_12_0_arm64.whl",
+            f"drake-{version[1:]}-cp311-cp311-macosx_13_0_arm64.whl",
             # Deb filenames.
             f"drake-dev_{version[1:]}-1_amd64-focal.deb",
             f"drake-dev_{version[1:]}-1_amd64-jammy.deb",


### PR DESCRIPTION
Relates: #20339

This is an implication of switching the wheel build as far as I know.  We have not had [nightly CI finish yet](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-arm-ventura-unprovisioned-clang-wheel-nightly-release/2/console) which will be the first CI job capable of producing an artifact similar to the staging urls being considered.

CC @BetsyMcPhail @jwnimmer-tri

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20520)
<!-- Reviewable:end -->
