### PR TITLE
[geometry] RenderEngine no longer inherits ShapeReifier

### DIFF
--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -83,7 +83,7 @@ namespace render {
  the PerceptionProperties, taking into account the configured default value and
  the documented @ref reserved_render_label "RenderLabel semantics"; see
  GetRenderLabelOrThrow().  */
-class RenderEngine : public ShapeReifier {
+class RenderEngine {
  public:
   /** Constructs a %RenderEngine with the given default render label. The
    default render label is applied to geometries that have not otherwise

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -90,7 +90,7 @@ namespace internal {
  These exceptions to the "shared" data have to be explicitly managed for each
  clone. Furthermore, the work has to be done with the engine's OpenGl context
  bound. Currently, all of this "clean up" work is done in DoClone(). */
-class RenderEngineGl final : public render::RenderEngine {
+class RenderEngineGl final : public render::RenderEngine, private ShapeReifier {
  public:
   /* @name Does not allow public copy, move, or assignment  */
   //@{
@@ -114,7 +114,7 @@ class RenderEngineGl final : public render::RenderEngine {
 
   /* @name    Shape reification  */
   //@{
-  using render::RenderEngine::ImplementGeometry;
+  using ShapeReifier::ImplementGeometry;
   void ImplementGeometry(const Box& box, void* user_data) final;
   void ImplementGeometry(const Capsule& capsule, void* user_data) final;
   void ImplementGeometry(const Convex& convex, void* user_data) final;

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -88,6 +88,7 @@ enum ImageType {
 
 /* See documentation of MakeRenderEngineVtk().  */
 class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
+                                        private ShapeReifier,
                                         private ModuleInitVtkRenderingOpenGL2 {
  public:
   /* @name Does not allow copy, move, or assignment  */
@@ -113,7 +114,7 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
 
   /* @name    Shape reification  */
   //@{
-  using RenderEngine::ImplementGeometry;
+  using ShapeReifier::ImplementGeometry;
   void ImplementGeometry(const Box& box, void* user_data) override;
   void ImplementGeometry(const Capsule& capsule, void* user_data) override;
   void ImplementGeometry(const Convex& convex, void* user_data) override;

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -36,7 +36,7 @@ namespace internal {
     and which aren't (and with what configurations).
  6. Records the camera pose provided to UpdateViewpoint() and report it with
     last_updated_X_WC().  */
-class DummyRenderEngine : public render::RenderEngine {
+class DummyRenderEngine : public render::RenderEngine, private ShapeReifier {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DummyRenderEngine);
 
@@ -59,7 +59,7 @@ class DummyRenderEngine : public render::RenderEngine {
   using render::RenderEngine::RenderDepthImage;
   using render::RenderEngine::RenderLabelImage;
 
-  using RenderEngine::ImplementGeometry;
+  using ShapeReifier::ImplementGeometry;
   void ImplementGeometry(const Box&, void*) override {}
   void ImplementGeometry(const Capsule&, void*) override {}
   void ImplementGeometry(const Convex&, void*) override {}


### PR DESCRIPTION
It doesn't make sense to let _users_ of a RenderEngine reify shapes into it.  The `void* user_data` would almost certainly be wrong, and segfault.

This might be a breaking change for code that implemented its own custom RenderEngine and was using `this` as the `ShapeReifier` receiver.  To fix the break, inherit from `ShapeReifier` directly yourself.

(There is not really any great way to deprecate this in a way that gives helpful compiler diagnostics.)

If you need your code to be compatible with versions of Drake both before and after this change, you can use a shim:
```c++
#include <type_traits>

...

namespace deprecation_shim {
struct Empty {};
using ShapeReifierOneWayOrAnother =
    std::conditional_t<std::is_base_of_v<drake::geometry::ShapeReifier,
                                         drake::geometry::render::RenderEngine>,
                       Empty, drake::geometry::ShapeReifier>;
}  // namespace deprecation_shim

class MySpecialRenderEngine
    : public drake::geometry::render::RenderEngine,
      private deprecation_shim::ShapeReifierOneWayOrAnother {
  // ...
};
```



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20873)
<!-- Reviewable:end -->
