### PR TITLE
[visualization] ConcatenateImages allows for variable size inputs

### DIFF
--- a/visualization/concatenate_images.h
+++ b/visualization/concatenate_images.h
@@ -20,10 +20,13 @@ output_ports:
 - color_image
 @endsystem
 
-As currently implemented, all inputs must be of type ImageRgba8U, must have
-identical width and height, and all ports must be connected (i.e., with no gaps
-in the grid of rows x cols). Any of those conditions could be generalized as
-future work.
+All inputs must be of type ImageRgba8U.
+
+Any input port may be disconnected, in which case it will be interpreted as
+zero-sized image.
+
+In case of non-uniform image sizes, any gaps between images will be filled with
+all-zero pixels (i.e., with 0% alpha).
 
 @tparam_double_only
 @ingroup visualization */

--- a/visualization/test/concatenate_images_test.cc
+++ b/visualization/test/concatenate_images_test.cc
@@ -4,6 +4,17 @@
 
 #include "drake/systems/sensors/test_utilities/image_compare.h"
 
+namespace {
+struct WH {
+  int width{};
+  int height{};
+};
+std::string to_string(const WH& wh) {
+  return fmt::format("{}x{}", wh.width, wh.height);
+}
+}  // namespace
+DRAKE_FORMATTER_AS(, , WH, x, to_string(x));
+
 namespace drake {
 namespace visualization {
 namespace {
@@ -45,6 +56,152 @@ GTEST_TEST(ConcatenateImagesTest, Basic) {
   expected.at(0, 2)[3] = 255;
   expected.at(4, 2)[3] = 255;
   expected.at(8, 2)[3] = 255;
+  const auto& actual =
+      dut.GetOutputPort("color_image").template Eval<ImageRgba8U>(*context);
+  EXPECT_EQ(actual, expected);
+}
+
+// Checks the output width and height for various input image sizes.
+GTEST_TEST(ConcatenateImagesTest, TilingSize) {
+  // Prepare the suite of tests.
+  using InputSizes = MatrixX<WH>;
+  struct TestCase {
+    InputSizes input_sizes;
+    WH expected_output_size;
+  };
+  // clang-format off
+  std::vector<TestCase> test_cases{
+      // All input images are zero size.
+      TestCase{.input_sizes = (InputSizes(1, 1) <<
+                   WH{0, 0}
+               ).finished(), .expected_output_size = {0, 0}},  // NOLINT
+      TestCase{.input_sizes = (InputSizes(3, 2) <<
+                   WH{0, 0}, WH{0, 0}, WH{0, 0},
+                   WH{0, 0}, WH{0, 0}, WH{0, 0}
+               ).finished(), .expected_output_size = {0, 0}},  // NOLINT
+      // All input images are a uniform non-zero size.
+      TestCase{.input_sizes = (InputSizes(1, 1) <<
+                   WH{4, 2}
+               ).finished(), .expected_output_size = {4, 2}},  // NOLINT
+      TestCase{.input_sizes = (InputSizes(1, 3) <<
+                   WH{4, 2}, WH{4, 2}, WH{4, 2}
+               ).finished(), .expected_output_size = {12, 2}},  // NOLINT
+      TestCase{.input_sizes = (InputSizes(3, 1) <<
+                   WH{4, 2},
+                   WH{4, 2},
+                   WH{4, 2}
+               ).finished(), .expected_output_size = {4, 6}},  // NOLINT
+      TestCase{.input_sizes = (InputSizes(3, 2) <<
+                   WH{4, 2}, WH{4, 2},
+                   WH{4, 2}, WH{4, 2},
+                   WH{4, 2}, WH{4, 2}
+               ).finished(), .expected_output_size = {8, 6}},  // NOLINT
+      // Some input images are empty; the larger images still dictate the size.
+      TestCase{.input_sizes = (InputSizes(3, 2) <<
+                   WH{4, 2}, WH{0, 0},
+                   WH{4, 2}, WH{0, 0},
+                   WH{0, 0}, WH{4, 2}
+               ).finished(), .expected_output_size = {8, 6}},  // NOLINT
+      // When a whole row is missing, it does not claim any space in the output.
+      TestCase{.input_sizes = (InputSizes(3, 2) <<
+                   WH{4, 2}, WH{0, 0},
+                   WH{0, 0}, WH{0, 0},
+                   WH{0, 0}, WH{4, 2}
+               ).finished(), .expected_output_size = {8, 4}},  // NOLINT
+      // When a whole col is missing, it does not claim any space in the output.
+      TestCase{.input_sizes = (InputSizes(3, 2) <<
+                   WH{4, 2}, WH{0, 0},
+                   WH{4, 2}, WH{0, 0},
+                   WH{4, 2}, WH{0, 0}
+               ).finished(), .expected_output_size = {4, 6}},  // NOLINT
+  };
+  // clang-format on
+
+  // Run the test cases one at a time.
+  for (const TestCase& test : test_cases) {
+    SCOPED_TRACE(fmt::format("input_sizes =\n{}", fmt_eigen(test.input_sizes)));
+    const int rows = test.input_sizes.rows();
+    const int cols = test.input_sizes.cols();
+    const ConcatenateImages<double> dut(rows, cols);
+    auto context = dut.CreateDefaultContext();
+    for (int row = 0; row < rows; ++row) {
+      for (int col = 0; col < cols; ++col) {
+        const WH& wh = test.input_sizes(row, col);
+        const ImageRgba8U image(wh.width, wh.height);
+        dut.get_input_port(row, col).FixValue(context.get(), image);
+      }
+    }
+    const auto& output =
+        dut.GetOutputPort("color_image").template Eval<ImageRgba8U>(*context);
+    EXPECT_EQ(output.width(), test.expected_output_size.width);
+    EXPECT_EQ(output.height(), test.expected_output_size.height);
+  }
+}
+
+// Spot-checks the actual rgb data during non-uniform tiling.
+GTEST_TEST(ConcatenateImagesTest, TilingData) {
+  // We use three distinct input images:
+  //
+  //   red: 1w x 1h image filled with all-red pixels
+  // green: 2w x 1h image filled with all-green pixels
+  //  blue: 1w x 2h image filled with all-blue pixels
+  //
+  // We'll tile them into 2 rows and 3 cols as follows:
+  //
+  //  red  green blue
+  //  blue red   green
+  //
+  // Thus, the output image should be as follows (using 'z' for zero padding):
+  //
+  //  R G G B z
+  //  z z z B z
+  //  B R z G G
+  //  B z z z z
+
+  // Prepare the inputs.
+  auto set_to_red = [](uint8_t* pixel) {
+    pixel[0] = 30;
+    pixel[3] = 255;
+  };
+  auto set_to_green = [](uint8_t* pixel) {
+    pixel[1] = 60;
+    pixel[3] = 255;
+  };
+  auto set_to_blue = [](uint8_t* pixel) {
+    pixel[2] = 90;
+    pixel[3] = 255;
+  };
+  ImageRgba8U red(1, 1);
+  set_to_red(red.at(0, 0));
+  ImageRgba8U green(2, 1);
+  set_to_green(green.at(0, 0));
+  set_to_green(green.at(1, 0));
+  ImageRgba8U blue(1, 2);
+  set_to_blue(blue.at(0, 0));
+  set_to_blue(blue.at(0, 1));
+
+  // Prepare the expected output:
+  ImageRgba8U expected(5, 4);
+  set_to_red(expected.at(0, 0));
+  set_to_red(expected.at(1, 2));
+  set_to_green(expected.at(1, 0));
+  set_to_green(expected.at(2, 0));
+  set_to_green(expected.at(3, 2));
+  set_to_green(expected.at(4, 2));
+  set_to_blue(expected.at(3, 0));
+  set_to_blue(expected.at(3, 1));
+  set_to_blue(expected.at(0, 2));
+  set_to_blue(expected.at(0, 3));
+
+  // Compute the actual output.
+  const ConcatenateImages<double> dut(2, 3);
+  auto context = dut.CreateDefaultContext();
+  dut.get_input_port(0, 0).FixValue(context.get(), red);
+  dut.get_input_port(0, 1).FixValue(context.get(), green);
+  dut.get_input_port(0, 2).FixValue(context.get(), blue);
+  dut.get_input_port(1, 0).FixValue(context.get(), blue);
+  dut.get_input_port(1, 1).FixValue(context.get(), red);
+  dut.get_input_port(1, 2).FixValue(context.get(), green);
   const auto& actual =
       dut.GetOutputPort("color_image").template Eval<ImageRgba8U>(*context);
   EXPECT_EQ(actual, expected);


### PR DESCRIPTION
Towards #18862.  When displaying image array messages received over LCM, we have no way enforce that the sizes will be uniform, so instead we'll need to pad them out to tile correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20599)
<!-- Reviewable:end -->
