### PR TITLE
[mkdoc] Fix handling of anoymous enums vs Apple Clang 15

### DIFF
--- a/tools/workspace/pybind11/mkdoc.py
+++ b/tools/workspace/pybind11/mkdoc.py
@@ -261,9 +261,11 @@ def get_name_chain(cursor):
         piece = p.spelling
         name_chain.insert(0, piece)
         p = p.semantic_parent
-    # Do not try to specify names for anonymous structs.
-    while '' in name_chain:
-        name_chain.remove('')
+    # Prune away the names of anonymous structs and enums.
+    name_chain = [
+        x for x in name_chain
+        if x != '' and not x.startswith('(unnamed')
+    ]
     return tuple(name_chain)
 
 
@@ -344,7 +346,8 @@ def extract(include_file_map, cursor, symbol_tree, deprecations=None):
     if cursor.kind in PRINT_LIST:
         if node is None:
             node = get_node()
-        if len(cursor.spelling) > 0:
+        name = cursor.spelling
+        if len(name) > 0 and not name.startswith('(unnamed'):
             comment = extract_comment(cursor, deprecations)
             comment = process_comment(comment)
             symbol = Symbol(cursor, name_chain, include, line, comment)


### PR DESCRIPTION
Towards #20339.

This resolves a newly-seen error XCode 15 seen [here](https://drake-cdash.csail.mit.edu/test/1289370145).

I'll use "none" for release notes because we'll wait to announce XCode 15 support concurrently with Sonoma support, once all of the other steps are finished.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20561)
<!-- Reviewable:end -->
