### PR TITLE
[solvers] Add an environment variable to disable SnoptSolver

### DIFF
--- a/bindings/pydrake/multibody/test/optimization_test.py
+++ b/bindings/pydrake/multibody/test/optimization_test.py
@@ -120,7 +120,8 @@ def split_se3(q_se3):
 
 class TestStaticEquilibriumProblem(unittest.TestCase):
 
-    @unittest.skipUnless(mp.SnoptSolver().available(), "Requires Snopt")
+    @unittest.skipUnless(mp.SnoptSolver().available()
+                         and mp.SnoptSolver().enabled(), "Requires SNOPT")
     def test_one_box(self):
         # Test with a single box.
         masses = [1.]

--- a/doc/doxygen_cxx/doxygen.h
+++ b/doc/doxygen_cxx/doxygen.h
@@ -220,6 +220,7 @@ namespace solvers {
  - <b>\ref drake::Parallelism "DRAKE_NUM_THREADS"</b>
  - <b>\ref pydrake_python_logging "DRAKE_PYTHON_LOGGING"</b>
  - <b>\ref drake::common::FindResource() "DRAKE_RESOURCE_ROOT"</b>
+ - <b>\ref drake::solvers::SnoptSolver "DRAKE_SNOPT_SOLVER_ENABLED"</b>
  - <b>\ref drake::solvers::GurobiSolver "GRB_LICENSE_FILE"</b> (see also 
    <a href="https://support.gurobi.com/hc/en-us/articles/360013417211-Where-do-I-place-the-Gurobi-license-file-gurobi-lic-">upstream documentation</a>)
  - <b>\ref drake::solvers::GurobiSolver "GUROBI_NUM_THREADS"</b>

--- a/examples/acrobot/test/run_swing_up_traj_optimization.cc
+++ b/examples/acrobot/test/run_swing_up_traj_optimization.cc
@@ -35,7 +35,8 @@ DEFINE_double(realtime_factor, 1.0,
               "Simulator::set_target_realtime_rate() for details.");
 
 int do_main() {
-  if (!solvers::SnoptSolver::is_available()) {
+  if (!(solvers::SnoptSolver::is_available() &&
+        solvers::SnoptSolver::is_enabled())) {
     std::cout << "This test was flaky with IPOPT, so currently requires SNOPT."
               << std::endl;
     return 0;

--- a/multibody/optimization/test/static_equilibrium_problem_test.cc
+++ b/multibody/optimization/test/static_equilibrium_problem_test.cc
@@ -39,7 +39,7 @@ GTEST_TEST(StaticEquilibriumProblemTest, SphereOnGroundTest) {
         // RigidBodies Through Contact by Michael Posa, Cecilia Cantu and Russ
         // Tedrake.
         solvers::SnoptSolver snopt_solver;
-        if (snopt_solver.available()) {
+        if (snopt_solver.available() && snopt_solver.enabled()) {
           const auto result = snopt_solver.Solve(dut.prog(), x_init, {});
           ASSERT_TRUE(result.is_success());
 
@@ -162,7 +162,7 @@ GTEST_TEST(TestStaticEquilibriumProblem, TwoSpheresWithinBin) {
        &wall_size](const Eigen::VectorXd& x_init) {
         // Now solve the static equilibrium problem.
         solvers::SnoptSolver snopt_solver;
-        if (snopt_solver.available()) {
+        if (snopt_solver.available() && snopt_solver.enabled()) {
           solvers::SolverOptions solver_options;
           const auto result =
               snopt_solver.Solve(dut.prog(), x_init, solver_options);

--- a/planning/trajectory_optimization/test/direct_transcription_test.cc
+++ b/planning/trajectory_optimization/test/direct_transcription_test.cc
@@ -296,8 +296,9 @@ GTEST_TEST(DirectTranscriptionTest, ContinuousTimeSymbolicConstraintTest) {
 void SolvePendulumTrajectory(bool continuous_time) {
   // Only solve under SNOPT (IPOPT is unreliable here).
   solvers::SnoptSolver snopt_solver;
-  if (!snopt_solver.is_available()) {
-    drake::log()->warn("SNOPT is unavailable; this test shall be skipped.");
+  if (!(snopt_solver.is_available() && snopt_solver.is_enabled())) {
+    drake::log()->warn(
+        "SNOPT is unavailable or disabled; this test shall be skipped.");
     return;
   }
 

--- a/solvers/snopt_solver.h
+++ b/solvers/snopt_solver.h
@@ -48,8 +48,9 @@ struct SnoptSolverDetails {
  * SolverInterface::available() will return true.
  * Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
  *
- * There is no license configuration required to use SNOPT, so
- * SolverInterface::enabled() will always return true.
+ * There is no license configuration required to use SNOPT, but you may set the
+ * environtment variable `DRAKE_SNOPT_SOLVER_ENABLED` to "0" to force-disable
+ * SNOPT, in which case SolverInterface::enabled() will return false.
  */
 class SnoptSolver final : public SolverBase {
  public:
@@ -68,6 +69,8 @@ class SnoptSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  /// Returns true iff the environment variable DRAKE_SNOPT_SOLVER_ENABLED is
+  /// unset or set to anything other than "0".
   static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}

--- a/solvers/snopt_solver_common.cc
+++ b/solvers/snopt_solver_common.cc
@@ -20,7 +20,11 @@ SolverId SnoptSolver::id() {
 }
 
 bool SnoptSolver::is_enabled() {
-  return true;
+  const char* snopt_solver_enabled = std::getenv("DRAKE_SNOPT_SOLVER_ENABLED");
+  if (snopt_solver_enabled == nullptr) {
+    return true;
+  }
+  return (std::string(snopt_solver_enabled) != "0");
 }
 
 bool SnoptSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {

--- a/solvers/test/complementary_problem_test.cc
+++ b/solvers/test/complementary_problem_test.cc
@@ -46,7 +46,7 @@ GTEST_TEST(TestComplementaryProblem, bard1) {
   prog.AddLinearComplementarityConstraint(M, q, {x, y, l});
 
   SnoptSolver snopt_solver;
-  if (snopt_solver.available()) {
+  if (snopt_solver.available() && snopt_solver.enabled()) {
     auto result = snopt_solver.Solve(prog, {}, {});
     EXPECT_TRUE(result.is_success());
     auto x_val = result.GetSolution(x);
@@ -82,7 +82,7 @@ GTEST_TEST(TestComplementaryProblem, flp2) {
   prog.AddLinearComplementarityConstraint(M, q, {x, y});
   prog.AddBoundingBoxConstraint(0, 10, x);
   SnoptSolver snopt_solver;
-  if (snopt_solver.available()) {
+  if (snopt_solver.available() && snopt_solver.enabled()) {
     MathematicalProgramResult result = Solve(prog);
     EXPECT_TRUE(result.is_success());
     const auto x_val = result.GetSolution(x);

--- a/solvers/test/gurobi_solver_grb_license_file_test.cc
+++ b/solvers/test/gurobi_solver_grb_license_file_test.cc
@@ -19,7 +19,7 @@ namespace {
 
 std::optional<std::string> GetEnvStr(const char* name) {
   const char* const value = std::getenv(name);
-  if (!name) {
+  if (!value) {
     return std::nullopt;
   }
   return std::string(value);

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -239,7 +239,7 @@ GTEST_TEST(TestMathematicalProgramResult, InfeasibleProblem) {
 }
 
 GTEST_TEST(TestMathematicalProgramResult, GetInfeasibleConstraintNames) {
-  if (SnoptSolver::is_available()) {
+  if (SnoptSolver::is_available() && SnoptSolver::is_enabled()) {
     MathematicalProgram prog;
     auto x = prog.NewContinuousVariables<1>();
     auto b0 = prog.AddBoundingBoxConstraint(0, 0, x);
@@ -280,7 +280,7 @@ GTEST_TEST(TestMathematicalProgramResult, GetInfeasibleConstraintBindings) {
   auto constraint1 = prog.AddBoundingBoxConstraint(value1, value1, x.head<2>());
   auto constraint2 = prog.AddBoundingBoxConstraint(value2, value2, x);
   SnoptSolver solver;
-  if (solver.is_available()) {
+  if (solver.is_available() && solver.is_enabled()) {
     const auto result = solver.Solve(prog);
     EXPECT_FALSE(result.is_success());
     const double tol = 1e-4;

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3748,7 +3748,7 @@ GTEST_TEST(TestMathematicalProgram, TestNonlinearExpressionConstraints) {
 
   prog.AddConstraint(x.transpose() * x == 1.);
 
-  if (SnoptSolver().available()) {
+  if (SnoptSolver().available() && SnoptSolver().enabled()) {
     // Add equivalent constraints using all of the other entry points.
     // Note: restricted to SNOPT because IPOPT complains about the redundant
     // constraints.

--- a/solvers/test/mosek_solver_moseklm_license_file_test.cc
+++ b/solvers/test/mosek_solver_moseklm_license_file_test.cc
@@ -19,7 +19,7 @@ namespace {
 
 std::optional<std::string> GetEnvStr(const char* name) {
   const char* const value = std::getenv(name);
-  if (!name) {
+  if (!value) {
     return std::nullopt;
   }
   return std::string(value);

--- a/solvers/test/nonlinear_program_test.cc
+++ b/solvers/test/nonlinear_program_test.cc
@@ -57,7 +57,7 @@ void RunNonlinearProgram(const MathematicalProgram& prog,
 
   for (const auto& solver : solvers) {
     SCOPED_TRACE(fmt::format("Using solver: {}", solver.first));
-    if (!solver.second->available()) {
+    if (!(solver.second->available() && solver.second->enabled())) {
       continue;
     }
     DRAKE_ASSERT_NO_THROW(solver.second->Solve(prog, x_init, {}, result));
@@ -587,7 +587,7 @@ GTEST_TEST(testNonlinearProgram, CallbackTest) {
       std::make_pair("Ipopt", &ipopt_solver)};
 
   for (const auto& solver : solvers) {
-    if (!solver.second->available()) {
+    if (!(solver.second->available() && solver.second->enabled())) {
       continue;
     }
 

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -49,7 +49,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_F(InfeasibleLinearProgramTest0, TestSnopt) {
   prog_->SetInitialGuessForAllVariables(Eigen::Vector2d(1, 2));
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     auto result = solver.Solve(*prog_, {}, {});
     EXPECT_EQ(result.get_solution_result(),
               SolutionResult::kInfeasibleConstraints);
@@ -69,7 +69,7 @@ TEST_F(UnboundedLinearProgramTest0, TestSnopt) {
 
 TEST_F(DuplicatedVariableLinearProgramTest1, Test) {
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     CheckSolution(solver);
   }
 }
@@ -87,7 +87,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 GTEST_TEST(QPtest, TestUnitBallExample) {
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     TestQPonUnitBallExample(solver);
   }
 }
@@ -433,7 +433,7 @@ GTEST_TEST(SnoptTest, AutoDiffOnlyCost) {
   prog.AddCost(std::make_shared<AutoDiffOnlyCost>(), x);
 
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     auto result = solver.Solve(prog, {}, {});
     EXPECT_TRUE(result.is_success());
     const double tol = 1E-6;
@@ -455,7 +455,7 @@ GTEST_TEST(SnoptTest, VariableScaling1) {
   prog.SetVariableScaling(x(1), 0.0001);
 
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     auto result = solver.Solve(prog, {}, {});
     EXPECT_TRUE(result.is_success());
     const double tol = 1E-6;
@@ -482,7 +482,7 @@ GTEST_TEST(SnoptTest, VariableScaling2) {
   prog.SetVariableScaling(x(0), s);
 
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     auto result = solver.Solve(prog, Eigen::Vector2d(1 * s, -1), {});
     EXPECT_TRUE(result.is_success());
     const double tol = 1E-6;
@@ -574,7 +574,7 @@ GTEST_TEST(SnoptSolverTest, BadStringParameter) {
 
 GTEST_TEST(SnoptSolverTest, TestNonconvexQP) {
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     TestNonconvexQP(solver, false);
   }
 }
@@ -597,7 +597,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(TestQPasSOCP, TestSOCP) {
   SnoptSolver snopt_solver;
-  if (snopt_solver.available()) {
+  if (snopt_solver.available() && snopt_solver.enabled()) {
     SolveAndCheckSolution(snopt_solver);
   }
 }
@@ -607,7 +607,7 @@ INSTANTIATE_TEST_SUITE_P(SnoptTest, TestQPasSOCP,
 
 TEST_P(TestFindSpringEquilibrium, TestSOCP) {
   SnoptSolver snopt_solver;
-  if (snopt_solver.available()) {
+  if (snopt_solver.available() && snopt_solver.enabled()) {
     SolveAndCheckSolution(snopt_solver, {}, 2E-3);
   }
 }
@@ -619,7 +619,7 @@ INSTANTIATE_TEST_SUITE_P(
 GTEST_TEST(TestSOCP, MaximizeGeometricMeanTrivialProblem1) {
   MaximizeGeometricMeanTrivialProblem1 prob;
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     const auto result = solver.Solve(prob.prog(), {}, {});
     prob.CheckSolution(result, 4E-6);
   }
@@ -655,7 +655,7 @@ GTEST_TEST(SnoptTest, TestCostExceptionHandling) {
   const auto x = prog.NewContinuousVariables<1>();
   prog.AddCost(std::make_shared<ThrowCost>(), x);
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     DRAKE_EXPECT_THROWS_MESSAGE(solver.Solve(prog),
                                 "Exception.*SNOPT.*ThrowCost.*");
   }
@@ -663,9 +663,39 @@ GTEST_TEST(SnoptTest, TestCostExceptionHandling) {
 
 TEST_F(QuadraticEqualityConstrainedProgram1, test) {
   SnoptSolver solver;
-  if (solver.available()) {
+  if (solver.available() && solver.enabled()) {
     CheckSolution(solver, Eigen::Vector2d(0.5, 0.8), std::nullopt, 1E-6);
   }
+}
+
+class SnoptSolverEnabledTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(solver_.available());
+    ASSERT_EQ(::getenv("DRAKE_SNOPT_SOLVER_ENABLED"), nullptr);
+    prog_.NewContinuousVariables<1>();
+  }
+
+  void TearDown() override {
+    EXPECT_EQ(::unsetenv("DRAKE_SNOPT_SOLVER_ENABLED"), 0);
+  }
+
+  MathematicalProgram prog_;
+  SnoptSolver solver_;
+};
+
+TEST_F(SnoptSolverEnabledTest, DefaultBehavior) {
+  EXPECT_EQ(solver_.enabled(), true);
+  EXPECT_NO_THROW(solver_.Solve(prog_));
+}
+
+TEST_F(SnoptSolverEnabledTest, ExplicitlyDisabled) {
+  EXPECT_EQ(solver_.enabled(), true);
+  ASSERT_EQ(::setenv("DRAKE_SNOPT_SOLVER_ENABLED", "0", 1), 0);
+  EXPECT_EQ(solver_.enabled(), false);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      solver_.Solve(prog_), ".*SnoptSolver has not been properly configured.*");
 }
 
 }  // namespace test


### PR DESCRIPTION
In a forthcoming refactoring of our build & test tactics w.r.t. commercial solvers, we need the ability to toggle them on/off using environment variables.  The MosekSolver and GurobiSolver already offer that with their `enabled()` logic.  Extend that to SNOPT as well, with a new environment variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20636)
<!-- Reviewable:end -->
