### PR TITLE
Reset IRIS consecutive_failures after falsifying lower bound

### DIFF
--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -776,8 +776,8 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
       for (const auto& binding : additional_constraint_bindings) {
         for (int index = 0; index < binding.evaluator()->num_constraints();
              ++index) {
-          int consecutive_failures = 0;
           for (bool falsify_lower_bound : {true, false}) {
+            int consecutive_failures = 0;
             if (falsify_lower_bound &&
                 std::isinf(binding.evaluator()->lower_bound()[index])) {
               continue;

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -843,10 +843,11 @@ GTEST_TEST(IrisInConfigurationSpaceTest, BoxesPrismaticPlusConstraints) {
   const double q_ub = M_PI / 8;
   DRAKE_ASSERT(q_ub < qmax);  // otherwise test will be pointless
   prog.AddConstraint(sin(q[0]), -1.0 / sqrt(2.0), sin(q_ub));
-  HPolyhedron region2 = IrisFromUrdf(boxes_urdf, sample, options);
+  // Calc the upper bounded region
+  HPolyhedron region_ub = IrisFromUrdf(boxes_urdf, sample, options);
   const double kMargin = options.configuration_space_margin;
-  EXPECT_TRUE(region2.PointInSet(Vector1d{q_ub - kTol - kMargin}));
-  EXPECT_FALSE(region2.PointInSet(Vector1d{q_ub + kTol - kMargin}));
+  EXPECT_TRUE(region_ub.PointInSet(Vector1d{q_ub - kTol - kMargin}));
+  EXPECT_FALSE(region_ub.PointInSet(Vector1d{q_ub + kTol - kMargin}));
 }
 
 // This double pendulum doesn't have any collision geometry, but we'll add


### PR DESCRIPTION
I noticed a small bug in `IrisInConfigurationSpace` when handling additional constraints. The algorithm first falsifies lower bound, and then must falsify upper bound. 

However, when both bounds are present, then all `consecutive_failures` are consumed by the lower bound, and the falsification of the upper bound is wrongly skipped, leading to invalid IRIS regions. 

Augmented an existing unit test to ensure this is working. Without the fix in this PR, the extra part of the unit test fails. 

cc @RussTedrake

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20627)
<!-- Reviewable:end -->
