### PR TITLE
[py planning] Fix deadlocks when using parallelize=True

### DIFF
--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -123,9 +123,11 @@ void init_perception(py::module m) {
             py::arg("p_CP"), cls_doc.FlipNormalsTowardPoint.doc)
         .def("VoxelizedDownSample", &Class::VoxelizedDownSample,
             py::arg("voxel_size"), py::arg("parallelize") = false,
+            py::call_guard<py::gil_scoped_release>(),
             cls_doc.VoxelizedDownSample.doc)
         .def("EstimateNormals", &Class::EstimateNormals, py::arg("radius"),
             py::arg("num_closest"), py::arg("parallelize") = false,
+            py::call_guard<py::gil_scoped_release>(),
             cls_doc.EstimateNormals.doc);
   }
 

--- a/bindings/pydrake/planning/BUILD.bazel
+++ b/bindings/pydrake/planning/BUILD.bazel
@@ -75,6 +75,18 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
+    name = "collision_checker_trace_test",
+    data = [
+        "//multibody:models",
+        "//planning/test_utilities:collision_ground_plane.sdf",
+    ],
+    num_threads = 2,
+    deps = [
+        ":planning",
+    ],
+)
+
+drake_py_unittest(
     name = "robot_diagram_test",
     data = [
         "//manipulation/models/iiwa_description:models",

--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -188,6 +188,7 @@ void DefinePlanningCollisionChecker(py::module m) {
             py::arg("q"), cls_doc.CheckContextConfigCollisionFree.doc)
         .def("CheckConfigsCollisionFree", &Class::CheckConfigsCollisionFree,
             py::arg("configs"), py::arg("parallelize") = true,
+            py::call_guard<py::gil_scoped_release>(),
             cls_doc.CheckConfigsCollisionFree.doc)
         .def("SetDistanceAndInterpolationProvider",
             &Class::SetDistanceAndInterpolationProvider, py::arg("provider"),
@@ -231,9 +232,11 @@ void DefinePlanningCollisionChecker(py::module m) {
         .def("CheckEdgeCollisionFreeParallel",
             &Class::CheckEdgeCollisionFreeParallel, py::arg("q1"),
             py::arg("q2"), py::arg("parallelize") = true,
+            py::call_guard<py::gil_scoped_release>(),
             cls_doc.CheckEdgeCollisionFreeParallel.doc)
         .def("CheckEdgesCollisionFree", &Class::CheckEdgesCollisionFree,
             py::arg("edges"), py::arg("parallelize") = true,
+            py::call_guard<py::gil_scoped_release>(),
             cls_doc.CheckEdgesCollisionFree.doc)
         .def("MeasureEdgeCollisionFree", &Class::MeasureEdgeCollisionFree,
             py::arg("q1"), py::arg("q2"),
@@ -246,9 +249,11 @@ void DefinePlanningCollisionChecker(py::module m) {
         .def("MeasureEdgeCollisionFreeParallel",
             &Class::MeasureEdgeCollisionFreeParallel, py::arg("q1"),
             py::arg("q2"), py::arg("parallelize") = true,
+            py::call_guard<py::gil_scoped_release>(),
             cls_doc.MeasureEdgeCollisionFreeParallel.doc)
         .def("MeasureEdgesCollisionFree", &Class::MeasureEdgesCollisionFree,
             py::arg("edges"), py::arg("parallelize") = true,
+            py::call_guard<py::gil_scoped_release>(),
             cls_doc.MeasureEdgesCollisionFree.doc)
         .def("CalcRobotClearance", &Class::CalcRobotClearance, py::arg("q"),
             py::arg("influence_distance"),

--- a/bindings/pydrake/planning/planning_py_visibility_graph.cc
+++ b/bindings/pydrake/planning/planning_py_visibility_graph.cc
@@ -13,7 +13,7 @@ void DefinePlanningVisibilityGraph(py::module m) {
 
   m.def("VisibilityGraph", &planning::VisibilityGraph, py::arg("checker"),
       py::arg("points"), py::arg("parallelize") = true,
-      doc.VisibilityGraph.doc);
+      py::call_guard<py::gil_scoped_release>(), doc.VisibilityGraph.doc);
 }
 
 }  // namespace internal

--- a/bindings/pydrake/planning/test/collision_checker_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_test.py
@@ -351,7 +351,7 @@ class TestCollisionChecker(unittest.TestCase):
         dut.CheckContextConfigCollisionFree(model_context=ccc, q=q)
         self.assertEqual(
             len(dut.CheckConfigsCollisionFree(
-                configs=[q]*4, parallelize=False)),
+                configs=[q]*4, parallelize=True)),
             4)
         dut.CheckConfigsCollisionFree([q])  # Omit the defaulted arg.
 
@@ -382,20 +382,20 @@ class TestCollisionChecker(unittest.TestCase):
         dut.CheckEdgeCollisionFree(q1=q, q2=q)
         dut.CheckEdgeCollisionFree(q1=q, q2=q, context_number=1)
         dut.CheckContextEdgeCollisionFree(model_context=ccc, q1=q, q2=q)
-        dut.CheckEdgeCollisionFreeParallel(q1=q, q2=q, parallelize=False)
+        dut.CheckEdgeCollisionFreeParallel(q1=q, q2=q, parallelize=True)
         self.assertEqual(
             len(dut.CheckEdgesCollisionFree(
                 edges=[(q, q)]*4,
-                parallelize=False)),
+                parallelize=True)),
             4)
         dut.CheckEdgesCollisionFree([(q, q)])  # Omit the defaulted arg.
 
         dut.MeasureEdgeCollisionFree(q1=q, q2=q)
         dut.MeasureEdgeCollisionFree(q1=q, q2=q, context_number=1)
         dut.MeasureContextEdgeCollisionFree(model_context=ccc, q1=q, q2=q)
-        dut.MeasureEdgeCollisionFreeParallel(q1=q, q2=q, parallelize=False)
+        dut.MeasureEdgeCollisionFreeParallel(q1=q, q2=q, parallelize=True)
         measures = dut.MeasureEdgesCollisionFree(
-            edges=[(q, q)]*4, parallelize=False)
+            edges=[(q, q)]*4, parallelize=True)
         self.assertEqual(len(measures), 4)
         self.assertIsInstance(measures[0], mut.EdgeMeasure)
         dut.MeasureEdgesCollisionFree([(q, q)])  # Omit the defaulted arg.
@@ -471,6 +471,6 @@ class TestCollisionChecker(unittest.TestCase):
         points[-1, 1] += 0.1
         A = mut.VisibilityGraph(checker=checker,
                                 points=points,
-                                parallelize=False)
+                                parallelize=True)
         self.assertEqual(A.shape, (num_points, num_points))
         self.assertIsInstance(A, scipy.sparse.csc_matrix)

--- a/bindings/pydrake/planning/test/collision_checker_trace_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_trace_test.py
@@ -1,0 +1,66 @@
+import pydrake.planning as mut
+
+import logging
+import textwrap
+import unittest
+
+import numpy as np
+
+
+class TestCollisionCheckerTrace(unittest.TestCase):
+    """Confirms that trace-level logging from the CollisionChecker's C++ worker
+    threads doesn't deadlock the Python interpreter.
+
+    A deadlock can happen when:
+    - the default pydrake logging configuration is still intact, where all text
+      logging flows through Python (i.e., use_native_cpp_logging() was not
+      called, DRAKE_PYTHON_LOGGING was not set, etc);
+    - some Python code calls a bound C++ function;
+    - that binding is NOT annotated with `gil_scoped_release`, so keeps hold of
+      its lock on the Python GIL;
+    - the C++ function spawns worker thread(s), and blocks awaiting their
+      completion (while still holding the GIL);
+    - one of the worker threads posts a log message using a log level that
+      isn't filtered out;
+    - the log sink blocks forever while trying to acquire the GIL, because the
+      lock is still held by the original function.
+
+    In short, here we are proving that the `gil_scoped_release` annotation is
+    present on the relevant function (CheckEdgeCollisionFreeParallel) and that
+    that annotation is sufficient to prevent a deadlock.
+    """
+
+    def _make_robot_diagram(self):
+        builder = mut.RobotDiagramBuilder()
+        scene_yaml = textwrap.dedent("""
+        directives:
+        - add_model:
+            name: box
+            file: package://drake/multibody/models/box.urdf
+        - add_model:
+            name: ground
+            file: package://drake/planning/test_utilities/collision_ground_plane.sdf  # noqa
+        - add_weld:
+            parent: world
+            child: ground::ground_plane_box
+        """)
+        builder.parser().AddModelsFromString(scene_yaml, "dmd.yaml")
+        model_instance_index = builder.plant().GetModelInstanceByName("box")
+        robot_diagram = builder.Build()
+        return (robot_diagram, model_instance_index)
+
+    def test_tracing(self):
+        # Prepare a checker with a box that can collide with the ground.
+        robot, index = self._make_robot_diagram()
+        dut = mut.SceneGraphCollisionChecker(
+            model=robot,
+            robot_model_instances=[index],
+            edge_step_size=0.125)
+
+        # Check an edge that has a box-ground collision.
+        q1 = np.array([-0.5] * 7)
+        q2 = np.array([0.5] * 7)
+        with self.assertLogs("drake", level=1) as manager:
+            free = dut.CheckEdgeCollisionFreeParallel(q1, q2, parallelize=True)
+        self.assertEqual(free, False)
+        self.assertRegex(manager.output[-1], "collision.*box.*ground")


### PR DESCRIPTION
New bindings rule: when a function accepts `Parallelism` as an argument, its binding should release the GIL.

See #20755 for some discussion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20759)
<!-- Reviewable:end -->
