### PR TITLE
Toppra::SolvePathParameterization can specify a solver.

### DIFF
--- a/bindings/pydrake/multibody/optimization_py.cc
+++ b/bindings/pydrake/multibody/optimization_py.cc
@@ -192,6 +192,7 @@ PYBIND11_MODULE(optimization, m) {
         .def_static("CalcGridPoints", &Class::CalcGridPoints, py::arg("path"),
             py::arg("options"), cls_doc.CalcGridPoints.doc)
         .def("SolvePathParameterization", &Class::SolvePathParameterization,
+            py::arg("solver_id") = std::nullopt,
             cls_doc.SolvePathParameterization.doc)
         .def("AddJointVelocityLimit", &Class::AddJointVelocityLimit,
             py::arg("lower_limit"), py::arg("upper_limit"),

--- a/bindings/pydrake/multibody/test/optimization_test.py
+++ b/bindings/pydrake/multibody/test/optimization_test.py
@@ -399,5 +399,5 @@ class TestToppra(unittest.TestCase):
         toppra = Toppra(path=path, plant=plant, gridpoints=gridpoints)
 
         toppra.AddJointAccelerationLimit([-1.], [1.])
-        trajectory = toppra.SolvePathParameterization()
+        trajectory = toppra.SolvePathParameterization(solver_id=None)
         self.assertIsInstance(trajectory, PiecewisePolynomial)

--- a/multibody/optimization/toppra.cc
+++ b/multibody/optimization/toppra.cc
@@ -602,14 +602,20 @@ Toppra::ComputeForwardPass(double s_dot_0,
   return std::make_pair(xstar, ustar);
 }
 
-std::optional<PiecewisePolynomial<double>> Toppra::SolvePathParameterization() {
+std::optional<PiecewisePolynomial<double>> Toppra::SolvePathParameterization(
+    const std::optional<solvers::SolverId>& solver_id) {
   const double s_dot_0 = 0;
   const double s_dot_N = 0;
 
   // Clp appears to outperform Mosek for these optimizations.
   // TODO(mpetersen94) Add Gurobi in the correct ordering
-  auto solver = solvers::MakeFirstAvailableSolver(
-      {solvers::ClpSolver::id(), solvers::MosekSolver::id()});
+  std::unique_ptr<solvers::SolverInterface> solver;
+  if (solver_id.has_value()) {
+    solver = solvers::MakeSolver(solver_id.value());
+  } else {
+    solver = solvers::MakeFirstAvailableSolver(
+        {solvers::ClpSolver::id(), solvers::MosekSolver::id()});
+  }
 
   const std::optional<Eigen::Matrix2Xd> K =
       ComputeBackwardPass(s_dot_0, s_dot_N, *solver);

--- a/multibody/optimization/toppra.h
+++ b/multibody/optimization/toppra.h
@@ -112,8 +112,12 @@ class Toppra {
    * generate a time parameterized trajectory.
    * The path parameterization has the same start time as the original path's
    * starting break.
+   *
+   * @param solver_id If not std::nullopt, then we will invoke this solver for
+   * the optimization problem. Otherwise Drake will choose the solver.
    */
-  std::optional<PiecewisePolynomial<double>> SolvePathParameterization();
+  std::optional<PiecewisePolynomial<double>> SolvePathParameterization(
+      const std::optional<solvers::SolverId>& solver_id = std::nullopt);
 
   /**
    * Adds a velocity limit to all the degrees of freedom in the plant. The


### PR DESCRIPTION
I would like to give the user more flexibility to choose the solver, rather than hard-code the solver within Drake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20664)
<!-- Reviewable:end -->
