### PR TITLE
[multibody/parsing] Improve error handling of AddFrame

### DIFF
--- a/multibody/parsing/model_directives.h
+++ b/multibody/parsing/model_directives.h
@@ -144,6 +144,11 @@ struct AddFrame {
     } else if (!X_PF.base_frame || X_PF.base_frame->empty()) {
       drake::log()->error("add_frame: `X_PF.base_frame` must be defined");
       return false;
+    } else if (!X_PF.IsDeterministic()) {
+      drake::log()->error(
+          "add_frame: `X_PF` must specify a deterministic transform, not a "
+          "distribution.");
+      return false;
     }
     return true;
   }

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -216,6 +216,24 @@ GTEST_TEST(ProcessModelDirectivesTest, AddFrameWithoutScope) {
       plant.HasFrameNamed("included_as_base_frame", simple_model_instance));
 }
 
+// Tests for rejection of non-deterministic frames.
+GTEST_TEST(ProcessModelDirectivesTest, AddStochasticFrameBad) {
+  // This nominal case works OK.
+  std::string yaml = R"""(
+directives:
+- add_frame:
+    name: my_frame
+    X_PF:
+      base_frame: world
+)""";
+  EXPECT_NO_THROW(LoadModelDirectivesFromString(yaml));
+
+  // Setting a stochastic transform yields a failure.
+  yaml += "      rotation: !Uniform {}\n";
+  DRAKE_EXPECT_THROWS_MESSAGE(LoadModelDirectivesFromString(yaml),
+                              ".*IsValid.*");
+}
+
 // Test backreference behavior in ModelDirectives.
 GTEST_TEST(ProcessModelDirectivesTest, TestBackreferences) {
   ModelDirectives directives = LoadModelDirectives(


### PR DESCRIPTION
Throws an error earlier in the parsing if the specified frame is not deterministic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20773)
<!-- Reviewable:end -->
