### PR TITLE
[py yaml] yaml_load_typed uses schema=type(defaults) by default

### DIFF
--- a/bindings/pydrake/common/test/yaml_typed_test.py
+++ b/bindings/pydrake/common/test/yaml_typed_test.py
@@ -587,6 +587,20 @@ class TestYamlTypedReadAcceptance(unittest.TestCase):
             retain_map_defaults=False)
         self.assertDictEqual(result.value, dict(some_key=1.0))
 
+    def test_load_inferred_schema(self):
+        data = dedent("""
+        value:
+          some_key: 1.0
+        """)
+        result = yaml_load_typed(data=data, defaults=MapStruct())
+        self.assertIsInstance(result, MapStruct)
+        self.assertDictEqual(result.value, dict(
+            nominal_float=nan,
+            some_key=1.0))
+
+        with self.assertRaisesRegex(Exception, "At least one"):
+            yaml_load_typed(data=data)
+
     def test_load_string_options(self):
         data = dedent("""
         value: some_value

--- a/bindings/pydrake/common/yaml.py
+++ b/bindings/pydrake/common/yaml.py
@@ -451,7 +451,7 @@ def _merge_yaml_dict_into_target(*, options, yaml_dict,
             target=target, value_schema=sub_schema)
 
 
-def yaml_load_typed(*, schema,
+def yaml_load_typed(*, schema=None,
                     data=None,
                     filename=None,
                     child_name=None,
@@ -469,7 +469,9 @@ def yaml_load_typed(*, schema,
         schema: The type to load as. This either must be a ``dataclass``, a C++
             class bound using pybind11 and ``DefAttributesUsingSerialize``, or
             a ``Mapping[str, ...]`` where the mapping's value type is one of
-            those two categories.
+            those two categories. If a non-None ``defaults`` is provided, then
+            ``schema`` can be ``None`` and will use ``type(defaults)`` in that
+            case.
         data: The string of YAML data to be loaded. Exactly one of either
             ``data`` or ``filename`` must be provided.
         filename: The filename of YAML data to be loaded. Exactly one of either
@@ -494,6 +496,14 @@ def yaml_load_typed(*, schema,
            schema can have default values that are left intact unless the YAML
            data provides a value *for that specific key*.
     """
+
+    # Infer the schema when possible.
+    if schema is None:
+        if defaults is None:
+            raise ValueError(
+                "At least one of schema= and defaults= must be provided")
+        schema = type(defaults)
+
     # Choose the allow/retain setting in case none were provided.
     options = _LoadYamlOptions(
         allow_yaml_with_no_schema=allow_yaml_with_no_schema,


### PR DESCRIPTION
Towards #20920.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20922)
<!-- Reviewable:end -->
