### PR TITLE
Touchup parsing documentation for mu_static

### DIFF
--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -720,9 +720,9 @@ The provided (dimensionless) value sets the static friction parameter for
 CoulombFriction. Refer to @ref stribeck_approximation for details on the
 friction model.
 
-@warning This value is ignored when modeling the multibody system with discrete
-dynamics, refer to MultibodyPlant's constructor documentation for details, in
-particular the parameter `time_step`.
+@warning Both `mu_dynamic` and `mu_static` are used by MultibodyPlant when the plant 
+`time_step=0`, but only `mu_dynamic` is used when `time_step>0`. Refer to 
+MultibodyPlant's constructor documentation for details.
 
 @see @ref tag_drake_proximity_properties, drake::multibody::CoulombFriction,
 @ref stribeck_approximation


### PR DESCRIPTION
The previous documentation told me that mu_static would be ignored, but didn't give me a breadcrumb to figure out what parameter I _should_ set. In the code, I found comments of this form repeated often, and they were much more helpful.

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20721)
<!-- Reviewable:end -->
