### PR TITLE
[tools] Change how wheel builds opt-out of LCM java

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -355,13 +355,22 @@ install(
 
 install(
     name = "install",
-    install_tests = [":test/drake-lcm-spy_install_test.py"],
+    install_tests = select({
+        "@lcm//:lcm_install_java_is_off": [],
+        "//conditions:default": [
+            ":test/drake-lcm-spy_install_test.py",
+        ],
+    }),
     targets = [
         ":_generated_lcmtypes_drake_py",
-        ":drake-lcm-spy",
-        ":drake-lcm-spy-launcher",
-        ":lcmtypes_drake_java",
-    ],
+    ] + select({
+        "@lcm//:lcm_install_java_is_off": [],
+        "//conditions:default": [
+            ":drake-lcm-spy",
+            ":drake-lcm-spy-launcher",
+            ":lcmtypes_drake_java",
+        ],
+    }),
     rename = {
         "share/java/liblcmtypes_drake_java.jar": "lcmtypes_drake.jar",
         "bin/drake-lcm-spy-launcher.sh": "drake-lcm-spy",

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -18,6 +18,7 @@ build --repository_cache=/var/cache/bazel/repository_cache
 build --repo_env=DRAKE_OS=manylinux
 build --repo_env=SNOPT_PATH=git
 build --config=packaging
+build --define=LCM_INSTALL_JAVA=OFF
 # Our wheel Eigen is new enough to undo the Focal-specific removal of Clarabel.
 build --define=NO_CLARABEL=OFF
 EOF

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -81,6 +81,7 @@ build --repository_cache=$HOME/.cache/drake-wheel-build/bazel/repository_cache
 build --repo_env=DRAKE_OS=macos_wheel
 build --repo_env=SNOPT_PATH=git
 build --config=packaging
+build --define=LCM_INSTALL_JAVA=OFF
 # See tools/wheel/wheel_builder/macos.py for more on this env variable.
 build --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
 EOF

--- a/tools/workspace/com_jidesoft_jide_oss/repository.bzl
+++ b/tools/workspace/com_jidesoft_jide_oss/repository.bzl
@@ -9,7 +9,7 @@ def com_jidesoft_jide_oss_repository(
     drake_java_import(
         name = name,
         licenses = ["restricted"],  # GPL-2.0 WITH Classpath-exception-2.0
-        local_os_targets = ["ubuntu"],
+        local_os_targets = ["linux"],
         local_jar = "/usr/share/java/jide-oss.jar",
         maven_jar = "com/jidesoft/jide-oss/2.9.7/jide-oss-2.9.7.jar",  # noqa
         maven_jar_sha256 = "a2edc2749cf482f6b2b1331f35f0383a1a11c19b1cf6d9a8cf7c69ce4cc8e04b",  # noqa

--- a/tools/workspace/commons_io/repository.bzl
+++ b/tools/workspace/commons_io/repository.bzl
@@ -9,7 +9,7 @@ def commons_io_repository(
     drake_java_import(
         name = name,
         licenses = ["notice"],  # Apache-2.0
-        local_os_targets = ["ubuntu"],
+        local_os_targets = ["linux"],
         local_jar = "/usr/share/java/commons-io.jar",
         maven_jar = "commons-io/commons-io/1.3.1/commons-io-1.3.1.jar",  # noqa
         maven_jar_sha256 = "3307319ddc221f1b23e8a1445aef10d2d2308e0ec46977b3f17cbb15c0ef335b",  # noqa

--- a/tools/workspace/java.bzl
+++ b/tools/workspace/java.bzl
@@ -1,20 +1,19 @@
 load("//tools/skylark:pathutils.bzl", "basename")
-load("//tools/workspace:os.bzl", "determine_os")
 load(
     "@bazel_tools//tools/build_defs/repo:java.bzl",
     "java_import_external",
 )
 
 def _impl(repo_ctx):
-    os_result = determine_os(repo_ctx)
-    if os_result.error != None:
-        fail(os_result.error)
+    os_name = repo_ctx.os.name
+    if os_name == "mac os x":
+        os_name = "osx"
 
     # Create the /jar/BUILD.bazel file.
     build_content = """\
 package(default_visibility = ["//visibility:public"])
 """
-    if os_result.target in repo_ctx.attr.local_os_targets:
+    if os_name in repo_ctx.attr.local_os_targets:
         is_local = True
         filename = basename(repo_ctx.attr.local_jar)
         repo_ctx.symlink(
@@ -75,8 +74,9 @@ def drake_java_import(
         mirrors):
     """A repository rule to bring in a Java dependency, either from the host's
     OS distribution, or else Maven. The list of local_os_targets indicates
-    which distributions provide this jar; for those, the local_jar is the full
-    path to the jar. Otherwise, the maven_jar will be used.
+    which OSs provide this jar; for those, the local_jar is the full path to
+    the jar. Otherwise, the maven_jar will be used. The recognized values for
+    OSs in the list of targets are either "linux" or "osx".
     """
     java_import_external(
         name = "_maven_{}".format(name),

--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -19,6 +19,14 @@ licenses([
 
 package(default_visibility = ["//visibility:public"])
 
+# Provide an opt-out that avoids installing Java LCM libraries (e.g., we don't
+# need Java when we're building a Python wheel). The java targets will still be
+# defined, they just won't be part of //:install.
+config_setting(
+    name = "lcm_install_java_is_off",
+    values = {"define": "LCM_INSTALL_JAVA=OFF"},
+)
+
 config_setting(
     name = "linux",
     values = {"cpu": "k8"},
@@ -310,15 +318,19 @@ install(
     ],
     targets = [
         ":lcm-gen",
-        ":lcm-java",
         ":lcm-logger",
         ":lcm-logplayer",
-        ":lcm-logplayer-gui",
-        ":lcm-logplayer-gui-launcher",
-        ":lcm-spy",
-        ":lcm-spy-launcher",
         ":libdrake_lcm.so",
-    ],
+    ] + select({
+        ":lcm_install_java_is_off": [],
+        "//conditions:default": [
+            ":lcm-java",
+            ":lcm-logplayer-gui",
+            ":lcm-logplayer-gui-launcher",
+            ":lcm-spy",
+            ":lcm-spy-launcher",
+        ],
+    }),
     py_strip_prefix = ["lcm-python"],
     hdrs = LCM_PUBLIC_HEADERS,
     hdr_dest = "include/" + CMAKE_PACKAGE,

--- a/tools/workspace/net_sf_jchart2d/repository.bzl
+++ b/tools/workspace/net_sf_jchart2d/repository.bzl
@@ -9,7 +9,7 @@ def net_sf_jchart2d_repository(
     drake_java_import(
         name = name,
         licenses = ["restricted"],  # LGPL-3.0+
-        local_os_targets = ["ubuntu"],
+        local_os_targets = ["linux"],
         local_jar = "/usr/share/java/jchart2d.jar",
         maven_jar = "net/sf/jchart2d/jchart2d/3.3.2/jchart2d-3.3.2.jar",  # noqa
         maven_jar_sha256 = "41af674b1bb00d8b89a0649ddaa569df5750911b4e33f89b211ae82e411d16cc",  # noqa

--- a/tools/workspace/org_apache_xmlgraphics_commons/repository.bzl
+++ b/tools/workspace/org_apache_xmlgraphics_commons/repository.bzl
@@ -6,7 +6,7 @@ def org_apache_xmlgraphics_commons_repository(
     drake_java_import(
         name = name,
         licenses = ["notice"],  # Apache-2.0
-        local_os_targets = ["ubuntu"],
+        local_os_targets = ["linux"],
         local_jar = "/usr/share/java/xmlgraphics-commons.jar",
         maven_jar = "org/apache/xmlgraphics/xmlgraphics-commons/1.3.1/xmlgraphics-commons-1.3.1.jar",  # noqa
         maven_jar_sha256 = "7ce0c924c84e2710c162ae1c98f5047d64f528268792aba642d4bae5e1de7181",  # noqa


### PR DESCRIPTION
Instead of using the "detected OS" ("manylinux" or "macos_wheel") to implicitly opt-out (by virtue of it not being "ubuntu"), we now have an (internal use only) opt-out flag that wheel builds toggle acutuely.

This still isn't terribly elegant, but it's at least slightly more readable and documented. The important upside is removing another use of the `determine_os()` function, which is scheduled for removal.

Towards #14967.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20850)
<!-- Reviewable:end -->
