### PR TITLE
[geometry] Fix race condition in meshcat unit test

### DIFF
--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -50,6 +50,9 @@ void CheckWebsocketCommand(const Meshcat& meshcat,
                            std::optional<int> expect_num_messages,
                            std::optional<std::string> expect_json,
                            bool expect_success = true) {
+  if (expect_num_messages) {
+    meshcat.Flush();
+  }
   std::vector<std::string> argv;
   argv.push_back(
       FindResourceOrThrow("drake/geometry/meshcat_websocket_client"));


### PR DESCRIPTION
Before launching an external process that talks to the websocket thread and expects a specific reply, we need to ensure that all of our Defer() calls that modify the scene tree (or etc.) have actually been processed by the websocket thread.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20899)
<!-- Reviewable:end -->
