### PR TITLE
[parsing] Add collision filter member groups

### DIFF
--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -2504,7 +2504,7 @@ TEST_F(GeometryStateTest, TestCollisionCandidates) {
                                 expected_candidates));
 
   // This relies on the correctness of CollisionFilterManager(). It implicitly
-  // tests that GeometryState::collisoin_filter_manager() produces a valid
+  // tests that GeometryState::collision_filter_manager() produces a valid
   // manager.
   while (!expected_candidates.empty()) {
     const auto pair = expected_candidates.begin();

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -109,6 +109,7 @@ drake_cc_library(
         "detail_common.h",
         "detail_ignition.h",
         "detail_path_utils.h",
+        "detail_strongly_connected_components.h",
         "detail_tinyxml.h",
         "detail_tinyxml2_diagnostic.h",
     ],
@@ -667,6 +668,13 @@ drake_cc_googletest(
     deps = [
         ":detail_misc",
         "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_strongly_connected_components_test",
+    deps = [
+        ":detail_misc",
     ],
 )
 

--- a/multibody/parsing/detail_collision_filter_group_resolver.cc
+++ b/multibody/parsing/detail_collision_filter_group_resolver.cc
@@ -1,6 +1,10 @@
 #include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
 
+#include <unordered_set>
+#include <vector>
+
 #include "drake/common/unused.h"
+#include "drake/multibody/parsing/detail_strongly_connected_components.h"
 #include "drake/multibody/tree/scoped_name.h"
 
 namespace drake {
@@ -29,6 +33,7 @@ void CollisionFilterGroupResolver::AddGroup(
     const DiagnosticPolicy& diagnostic,
     const std::string& group_name,
     const std::set<std::string>& body_names,
+    const std::set<std::string>& member_group_names,
     std::optional<ModelInstanceIndex> model_instance) {
   if (model_instance) {
     DRAKE_DEMAND(*model_instance < plant_->num_model_instances());
@@ -41,7 +46,12 @@ void CollisionFilterGroupResolver::AddGroup(
                                  full_group_name));
     return;
   }
-  if (body_names.empty()) {
+  if (groups_.count(full_group_name)) {
+    diagnostic.Error(fmt::format("group '{}' has already been defined",
+                                 full_group_name));
+    return;
+  }
+  if (body_names.empty() && member_group_names.empty()) {
     diagnostic.Error(fmt::format("group '{}' has no members", full_group_name));
     return;
   }
@@ -71,7 +81,25 @@ void CollisionFilterGroupResolver::AddGroup(
 
     geometry_set.Add(plant_->GetBodyFrameIdOrThrow(body->index()));
   }
-  groups_.insert({FullyQualify(group_name, model_instance), geometry_set});
+  groups_.insert({full_group_name, geometry_set});
+
+  // Group insertions get computed at resolution time. Here we build the
+  // directed graph of insertions, where edges point from the source group (the
+  // group whose members we should insert) to the destination group (the group
+  // into which we should insert members).
+  //
+  // Note that all of the successors in this graph (destinations) are names
+  // that we know to exist, because they have been built by this function. The
+  // keys of the graph map are names that need to be checked at resolution
+  // time.
+  for (const auto& insertion_group : member_group_names) {
+    const auto full_insertion_group{
+      FullyQualify(insertion_group, model_instance)};
+    if (!group_insertion_graph_.count(full_insertion_group)) {
+      group_insertion_graph_[full_insertion_group] = {};
+    }
+    group_insertion_graph_[full_insertion_group].insert(full_group_name);
+  }
 }
 
 void CollisionFilterGroupResolver::AddPair(
@@ -103,6 +131,74 @@ void CollisionFilterGroupResolver::Resolve(const DiagnosticPolicy& diagnostic) {
   DRAKE_DEMAND(!is_resolved_);
   is_resolved_ = true;
 
+  // TODO(rpoyner-tri): The source-file locality for naming errors discovered
+  // here is not great. Consider some scheme for remembering the source code
+  // line (bundled in `diagnostic` passed to AddGroup/AddPair/etc.) together
+  // with the name to be checked.
+
+  // Resolve whole-group insertions, which requires analyzing the insertion
+  // graph and editing the map of groups.
+
+  // TODO(rpoyner-tri): what follows is a lot of graph math, based on strings
+  // for node labels; consider swapping strings for purpose-built integer index
+  // labels if this turns out to be too slow.
+
+  // First check the insertion source group names, emit errors and remove any
+  // broken ones. Check names in order so that the order of error messages is
+  // stable.
+  std::set<std::string> ordered_names;
+  std::vector<std::string> bad_names;
+  for (const auto& item : group_insertion_graph_) {
+    ordered_names.insert(item.first);
+  }
+  for (const auto& name : ordered_names) {
+    if (!FindGroup(diagnostic, name)) {
+      bad_names.push_back(name);
+    }
+  }
+  for (const auto& name : bad_names) {
+    group_insertion_graph_.erase(name);
+  }
+
+  // It is perfectly well-defined and useful to allow nested group insertions:
+  // a=>b=>c. However, if we naively execute b=>c, then a=>c, we have failed to
+  // do the transitive insertion a=>c.  In order to efficiently and correctly
+  // execute the insertions, we need to have a topological sort of the
+  // insertion graph. It is possible (if maybe unlikely) that the graph could
+  // have cycles, or more generally, strongly connected components (SCCs). This
+  // is fine; the result of such a graph is that all groups in an SCC receive
+  // the union of all the groups' members. Happily, there is a linear-time
+  // algorithm to construct both the topo-sort and find the SCCs.
+  //
+  // Compute the sequence of strongly connected components, in reverse of
+  // insertion order.
+  StronglyConnectedComponents<std::string> sccs =
+      FindStronglyConnectedComponents(group_insertion_graph_);
+
+  // Execute the insertions.
+  for (auto it = sccs.rbegin(); it != sccs.rend(); ++it) {
+    const auto& scc = *it;
+    // The content to insert is the union of the SCC's members' contents.
+    GeometrySet contents_union;
+    for (const auto& node : scc) {
+      contents_union.Add(groups_[node]);
+    }
+
+    // The destinations are the the union of the SCC's' members' successors,
+    // plus the membership of the SCC itself.
+    std::unordered_set<std::string> destinations{scc};
+    for (const auto& node : scc) {
+      const auto& successors = group_insertion_graph_[node];
+      destinations.insert(successors.begin(), successors.end());
+    }
+
+    // Do the insertions.
+    for (const auto& destination : destinations) {
+      groups_[destination].Add(contents_union);
+    }
+  }
+
+  // Now that the groups are complete, evaluate the pairs into plant rules.
   for (const auto& [name_a, name_b] : pairs_) {
     const GeometrySet* set_a = FindGroup(diagnostic, name_a);
     const GeometrySet* set_b = FindGroup(diagnostic, name_b);
@@ -139,7 +235,7 @@ const GeometrySet* CollisionFilterGroupResolver::FindGroup(
 
 const RigidBody<double>* CollisionFilterGroupResolver::FindBody(
     std::string_view name,
-    ModelInstanceIndex model_instance) {
+    ModelInstanceIndex model_instance) const {
   if (plant_->HasBodyNamed(name, model_instance)) {
     return &plant_->GetBodyByName(name, model_instance);
   }

--- a/multibody/parsing/detail_collision_filter_group_resolver.h
+++ b/multibody/parsing/detail_collision_filter_group_resolver.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/sorted_pair.h"
 #include "drake/geometry/geometry_set.h"
+#include "drake/multibody/parsing/detail_strongly_connected_components.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
 namespace drake {
@@ -70,13 +71,16 @@ class CollisionFilterGroupResolver {
   }
 
   // Adds a collision filter group. Locates bodies by name immediately, and
-  // emits errors for illegal names, empty groups, or missing bodies.
+  // emits errors for illegal names, empty groups, missing bodies, or duplicate
+  // group definition attempts.
   //
-  // @param diagnostic     The error-reporting channel.
-  // @param group_name     The name of the group being defined.
-  // @param body_names     The names of the bodies that are group members.
-  // @param model_instance The current model, for scoping purposes.
-  //                       @see model_instance note above.
+  // @param diagnostic          The error-reporting channel.
+  // @param group_name          The name of the group being defined.
+  // @param body_names          The names of the bodies that are group members.
+  // @param member_group_names  The names of groups whose member bodies are
+  //                            group members.
+  // @param model_instance      The current model, for scoping purposes.
+  //                            @see model_instance note above.
   //
   // @pre group_name is not empty.
   // @pre no member strings of body_names are empty.
@@ -86,6 +90,7 @@ class CollisionFilterGroupResolver {
       const drake::internal::DiagnosticPolicy& diagnostic,
       const std::string& group_name,
       const std::set<std::string>& body_names,
+      const std::set<std::string>& member_group_names,
       std::optional<ModelInstanceIndex> model_instance);
 
   // Adds a group pair. Emits diagnostics for illegal names.  Two distinct
@@ -124,11 +129,13 @@ class CollisionFilterGroupResolver {
       const std::string& group_name) const;
 
   const RigidBody<double>* FindBody(std::string_view name,
-                                    ModelInstanceIndex model_instance);
+                                    ModelInstanceIndex model_instance) const;
 
   MultibodyPlant<double>* const plant_;
   std::map<std::string, geometry::GeometrySet> groups_;
   std::set<SortedPair<std::string>> pairs_;
+
+  DirectedGraph<std::string> group_insertion_graph_;
   bool is_resolved_{false};
   ModelInstanceIndex minimum_model_instance_index_{};
 };

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -207,7 +207,19 @@ void CollectCollisionFilterGroup(
 
     bodies.insert(body_name);
   }
-  resolver->AddGroup(diagnostic, group_name, bodies, model_instance);
+  std::set<std::string> member_groups;
+  for (auto member_node = next_child_element(group_node, "drake:member_group");
+       std::holds_alternative<sdf::ElementPtr>(member_node)
+           ? std::get<sdf::ElementPtr>(member_node) != nullptr
+           : std::get<tinyxml2::XMLElement*>(member_node) != nullptr;
+       member_node = next_sibling_element(member_node, "drake:member_group")) {
+    const std::string member_group_name = read_tag_string(member_node, "name");
+    if (member_group_name.empty()) { continue; }
+
+    member_groups.insert(member_group_name);
+  }
+  resolver->AddGroup(diagnostic, group_name, bodies, member_groups,
+                     model_instance);
 
   for (auto ignore_node = next_child_element(
            group_node, "drake:ignored_collision_filter_group");

--- a/multibody/parsing/detail_dmd_parser.cc
+++ b/multibody/parsing/detail_dmd_parser.cc
@@ -163,8 +163,10 @@ void ParseModelDirectivesImpl(
       drake::log()->debug("  add_collision_filter_group: {}", group.name);
       std::set<std::string> member_set(group.members.begin(),
                                        group.members.end());
-      collision_resolver->AddGroup(
-          diagnostic, group.name, member_set, model_instance);
+      std::set<std::string> member_groups_set(group.member_groups.begin(),
+                                              group.member_groups.end());
+      collision_resolver->AddGroup(diagnostic, group.name, member_set,
+                                   member_groups_set, model_instance);
       for (const auto& ignored_group : group.ignored_collision_filter_groups) {
         collision_resolver->AddPair(
             diagnostic, group.name, ignored_group, model_instance);

--- a/multibody/parsing/detail_strongly_connected_components.h
+++ b/multibody/parsing/detail_strongly_connected_components.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* The directed graph type to operate on. This is an adjacency list, mapping a
+node to its successors. */
+template <typename T>
+using DirectedGraph = std::unordered_map<T, std::unordered_set<T>>;
+
+/* The result type is an ordered sequence of strongly connected components. */
+template <typename T>
+using StronglyConnectedComponents = std::vector<std::unordered_set<T>>;
+
+/*
+Computes a top-down topologically ordered sequence of strongly connected
+components of a directed `graph`, using Tarjan's Algorithm.
+
+Tarjan's Algorithm (named for its discoverer, Robert Tarjan) is a graph theory
+algorithm for finding the strongly connected components (SCCs) of a graph.
+
+Based on:
+https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+https://logarithmic.net/pfh-files/blog/01208083168/tarjan.py
+
+Recall that strongly connected components are subgraphs where every node is
+reachable from every other node in the component. Strongly connected components
+form a partition of the graph.
+https://en.wikipedia.org/wiki/Strongly_connected_component
+
+@param graph  The graph to analyze.
+
+@returns a top-down topologically ordered sequence of SCCs, with properties
+further explained below.
+
+The return value for an empty graph will be an empty sequence.
+
+By the definition of partition, each of the SCCs is non-empty, and their number
+will be at least one for a non-empty graph, and at most the number of nodes in
+the graph. The sum of sizes of the SCCs will be equal to the number of nodes in
+the graph.
+
+Top-down ordering means that result[0] (the "highest" SCC) has no out-edges
+(its members have successors outside itself), and result[result.size() - 1]
+(the "lowest" SCC) has no in-edges (its members are not successors of nodes
+outside itself). Other returned SCCs may have any combination of in-edges or
+out-edges, provided topological sort order is maintained.
+
+Note that the returned SCCs form a condensed graph that is guaranteed to be
+acyclic -- all cycles have been "hidden" inside an SCC.
+
+@tparam T  The type used for labeling graph nodes.
+*/
+template <typename T>
+StronglyConnectedComponents<T> FindStronglyConnectedComponents(
+    const DirectedGraph<T>& graph) {
+  int index_counter{0};
+  std::vector<T> stack;
+  std::unordered_map<T, int> lowlinks;
+  std::unordered_map<T, int> index;
+  StronglyConnectedComponents<T> result;
+
+  std::function<void(T)> strongconnect;
+  strongconnect = [&](T node) {
+    // set the depth index for this node to the smallest unused index.
+    index[node] = index_counter;
+    lowlinks[node] = index_counter;
+    ++index_counter;
+    stack.push_back(node);
+
+    if (graph.count(node)) {
+      const auto& successors = graph.at(node);
+      for (const auto& successor : successors) {
+        if (!lowlinks.count(successor)) {
+          // Successor has not yet been visited; recurse on it.
+          strongconnect(successor);
+          lowlinks[node] = std::min(lowlinks[node], lowlinks[successor]);
+        } else if (std::find(stack.begin(), stack.end(), successor)
+                   != stack.end()) {
+          // the successor is in the stack and hence in the current strongly
+          // connected component (SCC).
+          lowlinks[node] = std::min(lowlinks[node], index[successor]);
+        }
+      }
+    }
+
+    // If `node` is a root node, pop the stack and generate an SCC.
+    if (lowlinks[node] == index[node]) {
+      std::unordered_set<T> connected_component;
+
+      while (true) {
+        T successor = stack.back();
+        stack.pop_back();
+        connected_component.insert(successor);
+        if (successor == node) { break; }
+      }
+      result.emplace_back(std::move(connected_component));
+    }
+  };
+
+  for (const auto& item : graph) {
+    const auto& node = item.first;
+    if (!lowlinks.count(node)) {
+      strongconnect(node);
+    }
+  }
+
+  return result;
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/model_directives.h
+++ b/multibody/parsing/model_directives.h
@@ -175,9 +175,10 @@ struct AddCollisionFilterGroup {
       drake::log()->error(
           "add_collision_filter_group: `name` must be non-empty");
       return false;
-    } else if (members.empty()) {
+    } else if (members.empty() && member_groups.empty()) {
       drake::log()->error(
-          "add_collision_filter_group: `members` must be non-empty");
+          "add_collision_filter_group:"
+          " at least one of `members` or `member_groups` must be non-empty");
       return false;
     }
     return true;
@@ -187,6 +188,7 @@ struct AddCollisionFilterGroup {
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(name));
     a->Visit(DRAKE_NVP(members));
+    a->Visit(DRAKE_NVP(member_groups));
     a->Visit(DRAKE_NVP(model_namespace));
     a->Visit(DRAKE_NVP(ignored_collision_filter_groups));
   }
@@ -201,6 +203,10 @@ struct AddCollisionFilterGroup {
   /// already added models. This data is analogous to a sequence of
   /// @ref tag_drake_member in XML model formats.
   std::vector<std::string> members;
+  /// Names of groups to add en masse as members of the group. May be scoped
+  /// and refer to bodies of already added models. This data is analogous to a
+  /// sequence of @ref tag_drake_member_group in XML model formats.
+  std::vector<std::string> member_groups;
   /// Names of groups against which to ignore collisions. If another group is
   /// named, collisions between this group and that group will be ignored. If
   /// this group is named, collisions within this group will be ignored. Names

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -50,7 +50,7 @@ future, we intend to update this documentation to itemize what isn't supported.
 Drake's SDFormat parsing supports composing multiple models into a single
 model, via lexical nesting and file inclusion. The file inclusion feature
 supports both SDFormat files and URDF files. Note that included URDF files pass
-through the Drake URDF parser, with all of it's extensions and limitations.
+through the Drake URDF parser, with all of its extensions and limitations.
 
 For full details, see the
 <a href='http://sdformat.org/tutorials?tut=composition_proposal#model-composition-proposed-behavior'>SDFormat documentation of model composition.</a>
@@ -92,11 +92,11 @@ Drake supports URDF files as described here: http://wiki.ros.org/urdf/XML.
 For Drake extensions to URDF format files, see
 @ref multibody_parsing_drake_extensions.
 
-@subsection multbody_parsing_urdf_unsupported URDF not supported by Drake
+@subsection multibody_parsing_urdf_unsupported URDF not supported by Drake
 
 Drake's parser does not implement all of the features of URDF. Here is a list
 of known URDF features that Drake does not use. For each, the parser applies
-one of several treaments:
+one of several treatments:
 
 - Issue a warning that the tag is unused.
 - Ignore silently, as documented below.
@@ -178,6 +178,7 @@ Here is the full list of custom elements:
 - @ref tag_drake_joint
 - @ref tag_drake_linear_bushing_rpy
 - @ref tag_drake_member
+- @ref tag_drake_member_group
 - @ref tag_drake_mesh_resolution_hint
 - @ref tag_drake_mimic
 - @ref tag_drake_mu_dynamic
@@ -423,14 +424,15 @@ with the child link of the joint being defined.
 - SDFormat path: `//model/drake:collision_filter_group`
 - URDF path: `/robot/drake:collision_filter_group`
 - Syntax: Attributes `name` (string) and `ignore` (boolean); nested elements
-          `drake:member` and `drake:ignored_collision_filter_group`.
+          `drake:member`, `drake:member_group`, and
+          `drake:ignored_collision_filter_group`.
 
 @subsubsection tag_drake_collision_filter_group_semantics Semantics
 
 This element names a group of bodies to participate in collision filtering
 rules. If the `ignore` attribute is present and true-valued, the entire element
 is skipped during parsing. The nested elements must included one or more
-`drake:member` elements, and zero or more
+`drake:member` or `drake:member_group` elements, and zero or more
 `drake:ignored_collision_filter_group` elements.
 
 This element defines a new group name that is only available during parsing. It
@@ -445,7 +447,7 @@ different collision groups excludes collisions between members of those groups
 naming the same group twice excludes collisions within the group (see
 drake::geometry::CollisionFilterDeclaration::ExcludeWithin()).
 
-@see @ref tag_drake_member, @ref tag_drake_ignored_collision_filter_group, @ref scoped_names
+@see @ref tag_drake_member, @ref tag_drake_member_group, @ref tag_drake_ignored_collision_filter_group, @ref scoped_names
 
 @subsection tag_drake_compliant_hydroelastic drake:compliant_hydroelastic
 
@@ -662,6 +664,22 @@ In SDFormat files only, the name may refer to a link within a nested model
 
 @see @ref tag_drake_collision_filter_group, @ref scoped_names
 
+@subsection tag_drake_member_group drake:member_group
+
+- SDFormat path: `//model/drake:collision_filter_group/drake:member_group`
+- URDF path: `/robot/drake:collision_filter_group/drake:member_group/@name`
+- Syntax: String.
+
+@subsubsection tag_drake_member_group_semantics Semantics
+
+This element names a collision filter group (defined elsewhere in the model), all
+of whose members become members of the parent collision filter group.
+
+In SDFormat files only, the name may refer to a link within a nested model
+(either URDF or SDFormat) by using a scoped name.
+
+@see @ref tag_drake_collision_filter_group, @ref scoped_names
+
 @subsection tag_drake_mesh_resolution_hint drake:mesh_resolution_hint
 
 - SDFormat path: `//model/link/collision/drake:proximity_properties/drake:mesh_resolution_hint`
@@ -720,8 +738,8 @@ The provided (dimensionless) value sets the static friction parameter for
 CoulombFriction. Refer to @ref stribeck_approximation for details on the
 friction model.
 
-@warning Both `mu_dynamic` and `mu_static` are used by MultibodyPlant when the plant 
-`time_step=0`, but only `mu_dynamic` is used when `time_step>0`. Refer to 
+@warning Both `mu_dynamic` and `mu_static` are used by MultibodyPlant when the plant
+`time_step=0`, but only `mu_dynamic` is used when `time_step>0`. Refer to
 MultibodyPlant's constructor documentation for details.
 
 @see @ref tag_drake_proximity_properties, drake::multibody::CoulombFriction,

--- a/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
+++ b/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
@@ -63,32 +63,55 @@ TEST_F(CollisionFilterGroupResolverTest, BogusPairGlobal) {
 
 TEST_F(CollisionFilterGroupResolverTest, BogusGroupName) {
   ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
-  resolver_.AddGroup(diagnostic_policy_, "haha::a", {}, r1);
+  resolver_.AddGroup(diagnostic_policy_, "haha::a", {}, {}, r1);
   EXPECT_THAT(TakeError(), MatchesRegex(".*haha::a' cannot be.*scoped.*"));
 }
 
 TEST_F(CollisionFilterGroupResolverTest, EmptyGroupGlobal) {
-  resolver_.AddGroup(diagnostic_policy_, "a", {}, {});
+  resolver_.AddGroup(diagnostic_policy_, "a", {}, {}, {});
   EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'a'.*no members"));
 }
 
 TEST_F(CollisionFilterGroupResolverTest, EmptyGroupsScoped) {
   ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
-  resolver_.AddGroup(diagnostic_policy_, "a", {}, r1);
+  resolver_.AddGroup(diagnostic_policy_, "a", {}, {}, r1);
   EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'r1::a'.*no members"));
   ModelInstanceIndex r2 = plant_.AddModelInstance("r2");
-  resolver_.AddGroup(diagnostic_policy_, "b", {}, r2);
+  resolver_.AddGroup(diagnostic_policy_, "b", {}, {}, r2);
   EXPECT_THAT(TakeError(), MatchesRegex(".*group.*'r2::b'.*no members"));
 }
 
 TEST_F(CollisionFilterGroupResolverTest, MissingBodyGlobal) {
   plant_.AddModelInstance("r1");
   resolver_.AddGroup(diagnostic_policy_, "a",
-                     {"abody", "r1::abody", "zzz::abody"}, {});
+                     {"abody", "r1::abody", "zzz::abody"}, {}, {});
   EXPECT_THAT(TakeError(), MatchesRegex(".*'abody'.*not found"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::abody'.*not found"));
   // Note that AddGroup() doesn't choke on an instance name that doesn't exist.
   EXPECT_THAT(TakeError(), MatchesRegex(".*'zzz::abody'.*not found"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, MissingMemberGroupGlobal) {
+  plant_.AddModelInstance("r1");
+  resolver_.AddGroup(diagnostic_policy_, "a", {},
+                     {"agroup", "r1::agroup", "zzz::agroup"}, {});
+  // Group insertions get evaluated at resolution time.
+  resolver_.Resolve(diagnostic_policy_);
+
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'agroup'.*not found"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::agroup'.*not found"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'zzz::agroup'.*not found"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, DuplicateGroupDefinitions) {
+  plant_.AddModelInstance("r1");
+  // The definitions are nonsense, but the redefinition attempt should emit
+  // error right away.
+  resolver_.AddGroup(diagnostic_policy_, "a", {},
+                     {"agroup", "r1::agroup", "zzz::agroup"}, {});
+  resolver_.AddGroup(diagnostic_policy_, "a", {},
+                     {"agroup", "r1::agroup", "zzz::agroup"}, {});
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'a'.*already.*defined.*"));
 }
 
 TEST_F(CollisionFilterGroupResolverTest, OutOfParseBodyGlobal) {
@@ -100,7 +123,7 @@ TEST_F(CollisionFilterGroupResolverTest, OutOfParseBodyGlobal) {
       "WorldModelInstance::world",
       "stuff",
     },
-    {});
+    {}, {});
   EXPECT_THAT(TakeError(), MatchesRegex(".*'DefaultModelInstance::stuff'"
                                         ".*outside the current parse"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*'WorldModelInstance::world'"
@@ -114,21 +137,52 @@ TEST_F(CollisionFilterGroupResolverTest, MissingBodyScoped) {
   ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
   plant_.AddModelInstance("r1::sub");
   resolver_.AddGroup(diagnostic_policy_, "a",
-                     {"abody", "sub::abody", "zzz::abody"}, r1);
+                     {"abody", "sub::abody", "zzz::abody"}, {}, r1);
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::abody'.*not found"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::sub::abody'.*not found"));
   // Note that AddGroup() doesn't choke on an instance name that doesn't exist.
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::zzz::abody'.*not found"));
 }
 
-TEST_F(CollisionFilterGroupResolverTest, GroupGlobal) {
-  // Ensure names can be resolved for groups defined at global scope.
+TEST_F(CollisionFilterGroupResolverTest, MissingMemberGroupScoped) {
+  ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
+  plant_.AddModelInstance("r1::sub");
+  resolver_.AddGroup(diagnostic_policy_, "a", {},
+                     {"agroup", "sub::agroup", "zzz::agroup"}, r1);
+  // Group insertions get evaluated at resolution time.
+  resolver_.Resolve(diagnostic_policy_);
+
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::agroup'.*not found"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::sub::agroup'.*not found"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::zzz::agroup'.*not found"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, GroupGlobalBodies) {
+  // Ensure body names can be resolved for groups defined at global scope.
   ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
   ModelInstanceIndex r2 = plant_.AddModelInstance("r2");
   GeometryId b1 = AddBody("body1", r1);
   GeometryId b2 = AddBody("body2", r2);
-  resolver_.AddGroup(diagnostic_policy_, "a", {"r1::body1"}, {});
-  resolver_.AddGroup(diagnostic_policy_, "b", {"r2::body2"}, {});
+  resolver_.AddGroup(diagnostic_policy_, "a", {"r1::body1"}, {}, {});
+  resolver_.AddGroup(diagnostic_policy_, "b", {"r2::body2"}, {}, {});
+  resolver_.AddPair(diagnostic_policy_, "a", "b", {});
+  resolver_.Resolve(diagnostic_policy_);
+  EXPECT_TRUE(inspector_.CollisionFiltered(b1, b2));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, GroupGlobalMemberGroups) {
+  // Ensure member group names can be resolved for groups defined at global
+  // scope.
+  ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
+  ModelInstanceIndex r2 = plant_.AddModelInstance("r2");
+
+  GeometryId b1 = AddBody("body1", r1);
+  resolver_.AddGroup(diagnostic_policy_, "ra", {"body1"}, {}, r1);
+  GeometryId b2 = AddBody("body2", r2);
+  resolver_.AddGroup(diagnostic_policy_, "rb", {"body2"}, {}, r2);
+
+  resolver_.AddGroup(diagnostic_policy_, "a", {}, {"r1::ra"}, {});
+  resolver_.AddGroup(diagnostic_policy_, "b", {}, {"r2::rb"}, {});
   resolver_.AddPair(diagnostic_policy_, "a", "b", {});
   resolver_.Resolve(diagnostic_policy_);
   EXPECT_TRUE(inspector_.CollisionFiltered(b1, b2));
@@ -141,13 +195,65 @@ TEST_F(CollisionFilterGroupResolverTest, LinkScoped) {
   ModelInstanceIndex sub = plant_.AddModelInstance("r1::sub");
   GeometryId rsa = AddBody("abody", sub);
 
-  resolver_.AddGroup(diagnostic_policy_, "a", {"abody", "sub::abody"}, r1);
+  resolver_.AddGroup(diagnostic_policy_, "a", {"abody", "sub::abody"}, {}, r1);
   resolver_.AddPair(diagnostic_policy_, "a", "a", r1);
   resolver_.Resolve(diagnostic_policy_);
 
   // The expected filter gets created on the plant/scene_graph.
   EXPECT_TRUE(inspector_.CollisionFiltered(ra, rsa));
 }
+
+// As a convenience, the tests below reuse body names as group names; each
+// group contains the correspondingly named body. Note, however, that group
+// names and body names are separate kinds; they never actually mix in the
+// resolution process.
+
+TEST_F(CollisionFilterGroupResolverTest, MemberGroupCycle) {
+  ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
+  const int length = 100;
+  std::vector<GeometryId> geoms;
+  auto body_of = [](int k) { return fmt::format("body{}", k); };
+  for (int k = 0; k < length; ++k) {
+    std::string body_k = body_of(k);
+    geoms.push_back(AddBody(body_k, r1));
+    resolver_.AddGroup(
+        diagnostic_policy_, body_k, {body_k}, {body_of((k + 1) % length)}, r1);
+  }
+  // Create a self-exclusion rule for testing. It doesn't matter which group
+  // name we pick, any group in the cycle will end up with all the member
+  // bodies.
+  std::string test_pair_name = body_of(length - 1);
+  resolver_.AddPair(diagnostic_policy_, test_pair_name, test_pair_name, r1);
+  resolver_.Resolve(diagnostic_policy_);
+  EXPECT_TRUE(inspector_.CollisionFiltered(geoms.front(), geoms.back()));
+  EXPECT_TRUE(inspector_.CollisionFiltered(
+      geoms.front(), geoms[geoms.size() / 2]));
+}
+
+
+TEST_F(CollisionFilterGroupResolverTest, MemberGroupDeepNest) {
+  ModelInstanceIndex r1 = plant_.AddModelInstance("r1");
+  const int depth = 100;
+  std::vector<GeometryId> geoms;
+  auto body_of = [](int k) { return fmt::format("body{}", k); };
+  for (int k = 0; k < depth; ++k) {
+    std::string body_k = body_of(k);
+    geoms.push_back(AddBody(body_k, r1));
+    if (k + 1 >= depth) {
+      resolver_.AddGroup(
+          diagnostic_policy_, body_k, {body_k}, {}, r1);
+    } else {
+      resolver_.AddGroup(
+          diagnostic_policy_, body_k, {body_k}, {body_of(k + 1)}, r1);
+    }
+  }
+  // Create a self-exclusion rule for testing. The group containing body0 is
+  // "top", and will contain all of the bodies and geometries.
+  resolver_.AddPair(diagnostic_policy_, body_of(0), body_of(0), r1);
+  resolver_.Resolve(diagnostic_policy_);
+  EXPECT_TRUE(inspector_.CollisionFiltered(geoms.front(), geoms.back()));
+}
+
 
 }  // namespace
 }  // namespace internal

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -3266,6 +3266,9 @@ TEST_F(SdfParserTest, CollisionFilterGroupParsingTest) {
     {"test::robot2::link3_sphere", "test::robot2::link5_sphere"},
     {"test::robot2::link3_sphere", "test::robot2::link6_sphere"},
     {"test::robot2::link5_sphere", "test::robot2::link6_sphere"},
+
+    // Filtered by group_of_groups.
+    {"test::robot1::link2_sphere", "test::robot2::link3_sphere"},
   };
   VerifyCollisionFilters(ids, expected_filters);
 
@@ -3292,10 +3295,13 @@ TEST_F(SdfParserTest, CollisionFilterGroupParsingErrorsTest) {
   <link name='a'/>
   <drake:collision_filter_group name="group_a">
     <drake:member></drake:member>
+    <drake:member_group></drake:member_group>
   </drake:collision_filter_group>
 </model>)"""));
   EXPECT_THAT(TakeError(), MatchesRegex(".*The tag <drake:member> is missing"
                                         " a required string value.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*The tag <drake:member_group> is"
+                                        " missing a required string value.*"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*'error2::group_a'.*no members"));
   FlushDiagnostics();
 

--- a/multibody/parsing/test/detail_strongly_connected_components_test.cc
+++ b/multibody/parsing/test/detail_strongly_connected_components_test.cc
@@ -1,0 +1,151 @@
+#include "drake/multibody/parsing/detail_strongly_connected_components.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using ::testing::UnorderedElementsAre;
+
+template <typename T>
+std::unordered_set<T> DirectedGraphNodes(const DirectedGraph<T>& graph) {
+  std::unordered_set<T> unique_nodes;
+  for (const auto& item : graph) {
+    unique_nodes.insert(item.first);
+    unique_nodes.insert(item.second.begin(), item.second.end());
+  }
+  return unique_nodes;
+}
+
+template <typename T>
+int DirectedGraphSize(const DirectedGraph<T>& graph) {
+  return DirectedGraphNodes(graph).size();
+}
+
+template <typename T>
+std::unordered_set<T> ComponentsNodes(
+    const StronglyConnectedComponents<T>& components) {
+  std::unordered_set<T> unique_nodes;
+  for (const auto& component : components) {
+    unique_nodes.insert(component.begin(), component.end());
+  }
+  return unique_nodes;
+}
+template <typename T>
+int SumComponentsSizes(const StronglyConnectedComponents<T>& components) {
+  int result{0};
+  for (const auto& component : components) {
+    result += component.size();
+  }
+  return result;
+}
+
+template <typename T>
+void CheckStronglyConnectedComponentsInvariants(
+    const DirectedGraph<T>& graph,
+    const StronglyConnectedComponents<T>& components) {
+  // Input and output use the same set of nodes.
+  auto graph_nodes = DirectedGraphNodes(graph);
+  EXPECT_EQ(graph_nodes, ComponentsNodes(components));
+
+  // The output partitions the graph.
+  EXPECT_EQ(graph_nodes.size(), SumComponentsSizes(components));
+
+  // Components are non-empty.
+  for (const auto& component : components) {
+    EXPECT_FALSE(component.empty());
+  }
+}
+
+GTEST_TEST(StronglyConnectedComponentsTest, Empty) {
+  // Empty graphs are boring, but don't cause problems.
+  DirectedGraph<int> graph;
+  auto sccs = FindStronglyConnectedComponents(graph);
+  CheckStronglyConnectedComponentsInvariants(graph, sccs);
+  EXPECT_EQ(sccs.size(), 0);
+}
+
+GTEST_TEST(StronglyConnectedComponentsTest, Self) {
+  // Self-edges are boring, but don't cause problems.
+  DirectedGraph<int> graph;
+  graph[0] = {0};
+  auto sccs = FindStronglyConnectedComponents(graph);
+  CheckStronglyConnectedComponentsInvariants(graph, sccs);
+  EXPECT_EQ(sccs.size(), 1);
+}
+
+GTEST_TEST(StronglyConnectedComponentsTest, Unrelated) {
+  // Unrelated edges don't cause problems.
+  DirectedGraph<int> graph;
+  graph[0] = {1};
+  graph[2] = {3};
+  auto sccs = FindStronglyConnectedComponents(graph);
+  CheckStronglyConnectedComponentsInvariants(graph, sccs);
+  EXPECT_EQ(sccs.size(), DirectedGraphSize<int>(graph));
+}
+
+GTEST_TEST(StronglyConnectedComponentsTest, Arbitrary) {
+  // Check the arbitrary graph shown in the Wikipedia animation linked below.
+  // https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm#/media/File:Tarjan's_Algorithm_Animation.gif
+  DirectedGraph<int> graph;
+  graph[1] = {2};
+  graph[2] = {3};
+  graph[3] = {1};
+
+  graph[4] = {2, 3, 5};
+  graph[5] = {4, 6};
+
+  graph[6] = {3, 7};
+  graph[7] = {6};
+
+  graph[8] = {5, 8};
+
+  auto sccs = FindStronglyConnectedComponents(graph);
+  CheckStronglyConnectedComponentsInvariants(graph, sccs);
+  EXPECT_EQ(sccs.size(), 4);
+  // We have cycles, so there must be fewer components than nodes in the input.
+  EXPECT_LT(sccs.size(), DirectedGraphSize<int>(graph));
+
+  EXPECT_THAT(sccs[0], UnorderedElementsAre(1, 2, 3));
+  EXPECT_THAT(sccs[1], UnorderedElementsAre(6, 7));
+  EXPECT_THAT(sccs[2], UnorderedElementsAre(4, 5));
+  EXPECT_THAT(sccs[3], UnorderedElementsAre(8));
+}
+
+GTEST_TEST(StronglyConnectedComponentsTest, Cycle) {
+  // A large cycle produces 1 scc.
+  const int length = 2'000;
+  DirectedGraph<int> graph;
+  for (int k = 0; k < length; ++k) {
+    graph[k] = {(k + 1) % length};
+  }
+  auto sccs = FindStronglyConnectedComponents(graph);
+  CheckStronglyConnectedComponentsInvariants(graph, sccs);
+  EXPECT_EQ(sccs.size(), 1);
+}
+
+GTEST_TEST(StronglyConnectedComponentsTest, DeepNest) {
+  // A long nesting path produces N sccs.
+  const int depth = 2'000;
+  DirectedGraph<int> graph;
+  for (int k = 0; k < depth - 1; ++k) {
+    graph[k] = {k + 1};
+  }
+  auto sccs = FindStronglyConnectedComponents(graph);
+  CheckStronglyConnectedComponentsInvariants(graph, sccs);
+  EXPECT_EQ(sccs.size(), depth);
+
+  // Ordering is top-down; successors before sources.
+  EXPECT_EQ(sccs[0].count(depth - 1), 1);
+  EXPECT_EQ(sccs[depth - 1].count(0), 1);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/process_model_directives_test/collision_filter_group.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/collision_filter_group.dmd.yaml
@@ -36,3 +36,32 @@ directives:
     members: [model3::base]
     ignored_collision_filter_groups: [nested::across_sub_models]
 
+- add_model:
+    name: model4
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_model:
+    name: model5
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_model:
+    name: model6
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_model:
+    name: model7
+    file: package://process_model_directives_test/simple_model.sdf
+
+# Build a group from other groups.
+- add_collision_filter_group:
+    name: group_45
+    members: [model4::base, model5::base]
+
+- add_collision_filter_group:
+    name: group_67
+    members: [model6::base, model7::base]
+
+- add_collision_filter_group:
+    name: group_4567
+    member_groups: [group_45, group_67]
+    ignored_collision_filter_groups: [group_4567]

--- a/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test/test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/collision_filter_group_parsing_test/test.sdf
@@ -20,5 +20,11 @@
       <drake:member>robot1::link3</drake:member>
       <drake:ignored_collision_filter_group>robot2::group_link3</drake:ignored_collision_filter_group>
     </drake:collision_filter_group>
+    <drake:collision_filter_group name="group_of_groups">
+      <!-- Build a group and rule from collision filter groups of nested robots. -->
+      <drake:member_group>robot1::group_link2</drake:member_group>
+      <drake:member_group>robot2::group_link3</drake:member_group>
+      <drake:ignored_collision_filter_group>group_of_groups</drake:ignored_collision_filter_group>
+    </drake:collision_filter_group>
   </model>
 </sdf>

--- a/multibody/parsing/test/urdf_parser_test/collision_filter_group_parsing_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/collision_filter_group_parsing_test.urdf
@@ -45,6 +45,34 @@ Defines a URDF model with collision filter groups.
       </geometry>
     </collision>
   </link>
+  <link name="link7">
+    <collision name="link7_sphere">
+      <geometry>
+        <sphere radius="0.40"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="link8">
+    <collision name="link8_sphere">
+      <geometry>
+        <sphere radius="0.40"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="link9">
+    <collision name="link9_sphere">
+      <geometry>
+        <sphere radius="0.40"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="link10">
+    <collision name="link10_sphere">
+      <geometry>
+        <sphere radius="0.40"/>
+      </geometry>
+    </collision>
+  </link>
   <drake:collision_filter_group name="group_link14">
     <drake:member link="link1"/>
     <drake:member link="link4"/>
@@ -69,5 +97,18 @@ Defines a URDF model with collision filter groups.
     <drake:ignored_collision_filter_group name="group_link56"/>
     <drake:ignored_collision_filter_group name="group_link3"/>
     <drake:ignored_collision_filter_group name="group_link2"/>
+  </drake:collision_filter_group>
+  <drake:collision_filter_group name="group_link78">
+    <drake:member link="link7"/>
+    <drake:member link="link8"/>
+  </drake:collision_filter_group>
+  <drake:collision_filter_group name="group_link910">
+    <drake:member link="link9"/>
+    <drake:member link="link10"/>
+  </drake:collision_filter_group>
+  <drake:collision_filter_group name="group_of_groups">
+    <drake:member_group name="group_link78"/>
+    <drake:member_group name="group_link910"/>
+    <drake:ignored_collision_filter_group name="group_of_groups"/>
   </drake:collision_filter_group>
 </robot>


### PR DESCRIPTION
This patch allows collision filter groups to add the members of other groups by naming the group, instead of (previously) re-iterating all of the member links.

Since groups naming other groups induces an arbitrary graph at resolution time, do the proper graph for reasonably efficient resolution. Graph cycles are permitted.

Implement and test parsing support in URDF, SDFormat, and Drake Model Directives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20925)
<!-- Reviewable:end -->
