### PR TITLE
[solvers] Adjust ClarabelSolver default tolerances

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -503,13 +503,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "iris_test",
-    args = select({
-        "@platforms//os:osx": [
-            # TODO(#20799) This test sometimes panics when run with OpenBLAS.
-            "--gtest_filter=-SceneGraphTester.MultipleBoxes",
-        ],
-        "//conditions:default": [],
-    }),
     deps = [
         ":iris",
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
When the program contains both PSD and Exponential cones, we must loosen the default tolerance to reduce the possibility of crashing the entire process.

This is not guaranteed to avoid the crashes, but in practice it seems to make it a lot less likely.

Relates to https://github.com/RobotLocomotion/drake/issues/20799 and https://github.com/oxfordcontrol/Clarabel.rs/issues/66.

---

```
bazel test //solvers:clarabel_solver_test \
  --nocache_test_results \
  --test_output=streamed \
  --test_arg=--spdlog_level=debug \
  --test_arg=--gtest_filter=TestExponentialConeProgram.MinimalEllipsoidConveringPoints
...
[----------] 1 test from TestExponentialConeProgram
[ RUN      ] TestExponentialConeProgram.MinimalEllipsoidConveringPoints
[2024-01-30 14:56:54.591] [console] [debug] ClarabelSolver is using loosened default tolerances due to the presence of SDP and Exponential Cone Constraints. This is done to prevent numerical issues from potentially crashing your program due to https://github.com/oxfordcontrol/Clarabel.rs/issues/66. If you need to solve your program to high precision, consider manually setting SolverOptions for 'tol_gap_abs', 'tol_gap_rel', and 'tol_feas'. Values set in SolverOptions take prececence over the defaults
[       OK ] TestExponentialConeProgram.MinimalEllipsoidConveringPoints (1 ms)
[----------] 1 test from TestExponentialConeProgram (1 ms total)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20844)
<!-- Reviewable:end -->
