### PR TITLE
[common] Add Sha256 utility class

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -53,6 +53,7 @@ drake_cc_package_library(
         ":reset_on_copy",
         ":scope_exit",
         ":scoped_singleton",
+        ":sha256",
         ":sorted_pair",
         ":temp_directory",
         ":timer",
@@ -447,6 +448,18 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "sha256",
+    srcs = ["sha256.cc"],
+    hdrs = ["sha256.h"],
+    interface_deps = [
+        ":essential",
+    ],
+    deps = [
+        "@picosha2_internal//:picosha2",
+    ],
+)
+
+drake_cc_library(
     name = "pointer_cast",
     srcs = ["pointer_cast.cc"],
     hdrs = ["pointer_cast.h"],
@@ -678,6 +691,14 @@ drake_cc_googletest(
     name = "reset_on_copy_test",
     deps = [
         ":reset_on_copy",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sha256_test",
+    deps = [
+        ":sha256",
+        ":temp_directory",
     ],
 )
 

--- a/common/sha256.cc
+++ b/common/sha256.cc
@@ -1,0 +1,81 @@
+#include "drake/common/sha256.h"
+
+#include <istream>
+#include <iterator>
+#include <utility>
+
+#include <picosha2.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+
+Sha256 Sha256::Checksum(std::string_view data) {
+  Sha256 result;
+  static_assert(sizeof(bytes_) == picosha2::k_digest_size);
+  picosha2::hash256(data, result.bytes_);
+  return result;
+}
+
+Sha256 Sha256::Checksum(std::istream* stream) {
+  DRAKE_THROW_UNLESS(stream != nullptr);
+  Sha256 result;
+  static_assert(sizeof(bytes_) == picosha2::k_digest_size);
+  picosha2::hash256(std::istreambuf_iterator<char>(*stream),
+                    std::istreambuf_iterator<char>(), result.bytes_);
+  return result;
+}
+
+namespace {
+
+/* Converts a hex char like '4' to its integer value 4.
+On error, overwrites `success` with `false`; otherwise, leaves it unchanged. */
+uint8_t ParseNibble(char nibble, bool* success) {
+  DRAKE_ASSERT(success != nullptr);
+  if (nibble >= '0' && nibble <= '9') {
+    return nibble - '0';
+  }
+  if (nibble >= 'a' && nibble <= 'f') {
+    return nibble - 'a' + 10;
+  }
+  if (nibble >= 'A' && nibble <= 'F') {
+    return nibble - 'A' + 10;
+  }
+  *success = false;
+  return 0;
+}
+
+/* Converts a two-digit hex string like "a0" to its integer value 0xa0.
+On error, overwrites `success` with `false`; otherwise, leaves it unchanged. */
+uint8_t ParseByte(std::string_view input, bool* success) {
+  const uint8_t hi = ParseNibble(input[0], success);
+  const uint8_t lo = ParseNibble(input[1], success);
+  return (hi << 4) | lo;
+}
+}  // namespace
+
+std::optional<Sha256> Sha256::Parse(std::string_view sha256) {
+  std::optional<Sha256> result;
+  constexpr int kNumBytes = sizeof(result->bytes_);
+  constexpr int kNumHexDigits = kNumBytes * 2;
+  if (sha256.size() == kNumHexDigits) {
+    result.emplace();
+    bool success = true;
+    for (size_t i = 0; i < kNumBytes; ++i) {
+      const size_t offset = 2 * i;
+      result->bytes_[i] =
+          ParseByte(sha256.substr(offset, offset + 2), &success);
+    }
+    if (!success) {
+      result.reset();
+    }
+  }
+  return result;
+}
+
+std::string Sha256::to_string() const {
+  return picosha2::bytes_to_hex_string(bytes_);
+}
+
+}  // namespace drake

--- a/common/sha256.h
+++ b/common/sha256.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <iosfwd>
+#include <optional>
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+
+/** Represents a SHA-256 cryptographic checksum.
+See also https://en.wikipedia.org/wiki/SHA-2.
+
+This class is not bound in pydrake, because Python programmers should prefer
+using https://docs.python.org/3/library/hashlib.html instead. */
+class Sha256 final {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Sha256);
+
+  /** Constructs an all-zero checksum.
+  Note that this is NOT the same as the checksum of empty (zero-sized) data. */
+  Sha256() { bytes_.fill(0); }
+
+  /** Computes the checksum of the given `data` buffer. */
+  static Sha256 Checksum(std::string_view data);
+
+  /** Computes the checksum of the given `stream`.
+  Does not check for istream errors; that is the responsibility of the caller.
+  @pre stream != nullptr. */
+  static Sha256 Checksum(std::istream* stream);
+
+  /** Parses the 64-character ASCII hex representation of a SHA-256 checksum.
+  Returns std::nullopt if the argument is an invalid checksum. */
+  static std::optional<Sha256> Parse(std::string_view sha256);
+
+  /** Returns the 64-character ASCII hex representation of this checksum. */
+  std::string to_string() const;
+
+  // Offer typical comparison operations.
+  bool operator==(const Sha256& other) const { return bytes_ == other.bytes_; }
+  bool operator!=(const Sha256& other) const { return bytes_ != other.bytes_; }
+  bool operator<(const Sha256& other) const { return bytes_ < other.bytes_; }
+
+ private:
+  friend class std::hash<Sha256>;
+
+  std::array<uint8_t, 32> bytes_;
+};
+
+}  // namespace drake
+
+namespace std {
+/** The STL container hash for Sha256 objects. This implementation avoids using
+drake::hash_append for performance. The checksum should already be well-mixed,
+so we can just squash it down into the required size. */
+template <>
+struct hash<drake::Sha256> {
+  size_t operator()(const drake::Sha256& x) const noexcept {
+    constexpr int kInputSize = sizeof(x.bytes_);
+    constexpr int kWordSize = sizeof(size_t);
+    static_assert(kInputSize % kWordSize == 0);
+    constexpr int kNumSteps = kInputSize / kWordSize;
+    size_t result = 0;
+    for (int i = 0; i < kNumSteps; ++i) {
+      // A memcpy is the canonical tool to convert raw memory between different
+      // compile-time types -- compilers will always optimize it away in release
+      // builds. The whole operator() implementation compiles down to just four
+      // instructions (the xor'ing of four 64-bit words).
+      size_t temp;
+      std::memcpy(&temp, x.bytes_.data() + i * kWordSize, kWordSize);
+      result = result ^ temp;
+    }
+    return result;
+  }
+};
+}  // namespace std

--- a/common/test/sha256_test.cc
+++ b/common/test/sha256_test.cc
@@ -1,0 +1,102 @@
+#include "drake/common/sha256.h"
+
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/temp_directory.h"
+
+namespace drake {
+namespace {
+
+// Our default constructor produces a dummy hash.
+GTEST_TEST(Sha256Test, Default) {
+  EXPECT_EQ(Sha256{}.to_string(), std::string(64, '0'));
+}
+
+// Since we're just a tiny wrapper around picosha, we don't need much testing of
+// the actual checksum math. We'll just spot-test a well-known value: one of the
+// standard test vectors for the SHA-2 family.
+GTEST_TEST(Sha256Test, WellKnownValue) {
+  const std::string data = "abc";
+  const std::string expected =
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+  EXPECT_EQ(Sha256::Checksum(data).to_string(), expected);
+  EXPECT_EQ(Sha256::Parse(expected), Sha256::Checksum(data));
+}
+
+// Hex strings can be uppercase and/or lowercase.
+GTEST_TEST(Sha256Test, ParseIgnoresCase) {
+  EXPECT_EQ(Sha256::Parse(std::string(64, 'c')),
+            Sha256::Parse(std::string(64, 'C')));
+}
+
+// A valid parse requires a 64-character hex string.
+GTEST_TEST(Sha256Test, ParseErrors) {
+  // Wrong number of characters.
+  EXPECT_FALSE(Sha256::Parse(std::string(60, '0')));
+  EXPECT_FALSE(Sha256::Parse(std::string(70, '0')));
+  // Non-hex letter.
+  EXPECT_FALSE(Sha256::Parse(std::string(64, 'z')));
+}
+
+// Here, we're cross-checking the exact implementation of our hash function
+// ("glass-box testing"). If we ever change to a different implementation,
+// we'll need to adjust this test to allow for it.
+GTEST_TEST(Sha256Test, Hash) {
+  const std::hash<Sha256> hasher;
+  EXPECT_EQ(hasher(Sha256{}), 0);
+  EXPECT_EQ(hasher(Sha256::Checksum("abc")),
+            // In our hash, the four words are directly XOR'd together. The
+            // to_string() prints the low-order byte first, but literals in C
+            // code give the high-order byte first, therefore the constants here
+            // are "reversed" versions of the words from the to_string().
+            0xeacf018fbf1678baULL ^      // ba7816bf8f01cfea, byte-reversed
+                0x2322ae5dde404141ULL ^  // 414140de5dae2223, byte-reversed
+                0x9c7a1796a36103b0ULL ^  // b00361a396177a9c, byte-reversed
+                0xad1500f261ff10b4ULL ^  // b410ff61f20015ad, byte-reversed
+                0);
+}
+
+GTEST_TEST(Sha256Test, Comparisons) {
+  auto zero = Sha256();
+  auto abc = Sha256::Checksum("abc");
+
+  EXPECT_TRUE(zero == zero);
+  EXPECT_TRUE(abc == abc);
+  EXPECT_FALSE(zero == abc);
+  EXPECT_FALSE(abc == zero);
+
+  EXPECT_FALSE(zero != zero);
+  EXPECT_FALSE(abc != abc);
+  EXPECT_TRUE(zero != abc);
+  EXPECT_TRUE(abc != zero);
+
+  EXPECT_FALSE(zero < zero);
+  EXPECT_FALSE(abc < abc);
+  EXPECT_TRUE(zero < abc);
+  EXPECT_FALSE(abc < zero);
+}
+
+// Reading from an empty file.
+GTEST_TEST(Sha256Test, EmptyFileTest) {
+  std::ifstream devnull("/dev/null");
+  EXPECT_EQ(Sha256::Checksum(&devnull), Sha256::Checksum(""));
+}
+
+// Reading from a non-empty file.
+GTEST_TEST(Sha256Test, RealFileTest) {
+  const std::string data = "abc";
+  const std::string temp_filename = temp_directory() + "/abc.txt";
+  {
+    std::ofstream temp_write(temp_filename);
+    temp_write << data;
+    DRAKE_THROW_UNLESS(temp_write.good());
+  }
+  std::ifstream temp_read(temp_filename);
+  EXPECT_EQ(Sha256::Checksum(&temp_read), Sha256::Checksum(data));
+}
+
+}  // namespace
+}  // namespace drake

--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -94,12 +94,12 @@ drake_cc_library(
         ":internal_http_service",
         ":internal_http_service_curl",
         ":render_engine_gltf_client_params",
+        "//common:sha256",
         "//common:temp_directory",
         "//geometry/render:render_camera",
         "//geometry/render:render_engine",
         "//systems/sensors:image",
         "//systems/sensors:image_io",
-        "@picosha2_internal//:picosha2",
     ],
 )
 

--- a/geometry/render_gltf_client/internal_render_client.cc
+++ b/geometry/render_gltf_client/internal_render_client.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/render_gltf_client/internal_render_client.h"
 
 #include <filesystem>
+#include <fstream>
 #include <map>
 #include <memory>
 #include <string>
@@ -9,8 +10,8 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <picosha2.h>
 
+#include "drake/common/sha256.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/text_logging.h"
 #include "drake/geometry/render_gltf_client/internal_http_service_curl.h"
@@ -237,9 +238,7 @@ std::string RenderClient::ComputeSha256(const std::string& path) {
     throw std::runtime_error(
         fmt::format("RenderClient: cannot open file '{}'.", path));
   }
-  std::vector<unsigned char> hash(picosha2::k_digest_size);
-  picosha2::hash256(f_in, hash.begin(), hash.end());
-  return picosha2::bytes_to_hex_string(hash.begin(), hash.end());
+  return Sha256::Checksum(&f_in).to_string();
 }
 
 std::string RenderClient::RenameHttpServiceResponse(

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -85,8 +85,8 @@ drake_cc_library(
         "//common:find_runfiles",
         "//common:network_policy",
         "//common:scope_exit",
+        "//common:sha256",
         "//common/yaml",
-        "@picosha2_internal//:picosha2",
         "@tinyxml2_internal//:tinyxml2",
     ],
 )
@@ -641,8 +641,8 @@ drake_cc_googletest(
         "//common:find_cache",
         "//common:find_resource",
         "//common:scope_exit",
+        "//common:sha256",
         "//common/test_utilities:expect_throws_message",
-        "@picosha2_internal//:picosha2",
     ],
 )
 

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -16,7 +16,6 @@
 #include <tuple>
 #include <utility>
 
-#include <picosha2.h>
 #include <tinyxml2.h>
 
 #include "drake/common/drake_assert.h"
@@ -27,6 +26,7 @@
 #include "drake/common/network_policy.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/scope_exit.h"
+#include "drake/common/sha256.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/yaml/yaml_io.h"
 
@@ -255,7 +255,7 @@ std::vector<std::string> GetAllowedUrls(const std::vector<std::string>& urls) {
 fs::path PackageData::GetCacheRelativePath() const {
   DRAKE_DEMAND(is_remote());
   const std::string hashed_strip_prefix =
-      picosha2::hash256_hex_string(remote_params_->strip_prefix.value_or(""));
+      Sha256::Checksum(remote_params_->strip_prefix.value_or("")).to_string();
   return fmt::format("{}-{}", remote_params_->sha256, hashed_strip_prefix);
 }
 

--- a/multibody/parsing/test/package_map_remote_test.cc
+++ b/multibody/parsing/test/package_map_remote_test.cc
@@ -2,12 +2,12 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <picosha2.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/find_cache.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/scope_exit.h"
+#include "drake/common/sha256.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/parsing/package_map.h"
 
@@ -30,7 +30,7 @@ class PackageMapRemoteTest : public ::testing::Test {
     const fs::path package_dir =
         try_cache.abspath /
         fmt::format("{}-{}", sha256,
-                    picosha2::hash256_hex_string(strip_prefix));
+                    Sha256::Checksum(strip_prefix).to_string());
     const bool exists = fs::create_directory(package_dir);
     DRAKE_DEMAND(exists);
     std::ofstream xml(package_dir / "package.xml");


### PR DESCRIPTION
I anticipate this being useful for #19598, but in any case factoring out a wrapper around picosha for rule-of-two seems plausible on its own.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20779)
<!-- Reviewable:end -->
