### PR TITLE
[geometry] Split MeshcatParams into its own file

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -483,6 +483,7 @@ drake_cc_library(
         "meshcat.h",
         "meshcat_file_storage_internal.h",
         "meshcat_internal.h",
+        "meshcat_params.h",
         "meshcat_types_internal.h",
     ],
     data = [":meshcat_resources"],
@@ -582,6 +583,14 @@ drake_cc_googletest(
     deps = [
         ":meshcat",
         "@nlohmann_internal//:nlohmann",
+    ],
+)
+
+drake_cc_googletest(
+    name = "meshcat_params_test",
+    deps = [
+        ":meshcat",
+        "//common/yaml:yaml_io",
     ],
 )
 

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -11,6 +11,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/name_value.h"
 #include "drake/geometry/meshcat_animation.h"
+#include "drake/geometry/meshcat_params.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/rgba.h"
 #include "drake/geometry/shape_specification.h"
@@ -20,52 +21,6 @@
 
 namespace drake {
 namespace geometry {
-
-/** The set of parameters for configuring Meshcat. */
-struct MeshcatParams {
-  /** Passes this object to an Archive.
-  Refer to @ref yaml_serialization "YAML Serialization" for background. */
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(host));
-    a->Visit(DRAKE_NVP(port));
-    a->Visit(DRAKE_NVP(web_url_pattern));
-    a->Visit(DRAKE_NVP(show_stats_plot));
-  }
-
-  /** Meshcat will listen only on the given hostname (e.g., "localhost").
-  If "*" is specified, then it will listen on all interfaces.
-  If empty, an appropriate default value will be chosen (currently "*"). */
-  std::string host{"*"};
-
-  /** Meshcat will listen on the given http `port`. If no port is specified,
-  then it will listen on the first available port starting at 7000 (up to 7999).
-  If port 0 is specified, it will listen on an arbitrary "ephemeral" port.
-  @pre We require `port` == 0 || `port` >= 1024. */
-  std::optional<int> port{std::nullopt};
-
-  /** The `web_url_pattern` may be used to change the web_url() (and therefore
-  the ws_url()) reported by Meshcat. This may be useful in case %Meshcat sits
-  behind a firewall or proxy.
-
-  The pattern follows the
-  <a href="https://en.cppreference.com/w/cpp/utility/format">std::format</a>
-  specification language, except that `arg-id` substitutions are performed
-  using named arguments instead of positional indices.
-
-  There are two arguments available to the pattern:
-  - `{port}` will be substituted with the %Meshcat server's listen port number;
-  - `{host}` will be substituted with this params structure's `host` field, or
-    else with "localhost" in case the `host` was one of the placeholders for
-    "all interfaces".
-  */
-  std::string web_url_pattern{"http://{host}:{port}"};
-
-  /** Determines whether or not to display the stats plot widget in the Meshcat
-  user interface. This plot including realtime rate and WebGL render
-  statistics. */
-  bool show_stats_plot{true};
-};
 
 /** Provides an interface to %Meshcat (https://github.com/meshcat-dev/meshcat).
 

--- a/geometry/meshcat_params.h
+++ b/geometry/meshcat_params.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "drake/common/name_value.h"
+
+namespace drake {
+namespace geometry {
+
+/** The set of parameters for configuring Meshcat. */
+struct MeshcatParams {
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(host));
+    a->Visit(DRAKE_NVP(port));
+    a->Visit(DRAKE_NVP(web_url_pattern));
+    a->Visit(DRAKE_NVP(show_stats_plot));
+  }
+
+  /** Meshcat will listen only on the given hostname (e.g., "localhost").
+  If "*" is specified, then it will listen on all interfaces.
+  If empty, an appropriate default value will be chosen (currently "*"). */
+  std::string host{"*"};
+
+  /** Meshcat will listen on the given http `port`. If no port is specified,
+  then it will listen on the first available port starting at 7000 (up to 7999).
+  If port 0 is specified, it will listen on an arbitrary "ephemeral" port.
+  @pre We require `port` == 0 || `port` >= 1024. */
+  std::optional<int> port{std::nullopt};
+
+  /** The `web_url_pattern` may be used to change the web_url() (and therefore
+  the ws_url()) reported by Meshcat. This may be useful in case %Meshcat sits
+  behind a firewall or proxy.
+
+  The pattern follows the
+  <a href="https://en.cppreference.com/w/cpp/utility/format">std::format</a>
+  specification language, except that `arg-id` substitutions are performed
+  using named arguments instead of positional indices.
+
+  There are two arguments available to the pattern:
+  - `{port}` will be substituted with the %Meshcat server's listen port number;
+  - `{host}` will be substituted with this params structure's `host` field, or
+    else with "localhost" in case the `host` was one of the placeholders for
+    "all interfaces".
+  */
+  std::string web_url_pattern{"http://{host}:{port}"};
+
+  /** Determines whether or not to display the stats plot widget in the Meshcat
+  user interface. This plot including realtime rate and WebGL render
+  statistics. */
+  bool show_stats_plot{true};
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/meshcat_params_test.cc
+++ b/geometry/test/meshcat_params_test.cc
@@ -1,0 +1,36 @@
+#include "drake/geometry/meshcat_params.h"
+
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/text_logging.h"
+#include "drake/common/yaml/yaml_io.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+GTEST_TEST(MeshcatParamsTest, RoundTrip) {
+  // Populate a params struct with interesting values.
+  const MeshcatParams original{
+      .host = "some_host",
+      .port = 7001,
+      .web_url_pattern = "http://{host}:{port}/proxy",
+  };
+
+  // Make sure we can save & re-load it.
+  const std::string yaml = yaml::SaveYamlString(original);
+  log()->info("Saved round-trip YAML:\n{}", yaml);
+  MeshcatParams readback;
+  EXPECT_NO_THROW(readback = yaml::LoadYamlString<MeshcatParams>(yaml));
+
+  // Check that everything made it back intact. We can rely on the YAML
+  // library's unit tests to check that save and re-load generally works,
+  // but we'll do a spot-check to be safe.
+  EXPECT_EQ(readback.port, original.port);
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Generally we aim for one class per file for clarity, but for config structs in particular we strongly prefer it so that config can use the schema without pulling in the full class.

Towards #20920.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20918)
<!-- Reviewable:end -->
