### PR TITLE
Update release scripts for staging changes

### DIFF
--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -33,6 +33,10 @@ Mac are available to download as attachments from Drake's GitHub
 The most recent release is
 [v1.22.0](https://github.com/RobotLocomotion/drake/releases/tag/v1.22.0):
 
+<!-- FIXME When 1.23.0 is released, the following URLs need to be updated to
+use version numbers instead of dates, e.g. v1.23.0/drake-1.23.0-focal.tar.gz.
+Once that happens, this note should be removed. -->
+
 * [https://github.com/RobotLocomotion/drake/releases/download/v1.22.0/drake-20231016-focal.tar.gz](https://github.com/RobotLocomotion/drake/releases/download/v1.22.0/drake-20231016-focal.tar.gz)
 * [https://github.com/RobotLocomotion/drake/releases/download/v1.22.0/drake-20231016-jammy.tar.gz](https://github.com/RobotLocomotion/drake/releases/download/v1.22.0/drake-20231016-jammy.tar.gz)
 * https://github.com/RobotLocomotion/drake/releases/download/v1.22.0/drake-20231016-mac.tar.gz (for x86_64)

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -123,13 +123,15 @@ the main body of the document:
       source code:
       [download_release_candidate.py](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/download_release_candidate.py).)
 2. Launch the staging builds for that git commit sha:
-   1. Open the following five Jenkins jobs (e.g., each in its own
+   1. Open the following seven Jenkins jobs (e.g., each in its own
       new browser tab):
-      - [Linux Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-focal-unprovisioned-gcc-wheel-staging-release/)
-      - [macOS x86 Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-x86-monterey-unprovisioned-clang-wheel-staging-release/)
-      - [macOS arm Jenkins Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-ventura-unprovisioned-clang-wheel-staging-release/)
+      - [Linux Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-focal-unprovisioned-gcc-wheel-staging-release/)
+      - [macOS x86 Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-x86-monterey-unprovisioned-clang-wheel-staging-release/)
+      - [macOS arm Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-ventura-unprovisioned-clang-wheel-staging-release/)
       - [Focal Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-focal-unprovisioned-gcc-bazel-staging-packaging/)
       - [Jammy Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-bazel-staging-packaging/)
+      - [macOS x86 Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-x86-monterey-unprovisioned-clang-bazel-staging-packaging/)
+      - [macOS arm Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-ventura-unprovisioned-clang-bazel-staging-packaging/)
    2. In the upper right, click "log in" (unless you're already logged in). This
       will use your GitHub credentials.
    3. Click "Build with Parameters".
@@ -138,18 +140,19 @@ the main body of the document:
       - If you mistakenly provide the "v" in "release_version", your build will
         appear to work, but actually fail 5-6 minutes later.
    5. Click "Build"; each build will take around an hour, give or take.
-   6. Note: The macOS wheel jobs will produce one `.whl` file, whereas the linux
+   6. Note: The macOS wheel jobs will produce one `.whl` file, whereas the Linux
       job will produce multiple `.whl` files (in the same job).
    7. Wait for all staging jobs to succeed.  It's OK to work on release notes
       finishing touches in the meantime, but do not merge the release notes nor
-      tag the release until all five builds have succeeded.
+      tag the release until all seven builds have succeeded.
 3. Update the release notes to have the ``YYYYMMDD`` we choose, and to make
    sure that the nightly build git sha from the prior steps matches the
    ``newest_commit`` whose changes are enumerated in the notes.  Some dates
    are YYYYMMDD format, some are YYYY-MM-DD format; be sure to manually fix
    them all. There is also a dummy date 2099-12-31 that should also be changed.
+   Also replace ``VERSION`` in the tarball name with the appropriate ``1.N.0``.
    1. Update the github links within ``doc/_pages/from_binary.md`` to reflect
-      the upcoming v1.N.0 and YYYYMMDD.
+      the upcoming v1.N.0.
 4. Re-enable CI by reverting the commit you added way up above in step 3 of **Prior to release**.
 5. Wait for the wheel builds to complete, and then download release artifacts:
    1. Use the

--- a/doc/_release-notes/template.txt
+++ b/doc/_release-notes/template.txt
@@ -119,7 +119,7 @@ Fixes
 
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/{version}) named
-``drake-YYYYMMDD-{{focal|jammy|mac|mac-arm64}}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
+``drake-VERSION-{{focal|jammy|mac|mac-arm64}}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/tools/release_engineering/dev/push_release.py
+++ b/tools/release_engineering/dev/push_release.py
@@ -52,11 +52,11 @@ class _Artifact:
 
 class _Manifest:
     """
-    Regex matching a tarball, e.g. 'drake-19990101-mac-arm64.tar.gz'.
+    Regex matching a tarball, e.g. 'drake-0.1.0-mac-arm64.tar.gz'.
     """
     RE_TAR = re.compile(
         r'^drake-'
-        r'(?P<id>[0-9]{8})-'
+        r'(?P<id>[0-9.]+)-'
         r'(?P<platform>\w+)'
         r'(-(?P<arch>\w+))?.'
         r'(?P<ext>tar.[gx]z)$')
@@ -339,17 +339,7 @@ def _push_tar(state: _State):
     """
     version = state.options.source_version
     for tar in state.find_artifacts(_Manifest.RE_TAR):
-        # TODO(mwoehlke-kitware):
-        # Eventually, the tarballs should use the version number and not the
-        # build date in their name, and we won't need this renaming logic. At
-        # that time, the code below should become:
-        #   state.push_artifact(tar, _AWS_BUCKET, f'drake/release/{tar.name}')
-        if tar.arch is None:
-            variant = tar.platform
-        else:
-            variant = f'{tar.platform}-{tar.arch}'
-        dest_name = f'drake-{version}-{variant}.{tar.ext}'
-        state.push_artifact(tar, _AWS_BUCKET, f'drake/release/{dest_name}')
+        state.push_artifact(tar, _AWS_BUCKET, f'drake/release/{tar.name}')
 
     dest_name = f'drake-{version}-src.tar.gz'
 

--- a/tools/release_engineering/download_release_candidate.py
+++ b/tools/release_engineering/download_release_candidate.py
@@ -2,21 +2,24 @@ r"""
 Downloads the to-be-released binaries, verifies they are all the same version,
 and prepares to upload them per the release playbook.
 
-Use bazel to build the tool:
+Use bazel to build the tool.
 
-Here's an example of how to obtain the git sha for the release.
+Here's an example of how to obtain the git sha for the release:
 
   bazel run //tools/release_engineering:download_release_candidate -- \
-      --timestamp 20220303 --find-git-sha
+      --find-git-sha YYYYMMDD
 
 Here's an example of how download the release artifacts:
 
   bazel run //tools/release_engineering:download_release_candidate -- \
-      --timestamp 20220303 --version v1.0.0
+      --version vX.Y.Z
 
-TODO(jwnimmer-tri) Rename this tool to something more general, like
-`release_candidate` (without the "download" part).
+In either example, the date/version placeholder must be replaced with a valid
+and sufficiently recent date/version.
 """
+
+# TODO(jwnimmer-tri) Rename this tool to something more general, like
+# `release_candidate` (without the "download" part).
 
 import argparse
 from io import StringIO
@@ -111,38 +114,49 @@ def _download_binaries(*, timestamp, staging, version):
     """Downloads the binaries as specified, and returns a list of (relative)
     paths.
 
-    The `timestamp` is a string like "YYYYMMDD".
+    The `timestamp` is a string like "YYYYMMDD", or None.
     The `staging` is a bool (whether to download staged wheels / debian).
-    The `version` is a string like "vM.m.p".
+    The `version` is a string like "vM.m.p", or None.
     """
-    assert (version is None) == (staging is False)
 
     # This is a partial inventory of our binary releases (tgz and wheel only).
     # The apt and docker releases are handled separately.
-    binaries = {
-        "https://drake-packages.csail.mit.edu/drake/nightly": [
-            f"drake-{timestamp}-focal.tar.gz",
-            f"drake-{timestamp}-jammy.tar.gz",
-            f"drake-{timestamp}-mac.tar.gz",
-            f"drake-{timestamp}-mac-arm64.tar.gz",
-        ],
-    }
-
     if staging:
-        binaries["https://drake-packages.csail.mit.edu/drake/staging"] = [
-            # Wheel filenames.
-            f"drake-{version[1:]}-cp38-cp38-manylinux_2_31_x86_64.whl",
-            f"drake-{version[1:]}-cp39-cp39-manylinux_2_31_x86_64.whl",
-            f"drake-{version[1:]}-cp310-cp310-manylinux_2_31_x86_64.whl",
-            f"drake-{version[1:]}-cp311-cp311-manylinux_2_31_x86_64.whl",
-            f"drake-{version[1:]}-cp312-cp312-manylinux_2_31_x86_64.whl",
-            f"drake-{version[1:]}-cp311-cp311-macosx_12_0_x86_64.whl",
-            f"drake-{version[1:]}-cp311-cp311-macosx_13_0_arm64.whl",
-            # Deb filenames.
-            f"drake-dev_{version[1:]}-1_amd64-focal.deb",
-            f"drake-dev_{version[1:]}-1_amd64-jammy.deb",
-            # TODO(18145): Download staging .tar.gz once it's ready.
-        ]
+        assert version is not None
+        assert timestamp is None
+
+        binaries = {
+            "https://drake-packages.csail.mit.edu/drake/staging": [
+                # Wheel filenames.
+                f"drake-{version[1:]}-cp38-cp38-manylinux_2_31_x86_64.whl",
+                f"drake-{version[1:]}-cp39-cp39-manylinux_2_31_x86_64.whl",
+                f"drake-{version[1:]}-cp310-cp310-manylinux_2_31_x86_64.whl",
+                f"drake-{version[1:]}-cp311-cp311-manylinux_2_31_x86_64.whl",
+                f"drake-{version[1:]}-cp312-cp312-manylinux_2_31_x86_64.whl",
+                f"drake-{version[1:]}-cp311-cp311-macosx_12_0_x86_64.whl",
+                f"drake-{version[1:]}-cp311-cp311-macosx_13_0_arm64.whl",
+                # Deb filenames.
+                f"drake-dev_{version[1:]}-1_amd64-focal.deb",
+                f"drake-dev_{version[1:]}-1_amd64-jammy.deb",
+                # Tarball filenames.
+                f"drake-{version[1:]}-focal.tar.gz",
+                f"drake-{version[1:]}-jammy.tar.gz",
+                f"drake-{version[1:]}-mac.tar.gz",
+                f"drake-{version[1:]}-mac-arm64.tar.gz",
+            ],
+        }
+    else:
+        assert timestamp is not None
+        assert version is None
+
+        binaries = {
+            "https://drake-packages.csail.mit.edu/drake/nightly": [
+                f"drake-{timestamp}-focal.tar.gz",
+                f"drake-{timestamp}-jammy.tar.gz",
+                f"drake-{timestamp}-mac.tar.gz",
+                f"drake-{timestamp}-mac-arm64.tar.gz",
+            ],
+        }
 
     # Build a list of flat URLs and a list of (base_url, filename) pairs.
     download_urls = []  # list[str]
@@ -222,7 +236,7 @@ def _check_deb_versions(*, filenames, version):
         raise UserError("\n".join(version_errors))
 
 
-def _download_version(*, timestamp, version):
+def _download_version(*, version):
     """Implements the --version (download) command line action.
     """
     if version[0] != "v":
@@ -238,7 +252,7 @@ def _download_version(*, timestamp, version):
     os.chdir(tmp_dir)
 
     filenames = _download_binaries(
-        timestamp=timestamp, staging=True, version=version)
+        timestamp=None, staging=True, version=version)
     git_sha = _get_consistent_git_commit_sha(filenames=filenames)
     print(f"The binaries all have the same git commit sha: {git_sha}")
 
@@ -258,22 +272,20 @@ def main():
     parser = argparse.ArgumentParser(
         prog="download_release_candidate", description=__doc__,
         formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument(
-        "--timestamp", type=str, required=True,
-        help="Drake archive timestamp in YYYYMMDD format.")
     action = parser.add_mutually_exclusive_group(required=True)
     action.add_argument(
-        "--find-git-sha", action="store_true",
-        help="Print the git sha to use for this release.")
+        "--find-git-sha", metavar="TIMESTAMP",
+        help="Print the git sha to use for the release "
+             "matching the YYYYMMDD nightly.")
     action.add_argument(
         "--version", type=str,
-        help="Release version in vX.Y.Z format.")
+        help="Download artifacts for the vX.Y.Z release.")
     args = parser.parse_args()
 
     if args.version is None:
-        _find_git_sha(timestamp=args.timestamp)
+        _find_git_sha(timestamp=args.find_git_sha)
     else:
-        _download_version(timestamp=args.timestamp, version=args.version)
+        _download_version(version=args.version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Staging jobs now produce packages with version numbers rather than timestamps in the file names. Update release instructions and related scripts accordingly.

Fixes #18300.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20532)
<!-- Reviewable:end -->
