### PR TITLE
[geometry] Add Shape::type_name, Shape::to_string, and fmt formatter

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -378,6 +378,8 @@ void DoScalarIndependentDefinitions(py::module m) {
   // shape_specification.h
   {
     py::class_<Shape> shape_cls(m, "Shape", doc.Shape.doc);
+    shape_cls  // BR
+        .def("__repr__", [](const Shape& self) { return self.to_string(); });
     DefClone(&shape_cls);
 
     py::class_<Box, Shape>(m, "Box", doc.Box.doc)

--- a/bindings/pydrake/geometry/test/common_test.py
+++ b/bindings/pydrake/geometry/test/common_test.py
@@ -391,9 +391,19 @@ class TestGeometryCore(unittest.TestCase):
         for shape in shapes:
             self.assertIsInstance(shape, mut.Shape)
             shape_cls = type(shape)
-            shape_copy = shape.Clone()
+            shape_cls_name = shape_cls.__name__
+
+            shape_clone = shape.Clone()
+            self.assertIsInstance(shape_clone, shape_cls)
+            self.assertIsNot(shape_clone, shape)
+
+            shape_copy = copy.deepcopy(shape)
             self.assertIsInstance(shape_copy, shape_cls)
-            self.assertIsNot(shape, shape_copy)
+            self.assertIsNot(shape_copy, shape)
+
+            new_shape = eval(repr(shape), dict([(shape_cls_name, shape_cls)]))
+            self.assertIsInstance(new_shape, shape_cls)
+            self.assertEqual(repr(new_shape), repr(shape))
 
     def test_shapes(self):
         # We'll test some invariants on all shapes as inherited from the Shape

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -935,6 +935,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "shape_to_string_test",
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":shape_to_string",
     ],

--- a/geometry/proximity/deformable_contact_geometries.h
+++ b/geometry/proximity/deformable_contact_geometries.h
@@ -120,7 +120,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
         "Rigid {} shapes are not currently supported for deformable "
         "contact; registration is allowed, but an error will be thrown "
         "during contact.",
-        ShapeName(shape));
+        shape.type_name());
     return {};
   }
   auto surface_mesh = std::make_unique<TriangleSurfaceMesh<double>>(

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -385,7 +385,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
       "Rigid {} shapes are not currently supported for hydroelastic "
       "contact; registration is allowed, but an error will be thrown "
       "during contact.",
-      ShapeName(shape));
+      shape.type_name());
   return {};
 }
 
@@ -437,7 +437,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(const Shape& shape,
   static const logging::Warn log_once(
       "Soft {} shapes are not currently supported for hydroelastic contact; "
       "registration is allowed, but an error will be thrown during contact.",
-      ShapeName(shape));
+      shape.type_name());
   return {};
 }
 

--- a/geometry/proximity/test/distance_to_point_characterize_test.cc
+++ b/geometry/proximity/test/distance_to_point_characterize_test.cc
@@ -72,7 +72,7 @@ class CharacterizePointDistanceResultTest : public CharacterizeResultTest<T> {
       const Shape& shape_A, const Shape& shape_B,
       const vector<double>& signed_distances) const override {
     // For this test, we require shape A to be a zero-radius sphere.
-    DRAKE_DEMAND(ShapeName(shape_A).name() == "Sphere");
+    DRAKE_DEMAND(shape_A.type_name() == "Sphere");
     vector<Configuration<T>> configs;
     // We'll create a tangent plane to the point with an arbitrary normal
     // direction.

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -796,7 +796,7 @@ void TestPropertyErrors(
     const char* property_name, const char* compliance,
     function<void(const ShapeType&, const ProximityProperties&)> maker,
     std::optional<ValueType> bad_value, const ProximityProperties& props) {
-  ShapeName shape_name(shape_spec);
+  const std::string_view shape_name = shape_spec.type_name();
 
   // Error case: missing property value.
   {
@@ -1232,9 +1232,8 @@ TYPED_TEST_SUITE_P(HydroelasticSoftGeometryErrorTests);
 TYPED_TEST_P(HydroelasticSoftGeometryErrorTests, BadResolutionHint) {
   using ShapeType = TypeParam;
   ShapeType shape_spec = make_default_shape<ShapeType>();
-  if (ShapeName(shape_spec).name() != "HalfSpace" &&
-      ShapeName(shape_spec).name() != "Box" &&
-      ShapeName(shape_spec).name() != "Convex") {
+  if (shape_spec.type_name() != "HalfSpace" &&
+      shape_spec.type_name() != "Box" && shape_spec.type_name() != "Convex") {
     TestPropertyErrors<ShapeType, double>(
         shape_spec, kHydroGroup, kRezHint, "soft",
         [](const ShapeType& s, const ProximityProperties& p) {
@@ -1265,7 +1264,7 @@ TYPED_TEST_P(HydroelasticSoftGeometryErrorTests, BadSlabThickness) {
   using ShapeType = TypeParam;
   ShapeType shape_spec = make_default_shape<ShapeType>();
   // Half space only!
-  if (ShapeName(shape_spec).name() == "HalfSpace") {
+  if (shape_spec.type_name() == "HalfSpace") {
     TestPropertyErrors<ShapeType, double>(
         shape_spec, kHydroGroup, kSlabThickness, "soft",
         [](const ShapeType& s, const ProximityProperties& p) {

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -6,6 +6,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/drake_throw.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/geometry/proximity/meshing_utilities.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
@@ -28,35 +29,21 @@ std::string GetExtensionLower(const std::string& filename) {
 
 using math::RigidTransform;
 
-Shape::~Shape() {}
+Shape::Shape() = default;
+
+Shape::~Shape() = default;
 
 void Shape::Reify(ShapeReifier* reifier, void* user_data) const {
-  reifier_(*this, reifier, user_data);
+  DRAKE_THROW_UNLESS(reifier != nullptr);
+  DoReify(reifier, user_data);
 }
 
 std::unique_ptr<Shape> Shape::Clone() const {
-  return cloner_(*this);
-}
-
-template <typename S>
-Shape::Shape(ShapeTag<S>) {
-  static_assert(std::is_base_of_v<Shape, S>,
-                "Concrete shapes *must* be derived from the Shape class");
-  cloner_ = [](const Shape& shape_arg) {
-    DRAKE_DEMAND(typeid(shape_arg) == typeid(S));
-    const S& derived_shape = static_cast<const S&>(shape_arg);
-    return std::unique_ptr<Shape>(new S(derived_shape));
-  };
-  reifier_ = [](const Shape& shape_arg, ShapeReifier* reifier,
-                void* user_data) {
-    DRAKE_DEMAND(typeid(shape_arg) == typeid(S));
-    const S& derived_shape = static_cast<const S&>(shape_arg);
-    reifier->ImplementGeometry(derived_shape, user_data);
-  };
+  return DoClone();
 }
 
 Box::Box(double width, double depth, double height)
-    : Shape(ShapeTag<Box>()), size_(width, depth, height) {
+    : size_(width, depth, height) {
   if (width <= 0 || depth <= 0 || height <= 0) {
     throw std::logic_error(
         fmt::format("Box width, depth, and height should all be > 0 (were {}, "
@@ -72,8 +59,13 @@ Box Box::MakeCube(double edge_size) {
   return Box(edge_size, edge_size, edge_size);
 }
 
+std::string Box::do_to_string() const {
+  return fmt::format("Box(width={}, depth={}, height={})", width(), depth(),
+                     height());
+}
+
 Capsule::Capsule(double radius, double length)
-    : Shape(ShapeTag<Capsule>()), radius_(radius), length_(length) {
+    : radius_(radius), length_(length) {
   if (radius <= 0 || length <= 0) {
     throw std::logic_error(
         fmt::format("Capsule radius and length should both be > 0 (were {} "
@@ -85,9 +77,12 @@ Capsule::Capsule(double radius, double length)
 Capsule::Capsule(const Vector2<double>& measures)
     : Capsule(measures(0), measures(1)) {}
 
+std::string Capsule::do_to_string() const {
+  return fmt::format("Capsule(radius={}, length={})", radius(), length());
+}
+
 Convex::Convex(const std::string& filename, double scale)
-    : Shape(ShapeTag<Convex>()),
-      filename_(std::filesystem::absolute(filename)),
+    : filename_(std::filesystem::absolute(filename)),
       extension_(GetExtensionLower(filename_)),
       scale_(scale) {
   if (std::abs(scale) < 1e-8) {
@@ -95,8 +90,12 @@ Convex::Convex(const std::string& filename, double scale)
   }
 }
 
+std::string Convex::do_to_string() const {
+  return fmt::format("Convex(filename='{}', scale={})", filename(), scale());
+}
+
 Cylinder::Cylinder(double radius, double length)
-    : Shape(ShapeTag<Cylinder>()), radius_(radius), length_(length) {
+    : radius_(radius), length_(length) {
   if (radius <= 0 || length <= 0) {
     throw std::logic_error(
         fmt::format("Cylinder radius and length should both be > 0 (were {} "
@@ -108,8 +107,11 @@ Cylinder::Cylinder(double radius, double length)
 Cylinder::Cylinder(const Vector2<double>& measures)
     : Cylinder(measures(0), measures(1)) {}
 
-Ellipsoid::Ellipsoid(double a, double b, double c)
-    : Shape(ShapeTag<Ellipsoid>()), radii_(a, b, c) {
+std::string Cylinder::do_to_string() const {
+  return fmt::format("Cylinder(radius={}, length={})", radius(), length());
+}
+
+Ellipsoid::Ellipsoid(double a, double b, double c) : radii_(a, b, c) {
   if (a <= 0 || b <= 0 || c <= 0) {
     throw std::logic_error(
         fmt::format("Ellipsoid lengths of principal semi-axes a, b, and c "
@@ -121,7 +123,11 @@ Ellipsoid::Ellipsoid(double a, double b, double c)
 Ellipsoid::Ellipsoid(const Vector3<double>& measures)
     : Ellipsoid(measures(0), measures(1), measures(2)) {}
 
-HalfSpace::HalfSpace() : Shape(ShapeTag<HalfSpace>()) {}
+std::string Ellipsoid::do_to_string() const {
+  return fmt::format("Ellipsoid(a={}, b={}, c={})", a(), b(), c());
+}
+
+HalfSpace::HalfSpace() = default;
 
 RigidTransform<double> HalfSpace::MakePose(const Vector3<double>& Hz_dir_F,
                                            const Vector3<double>& p_FB) {
@@ -154,9 +160,12 @@ RigidTransform<double> HalfSpace::MakePose(const Vector3<double>& Hz_dir_F,
   return RigidTransform<double>(R_FH, p_FH);
 }
 
+std::string HalfSpace::do_to_string() const {
+  return "HalfSpace()";
+}
+
 Mesh::Mesh(const std::string& filename, double scale)
-    : Shape(ShapeTag<Mesh>()),
-      filename_(std::filesystem::absolute(filename)),
+    : filename_(std::filesystem::absolute(filename)),
       extension_(GetExtensionLower(filename_)),
       scale_(scale) {
   if (std::abs(scale) < 1e-8) {
@@ -164,8 +173,12 @@ Mesh::Mesh(const std::string& filename, double scale)
   }
 }
 
+std::string Mesh::do_to_string() const {
+  return fmt::format("Mesh(filename='{}', scale={})", filename(), scale());
+}
+
 MeshcatCone::MeshcatCone(double height, double a, double b)
-    : Shape(ShapeTag<MeshcatCone>()), height_(height), a_(a), b_(b) {
+    : height_(height), a_(a), b_(b) {
   if (height <= 0 || a <= 0 || b <= 0) {
     throw std::logic_error(fmt::format(
         "MeshcatCone parameters height, a, and b should all be > 0 (they were "
@@ -177,11 +190,19 @@ MeshcatCone::MeshcatCone(double height, double a, double b)
 MeshcatCone::MeshcatCone(const Vector3<double>& measures)
     : MeshcatCone(measures(0), measures(1), measures(2)) {}
 
-Sphere::Sphere(double radius) : Shape(ShapeTag<Sphere>()), radius_(radius) {
+std::string MeshcatCone::do_to_string() const {
+  return fmt::format("MeshcatCone(height={}, a={}, b={})", height(), a(), b());
+}
+
+Sphere::Sphere(double radius) : radius_(radius) {
   if (radius < 0) {
     throw std::logic_error(
         fmt::format("Sphere radius should be >= 0 (was {}).", radius));
   }
+}
+
+std::string Sphere::do_to_string() const {
+  return fmt::format("Sphere(radius={})", radius());
 }
 
 ShapeReifier::~ShapeReifier() = default;
@@ -223,7 +244,7 @@ void ShapeReifier::ImplementGeometry(const Sphere& sphere, void*) {
 }
 
 void ShapeReifier::DefaultImplementGeometry(const Shape& shape) {
-  ThrowUnsupportedGeometry(ShapeName(shape).name());
+  ThrowUnsupportedGeometry(std::string{shape.type_name()});
 }
 
 void ShapeReifier::ThrowUnsupportedGeometry(const std::string& shape_name) {
@@ -237,46 +258,17 @@ ShapeName::ShapeName(const Shape& shape) {
 
 ShapeName::~ShapeName() = default;
 
-void ShapeName::ImplementGeometry(const Box&, void*) {
-  string_ = "Box";
+void ShapeName::DefaultImplementGeometry(const Shape& shape) {
+  string_ = shape.type_name();
 }
 
-void ShapeName::ImplementGeometry(const Capsule&, void*) {
-  string_ = "Capsule";
-}
-
-void ShapeName::ImplementGeometry(const Convex&, void*) {
-  string_ = "Convex";
-}
-
-void ShapeName::ImplementGeometry(const Cylinder&, void*) {
-  string_ = "Cylinder";
-}
-
-void ShapeName::ImplementGeometry(const Ellipsoid&, void*) {
-  string_ = "Ellipsoid";
-}
-
-void ShapeName::ImplementGeometry(const HalfSpace&, void*) {
-  string_ = "HalfSpace";
-}
-
-void ShapeName::ImplementGeometry(const Mesh&, void*) {
-  string_ = "Mesh";
-}
-
-void ShapeName::ImplementGeometry(const MeshcatCone&, void*) {
-  string_ = "MeshcatCone";
-}
-
-void ShapeName::ImplementGeometry(const Sphere&, void*) {
-  string_ = "Sphere";
-}
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 std::ostream& operator<<(std::ostream& out, const ShapeName& name) {
   out << name.name();
   return out;
 }
+#pragma GCC diagnostic pop
 
 namespace {
 
@@ -347,6 +339,32 @@ double CalcVolume(const Shape& shape) {
   shape.Reify(&reifier);
   return reifier.volume();
 }
+
+// The NVI function definitions are enough boilerplate to merit a macro to
+// implement them, and we might as well toss in the dtor for good measure.
+
+#define DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(ShapeType)              \
+  ShapeType::~ShapeType() = default;                                    \
+  void ShapeType::DoReify(ShapeReifier* shape_reifier, void* user_data) \
+      const {                                                           \
+    shape_reifier->ImplementGeometry(*this, user_data);                 \
+  }                                                                     \
+  std::unique_ptr<Shape> ShapeType::DoClone() const {                   \
+    return std::unique_ptr<ShapeType>(new ShapeType(*this));            \
+  }                                                                     \
+  std::string_view ShapeType::do_type_name() const { return #ShapeType; }
+
+DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(Box)
+DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(Capsule)
+DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(Convex)
+DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(Cylinder)
+DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(Ellipsoid)
+DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(HalfSpace)
+DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(Mesh)
+DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(MeshcatCone)
+DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE(Sphere)
+
+#undef DRAKE_DEFINE_SHAPE_SUBCLASS_BOILERPLATE
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <functional>
 #include <memory>
 #include <string>
 
-#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/math/rigid_transform.h"
@@ -19,39 +18,45 @@
 namespace drake {
 namespace geometry {
 
+#ifndef DRAKE_DOXYGEN_CXX
+class Box;
+class Capsule;
+class Convex;
+class Cylinder;
+class Ellipsoid;
+class HalfSpace;
+class Mesh;
+class MeshcatCone;
 class ShapeReifier;
+class Sphere;
+#endif
 
-/** Simple struct for instantiating the type-specific Shape functionality.
- A class derived from the Shape class will invoke the parent's constructor as
- Shape(ShapeTag<DerivedShape>()). */
-template <typename ShapeType>
-struct ShapeTag {};
+// Implementation note for Drake developers:
+//
+// When you add a new subclass of Shape to Drake, you must:
+//
+// 1. Add a virtual function ImplementGeometry() for the new shape in
+//    ShapeReifier that invokes the ThrowUnsupportedGeometry method, and add to
+//    the test for it in shape_specification_test.cc.
+//
+// 2. Implement ImplementGeometry in derived ShapeReifiers to continue support
+//    if desired, otherwise ensure unimplemented functions are not hidden in new
+//    derivations of ShapeReifier with `using`, for example, `using
+//    ShapeReifier::ImplementGeometry`. Existing subclasses should already have
+//    this. Otherwise, you might get a runtime error; we do not have an
+//    automatic way to enforce them at compile time.
 
-/** The base interface for all shape specifications. It has no public
-  constructor and cannot be instantiated directly. The Shape class has two
-  key properties:
+/** The abstract base class for all shape specifications. Concrete subclasses
+  exist for specific shapes (e.g., Box, Mesh, etc.).
+
+  The Shape class has two key properties:
 
    - it is cloneable, and
    - it can be "reified" (see ShapeReifier).
 
-  When you add a new subclass of Shape to Drake, you must:
-
-  1. add a virtual function ImplementGeometry() for the new shape in
-     ShapeReifier that invokes the ThrowUnsupportedGeometry method, and add to
-     the test for it in shape_specification_test.cc.
-  2. implement ImplementGeometry in derived ShapeReifiers to continue support
-     if desired, otherwise ensure unimplemented functions are not hidden in new
-     derivations of ShapeReifier with `using`, for example, `using
-     ShapeReifier::ImplementGeometry`. Existing subclasses should already have
-     this.
-
-  Otherwise, you might get a runtime error. We do not have an automatic way to
-  enforce them at compile time.
-
  Note that the Shape class hierarchy is closed to third-party extensions. All
  Shape classes must be defined within Drake directly (and in this h/cc file
- pair in particular).
- */
+ pair in particular). */
 class Shape {
  public:
   virtual ~Shape();
@@ -64,42 +69,38 @@ class Shape {
   /** Creates a unique copy of this shape. */
   std::unique_ptr<Shape> Clone() const;
 
+  /** Returns the (unqualified) type name of this Shape, e.g., "Box". */
+  std::string_view type_name() const { return do_type_name(); }
+
+  /** Returns a string representation of this shape. */
+  std::string to_string() const { return do_to_string(); }
+
  protected:
-  // This is *not* in the public section. However, this allows the children to
-  // also use this macro, but precludes the possibility of external users
-  // slicing Shapes.
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Shape)
+  /** (Internal use only) Constructor for use by derived classes.
+  All subclasses of Shape must be marked `final`. */
+  Shape();
 
-  /** Constructor available for derived class construction. A derived class
-   should invoke this in its initialization list, passing a ShapeTag
-   instantiated on its derived type, e.g.:
+  // This is DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN, marked "internal use only".
+  /** (Internal use only) For derived classes. */
+  Shape(const Shape&) = default;
+  /** (Internal use only) For derived classes. */
+  Shape& operator=(const Shape&) = default;
+  /** (Internal use only) For derived classes. */
+  Shape(Shape&&) = default;
+  /** (Internal use only) For derived classes. */
+  Shape& operator=(Shape&&) = default;
 
-   ```
-   class MyShape final : public Shape {
-    public:
-     MyShape() : Shape(ShapeTag<MyShape>()) {}
-     ...
-   };
-   ```
+  /** (Internal use only) NVI for Reify(). */
+  virtual void DoReify(ShapeReifier*, void*) const = 0;
 
-   The base class provides infrastructure for cloning and reification. To work
-   and to maintain sanity, we place the following requirements on derived
-   classes:
+  /** (Internal use only) NVI for Clone(). */
+  virtual std::unique_ptr<Shape> DoClone() const = 0;
 
-   1. they must have a public copy constructor,
-   2. they must be marked as final, and
-   3. their constructors must invoke the parent constructor with a ShapeTag
-      instance (as noted above), and
-   4. The ShapeReifier class must be extended to include an invocation of
-      ShapeReifier::ImplementGeometry() on the derived Shape class.
+  /** (Internal use only) NVI for type_name(). */
+  virtual std::string_view do_type_name() const = 0;
 
-   @tparam S    The derived shape class. It must derive from Shape. */
-  template <typename S>
-  explicit Shape(ShapeTag<S> tag);
-
- private:
-  std::function<std::unique_ptr<Shape>(const Shape&)> cloner_;
-  std::function<void(const Shape&, ShapeReifier*, void*)> reifier_;
+  /** (Internal use only) NVI for to_string(). */
+  virtual std::string do_to_string() const = 0;
 };
 
 /** Definition of a box. The box is centered on the origin of its canonical
@@ -121,6 +122,8 @@ class Box final : public Shape {
    @throws std::exception if the measures are not strictly positive. */
   explicit Box(const Vector3<double>& measures);
 
+  ~Box() final;
+
   /** Constructs a cube with the given `edge_size` for its width, depth, and
    height. */
   static Box MakeCube(double edge_size);
@@ -138,6 +141,11 @@ class Box final : public Shape {
   const Vector3<double>& size() const { return size_; }
 
  private:
+  void DoReify(ShapeReifier*, void*) const final;
+  std::unique_ptr<Shape> DoClone() const final;
+  std::string_view do_type_name() const final;
+  std::string do_to_string() const final;
+
   Vector3<double> size_;
 };
 
@@ -161,10 +169,17 @@ class Capsule final : public Shape {
    @throws std::exception if the measures are not strictly positive. */
   explicit Capsule(const Vector2<double>& measures);
 
+  ~Capsule() final;
+
   double radius() const { return radius_; }
   double length() const { return length_; }
 
  private:
+  void DoReify(ShapeReifier*, void*) const final;
+  std::unique_ptr<Shape> DoClone() const final;
+  std::string_view do_type_name() const final;
+  std::string do_to_string() const final;
+
   double radius_{};
   double length_{};
 };
@@ -201,6 +216,8 @@ class Convex final : public Shape {
                                 considering revisiting the model itself. */
   explicit Convex(const std::string& filename, double scale = 1.0);
 
+  ~Convex() final;
+
   const std::string& filename() const { return filename_; }
   /** Returns the extension of the mesh filename -- all lower case and including
    the dot. In other words /foo/bar/mesh.obj and /foo/bar/mesh.OBJ would both
@@ -210,6 +227,11 @@ class Convex final : public Shape {
   double scale() const { return scale_; }
 
  private:
+  void DoReify(ShapeReifier*, void*) const final;
+  std::unique_ptr<Shape> DoClone() const final;
+  std::string_view do_type_name() const final;
+  std::string do_to_string() const final;
+
   std::string filename_;
   std::string extension_;
   double scale_{};
@@ -230,10 +252,17 @@ class Cylinder final : public Shape {
    @throws std::exception if the measures are not strictly positive. */
   explicit Cylinder(const Vector2<double>& measures);
 
+  ~Cylinder() final;
+
   double radius() const { return radius_; }
   double length() const { return length_; }
 
  private:
+  void DoReify(ShapeReifier*, void*) const final;
+  std::unique_ptr<Shape> DoClone() const final;
+  std::string_view do_type_name() const final;
+  std::string do_to_string() const final;
+
   double radius_{};
   double length_{};
 };
@@ -264,11 +293,18 @@ class Ellipsoid final : public Shape {
    @throws std::exception if the measures are not strictly positive. */
   explicit Ellipsoid(const Vector3<double>& measures);
 
+  ~Ellipsoid() final;
+
   double a() const { return radii_(0); }
   double b() const { return radii_(1); }
   double c() const { return radii_(2); }
 
  private:
+  void DoReify(ShapeReifier*, void*) const final;
+  std::unique_ptr<Shape> DoClone() const final;
+  std::string_view do_type_name() const final;
+  std::string do_to_string() const final;
+
   Vector3<double> radii_;
 };
 
@@ -283,6 +319,8 @@ class HalfSpace final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HalfSpace)
 
   HalfSpace();
+
+  ~HalfSpace() final;
 
   /** Creates the pose of a canonical half space in frame F.
    The half space's normal is aligned to the positive z-axis of its canonical
@@ -300,6 +338,12 @@ class HalfSpace final : public Shape {
                           ‖normal_F‖₂ < ε). */
   static math::RigidTransform<double> MakePose(const Vector3<double>& Hz_dir_F,
                                                const Vector3<double>& p_FB);
+
+ private:
+  void DoReify(ShapeReifier*, void*) const final;
+  std::unique_ptr<Shape> DoClone() const final;
+  std::string_view do_type_name() const final;
+  std::string do_to_string() const final;
 };
 
 // TODO(DamrongGuoy): Update documentation when mesh is fully supported (i.e.,
@@ -326,6 +370,8 @@ class Mesh final : public Shape {
    should be plenty without considering revisiting the model itself. */
   explicit Mesh(const std::string& filename, double scale = 1.0);
 
+  ~Mesh() final;
+
   const std::string& filename() const { return filename_; }
   /** Returns the extension of the mesh filename -- all lower case and including
    the dot. In other words /foo/bar/mesh.obj and /foo/bar/mesh.OBJ would both
@@ -335,6 +381,11 @@ class Mesh final : public Shape {
   double scale() const { return scale_; }
 
  private:
+  void DoReify(ShapeReifier*, void*) const final;
+  std::unique_ptr<Shape> DoClone() const final;
+  std::string_view do_type_name() const final;
+  std::string do_to_string() const final;
+
   // NOTE: Cannot be const to support default copy/move semantics.
   std::string filename_;
   std::string extension_;
@@ -369,11 +420,18 @@ class MeshcatCone final : public Shape {
    @throws std::exception if the measures are not strictly positive. */
   explicit MeshcatCone(const Vector3<double>& measures);
 
+  ~MeshcatCone() final;
+
   double height() const { return height_; }
   double a() const { return a_; }
   double b() const { return b_; }
 
  private:
+  void DoReify(ShapeReifier*, void*) const final;
+  std::unique_ptr<Shape> DoClone() const final;
+  std::string_view do_type_name() const final;
+  std::string do_to_string() const final;
+
   double height_{};
   double a_{};
   double b_{};
@@ -390,9 +448,16 @@ class Sphere final : public Shape {
    considered valid. */
   explicit Sphere(double radius);
 
+  ~Sphere() final;
+
   double radius() const { return radius_; }
 
  private:
+  void DoReify(ShapeReifier*, void*) const final;
+  std::unique_ptr<Shape> DoClone() const final;
+  std::string_view do_type_name() const final;
+  std::string do_to_string() const final;
+
   double radius_{};
 };
 
@@ -475,11 +540,9 @@ class ShapeReifier {
   virtual void ThrowUnsupportedGeometry(const std::string& shape_name);
 };
 
-// TODO(SeanCurtis-TRI): Merge this into shape_to_string.h so that there's a
-//  single utility for getting a string from a shape.
-/** Class that reports the name of the type of shape being reified (e.g.,
- Sphere, Box, etc.)  */
-class ShapeName final : public ShapeReifier {
+class DRAKE_DEPRECATED("2024-06-01",
+                       "Use the Shape::type_name() member function instead")
+    ShapeName final : public ShapeReifier {
  public:
   ShapeName() = default;
 
@@ -489,33 +552,22 @@ class ShapeName final : public ShapeReifier {
 
   ~ShapeName() final;
 
-  /** @name  Implementation of ShapeReifier interface  */
-  //@{
-
-  using ShapeReifier::ImplementGeometry;
-
-  void ImplementGeometry(const Box&, void*) final;
-  void ImplementGeometry(const Capsule&, void*) final;
-  void ImplementGeometry(const Convex&, void*) final;
-  void ImplementGeometry(const Cylinder&, void*) final;
-  void ImplementGeometry(const Ellipsoid&, void*) final;
-  void ImplementGeometry(const HalfSpace&, void*) final;
-  void ImplementGeometry(const Mesh&, void*) final;
-  void ImplementGeometry(const MeshcatCone&, void*) final;
-  void ImplementGeometry(const Sphere&, void*) final;
-
-  //@}
-
   /** Returns the name of the last shape reified. Empty if no shape has been
    reified yet.  */
   std::string name() const { return string_; }
 
  private:
+  void DefaultImplementGeometry(const Shape& shape) final;
+
   std::string string_;
 };
 
-/** @relates ShapeName */
+#ifndef DRAKE_DOXYGEN_CXX
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 std::ostream& operator<<(std::ostream& out, const ShapeName& name);
+#pragma GCC diagnostic pop
+#endif
 
 /** Calculates the volume (in meters^3) for the Shape. For convex and mesh
  geometries, the algorithm only supports ".obj" files and only produces
@@ -530,8 +582,23 @@ double CalcVolume(const Shape& shape);
 }  // namespace geometry
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+#ifndef DRAKE_DOXYGEN_CXX
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 namespace fmt {
 template <>
 struct formatter<drake::geometry::ShapeName> : drake::ostream_formatter {};
 }  // namespace fmt
+#pragma GCC diagnostic pop
+#endif
+
+DRAKE_FORMATTER_AS(, drake::geometry, Box, x, x.to_string())
+DRAKE_FORMATTER_AS(, drake::geometry, Capsule, x, x.to_string())
+DRAKE_FORMATTER_AS(, drake::geometry, Convex, x, x.to_string())
+DRAKE_FORMATTER_AS(, drake::geometry, Cylinder, x, x.to_string())
+DRAKE_FORMATTER_AS(, drake::geometry, Ellipsoid, x, x.to_string())
+DRAKE_FORMATTER_AS(, drake::geometry, HalfSpace, x, x.to_string())
+DRAKE_FORMATTER_AS(, drake::geometry, Mesh, x, x.to_string())
+DRAKE_FORMATTER_AS(, drake::geometry, MeshcatCone, x, x.to_string())
+DRAKE_FORMATTER_AS(, drake::geometry, Shape, x, x.to_string())
+DRAKE_FORMATTER_AS(, drake::geometry, Sphere, x, x.to_string())

--- a/geometry/shape_to_string.cc
+++ b/geometry/shape_to_string.cc
@@ -1,50 +1,12 @@
 #include "drake/geometry/shape_to_string.h"
 
-#include <fmt/format.h>
-
 namespace drake {
 namespace geometry {
 
-void ShapeToString::ImplementGeometry(const Box& box, void*) {
-  string_ = fmt::format("Box(w: {}, d: {}, h: {})", box.width(), box.depth(),
-                        box.height());
-}
+ShapeToString::~ShapeToString() = default;
 
-void ShapeToString::ImplementGeometry(const Capsule& capsule, void*) {
-  string_ =
-      fmt::format("Capsule(r: {}, l: {})", capsule.radius(), capsule.length());
-}
-
-void ShapeToString::ImplementGeometry(const Convex& convex, void*) {
-  string_ =
-      fmt::format("Convex(s: {}, path: {})", convex.scale(), convex.filename());
-}
-
-void ShapeToString::ImplementGeometry(const Cylinder& cylinder, void*) {
-  string_ = fmt::format("Cylinder(r: {}, l: {})", cylinder.radius(),
-                        cylinder.length());
-}
-
-void ShapeToString::ImplementGeometry(const Ellipsoid& ellipsoid, void*) {
-  string_ = fmt::format("Ellipsoid(a: {}, b: {}, c: {})", ellipsoid.a(),
-                        ellipsoid.b(), ellipsoid.c());
-}
-
-void ShapeToString::ImplementGeometry(const HalfSpace&, void*) {
-  string_ = "Halfspace";
-}
-
-void ShapeToString::ImplementGeometry(const Mesh& mesh, void*) {
-  string_ = fmt::format("Mesh(s: {}, path: {})", mesh.scale(), mesh.filename());
-}
-
-void ShapeToString::ImplementGeometry(const MeshcatCone& cone, void*) {
-  string_ = fmt::format("MeshcatCone(height: {}, a: {}, b: {})", cone.height(),
-                        cone.a(), cone.b());
-}
-
-void ShapeToString::ImplementGeometry(const Sphere& sphere, void*) {
-  string_ = fmt::format("Sphere(r: {})", sphere.radius());
+void ShapeToString::DefaultImplementGeometry(const Shape& shape) {
+  string_ = shape.to_string();
 }
 
 }  // namespace geometry

--- a/geometry/shape_to_string.h
+++ b/geometry/shape_to_string.h
@@ -2,45 +2,23 @@
 
 #include <string>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
 namespace geometry {
 
-/** Class that turns a Shape into a std::string representation. This reifier has
- a string() member that gets updated for each shape reified. The expected
- workflow would be:
-
- ```c++
- ShapeToString reifier;
- SceneGraphInspector inspector = ...;  // Get the inspector from somewhere.
- for (GeometryId id : inspector.GetAllGeometryIds()) {
-   inspector.Reify(id, reifier);
-   std::cout << reifier.string() << "\n";
- }
- ```
-
- This will write out a string representation of every geometry registered to
- SceneGraph.  */
-class ShapeToString final : public ShapeReifier {
+class DRAKE_DEPRECATED("2024-06-01",
+                       "Use the Shape::to_string() member function instead")
+    ShapeToString final : public ShapeReifier {
  public:
-  /** @name  Implementation of ShapeReifier interface  */
-  //@{
-  using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Box& box, void* user_data) final;
-  void ImplementGeometry(const Capsule& capsule, void* user_data) final;
-  void ImplementGeometry(const Convex& convex, void* user_data) final;
-  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
-  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) final;
-  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
-  void ImplementGeometry(const Mesh& mesh, void* user_data) final;
-  void ImplementGeometry(const MeshcatCone& cone, void* user_data) final;
-  void ImplementGeometry(const Sphere& sphere, void* user_data) final;
+  ~ShapeToString() final;
 
-  //@}
   const std::string& string() const { return string_; }
 
  private:
+  void DefaultImplementGeometry(const Shape& shape) final;
+
   std::string string_;
 };
 

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -1790,7 +1790,7 @@ TEST_F(GeometryStateTest, ChangeShapeInternals) {
   const RigidTransformd X_FG2 = X_GG2 * geometry->X_FG();
 
   // Changing from sphere to box.
-  ASSERT_EQ(ShapeName(geometry->shape()).name(), ShapeName(Sphere(1.0)).name());
+  ASSERT_EQ(geometry->shape().type_name(), Sphere(1.0).type_name());
   const Box new_shape(1.0, 2.0, 3.0);
 
   geometry_state_.ChangeShape(s_id, g_id, new_shape, X_FG2);
@@ -1799,8 +1799,7 @@ TEST_F(GeometryStateTest, ChangeShapeInternals) {
   ASSERT_EQ(geometry, gs_tester_.GetGeometry(g_id));
 
   // Shape and pose have changed.
-  EXPECT_EQ(ShapeName(geometry->shape()).name(),
-            ShapeName(Box(1, 1, 1)).name());
+  EXPECT_EQ(geometry->shape().type_name(), Box(1, 1, 1).type_name());
   EXPECT_TRUE(
       CompareMatrices(X_FG2.GetAsMatrix34(), geometry->X_FG().GetAsMatrix34()));
 
@@ -1824,7 +1823,7 @@ TEST_F(GeometryStateTest, ChangeShapeIllustration) {
   const InternalGeometry original_geo(*geometry);
 
   // Changing from sphere to box.
-  ASSERT_EQ(ShapeName(geometry->shape()).name(), ShapeName(Sphere(1.0)).name());
+  ASSERT_EQ(geometry->shape().type_name(), Sphere(1.0).type_name());
   const Box new_shape(1.0, 2.0, 3.0);
 
   const GeometryVersion pre_version = geometry_state_.geometry_version();
@@ -1916,7 +1915,7 @@ TEST_F(GeometryStateTest, ChangeShapePerception) {
   ASSERT_NE(renderer1->get_and_clear_last_removed_id(), g_id);
   ASSERT_NE(renderer2->get_and_clear_last_removed_id(), g_id);
 
-  ASSERT_EQ(ShapeName(geometry->shape()).name(), ShapeName(Sphere(1.0)).name());
+  ASSERT_EQ(geometry->shape().type_name(), Sphere(1.0).type_name());
   const Box new_shape(0.1, 0.2, 0.3);
 
   const GeometryVersion pre_version = geometry_state_.geometry_version();
@@ -1960,7 +1959,7 @@ TEST_F(GeometryStateTest, ChangeShapeProximity) {
 
   // Changing from sphere to a *small* box (should be smaller than the sphere).
   // The distance between the two shapes should get *larger*.
-  ASSERT_EQ(ShapeName(geometry->shape()).name(), ShapeName(Sphere(1.0)).name());
+  ASSERT_EQ(geometry->shape().type_name(), Sphere(1.0).type_name());
   const Box new_shape(0.1, 0.2, 0.3);
 
   const GeometryVersion pre_version = geometry_state_.geometry_version();

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -97,11 +97,11 @@ GTEST_TEST(InternalGeometryTest, SetShape) {
   // Set it to a couple of arbitrary shapes to confirm the change registers.
   const Sphere s(1.5);
   geometry.SetShape(s);
-  EXPECT_EQ(ShapeName(s).name(), ShapeName(geometry.shape()).name());
+  EXPECT_EQ(s.type_name(), geometry.shape().type_name());
 
   const Box b(1, 2, 3);
   geometry.SetShape(b);
-  EXPECT_EQ(ShapeName(b).name(), ShapeName(geometry.shape()).name());
+  EXPECT_EQ(b.type_name(), geometry.shape().type_name());
 }
 
 GTEST_TEST(InternalGeometryTest, SetPose) {

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -629,24 +629,20 @@ TEST_F(SceneGraphTest, ChangeShape) {
       query_object().inspector();
 
   // Confirm the shape in the model and context is of the expected type.
-  ASSERT_EQ(ShapeName(sphere).name(),
-            ShapeName(model_inspector.GetShape(g_id)).name());
-  ASSERT_EQ(ShapeName(sphere).name(),
-            ShapeName(context_inspector.GetShape(g_id)).name());
+  ASSERT_EQ(sphere.type_name(), model_inspector.GetShape(g_id).type_name());
+  ASSERT_EQ(sphere.type_name(), context_inspector.GetShape(g_id).type_name());
 
   // Change shape without changing pose.
   const Box box(1.5, 2.5, 3.5);
 
   scene_graph_.ChangeShape(source_id, g_id, box);
-  EXPECT_EQ(ShapeName(box).name(),
-            ShapeName(model_inspector.GetShape(g_id)).name());
+  EXPECT_EQ(box.type_name(), model_inspector.GetShape(g_id).type_name());
   EXPECT_TRUE(
       CompareMatrices(X_WG_original.GetAsMatrix34(),
                       model_inspector.GetPoseInFrame(g_id).GetAsMatrix34()));
 
   scene_graph_.ChangeShape(context_.get(), source_id, g_id, box);
-  EXPECT_EQ(ShapeName(box).name(),
-            ShapeName(context_inspector.GetShape(g_id)).name());
+  EXPECT_EQ(box.type_name(), context_inspector.GetShape(g_id).type_name());
   EXPECT_TRUE(
       CompareMatrices(X_WG_original.GetAsMatrix34(),
                       context_inspector.GetPoseInFrame(g_id).GetAsMatrix34()));
@@ -659,15 +655,13 @@ TEST_F(SceneGraphTest, ChangeShape) {
   const RigidTransformd X_WG_new = X_WG_original * X_WG_original;
 
   scene_graph_.ChangeShape(source_id, g_id, cylinder, X_WG_new);
-  EXPECT_EQ(ShapeName(cylinder).name(),
-            ShapeName(model_inspector.GetShape(g_id)).name());
+  EXPECT_EQ(cylinder.type_name(), model_inspector.GetShape(g_id).type_name());
   EXPECT_TRUE(
       CompareMatrices(X_WG_new.GetAsMatrix34(),
                       model_inspector.GetPoseInFrame(g_id).GetAsMatrix34()));
 
   scene_graph_.ChangeShape(context_.get(), source_id, g_id, cylinder, X_WG_new);
-  EXPECT_EQ(ShapeName(cylinder).name(),
-            ShapeName(context_inspector.GetShape(g_id)).name());
+  EXPECT_EQ(cylinder.type_name(), context_inspector.GetShape(g_id).type_name());
   EXPECT_TRUE(
       CompareMatrices(X_WG_new.GetAsMatrix34(),
                       context_inspector.GetPoseInFrame(g_id).GetAsMatrix34()));

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -589,6 +589,55 @@ TEST_F(OverrideDefaultGeometryTest, UnsupportedGeometry) {
   EXPECT_NO_THROW(this->ImplementGeometry(Sphere(0.5), nullptr));
 }
 
+GTEST_TEST(ShapeTest, TypeNameAndToString) {
+  const Box box(1.5, 2.5, 3.5);
+  const Capsule capsule(1.25, 2.5);
+  const Convex convex("/some/file", 1.5);
+  const Cylinder cylinder(1.25, 2.5);
+  const Ellipsoid ellipsoid(1.25, 2.5, 0.5);
+  const HalfSpace half_space;
+  const Mesh mesh("/some/file", 1.5);
+  const MeshcatCone cone(1.5, 0.25, 0.5);
+  const Sphere sphere(1.25);
+
+  EXPECT_EQ(box.type_name(), "Box");
+  EXPECT_EQ(capsule.type_name(), "Capsule");
+  EXPECT_EQ(convex.type_name(), "Convex");
+  EXPECT_EQ(cylinder.type_name(), "Cylinder");
+  EXPECT_EQ(ellipsoid.type_name(), "Ellipsoid");
+  EXPECT_EQ(half_space.type_name(), "HalfSpace");
+  EXPECT_EQ(mesh.type_name(), "Mesh");
+  EXPECT_EQ(cone.type_name(), "MeshcatCone");
+  EXPECT_EQ(sphere.type_name(), "Sphere");
+
+  EXPECT_EQ(box.to_string(), "Box(width=1.5, depth=2.5, height=3.5)");
+  EXPECT_EQ(capsule.to_string(), "Capsule(radius=1.25, length=2.5)");
+  EXPECT_EQ(convex.to_string(), "Convex(filename='/some/file', scale=1.5)");
+  EXPECT_EQ(cylinder.to_string(), "Cylinder(radius=1.25, length=2.5)");
+  EXPECT_EQ(ellipsoid.to_string(), "Ellipsoid(a=1.25, b=2.5, c=0.5)");
+  EXPECT_EQ(half_space.to_string(), "HalfSpace()");
+  EXPECT_EQ(mesh.to_string(), "Mesh(filename='/some/file', scale=1.5)");
+  EXPECT_EQ(cone.to_string(), "MeshcatCone(height=1.5, a=0.25, b=0.5)");
+  EXPECT_EQ(sphere.to_string(), "Sphere(radius=1.25)");
+
+  EXPECT_EQ(fmt::to_string(box), "Box(width=1.5, depth=2.5, height=3.5)");
+  EXPECT_EQ(fmt::to_string(capsule), "Capsule(radius=1.25, length=2.5)");
+  EXPECT_EQ(fmt::to_string(convex), "Convex(filename='/some/file', scale=1.5)");
+  EXPECT_EQ(fmt::to_string(cylinder), "Cylinder(radius=1.25, length=2.5)");
+  EXPECT_EQ(fmt::to_string(ellipsoid), "Ellipsoid(a=1.25, b=2.5, c=0.5)");
+  EXPECT_EQ(fmt::to_string(half_space), "HalfSpace()");
+  EXPECT_EQ(fmt::to_string(mesh), "Mesh(filename='/some/file', scale=1.5)");
+  EXPECT_EQ(fmt::to_string(cone), "MeshcatCone(height=1.5, a=0.25, b=0.5)");
+  EXPECT_EQ(fmt::to_string(sphere), "Sphere(radius=1.25)");
+
+  const Shape& base = box;
+  EXPECT_EQ(base.type_name(), "Box");
+  EXPECT_EQ(base.to_string(), "Box(width=1.5, depth=2.5, height=3.5)");
+  EXPECT_EQ(fmt::to_string(base), "Box(width=1.5, depth=2.5, height=3.5)");
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(ShapeName, SimpleReification) {
   ShapeName name;
 
@@ -621,7 +670,6 @@ GTEST_TEST(ShapeName, SimpleReification) {
   Sphere(0.5).Reify(&name);
   EXPECT_EQ(name.name(), "Sphere");
 }
-
 GTEST_TEST(ShapeName, ReifyOnConstruction) {
   EXPECT_EQ(ShapeName(Box(1, 2, 3)).name(), "Box");
   EXPECT_EQ(ShapeName(Capsule(1, 2)).name(), "Capsule");
@@ -632,7 +680,6 @@ GTEST_TEST(ShapeName, ReifyOnConstruction) {
   EXPECT_EQ(ShapeName(Mesh("filepath", 1.0)).name(), "Mesh");
   EXPECT_EQ(ShapeName(Sphere(0.5)).name(), "Sphere");
 }
-
 GTEST_TEST(ShapeName, Streaming) {
   ShapeName name(Sphere(0.5));
   std::stringstream ss;
@@ -640,6 +687,7 @@ GTEST_TEST(ShapeName, Streaming) {
   EXPECT_EQ(name.name(), "Sphere");
   EXPECT_EQ(ss.str(), name.name());
 }
+#pragma GCC diagnostic pop
 
 GTEST_TEST(ShapeTest, Volume) {
   EXPECT_NEAR(CalcVolume(Box(1, 2, 3)), 6.0, 1e-14);

--- a/geometry/test/shape_to_string_test.cc
+++ b/geometry/test/shape_to_string_test.cc
@@ -6,67 +6,11 @@ namespace drake {
 namespace geometry {
 namespace {
 
-GTEST_TEST(ShapeToStringTest, Box) {
+GTEST_TEST(DeprecatedShapeToStringTest, Box) {
   ShapeToString reifier;
   Box b(1.5, 2.5, 3.5);
   b.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Box(w: 1.5, d: 2.5, h: 3.5)");
-}
-
-GTEST_TEST(ShapeToStringTest, Capsule) {
-  ShapeToString reifier;
-  Capsule c(1.25, 2.5);
-  c.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Capsule(r: 1.25, l: 2.5)");
-}
-
-GTEST_TEST(ShapeToStringTest, Convex) {
-  ShapeToString reifier;
-  Convex m("/path/to/file", 1.5);
-  m.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Convex(s: 1.5, path: /path/to/file)");
-}
-
-GTEST_TEST(ShapeToStringTest, Cylinder) {
-  ShapeToString reifier;
-  Cylinder c(1.25, 2.5);
-  c.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Cylinder(r: 1.25, l: 2.5)");
-}
-
-GTEST_TEST(ShapeToStringTest, Ellipsoid) {
-  ShapeToString reifier;
-  Ellipsoid e(1.25, 2.5, 0.5);
-  e.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Ellipsoid(a: 1.25, b: 2.5, c: 0.5)");
-}
-
-GTEST_TEST(ShapeToStringTest, Halfspace) {
-  ShapeToString reifier;
-  HalfSpace h;
-  h.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Halfspace");
-}
-
-GTEST_TEST(ShapeToStringTest, Mesh) {
-  ShapeToString reifier;
-  Mesh m("/path/to/file", 1.5);
-  m.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Mesh(s: 1.5, path: /path/to/file)");
-}
-
-GTEST_TEST(ShapeToStringTest, MeshcatCone) {
-  ShapeToString reifier;
-  MeshcatCone c(1.5, 0.25, 0.5);
-  c.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "MeshcatCone(height: 1.5, a: 0.25, b: 0.5)");
-}
-
-GTEST_TEST(ShapeToStringTest, Sphere) {
-  ShapeToString reifier;
-  Sphere s(1.25);
-  s.Reify(&reifier);
-  EXPECT_EQ(reifier.string(), "Sphere(r: 1.25)");
+  EXPECT_EQ(reifier.string(), "Box(width=1.5, depth=2.5, height=3.5)");
 }
 
 }  // namespace

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -384,7 +384,7 @@ std::optional<std::string> ParseGeometryName(
   if (ParseStringAttribute(node, "name", &result)) {
     explicitly_named = true;
   } else {
-    result = geometry::ShapeName(shape).name();
+    result = shape.type_name();
   }
 
   // Check if we need to salt it.

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -34,7 +34,6 @@ using geometry::GeometryId;
 using geometry::Role;
 using geometry::SceneGraph;
 using geometry::SceneGraphInspector;
-using geometry::ShapeName;
 using math::RigidTransformd;
 using math::RollPitchYawd;
 using math::RotationMatrixd;
@@ -293,19 +292,16 @@ TEST_F(MujocoParserTest, GeometryTypes) {
   const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
 
   auto CheckShape = [&inspector](const std::string& geometry_name,
-                                 const std::string& shape_name) {
+                                 std::string_view shape_type) {
     GeometryId geom_id = inspector.GetGeometryIdByName(
         inspector.world_frame_id(), Role::kProximity, geometry_name);
-    EXPECT_EQ(geometry::ShapeName(inspector.GetShape(geom_id)).name(),
-              shape_name);
+    EXPECT_EQ(inspector.GetShape(geom_id).type_name(), shape_type);
     geom_id = inspector.GetGeometryIdByName(inspector.world_frame_id(),
                                             Role::kPerception, geometry_name);
-    EXPECT_EQ(geometry::ShapeName(inspector.GetShape(geom_id)).name(),
-              shape_name);
+    EXPECT_EQ(inspector.GetShape(geom_id).type_name(), shape_type);
     geom_id = inspector.GetGeometryIdByName(inspector.world_frame_id(),
                                             Role::kIllustration, geometry_name);
-    EXPECT_EQ(geometry::ShapeName(inspector.GetShape(geom_id)).name(),
-              shape_name);
+    EXPECT_EQ(inspector.GetShape(geom_id).type_name(), shape_type);
   };
 
   // TODO(russt): Check the sizes of the shapes.  (It seems that none of our

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -2109,21 +2109,21 @@ TEST_F(SdfParserTest, TestSdformatParserPolicies) {
 }
 
 // Reports if the frame with the given id has a geometry with the given role
-// whose name is the same as what ShapeName(ShapeType{}) would produce.
+// whose name is the same as what ShapeType{}.type_name() would produce.
 template <typename ShapeType>
 ::testing::AssertionResult FrameHasShape(geometry::FrameId frame_id,
                                          geometry::Role role,
                                          const SceneGraph<double>& scene_graph,
                                          const ShapeType& shape) {
   const auto& inspector = scene_graph.model_inspector();
-  const std::string name = geometry::ShapeName(shape).name();
+  const std::string name{shape.type_name()};
   try {
     // Note: MBP prepends the model index to the geometry name; in this case
     // that model instance  name is "test_robot".
     const geometry::GeometryId geometry_id =
         inspector.GetGeometryIdByName(frame_id, role, "test_robot::" + name);
-    const std::string shape_type =
-        geometry::ShapeName(inspector.GetShape(geometry_id)).name();
+    const std::string_view shape_type =
+        inspector.GetShape(geometry_id).type_name();
     if (shape_type != name) {
       return ::testing::AssertionFailure()
         << "Geometry with role " << role << " has wrong shape type."

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -1129,21 +1129,21 @@ TEST_F(UrdfParserTest, AddingGeometriesToWorldLink) {
 }
 
 // Reports if the frame with the given id has a geometry with the given role
-// whose name is the same as what ShapeName(ShapeType{}) would produce.
+// whose name is the same as what ShapeType{}.type_name() would produce.
 template <typename ShapeType>
 ::testing::AssertionResult FrameHasShape(geometry::FrameId frame_id,
                                          geometry::Role role,
                                          const SceneGraph<double>& scene_graph,
                                          const ShapeType& shape) {
   const auto& inspector = scene_graph.model_inspector();
-  const std::string name = geometry::ShapeName(shape).name();
+  const std::string name{shape.type_name()};
   try {
     // Note: MBP prepends the model index to the geometry name; in this case
     // that model instance name is "test_robot".
     const geometry::GeometryId geometry_id =
         inspector.GetGeometryIdByName(frame_id, role, "test_robot::" + name);
-    const std::string shape_type =
-        geometry::ShapeName(inspector.GetShape(geometry_id)).name();
+    const std::string_view shape_type =
+        inspector.GetShape(geometry_id).type_name();
     if (shape_type != name) {
       return ::testing::AssertionFailure()
           << "Geometry with role " << role << " has wrong shape type."

--- a/multibody/parsing/test/sdf_parser_test/all_geometries_as_collision.sdf
+++ b/multibody/parsing/test/sdf_parser_test/all_geometries_as_collision.sdf
@@ -5,9 +5,9 @@
          contains one collision tag for each supported geometry type. We're
          confirming that each geometry declaration produces a corresponding
          Drake Shape. The *names* of each collision element match the string
-         that is produced by `ShapeName` (see shape_specification.h). This is
-         to facilitate testing and altering the names will cause the test to
-         fail.
+         that is produced by `Shape::type_name()` (see shape_specification.h).
+         This is to facilitate testing and altering the names will cause the
+         test to fail.
          Values in <inertial> are not important for this test model since
          it's only to test the parsing of visuals and collisions into a
          MultibodyPlant.

--- a/multibody/parsing/test/sdf_parser_test/all_geometries_as_visual.sdf
+++ b/multibody/parsing/test/sdf_parser_test/all_geometries_as_visual.sdf
@@ -5,9 +5,9 @@
          contains one visual tag for each supported geometry type. We're
          confirming that each geometry declaration produces a corresponding
          Drake Shape. The *names* of each visual element match the string
-         that is produced by `ShapeName` (see shape_specification.h). This is
-         to facilitate testing and altering the names will cause the test to
-         fail.
+         that is produced by `Shape::type_name()` (see shape_specification.h).
+         This is to facilitate testing and altering the names will cause the
+         test to fail.
          Values in <inertial> are not important for this test model since
          it's only to test the parsing of visuals and collisions into a
          MultibodyPlant.

--- a/multibody/parsing/test/urdf_parser_test/all_geometries_as_collision.urdf
+++ b/multibody/parsing/test/urdf_parser_test/all_geometries_as_collision.urdf
@@ -4,9 +4,9 @@
        contains one collision tag for each supported geometry type. We're
        confirming that each geometry declaration produces a corresponding
        Drake Shape. The *names* of each collision element match the string
-       that is produced by `ShapeName` (see shape_specification.h). This is
-       to facilitate testing and altering the names will cause the test to
-       fail.
+       that is produced by `Shape::type_name()` (see shape_specification.h).
+       This is to facilitate testing and altering the names will cause the
+       test to fail.
        Values in <inertial> are not important for this test model since
        it's only to test the parsing of visuals and collisions into a
        MultibodyPlant.

--- a/multibody/parsing/test/urdf_parser_test/all_geometries_as_visual.urdf
+++ b/multibody/parsing/test/urdf_parser_test/all_geometries_as_visual.urdf
@@ -4,9 +4,9 @@
        contains one collision tag for each supported geometry type. We're
        confirming that each geometry declaration produces a corresponding
        Drake Shape. The *names* of each collision element match the string
-       that is produced by `ShapeName` (see shape_specification.h). This is
-       to facilitate testing and altering the names will cause the test to
-       fail.
+       that is produced by `Shape::type_name()` (see shape_specification.h).
+       This is to facilitate testing and altering the names will cause the
+       test to fail.
        Values in <inertial> are not important for this test model since
        it's only to test the parsing of visuals and collisions into a
        MultibodyPlant.


### PR DESCRIPTION
Deprecate the (awkward) ShapeName and (unused) ShapeToString reifiers, which were the prior mechanisms to obtain the Shape::type_name and Shape::to_string values.

Refactor Shape to use a vtable instead of copying reference-counted std::function objects everywhere. Implementing vtables by hand is confusing and wasteful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20870)
<!-- Reviewable:end -->
