### PR TITLE
[schema] Nerf Transform::Sample back to a deprecation, not error

### DIFF
--- a/common/schema/BUILD.bazel
+++ b/common/schema/BUILD.bazel
@@ -81,9 +81,14 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "transform_test",
+    env = {
+        # On deprecation completion 2024-05-01 the next line should be removed.
+        "_DRAKE_DEPRECATION_IS_ERROR": "1",
+    },
     deps = [
         ":transform",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:symbolic_test_util",
         "//common/yaml",
     ],

--- a/common/schema/test/transform_test.cc
+++ b/common/schema/test/transform_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/math/rigid_transform.h"
@@ -116,7 +117,8 @@ GTEST_TEST(StochasticSampleTest, TransformTestWithBaseFrame) {
 
   Transform transform_with_base_frame = transform;
   transform_with_base_frame.base_frame = "baz";
-  EXPECT_THROW(transform_with_base_frame.Sample(&generator), std::exception);
+  DRAKE_EXPECT_THROWS_MESSAGE(transform_with_base_frame.Sample(&generator),
+                              ".*frame.*use.*SampleAsTransform.*instead.*");
   generator = drake::RandomGenerator(0);
   const Transform sampled_transform =
       transform_with_base_frame.SampleAsTransform(&generator);

--- a/common/schema/transform.cc
+++ b/common/schema/transform.cc
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
 #include "drake/math/rotation_matrix.h"
 
@@ -98,10 +99,13 @@ Transform Transform::SampleAsTransform(RandomGenerator* generator) const {
 
 math::RigidTransformd Transform::Sample(RandomGenerator* generator) const {
   if (base_frame.has_value() && (*base_frame != "world")) {
-    throw std::runtime_error(fmt::format(
-        "Transform::Sample() would discard non-trivial base frame \"{}\"; "
-        "use SampleAsTransform instead.",
-        *base_frame));
+    static const drake::internal::WarnDeprecated warn_once(
+        "2024-05-01",
+        fmt::format(
+            "Transform::Sample() would discard non-trivial base frame \"{}\"; "
+            "use Transform::SampleAsTransform() instead. This will become an "
+            "exception after the deprecation period ends.",
+            *base_frame));
   }
   return SampleInternal(*this, generator);
 }

--- a/common/schema/transform.h
+++ b/common/schema/transform.h
@@ -187,9 +187,10 @@ class Transform {
   /// Samples this Transform.  If this is deterministic, the result is the same
   /// as GetDeterministicValue.
   ///
-  /// @throw std::exception if this has a non-world base frame (because the
-  ///        return type has no base frame, so the returned value would be
-  ///        misleading).
+  /// @warning Calling this function when this object has a non-null, non-world
+  /// `base_frame` is deprecated and will become an error on 2024-05-01. (The
+  /// returned value would be misleading because it doesn't incorporate the base
+  /// frame.)
   math::RigidTransformd Sample(RandomGenerator* generator) const;
 
   /// Samples this Transform; the returned value is deterministic and has the


### PR DESCRIPTION
There is correct code downstream that was manually handling the base_frame propagation. We should allow users who did a good job to cross this API transition without a flag day.

Amends #20756.

+(priority: high) because this needs to land before the next release.

Ping to either +@calderpg-tri or +@ggould-tri for feature review.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20775)
<!-- Reviewable:end -->
