### PR TITLE
non-world reference frames for DiffIK

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -153,6 +153,22 @@ void DefineIkDifferential(py::module m) {
       "DoDifferentialInverseKinematics",
       [](const multibody::MultibodyPlant<double>& robot,
           const systems::Context<double>& context,
+          const Vector6<double>& V_AE_desired,
+          const multibody::Frame<double>& frame_A,
+          const multibody::Frame<double>& frame_E,
+          const DifferentialInverseKinematicsParameters& parameters) {
+        return DoDifferentialInverseKinematics(
+            robot, context, V_AE_desired, frame_A, frame_E, parameters);
+      },
+      py::arg("robot"), py::arg("context"), py::arg("V_AE_desired"),
+      py::arg("frame_A"), py::arg("frame_E"), py::arg("parameters"),
+      doc.DoDifferentialInverseKinematics
+          .doc_6args_robot_context_V_AE_desired_frame_A_frame_E_parameters);
+
+  m.def(
+      "DoDifferentialInverseKinematics",
+      [](const multibody::MultibodyPlant<double>& robot,
+          const systems::Context<double>& context,
           const math::RigidTransform<double>& X_WE_desired,
           const multibody::Frame<double>& frame_E,
           const DifferentialInverseKinematicsParameters& parameters) {
@@ -163,6 +179,22 @@ void DefineIkDifferential(py::module m) {
       py::arg("frame_E"), py::arg("parameters"),
       doc.DoDifferentialInverseKinematics
           .doc_5args_robot_context_X_WE_desired_frame_E_parameters);
+
+  m.def(
+      "DoDifferentialInverseKinematics",
+      [](const multibody::MultibodyPlant<double>& robot,
+          const systems::Context<double>& context,
+          const math::RigidTransform<double>& X_AE_desired,
+          const multibody::Frame<double>& frame_A,
+          const multibody::Frame<double>& frame_E,
+          const DifferentialInverseKinematicsParameters& parameters) {
+        return DoDifferentialInverseKinematics(
+            robot, context, X_AE_desired, frame_A, frame_E, parameters);
+      },
+      py::arg("robot"), py::arg("context"), py::arg("X_AE_desired"),
+      py::arg("frame_A"), py::arg("frame_E"), py::arg("parameters"),
+      doc.DoDifferentialInverseKinematics
+          .doc_6args_robot_context_X_AE_desired_frame_A_frame_E_parameters);
 
   {
     using Class = DifferentialInverseKinematicsIntegrator;

--- a/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
@@ -98,13 +98,40 @@ class TestPlanner(unittest.TestCase):
 
         context = plant.CreateDefaultContext()
         frame = plant.GetFrameByName("Link2")
+
+        world_frame = plant.world_frame()
+
         parameters = mut.DifferentialInverseKinematicsParameters(2, 2)
 
-        mut.DoDifferentialInverseKinematics(plant, context,
-                                            np.zeros(6), frame, parameters)
+        mut.DoDifferentialInverseKinematics(
+            robot=plant,
+            context=context,
+            V_WE_desired=np.zeros(6),
+            frame_E=frame,
+            parameters=parameters)
 
-        mut.DoDifferentialInverseKinematics(plant, context, RigidTransform(),
-                                            frame, parameters)
+        mut.DoDifferentialInverseKinematics(
+            robot=plant,
+            context=context,
+            X_WE_desired=RigidTransform(),
+            frame_E=frame,
+            parameters=parameters)
+
+        mut.DoDifferentialInverseKinematics(
+            robot=plant,
+            context=context,
+            V_AE_desired=np.zeros(6),
+            frame_A=world_frame,
+            frame_E=frame,
+            parameters=parameters)
+
+        mut.DoDifferentialInverseKinematics(
+            robot=plant,
+            context=context,
+            X_AE_desired=RigidTransform(),
+            frame_A=world_frame,
+            frame_E=frame,
+            parameters=parameters)
 
     def test_diff_ik_integrator(self):
         file_name = FindResourceOrThrow(

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.h
@@ -382,9 +382,36 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const DifferentialInverseKinematicsParameters& parameters);
 
 /**
+ * A wrapper over DoDifferentialInverseKinematics(q_current, v_current, V, J,
+ * params) that tracks frame E's spatial velocity in frame A.
+ * q_current and v_current are taken from @p context. V and J are expressed
+ * in E, and only the elements with non-zero gains in @p parameters
+ * get_end_effector_velocity_gains() are used in the program.
+ * @param robot A MultibodyPlant model.
+ * @param context Must be the Context of the MultibodyPlant. Contains the
+ * current generalized position and velocity.
+ * @param V_AE_desired Desired spatial velocity of @p frame_E in @p frame A.
+ * @param frame_A Reference frame (inertial or non-inertial).
+ * @param frame_E End effector frame.
+ * @param parameters Collection of various problem specific constraints and
+ * constants.
+ * @return If the solver successfully finds a solution, joint_velocities will
+ * be set to v, otherwise it will be nullopt.
+ *
+ * @ingroup planning_kinematics
+ */
+DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+    const MultibodyPlant<double>& robot,
+    const systems::Context<double>& context,
+    const Vector6<double>& V_AE_desired,
+    const Frame<double>& frame_A,
+    const Frame<double>& frame_E,
+    const DifferentialInverseKinematicsParameters& parameters);
+
+/**
  * A wrapper over DoDifferentialInverseKinematics(robot, context, V_WE_desired,
  * frame_E, params) that tracks frame E's pose in the world frame. q_current
- * and v_current are taken from @p cache. V_WE is computed by
+ * and v_current are taken from @p context. V_WE_desired is computed by
  * ComputePoseDiffInCommonFrame(X_WE, X_WE_desired) / dt, where X_WE is
  * computed from @p context, and dt is taken from @p parameters.
  * @param robot A MultibodyPlant model.
@@ -403,6 +430,33 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     const MultibodyPlant<double>& robot,
     const systems::Context<double>& context,
     const math::RigidTransform<double>& X_WE_desired,
+    const Frame<double>& frame_E,
+    const DifferentialInverseKinematicsParameters& parameters);
+
+/**
+ * A wrapper over DoDifferentialInverseKinematics(robot, context, V_AE_desired,
+ * frame_A, frame_E, params) that tracks frame E's pose in frame A. q_current
+ * and v_current are taken from @p context. V_AE_desired is computed by
+ * ComputePoseDiffInCommonFrame(X_AE, X_AE_desired) / dt, where X_WE is
+ * computed from @p context, and dt is taken from @p parameters.
+ * @param robot A MultibodyPlant model.
+ * @param context Must be the Context of the MultibodyPlant. Contains the
+ * current generalized position and velocity.
+ * @param X_AE_desired Desired pose of @p frame_E in @p frame_A.
+ * @param frame_A Reference frame (inertial or non-inertial).
+ * @param frame_E End effector frame.
+ * @param parameters Collection of various problem specific constraints and
+ * constants.
+ * @return If the solver successfully finds a solution, joint_velocities will
+ * be set to v, otherwise it will be nullopt.
+ *
+ * @ingroup planning_kinematics
+ */
+DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+    const MultibodyPlant<double>& robot,
+    const systems::Context<double>& context,
+    const math::RigidTransform<double>& X_AE_desired,
+    const Frame<double>& frame_A,
     const Frame<double>& frame_E,
     const DifferentialInverseKinematicsParameters& parameters);
 


### PR DESCRIPTION
Add support for non-world reference frames to differential inverse kinematics.
    
Adds two new overloads to DoDifferentialInverseKinematics().

Towards #19580

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20735)
<!-- Reviewable:end -->
