### PR TITLE
Add instructions to upgrade crate_universe monthly

### DIFF
--- a/tools/workspace/README.md
+++ b/tools/workspace/README.md
@@ -80,6 +80,14 @@ report anytime, to get the remaining items that need attention.  You can also
 list several externals to try to update at once, although this will complicate
 making changes to those commits if needed.
 
+Finally, crate_universe needs to be updated manually by running
+tools/workspace/crate_universe/upgrade.sh. This may result in a number of files
+in ``tools/workspace/crate_universe/lock`` being added, removed or changed.
+In this case, commit *all* such changes with the commit message
+``[workspace] Upgrade crate_universe to latest``.
+If the update is included with another 'cohort' package, use the message
+``[workspace] Upgrade <COHORT(S)>, crate_universe to latest``.
+
 Each external being upgraded should have exactly one commit that does the
 upgrade, and each commit should either a) only impact exactly one external, or
 b) impact exactly those externals of a cohort which need to be upgraded.  If we

--- a/tools/workspace/clarabel_cpp_internal/repository.bzl
+++ b/tools/workspace/clarabel_cpp_internal/repository.bzl
@@ -6,6 +6,10 @@ def clarabel_cpp_internal_repository(
     github_archive(
         name = name,
         repository = "oxfordcontrol/Clarabel.cpp",
+        upgrade_advice = """
+        When updating, any crate_universe changes should be made in the same
+        commit. See tools/workspace/README.md.
+        """,
         commit = "v0.6.0",
         sha256 = "281b1cbbe7e15520ad17a74d91f0ef9d83161ee79c0ff1954187f78c4516c8ec",  # noqa
         build_file = ":package.BUILD.bazel",


### PR DESCRIPTION
Add a paragraph to the monthly upgrades documentation that describes how to perform the crate_universe upgrade. Note that this should be done as a 'cohort' with clarabel_cpp if/when that is upgraded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20815)
<!-- Reviewable:end -->
