### PR TITLE
[multibody] Add rpy_floating_joint as an alternate to quaternion_floating_joint

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -49,6 +49,7 @@ from pydrake.multibody.tree import (
     RigidBody,
     RigidBody_,
     RotationalInertia_,
+    RpyFloatingJoint_,
     ScopedName,
     ScrewJoint,
     ScrewJoint_,
@@ -1896,6 +1897,15 @@ class TestPlant(unittest.TestCase):
                 damping=damping,
             )
 
+        def make_rpy_floating_joint(plant, P, C):
+            return RpyFloatingJoint_[T](
+                name="rpy_floating",
+                frame_on_parent=P,
+                frame_on_child=C,
+                angular_damping=damping,
+                translational_damping=damping,
+            )
+
         def make_screw_joint(plant, P, C):
             # First, check that the no-axis overload works.
             ScrewJoint_[T](
@@ -1937,6 +1947,7 @@ class TestPlant(unittest.TestCase):
             make_prismatic_joint,
             make_quaternion_floating_joint,
             make_revolute_joint,
+            make_rpy_floating_joint,
             make_screw_joint,
             make_universal_joint,
             make_weld_joint,
@@ -2087,7 +2098,12 @@ class TestPlant(unittest.TestCase):
                 joint.get_default_pose()
                 joint.set_default_quaternion(q_FM=Quaternion_[float]())
                 joint.set_default_position(p_FM=[0, 0, 0])
+                # Check that the base class supports these for this joint.
                 joint.SetDefaultPose(X_FM=RigidTransform_[float]())
+                joint.SetDefaultPosePair(q_FM=Quaternion_[float](),
+                                         p_FM=[0, 0, 0])
+                joint.GetDefaultPose()
+                joint.GetDefaultPosePair()
             elif joint.name() == "revolute":
                 numpy_compare.assert_equal(joint.revolute_axis(), x_axis)
                 self.assertEqual(joint.damping(), damping)
@@ -2115,6 +2131,35 @@ class TestPlant(unittest.TestCase):
                 joint.AddInOneForce(
                     context=context, joint_dof=0, joint_tau=0.0, forces=forces)
                 joint.AddInDamping(context=context, forces=forces)
+            elif joint.name() == "rpy_floating":
+                self.assertEqual(joint.type_name(), "rpy_floating")
+                self.assertEqual(joint.angular_damping(), damping)
+                self.assertEqual(joint.translational_damping(), damping)
+                joint.get_angles(context=context)
+                joint.set_angles(context=context, angles=[0, 0, 0])
+                joint.SetOrientation(context=context,
+                                     R_FM=RotationMatrix_[T]())
+                joint.get_translation(context=context)
+                joint.set_translation(context=context, p_FM=[0, 0, 0])
+                joint.GetPose(context=context)
+                joint.SetPose(context=context, X_FM=RigidTransform_[T]())
+                joint.get_angular_velocity(context=context)
+                joint.set_angular_velocity(context=context, w_FM=[0, 0, 0])
+                joint.get_translational_velocity(context=context)
+                joint.set_translational_velocity(context=context,
+                                                 v_FM=[0, 0, 0])
+                joint.set_random_angles_distribution(angles=[0, 0, 0])
+                joint.set_random_translation_distribution(p_FM=[0, 0, 0])
+                joint.get_default_angles()
+                joint.set_default_angles(angles=[0, 0, 0])
+                joint.get_default_translation()
+                joint.set_default_translation(p_FM=[0, 0, 0])
+                # Check that the base class supports these for this joint.
+                joint.SetDefaultPose(X_FM=RigidTransform_[float]())
+                joint.SetDefaultPosePair(q_FM=Quaternion_[float](),
+                                         p_FM=[0, 0, 0])
+                joint.GetDefaultPose()
+                joint.GetDefaultPosePair()
             elif joint.name() == "screw":
                 self.assertEqual(joint.damping(), damping)
                 joint.damping()

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -30,6 +30,7 @@
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/revolute_spring.h"
 #include "drake/multibody/tree/rigid_body.h"
+#include "drake/multibody/tree/rpy_floating_joint.h"
 #include "drake/multibody/tree/screw_joint.h"
 #include "drake/multibody/tree/universal_joint.h"
 #include "drake/multibody/tree/weld_joint.h"
@@ -407,6 +408,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         DefineTemplateClassWithDefault<Class>(m, "Joint", param, cls_doc.doc);
     BindMultibodyElementMixin<T>(&cls);
     cls  // BR
+        .def("index", &Class::index, cls_doc.index.doc)
         .def("name", &Class::name, cls_doc.name.doc)
         .def("parent_body", &Class::parent_body, py_rvp::reference_internal,
             cls_doc.parent_body.doc)
@@ -424,6 +426,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("num_positions", &Class::num_positions, cls_doc.num_positions.doc)
         .def("num_velocities", &Class::num_velocities,
             cls_doc.num_velocities.doc)
+        .def("can_rotate", &Class::can_rotate, cls_doc.can_rotate.doc)
+        .def("can_translate", &Class::can_translate, cls_doc.can_translate.doc)
         .def("position_suffix", &Class::position_suffix,
             cls_doc.position_suffix.doc)
         .def("velocity_suffix", &Class::velocity_suffix,
@@ -462,6 +466,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.set_acceleration_limits.doc)
         .def("set_default_positions", &Class::set_default_positions,
             py::arg("default_positions"), cls_doc.set_default_positions.doc)
+        .def("SetDefaultPose", &Class::SetDefaultPose, py::arg("X_FM"),
+            cls_doc.SetDefaultPose.doc)
+        .def("SetDefaultPosePair", &Class::SetDefaultPosePair, py::arg("q_FM"),
+            py::arg("p_FM"), cls_doc.SetDefaultPosePair.doc)
+        .def("GetDefaultPose", &Class::GetDefaultPose,
+            cls_doc.GetDefaultPose.doc)
+        .def("GetDefaultPosePair", &Class::GetDefaultPosePair,
+            cls_doc.GetDefaultPosePair.doc)
         .def("Lock", &Class::Lock, py::arg("context"), cls_doc.Lock.doc)
         .def("Unlock", &Class::Unlock, py::arg("context"), cls_doc.Unlock.doc)
         .def("is_locked", &Class::is_locked, py::arg("context"),
@@ -656,9 +668,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("set_default_quaternion", &Class::set_default_quaternion,
             py::arg("q_FM"), cls_doc.set_default_quaternion.doc)
         .def("set_default_position", &Class::set_default_position,
-            py::arg("p_FM"), cls_doc.set_default_position.doc)
-        .def("SetDefaultPose", &Class::SetDefaultPose, py::arg("X_FM"),
-            cls_doc.SetDefaultPose.doc);
+            py::arg("p_FM"), cls_doc.set_default_position.doc);
   }
 
   // RevoluteJoint
@@ -710,6 +720,62 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.get_default_angle.doc)
         .def("set_default_angle", &Class::set_default_angle, py::arg("angle"),
             cls_doc.set_default_angle.doc);
+  }
+
+  // RpyFloatingJoint
+  {
+    using Class = RpyFloatingJoint<T>;
+    constexpr auto& cls_doc = doc.RpyFloatingJoint;
+    auto cls = DefineTemplateClassWithDefault<Class, Joint<T>>(
+        m, "RpyFloatingJoint", param, cls_doc.doc);
+    cls  // BR
+        .def(py::init<const string&, const Frame<T>&, const Frame<T>&, double,
+                 double>(),
+            py::arg("name"), py::arg("frame_on_parent"),
+            py::arg("frame_on_child"), py::arg("angular_damping") = 0,
+            py::arg("translational_damping") = 0, cls_doc.ctor.doc)
+        .def("angular_damping", &Class::angular_damping,
+            cls_doc.angular_damping.doc)
+        .def("translational_damping", &Class::translational_damping,
+            cls_doc.translational_damping.doc)
+        .def("get_angles", &Class::get_angles, py::arg("context"),
+            cls_doc.get_angles.doc)
+        .def("set_angles", &Class::set_angles, py::arg("context"),
+            py::arg("angles"), cls_doc.set_angles.doc)
+        .def("SetOrientation", &Class::SetOrientation, py::arg("context"),
+            py::arg("R_FM"), cls_doc.SetOrientation.doc)
+        .def("get_translation", &Class::get_translation, py::arg("context"),
+            cls_doc.get_translation.doc)
+        .def("set_translation", &Class::set_translation, py::arg("context"),
+            py::arg("p_FM"), cls_doc.set_translation.doc)
+        .def(
+            "GetPose", &Class::GetPose, py::arg("context"), cls_doc.GetPose.doc)
+        .def("SetPose", &Class::SetPose, py::arg("context"), py::arg("X_FM"),
+            cls_doc.SetPose.doc)
+        .def("get_angular_velocity", &Class::get_angular_velocity,
+            py::arg("context"), cls_doc.get_angular_velocity.doc)
+        .def("set_angular_velocity", &Class::set_angular_velocity,
+            py::arg("context"), py::arg("w_FM"),
+            cls_doc.set_angular_velocity.doc)
+        .def("get_translational_velocity", &Class::get_translational_velocity,
+            py::arg("context"), cls_doc.get_translational_velocity.doc)
+        .def("set_translational_velocity", &Class::set_translational_velocity,
+            py::arg("context"), py::arg("v_FM"),
+            cls_doc.set_translational_velocity.doc)
+        .def("set_random_angles_distribution",
+            &Class::set_random_angles_distribution, py::arg("angles"),
+            cls_doc.set_random_angles_distribution.doc)
+        .def("set_random_translation_distribution",
+            &Class::set_random_translation_distribution, py::arg("p_FM"),
+            cls_doc.set_random_translation_distribution.doc)
+        .def("get_default_angles", &Class::get_default_angles,
+            cls_doc.get_default_angles.doc)
+        .def("set_default_angles", &Class::set_default_angles,
+            py::arg("angles"), cls_doc.set_default_angles.doc)
+        .def("get_default_translation", &Class::get_default_translation,
+            cls_doc.get_default_translation.doc)
+        .def("set_default_translation", &Class::set_default_translation,
+            py::arg("p_FM"), cls_doc.set_default_translation.doc);
   }
 
   // ScrewJoint

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3139,14 +3139,16 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                                       state);
   }
 
+  // TODO(sherm1) Rename this SetFreeBodyRandomTranslationDistribution()
+
   /// Sets the distribution used by SetRandomState() to populate the free
   /// body's x-y-z `position` with respect to World.
   /// @throws std::exception if `body` is not a free body in the model.
   /// @throws std::exception if called pre-finalize.
   void SetFreeBodyRandomPositionDistribution(
       const RigidBody<T>& body, const Vector3<symbolic::Expression>& position) {
-    this->mutable_tree().SetFreeBodyRandomPositionDistributionOrThrow(body,
-                                                                      position);
+    this->mutable_tree().SetFreeBodyRandomTranslationDistributionOrThrow(
+        body, position);
   }
 
   /// Sets the distribution used by SetRandomState() to populate the free

--- a/multibody/plant/test/floating_body_test.cc
+++ b/multibody/plant/test/floating_body_test.cc
@@ -99,7 +99,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
                          3.0 * Vector3d::UnitZ())
                             .normalized();
   const math::RotationMatrixd R_WB_test(AngleAxisd(M_PI / 3.0, axis));
-  mobilizer.SetFromRotationMatrix(&context, R_WB_test);
+  mobilizer.SetOrientation(&context, R_WB_test);
   // Verify we get the right quaternion.
   const Quaterniond q_WB_test = mobilizer.get_quaternion(context);
   const Quaterniond q_WB_test_expected = R_WB_test.ToQuaternion();
@@ -114,8 +114,8 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
                               q_WB_test2.coeffs(), kEpsilon,
                               MatrixCompareType::relative));
   const Vector3d p_WB_test(1, 2, 3);
-  mobilizer.set_position(&context, p_WB_test);
-  EXPECT_TRUE(CompareMatrices(mobilizer.get_position(context), p_WB_test,
+  mobilizer.set_translation(&context, p_WB_test);
+  EXPECT_TRUE(CompareMatrices(mobilizer.get_translation(context), p_WB_test,
                               kEpsilon, MatrixCompareType::relative));
 
   // Reset state to that initially set by
@@ -130,8 +130,9 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
   EXPECT_TRUE(CompareMatrices(mobilizer.get_quaternion(context).coeffs(),
                               Quaterniond::Identity().coeffs(), kEpsilon,
                               MatrixCompareType::relative));
-  EXPECT_TRUE(CompareMatrices(mobilizer.get_position(context), Vector3d::Zero(),
-                              kEpsilon, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(mobilizer.get_translation(context),
+                              Vector3d::Zero(), kEpsilon,
+                              MatrixCompareType::relative));
 
   EXPECT_EQ(context.num_continuous_states(), 13);
 

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -117,6 +117,7 @@ drake_cc_library(
         "revolute_spring.cc",
         "rigid_body.cc",
         "rpy_ball_mobilizer.cc",
+        "rpy_floating_joint.cc",
         "rpy_floating_mobilizer.cc",
         "screw_joint.cc",
         "screw_mobilizer.cc",
@@ -163,6 +164,7 @@ drake_cc_library(
         "revolute_spring.h",
         "rigid_body.h",
         "rpy_ball_mobilizer.h",
+        "rpy_floating_joint.h",
         "rpy_floating_mobilizer.h",
         "screw_joint.h",
         "screw_mobilizer.h",
@@ -672,6 +674,15 @@ drake_cc_googletest(
     name = "quaternion_floating_joint_test",
     deps = [
         ":tree",
+        "//common/test_utilities:expect_no_throw",
+    ],
+)
+
+drake_cc_googletest(
+    name = "rpy_floating_joint_test",
+    deps = [
+        ":tree",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
     ],
 )

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -279,9 +279,6 @@ class BallRpyJoint final : public Joint<T> {
   template <typename ToScalar>
   std::unique_ptr<Joint<ToScalar>> TemplatedDoCloneToScalar(
       const internal::MultibodyTree<ToScalar>& tree_clone) const;
-
-  // This joint's damping constant in N⋅m⋅s.
-  double damping_{0};
 };
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1040,7 +1040,7 @@ class MultibodyTree {
       const systems::Context<T>& context, systems::State<T>* state) const;
 
   // See MultibodyPlant::SetFreeBodyRandomPositionDistribution.
-  void SetFreeBodyRandomPositionDistributionOrThrow(
+  void SetFreeBodyRandomTranslationDistributionOrThrow(
       const RigidBody<T>& body,
       const Vector3<symbolic::Expression>& position);
 

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -127,28 +127,32 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// frame M in the inboard frame F. Refer to the documentation for this class
   /// for details.
   /// @param[in] context
-  ///   The context of the model this joint belongs to.
-  /// @returns The quaternion representing the orientation of frame M in F.
+  ///   A Context for the MultibodyPlant this joint belongs to.
+  /// @retval q_FM The quaternion representing the orientation of frame M in F.
   Quaternion<T> get_quaternion(const systems::Context<T>& context) const {
     return get_mobilizer().get_quaternion(context);
   }
+
+  // TODO(sherm1) Rename this get_translation()
 
   /// Returns the position `p_FM` of the outboard frame M's origin as measured
   /// and expressed in the inboard frame F. Refer to the documentation for this
   /// class for details.
   /// @param[in] context
-  ///   The context of the model this joint belongs to.
-  /// @returns The position vector of frame M's origin in frame F.
+  ///   A Context for the MultibodyPlant this joint belongs to.
+  /// @retval p_FM The position vector of frame M's origin in frame F.
   Vector3<T> get_position(const systems::Context<T>& context) const {
-    return get_mobilizer().get_position(context);
+    return get_mobilizer().get_translation(context);
   }
+
+  // TODO(sherm1) Rename this GetPose()
 
   /// Returns the pose `X_FM` of the outboard frame M as measured and expressed
   /// in the inboard frame F. Refer to the documentation for this class for
   /// details.
   /// @param[in] context
-  ///   The context of the model this joint belongs to.
-  /// @returns The pose of frame M in frame F.
+  ///   A Context for the MultibodyPlant this joint belongs to.
+  /// @retval X_FM The pose of frame M in frame F.
   math::RigidTransform<T> get_pose(const systems::Context<T>& context) const {
     return math::RigidTransform<T>(get_quaternion(context),
                                    get_position(context));
@@ -157,7 +161,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// Retrieves from `context` the angular velocity `w_FM` of the child frame
   /// M in the parent frame F, expressed in F.
   /// @param[in] context
-  ///   The context of the model this joint belongs to.
+  ///   A Context for the MultibodyPlant this joint belongs to.
   /// @retval w_FM
   ///   A vector in ℝ³ with the angular velocity of the child frame M in the
   ///   parent frame F, expressed in F. Refer to this class's documentation for
@@ -170,7 +174,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// the child frame M's origin as measured and expressed in the parent frame
   /// F.
   /// @param[in] context
-  ///   The context of the model this joint belongs to.
+  ///   A Context for the MultibodyPlant this joint belongs to.
   /// @retval v_FM
   ///   A vector in ℝ³ with the translational velocity of the origin of child
   ///   frame M in the parent frame F, expressed in F. Refer to this class's
@@ -188,7 +192,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// Sets `context` so that the orientation of frame M in F is given by the
   /// input quaternion `q_FM`.
   /// @param[out] context
-  ///   The context of the model this joint belongs to.
+  ///   A Context for the MultibodyPlant this joint belongs to.
   /// @param[in] q_FM
   ///   The desired orientation of M in F to be stored in `context`.
   /// @returns a constant reference to `this` joint.
@@ -198,48 +202,48 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return *this;
   }
 
-  // Sets `context` so this Joint's orientation is consistent with the given
-  // `R_FM` rotation matrix.
-  // @param[in] context
-  ///   The context of the model this joint belongs to.
-  // @param[in] R_FM
-  //   The rotation matrix relating the orientation of frame F and frame M.
-  // @returns a constant reference to `this` joint.
-  // @note: To create a RotationMatrix R_FM (which is inherently orthonormal)
-  // from a non-orthonormal Matrix3<T> m (e.g., m is approximate data), use
-  // R_FM = math::RotationMatrix<T>::ProjectToRotationMatrix( m ).
-  // Alternatively, set this joint's orientation with the two statements:
-  // const Eigen::Quaternion<T> q_FM = RotationMatrix<T>::ToQuaternion( m );
-  // set_quaternion(context, q_FM);
+  // TODO(sherm1) Rename this SetOrientation()
+
+  /// Sets `context` so this Joint's orientation is consistent with the given
+  /// `R_FM` rotation matrix.
+  /// @param[in] context
+  ///   A Context for the MultibodyPlant this joint belongs to.
+  /// @param[in] R_FM
+  ///   The rotation matrix relating the orientation of frame F and frame M.
+  /// @returns a constant reference to `this` joint.
   const QuaternionFloatingJoint<T>& SetFromRotationMatrix(
       systems::Context<T>* context, const math::RotationMatrix<T>& R_FM) const {
-    get_mobilizer().SetFromRotationMatrix(context, R_FM);
+    get_mobilizer().SetOrientation(context, R_FM);
     return *this;
   }
+
+  // TODO(sherm1) Rename this set_translation()
 
   /// Sets `context` to store the position `p_FM` of frame M's origin `Mo`
   /// measured and expressed in frame F.
   /// @param[out] context
-  ///   The context of the model this joint belongs to.
+  ///   A Context for the MultibodyPlant this joint belongs to.
   /// @param[in] p_FM
   ///   The desired position of frame M in F to be stored in `context`.
   /// @returns a constant reference to `this` joint.
   const QuaternionFloatingJoint<T>& set_position(systems::Context<T>* context,
                                                  const Vector3<T>& p_FM) const {
-    get_mobilizer().set_position(context, p_FM);
+    get_mobilizer().set_translation(context, p_FM);
     return *this;
   }
+
+  // TODO(sherm1) Rename this SetPose()
 
   /// Sets `context` to store `X_FM` the pose of frame M measured and expressed
   /// in frame F.
   /// @param[out] context
-  ///   The context of the model this joint belongs to.
+  ///   A Context for the MultibodyPlant this joint belongs to.
   /// @param[in] X_FM
   ///   The desired pose of frame M in F to be stored in `context`.
   /// @returns a constant reference to `this` joint.
   const QuaternionFloatingJoint<T>& set_pose(
       systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const {
-    get_mobilizer().set_position(context, X_FM.translation());
+    get_mobilizer().set_translation(context, X_FM.translation());
     get_mobilizer().set_quaternion(context, X_FM.rotation().ToQuaternion());
     return *this;
   }
@@ -247,7 +251,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// Sets in `context` the state for `this` joint so that the angular velocity
   /// of the child frame M in the parent frame F is `w_FM`.
   /// @param[out] context
-  ///   The context of the model this joint belongs to.
+  ///   A Context for the MultibodyPlant this joint belongs to.
   /// @param[in] w_FM
   ///   A vector in ℝ³ with the angular velocity of the child frame M in the
   ///   parent frame F, expressed in F. Refer to this class's documentation for
@@ -262,7 +266,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// Sets in `context` the state for `this` joint so that the translational
   /// velocity of the child frame M's origin in the parent frame F is `v_FM`.
   /// @param[out] context
-  ///   The context of the model this joint belongs to.
+  ///   A Context for the MultibodyPlant this joint belongs to.
   /// @param[in] w_FM
   ///   A vector in ℝ³ with the translational velocity of the child frame M's
   ///   origin in the parent frame F, expressed in F. Refer to this class's
@@ -277,18 +281,25 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @}
 
   /// @name Random distribution setters
+  /// @{
 
-  /// Sets the random distribution that positions of this joint will be randomly
-  /// sampled from. See get_position() for details on the position
-  /// representation.
+  // TODO(sherm1) Rename this set_random_translation_distribution()
+
+  /// Sets the random distribution that translation of this joint will be
+  /// randomly sampled from. If a quaternion distribution has already been
+  /// set with stochastic variables, it will remain so. Otherwise the quaternion
+  /// will be set to this joint's zero configuration. See get_position() for
+  /// details on the position representation.
   void set_random_position_distribution(
       const Vector3<symbolic::Expression>& p_FM) {
-    get_mutable_mobilizer()->set_random_position_distribution(p_FM);
+    get_mutable_mobilizer()->set_random_translation_distribution(p_FM);
   }
 
   /// (Advanced) Sets the random distribution that the orientation of this joint
-  /// will be randomly sampled from. See get_quaternion() for details on the
-  /// orientation representation.
+  /// will be randomly sampled from. If a translation (position) distribution
+  /// has already been set with stochastic variables, it will remain so.
+  /// Otherwise translation will be set to this joint's zero configuration.
+  /// See get_quaternion() for details on the orientation representation.
   /// @note Use caution when setting a quaternion distribution. A naive uniform
   /// sampling of each component will not lead to a uniform sampling of the unit
   /// sphere. See `set_random_quaternion_distribution_to_uniform()` for the most
@@ -319,11 +330,16 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return Quaternion<double>(q_FM[0], q_FM[1], q_FM[2], q_FM[3]);
   }
 
+  // TODO(sherm1) Rename this get_default_translation()
+
   /// Gets the default position `p_FM` for `this` joint.
   /// @returns The default position `p_FM` of `this` joint.
   Vector3<double> get_default_position() const {
     return this->default_positions().template tail<3>();
   }
+
+  // TODO(sherm1) Deprecate this and remove it since the base class
+  //  now provides GetDefaultPose().
 
   /// Gets the default pose `X_FM` for `this` joint.
   /// @returns The default pose `X_FM` of `this` joint.
@@ -351,6 +367,8 @@ class QuaternionFloatingJoint final : public Joint<T> {
     this->set_default_positions(default_positions);
   }
 
+  // TODO(sherm1) Rename this set_default_translation()
+
   /// Sets the default position `p_FM` of this joint.
   /// @param[in] p_FM
   ///   The desired default position of the joint.
@@ -359,21 +377,6 @@ class QuaternionFloatingJoint final : public Joint<T> {
     default_positions.template tail<3>() = p_FM;
     this->set_default_positions(default_positions);
   }
-
-  /// Sets the default pose `X_FM` of this joint.
-  /// @param[in] X_FM
-  ///   The desired default pose of the joint.
-  void SetDefaultPose(const math::RigidTransform<double>& X_FM) {
-    Vector<double, 7> default_positions;
-    const Quaternion<double> q_FM = X_FM.rotation().ToQuaternion();
-    default_positions[0] = q_FM.w();
-    default_positions[1] = q_FM.x();
-    default_positions[2] = q_FM.y();
-    default_positions[3] = q_FM.z();
-    default_positions.template tail<3>() = X_FM.translation();
-    this->set_default_positions(default_positions);
-  }
-
   /// @}
 
  protected:
@@ -420,6 +423,20 @@ class QuaternionFloatingJoint final : public Joint<T> {
     if (this->has_implementation()) {
       get_mutable_mobilizer()->set_default_position(default_positions);
     }
+  }
+
+  void DoSetDefaultPosePair(const Quaternion<double>& q_FM,
+                            const Vector3<double>& p_FM) final {
+    VectorX<double> q(7);
+    q << q_FM.w(), q_FM.vec(), p_FM;
+    this->set_default_positions(q);
+  }
+
+  std::pair<Eigen::Quaternion<double>, Vector3<double>>
+  DoGetDefaultPosePair() const final {
+    const VectorX<double>& q = this->default_positions();
+    return std::make_pair(Eigen::Quaternion<double>(q[0], q[1], q[2], q[3]),
+                          q.tail<3>());
   }
 
   // Joint<T> overrides:

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -73,7 +73,7 @@ Quaternion<T> QuaternionFloatingMobilizer<T>::get_quaternion(
 }
 
 template <typename T>
-Vector3<T> QuaternionFloatingMobilizer<T>::get_position(
+Vector3<T> QuaternionFloatingMobilizer<T>::get_translation(
     const systems::Context<T>& context) const {
   const auto q = this->get_positions(context);
   DRAKE_ASSERT(q.size() == kNq);
@@ -108,18 +108,18 @@ QuaternionFloatingMobilizer<T>::set_quaternion(
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-QuaternionFloatingMobilizer<T>::set_position(systems::Context<T>* context,
-                                             const Vector3<T>& p_FM) const {
+QuaternionFloatingMobilizer<T>::set_translation(systems::Context<T>* context,
+                                                const Vector3<T>& p_FM) const {
   DRAKE_DEMAND(context != nullptr);
-  set_position(*context, p_FM, &context->get_mutable_state());
+  set_translation(*context, p_FM, &context->get_mutable_state());
   return *this;
 }
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-QuaternionFloatingMobilizer<T>::set_position(const systems::Context<T>&,
-                                             const Vector3<T>& p_FM,
-                                             systems::State<T>* state) const {
+QuaternionFloatingMobilizer<T>::set_translation(
+    const systems::Context<T>&, const Vector3<T>& p_FM,
+    systems::State<T>* state) const {
   DRAKE_DEMAND(state != nullptr);
   auto q = this->get_mutable_positions(&*state);
   DRAKE_ASSERT(q.size() == kNq);
@@ -129,15 +129,15 @@ QuaternionFloatingMobilizer<T>::set_position(const systems::Context<T>&,
 }
 
 template <typename T>
-void QuaternionFloatingMobilizer<T>::set_random_position_distribution(
-    const Vector3<symbolic::Expression>& position) {
+void QuaternionFloatingMobilizer<T>::set_random_translation_distribution(
+    const Vector3<symbolic::Expression>& p_FM) {
   Vector<symbolic::Expression, kNq> positions;
   if (this->get_random_state_distribution()) {
     positions = this->get_random_state_distribution()->template head<kNq>();
   } else {
     positions = get_zero_position().template cast<symbolic::Expression>();
   }
-  positions.template segment<3>(4) = position;
+  positions.template segment<3>(4) = p_FM;
   MobilizerBase::set_random_position_distribution(positions);
 }
 

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -46,9 +46,9 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
                 const Frame<T>& outboard_frame_M) :
       MobilizerBase(inboard_frame_F, outboard_frame_M) {}
 
-  bool is_floating() const override { return true; }
+  bool is_floating() const final { return true; }
 
-  bool has_quaternion_dofs() const override { return true; }
+  bool has_quaternion_dofs() const final { return true; }
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
@@ -79,7 +79,7 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   //   belongs to.
   // @retval p_FM
   //   The position vector of frame M's origin in frame F.
-  Vector3<T> get_position(const systems::Context<T>& context) const;
+  Vector3<T> get_translation(const systems::Context<T>& context) const;
 
   // Sets `context` so that the orientation of frame M in F is given by the
   // input quaternion `q_FM`.
@@ -111,18 +111,18 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   // @param[in] p_FM
   //   The desired position of frame M in F to be stored in `context`.
   // @returns a constant reference to `this` mobilizer.
-  const QuaternionFloatingMobilizer<T>& set_position(
+  const QuaternionFloatingMobilizer<T>& set_translation(
       systems::Context<T>* context, const Vector3<T>& p_FM) const;
 
-  // Alternative signature to set_position(context, p_FM) to set `state` to
+  // Alternative signature to set_translation(context, p_FM) to set `state` to
   // store the position `p_FM` of M in F.
-  const QuaternionFloatingMobilizer<T>& set_position(
+  const QuaternionFloatingMobilizer<T>& set_translation(
       const systems::Context<T>& context, const Vector3<T>& p_FM,
       systems::State<T>* state) const;
 
   // Sets the distribution governing the random samples of the position
   // component of the mobilizer state.
-  void set_random_position_distribution(const Vector3<symbolic::Expression>&
+  void set_random_translation_distribution(const Vector3<symbolic::Expression>&
       position);
 
   // Sets `context` so this mobilizer's generalized coordinates (its quaternion
@@ -132,7 +132,7 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   // @param[in] R_FM
   //   The rotation matrix relating the orientation of frame F and frame M.
   // @returns a constant reference to `this` mobilizer.
-  const QuaternionFloatingMobilizer<T>& SetFromRotationMatrix(
+  const QuaternionFloatingMobilizer<T>& SetOrientation(
       systems::Context<T>* context, const math::RotationMatrix<T>& R_FM) const {
     const Eigen::Quaternion<T> q_FM = R_FM.ToQuaternion();
     return set_quaternion(context, q_FM);
@@ -193,38 +193,38 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   // Refer to the Mobilizer class documentation for details.
   // @{
   math::RigidTransform<T> CalcAcrossMobilizerTransform(
-      const systems::Context<T>& context) const override;
+      const systems::Context<T>& context) const final;
 
   SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(
       const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v) const override;
+      const Eigen::Ref<const VectorX<T>>& v) const final;
 
   SpatialAcceleration<T> CalcAcrossMobilizerSpatialAcceleration(
       const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& vdot) const override;
+      const Eigen::Ref<const VectorX<T>>& vdot) const final;
 
   void ProjectSpatialForce(
       const systems::Context<T>& context,
       const SpatialForce<T>& F_Mo_F,
-      Eigen::Ref<VectorX<T>> tau) const override;
+      Eigen::Ref<VectorX<T>> tau) const final;
 
-  bool is_velocity_equal_to_qdot() const override { return false; }
+  bool is_velocity_equal_to_qdot() const final { return false; }
 
   void MapVelocityToQDot(
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> qdot) const override;
+      EigenPtr<VectorX<T>> qdot) const final;
 
   void MapQDotToVelocity(
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& qdot,
-      EigenPtr<VectorX<T>> v) const override;
+      EigenPtr<VectorX<T>> v) const final;
   // @}
 
  protected:
   // Sets `state` to store a configuration in which M coincides with F (i.e.
   // q_FM is the identity quaternion).
-  Vector<double, 7> get_zero_position() const override;
+  Vector<double, 7> get_zero_position() const final;
 
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
@@ -233,13 +233,13 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
-      const MultibodyTree<double>& tree_clone) const override;
+      const MultibodyTree<double>& tree_clone) const final;
 
   std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
-      const MultibodyTree<AutoDiffXd>& tree_clone) const override;
+      const MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
   std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
-      const MultibodyTree<symbolic::Expression>& tree_clone) const override;
+      const MultibodyTree<symbolic::Expression>& tree_clone) const final;
 
  private:
   typedef MobilizerImpl<T, 7, 6> MobilizerBase;

--- a/multibody/tree/rpy_floating_joint.cc
+++ b/multibody/tree/rpy_floating_joint.cc
@@ -1,0 +1,78 @@
+#include "drake/multibody/tree/rpy_floating_joint.h"
+
+#include <memory>
+#include <stdexcept>
+
+#include "drake/multibody/tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+const std::string& RpyFloatingJoint<T>::type_name() const {
+  static const never_destroyed<std::string> name{kTypeName};
+  return name.access();
+}
+
+template <typename T>
+template <typename ToScalar>
+std::unique_ptr<Joint<ToScalar>> RpyFloatingJoint<T>::TemplatedDoCloneToScalar(
+    const internal::MultibodyTree<ToScalar>& tree_clone) const {
+  const Frame<ToScalar>& frame_on_parent_body_clone =
+      tree_clone.get_variant(this->frame_on_parent());
+  const Frame<ToScalar>& frame_on_child_body_clone =
+      tree_clone.get_variant(this->frame_on_child());
+
+  // Make the Joint<T> clone.
+  auto joint_clone = std::make_unique<RpyFloatingJoint<ToScalar>>(
+      this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
+      this->angular_damping(), this->translational_damping());
+  joint_clone->set_position_limits(this->position_lower_limits(),
+                                   this->position_upper_limits());
+  joint_clone->set_velocity_limits(this->velocity_lower_limits(),
+                                   this->velocity_upper_limits());
+  joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
+                                       this->acceleration_upper_limits());
+  joint_clone->set_default_positions(this->default_positions());
+
+  return joint_clone;
+}
+
+template <typename T>
+std::unique_ptr<Joint<double>> RpyFloatingJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<double>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<AutoDiffXd>> RpyFloatingJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<AutoDiffXd>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<symbolic::Expression>>
+RpyFloatingJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+// N.B. Due to esoteric linking errors on Mac (see #9345) involving
+// `MobilizerImpl`, we must place this implementation in the source file, not
+// in the header file.
+template <typename T>
+std::unique_ptr<typename Joint<T>::BluePrint>
+RpyFloatingJoint<T>::MakeImplementationBlueprint() const {
+  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
+  auto mobilizer = std::make_unique<internal::RpyFloatingMobilizer<T>>(
+      this->frame_on_parent(), this->frame_on_child());
+  mobilizer->set_default_position(this->default_positions());
+  blue_print->mobilizer = std::move(mobilizer);
+  return blue_print;
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::RpyFloatingJoint)

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -1,0 +1,470 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/joint.h"
+#include "drake/multibody/tree/multibody_forces.h"
+#include "drake/multibody/tree/rpy_floating_mobilizer.h"
+
+namespace drake {
+namespace multibody {
+
+/** This Joint allows a rigid body to move freely with respect to its parent
+rigid body. This is most commonly used to allow a body to move freely with
+respect to the World, but can be used with any parent. More precisely, given a
+frame F attached to the parent body P and a frame M attached to the child body
+B (see the Joint class's documentation), this joint allows frame M to translate
+and rotate freely with respect to F, introducing six degrees of freedom.
+However, unlike the QuaternionFloatingJoint, the orientation of M relative to
+F is parameterized with roll-pitch-yaw angles (see warning below). The
+generalized coordinates q for this joint are the three orientation angles
+followed by three generalized positions to describe the translation of frame
+M's origin Mo in F with a position vector `p_FM`. As generalized velocities, we
+use the angular velocity `w_FM` of frame M in F (_not_ the orientation angle
+time derivatives q̇) and the linear velocity `v_FM` of frame M's origin Mo in
+frame F.
+
+@warning Any three-parameter representation of orientation necessarily has a
+singularity somewhere. In this case, the singularity occurs when the pitch angle
+(second generalized coordinate q) is at π/2 + kπ (for any integer k), and
+numerical issues may occur when near one of those configurations. If you can't
+be sure your simulation will avoid the singularities, consider using the
+singularity-free QuaternionFloatingJoint instead.
+
+@tparam_default_scalar */
+template <typename T>
+class RpyFloatingJoint final : public Joint<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RpyFloatingJoint)
+
+  template <typename Scalar>
+  using Context = systems::Context<Scalar>;
+
+  /// The name for this Joint type.  It resolves to "rpy_floating".
+  static const char kTypeName[];
+
+  /** Constructor to create an rpy floating joint between two bodies so that
+  frame F attached to the parent body P and frame M attached to the child body
+  B move freely relative to one another. See this class's documentation for
+  further details on the definition of these frames and the generalized
+  positions q and generalized velocities v for this joint. This constructor
+  signature creates a joint with no joint limits, i.e. the joint position,
+  velocity and acceleration limits are the pair `(-∞, ∞)`. These can be set
+  using the Joint methods set_position_limits(), set_velocity_limits() and
+  set_acceleration_limits().
+
+  The first three arguments to this constructor are those of the Joint class
+  constructor. See the Joint class's documentation for details. The additional
+  parameters are:
+  @param[in] angular_damping
+    Viscous damping coefficient in N⋅m⋅s for the angular component of this
+    joint's velocity, used to model losses within the joint. See documentation
+    of angular_damping() for details on modeling of the damping force.
+  @param[in] translational_damping
+    Viscous damping coefficient in N⋅s/m for the translational component of
+    this joint's velocity, used to model losses within the joint. See
+    documentation of translational_damping() for details on modeling of the
+    damping force.
+  @throws std::exception if angular_damping is negative.
+  @throws std::exception if translational_damping is negative. */
+  RpyFloatingJoint(const std::string& name, const Frame<T>& frame_on_parent,
+                   const Frame<T>& frame_on_child, double angular_damping = 0.0,
+                   double translational_damping = 0.0)
+      : Joint<T>(name, frame_on_parent, frame_on_child,
+                 (Vector6d() << angular_damping, angular_damping,
+                  angular_damping, translational_damping, translational_damping,
+                  translational_damping)
+                     .finished(),
+                 Vector6d::Constant(-std::numeric_limits<double>::infinity()),
+                 Vector6d::Constant(std::numeric_limits<double>::infinity()),
+                 Vector6d::Constant(-std::numeric_limits<double>::infinity()),
+                 Vector6d::Constant(std::numeric_limits<double>::infinity()),
+                 Vector6d::Constant(-std::numeric_limits<double>::infinity()),
+                 Vector6d::Constant(std::numeric_limits<double>::infinity())) {
+    DRAKE_THROW_UNLESS(angular_damping >= 0);
+    DRAKE_THROW_UNLESS(translational_damping >= 0);
+    // Parent constructor sets all default positions to zero which is correct
+    // for this joint.
+  }
+
+  /** Returns the name of this joint type: "rpy_floating" */
+  const std::string& type_name() const final;
+
+  /** Returns this joint's angular damping constant in N⋅m⋅s. The damping
+  torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion, with
+  ω the angular velocity of frame M in F (see get_angular_velocity()) and τ
+  the torque on child body B (to which M is rigidly attached). */
+  double angular_damping() const {
+    // N.B. All 3 angular damping coefficients are set to the same value for
+    // this joint.
+    return this->damping_vector()[0];
+  }
+
+  /** Returns this joint's translational damping constant in N⋅s/m. The
+  damping force (in N) is modeled as `f = -damping⋅v` i.e. opposing motion,
+  with v the translational velocity of frame M in F (see
+  get_translational_velocity()) and f the force on child body B at Mo. */
+  double translational_damping() const {
+    // N.B. All 3 translational damping coefficients are set to the same value
+    // for this joint.
+    return this->damping_vector()[3];
+  }
+
+  /** @name Context-dependent value access
+  Functions in this section are given a Context and either get from it, or
+  set in it, quantities relevant to this %RpyFloatingJoint. These functions can
+  only be called after MultibodyPlant::Finalize(). */
+  /**@{*/
+
+  /** Gets the roll-pitch-yaw rotation angles of this joint from `context`.
+
+  The orientation `R_FM` of the child frame M in parent frame F is
+  parameterized with roll-pitch-yaw angles (also known as space-fixed
+  x-y-z Euler angles and extrinsic angles). That is, the angles θr, θp, θy,
+  correspond to a sequence of rotations about the Fx, Fy, and Fz axes of
+  parent frame F, respectively. Mathematically, rotation `R_FM` is given in
+  terms of angles θr, θp, θy by: <pre>
+    R_FM(q) = Rz(θy) * Ry(θp) * Rx(θr)
+  </pre>
+  where `Rx(θ)`, `Ry(θ)` and `Rz(θ)` correspond to the elemental rotations in
+  amount of θ about the Fx, Fy and Fz axes respectively. Zero θr, θp, θy angles
+  corresponds to frames F and M having the same orientation (their origins may
+  still be separated). Angles θr, θp, θy are defined to be positive according
+  to the right-hand-rule with the thumb aligned in the direction of their
+  respective axes.
+
+  @note Space `x-y-z` angles (extrinsic) are equivalent to Body `z-y-x`
+  angles (intrinsic).
+
+  @param[in] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @retval angles The angle coordinates of this joint stored in the `context`
+    ordered as θr, θp, θy. */
+  Vector3<T> get_angles(const Context<T>& context) const {
+    return get_mobilizer().get_angles(context);
+  }
+
+  /** Sets the `context` so that the generalized coordinates corresponding to
+  the roll-pitch-yaw rotation angles of this joint equals `angles`.
+  @param[in] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @param[in] angles
+    Angles in radians to be stored in `context` ordered as θr, θp, θy.
+  @warning See class documentation for discussion of singular configurations.
+  @returns a constant reference to this joint.
+  @see get_angles() for details */
+  const RpyFloatingJoint<T>& set_angles(Context<T>* context,
+                                        const Vector3<T>& angles) const {
+    get_mobilizer().set_angles(context, angles);
+    return *this;
+  }
+
+  /** Sets the roll-pitch-yaw angles in `context` so this Joint's orientation
+  is consistent with the given `R_FM` rotation matrix.
+  @param[in] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @param[in] R_FM
+    The rotation matrix giving the orientation of frame M in frame F.
+  @warning See class documentation for discussion of singular configurations.
+  @returns a constant reference to this joint. */
+  const RpyFloatingJoint<T>& SetOrientation(
+      systems::Context<T>* context, const math::RotationMatrix<T>& R_FM) const {
+    set_angles(context, math::RollPitchYaw(R_FM).vector());
+    return *this;
+  }
+
+  /** Returns the translation (position vector) `p_FM` of the child frame M's
+  origin Mo as measured and expressed in the parent frame F. Refer to the
+  class documentation for details.
+  @param[in] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @retval p_FM The position vector of frame M's origin in frame F. */
+  Vector3<T> get_translation(const systems::Context<T>& context) const {
+    return get_mobilizer().get_translation(context);
+  }
+
+  /** Sets `context` to store the translation (position vector) `p_FM` of frame
+  M's origin Mo measured and expressed in frame F.
+  @param[out] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @param[in] p_FM
+    The desired position of frame M's origin in frame F, to be stored in
+    `context`.
+  @returns a constant reference to this joint. */
+  const RpyFloatingJoint<T>& set_translation(systems::Context<T>* context,
+                                             const Vector3<T>& p_FM) const {
+    get_mobilizer().set_translation(context, p_FM);
+    return *this;
+  }
+
+  /** Returns the pose `X_FM` of the outboard frame M as measured and expressed
+  in the inboard frame F. Refer to the documentation for this class for
+  details.
+  @param[in] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @retval X_FM The pose of frame M in frame F. */
+  math::RigidTransform<T> GetPose(const systems::Context<T>& context) const {
+    return math::RigidTransform<T>(math::RollPitchYaw<T>(get_angles(context)),
+                                   get_translation(context));
+  }
+
+  /** Sets `context` to store `X_FM` the pose of frame M measured and expressed
+  in frame F.
+  @param[out] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @param[in] X_FM
+    The desired pose of frame M in F to be stored in `context`.
+  @warning See class documentation for discussion of singular configurations.
+  @returns a constant reference to `this` joint. */
+  const RpyFloatingJoint<T>& SetPose(
+      systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const {
+    const math::RotationMatrix<T>& R_FM = X_FM.rotation();
+    get_mobilizer().set_angles(context, math::RollPitchYaw<T>(R_FM).vector());
+    get_mobilizer().set_translation(context, X_FM.translation());
+    return *this;
+  }
+
+  /** Retrieves from `context` the angular velocity `w_FM` of the child frame
+  M in the parent frame F, expressed in F.
+
+  @param[in] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @retval w_FM
+    A vector in ℝ³ with the angular velocity of the child frame M in the
+    parent frame F, expressed in F. Refer to this class's documentation for
+    further details and definitions of these frames. */
+  Vector3<T> get_angular_velocity(const systems::Context<T>& context) const {
+    return get_mobilizer().get_angular_velocity(context);
+  }
+
+  /** Sets in `context` the state for this joint so that the angular velocity
+  of the child frame M in the parent frame F is `w_FM`.
+  @param[out] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @param[in] w_FM
+    A vector in ℝ³ with the angular velocity of the child frame M in the
+    parent frame F, expressed in F. Refer to this class's documentation for
+    further details and definitions of these frames.
+  @returns a constant reference to this joint. */
+  const RpyFloatingJoint<T>& set_angular_velocity(
+      systems::Context<T>* context, const Vector3<T>& w_FM) const {
+    get_mobilizer().set_angular_velocity(context, w_FM);
+    return *this;
+  }
+
+  /** Retrieves from `context` the translational velocity `v_FM` of
+  the child frame M's origin as measured and expressed in the parent frame F.
+  @param[in] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @retval v_FM
+    A vector in ℝ³ with the translational velocity of the origin of child
+    frame M in the parent frame F, expressed in F. Refer to this class's
+    documentation for further details and definitions of these frames. */
+  Vector3<T> get_translational_velocity(
+      const systems::Context<T>& context) const {
+    return get_mobilizer().get_translational_velocity(context);
+  }
+
+  /** Sets in `context` the state for this joint so that the translational
+  velocity of the child frame M's origin in the parent frame F is `v_FM`.
+  @param[out] context
+    A Context for the MultibodyPlant this joint belongs to.
+  @param[in] v_FM
+    A vector in ℝ³ with the translational velocity of the child frame M's
+    origin in the parent frame F, expressed in F. Refer to this class's
+    documentation for further details and definitions of these frames.
+  @returns a constant reference to this joint. */
+  const RpyFloatingJoint<T>& set_translational_velocity(
+      systems::Context<T>* context, const Vector3<T>& v_FM) const {
+    get_mobilizer().set_translational_velocity(context, v_FM);
+    return *this;
+  }
+  /**@}*/
+
+  /** @name Random distribution setters
+  These functions can only be called after MultibodyPlant::Finalize(). */
+  /**@{*/
+
+  /** Sets the random distribution from which the roll-pitch-yaw orientation
+  angles of this joint will be randomly sampled. See the %RpyFloatingJoint class
+  documentation for details on the orientation representation. If a translation
+  distribution has already been set with stochastic variables, it will remain
+  so. Otherwise translation will be set to this joint's zero configuration.
+  @warning Watch for random pitch angles near the singular configuration for
+    this joint (see class documentation). */
+  void set_random_angles_distribution(
+      const Vector3<symbolic::Expression>& angles) {
+    get_mutable_mobilizer().set_random_angles_distribution(angles);
+  }
+
+  /** Sets the random distribution that the translation vector of this joint
+  will be randomly sampled from. See the %RpyFloatingJoint class documentation
+  for details on the translation representation. If an angles distribution has
+  has already been set with stochastic variables, it will remain so. Otherwise
+  angles will be set to this joint's zero configuration. */
+  void set_random_translation_distribution(
+      const Vector3<symbolic::Expression>& p_FM) {
+    get_mutable_mobilizer().set_random_translation_distribution(p_FM);
+  }
+  /**@}*/
+
+  /** @name Default pose access
+  Functions in this section set or get the default values for the pose states q
+  (rpy angles and translation vector) of this %RpyFloatingJoint. These are
+  stored directly in the joint rather than in a Context and are used to
+  initialize Contexts. Note that the default velocities v are always zero. */
+  /**@{*/
+
+  /** Gets the default angles for this joint.
+  @retval angles The default roll-pitch-yaw angles as a Vector3. */
+  Vector3<double> get_default_angles() const {
+    return this->default_positions().template head<3>();
+  }
+
+  /** Sets the default roll-pitch-yaw angles of this joint.
+  @param[in] angles the desired default angles of the joint
+  @warning See class documentation for discussion of singular configurations. */
+  void set_default_angles(const Vector3<double>& angles) {
+    VectorX<double> default_positions = this->default_positions();
+    default_positions.template head<3>() = angles;
+    this->set_default_positions(default_positions);
+  }
+
+  /** Gets the default translation (position vector) `p_FM` for this joint.
+  @retval p_FM The default translation of this joint. */
+  Vector3<double> get_default_translation() const {
+    return this->default_positions().template tail<3>();
+  }
+
+  /** Sets the default translation (position vector) `p_FM` of this joint.
+  @param[in] p_FM The desired default translation of the joint. */
+  void set_default_translation(const Vector3<double>& p_FM) {
+    VectorX<double> default_positions = this->default_positions();
+    default_positions.template tail<3>() = p_FM;
+    this->set_default_positions(default_positions);
+  }
+  /**@}*/
+
+ protected:
+  /** Joint<T> override called through public NVI, Joint::AddInForce().
+  Adding forces per-dof for this joint is not supported. Therefore, this method
+  throws an exception if invoked. */
+  void DoAddInOneForce(const systems::Context<T>&, int, const T&,
+                       MultibodyForces<T>*) const final {
+    throw std::logic_error(
+        "RpyFloating joints do not allow applying forces to individual "
+        "degrees of freedom.");
+  }
+
+  /** Joint<T> override called through public NVI, Joint::AddInDamping().
+  Therefore arguments were already checked to be valid. This method adds into
+  `forces` a dissipative torque according to the viscous law `τ = -d⋅ω`, with
+  d the damping coefficient (see damping()). */
+  void DoAddInDamping(const systems::Context<T>& context,
+                      MultibodyForces<T>* forces) const final {
+    Eigen::Ref<VectorX<T>> t_BMo_F =
+        get_mobilizer().get_mutable_generalized_forces_from_array(
+            &forces->mutable_generalized_forces());
+    const Vector3<T>& w_FM = get_angular_velocity(context);
+    t_BMo_F = -angular_damping() * w_FM;
+  }
+
+ private:
+  int do_get_velocity_start() const final {
+    return get_mobilizer().velocity_start_in_v();
+  }
+
+  int do_get_num_velocities() const final { return 6; }
+
+  int do_get_position_start() const final {
+    return get_mobilizer().position_start_in_q();
+  }
+
+  int do_get_num_positions() const final { return 6; }
+
+  std::string do_get_position_suffix(int index) const final {
+    return get_mobilizer().position_suffix(index);
+  }
+
+  std::string do_get_velocity_suffix(int index) const final {
+    return get_mobilizer().velocity_suffix(index);
+  }
+
+  void do_set_default_positions(
+      const VectorX<double>& default_positions) final {
+    if (this->has_implementation()) {
+      get_mutable_mobilizer().set_default_position(default_positions);
+    }
+  }
+
+  void DoSetDefaultPosePair(const Quaternion<double>& q_FM,
+                            const Vector3<double>& p_FM) final {
+    const math::RollPitchYaw<double> rpy_FM(q_FM);
+    VectorX<double> q(6);
+    q << rpy_FM.vector(), p_FM;
+    this->set_default_positions(q);
+  }
+
+  std::pair<Eigen::Quaternion<double>, Vector3<double>> DoGetDefaultPosePair()
+      const final {
+    const VectorX<double>& q = this->default_positions();
+    const math::RollPitchYaw<double> rpy_FM(q.head<3>());
+    return std::make_pair(rpy_FM.ToQuaternion(), q.tail<3>());
+  }
+
+  // Joint<T> overrides:
+  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
+      const final;
+
+  std::unique_ptr<Joint<double>> DoCloneToScalar(
+      const internal::MultibodyTree<double>& tree_clone) const final;
+
+  std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
+
+  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const final;
+
+  // Make RpyFloatingJoint templated on every other scalar type a friend of
+  // RpyFloatingJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
+  // private members of RpyFloatingJoint<T>.
+  template <typename>
+  friend class RpyFloatingJoint;
+
+  // Returns the mobilizer implementing this joint.
+  const internal::RpyFloatingMobilizer<T>& get_mobilizer() const {
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
+    const auto* mobilizer =
+        dynamic_cast<const internal::RpyFloatingMobilizer<T>*>(
+            this->get_implementation().mobilizer);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return *mobilizer;
+  }
+
+  internal::RpyFloatingMobilizer<T>& get_mutable_mobilizer() {
+    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
+    auto* mobilizer = dynamic_cast<internal::RpyFloatingMobilizer<T>*>(
+        this->get_implementation().mobilizer);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return *mobilizer;
+  }
+
+  // Helper method to make a clone templated on ToScalar.
+  template <typename ToScalar>
+  std::unique_ptr<Joint<ToScalar>> TemplatedDoCloneToScalar(
+      const internal::MultibodyTree<ToScalar>& tree_clone) const;
+};
+
+template <typename T>
+const char RpyFloatingJoint<T>::kTypeName[] = "rpy_floating";
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::RpyFloatingJoint)

--- a/multibody/tree/rpy_floating_mobilizer.cc
+++ b/multibody/tree/rpy_floating_mobilizer.cc
@@ -137,6 +137,32 @@ RpyFloatingMobilizer<T>::SetFromRigidTransform(
 }
 
 template <typename T>
+void RpyFloatingMobilizer<T>::set_random_angles_distribution(
+    const Vector3<symbolic::Expression>& angles) {
+  Vector<symbolic::Expression, 6> q;
+  if (this->get_random_state_distribution()) {
+    q = this->get_random_state_distribution()->template head<6>();
+  } else {
+    q = this->get_zero_position().template cast<symbolic::Expression>();
+  }
+  q.template head<3>() = angles;
+  MobilizerBase::set_random_position_distribution(q);
+}
+
+template <typename T>
+void RpyFloatingMobilizer<T>::set_random_translation_distribution(
+    const Vector3<symbolic::Expression>& p_FM) {
+  Vector<symbolic::Expression, 6> q;
+  if (this->get_random_state_distribution()) {
+    q = this->get_random_state_distribution()->template head<6>();
+  } else {
+    q = this->get_zero_position().template cast<symbolic::Expression>();
+  }
+  q.template tail<3>() = p_FM;
+  MobilizerBase::set_random_position_distribution(q);
+}
+
+template <typename T>
 math::RigidTransform<T>
 RpyFloatingMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>& context) const {

--- a/multibody/tree/rpy_floating_mobilizer.h
+++ b/multibody/tree/rpy_floating_mobilizer.h
@@ -165,6 +165,16 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   const RpyFloatingMobilizer<T>& set_translation(
       systems::Context<T>* context, const Vector3<T>& p_FM) const;
 
+  // Sets the distribution governing the random samples of the rpy angles
+  // component of the mobilizer state.
+  void set_random_angles_distribution(
+      const Vector3<symbolic::Expression>& angles);
+
+  // Sets the distribution governing the random samples of the translation
+  // component of the mobilizer state.
+  void set_random_translation_distribution(
+      const Vector3<symbolic::Expression>& p_FM);
+
   // Sets in context the state for this mobilizer so that the angular
   // velocity of the outboard frame M in the inboard frame F is w_FM.
   // @param[in,out] context

--- a/multibody/tree/test/rpy_floating_joint_test.cc
+++ b/multibody/tree/test/rpy_floating_joint_test.cc
@@ -1,25 +1,26 @@
-#include "drake/multibody/tree/quaternion_floating_joint.h"
+// clang-format: off
+#include "drake/multibody/tree/multibody_tree-inl.h"
+// clang-format: on
 
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
-#include "drake/math/quaternion.h"
-#include "drake/multibody/tree/multibody_tree-inl.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/multibody/tree/rigid_body.h"
+#include "drake/multibody/tree/rpy_floating_joint.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace multibody {
 namespace {
 
-const double kTolerance = std::numeric_limits<double>::epsilon();
+const double kTolerance = 4 * std::numeric_limits<double>::epsilon();
 
 using Eigen::Vector3d;
 using math::RigidTransformd;
+using math::RollPitchYawd;
 using math::RotationMatrixd;
 using systems::Context;
-
-using Vector7d = Vector<double, 7>;
 
 constexpr double kPositionLowerLimit = -1.0;
 constexpr double kPositionUpperLimit = 1.5;
@@ -32,9 +33,9 @@ constexpr double kTranslationalDamping = 4;
 constexpr double kPositionNonZeroDefault =
     (kPositionLowerLimit + kPositionUpperLimit) / 2;
 
-class QuaternionFloatingJointTest : public ::testing::Test {
+class RpyFloatingJointTest : public ::testing::Test {
  public:
-  // Creates a MultibodyTree model of a single free body.
+  // Creates a MultibodyTree model of a spherical pendulum.
   void SetUp() override {
     // Spatial inertia for adding bodies. The actual value is not important for
     // these tests and therefore we do not initialize it.
@@ -43,19 +44,19 @@ class QuaternionFloatingJointTest : public ::testing::Test {
     // Create an empty model.
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
-    // Add a body so we can add a joint between world and body:
+    // Add some bodies so we can add joints between them:
     body_ = &model->AddRigidBody("Body", M_B);
 
-    // Add a quaternion floating joint between the world and body:
-    joint_ = &model->AddJoint<QuaternionFloatingJoint>(
+    // Add a ball rpy joint between the world and body:
+    joint_ = &model->AddJoint<RpyFloatingJoint>(
         "Joint", model->world_body(), std::nullopt, *body_, std::nullopt,
         kAngularDamping, kTranslationalDamping);
-    mutable_joint_ = dynamic_cast<QuaternionFloatingJoint<double>*>(
+    mutable_joint_ = dynamic_cast<RpyFloatingJoint<double>*>(
         &model->get_mutable_joint(joint_->index()));
     DRAKE_DEMAND(mutable_joint_ != nullptr);
     mutable_joint_->set_position_limits(
-        Vector7d::Constant(kPositionLowerLimit),
-        Vector7d::Constant(kPositionUpperLimit));
+        Vector6d::Constant(kPositionLowerLimit),
+        Vector6d::Constant(kPositionUpperLimit));
     mutable_joint_->set_velocity_limits(
         Vector6d::Constant(kVelocityLowerLimit),
         Vector6d::Constant(kVelocityUpperLimit));
@@ -79,37 +80,37 @@ class QuaternionFloatingJointTest : public ::testing::Test {
   std::unique_ptr<Context<double>> context_;
 
   const RigidBody<double>* body_{nullptr};
-  const QuaternionFloatingJoint<double>* joint_{nullptr};
-  QuaternionFloatingJoint<double>* mutable_joint_{nullptr};
+  const RpyFloatingJoint<double>* joint_{nullptr};
+  RpyFloatingJoint<double>* mutable_joint_{nullptr};
 };
 
-TEST_F(QuaternionFloatingJointTest, Type) {
+TEST_F(RpyFloatingJointTest, Type) {
   const Joint<double>& base = *joint_;
-  EXPECT_EQ(base.type_name(), QuaternionFloatingJoint<double>::kTypeName);
+  EXPECT_EQ(base.type_name(), RpyFloatingJoint<double>::kTypeName);
 }
 
 // Verify the expected number of dofs.
-TEST_F(QuaternionFloatingJointTest, NumDOFs) {
-  EXPECT_EQ(tree().num_positions(), 7);
+TEST_F(RpyFloatingJointTest, NumDOFs) {
+  EXPECT_EQ(tree().num_positions(), 6);
   EXPECT_EQ(tree().num_velocities(), 6);
-  EXPECT_EQ(joint_->num_positions(), 7);
+  EXPECT_EQ(joint_->num_positions(), 6);
   EXPECT_EQ(joint_->num_velocities(), 6);
   EXPECT_EQ(joint_->position_start(), 0);
   EXPECT_EQ(joint_->velocity_start(), 0);
 }
 
-TEST_F(QuaternionFloatingJointTest, GetJointLimits) {
-  EXPECT_EQ(joint_->position_lower_limits().size(), 7);
-  EXPECT_EQ(joint_->position_upper_limits().size(), 7);
+TEST_F(RpyFloatingJointTest, GetJointLimits) {
+  EXPECT_EQ(joint_->position_lower_limits().size(), 6);
+  EXPECT_EQ(joint_->position_upper_limits().size(), 6);
   EXPECT_EQ(joint_->velocity_lower_limits().size(), 6);
   EXPECT_EQ(joint_->velocity_upper_limits().size(), 6);
   EXPECT_EQ(joint_->acceleration_lower_limits().size(), 6);
   EXPECT_EQ(joint_->acceleration_upper_limits().size(), 6);
 
   EXPECT_EQ(joint_->position_lower_limits(),
-            (Vector7d::Constant(kPositionLowerLimit)));
+            Vector6d::Constant(kPositionLowerLimit));
   EXPECT_EQ(joint_->position_upper_limits(),
-            (Vector7d::Constant(kPositionUpperLimit)));
+            Vector6d::Constant(kPositionUpperLimit));
   EXPECT_EQ(joint_->velocity_lower_limits(),
             Vector6d::Constant(kVelocityLowerLimit));
   EXPECT_EQ(joint_->velocity_upper_limits(),
@@ -120,7 +121,7 @@ TEST_F(QuaternionFloatingJointTest, GetJointLimits) {
             Vector6d::Constant(kAccelerationUpperLimit));
 }
 
-TEST_F(QuaternionFloatingJointTest, Damping) {
+TEST_F(RpyFloatingJointTest, Damping) {
   EXPECT_EQ(joint_->angular_damping(), kAngularDamping);
   EXPECT_EQ(joint_->translational_damping(), kTranslationalDamping);
   EXPECT_EQ(
@@ -131,34 +132,36 @@ TEST_F(QuaternionFloatingJointTest, Damping) {
 }
 
 // Context-dependent value access.
-TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
-  const Vector3d position(1., 2., 3.);
+TEST_F(RpyFloatingJointTest, ContextDependentAccess) {
+  const Vector3d angles_A(M_PI_2, 0., 1.);
+  const Vector3d angles_B(0.25, 0.5, M_PI_2);
+  const Vector3d translation(1., 2., 3.);
   const Vector3d angular_velocity(0.5, 0.5, 0.5);
   const Vector3d translational_velocity(0.1, 0.2, 0.3);
-  Quaternion<double> quaternion_A(1., 2., 3., 4.);
-  Quaternion<double> quaternion_B(5., 6., 7., 8.);
-  quaternion_A.normalize();
-  quaternion_B.normalize();
-  const RigidTransformd transform_A(quaternion_A, position);
-  const RotationMatrixd rotation_matrix_B(quaternion_B);
+  const RotationMatrixd rotation_matrix_A =
+      RotationMatrixd(RollPitchYawd(angles_A));
+  const RotationMatrixd rotation_matrix_B =
+      RotationMatrixd(RollPitchYawd(angles_B));
+  const RigidTransformd transform_A(rotation_matrix_A, translation);
 
-  // Position access:
-  joint_->set_quaternion(context_.get(), quaternion_A);
-  EXPECT_EQ(joint_->get_quaternion(*context_).coeffs(), quaternion_A.coeffs());
+  // Pose access:
+  joint_->set_angles(context_.get(), angles_A);
+  EXPECT_EQ(joint_->get_angles(*context_), angles_A);
 
-  joint_->SetFromRotationMatrix(context_.get(), rotation_matrix_B);
-  EXPECT_TRUE(math::AreQuaternionsEqualForOrientation(
-      joint_->get_quaternion(*context_), quaternion_B, kTolerance));
+  joint_->SetOrientation(context_.get(), rotation_matrix_B);
+  EXPECT_TRUE(
+      CompareMatrices(joint_->get_angles(*context_), angles_B, kTolerance));
 
-  joint_->set_position(context_.get(), position);
-  EXPECT_EQ(joint_->get_position(*context_), position);
+  joint_->set_translation(context_.get(), translation);
+  EXPECT_EQ(joint_->get_translation(*context_), translation);
 
-  joint_->set_position(context_.get(), Vector3d::Zero());  // Zero out pose.
-  joint_->set_pose(context_.get(), transform_A);
-  // We expect a bit of roundoff error due to transforming between quaternion
+  joint_->set_angles(context_.get(), Vector3d::Zero());  // Zero out pose.
+  joint_->set_translation(context_.get(), Vector3d::Zero());
+  joint_->SetPose(context_.get(), transform_A);
+  // We expect a bit of roundoff error due to transforming between rpy
   // and rotation matrix representations.
   EXPECT_TRUE(
-      joint_->get_pose(*context_).IsNearlyEqualTo(transform_A, kTolerance));
+      joint_->GetPose(*context_).IsNearlyEqualTo(transform_A, kTolerance));
 
   // Angular velocity access:
   joint_->set_angular_velocity(context_.get(), angular_velocity);
@@ -169,22 +172,22 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
 
   // Joint locking.
   joint_->Lock(context_.get());
-  EXPECT_EQ(joint_->get_angular_velocity(*context_), Vector3d::Zero());
+  EXPECT_EQ(joint_->get_angular_velocity(*context_), Vector3d(0., 0., 0.));
   EXPECT_EQ(joint_->get_translational_velocity(*context_), Vector3d::Zero());
 }
 
 // Tests API to apply torques to joint.
-TEST_F(QuaternionFloatingJointTest, AddInOneForce) {
+TEST_F(RpyFloatingJointTest, AddInOneForce) {
   const double some_value = M_PI_2;
   MultibodyForces<double> forces(tree());
 
-  // Since adding forces to individual degrees of freedom of this joint does
-  // not make physical sense, this method should throw.
+  // Since adding forces to individual degrees of freedom of this joint is
+  // not supported, this method should throw.
   EXPECT_THROW(joint_->AddInOneForce(*context_, 0, some_value, &forces),
                std::exception);
 }
 
-TEST_F(QuaternionFloatingJointTest, Clone) {
+TEST_F(RpyFloatingJointTest, Clone) {
   auto model_clone = tree().CloneToScalar<AutoDiffXd>();
   const auto& joint_clone = model_clone->get_variant(*joint_);
 
@@ -208,12 +211,12 @@ TEST_F(QuaternionFloatingJointTest, Clone) {
   EXPECT_EQ(joint_clone.angular_damping(), joint_->angular_damping());
   EXPECT_EQ(joint_clone.translational_damping(),
             joint_->translational_damping());
-  EXPECT_EQ(joint_clone.get_default_quaternion().coeffs(),
-            joint_->get_default_quaternion().coeffs());
-  EXPECT_EQ(joint_clone.get_default_position(), joint_->get_default_position());
+  EXPECT_EQ(joint_clone.get_default_angles(), joint_->get_default_angles());
+  EXPECT_EQ(joint_clone.get_default_translation(),
+            joint_->get_default_translation());
 }
 
-TEST_F(QuaternionFloatingJointTest, SetVelocityAndAccelerationLimits) {
+TEST_F(RpyFloatingJointTest, SetVelocityAndAccelerationLimits) {
   const double new_lower = -0.2;
   const double new_upper = 0.2;
   // Check for velocity limits.
@@ -222,16 +225,16 @@ TEST_F(QuaternionFloatingJointTest, SetVelocityAndAccelerationLimits) {
   EXPECT_EQ(joint_->velocity_lower_limits(), Vector6d::Constant(new_lower));
   EXPECT_EQ(joint_->velocity_upper_limits(), Vector6d::Constant(new_upper));
   // Does not match num_velocities().
-  EXPECT_THROW(mutable_joint_->set_velocity_limits(VectorX<double>(3),
+  EXPECT_THROW(mutable_joint_->set_velocity_limits(VectorX<double>(6),
                                                    VectorX<double>()),
-               std::runtime_error);
+               std::exception);
   EXPECT_THROW(mutable_joint_->set_velocity_limits(VectorX<double>(),
-                                                   VectorX<double>(3)),
-               std::runtime_error);
+                                                   VectorX<double>(6)),
+               std::exception);
   // Lower limit is larger than upper limit.
   EXPECT_THROW(mutable_joint_->set_velocity_limits(Vector6d::Constant(2),
                                                    Vector6d::Constant(0)),
-               std::runtime_error);
+               std::exception);
 
   // Check for acceleration limits.
   mutable_joint_->set_acceleration_limits(Vector6d::Constant(new_lower),
@@ -239,31 +242,30 @@ TEST_F(QuaternionFloatingJointTest, SetVelocityAndAccelerationLimits) {
   EXPECT_EQ(joint_->acceleration_lower_limits(), Vector6d::Constant(new_lower));
   EXPECT_EQ(joint_->acceleration_upper_limits(), Vector6d::Constant(new_upper));
   // Does not match num_velocities().
-  EXPECT_THROW(mutable_joint_->set_acceleration_limits(VectorX<double>(3),
+  EXPECT_THROW(mutable_joint_->set_acceleration_limits(VectorX<double>(6),
                                                        VectorX<double>()),
-               std::runtime_error);
+               std::exception);
   EXPECT_THROW(mutable_joint_->set_acceleration_limits(VectorX<double>(),
-                                                       VectorX<double>(3)),
-               std::runtime_error);
+                                                       VectorX<double>(6)),
+               std::exception);
   // Lower limit is larger than upper limit.
   EXPECT_THROW(mutable_joint_->set_acceleration_limits(Vector6d::Constant(2),
                                                        Vector6d::Constant(0)),
-               std::runtime_error);
+               std::exception);
 }
 
-TEST_F(QuaternionFloatingJointTest, CanRotateOrTranslate) {
+TEST_F(RpyFloatingJointTest, CanRotateOrTranslate) {
   EXPECT_TRUE(joint_->can_rotate());
   EXPECT_TRUE(joint_->can_translate());
 }
 
-TEST_F(QuaternionFloatingJointTest, NameSuffix) {
-  EXPECT_EQ(joint_->position_suffix(0), "qw");
-  EXPECT_EQ(joint_->position_suffix(1), "qx");
-  EXPECT_EQ(joint_->position_suffix(2), "qy");
-  EXPECT_EQ(joint_->position_suffix(3), "qz");
-  EXPECT_EQ(joint_->position_suffix(4), "x");
-  EXPECT_EQ(joint_->position_suffix(5), "y");
-  EXPECT_EQ(joint_->position_suffix(6), "z");
+TEST_F(RpyFloatingJointTest, NameSuffix) {
+  EXPECT_EQ(joint_->position_suffix(0), "qx");
+  EXPECT_EQ(joint_->position_suffix(1), "qy");
+  EXPECT_EQ(joint_->position_suffix(2), "qz");
+  EXPECT_EQ(joint_->position_suffix(3), "x");
+  EXPECT_EQ(joint_->position_suffix(4), "y");
+  EXPECT_EQ(joint_->position_suffix(5), "z");
   EXPECT_EQ(joint_->velocity_suffix(0), "wx");
   EXPECT_EQ(joint_->velocity_suffix(1), "wy");
   EXPECT_EQ(joint_->velocity_suffix(2), "wz");
@@ -272,74 +274,72 @@ TEST_F(QuaternionFloatingJointTest, NameSuffix) {
   EXPECT_EQ(joint_->velocity_suffix(5), "vz");
 }
 
-TEST_F(QuaternionFloatingJointTest, DefaultAngles) {
-  const Vector7d lower_limit_angles = Vector7d::Constant(kPositionLowerLimit);
-  const Vector7d upper_limit_angles = Vector7d::Constant(kPositionUpperLimit);
+TEST_F(RpyFloatingJointTest, DefaultAnglesAndTranslation) {
+  const Vector3d lower_limit_angles = Vector3d::Constant(kPositionLowerLimit);
+  const Vector3d upper_limit_angles = Vector3d::Constant(kPositionUpperLimit);
 
-  const Vector7d default_angles = Vector7d::Identity();
+  const Vector3d default_angles = Vector3d::Zero();
 
-  const Vector7d new_default_angles =
-      Vector7d::Constant(kPositionNonZeroDefault);
+  const Vector3d new_default_angles =
+      Vector3d::Constant(kPositionNonZeroDefault);
 
-  const Vector7d out_of_bounds_low_angles =
-      lower_limit_angles - Vector7d::Constant(1);
-  const Vector7d out_of_bounds_high_angles =
-      upper_limit_angles + Vector7d::Constant(1);
+  const Vector3d out_of_bounds_low_angles =
+      lower_limit_angles - Vector3d::Constant(1);
+  const Vector3d out_of_bounds_high_angles =
+      upper_limit_angles + Vector3d::Constant(1);
 
   // Constructor should set the default angle to Vector3d::Zero()
-  EXPECT_EQ(joint_->default_positions(), default_angles);
+  EXPECT_EQ(joint_->get_default_angles(), default_angles);
 
   // Setting a new default angle should propagate so that `get_default_angle()`
   // remains correct.
-  mutable_joint_->set_default_positions(new_default_angles);
-  EXPECT_EQ(joint_->default_positions(), new_default_angles);
+  mutable_joint_->set_default_angles(new_default_angles);
+  EXPECT_EQ(joint_->get_default_angles(), new_default_angles);
 
   // Setting the default angle out of the bounds of the position limits
   // should NOT throw an exception
+  EXPECT_NO_THROW(mutable_joint_->set_default_angles(out_of_bounds_low_angles));
   EXPECT_NO_THROW(
-      mutable_joint_->set_default_positions(out_of_bounds_low_angles));
-  EXPECT_NO_THROW(
-      mutable_joint_->set_default_positions(out_of_bounds_high_angles));
+      mutable_joint_->set_default_angles(out_of_bounds_high_angles));
+
+  EXPECT_EQ(joint_->get_default_translation(), Vector3d::Zero());
+  mutable_joint_->set_default_translation(Vector3d(1.0, 2.0, 3.0));
+  EXPECT_EQ(joint_->get_default_translation(), Vector3d(1.0, 2.0, 3.0));
+
+  EXPECT_TRUE(joint_->GetDefaultPose().IsNearlyEqualTo(
+      RigidTransformd(RollPitchYawd(joint_->get_default_angles()),
+                      joint_->get_default_translation()),
+      kTolerance));
 }
 
-TEST_F(QuaternionFloatingJointTest, RandomState) {
+TEST_F(RpyFloatingJointTest, RandomState) {
   RandomGenerator generator;
   std::uniform_real_distribution<symbolic::Expression> uniform;
+  Eigen::Matrix<symbolic::Expression, 3, 1> zero_3(0.0, 0.0, 0.0);
 
   // Default behavior is to set to zero.
-  tree().SetRandomState(*context_, &context_->get_mutable_state(),
-                           &generator);
-  EXPECT_TRUE(joint_->get_pose(*context_).IsExactlyIdentity());
-  // Set the position distribution to arbitrary values.
-  Eigen::Matrix<symbolic::Expression, 3, 1> position_distribution;
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
+  EXPECT_TRUE(joint_->GetPose(*context_).IsExactlyIdentity());
+  // Set the angles & translation distribution to arbitrary values.
+  Eigen::Matrix<symbolic::Expression, 3, 1> angles_distribution;
+  Eigen::Matrix<symbolic::Expression, 3, 1> translation_distribution;
   for (int i = 0; i < 3; i++) {
-    position_distribution[i] = uniform(generator) + i + 1.0;
+    angles_distribution[i] = 0.0125 * (uniform(generator) + i + 1.0);
+    translation_distribution[i] = uniform(generator) + i + 1.0;
   }
 
-  mutable_joint_->set_random_quaternion_distribution(
-      math::UniformlyRandomQuaternion<symbolic::Expression>(&generator));
-  mutable_joint_->set_random_position_distribution(position_distribution);
-  tree().SetRandomState(*context_, &context_->get_mutable_state(),
-                           &generator);
+  mutable_joint_->set_random_angles_distribution(angles_distribution);
+  mutable_joint_->set_random_translation_distribution(translation_distribution);
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
   // We expect arbitrary non-zero values for the random state.
-  EXPECT_FALSE(joint_->get_pose(*context_).IsExactlyIdentity());
+  EXPECT_FALSE(joint_->GetPose(*context_).IsExactlyIdentity());
 
   // Set position and quaternion distributions back to 0.
-  mutable_joint_->set_random_quaternion_distribution(
-      Eigen::Quaternion<symbolic::Expression>::Identity());
-  mutable_joint_->set_random_position_distribution(
-      Eigen::Matrix<symbolic::Expression, 3, 1>::Zero());
-  tree().SetRandomState(*context_, &context_->get_mutable_state(),
-                           &generator);
+  mutable_joint_->set_random_angles_distribution(zero_3);
+  mutable_joint_->set_random_translation_distribution(zero_3);
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
   // We expect zero values for pose.
-  EXPECT_TRUE(joint_->get_pose(*context_).IsExactlyIdentity());
-
-  // Set the quaternion distribution using built in uniform sampling.
-  mutable_joint_->set_random_quaternion_distribution_to_uniform();
-  tree().SetRandomState(*context_, &context_->get_mutable_state(),
-                           &generator);
-  // We expect arbitrary non-zero pose.
-  EXPECT_FALSE(joint_->get_pose(*context_).IsExactlyIdentity());
+  EXPECT_TRUE(joint_->GetPose(*context_).IsExactlyIdentity());
 }
 
 }  // namespace


### PR DESCRIPTION
Adds RpyFloatingJoint for use in MultibodyPlant. This joint blends the features of BallRpyJoint and QuaternionFloatingJoint. The new joint is implemented using the existing RpyFloatingMobilizer.

This PR also generalizes the notion of a floating joint since there are now two kinds. Previously MbP assumed that if a body was floating it must be on a QuaternionFloatingJoint; that's no longer true. I added SetDefaultPose() and GetDefaultPose() to the Joint base class so that we don't need to know what kind of floating joint we've got.

This PR deals only in adding the new joint as an MbP API as needed for #20225 (new topology code). It does not attempt to make it accessible through the various file formats. See issue #19165.

There are also some minor cleanups in QuaternionFloatingJoint docs for compatibility between it and the new joint.

The API for RpyFloatingJoint is improved from QuaternionFloatingJoint but at the cost of consistency. Please see issue #20942 for the remediation plan.

Resolves #14949
Replaces WIP PR #19065

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20912)
<!-- Reviewable:end -->
