### PR TITLE
Check ConvexSet::IsBounded first in MaybeCalcAxisAlignedBoundingBox

### DIFF
--- a/geometry/optimization/hyperrectangle.cc
+++ b/geometry/optimization/hyperrectangle.cc
@@ -42,6 +42,9 @@ Hyperrectangle::Hyperrectangle(const Eigen::Ref<const Eigen::VectorXd>& lb,
 
 std::optional<Hyperrectangle> Hyperrectangle::MaybeCalcAxisAlignedBoundingBox(
     const ConvexSet& set) {
+  if (!set.IsBounded()) {
+    return std::nullopt;
+  }
   solvers::MathematicalProgram prog;
   int n = set.ambient_dimension();
   auto point = prog.NewContinuousVariables(n);

--- a/geometry/optimization/test/hyperrectangle_test.cc
+++ b/geometry/optimization/test/hyperrectangle_test.cc
@@ -262,6 +262,13 @@ GTEST_TEST(HyperrectangleTest, AxisAlignedBoundingBox) {
   }
 }
 
+GTEST_TEST(HyperrectangleTest, UnboundedEllipsoid) {
+  // Zero matrix in hyperellipsoid is unbounded.
+  Hyperellipsoid H(Eigen::MatrixXd::Zero(2, 2), Eigen::VectorXd::Zero(2));
+  const auto aabb = Hyperrectangle::MaybeCalcAxisAlignedBoundingBox(H);
+  EXPECT_FALSE(aabb.has_value());
+}
+
 GTEST_TEST(HyperrectangleTest, Serialize) {
   const Vector3d lb{-1, -2, -3};
   const Vector3d ub{3, 2, 1};


### PR DESCRIPTION
Closes https://github.com/RobotLocomotion/drake/issues/20667 by calling `ConvexSet::IsBounded` instead of solely relying on mathematical optimization, for which some solvers behave badly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20680)
<!-- Reviewable:end -->
