### PR TITLE
[vtk] Denote vtkCylinderSource patch already upstreamed

### DIFF
--- a/tools/workspace/vtk_internal/patches/filters_sources_cylinder.patch
+++ b/tools/workspace/vtk_internal/patches/filters_sources_cylinder.patch
@@ -1,6 +1,9 @@
 [vtk] Add missing member field initialization
 
-This fix should be submitted upstream.
+This patch has been upstreamed and will no longer apply, it
+can be deleted the next time drake upgrades VTK.
+
+https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10860
 
 --- Filters/Sources/vtkCylinderSource.cxx
 +++ Filters/Sources/vtkCylinderSource.cxx


### PR DESCRIPTION
The patch can be dropped during the next VTK upgrade.

VTK MR: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10860

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20864)
<!-- Reviewable:end -->
