### PR TITLE
Avoid Diagram pollution when opted-out of LCM

### DIFF
--- a/systems/sensors/camera_config_functions.cc
+++ b/systems/sensors/camera_config_functions.cc
@@ -246,6 +246,10 @@ void ApplyCameraConfig(const CameraConfig& config,
   lcm = FindOrCreateLcmBus(lcm, lcm_buses, builder, "ApplyCameraConfig",
                            config.lcm_bus);
   DRAKE_DEMAND(lcm != nullptr);
+  if (lcm->get_lcm_url() == LcmBuses::kLcmUrlMemqNull) {
+    // The user has opted-out of LCM.
+    return;
+  }
 
   // TODO(jwnimmer-tri) When the Simulator has concurrent update + publish
   // events, it effectively runs the publish event before the update event.

--- a/systems/sensors/test/camera_config_functions_test.cc
+++ b/systems/sensors/test/camera_config_functions_test.cc
@@ -570,6 +570,32 @@ TEST_F(CameraConfigFunctionsTest, BadLcmBus) {
                               ".*non-default.*special_request.*");
 }
 
+// The user can opt-out of LCM, in which case only the camera system is added.
+// LcmBuses object from the argument list.
+TEST_F(CameraConfigFunctionsTest, NullLcmBus) {
+  LcmBuses lcm_buses;
+  DrakeLcm default_lcm(LcmBuses::kLcmUrlMemqNull);
+  lcm_buses.Add("default", &default_lcm);
+
+  // Add the camera (only).
+  const CameraConfig config;
+  ApplyCameraConfig(config, &builder_, &lcm_buses);
+
+  // Check that no LCM-related objects are created.
+  for (const auto* system : builder_.GetSystems()) {
+    const std::string& name = system->get_name();
+    // Allow the MbP basics.
+    if (name == "plant" || name == "scene_graph") {
+      continue;
+    }
+    // Allow the camera itself.
+    if (name == "rgbd_sensor_preview_camera") {
+      continue;
+    }
+    GTEST_FAIL() << name << " should not exist in the diagram";
+  }
+}
+
 // Confirms that the render engine implementation follows the requested type
 // (when supported). We already know that the config gets validated, so we
 // don't need to test cases where an invalid renderer_class value is passed.

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -10,8 +10,6 @@
 namespace drake {
 namespace visualization {
 
-// TODO(jwnimmer-tri or trowell-tri) Add an option to disable LCM entirely.
-
 /** Settings for what MultibodyPlant and SceneGraph should send to Meshcat,
 Meldis, and/or the legacy ``drake_visualizer`` application of days past.
 


### PR DESCRIPTION
Closes #20668.

---

Using this patch to the example demo:

```
--- a/examples/hardware_sim/example_scenarios.yaml
+++ b/examples/hardware_sim/example_scenarios.yaml
@@ -3,6 +3,7 @@
 
 # This demo simulation shows an IIWA arm with an attached WSG gripper.
 Demo:
+  simulation_duration: 0
   directives:
   - add_model:
       name: amazon_table
@@ -46,9 +47,8 @@ Demo:
       parent: wsg_on_iiwa
       child: wsg::body
   lcm_buses:
-    driver_traffic:
-      # Use a non-default LCM url to communicate with the robot.
-      lcm_url: udpm://239.241.129.92:20185?ttl=0
+    default:
+      lcm_url: memq://null
   cameras:
     oracular_view:
       name: camera_0
@@ -56,8 +56,5 @@ Demo:
         translation: [1.5, 0.8, 1.25]
         rotation: !Rpy { deg: [-120, 5, 125] }
   model_drivers:
-    iiwa: !IiwaDriver
-      hand_model_name: wsg
-      lcm_bus: driver_traffic
-    wsg: !SchunkWsgDriver
-      lcm_bus: driver_traffic
+    iiwa: !ZeroForceDriver {}
+    wsg: !ZeroForceDriver {}
```

I end up with this graphviz:

![sim](https://github.com/RobotLocomotion/drake/assets/17596505/807a64db-d56e-485f-a194-d8732a7b8ae5)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20671)
<!-- Reviewable:end -->
