### PR TITLE
Disable two tests on macOS that fail with upgraded OpenBLAS

### DIFF
--- a/examples/pendulum/BUILD.bazel
+++ b/examples/pendulum/BUILD.bazel
@@ -120,7 +120,15 @@ drake_cc_binary(
     srcs = ["trajectory_optimization_simulation.cc"],
     add_test_rule = 1,
     data = [":models"],
-    test_rule_args = ["--target_realtime_rate=0.0"],
+    test_rule_args = ["--target_realtime_rate=0.0"] + select({
+        "@platforms//os:osx": [
+            # TODO(#20799) This started failing when OpenBLAS was upgraded.
+            # When we drop this nerf we should also drop the supporting
+            # `DEFINE_bool(ignore_solve_errors, ...)` in the program itself.
+            "--ignore_solve_errors",
+        ],
+        "//conditions:default": [],
+    }),
     # Non-deterministic IPOPT-related failures on macOS, see #10276.
     test_rule_flaky = 1,
     deps = [

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -503,6 +503,13 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "iris_test",
+    args = select({
+        "@platforms//os:osx": [
+            # TODO(#20799) This test sometimes panics when run with OpenBLAS.
+            "--gtest_filter=-SceneGraphTester.MultipleBoxes",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         ":iris",
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
Towards #20799.

Since we have no `WORKSPACE` control over the BLAS version that Homebrew ships, we need to disable tests to get CI back to green.  Then in due time we can work to overcome the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20803)
<!-- Reviewable:end -->
