### PR TITLE
Correct window sizing in RenderEngineGl

### DIFF
--- a/geometry/render_gl/internal_opengl_context.cc
+++ b/geometry/render_gl/internal_opengl_context.cc
@@ -231,7 +231,8 @@ class OpenGlContext::Impl {
   void DisplayWindow(const int width, const int height) {
     if (width != window_width_ || height != window_height_) {
       XResizeWindow(display(), window_, width, height);
-      WaitForExposeEvent();
+      // If the window isn't viewable, it won't send an expose event.
+      if (IsWindowViewable()) WaitForExposeEvent();
       window_width_ = width;
       window_height_ = height;
     }
@@ -302,13 +303,13 @@ class OpenGlContext::Impl {
 
   // The associated window to support display of rendering results.
   Window window_;
-  // The window's current size. We default it to an arbitrary 640x480.
-  // XCreateWindow (called in the constructor) has undocumented behavior for
-  // zero-area windows, or even very small windows (causing the constructor to
-  // fail or hang). Empirically, 640x480 allows things to work. The reason is
+  // The window's current size. We default it to an arbitrary 10x10 (a size a
+  // user is unlikely to call). XCreateWindow (called in the constructor) has
+  // undocumented behavior for zero-area windows, causing the constructor to
+  // fail or hang. Empirically, 10x10 allows things to work. The reason is
   // not yet understood.
-  int window_width_{640};
-  int window_height_{480};
+  int window_width_{10};
+  int window_height_{10};
 
   const bool debug_{};
 };

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -955,7 +955,7 @@ def drake_cc_googletest_linux_only(
     private.
     """
 
-    # We need add the source file to an intermediate cc_library so that our
+    # We need to add the source file to an intermediate cc_library so that our
     # linters will find it. The library will not be compiled on non-Linux.
     srcs = ["test/{}.cc".format(name)]
     drake_cc_library(
@@ -986,11 +986,14 @@ def drake_cc_googletest_linux_only(
     )
     drake_cc_googletest(
         name = name,
-        srcs = ["_{}_empty.h".format(name)],
+        srcs = select({
+            "@drake//tools/skylark:linux": srcs,
+            "//conditions:default": ["_{}_empty.h".format(name)],
+        }),
         tags = tags + ["nolint"],
         data = data,
         deps = select({
-            "@drake//tools/skylark:linux": [":_{}_compile".format(name)],
+            "@drake//tools/skylark:linux": deps,
             "//conditions:default": [],
         }),
         visibility = visibility,


### PR DESCRIPTION
If a `RenderEngineGl` is asked to render and *display* an image that didn't match the default window size in the `OpenGlContext`, it would hang.

This is because the resizing would wait for xwindows to provide an expose event. However, if the window isn't visible yet (i.e., it's being resized before being made visible), there won't be such an event. This leads to the process hanging, waiting for an event that will never come.

We've changed the context's default window size. The test on the `OpenGlContext` is sufficient to test the expected outcome.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20694)
<!-- Reviewable:end -->
