### PR TITLE
[doc] Fix Doxygen file-overview syntax typo

### DIFF
--- a/bindings/pydrake/geometry/geometry_py.h
+++ b/bindings/pydrake/geometry/geometry_py.h
@@ -1,9 +1,10 @@
 #pragma once
 
-/** @file This files declares the functions which bind various portions of the
- geometry namespace. These functions form a complete partition of all geometry
- bindings. The implementation of these methods are parceled out into
- various .cc files as indicated in each function's documentation. */
+/** @file
+ This files declares the functions which bind various portions of the geometry
+ namespace. These functions form a complete partition of all geometry
+ bindings. The implementation of these methods are parceled out into various .cc
+ files as indicated in each function's documentation. */
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 

--- a/common/autodiff.h
+++ b/common/autodiff.h
@@ -1,7 +1,8 @@
 #pragma once
-/// @file This header provides a single inclusion point for autodiff-related
-/// header files in the `drake/common` directory. Users should include this
-/// file. Including other individual headers such as `drake/common/autodiffxd.h`
+/// @file
+/// This header provides a single inclusion point for autodiff-related header
+/// files in the `drake/common` directory. Users should include this file.
+/// Including other individual headers such as `drake/common/autodiffxd.h`
 /// will generate a compile-time warning.
 
 // In each header included below, it asserts that this macro

--- a/common/overloaded.h
+++ b/common/overloaded.h
@@ -1,6 +1,7 @@
 #pragma once
 
-/** @file The "overloaded" variant-visit pattern.
+/** @file
+The "overloaded" variant-visit pattern.
 
 The C++ std::visit (typeswitch dispatch) is very useful for std::variant but
 doesn't support it natively.  There is a commonly used two-line boilerplate

--- a/examples/acrobot/acrobot_lcm.h
+++ b/examples/acrobot/acrobot_lcm.h
@@ -1,8 +1,8 @@
 #pragma once
 
-/// @file This file contains classes dealing with sending/receiving
-/// LCM messages related to acrobot. The classes in this file are based on
-/// iiwa_lcm.h
+/// @file
+/// This file contains classes dealing with sending/receiving LCM messages
+/// related to acrobot. The classes in this file are based on iiwa_lcm.h
 
 #include <memory>
 

--- a/examples/allegro_hand/allegro_lcm.h
+++ b/examples/allegro_hand/allegro_lcm.h
@@ -1,7 +1,8 @@
 #pragma once
 
-/// @file This file contains classes dealing with sending/receiving
-/// LCM messages related to the allegro hand.
+/// @file
+/// This file contains classes dealing with sending/receiving LCM messages
+/// related to the allegro hand.
 
 #include <memory>
 #include <utility>

--- a/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
+++ b/examples/planar_gripper/gripper_brick_planning_constraint_helper.h
@@ -3,8 +3,9 @@
 #include "drake/examples/planar_gripper/gripper_brick.h"
 #include "drake/solvers/mathematical_program.h"
 
-/// @file This file contains the utility function to add constraint in
-/// gripper/brick motion planning.
+/// @file
+/// This file contains the utility function to add constraint in gripper/brick
+/// motion planning.
 
 namespace drake {
 namespace examples {

--- a/geometry/proximity/detect_zero_simplex.h
+++ b/geometry/proximity/detect_zero_simplex.h
@@ -1,14 +1,14 @@
 #pragma once
 
-/* @file Detects if a tetrahedral mesh evaluates to zero signed-distance
- anywhere in its interior. A hydroelastic pressure field built
- on a mesh with this defect will have zero pressure in its interior.
- Because signed distance is defined at vertices and interpolated everywhere
- else, detection focuses on positive dimensional simplices (tetrahedra,
- triangles, edges).  A simplex is problematic, if all of its vertices lie on
- the boundary, and if the simplex intersects the mesh's interior.
- For example, a mesh with only a single tetrahedron is problematic since all its
- vertices lie on the mesh's boundary.
+/* @file
+ Detects if a tetrahedral mesh evaluates to zero signed-distance anywhere in its
+ interior. A hydroelastic pressure field built on a mesh with this defect will
+ have zero pressure in its interior.  Because signed distance is defined at
+ vertices and interpolated everywhere else, detection focuses on positive
+ dimensional simplices (tetrahedra, triangles, edges).  A simplex is
+ problematic, if all of its vertices lie on the boundary, and if the simplex
+ intersects the mesh's interior.  For example, a mesh with only a single
+ tetrahedron is problematic since all its vertices lie on the mesh's boundary.
 
  A tetrahedral mesh may have other problems. For example, a tetrahedron with
  all vertices at the same distance from the boundary. A hydroelastic pressure

--- a/geometry/proximity/distance_to_shape_callback.h
+++ b/geometry/proximity/distance_to_shape_callback.h
@@ -14,8 +14,9 @@
 #include "drake/geometry/query_results/signed_distance_pair.h"
 #include "drake/math/rigid_transform.h"
 
-/** @file Provides the structures and logic to support signed distance queries
- between shapes.  */
+/** @file
+ Provides the structures and logic to support signed distance queries between
+ shapes.  */
 
 namespace drake {
 namespace geometry {

--- a/geometry/proximity/distance_to_shape_touching.h
+++ b/geometry/proximity/distance_to_shape_touching.h
@@ -10,9 +10,10 @@
 #include "drake/common/eigen_types.h"
 #include "drake/math/rigid_transform.h"
 
-/* @file Support distance queries between shapes when they barely touch (have
- zero signed distance) by providing a reasonable distance gradient in fcl
- fallback CalcDistanceFallback() in distance_to_shape_callback.cc.
+/* @file
+ Support distance queries between shapes when they barely touch (have zero
+ signed distance) by providing a reasonable distance gradient in fcl fallback
+ CalcDistanceFallback() in distance_to_shape_callback.cc.
  */
 
 namespace drake {

--- a/geometry/proximity/test/characterization_utilities.h
+++ b/geometry/proximity/test/characterization_utilities.h
@@ -1,6 +1,7 @@
 #pragma once
 
-/* @file A collection of utilities to facilitate proximity query testing. The
+/* @file
+ A collection of utilities to facilitate proximity query testing. The
  functionality specifically targets proximity queries that are signed distance
  (or equivalent to signed distance). It allows for compact representation of
  test scenarios with outcome expectations and provides the common code to

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.h
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.h
@@ -1,7 +1,8 @@
 #pragma once
 
-/// @file This file contains classes dealing with sending/receiving
-/// LCM messages related to the Schunk WSG gripper.
+/// @file
+/// This file contains classes dealing with sending/receiving LCM messages
+/// related to the Schunk WSG gripper.
 
 #include <memory>
 #include <vector>

--- a/manipulation/util/robot_plan_utils.h
+++ b/manipulation/util/robot_plan_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
-/// @file Functions to help with the creation of lcmt_robot_plan messages.
+/// @file
+/// Functions to help with the creation of lcmt_robot_plan messages.
 
 #include <string>
 #include <vector>

--- a/solvers/rotation_constraint.h
+++ b/solvers/rotation_constraint.h
@@ -9,7 +9,8 @@
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/mathematical_program.h"
 
-/// @file Functions for reasoning about 3D rotations in a @MathematicalProgram.
+/// @file
+/// Functions for reasoning about 3D rotations in a @MathematicalProgram.
 ///
 /// There are a number of choices for representing 3D rotations in a
 /// mathematical program -- many of these choices involve using more than

--- a/systems/sensors/image_writer.h
+++ b/systems/sensors/image_writer.h
@@ -1,6 +1,7 @@
 #pragma once
 
-/** @file Provides utilities for writing images to disk.
+/** @file
+ Provides utilities for writing images to disk.
 
  This file provides two sets of utilities: stand alone methods that can be
  invoked in any context and a System that can be connected into a diagram to


### PR DESCRIPTION
A common mistake is to say `@file` followed by a topic sentence, but this is wrong. The text after `@file` is filename. We always need a line break before starting the topic sentence.

https://www.doxygen.nl/manual/commands.html#cmdfile

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20836)
<!-- Reviewable:end -->
