### PR TITLE
Support github 'release' externals

### DIFF
--- a/tools/workspace/mirrors.bzl
+++ b/tools/workspace/mirrors.bzl
@@ -16,11 +16,6 @@
 # PyPI, etc.) to CloudFront backed by an S3 bucket.
 #
 DEFAULT_MIRRORS = {
-    "buildifier": [
-        "https://drake-mirror.csail.mit.edu/github/bazelbuild/buildtools/releases/{version}/{filename}",  # noqa
-        "https://s3.amazonaws.com/drake-mirror/github/bazelbuild/buildtools/releases/{version}/{filename}",  # noqa
-        "https://github.com/bazelbuild/buildtools/releases/download/{version}/{filename}",  # noqa
-    ],
     "crate_universe": [
         # This pattern instructs us to allow the crates.io URL.
         "{default_url}",
@@ -43,6 +38,11 @@ DEFAULT_MIRRORS = {
         # For Drake's mirrors, we use a single pattern no matter the commit.
         "https://drake-mirror.csail.mit.edu/github/{repository}/{commit}.tar.gz",  # noqa
         "https://s3.amazonaws.com/drake-mirror/github/{repository}/{commit}.tar.gz",  # noqa
+    ],
+    "github_release": [
+        "https://github.com/{repository}/releases/download/{release}/{filename}",  # noqa
+        "https://drake-mirror.csail.mit.edu/github/{repository}/releases/{release}/{filename}",  # noqa
+        "https://s3.amazonaws.com/drake-mirror/github/{repository}/releases/{release}/{filename}",  # noqa
     ],
     "maven": [
         "https://jcenter.bintray.com/{fulljar}",


### PR DESCRIPTION
Add support for external artifacts from GitHub releases, where the artifact is platform dependent (e.g. pre-compiled binaries). Refactor buildifier to use this. Teach new_release to understand these.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20638)
<!-- Reviewable:end -->
