### PR TITLE
Implement per model instance net actuation output port

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -917,8 +917,15 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("model_instance"), py_rvp::reference_internal,
             cls_doc.get_actuation_input_port.doc_1args)
         .def("get_net_actuation_output_port",
-            &Class::get_net_actuation_output_port, py_rvp::reference_internal,
-            cls_doc.get_net_actuation_output_port.doc)
+            overload_cast_explicit<const systems::OutputPort<T>&>(
+                &Class::get_net_actuation_output_port),
+            py_rvp::reference_internal,
+            cls_doc.get_net_actuation_output_port.doc_0args)
+        .def("get_net_actuation_output_port",
+            overload_cast_explicit<const systems::OutputPort<T>&,
+                ModelInstanceIndex>(&Class::get_net_actuation_output_port),
+            py::arg("model_instance"), py_rvp::reference_internal,
+            cls_doc.get_net_actuation_output_port.doc_1args)
         .def("get_desired_state_input_port",
             overload_cast_explicit<const systems::InputPort<T>&,
                 multibody::ModelInstanceIndex>(

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -435,6 +435,8 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(
             plant.get_net_actuation_output_port(), OutputPort)
         self.assertIsInstance(
+            plant.get_net_actuation_output_port(model_instance), OutputPort)
+        self.assertIsInstance(
             plant.get_state_output_port(), OutputPort)
         self.assertIsInstance(
             plant.get_generalized_acceleration_output_port(), OutputPort)

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -214,6 +214,7 @@ output_ports:
   model_instance_name[i]</em>_generalized_acceleration'
 - '<em style="color:gray">
   model_instance_name[i]</em>_generalized_contact_forces'
+- <em style="color:gray">model_instance_name[i]</em>_net_actuation
 - <span style="color:green">geometry_pose</span>
 @endsystem
 
@@ -848,18 +849,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called before Finalize().
   const systems::InputPort<T>& get_actuation_input_port() const;
 
-  /// Returns a constant reference to the output port that reports actuation
-  /// values applied through joint actuators. This output port is a vector
-  /// valued port indexed by @ref JointActuatorIndex, see
-  /// JointActuator::index(). Models that include PD controllers will include
-  /// their contribution in this port, refer to @ref mbp_actuation "Actuation"
-  /// for further details.
-  /// @note PD controllers are not considered for actuators on locked joints,
-  /// see Joint::Lock(). Therefore they do not contribute to this port.
-  /// @pre Finalize() was already called on `this` plant.
-  /// @throws std::exception if called before Finalize().
-  const systems::OutputPort<T>& get_net_actuation_output_port() const;
-
   /// Returns a constant reference to the input port for external actuation for
   /// a specific model instance. This is a vector valued port with entries
   /// ordered by monotonically increasing @ref JointActuatorIndex within
@@ -875,6 +864,35 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called before Finalize().
   /// @throws std::exception if the model instance does not exist.
   const systems::InputPort<T>& get_actuation_input_port(
+      ModelInstanceIndex model_instance) const;
+
+  /// Returns a constant reference to the output port that reports actuation
+  /// values applied through joint actuators. This output port is a vector
+  /// valued port indexed by @ref JointActuatorIndex, see
+  /// JointActuator::index(). Models that include PD controllers will include
+  /// their contribution in this port, refer to @ref mbp_actuation "Actuation"
+  /// for further details.
+  /// @note PD controllers are not considered for actuators on locked joints,
+  /// see Joint::Lock(). Therefore they do not contribute to this port.
+  /// @pre Finalize() was already called on `this` plant.
+  /// @throws std::exception if called before Finalize().
+  const systems::OutputPort<T>& get_net_actuation_output_port() const;
+
+  /// Returns a constant reference to the output port that reports actuation
+  /// values applied through joint actuators, for a specific model instance.
+  /// Models that include PD controllers will include their contribution in this
+  /// port, refer to @ref mbp_actuation "Actuation" for further details. This is
+  /// a vector valued port with entries ordered by monotonically increasing @ref
+  /// JointActuatorIndex within `model_instance`.
+  ///
+  /// Every model instance in `this` plant model has a net actuation output
+  /// port, even if zero sized (for model instance with no actuators).
+  ///
+  /// @note PD controllers are not considered for actuators on locked joints,
+  /// see Joint::Lock(). Therefore they do not contribute to this port.
+  /// @pre Finalize() was already called on `this` plant.
+  /// @throws std::exception if called before Finalize().
+  const systems::OutputPort<T>& get_net_actuation_output_port(
       ModelInstanceIndex model_instance) const;
 
   /// For models with PD controlled joint actuators, returns the port to provide
@@ -5199,7 +5217,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // ports. The return value is indexed by JointActuatorIndex.
   VectorX<T> AssembleActuationInput(const systems::Context<T>& context) const;
 
-  // Computes the total applied actuation through actuators. For continuous
+  // Computes the net applied actuation through actuators. For continuous
   // models (thus far) this only inludes values coming from the
   // actuation_input_port. For discrete models, it includes actuator
   // controllers, see @ref mbp_actuation. Similarly to AssembleActuationInput(),
@@ -5700,6 +5718,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // Net actuation applied through actuators.
   systems::OutputPortIndex net_actuation_port_;
+
+  // Vector of net actuation output ports per model instance. Every model
+  // instance has a corresponding port, which might be zero sized for model
+  // instances with no actuators.
+  std::vector<systems::OutputPortIndex> instance_net_actuation_ports_;
 
   std::vector<systems::InputPortIndex> instance_desired_state_ports_;
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1725,9 +1725,12 @@ bool VerifyFeedthroughPorts(const MultibodyPlant<double>& plant) {
   ok_to_feedthrough.insert(plant.get_reaction_forces_output_port().get_index());
   ok_to_feedthrough.insert(
       plant.get_generalized_acceleration_output_port().get_index());
-  for (ModelInstanceIndex i(0); i < plant.num_model_instances(); ++i)
+  for (ModelInstanceIndex i(0); i < plant.num_model_instances(); ++i) {
     ok_to_feedthrough.insert(
         plant.get_generalized_acceleration_output_port(i).get_index());
+    ok_to_feedthrough.insert(
+        plant.get_net_actuation_output_port(i).get_index());
+  }
   ok_to_feedthrough.insert(
       plant.get_body_spatial_accelerations_output_port().get_index());
   if (plant.is_discrete()) {


### PR DESCRIPTION
Per @jwnimmer-tri's request during the review of #20421.
While in #20421 we only provide a port of the net actuation for the entire model, this PR adds the per model instance output ports.

cc'ing @JoseBarreiros-TRI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20549)
<!-- Reviewable:end -->
