### PR TITLE
[multibody] Adds LinkJointGraph skeleton

### DIFF
--- a/multibody/topology/BUILD.bazel
+++ b/multibody/topology/BUILD.bazel
@@ -32,4 +32,34 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_library(
+    name = "multibody_topology",
+    srcs = [
+        "link_joint_graph.cc",
+        "spanning_forest.cc",
+    ],
+    hdrs = [
+        "forest.h",
+        "graph.h",
+        "link_joint_graph.h",
+        "link_joint_graph_defs.h",
+        "link_joint_graph_inlines.h",
+        "link_joint_graph_joint.h",
+        "link_joint_graph_link.h",
+        "spanning_forest.h",
+    ],
+    deps = [
+        "//common:copyable_unique_ptr",
+        "//multibody/tree:multibody_tree_indexes",
+    ],
+)
+
+drake_cc_googletest(
+    name = "link_joint_graph_test",
+    deps = [
+        ":multibody_topology",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
 add_lint_tests()

--- a/multibody/topology/forest.h
+++ b/multibody/topology/forest.h
@@ -1,0 +1,18 @@
+#pragma once
+
+/** @file
+This is the file to #include to use SpanningForest. It includes
+subsidiary headers for nested class definitions to keep file sizes
+reasonable. */
+
+// TODO(sherm1) Not used yet by MultibodyPlant; see PR #20225.
+
+#define DRAKE_MULTIBODY_TOPOLOGY_FOREST_INCLUDED
+
+// Don't alpha-sort these internal includes; the order matters.
+// clang-format off
+#include "drake/multibody/topology/spanning_forest.h"
+// TODO(sherm1) More to come.
+// clang-format on
+
+#undef DRAKE_MULTIBODY_TOPOLOGY_FOREST_INCLUDED

--- a/multibody/topology/graph.h
+++ b/multibody/topology/graph.h
@@ -1,0 +1,20 @@
+#pragma once
+
+/** @file
+This is the file to #include to use LinkJointGraph. It includes
+subsidiary headers for nested class definitions to keep file sizes
+reasonable. */
+
+// TODO(sherm1) Not used yet by MultibodyPlant; see PR #20225.
+
+#define DRAKE_MULTIBODY_TOPOLOGY_GRAPH_INCLUDED
+
+// Don't alpha-sort these internal includes; the order matters.
+// clang-format off
+#include "drake/multibody/topology/link_joint_graph.h"
+#include "drake/multibody/topology/link_joint_graph_link.h"
+#include "drake/multibody/topology/link_joint_graph_joint.h"
+#include "drake/multibody/topology/link_joint_graph_inlines.h"
+// clang-format on
+
+#undef DRAKE_MULTIBODY_TOPOLOGY_GRAPH_INCLUDED

--- a/multibody/topology/link_joint_graph.cc
+++ b/multibody/topology/link_joint_graph.cc
@@ -1,0 +1,257 @@
+// NOLINTNEXTLINE(build/include): prevent complaint re link_joint_graph.h
+#include <fmt/format.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/multibody/topology/forest.h"
+#include "drake/multibody/topology/graph.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+LinkJointGraph::LinkJointGraph() {
+  Clear();
+}
+
+LinkJointGraph::LinkJointGraph(const LinkJointGraph& source)
+    : data_(source.data_) {
+  data_.forest->SetNewOwner(this);
+}
+
+LinkJointGraph::LinkJointGraph(LinkJointGraph&& source)
+    : data_(std::move(source.data_)) {
+  data_.forest->SetNewOwner(this);
+  source.Clear();
+}
+
+LinkJointGraph& LinkJointGraph::operator=(const LinkJointGraph& source) {
+  if (&source != this) {
+    data_ = source.data_;
+    data_.forest->SetNewOwner(this);
+  }
+  return *this;
+}
+
+LinkJointGraph& LinkJointGraph::operator=(LinkJointGraph&& source) {
+  if (&source != this) {
+    data_ = std::move(source.data_);
+    data_.forest->SetNewOwner(this);
+    source.Clear();
+  }
+  return *this;
+}
+
+void LinkJointGraph::Clear() {
+  // Preserve the SpanningForest if we have one already; we'll strip
+  // the contents below.
+  SpanningForest* saved_forest = data_.forest.release();
+
+  // Clear everything (marks the forest invalid).
+  data_ = Data{};
+
+  if (saved_forest != nullptr) {
+    saved_forest->Clear();        // Nothing useful there now.
+    data_.forest = saved_forest;  // Keep using the old object.
+  } else {
+    // Constructor is private so we can't use make_unique.
+    data_.forest = std::unique_ptr<SpanningForest>(new SpanningForest(this));
+  }
+
+  // Now take actions required by default construction.
+
+  // Joint type names used here must match the kTypeName members of the
+  // matching Drake Joint types. Order matters here so we match the
+  // predefined joint type indices.
+  DRAKE_DEMAND(RegisterJointType("weld", 0, 0) == weld_joint_type_index());
+  DRAKE_DEMAND(RegisterJointType("quaternion_floating", 7, 6, true) ==
+               quaternion_floating_joint_type_index());
+  DRAKE_DEMAND(RegisterJointType("rpy_floating", 6, 6) ==
+               rpy_floating_joint_type_index());
+
+  // Define the World Link.
+  const BodyIndex world_index = AddLink("world", world_model_instance());
+  DRAKE_DEMAND(world_index == BodyIndex(0));
+}
+
+void LinkJointGraph::BuildForest() {
+  InvalidateForest();
+  data_.forest->BuildForest();  // (Re)build
+  data_.forest_is_valid = true;
+}
+
+void LinkJointGraph::InvalidateForest() {
+  if (!forest_is_valid()) {
+    // Nothing to do but a few sanity checks.
+    DRAKE_DEMAND(ssize(data_.link_name_to_index) == data_.num_user_links);
+    DRAKE_DEMAND(ssize(data_.joint_name_to_index) == data_.num_user_joints);
+    DRAKE_DEMAND(data_.ephemeral_link_name_to_index.empty());
+    DRAKE_DEMAND(data_.ephemeral_joint_name_to_index.empty());
+    DRAKE_DEMAND(data_.link_composites.empty());
+    return;
+  }
+
+  // Gut the forest so it doesn't look valid when it's not.
+  DRAKE_DEMAND(data_.forest != nullptr);
+  data_.forest->Clear();
+  data_.forest_is_valid = false;
+
+  // Remove any ephemeral elements from the graph.
+  data_.links.erase(data_.links.begin() + data_.num_user_links,
+                    data_.links.end());
+  data_.joints.erase(data_.joints.begin() + data_.num_user_joints,
+                     data_.joints.end());
+
+  data_.ephemeral_link_name_to_index.clear();
+  data_.ephemeral_joint_name_to_index.clear();
+
+  // Remove all as-modeled information from the graph.
+  for (auto& link : data_.links) link.clear_model(data_.num_user_joints);
+  for (auto& joint : data_.joints) joint.clear_model();
+  data_.link_composites.clear();
+}
+
+const LinkJointGraph::Link& LinkJointGraph::world_link() const {
+  DRAKE_DEMAND(!links().empty());  // World is predefined at construction.
+  return links(BodyIndex(0));
+}
+
+BodyIndex LinkJointGraph::AddLink(const std::string& link_name,
+                                  ModelInstanceIndex model_instance,
+                                  LinkFlags flags) {
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  // Reject use of world model instance for any Link other than World.
+  if (ssize(links()) > 0 && model_instance == world_model_instance()) {
+    throw std::logic_error(fmt::format(
+        "{}(): Model instance index {} is reserved for the World link. "
+        " World is always predefined and is named '{}'.",
+        __func__, world_model_instance(), world_link().name()));
+  }
+
+  // Reject duplicate Link name.
+  if (HasLinkNamed(link_name, model_instance)) {
+    throw std::logic_error(
+        fmt::format("{}(): There is already a link named '{}' in "
+                    "the model instance with index {}.",
+                    __func__, link_name, model_instance));
+  }
+
+  // Reject addition of a Shadow link this way; that can only be set during
+  // forest building.
+  if (static_cast<bool>(flags & LinkFlags::kShadow)) {
+    throw std::logic_error(
+        fmt::format("{}(): Can't add link '{}' with the kShadow flag "
+                    "set. That can only be set by BuildForest().",
+                    __func__, link_name));
+  }
+
+  // If we have a SpanningForest, it's no good now.
+  InvalidateForest();
+
+  const BodyIndex link_index(ssize(links()));  // next available
+  // provide fast name lookup
+  data_.link_name_to_index.insert({link_name, link_index});
+
+  data_.links.emplace_back(Link(link_index, link_name, model_instance, flags));
+  data_.num_user_links = ssize(links());
+
+  Link& new_link = data_.links.back();
+
+  // These lists allow for efficient forest building but aren't otherwise
+  // useful. Note that if a link goes on the static list it must be a base
+  // body so we don't add it separately to the must_be_base_body list.
+  if (new_link.is_static()) {
+    data_.static_links.push_back(link_index);
+  } else if (new_link.must_be_base_body()) {
+    data_.non_static_must_be_base_body_links.push_back(link_index);
+  }
+
+  std::vector<BodyIndex>& links = data_.model_instance_to_links[model_instance];
+  links.push_back(link_index);
+
+  return link_index;
+}
+
+bool LinkJointGraph::HasLinkNamed(const std::string& name,
+                                  ModelInstanceIndex model_instance) const {
+  DRAKE_DEMAND(model_instance.is_valid());
+
+  // Search linearly on the assumption that we won't often have lots of
+  // Links with the same name in different model instances.  If this turns
+  // out to be incorrect we can switch to a different data structure.
+  const auto range = data_.link_name_to_index.equal_range(name);
+  for (auto it = range.first; it != range.second; ++it) {
+    if (links(it->second).model_instance() == model_instance) return true;
+  }
+
+  const auto model_range = data_.ephemeral_link_name_to_index.equal_range(name);
+  for (auto it = model_range.first; it != model_range.second; ++it) {
+    if (links(it->second).model_instance() == model_instance) return true;
+  }
+
+  return false;
+}
+
+JointTypeIndex LinkJointGraph::RegisterJointType(
+    const std::string& joint_type_name, int nq, int nv, bool has_quaternion) {
+  // Reject duplicate type name.
+  const auto it = data_.joint_type_name_to_index.find(joint_type_name);
+  if (it != data_.joint_type_name_to_index.end()) {
+    throw std::logic_error(fmt::format("{}(): Duplicate joint type: '{}'.",
+                                       __func__, joint_type_name));
+  }
+
+  // Sanity check the joint parameters.
+  DRAKE_DEMAND(0 <= nq && nq <= 7 && 0 <= nv && nv <= 6 && nv <= nq);
+  DRAKE_DEMAND(!has_quaternion || nq >= 4);
+
+  const JointTypeIndex joint_type_index(data_.joint_types.size());
+  data_.joint_types.push_back({.type_name = joint_type_name,
+                               .nq = nq,
+                               .nv = nv,
+                               .has_quaternion = has_quaternion});
+  data_.joint_type_name_to_index[joint_type_name] = joint_type_index;
+  DRAKE_DEMAND(data_.joint_type_name_to_index.size() ==
+               data_.joint_types.size());
+  return joint_type_index;
+}
+
+LinkJointGraph::Data::Data() = default;
+LinkJointGraph::Data::Data(const Data&) = default;
+LinkJointGraph::Data::Data(Data&&) = default;
+LinkJointGraph::Data::~Data() = default;
+auto LinkJointGraph::Data::operator=(const Data&) -> Data& = default;
+auto LinkJointGraph::Data::operator=(Data&&) -> Data& = default;
+
+LinkJointGraph::Link::Link(BodyIndex index, std::string name,
+                           ModelInstanceIndex model_instance, LinkFlags flags)
+    : index_(index),
+      name_(std::move(name)),
+      model_instance_(model_instance),
+      flags_(flags) {
+  DRAKE_DEMAND(index_.is_valid() && !name_.empty() &&
+               model_instance_.is_valid());
+}
+
+LinkJointGraph::Joint::Joint(JointIndex index, std::string name,
+                             ModelInstanceIndex model_instance,
+                             JointTypeIndex joint_type_index,
+                             BodyIndex parent_link_index,
+                             BodyIndex child_link_index, JointFlags flags)
+    : index_(index),
+      name_(std::move(name)),
+      model_instance_(model_instance),
+      flags_(flags),
+      type_index_(joint_type_index),
+      parent_link_index_(parent_link_index),
+      child_link_index_(child_link_index) {
+  DRAKE_DEMAND(index_.is_valid() && !name_.empty() &&
+               model_instance_.is_valid());
+  DRAKE_DEMAND(type_index_.is_valid() && parent_link_index_.is_valid() &&
+               child_link_index_.is_valid());
+  DRAKE_DEMAND(parent_link_index_ != child_link_index_);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/link_joint_graph.h
+++ b/multibody/topology/link_joint_graph.h
@@ -1,0 +1,406 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_GRAPH_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/graph.h".
+#endif
+
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/ssize.h"
+#include "drake/multibody/topology/link_joint_graph_defs.h"
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+// TODO(sherm1) The class comment describes the complete functionality of
+//  PR #20225; only part of that code is actually here.
+
+/** Represents a graph consisting of Links (user-defined rigid bodies)
+interconnected by Joints.
+
+Terminology note: for clarity we use "Link" here to mean what MultibodyPlant
+calls a "RigidBody" (or just "Body"), that is, what a user inputs as an sdf or
+urdf "link", as a MuJoCo "body", or using the AddRigidBody() call in
+MultibodyPlant's API. (It would have been preferable to use Link in
+MultibodyPlant as well, but that ship has sailed and there is less chance of
+confusion there.) The spanning forest we generate uses "mobilized bodies"
+(Mobods). A single Mobod may represent multiple Links (e.g., when multiple
+links are welded together). Conversely, a single Link may be split to create
+multiple Mobods (to break cycles in the graph). As there is not necessarily a
+one-to-one mapping, we're careful not to mix the two terms.
+
+%LinkJointGraph is a directed, possibly cyclic, graph whose nodes are Links and
+whose edges are Joints, defined by a sequence of calls to AddLink() and
+AddJoint(). At any point, a user can ask graph specific questions such as how
+Links are connected, by which Joints, or perform more complex queries such as
+what sets of Links are interconnected by Weld Joints.
+
+LinkJointGraph is intended to represent the user-specified elements and
+connectivity of a multibody system, such as might be supplied in an sdf file.
+For efficient computation in Drake (using joint-space coordinates) we need to
+create a model of this graph as a forest of spanning trees plus loop-closing
+constraints. We call that a SpanningForest, one of which is owned by the graph.
+The forest consists of "Mobods" (mobilized bodies), each representing a node of
+the forest and that node's unique root-directed edge. A Mobod represents (1) a
+rigid body (modeling one or more Links) and (2) that rigid body's unique inboard
+mobilizer (modeling a Joint). We say a Link "follows" a Mobod if it is one of
+the Links represented by that Mobod.
+
+When we build a SpanningForest for a LinkJointGraph, the process may add a
+limited set of _ephemeral_ "as built" Links, Joints, and Constraints to the
+graph. Those are kept distinct from _user_ Links and Joints so we can easily
+restore the graph to its original condition. These additions are limited to
+those needed for breaking loops (by splitting a Link) and ensuring that every
+body's mobility path leads to World (by adding floating or weld joints).
+
+In general during SpanningForest building:
+  - A user-specified Link may get split into a "primary" Link and one or more
+    "shadow" Links in order to break loops. Each of those has its own Mobod, so
+    a user Link can generate multiple Mobods. (Geometry should remain attached
+    to the primary Link.)
+  - A primary Link and its shadows must be welded together by Weld Constraints
+    which will be added to this Graph during modeling.
+  - Building the forest may require additional Joints to mobilize free bodies or
+    immobilize static bodies. Each Joint maps to at most one Mobod; some Joints
+    may instead be represented as Constraints or (for welds) implicitly as
+    part of a composite rigid body.
+  - Composite bodies (Links welded together) can be represented by a single
+    Mobod, so many Links may follow one Mobod.
+  - We never delete any of the user's Links or Joints; we may add new ones
+    during forest building but those are distinct from the user's.
+
+@note Links are indexed using MultibodyPlant's BodyIndex type; there is no
+separate LinkIndex type since these are necessarily the same. */
+class LinkJointGraph {
+ public:
+  class Link;  // Defined in separate headers.
+  class Joint;
+
+  struct JointType;  // Defined below.
+
+  // This Doxygen text is intended to mimic the text generated for
+  // DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN. There is some extra information
+  // but the formatting is consistent.
+
+  // clang-format off
+  // NOLINTNEXTLINE(whitespace/line_length)
+  /** @name Implements CopyConstructible, CopyAssignable, MoveConstructible, MoveAssignable */
+  // clang-format on
+  /**@{*/
+  /** Copies both the graph and the forest if there is one. */
+  LinkJointGraph(const LinkJointGraph&);
+  /** Assigns both the graph and the forest if there is one. */
+  LinkJointGraph& operator=(const LinkJointGraph&);
+  /** Move construction leaves the source as though it had just been
+  default constructed. */
+  LinkJointGraph(LinkJointGraph&&);
+  /** Move assignment leaves the source as though it had just been
+  default constructed. */
+  LinkJointGraph& operator=(LinkJointGraph&&);
+  /**@}*/
+
+  /** Default construction defines well-known joint types and World. */
+  LinkJointGraph();
+
+  /** Restores this graph to its default-constructed state. The contained
+  SpanningForest object is preserved but now invalid. */
+  void Clear();
+
+  /** Sets the forest building options to be used for elements of any model
+  instance that does not have its own forest building options set. Invalidates
+  the current forest.
+  @see SetForestBuildingOptions() */
+  void SetGlobalForestBuildingOptions(ForestBuildingOptions global_options) {
+    InvalidateForest();
+    data_.global_forest_building_options = global_options;
+  }
+
+  /** Gets the forest building options to be used for elements of any model
+  instance that does not have its own forest building options set. If no call
+  has yet been made to SetGlobalForestBuildingOptions(), returns
+  ForestBuildingOptions::kDefault. */
+  ForestBuildingOptions get_global_forest_building_options() const {
+    return data_.global_forest_building_options;
+  }
+
+  /** Sets the forest building options to be used for elements of the given
+  `model_instance`, completely overriding (not blending with) global options.
+  Invalidates the current forest. Model instances do not have to
+  be pre-declared; we will simply record the given `options` with the given
+  index and apply them if any elements are tagged with that index.
+  @note MultibodyPlant predefines model instances 0 and 1 as the
+  world_model_instance() and default_model_instance() respectively.
+  @see SetGlobalForestBuildingOptions() */
+  void SetForestBuildingOptions(ModelInstanceIndex model_instance,
+                                ForestBuildingOptions options) {
+    InvalidateForest();
+    data_.model_instance_forest_building_options[model_instance] = options;
+  }
+
+  /** Gets the forest building options to be used for elements of the given
+  `model_instance`. Returns the options set explicitly for this
+  `model_instance`, if any. Otherwise, returns what
+  get_global_forest_building_options() returns. */
+  ForestBuildingOptions get_forest_building_options_in_use(
+      ModelInstanceIndex model_instance) const {
+    auto instance_options =
+        data_.model_instance_forest_building_options.find(model_instance);
+    return instance_options ==
+                   data_.model_instance_forest_building_options.end()
+               ? get_global_forest_building_options()  // Use global default.
+               : instance_options->second;
+  }
+
+  /** Resets the global forest building options to kDefault and removes any
+  per-model instance options that were set. */
+  void ResetForestBuildingOptions() {
+    InvalidateForest();
+    data_.global_forest_building_options = ForestBuildingOptions::kDefault;
+    data_.model_instance_forest_building_options.clear();
+  }
+
+  /** Models this LinkJointGraph as a spanning forest, records the result
+  into this graph's SpanningForest object, and marks it valid. The currently-set
+  forest building options are used. This is done unconditionally; if there
+  was already a valid forest it is cleared and then rebuilt. If you don't want
+  to rebuild unnecessarily, call forest_is_valid() first to check.
+  @see forest_is_valid() to check whether the SpanningForest is already up
+    to date with the graph's contents.
+  @see forest() for access to the SpanningForest object.
+  @see InvalidateForest() */
+  void BuildForest();
+
+  /** Invalidates this LinkJointGraph's SpanningForest and removes ephemeral
+  "as-built" Link, Joint, and Constraint elements that were added to the graph
+  during forest building. After this call the graph will contain only
+  user-provided elements and forest_is_valid() will return `false`. A
+  subsequent call to BuildForest() is required to rebuild the forest.
+  @note Any change to graph contents or forest building options will also
+    invalidate the forest as a side effect. */
+  void InvalidateForest();
+
+  /** Has the SpanningForest been rebuilt with BuildForest() since the most
+  recent change to this LinkJointGraph or to the forest building options? If
+  this returns `false` then a call to BuildForest() is required before you can
+  make use of the SpanningForest. */
+  bool forest_is_valid() const { return data_.forest_is_valid; }
+
+  /** Returns a reference to this LinkJointGraph's SpanningForest
+  object (without rebuilding). The forest is a data member of LinkJointGraph and
+  the _reference_ remains unchanged across repeated graph modifications and
+  calls to BuildForest(), though the _contents_ will change. You can call the
+  graph's forest_is_valid() or the forest's `is_valid()` function to check
+  whether the forest is currently up to date with respect to the graph's
+  contents. Use BuildForest() to bring the forest up to date if necessary.
+  @warning If you retain this reference be aware that the contents are only
+    meaningful when `forest_is_valid()` returns true. We do not promise
+    anything about the contents otherwise. */
+  const SpanningForest& forest() const { return *data_.forest; }
+
+  // TODO(sherm1) Add editing functions like Remove{Link,Joint} and maybe
+  //  ReplaceJoint().
+
+  /** Adds a new Link to the graph. Invalidates the SpanningForest; call
+  BuildForest() to rebuild.
+  @param[in] name
+    A unique name for the new Link (rigid body) in the given `model_instance`.
+    Several Links can have the same name within a %LinkJointGraph as long as
+    they are unique within their model instances.
+  @param[in] model_instance
+    The model instance to which this Link belongs.
+  @param[in] flags
+    Any special handling required for this Link.
+  @note The World Link is always predefined with name "world" (case sensitive),
+    model instance world_model_instance(), and index 0.
+  @returns The unique BodyIndex for the added Link in the graph.
+  @throws std::exception if `name` is duplicated within `model_instance`.
+  @throws std::exception if an attempt is made to add a link into the World's
+    model instance
+  @throws std::exception if the internal-only Shadow flag is set. */
+  BodyIndex AddLink(const std::string& name, ModelInstanceIndex model_instance,
+                    LinkFlags flags = LinkFlags::kDefault);
+
+  /** Returns the Link that corresponds to World (always predefined). */
+  const Link& world_link() const;
+
+  /** Registers a joint type by name.
+  @param[in] joint_type_name
+    A unique string identifying a joint type, such as "revolute" or
+    "prismatic".
+  @param[in] nq
+    Number of generalized position coordinates q needed for implementation
+    of this type of Joint.
+  @param[in] nv
+    Number of generalized velocity coordinates v needed for implementation
+    of this type of Joint.
+  @param[in] has_quaternion
+    Whether the first four q values represent a quaternion (in w[xyz] order).
+  @retval joint_type_index
+    Unique index assigned to the new joint type.
+  @throws std::exception if `joint_type_name` already identifies a
+    previously registered joint type.
+  @pre 0 ≤ nq ≤ 7, 0 ≤ nv ≤ 6, nv ≤ nq, !has_quaternion or nq ≥ 4.
+
+  @note LinkJointGraph is preloaded with Drake-specific Joint types it needs to
+  know about including "weld", "quaternion_floating", and "rpy_floating". */
+  JointTypeIndex RegisterJointType(const std::string& joint_type_name, int nq,
+                                   int nv, bool has_quaternion = false);
+
+  /** Returns a reference to the vector of known and registered joint types. */
+  const std::vector<JointType>& joint_types() const {
+    return data_.joint_types;
+  }
+
+  /** Returns a reference to a particular JointType using one of the
+  predefined indices or an index returned by RegisterJointType(). */
+  const JointType& joint_types(JointTypeIndex index) const {
+    return joint_types()[index];
+  }
+
+  /** Returns a reference to the vector of Link objects. World is always the
+  first entry and is always present. */
+  const std::vector<Link>& links() const { return data_.links; }
+
+  /** Returns a reference to a particular Link. The World Link is index 0,
+  others use the index returned by AddLink(). Links added by BuildForest()
+  are indexed last. */
+  inline const Link& links(BodyIndex link_index) const;
+
+  /** Returns a reference to the vector of Joint objects. */
+  const std::vector<Joint>& joints() const { return data_.joints; }
+
+  /** Returns a reference to a particular Joint using the index returned by
+  AddJoint(). Joints added by BuildForest() are indexed last. */
+  inline const Joint& joints(JointIndex joint_index) const;
+
+  /** @returns `true` if a Link named `name` was added to `model_instance`.
+  @see AddLink().
+  @throws std::exception if `model_instance` is not a valid index. */
+  bool HasLinkNamed(const std::string& name,
+                    ModelInstanceIndex model_instance) const;
+
+  // Forest building requires these joint types so they are predefined.
+
+  /** The predefined index for the "weld" joint type. */
+  static JointTypeIndex weld_joint_type_index() { return JointTypeIndex(0); }
+
+  /** The predefined index for the "quaternion_floating" joint type. */
+  static JointTypeIndex quaternion_floating_joint_type_index() {
+    return JointTypeIndex(1);
+  }
+
+  /** The predefined index for the "rpy_floating" joint type. */
+  static JointTypeIndex rpy_floating_joint_type_index() {
+    return JointTypeIndex(2);
+  }
+
+  /** This is all we need to know about joint types for topological purposes. */
+  struct JointType {
+    std::string type_name;
+    int nq{-1};
+    int nv{-1};
+    bool has_quaternion;  // If so, the first 4 qs are wxyz.
+  };
+
+ private:
+  friend class SpanningForest;
+  friend class LinkJointGraphTester;
+
+  // Finds the assigned index for a joint type from the type name. Returns an
+  // invalid index if `joint_type_name` was not previously registered with a
+  // call to RegisterJointType().
+  JointTypeIndex GetJointTypeIndex(const std::string& joint_type_name) const;
+
+  // Links that were explicitly flagged LinkFlags::kStatic in AddLink().
+  const std::vector<BodyIndex>& static_links() const {
+    return data_.static_links;
+  }
+
+  // Links that were flagged LinkFlags::kMustBeBaseBody in AddLink() but were
+  // not also flagged kStatic (those are inherently base bodies since by
+  // definition they are welded to World).
+  const std::vector<BodyIndex>& non_static_must_be_base_body_links() const {
+    return data_.non_static_must_be_base_body_links;
+  }
+
+  // Group data members so we can have the compiler generate most of the
+  // copy/move/assign methods for us while still permitting pointer fixup.
+  struct Data {
+    // These are all default but definitions deferred to .cc file so
+    // that all the local classes are defined (Mac requirement).
+    Data();
+    Data(const Data&);
+    Data(Data&&);
+    ~Data();
+    Data& operator=(const Data&);
+    Data& operator=(Data&&);
+
+    std::vector<JointType> joint_types;
+
+    // The first entry in links is the World Link with BodyIndex(0) and name
+    // world_link().name().
+    std::vector<Link> links;
+    std::vector<Joint> joints;
+
+    // The first num_user_links etc. elements are user-supplied; the rest were
+    // added during modeling.
+    int num_user_links{0};
+    int num_user_joints{0};
+
+    std::vector<BodyIndex> static_links;
+    std::vector<BodyIndex> non_static_must_be_base_body_links;
+
+    // Every user Link, organized by Model Instance.
+    std::map<ModelInstanceIndex, std::vector<BodyIndex>>
+        model_instance_to_links;
+
+    // This must always have the same number of entries as joint_types_.
+    std::unordered_map<std::string, JointTypeIndex> joint_type_name_to_index;
+
+    // The xxx_name_to_index_ structures are multimaps because
+    // links/joints/actuators/etc may appear with the same name in different
+    // model instances. The index values are still unique across the graph.
+    // These include only user-supplied links and joints.
+    std::unordered_multimap<std::string, BodyIndex> link_name_to_index;
+    std::unordered_multimap<std::string, JointIndex> joint_name_to_index;
+
+    // The 0th composite always exists and contains World (listed first)
+    // and any links welded (recursively) to World. The other composites are
+    // only present if there are at least two Links welded together. The first
+    // Link in the composite is the active Link.
+    std::vector<std::vector<BodyIndex>> link_composites;
+
+    bool forest_is_valid{false};  // set false whenever changes are made
+
+    // These parallel {link,joint}_name_to_index except they hold mappings
+    // for ephemeral links and joints added during forest-building. We keep
+    // them separately so they are easy to get rid of.
+    std::unordered_multimap<std::string, BodyIndex>
+        ephemeral_link_name_to_index;
+    std::unordered_multimap<std::string, JointIndex>
+        ephemeral_joint_name_to_index;
+
+    ForestBuildingOptions global_forest_building_options{
+        ForestBuildingOptions::kDefault};
+    std::map<ModelInstanceIndex, ForestBuildingOptions>
+        model_instance_forest_building_options;
+
+    // Contains a back pointer to the graph so needs fixup post copy or move.
+    copyable_unique_ptr<SpanningForest> forest;
+  } data_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_GRAPH_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/graph.h".
+#endif
+
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+class SpanningForest;
+
+using JointTypeIndex = TypeSafeIndex<class JointTypeTag>;
+using LinkCompositeIndex = TypeSafeIndex<class LinkCompositeTag>;
+
+/** Link properties that can affect how the forest model gets built. Or-ing
+these also produces a LinkFlags object. */
+enum class LinkFlags : unsigned {
+  kDefault = 0,
+  kStatic = 1 << 0,           ///< Implicitly welded to World.
+  kMustBeBaseBody = 1 << 1,   ///< Ensure connection to World if none.
+  kTreatAsMassless = 1 << 2,  ///< Can't be a terminal body in a tree.
+  kShadow = 1 << 3            ///< Link is a shadow (internal use only).
+};
+
+/** Joint properties that can affect how the SpanningForest gets built. Or-ing
+these also produces a JointFlags object. */
+enum class JointFlags : unsigned {
+  kDefault = 0,
+  kMustBeModeled = 1 << 0  ///< Model explicitly even if ignorable weld.
+};
+
+/** Options for how to build the SpanningForest. Or-ing these also produces a
+ForestBuildingOptions object. These can be provided as per-model instance
+options to locally override global options. */
+enum class ForestBuildingOptions : unsigned {
+  kDefault = 0,
+  kStatic = 1 << 0,                ///< Weld all links to World.
+  kUseFixedBase = 1 << 1,          ///< Use welds rather than floating joints.
+  kUseRpyFloatingJoints = 1 << 2,  ///< For floating, use RPY not quaternion.
+  kCombineLinkComposites = 1 << 3  ///< Make a single Mobod for welded Links.
+};
+
+// These overloads make the above enums behave like bitmasks for the operations
+// we care about here.
+
+inline LinkFlags operator|(LinkFlags left, LinkFlags right) {
+  return static_cast<LinkFlags>(static_cast<unsigned>(left) |
+                                static_cast<unsigned>(right));
+}
+inline LinkFlags operator&(LinkFlags left, LinkFlags right) {
+  return static_cast<LinkFlags>(static_cast<unsigned>(left) &
+                                static_cast<unsigned>(right));
+}
+
+inline JointFlags operator|(JointFlags left, JointFlags right) {
+  return static_cast<JointFlags>(static_cast<unsigned>(left) |
+                                 static_cast<unsigned>(right));
+}
+inline JointFlags operator&(JointFlags left, JointFlags right) {
+  return static_cast<JointFlags>(static_cast<unsigned>(left) &
+                                 static_cast<unsigned>(right));
+}
+
+inline ForestBuildingOptions operator|(ForestBuildingOptions left,
+                                       ForestBuildingOptions right) {
+  return static_cast<ForestBuildingOptions>(static_cast<unsigned>(left) |
+                                            static_cast<unsigned>(right));
+}
+inline ForestBuildingOptions operator&(ForestBuildingOptions left,
+                                       ForestBuildingOptions right) {
+  return static_cast<ForestBuildingOptions>(static_cast<unsigned>(left) &
+                                            static_cast<unsigned>(right));
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/link_joint_graph_inlines.h
+++ b/multibody/topology/link_joint_graph_inlines.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_GRAPH_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/graph.h".
+#endif
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+// LinkJointGraph definitions deferred until Link defined.
+
+inline auto LinkJointGraph::links(BodyIndex link_index) const -> const Link& {
+  return links().at(link_index);
+}
+
+// LinkJointGraph definitions deferred until Joint defined.
+
+inline auto LinkJointGraph::joints(JointIndex joint_index) const
+    -> const Joint& {
+  return joints().at(joint_index);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/link_joint_graph_joint.h
+++ b/multibody/topology/link_joint_graph_joint.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_GRAPH_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/graph.h".
+#endif
+
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+class LinkJointGraph::Joint {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Joint)
+
+  /** Returns this %Joint's unique index in the graph. */
+  JointIndex index() const { return index_; }
+
+  /** Returns this %Joint's model instance. */
+  ModelInstanceIndex model_instance() const { return model_instance_; }
+
+  /** Returns this %Joint's name, unique within model_instance(). */
+  const std::string& name() const { return name_; }
+
+  /** Returns the index of this %Joint's parent Link. */
+  BodyIndex parent_link() const { return parent_link_index_; }
+
+  /** Returns the index of this %Joint's child Link. */
+  BodyIndex child_link() const { return child_link_index_; }
+
+  /** Returns `true` if this is a Weld %Joint. */
+  bool is_weld() const { return type_index() == weld_joint_type_index(); }
+
+  /** Returns the index of this %Joint's joint type. */
+  JointTypeIndex type_index() const { return type_index_; }
+
+  /** Returns `true` if either the parent or child Link of this %Joint is
+  the specified `link`. */
+  bool connects(BodyIndex link) const {
+    return link == parent_link() || link == child_link();
+  }
+
+  /** Returns `true` if this %Joint connects the two given Links. That is, if
+  one of these is the parent Link and the other is the child Link, in either
+  order. */
+  bool connects(BodyIndex link1, BodyIndex link2) const {
+    return (parent_link() == link1 && child_link() == link2) ||
+           (parent_link() == link2 && child_link() == link1);
+  }
+
+  // TODO(sherm1) Per Joe M an unchecked version of this could just do
+  //  return link_index ^ (parent_link_index ^ child_link_index);
+  //  with the second term precalculated. Consider that if performance warrants.
+
+  /** Given one of the Links connected by this %Joint, returns the other one.
+  @pre `link_index` is either the parent or child */
+  BodyIndex other_link_index(BodyIndex link_index) const {
+    DRAKE_DEMAND((parent_link() == link_index) || (child_link() == link_index));
+    return parent_link() == link_index ? child_link() : parent_link();
+  }
+
+  /** Returns `true` if this %Joint was added with
+  JointFlags::kMustBeModeled. */
+  bool must_be_modeled() const {
+    return static_cast<bool>(flags_ & JointFlags::kMustBeModeled);
+  }
+
+  /** Returns the index of the Mobod whose inboard mobilizer models this
+  %Joint, if any. If this %Joint is unmodeled then the returned index is
+  invalid. */
+  MobodIndex mobod_index() const {
+    if (!std::holds_alternative<MobodIndex>(how_modeled_)) return MobodIndex();
+    return std::get<MobodIndex>(how_modeled_);
+  }
+
+  /** (Internal use only) During construction of the forest, this is used
+  to check whether this %Joint has already been modeled. */
+  bool has_been_processed() const {
+    return !std::holds_alternative<std::monostate>(how_modeled_);
+  }
+
+ private:
+  friend class LinkJointGraph;
+  friend class LinkJointGraphTester;
+
+  Joint(JointIndex index, std::string name, ModelInstanceIndex model_instance,
+        JointTypeIndex joint_type_index, BodyIndex parent_link_index,
+        BodyIndex child_link_index, JointFlags flags);
+
+  void clear_model() { how_modeled_ = std::monostate{}; }
+
+  // (For testing) If `to_set` is JointFlags::kDefault sets the flags to
+  // kDefault. Otherwise or's in the given flags to the current set. Returns
+  // the updated value of this %Joint's flags.
+  JointFlags set_flags(JointFlags to_set) {
+    return flags_ = (to_set == JointFlags::kDefault ? JointFlags::kDefault
+                                                    : flags_ | to_set);
+  }
+
+  // Only joints that are modeled with Mobods need renumbering. This gets
+  // called on all joints but does nothing unless there is a misnumbered
+  // Mobod lurking beneath.
+  void renumber_mobod_indexes(const std::vector<MobodIndex>& old_to_new) {
+    if (std::holds_alternative<MobodIndex>(how_modeled_))
+      how_modeled_ = old_to_new[std::get<MobodIndex>(how_modeled_)];
+  }
+
+  struct IgnoredLoopJoint {};
+
+  JointIndex index_;
+  std::string name_;
+  ModelInstanceIndex model_instance_;
+  JointFlags flags_{JointFlags::kDefault};
+
+  JointTypeIndex type_index_;
+  BodyIndex parent_link_index_;
+  BodyIndex child_link_index_;
+
+  // Below here is the as-built information; must be flushed when the forest is
+  // cleared or rebuilt.
+
+  // Meaning of the variants:
+  // - monostate: not yet processed
+  // - MobodIndex: modeled directly by a mobilizer
+  // - ConstraintIndex: modeled as a constraint (TBD)
+  // - LinkCompositeIndex: not modeled because this is a weld interior to
+  //     the indicated composite and we are combining so that one Mobod serves
+  //     the whole composite.
+  // - IgnoredLoopJoint: not modeled because we intentionally ignored the Joint
+  //     (used with the IgnoreLoopJoints modeling option)
+  std::variant<std::monostate, MobodIndex, LinkCompositeIndex, IgnoredLoopJoint>
+      how_modeled_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/link_joint_graph_link.h
+++ b/multibody/topology/link_joint_graph_link.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_GRAPH_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/graph.h".
+#endif
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+/** Represents a %Link in the LinkJointGraph. This includes Links provided via
+user input and also those added during forest building as Shadow links created
+when we cut a user %Link in order to break a kinematic loop. Links may be
+modeled individually or can be combined into Composite Links comprising groups
+of Links that were connected by weld joints. */
+class LinkJointGraph::Link {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Link)
+
+  /** Returns this %Link's unique index in the graph. */
+  BodyIndex index() const { return index_; }
+
+  /** Returns this %Link's model instance. */
+  ModelInstanceIndex model_instance() const { return model_instance_; }
+
+  /** Returns this %Link's name, unique within model_instance(). */
+  const std::string& name() const { return name_; }
+
+  /** Returns indexes of all the Joints that connect to this %Link. This is
+  the union of joints_as_parent() and joints_as_child(). */
+  const std::vector<JointIndex>& joints() const { return joints_; }
+
+  /** Returns indexes of all the Joints that connect to this %Link in which
+  this is the parent %Link. */
+  const std::vector<JointIndex>& joints_as_parent() const {
+    return joints_as_parent_;
+  }
+
+  /** Returns indexes of all the joints that connect to this %Link in which
+  this is the child %Link. */
+  const std::vector<JointIndex>& joints_as_child() const {
+    return joints_as_child_;
+  }
+
+  /** Returns `true` only if this is the World %Link. Static Links and Links
+  in the World Composite are not included; see is_anchored() if you want to
+  include everything that is fixed with respect to World. */
+  bool is_world() const { return index_ == BodyIndex(0); }
+
+  /** After modeling, returns `true` if this %Link is fixed with respect to
+  World. That includes World itself, static Links, and any Link that is part
+  of the World Composite (that is, it is directly or indirectly welded to
+  World). */
+  bool is_anchored() const {
+    return is_world() || is_static() ||
+           (composite().is_valid() && composite() == LinkCompositeIndex(0));
+  }
+
+  /** Returns `true` if this %Link was added with LinkFlags::kStatic. */
+  bool is_static() const {
+    return static_cast<bool>(flags_ & LinkFlags::kStatic);
+  }
+
+  /** Returns `true` if this %Link was added with LinkFlags::kMustBeBaseBody. */
+  bool must_be_base_body() const {
+    return static_cast<bool>(flags_ & LinkFlags::kMustBeBaseBody);
+  }
+
+  /** Returns `true` if this %Link was added with
+  LinkFlags::kTreatAsMassless. */
+  bool treat_as_massless() const {
+    return static_cast<bool>(flags_ & LinkFlags::kTreatAsMassless);
+  }
+
+  /** Returns `true` if this is a shadow Link added by BuildForest(). */
+  bool is_shadow() const {
+    return static_cast<bool>(flags_ & LinkFlags::kShadow);
+  }
+
+  /** If this %Link is a shadow, returns the primary %Link it shadows. If
+  not a shadow then it is its own primary %Link so returns index(). */
+  BodyIndex primary_link() const { return primary_link_; }
+
+  /** If this is a primary %Link (not a shadow) returns the number of Shadow
+  Links that were added due to loop breaking. */
+  int num_shadows() const { return ssize(shadow_links_); }
+
+  /** Returns the index of the mobilized body (Mobod) that mobilizes this %Link.
+  If this %Link is part of a LinkComposite, this is the Mobod that mobilizes the
+  LinkComposite as a whole via the composite's active %Link. If you ask
+  this Mobod what Joint it represents, it will report the Joint that was used
+  to mobilize the LinkComposite; that won't necessarily be a Joint connected to
+  this %Link. See inboard_joint_index() to find the Joint that connected this
+  %Link to its LinkComposite. */
+  MobodIndex mobod_index() const { return mobod_; }
+
+  /** Returns the Joint that was used to associate this %Link with its
+  mobilized body. If this %Link is part of a LinkComposite, returns the Joint
+  that connects this %Link to the Composite, not necessarily the Joint that is
+  modeled by the Mobod returned by mobod_index(). */
+  JointIndex inboard_joint_index() const { return joint_; }
+
+  /** Returns the index of the Composite this %Link is part of, if any.
+  Otherwise returns an invalid index. */
+  LinkCompositeIndex composite() const { return link_composite_index_; }
+
+ private:
+  friend class LinkJointGraph;
+  friend class LinkJointGraphTester;
+
+  Link(BodyIndex index, std::string name, ModelInstanceIndex model_instance,
+       LinkFlags flags);
+
+  // (For testing) If `to_set` is LinkFlags::kDefault sets the flags to
+  // Default. Otherwise or's in the given flags to the current set. Returns
+  // the updated value of this %Link's flags.
+  LinkFlags set_flags(LinkFlags to_set) {
+    return flags_ = (to_set == LinkFlags::kDefault ? LinkFlags::kDefault
+                                                   : flags_ | to_set);
+  }
+
+  void renumber_mobod_indexes(const std::vector<MobodIndex>& old_to_new) {
+    if (mobod_.is_valid()) mobod_ = old_to_new[mobod_];
+  }
+
+  // Notes that this Link is connected by `joint`.
+  void add_joint_as_parent(JointIndex joint) {
+    joints_as_parent_.push_back(joint);
+    joints_.push_back(joint);
+  }
+
+  void add_joint_as_child(JointIndex joint) {
+    joints_as_child_.push_back(joint);
+    joints_.push_back(joint);
+  }
+
+  void clear_model(int num_user_joints) {
+    mobod_ = {};
+    joint_ = {};
+    primary_link_ = {};
+    shadow_links_.clear();
+    link_composite_index_ = {};
+
+    auto remove_model_joints =
+        [num_user_joints](std::vector<JointIndex>& joints) {
+          while (!joints.empty() && joints.back() >= num_user_joints)
+            joints.pop_back();
+        };
+
+    remove_model_joints(joints_as_parent_);
+    remove_model_joints(joints_as_child_);
+    remove_model_joints(joints_);
+  }
+
+  BodyIndex index_;
+  std::string name_;
+  ModelInstanceIndex model_instance_;
+  LinkFlags flags_{LinkFlags::kDefault};
+
+  // Members below here may contain as-modeled information that has to be
+  // removed when the SpanningForest is cleared or rebuilt. The joint
+  // lists always have the as-built extra joints at the end.
+
+  // Lists of joints connecting to this Link, in order of arrival.
+  std::vector<JointIndex> joints_as_parent_;
+  std::vector<JointIndex> joints_as_child_;
+  std::vector<JointIndex> joints_;  // All joints whether as parent or child.
+
+  MobodIndex mobod_;  // Which Mobod mobilizes this Link?
+  JointIndex joint_;  // Which Joint connected us to the Mobod?
+
+  BodyIndex primary_link_;  // Same as index_ if this is a primary link.
+  std::vector<BodyIndex> shadow_links_;
+
+  LinkCompositeIndex link_composite_index_;  // Invalid if not in composite.
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -1,0 +1,66 @@
+// NOLINTNEXTLINE(build/include): prevent complaint re spanning_forest.h
+#include <queue>
+#include <stack>
+#include <utility>
+
+#include "drake/multibody/topology/forest.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+SpanningForest::SpanningForest(const SpanningForest& source)
+    : data_(source.data_) {
+  FixInternalPointers();
+}
+
+SpanningForest::SpanningForest(SpanningForest&& source)
+    : data_(std::move(source.data_)) {
+  FixInternalPointers();
+}
+
+SpanningForest& SpanningForest::operator=(const SpanningForest& source) {
+  if (&source != this) {
+    data_ = source.data_;
+    FixInternalPointers();
+  }
+  return *this;
+}
+
+SpanningForest& SpanningForest::operator=(SpanningForest&& source) {
+  if (&source != this) {
+    data_ = std::move(source.data_);
+    FixInternalPointers();
+  }
+  return *this;
+}
+
+void SpanningForest::FixInternalPointers() {
+  // TODO(sherm1) Nothing yet, see #20225.
+}
+
+// Clear() leaves this with nothing, not even a Mobod for World.
+void SpanningForest::Clear() {
+  // We want the graph back pointer to remain unchanged.
+  LinkJointGraph* const saved_graph = data_.graph;
+  data_ = Data{};
+  data_.graph = saved_graph;
+}
+
+// This is the algorithm that takes an arbitrary link-joint graph and models
+// it as a spanning forest of mobilized bodies plus loop-closing constraints.
+// TODO(sherm1) Just a stub for now.
+void SpanningForest::BuildForest() {
+  Clear();  // In case we're reusing this forest.
+}
+
+SpanningForest::Data::Data() = default;
+SpanningForest::Data::Data(const Data&) = default;
+SpanningForest::Data::Data(Data&&) = default;
+SpanningForest::Data::~Data() = default;
+auto SpanningForest::Data::operator=(const Data&) -> Data& = default;
+auto SpanningForest::Data::operator=(Data&&) -> Data& = default;
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_FOREST_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/forest.h".
+#endif
+
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/ssize.h"
+#include "drake/multibody/topology/graph.h"
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+using WeldedMobodsIndex = TypeSafeIndex<class CompositeMobodTag>;
+using LoopConstraintIndex = TypeSafeIndex<class LoopConstraintTag>;
+
+/** SpanningForest models a LinkJointGraph via a set of spanning trees and
+loop-closing constraints. */
+// TODO(sherm1) Just a skeleton here; much more to come.
+class SpanningForest {
+ public:
+  // Constructors and assignment are private; only LinkJointGraph may access.
+  // These can't be default because there are back pointers to clean up.
+
+  /** Returns a reference to the graph that owns this forest (as set during
+  construction). */
+  const LinkJointGraph& graph() const {
+    DRAKE_ASSERT(data_.graph != nullptr);
+    return *data_.graph;
+  }
+
+  /** Returns `true` if this forest is up to date with respect to its owning
+  graph. */
+  bool is_valid() const { return graph().forest_is_valid(); }
+
+ private:
+  friend class LinkJointGraph;
+  friend class copyable_unique_ptr<SpanningForest>;
+
+  // Only the owning LinkJointGraph may call this constructor. The owner must
+  // outlive this model, which may be built and rebuilt repeatedly for the same
+  // owner. For copy and move, the owner is responsible for repairing the back
+  // pointer via SetNewOwner().
+  // @pre `graph` is non-null
+  explicit SpanningForest(LinkJointGraph* graph) {
+    DRAKE_DEMAND(graph != nullptr);
+    data_.graph = graph;
+  }
+
+  // The caller (only LinkJointGraph) must provide a new back pointer after copy
+  // or move so these can't be default.
+  SpanningForest(const SpanningForest& source);
+  SpanningForest(SpanningForest&& source);
+  SpanningForest& operator=(const SpanningForest& source);
+  SpanningForest& operator=(SpanningForest&& source);
+
+  // LinkJointGraph uses this to fix the graph back pointer after copy or move.
+  void SetNewOwner(LinkJointGraph* graph) {
+    DRAKE_DEMAND(graph != nullptr);
+    data_.graph = graph;
+  }
+
+  // After copy/move/assign: any element that has a pointer back to its owning
+  // SpanningForest should replace the pointer with `this`.
+  void FixInternalPointers();
+
+  // Clears the existing forest and builds a new one using the current forest
+  // building options in the owning LinkJointGraph. This is for LinkJointGraph
+  // to call _after_ it has cleaned out its own ephemeral elements and
+  // out-of-date modeling information. New ephemeral elements and modeling info
+  // will be written to the graph.
+  void BuildForest();
+
+  // Restores this SpanningTree to the state it has immediately after
+  // construction. The owning LinkJointGraph remains unchanged.
+  void Clear();
+
+  struct Data {
+    // These are all default but definitions deferred to .cc file so
+    // that all the local classes are defined (Mac requirement).
+    Data();
+    Data(const Data&);
+    Data(Data&&);
+    ~Data();
+    Data& operator=(const Data&);
+    Data& operator=(Data&&);
+
+    LinkJointGraph* graph{};  // The graph we're modeling.
+
+    // TODO(sherm1) More to come
+  } data_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/test/link_joint_graph_test.cc
+++ b/multibody/topology/test/link_joint_graph_test.cc
@@ -1,0 +1,401 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/multibody/topology/graph.h"
+/* clang-format on */
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/topology/forest.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// This class is a friend of subclasses that have private constructors and
+// member functions so that we can test those APIs standalone.
+class LinkJointGraphTester {
+ public:
+  static LinkJointGraph::Link MakeLink(BodyIndex index, std::string name,
+                                       ModelInstanceIndex model_instance,
+                                       LinkFlags flags) {
+    return LinkJointGraph::Link(index, std::move(name), model_instance, flags);
+  }
+
+  static LinkJointGraph::Joint MakeJoint(JointIndex index, std::string name,
+                                         ModelInstanceIndex model_instance,
+                                         JointTypeIndex joint_type_index,
+                                         BodyIndex parent_link_index,
+                                         BodyIndex child_link_index,
+                                         JointFlags flags) {
+    return LinkJointGraph::Joint(index, std::move(name), model_instance,
+                                 joint_type_index, parent_link_index,
+                                 child_link_index, flags);
+  }
+
+  static LinkFlags set_link_flags(LinkFlags to_set,
+                                  LinkJointGraph::Link* link) {
+    return link->set_flags(to_set);
+  }
+
+  static JointFlags set_joint_flags(JointFlags to_set,
+                                    LinkJointGraph::Joint* joint) {
+    return joint->set_flags(to_set);
+  }
+
+  static std::vector<BodyIndex> static_links(const LinkJointGraph& graph) {
+    return graph.static_links();
+  }
+
+  static std::vector<BodyIndex> non_static_must_be_base_body_links(
+      const LinkJointGraph& graph) {
+    return graph.non_static_must_be_base_body_links();
+  }
+};
+
+namespace {
+
+// Verify that the enums in link_joint_graph_defs.h work properly as bitmaps.
+GTEST_TEST(LinkJointGraph, FlagsAndOptions) {
+  const auto is_static = LinkFlags::kStatic;
+  const auto massless = LinkFlags::kTreatAsMassless;
+
+  // Or-ed flags still have LinkFlags type.
+  auto link_flags = is_static | massless;
+  static_assert(std::is_same_v<decltype(link_flags), LinkFlags>);
+
+  // And is bitwise but still returns LinkFlags, convertible to bool.
+  EXPECT_EQ(link_flags & is_static, LinkFlags::kStatic);
+  EXPECT_EQ(link_flags & massless, LinkFlags::kTreatAsMassless);
+  EXPECT_FALSE(static_cast<bool>(link_flags & LinkFlags::kMustBeBaseBody));
+  EXPECT_EQ(link_flags & LinkFlags::kMustBeBaseBody, LinkFlags::kDefault);
+
+  // Repeat for Modeling Options.
+  const auto use_fixed_base = ForestBuildingOptions::kUseFixedBase;
+  const auto combine_links = ForestBuildingOptions::kCombineLinkComposites;
+  auto forest_building_options = use_fixed_base | combine_links;
+  static_assert(
+      std::is_same_v<decltype(forest_building_options), ForestBuildingOptions>);
+  EXPECT_EQ(forest_building_options & use_fixed_base,
+            ForestBuildingOptions::kUseFixedBase);
+  EXPECT_EQ(forest_building_options & combine_links,
+            ForestBuildingOptions::kCombineLinkComposites);
+  EXPECT_FALSE(static_cast<bool>(forest_building_options &
+                                 ForestBuildingOptions::kUseRpyFloatingJoints));
+  EXPECT_EQ(
+      forest_building_options & ForestBuildingOptions::kUseRpyFloatingJoints,
+      ForestBuildingOptions::kDefault);
+
+  // Only one option in JointFlags currently.
+  auto joint_flags = JointFlags::kMustBeModeled;
+  static_assert(std::is_same_v<decltype(joint_flags), JointFlags>);
+  EXPECT_EQ(joint_flags & JointFlags::kMustBeModeled,
+            JointFlags::kMustBeModeled);
+  EXPECT_EQ(joint_flags | JointFlags::kMustBeModeled,
+            JointFlags::kMustBeModeled);
+}
+
+// Verify that forest building options can be set and reset properly. This
+// is not checking that they have the intended effects; just that we can
+// record them correctly.
+GTEST_TEST(LinkJointGraph, SpecifyForestBuildingOptions) {
+  LinkJointGraph graph;
+
+  const ForestBuildingOptions default_options = ForestBuildingOptions::kDefault;
+  const ForestBuildingOptions two_options =
+      ForestBuildingOptions::kCombineLinkComposites |
+      ForestBuildingOptions::kUseRpyFloatingJoints;
+
+  // If we haven't said anything, global and all ModelInstance options are
+  // just default.
+  EXPECT_EQ(graph.get_global_forest_building_options(), default_options);
+  EXPECT_EQ(graph.get_forest_building_options_in_use(default_model_instance()),
+            default_options);
+  EXPECT_EQ(graph.get_forest_building_options_in_use(ModelInstanceIndex(73)),
+            default_options);
+
+  // Global options should be used for any unrecognized model instance but
+  // should be overridden by instance-specific options.
+  graph.SetGlobalForestBuildingOptions(two_options);
+  graph.SetForestBuildingOptions(ModelInstanceIndex(9),
+                                 ForestBuildingOptions::kStatic);
+  EXPECT_EQ(graph.get_global_forest_building_options(), two_options);
+  EXPECT_EQ(graph.get_forest_building_options_in_use(ModelInstanceIndex(3)),
+            two_options);  // Nothing set for this instance.
+  EXPECT_EQ(graph.get_forest_building_options_in_use(ModelInstanceIndex(9)),
+            ForestBuildingOptions::kStatic);  // Overridden.
+
+  // Reset should put everything back as it was.
+  graph.ResetForestBuildingOptions();
+  EXPECT_EQ(graph.get_global_forest_building_options(), default_options);
+  EXPECT_EQ(graph.get_forest_building_options_in_use(ModelInstanceIndex(9)),
+            default_options);
+}
+
+// LinkJointGraph supports copy/move/assign, including the already-built
+// SpanningForest. That takes some sleight-of-hand to get back pointers right;
+// make sure it works. Note that the actual copying and moving of data members
+// is implemented using the corresponding compiler-generated defaults for the
+// Data structs in LinkJointGraph and SpanningForest. We can assume those are
+// working correctly so don't need to check every member.
+GTEST_TEST(LinkJointGraph, CopyMoveAssignTest) {
+  LinkJointGraph graph;
+  LinkJointGraph* graph_ptr = &graph;  // To avoid warnings below.
+  const SpanningForest* original_graph_forest_ptr = &graph.forest();
+
+  // These first checks don't use copy/move/assign but are here to make it
+  // clear what we have before we start with those.
+  EXPECT_EQ(&graph.forest().graph(), &graph);
+  EXPECT_FALSE(graph.forest_is_valid() || graph.forest().is_valid());
+  graph.BuildForest();
+  EXPECT_TRUE(graph.forest_is_valid() && graph.forest().is_valid());
+  graph.AddLink("link1", ModelInstanceIndex(19));  // Should invalidate forest.
+  EXPECT_FALSE(graph.forest_is_valid());
+  graph.BuildForest();  // Update the forest.
+
+  // Remember the memory address of link1 so we can see if we're re-using
+  // the same memory when we expect to be.
+  const LinkJointGraph::Link& original_link1 = graph.links()[1];
+
+  // Self copy-assign and self move-assign should be no-ops. It's hard to verify
+  // that no self-copying has occurred but we can at least see that we're still
+  // using the same memory afterwards.
+  graph = *graph_ptr;                  // Self copy-assign.
+  EXPECT_EQ(ssize(graph.links()), 2);  // World + link1.
+  EXPECT_EQ(&graph.forest(), original_graph_forest_ptr);
+  EXPECT_EQ(&graph.links()[1], &original_link1);
+
+  graph = std::move(*graph_ptr);       // Self move-assign.
+  EXPECT_EQ(ssize(graph.links()), 2);  // World + link1.
+  EXPECT_EQ(&graph.forest(), original_graph_forest_ptr);
+  EXPECT_EQ(&graph.links()[1], &original_link1);
+
+  LinkJointGraph graph_copy(graph);  // Copy constructor.
+  const SpanningForest* graph_copy_forest_ptr = &graph_copy.forest();
+  EXPECT_TRUE(graph_copy.HasLinkNamed("link1", ModelInstanceIndex(19)));
+  EXPECT_TRUE(graph_copy.forest_is_valid());
+  EXPECT_NE(graph_copy_forest_ptr, original_graph_forest_ptr);
+  EXPECT_EQ(&graph_copy.forest().graph(), &graph_copy);
+  EXPECT_NE(&graph_copy.links()[1], &original_link1);
+
+  LinkJointGraph graph_assign;
+  graph_assign = graph;  // Copy assignment.
+  EXPECT_TRUE(graph_assign.HasLinkNamed("link1", ModelInstanceIndex(19)));
+  EXPECT_TRUE(graph_assign.forest_is_valid());
+  EXPECT_NE(&graph_assign.forest(), &graph.forest());
+  EXPECT_EQ(&graph_assign.forest().graph(), &graph_assign);
+  EXPECT_NE(&graph_assign.links()[1], &original_link1);
+
+  EXPECT_TRUE(graph.forest_is_valid());  // Unchanged by assign-from.
+  EXPECT_EQ(ssize(graph.links()), 2);    // World + link1
+
+  LinkJointGraph graph_move(std::move(graph));  // Move constructor.
+  EXPECT_EQ(&graph_move.forest(), original_graph_forest_ptr);  // Stolen!
+  EXPECT_TRUE(graph_move.forest_is_valid());
+  EXPECT_TRUE(graph_move.HasLinkNamed("link1", ModelInstanceIndex(19)));
+  EXPECT_EQ(ssize(graph_move.links()), 2);             // World + link1
+  EXPECT_EQ(&graph_move.links()[1], &original_link1);  // Stolen!
+  EXPECT_EQ(ssize(graph.links()), 1);                  // Back to default state.
+
+  EXPECT_FALSE(graph.forest_is_valid());  // It was stolen.
+  // This should return a new SpanningForest object.
+  EXPECT_NE(&graph.forest(), original_graph_forest_ptr);
+
+  LinkJointGraph graph_move_assign;
+  const LinkJointGraph::Link& copy_link1 = graph_copy.links()[1];
+  graph_move_assign = std::move(graph_copy);  // Move assignent.
+  EXPECT_EQ(&graph_move_assign.forest(), graph_copy_forest_ptr);  // Stolen!
+  EXPECT_TRUE(graph_move_assign.forest_is_valid());
+  EXPECT_TRUE(graph_move_assign.HasLinkNamed("link1", ModelInstanceIndex(19)));
+  EXPECT_EQ(ssize(graph_move_assign.links()), 2);         // World + link1
+  EXPECT_EQ(&graph_move_assign.links()[1], &copy_link1);  // Stolen!
+  EXPECT_EQ(ssize(graph_copy.links()), 1);  // Back to default state.
+  // Should have a new forest.
+  EXPECT_NE(&graph_copy.forest(), graph_copy_forest_ptr);
+}
+
+// A default-constructed LinkJointGraph should contain a predefined World
+// Link, predefined joint types, and be suitable for generating a matching
+// SpanningForest.
+GTEST_TEST(LinkJointGraph, EmptyTest) {
+  LinkJointGraph graph;
+
+  // World is predefined.
+  EXPECT_EQ(ssize(graph.links()), 1);
+  EXPECT_TRUE(graph.joints().empty());
+  EXPECT_EQ(graph.world_link().name(), "world");
+  EXPECT_EQ(graph.world_link().model_instance(), world_model_instance());
+  EXPECT_EQ(graph.world_link().index(), BodyIndex(0));
+
+  // Topologically important joint types are predefined.
+  EXPECT_EQ(ssize(graph.joint_types()), 3);
+  const LinkJointGraph::JointType& weld_type =
+      graph.joint_types(LinkJointGraph::weld_joint_type_index());
+  EXPECT_EQ(weld_type.type_name, "weld");
+  EXPECT_EQ(weld_type.nq, 0);
+  EXPECT_EQ(weld_type.nv, 0);
+  EXPECT_EQ(weld_type.has_quaternion, false);
+  const LinkJointGraph::JointType& quaternion_floating_type =
+      graph.joint_types(LinkJointGraph::quaternion_floating_joint_type_index());
+  EXPECT_EQ(quaternion_floating_type.type_name, "quaternion_floating");
+  EXPECT_EQ(quaternion_floating_type.nq, 7);
+  EXPECT_EQ(quaternion_floating_type.nv, 6);
+  EXPECT_EQ(quaternion_floating_type.has_quaternion, true);
+  const LinkJointGraph::JointType& rpy_floating_type =
+      graph.joint_types(LinkJointGraph::rpy_floating_joint_type_index());
+  EXPECT_EQ(rpy_floating_type.type_name, "rpy_floating");
+  EXPECT_EQ(rpy_floating_type.nq, 6);
+  EXPECT_EQ(rpy_floating_type.nv, 6);
+  EXPECT_EQ(rpy_floating_type.has_quaternion, false);
+
+  EXPECT_FALSE(graph.forest_is_valid());
+
+  graph.BuildForest();
+  const SpanningForest& forest = graph.forest();
+  EXPECT_EQ(&forest.graph(), &graph);
+  EXPECT_TRUE(graph.forest_is_valid());
+
+  // Check that Clear() puts the graph back to default-constructed condition.
+  // First add some junk to the graph.
+  graph.RegisterJointType("revolute", 1, 1);
+  const BodyIndex dummy_index =
+      graph.AddLink("dummy", default_model_instance());
+  EXPECT_TRUE(graph.HasLinkNamed("dummy", default_model_instance()));
+  EXPECT_EQ(dummy_index, BodyIndex(1));
+  EXPECT_EQ(ssize(graph.links()), 2);
+  EXPECT_EQ(ssize(graph.joints()), 0);
+  EXPECT_EQ(ssize(graph.joint_types()), 4);
+  // Now get rid of that junk.
+  graph.Clear();
+  EXPECT_EQ(ssize(graph.links()), 1);  // World
+  EXPECT_TRUE(graph.joints().empty());
+  EXPECT_EQ(ssize(graph.joint_types()), 3);  // Predefineds
+  EXPECT_FALSE(graph.forest_is_valid());
+
+  // Make sure Clear() saved the existing forest.
+  const SpanningForest& same_forest = graph.forest();
+  EXPECT_EQ(&same_forest, &forest);
+  EXPECT_EQ(&forest.graph(), &graph);
+  EXPECT_FALSE(graph.forest_is_valid());
+  graph.BuildForest();  // OK to build even with just World in graph.
+  EXPECT_TRUE(graph.forest_is_valid());
+}
+
+// Make sure AddLink() rejects obvious errors.
+GTEST_TEST(LinkJointGraph, AddLinkErrors) {
+  LinkJointGraph graph;
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddLink("not_world", world_model_instance()),
+      "AddLink.*Model instance.*0.*reserved for.*World.*");
+
+  graph.AddLink("link1", ModelInstanceIndex(3));
+  graph.AddLink("link1", ModelInstanceIndex(4));  // OK, different instance.
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddLink("link1", ModelInstanceIndex(3)),
+      "AddLink.*already a link named.*link1.*model instance.*3.*");
+
+  // Addlink accepts flags, but not Shadow which is set internally only.
+  const BodyIndex link2_index =
+      graph.AddLink("link2", ModelInstanceIndex(3),
+                    LinkFlags::kTreatAsMassless | LinkFlags::kMustBeBaseBody);
+  const LinkJointGraph::Link& link2 = graph.links(link2_index);
+  EXPECT_TRUE(link2.treat_as_massless() && link2.must_be_base_body());
+  EXPECT_FALSE(link2.is_static() || link2.is_shadow());
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddLink("link3", ModelInstanceIndex(3), LinkFlags::kShadow),
+      "AddLink.*Can't add.*link3.*Shadow flag.*");
+}
+
+// LinkJointGraph collects and organizes some input information to facilitate
+// efficent forest building. Make sure that's done correctly.
+GTEST_TEST(LinkJointGraph, InternalListsAreBuiltCorrectly) {
+  LinkJointGraph graph;
+
+  const BodyIndex link1_index =
+      graph.AddLink("link1", default_model_instance(), LinkFlags::kStatic);
+  const BodyIndex link2_index = graph.AddLink("link2", default_model_instance(),
+                                              LinkFlags::kMustBeBaseBody);
+  const BodyIndex link3_index =
+      graph.AddLink("link3", default_model_instance(),
+                    LinkFlags::kStatic | LinkFlags::kMustBeBaseBody);
+
+  // Links 1 and 3 are static.
+  EXPECT_EQ(LinkJointGraphTester::static_links(graph),
+            (std::vector<BodyIndex>{link1_index, link3_index}));
+  // But only link 2 should be on the non-static must be base body list.
+  EXPECT_EQ(LinkJointGraphTester::non_static_must_be_base_body_links(graph),
+            std::vector<BodyIndex>{link2_index});
+}
+
+// Check operation of the public members of the Link subclass.
+GTEST_TEST(LinkJoinGraph, LinkTest) {
+  LinkJointGraph::Link link5 = LinkJointGraphTester::MakeLink(
+      BodyIndex(5), "link5", ModelInstanceIndex(7), LinkFlags::kMustBeBaseBody);
+  EXPECT_EQ(link5.index(), BodyIndex(5));
+  EXPECT_EQ(link5.model_instance(), ModelInstanceIndex(7));
+  EXPECT_EQ(link5.name(), "link5");
+
+  // Check flags.
+  EXPECT_FALSE(link5.is_world());
+  EXPECT_FALSE(link5.is_anchored());
+  EXPECT_FALSE(link5.is_static());
+  EXPECT_FALSE(link5.treat_as_massless());
+  EXPECT_FALSE(link5.is_shadow());
+  EXPECT_TRUE(link5.must_be_base_body());
+  LinkJointGraphTester::set_link_flags(LinkFlags::kStatic, &link5);
+  EXPECT_TRUE(link5.is_static());
+  EXPECT_TRUE(link5.is_anchored());  // Static links are anchored to World.
+  EXPECT_TRUE(link5.must_be_base_body());   // Unchanged.
+  EXPECT_FALSE(link5.treat_as_massless());  // Unchanged.
+
+  // Only LinkJointGraph sets these; no public interface.
+  EXPECT_TRUE(link5.joints().empty());
+  EXPECT_TRUE(link5.joints_as_parent().empty());
+  EXPECT_TRUE(link5.joints_as_child().empty());
+  EXPECT_EQ(link5.num_shadows(), 0);
+  EXPECT_FALSE(link5.primary_link().is_valid());
+  EXPECT_FALSE(link5.mobod_index().is_valid());
+  EXPECT_FALSE(link5.inboard_joint_index().is_valid());
+  EXPECT_FALSE(link5.composite().is_valid());
+}
+
+// Check operation of the public members of the Joint subclass.
+GTEST_TEST(LinkJointGraph, JointTest) {
+  const BodyIndex parent_index(1);
+  const BodyIndex child_index(2);
+  const BodyIndex other_body_index(3);  // Not connected by joint3.
+  LinkJointGraph::Joint joint3 = LinkJointGraphTester::MakeJoint(
+      JointIndex(3), "joint3", ModelInstanceIndex(9),
+      LinkJointGraph::rpy_floating_joint_type_index(), parent_index,
+      child_index, JointFlags::kMustBeModeled);
+  EXPECT_EQ(joint3.index(), JointIndex(3));
+  EXPECT_EQ(joint3.model_instance(), ModelInstanceIndex(9));
+  EXPECT_EQ(joint3.name(), "joint3");
+  EXPECT_EQ(joint3.parent_link(), parent_index);
+  EXPECT_EQ(joint3.child_link(), child_index);
+  EXPECT_FALSE(joint3.is_weld());
+  EXPECT_EQ(joint3.type_index(),
+            LinkJointGraph::rpy_floating_joint_type_index());
+  EXPECT_TRUE(joint3.connects(parent_index));
+  EXPECT_TRUE(joint3.connects(child_index));
+  EXPECT_FALSE(joint3.connects(other_body_index));
+  EXPECT_TRUE(joint3.connects(parent_index, child_index));
+  EXPECT_TRUE(joint3.connects(child_index, parent_index));
+  EXPECT_FALSE(joint3.connects(parent_index, other_body_index));
+  EXPECT_TRUE(joint3.must_be_modeled());
+  EXPECT_FALSE(joint3.mobod_index().is_valid());
+  EXPECT_FALSE(joint3.has_been_processed());
+  EXPECT_EQ(joint3.other_link_index(parent_index), child_index);
+  EXPECT_EQ(joint3.other_link_index(child_index), parent_index);
+  LinkJointGraphTester::set_joint_flags(JointFlags::kDefault, &joint3);
+  EXPECT_FALSE(joint3.must_be_modeled());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
First PR in a chain to get #20225 merged in digestible pieces.

This contains a skeleton of the LinkJointGraph, with the full structure and documentation in place but minimal functionality and most of the APIs left out. There is also a stripped-down SpanningForest here which can be "built" and "cleared" but doesn't do anything.

Before reviewing this PR, please read the PR comments in #20225 to get the big picture. The main things requiring review in this smaller PR are:
- the overall design
- the administrative functionality: copy and move, modeling and unmodeling, basic setters and getters, etc.
- comments
- adequacy of unit tests
- whether this is a reasonable way to gradually introduce a big chunk of code into Drake

Please refer freely to #20225 to see where this is headed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20806)
<!-- Reviewable:end -->
