### PR TITLE
Move common "overloaded" helper idiom to common

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -55,6 +55,8 @@ drake_py_library(
 generate_pybind_documentation_header(
     name = "generate_pybind_documentation_header",
     out = "documentation_pybind.h",
+    # Anonymous namespace and deduction guides both confuse pybind.
+    exclude_hdr_patterns = ["drake/common/overloaded.h"],
     root_name = "pydrake_doc",
     targets = [
         "//tools/install/libdrake:drake_headers",

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -44,6 +44,7 @@ drake_cc_package_library(
         ":name_value",
         ":network_policy",
         ":nice_type_name",
+        ":overloaded",
         ":parallelism",
         ":pointer_cast",
         ":polynomial",
@@ -394,6 +395,11 @@ drake_cc_library(
     deps = [
         ":nice_type_name_override_header",
     ],
+)
+
+drake_cc_library(
+    name = "overloaded",
+    hdrs = ["overloaded.h"],
 )
 
 drake_cc_library(
@@ -1018,6 +1024,13 @@ drake_cc_googletest(
     num_threads = 2,
     deps = [
         "//common:essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "overloaded_test",
+    deps = [
+        "//common:overloaded",
     ],
 )
 

--- a/common/overloaded.h
+++ b/common/overloaded.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/** @file The "overloaded" variant-visit pattern.
+
+The C++ std::visit (typeswitch dispatch) is very useful for std::variant but
+doesn't support it natively.  There is a commonly used two-line boilerplate
+that bridges this gap; see
+https://en.cppreference.com/w/cpp/utility/variant/visit
+
+This file should be included by classes that wish to
+use the variant visit pattern, i.e.
+
+@code {.cpp}
+  using MyVariant = std::variant<int, std::string>;
+  MyVariant v = 5;
+  std::string result = std::visit(overloaded{
+    [](const int arg) { return "found an int"; },
+    [](const std::string& arg) { return "found a string"; }
+  }, v);
+  EXPECT_EQ(result, "found an int");
+@endcode
+
+@warning This file must never be included by a header, only by a cc file.
+         This is enforced by a lint rule in `tools/lint/drakelint.py`.
+*/
+
+// We put this in the anonymous namespace to ensure that it will not generate
+// linkable symbols for every specialization in every library that uses it.
+namespace {  // NOLINT(build/namespaces)
+
+// Boilerplate for `std::visit`; see
+// https://en.cppreference.com/w/cpp/utility/variant/visit
+template <class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+// NOTE:  The second line above can be removed when we are compiling with
+// >= C++20 on all platforms.
+}  // namespace

--- a/common/schema/BUILD.bazel
+++ b/common/schema/BUILD.bazel
@@ -25,6 +25,7 @@ drake_cc_library(
     deps = [
         ":stochastic",
         "//common:name_value",
+        "//common:overloaded",
         "//math:geometric_transform",
     ],
 )
@@ -37,6 +38,7 @@ drake_cc_library(
         "//common:essential",
         "//common:name_value",
         "//common:nice_type_name",
+        "//common:overloaded",
         "//common:random",
         "//common:unused",
         "//common/symbolic:expression",

--- a/common/schema/rotation.cc
+++ b/common/schema/rotation.cc
@@ -1,6 +1,7 @@
 #include "drake/common/schema/rotation.h"
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/overloaded.h"
 #include "drake/math/random_rotation.h"
 #include "drake/math/rotation_matrix.h"
 
@@ -8,12 +9,6 @@ namespace drake {
 namespace schema {
 
 using symbolic::Expression;
-
-namespace {
-// Boilerplate for std::visit.
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
-}  // namespace
 
 Rotation::Rotation(const math::RotationMatrix<double>& arg)
     : Rotation(math::RollPitchYaw<double>(arg)) {}

--- a/common/schema/stochastic.cc
+++ b/common/schema/stochastic.cc
@@ -6,16 +6,11 @@
 #include <fmt/format.h>
 
 #include "drake/common/nice_type_name.h"
+#include "drake/common/overloaded.h"
 #include "drake/common/unused.h"
 
 using drake::symbolic::Expression;
 using std::unique_ptr;
-
-namespace {
-// Boilerplate for std::visit.
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
-}  // namespace
 
 namespace drake {
 namespace schema {

--- a/common/test/overloaded_test.cc
+++ b/common/test/overloaded_test.cc
@@ -1,0 +1,44 @@
+#include "drake/common/overloaded.h"
+
+#include <variant>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace {
+
+GTEST_TEST(OverloadedTest, CommentExampleTest) {
+  // Test the exact text of the example in the file comment.
+  using MyVariant = std::variant<int, std::string>;
+  MyVariant v = 5;
+  std::string result = std::visit(overloaded{
+    [](const int arg) { return "found an int"; },
+    [](const std::string& arg) { return "found a string"; }
+  }, v);
+  EXPECT_EQ(result, "found an int");
+}
+
+GTEST_TEST(OverloadedTest, AutoTest) {
+  using MyVariant = std::variant<int, std::string>;
+  MyVariant v = 5;
+
+  // An 'auto' arm doesn't match if there's any explicit match,
+  // no matter if it's earlier or later in the list.
+  std::string result = std::visit(overloaded{
+    [](const auto arg) { return "found an auto"; },
+    [](const int arg) { return "found an int"; },
+    [](const std::string& arg) { return "found a string"; },
+    [](const auto arg) { return "found an auto"; },
+  }, v);
+  EXPECT_EQ(result, "found an int");
+
+  // An 'auto' arm matches if there's no explicit match.
+  result = std::visit(overloaded{
+    [](const auto arg) { return "found an auto"; },
+    [](const std::string& arg) { return "found a string"; },
+  }, v);
+  EXPECT_EQ(result, "found an auto");
+}
+
+}  // namespace
+}  // namespace drake

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -321,6 +321,7 @@ drake_cc_googletest_linux_only(
         ":internal_render_engine_gl",
         ":internal_texture_library",
         "//common:find_resource",
+        "//common:overloaded",
         "//common/test_utilities:eigen_matrix_compare",
         "//systems/sensors:image",
         "//systems/sensors:image_writer",

--- a/geometry/render_gl/test/multithread_safety_test.cc
+++ b/geometry/render_gl/test/multithread_safety_test.cc
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/overloaded.h"
 #include "drake/common/ssize.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/text_logging.h"
@@ -155,15 +156,6 @@ GTEST_TEST(ThreadSafetyTest, OpenGlContext) {
 
   ASSERT_EQ(num_errors, 0);
 }
-
-/* Helper for variant resolution. */
-template <class... Ts>
-struct overloaded : Ts... {
-  using Ts::operator()...;
-};
-// explicit deduction guide (not needed as of C++20)
-template <class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
 
 /* Adds the given `shape` as an *anchored* geometry to the given `engine` at the
  given position `p_WS` with the given `diffuse` definition. */

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -84,6 +84,7 @@ drake_cc_library(
     srcs = ["joint_sliders.cc"],
     hdrs = ["joint_sliders.h"],
     deps = [
+        "//common:overloaded",
         "//common:scope_exit",
         "//geometry:meshcat",
         "//geometry:meshcat_graphviz",

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -9,15 +9,10 @@
 #include <fmt/format.h>
 
 #include "drake/common/autodiff_overloads.h"
+#include "drake/common/overloaded.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/unused.h"
 #include "drake/geometry/meshcat_graphviz.h"
-
-namespace {
-// Boilerplate for std::visit.
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
-}  // namespace
 
 namespace drake {
 namespace multibody {

--- a/tools/lint/drakelint.py
+++ b/tools/lint/drakelint.py
@@ -36,6 +36,23 @@ def _check_unguarded_openmp_uses(filename):
     return 0
 
 
+def _check_header_using_overloaded(filename):
+    """Return 0 if the file is not a header or doesn't include overloaded.h
+    Return 1 otherwise."""
+    forbidden_re = re.compile(
+        # This expression approximates section 6.10.2 except 6.10.2.4 of
+        # https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf
+        r'\s*#\s*include\s*[<"]drake/common/overloaded.h\s*[>"]')
+    if filename.endswith(".h"):
+        with open(filename, mode='r', encoding='utf-8') as file:
+            for line in file.readlines():
+                if forbidden_re.match(line):
+                    print("ERROR:  Header files must not include "
+                          "drake/common/overloaded.h")
+                    return 1
+    return 0
+
+
 def _check_invalid_line_endings(filename):
     """Return 0 if all of the newlines in @p filename are Unix, and 1
     otherwise.
@@ -223,6 +240,7 @@ def main():
             total_errors += _check_unguarded_openmp_uses(filename)
             total_errors += _check_iostream(filename)
             total_errors += _check_clang_format_toggles(filename)
+            total_errors += _check_header_using_overloaded(filename)
 
     if total_errors == 0:
         sys.exit(0)


### PR DESCRIPTION
* The C++ `std::visit` (typeswitch dispatch) is very useful for `std::variant` but doesn't support it natively.
* There is a two-line mystic sigil that is copied literally in a few Drake files (and many files downstream expected to move to drake).
* It is rule-of-three and should be factored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20644)
<!-- Reviewable:end -->
