### PR TITLE
Add EigenMapView to aid inerop with C++ containers

### DIFF
--- a/common/test/eigen_types_test.cc
+++ b/common/test/eigen_types_test.cc
@@ -85,6 +85,47 @@ GTEST_TEST(EigenTypesTest, TraitsSFINAE) {
   // EXPECT_FALSE((is_eigen_vector_of<std::string, double>::value));
 }
 
+GTEST_TEST(MapViewTest, CStyleArray) {
+  double foo[3] = {};
+  EXPECT_EQ(EigenMapView(foo).rows(), 3);
+  EXPECT_EQ(EigenMapView(foo).cols(), 1);
+  EigenMapView(foo) = Vector3d::Constant(1.0);
+  EXPECT_EQ(foo[1], 1.0);
+
+  const double bar[3] = {1.0, 2.0, 3.0};
+  EXPECT_EQ(EigenMapView(bar).rows(), 3);
+  EXPECT_EQ(EigenMapView(bar).cols(), 1);
+  const Eigen::Vector3d quux = EigenMapView(bar);
+  EXPECT_EQ(quux[1], 2.0);
+}
+
+GTEST_TEST(MapViewTest, StdArray) {
+  std::array<double, 3> foo = {};
+  EigenMapView(foo) = Vector3d::Constant(1.0);
+  EXPECT_EQ(foo[1], 1.0);
+
+  const std::array<double, 3> bar = {1.0, 2.0, 3.0};
+  const Eigen::Vector3d quux = EigenMapView(bar);
+  EXPECT_EQ(quux[1], 2.0);
+}
+
+GTEST_TEST(MapViewTest, StdVector) {
+  std::vector<double> foo;
+  EXPECT_EQ(EigenMapView(foo).size(), 0);
+
+  foo.resize(3);
+  EXPECT_EQ(EigenMapView(foo).rows(), 3);
+  EXPECT_EQ(EigenMapView(foo).cols(), 1);
+  EigenMapView(foo) = Vector3d::Constant(1.0);
+  EXPECT_EQ(foo[1], 1.0);
+
+  const std::vector<double> bar = {1.0, 2.0, 3.0};
+  EXPECT_EQ(EigenMapView(bar).rows(), 3);
+  EXPECT_EQ(EigenMapView(bar).cols(), 1);
+  const Eigen::Vector3d quux = EigenMapView(bar);
+  EXPECT_EQ(quux[1], 2.0);
+}
+
 GTEST_TEST(EigenTypesTest, EigenPtr_Null) {
   EigenPtr<const Matrix3d> null_ptr = nullptr;
   EXPECT_FALSE(null_ptr);

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -226,12 +226,6 @@ class ContactResultMaker final : public LeafSystem<double> {
     message.num_point_pair_contacts = num_pairs;
     message.point_pair_contact_info.resize(num_pairs);
 
-    auto write_double3 = [](const Vector3d& src, double* dest) {
-      dest[0] = src(0);
-      dest[1] = src(1);
-      dest[2] = src(2);
-    };
-
     const auto& inspector = query_object.inspector();
 
     // Contact surfaces.
@@ -271,11 +265,11 @@ class ContactResultMaker final : public LeafSystem<double> {
 
         // Fake contact *force* and *moment* data, with some variations across
         // different faces to facilitate visualizer testing.
-        write_double3(surface.centroid(), surface_message.centroid_W);
-        write_double3(Vector3<double>(1.2 * (i + 1), 0, 0),
-                      surface_message.force_C_W);
-        write_double3(Vector3<double>(0, 0, 0.5 * (i + 1)),
-                      surface_message.moment_C_W);
+        EigenMapView(surface_message.centroid_W) = surface.centroid();
+        EigenMapView(surface_message.force_C_W) =
+            Vector3<double>(1.2 * (i + 1), 0, 0);
+        EigenMapView(surface_message.moment_C_W) =
+            Vector3<double>(0, 0, 0.5 * (i + 1));
 
         // Write fake quadrature data.
         surface_message.num_quadrature_points = surface.num_faces();
@@ -284,11 +278,11 @@ class ContactResultMaker final : public LeafSystem<double> {
         for (int j = 0; j < surface_message.num_quadrature_points; ++j) {
           lcmt_hydroelastic_quadrature_per_point_data_for_viz&
               quad_data_message = surface_message.quadrature_point_data[j];
-          write_double3(surface.centroid(j), quad_data_message.p_WQ);
-          write_double3(Vector3d(0, 0.2 + (j * 0.005), 0),
-                        quad_data_message.vt_BqAq_W);
-          write_double3(Vector3d(0, -0.2 - (j * 0.005), 0),
-                        quad_data_message.traction_Aq_W);
+          EigenMapView(quad_data_message.p_WQ) = surface.centroid(j);
+          EigenMapView(quad_data_message.vt_BqAq_W) =
+              Vector3d(0, 0.2 + (j * 0.005), 0);
+          EigenMapView(quad_data_message.traction_Aq_W) =
+              Vector3d(0, -0.2 - (j * 0.005), 0);
         }
 
         // Now write the *real* mesh.
@@ -350,9 +344,9 @@ class ContactResultMaker final : public LeafSystem<double> {
       // Fake contact *force* data from strictly contact data. Contact point
       // is midway between the two contact points and force = normal.
       const Vector3d contact_point = (pair.p_WCa + pair.p_WCb) / 2.0;
-      write_double3(contact_point, info_message.contact_point);
-      write_double3(pair.nhat_BA_W, info_message.contact_force);
-      write_double3(pair.nhat_BA_W, info_message.normal);
+      EigenMapView(info_message.contact_point) = contact_point;
+      EigenMapView(info_message.contact_force) = pair.nhat_BA_W;
+      EigenMapView(info_message.normal) = pair.nhat_BA_W;
     }
   }
 

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -81,8 +81,8 @@ lcmt_viewer_geometry_data MakeHydroMesh(GeometryId geometry_id,
   // Saves the location and orientation of the visualization geometry in the
   // `lcmt_viewer_geometry_data` object. The location and orientation are
   // specified in the body's frame.
-  Eigen::Map<Eigen::Vector3f> position(geometry_data.position);
-  position = X_PG.translation().template cast<float>();
+  EigenMapView(geometry_data.position) =
+      X_PG.translation().template cast<float>();
   // LCM quaternion must be w, x, y, z.
   Quaterniond q(X_PG.rotation().ToQuaternion());
   geometry_data.quaternion[0] = q.w();
@@ -90,8 +90,7 @@ lcmt_viewer_geometry_data MakeHydroMesh(GeometryId geometry_id,
   geometry_data.quaternion[2] = q.y();
   geometry_data.quaternion[3] = q.z();
 
-  Eigen::Map<Eigen::Vector4f>(geometry_data.color) =
-      in_color.rgba().cast<float>();
+  EigenMapView(geometry_data.color) = in_color.rgba().cast<float>();
 
   // There are *two* ways to use the MESH geometry type. One is to set the
   // string value with a path to a parseable mesh file (see
@@ -177,8 +176,7 @@ lcmt_viewer_geometry_data MakeDeformableSurfaceMesh(
 
   geometry_data.string_data = deformable_data.name;
 
-  Eigen::Map<Eigen::Vector4f>(geometry_data.color) =
-      in_color.rgba().cast<float>();
+  EigenMapView(geometry_data.color) = in_color.rgba().cast<float>();
 
   // We can define the mesh in the float data as:
   // V | T | v0 | v1 | ... vN | t0 | t1 | ... | tM
@@ -363,8 +361,7 @@ class ShapeToLcm : public ShapeReifier {
     // Saves the location and orientation of the visualization geometry in the
     // `lcmt_viewer_geometry_data` object. The location and orientation are
     // specified in the body's frame.
-    Eigen::Map<Eigen::Vector3f> position(geometry_data_.position);
-    position = X_PG_.translation().cast<float>();
+    EigenMapView(geometry_data_.position) = X_PG_.translation().cast<float>();
     // LCM quaternion must be w, x, y, z.
     Quaterniond q(X_PG_.rotation().ToQuaternion());
     geometry_data_.quaternion[0] = q.w();
@@ -372,8 +369,8 @@ class ShapeToLcm : public ShapeReifier {
     geometry_data_.quaternion[2] = q.y();
     geometry_data_.quaternion[3] = q.z();
 
-    Eigen::Map<Eigen::Vector4f>(geometry_data_.color) =
-        in_color.rgba().cast<float>();
+    EigenMapView(geometry_data_.color) = in_color.rgba().cast<float>();
+
     return geometry_data_;
   }
 

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -283,13 +283,11 @@ class ContactResultMaker final : public LeafSystem<double> {
       surface_message.body1_name = "Id_" + to_string(surface.id_M());
       surface_message.body2_name = "Id_" + to_string(surface.id_N());
 
-      std::copy(surface.centroid().data(), surface.centroid().data() + 3,
-                surface_message.centroid_W);
-      const std::array<double, 3> fake_force{1e-2, 0, 0};
-      std::copy(fake_force.begin(), fake_force.end(),
-                surface_message.force_C_W);
-      const std::array<double, 3> moment{0, 0, 0};
-      std::copy(moment.begin(), moment.end(), surface_message.moment_C_W);
+      EigenMapView(surface_message.centroid_W) = surface.centroid();
+      const Vector3d fake_force{1e-2, 0, 0};
+      EigenMapView(surface_message.force_C_W) = fake_force;
+      const Vector3d moment{0, 0, 0};
+      EigenMapView(surface_message.moment_C_W) = moment;
 
       const int num_vertices = surface.num_vertices();
       surface_message.num_vertices = num_vertices;

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -189,12 +189,9 @@ class DummyRenderEngine : public render::RenderEngine, private ShapeReifier {
       std::vector<VectorXd> initial_positions;
       std::vector<VectorXd> initial_normals;
       for (int i = 0; i < ssize(render_meshes); ++i) {
-        VectorXd flat_positions =
-            Eigen::Map<const VectorXd>(render_meshes[i].positions.data(),
-                                       render_meshes[i].positions.size());
+        VectorXd flat_positions = EigenMapView(render_meshes[i].positions);
         initial_positions.push_back(std::move(flat_positions));
-        VectorXd flat_normals = Eigen::Map<const VectorXd>(
-            render_meshes[i].normals.data(), render_meshes[i].normals.size());
+        VectorXd flat_normals = EigenMapView(render_meshes[i].normals);
         initial_normals.push_back(std::move(flat_normals));
       }
       q_WGs_[id] = std::move(initial_positions);

--- a/multibody/meshcat/contact_visualizer.cc
+++ b/multibody/meshcat/contact_visualizer.cc
@@ -243,9 +243,7 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
 
       const std::vector<T>& field_pressures =
           contact_surface.tri_e_MN().values();
-      const VectorX<T> pressure_T =
-          Eigen::Map<const VectorX<T>, Eigen::Unaligned>(
-              field_pressures.data(), field_pressures.size());
+      const VectorX<T> pressure_T = EigenMapView(field_pressures);
       const Eigen::VectorXd pressure = ExtractDoubleOrThrow(pressure_T);
       result->emplace_back(std::move(body_A), std::move(body_B), centroid_W,
                            force_C_W, moment_C_W, vertices, faces, pressure);
@@ -275,9 +273,7 @@ void ContactVisualizer<T>::CalcHydroelasticContacts(
 
       const std::vector<T>& field_pressures =
           contact_surface.poly_e_MN().values();
-      const VectorX<T> pressure_T =
-          Eigen::Map<const VectorX<T>, Eigen::Unaligned>(
-              field_pressures.data(), field_pressures.size());
+      const VectorX<T> pressure_T = EigenMapView(field_pressures);
       const Eigen::VectorXd pressure = ExtractDoubleOrThrow(pressure_T);
 
       result->emplace_back(std::move(body_A), std::move(body_B), centroid_W,

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -579,17 +579,15 @@ TYPED_TEST(ContactResultsToLcmTest, PointPairContactOnly) {
     EXPECT_EQ(pair_message.timestamp, kTimeMicroSec);
     EXPECT_EQ(pair_message.body1_name, body_names[pair_data.bodyA_index()]);
     EXPECT_EQ(pair_message.body2_name, body_names[pair_data.bodyB_index()]);
-    // clang-format off
-    EXPECT_TRUE(CompareMatrices(
-        Vector3<double>(pair_message.contact_point),
+    EXPECT_TRUE(CompareMatrices(  // BR
+        EigenMapView(pair_message.contact_point),
         ExtractDoubleOrThrow(pair_data.contact_point())));
-    EXPECT_TRUE(CompareMatrices(
-        Vector3<double>(pair_message.contact_force),
+    EXPECT_TRUE(CompareMatrices(  // BR
+        EigenMapView(pair_message.contact_force),
         ExtractDoubleOrThrow(pair_data.contact_force())));
     EXPECT_TRUE(CompareMatrices(
-        Vector3<double>(pair_message.normal),
+        EigenMapView(pair_message.normal),
         ExtractDoubleOrThrow(pair_data.point_pair().nhat_BA_W)));
-    // clang-format on
     /* None of the rest of the pair data makes it to the message. */
   };
 
@@ -666,17 +664,15 @@ TYPED_TEST(ContactResultsToLcmTest, HydroContactOnly) {
     EXPECT_EQ(pair_message.collision_count2, name2.geometry_count);
 
     /* Mesh aggregate results: centroid, force, moment. */
-    // clang-format off
-    EXPECT_TRUE(CompareMatrices(
-        Vector3<double>(pair_message.centroid_W),
+    EXPECT_TRUE(CompareMatrices(  // BR
+        EigenMapView(pair_message.centroid_W),
         ExtractDoubleOrThrow(mesh.centroid())));
     EXPECT_TRUE(CompareMatrices(
-        Vector3<double>(pair_message.force_C_W),
+        EigenMapView(pair_message.force_C_W),
         ExtractDoubleOrThrow(pair_data.F_Ac_W().translational())));
-    EXPECT_TRUE(CompareMatrices(
-        Vector3<double>(pair_message.moment_C_W),
+    EXPECT_TRUE(CompareMatrices(  // BR
+        EigenMapView(pair_message.moment_C_W),
         ExtractDoubleOrThrow(pair_data.F_Ac_W().rotational())));
-    // clang-format on
 
     /* Compare meshes and pressure fields. */
 
@@ -714,17 +710,15 @@ TYPED_TEST(ContactResultsToLcmTest, HydroContactOnly) {
     EXPECT_EQ(pair_message.num_quadrature_points,
               mesh.num_triangles() * kNumPointPerTri);
     for (int q = 0; q < static_cast<int>(data_quads.size()); ++q) {
-      // clang-format off
-      EXPECT_TRUE(CompareMatrices(
-        Vector3<double>(message_quads[q].p_WQ),
-        ExtractDoubleOrThrow(data_quads[q].p_WQ)));
-      EXPECT_TRUE(CompareMatrices(
-        Vector3<double>(message_quads[q].vt_BqAq_W),
-        ExtractDoubleOrThrow(data_quads[q].vt_BqAq_W)));
-      EXPECT_TRUE(CompareMatrices(
-        Vector3<double>(message_quads[q].traction_Aq_W),
-        ExtractDoubleOrThrow(data_quads[q].traction_Aq_W)));
-      // clang-format on
+      EXPECT_TRUE(CompareMatrices(  // BR
+          EigenMapView(message_quads[q].p_WQ),
+          ExtractDoubleOrThrow(data_quads[q].p_WQ)));
+      EXPECT_TRUE(CompareMatrices(  // BR
+          EigenMapView(message_quads[q].vt_BqAq_W),
+          ExtractDoubleOrThrow(data_quads[q].vt_BqAq_W)));
+      EXPECT_TRUE(CompareMatrices(  // BR
+          EigenMapView(message_quads[q].traction_Aq_W),
+          ExtractDoubleOrThrow(data_quads[q].traction_Aq_W)));
     }
   };
 

--- a/multibody/rational/rational_forward_kinematics.cc
+++ b/multibody/rational/rational_forward_kinematics.cc
@@ -107,11 +107,8 @@ RationalForwardKinematics::RationalForwardKinematics(
     one_plus_s_angles_squared_(i) = symbolic::Polynomial(
         {{monomial_one, 1}, {symbolic::Monomial(s_angles_[i], 2), 1}});
   }
-  s_angle_variables_ =
-      symbolic::Variables(Eigen::Map<const VectorX<symbolic::Variable>>(
-          s_angles_.data(), s_angles_.size()));
-  s_variables_ = symbolic::Variables(
-      Eigen::Map<const VectorX<symbolic::Variable>>(s_.data(), s_.size()));
+  s_angle_variables_ = symbolic::Variables(EigenMapView(s_angles_));
+  s_variables_ = symbolic::Variables(EigenMapView(s_));
 }
 
 RationalForwardKinematics::Pose<symbolic::Polynomial>

--- a/multibody/rational/rational_forward_kinematics.h
+++ b/multibody/rational/rational_forward_kinematics.h
@@ -187,7 +187,7 @@ class RationalForwardKinematics {
   const MultibodyPlant<double>& plant() const { return plant_; }
 
   Eigen::Map<const VectorX<symbolic::Variable>> s() const {
-    return Eigen::Map<const VectorX<symbolic::Variable>>(s_.data(), s_.size());
+    return EigenMapView(s_);
   }
 
   /** map_mobilizer_to_s_index_[mobilizer_index] returns the starting index of


### PR DESCRIPTION
I've replaced a bunch of uses of longhand container-map conversion with this new sugar, but certainly haven't tried to hunt down all of them.

This arose in the context of switching to a new `lcm-gen` (#20761).  The upstream version of `lcm-gen` outputs C arrays as member fields in some cases, and we were relying on implicit decay of these to bare pointers to feed the `Eigen::Map` mumbo jumbo.  In my new `lcm_gen`, those member fields are generated as `std::array<>` types now instead of C arrays, so the decay doesn't work.  This is a feature!  Array decay is awful!  (It loses all ability to do size checking.)   I'm not 100% sure yet that I'll decide to make the breaking change to LCM message field types, but in any case (1) this helps us get ready and (2) OMG stop using array decay and all of this weird boilerplate.  The `EigenMapView` works on C arrays, std::array, std::vector, and a lot more.  It's super better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20906)
<!-- Reviewable:end -->
