### PR TITLE
[geometry] Apply clang-format to nearly all files

### DIFF
--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -702,16 +702,14 @@ void DrakeVisualizer<T>::SendLoadNonDeformableMessage(
     ++link_index;
   }
 
-
-  std::string channel = MakeLcmChannelNameForRole("DRAKE_VIEWER_LOAD_ROBOT",
-                                                  params);
+  std::string channel =
+      MakeLcmChannelNameForRole("DRAKE_VIEWER_LOAD_ROBOT", params);
   lcm::Publish(lcm, channel, message, time);
 }
 
 template <typename T>
 void DrakeVisualizer<T>::SendDrawNonDeformableMessage(
-    const QueryObject<T>& query_object,
-    const DrakeVisualizerParams& params,
+    const QueryObject<T>& query_object, const DrakeVisualizerParams& params,
     const vector<internal::DynamicFrameData>& dynamic_frames, double time,
     lcm::DrakeLcmInterface* lcm) {
   lcmt_viewer_draw message{};
@@ -746,8 +744,7 @@ void DrakeVisualizer<T>::SendDrawNonDeformableMessage(
     message.quaternion[i][3] = q.z();
   }
 
-  std::string channel = MakeLcmChannelNameForRole("DRAKE_VIEWER_DRAW",
-                                                  params);
+  std::string channel = MakeLcmChannelNameForRole("DRAKE_VIEWER_DRAW", params);
   lcm::Publish(lcm, channel, message, time);
 }
 
@@ -778,8 +775,8 @@ void DrakeVisualizer<T>::SendDeformableGeometriesMessage(
     message.geom[i] =
         MakeDeformableSurfaceMesh(vertex_positions, data, params.default_color);
   }
-  std::string channel = MakeLcmChannelNameForRole("DRAKE_VIEWER_DEFORMABLE",
-                                                  params);
+  std::string channel =
+      MakeLcmChannelNameForRole("DRAKE_VIEWER_DEFORMABLE", params);
   lcm::Publish(lcm, channel, message, time);
 }
 

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -274,8 +274,7 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
   /* Dispatches a "draw geometry" message (see lcmt_viewer_draw) -- the
    definition of the poses of all non-deformable geometries. */
   static void SendDrawNonDeformableMessage(
-      const QueryObject<T>& query_object,
-      const DrakeVisualizerParams& params,
+      const QueryObject<T>& query_object, const DrakeVisualizerParams& params,
       const std::vector<internal::DynamicFrameData>& dynamic_frames,
       double time, lcm::DrakeLcmInterface* lcm);
 

--- a/geometry/geometry_frame.cc
+++ b/geometry/geometry_frame.cc
@@ -10,8 +10,7 @@ GeometryFrame::GeometryFrame(const std::string& frame_name, int frame_group_id)
       name_(frame_name),
       frame_group_(frame_group_id) {
   if (frame_group_ < 0) {
-    throw std::logic_error(
-        "GeometryFrame requires a non-negative frame group");
+    throw std::logic_error("GeometryFrame requires a non-negative frame group");
   }
 }
 

--- a/geometry/geometry_ids.h
+++ b/geometry/geometry_ids.h
@@ -23,6 +23,7 @@ using FrameId = drake::Identifier<class FrameTag>;
 /** Type used to identify geometry instances in SceneGraph. */
 class GeometryId : public drake::Identifier<class GeometryTag> {
   using Base = drake::Identifier<class GeometryTag>;
+
  public:
   GeometryId() = default;
 

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -334,9 +334,8 @@ class GeometryProperties {
                              const std::string& name) const {
     const AbstractValue& abstract = GetPropertyAbstract(group_name, name);
     if constexpr (std::is_same_v<ValueType, Eigen::Vector4d>) {
-      const Rgba color =
-          GetValueOrThrow<Rgba>("GetProperty", group_name, name, abstract,
-                                typeid(Eigen::Vector4d));
+      const Rgba color = GetValueOrThrow<Rgba>(
+          "GetProperty", group_name, name, abstract, typeid(Eigen::Vector4d));
       return ToVector4d(color);
     } else {
       return GetValueOrThrow<ValueType>("GetProperty", group_name, name,
@@ -388,9 +387,9 @@ class GeometryProperties {
       return default_value;
     } else {
       if constexpr (std::is_same_v<ValueType, Eigen::Vector4d>) {
-        const Rgba color = GetValueOrThrow<Rgba>(
-            "GetPropertyOrDefault", group_name, name, *abstract,
-            typeid(Eigen::Vector4d));
+        const Rgba color =
+            GetValueOrThrow<Rgba>("GetPropertyOrDefault", group_name, name,
+                                  *abstract, typeid(Eigen::Vector4d));
         return ToVector4d(color);
       } else {
         // This incurs the cost of copying a stored value.
@@ -486,9 +485,7 @@ class GeometryProperties {
 
   // TODO(eric.cousineau): Deprecate this, saying: "Use Rgba instead of
   // Vector4d to define diffuse color."
-  static Eigen::Vector4d ToVector4d(const Rgba& color) {
-    return color.rgba();
-  }
+  static Eigen::Vector4d ToVector4d(const Rgba& color) { return color.rgba(); }
 
   // TODO(eric.cousineau): Deprecate this, saying: "Use Rgba instead of
   // Vector4d to define diffuse color."
@@ -502,7 +499,6 @@ class GeometryProperties {
 
 }  // namespace geometry
 }  // namespace drake
-
 
 // TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -164,7 +164,7 @@ class ProximityProperties final : public GeometryProperties {
  Examples of functionality that depends on the perception role:
    - render::RenderEngineVtk
  */
-class PerceptionProperties final : public GeometryProperties{
+class PerceptionProperties final : public GeometryProperties {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PerceptionProperties);
   // TODO(SeanCurtis-TRI): Should this have a render label built in?
@@ -197,9 +197,9 @@ enum class Role {
 /** The operations that can be performed on the given properties when assigning
  roles to geometry.  */
 enum class RoleAssign {
-  kNew,      ///< Assign the properties to a geometry that doesn't already have
-             ///< the role.
-  kReplace   ///< Replace the existing role properties completely.
+  kNew,     ///< Assign the properties to a geometry that doesn't already have
+            ///< the role.
+  kReplace  ///< Replace the existing role properties completely.
 };
 
 /** @name  Geometry role to string conversions

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -147,13 +147,10 @@ class GeometrySet {
     Add(frame_ids);
   }
 
-  template <
-      typename ContainerG,
-      typename ContainerF,
-      typename = typename std::enable_if_t<
-          std::is_same_v<typename ContainerG::value_type, GeometryId> &&
-          std::is_same_v<typename ContainerF::value_type, FrameId>>
-      >
+  template <typename ContainerG, typename ContainerF,
+            typename = typename std::enable_if_t<
+                std::is_same_v<typename ContainerG::value_type, GeometryId> &&
+                std::is_same_v<typename ContainerF::value_type, FrameId>>>
   GeometrySet(const ContainerG& geometry_ids, const ContainerF& frame_ids) {
     Add(geometry_ids, frame_ids);
   }
@@ -238,8 +235,7 @@ class GeometrySet {
   template <typename ContainerF>
   typename std::enable_if_t<
       std::is_same_v<typename ContainerF::value_type, FrameId>>
-  Add(
-      std::initializer_list<GeometryId> geometry_ids,
+  Add(std::initializer_list<GeometryId> geometry_ids,
       const ContainerF& frame_ids) {
     Add(geometry_ids);
     Add(frame_ids);
@@ -248,8 +244,7 @@ class GeometrySet {
   template <typename ContainerG>
   typename std::enable_if_t<
       std::is_same_v<typename ContainerG::value_type, GeometryId>>
-  Add(
-      const ContainerG& geometry_ids,
+  Add(const ContainerG& geometry_ids,
       std::initializer_list<FrameId> frame_ids) {
     Add(geometry_ids);
     Add(frame_ids);
@@ -257,8 +252,8 @@ class GeometrySet {
 
   void Add(const GeometrySet& other) {
     frame_ids_.insert(other.frame_ids_.begin(), other.frame_ids_.end());
-    geometry_ids_.insert(
-        other.geometry_ids_.begin(), other.geometry_ids_.end());
+    geometry_ids_.insert(other.geometry_ids_.begin(),
+                         other.geometry_ids_.end());
   }
 
   //@}
@@ -283,9 +278,7 @@ class GeometrySet {
 
   // Reports the number of geometries _explicitly_ in the set. It does _not_
   // count the geometries that belong to the added frames.
-  int num_geometries() const {
-    return static_cast<int>(geometry_ids_.size());
-  }
+  int num_geometries() const { return static_cast<int>(geometry_ids_.size()); }
 
   // Reports if the given `frame_id` has been added to the group.
   bool contains(FrameId frame_id) const {

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -125,8 +125,7 @@ GeometryState<T>::GeometryState()
   const FrameId world = InternalFrame::world_frame_id();
   // As an arbitrary design choice, we'll say the world frame is its own parent.
   frames_[world] = InternalFrame(self_source_, world, "world",
-                                 InternalFrame::world_frame_group(),
-                                 0, world);
+                                 InternalFrame::world_frame_group(), 0, world);
   frame_index_to_id_map_.push_back(world);
   kinematics_data_.X_WFs.push_back(RigidTransform<T>::Identity());
   kinematics_data_.X_PFs.push_back(RigidTransform<T>::Identity());
@@ -241,7 +240,7 @@ std::vector<GeometryId> GeometryState<T>::GetAllGeometryIds() const {
 
 template <typename T>
 unordered_set<GeometryId> GeometryState<T>::GetGeometryIds(
-      const GeometrySet& geometry_set, const std::optional<Role>& role) const {
+    const GeometrySet& geometry_set, const std::optional<Role>& role) const {
   return CollectIds(geometry_set, role, CollisionFilterScope::kAll);
 }
 
@@ -353,8 +352,7 @@ int GeometryState<T>::NumFramesForSource(SourceId source_id) const {
 }
 
 template <typename T>
-const FrameIdSet& GeometryState<T>::FramesForSource(
-    SourceId source_id) const {
+const FrameIdSet& GeometryState<T>::FramesForSource(SourceId source_id) const {
   return GetValueOrThrow(source_id, source_frame_id_map_);
 }
 
@@ -378,7 +376,7 @@ template <typename T>
 const std::string& GeometryState<T>::GetName(FrameId frame_id) const {
   FindOrThrow(frame_id, frames_, [frame_id]() {
     return "No frame name available for invalid frame id: " +
-        to_string(frame_id);
+           to_string(frame_id);
   });
   return frames_.at(frame_id).name();
 }
@@ -387,7 +385,7 @@ template <typename T>
 FrameId GeometryState<T>::GetParentFrame(FrameId frame_id) const {
   FindOrThrow(frame_id, frames_, [frame_id]() {
     return "No frame name available for invalid frame id: " +
-        to_string(frame_id);
+           to_string(frame_id);
   });
   const FrameId parent_frame_id = frames_.at(frame_id).parent_frame_id();
   if (parent_frame_id == frame_id) {
@@ -401,7 +399,7 @@ template <typename T>
 int GeometryState<T>::GetFrameGroup(FrameId frame_id) const {
   FindOrThrow(frame_id, frames_, [frame_id]() {
     return "No frame group available for invalid frame id: " +
-        to_string(frame_id);
+           to_string(frame_id);
   });
   return frames_.at(frame_id).frame_group();
 }
@@ -428,7 +426,7 @@ int GeometryState<T>::NumGeometriesWithRole(FrameId frame_id, Role role) const {
   int count = 0;
   FindOrThrow(frame_id, frames_, [frame_id, role]() {
     return "Cannot report number of geometries with the " + to_string(role) +
-        " role for invalid frame id: " + to_string(frame_id);
+           " role for invalid frame id: " + to_string(frame_id);
   });
   const InternalFrame& frame = frames_.at(frame_id);
   for (GeometryId id : frame.child_geometries()) {
@@ -507,7 +505,7 @@ template <typename T>
 bool GeometryState<T>::BelongsToSource(GeometryId geometry_id,
                                        SourceId source_id) const {
   // Confirm valid source id.
-  FindOrThrow(source_id, source_names_, [source_id](){
+  FindOrThrow(source_id, source_names_, [source_id]() {
     return get_missing_id_message(source_id);
   });
   // If this fails, the geometry_id is not valid and an exception is thrown.
@@ -533,7 +531,7 @@ const std::string& GeometryState<T>::GetName(GeometryId geometry_id) const {
   if (geometry != nullptr) return geometry->name();
 
   throw std::logic_error("No geometry available for invalid geometry id: " +
-      to_string(geometry_id));
+                         to_string(geometry_id));
 }
 
 template <typename T>
@@ -542,7 +540,7 @@ const Shape& GeometryState<T>::GetShape(GeometryId id) const {
   if (geometry != nullptr) return geometry->shape();
 
   throw std::logic_error("No geometry available for invalid geometry id: " +
-      to_string(id));
+                         to_string(id));
 }
 
 template <typename T>
@@ -636,7 +634,7 @@ template <typename T>
 bool GeometryState<T>::CollisionFiltered(GeometryId id1, GeometryId id2) const {
   std::string base_message =
       "Can't report collision filter status between geometries " +
-          to_string(id1) + " and " + to_string(id2) + "; ";
+      to_string(id1) + " and " + to_string(id2) + "; ";
   const internal::InternalGeometry* geometry1 = GetGeometry(id1);
   const internal::InternalGeometry* geometry2 = GetGeometry(id2);
   if (geometry1 != nullptr && geometry2 != nullptr) {
@@ -646,20 +644,20 @@ bool GeometryState<T>::CollisionFiltered(GeometryId id1, GeometryId id2) const {
     }
     if (geometry1->has_proximity_role()) {
       throw std::logic_error(base_message + to_string(id2) +
-          " does not have a proximity role");
+                             " does not have a proximity role");
     } else if (geometry2->has_proximity_role()) {
       throw std::logic_error(base_message + to_string(id1) +
-          " does not have a proximity role");
+                             " does not have a proximity role");
     } else {
       throw std::logic_error(base_message + " neither id has a proximity role");
     }
   }
   if (geometry1 != nullptr) {
     throw std::logic_error(base_message + to_string(id2) +
-        " is not a valid geometry");
+                           " is not a valid geometry");
   } else if (geometry2 != nullptr) {
     throw std::logic_error(base_message + to_string(id1) +
-        " is not a valid geometry");
+                           " is not a valid geometry");
   } else {
     throw std::logic_error(base_message + "neither id is a valid geometry");
   }
@@ -753,14 +751,16 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
   if (frames_.count(frame_id) > 0) {
     throw std::logic_error(
         "Registering frame with an id that has already been registered: " +
-            to_string(frame_id));
+        to_string(frame_id));
   }
 
   FrameIdSet& f_set = GetMutableValueOrThrow(source_id, &source_frame_id_map_);
   if (parent_id != InternalFrame::world_frame_id()) {
     FindOrThrow(parent_id, f_set, [parent_id, source_id]() {
-      return "Indicated parent id " + to_string(parent_id) + " does not belong "
-          "to the indicated source id " + to_string(source_id) + ".";
+      return "Indicated parent id " + to_string(parent_id) +
+             " does not belong "
+             "to the indicated source id " +
+             to_string(source_id) + ".";
     });
     frames_[parent_id].add_child(frame_id);
   } else {
@@ -782,29 +782,29 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
   kinematics_data_.X_WFs.emplace_back(RigidTransform<T>::Identity());
   frame_index_to_id_map_.push_back(frame_id);
   f_set.insert(frame_id);
-  frames_.emplace(frame_id, InternalFrame(source_id, frame_id, frame.name(),
-                                          frame.frame_group(), index,
-                                          parent_id));
+  frames_.emplace(frame_id,
+                  InternalFrame(source_id, frame_id, frame.name(),
+                                frame.frame_group(), index, parent_id));
   return frame_id;
 }
 
 template <typename T>
 void GeometryState<T>::RenameFrame(FrameId frame_id, const std::string& name) {
   FindOrThrow(frame_id, frames_, [frame_id]() {
-    return "Cannot rename frame with invalid frame id: " +
-        to_string(frame_id);
+    return "Cannot rename frame with invalid frame id: " + to_string(frame_id);
   });
   InternalFrame& frame = frames_.at(frame_id);
   const std::string old_name(frame.name());
-  if (old_name == name) { return; }
+  if (old_name == name) {
+    return;
+  }
 
   SourceId source_id = frame.source_id();
 
   // Edit source_frame_name_map_.
   FrameNameSet& f_name_set = source_frame_name_map_.at(source_id);
   f_name_set.erase(old_name);
-  const auto& [iterator, was_inserted] =
-      f_name_set.insert(std::string(name));
+  const auto& [iterator, was_inserted] = f_name_set.insert(std::string(name));
   if (!was_inserted) {
     throw std::logic_error(
         fmt::format("Renaming frame from '{}'"
@@ -821,9 +821,9 @@ GeometryId GeometryState<T>::RegisterGeometry(
     SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance> geometry) {
   if (geometry == nullptr) {
-    throw std::logic_error(
-        "Registering null geometry to frame " + to_string(frame_id) +
-            ", on source " + to_string(source_id) + ".");
+    throw std::logic_error("Registering null geometry to frame " +
+                           to_string(frame_id) + ", on source " +
+                           to_string(source_id) + ".");
   }
   const GeometryId geometry_id = geometry->id();
   ValidateRegistrationAndSetTopology(source_id, frame_id, geometry_id);
@@ -889,11 +889,12 @@ void GeometryState<T>::RenameGeometry(GeometryId geometry_id,
                                       const std::string& name) {
   InternalGeometry* geometry = GetMutableGeometry(geometry_id);
   if (geometry == nullptr) {
-    throw std::logic_error(
-        "Cannot rename geometry with invalid geometry id: "
-        + to_string(geometry_id));
+    throw std::logic_error("Cannot rename geometry with invalid geometry id: " +
+                           to_string(geometry_id));
   }
-  if (geometry->name() == name) { return; }
+  if (geometry->name() == name) {
+    return;
+  }
 
   // Check for name uniqueness in all assigned roles. Note: if the universe of
   // roles grows, this iteration will need to grow as well.
@@ -963,8 +964,7 @@ void GeometryState<T>::ChangeShape(SourceId source_id, GeometryId geometry_id,
 
 template <typename T>
 GeometryId GeometryState<T>::RegisterAnchoredGeometry(
-    SourceId source_id,
-    std::unique_ptr<GeometryInstance> geometry) {
+    SourceId source_id, std::unique_ptr<GeometryInstance> geometry) {
   return RegisterGeometry(source_id, InternalFrame::world_frame_id(),
                           std::move(geometry));
 }
@@ -973,10 +973,13 @@ template <typename T>
 void GeometryState<T>::RemoveGeometry(SourceId source_id,
                                       GeometryId geometry_id) {
   if (!BelongsToSource(geometry_id, source_id)) {
-    throw std::logic_error(
-        "Trying to remove geometry " + to_string(geometry_id) + " from "
-            "source " + to_string(source_id) + ", but the geometry doesn't "
-            "belong to that source.");
+    throw std::logic_error("Trying to remove geometry " +
+                           to_string(geometry_id) +
+                           " from "
+                           "source " +
+                           to_string(source_id) +
+                           ", but the geometry doesn't "
+                           "belong to that source.");
   }
 
   const InternalGeometry& geometry = GetValueOrThrow(geometry_id, geometries_);
@@ -1157,10 +1160,10 @@ template <typename T>
 int GeometryState<T>::RemoveRole(SourceId source_id, GeometryId geometry_id,
                                  Role role) {
   if (!BelongsToSource(geometry_id, source_id)) {
-    throw std::logic_error(
-        "Trying to remove the role " + to_string(role) + " from the geometry " +
-            to_string(geometry_id) + " from source " + to_string(source_id) +
-            ", but the geometry doesn't belong to that source.");
+    throw std::logic_error("Trying to remove the role " + to_string(role) +
+                           " from the geometry " + to_string(geometry_id) +
+                           " from source " + to_string(source_id) +
+                           ", but the geometry doesn't belong to that source.");
   }
 
   // One can't "remove" the unassigned role state.
@@ -1193,10 +1196,14 @@ int GeometryState<T>::RemoveFromRenderer(const std::string& renderer_name,
                                          SourceId source_id,
                                          GeometryId geometry_id) {
   if (!BelongsToSource(geometry_id, source_id)) {
-    throw std::logic_error(
-        "Trying to remove geometry " + to_string(geometry_id) + " from the "
-        "renderer '" + renderer_name + "', but the geometry doesn't belong to "
-        "given source " + to_string(source_id) + ".");
+    throw std::logic_error("Trying to remove geometry " +
+                           to_string(geometry_id) +
+                           " from the "
+                           "renderer '" +
+                           renderer_name +
+                           "', but the geometry doesn't belong to "
+                           "given source " +
+                           to_string(source_id) + ".");
   }
 
   return RemoveFromRendererUnchecked(renderer_name, geometry_id) ? 1 : 0;
@@ -1222,12 +1229,12 @@ void ThrowForNonProximity(const internal::InternalGeometry& g,
 
 template <typename T>
 SignedDistancePair<T> GeometryState<T>::ComputeSignedDistancePairClosestPoints(
-      GeometryId id_A, GeometryId id_B) const {
-    ThrowForNonProximity(GetValueOrThrow(id_A, geometries_), __func__);
-    ThrowForNonProximity(GetValueOrThrow(id_B, geometries_), __func__);
-    return geometry_engine_->ComputeSignedDistancePairClosestPoints(
-        id_A, id_B, kinematics_data_.X_WGs);
-  }
+    GeometryId id_A, GeometryId id_B) const {
+  ThrowForNonProximity(GetValueOrThrow(id_A, geometries_), __func__);
+  ThrowForNonProximity(GetValueOrThrow(id_B, geometries_), __func__);
+  return geometry_engine_->ComputeSignedDistancePairClosestPoints(
+      id_A, id_B, kinematics_data_.X_WGs);
+}
 
 template <typename T>
 void GeometryState<T>::AddRenderer(
@@ -1331,8 +1338,8 @@ void GeometryState<T>::RenderLabelImage(const ColorRenderCamera& camera,
 }
 
 template <typename T>
-std::unique_ptr<GeometryState<AutoDiffXd>>
-GeometryState<T>::ToAutoDiffXd() const {
+std::unique_ptr<GeometryState<AutoDiffXd>> GeometryState<T>::ToAutoDiffXd()
+    const {
   return std::unique_ptr<GeometryState<AutoDiffXd>>(
       new GeometryState<AutoDiffXd>(*this));
 }
@@ -1384,7 +1391,7 @@ void GeometryState<T>::SetFramePoses(
   const RigidTransform<T> world_pose = RigidTransform<T>::Identity();
   for (auto frame_id : source_root_frame_map_.at(source_id)) {
     UpdatePosesRecursively(frames_.at(frame_id), world_pose, poses,
-        kinematics_data);
+                           kinematics_data);
   }
 }
 
@@ -1409,10 +1416,10 @@ void GeometryState<T>::ValidateFrameIds(
   if (ref_frame_count != kinematics_data.size()) {
     // TODO(SeanCurtis-TRI): Determine if more specific information is required.
     // e.g., which frames are missing/added.
-    throw std::runtime_error(
-        "Disagreement in expected number of frames (" +
-        to_string(frames.size()) + ") and the given number of frames (" +
-        to_string(kinematics_data.size()) + ").");
+    throw std::runtime_error("Disagreement in expected number of frames (" +
+                             to_string(frames.size()) +
+                             ") and the given number of frames (" +
+                             to_string(kinematics_data.size()) + ").");
   }
   for (auto id : frames) {
     if (!kinematics_data.has_id(id)) {
@@ -1437,8 +1444,9 @@ void GeometryState<T>::ValidateRegistrationAndSetTopology(
   if (frame_id == InternalFrame::world_frame_id()) {
     // Explicitly validate the source id because it won't happen in acquiring
     // the world frame.
-    FindOrThrow(source_id, source_frame_id_map_,
-                [source_id]() { return get_missing_id_message(source_id); });
+    FindOrThrow(source_id, source_frame_id_map_, [source_id]() {
+      return get_missing_id_message(source_id);
+    });
     frame_source_id = self_source_;
   }
 
@@ -1460,9 +1468,9 @@ void GeometryState<T>::ValidateRegistrationAndSetTopology(
 
 template <typename T>
 void GeometryState<T>::FinalizePoseUpdate(
-      const internal::KinematicsData<T>& kinematics_data,
-      internal::ProximityEngine<T>* proximity_engine,
-      std::vector<render::RenderEngine*> render_engines) const {
+    const internal::KinematicsData<T>& kinematics_data,
+    internal::ProximityEngine<T>* proximity_engine,
+    std::vector<render::RenderEngine*> render_engines) const {
   proximity_engine->UpdateWorldPoses(kinematics_data.X_WGs);
   for (auto* render_engine : render_engines) {
     render_engine->UpdatePoses(kinematics_data.X_WGs);
@@ -1555,8 +1563,10 @@ template <typename T>
 void GeometryState<T>::ThrowIfNameExistsInRole(FrameId id, Role role,
                                                const std::string& name) const {
   if (!NameIsUnique(id, role, name)) {
-    throw std::logic_error("The name '" + name + "' has already been used by "
-        "a geometry with the '" + to_string(role) + "' role.");
+    throw std::logic_error("The name '" + name +
+                           "' has already been used by "
+                           "a geometry with the '" +
+                           to_string(role) + "' role.");
   }
 }
 
@@ -1591,8 +1601,8 @@ InternalGeometry& GeometryState<T>::ValidateRoleAssign(SourceId source_id,
                                                        RoleAssign assign) {
   if (!BelongsToSource(geometry_id, source_id)) {
     throw std::logic_error("Given geometry id " + to_string(geometry_id) +
-        " does not belong to the given source id " +
-        to_string(source_id));
+                           " does not belong to the given source id " +
+                           to_string(source_id));
   }
   InternalGeometry* geometry = GetMutableGeometry(geometry_id);
   // Must be non-null, otherwise, we never would've gotten past the
@@ -1604,14 +1614,14 @@ InternalGeometry& GeometryState<T>::ValidateRoleAssign(SourceId source_id,
   const bool has_role = geometry->has_role(role);
   if (has_role && assign == RoleAssign::kNew) {
     throw std::logic_error(
-        "Trying to assign the '" + to_string(role)
-        + "' role to geometry id " + to_string(geometry_id)
-        + " for the first time; it already has the role assigned");
+        "Trying to assign the '" + to_string(role) + "' role to geometry id " +
+        to_string(geometry_id) +
+        " for the first time; it already has the role assigned");
   } else if (!has_role && assign == RoleAssign::kReplace) {
     throw std::logic_error(
-        "Trying to replace the properties on geometry id "
-        + to_string(geometry_id) + " for the '" + to_string(role)
-        + "' role; it has not had the role initially assigned");
+        "Trying to replace the properties on geometry id " +
+        to_string(geometry_id) + " for the '" + to_string(role) +
+        "' role; it has not had the role initially assigned");
   }
 
   if (!has_role && assign == RoleAssign::kNew) {
@@ -1779,12 +1789,11 @@ const InternalFrame& GeometryState<T>::ValidateAndGetFrame(
     return frames_.at(frame_id);
   } else {
     // The generic test that the frame_id is owned by the source_id.
-    const FrameIdSet& set =
-        GetValueOrThrow(source_id, source_frame_id_map_);
+    const FrameIdSet& set = GetValueOrThrow(source_id, source_frame_id_map_);
     FindOrThrow(frame_id, set, [frame_id, source_id]() {
       return "Referenced frame " + to_string(frame_id) + " for source " +
-          to_string(source_id) +
-          ", but the frame doesn't belong to the source.";
+             to_string(source_id) +
+             ", but the frame doesn't belong to the source.";
     });
   }
   return frames_.at(frame_id);

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -377,9 +377,9 @@ class GeometryState {
   void RenameGeometry(GeometryId geometry_id, const std::string& name);
 
   /** Implementation of SceneGraph::ChangeShape().  */
-  void ChangeShape(
-      SourceId source_id, GeometryId geometry_id, const Shape& shape,
-      std::optional<math::RigidTransform<double>> X_FG);
+  void ChangeShape(SourceId source_id, GeometryId geometry_id,
+                   const Shape& shape,
+                   std::optional<math::RigidTransform<double>> X_FG);
 
   /** Implementation of SceneGraph::RemoveGeometry().  */
   void RemoveGeometry(SourceId source_id, GeometryId geometry_id);

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -46,11 +46,11 @@ class InternalFrame {
 
   /* Compares two %InternalFrame instances for "equality". Two internal frames
    are considered equal if they have the same frame identifier.  */
-  bool operator==(const InternalFrame &other) const;
+  bool operator==(const InternalFrame& other) const;
 
   /* Compares two %InternalFrame instances for inequality. See operator==()
    for the definition of equality.  */
-  bool operator!=(const InternalFrame &other) const;
+  bool operator!=(const InternalFrame& other) const;
 
   /* @name      Frame properties    */
   //@{
@@ -117,9 +117,7 @@ class InternalFrame {
 
   /* Adds the given `frame_id` to the set of frames that this frame considers
    to be children.  */
-  void add_child(FrameId frame_id) {
-    child_frames_.insert(frame_id);
-  }
+  void add_child(FrameId frame_id) { child_frames_.insert(frame_id); }
 
   /* Returns true if this frame considers the given `geometry_id` to be rigidly
    affixed to it.  */
@@ -142,9 +140,7 @@ class InternalFrame {
   }
 
   /* Changes the name of the frame to `name`. */
-  void set_name(const std::string& name) {
-    name_ = name;
-  }
+  void set_name(const std::string& name) { name_ = name; }
 
   /* The identifier used for identifying the single world frame in all
    instances of SceneGraph. The world frame will eventually have an arbitrary

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -72,13 +72,13 @@ class InternalGeometry {
   /* Compares two %InternalGeometry instances for "equality". Two internal
    geometries are considered equal if they have the same geometry identifier.
    */
-  bool operator==(const InternalGeometry &other) const {
+  bool operator==(const InternalGeometry& other) const {
     return id_ == other.id_;
   }
 
   /* Compares two %InternalGeometry instances for inequality. See operator==()
    for the definition of equality.  */
-  bool operator!=(const InternalGeometry &other) const {
+  bool operator!=(const InternalGeometry& other) const {
     return !(*this == other);
   }
 
@@ -210,26 +210,18 @@ class InternalGeometry {
 
   /* Removes the proximity role assigned to this geometry -- if there was
    no proximity role previously, this has no effect.  */
-  void RemoveProximityRole() {
-    proximity_props_ = std::nullopt;
-  }
+  void RemoveProximityRole() { proximity_props_ = std::nullopt; }
 
   /* Removes the illustration role assigned to this geometry -- if there was
    no illustration role previously, this has no effect.  */
-  void RemoveIllustrationRole() {
-    illustration_props_ = std::nullopt;
-  }
+  void RemoveIllustrationRole() { illustration_props_ = std::nullopt; }
 
   /* Removes the perception role assigned to this geometry -- if there was
    no perception role previously, this has no effect.  */
-  void RemovePerceptionRole() {
-    perception_props_ = std::nullopt;
-  }
+  void RemovePerceptionRole() { perception_props_ = std::nullopt; }
 
   /* Changes the name of the geometry to `name`. */
-  void set_name(const std::string& name) {
-    name_ = name;
-  }
+  void set_name(const std::string& name) { name_ = name; }
 
   //@}
 

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -157,8 +157,10 @@ Some notes on using the AR/VR modes:
 
 If you do not have AR/VR hardware, you can use an emulator in your browser to
 experiment with the mode. Use an browser plugin like WebXR API Emulator (i.e.,
-for [Chrome](https://chrome.google.com/webstore/detail/webxr-api-emulator/mjddjgeghkdijejnciaefnkjmkafnnje)
-or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/webxr-api-emulator/)).
+for
+[Chrome](https://chrome.google.com/webstore/detail/webxr-api-emulator/mjddjgeghkdijejnciaefnkjmkafnnje)
+or
+[Firefox](https://addons.mozilla.org/en-US/firefox/addon/webxr-api-emulator/)).
 
 @section network_access Network access
 

--- a/geometry/meshcat_animation.cc
+++ b/geometry/meshcat_animation.cc
@@ -19,18 +19,18 @@ void MeshcatAnimation::SetTransform(int frame, const std::string& path,
 }
 
 void MeshcatAnimation::SetProperty(int frame, const std::string& path,
-                  const std::string& property, bool value) {
+                                   const std::string& property, bool value) {
   SetProperty(frame, path, property, "boolean", value);
 }
 
 void MeshcatAnimation::SetProperty(int frame, const std::string& path,
-                  const std::string& property, double value) {
+                                   const std::string& property, double value) {
   SetProperty(frame, path, property, "number", value);
 }
 
 void MeshcatAnimation::SetProperty(int frame, const std::string& path,
-                  const std::string& property,
-                  const std::vector<double>& value) {
+                                   const std::string& property,
+                                   const std::vector<double>& value) {
   SetProperty(frame, path, property, "vector", value);
 }
 

--- a/geometry/meshcat_point_cloud_visualizer.cc
+++ b/geometry/meshcat_point_cloud_visualizer.cc
@@ -26,8 +26,7 @@ MeshcatPointCloudVisualizer<T>::MeshcatPointCloudVisualizer(
   DRAKE_DEMAND(publish_period >= 0.0);
 
   this->DeclarePeriodicPublishEvent(
-      publish_period, 0.0,
-      &MeshcatPointCloudVisualizer<T>::UpdateMeshcat);
+      publish_period, 0.0, &MeshcatPointCloudVisualizer<T>::UpdateMeshcat);
   this->DeclareForcedPublishEvent(
       &MeshcatPointCloudVisualizer<T>::UpdateMeshcat);
 

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -9,17 +9,13 @@
 #include <fmt/format.h>
 
 #include "drake/common/extract_double.h"
+#include "drake/common/overloaded.h"
 #include "drake/geometry/meshcat_graphviz.h"
 #include "drake/geometry/proximity/volume_to_surface_mesh.h"
 #include "drake/geometry/utilities.h"
 
 namespace drake {
 namespace geometry {
-namespace {
-// Boilerplate for std::visit.
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
-}  // namespace
 
 template <typename T>
 MeshcatVisualizer<T>::MeshcatVisualizer(std::shared_ptr<Meshcat> meshcat,
@@ -51,8 +47,7 @@ MeshcatVisualizer<T>::MeshcatVisualizer(std::shared_ptr<Meshcat> meshcat,
           .get_index();
 
   if (params_.enable_alpha_slider) {
-    meshcat_->AddSlider(
-      alpha_slider_name_, 0.02, 1.0, 0.02, alpha_value_);
+    meshcat_->AddSlider(alpha_slider_name_, 0.02, 1.0, 0.02, alpha_value_);
   }
 }
 
@@ -71,7 +66,7 @@ template <typename T>
 MeshcatAnimation* MeshcatVisualizer<T>::StartRecording(
     bool set_transforms_while_recording) {
   meshcat_->StartRecording(1.0 / params_.publish_period,
-                            set_transforms_while_recording);
+                           set_transforms_while_recording);
   return &meshcat_->get_mutable_recording();
 }
 
@@ -82,7 +77,7 @@ void MeshcatVisualizer<T>::StopRecording() {
 
 template <typename T>
 void MeshcatVisualizer<T>::PublishRecording() const {
-    meshcat_->PublishRecording();
+  meshcat_->PublishRecording();
 }
 
 template <typename T>
@@ -160,12 +155,12 @@ template <typename T>
 void MeshcatVisualizer<T>::SetObjects(
     const SceneGraphInspector<T>& inspector) const {
   // Frames registered previously that are not set again here should be deleted.
-  std::map <FrameId, std::string> frames_to_delete{};
+  std::map<FrameId, std::string> frames_to_delete{};
   dynamic_frames_.swap(frames_to_delete);
 
   // Geometries registered previously that are not set again here should be
   // deleted.
-  std::map <GeometryId, std::string> geometries_to_delete{};
+  std::map<GeometryId, std::string> geometries_to_delete{};
   geometries_.swap(geometries_to_delete);
 
   // TODO(SeanCurtis-TRI): Mimic the full tree structure in SceneGraph.

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -36,9 +36,9 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+using drake::geometry::internal::HydroelasticType;
 using Eigen::Vector3d;
 using fcl::CollisionObjectd;
-using drake::geometry::internal::HydroelasticType;
 using math::RigidTransform;
 using math::RigidTransformd;
 using std::make_shared;
@@ -151,8 +151,8 @@ void CopyFclObjectsOrThrow(
 // collision objects (the map populated by CopyFclObjectsOrThrow()).
 void BuildTreeFromReference(
     const fcl::DynamicAABBTreeCollisionManager<double>& other,
-    const std::unordered_map<const CollisionObjectd*,
-                             CollisionObjectd*>& copy_map,
+    const std::unordered_map<const CollisionObjectd*, CollisionObjectd*>&
+        copy_map,
     fcl::DynamicAABBTreeCollisionManager<double>* target) {
   std::vector<CollisionObjectd*> other_objects;
   other.getObjects(other_objects);
@@ -179,18 +179,16 @@ template <typename T, typename DataType>
 void FclCollide(const fcl::DynamicAABBTreeCollisionManager<double>& tree1,
                 const fcl::DynamicAABBTreeCollisionManager<double>& tree2,
                 DataType* data, fcl::CollisionCallBack<T> callback) {
-  tree1.collide(
-      const_cast<fcl::DynamicAABBTreeCollisionManager<T>*>(&tree2), data,
-      callback);
+  tree1.collide(const_cast<fcl::DynamicAABBTreeCollisionManager<T>*>(&tree2),
+                data, callback);
 }
 
 template <typename T, typename DataType>
 void FclDistance(const fcl::DynamicAABBTreeCollisionManager<double>& tree1,
                  const fcl::DynamicAABBTreeCollisionManager<double>& tree2,
                  DataType* data, fcl::DistanceCallBack<T> callback) {
-  tree1.distance(
-      const_cast<fcl::DynamicAABBTreeCollisionManager<T>*>(&tree2), data,
-      callback);
+  tree1.distance(const_cast<fcl::DynamicAABBTreeCollisionManager<T>*>(&tree2),
+                 data, callback);
 }
 
 // Compare function to use with ordering PenetrationAsPointPairs.
@@ -229,8 +227,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     anchored_objects_.clear();
 
     // Copy all of the geometry.
-    std::unordered_map<const CollisionObjectd*, CollisionObjectd*>
-        object_map;
+    std::unordered_map<const CollisionObjectd*, CollisionObjectd*> object_map;
     CopyFclObjectsOrThrow(other.anchored_objects_, &anchored_objects_,
                           &object_map);
     CopyFclObjectsOrThrow(other.dynamic_objects_, &dynamic_objects_,
@@ -257,8 +254,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     // types, modify this map to the appropriate scalar and modify consuming
     // functions accordingly.
     // Copy all of the geometry.
-    std::unordered_map<const CollisionObjectd*, CollisionObjectd*>
-        object_map;
+    std::unordered_map<const CollisionObjectd*, CollisionObjectd*> object_map;
     CopyFclObjectsOrThrow(anchored_objects_, &engine->anchored_objects_,
                           &object_map);
     CopyFclObjectsOrThrow(dynamic_objects_, &engine->dynamic_objects_,
@@ -382,13 +378,9 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   // Returns the total number of **rigid** geometries in this engine.
-  int num_geometries() const {
-    return num_dynamic() + num_anchored();
-  }
+  int num_geometries() const { return num_dynamic() + num_anchored(); }
 
-  int num_dynamic() const {
-    return static_cast<int>(dynamic_objects_.size());
-  }
+  int num_dynamic() const { return static_cast<int>(dynamic_objects_.size()); }
 
   int num_anchored() const {
     return static_cast<int>(anchored_objects_.size());
@@ -472,14 +464,13 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     int num_faces{0};
     if (convex.extension() == ".obj") {
       // Don't bother triangulating; Convex supports polygons.
-      std::tie(shared_verts, shared_faces, num_faces) =
-          ReadObjFile(convex.filename(), convex.scale(),
-                      false /* triangulate */);
-    } else if  (convex.extension() == ".vtk") {
-      auto surface_mesh = ConvertVolumeToSurfaceMesh(
-          ReadVtkToVolumeMesh(convex.filename()));
-      shared_verts = make_shared<const std::vector<Vector3d>>(
-          surface_mesh.vertices());
+      std::tie(shared_verts, shared_faces, num_faces) = ReadObjFile(
+          convex.filename(), convex.scale(), false /* triangulate */);
+    } else if (convex.extension() == ".vtk") {
+      auto surface_mesh =
+          ConvertVolumeToSurfaceMesh(ReadVtkToVolumeMesh(convex.filename()));
+      shared_verts =
+          make_shared<const std::vector<Vector3d>>(surface_mesh.vertices());
       shared_faces = make_shared<std::vector<int>>();
     } else {
       throw std::runtime_error(fmt::format(
@@ -503,8 +494,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   void ImplementGeometry(const Cylinder& cylinder, void* user_data) override {
     // Note: Using `shared_ptr` because of FCL API requirements.
-    auto fcl_cylinder = make_shared<fcl::Cylinderd>(cylinder.radius(),
-                                                    cylinder.length());
+    auto fcl_cylinder =
+        make_shared<fcl::Cylinderd>(cylinder.radius(), cylinder.length());
     TakeShapeOwnership(fcl_cylinder, user_data);
     ProcessHydroelastic(cylinder, user_data);
     ProcessGeometriesForDeformableContact(cylinder, user_data);
@@ -550,9 +541,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
       if (mesh.extension() == ".vtk") {
         // TODO(rpoyner-tri): could take convex hull here.
         shared_verts = make_shared<const std::vector<Vector3d>>(
-            ConvertVolumeToSurfaceMesh(
-                ReadVtkToVolumeMesh(mesh.filename()))
-            .vertices());
+            ConvertVolumeToSurfaceMesh(ReadVtkToVolumeMesh(mesh.filename()))
+                .vertices());
       } else if (mesh.extension() == ".obj") {
         // Don't bother triangulating; we're ignoring the faces.
         std::tie(shared_verts, std::ignore, std::ignore) =
@@ -670,8 +660,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
     std::vector<SignedDistanceToPoint<T>> distances;
 
-    point_distance::CallbackData<T> data{
-        &query_point, threshold, p_WQ, &X_WGs, &distances};
+    point_distance::CallbackData<T> data{&query_point, threshold, p_WQ, &X_WGs,
+                                         &distances};
 
     // Perform query of point vs dynamic objects.
     dynamic_tree_.distance(&query_point, &data, point_distance::Callback<T>);
@@ -1017,9 +1007,10 @@ void ProximityEngine<T>::AddDynamicGeometry(const Shape& shape,
 }
 
 template <typename T>
-void ProximityEngine<T>::AddAnchoredGeometry(
-    const Shape& shape, const RigidTransformd& X_WG, GeometryId id,
-    const ProximityProperties& props) {
+void ProximityEngine<T>::AddAnchoredGeometry(const Shape& shape,
+                                             const RigidTransformd& X_WG,
+                                             GeometryId id,
+                                             const ProximityProperties& props) {
   impl_->AddAnchoredGeometry(shape, X_WG, id, props);
 }
 

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -27,7 +27,8 @@
 namespace drake {
 namespace geometry {
 
-template <typename T> class GeometryState;
+template <typename T>
+class GeometryState;
 
 namespace internal {
 
@@ -206,8 +207,7 @@ class ProximityEngine {
    GeometryState::ComputeSignedDistancePairwiseClosestPoints().
    This includes `X_WGs`, the current poses of all geometries in World in the
    current scalar type, keyed on each geometry's GeometryId.  */
-  std::vector<SignedDistancePair<T>>
-  ComputeSignedDistancePairwiseClosestPoints(
+  std::vector<SignedDistancePair<T>> ComputeSignedDistancePairwiseClosestPoints(
       const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs,
       const double max_distance) const;
 
@@ -223,13 +223,11 @@ class ProximityEngine {
   /* Implementation of GeometryState::ComputeSignedDistanceToPoint().
    This includes `X_WGs`, the current poses of all geometries in World in the
    current scalar type, keyed on each geometry's GeometryId.  */
-  std::vector<SignedDistanceToPoint<T>>
-  ComputeSignedDistanceToPoint(
+  std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(
       const Vector3<T>& p_WQ,
       const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs,
       const double threshold = std::numeric_limits<double>::infinity()) const;
   //@}
-
 
   //----------------------------------------------------------------------------
   /* @name                Collision Queries
@@ -323,7 +321,8 @@ class ProximityEngine {
   explicit ProximityEngine(Impl* impl);
 
   // Engine on one scalar can see the members of other engines.
-  template <typename> friend class ProximityEngine;
+  template <typename>
+  friend class ProximityEngine;
 
   // Facilitate testing.
   friend class ProximityEngineTester;

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -62,13 +62,13 @@ extern const char* const kPointStiffness;  ///< Point stiffness property
  */
 //@{
 
-extern const char* const kHydroGroup;       ///< Hydroelastic group name.
-extern const char* const kElastic;          ///< Hydroelastic modulus property
-                                            ///< name.
-extern const char* const kRezHint;          ///< Resolution hint property name.
-extern const char* const kComplianceType;   ///< Compliance type property name.
-extern const char* const kSlabThickness;    ///< Slab thickness property name
-                                            ///< (for half spaces).
+extern const char* const kHydroGroup;      ///< Hydroelastic group name.
+extern const char* const kElastic;         ///< Hydroelastic modulus property
+                                           ///< name.
+extern const char* const kRezHint;         ///< Resolution hint property name.
+extern const char* const kComplianceType;  ///< Compliance type property name.
+extern const char* const kSlabThickness;   ///< Slab thickness property name
+                                           ///< (for half spaces).
 
 //@}
 

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -192,9 +192,8 @@ SignedDistancePair<T> QueryObject<T>::ComputeSignedDistancePairClosestPoints(
 
 template <typename T>
 std::vector<SignedDistanceToPoint<T>>
-QueryObject<T>::ComputeSignedDistanceToPoint(
-    const Vector3<T>& p_WQ,
-    const double threshold) const {
+QueryObject<T>::ComputeSignedDistanceToPoint(const Vector3<T>& p_WQ,
+                                             const double threshold) const {
   ThrowIfNotCallable();
 
   FullPoseUpdate();

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -138,9 +138,7 @@ class QueryObject {
 
   /** Provides an inspector for the topological structure of the underlying
    scene graph data (see SceneGraphInspector for details).  */
-  const SceneGraphInspector<T>& inspector() const {
-    return inspector_;
-  }
+  const SceneGraphInspector<T>& inspector() const { return inspector_; }
 
   /** @name                Configuration-dependent Introspection
 
@@ -770,12 +768,10 @@ class QueryObject {
                               values (and supporting data) for every supported
                               geometry as shown in the table. See
                               SignedDistanceToPoint. */
-  std::vector<SignedDistanceToPoint<T>>
-  ComputeSignedDistanceToPoint(const Vector3<T> &p_WQ,
-                               const double threshold
-                               = std::numeric_limits<double>::infinity()) const;
+  std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(
+      const Vector3<T>& p_WQ,
+      const double threshold = std::numeric_limits<double>::infinity()) const;
   //@}
-
 
   //---------------------------------------------------------------------------
   /**
@@ -830,7 +826,6 @@ class QueryObject {
   void RenderLabelImage(const render::ColorRenderCamera& camera,
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageLabel16I* label_image_out) const;
-
 
   /** Returns the named render engine, if it exists. The RenderEngine is
    guaranteed to be up to date w.r.t. the poses and data in the context. */
@@ -903,9 +898,7 @@ class QueryObject {
   }
 
   // Reports if the object can be copied; it must either be callable or default.
-  bool is_copyable() const {
-    return is_callable() || is_default();
-  }
+  bool is_copyable() const { return is_callable() || is_default(); }
 
   // Throws an exception if the QueryObject is neither "live" nor "baked" (see
   // class docs for discussion).

--- a/geometry/rgba.cc
+++ b/geometry/rgba.cc
@@ -17,17 +17,16 @@ void Rgba::set(const Eigen::Ref<const Eigen::VectorXd>& rgba) {
     new_value = rgba;
   } else {
     throw std::runtime_error(fmt::format(
-        "Rgba must contain either 3 or 4 elements (given [{}])",
-        rgba.size()));
+        "Rgba must contain either 3 or 4 elements (given [{}])", rgba.size()));
   }
 
   // Check the domain.
   for (int i = 0; i < 4; ++i) {
     if (!(new_value[i] >= 0 && new_value[i] <= 1.0)) {
-       throw std::runtime_error(fmt::format(
-           "Rgba values must be within the range [0, 1]. Values provided: "
-           "(r={}, g={}, b={}, a={})",
-           new_value[0], new_value[1], new_value[2], new_value[3]));
+      throw std::runtime_error(fmt::format(
+          "Rgba values must be within the range [0, 1]. Values provided: "
+          "(r={}, g={}, b={}, a={})",
+          new_value[0], new_value[1], new_value[2], new_value[3]));
     }
   }
 

--- a/geometry/rgba.h
+++ b/geometry/rgba.h
@@ -21,9 +21,7 @@ class Rgba {
 
   /** Constructs with given (r, g, b, a) values.
    @pre All values are within the range of [0, 1]. */
-  Rgba(double r, double g, double b, double a = 1.0) {
-    set(r, g, b, a);
-  }
+  Rgba(double r, double g, double b, double a = 1.0) { set(r, g, b, a); }
 
   /** Red. */
   double r() const { return value_[0]; }
@@ -70,13 +68,9 @@ class Rgba {
            std::abs(a() - other.a()) <= tolerance;
   }
 
-  bool operator==(const Rgba& other) const {
-    return value_ == other.value_;
-  }
+  bool operator==(const Rgba& other) const { return value_ == other.value_; }
 
-  bool operator!=(const Rgba& other) const {
-    return !(*this == other);
-  }
+  bool operator!=(const Rgba& other) const { return !(*this == other); }
 
   /** Computes the element-wise product of two rgba colors. This type of
    calculation is frequently used to modulate one color with another (e.g., for

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -107,8 +107,7 @@ SceneGraph<T>::SceneGraph()
 
 template <typename T>
 template <typename U>
-SceneGraph<T>::SceneGraph(const SceneGraph<U>& other)
-    : SceneGraph() {
+SceneGraph<T>::SceneGraph(const SceneGraph<U>& other) : SceneGraph() {
   model_ = GeometryState<T>(other.model_);
 
   // We need to guarantee that the same source ids map to the same port indices.
@@ -154,8 +153,7 @@ bool SceneGraph<T>::SourceIsRegistered(SourceId id) const {
 }
 
 template <typename T>
-const InputPort<T>& SceneGraph<T>::get_source_pose_port(
-    SourceId id) const {
+const InputPort<T>& SceneGraph<T>::get_source_pose_port(SourceId id) const {
   ThrowUnlessRegistered(id, "Can't acquire pose port for unknown source id: ");
   return this->get_input_port(input_source_ids_.at(id).pose_port);
 }
@@ -425,7 +423,7 @@ const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
 
 template <typename T>
 CollisionFilterManager SceneGraph<T>::collision_filter_manager() {
-  return model_.collision_filter_manager();;
+  return model_.collision_filter_manager();
 }
 
 template <typename T>
@@ -491,8 +489,7 @@ std::vector<FrameId> SceneGraph<T>::GetDynamicFrames(
 }
 
 template <typename T>
-void SceneGraph<T>::CalcPoseUpdate(const Context<T>& context,
-                                   int*) const {
+void SceneGraph<T>::CalcPoseUpdate(const Context<T>& context, int*) const {
   // TODO(SeanCurtis-TRI): Update this when the cache is available.
   // This method is const and the context is const. Ultimately, this will pull
   // cached entities to do the query work. For now, we have to const cast the
@@ -525,14 +522,12 @@ void SceneGraph<T>::CalcPoseUpdate(const Context<T>& context,
         }
         const auto& poses =
             pose_port.template Eval<FramePoseVector<T>>(context);
-        state.SetFramePoses(
-            source_id, poses, &kinematics_data);
+        state.SetFramePoses(source_id, poses, &kinematics_data);
       }
     }
   }
 
-  state.FinalizePoseUpdate(kinematics_data,
-                           &state.mutable_proximity_engine(),
+  state.FinalizePoseUpdate(kinematics_data, &state.mutable_proximity_engine(),
                            state.GetMutableRenderEngines());
 }
 
@@ -563,8 +558,8 @@ void SceneGraph<T>::CalcConfigurationUpdate(const Context<T>& context,
               state.GetName(source_id), source_id));
         }
         const auto& configs =
-            configuration_port
-                .template Eval<GeometryConfigurationVector<T>>(context);
+            configuration_port.template Eval<GeometryConfigurationVector<T>>(
+                context);
         state.SetGeometryConfiguration(source_id, configs, &kinematics_data);
       }
     }

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -419,8 +419,8 @@ class SceneGraphInspector {
            off of the original, but the returned id() will completely unique.
    @throws std::exception if the `geometry_id` does not refer to a valid
    geometry.  */
-  std::unique_ptr<GeometryInstance>
-  CloneGeometryInstance(GeometryId geometry_id) const;
+  std::unique_ptr<GeometryInstance> CloneGeometryInstance(
+      GeometryId geometry_id) const;
   //@}
 
  private:

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -34,7 +34,9 @@ void Shape::Reify(ShapeReifier* reifier, void* user_data) const {
   reifier_(*this, reifier, user_data);
 }
 
-std::unique_ptr<Shape> Shape::Clone() const { return cloner_(*this); }
+std::unique_ptr<Shape> Shape::Clone() const {
+  return cloner_(*this);
+}
 
 template <typename S>
 Shape::Shape(ShapeTag<S>) {
@@ -54,8 +56,7 @@ Shape::Shape(ShapeTag<S>) {
 }
 
 Box::Box(double width, double depth, double height)
-    : Shape(ShapeTag<Box>()),
-      size_(width, depth, height) {
+    : Shape(ShapeTag<Box>()), size_(width, depth, height) {
   if (width <= 0 || depth <= 0 || height <= 0) {
     throw std::logic_error(
         fmt::format("Box width, depth, and height should all be > 0 (were {}, "
@@ -95,9 +96,7 @@ Convex::Convex(const std::string& filename, double scale)
 }
 
 Cylinder::Cylinder(double radius, double length)
-    : Shape(ShapeTag<Cylinder>()),
-      radius_(radius),
-      length_(length) {
+    : Shape(ShapeTag<Cylinder>()), radius_(radius), length_(length) {
   if (radius <= 0 || length <= 0) {
     throw std::logic_error(
         fmt::format("Cylinder radius and length should both be > 0 (were {} "
@@ -178,8 +177,7 @@ MeshcatCone::MeshcatCone(double height, double a, double b)
 MeshcatCone::MeshcatCone(const Vector3<double>& measures)
     : MeshcatCone(measures(0), measures(1), measures(2)) {}
 
-Sphere::Sphere(double radius)
-    : Shape(ShapeTag<Sphere>()), radius_(radius) {
+Sphere::Sphere(double radius) : Shape(ShapeTag<Sphere>()), radius_(radius) {
   if (radius < 0) {
     throw std::logic_error(
         fmt::format("Sphere radius should be >= 0 (was {}).", radius));
@@ -286,7 +284,9 @@ template <class MeshType>
 double CalcMeshVolumeFromFile(const MeshType& mesh) {
   std::string extension = std::filesystem::path(mesh.filename()).extension();
   std::transform(extension.begin(), extension.end(), extension.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
+                 [](unsigned char c) {
+                   return std::tolower(c);
+                 });
   // TODO(russt): Support .vtk files.
   if (extension != ".obj") {
     throw std::runtime_error(fmt::format(
@@ -310,7 +310,7 @@ class CalcVolumeReifier final : public ShapeReifier {
   }
   void ImplementGeometry(const Capsule& capsule, void*) final {
     volume_ = M_PI * std::pow(capsule.radius(), 2) * capsule.length() +
-         4.0 / 3.0 * M_PI * std::pow(capsule.radius(), 3);
+              4.0 / 3.0 * M_PI * std::pow(capsule.radius(), 3);
   }
   void ImplementGeometry(const Convex& mesh, void*) {
     volume_ = CalcMeshVolumeFromFile(mesh);

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -25,7 +25,7 @@ class ShapeReifier;
  A class derived from the Shape class will invoke the parent's constructor as
  Shape(ShapeTag<DerivedShape>()). */
 template <typename ShapeType>
-struct ShapeTag{};
+struct ShapeTag {};
 
 /** The base interface for all shape specifications. It has no public
   constructor and cannot be instantiated directly. The Shape class has two
@@ -533,6 +533,5 @@ double CalcVolume(const Shape& shape);
 // TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {
 template <>
-struct formatter<drake::geometry::ShapeName>
-    : drake::ostream_formatter {};
+struct formatter<drake::geometry::ShapeName> : drake::ostream_formatter {};
 }  // namespace fmt

--- a/geometry/shape_to_string.cc
+++ b/geometry/shape_to_string.cc
@@ -11,8 +11,8 @@ void ShapeToString::ImplementGeometry(const Box& box, void*) {
 }
 
 void ShapeToString::ImplementGeometry(const Capsule& capsule, void*) {
-  string_ = fmt::format("Capsule(r: {}, l: {})", capsule.radius(),
-                        capsule.length());
+  string_ =
+      fmt::format("Capsule(r: {}, l: {})", capsule.radius(), capsule.length());
 }
 
 void ShapeToString::ImplementGeometry(const Convex& convex, void*) {

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -120,15 +120,13 @@ class ConfigurationSource : public systems::LeafSystem<T> {
         &ConfigurationSource<T>::ReadConfigurations);
   }
 
-  void SetConfigurations(
-    GeometryConfigurationVector<T> configurations) {
+  void SetConfigurations(GeometryConfigurationVector<T> configurations) {
     configurations_ = std::move(configurations);
   }
 
  private:
   void ReadConfigurations(
-      const Context<T>&,
-      GeometryConfigurationVector<T>* configurations) const {
+      const Context<T>&, GeometryConfigurationVector<T>* configurations) const {
     *configurations = configurations_;
   }
 
@@ -358,10 +356,10 @@ class DrakeVisualizerTest : public ::testing::Test {
 
   struct Subscribers;
   Subscribers& GetSubscribers(std::optional<Role> role) {
-    std::map<Role, Subscribers *> subscribers_{
-      {Role::kIllustration, &illustration_subs_},
-      {Role::kProximity, &proximity_subs_},
-      {Role::kPerception, &perception_subs_},
+    std::map<Role, Subscribers*> subscribers_{
+        {Role::kIllustration, &illustration_subs_},
+        {Role::kProximity, &proximity_subs_},
+        {Role::kPerception, &perception_subs_},
     };
     if (role.has_value()) {
       DRAKE_DEMAND(*role != Role::kUnassigned);
@@ -369,7 +367,6 @@ class DrakeVisualizerTest : public ::testing::Test {
     }
     return default_subs_;
   }
-
 
   static constexpr double kPublishPeriod = 1 / 64.0;
 
@@ -575,9 +572,9 @@ TYPED_TEST(DrakeVisualizerTest, ConfigureDefaultDiffuse) {
  provide data for the dynamic frames (i.e., "world" will not be included).  */
 TYPED_TEST(DrakeVisualizerTest, AnchoredAndDynamicGeometry) {
   using T = TypeParam;
-  this->ConfigureDiagram(
-      {.publish_period = this->kPublishPeriod, .role = Role::kProximity,
-       .use_role_channel_suffix = true});
+  this->ConfigureDiagram({.publish_period = this->kPublishPeriod,
+                          .role = Role::kProximity,
+                          .use_role_channel_suffix = true});
   const FrameId f_id = this->scene_graph_->RegisterFrame(
       this->pose_source_id_, GeometryFrame("frame", 0));
   const GeometryId g0_id = this->scene_graph_->RegisterGeometry(
@@ -643,16 +640,18 @@ TYPED_TEST(DrakeVisualizerTest, TargetRole) {
       {Role::kProximity, source_name + "::proximity"}};
   for (const auto& [role, name] : expected) {
     for (const bool use_suffix : {false, true}) {
-      SCOPED_TRACE(fmt::format("role '{}', name '{}', use_suffix '{}'",
-                               role, name, use_suffix));
-      this->ConfigureDiagram(
-          {.publish_period = this->kPublishPeriod, .role = role,
-           .use_role_channel_suffix = use_suffix});
+      SCOPED_TRACE(fmt::format("role '{}', name '{}', use_suffix '{}'", role,
+                               name, use_suffix));
+      this->ConfigureDiagram({.publish_period = this->kPublishPeriod,
+                              .role = role,
+                              .use_role_channel_suffix = use_suffix});
       this->PopulateScene();
       Simulator<T> simulator(*(this->diagram_));
       simulator.AdvanceTo(0.0);
       std::optional<Role> maybe_role;
-      if (use_suffix) { maybe_role = role; }
+      if (use_suffix) {
+        maybe_role = role;
+      }
       MessageResults results = this->ProcessMessages(maybe_role);
 
       /* Confirm that messages were sent.  */
@@ -691,9 +690,9 @@ TYPED_TEST(DrakeVisualizerTest, ForcePublish) {
  illustration role with color, that value is used instead of the default.  */
 TYPED_TEST(DrakeVisualizerTest, GeometryWithIllustrationFallback) {
   using T = TypeParam;
-  this->ConfigureDiagram(
-      {.publish_period = this->kPublishPeriod, .role = Role::kProximity,
-       .use_role_channel_suffix = true});
+  this->ConfigureDiagram({.publish_period = this->kPublishPeriod,
+                          .role = Role::kProximity,
+                          .use_role_channel_suffix = true});
   const GeometryId g_id = this->scene_graph_->RegisterAnchoredGeometry(
       this->pose_source_id_,
       make_unique<GeometryInstance>(RigidTransformd{}, make_unique<Sphere>(1),
@@ -724,9 +723,9 @@ TYPED_TEST(DrakeVisualizerTest, GeometryWithIllustrationFallback) {
 TYPED_TEST(DrakeVisualizerTest, AllRolesCanDefineDiffuse) {
   using T = TypeParam;
   for (const Role role : {Role::kProximity, Role::kPerception}) {
-    this->ConfigureDiagram(
-        {.publish_period = this->kPublishPeriod, .role = role,
-         .use_role_channel_suffix = true});
+    this->ConfigureDiagram({.publish_period = this->kPublishPeriod,
+                            .role = role,
+                            .use_role_channel_suffix = true});
     const GeometryId g_id = this->scene_graph_->RegisterAnchoredGeometry(
         this->pose_source_id_,
         make_unique<GeometryInstance>(RigidTransformd{}, make_unique<Sphere>(1),
@@ -788,9 +787,9 @@ TYPED_TEST(DrakeVisualizerTest, ChangesInVersion) {
   using T = TypeParam;
   for (const Role role :
        {Role::kProximity, Role::kPerception, Role::kIllustration}) {
-    this->ConfigureDiagram(
-        {.publish_period = this->kPublishPeriod, .role = role,
-         .use_role_channel_suffix = true});
+    this->ConfigureDiagram({.publish_period = this->kPublishPeriod,
+                            .role = role,
+                            .use_role_channel_suffix = true});
     const GeometryId g_id = this->scene_graph_->RegisterAnchoredGeometry(
         this->pose_source_id_,
         make_unique<GeometryInstance>(RigidTransformd{}, make_unique<Sphere>(1),

--- a/geometry/test/geometry_instance_test.cc
+++ b/geometry/test/geometry_instance_test.cc
@@ -20,8 +20,8 @@ GTEST_TEST(GeometryInstanceTest, IsCopyable) {
   // Verify that this is copyable as defined by copyable_unique_ptr. We don't
   // have a runtime check available but this will fail to compile if the class
   // is not copyable.
-  copyable_unique_ptr<GeometryInstance> geometry(make_unique<GeometryInstance>
-      (RigidTransformd(), make_unique<Sphere>(1), "sphere"));
+  copyable_unique_ptr<GeometryInstance> geometry(make_unique<GeometryInstance>(
+      RigidTransformd(), make_unique<Sphere>(1), "sphere"));
   EXPECT_TRUE(geometry->id().is_valid());
 }
 

--- a/geometry/test/geometry_set_test.cc
+++ b/geometry/test/geometry_set_test.cc
@@ -58,14 +58,15 @@ GTEST_TEST(GeometrySetTests, ConversionConstructor) {
   auto frame_list = {FrameId::get_new_id(), FrameId::get_new_id()};
   std::vector<FrameId> frame_vector{frame_list};
 
-  auto test_single_source_constructor = [](
-      const GeometrySet& set, const auto& source, int expected_frame_count,
-      int expected_geometry_count, const char* message) {
-    GeometrySetTester set_tester(&set);
-    EXPECT_EQ(set_tester.num_frames(), expected_frame_count) << message;
-    EXPECT_EQ(set_tester.num_geometries(), expected_geometry_count) << message;
-    ExpectContainsAll(set_tester, source, message);
-  };
+  auto test_single_source_constructor =
+      [](const GeometrySet& set, const auto& source, int expected_frame_count,
+         int expected_geometry_count, const char* message) {
+        GeometrySetTester set_tester(&set);
+        EXPECT_EQ(set_tester.num_frames(), expected_frame_count) << message;
+        EXPECT_EQ(set_tester.num_geometries(), expected_geometry_count)
+            << message;
+        ExpectContainsAll(set_tester, source, message);
+      };
 
   GeometrySet set1(g_id);
   test_single_source_constructor(set1, std::set<GeometryId>{g_id}, 0, 1,
@@ -138,10 +139,8 @@ GTEST_TEST(GeometrySetTests, ConversionConstructor) {
   EXPECT_EQ(tester12.num_frames(), static_cast<int>(frame_vector.size()));
   EXPECT_EQ(tester12.num_geometries(),
             static_cast<int>(geometry_vector.size()));
-  ExpectContainsAll(tester12, geometry_vector,
-                    "Geometry vector, frame vector");
-  ExpectContainsAll(tester12, frame_vector,
-                    "Geometry vector, frame vector");
+  ExpectContainsAll(tester12, geometry_vector, "Geometry vector, frame vector");
+  ExpectContainsAll(tester12, frame_vector, "Geometry vector, frame vector");
 }
 
 GTEST_TEST(GeometrySetTests, SingleFrameAdd) {
@@ -364,4 +363,3 @@ GTEST_TEST(GeometrySetTests, GeometrySetAdd) {
 }  // namespace
 }  // namespace geometry
 }  // namespace drake
-

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -69,9 +69,7 @@ class GeometryStateTester {
 
   FrameId get_world_frame() const { return InternalFrame::world_frame_id(); }
 
-  SourceId get_self_source_id() const {
-    return state_->self_source_;
-  }
+  SourceId get_self_source_id() const { return state_->self_source_; }
 
   const unordered_map<SourceId, string>& get_source_name_map() const {
     return state_->source_names_;
@@ -128,7 +126,7 @@ class GeometryStateTester {
   }
 
   void SetFramePoses(SourceId source_id, const FramePoseVector<T>& poses,
-     internal::KinematicsData<T>* kinematics_data) {
+                     internal::KinematicsData<T>* kinematics_data) {
     state_->SetFramePoses(source_id, poses, kinematics_data);
   }
 
@@ -176,7 +174,7 @@ class GeometryStateTester {
   }
 
   const GeometryVersion& geometry_version() const {
-      return state_->geometry_version_;
+    return state_->geometry_version_;
   }
 
   // Provides acesss to the scalar-converting copy constructor.
@@ -488,8 +486,8 @@ class GeometryStateTestBase {
     // 90° around x-axis.
     RigidTransformd pose(AngleAxis<double>(M_PI_2, Vector3d::UnitX()),
                          Vector3d{1, 2, 3});
-    frames_.push_back(geometry_state_.RegisterFrame(
-        source_id_, GeometryFrame("f0")));
+    frames_.push_back(
+        geometry_state_.RegisterFrame(source_id_, GeometryFrame("f0")));
     X_WFs_.push_back(pose);
     X_PFs_.push_back(pose);
 
@@ -497,15 +495,15 @@ class GeometryStateTestBase {
     // 90° around y-axis.
     pose = RigidTransformd(AngleAxis<double>(M_PI_2, Vector3d::UnitY()),
                            Vector3d{10, 20, 30});
-    frames_.push_back(geometry_state_.RegisterFrame(
-        source_id_, GeometryFrame("f1")));
+    frames_.push_back(
+        geometry_state_.RegisterFrame(source_id_, GeometryFrame("f1")));
     X_WFs_.push_back(pose);
     X_PFs_.push_back(pose);
 
     // Create f2.
     pose = pose.inverse();
-    frames_.push_back(geometry_state_.RegisterFrame(
-        source_id_, frames_[1], GeometryFrame("f2")));
+    frames_.push_back(geometry_state_.RegisterFrame(source_id_, frames_[1],
+                                                    GeometryFrame("f2")));
     X_WFs_.push_back(X_WFs_[1] * pose);
     X_PFs_.push_back(pose);
 
@@ -536,7 +534,7 @@ class GeometryStateTestBase {
     // (as that is how `RegisterAnchoredGeometry()` works.
     anchored_geometry_ = geometry_state_.RegisterAnchoredGeometry(
         source_id_, make_unique<GeometryInstance>(
-            X_WA_, make_unique<Box>(100, 100, 2), anchored_name_));
+                        X_WA_, make_unique<Box>(100, 100, 2), anchored_name_));
 
     if ((roles_to_assign & Assign::kProximity) != Assign::kNone) {
       AssignProximityToSingleSourceTree();
@@ -614,7 +612,7 @@ class GeometryStateTestBase {
   // Values for setting up and testing the dummy tree.
   enum Counts {
     kFrameCount = 3,
-    kGeometryCount = 2    // Geometries *per frame*.
+    kGeometryCount = 2  // Geometries *per frame*.
   };
   // The frame ids created in the dummy tree instantiation.
   vector<FrameId> frames_;
@@ -787,8 +785,9 @@ TEST_F(GeometryStateTest, Constructor) {
   // GeometryState always has a world frame.
   EXPECT_EQ(geometry_state_.get_num_frames(), 1);
   EXPECT_EQ(geometry_state_.get_num_geometries(), 0);
-  EXPECT_EQ(gs_tester_.get_source_frame_name_map().find(
-                gs_tester_.get_self_source_id())->second,
+  EXPECT_EQ(gs_tester_.get_source_frame_name_map()
+                .find(gs_tester_.get_self_source_id())
+                ->second,
             internal::FrameNameSet{"world"});
 }
 
@@ -796,8 +795,8 @@ TEST_F(GeometryStateTest, Constructor) {
 // introspection.
 TEST_F(GeometryStateTest, IntrospectShapes) {
   const SourceId source_id = geometry_state_.RegisterNewSource("test_source");
-  const FrameId frame_id = geometry_state_.RegisterFrame(
-      source_id, GeometryFrame("frame"));
+  const FrameId frame_id =
+      geometry_state_.RegisterFrame(source_id, GeometryFrame("frame"));
 
   // Test across all valid shapes.
   {
@@ -893,8 +892,7 @@ TEST_F(GeometryStateTest, GeometryStatistics) {
       "Referenced geometry source .* is not registered.");
   EXPECT_EQ(geometry_state_.NumDynamicGeometries(),
             single_tree_dynamic_geometry_count());
-  EXPECT_EQ(geometry_state_.NumAnchoredGeometries(),
-            anchored_geometry_count());
+  EXPECT_EQ(geometry_state_.NumAnchoredGeometries(), anchored_geometry_count());
   EXPECT_EQ(
       geometry_state_.NumAnchoredGeometries(),
       geometry_state_.NumGeometriesForFrame(InternalFrame::world_frame_id()));
@@ -926,9 +924,8 @@ TEST_F(GeometryStateTest, RenameFrame) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.RenameFrame(FrameId::get_new_id(), "invalid"),
       ".*Cannot rename.*invalid frame id:.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.RenameFrame(frames_[0], "f1"),
-      ".*already existing.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(geometry_state_.RenameFrame(frames_[0], "f1"),
+                              ".*already existing.*");
 
   // Renaming a frame to its existing name does not cause errors.
   std::string original_name0(geometry_state_.GetName(frames_[0]));
@@ -960,7 +957,6 @@ template <typename T>
 void ExpectSuccessfulTransmogrification(
     const GeometryStateTester<T>& T_tester,
     const GeometryStateTester<double>& d_tester) {
-
   // 1. Test all of the identifier -> trivially testable value maps
   EXPECT_EQ(T_tester.get_self_source_id(), d_tester.get_self_source_id());
   EXPECT_EQ(T_tester.get_source_name_map(), d_tester.get_source_name_map());
@@ -1000,8 +996,8 @@ void ExpectSuccessfulTransmogrification(
   };
 
   auto test_T_vs_double = [test_T_vs_double_pose](
-                               const vector<RigidTransform<T>>& test,
-                               const vector<RigidTransformd>& ref) {
+                              const vector<RigidTransform<T>>& test,
+                              const vector<RigidTransformd>& ref) {
     EXPECT_EQ(test.size(), ref.size());
     for (size_t i = 0; i < ref.size(); ++i) {
       test_T_vs_double_pose(test[i], ref[i]);
@@ -1032,7 +1028,7 @@ void ExpectSuccessfulTransmogrification(
       };
 
   test_T_vs_double(T_tester.get_frame_parent_poses(),
-                    d_tester.get_frame_parent_poses());
+                   d_tester.get_frame_parent_poses());
   test_T_vs_double_pose_map(T_tester.get_geometry_world_poses(),
                             d_tester.get_geometry_world_poses());
   test_T_vs_double(T_tester.get_frame_world_poses(),
@@ -1074,7 +1070,7 @@ TEST_F(GeometryStateTest, CopyAutoDiffIntoDouble) {
 
   // Convert.
   std::unique_ptr<GeometryState<double>> dut =
-    GeometryStateTester<double>::CopyGeometryState(ad_state);
+      GeometryStateTester<double>::CopyGeometryState(ad_state);
 
   // Check for equality.
   GeometryStateTester<double> d_tester;
@@ -1094,7 +1090,7 @@ TEST_F(GeometryStateTest, CopySymbolicIntoDouble) {
 
   // Convert.
   std::unique_ptr<GeometryState<double>> dut =
-    GeometryStateTester<double>::CopyGeometryState(sym_state);
+      GeometryStateTester<double>::CopyGeometryState(sym_state);
 
   // Check for equality.
   GeometryStateTester<double> d_tester;
@@ -1124,7 +1120,7 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
     const auto& s_f_id_map = gs_tester_.get_source_frame_id_map();
     EXPECT_EQ(s_f_id_map.size(), 2);
     EXPECT_NE(s_f_id_map.find(s_id), s_f_id_map.end());
-    const auto &f_id_set = s_f_id_map.at(s_id);
+    const auto& f_id_set = s_f_id_map.at(s_id);
     EXPECT_EQ(frames_.size(), f_id_set.size());
     for (int f = 0; f < kFrameCount; ++f) {
       EXPECT_NE(f_id_set.find(frames_[f]), f_id_set.end());
@@ -1137,7 +1133,7 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
     const auto& s_root_map = gs_tester_.get_source_root_frame_map();
     EXPECT_EQ(s_root_map.size(), 2);
     EXPECT_NE(s_root_map.find(s_id), s_root_map.end());
-    const auto &root_id_set = s_root_map.at(s_id);
+    const auto& root_id_set = s_root_map.at(s_id);
     EXPECT_NE(root_id_set.find(frames_[0]), root_id_set.end());
     EXPECT_NE(root_id_set.find(frames_[1]), root_id_set.end());
     EXPECT_EQ(root_id_set.find(frames_[2]), root_id_set.end());
@@ -1157,15 +1153,15 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
       EXPECT_EQ(frame.id(), frames_[i]);
       EXPECT_EQ(frame.name(), "f" + to_string(i));
       EXPECT_EQ(frame.frame_group(), 0);  // Defaults to zero.
-      EXPECT_EQ(frame.index(), i + 1);   // ith frame added.
+      EXPECT_EQ(frame.index(), i + 1);    // ith frame added.
       EXPECT_EQ(frame.parent_frame_id(), parent_id);
       EXPECT_EQ(frame.child_frames().size(), num_child_frames);
       const auto& child_geometries = frame.child_geometries();
       EXPECT_EQ(child_geometries.size(), 2);
       EXPECT_NE(child_geometries.find(geometries_[i * 2]),
-                                      child_geometries.end());
+                child_geometries.end());
       EXPECT_NE(child_geometries.find(geometries_[i * 2 + 1]),
-                                      child_geometries.end());
+                child_geometries.end());
       const auto& frame_in_parent = gs_tester_.get_frame_parent_poses();
       EXPECT_TRUE(
           CompareMatrices(frame_in_parent[frame.index()].GetAsMatrix34(),
@@ -1186,8 +1182,8 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
     for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
       poses.set_value(frames_[f], X_PFs_[f]);
     }
-    gs_tester_.SetFramePoses(
-        s_id, poses, &gs_tester_.mutable_kinematics_data());
+    gs_tester_.SetFramePoses(s_id, poses,
+                             &gs_tester_.mutable_kinematics_data());
     gs_tester_.FinalizePoseUpdate();
 
     test_frame(0, gs_tester_.get_world_frame(), 0);
@@ -1334,9 +1330,8 @@ TEST_F(GeometryStateTest, GetNumGeometryTests) {
               geometry_state_.NumGeometriesForFrame(frames_[i]));
     EXPECT_EQ(kGeometryCount, geometry_state_.NumGeometriesForFrameWithRole(
                                   frames_[i], Role::kProximity));
-    EXPECT_EQ(0,
-              geometry_state_.NumGeometriesForFrameWithRole(
-                  frames_[i], Role::kPerception));
+    EXPECT_EQ(0, geometry_state_.NumGeometriesForFrameWithRole(
+                     frames_[i], Role::kPerception));
     EXPECT_EQ(0, geometry_state_.NumGeometriesForFrameWithRole(
                      frames_[i], Role::kIllustration));
   }
@@ -1427,7 +1422,7 @@ TEST_F(GeometryStateTest, AddFirstFrameToValidSource) {
   const FrameId fid = geometry_state_.RegisterFrame(s_id, *frame_);
   EXPECT_EQ(fid, frame_->id());
   EXPECT_TRUE(geometry_state_.BelongsToSource(fid, s_id));
-  const auto &frame_set = geometry_state_.FramesForSource(s_id);
+  const auto& frame_set = geometry_state_.FramesForSource(s_id);
   EXPECT_NE(frame_set.find(fid), frame_set.end());
   EXPECT_EQ(frame_set.size(), 1);
   // The frame *is* a root frame; so both sets should be the same size.
@@ -2113,8 +2108,7 @@ TEST_F(GeometryStateTest, RemoveGeometryInvalid) {
 
   // Case: Invalid source id, valid geometry id.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.RemoveGeometry(SourceId::get_new_id(),
-                                     geometries_[0]),
+      geometry_state_.RemoveGeometry(SourceId::get_new_id(), geometries_[0]),
       "Referenced geometry source \\d+ is not registered.");
 
   // Case: Invalid geometry id, valid source id.
@@ -2135,7 +2129,7 @@ TEST_F(GeometryStateTest, RemoveGeometryInvalid) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.RemoveGeometry(s_id, g_id),
       "Trying to remove geometry \\d+ from source \\d+.+geometry doesn't "
-          "belong.+");
+      "belong.+");
 }
 
 // Tests removal of anchored geometry.
@@ -2233,8 +2227,7 @@ TEST_F(GeometryStateTest, SourceOwnershipInvalidSource) {
   const GeometryId anchored_id = geometry_state_.RegisterAnchoredGeometry(
       source_id_,
       make_unique<GeometryInstance>(RigidTransformd::Identity(),
-                                    make_unique<Sphere>(1),
-                                    "sphere"));
+                                    make_unique<Sphere>(1), "sphere"));
   // Valid frame/geometry ids.
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.BelongsToSource(frames_[0], source_id),
@@ -2266,8 +2259,7 @@ TEST_F(GeometryStateTest, SourceOwnershipGeometryId) {
   const SourceId s_id = SetUpSingleSourceTree();
   const GeometryId anchored_id = geometry_state_.RegisterAnchoredGeometry(
       s_id, make_unique<GeometryInstance>(RigidTransformd::Identity(),
-                                          make_unique<Sphere>(1),
-                                          "sphere"));
+                                          make_unique<Sphere>(1), "sphere"));
   // Test for invalid geometry.
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.BelongsToSource(GeometryId::get_new_id(), s_id),
@@ -2303,7 +2295,7 @@ TEST_F(GeometryStateTest, ValidateFrameIds) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       gs_tester_.ValidateFrameIds(s_id, frame_set_2),
       "Registered frame id \\(\\d+\\) belonging to source \\d+ was not found "
-          "in the provided kinematics data.");
+      "in the provided kinematics data.");
 
   // Case: Too few frames.
   FramePoseVector<double> frame_set_3;
@@ -2331,8 +2323,7 @@ TEST_F(GeometryStateTest, SetFramePoses) {
     frame_poses.push_back(RigidTransformd::Identity());
   }
 
-  auto make_pose_vector =
-      [&frame_poses, this]() -> FramePoseVector<double> {
+  auto make_pose_vector = [&frame_poses, this]() -> FramePoseVector<double> {
     const int count = static_cast<int>(this->frames_.size());
     FramePoseVector<double> poses;
     for (int i = 0; i < count; ++i) {
@@ -2452,19 +2443,25 @@ TEST_F(GeometryStateTest, TestCollisionCandidates) {
   // The explicit enumeration of candidate pairs. geometries 0 & 1, 2 & 3, and
   // 4 & 5 are siblings, therefore they are not valid candidate pairs. All other
   // combinations _are_.
-  set<pair<GeometryId, GeometryId>> expected_candidates =
-      {{geometries_[0], geometries_[2]}, {geometries_[0], geometries_[3]},
-       {geometries_[0], geometries_[4]}, {geometries_[0], geometries_[5]},
-       {geometries_[0], anchored_geometry_},
-       {geometries_[1], geometries_[2]}, {geometries_[1], geometries_[3]},
-       {geometries_[1], geometries_[4]}, {geometries_[1], geometries_[5]},
-       {geometries_[1], anchored_geometry_},
-       {geometries_[2], geometries_[4]}, {geometries_[2], geometries_[5]},
-       {geometries_[2], anchored_geometry_},
-       {geometries_[3], geometries_[4]}, {geometries_[3], geometries_[5]},
-       {geometries_[3], anchored_geometry_},
-       {geometries_[4], anchored_geometry_},
-       {geometries_[5], anchored_geometry_}};
+  set<pair<GeometryId, GeometryId>> expected_candidates = {
+      {geometries_[0], geometries_[2]},
+      {geometries_[0], geometries_[3]},
+      {geometries_[0], geometries_[4]},
+      {geometries_[0], geometries_[5]},
+      {geometries_[0], anchored_geometry_},
+      {geometries_[1], geometries_[2]},
+      {geometries_[1], geometries_[3]},
+      {geometries_[1], geometries_[4]},
+      {geometries_[1], geometries_[5]},
+      {geometries_[1], anchored_geometry_},
+      {geometries_[2], geometries_[4]},
+      {geometries_[2], geometries_[5]},
+      {geometries_[2], anchored_geometry_},
+      {geometries_[3], geometries_[4]},
+      {geometries_[3], geometries_[5]},
+      {geometries_[3], anchored_geometry_},
+      {geometries_[4], anchored_geometry_},
+      {geometries_[5], anchored_geometry_}};
 
   auto candidates_in_set =
       [](const set<pair<GeometryId, GeometryId>>& candidates,
@@ -2524,8 +2521,8 @@ TEST_F(GeometryStateTest, NonProximityRoleInCollisionFilter) {
   for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
     poses.set_value(frames_[f], X_PFs_[f]);
   }
-  gs_tester_.SetFramePoses(
-      source_id_, poses, &gs_tester_.mutable_kinematics_data());
+  gs_tester_.SetFramePoses(source_id_, poses,
+                           &gs_tester_.mutable_kinematics_data());
   gs_tester_.FinalizePoseUpdate();
 
   // This is *non* const; we'll decrement it as we filter more and more
@@ -2789,8 +2786,8 @@ TEST_F(GeometryStateTest, GeometryNameStorage) {
   {
     const GeometryId id = geometry_state_.RegisterGeometry(
         source_id_, frames_[0],
-        make_unique<GeometryInstance>(
-            RigidTransformd::Identity(), make_unique<Sphere>(1), " " + name));
+        make_unique<GeometryInstance>(RigidTransformd::Identity(),
+                                      make_unique<Sphere>(1), " " + name));
     EXPECT_EQ(geometry_state_.GetName(id), name);
   }
 
@@ -2799,8 +2796,8 @@ TEST_F(GeometryStateTest, GeometryNameStorage) {
   {
     const GeometryId id = geometry_state_.RegisterGeometry(
         source_id_, frames_[1],
-        make_unique<GeometryInstance>(
-            RigidTransformd::Identity(), make_unique<Sphere>(1), name));
+        make_unique<GeometryInstance>(RigidTransformd::Identity(),
+                                      make_unique<Sphere>(1), name));
     EXPECT_EQ(geometry_state_.GetName(id), name);
   }
 }
@@ -2811,10 +2808,10 @@ TEST_F(GeometryStateTest, GeometryAncestryStorage) {
 
   // {child, parent}
   std::map<std::string, std::string> expected_relationships = {
-    {"world", "world"},
-    {"f0", "world"},
-    {"f1", "world"},
-    {"f2", "f1"},
+      {"world", "world"},
+      {"f0", "world"},
+      {"f1", "world"},
+      {"f2", "f1"},
   };
 
   ASSERT_EQ(expected_relationships.size(), geometry_state_.get_num_frames());
@@ -2822,8 +2819,8 @@ TEST_F(GeometryStateTest, GeometryAncestryStorage) {
   for (const FrameId frame_id : geometry_state_.get_frame_ids()) {
     const std::string& frame_name = geometry_state_.GetName(frame_id);
     const FrameId parent_frame_id = geometry_state_.GetParentFrame(frame_id);
-    const std::string& parent_frame_name = geometry_state_.GetName(
-        parent_frame_id);
+    const std::string& parent_frame_name =
+        geometry_state_.GetName(parent_frame_id);
     EXPECT_EQ(parent_frame_name, expected_relationships[frame_name]);
   }
 }
@@ -2833,16 +2830,15 @@ TEST_F(GeometryStateTest, GeometryNameValidation) {
   SetUpSingleSourceTree(Assign::kProximity);
 
   // Case: Invalid frame should throw (regardless of name contents or role).
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.IsValidGeometryName(FrameId::get_new_id(),
-                                          Role::kProximity, ""),
-      "Given frame id is not valid: \\d+");
+  DRAKE_EXPECT_THROWS_MESSAGE(geometry_state_.IsValidGeometryName(
+                                  FrameId::get_new_id(), Role::kProximity, ""),
+                              "Given frame id is not valid: \\d+");
 
   auto expect_bad_name = [this](const string& name,
                                 const string& exception_message,
                                 const string& printable_name) {
-    EXPECT_FALSE(geometry_state_.IsValidGeometryName(frames_[0],
-                                                     Role::kProximity, name))
+    EXPECT_FALSE(
+        geometry_state_.IsValidGeometryName(frames_[0], Role::kProximity, name))
         << "Failed on input name: " << printable_name;
   };
 
@@ -2894,8 +2890,8 @@ TEST_F(GeometryStateTest, GeometryNameValidation) {
   // Update this when the following sdformat issue is resolved:
   // https://bitbucket.org/osrf/sdformat/issues/194/string-trimming-only-considers-space-and
   for (const char* const s : {"\n", " \n\t", " \f", "\v", "\r", "\ntest"}) {
-    EXPECT_TRUE(geometry_state_.IsValidGeometryName(frames_[0],
-                                                    Role::kProximity, s));
+    EXPECT_TRUE(
+        geometry_state_.IsValidGeometryName(frames_[0], Role::kProximity, s));
   }
 }
 
@@ -2972,12 +2968,11 @@ TEST_F(GeometryStateTest, AssignRolesToGeometry) {
     const bool perception = i & 0x4;
     const GeometryId id = geometries_[i];
     EXPECT_TRUE(has_expected_roles(id, false, false, false))
-              << "Geometry " << id << " at index (" << i
-              << ") didn't start without roles";
+        << "Geometry " << id << " at index (" << i
+        << ") didn't start without roles";
     set_roles(id, proximity, perception, illustration);
     EXPECT_TRUE(has_expected_roles(id, proximity, perception, illustration))
-              << "Incorrect roles for geometry " << id << " at index (" << i
-              << ").";
+        << "Incorrect roles for geometry " << id << " at index (" << i << ").";
   }
 
   // Confirm it works on anchored geometry. Pick, arbitrarily, assigning
@@ -3147,8 +3142,8 @@ TEST_F(GeometryStateTest, InstanceRoleAssignment) {
       geometry_state_.RegisterFrame(s_id, GeometryFrame("frame"));
 
   auto make_instance = [this](const string& name) {
-    return make_unique<GeometryInstance>(
-        instance_pose_, make_unique<Sphere>(1.0), name);
+    return make_unique<GeometryInstance>(instance_pose_,
+                                         make_unique<Sphere>(1.0), name);
   };
 
   PerceptionProperties perception_props =
@@ -3340,9 +3335,10 @@ TEST_F(GeometryStateTest, RoleAssignExceptions) {
   // Addition of geometry with duplicate name -- no problem. Assigning it a
   // duplicate role -- bad.
   const GeometryId new_id = geometry_state_.RegisterGeometry(
-      source_id_, frames_[0], make_unique<GeometryInstance>(
-                                  RigidTransformd::Identity(),
-                                  make_unique<Sphere>(1), geometry_names_[0]));
+      source_id_, frames_[0],
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
+                                    make_unique<Sphere>(1),
+                                    geometry_names_[0]));
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.AssignRole(source_id_, new_id, ProximityProperties()),
       "The name .* has already been used by a geometry with the 'proximity' "
@@ -3365,9 +3361,9 @@ TEST_F(GeometryStateTest, ChildGeometryRoleCount) {
   // Defaults to *no* roles being set.
   SetUpSingleSourceTree();
 
-  auto expected_roles = [this](
-      FrameId f_id, int num_proximity, int num_perception,
-      int num_illustration) -> ::testing::AssertionResult {
+  auto expected_roles =
+      [this](FrameId f_id, int num_proximity, int num_perception,
+             int num_illustration) -> ::testing::AssertionResult {
     bool success = true;
     ::testing::AssertionResult failure = ::testing::AssertionFailure();
     vector<pair<Role, int>> roles{{Role::kProximity, num_proximity},
@@ -3456,14 +3452,13 @@ TEST_F(GeometryStateTest, ChildGeometryRoleCount) {
 // Confirms that attempting to remove the "unassigned" role has no effect.
 TEST_F(GeometryStateTest, RemoveUnassignedRole) {
   SetUpSingleSourceTree(Assign::kProximity | Assign::kIllustration |
-      Assign::kPerception);
+                        Assign::kPerception);
 
   EXPECT_EQ(
       geometry_state_.RemoveRole(source_id_, geometries_[0], Role::kUnassigned),
       0);
   EXPECT_EQ(
-      geometry_state_.RemoveRole(source_id_, frames_[0], Role::kUnassigned),
-      0);
+      geometry_state_.RemoveRole(source_id_, frames_[0], Role::kUnassigned), 0);
 
   // Confirm that all geometries still have all roles.
   for (GeometryId id : geometries_) {
@@ -3494,18 +3489,18 @@ TEST_F(GeometryStateTest, RemoveGeometryFromRenderer) {
   // addition,
   //   a) report itself in the "other" render engine, xor
   //   b) be present in the `removed_from_renderer` set.
-  auto confirm_renderers = [this, &other_engine](
-                               set<GeometryId> removed_from_renderer) {
-    set<GeometryId> ids(geometries_.begin(), geometries_.end());
-    ids.insert(anchored_geometry_);
-    for (GeometryId id : ids) {
-      // All should report in the dummy renderer.
-      EXPECT_TRUE(render_engine_->has_geometry(id));
-      // Should report in the renderer if it is *not* in the removed set.
-      EXPECT_EQ(other_engine.has_geometry(id),
-                removed_from_renderer.count(id) == 0);
-    }
-  };
+  auto confirm_renderers =
+      [this, &other_engine](set<GeometryId> removed_from_renderer) {
+        set<GeometryId> ids(geometries_.begin(), geometries_.end());
+        ids.insert(anchored_geometry_);
+        for (GeometryId id : ids) {
+          // All should report in the dummy renderer.
+          EXPECT_TRUE(render_engine_->has_geometry(id));
+          // Should report in the renderer if it is *not* in the removed set.
+          EXPECT_EQ(other_engine.has_geometry(id),
+                    removed_from_renderer.count(id) == 0);
+        }
+      };
   set<GeometryId> removed_ids;
 
   // Confirm geometries assigned to _both_ renderers.
@@ -3570,18 +3565,18 @@ TEST_F(GeometryStateTest, RemoveFrameFromRenderer) {
   // addition,
   //   a) report itself in the "other" render engine, xor
   //   b) be present in the `removed_from_renderer` set.
-  auto confirm_renderers = [this, &other_engine](
-                               set<GeometryId> removed_from_renderer) {
-    set<GeometryId> ids(geometries_.begin(), geometries_.end());
-    ids.insert(anchored_geometry_);
-    for (GeometryId id : ids) {
-      // All should report in the dummy renderer.
-      EXPECT_TRUE(render_engine_->has_geometry(id));
-      // Should report in the renderer if it is *not* in the removed set.
-      EXPECT_EQ(other_engine.has_geometry(id),
-                removed_from_renderer.count(id) == 0);
-    }
-  };
+  auto confirm_renderers =
+      [this, &other_engine](set<GeometryId> removed_from_renderer) {
+        set<GeometryId> ids(geometries_.begin(), geometries_.end());
+        ids.insert(anchored_geometry_);
+        for (GeometryId id : ids) {
+          // All should report in the dummy renderer.
+          EXPECT_TRUE(render_engine_->has_geometry(id));
+          // Should report in the renderer if it is *not* in the removed set.
+          EXPECT_EQ(other_engine.has_geometry(id),
+                    removed_from_renderer.count(id) == 0);
+        }
+      };
   set<GeometryId> removed_ids;
 
   // Confirm geometries assigned to _both_ renderers.
@@ -3853,7 +3848,6 @@ TEST_F(GeometryStateTest, PostHocRenderEngineRespectAcceptingRenderer) {
   geometry_state_.AssignRole(source_id_, geometries_[3],
                              make_properties(kNoStatement));
 
-
   // We should already have a renderer with the name: kDummyRenderName. Add a
   // new renderer.
   auto second_renderer_owned = make_unique<DummyRenderEngine>();
@@ -3899,8 +3893,8 @@ TEST_F(GeometryStateTest, RendererPoseUpdate) {
   for (int f = 0; f < static_cast<int>(frames_.size()); ++f) {
     poses.set_value(frames_[f], X_PFs_[f]);
   }
-  gs_tester_.SetFramePoses(
-      source_id_, poses, &gs_tester_.mutable_kinematics_data());
+  gs_tester_.SetFramePoses(source_id_, poses,
+                           &gs_tester_.mutable_kinematics_data());
   gs_tester_.FinalizePoseUpdate();
 
   // Confirm poses between two GeometryId -> Pose maps.
@@ -3941,8 +3935,8 @@ TEST_F(GeometryStateTest, RendererPoseUpdate) {
   }
   EXPECT_EQ(second_engine->updated_ids().size(), 0u);
   EXPECT_EQ(render_engine_->updated_ids().size(), 0u);
-  gs_tester_.SetFramePoses(
-      source_id_, poses, &gs_tester_.mutable_kinematics_data());
+  gs_tester_.SetFramePoses(source_id_, poses,
+                           &gs_tester_.mutable_kinematics_data());
   gs_tester_.FinalizePoseUpdate();
 
   // Confirm poses.
@@ -4423,9 +4417,9 @@ class RemoveRoleTests : public GeometryStateTestBase,
 };
 
 INSTANTIATE_TEST_SUITE_P(GeometryStateTest, RemoveRoleTests,
-                        ::testing::Values(Role::kProximity,
-                                          Role::kIllustration,
-                                          Role::kPerception));
+                         ::testing::Values(Role::kProximity,
+                                           Role::kIllustration,
+                                           Role::kPerception));
 
 TEST_P(RemoveRoleTests, RemoveRoleFromGeometry) {
   TestRemoveRoleFromGeometry(GetParam());
@@ -4467,8 +4461,7 @@ TEST_F(RemoveRoleTests, RemoveRoleExceptions) {
   const SourceId source_id_2 =
       geometry_state_.RegisterNewSource("second_source");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      geometry_state_.RemoveRole(source_id_2, frames_[0],
-                                 Role::kUnassigned),
+      geometry_state_.RemoveRole(source_id_2, frames_[0], Role::kUnassigned),
       "Referenced .* frame doesn't belong to the source.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.RemoveRole(source_id_2, geometries_[0],
@@ -4582,8 +4575,8 @@ TEST_F(GeometryStateRenderTest, RenderColorImage) {
   // Case: valid render sets the viewport and calls the right API. We don't test
   //  to confirm that the image is passed along, that would be screamingly
   //  apparent.
-  geometry_state_.RenderColorImage(color_camera("engine1"), parent_id_,
-                                    X_PC_, &image);
+  geometry_state_.RenderColorImage(color_camera("engine1"), parent_id_, X_PC_,
+                                   &image);
   EXPECT_TRUE(CompareMatrices(engine1_->last_updated_X_WC().GetAsMatrix4(),
                               X_WS_.GetAsMatrix4(), 1e-15));
   EXPECT_EQ(engine1_->num_color_renders(), 1);
@@ -4592,8 +4585,8 @@ TEST_F(GeometryStateRenderTest, RenderColorImage) {
 
   // Passing another *valid* name doesn't throw (it finds the *other* engine).
   // But passing an invalid name throws.
-  EXPECT_NO_THROW(geometry_state_.RenderColorImage(
-      color_camera("engine2"), parent_id_, X_PC_, &image));
+  EXPECT_NO_THROW(geometry_state_.RenderColorImage(color_camera("engine2"),
+                                                   parent_id_, X_PC_, &image));
   EXPECT_THROW(geometry_state_.RenderColorImage(color_camera("not_an_engine"),
                                                 parent_id_, X_PC_, &image),
                std::exception);

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -27,8 +27,8 @@ then follow the instructions on your console. */
 namespace drake {
 namespace geometry {
 
-using Eigen::Vector3d;
 using common::MaybePauseForUser;
+using Eigen::Vector3d;
 using math::RigidTransformd;
 using math::RotationMatrixd;
 
@@ -124,8 +124,8 @@ int do_main() {
         {0, 0, 0}, {0.5, 0, 0}, {0.5, 0.5, 0}, {0, 0.5, 0.5}};
     std::vector<Vector3d> vertices;
     for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
-    TriangleSurfaceMesh<double> surface_mesh(
-        std::move(faces), std::move(vertices));
+    TriangleSurfaceMesh<double> surface_mesh(std::move(faces),
+                                             std::move(vertices));
     meshcat->SetObject("triangle_mesh", surface_mesh, Rgba(0.9, 0, 0.9, 1.0));
     meshcat->SetTransform("triangle_mesh",
                           RigidTransformd(Vector3d{++x, -0.25, 0}));
@@ -235,20 +235,19 @@ int do_main() {
   MeshcatAnimation animation;
   std::cout << "- the red sphere should move up and down in z.\n";
   animation.SetTransform(0, "sphere", RigidTransformd(sphere_home));
-  animation.SetTransform(20, "sphere", RigidTransformd(sphere_home +
-                                                       Vector3d::UnitZ()));
+  animation.SetTransform(20, "sphere",
+                         RigidTransformd(sphere_home + Vector3d::UnitZ()));
   animation.SetTransform(40, "sphere", RigidTransformd(sphere_home));
 
   std::cout << "- the blue box should spin clockwise about the +z axis.\n";
-  animation.SetTransform(0, "box",
-                         RigidTransformd(RotationMatrixd::MakeZRotation(0),
-                                         box_home));
-  animation.SetTransform(20, "box",
-                         RigidTransformd(RotationMatrixd::MakeZRotation(M_PI),
-                                         box_home));
   animation.SetTransform(
-      40, "box", RigidTransformd(RotationMatrixd::MakeZRotation(2 * M_PI),
-                                 box_home));
+      0, "box", RigidTransformd(RotationMatrixd::MakeZRotation(0), box_home));
+  animation.SetTransform(
+      20, "box",
+      RigidTransformd(RotationMatrixd::MakeZRotation(M_PI), box_home));
+  animation.SetTransform(
+      40, "box",
+      RigidTransformd(RotationMatrixd::MakeZRotation(2 * M_PI), box_home));
   animation.set_repetitions(4);
 
   std::cout << "- the green cylinder should appear and disappear.\n";
@@ -269,8 +268,8 @@ int do_main() {
   std::cout << "You can review/replay the animation from the controls menu.\n";
   MaybePauseForUser();
 
-  meshcat->Set2dRenderMode(math::RigidTransform(Vector3d{0, -3, 0}), -4,
-                           4, -2, 2);
+  meshcat->Set2dRenderMode(math::RigidTransform(Vector3d{0, -3, 0}), -4, 4, -2,
+                           2);
 
   std::cout << "- The scene should have switched to 2D rendering mode.\n";
   MaybePauseForUser();
@@ -440,9 +439,8 @@ int do_main() {
     MaybePauseForUser();
   }
 
-  std::cout
-      << "Now we'll add back an environment map and move the camera, in\n"
-         "preparation for testing the standalone HTML download ...\n\n";
+  std::cout << "Now we'll add back an environment map and move the camera, in\n"
+               "preparation for testing the standalone HTML download ...\n\n";
 
   meshcat->SetEnvironmentMap(
       FindResourceOrThrow("drake/geometry/test/env_256_cornell_box.png"));
@@ -489,7 +487,8 @@ int do_main() {
             << "Got " << meshcat->GetButtonClicks("Press t Key")
             << " clicks on \"Press t Key\".\n"
             << "Got " << meshcat->GetSliderValue("SliderTest")
-            << " value for SliderTest.\n\n" << std::endl;
+            << " value for SliderTest.\n\n"
+            << std::endl;
 
   std::cout << "Next, we'll test gamepad (i.e., joystick) features.\n\n";
   std::cout
@@ -580,4 +579,6 @@ int do_main() {
 }  // namespace geometry
 }  // namespace drake
 
-int main() { return drake::geometry::do_main(); }
+int main() {
+  return drake::geometry::do_main();
+}

--- a/geometry/test/meshcat_point_cloud_visualizer_test.cc
+++ b/geometry/test/meshcat_point_cloud_visualizer_test.cc
@@ -33,14 +33,16 @@ class MeshcatPointCloudVisualizerTest : public ::testing::Test {
       40, 50, 60;
     // clang-format on
 
-    auto cloud_system = builder.template AddSystem<
-      systems::ConstantValueSource>(Value<perception::PointCloud>(cloud));
+    auto cloud_system =
+        builder.template AddSystem<systems::ConstantValueSource>(
+            Value<perception::PointCloud>(cloud));
     builder.Connect(cloud_system->get_output_port(),
                     visualizer_->cloud_input_port());
 
     if (connect_pose) {
-      auto pose_system = builder.template AddSystem<
-        systems::ConstantValueSource>(Value<math::RigidTransformd>());
+      auto pose_system =
+          builder.template AddSystem<systems::ConstantValueSource>(
+              Value<math::RigidTransformd>());
       builder.Connect(pose_system->get_output_port(),
                       visualizer_->pose_input_port());
     }
@@ -54,7 +56,6 @@ class MeshcatPointCloudVisualizerTest : public ::testing::Test {
   std::unique_ptr<systems::Diagram<double>> diagram_{};
   std::unique_ptr<systems::Context<double>> context_{};
 };
-
 
 TEST_F(MeshcatPointCloudVisualizerTest, Publish) {
   SetUpDiagram();
@@ -78,7 +79,7 @@ TEST_F(MeshcatPointCloudVisualizerTest, NoPose) {
 }
 
 TEST_F(MeshcatPointCloudVisualizerTest, PublishPeriod) {
-  const double kPeriod = 1/12.0;
+  const double kPeriod = 1 / 12.0;
   SetUpDiagram(true, kPeriod);
 
   auto periodic_events_map = visualizer_->MapPeriodicEventsByTiming();

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -45,15 +45,14 @@ int SystemCall(const std::vector<std::string>& argv) {
 // @param expect_json Expected content of the final message, as a json string.
 // @param expect_success Whether to insist that the python helper finished and
 //     the expected_json (if given) was actually received.
-void CheckWebsocketCommand(
-    const Meshcat& meshcat,
-    std::optional<std::string> send_json,
-    std::optional<int> expect_num_messages,
-    std::optional<std::string> expect_json,
-    bool expect_success = true) {
+void CheckWebsocketCommand(const Meshcat& meshcat,
+                           std::optional<std::string> send_json,
+                           std::optional<int> expect_num_messages,
+                           std::optional<std::string> expect_json,
+                           bool expect_success = true) {
   std::vector<std::string> argv;
-  argv.push_back(FindResourceOrThrow(
-      "drake/geometry/meshcat_websocket_client"));
+  argv.push_back(
+      FindResourceOrThrow("drake/geometry/meshcat_websocket_client"));
   // Even when this unit test is itself running under valgrind, we don't want to
   // instrument the helper process. Our valgrind configuration recognizes this
   // argument and skips instrumentation of the child process.
@@ -64,15 +63,15 @@ void CheckWebsocketCommand(
     argv.push_back(fmt::format("--send_message={}", std::move(*send_json)));
   }
   if (expect_num_messages) {
-    argv.push_back(fmt::format("--expect_num_messages={}",
-        *expect_num_messages));
+    argv.push_back(
+        fmt::format("--expect_num_messages={}", *expect_num_messages));
   }
   if (expect_json) {
     DRAKE_DEMAND(!expect_json->empty());
     argv.push_back(fmt::format("--expect_message={}", std::move(*expect_json)));
   }
-  argv.push_back(fmt::format("--expect_success={}",
-      expect_success ? "1" : "0"));
+  argv.push_back(
+      fmt::format("--expect_success={}", expect_success ? "1" : "0"));
   const int exit_code = SystemCall(argv);
   if (expect_success) {
     EXPECT_EQ(exit_code, 0);
@@ -146,7 +145,8 @@ GTEST_TEST(MeshcatTest, EphemeralPort) {
   CheckWebsocketCommand(meshcat, R"""({
       "type": "button",
       "name": "button"
-    })""", {}, {});
+    })""",
+                        {}, {});
   EXPECT_EQ(meshcat.GetButtonClicks("button"), 1);
 }
 
@@ -211,9 +211,8 @@ GTEST_TEST(MeshcatTest, MalformedCustom) {
       Meshcat({"", std::nullopt, "http://localhost:{portnum}"}),
       ".*argument.*");
   // Only http or https are allowed.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Meshcat({"", std::nullopt, "file:///tmp"}),
-      ".*web_url_pattern.*http.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(Meshcat({"", std::nullopt, "file:///tmp"}),
+                              ".*web_url_pattern.*http.*");
 }
 
 // Checks that unparsable messages are ignored.
@@ -294,7 +293,7 @@ TEST_P(MeshcatFaultTest, WorkerThreadFault) {
 }
 
 INSTANTIATE_TEST_SUITE_P(AllFaults, MeshcatFaultTest,
-    testing::Range(0, Meshcat::kMaxFaultNumber + 1));
+                         testing::Range(0, Meshcat::kMaxFaultNumber + 1));
 
 GTEST_TEST(MeshcatTest, NumActive) {
   Meshcat meshcat;
@@ -321,19 +320,19 @@ GTEST_TEST(MeshcatTest, SetObjectWithShape) {
   meshcat.SetObject("capsule", Capsule(0.25, 0.5));
   EXPECT_FALSE(meshcat.GetPackedObject("capsule").empty());
   meshcat.SetObject(
-      "mesh", Mesh(FindResourceOrThrow(
-                       "drake/geometry/render/test/meshes/box.obj"),
-                   0.25));
+      "mesh",
+      Mesh(FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj"),
+           0.25));
   EXPECT_FALSE(meshcat.GetPackedObject("mesh").empty());
   meshcat.SetObject(
-      "gltf", Mesh(FindResourceOrThrow(
-                       "drake/geometry/render/test/meshes/cube.gltf"),
-                   0.25));
+      "gltf",
+      Mesh(FindResourceOrThrow("drake/geometry/render/test/meshes/cube.gltf"),
+           0.25));
   EXPECT_FALSE(meshcat.GetPackedObject("gltf").empty());
   meshcat.SetObject(
-      "convex", Convex(FindResourceOrThrow(
-                           "drake/geometry/render/test/meshes/box.obj"),
-                       0.25));
+      "convex",
+      Convex(FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj"),
+             0.25));
   EXPECT_FALSE(meshcat.GetPackedObject("convex").empty());
   // Bad filename (no extension).  Should only log a warning.
   meshcat.SetObject("bad", Mesh("test"));
@@ -383,8 +382,8 @@ GTEST_TEST(MeshcatTest, SetObjectWithTriangleSurfaceMesh) {
       {0, 0, 0}, {0.5, 0, 0}, {0.5, 0.5, 0}, {0, 0.5, 0.5}};
   std::vector<Eigen::Vector3d> vertices;
   for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
-  TriangleSurfaceMesh<double> surface_mesh(
-      std::move(faces), std::move(vertices));
+  TriangleSurfaceMesh<double> surface_mesh(std::move(faces),
+                                           std::move(vertices));
   meshcat.SetObject("triangle_mesh", surface_mesh, Rgba(0.9, 0, 0.9, 1.0));
   EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh").empty());
 
@@ -397,12 +396,10 @@ GTEST_TEST(MeshcatTest, PlotSurface) {
   Meshcat meshcat;
 
   constexpr int nx = 15, ny = 11;
-  Eigen::MatrixXd X =
-      RowVector<double, nx>::LinSpaced(0, 1).replicate<ny, 1>();
-  Eigen::MatrixXd Y =
-      Vector<double, ny>::LinSpaced(0, 1).replicate<1, nx>();
+  Eigen::MatrixXd X = RowVector<double, nx>::LinSpaced(0, 1).replicate<ny, 1>();
+  Eigen::MatrixXd Y = Vector<double, ny>::LinSpaced(0, 1).replicate<1, nx>();
   // z = y*sin(5*x)
-  Eigen::MatrixXd Z = (Y.array() * (5*X.array()).sin()).matrix();
+  Eigen::MatrixXd Z = (Y.array() * (5 * X.array()).sin()).matrix();
 
   // Wireframe = false.
   meshcat.PlotSurface("plot_surface", X, Y, Z, Rgba(0, 0, 0.9, 1.0), false);
@@ -457,7 +454,7 @@ GTEST_TEST(MeshcatTest, SetTriangleMesh) {
   // clang-format on
 
   meshcat.SetTriangleMesh("triangle_mesh", vertices.transpose(),
-                         faces.transpose(), Rgba(1, 0, 0, 1), true, 5.0);
+                          faces.transpose(), Rgba(1, 0, 0, 1), true, 5.0);
   EXPECT_FALSE(meshcat.GetPackedObject("triangle_mesh").empty());
 }
 
@@ -663,9 +660,8 @@ GTEST_TEST(MeshcatTest, Buttons) {
   Meshcat meshcat;
 
   // Asking for clicks prior to adding is an error.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.GetButtonClicks("alice"),
-      "Meshcat does not have any button named alice.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.GetButtonClicks("alice"),
+                              "Meshcat does not have any button named alice.*");
 
   // A new button starts out unclicked.
   meshcat.AddButton("alice");
@@ -694,14 +690,12 @@ GTEST_TEST(MeshcatTest, Buttons) {
 
   // Removing the button then asking for clicks is an error.
   meshcat.DeleteButton("alice");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.GetButtonClicks("alice"),
-      "Meshcat does not have any button named alice.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.GetButtonClicks("alice"),
+                              "Meshcat does not have any button named alice.*");
 
   // Removing a non-existent button is an error.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.DeleteButton("alice"),
-      "Meshcat does not have any button named alice.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.DeleteButton("alice"),
+                              "Meshcat does not have any button named alice.*");
 
   // Adding the button anew starts with a zero count again.
   meshcat.AddButton("alice");
@@ -710,12 +704,10 @@ GTEST_TEST(MeshcatTest, Buttons) {
   // Buttons are removed when deleting all controls.
   meshcat.AddButton("bob");
   meshcat.DeleteAddedControls();
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.GetButtonClicks("alice"),
-      "Meshcat does not have any button named alice.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.GetButtonClicks("bob"),
-      "Meshcat does not have any button named bob.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.GetButtonClicks("alice"),
+                              "Meshcat does not have any button named alice.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.GetButtonClicks("bob"),
+                              "Meshcat does not have any button named bob.*");
 
   // Adding a button with the keycode.
   meshcat.AddButton("alice", "KeyT");
@@ -725,13 +717,11 @@ GTEST_TEST(MeshcatTest, Buttons) {
   meshcat.AddButton("alice", "KeyT");
   EXPECT_EQ(meshcat.GetButtonClicks("alice"), 0);
   // Adding the same button with an empty keycode throws.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.AddButton("alice"),
-      ".*does not match the current keycode.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.AddButton("alice"),
+                              ".*does not match the current keycode.*");
   // Adding the same button with a different keycode throws.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.AddButton("alice", "KeyR"),
-      ".*does not match the current keycode.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.AddButton("alice", "KeyR"),
+                              ".*does not match the current keycode.*");
   meshcat.DeleteButton("alice");
 
   // Adding a button with the keycode empty, then populated works.
@@ -756,9 +746,8 @@ GTEST_TEST(MeshcatTest, Sliders) {
   EXPECT_NEAR(meshcat.GetSliderValue("slider"), 1.5, 1e-14);
   meshcat.SetSliderValue("slider", 1.245);
   EXPECT_NEAR(meshcat.GetSliderValue("slider"), 1.2, 1e-14);
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.AddSlider("slider", 0.2, 1.5, 0.1, 0.5),
-      "Meshcat already has a slider named slider.");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.AddSlider("slider", 0.2, 1.5, 0.1, 0.5),
+                              "Meshcat already has a slider named slider.");
 
   meshcat.DeleteSlider("slider");
 
@@ -792,15 +781,12 @@ GTEST_TEST(MeshcatTest, DuplicateMixedControls) {
 
   // We cannot use AddButton nor AddSlider to change the type of an existing
   // control by attempting to re-use its name.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.AddButton("slider"),
-      "Meshcat already has a slider named slider.");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.AddButton("slider", "KeyR"),
-      "Meshcat already has a slider named slider.");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      meshcat.AddSlider("button", 0.2, 1.5, 0.1, 0.5),
-      "Meshcat already has a button named button.");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.AddButton("slider"),
+                              "Meshcat already has a slider named slider.");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.AddButton("slider", "KeyR"),
+                              "Meshcat already has a slider named slider.");
+  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.AddSlider("button", 0.2, 1.5, 0.1, 0.5),
+                              "Meshcat already has a button named button.");
 }
 
 // Properly testing Meshcat's limited support for gamepads requires human
@@ -824,7 +810,8 @@ GTEST_TEST(MeshcatTest, Gamepad) {
         "button_values": [0, 0.5],
         "axes": [0.1, 0.2, 0.3, 0.4]
       }
-    })""", {}, {});
+    })""",
+                        {}, {});
 
   gamepad = meshcat.GetGamepad();
   EXPECT_TRUE(gamepad.index);
@@ -1074,9 +1061,8 @@ GTEST_TEST(MeshcatTest, Recording) {
       animation->get_key_frame<bool>(kFrame, "bool_property", "visible")
           .has_value());
   meshcat.SetProperty("bool_property", "visible", false, kTime);
-  EXPECT_TRUE(
-      animation->get_key_frame<bool>(kFrame, "bool_property", "visible")
-          .has_value());
+  EXPECT_TRUE(animation->get_key_frame<bool>(kFrame, "bool_property", "visible")
+                  .has_value());
 
   EXPECT_FALSE(
       animation
@@ -1143,8 +1129,7 @@ GTEST_TEST(MeshcatTest, Set2dRenderMode) {
   meshcat.Set2dRenderMode();
   // We simply confirm that all of the objects have been set, and use
   // meshcat_manual_test to check that the visualizer updates as we expect.
-  EXPECT_FALSE(
-      meshcat.GetPackedObject("/Cameras/default/rotated").empty());
+  EXPECT_FALSE(meshcat.GetPackedObject("/Cameras/default/rotated").empty());
   EXPECT_FALSE(meshcat.GetPackedTransform("/Cameras/default").empty());
   EXPECT_FALSE(
       meshcat.GetPackedProperty("/Cameras/default/rotated/<object>", "position")
@@ -1159,8 +1144,7 @@ GTEST_TEST(MeshcatTest, ResetRenderMode) {
   meshcat.ResetRenderMode();
   // We simply confirm that all of the objects have been set, and use
   // meshcat_manual_test to check that the visualizer updates as we expect.
-  EXPECT_FALSE(
-      meshcat.GetPackedObject("/Cameras/default/rotated").empty());
+  EXPECT_FALSE(meshcat.GetPackedObject("/Cameras/default/rotated").empty());
   EXPECT_FALSE(meshcat.GetPackedTransform("/Cameras/default").empty());
   EXPECT_FALSE(
       meshcat.GetPackedProperty("/Cameras/default/rotated/<object>", "position")
@@ -1234,10 +1218,12 @@ GTEST_TEST(MeshcatTest, CameraTracking) {
   // A message with a valid transform (16 floats and is perspective is True).
   internal::UserInterfaceEvent valid_pose_message;
   valid_pose_message.type = "camera_pose";
+  // clang-format off
   valid_pose_message.camera_pose = {1, 0, 0, 0,
                                     0, 1, 0, 0,
                                     0, 0, 1, 0,
                                     1, 2, 3, 1};
+  // clang-format on
   valid_pose_message.is_perspective = true;
 
   // Transform y-up to z-up, and from facing in the +z direction to the -z
@@ -1276,7 +1262,8 @@ GTEST_TEST(MeshcatTest, CameraTrackingDisconnect) {
         0, 0, 0, 0
       ],
       "is_perspective": true
-    })""", {}, {});
+    })""",
+                        {}, {});
   EXPECT_FALSE(meshcat.GetTrackedCameraPose().has_value());
 }
 

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -67,8 +67,7 @@ class MeshcatVisualizerWithIiwaTest : public ::testing::Test {
 
   void CheckVisible(const std::string& path, bool visibility) {
     ASSERT_TRUE(meshcat_->HasPath(path));
-    const std::string property =
-        meshcat_->GetPackedProperty(path, "visible");
+    const std::string property = meshcat_->GetPackedProperty(path, "visible");
     ASSERT_GT(property.size(), 0);
     msgpack::object_handle oh =
         msgpack::unpack(property.data(), property.size());
@@ -146,8 +145,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Roles) {
   }
 
   params.role = Role::kUnassigned;
-  DRAKE_EXPECT_THROWS_MESSAGE(SetUpDiagram(params),
-                              ".*Role::kUnassigned.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(SetUpDiagram(params), ".*Role::kUnassigned.*");
 }
 
 // Tests that adding multiple MeshcatVisualizers using the same role to a
@@ -201,7 +199,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
   SetUpDiagram(params);
   // Scribble a transform onto the scene tree beneath the visualizer prefix.
   meshcat_->SetTransform("/drake/visualizer/my_random_path",
-                        math::RigidTransformd());
+                         math::RigidTransformd());
   EXPECT_TRUE(meshcat_->HasPath("/drake/visualizer/my_random_path"));
 
   {  // Send an initialization event.
@@ -218,7 +216,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
   params.delete_on_initialization_event = false;
   SetUpDiagram(params);
   meshcat_->SetTransform("/drake/visualizer/my_random_path",
-                        math::RigidTransformd());
+                         math::RigidTransformd());
   {  // Send an initialization event.
     auto events = diagram_->AllocateCompositeEventCollection();
     diagram_->GetInitializationEvents(*context_, events.get());
@@ -243,8 +241,8 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Delete) {
 // "position".
 bool has_iiwa_frame(const MeshcatAnimation& animation, int frame) {
   return animation
-      .get_key_frame<std::vector<double>>(
-          0, "visualizer/iiwa14/iiwa_link_1", "position")
+      .get_key_frame<std::vector<double>>(0, "visualizer/iiwa14/iiwa_link_1",
+                                          "position")
       .has_value();
 }
 

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -15,9 +15,9 @@ using internal::kComplianceType;
 using internal::kElastic;
 using internal::kFriction;
 using internal::kHcDissipation;
-using internal::kPointStiffness;
 using internal::kHydroGroup;
 using internal::kMaterialGroup;
+using internal::kPointStiffness;
 using internal::kRezHint;
 using internal::kSlabThickness;
 using CoulombFrictiond = multibody::CoulombFriction<double>;
@@ -142,11 +142,11 @@ GTEST_TEST(ProximityPropertiesTest, AddCompliantProperties) {
     EXPECT_EQ(props.GetProperty<double>(kHydroGroup, kElastic), E);
   }
 
-  CheckDisallowedModulusValues(
-      "AddCompliantHydroelasticProperties",
-      [](double modulus, ProximityProperties* p) {
-        AddCompliantHydroelasticProperties(1., modulus, p);
-      });
+  CheckDisallowedModulusValues("AddCompliantHydroelasticProperties",
+                               [](double modulus, ProximityProperties* p) {
+                                 AddCompliantHydroelasticProperties(1., modulus,
+                                                                    p);
+                               });
 }
 
 // Tests the variant where the static pressure field is defined by the
@@ -165,11 +165,11 @@ GTEST_TEST(ProximityPropertiesTest, AddHalfSpaceSoftProperties) {
               HydroelasticType::kSoft);
   }
 
-  CheckDisallowedModulusValues(
-      "AddCompliantHydroelasticPropertiesForHalfSpace",
-      [](double modulus, ProximityProperties* p) {
-        AddCompliantHydroelasticPropertiesForHalfSpace(1., modulus, p);
-      });
+  CheckDisallowedModulusValues("AddCompliantHydroelasticPropertiesForHalfSpace",
+                               [](double modulus, ProximityProperties* p) {
+                                 AddCompliantHydroelasticPropertiesForHalfSpace(
+                                     1., modulus, p);
+                               });
 }
 
 }  // namespace

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -153,8 +153,8 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   EXPECT_TRUE(is_default(default_object));
 
 #define EXPECT_DEFAULT_ERROR(expression) \
-  DRAKE_EXPECT_THROWS_MESSAGE(expression, \
-      "Attempting to perform query on invalid QueryObject.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(           \
+      expression, "Attempting to perform query on invalid QueryObject.+");
 
   EXPECT_DEFAULT_ERROR(ThrowIfNotCallable(default_object));
 
@@ -221,8 +221,9 @@ TEST_F(QueryObjectTest, CreateValidInspector) {
   FrameId frame_id =
       scene_graph_.RegisterFrame(source_id, GeometryFrame("frame"));
   GeometryId geometry_id = scene_graph_.RegisterGeometry(
-      source_id, frame_id, make_unique<GeometryInstance>(
-                               identity, make_unique<Sphere>(1.0), "sphere"));
+      source_id, frame_id,
+      make_unique<GeometryInstance>(identity, make_unique<Sphere>(1.0),
+                                    "sphere"));
   unique_ptr<Context<double>> context = scene_graph_.CreateDefaultContext();
   unique_ptr<QueryObject<double>> query_object =
       MakeQueryObject(context.get(), &scene_graph_);

--- a/geometry/test/rgba_test.cc
+++ b/geometry/test/rgba_test.cc
@@ -65,15 +65,12 @@ GTEST_TEST(RgbaTest, Errors) {
   auto expect_error = [original](double ri, double gi, double bi, double ai) {
     const std::string expected_message = fmt::format(
         "Rgba values must be within the range \\[0, 1\\]. Values provided: "
-        "\\(r={}, g={}, b={}, a={}\\)", ri, gi, bi, ai);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        Rgba(ri, gi, bi, ai),
-        expected_message);
+        "\\(r={}, g={}, b={}, a={}\\)",
+        ri, gi, bi, ai);
+    DRAKE_EXPECT_THROWS_MESSAGE(Rgba(ri, gi, bi, ai), expected_message);
     // Check for transaction integrity.
     Rgba color = original;
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        color.set(ri, gi, bi, ai),
-        expected_message);
+    DRAKE_EXPECT_THROWS_MESSAGE(color.set(ri, gi, bi, ai), expected_message);
     EXPECT_EQ(color, original);
   };
 

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -77,11 +77,10 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.NumGeometriesForFrameWithRole(frame_id, Role::kUnassigned);
   inspector.GetGeometries(frame_id, Role::kUnassigned);
   // Register a geometry to prevent an exception being thrown.
-  const GeometryId geometry_id =
-      tester.mutable_state().RegisterGeometry(
-          source_id, frame_id,
-          make_unique<GeometryInstance>(RigidTransformd::Identity(),
-                                        make_unique<Sphere>(1.0), "sphere"));
+  const GeometryId geometry_id = tester.mutable_state().RegisterGeometry(
+      source_id, frame_id,
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
+                                    make_unique<Sphere>(1.0), "sphere"));
   inspector.GetGeometryIdByName(frame_id, Role::kUnassigned, "sphere");
 
   // Geometries and their properties.
@@ -100,11 +99,10 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.GetReferenceMesh(geometry_id);
   // Register an *additional* geometry and assign proximity properties to both
   // to prevent an exception being thrown.
-  const GeometryId geometry_id2 =
-      tester.mutable_state().RegisterGeometry(
-          source_id, frame_id,
-          make_unique<GeometryInstance>(RigidTransformd::Identity(),
-                                        make_unique<Sphere>(1.0), "sphere2"));
+  const GeometryId geometry_id2 = tester.mutable_state().RegisterGeometry(
+      source_id, frame_id,
+      make_unique<GeometryInstance>(RigidTransformd::Identity(),
+                                    make_unique<Sphere>(1.0), "sphere2"));
   tester.mutable_state().AssignRole(source_id, geometry_id,
                                     ProximityProperties());
   tester.mutable_state().AssignRole(source_id, geometry_id2,
@@ -128,8 +126,8 @@ GTEST_TEST(SceneGraphInspector, CloneGeometryInstance) {
       tester.mutable_state().RegisterFrame(source_id, GeometryFrame("frame"));
 
   // Geometry with no properties; confirm the other properties.
-  const GeometryInstance original(RigidTransformd(
-      Eigen::Vector3d(1, 2, 3)), Sphere(1.5), "test_sphere");
+  const GeometryInstance original(RigidTransformd(Eigen::Vector3d(1, 2, 3)),
+                                  Sphere(1.5), "test_sphere");
   const GeometryId geometry_id = tester.mutable_state().RegisterGeometry(
       source_id, frame_id, make_unique<GeometryInstance>(original));
 

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -100,8 +100,7 @@ class SceneGraphTester {
 namespace {
 
 // Convenience function for making a geometry instance.
-std::unique_ptr<GeometryInstance> make_sphere_instance(
-    double radius = 1.0) {
+std::unique_ptr<GeometryInstance> make_sphere_instance(double radius = 1.0) {
   return make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                        make_unique<Sphere>(radius), "sphere");
 }
@@ -226,8 +225,8 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
   FrameId old_frame_id =
       scene_graph_.RegisterFrame(id, GeometryFrame("old_frame"));
   // This geometry will be removed after allocation.
-  GeometryId old_geometry_id = scene_graph_.RegisterGeometry(id, old_frame_id,
-      make_sphere_instance());
+  GeometryId old_geometry_id =
+      scene_graph_.RegisterGeometry(id, old_frame_id, make_sphere_instance());
 
   CreateDefaultContext();
 
@@ -272,8 +271,7 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
 TEST_F(SceneGraphTest, DirectFeedThrough) {
   scene_graph_.RegisterSource();
   EXPECT_EQ(scene_graph_.GetDirectFeedthroughs().size(),
-            scene_graph_.num_input_ports() *
-                scene_graph_.num_output_ports());
+            scene_graph_.num_input_ports() * scene_graph_.num_output_ports());
 }
 
 // Test the functionality that accumulates the values from the input ports.
@@ -396,8 +394,8 @@ TYPED_TEST_P(TypedSceneGraphTest, TransmogrifyContext) {
   using U = TypeParam;
   SourceId s_id = this->scene_graph_.RegisterSource();
   // Register geometry that should be successfully transmogrified.
-  GeometryId g_id = this->scene_graph_.RegisterAnchoredGeometry(
-      s_id, make_sphere_instance());
+  GeometryId g_id =
+      this->scene_graph_.RegisterAnchoredGeometry(s_id, make_sphere_instance());
   this->CreateDefaultContext();
   const Context<double>& context_T = *this->context_;
   // This should transmogrify the internal *model*, so when I allocate the
@@ -432,11 +430,11 @@ TYPED_TEST_P(TypedSceneGraphTest, NonDoubleClone) {
   ASSERT_NE(copy, nullptr);
 }
 
-REGISTER_TYPED_TEST_SUITE_P(TypedSceneGraphTest,
-    TransmogrifyWithoutAllocation,
-    TransmogrifyPorts,
-    TransmogrifyContext,
-    NonDoubleClone);
+REGISTER_TYPED_TEST_SUITE_P(TypedSceneGraphTest,            //
+                            TransmogrifyWithoutAllocation,  //
+                            TransmogrifyPorts,              //
+                            TransmogrifyContext,            //
+                            NonDoubleClone);
 
 using NonDoubleScalarTypes = ::testing::Types<AutoDiffXd, Expression>;
 INSTANTIATE_TYPED_TEST_SUITE_P(My, TypedSceneGraphTest, NonDoubleScalarTypes);
@@ -703,8 +701,8 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
       const VolumeMesh<double>* mesh_ptr =
           inspector.GetReferenceMesh(deformable_id);
       DRAKE_DEMAND(mesh_ptr != nullptr);
-      configurations_.set_value(deformable_id,
-          VectorX<double>::Zero(mesh_ptr->num_vertices() * 3));
+      configurations_.set_value(
+          deformable_id, VectorX<double>::Zero(mesh_ptr->num_vertices() * 3));
     }
 
     // Set up output pose port now that the frame is registered.
@@ -785,11 +783,11 @@ GTEST_TEST(SceneGraphConnectionTest, FullPositionUpdateConnected) {
   systems::DiagramBuilder<double> builder;
   auto scene_graph = builder.AddSystem<SceneGraph<double>>();
   scene_graph->set_name("scene_graph");
-  auto mixed_source = builder.AddSystem<GeometrySourceSystem>(
-      scene_graph, true);
+  auto mixed_source =
+      builder.AddSystem<GeometrySourceSystem>(scene_graph, true);
   mixed_source->set_name("mixed source");
-  auto nondeformable_source = builder.AddSystem<GeometrySourceSystem>(
-      scene_graph, false);
+  auto nondeformable_source =
+      builder.AddSystem<GeometrySourceSystem>(scene_graph, false);
   nondeformable_source->set_name("nondeformable_only_source");
   SourceId mixed_source_id = mixed_source->get_source_id();
   SourceId nondeformable_source_id = nondeformable_source->get_source_id();
@@ -873,7 +871,6 @@ GTEST_TEST(SceneGraphExpressionTest, InstantiateExpression) {
       QueryObjectTest::MakeNullQueryObject<Expression>();
   SceneGraphTester::GetQueryObjectPortValue(scene_graph, *context, &handle);
 }
-
 
 // Tests that exercise the Context-modifying API
 

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -530,8 +530,7 @@ GTEST_TEST(ShapeTest, NumericalValidation) {
   DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(Vector3<double>{1, 1, 0}),
                               "MeshcatCone parameters .+ should all be > 0.*");
 
-  DRAKE_EXPECT_THROWS_MESSAGE(Sphere(-0.5),
-                              "Sphere radius should be >= 0.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(Sphere(-0.5), "Sphere radius should be >= 0.+");
   DRAKE_EXPECT_NO_THROW(Sphere(0));  // Special case for 0 radius.
 }
 
@@ -547,9 +546,9 @@ TEST_F(DefaultReifierTest, UnsupportedGeometry) {
                               "This class (.+) does not support Convex.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Cylinder(1, 2), nullptr),
                               "This class (.+) does not support Cylinder.");
-  DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Ellipsoid(1, 1, 1),
-                              nullptr),
-                              "This class (.+) does not support Ellipsoid.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      this->ImplementGeometry(Ellipsoid(1, 1, 1), nullptr),
+      "This class (.+) does not support Ellipsoid.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(HalfSpace(), nullptr),
                               "This class (.+) does not support HalfSpace.");
   DRAKE_EXPECT_THROWS_MESSAGE(this->ImplementGeometry(Mesh("foo", 1), nullptr),

--- a/geometry/test/utilities_test.cc
+++ b/geometry/test/utilities_test.cc
@@ -31,8 +31,8 @@ GTEST_TEST(GeometryUtilities, CanonicalizeGeometryName) {
 
   // Test various names -- including names with internal whitespace.
   for (const std::string& canonical : std::initializer_list<std::string>{
-        "name", "with space", "with\ttab", "with\nnewline",
-        "with\vvertical tab", "with\fformfeed"}) {
+           "name", "with space", "with\ttab", "with\nnewline",
+           "with\vvertical tab", "with\fformfeed"}) {
     // Confirms that the given name canonicalizes to the given canonical name.
     auto expect_canonical = [&canonical](const std::string& name) {
       const std::string canonicalized = CanonicalizeStringName(name);

--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -86,8 +86,7 @@ inline const Vector3<double>& convert_to_double(const Vector3<double>& vec) {
 }
 
 template <class T>
-Vector3<double> convert_to_double(
-    const Vector3<T>& vec) {
+Vector3<double> convert_to_double(const Vector3<T>& vec) {
   Vector3<double> result;
   for (int r = 0; r < 3; ++r) {
     result(r) = ExtractDoubleOrThrow(vec(r));
@@ -119,7 +118,6 @@ inline math::RigidTransformd convert_to_double(
   return math::RigidTransform<double>(
       ExtractDoubleOrThrow(X_AB.GetAsMatrix34()));
 }
-
 
 //@}
 


### PR DESCRIPTION
For clarity -- this only changes the `//geometry:all` root package code; the code in subdirectories like "proximity" is unchanged.

However, we don't enable the clang-format linter yet because a few places (e.g., documentation) can't survive it.

Towards #4843.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20768)
<!-- Reviewable:end -->
