### PR TITLE
Implements MultibodyPlant::RemoveConstraint

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -285,7 +285,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py_rvp::reference_internal, cls_doc.AddBallConstraint.doc)
         .def("AddWeldConstraint", &Class::AddWeldConstraint, py::arg("body_A"),
             py::arg("X_AP"), py::arg("body_B"), py::arg("X_BQ"),
-            py_rvp::reference_internal, cls_doc.AddWeldConstraint.doc);
+            py_rvp::reference_internal, cls_doc.AddWeldConstraint.doc)
+        .def("RemoveConstraint", &Class::RemoveConstraint, py::arg("id"),
+            cls_doc.RemoveConstraint.doc);
     // Mathy bits
     cls  // BR
         .def(

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2506,6 +2506,30 @@ class TestPlant(unittest.TestCase):
         self.assertEqual(plant.num_constraints(), 1)
 
     @numpy_compare.check_all_types
+    def test_remove_constraint(self, T):
+        plant = MultibodyPlant_[T](0.01)
+        plant.set_discrete_contact_approximation(
+            DiscreteContactApproximation.kSap)
+
+        # Add weld constraint. Since we won't be performing dynamics
+        # computations, using garbage inertia is ok for this test.
+        M = SpatialInertia_[float]()
+        body_A = plant.AddRigidBody(name="A", M_BBo_B=M)
+        body_B = plant.AddRigidBody(name="B", M_BBo_B=M)
+        X_AP = RigidTransform_[float]()
+        X_BQ = RigidTransform_[float]()
+        id = plant.AddWeldConstraint(
+            body_A=body_A, X_AP=X_AP, body_B=body_B, X_BQ=X_BQ)
+
+        plant.RemoveConstraint(id=id)
+
+        # We are done creating the model.
+        plant.Finalize()
+
+        # Verify no constraint was added.
+        self.assertEqual(plant.num_constraints(), 0)
+
+    @numpy_compare.check_all_types
     def test_multibody_dynamics(self, T):
         MultibodyPlant = MultibodyPlant_[T]
         MultibodyForces = MultibodyForces_[T]

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -640,6 +640,26 @@ MultibodyConstraintId MultibodyPlant<T>::AddWeldConstraint(
 }
 
 template <typename T>
+void MultibodyPlant<T>::RemoveConstraint(MultibodyConstraintId id) {
+  // N.B. The manager and parameters are set up at Finalize() and therefore we
+  // must require constraints to be removed pre-finalize.
+  DRAKE_MBP_THROW_IF_FINALIZED();
+
+  int num_removed = 0;
+  num_removed += coupler_constraints_specs_.erase(id);
+  num_removed += distance_constraints_specs_.erase(id);
+  num_removed += ball_constraints_specs_.erase(id);
+  num_removed += weld_constraints_specs_.erase(id);
+  if (num_removed != 1) {
+    throw std::runtime_error(fmt::format(
+        "RemoveConstraint(): The constraint id {} does not match "
+        "any constraint registered with this plant. Note that this method does "
+        "not check constraints registered with DeformableModel.",
+        id));
+  }
+}
+
+template <typename T>
 std::string MultibodyPlant<T>::GetTopologyGraphvizString() const {
   std::string graphviz = "digraph MultibodyPlant {\n";
   graphviz += "label=\"" + this->get_name() + "\";\n";
@@ -684,6 +704,13 @@ void MultibodyPlant<T>::set_discrete_contact_solver(
   DRAKE_MBP_THROW_IF_FINALIZED();
   switch (contact_solver) {
     case DiscreteContactSolver::kTamsi:
+      if (num_constraints() > 0) {
+        throw std::runtime_error(fmt::format(
+            "You selected TAMSI as the solver, but you have constraints "
+            "registered with this model (num_constraints() == {}). TAMSI does "
+            "not support constraints.",
+            num_constraints()));
+      }
       discrete_contact_approximation_ = DiscreteContactApproximation::kTamsi;
       break;
     case DiscreteContactSolver::kSap:
@@ -706,6 +733,16 @@ void MultibodyPlant<T>::set_discrete_contact_approximation(
     DiscreteContactApproximation approximation) {
   DRAKE_MBP_THROW_IF_FINALIZED();
   DRAKE_THROW_UNLESS(is_discrete());
+
+  if (approximation == DiscreteContactApproximation::kTamsi &&
+      num_constraints() > 0) {
+    throw std::runtime_error(fmt::format(
+        "You selected TAMSI as the contact approximation, but you have "
+        "constraints registered with this model (num_constraints() == {}). "
+        "TAMSI does not support constraints.",
+        num_constraints()));
+  }
+
   discrete_contact_approximation_ = approximation;
 }
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1716,6 +1716,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Body<T>& body_A, const math::RigidTransform<double>& X_AP,
       const Body<T>& body_B, const math::RigidTransform<double>& X_BQ);
 
+  /// Removes the constraint `id` from the plant. Note that this will _not_
+  /// remove constraints registered directly with DeformableModel.
+  ///
+  /// @throws std::exception if the %MultibodyPlant has already been finalized.
+  /// @throws std::exception if `id` does not identify any multibody constraint
+  /// in this plant.
+  void RemoveConstraint(MultibodyConstraintId id);
+
   /// <!-- TODO(#18732): Add getters to interrogate existing constraints.
   /// -->
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3894,6 +3894,16 @@ GTEST_TEST(MultibodyPlantTests, ConstraintActiveStatus) {
   MultibodyConstraintId weld_id = plant.AddWeldConstraint(
       body_A, RigidTransformd(), body_B, RigidTransformd());
 
+  DRAKE_EXPECT_THROWS_MESSAGE(plant.set_discrete_contact_approximation(
+                                  DiscreteContactApproximation::kTamsi),
+                              ".*TAMSI does not support constraints.*");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.set_discrete_contact_solver(DiscreteContactSolver::kTamsi),
+      ".*TAMSI does not support constraints.*");
+#pragma GCC diagnostic pop
+
   plant.Finalize();
 
   std::unique_ptr<Context<double>> context = plant.CreateDefaultContext();
@@ -3927,6 +3937,58 @@ GTEST_TEST(MultibodyPlantTests, ConstraintActiveStatus) {
   EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, distance_id));
   EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, ball_id));
   EXPECT_TRUE(plant.GetConstraintActiveStatus(*context, weld_id));
+}
+
+GTEST_TEST(MultibodyPlantTests, RemoveConstraint) {
+  // Set up a plant with 3 constraints with arbitrary parameters.
+  MultibodyPlant<double> plant(0.01);
+  // N.B. This feature is only supported by the SAP solver. Therefore we
+  // arbitrarily choose one model approximation that uses the SAP solver.
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  const Body<double>& body_A =
+      plant.AddRigidBody("body_A", SpatialInertia<double>{});
+  const Body<double>& body_B =
+      plant.AddRigidBody("body_B", SpatialInertia<double>{});
+  const RevoluteJoint<double>& world_A =
+      plant.AddJoint<RevoluteJoint>("world_A", plant.world_body(), std::nullopt,
+                                    body_A, std::nullopt, Vector3d::UnitZ());
+  const RevoluteJoint<double>& A_B = plant.AddJoint<RevoluteJoint>(
+      "A_B", body_A, std::nullopt, body_B, std::nullopt, Vector3d::UnitZ());
+  MultibodyConstraintId coupler_id =
+      plant.AddCouplerConstraint(world_A, A_B, 2.3);
+  MultibodyConstraintId distance_id = plant.AddDistanceConstraint(
+      body_A, Vector3d(1.0, 2.0, 3.0), body_B, Vector3d(4.0, 5.0, 6.0), 2.0);
+  MultibodyConstraintId ball_id = plant.AddBallConstraint(
+      body_A, Vector3d(-1.0, -2.0, -3.0), body_B, Vector3d(-4.0, -5.0, -6.0));
+  MultibodyConstraintId weld_id = plant.AddWeldConstraint(
+      body_A, RigidTransformd(), body_B, RigidTransformd());
+
+  EXPECT_EQ(plant.num_coupler_constraints(), 1);
+  EXPECT_EQ(plant.num_distance_constraints(), 1);
+  EXPECT_EQ(plant.num_ball_constraints(), 1);
+  EXPECT_EQ(plant.num_weld_constraints(), 1);
+  plant.RemoveConstraint(coupler_id);
+  plant.RemoveConstraint(distance_id);
+  plant.RemoveConstraint(ball_id);
+  plant.RemoveConstraint(weld_id);
+  EXPECT_EQ(plant.num_coupler_constraints(), 0);
+  EXPECT_EQ(plant.num_distance_constraints(), 0);
+  EXPECT_EQ(plant.num_ball_constraints(), 0);
+  EXPECT_EQ(plant.num_weld_constraints(), 0);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(plant.RemoveConstraint(coupler_id),
+                              ".*does not match any constraint.*");
+
+  // Add a new coupler constraint
+  MultibodyConstraintId coupler_id2 =
+      plant.AddCouplerConstraint(world_A, A_B, 2.3);
+  EXPECT_EQ(plant.num_coupler_constraints(), 1);
+
+  plant.Finalize();
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.RemoveConstraint(coupler_id2),
+      ".*Post-finalize calls to .*RemoveConstraint.* are not allowed.*");
 }
 
 GTEST_TEST(MultibodyPlantTests, FixedOffsetFrameFunctions) {


### PR DESCRIPTION
Adds a pre-finalize method to remove MbP constraints.

An example use case for this is when I've parsed a gripper into my plant with the parser, but then want to go through and replace all of the joints with weld joints. In that workflow, I'll also have to remove any constraints that were added by the parser, but will now become invalid.

+@joemasterjohn for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20720)
<!-- Reviewable:end -->
