### PR TITLE
Adds methods for enforcing that a principal submatrix of a symmetric matrix be positive semidefinite

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1131,19 +1131,16 @@ void BindMathematicalProgram(py::module m) {
             return self->AddPrincipalSubmatrixIsPsdConstraint(
                 vars, minor_indices);
           },
-          doc.MathematicalProgram
-              .AddPrincipalSubmatrixIsPsdConstraint
+          doc.MathematicalProgram.AddPrincipalSubmatrixIsPsdConstraint
               .doc_2args_symmetric_matrix_var_minor_indices)
       .def(
           "AddPrincipalSubmatrixIsPsdConstraint",
           [](MathematicalProgram* self,
               const Eigen::Ref<const MatrixX<Expression>>& e,
               std::set<int> minor_indices) {
-            return self->AddPrincipalSubmatrixIsPsdConstraint(
-                e, minor_indices);
+            return self->AddPrincipalSubmatrixIsPsdConstraint(e, minor_indices);
           },
-          doc.MathematicalProgram
-              .AddPrincipalSubmatrixIsPsdConstraint
+          doc.MathematicalProgram.AddPrincipalSubmatrixIsPsdConstraint
               .doc_2args_e_minor_indices)
       .def(
           "AddLinearMatrixInequalityConstraint",

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1124,26 +1124,26 @@ void BindMathematicalProgram(py::module m) {
           },
           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args_e)
       .def(
-          "AddPrincipleMinorIsPositiveSemidefiniteConstraint",
+          "AddPrincipalMinorIsPositiveSemidefiniteConstraint",
           [](MathematicalProgram* self,
               const Eigen::Ref<const MatrixXDecisionVariable>& vars,
               std::set<int> minor_indices) {
-            return self->AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+            return self->AddPrincipalMinorIsPositiveSemidefiniteConstraint(
                 vars, minor_indices);
           },
           doc.MathematicalProgram
-              .AddPrincipleMinorIsPositiveSemidefiniteConstraint
+              .AddPrincipalMinorIsPositiveSemidefiniteConstraint
               .doc_2args_symmetric_matrix_var_minor_indices)
       .def(
-          "AddPrincipleMinorIsPositiveSemidefiniteConstraint",
+          "AddPrincipalMinorIsPositiveSemidefiniteConstraint",
           [](MathematicalProgram* self,
               const Eigen::Ref<const MatrixX<Expression>>& e,
               std::set<int> minor_indices) {
-            return self->AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+            return self->AddPrincipalMinorIsPositiveSemidefiniteConstraint(
                 e, minor_indices);
           },
           doc.MathematicalProgram
-              .AddPrincipleMinorIsPositiveSemidefiniteConstraint
+              .AddPrincipalMinorIsPositiveSemidefiniteConstraint
               .doc_2args_e_minor_indices)
       .def(
           "AddLinearMatrixInequalityConstraint",

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1124,26 +1124,26 @@ void BindMathematicalProgram(py::module m) {
           },
           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args_e)
       .def(
-          "AddPrincipalMinorIsPositiveSemidefiniteConstraint",
+          "AddPrincipalSubmatrixIsPsdConstraint",
           [](MathematicalProgram* self,
               const Eigen::Ref<const MatrixXDecisionVariable>& vars,
               std::set<int> minor_indices) {
-            return self->AddPrincipalMinorIsPositiveSemidefiniteConstraint(
+            return self->AddPrincipalSubmatrixIsPsdConstraint(
                 vars, minor_indices);
           },
           doc.MathematicalProgram
-              .AddPrincipalMinorIsPositiveSemidefiniteConstraint
+              .AddPrincipalSubmatrixIsPsdConstraint
               .doc_2args_symmetric_matrix_var_minor_indices)
       .def(
-          "AddPrincipalMinorIsPositiveSemidefiniteConstraint",
+          "AddPrincipalSubmatrixIsPsdConstraint",
           [](MathematicalProgram* self,
               const Eigen::Ref<const MatrixX<Expression>>& e,
               std::set<int> minor_indices) {
-            return self->AddPrincipalMinorIsPositiveSemidefiniteConstraint(
+            return self->AddPrincipalSubmatrixIsPsdConstraint(
                 e, minor_indices);
           },
           doc.MathematicalProgram
-              .AddPrincipalMinorIsPositiveSemidefiniteConstraint
+              .AddPrincipalSubmatrixIsPsdConstraint
               .doc_2args_e_minor_indices)
       .def(
           "AddLinearMatrixInequalityConstraint",

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1,5 +1,6 @@
 #include <cstddef>
 #include <memory>
+#include <set>
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
@@ -1122,6 +1123,28 @@ void BindMathematicalProgram(py::module m) {
             return self->AddPositiveSemidefiniteConstraint(e);
           },
           doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args_e)
+      .def(
+          "AddPrincipleMinorIsPositiveSemidefiniteConstraint",
+          [](MathematicalProgram* self,
+              const Eigen::Ref<const MatrixXDecisionVariable>& vars,
+              std::set<int> minor_indices) {
+            return self->AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+                vars, minor_indices);
+          },
+          doc.MathematicalProgram
+              .AddPrincipleMinorIsPositiveSemidefiniteConstraint
+              .doc_2args_symmetric_matrix_var_minor_indices)
+      .def(
+          "AddPrincipleMinorIsPositiveSemidefiniteConstraint",
+          [](MathematicalProgram* self,
+              const Eigen::Ref<const MatrixX<Expression>>& e,
+              std::set<int> minor_indices) {
+            return self->AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+                e, minor_indices);
+          },
+          doc.MathematicalProgram
+              .AddPrincipleMinorIsPositiveSemidefiniteConstraint
+              .doc_2args_e_minor_indices)
       .def(
           "AddLinearMatrixInequalityConstraint",
           [](MathematicalProgram* self,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -543,15 +543,13 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(
             prog.positive_semidefinite_constraints()[0].evaluator().
             matrix_rows(), 3)
-        prog.AddPrincipalMinorIsPositiveSemidefiniteConstraint(S,
-                                                               minor_indices)
+        prog.AddPrincipalSubmatrixIsPsdConstraint(S, minor_indices)
         self.assertEqual(len(prog.positive_semidefinite_constraints()), 2)
         self.assertEqual(
             prog.positive_semidefinite_constraints()[1].evaluator().
             matrix_rows(), 2)
         prog.AddPositiveSemidefiniteConstraint(S+S)
-        prog.AddPrincipalMinorIsPositiveSemidefiniteConstraint(S+S,
-                                                               minor_indices)
+        prog.AddPrincipalSubmatrixIsPsdConstraint(S+S, minor_indices)
         prog.AddPositiveDiagonallyDominantMatrixConstraint(X=S)
         prog.AddPositiveDiagonallyDominantDualConeMatrixConstraint(X=S)
         prog.AddPositiveDiagonallyDominantDualConeMatrixConstraint(X=S+S)

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -538,11 +538,20 @@ class TestMathematicalProgram(unittest.TestCase):
         S = prog.NewSymmetricContinuousVariables(3, "S")
         prog.AddLinearConstraint(S[0, 1] >= 1)
         prog.AddPositiveSemidefiniteConstraint(S)
+        minor_indices = {0, 2}
         self.assertEqual(len(prog.positive_semidefinite_constraints()), 1)
         self.assertEqual(
             prog.positive_semidefinite_constraints()[0].evaluator().
             matrix_rows(), 3)
+        prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(S,
+                                                               minor_indices)
+        self.assertEqual(len(prog.positive_semidefinite_constraints()), 2)
+        self.assertEqual(
+            prog.positive_semidefinite_constraints()[1].evaluator().
+            matrix_rows(), 2)
         prog.AddPositiveSemidefiniteConstraint(S+S)
+        prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(S+S,
+                                                               minor_indices)
         prog.AddPositiveDiagonallyDominantMatrixConstraint(X=S)
         prog.AddPositiveDiagonallyDominantDualConeMatrixConstraint(X=S)
         prog.AddPositiveDiagonallyDominantDualConeMatrixConstraint(X=S+S)

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -543,14 +543,14 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(
             prog.positive_semidefinite_constraints()[0].evaluator().
             matrix_rows(), 3)
-        prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(S,
+        prog.AddPrincipalMinorIsPositiveSemidefiniteConstraint(S,
                                                                minor_indices)
         self.assertEqual(len(prog.positive_semidefinite_constraints()), 2)
         self.assertEqual(
             prog.positive_semidefinite_constraints()[1].evaluator().
             matrix_rows(), 2)
         prog.AddPositiveSemidefiniteConstraint(S+S)
-        prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(S+S,
+        prog.AddPrincipalMinorIsPositiveSemidefiniteConstraint(S+S,
                                                                minor_indices)
         prog.AddPositiveDiagonallyDominantMatrixConstraint(X=S)
         prog.AddPositiveDiagonallyDominantDualConeMatrixConstraint(X=S)

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -1150,7 +1150,7 @@ namespace {
 
 template <typename T>
 MatrixX<T> MakeMinor(const Eigen::Ref<const MatrixX<T>>& mat,
-                     std::set<int> minor_indices) {
+                     const std::set<int>& minor_indices) {
   // In Debug builds, check if the minor_indices are valid.
   if (kDrakeAssertIsArmed) {
     auto elt_is_in_bounds = [&mat](int elt) {
@@ -1180,7 +1180,7 @@ MatrixX<T> MakeMinor(const Eigen::Ref<const MatrixX<T>>& mat,
 Binding<PositiveSemidefiniteConstraint>
 MathematicalProgram::AddPrincipleMinorIsPositiveSemidefiniteConstraint(
     const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var,
-    std::set<int> minor_indices) {
+    const std::set<int>& minor_indices) {
   return AddPositiveSemidefiniteConstraint(
       MakeMinor<symbolic::Variable>(symmetric_matrix_var, minor_indices));
 }
@@ -1188,7 +1188,7 @@ MathematicalProgram::AddPrincipleMinorIsPositiveSemidefiniteConstraint(
 Binding<PositiveSemidefiniteConstraint>
 MathematicalProgram::AddPrincipleMinorIsPositiveSemidefiniteConstraint(
     const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
-    std::set<int> minor_indices) {
+    const std::set<int>& minor_indices) {
   return AddPositiveSemidefiniteConstraint(
       MakeMinor<symbolic::Expression>(e, minor_indices));
 }

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -1150,15 +1150,16 @@ namespace {
 
 template <typename T>
 MatrixX<T> MakeMinor(const Eigen::Ref<const MatrixX<T>>& mat,
-            std::set<int> minor_indices) {
-  DRAKE_ASSERT(
-      std::all_of(minor_indices.begin(), minor_indices.end(), [](int elt) {
-        return elt >= 0;
-      }));
-  DRAKE_ASSERT(std::all_of(minor_indices.begin(), minor_indices.end(),
-                           [&mat](int elt) {
-                             return elt < mat.rows();
-                           }));
+                     std::set<int> minor_indices) {
+  // In Debug builds, check if the minor_indices are valid.
+  if (kDrakeAssertIsArmed) {
+    auto elt_is_in_bounds = [&mat](int elt) {
+      return elt >= 0 && elt < mat.rows();
+    };
+    DRAKE_ASSERT(std::all_of(minor_indices.begin(), minor_indices.end(),
+                             elt_is_in_bounds));
+  }
+
   MatrixX<T> minor(minor_indices.size(), minor_indices.size());
   int row_count = 0;
   for (auto row_it = minor_indices.begin(); row_it != minor_indices.cend();

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -1149,9 +1149,9 @@ MathematicalProgram::AddPositiveSemidefiniteConstraint(
 namespace {
 
 template <typename T>
-// Extract the principal submatirx from the ordered set of minor_indices. This
-// method makes no assumptions about the symmetry of the matrix, nor that the
-// matrix is square.
+// Extract the principal submatrix from the ordered set of minor_indices. The
+// minor_indices must be in monotonically increasing order. This method makes no
+// assumptions about the symmetry of the matrix, nor that the matrix is square.
 MatrixX<T> MakePrincipalSubmatrix(const Eigen::Ref<const MatrixX<T>>& mat,
                                   const std::set<int>& minor_indices) {
   // In Debug builds, check if the minor_indices are valid.
@@ -1184,8 +1184,8 @@ Binding<PositiveSemidefiniteConstraint>
 MathematicalProgram::AddPrincipalSubmatrixIsPsdConstraint(
     const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var,
     const std::set<int>& minor_indices) {
-  // The call to AddPositiveSemidefiniteConstraint will throw if
-  // symmetric_matrix_var is not symmetric and we are in debug mode.
+  // This function relies on AddPositiveSemidefiniteConstraint to validate the
+  // documented symmetry prerequisite.
   return AddPositiveSemidefiniteConstraint(
       MakePrincipalSubmatrix<symbolic::Variable>(symmetric_matrix_var,
                                                  minor_indices));
@@ -1195,8 +1195,8 @@ Binding<PositiveSemidefiniteConstraint>
 MathematicalProgram::AddPrincipalSubmatrixIsPsdConstraint(
     const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
     const std::set<int>& minor_indices) {
-  // The call to AddPositiveSemidefiniteConstraint will throw if
-  // symmetric_matrix_var is not symmetric and we are in debug mode.
+  // This function relies on AddPositiveSemidefiniteConstraint to validate the
+  // documented symmetry prerequisite.
   return AddPositiveSemidefiniteConstraint(
       MakePrincipalSubmatrix<symbolic::Expression>(e, minor_indices));
 }

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -1152,6 +1152,7 @@ template <typename T>
 // Extract the principal submatrix from the ordered set of minor_indices. The
 // minor_indices must be in monotonically increasing order. This method makes no
 // assumptions about the symmetry of the matrix, nor that the matrix is square.
+// TODO(hongkai.dai)  move this to matrix_utils.h
 MatrixX<T> MakePrincipalSubmatrix(const Eigen::Ref<const MatrixX<T>>& mat,
                                   const std::set<int>& minor_indices) {
   // In Debug builds, check if the minor_indices are valid.

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -1178,7 +1178,7 @@ MatrixX<T> MakeMinor(const Eigen::Ref<const MatrixX<T>>& mat,
 }  // namespace
 
 Binding<PositiveSemidefiniteConstraint>
-MathematicalProgram::AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+MathematicalProgram::AddPrincipalMinorIsPositiveSemidefiniteConstraint(
     const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var,
     const std::set<int>& minor_indices) {
   return AddPositiveSemidefiniteConstraint(
@@ -1186,7 +1186,7 @@ MathematicalProgram::AddPrincipleMinorIsPositiveSemidefiniteConstraint(
 }
 
 Binding<PositiveSemidefiniteConstraint>
-MathematicalProgram::AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+MathematicalProgram::AddPrincipalMinorIsPositiveSemidefiniteConstraint(
     const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
     const std::set<int>& minor_indices) {
   return AddPositiveSemidefiniteConstraint(

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2602,7 +2602,7 @@ class MathematicalProgram {
   Binding<PositiveSemidefiniteConstraint>
   AddPrincipleMinorIsPositiveSemidefiniteConstraint(
       const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var,
-      std::set<int> minor_indices);
+      const std::set<int>& minor_indices);
 
   /**
    * Adds a constraint the that the principle minor of a symmetric matrix of
@@ -2618,7 +2618,7 @@ class MathematicalProgram {
   Binding<PositiveSemidefiniteConstraint>
   AddPrincipleMinorIsPositiveSemidefiniteConstraint(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
-      std::set<int> minor_indices);
+      const std::set<int>& minor_indices);
 
   /**
    * Adds a linear matrix inequality constraint to the program.

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2594,13 +2594,13 @@ class MathematicalProgram {
    * composed of the indices in minor_indices is positive semidefinite.
    *
    * @throws std::exception in Debug mode if @p symmetric_matrix_var is not
-   * symmetric or if minor_indices contains an larger than
+   * symmetric or if minor_indices contains a value larger than or equal to
    * symmetric_matrix_var.rows() or smaller than 0.
    * @param symmetric_matrix_var A symmetric MatrixDecisionVariable object.
    * @see AddPositiveSemidefiniteConstraint.
    */
   Binding<PositiveSemidefiniteConstraint>
-  AddPrincipalMinorIsPositiveSemidefiniteConstraint(
+  AddPrincipalSubmatrixIsPsdConstraint(
       const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var,
       const std::set<int>& minor_indices);
 
@@ -2610,13 +2610,13 @@ class MathematicalProgram {
    * semidefinite.
    *
    * @throws std::exception in Debug mode if @p symmetric_matrix_var is not
-   * symmetric or if minor_indices contains an larger than
+   * symmetric or if minor_indices contains a value larger than or equal to
    * symmetric_matrix_var.rows() or smaller than 0.
    * @param e Imposes constraint "e is positive semidefinite".
    * @see AddPositiveSemidefiniteConstraint.
    */
   Binding<PositiveSemidefiniteConstraint>
-  AddPrincipalMinorIsPositiveSemidefiniteConstraint(
+  AddPrincipalSubmatrixIsPsdConstraint(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
       const std::set<int>& minor_indices);
 

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2590,33 +2590,31 @@ class MathematicalProgram {
   }
 
   /**
-   * Adds a constraint that the principal minor of a symmetric matrix
+   * Adds a constraint that the principal submatrix of a symmetric matrix
    * composed of the indices in minor_indices is positive semidefinite.
    *
-   * @throws std::exception in Debug mode if @p symmetric_matrix_var is not
-   * symmetric or if minor_indices contains a value larger than or equal to
-   * symmetric_matrix_var.rows() or smaller than 0.
+   * @pre The passed @p symmetric_matrix_var is a symmetric matrix.
+   * @pre The pass @p minor_indices contains a value larger than or equal to
+   * symmetric_matrix_var.rows() or smaller than 0.0.
    * @param symmetric_matrix_var A symmetric MatrixDecisionVariable object.
    * @see AddPositiveSemidefiniteConstraint.
    */
-  Binding<PositiveSemidefiniteConstraint>
-  AddPrincipalSubmatrixIsPsdConstraint(
+  Binding<PositiveSemidefiniteConstraint> AddPrincipalSubmatrixIsPsdConstraint(
       const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var,
       const std::set<int>& minor_indices);
 
   /**
-   * Adds a constraint the that the principal minor of a symmetric matrix of
+   * Adds a constraint the that the principal submatrix of a symmetric matrix of
    * expressions composed of the indices in minor_indices is positive
    * semidefinite.
    *
-   * @throws std::exception in Debug mode if @p symmetric_matrix_var is not
-   * symmetric or if minor_indices contains a value larger than or equal to
-   * symmetric_matrix_var.rows() or smaller than 0.
+   * @pre The passed @p symmetric_matrix_var is a symmetric matrix.
+   * @pre The pass @p minor_indices contains a value larger than or equal to
+   * symmetric_matrix_var.rows() or smaller than 0.0.
    * @param e Imposes constraint "e is positive semidefinite".
    * @see AddPositiveSemidefiniteConstraint.
    */
-  Binding<PositiveSemidefiniteConstraint>
-  AddPrincipalSubmatrixIsPsdConstraint(
+  Binding<PositiveSemidefiniteConstraint> AddPrincipalSubmatrixIsPsdConstraint(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
       const std::set<int>& minor_indices);
 

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2590,6 +2590,37 @@ class MathematicalProgram {
   }
 
   /**
+   * Adds a constraint the that the principle minor of a symmetric matrix
+   * composed of the indices in minor_indices is positive semidefinite.
+   *
+   * @throws std::exception in Debug mode if @p symmetric_matrix_var is not
+   * symmetric or if minor_indices contains an larger than
+   * symmetric_matrix_var.rows() or smaller than 0.
+   * @param symmetric_matrix_var A symmetric MatrixDecisionVariable object.
+   * @see AddPositiveSemidefiniteConstraint.
+   */
+  Binding<PositiveSemidefiniteConstraint>
+  AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+      const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var,
+      std::set<int> minor_indices);
+
+  /**
+   * Adds a constraint the that the principle minor of a symmetric matrix of
+   * expressions composed of the indices in minor_indices is positive
+   * semidefinite.
+   *
+   * @throws std::exception in Debug mode if @p symmetric_matrix_var is not
+   * symmetric or if minor_indices contains an larger than
+   * symmetric_matrix_var.rows() or smaller than 0.
+   * @param e Imposes constraint "e is positive semidefinite".
+   * @see AddPositiveSemidefiniteConstraint.
+   */
+  Binding<PositiveSemidefiniteConstraint>
+  AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+      const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
+      std::set<int> minor_indices);
+
+  /**
    * Adds a linear matrix inequality constraint to the program.
    *
    * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2594,8 +2594,8 @@ class MathematicalProgram {
    * composed of the indices in minor_indices is positive semidefinite.
    *
    * @pre The passed @p symmetric_matrix_var is a symmetric matrix.
-   * @pre The pass @p minor_indices contains a value larger than or equal to
-   * symmetric_matrix_var.rows() or smaller than 0.0.
+   * @pre All values in  `minor_indices` lie in the range [0,
+   * symmetric_matrix_var.rows() - 1].
    * @param symmetric_matrix_var A symmetric MatrixDecisionVariable object.
    * @see AddPositiveSemidefiniteConstraint.
    */
@@ -2609,8 +2609,8 @@ class MathematicalProgram {
    * semidefinite.
    *
    * @pre The passed @p symmetric_matrix_var is a symmetric matrix.
-   * @pre The pass @p minor_indices contains a value larger than or equal to
-   * symmetric_matrix_var.rows() or smaller than 0.0.
+   * @pre All values in  `minor_indices` lie in the range [0,
+   * symmetric_matrix_var.rows() - 1].
    * @param e Imposes constraint "e is positive semidefinite".
    * @see AddPositiveSemidefiniteConstraint.
    */

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2590,7 +2590,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Adds a constraint the that the principle minor of a symmetric matrix
+   * Adds a constraint that the principal minor of a symmetric matrix
    * composed of the indices in minor_indices is positive semidefinite.
    *
    * @throws std::exception in Debug mode if @p symmetric_matrix_var is not
@@ -2600,12 +2600,12 @@ class MathematicalProgram {
    * @see AddPositiveSemidefiniteConstraint.
    */
   Binding<PositiveSemidefiniteConstraint>
-  AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+  AddPrincipalMinorIsPositiveSemidefiniteConstraint(
       const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var,
       const std::set<int>& minor_indices);
 
   /**
-   * Adds a constraint the that the principle minor of a symmetric matrix of
+   * Adds a constraint the that the principal minor of a symmetric matrix of
    * expressions composed of the indices in minor_indices is positive
    * semidefinite.
    *
@@ -2616,7 +2616,7 @@ class MathematicalProgram {
    * @see AddPositiveSemidefiniteConstraint.
    */
   Binding<PositiveSemidefiniteConstraint>
-  AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+  AddPrincipalMinorIsPositiveSemidefiniteConstraint(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
       const std::set<int>& minor_indices);
 

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2981,9 +2981,12 @@ GTEST_TEST(TestMathematicalProgram,
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
 
   std::set<int> minor_indices{0, 1, 3};
-  Matrix<symbolic::Variable, 3, 3> minor_manual{{X(0, 0), X(0, 1), X(0, 3)},
-                                                {X(1, 0), X(1, 1), X(1, 3)},
-                                                {X(3, 0), X(3, 1), X(3, 3)}};
+  MatrixXDecisionVariable minor_manual(3,3);
+  // clang-format off
+  minor_manual << X(0, 0), X(0, 1), X(0, 3),
+                  X(1, 0), X(1, 1), X(1, 3),
+                  X(3, 0), X(3, 1), X(3, 3);
+  // clang-format on
 
   auto psd_cnstr =
       prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(X, minor_indices)
@@ -3001,9 +3004,12 @@ GTEST_TEST(TestMathematicalProgram,
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
   std::set<int> minor_indices{0, 1, 3};
-  Matrix<symbolic::Variable, 3, 3> minor_manual{{X(0, 0), X(0, 1), X(0, 3)},
-                                                {X(1, 0), X(1, 1), X(1, 3)},
-                                                {X(3, 0), X(3, 1), X(3, 3)}};
+  MatrixXDecisionVariable minor_manual(3,3);
+  // clang-format off
+  minor_manual << X(0, 0), X(0, 1), X(0, 3),
+                  X(1, 0), X(1, 1), X(1, 3),
+                  X(3, 0), X(3, 1), X(3, 3);
+  // clang-format on
 
   auto psd_cnstr = prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(
                            2 * Matrix4d::Identity() * X, minor_indices)

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3017,8 +3017,9 @@ GTEST_TEST(TestMathematicalProgram,
 
   MathematicalProgram prog_manual;
   prog_manual.AddDecisionVariables(minor_manual);
-  auto psd_cnstr_manual = prog.AddPositiveSemidefiniteConstraint(
-                                  2 * Matrix4d::Identity() * minor_manual)
+  auto psd_cnstr_manual = prog_manual
+                              .AddPositiveSemidefiniteConstraint(
+                                  2 * Matrix3d::Identity() * minor_manual)
                               .evaluator();
   const auto& new_psd_cnstr_manual =
       prog.positive_semidefinite_constraints().back();
@@ -3033,12 +3034,6 @@ GTEST_TEST(TestMathematicalProgram,
   EXPECT_EQ(prog.GetAllConstraints().size(),
             prog_manual.GetAllConstraints().size());
 
-  EXPECT_EQ(prog.linear_equality_constraints()[0].variables(),
-            prog_manual.linear_equality_constraints()[0].variables());
-  //TODO THIS WILL FAIL.
-  EXPECT_TRUE(CompareMatrices(
-      prog.linear_equality_constraints()[0].evaluator()->GetDenseA(),
-      prog_manual.linear_equality_constraints()[0].evaluator()->GetDenseA()));
   EXPECT_TRUE(CompareMatrices(
       prog.linear_equality_constraints()[0].evaluator()->upper_bound(),
       prog_manual.linear_equality_constraints()[0].evaluator()->upper_bound()));

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2975,6 +2975,78 @@ GTEST_TEST(TestMathematicalProgram, AddPositiveSemidefiniteConstraint) {
   CheckAddedSymbolicPositiveSemidefiniteConstraint(&prog, Y);
 }
 
+GTEST_TEST(TestMathematicalProgram,
+           AddPrincipleMinorIsPositiveSemidefiniteConstraintVariable) {
+  MathematicalProgram prog;
+  auto X = prog.NewSymmetricContinuousVariables<4>("X");
+
+  std::set<int> minor_indices{0, 1, 3};
+  MatrixXDecisionVariable minor_manual{{X(0, 0), X(0, 1), X(0, 3)},
+                                       {X(1, 0), X(1, 1), X(1, 3)},
+                                       {X(3, 0), X(3, 1), X(3, 3)}};
+
+  auto psd_cnstr =
+      prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(X, minor_indices)
+          .evaluator();
+  EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(prog.GetAllConstraints().size(), 1);
+  const auto& new_psd_cnstr = prog.positive_semidefinite_constraints().back();
+  EXPECT_EQ(psd_cnstr.get(), new_psd_cnstr.evaluator().get());
+  Eigen::Map<Eigen::Matrix<Variable, 9, 1>> minor_flat(&minor_manual(0, 0));
+  EXPECT_TRUE(CheckStructuralEquality(minor_flat, new_psd_cnstr.variables()));
+}
+
+GTEST_TEST(TestMathematicalProgram,
+           AddPrincipleMinorIsPositiveSemidefiniteConstraintExpression) {
+  MathematicalProgram prog;
+  auto X = prog.NewSymmetricContinuousVariables<4>("X");
+  std::set<int> minor_indices{0, 1, 3};
+  MatrixXDecisionVariable minor_manual{{X(0, 0), X(0, 1), X(0, 3)},
+                                       {X(1, 0), X(1, 1), X(1, 3)},
+                                       {X(3, 0), X(3, 1), X(3, 3)}};
+
+  auto psd_cnstr = prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+                           2 * Matrix4d::Identity() * X, minor_indices)
+                       .evaluator();
+
+  EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(prog.GetAllConstraints().size(), 2);
+
+  const auto& new_psd_cnstr = prog.positive_semidefinite_constraints().back();
+  EXPECT_EQ(psd_cnstr.get(), new_psd_cnstr.evaluator().get());
+
+  MathematicalProgram prog_manual;
+  prog_manual.AddDecisionVariables(minor_manual);
+  auto psd_cnstr_manual = prog.AddPositiveSemidefiniteConstraint(
+                                  2 * Matrix4d::Identity() * minor_manual)
+                              .evaluator();
+  const auto& new_psd_cnstr_manual =
+      prog.positive_semidefinite_constraints().back();
+
+  EXPECT_TRUE(CheckStructuralEquality(new_psd_cnstr_manual.variables(),
+                                      new_psd_cnstr.variables()));
+  EXPECT_EQ(prog.positive_semidefinite_constraints().size(),
+            prog_manual.positive_semidefinite_constraints().size());
+  EXPECT_EQ(prog.linear_equality_constraints().size(),
+            prog_manual.linear_equality_constraints().size());
+  EXPECT_EQ(prog.linear_equality_constraints().size(), 1);
+  EXPECT_EQ(prog.GetAllConstraints().size(),
+            prog_manual.GetAllConstraints().size());
+
+  EXPECT_EQ(prog.linear_equality_constraints()[0].variables(),
+            prog_manual.linear_equality_constraints()[0].variables());
+  //TODO THIS WILL FAIL.
+  EXPECT_TRUE(CompareMatrices(
+      prog.linear_equality_constraints()[0].evaluator()->GetDenseA(),
+      prog_manual.linear_equality_constraints()[0].evaluator()->GetDenseA()));
+  EXPECT_TRUE(CompareMatrices(
+      prog.linear_equality_constraints()[0].evaluator()->upper_bound(),
+      prog_manual.linear_equality_constraints()[0].evaluator()->upper_bound()));
+  EXPECT_TRUE(CompareMatrices(
+      prog.linear_equality_constraints()[0].evaluator()->lower_bound(),
+      prog_manual.linear_equality_constraints()[0].evaluator()->lower_bound()));
+}
+
 GTEST_TEST(TestMathematicalProgram, TestExponentialConeConstraint) {
   MathematicalProgram prog;
   EXPECT_EQ(prog.required_capabilities().count(

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2976,12 +2976,12 @@ GTEST_TEST(TestMathematicalProgram, AddPositiveSemidefiniteConstraint) {
 }
 
 GTEST_TEST(TestMathematicalProgram,
-           AddPrincipleMinorIsPositiveSemidefiniteConstraintVariable) {
+           AddPrincipalMinorIsPositiveSemidefiniteConstraintVariable) {
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
 
   std::set<int> minor_indices{0, 1, 3};
-  MatrixXDecisionVariable minor_manual(3,3);
+  MatrixXDecisionVariable minor_manual(3, 3);
   // clang-format off
   minor_manual << X(0, 0), X(0, 1), X(0, 3),
                   X(1, 0), X(1, 1), X(1, 3),
@@ -2989,7 +2989,7 @@ GTEST_TEST(TestMathematicalProgram,
   // clang-format on
 
   auto psd_cnstr =
-      prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(X, minor_indices)
+      prog.AddPrincipalMinorIsPositiveSemidefiniteConstraint(X, minor_indices)
           .evaluator();
   EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1);
   EXPECT_EQ(prog.GetAllConstraints().size(), 1);
@@ -3000,18 +3000,18 @@ GTEST_TEST(TestMathematicalProgram,
 }
 
 GTEST_TEST(TestMathematicalProgram,
-           AddPrincipleMinorIsPositiveSemidefiniteConstraintExpression) {
+           AddPrincipalMinorIsPositiveSemidefiniteConstraintExpression) {
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
   std::set<int> minor_indices{0, 1, 3};
-  MatrixXDecisionVariable minor_manual(3,3);
+  MatrixXDecisionVariable minor_manual(3, 3);
   // clang-format off
   minor_manual << X(0, 0), X(0, 1), X(0, 3),
                   X(1, 0), X(1, 1), X(1, 3),
                   X(3, 0), X(3, 1), X(3, 3);
   // clang-format on
 
-  auto psd_cnstr = prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(
+  auto psd_cnstr = prog.AddPrincipalMinorIsPositiveSemidefiniteConstraint(
                            2 * Matrix4d::Identity() * X, minor_indices)
                        .evaluator();
 

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2976,7 +2976,7 @@ GTEST_TEST(TestMathematicalProgram, AddPositiveSemidefiniteConstraint) {
 }
 
 GTEST_TEST(TestMathematicalProgram,
-           AddPrincipalMinorIsPositiveSemidefiniteConstraintVariable) {
+           AddPrincipalSubmatrixIsPsdConstraintVariable) {
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
 
@@ -2989,7 +2989,7 @@ GTEST_TEST(TestMathematicalProgram,
   // clang-format on
 
   auto psd_cnstr =
-      prog.AddPrincipalMinorIsPositiveSemidefiniteConstraint(X, minor_indices)
+      prog.AddPrincipalSubmatrixIsPsdConstraint(X, minor_indices)
           .evaluator();
   EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1);
   EXPECT_EQ(prog.GetAllConstraints().size(), 1);
@@ -3000,7 +3000,7 @@ GTEST_TEST(TestMathematicalProgram,
 }
 
 GTEST_TEST(TestMathematicalProgram,
-           AddPrincipalMinorIsPositiveSemidefiniteConstraintExpression) {
+           AddPrincipalSubmatrixIsPsdConstraintExpression) {
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
   std::set<int> minor_indices{0, 1, 3};
@@ -3011,7 +3011,7 @@ GTEST_TEST(TestMathematicalProgram,
                   X(3, 0), X(3, 1), X(3, 3);
   // clang-format on
 
-  auto psd_cnstr = prog.AddPrincipalMinorIsPositiveSemidefiniteConstraint(
+  auto psd_cnstr = prog.AddPrincipalSubmatrixIsPsdConstraint(
                            2 * Matrix4d::Identity() * X, minor_indices)
                        .evaluator();
 

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -2981,9 +2981,9 @@ GTEST_TEST(TestMathematicalProgram,
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
 
   std::set<int> minor_indices{0, 1, 3};
-  MatrixXDecisionVariable minor_manual{{X(0, 0), X(0, 1), X(0, 3)},
-                                       {X(1, 0), X(1, 1), X(1, 3)},
-                                       {X(3, 0), X(3, 1), X(3, 3)}};
+  Matrix<symbolic::Variable, 3, 3> minor_manual{{X(0, 0), X(0, 1), X(0, 3)},
+                                                {X(1, 0), X(1, 1), X(1, 3)},
+                                                {X(3, 0), X(3, 1), X(3, 3)}};
 
   auto psd_cnstr =
       prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(X, minor_indices)
@@ -3001,9 +3001,9 @@ GTEST_TEST(TestMathematicalProgram,
   MathematicalProgram prog;
   auto X = prog.NewSymmetricContinuousVariables<4>("X");
   std::set<int> minor_indices{0, 1, 3};
-  MatrixXDecisionVariable minor_manual{{X(0, 0), X(0, 1), X(0, 3)},
-                                       {X(1, 0), X(1, 1), X(1, 3)},
-                                       {X(3, 0), X(3, 1), X(3, 3)}};
+  Matrix<symbolic::Variable, 3, 3> minor_manual{{X(0, 0), X(0, 1), X(0, 3)},
+                                                {X(1, 0), X(1, 1), X(1, 3)},
+                                                {X(3, 0), X(3, 1), X(3, 3)}};
 
   auto psd_cnstr = prog.AddPrincipleMinorIsPositiveSemidefiniteConstraint(
                            2 * Matrix4d::Identity() * X, minor_indices)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20586)
<!-- Reviewable:end -->
