### PR TITLE
Aspirational dev branch for URDF schema checking

### DIFF
--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -819,15 +819,6 @@ class TestCspaceFreePolytope(unittest.TestCase):
                      <collision>
                        <geometry><box size="0.1 0.1 0.1"/></geometry>
                      </collision>
-                      <geometry>
-                          <cylinder length="0.1" radius="0.2"/>
-                     </geometry>
-                     <geometry>
-                          <capsule length="0.1" radius="0.2"/>
-                     </geometry>
-                     <geometry>
-                          <sphere radius="0.2"/>
-                     </geometry>
                    </link>
                    <link name="unmovable">
                      <collision>

--- a/examples/multibody/strandbeest/model/LegAssembly.xacro
+++ b/examples/multibody/strandbeest/model/LegAssembly.xacro
@@ -7,7 +7,7 @@
 
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
-<robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="http://drake.mit.edu ../../doc/drakeURDF.xsd" name="LegAssembly">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://ros.org/wiki/xacro" name="LegAssembly">
   <xacro:include filename="Macros.xacro"/>
   <xacro:macro name="strandbeest_leg" params="prefix with_constraints">
     <!-- Links -->

--- a/examples/multibody/strandbeest/model/LegPair.xacro
+++ b/examples/multibody/strandbeest/model/LegPair.xacro
@@ -7,7 +7,7 @@
 
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
-<robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="http://drake.mit.edu ../../doc/drakeURDF.xsd" name="LegPair">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://ros.org/wiki/xacro" name="LegPair">
   <xacro:include filename="Macros.xacro"/>
   <xacro:include filename="LegAssembly.xacro"/>
   <xacro:macro name="strandbeest_leg_pair" params="prefix with_constraints">

--- a/examples/multibody/strandbeest/model/Macros.xacro
+++ b/examples/multibody/strandbeest/model/Macros.xacro
@@ -7,7 +7,7 @@
 
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
-<robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="http://drake.mit.edu ../../doc/drakeURDF.xsd" name="Macros">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://ros.org/wiki/xacro" name="Macros">
   <!-- LinearBushingRollPitchYaw parameters -->
   <xacro:property name="torque_stiffness" value="20000"/>
   <xacro:property name="torque_damping" value="2000"/>

--- a/examples/multibody/strandbeest/model/Strandbeest.xacro
+++ b/examples/multibody/strandbeest/model/Strandbeest.xacro
@@ -11,7 +11,7 @@
 
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
-<robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="../../doc/drakeURDF.xsd" name="Strandbeest">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://ros.org/wiki/xacro" name="Strandbeest">
   <xacro:macro name="strandbeest" params="with_constraints">
     <xacro:include filename="Macros.xacro"/>
     <xacro:include filename="LegPair.xacro"/>

--- a/examples/multibody/strandbeest/model/StrandbeestBushings.urdf.xacro
+++ b/examples/multibody/strandbeest/model/StrandbeestBushings.urdf.xacro
@@ -7,7 +7,7 @@
 
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
-<robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="../../doc/drakeURDF.xsd" name="Strandbeest">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://ros.org/wiki/xacro" name="Strandbeest">
   <xacro:include filename="Strandbeest.xacro"/>
   <xacro:strandbeest with_constraints="false" />
 </robot>

--- a/examples/multibody/strandbeest/model/StrandbeestConstraints.urdf.xacro
+++ b/examples/multibody/strandbeest/model/StrandbeestConstraints.urdf.xacro
@@ -7,7 +7,7 @@
 
      https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/examples/Strandbeest/
 -->
-<robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacro="http://ros.org/wiki/xacro" xsi:schemaLocation="../../doc/drakeURDF.xsd" name="Strandbeest">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xacro="http://ros.org/wiki/xacro" name="Strandbeest">
   <xacro:include filename="Strandbeest.xacro"/>
   <xacro:strandbeest with_constraints="true" />
 </robot>

--- a/examples/pr2/models/pr2_description/urdf/pr2_simplified.urdf
+++ b/examples/pr2/models/pr2_description/urdf/pr2_simplified.urdf
@@ -30,7 +30,7 @@
 -->
 
 <!-- ======================================================================= -->
-<robot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#slider" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:xacro="http://ros.org/wiki/xacro" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" name="pr2">
+<robot xmlns:drake="http://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#slider" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:xacro="http://ros.org/wiki/xacro" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" name="pr2">
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- misc common stuff? -->
   <!-- PR2 Arm -->

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -138,7 +138,7 @@ GTEST_TEST(IrisInConfigurationSpaceTest, ConfigurationSpaceMargin) {
 }
 
 const char boxes_with_mesh_urdf[] = R"""(
-<robot name="boxes">
+<robot xmlns:drake="http://drake.mit.edu" name="boxes">
   <link name="fixed">
     <collision name="right">
       <origin rpy="0 0 0" xyz="2.5 0 0"/>

--- a/manipulation/models/franka_description/urdf/panda_hand.urdf
+++ b/manipulation/models/franka_description/urdf/panda_hand.urdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<robot name="panda_hand">
+<robot xmlns:drake='http://drake.mit.edu' name="panda_hand">
   <link name="panda_hand">
     <inertial>
       <mass value="0.73"/>

--- a/manipulation/models/tri_homecart/homecart_bimanual.urdf.xacro
+++ b/manipulation/models/tri_homecart/homecart_bimanual.urdf.xacro
@@ -24,9 +24,7 @@
       Positive origin axes extend "forward" for X and "left" for Y, with
       respect to the robot arm origins.
   -->
-  <link name="homecart_base_link">
-    <origin xyz="0 0 0" rpy="0 0 0"/>
-  </link>
+  <link name="homecart_base_link"/>
   <xacro:property name="arm_mount_cantilever_length" value="0.254"/>
   <xacro:property name="arm_mount_cantilever_height" value="0.015"/>
   <xacro:property name="arm_mount_stack_plate_side" value="0.1275"/>
@@ -104,9 +102,7 @@
       <parent link="${side}arm_mount_cantilever_link"/>
       <child link="${side}arm_mount_stack_link"/>
     </joint>
-    <link name="${side}arm_base_link">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-    </link>
+    <link name="${side}arm_base_link"/>
     <joint name="${side}arm_base_joint" type="fixed">
       <origin xyz="0 0 ${num_plates*0.02}" rpy="0 0 0"/>
       <parent link="${side}arm_mount_stack_link"/>
@@ -222,7 +218,7 @@
       <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100"/>
     </inertial>
     <visual>
-    <origin xyz="0 0 0" rpy="0 0 0"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="package://drake_models/tri_homecart/homecart_bimanual_upper_structure.obj"/>
       </geometry>

--- a/manipulation/models/ur3e/ur3e.urdf.xacro
+++ b/manipulation/models/ur3e/ur3e.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro" xmlns:drake="https://drake.mit.edu">
+<robot xmlns:xacro="http://ros.org/wiki/xacro" xmlns:drake="http://drake.mit.edu">
 
 <!--
   Author: Felix Messmer
@@ -548,7 +548,6 @@
     </joint>
 
     <link name="${prefix}wrist_2_link">
-      <origin rpy="${pi / 2} 0 0" xyz="0.0 0.0 0.0"/>
       <visual>
         <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
         <geometry>

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -283,6 +283,19 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "detail_schema_checker",
+    srcs = ["detail_schema_checker.cc"],
+    hdrs = ["detail_schema_checker.h"],
+    internal = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        "//common:diagnostic_policy",
+        "//common:scope_exit",
+        "@rnv_internal//:rnv",
+    ],
+)
+
+drake_cc_library(
     name = "detail_select_parser",
     srcs = ["detail_select_parser.cc"],
     hdrs = ["detail_select_parser.h"],
@@ -432,6 +445,26 @@ drake_cc_binary(
     ],
 )
 
+drake_cc_binary(
+    name = "schema_validator",
+    testonly = 1,
+    srcs = ["schema_validator.cc"],
+    add_test_rule = 1,
+    data = [
+        "urdf.rnc",
+        ":test_models",
+    ],
+    test_rule_args = [
+        "multibody/parsing/urdf.rnc",
+        "multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf",
+    ],
+    deps = [
+        ":detail_schema_checker",
+        "//common:add_text_logging_gflags",
+        "@gflags",
+    ],
+)
+
 drake_cc_googletest(
     name = "parser_test",
     data = [
@@ -534,6 +567,19 @@ drake_cc_googletest(
         ":detail_sdf_parser",
         "//common:find_resource",
         "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_schema_checker_test",
+    data = [
+        "test/SVG-1.2-RFC.rnc",
+        "test/draft-rfcxml-general-template-annotated-00.xml",
+        "test/draft-rfcxml-general-template-bare-00.xml",
+        "test/rfc7991bis.rnc",
+    ],
+    deps = [
+        ":detail_schema_checker",
     ],
 )
 

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -211,12 +211,14 @@ drake_cc_library(
         "detail_urdf_geometry.h",
         "detail_urdf_parser.h",
     ],
+    data = ["urdf.rnc"],
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
         ":detail_make_model_name",
         ":detail_misc",
         ":detail_parsing_workspace",
+        ":detail_schema_checker",
         ":scoped_names",
         "@fmt",
         "@tinyxml2_internal//:tinyxml2",
@@ -746,6 +748,7 @@ install_files(
     files = [
         "drake_models.json",
         "package_downloader.py",
+        "urdf.rnc",
     ],
     visibility = ["//visibility:public"],
 )

--- a/multibody/parsing/detail_schema_checker.cc
+++ b/multibody/parsing/detail_schema_checker.cc
@@ -1,0 +1,267 @@
+#include "drake/multibody/parsing/detail_schema_checker.h"
+
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <regex>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+extern "C" {
+// Fix these by adjusting the internal build rules.
+// NOLINTNEXTLINE(build/include)
+#include "er.h"
+// NOLINTNEXTLINE(build/include)
+#include "xcl.h"
+};
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/common/scope_exit.h"
+#include "drake/common/ssize.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+using drake::internal::DiagnosticDetail;
+using drake::internal::DiagnosticPolicy;
+
+namespace {
+
+// Use this singleton mutex to protect both the one global variable below, and
+// the static global state within the rnv library.
+static std::mutex& library_mutex() {
+  static drake::never_destroyed<std::mutex> mutex;
+  return mutex.access();
+}
+
+// This helper allows writing assertions about the mutex state.
+bool library_mutex_is_locked() {
+  auto& mutex = library_mutex();
+  if (mutex.try_lock()) {
+    mutex.unlock();
+    return false;
+  }
+  return true;
+}
+
+// Capture and redirect error messages from the rnv library to a diagnostic
+// policy object. Note that this requires manipulation of global state
+// (function and instance pointers) both in this class and in the rnv library.
+//
+// This class does not fully enforce thread safety itself, but requires that
+// any client be holding the library mutex at construction time, and assumes
+// that it will be held for the lifetime of any instance.
+class DiagnosticAdapter {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagnosticAdapter)
+  explicit DiagnosticAdapter(const DiagnosticPolicy* policy)
+  : policy_(policy) {
+    DRAKE_DEMAND(library_mutex_is_locked());
+    DRAKE_ASSERT(the_adapter == nullptr);
+    the_adapter = this;
+    old_er_vprintf_ = ::er_vprintf;
+    ::er_vprintf = DiagnosticAdapter::er_vprintf;
+  }
+
+  ~DiagnosticAdapter() {
+    ::er_vprintf = old_er_vprintf_;
+    the_adapter = nullptr;
+  }
+
+  // This could have been the destructor, except for the fact that Error() most
+  // commonly throws exceptions.
+  void Finish() {
+    flush();
+    for (const auto& event : diagnostic_events_) {
+      switch (event.mode) {
+        case Unknown: { break; }
+        case Error: { policy_->Error(event.detail); break; }
+        case Warning: { policy_->Warning(event.detail); break; }
+      }
+    }
+  }
+
+  int error_count() const { return error_count_; }
+
+ private:
+  static int er_vprintf(char* format, va_list ap) {
+    return the_adapter->ErVprintf(format, ap);
+  }
+
+  int ErVprintf(char* format, va_list ap) noexcept {
+    std::array<char, 4096> buffer{};
+    vsnprintf(buffer.data(), buffer.size(), format, ap);
+    buffer[buffer.size() - 1] = 0;
+    std::string result(buffer.data());
+
+    // Since the library issues informative multiline comments, parse them here
+    // into multiline Error() or Warning() events.
+    std::smatch m;
+    static constexpr char kPattern[] =
+        R"""(^([^:]*):(\d+):(\d+:)? (warning|error): (.*))""";
+    std::regex_search(result, m, std::regex(kPattern));
+    if (!m.empty()) {
+      flush();
+      // set mode, filename, line.
+      switch (*m[4].first) {
+        case 'w': { mode_ = Warning; break; }
+        case 'e': { mode_ = Error; ++error_count_; break; }
+        default: { mode_ = Unknown; break; }
+      }
+      filename_ = m[1];
+      line_ = std::stoi(m[2]);
+      result = m[5];
+    }
+    // store.
+    buffer_.push_back(result);
+    return result.size();
+  }
+
+  void flush() {
+    DiagnosticDetail detail;
+    detail.filename = filename_;
+    detail.line = line_;
+    for (int k = 0; k < ssize(buffer_); ++k) {
+      detail.message += buffer_[k];
+    }
+    // We can't throw any exceptions while the rnv-implemented parse is
+    // running, so buffer up the completed events and emit them later.
+    switch (mode_) {
+      case Unknown: { break; }
+      case Error: { diagnostic_events_.push_back({Error, detail}); break; }
+      case Warning: { diagnostic_events_.push_back({Warning, detail}); break; }
+    }
+    buffer_.clear();
+  }
+
+  // This is global state containing and instance pointer, which allows us to
+  // crawl back from a patched global function pointer to the relevant live
+  // instance of this class.
+  static DiagnosticAdapter* the_adapter;
+
+  const DiagnosticPolicy* policy_;
+  typedef int (*ErVprintfFunc)(char *format, va_list ap);
+  ErVprintfFunc old_er_vprintf_{};
+
+  enum Mode { Unknown, Error, Warning } mode_ {Unknown};
+  std::string filename_;
+  int line_{};
+  int error_count_{0};
+  std::vector<std::string> buffer_;
+  struct Event {
+    Mode mode;
+    DiagnosticDetail detail;
+  };
+  std::vector<Event> diagnostic_events_;
+};
+DiagnosticAdapter* DiagnosticAdapter::the_adapter{nullptr};
+
+// While `rnv` is a very nice tool to use from the command line, it is not well
+// suited for use as a library. The `RnvGuard` takes care of several necessary
+// adaptations.
+//
+// * static global state: hold the global library mutex
+// * static global state: init and clear operations
+// * diagnostic redirection
+class RnvGuard {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RnvGuard)
+  explicit RnvGuard(const DiagnosticPolicy* policy)
+  : adapter_(policy) {
+    xcl_init();
+  }
+  ~RnvGuard() {
+    xcl_clear();
+  }
+
+  int error_count() const {
+    return adapter_.error_count();
+  }
+
+  void Finish() {
+    adapter_.Finish();
+  }
+
+ private:
+  // This guard holds the mutex to protect both the DiagnosticAdapter, and the
+  // underlying global state in the rnv library.
+  std::lock_guard<std::mutex> guard_{library_mutex()};
+  DiagnosticAdapter adapter_;
+};
+
+// Manage a file read descriptor in RAII style, with error reporting via
+// diagnostic policy.
+class ReadFd {
+ public:
+  explicit ReadFd(const DiagnosticPolicy& diagnostic,
+    const std::string& filename) {
+    fd_ = open(filename.c_str(), O_RDONLY);
+    if (!ok()) {
+        diagnostic.Error(fmt::format("Failed to read file '{}': {}",
+                                     filename, strerror(errno)));
+    }
+  }
+  ~ReadFd() {
+    if (ok()) { close(fd_); }
+  }
+  bool ok() const { return fd_ >= 0; }
+  operator int () { return fd_; }
+ private:
+  int fd_{};
+};
+
+}  // namespace
+
+bool CheckDocumentFileAgainstRncSchemaFile(
+    const DiagnosticPolicy& diagnostic,
+    const std::filesystem::path& rnc_schema,
+    const std::filesystem::path& document) {
+  RnvGuard rnv_guard(&diagnostic);
+  DRAKE_ASSERT(library_mutex_is_locked());
+  ReadFd schema_fd(diagnostic, rnc_schema);
+  if (!schema_fd.ok()) { return false; }
+  xcl_rnl_fd(const_cast<char*>(rnc_schema.c_str()), schema_fd);
+  if (rnv_guard.error_count() > 0) {
+    rnv_guard.Finish();
+    return false;
+  }
+  ReadFd fd(diagnostic, document);
+  if (!fd.ok()) { return false; }
+  xcl_validate_fd(fd, document.c_str());
+  rnv_guard.Finish();
+  return (rnv_guard.error_count() == 0);
+}
+
+bool CheckDocumentStringAgainstRncSchemaFile(
+    const DiagnosticPolicy& diagnostic,
+    const std::filesystem::path& rnc_schema,
+    const std::string& document_contents,
+    const std::string& document_filename) {
+  RnvGuard rnv_guard(&diagnostic);
+  DRAKE_ASSERT(library_mutex_is_locked());
+  ReadFd schema_fd(diagnostic, rnc_schema);
+  if (!schema_fd.ok()) { return false; }
+  xcl_rnl_fd(const_cast<char*>(rnc_schema.c_str()), schema_fd);
+  if (rnv_guard.error_count() > 0) {
+    rnv_guard.Finish();
+    return false;
+  }
+  xcl_validate_memory(const_cast<char*>(document_contents.c_str()),
+                      document_contents.size(),
+                      document_filename.c_str());
+  rnv_guard.Finish();
+  return (rnv_guard.error_count() == 0);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_schema_checker.h
+++ b/multibody/parsing/detail_schema_checker.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include "drake/common/diagnostic_policy.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* Here are three overloaded versions of CheckDocumentAgainstRncSchema(). They
+all do roughly the same thing, with different inputs: validate a document
+against a schema written in RelaxNG Compact format, emitting warnings and/or
+errors to a diagnostic policy object. The return value is true
+if both schema parsing and validation complete without error.
+*/
+
+/* Validate a document against a schema, both provided as files. */
+bool CheckDocumentFileAgainstRncSchemaFile(
+    const drake::internal::DiagnosticPolicy& diagnostic,
+    const std::filesystem::path& rnc_schema,
+    const std::filesystem::path& document);
+
+/* Validate a document, provided as an in-memory string, against a schema,
+whose contents are provided as a file. The `document_filename` is only used to
+construct diagnostic messages; the value should be chosen to help the user
+interpret the messages. */
+bool CheckDocumentStringAgainstRncSchemaFile(
+    const drake::internal::DiagnosticPolicy& diagnostic,
+    const std::filesystem::path& rnc_schema,
+    const std::string& document_contents,
+    const std::string& document_filename);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+

--- a/multibody/parsing/schema_validator.cc
+++ b/multibody/parsing/schema_validator.cc
@@ -1,0 +1,46 @@
+#include <gflags/gflags.h>
+
+#include "drake/common/text_logging.h"
+#include "drake/multibody/parsing/detail_schema_checker.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using drake::internal::DiagnosticDetail;
+using drake::internal::DiagnosticPolicy;
+
+int do_main(int argc, char* argv[]) {
+  gflags::SetUsageMessage("[INPUT-FILE]\n"
+                          "Run schema checker; print errors if any");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  if (argc < 3) {
+    drake::log()->error("missing input filename");
+    return 1;
+  }
+
+  // Hardcode a log pattern that gives us un-decorated error messages.
+  // This defeats the `-spdlog_pattern` command line option; oh well.
+  drake::logging::set_log_pattern("%v");
+
+  drake::log()->info("checking {} against {}", argv[2], argv[1]);
+
+  // We want to see all errors and warnings.
+  DiagnosticPolicy policy;
+  policy.SetActionForErrors([&policy] (const DiagnosticDetail& detail) {
+    policy.WarningDefaultAction(detail);
+  });
+
+  std::filesystem::path schema(argv[1]);
+  std::filesystem::path document(argv[2]);
+  return !internal::CheckDocumentFileAgainstRncSchemaFile(
+      policy, schema, document);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  return drake::multibody::do_main(argc, argv);
+}

--- a/multibody/parsing/test/SVG-1.2-RFC.rnc
+++ b/multibody/parsing/test/SVG-1.2-RFC.rnc
@@ -1,0 +1,1676 @@
+#   SVG-1.2-RFC.rnc
+#
+#   SVG 1.2 RFC RNC schema as specified in RFC 7996.
+#
+#   This schema is automatically included by the parent RFCXML v3 RNC schema
+#   and so needs to be present for succesful validation but does not need to 
+#   be specified separately.
+#
+#   Documentation is at https://authors.ietf.org/en/templates-and-schemas
+#
+#   Nevil Brownlee, Tue Jan 16 2018 (NZDT)
+
+default namespace = "http://www.w3.org/2000/svg"
+namespace xlink = "http://www.w3.org/1999/xlink"
+
+rfc-color = (  # SVG-1.2-RFC doesn't allow "color or grey-scale"
+  "black" | "white" | "#000000" | "#FFFFFF" | "#ffffff" |
+  "currentColor" | "inherit" )
+
+start = svg
+
+svg =
+  element svg {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"}?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute width { xsd:string }?,
+    attribute height { xsd:string }?,
+    attribute preserveAspectRatio {
+      xsd:string { pattern = "\s*(none|xMidYMid)\s*(meet)?\s*" }
+    }?,
+    attribute viewBox { text }?,
+    attribute version {
+      xsd:string "1.0" | xsd:string "1.1" | xsd:string "1.2"
+    }?,
+    attribute baseProfile {
+      xsd:string "none"
+      | xsd:string "tiny"
+      | xsd:string "basic"
+      | xsd:string "full"
+    }?,
+    attribute snapshotTime { xsd:string "none" | xsd:string }?,
+    (desc
+     | svgTitle
+     | path
+     | rect
+     | circle
+     | line
+     | ellipse
+     | polyline
+     | polygon
+     | solidColor
+     | textArea
+     | \text
+     | g
+     | defs
+     | use
+     | a)*
+  }
+
+desc =
+  element desc {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    ((attribute display {
+        "inline"
+        | "block"
+        | "list-item"
+        | "run-in"
+        | "compact"
+        | "marker"
+        | "table"
+        | "inline-table"
+        | "table-row-group"
+        | "table-header-group"
+        | "table-footer-group"
+        | "table-row"
+        | "table-column-group"
+        | "table-column"
+        | "table-cell"
+        | "table-caption"
+        | "none"
+        | "inherit"
+      }?,
+      attribute visibility { "visible" | "hidden" | "collapse" | "inherit" }?,
+      attribute image-rendering {
+        "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+      }?,
+      attribute shape-rendering {
+        "auto"
+        | "optimizeSpeed"
+        | "crispEdges"
+        | "geometricPrecision"
+        | "inherit"
+      }?,
+      attribute text-rendering {
+        "auto"
+        | "optimizeSpeed"
+        | "optimizeLegibility"
+        | "geometricPrecision"
+        | "inherit"
+      }?,
+      attribute buffered-rendering {
+        "auto" | "dynamic" | "static" | "inherit"
+      }?)
+     & (attribute viewport-fill { "none" | rfc-color }?,
+        attribute viewport-fill-opacity { "inherit" | xsd:string }?)),
+    text
+  }
+
+svgTitle =
+  element title {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    ((attribute display {
+        "inline"
+        | "block"
+        | "list-item"
+        | "run-in"
+        | "compact"
+        | "marker"
+        | "table"
+        | "inline-table"
+        | "table-row-group"
+        | "table-header-group"
+        | "table-footer-group"
+        | "table-row"
+        | "table-column-group"
+        | "table-column"
+        | "table-cell"
+        | "table-caption"
+        | "none"
+        | "inherit"
+      }?,
+      attribute visibility { "visible" | "hidden" | "collapse" | "inherit" }?,
+      attribute image-rendering {
+        "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+      }?,
+      attribute shape-rendering {
+        "auto"
+        | "optimizeSpeed"
+        | "crispEdges"
+        | "geometricPrecision"
+        | "inherit"
+      }?,
+      attribute text-rendering {
+        "auto"
+        | "optimizeSpeed"
+        | "optimizeLegibility"
+        | "geometricPrecision"
+        | "inherit"
+      }?,
+      attribute buffered-rendering {
+        "auto" | "dynamic" | "static" | "inherit"
+      }?)
+     & (attribute viewport-fill { "none" | rfc-color }?,
+        attribute viewport-fill-opacity { "inherit" | xsd:string }?)),
+    text
+  }
+
+path =
+  element path {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute d { xsd:string }?,
+    attribute pathLength { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+rect =
+  element rect {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute x { xsd:string }?,
+    attribute y { xsd:string }?,
+    attribute width { xsd:string }?,
+    attribute height { xsd:string }?,
+    attribute rx { xsd:string }?,
+    attribute ry { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+circle =
+  element circle {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute cx { xsd:string }?,
+    attribute cy { xsd:string }?,
+    attribute r { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+line =
+  element line {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute x1 { xsd:string }?,
+    attribute y1 { xsd:string }?,
+    attribute x2 { xsd:string }?,
+    attribute y2 { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+ellipse =
+  element ellipse {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute rx { xsd:string }?,
+    attribute ry { xsd:string }?,
+    attribute cx { xsd:string }?,
+    attribute cy { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+polyline =
+  element polyline {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute points { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+polygon =
+  element polygon {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute points { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+solidColor =
+  element solidColor {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    (desc
+     | svgTitle)*
+  }
+
+textArea =
+  element textArea {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    attribute x { xsd:string }?,
+    attribute y { xsd:string }?,
+    attribute width { xsd:string | "auto" }?,
+    attribute height { xsd:string | "auto" }?,
+    (tspan
+     | desc
+     | svgTitle
+     | tspan_2
+     | text
+     | a_2)+
+  }
+
+\text =
+  element text {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    attribute x { xsd:string }?,
+    attribute y { xsd:string }?,
+    attribute rotate { xsd:string }?,
+    (desc
+     | svgTitle
+     | tspan_2
+     | text
+     | a_2)+
+  }
+
+g =
+  element g {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    (desc
+     | svgTitle
+     | path
+     | rect
+     | circle
+     | line
+     | ellipse
+     | polyline
+     | polygon
+     | solidColor
+     | textArea
+     | \text
+     | g
+     | defs
+     | use
+     | a)*
+  }
+
+defs =
+  element defs {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    (desc
+     | svgTitle
+     | path
+     | rect
+     | circle
+     | line
+     | ellipse
+     | polyline
+     | polygon
+     | solidColor
+     | textArea
+     | \text
+     | g
+     | defs
+     | use
+     | a)*
+  }
+
+use =
+  element use {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    attribute xlink:show { "embed" }?,
+    attribute xlink:actuate { "onLoad" }?,
+    attribute xlink:type { "simple" }?,
+    attribute xlink:role { xsd:anyURI | xsd:string }?,
+    attribute xlink:arcrole { xsd:anyURI | xsd:string }?,
+    attribute xlink:title { text }?,
+    attribute xlink:href { xsd:anyURI | xsd:string }?,
+    attribute x { xsd:string }?,
+    attribute y { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+a =
+  element a {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute transform { xsd:string | "none" }?,
+    attribute xlink:show { "new" | "replace" }?,
+    attribute xlink:actuate { "onRequest" }?,
+    attribute xlink:type { "simple" }?,
+    attribute xlink:role { xsd:anyURI | xsd:string }?,
+    attribute xlink:arcrole { xsd:anyURI | xsd:string }?,
+    attribute xlink:title { text }?,
+    attribute xlink:href { xsd:anyURI | xsd:string }?,
+    attribute target {
+      "_replace" | "_self" | "_parent" | "_top" | "_blank" | xsd:Name
+    }?,
+    (desc
+     | svgTitle
+     | path
+     | rect
+     | circle
+     | line
+     | ellipse
+     | polyline
+     | polygon
+     | solidColor
+     | textArea
+     | \text
+     | g
+     | defs
+     | use)*
+  }
+
+tspan =
+  element tspan {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute x { xsd:string }?,  # For SVG-1.2-RFC
+    attribute y { xsd:string }?,
+    (tbreak
+     | desc
+     | svgTitle
+     | tspan_2
+     | text
+     | a_2)+
+  }
+
+tspan_2 =
+  element tspan {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute x { xsd:string }?,  # For SVG-1.2-RFC
+    attribute y { xsd:string }?,
+    (desc
+     | svgTitle
+     | tspan_2
+     | text
+     | a_2)+
+  }
+
+a_2 =
+  element a {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute transform { xsd:string | "none" }?,
+    attribute xlink:show { "new" | "replace" }?,
+    attribute xlink:actuate { "onRequest" }?,
+    attribute xlink:type { "simple" }?,
+    attribute xlink:role { xsd:anyURI | xsd:string }?,
+    attribute xlink:arcrole { xsd:anyURI | xsd:string }?,
+    attribute xlink:title { text }?,
+    attribute xlink:href { xsd:anyURI | xsd:string }?,
+    attribute target {
+      "_replace" | "_self" | "_parent" | "_top" | "_blank" | xsd:Name
+    }?,
+    (desc
+     | svgTitle
+     | tspan_2
+     | text)+
+  }
+
+tbreak =
+  element tbreak {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?
+  }
+
+#---  End of SVG 1.2 RFC rnc schema

--- a/multibody/parsing/test/detail_schema_checker_test.cc
+++ b/multibody/parsing/test/detail_schema_checker_test.cc
@@ -1,0 +1,101 @@
+#include "drake/multibody/parsing/detail_schema_checker.h"
+
+#include <fstream>
+#include <sstream>
+#include <thread>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+namespace {
+
+using drake::internal::DiagnosticDetail;
+using drake::internal::DiagnosticPolicy;
+
+// Here are some fairly arbitrary and complicated schema and document files,
+// taken from:
+// https://authors.ietf.org/templates-and-schemas
+//
+const std::filesystem::path testdir("multibody/parsing/test");
+const std::filesystem::path schema("rfc7991bis.rnc");
+// This document will emit an error, fairly deep in the document file.
+const std::filesystem::path doc_bad(
+    "draft-rfcxml-general-template-annotated-00.xml");
+// This document will validate cleanly.
+const std::filesystem::path doc_good(
+    "draft-rfcxml-general-template-bare-00.xml");
+
+std::string slurp(const std::filesystem::path& path) {
+  std::ifstream in;
+  in.open(path, std::ifstream::in | std::ifstream::binary);
+  DRAKE_DEMAND(in.good());
+  std::stringstream stream;
+  stream << in.rdbuf();
+  in.close();
+  return stream.str();
+}
+
+GTEST_TEST(SchemaCheckerTest, ThreadedTest) {
+  std::vector<std::filesystem::path> docs{doc_bad, doc_good};
+  std::vector<int> docs_results{false, true};
+  std::vector<std::string> doc_strs;
+  for (const auto& doc : docs) {
+    doc_strs.push_back(slurp(testdir / doc));
+  }
+
+  auto thread_action = [&](int index) {
+    SCOPED_TRACE(fmt::format("thread index {}", index));
+    DiagnosticPolicy policy;
+    int errors{0};
+    int warnings{0};
+    policy.SetActionForErrors(
+        [&errors](const DiagnosticDetail& detail) {
+          ++errors;
+        });
+    policy.SetActionForWarnings(
+        [&warnings](const DiagnosticDetail& detail) { ++warnings; });
+
+    // Cycle over the API entry points and documents.
+    int entry_point = index % 2;
+    int doc_index = index % docs.size();
+    bool result{};
+    switch (entry_point) {
+      case 0:
+        result = CheckDocumentFileAgainstRncSchemaFile(
+            policy, testdir / schema, testdir / docs[doc_index]);
+        break;
+      case 1:
+        result = CheckDocumentStringAgainstRncSchemaFile(
+            policy, testdir / schema,
+            doc_strs[doc_index], testdir / docs[doc_index]);
+        break;
+      default:
+        DRAKE_UNREACHABLE();
+    }
+    EXPECT_EQ(result, !errors);
+    EXPECT_EQ(result, docs_results[doc_index]);
+    EXPECT_EQ(warnings, 0);
+  };
+
+  // Launch many threads as quickly as possible, each doing thread_action.
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 10; ++i) {
+    threads.emplace_back(thread_action, i);
+  }
+
+  // Wait for them all to finish.
+  for (auto& item : threads) {
+    item.join();
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -112,8 +112,7 @@ TEST_F(UrdfParserTest, BadXmlString) {
 
 TEST_F(UrdfParserTest, NoRobot) {
   EXPECT_EQ(AddModelFromUrdfString("<empty/>", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*URDF does not contain a robot tag."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*not.*robot.*"));
 }
 
 TEST_F(UrdfParserTest, NoName) {
@@ -149,12 +148,11 @@ TEST_F(UrdfParserTest, LegacyDrakeIgnoreBody) {
 }
 
 TEST_F(UrdfParserTest, BodyNameBroken) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link naQQQme='broken'/>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*link tag is missing name attribute."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*name.*attribute.*"));
 }
 
 TEST_F(UrdfParserTest, LegacyDrakeIgnoreJoint) {
@@ -166,37 +164,35 @@ TEST_F(UrdfParserTest, LegacyDrakeIgnoreJoint) {
 }
 
 TEST_F(UrdfParserTest, JointNameBroken) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <joint naQQQme='broken'/>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*joint tag is missing name attribute"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*name.*attribute.*"));
 }
 
 TEST_F(UrdfParserTest, JointTypeBroken) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <joint name='a' tyQQQpe='broken'/>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*joint 'a' is missing type attribute"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*type.*attribute.*"));
 }
 
 TEST_F(UrdfParserTest, JointNoParent) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <joint name='a' type='revolute'>
         <parQQQent link='parent'/>
         <child link='child'/>
       </joint>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*joint 'a' doesn't have a parent node!"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*parent.*element.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*unfinished.*joint.*"));
 }
 
 TEST_F(UrdfParserTest, JointParentLinkBroken) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
       <link name='child'/>
@@ -205,24 +201,23 @@ TEST_F(UrdfParserTest, JointParentLinkBroken) {
         <child link='child'/>
       </joint>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*joint a's parent does not have a link attribute!"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*link.*"));
 }
 
 TEST_F(UrdfParserTest, JointNoChild) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <joint name='a' type='revolute'>
         <parent link='parent'/>
         <chiQQQld link='child'/>
       </joint>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*joint 'a' doesn't have a child node!"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*child.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*unfinished.*joint.*"));
 }
 
 TEST_F(UrdfParserTest, JointChildLinkBroken) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
       <link name='child'/>
@@ -231,8 +226,7 @@ TEST_F(UrdfParserTest, JointChildLinkBroken) {
         <child liQQQnk='broken'/>
       </joint>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*joint a's child does not have a link attribute!"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*link.*"));
 }
 
 TEST_F(UrdfParserTest, JointBadDynamicsAttributes) {
@@ -361,7 +355,7 @@ TEST_F(UrdfParserTest, MimicNoSap) {
       <joint name='joint' type='revolute'>
         <parent link='parent'/>
         <child link='child'/>
-        <mimic/>
+        <mimic joint='nope'/>
       </joint>
     </robot>)""", ""), std::nullopt);
   EXPECT_THAT(
@@ -374,7 +368,7 @@ TEST_F(UrdfParserTest, MimicNoSap) {
 TEST_F(UrdfParserTest, MimicNoJoint) {
   // Currently the <mimic> tag is only supported by SAP.
   plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name='a'>
       <link name='parent'/>
       <link name='child'/>
@@ -384,9 +378,7 @@ TEST_F(UrdfParserTest, MimicNoJoint) {
         <mimic/>
       </joint>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*Joint 'joint' mimic element is missing the "
-                           "required 'joint' attribute."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*mimic.*joint.*"));
 }
 
 TEST_F(UrdfParserTest, MimicBadJoint) {
@@ -559,20 +551,19 @@ TEST_F(UrdfParserTest, Material) {
 }
 
 TEST_F(UrdfParserTest, FrameNameBroken) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name="a">
       <frame naQQQme="broken" link="A" rpy="0 0 0" xyz="0 0 0"/>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(".*parsing frame name."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*name.*attribute.*"));
 }
 
 TEST_F(UrdfParserTest, FrameLinkBroken) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name="a">
       <frame name="frameA" liQQQnk="broken" rpy="0 0 0" xyz="0 0 0"/>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*missing link name for frame frameA."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*link.*attribute.*"));
 }
 
 TEST_F(UrdfParserTest, TransmissionTypeBroken) {
@@ -664,7 +655,7 @@ TEST_F(UrdfParserTest, TransmissionJointNotExist) {
 
 TEST_F(UrdfParserTest, TransmissionJointBadLimits) {
   constexpr const char* base = R"""(
-    <robot name='a'>
+    <robot xmlns:drake='http://drake.mit.edu' name='a'>
       <link name='parent'/>
       <link name='child'/>
       <joint name='a' type='revolute'>
@@ -1023,7 +1014,7 @@ TEST_F(UrdfParserTest, JointParsingTest) {
 // Custom planar joints were not necessary, but long supported. See #18730.
 TEST_F(UrdfParserTest, LegacyPlanarJointAsCustomTest) {
   constexpr const char* model = R"""(
-    <robot name='a'>
+    <robot xmlns:drake='http://drake.mit.edu' name='a'>
       <link name="link1"/>
       <link name="link2"/>
       <drake:joint name="planar_joint" type="planar">
@@ -1082,8 +1073,7 @@ TEST_F(UrdfParserTest, JointParsingTagMissingScrewParametersTest) {
 // the geometry parsing got triggered, it is correct and ignore the other
 // details.
 TEST_F(UrdfParserTest, AddingGeometriesToWorldLink) {
-  const std::string test_urdf = R"""(
-<?xml version="1.0"?>
+  const std::string test_urdf = R"""(<?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="joint_parsing_test">
   <link name="world">
     <!-- Declaring mass properties on the "world" link is bad. But it won't
@@ -1096,10 +1086,10 @@ TEST_F(UrdfParserTest, AddingGeometriesToWorldLink) {
     <visual>
       <geometry>
         <box size="0.1 0.2 0.3"/>
-        <material>
-          <color rgba="0.8 0.7 0.6 0.5"/>
-        </material>
       </geometry>
+      <material>
+        <color rgba="0.8 0.7 0.6 0.5"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -1359,7 +1349,7 @@ TEST_F(UrdfParserTest, BadInertiaFormats) {
 TEST_F(UrdfParserTest, BushingParsing) {
   // Test successful parsing.
   const std::string good_bushing_model = R"""(
-    <robot name="bushing_test">
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
         <link name='A'/>
         <link name='C'/>
         <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1402,8 +1392,8 @@ TEST_F(UrdfParserTest, BushingParsing) {
 }
 
 TEST_F(UrdfParserTest, BushingMissingFrameTag) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1417,13 +1407,12 @@ TEST_F(UrdfParserTest, BushingMissingFrameTag) {
         <drake:bushing_force_damping    value="10 11 12"/>
       </drake:linear_bushing_rpy>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*Unable to find the <drake:bushing_frameC> tag"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*unfinished.*bushing_frameC.*"));
 }
 
 TEST_F(UrdfParserTest, BushingFrameTagNameBroken) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1438,14 +1427,12 @@ TEST_F(UrdfParserTest, BushingFrameTagNameBroken) {
         <drake:bushing_force_damping    value="10 11 12"/>
       </drake:linear_bushing_rpy>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*Unable to read the 'name' attribute for the"
-                  " <drake:bushing_frameC> tag"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*attribute.*name.*"));
 }
 
 TEST_F(UrdfParserTest, BushingFrameNotExist) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1466,8 +1453,8 @@ TEST_F(UrdfParserTest, BushingFrameNotExist) {
 }
 
 TEST_F(UrdfParserTest, BushingMissingDamping) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1481,13 +1468,13 @@ TEST_F(UrdfParserTest, BushingMissingDamping) {
         <drake:bushing_force_damping    value="10 11 12"/>
       </drake:linear_bushing_rpy>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*Unable to find the <drake:bushing_torque_damping> tag"));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*unfinished.*bushing_torque_damping.*"));
 }
 
 TEST_F(UrdfParserTest, BushingMissingValueAttribute) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1502,9 +1489,7 @@ TEST_F(UrdfParserTest, BushingMissingValueAttribute) {
         <drake:bushing_force_damping    value="10 11 12"/>
       </drake:linear_bushing_rpy>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*Unable to read the 'value' attribute for the"
-                  " <drake:bushing_torque_stiffness> tag"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*attribute.*value.*"));
 }
 
 class BallConstraintTest : public UrdfParserTest {
@@ -1547,7 +1532,8 @@ class BallConstraintTest : public UrdfParserTest {
                     const std::optional<const std::string>& body_B,
                     const std::optional<const Vector3d>& p_AP,
                     const std::optional<const Vector3d>& p_BQ,
-                    const std::string& error_pattern) {
+                    const std::string& error_pattern,
+                    bool expect_parse_success = false) {
     std::string text = fmt::format(
         kTestString,
         body_A.has_value()
@@ -1566,14 +1552,18 @@ class BallConstraintTest : public UrdfParserTest {
             ? fmt::format("<drake:ball_constraint_p_BQ value=\"{} {} {}\"/>",
                           p_BQ.value().x(), p_BQ.value().y(), p_BQ.value().z())
             : "");
-    EXPECT_NE(AddModelFromUrdfString(text, ""), std::nullopt);
+    if (expect_parse_success) {
+      EXPECT_NE(AddModelFromUrdfString(text, ""), std::nullopt);
+    } else {
+      EXPECT_EQ(AddModelFromUrdfString(text, ""), std::nullopt);
+    }
     EXPECT_THAT(TakeError(), MatchesRegex(error_pattern));
   }
 
  protected:
   // Common URDF string with format options for the two custom tags.
   static constexpr const char* kTestString = R"""(
-    <robot name='ball_constraint_test'>
+    <robot xmlns:drake='http://drake.mit.edu' name='ball_constraint_test'>
       <link name='A'/>
       <link name='B'/>
       <drake:ball_constraint>
@@ -1592,29 +1582,29 @@ TEST_F(BallConstraintTest, AllParameters) {
 
 TEST_F(BallConstraintTest, MissingBodyA) {
   ProvokeError({}, "B", Vector3d(1, 2, 3), Vector3d(4, 5, 6),
-               ".*Unable to find the <drake:ball_constraint_body_A> tag");
+               ".*unfinished.*ball_constraint_body_A.*");
 }
 
 TEST_F(BallConstraintTest, MissingBodyB) {
   ProvokeError("A", {}, Vector3d(1, 2, 3), Vector3d(4, 5, 6),
-               ".*Unable to find the <drake:ball_constraint_body_B> tag");
+               ".*unfinished.*ball_constraint_body_B.*");
 }
 
 TEST_F(BallConstraintTest, Missing_p_AP) {
   ProvokeError("A", "B", {}, Vector3d(4, 5, 6),
-               ".*Unable to find the <drake:ball_constraint_p_AP> tag");
+               ".*unfinished.*ball_constraint_p_AP.*");
 }
 
 TEST_F(BallConstraintTest, Missing_p_BQ) {
   ProvokeError("A", "B", Vector3d(1, 2, 3), {},
-               ".*Unable to find the <drake:ball_constraint_p_BQ> tag");
+               ".*unfinished.*ball_constraint_p_BQ.*");
 }
 
 TEST_F(BallConstraintTest, InvalidBody) {
   ProvokeError(
       "INVALID", "B", Vector3d(1, 2, 3), Vector3d(4, 5, 6),
       ".*Body: INVALID specified for <drake:ball_constraint_body_A> does not"
-      " exist in the model.");
+      " exist in the model.", /*expect_parse_sucess*/true);
 }
 
 class ReflectedInertiaTest : public UrdfParserTest {
@@ -1646,7 +1636,7 @@ class ReflectedInertiaTest : public UrdfParserTest {
  protected:
   // Common URDF string with format options for the two custom tags.
   static constexpr const char* kTestString = R"""(
-    <robot name='reflected_inertia_test'>
+    <robot xmlns:drake='http://drake.mit.edu' name='reflected_inertia_test'>
       <link name='A'/>
       <link name='B'/>
       <joint name='revolute_AB' type='revolute'>
@@ -1734,7 +1724,7 @@ class ControllerGainsTest : public UrdfParserTest {
   // Common URDF string with format options for the custom tag with two
   // attributes.
   static constexpr const char* kTestString = R"""(
-    <robot name='reflected_inertia_test'>
+    <robot xmlns:drake='http://drake.mit.edu' name='reflected_inertia_test'>
       <link name='A'/>
       <link name='B'/>
       <joint name='revolute_AB' type='revolute'>
@@ -1853,42 +1843,34 @@ TEST_F(UrdfParserTest, CollisionFilterGroupParsingTest) {
 }
 
 TEST_F(UrdfParserTest, CollisionFilterGroupMissingName) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name='robot'>
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
+    <robot xmlns:drake='http://drake.mit.edu' name='robot'>
       <link name='a'/>
         <drake:collision_filter_group/>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*The tag <drake:collision_filter_group> does not specify"
-                  " the required attribute \"name\"."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*attribute.*name.*"));
 }
 
 TEST_F(UrdfParserTest, CollisionFilterGroupMissingLink) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name='robot'>
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
+    <robot xmlns:drake='http://drake.mit.edu' name='robot'>
       <link name='a'/>
       <drake:collision_filter_group name="group_a">
         <drake:member/>
       </drake:collision_filter_group>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*The tag <drake:member> does not specify the required "
-                  "attribute \"link\"."));
-  EXPECT_THAT(TakeError(), MatchesRegex(".*'robot::group_a'.*no members"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*attribute.*link.*"));
 }
 
 TEST_F(UrdfParserTest, IgnoredCollisionFilterGroupMissingName) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name='robot'>
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
+    <robot xmlns:drake='http://drake.mit.edu' name='robot'>
       <link name='a'/>
       <drake:collision_filter_group name="group_a">
         <drake:ignored_collision_filter_group/>
       </drake:collision_filter_group>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(".*'robot::group_a'.*no members"));
-  EXPECT_THAT(TakeError(), MatchesRegex(
-                  ".*The tag <drake:ignored_collision_filter_group> does not"
-                  " specify the required attribute \"name\"."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*attribute.*name.*"));
 }
 
 // Here follow tests to verify that Drake issues a warning when it ignores
@@ -1903,11 +1885,11 @@ TEST_F(UrdfParserTest, UnsupportedVersionIgnored) {
 }
 
 TEST_F(UrdfParserTest, UnsupportedLinkTypeIgnored) {
-  EXPECT_NE(AddModelFromUrdfString(R"""(
+  EXPECT_EQ(AddModelFromUrdfString(R"""(
     <robot name='robot'>
       <link name='a' type='unknown'/>
     </robot>)""", ""), std::nullopt);
-  EXPECT_THAT(TakeWarning(), MatchesRegex(".*type.*link.*ignored.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*type.*not.*"));
 }
 
 TEST_F(UrdfParserTest, UnsupportedJointStuffIgnored) {
@@ -2061,7 +2043,7 @@ TEST_F(UrdfParserTest, UnsupportedMechanicalReductionIgnoredMaybe) {
 
 TEST_F(UrdfParserTest, PlanarJointAxisRespected) {
   constexpr const char* model = R"""(
-    <robot name='a'>
+    <robot xmlns:drake='http://drake.mit.edu' name='a'>
       <link name="link1"/>
       <link name="link2"/>
       <drake:joint name="planar_joint" type="planar">
@@ -2091,7 +2073,7 @@ TEST_F(UrdfParserTest, PlanarJointAxisRespected) {
 
 TEST_F(UrdfParserTest, PlanarJointCanonicalFrame) {
   constexpr const char* model = R"""(
-    <robot name='a'>
+    <robot xmlns:drake='http://drake.mit.edu' name='a'>
       <link name="link1"/>
       <link name="link2"/>
       <drake:joint name="planar_joint" type="planar">

--- a/multibody/parsing/test/draft-rfcxml-general-template-annotated-00.xml
+++ b/multibody/parsing/test/draft-rfcxml-general-template-annotated-00.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+     draft-rfcxml-general-template-annotated-00
+  
+     This template includes examples of most of the features of RFCXML with comments explaining 
+     how to customise them, and examples of how to achieve specific formatting.
+     
+     Documentation is at https://authors.ietf.org/en/templates-and-schemas
+-->
+<?xml-model href="rfc7991bis.rnc"?>  <!-- Required for schema validation and schema-aware editing -->
+<!-- <?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?> --> 
+<!-- This third-party XSLT can be enabled for direct transformations in XML processors, including most browsers -->
+
+<!DOCTYPE rfc [
+  <!ENTITY nbsp    "&#160;">
+  <!ENTITY zwsp   "&#8203;">
+  <!ENTITY nbhy   "&#8209;">
+  <!ENTITY wj     "&#8288;">
+]>
+<!-- If further character entities are required then they should be added to the DOCTYPE above.
+     Use of an external entity file is not recommended. -->
+
+<rfc
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  category="info"
+  docName="draft-rfcxml-general-template-annotated-00"
+  ipr="trust200902"
+  obsoletes=""
+  updates=""
+  submissionType="IETF"
+  xml:lang="en"
+  version="3">
+<!-- 
+    * docName should be the name of your draft
+    * category should be one of std, bcp, info, exp, historic
+    * ipr should be one of trust200902, noModificationTrust200902, noDerivativesTrust200902, pre5378Trust200902
+    * updates can be an RFC number as NNNN
+    * obsoletes can be an RFC number as NNNN 
+-->
+
+  <front>
+    <title abbrev="Abbreviated Title">Title</title> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#title-4 -->
+    <!--  The abbreviated title is required if the full title is longer than 39 characters -->
+
+    <seriesInfo name="Internet-Draft" value="draft-rfcxml-general-template-annotated-00"/> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#seriesinfo -->
+    <!-- Set value to the name of the draft  -->
+   
+    <author fullname="Author's Full Name" initials="Author's Initials" role="editor" surname="Author's Surname"> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#author -->
+    <!-- initials should not include an initial for the surname -->
+    <!-- role="editor" is optional -->
+    <!-- Can have more than one author -->
+      
+    <!-- all of the following elements are optional -->
+      <organization>Organization</organization> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#organization -->
+      <address> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#address -->
+        <postal>
+          <!-- Reorder these if your country does things differently -->
+          <street>Street</street>
+          <city>City</city>
+          <region>Region</region>
+          <code>Postal code</code>
+          <country>Country</country>
+          <!-- Can use two letter country code -->
+        </postal>        
+        <phone>Phone</phone>
+        <email>Email</email>  
+        <!-- Can have more than one <email> element -->
+        <uri>URI</uri>
+      </address>
+    </author>
+   
+    <date year="2023" month="3" day="1"/> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#date -->
+    <!-- On draft subbmission:
+         * If only the current year is specified, the current day and month will be used.
+         * If the month and year are both specified and are the current ones, the current day will
+           be used
+         * If the year is not the current one, it is necessary to specify at least a month and day="1" will be used.
+    -->
+
+    <area>General</area>
+    <workgroup>Internet Engineering Task Force</workgroup>
+    <!-- "Internet Engineering Task Force" is fine for individual submissions.  If this element is 
+          not present, the default is "Network Working Group", which is used by the RFC Editor as 
+          a nod to the history of the RFC Series. -->
+    
+    <keyword>template</keyword>
+    <!-- Multiple keywords are allowed.  Keywords are incorporated into HTML output files for 
+         use by search engines. -->
+
+    <abstract>
+      <t>Abstract</t>
+    </abstract>
+ 
+  </front>
+
+  <middle>
+    
+    <section>
+    <!-- The default attributes for <section> are numbered="true" and toc="default" -->
+      <name>Introduction</name>
+      <t>Introductory text</t>
+      
+      <section anchor="requirements">
+      <!-- anchor is an optional attribute -->
+        <name>Requirements Language</name>
+        <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL",
+          "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT
+          RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+          interpreted as described in BCP 14 <xref target="RFC2119"/>
+          <xref target="RFC8174"/> when, and only when, they appear in
+          all capitals, as shown here.</t>
+      </section>
+      <!-- The 'Requirements Language' section is optional -->
+    </section>
+    
+    <section>
+      <name>Body</name>
+      <t>Body text</t>
+    </section>
+    
+    <section>
+      <name>List Examples</name>
+      
+      <section>
+        <name>Simple Unordered (Bullet) List</name>
+        <t>Text before the list</t>
+        <ul spacing="normal">
+          <li>First bullet</li>
+          <li>Second bullet</li>
+        </ul>
+        <t>Text after the list.</t>
+      </section>
+      
+      <section>
+        <name>Ordered List With Lowercase Letters in Brackets Instead of Numbers</name>
+        <ol type="(%c)"> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#type-1 -->
+          <li>List item (a)</li>
+          <li>List item (b)</li>
+        </ol>
+      </section>
+      
+      <section>
+        <name>Continuous Numbering in a List That is Split by Text or Sections</name>
+        <!-- The following two lists render as 
+        Text to introduce the list
+        REQ1: This will be "REQ1:"
+        REQ2: This will be "REQ2:"
+        Some text in between
+        REQ3: This will be "REQ3:"
+        REQ4: This will be "REQ4:"
+        -->
+        <t>Text to introduce the list</t>
+        <ol type="REQ%d:" group="reqs">  <!-- value of group is user-defined https://authors.ietf.org/en/rfcxml-vocabulary#group -->
+          <li>This will be "REQ1:"</li>
+          <li>This will be "REQ2:"</li>
+        </ol>
+        <t>Some text in between</t>
+        <ol type="REQ%d:" group="reqs">  <!-- same value of group as before -->
+          <li>This will be "REQ3:"</li>
+          <li>This will be "REQ4:"</li>
+        </ol>
+        <section>
+          <name>Section in-between</name>
+          <t>More text in-between</t>
+          <ol type="REQ%d:" group="reqs">  <!-- same value of group as before -->
+            <li>This will be REQ5:</li>
+            <li>This will be REQ6:</li>
+          </ol>
+        </section>
+      </section>
+      
+      <section>
+        <name>Definition Lists</name> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#dl -->
+        <dl newline="true"> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#newline -->
+        <!-- Omit newline="true" if you want each definition to start on the same line as the corresponding term -->
+          <dt>First term:</dt>
+          <dd>Definition of the first term</dd>
+          <dt>Second term:</dt>
+          <dd>Definition of the second term</dd>
+        </dl>
+      </section>
+      
+      <section>
+        <name>Lists With Hanging Labels</name>
+        <t>the list item is indented the value of indent</t>  <!--  https://authors.ietf.org/en/rfcxml-vocabulary#indent -->
+        <dl newline="true" spacing="normal" indent="8">
+        <!-- Custom indent of 8 with the defintion starting on a new line after the term -->
+          <dt>short</dt>
+          <dd>With a label shorter than the indent.</dd>
+          <dt>fantastically long label</dt>
+          <dd>With a label longer than the indent.</dd>
+        </dl>
+      </section>
+    </section>
+    
+    <section>
+      <name>Tables</name>
+      <table> <!-- https://authors.ietf.org/rfcxml-vocabulary#table -->
+        <thead> <!-- https://authors.ietf.org/rfcxml-vocabulary#thead -->
+        <!-- A table header is optional -->
+          <tr><th>Column 1</th><th>Column 2</th><th>Column 3</th></tr>
+        </thead>
+        <tbody> <!-- https://authors.ietf.org/rfcxml-vocabulary#tbody -->
+        <!-- A table body is required -->
+          <tr><td align="left">Left cell</td><td colspan="2">Colspan cell</td></tr>
+          <!-- align can be right, left or center.  colspan and rowspan work as they do in HTML -->
+          <tr><td rowspan="2">Rowspan cell</td><td align="center">Center cell</td><td align="right">Right cell</td></tr>
+          <tr><td>Cell</td><td>Cell</td></tr>
+        </tbody>
+        <tfoot> <!-- https://authors.ietf.org/rfcxml-vocabulary#tfoot -->
+        <!-- A table footer is optional -->
+          <tr><td colspan="3">Colspan footer</td></tr>
+        </tfoot>
+      </table>
+    </section>
+    
+    <section>
+      <name>Source Code Examples</name>
+      <t>This is an example C program</t>
+        <sourcecode name="helloworld.c" type="c" markers="true"> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#sourcecode -->
+          <![CDATA[
+#include <stdio.h>
+        
+int main() {
+  printf("Hello World");
+  return 0;
+}
+          ]]>
+        </sourcecode>
+        <!-- markers="true" means that the rendered file will have <CODE BEGINS> and <CODE ENDS> added. -->
+        <!-- The CDATA wrapper is optional but is strongly recommended to avoid any unexpected processing
+             or issues with angle brackets. 
+             <sourcecode></sourcecode> can optionally be wrapped in <figure></figure> -->
+    </section>
+    
+    <section anchor="adding-diagrams">
+    <!-- anchor is optional and used for reference below -->
+      <name>Adding Diagrams</name>
+      <figure>
+        <name>A Box</name>
+        <artset>  <!-- https://authors.ietf.org/en/rfcxml-vocabulary#artset -->
+        <!-- This <artset> includes two <artwork> elements, each of a different type.  Both are not 
+             always needed.  See https://authors.ietf.org/e/en/adding-diagrams -->
+          <artwork type="svg" name="https://www.rfc-editor.org/materials/format/svg/stream.svg">  <!-- https://authors.ietf.org/en/rfcxml-vocabulary#artwork -->
+            <!-- Inserting the SVG like this is only one way of adding an SVG diagram.  Another way is 
+                 to use the src attribute to point to an external file or URI.  The name attribute 
+                 recommends a filename to use if the artwork is extracted to a file. -->
+            <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 71 40">
+              <g>
+                <title>Layer 1</title>
+                <rect x="4.5" y="6.5" width="61.0" height="27.0" stroke="black" stroke-width="1.0" stroke-linecap="square" stroke-linejoin="miter" fill="none" />
+                <text x="33.883" text-anchor="middle" y="26.559">
+                  <tspan fill="black" font-size="13.0">A box</tspan>
+                </text>
+              </g>
+            </svg>
+          </artwork>
+          <artwork type="ascii-art" name="box.txt">
+            <![CDATA[
+ +--------+
+ | A box  |
+ +--------+          
+            ]]>
+          </artwork>
+        </artset>      
+      </figure>
+    </section>
+    
+    <section>
+      <name>Using xref</name>
+      <t>A reference to <xref target="adding-diagrams"/></t>
+      <t>A reference to <xref target="RFC8174" sectionFormat="of" section="2"/></t>
+    </section>
+    
+    <section anchor="IANA">
+    <!-- All drafts are required to have an IANA considerations section. See RFC 8126 for a guide.-->
+      <name>IANA Considerations</name>
+      <t>This memo includes no request to IANA.</t>
+    </section>
+    
+    <section anchor="Security">
+      <!-- All drafts are required to have a security considerations section. See RFC 3552 for a guide. -->
+      <name>Security Considerations</name>
+      <t>This document should not affect the security of the Internet.</t>
+    </section>
+    
+    <!-- NOTE: The Acknowledgements and Contributors sections are at the end of this template -->
+  </middle>
+
+  <back>
+    <references>
+      <name>References</name>
+      <references>
+        <name>Normative References</name>
+        
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+        <!-- The recommended and simplest way to include a well known reference -->
+        
+      </references>
+ 
+      <references>
+        <name>Informative References</name>
+       
+        <reference anchor="RFC2119" target="https://www.rfc-editor.org/info/rfc2119">
+        <!-- Manually added reference -->
+          <front>
+            <title>Key words for use in RFCs to Indicate Requirement Levels</title>
+            <author initials="S." surname="Bradner" fullname="S. Bradner">
+              <organization/>
+            </author>
+            <date year="1997" month="March"/>
+            <abstract>
+              <t>In many standards track documents several words are used to signify the requirements in the specification. These words are often capitalized. This document defines these words as they should be interpreted in IETF documents. This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.
+              </t>
+            </abstract>
+          </front>
+          <seriesInfo name="BCP" value="14"/>
+          <seriesInfo name="RFC" value="2119"/>
+          <seriesInfo name="DOI" value="10.17487/RFC2119"/>
+        </reference>
+       
+        <reference anchor="exampleRefMin">
+        <!-- Example minimum reference -->
+          <front>
+            <title>Title</title>
+            <author initials="Initials" surname="Surname">
+              <organization/>
+            </author>
+            <date year="2006"/>
+          </front>
+        </reference>
+
+        <reference anchor="exampleRefOrg" target="http://www.example.com/">
+        <!-- Example reference written by an organization not a person -->
+          <front>
+            <title>Title</title>
+            <author>
+              <organization>Organization</organization>
+            </author>
+            <date year="1984"/>
+          </front>
+        </reference>       
+       
+      </references>
+    </references>
+    
+    <section>
+      <name>Appendix 1</name>
+      <t>This becomes an Appendix</t>
+    </section>
+
+    <section anchor="Acknowledgements" numbered="false">
+      <!-- an Acknowledgements section is optional -->
+      <name>Acknowledgements</name>
+      <t>This template uses extracts from templates written by Pekka Savola, Elwyn Davies and 
+        Henrik Levkowetz.</t>
+    </section>
+    
+    <section anchor="Contributors" numbered="false">
+      <!-- a Contributors section is optional -->
+      <name>Contributors</name>
+      <t>Thanks to all of the contributors.</t>
+      <contact fullname="Jane Doe" initials="J" surname="Doe"><!-- https://authors.ietf.org/en/rfcxml-vocabulary#contact-->
+        <!-- including contact information for contributors is optional -->
+        <organization>Acme</organization>
+        <address>
+          <email>jdoe@example.com</email>
+        </address>
+      </contact>
+    </section>
+    
+ </back>
+</rfc>

--- a/multibody/parsing/test/draft-rfcxml-general-template-bare-00.xml
+++ b/multibody/parsing/test/draft-rfcxml-general-template-bare-00.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+     draft-rfcxml-general-template-bare-00
+  
+     This templates includes the bare minimum needed for the template to successfully validate 
+     against the RFCXML schema.  While it validates, it is not a valid Internet-Draft. This 
+     template is best used with an RNC schema-aware editor to assist with inserting valid elements 
+     and attributes. 
+     
+     Documentation is at https://authors.ietf.org/en/templates-and-schemas
+-->
+<?xml-model href="rfc7991bis.rnc"?>  <!-- Required for schema validation and schema-aware editing -->
+
+<!DOCTYPE rfc [
+  <!ENTITY nbsp    "&#160;">
+  <!ENTITY zwsp   "&#8203;">
+  <!ENTITY nbhy   "&#8209;">
+  <!ENTITY wj     "&#8288;">
+]>
+<!-- If further character entities are required then they should be added to the DOCTYPE above.
+     Use of an external entity file is not recommended. -->
+
+<rfc>
+  <front>
+    <title></title>
+    <author></author>
+   </front>
+  
+  <middle>
+    <section>
+    </section>
+  </middle>
+
+  <back>
+ </back>
+</rfc>

--- a/multibody/parsing/test/rfc7991bis.rnc
+++ b/multibody/parsing/test/rfc7991bis.rnc
@@ -1,0 +1,1150 @@
+#   rfc7991bis.rnc
+#
+#   RFCXML v3 RNC schema. Includes changes made after the publication of RFC
+#   7991 and features deprecated in RFC 7991.
+#
+#   To use in an RFCXML I-D add the following line before the <rfc> element:
+#        <?xml-model href="rfc7991bis.rnc"?>
+#
+#   Documentation is at https://authors.ietf.org/en/templates-and-schemas
+
+namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
+
+rfc =
+ element rfc {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute number { text }?,
+   [ a:defaultValue = "" ] attribute obsoletes { text }?,
+   [ a:defaultValue = "" ] attribute updates { text }?,
+   attribute category {
+     "std" | "bcp" | "exp" | "info" | "historic"
+   }?,
+   attribute mode { text }?,
+   [ a:defaultValue = "false" ]
+   attribute consensus { "no" | "yes" | "false" | "true" }?,
+   attribute seriesNo { text }?,
+   attribute ipr { text }?,
+   attribute iprExtract { xsd:IDREF }?,
+   [ a:defaultValue = "IETF" ]
+   attribute submissionType {
+     "IETF" | "IAB" | "IRTF" | "independent"
+   }?,
+   attribute docName { text }?,
+   [ a:defaultValue = "false" ]
+   attribute sortRefs { "true" | "false" }?,
+   [ a:defaultValue = "true" ]
+   attribute symRefs { "true" | "false" }?,
+   [ a:defaultValue = "true" ]
+   attribute tocInclude { "true" | "false" }?,
+   [ a:defaultValue = "3" ] attribute tocDepth { text }?,
+   attribute prepTime { text }?,
+   [ a:defaultValue = "true" ]
+   attribute indexInclude { "true" | "false" }?,
+   attribute version { text }?,
+   [ a:defaultValue = "Common,Latin" ] attribute scripts { text }?,
+   attribute expiresDate { text }?,
+   link*,
+   front,
+   middle,
+   back?
+ }
+
+link =
+ element link {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute href { text },
+   attribute rel { text }?
+ }
+
+front =
+ element front {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   title,
+   seriesInfo*,
+   author+,
+   date?,
+   area*,
+   workgroup*,
+   keyword*,
+   abstract?,
+   note*,
+   boilerplate?,
+   toc?
+ }
+
+title =
+ element title {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute abbrev { text }?,
+   attribute ascii { text }?,
+   (text | br)*
+ }
+
+author =
+ element author {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute initials { text }?,
+   attribute asciiInitials { text }?,
+   attribute surname { text }?,
+   attribute asciiSurname { text }?,
+   attribute fullname { text }?,
+   attribute role { "editor" }?,
+   attribute asciiFullname { text }?,
+   organization?,
+   address?
+ }
+
+contact =
+ element contact {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute initials { text }?,
+   attribute asciiInitials { text }?,
+   attribute surname { text }?,
+   attribute asciiSurname { text }?,
+   attribute fullname { text }?,
+   attribute asciiFullname { text }?,
+   organization?,
+   address?
+ }
+
+organization =
+ element organization {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute abbrev { text }?,
+   attribute ascii { text }?,
+   attribute asciiAbbrev { text }?,
+   [ a:defaultValue = "true" ]
+   attribute showOnFrontPage { "true" | "false" }?,
+   text
+ }
+
+address =
+ element address {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   postal?,
+   phone?,
+   facsimile?,
+   email*,
+   uri?
+ }
+
+postal =
+ element postal {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (( city | cityarea | code | country | extaddr | pobox | region
+      | sortingcode | street)*
+    | postalLine+)
+ }
+
+extaddr =
+ element extaddr {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+pobox =
+ element pobox {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+street =
+ element street {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+cityarea =
+ element cityarea {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+city =
+ element city {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+region =
+ element region {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+code =
+ element code {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+sortingcode =
+ element sortingcode {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+country =
+ element country {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+postalLine =
+ element postalLine {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+phone =
+ element phone {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+facsimile =
+ element facsimile {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+email =
+ element email {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+uri =
+ element uri {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+date =
+ element date {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute day { text }?,
+   attribute month { text }?,
+   attribute year { text }?,
+   text
+ }
+
+area =
+ element area {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+workgroup =
+ element workgroup {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+keyword =
+ element keyword {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+abstract =
+ element abstract {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   (dl | ol | t | ul)+
+ }
+
+note =
+ element note {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute title { text }?,
+   attribute pn { xsd:ID }?,
+   [ a:defaultValue = "false" ]
+   attribute removeInRFC { "true" | "false" }?,
+   name?,
+   (dl | ol | t | ul)+
+ }
+
+boilerplate =
+ element boilerplate {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   section+
+ }
+
+toc =
+ element toc {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   section*
+ }
+
+middle =
+ element middle {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   section+
+ }
+
+section =
+ element section {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   attribute title { text }?,
+   [ a:defaultValue = "true" ]
+   attribute numbered { "true" | "false" }?,
+   [ a:defaultValue = "default" ]
+   attribute toc { "include" | "exclude" | "default" }?,
+   [ a:defaultValue = "false" ]
+   attribute removeInRFC { "true" | "false" }?,
+   name?,
+   (artset
+    | artwork
+    | aside
+    | author
+    | blockquote
+    | contact
+    | dl
+    | figure
+    | iref
+    | ol
+    | sourcecode
+    | t
+    | table
+    | texttable
+    | ul)*,
+   section*
+ }
+
+name =
+ element name {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute slugifiedName { xsd:ID }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+br =
+ element br {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   empty
+ }
+
+t =
+ element t {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   attribute hangText { text }?,
+   [ a:defaultValue = "0" ]
+   attribute indent { text }?,
+   [ a:defaultValue = "false" ]
+   attribute keepWithNext { "true" | "false" }?,
+   [ a:defaultValue = "false" ]
+   attribute keepWithPrevious { "true" | "false" }?,
+   (text
+    | bcp14
+    | br
+    | contact
+    | cref
+    | em
+    | eref
+    | iref
+    | \list
+    | relref
+    | spanx
+    | strong
+    | sub
+    | sup
+    | tt
+    | u
+    | vspace
+    | xref)*
+ }
+
+aside =
+ element aside {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   (artset
+    | artwork
+    | blockquote
+    | dl
+    | figure
+    | iref
+    | ol
+    | t
+    | table
+    | ul)*
+
+ }
+
+blockquote =
+ element blockquote {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   attribute cite { text }?,
+   attribute quotedFrom { text }?,
+   ((artset | artwork | dl | figure | ol | sourcecode | t | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)+)
+ }
+
+\list =
+ element list {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "empty" ] attribute style { text }?,
+   attribute hangIndent { text }?,
+   attribute counter { text }?,
+   attribute pn { xsd:ID }?,
+   t+
+ }
+
+ol =
+ element ol {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "1" ] attribute type { text }?,
+   [ a:defaultValue = "1" ] attribute start { text }?,
+   attribute group { text }?,
+   [ a:defaultValue = "normal" ]
+   attribute spacing { "normal" | "compact" }?,
+   [ a:defaultValue = "adaptive" ]
+   attribute indent { text | "adaptive" }?,
+   attribute pn { xsd:ID }?,
+   li+
+ }
+
+ul =
+ element ul {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "normal" ]
+   attribute spacing { "normal" | "compact" }?,
+   ([ a:defaultValue = "false" ]
+    attribute empty { "true" | "false" },
+    [ a:defaultValue = "false" ]
+    attribute bare { "true" | "false" }?)?,
+   [ a:defaultValue = "3" ]
+    attribute indent { text }?,
+    attribute pn { xsd:ID }?,
+   li+
+ }
+
+li =
+ element li {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute derivedCounter { text }?,
+   attribute pn { xsd:ID }?,
+   (( artset
+      | artwork
+      | blockquote
+      | dl
+      | figure
+      | ol
+      | sourcecode
+      | t
+      | table
+      | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)+)
+ }
+
+dl =
+ element dl {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "normal" ]
+   attribute spacing { "normal" | "compact" }?,
+   [ a:defaultValue = "false" ]
+   attribute newline { "true" | "false" }?,
+   [ a:defaultValue = "3" ]
+   attribute indent { text }?,
+   attribute pn { xsd:ID }?,
+   (dt, dd)+
+ }
+
+dt =
+ element dt {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+dd =
+ element dd {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   (( artset
+      | artwork
+      | aside
+      | dl
+      | figure
+      | ol
+      | sourcecode
+      | t
+      | table
+      | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)+)
+ }
+
+xref =
+ element xref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute target { xsd:IDREF },
+   [ a:defaultValue = "false" ]
+   attribute pageno { "true" | "false" }?,
+   [ a:defaultValue = "default" ]
+   attribute format { "default" | "title" | "counter" | "none" }?,
+   attribute derivedContent { text }?,
+   [ a:defaultValue = "of" ]
+   attribute sectionFormat { "of" | "comma" | "parens" | "bare" }?,
+   attribute section { text }?,
+   attribute relative { text }?,
+   attribute derivedLink { text }?,
+   (text | em | strong | sub | sup | tt)*
+ }
+
+relref =
+ element relref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute target { xsd:IDREF },
+   [ a:defaultValue = "of" ]
+   attribute displayFormat { "of" | "comma" | "parens" | "bare" }?,
+   attribute derivedContent { text }?,
+   attribute section { text },
+   attribute relative { text }?,
+   attribute derivedLink { text }?,
+   text
+ }
+
+eref =
+ element eref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "none" ]
+   attribute brackets { "none" | "angle" }?,
+   attribute target { text },
+   text
+ }
+
+iref =
+ element iref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute item { text },
+   [ a:defaultValue = "" ] attribute subitem { text }?,
+   [ a:defaultValue = "false" ]
+   attribute primary { "true" | "false" }?,
+   attribute pn { xsd:ID }?,
+   empty
+ }
+
+cref =
+ element cref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute source { text }?,
+   [ a:defaultValue = "true" ]
+   attribute display { "true" | "false" }?,
+   (text
+    | br
+    | em
+    | eref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+tt =
+ element tt {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | xref)*
+ }
+
+strong =
+ element strong {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+em =
+ element em {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+sub =
+ element sub {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+sup =
+ element sup {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+spanx =
+ element spanx {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "preserve" ]
+   attribute xml:space { "default" | "preserve" }?,
+   [ a:defaultValue = "emph" ] attribute style { text }?,
+   text
+ }
+
+vspace =
+ element vspace {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "0" ] attribute blankLines { text }?,
+   empty
+ }
+
+figure =
+ element figure {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   [ a:defaultValue = "" ] attribute title { text }?,
+   [ a:defaultValue = "false" ]
+   attribute suppress-title { "true" | "false" }?,
+   attribute src { text }?,
+   attribute originalSrc { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   [ a:defaultValue = "" ] attribute alt { text }?,
+   [ a:defaultValue = "" ] attribute width { text }?,
+   [ a:defaultValue = "" ] attribute height { text }?,
+   name?,
+   iref*,
+   preamble?,
+   (artset | artwork | sourcecode)+,
+   postamble?
+ }
+
+table =
+ element table {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "center" ]
+   attribute align { "left" | "center" | "right" }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   name?,
+   iref*,
+   thead?,
+   tbody+,
+   tfoot?
+ }
+
+preamble =
+ element preamble {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | spanx
+    | strong
+    | sub
+    | sup
+    | tt
+    | u
+    | xref)*
+ }
+
+artset =
+ element artset {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   artwork+
+ }
+
+
+artwork =
+ element artwork {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   attribute xml:space { text }?,
+   [ a:defaultValue = "" ] attribute name { text }?,
+   [ a:defaultValue = "" ] attribute type { text }?,
+   attribute src { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   [ a:defaultValue = "" ] attribute alt { text }?,
+   [ a:defaultValue = "" ] attribute width { text }?,
+   [ a:defaultValue = "" ] attribute height { text }?,
+   attribute originalSrc { text }?,
+   (text* | svg)
+ }
+include "SVG-1.2-RFC.rnc"
+
+sourcecode =
+ element sourcecode {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   [ a:defaultValue = "" ] attribute name { text }?,
+   [ a:defaultValue = "" ] attribute type { text }?,
+   [ a:defaultValue = "false" ]
+   attribute markers { "true" | "false" }?,
+   attribute src { text }?,
+   attribute originalSrc { text }?,
+   text
+ }
+
+thead =
+ element thead {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   tr+
+ }
+
+tbody =
+ element tbody {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   tr+
+ }
+
+tfoot =
+ element tfoot {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   tr+
+ }
+
+tr =
+ element tr {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   (td | th)+
+ }
+
+td =
+ element td {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "1" ] attribute colspan { text }?,
+   [ a:defaultValue = "1" ] attribute rowspan { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   ((artset | artwork | dl | figure | ol | sourcecode | t | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)*)
+ }
+
+th =
+ element th {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "1" ] attribute colspan { text }?,
+   [ a:defaultValue = "1" ] attribute rowspan { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   ((artset | artwork | dl | figure | ol | sourcecode | t | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)*)
+ }
+
+postamble =
+ element postamble {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text | cref | eref | iref | spanx | xref)*
+ }
+
+texttable =
+ element texttable {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "" ] attribute title { text }?,
+   [ a:defaultValue = "false" ]
+   attribute suppress-title { "true" | "false" }?,
+   [ a:defaultValue = "center" ]
+   attribute align { "left" | "center" | "right" }?,
+   [ a:defaultValue = "full" ]
+   attribute style { "all" | "none" | "headers" | "full" }?,
+   name?,
+   preamble?,
+   ttcol+,
+   c*,
+   postamble?
+ }
+
+ttcol =
+ element ttcol {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute width { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   (cref | eref | iref | xref | text)*
+ }
+
+c =
+ element c {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text | cref | eref | iref | spanx | xref)*
+ }
+
+bcp14 =
+ element bcp14 {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+back =
+ element back {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   displayreference*,
+   references*,
+   section*
+ }
+
+displayreference =
+ element displayreference {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute target { xsd:IDREF },
+   attribute to { text }
+ }
+
+references =
+ element references {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute pn { xsd:ID }?,
+   attribute anchor { xsd:ID }?,
+   attribute title { text }?,
+   name?,
+   (references+ | (reference | referencegroup)*)
+ }
+
+reference =
+ element reference {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID },
+   attribute derivedAnchor { text }?,
+   attribute target { text }?,
+   [ a:defaultValue = "true" ]
+   attribute quoteTitle { "true" | "false" }?,
+   attribute quote-title { "true" | "false" }?,
+   stream?,
+   front,
+   (annotation | format | refcontent | seriesInfo)*
+ }
+
+stream =
+ element stream {
+   ( "IETF" | "IAB" | "IRTF" | "independent" )?
+}
+
+referencegroup =
+ element referencegroup {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID },
+   attribute derivedAnchor { text }?,
+   attribute target { text }?,
+   reference+
+ }
+
+seriesInfo =
+ element seriesInfo {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute name { text },
+   attribute value { text },
+   attribute asciiName { text }?,
+   attribute asciiValue { text }?,
+   attribute status { text }?,
+   attribute stream { "IETF" | "IAB" | "IRTF" | "independent" }?,
+   empty
+ }
+
+format =
+ element format {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute target { text }?,
+   attribute type { text },
+   attribute octets { text }?,
+   empty
+ }
+
+annotation =
+ element annotation {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | spanx
+    | strong
+    | sub
+    | sup
+    | tt
+    | u
+    | xref)*
+ }
+
+refcontent =
+ element refcontent {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text | bcp14 | em | strong | sub | sup | tt)*
+ }
+
+u =
+ element u {
+   attribute anchor { xsd:ID }?,
+   attribute ascii { text }?,
+   [ a:defaultValue = "lit-name-num" ]
+   attribute format { text }?,
+   attribute pn { xsd:ID }?,
+   text
+ }
+
+start |= rfc

--- a/multibody/parsing/urdf.rnc
+++ b/multibody/parsing/urdf.rnc
@@ -1,0 +1,202 @@
+# Schema for URDF as seen and used by Drake.
+# Relax NG Compact Syntax.
+#
+# An easy but runtime-slow way to validate:
+#  $ apt install jing
+#  $ jing -c urdf.rnc [ROBOT-FILE...]
+#
+# A faster way (that could maybe get linked directly into drake later):
+#   $ git clone git@github.com:hartwork/rnv.git
+#   $ cd rnv
+#   $ apt install asciidoc-base  # could skip, with some patching
+#   $ apt install libexpat1-dev
+#   $ ./bootstrap
+#   $ ./configure
+#   $ make
+#   $ ./rnv urdf.rnc [ROBOT-FILE]
+#
+# TODO proper Drake tag checking
+# TODO refine open schema tricks
+namespace drake = "http://drake.mit.edu"
+
+grammar {
+   start = Robot
+   Robot = element robot {
+      Name?, attribute version { text }?,
+      (Joint* &
+         LinkE* &
+         Frame* &
+         MaterialGlobal* &
+         Transmission* &
+         DrakeBallConstraint* &
+         DrakeJoint* &
+         DrakeLinearBushingRpy* &
+         DrakeCollisionFilterGroup* &
+         Gazebo* &
+         ObsoleteLoopJoint* &
+         Force*)
+   }
+
+   # This appears to be a bullet extension.
+   Force = element force_element { Anything }
+
+   # Extension back doors.
+   Gazebo = element gazebo { Anything }
+   ObsoleteLoopJoint = element loop_joint { Anything }
+
+   Frame = element frame { Name, LinkA, Pose }
+
+   Joint = element joint {
+      (Name, DrakeIgnoreTrue, AnyE) |
+      (Name, DrakeIgnoreFalse? , Type,
+         (Origin? &
+            Parent &
+            Child &
+            Axis? &
+            Calibration? &
+            Dynamics? &
+            Limit? &
+            SafetyController? &
+            Mimic?))
+   }
+   DrakeJoint = element drake:joint {
+      (Name, DrakeIgnoreTrue, AnyE) |
+      (Name, DrakeIgnoreFalse? , Type,
+         (Origin? &
+            Parent &
+            Child &
+            Axis? &
+            Calibration? &
+            Dynamics? &
+            Limit? &
+            SafetyController? &
+            Mimic? &
+            DrakeScrewThreadPitch?))
+   }
+   DrakeLinearBushingRpy = element drake:linear_bushing_rpy {
+      element drake:bushing_frameA { Name } &
+      element drake:bushing_frameC { Name } &
+      element drake:bushing_torque_stiffness { Value } &
+      element drake:bushing_torque_damping { Value } &
+      element drake:bushing_force_stiffness { Value } &
+      element drake:bushing_force_damping { Value }
+   }
+
+   LinkE = element link {
+      (Name, DrakeIgnoreTrue, AnyE) |
+      (Name, DrakeIgnoreFalse? ,
+      (Inertial? & Visual* & Collision* & SelfCollisionChecking*))
+   }
+   MaterialGlobal = element material { Name, (Color? & Texture?) }
+   Material = element material { Name?, (Color? & Texture?) }
+   # Transmission specs seem contradictory and full of lies; best to give up.
+   Transmission = element transmission { Anything }
+
+   Origin = element origin { Pose }
+   Parent = element parent { LinkA }
+   Child = element child { LinkA }
+   Axis = element axis { attribute xyz { text }? }
+   Calibration = element calibration {
+      attribute reference_position { text }?,
+      attribute rising { text }?,
+      attribute falling { text }?
+   }
+   Dynamics = element dynamics {
+      attribute damping { text }?,
+      attribute friction { text }?,
+      # Paleo-Drake extension; now ignored. Perhaps it should go.
+      attribute coulomb_window { text }?
+   }
+   Limit = element limit {
+      attribute lower { text }?,
+      attribute upper { text }?,
+      attribute effort { text }?,
+      attribute velocity { text }?,
+      attribute drake:acceleration { text }?
+   }
+   # Drake ignores this, so don't police it here.
+   SafetyController = element safety_controller { Anything }
+   Mimic = element mimic {
+      attribute joint { text },
+      attribute multiplier { text }?,
+      attribute offset { text }?
+   }
+
+   Inertial = element inertial {
+      (Origin? & Mass? & Inertia?)
+   }
+   Visual = element visual {
+      Name?, (Origin? & Geometry & Material? & DrakeAcceptingRenderer? )
+   }
+   DrakeAcceptingRenderer = element drake:accepting_renderer { Name }
+   Collision = element collision {
+      Name?, (Origin? & Geometry & Material? & Verbose? & DrakeProximityProperties? )
+   }
+   SelfCollisionChecking = element self_collision_checking {
+      Name?, (Origin? & Geometry & Material? & Verbose?)
+   }
+
+   Geometry = element geometry {
+      # Capsule is non-standard magic: bullet has it, ROS is torn.
+      (Box | Cylinder | Sphere | Mesh | Capsule | DrakeCapsule | DrakeEllipsoid )
+   }
+
+   Inertia = element inertia {
+      attribute ixx { text }?,
+      attribute ixy { text }?,
+      attribute ixz { text }?,
+      attribute iyy { text }?,
+      attribute iyz { text }?,
+      attribute izz { text }?
+   }
+
+   Box = element box { attribute size { text }? }
+   Capsule = element capsule { CapsuleContents }
+   DrakeCapsule = element drake:capsule { CapsuleContents }
+   CapsuleContents = ( attribute radius { text }, attribute length { text} )
+   Cylinder = element cylinder { attribute radius { text }, attribute length { text} }
+   Mesh = element mesh { attribute filename { text }, attribute scale { text }?,
+      DrakeDeclareConvex? }
+   DrakeDeclareConvex = element drake:declare_convex { empty }
+   Sphere = element sphere { attribute radius { text } }
+   DrakeEllipsoid = element drake:ellipsoid {
+      attribute a { text }, attribute b { text }, attribute c { text } }
+
+   Color = element color { attribute rgba { text }? }
+   Mass = element mass { Value? }
+   Texture = element texture { attribute filename { text } }
+   Verbose = element verbose { Value }
+
+   # drake_ignore is dumb and should go away.
+   DrakeIgnoreFalse = attribute drake_ignore { string - "true" }
+   DrakeIgnoreTrue = attribute drake_ignore { "true" }
+
+   LinkA = attribute link { text }
+   Pose = attribute xyz { text }?, attribute rpy { text }?
+   Name = attribute name { text }
+   Type = attribute type { text }
+   Value = attribute value { text }
+
+   DrakeBallConstraint = element drake:ball_constraint {
+      element drake:ball_constraint_body_A { Name } &
+      element drake:ball_constraint_body_B { Name } &
+      element drake:ball_constraint_p_AP { Value } &
+      element drake:ball_constraint_p_BQ { Value }
+   }
+
+   DrakeCollisionFilterGroup = element drake:collision_filter_group {
+      Name, attribute ignore { text }?,
+      (DrakeMember* & DrakeIgnoredCollisionFilterGroup* )
+   }
+   DrakeMember = element drake:member { LinkA }
+   DrakeIgnoredCollisionFilterGroup = element drake:ignored_collision_filter_group { Name }
+
+   # TBD
+   DrakeProximityProperties = element drake:proximity_properties { Anything }
+   DrakeScrewThreadPitch = element drake:screw_thread_pitch { Anything }
+
+   # Patterns for things we pass over in silence.
+   Anything = ( element * { Anything } | attribute * { text } | text )*
+   AnyA = ( attribute * { Anything } )*
+   AnyE = ( element * { Anything } )*
+}

--- a/multibody/parsing/urdf.rnc
+++ b/multibody/parsing/urdf.rnc
@@ -1,22 +1,15 @@
 # Schema for URDF as seen and used by Drake.
 # Relax NG Compact Syntax.
 #
-# An easy but runtime-slow way to validate:
+# An external-to-drake way to validate:
 #  $ apt install jing
 #  $ jing -c urdf.rnc [ROBOT-FILE...]
 #
-# A faster way (that could maybe get linked directly into drake later):
-#   $ git clone git@github.com:hartwork/rnv.git
-#   $ cd rnv
-#   $ apt install asciidoc-base  # could skip, with some patching
-#   $ apt install libexpat1-dev
-#   $ ./bootstrap
-#   $ ./configure
-#   $ make
-#   $ ./rnv urdf.rnc [ROBOT-FILE]
+# A drake-source-build way to validate:
+#   $ bazel build //multibody/parsing:schema_validator
+#   $ bazel-bin/multibody/parsing/schema_validator \
+#       multibody/parsing/urdf.rnc [ROBOT-FILE]
 #
-# TODO proper Drake tag checking
-# TODO refine open schema tricks
 namespace drake = "http://drake.mit.edu"
 
 grammar {

--- a/multibody/plant/test/multibody_plant_query_object_connect_test.cc
+++ b/multibody/plant/test/multibody_plant_query_object_connect_test.cc
@@ -28,7 +28,6 @@ using systems::Context;
 using systems::DiagramBuilder;
 
 constexpr char kModelWithCollisions[] = R"""(
-<?xml version="1.0"?>
 <robot name="box">
   <link name="box">
     <inertial>
@@ -45,7 +44,6 @@ constexpr char kModelWithCollisions[] = R"""(
 )""";
 
 constexpr char kModelWithoutCollisions[] = R"""(
-<?xml version="1.0"?>
 <robot name="box">
   <link name="box">
     <inertial>

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -78,6 +78,7 @@ load("//tools/workspace/pycodestyle:repository.bzl", "pycodestyle_repository")
 load("//tools/workspace/python:repository.bzl", "python_repository")
 load("//tools/workspace/qdldl_internal:repository.bzl", "qdldl_internal_repository")  # noqa
 load("//tools/workspace/qhull_internal:repository.bzl", "qhull_internal_repository")  # noqa
+load("//tools/workspace/rnv_internal:repository.bzl", "rnv_internal_repository")  # noqa
 load("//tools/workspace/ros_xacro_internal:repository.bzl", "ros_xacro_internal_repository")  # noqa
 load("//tools/workspace/rules_license:repository.bzl", "rules_license_repository")  # noqa
 load("//tools/workspace/rules_python:repository.bzl", "rules_python_repository")  # noqa
@@ -286,6 +287,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         qdldl_internal_repository(name = "qdldl_internal", mirrors = mirrors)
     if "qhull_internal" not in excludes:
         qhull_internal_repository(name = "qhull_internal", mirrors = mirrors)
+    if "rnv_internal" not in excludes:
+        rnv_internal_repository(name = "rnv_internal", mirrors = mirrors)
     if "ros_xacro_internal" not in excludes:
         ros_xacro_internal_repository(name = "ros_xacro_internal", mirrors = mirrors)  # noqa
     if "rules_license" not in excludes:

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -25,6 +25,7 @@ load("//tools/workspace/drake_models:repository.bzl", "drake_models_repository")
 load("//tools/workspace/drake_visualizer:repository.bzl", "drake_visualizer_repository")  # noqa
 load("//tools/workspace/eigen:repository.bzl", "eigen_repository")
 load("//tools/workspace/expat:repository.bzl", "expat_repository")
+load("//tools/workspace/expat_internal:repository.bzl", "expat_internal_repository")  # noqa
 load("//tools/workspace/fcl_internal:repository.bzl", "fcl_internal_repository")  # noqa
 load("//tools/workspace/fmt:repository.bzl", "fmt_repository")
 load("//tools/workspace/gflags:repository.bzl", "gflags_repository")
@@ -173,6 +174,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         # The @expat external is deprecated in Drake's WORKSPACE and will be
         # removed on or after 2024-02-01.
         expat_repository(name = "expat")
+    if "expat_internal" not in excludes:
+        expat_internal_repository(name = "expat_internal", mirrors = mirrors)
     if "fcl_internal" not in excludes:
         fcl_internal_repository(name = "fcl_internal", mirrors = mirrors)
     if "fmt" not in excludes:

--- a/tools/workspace/expat_internal/BUILD.bazel
+++ b/tools/workspace/expat_internal/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/expat_internal/cmakedefines.bzl
+++ b/tools/workspace/expat_internal/cmakedefines.bzl
@@ -1,0 +1,28 @@
+# These are the Apple-specific CMake definitions we want to enable for Drake.
+# Keep this list alpha-sorted.
+_APPLE_CMAKE_DEFINES = [
+    "HAVE_ARC4RANDOM_BUF=1",
+]
+
+# These are the Linux-specific CMake definitions we want to enable for Drake.
+# Keep this list alpha-sorted.
+_LINUX_CMAKE_DEFINES = [
+    "HAVE_GETRANDOM=1",
+]
+
+# These are the settings we want to enable for Drake. A few of them towards the
+# bottom are conditional for Apple vs Linux. Keep this list alpha-sorted.
+CMAKE_DEFINES = [
+    "PACKAGE_NAME=\"expat\"",
+    "XML_CONTEXT_BYTES=1024",
+    "XML_GE=1",
+] + select({
+    "@drake//tools/cc_toolchain:apple": _APPLE_CMAKE_DEFINES,
+    "@drake//tools/cc_toolchain:linux": _LINUX_CMAKE_DEFINES,
+    "//conditions:default": [],
+})
+
+# These are the settings we want to disable for Drake on all platforms.
+# Keep this list alpha-sorted.
+CMAKE_UNDEFINES = [
+]

--- a/tools/workspace/expat_internal/package.BUILD.bazel
+++ b/tools/workspace/expat_internal/package.BUILD.bazel
@@ -1,0 +1,85 @@
+# -*- bazel -*-
+
+load("@drake//tools/skylark:cc.bzl", "cc_library")
+load(
+    "@drake//tools/workspace:cmake_configure_file.bzl",
+    "cmake_configure_file",
+)
+load("@drake//tools/install:install.bzl", "install")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_linkonly_library",
+)
+load(
+    "@drake//tools/workspace/expat_internal:cmakedefines.bzl",
+    "CMAKE_DEFINES",
+    "CMAKE_UNDEFINES",
+)
+
+licenses(["notice"])  # MIT
+
+package(default_visibility = ["//visibility:private"])
+
+# Group the headers exported by this library.
+cc_library(
+    name = "hdrs",
+    hdrs = ["expat/lib/expat.h"],
+)
+
+# Generate expat_config.h.
+cmake_configure_file(
+    name = "configure_file",
+    src = "expat/expat_config.h.cmake",
+    out = "expat/expat_config.h",
+    defines = CMAKE_DEFINES,
+    undefines = CMAKE_UNDEFINES,
+    strict = False,
+)
+
+# Compile the code (using both its exported headers and its private headers).
+cc_library(
+    name = "compiled",
+    srcs = glob(
+        ["expat/lib/*.c"],
+        allow_empty = False,
+    ),
+    hdrs = glob(["expat/lib/*.h"], allow_empty = False) + [
+        "expat/expat_config.h",
+        "expat/lib/xmltok_impl.c",
+        "expat/lib/xmltok_ns.c",
+    ],
+    copts = [
+        "-Wno-all",
+        "-fvisibility=hidden",
+    ],
+    includes = [
+        "expat",
+        "expat/lib",
+    ],
+    linkstatic = True,
+    deps = [":hdrs"],
+)
+
+# Strip the private headers out; we just want the object code.
+cc_linkonly_library(
+    name = "archive",
+    deps = [":compiled"],
+)
+
+# Combine the public headers with the object code.
+# This does not provide the private headers.
+cc_library(
+    name = "expat",
+    linkstatic = True,
+    deps = [
+        ":archive",
+        ":hdrs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+install(
+    name = "install",
+    docs = ["COPYING"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/workspace/expat_internal/repository.bzl
+++ b/tools/workspace/expat_internal/repository.bzl
@@ -1,0 +1,13 @@
+load("//tools/workspace:github.bzl", "github_archive")
+
+def expat_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "libexpat/libexpat",
+        commit = "be47f6d5e871382dc2ab783a9df416ec4370074e",
+        sha256 = "f8d003d61297773c3dbe84b8efc3e6ca1721cf12a1815e378b4a081b9b97eb57",  # noqa
+        build_file = ":package.BUILD.bazel",
+        mirrors = mirrors,
+    )

--- a/tools/workspace/rnv_internal/BUILD.bazel
+++ b/tools/workspace/rnv_internal/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/rnv_internal/package.BUILD.bazel
+++ b/tools/workspace/rnv_internal/package.BUILD.bazel
@@ -1,0 +1,73 @@
+# -*- bazel -*-
+
+load("@drake//tools/skylark:cc.bzl", "cc_library")
+load(
+    "@drake//tools/workspace:cmake_configure_file.bzl",
+    "cmake_configure_file",
+)
+load("@drake//tools/install:install.bzl", "install")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_linkonly_library",
+)
+
+licenses(["notice"])  # BSD-3-Clause
+
+package(default_visibility = ["//visibility:private"])
+
+# Group the headers exported by this library.
+cc_library(
+    name = "hdrs",
+    hdrs = ["er.h", "rnl.h", "xcl.h"],
+)
+
+# Compile the code (using both its exported headers and its private headers).
+cc_library(
+    name = "compiled",
+    srcs = glob(
+        ["*.c"],
+        exclude = ["arx.c", "rvp.c", "test.c", "xsdck.c"],
+        allow_empty = False,
+    ),
+    hdrs = glob(["rx_cls_*.c", "*.h"], allow_empty = False),
+    copts = [
+        "-Wno-all",
+        "-Wno-empty-body",
+        "-fvisibility=hidden",
+    ],
+    defines = [
+        "EXPAT_H=<expat.h>",
+        "UNISTD_H=<unistd.h>",
+        "SUPPRESS_MAIN",
+        'ARX_VERSION=\\"dontcare\\"',
+        'RNV_VERSION=\\"dontcare\\"',
+        'RVP_VERSION=\\"dontcare\\"',
+    ],
+    linkstatic = True,
+    deps = [":hdrs"],
+)
+
+# Strip the private headers out; we just want the object code.
+cc_linkonly_library(
+    name = "archive",
+    deps = [":compiled"],
+)
+
+# Combine the public headers with the object code.
+# This does not provide the private headers.
+cc_library(
+    name = "rnv",
+    linkstatic = True,
+    deps = [
+        ":archive",
+        ":hdrs",
+        "@expat_internal//:expat",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+install(
+    name = "install",
+    docs = ["COPYING"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/workspace/rnv_internal/patches/doc_api.patch
+++ b/tools/workspace/rnv_internal/patches/doc_api.patch
@@ -1,0 +1,196 @@
+[rnv] Expose schema validation via library functions
+
+As offered, rnv builds a number of command line programs. Drake uses
+portions of it as a library. This patch re-organizes and exposes schema
+parsing and document validation via library functions, with shared
+internal global state. The resulting interface is not thread-safe;
+clients should take the necessary precautions.
+
+--- xcl.c
++++ xcl.c
+@@ -1,4 +1,5 @@
+ /* $Id$ */
++#include "xcl.h"
+ 
+ #include <stdlib.h>
+ #include <stdarg.h>
+@@ -103,11 +104,20 @@ static void init(void) {
+   }
+ }
+ 
++void xcl_init(void) {
++  /* Configure the same defaults as main() does. */
++  verbose = 1;
++  nexp = NEXP;
++  init();
++}
++
+ static void clear(void) {
+   if(len_txt>LIM_T) {m_free(text); text=(char*)m_alloc(len_txt=LEN_T,sizeof(char));}
+   windup();
+ }
+ 
++void xcl_clear(void) { clear(); }
++
+ static void windup(void) {
+   text[n_txt=0]='\0';
+   level=0; lastline=lastcol=-1;
+@@ -156,7 +166,7 @@ static void characters(void *userData,const char *s,int len) {
+ static void processingInstruction(void *userData,
+     const char *target,const char *data) {
+   if(strcmp(PIXGFILE,target)==0) {
+-    if(xgfile) m_free(xgfile); 
++    if(xgfile) m_free(xgfile);
+     xgfile=s_clone((char*)data);
+   } else if(strcmp(PIXGPOS,target)==0) {
+     if(xgpos) m_free(xgpos);
+@@ -173,11 +183,13 @@ static int pipeout(void *buf,int len) {
+   }
+ }
+ 
+-static int process(int fd) {
++typedef int (*READABLE_FN)(void*, void*, int);
++
++static int process_readable(void* read_data, READABLE_FN read_fn) {
+   void *buf; int len;
+   for(;;) {
+     buf=XML_GetBuffer(expat,BUFSIZE);
+-    len=read(fd,buf,BUFSIZE);
++    len=read_fn(read_data,buf,BUFSIZE);
+     if(len<0) {
+       error_handler(XCL_ER_IO,xml,strerror(errno));
+       goto ERROR;
+@@ -190,18 +202,52 @@ static int process(int fd) {
+ 
+ PARSE_ERROR:
+   error_handler(XCL_ER_XML,XML_ErrorString(XML_GetErrorCode(expat)));
+-  while(peipe&&(len=read(fd,buf,BUFSIZE))!=0) peipe=peipe&&pipeout(buf,len);
++  while(peipe&&(len=read_fn(read_data,buf,BUFSIZE))!=0) {
++    peipe=peipe&&pipeout(buf,len);
++  }
+ ERROR:
+   return 0;
+ }
+ 
++static int fd_read(void* read_data, void* buf, int len) {
++  int fd = *(int*)read_data;
++  return read(fd, buf, len);
++}
++
++static int process(int fd) {
++  return process_readable(&fd, fd_read);
++}
++
++struct MemBlock {
++  const void* buf;
++  int len;
++  int cursor;
++} MemBlock;
++
++static int memory_read(void* read_data, void* buf, int len) {
++  struct MemBlock* mem_block = (struct MemBlock*)read_data;
++  int remaining = mem_block->len - mem_block->cursor;
++  if (remaining <= 0) { return 0; }
++  int result;
++  if (remaining > len) {
++    result = len;
++  } else {
++    result = remaining;
++  }
++  memcpy(buf, (char*)(mem_block->buf) + mem_block->cursor, result);
++  mem_block->cursor += result;
++  return result;
++}
++
+ static int externalEntityRef(XML_Parser p,const char *context,
+     const char *base,const char *systemId,const char *publicId) {
+   error_handler(XCL_ER_XENT);
+   return 1;
+ }
+ 
+-static void validate(int fd) {
++static void validate_readable(void* read_data, READABLE_FN read_fn,
++                                  const char* document_filename) {
++  xml = (char*)document_filename;  /* const_cast */
+   previous=current=start;
+   expat=XML_ParserCreateNS(NULL,':');
+   XML_SetParamEntityParsing(expat,XML_PARAM_ENTITY_PARSING_ALWAYS);
+@@ -209,10 +255,37 @@ static void validate(int fd) {
+   XML_SetCharacterDataHandler(expat,&characters);
+   XML_SetExternalEntityRefHandler(expat,&externalEntityRef);
+   XML_SetProcessingInstructionHandler(expat,&processingInstruction);
+-  ok=process(fd);
++  ok=process_readable(read_data, read_fn);
+   XML_ParserFree(expat);
+ }
+ 
++void xcl_validate_memory(const void* inbuf, int inlen,
++                         const char* document_filename) {
++  struct MemBlock mem_block = { inbuf, inlen, 0 };
++  validate_readable(&mem_block, memory_read, document_filename);
++}
++
++void xcl_validate_fd(int fd, const char* document_filename) {
++  validate_readable(&fd, fd_read, document_filename);
++}
++
++static void validate(int fd) {
++  xcl_validate_fd(fd, xml);
++}
++
++void xcl_rnl_fd(const char* schema_filename, int fd) {
++  start = rnl_fd((char*)schema_filename, fd);  /* const_cast */
++}
++
++void xcl_rnl_s(const char* schema_filename,
++               const char* schema_contents,
++               int schema_len) {
++  start = rnl_s((char*)schema_filename,  /* const_cast */
++                (char*)schema_contents,  /* const_cast */
++                schema_len);
++}
++
++
+ static void version(void) {(*er_printf)("rnv version %s\n",RNV_VERSION);}
+ static void usage(void) {(*er_printf)("usage: rnv {-[qnspc"
+ #if DXL_EXC
+diff --git xcl.h xcl.h
+new file mode 100644
+index 0000000..fd9f92f
+--- /dev/null
++++ xcl.h
+@@ -0,0 +1,34 @@
++/* $Id$ */
++
++#ifndef XCL_H
++#define XCL_H 1
++
++/* Prepare the validation library for use. The must be called before any other
++ * functions, and again to use the library after having called xcl_clear(). */
++extern void xcl_init(void);
++
++/* Release internally held resources. */
++extern void xcl_clear(void);
++
++/* Parse a schema, provided as an open file descriptor, and prepare internal
++ * resources for validating documents against it. The schema_filename is just a
++ * string to use in error messages. */
++extern void xcl_rnl_fd(const char* schema_filename, int fd);
++
++/* Parse a schema, provided as an in-memory string, and prepare internal
++ * resources for validating documents against it. The schema_filename is just a
++ * string to use in error messages. */
++extern void xcl_rnl_s(const char* schema_filename,
++                      const char* schema_contents,
++                      int schema_len);
++
++/* Validate a document, provided as an open file descriptor. The
++ * document_filename is just a string to use in error messages. */
++extern void xcl_validate_fd(int fd, const char* document_filename);
++
++/* Validate a document, provided as a memory buffer. The document_filename is
++ * just a string to use in error messages. */
++extern void xcl_validate_memory(const void* buf, int size,
++                                const char* document_filename);
++
++#endif

--- a/tools/workspace/rnv_internal/patches/memcheck.patch
+++ b/tools/workspace/rnv_internal/patches/memcheck.patch
@@ -1,0 +1,25 @@
+[rnv] Avoid valgrind memcheck errors
+
+This patch initializes some stack data, previously (and harmlessly) left
+unitialized, to avoid complaints from valgrind memcheck.
+
+Similar hazards in functions that Drake does not use are left untouched.
+
+diff --git rnl.c rnl.c
+index 65d899c..81986ed 100644
+--- rnl.c
++++ rnl.c
+@@ -45,11 +45,11 @@ int rnl_fn(char *fn) {
+ }
+ 
+ int rnl_fd(char *fn,int fd) {
+-  struct rnc_source src;
++  struct rnc_source src = {0};
+   rnc_bind(&src,fn,fd); return load(&src);
+ }
+ 
+ int rnl_s(char *fn,char *s,int len) {
+-  struct rnc_source src;
++  struct rnc_source src = {0};
+   rnc_stropen(&src,fn,s,len); return load(&src);
+ }

--- a/tools/workspace/rnv_internal/patches/no_exit.patch
+++ b/tools/workspace/rnv_internal/patches/no_exit.patch
@@ -1,0 +1,32 @@
+[rnv] Avoid calling exit(1)
+
+As offered, rnv builds a number of command line programs. Drake uses
+portions of it as a library.  This patch fixes some rare error handling
+branches to call abort() instead of exit(1). In the unlikely event that
+Drake usage causes defective memory allocation, the result will be an
+obvious crash and possible crash dump file, instead of a somewhat
+mysterious orderly exit.
+
+This patch should not be upstreamed to rnv as-is -- it will change the
+error behavior of the command-line programs.
+
+--- m.c
++++ m.c
+@@ -29,7 +29,7 @@ void *m_alloc(int length,int size) {
+   pmp=mp; mp+=(n+sizeof(int)-1)/sizeof(int)*sizeof(int);
+   if(mp>=memory+M_STATIC) {
+     (*er_printf)("failed to allocate %i bytes of memory\n",length*size);
+-    exit(1);
++    abort();
+   }
+   if(M_FILL!=-1) while(q!=mp) *(q++)=M_FILL;
+   return (char*)p;
+@@ -45,7 +45,7 @@ void *m_alloc(int length,int size) {
+   void *p=malloc(length*size);
+   if(p==NULL) {
+     (*er_printf)("failed to allocate %i bytes of memory\n",length*size);
+-    exit(1);
++    abort();
+   }
+   return p;
+ }

--- a/tools/workspace/rnv_internal/patches/no_main_symbol.patch
+++ b/tools/workspace/rnv_internal/patches/no_main_symbol.patch
@@ -1,0 +1,20 @@
+[rnv] Avoid main symbol for use as a library
+
+As offered, rnv builds a number of command line programs. Drake uses
+portions of it as a library. It is necessary to prevent useful modules
+from occupying the magic `main` symbol.
+
+This patch should not be upstreamed to rnv as-is -- it will break the
+upstream build.
+
+--- xcl.c
++++ xcl.c
+@@ -223,7 +223,7 @@ static void usage(void) {(*er_printf)("usage: rnv {-[qnspc"
+ #endif
+ "vh?]} schema.rnc {document.xml}\n");}
+ 
+-int main(int argc,char **argv) {
++int xcl_main(int argc,char **argv) {
+   init();
+ 
+   peipe=0; verbose=1; nexp=NEXP; rnck=0;

--- a/tools/workspace/rnv_internal/repository.bzl
+++ b/tools/workspace/rnv_internal/repository.bzl
@@ -1,0 +1,19 @@
+load("//tools/workspace:github.bzl", "github_archive")
+
+def rnv_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "hartwork/rnv",
+        commit = "e2435bfd9e67a1e8b3a34bae6919ee572465d435",
+        sha256 = "17a3b36a47a7c2be176b6152754eb362b9103b6656fc00736230f99555df8a37",  # noqa
+        build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/doc_api.patch",
+            ":patches/memcheck.patch",
+            ":patches/no_exit.patch",
+            ":patches/no_main_symbol.patch",
+        ],
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
Add schema-based structure checking to the URDF parser.

This is a draft and a roadmap; likely it will be split into chunks and merged piecewise.

Design reviews and build system clues are welcome here, but I don't expect this is really merge-ready yet.

Known defect: this currently relies on the deprecated `@expat` dependency. Presumably I would have to offer a source-built `@expat_internal` to be merge-ready.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20748)
<!-- Reviewable:end -->
