### PR TITLE
[doc] Tidy up release playbook version docs and tools

### DIFF
--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -145,13 +145,11 @@ the main body of the document:
    7. Wait for all staging jobs to succeed.  It's OK to work on release notes
       finishing touches in the meantime, but do not merge the release notes nor
       tag the release until all seven builds have succeeded.
-3. Update the release notes to have the ``YYYYMMDD`` we choose, and to make
-   sure that the nightly build git sha from the prior steps matches the
-   ``newest_commit`` whose changes are enumerated in the notes.  Some dates
-   are YYYYMMDD format, some are YYYY-MM-DD format; be sure to manually fix
-   them all. There is also a dummy date 2099-12-31 that should also be changed.
-   Also replace ``VERSION`` in the tarball name with the appropriate ``1.N.0``.
-   1. Update the github links within ``doc/_pages/from_binary.md`` to reflect
+3. Update the release notes to have the ``YYYY-MM-DD`` we choose.
+   1. There is a dummy date 2099-12-31 nearby that should likewise be changed.
+   2. Make sure that the nightly build git sha from the prior steps matches the
+      ``newest_commit`` whose changes are enumerated in the notes.
+   3. Update the github links within ``doc/_pages/from_binary.md`` to reflect
       the upcoming v1.N.0.
 4. Re-enable CI by reverting the commit you added way up above in step 3 of **Prior to release**.
 5. Wait for the wheel builds to complete, and then download release artifacts:

--- a/doc/_release-notes/template.txt
+++ b/doc/_release-notes/template.txt
@@ -1,6 +1,6 @@
 <!-- This document is the template used by tools/release_engineering/relnotes. -->
 ---
-title: Drake {version}
+title: Drake v{version}
 date: 2099-12-31
 released: YYYY-MM-DD
 ---
@@ -9,14 +9,14 @@ released: YYYY-MM-DD
 
 * TBD
 
-# Breaking changes since {prior_version}
+# Breaking changes since v{prior_version}
 
 * TBD
 
 Refer to our [Drake Stability Guidelines](/stable.html) for our policy
 on API changes.
 
-# Changes since {prior_version}
+# Changes since v{prior_version}
 
 ## Dynamical Systems
 
@@ -118,8 +118,8 @@ Fixes
 # Notes
 
 
-This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/{version}) named
-``drake-VERSION-{{focal|jammy|mac|mac-arm64}}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
+This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v{version}) named
+``drake-{version}-{{focal|jammy|mac|mac-arm64}}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/tools/release_engineering/relnotes.py
+++ b/tools/release_engineering/relnotes.py
@@ -312,8 +312,8 @@ def _create(args, notes_dir, notes_filename, gh, drake):
     with open(f"{notes_dir}/template.txt", "r") as f:
         template = f.read()
     content = template.format(
-        version=args.version,
-        prior_version=args.prior_version,
+        version=args.version[1:],
+        prior_version=args.prior_version[1:],
         oldest_commit_exclusive=prior_sha,
         newest_commit_inclusive=prior_sha,
     )


### PR DESCRIPTION
We can fill in the version number ahead of time, in the template.
We only have YYYY-MM-DD now in the notes, not YYYYMMDD.

+@EricCousineau-TRI for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20553)
<!-- Reviewable:end -->
