### PR TITLE
[vtk] Simplify VTK_VERSION patching

### DIFF
--- a/tools/workspace/vtk_internal/patches/common_core_version.patch
+++ b/tools/workspace/vtk_internal/patches/common_core_version.patch
@@ -2,8 +2,8 @@
 
 In our Bazel rules we scrape vtk/CMake/vtkVersion.cmake for what it
 contains (VTK_MAJOR_VERSION, VTK_MINOR_VERSION, VTK_BUILD_VERSION),
-but that doesn't give us values for VTK_VERSION_FULL (all three
-numbers concatenated) nor VTK_EPOCH_VERSION (some upstream CI voodoo).
+but that doesn't give us values for VTK_VERSION_FULL (nominally
+scraped from git) nor VTK_EPOCH_VERSION (some upstream CI voodoo).
 We need to patch those substitutions using what we do have access to.
 
 This change is Drake-specific, so we do not plan to upstream it.
@@ -19,18 +19,6 @@ This change is Drake-specific, so we do not plan to upstream it.
  
  #endif
 
-
---- Common/Core/vtkVersionMacros.h.in
-+++ Common/Core/vtkVersionMacros.h.in
-@@ -8,7 +8,7 @@
- /* Note: this file is deliberately both valid C and valid C++. */
-
- #define VTK_BUILD_VERSION @VTK_BUILD_VERSION@
--#define VTK_VERSION "@VTK_VERSION@"
-+#define VTK_VERSION "@VTK_MAJOR_VERSION@.@VTK_MINOR_VERSION@.@VTK_BUILD_VERSION@"
- 
- #define VTK_SOURCE_VERSION "vtk version " VTK_VERSION
- 
 
 --- Common/Core/vtkVersionQuick.h.in
 +++ Common/Core/vtkVersionQuick.h.in

--- a/tools/workspace/vtk_internal/settings.bzl
+++ b/tools/workspace/vtk_internal/settings.bzl
@@ -132,6 +132,8 @@ MODULE_SETTINGS = {
             "CMake/vtkVersion.cmake",
         ],
         "cmake_defines": [
+            # Emulate the concatenation found in the root CMakeLists.txt.
+            "VTK_VERSION=@VTK_MAJOR_VERSION@.@VTK_MINOR_VERSION@.@VTK_BUILD_VERSION@",  # noqa
             # ABI
             "VTK_HAS_ABI_NAMESPACE=1",
             "VTK_ABI_NAMESPACE_NAME=drake_vendor",


### PR DESCRIPTION
We don't need to patch out quite as much. I'd forgotten that our cmake_configure_file accepts recursive definitions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20924)
<!-- Reviewable:end -->
