### PR TITLE
Refactor macOS wheel build

### DIFF
--- a/tools/wheel/macos/build-dependencies.sh
+++ b/tools/wheel/macos/build-dependencies.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Internal script to build dependencies for a macOS Drake wheel. This is a
+# wrapper over the generic script that performs additional environment
+# preparation.
+
+set -eu -o pipefail
+
+readonly resource_root="$(
+    cd "$(dirname "${BASH_SOURCE}")" && \
+    realpath ..
+)"
+
+# Ensure nothing is left from previous builds.
+rm -rf /opt/drake-dependencies
+
+rm -rf "/opt/drake-wheel-build/dependencies"
+mkdir -p "/opt/drake-wheel-build/dependencies"
+
+# Copy the main script into the correct location and run it.
+cp -R \
+    "$resource_root/image/dependencies" \
+    "/opt/drake-wheel-build/dependencies/src"
+
+"$resource_root/image/build-dependencies.sh"


### PR DESCRIPTION
Rework macOS wheel build script to completely separate provisioning, dependency building, and building of the actual wheel. This more closely aligns with how the builder allows these stages to be skipped, and will also make it easier to build multiple wheels (which can share a dependency build).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20595)
<!-- Reviewable:end -->
