### PR TITLE
[multibody_doxygen] Remove incorrect statement about model frames

### DIFF
--- a/multibody/multibody_doxygen.h
+++ b/multibody/multibody_doxygen.h
@@ -198,9 +198,6 @@ Frame F's origin point Fo locates the frame and its basis orients the frame.
 Newton's laws of motion are valid in a non-rotating, non-accelerating "inertial
 frame", herein called the _World_ frame W (also called _Ground_ frame G or
 _Newtonian Frame_ N).  Any frame with fixed pose in W is also an inertial frame.
-Drake supports _Model_ frames (inertial frames fixed in W) so a simulation can
-be built from multiple independent models, each defined with respect to its own
-Model frame. This corresponds to the `<model>` tag in an `.sdf` file.
 
 In unambiguous situations, abbreviated notation uses the _frame_ name to also
 designate the frame's _origin_ or the frame's _basis_.  For example, if `A` and


### PR DESCRIPTION
As mentioned in https://github.com/RobotLocomotion/drake/pull/14397#issuecomment-1879309659

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20749)
<!-- Reviewable:end -->
