### PR TITLE
MJCF parser supports eulerseq (and fixes the default)

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -567,6 +567,9 @@ drake_cc_googletest(
         "//common/test_utilities:diagnostic_policy_test_base",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//common/test_utilities:maybe_pause_for_user",
+        "//geometry/test_utilities:meshcat_environment",
+        "//visualization",
     ],
 )
 

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -100,10 +100,12 @@ class MujocoParser {
       return {};
     }
 
-    Vector4d quat;  // MuJoCo uses w,x,y,z order.
-    if (ParseVectorAttribute(node, "quat", &quat)) {
-      return RigidTransformd(
-          Eigen::Quaternion<double>(quat[0], quat[1], quat[2], quat[3]), pos);
+    {
+      Vector4d quat;  // MuJoCo uses w,x,y,z order.
+      if (ParseVectorAttribute(node, "quat", &quat)) {
+        return RigidTransformd(
+            Eigen::Quaternion<double>(quat[0], quat[1], quat[2], quat[3]), pos);
+      }
     }
 
     Vector4d axisangle;
@@ -120,8 +122,32 @@ class MujocoParser {
       if (angle_ == kDegree) {
         euler *= (M_PI / 180.0);
       }
-      // Default is extrinsic xyz.  See eulerseq compiler option.
-      return RigidTransformd(math::RollPitchYawd(euler), pos);
+      Quaternion<double> quat(1, 0, 0, 0);
+      DRAKE_DEMAND(eulerseq_.size() == 3);
+      for (int i = 0; i < 3; ++i) {
+        Quaternion<double> this_quat(cos(euler[i] / 2.0), 0, 0, 0);
+        double sa = sin(euler[i] / 2.0);
+
+        if (eulerseq_[i] == 'x' || eulerseq_[i] == 'X') {
+          this_quat.x() = sa;
+        } else if (eulerseq_[i] == 'y' || eulerseq_[i] == 'Y') {
+          this_quat.y() = sa;
+        } else {
+          // We already confirmed that eulerseq_ only has 'xyzXYZ' when it was
+          // parsed.
+          DRAKE_DEMAND(eulerseq_[i] == 'z' || eulerseq_[i] == 'Z');
+          this_quat.z() = sa;
+        }
+
+        if (eulerseq_[i] == 'x' || eulerseq_[i] == 'y' || eulerseq_[i] == 'z') {
+          // moving axes: post-multiply
+          quat = quat * this_quat;
+        } else {
+          // fixed axes: pre-multiply
+          quat = this_quat * quat;
+        }
+      }
+      return RigidTransformd(RotationMatrixd(quat), pos);
     }
 
     Vector6d xyaxes;
@@ -1133,7 +1159,23 @@ class MujocoParser {
     }
 
     WarnUnsupportedAttribute(*node, "fitaabb");
-    WarnUnsupportedAttribute(*node, "eulerseq");
+
+    std::string eulerseq;
+    if (ParseStringAttribute(node, "eulerseq", &eulerseq)) {
+      if (eulerseq.size() != 3 ||
+          eulerseq.find_first_not_of("xyzXYZ") != std::string::npos) {
+        Error(
+            *node,
+            fmt::format(
+                "Illegal value '{}' for the eulerseq in {}. Valid eulerseq are "
+                "exactly three characters from the set [x,y,z,X,Y,Z]",
+                eulerseq, node->Name()));
+
+      } else {
+        eulerseq_ = eulerseq;
+      }
+    }
+
     WarnUnsupportedAttribute(*node, "texturedir");
     WarnUnsupportedAttribute(*node, "discardvisual");
     WarnUnsupportedAttribute(*node, "convexhull");
@@ -1430,6 +1472,7 @@ class MujocoParser {
   InertiaFromGeometry inertia_from_geom_{kAuto};
   std::map<std::string, XMLElement*> material_{};
   std::optional<std::filesystem::path> meshdir_{};
+  std::string eulerseq_{"xyz"};
   std::map<std::string, std::unique_ptr<geometry::Mesh>> mesh_{};
   // Spatial inertia of mesh assets assuming density = 1.
   std::map<std::string, SpatialInertia<double>> mesh_inertia_;

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -9,11 +9,14 @@
 #include "drake/common/test_utilities/diagnostic_policy_test_base.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/test_utilities/maybe_pause_for_user.h"
 #include "drake/common/text_logging.h"
+#include "drake/geometry/test_utilities/meshcat_environment.h"
 #include "drake/multibody/tree/ball_rpy_joint.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/weld_joint.h"
+#include "drake/visualization/visualization_config_functions.h"
 
 namespace drake {
 namespace multibody {
@@ -129,11 +132,50 @@ TEST_P(GymModelTest, GymModel) {
 }
 
 const char* gym_models[] = {
-  "acrobot", "cartpole", "cheetah", "finger", "fish", "hopper",
-  "humanoid", "humanoid_CMU", "lqr", "manipulator", "pendulum",
-  "point_mass", "reacher", "stacker", "swimmer", "walker"};
+    "acrobot",  "cartpole",   "cheetah",      "finger",  "fish",
+    "hopper",   "humanoid",   "humanoid_CMU", "lqr",     "manipulator",
+    "pendulum", "point_mass", "quadruped",    "reacher", "stacker",
+    "swimmer",  "walker"};
 INSTANTIATE_TEST_SUITE_P(GymModels, GymModelTest,
                          testing::ValuesIn(gym_models));
+
+// In addition to confirming that the parser can successfully parse the model,
+// this test can be used to manually inspect the resulting visualization.
+GTEST_TEST(MujocoParserExtraTest, Visualize) {
+  systems::DiagramBuilder<double> builder;
+  std::shared_ptr<geometry::Meshcat> meshcat =
+      geometry::GetTestEnvironmentMeshcat();
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
+
+  ParsingOptions options;
+  PackageMap package_map;
+  MujocoParserWrapper wrapper;
+  internal::CollisionFilterGroupResolver resolver{&plant};
+  internal::DiagnosticPolicy diagnostic_policy;
+  ParsingWorkspace w{
+      options,
+      package_map,
+      diagnostic_policy,
+      &plant,
+      &resolver,
+      [](const drake::internal::DiagnosticPolicy&,
+         const std::string&) -> drake::multibody::internal::ParserInterface& {
+        DRAKE_UNREACHABLE();
+      }};
+  const std::string model_name = "quadruped";
+  const std::string filename = FindResourceOrThrow(fmt::format(
+      "drake/multibody/parsing/dm_control/suite/{}.xml", model_name));
+  wrapper.AddModel({DataSource::kFilename, &filename}, model_name, {}, w);
+  resolver.Resolve(diagnostic_policy);
+  plant.Finalize();
+  visualization::AddDefaultVisualization(&builder, meshcat);
+
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+  diagram->ExecuteInitializationEvents(context.get());
+  diagram->ForcedPublish(*context);
+  common::MaybePauseForUser();
+}
 
 TEST_F(MujocoParserTest, CartPole) {
   const std::string filename = FindResourceOrThrow(
@@ -313,6 +355,7 @@ TEST_F(MujocoParserTest, GeometryPose) {
   // By default, angles are in degrees.
   std::string xml = R"""(
 <mujoco model="test">
+  <compiler eulerseq="XYZ"/>
   <default class="default_pose">
     <geom pos="1 2 3" quat="0 1 0 0"/>
   </default>
@@ -334,7 +377,7 @@ TEST_F(MujocoParserTest, GeometryPose) {
 </mujoco>
 )""";
 
-  // Explicitly set radians.
+  // Explicitly set radians. Eulerseq is default "xyz".
   std::string radians_xml = R"""(
 <mujoco model="test">
   <compiler angle="radian"/>
@@ -347,10 +390,10 @@ TEST_F(MujocoParserTest, GeometryPose) {
 </mujoco>
 )""";
 
-  // Explicitly set degrees.
+  // Explicitly set degrees. Eulerseq is "ZYZ".
   std::string degrees_xml = R"""(
 <mujoco model="test">
-  <compiler angle="degree"/>
+  <compiler angle="degree" eulerseq="ZYZ"/>
   <worldbody>
     <geom name="axisangle_deg" axisangle="4 5 6 30" pos="1 2 3" type="sphere"
           size="0.1" />
@@ -370,13 +413,16 @@ TEST_F(MujocoParserTest, GeometryPose) {
                                 const RigidTransformd& X_FG) {
     GeometryId geom_id = inspector.GetGeometryIdByName(
         inspector.world_frame_id(), Role::kProximity, geometry_name);
-    EXPECT_TRUE(inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(X_FG, 1e-14));
+    EXPECT_TRUE(inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(X_FG, 1e-14))
+        << geometry_name;
     geom_id = inspector.GetGeometryIdByName(inspector.world_frame_id(),
                                             Role::kPerception, geometry_name);
-    EXPECT_TRUE(inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(X_FG, 1e-14));
+    EXPECT_TRUE(inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(X_FG, 1e-14))
+        << geometry_name;
     geom_id = inspector.GetGeometryIdByName(inspector.world_frame_id(),
                                             Role::kIllustration, geometry_name);
-    EXPECT_TRUE(inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(X_FG, 1e-14));
+    EXPECT_TRUE(inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(X_FG, 1e-14))
+        << geometry_name;
   };
 
   const Vector3d p{1, 2, 3};
@@ -401,14 +447,22 @@ TEST_F(MujocoParserTest, GeometryPose) {
   CheckPose(
       "axisangle_rad",
       RigidTransformd(Eigen::AngleAxis<double>(0.5, Vector3d{4, 5, 6}), p));
-  CheckPose("euler_rad", RigidTransformd(RollPitchYawd{0.5, 0.7, 1.05}, p));
+  CheckPose("euler_rad",
+            RigidTransformd(RotationMatrixd::MakeXRotation(0.5) *
+                                RotationMatrixd::MakeYRotation(0.7) *
+                                RotationMatrixd::MakeZRotation(1.05),
+                            p));
   CheckPose("axisangle_deg",
             RigidTransformd(
                 Eigen::AngleAxis<double>(M_PI / 6.0, Vector3d{4, 5, 6}), p));
-  CheckPose(
-      "euler_deg",
-      RigidTransformd(RollPitchYawd{M_PI / 6.0, M_PI / 4.0, M_PI / 3.0}, p));
+  CheckPose("euler_deg",
+            RigidTransformd(RotationMatrixd::MakeZRotation(M_PI / 3.0) *
+                                RotationMatrixd::MakeYRotation(M_PI / 4.0) *
+                                RotationMatrixd::MakeZRotation(M_PI / 6.0),
+                            p));
 }
+
+
 
 TEST_F(MujocoParserTest, GeometryPoseErrors) {
   const std::string xml = R"""(
@@ -863,7 +917,10 @@ TEST_F(MujocoParserTest, InertiaFromGeometry) {
 TEST_F(MujocoParserTest, CompilerErrors) {
   std::string xml = R"""(
 <mujoco model="test">
-  <compiler coordinate="global" angle="grad" inertiafromgeom="QQQ"/>
+  <compiler coordinate="global" angle="grad" inertiafromgeom="QQQ" eulerseq="abc"/>
+  <worldbody>
+    <body name="trigger_bad_euler_seq" euler="30 45 60"/>
+  </worldbody>
 </mujoco>
 )""";
 
@@ -872,6 +929,26 @@ TEST_F(MujocoParserTest, CompilerErrors) {
   EXPECT_THAT(TakeWarning(),
               MatchesRegex(".*inertiafromgeom.*interpret.*ignored.*"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*coordinate.*not supported.*"));
+  EXPECT_THAT(
+      TakeError(),
+      MatchesRegex(".*Illegal value 'abc' for the eulerseq in compiler.*"));
+}
+
+TEST_F(MujocoParserTest, CompilerErrorsShortEulerSeq) {
+  // Eulerseq is 1 character instead of 3.
+  std::string xml = R"""(
+<mujoco model="test">
+  <compiler eulerseq="a"/>
+  <worldbody>
+    <body name="trigger_bad_euler_seq" euler="30 45 60"/>
+  </worldbody>
+</mujoco>
+)""";
+
+  AddModelFromString(xml, "test");
+  EXPECT_THAT(
+      TakeError(),
+      MatchesRegex(".*Illegal value 'a' for the eulerseq in compiler.*"));
 }
 
 TEST_F(MujocoParserTest, AssetErrors) {
@@ -910,6 +987,7 @@ TEST_F(MujocoParserTest, BodyError) {
 TEST_F(MujocoParserTest, Joint) {
   std::string xml = R"""(
 <mujoco model="test">
+  <compiler eulerseq="XYZ"/>
   <default>
     <geom type="sphere" size="1"/>
     <default class="default_joint">

--- a/multibody/parsing/test/sdf_parser_test/interface_api_test/arm.xml
+++ b/multibody/parsing/test/sdf_parser_test/interface_api_test/arm.xml
@@ -1,4 +1,5 @@
 <mujoco model="arm">
+  <compiler eulerseq="XYZ"/>
   <worldbody>
     <body name="L1">
       <geom type="sphere" size="0.4"/>

--- a/tools/workspace/dm_control_internal/files.bzl
+++ b/tools/workspace/dm_control_internal/files.bzl
@@ -19,6 +19,7 @@ def dm_control_mujoco_files():
         "dm_control/suite/manipulator.xml",
         "dm_control/suite/pendulum.xml",
         "dm_control/suite/point_mass.xml",
+        "dm_control/suite/quadruped.xml",
         "dm_control/suite/reacher.xml",
         "dm_control/suite/stacker.xml",
         "dm_control/suite/swimmer.xml",


### PR DESCRIPTION
Towards #20232.  Related to #20444.

In #20232 we realized that the default eulerseq in MJCF is "xyz", which is NOT the standard eulerseq in urdf/sdf. This PR fixes a bug in which we assumed the wrong eulerseq by default, leading to incorrect kinematics in some parsed models. It also adds support for non-default eulerseq.

It also adds a test so that we can readily visualize the parsed kinematics from the dm_control suite which are being used to test the parser.

+@joemasterjohn for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20620)
<!-- Reviewable:end -->
