### PR TITLE
Enable clang_format for multibody/topology directory

### DIFF
--- a/multibody/topology/BUILD.bazel
+++ b/multibody/topology/BUILD.bazel
@@ -32,4 +32,4 @@ drake_cc_googletest(
     ],
 )
 
-add_lint_tests(enable_clang_format_lint = False)
+add_lint_tests()

--- a/multibody/topology/multibody_graph.cc
+++ b/multibody/topology/multibody_graph.cc
@@ -141,9 +141,8 @@ JointIndex MultibodyGraph::AddJoint(const std::string& name,
     const auto& new_child = get_body(child_body_index);
     throw std::runtime_error(
         "This MultibodyGraph already has a joint '" + existing_joint.name() +
-        "' connecting '" + existing_parent.name() +
-        "' to '" + existing_child.name() +
-        "'. Therefore adding joint '" + name +
+        "' connecting '" + existing_parent.name() + "' to '" +
+        existing_child.name() + "'. Therefore adding joint '" + name +
         "' connecting '" + new_parent.name() + "' to '" + new_child.name() +
         "' is not allowed.");
   }


### PR DESCRIPTION
Sets `enable_clang_format_lint` to `True`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20801)
<!-- Reviewable:end -->
