### PR TITLE
Mujoco parser support for visual-only and/or collision-only geometry

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -442,6 +442,8 @@ class MujocoParser {
     Vector4d rgba{.5, .5, .5, 1};
     CoulombFriction<double> friction{1.0, 1.0};
     SpatialInertia<double> M_GBo_B{};
+    bool register_collision{true};
+    bool register_visual{true};
   };
 
   MujocoGeometry ParseGeometry(XMLElement* node, int num_geom,
@@ -504,12 +506,12 @@ class MujocoParser {
       geom.shape = std::make_unique<geometry::HalfSpace>();
     } else if (type == "sphere") {
       if (size.size() < 1) {
-        Error(*node,
-              "The size attribute for sphere geom must have at least one "
-              "element.");
-        return geom;
+        // Allow zero-radius spheres (the MJCF default size is 0 0 0).
+        geom.shape = std::make_unique<geometry::Sphere>(0.0);
+        compute_inertia = false;
+      } else {
+        geom.shape = std::make_unique<geometry::Sphere>(size[0]);
       }
-      geom.shape = std::make_unique<geometry::Sphere>(size[0]);
     } else if (type == "capsule") {
       if (has_fromto) {
         if (size.size() < 1) {
@@ -627,7 +629,11 @@ class MujocoParser {
     ParseScalarAttribute(node, "contype", &contype);
     ParseScalarAttribute(node, "conaffinity", &conaffinity);
     ParseScalarAttribute(node, "condim", &condim);
-    if (contype != 1 || conaffinity != 1) {
+    if (contype == 0 && conaffinity == 0) {
+      // This is a common mechanism used by MJCF authors to specify visual-only
+      // geometry.
+      geom.register_collision = false;
+    } else if (contype != 1 || conaffinity != 1) {
       Warning(
           *node,
           fmt::format(
@@ -645,7 +651,26 @@ class MujocoParser {
                                  geom.name, condim));
     }
 
-    WarnUnsupportedAttribute(*node, "group");
+    if (geom.register_collision && type == "sphere" && size.size() < 1) {
+      Warning(*node,
+              fmt::format(
+                  "Using zero-radius spheres (MuJoCo's default geometry) for "
+                  "collision geometry may not be supported by all features in "
+                  "Drake. Consider specifying a non-zero size for geom {}.",
+                  geom.name));
+    }
+
+    int group{0};
+    ParseScalarAttribute(node, "group", &group);
+    if (group > 2) {
+      // By default, the MuJoCo visualizer does not render geom with group > 2.
+      // Setting the group > 2 is a common mechanism that MuJoCo uses to
+      // register collision-only geometry.
+      geom.register_visual = false;
+      // TODO(russt): Consider adding a <drake::enable_visual_for_group> tag so
+      // that mjcf authors can configure this behavior.
+    }
+
     WarnUnsupportedAttribute(*node, "priority");
 
     std::string material;
@@ -764,7 +789,7 @@ class MujocoParser {
       auto geom = ParseGeometry(link_node, geometries.size(), compute_inertia,
                                 child_class);
       if (!geom.shape) continue;
-      if (compute_inertia) {
+      if (compute_inertia && geom.M_GBo_B.get_mass() > 0) {
         M_BBo_B += geom.M_GBo_B;
       }
       geometries.push_back(std::move(geom));
@@ -776,10 +801,14 @@ class MujocoParser {
 
     if (plant_->geometry_source_is_registered()) {
       for (auto& geom : geometries) {
-        plant_->RegisterVisualGeometry(body, geom.X_BG, *geom.shape, geom.name,
-                                       geom.rgba);
-        plant_->RegisterCollisionGeometry(body, geom.X_BG, *geom.shape,
-                                          geom.name, geom.friction);
+        if (geom.register_visual) {
+          plant_->RegisterVisualGeometry(body, geom.X_BG, *geom.shape,
+                                         geom.name, geom.rgba);
+        }
+        if (geom.register_collision) {
+          plant_->RegisterCollisionGeometry(body, geom.X_BG, *geom.shape,
+                                            geom.name, geom.friction);
+        }
       }
     }
 
@@ -851,11 +880,15 @@ class MujocoParser {
            link_node = link_node->NextSiblingElement("geom")) {
         auto geom = ParseGeometry(link_node, geometries.size(), false);
         if (!geom.shape) continue;
-        plant_->RegisterVisualGeometry(plant_->world_body(), geom.X_BG,
-                                       *geom.shape, geom.name, geom.rgba);
-        plant_->RegisterCollisionGeometry(plant_->world_body(), geom.X_BG,
-                                          *geom.shape, geom.name,
-                                          geom.friction);
+        if (geom.register_visual) {
+          plant_->RegisterVisualGeometry(plant_->world_body(), geom.X_BG,
+                                         *geom.shape, geom.name, geom.rgba);
+        }
+        if (geom.register_collision) {
+          plant_->RegisterCollisionGeometry(plant_->world_body(), geom.X_BG,
+                                            *geom.shape, geom.name,
+                                            geom.friction);
+        }
       }
     }
 

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -444,6 +444,8 @@ TEST_F(MujocoParserTest, GeometryProperties) {
     <geom name="red" type="sphere" size="0.1" material="Orange" rgba="1 0 0 1"/>
     <geom name="green" type="sphere" size="0.1" material="Orange"
           class="default_rgba"/>
+    <geom name="no_collision" contype="0" conaffinity="0" />
+    <geom name="no_visual" size="0.1" group="3" />
   </worldbody>
 </mujoco>
 )""";
@@ -453,35 +455,59 @@ TEST_F(MujocoParserTest, GeometryProperties) {
   const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
 
   auto CheckProperties = [&inspector](const std::string& geometry_name,
-                                      double mu, const Vector4d& rgba) {
-    GeometryId geom_id = inspector.GetGeometryIdByName(
-        inspector.world_frame_id(), Role::kProximity, geometry_name);
-    const geometry::ProximityProperties* proximity_prop =
-        inspector.GetProximityProperties(geom_id);
-    EXPECT_TRUE(proximity_prop);
-    EXPECT_TRUE(proximity_prop->HasProperty("material", "coulomb_friction"));
-    const auto& friction = proximity_prop->GetProperty<CoulombFriction<double>>(
-        "material", "coulomb_friction");
-    EXPECT_EQ(friction.static_friction(), mu);
-    EXPECT_EQ(friction.dynamic_friction(), mu);
+                                      double mu, const Vector4d& rgba,
+                                      bool has_collision = true,
+                                      bool has_visual = true) {
+    if (has_collision) {
+      GeometryId geom_id = inspector.GetGeometryIdByName(
+          inspector.world_frame_id(), Role::kProximity, geometry_name);
+      const geometry::ProximityProperties* proximity_prop =
+          inspector.GetProximityProperties(geom_id);
+      EXPECT_TRUE(proximity_prop);
+      EXPECT_TRUE(proximity_prop->HasProperty("material", "coulomb_friction"));
+      const auto& friction =
+          proximity_prop->GetProperty<CoulombFriction<double>>(
+              "material", "coulomb_friction");
+      EXPECT_EQ(friction.static_friction(), mu);
+      EXPECT_EQ(friction.dynamic_friction(), mu);
+    } else {
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          inspector.GetGeometryIdByName(inspector.world_frame_id(),
+                                        Role::kProximity, geometry_name),
+          ".*has no geometry.*");
+    }
 
-    geom_id = inspector.GetGeometryIdByName(inspector.world_frame_id(),
-                                            Role::kPerception, geometry_name);
-    const geometry::PerceptionProperties* perception_prop =
-        inspector.GetPerceptionProperties(geom_id);
-    EXPECT_TRUE(perception_prop);
-    EXPECT_TRUE(perception_prop->HasProperty("phong", "diffuse"));
-    EXPECT_TRUE(CompareMatrices(
-        perception_prop->GetProperty<Vector4d>("phong", "diffuse"), rgba));
+    if (has_visual) {
+      GeometryId geom_id = inspector.GetGeometryIdByName(
+          inspector.world_frame_id(), Role::kPerception, geometry_name);
+      const geometry::PerceptionProperties* perception_prop =
+          inspector.GetPerceptionProperties(geom_id);
+      EXPECT_TRUE(perception_prop);
+      EXPECT_TRUE(perception_prop->HasProperty("phong", "diffuse"));
+      EXPECT_TRUE(CompareMatrices(
+          perception_prop->GetProperty<Vector4d>("phong", "diffuse"), rgba));
+    } else {
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          inspector.GetGeometryIdByName(inspector.world_frame_id(),
+                                        Role::kPerception, geometry_name),
+          ".*has no geometry.*");
+    }
 
-    geom_id = inspector.GetGeometryIdByName(inspector.world_frame_id(),
-                                            Role::kIllustration, geometry_name);
-    const geometry::IllustrationProperties* illustration_prop =
-        inspector.GetIllustrationProperties(geom_id);
-    EXPECT_TRUE(illustration_prop);
-    EXPECT_TRUE(illustration_prop->HasProperty("phong", "diffuse"));
-    EXPECT_TRUE(CompareMatrices(
-        illustration_prop->GetProperty<Vector4d>("phong", "diffuse"), rgba));
+    if (has_visual) {
+      GeometryId geom_id = inspector.GetGeometryIdByName(
+          inspector.world_frame_id(), Role::kIllustration, geometry_name);
+      const geometry::IllustrationProperties* illustration_prop =
+          inspector.GetIllustrationProperties(geom_id);
+      EXPECT_TRUE(illustration_prop);
+      EXPECT_TRUE(illustration_prop->HasProperty("phong", "diffuse"));
+      EXPECT_TRUE(CompareMatrices(
+          illustration_prop->GetProperty<Vector4d>("phong", "diffuse"), rgba));
+    } else {
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          inspector.GetGeometryIdByName(inspector.world_frame_id(),
+                                        Role::kIllustration, geometry_name),
+          ".*has no geometry.*");
+    }
   };
 
   CheckProperties("default", 1.0, Vector4d{.5, .5, .5, 1});
@@ -491,6 +517,19 @@ TEST_F(MujocoParserTest, GeometryProperties) {
   // If both material and rgba are specified, rgba wins.
   CheckProperties("red", 1.0, Vector4d{1, 0, 0, 1});
   CheckProperties("green", 1.0, Vector4d{0, 1, 0, 1});
+  CheckProperties("no_collision", 1.0, Vector4d{.5, .5, .5, 1},
+                  false /* has collision */, true /* has visual */);
+  CheckProperties("no_visual", 1.0, Vector4d{.5, .5, .5, 1},
+                  true /* has collision */, false /* has visual */);
+
+  // Confirm that the default geometry is a zero-radius sphere.
+  GeometryId no_collision_id = inspector.GetGeometryIdByName(
+      inspector.world_frame_id(), Role::kIllustration, "no_collision");
+  const geometry::Sphere* no_collision_shape =
+      dynamic_cast<const geometry::Sphere*>(
+          &inspector.GetShape(no_collision_id));
+  ASSERT_NE(no_collision_shape, nullptr);
+  EXPECT_EQ(no_collision_shape->radius(), 0.0);
 }
 
 class BoxMeshTest : public MujocoParserTest {
@@ -1183,6 +1222,8 @@ TEST_F(MujocoParserTest, GeomErrors) {
   AddModelFromString(xml, "test");
 
   EXPECT_THAT(TakeWarning(), MatchesRegex(
+      ".*zero-radius spheres.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(
       ".*fromto.*ellipsoid.*unsupported.*ignored.*"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(
       ".*fromto.*box.*unsupported.*ignored.*"));
@@ -1191,8 +1232,6 @@ TEST_F(MujocoParserTest, GeomErrors) {
   EXPECT_THAT(TakeWarning(), MatchesRegex(
       ".*hfield.*unsupported.*ignored.*"));
 
-  EXPECT_THAT(TakeError(), MatchesRegex(
-      ".*size.*sphere.*must have.*element.*"));
   EXPECT_THAT(TakeError(), MatchesRegex(
       ".*size.*capsule.*must have.*two elements.*"));
   EXPECT_THAT(TakeError(), MatchesRegex(


### PR DESCRIPTION
Towards #20444.

As discussed in
https://drakedevelopers.slack.com/archives/C43KX47A9/p1697895553790089 , this PR:
- avoids registering collision geometry for geom with contype==conaffinity==0
- avoids registering visual geometry for group > 2.

+@joemasterjohn for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20622)
<!-- Reviewable:end -->
