### PR TITLE
[workspace] Avoid installing vestigial drake_visualizer scripts

### DIFF
--- a/tools/workspace/drake_visualizer/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/BUILD.bazel
@@ -69,7 +69,7 @@ install(
         ":install_wrapper_script",
         "//tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts:install",  # noqa
         "@drake_visualizer//:install",
-    ],
+    ] if _DRAKE_VISUALIZER_ENABLED else [],
 )
 
 drake_py_unittest(

--- a/tools/workspace/drake_visualizer/package-stub.BUILD.bazel
+++ b/tools/workspace/drake_visualizer/package-stub.BUILD.bazel
@@ -1,7 +1,6 @@
 # -*- bazel -*-
 
 load("@drake//tools/skylark:py.bzl", "py_library")
-load("@drake//tools/install:install.bzl", "install")
 
 py_library(
     name = "drake_visualizer_python_deps",
@@ -10,10 +9,5 @@ py_library(
 
 filegroup(
     name = "drake_visualizer",
-    visibility = ["//visibility:public"],
-)
-
-install(
-    name = "install",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
These should only be installed when drake_visualizer itself is being installed (i.e., only on Focal).