### PR TITLE
Implement wraparound edges together with the subspace machinery.

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -431,6 +431,7 @@ drake_cc_googletest(
     deps = [
         ":convex_set",
         ":geodesic_convexity",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/geometry/optimization/geodesic_convexity.cc
+++ b/geometry/optimization/geodesic_convexity.cc
@@ -21,35 +21,93 @@ using Eigen::VectorXd;
 
 std::pair<double, double> internal::GetMinimumAndMaximumValueAlongDimension(
     const ConvexSet& region, int dimension) {
-  DRAKE_THROW_UNLESS(dimension >= 0 && dimension < region.ambient_dimension());
+  // We formulate the problem in the vectorized overload instead of here so that
+  // we can reuse the same MathematicalProgram for multiple evaluations.
+  return internal::GetMinimumAndMaximumValueAlongDimension(
+      region, std::vector<int>{dimension})[0];
+}
+
+std::vector<std::pair<double, double>>
+internal::GetMinimumAndMaximumValueAlongDimension(const ConvexSet& region,
+                                                  std::vector<int> dimensions) {
+  std::vector<std::pair<double, double>> bounds;
   MathematicalProgram prog;
   VectorXDecisionVariable y =
       prog.NewContinuousVariables(region.ambient_dimension());
   region.AddPointInSetConstraints(&prog, y);
   VectorXd objective_vector = VectorXd::Zero(region.ambient_dimension());
-  objective_vector[dimension] = 1;
   auto objective = prog.AddLinearCost(objective_vector, y);
+  for (const auto& dimension : dimensions) {
+    DRAKE_THROW_UNLESS(dimension >= 0 &&
+                       dimension < region.ambient_dimension());
+    objective_vector.setZero();
+    objective_vector[dimension] = 1;
+    objective.evaluator()->UpdateCoefficients(objective_vector);
 
-  auto result = Solve(prog);
-  if (!result.is_success()) {
-    throw std::runtime_error(
-        "GcsTrajectoryOptimization: Failed to compute lower bound of a convex "
-        "set!");
+    auto result = Solve(prog);
+    if (!result.is_success()) {
+      throw std::runtime_error(
+          fmt::format("Failed to compute the lower bound of a convex set along "
+                      "dimension {}!",
+                      dimension));
+    }
+    const double lower_bound = result.GetSolution(y)[dimension];
+
+    objective_vector[dimension] = -1;
+    objective.evaluator()->UpdateCoefficients(objective_vector);
+
+    result = Solve(prog);
+    if (!result.is_success()) {
+      throw std::runtime_error(
+          fmt::format("Failed to compute the upper bound of a convex set along "
+                      "dimension {}!",
+                      dimension));
+    }
+    const double upper_bound = result.GetSolution(y)[dimension];
+    bounds.push_back({lower_bound, upper_bound});
   }
-  const double lower_bound = result.GetSolution(y)[dimension];
 
-  objective_vector[dimension] = -1;
-  objective.evaluator()->UpdateCoefficients(objective_vector);
+  return bounds;
+}
 
-  result = Solve(prog);
-  if (!result.is_success()) {
-    throw std::runtime_error(
-        "GcsTrajectoryOptimization: Failed to compute upper bound of a convex "
-        "set!");
+VectorXd internal::ComputeOffsetContinuousRevoluteJoints(
+    const int num_positions, const std::vector<int>& continuous_revolute_joints,
+    const std::vector<std::pair<double, double>>& continuous_bbox_A,
+    const std::vector<std::pair<double, double>>& continuous_bbox_B) {
+  internal::ThrowsForInvalidContinuousJointsList(num_positions,
+                                                 continuous_revolute_joints);
+  DRAKE_THROW_UNLESS(continuous_bbox_A.size() == continuous_bbox_B.size());
+  VectorXd offset = Eigen::VectorXd::Zero(num_positions);
+
+  for (int i = 0; i < ssize(continuous_revolute_joints); ++i) {
+    const int joint_index = continuous_revolute_joints.at(i);
+    if (continuous_bbox_A.at(i).first < continuous_bbox_B.at(i).first) {
+      // In this case, the minimum value of convex_sets_A[i] along dimension
+      // joint_index is smaller than the minimum value of convex_sets_B[j] along
+      // dimension joint_index, so we must translate by a positive amount. By
+      // the convexity radius property (which has already been checked), we know
+      // that the width of each set is strictly less than π. So we need to
+      // translate convex_sets_A[i] by some multiple of 2π such that the
+      // difference between the maximum value in convex_sets_B[j] and the
+      // minimum value in convex_sets_A[i] is less than 2π. This is computed
+      // by taking that difference, dividing by 2π, and truncating.
+      offset(joint_index) = 2 * M_PI *
+                            std::floor((continuous_bbox_B.at(i).second -
+                                        continuous_bbox_A.at(i).first) /
+                                       (2 * M_PI));
+    } else {
+      // In this case, the minimum value of convex_sets_B[j] along dimension
+      // joint_index is smaller than the minimum value of convex_sets_A[i] along
+      // dimension joint_index. We do the same thing as above, but flip the
+      // order of the sets. As a result, we also flip the sign of the resulting
+      // translation.
+      offset(joint_index) = -2 * M_PI *
+                            std::floor((continuous_bbox_A.at(i).second -
+                                        continuous_bbox_B.at(i).first) /
+                                       (2 * M_PI));
+    }
   }
-  const double upper_bound = result.GetSolution(y)[dimension];
-
-  return {lower_bound, upper_bound};
+  return offset;
 }
 
 void internal::ThrowsForInvalidContinuousJointsList(

--- a/geometry/optimization/geodesic_convexity.h
+++ b/geometry/optimization/geodesic_convexity.h
@@ -23,11 +23,28 @@ namespace optimization {
 namespace internal {
 
 /* Computes the minimum and maximum values that can be attained along a certain
-dimension for a point constrained to lie within a convex set.
+dimension for a point constrained to lie within a convex set region.
+@param region is the convex set we're examining.
+@param dimension specifies for which dimension we compute the minimum and
+maximum values.
 @throws std::exception if dimension is outside the interval
 [0, region.ambient_dimension()). */
 std::pair<double, double> GetMinimumAndMaximumValueAlongDimension(
     const ConvexSet& region, int dimension);
+
+/* Convenience overload to find the minimum and maximum values that can be
+attained along a list of dimensions for a point constrained to lie within a
+convex set.
+@param region is the convex set we're examining.
+@param dimensions specifies a list of dimensions for which we compute the
+minimum and maximum values.
+@returns a vector of pairs, where the entry in index i is the pair (min, max)
+describing the minimum and maximum value along the dimension given by index i
+of the input dimensions vector.
+@throws std::exception if any entry of dimensions is outside the interval
+[0, region.ambient_dimension()). */
+std::vector<std::pair<double, double>> GetMinimumAndMaximumValueAlongDimension(
+    const ConvexSet& region, std::vector<int> dimensions);
 
 /* Helper function to assert that a given list of continuous revolute joint
 indices satisfies the requirements for the constructor to
@@ -35,6 +52,23 @@ GcsTrajectoryOptimization, as well as any static functions that may take in
 such a list. */
 void ThrowsForInvalidContinuousJointsList(
     int num_positions, const std::vector<int>& continuous_revolute_joints);
+
+/* Given two convex sets A and B with ambient dimension num_positions, we denote
+a subset of those positions as continuous_revolute_joints, and the bounding box
+along these positions is obtained via GetMinimumAndMaximumValueAlongDimension().
+This function takes in the bounding boxes, and computes the translation that
+should be applied to the first convex set to align it with the second, such that
+intersections can directly be checked without considering the 2π wraparound that
+may occur with continuous revolute joints.
+@throws std::exception if continuous_bbox_A.size() != continuous_bbox_B.size().
+@throws std::exception if num_positions and continuous_revolute_joints do not
+satisfy the conditions checked by
+internal::ThrowsForInvalidContinuousJointsList.
+*/
+Eigen::VectorXd ComputeOffsetContinuousRevoluteJoints(
+    const int num_positions, const std::vector<int>& continuous_revolute_joints,
+    const std::vector<std::pair<double, double>>& continuous_bbox_A,
+    const std::vector<std::pair<double, double>>& continuous_bbox_B);
 }  // namespace internal
 
 /** Given a convex set, and a list of indices corresponding to continuous

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -41,6 +41,21 @@ to facilitate multi-modal motion planning such as: Subgraph A: find a
 collision-free trajectory for the robot to a grasping posture, Subgraph B: find
 a collision-free trajectory for the robot with the object in its hand to a
 placing posture, etc.
+
+@anchor continuous_revolute_joints
+### Continuous Revolute Joints
+
+This class also supports robots with continuous revolute joints (revolute joints
+that don't have any joint limits) and mobile bases. Adding or subtracting 2π to
+such a joint's angle leaves it unchanged; this logic is implemented behind the
+scenes. To use it, one should specify the joint indices that don't have limits,
+and ensure all sets satisfy the "convexity radius" property -- their width along
+a dimension corresponding to a continuous revolute joint must be less than π.
+This can be enforced when constructing the convex sets, or after the fact with
+`geometry::optimization::PartitionConvexSet`. The `GcsTrajectoryOptimization`
+methods `AddRegions` and `AddEdges` will handle all of the intersection checks
+behind the scenes, including applying the appropriate logic to connect sets that
+"wrap around" 2π.
 */
 class GcsTrajectoryOptimization final {
  public:
@@ -256,7 +271,10 @@ class GcsTrajectoryOptimization final {
     bool RegionsConnectThroughSubspace(
         const geometry::optimization::ConvexSet& A,
         const geometry::optimization::ConvexSet& B,
-        const geometry::optimization::ConvexSet& subspace);
+        const geometry::optimization::ConvexSet& subspace,
+        std::optional<const Eigen::VectorXd> maybe_set_B_offset = std::nullopt,
+        std::optional<const Eigen::VectorXd> maybe_subspace_offset =
+            std::nullopt);
 
     /* Extracts the control points variables from an edge. */
     Eigen::Map<const MatrixX<symbolic::Variable>> GetControlPointsU(

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -1409,6 +1409,60 @@ GTEST_TEST(GcsTrajectoryOptimizationTest,
                               ".*doesn't respect the convexity radius.*");
 }
 
+GTEST_TEST(GcsTrajectoryOptimizationTest, WraparoundSubspace) {
+  // 1D example.
+  Eigen::Matrix<double, 1, 2> points1;
+  Eigen::Matrix<double, 1, 2> points2;
+  Eigen::Matrix<double, 1, 2> points3;
+  points1 << 0, 3;
+  points2 << 2.5, 5.5;
+  points3 << 5, 8;
+  const VPolytope v1(points1);
+  const VPolytope v2(points2);
+  const VPolytope v3(points3);
+  std::vector<int> continuous_revolute_joints = {0};
+  const Point subspace12(Vector1d{2.75 + (6 * M_PI)});
+  const Point subspace23(Vector1d{5.25 - (4 * M_PI)});
+  const Point subspace13(Vector1d{7.0 + (2 * M_PI)});
+
+  GcsTrajectoryOptimization gcs(1, continuous_revolute_joints);
+  auto& subgraph1 = gcs.AddRegions(MakeConvexSets(HPolyhedron(v1)), 1);
+  auto& subgraph2 =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron(v2), HPolyhedron(v3)), 1);
+
+  // Initially, there should be two edges, v2 -> v3 and v3 -> v2.
+  int expected_num_edges = 2;
+
+  // When we add edges from subgraph1 to subgraph2, we add edges v1 -> v2
+  // and v1 -> v3.
+  gcs.AddEdges(subgraph1, subgraph2);
+  expected_num_edges += 2;
+  EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), expected_num_edges);
+
+  // When we add edges from subgraph1 to subgraph2 through subspace12, only
+  // v1 -> v2 is added as an edge, since their intersection overlaps with
+  // subspace12. the intersection of v1 and v3 does not overlap with subspace12,
+  // so v1 -> v3 is not added.
+  gcs.AddEdges(subgraph1, subgraph2, &subspace12);
+  expected_num_edges += 1;
+  EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), expected_num_edges);
+
+  // When we add edges from subgraph1 to subgraph2 through subspace13, only
+  // v1 -> v3 is added as an edge, since their intersection overlaps with
+  // subspace13. the intersection of v1 and v2 does not overlap with subspace13,
+  // so v1 -> v2 is not added.
+  gcs.AddEdges(subgraph1, subgraph2, &subspace13);
+  expected_num_edges += 1;
+  EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), expected_num_edges);
+
+  // When we add edges from subgraph1 to subgraph2 through subspace23, no edges
+  // are added, since the intersection between v1 and v2 does not overlap with
+  // subspace23, and the intersection between v1 and v3 does not overlap with
+  // subspace23.
+  gcs.AddEdges(subgraph1, subgraph2, &subspace23);
+  EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), expected_num_edges);
+}
+
 GTEST_TEST(GcsTrajectoryOptimizationTest, ContinuousJointsApi) {
   Eigen::Matrix<double, 1, 2> points;
   points << 0, 2;


### PR DESCRIPTION
Allows the construction of edges between subgraphs while restricting the edges to be contained in a subspace. Completes #20449.

Still need to add test cases. Will request a reviewer once that is done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20886)
<!-- Reviewable:end -->
