### PR TITLE
[workspace] Add rules_license 0.0.7

### DIFF
--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -84,6 +84,7 @@ load("//tools/workspace/python:repository.bzl", "python_repository")
 load("//tools/workspace/qdldl_internal:repository.bzl", "qdldl_internal_repository")  # noqa
 load("//tools/workspace/qhull_internal:repository.bzl", "qhull_internal_repository")  # noqa
 load("//tools/workspace/ros_xacro_internal:repository.bzl", "ros_xacro_internal_repository")  # noqa
+load("//tools/workspace/rules_license:repository.bzl", "rules_license_repository")  # noqa
 load("//tools/workspace/rules_python:repository.bzl", "rules_python_repository")  # noqa
 load("//tools/workspace/rules_rust:repository.bzl", "rules_rust_repository")
 load("//tools/workspace/rules_rust_tinyjson:repository.bzl", "rules_rust_tinyjson_repository")  # noqa
@@ -314,6 +315,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         qhull_internal_repository(name = "qhull_internal", mirrors = mirrors)
     if "ros_xacro_internal" not in excludes:
         ros_xacro_internal_repository(name = "ros_xacro_internal", mirrors = mirrors)  # noqa
+    if "rules_license" not in excludes:
+        rules_license_repository(name = "rules_license", mirrors = mirrors)
     if "rules_python" not in excludes:
         rules_python_repository(name = "rules_python", mirrors = mirrors)
     if "rules_rust" not in excludes:

--- a/tools/workspace/rules_license/BUILD.bazel
+++ b/tools/workspace/rules_license/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/rules_license/repository.bzl
+++ b/tools/workspace/rules_license/repository.bzl
@@ -1,0 +1,16 @@
+load("//tools/workspace:github.bzl", "github_archive")
+
+# Note that we do NOT install a LICENSE file as part of the Drake install
+# because this repository is required only when building and testing with
+# Bazel.
+
+def rules_license_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "bazelbuild/rules_license",  # License: Apache-2.0,
+        commit = "0.0.7",
+        sha256 = "7626bea5473d3b11d44269c5b510a210f11a78bca1ed639b0f846af955b0fe31",  # noqa
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
This is required by the `@platforms` external. In modern versions of Bazel a sufficiently new version of `@rules_license` is built-in, but the older Bazel 5.x series will fail without this. In any case, we should affirmatively control the versions of all of our dependencies, so relying on the built-in one is poor form anyway.