### PR TITLE
[pydrake] Release the GIL during "Run" functions

### DIFF
--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -24,11 +24,13 @@ class PyObjectValue : public drake::Value<Object> {
 
   // Override `Clone()` to perform a deep copy on the object.
   std::unique_ptr<AbstractValue> Clone() const override {
+    py::gil_scoped_acquire guard;
     return std::make_unique<PyObjectValue>(get_value().Clone());
   }
 
   // Override `SetFrom()` to perform a deep copy on the object.
   void SetFrom(const AbstractValue& other) override {
+    py::gil_scoped_acquire guard;
     get_mutable_value() = other.get_value<Object>().Clone();
   }
 };

--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -187,7 +187,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("Delete", &Class::Delete, cls_doc.Delete.doc)
         .def("Run", &Class::Run, py::arg("diagram"),
             py::arg("timeout") = py::none(),
-            py::arg("stop_button_keycode") = "Escape", cls_doc.Run.doc)
+            py::arg("stop_button_keycode") = "Escape",
+            // This is a long-running function that sleeps; for both reasons, we
+            // must release the GIL.
+            py::call_guard<py::gil_scoped_release>(), cls_doc.Run.doc)
         .def("SetPositions", &Class::SetPositions, py::arg("q"),
             cls_doc.SetPositions.doc);
   }

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -28,6 +28,7 @@ namespace {
 // https://docs.python.org/3/c-api/exceptions.html#c.PyErr_CheckSignals
 // https://pybind11.readthedocs.io/en/stable/faq.html#how-can-i-properly-handle-ctrl-c-in-long-running-functions
 void ThrowIfPythonHasPendingSignals() {
+  py::gil_scoped_acquire guard;
   if (PyErr_CheckSignals() != 0) {
     throw py::error_already_set();
   }
@@ -240,6 +241,9 @@ PYBIND11_MODULE(analysis, m) {
               return self->AdvanceTo(boundary_time);
             },
             py::arg("boundary_time"), py::arg("interruptible") = true,
+            // This is a long-running function that might sleep; for both
+            // reasons, we must release the GIL.
+            py::call_guard<py::gil_scoped_release>(),
             // Amend the docstring with the additional parameter.
             []() {
               std::string new_doc = doc.Simulator.AdvanceTo.doc;

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -172,6 +172,7 @@ struct Impl {
     // trampoline if this is needed outside of LeafSystem.
     void DoGetWitnessFunctions(const Context<T>& context,
         std::vector<const WitnessFunction<T>*>* witnesses) const override {
+      py::gil_scoped_acquire guard;
       auto wrapped =
           [&]() -> std::optional<std::vector<const WitnessFunction<T>*>> {
         PYBIND11_OVERLOAD_INT(

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -47,6 +47,7 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
 
   void Deserialize(const void* message_bytes, int message_length,
       AbstractValue* abstract_value) const override {
+    py::gil_scoped_acquire guard;
     py::bytes buffer(
         reinterpret_cast<const char*>(message_bytes), message_length);
     PYBIND11_OVERLOAD_PURE(
@@ -55,6 +56,7 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
 
   void Serialize(const AbstractValue& abstract_value,
       std::vector<uint8_t>* message_bytes) const override {
+    py::gil_scoped_acquire guard;
     auto wrapped = [&]() -> py::bytes {
       // N.B. We must pass `abstract_value` as a pointer to prevent `pybind11`
       // from copying it.

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -4,7 +4,6 @@ Test bindings of LCM integration with the Systems framework.
 import pydrake.systems.lcm as mut
 
 import collections
-from multiprocessing import Process
 import time
 import unittest
 

--- a/bindings/pydrake/visualization/visualization_py_sliders.cc
+++ b/bindings/pydrake/visualization/visualization_py_sliders.cc
@@ -47,7 +47,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("Delete", &Class::Delete, cls_doc.Delete.doc)
         .def("Run", &Class::Run, py::arg("system"), py::arg("context"),
             py::arg("timeout") = py::none(),
-            py::arg("stop_button_keycode") = "Escape", cls_doc.Run.doc)
+            py::arg("stop_button_keycode") = "Escape",
+            // This is a long-running function that sleeps; for both reasons, we
+            // must release the GIL.
+            py::call_guard<py::gil_scoped_release>(), cls_doc.Run.doc)
         .def("SetPose", &Class::SetPose, py::arg("pose"), cls_doc.SetPose.doc);
   }
 }


### PR DESCRIPTION
Functions that run indefinitely (or sleep) in C++ should release the GIL so that other Python-based work can be scheduled on some other thread.

Fixing the Run functions releasing pointed out a few places we were missing some `scoped_acquire` annotations (in non-trivial `PYBIND11_OVERRIDE` bodies).  The `pybind11` library has built-in checks that flag those oversights in Debug builds, so CI caught and reminded us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20811)
<!-- Reviewable:end -->
