### PR TITLE
[geometry] Add optional role parameter to GetAllGeometryIds

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -60,7 +60,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("num_geometries", &Class::num_geometries,
             cls_doc.num_geometries.doc)
         .def("GetAllGeometryIds", &Class::GetAllGeometryIds,
-            cls_doc.GetAllGeometryIds.doc)
+            py::arg("role") = std::nullopt, cls_doc.GetAllGeometryIds.doc)
         .def("GetGeometryIds", &Class::GetGeometryIds, py::arg("geometry_set"),
             py::arg("role") = std::nullopt, cls_doc.GetGeometryIds.doc)
         .def("NumGeometriesWithRole", &Class::NumGeometriesWithRole,

--- a/bindings/pydrake/geometry/test/scene_graph_test.py
+++ b/bindings/pydrake/geometry/test/scene_graph_test.py
@@ -107,7 +107,12 @@ class TestGeometrySceneGraph(unittest.TestCase):
         self.assertTrue(global_frame in inspector.GetAllFrameIds())
         self.assertIsInstance(inspector.world_frame_id(), mut.FrameId)
         self.assertEqual(inspector.num_geometries(), 3)
-        self.assertEqual(len(inspector.GetAllGeometryIds()), 3)
+        self.assertEqual(
+            len(inspector.GetAllGeometryIds()),
+            3)
+        self.assertEqual(
+            len(inspector.GetAllGeometryIds(role=mut.Role.kProximity)),
+            2)
 
         # Test both GeometrySet API as well as SceneGraphInspector's
         # GeometrySet API.

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -227,20 +227,30 @@ GeometryState<T>::GeometryState(const GeometryState<U>& source)
     }
   }
 }
+
 template <typename T>
-std::vector<GeometryId> GeometryState<T>::GetAllGeometryIds() const {
-  std::vector<GeometryId> ids;
-  ids.reserve(geometries_.size());
-  for (const auto& id_geometry_pair : geometries_) {
-    ids.push_back(id_geometry_pair.first);
+std::vector<GeometryId> GeometryState<T>::GetAllGeometryIds(
+    std::optional<Role> role) const {
+  std::vector<GeometryId> result;
+  if (role.has_value()) {
+    for (const auto& [geometry_id, internal_geometry] : geometries_) {
+      if (internal_geometry.has_role(*role)) {
+        result.push_back(geometry_id);
+      }
+    }
+  } else {
+    result.reserve(geometries_.size());
+    for (const auto& [geometry_id, _] : geometries_) {
+      result.push_back(geometry_id);
+    }
   }
-  std::sort(ids.begin(), ids.end());
-  return ids;
+  std::sort(result.begin(), result.end());
+  return result;
 }
 
 template <typename T>
 unordered_set<GeometryId> GeometryState<T>::GetGeometryIds(
-    const GeometrySet& geometry_set, const std::optional<Role>& role) const {
+    const GeometrySet& geometry_set, std::optional<Role> role) const {
   return CollectIds(geometry_set, role, CollisionFilterScope::kAll);
 }
 

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -161,11 +161,11 @@ class GeometryState {
   }
 
   /** Implementation of SceneGraphInspector::GetAllGeometryIds().  */
-  std::vector<GeometryId> GetAllGeometryIds() const;
+  std::vector<GeometryId> GetAllGeometryIds(std::optional<Role> role) const;
 
   /** Implementation of SceneGraphInspector::GetGeometryIds().  */
-  std::unordered_set<GeometryId> GetGeometryIds(
-      const GeometrySet& geometry_set, const std::optional<Role>& role) const;
+  std::unordered_set<GeometryId> GetGeometryIds(const GeometrySet& geometry_set,
+                                                std::optional<Role> role) const;
 
   /** Implementation of SceneGraphInspector::NumGeometriesWithRole().  */
   int NumGeometriesWithRole(Role role) const;

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -214,9 +214,8 @@ class IrisConvexSetMaker final : public ShapeReifier {
 ConvexSets MakeIrisObstacles(const QueryObject<double>& query_object,
                              std::optional<FrameId> reference_frame) {
   const SceneGraphInspector<double>& inspector = query_object.inspector();
-  const GeometrySet all_ids(inspector.GetAllGeometryIds());
-  const std::unordered_set<GeometryId> geom_ids =
-      inspector.GetGeometryIds(all_ids, Role::kProximity);
+  const std::vector<GeometryId> geom_ids =
+      inspector.GetAllGeometryIds(Role::kProximity);
   ConvexSets sets(geom_ids.size());
 
   IrisConvexSetMaker maker(query_object, reference_frame);
@@ -487,8 +486,8 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
   IrisConvexSetMaker maker(query_object, inspector.world_frame_id());
   std::unordered_map<GeometryId, copyable_unique_ptr<ConvexSet>> sets{};
   std::unordered_map<GeometryId, const multibody::Frame<double>*> frames{};
-  const std::unordered_set<GeometryId> geom_ids = inspector.GetGeometryIds(
-      GeometrySet(inspector.GetAllGeometryIds()), Role::kProximity);
+  const std::vector<GeometryId> geom_ids =
+      inspector.GetAllGeometryIds(Role::kProximity);
   copyable_unique_ptr<ConvexSet> temp_set;
   for (GeometryId geom_id : geom_ids) {
     // Make all sets in the local geometry frame.

--- a/geometry/scene_graph_inspector.cc
+++ b/geometry/scene_graph_inspector.cc
@@ -42,14 +42,15 @@ int SceneGraphInspector<T>::num_geometries() const {
 }
 
 template <typename T>
-std::vector<GeometryId> SceneGraphInspector<T>::GetAllGeometryIds() const {
+std::vector<GeometryId> SceneGraphInspector<T>::GetAllGeometryIds(
+    std::optional<Role> role) const {
   DRAKE_DEMAND(state_ != nullptr);
-  return state_->GetAllGeometryIds();
+  return state_->GetAllGeometryIds(role);
 }
 
 template <typename T>
 std::unordered_set<GeometryId> SceneGraphInspector<T>::GetGeometryIds(
-    const GeometrySet& geometry_set, const std::optional<Role>& role) const {
+    const GeometrySet& geometry_set, std::optional<Role> role) const {
   DRAKE_DEMAND(state_ != nullptr);
   return state_->GetGeometryIds(geometry_set, role);
 }

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -106,8 +106,10 @@ class SceneGraphInspector {
   int num_geometries() const;
 
   /** Returns the set of all ids for registered geometries. The order is
-   guaranteed to be stable and consistent.  */
-  std::vector<GeometryId> GetAllGeometryIds() const;
+   guaranteed to be stable and consistent.
+   @param role  The requested role; if omitted, all geometries are returned.  */
+  std::vector<GeometryId> GetAllGeometryIds(
+      std::optional<Role> role = std::nullopt) const;
 
   /** Returns the geometry ids that are *implied* by the given GeometrySet and
    `role`. Remember that a GeometrySet can reference a FrameId in place of the
@@ -123,10 +125,13 @@ class SceneGraphInspector {
    @param geometry_set    The encoding of the set of geometries.
    @param role            The requested role; if omitted, all geometries
                           registered to the frame are returned.
-   @returns The requested unique geometry ids.  */
+   @returns The requested unique geometry ids.
+
+   @warning For C++ users: this returns an _unordered_ set, which means
+   iteration order will be non-deterministic.  */
   std::unordered_set<GeometryId> GetGeometryIds(
       const GeometrySet& geometry_set,
-      const std::optional<Role>& role = std::nullopt) const;
+      std::optional<Role> role = std::nullopt) const;
 
   /** Reports the _total_ number of geometries in the scene graph with the
    indicated role.  */

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -1219,6 +1219,8 @@ TEST_F(GeometryStateTest, GetAllGeometryIds) {
   const GeometryId local_anchored_id = geometry_state_.RegisterAnchoredGeometry(
       test_source, make_unique<GeometryInstance>(
                        RigidTransformd(), make_unique<Sphere>(1), "anchored"));
+  geometry_state_.AssignRole(test_source, local_anchored_id,
+                             ProximityProperties{});
   SetUpSingleSourceTree();
 
   vector<GeometryId> expected_ids(geometries_);
@@ -1226,8 +1228,16 @@ TEST_F(GeometryStateTest, GetAllGeometryIds) {
   expected_ids.push_back(anchored_geometry_);
   std::sort(expected_ids.begin(), expected_ids.end());
 
-  const vector<GeometryId> all_ids = geometry_state_.GetAllGeometryIds();
+  const vector<GeometryId> all_ids =
+      geometry_state_.GetAllGeometryIds(/* role = */ std::nullopt);
   EXPECT_EQ(all_ids, expected_ids);
+
+  expected_ids.clear();
+  expected_ids.push_back(local_anchored_id);
+
+  const vector<GeometryId> proximity_ids =
+      geometry_state_.GetAllGeometryIds(Role::kProximity);
+  EXPECT_EQ(proximity_ids, expected_ids);
 }
 
 // Confirms that a GeometrySet can be converted into a set of geometry ids.


### PR DESCRIPTION
Use this in IRIS so obstacles are created in a deterministic order.  Looping over an `unordered_set` is bad juju.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20834)
<!-- Reviewable:end -->
