### PR TITLE
[optimization] Deprecate ShapeReifier as a public base of ConvexSet

### DIFF
--- a/geometry/optimization/cartesian_product.cc
+++ b/geometry/optimization/cartesian_product.cc
@@ -91,7 +91,9 @@ CartesianProduct::CartesianProduct(const QueryObject<double>& query_object,
                                    std::optional<FrameId> reference_frame)
     : ConvexSet(3, false) {
   Cylinder cylinder(1., 1.);
-  query_object.inspector().GetShape(geometry_id).Reify(this, &cylinder);
+  query_object.inspector()
+      .GetShape(geometry_id)
+      .Reify(internal::ConvexSetReifierAttorney::get_reifier(this), &cylinder);
 
   // Make the cylinder out of a circle (2D sphere) and a line segment (1D box).
   sets_.emplace_back(

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -128,7 +128,7 @@ class CartesianProduct final : public ConvexSet {
       const final;
 
   // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
+  using ConvexSet::ImplementGeometry;
   void ImplementGeometry(const Cylinder& cylinder, void* data) final;
 
   // The member variables are not const in order to support move semantics.

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -281,6 +281,36 @@ double ConvexSet::DoCalcVolume() const {
                   NiceTypeName::Get(*this)));
 }
 
+// TODO(jwnimmer-tri) On 2024-06-01 upon completion of deprecation, remove this
+// entire block of code.
+void ConvexSet::ImplementGeometry(const Box& shape, void* user_data) {
+  ShapeReifier::ImplementGeometry(shape, user_data);
+}
+void ConvexSet::ImplementGeometry(const Capsule& shape, void* user_data) {
+  ShapeReifier::ImplementGeometry(shape, user_data);
+}
+void ConvexSet::ImplementGeometry(const Convex& shape, void* user_data) {
+  ShapeReifier::ImplementGeometry(shape, user_data);
+}
+void ConvexSet::ImplementGeometry(const Cylinder& shape, void* user_data) {
+  ShapeReifier::ImplementGeometry(shape, user_data);
+}
+void ConvexSet::ImplementGeometry(const Ellipsoid& shape, void* user_data) {
+  ShapeReifier::ImplementGeometry(shape, user_data);
+}
+void ConvexSet::ImplementGeometry(const HalfSpace& shape, void* user_data) {
+  ShapeReifier::ImplementGeometry(shape, user_data);
+}
+void ConvexSet::ImplementGeometry(const Mesh& shape, void* user_data) {
+  ShapeReifier::ImplementGeometry(shape, user_data);
+}
+void ConvexSet::ImplementGeometry(const MeshcatCone& shape, void* user_data) {
+  ShapeReifier::ImplementGeometry(shape, user_data);
+}
+void ConvexSet::ImplementGeometry(const Sphere& shape, void* user_data) {
+  ShapeReifier::ImplementGeometry(shape, user_data);
+}
+
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -19,6 +19,12 @@ namespace drake {
 namespace geometry {
 namespace optimization {
 
+// TODO(jwnimmer-tri) Remove on 2024-06-01 upon completion of deprecation.
+namespace internal {
+// This class is defined later in the file.
+class ConvexSetReifierAttorney;
+}  // namespace internal
+
 // TODO(russt): Remove the experimental caveat once we've given this a proper
 // spin.
 /** @defgroup geometry_optimization Geometry Optimization
@@ -72,7 +78,7 @@ struct SampledVolume {
 
 /** Abstract base class for defining a convex set.
 @ingroup geometry_optimization */
-class ConvexSet : public ShapeReifier {
+class ConvexSet : private ShapeReifier {
  public:
   virtual ~ConvexSet();
 
@@ -397,7 +403,33 @@ class ConvexSet : public ShapeReifier {
       solvers::MathematicalProgram* prog, const ConvexSet& set,
       std::vector<solvers::Binding<solvers::Constraint>>* constraints) const;
 
+  // TODO(jwnimmer-tri) On 2024-06-01 upon completion of deprecation, remove
+  // this entire block of code.
+#ifndef DRAKE_DOXYGEN_CXX
+  DRAKE_DEPRECATED("2024-06-01", "The ShapeReifier base class is now private")
+  void ImplementGeometry(const Box& shape, void* user_data) override;
+  DRAKE_DEPRECATED("2024-06-01", "The ShapeReifier base class is now private")
+  void ImplementGeometry(const Capsule& shape, void* user_data) override;
+  DRAKE_DEPRECATED("2024-06-01", "The ShapeReifier base class is now private")
+  void ImplementGeometry(const Convex& shape, void* user_data) override;
+  DRAKE_DEPRECATED("2024-06-01", "The ShapeReifier base class is now private")
+  void ImplementGeometry(const Cylinder& shape, void* user_data) override;
+  DRAKE_DEPRECATED("2024-06-01", "The ShapeReifier base class is now private")
+  void ImplementGeometry(const Ellipsoid& shape, void* user_data) override;
+  DRAKE_DEPRECATED("2024-06-01", "The ShapeReifier base class is now private")
+  void ImplementGeometry(const HalfSpace& shape, void* user_data) override;
+  DRAKE_DEPRECATED("2024-06-01", "The ShapeReifier base class is now private")
+  void ImplementGeometry(const Mesh& shape, void* user_data) override;
+  DRAKE_DEPRECATED("2024-06-01", "The ShapeReifier base class is now private")
+  void ImplementGeometry(const MeshcatCone& shape, void* user_data) override;
+  DRAKE_DEPRECATED("2024-06-01", "The ShapeReifier base class is now private")
+  void ImplementGeometry(const Sphere& shape, void* user_data) override;
+#endif
+
  private:
+  // TODO(jwnimmer-tri) Remove on 2024-06-01 upon completion of deprecation.
+  friend internal::ConvexSetReifierAttorney;
+
   /** Generic implementation for IsBounded() -- applicable for all convex sets.
   @pre ambient_dimension() >= 0 */
   bool GenericDoIsBounded() const;
@@ -442,6 +474,36 @@ ConvexSets MakeConvexSets(Args&&... args) {
   seq_into_sets(std::make_index_sequence<N>{});
   return sets;
 }
+
+// TODO(jwnimmer-tri) On 2024-06-01 upon completion of deprecation, remove this
+// entire block of code. Also remove `private ShapeReifier` inheritance from the
+// ConvexSet base class and have each set that needs it (i.e., the six classes
+// listed as friends below) privately inherit `ShapeReifier` on thier own.
+#ifndef DRAKE_DOXYGEN_CXX
+class CartesianProduct;
+class HPolyhedron;
+class Hyperellipsoid;
+class MinkowskiSum;
+class Point;
+class VPolytope;
+namespace internal {
+class ConvexSetReifierAttorney {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ConvexSetReifierAttorney);
+  ConvexSetReifierAttorney() = delete;
+
+ private:
+  friend optimization::CartesianProduct;
+  friend optimization::HPolyhedron;
+  friend optimization::Hyperellipsoid;
+  friend optimization::MinkowskiSum;
+  friend optimization::Point;
+  friend optimization::VPolytope;
+
+  static ShapeReifier* get_reifier(ConvexSet* convex_set) { return convex_set; }
+};
+}  // namespace internal
+#endif
 
 }  // namespace optimization
 }  // namespace geometry

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -119,7 +119,9 @@ HPolyhedron::HPolyhedron(const QueryObject<double>& query_object,
                          std::optional<FrameId> reference_frame)
     : ConvexSet(3, false) {
   std::pair<MatrixXd, VectorXd> Ab_G;
-  query_object.inspector().GetShape(geometry_id).Reify(this, &Ab_G);
+  query_object.inspector()
+      .GetShape(geometry_id)
+      .Reify(internal::ConvexSetReifierAttorney::get_reifier(this), &Ab_G);
 
   const RigidTransformd X_WE =
       reference_frame ? query_object.GetPoseInWorld(*reference_frame)

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -279,7 +279,7 @@ class HPolyhedron final : public ConvexSet {
       const final;
 
   // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
+  using ConvexSet::ImplementGeometry;
   void ImplementGeometry(const Box& box, void* data) final;
   void ImplementGeometry(const HalfSpace&, void* data) final;
   // TODO(russt): Support ImplementGeometry(const Convex& convex, ...);

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -46,7 +46,9 @@ Hyperellipsoid::Hyperellipsoid(const QueryObject<double>& query_object,
                                std::optional<FrameId> reference_frame)
     : ConvexSet(3, true) {
   Eigen::Matrix3d A_G;
-  query_object.inspector().GetShape(geometry_id).Reify(this, &A_G);
+  query_object.inspector()
+      .GetShape(geometry_id)
+      .Reify(internal::ConvexSetReifierAttorney::get_reifier(this), &A_G);
   // p_GG_varᵀ * A_Gᵀ * A_G * p_GG_var ≤ 1
 
   const RigidTransformd X_WE =

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -182,7 +182,7 @@ class Hyperellipsoid final : public ConvexSet {
   void CheckInvariants() const;
 
   // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
+  using ConvexSet::ImplementGeometry;
   void ImplementGeometry(const Ellipsoid& ellipsoid, void* data) final;
   void ImplementGeometry(const Sphere& sphere, void* data) final;
 

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -59,7 +59,9 @@ MinkowskiSum::MinkowskiSum(const QueryObject<double>& query_object,
                            std::optional<FrameId> reference_frame)
     : ConvexSet(3, false) {
   Capsule capsule(1., 1.);
-  query_object.inspector().GetShape(geometry_id).Reify(this, &capsule);
+  query_object.inspector()
+      .GetShape(geometry_id)
+      .Reify(internal::ConvexSetReifierAttorney::get_reifier(this), &capsule);
 
   // Sphere at zero.
   sets_.emplace_back(

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -102,7 +102,7 @@ class MinkowskiSum final : public ConvexSet {
       const final;
 
   // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
+  using ConvexSet::ImplementGeometry;
   void ImplementGeometry(const Capsule& capsule, void* data) final;
 
   ConvexSets sets_{};  // Not marked const to support move semantics.

--- a/geometry/optimization/point.cc
+++ b/geometry/optimization/point.cc
@@ -30,7 +30,9 @@ Point::Point(const QueryObject<double>& query_object, GeometryId geometry_id,
              double maximum_allowable_radius)
     : ConvexSet(3, true) {
   double radius = -1.0;
-  query_object.inspector().GetShape(geometry_id).Reify(this, &radius);
+  query_object.inspector()
+      .GetShape(geometry_id)
+      .Reify(internal::ConvexSetReifierAttorney::get_reifier(this), &radius);
   if (radius > maximum_allowable_radius) {
     throw std::runtime_error(
         fmt::format("GeometryID {} has a radius {} is larger than the "

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -88,7 +88,7 @@ class Point final : public ConvexSet {
   double DoCalcVolume() const final { return 0.0; }
 
   // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
+  using ConvexSet::ImplementGeometry;
   void ImplementGeometry(const Sphere& sphere, void* data) final;
 
   Eigen::VectorXd x_;

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -90,7 +90,8 @@ MatrixXd GetConvexHullFromObjFile(const std::string& filename,
         prefix, filename));
   }
   const auto [tinyobj_vertices, faces, num_faces] =
-      internal::ReadObjFile(filename, scale, /* triangulate = */ false);
+      geometry::internal::ReadObjFile(filename, scale,
+                                      /* triangulate = */ false);
   unused(faces);
   unused(num_faces);
   orgQhull::Qhull qhull;
@@ -129,7 +130,9 @@ VPolytope::VPolytope(const QueryObject<double>& query_object,
                      std::optional<FrameId> reference_frame)
     : ConvexSet(3, true) {
   Matrix3Xd vertices;
-  query_object.inspector().GetShape(geometry_id).Reify(this, &vertices);
+  query_object.inspector()
+      .GetShape(geometry_id)
+      .Reify(internal::ConvexSetReifierAttorney::get_reifier(this), &vertices);
 
   const RigidTransformd X_WE =
       reference_frame ? query_object.GetPoseInWorld(*reference_frame)

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -140,7 +140,7 @@ class VPolytope final : public ConvexSet {
   double DoCalcVolume() const final;
 
   // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
+  using ConvexSet::ImplementGeometry;
   void ImplementGeometry(const Box& box, void* data) final;
   void ImplementGeometry(const Convex& convex, void* data) final;
   void ImplementGeometry(const Mesh& mesh, void* data) final;


### PR DESCRIPTION
Offering these functions up to users is at best misleading, and at worst a segfault (writing through an invalid `static_cast`).

Amends #15194 (see discussion labeled `geometry/optimization/convex_set.cc, line 42 at r3`): _"I'll leave this for now. It's easy enough to change (without changing any of the intended public API) later if we prefer."_.

Closes #20832. (This is an alternative approach to the same goal.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20830)
<!-- Reviewable:end -->
