### PR TITLE
[geometry] Meshcat's "drake" panel is unfolded by default

### DIFF
--- a/geometry/meshcat.html
+++ b/geometry/meshcat.html
@@ -135,6 +135,9 @@
                         0.3);
     viewer.set_property(["Lights", "FillLight", "<object>"], "intensity", 0.5);
 
+    // The "/drake" tree should start out open in the GUI.
+    viewer.scene_tree.find(["drake"]).folder.open();
+
     <!-- CONNECTION BLOCK BEGIN -->
     // The lifespan of the server may be much shorter than this visualizer
     // client. We'd like the user to not have to explicitly reload when they

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -284,7 +284,16 @@ Ignore those for now; we'll need to circle back and fix them later.
 
   meshcat->SetAnimation(animation);
 
-  std::cout << "You can review/replay the animation from the controls menu.\n";
+  std::cout << R"""(
+Click "Open Controls" in the upper right to unfold the Control Panel.
+
+Confirm that the "Scene => drake" sub-tree is already unfolded by default, so
+that you see all of the shape names (box, capsule, etc.). Click on "drake"
+to fold it away again to de-clutter the controls.
+
+Replay the animation by clicking the "play" button under "Scene => Animations =>
+default" and confirm that it plays.
+)""";
   MaybePauseForUser();
 
   meshcat->Set2dRenderMode(math::RigidTransform(Vector3d{0, -3, 0}), -4, 4, -2,


### PR DESCRIPTION
By default, a new window still starts with the control panel hidden, and an "Open Controls" button in the upper right.  The difference now is that when a user clicks "Open Controls", the "drake" sub-tree is unfolded by default.  See the samples below (after clicking "Open Controls").

---

Here's what it looks like now in `model_visualizer` after running its default command line.

![image](https://github.com/RobotLocomotion/drake/assets/17596505/a3c764f4-4fe4-4590-8f0d-1ea663a43106)

---

Here's what it looks like in Meldis (using `//examples/hardware_sim`):

![image](https://github.com/RobotLocomotion/drake/assets/17596505/9e414063-661e-4a8d-82ab-a1ed924fa134)

---

Here's what it looks like for code (e.g., `meshcat_manual_test`) that doesn't use the `MeshcatVisualizer` system:

![image](https://github.com/RobotLocomotion/drake/assets/17596505/b287e10a-8e4a-4926-85fa-1bcb0c5ca902)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20797)
<!-- Reviewable:end -->
