### PR TITLE
Revert "[workspace] Upgrade MOSEK to latest release 10.1.21"

### DIFF
--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1991,7 +1991,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/10.1/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/10.0/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
@@ -2003,7 +2003,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/10.1/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/10.0/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    @param vars x in the documentation above.
    @param hessian_type Whether the Hessian is positive semidefinite, negative
@@ -2025,7 +2025,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/10.1/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/10.0/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    @param vars x in the documentation above.
    @param hessian_type Whether the Hessian is positive semidefinite, negative
@@ -2047,7 +2047,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/10.1/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/10.0/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    */
   Binding<QuadraticConstraint> AddQuadraticConstraint(

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -295,7 +295,7 @@ class MathematicalProgramResult final {
    *    GurobiSolver solver;
    *    // Explicitly tell the solver to compute the dual solution for Lorentz
    *    // cone or rotated Lorentz cone constraint, check
-   *    // https://www.gurobi.com/documentation/10.1/refman/qcpdual.html for
+   *    // https://www.gurobi.com/documentation/10.0/refman/qcpdual.html for
    *    // more information.
    *    SolverOptions options;
    *    options.SetOption(GurobiSolver::id(), "QCPDual", 1);
@@ -314,7 +314,7 @@ class MathematicalProgramResult final {
    *    solution to the (rotated) Lorentz cone constraint doesn't have the
    *    "shadow price" interpretation, but should lie in the dual cone, and
    *    satisfy the KKT condition. For more information, refer to
-   *    https://docs.mosek.com/10.1/capi/prob-def-conic.html#duality-for-conic-optimization
+   *    https://docs.mosek.com/10.0/capi/prob-def-conic.html#duality-for-conic-optimization
    *    as an explanation.
    *
    * The interpretation for the dual variable to conic constraint x ∈ K can be

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -52,7 +52,7 @@ class MosekSolver::License {
     if (rescode != MSK_RES_OK) {
       throw std::runtime_error(
           fmt::format("Could not acquire MOSEK license: {}. See "
-                      "https://docs.mosek.com/10.1/capi/"
+                      "https://docs.mosek.com/10.0/capi/"
                       "response-codes.html#mosek.rescode for details.",
                       fmt_streamed(rescode)));
     }

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -18,15 +18,15 @@ namespace solvers {
  */
 struct MosekSolverDetails {
   /// The MOSEK™ optimization time. Please refer to MSK_DINF_OPTIMIZER_TIME in
-  /// https://docs.mosek.com/10.1/capi/constants.html?highlight=msk_dinf_optimizer_time
+  /// https://docs.mosek.com/10.0/capi/constants.html?highlight=msk_dinf_optimizer_time
   double optimizer_time{};
   /// The response code returned from MOSEK™ solver. Check
-  /// https://docs.mosek.com/10.1/capi/response-codes.html for the meaning on
+  /// https://docs.mosek.com/10.0/capi/response-codes.html for the meaning on
   /// the response code.
   int rescode{};
   /// The solution status after solving the problem. Check
-  /// https://docs.mosek.com/10.1/capi/accessing-solution.html and
-  /// https://docs.mosek.com/10.1/capi/constants.html#mosek.solsta for the
+  /// https://docs.mosek.com/10.0/capi/accessing-solution.html and
+  /// https://docs.mosek.com/10.0/capi/constants.html#mosek.solsta for the
   /// meaning on the solution status.
   int solution_status{};
 };
@@ -54,19 +54,19 @@ struct MosekSolverDetails {
  * (MOSEK™ might change the values of the integer/binary variables in the
  * subsequent iterations.) If the specified integer solution is infeasible or
  * incomplete, MOSEK™ will simply ignore it. For more details, check
- * https://docs.mosek.com/10.1/capi/tutorial-mio-shared.html?highlight=initial
+ * https://docs.mosek.com/10.0/capi/tutorial-mio-shared.html?highlight=initial
  *
  * MOSEK™ supports many solver parameters. You can refer to the full list of
  * parameters in
- * https://docs.mosek.com/10.1/capi/param-groups.html#doc-param-groups. On top
+ * https://docs.mosek.com/10.0/capi/param-groups.html#doc-param-groups. On top
  * of these parameters, we also provide the following additional parameters
  *
  * - "writedata"
  *    set to a file name so that MOSEK™ solver will write the
  *    optimization model to this file. check
- *    https://docs.mosek.com/10.1/capi/solver-io.html#saving-a-problem-to-a-file
+ *    https://docs.mosek.com/10.0/capi/solver-io.html#saving-a-problem-to-a-file
  *    for more details. The supported file extensions are listed in
- *    https://docs.mosek.com/10.1/capi/supported-file-formats.html#doc-shared-file-formats.
+ *    https://docs.mosek.com/10.0/capi/supported-file-formats.html#doc-shared-file-formats.
  *    Set this parameter to "" if you don't want to write to a file. Default is
  *    not to write to a file.
  */

--- a/solvers/mosek_solver_internal.cc
+++ b/solvers/mosek_solver_internal.cc
@@ -48,7 +48,7 @@ MosekSolverProgram::MosekSolverProgram(const MathematicalProgram& prog,
     : map_decision_var_to_mosek_var_{prog} {
   // Create the optimization task.
   // task is initialized as a null pointer, same as in Mosek's documentation
-  // https://docs.mosek.com/10.1/capi/design.html#hello-world-in-mosek
+  // https://docs.mosek.com/10.0/capi/design.html#hello-world-in-mosek
   task_ = nullptr;
   MSK_maketask(env, 0,
                map_decision_var_to_mosek_var_
@@ -692,7 +692,7 @@ MSKrescodee MosekSolverProgram::AddQuadraticConstraints(
     }
 
     // Pre-allocate the size for the Q matrix according to
-    // https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.putqcon
+    // https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.putqcon
     rescode = MSK_putmaxnumqnz(task_, qcsubi.size());
     if (rescode != MSK_RES_OK) {
       return rescode;
@@ -1440,8 +1440,8 @@ void ThrowForInvalidOption(MSKrescodee rescode, const std::string& option,
 
 // This function is used to print information for each iteration to the console,
 // it will show PRSTATUS, PFEAS, DFEAS, etc. For more information, check out
-// https://docs.mosek.com/10.1/capi/solver-io.html. This printstr is copied
-// directly from https://docs.mosek.com/10.1/capi/solver-io.html#stream-logging.
+// https://docs.mosek.com/10.0/capi/solver-io.html. This printstr is copied
+// directly from https://docs.mosek.com/10.0/capi/solver-io.html#stream-logging.
 void MSKAPI printstr(void*, const char str[]) {
   printf("%s", str);
 }
@@ -1484,7 +1484,7 @@ MSKrescodee MosekSolverProgram::UpdateOptions(
   // log file.
   *print_to_console = merged_options.get_print_to_console();
   *print_file_name = merged_options.get_print_file_name();
-  // Refer to https://docs.mosek.com/10.1/capi/solver-io.html#stream-logging
+  // Refer to https://docs.mosek.com/10.0/capi/solver-io.html#stream-logging
   // for Mosek stream logging.
   // First we check if the user wants to print to both the console and the file.
   // If true, throw an error BEFORE we create the log file through
@@ -1534,7 +1534,7 @@ MSKrescodee MosekSolverProgram::SetDualSolution(
   if (which_sol == MSK_SOL_ITG) {
     // Mosek cannot return dual solution if the solution type is MSK_SOL_ITG
     // (which stands for mixed integer optimizer), see
-    // https://docs.mosek.com/10.1/capi/accessing-solution.html#available-solutions
+    // https://docs.mosek.com/10.0/capi/accessing-solution.html#available-solutions
     return rescode;
   }
   int num_mosek_vars{0};
@@ -1544,7 +1544,7 @@ MSKrescodee MosekSolverProgram::SetDualSolution(
   }
   // Mosek dual variables for variable lower bounds (slx) and upper bounds
   // (sux). Refer to
-  // https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsolution
+  // https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
   // for more explanation.
   std::vector<MSKrealt> slx(num_mosek_vars);
   std::vector<MSKrealt> sux(num_mosek_vars);
@@ -1563,7 +1563,7 @@ MSKrescodee MosekSolverProgram::SetDualSolution(
   }
   // Mosek dual variables for linear constraints lower bounds (slc) and upper
   // bounds (suc). Refer to
-  // https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsolution
+  // https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
   // for more explanation.
   std::vector<MSKrealt> slc(num_linear_constraints);
   std::vector<MSKrealt> suc(num_linear_constraints);

--- a/solvers/mosek_solver_internal.h
+++ b/solvers/mosek_solver_internal.h
@@ -19,10 +19,10 @@ namespace drake {
 namespace solvers {
 namespace internal {
 // Mosek treats psd matrix variables in a special manner.
-// Check https://docs.mosek.com/10.1/capi/tutorial-sdo-shared.html for more
+// Check https://docs.mosek.com/10.0/capi/tutorial-sdo-shared.html for more
 // details. To summarize, Mosek stores a positive semidefinite (psd) matrix
 // variable as a "bar var" (as called in Mosek's API, for example
-// https://docs.mosek.com/10.1/capi/tutorial-sdo-shared.html). Inside Mosek, it
+// https://docs.mosek.com/10.0/capi/tutorial-sdo-shared.html). Inside Mosek, it
 // accesses each of the psd matrix variable with a unique ID. Moreover, the
 // Mosek user cannot access the entries of the psd matrix variable individually;
 // instead, the user can only access the matrix X̅ as a whole. To impose
@@ -78,7 +78,7 @@ class MatrixVariableEntry {
 
 // Mosek stores dual variable in different categories, called slc, suc, slx, sux
 // and snx. Refer to
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsolution
+// https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
 // for more information.
 enum class DualVarType {
   kLinearConstraint,  ///< Corresponds to Mosek's slc and suc.
@@ -496,13 +496,13 @@ MSKrescodee MosekSolverProgram::AddConeConstraints(
 }
 
 // @param slx Mosek dual variables for variable lower bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getslx
+// https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getslx
 // @param sux Mosek dual variables for variable upper bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsux
+// https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getsux
 // @param slc Mosek dual variables for linear constraint lower bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getslc
+// https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getslc
 // @param suc Mosek dual variables for linear constraint upper bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsuc
+// https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getsuc
 void SetBoundingBoxDualSolution(
     const std::vector<Binding<BoundingBoxConstraint>>& constraints,
     const std::vector<MSKrealt>& slx, const std::vector<MSKrealt>& sux,
@@ -542,10 +542,10 @@ void SetLinearConstraintDualSolution(
 
 // @param slc Mosek dual variables for linear and quadratic constraint lower
 // bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getslc
+// https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getslc
 // @param suc Mosek dual variables for linear and quadratic constraint upper
 // bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsuc
+// https://docs.mosek.com/10.0/capi/alphabetic-functionalities.html#mosek.task.getsuc
 void SetQuadraticConstraintDualSolution(
     const std::vector<Binding<QuadraticConstraint>>& constraints,
     const std::vector<MSKrealt>& slc, const std::vector<MSKrealt>& suc,

--- a/solvers/test/linear_program_examples.h
+++ b/solvers/test/linear_program_examples.h
@@ -79,7 +79,7 @@ class LinearProgram1 : public OptimizationProgram {
 };
 
 // Test a simple linear programming problem
-// Adapted from https://docs.mosek.com/10.1/capi/tutorial-lo-shared.html
+// Adapted from https://docs.mosek.com/10.0/capi/tutorial-lo-shared.html
 // min -3x0 - x1 - 5x2 - x3
 // s.t     3x0 +  x1 + 2x2        = 30
 //   15 <= 2x0 +  x1 + 3x2 +  x3 <= inf

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -44,7 +44,7 @@ TEST_F(UnboundedLinearProgramTest0, Test) {
         result.get_solver_details<MosekSolver>();
     EXPECT_EQ(mosek_solver_details.rescode, 0);
     // This problem status is defined in
-    // https://docs.mosek.com/10.1/capi/constants.html#mosek.prosta
+    // https://docs.mosek.com/10.0/capi/constants.html#mosek.prosta
     const int MSK_SOL_STA_DUAL_INFEAS_CER = 6;
     EXPECT_EQ(mosek_solver_details.solution_status,
               MSK_SOL_STA_DUAL_INFEAS_CER);
@@ -287,7 +287,7 @@ GTEST_TEST(MosekTest, SolverOptionsTest) {
   mosek_solver.Solve(prog, {}, solver_options, &result);
   EXPECT_FALSE(result.is_success());
   // This response code is defined in
-  // https://docs.mosek.com/10.1/capi/response-codes.html#mosek.rescode
+  // https://docs.mosek.com/10.0/capi/response-codes.html#mosek.rescode
   const int MSK_RES_ERR_HUGE_C{1375};
   EXPECT_EQ(result.get_solver_details<MosekSolver>().rescode,
             MSK_RES_ERR_HUGE_C);
@@ -419,7 +419,7 @@ GTEST_TEST(MosekTest, MotzkinPolynomial) {
   MosekSolver solver;
   if (solver.available()) {
     const auto result = solver.Solve(dut.prog());
-    dut.CheckResult(result, 1E-8);
+    dut.CheckResult(result, 1.3E-9);
   }
 }
 

--- a/solvers/test/semidefinite_program_examples.h
+++ b/solvers/test/semidefinite_program_examples.h
@@ -69,7 +69,7 @@ void SolveEigenvalueProblem(const SolverInterface& solver,
                             double tol);
 
 /// Solve an SDP with a second order cone constraint. This example is taken from
-/// https://docs.mosek.com/10.1/capi/tutorial-sdo-shared.html
+/// https://docs.mosek.com/10.0/capi/tutorial-sdo-shared.html
 void SolveSDPwithSecondOrderConeExample1(const SolverInterface& solver,
                                          double tol);
 

--- a/tools/dynamic_analysis/tsan.supp
+++ b/tools/dynamic_analysis/tsan.supp
@@ -23,8 +23,8 @@ thread:__kmp_create_worker
 # thread leak (libiomp5.*) in __kmp_create_monitor
 thread:__kmp_create_monitor
 
-# data race libmosek64.so.10.1.  MOSEK has not been instrumented with TSan.
-called_from_lib:libmosek64.so.10.1
+# data race libmosek64.so.10.0.  MOSEK has not been instrumented with TSan.
+called_from_lib:libmosek64.so.10.0
 
 # data race (libglib-2.0.*) in g_static_rec_mutex_lock
 race:g_static_rec_mutex_lock

--- a/tools/workspace/mosek/repository.bzl
+++ b/tools/workspace/mosek/repository.bzl
@@ -27,8 +27,8 @@ def _impl(repository_ctx):
     # - LICENSE.third_party may also need updating to match
     #     https://docs.mosek.com/latest/licensing/license-agreement-info.html
     mosek_major_version = 10
-    mosek_minor_version = 1
-    mosek_patch_version = 21
+    mosek_minor_version = 0
+    mosek_patch_version = 46
 
     os_name = repository_ctx.os.name  # 'linux' or 'mac os x' (=> 'darwin')
     if os_name == "mac os x":
@@ -37,14 +37,14 @@ def _impl(repository_ctx):
     if os_name == "darwin":
         if os_arch == "aarch64":
             mosek_platform = "osxaarch64"
-            sha256 = "f6e862cab171b7897a6f1ad21c3c0fbdf33dc1310f50c792295ab008321950c7"  # noqa
+            sha256 = "85724bd519d5fe120b4e8d2676b65143b9ce6dce666a07ca4f44ec54727b5ab5"  # noqa
         else:
             mosek_platform = "osx64x86"
-            sha256 = "3ad45f7e535b6d3bb8be955f403ded30a7f186424057f11024afc57427cbb012"  # noqa
+            sha256 = "16885bbee2c1d86e0a3f9d9a2c60bbab1bb88e6f1b843ac1fb8da0c62292344f"  # noqa
     else:
         # TODO(jwnimmer-tri) We should add linux aarch64 support here.
         mosek_platform = "linux64x86"
-        sha256 = "f37b7b3806e467c64a02e95b2ab009f6fe8430f25ffc72ed56885f7684dec486"  # noqa
+        sha256 = "a6862954137493b74f55c0f2745b7f1672e602cfe9cd8974a95feaf9993f06bf"  # noqa
 
     # TODO(jwnimmer-tri) Port to use mirrors.bzl.
     template = "https://download.mosek.com/stable/{}.{}.{}/mosektools{}.tar.bz2"  # noqa
@@ -74,7 +74,7 @@ def _impl(repository_ctx):
 
         files = [
             "bin/libtbb.12.dylib",
-            "bin/libtbb.12.8.dylib",
+            "bin/libtbb.12.5.dylib",
             "bin/libmosek64.{}.{}.dylib".format(
                 mosek_major_version,
                 mosek_minor_version,
@@ -112,7 +112,7 @@ def _impl(repository_ctx):
             # We use the the MOSEK™ copy of libtbb. The version of libtbb
             # available in Ubuntu is too old.
             "bin/libtbb.so.12",
-            "bin/libtbb.so.12.8",
+            "bin/libtbb.so.12.6",
             "bin/libmosek64.so.{}.{}".format(
                 mosek_major_version,
                 mosek_minor_version,


### PR DESCRIPTION
The upgrade seems to be experiencing test failures:

```
[ RUN      ] ShortestPathTest.TobiasToyExample
[2023-12-11 07:35:15.996] [console] [info] Solved GCS shortest path using Mosek with convex_relaxation=false and preprocessing=false and no rounding.
geometry/optimization/test/graph_of_convex_sets_test.cc:1916: Failure
Value of: CompareMatrices(result.GetSolution(v->x()), active_edges_result.GetSolution(v->x()), 2e-3)
  Actual: false (NaN mismatch at (0, 0):
m1 =
1.286711007859356e-07
-5.70149511098822e-08
m2 =
nan
nan)
Expected: true

[2023-12-11 07:35:16.177] [console] [info] Solved GCS shortest path using Mosek with convex_relaxation=false and preprocessing=false and no rounding.
[2023-12-11 07:35:16.351] [console] [info] Solved GCS shortest path using Mosek with convex_relaxation=false and preprocessing=false and no rounding.
[  FAILED  ] ShortestPathTest.TobiasToyExample (420 ms)
```

---

This reverts #20634.
This reverts #20647.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20651)
<!-- Reviewable:end -->
