### PR TITLE
Build macOS wheels for multiple Python versions

### DIFF
--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -178,13 +178,13 @@ the main body of the document:
       appropriate edits as follows:
       * The version number
    5. Click the box labeled "Attach binaries by dropping them here or selecting
-      them." and then choose for upload the 39 release files from
+      them." and then choose for upload the 45 release files from
       ``/tmp/drake-release/v1.N.0/...``:
       - 12: 4 `.tar.gz` + 8 checksums
       - 6: 2 `.deb` + 4 checksums
       - 15: 5 linux `.whl` + 10 checksums
-      - 3: 1 macOS x86 `.whl` + 2 checksums
-      - 3: 1 macOS arm `.whl` + 2 checksums
+      - 3: 2 macOS x86 `.whl` + 4 checksums
+      - 3: 2 macOS arm `.whl` + 4 checksums
       * Note that on Jammy with `snap` provided Firefox, drag-and-drop from
         Nautilus will fail, and drop all of your release page inputs typed so
         far. Use the Firefox-provided selection dialog instead, by clicking on

--- a/tools/release_engineering/download_release_candidate.py
+++ b/tools/release_engineering/download_release_candidate.py
@@ -136,7 +136,9 @@ def _download_binaries(*, timestamp, staging, version):
                 f"drake-{version[1:]}-cp311-cp311-manylinux_2_31_x86_64.whl",
                 f"drake-{version[1:]}-cp312-cp312-manylinux_2_31_x86_64.whl",
                 f"drake-{version[1:]}-cp311-cp311-macosx_12_0_x86_64.whl",
+                f"drake-{version[1:]}-cp311-cp312-macosx_12_0_x86_64.whl",
                 f"drake-{version[1:]}-cp311-cp311-macosx_13_0_arm64.whl",
+                f"drake-{version[1:]}-cp311-cp312-macosx_13_0_arm64.whl",
                 # Deb filenames.
                 f"drake-dev_{version[1:]}-1_amd64-focal.deb",
                 f"drake-dev_{version[1:]}-1_amd64-jammy.deb",

--- a/tools/wheel/BUILD.bazel
+++ b/tools/wheel/BUILD.bazel
@@ -20,6 +20,7 @@ drake_py_binary(
         "wheel_builder/linux.py",
         "wheel_builder/linux_types.py",
         "wheel_builder/macos.py",
+        "wheel_builder/macos_types.py",
         "wheel_builder/main.py",
     ],
     main = "wheel_builder/main.py",

--- a/tools/wheel/README.rst
+++ b/tools/wheel/README.rst
@@ -138,14 +138,16 @@ are used:
 - ``/opt/drake-dependencies``:
   Contains installations of various dependencies needed to build Drake.
 
-- ``/opt/vtk``:
-  Contains the VTK installation used to build Drake.
-
-- ``/opt/drake``:
+- ``/opt/drake-dist``:
   Contains the Drake installation used to build the wheel.
 
 - ``/opt/drake-wheel-test``:
   Contains a Python virtual environment used to test the wheel.
+
+In addition, the wheel creation script requires that the Drake installation is
+located at ``/opt/drake``. Since multiple builds may be present, a temporary
+symlink is created at this path to the actual, Python-version-specific
+installation while building the wheel. Therefore, this path must be available.
 
 After performing wheel-specific provisioning using ``brew``, the builder
 invokes ``macos/build-wheel.sh``, optionally (and if the build succeeded)

--- a/tools/wheel/macos/provision-test-python.sh
+++ b/tools/wheel/macos/provision-test-python.sh
@@ -6,10 +6,17 @@
 
 set -eu -o pipefail
 
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <python-version>" >&2
+    exit 1
+fi
+
 # Clean up from old tests.
 rm -rf /opt/drake-wheel-test
 
 # Prepare test environment.
+mkdir /opt/drake-wheel-test
+
 # NOTE: Xcode ships python3, make sure to use the one from brew.
-$(brew --prefix python@3.11)/bin/python3.11 \
-    -m venv /opt/drake-wheel-test/python
+$(brew --prefix python@$1)/bin/python$1 \
+    -m venv /opt/drake-wheel-test/python$1

--- a/tools/wheel/wheel_builder/common.py
+++ b/tools/wheel/wheel_builder/common.py
@@ -13,7 +13,8 @@ build_root = '/opt/drake-wheel-build'
 test_root = '/opt/drake-wheel-test'
 
 # Location where the wheel will be produced.
-wheelhouse = os.path.join(build_root, 'wheel', 'wheelhouse')
+wheel_root = os.path.join(build_root, 'wheel')
+wheelhouse = os.path.join(wheel_root, 'wheelhouse')
 
 # Location of various scripts and other artifacts used to complete the build.
 resource_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -122,8 +123,6 @@ def do_main(args, platform):
 
     # Parse arguments.
     options = parser.parse_args(args)
-    if not options.extract:
-        options.test = False
     if platform is not None:
         platform.fixup_options(options)
 

--- a/tools/wheel/wheel_builder/macos_types.py
+++ b/tools/wheel/wheel_builder/macos_types.py
@@ -1,0 +1,23 @@
+# This file contains data types used by the macOS-specific build logic. See
+# //tools/wheel:builder for the user interface.
+
+class PythonTarget:
+    """
+    A representation of a Python version target, constructed from the version
+    number tuple.
+
+    Example:
+        PythonTarget(3, 2, 1)
+
+    Members:
+        version_tuple: Target version as a tuple, e.g. (3, 2, 1)
+        version_full: Target full version as a string, e.g. '3.2.1'
+        version: Target major/minor version as a string, e.g. '3.2'
+        tag: Target major/minor version without separators, e.g. '32'
+    """
+    def __init__(self, *version_parts):
+        pv_parts = tuple(map(str, version_parts))
+        self.version_tuple = tuple(version_parts)
+        self.version_full = '.'.join(pv_parts)
+        self.version = '.'.join(pv_parts[:2])
+        self.tag = ''.join(pv_parts[:2])


### PR DESCRIPTION
Rework macOS wheel build scripts to use Python-version-specific permanent locations for all operations, with temporary symlinks used for operations shared with the Linux wheel builds that expect non-versioned locations. Also rework builder to support a set of Python targets and to be able to build multiple wheels in a manner similar to how things work for Linux.

This changes the macOS wheel build to produce wheels for (as of writing) both Python 3.11 and 3.12.

Fixes #18791.
Fixes #19098.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20616)
<!-- Reviewable:end -->
