### PR TITLE
[optimization] Disable LSan on cspace_free_polytope_with_mosek_test

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -300,9 +300,15 @@ drake_cc_googletest(
     # Some of these test cases take a very long time to run. Run each test case
     # in its own process (in parallel) to improve test latency.
     shard_count = 12,
-    # This test launches 2 threads to test both serial and parallel code paths
-    # in CspaceFreePolytope.
-    tags = mosek_test_tags() + ["cpu:2"] + ["no_memcheck"],
+    tags = mosek_test_tags() + [
+        # This test launches 2 threads to test both serial and parallel code
+        # paths in CspaceFreePolytope.
+        "cpu:2",
+        # The memcheck build was disabled by accident:
+        #  https://github.com/RobotLocomotion/drake/pull/18621
+        # TODO(hongkai-dai) Figure out whether we can re-enable this.
+        "no_memcheck",
+    ],
     use_default_main = False,
     deps = [
         "//common/test_utilities:eigen_matrix_compare",
@@ -340,9 +346,20 @@ drake_cc_googletest(
     # Some of these test cases take a very long time to run. Run each test case
     # in its own process (in parallel) to improve test latency.
     shard_count = 12,
-    # This test launches 2 threads to test both serial and parallel code paths
-    # in CspaceFreePolytope.
-    tags = mosek_test_tags() + ["cpu:2"] + ["no_memcheck"],
+    tags = mosek_test_tags() + [
+        # This test launches 2 threads to test both serial and parallel code
+        # paths in CspaceFreePolytope.
+        "cpu:2",
+        # This test experiences random segfaults in the "LSan Everything" build
+        # when both Mosek and Gurobi are used at the same time. Since we can't
+        # debug closed-source software, we have no choice but to ignore those
+        # errors.
+        "no_lsan",
+        # The memcheck build was disabled by accident:
+        #  https://github.com/RobotLocomotion/drake/pull/18621
+        # TODO(hongkai-dai) Figure out whether we can re-enable this.
+        "no_memcheck",
+    ],
     use_default_main = False,
     deps = [
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
See [example failure](https://drake-jenkins.csail.mit.edu/view/Production/job/linux-jammy-clang-bazel-nightly-everything-leak-sanitizer/7/).

This also adds a `no_memcheck` comment missed in #18621.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20546)
<!-- Reviewable:end -->
