### PR TITLE
RenderEngine accepts and updates deformable geometries

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -53,6 +53,7 @@ drake_cc_library(
     deps = [
         ":render_camera",
         ":render_label",
+        ":render_mesh",
         "//common:essential",
         "//geometry:geometry_ids",
         "//geometry:geometry_roles",

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -21,12 +21,14 @@ class RenderEngineTester {
 
   int num_geometries() const {
     return static_cast<int>(engine_.update_ids_.size() +
-                            engine_.anchored_ids_.size());
+                            engine_.anchored_ids_.size() +
+                            engine_.deformable_mesh_dofs_.size());
   }
 
   bool has_id(GeometryId id) const {
     return engine_.update_ids_.count(id) > 0 ||
-           engine_.anchored_ids_.count(id) > 0;
+           engine_.anchored_ids_.count(id) > 0 ||
+           engine_.deformable_mesh_dofs_.count(id) > 0;
   }
 
  private:
@@ -35,7 +37,9 @@ class RenderEngineTester {
 
 namespace {
 
+using Eigen::Vector2d;
 using Eigen::Vector3d;
+using Eigen::VectorXd;
 using geometry::internal::DummyRenderEngine;
 using math::RigidTransformd;
 using std::set;
@@ -70,11 +74,150 @@ class MinimumEngine : public RenderEngine {
   std::unique_ptr<RenderEngine> DoClone() const override { return nullptr; }
 };
 
+GTEST_TEST(RenderEngine, DeformableGeometryRegistrationAndUpdate) {
+  DummyRenderEngine engine;
+
+  geometry::internal::RenderMesh mesh;
+  mesh.positions.resize(1, 3);
+  mesh.normals.resize(1, 3);
+  mesh.uvs.resize(1, 2);
+  const Vector3d initial_q = Vector3d(1, 2, 3);
+  const Vector3d initial_normal = Vector3d(-1, 0, 0);
+  mesh.positions.row(0) = initial_q;
+  mesh.normals.row(0) = initial_normal;
+  mesh.uvs.row(0) = Vector2d(1, 0).transpose();
+
+  PerceptionProperties properties = engine.accepting_properties();
+  const GeometryId id0 = GeometryId::get_new_id();
+  const GeometryId id1 = GeometryId::get_new_id();
+  const GeometryId id2 = GeometryId::get_new_id();
+  engine.RegisterDeformableVisual(id0, {mesh}, properties);
+  // Throw if id is already registered.
+  EXPECT_THROW(engine.RegisterDeformableVisual(id0, {mesh}, properties),
+               std::exception);
+  // Throw if no mesh is specified.
+  EXPECT_THROW(engine.RegisterDeformableVisual(id1, {}, properties),
+               std::exception);
+  // Register a geometry with multiple meshes.
+  engine.RegisterDeformableVisual(id1, {mesh, mesh}, properties);
+
+  // Register another geometry with a property that prevents the registration.
+  const PerceptionProperties skip_properties = engine.rejecting_properties();
+  engine.RegisterDeformableVisual(id2, {mesh}, skip_properties);
+
+  EXPECT_EQ(engine.num_registered(), 2);
+  EXPECT_TRUE(engine.is_registered(id0));
+  EXPECT_TRUE(engine.is_registered(id1));
+  EXPECT_TRUE(engine.has_geometry(id0));
+  EXPECT_TRUE(engine.has_geometry(id1));
+  // Verify that geometry with arbitrary id is not registered.
+  EXPECT_FALSE(engine.is_registered(GeometryId::get_new_id()));
+  EXPECT_FALSE(engine.has_geometry(GeometryId::get_new_id()));
+  // Verify that geometry with id2 is not registered.
+  EXPECT_FALSE(engine.is_registered(id2));
+  EXPECT_FALSE(engine.has_geometry(id2));
+
+  {
+    const std::vector<VectorXd>& q0 = engine.world_configurations(id0);
+    ASSERT_EQ(q0.size(), 1);
+    EXPECT_EQ(q0[0], initial_q);
+    const std::vector<VectorXd>& q1 = engine.world_configurations(id1);
+    ASSERT_EQ(q1.size(), 2);
+    EXPECT_EQ(q1[0], initial_q);
+    EXPECT_EQ(q1[1], initial_q);
+  }
+
+  {
+    const std::vector<VectorXd>& n0 = engine.world_normals(id0);
+    ASSERT_EQ(n0.size(), 1);
+    EXPECT_EQ(n0[0], initial_normal);
+    const std::vector<VectorXd>& n1 = engine.world_normals(id1);
+    ASSERT_EQ(n1.size(), 2);
+    EXPECT_EQ(n1[0], initial_normal);
+    EXPECT_EQ(n1[1], initial_normal);
+  }
+
+  // Update id0 but not id1.
+  VectorXd new_q(3);
+  VectorXd new_normal(3);
+  new_q << 4, 5, 6;
+  new_normal << 7, 8, 9;
+  new_normal.normalize();
+  engine.UpdateDeformableConfigurations(id0, {new_q}, {new_normal});
+  {
+    const std::vector<VectorXd>& q0 = engine.world_configurations(id0);
+    ASSERT_EQ(q0.size(), 1);
+    EXPECT_EQ(q0[0], new_q);
+    const std::vector<VectorXd>& q1 = engine.world_configurations(id1);
+    ASSERT_EQ(q1.size(), 2);
+    EXPECT_EQ(q1[0], initial_q);
+    EXPECT_EQ(q1[1], initial_q);
+  }
+  {
+    const std::vector<VectorXd>& n0 = engine.world_normals(id0);
+    ASSERT_EQ(n0.size(), 1);
+    EXPECT_EQ(n0[0], new_normal);
+    const std::vector<VectorXd>& n1 = engine.world_normals(id1);
+    ASSERT_EQ(n1.size(), 2);
+    EXPECT_EQ(n1[0], initial_normal);
+    EXPECT_EQ(n1[1], initial_normal);
+  }
+
+  // Now update id1 to verify that updates to a multi-mesh geometry go to the
+  // right meshes.
+  VectorXd another_q(3);
+  VectorXd another_normal(3);
+  another_q << 40, 50, 60;
+  another_normal << 70, 80, 90;
+  another_normal.normalize();
+  engine.UpdateDeformableConfigurations(id1, {new_q, another_q},
+                                        {new_normal, another_normal});
+  {
+    const std::vector<VectorXd>& q1 = engine.world_configurations(id1);
+    ASSERT_EQ(q1.size(), 2);
+    EXPECT_EQ(q1[0], new_q);
+    EXPECT_EQ(q1[1], another_q);
+    const std::vector<VectorXd>& n1 = engine.world_normals(id1);
+    ASSERT_EQ(n1.size(), 2);
+    EXPECT_EQ(n1[0], new_normal);
+    EXPECT_EQ(n1[1], another_normal);
+  }
+
+  // Now we test for throw conditions for the update.
+  // Non-existant geometry.
+  const GeometryId fake_id = GeometryId::get_new_id();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.UpdateDeformableConfigurations(fake_id, {new_q}, {new_normal}),
+      "No deformable geometry with id.*");
+  // Wrong number of vertex positions/normals.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.UpdateDeformableConfigurations(id0, {new_q, new_q}, {new_normal}),
+      "Vertex data for the wrong number of meshes.*1 meshes are "
+      "registered.*vertex positions for 2 meshes and vertex normals for 1 "
+      "meshes are provided.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.UpdateDeformableConfigurations(id0, {new_q},
+                                            {new_normal, new_normal}),
+      "Vertex data for the wrong number of meshes.*1 meshes are "
+      "registered.*vertex positions for 1 meshes and vertex normals for 2 "
+      "meshes are provided.*");
+  // Wrong size for the vertex positions/normal vectors.
+  VectorXd incorrectly_sized_vector(4);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.UpdateDeformableConfigurations(id0, {incorrectly_sized_vector},
+                                            {new_normal}),
+      "Wrong dofs in vertex positions and/or normals.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.UpdateDeformableConfigurations(id0, {new_q},
+                                            {incorrectly_sized_vector}),
+      "Wrong dofs in vertex positions and/or normals.*");
+}
+
 // Tests the RenderEngine-specific functionality for managing registration of
-// geometry and its corresponding update behavior. The former should configure
-// each geometry correctly on whether it gets updated or not, and the latter
-// will confirm that the right geometries get updated.
-GTEST_TEST(RenderEngine, RegistrationAndUpdate) {
+// rigid geometry and its corresponding update behavior. The former should
+// configure each geometry correctly on whether it gets updated or not, and the
+// latter will confirm that the right geometries get updated.
+GTEST_TEST(RenderEngine, RigidGeometryRegistrationAndUpdate) {
   // Change the default render label to something registerable.
   DummyRenderEngine engine({RenderLabel::kDontCare});
 
@@ -180,6 +323,7 @@ GTEST_TEST(RenderEngine, RemoveGeometry) {
 
   set<GeometryId> ids;
 
+  // Register rigid geometries.
   for (int i = 0; i < need_update_count + anchored_count; ++i) {
     const GeometryId id = GeometryId::get_new_id();
     const bool is_dynamic = i % 2 == 0;  // alternate dynamic, anchored, etc.
@@ -190,6 +334,17 @@ GTEST_TEST(RenderEngine, RemoveGeometry) {
     }
     ids.insert(id);
   }
+
+  // Register a single deformable geometry.
+  geometry::internal::RenderMesh mesh;
+  GeometryId deformable_id = GeometryId::get_new_id();
+  const bool accepted =
+      engine.RegisterDeformableVisual(deformable_id, {mesh}, add_properties);
+  if (!accepted) {
+    throw std::logic_error("The geometry wasn't accepted for registration");
+  }
+  ids.insert(deformable_id);
+
   RenderEngineTester tester(&engine);
 
   // Case: invalid ids don't get removed.
@@ -197,7 +352,7 @@ GTEST_TEST(RenderEngine, RemoveGeometry) {
 
   // Case: Systematically remove remaining geometries and confirm state --
   // because of how geometries were added, this will alternate dynamic,
-  // anchored, dynamic, etc.
+  // anchored, dynamic, etc, with the last geometry being deformable.
   while (!ids.empty()) {
     const GeometryId id = *ids.begin();
     EXPECT_TRUE(engine.RemoveGeometry(id));

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -5,8 +5,11 @@
 #include <optional>
 #include <string>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/ssize.h"
 #include "drake/geometry/render/render_engine.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/systems/sensors/color_palette.h"
@@ -29,7 +32,10 @@ namespace internal {
     knows to be registered).
  4. Records which poses have been updated via UpdatePoses() to validate which
     ids values are updated and which aren't (and with what pose).
- 5. Records the camera pose provided to UpdateViewpoint() and report it with
+ 5. Records which deformable configurations have been updated via
+    UpdateDeformableConfigurations() to validate which id values are updated
+    and which aren't (and with what configurations).
+ 6. Records the camera pose provided to UpdateViewpoint() and report it with
     last_updated_X_WC().  */
 class DummyRenderEngine : public render::RenderEngine {
  public:
@@ -132,6 +138,19 @@ class DummyRenderEngine : public render::RenderEngine {
     return X_WGs_.at(id);
   }
 
+  /* Returns the most recent vertex normals of the render meshes for the
+   deformable geometry with the given `id` in the world frame.  */
+  const std::vector<Eigen::VectorXd>& world_normals(GeometryId id) const {
+    return nhats_W_.at(id);
+  }
+
+  /* Returns the most recent configurations of the render meshes for the
+   deformable geometry with the given `id` in the world frame.  */
+  const std::vector<Eigen::VectorXd>& world_configurations(
+      GeometryId id) const {
+    return q_WGs_.at(id);
+  }
+
   const math::RigidTransformd& last_updated_X_WC() const { return X_WC_; }
 
   // Promote these to be public to facilitate testing.
@@ -143,7 +162,7 @@ class DummyRenderEngine : public render::RenderEngine {
   /* Dummy implementation that registers the given `shape` if the `properties`
    contains the "in_test" group or the render engine has been forced to accept
    all geometries (via set_force_accept()). (Also counts the number of
-   successfully registered shape over the lifespan of `this` instance.)  */
+   successfully registered shape over the lifespan of `this` instance.) */
   bool DoRegisterVisual(GeometryId id, const Shape&,
                         const PerceptionProperties& properties,
                         const math::RigidTransformd& X_WG) override {
@@ -156,6 +175,34 @@ class DummyRenderEngine : public render::RenderEngine {
     return false;
   }
 
+  /* Dummy implementation that registers the given deformable geometry with `id`
+   and records the meshes' initial configurations if the `properties` contains
+   the "in_test" group or the render engine has been forced to accept all
+   geometries (via set_force_accept()). */
+  bool DoRegisterDeformableVisual(
+      GeometryId id, const std::vector<internal::RenderMesh>& render_meshes,
+      const PerceptionProperties& properties) override {
+    if (force_accept_ || properties.HasGroup(include_group_name_)) {
+      using Eigen::VectorXd;
+      registered_geometries_.insert(id);
+      std::vector<VectorXd> initial_positions;
+      std::vector<VectorXd> initial_normals;
+      for (int i = 0; i < ssize(render_meshes); ++i) {
+        VectorXd flat_positions =
+            Eigen::Map<const VectorXd>(render_meshes[i].positions.data(),
+                                       render_meshes[i].positions.size());
+        initial_positions.push_back(std::move(flat_positions));
+        VectorXd flat_normals = Eigen::Map<const VectorXd>(
+            render_meshes[i].normals.data(), render_meshes[i].normals.size());
+        initial_normals.push_back(std::move(flat_normals));
+      }
+      q_WGs_[id] = std::move(initial_positions);
+      nhats_W_[id] = std::move(initial_normals);
+      return true;
+    }
+    return false;
+  }
+
   /* Updates the pose X_WG for the geometry with the given `id`. Also tracks
    which ids have been updated and the poses set (over the _lifespan_ of
    `this` instance). This can be reset with a call to init_test_data().  */
@@ -163,6 +210,13 @@ class DummyRenderEngine : public render::RenderEngine {
                           const math::RigidTransformd& X_WG) override {
     updated_ids_[id] = X_WG;
     X_WGs_[id] = X_WG;
+  }
+
+  void DoUpdateDeformableConfigurations(
+      GeometryId id, const std::vector<VectorX<double>>& q_WGs,
+      const std::vector<VectorX<double>>& nhats_W) override {
+    q_WGs_[id] = q_WGs;
+    nhats_W_[id] = nhats_W;
   }
 
   /* Removes the given geometry id (if it is registered).  */
@@ -204,6 +258,15 @@ class DummyRenderEngine : public render::RenderEngine {
 
   // The current poses of the geometries in the world frame.
   std::map<GeometryId, math::RigidTransformd> X_WGs_;
+
+  // The current configurations of the deformable render meshes in the world
+  // frame.
+  std::map<GeometryId, std::vector<Eigen::VectorXd>> q_WGs_;
+
+  // The current vertex normals of the deformable render meshes in the world
+  // frame.
+  std::map<GeometryId, std::vector<Eigen::VectorXd>> nhats_W_;
+
   // TODO(SeanCurtis-TRI) Shuffle this around so that the updated ids no longer
   //  redundantly stores the updated poses; those should be accessible via
   //  X_WGs_.


### PR DESCRIPTION
Towards #18922.
See the full wip branch at #20780 for bigger picture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20781)
<!-- Reviewable:end -->
