### PR TITLE
[sensors] Deprecate Color, ColorI, ColorD, ColorPalette

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -210,7 +210,8 @@ void DoScalarIndependentDefinitions(py::module m) {
   {
     using Class = RenderEngine;
     const auto& cls_doc = doc.RenderEngine;
-    py::class_<Class, PyRenderEngine>(m, "RenderEngine")
+    py::class_<Class, PyRenderEngine> cls(m, "RenderEngine");
+    cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def("Clone",
             static_cast<::std::unique_ptr<Class> (Class::*)() const>(
@@ -261,18 +262,6 @@ void DoScalarIndependentDefinitions(py::module m) {
             static_cast<RenderLabel (Class::*)(PerceptionProperties const&)
                     const>(&PyRenderEngine::GetRenderLabelOrThrow),
             py::arg("properties"), cls_doc.GetRenderLabelOrThrow.doc)
-        .def_static("LabelFromColor",
-            static_cast<RenderLabel (*)(ColorI const&)>(
-                &PyRenderEngine::LabelFromColor),
-            py::arg("color"), cls_doc.LabelFromColor.doc)
-        .def_static("GetColorIFromLabel",
-            static_cast<ColorI (*)(RenderLabel const&)>(
-                &PyRenderEngine::GetColorIFromLabel),
-            py::arg("label"), cls_doc.GetColorIFromLabel.doc)
-        .def_static("GetColorDFromLabel",
-            static_cast<ColorD (*)(RenderLabel const&)>(
-                &PyRenderEngine::GetColorDFromLabel),
-            py::arg("label"), cls_doc.GetColorDFromLabel.doc)
         .def("SetDefaultLightPosition",
             static_cast<void (Class::*)(Vector3d const&)>(
                 &PyRenderEngine::SetDefaultLightPosition),
@@ -295,6 +284,27 @@ void DoScalarIndependentDefinitions(py::module m) {
                 &PyRenderEngine::ThrowIfInvalid<Image<PixelType::kLabel16I>>),
             py::arg("intrinsics"), py::arg("image"), py::arg("image_type"),
             cls_doc.ThrowIfInvalid.doc);
+    // Note that we do not bind MakeRgbFromLabel nor MakeLabelFromRgb, because
+    // crossing the C++ <=> Python boundary one pixel at a time would be
+    // extraordinarily inefficient.
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // To be removed on 2024-05-01.
+    cls  // BR
+        .def_static("LabelFromColor",
+            static_cast<RenderLabel (*)(ColorI const&)>(
+                &PyRenderEngine::LabelFromColor),
+            py::arg("color"))
+        .def_static("GetColorIFromLabel",
+            static_cast<ColorI (*)(RenderLabel const&)>(
+                &PyRenderEngine::GetColorIFromLabel),
+            py::arg("label"))
+        .def_static("GetColorDFromLabel",
+            static_cast<ColorD (*)(RenderLabel const&)>(
+                &PyRenderEngine::GetColorDFromLabel),
+            py::arg("label"));
+#pragma GCC diagnostic pop
   }
 
   {

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -13,12 +13,22 @@ drake_cc_package_library(
     name = "render",
     visibility = ["//visibility:public"],
     deps = [
+        ":color_deprecated",
         ":light_parameter",
         ":render_camera",
         ":render_engine",
         ":render_label",
         ":render_material",
         ":render_mesh",
+    ],
+)
+
+drake_cc_library(
+    name = "color_deprecated",
+    hdrs = ["color_deprecated.h"],
+    deps = [
+        "//common:essential",
+        "//common:hash",
     ],
 )
 

--- a/geometry/render/color_deprecated.h
+++ b/geometry/render/color_deprecated.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <ostream>
+
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt_ostream.h"
+#include "drake/common/hash.h"
+
+// N.B. The namespaces in this file are weird (to simplify deprecation).
+
+namespace drake {
+namespace deprecated {
+namespace internal {
+
+template <typename T>
+struct Color {
+  T r;
+  T g;
+  T b;
+
+  bool operator==(const Color<T>& other) const {
+    return this->r == other.r && this->g == other.g && this->b == other.b;
+  }
+
+  template <class HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher, const Color& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.r);
+    hash_append(hasher, item.g);
+    hash_append(hasher, item.b);
+  }
+};
+
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const Color<T>& color) {
+  out << "(" << color.r << ", " << color.g << ", " << color.b << ")";
+  return out;
+}
+
+}  // namespace internal
+}  // namespace deprecated
+}  // namespace drake
+
+namespace std {
+template <typename T>
+struct hash<drake::deprecated::internal::Color<T>> : public drake::DefaultHash {
+};
+}  // namespace std
+
+namespace fmt {
+template <typename T>
+struct formatter<drake::deprecated::internal::Color<T>>
+    : drake::ostream_formatter {};
+}  // namespace fmt
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+template <typename T>
+using Color DRAKE_DEPRECATED("2024-05-01", "This class is being removed") =
+    drake::deprecated::internal::Color<T>;
+
+using ColorI DRAKE_DEPRECATED("2024-05-01", "This class is being removed") =
+    drake::deprecated::internal::Color<int>;
+
+using ColorD DRAKE_DEPRECATED("2024-05-01", "This class is being removed") =
+    drake::deprecated::internal::Color<double>;
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -322,7 +322,7 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
   Rgba default_diffuse_{0.9, 0.45, 0.1, 1.0};
 
   // The color to clear the color buffer to.
-  systems::sensors::ColorD default_clear_color_;
+  Rgba default_clear_color_;
 
   // The collection of per-geometry actors -- one actor per pipeline (color,
   // depth, and label) -- keyed by the geometry's GeometryId.

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -12,7 +12,6 @@
 #include "drake/common/ssize.h"
 #include "drake/geometry/render/render_engine.h"
 #include "drake/math/rigid_transform.h"
-#include "drake/systems/sensors/color_palette.h"
 
 namespace drake {
 namespace geometry {
@@ -157,6 +156,8 @@ class DummyRenderEngine : public render::RenderEngine {
   using RenderEngine::GetColorDFromLabel;
   using RenderEngine::GetColorIFromLabel;
   using RenderEngine::LabelFromColor;
+  using RenderEngine::MakeLabelFromRgb;
+  using RenderEngine::MakeRgbFromLabel;
 
  protected:
   /* Dummy implementation that registers the given `shape` if the `properties`

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -271,7 +271,10 @@ drake_cc_binary(
 drake_cc_library(
     name = "color_palette",
     hdrs = ["color_palette.h"],
-    deps = ["//common"],
+    deps = [
+        "//common",
+        "//geometry/render:color_deprecated",
+    ],
 )
 
 drake_cc_library(

--- a/systems/sensors/color_palette.h
+++ b/systems/sensors/color_palette.h
@@ -1,71 +1,17 @@
 #pragma once
 
-#include <functional>
-#include <ostream>
 #include <unordered_map>
 #include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
-#include "drake/common/hash.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/geometry/render/color_deprecated.h"
 
 namespace drake {
 namespace systems {
 namespace sensors {
 
-/// Holds r, g, b values to represent a color pixel.
-///
-/// @tparam T A type for each color channel.
-template <typename T>
-struct Color {
-  T r;  /// Red.
-  T g;  /// Green.
-  T b;  /// Blue.
-
-  bool operator==(const Color<T>& other) const {
-    return this->r == other.r && this->g == other.g && this->b == other.b;
-  }
-
-  /// Implements the @ref hash_append concept.
-  template <class HashAlgorithm>
-  friend void hash_append(HashAlgorithm& hasher, const Color& item) noexcept {
-    using drake::hash_append;
-    hash_append(hasher, item.r);
-    hash_append(hasher, item.g);
-    hash_append(hasher, item.b);
-  }
-};
-
-template <typename T>
-std::ostream& operator<<(std::ostream& out, const Color<T>& color) {
-  out << "(" << color.r << ", " << color.g << ", " << color.b << ")";
-  return out;
-}
-
-}  // namespace sensors
-}  // namespace systems
-}  // namespace drake
-
-namespace std {
-template <typename T>
-struct hash<drake::systems::sensors::Color<T>> : public drake::DefaultHash {};
-}  // namespace std
-
-namespace drake {
-namespace systems {
-namespace sensors {
-
-/// Defines a color based on its three primary additive colors: red, green, and
-/// blue. Each of these primary additive colors are in the range of [0, 255].
-using ColorI = Color<int>;
-
-/// Defines a color based on its three primary additive colors: red, green, and
-/// blue. Each of these primary additive colors are in the range of [0, 1].
-using ColorD = Color<double>;
-
-// TODO(SeanCurtis-TRI): As indicated in #9628, provide unit tests for the
-// contents of this file.
 /// Creates and holds a palette of colors for visualizing different objects in a
 /// scene (the intent is for a different color to be applied to each identified
 /// object). The colors are chosen so as to be easily distinguishable. In other
@@ -76,9 +22,13 @@ using ColorD = Color<double>;
 ///
 /// @tparam IdType  The type of value used for label values.
 template <typename IdType>
-class ColorPalette {
+class DRAKE_DEPRECATED("2024-05-01",
+                       "This class is being removed") ColorPalette {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ColorPalette)
+
+  using ColorD = drake::deprecated::internal::Color<double>;
+  using ColorI = drake::deprecated::internal::Color<int>;
 
   /// A constructor for %ColorPalette.
   ///
@@ -191,10 +141,3 @@ class ColorPalette {
 }  // namespace sensors
 }  // namespace systems
 }  // namespace drake
-
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <typename T>
-struct formatter<drake::systems::sensors::Color<T>> : drake::ostream_formatter {
-};
-}  // namespace fmt


### PR DESCRIPTION
Closes #9628.

Rationale:
- `ColorPalette` is dead code with no tests.
- `Color<T>`  is not used generically, only as an implementation trick for `ColorI` and `ColorD`.
- `ColorI` is only used by dead code.
- `ColorD` was still lightly used, but is confusingly duplicative of `geometry::Rgba`, but with less sugar and fine-tuning.  Better to just use the canonical type everywhere.  The extra alpha-channel is no harm done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20860)
<!-- Reviewable:end -->
