### PR TITLE
[multibody] Make weld constraint use active status.

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2428,10 +2428,14 @@ class TestPlant(unittest.TestCase):
         # Add ball and distance constraints.
         p_AP = [0.0, 0.0, 0.0]
         p_BQ = [0.0, 0.0, 0.0]
+        X_AP = RigidTransform_[float](p_AP)
+        X_BQ = RigidTransform_[float](p_BQ)
         distance_id = plant.AddDistanceConstraint(
             body_A=body_A, p_AP=p_AP, body_B=body_B, p_BQ=p_BQ, distance=0.01)
         ball_id = plant.AddBallConstraint(
             body_A=body_A, p_AP=p_AP, body_B=body_B, p_BQ=p_BQ)
+        weld_id = plant.AddWeldConstraint(
+            body_A=body_A, X_AP=X_AP, body_B=body_B, X_BQ=X_BQ)
 
         Parser(plant).AddModelsFromUrl(
             "package://drake/manipulation/models/"
@@ -2457,6 +2461,8 @@ class TestPlant(unittest.TestCase):
             plant.GetConstraintActiveStatus(context=context, id=distance_id))
         self.assertTrue(
             plant.GetConstraintActiveStatus(context=context, id=ball_id))
+        self.assertTrue(
+            plant.GetConstraintActiveStatus(context=context, id=weld_id))
 
         # Set all constraints to inactive.
         plant.SetConstraintActiveStatus(
@@ -2465,6 +2471,8 @@ class TestPlant(unittest.TestCase):
             context=context, id=distance_id, status=False)
         plant.SetConstraintActiveStatus(
             context=context, id=ball_id, status=False)
+        plant.SetConstraintActiveStatus(
+            context=context, id=weld_id, status=False)
 
         # Verify all constraints are inactive in the context.
         self.assertFalse(
@@ -2473,6 +2481,8 @@ class TestPlant(unittest.TestCase):
             plant.GetConstraintActiveStatus(context=context, id=distance_id))
         self.assertFalse(
             plant.GetConstraintActiveStatus(context=context, id=ball_id))
+        self.assertFalse(
+            plant.GetConstraintActiveStatus(context=context, id=weld_id))
 
         # Set all constraints to back to active.
         plant.SetConstraintActiveStatus(
@@ -2481,6 +2491,8 @@ class TestPlant(unittest.TestCase):
             context=context, id=distance_id, status=True)
         plant.SetConstraintActiveStatus(
             context=context, id=ball_id, status=True)
+        plant.SetConstraintActiveStatus(
+            context=context, id=weld_id, status=True)
 
         # Verify all constraints are active in the context.
         self.assertTrue(
@@ -2489,6 +2501,8 @@ class TestPlant(unittest.TestCase):
             plant.GetConstraintActiveStatus(context=context, id=distance_id))
         self.assertTrue(
             plant.GetConstraintActiveStatus(context=context, id=ball_id))
+        self.assertTrue(
+            plant.GetConstraintActiveStatus(context=context, id=weld_id))
 
     @numpy_compare.check_all_types
     def test_weld_constraint_api(self, T):

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -598,6 +598,17 @@ MultibodyConstraintId MultibodyPlant<T>::AddWeldConstraint(
         "MultibodyPlant models.");
   }
 
+  // TAMSI does not support weld constraints. For all other solvers, we let
+  // the discrete update manager throw an exception at finalize time.
+  if (contact_solver_enum_ == DiscreteContactSolver::kTamsi) {
+    throw std::runtime_error(
+        "Currently this MultibodyPlant is set to use the TAMSI solver. TAMSI "
+        "does not support weld constraints. Use "
+        "set_discrete_contact_solver(DiscreteContactSolver::kSap) to use the "
+        "SAP solver instead. For other solvers, refer to "
+        "DiscreteContactSolver.");
+  }
+
   const MultibodyConstraintId constraint_id =
       MultibodyConstraintId::get_new_id();
 
@@ -3101,6 +3112,9 @@ void MultibodyPlant<T>::DeclareParameters() {
     constraint_active_status_map[id] = true;
   }
   for (const auto& [id, spec] : ball_constraints_specs_) {
+    constraint_active_status_map[id] = true;
+  }
+  for (const auto& [id, spec] : weld_constraints_specs_) {
     constraint_active_status_map[id] = true;
   }
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1529,6 +1529,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///
   /// @throws if joint0 and joint1 are not both single-dof joints.
   /// @throws std::exception if the %MultibodyPlant has already been finalized.
+  /// @throws std::exception if `this` %MultibodyPlant is not a discrete model
+  /// (is_discrete() == false)
+  /// @throws std::exception if `this` %MultibodyPlant's underlying contact
+  /// solver is not SAP. (i.e. get_discrete_contact_solver() !=
+  /// DiscreteContactSolver::kSap)
   MultibodyConstraintId AddCouplerConstraint(const Joint<T>& joint0,
                                              const Joint<T>& joint1,
                                              double gear_ratio,
@@ -1574,6 +1579,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if `stiffness` is not positive or zero.
   /// @throws std::exception if `damping` is not positive or zero.
   /// @throws std::exception if the %MultibodyPlant has already been finalized.
+  /// @throws std::exception if `this` %MultibodyPlant is not a discrete model
+  /// (is_discrete() == false)
+  /// @throws std::exception if `this` %MultibodyPlant's underlying contact
+  /// solver is not SAP. (i.e. get_discrete_contact_solver() !=
+  /// DiscreteContactSolver::kSap)
   MultibodyConstraintId AddDistanceConstraint(
       const Body<T>& body_A, const Vector3<double>& p_AP, const Body<T>& body_B,
       const Vector3<double>& p_BQ, double distance,
@@ -1592,6 +1602,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///
   /// @throws std::exception if bodies A and B are the same body.
   /// @throws std::exception if the %MultibodyPlant has already been finalized.
+  /// @throws std::exception if `this` %MultibodyPlant is not a discrete model
+  /// (is_discrete() == false)
+  /// @throws std::exception if `this` %MultibodyPlant's underlying contact
+  /// solver is not SAP. (i.e. get_discrete_contact_solver() !=
+  /// DiscreteContactSolver::kSap)
   MultibodyConstraintId AddBallConstraint(const Body<T>& body_A,
                                           const Vector3<double>& p_AP,
                                           const Body<T>& body_B,
@@ -1609,6 +1624,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///
   /// @throws std::exception if bodies A and B are the same body.
   /// @throws std::exception if the %MultibodyPlant has already been finalized.
+  /// @throws std::exception if `this` %MultibodyPlant is not a discrete model
+  /// (is_discrete() == false)
+  /// @throws std::exception if `this` %MultibodyPlant's underlying contact
+  /// solver is not SAP. (i.e. get_discrete_contact_solver() !=
+  /// DiscreteContactSolver::kSap)
   MultibodyConstraintId AddWeldConstraint(
       const Body<T>& body_A, const math::RigidTransform<double>& X_AP,
       const Body<T>& body_B, const math::RigidTransform<double>& X_BQ);

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -593,7 +593,13 @@ void SapDriver<T>::AddWeldConstraints(
 
   const Frame<T>& frame_W = plant().world_frame();
 
+  const std::map<MultibodyConstraintId, bool>& constraint_active_status =
+      manager().GetConstraintActiveStatus(context);
+
   for (const auto& [id, spec] : manager().weld_constraints_specs()) {
+    // skip this constraint if it is not active.
+    if (!constraint_active_status.at(id)) continue;
+
     const Body<T>& body_A = plant().get_body(spec.body_A);
     const Body<T>& body_B = plant().get_body(spec.body_B);
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3886,6 +3886,8 @@ GTEST_TEST(MultibodyPlantTests, ConstraintActiveStatus) {
       body_A, Vector3d(1.0, 2.0, 3.0), body_B, Vector3d(4.0, 5.0, 6.0), 2.0);
   MultibodyConstraintId ball_id = plant.AddBallConstraint(
       body_A, Vector3d(-1.0, -2.0, -3.0), body_B, Vector3d(-4.0, -5.0, -6.0));
+  MultibodyConstraintId weld_id = plant.AddWeldConstraint(
+      body_A, RigidTransformd(), body_B, RigidTransformd());
 
   plant.Finalize();
 
@@ -3895,26 +3897,31 @@ GTEST_TEST(MultibodyPlantTests, ConstraintActiveStatus) {
   EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, coupler_id));
   EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, distance_id));
   EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, ball_id));
+  EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, weld_id));
 
   // Set all constraints to inactive.
   plant.SetConstraintActiveStatus(context.get(), coupler_id, false);
   plant.SetConstraintActiveStatus(context.get(), distance_id, false);
   plant.SetConstraintActiveStatus(context.get(), ball_id, false);
+  plant.SetConstraintActiveStatus(context.get(), weld_id, false);
 
   // Verify all constraints are inactive in the context.
   EXPECT_FALSE(plant.GetConstraintActiveStatus(*context, coupler_id));
   EXPECT_FALSE(plant.GetConstraintActiveStatus(*context, distance_id));
   EXPECT_FALSE(plant.GetConstraintActiveStatus(*context, ball_id));
+  EXPECT_FALSE(plant.GetConstraintActiveStatus(*context, weld_id));
 
   // Set all constraints to back to active.
   plant.SetConstraintActiveStatus(context.get(), coupler_id, true);
   plant.SetConstraintActiveStatus(context.get(), distance_id, true);
   plant.SetConstraintActiveStatus(context.get(), ball_id, true);
+  plant.SetConstraintActiveStatus(context.get(), weld_id, true);
 
   // Verify all constraints are active in the context.
   EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, coupler_id));
   EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, distance_id));
   EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, ball_id));
+  EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, weld_id));
 }
 
 GTEST_TEST(MultibodyPlantTests, FixedOffsetFrameFunctions) {

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -393,14 +393,16 @@ GTEST_TEST(SapDriverTest, ConstraintActiveStatus) {
       "A_B", body_A, RigidTransformd::Identity(), body_B,
       RigidTransformd::Identity(), Vector3d::UnitZ());
 
-  // Add one coupler constraint, one distance constraint, and one ball
-  // constraint.
+  // Add one coupler constraint, one distance constraint, one ball
+  // constraint and one weld constraint.
   MultibodyConstraintId coupler_constraint_id =
       plant.AddCouplerConstraint(world_A, A_B, 1.2);
   MultibodyConstraintId distance_constraint_id = plant.AddDistanceConstraint(
       body_A, Vector3d::Zero(), body_B, Vector3d(1.0, 2.0, 3.0), 1.0);
   MultibodyConstraintId ball_constraint_id = plant.AddBallConstraint(
       body_A, Vector3d::Zero(), body_B, Vector3d::Zero());
+  MultibodyConstraintId weld_constraint_id = plant.AddWeldConstraint(
+      body_A, RigidTransformd(), body_B, RigidTransformd());
 
   // Finalize and set the manager/driver.
   plant.Finalize();
@@ -422,22 +424,23 @@ GTEST_TEST(SapDriverTest, ConstraintActiveStatus) {
     const SapContactProblem<double>& problem = *problem_cache.sap_problem;
 
     // Verify number of constraints when all are active. There is no contact
-    // so we expect one coupler constraint, one distance constraint and one
-    // ball constraint.
-    EXPECT_EQ(problem.num_constraints(), 3);
+    // so we expect one coupler constraint, one distance constraint one
+    // ball constraint and one weld constraint.
+    EXPECT_EQ(problem.num_constraints(), 4);
     EXPECT_EQ(problem.num_constraint_equations(),
               1 /* coupler constraint */ + 1 /* distance constraint */ +
-                  3 /* ball constraint */);
+                  3 /* ball constraint */ + 6 /* weld constraint*/);
     // TODO(joemasterjohn): When these constraints become first class citizens,
     // verify the constraints via type casts rather than just looking at the
     // number of constraint equations as a proxy.
     EXPECT_EQ(problem.get_constraint(0).num_constraint_equations(), 1);
     EXPECT_EQ(problem.get_constraint(1).num_constraint_equations(), 1);
     EXPECT_EQ(problem.get_constraint(2).num_constraint_equations(), 3);
+    EXPECT_EQ(problem.get_constraint(3).num_constraint_equations(), 6);
   }
 
-  // Set the distance and ball constraint to inactive and verify that only the
-  // coupler constraint shows up in the problem.
+  // Set the distance and ball constraints to inactive and verify that only the
+  // coupler and weld constraints show up in the problem.
   {
     plant.SetConstraintActiveStatus(context.get(), distance_constraint_id,
                                     false);
@@ -447,17 +450,21 @@ GTEST_TEST(SapDriverTest, ConstraintActiveStatus) {
         SapDriverTest::EvalContactProblemCache(sap_driver, *context);
     const SapContactProblem<double>& problem = *problem_cache.sap_problem;
 
-    // Verify number of constraints when only the coupler constraint is active.
-    EXPECT_EQ(problem.num_constraints(), 1);
-    EXPECT_EQ(problem.num_constraint_equations(), 1 /* coupler constraint */);
+    // Verify number of constraints when only the coupler and weld constraints
+    // are active.
+    EXPECT_EQ(problem.num_constraints(), 2);
+    EXPECT_EQ(problem.num_constraint_equations(),
+              1 /* coupler constraint */ + 6 /* weld constraint */);
     EXPECT_EQ(problem.get_constraint(0).num_constraint_equations(), 1);
+    EXPECT_EQ(problem.get_constraint(1).num_constraint_equations(), 6);
   }
 
-  // Now disable the coupler constraint and verify that the problem has 0
-  // constraints.
+  // Now disable the coupler and weld constraints and verify that the problem
+  // has 0 constraints.
   {
     plant.SetConstraintActiveStatus(context.get(), coupler_constraint_id,
                                     false);
+    plant.SetConstraintActiveStatus(context.get(), weld_constraint_id, false);
 
     const ContactProblemCache<double>& problem_cache =
         SapDriverTest::EvalContactProblemCache(sap_driver, *context);
@@ -474,24 +481,26 @@ GTEST_TEST(SapDriverTest, ConstraintActiveStatus) {
                                     true);
     plant.SetConstraintActiveStatus(context.get(), ball_constraint_id, true);
     plant.SetConstraintActiveStatus(context.get(), coupler_constraint_id, true);
+    plant.SetConstraintActiveStatus(context.get(), weld_constraint_id, true);
 
     const ContactProblemCache<double>& problem_cache =
         SapDriverTest::EvalContactProblemCache(sap_driver, *context);
     const SapContactProblem<double>& problem = *problem_cache.sap_problem;
 
     // Verify number of constraints when all are active. There is no contact
-    // so we expect one coupler constraint, one distance constraint and one
-    // ball constraint.
-    EXPECT_EQ(problem.num_constraints(), 3);
+    // so we expect one coupler constraint, one distance constraint, one
+    // ball constraint and one weld constraint.
+    EXPECT_EQ(problem.num_constraints(), 4);
     EXPECT_EQ(problem.num_constraint_equations(),
               1 /* coupler constraint */ + 1 /* distance constraint */ +
-                  3 /* ball constraint */);
+                  3 /* ball constraint */ + 6 /* weld constraint */);
     // TODO(joemasterjohn): When these constraints become first class citizens,
     // verify the constraints via type casts rather than just looking at the
     // number of constraint equations as a proxy.
     EXPECT_EQ(problem.get_constraint(0).num_constraint_equations(), 1);
     EXPECT_EQ(problem.get_constraint(1).num_constraint_equations(), 1);
     EXPECT_EQ(problem.get_constraint(2).num_constraint_equations(), 3);
+    EXPECT_EQ(problem.get_constraint(3).num_constraint_equations(), 6);
   }
 }
 

--- a/multibody/plant/test/sap_driver_weld_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_weld_constraints_test.cc
@@ -310,6 +310,18 @@ GTEST_TEST(WeldConstraintsTests, VerifyIdMapping) {
   EXPECT_THROW(plant.get_distance_constraint_specs(weld_id), std::exception);
 }
 
+GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
+  MultibodyPlant<double> plant{0.1};
+  plant.set_discrete_contact_solver(DiscreteContactSolver::kTamsi);
+  const RigidBody<double>& bodyA =
+      plant.AddRigidBody("A", SpatialInertia<double>{});
+  const RigidBody<double>& bodyB =
+      plant.AddRigidBody("B", SpatialInertia<double>{});
+  DRAKE_EXPECT_THROWS_MESSAGE(plant.AddWeldConstraint(bodyA, RigidTransformd(),
+                                                      bodyB, RigidTransformd()),
+                              ".*TAMSI does not support weld constraints.*");
+}
+
 GTEST_TEST(WeldConstraintTests, FailOnContinuous) {
   MultibodyPlant<double> plant{0.0};
   const RigidBody<double>& bodyA =


### PR DESCRIPTION
Fixes #20527.

The weld constraint was not wired up to use the constraint active status mechanism, this PR adds the missing feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20530)
<!-- Reviewable:end -->
