### PR TITLE
Throw when Transform::Sample is called with a base frame.

### DIFF
--- a/common/schema/test/transform_test.cc
+++ b/common/schema/test/transform_test.cc
@@ -60,7 +60,6 @@ GTEST_TEST(StochasticTest, TransformTest) {
 }
 
 const char* random_bounded = R"""(
-base_frame: baz
 translation: !UniformVector { min: [1., 2., 3.], max: [4., 5., 6.] }
 rotation: !Rpy
   deg: !UniformVector
@@ -107,6 +106,26 @@ GTEST_TEST(StochasticSampleTest, TransformTest) {
           Eigen::Vector3d(390., 0., 0.) * (M_PI / 180.0)),
       Eigen::Vector3d(2.5, 3.5, 4.5));
   EXPECT_TRUE(transform.Mean().IsExactlyEqualTo(expected_mean));
+}
+
+GTEST_TEST(StochasticSampleTest, TransformTestWithBaseFrame) {
+  const Transform transform = LoadYamlString<Transform>(random_bounded);
+  drake::RandomGenerator generator(0);
+  const math::RigidTransformd sampled_rigidtransformd =
+      transform.Sample(&generator);
+
+  Transform transform_with_base_frame = transform;
+  transform_with_base_frame.base_frame = "baz";
+  EXPECT_THROW(transform_with_base_frame.Sample(&generator), std::exception);
+  generator = drake::RandomGenerator(0);
+  const Transform sampled_transform =
+      transform_with_base_frame.SampleAsTransform(&generator);
+
+  EXPECT_EQ(sampled_transform.GetDeterministicValue().translation(),
+            sampled_rigidtransformd.translation());
+  EXPECT_TRUE(
+    sampled_transform.GetDeterministicValue().rotation().IsNearlyEqualTo(
+        sampled_rigidtransformd.rotation(), 1e-14));
 }
 
 }  // namespace

--- a/common/schema/transform.cc
+++ b/common/schema/transform.cc
@@ -2,6 +2,8 @@
 
 #include <stdexcept>
 
+#include <fmt/format.h>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
 #include "drake/math/rotation_matrix.h"
@@ -10,6 +12,35 @@ namespace drake {
 namespace schema {
 
 using symbolic::Expression;
+
+namespace {
+math::RigidTransformd SampleInternal(const Transform& stochastic_transform,
+                                     RandomGenerator* generator) {
+  // It is somewhat yak-shavey to get an actual materialized transform here.
+  // We convert to symbolic, convert the symbolic to a vector and matrix of
+  // symbolic, `Evaluate` those, convert the result back to a
+  // `RigidTransform<double>`, and build the resulting values into a new
+  // fully deterministic `Transform`.
+  //
+  // This is *much* prettier written with `auto` but please do not be
+  // tempted to use it here: I have left the long type names in because it
+  // is impossible to debug Eigen `enable_if` error messages without them.
+  const math::RigidTransform<Expression> symbolic_transform =
+      stochastic_transform.ToSymbolic();
+
+  const Vector3<Expression> symbolic_translation =
+      symbolic_transform.translation();
+  const Eigen::Vector3d concrete_translation =
+      symbolic::Evaluate(symbolic_translation, {}, generator);
+
+  const math::RotationMatrix<Expression> symbolic_rotation =
+      symbolic_transform.rotation();
+  const math::RotationMatrixd concrete_rotation(
+      symbolic::Evaluate(symbolic_rotation.matrix(), {}, generator));
+
+  return math::RigidTransformd{concrete_rotation, concrete_translation};
+}
+}  // namespace
 
 Transform::Transform(const math::RigidTransformd& x) {
   translation = x.translation();
@@ -59,31 +90,20 @@ math::RigidTransformd Transform::Mean() const {
       symbolic.GetAsMatrix34().unaryExpr(to_double));
 }
 
-math::RigidTransformd Transform::Sample(
-    RandomGenerator* generator) const {
-  // It is somewhat yak-shavey to get an actual materialized transform here.
-  // We convert to symbolic, convert the symbolic to a vector and matrix of
-  // symbolic, `Evaluate` those, convert the result back to a
-  // `RigidTransform<double>`, and build the resulting values into a new
-  // fully deterministic `Transform`.
-  //
-  // This is *much* prettier written with `auto` but please do not be
-  // tempted to use it here: I have left the long type names in because it
-  // is impossible to debug Eigen `enable_if` error messages without them.
-  const math::RigidTransform<Expression> symbolic_transform =
-      ToSymbolic();
+Transform Transform::SampleAsTransform(RandomGenerator* generator) const {
+  Transform result(SampleInternal(*this, generator));
+  result.base_frame = base_frame;
+  return result;
+}
 
-  const Vector3<Expression> symbolic_translation =
-      symbolic_transform.translation();
-  const Eigen::Vector3d concrete_translation =
-      symbolic::Evaluate(symbolic_translation, {}, generator);
-
-  const math::RotationMatrix<Expression> symbolic_rotation =
-      symbolic_transform.rotation();
-  const math::RotationMatrixd concrete_rotation(
-      symbolic::Evaluate(symbolic_rotation.matrix(), {}, generator));
-
-  return math::RigidTransformd{concrete_rotation, concrete_translation};
+math::RigidTransformd Transform::Sample(RandomGenerator* generator) const {
+  if (base_frame.has_value() && (*base_frame != "world")) {
+    throw std::runtime_error(fmt::format(
+        "Transform::Sample() would discard non-trivial base frame \"{}\"; "
+        "use SampleAsTransform instead.",
+        *base_frame));
+  }
+  return SampleInternal(*this, generator);
 }
 
 }  // namespace schema

--- a/common/schema/transform.h
+++ b/common/schema/transform.h
@@ -186,7 +186,15 @@ class Transform {
 
   /// Samples this Transform.  If this is deterministic, the result is the same
   /// as GetDeterministicValue.
+  ///
+  /// @throw std::exception if this has a non-world base frame (because the
+  ///        return type has no base frame, so the returned value would be
+  ///        misleading).
   math::RigidTransformd Sample(RandomGenerator* generator) const;
+
+  /// Samples this Transform; the returned value is deterministic and has the
+  /// same base frame.
+  Transform SampleAsTransform(RandomGenerator* generator) const;
 
   template <typename Archive>
   void Serialize(Archive* a) {


### PR DESCRIPTION
 * Resolves #20754:  Sample() was silently discarding base_frame.
 * Throws when called in the dangerous case.
 * Adds new SampleAsTransform() method that samples into the same type, preseving the frame.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20756)
<!-- Reviewable:end -->
