### PR TITLE
gcs: remove incoming/outgoing edges of a vertex when they don't exist

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -279,8 +279,11 @@ void GraphOfConvexSets::RemoveVertex(Vertex* vertex) {
   VertexId vertex_id = vertex->id();
   DRAKE_THROW_UNLESS(vertices_.count(vertex_id) > 0);
   for (auto it = edges_.begin(); it != edges_.end();) {
-    if (it->second->u().id() == vertex_id ||
-        it->second->v().id() == vertex_id) {
+    if (it->second->u().id() == vertex_id) {
+      it->second->v().RemoveIncomingEdge(it->second.get());
+      it = edges_.erase(it);
+    } else if (it->second->v().id() == vertex_id) {
+      it->second->u().RemoveOutgoingEdge(it->second.get());
       it = edges_.erase(it);
     } else {
       ++it;

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -170,6 +170,8 @@ GTEST_TEST(GraphOfConvexSetsTest, RemoveVertex) {
   Edge* e1 = g.AddEdge(v1, v2);
   g.AddEdge(v1, v3);
   g.AddEdge(v3, v1);
+  EXPECT_EQ(v1->incoming_edges().size(), 1);
+  EXPECT_EQ(v1->outgoing_edges().size(), 2);
 
   EXPECT_EQ(g.Vertices().size(), 3);
   EXPECT_EQ(g.Edges().size(), 3);
@@ -179,12 +181,14 @@ GTEST_TEST(GraphOfConvexSetsTest, RemoveVertex) {
   auto edges = g.Edges();
   EXPECT_EQ(edges.size(), 1);
   EXPECT_EQ(edges.at(0), e1);
+  EXPECT_EQ(v1->incoming_edges().size(), 0);
 
   g.RemoveVertex(v2);
   auto vertices = g.Vertices();
   EXPECT_EQ(vertices.size(), 1);
   EXPECT_EQ(vertices.at(0), v1);
   EXPECT_EQ(g.Edges().size(), 0);
+  EXPECT_EQ(v1->outgoing_edges().size(), 0);
 }
 
 /*


### PR DESCRIPTION
When we remove a vertex, we also remove the edges connected to it. But those should also be removed from the outgoing/incoming edge lists of the corresponding vertices.

Also modified the unit test which would fail otherwise.

I came across this problem on a custom code when extracting the solution path from `GcsTrajectoryOptimization` with multiple sets as source/target ran into non-existing edges, because the edges from/to the `dummy_source` and `dummy_target` [in here](https://github.com/RobotLocomotion/drake/blob/10c26ec8b5037d477a40423e93f3c012f00e069f/planning/trajectory_optimization/gcs_trajectory_optimization.cc#L1027) don't get properly cleaned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20875)
<!-- Reviewable:end -->
