### PR TITLE
[geometry] Fix minor typo in implementation comment

### DIFF
--- a/geometry/optimization/test/spectrahedron_test.cc
+++ b/geometry/optimization/test/spectrahedron_test.cc
@@ -330,7 +330,7 @@ GTEST_TEST(SpectrahedronTest, UnboundedTest) {
   Spectrahedron spect(prog);
   EXPECT_FALSE(spect.IsBounded());
 
-  // Construct an unbounded but constrainted SDP, and check that IsBounded
+  // Construct an unbounded but constrained SDP, and check that IsBounded
   // notices.
   prog.AddLinearConstraint(X1(0, 0) >= 0);
   Spectrahedron spect2(prog);


### PR DESCRIPTION
Constrainted => constrained.

Really this PR is getting opened to confirm results of #20865 and triggers are working.

While this was introduced in #19888, I'm going to post on #code_review for an internal developer to stamp it given the perceived role of the original author there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20871)
<!-- Reviewable:end -->
