### PR TITLE
Minor style fixup in cartpole DrakeGymEnv example.

### DIFF
--- a/bindings/pydrake/examples/gym/envs/cart_pole.py
+++ b/bindings/pydrake/examples/gym/envs/cart_pole.py
@@ -194,13 +194,13 @@ def make_sim(meshcat=None,
             ), False)
         depth_camera = DepthRenderCamera(color_camera.core(),
                                          DepthRange(0.01, 10.0))
-        parent_id = plant.GetBodyFrameIdIfExists(plant.world_body().index())
         X_PB = RigidTransform(RollPitchYaw(-np.pi/2, 0, 0),
                               np.array([0, -2.5, 0.4]))
-        rgbd_camera = builder.AddSystem(RgbdSensor(parent_id=parent_id,
-                                                   X_PB=X_PB,
-                                                   color_camera=color_camera,
-                                                   depth_camera=depth_camera))
+        rgbd_camera = builder.AddSystem(
+            RgbdSensor(parent_id=scene_graph.world_frame_id(),
+                       X_PB=X_PB,
+                       color_camera=color_camera,
+                       depth_camera=depth_camera))
         builder.Connect(scene_graph.get_query_output_port(),
                         rgbd_camera.query_object_input_port())
         builder.ExportOutput(


### PR DESCRIPTION
Use the much more direct way to get the SceneGraph world frame id, since many people might copy from this example.

+@JoseBarreiros-TRI for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20580)
<!-- Reviewable:end -->
