### PR TITLE
[geometry] Fix Meshcat browser console error messages

### DIFF
--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -50,6 +50,14 @@ namespace {
 using math::RigidTransformd;
 using math::RotationMatrixd;
 
+// TODO(jwnimmer-tri) Use the C++ built-in ends_with when we drop C++17.
+bool EndsWith(std::string_view str, std::string_view suffix) {
+  if (str.size() < suffix.size()) {
+    return false;
+  }
+  return str.substr(str.size() - suffix.size()) == suffix;
+}
+
 template <typename Mapping>
 [[noreturn]] void ThrowThingNotFound(std::string_view thing,
                                      std::string_view name, Mapping thing_map) {
@@ -1922,6 +1930,8 @@ class Meshcat::Impl {
             internal::GetMeshcatStaticResource(url_path)) {
       if (content->substr(0, 15) == "<!DOCTYPE html>") {
         response->writeHeader("Content-Type", "text/html; charset=utf-8");
+      } else if (EndsWith(url_path, ".js")) {
+        response->writeHeader("Content-Type", "text/javascript; charset=utf-8");
       }
       response->end(*content);
       return;

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -162,6 +162,9 @@ for
 or
 [Firefox](https://addons.mozilla.org/en-US/firefox/addon/webxr-api-emulator/)).
 
+The AR/VR mode is not currently supported in offline mode (i.e., when saving as
+StaticHtml()).
+
 @section network_access Network access
 
 See MeshcatParams for options to control the hostname and port to bind to.

--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -215,7 +215,11 @@
     url = url.replace("/index.html", "/")
     url = url.replace("/meshcat.html", "/")
     make_connection(url, reconnect_ms);
-    <!-- CONNECTION BLOCK END -->
+
+    // Per our meshcat.h docs, using XR when offline is not supported. Adding
+    // offline support might be possible by moving the 'webxr' and 'controller'
+    // handling outside of the CONNECTION BLOCK comment region and adding
+    // meshcat_manual_test coverage.
 
     const webxrMode = urlParams.get('webxr');
     if (webxrMode) {
@@ -231,8 +235,7 @@
         type: "visualize_vr_controller"
       });
     }
-
-
+    <!-- CONNECTION BLOCK END -->
 
   </script>
 

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -204,6 +204,23 @@ int do_main() {
   }
 
   std::cout << R"""(
+Open the developer tools of your browser (F12) and within that panel switch to
+the "Console" tab.
+
+Keep that panel visible throughout the entire testing process. Any errors or
+warnings displayed in that Console most likely indicate a bug in our code and
+should be fixed. (If you are running this test as part of a pull request code
+review, be sure to post the message as a Reviewable discussion.)
+
+Less severe Console messages (info, debug, etc.) are not bugs and can be
+ignored.
+
+Caveat: At the moment, you might see Console warnings related to deprecations.
+Ignore those for now; we'll need to circle back and fix them later.
+)""";
+  MaybePauseForUser();
+
+  std::cout << R"""(
 - The background should be grey.
 - From left to right along the x axis, you should see:
   - a red sphere
@@ -456,8 +473,11 @@ int do_main() {
          "- the camera is focused on the contact point between the robot and "
          "table,\n"
          "- the iiwa is visible,\n"
-         "- the animation plays, and\n"
-         "- the environment map is present.\n";
+         "- the animation plays,\n"
+         "- the environment map is present, and\n"
+         "- the browser Console has no warnings nor errors\n"
+         "  (use F12 to open the panel with the Console).\n\n";
+  std::cout << "When you're done, close the browser tab.\n";
 
   MaybePauseForUser();
 


### PR DESCRIPTION
Prior to this, `Uncaught ReferenceError: urlParams is not defined` was printed from any static HTML page.

Amends #20430.

+@SeanCurtis-TRI for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20791)
<!-- Reviewable:end -->
