### PR TITLE
[workspace] Simplify os_specific_alias_repository logic

### DIFF
--- a/tools/workspace/blas/repository.bzl
+++ b/tools/workspace/blas/repository.bzl
@@ -15,8 +15,7 @@ def blas_repository(name):
     os_specific_alias_repository(
         name = name,
         mapping = {
-            "macOS default": ["blas=@openblas"],
-            "Ubuntu default": ["blas=@libblas"],
-            "manylinux": ["blas=@libblas"],
+            "linux": ["blas=@libblas"],
+            "osx": ["blas=@openblas"],
         },
     )

--- a/tools/workspace/ipopt/repository.bzl
+++ b/tools/workspace/ipopt/repository.bzl
@@ -5,13 +5,13 @@ def ipopt_repository(name):
     os_specific_alias_repository(
         name = name,
         mapping = {
-            "macOS default": [
-                "ipopt=@ipopt_internal_pkgconfig//:ipopt_internal_pkgconfig",
-                "install=@ipopt_internal_pkgconfig//:install",
-            ],
-            "Ubuntu default": [
+            "linux": [
                 "ipopt=@ipopt_internal_fromsource//:ipopt",
                 "install=@ipopt_internal_fromsource//:install",
+            ],
+            "osx": [
+                "ipopt=@ipopt_internal_pkgconfig//:ipopt_internal_pkgconfig",
+                "install=@ipopt_internal_pkgconfig//:install",
             ],
         },
     )

--- a/tools/workspace/lapack/repository.bzl
+++ b/tools/workspace/lapack/repository.bzl
@@ -7,7 +7,7 @@ load("//tools/workspace:os.bzl", "os_specific_alias_repository")
 # from (potentially) different vendors depending on the operating system, this
 # alias exists to select the correct operating-system-specific LAPACK
 # implementation. On macOS, the @lapack and @openblas targets will always refer
-# to OpenBLAS. On Ubuntu, the @lapack and @liblapack targets will depend on a
+# to OpenBLAS. On Linux, the @lapack and @liblapack targets will depend on a
 # LAPACK implementation typically chosen by the Ubuntu alternatives system,
 # such as the reference implementation from Netlib, Automatically Tuned Linear
 # Algebra Software (ATLAS), and OpenBLAS.
@@ -15,8 +15,7 @@ def lapack_repository(name):
     os_specific_alias_repository(
         name = name,
         mapping = {
-            "macOS default": ["lapack=@openblas"],
-            "Ubuntu default": ["lapack=@liblapack"],
-            "manylinux": ["lapack=@liblapack"],
+            "linux": ["lapack=@liblapack"],
+            "osx": ["lapack=@openblas"],
         },
     )

--- a/tools/workspace/os.bzl
+++ b/tools/workspace/os.bzl
@@ -251,44 +251,18 @@ def os_specific_alias(repository_ctx, mapping):
 
     Argument:
         repository_ctx: The context passed to the repository_rule calling this.
-        mapping: dict(str, list(str)) where the keys match the OS, and the list
-            of values are of the form name=actual as in alias(name, actual).
-
-    The keys of mapping are searched in the following preferential order:
-    - Exact release, via e.g., "Ubuntu 20.04" or "macOS 11"
-    - Any release, via "Ubuntu default" or "macOS default"
-    - Anything else, via "default"
+        mapping: dict(str, list(str)) where the keys match the OS (which must
+            be either "linux" or "osx", and the list of values are of the form
+            name=actual as in alias(name, actual).
     """
 
-    os_result = determine_os(repository_ctx)
-    if os_result.error != None:
-        fail(os_result.error)
+    key = repository_ctx.os.name
+    if key == "mac os x":
+        key = "osx"
 
-    # Find the best match in the mapping dict for our OS.
-    keys = []
-    if os_result.ubuntu_release:
-        keys = [
-            "Ubuntu " + os_result.ubuntu_release,
-            "Ubuntu default",
-            "default",
-        ]
-    elif os_result.macos_release:
-        keys = [
-            "macOS " + os_result.macos_release,
-            "macOS default",
-            "default",
-        ]
-    elif os_result.is_manylinux:
-        keys = [
-            "manylinux",
-        ]
-    found_items = None
-    for key in keys:
-        if key in mapping:
-            found_items = mapping[key]
-            break
-    if not found_items:
-        fail("Unsupported os_result " + repr(os_result))
+    if key not in mapping:
+        fail("Unsupported os.name " + key)
+    items = mapping[key]
 
     # Emit the list of aliases.
     file_content = """\
@@ -297,7 +271,7 @@ def os_specific_alias(repository_ctx, mapping):
 package(default_visibility = ["//visibility:public"])
 """
 
-    for item in found_items:
+    for item in items:
         name, actual = item.split("=")
         file_content += 'alias(name = "{}", actual = "{}")\n'.format(
             name,


### PR DESCRIPTION
The aliases need not deal with specific version numbers; the only necessary condition is linux vs osx, which we can look up without relying on the more brittle os.bzl logic.

Towards #14967.