### PR TITLE
Adjust tolerance for KinTrajOpt w/ new ipopt on mac arm

### DIFF
--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -184,6 +184,7 @@ drake_cc_googletest(
         ":kinematic_trajectory_optimization",
         "//common/test_utilities:eigen_matrix_compare",
         "//solvers:constraint",
+        "//solvers:ipopt_solver",
         "//solvers:osqp_solver",
         "//solvers:solve",
     ],

--- a/planning/trajectory_optimization/test/kinematic_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/kinematic_trajectory_optimization_test.cc
@@ -9,6 +9,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/text_logging.h"
 #include "drake/math/matrix_util.h"
+#include "drake/solvers/ipopt_solver.h"
 #include "drake/solvers/osqp_solver.h"
 #include "drake/solvers/solve.h"
 
@@ -310,6 +311,11 @@ TEST_F(KinematicTrajectoryOptimizationTest, AddJerkBounds) {
         trajopt_.control_points().col(i));
   }
   trajopt_.AddDurationConstraint(1, 1);
+
+  // Help IPOPT.
+  trajopt_.AddPositionBounds(Vector3d::Constant(-20), Vector3d::Constant(20));
+  trajopt_.get_mutable_prog().SetSolverOption(solvers::IpoptSolver::id(), "tol",
+                                              1e-6);
 
   MathematicalProgramResult result = Solve(trajopt_.prog());
   EXPECT_TRUE(result.is_success());


### PR DESCRIPTION
Resolves a CI failure at
https://drake-jenkins.csail.mit.edu/job/mac-arm-monterey-unprovisioned-clang-bazel-nightly-release/409/consoleFull

Homebrew upgraded from ipopt 3.14.14 (which passed) to ipopt 3.14.13 (which failed).  This is a new failure due to the homebrew upgrade.

The solver was actually finding a solution which passed the test, but reporting failure because it could not achieve the desired tolerance. Additionally, IPOPT was complaining about unbounded variables. This PR adds bounds to the unbounded variables and adjusts the solver convergence tolerance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20526)
<!-- Reviewable:end -->
