### PR TITLE
[yaml] Fix output spelling of negative infinity

### DIFF
--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -60,7 +60,7 @@ TEST_F(YamlWriteArchiveTest, Double) {
   // See https://yaml.org/spec/1.2.2/#10214-floating-point for the specs.
   test(std::numeric_limits<double>::quiet_NaN(), ".nan");
   test(std::numeric_limits<double>::infinity(), ".inf");
-  test(-std::numeric_limits<double>::infinity(), ".-inf");
+  test(-std::numeric_limits<double>::infinity(), "-.inf");
 }
 
 TEST_F(YamlWriteArchiveTest, String) {

--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -182,7 +182,7 @@ void WriteJson(std::ostream& os, const internal::Node& node) {
           os << "Infinity";
           return;
         }
-        if (scalar == ".-inf") {
+        if (scalar == "-.inf") {
           os << "-Infinity";
           return;
         }

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -219,9 +219,11 @@ class YamlWriteArchive final {
     using T = typename NVP::value_type;
     const T& value = *nvp.value();
     if constexpr (std::is_floating_point_v<T>) {
-      // We must be sure to add the required leading period for special values.
-      auto scalar = internal::Node::MakeScalar(fmt::format(
-          "{}{}", std::isfinite(value) ? "" : ".", fmt_floating_point(value)));
+      std::string value_str = std::isfinite(value) ? fmt_floating_point(value)
+                              : std::isnan(value)  ? ".nan"
+                              : (value > 0)        ? ".inf"
+                                                   : "-.inf";
+      auto scalar = internal::Node::MakeScalar(std::move(value_str));
       scalar.SetTag(internal::JsonSchemaTag::kFloat);
       root_.Add(nvp.name(), std::move(scalar));
       return;


### PR DESCRIPTION
Per the [YAML specification](https://yaml.org/spec/1.2.2/#10214-floating-point), the negative sign should precede the dot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20719)
<!-- Reviewable:end -->
