### PR TITLE
Patch VTK's glTF parser logic

### DIFF
--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -181,4 +181,33 @@ drake_cc_googletest(
     ],
 )
 
+# The generated glTF file can be removed when we're no longer testing the glTF
+# parser patch (see :internal_vtk_gltf_parser_patch_test).
+
+genrule(
+    name = "gltf_pyramid_no_color_texture",
+    srcs = ["//geometry/render:test/meshes/fully_textured_pyramid.gltf"],
+    outs = ["test/pyramid_no_color_texture.gltf"],
+    cmd = "sed '/baseColorTexture/,/},/d' $< > $@",
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "patch_test_models",
+    testonly = 1,
+    srcs = [":gltf_pyramid_no_color_texture"],
+)
+
+drake_cc_googletest(
+    name = "internal_vtk_gltf_parser_patch_test",
+    data = [":patch_test_models"],
+    deps = [
+        ":factory",
+        "//common:find_resource",
+        "@vtk_internal//:vtkCommonCore",
+        "@vtk_internal//:vtkIOImport",
+        "@vtk_internal//:vtkRenderingCore",
+    ],
+)
+
 add_lint_tests()

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -459,6 +459,8 @@ bool RenderEngineVtk::ImplementObj(const std::string& file_name, double scale,
 
 bool RenderEngineVtk::ImplementGltf(const std::string& file_name, double scale,
                                     const RegistrationData& data) {
+  // TODO(SeanCurtis-TRI): introduce VtkDiagnosticEventObserver on the gltf
+  // importer (see systems/sensors/image_io_load.cc).
   vtkNew<vtkGLTFImporter> importer;
   importer->SetFileName(file_name.c_str());
   importer->Update();

--- a/geometry/render_vtk/test/internal_vtk_gltf_parser_patch_test.cc
+++ b/geometry/render_vtk/test/internal_vtk_gltf_parser_patch_test.cc
@@ -1,0 +1,74 @@
+/* This test supports the patch in internal_vtk/patches/gltf_parser.patch. A
+ condition of removing that patch is that these tests should still pass.
+
+ The patch does several things -- not all of which are tested here.
+
+   Defect 1:
+     - When a glTF has a material with textures *but no color texture*, VTK
+       throws out all of the textures.
+     - Test by loading such a glTF and confirm that the specified textures are
+       present.
+   Defect 2:
+     - For the glTF file described in defect 1, the glTF importer would
+       incorrectly conclude that the glTF had multiple sets of texture
+       coordinates.
+     - This is *not* tested because it would manifest itself as a warning
+       written to the console (which we can't detect here). When the TODO in
+       RenderEngineVtk::ImplementGltf is resolved, we can test it here. (There
+       should be no logged warning). However, if the patch under test is not
+       applied, the test fails and the resultant console dump includes the
+       warning.
+    Defect 3:
+      - The VTK importer would force the warnings to go to the console, ignoring
+        any event observers registered with the importer.
+      - This, again, can only be tested once the TODO in
+        RenderEngineVtk::ImplementGltf is resolved. */
+
+#include <gtest/gtest.h>
+
+// To ease build system upkeep, we annotate VTK includes with their deps.
+#include <vtkGLTFImporter.h>  // vtkIOImport
+#include <vtkNew.h>           // vtkCommonCore
+#include <vtkProperty.h>      // vtkRenderingCore
+#include <vtkRenderer.h>      // vtkRenderingCore
+
+#include "drake/common/find_resource.h"
+#include "drake/geometry/render_vtk/factory.h"
+
+namespace drake {
+namespace {
+
+// The test for defect 1 (described above).
+GTEST_TEST(VtkGltfParserPatchTest, ColorTextureNotRequired) {
+  // Instantiating RenderEngineVtk implicitly initializes VTK to use OpenGL.
+  geometry::MakeRenderEngineVtk({});
+
+  // This glTF uses all supported glTF textures types *except* base color.
+  const std::string gltf_path = FindResourceOrThrow(
+      "drake/geometry/render_vtk/test/pyramid_no_color_texture.gltf");
+  vtkNew<vtkGLTFImporter> importer;
+  importer->SetFileName(gltf_path.c_str());
+  importer->Update();
+
+  vtkRenderer* renderer = importer->GetRenderer();
+  DRAKE_DEMAND(renderer != nullptr);
+  ASSERT_EQ(renderer->VisibleActorCount(), 1);
+
+  auto* actors = renderer->GetActors();
+  actors->InitTraversal();
+  vtkActor* actor = actors->GetNextActor();
+
+  // We expect no color texture (aka "albedo"), but all of the other supported
+  // textures. These names are lifted from VTK's code -- it is the name VTK
+  // gives to the various textures instantiated by the glTF parser.
+  EXPECT_EQ(actor->GetProperty()->GetTexture("albedoTex"), nullptr);
+  EXPECT_NE(actor->GetProperty()->GetTexture("normalTex"), nullptr);
+  EXPECT_NE(actor->GetProperty()->GetTexture("emissiveTex"), nullptr);
+  // Material includes ambient occlusion in R, roughness in G, and metallic in
+  // B. We don't need to check the values; the presence of the texture is
+  // enough.
+  EXPECT_NE(actor->GetProperty()->GetTexture("materialTex"), nullptr);
+}
+
+}  // namespace
+}  // namespace drake

--- a/tools/workspace/vtk_internal/patches/gltf_parser.patch
+++ b/tools/workspace/vtk_internal/patches/gltf_parser.patch
@@ -1,0 +1,155 @@
+This corrects a few defects in VTK's glTF parsing.
+
+The first defects share a common origin: VTK assumes that if *any* texture is
+present, it must be the base color texture. If this texture is missing, then
+other textures confuse VTK, leading to spurious warnings (multiple sets of UVs
+defined) and otherwise cause the textures to get ignored.
+
+We address this with two independent changes:
+
+  - Change the logic that the glTF parser uses to determine if a mesh primitive
+    has been defined with multiple sets of uv coordinates.
+  - Make the inclusion of metallic, normal, emmissive, and ambient occlusion
+    maps *no longer* dependent on the presence of a base color map.
+
+Furthermore, those warnings use the vtkWarningWithObjectMacro in a way which
+forces the messages to be written directly to the console. We change the
+calls so that it gets registered with an objects event listener so that Drake
+can choose to capture the warnings and present as it sees fit.
+
+These changes *should* be upstreamed to VTK.
+
+--- IO/Geometry/vtkGLTFDocumentLoader.h
++++ IO/Geometry/vtkGLTFDocumentLoader.h
+@@ -265,7 +265,7 @@ public:
+   struct TextureInfo
+   {
+     int Index = -1;
+-    int TexCoord;
++    int TexCoord = -1;
+   };
+ 
+   /**
+
+--- IO/Import/vtkGLTFImporter.cxx
++++ IO/Import/vtkGLTFImporter.cxx
+@@ -43,6 +43,7 @@
+ 
+ #include <algorithm>
+ #include <array>
++#include <set>
+ #include <stack>
+ 
+ VTK_ABI_NAMESPACE_BEGIN
+@@ -80,7 +81,8 @@ vtkSmartPointer<vtkCamera> GLTFCameraToVTKCamera(const vtkGLTFDocumentLoader::Ca
+ //------------------------------------------------------------------------------
+ vtkSmartPointer<vtkTexture> CreateVTKTextureFromGLTFTexture(
+   std::shared_ptr<vtkGLTFDocumentLoader::Model> model, int textureIndex,
+-  std::map<int, vtkSmartPointer<vtkTexture>>& existingTextures)
++  std::map<int, vtkSmartPointer<vtkTexture>>& existingTextures,
++  vtkGLTFImporter* parent)
+ {
+ 
+   if (existingTextures.count(textureIndex))
+@@ -160,14 +162,23 @@ vtkSmartPointer<vtkTexture> CreateVTKTextureFromGLTFTexture(
+ }
+ 
+ //------------------------------------------------------------------------------
+-bool MaterialHasMultipleUVs(const vtkGLTFDocumentLoader::Material& material)
++bool MaterialHasMultipleUVs(const vtkGLTFDocumentLoader::Material& material,
++                            vtkGLTFImporter* parent)
+ {
+-  int firstUV = material.PbrMetallicRoughness.BaseColorTexture.TexCoord;
+-  return (material.EmissiveTexture.Index >= 0 && material.EmissiveTexture.TexCoord != firstUV) ||
+-    (material.NormalTexture.Index >= 0 && material.NormalTexture.TexCoord != firstUV) ||
+-    (material.OcclusionTexture.Index >= 0 && material.OcclusionTexture.TexCoord != firstUV) ||
+-    (material.PbrMetallicRoughness.MetallicRoughnessTexture.Index >= 0 &&
+-      material.PbrMetallicRoughness.MetallicRoughnessTexture.TexCoord != firstUV);
++  std::set<int> uv_sets;
++  for (const vtkGLTFDocumentLoader::TextureInfo& info :
++    { material.PbrMetallicRoughness.BaseColorTexture, material.EmissiveTexture,
++      material.NormalTexture, material.OcclusionTexture,
++      material.PbrMetallicRoughness.MetallicRoughnessTexture })
++  {
++    if (info.Index >= 0) uv_sets.insert(info.TexCoord);
++  }
++  if (uv_sets.count(-1) > 0) {
++    vtkErrorWithObjectMacro(parent,
++                            "A material defined a texture index without "
++                            "defining a texture coordinate set.");
++  }
++  return uv_sets.size() > 1;
+ }
+ 
+ //------------------------------------------------------------------------------
+@@ -188,15 +199,16 @@ bool PrimitiveNeedsTangents(const std::shared_ptr<vtkGLTFDocumentLoader::Model>
+ //------------------------------------------------------------------------------
+ void ApplyGLTFMaterialToVTKActor(std::shared_ptr<vtkGLTFDocumentLoader::Model> model,
+   vtkGLTFDocumentLoader::Primitive& primitive, vtkSmartPointer<vtkActor> actor,
+-  std::map<int, vtkSmartPointer<vtkTexture>>& existingTextures)
++  std::map<int, vtkSmartPointer<vtkTexture>>& existingTextures,
++  vtkGLTFImporter* parent)
+ {
+   vtkGLTFDocumentLoader::Material& material = model->Materials[primitive.Material];
+ 
+-  bool hasMultipleUVs = MaterialHasMultipleUVs(material);
++  bool hasMultipleUVs = MaterialHasMultipleUVs(material, parent);
+   if (hasMultipleUVs)
+   {
+     vtkWarningWithObjectMacro(
+-      nullptr, "Using multiple texture coordinates for the same model is not supported.");
++      parent, "Using multiple texture coordinates for the same model is not supported.");
+   }
+   auto property = actor->GetProperty();
+   property->SetInterpolationToPBR();
+@@ -233,9 +245,10 @@ void ApplyGLTFMaterialToVTKActor(std::shared_ptr<vtkGLTFDocumentLoader::Model> m
+   {
+     // set albedo texture
+     vtkSmartPointer<vtkTexture> baseColorTex;
+-    baseColorTex = CreateVTKTextureFromGLTFTexture(model, texIndex, existingTextures);
++    baseColorTex = CreateVTKTextureFromGLTFTexture(model, texIndex, existingTextures, parent);
+     baseColorTex->UseSRGBColorSpaceOn();
+     property->SetBaseColorTexture(baseColorTex);
++  }
+ 
+     // merge ambient occlusion and metallic/roughness, then set material texture
+     int pbrTexIndex = material.PbrMetallicRoughness.MetallicRoughnessTexture.Index;
+@@ -291,7 +304,7 @@ void ApplyGLTFMaterialToVTKActor(std::shared_ptr<vtkGLTFDocumentLoader::Model> m
+         {
+           pbrImage.ImageData->GetPointData()->GetScalars()->FillComponent(0, 255);
+         }
+-        auto materialTex = CreateVTKTextureFromGLTFTexture(model, pbrTexIndex, existingTextures);
++        auto materialTex = CreateVTKTextureFromGLTFTexture(model, pbrTexIndex, existingTextures, parent);
+         property->SetORMTexture(materialTex);
+       }
+     }
+@@ -300,7 +313,7 @@ void ApplyGLTFMaterialToVTKActor(std::shared_ptr<vtkGLTFDocumentLoader::Model> m
+     int emissiveTexIndex = material.EmissiveTexture.Index;
+     if (emissiveTexIndex >= 0 && emissiveTexIndex < static_cast<int>(model->Textures.size()))
+     {
+-      auto emissiveTex = CreateVTKTextureFromGLTFTexture(model, emissiveTexIndex, existingTextures);
++      auto emissiveTex = CreateVTKTextureFromGLTFTexture(model, emissiveTexIndex, existingTextures, parent);
+       emissiveTex->UseSRGBColorSpaceOn();
+       property->SetEmissiveTexture(emissiveTex);
+     }
+@@ -309,10 +322,9 @@ void ApplyGLTFMaterialToVTKActor(std::shared_ptr<vtkGLTFDocumentLoader::Model> m
+     if (normalMapIndex >= 0 && normalMapIndex < static_cast<int>(model->Textures.size()))
+     {
+       actor->GetProperty()->SetNormalScale(material.NormalTextureScale);
+-      auto normalTex = CreateVTKTextureFromGLTFTexture(model, normalMapIndex, existingTextures);
++      auto normalTex = CreateVTKTextureFromGLTFTexture(model, normalMapIndex, existingTextures, parent);
+       property->SetNormalTexture(normalTex);
+     }
+-  }
+ 
+   // extension KHR_materials_unlit
+   actor->GetProperty()->SetLighting(!material.Unlit);
+@@ -496,7 +508,7 @@ void vtkGLTFImporter::ImportActors(vtkRenderer* renderer)
+         if (primitive.Material >= 0 &&
+           primitive.Material < static_cast<int>(model->Materials.size()))
+         {
+-          ApplyGLTFMaterialToVTKActor(model, primitive, actor, this->Textures);
++          ApplyGLTFMaterialToVTKActor(model, primitive, actor, this->Textures, this);
+         }
+         renderer->AddActor(actor);
+ 

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -149,6 +149,7 @@ vtk_internal_repository = repository_rule(
                 "@drake//tools/workspace/vtk_internal:patches/common_core_vs_data_model_cycle.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/common_core_warnings.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/common_data_model_warnings.patch",  # noqa
+                "@drake//tools/workspace/vtk_internal:patches/gltf_parser.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/io_image_formats.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/io_image_png_messages.patch",  # noqa
                 "@drake//tools/workspace/vtk_internal:patches/io_legacy_data_reader_uninit.patch",  # noqa


### PR DESCRIPTION
Patches some bugs in VTK's glTF parsing.

 - A material with only non-color textures would ignore its textures.
 - A material with only non-color textures would erroneously report multiple UV texture coordinate sets.
 - Warnings in the glTF parser were coded to go straight to the console (no event observer could intervene).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20818)
<!-- Reviewable:end -->
