### PR TITLE
Allow add_directives of directives including collision filters

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -462,6 +462,7 @@ drake_cc_googletest(
     deps = [
         ":process_model_directives",
         "//common/test_utilities",
+        "//common/yaml",
     ],
 )
 

--- a/multibody/parsing/detail_dmd_parser.cc
+++ b/multibody/parsing/detail_dmd_parser.cc
@@ -58,12 +58,8 @@ void ParseModelDirectivesImpl(
   DRAKE_DEMAND(plant != nullptr);
   auto get_scoped_frame = [plant = plant, &model_namespace](
                               const std::string& name) -> const Frame<double>& {
-    // TODO(eric.cousineau): Simplify logic?
-    if (name == "world") {
-      return plant->world_frame();
-    }
     return GetScopedFrameByName(
-        *plant, ScopedName::Join(model_namespace, name).to_string());
+        *plant, DmdScopedNameJoin(model_namespace, name).to_string());
   };
 
   for (auto& directive : directives.directives) {
@@ -153,15 +149,17 @@ void ParseModelDirectivesImpl(
       if (!plant->geometry_source_is_registered()) {
         continue;
       }
+      auto& group = *directive.add_collision_filter_group;
 
       // Find the model instance index that corresponds to model_namespace, if
       // the name is non-empty.
       std::optional<ModelInstanceIndex> model_instance;
       if (!model_namespace.empty()) {
         model_instance = plant->GetModelInstanceByName(model_namespace);
+      } else if (group.model_namespace.has_value()) {
+        model_instance = plant->GetModelInstanceByName(*group.model_namespace);
       }
 
-      auto& group = *directive.add_collision_filter_group;
       drake::log()->debug("  add_collision_filter_group: {}", group.name);
       std::set<std::string> member_set(group.members.begin(),
                                        group.members.end());
@@ -196,6 +194,12 @@ void ParseModelDirectivesImpl(
 }
 
 }  // namespace
+
+ScopedName DmdScopedNameJoin(const std::string& namespace_name,
+                             const std::string& element_name) {
+  if (element_name == "world") return ScopedName("", element_name);
+  return ScopedName::Join(namespace_name, element_name);
+}
 
 ModelDirectives LoadModelDirectives(const DataSource& data_source) {
   // Even though the 'defaults' we use to start parsing here are empty, by

--- a/multibody/parsing/detail_dmd_parser.h
+++ b/multibody/parsing/detail_dmd_parser.h
@@ -9,10 +9,16 @@
 #include "drake/multibody/parsing/model_directives.h"
 #include "drake/multibody/parsing/model_instance_info.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
+#include "drake/multibody/tree/scoped_name.h"
 
 namespace drake {
 namespace multibody {
 namespace internal {
+
+// DMD adds one small bit of sugar to Drake's ScopedName idiom:  The name
+// "world" always refers to the world regardless of any enclosing scopes.
+ScopedName DmdScopedNameJoin(const std::string& namespace_name,
+                             const std::string& element_name);
 
 // TODO(#18052): diagnostic policy?
 parsing::ModelDirectives LoadModelDirectives(const DataSource& data_source);

--- a/multibody/parsing/model_directives.h
+++ b/multibody/parsing/model_directives.h
@@ -187,11 +187,16 @@ struct AddCollisionFilterGroup {
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(name));
     a->Visit(DRAKE_NVP(members));
+    a->Visit(DRAKE_NVP(model_namespace));
     a->Visit(DRAKE_NVP(ignored_collision_filter_groups));
   }
 
-  /// Name of group to be added. Must not be a scoped name.
+  /// Name of group to be added.  This is an unscoped name, and must be
+  /// unique either globally or within its specified model namespace.
   std::string name;
+  /// Optional model namespace.  Allows `name` to be reused between models
+  /// and lets you use the scoped name in `ignored_collision_filter_groups`.
+  std::optional<std::string> model_namespace;
   /// Names of members of the group. May be scoped and refer to bodies of
   /// already added models. This data is analogous to a sequence of
   /// @ref tag_drake_member in XML model formats.

--- a/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
+++ b/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
@@ -62,8 +62,9 @@ TEST_F(CollisionFilterGroupResolverTest, BogusPairGlobal) {
 }
 
 TEST_F(CollisionFilterGroupResolverTest, BogusGroupName) {
-  resolver_.AddGroup(diagnostic_policy_, "haha::a", {}, {});
-  EXPECT_THAT(TakeError(), MatchesRegex(".*'haha::a' cannot be.*scoped.*"));
+  ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
+  resolver_.AddGroup(diagnostic_policy_, "haha::a", {}, r1);
+  EXPECT_THAT(TakeError(), MatchesRegex(".*haha::a' cannot be.*scoped.*"));
 }
 
 TEST_F(CollisionFilterGroupResolverTest, EmptyGroupGlobal) {

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -9,6 +9,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/yaml/yaml_io.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/revolute_joint.h"
@@ -32,13 +33,19 @@ using drake::systems::DiagramBuilder;
 const char* const kTestDir =
     "drake/multibody/parsing/test/process_model_directives_test";
 
-// Our unit test's package is not normally loaded; construct a parser that
-// has it and can resolve package://process_model_directives_test urls.
-std::unique_ptr<Parser> make_parser(MultibodyPlant<double>* plant) {
-  auto parser = std::make_unique<Parser>(plant);
+void add_test_package(PackageMap* package_map) {
   const std::filesystem::path abspath_xml = FindResourceOrThrow(
       std::string(kTestDir) + "/package.xml");
-  parser->package_map().AddPackageXml(abspath_xml.string());
+  package_map->AddPackageXml(abspath_xml.string());
+}
+
+// Our unit test's package is not normally loaded; construct a parser that
+// has it and can resolve package://process_model_directives_test urls.
+std::unique_ptr<Parser> make_parser(
+  MultibodyPlant<double>* plant,
+  geometry::SceneGraph<double>* scene_graph = nullptr) {
+  auto parser = std::make_unique<Parser>(plant, scene_graph);
+  add_test_package(&(parser->package_map()));
   return parser;
 }
 
@@ -472,6 +479,56 @@ GTEST_TEST(ProcessModelDirectivesTest, Flatten) {
     reflattened_names.insert(info.model_name);
   }
   EXPECT_EQ(flat_names, reflattened_names);
+}
+
+// Test adapted from
+// https://github.com/RobotLocomotion/drake/pull/20757#issuecomment-1884115261
+// to verify the expected result of flattening two copies of the same file
+// containing a collision filter group.
+GTEST_TEST(ProcessModelDirectivesTest, FlattenCollisionGroups) {
+  PackageMap package_map;
+  add_test_package(&package_map);
+
+  // Load the directives hierarchy.
+  const ModelDirectives directives = LoadModelDirectives(FindResourceOrThrow(
+      std::string(kTestDir) + "/unflattened_top.dmd.yaml"));
+
+  // Flatten the directives hierarchy.
+  ModelDirectives flat_directives;
+  FlattenModelDirectives(directives, package_map, &flat_directives);
+
+  // Load the expected result of flattening.
+  const ModelDirectives expected_directives =
+      LoadModelDirectives(FindResourceOrThrow(
+          std::string(kTestDir) + "/flattened.dmd.yaml"));
+
+  // Check that the flattened directives are identical to the expected ones.
+  const std::string flattened = yaml::SaveYamlString(flat_directives);
+  const std::string expected = yaml::SaveYamlString(expected_directives);
+  EXPECT_EQ(flattened, expected);
+
+  // Check that both flattened and expected can be processed.
+  {
+    MultibodyPlant<double> plant(0.0);
+    geometry::SceneGraph<double> scene_graph;
+    std::unique_ptr<Parser> parser = make_parser(&plant, &scene_graph);
+    std::vector<ModelInstanceInfo> added_models =
+      ProcessModelDirectives(flat_directives, parser.get());
+    ASSERT_EQ(added_models.size(), 4);
+  }
+  {
+    MultibodyPlant<double> plant(0.0);
+    geometry::SceneGraph<double> scene_graph;
+    std::unique_ptr<Parser> parser = make_parser(&plant, &scene_graph);
+    std::vector<ModelInstanceInfo> added_models =
+      ProcessModelDirectives(expected_directives, parser.get());
+    ASSERT_EQ(added_models.size(), 4);
+  }
+
+  // This test does not directly test collision filtering, as we know it
+  // should work because the test dmd.yaml file contains collision filter
+  // groups that reference one another by scoped name.  For testing against
+  // collision filtering, see CollisionFilterGroupSmokeTest.
 }
 
 GTEST_TEST(ProcessModelDirectivesTest, FlattenWithWorld) {

--- a/multibody/parsing/test/process_model_directives_test/add_scoped_sub.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/add_scoped_sub.dmd.yaml
@@ -30,3 +30,9 @@ directives:
 - add_weld:
     parent: simple_model::frame
     child: extra_model::base
+
+- add_collision_filter_group:
+    name: sub_filter_group
+    members:
+    - extra_model::base
+    - simple_model::base

--- a/multibody/parsing/test/process_model_directives_test/fake_camera.sdf
+++ b/multibody/parsing/test/process_model_directives_test/fake_camera.sdf
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="fake_camera">
+    <link name="body">
+      <inertial>
+        <mass>0.1</mass>
+        <pose>0.01 0.02 0.03  0 0 0</pose>
+        <inertia>
+          <ixx>0.1</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.1</iyy>
+          <iyz>0</iyz>
+          <izz>0.1</izz>
+        </inertia>
+      </inertial>
+    </link>
+  </model>
+</sdf>

--- a/multibody/parsing/test/process_model_directives_test/flattened.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/flattened.dmd.yaml
@@ -1,0 +1,42 @@
+# The expected result of flattening `flatten_test_top.dmd.yaml`.
+directives:
+- add_model_instance:
+    name: right
+- add_model:
+    name: right::panda
+    file: package://drake/manipulation/models/franka_description/urdf/panda_arm.urdf
+- add_collision_filter_group:
+    name: panda_wrist_filter_group
+    model_namespace: right
+    members:
+    - panda::panda_link7
+- add_model:
+    name: right::camera
+    file: package://process_model_directives_test/fake_camera.sdf
+- add_collision_filter_group:
+    name: camera_filter_group
+    model_namespace: right
+    members:
+    - camera::body
+    ignored_collision_filter_groups:
+    - panda_wrist_filter_group
+- add_model_instance:
+    name: left
+- add_model:
+    name: left::panda
+    file: package://drake/manipulation/models/franka_description/urdf/panda_arm.urdf
+- add_collision_filter_group:
+    name: panda_wrist_filter_group
+    model_namespace: left
+    members:
+    - panda::panda_link7
+- add_model:
+    name: left::camera
+    file: package://process_model_directives_test/fake_camera.sdf
+- add_collision_filter_group:
+    name: camera_filter_group
+    model_namespace: left
+    members:
+    - camera::body
+    ignored_collision_filter_groups:
+    - panda_wrist_filter_group

--- a/multibody/parsing/test/process_model_directives_test/unflattened_arm.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/unflattened_arm.dmd.yaml
@@ -1,0 +1,23 @@
+# An example of a model directives file with an internal collision filter
+# group that could not be correctly imported by another dmd file prior to
+# #20757.
+#
+# Note that this is "unflattened" in that FlattenModeDirectives will impose a
+# model namespace on the `add_collision_filter_group` members.
+directives:
+- add_model:
+    name: panda
+    file: package://drake/manipulation/models/franka_description/urdf/panda_arm.urdf
+- add_collision_filter_group:
+    name: panda_wrist_filter_group
+    members:
+    - panda::panda_link7
+- add_model:
+    name: camera
+    file: package://process_model_directives_test/fake_camera.sdf
+- add_collision_filter_group:
+    name: camera_filter_group
+    members:
+    - camera::body
+    ignored_collision_filter_groups:
+    - panda_wrist_filter_group

--- a/multibody/parsing/test/process_model_directives_test/unflattened_top.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/unflattened_top.dmd.yaml
@@ -1,0 +1,14 @@
+# An example of a model directives file that mulitply imports another
+# directives file with an internal collision filter group.
+
+directives:
+- add_model_instance:
+    name: right
+- add_directives:
+    model_namespace: right
+    file: package://process_model_directives_test/unflattened_arm.dmd.yaml
+- add_model_instance:
+    name: left
+- add_directives:
+    model_namespace: left
+    file: package://process_model_directives_test/unflattened_arm.dmd.yaml


### PR DESCRIPTION
* add_collision_filter_group does not permit a scoped name
* add_directives has a model_namespace to apply to the included directives
* As a result, add_directives would cause a throw when flattening a dmd file containing add_collision_filter_group, even though that dmd file was valid.
* The more correct outcome is to use the add_directives model_namespace when processing filter groups.

This implicitly breaks the semantics of CollisionFilterGroupResolver, which forbids scoped names.  But afaict that is only because it can take a model instance as parsing context, which could conflict with the namespace. In fact the namespace and model instance context cases seem to be non- overlapping.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20757)
<!-- Reviewable:end -->
