### PR TITLE
Add discrete output port to MbP that don't recompute contact solver result

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -3212,6 +3212,19 @@ const systems::OutputPort<T>& MultibodyPlant<T>::get_net_actuation_output_port()
 }
 
 template <typename T>
+const systems::OutputPort<T>&
+MultibodyPlant<T>::get_discrete_net_actuation_output_port() const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  if (!is_discrete()) {
+    throw std::runtime_error(
+        "Discrete net acutation is only available for a discrete "
+        "MultibodyPlant.");
+  }
+  DRAKE_DEMAND(discrete_update_manager_ != nullptr);
+  return discrete_update_manager_->get_discrete_net_actuation_output_port();
+}
+
+template <typename T>
 const systems::OutputPort<T>& MultibodyPlant<T>::get_net_actuation_output_port(
     ModelInstanceIndex model_instance) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
@@ -3287,6 +3300,19 @@ const systems::OutputPort<T>&
 MultibodyPlant<T>::get_contact_results_output_port() const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   return this->get_output_port(contact_results_port_);
+}
+
+template <typename T>
+const systems::OutputPort<T>&
+MultibodyPlant<T>::get_discrete_contact_results_output_port() const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  if (!is_discrete()) {
+    throw std::runtime_error(
+        "Discrete contact results is only available for a discrete "
+        "MultibodyPlant.");
+  }
+  DRAKE_DEMAND(discrete_update_manager_ != nullptr);
+  return discrete_update_manager_->get_discrete_contact_results_output_port();
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -878,6 +878,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called before Finalize().
   const systems::OutputPort<T>& get_net_actuation_output_port() const;
 
+  /// Returns a constant reference to the port that outputs the discrete
+  /// net actuation.
+  /// @throws std::exception if called pre-finalize, see Finalize().
+  /// @throws std::exception if `this` %MultibodyPlant is not discrete.
+  const systems::OutputPort<T>& get_discrete_net_actuation_output_port() const;
+
   /// Returns a constant reference to the output port that reports actuation
   /// values applied through joint actuators, for a specific model instance.
   /// Models that include PD controllers will include their contribution in this
@@ -1007,6 +1013,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// Returns a constant reference to the port that outputs ContactResults.
   /// @throws std::exception if called pre-finalize, see Finalize().
   const systems::OutputPort<T>& get_contact_results_output_port() const;
+
+  /// Returns a constant reference to the port that outputs discrete
+  /// ContactResults.
+  /// @throws std::exception if called pre-finalize, see Finalize().
+  /// @throws std::exception if `this` %MultibodyPlant is not discrete.
+  const systems::OutputPort<T>& get_discrete_contact_results_output_port()
+      const;
 
   /// Returns the output port of frames' poses to communicate with a
   /// SceneGraph.

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "drake/common/drake_assert.h"
@@ -41,6 +42,33 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant->DeclareCacheEntry(std::move(description),
                                     std::move(value_producer),
                                     std::move(prerequisites_of_calc));
+  }
+
+  static systems::LeafOutputPort<T>& DeclareAbstractOutputPort(
+      MultibodyPlant<T>* plant,
+      std::variant<std::string, systems::UseDefaultName> name,
+      typename systems::LeafOutputPort<T>::AllocCallback alloc_function,
+      typename systems::LeafOutputPort<T>::CalcCallback calc_function,
+      std::set<systems::DependencyTicket> prerequisites_of_calc = {
+          systems::System<T>::all_sources_ticket()}) {
+    DRAKE_DEMAND(plant != nullptr);
+    return plant->DeclareAbstractOutputPort(
+        std::move(name), std::move(alloc_function), std::move(calc_function),
+        std::move(prerequisites_of_calc));
+  }
+
+  static systems::LeafOutputPort<T>& DeclareVectorOutputPort(
+      MultibodyPlant<T>* plant,
+      std::variant<std::string, systems::UseDefaultName> name,
+      const systems::BasicVector<T>& model_vector,
+      typename systems::LeafOutputPort<T>::CalcVectorCallback
+          vector_calc_function,
+      std::set<systems::DependencyTicket> prerequisites_of_calc = {
+          systems::System<T>::all_sources_ticket()}) {
+    DRAKE_DEMAND(plant != nullptr);
+    return plant->DeclareVectorOutputPort(std::move(name), model_vector,
+                                          std::move(vector_calc_function),
+                                          std::move(prerequisites_of_calc));
   }
 
   static const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(


### PR DESCRIPTION
Existing MbP output ports now correctly depend on input ports and may become more expensive.

TODO: Add similar fast discrete ports for other MbP output ports (per-instance actuation, generalized_contact_force, etc).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20609)
<!-- Reviewable:end -->
