### PR TITLE
Update stale MultibodyPlant contact docs

### DIFF
--- a/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
+++ b/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
@@ -215,8 +215,15 @@ each of the properties and then discuss how they can be specified.
   - Notes on choosing a value:
     - For objects that are nominally rigid, starting with zero-damping is good.
     - If the behavior seems “jittery”, gradually increase the amount of
-      dissipation. Typical values would remain in the range [0, 3] with 1 being
-      a typical damping amount.
+      dissipation. Typical values would remain in the range [0, 100] with 10 to
+      50 being a typical damping amount.
+    - The inverse of the Hunt-Crossley dissipation is the maximum bounce
+      velocity between two objects. Therefore, if maximum bounce velocities of
+      10 cm/s are acceptable, a dissipation of 10 s/m will keep bounce
+      velocities bounded to this range.
+    - Warning: values larger than about 500 s/m are unphysical and typically
+      lead to numerical problems. Due to time discretization errors, the user
+      will see objects that take a long time to go back to their rest state.
     - Remember, as this value increases, your simulation will lose energy at a
       higher rate.
   - See @ref mbp_dissipation_model "Modeling Dissipation" for details.
@@ -610,16 +617,22 @@ indicate what can and cannot be done with hydroelastic contact.
 
 @subsection hug_dissipation_and_solver Current dissipation models
 
-- SAP does not support Hunt-Crossley dissipation at this time for both
-  point and hydroelastic contact
-  (issue [19320](https://github.com/RobotLocomotion/drake/issues/19320)).
-  See the documentation for that in the
-  [MultibodyPlant documentation.]
+- The TAMSI (DiscreteContactApproximation::kTamsi), Similar
+  (DiscreteContactApproximation::kSimilar), and Lagged
+  (DiscreteContactApproximation::kLagged) model approximations use a
+  Hunt-Crossley model of dissipation, parameterized by
+  `hunt_crossley_dissipation`, for both point and hydroelastic contact. The SAP
+  approximation parameter `relaxation_time` is ignored by these approximations.
+- The SAP model approximation (DiscreteContactApproximation::kSap) uses a linear
+  Kelvin–Voigt model of dissipation parameterized by `relaxation_time`, for both
+  point and hydroelastic contact. The Hunt-Crossley dissipation parameter is
+  ignored by this approximation.
+- We allow the user to specify both `hunt_crossley_dissipation` (TAMSI, Similar
+  and Lagged discrete approximations as well as continuous plant model) and
+  `relaxation_time` (SAP approximation specific parameter) on the model, but the
+  parameter may be ignored depending on your plant configuration. See the
+  documentation for that in the [MultibodyPlant documentation.]
   (https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html#:~:text=%E2%81%B4%20We%20allow%20to,will%20be%20ignored.)
-  We allow the user to specify both hunt_crossley_dissipation (TAMSI and
-  continuous mode parameter) and relaxation_time (SAP specific parameter) on
-  the model, but the parameter may be ignored depending on your plant
-  configuration.
 
 @section hydro_appendix_examples_and_tutorials Appendix C: Examples and Tutorials
 - Example

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -752,7 +752,7 @@ If present, this element provides a stiffness value (units of N/m) for point
 contact calculations for this specific geometry. It is stored in a
 ProximityProperties object under `(material, point_contact_stiffness)`.
 
-@see @ref accessing_contact_properties, @ref mbp_penalty_method,
+@see @ref accessing_contact_properties, @ref mbp_compliant_point_contact,
 drake::geometry::ProximityProperties
 
 @subsection tag_drake_proximity_properties drake:proximity_properties

--- a/multibody/plant/contact_model_doxygen.h
+++ b/multibody/plant/contact_model_doxygen.h
@@ -199,7 +199,7 @@ Next topic: @ref contact_engineering
    2. Global parameters controlling the stiffness of normal penalty forces.
       @ref drake::multibody::MultibodyPlant "MultibodyPlant" offers a single
       global parameter, the "penetration allowance", described in detail in
-      section @ref mbp_penalty_method "Contact by penalty method".
+      section @ref mbp_compliant_point_contact "Compliant point contact model".
    3. Global parameter controlling the Stribeck approximation of Coulomb
       friction, refer to section @ref stribeck_approximation for details.
       @ref drake::multibody::MultibodyPlant::set_stiction_tolerance()


### PR DESCRIPTION
This PR updates stale contact documentation in `@anchor mbp_contact_modeling` in MultibodyPlant. 
With the new hydroelatic guide and contact solver these docs lagged behind.

We should definitely still do a more hollistic pass to update this section, the hydro guide and "Contact Modeling in Drake" Doxygen module. Some information is either repeated across these three or even slightly contradictory.
This is NOT the purpose of this PR.

This PR simply focuses on making  sure `@anchor mbp_contact_modeling`  is no longer a lie, providing a quick read for those setting contact parameters, with links to the more detailed discussions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20682)
<!-- Reviewable:end -->
