### PR TITLE
Correct phong-to-pbr promotion in presence of diffuse texture

### DIFF
--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -822,7 +822,12 @@ void RenderEngineVtk::ImplementPolyData(vtkPolyDataAlgorithm* source,
     const bool need_repeat = uv_scale[0] > 1 || uv_scale[1] > 1;
     texture->SetRepeat(need_repeat);
     texture->InterpolateOn();
-    color_actor->SetTexture(texture.Get());
+    if (use_pbr_materials_) {
+      texture->SetUseSRGBColorSpace(true);
+      color_actor->GetProperty()->SetBaseColorTexture(texture);
+    } else {
+      color_actor->SetTexture(texture.Get());
+    }
   }
 
   // Note: This allows the color map to be modulated by an arbitrary diffuse
@@ -868,6 +873,16 @@ void RenderEngineVtk::SetPbrMaterials() {
     for (auto& [_, prop_array] : props_) {
       for (auto& part : prop_array[ImageType::kColor].parts) {
         part.actor->GetProperty()->SetInterpolationToPBR();
+        if (part.actor->GetTexture() != nullptr &&
+            part.actor->GetProperty()->GetTexture("albedoTex") == nullptr) {
+          // Phong lighting uses the generic vtkActor "texture". PBR lighting
+          // uses the "albedoTex" (sRGB) texture. We should promote the texture
+          // as well.
+          vtkTexture* texture = part.actor->GetTexture();
+          texture->SetUseSRGBColorSpace(true);
+          part.actor->GetProperty()->SetBaseColorTexture(
+              part.actor->GetTexture());
+        }
       }
     }
   }

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -2084,7 +2084,7 @@ TEST_F(RenderEngineVtkTest, EnvironmentMap) {
 // This test we'll simply confirm that the introduction of a glTF shows an
 // illumination change without any other step (indicating material promotion).
 TEST_F(RenderEngineVtkTest, PbrMaterialPromotion) {
-  auto test_sphere_color = [this](bool matches_default,
+  auto test_sphere_color = [this](const RgbaColor expected_color,
                                   RenderEngineVtk* renderer) {
     const ColorRenderCamera camera(depth_camera_.core(), FLAGS_show_window);
     ImageRgba8U image(camera.core().intrinsics().width(),
@@ -2096,9 +2096,9 @@ TEST_F(RenderEngineVtkTest, PbrMaterialPromotion) {
     renderer->RenderColorImage(camera, &image);
 
     const RgbaColor sampled_color(image.at(cx, cy));
-    EXPECT_EQ(IsColorNear(sampled_color, default_color_), matches_default)
+    EXPECT_TRUE(IsColorNear(sampled_color, expected_color))
         << "  rendered color: " << sampled_color << "\n"
-        << "  expected color: " << default_color_;
+        << "  expected color: " << expected_color;
   };
 
   // Baseline test; sphere only reproduces the phong color at the center.
@@ -2113,15 +2113,16 @@ TEST_F(RenderEngineVtkTest, PbrMaterialPromotion) {
                                        .environment_map = EnvironmentMap()};
     auto renderer = make_unique<RenderEngineVtk>(params);
     InitializeRenderer(X_WC_, /* add_terrain = */ true, renderer.get());
-    PopulateSphereTest(renderer.get());
-    test_sphere_color(/* matches_default = */ true, renderer.get());
+    PopulateSphereTest(renderer.get(), true);
+    const RgbaColor texture_color(kTextureColor, 255);
+    test_sphere_color(texture_color, renderer.get());
   }
 
   // Add a glTF file; material promoted to PBR no longer matches Phong color.
   {
     SCOPED_TRACE("glTF added");
     Init(X_WC_, true);
-    PopulateSphereTest(renderer_.get());
+    PopulateSphereTest(renderer_.get(), true);
 
     // Place a glTF mesh far away from the origin; we can't see it but it
     // should still change how things render.
@@ -2133,7 +2134,10 @@ TEST_F(RenderEngineVtkTest, PbrMaterialPromotion) {
                               RigidTransformd(Vector3d(30, 0, 0)),
                               false /* needs update */);
 
-    test_sphere_color(/* matches_default = */ false, renderer_.get());
+    // We should still basically be green (because of the green texture), but
+    // the saturation and brightness changes in the presence of PBR material.
+    const RgbaColor pbr_texture_color(ColorI{66, 152, 68}, 255);
+    test_sphere_color(pbr_texture_color, renderer_.get());
   }
 }
 


### PR DESCRIPTION
The generic phong model uses vtkActor::Texture to define the diffuse texture.

The Pbr illumination model uses a texture assigned to the actor's properties (the "albedo texture"). Furthermore, that texture must be marked as sRGB.

This correct both the assignment (when PBR is active) as well as the upgrade when it is activated after geometries have aleady been assigned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20607)
<!-- Reviewable:end -->
