### PR TITLE
Fix GCS test when running w/ Mosek's MI solver.

### DIFF
--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1905,15 +1905,20 @@ GTEST_TEST(ShortestPathTest, TobiasToyExample) {
   }
 
   // Test that solving with the known shortest path returns the same results.
-  auto active_edges_result = spp.SolveConvexRestriction(
-      spp.GetSolutionPath(*source, *target, result), options);
+  std::vector<const Edge*> path = spp.GetSolutionPath(*source, *target, result);
+  auto active_edges_result = spp.SolveConvexRestriction(path, options);
   ASSERT_TRUE(active_edges_result.is_success());
   // The optimal costs should match.
   EXPECT_NEAR(result.get_optimal_cost(), active_edges_result.get_optimal_cost(),
               3e-5);
-  for (const auto* v : spp.Vertices()) {
-    EXPECT_TRUE(CompareMatrices(result.GetSolution(v->x()),
-                                active_edges_result.GetSolution(v->x()), 2e-3));
+  // The vertex solutions should match on the shortest path.
+  EXPECT_TRUE(CompareMatrices(result.GetSolution(source->x()),
+                              active_edges_result.GetSolution(source->x()),
+                              2e-3));
+  for (const auto* e : path) {
+    EXPECT_TRUE(CompareMatrices(result.GetSolution(e->xv()),
+                                active_edges_result.GetSolution(e->xv()),
+                                2e-3));
   }
 
   // Test that forcing an edge not on the shortest path to be active yields a


### PR DESCRIPTION
Previously this test was checking the convex restriction result with the full MIP result at all vertices. It should have only been checking along the shortest path.

This should avoid the revert in #20651.  
(Closes: #20651)

cc @TobiaMarcucci 
+@jwnimmer-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20657)
<!-- Reviewable:end -->
