### PR TITLE
When using visit with overloaded, prescribe the return type

### DIFF
--- a/common/overloaded.h
+++ b/common/overloaded.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <utility>
+#include <variant>
+
 /** @file
 The "overloaded" variant-visit pattern.
 
@@ -8,8 +11,8 @@ doesn't support it natively.  There is a commonly used two-line boilerplate
 that bridges this gap; see
 https://en.cppreference.com/w/cpp/utility/variant/visit
 
-This file should be included by classes that wish to
-use the variant visit pattern, i.e.
+This file should be included by classes that wish to use the variant visit
+pattern, i.e.:
 
 @code {.cpp}
   using MyVariant = std::variant<int, std::string>;
@@ -20,6 +23,23 @@ use the variant visit pattern, i.e.
   }, v);
   EXPECT_EQ(result, "found an int");
 @endcode
+
+However, note that the prior example DOES NOT WORK yet in Drake. In order to
+support C++17 we must also (for now) use a polyfill for `std::visit<T>` which
+we've named `visit_overloaded<T>`, so within Drake we must spell it like this:
+
+@code {.cpp}
+  using MyVariant = std::variant<int, std::string>;
+  MyVariant v = 5;
+  std::string result = visit_overloaded<const char*>(overloaded{
+    [](const int arg) { return "found an int"; },
+    [](const std::string& arg) { return "found a string"; }
+  }, v);
+  EXPECT_EQ(result, "found an int");
+@endcode
+
+When we drop support for C++17, we'll be able to return back to the normal
+pattern.
 
 @warning This file must never be included by a header, only by a cc file.
          This is enforced by a lint rule in `tools/lint/drakelint.py`.
@@ -40,4 +60,27 @@ overloaded(Ts...) -> overloaded<Ts...>;
 
 // NOTE:  The second line above can be removed when we are compiling with
 // >= C++20 on all platforms.
+
+// This is a polyfill for C++20's std::visit<Return>(visitor, variant) that we
+// need while we still support C++17. Once we drop C++17 (i.e., once we drop
+// Ubuntu 20.04), we should switch back to the conventional spelling and remove
+// this entire block of code.
+#if __cplusplus > 201703L
+// On reasonable platforms, we can just call std::visit.
+template <typename Return, typename Visitor, typename Variant>
+auto visit_overloaded(Visitor&& visitor, Variant&& variant) -> decltype(auto) {
+  return std::visit<Return>(std::forward<Visitor>(visitor),
+                            std::forward<Variant>(variant));
+}
+#else
+// On Focal, we need to do a polyfill.
+template <typename Return, typename Visitor, typename Variant>
+auto visit_overloaded(Visitor&& visitor, Variant&& variant) -> Return {
+  auto visitor_coerced = [&visitor]<typename Value>(Value&& value) -> Return {
+    return visitor(std::forward<Value>(value));
+  };
+  return std::visit(visitor_coerced, std::forward<Variant>(variant));
+}
+#endif
+
 }  // namespace

--- a/common/overloaded.h
+++ b/common/overloaded.h
@@ -14,7 +14,7 @@ use the variant visit pattern, i.e.
 @code {.cpp}
   using MyVariant = std::variant<int, std::string>;
   MyVariant v = 5;
-  std::string result = std::visit(overloaded{
+  std::string result = std::visit<const char*>(overloaded{
     [](const int arg) { return "found an int"; },
     [](const std::string& arg) { return "found a string"; }
   }, v);

--- a/common/schema/rotation.cc
+++ b/common/schema/rotation.cc
@@ -19,19 +19,18 @@ Rotation::Rotation(const math::RollPitchYaw<double>& arg) {
 }
 
 bool Rotation::IsDeterministic() const {
-  using Result = bool;
-  return std::visit(overloaded{
-    [](const Identity&) -> Result {
+  return std::visit<bool>(overloaded{
+    [](const Identity&) {
       return true;
     },
-    [](const Rpy& rpy) -> Result {
+    [](const Rpy& rpy) {
       return schema::IsDeterministic(rpy.deg);
     },
-    [](const AngleAxis& aa) -> Result {
+    [](const AngleAxis& aa) {
       return schema::IsDeterministic(aa.angle_deg) &&
              schema::IsDeterministic(aa.axis);
     },
-    [](const Uniform&) -> Result {
+    [](const Uniform&) {
       return false;
     },
   }, value);
@@ -66,22 +65,22 @@ Vector<Expression, Size> deg2rad(
 
 math::RotationMatrix<Expression> Rotation::ToSymbolic() const {
   using Result = math::RotationMatrix<Expression>;
-  return std::visit(overloaded{
-    [](const Identity&) -> Result {
+  return std::visit<Result>(overloaded{
+    [](const Identity&) {
       return Result{};
     },
-    [](const Rpy& rpy) -> Result {
+    [](const Rpy& rpy) {
       const Vector3<Expression> rpy_rad = deg2rad(rpy.deg);
       return Result{math::RollPitchYaw<Expression>(rpy_rad)};
     },
-    [](const AngleAxis& aa) -> Result {
+    [](const AngleAxis& aa) {
       const Expression angle_rad = deg2rad(aa.angle_deg);
       const Vector3<Expression> axis =
           schema::ToDistributionVector(aa.axis)->ToSymbolic().normalized();
       const Eigen::AngleAxis<Expression> theta_lambda(angle_rad, axis);
       return Result{theta_lambda};
     },
-    [](const Uniform&) -> Result {
+    [](const Uniform&) {
       RandomGenerator generator;
       return math::UniformlyRandomRotationMatrix<Expression>(&generator);
     },

--- a/common/schema/rotation.cc
+++ b/common/schema/rotation.cc
@@ -19,7 +19,7 @@ Rotation::Rotation(const math::RollPitchYaw<double>& arg) {
 }
 
 bool Rotation::IsDeterministic() const {
-  return std::visit<bool>(overloaded{
+  return visit_overloaded<bool>(overloaded{
     [](const Identity&) {
       return true;
     },
@@ -65,7 +65,7 @@ Vector<Expression, Size> deg2rad(
 
 math::RotationMatrix<Expression> Rotation::ToSymbolic() const {
   using Result = math::RotationMatrix<Expression>;
-  return std::visit<Result>(overloaded{
+  return visit_overloaded<Result>(overloaded{
     [](const Identity&) {
       return Result{};
     },

--- a/common/schema/stochastic.cc
+++ b/common/schema/stochastic.cc
@@ -183,7 +183,7 @@ drake::VectorX<Expression> ToSymbolic(
 }
 
 bool IsDeterministic(const DistributionVariant& var) {
-  return std::visit<bool>(overloaded{
+  return visit_overloaded<bool>(overloaded{
     [](const double&) {
       return true;
     },
@@ -350,7 +350,7 @@ drake::VectorX<Expression> UniformVector<Size>::ToSymbolic() const {
 template <int Size>
 unique_ptr<DistributionVector> ToDistributionVector(
     const DistributionVectorVariant<Size>& vec) {
-  return std::visit<unique_ptr<DistributionVector>>(overloaded{
+  return visit_overloaded<unique_ptr<DistributionVector>>(overloaded{
     // NOLINTNEXTLINE(whitespace/line_length)
     [](const drake::Vector<double, Size>& arg) {
       return std::make_unique<DeterministicVector<Size>>(arg);
@@ -387,7 +387,7 @@ unique_ptr<DistributionVector> ToDistributionVector(
 
 template <int Size>
 bool IsDeterministic(const DistributionVectorVariant<Size>& vec) {
-  return std::visit<bool>(overloaded{
+  return visit_overloaded<bool>(overloaded{
     [](const drake::Vector<double, Size>&) {
       return true;
     },

--- a/common/schema/stochastic.cc
+++ b/common/schema/stochastic.cc
@@ -183,20 +183,20 @@ drake::VectorX<Expression> ToSymbolic(
 }
 
 bool IsDeterministic(const DistributionVariant& var) {
-  return std::visit(overloaded{
-    [](const double&) -> bool {
+  return std::visit<bool>(overloaded{
+    [](const double&) {
       return true;
     },
-    [](const Deterministic&) -> bool {
+    [](const Deterministic&) {
       return true;
     },
-    [](const Gaussian& arg) -> bool {
+    [](const Gaussian& arg) {
       return arg.stddev == 0.0;
     },
-    [](const Uniform& arg) -> bool {
+    [](const Uniform& arg) {
       return arg.min == arg.max;
     },
-    [](const UniformDiscrete& arg) -> bool {
+    [](const UniformDiscrete& arg) {
       return arg.values.size() == 1;
     },
   }, var);
@@ -350,44 +350,36 @@ drake::VectorX<Expression> UniformVector<Size>::ToSymbolic() const {
 template <int Size>
 unique_ptr<DistributionVector> ToDistributionVector(
     const DistributionVectorVariant<Size>& vec) {
-  return std::visit(overloaded{
+  return std::visit<unique_ptr<DistributionVector>>(overloaded{
     // NOLINTNEXTLINE(whitespace/line_length)
-    [](const drake::Vector<double, Size>& arg) -> unique_ptr<DistributionVector> {
+    [](const drake::Vector<double, Size>& arg) {
       return std::make_unique<DeterministicVector<Size>>(arg);
     },
-    [](const DeterministicVector<Size>& arg) -> unique_ptr<DistributionVector> {
+    [](const DeterministicVector<Size>& arg) {
       return std::make_unique<DeterministicVector<Size>>(arg);
     },
-    [](const GaussianVector<Size>& arg) -> unique_ptr<DistributionVector> {
+    [](const GaussianVector<Size>& arg) {
       return std::make_unique<GaussianVector<Size>>(arg);
     },
-    [](const UniformVector<Size>& arg) -> unique_ptr<DistributionVector> {
+    [](const UniformVector<Size>& arg) {
       return std::make_unique<UniformVector<Size>>(arg);
     },
-    [](const Deterministic& arg) -> unique_ptr<DistributionVector> {
+    [](const Deterministic& arg) {
       return std::make_unique<DeterministicVector<Size>>(
           Eigen::VectorXd::Constant(1, arg.value));
     },
-    [](const Gaussian& arg) -> unique_ptr<DistributionVector> {
+    [](const Gaussian& arg) {
       return std::make_unique<GaussianVector<Size>>(
           Eigen::VectorXd::Constant(1, arg.mean),
           Eigen::VectorXd::Constant(1, arg.stddev));
     },
-    [](const Uniform& arg) -> unique_ptr<DistributionVector> {
+    [](const Uniform& arg) {
       return std::make_unique<UniformVector<Size>>(
           Eigen::VectorXd::Constant(1, arg.min),
           Eigen::VectorXd::Constant(1, arg.max));
     },
-    [](const internal::InvalidVariantSelection<Deterministic>&)
-        -> unique_ptr<DistributionVector> {
-      DRAKE_UNREACHABLE();
-    },
-    [](const internal::InvalidVariantSelection<Gaussian>&)
-        -> unique_ptr<DistributionVector> {
-      DRAKE_UNREACHABLE();
-    },
-    [](const internal::InvalidVariantSelection<Uniform>&)
-        -> unique_ptr<DistributionVector> {
+    []<typename T>(const internal::InvalidVariantSelection<T>&)
+        -> std::nullptr_t {
       DRAKE_UNREACHABLE();
     },
   }, vec);
@@ -395,35 +387,30 @@ unique_ptr<DistributionVector> ToDistributionVector(
 
 template <int Size>
 bool IsDeterministic(const DistributionVectorVariant<Size>& vec) {
-  return std::visit(overloaded{
-    [](const drake::Vector<double, Size>&) -> bool {
+  return std::visit<bool>(overloaded{
+    [](const drake::Vector<double, Size>&) {
       return true;
     },
-    [](const DeterministicVector<Size>&) -> bool {
+    [](const DeterministicVector<Size>&) {
       return true;
     },
-    [](const GaussianVector<Size>& arg) -> bool {
+    [](const GaussianVector<Size>& arg) {
       return arg.stddev.isZero(0.0);
     },
-    [](const UniformVector<Size>& arg) -> bool {
+    [](const UniformVector<Size>& arg) {
       return arg.min == arg.max;
     },
-    [](const Deterministic&) -> bool {
+    [](const Deterministic&) {
       return true;
     },
-    [](const Gaussian& arg) -> bool {
+    [](const Gaussian& arg) {
       return arg.stddev == 0.0;
     },
-    [](const Uniform& arg) -> bool {
+    [](const Uniform& arg) {
       return arg.min == arg.max;
     },
-    [](const internal::InvalidVariantSelection<Deterministic>&) -> bool {
-      DRAKE_UNREACHABLE();
-    },
-    [](const internal::InvalidVariantSelection<Gaussian>&) -> bool {
-      DRAKE_UNREACHABLE();
-    },
-    [](const internal::InvalidVariantSelection<Uniform>&) -> bool {
+    []<typename T>(const internal::InvalidVariantSelection<T>&)
+        -> std::false_type {
       DRAKE_UNREACHABLE();
     },
   }, vec);

--- a/common/test/overloaded_test.cc
+++ b/common/test/overloaded_test.cc
@@ -11,7 +11,7 @@ GTEST_TEST(OverloadedTest, CommentExampleTest) {
   // Test the exact text of the example in the file comment.
   using MyVariant = std::variant<int, std::string>;
   MyVariant v = 5;
-  std::string result = std::visit(overloaded{
+  std::string result = std::visit<const char*>(overloaded{
     [](const int arg) { return "found an int"; },
     [](const std::string& arg) { return "found a string"; }
   }, v);
@@ -24,7 +24,7 @@ GTEST_TEST(OverloadedTest, AutoTest) {
 
   // An 'auto' arm doesn't match if there's any explicit match,
   // no matter if it's earlier or later in the list.
-  std::string result = std::visit(overloaded{
+  std::string result = std::visit<const char*>(overloaded{
     [](const auto arg) { return "found an auto"; },
     [](const int arg) { return "found an int"; },
     [](const std::string& arg) { return "found a string"; },
@@ -33,7 +33,7 @@ GTEST_TEST(OverloadedTest, AutoTest) {
   EXPECT_EQ(result, "found an int");
 
   // An 'auto' arm matches if there's no explicit match.
-  result = std::visit(overloaded{
+  result = std::visit<const char*>(overloaded{
     [](const auto arg) { return "found an auto"; },
     [](const std::string& arg) { return "found a string"; },
   }, v);

--- a/common/test/overloaded_test.cc
+++ b/common/test/overloaded_test.cc
@@ -11,7 +11,7 @@ GTEST_TEST(OverloadedTest, CommentExampleTest) {
   // Test the exact text of the example in the file comment.
   using MyVariant = std::variant<int, std::string>;
   MyVariant v = 5;
-  std::string result = std::visit<const char*>(overloaded{
+  std::string result = visit_overloaded<const char*>(overloaded{
     [](const int arg) { return "found an int"; },
     [](const std::string& arg) { return "found a string"; }
   }, v);
@@ -24,7 +24,7 @@ GTEST_TEST(OverloadedTest, AutoTest) {
 
   // An 'auto' arm doesn't match if there's any explicit match,
   // no matter if it's earlier or later in the list.
-  std::string result = std::visit<const char*>(overloaded{
+  std::string result = visit_overloaded<const char*>(overloaded{
     [](const auto arg) { return "found an auto"; },
     [](const int arg) { return "found an int"; },
     [](const std::string& arg) { return "found a string"; },
@@ -33,7 +33,7 @@ GTEST_TEST(OverloadedTest, AutoTest) {
   EXPECT_EQ(result, "found an int");
 
   // An 'auto' arm matches if there's no explicit match.
-  result = std::visit<const char*>(overloaded{
+  result = visit_overloaded<const char*>(overloaded{
     [](const auto arg) { return "found an auto"; },
     [](const std::string& arg) { return "found a string"; },
   }, v);

--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_library(
     hdrs = ["yaml_node.h"],
     deps = [
         "//common:essential",
+        "//common:overloaded",
     ],
 )
 
@@ -62,6 +63,7 @@ drake_cc_library(
         "//common:essential",
         "//common:name_value",
         "//common:nice_type_name",
+        "//common:overloaded",
         "//common:unused",
         "@yaml_cpp_internal//:yaml_cpp",
     ],

--- a/common/yaml/yaml_node.cc
+++ b/common/yaml/yaml_node.cc
@@ -6,19 +6,12 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/overloaded.h"
 
 namespace drake {
 namespace yaml {
 namespace internal {
 namespace {
-
-// Boilerplate for std::visit.
-template <class... Ts>
-struct overloaded : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
 
 // Converts a type T from our variant<> into a string name for errors.
 template <typename T>
@@ -62,7 +55,7 @@ Node Node::MakeNull() {
 }
 
 NodeType Node::GetType() const {
-  return std::visit(  // BR
+  return std::visit<NodeType>(  // BR
       overloaded{
           [](const ScalarData&) {
             return NodeType::kScalar;
@@ -137,12 +130,12 @@ bool operator==(const Node::MappingData& a, const Node::MappingData& b) {
 }
 
 std::string_view Node::GetTag() const {
-  return std::visit(  // BR
+  return std::visit<std::string_view>(  // BR
       overloaded{
-          [](const std::string& tag) -> std::string_view {
-            return tag;
+          [](const std::string& tag) {
+            return std::string_view{tag};
           },
-          [](JsonSchemaTag tag) -> std::string_view {
+          [](JsonSchemaTag tag) {
             switch (tag) {
               case JsonSchemaTag::kNull:
                 return kTagNull;
@@ -188,12 +181,12 @@ const std::optional<Node::Mark>& Node::GetMark() const {
 }
 
 const std::string& Node::GetScalar() const {
-  return std::visit(
+  return *std::visit<const std::string*>(
       overloaded{
-          [](const ScalarData& data) -> const std::string& {
-            return data.scalar;
+          [](const ScalarData& data) {
+            return &data.scalar;
           },
-          [](auto&& data) -> const std::string& {
+          [](auto&& data) -> std::nullptr_t {
             throw std::logic_error(fmt::format("Cannot Node::GetScalar on a {}",
                                                GetNiceVariantName(data)));
           },
@@ -202,12 +195,12 @@ const std::string& Node::GetScalar() const {
 }
 
 const std::vector<Node>& Node::GetSequence() const {
-  return std::visit(
+  return *std::visit<const std::vector<Node>*>(
       overloaded{
-          [](const SequenceData& data) -> const std::vector<Node>& {
-            return data.sequence;
+          [](const SequenceData& data) {
+            return &data.sequence;
           },
-          [](auto&& data) -> const std::vector<Node>& {
+          [](auto&& data) -> std::nullptr_t {
             throw std::logic_error(fmt::format(
                 "Cannot Node::GetSequence on a {}", GetNiceVariantName(data)));
           },
@@ -216,12 +209,12 @@ const std::vector<Node>& Node::GetSequence() const {
 }
 
 void Node::Add(Node value) {
-  return std::visit(
+  return std::visit<void>(
       overloaded{
-          [&value](SequenceData& data) -> void {
+          [&value](SequenceData& data) {
             data.sequence.push_back(std::move(value));
           },
-          [](auto&& data) -> void {
+          [](auto&& data) {
             throw std::logic_error(fmt::format(
                 "Cannot Node::Add(value) on a {}", GetNiceVariantName(data)));
           },
@@ -230,12 +223,12 @@ void Node::Add(Node value) {
 }
 
 const std::map<std::string, Node>& Node::GetMapping() const {
-  return std::visit(
+  return *std::visit<const std::map<std::string, Node>*>(
       overloaded{
-          [](const MappingData& data) -> const std::map<std::string, Node>& {
-            return data.mapping;
+          [](const MappingData& data) {
+            return &data.mapping;
           },
-          [](auto&& data) -> const std::map<std::string, Node>& {
+          [](auto&& data) -> std::nullptr_t {
             throw std::logic_error(fmt::format(
                 "Cannot Node::GetMapping on a {}", GetNiceVariantName(data)));
           },
@@ -244,9 +237,9 @@ const std::map<std::string, Node>& Node::GetMapping() const {
 }
 
 void Node::Add(std::string key, Node value) {
-  return std::visit(
+  return std::visit<void>(
       overloaded{
-          [&key, &value](MappingData& data) -> void {
+          [&key, &value](MappingData& data) {
             const auto result =
                 data.mapping.insert({std::move(key), std::move(value)});
             const bool inserted = result.second;
@@ -260,7 +253,7 @@ void Node::Add(std::string key, Node value) {
                   old_key));
             }
           },
-          [](auto&& data) -> void {
+          [](auto&& data) {
             throw std::logic_error(
                 fmt::format("Cannot Node::Add(key, value) on a {}",
                             GetNiceVariantName(data)));
@@ -270,12 +263,12 @@ void Node::Add(std::string key, Node value) {
 }
 
 Node& Node::At(std::string_view key) {
-  return std::visit(
+  return *std::visit<Node*>(
       overloaded{
-          [key](MappingData& data) -> Node& {
-            return data.mapping.at(std::string{key});
+          [key](MappingData& data) {
+            return &data.mapping.at(std::string{key});
           },
-          [](auto&& data) -> Node& {
+          [](auto&& data) -> std::nullptr_t {
             throw std::logic_error(fmt::format("Cannot Node::At(key) on a {}",
                                                GetNiceVariantName(data)));
           },
@@ -284,16 +277,16 @@ Node& Node::At(std::string_view key) {
 }
 
 void Node::Remove(std::string_view key) {
-  return std::visit(
+  return std::visit<void>(
       overloaded{
-          [key](MappingData& data) -> void {
+          [key](MappingData& data) {
             auto erased = data.mapping.erase(std::string{key});
             if (!erased) {
               throw std::logic_error(fmt::format(
                   "No such key '{}' during Node::Remove(key)", key));
             }
           },
-          [](auto&& data) -> void {
+          [](auto&& data) {
             throw std::logic_error(fmt::format(
                 "Cannot Node::Remove(key) on a {}", GetNiceVariantName(data)));
           },

--- a/common/yaml/yaml_node.cc
+++ b/common/yaml/yaml_node.cc
@@ -55,7 +55,7 @@ Node Node::MakeNull() {
 }
 
 NodeType Node::GetType() const {
-  return std::visit<NodeType>(  // BR
+  return visit_overloaded<NodeType>(  // BR
       overloaded{
           [](const ScalarData&) {
             return NodeType::kScalar;
@@ -130,7 +130,7 @@ bool operator==(const Node::MappingData& a, const Node::MappingData& b) {
 }
 
 std::string_view Node::GetTag() const {
-  return std::visit<std::string_view>(  // BR
+  return visit_overloaded<std::string_view>(  // BR
       overloaded{
           [](const std::string& tag) {
             return std::string_view{tag};
@@ -181,7 +181,7 @@ const std::optional<Node::Mark>& Node::GetMark() const {
 }
 
 const std::string& Node::GetScalar() const {
-  return *std::visit<const std::string*>(
+  return *visit_overloaded<const std::string*>(
       overloaded{
           [](const ScalarData& data) {
             return &data.scalar;
@@ -195,7 +195,7 @@ const std::string& Node::GetScalar() const {
 }
 
 const std::vector<Node>& Node::GetSequence() const {
-  return *std::visit<const std::vector<Node>*>(
+  return *visit_overloaded<const std::vector<Node>*>(
       overloaded{
           [](const SequenceData& data) {
             return &data.sequence;
@@ -209,7 +209,7 @@ const std::vector<Node>& Node::GetSequence() const {
 }
 
 void Node::Add(Node value) {
-  return std::visit<void>(
+  return visit_overloaded<void>(
       overloaded{
           [&value](SequenceData& data) {
             data.sequence.push_back(std::move(value));
@@ -223,7 +223,7 @@ void Node::Add(Node value) {
 }
 
 const std::map<std::string, Node>& Node::GetMapping() const {
-  return *std::visit<const std::map<std::string, Node>*>(
+  return *visit_overloaded<const std::map<std::string, Node>*>(
       overloaded{
           [](const MappingData& data) {
             return &data.mapping;
@@ -237,7 +237,7 @@ const std::map<std::string, Node>& Node::GetMapping() const {
 }
 
 void Node::Add(std::string key, Node value) {
-  return std::visit<void>(
+  return visit_overloaded<void>(
       overloaded{
           [&key, &value](MappingData& data) {
             const auto result =
@@ -263,7 +263,7 @@ void Node::Add(std::string key, Node value) {
 }
 
 Node& Node::At(std::string_view key) {
-  return *std::visit<Node*>(
+  return *visit_overloaded<Node*>(
       overloaded{
           [key](MappingData& data) {
             return &data.mapping.at(std::string{key});
@@ -277,7 +277,7 @@ Node& Node::At(std::string_view key) {
 }
 
 void Node::Remove(std::string_view key) {
-  return std::visit<void>(
+  return visit_overloaded<void>(
       overloaded{
           [key](MappingData& data) {
             auto erased = data.mapping.erase(std::string{key});

--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -9,20 +9,13 @@
 #include <yaml-cpp/yaml.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/overloaded.h"
 #include "drake/common/unused.h"
 
 namespace drake {
 namespace yaml {
 namespace internal {
 namespace {
-
-// Boilerplate for std::visit.
-template <class... Ts>
-struct overloaded : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
 
 constexpr const char* const kKeyOrder = "__key_order";
 

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -414,7 +414,7 @@ class MeshcatShapeReifier : public ShapeReifier {
     }
 
     // Set the scale.
-    std::visit<void>(
+    visit_overloaded<void>(
         overloaded{[](std::monostate) {},
                    [scale](auto& lumped_object) {
                      Eigen::Map<Eigen::Matrix4d> matrix(lumped_object.matrix);

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -414,7 +414,7 @@ class MeshcatShapeReifier : public ShapeReifier {
     }
 
     // Set the scale.
-    std::visit(
+    std::visit<void>(
         overloaded{[](std::monostate) {},
                    [scale](auto& lumped_object) {
                      Eigen::Map<Eigen::Matrix4d> matrix(lumped_object.matrix);

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -204,14 +204,14 @@ void MeshcatVisualizer<T>::SetObjects(
       if constexpr (std::is_same_v<T, double>) {
         if (params_.show_hydroelastic) {
           auto maybe_mesh = inspector.maybe_get_hydroelastic_mesh(geom_id);
-          std::visit(
-              overloaded{[](std::monostate) -> void {},
-                         [&](const TriangleSurfaceMesh<double>* mesh) -> void {
+          std::visit<void>(
+              overloaded{[](std::monostate) {},
+                         [&](const TriangleSurfaceMesh<double>* mesh) {
                            DRAKE_DEMAND(mesh != nullptr);
                            meshcat_->SetObject(path, *mesh, rgba);
                            used_hydroelastic = true;
                          },
-                         [&](const VolumeMesh<double>* mesh) -> void {
+                         [&](const VolumeMesh<double>* mesh) {
                            DRAKE_DEMAND(mesh != nullptr);
                            meshcat_->SetObject(
                                path, ConvertVolumeToSurfaceMesh(*mesh), rgba);

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -204,7 +204,7 @@ void MeshcatVisualizer<T>::SetObjects(
       if constexpr (std::is_same_v<T, double>) {
         if (params_.show_hydroelastic) {
           auto maybe_mesh = inspector.maybe_get_hydroelastic_mesh(geom_id);
-          std::visit<void>(
+          visit_overloaded<void>(
               overloaded{[](std::monostate) {},
                          [&](const TriangleSurfaceMesh<double>* mesh) {
                            DRAKE_DEMAND(mesh != nullptr);

--- a/geometry/render_gl/test/multithread_safety_test.cc
+++ b/geometry/render_gl/test/multithread_safety_test.cc
@@ -163,7 +163,7 @@ void AddShape(const Shape& shape, const Vector3d& p_WS,
               std::variant<Rgba, std::string> diffuse, RenderEngine* engine) {
   PerceptionProperties material;
   material.AddProperty("label", "id", render::RenderLabel::kDontCare);
-  std::visit<void>(  // BR
+  visit_overloaded<void>(  // BR
       overloaded{[&material](const Rgba& rgba) {
                    material.AddProperty("phong", "diffuse", rgba);
                  },

--- a/geometry/render_gl/test/multithread_safety_test.cc
+++ b/geometry/render_gl/test/multithread_safety_test.cc
@@ -163,14 +163,14 @@ void AddShape(const Shape& shape, const Vector3d& p_WS,
               std::variant<Rgba, std::string> diffuse, RenderEngine* engine) {
   PerceptionProperties material;
   material.AddProperty("label", "id", render::RenderLabel::kDontCare);
-  std::visit(overloaded{[&material](const Rgba& rgba) {
-                          material.AddProperty("phong", "diffuse", rgba);
-                        },
-                        [&material](const std::string& diffuse_map) {
-                          material.AddProperty("phong", "diffuse_map",
-                                               diffuse_map);
-                        }},
-             diffuse);
+  std::visit<void>(  // BR
+      overloaded{[&material](const Rgba& rgba) {
+                   material.AddProperty("phong", "diffuse", rgba);
+                 },
+                 [&material](const std::string& diffuse_map) {
+                   material.AddProperty("phong", "diffuse_map", diffuse_map);
+                 }},
+      diffuse);
   engine->RegisterVisual(GeometryId::get_new_id(), shape, material,
                          math::RigidTransformd(p_WS), false /* needs update */);
 }

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -107,14 +107,14 @@ std::map<int, std::string> GetPositionNames(
 VectorXd Broadcast(
     const char* diagnostic_name, double default_value, int num_positions,
     std::variant<std::monostate, double, VectorXd> value) {
-  return std::visit(overloaded{
-    [num_positions, default_value](std::monostate) -> VectorXd {
+  return std::visit<VectorXd>(overloaded{
+    [num_positions, default_value](std::monostate) {
       return VectorXd::Constant(num_positions, default_value);
     },
-    [num_positions](double arg) -> VectorXd {
+    [num_positions](double arg) {
       return VectorXd::Constant(num_positions, arg);
     },
-    [num_positions, diagnostic_name](VectorXd&& arg) -> VectorXd {
+    [num_positions, diagnostic_name](VectorXd&& arg) {
       if (arg.size() != num_positions) {
         throw std::logic_error(fmt::format(
             "Expected {} of size {}, but got size {} instead",

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -107,7 +107,7 @@ std::map<int, std::string> GetPositionNames(
 VectorXd Broadcast(
     const char* diagnostic_name, double default_value, int num_positions,
     std::variant<std::monostate, double, VectorXd> value) {
-  return std::visit<VectorXd>(overloaded{
+  return visit_overloaded<VectorXd>(overloaded{
     [num_positions, default_value](std::monostate) {
       return VectorXd::Constant(num_positions, default_value);
     },

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -106,6 +106,7 @@ drake_cc_library(
         ":rgbd_sensor",
         ":rgbd_sensor_async",
         ":sim_rgbd_sensor",
+        "//common:overloaded",
         "//geometry/render_gl",
         "//geometry/render_gltf_client",
         "//geometry/render_vtk",

--- a/systems/sensors/camera_config_functions.cc
+++ b/systems/sensors/camera_config_functions.cc
@@ -127,7 +127,7 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
   bool already_exists = !type_name.empty();
 
   if (already_exists) {
-    std::visit<void>(
+    visit_overloaded<void>(
         overloaded{
             [&type_name, &config](const std::string& class_name) {
               if (!class_name.empty() &&
@@ -152,7 +152,7 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
 
   if (already_exists) return;
 
-  std::visit<void>(
+  visit_overloaded<void>(
       overloaded{
           [&config, scene_graph](const std::string& class_name) {
             MakeEngineByClassName(class_name, config, scene_graph);

--- a/systems/sensors/camera_config_functions.cc
+++ b/systems/sensors/camera_config_functions.cc
@@ -11,6 +11,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/nice_type_name.h"
+#include "drake/common/overloaded.h"
 #include "drake/geometry/render/render_camera.h"
 #include "drake/geometry/render_gl/factory.h"
 #include "drake/geometry/render_gltf_client/factory.h"
@@ -47,14 +48,6 @@ using multibody::MultibodyPlant;
 using multibody::parsing::GetScopedFrameByName;
 
 namespace {
-
-// Boilerplate for std::visit.
-template <class... Ts>
-struct overloaded : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
 
 // Given a valid string containing a supported RenderEngine class name, returns
 // the full name as would be returned by SceneGraph::GetRendererTypeName().
@@ -134,9 +127,9 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
   bool already_exists = !type_name.empty();
 
   if (already_exists) {
-    std::visit(
+    std::visit<void>(
         overloaded{
-            [&type_name, &config](const std::string& class_name) -> void {
+            [&type_name, &config](const std::string& class_name) {
               if (!class_name.empty() &&
                   LookupEngineType(class_name) != type_name) {
                 throw std::logic_error(fmt::format(
@@ -146,7 +139,7 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
                     config.renderer_name, class_name, type_name));
               }
             },
-            [&config](auto&&) -> void {
+            [&config](auto&&) {
               throw std::logic_error(fmt::format(
                   "Invalid camera configuration; requested renderer_name "
                   " = '{}' with renderer parameters, but the named renderer "
@@ -159,7 +152,7 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
 
   if (already_exists) return;
 
-  std::visit(
+  std::visit<void>(
       overloaded{
           [&config, scene_graph](const std::string& class_name) {
             MakeEngineByClassName(class_name, config, scene_graph);


### PR DESCRIPTION
This helps avoid boilerplate and improve clarity.

Unfortunately, the `std::visit` feature we need is C++ 20 only, so we need to temporarily lobotomize this for C++17 until we drop Focal.

In Reviewable, r⊥..r1 shows what the code will look like long-term.  The r1..head is the Focal band-aid that will be reverted in a couple months when we drop Focal.

---

Examples:

```c++
  // Visiting a generic lambda with a uniform return type.
  // No need to pass a template argument to std::visit.
  // For code in this form, this PR doesn't change anything.
  const int size = std::visit(
      [](auto&& arg) {
        return arg.size();
      },
      some_variant);

  // Visiting an overloaded group of lambdas.
  // Pass a template argument to std::visit to unify the return types.
  // This template argument is new in this PR; previously, we wrote `-> VectorXd` on every lambda.
  VectorXd result = std::visit<VectorXd>(
      overloaded{
          [](const Foo& arg) {
            return arg.Normalized();
          },
          [](auto&& arg) {
            return VectorXd::Zero(arg.size());
          },
      },
      some_variant);

  // Except so long as we support C++17, we need to use the polyfill for `std::visit<Return>`.
  // The first line changes to say `visit_overloaded<T>` instead of `std::visit<T>`.
  VectorXd result = visit_overloaded<VectorXd>(
      overloaded{
          [](const Foo& arg) {
            return arg.Normalized();
          },
          [](auto&& arg) {
            return VectorXd::Zero(arg.size());
          },
      },
      some_variant);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20833)
<!-- Reviewable:end -->
