### PR TITLE
[yaml] Improve variant support for primitive types

### DIFF
--- a/common/yaml/test/example_structs.h
+++ b/common/yaml/test/example_structs.h
@@ -264,6 +264,18 @@ struct VariantWrappingStruct {
   VariantStruct inner;
 };
 
+using PrimitiveVariant =
+    std::variant<std::vector<double>, bool, int, double, std::string>;
+
+struct PrimitiveVariantStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  PrimitiveVariant value = kNominalDouble;
+};
+
 struct OuterStruct {
   struct InnerStruct {
     template <typename Archive>

--- a/common/yaml/test/json_test.cc
+++ b/common/yaml/test/json_test.cc
@@ -79,32 +79,14 @@ GTEST_TEST(YamlJsonTest, WriteVariant) {
   data.value = std::string{"foo"};
   EXPECT_EQ(SaveJsonString(data), R"""({"value":"foo"})""");
 
+  data.value = 0.5;
+  EXPECT_EQ(SaveJsonString(data), R"""({"value":0.5})""");
+
   // It would be plausible here to use the `_tag` convention to annotate
   // variant tags, matching what we do in our yaml.py conventions.
   data.value = DoubleStruct{};
   DRAKE_EXPECT_THROWS_MESSAGE(SaveJsonString(data),
                               ".*SaveJsonString.*mapping.*tag.*");
-}
-
-struct IntVariant {
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-
-  std::variant<int, uint64_t> value{0};
-};
-
-GTEST_TEST(YamlJsonTest, WriteVariantScalar) {
-  IntVariant data;
-
-  data.value.emplace<int>(1);
-  EXPECT_EQ(SaveJsonString(data), R"""({"value":1})""");
-
-  // There is no syntax that could express this in JSON.
-  data.value.emplace<uint64_t>(22);
-  DRAKE_EXPECT_THROWS_MESSAGE(SaveJsonString(data),
-                              ".*SaveJsonString.*scalar.*22.*tag.*");
 }
 
 GTEST_TEST(YamlJsonTest, FileRoundTrip) {

--- a/common/yaml/test/yaml_node_test.cc
+++ b/common/yaml/test/yaml_node_test.cc
@@ -117,12 +117,23 @@ TEST_P(YamlNodeParamaterizedTest, JsonSchemaTag) {
   Node dut = MakeEmptyDut();
   dut.SetTag(JsonSchemaTag::kNull);
   EXPECT_EQ(dut.GetTag(), Node::kTagNull);
+  EXPECT_FALSE(dut.IsTagImportant());
   dut.SetTag(JsonSchemaTag::kBool);
   EXPECT_EQ(dut.GetTag(), Node::kTagBool);
+  EXPECT_FALSE(dut.IsTagImportant());
   dut.SetTag(JsonSchemaTag::kInt);
   EXPECT_EQ(dut.GetTag(), Node::kTagInt);
+  EXPECT_FALSE(dut.IsTagImportant());
   dut.SetTag(JsonSchemaTag::kFloat);
   EXPECT_EQ(dut.GetTag(), Node::kTagFloat);
+  EXPECT_FALSE(dut.IsTagImportant());
+  dut.SetTag(JsonSchemaTag::kStr);
+  EXPECT_EQ(dut.GetTag(), Node::kTagStr);
+  EXPECT_FALSE(dut.IsTagImportant());
+  // Make sure `important = true` makes it all the way through.
+  dut.SetTag(JsonSchemaTag::kBool, true);
+  EXPECT_EQ(dut.GetTag(), Node::kTagBool);
+  EXPECT_TRUE(dut.IsTagImportant());
 }
 
 // Check mark getting and setting.

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -534,6 +534,30 @@ TEST_P(YamlReadArchiveTest, Variant) {
   test("doc:\n  value: !DoubleStruct { value: 1.0 }", DoubleStruct{1.0});
 }
 
+TEST_P(YamlReadArchiveTest, PrimitiveVariant) {
+  const auto test = [](const std::string& doc,
+                       const PrimitiveVariant& expected) {
+    const auto& x = AcceptNoThrow<PrimitiveVariantStruct>(Load(doc));
+    EXPECT_EQ(x.value, expected) << doc;
+  };
+
+  test("doc:\n  value: [1.0, 2.0]", std::vector<double>{1.0, 2.0});
+  test("doc:\n  value: !!bool true", true);
+  test("doc:\n  value: !!bool 'true'", true);
+  test("doc:\n  value: !!int 10", 10);
+  test("doc:\n  value: !!int '10'", 10);
+  test("doc:\n  value: !!float 1.0", 1.0);
+  test("doc:\n  value: !!float '1.0'", 1.0);
+  test("doc:\n  value: !!str foo", std::string("foo"));
+  test("doc:\n  value: !!str 'foo'", std::string("foo"));
+
+  // It might be sensible for this case to pass, but for now we'll require that
+  // non-0'th variant indices always use a tag even where it could be inferred.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      AcceptIntoDummy<PrimitiveVariantStruct>(Load("doc:\n  value: 1.0")),
+      ".*vector.*double.*");
+}
+
 // When loading a variant, the default value should remain intact in cases where
 // the type tag is unchanged.
 TEST_P(YamlReadArchiveTest, VariantNestedDefaults) {

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -210,15 +210,24 @@ TEST_F(YamlWriteArchiveTest, Variant) {
 
   test(Variant4(std::string()), "\"\"");
   test(Variant4(std::string("foo")), "foo");
+  test(Variant4(1.0), "!!float 1.0");
   test(Variant4(DoubleStruct{1.0}), "!DoubleStruct\n    value: 1.0");
   test(Variant4(EigenVecStruct{Eigen::Vector2d(1.0, 2.0)}),
        "!EigenStruct\n    value: [1.0, 2.0]");
+}
 
-  // TODO(jwnimmer-tri) We'd like to see "!!float 1.0" here, but our writer
-  // does not yet support that output syntax.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      Save(VariantStruct{double{1.0}}),
-      "Cannot YamlWriteArchive the variant type double with a non-zero index");
+TEST_F(YamlWriteArchiveTest, PrimitiveVariant) {
+  const auto test = [](const PrimitiveVariant& value,
+                       const std::string& expected) {
+    const PrimitiveVariantStruct x{value};
+    EXPECT_EQ(Save(x), WrapDoc(expected));
+  };
+
+  test(std::vector<double>{1.0, 2.0}, "[1.0, 2.0]");
+  test(true, "!!bool true");
+  test(10, "!!int 10");
+  test(1.0, "!!float 1.0");
+  test(std::string("foo"), "!!str foo");
 }
 
 TEST_F(YamlWriteArchiveTest, EigenVector) {

--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -34,9 +34,17 @@ void RecursiveEmit(const internal::Node& node, YAML::EmitFromEvents* sink) {
   if ((tag == internal::Node::kTagNull) || (tag == internal::Node::kTagBool) ||
       (tag == internal::Node::kTagInt) || (tag == internal::Node::kTagFloat) ||
       (tag == internal::Node::kTagStr)) {
-    // We don't need to emit the "JSON Schema" tags for YAML data. They are
-    // implied by default.
-    tag.clear();
+    // In most cases we don't need to emit the "JSON Schema" tags for YAML data,
+    // because they are implied by default. However, YamlWriteArchive on variant
+    // types sometimes marks the tag as important.
+    if (node.IsTagImportant()) {
+      DRAKE_DEMAND(tag.size() > 0);
+      // The `internal::Node::kTagFoo` all look like "tag:yaml.org,2002:foo".
+      // We only want the "foo" part (after the second colon).
+      tag = "!!" + tag.substr(18);
+    } else {
+      tag.clear();
+    }
   }
   node.Visit(overloaded{
       [&](const internal::Node::ScalarData& data) {

--- a/geometry/test/meshcat_params_test.cc
+++ b/geometry/test/meshcat_params_test.cc
@@ -9,14 +9,33 @@
 
 namespace drake {
 namespace geometry {
+
+// TODO(jwnimmer-tri) Possibly we could promote this into the header file?
+// Really, we should code-gen it from the Serialize function automatically.
+bool operator==(const MeshcatParams::PropertyTuple& a,
+                const MeshcatParams::PropertyTuple& b) {
+  return std::tie(a.path, a.property, a.value) ==
+         std::tie(b.path, b.property, b.value);
+}
+
 namespace {
 
 GTEST_TEST(MeshcatParamsTest, RoundTrip) {
   // Populate a params struct with interesting values.
+  const std::vector<double> some_vector{1.0, 2.0};
+  const std::string some_string{"hello"};
+  const bool some_bool{true};
+  const double some_double{22.2};
   const MeshcatParams original{
       .host = "some_host",
       .port = 7001,
       .web_url_pattern = "http://{host}:{port}/proxy",
+      .initial_properties = {
+          {.path = "a", .property = "p1", .value = some_vector},
+          {.path = "b", .property = "p2", .value = some_string},
+          {.path = "c", .property = "p3", .value = some_bool},
+          {.path = "d", .property = "p4", .value = some_double},
+      },
   };
 
   // Make sure we can save & re-load it.
@@ -27,8 +46,9 @@ GTEST_TEST(MeshcatParamsTest, RoundTrip) {
 
   // Check that everything made it back intact. We can rely on the YAML
   // library's unit tests to check that save and re-load generally works,
-  // but we'll do a spot-check to be safe.
+  // but we'll spot-check a few of the more interesting values to be safe.
   EXPECT_EQ(readback.port, original.port);
+  EXPECT_EQ(readback.initial_properties, original.initial_properties);
 }
 
 }  // namespace

--- a/tools/workspace/yaml_cpp_internal/patches/emit-local-tag.patch
+++ b/tools/workspace/yaml_cpp_internal/patches/emit-local-tag.patch
@@ -1,14 +1,12 @@
-From b13b20e7ffe8f9744206f57dddf562d342d6d97b Mon Sep 17 00:00:00 2001
-From: Jeremy Nimmer <jeremy.nimmer@tri.global>
-Date: Thu, 9 Jul 2020 11:57:02 -0400
-Subject: [PATCH] yaml: Permit writing variant values beyond the 0'th index (#13631)
+[yaml_cpp] Customize tag emitting for Drake
 
 Upstream yaml-cpp does not support writing out primary tags, so here
-we also patch our vendored copy of yaml-cpp's emitter to write them.
+we patch our vendored copy of yaml-cpp's emitter to write them, so
+that Drake's YamlWriteArchive can support std::variant<> emitting.
 
 --- src/emitfromevents.cpp
 +++ src/emitfromevents.cpp
-@@ -109,8 +109,14 @@ void EmitFromEvents::BeginNode() {
+@@ -109,8 +109,18 @@ void EmitFromEvents::BeginNode() {
  }
  
  void EmitFromEvents::EmitProps(const std::string& tag, anchor_t anchor) {
@@ -16,11 +14,15 @@ we also patch our vendored copy of yaml-cpp's emitter to write them.
 -    m_emitter << VerbatimTag(tag);
 +  if (!tag.empty() && tag != "?" && tag != "!") {
 +    // N.B. The upstream yaml-cpp uses VerbatimTag here, but Drake has patched
-+    // this file to use LocalTag instead.  Upstream support for custom tags
++    // this file to meet our needs instead. Upstream support for custom tags
 +    // during emitting is "pretty bad" (i.e., non-existent); for details see
 +    // https://github.com/jbeder/yaml-cpp/issues/311 and
 +    // https://github.com/jbeder/yaml-cpp/issues/447.
-+    m_emitter << LocalTag(tag);
++    if (tag.substr(0, 2) == "!!") {
++      m_emitter << SecondaryTag(tag.substr(2));
++    } else {
++      m_emitter << LocalTag(tag);
++    }
 +  }
    if (anchor)
      m_emitter << Anchor(ToString(anchor));


### PR DESCRIPTION
This is necessary for C++ code to be able to parse the YAML syntax used in #20920.

The general idea is that when a `std::variant<>` (or `typing.Union`) meets YAML, we want use the YAML tag to disambiguate which type is being used in the document.  For user-defined types, we can just say `!MySubStruct` can call it a day.  For primitive types, there is already a tag convention that we need to follow: the "JSON schema" tags.  Using those tags requires special code paths, so I waited to implement it until we needed it.  Now we need it.

YAML processing rules also have a bunch of language about how to _infer_ a tag when none is provided.  So far, we're not going to support that usage; instead we'll always require the YAML document to write down a specific type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20937)
<!-- Reviewable:end -->
