### PR TITLE
Normalize constraints in HPolyhedron::MaximumVolumeInscribedEllipsoid

### DIFF
--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -425,6 +425,26 @@ GTEST_TEST(HPolyhedronTest, InscribedEllipsoidTest) {
   const VectorXd polytope_halfspace_residue =
       b - A * E2.center() - ((A * C).rowwise().lpNorm<2>());
   EXPECT_NEAR(polytope_halfspace_residue.minCoeff(), 0, kTol);
+
+  // Check numerical stability for poorly-formed A and b matrices
+  MatrixXd A2(24, 12);
+  VectorXd b2(24);
+  // clang-format off
+  A2 << MatrixXd::Identity(12, 12),
+        -MatrixXd::Identity(12, 12);
+  b2 << VectorXd::Ones(12),
+        VectorXd::Zero(12);
+  // clang-format on
+  for (int i = 0; i < A2.rows(); ++i) {
+    double scaling_factor = std::pow(10, i - 12);
+    A2.row(i) *= scaling_factor;
+    b2(i) *= scaling_factor;
+  }
+  HPolyhedron H4(A2, b2);
+
+  // Check that we can compute the maximum volume inscribed ellipsoid of the
+  // HPolyhedron defined by the ill-formed matrix.
+  EXPECT_NO_THROW(unused(H4.MaximumVolumeInscribedEllipsoid()));
 }
 
 GTEST_TEST(HPolyhedronTest, ChebyshevCenter) {


### PR DESCRIPTION
This is occasionally necessary to prevent certain numerical issues, such as those described in #20839. An example of an HPolyhedron that experiences these numerical issues is available [here](https://gist.github.com/cohnt/56e887560451751d88149b1ff42981d4).

Runtime should be insignificant relative to solving the SDP, so it's probably easiest just to do it in every instance. An alternative is only calling this version if the first solve fails.

+@AlexandreAmice for feature review

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20849)
<!-- Reviewable:end -->
