### PR TITLE
Adding Python Binding for InverseKinematics.AddMinimumDistanceUpperBoundConstraint

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -135,6 +135,10 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             &Class::AddMinimumDistanceLowerBoundConstraint, py::arg("bound"),
             py::arg("influence_distance_offset") = 0.01,
             cls_doc.AddMinimumDistanceLowerBoundConstraint.doc)
+        .def("AddMinimumDistanceUpperBoundConstraint",
+            &Class::AddMinimumDistanceUpperBoundConstraint, py::arg("bound"),
+            py::arg("influence_distance_offset"),
+            cls_doc.AddMinimumDistanceUpperBoundConstraint.doc)
         .def("AddDistanceConstraint", &Class::AddDistanceConstraint,
             py::arg("geometry_pair"), py::arg("distance_lower"),
             py::arg("distance_upper"), cls_doc.AddDistanceConstraint.doc)

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -453,6 +453,12 @@ class TestInverseKinematics(unittest.TestCase):
         self.assertTrue(result.is_success())
         self.assertTrue(np.allclose(result.GetSolution(ik.q()), q_val))
 
+    def test_AddMinimumDistanceUpperBoundConstraint(self):
+        ik = self.ik_two_bodies
+        ik.AddMinimumDistanceUpperBoundConstraint(
+            bound=0.1,
+            influence_distance_offset=0.01)
+
     def test_AddDistanceConstraint(self):
         ik = self.ik_two_bodies
         W = self.plant.world_frame()


### PR DESCRIPTION
Currently, there is no python binding for InverseKinematics::AddMinimumDistanceUpperBoundConstraint

Added such a binding in [bindings/pydrake/multibody/inverse_kinematics_py.cc]

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20736)
<!-- Reviewable:end -->
