### PR TITLE
[tools] Disable kcov for exported_symbols_test

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -260,6 +260,7 @@ drake_py_unittest(
     data = [
         ":libdrake.so",
     ],
+    tags = ["no_kcov"],
 )
 
 drake_py_unittest(


### PR DESCRIPTION
Avoids a crash that was breaking coverage uploads in CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20800)
<!-- Reviewable:end -->
