### PR TITLE
GcsTrajectoryOptimization helper function to get indices associated to continuous revolute joints.

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -460,6 +460,9 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def_static("NormalizeSegmentTimes", &Class::NormalizeSegmentTimes,
             py::arg("trajectory"), cls_doc.NormalizeSegmentTimes.doc);
   }
+
+  m.def("GetContinuousRevoluteJointIndices", &GetContinuousRevoluteJointIndices,
+      py::arg("plant"), doc.GetContinuousRevoluteJointIndices.doc);
 }
 
 }  // namespace internal

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -13,6 +13,7 @@ from pydrake.planning import (
     DirectTranscription,
     GcsTrajectoryOptimization,
     KinematicTrajectoryOptimization,
+    GetContinuousRevoluteJointIndices
 )
 from pydrake.geometry.optimization import (
     GraphOfConvexSetsOptions,
@@ -21,6 +22,7 @@ from pydrake.geometry.optimization import (
     Point,
     VPolytope,
 )
+from pydrake.multibody.plant import MultibodyPlant
 import pydrake.solvers as mp
 from pydrake.symbolic import Variable
 from pydrake.systems.framework import InputPortSelection
@@ -545,3 +547,9 @@ class TestTrajectoryOptimization(unittest.TestCase):
                                   order=1,
                                   edges_between_regions=[[0, 1]],
                                   edge_offsets=[[2*np.pi]])
+
+    def test_get_continuous_revolute_joint_indices(self):
+        plant = MultibodyPlant(0.0)
+        plant.Finalize()
+        indices = GetContinuousRevoluteJointIndices(plant=plant)
+        self.assertEqual(len(indices), 0)

--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -110,6 +110,7 @@ drake_cc_library(
         "//common/trajectories:bezier_curve",
         "//common/trajectories:composite_trajectory",
         "//geometry/optimization:graph_of_convex_sets",
+        "//multibody/plant",
         "//solvers:solve",
     ],
 )

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -11,6 +11,7 @@
 #include "drake/common/trajectories/composite_trajectory.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/graph_of_convex_sets.h"
+#include "drake/multibody/plant/multibody_plant.h"
 
 namespace drake {
 namespace planning {
@@ -550,6 +551,12 @@ class GcsTrajectoryOptimization final {
       global_velocity_bounds_{};
   std::vector<int> global_continuity_constraints_{};
 };
+
+/** Returns a list of indices in the plant's generalized positions which
+correspond to a continuous revolute joint (a revolute joint with no joint
+limits). This includes the revolute component of a planar joint */
+std::vector<int> GetContinuousRevoluteJointIndices(
+    const multibody::MultibodyPlant<double>& plant);
 
 }  // namespace trajectory_optimization
 }  // namespace planning

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -10,6 +10,9 @@
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/point.h"
 #include "drake/geometry/optimization/vpolytope.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/planar_joint.h"
+#include "drake/multibody/tree/revolute_joint.h"
 #include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/mosek_solver.h"
 
@@ -31,6 +34,11 @@ using geometry::optimization::HPolyhedron;
 using geometry::optimization::MakeConvexSets;
 using geometry::optimization::Point;
 using geometry::optimization::VPolytope;
+using multibody::MultibodyPlant;
+using multibody::PlanarJoint;
+using multibody::RevoluteJoint;
+using multibody::RigidBody;
+using multibody::SpatialInertia;
 using solvers::MathematicalProgram;
 
 bool GurobiOrMosekSolverAvailable() {
@@ -1320,6 +1328,47 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, ContinuousJointsApi) {
       GcsTrajectoryOptimization(1, continuous_revolute_joints),
       ".*Each joint index in continuous_revolute_joints must lie in the "
       "interval.*");
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, GetContinuousJoints) {
+  MultibodyPlant<double> plant(0.0);
+  const RigidBody<double>& first_body =
+      plant.AddRigidBody("first_body", SpatialInertia<double>());
+  const RigidBody<double>& second_body =
+      plant.AddRigidBody("second_body", SpatialInertia<double>());
+  const RigidBody<double>& third_body =
+      plant.AddRigidBody("third_body", SpatialInertia<double>());
+  const RigidBody<double>& fourth_body =
+      plant.AddRigidBody("fourth_body", SpatialInertia<double>());
+
+  // Add a planar joint without limits
+  plant.AddJoint<PlanarJoint>("first_joint", plant.world_body(), {}, first_body,
+                              {}, Eigen::Matrix<double, 3, 1>::Zero());
+
+  // Add a planar joint with limits
+  std::unique_ptr<PlanarJoint<double>> second_joint_ptr(new PlanarJoint<double>(
+      "second_joint", first_body.body_frame(), second_body.body_frame(),
+      Eigen::Matrix<double, 3, 1>::Zero()));
+  second_joint_ptr->set_position_limits(Eigen::Vector3d{-1.0, -1.0, -1.0},
+                                        Eigen::Vector3d{1.0, 1.0, 1.0});
+  plant.AddJoint<PlanarJoint>(std::move(second_joint_ptr));
+
+  // Add a revolute joint without limits
+  plant.AddJoint<RevoluteJoint>("third_joint", second_body, {}, third_body, {},
+                                Eigen::Matrix<double, 3, 1>{1.0, 0.0, 0.0});
+
+  // Add a revolute joint with limits
+  plant.AddJoint<RevoluteJoint>("fourth_joint", third_body, {}, fourth_body, {},
+                                Eigen::Matrix<double, 3, 1>{1.0, 0.0, 0.0},
+                                -1.0, 1.0);
+
+  plant.Finalize();
+
+  const std::vector<int> continuous_joint_indices =
+      trajectory_optimization::GetContinuousRevoluteJointIndices(plant);
+  ASSERT_EQ(continuous_joint_indices.size(), 2);
+  EXPECT_EQ(continuous_joint_indices[0], 2);
+  EXPECT_EQ(continuous_joint_indices[1], 6);
 }
 
 }  // namespace


### PR DESCRIPTION
Towards #20449.

Performs introspection on a MulitbodyPlant, returning the indices in the internal configuration vector which are associated to continuous revolute joints and mobile bases (stored as `PlanarJoint` which are implicitly just two prismatic joints and a revolute joint). This list of indices can then be passed directly into the GcsTrajectoryOptimization constructor, and the joint indices will align with IRIS regions created from the same multibody plant.

+@sadraddini for feature review, please

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20652)
<!-- Reviewable:end -->
