### PR TITLE
[geometry] Defer surface meshing for deformables when inactive

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -196,6 +196,7 @@ drake_cc_library(
         ":deformable_mesh_intersection",
         "//common:essential",
         "//geometry:geometry_ids",
+        "//geometry:geometry_instance",
         "//geometry:shape_specification",
         "//geometry/query_results:deformable_contact",
     ],

--- a/geometry/proximity/deformable_contact_internal.h
+++ b/geometry/proximity/deformable_contact_internal.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/proximity/collision_filter.h"
 #include "drake/geometry/proximity/deformable_contact_geometries.h"
 #include "drake/geometry/proximity/volume_mesh.h"
@@ -45,7 +46,8 @@ class Geometries final : public ShapeReifier {
   /* Returns true if a rigid (non-deformable) geometry representation with the
    given `id` exists. */
   bool is_rigid(GeometryId id) const {
-    return rigid_geometries_.count(id) != 0;
+    return rigid_geometries_.count(id) != 0 ||
+           rigid_geometries_pending_.count(id) != 0;
   }
 
   /* Returns true if a deformable geometry representation with the given `id`
@@ -133,11 +135,22 @@ class Geometries final : public ShapeReifier {
   template <typename ShapeType>
   void AddRigidGeometry(const ShapeType& shape, const ReifyData& data);
 
+  /* Moves rigid_geometries_pending_ into rigid_geometries_. */
+  void FlushPendingRigidGeometry();
+
   // The representations of all deformable geometries.
   std::unordered_map<GeometryId, DeformableGeometry> deformable_geometries_;
 
-  // The representations of all rigid geometries.
+  // The representations of all rigid geometries. For performance, we store them
+  // in 'pending' until a deformable geometry appears.
+  std::unordered_map<GeometryId, GeometryInstance> rigid_geometries_pending_;
   std::unordered_map<GeometryId, RigidGeometry> rigid_geometries_;
+
+  // This is always true in practice (there is no setter). Only certain unit
+  // tests' obscene need to access our private member fields using friendship
+  // will ever set it to false, so that they don't need to worry about the two
+  // different rigid geometry maps.
+  bool enable_rigid_geometries_pending_{true};
 };
 
 }  // namespace deformable

--- a/geometry/proximity/test/deformable_contact_internal_test.cc
+++ b/geometry/proximity/test/deformable_contact_internal_test.cc
@@ -56,6 +56,10 @@ class GeometriesTester {
   deformable_geometries(const Geometries& geometries) {
     return geometries.deformable_geometries_;
   }
+
+  static void disable_rigid_geometry_deferral(Geometries* geometries) {
+    geometries->enable_rigid_geometries_pending_ = false;
+  }
 };
 
 namespace {
@@ -216,6 +220,7 @@ GTEST_TEST(GeometriesTest, SupportedRigidShapes) {
 
 GTEST_TEST(GeometriesTest, UpdateRigidWorldPose) {
   Geometries geometries;
+  GeometriesTester::disable_rigid_geometry_deferral(&geometries);
 
   /* Add a rigid geometry. */
   GeometryId rigid_id = GeometryId::get_new_id();

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -95,6 +95,10 @@ class GeometriesTester {
                                                  GeometryId id) {
     return geometries.rigid_geometries_.at(id);
   }
+
+  static void disable_rigid_geometry_deferral(Geometries* geometries) {
+    geometries->enable_rigid_geometries_pending_ = false;
+  }
 };
 
 }  // namespace deformable
@@ -4469,6 +4473,13 @@ GTEST_TEST(ProximityEngineTests, ExpressionUnsupported) {
 class ProximityEngineDeformableContactTest : public testing::Test {
  protected:
   static constexpr double kSphereRadius = 1.0;
+
+  ProximityEngineDeformableContactTest() {
+    const internal::deformable::Geometries& geometries =
+        deformable_contact_geometries();
+    internal::deformable::GeometriesTester::disable_rigid_geometry_deferral(
+        const_cast<internal::deformable::Geometries*>(&geometries));
+  }
 
   ProximityProperties MakeProximityPropsWithRezHint(double resolution_hint) {
     ProximityProperties props;


### PR DESCRIPTION
When no deformable shapes appear in proximity engine, don't bother computing the deformables-specific surface meshes for rigid shapes since it will never be used and can be very expensive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20822)
<!-- Reviewable:end -->
