### PR TITLE
[geometry] Introduce automatic hydroelastic config feature

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -128,6 +128,7 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("HasGroup", &Class::HasGroup, py::arg("group_name"),
             cls_doc.HasGroup.doc)
         .def("num_groups", &Class::num_groups, cls_doc.num_groups.doc)
+        .def("IsEmpty", &Class::IsEmpty, cls_doc.IsEmpty.doc)
         .def(
             "GetPropertiesInGroup",
             [](const Class& self, const std::string& group_name) {

--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -4,11 +4,13 @@
  pydrake.geometry module. */
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/geometry/scene_graph_config.h"
 
 namespace drake {
 namespace pydrake {
@@ -30,6 +32,28 @@ void DoScalarIndependentDefinitions(py::module m) {
     py::enum_<Class>(m, "HydroelasticContactRepresentation", cls_doc.doc)
         .value("kTriangle", Class::kTriangle, cls_doc.kTriangle.doc)
         .value("kPolygon", Class::kPolygon, cls_doc.kPolygon.doc);
+  }
+
+  {
+    using Class = geometry::DefaultProximityProperties;
+    constexpr auto& cls_doc = doc.DefaultProximityProperties;
+    py::class_<Class> cls(m, "DefaultProximityProperties", cls_doc.doc);
+    cls  // BR
+        .def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  {
+    using Class = geometry::SceneGraphConfig;
+    constexpr auto& cls_doc = doc.SceneGraphConfig;
+    py::class_<Class> cls(m, "SceneGraphConfig", cls_doc.doc);
+    cls  // BR
+        .def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
   }
 }
 
@@ -164,7 +188,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class, LeafSystem<T>>(
         m, "SceneGraph", param, cls_doc.doc);
     cls  // BR
-        .def(py::init<>(), cls_doc.ctor.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
+        .def(py::init<SceneGraphConfig>(), py::arg("config"),
+            cls_doc.ctor.doc_1args)
+        .def("set_config", &Class::set_config, py::arg("config"),
+            cls_doc.set_config.doc)
+        .def("get_config", &Class::get_config, cls_doc.get_config.doc)
         .def("get_source_pose_port", &Class::get_source_pose_port,
             py_rvp::reference_internal, cls_doc.get_source_pose_port.doc)
         .def("get_source_configuration_port",

--- a/bindings/pydrake/geometry/test/common_test.py
+++ b/bindings/pydrake/geometry/test/common_test.py
@@ -102,12 +102,14 @@ class TestGeometryCore(unittest.TestCase):
         self.assertEqual(actual_color, test_color)
         # Test proximity properties.
         prop = mut.ProximityProperties()
+        self.assertTrue(prop.IsEmpty())
         self.assertEqual(str(prop), "[__default__]")
         default_group = prop.default_group_name()
         self.assertTrue(prop.HasGroup(group_name=default_group))
         self.assertEqual(prop.num_groups(), 1)
         self.assertTrue(default_group in prop.GetGroupNames())
         prop.AddProperty(group_name=default_group, name="test", value=3)
+        self.assertFalse(prop.IsEmpty())
         self.assertTrue(prop.HasProperty(group_name=default_group,
                                          name="test"))
         self.assertEqual(

--- a/bindings/pydrake/geometry/test/scene_graph_test.py
+++ b/bindings/pydrake/geometry/test/scene_graph_test.py
@@ -335,6 +335,41 @@ class TestGeometrySceneGraph(unittest.TestCase):
                     frame_id=global_frame, role=role),
                 1 if i == 0 else 0)
 
+    def test_scene_graph_config(self):
+        mut.DefaultProximityProperties()
+        scene_graph_config = mut.SceneGraphConfig()
+        scene_graph = mut.SceneGraph(config=scene_graph_config)
+        got_config = scene_graph.get_config()
+        self.assertEqual(
+            got_config.default_proximity_properties.compliance_type,
+            "undefined")
+        scene_graph_config.default_proximity_properties.compliance_type = \
+            "compliant"
+        scene_graph.set_config(config=scene_graph_config)
+        got_config = scene_graph.get_config()
+        self.assertEqual(
+            got_config.default_proximity_properties.compliance_type,
+            "compliant")
+
+        # ParamInit.
+        param_init_props = mut.DefaultProximityProperties(
+            compliance_type="compliant",
+            hydroelastic_modulus=2,
+            resolution_hint=3,
+            slab_thickness=4,
+            dynamic_friction=5,
+            static_friction=6,
+            hunt_crossley_dissipation=7,
+            relaxation_time=None,  # Test optionality.
+            point_stiffness=9,
+        )
+        param_init_scene_graph = mut.SceneGraphConfig(
+            default_proximity_properties=param_init_props)
+        # Spot-check that at least some value got passed through.
+        got_props = param_init_scene_graph.default_proximity_properties
+        self.assertEqual(got_props.relaxation_time, None)
+        self.assertEqual(got_props.point_stiffness, 9)
+
     @numpy_compare.check_all_types
     def test_scene_graph_renderer_with_context(self, T):
         SceneGraph = mut.SceneGraph_[T]

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1337,7 +1337,19 @@ void DoScalarDependentDefinitions(py::module m, T) {
             auto pair = AddMultibodyPlant(config, builder);
             return result_to_tuple(builder, pair);
           },
-          py::arg("config"), py::arg("builder"), doc.AddMultibodyPlant.doc);
+          py::arg("config"), py::arg("builder"),
+          doc.AddMultibodyPlant.doc_2args);
+      m.def(
+          "AddMultibodyPlant",
+          [result_to_tuple](const MultibodyPlantConfig& plant_config,
+              const geometry::SceneGraphConfig& scene_graph_config,
+              systems::DiagramBuilder<T>* builder) {
+            auto pair =
+                AddMultibodyPlant(plant_config, scene_graph_config, builder);
+            return result_to_tuple(builder, pair);
+          },
+          py::arg("plant_config"), py::arg("scene_graph_config"),
+          py::arg("builder"), doc.AddMultibodyPlant.doc_3args);
       m.def("ApplyMultibodyPlantConfig", &ApplyMultibodyPlantConfig,
           py::arg("config"), py::arg("plant"),
           doc.ApplyMultibodyPlantConfig.doc);

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -115,6 +115,7 @@ from pydrake.geometry import (
     Role,
     PenetrationAsPointPair_,
     ProximityProperties,
+    SceneGraphConfig,
     SignedDistancePair_,
     SignedDistanceToPoint_,
     Sphere,
@@ -308,6 +309,18 @@ class TestPlant(unittest.TestCase):
         ApplyMultibodyPlantConfig(config=config, plant=plant)
         self.assertEqual(plant.get_contact_model(),
                          ContactModel.kHydroelasticsOnly)
+
+    def test_multibody_plant_config_3args(self):
+        plant_config = MultibodyPlantConfig(time_step=0.01)
+        scene_graph_config = SceneGraphConfig()
+
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlant(
+            plant_config=plant_config,
+            scene_graph_config=scene_graph_config,
+            builder=builder)
+        self.assertIsNotNone(plant)
+        self.assertIsNotNone(scene_graph)
 
     @numpy_compare.check_all_types
     def test_get_bodies_welded_to_keep_alive(self, T):

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -27,6 +27,7 @@ namespace {
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using geometry::SceneGraph;
+using geometry::SceneGraphConfig;
 using geometry::Sphere;
 using math::RigidTransformd;
 using math::RollPitchYawd;
@@ -60,6 +61,10 @@ DEFINE_double(penetration_allowance, 1.0e-2,
               "See MultibodyPlant::set_penetration_allowance().");
 DEFINE_double(v_stiction_tolerance, 1.0e-2,
               "The maximum slipping speed allowed during stiction. [m/s].");
+DEFINE_string(default_compliance_type, "undefined",
+              "Set default compliance type for geometries, one of"
+              " [undefined, rigid, compliant]. See"
+              " geometry::DefaultProximityProperties::compliance_type.");
 
 // Pads parameters
 DEFINE_int32(ring_samples, 8,
@@ -166,8 +171,11 @@ int do_main() {
   MultibodyPlantConfig plant_config;
   plant_config.time_step = FLAGS_mbp_discrete_update_period;
   plant_config.discrete_contact_approximation = FLAGS_contact_approximation;
+  SceneGraphConfig scene_graph_config;
+  scene_graph_config.default_proximity_properties.compliance_type =
+      FLAGS_default_compliance_type;
   auto [plant, scene_graph] =
-      multibody::AddMultibodyPlant(plant_config, &builder);
+      multibody::AddMultibodyPlant(plant_config, scene_graph_config, &builder);
 
   Parser parser(&plant);
   parser.AddModelsFromUrl(

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -328,6 +328,7 @@ drake_cc_library(
     ],
     deps = [
         ":geometry_state",
+        ":scene_graph_config",
         ":scene_graph_inspector",
         "//common:essential",
         "//common:nice_type_name",
@@ -974,6 +975,10 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "scene_graph_test",
+    data = [
+        ":test_obj_files",
+        ":test_vtk_files",
+    ],
     deps = [
         ":scene_graph",
         "//common/test_utilities:eigen_matrix_compare",

--- a/geometry/benchmarking/BUILD.bazel
+++ b/geometry/benchmarking/BUILD.bazel
@@ -82,4 +82,20 @@ drake_py_experiment_binary(
     googlebench_binary = ":render_benchmark",
 )
 
+drake_cc_googlebench_binary(
+    name = "proximity_defaults_benchmark",
+    srcs = ["proximity_defaults_benchmark.cc"],
+    add_test_rule = True,
+    deps = [
+        "//geometry:scene_graph",
+        "//tools/performance:gflags_main",
+        "@fmt",
+    ],
+)
+
+drake_py_experiment_binary(
+    name = "proximity_defaults_experiment",
+    googlebench_binary = ":proximity_defaults_benchmark",
+)
+
 add_lint_tests()

--- a/geometry/benchmarking/proximity_defaults_benchmark.cc
+++ b/geometry/benchmarking/proximity_defaults_benchmark.cc
@@ -1,0 +1,93 @@
+#include <benchmark/benchmark.h>
+#include <fmt/format.h>
+
+#include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/scene_graph.h"
+
+// These benchmarks help measure the impact of apply proximity defaults during
+// scene graph context creation. Applying those settings can trigger expensive
+// operations in proximity engine. These benchmarks can help demonstrate that
+// caching within SceneGraph can avoid repeating expensive operations when they
+// are not necessary: in creating multiple contexts when the configuration has
+// not changed.
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+namespace {
+
+// We can't pass enums through the google benchmark arguments feature. Here are
+// some conversion operators.
+
+int64_t enum2int(HydroelasticType type) {
+  return static_cast<int64_t>(type);
+}
+
+HydroelasticType int2enum(int64_t arg) {
+  return static_cast<HydroelasticType>(arg);
+}
+
+}  // namespace
+
+class ProximityDefaultsBenchmark : public benchmark::Fixture {
+ public:
+  void SetupScene(const benchmark::State& state) {
+    // Pull in the benchmark arguments:
+    // * compliance_type
+    // * num_geoms
+    SceneGraphConfig scene_graph_config;
+    scene_graph_config.default_proximity_properties.compliance_type =
+        GetStringFromHydroelasticType(int2enum(state.range(0)));
+    int num_geoms = state.range(1);
+
+    // If the default properties won't build hydroelastic assets, prepare some
+    // properties to simulate a manually annotated model.
+    ProximityProperties props;
+    // Make a convenient alias for the configured default properties.
+    const auto& config_props = scene_graph_config.default_proximity_properties;
+    if (config_props.compliance_type == "unknown") {
+      // Simulate a manually annotated model.
+      AddCompliantHydroelasticProperties(*config_props.resolution_hint,
+                                         *config_props.hydroelastic_modulus,
+                                         &props);
+    }
+
+    // Populate a scene graph with `num_geoms` geometries, and give them all a
+    // proximity role.
+    scene_graph_ = std::make_unique<SceneGraph<double>>(scene_graph_config);
+    auto source_id = scene_graph_->RegisterSource("benchmark");
+    auto frame_id =
+        scene_graph_->RegisterFrame(source_id, GeometryFrame{"frame0"});
+    for (int k = 0; k < num_geoms; ++k) {
+      auto geom_id = scene_graph_->RegisterGeometry(
+          source_id, frame_id,
+          std::make_unique<GeometryInstance>(math::RigidTransformd(),
+                                             Box(1.0, 1.0, 1.0),
+                                             fmt::format("box{}", k)));
+      scene_graph_->AssignRole(source_id, geom_id, props);
+    }
+  }
+
+  std::unique_ptr<SceneGraph<double>> scene_graph_;
+};
+
+BENCHMARK_DEFINE_F(ProximityDefaultsBenchmark, CreateDefaultContext)
+// NOLINTNEXTLINE(runtime/references)
+(benchmark::State& state) {
+  SetupScene(state);
+  for (auto _ : state) {
+    scene_graph_->CreateDefaultContext();
+  }
+}
+
+BENCHMARK_REGISTER_F(ProximityDefaultsBenchmark, CreateDefaultContext)
+    ->Unit(benchmark::kMillisecond)
+    ->ArgsProduct({{enum2int(HydroelasticType::kUndefined),
+                    enum2int(HydroelasticType::kRigid),
+                    enum2int(HydroelasticType::kSoft)},
+                   {1, 100}});
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/geometry_properties.cc
+++ b/geometry/geometry_properties.cc
@@ -19,6 +19,14 @@ const GeometryProperties::Group& GeometryProperties::GetPropertiesInGroup(
                   group_name));
 }
 
+bool GeometryProperties::IsEmpty() const {
+  bool result{true};
+  for (const auto& [_, group] : values_) {
+    result &= group.empty();
+  }
+  return result;
+}
+
 std::set<string> GeometryProperties::GetGroupNames() const {
   std::set<string> group_names;
   for (const auto& pair : values_) {

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -239,6 +239,9 @@ class GeometryProperties {
   /** Reports the number of property groups in this set.  */
   int num_groups() const { return static_cast<int>(values_.size()); }
 
+  /** @returns true if all groups are empty. */
+  bool IsEmpty() const;
+
   /** Retrieves the indicated property group. The returned group is valid for
    as long as this instance.
    @throws std::exception if there is no group with the given name.  */

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -79,16 +79,89 @@ class GeometryStateValue final : public Value<GeometryState<T>> {
   template <typename>
   friend class GeometryStateValue;
 };
+
 }  // namespace
+
+
+/* Hub: Encapsulate some state to internally enforce the invariants for
+ augmented model caching in one place, with otherwise unrestricted
+ access to models and configuration.
+
+ Invariants are as follows:
+
+ * The augmented model cache is either:
+    * empty, or
+    * up-to-date with the current model and configuration.
+
+ To enforce the cache invariant:
+
+ * whenever we wish to mutate the model or configuration, invalidated any
+   previously cached augmented model.
+ * whenever we request a augmented model:
+   * if the cache is empty, make a new augmented model and cache it.
+   * if the cache is populated, return the cache value.
+*/
+template <typename T>
+class SceneGraph<T>::Hub {
+ public:
+  Hub() = default;
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Hub)
+
+  const SceneGraphConfig& config() const { return config_; }
+
+  SceneGraphConfig& mutable_config() {
+    // This doesn't need a lock_guard; users are never allowed to call
+    // non-const methods on multiple threads concurrently.
+    augmented_model_cache_.reset();
+    return config_;
+  }
+
+  const GeometryState<T>& model() const { return model_; }
+
+  GeometryState<T>& mutable_model() {
+    // This doesn't need a lock_guard; users are never allowed to call
+    // non-const methods on multiple threads concurrently.
+    augmented_model_cache_.reset();
+    return model_;
+  }
+
+  std::unique_ptr<GeometryState<T>> MakeAugmentedModel() const {
+    std::lock_guard<std::mutex> guard(augmented_model_cache_mutex_);
+    if (augmented_model_cache_ != nullptr) {
+      // Our cache was up-to-date, so we can simply clone it.
+      return std::make_unique<GeometryState<T>>(*augmented_model_cache_);
+    } else {
+      // Our cache was out-of-date, so we need to refresh it.
+      auto result = std::make_unique<GeometryState<T>>(model_);
+      result->ApplyProximityDefaults(config_.default_proximity_properties);
+      augmented_model_cache_ =
+          std::make_unique<const GeometryState<T>>(*result);
+      return result;
+    }
+  }
+
+ private:
+  SceneGraphConfig config_;
+  GeometryState<T> model_;
+
+  // The cached augmented model, maybe. It is created on demand and invalidated
+  // by mutable access to either `model_` or `config_`. Access from const
+  // methods is exclusive, so that construction of new contexts remains
+  // thread-safe.
+  mutable std::mutex augmented_model_cache_mutex_;
+  mutable std::unique_ptr<const GeometryState<T>> augmented_model_cache_;
+};
 
 template <typename T>
 SceneGraph<T>::SceneGraph()
     : LeafSystem<T>(SystemTypeTag<SceneGraph>{}),
-      owned_model_(std::make_unique<GeometryState<T>>()),
-      model_(*owned_model_) {
-  model_inspector_.set(&model_);
+      owned_hub_(std::make_unique<Hub>()),
+      hub_(*owned_hub_) {
+  model_inspector_.set(&hub_.model());
   geometry_state_index_ =
       this->DeclareAbstractParameter(GeometryStateValue<T>());
+  scene_graph_config_index_ =
+      this->DeclareAbstractParameter(Value<SceneGraphConfig>());
 
   query_port_index_ =
       this->DeclareAbstractOutputPort("query", &SceneGraph::CalcQueryObject)
@@ -106,9 +179,19 @@ SceneGraph<T>::SceneGraph()
 }
 
 template <typename T>
+SceneGraph<T>::SceneGraph(const SceneGraphConfig& config)
+    : SceneGraph() {
+  config.ValidateOrThrow();
+  hub_.mutable_config() = config;
+}
+
+template <typename T>
 template <typename U>
-SceneGraph<T>::SceneGraph(const SceneGraph<U>& other) : SceneGraph() {
-  model_ = GeometryState<T>(other.model_);
+SceneGraph<T>::SceneGraph(const SceneGraph<U>& other)
+    : SceneGraph() {
+  hub_.mutable_config() = other.hub_.config();
+  hub_.mutable_model() =
+      GeometryState<T>(other.hub_.model());
 
   // We need to guarantee that the same source ids map to the same port indices.
   // We'll do this by processing the source ids in monotonically increasing
@@ -142,9 +225,20 @@ SceneGraph<T>::~SceneGraph() = default;
 
 template <typename T>
 SourceId SceneGraph<T>::RegisterSource(const std::string& name) {
-  SourceId source_id = model_.RegisterNewSource(name);
+  SourceId source_id = hub_.mutable_model().RegisterNewSource(name);
   MakeSourcePorts(source_id);
   return source_id;
+}
+
+template <typename T>
+void SceneGraph<T>::set_config(const SceneGraphConfig& config) {
+  config.ValidateOrThrow();
+  hub_.mutable_config() = config;
+}
+
+template <typename T>
+const SceneGraphConfig& SceneGraph<T>::get_config() const {
+  return hub_.config();
 }
 
 template <typename T>
@@ -169,25 +263,27 @@ const InputPort<T>& SceneGraph<T>::get_source_configuration_port(
 template <typename T>
 FrameId SceneGraph<T>::RegisterFrame(SourceId source_id,
                                      const GeometryFrame& frame) {
-  return model_.RegisterFrame(source_id, frame);
+  return hub_.mutable_model().RegisterFrame(source_id, frame);
 }
 
 template <typename T>
 FrameId SceneGraph<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
                                      const GeometryFrame& frame) {
-  return model_.RegisterFrame(source_id, parent_id, frame);
+  return hub_.mutable_model().RegisterFrame(
+      source_id, parent_id, frame);
 }
 
 template <typename T>
 void SceneGraph<T>::RenameFrame(FrameId frame_id, const std::string& name) {
-  return model_.RenameFrame(frame_id, name);
+  return hub_.mutable_model().RenameFrame(frame_id, name);
 }
 
 template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance> geometry) {
-  return model_.RegisterGeometry(source_id, frame_id, std::move(geometry));
+  return hub_.mutable_model().RegisterGeometry(
+      source_id, frame_id, std::move(geometry));
 }
 
 template <typename T>
@@ -195,20 +291,29 @@ GeometryId SceneGraph<T>::RegisterGeometry(
     Context<T>* context, SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance> geometry) const {
   auto& g_state = mutable_geometry_state(context);
-  return g_state.RegisterGeometry(source_id, frame_id, std::move(geometry));
+  bool has_proximity = (geometry->proximity_properties() != nullptr);
+  auto geometry_id =
+      g_state.RegisterGeometry(source_id, frame_id, std::move(geometry));
+  const auto& config = scene_graph_config(*context);
+  if (has_proximity) {
+    g_state.ApplyProximityDefaults(config.default_proximity_properties,
+                                   geometry_id);
+  }
+  return geometry_id;
 }
 
 template <typename T>
 GeometryId SceneGraph<T>::RegisterAnchoredGeometry(
     SourceId source_id, std::unique_ptr<GeometryInstance> geometry) {
-  return model_.RegisterAnchoredGeometry(source_id, std::move(geometry));
+  return hub_.mutable_model().RegisterAnchoredGeometry(
+      source_id, std::move(geometry));
 }
 
 template <typename T>
 GeometryId SceneGraph<T>::RegisterDeformableGeometry(
     SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance> geometry, double resolution_hint) {
-  return model_.RegisterDeformableGeometry(
+  return hub_.mutable_model().RegisterDeformableGeometry(
       source_id, frame_id, std::move(geometry), resolution_hint);
 }
 
@@ -224,14 +329,14 @@ GeometryId SceneGraph<T>::RegisterDeformableGeometry(
 template <typename T>
 void SceneGraph<T>::RenameGeometry(GeometryId geometry_id,
                                    const std::string& name) {
-  return model_.RenameGeometry(geometry_id, name);
+  return hub_.mutable_model().RenameGeometry(geometry_id, name);
 }
 
 template <typename T>
 void SceneGraph<T>::ChangeShape(
     SourceId source_id, GeometryId geometry_id, const Shape& shape,
     std::optional<math::RigidTransform<double>> X_FG) {
-  return model_.ChangeShape(source_id, geometry_id, shape, X_FG);
+  return hub_.mutable_model().ChangeShape(source_id, geometry_id, shape, X_FG);
 }
 
 template <typename T>
@@ -239,12 +344,12 @@ void SceneGraph<T>::ChangeShape(
     Context<T>* context, SourceId source_id, GeometryId geometry_id,
     const Shape& shape, std::optional<math::RigidTransform<double>> X_FG) {
   auto& g_state = mutable_geometry_state(context);
-  return g_state.ChangeShape(source_id, geometry_id, shape, X_FG);
+  g_state.ChangeShape(source_id, geometry_id, shape, X_FG);
 }
 
 template <typename T>
 void SceneGraph<T>::RemoveGeometry(SourceId source_id, GeometryId geometry_id) {
-  model_.RemoveGeometry(source_id, geometry_id);
+  hub_.mutable_model().RemoveGeometry(source_id, geometry_id);
 }
 
 template <typename T>
@@ -257,7 +362,8 @@ void SceneGraph<T>::RemoveGeometry(Context<T>* context, SourceId source_id,
 template <typename T>
 void SceneGraph<T>::AddRenderer(
     std::string name, std::unique_ptr<render::RenderEngine> renderer) {
-  return model_.AddRenderer(std::move(name), std::move(renderer));
+  return hub_.mutable_model().AddRenderer(
+      std::move(name), std::move(renderer));
 }
 
 template <typename T>
@@ -270,7 +376,7 @@ void SceneGraph<T>::AddRenderer(
 
 template <typename T>
 void SceneGraph<T>::RemoveRenderer(const std::string& name) {
-  return model_.RemoveRenderer(name);
+  return hub_.mutable_model().RemoveRenderer(name);
 }
 
 template <typename T>
@@ -282,7 +388,7 @@ void SceneGraph<T>::RemoveRenderer(Context<T>* context,
 
 template <typename T>
 bool SceneGraph<T>::HasRenderer(const std::string& name) const {
-  return model_.HasRenderer(name);
+  return hub_.model().HasRenderer(name);
 }
 
 template <typename T>
@@ -294,7 +400,8 @@ bool SceneGraph<T>::HasRenderer(const Context<T>& context,
 
 template <typename T>
 std::string SceneGraph<T>::GetRendererTypeName(const std::string& name) const {
-  const render::RenderEngine* engine = model_.GetRenderEngineByName(name);
+  const render::RenderEngine* engine =
+      hub_.model().GetRenderEngineByName(name);
   if (engine == nullptr) {
     return {};
   }
@@ -316,7 +423,7 @@ std::string SceneGraph<T>::GetRendererTypeName(const Context<T>& context,
 
 template <typename T>
 int SceneGraph<T>::RendererCount() const {
-  return model_.RendererCount();
+  return hub_.model().RendererCount();
 }
 
 template <typename T>
@@ -327,7 +434,7 @@ int SceneGraph<T>::RendererCount(const Context<T>& context) const {
 
 template <typename T>
 vector<std::string> SceneGraph<T>::RegisteredRendererNames() const {
-  return model_.RegisteredRendererNames();
+  return hub_.model().RegisteredRendererNames();
 }
 
 template <typename T>
@@ -341,7 +448,8 @@ template <typename T>
 void SceneGraph<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
                                ProximityProperties properties,
                                RoleAssign assign) {
-  model_.AssignRole(source_id, geometry_id, std::move(properties), assign);
+  hub_.mutable_model().AssignRole(
+      source_id, geometry_id, std::move(properties), assign);
 }
 
 template <typename T>
@@ -350,14 +458,21 @@ void SceneGraph<T>::AssignRole(Context<T>* context, SourceId source_id,
                                ProximityProperties properties,
                                RoleAssign assign) const {
   auto& g_state = mutable_geometry_state(context);
+  bool properties_are_empty = properties.IsEmpty();
   g_state.AssignRole(source_id, geometry_id, std::move(properties), assign);
+  const auto& config = scene_graph_config(*context);
+  if (assign == RoleAssign::kNew || properties_are_empty) {
+    g_state.ApplyProximityDefaults(config.default_proximity_properties,
+                                   geometry_id);
+  }
 }
 
 template <typename T>
 void SceneGraph<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
                                PerceptionProperties properties,
                                RoleAssign assign) {
-  model_.AssignRole(source_id, geometry_id, std::move(properties), assign);
+  hub_.mutable_model().AssignRole(
+      source_id, geometry_id, std::move(properties), assign);
 }
 
 template <typename T>
@@ -373,7 +488,8 @@ template <typename T>
 void SceneGraph<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
                                IllustrationProperties properties,
                                RoleAssign assign) {
-  model_.AssignRole(source_id, geometry_id, std::move(properties), assign);
+  hub_.mutable_model().AssignRole(
+      source_id, geometry_id, std::move(properties), assign);
 }
 
 template <typename T>
@@ -394,7 +510,7 @@ void SceneGraph<T>::AssignRole(Context<T>* context, SourceId source_id,
 
 template <typename T>
 int SceneGraph<T>::RemoveRole(SourceId source_id, FrameId frame_id, Role role) {
-  return model_.RemoveRole(source_id, frame_id, role);
+  return hub_.mutable_model().RemoveRole(source_id, frame_id, role);
 }
 
 template <typename T>
@@ -407,7 +523,8 @@ int SceneGraph<T>::RemoveRole(Context<T>* context, SourceId source_id,
 template <typename T>
 int SceneGraph<T>::RemoveRole(SourceId source_id, GeometryId geometry_id,
                               Role role) {
-  return model_.RemoveRole(source_id, geometry_id, role);
+  return hub_.mutable_model().RemoveRole(
+      source_id, geometry_id, role);
 }
 
 template <typename T>
@@ -424,7 +541,7 @@ const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
 
 template <typename T>
 CollisionFilterManager SceneGraph<T>::collision_filter_manager() {
-  return model_.collision_filter_manager();
+  return hub_.mutable_model().collision_filter_manager();
 }
 
 template <typename T>
@@ -437,8 +554,11 @@ template <typename T>
 void SceneGraph<T>::SetDefaultParameters(const Context<T>& context,
                                          Parameters<T>* parameters) const {
   LeafSystem<T>::SetDefaultParameters(context, parameters);
+  std::unique_ptr<GeometryState<T>> state = hub_.MakeAugmentedModel();
   parameters->template get_mutable_abstract_parameter<GeometryState<T>>(
-      geometry_state_index_) = model_;
+      geometry_state_index_) = std::move(*state);
+  parameters->template get_mutable_abstract_parameter<SceneGraphConfig>(
+      scene_graph_config_index_) = hub_.config();
 }
 
 template <typename T>
@@ -448,14 +568,15 @@ void SceneGraph<T>::MakeSourcePorts(SourceId source_id) {
   // Create and store the input ports for this source id.
   SourcePorts& source_ports = input_source_ids_[source_id];
   source_ports.pose_port =
-      this->DeclareAbstractInputPort(model_.GetName(source_id) + "_pose",
-                                     Value<FramePoseVector<T>>())
-          .get_index();
+      this->DeclareAbstractInputPort(
+          hub_.model().GetName(source_id) + "_pose",
+          Value<FramePoseVector<T>>())
+      .get_index();
   source_ports.configuration_port =
       this->DeclareAbstractInputPort(
-              model_.GetName(source_id) + "_configuration",
-              Value<GeometryConfigurationVector<T>>())
-          .get_index();
+          hub_.model().GetName(source_id) + "_configuration",
+          Value<GeometryConfigurationVector<T>>())
+      .get_index();
 }
 
 template <typename T>
@@ -599,6 +720,14 @@ const GeometryState<T>& SceneGraph<T>::geometry_state(
     const Context<T>& context) const {
   return context.get_parameters()
       .template get_abstract_parameter<GeometryState<T>>(geometry_state_index_);
+}
+
+template <typename T>
+const SceneGraphConfig& SceneGraph<T>::scene_graph_config(
+    const systems::Context<T>& context) const {
+  return context.get_parameters()
+      .template get_abstract_parameter<SceneGraphConfig>(
+          scene_graph_config_index_);
 }
 
 }  // namespace geometry

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -12,6 +12,7 @@
 #include "drake/geometry/kinematics_vector.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
+#include "drake/geometry/scene_graph_config.h"
 #include "drake/geometry/scene_graph_inspector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -323,11 +324,28 @@ class SceneGraph final : public systems::LeafSystem<T> {
   /** Constructs a default (empty) scene graph. */
   SceneGraph();
 
+  /** Constructs an empty scene graph with the provided configuration. */
+  explicit SceneGraph(const SceneGraphConfig& config);
+
   /** Constructor used for scalar conversions. */
   template <typename U>
   explicit SceneGraph(const SceneGraph<U>& other);
 
   ~SceneGraph() final;
+
+  /** @name      Configuration
+   Allows configuration changes to scene graph systems.
+   */
+  //@{
+
+  /** Sets the configuration. */
+  void set_config(const SceneGraphConfig& config);
+
+  /** @return the current configuration. */
+  const SceneGraphConfig& get_config() const;
+
+  //@}
+
 
   /** @name       Port management
    Access to SceneGraph's input/output ports. This topic includes
@@ -1108,6 +1126,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
   const GeometryState<T>& geometry_state(
       const systems::Context<T>& context) const;
 
+  // Extracts a reference to the scene graph configuration from the given
+  // context. The context's scene graph configuration is copied from the main
+  // scene graph configuration at context construction time.
+  const SceneGraphConfig& scene_graph_config(
+      const systems::Context<T>& context) const;
+
   // A struct that stores the port indices for a given source.
   // TODO(SeanCurtis-TRI): Consider making these TypeSafeIndex values.
   struct SourcePorts {
@@ -1122,19 +1146,20 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // The index of the output port with the QueryObject abstract value.
   int query_port_index_{-1};
 
-  // SceneGraph owns its configured model; it gets copied into the context when
-  // the context is set to its "default" state. We use unique_ptr in support of
-  // forward-declaring GeometryState<T> to reduce our #include footprint, but
-  // initialize a model_ reference to always point to the owned_model_, as a
-  // convenient shortcut in the code to treat it as if it were a direct member.
-  std::unique_ptr<GeometryState<T>> owned_model_;
-  GeometryState<T>& model_;
+  // Encapsulate some model detail to help enforce internal invariants.
+  class Hub;
+  std::unique_ptr<Hub> owned_hub_;
+  class Hub& hub_;
 
   SceneGraphInspector<T> model_inspector_;
 
-  // The geometry state is stored in the Context either as a Parameter with this
+  // The geometry state is stored in the Context as a Parameter with this
   // index.
   int geometry_state_index_{-1};
+
+  // The scene graph configuration from the time the context was created is
+  // stored in the Context as a Parameter with this index.
+  int scene_graph_config_index_{-1};
 
   // The cache indices for the pose and configuration update cache entries.
   systems::CacheIndex pose_update_index_{};

--- a/geometry/scene_graph_config.cc
+++ b/geometry/scene_graph_config.cc
@@ -100,4 +100,3 @@ void SceneGraphConfig::ValidateOrThrow() const {
 
 }  // namespace geometry
 }  // namespace drake
-

--- a/geometry/scene_graph_config.h
+++ b/geometry/scene_graph_config.h
@@ -59,7 +59,7 @@ struct DefaultProximityProperties {
 
   /** For a halfspace, the thickness of compliant material to model, in units
   of meters. */
-  std::optional<double> slab_thickness{10.0};
+  std::optional<double> slab_thickness;
   /// @}
 
   /** @name General Contact Properties

--- a/geometry/test/geometry_properties_test.cc
+++ b/geometry/test/geometry_properties_test.cc
@@ -27,6 +27,7 @@ class TestProperties : public GeometryProperties {
 
 GTEST_TEST(GeometryProperties, ManagingGroups) {
   TestProperties properties;
+  ASSERT_TRUE(properties.IsEmpty());
   const string& group_name{"some_group"};
   // Only contains the default group.
   ASSERT_EQ(1, properties.num_groups());
@@ -35,6 +36,7 @@ GTEST_TEST(GeometryProperties, ManagingGroups) {
 
   // Add the group for the first time by adding a property.
   properties.AddProperty(group_name, "junk_value", 1);
+  ASSERT_FALSE(properties.IsEmpty());
   ASSERT_TRUE(properties.HasGroup(group_name));
   ASSERT_EQ(2, properties.num_groups());
 

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -6,6 +6,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/find_resource.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
@@ -15,6 +16,7 @@
 #include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/make_mesh_for_deformable.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/render/render_label.h"
 #include "drake/geometry/shape_specification.h"
@@ -34,6 +36,10 @@ namespace drake {
 namespace geometry {
 
 using internal::DummyRenderEngine;
+using internal::HydroelasticType;
+using internal::kComplianceType;
+using internal::kHydroGroup;
+using internal::kSlabThickness;
 using math::RigidTransformd;
 using std::make_unique;
 using std::unique_ptr;
@@ -346,6 +352,80 @@ TEST_F(SceneGraphTest, RegisterUnsupportedDeformableGeometry) {
           s_id, scene_graph_.world_frame_id(), std::move(geometry_instance),
           kRezHint),
       ".*don't yet generate deformable meshes.+ Cylinder.*");
+}
+
+// Smoke test augmented context configuration. Fine detail should be
+// tested in geometry_state_test.
+TEST_F(SceneGraphTest, ApplyConfig) {
+  EXPECT_EQ(
+      scene_graph_.get_config().default_proximity_properties.compliance_type,
+      "undefined");
+  SourceId s_id = scene_graph_.RegisterSource();
+  auto geometry_instance = make_unique<GeometryInstance>(
+      RigidTransformd::Identity(), make_unique<Box>(1.0, 2.0, 3.0), "box");
+  geometry_instance->set_proximity_properties(ProximityProperties());
+  auto g_id = scene_graph_.RegisterGeometry(
+      s_id, scene_graph_.world_frame_id(), std::move(geometry_instance));
+  // Plain context.
+  CreateDefaultContext();
+  auto props = query_object().inspector().GetProximityProperties(g_id);
+  EXPECT_TRUE(props->HasGroup(kHydroGroup));
+
+  SceneGraphConfig config;
+  config.default_proximity_properties.compliance_type = "compliant";
+  scene_graph_.set_config(config);
+  const auto& defaults = scene_graph_.get_config().default_proximity_properties;
+  EXPECT_EQ(defaults.compliance_type, "compliant");
+  // Hydroelastic-compliant configured context.
+  CreateDefaultContext();
+  props = query_object().inspector().GetProximityProperties(g_id);
+  EXPECT_TRUE(props->HasGroup(kHydroGroup));
+
+  // Add a new shape into the context, with empty proximity role. The resulting
+  // registered geometry has proximity defaults applied.
+  geometry_instance = make_unique<GeometryInstance>(
+      RigidTransformd::Identity(), make_unique<Box>(1.0, 3.0, 5.0), "box2");
+  geometry_instance->set_proximity_properties(ProximityProperties());
+  g_id = scene_graph_.RegisterGeometry(
+      context_.get(), s_id, scene_graph_.world_frame_id(),
+      std::move(geometry_instance));
+  props = query_object().inspector().GetProximityProperties(g_id);
+  EXPECT_TRUE(props->HasGroup(kHydroGroup));
+
+  // Add a new shape into the context, then assign an empty proximity role. The
+  // resulting properties have proximity defaults applied.
+  geometry_instance = make_unique<GeometryInstance>(
+      RigidTransformd::Identity(), make_unique<Box>(1.0, 1.0, 1.0), "box3");
+  g_id = scene_graph_.RegisterGeometry(
+      context_.get(), s_id, scene_graph_.world_frame_id(),
+      std::move(geometry_instance));
+  scene_graph_.AssignRole(context_.get(), s_id, g_id, ProximityProperties());
+  props = query_object().inspector().GetProximityProperties(g_id);
+  EXPECT_TRUE(props->HasGroup(kHydroGroup));
+  EXPECT_EQ(props->GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
+            HydroelasticType::kCompliant);
+
+  // Replace the role, with a blank set of properties. The resulting properties
+  // are hydroelastic configured.
+  scene_graph_.AssignRole(context_.get(), s_id, g_id, ProximityProperties(),
+                          RoleAssign::kReplace);
+  props = query_object().inspector().GetProximityProperties(g_id);
+  EXPECT_TRUE(props->HasGroup(kHydroGroup));
+  EXPECT_EQ(props->GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
+            HydroelasticType::kCompliant);
+
+  // Replace the role, removing an arbitrary property. The property stays
+  // removed.
+  ProximityProperties edit_props(
+      *query_object().inspector().GetProximityProperties(g_id));
+  edit_props.RemoveProperty(kHydroGroup, kSlabThickness);
+  scene_graph_.AssignRole(context_.get(), s_id, g_id, edit_props,
+                          RoleAssign::kReplace);
+  props = query_object().inspector().GetProximityProperties(g_id);
+  EXPECT_TRUE(props->HasGroup(kHydroGroup));
+  EXPECT_FALSE(props->HasProperty(kHydroGroup, kSlabThickness));
+  EXPECT_EQ(props->GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
+            HydroelasticType::kCompliant);
 }
 
 template <typename T>

--- a/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
+++ b/multibody/hydroelastics/hydroelastic_user_guide_doxygen.h
@@ -27,6 +27,51 @@ hydroelastic contact. See @ref hydro_appendix_a for a fuller discussion of the
 theory and practice of contact models. For notes on implementation status, see
 @ref hydro_appendix_b. Also see @ref hydro_appendix_examples_and_tutorials.
 
+@subsubsection hug_quick_hydro Hydroelastic Quickstart
+
+The proximity default configuration settings of SceneGraph offer a quick-start
+path to using hydroelastic contact, without the need to fully annotate the
+collision geometries of robot models. (The full annotation process is described
+in the sections following this one.)
+
+While it is unlikely that the homogeneous parameters set by automatic
+hydroelastic configuration will be sufficient to model diverse sets of
+collision geometries, it may be a good starting point for some. It allows an
+incremental approach to adding hydroelastic annotations as needed.
+
+To get very simple and quick hydroelastic configuration, all that is needed is
+to set a configuration item for drake::geometry::SceneGraph:
+
+@code
+  geometry::SceneGraphConfig scene_graph_config;
+  scene_graph_config.default_proximity_properties.compliance_type = "compliant";
+  auto [plant, scene_graph] =
+      multibody::AddMultibodyPlant(plant_config, scene_graph_config, &builder);
+@endcode
+
+For an example of a trivial conversion of an existing simulation, see the <a
+href="https://github.com/RobotLocomotion/drake/tree/master/examples/simple_gripper">examples/simple_gripper</a>
+program in the Drake source code. It offers a `--default_compliance_type`
+command line option, which permits trying various compliance types.
+
+All of the geometries in contexts created for the scene graph will be annotated
+with a default set of proximity properties. In addition, geometries that
+receive a compliance type of "compliant", and are too small to be compatible
+with generation of a volume mesh, will be ignored for collisions. This allows
+quick adaption of models that have been augmented with tiny collision spheres
+to operate with point contact.
+
+These transformations will allow hydroelastic contact to work, but the values
+of the properties may not be ideal. The default set of properties are
+controlled by drake::geometry::DefaultProximityProperties, and can be changed
+for each application.
+
+Having used scene graph configuration proximity defaults to get up and running,
+it may still be useful to add specific hydroelastic annotations to model
+files. Any explicit properties in model files (or applied by calling Drake
+APIs) will take precedence over the default proximity properties for the
+annotated geometries.
+
 @subsection hug_working_with_hydro Working with Hydroelastic Contact
 
 It is relatively simple to enable a simulation to use hydroelastic

--- a/multibody/plant/multibody_plant_config_functions.cc
+++ b/multibody/plant/multibody_plant_config_functions.cc
@@ -27,6 +27,17 @@ AddResult AddMultibodyPlant(const MultibodyPlantConfig& config,
   return result;
 }
 
+AddMultibodyPlantSceneGraphResult<double> AddMultibodyPlant(
+    const MultibodyPlantConfig& plant_config,
+    const geometry::SceneGraphConfig& scene_graph_config,
+    systems::DiagramBuilder<double>* builder) {
+  AddResult result =
+      AddMultibodyPlantSceneGraph(builder, plant_config.time_step);
+  ApplyMultibodyPlantConfig(plant_config, &result.plant);
+  result.scene_graph.set_config(scene_graph_config);
+  return result;
+}
+
 void ApplyMultibodyPlantConfig(const MultibodyPlantConfig& config,
                                MultibodyPlant<double>* plant) {
   DRAKE_THROW_UNLESS(plant != nullptr);

--- a/multibody/plant/multibody_plant_config_functions.h
+++ b/multibody/plant/multibody_plant_config_functions.h
@@ -16,6 +16,15 @@ AddMultibodyPlantSceneGraphResult<double> AddMultibodyPlant(
     const MultibodyPlantConfig& config,
     systems::DiagramBuilder<double>* builder);
 
+/// Adds a new MultibodyPlant and SceneGraph to the given `builder`.  The
+/// plant's settings such as `time_step` are set using the given
+/// `plant_config`. The scene graph's settings are set using the given
+/// `scene_graph_config`.
+AddMultibodyPlantSceneGraphResult<double> AddMultibodyPlant(
+    const MultibodyPlantConfig& plant_config,
+    const geometry::SceneGraphConfig& scene_graph_config,
+    systems::DiagramBuilder<double>* builder);
+
 /// Applies settings given in `config` to an existing `plant`. The `time_step`
 /// is the one value in `config` that cannot be updated -- it can only be set
 /// in the MultibodyPlant constructor. Consider using AddMultibodyPlant() or

--- a/multibody/plant/test/multibody_plant_config_functions_test.cc
+++ b/multibody/plant/test/multibody_plant_config_functions_test.cc
@@ -35,6 +35,29 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, AddMultibodyBasicTest) {
 }
 
 GTEST_TEST(MultibodyPlantConfigFunctionsTest,
+           AddMultibodySceneGraphConfigTest) {
+  // Demonstrate that SceneGraph gets configured in the 3-argument overload.
+  MultibodyPlantConfig plant_config;
+  geometry::SceneGraphConfig scene_graph_config;
+  // Take a convenient alias to the inner struct.
+  auto& hydro = scene_graph_config.default_proximity_properties;
+  // Set a bunch of arbitrary, and mostly nonsensical, values.
+  hydro.compliance_type = "compliant";
+  hydro.hydroelastic_modulus = 2;
+  hydro.resolution_hint = 3;
+  hydro.slab_thickness = 4;
+
+  drake::systems::DiagramBuilder<double> builder;
+  auto result = AddMultibodyPlant(plant_config, scene_graph_config, &builder);
+  const auto& got_hydro =
+      result.scene_graph.get_config().default_proximity_properties;
+  EXPECT_EQ(got_hydro.compliance_type, "compliant");
+  EXPECT_EQ(got_hydro.hydroelastic_modulus, 2);
+  EXPECT_EQ(got_hydro.resolution_hint, 3);
+  EXPECT_EQ(got_hydro.slab_thickness, 4);
+}
+
+GTEST_TEST(MultibodyPlantConfigFunctionsTest,
            ApplyMultibodyPlantConfigBasicTest) {
   MultibodyPlantConfig config;
   config.time_step = 0.002;

--- a/tutorials/BUILD.bazel
+++ b/tutorials/BUILD.bazel
@@ -115,6 +115,7 @@ drake_jupyter_py_binary(
         "@drake_models//:dishes",
         "@drake_models//:veggies",
     ],
+    test_timeout = "moderate",
     deps = [
         "//bindings/pydrake",
     ],


### PR DESCRIPTION
Closes #19709.

This is a successor to https://github.com/RobotLocomotion/drake/pull/20059, which just got too unwieldy in reviewable. I hope to get a fresh read from the same reviewers.

The code here should start out identical to the prior PR's `r36`. I'll maybe also copy forward some discussion items.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20764)
<!-- Reviewable:end -->
