### PR TITLE
Rework deformable torus example to demo external force

### DIFF
--- a/examples/multibody/deformable_torus/BUILD.bazel
+++ b/examples/multibody/deformable_torus/BUILD.bazel
@@ -1,8 +1,49 @@
 load(
     "//tools/skylark:drake_cc.bzl",
     "drake_cc_binary",
+    "drake_cc_googletest",
+    "drake_cc_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+drake_cc_library(
+    name = "parallel_gripper_controller",
+    srcs = [
+        "parallel_gripper_controller.cc",
+    ],
+    hdrs = [
+        "parallel_gripper_controller.h",
+    ],
+    deps = [
+        "//multibody/plant",
+    ],
+)
+
+drake_cc_library(
+    name = "point_source_force_field",
+    srcs = [
+        "point_source_force_field.cc",
+    ],
+    hdrs = [
+        "point_source_force_field.h",
+    ],
+    deps = [
+        "//multibody/plant",
+    ],
+)
+
+drake_cc_library(
+    name = "suction_cup_controller",
+    srcs = [
+        "suction_cup_controller.cc",
+    ],
+    hdrs = [
+        "suction_cup_controller.h",
+    ],
+    deps = [
+        "//multibody/plant",
+    ],
+)
 
 drake_cc_binary(
     name = "deformable_torus",
@@ -19,6 +60,9 @@ drake_cc_binary(
         "-realtime_rate=0.0",
     ],
     deps = [
+        ":parallel_gripper_controller",
+        ":point_source_force_field",
+        ":suction_cup_controller",
         "//geometry:drake_visualizer",
         "//geometry:scene_graph",
         "//multibody/parsing",
@@ -29,4 +73,12 @@ drake_cc_binary(
     ],
 )
 
-add_lint_tests(enable_clang_format_lint = False)
+drake_cc_googletest(
+    name = "point_source_force_field_test",
+    deps = [
+        ":point_source_force_field",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+add_lint_tests()

--- a/examples/multibody/deformable_torus/README.md
+++ b/examples/multibody/deformable_torus/README.md
@@ -2,8 +2,11 @@
 
 This is an example of simulation of deformable bodies in Drake.
 The example poses a deformable torus on the ground and uses a PD controlled
-gripper that follows a prescribed kinematics to pick up the torus, lift it up in
-the air, and then drop it back on the ground.
+gripper that follows a prescribed kinematics to pick up the torus, lift it up
+in the air, and then drop it back on the ground. Users can switch between a
+parallel jaw gripper model and a suction cup gripper model with the `--gripper`
+flag.
+
 This demonstrates the dynamics of deformable bodies and showcases the SAP solver
 in handling contact between deformable and rigid bodies.
 

--- a/examples/multibody/deformable_torus/deformable_torus.cc
+++ b/examples/multibody/deformable_torus/deformable_torus.cc
@@ -3,6 +3,9 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/examples/multibody/deformable_torus/parallel_gripper_controller.h"
+#include "drake/examples/multibody/deformable_torus/point_source_force_field.h"
+#include "drake/examples/multibody/deformable_torus/suction_cup_controller.h"
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/scene_graph.h"
@@ -17,35 +20,51 @@
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
 
-DEFINE_double(simulation_time, 8.0, "Desired duration of the simulation [s].");
+DEFINE_double(simulation_time, 12.0, "Desired duration of the simulation [s].");
 DEFINE_double(realtime_rate, 1.0, "Desired real time rate.");
 DEFINE_double(time_step, 1e-2,
               "Discrete time step for the system [s]. Must be positive.");
-DEFINE_double(E, 1e4, "Young's modulus of the deformable body [Pa].");
+DEFINE_double(E, 3e4, "Young's modulus of the deformable body [Pa].");
 DEFINE_double(nu, 0.4, "Poisson's ratio of the deformable body, unitless.");
-DEFINE_double(density, 1e3, "Mass density of the deformable body [kg/m³].");
+DEFINE_double(density, 1e3,
+              "Mass density of the deformable body [kg/m³]. We observe that "
+              "density above 2400 kg/m³ makes the torus too heavy to be picked "
+              "up by the suction gripper.");
 DEFINE_double(beta, 0.01,
               "Stiffness damping coefficient for the deformable body [1/s].");
+DEFINE_string(gripper, "parallel",
+              "Type of gripper used to pick up the deformable torus. Options "
+              "are: 'parallel' and 'suction'.");
 
+using drake::examples::deformable_torus::ParallelGripperController;
+using drake::examples::deformable_torus::PointSourceForceField;
+using drake::examples::deformable_torus::SuctionCupController;
 using drake::geometry::AddContactMaterial;
 using drake::geometry::Box;
+using drake::geometry::Capsule;
+using drake::geometry::Ellipsoid;
 using drake::geometry::GeometryInstance;
 using drake::geometry::IllustrationProperties;
 using drake::geometry::Mesh;
 using drake::geometry::ProximityProperties;
+using drake::geometry::Sphere;
 using drake::math::RigidTransformd;
 using drake::multibody::AddMultibodyPlant;
 using drake::multibody::Body;
 using drake::multibody::CoulombFriction;
+using drake::multibody::DeformableBodyId;
+using drake::multibody::DeformableModel;
+using drake::multibody::ModelInstanceIndex;
+using drake::multibody::MultibodyPlant;
 using drake::multibody::MultibodyPlantConfig;
 using drake::multibody::Parser;
 using drake::multibody::PrismaticJoint;
+using drake::multibody::SpatialInertia;
 using drake::multibody::fem::DeformableBodyConfig;
-using drake::multibody::DeformableBodyId;
-using drake::multibody::DeformableModel;
 using drake::systems::BasicVector;
 using drake::systems::Context;
 using Eigen::Vector2d;
+using Eigen::Vector3d;
 using Eigen::Vector4d;
 using Eigen::VectorXd;
 
@@ -53,91 +72,84 @@ namespace drake {
 namespace examples {
 namespace {
 
-/* We create a leaf system that uses PD control to output a force signal to
- a gripper to follow a close-lift-open motion sequence. The signal is
- 2-dimensional with the first element corresponding to the wrist degree of
- freedom and the second element corresponding to the left finger degree of
- freedom. This control is a time-based state machine, where forces change based
- on the context time. This is strictly for demo purposes and is not intended to
- generalize to other cases. There are four states: 0. The fingers are open in
- the initial state.
-  1. The fingers are closed to secure a grasp.
-  2. The gripper is lifted to a prescribed final height.
-  3. The fingers are open to loosen a grasp.
- The desired state is interpolated between these states. */
-class GripperPositionControl : public systems::LeafSystem<double> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GripperPositionControl);
+/* Adds a suction gripper to the given MultibodyPlant and assign
+ `proximity_props` to all the registered collision geometries. Returns the
+ ModelInstanceIndex of the gripper model. */
+ModelInstanceIndex AddSuctionGripper(
+    MultibodyPlant<double>* plant, const ProximityProperties& proximity_props) {
+  const double radius = 0.02;
+  const double length = 0.1;
+  const auto M = SpatialInertia<double>::SolidCapsuleWithMass(
+      0.1, radius, length, Vector3d::UnitZ());
+  ModelInstanceIndex model_instance = plant->AddModelInstance("instance");
+  const auto& body = plant->AddRigidBody("cup_body", model_instance, M);
+  const Capsule capsule{radius, length};
+  IllustrationProperties cup_illustration_props;
+  cup_illustration_props.AddProperty("phong", "diffuse",
+                                     Vector4d(0.9, 0.1, 0.1, 0.8));
+  plant->RegisterVisualGeometry(body, RigidTransformd::Identity(), capsule,
+                                "cup_visual", cup_illustration_props);
+  /* Add a visual hint for the center of the suction force source. */
+  const Sphere sphere{0.0075};
+  IllustrationProperties source_illustration_props;
+  source_illustration_props.AddProperty("phong", "diffuse",
+                                        Vector4d(0.1, 0.9, 0.1, 0.8));
+  plant->RegisterVisualGeometry(body, RigidTransformd(Vector3d(0, 0, -0.07)),
+                                sphere, "source_visual",
+                                source_illustration_props);
+  plant->RegisterCollisionGeometry(body, RigidTransformd::Identity(), capsule,
+                                   "cup_collision", proximity_props);
+  /* Adds an actuated joint between the suction cup body and the world. */
+  const RigidTransformd X_WF(Vector3d(0.04, 0, -0.05));
+  const auto& prismatic_joint = plant->AddJoint<PrismaticJoint>(
+      "translate_z_joint", plant->world_body(), X_WF, body, std::nullopt,
+      Vector3d::UnitZ());
+  plant->GetMutableJointByName<PrismaticJoint>("translate_z_joint")
+      .set_default_translation(0.5);
+  const auto actuator_index =
+      plant->AddJointActuator("prismatic joint actuator", prismatic_joint)
+          .index();
+  plant->get_mutable_joint_actuator(actuator_index)
+      .set_controller_gains({1e4, 1});
 
-  /* Constructs a GripperPositionControl system with the given parameters.
-   @param[in] open_width   The width between fingers in the open state. (meters)
-   @param[in] closed_width The width between fingers in the closed state.
-                           (meters)
-   @param[in] height       The height of the gripper in the lifted state.
-                           (meters) */
-  GripperPositionControl(double open_width, double closed_width, double height)
-      : initial_state_(0, -open_width / 2),
-        closed_state_(0, -closed_width / 2),
-        lifted_state_(height, -closed_width / 2),
-        open_state_(height, -open_width / 2) {
-    this->DeclareVectorOutputPort("gripper force", BasicVector<double>(2),
-                                  &GripperPositionControl::SetAppliedForce);
-    this->DeclareVectorInputPort("gripper state", BasicVector<double>(6));
-  }
+  return model_instance;
+}
 
- private:
-  void SetAppliedForce(const Context<double>& context,
-                       BasicVector<double>* output) const {
-    const VectorXd gripper_state =
-        EvalVectorInput(context, GetInputPort("gripper state").get_index())
-            ->get_value();
-    /* There are 6 dofs in the state, corresponding to
-     q_translate_joint, q_left_finger, q_right_finger,
-     v_translate_joint, v_left_finger, v_right_finger. */
-    /* The positions of the translate joint and the left finger. */
-    const Vector2d measured_positions = gripper_state.head(2);
-    /* The velocities of the translate joint and the left finger. */
-    const Vector2d measured_velocities = gripper_state.segment<2>(3);
-    const Vector2d desired_velocities(0, 0);
-    Vector2d desired_positions;
-    const double t = context.get_time();
-    if (t < fingers_closed_time_) {
-      const double end_time = fingers_closed_time_;
-      const double theta = t / end_time;
-      desired_positions =
-          theta * closed_state_ + (1.0 - theta) * initial_state_;
-    } else if (t < gripper_lifted_time_) {
-      const double end_time = gripper_lifted_time_ - fingers_closed_time_;
-      const double theta = (t - fingers_closed_time_) / end_time;
-      desired_positions = theta * lifted_state_ + (1.0 - theta) * closed_state_;
-    } else if (t < hold_time_) {
-      desired_positions = lifted_state_;
-    } else if (t < fingers_open_time_) {
-      const double end_time = fingers_open_time_ - hold_time_;
-      const double theta = (t - hold_time_) / end_time;
-      desired_positions = theta * open_state_ + (1.0 - theta) * lifted_state_;
-    } else {
-      desired_positions = open_state_;
-    }
-    const Vector2d force = kp_ * (desired_positions - measured_positions) +
-                           kd_ * (desired_velocities - measured_velocities);
-    output->get_mutable_value() << force;
-  }
+/* Adds a parallel gripper to the given MultibodyPlant and assign
+ `proximity_props` to all the registered collision geometries. Returns the
+ ModelInstanceIndex of the gripper model. */
+ModelInstanceIndex AddParallelGripper(
+    MultibodyPlant<double>* plant, const ProximityProperties& proximity_props) {
+  // TODO(xuchenhan-tri): Consider using a schunk gripper from the manipulation
+  // station instead.
+  Parser parser(plant);
+  ModelInstanceIndex model_instance = parser.AddModelsFromUrl(
+      "package://drake/examples/multibody/deformable_torus/simple_gripper.sdf")
+                                          [0];
+  /* Add collision geometries. */
+  const RigidTransformd X_BG =
+      RigidTransformd(math::RollPitchYawd(M_PI_2, 0, 0), Vector3d::Zero());
+  const Body<double>& left_finger = plant->GetBodyByName("left_finger");
+  const Body<double>& right_finger = plant->GetBodyByName("right_finger");
+  /* The size of the fingers is set to match the visual geometries in
+   simple_gripper.sdf. */
+  Capsule capsule(0.01, 0.08);
+  plant->RegisterCollisionGeometry(left_finger, X_BG, capsule,
+                                   "left_finger_collision", proximity_props);
+  plant->RegisterCollisionGeometry(right_finger, X_BG, capsule,
+                                   "right_finger_collision", proximity_props);
+  /* Get joints so that we can set initial conditions. */
+  PrismaticJoint<double>& left_slider =
+      plant->GetMutableJointByName<PrismaticJoint>("left_slider");
+  PrismaticJoint<double>& right_slider =
+      plant->GetMutableJointByName<PrismaticJoint>("right_slider");
+  /* Initialize the gripper in an "open" position. */
+  const double kInitialWidth = 0.085;
+  left_slider.set_default_translation(-kInitialWidth / 2.0);
+  right_slider.set_default_translation(kInitialWidth / 2.0);
 
-  /* The time at which the fingers reach the desired closed state. */
-  const double fingers_closed_time_{1.5};
-  /* The time at which the gripper reaches the desired "lifted" state. */
-  const double gripper_lifted_time_{3.0};
-  const double hold_time_{5.5};
-  /* The time at which the fingers reach the desired open state. */
-  const double fingers_open_time_{7.0};
-  Vector2d initial_state_;
-  Vector2d closed_state_;
-  Vector2d lifted_state_;
-  Vector2d open_state_;
-  const double kp_{2000};
-  const double kd_{60.0};
-};
+  return model_instance;
+}
 
 int do_main() {
   systems::DiagramBuilder<double> builder;
@@ -153,13 +165,14 @@ int do_main() {
    deformable bodies.
    1. A valid Coulomb friction coefficient, and
    2. A resolution hint. (Rigid bodies need to be tessellated so that collision
-   queries can be performed against deformable geometries.) */
+   queries can be performed against deformable geometries.) The value dictates
+   how fine the mesh used to represent the rigid collision geometry is. */
   ProximityProperties rigid_proximity_props;
   /* Set the friction coefficient close to that of rubber against rubber. */
   const CoulombFriction<double> surface_friction(1.15, 1.15);
   AddContactMaterial({}, {}, surface_friction, &rigid_proximity_props);
   rigid_proximity_props.AddProperty(geometry::internal::kHydroGroup,
-                                    geometry::internal::kRezHint, 1.0);
+                                    geometry::internal::kRezHint, 0.01);
   /* Set up a ground. */
   Box ground{4, 4, 4};
   const RigidTransformd X_WG(Eigen::Vector3d{0, 0, -2});
@@ -171,24 +184,12 @@ int do_main() {
   plant.RegisterVisualGeometry(plant.world_body(), X_WG, ground,
                                "ground_visual", std::move(illustration_props));
 
-  // TODO(xuchenhan-tri): Consider using a schunk gripper from the manipulation
-  // station instead.
-  /* Set up a simple gripper. */
-  Parser parser(&plant);
-  parser.AddModelsFromUrl(
-      "package://drake/examples/multibody/deformable_torus/simple_gripper.sdf");
-  /* Add collision geometries. */
-  const RigidTransformd X_BG = RigidTransformd::Identity();
-  const Body<double>& left_finger = plant.GetBodyByName("left_finger");
-  const Body<double>& right_finger = plant.GetBodyByName("right_finger");
-  /* The size of the fingers is set to match the visual geometries in
-   simple_gripper.sdf. */
-  plant.RegisterCollisionGeometry(left_finger, X_BG, Box(0.007, 0.081, 0.028),
-                                  "left_finger_collision",
-                                  rigid_proximity_props);
-  plant.RegisterCollisionGeometry(right_finger, X_BG, Box(0.007, 0.081, 0.028),
-                                  "left_finger_collision",
-                                  rigid_proximity_props);
+  /* Add a parallel gripper or a suction gripper depending on the runtime flag.
+   */
+  const bool use_suction = FLAGS_gripper == "suction";
+  ModelInstanceIndex gripper_instance =
+      use_suction ? AddSuctionGripper(&plant, rigid_proximity_props)
+                  : AddParallelGripper(&plant, rigid_proximity_props);
 
   /* Set up a deformable torus. */
   auto owned_deformable_model =
@@ -229,20 +230,19 @@ int do_main() {
   const double unused_resolution_hint = 1.0;
   owned_deformable_model->RegisterDeformableBody(
       std::move(torus_instance), deformable_config, unused_resolution_hint);
+
+  /* Add an external suction force if using a suction gripper. */
+  const PointSourceForceField* suction_force_ptr{nullptr};
+  if (use_suction) {
+    auto suction_force = std::make_unique<PointSourceForceField>(
+        plant, plant.GetBodyByName("cup_body"), Vector3d(0, 0, -0.07), 0.1);
+    suction_force_ptr = suction_force.get();
+    owned_deformable_model->AddExternalForce(std::move(suction_force));
+  }
+
   const DeformableModel<double>* deformable_model =
       owned_deformable_model.get();
   plant.AddPhysicalModel(std::move(owned_deformable_model));
-
-  /* Get joints so that we can set constraints and initial conditions. */
-  PrismaticJoint<double>& left_slider =
-      plant.GetMutableJointByName<PrismaticJoint>("left_slider");
-  PrismaticJoint<double>& right_slider =
-      plant.GetMutableJointByName<PrismaticJoint>("right_slider");
-  /* Constrain the left and the right fingers such that qₗ = -qᵣ. */
-  plant.AddCouplerConstraint(left_slider, right_slider, -1.0);
-  /* Viscous damping for the finger joints, in N⋅s/m. */
-  left_slider.set_default_damping(50.0);
-  right_slider.set_default_damping(50.0);
 
   /* All rigid and deformable models have been added. Finalize the plant. */
   plant.Finalize();
@@ -255,28 +255,41 @@ int do_main() {
       scene_graph.get_source_configuration_port(plant.get_source_id().value()));
 
   /* Add a visualizer that emits LCM messages for visualization. */
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
+  geometry::DrakeVisualizerParams params;
+  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, nullptr,
+                                           params);
 
-  /* Set the width between the fingers for open and closed states as well as the
-   height to which the gripper lifts the deformable torus. */
-  const double open_width = kL * 1.5;
-  const double closed_width = kL * 0.4;
-  const double lifted_height = 0.18;
-
-  const auto& control = *builder.AddSystem<GripperPositionControl>(
-      open_width, closed_width, lifted_height);
-  builder.Connect(plant.get_state_output_port(), control.get_input_port());
-  builder.Connect(control.get_output_port(), plant.get_actuation_input_port());
+  /* Add a controller appropriate for the type of gripper. */
+  if (use_suction) {
+    const double kInitialHeight = 0.5;
+    const double kStartSuctionHeight =
+        0.15;  // The height at which to turn on suction.
+    const double kApproachTime = 3.0;      // Time to start the action
+    const double kStartSuctionTime = 4.0;  // Time to turn on suction
+    const double kRetrieveTime = 6.0;      // Time to retrieve the gripper
+    const double kDropTime = 9.0;          // Time to turn off suction
+    const auto& suction = *builder.AddSystem<SuctionCupController>(
+        kInitialHeight, kStartSuctionHeight, kApproachTime, kStartSuctionTime,
+        kRetrieveTime, kDropTime);
+    builder.Connect(suction.maximum_force_density_port(),
+                    suction_force_ptr->maximum_force_density_input_port());
+    builder.Connect(suction.desired_state_output_port(),
+                    plant.get_desired_state_input_port(gripper_instance));
+  } else {
+    /* Set the width between the fingers for open and closed states as well as
+     the height to which the gripper lifts the deformable torus. */
+    const double kOpenWidth = kL * 1.5;
+    const double kClosedWidth = kL * 0.4;
+    const double kLiftedHeight = 0.18;
+    const auto& control = *builder.AddSystem<ParallelGripperController>(
+        kOpenWidth, kClosedWidth, kLiftedHeight);
+    builder.Connect(control.get_output_port(),
+                    plant.get_desired_state_input_port(gripper_instance));
+  }
 
   auto diagram = builder.Build();
   std::unique_ptr<Context<double>> diagram_context =
       diagram->CreateDefaultContext();
-
-  /* Set initial conditions for the gripper. */
-  auto& plant_context =
-      diagram->GetMutableSubsystemContext(plant, diagram_context.get());
-  left_slider.set_translation(&plant_context, -open_width / 2.0);
-  right_slider.set_translation(&plant_context, open_width / 2.0);
 
   /* Build the simulator and run! */
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
@@ -294,8 +307,8 @@ int do_main() {
 int main(int argc, char* argv[]) {
   gflags::SetUsageMessage(
       "This is a demo used to showcase deformable body simulations in Drake. "
-      "A simple parallel gripper grasps a deformable torus on the ground, "
-      "lifts it up, and then drops it back on the ground. "
+      "A parallel (or suction) gripper grasps a deformable torus on the "
+      "ground, lifts it up, and then drops it back on the ground. "
       "Launch meldis before running this example. "
       "Refer to README for instructions on meldis as well as optional flags.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);

--- a/examples/multibody/deformable_torus/parallel_gripper_controller.cc
+++ b/examples/multibody/deformable_torus/parallel_gripper_controller.cc
@@ -1,0 +1,53 @@
+#include "drake/examples/multibody/deformable_torus/parallel_gripper_controller.h"
+
+namespace drake {
+namespace examples {
+namespace deformable_torus {
+
+using drake::systems::BasicVector;
+using drake::systems::Context;
+using Eigen::Vector2d;
+using Eigen::VectorXd;
+
+ParallelGripperController::ParallelGripperController(double open_width,
+                                                     double closed_width,
+                                                     double height)
+    : initial_configuration_(0, -open_width / 2),
+      closed_configuration_(0, -closed_width / 2),
+      lifted_configuration_(height, -closed_width / 2),
+      open_configuration_(height, -open_width / 2) {
+  this->DeclareVectorOutputPort("desired state", BasicVector<double>(4),
+                                &ParallelGripperController::CalcDesiredState);
+}
+
+void ParallelGripperController::CalcDesiredState(
+    const Context<double>& context, BasicVector<double>* output) const {
+  const Vector2d desired_velocities = Vector2d::Zero();
+  Vector2d desired_positions;
+  const double t = context.get_time();
+  if (t < fingers_closed_time_) {
+    const double end_time = fingers_closed_time_;
+    const double theta = t / end_time;
+    desired_positions =
+        theta * closed_configuration_ + (1.0 - theta) * initial_configuration_;
+  } else if (t < gripper_lifted_time_) {
+    const double end_time = gripper_lifted_time_ - fingers_closed_time_;
+    const double theta = (t - fingers_closed_time_) / end_time;
+    desired_positions =
+        theta * lifted_configuration_ + (1.0 - theta) * closed_configuration_;
+  } else if (t < hold_time_) {
+    desired_positions = lifted_configuration_;
+  } else if (t < fingers_open_time_) {
+    const double end_time = fingers_open_time_ - hold_time_;
+    const double theta = (t - hold_time_) / end_time;
+    desired_positions =
+        theta * open_configuration_ + (1.0 - theta) * lifted_configuration_;
+  } else {
+    desired_positions = open_configuration_;
+  }
+  output->get_mutable_value() << desired_positions, desired_velocities;
+}
+
+}  // namespace deformable_torus
+}  // namespace examples
+}  // namespace drake

--- a/examples/multibody/deformable_torus/parallel_gripper_controller.h
+++ b/examples/multibody/deformable_torus/parallel_gripper_controller.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace deformable_torus {
+
+/* We create a leaf system that outputs the desired state of a parallel jaw
+ gripper to follow a close-lift-open motion sequence. The desired position is
+ 2-dimensional with the first element corresponding to the wrist degree of
+ freedom and the second element corresponding to the left finger degree of
+ freedom. This control is a time-based state machine, where desired state
+ changes based on the context time. There are four states, executed in the
+ following order:
+
+  0. The fingers are open in the initial state.
+  1. The fingers are closed to secure a grasp.
+  2. The gripper is lifted to a prescribed final height.
+  3. The fingers are open to loosen the grasp.
+
+ The desired state is interpolated between these states. */
+class ParallelGripperController : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ParallelGripperController);
+
+  /* Constructs a ParallelGripperController system with the given parameters.
+   @param[in] open_width   The width between fingers in the open state. (meters)
+   @param[in] closed_width The width between fingers in the closed state.
+                           (meters)
+   @param[in] height       The height of the gripper in the lifted state.
+                           (meters) */
+  ParallelGripperController(double open_width, double closed_width,
+                            double height);
+
+ private:
+  /* Computes the output desired state of the parallel gripper. */
+  void CalcDesiredState(const systems::Context<double>& context,
+                        systems::BasicVector<double>* output) const;
+
+  /* The time at which the fingers reach the desired closed state. */
+  const double fingers_closed_time_{1.5};
+  /* The time at which the gripper reaches the desired "lifted" state. */
+  const double gripper_lifted_time_{3.0};
+  const double hold_time_{5.5};
+  /* The time at which the fingers reach the desired open state. */
+  const double fingers_open_time_{7.0};
+  Eigen::Vector2d initial_configuration_;
+  Eigen::Vector2d closed_configuration_;
+  Eigen::Vector2d lifted_configuration_;
+  Eigen::Vector2d open_configuration_;
+};
+
+}  // namespace deformable_torus
+}  // namespace examples
+}  // namespace drake

--- a/examples/multibody/deformable_torus/point_source_force_field.cc
+++ b/examples/multibody/deformable_torus/point_source_force_field.cc
@@ -1,0 +1,70 @@
+#include "drake/examples/multibody/deformable_torus/point_source_force_field.h"
+
+namespace drake {
+namespace examples {
+namespace deformable_torus {
+
+using multibody::Body;
+using multibody::ForceDensityField;
+using multibody::MultibodyPlant;
+using systems::BasicVector;
+using systems::Context;
+
+PointSourceForceField::PointSourceForceField(
+    const MultibodyPlant<double>& plant, const Body<double>& body,
+    const Vector3<double>& p_BC, double falloff_distance)
+    : plant_(&plant),
+      body_(body.index()),
+      p_BC_(p_BC),
+      falloff_distance_(falloff_distance) {
+  DRAKE_THROW_UNLESS(falloff_distance_ > 0);
+}
+
+Vector3<double> PointSourceForceField::DoEvaluateAt(
+    const Context<double>& context, const Vector3<double>& p_WQ) const {
+  const Vector3<double>& p_WC = EvalPointSourceLocation(context);
+  Vector3<double> p_QC_W = p_WC - p_WQ;
+  const double dist = p_QC_W.norm();
+  if (dist == 0 || dist > falloff_distance_) {
+    return Vector3<double>::Zero();
+  }
+  const double max_value =
+      maximum_force_density_input_port().HasValue(context)
+          ? maximum_force_density_input_port()
+                .Eval<systems::BasicVector<double>>(context)[0]
+          : 0.0;
+  const double magnitude =
+      (falloff_distance_ - dist) * max_value / falloff_distance_;
+  return magnitude * p_QC_W / p_QC_W.norm();
+}
+
+std::unique_ptr<ForceDensityField<double>> PointSourceForceField::DoClone()
+    const {
+  return std::make_unique<PointSourceForceField>(
+      *plant_, plant_->get_body(body_), p_BC_, falloff_distance_);
+}
+
+void PointSourceForceField::DoDeclareCacheEntries(
+    MultibodyPlant<double>* plant) {
+  /* We store the location of the point source C in the world frame as a cache
+   entry so we don't need to repeatedly compute it. */
+  point_source_position_cache_index_ =
+      this->DeclareCacheEntry(
+              plant, "point source of the force field",
+              systems::ValueProducer(
+                  this, &PointSourceForceField::CalcPointSourceLocation),
+              {systems::System<double>::xd_ticket()})
+          .cache_index();
+}
+
+void PointSourceForceField::DoDeclareInputPorts(MultibodyPlant<double>* plant) {
+  maximum_force_density_port_index_ =
+      this->DeclareVectorInputPort(plant,
+                                   "maximum force density magnitude in N/m³",
+                                   BasicVector<double>(1))
+          .get_index();
+}
+
+}  // namespace deformable_torus
+}  // namespace examples
+}  // namespace drake

--- a/examples/multibody/deformable_torus/point_source_force_field.h
+++ b/examples/multibody/deformable_torus/point_source_force_field.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/multibody/plant/force_density_field.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace examples {
+namespace deformable_torus {
+
+/* A custom external force density field that applies external force to
+ deformable bodies. The force density points towards a point C affixed to a
+ rigid body. The magnitude of the force density decays linearly with the
+ distance to the point C and floors at 0. The maximum force density is read from
+ a double-valued input port (see maximum_force_density_input_port()). If the
+ port is unconnected, it reads as zero. */
+class PointSourceForceField final
+    : public multibody::ForceDensityField<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PointSourceForceField)
+
+  /* Constructs a new PointSourceForceField object
+   @param plant             The MultibodyPlant that owns this force field.
+   @param body              The body to which the source of the force field C is
+                            affixed to.
+   @param p_BC              The fixed offset from the body origin to the point
+                            source of the force field.
+   @param falloff_distance  The force density decays linearly.
+                            `falloff_distance` in meters is the distance from
+                            the point source beyond which the force density is
+                            zero. Must be positive and finite. */
+  PointSourceForceField(const multibody::MultibodyPlant<double>& plant,
+                        const multibody::Body<double>& body,
+                        const Vector3<double>& p_BC, double falloff_distance);
+
+  /* Input port for desired maximum force density with units of N/m³.
+   The port belongs to the MultibodyPlant that owns this density field. */
+  const systems::InputPort<double>& maximum_force_density_input_port() const {
+    return parent_system_or_throw().get_input_port(
+        maximum_force_density_port_index_);
+  }
+
+ private:
+  /* Computes the world frame position of the center of the point source force
+   field. */
+  Vector3<double> CalcPointSourceLocation(
+      const systems::Context<double>& context) const {
+    return plant_->EvalBodyPoseInWorld(context, plant_->get_body(body_)) *
+           p_BC_;
+  }
+
+  /* Eval version of `CalcPointSourceLocation()`. */
+  const Vector3<double>& EvalPointSourceLocation(
+      const systems::Context<double>& context) const {
+    return parent_system_or_throw()
+        .get_cache_entry(point_source_position_cache_index_)
+        .template Eval<Vector3<double>>(context);
+  }
+
+  Vector3<double> DoEvaluateAt(const systems::Context<double>& context,
+                               const Vector3<double>& p_WQ) const final;
+
+  std::unique_ptr<ForceDensityField<double>> DoClone() const final;
+
+  void DoDeclareCacheEntries(multibody::MultibodyPlant<double>* plant) final;
+
+  void DoDeclareInputPorts(multibody::MultibodyPlant<double>* plant) final;
+
+  const multibody::MultibodyPlant<double>* plant_{};
+  const multibody::BodyIndex body_;
+  Vector3<double> p_BC_;
+  double falloff_distance_{};
+  systems::CacheIndex point_source_position_cache_index_;
+  systems::InputPortIndex maximum_force_density_port_index_;
+};
+
+}  // namespace deformable_torus
+}  // namespace examples
+}  // namespace drake

--- a/examples/multibody/deformable_torus/simple_gripper.sdf
+++ b/examples/multibody/deformable_torus/simple_gripper.sdf
@@ -4,51 +4,23 @@
        deformable_torus.cc and therefore these files must be kept in sync.
 
        This file defines the model for a simple gripper having two fingers on
-       prismatic joints. Only the left finger is actuated. The modeler will want
-       to add a coupler constraint between the fingers (if the selected solver
-       supports it) or simply lock the right finger in place.
+       prismatic joints. Only the left finger is actuated and the right finger
+       coupler constrained to the left finger.
 
        The frame of the gripper, G, has its x-axis pointing to the right
        of the gripper, its y-axis pointing "forward" (towards the fingers
        side) and, the z-axis pointing upwards. This file only defines visual
        geometry but not contact geometry.
-
-       TODO(xuchenhan-tri): The simple_gripper.sdf should not hard-code a weld
-       joint to the world. We should be loading the gripper file using a
-       dmd.yaml file (or more likely, inline string) that postures the weld as
-       part of the example program itself.
   -->
   <model name="simple_gripper">
-    <!-- Pose X_WG of the gripper model frame G in the world frame W. -->
-    <pose>0.0 0.06 0.08 -1.57 0 1.57</pose>
-    <joint name="weld_base" type="fixed">
-      <parent>world</parent>
-      <child>y_translate_link</child>
-    </joint>
-    <link name="y_translate_link">
-      <inertial>
-        <mass>0.0001</mass>
-        <inertia>
-          <ixx>0.0001</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.0001</iyy>
-          <iyz>0</iyz>
-          <izz>0.0001</izz>
-        </inertia>
-      </inertial>
-    </link>
+    <pose>0 0.06 0.08 -1.57 0 1.57</pose>
     <joint name="translate_joint" type="prismatic">
-      <parent>y_translate_link</parent>
+      <parent>world</parent>
       <child>body</child>
       <axis>
         <xyz expressed_in="__model__">0 -1 0</xyz>
-        <!-- Drake attaches an actuator to all joints with a non-zero effort
-             limit. We do want an actuator for this joint. -->
-        <limit>
-          <effort>500</effort>
-        </limit>
       </axis>
+      <drake:controller_gains p='10000.0' d='1.0' />
     </joint>
     <link name="body">
       <pose>0 -0.049133 0 0 0 0</pose>
@@ -91,10 +63,12 @@
         </inertia>
       </inertial>
       <visual name="visual">
+        <pose>0 0.0 0.0 1.57 0 0</pose>
         <geometry>
-          <box>
-            <size>0.007 0.081 0.028</size>
-          </box>
+          <capsule>
+            <radius>0.01</radius>
+            <length>0.08</length>
+          </capsule>
         </geometry>
         <material>
           <diffuse>0.3 0.3 0.3 0.9</diffuse>
@@ -118,10 +92,12 @@
         </inertia>
       </inertial>
       <visual name="visual">
+        <pose>0 0.0 0.0 1.57 0 0</pose>
         <geometry>
-          <box>
-            <size>0.007 0.081 0.028</size>
-          </box>
+          <capsule>
+            <radius>0.01</radius>
+            <length>0.08</length>
+          </capsule>
         </geometry>
         <material>
           <diffuse>0.3 0.3 0.3 0.9</diffuse>
@@ -133,20 +109,18 @@
       <child>left_finger</child>
       <axis>
         <xyz>1 0 0</xyz>
-        <!-- Drake attaches an actuator to all joints with a non-zero effort
-             limit. We do want an actuator for this joint. -->
-        <limit>
-          <effort>500</effort>
-        </limit>
       </axis>
+      <drake:controller_gains p='10000.0' d='1.0' />
     </joint>
     <joint name="right_slider" type="prismatic">
       <parent>body</parent>
       <child>right_finger</child>
+      <drake:mimic joint='left_slider' multiplier='-1' offset='0.0'/>
       <axis>
         <xyz>1 0 0</xyz>
-        <!-- Drake attaches an actuator to all joints with a non-zero effort
-             limit. We do NOT want an actuator for this joint. -->
+        <!-- Drake attaches an actuator to all joints if the effort limit isn't
+        explicitly set to zero. We do NOT want an actuator for this joint due
+        to the existence of the mimic tag. -->
         <limit>
           <effort>0</effort>
         </limit>

--- a/examples/multibody/deformable_torus/suction_cup_controller.cc
+++ b/examples/multibody/deformable_torus/suction_cup_controller.cc
@@ -1,0 +1,73 @@
+#include "drake/examples/multibody/deformable_torus/suction_cup_controller.h"
+
+namespace drake {
+namespace examples {
+namespace deformable_torus {
+
+using Eigen::Vector2d;
+using systems::BasicVector;
+using systems::Context;
+
+SuctionCupController::SuctionCupController(double initial_height,
+                                           double object_height,
+                                           double approach_time,
+                                           double start_suction_time,
+                                           double retrieve_time,
+                                           double release_suction_time)
+    : initial_height_(initial_height),
+      object_height_(object_height),
+      approach_time_(approach_time),
+      start_suction_time_(start_suction_time),
+      retrieve_time_(retrieve_time),
+      release_suction_time_(release_suction_time) {
+  desired_state_port_index_ =
+      DeclareVectorOutputPort("desired state", BasicVector<double>(2),
+                              &SuctionCupController::CalcDesiredState)
+          .get_index();
+  maximum_force_density_port_index_ =
+      DeclareVectorOutputPort("maximum suction force density [N/m³]",
+                              BasicVector<double>(1),
+                              &SuctionCupController::CalcMaxForceDensity)
+          .get_index();
+}
+
+void SuctionCupController::CalcDesiredState(
+    const Context<double>& context, BasicVector<double>* desired_state) const {
+  const double t = context.get_time();
+  /* Time to move from the initial height to the object height. */
+  const double travel_time = start_suction_time_ - approach_time_;
+  Vector2d state_value;
+  if (t < approach_time_) {
+    state_value << initial_height_, 0;
+  } else if (t < start_suction_time_) {
+    const double v = (object_height_ - initial_height_) / travel_time;
+    const double dt = t - approach_time_;
+    state_value << initial_height_ + dt * v, v;
+  } else if (t < retrieve_time_) {
+    state_value << object_height_, 0;
+  } else if (t < retrieve_time_ + travel_time) {
+    const double v = (initial_height_ - object_height_) / travel_time;
+    const double dt = t - retrieve_time_;
+    state_value << object_height_ + dt * v, v;
+  } else {
+    state_value << initial_height_, 0;
+  }
+  desired_state->set_value(state_value);
+}
+
+void SuctionCupController::CalcMaxForceDensity(
+    const Context<double>& context,
+    BasicVector<double>* max_force_density) const {
+  const double time = context.get_time();
+  if (time >= start_suction_time_ && time <= release_suction_time_) {
+    // An arbitrary value that's reasonable for picking up the deformable torus
+    // in the example with density comparable to water.
+    (*max_force_density)[0] = 2.0e5;
+  } else {
+    (*max_force_density)[0] = 0.0;
+  }
+}
+
+}  // namespace deformable_torus
+}  // namespace examples
+}  // namespace drake

--- a/examples/multibody/deformable_torus/suction_cup_controller.h
+++ b/examples/multibody/deformable_torus/suction_cup_controller.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace examples {
+namespace deformable_torus {
+
+/* We create a leaf system that outputs the desire state of a suction cup
+ gripper mounted on a prismatic joint to the world. This control is a time-based
+ state machine, where the desired state changes based on the context time. The
+ desired state is described through two output ports, one containing the desired
+ position and velocity of the prismatic joint to the world, the other containing
+ the maximum suction force density. The suction cup is first lowered to approach
+ the object, then the suction force is turned on to pick up the object. Then the
+ suction cup is raised to the initial height and the suction force is turned off
+ to release the object. This is strictly for demo purposes and is not intended
+ as a generalized model for suction grippers. */
+class SuctionCupController : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SuctionCupController);
+
+  /* Constructs a SuctionCupController system with the given parameters. The
+   trajectory is characterized by 4 key time stamps and 2 key positions. The 4
+   key time stamps are `approach_time`, `start_suction_time`,
+   `retrieve_time`, and `release_suction_time`. They must be in increasing
+   order. The 2 key positions are `initial_height` and `object_height`.
+   @param[in] initial_height        Initial height of the gripper.
+   @param[in] object_height         The estimated height of the object. We turn
+                                    suction on when the gripper first reach this
+                                    height.
+   @param[in] approach_time         The time at which the gripper starts to
+                                    approach the manipuland.
+   @param[in] start_suction_time    The time at which suction force turns on.
+   @param[in] retrieve_time         The time at which to start lifting the
+                                    gripper.
+   @param[in] release_suction_time  The time at which suction turns off. */
+  SuctionCupController(double initial_height, double object_height,
+                       double approach_time, double start_suction_time,
+                       double retrieve_time, double release_suction_time);
+
+  const systems::OutputPort<double>& desired_state_output_port() const {
+    return get_output_port(desired_state_port_index_);
+  }
+
+  const systems::OutputPort<double>& maximum_force_density_port() const {
+    return get_output_port(maximum_force_density_port_index_);
+  }
+
+ private:
+  /* Computes the output desired state of the suction cup. */
+  void CalcDesiredState(const systems::Context<double>& context,
+                        systems::BasicVector<double>* desired_state) const;
+
+  /* Computes the maximum suction force in Newtons based on time. */
+  void CalcMaxForceDensity(
+      const systems::Context<double>& context,
+      systems::BasicVector<double>* max_force_density) const;
+
+  double initial_height_{};
+  double object_height_{};
+  double approach_time_{};
+  double start_suction_time_{};
+  double retrieve_time_{};
+  double release_suction_time_{};
+
+  int desired_state_port_index_{};
+  int maximum_force_density_port_index_{};
+};
+
+}  // namespace deformable_torus
+}  // namespace examples
+}  // namespace drake

--- a/examples/multibody/deformable_torus/test/point_source_force_field_test.cc
+++ b/examples/multibody/deformable_torus/test/point_source_force_field_test.cc
@@ -1,0 +1,61 @@
+#include "drake/examples/multibody/deformable_torus/point_source_force_field.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace examples {
+namespace deformable_torus {
+namespace {
+
+using drake::math::RigidTransformd;
+using drake::math::RollPitchYawd;
+using drake::multibody::Body;
+using drake::multibody::MultibodyPlant;
+using drake::multibody::SpatialInertia;
+using drake::systems::Context;
+using Eigen::Vector3d;
+
+GTEST_TEST(PointSourceForceFieldTest, EvaluateAt) {
+  MultibodyPlant<double> plant(0.01);
+  const Body<double>& box = plant.AddRigidBody(
+      "box", SpatialInertia<double>::SolidCubeWithMass(1.0, 0.1));
+  /* The fixed offset from the body origin B to the point source of
+   the force field C. */
+  const Vector3d p_BC(0, 0, 0.123);
+  const double max_distance = 0.2;
+  PointSourceForceField force_field(plant, box, p_BC, max_distance);
+  force_field.DeclareSystemResources(&plant);
+  plant.Finalize();
+
+  auto context = plant.CreateDefaultContext();
+  const RigidTransformd X_WB(RollPitchYawd(1, 2, 3), Vector3d(3, 4, 5));
+  plant.SetFreeBodyPose(context.get(), box, X_WB);
+  const double max_force_density = 42.0;
+  /* Turn the force on. */
+  force_field.maximum_force_density_input_port().FixValue(context.get(),
+                                                          max_force_density);
+  const Vector3d p_WC = X_WB * p_BC;
+  /* Inside the non-zero range. */
+  const Vector3d p_CQ1_W = Vector3d(0, 0, 0.1);
+  const Vector3d p_WQ1 = p_WC + p_CQ1_W;
+  Vector3d expected_force =
+      -0.1 / max_distance * max_force_density * p_CQ1_W.normalized();
+  EXPECT_TRUE(CompareMatrices(force_field.EvaluateAt(*context, p_WQ1),
+                              expected_force, 1e-13));
+  /* Outside the non-zero range. */
+  const Vector3d p_CQ2_W = Vector3d(0, 0, 0.3);
+  const Vector3d p_WQ2 = p_WC + p_CQ2_W;
+  EXPECT_TRUE(CompareMatrices(force_field.EvaluateAt(*context, p_WQ2),
+                              Vector3d::Zero()));
+  /* Turn the force off. */
+  force_field.maximum_force_density_input_port().FixValue(context.get(), 0.0);
+  EXPECT_TRUE(CompareMatrices(force_field.EvaluateAt(*context, p_WQ1),
+                              Vector3d::Zero()));
+}
+
+}  // namespace
+}  // namespace deformable_torus
+}  // namespace examples
+}  // namespace drake


### PR DESCRIPTION
- Add PointSourceForceField as an example of a concrete ForceDensityField.
- Add a `gripper` flag so that one can toggle between a parallel gripper and a suction gripper to pick up the deformable torus.
- Refactor the controller into separate files to reduce the lines of code in the example .cc file.
- Change the parallel fingers to capsule shape to avoid sticking resulting from the sharp change in contact normal from boxes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20629)
<!-- Reviewable:end -->
