### PR TITLE
Deprecates MultibodyPlant::set_discrete_contact_solver()

### DIFF
--- a/bindings/pydrake/examples/gym/envs/cart_pole.py
+++ b/bindings/pydrake/examples/gym/envs/cart_pole.py
@@ -53,8 +53,8 @@ controller_time_step = 0.01
 gym_time_limit = 5
 drake_contact_models = ['point', 'hydroelastic_with_fallback']
 contact_model = drake_contact_models[0]
-drake_contact_solvers = ['sap', 'tamsi']
-contact_solver = drake_contact_solvers[0]
+drake_contact_approximations = ['sap', 'tamsi', 'similar', 'lagged']
+contact_approximation = drake_contact_approximations[0]
 
 
 def AddAgent(plant):
@@ -77,7 +77,7 @@ def make_sim(meshcat=None,
     multibody_plant_config = MultibodyPlantConfig(
         time_step=sim_time_step,
         contact_model=contact_model,
-        discrete_contact_solver=contact_solver,
+        discrete_contact_approximation=contact_approximation,
         )
 
     plant, scene_graph = AddMultibodyPlant(multibody_plant_config, builder)

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1004,9 +1004,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("set_contact_model", &Class::set_contact_model, py::arg("model"),
             cls_doc.set_contact_model.doc)
         .def("get_contact_model", &Class::get_contact_model,
-            cls_doc.get_contact_model.doc)
-        .def("set_discrete_contact_solver", &Class::set_discrete_contact_solver,
-            py::arg("contact_solver"), cls_doc.set_discrete_contact_solver.doc)
+            cls_doc.get_contact_model.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("set_discrete_contact_solver",
+            WrapDeprecated(cls_doc.set_discrete_contact_solver.doc_deprecated,
+                &Class::set_discrete_contact_solver),
+            py::arg("contact_solver"),
+            cls_doc.set_discrete_contact_solver.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
         .def("get_discrete_contact_solver", &Class::get_discrete_contact_solver,
             cls_doc.get_discrete_contact_solver.doc)
         .def("set_discrete_contact_approximation",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2330,7 +2330,8 @@ class TestPlant(unittest.TestCase):
     def test_coupler_constraint_api(self):
         # Create a MultibodyPlant with only a WSG gripper.
         plant = MultibodyPlant_[float](0.01)
-        plant.set_discrete_contact_solver(DiscreteContactSolver.kSap)
+        plant.set_discrete_contact_approximation(
+            DiscreteContactApproximation.kSap)
         Parser(plant).AddModelsFromUrl(
             "package://drake/manipulation/models/"
             "wsg_50_description/sdf/schunk_wsg_50.sdf")
@@ -2351,7 +2352,8 @@ class TestPlant(unittest.TestCase):
     @numpy_compare.check_all_types
     def test_distance_constraint_api(self, T):
         plant = MultibodyPlant_[T](0.01)
-        plant.set_discrete_contact_solver(DiscreteContactSolver.kSap)
+        plant.set_discrete_contact_approximation(
+            DiscreteContactApproximation.kSap)
 
         # Add a distance constraint. Since we won't be performing dynamics
         # computations, using garbage inertia is ok for this test.
@@ -2372,7 +2374,8 @@ class TestPlant(unittest.TestCase):
     @numpy_compare.check_all_types
     def test_ball_constraint_api(self, T):
         plant = MultibodyPlant_[T](0.01)
-        plant.set_discrete_contact_solver(DiscreteContactSolver.kSap)
+        plant.set_discrete_contact_approximation(
+            DiscreteContactApproximation.kSap)
 
         # Add ball constraint. Since we won't be performing dynamics
         # computations, using garbage inertia is ok for this test.
@@ -2392,7 +2395,8 @@ class TestPlant(unittest.TestCase):
 
     def test_constraint_active_status_api(self):
         plant = MultibodyPlant_[float](0.01)
-        plant.set_discrete_contact_solver(DiscreteContactSolver.kSap)
+        plant.set_discrete_contact_approximation(
+            DiscreteContactApproximation.kSap)
 
         # Since we won't be performing dynamics computations,
         # using garbage inertia is ok for this test.
@@ -2482,7 +2486,8 @@ class TestPlant(unittest.TestCase):
     @numpy_compare.check_all_types
     def test_weld_constraint_api(self, T):
         plant = MultibodyPlant_[T](0.01)
-        plant.set_discrete_contact_solver(DiscreteContactSolver.kSap)
+        plant.set_discrete_contact_approximation(
+            DiscreteContactApproximation.kSap)
 
         # Add weld constraint. Since we won't be performing dynamics
         # computations, using garbage inertia is ok for this test.
@@ -2687,6 +2692,9 @@ class TestPlant(unittest.TestCase):
             plant.set_contact_model(model)
             self.assertEqual(plant.get_contact_model(), model)
 
+    # N.B. MultibodyPlant::set_discrete_contact_solver() is deprecated and will
+    # be removed on or after 2024-04-01. This entire unit test can be removed
+    # entirely with the removal of discrete_contact_solver().
     def test_discrete_contact_solver(self):
         plant = MultibodyPlant_[float](0.1)
         models = [
@@ -2694,10 +2702,9 @@ class TestPlant(unittest.TestCase):
             DiscreteContactSolver.kSap,
         ]
         for model in models:
-            plant.set_discrete_contact_solver(model)
+            with catch_drake_warnings(expected_count=1) as w:
+                plant.set_discrete_contact_solver(model)
             self.assertEqual(plant.get_discrete_contact_solver(), model)
-        plant.get_sap_near_rigid_threshold()
-        plant.set_sap_near_rigid_threshold(near_rigid_threshold=0.03)
 
     def test_discrete_contact_approximation(self):
         plant = MultibodyPlant_[float](0.1)
@@ -2711,6 +2718,9 @@ class TestPlant(unittest.TestCase):
             plant.set_discrete_contact_approximation(approximation)
             self.assertEqual(plant.get_discrete_contact_approximation(),
                              approximation)
+        plant.get_sap_near_rigid_threshold()
+        plant.set_sap_near_rigid_threshold(near_rigid_threshold=0.03)
+        plant.get_discrete_contact_solver()
 
     def test_contact_surface_representation(self):
         for time_step in [0.0, 0.1]:
@@ -3048,7 +3058,8 @@ class TestPlant(unittest.TestCase):
         self.assertEqual(len(registered_models), 1)
         self.assertEqual(registered_models[0].num_bodies(), 1)
         # Turn on SAP and finalize.
-        plant.set_discrete_contact_solver(DiscreteContactSolver.kSap)
+        plant.set_discrete_contact_approximation(
+            DiscreteContactApproximation.kSap)
         plant.Finalize()
 
         # Post-finalize operations.

--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -21,8 +21,9 @@ DEFINE_double(
     "multibody plant modeled as a discrete system. Strictly positive. "
     "Set to zero for a continuous plant model. When using TAMSI, a smaller "
     "time step of 1.0e-3 is recommended.");
-DEFINE_string(discrete_solver, "sap",
-              "Discrete contact solver. Options are: 'tamsi', 'sap'.");
+DEFINE_string(contact_approximation, "sap",
+              "Discrete contact approximation. Options are: 'tamsi', 'sap', "
+              "'similar', 'lagged'");
 
 namespace drake {
 namespace examples {
@@ -47,7 +48,7 @@ int do_main() {
   MultibodyPlantConfig plant_config;
   plant_config.time_step = FLAGS_mbp_discrete_update_period;
   plant_config.stiction_tolerance = FLAGS_stiction_tolerance;
-  plant_config.discrete_contact_solver = FLAGS_discrete_solver;
+  plant_config.discrete_contact_approximation = FLAGS_contact_approximation;
   auto [plant, scene_graph] =
       multibody::AddMultibodyPlant(plant_config, &builder);
 

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -37,8 +37,9 @@ DEFINE_string(contact_model, "hydroelastic",
 DEFINE_string(contact_surface_representation, "polygon",
               "Contact-surface representation for hydroelastics. "
               "Options are: 'triangle' or 'polygon'.");
-DEFINE_string(discrete_solver, "tamsi",
-              "Discrete contact solver. Options are: 'tamsi', 'sap'.");
+DEFINE_string(contact_approximation, "tamsi",
+              "Discrete contact approximation. Options are: 'tamsi', "
+              "'sap', 'similar', 'lagged'");
 
 // Simulator settings.
 DEFINE_double(realtime_rate, 1,
@@ -134,7 +135,7 @@ int DoMain() {
   plant_config.time_step = FLAGS_mbp_discrete_update_period;
   plant_config.stiction_tolerance = FLAGS_stiction_tolerance;
   plant_config.contact_model = FLAGS_contact_model;
-  plant_config.discrete_contact_solver = FLAGS_discrete_solver;
+  plant_config.discrete_contact_approximation = FLAGS_contact_approximation;
   plant_config.contact_surface_representation =
       FLAGS_contact_surface_representation;
 

--- a/examples/multibody/deformable_torus/deformable_torus.cc
+++ b/examples/multibody/deformable_torus/deformable_torus.cc
@@ -156,8 +156,8 @@ int do_main() {
 
   MultibodyPlantConfig plant_config;
   plant_config.time_step = FLAGS_time_step;
-  /* Deformable simulation only works with SAP solver. */
-  plant_config.discrete_contact_solver = "sap";
+  /* Deformable simulation only works with SAP. */
+  plant_config.discrete_contact_approximation = "sap";
 
   auto [plant, scene_graph] = AddMultibodyPlant(plant_config, &builder);
 

--- a/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
+++ b/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
@@ -59,8 +59,9 @@ DEFINE_bool(is_inclined_plane_half_space, true,
             "Is inclined plane a half-space (true) or box (false).");
 DEFINE_string(bodyB_type, "sphere", "Valid body types are "
               "'sphere', 'block', or 'block_with_4Spheres'");
-DEFINE_string(contact_solver, "tamsi", "Options are: "
-              "'tamsi', 'sap'");
+DEFINE_string(contact_approximation, "tamsi",
+              "Discrete contact approximation. Options are: 'tamsi', "
+              "'sap', 'similar', 'lagged'");
 
 using drake::multibody::MultibodyPlant;
 
@@ -71,7 +72,7 @@ int do_main() {
   MultibodyPlantConfig plant_config;
   plant_config.time_step = FLAGS_time_step;
   plant_config.stiction_tolerance = FLAGS_stiction_tolerance;
-  plant_config.discrete_contact_solver = FLAGS_contact_solver;
+  plant_config.discrete_contact_approximation = FLAGS_contact_approximation;
   auto [plant, scene_graph] =
       multibody::AddMultibodyPlant(plant_config, &builder);
 

--- a/examples/multibody/strandbeest/run_with_motor.cc
+++ b/examples/multibody/strandbeest/run_with_motor.cc
@@ -127,8 +127,8 @@ int do_main() {
                               : "package://drake/examples/multibody/"
                                 "strandbeest/model/StrandbeestBushings.urdf");
   if (FLAGS_with_constraints) {
-    strandbeest.set_discrete_contact_solver(
-        drake::multibody::DiscreteContactSolver::kSap);
+    strandbeest.set_discrete_contact_approximation(
+        drake::multibody::DiscreteContactApproximation::kSap);
   }
   Parser parser(&strandbeest);
   parser.AddModelsFromUrl(urdf_url);

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -62,6 +62,12 @@ using CollisionPair = SortedPair<std::string>;
 
 const double kEps = std::numeric_limits<double>::epsilon();
 
+// Fixture to add test coverage for the SDF parser. Some features such as mimic
+// joints and ball constraints are only supported in discrete mode when using
+// the SAP solver. For testing such features, we set a model approximation that
+// uses the SAP solver. More specifically, we call
+// set_discrete_contact_approximation(DiscreteContactApproximation::kSap) on the
+// MultibodyPlant used for testing before parsing.
 class SdfParserTest : public test::DiagnosticPolicyTestBase{
  public:
   SdfParserTest() {
@@ -991,7 +997,7 @@ TEST_F(SdfParserTest, DrakeJointNestedChildBad) {
 }
 
 TEST_F(SdfParserTest, MimicSuccessfulParsing) {
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   ParseTestString(R"""(
     <model name='a'>
       <link name='A'/>
@@ -1031,7 +1037,7 @@ TEST_F(SdfParserTest, MimicSuccessfulParsing) {
 }
 
 TEST_F(SdfParserTest, MimicSuccessfulParsingForwardReference) {
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   ParseTestString(R"""(
     <model name='a'>
       <link name='A'/>
@@ -1071,7 +1077,8 @@ TEST_F(SdfParserTest, MimicSuccessfulParsingForwardReference) {
 }
 
 TEST_F(SdfParserTest, MimicNoSap) {
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kTamsi);
+  plant_.set_discrete_contact_approximation(
+      DiscreteContactApproximation::kTamsi);
   ParseTestString(R"""(
     <model name='a'>
       <link name='A'/>
@@ -1102,7 +1109,7 @@ TEST_F(SdfParserTest, MimicNoSap) {
 }
 
 TEST_F(SdfParserTest, MimicNoJoint) {
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   ParseTestString(R"""(
     <model name='a'>
       <link name='A'/>
@@ -1131,7 +1138,7 @@ TEST_F(SdfParserTest, MimicNoJoint) {
 }
 
 TEST_F(SdfParserTest, MimicBadJoint) {
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   ParseTestString(R"""(
     <model name='a'>
       <link name='A'/>
@@ -1160,7 +1167,7 @@ TEST_F(SdfParserTest, MimicBadJoint) {
 }
 
 TEST_F(SdfParserTest, MimicSameJoint) {
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   ParseTestString(R"""(
     <model name='a'>
       <link name='A'/>
@@ -1181,7 +1188,7 @@ TEST_F(SdfParserTest, MimicSameJoint) {
 }
 
 TEST_F(SdfParserTest, MimicNoMultiplier) {
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   ParseTestString(R"""(
     <model name='a'>
       <link name='A'/>
@@ -1210,7 +1217,7 @@ TEST_F(SdfParserTest, MimicNoMultiplier) {
 }
 
 TEST_F(SdfParserTest, MimicNoOffset) {
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   ParseTestString(R"""(
     <model name='a'>
       <link name='A'/>
@@ -1239,7 +1246,7 @@ TEST_F(SdfParserTest, MimicNoOffset) {
 }
 
 TEST_F(SdfParserTest, MimicOnlyOneDOFJoint) {
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   ParseTestString(R"""(
     <model name='a'>
       <link name='A'/>
@@ -2193,7 +2200,7 @@ TEST_F(SdfParserTest, BallConstraint) {
 
   // TODO(joemasterjohn): Currently ball constraints are only supported in SAP.
   // Add coverage for other solvers and continuous mode when available.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
 
   // Test successful parsing.
   ParseTestString(R"""(
@@ -2235,7 +2242,7 @@ TEST_F(SdfParserTest, BallConstraintMissingBody) {
 
   // TODO(joemasterjohn): Currently ball constraints are only supported in SAP.
   // Add coverage for other solvers and continuous mode when available.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
 
   ParseTestString(R"""(
     <world name='World'>
@@ -2261,7 +2268,7 @@ TEST_F(SdfParserTest, BallConstraintMissingPoint) {
 
   // TODO(joemasterjohn): Currently ball constraints are only supported in SAP.
   // Add coverage for other solvers and continuous mode when available.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
 
   ParseTestString(R"""(
     <world name='World'>
@@ -2287,7 +2294,7 @@ TEST_F(SdfParserTest, BallConstraintNonExistentBody) {
 
   // TODO(joemasterjohn): Currently ball constraints are only supported in SAP.
   // Add coverage for other solvers and continuous mode when available.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
 
   ParseTestString(R"""(
     <world name='World'>

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -42,6 +42,12 @@ using drake::internal::DiagnosticPolicy;
 using geometry::GeometryId;
 using geometry::SceneGraph;
 
+// Fixture to add test coverage for the URDF parser. Some features such as mimic
+// joints and ball constraints are only supported in discrete mode when using
+// the SAP solver. For testing such features, we set a model approximation that
+// uses the SAP solver. More specifically, we call
+// set_discrete_contact_approximation(DiscreteContactApproximation::kSap) on the
+// MultibodyPlant used for testing before parsing.
 class UrdfParserTest : public test::DiagnosticPolicyTestBase {
  public:
   UrdfParserTest() {
@@ -346,7 +352,8 @@ TEST_F(UrdfParserTest, JointTypeUnknown) {
 TEST_F(UrdfParserTest, MimicNoSap) {
   // Currently the <mimic> tag is only supported by SAP. Setting the solver
   // to TAMSI should be a warning.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kTamsi);
+  plant_.set_discrete_contact_approximation(
+      DiscreteContactApproximation::kTamsi);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
@@ -366,7 +373,7 @@ TEST_F(UrdfParserTest, MimicNoSap) {
 
 TEST_F(UrdfParserTest, MimicNoJoint) {
   // Currently the <mimic> tag is only supported by SAP.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
@@ -384,7 +391,7 @@ TEST_F(UrdfParserTest, MimicNoJoint) {
 
 TEST_F(UrdfParserTest, MimicBadJoint) {
   // Currently the <mimic> tag is only supported by SAP.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
@@ -402,7 +409,7 @@ TEST_F(UrdfParserTest, MimicBadJoint) {
 
 TEST_F(UrdfParserTest, MimicSameJoint) {
   // Currently the <mimic> tag is only supported by SAP.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
@@ -420,7 +427,7 @@ TEST_F(UrdfParserTest, MimicSameJoint) {
 
 TEST_F(UrdfParserTest, MimicMismatchedJoint) {
   // Currently the <mimic> tag is only supported by SAP.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
@@ -443,7 +450,7 @@ TEST_F(UrdfParserTest, MimicMismatchedJoint) {
 
 TEST_F(UrdfParserTest, MimicOnlyOneDOFJoint) {
   // Currently the <mimic> tag is only supported by SAP.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
@@ -466,7 +473,7 @@ TEST_F(UrdfParserTest, MimicOnlyOneDOFJoint) {
 
 TEST_F(UrdfParserTest, MimicFloatingJoint) {
   // Currently the <mimic> tag is only supported by SAP.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
@@ -494,7 +501,7 @@ TEST_F(UrdfParserTest, MimicFloatingJoint) {
 // error.
 TEST_F(UrdfParserTest, MimicDifferentModelInstances) {
   // Currently the <mimic> tag is only supported by SAP.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   EXPECT_NE(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
@@ -796,7 +803,7 @@ TEST_F(UrdfParserTest, TestRegisteredSceneGraph) {
 
 TEST_F(UrdfParserTest, JointParsingTest) {
   // We currently need kSap for the mimic element to parse without error.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const std::string full_name = FindResourceOrThrow(
       "drake/multibody/parsing/test/urdf_parser_test/"
       "joint_parsing_test.urdf");
@@ -1506,7 +1513,8 @@ class BallConstraintTest : public UrdfParserTest {
     // TODO(joemasterjohn): Currently ball constraints are only supported in
     // SAP.
     // Add coverage for other solvers and continuous mode when available.
-    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    plant_.set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
   }
 
   void VerifyParameters(const std::string& body_A, const std::string& body_B,

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -295,11 +295,19 @@ MultibodyPlant<T>::MultibodyPlant(double time_step)
   DRAKE_DEMAND(contact_model_ == ContactModel::kHydroelasticWithFallback);
   DRAKE_DEMAND(MultibodyPlantConfig{}.contact_model ==
                "hydroelastic_with_fallback");
-  DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_solver == "tamsi");
-  // By default, MultibodyPlantConfig::discrete_contact_approximation is empty
-  // and therefore the solver determines the contact model.
+  // By default, MultibodyPlantConfig::discrete_contact_approximation and
+  // MultibodyPlantConfig::discrete_contact_solver are empty, indicating that
+  // TAMSI is the default approximation and solver.
+  // TODO(amcastro-tri): Along the removal of
+  // MultibodyPlant::set_discrete_contact_solver() on or after 2024-04-01,
+  // the code below should be updated to:
+  //   DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_approximation ==
+  //     "[approximation]");
+  // with [approximation] the name of the default contact approximation
+  // consistent with MultibodyPlantConfig.
   DRAKE_DEMAND(discrete_contact_approximation_ ==
                DiscreteContactApproximation::kTamsi);
+  DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_solver == "");
   DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_approximation == "");
 }
 
@@ -478,7 +486,8 @@ MultibodyConstraintId MultibodyPlant<T>::AddCouplerConstraint(
     throw std::runtime_error(
         "Currently this MultibodyPlant is set to use the TAMSI solver. TAMSI "
         "does not support coupler constraints. Use "
-        "set_discrete_contact_solver() to set a different solver type.");
+        "set_discrete_contact_approximation() to set a model approximation "
+        "that uses the SAP solver instead (kSap, kSimilar, or kLagged).");
   }
 
   if (joint0.num_velocities() != 1 || joint1.num_velocities() != 1) {
@@ -521,9 +530,8 @@ MultibodyConstraintId MultibodyPlant<T>::AddDistanceConstraint(
     throw std::runtime_error(
         "Currently this MultibodyPlant is set to use the TAMSI solver. TAMSI "
         "does not support distance constraints. Use "
-        "set_discrete_contact_solver(DiscreteContactSolver::kSap) to use the "
-        "SAP solver instead. For other solvers, refer to "
-        "DiscreteContactSolver.");
+        "set_discrete_contact_approximation() to set a model approximation "
+        "that uses the SAP solver instead (kSap, kSimilar, or kLagged).");
   }
 
   const MultibodyConstraintId constraint_id =
@@ -565,9 +573,8 @@ MultibodyConstraintId MultibodyPlant<T>::AddBallConstraint(
     throw std::runtime_error(
         "Currently this MultibodyPlant is set to use the TAMSI solver. TAMSI "
         "does not support ball constraints. Use "
-        "set_discrete_contact_solver(DiscreteContactSolver::kSap) to use the "
-        "SAP solver instead. For other solvers, refer to "
-        "DiscreteContactSolver.");
+        "set_discrete_contact_approximation() to set a model approximation "
+        "that uses the SAP solver instead (kSap, kSimilar, or kLagged).");
   }
 
   const MultibodyConstraintId constraint_id =
@@ -609,9 +616,8 @@ MultibodyConstraintId MultibodyPlant<T>::AddWeldConstraint(
     throw std::runtime_error(
         "Currently this MultibodyPlant is set to use the TAMSI solver. TAMSI "
         "does not support weld constraints. Use "
-        "set_discrete_contact_solver(DiscreteContactSolver::kSap) to use the "
-        "SAP solver instead. For other solvers, refer to "
-        "DiscreteContactSolver.");
+        "set_discrete_contact_approximation() to set a model approximation "
+        "that uses the SAP solver instead (kSap, kSimilar, or kLagged).");
   }
 
   const MultibodyConstraintId constraint_id =

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "drake/common/default_scalars.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/random.h"
 #include "drake/geometry/scene_graph.h"
@@ -663,11 +664,12 @@ the following properties for point contact modeling:
 
 ⁴ We allow to specify both hunt_crossley_dissipation and relaxation_time for a
   given geometry. However only one of these will get used, depending on the
-  configuration of the %MultibodyPlant. As an example, if the SAP solver is
-  specified (see set_discrete_contact_solver()) only the relaxation_time is used
-  while hunt_crossley_dissipation is ignored. Conversely, if the TAMSI solver is
-  used (see set_discrete_contact_solver()) only hunt_crossley_dissipation is
-  used while relaxation_time is ignored. Currently, a continuous %MultibodyPlant
+  configuration of the %MultibodyPlant. As an example, if the SAP contact
+  approximation is specified (see set_discrete_contact_approximation()) only the
+  relaxation_time is used while hunt_crossley_dissipation is ignored.
+  Conversely, if the TAMSI, Similar or Lagged approximation is used (see
+  set_discrete_contact_approximation()) only hunt_crossley_dissipation is used
+  while relaxation_time is ignored. Currently, a continuous %MultibodyPlant
   model will always use the Hunt & Crossley model and relaxation_time will be
   ignored.
 
@@ -1466,12 +1468,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///
   /// Currently constraints are only supported for discrete %MultibodyPlant
   /// models and not for all discrete solvers, see
-  /// set_discrete_contact_solver(). If the model contains constraints not
+  /// get_discrete_contact_solver(). If the model contains constraints not
   /// supported by the discrete solver, the plant will throw an exception at
-  /// Finalize() time. At this point the user has the option to either change
-  /// the contact solver with set_discrete_contact_solver() or in the
-  /// MultibodyPlantConfig, or to re-define the model so that such a constraint
-  /// is not needed.
+  /// Finalize() time. At this point the user has the option to select a contact
+  /// model approximation that uses a solver that supports constraints, or to
+  /// re-define the model so that such a constraint is not needed. A contact
+  /// model approximation can be set with set_discrete_contact_approximation()
+  /// or in the MultibodyPlantConfig.
   ///
   /// Each constraint is identified with a MultibodyConstraintId returned
   /// by the function used to add it (e.g. AddCouplerConstraint()). It is
@@ -2209,6 +2212,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @warning This function is a no-op for continuous models (when
   /// is_discrete() is false.)
   /// @throws std::exception iff called post-finalize.
+  DRAKE_DEPRECATED(
+      "2024-04-01",
+      "Use set_discrete_contact_approximation() to set the contact model "
+      "approximation. The underlying solver will be inferred automatically.")
   void set_discrete_contact_solver(DiscreteContactSolver contact_solver);
 
   /// Returns the contact solver type used for discrete %MultibodyPlant models.

--- a/multibody/plant/multibody_plant_config.h
+++ b/multibody/plant/multibody_plant_config.h
@@ -48,24 +48,29 @@ struct MultibodyPlantConfig {
   /// - "hydroelastic_with_fallback"
   std::string contact_model{"hydroelastic_with_fallback"};
 
-  // TODO(amcastro-tri): Deprecate. Use discrete_contact_approximation instead.
   /// Configures the MultibodyPlant::set_discrete_contact_solver().
   /// Refer to drake::multibody::DiscreteContactSolver for details.
   /// Valid strings are:
   /// - "tamsi", uses the TAMSI model approximation.
   /// - "sap"  , uses the SAP model approximation.
   ///
-  /// @warning This option is ignored if discrete_contact_approximation is not
-  /// empty. discrete_contact_approximation is the preferred method to choose
-  /// contact model approximations and thus it has precedence over
-  /// discrete_contact_solver.
+  /// @note If empty, the contact solver is determined by
+  /// discrete_contact_approximation, see
+  /// MultibodyPlant::set_discrete_contact_approximation(). If both
+  /// discrete_contact_solver and discrete_contact_approximation are empty, the
+  /// default model (and solver) is TAMSI.
   ///
-  /// @note This config option coordinates with discrete_contact_approximation.
-  /// Using "tamsi" solver has the same effect as setting the
-  /// "tamsi" approximation. Using the "sap" solver has the same effect as
-  /// setting the "sap" approximation.
-  std::string discrete_contact_solver{"tamsi"};
+  /// @warning discrete_contact_solver is deprecated.
+  /// Use discrete_contact_approximation to set the contact model approximation.
+  /// The underlying solver will be inferred automatically. The deprecated code
+  /// will be removed from Drake on or after 2024-04-01.
+  std::string discrete_contact_solver{""};
 
+  // TODO(amcastro-tri): Along the removal of discrete_contact_solver on or
+  // after 2024-04-01, update the default value of
+  // discrete_contact_approximation to be non-empty. The value will be either
+  // "similar" or "lagged", to be decided based on the information we collect
+  // from our users.
   /// Configures the MultibodyPlant::set_discrete_contact_approximation().
   /// Refer to drake::multibody::DiscreteContactApproximation for details.
   /// Valid strings are:
@@ -77,8 +82,10 @@ struct MultibodyPlantConfig {
   /// Refer to MultibodyPlant::set_discrete_contact_approximation() and the
   /// references therein for further details.
   ///
-  /// @note For backwards compatibility, an empty string means that the
-  /// approximation is determined by discrete_contact_solver.
+  /// @note If empty, the contact approximation is determined by
+  /// discrete_contact_solver, see set_discrete_contact_solver(). If both
+  /// discrete_contact_solver and discrete_contact_approximation are empty, the
+  /// default model (and solver) is TAMSI.
   std::string discrete_contact_approximation{""};
 
   // TODO(amcastro-tri): Change default to zero, or simply eliminate.

--- a/multibody/plant/multibody_plant_config_functions.cc
+++ b/multibody/plant/multibody_plant_config_functions.cc
@@ -14,6 +14,15 @@ using AddResult = AddMultibodyPlantSceneGraphResult<double>;
 AddResult AddMultibodyPlant(const MultibodyPlantConfig& config,
                             systems::DiagramBuilder<double>* builder) {
   AddResult result = AddMultibodyPlantSceneGraph(builder, config.time_step);
+  // Sanity check that MultibodyPlant defaults match the MultibodyPlantConfig
+  // defaults.
+  if (result.plant.is_discrete()) {
+    DRAKE_DEMAND(result.plant.get_discrete_contact_approximation() ==
+                 DiscreteContactApproximation::kTamsi);
+    DRAKE_DEMAND(result.plant.get_discrete_contact_solver() ==
+                 DiscreteContactSolver::kTamsi);
+  }
+
   ApplyMultibodyPlantConfig(config, &result.plant);
   return result;
 }
@@ -27,17 +36,42 @@ void ApplyMultibodyPlantConfig(const MultibodyPlantConfig& config,
   plant->set_stiction_tolerance(config.stiction_tolerance);
   plant->set_contact_model(
       internal::GetContactModelFromString(config.contact_model));
-  if (config.discrete_contact_approximation.empty()) {
-    // Solver is respected.
-    plant->set_discrete_contact_solver(
-        internal::GetDiscreteContactSolverFromString(
-            config.discrete_contact_solver));
-  } else {
-    // Contact model determines the solver to be used. Therefore
-    // discrete_contact_solver is ignored.
-    plant->set_discrete_contact_approximation(
-        internal::GetDiscreteContactApproximationFromString(
-            config.discrete_contact_approximation));
+  // Only one of these can be non-empty at a time.
+  if (!config.discrete_contact_solver.empty() &&
+      !config.discrete_contact_approximation.empty()) {
+    throw std::logic_error(
+        "In a MultibodyPlantConfig, only one of discrete_contact_solver and "
+        "discrete_contact_approximation can be non-empty at a time.");
+  }
+  if (plant->is_discrete()) {
+    if (!config.discrete_contact_solver.empty()) {
+      // discrete_contact_approximation is empty, therefore
+      // discrete_contact_solver determines both model approximation and solver.
+      static const drake::internal::WarnDeprecated warn_once(
+          "2024-04-01",
+          "Use MultibodyPlantConfig::discrete_contact_approximation instead of "
+          "MultibodyPlantConfig::discrete_contact_solver.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+      // Until its removal, discrete_contact_solver has precedence over
+      // discrete_contact_approximation.
+      plant->set_discrete_contact_solver(
+          internal::GetDiscreteContactSolverFromString(
+              config.discrete_contact_solver));
+#pragma GCC diagnostic pop
+    } else if (!config.discrete_contact_approximation.empty()) {
+      // discrete_contact_solver is empty, therefore
+      // discrete_contact_approximation determines both model approximation and
+      // solver.
+      plant->set_discrete_contact_approximation(
+          internal::GetDiscreteContactApproximationFromString(
+              config.discrete_contact_approximation));
+    } else {
+      // Both discrete_contact_approximation and discrete_contact_solver are
+      // empty. Default to TAMSI.
+      plant->set_discrete_contact_approximation(
+          DiscreteContactApproximation::kTamsi);
+    }
   }
   plant->set_sap_near_rigid_threshold(config.sap_near_rigid_threshold);
   plant->set_contact_surface_representation(

--- a/multibody/plant/test/actuated_models_test.cc
+++ b/multibody/plant/test/actuated_models_test.cc
@@ -58,12 +58,12 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
   };
 
   // Sets a model with PD controllers as specified by `model_config`. The
-  // MultibodyPlant model is discrete and uses the SAP solver by default, but
-  // this can be changed with `config`.
+  // MultibodyPlant model is discrete and uses the SAP model approximation by
+  // default, but this can be changed with `config`.
   void SetUpModel(
       ModelConfiguration model_config = ModelConfiguration::kArmIsNotControlled,
       const MultibodyPlantConfig& config = MultibodyPlantConfig{
-          .time_step = 0.01, .discrete_contact_solver = "sap"}) {
+          .time_step = 0.01, .discrete_contact_approximation = "sap"}) {
     const char kArmSdfPath[] =
         "drake/manipulation/models/iiwa_description/iiwa7/"
         "iiwa7_no_collision.sdf";
@@ -649,7 +649,7 @@ TEST_F(ActuatedIiiwaArmTest,
        ActuationOutputForDiscreteNonSapModelsFeedsThroughActuationInput) {
   SetUpModel(ModelConfiguration::kNoPdControl,
              MultibodyPlantConfig{.time_step = 0.01,
-                                  .discrete_contact_solver = "tamsi"});
+                                  .discrete_contact_approximation = "tamsi"});
   VerifyActuationOutputFeedsThroughActuationInputs();
 }
 
@@ -659,7 +659,7 @@ TEST_F(ActuatedIiiwaArmTest,
        ActuationOutputForDiscreteSapModelsFeedsThroughActuationInput) {
   SetUpModel(ModelConfiguration::kNoPdControl,
              MultibodyPlantConfig{.time_step = 0.01,
-                                  .discrete_contact_solver = "sap"});
+                                  .discrete_contact_approximation = "sap"});
   VerifyActuationOutputFeedsThroughActuationInputs();
 }
 

--- a/multibody/plant/test/compliant_contact_manager_scalar_conversion_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_scalar_conversion_test.cc
@@ -52,12 +52,25 @@ TYPED_TEST(CompliantContactManagerScalarConversionTest, ToSymbolic) {
 constexpr double kTimeStep = 0.001;
 
 // Constructs a plant with a free rigid body and uses the SAP solver.
+// The argument `solver_type` allows to exercise the TAMSI and SAP solver
+// pipelines.
 template <typename T>
 std::unique_ptr<MultibodyPlant<T>> MakePlant(
     DiscreteContactSolver solver_type) {
   auto plant = std::make_unique<MultibodyPlant<T>>(kTimeStep);
   plant->AddRigidBody("Body", SpatialInertia<double>::MakeUnitary());
-  plant->set_discrete_contact_solver(solver_type);
+  // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
+  // arbitrarily choose two model approximations to accomplish this.
+  switch (solver_type) {
+    case DiscreteContactSolver::kTamsi:
+      plant->set_discrete_contact_approximation(
+          DiscreteContactApproximation::kTamsi);
+      break;
+    case DiscreteContactSolver::kSap:
+      plant->set_discrete_contact_approximation(
+          DiscreteContactApproximation::kSap);
+      break;
+  }
   plant->Finalize();
   return plant;
 }

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -91,8 +91,10 @@ GTEST_TEST(CompliantContactManagerTest, ExtractModelInfo) {
   MultibodyPlant<double> plant(0.01);
   auto deformable_model = std::make_unique<DeformableModel<double>>(&plant);
   plant.AddPhysicalModel(std::move(deformable_model));
-  // N.B. Currently the manager only supports SAP.
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  // N.B. Deformables are only supported with the SAP solver.
+  // Thus for testing we choose one arbitrary contact approximation that uses
+  // the SAP solver.
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   plant.Finalize();
   auto contact_manager = std::make_unique<CompliantContactManager<double>>();
   const CompliantContactManager<double>* contact_manager_ptr =

--- a/multibody/plant/test/deformable_boundary_condition_test.cc
+++ b/multibody/plant/test/deformable_boundary_condition_test.cc
@@ -59,7 +59,11 @@ class DeformableIntegrationTest : public ::testing::Test {
     deformable_model->SetWallBoundaryCondition(body_id_, p_WQ_, n_W_);
     model_ = deformable_model.get();
     plant_->AddPhysicalModel(std::move(deformable_model));
-    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    // N.B. Deformables are only supported with the SAP solver.
+    // Thus for testing we choose one arbitrary contact approximation that uses
+    // the SAP solver.
+    plant_->set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
 
     /* Register a visual geometry for the "wall". */
     constexpr double box_height = 0.4;

--- a/multibody/plant/test/deformable_collision_filter_test.cc
+++ b/multibody/plant/test/deformable_collision_filter_test.cc
@@ -39,7 +39,11 @@ class DeformableCollisionFilterTest : public ::testing::Test {
         deformable_model->GetGeometryId(deformable_body_id);
     model_ = deformable_model.get();
     plant_->AddPhysicalModel(std::move(deformable_model));
-    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    // N.B. Deformables are only supported with the SAP solver.
+    // Thus for testing we choose one arbitrary contact approximation that uses
+    // the SAP solver.
+    plant_->set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
 
     /* Register a rigid body welded to the world. */
     ProximityProperties proximity_prop;

--- a/multibody/plant/test/deformable_contact_results_test.cc
+++ b/multibody/plant/test/deformable_contact_results_test.cc
@@ -24,7 +24,7 @@ GTEST_TEST(CompliantContactManagerTest, ContactResultsWithDeformable) {
 
   MultibodyPlantConfig plant_config;
   plant_config.time_step = 1.0e-3;
-  plant_config.discrete_contact_solver = "sap";
+  plant_config.discrete_contact_approximation = "sap";
   auto [plant, scene_graph] = AddMultibodyPlant(plant_config, &builder);
 
   /* Add a hydro ground weld to the world*/

--- a/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
@@ -142,7 +142,11 @@ class DeformableDriverContactKinematicsTest
                                  X_WF_, geometry::Box(10, 10, 1), X_BR);
     }
 
-    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    // N.B. Deformables are only supported with the SAP solver.
+    // Thus for testing we choose one arbitrary contact approximation that uses
+    // the SAP solver.
+    plant_->set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
     plant_->Finalize();
     auto contact_manager = make_unique<CompliantContactManager<double>>();
     manager_ = contact_manager.get();
@@ -430,7 +434,10 @@ GTEST_TEST(DeformableDriverContactKinematicsWithBcTest,
       plant.world_body(), X_WR, geometry::Box(10, 10, 1),
       "static_collision_geometry", rigid_proximity_props);
 
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  // N.B. Deformables are only supported with the SAP solver.
+  // Thus for testing we choose one arbitrary contact approximation that uses
+  // the SAP solver.
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   plant.Finalize();
   auto contact_manager = make_unique<CompliantContactManager<double>>();
   const CompliantContactManager<double>* manager = contact_manager.get();
@@ -486,7 +493,10 @@ GTEST_TEST(DeformableDriverConstraintParticipation, ConstraintWithoutContact) {
   model->AddFixedConstraint(
       body_id, plant.world_body(), RigidTransformd::Identity(),
       geometry::Box(10, 10, 10), RigidTransformd::Identity());
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  // N.B. Deformables are only supported with the SAP solver.
+  // Thus for testing we choose one arbitrary contact approximation that uses
+  // the SAP solver.
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   plant.Finalize();
   auto contact_manager = make_unique<CompliantContactManager<double>>();
   const CompliantContactManager<double>* manager = contact_manager.get();

--- a/multibody/plant/test/deformable_driver_contact_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_test.cc
@@ -62,8 +62,13 @@ class DeformableDriverContactTest : public ::testing::Test {
                                              "deformable1");
     model_ = deformable_model.get();
     plant_->AddPhysicalModel(std::move(deformable_model));
-    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
-    /* Register the rigid box intersecting with both deformable octahedrons. */
+    // N.B. Deformables are only supported with the SAP solver.
+    // Thus for testing we choose one arbitrary contact approximation that uses
+    // the SAP solver.
+    plant_->set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
+    /* Register a rigid collision geometry intersecting with the bottom half of
+     the deformable octahedrons. */
     geometry::ProximityProperties proximity_prop;
     geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
                                  &proximity_prop);

--- a/multibody/plant/test/deformable_driver_test.cc
+++ b/multibody/plant/test/deformable_driver_test.cc
@@ -38,8 +38,11 @@ class DeformableDriverTest : public ::testing::Test {
     plant_->AddPhysicalModel(std::move(deformable_model));
     const RigidBody<double>& body = plant_->AddRigidBody(
         "rigid_body", SpatialInertia<double>::SolidSphereWithMass(1.0, 1.0));
-    // N.B. Currently the manager only supports SAP.
-    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    // N.B. Deformables are only supported with the SAP solver.
+    // Thus for testing we choose one arbitrary contact approximation that uses
+    // the SAP solver.
+    plant_->set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
     plant_->Finalize();
     auto contact_manager = make_unique<CompliantContactManager<double>>();
     manager_ = contact_manager.get();

--- a/multibody/plant/test/deformable_fixed_constraint_test.cc
+++ b/multibody/plant/test/deformable_fixed_constraint_test.cc
@@ -73,7 +73,7 @@ class DeformableFixedConstraintTest : public ::testing::Test {
     systems::DiagramBuilder<double> builder;
     MultibodyPlantConfig plant_config;
     plant_config.time_step = kDt;
-    plant_config.discrete_contact_solver = "sap";
+    plant_config.discrete_contact_approximation = "sap";
     std::tie(plant_, scene_graph_) = AddMultibodyPlant(plant_config, &builder);
 
     auto deformable_model = make_unique<DeformableModel<double>>(plant_);

--- a/multibody/plant/test/deformable_integration_test.cc
+++ b/multibody/plant/test/deformable_integration_test.cc
@@ -68,7 +68,11 @@ class DeformableIntegrationTest : public ::testing::Test {
         RegisterDeformableOctahedron(deformable_model.get(), "deformable");
     model_ = deformable_model.get();
     plant_->AddPhysicalModel(std::move(deformable_model));
-    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    // N.B. Deformables are only supported with the SAP solver.
+    // Thus for testing we choose one arbitrary contact approximation that uses
+    // the SAP solver.
+    plant_->set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
 
     /* Register a rigid geometry that serves as an inclined plane. */
     ProximityProperties proximity_prop;

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -289,12 +289,13 @@ class AlgebraicLoopDetection
  public:
   // Makes a system containing a multibody plant. When with_algebraic_loop =
   // true the model includes a feedback system that creates an algebraic loop.
-  void MakeDiagram(bool with_algebraic_loop, std::string_view solver_type) {
+  void MakeDiagram(bool with_algebraic_loop,
+                   std::string_view contact_approximation) {
     systems::DiagramBuilder<double> builder;
 
     MultibodyPlantConfig plant_config;
     plant_config.time_step = 1.0e-3;
-    plant_config.discrete_contact_solver = solver_type;
+    plant_config.discrete_contact_approximation = contact_approximation;
     std::tie(plant_, scene_graph_) =
         multibody::AddMultibodyPlant(plant_config, &builder);
     plant_->Finalize();
@@ -363,10 +364,12 @@ INSTANTIATE_TEST_SUITE_P(AlgebraicLoopTests, AlgebraicLoopDetection,
                          ::testing::Combine(::testing::Bool(),
                                             ::testing::Values("tamsi", "sap")));
 
+// N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
+// arbitrarily choose two model approximations to accomplish this.
 TEST_P(AlgebraicLoopDetection, LoopDetectionTest) {
-  const auto& [with_algebraic_loop, solver_type] = GetParam();
+  const auto& [with_algebraic_loop, contact_approximation] = GetParam();
 
-  MakeDiagram(with_algebraic_loop, solver_type);
+  MakeDiagram(with_algebraic_loop, contact_approximation);
   if (with_algebraic_loop) {
     VerifyLoopIsDetected();
   } else {
@@ -384,9 +387,9 @@ TEST_P(AlgebraicLoopDetection, LoopDetectionTest) {
 }
 
 TEST_P(AlgebraicLoopDetection, LoopDetectionTestWhenCachingIsDisabled) {
-  const auto& [with_algebraic_loop, solver_type] = GetParam();
+  const auto& [with_algebraic_loop, contact_approximation] = GetParam();
 
-  MakeDiagram(with_algebraic_loop, solver_type);
+  MakeDiagram(with_algebraic_loop, contact_approximation);
   diagram_context_->DisableCaching();
 
   if (with_algebraic_loop) {

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -328,7 +328,18 @@ class TrajectoryTest : public ::testing::TestWithParam<TrajectoryTestConfig> {
       bool weld_elbow, DiscreteContactSolver solver) {
     std::unique_ptr<MultibodyPlant<double>> plant;
     plant = std::make_unique<MultibodyPlant<double>>(kTimestep);
-    plant->set_discrete_contact_solver(solver);
+    // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
+    // arbitrarily choose two model approximations to accomplish this.
+    switch (solver) {
+      case DiscreteContactSolver::kTamsi:
+        plant->set_discrete_contact_approximation(
+            DiscreteContactApproximation::kTamsi);
+        break;
+      case DiscreteContactSolver::kSap:
+        plant->set_discrete_contact_approximation(
+            DiscreteContactApproximation::kSap);
+        break;
+    }
 
     const RigidBody<double>& body1 =
         plant->AddRigidBody("upper_arm", SpatialInertia<double>::MakeUnitary());
@@ -486,7 +497,18 @@ class FilteredContactResultsTest
     systems::DiagramBuilder<double> builder;
     plant_ = &AddMultibodyPlantSceneGraph(&builder, 0.01 /* time_step */).plant;
     plant_->set_contact_model(config.contact_model);
-    plant_->set_discrete_contact_solver(config.solver);
+    // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
+    // arbitrarily choose two model approximations to accomplish this.
+    switch (config.solver) {
+      case DiscreteContactSolver::kTamsi:
+        plant_->set_discrete_contact_approximation(
+            DiscreteContactApproximation::kTamsi);
+        break;
+      case DiscreteContactSolver::kSap:
+        plant_->set_discrete_contact_approximation(
+            DiscreteContactApproximation::kSap);
+        break;
+    }
 
     const RigidBody<double>& ball_A = AddBall("ball_A");
     const RigidBody<double>& ball_B = AddBall("ball_B");

--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -134,7 +134,20 @@ class LadderTest : public ::testing::TestWithParam<LadderTestConfig> {
     plant_->mutable_gravity_field().set_gravity_vector(
         Vector3d(0.0, 0.0, -kGravity));
 
-    plant_->set_discrete_contact_solver(config.contact_solver);
+    if (plant_->is_discrete()) {
+      // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
+      // arbitrarily choose two model approximations to accomplish this.
+      switch (config.contact_solver) {
+        case DiscreteContactSolver::kTamsi:
+          plant_->set_discrete_contact_approximation(
+              DiscreteContactApproximation::kTamsi);
+          break;
+        case DiscreteContactSolver::kSap:
+          plant_->set_discrete_contact_approximation(
+              DiscreteContactApproximation::kSap);
+          break;
+      }
+    }
 
     plant_->Finalize();
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3873,7 +3873,9 @@ GTEST_TEST(MultibodyPlantTest, AutoDiffAcrobotParameters) {
 GTEST_TEST(MultibodyPlantTests, ConstraintActiveStatus) {
   // Set up a plant with 3 constraints with arbitrary parameters.
   MultibodyPlant<double> plant(0.01);
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  // N.B. This feature is only supported by the SAP solver. Therefore we
+  // arbitrarily choose one model approximation that uses the SAP solver.
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const Body<double>& body_A =
       plant.AddRigidBody("body_A", SpatialInertia<double>{});
   const Body<double>& body_B =
@@ -4761,7 +4763,10 @@ GTEST_TEST(MultibodyPlantTests, DiscreteContactApproximation) {
 
   auto set_solver_and_check_approximation =
       [&plant](DiscreteContactSolver solver) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         plant.set_discrete_contact_solver(solver);
+#pragma GCC diagnostic pop
         EXPECT_EQ(plant.get_discrete_contact_solver(), solver);
         if (solver == DiscreteContactSolver::kTamsi) {
           // TAMSI can only solve the TAMSI approximation.

--- a/multibody/plant/test/sap_driver_ball_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_ball_constraints_test.cc
@@ -12,7 +12,13 @@
 #include "drake/multibody/plant/sap_driver.h"
 #include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
 
-/* @file This file tests SapDriver's support for ball constraints. */
+/* @file This file tests SapDriver's support for ball constraints.
+
+  Constraints are only supported by the SAP solver. Therefore, to exercise the
+  relevant code paths, we arbitrarily choose one contact approximation that uses
+  the SAP solver. More precisely, in the unit tests below we call
+  set_discrete_contact_approximation(DiscreteContactApproximation::kSap) on the
+  MultibodyPlant used for testing, before constraints are added. */
 
 using drake::math::RigidTransformd;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
@@ -59,7 +65,8 @@ class TwoBodiesTest : public ::testing::TestWithParam<TestConfig> {
   // @param[in] anchor_bodyA If true, body A will be anchored to the world.
   // Otherwise body A has 6 DOFs as body B does.
   void MakeModel(bool anchor_bodyA) {
-    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    plant_.set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
 
     // Arbitrary inertia values only used by the driver to build a valid contact
     // problem.
@@ -231,7 +238,7 @@ INSTANTIATE_TEST_SUITE_P(SapBallConstraintTests, TwoBodiesTest,
 
 GTEST_TEST(BallConstraintsTests, VerifyIdMapping) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =
@@ -273,7 +280,8 @@ GTEST_TEST(BallConstraintsTests, VerifyIdMapping) {
 
 GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kTamsi);
+  plant.set_discrete_contact_approximation(
+      DiscreteContactApproximation::kTamsi);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =
@@ -298,7 +306,7 @@ GTEST_TEST(BallConstraintTests, FailOnContinuous) {
 
 GTEST_TEST(BallConstraintTests, FailOnFinalized) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =
@@ -312,7 +320,7 @@ GTEST_TEST(BallConstraintTests, FailOnFinalized) {
 
 GTEST_TEST(BallConstraintTests, FailOnSameBody) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   DRAKE_EXPECT_THROWS_MESSAGE(

--- a/multibody/plant/test/sap_driver_distance_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_distance_constraints_test.cc
@@ -13,7 +13,13 @@
 #include "drake/multibody/plant/sap_driver.h"
 #include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
 
-/* @file This file tests SapDriver's support for distance constraints. */
+/* @file This file tests SapDriver's support for distance constraints.
+
+  Constraints are only supported by the SAP solver. Therefore, to exercise the
+  relevant code paths, we arbitrarily choose one contact approximation that uses
+  the SAP solver. More precisely, in the unit tests below we call
+  set_discrete_contact_approximation(DiscreteContactApproximation::kSap) on the
+  MultibodyPlant used for testing, before constraints are added. */
 
 using drake::math::RigidTransformd;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
@@ -64,7 +70,8 @@ class TwoBodiesTest : public ::testing::TestWithParam<TestConfig> {
   // MultibodyPlant::AddDistanceConstraint() defaults for a hard constraint with
   // no dissipation.
   void MakeModel(bool anchor_bodyA, bool use_hard_constraint_defaults) {
-    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    plant_.set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
 
     // Arbitrary inertia values only used by the driver to build a valid contact
     // problem.
@@ -233,7 +240,7 @@ INSTANTIATE_TEST_SUITE_P(SapDistanceConstraintTests, TwoBodiesTest,
 
 GTEST_TEST(DistanceConstraintsTests, VerifyIdMapping) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =
@@ -279,7 +286,8 @@ GTEST_TEST(DistanceConstraintsTests, VerifyIdMapping) {
 
 GTEST_TEST(DistanceConstraintTests, FailOnTAMSI) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kTamsi);
+  plant.set_discrete_contact_approximation(
+      DiscreteContactApproximation::kTamsi);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =
@@ -305,7 +313,7 @@ GTEST_TEST(DistanceConstraintTests, FailOnContinuous) {
 
 GTEST_TEST(DistanceConstraintTests, FailOnFinalized) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =
@@ -320,7 +328,7 @@ GTEST_TEST(DistanceConstraintTests, FailOnFinalized) {
 
 GTEST_TEST(DistanceConstraintTests, FailOnInvalidSpecs) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -18,7 +18,13 @@
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 
-/* @file This file tests SapDriver's support for joint limits. */
+/* @file This file tests SapDriver's support for joint limits.
+
+  Constraints are only supported by the SAP solver. Therefore, to exercise the
+  relevant code paths, we arbitrarily choose one contact approximation that uses
+  the SAP solver. More precisely, in the unit tests below we call
+  set_discrete_contact_approximation(DiscreteContactApproximation::kSap) on the
+  MultibodyPlant used for testing, before constraints are added. */
 
 using drake::multibody::contact_solvers::internal::ContactSolverResults;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
@@ -87,7 +93,8 @@ class KukaIiwaArmTests : public ::testing::Test {
   // arbitrary non-zero values.
   void SetSingleRobotModel() {
     // Only SAP supports the modeling of constraints.
-    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    plant_.set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
 
     // Load robot model from files.
     const std::vector<ModelInstanceIndex> models = SetUpArmModel(&plant_);
@@ -533,7 +540,7 @@ TEST_F(KukaIiwaArmTests, LimitConstraints) {
 // the coupler constraints specified in the MultibodyPlant model.
 TEST_F(KukaIiwaArmTests, CouplerConstraints) {
   // Only SAP supports the modeling of constraints.
-  plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
 
   // Load two robot models.
   std::vector<ModelInstanceIndex> arm_gripper1 = SetUpArmModel(&plant_);

--- a/multibody/plant/test/sap_driver_multidof_joints_test.cc
+++ b/multibody/plant/test/sap_driver_multidof_joints_test.cc
@@ -10,7 +10,13 @@
 #include "drake/multibody/tree/space_xyz_mobilizer.h"
 
 /* @file This file provides testing for the SapDriver's limited support for
-joint limits on joints with multiple degrees of freedom. */
+joint limits on joints with multiple degrees of freedom.
+
+    Constraints are only supported by the SAP solver. Therefore, to exercise the
+  relevant code paths, we arbitrarily choose one contact approximation that uses
+  the SAP solver. More precisely, in the unit tests below we call
+  set_discrete_contact_approximation(DiscreteContactApproximation::kSap) on the
+  MultibodyPlant used for testing, before constraints are added. */
 
 using drake::multibody::contact_solvers::internal::SapContactProblem;
 using drake::systems::Context;
@@ -141,7 +147,7 @@ class MultiDofJointWithLimits final : public Joint<T> {
 GTEST_TEST(MultiDofJointWithLimitsTest, ThrowForUnsupportedJoints) {
   MultibodyPlant<double> plant(1.0e-3);
   // N.B. Currently only SAP goes through the manager.
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   // To avoid unnecessary warnings/errors, use a non-zero spatial inertia.
   const RigidBody<double>& body =
       plant.AddRigidBody("DummyBody", SpatialInertia<double>::MakeUnitary());
@@ -176,7 +182,7 @@ GTEST_TEST(MultiDofJointWithLimitsTest,
            VerifyMultiDofJointsWithoutLimitsAreSupported) {
   MultibodyPlant<double> plant(1.0e-3);
   // N.B. Currently only SAP goes through the manager.
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   // To avoid unnecessary warnings/errors, use a non-zero spatial inertia.
   const RigidBody<double>& body =
       plant.AddRigidBody("DummyBody", SpatialInertia<double>::MakeUnitary());

--- a/multibody/plant/test/sap_driver_pd_controller_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_pd_controller_constraints_test.cc
@@ -12,7 +12,13 @@
 #include "drake/multibody/plant/sap_driver.h"
 #include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
 
-/* @file This file tests SapDriver's support for PD controller constraints. */
+/* @file This file tests SapDriver's support for PD controller constraints.
+
+  Constraints are only supported by the SAP solver. Therefore, to exercise the
+  relevant code paths, we arbitrarily choose one contact approximation that uses
+  the SAP solver. More precisely, in the unit tests below we call
+  set_discrete_contact_approximation(DiscreteContactApproximation::kSap) on the
+  MultibodyPlant used for testing, before constraints are added. */
 
 using drake::math::RigidTransformd;
 using drake::multibody::Parser;
@@ -72,7 +78,8 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
     plant_ = std::make_unique<MultibodyPlant<double>>(0.01 /* update period */);
     // Use the SAP solver. Thus far only SAP support the modeling of PD
     // controllers.
-    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    plant_->set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
 
     Parser parser(plant_.get());
 

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -376,7 +376,11 @@ TEST_F(SpheresStackTest, EvalContactSolverResults) {
 // recalculates the cached SapContactProblem with constraint parameters change.
 GTEST_TEST(SapDriverTest, ConstraintActiveStatus) {
   MultibodyPlant<double> plant(0.01);
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+
+  // Constraints are only supported by the SAP solver. Therefore, to exercise
+  // the relevant code paths, we arbitrarily choose one contact approximation
+  // that uses the SAP solver.
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
 
   // Add two bodies and two joints in order to cover all constraint types.
   // We aren't doing any physics in this test, just checking that constraint

--- a/multibody/plant/test/sap_driver_weld_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_weld_constraints_test.cc
@@ -14,7 +14,13 @@
 #include "drake/multibody/plant/sap_driver.h"
 #include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
 
-/* @file This file tests SapDriver's support for weld constraints. */
+/* @file This file tests SapDriver's support for weld constraints.
+
+  Constraints are only supported by the SAP solver. Therefore, to exercise the
+  relevant code paths, we arbitrarily choose one contact approximation that uses
+  the SAP solver. More precisely, in the unit tests below we call
+  set_discrete_contact_approximation(DiscreteContactApproximation::kSap) on the
+  MultibodyPlant used for testing, before constraints are added. */
 
 using drake::math::RigidTransformd;
 using drake::math::RotationMatrixd;
@@ -67,7 +73,8 @@ class TwoBodiesTest : public ::testing::TestWithParam<TestConfig> {
   // @param[in] anchor_bodyA If true, body A will be anchored to the world.
   // Otherwise body A has 6 DOFs as body B does.
   void MakeModel(bool anchor_bodyA) {
-    plant_.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    plant_.set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
 
     // Arbitrary inertia values only used by the driver to build a valid contact
     // problem.
@@ -270,7 +277,7 @@ INSTANTIATE_TEST_SUITE_P(SapWeldConstraintTests, TwoBodiesTest,
 
 GTEST_TEST(WeldConstraintsTests, VerifyIdMapping) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =
@@ -312,7 +319,8 @@ GTEST_TEST(WeldConstraintsTests, VerifyIdMapping) {
 
 GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kTamsi);
+  plant.set_discrete_contact_approximation(
+      DiscreteContactApproximation::kTamsi);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =
@@ -337,7 +345,7 @@ GTEST_TEST(WeldConstraintTests, FailOnContinuous) {
 
 GTEST_TEST(WeldConstraintTests, FailOnFinalized) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   const RigidBody<double>& bodyB =
@@ -351,7 +359,7 @@ GTEST_TEST(WeldConstraintTests, FailOnFinalized) {
 
 GTEST_TEST(WeldConstraintTests, FailOnSameBody) {
   MultibodyPlant<double> plant{0.1};
-  plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
   const RigidBody<double>& bodyA =
       plant.AddRigidBody("A", SpatialInertia<double>{});
   DRAKE_EXPECT_THROWS_MESSAGE(

--- a/multibody/plant/test/spheres_stack.h
+++ b/multibody/plant/test/spheres_stack.h
@@ -42,6 +42,10 @@ static constexpr double nan() {
 // on top the first sphere. They are assigned to be rigid-hydroelastic,
 // compliant-hydroelastic, or non-hydroelastic to test various cases of
 // contact quantities computed by the CompliantContactManager.
+//
+// N.B. This testing class only exercises the SapDriver code paths. In
+// particular, it uses the DiscreteContactApproximation::kSap contact model
+// approximation.
 class SpheresStack {
  public:
   // Contact model parameters.
@@ -117,8 +121,8 @@ class SpheresStack {
     systems::DiagramBuilder<double> builder;
     std::tie(plant_, scene_graph_) =
         AddMultibodyPlantSceneGraph(&builder, time_step_);
-    // N.B. Currently only SAP goes through the manager.
-    plant_->set_discrete_contact_solver(DiscreteContactSolver::kSap);
+    plant_->set_discrete_contact_approximation(
+        DiscreteContactApproximation::kSap);
 
     // Add model of the ground.
     if (ground_params) {

--- a/multibody/plant/test_utilities/rigid_body_on_compliant_ground.h
+++ b/multibody/plant/test_utilities/rigid_body_on_compliant_ground.h
@@ -44,6 +44,7 @@ struct ContactTestConfig {
   // testing of cases using the hydroelastic contact model, whether point
   // contact is used or not.
   ContactModel contact_model{ContactModel::kHydroelasticWithFallback};
+  // Option that allows to exercise the TAMSI and SAP solver code paths
   DiscreteContactSolver contact_solver{DiscreteContactSolver::kTamsi};
 };
 
@@ -54,13 +55,12 @@ std::ostream& operator<<(std::ostream& out, const ContactTestConfig& c) {
   return out;
 }
 
-// The purpose of this fixture is to verify the implementation of TamsiDriver's
-// CalcContactSolverResults(). In this regard this is more of an integration
-// test where the correctness of the results rely on the ability of the driver
-// to properly setup a contact problem for TAMSI using MultibodyPlant (for
+// The purpose of this fixture is to unit test the implementation of TamsiDriver
+// and SapDriver's contact computations. In this regard this is more of an
+// integration test where the correctness of the results rely on the ability of
+// the driver to properly setup a contact problem using MultibodyPlant (for
 // kinematics and dynamics) and CompliantContactManager's services (for
-// contact), and solve it with TAMSI. MultibodyPlant, CompliantContactManager
-// and TamsiSolver are tested elsewhere.
+// contact), and solve it with the corresponding solver.
 class RigidBodyOnCompliantGround
     : public ::testing::TestWithParam<ContactTestConfig> {
  public:
@@ -76,7 +76,18 @@ class RigidBodyOnCompliantGround
     DiagramBuilder<double> builder;
     auto items = AddMultibodyPlantSceneGraph(&builder, kTimeStep_);
     plant_ = &items.plant;
-    plant_->set_discrete_contact_solver(config.contact_solver);
+    // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
+    // arbitrarily choose two model approximations to accomplish this.
+    switch (config.contact_solver) {
+      case DiscreteContactSolver::kTamsi:
+        plant_->set_discrete_contact_approximation(
+            DiscreteContactApproximation::kTamsi);
+        break;
+      case DiscreteContactSolver::kSap:
+        plant_->set_discrete_contact_approximation(
+            DiscreteContactApproximation::kSap);
+        break;
+    }
 
     // We change the default gravity magnitude so that numbers are simpler to
     // work with.

--- a/tutorials/hydroelastic_contact_basics.ipynb
+++ b/tutorials/hydroelastic_contact_basics.ipynb
@@ -215,7 +215,7 @@
     "\n",
     "We set `<drake:mu_dynamic>` (unitless) to 0.5 for the coefficient of dynamic (i.e., kinetic) friction.\n",
     "\n",
-    "We set `<drake:hunt_crossley_dissipation>` to 1.25 seconds/meter as the dissipation constant for TAMSI contact solver. In the future, SAP will support the Hunt & Crossley dissipation model too. See issue [19320](https://github.com/RobotLocomotion/drake/issues/19320). Intuitively the bouncing speed (speed when the box bounces back) is bounded by the inverse of the Hunt & Crossley dissipation constant. Here we set it to 1.25 s/m, so the bouncing speed is at most 0.8 m/s. See [Contact Modeling](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html#mbp_contact_modeling) in [MultibodyPlant](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html) documentation for more details."
+    "We set `<drake:hunt_crossley_dissipation>` to 1.25 seconds/meter as the dissipation constant for the Hunt & Crossley model."
    ]
   },
   {
@@ -482,12 +482,12 @@
     "    meshcat.Delete()\n",
     "    meshcat.DeleteAddedControls()\n",
     "\n",
-    "def add_scene(time_step=1e-3, solver=\"tamsi\"):\n",
+    "def add_scene(time_step=1e-3, contact_approximation=\"tamsi\"):\n",
     "    builder = DiagramBuilder()\n",
     "    plant, scene_graph = AddMultibodyPlant(\n",
     "        MultibodyPlantConfig(\n",
     "            time_step=time_step,\n",
-    "            discrete_contact_solver=solver),\n",
+    "            discrete_contact_approximation=contact_approximation),\n",
     "        builder)\n",
     "    parser = Parser(plant)\n",
     "\n",
@@ -577,10 +577,10 @@
    "source": [
     "from pydrake.systems.analysis import Simulator\n",
     "\n",
-    "def run_simulation(sim_time, time_step=1e-3, solver=\"tamsi\"):\n",
+    "def run_simulation(sim_time, time_step=1e-3, contact_approximation=\"tamsi\"):\n",
     "    clear_meshcat()\n",
     "    \n",
-    "    builder, plant = add_scene(time_step, solver)\n",
+    "    builder, plant = add_scene(time_step, contact_approximation)\n",
     "    add_viz(builder, plant)\n",
     "    \n",
     "    diagram = builder.Build()\n",
@@ -744,10 +744,10 @@
    "source": [
     "from pydrake.systems.analysis import Simulator\n",
     "\n",
-    "def run_simulation_with_contact_report(sim_time, time_step=1e-3, solver=\"tamsi\"):\n",
+    "def run_simulation_with_contact_report(sim_time, time_step=1e-3, contact_approximation=\"tamsi\"):\n",
     "    clear_meshcat()\n",
     "    \n",
-    "    builder, plant = add_scene(time_step, solver)\n",
+    "    builder, plant = add_scene(time_step, contact_approximation)\n",
     "    add_viz(builder, plant)\n",
     "    add_contact_report(builder, plant)\n",
     "    \n",
@@ -861,10 +861,10 @@
    "source": [
     "from pydrake.systems.analysis import Simulator\n",
     "\n",
-    "def run_simulation_with_contact_report_and_viz(sim_time, time_step=1e-3, solver=\"tamsi\"):\n",
+    "def run_simulation_with_contact_report_and_viz(sim_time, time_step=1e-3, contact_approximation=\"tamsi\"):\n",
     "    clear_meshcat()\n",
     "    \n",
-    "    builder, plant = add_scene(time_step, solver)\n",
+    "    builder, plant = add_scene(time_step, contact_approximation)\n",
     "    add_viz(builder, plant)\n",
     "    add_contact_report(builder, plant)\n",
     "    add_contact_viz(builder, plant)\n",


### PR DESCRIPTION
Follow up to PR #20654 to deprecate `MultibodyPlant::set_discrete_contact_solver()` in favor of `MultibodyPlant::set_discrete_contact_approximation()`.
The deprecation includes deprecation of `MultibodPlantConfig.discrete_contact_solver`.

Instead of choosing a solvers, users now must choose a discrete contact approximation. The solver is inferred from the approximation. Users can select an approximation with MultibodyPlant::set_discrete_contact_approximation() or via MultibodyPlantConfig::discrete_contact_approximation.

Do not merge label applied for coordination with Anzu.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20672)
<!-- Reviewable:end -->
