### PR TITLE
MultibodyPlant uses the new Hunt&Crossley model from SAP

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1009,6 +1009,13 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("contact_solver"), cls_doc.set_discrete_contact_solver.doc)
         .def("get_discrete_contact_solver", &Class::get_discrete_contact_solver,
             cls_doc.get_discrete_contact_solver.doc)
+        .def("set_discrete_contact_approximation",
+            &Class::set_discrete_contact_approximation,
+            py::arg("approximation"),
+            cls_doc.set_discrete_contact_approximation.doc)
+        .def("get_discrete_contact_approximation",
+            &Class::get_discrete_contact_approximation,
+            cls_doc.get_discrete_contact_approximation.doc)
         .def("set_sap_near_rigid_threshold",
             &Class::set_sap_near_rigid_threshold,
             py::arg("near_rigid_threshold") =
@@ -1524,6 +1531,16 @@ PYBIND11_MODULE(plant, m) {
     py::enum_<Class>(m, "DiscreteContactSolver", cls_doc.doc)
         .value("kTamsi", Class::kTamsi, cls_doc.kTamsi.doc)
         .value("kSap", Class::kSap, cls_doc.kSap.doc);
+  }
+
+  {
+    using Class = DiscreteContactApproximation;
+    constexpr auto& cls_doc = doc.DiscreteContactApproximation;
+    py::enum_<Class>(m, "DiscreteContactApproximation", cls_doc.doc)
+        .value("kTamsi", Class::kTamsi, cls_doc.kTamsi.doc)
+        .value("kSap", Class::kSap, cls_doc.kSap.doc)
+        .value("kSimilar", Class::kSimilar, cls_doc.kSimilar.doc)
+        .value("kLagged", Class::kLagged, cls_doc.kLagged.doc);
   }
 
   {

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -78,6 +78,7 @@ from pydrake.multibody.plant import (
     ContactResultsToLcmSystem,
     CoulombFriction_,
     DeformableModel,
+    DiscreteContactApproximation,
     DiscreteContactSolver,
     ExternallyAppliedSpatialForce_,
     ExternallyAppliedSpatialForceMultiplexer_,
@@ -2697,6 +2698,19 @@ class TestPlant(unittest.TestCase):
             self.assertEqual(plant.get_discrete_contact_solver(), model)
         plant.get_sap_near_rigid_threshold()
         plant.set_sap_near_rigid_threshold(near_rigid_threshold=0.03)
+
+    def test_discrete_contact_approximation(self):
+        plant = MultibodyPlant_[float](0.1)
+        approximations = [
+            DiscreteContactApproximation.kTamsi,
+            DiscreteContactApproximation.kSap,
+            DiscreteContactApproximation.kLagged,
+            DiscreteContactApproximation.kSimilar,
+        ]
+        for approximation in approximations:
+            plant.set_discrete_contact_approximation(approximation)
+            self.assertEqual(plant.get_discrete_contact_approximation(),
+                             approximation)
 
     def test_contact_surface_representation(self):
         for time_step in [0.0, 0.1]:

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -539,6 +539,16 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "sap_driver_contact_constraints_test",
+    deps = [
+        ":compliant_contact_manager_tester",
+        ":plant",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
     name = "sap_driver_distance_constraints_test",
     deps = [
         ":compliant_contact_manager_tester",

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -175,6 +175,68 @@ enum class DiscreteContactSolver {
   kSap,
 };
 
+/// The type of the contact approximation used for a discrete MultibodyPlant
+/// model.
+///
+/// kTamsi, kSimilar and kLagged are all approximations to the same contact
+/// model --  Compliant contact with regularized friction, refer to
+/// @ref mbp_contact_modeling "Contact Modeling" for further details.
+/// The key difference however, is that the kSimilar and kLagged approximations
+/// are convex and therefore our contact solver has both theoretical and
+/// practical convergence guarantees ---  the solver will always succeed.
+/// Conversely, being non-convex, kTamsi can fail to find a solution.
+///
+/// kSap is also a convex model of compliant contact with regularized friction.
+/// There are a couple of key differences however:
+/// - Dissipation is modeled using a linear Kelvin–Voigt model, parameterized by
+///   a relaxation time constant.
+///   See @ref accessing_contact_properties "contact parameters".
+/// - Unlike kTamsi, kSimilar and kLagged where regularization of friction is
+///   parameterized by a stiction tolerance (see set_stiction_tolerance()), SAP
+///   determines regularization automatically solely based on numerics. Users
+///   have no control on the amount of regularization.
+///
+/// ## How to choose an approximation
+///
+/// The Hunt & Crossley model is based on physics, it is continuous and has been
+/// experimentally validated. Therefore it is the preferred model to capture the
+/// physics of contact.
+///
+/// Being approximations, kSap and kSimilar introduce a spurious
+/// effect of "gliding" in sliding contact, see [Castro et al., 2023]. This
+/// artifact is 𝒪(δt) but can be significant at large time steps and/or large
+/// slip velocities. kLagged does not suffer from this, but introduces a "weak"
+/// coupling of friction that can introduce non-negligible effects in the
+/// dynamics during impacts or strong transients.
+///
+/// Summarizing, kLagged is the preferred approximation when strong transients
+/// are not expected or don't need to be accurately resolved.
+/// If strong transients do need to be accurately resolved (unusual for robotics
+/// applications), kSimilar is the preferred approximation.
+///
+/// <h2>References</h2>
+/// - [Castro et al., 2019] Castro A., Qu A., Kuppuswamy N., Alspach A.,
+///   Sherman M, 2019. A Transition-Aware Method for the Simulation of
+///   Compliant Contact with Regularized Friction. Available online at
+///   https://arxiv.org/abs/1909.05700.
+/// - [Castro et al., 2022] Castro A., Permenter F. and Han X., 2022. An
+///   Unconstrained Convex Formulation of Compliant Contact. Available online at
+///   https://arxiv.org/abs/2110.10107.
+/// - [Castro et al., 2023] Castro A., Han X., and Masterjohn J., 2023. A Theory
+///   of Irrotational Contact Fields. Available online at
+///   https://arxiv.org/abs/2312.03908
+enum class DiscreteContactApproximation {
+  /// TAMSI solver approximation, see [Castro et al., 2019].
+  kTamsi,
+  /// SAP solver model approximation, see [Castro et al., 2022].
+  kSap,
+  /// Similarity approximation found in [Castro et al., 2023].
+  kSimilar,
+  /// Approximation in which the normal force is lagged in Coulomb's law, such
+  /// that ‖γₜ‖ ≤ μ γₙ₀, [Castro et al., 2023].
+  kLagged,
+};
+
 /// @cond
 // Helper macro to throw an exception within methods that should not be called
 // post-finalize.
@@ -2136,6 +2198,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void set_contact_model(ContactModel model);
 
   /// Sets the contact solver type used for discrete %MultibodyPlant models.
+  ///
+  /// @note Calling this method also sets a default discrete approximation of
+  /// contact (see set_discrete_contact_approximation()) according to:
+  /// - DiscreteContactSolver::kTamsi sets the approximation to
+  ///   DiscreteContactApproximation::kTamsi.
+  /// - DiscreteContactSolver::kSap sets the approximation to
+  ///   DiscreteContactApproximation::kSap.
+  ///
   /// @warning This function is a no-op for continuous models (when
   /// is_discrete() is false.)
   /// @throws std::exception iff called post-finalize.
@@ -2143,6 +2213,25 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns the contact solver type used for discrete %MultibodyPlant models.
   DiscreteContactSolver get_discrete_contact_solver() const;
+
+  /// Sets the discrete contact model approximation.
+  ///
+  /// @note Calling this method also sets the contact solver type (see
+  /// set_discrete_contact_solver()) according to:
+  /// - DiscreteContactApproximation::kTamsi sets the solver to
+  ///   DiscreteContactSolver::kTamsi.
+  /// - DiscreteContactApproximation::kSap,
+  ///   DiscreteContactApproximation::kSimilar and
+  ///   DiscreteContactApproximation::kLagged set the solver to
+  ///   DiscreteContactSolver::kSap.
+  ///
+  /// @throws iff `this` plant is continuous (i.e. is_discrete() is `false`.)
+  /// @throws std::exception iff called post-finalize.
+  void set_discrete_contact_approximation(
+      DiscreteContactApproximation approximation);
+
+  /// @returns the discrete contact solver approximation.
+  DiscreteContactApproximation get_discrete_contact_approximation() const;
 
   /// Non-negative dimensionless number typically in the range [0.0, 1.0],
   /// though larger values are allowed even if uncommon. This parameter controls
@@ -5679,10 +5768,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // assertions in the cc file that enforce this.
   ContactModel contact_model_{ContactModel::kHydroelasticWithFallback};
 
-  // The solver type used by a discrete plant. Keep this in sync
-  // with the default value in multibody_plant_config.h; there are already
-  // assertions in the cc file that enforce this.
-  DiscreteContactSolver contact_solver_enum_{DiscreteContactSolver::kTamsi};
+  // The contact model approximation used by discrete MultibodyPlant models.
+  DiscreteContactApproximation discrete_contact_approximation_{
+      DiscreteContactApproximation::kTamsi};
 
   // Near rigid regime parameter from [Castro et al., 2021]. Refer to
   // set_near_rigid_threshold() for details.

--- a/multibody/plant/multibody_plant_config.h
+++ b/multibody/plant/multibody_plant_config.h
@@ -20,6 +20,7 @@ struct MultibodyPlantConfig {
     a->Visit(DRAKE_NVP(penetration_allowance));
     a->Visit(DRAKE_NVP(stiction_tolerance));
     a->Visit(DRAKE_NVP(contact_model));
+    a->Visit(DRAKE_NVP(discrete_contact_approximation));
     a->Visit(DRAKE_NVP(discrete_contact_solver));
     a->Visit(DRAKE_NVP(sap_near_rigid_threshold));
     a->Visit(DRAKE_NVP(contact_surface_representation));
@@ -47,12 +48,38 @@ struct MultibodyPlantConfig {
   /// - "hydroelastic_with_fallback"
   std::string contact_model{"hydroelastic_with_fallback"};
 
+  // TODO(amcastro-tri): Deprecate. Use discrete_contact_approximation instead.
   /// Configures the MultibodyPlant::set_discrete_contact_solver().
   /// Refer to drake::multibody::DiscreteContactSolver for details.
   /// Valid strings are:
+  /// - "tamsi", uses the TAMSI model approximation.
+  /// - "sap"  , uses the SAP model approximation.
+  ///
+  /// @warning This option is ignored if discrete_contact_approximation is not
+  /// empty. discrete_contact_approximation is the preferred method to choose
+  /// contact model approximations and thus it has precedence over
+  /// discrete_contact_solver.
+  ///
+  /// @note This config option coordinates with discrete_contact_approximation.
+  /// Using "tamsi" solver has the same effect as setting the
+  /// "tamsi" approximation. Using the "sap" solver has the same effect as
+  /// setting the "sap" approximation.
+  std::string discrete_contact_solver{"tamsi"};
+
+  /// Configures the MultibodyPlant::set_discrete_contact_approximation().
+  /// Refer to drake::multibody::DiscreteContactApproximation for details.
+  /// Valid strings are:
   /// - "tamsi"
   /// - "sap"
-  std::string discrete_contact_solver{"tamsi"};
+  /// - "similar"
+  /// - "lagged"
+  ///
+  /// Refer to MultibodyPlant::set_discrete_contact_approximation() and the
+  /// references therein for further details.
+  ///
+  /// @note For backwards compatibility, an empty string means that the
+  /// approximation is determined by discrete_contact_solver.
+  std::string discrete_contact_approximation{""};
 
   // TODO(amcastro-tri): Change default to zero, or simply eliminate.
   /// Non-negative dimensionless number typically in the range [0.0, 1.0],

--- a/multibody/plant/multibody_plant_config_functions.h
+++ b/multibody/plant/multibody_plant_config_functions.h
@@ -51,6 +51,11 @@ DiscreteContactSolver GetDiscreteContactSolverFromString(
 std::string GetStringFromDiscreteContactSolver(
     DiscreteContactSolver discrete_contact_solver);
 
+DiscreteContactApproximation GetDiscreteContactApproximationFromString(
+    std::string_view discrete_contact_approximation);
+std::string GetStringFromDiscreteContactApproximation(
+    DiscreteContactApproximation discrete_contact_approximation);
+
 // (Exposed for unit testing only.)
 // Parses a string name for a contact representation and returns the enumerated
 // value.  Valid string names are listed in MultibodyPlantConfig's class

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -19,6 +19,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_fixed_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_hunt_crossley_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_limit_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_pd_controller_constraint.h"
 #include "drake/multibody/contact_solvers/sap/sap_solver.h"
@@ -45,6 +46,8 @@ using drake::multibody::contact_solvers::internal::SapDistanceConstraint;
 using drake::multibody::contact_solvers::internal::SapFixedConstraint;
 using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
 using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
+using drake::multibody::contact_solvers::internal::SapHuntCrossleyApproximation;
+using drake::multibody::contact_solvers::internal::SapHuntCrossleyConstraint;
 using drake::multibody::contact_solvers::internal::SapLimitConstraint;
 using drake::multibody::contact_solvers::internal::SapPdControllerConstraint;
 using drake::multibody::contact_solvers::internal::SapSolver;
@@ -195,6 +198,8 @@ template <typename T>
 std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
     const systems::Context<T>& context, SapContactProblem<T>* problem) const {
   DRAKE_DEMAND(problem != nullptr);
+  DRAKE_DEMAND(plant().get_discrete_contact_approximation() !=
+               DiscreteContactApproximation::kTamsi);
 
   // Parameters used by SAP to estimate regularization, see [Castro et al.,
   // 2021].
@@ -218,6 +223,7 @@ std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
 
     const T stiffness = discrete_pair.stiffness;
     const T dissipation_time_scale = discrete_pair.dissipation_time_scale;
+    const T damping = discrete_pair.damping;
     const T friction = discrete_pair.friction_coefficient;
     const ContactConfiguration<T>& configuration =
         contact_kinematics[icontact].configuration;
@@ -231,23 +237,56 @@ std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
     const double beta = (stiffness == std::numeric_limits<double>::infinity())
                             ? 1.0
                             : near_rigid_threshold_;
-    typename SapFrictionConeConstraint<T>::Parameters parameters{
-        friction, stiffness, dissipation_time_scale, beta, sigma};
 
-    // TODO(amcastro-tri): remove this extra copy of R_WC. Contact constraints
-    // store R_WC in their ContactConfiguration.
+    auto make_sap_parameters = [&]() {
+      return typename SapFrictionConeConstraint<T>::Parameters{
+          friction, stiffness, dissipation_time_scale, beta, sigma};
+    };
+
+    auto make_hunt_crossley_parameters = [&]() {
+      const double vs = plant().stiction_tolerance();
+      SapHuntCrossleyApproximation model;
+      switch (plant().get_discrete_contact_approximation()) {
+        case DiscreteContactApproximation::kSimilar:
+          model = SapHuntCrossleyApproximation::kSimilar;
+          break;
+        case DiscreteContactApproximation::kLagged:
+          model = SapHuntCrossleyApproximation::kLagged;
+          break;
+        default:
+          DRAKE_UNREACHABLE();
+      }
+      return typename SapHuntCrossleyConstraint<T>::Parameters{
+          model, friction, stiffness, damping, vs, sigma};
+    };
+
     R_WC.push_back(configuration.R_WC);
+
     if (jacobian_blocks.size() == 1) {
       SapConstraintJacobian<T> J(jacobian_blocks[0].tree,
                                  std::move(jacobian_blocks[0].J));
-      problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
-          configuration, std::move(J), std::move(parameters)));
+      if (plant().get_discrete_contact_approximation() ==
+          DiscreteContactApproximation::kSap) {
+        problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
+            std::move(configuration), std::move(J), make_sap_parameters()));
+      } else {
+        problem->AddConstraint(std::make_unique<SapHuntCrossleyConstraint<T>>(
+            std::move(configuration), std::move(J),
+            make_hunt_crossley_parameters()));
+      }
     } else {
       SapConstraintJacobian<T> J(
           jacobian_blocks[0].tree, std::move(jacobian_blocks[0].J),
           jacobian_blocks[1].tree, std::move(jacobian_blocks[1].J));
-      problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
-          configuration, std::move(J), std::move(parameters)));
+      if (plant().get_discrete_contact_approximation() ==
+          DiscreteContactApproximation::kSap) {
+        problem->AddConstraint(std::make_unique<SapFrictionConeConstraint<T>>(
+            std::move(configuration), std::move(J), make_sap_parameters()));
+      } else {
+        problem->AddConstraint(std::make_unique<SapHuntCrossleyConstraint<T>>(
+            std::move(configuration), std::move(J),
+            make_hunt_crossley_parameters()));
+      }
     }
   }
   return R_WC;

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -4754,6 +4754,63 @@ GTEST_TEST(MultibodyPlantTest, RenameModelInstance) {
                               ".*finalized.*");
 }
 
+// Verify the proper coordination of discrete contact approximations with their
+// corresponding solvers.
+GTEST_TEST(MultibodyPlantTests, DiscreteContactApproximation) {
+  MultibodyPlant<double> plant(0.01);
+
+  auto set_solver_and_check_approximation =
+      [&plant](DiscreteContactSolver solver) {
+        plant.set_discrete_contact_solver(solver);
+        EXPECT_EQ(plant.get_discrete_contact_solver(), solver);
+        if (solver == DiscreteContactSolver::kTamsi) {
+          // TAMSI can only solve the TAMSI approximation.
+          EXPECT_EQ(plant.get_discrete_contact_approximation(),
+                    DiscreteContactApproximation::kTamsi);
+        } else {
+          // SAP can solve all approximations other than TAMSI.
+          EXPECT_EQ(plant.get_discrete_contact_approximation(),
+                    DiscreteContactApproximation::kSap);
+        }
+      };
+
+  auto set_approximation_and_check_solver =
+      [&plant](DiscreteContactApproximation approximation) {
+        plant.set_discrete_contact_approximation(approximation);
+        EXPECT_EQ(plant.get_discrete_contact_approximation(), approximation);
+        if (approximation == DiscreteContactApproximation::kTamsi) {
+          // Only the TAMSI solver can be used with the TAMSI approximation.
+          EXPECT_EQ(plant.get_discrete_contact_solver(),
+                    DiscreteContactSolver::kTamsi);
+        } else {
+          // Approximations other than TAMSI use the SAP solver.
+          EXPECT_EQ(plant.get_discrete_contact_solver(),
+                    DiscreteContactSolver::kSap);
+        }
+      };
+
+  // Verify that setting the solver sets a consistent contact approximation.
+  set_solver_and_check_approximation(DiscreteContactSolver::kTamsi);
+  set_solver_and_check_approximation(DiscreteContactSolver::kSap);
+
+  // Verify that setting an apprximation sets the proper solver.
+  set_solver_and_check_approximation(DiscreteContactSolver::kTamsi);
+  set_approximation_and_check_solver(DiscreteContactApproximation::kSap);
+
+  set_solver_and_check_approximation(DiscreteContactSolver::kTamsi);
+  set_approximation_and_check_solver(DiscreteContactApproximation::kLagged);
+
+  set_solver_and_check_approximation(DiscreteContactSolver::kTamsi);
+  set_approximation_and_check_solver(DiscreteContactApproximation::kSimilar);
+
+  // Post-finalize calls to set_discrete_contact_approximation() throws.
+  plant.Finalize();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.set_discrete_contact_approximation(
+          DiscreteContactApproximation::kTamsi),
+      "Post-finalize calls to '.*' are not allowed; .*");
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/test/sap_driver_contact_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_contact_constraints_test.cc
@@ -1,0 +1,283 @@
+#include <algorithm>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity_properties.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
+#include "drake/multibody/contact_solvers/sap/sap_hunt_crossley_constraint.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/sap_driver.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+
+/* @file This file tests SapDriver's support for contact constraints. */
+
+using drake::geometry::ProximityProperties;
+using drake::math::RigidTransformd;
+using drake::multibody::contact_solvers::internal::ContactConfiguration;
+using drake::multibody::contact_solvers::internal::SapConstraint;
+using drake::multibody::contact_solvers::internal::SapContactProblem;
+using drake::multibody::contact_solvers::internal::SapFrictionConeConstraint;
+using drake::multibody::contact_solvers::internal::SapHuntCrossleyApproximation;
+using drake::multibody::contact_solvers::internal::SapHuntCrossleyConstraint;
+using drake::systems::Context;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+bool operator==(const ContactConfiguration<double>& c1,
+                const ContactConfiguration<double>& c2) {
+  if (c1.objectA != c2.objectA) return false;
+  if (c1.p_ApC_W != c2.p_ApC_W) return false;
+  if (c1.objectB != c2.objectB) return false;
+  if (c1.p_BqC_W != c2.p_BqC_W) return false;
+  if (c1.phi != c2.phi) return false;
+  if (c1.fe != c2.fe) return false;
+  if (c1.vn != c2.vn) return false;
+  if (!c1.R_WC.IsExactlyEqualTo(c2.R_WC)) return false;
+  return true;
+}
+}  // namespace internal
+}  // namespace contact_solvers
+
+namespace internal {
+
+// Friend class used to provide access to a selection of private functions in
+// SapDriver for testing purposes.
+class SapDriverTest {
+ public:
+  static const ContactProblemCache<double>& EvalContactProblemCache(
+      const SapDriver<double>& driver, const Context<double>& context) {
+    return driver.EvalContactProblemCache(context);
+  }
+};
+
+struct TestConfig {
+  // This is a gtest test suffix; no underscores or spaces.
+  std::string description;
+  // Contact model approximation.
+  DiscreteContactApproximation contact_approximation;
+};
+
+// This provides the suffix for each test parameter: the test config
+// description.
+std::ostream& operator<<(std::ostream& out, const TestConfig& c) {
+  out << c.description;
+  return out;
+}
+
+// Fixture that sets a MultibodyPlant model with two bodies A and B in contact.
+// The purpose of this test is to verify that contact constraints are
+// appropiately added by the SapDriver according to the model approximation set
+// in the TestConfig.
+class TwoBodiesTest : public ::testing::TestWithParam<TestConfig> {
+ public:
+  // Makes a model with two spherical bodies A and B in contact.
+  void MakeModel() {
+    systems::DiagramBuilder<double> builder;
+    plant_ =
+        &AddMultibodyPlantSceneGraph(&builder, 0.01 /* Discrete model */).plant;
+    plant_->set_discrete_contact_approximation(
+        GetParam().contact_approximation);
+
+    // Arbitrary inertia values only used by the driver to build a valid contact
+    // problem.
+    const double mass = 1.5;
+    const double radius = 0.1;
+    const SpatialInertia<double> M_BBcm =
+        SpatialInertia<double>::SolidSphereWithMass(mass, radius);
+
+    // Both bodies have the same geometry and proximity properties.
+    const ProximityProperties properties = MakeProximityProperties();
+    const geometry::Sphere shape(kRadius_);
+
+    bodyA_ = &plant_->AddRigidBody("A", M_BBcm);
+    plant_->RegisterCollisionGeometry(*bodyA_, RigidTransformd(), shape,
+                                      "bodyA_collision", properties);
+    bodyB_ = &plant_->AddRigidBody("B", M_BBcm);
+    plant_->RegisterCollisionGeometry(*bodyB_, RigidTransformd(), shape,
+                                      "bodyB_collision", properties);
+
+    plant_->Finalize();
+
+    // Adding the manager programatically gives us access to the manager and the
+    // driver.
+    auto owned_contact_manager =
+        std::make_unique<CompliantContactManager<double>>();
+    manager_ = owned_contact_manager.get();
+    plant_->SetDiscreteUpdateManager(std::move(owned_contact_manager));
+
+    // Build Diagram with MultibodyPlant and SceneGraph connected, and create
+    // context.
+    diagram_ = builder.Build();
+    context_ = diagram_->CreateDefaultContext();
+    plant_context_ = &plant_->GetMyMutableContextFromRoot(context_.get());
+
+    // Set the state so that the spheres are in contact.
+    const RigidTransformd X_WA(Vector3d(0.0, 0.0, 0.0));
+    const RigidTransformd X_WB(
+        Vector3d(2.0 * kRadius_ - kPenetration_, 0.0, 0.0));
+    plant_->SetFreeBodyPose(plant_context_, *bodyA_, X_WA);
+    plant_->SetFreeBodyPose(plant_context_, *bodyB_, X_WB);
+  }
+
+ protected:
+  ProximityProperties MakeProximityProperties() const {
+    ProximityProperties properties;
+    geometry::AddContactMaterial(
+        kHuntCrossleyDissipation_, kStiffness_,
+        CoulombFriction<double>(kFriction_, kFriction_), &properties);
+    properties.AddProperty(geometry::internal::kMaterialGroup,
+                           geometry::internal::kRelaxationTime,
+                           kRelaxationTime_);
+    return properties;
+  }
+
+  const SapDriver<double>& sap_driver() const {
+    return CompliantContactManagerTester::sap_driver(*manager_);
+  }
+
+  DiscreteContactData<ContactPairKinematics<double>> CalcContactKinematics(
+      const Context<double>& context) const {
+    return CompliantContactManagerTester::CalcContactKinematics(*manager_,
+                                                                context);
+  }
+
+  const DiscreteContactData<DiscreteContactPair<double>>&
+  EvalDiscreteContactPairs(const Context<double>& context) const {
+    return CompliantContactManagerTester::EvalDiscreteContactPairs(*manager_,
+                                                                   context);
+  }
+
+  std::unique_ptr<systems::Diagram<double>> diagram_;
+  MultibodyPlant<double>* plant_{nullptr};
+  const RigidBody<double>* bodyA_{nullptr};
+  const RigidBody<double>* bodyB_{nullptr};
+  CompliantContactManager<double>* manager_{nullptr};
+  std::unique_ptr<Context<double>> context_;
+  systems::Context<double>* plant_context_{nullptr};
+
+  // Parameters of the problem.
+  const double kRadius_{0.01};
+  const double kPenetration_{1.0e-3};  // Penetration of the spheres in contact.
+  const double kStiffness_{3.0e4};
+  const double kHuntCrossleyDissipation_{25.0};
+  const double kRelaxationTime_{0.01};
+  const double kFriction_{1.2};
+};
+
+// This test verifies that the SapContactProblem built by the driver is
+// consistent with the contact kinematics computed with CalcContactKinematics().
+TEST_P(TwoBodiesTest, ConfirmContactConstraintProperties) {
+  // const TestConfig& config = GetParam();
+  MakeModel();
+
+  const ContactProblemCache<double>& problem_cache =
+      SapDriverTest::EvalContactProblemCache(sap_driver(), *plant_context_);
+  const SapContactProblem<double>& problem = *problem_cache.sap_problem;
+
+  // Verify the expected number of constraints and equations for a contact.
+  EXPECT_EQ(problem.num_constraints(), 1);
+  EXPECT_EQ(problem.num_constraint_equations(), 3);
+
+  // Verify it is only a single point contact.
+  const DiscreteContactData<DiscreteContactPair<double>>& pairs =
+      EvalDiscreteContactPairs(*plant_context_);
+  EXPECT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.num_point_contacts(), 1);
+  const DiscreteContactData<ContactPairKinematics<double>> contact_kinematics =
+      CalcContactKinematics(*plant_context_);
+  EXPECT_EQ(contact_kinematics.size(), 1);
+  EXPECT_EQ(contact_kinematics.num_point_contacts(), 1);
+
+  const DiscreteContactPair<double>& discrete_pair = pairs[0];
+  const ContactPairKinematics<double>& pair_kinematics = contact_kinematics[0];
+  const SapConstraint<double>& constraint = problem.get_constraint(0);
+
+  // Check Jacobian and number of cliques.
+  ASSERT_EQ(constraint.num_cliques(), 2);  // Two floating bodies.
+  EXPECT_EQ(constraint.first_clique(), pair_kinematics.jacobian[0].tree);
+  EXPECT_EQ(constraint.first_clique_jacobian().MakeDenseMatrix(),
+            pair_kinematics.jacobian[0].J.MakeDenseMatrix());
+  EXPECT_EQ(constraint.second_clique(), pair_kinematics.jacobian[1].tree);
+  EXPECT_EQ(constraint.second_clique_jacobian().MakeDenseMatrix(),
+            pair_kinematics.jacobian[1].J.MakeDenseMatrix());
+
+  const ContactConfiguration<double>& expected_configuration =
+      pair_kinematics.configuration;
+
+  // Verify constraint type, configuration and its parameters.
+  if (GetParam().contact_approximation == DiscreteContactApproximation::kSap) {
+    // Constraint type.
+    const auto* contact_constraint =
+        dynamic_cast<const SapFrictionConeConstraint<double>*>(&constraint);
+    ASSERT_NE(contact_constraint, nullptr);
+    // Configuration.
+    EXPECT_EQ(contact_constraint->configuration(), expected_configuration);
+    // Parameters.
+    EXPECT_EQ(contact_constraint->parameters().mu,
+              discrete_pair.friction_coefficient);
+    EXPECT_EQ(contact_constraint->parameters().stiffness,
+              discrete_pair.stiffness);
+    EXPECT_EQ(contact_constraint->parameters().dissipation_time_scale,
+              discrete_pair.dissipation_time_scale);
+    EXPECT_EQ(contact_constraint->parameters().beta,
+              plant_->get_sap_near_rigid_threshold());
+    // This parameter sigma is for now hard-code in the manager to these value.
+    // Here we simply test they are consistent with those hard-coded values.
+    EXPECT_EQ(contact_constraint->parameters().sigma, 1.0e-3);
+  } else {
+    // Constraint type.
+    const auto* contact_constraint =
+        dynamic_cast<const SapHuntCrossleyConstraint<double>*>(&constraint);
+    ASSERT_NE(contact_constraint, nullptr);
+    // Configuration.
+    EXPECT_EQ(contact_constraint->configuration(), expected_configuration);
+    // Parameters.
+    const SapHuntCrossleyApproximation expected_model =
+        GetParam().contact_approximation ==
+                DiscreteContactApproximation::kLagged
+            ? SapHuntCrossleyApproximation::kLagged
+            : SapHuntCrossleyApproximation::kSimilar;
+    EXPECT_EQ(contact_constraint->parameters().model, expected_model);
+    EXPECT_EQ(contact_constraint->parameters().friction,
+              discrete_pair.friction_coefficient);
+    EXPECT_EQ(contact_constraint->parameters().stiffness,
+              discrete_pair.stiffness);
+    EXPECT_EQ(contact_constraint->parameters().dissipation,
+              discrete_pair.damping);
+    EXPECT_EQ(contact_constraint->parameters().stiction_tolerance,
+              plant_->stiction_tolerance());
+    // This parameter sigma is for now hard-coded in the manager to this value.
+    // Here we simply test it is consistent with that hard-coded value.
+    EXPECT_EQ(contact_constraint->parameters().sigma, 1.0e-3);
+  }
+}
+
+std::vector<TestConfig> MakeTestCases() {
+  return std::vector<TestConfig>{
+      {.description = "SAP",
+       .contact_approximation = DiscreteContactApproximation::kSap},
+      {.description = "Lagged",
+       .contact_approximation = DiscreteContactApproximation::kLagged},
+      {.description = "Similar",
+       .contact_approximation = DiscreteContactApproximation::kSimilar},
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(SapDriverContactConstraintsTests, TwoBodiesTest,
+                         testing::ValuesIn(MakeTestCases()),
+                         testing::PrintToStringParamName());
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Closes #19320.
Towards #19322

In a nutshell, with this PR the `SapDriver` now makes uses of the `SapHuntCrossleyConstraint` (#20635).

To choose among contact model approximations, the users can call:
 - `MultibodyPlant::set_discrete_contact_approximation()` or,
 - Use the `MultibodyPlantConfig::discrete_contact_approximation`

Notice that:
  1. for backwards compatibility, the default approximaiton is `DiscreteContactApproximation::kTamsi`.
  2. The new API to set model approximations is consistent with the API to set discrete solvers.
  3. There are no deprecations in this PR, though depreaction of `MbP::set_discrete_contact_solver()` in the future is a posibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20654)
<!-- Reviewable:end -->
