### PR TITLE
[optimization] Remove ShapeReifier as a public base of ConvexSet

### DIFF
--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -29,7 +29,7 @@ Otherwise, if any set in the cartesian product is empty, the whole product
 is empty.
 
 @ingroup geometry_optimization */
-class CartesianProduct final : public ConvexSet {
+class CartesianProduct final : public ConvexSet, private ShapeReifier {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CartesianProduct)
 

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -72,7 +72,7 @@ struct SampledVolume {
 
 /** Abstract base class for defining a convex set.
 @ingroup geometry_optimization */
-class ConvexSet : public ShapeReifier {
+class ConvexSet {
  public:
   virtual ~ConvexSet();
 

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -22,7 +22,7 @@ class VPolytope;
 By convention, we treat a zero-dimensional HPolyhedron as nonempty.
 
 @ingroup geometry_optimization */
-class HPolyhedron final : public ConvexSet {
+class HPolyhedron final : public ConvexSet, private ShapeReifier {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HPolyhedron)
 

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -30,7 +30,7 @@ A hyperellipsoid can never be empty -- it always contains its center. This
 includes the zero-dimensional case.
 
 @ingroup geometry_optimization */
-class Hyperellipsoid final : public ConvexSet {
+class Hyperellipsoid final : public ConvexSet, private ShapeReifier {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Hyperellipsoid)
 

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -21,7 +21,7 @@ have sets_.size() == 0) is treated as the singleton {0}, which is nonempty.
 This includes the zero-dimensional case.
 
 @ingroup geometry_optimization */
-class MinkowskiSum final : public ConvexSet {
+class MinkowskiSum final : public ConvexSet, private ShapeReifier {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MinkowskiSum)
 

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -17,7 +17,7 @@ singleton or unit set.
 This set is always nonempty, even in the zero-dimensional case.
 
 @ingroup geometry_optimization */
-class Point final : public ConvexSet {
+class Point final : public ConvexSet, private ShapeReifier {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Point)
 

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -31,7 +31,7 @@ and vertices_.cols() are zero, we treat this as no points in {0}, which is
 empty.
 
 @ingroup geometry_optimization */
-class VPolytope final : public ConvexSet {
+class VPolytope final : public ConvexSet, private ShapeReifier {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VPolytope)
 


### PR DESCRIPTION
Offering these functions up to users is at best misleading, and at worst a segfault (writing through an invalid `static_cast`).

Amends #15194 (see discussion labeled `geometry/optimization/convex_set.cc, line 42 at r3`): _"I'll leave this for now. It's easy enough to change (without changing any of the intended public API) later if we prefer."_.

Closes #20830.  (This is an alternative approach to the same goal.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20832)
<!-- Reviewable:end -->
