### PR TITLE
Added solving a path via convex restriction

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -349,6 +349,11 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("name", &Class::Subgraph::name, subgraph_doc.name.doc)
         .def("order", &Class::Subgraph::order, subgraph_doc.order.doc)
         .def("size", &Class::Subgraph::size, subgraph_doc.size.doc)
+        .def("Vertices",
+            overload_cast_explicit<const std::vector<
+                geometry::optimization::GraphOfConvexSets::Vertex*>&>(
+                &Class::Subgraph::Vertices),
+            py_rvp::reference_internal, subgraph_doc.Vertices.doc)
         .def(
             "regions",
             [](Class::Subgraph* self) {
@@ -456,6 +461,11 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py::arg("options") =
                 geometry::optimization::GraphOfConvexSetsOptions(),
             cls_doc.SolvePath.doc)
+        .def("SolveConvexRestriction", &Class::SolveConvexRestriction,
+            py::arg("active_vertices"),
+            py::arg("options") =
+                geometry::optimization::GraphOfConvexSetsOptions(),
+            cls_doc.SolveConvexRestriction.doc)
         .def("graph_of_convex_sets", &Class::graph_of_convex_sets,
             py_rvp::reference_internal, cls_doc.graph_of_convex_sets.doc)
         .def_static("NormalizeSegmentTimes", &Class::NormalizeSegmentTimes,

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -85,6 +85,28 @@ class GcsTrajectoryOptimization final {
     /** Returns the number of vertices in the subgraph. */
     int size() const { return vertices_.size(); }
 
+    /** Returns constant reference to a vector of mutable pointers to the
+    vertices stored in the subgraph. The order of the vertices is the same as
+    the order the regions were added.*/
+    const std::vector<geometry::optimization::GraphOfConvexSets::Vertex*>&
+    Vertices() {
+      return vertices_;
+    }
+
+    /** Returns pointers to the vertices stored in the subgraph.
+    The order of the vertices is the same as the order the regions were added.
+    @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.} */
+    std::vector<const geometry::optimization::GraphOfConvexSets::Vertex*>
+    Vertices() const {
+      std::vector<const geometry::optimization::GraphOfConvexSets::Vertex*>
+          vertices;
+      vertices.reserve(vertices_.size());
+      for (const auto& v : vertices_) {
+        vertices.push_back(v);
+      }
+      return vertices;
+    }
+
     /** Returns the regions associated with this subgraph before the
     CartesianProduct. */
     const geometry::optimization::ConvexSets& regions() const {
@@ -499,6 +521,36 @@ class GcsTrajectoryOptimization final {
       const Subgraph& source, const Subgraph& target,
       const geometry::optimization::GraphOfConvexSetsOptions& options = {});
 
+  /** Solves a trajectory optimization problem through specific vertices.
+
+  This method allows for targeted optimization by considering only selected
+  active vertices, reducing the problem's complexity.
+  See geometry::optimization::GraphOfConvexSets::SolveConvexRestriction().
+  This API prefers a sequence of vertices over edges, as a user may know which
+  regions the solution should pass through.
+  GcsTrajectoryOptimization::AddRegions() automatically manages edge creation
+  and intersection checks, which makes passing a sequence of edges less
+  convenient.
+
+  @param active_vertices A sequence of ordered vertices of subgraphs to be
+    included in the problem.
+  @param options include all settings for solving the shortest path problem.
+
+  @pre There must be at least two vertices in active_vertices.
+  @throws std::exception if the vertices are not connected.
+  @throws std::exception if two vertices are connected by multiple edges. This
+    may happen if one connects two graphs through multiple subspaces, which is
+    currently not supported with this method.
+  @throws std::exception if the program cannot be written as a convex
+  optimization consumable by one of the standard solvers.*/
+  std::pair<trajectories::CompositeTrajectory<double>,
+            solvers::MathematicalProgramResult>
+  SolveConvexRestriction(
+      const std::vector<
+          const geometry::optimization::GraphOfConvexSets::Vertex*>&
+          active_vertices,
+      const geometry::optimization::GraphOfConvexSetsOptions& options = {});
+
   /** Provide a heuristic estimate of the complexity of the underlying
   GCS mathematical program, for regression testing purposes.
   Here we sum the total number of variable appearances in our costs and
@@ -527,6 +579,11 @@ class GcsTrajectoryOptimization final {
  private:
   const int num_positions_;
   const std::vector<int> continuous_revolute_joints_;
+
+  trajectories::CompositeTrajectory<double>
+  ReconstructTrajectoryFromSolutionPath(
+      std::vector<const geometry::optimization::GraphOfConvexSets::Edge*> edges,
+      const solvers::MathematicalProgramResult& result);
 
   // Adds a Edge to gcs_ with the name "{u.name} -> {v.name}".
   geometry::optimization::GraphOfConvexSets::Edge* AddEdge(


### PR DESCRIPTION
This is an attempt to provide an API where users can plan through a sequence of vertices in GCS trajectory optimization.
While GraphOfConvexSets::SolveConvexRestriction takes in a list of edges, it turns out using the edges in the Subgraph class are not as straightforward as the vertices since the edges are often automatically connected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20895)
<!-- Reviewable:end -->
