### PR TITLE
[parsing] Working PR for Schema checking of URDF

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -230,6 +230,7 @@ use_repo(
     "poisson_disk_sampling_internal",
     "qdldl_internal",
     "qhull_internal",
+    "rnv_internal",
     "ros_xacro_internal",
     "rules_python_drake_constants",  # TODO(jwnimmer-tri) Remove 2025-09-01.
     "scs_internal",

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -376,6 +376,19 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "detail_schema_checker",
+    srcs = ["detail_schema_checker.cc"],
+    hdrs = ["detail_schema_checker.h"],
+    internal = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        "//common:diagnostic_policy",
+        "//common:find_resource",
+        "@rnv_internal//:rnv",
+    ],
+)
+
+drake_cc_library(
     name = "detail_select_parser",
     srcs = ["detail_select_parser.cc"],
     hdrs = ["detail_select_parser.h"],
@@ -528,6 +541,26 @@ drake_cc_binary(
     ],
 )
 
+drake_cc_binary(
+    name = "schema_validator",
+    testonly = 1,
+    srcs = ["schema_validator.cc"],
+    add_test_rule = 1,
+    test_rule_args = [
+        "multibody/parsing/urdf.rnc",
+        "multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf",
+    ],
+    test_rule_data = [
+        "urdf.rnc",
+        ":test_models",
+    ],
+    deps = [
+        ":detail_schema_checker",
+        "//common:add_text_logging_gflags",
+        "@gflags",
+    ],
+)
+
 drake_cc_googletest(
     name = "parser_test",
     data = [
@@ -647,6 +680,19 @@ drake_cc_googletest(
         ":detail_sdf_parser",
         "//common:find_resource",
         "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_schema_checker_test",
+    data = [
+        "test/SVG-1.2-RFC.rnc",
+        "test/draft-rfcxml-general-template-annotated-00.xml",
+        "test/draft-rfcxml-general-template-bare-00.xml",
+        "test/rfc7991bis.rnc",
+    ],
+    deps = [
+        ":detail_schema_checker",
     ],
 )
 

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -257,12 +257,14 @@ drake_cc_library(
         "detail_urdf_geometry.h",
         "detail_urdf_parser.h",
     ],
+    data = ["urdf.rnc"],
     internal = True,
     visibility = ["//visibility:private"],
     deps = [
         ":detail_make_model_name",
         ":detail_misc",
         ":detail_parsing_workspace",
+        ":detail_schema_checker",
         ":scoped_names",
         "@fmt",
         "@tinyxml2_internal//:tinyxml2",
@@ -951,9 +953,12 @@ install_files(
     files = [
         "drake_models.json",
         "package_downloader.py",
+        "urdf.rnc",
     ],
     visibility = ["//visibility:public"],
 )
+
+exports_files(["urdf.rnc"])
 
 add_lint_tests(
     cpplint_extra_srcs = [

--- a/multibody/parsing/detail_schema_checker.cc
+++ b/multibody/parsing/detail_schema_checker.cc
@@ -1,0 +1,187 @@
+#include "drake/multibody/parsing/detail_schema_checker.h"
+
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <optional>
+#include <regex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+extern "C" {
+// Fix these by adjusting the internal build rules.
+// NOLINTNEXTLINE(build/include)
+#include "er.h"
+// NOLINTNEXTLINE(build/include)
+#include "xcl.h"
+};
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/find_resource.h"
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+using drake::internal::DiagnosticDetail;
+using drake::internal::DiagnosticPolicy;
+
+namespace {
+
+// Reprocesses errors and warnings from the rnv library to a diagnostic policy.
+bool ReplayDiagnostics(const DiagnosticPolicy& diagnostic,
+                       const std::vector<std::string>& rnv_messages,
+                       Strictness strictness) {
+  bool success = true;
+
+  // Allow adjustments of severity based on strictness.
+  enum class Severity { Error, Warning } severity = Severity::Error;
+  auto adjusted_severity = [&severity, &strictness]() {
+    switch (strictness) {
+      case Strictness::kLax:
+        return Severity::Warning;
+      case Strictness::kStrict:
+        return Severity::Error;
+      case Strictness::kNormal:
+        return severity;
+    }
+    DRAKE_UNREACHABLE();
+  };
+
+  // Since the library issues informative multiline comments, group them here
+  // into multiline Error() or Warning() events.
+  static constexpr char kPattern[] =
+      R"""(^([^:]*):(\d+):(\d+:)? (warning|error): (.*))""";
+  std::regex regex(kPattern);
+
+  // These hold the work-in-progress message.
+  DiagnosticDetail detail;
+  auto flush = [&diagnostic, &success, &detail, &adjusted_severity]() {
+    if (!detail.message.empty()) {
+      if (adjusted_severity() == Severity::Error) {
+        diagnostic.Error(detail);
+        success = false;
+      } else {
+        diagnostic.Warning(detail);
+      }
+    }
+    detail = {};
+  };
+
+  // Loop over all of the "printed" messages.
+  for (const std::string& rnv_message : rnv_messages) {
+    std::smatch match;
+    std::regex_search(rnv_message, match, regex);
+    if (match.empty()) {
+      detail.message += rnv_message;
+    } else {
+      flush();
+      detail.filename = match[1];
+      detail.line = std::stoi(match[2]);
+      severity = (*match[4].first == 'w') ? Severity::Warning : Severity::Error;
+      detail.message = match[5];
+    }
+  }
+
+  // Be sure to get the last one.
+  flush();
+
+  return success;
+}
+
+// While `rnv` is a very nice tool to use from the command line, it is not well
+// suited for use as a library. The `RnvGuard` takes care of several necessary
+// adaptations.
+//
+// * static global state: hold the global library mutex
+// * static global state: init and clear operations
+// * diagnostic redirection
+class RnvGuard {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RnvGuard)
+
+  explicit RnvGuard(std::vector<std::string>* messages) : messages_(messages) {
+    DRAKE_DEMAND(g_singleton == nullptr);
+    g_singleton = this;
+    ::er_vprintf = &RnvGuard::vprintf_callback;
+    xcl_init();
+  }
+
+  ~RnvGuard() {
+    xcl_clear();
+    er_vprintf = nullptr;
+    g_singleton = nullptr;
+  }
+
+ private:
+  // This mutex ensures that at most one RnvGuard is ever created per process.
+  static std::mutex& singleton_mutex() {
+    static drake::never_destroyed<std::mutex> mutex;
+    return mutex.access();
+  }
+
+  static int vprintf_callback(char* format, va_list ap) {
+    DRAKE_DEMAND(g_singleton != nullptr);
+    std::array<char, 4096> buffer{};
+    ::vsnprintf(buffer.data(), buffer.size(), format, ap);
+    buffer[buffer.size() - 1] = 0;
+    std::string message(buffer.data());
+    int result = message.size();
+    g_singleton->messages_->push_back(std::move(message));
+    return result;
+  }
+
+  std::lock_guard<std::mutex> guard_{singleton_mutex()};
+  std::vector<std::string>* const messages_;
+  static RnvGuard* g_singleton;
+};
+
+RnvGuard* RnvGuard::g_singleton = nullptr;
+
+}  // namespace
+
+bool CheckDocumentFileAgainstRncSchemaFile(
+    const DiagnosticPolicy& diagnostic, const std::filesystem::path& rnc_schema,
+    const std::filesystem::path& document, Strictness strictness) {
+  const std::optional<std::string> contents = ReadFile(document);
+  if (!contents) {
+    diagnostic.Error(
+        fmt::format("Could not open file '{}'", document.string()));
+  }
+  return CheckDocumentStringAgainstRncSchemaFile(
+      diagnostic, rnc_schema, *contents, document, strictness);
+}
+
+bool CheckDocumentStringAgainstRncSchemaFile(
+    const DiagnosticPolicy& diagnostic, const std::filesystem::path& rnc_schema,
+    const std::string& document_contents, const std::string& document_filename,
+    Strictness strictness) {
+  const std::string rnc_data = ReadFileOrThrow(rnc_schema);
+  std::vector<std::string> rnv_messages;
+  {
+    RnvGuard rnv_guard(&rnv_messages);
+    xcl_rnl_s(const_cast<char*>(rnc_schema.c_str()),
+              const_cast<char*>(rnc_data.c_str()), rnc_data.size());
+    if (!rnv_messages.empty()) {
+      throw std::runtime_error(fmt::format("Errors parsing '{}':\n{}",
+                                           rnc_schema.string(),
+                                           fmt::join(rnv_messages, "")));
+    }
+    xcl_validate_memory(const_cast<char*>(document_contents.c_str()),
+                        document_contents.size(), document_filename.c_str());
+  }
+  return ReplayDiagnostics(diagnostic, rnv_messages, strictness);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_schema_checker.h
+++ b/multibody/parsing/detail_schema_checker.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include "drake/common/diagnostic_policy.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+enum class Strictness {
+  kLax,     // Everything is a warning.
+  kNormal,  // Use severity of underlying messages.
+  kStrict,  // Everything is an error.
+};
+
+/* Here are several versions of CheckDocument*AgainstRncSchema*(). They
+all do roughly the same thing, with different inputs: validate a document
+against a schema written in RelaxNG Compact format, emitting warnings and/or
+errors to a diagnostic policy object. The return value is true
+if both schema parsing and validation complete without error.
+*/
+
+/* Validate a document against a schema, both provided as files. */
+bool CheckDocumentFileAgainstRncSchemaFile(
+    const drake::internal::DiagnosticPolicy& diagnostic,
+    const std::filesystem::path& rnc_schema,
+    const std::filesystem::path& document,
+    Strictness strictness = Strictness::kNormal);
+
+/* Validate a document, provided as an in-memory string, against a schema,
+whose contents are provided as a file. The `document_filename` is only used to
+construct diagnostic messages; the value should be chosen to help the user
+interpret the messages. */
+bool CheckDocumentStringAgainstRncSchemaFile(
+    const drake::internal::DiagnosticPolicy& diagnostic,
+    const std::filesystem::path& rnc_schema,
+    const std::string& document_contents, const std::string& document_filename,
+    Strictness strictness = Strictness::kNormal);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -16,11 +16,13 @@
 #include <fmt/format.h>
 #include <tinyxml2.h>
 
+#include "drake/common/find_resource.h"
 #include "drake/common/sorted_pair.h"
 #include "drake/common/trajectories/piecewise_constant_curvature_trajectory.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/detail_make_model_name.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
+#include "drake/multibody/parsing/detail_schema_checker.h"
 #include "drake/multibody/parsing/detail_tinyxml.h"
 #include "drake/multibody/parsing/detail_tinyxml2_diagnostic.h"
 #include "drake/multibody/parsing/detail_urdf_geometry.h"
@@ -1249,11 +1251,6 @@ std::pair<std::optional<ModelInstanceIndex>, std::string> UrdfParser::Parse() {
     ParseTransmission(joint_effort_limits, transmission_node);
   }
 
-  if (node->FirstChildElement("loop_joint")) {
-    Error(*node, "loop joints are not supported in MultibodyPlant");
-    return std::make_pair(model_instance_, model_name);
-  }
-
   // Parses the model's Drake frame elements.
   for (XMLElement* frame_node = node->FirstChildElement("frame"); frame_node;
        frame_node = frame_node->NextSiblingElement("frame")) {
@@ -1278,6 +1275,23 @@ std::pair<std::optional<ModelInstanceIndex>, std::string> UrdfParser::Parse() {
   }
 
   return std::make_pair(model_instance_, model_name);
+}
+
+bool CheckDocumentAgainstUrdfSchema(const ParsingWorkspace& workspace,
+                                    const DataSource& data_source) {
+  std::string schema_file =
+      FindResourceOrThrow("drake/multibody/parsing/urdf.rnc");
+  if (data_source.IsFilename()) {
+    return CheckDocumentFileAgainstRncSchemaFile(
+        workspace.diagnostic, schema_file, data_source.GetAbsolutePath(),
+        Strictness::kLax);
+  } else {
+    DRAKE_ASSERT(data_source.IsContents());
+    return CheckDocumentStringAgainstRncSchemaFile(
+        workspace.diagnostic, schema_file, data_source.contents(),
+        data_source.GetStem() + ".urdf", Strictness::kLax);
+  }
+  DRAKE_UNREACHABLE();
 }
 
 std::pair<std::optional<ModelInstanceIndex>, std::string>
@@ -1307,6 +1321,11 @@ AddOrMergeModelFromUrdf(
                                       xml_doc.ErrorName()));
       return std::make_pair(std::nullopt, "");
     }
+  }
+
+  // Checks that the document is conforming Drake-flavored URDF.
+  if (!CheckDocumentAgainstUrdfSchema(workspace, data_source)) {
+    return std::make_pair(std::nullopt, "");
   }
 
   UrdfParser parser(&data_source, model_name_in, parent_model_name,

--- a/multibody/parsing/schema_validator.cc
+++ b/multibody/parsing/schema_validator.cc
@@ -1,0 +1,58 @@
+#include <gflags/gflags.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
+#include "drake/multibody/parsing/detail_schema_checker.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using drake::internal::DiagnosticDetail;
+using drake::internal::DiagnosticPolicy;
+
+int do_main(int argc, char* argv[]) {
+  gflags::SetUsageMessage(
+      "[SCHEMA-RNC-FILE] [XML-DOCUMENT-FILE]\n"
+      "Run schema checker; print errors if any");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  if (argc < 3) {
+    drake::log()->error("missing input filename");
+    return 1;
+  }
+
+  // If running under `bazel run`, set working directory to where the user
+  // invoked this program, not somewhere in runfiles.
+  const char* workspace = ::getenv("BUILD_WORKSPACE_DIRECTORY");
+  if (workspace) {
+    const char* working = ::getenv("BUILD_WORKING_DIRECTORY");
+    DRAKE_DEMAND(working != nullptr);
+    std::filesystem::current_path(working);
+  }
+
+  // Hardcode a log pattern that gives us un-decorated error messages.
+  // This defeats the `-spdlog_pattern` command line option; oh well.
+  drake::logging::set_log_pattern("%v");
+
+  drake::log()->info("checking {} against {}", argv[2], argv[1]);
+
+  DiagnosticPolicy policy;
+
+  try {
+    std::filesystem::path schema(argv[1]);
+    std::filesystem::path document(argv[2]);
+    return !internal::CheckDocumentFileAgainstRncSchemaFile(
+        policy, schema, document, internal::Strictness::kLax);
+  } catch (const std::exception& e) {
+    drake::log()->error(e.what());
+    return EXIT_FAILURE;
+  }
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  return drake::multibody::do_main(argc, argv);
+}

--- a/multibody/parsing/test/SVG-1.2-RFC.rnc
+++ b/multibody/parsing/test/SVG-1.2-RFC.rnc
@@ -1,0 +1,1676 @@
+#   SVG-1.2-RFC.rnc
+#
+#   SVG 1.2 RFC RNC schema as specified in RFC 7996.
+#
+#   This schema is automatically included by the parent RFCXML v3 RNC schema
+#   and so needs to be present for succesful validation but does not need to 
+#   be specified separately.
+#
+#   Documentation is at https://authors.ietf.org/en/templates-and-schemas
+#
+#   Nevil Brownlee, Tue Jan 16 2018 (NZDT)
+
+default namespace = "http://www.w3.org/2000/svg"
+namespace xlink = "http://www.w3.org/1999/xlink"
+
+rfc-color = (  # SVG-1.2-RFC doesn't allow "color or grey-scale"
+  "black" | "white" | "#000000" | "#FFFFFF" | "#ffffff" |
+  "currentColor" | "inherit" )
+
+start = svg
+
+svg =
+  element svg {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"}?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute width { xsd:string }?,
+    attribute height { xsd:string }?,
+    attribute preserveAspectRatio {
+      xsd:string { pattern = "\s*(none|xMidYMid)\s*(meet)?\s*" }
+    }?,
+    attribute viewBox { text }?,
+    attribute version {
+      xsd:string "1.0" | xsd:string "1.1" | xsd:string "1.2"
+    }?,
+    attribute baseProfile {
+      xsd:string "none"
+      | xsd:string "tiny"
+      | xsd:string "basic"
+      | xsd:string "full"
+    }?,
+    attribute snapshotTime { xsd:string "none" | xsd:string }?,
+    (desc
+     | svgTitle
+     | path
+     | rect
+     | circle
+     | line
+     | ellipse
+     | polyline
+     | polygon
+     | solidColor
+     | textArea
+     | \text
+     | g
+     | defs
+     | use
+     | a)*
+  }
+
+desc =
+  element desc {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    ((attribute display {
+        "inline"
+        | "block"
+        | "list-item"
+        | "run-in"
+        | "compact"
+        | "marker"
+        | "table"
+        | "inline-table"
+        | "table-row-group"
+        | "table-header-group"
+        | "table-footer-group"
+        | "table-row"
+        | "table-column-group"
+        | "table-column"
+        | "table-cell"
+        | "table-caption"
+        | "none"
+        | "inherit"
+      }?,
+      attribute visibility { "visible" | "hidden" | "collapse" | "inherit" }?,
+      attribute image-rendering {
+        "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+      }?,
+      attribute shape-rendering {
+        "auto"
+        | "optimizeSpeed"
+        | "crispEdges"
+        | "geometricPrecision"
+        | "inherit"
+      }?,
+      attribute text-rendering {
+        "auto"
+        | "optimizeSpeed"
+        | "optimizeLegibility"
+        | "geometricPrecision"
+        | "inherit"
+      }?,
+      attribute buffered-rendering {
+        "auto" | "dynamic" | "static" | "inherit"
+      }?)
+     & (attribute viewport-fill { "none" | rfc-color }?,
+        attribute viewport-fill-opacity { "inherit" | xsd:string }?)),
+    text
+  }
+
+svgTitle =
+  element title {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    ((attribute display {
+        "inline"
+        | "block"
+        | "list-item"
+        | "run-in"
+        | "compact"
+        | "marker"
+        | "table"
+        | "inline-table"
+        | "table-row-group"
+        | "table-header-group"
+        | "table-footer-group"
+        | "table-row"
+        | "table-column-group"
+        | "table-column"
+        | "table-cell"
+        | "table-caption"
+        | "none"
+        | "inherit"
+      }?,
+      attribute visibility { "visible" | "hidden" | "collapse" | "inherit" }?,
+      attribute image-rendering {
+        "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+      }?,
+      attribute shape-rendering {
+        "auto"
+        | "optimizeSpeed"
+        | "crispEdges"
+        | "geometricPrecision"
+        | "inherit"
+      }?,
+      attribute text-rendering {
+        "auto"
+        | "optimizeSpeed"
+        | "optimizeLegibility"
+        | "geometricPrecision"
+        | "inherit"
+      }?,
+      attribute buffered-rendering {
+        "auto" | "dynamic" | "static" | "inherit"
+      }?)
+     & (attribute viewport-fill { "none" | rfc-color }?,
+        attribute viewport-fill-opacity { "inherit" | xsd:string }?)),
+    text
+  }
+
+path =
+  element path {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute d { xsd:string }?,
+    attribute pathLength { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+rect =
+  element rect {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute x { xsd:string }?,
+    attribute y { xsd:string }?,
+    attribute width { xsd:string }?,
+    attribute height { xsd:string }?,
+    attribute rx { xsd:string }?,
+    attribute ry { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+circle =
+  element circle {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute cx { xsd:string }?,
+    attribute cy { xsd:string }?,
+    attribute r { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+line =
+  element line {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute x1 { xsd:string }?,
+    attribute y1 { xsd:string }?,
+    attribute x2 { xsd:string }?,
+    attribute y2 { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+ellipse =
+  element ellipse {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute rx { xsd:string }?,
+    attribute ry { xsd:string }?,
+    attribute cx { xsd:string }?,
+    attribute cy { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+polyline =
+  element polyline {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute points { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+polygon =
+  element polygon {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute points { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+solidColor =
+  element solidColor {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    (desc
+     | svgTitle)*
+  }
+
+textArea =
+  element textArea {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    attribute x { xsd:string }?,
+    attribute y { xsd:string }?,
+    attribute width { xsd:string | "auto" }?,
+    attribute height { xsd:string | "auto" }?,
+    (tspan
+     | desc
+     | svgTitle
+     | tspan_2
+     | text
+     | a_2)+
+  }
+
+\text =
+  element text {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    attribute x { xsd:string }?,
+    attribute y { xsd:string }?,
+    attribute rotate { xsd:string }?,
+    (desc
+     | svgTitle
+     | tspan_2
+     | text
+     | a_2)+
+  }
+
+g =
+  element g {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    (desc
+     | svgTitle
+     | path
+     | rect
+     | circle
+     | line
+     | ellipse
+     | polyline
+     | polygon
+     | solidColor
+     | textArea
+     | \text
+     | g
+     | defs
+     | use
+     | a)*
+  }
+
+defs =
+  element defs {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    (desc
+     | svgTitle
+     | path
+     | rect
+     | circle
+     | line
+     | ellipse
+     | polyline
+     | polygon
+     | solidColor
+     | textArea
+     | \text
+     | g
+     | defs
+     | use
+     | a)*
+  }
+
+use =
+  element use {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute transform { xsd:string | "none" }?,
+    attribute xlink:show { "embed" }?,
+    attribute xlink:actuate { "onLoad" }?,
+    attribute xlink:type { "simple" }?,
+    attribute xlink:role { xsd:anyURI | xsd:string }?,
+    attribute xlink:arcrole { xsd:anyURI | xsd:string }?,
+    attribute xlink:title { text }?,
+    attribute xlink:href { xsd:anyURI | xsd:string }?,
+    attribute x { xsd:string }?,
+    attribute y { xsd:string }?,
+    (desc
+     | svgTitle)*
+  }
+
+a =
+  element a {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute transform { xsd:string | "none" }?,
+    attribute xlink:show { "new" | "replace" }?,
+    attribute xlink:actuate { "onRequest" }?,
+    attribute xlink:type { "simple" }?,
+    attribute xlink:role { xsd:anyURI | xsd:string }?,
+    attribute xlink:arcrole { xsd:anyURI | xsd:string }?,
+    attribute xlink:title { text }?,
+    attribute xlink:href { xsd:anyURI | xsd:string }?,
+    attribute target {
+      "_replace" | "_self" | "_parent" | "_top" | "_blank" | xsd:Name
+    }?,
+    (desc
+     | svgTitle
+     | path
+     | rect
+     | circle
+     | line
+     | ellipse
+     | polyline
+     | polygon
+     | solidColor
+     | textArea
+     | \text
+     | g
+     | defs
+     | use)*
+  }
+
+tspan =
+  element tspan {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute x { xsd:string }?,  # For SVG-1.2-RFC
+    attribute y { xsd:string }?,
+    (tbreak
+     | desc
+     | svgTitle
+     | tspan_2
+     | text
+     | a_2)+
+  }
+
+tspan_2 =
+  element tspan {
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    attribute x { xsd:string }?,  # For SVG-1.2-RFC
+    attribute y { xsd:string }?,
+    (desc
+     | svgTitle
+     | tspan_2
+     | text
+     | a_2)+
+  }
+
+a_2 =
+  element a {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?,
+    ((attribute fill-opacity { "inherit" | xsd:string }?,
+      attribute stroke-opacity { "inherit" | xsd:string }?)
+     & (attribute fill { "none" | rfc-color }?,
+        attribute fill-rule { "inherit" | "nonzero" | "evenodd" }?,
+        attribute stroke { rfc-color }?,
+        attribute stroke-dasharray { "inherit" | "none" | xsd:string }?,
+        attribute stroke-dashoffset { "inherit" | xsd:string }?,
+        attribute stroke-linecap {
+          "butt" | "round" | "square" | "inherit"
+        }?,
+        attribute stroke-linejoin {
+          "miter" | "round" | "bevel" | "inherit"
+        }?,
+        attribute stroke-miterlimit { "inherit" | xsd:string }?,
+        attribute stroke-width { "inherit" | xsd:string }?,
+        attribute color { rfc-color }?,
+        attribute color-rendering {
+          "auto" | "optimizeSpeed" | "optimizeQuality" | "inherit"
+        }?)
+     & attribute vector-effect {
+         "none" | "non-scaling-stroke" | "inherit"
+       }?
+     & (attribute direction { "ltr" | "rtl" | "inherit" }?,
+        attribute unicode-bidi {
+          "normal" | "embed" | "bidi-override" | "inherit"
+        }?)
+     & (attribute solid-color { rfc-color }?,
+        attribute solid-opacity { "inherit" | xsd:string }?)
+     & (attribute display-align {
+          "auto" | "before" | "center" | "after" | "inherit"
+        }?,
+        attribute line-increment { "auto" | "inherit" | xsd:string }?)
+     & (attribute stop-color { rfc-color }?,
+        attribute stop-opacity { "inherit" | xsd:string }?)
+     & (attribute font-family { "serif" | "sans-serif" | "monospace"
+         | "inherit" }?,
+        attribute font-size { "inherit" | xsd:string }?,
+        attribute font-style {
+          "normal" | "italic" | "oblique" | "inherit"
+        }?,
+        attribute font-variant { "normal" | "small-caps" | "inherit" }?,
+        attribute font-weight {
+          "normal"
+          | "bold"
+          | "bolder"
+          | "lighter"
+          | "inherit"
+        }?,
+        attribute text-anchor {
+          "start" | "middle" | "end" | "inherit"
+        }?,
+        attribute text-align {
+          "start" | "center" | "end" | "inherit"
+        }?)),
+    attribute transform { xsd:string | "none" }?,
+    attribute xlink:show { "new" | "replace" }?,
+    attribute xlink:actuate { "onRequest" }?,
+    attribute xlink:type { "simple" }?,
+    attribute xlink:role { xsd:anyURI | xsd:string }?,
+    attribute xlink:arcrole { xsd:anyURI | xsd:string }?,
+    attribute xlink:title { text }?,
+    attribute xlink:href { xsd:anyURI | xsd:string }?,
+    attribute target {
+      "_replace" | "_self" | "_parent" | "_top" | "_blank" | xsd:Name
+    }?,
+    (desc
+     | svgTitle
+     | tspan_2
+     | text)+
+  }
+
+tbreak =
+  element tbreak {
+    (attribute id { xsd:NCName }
+     | attribute xml:id { xsd:NCName })?,
+    attribute xml:base { xsd:anyURI | xsd:string }?,
+    attribute xml:lang { xsd:language? }?,
+    attribute class { xsd:NMTOKENS }?,
+    attribute role { xsd:string }?,
+    attribute rel { xsd:string }?,
+    attribute rev { xsd:string }?,
+    attribute typeof { xsd:string }?,
+    attribute content { xsd:string }?,
+    attribute datatype { xsd:string }?,
+    attribute resource { xsd:string }?,
+    attribute about { xsd:string }?,
+    attribute property { xsd:string }?,
+    attribute xml:space { "default" | "preserve" }?
+  }
+
+#---  End of SVG 1.2 RFC rnc schema

--- a/multibody/parsing/test/detail_schema_checker_test.cc
+++ b/multibody/parsing/test/detail_schema_checker_test.cc
@@ -1,0 +1,101 @@
+#include "drake/multibody/parsing/detail_schema_checker.h"
+
+#include <fstream>
+#include <sstream>
+#include <thread>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+namespace {
+
+using drake::internal::DiagnosticDetail;
+using drake::internal::DiagnosticPolicy;
+
+// Here are some fairly arbitrary and complicated schema and document files,
+// taken from:
+// https://authors.ietf.org/templates-and-schemas
+//
+const std::filesystem::path testdir("multibody/parsing/test");
+const std::filesystem::path schema("rfc7991bis.rnc");
+// This document will emit an error, fairly deep in the document file.
+const std::filesystem::path doc_bad(
+    "draft-rfcxml-general-template-annotated-00.xml");
+// This document will validate cleanly.
+const std::filesystem::path doc_good(
+    "draft-rfcxml-general-template-bare-00.xml");
+
+std::string slurp(const std::filesystem::path& path) {
+  std::ifstream in;
+  in.open(path, std::ifstream::in | std::ifstream::binary);
+  DRAKE_DEMAND(in.good());
+  std::stringstream stream;
+  stream << in.rdbuf();
+  in.close();
+  return stream.str();
+}
+
+GTEST_TEST(SchemaCheckerTest, ThreadedTest) {
+  std::vector<std::filesystem::path> docs{doc_bad, doc_good};
+  std::vector<int> docs_results{false, true};
+  std::vector<std::string> doc_strs;
+  for (const auto& doc : docs) {
+    doc_strs.push_back(slurp(testdir / doc));
+  }
+
+  auto thread_action = [&](int index) {
+    SCOPED_TRACE(fmt::format("thread index {}", index));
+    DiagnosticPolicy policy;
+    int errors{0};
+    int warnings{0};
+    policy.SetActionForErrors([&errors](const DiagnosticDetail& detail) {
+      ++errors;
+    });
+    policy.SetActionForWarnings([&warnings](const DiagnosticDetail& detail) {
+      ++warnings;
+    });
+
+    // Cycle over the API entry points and documents.
+    int entry_point = index % 2;
+    int doc_index = index % docs.size();
+    bool result{};
+    switch (entry_point) {
+      case 0:
+        result = CheckDocumentFileAgainstRncSchemaFile(
+            policy, testdir / schema, testdir / docs[doc_index]);
+        break;
+      case 1:
+        result = CheckDocumentStringAgainstRncSchemaFile(
+            policy, testdir / schema, doc_strs[doc_index],
+            testdir / docs[doc_index]);
+        break;
+      default:
+        DRAKE_UNREACHABLE();
+    }
+    EXPECT_EQ(result, !errors);
+    EXPECT_EQ(result, docs_results[doc_index]);
+    EXPECT_EQ(warnings, 0);
+  };
+
+  // Launch many threads as quickly as possible, each doing thread_action.
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 10; ++i) {
+    threads.emplace_back(thread_action, i);
+  }
+
+  // Wait for them all to finish.
+  for (auto& item : threads) {
+    item.join();
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -120,8 +120,8 @@ TEST_F(UrdfParserTest, BadXmlString) {
 
 TEST_F(UrdfParserTest, NoRobot) {
   EXPECT_EQ(AddModelFromUrdfString("<empty/>", ""), std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*URDF does not contain a robot tag."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*not.*robot.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*empty.*not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, NoName) {
@@ -145,9 +145,7 @@ TEST_F(UrdfParserTest, ModelRenameWithColons) {
 TEST_F(UrdfParserTest, ObsoleteLoopJoint) {
   EXPECT_NE(AddModelFromUrdfString("<robot name='a'><loop_joint/></robot>", ""),
             std::nullopt);
-  EXPECT_THAT(
-      TakeError(),
-      MatchesRegex(".*loop joints are not supported in MultibodyPlant"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*loop_joint not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, LegacyDrakeIgnoreBody) {
@@ -169,8 +167,8 @@ TEST_F(UrdfParserTest, BodyNameBroken) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*link tag is missing name attribute."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*name.*attribute.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*naQQQme.*not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, LegacyDrakeIgnoreJoint) {
@@ -190,8 +188,8 @@ TEST_F(UrdfParserTest, JointNameBroken) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*joint tag is missing name attribute"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*name.*attribute.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*naQQQme.*not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, JointTypeBroken) {
@@ -201,8 +199,8 @@ TEST_F(UrdfParserTest, JointTypeBroken) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*joint 'a' is missing type attribute"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*type.*attribute.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*tyQQQpe.*not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, JointNoParent) {
@@ -215,8 +213,9 @@ TEST_F(UrdfParserTest, JointNoParent) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*joint 'a' doesn't have a parent node!"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*parent.*node.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*parQQQent.*not allowed.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*unfinished.*joint.*"));
 }
 
 TEST_F(UrdfParserTest, JointParentLinkBroken) {
@@ -231,9 +230,8 @@ TEST_F(UrdfParserTest, JointParentLinkBroken) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(
-      TakeError(),
-      MatchesRegex(".*joint a's parent does not have a link attribute!"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*link.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*liQQQnk.*not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, JointNoChild) {
@@ -246,8 +244,9 @@ TEST_F(UrdfParserTest, JointNoChild) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*joint 'a' doesn't have a child node!"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*child.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*chiQQQld.*not allowed.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*unfinished.*joint.*"));
 }
 
 TEST_F(UrdfParserTest, JointChildLinkBroken) {
@@ -262,9 +261,8 @@ TEST_F(UrdfParserTest, JointChildLinkBroken) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(
-      TakeError(),
-      MatchesRegex(".*joint a's child does not have a link attribute!"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*link.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*liQQQnk.*not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, JointBadDynamicsAttributes) {
@@ -319,6 +317,7 @@ TEST_F(UrdfParserTest, DrakeCoulombWarning) {
     </robot>)""",
                                    ""),
             std::nullopt);
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*coulomb_window.*not allowed.*"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*coulomb_window.*ignored.*"));
 }
 
@@ -407,7 +406,7 @@ TEST_F(UrdfParserTest, MimicNoSap) {
       <joint name='joint' type='revolute'>
         <parent link='parent'/>
         <child link='child'/>
-        <mimic/>
+        <mimic joint='nope'/>
       </joint>
     </robot>)""",
                                    ""),
@@ -434,9 +433,8 @@ TEST_F(UrdfParserTest, MimicNoJoint) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*Joint 'joint' mimic element is missing the "
-                           "required 'joint' attribute."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*mimic.*joint.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*missing attributes.*mimic.*"));
 }
 
 TEST_F(UrdfParserTest, MimicBadJoint) {
@@ -629,7 +627,8 @@ TEST_F(UrdfParserTest, FrameNameBroken) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(".*parsing frame name."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*frame name.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*naQQQme.*not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, FrameLinkBroken) {
@@ -639,8 +638,8 @@ TEST_F(UrdfParserTest, FrameLinkBroken) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*missing link name for frame frameA."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*missing link name.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*liQQQnk.*not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, TransmissionTypeBroken) {
@@ -748,7 +747,7 @@ TEST_F(UrdfParserTest, TransmissionJointNotExist) {
 
 TEST_F(UrdfParserTest, TransmissionJointBadLimits) {
   constexpr const char* base = R"""(
-    <robot name='a'>
+    <robot xmlns:drake='http://drake.mit.edu' name='a'>
       <link name='parent'/>
       <link name='child'/>
       <joint name='a' type='revolute'>
@@ -1186,7 +1185,7 @@ TEST_F(UrdfParserTest, JointParsingTest) {
 // Custom planar joints were not necessary, but long supported. See #18730.
 TEST_F(UrdfParserTest, LegacyPlanarJointAsCustomTest) {
   constexpr const char* model = R"""(
-    <robot name='a'>
+    <robot xmlns:drake='http://drake.mit.edu' name='a'>
       <link name="link1"/>
       <link name="link2"/>
       <drake:joint name="planar_joint" type="planar">
@@ -1217,7 +1216,7 @@ TEST_F(UrdfParserTest, JointParsingTagMismatchTest) {
                            " type, and should be a <drake:joint>"));
 }
 
-TEST_F(UrdfParserTest, JointParsingTagMissingScrewParametersTest) {
+TEST_F(UrdfParserTest, JointParsingTagMissingScrewTagTest) {
   // Screw joint with missing thread pitch parameter.
   const std::string full_name_missing_element = FindResourceOrThrow(
       "drake/multibody/parsing/test/urdf_parser_test/"
@@ -1227,15 +1226,18 @@ TEST_F(UrdfParserTest, JointParsingTagMissingScrewParametersTest) {
       TakeError(),
       MatchesRegex(".*A screw joint is missing the <drake:screw_thread_pitch>"
                    " tag."));
+}
 
+TEST_F(UrdfParserTest, JointParsingTagMissingScrewAttributeTest) {
   const std::string full_name_missing_attribute = FindResourceOrThrow(
       "drake/multibody/parsing/test/urdf_parser_test/"
       "joint_parsing_test_missing_screw_thread_pitch_attribute.urdf");
   AddModelFromUrdfFile(full_name_missing_attribute, "");
   EXPECT_THAT(
       TakeError(),
-      MatchesRegex(".*A screw joint has a <drake:screw_thread_pitch> tag"
-                   " that is missing the 'value' attribute."));
+      MatchesRegex(".*screw_thread_pitch.*missing.*value.*attribute.*"));
+  EXPECT_THAT(TakeWarning(),
+              MatchesRegex(".*missing attribute.*screw_thread_pitch.*"));
 }
 
 // We allow users to declare the "world" link for the purpose of declaring
@@ -1248,8 +1250,7 @@ TEST_F(UrdfParserTest, JointParsingTagMissingScrewParametersTest) {
 // the geometry parsing got triggered, it is correct and ignore the other
 // details.
 TEST_F(UrdfParserTest, AddingGeometriesToWorldLink) {
-  const std::string test_urdf = R"""(
-<?xml version="1.0"?>
+  const std::string test_urdf = R"""(<?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="joint_parsing_test">
   <link name="world">
     <!-- Declaring mass properties on the "world" link is bad. But it won't
@@ -1262,10 +1263,10 @@ TEST_F(UrdfParserTest, AddingGeometriesToWorldLink) {
     <visual>
       <geometry>
         <box size="0.1 0.2 0.3"/>
-        <material>
-          <color rgba="0.8 0.7 0.6 0.5"/>
-        </material>
       </geometry>
+      <material>
+        <color rgba="0.8 0.7 0.6 0.5"/>
+      </material>
     </visual>
     <collision>
       <geometry>
@@ -1541,7 +1542,7 @@ TEST_F(UrdfParserTest, BadInertiaFormats) {
 TEST_F(UrdfParserTest, BushingParsing) {
   // Test successful parsing.
   const std::string good_bushing_model = R"""(
-    <robot name="bushing_test">
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
         <link name='A'/>
         <link name='C'/>
         <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1584,7 +1585,7 @@ TEST_F(UrdfParserTest, BushingParsing) {
 
 TEST_F(UrdfParserTest, BushingMissingFrameTag) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1600,13 +1601,14 @@ TEST_F(UrdfParserTest, BushingMissingFrameTag) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*Unable to find the <drake:bushing_frameC> tag"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*Unable to find.*bushing_frameC.*"));
+  EXPECT_THAT(TakeWarning(),
+              MatchesRegex(".*unfinished.*linear_bushing_rpy.*"));
 }
 
 TEST_F(UrdfParserTest, BushingFrameTagNameBroken) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1623,14 +1625,13 @@ TEST_F(UrdfParserTest, BushingFrameTagNameBroken) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*Unable to read the 'name' attribute for the"
-                           " <drake:bushing_frameC> tag"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*name.*attribute.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*naQQQme.*not allowed.*"));
 }
 
 TEST_F(UrdfParserTest, BushingFrameNotExist) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1655,7 +1656,7 @@ TEST_F(UrdfParserTest, BushingFrameNotExist) {
 
 TEST_F(UrdfParserTest, BushingMissingDamping) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1671,14 +1672,15 @@ TEST_F(UrdfParserTest, BushingMissingDamping) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(
-      TakeError(),
-      MatchesRegex(".*Unable to find the <drake:bushing_torque_damping> tag"));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*Unable to find.*bushing_torque_damping.*"));
+  EXPECT_THAT(TakeWarning(),
+              MatchesRegex(".*unfinished.*linear_bushing_rpy.*"));
 }
 
 TEST_F(UrdfParserTest, BushingMissingValueAttribute) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name="bushing_test">
+    <robot xmlns:drake='http://drake.mit.edu' name="bushing_test">
       <link name='A'/>
       <link name='C'/>
       <frame name="frameA" link="A" rpy="0 0 0" xyz="0 0 0"/>
@@ -1695,9 +1697,9 @@ TEST_F(UrdfParserTest, BushingMissingValueAttribute) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*Unable to read the 'value' attribute for the"
-                           " <drake:bushing_torque_stiffness> tag"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*Unable to read.*value.*"));
+  EXPECT_THAT(TakeWarning(),
+              MatchesRegex(".*missing attribute.*bushing_torque_stiffness.*"));
 }
 
 class BallConstraintTest : public UrdfParserTest {
@@ -1740,7 +1742,8 @@ class BallConstraintTest : public UrdfParserTest {
                     const std::optional<const std::string>& body_B,
                     const std::optional<const Vector3d>& p_AP,
                     const std::optional<const Vector3d>& p_BQ,
-                    const std::string& error_pattern) {
+                    const std::string& error_pattern,
+                    const std::string& warning_pattern) {
     std::string text = fmt::format(
         kTestString,
         body_A.has_value()
@@ -1760,13 +1763,16 @@ class BallConstraintTest : public UrdfParserTest {
                           p_BQ.value().x(), p_BQ.value().y(), p_BQ.value().z())
             : "");
     EXPECT_NE(AddModelFromUrdfString(text, ""), std::nullopt);
+    if (!warning_pattern.empty()) {
+      EXPECT_THAT(TakeWarning(), MatchesRegex(warning_pattern));
+    }
     EXPECT_THAT(TakeError(), MatchesRegex(error_pattern));
   }
 
  protected:
   // Common URDF string with format options for the two custom tags.
   static constexpr const char* kTestString = R"""(
-    <robot name='ball_constraint_test'>
+    <robot xmlns:drake='http://drake.mit.edu' name='ball_constraint_test'>
       <link name='A'/>
       <link name='B'/>
       <drake:ball_constraint>
@@ -1785,29 +1791,34 @@ TEST_F(BallConstraintTest, AllParameters) {
 
 TEST_F(BallConstraintTest, MissingBodyA) {
   ProvokeError({}, "B", Vector3d(1, 2, 3), Vector3d(4, 5, 6),
-               ".*Unable to find the <drake:ball_constraint_body_A> tag");
+               ".*Unable to find.*ball_constraint_body_A.*",
+               ".*unfinished.*ball_constraint.*");
 }
 
 TEST_F(BallConstraintTest, MissingBodyB) {
   ProvokeError("A", {}, Vector3d(1, 2, 3), Vector3d(4, 5, 6),
-               ".*Unable to find the <drake:ball_constraint_body_B> tag");
+               ".*Unable to find.*ball_constraint_body_B.*",
+               ".*unfinished.*ball_constraint.*");
 }
 
 TEST_F(BallConstraintTest, Missing_p_AP) {
   ProvokeError("A", "B", {}, Vector3d(4, 5, 6),
-               ".*Unable to find the <drake:ball_constraint_p_AP> tag");
+               ".*Unable to find.*ball_constraint_p_AP.*",
+               ".*unfinished.*ball_constraint.*");
 }
 
 TEST_F(BallConstraintTest, Missing_p_BQ) {
   ProvokeError("A", "B", Vector3d(1, 2, 3), {},
-               ".*Unable to find the <drake:ball_constraint_p_BQ> tag");
+               ".*Unable to find.*ball_constraint_p_BQ.*",
+               ".*unfinished.*ball_constraint.*");
 }
 
 TEST_F(BallConstraintTest, InvalidBody) {
   ProvokeError(
       "INVALID", "B", Vector3d(1, 2, 3), Vector3d(4, 5, 6),
       ".*Body: INVALID specified for <drake:ball_constraint_body_A> does not"
-      " exist in the model.");
+      " exist in the model.",
+      "");
 }
 
 class ReflectedInertiaTest : public UrdfParserTest {
@@ -1838,7 +1849,7 @@ class ReflectedInertiaTest : public UrdfParserTest {
  protected:
   // Common URDF string with format options for the two custom tags.
   static constexpr const char* kTestString = R"""(
-    <robot name='reflected_inertia_test'>
+    <robot xmlns:drake='http://drake.mit.edu' name='reflected_inertia_test'>
       <link name='A'/>
       <link name='B'/>
       <joint name='revolute_AB' type='revolute'>
@@ -1925,7 +1936,7 @@ class ControllerGainsTest : public UrdfParserTest {
   // Common URDF string with format options for the custom tag with two
   // attributes.
   static constexpr const char* kTestString = R"""(
-    <robot name='reflected_inertia_test'>
+    <robot xmlns:drake='http://drake.mit.edu' name='reflected_inertia_test'>
       <link name='A'/>
       <link name='B'/>
       <joint name='revolute_AB' type='revolute'>
@@ -2060,40 +2071,35 @@ TEST_F(UrdfParserTest, CollisionFilterGroupParsingTest) {
 
 TEST_F(UrdfParserTest, CollisionFilterGroupMissingName) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name='robot'>
+    <robot xmlns:drake='http://drake.mit.edu' name='robot'>
       <link name='a'/>
         <drake:collision_filter_group/>
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(
-      TakeError(),
-      MatchesRegex(".*The tag <drake:collision_filter_group> does not specify"
-                   " the required attribute \"name\"."));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*attribute.*name.*"));
+  EXPECT_THAT(TakeWarning(),
+              MatchesRegex(".*missing attribute.*collision_filter_group.*"));
 }
 
 TEST_F(UrdfParserTest, CollisionFilterGroupMissingLink) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name='robot'>
+    <robot xmlns:drake='http://drake.mit.edu' name='robot'>
       <link name='a'/>
       <drake:collision_filter_group name="group_a">
-        <drake:member/>
       </drake:collision_filter_group>
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(
-      TakeError(),
-      MatchesRegex(".*The tag <drake:member> does not specify the required "
-                   "attribute \"link\"."));
-  EXPECT_THAT(TakeError(), MatchesRegex(".*'robot::group_a'.*no members"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*group.*no members.*"));
 }
 
 TEST_F(UrdfParserTest, CollisionFilterGroupMissingMemberGroupName) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name='robot'>
+    <robot xmlns:drake='http://drake.mit.edu' name='robot'>
       <link name='a'/>
       <drake:collision_filter_group name="group_a">
+        <drake:member link='a'/>
         <drake:member_group/>
       </drake:collision_filter_group>
     </robot>)""",
@@ -2102,24 +2108,26 @@ TEST_F(UrdfParserTest, CollisionFilterGroupMissingMemberGroupName) {
   EXPECT_THAT(TakeError(),
               MatchesRegex(".*The tag <drake:member_group> does not specify the"
                            " required attribute \"name\"."));
-  EXPECT_THAT(TakeError(), MatchesRegex(".*'robot::group_a'.*no members"));
+  EXPECT_THAT(TakeWarning(),
+              MatchesRegex(".*missing attribute.*member_group.*"));
 }
 
 TEST_F(UrdfParserTest, IgnoredCollisionFilterGroupMissingName) {
   EXPECT_NE(AddModelFromUrdfString(R"""(
-    <robot name='robot'>
+    <robot xmlns:drake='http://drake.mit.edu' name='robot'>
       <link name='a'/>
       <drake:collision_filter_group name="group_a">
+        <drake:member link='a'/>
         <drake:ignored_collision_filter_group/>
       </drake:collision_filter_group>
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeError(), MatchesRegex(".*'robot::group_a'.*no members"));
   EXPECT_THAT(
       TakeError(),
       MatchesRegex(".*The tag <drake:ignored_collision_filter_group> does not"
                    " specify the required attribute \"name\"."));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*missing attribute.*"));
 }
 
 // Here follow tests to verify that Drake issues a warning when it ignores
@@ -2142,7 +2150,7 @@ TEST_F(UrdfParserTest, UnsupportedLinkTypeIgnored) {
     </robot>)""",
                                    ""),
             std::nullopt);
-  EXPECT_THAT(TakeWarning(), MatchesRegex(".*type.*link.*ignored.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*type.*unsupported.*ignored.*"));
 }
 
 TEST_F(UrdfParserTest, UnsupportedJointStuffIgnored) {
@@ -2313,7 +2321,7 @@ TEST_F(UrdfParserTest, UnsupportedMechanicalReductionIgnoredMaybe) {
 
 TEST_F(UrdfParserTest, PlanarJointAxisRespected) {
   constexpr const char* model = R"""(
-    <robot name='a'>
+    <robot xmlns:drake='http://drake.mit.edu' name='a'>
       <link name="link1"/>
       <link name="link2"/>
       <drake:joint name="planar_joint" type="planar">
@@ -2343,7 +2351,7 @@ TEST_F(UrdfParserTest, PlanarJointAxisRespected) {
 
 TEST_F(UrdfParserTest, PlanarJointCanonicalFrame) {
   constexpr const char* model = R"""(
-    <robot name='a'>
+    <robot xmlns:drake='http://drake.mit.edu' name='a'>
       <link name="link1"/>
       <link name="link2"/>
       <drake:joint name="planar_joint" type="planar">

--- a/multibody/parsing/test/draft-rfcxml-general-template-annotated-00.xml
+++ b/multibody/parsing/test/draft-rfcxml-general-template-annotated-00.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+     draft-rfcxml-general-template-annotated-00
+  
+     This template includes examples of most of the features of RFCXML with comments explaining 
+     how to customise them, and examples of how to achieve specific formatting.
+     
+     Documentation is at https://authors.ietf.org/en/templates-and-schemas
+-->
+<?xml-model href="rfc7991bis.rnc"?>  <!-- Required for schema validation and schema-aware editing -->
+<!-- <?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?> --> 
+<!-- This third-party XSLT can be enabled for direct transformations in XML processors, including most browsers -->
+
+<!DOCTYPE rfc [
+  <!ENTITY nbsp    "&#160;">
+  <!ENTITY zwsp   "&#8203;">
+  <!ENTITY nbhy   "&#8209;">
+  <!ENTITY wj     "&#8288;">
+]>
+<!-- If further character entities are required then they should be added to the DOCTYPE above.
+     Use of an external entity file is not recommended. -->
+
+<rfc
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  category="info"
+  docName="draft-rfcxml-general-template-annotated-00"
+  ipr="trust200902"
+  obsoletes=""
+  updates=""
+  submissionType="IETF"
+  xml:lang="en"
+  version="3">
+<!-- 
+    * docName should be the name of your draft
+    * category should be one of std, bcp, info, exp, historic
+    * ipr should be one of trust200902, noModificationTrust200902, noDerivativesTrust200902, pre5378Trust200902
+    * updates can be an RFC number as NNNN
+    * obsoletes can be an RFC number as NNNN 
+-->
+
+  <front>
+    <title abbrev="Abbreviated Title">Title</title> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#title-4 -->
+    <!--  The abbreviated title is required if the full title is longer than 39 characters -->
+
+    <seriesInfo name="Internet-Draft" value="draft-rfcxml-general-template-annotated-00"/> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#seriesinfo -->
+    <!-- Set value to the name of the draft  -->
+   
+    <author fullname="Author's Full Name" initials="Author's Initials" role="editor" surname="Author's Surname"> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#author -->
+    <!-- initials should not include an initial for the surname -->
+    <!-- role="editor" is optional -->
+    <!-- Can have more than one author -->
+      
+    <!-- all of the following elements are optional -->
+      <organization>Organization</organization> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#organization -->
+      <address> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#address -->
+        <postal>
+          <!-- Reorder these if your country does things differently -->
+          <street>Street</street>
+          <city>City</city>
+          <region>Region</region>
+          <code>Postal code</code>
+          <country>Country</country>
+          <!-- Can use two letter country code -->
+        </postal>        
+        <phone>Phone</phone>
+        <email>Email</email>  
+        <!-- Can have more than one <email> element -->
+        <uri>URI</uri>
+      </address>
+    </author>
+   
+    <date year="2023" month="3" day="1"/> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#date -->
+    <!-- On draft subbmission:
+         * If only the current year is specified, the current day and month will be used.
+         * If the month and year are both specified and are the current ones, the current day will
+           be used
+         * If the year is not the current one, it is necessary to specify at least a month and day="1" will be used.
+    -->
+
+    <area>General</area>
+    <workgroup>Internet Engineering Task Force</workgroup>
+    <!-- "Internet Engineering Task Force" is fine for individual submissions.  If this element is 
+          not present, the default is "Network Working Group", which is used by the RFC Editor as 
+          a nod to the history of the RFC Series. -->
+    
+    <keyword>template</keyword>
+    <!-- Multiple keywords are allowed.  Keywords are incorporated into HTML output files for 
+         use by search engines. -->
+
+    <abstract>
+      <t>Abstract</t>
+    </abstract>
+ 
+  </front>
+
+  <middle>
+    
+    <section>
+    <!-- The default attributes for <section> are numbered="true" and toc="default" -->
+      <name>Introduction</name>
+      <t>Introductory text</t>
+      
+      <section anchor="requirements">
+      <!-- anchor is an optional attribute -->
+        <name>Requirements Language</name>
+        <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL",
+          "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT
+          RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+          interpreted as described in BCP 14 <xref target="RFC2119"/>
+          <xref target="RFC8174"/> when, and only when, they appear in
+          all capitals, as shown here.</t>
+      </section>
+      <!-- The 'Requirements Language' section is optional -->
+    </section>
+    
+    <section>
+      <name>Body</name>
+      <t>Body text</t>
+    </section>
+    
+    <section>
+      <name>List Examples</name>
+      
+      <section>
+        <name>Simple Unordered (Bullet) List</name>
+        <t>Text before the list</t>
+        <ul spacing="normal">
+          <li>First bullet</li>
+          <li>Second bullet</li>
+        </ul>
+        <t>Text after the list.</t>
+      </section>
+      
+      <section>
+        <name>Ordered List With Lowercase Letters in Brackets Instead of Numbers</name>
+        <ol type="(%c)"> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#type-1 -->
+          <li>List item (a)</li>
+          <li>List item (b)</li>
+        </ol>
+      </section>
+      
+      <section>
+        <name>Continuous Numbering in a List That is Split by Text or Sections</name>
+        <!-- The following two lists render as 
+        Text to introduce the list
+        REQ1: This will be "REQ1:"
+        REQ2: This will be "REQ2:"
+        Some text in between
+        REQ3: This will be "REQ3:"
+        REQ4: This will be "REQ4:"
+        -->
+        <t>Text to introduce the list</t>
+        <ol type="REQ%d:" group="reqs">  <!-- value of group is user-defined https://authors.ietf.org/en/rfcxml-vocabulary#group -->
+          <li>This will be "REQ1:"</li>
+          <li>This will be "REQ2:"</li>
+        </ol>
+        <t>Some text in between</t>
+        <ol type="REQ%d:" group="reqs">  <!-- same value of group as before -->
+          <li>This will be "REQ3:"</li>
+          <li>This will be "REQ4:"</li>
+        </ol>
+        <section>
+          <name>Section in-between</name>
+          <t>More text in-between</t>
+          <ol type="REQ%d:" group="reqs">  <!-- same value of group as before -->
+            <li>This will be REQ5:</li>
+            <li>This will be REQ6:</li>
+          </ol>
+        </section>
+      </section>
+      
+      <section>
+        <name>Definition Lists</name> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#dl -->
+        <dl newline="true"> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#newline -->
+        <!-- Omit newline="true" if you want each definition to start on the same line as the corresponding term -->
+          <dt>First term:</dt>
+          <dd>Definition of the first term</dd>
+          <dt>Second term:</dt>
+          <dd>Definition of the second term</dd>
+        </dl>
+      </section>
+      
+      <section>
+        <name>Lists With Hanging Labels</name>
+        <t>the list item is indented the value of indent</t>  <!--  https://authors.ietf.org/en/rfcxml-vocabulary#indent -->
+        <dl newline="true" spacing="normal" indent="8">
+        <!-- Custom indent of 8 with the defintion starting on a new line after the term -->
+          <dt>short</dt>
+          <dd>With a label shorter than the indent.</dd>
+          <dt>fantastically long label</dt>
+          <dd>With a label longer than the indent.</dd>
+        </dl>
+      </section>
+    </section>
+    
+    <section>
+      <name>Tables</name>
+      <table> <!-- https://authors.ietf.org/rfcxml-vocabulary#table -->
+        <thead> <!-- https://authors.ietf.org/rfcxml-vocabulary#thead -->
+        <!-- A table header is optional -->
+          <tr><th>Column 1</th><th>Column 2</th><th>Column 3</th></tr>
+        </thead>
+        <tbody> <!-- https://authors.ietf.org/rfcxml-vocabulary#tbody -->
+        <!-- A table body is required -->
+          <tr><td align="left">Left cell</td><td colspan="2">Colspan cell</td></tr>
+          <!-- align can be right, left or center.  colspan and rowspan work as they do in HTML -->
+          <tr><td rowspan="2">Rowspan cell</td><td align="center">Center cell</td><td align="right">Right cell</td></tr>
+          <tr><td>Cell</td><td>Cell</td></tr>
+        </tbody>
+        <tfoot> <!-- https://authors.ietf.org/rfcxml-vocabulary#tfoot -->
+        <!-- A table footer is optional -->
+          <tr><td colspan="3">Colspan footer</td></tr>
+        </tfoot>
+      </table>
+    </section>
+    
+    <section>
+      <name>Source Code Examples</name>
+      <t>This is an example C program</t>
+        <sourcecode name="helloworld.c" type="c" markers="true"> <!-- https://authors.ietf.org/en/rfcxml-vocabulary#sourcecode -->
+          <![CDATA[
+#include <stdio.h>
+        
+int main() {
+  printf("Hello World");
+  return 0;
+}
+          ]]>
+        </sourcecode>
+        <!-- markers="true" means that the rendered file will have <CODE BEGINS> and <CODE ENDS> added. -->
+        <!-- The CDATA wrapper is optional but is strongly recommended to avoid any unexpected processing
+             or issues with angle brackets. 
+             <sourcecode></sourcecode> can optionally be wrapped in <figure></figure> -->
+    </section>
+    
+    <section anchor="adding-diagrams">
+    <!-- anchor is optional and used for reference below -->
+      <name>Adding Diagrams</name>
+      <figure>
+        <name>A Box</name>
+        <artset>  <!-- https://authors.ietf.org/en/rfcxml-vocabulary#artset -->
+        <!-- This <artset> includes two <artwork> elements, each of a different type.  Both are not 
+             always needed.  See https://authors.ietf.org/e/en/adding-diagrams -->
+          <artwork type="svg" name="https://www.rfc-editor.org/materials/format/svg/stream.svg">  <!-- https://authors.ietf.org/en/rfcxml-vocabulary#artwork -->
+            <!-- Inserting the SVG like this is only one way of adding an SVG diagram.  Another way is 
+                 to use the src attribute to point to an external file or URI.  The name attribute 
+                 recommends a filename to use if the artwork is extracted to a file. -->
+            <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 71 40">
+              <g>
+                <title>Layer 1</title>
+                <rect x="4.5" y="6.5" width="61.0" height="27.0" stroke="black" stroke-width="1.0" stroke-linecap="square" stroke-linejoin="miter" fill="none" />
+                <text x="33.883" text-anchor="middle" y="26.559">
+                  <tspan fill="black" font-size="13.0">A box</tspan>
+                </text>
+              </g>
+            </svg>
+          </artwork>
+          <artwork type="ascii-art" name="box.txt">
+            <![CDATA[
+ +--------+
+ | A box  |
+ +--------+          
+            ]]>
+          </artwork>
+        </artset>      
+      </figure>
+    </section>
+    
+    <section>
+      <name>Using xref</name>
+      <t>A reference to <xref target="adding-diagrams"/></t>
+      <t>A reference to <xref target="RFC8174" sectionFormat="of" section="2"/></t>
+    </section>
+    
+    <section anchor="IANA">
+    <!-- All drafts are required to have an IANA considerations section. See RFC 8126 for a guide.-->
+      <name>IANA Considerations</name>
+      <t>This memo includes no request to IANA.</t>
+    </section>
+    
+    <section anchor="Security">
+      <!-- All drafts are required to have a security considerations section. See RFC 3552 for a guide. -->
+      <name>Security Considerations</name>
+      <t>This document should not affect the security of the Internet.</t>
+    </section>
+    
+    <!-- NOTE: The Acknowledgements and Contributors sections are at the end of this template -->
+  </middle>
+
+  <back>
+    <references>
+      <name>References</name>
+      <references>
+        <name>Normative References</name>
+        
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+        <!-- The recommended and simplest way to include a well known reference -->
+        
+      </references>
+ 
+      <references>
+        <name>Informative References</name>
+       
+        <reference anchor="RFC2119" target="https://www.rfc-editor.org/info/rfc2119">
+        <!-- Manually added reference -->
+          <front>
+            <title>Key words for use in RFCs to Indicate Requirement Levels</title>
+            <author initials="S." surname="Bradner" fullname="S. Bradner">
+              <organization/>
+            </author>
+            <date year="1997" month="March"/>
+            <abstract>
+              <t>In many standards track documents several words are used to signify the requirements in the specification. These words are often capitalized. This document defines these words as they should be interpreted in IETF documents. This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.
+              </t>
+            </abstract>
+          </front>
+          <seriesInfo name="BCP" value="14"/>
+          <seriesInfo name="RFC" value="2119"/>
+          <seriesInfo name="DOI" value="10.17487/RFC2119"/>
+        </reference>
+       
+        <reference anchor="exampleRefMin">
+        <!-- Example minimum reference -->
+          <front>
+            <title>Title</title>
+            <author initials="Initials" surname="Surname">
+              <organization/>
+            </author>
+            <date year="2006"/>
+          </front>
+        </reference>
+
+        <reference anchor="exampleRefOrg" target="http://www.example.com/">
+        <!-- Example reference written by an organization not a person -->
+          <front>
+            <title>Title</title>
+            <author>
+              <organization>Organization</organization>
+            </author>
+            <date year="1984"/>
+          </front>
+        </reference>       
+       
+      </references>
+    </references>
+    
+    <section>
+      <name>Appendix 1</name>
+      <t>This becomes an Appendix</t>
+    </section>
+
+    <section anchor="Acknowledgements" numbered="false">
+      <!-- an Acknowledgements section is optional -->
+      <name>Acknowledgements</name>
+      <t>This template uses extracts from templates written by Pekka Savola, Elwyn Davies and 
+        Henrik Levkowetz.</t>
+    </section>
+    
+    <section anchor="Contributors" numbered="false">
+      <!-- a Contributors section is optional -->
+      <name>Contributors</name>
+      <t>Thanks to all of the contributors.</t>
+      <contact fullname="Jane Doe" initials="J" surname="Doe"><!-- https://authors.ietf.org/en/rfcxml-vocabulary#contact-->
+        <!-- including contact information for contributors is optional -->
+        <organization>Acme</organization>
+        <address>
+          <email>jdoe@example.com</email>
+        </address>
+      </contact>
+    </section>
+    
+ </back>
+</rfc>

--- a/multibody/parsing/test/draft-rfcxml-general-template-bare-00.xml
+++ b/multibody/parsing/test/draft-rfcxml-general-template-bare-00.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+     draft-rfcxml-general-template-bare-00
+  
+     This templates includes the bare minimum needed for the template to successfully validate 
+     against the RFCXML schema.  While it validates, it is not a valid Internet-Draft. This 
+     template is best used with an RNC schema-aware editor to assist with inserting valid elements 
+     and attributes. 
+     
+     Documentation is at https://authors.ietf.org/en/templates-and-schemas
+-->
+<?xml-model href="rfc7991bis.rnc"?>  <!-- Required for schema validation and schema-aware editing -->
+
+<!DOCTYPE rfc [
+  <!ENTITY nbsp    "&#160;">
+  <!ENTITY zwsp   "&#8203;">
+  <!ENTITY nbhy   "&#8209;">
+  <!ENTITY wj     "&#8288;">
+]>
+<!-- If further character entities are required then they should be added to the DOCTYPE above.
+     Use of an external entity file is not recommended. -->
+
+<rfc>
+  <front>
+    <title></title>
+    <author></author>
+   </front>
+  
+  <middle>
+    <section>
+    </section>
+  </middle>
+
+  <back>
+ </back>
+</rfc>

--- a/multibody/parsing/test/rfc7991bis.rnc
+++ b/multibody/parsing/test/rfc7991bis.rnc
@@ -1,0 +1,1150 @@
+#   rfc7991bis.rnc
+#
+#   RFCXML v3 RNC schema. Includes changes made after the publication of RFC
+#   7991 and features deprecated in RFC 7991.
+#
+#   To use in an RFCXML I-D add the following line before the <rfc> element:
+#        <?xml-model href="rfc7991bis.rnc"?>
+#
+#   Documentation is at https://authors.ietf.org/en/templates-and-schemas
+
+namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
+
+rfc =
+ element rfc {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute number { text }?,
+   [ a:defaultValue = "" ] attribute obsoletes { text }?,
+   [ a:defaultValue = "" ] attribute updates { text }?,
+   attribute category {
+     "std" | "bcp" | "exp" | "info" | "historic"
+   }?,
+   attribute mode { text }?,
+   [ a:defaultValue = "false" ]
+   attribute consensus { "no" | "yes" | "false" | "true" }?,
+   attribute seriesNo { text }?,
+   attribute ipr { text }?,
+   attribute iprExtract { xsd:IDREF }?,
+   [ a:defaultValue = "IETF" ]
+   attribute submissionType {
+     "IETF" | "IAB" | "IRTF" | "independent"
+   }?,
+   attribute docName { text }?,
+   [ a:defaultValue = "false" ]
+   attribute sortRefs { "true" | "false" }?,
+   [ a:defaultValue = "true" ]
+   attribute symRefs { "true" | "false" }?,
+   [ a:defaultValue = "true" ]
+   attribute tocInclude { "true" | "false" }?,
+   [ a:defaultValue = "3" ] attribute tocDepth { text }?,
+   attribute prepTime { text }?,
+   [ a:defaultValue = "true" ]
+   attribute indexInclude { "true" | "false" }?,
+   attribute version { text }?,
+   [ a:defaultValue = "Common,Latin" ] attribute scripts { text }?,
+   attribute expiresDate { text }?,
+   link*,
+   front,
+   middle,
+   back?
+ }
+
+link =
+ element link {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute href { text },
+   attribute rel { text }?
+ }
+
+front =
+ element front {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   title,
+   seriesInfo*,
+   author+,
+   date?,
+   area*,
+   workgroup*,
+   keyword*,
+   abstract?,
+   note*,
+   boilerplate?,
+   toc?
+ }
+
+title =
+ element title {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute abbrev { text }?,
+   attribute ascii { text }?,
+   (text | br)*
+ }
+
+author =
+ element author {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute initials { text }?,
+   attribute asciiInitials { text }?,
+   attribute surname { text }?,
+   attribute asciiSurname { text }?,
+   attribute fullname { text }?,
+   attribute role { "editor" }?,
+   attribute asciiFullname { text }?,
+   organization?,
+   address?
+ }
+
+contact =
+ element contact {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute initials { text }?,
+   attribute asciiInitials { text }?,
+   attribute surname { text }?,
+   attribute asciiSurname { text }?,
+   attribute fullname { text }?,
+   attribute asciiFullname { text }?,
+   organization?,
+   address?
+ }
+
+organization =
+ element organization {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute abbrev { text }?,
+   attribute ascii { text }?,
+   attribute asciiAbbrev { text }?,
+   [ a:defaultValue = "true" ]
+   attribute showOnFrontPage { "true" | "false" }?,
+   text
+ }
+
+address =
+ element address {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   postal?,
+   phone?,
+   facsimile?,
+   email*,
+   uri?
+ }
+
+postal =
+ element postal {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (( city | cityarea | code | country | extaddr | pobox | region
+      | sortingcode | street)*
+    | postalLine+)
+ }
+
+extaddr =
+ element extaddr {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+pobox =
+ element pobox {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+street =
+ element street {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+cityarea =
+ element cityarea {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+city =
+ element city {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+region =
+ element region {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+code =
+ element code {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+sortingcode =
+ element sortingcode {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+country =
+ element country {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+postalLine =
+ element postalLine {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+phone =
+ element phone {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+facsimile =
+ element facsimile {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+email =
+ element email {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute ascii { text }?,
+   text
+ }
+
+uri =
+ element uri {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+date =
+ element date {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute day { text }?,
+   attribute month { text }?,
+   attribute year { text }?,
+   text
+ }
+
+area =
+ element area {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+workgroup =
+ element workgroup {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+keyword =
+ element keyword {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+abstract =
+ element abstract {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   (dl | ol | t | ul)+
+ }
+
+note =
+ element note {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute title { text }?,
+   attribute pn { xsd:ID }?,
+   [ a:defaultValue = "false" ]
+   attribute removeInRFC { "true" | "false" }?,
+   name?,
+   (dl | ol | t | ul)+
+ }
+
+boilerplate =
+ element boilerplate {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   section+
+ }
+
+toc =
+ element toc {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   section*
+ }
+
+middle =
+ element middle {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   section+
+ }
+
+section =
+ element section {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   attribute title { text }?,
+   [ a:defaultValue = "true" ]
+   attribute numbered { "true" | "false" }?,
+   [ a:defaultValue = "default" ]
+   attribute toc { "include" | "exclude" | "default" }?,
+   [ a:defaultValue = "false" ]
+   attribute removeInRFC { "true" | "false" }?,
+   name?,
+   (artset
+    | artwork
+    | aside
+    | author
+    | blockquote
+    | contact
+    | dl
+    | figure
+    | iref
+    | ol
+    | sourcecode
+    | t
+    | table
+    | texttable
+    | ul)*,
+   section*
+ }
+
+name =
+ element name {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute slugifiedName { xsd:ID }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+br =
+ element br {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   empty
+ }
+
+t =
+ element t {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   attribute hangText { text }?,
+   [ a:defaultValue = "0" ]
+   attribute indent { text }?,
+   [ a:defaultValue = "false" ]
+   attribute keepWithNext { "true" | "false" }?,
+   [ a:defaultValue = "false" ]
+   attribute keepWithPrevious { "true" | "false" }?,
+   (text
+    | bcp14
+    | br
+    | contact
+    | cref
+    | em
+    | eref
+    | iref
+    | \list
+    | relref
+    | spanx
+    | strong
+    | sub
+    | sup
+    | tt
+    | u
+    | vspace
+    | xref)*
+ }
+
+aside =
+ element aside {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   (artset
+    | artwork
+    | blockquote
+    | dl
+    | figure
+    | iref
+    | ol
+    | t
+    | table
+    | ul)*
+
+ }
+
+blockquote =
+ element blockquote {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   attribute cite { text }?,
+   attribute quotedFrom { text }?,
+   ((artset | artwork | dl | figure | ol | sourcecode | t | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)+)
+ }
+
+\list =
+ element list {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "empty" ] attribute style { text }?,
+   attribute hangIndent { text }?,
+   attribute counter { text }?,
+   attribute pn { xsd:ID }?,
+   t+
+ }
+
+ol =
+ element ol {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "1" ] attribute type { text }?,
+   [ a:defaultValue = "1" ] attribute start { text }?,
+   attribute group { text }?,
+   [ a:defaultValue = "normal" ]
+   attribute spacing { "normal" | "compact" }?,
+   [ a:defaultValue = "adaptive" ]
+   attribute indent { text | "adaptive" }?,
+   attribute pn { xsd:ID }?,
+   li+
+ }
+
+ul =
+ element ul {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "normal" ]
+   attribute spacing { "normal" | "compact" }?,
+   ([ a:defaultValue = "false" ]
+    attribute empty { "true" | "false" },
+    [ a:defaultValue = "false" ]
+    attribute bare { "true" | "false" }?)?,
+   [ a:defaultValue = "3" ]
+    attribute indent { text }?,
+    attribute pn { xsd:ID }?,
+   li+
+ }
+
+li =
+ element li {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute derivedCounter { text }?,
+   attribute pn { xsd:ID }?,
+   (( artset
+      | artwork
+      | blockquote
+      | dl
+      | figure
+      | ol
+      | sourcecode
+      | t
+      | table
+      | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)+)
+ }
+
+dl =
+ element dl {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "normal" ]
+   attribute spacing { "normal" | "compact" }?,
+   [ a:defaultValue = "false" ]
+   attribute newline { "true" | "false" }?,
+   [ a:defaultValue = "3" ]
+   attribute indent { text }?,
+   attribute pn { xsd:ID }?,
+   (dt, dd)+
+ }
+
+dt =
+ element dt {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+dd =
+ element dd {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   (( artset
+      | artwork
+      | aside
+      | dl
+      | figure
+      | ol
+      | sourcecode
+      | t
+      | table
+      | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)+)
+ }
+
+xref =
+ element xref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute target { xsd:IDREF },
+   [ a:defaultValue = "false" ]
+   attribute pageno { "true" | "false" }?,
+   [ a:defaultValue = "default" ]
+   attribute format { "default" | "title" | "counter" | "none" }?,
+   attribute derivedContent { text }?,
+   [ a:defaultValue = "of" ]
+   attribute sectionFormat { "of" | "comma" | "parens" | "bare" }?,
+   attribute section { text }?,
+   attribute relative { text }?,
+   attribute derivedLink { text }?,
+   (text | em | strong | sub | sup | tt)*
+ }
+
+relref =
+ element relref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute target { xsd:IDREF },
+   [ a:defaultValue = "of" ]
+   attribute displayFormat { "of" | "comma" | "parens" | "bare" }?,
+   attribute derivedContent { text }?,
+   attribute section { text },
+   attribute relative { text }?,
+   attribute derivedLink { text }?,
+   text
+ }
+
+eref =
+ element eref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "none" ]
+   attribute brackets { "none" | "angle" }?,
+   attribute target { text },
+   text
+ }
+
+iref =
+ element iref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute item { text },
+   [ a:defaultValue = "" ] attribute subitem { text }?,
+   [ a:defaultValue = "false" ]
+   attribute primary { "true" | "false" }?,
+   attribute pn { xsd:ID }?,
+   empty
+ }
+
+cref =
+ element cref {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute source { text }?,
+   [ a:defaultValue = "true" ]
+   attribute display { "true" | "false" }?,
+   (text
+    | br
+    | em
+    | eref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+tt =
+ element tt {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | xref)*
+ }
+
+strong =
+ element strong {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+em =
+ element em {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | br
+    | cref
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+sub =
+ element sub {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+sup =
+ element sup {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | strong
+    | sub
+    | sup
+    | tt
+    | xref)*
+ }
+
+spanx =
+ element spanx {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "preserve" ]
+   attribute xml:space { "default" | "preserve" }?,
+   [ a:defaultValue = "emph" ] attribute style { text }?,
+   text
+ }
+
+vspace =
+ element vspace {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "0" ] attribute blankLines { text }?,
+   empty
+ }
+
+figure =
+ element figure {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   [ a:defaultValue = "" ] attribute title { text }?,
+   [ a:defaultValue = "false" ]
+   attribute suppress-title { "true" | "false" }?,
+   attribute src { text }?,
+   attribute originalSrc { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   [ a:defaultValue = "" ] attribute alt { text }?,
+   [ a:defaultValue = "" ] attribute width { text }?,
+   [ a:defaultValue = "" ] attribute height { text }?,
+   name?,
+   iref*,
+   preamble?,
+   (artset | artwork | sourcecode)+,
+   postamble?
+ }
+
+table =
+ element table {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   [ a:defaultValue = "center" ]
+   attribute align { "left" | "center" | "right" }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   name?,
+   iref*,
+   thead?,
+   tbody+,
+   tfoot?
+ }
+
+preamble =
+ element preamble {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | spanx
+    | strong
+    | sub
+    | sup
+    | tt
+    | u
+    | xref)*
+ }
+
+artset =
+ element artset {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   artwork+
+ }
+
+
+artwork =
+ element artwork {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   attribute xml:space { text }?,
+   [ a:defaultValue = "" ] attribute name { text }?,
+   [ a:defaultValue = "" ] attribute type { text }?,
+   attribute src { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   [ a:defaultValue = "" ] attribute alt { text }?,
+   [ a:defaultValue = "" ] attribute width { text }?,
+   [ a:defaultValue = "" ] attribute height { text }?,
+   attribute originalSrc { text }?,
+   (text* | svg)
+ }
+include "SVG-1.2-RFC.rnc"
+
+sourcecode =
+ element sourcecode {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   attribute pn { xsd:ID }?,
+   [ a:defaultValue = "" ] attribute name { text }?,
+   [ a:defaultValue = "" ] attribute type { text }?,
+   [ a:defaultValue = "false" ]
+   attribute markers { "true" | "false" }?,
+   attribute src { text }?,
+   attribute originalSrc { text }?,
+   text
+ }
+
+thead =
+ element thead {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   tr+
+ }
+
+tbody =
+ element tbody {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   tr+
+ }
+
+tfoot =
+ element tfoot {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   tr+
+ }
+
+tr =
+ element tr {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   (td | th)+
+ }
+
+td =
+ element td {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "1" ] attribute colspan { text }?,
+   [ a:defaultValue = "1" ] attribute rowspan { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   ((artset | artwork | dl | figure | ol | sourcecode | t | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)*)
+ }
+
+th =
+ element th {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "1" ] attribute colspan { text }?,
+   [ a:defaultValue = "1" ] attribute rowspan { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   ((artset | artwork | dl | figure | ol | sourcecode | t | ul)+
+    | (text
+       | bcp14
+       | br
+       | cref
+       | em
+       | eref
+       | iref
+       | relref
+       | strong
+       | sub
+       | sup
+       | tt
+       | u
+       | xref)*)
+ }
+
+postamble =
+ element postamble {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text | cref | eref | iref | spanx | xref)*
+ }
+
+texttable =
+ element texttable {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID }?,
+   [ a:defaultValue = "" ] attribute title { text }?,
+   [ a:defaultValue = "false" ]
+   attribute suppress-title { "true" | "false" }?,
+   [ a:defaultValue = "center" ]
+   attribute align { "left" | "center" | "right" }?,
+   [ a:defaultValue = "full" ]
+   attribute style { "all" | "none" | "headers" | "full" }?,
+   name?,
+   preamble?,
+   ttcol+,
+   c*,
+   postamble?
+ }
+
+ttcol =
+ element ttcol {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute width { text }?,
+   [ a:defaultValue = "left" ]
+   attribute align { "left" | "center" | "right" }?,
+   (cref | eref | iref | xref | text)*
+ }
+
+c =
+ element c {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text | cref | eref | iref | spanx | xref)*
+ }
+
+bcp14 =
+ element bcp14 {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   text
+ }
+
+back =
+ element back {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   displayreference*,
+   references*,
+   section*
+ }
+
+displayreference =
+ element displayreference {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute target { xsd:IDREF },
+   attribute to { text }
+ }
+
+references =
+ element references {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute pn { xsd:ID }?,
+   attribute anchor { xsd:ID }?,
+   attribute title { text }?,
+   name?,
+   (references+ | (reference | referencegroup)*)
+ }
+
+reference =
+ element reference {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID },
+   attribute derivedAnchor { text }?,
+   attribute target { text }?,
+   [ a:defaultValue = "true" ]
+   attribute quoteTitle { "true" | "false" }?,
+   attribute quote-title { "true" | "false" }?,
+   stream?,
+   front,
+   (annotation | format | refcontent | seriesInfo)*
+ }
+
+stream =
+ element stream {
+   ( "IETF" | "IAB" | "IRTF" | "independent" )?
+}
+
+referencegroup =
+ element referencegroup {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute anchor { xsd:ID },
+   attribute derivedAnchor { text }?,
+   attribute target { text }?,
+   reference+
+ }
+
+seriesInfo =
+ element seriesInfo {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute name { text },
+   attribute value { text },
+   attribute asciiName { text }?,
+   attribute asciiValue { text }?,
+   attribute status { text }?,
+   attribute stream { "IETF" | "IAB" | "IRTF" | "independent" }?,
+   empty
+ }
+
+format =
+ element format {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   attribute target { text }?,
+   attribute type { text },
+   attribute octets { text }?,
+   empty
+ }
+
+annotation =
+ element annotation {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text
+    | bcp14
+    | cref
+    | em
+    | eref
+    | iref
+    | relref
+    | spanx
+    | strong
+    | sub
+    | sup
+    | tt
+    | u
+    | xref)*
+ }
+
+refcontent =
+ element refcontent {
+   attribute xml:base { text }?,
+   attribute xml:lang { text }?,
+   (text | bcp14 | em | strong | sub | sup | tt)*
+ }
+
+u =
+ element u {
+   attribute anchor { xsd:ID }?,
+   attribute ascii { text }?,
+   [ a:defaultValue = "lit-name-num" ]
+   attribute format { text }?,
+   attribute pn { xsd:ID }?,
+   text
+ }
+
+start |= rfc

--- a/multibody/parsing/urdf.rnc
+++ b/multibody/parsing/urdf.rnc
@@ -12,15 +12,10 @@
 #  $ apt install jing
 #  $ jing -c urdf.rnc [ROBOT-FILE...]
 #
-# A faster way (that could maybe get linked directly into drake later):
-#   $ git clone git@github.com:hartwork/rnv.git
-#   $ cd rnv
-#   $ apt install asciidoc-base  # could skip, with some patching
-#   $ apt install libexpat1-dev
-#   $ ./bootstrap
-#   $ ./configure
-#   $ make
-#   $ ./rnv urdf.rnc [ROBOT-FILE]
+# A drake-source-build way to validate:
+#   $ bazel build //multibody/parsing:schema_validator
+#   $ bazel-bin/multibody/parsing/schema_validator \
+#       multibody/parsing/urdf.rnc [ROBOT-FILE]
 #
 
 # Enumerate the drake namespace and the anonymous URDF-spec "local" namespace.

--- a/multibody/parsing/urdf.rnc
+++ b/multibody/parsing/urdf.rnc
@@ -1,0 +1,263 @@
+# Schema for URDF as seen and used by Drake.
+# Relax NG Compact Syntax. See https://relaxng.org/
+#
+# URDF language reference:
+# https://wiki.ros.org/urdf/XML
+#
+# Not particularly authoritative URDF schema:
+# https://github.com/ros/urdfdom/blob/4.0.0/xsd/urdf.xsd
+#
+#
+# An external-to-drake way to validate:
+#  $ apt install jing
+#  $ jing -c urdf.rnc [ROBOT-FILE...]
+#
+# A faster way (that could maybe get linked directly into drake later):
+#   $ git clone git@github.com:hartwork/rnv.git
+#   $ cd rnv
+#   $ apt install asciidoc-base  # could skip, with some patching
+#   $ apt install libexpat1-dev
+#   $ ./bootstrap
+#   $ ./configure
+#   $ make
+#   $ ./rnv urdf.rnc [ROBOT-FILE]
+#
+
+# Enumerate the drake namespace and the anonymous URDF-spec "local" namespace.
+namespace drake = "http://drake.mit.edu"
+namespace local = ""
+
+# Define the grammar for URDF, drake namespaced (e.g. drake:joint) and legacy
+# (e.g. frame) extensions, and indicate where other foreign namespace
+# extensions are permitted. As a rule, URDF-specified nodes are open to foreign
+# extensions, drake-specified nodes are not.
+grammar {
+   start = Robot
+   Robot = element robot {
+      Name?,
+      # The version attribute is proposed in urdf.xsd, but not documented
+      # elsehwere.
+      attribute version { text }?,
+      ForeignAttributes,
+      (Joint* &
+         LinkE* &
+         Frame* &
+         MaterialGlobal* &
+         Transmission* &
+         DrakeBallConstraint* &
+         DrakeJoint* &
+         DrakeLinearBushingRpy* &
+         DrakeCollisionFilterGroup* &
+         Gazebo* &
+         ForeignElements)
+   }
+
+   # TODO(#20837): Frame is a legacy Drake extension that is not properly
+   # namespaced.
+   Frame = element frame { Name, LinkA, Pose }
+
+
+   Joint = element joint {
+      (Name, DrakeIgnoreTrue, AnyE) |
+      (Name, DrakeIgnoreFalse?, Type, ForeignAttributes,
+         (JointSubElements &
+         ForeignElements))
+   }
+
+   DrakeJoint = element drake:joint {
+      (Name, DrakeIgnoreTrue, AnyE) |
+      (Name, DrakeIgnoreFalse?, Type,
+         (JointSubElements & DrakeJointSubElements))
+   }
+   DrakeLinearBushingRpy = element drake:linear_bushing_rpy {
+      element drake:bushing_frameA { Name } &
+      element drake:bushing_frameC { Name } &
+      element drake:bushing_torque_stiffness { Value } &
+      element drake:bushing_torque_damping { Value } &
+      element drake:bushing_force_stiffness { Value } &
+      element drake:bushing_force_damping { Value }
+   }
+   JointSubElements = Origin? &
+      Parent &
+      Child &
+      Axis? &
+      Dynamics? &
+      Limit? &
+      Calibration? &
+      SafetyController? &
+      Mimic?
+   DrakeJointSubElements = DrakeScrewThreadPitch? &
+      DrakeCurves? &
+      DrakeInitialTangent? &
+      DrakeIsPeriodic? &
+      DrakePlaneNormal?
+
+   # Drake ignores these, but gives better error messages within the parser
+   # than schema checking would.
+   Gazebo = element gazebo { Anything }
+   Calibration = element calibration { Anything }
+   SafetyController = element safety_controller { Anything }
+
+   LinkE = element link {
+      (Name, DrakeIgnoreTrue, AnyE) |
+      (Name, DrakeIgnoreFalse?,
+         # The link@type attribute is seen in the urdf.xsd, but not documented
+         # elsewhere.
+         Type?,
+         ForeignAttributes,
+      (Inertial? & Visual* & Collision* & SelfCollisionChecking* &
+         ForeignElements))
+   }
+
+   MaterialGlobal = element material {
+      Name, ForeignAttributes, (Color? & Texture? & ForeignElements) }
+
+   Material = element material {
+      Name?, ForeignAttributes, (Color? & Texture? & ForeignElements) }
+
+   # Transmission specs seem contradictory and full of lies; best to give up.
+   Transmission = element transmission { Anything }
+
+   Origin = element origin { Pose, ForeignNodes }
+   Parent = element parent { LinkA, ForeignNodes }
+   Child = element child { LinkA, ForeignNodes }
+   Axis = element axis { attribute xyz { text }?, ForeignNodes }
+   Dynamics = element dynamics {
+      attribute damping { text }?,
+      attribute friction { text }?,
+      ForeignNodes
+   }
+
+   Limit = element limit {
+      attribute lower { text }?,
+      attribute upper { text }?,
+      attribute effort { text }?,
+      attribute velocity { text }?,
+      attribute drake:acceleration { text }?,
+      ForeignNodes
+   }
+
+   Mimic = element mimic {
+      attribute joint { text },
+      attribute multiplier { text }?,
+      attribute offset { text }?,
+      ForeignNodes
+   }
+
+   Inertial = element inertial {
+      ForeignAttributes,
+      # The URDF language reference marks the mass and inertia tags as
+      # required, but many Drake files treat them as optional. TODO(#20840)
+      # decide which disposition (required or optional) is best, and implement
+      # that.
+      (Origin? & Mass? & Inertia? & ForeignElements)
+   }
+   Visual = element visual {
+      Name?, ForeignAttributes,
+      (Origin? & Geometry & Material? & DrakeAcceptingRenderer* &
+         ForeignElements)
+   }
+
+   DrakeAcceptingRenderer = element drake:accepting_renderer { Name }
+   Collision = element collision {
+      Name?, ForeignAttributes,
+      (Origin? & Geometry & Verbose? & DrakeProximityProperties? &
+         ForeignElements)
+   }
+
+   SelfCollisionChecking = element self_collision_checking {
+      Name?, ForeignAttributes,
+      (Origin? & Geometry & Material? & Verbose? &
+         ForeignElements)
+   }
+
+   Geometry = element geometry {
+      ForeignAttributes,
+      # Capsule is non-standard magic: bullet has it, ROS is torn.
+      ((Box | Cylinder | Sphere | Mesh | Capsule | DrakeCapsule | DrakeEllipsoid) &
+         ForeignElements)
+   }
+
+   Inertia = element inertia {
+      attribute ixx { text }?,
+      attribute ixy { text }?,
+      attribute ixz { text }?,
+      attribute iyy { text }?,
+      attribute iyz { text }?,
+      attribute izz { text }?,
+      ForeignNodes
+   }
+
+   Box = element box { attribute size { text }, ForeignNodes }
+   Capsule = element capsule { CapsuleContents, ForeignNodes }
+   DrakeCapsule = element drake:capsule { CapsuleContents }
+   CapsuleContents = ( attribute radius { text }, attribute length { text} )
+   Cylinder = element cylinder {
+      attribute radius { text }, attribute length { text},
+      ForeignNodes
+   }
+   Mesh = element mesh {
+      attribute filename { text }, attribute scale { text }?,
+      DrakeDeclareConvex?, ForeignNodes }
+   DrakeDeclareConvex = element drake:declare_convex { empty }
+   Sphere = element sphere { attribute radius { text }, ForeignNodes }
+   DrakeEllipsoid = element drake:ellipsoid {
+      attribute a { text }, attribute b { text }, attribute c { text } }
+
+   Color = element color { attribute rgba { text }, ForeignNodes }
+   Mass = element mass { Value, ForeignNodes }
+   Texture = element texture { attribute filename { text }, ForeignNodes }
+   Verbose = element verbose { Value, ForeignNodes }
+
+   # drake_ignore is legacy and should go away.
+   DrakeIgnoreFalse = attribute drake_ignore { string - "true" }
+   DrakeIgnoreTrue = attribute drake_ignore { "true" }
+
+   LinkA = attribute link { text }
+   Pose = attribute xyz { text }?, attribute rpy { text }?
+   Name = attribute name { text }
+   Type = attribute type { text }
+   Value = attribute value { text }
+
+   DrakeBallConstraint = element drake:ball_constraint {
+      element drake:ball_constraint_body_A { Name } &
+      element drake:ball_constraint_body_B { Name } &
+      element drake:ball_constraint_p_AP { Value } &
+      element drake:ball_constraint_p_BQ { Value }
+   }
+
+   DrakeCollisionFilterGroup = element drake:collision_filter_group {
+      Name, attribute ignore { text }?,
+      (DrakeMember* & DrakeMemberGroup* & DrakeIgnoredCollisionFilterGroup* )
+   }
+   DrakeMember = element drake:member { LinkA }
+   DrakeMemberGroup = element drake:member_group { Name }
+   DrakeIgnoredCollisionFilterGroup = element drake:ignored_collision_filter_group { Name }
+
+   DrakeProximityProperties = element drake:proximity_properties {
+      ( element drake:compliant_hydroelastic { empty } |
+         element drake:rigid_hydroelastic { empty } )? &
+      element drake:hunt_crossley_dissipation { Value }? &
+      element drake:hydroelastic_modulus { Value }? &
+      element drake:mesh_resolution_hint { Value }? &
+      element drake:mu_dynamic { Value }? &
+      element drake:mu_static { Value }? &
+      element drake:point_contact_stiffness { Value }?
+   }
+   DrakeScrewThreadPitch = element drake:screw_thread_pitch { Value }
+   DrakeCurves = element drake:curves { DrakeLineSegment* & DrakeCircularArc* }
+   DrakeInitialTangent = element drake:initial_tangent { attribute xyz { text }}
+   DrakeIsPeriodic = element drake:is_periodic { Value }
+   DrakePlaneNormal = element drake:plane_normal { attribute xyz { text }}
+   DrakeLineSegment = element drake:line_segment { attribute length {text }}
+   DrakeCircularArc = element drake:circular_arc { attribute radius { text }, attribute angle { text }}
+
+   # Patterns for things we pass over in silence.
+   Anything = ( element * { Anything } | attribute * { text } | text )*
+   AnyE = ( element * { Anything } )*
+
+   # Support for foreign namespaced nodes.
+   ForeignElements = element * - (local:* | drake:*) { Anything }*
+   ForeignAttributes = attribute * - (local:* | drake:*) { text }*
+   ForeignNodes = ( ForeignAttributes | ForeignElements )*
+}

--- a/multibody/plant/test/multibody_plant_query_object_connect_test.cc
+++ b/multibody/plant/test/multibody_plant_query_object_connect_test.cc
@@ -30,7 +30,6 @@ using systems::DiagramBuilder;
 using systems::System;
 
 constexpr char kModelWithCollisions[] = R"""(
-<?xml version="1.0"?>
 <robot name="box">
   <link name="box">
     <inertial>
@@ -47,7 +46,6 @@ constexpr char kModelWithCollisions[] = R"""(
 )""";
 
 constexpr char kModelWithoutCollisions[] = R"""(
-<?xml version="1.0"?>
 <robot name="box">
   <link name="box">
     <inertial>

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -77,6 +77,7 @@ load("//tools/workspace/pycodestyle:repository.bzl", "pycodestyle_repository")
 load("//tools/workspace/python:repository.bzl", "python_repository")
 load("//tools/workspace/qdldl_internal:repository.bzl", "qdldl_internal_repository")  # noqa
 load("//tools/workspace/qhull_internal:repository.bzl", "qhull_internal_repository")  # noqa
+load("//tools/workspace/rnv_internal:repository.bzl", "rnv_internal_repository")  # noqa
 load("//tools/workspace/ros_xacro_internal:repository.bzl", "ros_xacro_internal_repository")  # noqa
 load("//tools/workspace/rules_cc:repository.bzl", "rules_cc_repository")  # noqa
 load("//tools/workspace/rules_java:repository.bzl", "rules_java_repository")
@@ -312,6 +313,8 @@ def add_default_repositories(
         qdldl_internal_repository(name = "qdldl_internal", mirrors = mirrors)
     if "qhull_internal" not in excludes:
         qhull_internal_repository(name = "qhull_internal", mirrors = mirrors)
+    if "rnv_internal" not in excludes:
+        rnv_internal_repository(name = "rnv_internal", mirrors = mirrors)
     if "ros_xacro_internal" not in excludes:
         ros_xacro_internal_repository(name = "ros_xacro_internal", mirrors = mirrors)  # noqa
     if "rules_cc" not in excludes:

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -22,6 +22,7 @@ load("//tools/workspace/dm_control_internal:repository.bzl", "dm_control_interna
 load("//tools/workspace/doxygen:repository.bzl", "doxygen_repository")
 load("//tools/workspace/drake_models:repository.bzl", "drake_models_repository")  # noqa
 load("//tools/workspace/eigen:repository.bzl", "eigen_repository")
+load("//tools/workspace/expat_internal:repository.bzl", "expat_internal_repository")  # noqa
 load("//tools/workspace/fcl_internal:repository.bzl", "fcl_internal_repository")  # noqa
 load("//tools/workspace/fmt:repository.bzl", "fmt_repository")
 load("//tools/workspace/gflags:repository.bzl", "gflags_repository")
@@ -182,6 +183,8 @@ def add_default_repositories(
         drake_models_repository(name = "drake_models", mirrors = mirrors)
     if "eigen" not in excludes:
         eigen_repository(name = "eigen")
+    if "expat_internal" not in excludes:
+        expat_internal_repository(name = "expat_internal", mirrors = mirrors)
     if "fcl_internal" not in excludes:
         fcl_internal_repository(name = "fcl_internal", mirrors = mirrors)
     if "fmt" not in excludes:

--- a/tools/workspace/expat_internal/BUILD.bazel
+++ b/tools/workspace/expat_internal/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/expat_internal/cmakedefines.bzl
+++ b/tools/workspace/expat_internal/cmakedefines.bzl
@@ -1,0 +1,28 @@
+# These are the Apple-specific CMake definitions we want to enable for Drake.
+# Keep this list alpha-sorted.
+_APPLE_CMAKE_DEFINES = [
+    "HAVE_ARC4RANDOM_BUF=1",
+]
+
+# These are the Linux-specific CMake definitions we want to enable for Drake.
+# Keep this list alpha-sorted.
+_LINUX_CMAKE_DEFINES = [
+    "HAVE_GETRANDOM=1",
+]
+
+# These are the settings we want to enable for Drake. A few of them towards the
+# bottom are conditional for Apple vs Linux. Keep this list alpha-sorted.
+CMAKE_DEFINES = [
+    "PACKAGE_NAME=\"expat\"",
+    "XML_CONTEXT_BYTES=1024",
+    "XML_GE=1",
+] + select({
+    "@drake//tools/cc_toolchain:apple": _APPLE_CMAKE_DEFINES,
+    "@drake//tools/cc_toolchain:linux": _LINUX_CMAKE_DEFINES,
+    "//conditions:default": [],
+})
+
+# These are the settings we want to disable for Drake on all platforms.
+# Keep this list alpha-sorted.
+CMAKE_UNDEFINES = [
+]

--- a/tools/workspace/expat_internal/package.BUILD.bazel
+++ b/tools/workspace/expat_internal/package.BUILD.bazel
@@ -1,0 +1,85 @@
+# -*- bazel -*-
+
+load("@drake//tools/install:install.bzl", "install")
+load("@drake//tools/skylark:cc.bzl", "cc_library")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_linkonly_library",
+)
+load(
+    "@drake//tools/workspace:cmake_configure_file.bzl",
+    "cmake_configure_file",
+)
+load(
+    "@drake//tools/workspace/expat_internal:cmakedefines.bzl",
+    "CMAKE_DEFINES",
+    "CMAKE_UNDEFINES",
+)
+
+licenses(["notice"])  # MIT
+
+package(default_visibility = ["//visibility:private"])
+
+# Group the headers exported by this library.
+cc_library(
+    name = "hdrs",
+    hdrs = ["expat/lib/expat.h"],
+)
+
+# Generate expat_config.h.
+cmake_configure_file(
+    name = "configure_file",
+    src = "expat/expat_config.h.cmake",
+    out = "expat/expat_config.h",
+    defines = CMAKE_DEFINES,
+    undefines = CMAKE_UNDEFINES,
+    strict = False,
+)
+
+# Compile the code (using both its exported headers and its private headers).
+cc_library(
+    name = "compiled",
+    srcs = glob(
+        ["expat/lib/*.c"],
+        allow_empty = False,
+    ),
+    hdrs = glob(["expat/lib/*.h"], allow_empty = False) + [
+        "expat/expat_config.h",
+        "expat/lib/xmltok_impl.c",
+        "expat/lib/xmltok_ns.c",
+    ],
+    copts = [
+        "-Wno-all",
+        "-fvisibility=hidden",
+    ],
+    includes = [
+        "expat",
+        "expat/lib",
+    ],
+    linkstatic = True,
+    deps = [":hdrs"],
+)
+
+# Strip the private headers out; we just want the object code.
+cc_linkonly_library(
+    name = "archive",
+    deps = [":compiled"],
+)
+
+# Combine the public headers with the object code.
+# This does not provide the private headers.
+cc_library(
+    name = "expat",
+    linkstatic = True,
+    deps = [
+        ":archive",
+        ":hdrs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+install(
+    name = "install",
+    docs = ["COPYING"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/workspace/expat_internal/repository.bzl
+++ b/tools/workspace/expat_internal/repository.bzl
@@ -1,0 +1,13 @@
+load("//tools/workspace:github.bzl", "github_archive")
+
+def expat_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "libexpat/libexpat",
+        commit = "be47f6d5e871382dc2ab783a9df416ec4370074e",
+        sha256 = "f8d003d61297773c3dbe84b8efc3e6ca1721cf12a1815e378b4a081b9b97eb57",  # noqa
+        build_file = ":package.BUILD.bazel",
+        mirrors = mirrors,
+    )

--- a/tools/workspace/rnv_internal/BUILD.bazel
+++ b/tools/workspace/rnv_internal/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/rnv_internal/package.BUILD.bazel
+++ b/tools/workspace/rnv_internal/package.BUILD.bazel
@@ -1,0 +1,73 @@
+# -*- bazel -*-
+
+load("@drake//tools/install:install.bzl", "install")
+load("@drake//tools/skylark:cc.bzl", "cc_library")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_linkonly_library",
+)
+load(
+    "@drake//tools/workspace:cmake_configure_file.bzl",
+    "cmake_configure_file",
+)
+
+licenses(["notice"])  # BSD-3-Clause
+
+package(default_visibility = ["//visibility:private"])
+
+# Group the headers exported by this library.
+cc_library(
+    name = "hdrs",
+    hdrs = ["er.h", "rnl.h", "xcl.h"],
+)
+
+# Compile the code (using both its exported headers and its private headers).
+cc_library(
+    name = "compiled",
+    srcs = glob(
+        ["*.c"],
+        exclude = ["arx.c", "rvp.c", "test.c", "xsdck.c"],
+        allow_empty = False,
+    ),
+    hdrs = glob(["rx_cls_*.c", "*.h"], allow_empty = False),
+    copts = [
+        "-Wno-all",
+        "-Wno-empty-body",
+        "-fvisibility=hidden",
+    ],
+    defines = [
+        "EXPAT_H=<expat.h>",
+        "UNISTD_H=<unistd.h>",
+        "SUPPRESS_MAIN",
+        'ARX_VERSION=\\"dontcare\\"',
+        'RNV_VERSION=\\"dontcare\\"',
+        'RVP_VERSION=\\"dontcare\\"',
+    ],
+    linkstatic = True,
+    deps = [":hdrs"],
+)
+
+# Strip the private headers out; we just want the object code.
+cc_linkonly_library(
+    name = "archive",
+    deps = [":compiled"],
+)
+
+# Combine the public headers with the object code.
+# This does not provide the private headers.
+cc_library(
+    name = "rnv",
+    linkstatic = True,
+    deps = [
+        ":archive",
+        ":hdrs",
+        "@expat_internal//:expat",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+install(
+    name = "install",
+    docs = ["COPYING"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/workspace/rnv_internal/patches/doc_api.patch
+++ b/tools/workspace/rnv_internal/patches/doc_api.patch
@@ -1,0 +1,196 @@
+[rnv] Expose schema validation via library functions
+
+As offered, rnv builds a number of command line programs. Drake uses
+portions of it as a library. This patch re-organizes and exposes schema
+parsing and document validation via library functions, with shared
+internal global state. The resulting interface is not thread-safe;
+clients should take the necessary precautions.
+
+--- xcl.c
++++ xcl.c
+@@ -1,4 +1,5 @@
+ /* $Id$ */
++#include "xcl.h"
+ 
+ #include <stdlib.h>
+ #include <stdarg.h>
+@@ -103,11 +104,20 @@ static void init(void) {
+   }
+ }
+ 
++void xcl_init(void) {
++  /* Configure the same defaults as main() does. */
++  verbose = 1;
++  nexp = NEXP;
++  init();
++}
++
+ static void clear(void) {
+   if(len_txt>LIM_T) {m_free(text); text=(char*)m_alloc(len_txt=LEN_T,sizeof(char));}
+   windup();
+ }
+ 
++void xcl_clear(void) { clear(); }
++
+ static void windup(void) {
+   text[n_txt=0]='\0';
+   level=0; lastline=lastcol=-1;
+@@ -156,7 +166,7 @@ static void characters(void *userData,const char *s,int len) {
+ static void processingInstruction(void *userData,
+     const char *target,const char *data) {
+   if(strcmp(PIXGFILE,target)==0) {
+-    if(xgfile) m_free(xgfile); 
++    if(xgfile) m_free(xgfile);
+     xgfile=s_clone((char*)data);
+   } else if(strcmp(PIXGPOS,target)==0) {
+     if(xgpos) m_free(xgpos);
+@@ -173,11 +183,13 @@ static int pipeout(void *buf,int len) {
+   }
+ }
+ 
+-static int process(int fd) {
++typedef int (*READABLE_FN)(void*, void*, int);
++
++static int process_readable(void* read_data, READABLE_FN read_fn) {
+   void *buf; int len;
+   for(;;) {
+     buf=XML_GetBuffer(expat,BUFSIZE);
+-    len=read(fd,buf,BUFSIZE);
++    len=read_fn(read_data,buf,BUFSIZE);
+     if(len<0) {
+       error_handler(XCL_ER_IO,xml,strerror(errno));
+       goto ERROR;
+@@ -190,18 +202,52 @@ static int process(int fd) {
+ 
+ PARSE_ERROR:
+   error_handler(XCL_ER_XML,XML_ErrorString(XML_GetErrorCode(expat)));
+-  while(peipe&&(len=read(fd,buf,BUFSIZE))!=0) peipe=peipe&&pipeout(buf,len);
++  while(peipe&&(len=read_fn(read_data,buf,BUFSIZE))!=0) {
++    peipe=peipe&&pipeout(buf,len);
++  }
+ ERROR:
+   return 0;
+ }
+ 
++static int fd_read(void* read_data, void* buf, int len) {
++  int fd = *(int*)read_data;
++  return read(fd, buf, len);
++}
++
++static int process(int fd) {
++  return process_readable(&fd, fd_read);
++}
++
++struct MemBlock {
++  const void* buf;
++  int len;
++  int cursor;
++} MemBlock;
++
++static int memory_read(void* read_data, void* buf, int len) {
++  struct MemBlock* mem_block = (struct MemBlock*)read_data;
++  int remaining = mem_block->len - mem_block->cursor;
++  if (remaining <= 0) { return 0; }
++  int result;
++  if (remaining > len) {
++    result = len;
++  } else {
++    result = remaining;
++  }
++  memcpy(buf, (char*)(mem_block->buf) + mem_block->cursor, result);
++  mem_block->cursor += result;
++  return result;
++}
++
+ static int externalEntityRef(XML_Parser p,const char *context,
+     const char *base,const char *systemId,const char *publicId) {
+   error_handler(XCL_ER_XENT);
+   return 1;
+ }
+ 
+-static void validate(int fd) {
++static void validate_readable(void* read_data, READABLE_FN read_fn,
++                                  const char* document_filename) {
++  xml = (char*)document_filename;  /* const_cast */
+   previous=current=start;
+   expat=XML_ParserCreateNS(NULL,':');
+   XML_SetParamEntityParsing(expat,XML_PARAM_ENTITY_PARSING_ALWAYS);
+@@ -209,10 +255,37 @@ static void validate(int fd) {
+   XML_SetCharacterDataHandler(expat,&characters);
+   XML_SetExternalEntityRefHandler(expat,&externalEntityRef);
+   XML_SetProcessingInstructionHandler(expat,&processingInstruction);
+-  ok=process(fd);
++  ok=process_readable(read_data, read_fn);
+   XML_ParserFree(expat);
+ }
+ 
++void xcl_validate_memory(const void* inbuf, int inlen,
++                         const char* document_filename) {
++  struct MemBlock mem_block = { inbuf, inlen, 0 };
++  validate_readable(&mem_block, memory_read, document_filename);
++}
++
++void xcl_validate_fd(int fd, const char* document_filename) {
++  validate_readable(&fd, fd_read, document_filename);
++}
++
++static void validate(int fd) {
++  xcl_validate_fd(fd, xml);
++}
++
++void xcl_rnl_fd(const char* schema_filename, int fd) {
++  start = rnl_fd((char*)schema_filename, fd);  /* const_cast */
++}
++
++void xcl_rnl_s(const char* schema_filename,
++               const char* schema_contents,
++               int schema_len) {
++  start = rnl_s((char*)schema_filename,  /* const_cast */
++                (char*)schema_contents,  /* const_cast */
++                schema_len);
++}
++
++
+ static void version(void) {(*er_printf)("rnv version %s\n",RNV_VERSION);}
+ static void usage(void) {(*er_printf)("usage: rnv {-[qnspc"
+ #if DXL_EXC
+diff --git xcl.h xcl.h
+new file mode 100644
+index 0000000..fd9f92f
+--- /dev/null
++++ xcl.h
+@@ -0,0 +1,34 @@
++/* $Id$ */
++
++#ifndef XCL_H
++#define XCL_H 1
++
++/* Prepare the validation library for use. The must be called before any other
++ * functions, and again to use the library after having called xcl_clear(). */
++extern void xcl_init(void);
++
++/* Release internally held resources. */
++extern void xcl_clear(void);
++
++/* Parse a schema, provided as an open file descriptor, and prepare internal
++ * resources for validating documents against it. The schema_filename is just a
++ * string to use in error messages. */
++extern void xcl_rnl_fd(const char* schema_filename, int fd);
++
++/* Parse a schema, provided as an in-memory string, and prepare internal
++ * resources for validating documents against it. The schema_filename is just a
++ * string to use in error messages. */
++extern void xcl_rnl_s(const char* schema_filename,
++                      const char* schema_contents,
++                      int schema_len);
++
++/* Validate a document, provided as an open file descriptor. The
++ * document_filename is just a string to use in error messages. */
++extern void xcl_validate_fd(int fd, const char* document_filename);
++
++/* Validate a document, provided as a memory buffer. The document_filename is
++ * just a string to use in error messages. */
++extern void xcl_validate_memory(const void* buf, int size,
++                                const char* document_filename);
++
++#endif

--- a/tools/workspace/rnv_internal/patches/memcheck.patch
+++ b/tools/workspace/rnv_internal/patches/memcheck.patch
@@ -1,0 +1,25 @@
+[rnv] Avoid valgrind memcheck errors
+
+This patch initializes some stack data, previously (and harmlessly) left
+unitialized, to avoid complaints from valgrind memcheck.
+
+Similar hazards in functions that Drake does not use are left untouched.
+
+diff --git rnl.c rnl.c
+index 65d899c..81986ed 100644
+--- rnl.c
++++ rnl.c
+@@ -45,11 +45,11 @@ int rnl_fn(char *fn) {
+ }
+ 
+ int rnl_fd(char *fn,int fd) {
+-  struct rnc_source src;
++  struct rnc_source src = {0};
+   rnc_bind(&src,fn,fd); return load(&src);
+ }
+ 
+ int rnl_s(char *fn,char *s,int len) {
+-  struct rnc_source src;
++  struct rnc_source src = {0};
+   rnc_stropen(&src,fn,s,len); return load(&src);
+ }

--- a/tools/workspace/rnv_internal/patches/no_after_in_messages.patch
+++ b/tools/workspace/rnv_internal/patches/no_after_in_messages.patch
@@ -1,0 +1,40 @@
+[rnv] Don't say "after" in messages
+
+The compiled form of the schema uses bytecodes, some of which will be
+meaningless to anyone other than developers of the library. The
+"required" section of the typical validation error message just dumps
+the name of the current bytecode, which is of little help to anyone. So,
+just skip the "required" section altogether.
+
+Also, in the internal logic of the validator, the "after" bytecode is
+something that might have matched in case of failure, but no human knows
+what this means. Suppress reports about "after" in the allowed section
+as well.
+
+index c844dc6..fd088d2 100644
+--- xcl.c
++++ xcl.c
+@@ -20,6 +20,7 @@
+ #include "dxl.h"
+ #include "dsl.h"
+ #include "er.h"
++#include "rn.h"
+ 
+ extern int rn_notAllowed,rx_compact,drv_compact;
+ 
+@@ -62,13 +63,14 @@ static void verror_handler(int erno,va_list ap) {
+       (*er_printf)("%s:%i:%i: error: ",xml,line,col);
+       if(erno&ERBIT_RNV) {
+ 	rnv_default_verror_handler(erno&~ERBIT_RNV,ap);
+-	if(nexp) { int req=2, i=0; char *s;
++	if(nexp) { int req=1, i=0; char *s;
+ 	  while(req--) {
+ 	    rnx_expected(previous,req);
+ 	    if(i==rnx_n_exp) continue;
+ 	    if(rnx_n_exp>nexp) break;
+ 	    (*er_printf)((char*)(req?"required:\n":"allowed:\n"));
+ 	    for(;i!=rnx_n_exp;++i) {
++              if (RN_P_IS(rnx_exp[i],RN_P_AFTER)) { continue; }
+ 	      (*er_printf)("\t%s\n",s=rnx_p2str(rnx_exp[i]));
+ 	      m_free(s);
+ 	    }

--- a/tools/workspace/rnv_internal/patches/no_exit.patch
+++ b/tools/workspace/rnv_internal/patches/no_exit.patch
@@ -1,0 +1,32 @@
+[rnv] Avoid calling exit(1)
+
+As offered, rnv builds a number of command line programs. Drake uses
+portions of it as a library.  This patch fixes some rare error handling
+branches to call abort() instead of exit(1). In the unlikely event that
+Drake usage causes defective memory allocation, the result will be an
+obvious crash and possible crash dump file, instead of a somewhat
+mysterious orderly exit.
+
+This patch should not be upstreamed to rnv as-is -- it will change the
+error behavior of the command-line programs.
+
+--- m.c
++++ m.c
+@@ -29,7 +29,7 @@ void *m_alloc(int length,int size) {
+   pmp=mp; mp+=(n+sizeof(int)-1)/sizeof(int)*sizeof(int);
+   if(mp>=memory+M_STATIC) {
+     (*er_printf)("failed to allocate %i bytes of memory\n",length*size);
+-    exit(1);
++    abort();
+   }
+   if(M_FILL!=-1) while(q!=mp) *(q++)=M_FILL;
+   return (char*)p;
+@@ -45,7 +45,7 @@ void *m_alloc(int length,int size) {
+   void *p=malloc(length*size);
+   if(p==NULL) {
+     (*er_printf)("failed to allocate %i bytes of memory\n",length*size);
+-    exit(1);
++    abort();
+   }
+   return p;
+ }

--- a/tools/workspace/rnv_internal/patches/no_main_symbol.patch
+++ b/tools/workspace/rnv_internal/patches/no_main_symbol.patch
@@ -1,0 +1,20 @@
+[rnv] Avoid main symbol for use as a library
+
+As offered, rnv builds a number of command line programs. Drake uses
+portions of it as a library. It is necessary to prevent useful modules
+from occupying the magic `main` symbol.
+
+This patch should not be upstreamed to rnv as-is -- it will break the
+upstream build.
+
+--- xcl.c
++++ xcl.c
+@@ -223,7 +223,7 @@ static void usage(void) {(*er_printf)("usage: rnv {-[qnspc"
+ #endif
+ "vh?]} schema.rnc {document.xml}\n");}
+ 
+-int main(int argc,char **argv) {
++int xcl_main(int argc,char **argv) {
+   init();
+ 
+   peipe=0; verbose=1; nexp=NEXP; rnck=0;

--- a/tools/workspace/rnv_internal/repository.bzl
+++ b/tools/workspace/rnv_internal/repository.bzl
@@ -1,0 +1,20 @@
+load("//tools/workspace:github.bzl", "github_archive")
+
+def rnv_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "hartwork/rnv",
+        commit = "e2435bfd9e67a1e8b3a34bae6919ee572465d435",
+        sha256 = "17a3b36a47a7c2be176b6152754eb362b9103b6656fc00736230f99555df8a37",  # noqa
+        build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/doc_api.patch",
+            ":patches/memcheck.patch",
+            ":patches/no_after_in_messages.patch",
+            ":patches/no_exit.patch",
+            ":patches/no_main_symbol.patch",
+        ],
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
[Draft] This is the complete set of changes to implement Schema checking of URDF. The full set is too big to review, so this branch serves as a reference for the chain of smaller PRs that could actually merge.

Relevant issues are #19981 and friends: #16997, #12610, etc.

The new (for Drake, but actually old) technology here is RelaxNG schema validation, using the compact syntax.
https://relaxng.org/
https://relaxng.org/compact-tutorial-20030326.html

This branch introduces a dependency on [rnv](https://github.com/hartwork/rnv),  a schema validator command line tool, adapted here for use as a library. Also re-introduced is expat, required by rnv, and re-integrated here as an internal dependency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20824)
<!-- Reviewable:end -->
