### PR TITLE
Transform between HPolyhedron and VPolytope with ambient dimension 1.

### DIFF
--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -153,6 +153,19 @@ HPolyhedron::HPolyhedron(const VPolytope& vpoly)
       return;
     }
   }
+  if (vpoly.ambient_dimension() == 1) {
+    // In 1D, QHull doesn't work. We can simply choose the largest and smallest
+    // points, and add a hyperplane there.
+    double min_val = vpoly.vertices().minCoeff();
+    double max_val = vpoly.vertices().maxCoeff();
+    Eigen::MatrixXd A(2, 1);
+    Eigen::VectorXd b(2);
+    // x <= max_val and x >= min_val (written as -x <= -min_val)
+    A << 1, -1;
+    b << max_val, -min_val;
+    *this = HPolyhedron(A, b);
+    return;
+  }
   // Next, handle the case where the VPolytope is not full dimensional.
   const AffineSubspace affine_hull(vpoly);
   if (affine_hull.AffineDimension() < affine_hull.ambient_dimension()) {

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -160,6 +160,28 @@ GTEST_TEST(HPolyhedronTest, ConstructorFromVPolytope) {
   EXPECT_TRUE(hpoly2.PointInSet(hpoly2.MaybeGetFeasiblePoint().value()));
 }
 
+GTEST_TEST(HPolyhedronTest, ConstructorFromVPolytope1D) {
+  const double eps = 1e-6;
+
+  Eigen::Matrix<double, 1, 4> vert1;
+  vert1 << 1, 0, 3, 2;
+  VPolytope v1(vert1);
+  EXPECT_NO_THROW(HPolyhedron{v1});
+  HPolyhedron h1(v1);
+  EXPECT_TRUE(h1.PointInSet(Vector1d(0)));
+  EXPECT_TRUE(h1.PointInSet(Vector1d(3)));
+  EXPECT_FALSE(h1.PointInSet(Vector1d(0 - eps)));
+  EXPECT_FALSE(h1.PointInSet(Vector1d(3 + eps)));
+
+  Eigen::Matrix<double, 1, 1> vert2;
+  vert2 << 43;
+  VPolytope v2(vert2);
+  HPolyhedron h2(v2);
+  EXPECT_TRUE(h2.PointInSet(Vector1d(43)));
+  EXPECT_FALSE(h2.PointInSet(Vector1d(43 - eps)));
+  EXPECT_FALSE(h2.PointInSet(Vector1d(43 + eps)));
+}
+
 void CheckHPolyhedronContainsVPolyhedron(const HPolyhedron& h,
                                          const VPolytope& v, double tol = 0) {
   for (int i = 0; i < v.vertices().cols(); ++i) {

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -561,6 +561,22 @@ GTEST_TEST(VPolytopeTest, ConstructorFromHPolyhedronQHullProblems) {
   EXPECT_FALSE(vpoly3.PointInSet(Eigen::Vector3d(0, 2, 0), vpolyTol));
   EXPECT_FALSE(vpoly3.PointInSet(Eigen::Vector3d(0, 0, -1), vpolyTol));
   EXPECT_FALSE(vpoly3.PointInSet(Eigen::Vector3d(0, 0, 2), vpolyTol));
+
+  // 1D ambient dimension.
+  Eigen::Matrix<double, 2, 1> A4;
+  A4 << 1, -1;
+  Eigen::Vector2d b4;
+  b4 << 1, 0;
+  HPolyhedron hpoly4(A4, b4);
+  EXPECT_NO_THROW(VPolytope{hpoly4});
+  const VPolytope vpoly4(hpoly4);
+  EXPECT_TRUE(vpoly4.PointInSet(Vector1d(1), vpolyTol));
+  EXPECT_TRUE(vpoly4.PointInSet(Vector1d(0), vpolyTol));
+  // Ensure points just outside the boundary are not in the set. Note that we
+  // use 2 * vpolyTol, since a point that is only vpolyTol outside of the set
+  // could be considered to be in the set due to the numerical tolerance.
+  EXPECT_FALSE(vpoly4.PointInSet(Vector1d(1 + 2 * vpolyTol), vpolyTol));
+  EXPECT_FALSE(vpoly4.PointInSet(Vector1d(0 - 2 * vpolyTol), vpolyTol));
 }
 
 GTEST_TEST(VPolytopeTest, CloneTest) {


### PR DESCRIPTION
Previously, this would call QHull, which would lead to errors such as `QH6050 qhull error: dimension 1 must be > 1`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20893)
<!-- Reviewable:end -->
