### PR TITLE
[vtk_internal] DataModel warnings patch is no longer needed

### DIFF
--- a/tools/workspace/vtk_internal/patches/common_data_model_warnings.patch
+++ b/tools/workspace/vtk_internal/patches/common_data_model_warnings.patch
@@ -2,7 +2,9 @@
 
 vtkBoundingBox: -Wold-style-cast
 
-TODO(jwnimmer-tri) We should upstream this patch.
+This patch is no longer needed upstream, and can be removed
+from drake the next time we update VTK.  The VTK module
+upstream has been rewritten and the patch will no longer apply.
 
 --- Common/DataModel/vtkBoundingBox.h
 +++ Common/DataModel/vtkBoundingBox.h


### PR DESCRIPTION
VTK update re-writes this module and this patch is not longer needed nor applies.

@svenevs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20746)
<!-- Reviewable:end -->
