### PR TITLE
Increase verbosity of GetElementByName error message.

### DIFF
--- a/multibody/parsing/test/scoped_names_test.cc
+++ b/multibody/parsing/test/scoped_names_test.cc
@@ -33,17 +33,17 @@ GTEST_TEST(ScopedNamesTest, GetScopedFrameByName) {
   full_name = "foo";
   EXPECT_EQ(GetScopedFrameByNameMaybe(plant, full_name), nullptr);
   DRAKE_EXPECT_THROWS_MESSAGE(GetScopedFrameByName(plant, full_name),
-                              ".*no.*foo.*names are.*world.*");
+                              ".*no.*foo.*valid names .*world.*");
 
   full_name = "scoped_names_model::foo";
   EXPECT_EQ(GetScopedFrameByNameMaybe(plant, full_name), nullptr);
   DRAKE_EXPECT_THROWS_MESSAGE(GetScopedFrameByName(plant, full_name),
-                              ".*no.*foo.*names are.*base.*");
+                              ".*no.*foo.*valid names .*base.*");
 
   full_name = "scoped_names_model::inner_model::foo";
   EXPECT_EQ(GetScopedFrameByNameMaybe(plant, full_name), nullptr);
   DRAKE_EXPECT_THROWS_MESSAGE(GetScopedFrameByName(plant, full_name),
-                              ".*no.*foo.*names are.*inner_frame.*");
+                              ".*no.*foo.*valid names .*inner_frame.*");
 
   full_name = "bar_model::foo";
   EXPECT_EQ(GetScopedFrameByNameMaybe(plant, full_name), nullptr);

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -265,19 +266,37 @@ const auto& GetElementByName(
   // If the name is non-existent, then say so, whether or not a specific model
   // instance was requested.
   if (lower == upper) {
-    std::vector<std::string_view> all_keys;
-    all_keys.reserve(name_to_index.size());
-    for (auto it = name_to_index.begin(),
-             end = name_to_index.end();
-         it != end;
-         it = name_to_index.equal_range(it->first).second) {
-      all_keys.push_back(it->first.view());
+    std::string message = fmt::format(
+        "Get{}ByName(): There is no {} named '{}' anywhere in the model ",
+        element_classname, element_classname, name);
+    // We use a std::map of vectors here instead of multimap to sort in place
+    // below. Note that model instances with no elements are not included in
+    // the map.
+    std::map<ModelInstanceIndex, std::vector<std::string_view>>
+        names_by_model_instance;
+    for (const auto& [element_name, element_index] : name_to_index) {
+      const auto& element = GetElementByIndex(tree, element_index);
+      names_by_model_instance[element.model_instance()].push_back(
+          element_name.view());
     }
-    std::sort(all_keys.begin(), all_keys.end());
-    throw std::logic_error(fmt::format(
-        "Get{}ByName(): There is no {} named '{}' anywhere in the model "
-        "(valid names are: {})",
-        element_classname, element_classname, name, fmt::join(all_keys, ", ")));
+    if (names_by_model_instance.empty()) {
+      message =
+          fmt::format("Get{}ByName(): There are no {}s defined in the model",
+                      element_classname, element_classname);
+    } else {
+      std::vector<std::string> instance_messages;
+      instance_messages.reserve(names_by_model_instance.size());
+      for (auto& [model_instance_index, element_names] :
+           names_by_model_instance) {
+        std::sort(element_names.begin(), element_names.end());
+        instance_messages.push_back(
+            fmt::format("valid names in model instance '{}' are: {}",
+                        tree.GetModelInstanceName(model_instance_index),
+                        fmt::join(element_names, ", ")));
+      }
+      message += fmt::format("({})", fmt::join(instance_messages, "; "));
+    }
+    throw std::logic_error(message);
   }
 
   // Filter for the requested model_instance, if one was provided.

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -134,7 +134,9 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetBodyByName(kInvalidName),
-      ".*There is no Body named .*valid names are.* iiwa_link_1.*");
+      ".*There is no Body named .*valid names in model instance "
+      "'WorldModelInstance' are: world; valid names in model instance "
+      "'DefaultModelInstance' are: iiwa_link_1, iiwa_link_2.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetBodyByName(kLinkNames[0], world_model_instance()),
       ".*There is no Body.*but one does exist in other model instances.*");
@@ -154,7 +156,8 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetRigidBodyByName(kInvalidName),
-      ".*There is no Body named .*valid names are.* iiwa_link_1.*");
+      ".*There is no Body named .*valid names in model instance "
+      "'DefaultModelInstance' are.* iiwa_link_1.*");
 
   // Get frames by name.
   for (const std::string& frame_name : kFrameNames) {
@@ -166,7 +169,8 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetFrameByName(kInvalidName),
-      ".*There is no Frame named .*valid names are.* iiwa_link_1.*");
+      ".*There is no Frame named .*valid names in model instance "
+      "'DefaultModelInstance' are.* iiwa_link_1.*");
 
   // Get joints by name.
   for (const std::string& joint_name : kJointNames) {
@@ -176,7 +180,8 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetJointByName(kInvalidName),
-      ".*There is no Joint named .*valid names are.* iiwa_joint_1.*");
+      ".*There is no Joint named .*valid names in model instance "
+      "'DefaultModelInstance' are.* iiwa_joint_1.*");
 
   // Templatized version to obtain a particular known type of joint.
   for (const std::string& joint_name : kJointNames) {
@@ -187,7 +192,8 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.template GetJointByName<RevoluteJoint>(kInvalidName),
-      ".*There is no Joint named .*valid names are.* iiwa_joint_1.*");
+      ".*There is no Joint named .*valid names in model instance "
+      "'DefaultModelInstance' are.* iiwa_joint_1.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.template GetJointByName<PrismaticJoint>(kJointNames[0]),
       ".*not of type.*PrismaticJoint.*but.*RevoluteJoint.*");
@@ -199,10 +205,10 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
         model.GetJointActuatorByName(actuator_name);
     EXPECT_EQ(actuator.name(), actuator_name);
   }
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      model.GetJointActuatorByName(kInvalidName),
-      ".*There is no JointActuator named .*valid names are.* "
-      "iiwa_actuator_1.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(model.GetJointActuatorByName(kInvalidName),
+                              ".*There is no JointActuator named .*valid names "
+                              "in model instance 'DefaultModelInstance' are.* "
+                              "iiwa_actuator_1.*");
 
   // Test we can retrieve joints from the actuators.
   int names_index = 0;
@@ -277,6 +283,32 @@ GTEST_TEST(MultibodyTree, VerifyModelBasics) {
   EXPECT_THROW(model->Finalize(), std::logic_error);
 
   VerifyModelBasics(*model);
+}
+
+// Confirms that the error messages produced by GetElementByName are reasonable
+// even for an empty model.
+GTEST_TEST(MultibodyTree, EmptyGetElementByName) {
+  // Create an empty model.
+  MultibodyTree<double> model;
+  const std::string kInvalidName = "InvalidName";
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model.GetBodyByName(kInvalidName),
+      ".*There is no Body named .*valid names in model instance "
+      "'WorldModelInstance' are.* world.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model.GetFrameByName(kInvalidName),
+      ".*There is no Frame named .*valid names in model instance "
+      "'WorldModelInstance' are.* world.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model.GetJointByName(kInvalidName),
+      ".*There are no Joints defined in the model");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model.template GetJointByName<RevoluteJoint>(kInvalidName),
+      ".*There are no Joints defined in the model");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model.GetJointActuatorByName(kInvalidName),
+      ".*There are no JointActuators defined in the model");
 }
 
 // Exercises the error detection and reporting for retrieving model elements by


### PR DESCRIPTION
I've seen a number of students confused by the following sequence of events:
1) they add a new manipuland, let's call it "mug", into the simulation (typically via mesh_to_model, and then loading the sdf into the HardwareStation via model directives.
2) they call `GetBodyByName("mug")`. Not only does it fail, but it prints out a list of bodies, none of which resemble the name mug.

The problem, of course, is that "mug" is the model instance name, but not the body name. The body name is an obfuscated "body", which was autogenerated by mesh_to_model; at no time were they aware of that string and don't immediately associate it with the mug. Instead, they suspect that something was wrong with the dmd string and they failed to parse the mug. Moreover, the entire concept of MultibodyPlant organizing itself around model instances is a metaconcept that is not easy to find in the docs/tutorials.

This PR attempts to improve the situation by spelling out the association between model instances and element names in the error message.

Before: "(valid names are: {body, iiwa_link_0, iiwa_link_1, ...})"

After: "(valid names in ... model instance 'mug' are {body}; valid names in model instance 'iiwa' are {iiwa_link_0, iiwa_link_1, ...}"

+@jwnimmer-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20617)
<!-- Reviewable:end -->
