### PR TITLE
Bind Hyperrectangle::MaybeCalcAxisAlignedBoundingBox

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -346,7 +346,10 @@ void DefineGeometryOptimization(py::module m) {
             },
             [](std::pair<Eigen::VectorXd, Eigen::VectorXd> args) {
               return Hyperrectangle(std::get<0>(args), std::get<1>(args));
-            }));
+            }))
+        .def_static("MaybeCalcAxisAlignedBoundingBox",
+            &Hyperrectangle::MaybeCalcAxisAlignedBoundingBox, py::arg("set"),
+            cls_doc.MaybeCalcAxisAlignedBoundingBox.doc);
   }
 
   // Intersection

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -379,6 +379,10 @@ class TestGeometryOptimization(unittest.TestCase):
         np.testing.assert_array_equal(hpoly.b(), box.b())
         assert_pickle(self, rect, lambda S: np.vstack((S.lb(), S.ub())))
 
+        other = mut.VPolytope(np.eye(2))
+        bbox = mut.Hyperrectangle.MaybeCalcAxisAlignedBoundingBox(set=other)
+        self.assertIsInstance(bbox, mut.Hyperrectangle)
+
     def test_minkowski_sum(self):
         mut.MinkowskiSum()
         point = mut.Point(np.array([11.1, 12.2, 13.3]))


### PR DESCRIPTION
Very small PR to create a python binding for the static method `Hyperrectangle::MaybeCalcAxisAlignedBoundingBox`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20804)
<!-- Reviewable:end -->
