### PR TITLE
Implements mixing for uniform sampling in HPolyhedra

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -267,12 +267,13 @@ void DefineGeometryOptimization(py::module m) {
             overload_cast_explicit<Eigen::VectorXd, RandomGenerator*,
                 const Eigen::Ref<const Eigen::VectorXd>&, const int>(
                 &HPolyhedron::UniformSample),
-            py::arg("generator"), py::arg("previous_sample"), py::arg("mixing_steps"),
-            cls_doc.UniformSample.doc_3args)
+            py::arg("generator"), py::arg("previous_sample"),
+            py::arg("mixing_steps") = 10, cls_doc.UniformSample.doc_3args)
         .def("UniformSample",
-            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*, const int>(
-                &HPolyhedron::UniformSample),
-            py::arg("generator"),py::arg("mixing_steps"), cls_doc.UniformSample.doc_2args)
+            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*,
+                const int>(&HPolyhedron::UniformSample),
+            py::arg("generator"), py::arg("mixing_steps") = 10,
+            cls_doc.UniformSample.doc_2args)
         .def_static("MakeBox", &HPolyhedron::MakeBox, py::arg("lb"),
             py::arg("ub"), cls_doc.MakeBox.doc)
         .def_static("MakeUnitBox", &HPolyhedron::MakeUnitBox, py::arg("dim"),

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -265,14 +265,14 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("other"), cls_doc.PontryaginDifference.doc)
         .def("UniformSample",
             overload_cast_explicit<Eigen::VectorXd, RandomGenerator*,
-                const Eigen::Ref<const Eigen::VectorXd>&>(
+                const Eigen::Ref<const Eigen::VectorXd>&, const int>(
                 &HPolyhedron::UniformSample),
-            py::arg("generator"), py::arg("previous_sample"),
-            cls_doc.UniformSample.doc_2args)
+            py::arg("generator"), py::arg("previous_sample"), py::arg("mixing_steps"),
+            cls_doc.UniformSample.doc_3args)
         .def("UniformSample",
-            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*>(
+            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*, const int>(
                 &HPolyhedron::UniformSample),
-            py::arg("generator"), cls_doc.UniformSample.doc_1args)
+            py::arg("generator"),py::arg("mixing_steps"), cls_doc.UniformSample.doc_2args)
         .def_static("MakeBox", &HPolyhedron::MakeBox, py::arg("lb"),
             py::arg("ub"), cls_doc.MakeBox.doc)
         .def_static("MakeUnitBox", &HPolyhedron::MakeUnitBox, py::arg("dim"),

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -265,13 +265,13 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("other"), cls_doc.PontryaginDifference.doc)
         .def("UniformSample",
             overload_cast_explicit<Eigen::VectorXd, RandomGenerator*,
-                const Eigen::Ref<const Eigen::VectorXd>&, const int>(
+                const Eigen::Ref<const Eigen::VectorXd>&, int>(
                 &HPolyhedron::UniformSample),
             py::arg("generator"), py::arg("previous_sample"),
             py::arg("mixing_steps") = 10, cls_doc.UniformSample.doc_3args)
         .def("UniformSample",
-            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*,
-                const int>(&HPolyhedron::UniformSample),
+            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*, int>(
+                &HPolyhedron::UniformSample),
             py::arg("generator"), py::arg("mixing_steps") = 10,
             cls_doc.UniformSample.doc_2args)
         .def_static("MakeBox", &HPolyhedron::MakeBox, py::arg("lb"),

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -237,14 +237,14 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertIsInstance(h5, mut.HPolyhedron)
         np.testing.assert_array_equal(h5.A(), h_box.A())
         np.testing.assert_array_equal(h5.b(), np.zeros(6))
-
         generator = RandomGenerator()
         sample = h_box.UniformSample(generator=generator)
         self.assertEqual(sample.shape, (3,))
         self.assertEqual(
             h_box.UniformSample(generator=generator,
-                                previous_sample=sample).shape, (3, ))
-        h_box.UniformSample(generator=generator, mixing_steps=100)
+                                previous_sample=sample,
+                                mixing_steps=7).shape, (3, ))
+        h_box.UniformSample(generator=generator, mixing_steps=7)
         h_half_box = mut.HPolyhedron.MakeBox(
             lb=[-0.5, -0.5, -0.5], ub=[0.5, 0.5, 0.5])
         self.assertTrue(h_half_box.ContainedIn

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -244,7 +244,7 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(
             h_box.UniformSample(generator=generator,
                                 previous_sample=sample).shape, (3, ))
-
+        h_box.UniformSample(generator=generator, mixing_steps=100)
         h_half_box = mut.HPolyhedron.MakeBox(
             lb=[-0.5, -0.5, -0.5], ub=[0.5, 0.5, 0.5])
         self.assertTrue(h_half_box.ContainedIn

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -388,14 +388,14 @@ VectorXd HPolyhedron::UniformSample(
     const Eigen::Ref<const Eigen::VectorXd>& previous_sample,
     const int mixing_steps) const {
   std::normal_distribution<double> gaussian;
-  
+
   VectorXd direction(ambient_dimension());
   VectorXd current_sample = previous_sample;
-  
-  for(int step = 0; step<mixing_steps; ++step){
+
+  for (int step = 0; step < mixing_steps; ++step) {
     // Choose a random direction.
     for (int i = 0; i < direction.size(); ++i) {
-        direction[i] = gaussian(*generator);
+      direction[i] = gaussian(*generator);
     }
     // Find max and min θ subject to
     //   A(previous_sample + θ*direction) ≤ b,
@@ -405,18 +405,21 @@ VectorXd HPolyhedron::UniformSample(
     double theta_max = std::numeric_limits<double>::infinity();
     double theta_min = -theta_max;
     for (int i = 0; i < line_a.size(); ++i) {
-    if (line_a[i] < 0.0) {
+      if (line_a[i] < 0.0) {
         theta_min = std::max(theta_min, line_b[i] / line_a[i]);
-    } else if (line_a[i] > 0.0) {
+      } else if (line_a[i] > 0.0) {
         theta_max = std::min(theta_max, line_b[i] / line_a[i]);
+      }
     }
-    }
-    if (std::isinf(theta_max) || std::isinf(theta_min) || theta_max < theta_min) {
-    throw std::invalid_argument(fmt::format(
-        "The Hit and Run algorithm failed to find a feasible point in the set. "
-        "The `previous_sample` must be in the set.\nmax(A * previous_sample - "
-        "b) = {}",
-        (A_ * current_sample - b_).maxCoeff()));
+    if (std::isinf(theta_max) || std::isinf(theta_min) ||
+        theta_max < theta_min) {
+      throw std::invalid_argument(
+          fmt::format("The Hit and Run algorithm failed to find a feasible "
+                      "point in the set. "
+                      "The `previous_sample` must be in the set.\nmax(A * "
+                      "previous_sample - "
+                      "b) = {}",
+                      (A_ * current_sample - b_).maxCoeff()));
     }
     // Now pick θ uniformly from [θ_min, θ_max).
     std::uniform_real_distribution<double> uniform_theta(theta_min, theta_max);
@@ -430,7 +433,8 @@ VectorXd HPolyhedron::UniformSample(
 // Note: This method only exists to effectively provide ChebyshevCenter(),
 // which is a non-static class method, as a default argument for
 // previous_sample in the UniformSample method above.
-VectorXd HPolyhedron::UniformSample(RandomGenerator* generator, const int mixing_steps) const {
+VectorXd HPolyhedron::UniformSample(RandomGenerator* generator,
+                                    const int mixing_steps) const {
   VectorXd center = ChebyshevCenter();
   return UniformSample(generator, center, mixing_steps);
 }

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -387,8 +387,9 @@ VectorXd HPolyhedron::UniformSample(
     RandomGenerator* generator,
     const Eigen::Ref<const Eigen::VectorXd>& previous_sample,
     const int mixing_steps) const {
-  std::normal_distribution<double> gaussian;
+  DRAKE_THROW_UNLESS(mixing_steps >= 1);
 
+  std::normal_distribution<double> gaussian;
   VectorXd direction(ambient_dimension());
   VectorXd current_sample = previous_sample;
 

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -414,13 +414,11 @@ VectorXd HPolyhedron::UniformSample(
     }
     if (std::isinf(theta_max) || std::isinf(theta_min) ||
         theta_max < theta_min) {
-      throw std::invalid_argument(
-          fmt::format("The Hit and Run algorithm failed to find a feasible "
-                      "point in the set. "
-                      "The `previous_sample` must be in the set.\nmax(A * "
-                      "previous_sample - "
-                      "b) = {}",
-                      (A_ * current_sample - b_).maxCoeff()));
+      throw std::invalid_argument(fmt::format(
+          "The Hit and Run algorithm failed to find a feasible point in the "
+          "set. The `previous_sample` must be in the set.\n"
+          "max(A * previous_sample - b) = {}",
+          (A_ * current_sample - b_).maxCoeff()));
     }
     // Now pick θ uniformly from [θ_min, θ_max).
     std::uniform_real_distribution<double> uniform_theta(theta_min, theta_max);

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -191,11 +191,11 @@ class HPolyhedron final : public ConvexSet {
   @throws std::exception if previous_sample is not in the set. */
   Eigen::VectorXd UniformSample(
       RandomGenerator* generator,
-      const Eigen::Ref<const Eigen::VectorXd>& previous_sample) const;
+      const Eigen::Ref<const Eigen::VectorXd>& previous_sample, const int mixing_steps = 10) const;
 
   /** Variant of UniformSample that uses the ChebyshevCenter() as the
   previous_sample as a feasible point to start the Markov chain sampling. */
-  Eigen::VectorXd UniformSample(RandomGenerator* generator) const;
+  Eigen::VectorXd UniformSample(RandomGenerator* generator, const int mixing_steps = 10) const;
 
   /** Constructs a polyhedron as an axis-aligned box from the lower and upper
   corners. */

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -194,12 +194,12 @@ class HPolyhedron final : public ConvexSet {
   Eigen::VectorXd UniformSample(
       RandomGenerator* generator,
       const Eigen::Ref<const Eigen::VectorXd>& previous_sample,
-      const int mixing_steps = 10) const;
+      int mixing_steps = 10) const;
 
   /** Variant of UniformSample that uses the ChebyshevCenter() as the
   previous_sample as a feasible point to start the Markov chain sampling. */
   Eigen::VectorXd UniformSample(RandomGenerator* generator,
-                                const int mixing_steps = 10) const;
+                                int mixing_steps = 10) const;
 
   /** Constructs a polyhedron as an axis-aligned box from the lower and upper
   corners. */

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -187,7 +187,8 @@ class HPolyhedron final : public ConvexSet {
   `previous_sample` to the next; in this case the distribution of samples will
   converge to the true uniform distribution in total variation at a geometric
   rate.  If `previous_sample` is not set, then the ChebyshevCenter() will be
-  used to seed the algorithm.
+  used to seed the algorithm. Mixing steps sets the number of hit and run iterations
+  between samples.
   @throws std::exception if previous_sample is not in the set. */
   Eigen::VectorXd UniformSample(
       RandomGenerator* generator,

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -183,20 +183,23 @@ class HPolyhedron final : public ConvexSet {
   /** Draw an (approximately) uniform sample from the set using the hit and run
   Markov-chain Monte-Carlo strategy described in
   https://link.springer.com/article/10.1007/s101070050099.
-  To draw many samples from the uniform distribution, pass the output of one iteration
-  in as the `previous_sample` to the next, with `mixing_steps` set to a relatively low number.
-  When drawing a single sample, `mixing_steps` should be set relatively high in order to obtain
-  an approximately uniformly random point. The distribution of samples will converge to the true
-  uniform distribution at a geometric rate in the total number of hit-and-run steps which is
-  `mixing_steps` * the number of times this function is called.
+  To draw many samples from the uniform distribution, pass the output of one
+  iteration in as the `previous_sample` to the next, with `mixing_steps` set to
+  a relatively low number. When drawing a single sample, `mixing_steps` should
+  be set relatively high in order to obtain an approximately uniformly random
+  point. The distribution of samples will converge to the true uniform
+  distribution at a geometric rate in the total number of hit-and-run steps
+  which is `mixing_steps` * the number of times this function is called.
   @throws std::exception if previous_sample is not in the set. */
   Eigen::VectorXd UniformSample(
       RandomGenerator* generator,
-      const Eigen::Ref<const Eigen::VectorXd>& previous_sample, const int mixing_steps = 10) const;
+      const Eigen::Ref<const Eigen::VectorXd>& previous_sample,
+      const int mixing_steps = 10) const;
 
   /** Variant of UniformSample that uses the ChebyshevCenter() as the
   previous_sample as a feasible point to start the Markov chain sampling. */
-  Eigen::VectorXd UniformSample(RandomGenerator* generator, const int mixing_steps = 10) const;
+  Eigen::VectorXd UniformSample(RandomGenerator* generator,
+                                const int mixing_steps = 10) const;
 
   /** Constructs a polyhedron as an axis-aligned box from the lower and upper
   corners. */

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -181,14 +181,14 @@ class HPolyhedron final : public ConvexSet {
       const HPolyhedron& other) const;
 
   /** Draw an (approximately) uniform sample from the set using the hit and run
-  Markov-chain Monte-Carlo strategy described at
-  https://mathoverflow.net/a/162327 and the cited paper.
-  To generate many samples, pass the output of one iteration in as the
-  `previous_sample` to the next; in this case the distribution of samples will
-  converge to the true uniform distribution in total variation at a geometric
-  rate.  If `previous_sample` is not set, then the ChebyshevCenter() will be
-  used to seed the algorithm. Mixing steps sets the number of hit and run iterations
-  between samples.
+  Markov-chain Monte-Carlo strategy described in
+  https://link.springer.com/article/10.1007/s101070050099.
+  To draw many samples from the uniform distribution, pass the output of one iteration
+  in as the `previous_sample` to the next, with `mixing_steps` set to a relatively low number.
+  When drawing a single sample, `mixing_steps` should be set relatively high in order to obtain
+  an approximately uniformly random point. The distribution of samples will converge to the true
+  uniform distribution at a geometric rate in the total number of hit-and-run steps which is
+  `mixing_steps` * the number of times this function is called.
   @throws std::exception if previous_sample is not in the set. */
   Eigen::VectorXd UniformSample(
       RandomGenerator* generator,

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1094,7 +1094,6 @@ GTEST_TEST(HPolyhedronTest, UniformSampleTest) {
                   .count(),
               N / 10, kTol);
 }
-
 // Test the case where the sample point is outside the region, but the max
 // threshold can be smaller than the min threshold. (This was a bug uncovered
 // by hammering on this code from IRIS).
@@ -1140,7 +1139,33 @@ GTEST_TEST(HPolyhedronTest, UniformSampleTest2) {
   EXPECT_GT(num_throws, 0);
   EXPECT_GT(num_success, 0);
 }
+// Test that the argument mixing_steps is working by sampling three points: A
+// with 5 mixing steps starting from the Chebyshev center, B starting from the
+// same random seed as A, but with 2 mixing steps, and C starting from B with 2
+// mixing steps. We expect A==C but A!=B.
+GTEST_TEST(HPolyhedronTest, UniformSampleTest3) {
+  Matrix<double, 4, 2> D;
+  Vector4d e;
+  // clang-format off
+  D << -2, -1,  // 2x + y ≥ 4
+        2,  1,  // 2x + y ≤ 6
+       -1,  2,  // x - 2y ≥ 2
+        1, -2;  // x - 2y ≤ 8
+  e << -4, 6, -2, 8;
+  // clang-format on
+  HPolyhedron H(D, e);
 
+  // Draw random samples.
+  RandomGenerator generator(1234);
+  Vector2d A = H.UniformSample(&generator, 5);
+  RandomGenerator generator2(1234);
+  Vector2d B = H.UniformSample(&generator2, 2);
+  Vector2d C = H.UniformSample(&generator2, B, 3);
+  const double kTol = 1e-7;
+
+  EXPECT_TRUE(CompareMatrices(A, C, kTol));
+  EXPECT_FALSE(CompareMatrices(A, B, kTol));
+}
 GTEST_TEST(HPolyhedronTest, Serialize) {
   const HPolyhedron H = HPolyhedron::MakeL1Ball(3);
   const std::string yaml = yaml::SaveYamlString(H);

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1053,9 +1053,11 @@ GTEST_TEST(HPolyhedronTest, UniformSampleTest) {
   RandomGenerator generator(1234);
   const int N{10000};
   MatrixXd samples(2, N);
-  samples.col(0) = H.UniformSample(&generator);
+  const int mixing_steps{7};
+  samples.col(0) = H.UniformSample(&generator, mixing_steps);
   for (int i = 1; i < N; ++i) {
-    samples.col(i) = H.UniformSample(&generator, samples.col(i - 1));
+    samples.col(i) =
+        H.UniformSample(&generator, samples.col(i - 1), mixing_steps);
   }
 
   // Provide a visualization of the points.

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1037,7 +1037,7 @@ GTEST_TEST(HPolyhedronTest, PontryaginDifferenceTestNonAxisAligned) {
   EXPECT_TRUE(CompareMatrices(H_C.b(), H_C_expected.b(), 1e-8));
 }
 
-GTEST_TEST(HPolyhedronTest, UniformSampleTest) {
+GTEST_TEST(HPolyhedronTest, UniformSampleTest1) {
   Matrix<double, 4, 2> A;
   Vector4d b;
   // clang-format off
@@ -1094,6 +1094,7 @@ GTEST_TEST(HPolyhedronTest, UniformSampleTest) {
                   .count(),
               N / 10, kTol);
 }
+
 // Test the case where the sample point is outside the region, but the max
 // threshold can be smaller than the min threshold. (This was a bug uncovered
 // by hammering on this code from IRIS).
@@ -1139,6 +1140,7 @@ GTEST_TEST(HPolyhedronTest, UniformSampleTest2) {
   EXPECT_GT(num_throws, 0);
   EXPECT_GT(num_success, 0);
 }
+
 // Test that the argument mixing_steps is working by sampling three points: A
 // with 5 mixing steps starting from the Chebyshev center, B starting from the
 // same random seed as A, but with 2 mixing steps, and C starting from B with 2
@@ -1166,6 +1168,7 @@ GTEST_TEST(HPolyhedronTest, UniformSampleTest3) {
   EXPECT_TRUE(CompareMatrices(A, C, kTol));
   EXPECT_FALSE(CompareMatrices(A, B, kTol));
 }
+
 GTEST_TEST(HPolyhedronTest, Serialize) {
   const HPolyhedron H = HPolyhedron::MakeL1Ball(3);
   const std::string yaml = yaml::SaveYamlString(H);


### PR DESCRIPTION
More than a single step of hit and run between samples is required to get a distribuiton that converges to a uniform distribution for general HPolyhedra. This PR adds an optional argument 'mixing_steps' that sets the number of hit and run iterations between samples.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20817)
<!-- Reviewable:end -->
