### PR TITLE
Don't install as build step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,7 +543,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   )
 endif()
 
-set(BAZEL_INSTALL_ARGS "${CMAKE_INSTALL_PREFIX}")
+set(BAZEL_INSTALL_ARGS "\${CMAKE_INSTALL_PREFIX}")
 
 if(CMAKE_COLOR_MAKEFILE)
   list(INSERT BAZEL_INSTALL_ARGS 0 "--color")
@@ -588,29 +588,6 @@ configure_file(cmake/bazel.rc.in drake_build_cwd/.bazelrc @ONLY)
 configure_file(cmake/WORKSPACE.in drake_build_cwd/WORKSPACE.bazel @ONLY)
 file(CREATE_LINK "${PROJECT_SOURCE_DIR}/.bazeliskrc" drake_build_cwd/.bazeliskrc SYMBOLIC)
 
-include(ExternalProject)
-
-ExternalProject_Add(drake_cxx_python
-  SOURCE_DIR "${PROJECT_SOURCE_DIR}"
-  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/drake_build_cwd"
-  CONFIGURE_COMMAND
-    "${Bazel_EXECUTABLE}"
-    info --announce_rc
-  BUILD_COMMAND
-    "${Bazel_EXECUTABLE}"
-    build
-    ${BAZEL_INSTALL_TARGET}
-  BUILD_ALWAYS ON
-  INSTALL_COMMAND
-    "${Bazel_EXECUTABLE}"
-    run
-    ${BAZEL_INSTALL_TARGET}
-    --
-    ${BAZEL_INSTALL_ARGS}
-  USES_TERMINAL_BUILD ON
-  USES_TERMINAL_INSTALL ON
-)
-
 set(GIT_DIR "${PROJECT_SOURCE_DIR}/.git")
 set(GIT_REVISION HEAD)
 
@@ -632,5 +609,26 @@ endif()
 string(TIMESTAMP BUILD_TIMESTAMP "%Y%m%d%H%M%S")
 
 configure_file(tools/install/libdrake/VERSION.TXT.in VERSION.TXT @ONLY)
+
+execute_process(
+  COMMAND "${Bazel_EXECUTABLE}" info --announce_rc
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/drake_build_cwd"
+)
+
+add_custom_target(drake_cxx_python ALL
+  COMMAND "${Bazel_EXECUTABLE}" build ${BAZEL_INSTALL_TARGET}
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/drake_build_cwd"
+  USES_TERMINAL
+)
+
+install(CODE
+  "execute_process(
+    COMMAND
+      \"${Bazel_EXECUTABLE}\" run ${BAZEL_INSTALL_TARGET}
+      -- ${BAZEL_INSTALL_ARGS}
+    WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}/drake_build_cwd\"
+  )"
+  ALL_COMPONENTS
+)
 
 install(FILES "${PROJECT_BINARY_DIR}/VERSION.TXT" DESTINATION share/doc/drake)


### PR DESCRIPTION
Rip out use of ExternalProject to drive the build, as we aren't doing anything that really benefits from it. Move the install logic to `install(CODE)` so that it happens via `make install` (or the equivalent), rather than as part of the build (e.g. `make`). Similarly, move the call that announces build information to the configure stage.

Fixes #20908.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20916)
<!-- Reviewable:end -->
