### PR TITLE
Improve wheel testing instructions

### DIFF
--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -160,16 +160,36 @@ or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-inter
 to schedule a build of one of the [Wheel](https://drake-jenkins.csail.mit.edu/view/Wheel/)
 jobs with **experimental** in its name.
 
-To download the built wheel, open the Jenkins console log for the completed
-build (click on "Console Output" then "Full Log") and search for the text
-"Upload complete" to find the download URL.  For example:
+To download or install the built wheel, open the Jenkins console log for the
+completed build (click on "Details" for a wheel build in the pull request's
+list of checks, then "Console Output") and search for the text "Artifacts
+uploaded to AWS" to find the download URL (usually about a screen's-worth of
+text above the end of the log).  For example:
 
 ```
 ...
-[12:42:41 PM]  -- Upload complete: https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.2023.4.24.18.52.8%2Bgit51c87b29-cp310-cp310-manylinux_2_31_x86_64.whl
+[12:00:00 AM]  -- Artifacts uploaded to AWS:
+[12:00:00 AM]  https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.1999.1.1.0.0.0%2Bgitffffffff-cp310-cp310-manylinux_2_31_x86_64.whl
 ...
 ```
 
 Note that there might be multiple wheel files uploaded for different versions
 of Python. Be sure to match the Python ``M.NN`` version you will be using to
 the ``-cpMNN-`` substring in the URL.
+
+(In some cases, it may be necessary to click the "Full Log" and search for the
+text "Upload complete", particularly if you wish to also find the checksum
+URLs.)
+
+To download the wheel, simply click the link or use your favorite HTTP
+retrieval tool (e.g. ``wget`` or ``curl``).
+
+Wheels may also be installed locally for testing without downloading the wheel
+as a separate step:
+
+```bash
+python3 -m venv env
+env/bin/pip install --upgrade pip
+env/bin/pip install <url-of-experimental-wheel>
+source env/bin/activate
+```


### PR DESCRIPTION
Update the instructions for how to find the URL of a wheel built as part of a pull request experimental build (the links are now easier to find). Add instructions for how to locally install the wheel.

Fixes #18968.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20661)
<!-- Reviewable:end -->
