### PR TITLE
Add flake8 configuration file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+application_import_names = drake, pydrake
+import-order-style = edited


### PR DESCRIPTION
Add a configuration file for flake8. Right now it only affects flake8-include-order; specifically, use the `edited` style rather than the default `cryptography` style, and recognize `[py]drake` as local imports.

This should result in flake8-include-order giving useful gripes without complaining about things we don't want to change, at least for the most part.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20838)
<!-- Reviewable:end -->
