### PR TITLE
Enforce UTF-8 during wheel builds

### DIFF
--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -43,7 +43,7 @@ def _actually_find_packages():
 # Generate a source file we can use to produce an extension library (which we
 # do to force the wheel to not be platform-agnostic. We need this because
 # trying to build an extension module with no sources is not reliable.
-with open('dummy.c', 'wt') as f:
+with open('dummy.c', 'wt', encoding='utf-8') as f:
     f.write('void not_used() {}')
 
 

--- a/tools/wheel/wheel_builder/common.py
+++ b/tools/wheel/wheel_builder/common.py
@@ -2,6 +2,7 @@
 # //tools/wheel:builder for the user interface.
 
 import argparse
+import locale
 import os
 import re
 import sys
@@ -87,6 +88,14 @@ def do_main(args, platform):
     platform-specific implementations of various operations necessary to
     complete the build.
     """
+
+    # Ensure we and any subprocesses are speaking UTF-8.
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+    locale_keys = [k for k in os.environ.keys() if k.startswith('LC_')]
+    for k in locale_keys:
+        os.environ.pop(k)
+    os.environ['LC_ALL'] = 'en_US.UTF-8'
+    os.environ['LANG'] = 'en_US.UTF-8'
 
     # Work around `bazel run` changing the working directory; this is to allow
     # the user to pass in relative paths in a sane manner.

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -220,7 +220,8 @@ def _build_image(target, identifier, options):
     # Build the image.
     if options.tag_stages:
         # Inspect Dockerfile, find stages, and build them.
-        for line in open(os.path.join(resource_root, 'Dockerfile')):
+        dockerfile = os.path.join(resource_root, 'Dockerfile')
+        for line in open(dockerfile, encoding='utf-8'):
             if line.startswith('FROM'):
                 stage = line.strip().split()[-1]
                 tag = _build_stage(target, args, tag_prefix=stage, stage=stage)

--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -86,7 +86,7 @@ def _provision(python_targets):
 
     host_keys = ''
     known_hosts_path = os.path.join(resource_root, 'image', 'known_hosts')
-    with open(known_hosts_path) as f:
+    with open(known_hosts_path, 'rt', encoding='utf-8') as f:
         for line in f:
             host, key_type, key = line.strip().split()
             if key_type in _find_host_key_types(host):
@@ -95,7 +95,8 @@ def _provision(python_targets):
             host_keys += line
 
     if host_keys:
-        with open(os.path.expanduser('~/.ssh/known_hosts'), 'a') as f:
+        known_hosts_path = os.path.expanduser('~/.ssh/known_hosts')
+        with open(known_hosts_path, 'at', encoding='utf-8') as f:
             f.write(''.join(host_keys))
             os.fchmod(f.fileno(), 0o600)
 


### PR DESCRIPTION
Add logic to the wheel builder to set the current locale to a UTF-8 locale. This should ensure that any IPC happens in UTF-8 as opposed to just hoping that the system locale is UTF-8. Also, modify some file I/O to always specify the intended encoding.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20640)
<!-- Reviewable:end -->
