### PR TITLE
Add per-build bazelrc

### DIFF
--- a/cmake/bazel.rc.in
+++ b/cmake/bazel.rc.in
@@ -45,5 +45,8 @@ build @BAZEL_CONFIG@
 # Respect user.bazelrc (when present).
 try-import @PROJECT_SOURCE_DIR@/user.bazelrc
 
+# Use build-specific bazel options (if present).
+try-import @PROJECT_BINARY_DIR@/drake.bazelrc
+
 # TODO(jwnimmer-tri) Pass along CMAKE_C_FLAGS and CMAKE_CXX_FLAGS also, and
 # specifically make sure the user's -std=c++NN is respected.

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -12,7 +12,7 @@ cd /opt/drake-wheel-build/drake-build
 export BAZELISK_HOME=/var/cache/bazel/bazelisk
 
 # Add wheel-specific bazel options.
-cat > /etc/bazel.bazelrc << EOF
+cat > /opt/drake-wheel-build/drake-build/drake.bazelrc << EOF
 build --disk_cache=/var/cache/bazel/disk_cache
 build --repository_cache=/var/cache/bazel/repository_cache
 build --repo_env=DRAKE_OS=manylinux


### PR DESCRIPTION
Change the CMake-generated bazelrc file to also look for an (optional) per-build bazelrc. This gives users a way to create a bazelrc that only applies to a specific CMake build tree, in addition to the user.bazelrc that applies to the Drake checkout.

Also, change the Linux wheel build to use this rather than the system bazelrc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20566)
<!-- Reviewable:end -->
