### PR TITLE
[geometry]  Accelerate initialization of compliant-hydroelastic nonconvex meshes

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -120,9 +120,14 @@ drake_cc_library(
     hdrs = ["calc_distance_to_surface_mesh.h"],
     internal = True,
     visibility = ["//visibility:private"],
-    deps = [
+    interface_deps = [
+        ":bv",
+        ":bvh",
         ":triangle_surface_mesh",
         "//common:essential",
+    ],
+    deps = [
+        ":distance_to_point_callback",
         "//math:geometric_transform",
     ],
 )
@@ -942,6 +947,7 @@ drake_cc_googletest(
     name = "calc_distance_to_surface_mesh_test",
     deps = [
         ":calc_distance_to_surface_mesh",
+        ":make_box_mesh",
     ],
 )
 

--- a/geometry/proximity/calc_distance_to_surface_mesh.cc
+++ b/geometry/proximity/calc_distance_to_surface_mesh.cc
@@ -4,11 +4,16 @@
 #include <limits>
 #include <vector>
 
+#include "drake/geometry/proximity/distance_to_point_callback.h"
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+
 namespace {
 
 /* Struct to hold vertex positions of a triangle. */
@@ -112,23 +117,90 @@ double CalcSquaredDistanceToTriangle(const Vector3<double>& p_WQ,
   return std::min({d_AB_squared, d_AC_squared, d_BC_squared});
 }
 
+// TODO(xuchenhan-tri): Consider using the algorithm presented in chapter 5.1.5
+//  of "Real Time Collision Detection" (Christer Ericson) with fewer flops if
+//  performance is an issue for CalcSquaredDistanceToTriangle().
+
+class BvhVisitor {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BvhVisitor);
+
+  static double CalcMinDistance(
+      const Vector3d& p_WQ, const TriangleSurfaceMesh<double>& mesh_W,
+      const Bvh<Obb, TriangleSurfaceMesh<double>>::NodeType& node_W) {
+    BvhVisitor visitor{p_WQ, mesh_W};
+    visitor.Visit(node_W);
+    return std::sqrt(visitor.min_squared_);
+  }
+
+ private:
+  BvhVisitor(const Vector3d& p_WQ, const TriangleSurfaceMesh<double>& mesh_W)
+      : p_WQ_{p_WQ}, mesh_W_{mesh_W} {}
+
+  void Visit(const Bvh<Obb, TriangleSurfaceMesh<double>>::NodeType& node_W) {
+    if (node_W.is_leaf()) {
+      for (int i = 0; i < node_W.num_element_indices(); ++i) {
+        const SurfaceTriangle& t = mesh_W_.triangles()[node_W.element_index(i)];
+        min_squared_ = std::min(min_squared_,
+                                CalcSquaredDistanceToTriangle(
+                                    p_WQ_, {mesh_W_.vertices()[t.vertex(0)],
+                                            mesh_W_.vertices()[t.vertex(1)],
+                                            mesh_W_.vertices()[t.vertex(2)]}));
+      }
+      return;
+    }
+
+    // The rest of this function is for the subtree of the internal node rooted
+    // at node_W.
+
+    const Vector3d box_half_width_B = node_W.bv().half_width();
+    const RigidTransformd& X_WB = node_W.bv().pose();
+    const Vector3d p_BQ = X_WB.inverse() * p_WQ_;
+
+    const auto [closest_point_on_box_boundary_B, grad_signed_distance_B, _] =
+        point_distance::DistanceToPoint<double>::ComputeDistanceToBox<3>(
+            box_half_width_B, p_BQ);
+    // Mathematically we can calculate the signed distance phi from the gradient
+    // grad_phi, the query point Q and its closest point C on the box's
+    // boundary as:
+    //      phi = grad_phi.dot(Q - C)
+    // because:
+    // 1. The unsigned distance is clearly |Q-C|. We just need to set the
+    //    correct sign depending on the location of Q relative to the box.
+    // 2. grad_phi is a unit vector pointing outward from the box.  It is
+    //    parallel to Q-C (or antiparallel if Q is inside the box).
+    const double signed_distance =
+        grad_signed_distance_B.dot(p_BQ - closest_point_on_box_boundary_B);
+
+    // Check for possible pruning.
+    if (signed_distance > 0) {
+      // The query point is outside, so we can get the lower bound.
+      const double squared_distance_from_this_node_is_at_least =
+          signed_distance * signed_distance;
+      // Use the lower bound to possibly prune this subtree.
+      if (squared_distance_from_this_node_is_at_least > min_squared_) {
+        return;
+      }
+    }
+
+    // We couldn't prune the subtree, recursively search both children.
+    this->Visit(node_W.left());
+    this->Visit(node_W.right());
+  }
+
+ private:
+  const Vector3<double>& p_WQ_;
+  const TriangleSurfaceMesh<double>& mesh_W_;
+
+  double min_squared_{std::numeric_limits<double>::infinity()};
+};
+
 }  // namespace
 
-// TODO(xuchenhan-tri): Consider using the algorithm presented in chapter 5.1.5
-// of "Real Time Collision Detection" (Christer Ericson) with fewer flops if
-// performance is an issue.
-double CalcDistanceToSurfaceMesh(const Vector3<double>& p_WQ,
-                                 const TriangleSurfaceMesh<double>& mesh_W) {
-  double distance_squared = std::numeric_limits<double>::infinity();
-  const std::vector<Vector3<double>>& vertices = mesh_W.vertices();
-  for (const SurfaceTriangle& t : mesh_W.triangles()) {
-    distance_squared =
-        std::min(distance_squared,
-                 CalcSquaredDistanceToTriangle(
-                     p_WQ, {vertices[t.vertex(0)], vertices[t.vertex(1)],
-                            vertices[t.vertex(2)]}));
-  }
-  return std::sqrt(distance_squared);
+double CalcDistanceToSurfaceMesh(
+    const Vector3<double>& p_WQ, const TriangleSurfaceMesh<double>& mesh_W,
+    const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_W) {
+  return BvhVisitor::CalcMinDistance(p_WQ, mesh_W, bvh_W.root_node());
 }
 
 }  // namespace internal

--- a/geometry/proximity/calc_distance_to_surface_mesh.h
+++ b/geometry/proximity/calc_distance_to_surface_mesh.h
@@ -1,18 +1,21 @@
 #pragma once
 
+#include "drake/geometry/proximity/bvh.h"
+#include "drake/geometry/proximity/obb.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
-// TODO(xuchenhan-tri): This uses an inefficient O(number of triangles)
-// algorithm and can be accelerated with a BVH.
 /* Computes the shortest unsigned distance between the point p_WQ and any point
- on the surface mesh `mesh_W`. The returned valued is non-negative.
+ on the surface mesh `mesh_W`. The returned value is non-negative.
+ The algorithm is accelerated with the bounding volume hierarchy `bvh_W` of
+ the surface mesh.
  @pre Each element in `mesh_W` has non-zero area. */
-double CalcDistanceToSurfaceMesh(const Vector3<double>& p_WQ,
-                                 const TriangleSurfaceMesh<double>& mesh_W);
+double CalcDistanceToSurfaceMesh(
+    const Vector3<double>& p_WQ, const TriangleSurfaceMesh<double>& mesh_W,
+    const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_W);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/deformable_contact_geometries.cc
+++ b/geometry/proximity/deformable_contact_geometries.cc
@@ -25,15 +25,22 @@ using std::vector;
 std::unique_ptr<VolumeMeshFieldLinear<double, double>>
 ApproximateSignedDistanceField(const VolumeMesh<double>* mesh) {
   DRAKE_DEMAND(mesh != nullptr);
+  const int num_vertices = mesh->num_vertices();
   vector<double> signed_distance;
-  signed_distance.reserve(mesh->num_vertices());
+  signed_distance.reserve(num_vertices);
+  std::vector<int> boundary_vertices;
   const TriangleSurfaceMesh<double> surface_mesh =
-      ConvertVolumeToSurfaceMesh(*mesh);
-  /* The values for vertices on the surface are zero (to the accuracy of
-   `CalcDistanceSurfaceMesh`). */
-  for (const Vector3<double>& vertex : mesh->vertices()) {
-    signed_distance.emplace_back(
-        -CalcDistanceToSurfaceMesh(vertex, surface_mesh));
+      ConvertVolumeToSurfaceMeshWithBoundaryVertices(*mesh, &boundary_vertices);
+  const Bvh<Obb, TriangleSurfaceMesh<double>> bvh_of_surface(surface_mesh);
+  auto boundary_iter = boundary_vertices.begin();
+  for (int v = 0; v < num_vertices; ++v) {
+    if (boundary_iter != boundary_vertices.end() && *boundary_iter == v) {
+      ++boundary_iter;
+      signed_distance.push_back(0);
+      continue;
+    }
+    signed_distance.emplace_back(-CalcDistanceToSurfaceMesh(
+        mesh->vertex(v), surface_mesh, bvh_of_surface));
   }
   return make_unique<VolumeMeshFieldLinear<double, double>>(
       std::move(signed_distance), mesh);

--- a/geometry/proximity/make_mesh_field.cc
+++ b/geometry/proximity/make_mesh_field.cc
@@ -8,6 +8,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/extract_double.h"
+#include "drake/common/ssize.h"
 #include "drake/geometry/proximity/calc_distance_to_surface_mesh.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/proximity/volume_to_surface_mesh.h"
@@ -20,8 +21,10 @@ namespace {
 
 template <typename T>
 TriangleSurfaceMesh<double> ConvertVolumeToSurfaceMeshDouble(
-    const VolumeMesh<T>& volume_mesh) {
-  TriangleSurfaceMesh<T> surface = ConvertVolumeToSurfaceMesh(volume_mesh);
+    const VolumeMesh<T>& volume_mesh, std::vector<int>* boundary_vertices) {
+  TriangleSurfaceMesh<T> surface =
+      ConvertVolumeToSurfaceMeshWithBoundaryVertices(volume_mesh,
+                                                     boundary_vertices);
   if constexpr (std::is_same_v<T, double>) {
     return surface;
   } else {
@@ -43,9 +46,10 @@ VolumeMeshFieldLinear<T, T> MakeVolumeMeshPressureField(
     const VolumeMesh<T>* mesh_M, const T& hydroelastic_modulus) {
   DRAKE_DEMAND(hydroelastic_modulus > T(0));
   DRAKE_DEMAND(mesh_M != nullptr);
+  std::vector<int> boundary_vertices;
   // The subscript _d is for the scalar type double.
   TriangleSurfaceMesh<double> surface_d =
-      ConvertVolumeToSurfaceMeshDouble(*mesh_M);
+      ConvertVolumeToSurfaceMeshDouble(*mesh_M, &boundary_vertices);
 
   // TODO(DamrongGuoy): Check whether there could be numerical roundings that
   //  cause a vertex on the boundary to have a non-zero value. Consider
@@ -54,10 +58,18 @@ VolumeMeshFieldLinear<T, T> MakeVolumeMeshPressureField(
   std::vector<T> pressure_values;
   T max_value(std::numeric_limits<double>::lowest());
   // First round, it's actually unsigned distance, not pressure values yet.
-  for (const Vector3<T>& p_MV : mesh_M->vertices()) {
-    Vector3<double> p_MV_d = ExtractDoubleOrThrow(p_MV);
-    T pressure(internal::CalcDistanceToSurfaceMesh(p_MV_d, surface_d));
-    pressure_values.emplace_back(pressure);
+  const Bvh<Obb, TriangleSurfaceMesh<double>> bvh(surface_d);
+  auto boundary_iter = boundary_vertices.begin();
+  for (int v = 0; v < ssize(mesh_M->vertices()); ++v) {
+    if (boundary_iter != boundary_vertices.end() && *boundary_iter == v) {
+      ++boundary_iter;
+      pressure_values.push_back(0);
+      continue;
+    }
+    const Vector3<T>& p_MV = mesh_M->vertex(v);
+    const Vector3<double> p_MV_d = ExtractDoubleOrThrow(p_MV);
+    T pressure = internal::CalcDistanceToSurfaceMesh(p_MV_d, surface_d, bvh);
+    pressure_values.push_back(pressure);
     if (max_value < pressure) {
       max_value = pressure;
     }

--- a/geometry/proximity/test/calc_distance_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/calc_distance_to_surface_mesh_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/geometry/proximity/make_box_mesh.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
@@ -71,7 +72,9 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, SingleTriangle) {
 
   vector<Vector3d> vertices = {X_WT * p_TA, X_WT * p_TB, X_WT * p_TC};
   vector<SurfaceTriangle> triangles = {{0, 1, 2}};
-  TriangleSurfaceMesh<double> mesh_W(std::move(triangles), std::move(vertices));
+  const TriangleSurfaceMesh<double> mesh_W(std::move(triangles),
+                                           std::move(vertices));
+  const Bvh<Obb, TriangleSurfaceMesh<double>> bvh_W(mesh_W);
 
   constexpr double kEps = 1e-14;
   constexpr double kZScale = 0.5;
@@ -86,7 +89,7 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, SingleTriangle) {
       const Vector3d p_TQ(0.25, 0.25, sign_z * kZScale);
       const Vector3d p_WQ = X_WT * p_TQ;
       EXPECT_NEAR(CalcDistanceToTxyPlane(p_TQ),
-                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W), kEps);
+                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W, bvh_W), kEps);
     }
   }
   // Region 1.
@@ -96,7 +99,7 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, SingleTriangle) {
       const Vector3d p_TQ(0.25, -0.25, sign_z * kZScale);
       const Vector3d p_WQ = X_WT * p_TQ;
       EXPECT_NEAR(CalcDistanceToLine(p_TQ, {p_TA, p_TB}),
-                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W), kEps);
+                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W, bvh_W), kEps);
     }
   }
   // Region 2.
@@ -106,7 +109,7 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, SingleTriangle) {
       const Vector3d p_TQ(-0.25, -0.25, sign_z * kZScale);
       const Vector3d p_WQ = X_WT * p_TQ;
       EXPECT_NEAR(CalcDistanceToPoint(p_TQ, p_TA),
-                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W), kEps);
+                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W, bvh_W), kEps);
     }
   }
   // Region 3.
@@ -116,7 +119,7 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, SingleTriangle) {
       const Vector3d p_TQ(-0.25, 0.0, sign_z * kZScale);
       const Vector3d p_WQ = X_WT * p_TQ;
       EXPECT_NEAR(CalcDistanceToLine(p_TQ, {p_TA, p_TC}),
-                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W), kEps);
+                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W, bvh_W), kEps);
     }
   }
   // Region 4.
@@ -126,7 +129,7 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, SingleTriangle) {
       const Vector3d p_TQ(-0.25, 1.5, sign_z * kZScale);
       const Vector3d p_WQ = X_WT * p_TQ;
       EXPECT_NEAR(CalcDistanceToPoint(p_TQ, p_TC),
-                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W), kEps);
+                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W, bvh_W), kEps);
     }
   }
   // Region 5.
@@ -136,7 +139,7 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, SingleTriangle) {
       const Vector3d p_TQ(1.0, 1.5, sign_z * kZScale);
       const Vector3d p_WQ = X_WT * p_TQ;
       EXPECT_NEAR(CalcDistanceToLine(p_TQ, {p_TB, p_TC}),
-                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W), kEps);
+                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W, bvh_W), kEps);
     }
   }
   // Region 6.
@@ -146,7 +149,7 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, SingleTriangle) {
       const Vector3d p_TQ(1.2, -0.3, sign_z * kZScale);
       const Vector3d p_WQ = X_WT * p_TQ;
       EXPECT_NEAR(CalcDistanceToPoint(p_TQ, p_TB),
-                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W), kEps);
+                  CalcDistanceToSurfaceMesh(p_WQ, mesh_W, bvh_W), kEps);
     }
   }
 }
@@ -186,7 +189,9 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, MultipleTriangles2) {
   vector<Vector3d> vertices = {X_WT * p_TA, X_WT * p_TB, X_WT * p_TC,
                                X_WT * p_TD};
   vector<SurfaceTriangle> triangles = {{0, 1, 2}, {1, 2, 3}};
-  TriangleSurfaceMesh<double> mesh_W(std::move(triangles), std::move(vertices));
+  const TriangleSurfaceMesh<double> mesh_W(std::move(triangles),
+                                           std::move(vertices));
+  const Bvh<Obb, TriangleSurfaceMesh<double>> bvh_W(mesh_W);
 
   constexpr double kEps = 1e-14;
   /* Q lines on the z-axis half way up. Its distance to the mesh should be equal
@@ -196,7 +201,7 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, MultipleTriangles2) {
   const double d_Q_expected =
       CalcDistanceToLine(p_TQ, {Vector3d::UnitX(), Vector3d::UnitZ()});
   const Vector3d p_WQ = X_WT * p_TQ;
-  const double d_Q = CalcDistanceToSurfaceMesh(p_WQ, mesh_W);
+  const double d_Q = CalcDistanceToSurfaceMesh(p_WQ, mesh_W, bvh_W);
   EXPECT_NEAR(d_Q, d_Q_expected, kEps);
 
   /* Perturbation amount (as introduced in the test description). Any positive
@@ -206,12 +211,32 @@ GTEST_TEST(CalcDistanceToSurfaceMeshTest, MultipleTriangles2) {
   /* Q1 is slightly to the left of Q. */
   const Vector3d p_TQ1 = p_TQ + Vector3d{-kPerturb, 0, 0};
   const Vector3d p_WQ1 = X_WT * p_TQ1;
-  EXPECT_LT(CalcDistanceToSurfaceMesh(p_WQ1, mesh_W), d_Q);
+  EXPECT_LT(CalcDistanceToSurfaceMesh(p_WQ1, mesh_W, bvh_W), d_Q);
 
   /* Q2 is slightly to the right of Q. */
   const Vector3d p_TQ2 = p_TQ + Vector3d{kPerturb, 0, 0};
   const Vector3d p_WQ2 = X_WT * p_TQ2;
-  EXPECT_LT(CalcDistanceToSurfaceMesh(p_WQ2, mesh_W), d_Q);
+  EXPECT_LT(CalcDistanceToSurfaceMesh(p_WQ2, mesh_W, bvh_W), d_Q);
+}
+
+/* This is a coverage test (kcov) of the recursive search. We use many
+ surface triangles of a long box with the query point at the box center, so
+ the search likely consists of both pruning steps and recursive steps.
+ See https://drake.mit.edu/bazel.html#kcov how to run kcov locally.  */
+GTEST_TEST(CalcDistanceToSurfaceMeshTest, ManyTrianglesForRecursion) {
+  const double kLongLength = 0.04;   // 4cm
+  const double kShortLength = 0.01;  // 1cm
+  const double kResolution = 0.005;  // 5mm
+  const TriangleSurfaceMesh<double> surface_W = MakeBoxSurfaceMesh<double>(
+      Box(kLongLength, kShortLength, kShortLength), kResolution);
+  // Confirm there are many triangles in the surface mesh enough for covering
+  // the recursive search.
+  ASSERT_EQ(surface_W.num_triangles(), 144);
+  const Bvh<Obb, TriangleSurfaceMesh<double>> bvh_W(surface_W);
+
+  const double distance_from_center =
+      CalcDistanceToSurfaceMesh(Vector3d::Zero(), surface_W, bvh_W);
+  EXPECT_NEAR(distance_from_center, kShortLength / 2, 1e-10);
 }
 
 }  // namespace

--- a/geometry/proximity/volume_to_surface_mesh.cc
+++ b/geometry/proximity/volume_to_surface_mesh.cc
@@ -116,14 +116,13 @@ std::vector<int> CollectUniqueVertices(
   return std::vector<int>(vertex_set.begin(), vertex_set.end());
 }
 
-}  // namespace internal
-
 template <class T>
-TriangleSurfaceMesh<T> ConvertVolumeToSurfaceMesh(const VolumeMesh<T>& volume) {
+TriangleSurfaceMesh<T> ConvertVolumeToSurfaceMeshWithBoundaryVertices(
+    const VolumeMesh<T>& volume, std::vector<int>* boundary_vertices_out) {
   const std::vector<std::array<int, 3>> boundary_faces =
       internal::IdentifyBoundaryFaces(volume.tetrahedra());
 
-  const std::vector<int> boundary_vertices =
+  std::vector<int> boundary_vertices =
       internal::CollectUniqueVertices(boundary_faces);
 
   std::vector<Vector3<T>> surface_vertices;
@@ -145,12 +144,16 @@ TriangleSurfaceMesh<T> ConvertVolumeToSurfaceMesh(const VolumeMesh<T>& volume) {
                                volume_to_surface.at(face_vertices[2]));
   }
 
+  if (boundary_vertices_out != nullptr) {
+    *boundary_vertices_out = std::move(boundary_vertices);
+  }
   return TriangleSurfaceMesh<T>(std::move(surface_faces),
                                 std::move(surface_vertices));
 }
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    (&ConvertVolumeToSurfaceMesh<T>))
+    (&ConvertVolumeToSurfaceMeshWithBoundaryVertices<T>))
 
+}  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/volume_to_surface_mesh.h
+++ b/geometry/proximity/volume_to_surface_mesh.h
@@ -30,10 +30,22 @@ std::vector<std::array<int, 3>> IdentifyBoundaryFaces(
  multiple faces is reported once. Each face is represented as an array of
  three vertices of a volume mesh.
  @param[in] faces
- @return    vertices used by the faces.
+ @return    vertices used by the faces. The vertex indices are sorted in
+            increasing order.
  */
 std::vector<int> CollectUniqueVertices(
     const std::vector<std::array<int, 3>>& faces);
+
+/*
+ Implements the public API ConvertVolumeToSurfaceMesh() with optional return
+ of the boundary vertices that we can use internally.
+     The returned integer indices are sorted in increasing order and refer
+ to vertices in the input `volume` mesh.
+ */
+template <class T>
+TriangleSurfaceMesh<T> ConvertVolumeToSurfaceMeshWithBoundaryVertices(
+    const VolumeMesh<T>& volume,
+    std::vector<int>* boundary_vertices_out = nullptr);
 
 }  // namespace internal
 
@@ -50,7 +62,10 @@ std::vector<int> CollectUniqueVertices(
                 boundary triangles of the volume.
  @tparam_nonsymbolic_scalar */
 template <class T>
-TriangleSurfaceMesh<T> ConvertVolumeToSurfaceMesh(const VolumeMesh<T>& volume);
+TriangleSurfaceMesh<T> ConvertVolumeToSurfaceMesh(const VolumeMesh<T>& volume) {
+  return internal::ConvertVolumeToSurfaceMeshWithBoundaryVertices(volume,
+                                                                  nullptr);
+}
 
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
Speed up loading a tetrahedral-mesh VTK file. Improve pressure-field computation from O(mn) to O(n log n + m log n) using BVH, about 10X speed up in practice for moderate meshes.

Use BVH in CalcDistanceToSurfaceMesh.

Prequel of #20774.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20798)
<!-- Reviewable:end -->
