### PR TITLE
Use CMake to build macOS wheels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,7 +575,9 @@ foreach(import IN LISTS BAZELRC_IMPORTS)
 endforeach()
 
 # We need to run Bazel in a dedicated temporary directory. The particular
-# name `drake_build_cwd` isn't important, it just needs to be unique.
+# name `drake_build_cwd` isn't important, it just needs to be unique. Note,
+# however, that the macOS wheel builds also need to know this path, so if it
+# ever changes, tools/wheel/macos/build-wheel.sh will also need to be updated.
 configure_file(cmake/bazel.rc.in drake_build_cwd/.bazelrc @ONLY)
 configure_file(cmake/WORKSPACE.in drake_build_cwd/WORKSPACE.bazel @ONLY)
 file(CREATE_LINK "${PROJECT_SOURCE_DIR}/.bazeliskrc" drake_build_cwd/.bazeliskrc SYMBOLIC)

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -76,27 +76,36 @@ fi
 # Build and "install" Drake.
 # -----------------------------------------------------------------------------
 
-cd "$git_root"
+readonly build_root="/opt/drake-wheel-build/drake-build"
 
-export SNOPT_PATH=git
+mkdir -p "$build_root"
+cd "$build_root"
 
-# TODO(jwnimmer-tri) To make it easier to build a macOS wheel for a different
-# Python, we should to switch to using CMake for this step so that we can use
-# use the canonical `-DPython_EXECUTABLE`.
+# Add wheel-specific bazel options.
+cat > "$build_root/drake.bazelrc" << EOF
+build --repo_env=DRAKE_OS=macos_wheel
+build --repo_env=SNOPT_PATH=git
+build --config=packaging
+# See tools/wheel/wheel_builder/macos.py for more on this env variable.
+build --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
+EOF
 
-declare -a bazel_args=(
-    --repo_env=DRAKE_OS=macos_wheel
-    --define=NO_DRAKE_VISUALIZER=ON
-    --define=WITH_MOSEK=ON
-    --define=WITH_SNOPT=ON
-    # See tools/wheel/wheel_builder/macos.py for more on this env variable.
-    --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
-)
+# Install Drake.
+cmake "$git_root" \
+    -DCMAKE_INSTALL_PREFIX=/opt/drake
+make install
 
-bazel build "${bazel_args[@]}" //tools/wheel:strip_rpath
-bazel build "${bazel_args[@]}" //tools/wheel:change_lpath
+# Build wheel tools.
+cd "$build_root/drake_build_cwd"
 
-bazel run "${bazel_args[@]}" //:install -- /opt/drake
+bazel build //tools/wheel:strip_rpath
+bazel build //tools/wheel:change_lpath
+
+ln -s "$(bazel info bazel-bin)" "$build_root"/bazel-bin
+
+# Ensure that the user (or build script) will be able to delete the build tree
+# later.
+find "$build_root" -type d -print0 | xargs -0 chmod u+w
 
 # -----------------------------------------------------------------------------
 # Set up a Python virtual environment with the latest setuptools.
@@ -116,11 +125,11 @@ pip install --upgrade \
     wheel
 
 ln -s \
-    "$git_root/bazel-bin/tools/wheel/strip_rpath" \
+    "$build_root/bazel-bin/tools/wheel/strip_rpath" \
     "/opt/drake-wheel-build/python/bin/strip_rpath"
 
 ln -s \
-    "$git_root/bazel-bin/tools/wheel/change_lpath" \
+    "$build_root/bazel-bin/tools/wheel/change_lpath" \
     "/opt/drake-wheel-build/python/bin/change_lpath"
 
 # -----------------------------------------------------------------------------

--- a/tools/wheel/wheel_builder/common.py
+++ b/tools/wheel/wheel_builder/common.py
@@ -111,11 +111,6 @@ def do_main(args, platform):
     parser.add_argument(
         '--no-test', dest='test', action='store_false',
         help='build images but do not run tests')
-    # TODO(jwnimmer-tri) Remove this argument after we've updated CI not to
-    # provide it anymore.
-    parser.add_argument(
-        '-t', dest='_', action='store_true',
-        help='ignored for backwards compatibility')
 
     if platform is not None:
         platform.add_build_arguments(parser)

--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -77,7 +77,8 @@ def build(options):
     if options.extract:
         _assert_isdir(options.output_dir, 'Output location')
 
-    _provision()
+    if options.provision:
+        _provision()
 
     # Sanitize the build/test environment.
     environment = os.environ.copy()
@@ -101,7 +102,7 @@ def build(options):
     # Build the wheel.
     build_script = os.path.join(resource_root, 'macos', 'build-wheel.sh')
     build_command = ['bash', build_script]
-    if options.incremental:
+    if not options.dependencies:
         build_command.append('--no-deps')
     build_command.append(options.version)
 
@@ -133,8 +134,12 @@ def add_build_arguments(parser):
         help='do not delete build/test trees on success '
              '(tree(s) are always retained on failure)')
     parser.add_argument(
-        '--incremental', action='store_true',
-        help='only build Drake itself '
+        '--no-provision', dest='provision', action='store_false',
+        help='skip host provisioning '
+             '(requires already-povisioned host)')
+    parser.add_argument(
+        '--no-dependencies', dest='dependencies', action='store_false',
+        help='skip building dependencies '
              '(requires previously built dependencies)')
 
 


### PR DESCRIPTION
Change the macOS wheel builder to use the CMake front-end to build Drake.

Also, clean up the wheel builder script a bit, removing a deprecated and unneeded option, and adding an option to skip provisioning on macOS. (The latter is needed to build as a user that doesn't own the homebrew installation.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20570)
<!-- Reviewable:end -->
