### PR TITLE
[parsing] Fix urdf mimic parsing multiple model instances.

### DIFF
--- a/common/test_utilities/diagnostic_policy_test_base.h
+++ b/common/test_utilities/diagnostic_policy_test_base.h
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/diagnostic_policy.h"
+#include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {
@@ -47,6 +48,16 @@ class DiagnosticPolicyTestBase : public ::testing::Test {
   std::string TakeWarning() {
     EXPECT_FALSE(warning_records_.empty());
     return Take(&warning_records_).FormatWarning();
+  }
+
+  /// Return the current number of errors.
+  int NumErrors() {
+    return ssize(error_records_);
+  }
+
+  /// Return the current number of warnings.
+  int NumWarnings() {
+    return ssize(warning_records_);
   }
 
   // This resets the diagnostic collections so that lingering reports to not

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -677,7 +677,7 @@ void UrdfParser::ParseMimicTag(XMLElement* node) {
   ParseScalarAttribute(mimic_node, "multiplier", &gear_ratio);
   ParseScalarAttribute(mimic_node, "offset", &offset);
 
-  if (!plant->HasJointNamed(name)) {
+  if (!plant->HasJointNamed(name, model_instance_)) {
     // This can currently happen if we have a "floating" joint, which does
     // not produce the actual QuaternionFloatingJoint above.
     Warning(*mimic_node,
@@ -688,7 +688,7 @@ void UrdfParser::ParseMimicTag(XMLElement* node) {
     return;
   }
 
-  const Joint<double>& joint0 = plant->GetJointByName(name);
+  const Joint<double>& joint0 = plant->GetJointByName(name, model_instance_);
   const Joint<double>& joint1 =
       plant->GetJointByName(joint_to_mimic, model_instance_);
 

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -344,6 +344,8 @@ TEST_F(UrdfParserTest, JointTypeUnknown) {
 // warning as MimicNoSap).
 
 TEST_F(UrdfParserTest, MimicNoSap) {
+  // Currently the <mimic> tag is only supported by SAP. Setting the solver
+  // to TAMSI should be a warning.
   plant_.set_discrete_contact_solver(DiscreteContactSolver::kTamsi);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
@@ -363,6 +365,7 @@ TEST_F(UrdfParserTest, MimicNoSap) {
 }
 
 TEST_F(UrdfParserTest, MimicNoJoint) {
+  // Currently the <mimic> tag is only supported by SAP.
   plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
@@ -380,6 +383,7 @@ TEST_F(UrdfParserTest, MimicNoJoint) {
 }
 
 TEST_F(UrdfParserTest, MimicBadJoint) {
+  // Currently the <mimic> tag is only supported by SAP.
   plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
@@ -397,6 +401,7 @@ TEST_F(UrdfParserTest, MimicBadJoint) {
 }
 
 TEST_F(UrdfParserTest, MimicSameJoint) {
+  // Currently the <mimic> tag is only supported by SAP.
   plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
@@ -414,6 +419,7 @@ TEST_F(UrdfParserTest, MimicSameJoint) {
 }
 
 TEST_F(UrdfParserTest, MimicMismatchedJoint) {
+  // Currently the <mimic> tag is only supported by SAP.
   plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
@@ -436,6 +442,7 @@ TEST_F(UrdfParserTest, MimicMismatchedJoint) {
 }
 
 TEST_F(UrdfParserTest, MimicOnlyOneDOFJoint) {
+  // Currently the <mimic> tag is only supported by SAP.
   plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
@@ -458,6 +465,7 @@ TEST_F(UrdfParserTest, MimicOnlyOneDOFJoint) {
 }
 
 TEST_F(UrdfParserTest, MimicFloatingJoint) {
+  // Currently the <mimic> tag is only supported by SAP.
   plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
@@ -479,6 +487,48 @@ TEST_F(UrdfParserTest, MimicFloatingJoint) {
   EXPECT_THAT(TakeWarning(),
               MatchesRegex(".*Drake only supports the mimic element for "
                            "single-dof joints.*"));
+}
+
+// Test that mimic tags in different model instances that refer to joints that
+// have colliding names with joints in other model instances don't produce an
+// error.
+TEST_F(UrdfParserTest, MimicDifferentModelInstances) {
+  // Currently the <mimic> tag is only supported by SAP.
+  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  EXPECT_NE(AddModelFromUrdfString(R"""(
+    <robot name='a'>
+      <link name='parent'/>
+      <link name='child0'/>
+      <link name='child1'/>
+      <joint name='joint0' type='revolute'>
+        <parent link='parent'/>
+        <child link='child0'/>
+      </joint>
+      <joint name='joint1' type='revolute'>
+        <parent link='parent'/>
+        <child link='child1'/>
+        <mimic joint='joint0' multiplier='1' offset='0' />
+      </joint>
+    </robot>)""", ""),
+      std::nullopt /* valid model instance index was parsed */);
+  EXPECT_NE(AddModelFromUrdfString(R"""(
+    <robot name='b'>
+      <link name='parent'/>
+      <link name='child0'/>
+      <link name='child1'/>
+      <joint name='joint0' type='revolute'>
+        <parent link='parent'/>
+        <child link='child0'/>
+      </joint>
+      <joint name='joint1' type='revolute'>
+        <parent link='parent'/>
+        <child link='child1'/>
+        <mimic joint='joint0' multiplier='1' offset='0' />
+      </joint>
+    </robot>)""", ""),
+      std::nullopt /* valid model instance index was parsed */);
+  EXPECT_EQ(NumErrors(), 0);
+  EXPECT_EQ(NumWarnings(), 0);
 }
 
 TEST_F(UrdfParserTest, Material) {


### PR DESCRIPTION
Fixes #20538.

This bug was introduced #20503. I forgot to use the model instance specific joint getter APIs on a few calls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20551)
<!-- Reviewable:end -->
