### PR TITLE
[Meshcat] Change the default recording framerate to 64 fps.

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -343,7 +343,7 @@ void DoScalarIndependentDefinitions(py::module m) {
             // on a worker thread; for both reasons, we must release the GIL.
             py::call_guard<py::gil_scoped_release>(), cls_doc.StaticHtml.doc)
         .def("StartRecording", &Class::StartRecording,
-            py::arg("frames_per_second") = 32.0,
+            py::arg("frames_per_second") = 64.0,
             py::arg("set_visualizations_while_recording") = true,
             cls_doc.StartRecording.doc)
         .def("StopRecording", &Class::StopRecording, cls_doc.StopRecording.doc)

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -836,7 +836,7 @@ class Meshcat {
   the visualizer immediately (because meshcat animations do not support
   SetObject).
   */
-  void StartRecording(double frames_per_second = 32.0,
+  void StartRecording(double frames_per_second = 64.0,
                       bool set_visualizations_while_recording = true);
 
   /** Sets a flag to pause/stop recording.  When stopped, publish events will

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -321,6 +321,36 @@ TEST_F(MeshcatVisualizerWithIiwaTest, RecordingWithoutSetTransform) {
       X_7_message);
 }
 
+// Confirm that the default frame rates match the publish period of the
+// visualizer. Otherwise the rounding to an animation frame done in
+// MeshcatAnimation can lead to odd visualization artifacts, like the first
+// visualized frame not being the initial state. (Technically, it's OK to have
+// the visualizer's publish period be any integer multiple of the meshcat
+// recording's keyframe period; for expediency, we just test for exact
+// equality.)
+TEST_F(MeshcatVisualizerWithIiwaTest, RecordingFrameRate) {
+  MeshcatVisualizerParams params;
+  SetUpDiagram(params);
+
+  // StartRecording via the MeshcatVisualizer API.
+  visualizer_->StartRecording();
+  MeshcatAnimation* animation = &meshcat_->get_mutable_recording();
+  EXPECT_EQ(1.0 / animation->frames_per_second(), params.publish_period);
+  visualizer_->DeleteRecording();
+
+  // Set the animation to a different frame rate before our final test, for good
+  // measure.
+  meshcat_->StartRecording(12.3);
+  animation = &meshcat_->get_mutable_recording();
+  EXPECT_EQ(animation->frames_per_second(), 12.3);
+  visualizer_->DeleteRecording();
+
+  // StartRecording via the Meshcat API.
+  meshcat_->StartRecording();
+  animation = &meshcat_->get_mutable_recording();
+  EXPECT_EQ(1.0 / animation->frames_per_second(), params.publish_period);
+}
+
 TEST_F(MeshcatVisualizerWithIiwaTest, ScalarConversion) {
   SetUpDiagram();
 


### PR DESCRIPTION
The default framerate for StartRecording should match the default publish period of MeshcatVisualizer. Mismatches can lead to unexpected behavior:
https://stackoverflow.com/questions/77916511/meshcat-not-visualizing-initial-conditions-correctly-drake/77979312#77979312

+@jwnimmer-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20926)
<!-- Reviewable:end -->
