### PR TITLE
Fix for SchunkWsgTrajectoryGenerator failing on delta=0

### DIFF
--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -123,6 +123,11 @@ void SchunkWsgTrajectoryGenerator::UpdateTrajectory(
 
   const double direction = (cur_position < target_position) ? 1 : -1;
   const double delta = std::abs(target_position - cur_position);
+  if (delta == 0) {
+    // Create the constant trajectory.
+    trajectory_.reset(new trajectories::PiecewisePolynomial<double>(knots[0]));
+    return;
+  }
 
   // The trajectory creation code below is, to say the best, a bit
   // primitive.  I (sam.creasey) would not be surprised if it could


### PR DESCRIPTION
There was a particular set of initial conditions which could cause the trajectory generator to fail, because it passed times=[0, 0, 0] to the PiecewisePolynomial.FirstOrderHold, which then complained about non-increasing times.

This PR adds a test which captures the failure, and the fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20828)
<!-- Reviewable:end -->
