### PR TITLE
Improve iiwa 7 effort and velocity limits

### DIFF
--- a/manipulation/models/iiwa_description/README.md
+++ b/manipulation/models/iiwa_description/README.md
@@ -33,7 +33,28 @@ manually.
 Limits have been added to the xacro files, and then manually merged into the
 hand-edited files.
 
-### Velocity and Effort Limits
+### Velocity and Effort Limits for IIWA 7
+
+Velocity and effort limits were derived from the third table at page 1 of the
+followking KUKA brochure:
+
+* "KUKA LBR iiwa technical data. (URL:
+<https://www.reeco.co.uk/wp-content/uploads/2020/05/KUKA-LBR-iiwa-technical-data.pdf>
+, Accessed on 2024-02-09)
+
+For the record, the velocity and effort limits:
+
+|Axis data  |Max. Torque|Max. Velocity|
+|-----------|----------:|------------:|
+|Axis 1 (A1)|176 Nm     |98 deg/s     |
+|Axis 2 (A2)|176 Nm     |98 deg/s     |
+|Axis 3 (A3)|110 Nm     |100 deg/s    |
+|Axis 4 (A4)|110 Nm     |130 deg/s    |
+|Axis 5 (A5)|110 Nm     |140 deg/s    |
+|Axis 6 (A6)|40 Nm      |180 deg/s    |
+|Axis 7 (A7)|40 Nm      |180 deg/s    |
+
+### Velocity and Effort Limits for IIWA 14
 
 Velocity and effort limits were derived from the third table at page 30 of the
 followking KUKA brochure:

--- a/manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf
+++ b/manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf
@@ -62,8 +62,8 @@
         <limit>
           <lower>-2.96706</lower>
           <upper>2.96706</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>176</effort>
+          <velocity>1.7104226670</velocity>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -110,8 +110,8 @@
         <limit>
           <lower>-2.0944</lower>
           <upper>2.0944</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>176</effort>
+          <velocity>1.7104226670</velocity>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -158,8 +158,8 @@
         <limit>
           <lower>-2.96706</lower>
           <upper>2.96706</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>110</effort>
+          <velocity>1.7453292520</velocity>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -206,8 +206,8 @@
         <limit>
           <lower>-2.0944</lower>
           <upper>2.0944</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>110</effort>
+          <velocity>2.2689280276</velocity>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -254,8 +254,8 @@
         <limit>
           <lower>-2.96706</lower>
           <upper>2.96706</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>110</effort>
+          <velocity>2.4434609528</velocity>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -303,8 +303,8 @@
         <limit>
           <lower>-2.0944</lower>
           <upper>2.0944</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>40</effort>
+          <velocity>3.1415926536</velocity>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -351,8 +351,8 @@
         <limit>
           <lower>-3.05433</lower>
           <upper>3.05433</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>40</effort>
+          <velocity>3.1415926536</velocity>
         </limit>
         <dynamics>
           <damping>0.0</damping>

--- a/manipulation/models/iiwa_description/iiwa7/iiwa7_with_box_collision.sdf
+++ b/manipulation/models/iiwa_description/iiwa7/iiwa7_with_box_collision.sdf
@@ -76,8 +76,8 @@
         <limit>
           <lower>-2.96706</lower>
           <upper>2.96706</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>176</effort>
+          <velocity>1.7104226670</velocity>
         </limit>
         <dynamics>
           <damping>0.0</damping>
@@ -131,8 +131,8 @@
         <limit>
           <lower>-2.0944</lower>
           <upper>2.0944</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>176</effort>
+          <velocity>1.7104226670</velocity>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -186,8 +186,8 @@
         <limit>
           <lower>-2.96706</lower>
           <upper>2.96706</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>110</effort>
+          <velocity>1.7453292520</velocity>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -241,8 +241,8 @@
         <limit>
           <lower>-2.0944</lower>
           <upper>2.0944</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>110</effort>
+          <velocity>2.2689280276</velocity>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -296,8 +296,8 @@
         <limit>
           <lower>-2.96706</lower>
           <upper>2.96706</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>110</effort>
+          <velocity>2.4434609528</velocity>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -351,8 +351,8 @@
         <limit>
           <lower>-2.0944</lower>
           <upper>2.0944</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>40</effort>
+          <velocity>3.1415926536</velocity>
         </limit>
         <dynamics>
           <damping>0</damping>
@@ -406,8 +406,8 @@
         <limit>
           <lower>-3.05433</lower>
           <upper>3.05433</upper>
-          <effort>300</effort>
-          <velocity>10</velocity>
+          <effort>40</effort>
+          <velocity>3.1415926536</velocity>
         </limit>
         <dynamics>
           <damping>0</damping>


### PR DESCRIPTION
I copied the effort and velocity limits from [this](https://www.reeco.co.uk/wp-content/uploads/2020/05/KUKA-LBR-iiwa-technical-data.pdf) brochure. I kept 10 significant figures when converting degrees per second to radians per second.

This PR is towards https://github.com/RobotLocomotion/drake/issues/20907

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20917)
<!-- Reviewable:end -->
