### PR TITLE
Change how linux-only tests get built

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -973,6 +973,7 @@ def drake_cc_googletest_linux_only(
             "@drake//tools/skylark:linux": linkopts,
             "//conditions:default": [],
         }),
+        alwayslink = True,
         visibility = ["//visibility:private"],
     )
 


### PR DESCRIPTION
It appears that if we have a .cc file that declares unit tests (e.g., using TEST_F), if we build it into a library against @gtest//:without_main, the actual tests get omitted.

This tweaks the set up slightly so that if we're on linux, the test declaration uses the .cc file directly and links with drake's default gtest main function.

(Incidentally fixes a typo.)

relates to #20576

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20689)
<!-- Reviewable:end -->
