### PR TITLE
Fix "Teach new_release to use upgrade scripts" vs S3

### DIFF
--- a/tools/workspace/metadata.py
+++ b/tools/workspace/metadata.py
@@ -57,6 +57,7 @@ def read_repository_metadata(repositories=None):
     result["crate_universe"] = {
         "repository_rule_type": "scripted",
         "upgrade_script": "upgrade.sh",
+        "downloads": {},
     }
 
     return result


### PR DESCRIPTION
Affirm to the S3 mirroring script that `crate_universe` itself doesn't have any downloads to be archived.

Amends #20855.
https://drake-jenkins.csail.mit.edu/view/Production/job/linux-jammy-unprovisioned-gcc-bazel-continuous-mirror-to-s3/
+(priority: emergency)

+@mwoehlke-kitware for review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20869)
<!-- Reviewable:end -->
