### PR TITLE
[geometry] Add MeshcatParams option for initial_properties

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -174,8 +174,17 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.MeshcatParams;
     py::class_<Class, std::shared_ptr<Class>> cls(
         m, "MeshcatParams", py::dynamic_attr(), cls_doc.doc);
-    cls  // BR
-        .def(ParamInit<Class>());
+    // MeshcatParams::PropertyTuple
+    {
+      using Nested = MeshcatParams::PropertyTuple;
+      constexpr auto& nested_doc = doc.MeshcatParams.PropertyTuple;
+      py::class_<Nested> nested(cls, "PropertyTuple", nested_doc.doc);
+      nested.def(ParamInit<Nested>());
+      DefAttributesUsingSerialize(&nested, nested_doc);
+      DefReprUsingSerialize(&nested);
+      DefCopyAndDeepCopy(&nested);
+    }
+    cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
     DefCopyAndDeepCopy(&cls);

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -86,13 +86,41 @@ class TestGeometryVisualizers(unittest.TestCase):
         load_subscriber.clear()
         draw_subscriber.clear()
 
-    def test_meshcat(self):
-        port = 7051
+    def test_meshcat_params(self):
+        prop_a = mut.MeshcatParams.PropertyTuple(
+            path="a",
+            property="p1",
+            value=[1.0, 2.0],
+        )
+        prop_b = mut.MeshcatParams.PropertyTuple(
+            path="b",
+            property="p2",
+            value="hello",
+        )
+        prop_c = mut.MeshcatParams.PropertyTuple(
+            path="c",
+            property="p3",
+            value=True,
+        )
+        prop_d = mut.MeshcatParams.PropertyTuple(
+            path="d",
+            property="p4",
+            value=22.2,
+        )
         params = mut.MeshcatParams(
             host="*",
-            port=port,
+            port=7777,
             web_url_pattern="http://host:{port}",
+            initial_properties=[prop_a, prop_b, prop_c, prop_d],
             show_stats_plot=False)
+        self.assertIn("port=7777", repr(params))
+        self.assertIn("path='a'", repr(prop_a))
+        copy.copy(prop_a)
+        copy.copy(params)
+
+    def test_meshcat(self):
+        port = 7051
+        params = mut.MeshcatParams(port=port)
         meshcat = mut.Meshcat(params=params)
         self.assertEqual(meshcat.port(), port)
         self.assertIn("host", repr(params))

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -664,6 +664,14 @@ class Meshcat::Impl {
       websocket_thread_.join();
       throw std::runtime_error("Meshcat failed to open a websocket port.");
     }
+
+    for (const auto& item : params_.initial_properties) {
+      std::visit(
+          [this, &item](const auto& value) {
+            this->SetProperty(item.path, item.property, value);
+          },
+          item.value);
+    }
   }
 
   ~Impl() {

--- a/geometry/meshcat_params.h
+++ b/geometry/meshcat_params.h
@@ -2,6 +2,8 @@
 
 #include <optional>
 #include <string>
+#include <variant>
+#include <vector>
 
 #include "drake/common/name_value.h"
 
@@ -17,6 +19,7 @@ struct MeshcatParams {
     a->Visit(DRAKE_NVP(host));
     a->Visit(DRAKE_NVP(port));
     a->Visit(DRAKE_NVP(web_url_pattern));
+    a->Visit(DRAKE_NVP(initial_properties));
     a->Visit(DRAKE_NVP(show_stats_plot));
   }
 
@@ -47,6 +50,33 @@ struct MeshcatParams {
     "all interfaces".
   */
   std::string web_url_pattern{"http://{host}:{port}"};
+
+  /** A helper struct for the `initial_properties` params. The members follow
+  the same semantics as calls to Meshcat::SetProperty(path, property, value). */
+  struct PropertyTuple {
+    /** Passes this object to an Archive.
+    Refer to @ref yaml_serialization "YAML Serialization" for background. */
+    template <typename Archive>
+    void Serialize(Archive* a) {
+      a->Visit(DRAKE_NVP(path));
+      a->Visit(DRAKE_NVP(property));
+      a->Visit(DRAKE_NVP(value));
+    }
+
+    std::string path;
+    std::string property;
+    std::variant<std::vector<double>, std::string, bool, double> value;
+  };
+
+  /** Configures the initial conditions for Meshcat. These properties will be
+  applied immediately during construction. This can be used to change defaults
+  such as background, lighting, etc.
+
+  In other words, instead calling the Meshcat() constructor and then immediately
+  making a bunch of SetProperty(path, property, value) calls to configure the
+  newly-created object, instead you can append those (path, property, value) to
+  to this list, and the Meshcat() constructor will take care of it. */
+  std::vector<PropertyTuple> initial_properties;
 
   /** Determines whether or not to display the stats plot widget in the Meshcat
   user interface. This plot including realtime rate and WebGL render


### PR DESCRIPTION
Towards #20927.

This works with Python YAML loading, but not yet C++ YAML loading.  C++ loading support will appear in a follow-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20920)
<!-- Reviewable:end -->
