### PR TITLE
[geometry] Simplify HydroelasticVolumeIntersector template

### DIFF
--- a/geometry/proximity/field_intersection.h
+++ b/geometry/proximity/field_intersection.h
@@ -5,6 +5,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/bvh.h"
+#include "drake/geometry/proximity/obb.h"
 #include "drake/geometry/proximity/plane.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/proximity/volume_mesh_field.h"
@@ -204,14 +205,9 @@ class VolumeIntersector {
  @tparam MeshBuilder
    The type of mesh-output builder of the contact surface. It can be
    TriMeshBuilder<T> or PolyMeshBuilder<T> for T = double or AutoDiffXd.
-   See contact_surface_utility.h for details.
-
- @tparam BvType
-   The type of bounding volumes for the tetrahedra. It should be Obb
-   for hydroelastics.  */
-template <class MeshBuilder, class BvType>
-class HydroelasticVolumeIntersector
-    : public VolumeIntersector<MeshBuilder, BvType> {
+   See contact_surface_utility.h for details.  */
+template <class MeshBuilder>
+class HydroelasticVolumeIntersector {
  public:
   // T is double or AutoDiffXd.
   using T = typename MeshBuilder::ScalarType;
@@ -238,10 +234,10 @@ class HydroelasticVolumeIntersector
                          If there is no contact, nullptr is returned.  */
   void IntersectCompliantVolumes(
       GeometryId id0, const VolumeMeshFieldLinear<double, double>& field0_M,
-      const Bvh<BvType, VolumeMesh<double>>& bvh0_M,
+      const Bvh<Obb, VolumeMesh<double>>& bvh0_M,
       const math::RigidTransform<T>& X_WM, GeometryId id1,
       const VolumeMeshFieldLinear<double, double>& field1_N,
-      const Bvh<BvType, VolumeMesh<double>>& bvh1_N,
+      const Bvh<Obb, VolumeMesh<double>>& bvh1_N,
       const math::RigidTransform<T>& X_WN,
       std::unique_ptr<ContactSurface<T>>* contact_surface_W);
 };

--- a/geometry/proximity/test/field_intersection_test.cc
+++ b/geometry/proximity/test/field_intersection_test.cc
@@ -399,7 +399,7 @@ TEST_F(VolumeIntersectorTest, IntersectCompliantVolumes) {
   {
     SCOPED_TRACE("Triangle contact surface.");
     std::unique_ptr<ContactSurface<double>> contact_patch_W;
-    HydroelasticVolumeIntersector<TriMeshBuilder<double>, Obb>()
+    HydroelasticVolumeIntersector<TriMeshBuilder<double>>()
         .IntersectCompliantVolumes(first_id, box_field0_M_, box_bvh0_M_, X_WM,
                                    second_id, octahedron_field1_N_,
                                    octahedron_bvh1_N_, X_WN, &contact_patch_W);
@@ -410,7 +410,7 @@ TEST_F(VolumeIntersectorTest, IntersectCompliantVolumes) {
   {
     SCOPED_TRACE("Polygon contact surface.");
     std::unique_ptr<ContactSurface<double>> contact_patch_W;
-    HydroelasticVolumeIntersector<PolyMeshBuilder<double>, Obb>()
+    HydroelasticVolumeIntersector<PolyMeshBuilder<double>>()
         .IntersectCompliantVolumes(first_id, box_field0_M_, box_bvh0_M_, X_WM,
                                    second_id, octahedron_field1_N_,
                                    octahedron_bvh1_N_, X_WN, &contact_patch_W);
@@ -449,7 +449,7 @@ TEST_F(VolumeIntersectorTest, IntersectCompliantVolumesAutoDiffXd) {
   {
     SCOPED_TRACE("Triangle contact surface.");
     std::unique_ptr<ContactSurface<AutoDiffXd>> contact_patch_W;
-    HydroelasticVolumeIntersector<TriMeshBuilder<AutoDiffXd>, Obb>()
+    HydroelasticVolumeIntersector<TriMeshBuilder<AutoDiffXd>>()
         .IntersectCompliantVolumes(first_id, box_field0_M_, box_bvh0_M_, X_WM,
                                    second_id, octahedron_field1_N_,
                                    octahedron_bvh1_N_, X_WN, &contact_patch_W);
@@ -460,7 +460,7 @@ TEST_F(VolumeIntersectorTest, IntersectCompliantVolumesAutoDiffXd) {
   {
     SCOPED_TRACE("Polygon contact surface.");
     std::unique_ptr<ContactSurface<AutoDiffXd>> contact_patch_W;
-    HydroelasticVolumeIntersector<PolyMeshBuilder<AutoDiffXd>, Obb>()
+    HydroelasticVolumeIntersector<PolyMeshBuilder<AutoDiffXd>>()
         .IntersectCompliantVolumes(first_id, box_field0_M_, box_bvh0_M_, X_WM,
                                    second_id, octahedron_field1_N_,
                                    octahedron_bvh1_N_, X_WN, &contact_patch_W);
@@ -480,7 +480,7 @@ TEST_F(VolumeIntersectorTest, IntersectCompliantVolumesNoIntersection) {
   const RigidTransformd X_WN(Vector3d::UnitX());
 
   std::unique_ptr<ContactSurface<double>> contact_patch_W;
-  HydroelasticVolumeIntersector<PolyMeshBuilder<double>, Obb>()
+  HydroelasticVolumeIntersector<PolyMeshBuilder<double>>()
       .IntersectCompliantVolumes(first_id, box_field0_M_, box_bvh0_M_, X_WM,
                                  second_id, octahedron_field1_N_,
                                  octahedron_bvh1_N_, X_WN, &contact_patch_W);


### PR DESCRIPTION
- Remove template parameter BvType because it's always Obb for hydroelastics.

Related to #19704

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20555)
<!-- Reviewable:end -->
