### PR TITLE
[multibody] Replace BodyNodeIndex with MobodIndex

### DIFF
--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1062,7 +1062,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("mutable_generalized_forces", &Class::mutable_generalized_forces,
             py_rvp::reference_internal, cls_doc.mutable_generalized_forces.doc)
         // WARNING: Do not bind `body_forces` or `mutable_body_forces` because
-        // they use `internal::BodyNodeIndex`. Instead, use force API in Body.
+        // they use `internal::MobodIndex`. Instead, use force API in Body.
         .def("AddInForces", &Class::AddInForces, py::arg("addend"),
             cls_doc.AddInForces.doc);
     DefCopyAndDeepCopy(&cls);

--- a/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
+++ b/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
@@ -148,18 +148,18 @@ class DrakeKukaIIwaRobot {
 
     // Retrieve end-effector pose from position kinematics cache.
     tree().CalcPositionKinematicsCache(*context_, &pc);
-    const math::RigidTransform<T>& X_NG = pc.get_X_WB(linkG_->node_index());
+    const math::RigidTransform<T>& X_NG = pc.get_X_WB(linkG_->mobod_index());
 
     // Retrieve end-effector spatial velocity from velocity kinematics cache.
     tree().CalcVelocityKinematicsCache(*context_, pc, &vc);
-    const SpatialVelocity<T>& V_NG_N = vc.get_V_WB(linkG_->node_index());
+    const SpatialVelocity<T>& V_NG_N = vc.get_V_WB(linkG_->mobod_index());
 
     // Retrieve end-effector spatial acceleration from acceleration cache.
     std::vector<SpatialAcceleration<T>> A_WB(tree().num_bodies());
     // TODO(eric.cousineau): For this model, the end effector's BodyIndex
-    // matches its BodyNodeIndex, thus we're not really checking the difference
+    // matches its MobodIndex, thus we're not really checking the difference
     // between MultibodyPlant and MultibodyTree's ordering.
-    DRAKE_DEMAND(int{linkG_->index()} == int{linkG_->node_index()});
+    DRAKE_DEMAND(int{linkG_->index()} == int{linkG_->mobod_index()});
     plant().CalcSpatialAccelerationsFromVdot(*context_, qDDt, &A_WB);
     const SpatialAcceleration<T>& A_NG_N = A_WB[linkG_->index()];
 
@@ -231,13 +231,13 @@ class DrakeKukaIIwaRobot {
 
     // Put joint reaction forces into return struct.
     KukaRobotJointReactionForces<T> reaction_forces;
-    reaction_forces.F_Ao_W = F_BMo_W_array[linkA_->node_index()];
-    reaction_forces.F_Bo_W = F_BMo_W_array[linkB_->node_index()];
-    reaction_forces.F_Co_W = F_BMo_W_array[linkC_->node_index()];
-    reaction_forces.F_Do_W = F_BMo_W_array[linkD_->node_index()];
-    reaction_forces.F_Eo_W = F_BMo_W_array[linkE_->node_index()];
-    reaction_forces.F_Fo_W = F_BMo_W_array[linkF_->node_index()];
-    reaction_forces.F_Go_W = F_BMo_W_array[linkG_->node_index()];
+    reaction_forces.F_Ao_W = F_BMo_W_array[linkA_->mobod_index()];
+    reaction_forces.F_Bo_W = F_BMo_W_array[linkB_->mobod_index()];
+    reaction_forces.F_Co_W = F_BMo_W_array[linkC_->mobod_index()];
+    reaction_forces.F_Do_W = F_BMo_W_array[linkD_->mobod_index()];
+    reaction_forces.F_Eo_W = F_BMo_W_array[linkE_->mobod_index()];
+    reaction_forces.F_Fo_W = F_BMo_W_array[linkF_->mobod_index()];
+    reaction_forces.F_Go_W = F_BMo_W_array[linkG_->mobod_index()];
     return reaction_forces;
   }
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1004,17 +1004,17 @@ void MultibodyPlant<T>::CalcSpatialAccelerationsFromVdot(
   internal_tree().CalcSpatialAccelerationsFromVdot(
       context, internal_tree().EvalPositionKinematics(context),
       internal_tree().EvalVelocityKinematics(context), known_vdot, A_WB_array);
-  // Permute BodyNodeIndex -> BodyIndex.
+  // Permute MobodIndex -> BodyIndex.
   // TODO(eric.cousineau): Remove dynamic allocations. Making this in-place
-  // still required dynamic allocation for recording permutation indices.
-  // Can change implementation once MultibodyTree becomes fully internal.
-  std::vector<SpatialAcceleration<T>> A_WB_array_node = *A_WB_array;
+  //  still required dynamic allocation for recording permutation indices.
+  //  Can change implementation once MultibodyTree becomes fully internal.
+  std::vector<SpatialAcceleration<T>> A_WB_array_mobod = *A_WB_array;
   const internal::MultibodyTreeTopology& topology =
       internal_tree().get_topology();
-  for (internal::BodyNodeIndex node_index(1);
-       node_index < topology.get_num_body_nodes(); ++node_index) {
-    const BodyIndex body_index = topology.get_body_node(node_index).body;
-    (*A_WB_array)[body_index] = A_WB_array_node[node_index];
+  for (internal::MobodIndex mobod_index(1); mobod_index < topology.num_mobods();
+       ++mobod_index) {
+    const BodyIndex body_index = topology.get_body_node(mobod_index).body;
+    (*A_WB_array)[body_index] = A_WB_array_mobod[mobod_index];
   }
 }
 
@@ -1889,10 +1889,10 @@ void MultibodyPlant<T>::AppendContactResultsContinuousPointPair(
     const BodyIndex bodyA_index = FindBodyByGeometryId(geometryA_id);
     const BodyIndex bodyB_index = FindBodyByGeometryId(geometryB_id);
 
-    internal::BodyNodeIndex bodyA_node_index =
-        get_body(bodyA_index).node_index();
-    internal::BodyNodeIndex bodyB_node_index =
-        get_body(bodyB_index).node_index();
+    internal::MobodIndex bodyA_mobod_index =
+        get_body(bodyA_index).mobod_index();
+    internal::MobodIndex bodyB_mobod_index =
+        get_body(bodyB_index).mobod_index();
 
     // Penetration depth, > 0 during pair.
     const T& x = pair.depth;
@@ -1905,18 +1905,18 @@ void MultibodyPlant<T>::AppendContactResultsContinuousPointPair(
     const Vector3<T> p_WC = 0.5 * (p_WCa + p_WCb);
 
     // Contact point position on body A.
-    const Vector3<T>& p_WAo = pc.get_X_WB(bodyA_node_index).translation();
+    const Vector3<T>& p_WAo = pc.get_X_WB(bodyA_mobod_index).translation();
     const Vector3<T>& p_CoAo_W = p_WAo - p_WC;
 
     // Contact point position on body B.
-    const Vector3<T>& p_WBo = pc.get_X_WB(bodyB_node_index).translation();
+    const Vector3<T>& p_WBo = pc.get_X_WB(bodyB_mobod_index).translation();
     const Vector3<T>& p_CoBo_W = p_WBo - p_WC;
 
     // Separation velocity, > 0  if objects separate.
     const Vector3<T> v_WAc =
-        vc.get_V_WB(bodyA_node_index).Shift(-p_CoAo_W).translational();
+        vc.get_V_WB(bodyA_mobod_index).Shift(-p_CoAo_W).translational();
     const Vector3<T> v_WBc =
-        vc.get_V_WB(bodyB_node_index).Shift(-p_CoBo_W).translational();
+        vc.get_V_WB(bodyB_mobod_index).Shift(-p_CoBo_W).translational();
     const Vector3<T> v_AcBc_W = v_WBc - v_WAc;
 
     // if xdot = vn > 0 ==> they are getting closer.
@@ -2002,20 +2002,20 @@ void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
     const BodyIndex bodyA_index = FindBodyByGeometryId(geometryA_id);
     const BodyIndex bodyB_index = FindBodyByGeometryId(geometryB_id);
 
-    internal::BodyNodeIndex bodyA_node_index =
-        get_body(bodyA_index).node_index();
-    internal::BodyNodeIndex bodyB_node_index =
-        get_body(bodyB_index).node_index();
+    const internal::MobodIndex bodyA_mobod_index =
+        get_body(bodyA_index).mobod_index();
+    const internal::MobodIndex bodyB_mobod_index =
+        get_body(bodyB_index).mobod_index();
 
     // Contact point C.
     const Vector3<T> p_WC = contact_info.contact_point();
 
     // Contact point position on body A.
-    const Vector3<T>& p_WAo = pc.get_X_WB(bodyA_node_index).translation();
+    const Vector3<T>& p_WAo = pc.get_X_WB(bodyA_mobod_index).translation();
     const Vector3<T>& p_CoAo_W = p_WAo - p_WC;
 
     // Contact point position on body B.
-    const Vector3<T>& p_WBo = pc.get_X_WB(bodyB_node_index).translation();
+    const Vector3<T>& p_WBo = pc.get_X_WB(bodyB_mobod_index).translation();
     const Vector3<T>& p_CoBo_W = p_WBo - p_WC;
 
     const Vector3<T> f_Bc_W = contact_info.contact_force();
@@ -2024,13 +2024,13 @@ void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
     if (bodyA_index != world_index()) {
       // Spatial force on body A at Ao, expressed in W.
       const SpatialForce<T> F_AAo_W = F_AC_W.Shift(p_CoAo_W);
-      F_BBo_W_array->at(bodyA_node_index) += F_AAo_W;
+      F_BBo_W_array->at(bodyA_mobod_index) += F_AAo_W;
     }
 
     if (bodyB_index != world_index()) {
       // Spatial force on body B at Bo, expressed in W.
       const SpatialForce<T> F_BBo_W = -F_AC_W.Shift(p_CoBo_W);
-      F_BBo_W_array->at(bodyB_node_index) += F_BBo_W;
+      F_BBo_W_array->at(bodyB_mobod_index) += F_BBo_W;
     }
   }
 }
@@ -2138,11 +2138,11 @@ void MultibodyPlant<T>::CalcHydroelasticContactForces(
         data, F_Ac_W, &F_Ao_W, &F_Bo_W);
 
     if (bodyA_index != world_index()) {
-      F_BBo_W_array.at(bodyA.node_index()) += F_Ao_W;
+      F_BBo_W_array.at(bodyA.mobod_index()) += F_Ao_W;
     }
 
     if (bodyB_index != world_index()) {
-      F_BBo_W_array.at(bodyB.node_index()) += F_Bo_W;
+      F_BBo_W_array.at(bodyB.mobod_index()) += F_Bo_W;
     }
 
     // Add the information for contact reporting.
@@ -2231,7 +2231,7 @@ void MultibodyPlant<T>::AddAppliedExternalSpatialForces(
     throw_if_contains_nan(force_structure);
     const BodyIndex body_index = force_structure.body_index;
     const Body<T>& body = get_body(body_index);
-    const auto body_node_index = body.node_index();
+    const auto body_mobod_index = body.mobod_index();
 
     // Get the pose for this body in the world frame.
     const RigidTransform<T>& X_WB = EvalBodyPoseInWorld(context, body);
@@ -2241,7 +2241,7 @@ void MultibodyPlant<T>::AddAppliedExternalSpatialForces(
     const Vector3<T> p_BoBq_W = X_WB.rotation() * force_structure.p_BoBq_B;
 
     // Shift the spatial force from Bq to Bo.
-    F_BBo_W_array[body_node_index] += force_structure.F_Bq_W.Shift(-p_BoBq_W);
+    F_BBo_W_array[body_mobod_index] += force_structure.F_Bq_W.Shift(-p_BoBq_W);
   }
 }
 
@@ -2570,7 +2570,7 @@ void MultibodyPlant<T>::CalcGeneralizedContactForcesContinuous(
       EvalSpatialContactForcesContinuous(context);
 
   // Bodies' accelerations and inboard mobilizer reaction forces, respectively,
-  // ordered by BodyNodeIndex and required as output arguments for
+  // ordered by MobodIndex and required as output arguments for
   // CalcInverseDynamics() below but otherwise not used by this method.
   std::vector<SpatialAcceleration<T>> A_WB_array(num_bodies());
   std::vector<SpatialForce<T>> F_BMo_W_array(num_bodies());
@@ -3345,7 +3345,7 @@ void MultibodyPlant<T>::CalcBodySpatialAccelerationsOutput(
   const AccelerationKinematicsCache<T>& ac = this->EvalForwardDynamics(context);
   for (BodyIndex body_index(0); body_index < this->num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
-    A_WB_all->at(body_index) = ac.get_A_WB(body.node_index());
+    A_WB_all->at(body_index) = ac.get_A_WB(body.mobod_index());
   }
 }
 
@@ -3358,7 +3358,7 @@ MultibodyPlant<T>::EvalBodySpatialAccelerationInWorld(
   DRAKE_DEMAND(this == &body_B.GetParentPlant());
   this->ValidateContext(context);
   const AccelerationKinematicsCache<T>& ac = this->EvalForwardDynamics(context);
-  return ac.get_A_WB(body_B.node_index());
+  return ac.get_A_WB(body_B.mobod_index());
 }
 
 template <typename T>
@@ -3383,7 +3383,7 @@ void MultibodyPlant<T>::CalcFramePoseOutput(const Context<T>& context,
     // NOTE: The GeometryFrames for each body were registered in the world
     // frame, so we report poses in the world frame.
     poses->set_value(body_index_to_frame_id_.at(body_index),
-                     pc.get_X_WB(body.node_index()));
+                     pc.get_X_WB(body.mobod_index()));
   }
 }
 
@@ -3446,12 +3446,12 @@ void MultibodyPlant<T>::CalcReactionForces(
         internal_tree().get_joint_mobilizer(joint_index);
     const internal::Mobilizer<T>& mobilizer =
         internal_tree().get_mobilizer(mobilizer_index);
-    const internal::BodyNodeIndex body_node_index =
-        mobilizer.get_topology().body_node;
+    const internal::MobodIndex mobod_index =
+        mobilizer.get_topology().mobod_index;
 
     // Force on mobilized body B at mobilized frame's origin Mo, expressed in
     // world frame.
-    const SpatialForce<T>& F_BMo_W = F_BMo_W_vector[body_node_index];
+    const SpatialForce<T>& F_BMo_W = F_BMo_W_vector[mobod_index];
 
     // Frames:
     const Frame<T>& frame_Jp = joint.frame_on_parent();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -56,7 +56,7 @@ struct HydroelasticContactInfoAndBodySpatialForces {
   }
 
   // Forces from hydroelastic contact applied to the origin of each body
-  // (indexed by BodyNodeIndex) in the MultibodyPlant.
+  // (indexed by MobodIndex) in the MultibodyPlant.
   std::vector<SpatialForce<T>> F_BBo_W_array;
 
   // Information used for contact reporting collected through the evaluation
@@ -5509,7 +5509,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       std::vector<SpatialForce<T>>* F_BBo_W_array) const;
 
   // Helper method to compute contact forces using the hydroelastic model.
-  // F_BBo_W_array is indexed by BodyNodeIndex and it gets overwritten on
+  // F_BBo_W_array is indexed by MobodIndex and it gets overwritten on
   // output. F_BBo_W_array must be of size num_bodies() or an exception is
   // thrown.
   void CalcHydroelasticContactForces(

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -1037,11 +1037,11 @@ void SapDriver<T>::CalcDiscreteUpdateMultibodyForces(
 
   // N.B. The CompliantContactManager indexes constraints objects with body
   // indexes. Therefore using body indices on constraint_spatial_forces is
-  // correct. However MultibodyForce uses BodyNodeIndex, see below.
+  // correct. However MultibodyForce uses MobodIndex, see below.
   for (BodyIndex b(0); b < plant().num_bodies(); ++b) {
-    // MultibodyForce indexes spatial body forces by BodyNodeIndex.
-    const BodyNodeIndex node_index = plant().get_body(b).node_index();
-    spatial_forces[node_index] += constraint_spatial_forces[b];
+    // MultibodyForce indexes spatial body forces by MobodIndex.
+    const MobodIndex mobod_index = plant().get_body(b).mobod_index();
+    spatial_forces[mobod_index] += constraint_spatial_forces[b];
   }
 }
 

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -94,7 +94,7 @@ void TamsiDriver<T>::CalcContactSolverResults(
   plant().CalcMassMatrix(context, &M0);
 
   // Workspace for inverse dynamics:
-  // Bodies' accelerations, ordered by BodyNodeIndex.
+  // Bodies' accelerations, ordered by MobodIndex.
   std::vector<SpatialAcceleration<T>> A_WB_array(plant().num_bodies());
   // Generalized accelerations.
   VectorX<T> vdot = VectorX<T>::Zero(nv);
@@ -332,8 +332,8 @@ void TamsiDriver<T>::CalcAndAddSpatialContactForcesFromContactResults(
     const Vector3<T> p_CB_W = p_WB - p_WC;
     const SpatialForce<T> F_Bo_W = F_Bc_W.Shift(p_CB_W);
 
-    spatial_contact_forces->at(bodyA.node_index()) += F_Ao_W;
-    spatial_contact_forces->at(bodyB.node_index()) += F_Bo_W;
+    spatial_contact_forces->at(bodyA.mobod_index()) += F_Ao_W;
+    spatial_contact_forces->at(bodyB.mobod_index()) += F_Bo_W;
   }
 
   // Add contribution from hydroelastic contact.
@@ -364,8 +364,8 @@ void TamsiDriver<T>::CalcAndAddSpatialContactForcesFromContactResults(
     const Vector3<T> p_CB_W = p_WB - p_WC;
     const SpatialForce<T> F_Bo_W = -F_Ac_W.Shift(p_CB_W);
 
-    spatial_contact_forces->at(bodyA.node_index()) += F_Ao_W;
-    spatial_contact_forces->at(bodyB.node_index()) += F_Bo_W;
+    spatial_contact_forces->at(bodyA.mobod_index()) += F_Ao_W;
+    spatial_contact_forces->at(bodyB.mobod_index()) += F_Bo_W;
   }
 }
 

--- a/multibody/plant/test/energy_and_power_test.cc
+++ b/multibody/plant/test/energy_and_power_test.cc
@@ -73,7 +73,7 @@ class EnergyAndPowerTester : public ::testing::Test {
   const SpatialInertia<double>& get_M_B_W() const {
     const std::vector<SpatialInertia<double>>& M_Bi_W =
         plant_.EvalSpatialInertiaInWorldCache(*context_);
-    return M_Bi_W[body_->node_index()];
+    return M_Bi_W[body_->mobod_index()];
   }
 
   // Return an appropriate tolerance to be used in checking the given quantity.

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -220,7 +220,7 @@ class HydroelasticModelTests : public ::testing::Test {
     const auto& F_BBo_W_array =
         MultibodyPlantTester::EvalHydroelasticContactForces(*plant_,
                                                             plant_context);
-    *F_BBo_W = F_BBo_W_array[body_->node_index()];
+    *F_BBo_W = F_BBo_W_array[body_->mobod_index()];
     *p_WB_W = plant_->GetFreeBodyPose(plant_context, *body_).translation();
   }
 
@@ -259,7 +259,7 @@ TEST_F(HydroelasticModelTests, ContactForce) {
     const auto& F_BBo_W_array =
         MultibodyPlantTester::EvalHydroelasticContactForces(*plant_,
                                                             *plant_context_);
-    const SpatialForce<double>& F_BBo_W = F_BBo_W_array[body_->node_index()];
+    const SpatialForce<double>& F_BBo_W = F_BBo_W_array[body_->mobod_index()];
     return F_BBo_W.translational()[2];  // Normal force.
   };
 
@@ -305,7 +305,7 @@ TEST_F(HydroelasticModelTests, ContactDynamics) {
   const auto& F_BBo_W_array =
       MultibodyPlantTester::EvalHydroelasticContactForces(*plant_,
                                                           *plant_context_);
-  const SpatialForce<double>& F_BBo_W = F_BBo_W_array[body_->node_index()];
+  const SpatialForce<double>& F_BBo_W = F_BBo_W_array[body_->mobod_index()];
   // Contact force by hydroelastics.
   const Vector3<double> fhydro_BBo_W = F_BBo_W.translational();
 
@@ -571,8 +571,8 @@ class ContactModelTest : public ::testing::Test {
   // MultibodyPlant::EvalSpatialContactForcesContinuous() from contact results.
   // EvalSpatialContactForcesContinuous() is an internal private method of
   // MultibodyPlant and, as many other multibody methods, sorts the results in
-  // the returned array of spatial forces by BodyNodeIndex. Therefore, the
-  // expected results being generated must also be sorted by BodyNodeIndex.
+  // the returned array of spatial forces by MobodIndex. Therefore, the
+  // expected results being generated must also be sorted by MobodIndex.
   std::vector<SpatialForce<double>> SpatialForceFromContactResults(
       const ContactResults<double>& contacts) {
     std::vector<SpatialForce<double>> F_BBo_W_array(
@@ -596,9 +596,9 @@ class ContactModelTest : public ::testing::Test {
       // N.B. Since we are using this method to test the internal (private)
       // MultibodyPlant::EvalSpatialContactForcesContinuous(), we must use
       // internal API to generate a forces vector sorted in the same way, by
-      // internal::BodyNodeIndex.
-      F_BBo_W_array[bodyB.node_index()] += F_Bc_W.Shift(p_CBo_W);
-      F_BBo_W_array[bodyA.node_index()] -= F_Bc_W.Shift(p_CAo_W);
+      // internal::MobodIndex.
+      F_BBo_W_array[bodyB.mobod_index()] += F_Bc_W.Shift(p_CBo_W);
+      F_BBo_W_array[bodyA.mobod_index()] -= F_Bc_W.Shift(p_CAo_W);
     }
 
     for (int i = 0; i < contacts.num_hydroelastic_contacts(); ++i) {
@@ -624,8 +624,8 @@ class ContactModelTest : public ::testing::Test {
       // The force applied to body A at a fixed point coincident with the
       // centroid point C.
       const SpatialForce<double>& F_Ac_W = contact_info.F_Ac_W();
-      F_BBo_W_array[body_A.node_index()] += F_Ac_W.Shift(p_CAo_W);
-      F_BBo_W_array[body_B.node_index()] -= F_Ac_W.Shift(p_CBo_W);
+      F_BBo_W_array[body_A.mobod_index()] += F_Ac_W.Shift(p_CAo_W);
+      F_BBo_W_array[body_B.mobod_index()] -= F_Ac_W.Shift(p_CBo_W);
     }
 
     return F_BBo_W_array;

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -407,7 +407,7 @@ TEST_F(KukaIiwaArmTests, CalcAccelerationKinematicsCache) {
   EXPECT_TRUE(CompareMatrices(ac.get_vdot(), a_expected));
   for (BodyIndex b(0); b < plant_.num_bodies(); ++b) {
     const auto& body = plant_.get_body(b);
-    EXPECT_TRUE(ac.get_A_WB(body.node_index()).IsApprox(A_WB_expected[b]));
+    EXPECT_TRUE(ac.get_A_WB(body.mobod_index()).IsApprox(A_WB_expected[b]));
   }
 }
 

--- a/multibody/test_utilities/floating_body_plant.cc
+++ b/multibody/test_utilities/floating_body_plant.cc
@@ -80,7 +80,7 @@ math::RigidTransform<T> AxiallySymmetricFreeBodyPlant<T>::CalcPoseInWorldFrame(
     const systems::Context<T>& context) const {
   internal::PositionKinematicsCache<T> pc(this->tree().get_topology());
   this->tree().CalcPositionKinematicsCache(context, &pc);
-  return math::RigidTransform<T>(pc.get_X_WB(body_->node_index()));
+  return math::RigidTransform<T>(pc.get_X_WB(body_->mobod_index()));
 }
 
 template<typename T>
@@ -91,7 +91,7 @@ AxiallySymmetricFreeBodyPlant<T>::CalcSpatialVelocityInWorldFrame(
   this->tree().CalcPositionKinematicsCache(context, &pc);
   internal::VelocityKinematicsCache<T> vc(this->tree().get_topology());
   this->tree().CalcVelocityKinematicsCache(context, pc, &vc);
-  return vc.get_V_WB(body_->node_index());
+  return vc.get_V_WB(body_->mobod_index());
 }
 
 }  // namespace test

--- a/multibody/tree/acceleration_kinematics_cache.h
+++ b/multibody/tree/acceleration_kinematics_cache.h
@@ -39,35 +39,35 @@ class AccelerationKinematicsCache {
   explicit AccelerationKinematicsCache(const MultibodyTreeTopology& topology) {
     Allocate(topology);
     DRAKE_ASSERT_VOID(InitializeToNaN());
-    // Sets defaults: drake::multibody::world_index() defines the unique index
-    // to the world body and is defined in multibody_tree_indexes.h.
+    // Sets defaults: drake::multibody::world_mobod_index() defines the unique
+    // index to the world body and is defined in multibody_tree_indexes.h.
     // World's acceleration is always zero.
-    A_WB_pool_[world_index()].SetZero();
+    A_WB_pool_[world_mobod_index()].SetZero();
     vdot_.setZero();
   }
 
-  // For the body B associated with node @p body_node_index, returns A_WB,
+  // For the body B associated with mobilized body `mobod_index`, returns A_WB,
   // body B's spatial acceleration in the world frame W.
-  // This method aborts in Debug builds if `body_node_index` does not
+  // This method aborts in Debug builds if `mobod_index` does not
   // correspond to a valid BodyNode in the MultibodyTree.
-  // @param[in] body_node_index The unique index for the computational
-  //                            BodyNode object associated with body B.
+  // @param[in] mobod_index The unique index for the computational
+  //                        BodyNode object associated with body B.
   // @retval A_WB_W body B's spatial acceleration in the world frame W,
   // expressed in W (for point Bo, the body's origin).
-  const SpatialAcceleration<T>& get_A_WB(BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < get_num_nodes());
-    return A_WB_pool_[body_node_index];
+  const SpatialAcceleration<T>& get_A_WB(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < get_num_mobods());
+    return A_WB_pool_[mobod_index];
   }
 
   // Mutable version of get_A_WB().
-  SpatialAcceleration<T>& get_mutable_A_WB(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < get_num_nodes());
-    return A_WB_pool_[body_node_index];
+  SpatialAcceleration<T>& get_mutable_A_WB(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < get_num_mobods());
+    return A_WB_pool_[mobod_index];
   }
 
   // Returns a const reference to the pool of body accelerations.
   // The pool is returned as a `std::vector` of SpatialAcceleration objects
-  // ordered by BodyNodeIndex.
+  // ordered by MobodIndex.
   // Most users should not need to call this method.
   const std::vector<SpatialAcceleration<T>>& get_A_WB_pool() const {
     return A_WB_pool_;
@@ -90,21 +90,20 @@ class AccelerationKinematicsCache {
   }
 
  private:
-  // Pools store entries in the same order that multibody tree nodes are
-  // ordered in the tree, i.e. in DFT (Depth-First Traversal) order. Therefore
-  // clients of this class will access entries by BodyNodeIndex, see
+  // Pools store entries in the same order as the mobilized bodies (BodyNodes)
+  // in the multibody forest, i.e. in DFT (Depth-First Traversal) order.
+  // Therefore clients of this class will access entries by MobodIndex, see
   // `get_A_WB()` for instance.
 
-  // Helper method to return the number of nodes in this multibody tree cache.
-  // It eliminates having to use static_cast<int>() when requesting a pool size.
-  int get_num_nodes() const {
+  // Return the number of mobilized bodies in this multibody tree cache.
+  int get_num_mobods() const {
     return static_cast<int>(A_WB_pool_.size());
   }
 
   // Allocates resources for this acceleration kinematics cache.
   void Allocate(const MultibodyTreeTopology& topology) {
-    const int num_nodes = topology.num_bodies();
-    A_WB_pool_.resize(num_nodes);
+    const int num_mobods = topology.num_mobods();
+    A_WB_pool_.resize(num_mobods);
     const int num_velocities = topology.num_velocities();
     vdot_.resize(num_velocities);
   }
@@ -112,14 +111,14 @@ class AccelerationKinematicsCache {
   // Initializes all pools to have NaN values to ease bug detection when entries
   // are accidentally left uninitialized.
   void InitializeToNaN() {
-    for (BodyNodeIndex body_node_index(0); body_node_index < get_num_nodes();
-         ++body_node_index) {
-      A_WB_pool_[body_node_index].SetNaN();
+    for (MobodIndex mobod_index(0); mobod_index < get_num_mobods();
+         ++mobod_index) {
+      A_WB_pool_[mobod_index].SetNaN();
     }
   }
 
   // Number of body nodes in the corresponding MultibodyTree.
-  std::vector<SpatialAcceleration<T>> A_WB_pool_;  // Indexed by BodyNodeIndex.
+  std::vector<SpatialAcceleration<T>> A_WB_pool_;  // Indexed by MobodIndex.
   VectorX<T> vdot_;
 };
 

--- a/multibody/tree/articulated_body_force_cache.h
+++ b/multibody/tree/articulated_body_force_cache.h
@@ -31,47 +31,47 @@ class ArticulatedBodyForceCache {
   // store the force bias terms for a model with the given `topology`.
   explicit ArticulatedBodyForceCache(
       const MultibodyTreeTopology& topology) :
-      num_nodes_(topology.num_bodies()) {
+      num_mobods_(topology.num_mobods()) {
     Allocate();
   }
 
-  // The articulated body inertia residual force `Zplus_PB_W` for this body
-  // projected across its inboard mobilizer to frame P.
-  const SpatialForce<T>& get_Zplus_PB_W(BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return Zplus_PB_W_[body_node_index];
+  // The articulated body inertia residual force `Zplus_PB_W` for this mobilized
+  // body projected across its inboard mobilizer to frame P.
+  const SpatialForce<T>& get_Zplus_PB_W(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return Zplus_PB_W_[mobod_index];
   }
 
   // Mutable version of get_Zplus_PB_W().
-  SpatialForce<T>& get_mutable_Zplus_PB_W(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return Zplus_PB_W_[body_node_index];
+  SpatialForce<T>& get_mutable_Zplus_PB_W(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return Zplus_PB_W_[mobod_index];
   }
 
   // The articulated body inertia innovations generalized force `e_B` for this
-  // body's mobilizer.
-  const VectorUpTo6<T>& get_e_B(BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return e_B_[body_node_index];
+  // mobilized body's mobilizer.
+  const VectorUpTo6<T>& get_e_B(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return e_B_[mobod_index];
   }
 
   // Mutable version of get_e_B().
-  VectorUpTo6<T>& get_mutable_e_B(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return e_B_[body_node_index];
+  VectorUpTo6<T>& get_mutable_e_B(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return e_B_[mobod_index];
   }
 
  private:
   // Allocates resources for this articulated body cache.
   void Allocate() {
-    Zplus_PB_W_.resize(num_nodes_);
-    e_B_.resize(num_nodes_);
+    Zplus_PB_W_.resize(num_mobods_);
+    e_B_.resize(num_mobods_);
   }
 
-  // Number of body nodes in the corresponding MultibodyTree.
-  int num_nodes_{0};
+  // Number of mobilized bodies in the corresponding MultibodyTree.
+  int num_mobods_{0};
 
-  // Pools indexed by BodyNodeIndex.
+  // Pools indexed by MobodIndex.
   std::vector<SpatialForce<T>> Zplus_PB_W_;
   std::vector<VectorUpTo6<T>> e_B_;
 };

--- a/multibody/tree/articulated_body_inertia_cache.h
+++ b/multibody/tree/articulated_body_inertia_cache.h
@@ -38,82 +38,82 @@ class ArticulatedBodyInertiaCache {
   // Constructs an articulated body cache entry for the given
   // MultibodyTreeTopology.
   explicit ArticulatedBodyInertiaCache(const MultibodyTreeTopology& topology) :
-      num_nodes_(topology.num_bodies()) {
+      num_mobods_(topology.num_mobods()) {
     Allocate();
   }
 
   // Articulated body inertia `P_B_W` of the body taken about Bo and expressed
   // in W.
   const ArticulatedBodyInertia<T>& get_P_B_W(
-      BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return P_B_W_[body_node_index];
+      MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return P_B_W_[mobod_index];
   }
 
   // Mutable version of get_P_B_W().
   ArticulatedBodyInertia<T>& get_mutable_P_B_W(
-      BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return P_B_W_[body_node_index];
+      MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return P_B_W_[mobod_index];
   }
 
   // Articulated body inertia `Pplus_PB_W`, which can be thought of as the
   // articulated body inertia of parent body P as though it were inertialess,
   // but taken about Bo and expressed in W.
   const ArticulatedBodyInertia<T>& get_Pplus_PB_W(
-      BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return Pplus_PB_W_[body_node_index];
+      MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return Pplus_PB_W_[mobod_index];
   }
 
   // Mutable version of get_Pplus_PB_W().
   ArticulatedBodyInertia<T>& get_mutable_Pplus_PB_W(
-      BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return Pplus_PB_W_[body_node_index];
+      MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return Pplus_PB_W_[mobod_index];
   }
 
   // LLT factorization `llt_D_B` of the articulated body hinge inertia.
   const math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& get_llt_D_B(
-      BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return llt_D_B_[body_node_index];
+      MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return llt_D_B_[mobod_index];
   }
 
   // Mutable version of get_llt_D_B().
   math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& get_mutable_llt_D_B(
-      BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return llt_D_B_[body_node_index];
+      MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return llt_D_B_[mobod_index];
   }
 
   // The Kalman gain `g_PB_W` of the body.
   const Matrix6xUpTo6<T>& get_g_PB_W(
-      BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return g_PB_W_[body_node_index];
+      MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return g_PB_W_[mobod_index];
   }
 
   // Mutable version of get_g_PB_W().
   Matrix6xUpTo6<T>& get_mutable_g_PB_W(
-      BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return g_PB_W_[body_node_index];
+      MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return g_PB_W_[mobod_index];
   }
 
  private:
   // Allocates resources for this articulated body cache.
   void Allocate() {
-    P_B_W_.resize(num_nodes_);
-    Pplus_PB_W_.resize(num_nodes_);
-    llt_D_B_.resize(num_nodes_);
-    g_PB_W_.resize(num_nodes_);
+    P_B_W_.resize(num_mobods_);
+    Pplus_PB_W_.resize(num_mobods_);
+    llt_D_B_.resize(num_mobods_);
+    g_PB_W_.resize(num_mobods_);
 
     // Initialize entries corresponding to world index to NaNs, since they
     // should not be used.
-    P_B_W_[world_index()] = ArticulatedBodyInertia<T>();
-    Pplus_PB_W_[world_index()] = ArticulatedBodyInertia<T>();
-    g_PB_W_[world_index()] = Matrix6<T>::Constant(nan());
+    P_B_W_[world_mobod_index()] = ArticulatedBodyInertia<T>();
+    Pplus_PB_W_[world_mobod_index()] = ArticulatedBodyInertia<T>();
+    g_PB_W_[world_mobod_index()] = Matrix6<T>::Constant(nan());
   }
 
   // Helper method for NaN initialization.
@@ -122,10 +122,10 @@ class ArticulatedBodyInertiaCache {
         typename Eigen::NumTraits<T>::Literal>::quiet_NaN();
   }
 
-  // Number of body nodes in the corresponding MultibodyTree.
-  int num_nodes_{0};
+  // Number of mobilized bodies in the corresponding multibody forest.
+  int num_mobods_{0};
 
-  // Pools indexed by BodyNodeIndex.
+  // Pools indexed by MobodIndex.
   std::vector<ArticulatedBodyInertia<T>> P_B_W_;
   std::vector<ArticulatedBodyInertia<T>> Pplus_PB_W_;
   std::vector<math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>> llt_D_B_;

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -229,11 +229,16 @@ class Body : public MultibodyElement<T> {
         .is_locked(context);
   }
 
-  /// (Advanced) Returns the index of the node in the underlying tree structure
-  /// of the parent MultibodyTree to which this body belongs.
-  internal::BodyNodeIndex node_index() const {
-    return topology_.body_node;
+  /// (Advanced) Returns the index of the mobilized body ("mobod") in the
+  /// computational directed forest structure of the owning MultibodyTree to
+  /// which this %Body belongs. This serves as the BodyNode index and the index
+  /// into all associated quantities.
+  internal::MobodIndex mobod_index() const {
+    return topology_.mobod_index;
   }
+
+  DRAKE_DEPRECATED("2024-03-01",  "Use mobod_index() instead.")
+  internal::MobodIndex node_index() const { return mobod_index(); }
 
   /// (Advanced) Returns `true` if `this` body is granted 6-dofs by a Mobilizer
   /// and the parent body of this body's associated 6-dof joint is `world`.
@@ -411,7 +416,7 @@ class Body : public MultibodyElement<T> {
       const systems::Context<T>&, const MultibodyForces<T>& forces) const {
     DRAKE_THROW_UNLESS(
         forces.CheckHasRightSizeForModel(this->get_parent_tree()));
-    return forces.body_forces()[node_index()];
+    return forces.body_forces()[mobod_index()];
   }
 
   /// Adds the spatial force on `this` body B, applied at body B's origin Bo and
@@ -422,7 +427,7 @@ class Body : public MultibodyElement<T> {
     DRAKE_THROW_UNLESS(forces != nullptr);
     DRAKE_THROW_UNLESS(
         forces->CheckHasRightSizeForModel(this->get_parent_tree()));
-    forces->mutable_body_forces()[node_index()] += F_Bo_W;
+    forces->mutable_body_forces()[mobod_index()] += F_Bo_W;
   }
 
   /// Adds the spatial force on `this` body B, applied at point P and

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -116,8 +116,8 @@ class BodyNode : public MultibodyElement<T> {
   }
 
   // Returns this element's unique index.
-  BodyNodeIndex index() const {
-    return this->template index_impl<BodyNodeIndex>();
+  MobodIndex index() const {
+    return this->template index_impl<MobodIndex>();
   }
 
   // Returns a constant reference to the body B associated with this node.
@@ -359,10 +359,10 @@ class BodyNode : public MultibodyElement<T> {
   //   must contain already pre-computed spatial accelerations for the inboard
   //   bodies to this node's body B, see precondition below.  It must be of
   //   size equal to the number of bodies in the MultibodyTree and ordered by
-  //   BodyNodeIndex. The calling MultibodyTree method must guarantee these
+  //   MobodIndex. The calling MultibodyTree method must guarantee these
   //   conditions are satisfied. This method will abort if the pointer is
   //   null. There is no mechanism to assert that `A_WB_array_ptr` is ordered
-  //   by BodyNodeIndex and the correctness of MultibodyTree methods, properly
+  //   by MobodIndex and the correctness of MultibodyTree methods, properly
   //   unit tested, should guarantee this condition.
   //
   // @pre The position kinematics cache `pc` was already updated to be in sync
@@ -545,7 +545,7 @@ class BodyNode : public MultibodyElement<T> {
   //   A vector of known spatial accelerations containing the spatial
   //   acceleration `A_WB` for each body in the MultibodyTree model. It must be
   //   of size equal to the number of bodies in the MultibodyTree and ordered
-  //   by BodyNodeIndex. The calling MultibodyTree method must guarantee these
+  //   by MobodIndex. The calling MultibodyTree method must guarantee these
   //   conditions are satisfied.
   // @param[in] Fapplied_Bo_W
   //   Externally applied spatial force on this node's body B at the body's
@@ -565,10 +565,10 @@ class BodyNode : public MultibodyElement<T> {
   //   inboard mobilizer reaction forces on body B applied at the origin `Mo`
   //   of the inboard mobilizer, expressed in the world frame W.  It must be of
   //   size equal to the number of bodies in the MultibodyTree and ordered by
-  //   BodyNodeIndex. The calling MultibodyTree method must guarantee these
+  //   MobodIndex. The calling MultibodyTree method must guarantee these
   //   conditions are satisfied. This method will abort if the pointer is null.
   //   To access a mobilizer's reaction force on a given body B, access this
-  //   array with the index returned by Body::node_index().
+  //   array with the index returned by Body::mobod_index().
   // @param[out] tau_array
   //   A non-null pointer to the output vector of generalized forces that would
   //   result in body B having spatial acceleration `A_WB`. This method will
@@ -577,7 +577,7 @@ class BodyNode : public MultibodyElement<T> {
   //   in the model.
   //
   // @note There is no mechanism to assert that either `A_WB_array` nor
-  //   `F_BMo_W_array_ptr` are ordered by BodyNodeIndex and the correctness of
+  //   `F_BMo_W_array_ptr` are ordered by MobodIndex and the correctness of
   //   MultibodyTree methods, properly unit tested, should guarantee this
   //   condition.
   //
@@ -690,7 +690,7 @@ class BodyNode : public MultibodyElement<T> {
     // Shift spatial force on B to Mo.
     F_BMo_W = Ftot_BBo_W.Shift(p_BoMo_W);
     for (const BodyNode<T>* child_node : children_) {
-      BodyNodeIndex child_node_index = child_node->index();
+      MobodIndex child_node_index = child_node->index();
 
       // Shift vector from Bo to Co, expressed in the world frame W.
       const Vector3<T>& p_BoCo_W = child_node->get_p_PoBo_W(pc);
@@ -1666,7 +1666,7 @@ class BodyNode : public MultibodyElement<T> {
 
   // =========================================================================
   // Per Node Array Accessors.
-  // Quantities are ordered by BodyNodeIndex unless otherwise specified.
+  // Quantities are ordered by MobodIndex unless otherwise specified.
 
   // Returns a const reference to the spatial acceleration of the body B
   // associated with this node as measured and expressed in the world frame W,
@@ -1834,7 +1834,7 @@ class BodyNode : public MultibodyElement<T> {
     const Body<T>& body_B = body();
 
     // Body B spatial inertia about Bo expressed in world W.
-    const SpatialInertia<T>& M_B_W = M_B_W_cache[body_B.node_index()];
+    const SpatialInertia<T>& M_B_W = M_B_W_cache[body_B.mobod_index()];
 
     // Equations of motion for a rigid body written at a generic point Bo not
     // necessarily coincident with the body's center of mass. This corresponds
@@ -1844,7 +1844,7 @@ class BodyNode : public MultibodyElement<T> {
     // If velocities are zero, then Fb_Bo_W is zero and does not contribute.
     if (Fb_Bo_W_cache != nullptr) {
       // Dynamic bias for body B.
-      const SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_cache)[body_B.node_index()];
+      const SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_cache)[body_B.mobod_index()];
       Ftot_BBo_W += Fb_Bo_W;
     }
   }

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.cc
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.cc
@@ -135,8 +135,8 @@ void LinearBushingRollPitchYaw<T>::DoCalcAndAddForceContribution(
 
   // Apply a torque to link L0 and apply the force −𝐟 to L0ₒ.
   // Apply a torque to link L1 and apply the force +𝐟 to L1ₒ.
-  F_BodyOrigin_W_array[link0().node_index()] += F_L0_W;
-  F_BodyOrigin_W_array[link1().node_index()] += F_L1_W;
+  F_BodyOrigin_W_array[link0().mobod_index()] += F_L0_W;
+  F_BodyOrigin_W_array[link1().mobod_index()] += F_L1_W;
 }
 
 template <typename T>

--- a/multibody/tree/linear_spring_damper.cc
+++ b/multibody/tree/linear_spring_damper.cc
@@ -35,8 +35,8 @@ void LinearSpringDamper<T>::DoCalcAndAddForceContribution(
     MultibodyForces<T>* forces) const {
   using std::sqrt;
 
-  const math::RigidTransform<T>& X_WA = pc.get_X_WB(bodyA().node_index());
-  const math::RigidTransform<T>& X_WB = pc.get_X_WB(bodyB().node_index());
+  const math::RigidTransform<T>& X_WA = pc.get_X_WB(bodyA().mobod_index());
+  const math::RigidTransform<T>& X_WB = pc.get_X_WB(bodyB().mobod_index());
 
   const Vector3<T> p_WP = X_WA * p_AP_.template cast<T>();
   const Vector3<T> p_WQ = X_WB * p_BQ_.template cast<T>();
@@ -66,12 +66,12 @@ void LinearSpringDamper<T>::DoCalcAndAddForceContribution(
 
   // p_PAo = p_WAo - p_WP
   const Vector3<T> p_PAo_W = X_WA.translation() - p_WP;
-  F_Bo_W_array[bodyA().node_index()] +=
+  F_Bo_W_array[bodyA().mobod_index()] +=
       SpatialForce<T>(Vector3<T>::Zero(), f_AP_W).Shift(p_PAo_W);
 
   // p_QBo = p_WBo - p_WQ
   const Vector3<T> p_QBo_W = X_WB.translation() - p_WQ;
-  F_Bo_W_array[bodyB().node_index()] +=
+  F_Bo_W_array[bodyB().mobod_index()] +=
       SpatialForce<T>(Vector3<T>::Zero(), -f_AP_W).Shift(p_QBo_W);
 }
 
@@ -79,8 +79,8 @@ template <typename T>
 T LinearSpringDamper<T>::CalcPotentialEnergy(
     const systems::Context<T>&,
     const internal::PositionKinematicsCache<T>& pc) const {
-  const math::RigidTransform<T>& X_WA = pc.get_X_WB(bodyA().node_index());
-  const math::RigidTransform<T>& X_WB = pc.get_X_WB(bodyB().node_index());
+  const math::RigidTransform<T>& X_WA = pc.get_X_WB(bodyA().mobod_index());
+  const math::RigidTransform<T>& X_WB = pc.get_X_WB(bodyB().mobod_index());
 
   const Vector3<T> p_WP = X_WA * p_AP_.template cast<T>();
   const Vector3<T> p_WQ = X_WB * p_BQ_.template cast<T>();
@@ -105,8 +105,8 @@ T LinearSpringDamper<T>::CalcConservativePower(
   //  Pc = -d(V)/dt
   // being positive when the potential energy decreases.
 
-  const math::RigidTransform<T>& X_WA = pc.get_X_WB(bodyA().node_index());
-  const math::RigidTransform<T>& X_WB = pc.get_X_WB(bodyB().node_index());
+  const math::RigidTransform<T>& X_WA = pc.get_X_WB(bodyA().mobod_index());
+  const math::RigidTransform<T>& X_WB = pc.get_X_WB(bodyB().mobod_index());
 
   const Vector3<T> p_WP = X_WA * p_AP_.template cast<T>();
   const Vector3<T> p_WQ = X_WB * p_BQ_.template cast<T>();
@@ -194,8 +194,8 @@ template <typename T>
 T LinearSpringDamper<T>::CalcLengthTimeDerivative(
     const internal::PositionKinematicsCache<T>& pc,
     const internal::VelocityKinematicsCache<T>& vc) const {
-  const math::RigidTransform<T>& X_WA = pc.get_X_WB(bodyA().node_index());
-  const math::RigidTransform<T>& X_WB = pc.get_X_WB(bodyB().node_index());
+  const math::RigidTransform<T>& X_WA = pc.get_X_WB(bodyA().mobod_index());
+  const math::RigidTransform<T>& X_WB = pc.get_X_WB(bodyB().mobod_index());
 
   const Vector3<T> p_WP = X_WA * p_AP_.template cast<T>();
   const Vector3<T> p_WQ = X_WB * p_BQ_.template cast<T>();
@@ -212,12 +212,12 @@ T LinearSpringDamper<T>::CalcLengthTimeDerivative(
   // p_PAo = p_WAo - p_WP
   const Vector3<T> p_PAo_W = X_WA.translation() - p_WP;
   const SpatialVelocity<T>& V_WP =
-      vc.get_V_WB(bodyA().node_index()).Shift(-p_PAo_W);
+      vc.get_V_WB(bodyA().mobod_index()).Shift(-p_PAo_W);
 
   // p_QBo = p_WBo - p_WQ
   const Vector3<T> p_QBo_W = X_WB.translation() - p_WQ;
   const SpatialVelocity<T>& V_WQ =
-      vc.get_V_WB(bodyB().node_index()).Shift(-p_QBo_W);
+      vc.get_V_WB(bodyB().mobod_index()).Shift(-p_QBo_W);
 
   // Relative velocity of P in Q, expressed in the world frame.
   const Vector3<T> v_PQ_W = V_WQ.translational() - V_WP.translational();

--- a/multibody/tree/multibody_forces.h
+++ b/multibody/tree/multibody_forces.h
@@ -38,7 +38,7 @@ class MultibodyForces {
 
   /// Number of bodies and number of generalized velocities overload. This
   /// constructor is useful for constructing the MultibodyForces structure
-  /// before a MultibodyPlant has been consructed.
+  /// before a MultibodyPlant has been constructed.
   MultibodyForces(int nb, int nv);
 
   /// Sets `this` to store zero forces (no applied forces).
@@ -64,7 +64,7 @@ class MultibodyForces {
   /// (Advanced) Returns a constant reference to the vector of spatial body
   /// forces `F_BBo_W` on each body B in the model, at the body's frame
   /// origin `Bo`, expressed in the world frame W.
-  /// @note Entries are ordered by BodyNodeIndex.
+  /// @note Entries are ordered by MobodIndex.
   const std::vector<SpatialForce<T>>& body_forces() const { return F_B_W_; }
 
   /// (Advanced) Mutable version of body_forces().
@@ -86,7 +86,7 @@ class MultibodyForces {
  private:
   // Vector holding, for each body in the MultibodyTree, the externally applied
   // force F_Bi_W on the i-th body Bi, expressed in the world frame W.
-  // Store by BodyNodeIndex order.
+  // Store by MobodIndex order.
   std::vector<SpatialForce<T>> F_B_W_;
 
   // Vector of generalized forces applied on each mobilizer in the

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -749,19 +749,19 @@ void MultibodyTree<T>::FinalizeInternals() {
   }
 
   body_node_levels_.resize(topology_.forest_height());
-  for (BodyNodeIndex body_node_index(1);
-       body_node_index < topology_.get_num_body_nodes(); ++body_node_index) {
+  for (MobodIndex mobod_index(1);
+       mobod_index < topology_.num_mobods(); ++mobod_index) {
     const BodyNodeTopology& node_topology =
-        topology_.get_body_node(body_node_index);
-    body_node_levels_[node_topology.level].push_back(body_node_index);
+        topology_.get_body_node(mobod_index);
+    body_node_levels_[node_topology.level].push_back(mobod_index);
   }
 
-  // Creates BodyNode's:
+  // Creates BodyNodes:
   // This recursion order ensures that a BodyNode's parent is created before the
   // node itself, since BodyNode objects are in Depth First Traversal order.
-  for (BodyNodeIndex body_node_index(0);
-       body_node_index < topology_.get_num_body_nodes(); ++body_node_index) {
-    CreateBodyNode(body_node_index);
+  for (MobodIndex mobod_index(0);
+       mobod_index < topology_.num_mobods(); ++mobod_index) {
+    CreateBodyNode(mobod_index);
   }
 
   CreateModelInstances();
@@ -774,8 +774,8 @@ void MultibodyTree<T>::FinalizeInternals() {
     if (body.is_floating()) {
       // Set default positions for the floating joints.
       // TODO(xuchenhan-tri): This assumes that the only type of floating
-      // joint is the quaternion floating joint. This may change pending
-      // the resolution of #14949.
+      //  joint is the quaternion floating joint. This may change pending
+      //  the resolution of #14949.
       auto* quaternion_floating_joint =
           dynamic_cast<QuaternionFloatingJoint<T>*>(joint.get());
       DRAKE_DEMAND(quaternion_floating_joint != nullptr);
@@ -807,9 +807,9 @@ void MultibodyTree<T>::Finalize() {
 }
 
 template <typename T>
-void MultibodyTree<T>::CreateBodyNode(BodyNodeIndex body_node_index) {
+void MultibodyTree<T>::CreateBodyNode(MobodIndex mobod_index) {
   const BodyNodeTopology& node_topology =
-      topology_.get_body_node(body_node_index);
+      topology_.get_body_node(mobod_index);
   const BodyIndex body_index = node_topology.body;
 
   const Body<T>* body = owned_bodies_[node_topology.body].get();
@@ -831,7 +831,7 @@ void MultibodyTree<T>::CreateBodyNode(BodyNodeIndex body_node_index) {
     body_node = mobilizer->CreateBodyNode(parent_node, body, mobilizer);
     parent_node->add_child_node(body_node.get());
   }
-  body_node->set_parent_tree(this, body_node_index);
+  body_node->set_parent_tree(this, mobod_index);
   body_node->SetTopology(topology_);
 
   body_nodes_.push_back(std::move(body_node));
@@ -959,7 +959,7 @@ RigidTransform<T> MultibodyTree<T>::GetFreeBodyPoseOrThrow(
   const QuaternionFloatingMobilizer<T>& mobilizer =
       GetFreeBodyMobilizerOrThrow(body);
   return RigidTransform<T>(mobilizer.get_quaternion(context),
-                                 mobilizer.get_position(context));
+                           mobilizer.get_position(context));
 }
 
 template <typename T>
@@ -1072,6 +1072,7 @@ void MultibodyTree<T>::SetFreeBodyRandomRotationDistributionOrThrow(
   mobilizer.set_random_quaternion_distribution(rotation);
 }
 
+// Note that the result is indexed by BodyIndex, not MobodIndex.
 template <typename T>
 void MultibodyTree<T>::CalcAllBodyPosesInWorld(
     const systems::Context<T>& context,
@@ -1082,11 +1083,12 @@ void MultibodyTree<T>::CalcAllBodyPosesInWorld(
   }
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   for (BodyIndex body_index(0); body_index < num_bodies(); ++body_index) {
-    const BodyNodeIndex node_index = get_body(body_index).node_index();
-    X_WB->at(body_index) = pc.get_X_WB(node_index);
+    const MobodIndex mobod_index = get_body(body_index).mobod_index();
+    X_WB->at(body_index) = pc.get_X_WB(mobod_index);
   }
 }
 
+// Note that the result is indexed by BodyIndex, not MobodIndex.
 template <typename T>
 void MultibodyTree<T>::CalcAllBodySpatialVelocitiesInWorld(
     const systems::Context<T>& context,
@@ -1097,8 +1099,8 @@ void MultibodyTree<T>::CalcAllBodySpatialVelocitiesInWorld(
   }
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
   for (BodyIndex body_index(0); body_index < num_bodies(); ++body_index) {
-    const BodyNodeIndex node_index = get_body(body_index).node_index();
-    V_WB->at(body_index) = vc.get_V_WB(node_index);
+    const MobodIndex mobod_index = get_body(body_index).mobod_index();
+    V_WB->at(body_index) = vc.get_V_WB(mobod_index);
   }
 }
 
@@ -1108,16 +1110,16 @@ void MultibodyTree<T>::CalcPositionKinematicsCache(
     PositionKinematicsCache<T>* pc) const {
   DRAKE_DEMAND(pc != nullptr);
 
-  // With the kinematics information across mobilizer's and the kinematics
+  // With the kinematics information across mobilizers and the kinematics
   // information for each body, we are now in position to perform a base-to-tip
   // recursion to update world positions and parent to child body transforms.
   // This skips the world, level = 0.
   for (int level = 1; level < tree_height(); ++level) {
-    for (BodyNodeIndex body_node_index : body_node_levels_[level]) {
-      const BodyNode<T>& node = *body_nodes_[body_node_index];
+    for (MobodIndex mobod_index : body_node_levels_[level]) {
+      const BodyNode<T>& node = *body_nodes_[mobod_index];
 
       DRAKE_ASSERT(node.get_topology().level == level);
-      DRAKE_ASSERT(node.index() == body_node_index);
+      DRAKE_ASSERT(node.index() == mobod_index);
 
       // Update per-node kinematics.
       node.CalcPositionKinematicsCache_BaseToTip(context, pc);
@@ -1143,13 +1145,13 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
       EvalAcrossNodeJacobianWrtVExpressedInWorld(context);
 
   // Performs a base-to-tip recursion computing body velocities.
-  // This skips the world, depth = 0.
-  for (int depth = 1; depth < tree_height(); ++depth) {
-    for (BodyNodeIndex body_node_index : body_node_levels_[depth]) {
-      const BodyNode<T>& node = *body_nodes_[body_node_index];
+  // This skips the world, level = 0.
+  for (int level = 1; level < tree_height(); ++level) {
+    for (MobodIndex mobod_index : body_node_levels_[level]) {
+      const BodyNode<T>& node = *body_nodes_[mobod_index];
 
-      DRAKE_ASSERT(node.get_topology().level == depth);
-      DRAKE_ASSERT(node.index() == body_node_index);
+      DRAKE_ASSERT(node.get_topology().level == level);
+      DRAKE_ASSERT(node.index() == mobod_index);
 
       // Hinge matrix for this node. H_PB_W ∈ ℝ⁶ˣⁿᵐ with nm ∈ [0; 6] the
       // number of mobilities for this node. Therefore, the return is a
@@ -1166,12 +1168,14 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
   }
 }
 
+// Result is indexed by MobodIndex, not BodyIndex.
 template <typename T>
 void MultibodyTree<T>::CalcSpatialInertiasInWorld(
     const systems::Context<T>& context,
     std::vector<SpatialInertia<T>>* M_B_W_all) const {
   DRAKE_THROW_UNLESS(M_B_W_all != nullptr);
-  DRAKE_THROW_UNLESS(static_cast<int>(M_B_W_all->size()) == num_bodies());
+  DRAKE_THROW_UNLESS(static_cast<int>(M_B_W_all->size()) ==
+      topology_.num_mobods());
 
   const PositionKinematicsCache<T>& pc = this->EvalPositionKinematics(context);
 
@@ -1180,7 +1184,7 @@ void MultibodyTree<T>::CalcSpatialInertiasInWorld(
   //  inertias for locked floating bodies.
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
-    const RigidTransform<T>& X_WB = pc.get_X_WB(body.node_index());
+    const RigidTransform<T>& X_WB = pc.get_X_WB(body.mobod_index());
 
     // Orientation of B in W.
     const RotationMatrix<T>& R_WB = X_WB.rotation();
@@ -1189,7 +1193,7 @@ void MultibodyTree<T>::CalcSpatialInertiasInWorld(
     // This call has zero cost for rigid bodies.
     const SpatialInertia<T> M_B = body.CalcSpatialInertiaInBodyFrame(context);
     // Re-express body B's spatial inertia in the world frame W.
-    SpatialInertia<T>& M_B_W = (*M_B_W_all)[body.node_index()];
+    SpatialInertia<T>& M_B_W = (*M_B_W_all)[body.mobod_index()];
     M_B_W = M_B.ReExpress(R_WB);
   }
 }
@@ -1220,18 +1224,19 @@ void MultibodyTree<T>::CalcCompositeBodyInertiasInWorld(
       EvalSpatialInertiaInWorldCache(context);
 
   // Perform tip-to-base recursion for each composite body, skipping the world.
-  for (int depth = tree_height() - 1; depth > 0; --depth) {
-    for (BodyNodeIndex composite_node_index : body_node_levels_[depth]) {
-      // Node corresponding to the composite body C.
-      const BodyNode<T>& composite_node = *body_nodes_[composite_node_index];
+  for (int level = tree_height() - 1; level > 0; --level) {
+    for (MobodIndex mobod_index : body_node_levels_[level]) {
+      // Node corresponding to the base of composite body C. We'll add in
+      // everything outboard of this node.
+      const BodyNode<T>& composite_node = *body_nodes_[mobod_index];
 
       // This node's spatial inertia.
-      const SpatialInertia<T>& M_C_W = M_B_W_all[composite_node_index];
+      const SpatialInertia<T>& M_C_W = M_B_W_all[mobod_index];
 
       // Compute the spatial inertia Mc_C_W of the composite body C
-      // corresponding to the node with index composite_node_index. Computed
+      // corresponding to the node with index mobod_index. Computed
       // about C's origin Co and expressed in the world frame W.
-      SpatialInertia<T>& Mc_C_W = (*Mc_B_W_all)[composite_node_index];
+      SpatialInertia<T>& Mc_C_W = (*Mc_B_W_all)[mobod_index];
       composite_node.CalcCompositeBodyInertia_TipToBase(M_C_W, pc, *Mc_B_W_all,
                                                         &Mc_C_W);
     }
@@ -1246,17 +1251,17 @@ void MultibodyTree<T>::CalcSpatialAccelerationBias(
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
 
-  // This skips the world, body_node_index = 0.
-  // For the world body we opted for leaving Ab_WB initialized to NaN so that
+  // This skips the world mobilized body, mobod_index 0.
+  // For world we opted for leaving Ab_WB initialized to NaN so that
   // an accidental usage (most likely indicating unnecessary math) in code would
   // immediately trigger a trail of NaNs that we can track to the source.
   // TODO(joemasterjohn): Consider an optimization where we avoid computing
   //  `Ab_WB` for locked floating bodies.
-  (*Ab_WB_all)[world_index()].SetNaN();
-  for (BodyNodeIndex body_node_index(1); body_node_index < num_bodies();
-       ++body_node_index) {
-    const BodyNode<T>& node = *body_nodes_[body_node_index];
-    SpatialAcceleration<T>& Ab_WB = (*Ab_WB_all)[body_node_index];
+  (*Ab_WB_all)[world_mobod_index()].SetNaN();
+  for (MobodIndex mobod_index(1);
+       mobod_index < topology_.num_mobods(); ++mobod_index) {
+    const BodyNode<T>& node = *body_nodes_[mobod_index];
+    SpatialAcceleration<T>& Ab_WB = (*Ab_WB_all)[mobod_index];
     node.CalcSpatialAccelerationBias(context, pc, vc, &Ab_WB);
   }
 }
@@ -1267,44 +1272,49 @@ void MultibodyTree<T>::CalcArticulatedBodyForceBias(
     const ArticulatedBodyInertiaCache<T>& abic,
     std::vector<SpatialForce<T>>* Zb_Bo_W_all) const {
   DRAKE_THROW_UNLESS(Zb_Bo_W_all != nullptr);
-  DRAKE_THROW_UNLESS(static_cast<int>(Zb_Bo_W_all->size()) == num_bodies());
+  DRAKE_THROW_UNLESS(static_cast<int>(Zb_Bo_W_all->size()) ==
+      topology_.num_mobods());
   const std::vector<SpatialAcceleration<T>>& Ab_WB_cache =
       EvalSpatialAccelerationBiasCache(context);
 
-  // This skips the world, body_node_index = 0.
-  // For the world body we opted for leaving Zb_Bo_W initialized to NaN so that
+  // This skips the world mobilized body, mobod_index 0.
+  // For the world we opted for leaving Zb_Bo_W initialized to NaN so that
   // an accidental usage (most likely indicating unnecessary math) in code would
   // immediately trigger a trail of NaNs that we can track to the source.
   // TODO(joemasterjohn): Consider an optimization to avoid computing `Zb_Bo_W`
   //  for locked floating bodies.
-  (*Zb_Bo_W_all)[world_index()].SetNaN();
-  for (BodyNodeIndex body_node_index(1); body_node_index < num_bodies();
-       ++body_node_index) {
+  (*Zb_Bo_W_all)[world_mobod_index()].SetNaN();
+  for (MobodIndex mobod_index(1);
+       mobod_index < topology_.num_mobods(); ++mobod_index) {
     const ArticulatedBodyInertia<T>& Pplus_PB_W =
-        abic.get_Pplus_PB_W(body_node_index);
-    const SpatialAcceleration<T>& Ab_WB = Ab_WB_cache[body_node_index];
-    SpatialForce<T>& Zb_Bo_W = (*Zb_Bo_W_all)[body_node_index];
+        abic.get_Pplus_PB_W(mobod_index);
+    const SpatialAcceleration<T>& Ab_WB = Ab_WB_cache[mobod_index];
+    SpatialForce<T>& Zb_Bo_W = (*Zb_Bo_W_all)[mobod_index];
     Zb_Bo_W = Pplus_PB_W * Ab_WB;
   }
 }
 
+// Result is indexed by MobodIndex.
 template <typename T>
 void MultibodyTree<T>::CalcArticulatedBodyForceBias(
     const systems::Context<T>& context,
     std::vector<SpatialForce<T>>* Zb_Bo_W_all) const {
   DRAKE_THROW_UNLESS(Zb_Bo_W_all != nullptr);
-  DRAKE_THROW_UNLESS(static_cast<int>(Zb_Bo_W_all->size()) == num_bodies());
+  DRAKE_THROW_UNLESS(static_cast<int>(Zb_Bo_W_all->size()) ==
+      topology_.num_mobods());
   const ArticulatedBodyInertiaCache<T>& abic =
       EvalArticulatedBodyInertiaCache(context);
   CalcArticulatedBodyForceBias(context, abic, Zb_Bo_W_all);
 }
 
+// Result is indexed by MobodIndex.
 template <typename T>
 void MultibodyTree<T>::CalcDynamicBiasForces(
     const systems::Context<T>& context,
     std::vector<SpatialForce<T>>* Fb_Bo_W_all) const {
   DRAKE_THROW_UNLESS(Fb_Bo_W_all != nullptr);
-  DRAKE_THROW_UNLESS(static_cast<int>(Fb_Bo_W_all->size()) == num_bodies());
+  DRAKE_THROW_UNLESS(static_cast<int>(Fb_Bo_W_all->size()) ==
+      topology_.num_mobods());
 
   const std::vector<SpatialInertia<T>>& spatial_inertia_in_world_cache =
       EvalSpatialInertiaInWorldCache(context);
@@ -1316,7 +1326,7 @@ void MultibodyTree<T>::CalcDynamicBiasForces(
     const Body<T>& body = get_body(body_index);
 
     const SpatialInertia<T>& M_B_W =
-        spatial_inertia_in_world_cache[body.node_index()];
+        spatial_inertia_in_world_cache[body.mobod_index()];
 
     const T& mass = M_B_W.get_mass();
     // B's center of mass measured in B and expressed in W.
@@ -1326,9 +1336,9 @@ void MultibodyTree<T>::CalcDynamicBiasForces(
 
     // Gyroscopic spatial force Fb_Bo_W(q, v) on body B about Bo, expressed in
     // W.
-    const SpatialVelocity<T>& V_WB = vc.get_V_WB(body.node_index());
+    const SpatialVelocity<T>& V_WB = vc.get_V_WB(body.mobod_index());
     const Vector3<T>& w_WB = V_WB.rotational();
-    SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_all)[body.node_index()];
+    SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_all)[body.mobod_index()];
     Fb_Bo_W = mass * SpatialForce<T>(
                         w_WB.cross(G_B_W * w_WB), /* rotational */
                         w_WB.cross(w_WB.cross(p_BoBcm_W)) /* translational */);
@@ -1354,7 +1364,8 @@ void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
     bool ignore_velocities,
     std::vector<SpatialAcceleration<T>>* A_WB_array) const {
   DRAKE_DEMAND(A_WB_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(A_WB_array->size()) == num_bodies());
+  DRAKE_DEMAND(static_cast<int>(A_WB_array->size()) ==
+      topology_.num_mobods());
 
   DRAKE_DEMAND(known_vdot.size() == topology_.num_velocities());
 
@@ -1363,16 +1374,16 @@ void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
       ignore_velocities ? nullptr : &EvalVelocityKinematics(context);
 
   // The world's spatial acceleration is always zero.
-  A_WB_array->at(world_index()) = SpatialAcceleration<T>::Zero();
+  A_WB_array->at(world_mobod_index()) = SpatialAcceleration<T>::Zero();
 
   // Performs a base-to-tip recursion computing body accelerations.
   // This skips the world, depth = 0.
-  for (int depth = 1; depth < tree_height(); ++depth) {
-    for (BodyNodeIndex body_node_index : body_node_levels_[depth]) {
-      const BodyNode<T>& node = *body_nodes_[body_node_index];
+  for (int level = 1; level < tree_height(); ++level) {
+    for (MobodIndex mobod_index : body_node_levels_[level]) {
+      const BodyNode<T>& node = *body_nodes_[mobod_index];
 
-      DRAKE_ASSERT(node.get_topology().level == depth);
-      DRAKE_ASSERT(node.index() == body_node_index);
+      DRAKE_ASSERT(node.get_topology().level == level);
+      DRAKE_ASSERT(node.index() == mobod_index);
 
       // Update per-node kinematics.
       node.CalcSpatialAcceleration_BaseToTip(
@@ -1412,6 +1423,7 @@ VectorX<T> MultibodyTree<T>::CalcInverseDynamics(
   return tau;
 }
 
+// All argument vectors are indexed by MobodIndex.
 template <typename T>
 void MultibodyTree<T>::CalcInverseDynamics(
     const systems::Context<T>& context, const VectorX<T>& known_vdot,
@@ -1426,6 +1438,7 @@ void MultibodyTree<T>::CalcInverseDynamics(
                       F_BMo_W_array, tau_array);
 }
 
+// All argument vectors are indexed by MobodIndex.
 template <typename T>
 void MultibodyTree<T>::CalcInverseDynamics(
     const systems::Context<T>& context,
@@ -1438,16 +1451,18 @@ void MultibodyTree<T>::CalcInverseDynamics(
     EigenPtr<VectorX<T>> tau_array) const {
   DRAKE_DEMAND(known_vdot.size() == num_velocities());
   const int Fapplied_size = static_cast<int>(Fapplied_Bo_W_array.size());
-  DRAKE_DEMAND(Fapplied_size == num_bodies() || Fapplied_size == 0);
+  DRAKE_DEMAND(Fapplied_size == topology_.num_mobods() ||
+               Fapplied_size == 0);
   const int tau_applied_size = tau_applied_array.size();
-  DRAKE_DEMAND(
-      tau_applied_size == num_velocities() || tau_applied_size == 0);
+  DRAKE_DEMAND(tau_applied_size == num_velocities() || tau_applied_size == 0);
 
   DRAKE_DEMAND(A_WB_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(A_WB_array->size()) == num_bodies());
+  DRAKE_DEMAND(static_cast<int>(A_WB_array->size()) ==
+      topology_.num_mobods());
 
   DRAKE_DEMAND(F_BMo_W_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(F_BMo_W_array->size()) == num_bodies());
+  DRAKE_DEMAND(static_cast<int>(F_BMo_W_array->size()) ==
+      topology_.num_mobods());
 
   DRAKE_DEMAND(tau_array->size() == num_velocities());
 
@@ -1478,15 +1493,15 @@ void MultibodyTree<T>::CalcInverseDynamics(
 
   // Performs a tip-to-base recursion computing the total spatial force F_BMo_W
   // acting on body B, about point Mo, expressed in the world frame W.
-  // This includes the world (depth = 0) so that F_BMo_W_array[world_index()]
-  // contains the total force of the bodies connected to the world by a
-  // mobilizer.
-  for (int depth = tree_height() - 1; depth >= 0; --depth) {
-    for (BodyNodeIndex body_node_index : body_node_levels_[depth]) {
-      const BodyNode<T>& node = *body_nodes_[body_node_index];
+  // This includes the world (depth = 0) so that
+  // F_BMo_W_array[world_mobod_index()] contains the total force of the bodies
+  // connected to the world by a mobilizer.
+  for (int level = tree_height() - 1; level >= 0; --level) {
+    for (MobodIndex mobod_index : body_node_levels_[level]) {
+      const BodyNode<T>& node = *body_nodes_[mobod_index];
 
-      DRAKE_ASSERT(node.get_topology().level == depth);
-      DRAKE_ASSERT(node.index() == body_node_index);
+      DRAKE_ASSERT(node.get_topology().level == level);
+      DRAKE_ASSERT(node.index() == mobod_index);
 
       // Make a copy to the total applied forces since the call to
       // CalcInverseDynamics_TipToBase() below could overwrite the entry for the
@@ -1501,7 +1516,7 @@ void MultibodyTree<T>::CalcInverseDynamics(
                 tau_applied_array);
       }
       if (Fapplied_size != 0) {
-        Fapplied_Bo_W = Fapplied_Bo_W_array[body_node_index];
+        Fapplied_Bo_W = Fapplied_Bo_W_array[mobod_index];
       }
 
       // Compute F_BMo_W for the body associated with this node and project it
@@ -1677,8 +1692,8 @@ void MultibodyTree<T>::CalcMassMatrixViaInverseDynamics(
   VectorX<T> vdot(nv);
   VectorX<T> tau(nv);
   // Auxiliary arrays used by inverse dynamics.
-  std::vector<SpatialAcceleration<T>> A_WB_array(num_bodies());
-  std::vector<SpatialForce<T>> F_BMo_W_array(num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB_array(topology_.num_mobods());
+  std::vector<SpatialForce<T>> F_BMo_W_array(topology_.num_mobods());
 
   // The mass matrix is only a function of configuration q. Therefore velocity
   // terms are not considered.
@@ -1733,16 +1748,16 @@ void MultibodyTree<T>::CalcMassMatrix(const systems::Context<T>& context,
   (*M) = reflected_inertia.asDiagonal();
 
   // Perform tip-to-base recursion for each composite body, skipping the world.
-  for (int depth = tree_height() - 1; depth > 0; --depth) {
-    for (BodyNodeIndex composite_node_index : body_node_levels_[depth]) {
+  for (int level = tree_height() - 1; level > 0; --level) {
+    for (MobodIndex mobod_index : body_node_levels_[level]) {
       // Node corresponding to the composite body C.
-      const BodyNode<T>& composite_node = *body_nodes_[composite_node_index];
+      const BodyNode<T>& composite_node = *body_nodes_[mobod_index];
       const int cnv = composite_node.get_num_mobilizer_velocities();
 
       if (cnv == 0) continue;  // Weld has no generalized coordinates, so skip.
 
       // This node's 6x6 composite body inertia.
-      const SpatialInertia<T>& Mc_C_W = Mc_B_W_cache[composite_node_index];
+      const SpatialInertia<T>& Mc_C_W = Mc_B_W_cache[mobod_index];
 
       // Across-mobilizer 6 x cnv hinge matrix, from C's parent Cp to C.
       Eigen::Map<const MatrixUpTo6<T>> H_CpC_W =
@@ -1775,7 +1790,7 @@ void MultibodyTree<T>::CalcMassMatrix(const systems::Context<T>& context,
 
       const int composite_start_in_v = composite_node.velocity_start_in_v();
 
-      // Diagonal block corresponding to current node (composite_node_index).
+      // Diagonal block corresponding to current node (mobod_index).
       M->block(composite_start_in_v, composite_start_in_v, cnv, cnv) +=
           H_CpC_W.transpose() * Fm_CCo_W;
 
@@ -1832,8 +1847,8 @@ void MultibodyTree<T>::CalcBiasTerm(
   const int nv = num_velocities();
   const VectorX<T> vdot = VectorX<T>::Zero(nv);
   // Auxiliary arrays used by inverse dynamics.
-  std::vector<SpatialAcceleration<T>> A_WB_array(num_bodies());
-  std::vector<SpatialForce<T>> F_BMo_W_array(num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB_array(topology_.num_mobods());
+  std::vector<SpatialForce<T>> F_BMo_W_array(topology_.num_mobods());
   // TODO(amcastro-tri): provide specific API for when vdot = 0.
   CalcInverseDynamics(context, vdot, {}, VectorX<T>(),
                       &A_WB_array, &F_BMo_W_array, Cv);
@@ -1860,8 +1875,8 @@ RigidTransform<T> MultibodyTree<T>::CalcRelativeTransform(
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const Body<T>& A = frame_F.body();
   const Body<T>& B = frame_G.body();
-  const RigidTransform<T>& X_WA = pc.get_X_WB(A.node_index());
-  const RigidTransform<T>& X_WB = pc.get_X_WB(B.node_index());
+  const RigidTransform<T>& X_WA = pc.get_X_WB(A.mobod_index());
+  const RigidTransform<T>& X_WB = pc.get_X_WB(B.mobod_index());
   const RigidTransform<T> X_WF = X_WA * frame_F.CalcPoseInBodyFrame(context);
   const RigidTransform<T> X_WG = X_WB * frame_G.CalcPoseInBodyFrame(context);
   return X_WF.InvertAndCompose(X_WG);  // X_FG = X_FW * X_WG;
@@ -1878,8 +1893,8 @@ RotationMatrix<T> MultibodyTree<T>::CalcRelativeRotationMatrix(
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const Body<T>& A = frame_F.body();
   const Body<T>& B = frame_G.body();
-  const RotationMatrix<T>& R_WA = pc.get_R_WB(A.node_index());
-  const RotationMatrix<T>& R_WB = pc.get_R_WB(B.node_index());
+  const RotationMatrix<T>& R_WA = pc.get_R_WB(A.mobod_index());
+  const RotationMatrix<T>& R_WB = pc.get_R_WB(B.mobod_index());
   const RotationMatrix<T> R_AF = frame_F.CalcRotationMatrixInBodyFrame(context);
   const RotationMatrix<T> R_BG = frame_G.CalcRotationMatrixInBodyFrame(context);
   const RotationMatrix<T> R_WF = R_WA * R_AF;
@@ -2060,11 +2075,11 @@ SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
 
     // Get the current body B's spatial inertia about Bo (body B's origin),
     // expressed in the world frame W.
-    const BodyNodeIndex body_node_index = get_body(body_index).node_index();
-    const SpatialInertia<T>& M_BBo_W = M_Bi_W[body_node_index];
+    const MobodIndex mobod_index = get_body(body_index).mobod_index();
+    const SpatialInertia<T>& M_BBo_W = M_Bi_W[mobod_index];
 
     // Shift M_BBo_W from about-point Bo to about-point Wo and add to the sum.
-    const RigidTransform<T>& X_WB = pc.get_X_WB(body_node_index);
+    const RigidTransform<T>& X_WB = pc.get_X_WB(mobod_index);
     const Vector3<T>& p_WoBo_W = X_WB.translation();
     M_SWo_W += M_BBo_W.Shift(-p_WoBo_W);  // Shift from Bo to Wo by p_BoWo_W.
   }
@@ -2245,13 +2260,13 @@ SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
     DRAKE_DEMAND(body_index < num_bodies());
 
     // Form the current body's spatial momentum in W about Bo, expressed in W.
-    const BodyNodeIndex body_node_index = get_body(body_index).node_index();
-    const SpatialInertia<T>& M_BBo_W = M_Bi_W[body_node_index];
-    const SpatialVelocity<T>& V_WBo_W = vc.get_V_WB(body_node_index);
+    const MobodIndex mobod_index = get_body(body_index).mobod_index();
+    const SpatialInertia<T>& M_BBo_W = M_Bi_W[mobod_index];
+    const SpatialVelocity<T>& V_WBo_W = vc.get_V_WB(mobod_index);
     SpatialMomentum<T> L_WBo_W = M_BBo_W * V_WBo_W;
 
     // Shift L_WBo_W from about Bo to about Wo and accumulate the sum.
-    const RigidTransform<T>& X_WB = pc.get_X_WB(body_node_index);
+    const RigidTransform<T>& X_WB = pc.get_X_WB(mobod_index);
     const Vector3<T>& p_WoBo_W = X_WB.translation();
     L_WS_W += L_WBo_W.ShiftInPlace(-p_WoBo_W);
   }
@@ -2265,7 +2280,7 @@ const RigidTransform<T>& MultibodyTree<T>::EvalBodyPoseInWorld(
     const Body<T>& body_B) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   body_B.HasThisParentTreeOrThrow(this);
-  return EvalPositionKinematics(context).get_X_WB(body_B.node_index());
+  return EvalPositionKinematics(context).get_X_WB(body_B.mobod_index());
 }
 
 template <typename T>
@@ -2274,7 +2289,7 @@ const SpatialVelocity<T>& MultibodyTree<T>::EvalBodySpatialVelocityInWorld(
     const Body<T>& body_B) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   body_B.HasThisParentTreeOrThrow(this);
-  return EvalVelocityKinematics(context).get_V_WB(body_B.node_index());
+  return EvalVelocityKinematics(context).get_V_WB(body_B.mobod_index());
 }
 
 template <typename T>
@@ -2289,9 +2304,10 @@ void MultibodyTree<T>::CalcAcrossNodeJacobianWrtVExpressedInWorld(
   if (num_velocities() == 0) return;
 
   // TODO(joemasterjohn): Consider and optimization where we avoid computing
-  // `H_PB_W` for locked floating bodies.
-  for (BodyNodeIndex node_index(1); node_index < num_bodies(); ++node_index) {
-    const BodyNode<T>& node = *body_nodes_[node_index];
+  //  `H_PB_W` for locked floating bodies.
+  for (MobodIndex mobod_index(1);
+       mobod_index < topology_.num_mobods(); ++mobod_index) {
+    const BodyNode<T>& node = *body_nodes_[mobod_index];
 
     // The body-node hinge matrix is H_PB_W ∈ ℝ⁶ˣⁿᵐ, with nm ∈ [0; 6] the number
     // of mobilities for this node.
@@ -2355,13 +2371,13 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcBiasSpatialAcceleration(
   // Extract body_B's spatial acceleration bias in W from AsBias_WB_all.
   const Body<T>& body_B = frame_B.body();
   const SpatialAcceleration<T> AsBias_WBodyB_W =
-      AsBias_WB_all[body_B.node_index()];
+      AsBias_WB_all[body_B.mobod_index()];
 
   // Frame_A is regarded as fixed/welded to a body herein named body_A.
   // Extract body_A's spatial acceleration bias in W from AsBias_WB_all.
   const Body<T>& body_A = frame_A.body();
   const SpatialAcceleration<T> AsBias_WBodyA_W =
-      AsBias_WB_all[body_A.node_index()];
+      AsBias_WB_all[body_A.mobod_index()];
 
   // Calculate Bp's spatial acceleration bias in body_A, expressed in frame_E.
   return CalcSpatialAccelerationHelper(context, frame_B, p_BoBp_B, body_A,
@@ -2515,12 +2531,12 @@ SpatialAcceleration<T> MultibodyTree<T>::ShiftSpatialAccelerationInWorld(
   }
 
   // Form the position vector from Ao to Bp, expressed in the world frame W.
-  const RotationMatrix<T>& R_WA = pc.get_R_WB(body_A.node_index());
+  const RotationMatrix<T>& R_WA = pc.get_R_WB(body_A.mobod_index());
   const Vector3<T> p_AoBp_W = R_WA * p_AoBp_A;
 
   // Shift spatial acceleration from body_A to frame_Bp.
   // Note: Since frame_B is assumed to be fixed to body_A, w_WB = w_WA.
-  const Vector3<T>& w_WA_W = vc.get_V_WB(body_A.node_index()).rotational();
+  const Vector3<T>& w_WA_W = vc.get_V_WB(body_A.mobod_index()).rotational();
   SpatialAcceleration<T> A_WBp_W = A_WA_W.Shift(p_AoBp_W, w_WA_W);
   return A_WBp_W;
 }
@@ -2656,16 +2672,16 @@ void MultibodyTree<T>::CalcJacobianAngularVelocity(
   // Js_w_AB_E = R_EW * (Js_w_WB_W - Js_w_WA_W).
 
   // TODO(Mitiguy): When performance becomes an issue, optimize this method by
-  // only using the kinematics path from A to B.
+  //  only using the kinematics path from A to B.
 
   // Create dummy position list for signature requirements of next method.
   const Eigen::Matrix<T, 3, 0> empty_position_list;
 
   // TODO(Mitiguy) One way to avoid memory allocation and speed this up is to
-  // be clever and use the input argument as follows:
-  // Eigen::Ref<MatrixX<T>> Js_w_WA_W = *Js_w_AB_E;
-  // Also modify CalcJacobianAngularAndOrTranslationalVelocityInWorld() so
-  // it can add or subtract to the Jacobian that is passed to it.
+  //  be clever and use the input argument as follows:
+  //  Eigen::Ref<MatrixX<T>> Js_w_WA_W = *Js_w_AB_E;
+  //  Also modify CalcJacobianAngularAndOrTranslationalVelocityInWorld() so
+  //  it can add or subtract to the Jacobian that is passed to it.
   Matrix3X<T> Js_w_WA_W(3, num_columns);
   CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
       with_respect_to, frame_A, empty_position_list, &Js_w_WA_W, nullptr);
@@ -2712,7 +2728,7 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocityHelper(
   // Rearrange to calculate Bi's velocity in A as v_ABi = v_WBi - v_WAi.
 
   // TODO(Mitiguy): When performance becomes an issue, optimize this method by
-  // only using the kinematics path from A to B.
+  //  only using the kinematics path from A to B.
 
   // Calculate each point Bi's translational velocity Jacobian in world W.
   // The result is Js_v_WBi_W, but we store into Js_v_ABi_W for performance.
@@ -2820,8 +2836,8 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
   if (body_F.index() == world_index()) return;
 
   // Form kinematic path from body_F to the world.
-  std::vector<BodyNodeIndex> path_to_world;
-  topology_.GetKinematicPathToWorld(body_F.node_index(), &path_to_world);
+  std::vector<MobodIndex> path_to_world;
+  topology_.GetKinematicPathToWorld(body_F.mobod_index(), &path_to_world);
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
 
   const std::vector<Vector6<T>>& H_PB_W_cache =
@@ -2832,10 +2848,10 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
 
   // For all bodies in the kinematic path from the world to body_F, compute
   // each node's contribution to the Jacobians.
-  // Skip the world (ilevel = 0).
-  for (size_t ilevel = 1; ilevel < path_to_world.size(); ++ilevel) {
-    const BodyNodeIndex body_node_index = path_to_world[ilevel];
-    const BodyNode<T>& node = *body_nodes_[body_node_index];
+  // Skip the world (level = 0).
+  for (size_t level = 1; level < path_to_world.size(); ++level) {
+    const MobodIndex mobod_index = path_to_world[level];
+    const BodyNode<T>& node = *body_nodes_[mobod_index];
     const BodyNodeTopology& node_topology = node.get_topology();
     const Mobilizer<T>& mobilizer = node.get_mobilizer();
     const int start_index_in_v = node_topology.mobilizer_velocities_start_in_v;
@@ -2866,8 +2882,8 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
     // Mapping defined by v = N⁺(q)⋅q̇.
     if (is_wrt_qdot) {
       // TODO(amcastro-tri): consider using an operator version instead only
-      // if/when the computational cost of multiplying with Nplus from the
-      // right becomes a bottleneck.
+      //  if/when the computational cost of multiplying with Nplus from the
+      //  right becomes a bottleneck.
       // TODO(amcastro-tri): cache Nplus to avoid memory allocations.
       Nplus.resize(mobilizer_num_velocities, mobilizer_num_positions);
       mobilizer.CalcNplusMatrix(context, &Nplus);
@@ -2924,9 +2940,9 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
         } else {
           Hv_PFpi_W = Hv_PB_W + Hw_PB_W.colwise().cross(p_BoFp_W);
         }
-      }  // ipoint.
+      }
     }
-  }  // body_node_index
+  }
 }
 
 template <typename T>
@@ -3103,9 +3119,9 @@ T MultibodyTree<T>::CalcKineticEnergy(
   T twice_kinetic_energy_W = 0.0;
   // Add contributions from each body (except World).
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const BodyNodeIndex node_index = get_body(body_index).node_index();
-    const SpatialInertia<T>& M_B_W = M_Bi_W[node_index];
-    const SpatialVelocity<T>& V_WB = vc.get_V_WB(node_index);
+    const MobodIndex mobod_index = get_body(body_index).mobod_index();
+    const SpatialInertia<T>& M_B_W = M_Bi_W[mobod_index];
+    const SpatialVelocity<T>& V_WB = vc.get_V_WB(mobod_index);
     const SpatialMomentum<T> L_WB = M_B_W * V_WB;
 
     twice_kinetic_energy_W += L_WB.dot(V_WB);
@@ -3212,9 +3228,9 @@ void MultibodyTree<T>::ThrowDefaultMassInertiaError() const {
     // Determine whether this set of welded bodies is a most distal leaf in
     // a multibody tree. Reminder, there can be more than one distal leaf as a
     // robot may two or more arms, each with grippers that are distal leafs.
-    const BodyNodeIndex parent_body_node_index = parent_body_topology.body_node;
+    const MobodIndex parent_mobod_index = parent_body_topology.mobod_index;
     const BodyNodeTopology& parent_body_node_topology =
-        tree_topology.get_body_node(parent_body_node_index);
+        tree_topology.get_body_node(parent_mobod_index);
     const bool is_composite_body_distal_leaf_in_tree =
         tree_topology.CalcNumberOfOutboardVelocitiesExcludingBase(
             parent_body_node_topology) == 0;
@@ -3311,7 +3327,7 @@ void MultibodyTree<T>::CalcArticulatedBodyInertiaCache(
   DRAKE_DEMAND(abic != nullptr);
 
   // TODO(amcastro-tri): consider combining these to improve memory access
-  // pattern into a single position kinematics pass.
+  //  pattern into a single position kinematics pass.
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const std::vector<Vector6<T>>& H_PB_W_cache =
       EvalAcrossNodeJacobianWrtVExpressedInWorld(context);
@@ -3320,14 +3336,14 @@ void MultibodyTree<T>::CalcArticulatedBodyInertiaCache(
 
   // Perform tip-to-base recursion, skipping the world.
   for (int depth = tree_height() - 1; depth > 0; --depth) {
-    for (BodyNodeIndex body_node_index : body_node_levels_[depth]) {
-      const BodyNode<T>& node = *body_nodes_[body_node_index];
+    for (MobodIndex mobod_index : body_node_levels_[depth]) {
+      const BodyNode<T>& node = *body_nodes_[mobod_index];
 
       // Get hinge matrix and spatial inertia for this node.
       Eigen::Map<const MatrixUpTo6<T>> H_PB_W =
           node.GetJacobianFromArray(H_PB_W_cache);
       const SpatialInertia<T>& M_B_W =
-          spatial_inertia_in_world_cache[body_node_index];
+          spatial_inertia_in_world_cache[mobod_index];
 
       node.CalcArticulatedBodyInertiaCache_TipToBase(
           context, pc, H_PB_W, M_B_W, diagonal_inertias, abic);
@@ -3363,20 +3379,20 @@ void MultibodyTree<T>::CalcArticulatedBodyForceCache(
 
   // Perform tip-to-base recursion, skipping the world.
   for (int depth = tree_height() - 1; depth > 0; --depth) {
-    for (BodyNodeIndex body_node_index : body_node_levels_[depth]) {
-      const BodyNode<T>& node = *body_nodes_[body_node_index];
+    for (MobodIndex mobod_index : body_node_levels_[depth]) {
+      const BodyNode<T>& node = *body_nodes_[mobod_index];
 
       // Get generalized force and body force for this node.
       Eigen::Ref<const VectorX<T>> tau_applied =
           node.get_mobilizer().get_generalized_forces_from_array(
               generalized_forces);
-      const SpatialForce<T>& Fapplied_Bo_W = body_forces[body_node_index];
+      const SpatialForce<T>& Fapplied_Bo_W = body_forces[mobod_index];
 
       // Get references to the hinge matrix and force bias for this node.
       Eigen::Map<const MatrixUpTo6<T>> H_PB_W =
           node.GetJacobianFromArray(H_PB_W_cache);
-      const SpatialForce<T>& Fb_B_W = dynamic_bias_cache[body_node_index];
-      const SpatialForce<T>& Zb_Bo_W = Zb_Bo_W_cache[body_node_index];
+      const SpatialForce<T>& Fb_B_W = dynamic_bias_cache[mobod_index];
+      const SpatialForce<T>& Zb_Bo_W = Zb_Bo_W_cache[mobod_index];
 
       node.CalcArticulatedBodyForceCache_TipToBase(
           context, pc, &vc, Fb_B_W, abic, Zb_Bo_W, Fapplied_Bo_W, tau_applied,
@@ -3416,11 +3432,11 @@ void MultibodyTree<T>::CalcArticulatedBodyAccelerations(
       EvalSpatialAccelerationBiasCache(context);
 
   // Perform base-to-tip recursion, skipping the world.
-  for (int depth = 1; depth < tree_height(); ++depth) {
-    for (BodyNodeIndex body_node_index : body_node_levels_[depth]) {
-      const BodyNode<T>& node = *body_nodes_[body_node_index];
+  for (int level = 1; level < tree_height(); ++level) {
+    for (MobodIndex mobod_index : body_node_levels_[level]) {
+      const BodyNode<T>& node = *body_nodes_[mobod_index];
 
-      const SpatialAcceleration<T>& Ab_WB = Ab_WB_cache[body_node_index];
+      const SpatialAcceleration<T>& Ab_WB = Ab_WB_cache[mobod_index];
 
       // Get reference to the hinge mapping matrix.
       Eigen::Map<const MatrixUpTo6<T>> H_PB_W =

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -554,37 +554,27 @@ class MultibodyTree {
   // Closes Doxygen section "Methods to add new MultibodyTree elements."
 
   // See MultibodyPlant method.
-  int num_frames() const {
-    return static_cast<int>(frames_.size());
-  }
+  int num_frames() const { return ssize(frames_); }
 
-  // Returns the number of bodies in the %MultibodyTree including the *world*
-  // body. Therefore the minimum number of bodies in a MultibodyTree is one.
-  int num_bodies() const { return static_cast<int>(owned_bodies_.size()); }
+  // Returns the number of bodies in the MultibodyPlant including the world
+  // body. Therefore the minimum number of bodies is one.
+  int num_bodies() const { return ssize(owned_bodies_); }
 
   // Returns the number of joints added with AddJoint() to the %MultibodyTree.
-  int num_joints() const { return static_cast<int>(owned_joints_.size()); }
+  int num_joints() const { return ssize(owned_joints_); }
 
   // Returns the number of actuators in the model.
   // @see AddJointActuator().
-  int num_actuators() const {
-    return static_cast<int>(owned_actuators_.size());
-  }
+  int num_actuators() const { return ssize(owned_actuators_); }
 
   // See MultibodyPlant method.
-  int num_mobilizers() const {
-    return static_cast<int>(owned_mobilizers_.size());
-  }
+  int num_mobilizers() const { return ssize(owned_mobilizers_); }
 
   // See MultibodyPlant method.
-  int num_force_elements() const {
-    return static_cast<int>(owned_force_elements_.size());
-  }
+  int num_force_elements() const { return ssize(owned_force_elements_); }
 
   // Returns the number of model instances in the MultibodyTree.
-  int num_model_instances() const {
-    return static_cast<int>(instance_name_to_index_.size());
-  }
+  int num_model_instances() const { return ssize(instance_name_to_index_); }
 
   // Returns the number of generalized positions of the model.
   int num_positions() const {
@@ -1435,7 +1425,7 @@ class MultibodyTree {
   // @param[in] context
   //   The context storing the state of the model.
   // @param[out] M_B_W_all
-  //   For each body in the model, entry Body::node_index() in M_B_W_all
+  //   For each body in the model, entry Body::mobod_index() in M_B_W_all
   //   contains the updated spatial inertia `M_B_W(q)` for that body. On input
   //   it must be a valid pointer to a vector of size num_bodies().
   // @throws std::exception if M_B_W_all is nullptr or if its size is not
@@ -1462,7 +1452,7 @@ class MultibodyTree {
   // @param[in] context
   //   The context storing the state of the model.
   // @param[out] Mc_B_W_all
-  //   For each body in the model, entry Body::node_index() in M_B_W_all
+  //   For each body in the model, entry Body::mobod_index() in M_B_W_all
   //   contains the updated composite body inertia `Mc_B_W(q)` for that body.
   //   On input it must be a valid pointer to a vector of size num_bodies().
   // @throws std::exception if Mc_B_W_all is nullptr or if its size is not
@@ -1479,7 +1469,7 @@ class MultibodyTree {
   // @param[in] context
   //   The context storing the state of the model.
   // @param[out] Fb_Bo_W_all
-  //   For each body in the model, entry Body::node_index() in Fb_Bo_W_all
+  //   For each body in the model, entry Body::mobod_index() in Fb_Bo_W_all
   //   contains the updated bias term `Fb_Bo_W(q, v)` for that body. On input
   //   it must be a valid pointer to a vector of size num_bodies().
   // @throws std::exception if Fb_Bo_W_cache is nullptr or if its size is not
@@ -1521,7 +1511,7 @@ class MultibodyTree {
       AccelerationKinematicsCache<T>* ac) const;
 
   // See MultibodyPlant method.
-  // @warning The output parameter `A_WB_array` is indexed by BodyNodeIndex,
+  // @warning The output parameter `A_WB_array` is indexed by MobodIndex,
   // while MultibodyPlant's method returns accelerations indexed by BodyIndex.
   void CalcSpatialAccelerationsFromVdot(
       const systems::Context<T>& context,
@@ -1574,8 +1564,8 @@ class MultibodyTree {
   //   `Fapplied_Bo_W_array` can have zero size which means there are no
   //   applied forces. To apply non-zero forces, `Fapplied_Bo_W_array` must be
   //   of size equal to the number of bodies in `this` %MultibodyTree model.
-  //   This array must be ordered by BodyNodeIndex, which for a given body can
-  //   be retrieved with Body::node_index().
+  //   This array must be ordered by MobodIndex, which for a given body can
+  //   be retrieved with Body::mobod_index().
   //   This method will abort if provided with an array that does not have a
   //   size of either `num_bodies()` or zero.
   // @param[in] tau_applied_array
@@ -1595,9 +1585,9 @@ class MultibodyTree {
   //   containing the spatial acceleration `A_WB` for each body. It must be of
   //   size equal to the number of bodies. This method will abort if the
   //   pointer is null or if `A_WB_array` is not of size `num_bodies()`.
-  //   On output, entries will be ordered by BodyNodeIndex.
+  //   On output, entries will be ordered by MobodIndex.
   //   To access the acceleration `A_WB` of given body B in this array, use the
-  //   index returned by Body::node_index().
+  //   index returned by Body::mobod_index().
   // @param[out] F_BMo_W_array
   //   A pointer to a valid, non nullptr, vector of spatial forces
   //   containing, for each body B, the spatial force `F_BMo_W` corresponding
@@ -1606,9 +1596,9 @@ class MultibodyTree {
   //   It must be of size equal to the number of bodies in the MultibodyTree.
   //   This method will abort if the pointer is null or if `F_BMo_W_array`
   //   is not of size `num_bodies()`.
-  //   On output, entries will be ordered by BodyNodeIndex.
+  //   On output, entries will be ordered by MobodIndex.
   //   To access a mobilizer's reaction force on given body B in this array,
-  //   use the index returned by Body::node_index().
+  //   use the index returned by Body::mobod_index().
   // @param[out] tau_array
   //   On output this array will contain the generalized forces that must be
   //   applied in order to achieve the desired generalized accelerations given
@@ -1618,8 +1608,8 @@ class MultibodyTree {
   //   Mobilizer::get_generalized_forces_from_array().
   //
   // @warning There is no mechanism to assert that either `A_WB_array` nor
-  //   `F_BMo_W_array` are ordered by BodyNodeIndex. You can use
-  //   Body::node_index() to obtain the node index for a given body.
+  //   `F_BMo_W_array` are ordered by MobodIndex. You can use
+  //   Body::mobod_index() to obtain the node index for a given body.
   //
   // @note This method uses `F_BMo_W_array` and `tau_array` as the only local
   // temporaries and therefore no additional dynamic memory allocation is
@@ -2045,15 +2035,15 @@ class MultibodyTree {
   // Φᵀ(p_PB) * A_WP` the rigidly shifted spatial acceleration of the inboard
   // body P and `H_PB_W` and `vdot_B` its mobilizer's hinge matrix and
   // mobilities, respectively. See @ref abi_computing_accelerations for further
-  // details. On output `Ab_WB_all[body_node_index]`
-  // contains `Ab_WB` for the body with node index `body_node_index`.
+  // details. On output `Ab_WB_all[mobod_index]`
+  // contains `Ab_WB` for the body with node index `mobod_index`.
   void CalcSpatialAccelerationBias(
       const systems::Context<T>& context,
       std::vector<SpatialAcceleration<T>>* Ab_WB_all) const;
 
   // Computes the articulated body force bias `Zb_Bo_W = Pplus_PB_W * Ab_WB`
-  // for each articulated body B. On output `Zb_Bo_W_all[body_node_index]`
-  // contains `Zb_Bo_W` for the body B with node index `body_node_index`.
+  // for each articulated body B. On output `Zb_Bo_W_all[mobod_index]`
+  // contains `Zb_Bo_W` for the body B with node index `mobod_index`.
   void CalcArticulatedBodyForceBias(
       const systems::Context<T>& context,
       std::vector<SpatialForce<T>>* Zb_Bo_W_all) const;
@@ -2922,13 +2912,13 @@ class MultibodyTree {
   // forces for a quick simple solution. This allows clients of MBT (namely MBP)
   // to implement their own customized (implicit) time stepping schemes.
   // TODO(amcastro-tri): Consider updating ForceElement to also compute a
-  // Jacobian for general force models. That would allow us to implement
-  // implicit schemes for any forces using a more general infrastructure rather
-  // than having to deal with damping in a special way.
+  //  Jacobian for general force models. That would allow us to implement
+  //  implicit schemes for any forces using a more general infrastructure rather
+  //  than having to deal with damping in a special way.
   void AddJointDampingForces(
       const systems::Context<T>& context, MultibodyForces<T>* forces) const;
 
-  void CreateBodyNode(BodyNodeIndex body_node_index);
+  void CreateBodyNode(MobodIndex mobod_index);
 
   void CreateModelInstances();
 
@@ -3148,7 +3138,7 @@ class MultibodyTree {
   // Body node indexes ordered by level (a.k.a depth). Therefore for the
   // i-th level body_node_levels_[i] contains the list of all body node indexes
   // in that level.
-  std::vector<std::vector<BodyNodeIndex>> body_node_levels_;
+  std::vector<std::vector<MobodIndex>> body_node_levels_;
 
   // Joint to Mobilizer map, of size num_joints(). For a joint with index
   // joint_index, mobilizer_index = joint_to_mobilizer_[joint_index] maps to the

--- a/multibody/tree/multibody_tree_indexes.h
+++ b/multibody/tree/multibody_tree_indexes.h
@@ -11,12 +11,20 @@ namespace internal {
 // Type used to identify mobilizers by index in a multibody tree system.
 using MobilizerIndex = TypeSafeIndex<class MobilizerTag>;
 
-// Type used to identify tree nodes by index within a multibody tree system.
-using BodyNodeIndex = TypeSafeIndex<class BodyNodeTag>;
+// Type used to identify any quantity associated with a "mobilized body"
+// (abbreviated "mobod"), which is a depth-first numbered node of the spanning
+// forest used to model a multibody system. This includes BodyNodes and
+// associated computed quantities such as their accelerations.
+// TODO(sherm1) Bring more objects into this numbering scheme,
+//  including Mobilizers.
+using MobodIndex = TypeSafeIndex<class MobodTag>;
 
 // Type used to identify a topological tree within the "forest" of a multibody
 // system.
 using TreeIndex = TypeSafeIndex<class TreeTag>;
+
+// World is always modeled as the 0th mobilized body.
+inline MobodIndex world_mobod_index() { return MobodIndex(0); }
 
 }  // namespace internal
 

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -68,7 +68,7 @@ struct BodyTopology {
     if (child_bodies != other.child_bodies) return false;
     if (body_frame != other.body_frame) return false;
     if (level != other.level) return false;
-    if (body_node != other.body_node) return false;
+    if (mobod_index != other.mobod_index) return false;
     if (is_floating != other.is_floating) return false;
     if (has_quaternion_dofs != other.has_quaternion_dofs) return false;
     if (floating_positions_start != other.floating_positions_start)
@@ -108,8 +108,8 @@ struct BodyTopology {
   // Finalize() when a user forgets to connect a body with a mobilizer.
   int level{-1};
 
-  // Index to the tree body node in the MultibodyTree.
-  BodyNodeIndex body_node;
+  // Index to the mobilized body (BodyNode) modeling this Body.
+  MobodIndex mobod_index;
 
   // `true` if this topology corresponds to a floating body in space.
   bool is_floating{false};
@@ -195,7 +195,7 @@ struct MobilizerTopology {
     if (inboard_body != other.inboard_body) return false;
     if (outboard_body != other.outboard_body) return false;
 
-    if (body_node != other.body_node) return false;
+    if (mobod_index != other.mobod_index) return false;
 
     if (num_positions != other.num_positions) return false;
     if (positions_start != other.positions_start) return false;
@@ -237,10 +237,8 @@ struct MobilizerTopology {
   BodyIndex inboard_body;
   // Index to the outboard body.
   BodyIndex outboard_body;
-  // Index to the tree node in the MultibodyTree responsible for this
-  // mobilizer's computations. See the documentation for BodyNodeTopology for
-  // further details on how these computations are organized.
-  BodyNodeIndex body_node;
+  // Index to the mobilized body (BodyNode) modeling this Mobilizer.
+  MobodIndex mobod_index;
 
   // Mobilizer indexing info: Set at Finalize() time.
   // Number of generalized coordinates granted by this mobilizer.
@@ -351,8 +349,8 @@ struct BodyNodeTopology {
   //                       body associated with node `parent_node_in`.
   // @param mobilizer_in The index to the mobilizer associated with this node.
   BodyNodeTopology(
-      BodyNodeIndex index_in, int level_in,
-      BodyNodeIndex parent_node_in,
+      MobodIndex index_in, int level_in,
+      MobodIndex parent_node_in,
       BodyIndex body_in, BodyIndex parent_body_in, MobilizerIndex mobilizer_in)
       : index(index_in), level(level_in),
       parent_body_node(parent_node_in),
@@ -397,13 +395,13 @@ struct BodyNodeTopology {
   }
 
   // Unique index of this node in the MultibodyTree.
-  BodyNodeIndex index{};
+  MobodIndex index{};
 
   // Depth level in the MultibodyTree, level = 0 for the world.
   int level{-1};
 
   // The unique index to the parent BodyNode of this node.
-  BodyNodeIndex parent_body_node;
+  MobodIndex parent_body_node;
 
   BodyIndex body;         // This node's body B.
   BodyIndex parent_body;  // This node's parent body P.
@@ -411,7 +409,7 @@ struct BodyNodeTopology {
   MobilizerIndex mobilizer;  // The mobilizer connecting bodies P and B.
 
   // The list of child body nodes to this node.
-  std::vector<BodyNodeIndex> child_nodes;
+  std::vector<MobodIndex> child_nodes;
 
   // Returns the number of children to this node.
   int get_num_children() const { return ssize(child_nodes);}
@@ -474,13 +472,16 @@ class MultibodyTreeTopology {
 
   // Returns the number of mobilizers in the multibody tree. Since the "world"
   // body does not have a mobilizer, the number of mobilizers will always equal
-  // the number of bodies minus one.
+  // the number of mobilized bodies minus one.
   int num_mobilizers() const {
     return ssize(mobilizers_);
   }
 
-  // Returns the number of tree nodes. This must equal the number of bodies.
-  int get_num_body_nodes() const {
+  // Returns the number of mobilized bodies (BodyNodes). Currently this is
+  // restricted to being equal to the number of user-supplied Body objects.
+  // TODO(sherm1) Relax this restriction -- the number of mobilized bodies can
+  //  differ from the number of user-provided links.
+  int num_mobods() const {
     return ssize(body_nodes_);
   }
 
@@ -535,9 +536,9 @@ class MultibodyTreeTopology {
   }
 
   // Returns a constant reference to the corresponding BodyNodeTopology given
-  // a BodyNodeIndex.
-  const BodyNodeTopology& get_body_node(BodyNodeIndex index) const {
-    DRAKE_ASSERT(index < get_num_body_nodes());
+  // a MobodIndex.
+  const BodyNodeTopology& get_body_node(MobodIndex index) const {
+    DRAKE_ASSERT(index < num_mobods());
     return body_nodes_[index];
   }
 
@@ -798,18 +799,18 @@ class MultibodyTreeTopology {
     forest_height_ = 1;  // At least one level with the world body at the root.
     body_nodes_.reserve(num_bodies());
     while (!stack.empty()) {
-      const BodyNodeIndex node(get_num_body_nodes());
+      const MobodIndex node(num_mobods());
       const BodyIndex current = stack.top();
       const BodyIndex parent = bodies_[current].parent_body;
 
-      bodies_[current].body_node = node;
+      bodies_[current].mobod_index = node;
 
       // Computes level.
       int level = 0;  // level = 0 for the world body.
       if (current != 0) {  // Not the world body.
         level = bodies_[parent].level + 1;
         const MobilizerIndex mobilizer = bodies_[current].inboard_mobilizer;
-        mobilizers_[mobilizer].body_node = node;
+        mobilizers_[mobilizer].mobod_index = node;
       }
       // Updates body levels.
       bodies_[current].level = level;
@@ -818,9 +819,9 @@ class MultibodyTreeTopology {
 
       // Since we are doing a DFT, it is valid to ask for the parent node,
       // unless we are at the root.
-      BodyNodeIndex parent_node;
+      MobodIndex parent_node;
       if (node != 0) {  // If we are not at the root:
-        parent_node = bodies_[parent].body_node;
+        parent_node = bodies_[parent].mobod_index;
         body_nodes_[parent_node].child_nodes.push_back(node);
       }
 
@@ -861,7 +862,7 @@ class MultibodyTreeTopology {
 
     // After we checked all bodies were reached above, the number of tree nodes
     // should equal the number of bodies in the tree.
-    DRAKE_DEMAND(num_bodies() == get_num_body_nodes());
+    DRAKE_DEMAND(num_bodies() == num_mobods());
 
     // Compile information regarding the size of the system:
     // - Number of degrees of freedom (generalized positions and velocities).
@@ -882,8 +883,8 @@ class MultibodyTreeTopology {
     // velocities.
     int position_index = 0;
     int velocity_index_in_state = num_positions_;
-    for (BodyNodeIndex node_index(1);
-         node_index < get_num_body_nodes(); ++node_index) {
+    for (MobodIndex node_index(1);
+         node_index < num_mobods(); ++node_index) {
       BodyNodeTopology& node = body_nodes_[node_index];
       MobilizerTopology& mobilizer = mobilizers_[node.mobilizer];
 
@@ -951,7 +952,7 @@ class MultibodyTreeTopology {
   // Returns the total number of actuated joint dofs in the model.
   int num_actuated_dofs() const { return num_actuated_dofs_; }
 
-  // Given a node in `this` topology, specified by its BodyNodeIndex `from`,
+  // Given a node in `this` topology, specified by its MobodIndex `from`,
   // this method computes the kinematic path formed by all the nodes in the
   // tree that connect `from` with the root (corresponding to the world).
   //
@@ -970,16 +971,16 @@ class MultibodyTreeTopology {
   //   (BodyNodeTopology::level) of body node `from` plus one (so that we can
   //   include the root node in the path).
   void GetKinematicPathToWorld(
-      BodyNodeIndex from, std::vector<BodyNodeIndex>* path_to_world) const {
+      MobodIndex from, std::vector<MobodIndex>* path_to_world) const {
     DRAKE_THROW_UNLESS(path_to_world != nullptr);
 
     const int path_size = get_body_node(from).level + 1;
     path_to_world->resize(path_size);
-    (*path_to_world)[0] = BodyNodeIndex(0);  // Add the world.
-    if (from == BodyNodeIndex(0)) return;
+    (*path_to_world)[0] = world_mobod_index();  // Add the world.
+    if (from == world_mobod_index()) return;
 
     // Navigate the tree inwards starting at "from" and ending at the root.
-    for (BodyNodeIndex node = from; node > BodyNodeIndex(0);
+    for (MobodIndex node = from; node > world_mobod_index();
         node = get_body_node(node).parent_body_node) {
       (*path_to_world)[get_body_node(node).level] = node;
     }
@@ -996,8 +997,8 @@ class MultibodyTreeTopology {
   bool IsBodyAnchored(BodyIndex body_index) const {
     DRAKE_DEMAND(is_valid());
     const BodyTopology& body = get_body(body_index);
-    std::vector<BodyNodeIndex> path_to_world;
-    GetKinematicPathToWorld(body.body_node, &path_to_world);
+    std::vector<MobodIndex> path_to_world;
+    GetKinematicPathToWorld(body.mobod_index, &path_to_world);
     // Skip the world at path_to_world[0].
     for (size_t path_index = 1; path_index < path_to_world.size();
          ++path_index) {
@@ -1073,7 +1074,7 @@ class MultibodyTreeTopology {
       // being the root has necessarily been traversed already.
       if (outboard_bodies.count(body_index) == 0) {
         const BodyNodeTopology& root =
-            get_body_node(get_body(body_index).body_node);
+            get_body_node(get_body(body_index).mobod_index);
         TraverseOutboardNodes(root, collect_body);
       }
     }
@@ -1145,14 +1146,14 @@ class MultibodyTreeTopology {
   void TraverseOutboardNodes(
       const BodyNodeTopology& base,
       std::function<void(const BodyNodeTopology&)> operation) const {
-    DRAKE_DEMAND(get_num_body_nodes() != 0);
+    DRAKE_DEMAND(num_mobods() != 0);
     operation(base);
     // We are done if the base has no more children.
     if (base.get_num_children() == 0) return;
     // Traverse outboard nodes. Since the tree is finalized, we know nodes are
     // in DFT order.
     const int base_level = base.level;
-    for (BodyNodeIndex node_index(base.index + 1);
+    for (MobodIndex node_index(base.index + 1);
          /* Reached the last node in the model. */
          node_index < num_bodies() &&
          /* Reached next tree in the multibody forest */
@@ -1166,7 +1167,7 @@ class MultibodyTreeTopology {
   // nodes outboard of `base`, including the generalized velocities of `base`.
   // @pre Body nodes were already created.
   int CalcNumberOfOutboardVelocities(const BodyNodeTopology& base) const {
-    DRAKE_DEMAND(get_num_body_nodes() != 0);
+    DRAKE_DEMAND(num_mobods() != 0);
     int nv = 0;
     TraverseOutboardNodes(base, [&nv](const BodyNodeTopology& node) {
       nv += node.num_mobilizer_velocities;
@@ -1177,13 +1178,13 @@ class MultibodyTreeTopology {
   // Helper method to be used within Finalize() to obtain the topological
   // information that describes the multibody system as a "forest" of trees.
   void ExtractForestInfo() {
-    const BodyNodeTopology& root = get_body_node(BodyNodeIndex(0));
+    const BodyNodeTopology& root = get_body_node(world_mobod_index());
     const int max_num_trees = root.child_nodes.size();
     num_tree_velocities_.reserve(max_num_trees);
     body_to_tree_index_.resize(num_bodies());
     velocity_to_tree_index_.resize(num_velocities());
 
-    for (const BodyNodeIndex& root_child_index : root.child_nodes) {
+    for (const MobodIndex& root_child_index : root.child_nodes) {
       const BodyNodeTopology& root_child = get_body_node(root_child_index);
       const int nt = CalcNumberOfOutboardVelocities(root_child);
       const TreeIndex tree_index(num_trees());

--- a/multibody/tree/position_kinematics_cache.h
+++ b/multibody/tree/position_kinematics_cache.h
@@ -40,93 +40,92 @@ class PositionKinematicsCache {
   // Constructs a position kinematics cache entry for the given
   // MultibodyTreeTopology.
   explicit PositionKinematicsCache(const MultibodyTreeTopology& topology)
-      : num_nodes_(topology.num_bodies()) {
+      : num_mobods_(topology.num_mobods()) {
     Allocate();
   }
 
   // Returns a const reference to pose `X_WB` of the body B (associated with
-  // node @p body_node_index) as measured and expressed in the world frame W.
-  // @param[in] body_node_index The unique index for the computational
-  //                            BodyNode object associated with body B.
+  // mobilized body mobod_index) as measured and expressed in the world frame W.
+  // @param[in] mobod_index The unique index for the computational
+  //                        BodyNode object associated with body B.
 
   // @returns `X_WB` the pose of the body frame B measured and expressed in
   //                 the world frame W.
-  const RigidTransform<T>& get_X_WB(BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return X_WB_pool_[body_node_index];
+  const RigidTransform<T>& get_X_WB(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return X_WB_pool_[mobod_index];
   }
 
   // See documentation on the const version get_X_WB() for details.
-  RigidTransform<T>& get_mutable_X_WB(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return X_WB_pool_[body_node_index];
+  RigidTransform<T>& get_mutable_X_WB(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return X_WB_pool_[mobod_index];
   }
 
   // Returns a const reference to the rotation matrix `R_WB` that relates the
   // orientation of the world frame W with the body frame B.
-  // @param[in] body_node_index The unique index for the computational
-  //                            BodyNode object associated with body B.
-  const math::RotationMatrix<T>& get_R_WB(BodyNodeIndex body_node_index) const {
-    const RigidTransform<T>& X_WB = get_X_WB(body_node_index);
+  // @param[in] mobod_index The unique index for the computational
+  //                        BodyNode object associated with body B.
+  const math::RotationMatrix<T>& get_R_WB(MobodIndex mobod_index) const {
+    const RigidTransform<T>& X_WB = get_X_WB(mobod_index);
     return X_WB.rotation();
   }
 
   // Returns a const reference to the pose `X_PB` of the body frame B
   // as measured and expressed in its parent body frame P.
-  // @param[in] body_node_id The unique identifier for the computational
-  //                         BodyNode object associated with body B.
+  // @param[in] mobod_index The unique identifier for the computational
+  //                        BodyNode object associated with body B.
   // @returns `X_PB` a const reference to the pose of the body frame B
   //                 measured and expressed in the parent body frame P.
-  const RigidTransform<T>& get_X_PB(BodyNodeIndex body_node_id) const {
-    DRAKE_ASSERT(0 <= body_node_id && body_node_id < num_nodes_);
-    return X_PB_pool_[body_node_id];
+  const RigidTransform<T>& get_X_PB(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return X_PB_pool_[mobod_index];
   }
 
   // See documentation on the const version get_X_PB() for details.
-  RigidTransform<T>& get_mutable_X_PB(BodyNodeIndex body_node_id) {
-    DRAKE_ASSERT(0 <= body_node_id && body_node_id < num_nodes_);
-    return X_PB_pool_[body_node_id];
+  RigidTransform<T>& get_mutable_X_PB(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return X_PB_pool_[mobod_index];
   }
 
   // For the mobilizer associated with the body node indexed by
-  // `body_node_index`, this method returns a const reference to the pose
+  // `mobod_index`, this method returns a const reference to the pose
   // `X_FM` of the outboard frame M as measured and expressed in the inboard
   // frame F.
   //
-  // @param[in] body_node_index The unique index for the computational
-  //                            BodyNode object associated with the mobilizer
-  //                            of interest.
+  // @param[in] mobod_index The unique index for the computational BodyNode
+  //                        object associated with the mobilizer of interest.
   // @returns A const reference to the pose `X_FM` of the outboard frame M
   //          as measured and expressed in the inboard frame F.
-  const RigidTransform<T>& get_X_FM(BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return X_FM_pool_[body_node_index];
+  const RigidTransform<T>& get_X_FM(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return X_FM_pool_[mobod_index];
   }
 
   // See documentation on the const version get_X_FM() for details.
-  RigidTransform<T>& get_mutable_X_FM(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return X_FM_pool_[body_node_index];
+  RigidTransform<T>& get_mutable_X_FM(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return X_FM_pool_[mobod_index];
   }
 
-  // Position of node B, with index `body_node_index`, measured in the inboard
+  // Position of node B, with index `mobod_index`, measured in the inboard
   // body frame P, expressed in the world frame W.
-  const Vector3<T>& get_p_PoBo_W(BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return p_PoBo_W_pool_[body_node_index];
+  const Vector3<T>& get_p_PoBo_W(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return p_PoBo_W_pool_[mobod_index];
   }
 
   // Mutable version of get_p_PoBo_W().
-  Vector3<T>& get_mutable_p_PoBo_W(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return p_PoBo_W_pool_[body_node_index];
+  Vector3<T>& get_mutable_p_PoBo_W(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return p_PoBo_W_pool_[mobod_index];
   }
 
  private:
   // Pool types:
-  // Pools store entries in the same order multibody tree nodes are
-  // ordered in the tree, i.e. in DFT (Depth-First Traversal) order. Therefore
-  // clients of this class will access entries by BodyNodeIndex, see
+  // Pools store entries in the same order as the mobilized bodies (BodyNodes)
+  // in the multibody forest, i.e. in DFT (Depth-First Traversal) order.
+  // Therefore clients of this class will access entries by MobodIndex, see
   // `get_X_WB()` for instance.
 
   // The type of pools for storing poses.
@@ -137,23 +136,23 @@ class PositionKinematicsCache {
 
   // Allocates resources for this position kinematics cache.
   void Allocate() {
-    X_WB_pool_.resize(num_nodes_);
+    X_WB_pool_.resize(num_mobods_);
     // Even though RigidTransform defaults to identity, we make it explicit.
     // This pose will never change after this initialization.
-    X_WB_pool_[world_index()] = RigidTransform<T>::Identity();
+    X_WB_pool_[world_mobod_index()] = RigidTransform<T>::Identity();
 
-    X_PB_pool_.resize(num_nodes_);
-    X_PB_pool_[world_index()] = NaNPose();  // It should never be used.
+    X_PB_pool_.resize(num_mobods_);
+    X_PB_pool_[world_mobod_index()] = NaNPose();  // It should never be used.
 
-    X_FM_pool_.resize(num_nodes_);
-    X_FM_pool_[world_index()] = NaNPose();  // It should never be used.
+    X_FM_pool_.resize(num_mobods_);
+    X_FM_pool_[world_mobod_index()] = NaNPose();  // It should never be used.
 
-    X_MB_pool_.resize(num_nodes_);
-    X_MB_pool_[world_index()] = NaNPose();  // It should never be used.
+    X_MB_pool_.resize(num_mobods_);
+    X_MB_pool_[world_mobod_index()] = NaNPose();  // It should never be used.
 
-    p_PoBo_W_pool_.resize(num_nodes_);
+    p_PoBo_W_pool_.resize(num_mobods_);
     // p_PoBo_W for the world body should never be used.
-    p_PoBo_W_pool_[world_index()].setConstant(
+    p_PoBo_W_pool_[world_mobod_index()].setConstant(
         std::numeric_limits<
             typename Eigen::NumTraits<T>::Literal>::quiet_NaN());
   }
@@ -168,9 +167,9 @@ class PositionKinematicsCache {
         Vector3<T>::Constant(Eigen::NumTraits<double>::quiet_NaN()));
   }
 
-  // Number of body nodes in the corresponding MultibodyTree.
-  int num_nodes_{0};
-  // Pools indexed by BodyNodeIndex.
+  // Number of mobilized bodies in the corresponding multibody forest.
+  int num_mobods_{0};
+  // Pools indexed by MobodIndex.
   X_PoolType X_WB_pool_;
   X_PoolType X_PB_pool_;
   X_PoolType X_FM_pool_;

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -267,7 +267,7 @@ class RigidBody : public Body<T> {
   /// @retval X_WB pose of rigid body B in world frame W.
   const math::RigidTransform<T>& get_pose_in_world(
       const internal::PositionKinematicsCache<T>& pc) const {
-    return pc.get_X_WB(this->node_index());
+    return pc.get_X_WB(this->mobod_index());
   }
 
   /// (Advanced) Extract the rotation matrix relating the world frame to this
@@ -302,7 +302,7 @@ class RigidBody : public Body<T> {
   /// frame W, expressed in W (for point Bo, the body frame's origin).
   const SpatialVelocity<T>& get_spatial_velocity_in_world(
       const internal::VelocityKinematicsCache<T>& vc) const {
-    return vc.get_V_WB(this->node_index());
+    return vc.get_V_WB(this->mobod_index());
   }
 
   /// (Advanced) Extract this body angular velocity in world, expressed in
@@ -336,7 +336,7 @@ class RigidBody : public Body<T> {
   /// frame W, expressed in W (for point Bo, the body frame's origin).
   const SpatialAcceleration<T>& get_spatial_acceleration_in_world(
       const internal::AccelerationKinematicsCache<T>& ac) const {
-    return ac.get_A_WB(this->node_index());
+    return ac.get_A_WB(this->mobod_index());
   }
 
   /// (Advanced) Extract this body's angular acceleration in world, expressed

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -102,7 +102,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, FeatherstoneExample) {
 
   // Compare results.
   const ArticulatedBodyInertia<double>& Pplus_C_W_actual =
-      abc.get_Pplus_PB_W(cylinder_link.node_index());
+      abc.get_Pplus_PB_W(cylinder_link.mobod_index());
   EXPECT_TRUE(CompareMatrices(Pplus_C_W_expected_mat,
                               Pplus_C_W_actual.CopyToFullMatrix6(), kEpsilon));
 
@@ -110,7 +110,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, FeatherstoneExample) {
   Pplus_M_W_expected_mat(0, 0) = 0.0;  // x inertia projected out
 
   const ArticulatedBodyInertia<double>& Pplus_M_W_actual =
-      abc.get_Pplus_PB_W(massless_link.node_index());
+      abc.get_Pplus_PB_W(massless_link.mobod_index());
   EXPECT_TRUE(CompareMatrices(Pplus_M_W_expected_mat,
       Pplus_M_W_actual.CopyToFullMatrix6(), kEpsilon));
 
@@ -123,7 +123,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, FeatherstoneExample) {
 
   // Compare results.
   const ArticulatedBodyInertia<double>& P_B_W_actual =
-      abc.get_Pplus_PB_W(box_link.node_index());
+      abc.get_Pplus_PB_W(box_link.mobod_index());
   EXPECT_TRUE(CompareMatrices(Pplus_B_W_expected_mat,
       P_B_W_actual.CopyToFullMatrix6(), kEpsilon));
 }
@@ -233,7 +233,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
   const ArticulatedBodyInertia<double>& Pplus_C_W_expected =
       ArticulatedBodyInertia<double>(Pplus_C_W_expected_mat);
   const ArticulatedBodyInertia<double>& Pplus_C_W_actual =
-      abc.get_Pplus_PB_W(cylinder_link.node_index());
+      abc.get_Pplus_PB_W(cylinder_link.mobod_index());
   EXPECT_TRUE(CompareMatrices(Pplus_C_W_expected_mat,
                               Pplus_C_W_actual.CopyToFullMatrix6(), kEpsilon));
 
@@ -245,7 +245,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
 
   // Verify that we get the right P_M.
   const ArticulatedBodyInertia<double>& P_M_W_actual =
-      abc.get_P_B_W(massless_link.node_index());
+      abc.get_P_B_W(massless_link.mobod_index());
   EXPECT_TRUE(CompareMatrices(P_M_W_expected_mat,
                               P_M_W_actual.CopyToFullMatrix6(), kEpsilon));
 
@@ -258,7 +258,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
   const ArticulatedBodyInertia<double> Pplus_M_W_expected(
       Pplus_M_W_expected_mat);
   const ArticulatedBodyInertia<double>& Pplus_M_W_actual =
-      abc.get_Pplus_PB_W(massless_link.node_index());
+      abc.get_Pplus_PB_W(massless_link.mobod_index());
   EXPECT_TRUE(CompareMatrices(Pplus_M_W_expected_mat,
                               Pplus_M_W_actual.CopyToFullMatrix6(), kEpsilon));
 
@@ -278,7 +278,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
 
   // Compare results.
   const ArticulatedBodyInertia<double>& Pplus_B_W_actual =
-      abc.get_Pplus_PB_W(box_link.node_index());
+      abc.get_Pplus_PB_W(box_link.mobod_index());
   EXPECT_TRUE(CompareMatrices(Pplus_B_W_expected_mat,
       Pplus_B_W_actual.CopyToFullMatrix6(), kEpsilon));
 }

--- a/multibody/tree/test/free_rotating_body_plant.cc
+++ b/multibody/tree/test/free_rotating_body_plant.cc
@@ -77,14 +77,14 @@ template<typename T>
 math::RigidTransform<T> FreeRotatingBodyPlant<T>::CalcPoseInWorldFrame(
     const systems::Context<T>& context) const {
   auto& pc = this->EvalPositionKinematics(context);
-  return math::RigidTransform<T>(pc.get_X_WB(body_->node_index()));
+  return math::RigidTransform<T>(pc.get_X_WB(body_->mobod_index()));
 }
 
 template<typename T>
 SpatialVelocity<T> FreeRotatingBodyPlant<T>::CalcSpatialVelocityInWorldFrame(
     const systems::Context<T>& context) const {
   auto& vc = this->EvalVelocityKinematics(context);
-  return vc.get_V_WB(body_->node_index());
+  return vc.get_V_WB(body_->mobod_index());
 }
 
 }  // namespace test

--- a/multibody/tree/test/linear_spring_damper_test.cc
+++ b/multibody/tree/test/linear_spring_damper_test.cc
@@ -65,11 +65,11 @@ class SpringDamperTester : public ::testing::Test {
   }
 
   const SpatialForce<double>& GetSpatialForceOnBodyA() const {
-    return forces_->body_forces().at(bodyA_->node_index());
+    return forces_->body_forces().at(bodyA_->mobod_index());
   }
 
   const SpatialForce<double>& GetSpatialForceOnBodyB() const {
-    return forces_->body_forces().at(bodyB_->node_index());
+    return forces_->body_forces().at(bodyB_->mobod_index());
   }
 
  protected:

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -236,10 +236,9 @@ class PendulumTests : public ::testing::Test {
       const PositionKinematicsCache<T>& pc,
       const Body<T>& body) {
     const MultibodyTreeTopology& topology = tree.get_topology();
-    // Cache entries are accessed by BodyNodeIndex for fast traversals.
-    const BodyNodeIndex body_node_index =
-        topology.get_body(body.index()).body_node;
-    return RigidTransform<T>(pc.get_X_WB(body_node_index));
+    // Cache entries are accessed by MobodIndex for fast traversals.
+    const MobodIndex mobod_index = topology.get_body(body.index()).mobod_index;
+    return RigidTransform<T>(pc.get_X_WB(mobod_index));
   }
 
   // Helper method to extract spatial velocity from the velocity kinematics
@@ -253,8 +252,8 @@ class PendulumTests : public ::testing::Test {
       const VelocityKinematicsCache<double>& vc,
       const Body<double>& body) {
     const MultibodyTreeTopology& topology = tree.get_topology();
-    // Cache entries are accessed by BodyNodeIndex for fast traversals.
-    return vc.get_V_WB(topology.get_body(body.index()).body_node);
+    // Cache entries are accessed by MobodIndex for fast traversals.
+    return vc.get_V_WB(topology.get_body(body.index()).mobod_index);
   }
 
   // Helper method to extract spatial acceleration from the acceleration
@@ -268,8 +267,8 @@ class PendulumTests : public ::testing::Test {
       const MultibodyTree<double>& tree,
       const AccelerationKinematicsCache<double>& ac, const Body<double>& body) {
     const MultibodyTreeTopology& topology = tree.get_topology();
-    // Cache entries are accessed by BodyNodeIndex for fast traversals.
-    return ac.get_A_WB(topology.get_body(body.index()).body_node);
+    // Cache entries are accessed by MobodIndex for fast traversals.
+    return ac.get_A_WB(topology.get_body(body.index()).mobod_index);
   }
 
  protected:
@@ -277,7 +276,7 @@ class PendulumTests : public ::testing::Test {
   // this method initializes the poses of each link in the position kinematics
   // cache.
   void SetPendulumPoses(PositionKinematicsCache<double>* pc) {
-    pc->get_mutable_X_WB(BodyNodeIndex(1)) = X_WL_;
+    pc->get_mutable_X_WB(MobodIndex(1)) = X_WL_;
   }
 
   // Add elements to this model_ and then transfer the whole thing to
@@ -825,9 +824,9 @@ class PendulumKinematicTests : public PendulumTests {
         get_body_spatial_acceleration_in_world(tree(), ac, *lower_link_);
     // From inverse dynamics.
     const SpatialAcceleration<double>& A_WUcm_id =
-        A_WB_array[upper_link_->node_index()];
+        A_WB_array[upper_link_->mobod_index()];
     const SpatialAcceleration<double>& A_WL_id =
-        A_WB_array[lower_link_->node_index()];
+        A_WB_array[lower_link_->mobod_index()];
     EXPECT_TRUE(A_WUcm_id.IsApprox(A_WUcm_ac, kTolerance));
     EXPECT_TRUE(A_WL_id.IsApprox(A_WL_ac, kTolerance));
 
@@ -886,10 +885,10 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
       tree().CalcPositionKinematicsCache(*context_, &pc);
 
       // Indexes to the BodyNode objects associated with each mobilizer.
-      const BodyNodeIndex shoulder_node =
-          shoulder_mobilizer_->get_topology().body_node;
-      const BodyNodeIndex elbow_node =
-          elbow_mobilizer_->get_topology().body_node;
+      const MobodIndex shoulder_node =
+          shoulder_mobilizer_->get_topology().mobod_index;
+      const MobodIndex elbow_node =
+          elbow_mobilizer_->get_topology().mobod_index;
 
       // Expected poses of the outboard frames measured in the inboard frame.
       RigidTransformd X_SiSo(RotationMatrixd::MakeZRotation(shoulder_angle));

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -108,19 +108,19 @@ void UniformGravityFieldElement<T>::DoCalcAndAddForceContribution(
     // Skip this body if gravity is disabled.
     if (!is_enabled(body.model_instance())) continue;
 
-    internal::BodyNodeIndex node_index = body.node_index();
+    internal::MobodIndex mobod_index = body.mobod_index();
 
     // TODO(amcastro-tri): Replace this CalcFoo() calls by GetFoo() calls once
     // caching is in place.
     const T mass = body.get_mass(context);
     const Vector3<T> p_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
-    const math::RotationMatrix<T> R_WB = pc.get_R_WB(node_index);
+    const math::RotationMatrix<T> R_WB = pc.get_R_WB(mobod_index);
     // TODO(amcastro-tri): Consider caching p_BoBcm_W.
     const Vector3<T> p_BoBcm_W = R_WB * p_BoBcm_B;
 
     const Vector3<T> f_Bcm_W = mass * gravity_vector();
     const SpatialForce<T> F_Bo_W(p_BoBcm_W.cross(f_Bcm_W), f_Bcm_W);
-    F_Bo_W_array[node_index] += F_Bo_W;
+    F_Bo_W_array[mobod_index] += F_Bo_W;
   }
 }
 
@@ -144,7 +144,7 @@ T UniformGravityFieldElement<T>::CalcPotentialEnergy(
     // caching is in place.
     const T mass = body.get_mass(context);
     const Vector3<T> p_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
-    const math::RigidTransform<T>& X_WB = pc.get_X_WB(body.node_index());
+    const math::RigidTransform<T>& X_WB = pc.get_X_WB(body.mobod_index());
     const math::RotationMatrix<T> R_WB = X_WB.rotation();
     const Vector3<T> p_WBo = X_WB.translation();
     // TODO(amcastro-tri): Consider caching p_BoBcm_W and/or p_WBcm.
@@ -177,12 +177,12 @@ T UniformGravityFieldElement<T>::CalcConservativePower(
     // caching is in place.
     const T mass = body.get_mass(context);
     const Vector3<T> p_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
-    const math::RigidTransform<T>& X_WB = pc.get_X_WB(body.node_index());
+    const math::RigidTransform<T>& X_WB = pc.get_X_WB(body.mobod_index());
     const math::RotationMatrix<T> R_WB = X_WB.rotation();
     // TODO(amcastro-tri): Consider caching p_BoBcm_W.
     const Vector3<T> p_BoBcm_W = R_WB * p_BoBcm_B;
 
-    const SpatialVelocity<T>& V_WB = vc.get_V_WB(body.node_index());
+    const SpatialVelocity<T>& V_WB = vc.get_V_WB(body.mobod_index());
     const SpatialVelocity<T> V_WBcm = V_WB.Shift(p_BoBcm_W);
     const Vector3<T>& v_WBcm = V_WBcm.translational();
 

--- a/multibody/tree/velocity_kinematics_cache.h
+++ b/multibody/tree/velocity_kinematics_cache.h
@@ -42,75 +42,75 @@ class VelocityKinematicsCache {
   // zero cost operation. However in Debug builds those entries are set to NaN
   // so that operations using this uninitialized cache entry fail fast, easing
   // bug detection.
-  explicit VelocityKinematicsCache(const MultibodyTreeTopology& topology) :
-      num_nodes_(topology.num_bodies()) {
+  explicit VelocityKinematicsCache(const MultibodyTreeTopology& topology)
+      : num_mobods_(topology.num_mobods()) {
     Allocate();
     DRAKE_ASSERT_VOID(InitializeToNaN());
     // Sets defaults.
-    V_WB_pool_[world_index()].SetZero();  // World's velocity is always zero.
-    V_FM_pool_[world_index()].SetNaN();  // It must never be used.
-    V_PB_W_pool_[world_index()].SetNaN();  // It must never be used.
+    V_WB_pool_[world_mobod_index()].SetZero();   // World's velocity is zero.
+    V_FM_pool_[world_mobod_index()].SetNaN();    // It must never be used.
+    V_PB_W_pool_[world_mobod_index()].SetNaN();  // It must never be used.
   }
 
   // Initializes `this` %VelocityKinematicsCache as if all generalized
   // velocities of the corresponding MultibodyTree model were zero.
   void InitializeToZero() {
-    for (BodyNodeIndex body_node_index(0); body_node_index < num_nodes_;
-         ++body_node_index) {
-      V_WB_pool_[body_node_index].SetZero();
-      V_FM_pool_[body_node_index].SetZero();
-      V_PB_W_pool_[body_node_index].SetZero();
+    for (MobodIndex mobod_index(0); mobod_index < num_mobods_;
+         ++mobod_index) {
+      V_WB_pool_[mobod_index].SetZero();
+      V_FM_pool_[mobod_index].SetZero();
+      V_PB_W_pool_[mobod_index].SetZero();
     }
   }
 
   // Returns V_WB, body B's spatial velocity in the world frame W.
-  // @param[in] body_node_index The unique index for the computational
-  //                            BodyNode object associated with body B.
+  // @param[in] mobod_index The unique index for the computational
+  //                        BodyNode object associated with body B.
   // @retval V_WB_W body B's spatial velocity in the world frame W,
   // expressed in W (for point Bo, the body frame's origin).
-  const SpatialVelocity<T>& get_V_WB(BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return V_WB_pool_[body_node_index];
+  const SpatialVelocity<T>& get_V_WB(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return V_WB_pool_[mobod_index];
   }
 
   // Mutable version of get_V_WB().
-  SpatialVelocity<T>& get_mutable_V_WB(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return V_WB_pool_[body_node_index];
+  SpatialVelocity<T>& get_mutable_V_WB(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return V_WB_pool_[mobod_index];
   }
 
-  // Returns a const reference to the across-mobilizer (associated with node
-  // `body_node_index`) spatial velocity `V_FM` of the outboard frame M in the
-  // inboard frame F.
-  const SpatialVelocity<T>& get_V_FM(BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return V_FM_pool_[body_node_index];
+  // Returns a const reference to the across-mobilizer (associated with
+  // mobilized body `mobod_index`) spatial velocity `V_FM` of the outboard frame
+  // M in the inboard frame F.
+  const SpatialVelocity<T>& get_V_FM(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return V_FM_pool_[mobod_index];
   }
 
   // Mutable version of get_V_FM().
-  SpatialVelocity<T>& get_mutable_V_FM(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return V_FM_pool_[body_node_index];
+  SpatialVelocity<T>& get_mutable_V_FM(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return V_FM_pool_[mobod_index];
   }
 
   // Returns a const reference to the spatial velocity `V_PB_W` of the
-  // body B associated with node `body_node_index` in the parent node's body
+  // body B associated with mobilized body `mobod_index` in the parent body's
   // frame P, expressed in the world frame W.
-  const SpatialVelocity<T>& get_V_PB_W(BodyNodeIndex body_node_index) const {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return V_PB_W_pool_[body_node_index];
+  const SpatialVelocity<T>& get_V_PB_W(MobodIndex mobod_index) const {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return V_PB_W_pool_[mobod_index];
   }
 
   // Mutable version of get_V_PB_W().
-  SpatialVelocity<T>& get_mutable_V_PB_W(BodyNodeIndex body_node_index) {
-    DRAKE_ASSERT(0 <= body_node_index && body_node_index < num_nodes_);
-    return V_PB_W_pool_[body_node_index];
+  SpatialVelocity<T>& get_mutable_V_PB_W(MobodIndex mobod_index) {
+    DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
+    return V_PB_W_pool_[mobod_index];
   }
 
  private:
-  // Pools store entries in the same order multibody tree nodes are
-  // ordered in the tree, i.e. in DFT (Depth-First Traversal) order. Therefore
-  // clients of this class will access entries by BodyNodeIndex, see
+  // Pools store entries in the same order as the mobilized bodies (BodyNodes)
+  // in the multibody forest, i.e. in DFT (Depth-First Traversal) order.
+  // Therefore clients of this class will access entries by MobodIndex, see
   // `get_V_WB()` for instance.
 
   // The type of the pools for storing spatial velocities.
@@ -118,24 +118,24 @@ class VelocityKinematicsCache {
 
   // Allocates resources for this position kinematics cache.
   void Allocate() {
-    V_WB_pool_.resize(num_nodes_);
-    V_FM_pool_.resize(num_nodes_);
-    V_PB_W_pool_.resize(num_nodes_);
+    V_WB_pool_.resize(num_mobods_);
+    V_FM_pool_.resize(num_mobods_);
+    V_PB_W_pool_.resize(num_mobods_);
   }
 
   // Initializes all pools to have NaN values to ease bug detection when entries
   // are accidentally left uninitialized.
   void InitializeToNaN() {
-    for (BodyNodeIndex body_node_index(0); body_node_index < num_nodes_;
-         ++body_node_index) {
-      V_WB_pool_[body_node_index].SetNaN();
-      V_FM_pool_[body_node_index].SetNaN();
-      V_PB_W_pool_[body_node_index].SetNaN();
+    for (MobodIndex mobod_index(0); mobod_index < num_mobods_;
+         ++mobod_index) {
+      V_WB_pool_[mobod_index].SetNaN();
+      V_FM_pool_[mobod_index].SetNaN();
+      V_PB_W_pool_[mobod_index].SetNaN();
     }
   }
 
   // Number of body nodes in the corresponding MultibodyTree.
-  int num_nodes_{0};
+  int num_mobods_{0};
   SpatialVelocity_PoolType V_WB_pool_;
   SpatialVelocity_PoolType V_FM_pool_;
   SpatialVelocity_PoolType V_PB_W_pool_;


### PR DESCRIPTION
Replaces `internal::BodyNodeIndex` with `internal::MobodIndex` in preparation for upcoming multibody topology changes.

This is a yak shave in preparation for review of the new topology code in #20225. The purpose of making this name change now is to reduce the number of files that are touched in the already-too-large PRs to come.

In #20225 the primary internal multibody object is the "mobilized body", and the same index is used for mobilized bodies and their implementation as (Mobilizer, BodyNode) pairs in MbT. So there is only MobodIndex, no MobilizerIndex and no BodyNodeIndex. In this PR we are still stuck with MobilizerIndex since those are currently numbered differently from BodyNodes.

Why the abbreviation "Mobod" rather than spelling out "MobilizedBody"? I started out with the full spelling but it soon got painful to read. The name is used 730 times in #20225, often several times on the same line. Something short like "Body" or "Joint" is needed for fundamental objects and Mobod is distinctive, suggestive, and pronounceable. It is also an internal object, not something typical Drake users will encounter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20603)
<!-- Reviewable:end -->
