### PR TITLE
[geometry] Enable log level control in meshcat_manual_test

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -497,6 +497,7 @@ drake_cc_binary(
     deps = [
         ":meshcat",
         ":meshcat_visualizer",
+        "//common:add_text_logging_gflags",
         "//common/test_utilities:maybe_pause_for_user",
         "//multibody/meshcat:contact_visualizer",
         "//multibody/parsing",

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <thread>
 
+#include <gflags/gflags.h>
+
 #include "drake/common/find_resource.h"
 #include "drake/common/find_runfiles.h"
 #include "drake/common/temp_directory.h"
@@ -579,6 +581,8 @@ int do_main() {
 }  // namespace geometry
 }  // namespace drake
 
-int main() {
+int main(int argc, char* argv[]) {
+  // This enables ":add_text_logging_gflags" to control the spdlog level.
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::geometry::do_main();
 }


### PR DESCRIPTION
This can be useful to read DEBUG-level messages when using the program for local manual debugging.

+@rpoyner-tri for both reviews per schedule, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20778)
<!-- Reviewable:end -->
