### PR TITLE
[plant] Fix exception safety bug in AddJointActuator

### DIFF
--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -297,11 +297,13 @@ const JointActuator<T>& MultibodyTree<T>::AddJointActuator(
                            "See documentation for Finalize() for details.");
   }
 
+  // Create the JointActuator before making any changes to our member fields, so
+  // if the JointActuator constructor throws our state will still be valid.
+  auto owned = std::make_unique<JointActuator<T>>(name, joint, effort_limit);
+  JointActuator<T>* actuator = owned.get();
   const JointActuatorIndex actuator_index =
       topology_.add_joint_actuator(joint.num_velocities());
-  owned_actuators_.push_back(
-      std::make_unique<JointActuator<T>>(name, joint, effort_limit));
-  JointActuator<T>* actuator = owned_actuators_.back().get();
+  owned_actuators_.push_back(std::move(owned));
   actuator->set_parent_tree(this, actuator_index);
   this->SetElementIndex(name, actuator_index, &actuator_name_to_index_);
   return *actuator;

--- a/multibody/tree/test/joint_actuator_test.cc
+++ b/multibody/tree/test/joint_actuator_test.cc
@@ -85,8 +85,15 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
 
   tree.Finalize();
 
-  EXPECT_EQ(tree.num_actuated_dofs(), 6);
-  EXPECT_EQ(actuator4.input_start(), 3);
+  // Tally of *successfully* added actuators:
+  // - act1 has 1 dof
+  // - act2 was an error (never added)
+  // - act3 was an error (never added)
+  // - act4 has 3 dofs
+  EXPECT_EQ(tree.num_actuated_dofs(), 4);
+  EXPECT_EQ(actuator1.input_start(), 0);
+  EXPECT_EQ(actuator1.num_inputs(), 1);
+  EXPECT_EQ(actuator4.input_start(), 1);
   EXPECT_EQ(actuator4.num_inputs(), 3);
 }
 


### PR DESCRIPTION
Extracted out of #20711, with improved unit test clarity.

+@sherm1 for both reviews, please.

\CC @RussTedrake FYI

---

This was previously observed here:

> Note: It's a little strange that the actuators which throw an exception in the existing tests are still added to the topology.

-- https://github.com/RobotLocomotion/drake/pull/16835#pullrequestreview-918689989

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20751)
<!-- Reviewable:end -->
