### PR TITLE
[sensors] Sensor poses are parameters

### DIFF
--- a/bindings/pydrake/systems/sensors_py_rgbd.cc
+++ b/bindings/pydrake/systems/sensors_py_rgbd.cc
@@ -1,3 +1,4 @@
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/systems/sensors_py.h"
 #include "drake/systems/sensors/camera_info.h"
@@ -100,7 +101,11 @@ void DefineSensorsRgbd(py::module m) {
       .def("X_BC", &RgbdSensor::X_BC, doc.RgbdSensor.X_BC.doc)
       .def("X_BD", &RgbdSensor::X_BD, doc.RgbdSensor.X_BD.doc)
       .def("parent_frame_id", &RgbdSensor::parent_frame_id,
-          py_rvp::reference_internal, doc.RgbdSensor.parent_frame_id.doc);
+          py_rvp::reference_internal, doc.RgbdSensor.parent_frame_id.doc)
+      .def("GetPoseInParent", &RgbdSensor::GetPoseInParent, py::arg("context"),
+          doc.RgbdSensor.GetPoseInParent.doc)
+      .def("SetPoseInParent", &RgbdSensor::SetPoseInParent, py::arg("context"),
+          py::arg("X_PB"), doc.RgbdSensor.SetPoseInParent.doc);
   def_camera_ports(&rgbd_sensor, doc.RgbdSensor);
 
   py::class_<RgbdSensorDiscrete, Diagram<double>> rgbd_camera_discrete(
@@ -125,7 +130,8 @@ void DefineSensorsRgbd(py::module m) {
   {
     using Class = RgbdSensorAsync;
     constexpr auto& cls_doc = doc.RgbdSensorAsync;
-    py::class_<Class, LeafSystem<double>>(m, "RgbdSensorAsync", cls_doc.doc)
+    auto cls = py::class_<Class, LeafSystem<double>>(m, "RgbdSensorAsync", cls_doc.doc);
+    cls  // BR
         .def(py::init<const geometry::SceneGraph<double>*, geometry::FrameId,
                  const math::RigidTransformd&, double, double, double,
                  std::optional<ColorRenderCamera>,
@@ -135,7 +141,10 @@ void DefineSensorsRgbd(py::module m) {
             py::arg("color_camera"), py::arg("depth_camera") = std::nullopt,
             py::arg("render_label_image") = false, cls_doc.ctor.doc)
         .def("parent_id", &Class::parent_id, cls_doc.parent_id.doc)
-        .def("X_PB", &Class::X_PB, cls_doc.X_PB.doc)
+        .def("GetPoseInParent", &Class::GetPoseInParent, py::arg("context"),
+            cls_doc.GetPoseInParent.doc)
+        .def("SetPoseInParent", &Class::SetPoseInParent, py::arg("context"),
+            py::arg("X_PB"), cls_doc.SetPoseInParent.doc)
         .def("fps", &Class::fps, cls_doc.fps.doc)
         .def("capture_offset", &Class::capture_offset,
             cls_doc.capture_offset.doc)
@@ -155,6 +164,11 @@ void DefineSensorsRgbd(py::module m) {
             cls_doc.body_pose_in_world_output_port.doc)
         .def("image_time_output_port", &Class::image_time_output_port,
             py_rvp::reference_internal, cls_doc.image_time_output_port.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("X_PB", WrapDeprecated(cls_doc.X_PB.doc_deprecated, &Class::X_PB));
+#pragma GCC diagnostic pop
   }
 }
 

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -473,6 +473,13 @@ class TestSensors(unittest.TestCase):
             self.assertEqual(sensor.parent_frame_id(), parent_id)
             check_ports(sensor)
 
+        # Test reposing the camera; simply use the last camera constructed.
+        sensor.SetPoseInParent(context=sensor.CreateDefaultContext(),
+                               X_PB=RigidTransform(p=[1, 2, 3]))
+        self.assertIsInstance(
+            sensor.GetPoseInParent(context=sensor.CreateDefaultContext()),
+            RigidTransform)
+
         # Test discrete camera. We'll simply use the last sensor constructed.
 
         period = mut.RgbdSensorDiscrete.kDefaultPeriod
@@ -510,7 +517,6 @@ class TestSensors(unittest.TestCase):
                                   depth_camera=depth_camera,
                                   render_label_image=True)
         dut.parent_id()
-        dut.X_PB()
         dut.fps()
         dut.capture_offset()
         dut.output_delay()
@@ -522,6 +528,15 @@ class TestSensors(unittest.TestCase):
         dut.label_image_output_port()
         dut.body_pose_in_world_output_port()
         dut.image_time_output_port()
+
+        with catch_drake_warnings(expected_count=1):
+            dut.X_PB()        
+        # Test reposing the camera.
+        dut.SetPoseInParent(context=dut.CreateDefaultContext(),
+                            X_PB=RigidTransform(p=[1, 2, 3]))
+        self.assertIsInstance(
+            dut.GetPoseInParent(context=dut.CreateDefaultContext()),
+            RigidTransform)
 
     def test_image_file_format(self):
         mut.ImageFileFormat.kJpeg

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -60,6 +60,11 @@ namespace sensors {
  image. Only if the depth or color frames are re-oriented relative to the body
  does further reasoning need to be applied.
 
+ The pose of the camera body with respect to its parent frame is a system
+ parameter. The value is initially defined at construction but you can use
+ GetPoseInParent() and SetPoseInParent() to read/write that pose after
+ construction.
+
  Output port image formats:
 
    - color_image: Four channels, each channel uint8_t, in the following order:
@@ -175,6 +180,15 @@ class RgbdSensor final : public LeafSystem<double> {
    the current time). */
   const OutputPort<double>& image_time_output_port() const;
 
+  /** Retrieves the pose of the sensor body in the parent frame. */
+  const math::RigidTransformd& GetPoseInParent(
+      const Context<double>& context) const;
+
+  /** The pose of the sensor body in the parent frame is a system parameter.
+   It is stored in the context and can be edited. */
+  void SetPoseInParent(Context<double>* context,
+                       const math::RigidTransformd& X_PB) const;
+
  private:
   // The calculator methods for the four output ports.
   void CalcColorImage(const Context<double>& context,
@@ -211,8 +225,9 @@ class RgbdSensor final : public LeafSystem<double> {
   // The camera specifications for color/label and depth.
   const geometry::render::ColorRenderCamera color_camera_;
   const geometry::render::DepthRenderCamera depth_camera_;
-  // The position of the camera's B frame relative to its parent frame P.
-  const math::RigidTransformd X_PB_;
+
+  // The index of the X_PB parameter in the context.
+  int X_PB_index_{};
 };
 
 }  // namespace sensors

--- a/systems/sensors/rgbd_sensor_async.cc
+++ b/systems/sensors/rgbd_sensor_async.cc
@@ -129,15 +129,15 @@ class SnapshotSensor final : public Diagram<double> {
     geometry_version_ = scene_graph->model_inspector().geometry_version();
     DiagramBuilder<double> builder;
     auto* chef = builder.AddNamedSystem<QueryObjectChef>("chef", scene_graph);
-    auto* rgbd = builder.AddNamedSystem<RgbdSensor>("camera", parent_id, X_PB,
-                                                    color_camera, depth_camera);
-    builder.Connect(*chef, *rgbd);
+    rgbd_ = builder.AddNamedSystem<RgbdSensor>("camera", parent_id, X_PB,
+                                               color_camera, depth_camera);
+    builder.Connect(*chef, *rgbd_);
     for (InputPortIndex i{0}; i < chef->num_input_ports(); ++i) {
       const auto& input_port = chef->get_input_port(i);
       builder.ExportInput(input_port, input_port.get_name());
     }
-    for (OutputPortIndex i{0}; i < rgbd->num_output_ports(); ++i) {
-      const auto& output_port = rgbd->get_output_port(i);
+    for (OutputPortIndex i{0}; i < rgbd_->num_output_ports(); ++i) {
+      const auto& output_port = rgbd_->get_output_port(i);
       builder.ExportOutput(output_port, output_port.get_name());
     }
     builder.BuildInto(this);
@@ -146,8 +146,17 @@ class SnapshotSensor final : public Diagram<double> {
   /* Returns the version as of when this sensor was created. */
   const GeometryVersion& geometry_version() const { return geometry_version_; }
 
+  /* Sets the pose of the underlying RgbdSensor with respect to its parent
+  frame. */
+  void SetPoseInParent(Context<double>* context,
+                       const RigidTransformd& X_PB) const {
+    auto& rgbd_context = this->GetMutableSubsystemContext(*rgbd_, context);
+    rgbd_->SetPoseInParent(&rgbd_context, X_PB);
+  }
+
  private:
   GeometryVersion geometry_version_;
+  RgbdSensor* rgbd_{};
 };
 
 /* The results of camera rendering. */
@@ -187,6 +196,12 @@ class Worker {
   not been called since the most recent Finish), returns a default-constructed
   value (i.e., with nullptr for the images). */
   RenderedImages Finish();
+
+  /* Sets the pose of the underlying RgbdSensor with respect to its parent
+  frame. */
+  void SetPoseInParent(const RigidTransformd& X_PB) const {
+    sensor_->SetPoseInParent(sensor_context_.get(), X_PB);
+  }
 
  private:
   const std::shared_ptr<const SnapshotSensor> sensor_;
@@ -237,6 +252,8 @@ RgbdSensorAsync::RgbdSensorAsync(const SceneGraph<double>* scene_graph,
   // TODO(jwnimmer-tri) Check that the render engine named by either of the two
   // cameras is not the (known non-threadsafe) VTK engine.
 
+  X_PB_index_ = this->DeclareAbstractParameter(Value(X_PB));
+
   // Input.
   DeclareAbstractInputPort("geometry_query", Value<QueryObject<double>>{});
 
@@ -263,6 +280,19 @@ RgbdSensorAsync::RgbdSensorAsync(const SceneGraph<double>* scene_graph,
   }
   DeclareAbstractOutputPort("body_pose_in_world", &Self::CalcX_WB, state);
   DeclareVectorOutputPort("image_time", 1, &Self::CalcImageTime, state);
+}
+
+const RigidTransformd& RgbdSensorAsync::GetPoseInParent(
+    const Context<double>& context) const {
+  return context.get_parameters()
+      .template get_abstract_parameter<RigidTransformd>(X_PB_index_);
+}
+
+void RgbdSensorAsync::SetPoseInParent(Context<double>* context,
+                                      const math::RigidTransformd& X_PB) const {
+  context->get_mutable_parameters()
+      .template get_mutable_abstract_parameter<RigidTransformd>(X_PB_index_) =
+      X_PB;
 }
 
 const OutputPort<double>& RgbdSensorAsync::color_image_output_port() const {
@@ -336,7 +366,8 @@ EventStatus RgbdSensorAsync::Initialize(const Context<double>& context,
   // job during initialization is to reset the nested system and any prior
   // output.
   auto sensor = std::make_shared<const SnapshotSensor>(
-      scene_graph_, parent_id_, X_PB_, std::move(*color), std::move(*depth));
+      scene_graph_, parent_id_, GetPoseInParent(context), std::move(*color),
+      std::move(*depth));
   next_state.worker =
       std::make_shared<Worker>(std::move(sensor), color_camera_.has_value(),
                                depth_camera_.has_value(), render_label_image_);
@@ -363,6 +394,11 @@ void RgbdSensorAsync::CalcTick(const Context<double>& context,
   } else {
     next_state.worker = prior_state.worker;
   }
+
+  // Always pull the freshest camera pose when starting a tick.
+  next_state.worker->SetPoseInParent(
+      context.get_parameters().get_abstract_parameter<RigidTransformd>(
+          X_PB_index_));
 
   // Start the worker on its next task.
   next_state.worker->Start(context.get_time(), query);

--- a/systems/sensors/rgbd_sensor_async.h
+++ b/systems/sensors/rgbd_sensor_async.h
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/render/render_camera.h"
@@ -79,6 +80,13 @@ associated with rendering.
 See also RgbdSensorDiscrete for a simpler (unthreaded) discrete sensor model, or
 RgbdSensor for a continuous model.
 
+The camera is posed using a parent frame, P, and a pose relative to that parent
+frame, X_PB. Like with RgbdSensor, the pose X_PB is a parameter of the system
+and can be changed. %RgbdSensorAsync adds a subtle wrinkle to that act. If
+the pose is changed between "capture" and "output" times, the output will
+reflect the pose at the time of the previous capture. The new pose will only
+affect *subsequent* images.
+
 @warning As the moment, this implementation cannnot respond to changes to
 geometry shapes, textures, etc. after a simulation has started. The only thing
 it responds to are changes to geometry poses. If you change anything beyond
@@ -128,7 +136,17 @@ class RgbdSensorAsync final : public LeafSystem<double> {
   geometry::FrameId parent_id() const { return parent_id_; }
 
   /** Returns the `X_PB` passed to the constructor. */
+  DRAKE_DEPRECATED("2024-03-01", "X_PB is now a system parameter; use "
+                                 "GetPoseInParent() to query the value")
   const math::RigidTransformd& X_PB() const { return X_PB_; }
+
+  /** See RgbdSensor::GetPoseInParent(). */
+  const math::RigidTransformd& GetPoseInParent(
+      const systems::Context<double>& context) const;
+
+  /** See RgbdSensor::SetPoseInParent(). */
+  void SetPoseInParent(systems::Context<double>* context,
+                       const math::RigidTransformd& X_PB) const;
 
   /** Returns the `fps` passed to the constructor. */
   double fps() const { return fps_; }
@@ -199,7 +217,9 @@ class RgbdSensorAsync final : public LeafSystem<double> {
 
   const geometry::SceneGraph<double>* const scene_graph_;
   const geometry::FrameId parent_id_;
+  // 2024-03-01 - remove when removing deprecation.
   const math::RigidTransformd X_PB_;
+  int X_PB_index_{};
   const double fps_;
   const double capture_offset_;
   const double output_delay_;

--- a/systems/sensors/test/rgbd_sensor_async_test.cc
+++ b/systems/sensors/test/rgbd_sensor_async_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/sensors/rgbd_sensor_async.h"
 
+#include <functional>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -45,7 +47,11 @@ class SimpleRenderEngine final : public DummyRenderEngine {
       ImageTraits<PixelType::kDepth16U>::kTooFar;
   static const RenderLabel& kClearLabel;
 
-  SimpleRenderEngine() { this->set_force_accept(true); }
+  SimpleRenderEngine(std::function<void(const RigidTransform<double>&)>
+                         viewpoint_callback = nullptr)
+      : viewpoint_callback_(std::move(viewpoint_callback)) {
+    this->set_force_accept(true);
+  }
 
  private:
   std::unique_ptr<RenderEngine> DoClone() const final {
@@ -72,6 +78,14 @@ class SimpleRenderEngine final : public DummyRenderEngine {
     *output = ImageLabel16I(camera.core().intrinsics().width(),
                             camera.core().intrinsics().height(), kClearLabel);
   }
+
+  void UpdateViewpoint(const RigidTransform<double>& X_WC) override {
+    if (viewpoint_callback_) {
+      viewpoint_callback_(X_WC);
+    }
+  }
+
+  std::function<void(const RigidTransform<double>&)> viewpoint_callback_;
 };
 
 const RenderLabel& SimpleRenderEngine::kClearLabel = RenderLabel::kEmpty;
@@ -180,7 +194,10 @@ TEST_F(RgbdSensorAsyncTest, ConstructorAndSimpleAccessors) {
                             render_label_image);
 
   EXPECT_EQ(dut.parent_id(), parent_id);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_EQ(dut.X_PB().GetAsMatrix34(), X_PB.GetAsMatrix34());
+#pragma GCC diagnostic pop
   EXPECT_EQ(dut.fps(), fps);
   EXPECT_EQ(dut.capture_offset(), capture_offset);
   EXPECT_EQ(dut.output_delay(), output_delay);
@@ -199,7 +216,59 @@ TEST_F(RgbdSensorAsyncTest, ConstructorAndSimpleAccessors) {
   simulator.Initialize();
 }
 
-// Confirm that we fail-fast when geometry changes post-initialze.
+TEST_F(RgbdSensorAsyncTest, PoseInParentParameter) {
+  DiagramBuilder<double> builder;
+
+  // Add scene graph and renderer we can query later.
+  auto* scene_graph = builder.AddSystem<SceneGraph<double>>();
+  // We'll capture the camera pose passed to the render engine in X_WC_passed.
+  RigidTransform<double> X_WC_passed;
+  auto render_engine_unique = std::make_unique<SimpleRenderEngine>(
+      [&X_WC_passed](const RigidTransform<double>& X_WC) {
+        X_WC_passed = X_WC;
+      });
+  scene_graph->AddRenderer(kRendererName, std::move(render_engine_unique));
+
+  // Add RgbdSensorAsync.
+  const FrameId parent_id = SceneGraph<double>::world_frame_id();
+  const RigidTransform<double> X_PB_initial(Eigen::Vector3d(1, 2, 3));
+  const double fps = 4;                   // FPS is irrelevant.
+  const double capture_offset = 0;        // First tick happens at t = 0.
+  const double output_delay = 0.001;      // Small tock.
+  const bool render_label_image = false;  // We'll omit label for simplicity.
+  const auto* dut = builder.AddSystem<RgbdSensorAsync>(
+      scene_graph, parent_id, X_PB_initial, fps, capture_offset, output_delay,
+      color_camera_, depth_camera_, render_label_image);
+  builder.Connect(scene_graph->get_query_output_port(), dut->get_input_port());
+
+  Simulator<double> simulator(builder.Build());
+
+  auto& async_context =
+      dut->GetMyMutableContextFromRoot(&simulator.get_mutable_context());
+
+  // The construction parameter comes back in the default context.
+  EXPECT_EQ(dut->GetPoseInParent(async_context).GetAsMatrix34(),
+            X_PB_initial.GetAsMatrix34());
+
+  // Setting the pose works (we can write and then read it).
+  const RigidTransform<double> X_PB_new(X_PB_initial.translation() +
+                                        Eigen::Vector3d(2, 4, 6));
+  dut->SetPoseInParent(&async_context, X_PB_new);
+  EXPECT_EQ(dut->GetPoseInParent(async_context).GetAsMatrix34(),
+            X_PB_new.GetAsMatrix34());
+
+  // The worker renderer gets the current parameter value.
+  // Before advancing to the tock event, confirm initial value of X_WC_passed.
+  EXPECT_TRUE(X_WC_passed.IsExactlyIdentity());
+
+  // Advance to *just* beyond to tock event, so we know that the rendering
+  // work thread has been properly evaluated. We should have passed X_PB_new.
+  simulator.AdvanceTo(output_delay + 0.01);
+
+  EXPECT_EQ(X_WC_passed.GetAsMatrix34(), X_PB_new.GetAsMatrix34());
+}
+
+// Confirm that we fail-fast when geometry changes post-initialize.
 TEST_F(RgbdSensorAsyncTest, GeometryVersionFailFast) {
   // Prepare a full simulation.
   DiagramBuilder<double> builder;

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -250,7 +250,8 @@ class RgbdSensorTest : public ::testing::Test {
 
     // Confirm the pose used by the renderer is the expected X_WC pose. We do
     // this by invoking a render (the dummy render engine will cache the last
-    // call to UpdateViewpoint()).
+    // call to UpdateViewpoint()). This only tests the color rendering. We're
+    // assuming if it's correct for color, then depth and label will be ok.
     if (pre_render_callback) pre_render_callback();
     sensor_->color_image_output_port().Eval<ImageRgba8U>(*sensor_context_);
     EXPECT_TRUE(
@@ -313,6 +314,15 @@ TEST_F(RgbdSensorTest, ConstructAnchoredCamera) {
       ValidateConstruction(scene_graph_->world_frame_id(), X_WC_expected));
   EXPECT_EQ(sensor_->image_time_output_port().Eval(*sensor_context_),
             Vector1d{22.2});
+
+  // Now confirm we can change its pose in the parent frame and see it percolate
+  // through. It should manifest in the pose reported to the render engine.
+  const RigidTransformd X_WB_new(RollPitchYawd(0.5, 0.75, 1.0),
+                                 Vector3d(-1, 0, 1));
+  sensor_->SetPoseInParent(sensor_context_, X_WB_new);
+  const RigidTransformd X_WC_new_expected = X_WB_new * X_BC;
+  EXPECT_TRUE(
+      ValidateConstruction(scene_graph_->world_frame_id(), X_WC_new_expected));
 }
 
 // Similar to the AnchoredCamera test -- but, in this case, the reported pose


### PR DESCRIPTION
The pose of the sensor body w.r.t. to its parent frame is now a `System` `Parameter` and can be modified in the context. `RgbdSensor` and `RgbdSensorAsync` change to reflect this. `RgbdSensorDiscrete` requires no change because it simply exposes its underlying `RgbdSensor`.

This deprecates the old `X_PB()` method on `RgbdSensorAsync` in favor of the new parameter.