### PR TITLE
InverseKinematics: set non-zero initial guess for quaternion joints.

### DIFF
--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -96,10 +96,14 @@ InverseKinematics::InverseKinematics(
             current_positions.segment<size>(start).normalized();
         lb.segment<size>(start) = quat;
         ub.segment<size>(start) = quat;
+        prog_->SetInitialGuess(q_.segment<size>(start), quat);
       } else {
         prog_->AddConstraint(solvers::Binding<solvers::Constraint>(
             std::make_shared<UnitQuaternionConstraint>(),
             q_.segment<size>(start)));
+        // Set a non-zero initial guess to help avoid singularities.
+        prog_->SetInitialGuess(q_.segment<size>(start),
+                              Eigen::Vector4d{1, 0, 0, 0});
       }
     }
   }

--- a/multibody/inverse_kinematics/unit_quaternion_constraint.cc
+++ b/multibody/inverse_kinematics/unit_quaternion_constraint.cc
@@ -33,9 +33,13 @@ void AddUnitQuaternionConstraintOnPlant(
   for (BodyIndex body_index{0}; body_index < plant.num_bodies(); ++body_index) {
     const auto& body = plant.get_body(body_index);
     if (body.has_quaternion_dofs()) {
+      Vector4<symbolic::Variable> quat_vars =
+          q_vars.segment<4>(body.floating_positions_start());
       prog->AddConstraint(solvers::Binding<solvers::Constraint>(
-          std::make_shared<UnitQuaternionConstraint>(),
-          q_vars.segment<4>(body.floating_positions_start())));
+          std::make_shared<UnitQuaternionConstraint>(), quat_vars));
+      if (prog->GetInitialGuess(quat_vars).array().isNaN().all()) {
+        prog->SetInitialGuess(quat_vars, Eigen::Vector4d(1, 0, 0, 0));
+      }
     }
   }
 }

--- a/multibody/inverse_kinematics/unit_quaternion_constraint.h
+++ b/multibody/inverse_kinematics/unit_quaternion_constraint.h
@@ -9,9 +9,17 @@
 namespace drake {
 namespace multibody {
 /**
- * Constrains the quaternion to have a unit length.
- *
- * @ingroup solver_evaluators
+ Constrains the quaternion to have a unit length.
+
+ @note: It is highly recommended that in addition to adding this constraint,
+ you also call MathematicalProgram::SetInitialGuess(), e.g.
+ @code
+ // Set a non-zero initial guess to help avoid singularities.
+ prog_->SetInitialGuess(q_.segment<4>(quaternion_start),
+                        Eigen::Vector4d{1, 0, 0, 0});
+ @endcode
+
+ @ingroup solver_evaluators
  */
 class UnitQuaternionConstraint : public solvers::Constraint {
  public:
@@ -40,19 +48,25 @@ class UnitQuaternionConstraint : public solvers::Constraint {
 };
 
 /**
- * Add unit length constraints to all the variables representing quaternion in
- * `q_vars`. Namely the quaternions for floating base joints in `plant` will be
- * enforced to have a unit length.
- * @param plant The plant on which we impose the unit quaternion constraints.
- * @param q_vars The decision variables for the generalized position of the
- * plant.
- * @param prog The unit quaternion constraints are added to this prog.
- * @tparam_default_scalar
+ Add unit length constraints to all the variables representing quaternion in
+ `q_vars`. Namely the quaternions for floating base joints in `plant` will be
+ enforced to have a unit length.
+
+ Additionally, if the initial guess for the quaternion variables has not been
+ set (it is nan), then this method calls MathematicalProgram::SetInitialGuess()
+ with [1, 0, 0, 0], to help the solver avoid singularities.
+
+ @param plant The plant on which we impose the unit quaternion constraints.
+ @param q_vars The decision variables for the generalized position of the
+ plant.
+ @param prog The unit quaternion constraints are added to this prog.
+ @tparam_default_scalar
  */
 template <typename T>
 void AddUnitQuaternionConstraintOnPlant(
     const MultibodyPlant<T>& plant,
     const Eigen::Ref<const VectorX<symbolic::Variable>>& q_vars,
     solvers::MathematicalProgram* prog);
+
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Resolves #17726.

+@hongkai-dai for feature review, please.
cc @cohnt

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20624)
<!-- Reviewable:end -->
