### PR TITLE
[geometry] Meshcat's server returns 404 (not 200) on failures

### DIFF
--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -261,6 +261,18 @@ class TestGeometryVisualizers(unittest.TestCase):
         # The pose is None because no meshcat session has broadcast its pose.
         self.assertIsNone(meshcat.GetTrackedCameraPose())
 
+    def test_meshcat_404(self):
+        meshcat = mut.Meshcat()
+
+        good_url = meshcat.web_url()
+        with urllib.request.urlopen(good_url) as response:
+            self.assertTrue(response.read(1))
+
+        bad_url = f"{good_url}/no_such_file"
+        with self.assertRaisesRegex(Exception, "HTTP.*404"):
+            with urllib.request.urlopen(bad_url) as response:
+                response.read(1)
+
     def test_meshcat_animation(self):
         animation = mut.MeshcatAnimation(frames_per_second=64)
         self.assertEqual(animation.frames_per_second(), 64)

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -919,6 +919,7 @@ drake_cc_googletest(
         ":drake_path",
         ":find_resource",
         "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -1,7 +1,9 @@
 #include "drake/common/find_resource.h"
 
 #include <cstdlib>
-#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -289,6 +291,26 @@ Result FindResource(const string& resource_path) {
 
 string FindResourceOrThrow(const string& resource_path) {
   return FindResource(resource_path).get_absolute_path_or_throw();
+}
+
+std::optional<string> ReadFile(const std::filesystem::path& path) {
+  std::optional<string> result;
+  std::ifstream input(path, std::ios::binary);
+  if (input.is_open()) {
+    std::stringstream content;
+    content << input.rdbuf();
+    result.emplace(std::move(content).str());
+  }
+  return result;
+}
+
+std::string ReadFileOrThrow(const std::filesystem::path& path) {
+  std::optional<string> result = ReadFile(path);
+  if (!result) {
+    throw std::runtime_error(
+        fmt::format("Error reading from '{}'", path.string()));
+  }
+  return std::move(*result);
 }
 
 }  // namespace drake

--- a/common/find_resource.h
+++ b/common/find_resource.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <vector>
@@ -124,5 +125,13 @@ std::string FindResourceOrThrow(const std::string& resource_path);
 /// The intended use of this variable is to seek resources from an installed
 /// copy of Drake, in case other methods have failed.
 extern const char* const kDrakeResourceRootEnvironmentVariableName;
+
+/// Returns the content of the file at the given path, or nullopt if it cannot
+/// be read. Note that the path is a filesystem path, not a `resource_path`.
+std::optional<std::string> ReadFile(const std::filesystem::path& path);
+
+/// Returns the content of the file at the given path, or throws if it cannot
+/// be read. Note that the path is a filesystem path, not a `resource_path`.
+std::string ReadFileOrThrow(const std::filesystem::path& path);
 
 }  // namespace drake

--- a/common/test/find_resource_test.cc
+++ b/common/test/find_resource_test.cc
@@ -2,10 +2,8 @@
 
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 #include <functional>
 #include <memory>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -16,6 +14,7 @@
 #include "drake/common/drake_path.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 
 using std::string;
 
@@ -84,13 +83,8 @@ GTEST_TEST(FindResourceTest, FoundDeclaredData) {
   // The path is the correct answer.
   ASSERT_FALSE(absolute_path.empty());
   EXPECT_EQ(absolute_path[0], '/');
-  std::ifstream input(absolute_path, std::ios::binary);
-  ASSERT_TRUE(input);
-  std::stringstream buffer;
-  buffer << input.rdbuf();
-  EXPECT_EQ(
-      buffer.str(),
-      "Test data for drake/common/test/find_resource_test.cc.\n");
+  EXPECT_EQ(ReadFileOrThrow(absolute_path),
+            "Test data for drake/common/test/find_resource_test.cc.\n");
 
   // Sugar works the same way.
   EXPECT_EQ(FindResourceOrThrow(relpath), absolute_path);
@@ -118,6 +112,12 @@ GTEST_TEST(GetDrakePathTest, PathIncludesDrake) {
       std::filesystem::path(*result) /
       std::filesystem::path("common/test/find_resource_test_data.txt");
   EXPECT_TRUE(std::filesystem::exists(expected));
+}
+
+GTEST_TEST(ReadFileTest, NoSuchPath) {
+  EXPECT_FALSE(ReadFile("/foo/bar/missing"));
+  DRAKE_EXPECT_THROWS_MESSAGE(ReadFileOrThrow("/foo/bar/missing"),
+                              "Error reading.*/foo/bar/missing.*");
 }
 
 }  // namespace

--- a/common/yaml/test/yaml_doxygen_test.cc
+++ b/common/yaml/test/yaml_doxygen_test.cc
@@ -30,16 +30,6 @@ std::string WriteTemp(const std::string& data) {
   return filename;
 }
 
-// Read data from a scratch file.
-// (This is a test helper, not part of the Doxygen header.)
-std::string ReadTemp(const std::string& filename) {
-  std::ifstream input(filename, std::ios::binary);
-  DRAKE_DEMAND(!input.fail());
-  std::stringstream buffer;
-  buffer << input.rdbuf();
-  return buffer.str();
-}
-
 // This is an example from the Doxygen header.
 struct MyData {
   template <typename Archive>
@@ -80,7 +70,7 @@ GTEST_TEST(YamlDoxygenTest, ExamplesSaving) {
   SaveYamlFile(output_filename, data);
 
   // This data is an example from the Doxygen header.
-  const std::string output = ReadTemp(output_filename);
+  const std::string output = ReadFileOrThrow(output_filename);
   const std::string expected_output = R"""(
 foo: 4.0
 bar: [5.0, 6.0]

--- a/common/yaml/test/yaml_io_test.cc
+++ b/common/yaml/test/yaml_io_test.cc
@@ -21,14 +21,6 @@ namespace yaml {
 namespace test {
 namespace {
 
-std::string ReadTestFileAsString(const std::string& filename) {
-  std::ifstream input(filename, std::ios::binary);
-  DRAKE_DEMAND(!input.fail());
-  std::stringstream buffer;
-  buffer << input.rdbuf();
-  return buffer.str();
-}
-
 GTEST_TEST(YamlIoTest, LoadString) {
   const std::string data = R"""(
 value:
@@ -182,7 +174,7 @@ GTEST_TEST(YamlIoTest, SaveFile) {
   const std::string filename = temp_directory() + "/SaveFile1.yaml";
   const StringStruct data{.value = "save_file_1"};
   SaveYamlFile(filename, data);
-  const auto result = ReadTestFileAsString(filename);
+  const auto result = ReadFileOrThrow(filename);
   EXPECT_EQ(result, "value: save_file_1\n");
 }
 
@@ -194,7 +186,7 @@ GTEST_TEST(YamlIoTest, SaveFileAllArgs) {
   data.value.insert({"save_file_4", 1.0});
   ASSERT_EQ(data.value.size(), 2);
   SaveYamlFile(filename, data, child_name, {defaults});
-  const auto result = ReadTestFileAsString(filename);
+  const auto result = ReadFileOrThrow(filename);
   EXPECT_EQ(result, "some_child:\n  value:\n    save_file_4: 1.0\n");
 }
 

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -452,13 +452,18 @@ drake_cc_googletest(
 
 drake_cc_library(
     name = "meshcat",
-    srcs = ["meshcat.cc"],
+    srcs = [
+        "meshcat.cc",
+        "meshcat_internal.cc",
+    ],
     hdrs = [
         "meshcat.h",
+        "meshcat_internal.h",
         "meshcat_types_internal.h",
     ],
     data = [":meshcat_resources"],
     install_hdrs_exclude = [
+        "meshcat_internal.h",
         "meshcat_types_internal.h",
     ],
     interface_deps = [
@@ -532,6 +537,13 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "@msgpack_internal//:msgpack",
+    ],
+)
+
+drake_cc_googletest(
+    name = "meshcat_internal_test",
+    deps = [
+        ":meshcat",
     ],
 )
 

--- a/geometry/meshcat_internal.cc
+++ b/geometry/meshcat_internal.cc
@@ -1,0 +1,61 @@
+#include "drake/geometry/meshcat_internal.h"
+
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+#include <fmt/format.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/never_destroyed.h"
+
+namespace fs = std::filesystem;
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+namespace {
+
+std::string LoadResource(const std::string& resource_name) {
+  const std::string resource = FindResourceOrThrow(resource_name);
+  std::optional<std::string> content = ReadFile(resource);
+  if (!content) {
+    throw std::runtime_error(
+        fmt::format("Error opening resource: {}", resource_name));
+  }
+  return std::move(*content);
+}
+
+}  //  namespace
+
+std::optional<std::string_view> GetMeshcatStaticResource(
+    std::string_view url_path) {
+  static const drake::never_destroyed<std::string> meshcat_js(
+      LoadResource("drake/geometry/meshcat.js"));
+  static const drake::never_destroyed<std::string> stats_js(
+      LoadResource("drake/geometry/stats.min.js"));
+  static const drake::never_destroyed<std::string> meshcat_ico(
+      LoadResource("drake/geometry/meshcat.ico"));
+  static const drake::never_destroyed<std::string> meshcat_html(
+      LoadResource("drake/geometry/meshcat.html"));
+  if ((url_path == "/") || (url_path == "/index.html") ||
+      (url_path == "/meshcat.html")) {
+    return meshcat_html.access();
+  }
+  if (url_path == "/meshcat.js") {
+    return meshcat_js.access();
+  }
+  if (url_path == "/stats.min.js") {
+    return stats_js.access();
+  }
+  if (url_path == "/favicon.ico") {
+    return meshcat_ico.access();
+  }
+  return {};
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/meshcat_internal.h
+++ b/geometry/meshcat_internal.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* Returns the static content for the given URL, or nullopt when the URL is
+invalid. The valid static resource URLs are:
+- `/`
+- `/favicon.ico`
+- `/index.html`
+- `/meshcat.html`
+- `/meshcat.js`
+- `/stats.min.js` */
+std::optional<std::string_view> GetMeshcatStaticResource(
+    std::string_view url_path);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render_gl/internal_shader_program.cc
+++ b/geometry/render_gl/internal_shader_program.cc
@@ -4,9 +4,12 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
+
+#include "drake/common/find_resource.h"
 
 namespace drake {
 namespace geometry {
@@ -90,13 +93,10 @@ void ShaderProgram::LoadFromSources(const std::string& vertex_shader_source,
 
 namespace {
 std::string LoadFile(const std::string& filename) {
-  std::ifstream file(filename.c_str(), std::ios::in);
-  if (!file.is_open())
+  std::optional<std::string> content = ReadFile(filename);
+  if (!content)
     throw std::runtime_error("Error opening shader file: " + filename);
-  std::stringstream content;
-  content << file.rdbuf();
-  file.close();
-  return content.str();
+  return std::move(*content);
 }
 }  // namespace
 

--- a/geometry/render_gltf_client/internal_render_client.cc
+++ b/geometry/render_gltf_client/internal_render_client.cc
@@ -11,6 +11,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/find_resource.h"
 #include "drake/common/sha256.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/text_logging.h"
@@ -178,11 +179,8 @@ std::string RenderClient::RenderOnServer(
       const std::string& data_path = response.data_path.value();
       const std::uintmax_t bin_size = fs::file_size(data_path);
       if (bin_size > 0 && bin_size < 8192) {
-        std::ifstream bin_in(data_path, std::ios::binary);
-        if (bin_in.is_open()) {
-          std::stringstream buff;
-          buff << bin_in.rdbuf();
-          server_message = buff.str();
+        if (std::optional<std::string> data = ReadFile(data_path)) {
+          server_message = std::move(*data);
         }
       }
     }

--- a/geometry/test/meshcat_internal_test.cc
+++ b/geometry/test/meshcat_internal_test.cc
@@ -1,0 +1,28 @@
+#include "drake/geometry/meshcat_internal.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+GTEST_TEST(MeshcatInternalTest, GetMeshcatStaticResource) {
+  // This matches the list of URLs in the API doc.
+  const std::vector<const char*> urls{
+      "/",           "/favicon.ico",  "/index.html", "/meshcat.html",
+      "/meshcat.js", "/stats.min.js",
+  };
+  for (const auto& url : urls) {
+    SCOPED_TRACE(fmt::format("url = {}", url));
+    const std::optional<std::string_view> result =
+        GetMeshcatStaticResource(url);
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(result->empty());
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -7,7 +7,6 @@
 #include <cctype>
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 #include <initializer_list>
 #include <map>
 #include <optional>
@@ -367,17 +366,14 @@ const std::string& PackageData::GetPathWithAutomaticFetching(
   const int returncode = std::system(command.c_str());
   if (returncode != 0) {
     // Try to read the error message text from the downloader.
-    std::ifstream error_file(error_filename);
-    std::stringstream error_stream;
-    error_stream << error_file.rdbuf();
-    std::string error = error_stream.str();
-    if (error.empty()) {
+    std::optional<std::string> error = ReadFile(error_filename);
+    if (!error || error->empty()) {
       error = fmt::format("returncode == {}", returncode);
     }
     throw std::runtime_error(fmt::format(
         "PackageMap: when downloading '{}', the downloader experienced an "
         "error: {}",
-        package_name, error));
+        package_name, *error));
   }
 
   // Confirm that it actually fetched.

--- a/multibody/parsing/test/package_map_remote_test.cc
+++ b/multibody/parsing/test/package_map_remote_test.cc
@@ -94,10 +94,7 @@ TEST_F(PackageMapRemoteTest, ActuallyFetch) {
   EXPECT_TRUE(fs::is_regular_file(readme_path)) << readme_path;
 
   // Double-check the file content.
-  std::ifstream readme(readme_path);
-  std::stringstream buffer;
-  buffer << readme.rdbuf();
-  EXPECT_EQ(buffer.str(), "This package is empty.\n");
+  EXPECT_EQ(ReadFileOrThrow(readme_path), "This package is empty.\n");
 }
 
 // Fetch a remote zip file, then again with a different strip_prefix.

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -1,8 +1,6 @@
 #include "drake/multibody/parsing/parser.h"
 
 #include <filesystem>
-#include <fstream>
-#include <sstream>
 
 #include <gtest/gtest.h>
 
@@ -14,14 +12,6 @@
 namespace drake {
 namespace multibody {
 namespace {
-
-std::string ReadEntireFile(const std::string& file_name) {
-  std::ifstream input(file_name);
-  DRAKE_DEMAND(input.good());
-  std::stringstream result;
-  result << input.rdbuf();
-  return result.str();
-}
 
 GTEST_TEST(FileParserTest, BasicTest) {
   const std::string sdf_name = FindResourceOrThrow(
@@ -131,7 +121,7 @@ GTEST_TEST(FileParserTest, BasicStringTest) {
 
   // Load an SDF via string using plural method.
   {
-    const std::string sdf_contents = ReadEntireFile(sdf_name);
+    const std::string sdf_contents = ReadFileOrThrow(sdf_name);
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     const std::vector<ModelInstanceIndex> ids =
@@ -142,7 +132,7 @@ GTEST_TEST(FileParserTest, BasicStringTest) {
 
   // Load an URDF via string using plural method.
   {
-    const std::string urdf_contents = ReadEntireFile(urdf_name);
+    const std::string urdf_contents = ReadFileOrThrow(urdf_name);
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     const std::vector<ModelInstanceIndex> ids =
@@ -153,7 +143,7 @@ GTEST_TEST(FileParserTest, BasicStringTest) {
 
   // Load an MJCF via string using plural method.
   {
-    const std::string xml_contents = ReadEntireFile(xml_name);
+    const std::string xml_contents = ReadFileOrThrow(xml_name);
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     const std::vector<ModelInstanceIndex> ids =
@@ -164,7 +154,7 @@ GTEST_TEST(FileParserTest, BasicStringTest) {
 
   // Load a DMD.YAML via string using plural method.
   {
-    const std::string dmd_contents = ReadEntireFile(dmd_name);
+    const std::string dmd_contents = ReadFileOrThrow(dmd_name);
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     const std::vector<ModelInstanceIndex> ids =

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -1,9 +1,7 @@
 #include "drake/multibody/parsing/process_model_directives.h"
 
 #include <filesystem>
-#include <fstream>
 #include <memory>
-#include <sstream>
 #include <stdexcept>
 
 #include <gtest/gtest.h>
@@ -98,12 +96,9 @@ GTEST_TEST(ProcessModelDirectivesTest, BasicSmokeTest) {
 
 // Smoke test of the most basic model directives, now loading from string.
 GTEST_TEST(ProcessModelDirectivesTest, FromString) {
-  std::ifstream file_stream(
-      FindResourceOrThrow(std::string(kTestDir) + "/add_scoped_sub.dmd.yaml"));
-  std::stringstream yaml;
-  yaml << file_stream.rdbuf();
   ModelDirectives station_directives =
-      LoadModelDirectivesFromString(yaml.str());
+      LoadModelDirectivesFromString(ReadFileOrThrow(FindResourceOrThrow(
+          std::string(kTestDir) + "/add_scoped_sub.dmd.yaml")));
 
   const MultibodyPlant<double> empty_plant(0.0);
 

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -806,6 +806,7 @@ drake_cc_variant_library(
     ],
     deps_enabled = [
         "//math:eigen_sparse_triplet",
+        "//common:find_resource",
         "//common:scope_exit",
         "//common:scoped_singleton",
         "@gurobi//:gurobi_c",
@@ -1718,6 +1719,7 @@ drake_cc_googletest(
         ":quadratic_program_examples",
         ":second_order_cone_program_examples",
         ":snopt_solver",
+        "//common:find_resource",
         "//common:temp_directory",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -24,6 +24,7 @@
 #include "gurobi_c.h"
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/find_resource.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/scoped_singleton.h"
 #include "drake/common/text_logging.h"
@@ -1084,13 +1085,11 @@ bool IsGrbLicenseFileLocalHost() {
   if (grb_license_file == nullptr) {
     return false;
   }
-  std::ifstream stream{grb_license_file};
-  const std::string contents{std::istreambuf_iterator<char>{stream},
-                             std::istreambuf_iterator<char>{}};
-  if (stream.fail()) {
+  const std::optional<std::string> contents = ReadFile(grb_license_file);
+  if (!contents) {
     return false;
   }
-  return contents.find("HOSTID") != std::string::npos;
+  return contents->find("HOSTID") != std::string::npos;
 }
 }  // namespace
 


### PR DESCRIPTION
Towards #19598.

Returning cacheable 200 responses with empty bodies is seriously misleading to the browser-side code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20790)
<!-- Reviewable:end -->
