### PR TITLE
[multibody] Make joint damping a system parameter

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1840,6 +1840,7 @@ class TestPlant(unittest.TestCase):
         """
         array_T = np.vectorize(T)
         damping = 2.
+        different_damping = 3.4
         x_axis = [1., 0., 0.]
         X_PC = RigidTransform_[float](p=[1., 2., 3.])
 
@@ -1856,7 +1857,7 @@ class TestPlant(unittest.TestCase):
                 name="planar",
                 frame_on_parent=P,
                 frame_on_child=C,
-                damping=[1., 2., 3.],
+                damping=[damping, damping, damping],
             )
 
         def make_prismatic_joint(plant, P, C):
@@ -1971,9 +1972,25 @@ class TestPlant(unittest.TestCase):
                     "tau", default_model_instance()))
                 self.assertIsInstance(actuator, JointActuator_[T])
 
+            damping_vector = []
+            different_damping_vector = []
+
+            if joint.name() != "weld":
+                damping_vector = joint.num_velocities() * [damping]
+                different_damping_vector = \
+                    joint.num_velocities() * [different_damping]
+                numpy_compare.assert_equal(
+                    joint.default_damping_vector(), damping_vector)
+                joint.set_default_damping_vector(
+                    damping=different_damping_vector)
+                numpy_compare.assert_equal(
+                    joint.default_damping_vector(), different_damping_vector)
+                joint.set_default_damping_vector(damping=damping_vector)
+
             if joint.name() in ["prismatic", "revolute"]:
                 # This must be called pre-Finalize().
                 joint.set_default_damping(damping=damping)
+                self.assertEqual(joint.damping(), damping)
 
             plant.Finalize()
             context = plant.CreateDefaultContext()
@@ -2005,6 +2022,17 @@ class TestPlant(unittest.TestCase):
                 self.assertTrue(joint.is_locked(context))
                 joint.Unlock(context)
                 self.assertFalse(joint.is_locked(context))
+
+            if joint.name() != "weld":
+                numpy_compare.assert_equal(
+                    joint.GetDampingVector(context), array_T(damping_vector))
+                joint.SetDampingVector(context,
+                                       array_T(different_damping_vector))
+                numpy_compare.assert_equal(
+                    joint.GetDampingVector(context),
+                    array_T(different_damping_vector))
+                joint.SetDampingVector(context,
+                                       array_T(damping_vector))
 
             if joint.name() == "ball_rpy":
                 joint.damping()
@@ -2073,6 +2101,11 @@ class TestPlant(unittest.TestCase):
                 joint.acceleration_upper_limit()
                 joint.get_default_translation()
                 joint.set_default_translation(translation=0.0)
+                numpy_compare.assert_equal(
+                    joint.GetDamping(context), T(damping))
+                joint.SetDamping(context, T(different_damping))
+                numpy_compare.assert_equal(
+                    joint.GetDamping(context), T(different_damping))
             elif joint.name() == "quaternion_floating":
                 self.assertEqual(joint.angular_damping(), damping)
                 self.assertEqual(joint.translational_damping(), damping)
@@ -2131,6 +2164,11 @@ class TestPlant(unittest.TestCase):
                 joint.AddInOneForce(
                     context=context, joint_dof=0, joint_tau=0.0, forces=forces)
                 joint.AddInDamping(context=context, forces=forces)
+                numpy_compare.assert_equal(
+                    joint.GetDamping(context), T(damping))
+                joint.SetDamping(context, T(different_damping))
+                numpy_compare.assert_equal(
+                    joint.GetDamping(context), T(different_damping))
             elif joint.name() == "rpy_floating":
                 self.assertEqual(joint.type_name(), "rpy_floating")
                 self.assertEqual(joint.angular_damping(), damping)
@@ -2177,6 +2215,11 @@ class TestPlant(unittest.TestCase):
                 # Check the Joint base class sugar for 1dof.
                 joint.GetOnePosition(context=context)
                 joint.GetOneVelocity(context=context)
+                numpy_compare.assert_equal(
+                    joint.GetDamping(context), T(damping))
+                joint.SetDamping(context, T(different_damping))
+                numpy_compare.assert_equal(
+                    joint.GetDamping(context), T(different_damping))
             elif joint.name() == "universal":
                 self.assertEqual(joint.damping(), damping)
                 set_point = array_T([1., 2.])

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1975,12 +1975,22 @@ class TestPlant(unittest.TestCase):
             damping_vector = []
             different_damping_vector = []
 
+            # Calling deprecated Joint.damping_vector() should raise a warning.
+            with catch_drake_warnings(expected_count=1) as w:
+                joint.damping_vector()
+                self.assertIn("2024-06-01", str(w[0].message))
+
             if joint.name() != "weld":
                 damping_vector = joint.num_velocities() * [damping]
                 different_damping_vector = \
                     joint.num_velocities() * [different_damping]
                 numpy_compare.assert_equal(
                     joint.default_damping_vector(), damping_vector)
+                # Test deprecated API still works until removal.
+                with catch_drake_warnings(expected_count=1) as w:
+                    numpy_compare.assert_equal(joint.damping_vector(),
+                                               damping_vector)
+                    self.assertIn("2024-06-01", str(w[0].message))
                 joint.set_default_damping_vector(
                     damping=different_damping_vector)
                 numpy_compare.assert_equal(
@@ -1990,7 +2000,7 @@ class TestPlant(unittest.TestCase):
             if joint.name() in ["prismatic", "revolute"]:
                 # This must be called pre-Finalize().
                 joint.set_default_damping(damping=damping)
-                self.assertEqual(joint.damping(), damping)
+                self.assertEqual(joint.default_damping(), damping)
 
             plant.Finalize()
             context = plant.CreateDefaultContext()
@@ -2035,7 +2045,12 @@ class TestPlant(unittest.TestCase):
                                        array_T(damping_vector))
 
             if joint.name() == "ball_rpy":
-                joint.damping()
+                self.assertEqual(joint.default_damping(), damping)
+                # Calling deprecated BallRpyJoint.damping() should raise a
+                # warning.
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(joint.damping(), damping)
+                    self.assertIn("2024-06-01", str(w[0].message))
                 set_point = array_T([1., 2., 3.])
                 joint.set_angles(context=context, angles=set_point)
                 numpy_compare.assert_equal(
@@ -2050,7 +2065,12 @@ class TestPlant(unittest.TestCase):
                 joint.get_default_angles()
                 joint.set_default_angles(angles=[0.0, 0.0, 0.0])
             elif joint.name() == "planar":
-                self.assertEqual(len(joint.damping()), 3)
+                self.assertEqual(len(joint.default_damping()), 3)
+                # Calling deprecated PlanarJoint.damping() should raise a
+                # warning.
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(len(joint.damping()), 3)
+                    self.assertIn("2024-06-01", str(w[0].message))
                 set_translation = array_T([1., 2.])
                 set_angle = T(3.)
                 joint.set_translation(context=context,
@@ -2080,7 +2100,12 @@ class TestPlant(unittest.TestCase):
                 joint.set_default_rotation(theta=0.0)
                 joint.set_default_pose(p_FoMo_F=[0.0, 0.0], theta=0.0)
             elif joint.name() == "prismatic":
-                self.assertEqual(joint.damping(), damping)
+                self.assertEqual(joint.default_damping(), damping)
+                # Calling deprecated PrismaticJoint.damping() should raise a
+                # warning.
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(joint.damping(), damping)
+                    self.assertIn("2024-06-01", str(w[0].message))
                 numpy_compare.assert_equal(joint.translation_axis(), x_axis)
                 set_point = T(1.)
                 joint.set_translation(context=context, translation=set_point)
@@ -2107,8 +2132,17 @@ class TestPlant(unittest.TestCase):
                 numpy_compare.assert_equal(
                     joint.GetDamping(context), T(different_damping))
             elif joint.name() == "quaternion_floating":
-                self.assertEqual(joint.angular_damping(), damping)
-                self.assertEqual(joint.translational_damping(), damping)
+                self.assertEqual(joint.default_angular_damping(), damping)
+                self.assertEqual(joint.default_translational_damping(),
+                                 damping)
+                # Calling deprecated QuaternionFloatingJoint.angular_damping()
+                # and .translational_damping() should raise a warning.
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(joint.angular_damping(), damping)
+                    self.assertIn("2024-06-01", str(w[0].message))
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(joint.translational_damping(), damping)
+                    self.assertIn("2024-06-01", str(w[0].message))
                 joint.get_quaternion(context=context)
                 joint.get_position(context=context)
                 joint.get_pose(context=context)
@@ -2139,7 +2173,12 @@ class TestPlant(unittest.TestCase):
                 joint.GetDefaultPosePair()
             elif joint.name() == "revolute":
                 numpy_compare.assert_equal(joint.revolute_axis(), x_axis)
-                self.assertEqual(joint.damping(), damping)
+                self.assertEqual(joint.default_damping(), damping)
+                # Calling deprecated RevoluteJoint.damping() should raise a
+                # warning.
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(joint.damping(), damping)
+                    self.assertIn("2024-06-01", str(w[0].message))
                 set_point = T(1.)
                 joint.set_angle(context=context, angle=set_point)
                 numpy_compare.assert_equal(
@@ -2171,8 +2210,17 @@ class TestPlant(unittest.TestCase):
                     joint.GetDamping(context), T(different_damping))
             elif joint.name() == "rpy_floating":
                 self.assertEqual(joint.type_name(), "rpy_floating")
-                self.assertEqual(joint.angular_damping(), damping)
-                self.assertEqual(joint.translational_damping(), damping)
+                self.assertEqual(joint.default_angular_damping(), damping)
+                self.assertEqual(joint.default_translational_damping(),
+                                 damping)
+                # Calling deprecated RpyFloatingJoint.angular_damping()
+                # and .translational_damping() should raise a warning.
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(joint.angular_damping(), damping)
+                    self.assertIn("2024-06-01", str(w[0].message))
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(joint.translational_damping(), damping)
+                    self.assertIn("2024-06-01", str(w[0].message))
                 joint.get_angles(context=context)
                 joint.set_angles(context=context, angles=[0, 0, 0])
                 joint.SetOrientation(context=context,
@@ -2199,8 +2247,12 @@ class TestPlant(unittest.TestCase):
                 joint.GetDefaultPose()
                 joint.GetDefaultPosePair()
             elif joint.name() == "screw":
-                self.assertEqual(joint.damping(), damping)
-                joint.damping()
+                self.assertEqual(joint.default_damping(), damping)
+                # Calling deprecated ScrewJoint.damping() should raise a
+                # warning.
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(joint.damping(), damping)
+                    self.assertIn("2024-06-01", str(w[0].message))
                 joint.screw_pitch()
                 joint.get_default_rotation()
                 joint.set_default_rotation(0.0)
@@ -2221,7 +2273,12 @@ class TestPlant(unittest.TestCase):
                 numpy_compare.assert_equal(
                     joint.GetDamping(context), T(different_damping))
             elif joint.name() == "universal":
-                self.assertEqual(joint.damping(), damping)
+                self.assertEqual(joint.default_damping(), damping)
+                # Calling deprecated UniversalJoint.damping() should raise a
+                # warning.
+                with catch_drake_warnings(expected_count=1) as w:
+                    self.assertEqual(joint.damping(), damping)
+                    self.assertIn("2024-06-01", str(w[0].message))
                 set_point = array_T([1., 2.])
                 joint.set_angles(context=context, angles=set_point)
                 numpy_compare.assert_equal(

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -477,7 +477,19 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("Lock", &Class::Lock, py::arg("context"), cls_doc.Lock.doc)
         .def("Unlock", &Class::Unlock, py::arg("context"), cls_doc.Unlock.doc)
         .def("is_locked", &Class::is_locked, py::arg("context"),
-            cls_doc.is_locked.doc);
+            cls_doc.is_locked.doc)
+        .def("damping_vector",
+            WrapDeprecated(
+                cls_doc.damping_vector.doc_deprecated, &Class::damping_vector),
+            cls_doc.damping_vector.doc_deprecated)
+        .def("default_damping_vector", &Class::default_damping_vector,
+            cls_doc.default_damping_vector.doc)
+        .def("set_default_damping_vector", &Class::set_default_damping_vector,
+            py::arg("damping"), cls_doc.set_default_damping_vector.doc)
+        .def("GetDampingVector", &Class::GetDampingVector, py::arg("context"),
+            cls_doc.GetDampingVector.doc)
+        .def("SetDampingVector", &Class::SetDampingVector, py::arg("context"),
+            py::arg("damping"), cls_doc.SetDampingVector.doc);
   }
 
   // BallRpyJoint
@@ -606,7 +618,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("translation"), cls_doc.set_default_translation.doc)
         .def("set_random_translation_distribution",
             &Class::set_random_translation_distribution, py::arg("translation"),
-            cls_doc.set_random_translation_distribution.doc);
+            cls_doc.set_random_translation_distribution.doc)
+        .def("GetDamping", &Class::GetDamping, py::arg("context"),
+            cls_doc.GetDamping.doc)
+        .def("SetDamping", &Class::SetDamping, py::arg("context"),
+            py::arg("damping"), cls_doc.SetDamping.doc);
   }
 
   // QuaternionFloatingJoint
@@ -719,7 +735,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_default_angle", &Class::get_default_angle,
             cls_doc.get_default_angle.doc)
         .def("set_default_angle", &Class::set_default_angle, py::arg("angle"),
-            cls_doc.set_default_angle.doc);
+            cls_doc.set_default_angle.doc)
+        .def("GetDamping", &Class::GetDamping, py::arg("context"),
+            cls_doc.GetDamping.doc)
+        .def("SetDamping", &Class::SetDamping, py::arg("context"),
+            py::arg("damping"), cls_doc.SetDamping.doc);
   }
 
   // RpyFloatingJoint
@@ -823,7 +843,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.set_angular_velocity.doc)
         .def("set_random_pose_distribution",
             &Class::set_random_pose_distribution, py::arg("theta"),
-            cls_doc.set_random_pose_distribution.doc);
+            cls_doc.set_random_pose_distribution.doc)
+        .def("GetDamping", &Class::GetDamping, py::arg("context"),
+            cls_doc.GetDamping.doc)
+        .def("SetDamping", &Class::SetDamping, py::arg("context"),
+            py::arg("damping"), cls_doc.SetDamping.doc);
   }
 
   // UniversalJoint

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -477,16 +477,24 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("Lock", &Class::Lock, py::arg("context"), cls_doc.Lock.doc)
         .def("Unlock", &Class::Unlock, py::arg("context"), cls_doc.Unlock.doc)
         .def("is_locked", &Class::is_locked, py::arg("context"),
-            cls_doc.is_locked.doc)
+            cls_doc.is_locked.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
         .def("damping_vector",
             WrapDeprecated(
                 cls_doc.damping_vector.doc_deprecated, &Class::damping_vector),
-            cls_doc.damping_vector.doc_deprecated)
+            cls_doc.damping_vector.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
         .def("default_damping_vector", &Class::default_damping_vector,
+            return_value_policy_for_scalar_type<T>(),
             cls_doc.default_damping_vector.doc)
         .def("set_default_damping_vector", &Class::set_default_damping_vector,
             py::arg("damping"), cls_doc.set_default_damping_vector.doc)
         .def("GetDampingVector", &Class::GetDampingVector, py::arg("context"),
+            // Keep alive, ownership: `return` keeps `context` alive.
+            py::keep_alive<0, 2>(), return_value_policy_for_scalar_type<T>(),
             cls_doc.GetDampingVector.doc)
         .def("SetDampingVector", &Class::SetDampingVector, py::arg("context"),
             py::arg("damping"), cls_doc.SetDampingVector.doc);
@@ -502,8 +510,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(
             py::init<const string&, const Frame<T>&, const Frame<T>&, double>(),
             py::arg("name"), py::arg("frame_on_parent"),
-            py::arg("frame_on_child"), py::arg("damping") = 0, cls_doc.ctor.doc)
-        .def("damping", &Class::damping, cls_doc.damping.doc)
+            py::arg("frame_on_child"), py::arg("damping") = 0,
+            cls_doc.ctor.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("damping",
+            WrapDeprecated(cls_doc.damping.doc_deprecated, &Class::damping),
+            cls_doc.damping.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
+        .def("default_damping", &Class::default_damping,
+            cls_doc.default_damping.doc)
         .def("get_angles", &Class::get_angles, py::arg("context"),
             cls_doc.get_angles.doc)
         .def("set_angles", &Class::set_angles, py::arg("context"),
@@ -533,8 +551,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
                  Vector3<double>>(),
             py::arg("name"), py::arg("frame_on_parent"),
             py::arg("frame_on_child"),
-            py::arg("damping") = Vector3<double>::Zero(), cls_doc.ctor.doc)
-        .def("damping", &Class::damping, cls_doc.damping.doc)
+            py::arg("damping") = Vector3<double>::Zero(), cls_doc.ctor.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("damping",
+            WrapDeprecated(cls_doc.damping.doc_deprecated, &Class::damping),
+            cls_doc.damping.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
+        .def("default_damping", &Class::default_damping,
+            cls_doc.default_damping.doc)
         .def("get_translation", &Class::get_translation, py::arg("context"),
             cls_doc.get_translation.doc)
         .def("set_translation", &Class::set_translation, py::arg("context"),
@@ -587,8 +614,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 std::numeric_limits<double>::infinity(),
             py::arg("damping") = 0, cls_doc.ctor.doc)
         .def("translation_axis", &Class::translation_axis,
-            cls_doc.translation_axis.doc)
-        .def("damping", &Class::damping, cls_doc.damping.doc)
+            cls_doc.translation_axis.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("damping",
+            WrapDeprecated(cls_doc.damping.doc_deprecated, &Class::damping),
+            cls_doc.damping.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
+        .def("default_damping", &Class::default_damping,
+            cls_doc.default_damping.doc)
         .def("set_default_damping", &Class::set_default_damping,
             py::arg("damping"), cls_doc.set_default_damping.doc)
         .def("position_lower_limit", &Class::position_lower_limit,
@@ -636,11 +672,25 @@ void DoScalarDependentDefinitions(py::module m, T) {
                  double>(),
             py::arg("name"), py::arg("frame_on_parent"),
             py::arg("frame_on_child"), py::arg("angular_damping") = 0,
-            py::arg("translational_damping") = 0, cls_doc.ctor.doc)
-        .def("angular_damping", &Class::angular_damping,
-            cls_doc.angular_damping.doc)
-        .def("translational_damping", &Class::translational_damping,
-            cls_doc.translational_damping.doc)
+            py::arg("translational_damping") = 0, cls_doc.ctor.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("angular_damping",
+            WrapDeprecated(cls_doc.angular_damping.doc_deprecated,
+                &Class::angular_damping),
+            cls_doc.angular_damping.doc_deprecated)
+        .def("translational_damping",
+            WrapDeprecated(cls_doc.translational_damping.doc_deprecated,
+                &Class::translational_damping),
+            cls_doc.translational_damping.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
+        .def("default_angular_damping", &Class::default_angular_damping,
+            cls_doc.default_angular_damping.doc)
+        .def("default_translational_damping",
+            &Class::default_translational_damping,
+            cls_doc.default_translational_damping.doc)
         .def("get_quaternion", &Class::get_quaternion, py::arg("context"),
             cls_doc.get_quaternion.doc)
         .def("get_position", &Class::get_position, py::arg("context"),
@@ -705,8 +755,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("frame_on_child"), py::arg("axis"),
             py::arg("pos_lower_limit"), py::arg("pos_upper_limit"),
             py::arg("damping") = 0.0, cls_doc.ctor.doc_7args)
-        .def("revolute_axis", &Class::revolute_axis, cls_doc.revolute_axis.doc)
-        .def("damping", &Class::damping, cls_doc.damping.doc)
+        .def("revolute_axis", &Class::revolute_axis, cls_doc.revolute_axis.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("damping",
+            WrapDeprecated(cls_doc.damping.doc_deprecated, &Class::damping),
+            cls_doc.damping.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
+        .def("default_damping", &Class::default_damping,
+            cls_doc.default_damping.doc)
         .def("set_default_damping", &Class::set_default_damping,
             py::arg("damping"), cls_doc.set_default_damping.doc)
         .def("position_lower_limit", &Class::position_lower_limit,
@@ -753,11 +812,25 @@ void DoScalarDependentDefinitions(py::module m, T) {
                  double>(),
             py::arg("name"), py::arg("frame_on_parent"),
             py::arg("frame_on_child"), py::arg("angular_damping") = 0,
-            py::arg("translational_damping") = 0, cls_doc.ctor.doc)
-        .def("angular_damping", &Class::angular_damping,
-            cls_doc.angular_damping.doc)
-        .def("translational_damping", &Class::translational_damping,
-            cls_doc.translational_damping.doc)
+            py::arg("translational_damping") = 0, cls_doc.ctor.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("angular_damping",
+            WrapDeprecated(cls_doc.angular_damping.doc_deprecated,
+                &Class::angular_damping),
+            cls_doc.angular_damping.doc_deprecated)
+        .def("translational_damping",
+            WrapDeprecated(cls_doc.translational_damping.doc_deprecated,
+                &Class::translational_damping),
+            cls_doc.translational_damping.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
+        .def("default_angular_damping", &Class::default_angular_damping,
+            cls_doc.default_angular_damping.doc)
+        .def("default_translational_damping",
+            &Class::default_translational_damping,
+            cls_doc.default_translational_damping.doc)
         .def("get_angles", &Class::get_angles, py::arg("context"),
             cls_doc.get_angles.doc)
         .def("set_angles", &Class::set_angles, py::arg("context"),
@@ -815,8 +888,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("name"), py::arg("frame_on_parent"),
             py::arg("frame_on_child"), py::arg("axis"), py::arg("screw_pitch"),
             py::arg("damping"), cls_doc.ctor.doc_6args)
-        .def("screw_pitch", &Class::screw_pitch, cls_doc.screw_pitch.doc)
-        .def("damping", &Class::damping, cls_doc.damping.doc)
+        .def("screw_pitch", &Class::screw_pitch, cls_doc.screw_pitch.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("damping",
+            WrapDeprecated(cls_doc.damping.doc_deprecated, &Class::damping),
+            cls_doc.damping.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
+        .def("default_damping", &Class::default_damping,
+            cls_doc.default_damping.doc)
         .def("get_default_translation", &Class::get_default_translation,
             cls_doc.get_default_translation.doc)
         .def("set_default_translation", &Class::set_default_translation,
@@ -860,8 +942,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(
             py::init<const string&, const Frame<T>&, const Frame<T>&, double>(),
             py::arg("name"), py::arg("frame_on_parent"),
-            py::arg("frame_on_child"), py::arg("damping") = 0, cls_doc.ctor.doc)
-        .def("damping", &Class::damping, cls_doc.damping.doc)
+            py::arg("frame_on_child"), py::arg("damping") = 0,
+            cls_doc.ctor.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("damping",
+            WrapDeprecated(cls_doc.damping.doc_deprecated, &Class::damping),
+            cls_doc.damping.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
+        .def("default_damping", &Class::default_damping,
+            cls_doc.default_damping.doc)
         .def("get_angles", &Class::get_angles, py::arg("context"),
             cls_doc.get_angles.doc)
         .def("set_angles", &Class::set_angles, py::arg("context"),

--- a/multibody/parsing/test/acrobot_parser_test.cc
+++ b/multibody/parsing/test/acrobot_parser_test.cc
@@ -116,8 +116,8 @@ TEST_P(AcrobotModelTests, ModelBasics) {
             elbow_->index());
 
   // Verify we parse damping correctly.
-  EXPECT_EQ(shoulder_->damping(), parameters_.b1());
-  EXPECT_EQ(elbow_->damping(), parameters_.b2());
+  EXPECT_EQ(shoulder_->default_damping(), parameters_.b1());
+  EXPECT_EQ(elbow_->default_damping(), parameters_.b2());
 
   // State size.
   EXPECT_EQ(plant_->num_positions(), benchmark_plant_->num_positions());

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -1136,7 +1136,7 @@ TEST_F(MujocoParserTest, Joint) {
 
   const BallRpyJoint<double>& ball_joint =
       plant_.GetJointByName<BallRpyJoint>("ball");
-  EXPECT_EQ(ball_joint.damping(), 0.1);
+  EXPECT_EQ(ball_joint.default_damping(), 0.1);
   EXPECT_TRUE(ball_joint.frame_on_child()
                   .CalcPoseInBodyFrame(*context)
                   .IsNearlyEqualTo(RigidTransformd(pos), 1e-14));
@@ -1146,7 +1146,7 @@ TEST_F(MujocoParserTest, Joint) {
 
   const PrismaticJoint<double>& slide_joint =
       plant_.GetJointByName<PrismaticJoint>("slide");
-  EXPECT_EQ(slide_joint.damping(), 0.2);
+  EXPECT_EQ(slide_joint.default_damping(), 0.2);
   EXPECT_TRUE(slide_joint.frame_on_child()
                   .CalcPoseInBodyFrame(*context)
                   .IsNearlyEqualTo(RigidTransformd(pos), 1e-14));
@@ -1162,7 +1162,7 @@ TEST_F(MujocoParserTest, Joint) {
 
   const RevoluteJoint<double>& hinge_joint =
       plant_.GetJointByName<RevoluteJoint>("hinge");
-  EXPECT_EQ(hinge_joint.damping(), 0.3);
+  EXPECT_EQ(hinge_joint.default_damping(), 0.3);
   EXPECT_TRUE(hinge_joint.frame_on_child()
                   .CalcPoseInBodyFrame(*context)
                   .IsNearlyEqualTo(RigidTransformd(pos), 1e-14));
@@ -1179,7 +1179,7 @@ TEST_F(MujocoParserTest, Joint) {
 
   const RevoluteJoint<double>& hinge_w_joint_defaults_joint =
       plant_.GetJointByName<RevoluteJoint>("hinge_w_joint_defaults");
-  EXPECT_EQ(hinge_w_joint_defaults_joint.damping(), 0.24);
+  EXPECT_EQ(hinge_w_joint_defaults_joint.default_damping(), 0.24);
   EXPECT_TRUE(
       hinge_w_joint_defaults_joint.frame_on_child()
           .CalcPoseInBodyFrame(*context)
@@ -1198,7 +1198,7 @@ TEST_F(MujocoParserTest, Joint) {
 
   const RevoluteJoint<double>& default_joint =
       plant_.GetJointByName<RevoluteJoint>("default");
-  EXPECT_EQ(default_joint.damping(), 0.4);
+  EXPECT_EQ(default_joint.default_damping(), 0.4);
   EXPECT_TRUE(default_joint.frame_on_child()
                   .CalcPoseInBodyFrame(*context)
                   .IsNearlyIdentity(1e-14));
@@ -1216,14 +1216,14 @@ TEST_F(MujocoParserTest, Joint) {
 
   const RevoluteJoint<double>& hinge1_joint =
       plant_.GetJointByName<RevoluteJoint>("hinge1");
-  EXPECT_EQ(hinge1_joint.damping(), 0.5);
+  EXPECT_EQ(hinge1_joint.default_damping(), 0.5);
   EXPECT_TRUE(CompareMatrices(hinge1_joint.revolute_axis(), Vector3d{1, 0, 0}));
   EXPECT_TRUE(hinge1_joint.frame_on_parent()
                   .CalcPoseInBodyFrame(*context)
                   .IsNearlyEqualTo(RigidTransformd(pos), 1e-14));
   const RevoluteJoint<double>& hinge2_joint =
       plant_.GetJointByName<RevoluteJoint>("hinge2");
-  EXPECT_EQ(hinge2_joint.damping(), 0.6);
+  EXPECT_EQ(hinge2_joint.default_damping(), 0.6);
   EXPECT_TRUE(CompareMatrices(hinge2_joint.revolute_axis(), Vector3d{0, 1, 0}));
   EXPECT_TRUE(hinge2_joint.frame_on_child()
                   .CalcPoseInBodyFrame(*context)

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1420,7 +1420,7 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_EQ(revolute_joint.parent_body().name(), "link1");
   EXPECT_EQ(revolute_joint.child_body().name(), "link2");
   EXPECT_EQ(revolute_joint.revolute_axis(), Vector3d::UnitZ());
-  EXPECT_EQ(revolute_joint.damping(), 0.2);
+  EXPECT_EQ(revolute_joint.default_damping(), 0.2);
   EXPECT_TRUE(CompareMatrices(
       revolute_joint.position_lower_limits(), Vector1d(-1)));
   EXPECT_TRUE(CompareMatrices(
@@ -1443,7 +1443,7 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_EQ(prismatic_joint.parent_body().name(), "link2");
   EXPECT_EQ(prismatic_joint.child_body().name(), "link3");
   EXPECT_EQ(prismatic_joint.translation_axis(), Vector3d::UnitZ());
-  EXPECT_EQ(prismatic_joint.damping(), 0.3);
+  EXPECT_EQ(prismatic_joint.default_damping(), 0.3);
   EXPECT_TRUE(CompareMatrices(
       prismatic_joint.position_lower_limits(), Vector1d(-2)));
   EXPECT_TRUE(CompareMatrices(
@@ -1485,7 +1485,7 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_EQ(ball_joint.name(), "ball_joint");
   EXPECT_EQ(ball_joint.parent_body().name(), "link4");
   EXPECT_EQ(ball_joint.child_body().name(), "link5");
-  EXPECT_EQ(ball_joint.damping(), 0.1);
+  EXPECT_EQ(ball_joint.default_damping(), 0.1);
   const Vector3d inf3(std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity());
@@ -1511,7 +1511,7 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_EQ(universal_joint.name(), "universal_joint");
   EXPECT_EQ(universal_joint.parent_body().name(), "link5");
   EXPECT_EQ(universal_joint.child_body().name(), "link6");
-  EXPECT_EQ(universal_joint.damping(), 0.1);
+  EXPECT_EQ(universal_joint.default_damping(), 0.1);
   const Vector2d inf2(std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity());
   const Vector2d neg_inf2(-std::numeric_limits<double>::infinity(),
@@ -1558,7 +1558,8 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_EQ(planar_joint.parent_body().model_instance(), instance1);
   EXPECT_EQ(planar_joint.child_body().name(), "link7");
   EXPECT_EQ(planar_joint.child_body().model_instance(), instance1);
-  EXPECT_TRUE(CompareMatrices(planar_joint.damping(), Vector3d::Constant(0.1)));
+  EXPECT_TRUE(
+      CompareMatrices(planar_joint.default_damping(), Vector3d::Constant(0.1)));
   EXPECT_TRUE(CompareMatrices(planar_joint.position_lower_limits(), neg_inf3));
   EXPECT_TRUE(CompareMatrices(planar_joint.position_upper_limits(), inf3));
   EXPECT_TRUE(CompareMatrices(planar_joint.velocity_lower_limits(), neg_inf3));
@@ -1574,7 +1575,7 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_EQ(planar_joint2.parent_body().model_instance(), instance2);
   EXPECT_EQ(planar_joint2.child_body().name(), "link7");
   EXPECT_EQ(planar_joint2.child_body().model_instance(), instance2);
-  EXPECT_TRUE(CompareMatrices(planar_joint2.damping(),
+  EXPECT_TRUE(CompareMatrices(planar_joint2.default_damping(),
                               Vector3d::Constant(0.2)));
   EXPECT_TRUE(CompareMatrices(planar_joint2.position_lower_limits(), neg_inf3));
   EXPECT_TRUE(CompareMatrices(planar_joint2.position_upper_limits(), inf3));
@@ -1611,7 +1612,7 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_EQ(screw_joint.child_body().name(), "link9");
   EXPECT_EQ(screw_joint.screw_axis(), Vector3d::UnitX());
   EXPECT_EQ(screw_joint.screw_pitch(), 0.04);
-  EXPECT_EQ(screw_joint.damping(), 0.1);
+  EXPECT_EQ(screw_joint.default_damping(), 0.1);
   EXPECT_TRUE(
       CompareMatrices(screw_joint.position_lower_limits(), neg_inf));
   EXPECT_TRUE(CompareMatrices(screw_joint.position_upper_limits(), inf));

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -820,7 +820,7 @@ TEST_F(UrdfParserTest, JointParsingTest) {
   EXPECT_EQ(revolute_joint.parent_body().name(), "link1");
   EXPECT_EQ(revolute_joint.child_body().name(), "link2");
   EXPECT_EQ(revolute_joint.revolute_axis(), Vector3d::UnitZ());
-  EXPECT_EQ(revolute_joint.damping(), 0.1);
+  EXPECT_EQ(revolute_joint.default_damping(), 0.1);
   EXPECT_TRUE(
       CompareMatrices(revolute_joint.position_lower_limits(), Vector1d(-1)));
   EXPECT_TRUE(
@@ -848,7 +848,7 @@ TEST_F(UrdfParserTest, JointParsingTest) {
   EXPECT_EQ(prismatic_joint.parent_body().name(), "link2");
   EXPECT_EQ(prismatic_joint.child_body().name(), "link3");
   EXPECT_EQ(prismatic_joint.translation_axis(), Vector3d::UnitZ());
-  EXPECT_EQ(prismatic_joint.damping(), 0.1);
+  EXPECT_EQ(prismatic_joint.default_damping(), 0.1);
   EXPECT_TRUE(
       CompareMatrices(prismatic_joint.position_lower_limits(), Vector1d(-2)));
   EXPECT_TRUE(
@@ -871,7 +871,7 @@ TEST_F(UrdfParserTest, JointParsingTest) {
   EXPECT_EQ(ball_joint.name(), "ball_joint");
   EXPECT_EQ(ball_joint.parent_body().name(), "link3");
   EXPECT_EQ(ball_joint.child_body().name(), "link4");
-  EXPECT_EQ(ball_joint.damping(), 0.1);
+  EXPECT_EQ(ball_joint.default_damping(), 0.1);
   const Vector3d inf3(std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity());
@@ -912,7 +912,7 @@ TEST_F(UrdfParserTest, JointParsingTest) {
   EXPECT_EQ(universal_joint.name(), "universal_joint");
   EXPECT_EQ(universal_joint.parent_body().name(), "link5");
   EXPECT_EQ(universal_joint.child_body().name(), "link6");
-  EXPECT_EQ(universal_joint.damping(), 0.1);
+  EXPECT_EQ(universal_joint.default_damping(), 0.1);
   const Vector2d inf2(std::numeric_limits<double>::infinity(),
                       std::numeric_limits<double>::infinity());
   const Vector2d neg_inf2(-std::numeric_limits<double>::infinity(),
@@ -931,7 +931,8 @@ TEST_F(UrdfParserTest, JointParsingTest) {
   EXPECT_EQ(planar_joint.name(), "planar_joint");
   EXPECT_EQ(planar_joint.parent_body().name(), "link6");
   EXPECT_EQ(planar_joint.child_body().name(), "link7");
-  EXPECT_TRUE(CompareMatrices(planar_joint.damping(), Vector3d::Constant(0.1)));
+  EXPECT_TRUE(
+      CompareMatrices(planar_joint.default_damping(), Vector3d::Constant(0.1)));
   EXPECT_TRUE(CompareMatrices(planar_joint.position_lower_limits(), neg_inf3));
   EXPECT_TRUE(CompareMatrices(planar_joint.position_upper_limits(), inf3));
   EXPECT_TRUE(CompareMatrices(planar_joint.velocity_lower_limits(), neg_inf3));
@@ -967,7 +968,7 @@ TEST_F(UrdfParserTest, JointParsingTest) {
   EXPECT_EQ(screw_joint.child_body().name(), "link9");
   EXPECT_EQ(screw_joint.screw_axis(), Vector3d::UnitX());
   EXPECT_EQ(screw_joint.screw_pitch(), 0.04);
-  EXPECT_EQ(screw_joint.damping(), 0.1);
+  EXPECT_EQ(screw_joint.default_damping(), 0.1);
   EXPECT_TRUE(
       CompareMatrices(screw_joint.position_lower_limits(), neg_inf));
   EXPECT_TRUE(CompareMatrices(screw_joint.position_upper_limits(), inf));

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -118,7 +118,7 @@ VectorX<T> CompliantContactManager<T>::CalcEffectiveDamping(
     const systems::Context<T>& context) const {
   const VectorX<T> diagonal_inertia =
       plant().EvalReflectedInertiaCache(context) +
-      joint_damping_ * plant().time_step();
+      plant().EvalJointDampingCache(context) * plant().time_step();
   return diagonal_inertia;
 }
 
@@ -248,15 +248,6 @@ CompliantContactManager<T>::CloneToSymbolic() const {
 
 template <typename T>
 void CompliantContactManager<T>::DoExtractModelInfo() {
-  // Collect joint damping coefficients into a vector.
-  joint_damping_ = VectorX<T>::Zero(plant().num_velocities());
-  for (JointIndex j(0); j < plant().num_joints(); ++j) {
-    const Joint<T>& joint = plant().get_joint(j);
-    const int velocity_start = joint.velocity_start();
-    const int nv = joint.num_velocities();
-    joint_damping_.segment(velocity_start, nv) = joint.damping_vector();
-  }
-
   // Solver drivers are only created when ExtractModelInfo() is called and
   // therefore we expect these pointers to equal nullptr. The only reason for
   // one of them to be non-nullptr would be a bug leading to this method being

--- a/multibody/plant/sap_driver.h
+++ b/multibody/plant/sap_driver.h
@@ -286,9 +286,6 @@ class SapDriver {
   const double near_rigid_threshold_;
   systems::CacheIndex contact_problem_;
   systems::CacheIndex sap_results_;
-  // Vector of joint damping coefficients, of size plant().num_velocities().
-  // This information is extracted during the call to ExtractModelInfo().
-  VectorX<T> joint_damping_;
   // Parameters for SAP.
   contact_solvers::internal::SapSolverParameters sap_parameters_;
 };

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -152,20 +152,8 @@ class KukaIiwaArmTests : public ::testing::Test {
     const int nv = plant_.num_velocities();
     MatrixXd A(nv, nv);
     plant_.CalcMassMatrix(*context_, &A);
-    // Include term due to the implicit treatment of dissipation.
-    VectorXd damping = VectorXd::Zero(plant_.num_velocities());
-    for (JointIndex joint_index(0); joint_index < plant_.num_joints();
-         ++joint_index) {
-      const Joint<double>& joint = plant_.get_joint(joint_index);
-      if (joint.num_velocities() > 0) {  // skip welds.
-        const VectorXd& joint_damping = joint.damping_vector();
-        // For this model we expect 1 DOF revolute and prismatic joints only.
-        EXPECT_EQ(joint_damping.size(), 1);
-        EXPECT_EQ(joint.num_velocities(), 1);
-        damping(joint.velocity_start()) = joint_damping(0);
-      }
-    }
-    A.diagonal() += plant_.time_step() * damping;
+    A.diagonal() +=
+        plant_.time_step() * plant_.EvalJointDampingCache(*context_);
     return A;
   }
 
@@ -315,22 +303,30 @@ class KukaIiwaArmTests : public ::testing::Test {
         // Arbitrary position within position limits.
         const double ql = revolute_joint.position_lower_limit();
         const double qu = revolute_joint.position_upper_limit();
-        const double w = joint_index / kNumJoints;  // Number in (0,1).
-        const double q = w * ql + (1.0 - w) * qu;   // q in (ql, qu)
+        const double w =
+            revolute_joint.velocity_start() / kNumJoints;  // Number in (0,1).
+        const double q = w * ql + (1.0 - w) * qu;          // q in (ql, qu)
         revolute_joint.set_angle(context, q);
         // Arbitrary velocity.
         revolute_joint.set_angular_rate(context, 0.5 * joint_index);
+        // Set damping.
+        revolute_joint.SetDamping(
+            context, kJointDamping(revolute_joint.velocity_start()));
       } else if (joint.type_name() == "prismatic") {
         const PrismaticJoint<double>& prismatic_joint =
             dynamic_cast<const PrismaticJoint<double>&>(joint);
         // Arbitrary position within position limits.
         const double ql = prismatic_joint.position_lower_limit();
         const double qu = prismatic_joint.position_upper_limit();
-        const double w = joint_index / kNumJoints;  // Number in (0,1).
-        const double q = w * ql + (1.0 - w) * qu;   // q in (ql, qu)
+        const double w =
+            prismatic_joint.velocity_start() / kNumJoints;  // Number in (0,1).
+        const double q = w * ql + (1.0 - w) * qu;           // q in (ql, qu)
         prismatic_joint.set_translation(context, q);
         // Arbitrary velocity.
         prismatic_joint.set_translation_rate(context, 0.5 * joint_index);
+        // Set damping.
+        prismatic_joint.SetDamping(
+            context, kJointDamping(prismatic_joint.velocity_start()));
       }
     }
   }
@@ -340,6 +336,7 @@ class KukaIiwaArmTests : public ::testing::Test {
   const double kTimeStep{0.015};
   const VectorXd kRotorInertias{VectorXd::LinSpaced(kNumJoints, 0.1, 12.0)};
   const VectorXd kGearRatios{VectorXd::LinSpaced(kNumJoints, 1.5, 100.0)};
+  const VectorXd kJointDamping{VectorXd::LinSpaced(kNumJoints, 0.3, 30)};
   const double kCouplerGearRatio{-1.5};
   const double kCouplerOffset{3.1};
   MultibodyPlant<double> plant_{kTimeStep};

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -303,9 +303,9 @@ class KukaIiwaArmTests : public ::testing::Test {
         // Arbitrary position within position limits.
         const double ql = revolute_joint.position_lower_limit();
         const double qu = revolute_joint.position_upper_limit();
-        const double w =
-            revolute_joint.velocity_start() / kNumJoints;  // Number in (0,1).
-        const double q = w * ql + (1.0 - w) * qu;          // q in (ql, qu)
+        const double w = 1. * revolute_joint.velocity_start() /
+                         kNumJoints;               // Number in [0,1).
+        const double q = w * ql + (1.0 - w) * qu;  // q in (ql, qu)
         revolute_joint.set_angle(context, q);
         // Arbitrary velocity.
         revolute_joint.set_angular_rate(context, 0.5 * joint_index);
@@ -318,9 +318,9 @@ class KukaIiwaArmTests : public ::testing::Test {
         // Arbitrary position within position limits.
         const double ql = prismatic_joint.position_lower_limit();
         const double qu = prismatic_joint.position_upper_limit();
-        const double w =
-            prismatic_joint.velocity_start() / kNumJoints;  // Number in (0,1).
-        const double q = w * ql + (1.0 - w) * qu;           // q in (ql, qu)
+        const double w = 1. * prismatic_joint.velocity_start() /
+                         kNumJoints;               // Number in [0,1).
+        const double q = w * ql + (1.0 - w) * qu;  // q in (ql, qu)
         prismatic_joint.set_translation(context, q);
         // Arbitrary velocity.
         prismatic_joint.set_translation_rate(context, 0.5 * joint_index);

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -622,6 +622,7 @@ drake_cc_googletest(
     name = "revolute_joint_test",
     deps = [
         ":tree",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -26,7 +26,7 @@ std::unique_ptr<Joint<ToScalar>> BallRpyJoint<T>::TemplatedDoCloneToScalar(
   // Make the Joint<T> clone.
   auto joint_clone = std::make_unique<BallRpyJoint<ToScalar>>(
       this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
-      this->damping());
+      this->default_damping());
   joint_clone->set_position_limits(this->position_lower_limits(),
                                    this->position_upper_limits());
   joint_clone->set_velocity_limits(this->velocity_lower_limits(),

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -49,8 +49,8 @@ class BallRpyJoint final : public Joint<T> {
   /// The additional parameters are:
   /// @param[in] damping
   ///   Viscous damping coefficient, in N⋅m⋅s, used to model losses within the
-  ///   joint. See documentation of damping() for details on modelling of the
-  ///   damping torque.
+  ///   joint. See documentation of default_damping() for details on modelling
+  ///   of the damping torque.
   /// @throws std::exception if damping is negative.
   BallRpyJoint(const std::string& name, const Frame<T>& frame_on_parent,
                const Frame<T>& frame_on_child, double damping = 0)
@@ -73,10 +73,16 @@ class BallRpyJoint final : public Joint<T> {
 
   const std::string& type_name() const override;
 
-  /// Returns `this` joint's damping constant in N⋅m⋅s. The damping torque
-  /// (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion, with ω the
-  /// angular velocity of frame M in F (see get_angular_velocity()) and τ the
-  /// torque on child body B (to which M is rigidly attached).
+  /// Returns `this` joint's default damping constant in N⋅m⋅s. The damping
+  /// torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion, with
+  /// ω the angular velocity of frame M in F (see get_angular_velocity()) and τ
+  /// the torque on child body B (to which M is rigidly attached).
+  double default_damping() const {
+    // N.B. All damping coefficients are set to the same value for this joint.
+    return this->default_damping_vector()[0];
+  }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_damping() instead.")
   double damping() const {
     // N.B. All damping coefficients are set to the same value for this joint.
     return this->default_damping_vector()[0];
@@ -198,7 +204,8 @@ class BallRpyJoint final : public Joint<T> {
   /// Joint<T> override called through public NVI, Joint::AddInDamping().
   /// Therefore arguments were already checked to be valid.
   /// This method adds into `forces` a dissipative torque according to the
-  /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see damping()).
+  /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see
+  /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const override {
     Eigen::Ref<VectorX<T>> t_BMo_F =

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -79,7 +79,7 @@ class BallRpyJoint final : public Joint<T> {
   /// torque on child body B (to which M is rigidly attached).
   double damping() const {
     // N.B. All damping coefficients are set to the same value for this joint.
-    return this->damping_vector()[0];
+    return this->default_damping_vector()[0];
   }
 
   /// @name Context-dependent value access
@@ -205,7 +205,7 @@ class BallRpyJoint final : public Joint<T> {
         get_mobilizer()->get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     const Vector3<T>& w_FM = get_angular_velocity(context);
-    t_BMo_F = -damping() * w_FM;
+    t_BMo_F = -this->GetDampingVector(context)[0] * w_FM;
   }
 
  private:

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -93,7 +93,7 @@ class Joint : public MultibodyElement<T> {
   ///   The frame M attached on the child body connected by this joint.
   /// @param[in] damping
   ///   A vector of viscous damping coefficients, of size num_velocities().
-  ///   See damping_vector() for details.
+  ///   See default_damping_vector() for details.
   /// @param[in] pos_lower_limits
   ///   A vector storing the lower limit for each generalized position.
   ///   It must have the same size as `pos_upper_limit`.
@@ -511,9 +511,9 @@ class Joint : public MultibodyElement<T> {
 
   /// @}
 
-  /// Returns all damping coefficients for joints that model viscous damping, of
-  /// size num_velocities(). Joints that do not model damping return a zero
-  /// vector of size num_velocities(). If vj is the vector of generalized
+  /// Returns all default damping coefficients for joints that model viscous
+  /// damping, of size num_velocities(). Joints that do not model damping return
+  /// a zero vector of size num_velocities(). If vj is the vector of generalized
   /// velocities for this joint, of size num_velocities(), viscous damping
   /// models a generalized force at the joint of the form tau = -diag(dj)⋅vj,
   /// with dj the vector returned by this function. The units of the
@@ -521,12 +521,21 @@ class Joint : public MultibodyElement<T> {
   /// revolute joint where vj is an angular velocity with units of rad/s and tau
   /// having units of N⋅m, the coefficient of viscous damping has units of
   /// N⋅m⋅s. Refer to each joint's documentation for further details.
-  const VectorX<double>& damping_vector() const {
-    return damping_;
+  const VectorX<double>& default_damping_vector() const { return damping_; }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_damping_vector() instead.");
+  const VectorX<double>& damping_vector() const { return damping_; }
+
+  /// Returns the Context dependent damping coefficients stored as parameters in
+  /// `context`. Refer to default_damping_vector() for details.
+  /// @param[in] context The context storing the state and parameters for the
+  /// model to which `this` joint belongs.
+  const VectorX<T>& GetDampingVector(const systems::Context<T>& context) const {
+    return context.get_numeric_parameter(damping_parameter_index_).value();
   }
 
   /// Sets the default value of the viscous damping coefficients for this joint.
-  /// Refer to damping_vector() for details.
+  /// Refer to default_damping_vector() for details.
   /// @throws std::exception if damping.size() != num_velocities().
   /// @throws std::exception if any of the damping coefficients is negative.
   /// @pre the MultibodyPlant must not be finalized.
@@ -535,6 +544,21 @@ class Joint : public MultibodyElement<T> {
     DRAKE_THROW_UNLESS((damping.array() >= 0).all());
     DRAKE_DEMAND(!this->get_parent_tree().topology_is_valid());
     damping_ = damping;
+  }
+
+  /// Sets the value of the viscous damping coefficients for this joint, stored
+  /// as parameters in `context`. Refer to default_damping_vector() for details.
+  /// @param[out] context The context storing the state and parameters for the
+  /// model to which `this` joint belongs.
+  /// @param[in] damping The vector of damping values.
+  /// @throws std::exception if damping.size() != num_velocities().
+  /// @throws std::exception if any of the damping coefficients is negative.
+  void SetDampingVector(systems::Context<T>* context,
+                        const VectorX<T>& damping) const {
+    DRAKE_THROW_UNLESS(damping.size() == num_velocities());
+    DRAKE_THROW_UNLESS((damping.array() >= 0).all());
+    context->get_mutable_numeric_parameter(damping_parameter_index_)
+        .set_value(damping);
   }
 
   // Hide the following section from Doxygen.
@@ -778,6 +802,14 @@ class Joint : public MultibodyElement<T> {
   /// If the MultibodyTree has been finalized, this will return true.
   bool has_implementation() const { return implementation_ != nullptr; }
 
+  /// Called by DoDeclareParameters(). Derived classes may choose to override
+  /// to declare their sub-class specific parameters.
+  virtual void DoDeclareJointParameters(internal::MultibodyTreeSystem<T>*) {}
+
+  /// Called by DoSetDefaultParameters(). Derived classes may choose to override
+  /// to set their sub-class specific parameters.
+  virtual void DoSetDefaultJointParameters(systems::Parameters<T>*) const {}
+
  private:
   // Make all other Joint<U> objects a friend of Joint<T> so they can make
   // Joint<ToScalar>::JointImplementation from CloneToScalar<ToScalar>().
@@ -793,6 +825,26 @@ class Joint : public MultibodyElement<T> {
   // method is called to pass ownership of an implementation to the Joint.
   void OwnImplementation(std::unique_ptr<JointImplementation> implementation) {
     implementation_ = std::move(implementation);
+  }
+
+  // Implementation for MultibodyElement::DoDeclareParameters().
+  void DoDeclareParameters(
+      internal::MultibodyTreeSystem<T>* tree_system) final {
+    DoDeclareJointParameters(tree_system);
+
+    // Declare a parameter for damping.
+    damping_parameter_index_ = this->DeclareNumericParameter(
+        tree_system, systems::BasicVector<T>(damping_.size()));
+  }
+
+  // Implementation for MultibodyElement::DoSetDefaultParameters().
+  void DoSetDefaultParameters(systems::Parameters<T>* parameters) const final {
+    DoSetDefaultJointParameters(parameters);
+
+    // Set default damping.
+    systems::BasicVector<T>& damping_parameter =
+        parameters->get_mutable_numeric_parameter(damping_parameter_index_);
+    damping_parameter.set_value(VectorX<T>(damping_));
   }
 
   std::string name_;
@@ -821,6 +873,9 @@ class Joint : public MultibodyElement<T> {
 
   // The Joint<T> implementation:
   std::unique_ptr<JointImplementation> implementation_;
+
+  // System parameter indices.
+  systems::NumericParameterIndex damping_parameter_index_;
 };
 
 }  // namespace multibody

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1260,8 +1260,7 @@ template <typename T>
 void MultibodyTree<T>::CalcJointDamping(const systems::Context<T>& context,
                                         VectorX<T>* joint_damping) const {
   DRAKE_THROW_UNLESS(joint_damping != nullptr);
-  DRAKE_THROW_UNLESS(static_cast<int>(joint_damping->size()) ==
-                     num_velocities());
+  DRAKE_THROW_UNLESS(ssize(*joint_damping) == num_velocities());
 
   for (const Joint<T>* joint : joints_.elements()) {
     joint_damping->segment(joint->velocity_start(), joint->num_velocities()) =

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1246,13 +1246,26 @@ void MultibodyTree<T>::CalcReflectedInertia(
                      num_velocities());
 
   // See JointActuator::reflected_inertia().
-  *reflected_inertia = VectorX<double>::Zero(num_velocities());
+  reflected_inertia->setZero();
 
   for (const JointActuator<T>* actuator : actuators_.elements()) {
     const int joint_velocity_index =
         actuator->joint().velocity_start();  // within v
     (*reflected_inertia)(joint_velocity_index) =
         actuator->calc_reflected_inertia(context);
+  }
+}
+
+template <typename T>
+void MultibodyTree<T>::CalcJointDamping(const systems::Context<T>& context,
+                                        VectorX<T>* joint_damping) const {
+  DRAKE_THROW_UNLESS(joint_damping != nullptr);
+  DRAKE_THROW_UNLESS(static_cast<int>(joint_damping->size()) ==
+                     num_velocities());
+
+  for (const Joint<T>* joint : joints_.elements()) {
+    joint_damping->segment(joint->velocity_start(), joint->num_velocities()) =
+        joint->GetDampingVector(context);
   }
 }
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1319,6 +1319,17 @@ class MultibodyTree {
   void CalcReflectedInertia(const systems::Context<T>& context,
       VectorX<T>* reflected_inertia) const;
 
+  // Computes the joint damping for each velocity index.
+  // @param[in] context
+  //  The context storing the state of the model.
+  // @param[out] joint_damping
+  //  For each degree of freedom, joint_damping[i] contains the viscous damping
+  //  coefficient for the i-th degree of freedom.
+  // @throws std::exception if joint_damping is nullptr or if its size is not
+  // num_velocities().
+  void CalcJointDamping(const systems::Context<T>& context,
+                        VectorX<T>* joint_damping) const;
+
   // Computes the composite body inertia Mc_B_W(q) for each body B in the
   // model about its frame origin Bo and expressed in the world frame W.
   // The composite body inertia is the effective mass properties B would have
@@ -2703,6 +2714,14 @@ class MultibodyTree {
       const systems::Context<T>& context) const {
     DRAKE_ASSERT(tree_system_ != nullptr);
     return tree_system_->EvalReflectedInertiaCache(context);
+  }
+
+  // Evaluates the cache entry stored in context with the joint damping for each
+  // degree of freedom in the system. These will be updated as needed.
+  const VectorX<T>& EvalJointDampingCache(
+      const systems::Context<T>& context) const {
+    DRAKE_ASSERT(tree_system_ != nullptr);
+    return tree_system_->EvalJointDampingCache(context);
   }
 
   const std::vector<SpatialInertia<T>>& EvalCompositeBodyInertiaInWorldCache(

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -229,6 +229,13 @@ void MultibodyTreeSystem<T>::Finalize() {
       &MultibodyTreeSystem<T>::CalcReflectedInertia,
       {this->all_parameters_ticket()}).cache_index();
 
+  // Allocate cache entry for joint damping.
+  cache_indexes_.joint_damping = this->DeclareCacheEntry(
+      std::string("joint damping"),
+      VectorX<T>(internal_tree().num_velocities()),
+      &MultibodyTreeSystem<T>::CalcJointDamping,
+      {this->all_parameters_ticket()}).cache_index();
+
   // Allocate cache entry for composite-body inertias Mc_B_W(q) for each body.
   cache_indexes_.composite_body_inertia_in_world = this->DeclareCacheEntry(
       std::string("composite body inertia in world (Mc_B_W)"),

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -150,6 +150,15 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
         .template Eval<VectorX<T>>(context);
   }
 
+  /* Returns a reference to the up-to-date cache of per-dof joint damping
+  in the given Context, recalculating it first if necessary. */
+  const VectorX<T>& EvalJointDampingCache(
+      const systems::Context<T>& context) const {
+    this->ValidateContext(context);
+    return this->get_cache_entry(cache_indexes_.joint_damping)
+        .template Eval<VectorX<T>>(context);
+  }
+
   /* Returns a reference to the up-to-date cache of composite-body inertias
   in the given Context, recalculating it first if necessary. */
   const std::vector<SpatialInertia<T>>& EvalCompositeBodyInertiaInWorldCache(
@@ -394,6 +403,11 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
     internal_tree().CalcReflectedInertia(context, reflected_inertia);
   }
 
+  void CalcJointDamping(const systems::Context<T>& context,
+                        VectorX<T>* joint_damping) const {
+    internal_tree().CalcJointDamping(context, joint_damping);
+  }
+
   void CalcCompositeBodyInertiasInWorld(
       const systems::Context<T>& context,
       std::vector<SpatialInertia<T>>* composite_body_inertias) const {
@@ -510,6 +524,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
     systems::CacheIndex spatial_acceleration_bias;
     systems::CacheIndex velocity_kinematics;
     systems::CacheIndex reflected_inertia;
+    systems::CacheIndex joint_damping;
   };
 
   // This is the one real constructor. From the public API, a null tree is

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -25,7 +25,7 @@ std::unique_ptr<Joint<ToScalar>> PlanarJoint<T>::TemplatedDoCloneToScalar(
   // Make the Joint<T> clone.
   auto joint_clone = std::make_unique<PlanarJoint<ToScalar>>(
       this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
-      this->damping());
+      this->default_damping());
   joint_clone->set_position_limits(this->position_lower_limits(),
                                    this->position_upper_limits());
   joint_clone->set_velocity_limits(this->velocity_lower_limits(),

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -86,7 +86,7 @@ class PlanarJoint final : public Joint<T> {
   /// rate for `this` joint (see get_angular_velocity()) and τ the torque on
   /// child body B expressed in frame F as t_B_F = τ⋅Fz_F.
   // TODO(amcastro-tri): return reference instead.
-  Vector3<double> damping() const { return this->damping_vector(); }
+  Vector3<double> damping() const { return this->default_damping_vector(); }
 
   /// @name Context-dependent value access
   /// @{
@@ -282,7 +282,7 @@ class PlanarJoint final : public Joint<T> {
             &forces->mutable_generalized_forces());
     const Vector2<T>& v_translation = get_translational_velocity(context);
     const T& v_angular = get_angular_velocity(context);
-    const Vector3<double> damping_coeff = damping();
+    const Vector3<T> damping_coeff = this->GetDampingVector(context);
     tau[0] -= damping_coeff[0] * v_translation[0];
     tau[1] -= damping_coeff[1] * v_translation[1];
     tau[2] -= damping_coeff[2] * v_angular;

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -53,12 +53,12 @@ class PlanarJoint final : public Joint<T> {
   /// @param[in] damping
   ///   Viscous damping coefficient, in N⋅s/m for translation and N⋅m⋅s for
   ///   rotation, used to model losses within the joint. See documentation of
-  ///   damping() for details on modelling of the damping force and torque.
+  ///   default_damping() for details on modelling of the damping force and
+  ///   torque.
   /// @throws std::exception if any element of damping is negative.
   PlanarJoint(const std::string& name, const Frame<T>& frame_on_parent,
               const Frame<T>& frame_on_child, Vector3<double> damping)
-      : Joint<T>(name, frame_on_parent, frame_on_child,
-                 std::move(damping),
+      : Joint<T>(name, frame_on_parent, frame_on_child, std::move(damping),
                  VectorX<double>::Constant(
                      3, -std::numeric_limits<double>::infinity()),
                  VectorX<double>::Constant(
@@ -76,16 +76,21 @@ class PlanarJoint final : public Joint<T> {
 
   const std::string& type_name() const final;
 
-  /// Returns `this` joint's damping constant in N⋅s/m for the translational
-  /// degrees and N⋅m⋅s for the rotational degree. The damping force (in N) is
-  /// modeled as `fᵢ = -dampingᵢ⋅vᵢ, i = 1, 2` i.e. opposing motion, with vᵢ
-  /// the translation rates along the i-th axis for `this` joint (see
-  /// get_translational_velocity()) and fᵢ the force on child body B at Mo and
-  /// expressed in F. That is, f_BMo_F = (f₁, f₂). The damping torque (in N⋅m)
-  /// is modeled as `τ = -damping₃⋅ω` i.e. opposing motion, with ω the angular
-  /// rate for `this` joint (see get_angular_velocity()) and τ the torque on
-  /// child body B expressed in frame F as t_B_F = τ⋅Fz_F.
+  /// Returns `this` joint's default damping constant in N⋅s/m for the
+  /// translational degrees and N⋅m⋅s for the rotational degree. The damping
+  /// force (in N) is modeled as `fᵢ = -dampingᵢ⋅vᵢ, i = 1, 2` i.e. opposing
+  /// motion, with vᵢ the translation rates along the i-th axis for `this` joint
+  /// (see get_translational_velocity()) and fᵢ the force on child body B at Mo
+  /// and expressed in F. That is, f_BMo_F = (f₁, f₂). The damping torque (in
+  /// N⋅m) is modeled as `τ = -damping₃⋅ω` i.e. opposing motion, with ω the
+  /// angular rate for `this` joint (see get_angular_velocity()) and τ the
+  /// torque on child body B expressed in frame F as t_B_F = τ⋅Fz_F.
   // TODO(amcastro-tri): return reference instead.
+  Vector3<double> default_damping() const {
+    return this->default_damping_vector();
+  }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_damping() instead.")
   Vector3<double> damping() const { return this->default_damping_vector(); }
 
   /// @name Context-dependent value access
@@ -274,7 +279,8 @@ class PlanarJoint final : public Joint<T> {
   /// Joint<T> override called through public NVI, Joint::AddInDamping().
   /// Therefore arguments were already checked to be valid.
   /// This method adds into `forces` a dissipative force according to the
-  /// viscous law `f = -d⋅v`, with d the damping coefficient (see damping()).
+  /// viscous law `f = -d⋅v`, with d the damping coefficient (see
+  /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const final {
     Eigen::Ref<VectorX<T>> tau =

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -55,7 +55,7 @@ std::unique_ptr<Joint<ToScalar>> PrismaticJoint<T>::TemplatedDoCloneToScalar(
   auto joint_clone = std::make_unique<PrismaticJoint<ToScalar>>(
       this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
       this->translation_axis(), this->position_lower_limit(),
-      this->position_upper_limit(), this->damping());
+      this->position_upper_limit(), this->default_damping());
   joint_clone->set_velocity_limits(this->velocity_lower_limits(),
                                    this->velocity_upper_limits());
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -81,8 +81,12 @@ class PrismaticJoint final : public Joint<T> {
     return axis_;
   }
 
-  /// Returns `this` joint's damping constant in N⋅s/m.
+  /// Returns `this` joint's default damping constant in N⋅s/m.
+  double default_damping() const { return this->default_damping_vector()[0]; }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_damping() instead.")
   double damping() const { return this->default_damping_vector()[0]; }
+
 
   /// Sets the default value of viscous damping for this joint, in N⋅s/m.
   /// @throws std::exception if damping is negative.
@@ -175,7 +179,7 @@ class PrismaticJoint final : public Joint<T> {
   }
 
   /// Returns the Context dependent damping coefficient stored as a parameter in
-  /// `context`. Refer to damping() for details.
+  /// `context`. Refer to default_damping() for details.
   /// @param[in] context The context storing the state and parameters for the
   /// model to which `this` joint belongs.
   const T& GetDamping(const Context<T>& context) const {
@@ -183,7 +187,7 @@ class PrismaticJoint final : public Joint<T> {
   }
 
   /// Sets the value of the viscous damping coefficient for this joint, stored
-  /// as a parameter in `context`. Refer to damping() for details.
+  /// as a parameter in `context`. Refer to default_damping() for details.
   /// @param[out] context The context storing the state and parameters for the
   /// model to which `this` joint belongs.
   /// @param[in] damping The damping value.
@@ -256,7 +260,8 @@ class PrismaticJoint final : public Joint<T> {
   /// Joint<T> override called through public NVI, Joint::AddInDamping().
   /// Therefore arguments were already checked to be valid.
   /// This method adds into `forces` a dissipative force according to the
-  /// viscous law `f = -d⋅v`, with d the damping coefficient (see damping()).
+  /// viscous law `f = -d⋅v`, with d the damping coefficient (see
+  /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const override {
     const T damping_force =

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -82,7 +82,7 @@ class PrismaticJoint final : public Joint<T> {
   }
 
   /// Returns `this` joint's damping constant in N⋅s/m.
-  double damping() const { return this->damping_vector()[0]; }
+  double damping() const { return this->default_damping_vector()[0]; }
 
   /// Sets the default value of viscous damping for this joint, in N⋅s/m.
   /// @throws std::exception if damping is negative.
@@ -174,6 +174,25 @@ class PrismaticJoint final : public Joint<T> {
     return *this;
   }
 
+  /// Returns the Context dependent damping coefficient stored as a parameter in
+  /// `context`. Refer to damping() for details.
+  /// @param[in] context The context storing the state and parameters for the
+  /// model to which `this` joint belongs.
+  const T& GetDamping(const Context<T>& context) const {
+    return this->GetDampingVector(context)[0];
+  }
+
+  /// Sets the value of the viscous damping coefficient for this joint, stored
+  /// as a parameter in `context`. Refer to damping() for details.
+  /// @param[out] context The context storing the state and parameters for the
+  /// model to which `this` joint belongs.
+  /// @param[in] damping The damping value.
+  /// @throws std::exception if `damping` is negative.
+  void SetDamping(Context<T>* context, const T& damping) const {
+    DRAKE_THROW_UNLESS(damping >= 0);
+    this->SetDampingVector(context, Vector1<T>(damping));
+  }
+
   /// @}
 
   /// Gets the default translation. Wrapper for the more general
@@ -240,7 +259,8 @@ class PrismaticJoint final : public Joint<T> {
   /// viscous law `f = -d⋅v`, with d the damping coefficient (see damping()).
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const override {
-    const T damping_force = -this->damping() * get_translation_rate(context);
+    const T damping_force =
+        -this->GetDamping(context) * get_translation_rate(context);
     AddInForce(context, damping_force, forces);
   }
 

--- a/multibody/tree/quaternion_floating_joint.cc
+++ b/multibody/tree/quaternion_floating_joint.cc
@@ -21,7 +21,7 @@ QuaternionFloatingJoint<T>::TemplatedDoCloneToScalar(
   // Make the Joint<T> clone.
   auto joint_clone = std::make_unique<QuaternionFloatingJoint<ToScalar>>(
       this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
-      this->angular_damping(), this->translational_damping());
+      this->default_angular_damping(), this->default_translational_damping());
   joint_clone->set_position_limits(this->position_lower_limits(),
                                    this->position_upper_limits());
   joint_clone->set_velocity_limits(this->velocity_lower_limits(),

--- a/multibody/tree/quaternion_floating_joint.cc
+++ b/multibody/tree/quaternion_floating_joint.cc
@@ -85,8 +85,10 @@ void QuaternionFloatingJoint<T>::DoAddInDamping(
           &forces->mutable_generalized_forces());
   const Vector3<T>& w_FM = get_angular_velocity(context);
   const Vector3<T>& v_FM = get_translational_velocity(context);
-  t_BMo_F.template head<3>() -= angular_damping() * w_FM;
-  t_BMo_F.template tail<3>() -= translational_damping() * v_FM;
+  const T& angular_damping = this->GetDampingVector(context)[0];
+  const T& translational_damping = this->GetDampingVector(context)[3];
+  t_BMo_F.template head<3>() -= angular_damping * w_FM;
+  t_BMo_F.template tail<3>() -= translational_damping * v_FM;
 }
 
 }  // namespace multibody

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -60,13 +60,13 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @param[in] angular_damping
   ///  Viscous damping coefficient in N⋅m⋅s for the angular component of
   ///  this joint's velocity, used to model losses within the joint. See
-  ///  documentation of angular_damping() for details on modelling of the
-  ///  damping force.
+  ///  documentation of default_angular_damping() for details on modelling of
+  ///  the damping force.
   /// @param[in] translational_damping
   ///  Viscous damping coefficient in N⋅s/m for the translational component of
   ///  this joint's velocity, used to model losses within the joint. See
-  ///  documentation of translational_damping() for details on modelling of the
-  ///  damping force.
+  ///  documentation of default_translational_damping() for details on modelling
+  ///  of the damping force.
   /// @throws std::exception if angular_damping is negative.
   /// @throws std::exception if translational_damping is negative.
   QuaternionFloatingJoint(const std::string& name,
@@ -100,20 +100,35 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return name.access();
   }
 
-  /// Returns `this` joint's angular damping constant in N⋅m⋅s. The damping
-  /// torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion, with
-  /// ω the angular velocity of frame M in F (see get_angular_velocity()) and τ
-  /// the torque on child body B (to which M is rigidly attached).
+  /// Returns `this` joint's default angular damping constant in N⋅m⋅s. The
+  /// damping torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing
+  /// motion, with ω the angular velocity of frame M in F (see
+  /// get_angular_velocity()) and τ the torque on child body B (to which M is
+  /// rigidly attached).
+  double default_angular_damping() const {
+    // N.B. All 3 angular damping coefficients are set to the same value for
+    // this joint.
+    return this->default_damping_vector()[0];
+  }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_angular_damping() instead.")
   double angular_damping() const {
     // N.B. All 3 angular damping coefficients are set to the same value for
     // this joint.
     return this->default_damping_vector()[0];
   }
 
-  /// Returns `this` joint's translational damping constant in N⋅s/m. The
-  /// damping force (in N) is modeled aswrote `f = -damping⋅v` i.e. opposing
+  /// Returns `this` joint's default translational damping constant in N⋅s/m.
+  /// The damping force (in N) is modeled as `f = -damping⋅v` i.e. opposing
   /// motion, with v the translational velocity of frame M in F (see
   /// get_translational_velocity()) and f the force on child body B at Mo.
+  double default_translational_damping() const {
+    // N.B. All 3 translational damping coefficients are set to the same value
+    // for this joint.
+    return this->default_damping_vector()[3];
+  }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_translational_damping() instead.")
   double translational_damping() const {
     // N.B. All 3 translational damping coefficients are set to the same value
     // for this joint.
@@ -390,10 +405,10 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// Therefore arguments were already checked to be valid.
   /// This method adds into the translational component of `forces` for `this`
   /// joint a dissipative force according to the viscous law `f = -d⋅v`, with d
-  /// the damping coefficient (see translational_damping()). This method also
-  /// adds into the angular component of `forces` for `this` joint a dissipative
-  /// torque according to the viscous law `τ = -d⋅ω`, with d the damping
-  /// coefficient (see angular_damping()).
+  /// the damping coefficient (see default_translational_damping()). This method
+  /// also adds into the angular component of `forces` for `this` joint a
+  /// dissipative torque according to the viscous law `τ = -d⋅ω`, with d the
+  /// damping coefficient (see default_angular_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const override;
 

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -107,17 +107,17 @@ class QuaternionFloatingJoint final : public Joint<T> {
   double angular_damping() const {
     // N.B. All 3 angular damping coefficients are set to the same value for
     // this joint.
-    return this->damping_vector()[0];
+    return this->default_damping_vector()[0];
   }
 
   /// Returns `this` joint's translational damping constant in N⋅s/m. The
-  /// damping force (in N) is modeled as `f = -damping⋅v` i.e. opposing motion,
-  /// with v the translational velocity of frame M in F (see
+  /// damping force (in N) is modeled aswrote `f = -damping⋅v` i.e. opposing
+  /// motion, with v the translational velocity of frame M in F (see
   /// get_translational_velocity()) and f the force on child body B at Mo.
   double translational_damping() const {
     // N.B. All 3 translational damping coefficients are set to the same value
     // for this joint.
-    return this->damping_vector()[3];
+    return this->default_damping_vector()[3];
   }
 
   /// @name Context-dependent value access

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -55,7 +55,7 @@ std::unique_ptr<Joint<ToScalar>> RevoluteJoint<T>::TemplatedDoCloneToScalar(
   auto joint_clone = std::make_unique<RevoluteJoint<ToScalar>>(
       this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
       this->revolute_axis(), this->position_lower_limits()[0],
-      this->position_upper_limit(), this->damping());
+      this->position_upper_limit(), this->default_damping());
   joint_clone->set_velocity_limits(this->velocity_lower_limits(),
                                    this->velocity_upper_limits());
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -116,7 +116,7 @@ class RevoluteJoint final : public Joint<T> {
   }
 
   /// Returns `this` joint's damping constant in N⋅m⋅s.
-  double damping() const { return this->damping_vector()[0]; }
+  double damping() const { return this->default_damping_vector()[0]; }
 
   /// Sets the default value of viscous damping for this joint, in N⋅m⋅s.
   /// @throws std::exception if damping is negative.
@@ -211,6 +211,25 @@ class RevoluteJoint final : public Joint<T> {
     return *this;
   }
 
+  /// Returns the Context dependent damping coefficient stored as a parameter in
+  /// `context`. Refer to damping() for details.
+  /// @param[in] context The context storing the state and parameters for the
+  /// model to which `this` joint belongs.
+  const T& GetDamping(const Context<T>& context) const {
+    return this->GetDampingVector(context)[0];
+  }
+
+  /// Sets the value of the viscous damping coefficient for this joint, stored
+  /// as a parameter in `context`. Refer to damping() for details.
+  /// @param[out] context The context storing the state and parameters for the
+  /// model to which `this` joint belongs.
+  /// @param[in] damping The damping value.
+  /// @throws std::exception if `damping` is negative.
+  void SetDamping(Context<T>* context, const T& damping) const {
+    DRAKE_THROW_UNLESS(damping >= 0);
+    this->SetDampingVector(context, Vector1<T>(damping));
+  }
+
   /// @}
 
   /// Gets the default rotation angle. Wrapper for the more general
@@ -274,7 +293,8 @@ class RevoluteJoint final : public Joint<T> {
   /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see damping()).
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const override {
-    const T damping_torque = -this->damping() * get_angular_rate(context);
+    const T damping_torque =
+        -this->GetDamping(context) * get_angular_rate(context);
     AddInTorque(context, damping_torque, forces);
   }
 

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -115,7 +115,10 @@ class RevoluteJoint final : public Joint<T> {
     return axis_;
   }
 
-  /// Returns `this` joint's damping constant in N⋅m⋅s.
+  /// Returns `this` joint's default damping constant in N⋅m⋅s.
+  double default_damping() const { return this->default_damping_vector()[0]; }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_damping() instead.")
   double damping() const { return this->default_damping_vector()[0]; }
 
   /// Sets the default value of viscous damping for this joint, in N⋅m⋅s.
@@ -212,7 +215,7 @@ class RevoluteJoint final : public Joint<T> {
   }
 
   /// Returns the Context dependent damping coefficient stored as a parameter in
-  /// `context`. Refer to damping() for details.
+  /// `context`. Refer to default_damping() for details.
   /// @param[in] context The context storing the state and parameters for the
   /// model to which `this` joint belongs.
   const T& GetDamping(const Context<T>& context) const {
@@ -220,7 +223,7 @@ class RevoluteJoint final : public Joint<T> {
   }
 
   /// Sets the value of the viscous damping coefficient for this joint, stored
-  /// as a parameter in `context`. Refer to damping() for details.
+  /// as a parameter in `context`. Refer to default_damping() for details.
   /// @param[out] context The context storing the state and parameters for the
   /// model to which `this` joint belongs.
   /// @param[in] damping The damping value.
@@ -290,7 +293,8 @@ class RevoluteJoint final : public Joint<T> {
   /// Joint<T> override called through public NVI, Joint::AddInDamping().
   /// Therefore arguments were already checked to be valid.
   /// This method adds into `forces` a dissipative torque according to the
-  /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see damping()).
+  /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see
+  /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const override {
     const T damping_torque =

--- a/multibody/tree/rpy_floating_joint.cc
+++ b/multibody/tree/rpy_floating_joint.cc
@@ -26,7 +26,7 @@ std::unique_ptr<Joint<ToScalar>> RpyFloatingJoint<T>::TemplatedDoCloneToScalar(
   // Make the Joint<T> clone.
   auto joint_clone = std::make_unique<RpyFloatingJoint<ToScalar>>(
       this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
-      this->angular_damping(), this->translational_damping());
+      this->default_angular_damping(), this->default_translational_damping());
   joint_clone->set_position_limits(this->position_lower_limits(),
                                    this->position_upper_limits());
   joint_clone->set_velocity_limits(this->velocity_lower_limits(),

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -64,12 +64,12 @@ class RpyFloatingJoint final : public Joint<T> {
   @param[in] angular_damping
     Viscous damping coefficient in N⋅m⋅s for the angular component of this
     joint's velocity, used to model losses within the joint. See documentation
-    of angular_damping() for details on modeling of the damping force.
+    of default_angular_damping() for details on modeling of the damping force.
   @param[in] translational_damping
     Viscous damping coefficient in N⋅s/m for the translational component of
     this joint's velocity, used to model losses within the joint. See
-    documentation of translational_damping() for details on modeling of the
-    damping force.
+    documentation of default_translational_damping() for details on modeling of
+  the damping force.
   @throws std::exception if angular_damping is negative.
   @throws std::exception if translational_damping is negative. */
   RpyFloatingJoint(const std::string& name, const Frame<T>& frame_on_parent,
@@ -88,6 +88,7 @@ class RpyFloatingJoint final : public Joint<T> {
                  Vector6d::Constant(std::numeric_limits<double>::infinity())) {
     DRAKE_THROW_UNLESS(angular_damping >= 0);
     DRAKE_THROW_UNLESS(translational_damping >= 0);
+
     // Parent constructor sets all default positions to zero which is correct
     // for this joint.
   }
@@ -95,24 +96,38 @@ class RpyFloatingJoint final : public Joint<T> {
   /** Returns the name of this joint type: "rpy_floating" */
   const std::string& type_name() const final;
 
-  /** Returns this joint's angular damping constant in N⋅m⋅s. The damping
-  torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion, with
-  ω the angular velocity of frame M in F (see get_angular_velocity()) and τ
+  /** Returns this joint's default angular damping constant in N⋅m⋅s. The
+  damping torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion,
+  with ω the angular velocity of frame M in F (see get_angular_velocity()) and τ
   the torque on child body B (to which M is rigidly attached). */
+  double default_angular_damping() const {
+    // N.B. All 3 angular damping coefficients are set to the same value for
+    // this joint.
+    return this->default_damping_vector()[0];
+  }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_angular_damping() instead.")
   double angular_damping() const {
     // N.B. All 3 angular damping coefficients are set to the same value for
     // this joint.
-    return this->damping_vector()[0];
+    return this->default_damping_vector()[0];
   }
 
-  /** Returns this joint's translational damping constant in N⋅s/m. The
+  /** Returns this joint's default translational damping constant in N⋅s/m. The
   damping force (in N) is modeled as `f = -damping⋅v` i.e. opposing motion,
   with v the translational velocity of frame M in F (see
   get_translational_velocity()) and f the force on child body B at Mo. */
+  double default_translational_damping() const {
+    // N.B. All 3 translational damping coefficients are set to the same value
+    // for this joint.
+    return this->default_damping_vector()[3];
+  }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_translational_damping() instead.")
   double translational_damping() const {
     // N.B. All 3 translational damping coefficients are set to the same value
     // for this joint.
-    return this->damping_vector()[3];
+    return this->default_damping_vector()[3];
   }
 
   /** @name Context-dependent value access
@@ -365,9 +380,10 @@ class RpyFloatingJoint final : public Joint<T> {
   Therefore arguments were already checked to be valid. This method adds into
   the translational component of `forces` for `this` joint a dissipative force
   according to the viscous law `f = -d⋅v`, with d the damping coefficient (see
-  translational_damping()). This method also adds into the angular component of
-  `forces` for `this` joint a dissipative torque according to the viscous law
-  `τ = -d⋅ω`, with d the damping coefficient (see angular_damping()). */
+  default_translational_damping()). This method also adds into the angular
+  component of `forces` for `this` joint a dissipative torque according to the
+  viscous law `τ = -d⋅ω`, with d the damping coefficient (see
+  default_angular_damping()). */
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const final {
     Eigen::Ref<VectorX<T>> t_BMo_F =

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -57,7 +57,7 @@ std::unique_ptr<Joint<ToScalar>> ScrewJoint<T>::TemplatedDoCloneToScalar(
       this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
       this->screw_axis(),
       this->screw_pitch(),
-      this->damping());
+      this->default_damping());
   joint_clone->set_position_limits(this->position_lower_limits(),
                                    this->position_upper_limits());
   joint_clone->set_velocity_limits(this->velocity_lower_limits(),

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -126,7 +126,7 @@ class ScrewJoint final : public Joint<T> {
   ///  opposing motion, with ω the angular rate for `this` joint
   ///  (see get_angular_velocity()) and τ the torque on
   /// child body B expressed in frame F as t_B_F = τ⋅Fâ_F.
-  double damping() const { return this->damping_vector()[0]; }
+  double damping() const { return this->default_damping_vector()[0]; }
 
   /// @name Context-dependent value access
   /// @{
@@ -220,6 +220,25 @@ class ScrewJoint final : public Joint<T> {
     return *this;
   }
 
+  /// Returns the Context dependent damping coefficient stored as a parameter in
+  /// `context`. Refer to damping() for details.
+  /// @param[in] context The context storing the state and parameters for the
+  /// model to which `this` joint belongs.
+  const T& GetDamping(const Context<T>& context) const {
+    return this->GetDampingVector(context)[0];
+  }
+
+  /// Sets the value of the viscous damping coefficient for this joint, stored
+  /// as a parameter in `context`. Refer to damping() for details.
+  /// @param[out] context The context storing the state and parameters for the
+  /// model to which `this` joint belongs.
+  /// @param[in] damping The damping value.
+  /// @throws std::exception if `damping` is negative.
+  void SetDamping(Context<T>* context, const T& damping) const {
+    DRAKE_THROW_UNLESS(damping >= 0);
+    this->SetDampingVector(context, Vector1<T>(damping));
+  }
+
   /// @}
 
   /// Gets the default position for `this` joint.
@@ -292,7 +311,7 @@ class ScrewJoint final : public Joint<T> {
         get_mobilizer()->get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     const T& v_angular = get_angular_velocity(context);
-    tau[0] -= damping() * v_angular;
+    tau[0] -= this->GetDamping(context) * v_angular;
   }
 
   int do_get_velocity_start() const final {

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -63,7 +63,7 @@ class ScrewJoint final : public Joint<T> {
   /// @param[in] damping
   ///   Viscous damping coefficient, N⋅m⋅s/rad for
   ///   rotation, used to model losses within the joint. See documentation of
-  ///   damping() for details on modelling of the damping torque.
+  ///   default_damping() for details on modelling of the damping torque.
   /// @throws std::exception if damping is negative.
   ScrewJoint(const std::string& name, const Frame<T>& frame_on_parent,
              const Frame<T>& frame_on_child, double screw_pitch,
@@ -99,7 +99,7 @@ class ScrewJoint final : public Joint<T> {
   /// @param[in] damping
   ///   Viscous damping coefficient, N⋅m⋅s/rad for
   ///   rotation, used to model losses within the joint. See documentation of
-  ///   damping() for details on modelling of the damping torque.
+  ///   default_damping() for details on modelling of the damping torque.
   /// @throws std::exception if the L2 norm of `axis` is less than the square
   /// root of machine epsilon.
   /// @throws std::exception if damping is negative.
@@ -121,11 +121,14 @@ class ScrewJoint final : public Joint<T> {
   /// occurring over a one full revolution.
   double screw_pitch() const { return screw_pitch_; }
 
-  /// Returns `this` joint's damping constant N⋅m⋅s for the rotational degree.
-  /// The damping torque (in N⋅m) is modeled as `τ = -damping⋅ω` i.e.
+  /// Returns `this` joint's default damping constant N⋅m⋅s for the rotational
+  /// degree. The damping torque (in N⋅m) is modeled as `τ = -damping⋅ω` i.e.
   ///  opposing motion, with ω the angular rate for `this` joint
   ///  (see get_angular_velocity()) and τ the torque on
   /// child body B expressed in frame F as t_B_F = τ⋅Fâ_F.
+  double default_damping() const { return this->default_damping_vector()[0]; }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use default_damping() instead.")
   double damping() const { return this->default_damping_vector()[0]; }
 
   /// @name Context-dependent value access
@@ -221,7 +224,7 @@ class ScrewJoint final : public Joint<T> {
   }
 
   /// Returns the Context dependent damping coefficient stored as a parameter in
-  /// `context`. Refer to damping() for details.
+  /// `context`. Refer to default_damping() for details.
   /// @param[in] context The context storing the state and parameters for the
   /// model to which `this` joint belongs.
   const T& GetDamping(const Context<T>& context) const {
@@ -229,7 +232,7 @@ class ScrewJoint final : public Joint<T> {
   }
 
   /// Sets the value of the viscous damping coefficient for this joint, stored
-  /// as a parameter in `context`. Refer to damping() for details.
+  /// as a parameter in `context`. Refer to default_damping() for details.
   /// @param[out] context The context storing the state and parameters for the
   /// model to which `this` joint belongs.
   /// @param[in] damping The damping value.
@@ -304,7 +307,8 @@ class ScrewJoint final : public Joint<T> {
   /*  Joint<T> override called through public NVI, Joint::AddInDamping().
     Therefore arguments were already checked to be valid.
     This method adds into `forces` a dissipative force according to the
-    viscous law `f = -d⋅v`, with d the damping coefficient (see damping()). */
+    viscous law `f = -d⋅v`, with d the damping coefficient (see
+    default_damping()). */
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const final {
     Eigen::Ref<VectorX<T>> tau =

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -116,7 +116,7 @@ TEST_F(BallRpyJointTest, GetJointLimits) {
 
 TEST_F(BallRpyJointTest, Damping) {
   EXPECT_EQ(joint_->damping(), kDamping);
-  EXPECT_EQ(joint_->damping_vector(), Vector3d::Constant(kDamping));
+  EXPECT_EQ(joint_->default_damping_vector(), Vector3d::Constant(kDamping));
 }
 
 // Context-dependent value access.
@@ -133,6 +133,11 @@ TEST_F(BallRpyJointTest, ContextDependentAccess) {
   // Joint locking.
   joint_->Lock(context_.get());
   EXPECT_EQ(joint_->get_angular_velocity(*context_), Vector3d(0., 0., 0.));
+
+  // Damping.
+  EXPECT_EQ(joint_->GetDampingVector(*context_), Vector3d::Constant(kDamping));
+  EXPECT_NO_THROW(joint_->SetDampingVector(context_.get(), some_value));
+  EXPECT_EQ(joint_->GetDampingVector(*context_), some_value);
 }
 
 // Tests API to apply torques to joint.
@@ -144,6 +149,21 @@ TEST_F(BallRpyJointTest, AddInOneForce) {
   // not make physical sense, this method should throw.
   EXPECT_THROW(joint_->AddInOneForce(*context_, 0, some_value, &forces),
                std::logic_error);
+}
+
+// Tests API to add in damping forces.
+TEST_F(BallRpyJointTest, AddInDampingForces) {
+  const Vector3d angular_velocity(0.1, 0.2, 0.3);
+  const double damping = 3 * kDamping;
+
+  const Vector3d damping_forces_expected = -damping * angular_velocity;
+
+  joint_->set_angular_velocity(context_.get(), angular_velocity);
+  joint_->SetDampingVector(context_.get(), Vector3d::Constant(damping));
+
+  MultibodyForces<double> forces(tree());
+  joint_->AddInDamping(*context_, &forces);
+  EXPECT_EQ(forces.generalized_forces(), damping_forces_expected);
 }
 
 TEST_F(BallRpyJointTest, Clone) {

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -115,8 +115,15 @@ TEST_F(BallRpyJointTest, GetJointLimits) {
 }
 
 TEST_F(BallRpyJointTest, Damping) {
-  EXPECT_EQ(joint_->damping(), kDamping);
+  EXPECT_EQ(joint_->default_damping(), kDamping);
   EXPECT_EQ(joint_->default_damping_vector(), Vector3d::Constant(kDamping));
+
+  // Ensure the deprecated versions are correct until removal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(joint_->damping(), kDamping);
+  EXPECT_EQ(joint_->damping_vector(), Vector3d::Constant(kDamping));
+#pragma GCC diagnostic pop
 }
 
 // Context-dependent value access.
@@ -138,6 +145,10 @@ TEST_F(BallRpyJointTest, ContextDependentAccess) {
   EXPECT_EQ(joint_->GetDampingVector(*context_), Vector3d::Constant(kDamping));
   EXPECT_NO_THROW(joint_->SetDampingVector(context_.get(), some_value));
   EXPECT_EQ(joint_->GetDampingVector(*context_), some_value);
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint_->SetDampingVector(context_.get(), Vector3d::Constant(-1)),
+               std::exception);
 }
 
 // Tests API to apply torques to joint.
@@ -187,7 +198,7 @@ TEST_F(BallRpyJointTest, Clone) {
             joint_->acceleration_lower_limits());
   EXPECT_EQ(joint_clone.acceleration_upper_limits(),
             joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.damping(), joint_->damping());
+  EXPECT_EQ(joint_clone.default_damping(), joint_->default_damping());
   EXPECT_EQ(joint_clone.get_default_angles(), joint_->get_default_angles());
 }
 
@@ -202,14 +213,14 @@ TEST_F(BallRpyJointTest, SetVelocityAndAccelerationLimits) {
   // Does not match num_velocities().
   EXPECT_THROW(mutable_joint_->set_velocity_limits(VectorX<double>(3),
                                                    VectorX<double>()),
-               std::runtime_error);
+               std::exception);
   EXPECT_THROW(mutable_joint_->set_velocity_limits(VectorX<double>(),
                                                    VectorX<double>(3)),
-               std::runtime_error);
+               std::exception);
   // Lower limit is larger than upper limit.
   EXPECT_THROW(mutable_joint_->set_velocity_limits(Vector3d::Constant(2),
                                                    Vector3d::Constant(0)),
-               std::runtime_error);
+               std::exception);
 
   // Check for acceleration limits.
   mutable_joint_->set_acceleration_limits(Vector3d::Constant(new_lower),
@@ -219,14 +230,14 @@ TEST_F(BallRpyJointTest, SetVelocityAndAccelerationLimits) {
   // Does not match num_velocities().
   EXPECT_THROW(mutable_joint_->set_acceleration_limits(VectorX<double>(3),
                                                        VectorX<double>()),
-               std::runtime_error);
+               std::exception);
   EXPECT_THROW(mutable_joint_->set_acceleration_limits(VectorX<double>(),
                                                        VectorX<double>(3)),
-               std::runtime_error);
+               std::exception);
   // Lower limit is larger than upper limit.
   EXPECT_THROW(mutable_joint_->set_acceleration_limits(Vector3d::Constant(2),
                                                        Vector3d::Constant(0)),
-               std::runtime_error);
+               std::exception);
 }
 
 TEST_F(BallRpyJointTest, CanRotateOrTranslate) {

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -117,8 +117,15 @@ TEST_F(PlanarJointTest, GetJointLimits) {
 }
 
 TEST_F(PlanarJointTest, Damping) {
-  EXPECT_EQ(joint_->damping(), Vector3d::Constant(kDamping));
+  EXPECT_EQ(joint_->default_damping(), Vector3d::Constant(kDamping));
   EXPECT_EQ(joint_->default_damping_vector(), Vector3d::Constant(kDamping));
+
+  // Ensure the deprecated versions are correct until removal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(joint_->damping(), Vector3d::Constant(kDamping));
+  EXPECT_EQ(joint_->damping_vector(), Vector3d::Constant(kDamping));
+#pragma GCC diagnostic pop
 }
 
 // Context-dependent value access.
@@ -152,6 +159,10 @@ TEST_F(PlanarJointTest, ContextDependentAccess) {
   EXPECT_EQ(joint_->GetDampingVector(*context_), Vector3d::Constant(kDamping));
   EXPECT_NO_THROW(joint_->SetDampingVector(context_.get(), different_damping));
   EXPECT_EQ(joint_->GetDampingVector(*context_), different_damping);
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint_->SetDampingVector(context_.get(), Vector3d::Constant(-1)),
+               std::exception);
 }
 
 // Tests API to apply torques to individual dof of joint. Ensures that adding
@@ -223,7 +234,7 @@ TEST_F(PlanarJointTest, Clone) {
             joint_->acceleration_lower_limits());
   EXPECT_EQ(joint_clone.acceleration_upper_limits(),
             joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.damping(), joint_->damping());
+  EXPECT_EQ(joint_clone.default_damping(), joint_->default_damping());
   EXPECT_EQ(joint_clone.get_default_rotation(), joint_->get_default_rotation());
   EXPECT_EQ(joint_clone.get_default_translation(),
             joint_->get_default_translation());

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -118,7 +118,7 @@ TEST_F(PlanarJointTest, GetJointLimits) {
 
 TEST_F(PlanarJointTest, Damping) {
   EXPECT_EQ(joint_->damping(), Vector3d::Constant(kDamping));
-  EXPECT_EQ(joint_->damping_vector(), Vector3d::Constant(kDamping));
+  EXPECT_EQ(joint_->default_damping_vector(), Vector3d::Constant(kDamping));
 }
 
 // Context-dependent value access.
@@ -146,6 +146,12 @@ TEST_F(PlanarJointTest, ContextDependentAccess) {
   joint_->Lock(context_.get());
   EXPECT_EQ(joint_->get_translational_velocity(*context_), Vector2d(0., 0.));
   EXPECT_EQ(joint_->get_angular_velocity(*context_), 0.);
+
+  // Damping.
+  const Vector3d different_damping = Vector3d::Constant(5.6);
+  EXPECT_EQ(joint_->GetDampingVector(*context_), Vector3d::Constant(kDamping));
+  EXPECT_NO_THROW(joint_->SetDampingVector(context_.get(), different_damping));
+  EXPECT_EQ(joint_->GetDampingVector(*context_), different_damping);
 }
 
 // Tests API to apply torques to individual dof of joint. Ensures that adding
@@ -171,6 +177,29 @@ TEST_F(PlanarJointTest, AddInOneForce) {
   auto F2 = forces2.body_forces().cbegin();
   for (auto& F1 : forces1.body_forces())
     EXPECT_TRUE(F1.IsApprox(*F2++, kEpsilon));
+}
+
+// Tests API to add in damping forces.
+TEST_F(PlanarJointTest, AddInDampingForces) {
+  const Vector2d translational_velocity = Vector2d(0.1, 0.2);
+  const double angular_velocity = 0.3;
+  const double translational_damping = 0.5 * kDamping;
+  const double angular_damping = 0.4 * kDamping;
+
+  const Vector3d damping_forces_expected =
+      (Vector3d() << -translational_damping * translational_velocity,
+       -angular_damping * angular_velocity)
+          .finished();
+
+  joint_->set_translational_velocity(context_.get(), translational_velocity);
+  joint_->set_angular_velocity(context_.get(), angular_velocity);
+  joint_->SetDampingVector(
+      context_.get(),
+      Vector3d(translational_damping, translational_damping, angular_damping));
+
+  MultibodyForces<double> forces(tree());
+  joint_->AddInDamping(*context_, &forces);
+  EXPECT_EQ(forces.generalized_forces(), damping_forces_expected);
 }
 
 TEST_F(PlanarJointTest, Clone) {

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -117,12 +117,22 @@ TEST_F(PrismaticJointTest, GetJointLimits) {
 TEST_F(PrismaticJointTest, Damping) {
   std::unique_ptr<internal::MultibodyTree<double>> model = MakeModel();
   auto& joint = model->GetMutableJointByName<PrismaticJoint>("Joint1");
-  EXPECT_EQ(joint.damping(), kDamping);
+  EXPECT_EQ(joint.default_damping(), kDamping);
   EXPECT_EQ(joint.default_damping_vector(), Vector1d(kDamping));
   const double new_damping = 2.0 * kDamping;
   joint.set_default_damping(new_damping);
-  EXPECT_EQ(joint.damping(), new_damping);
+  EXPECT_EQ(joint.default_damping(), new_damping);
   EXPECT_EQ(joint.default_damping_vector(), Vector1d(new_damping));
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint.set_default_damping(-1), std::exception);
+
+  // Ensure the deprecated versions are correct until removal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(joint.damping(), new_damping);
+  EXPECT_EQ(joint.damping_vector(), Vector1d(new_damping));
+#pragma GCC diagnostic pop
 }
 
 // Context-dependent value access.
@@ -152,6 +162,11 @@ TEST_F(PrismaticJointTest, ContextDependentAccess) {
   EXPECT_NO_THROW(joint1_->SetDamping(context_.get(), kDamping));
   EXPECT_EQ(joint1_->GetDamping(*context_), kDamping);
   EXPECT_EQ(joint1_->GetDampingVector(*context_), Vector1d(kDamping));
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint1_->SetDamping(context_.get(), -1), std::exception);
+  EXPECT_THROW(joint1_->SetDampingVector(context_.get(), Vector1d(-1)),
+               std::exception);
 }
 
 // Tests API to apply torques to a joint.
@@ -214,7 +229,7 @@ TEST_F(PrismaticJointTest, Clone) {
             joint1_->acceleration_lower_limits());
   EXPECT_EQ(joint1_clone.acceleration_upper_limits(),
             joint1_->acceleration_upper_limits());
-  EXPECT_EQ(joint1_clone.damping(), joint1_->damping());
+  EXPECT_EQ(joint1_clone.default_damping(), joint1_->default_damping());
   EXPECT_EQ(joint1_clone.get_default_translation(),
             joint1_->get_default_translation());
 }

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -118,11 +118,11 @@ TEST_F(PrismaticJointTest, Damping) {
   std::unique_ptr<internal::MultibodyTree<double>> model = MakeModel();
   auto& joint = model->GetMutableJointByName<PrismaticJoint>("Joint1");
   EXPECT_EQ(joint.damping(), kDamping);
-  EXPECT_EQ(joint.damping_vector(), Vector1d(kDamping));
+  EXPECT_EQ(joint.default_damping_vector(), Vector1d(kDamping));
   const double new_damping = 2.0 * kDamping;
   joint.set_default_damping(new_damping);
   EXPECT_EQ(joint.damping(), new_damping);
-  EXPECT_EQ(joint.damping_vector(), Vector1d(new_damping));
+  EXPECT_EQ(joint.default_damping_vector(), Vector1d(new_damping));
 }
 
 // Context-dependent value access.
@@ -139,6 +139,19 @@ TEST_F(PrismaticJointTest, ContextDependentAccess) {
   // Joint locking.
   joint1_->Lock(context_.get());
   EXPECT_EQ(joint1_->get_translation_rate(*context_), 0.);
+
+  // Damping.
+  EXPECT_EQ(joint1_->GetDamping(*context_), kDamping);
+  EXPECT_EQ(joint1_->GetDampingVector(*context_), Vector1d(kDamping));
+
+  EXPECT_NO_THROW(
+      joint1_->SetDampingVector(context_.get(), Vector1d(some_value)));
+  EXPECT_EQ(joint1_->GetDamping(*context_), some_value);
+  EXPECT_EQ(joint1_->GetDampingVector(*context_), Vector1d(some_value));
+
+  EXPECT_NO_THROW(joint1_->SetDamping(context_.get(), kDamping));
+  EXPECT_EQ(joint1_->GetDamping(*context_), kDamping);
+  EXPECT_EQ(joint1_->GetDampingVector(*context_), Vector1d(kDamping));
 }
 
 // Tests API to apply torques to a joint.
@@ -162,6 +175,21 @@ TEST_F(PrismaticJointTest, AddInForces) {
   auto F2 = forces2.body_forces().cbegin();
   for (auto& F1 : forces1.body_forces())
     EXPECT_TRUE(F1.IsApprox(*F2++, kEpsilon));
+}
+
+// Tests API to add in damping forces.
+TEST_F(PrismaticJointTest, AddInDampingForces) {
+  const double translational_velocity = 0.1;
+  const double damping = 0.2 * kDamping;
+
+  const Vector1d damping_force_expected(-damping * translational_velocity);
+
+  joint1_->set_translation_rate(context_.get(), translational_velocity);
+  joint1_->SetDamping(context_.get(), damping);
+
+  MultibodyForces<double> forces(tree());
+  joint1_->AddInDamping(*context_, &forces);
+  EXPECT_EQ(forces.generalized_forces(), damping_force_expected);
 }
 
 TEST_F(PrismaticJointTest, Clone) {

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -121,13 +121,25 @@ TEST_F(QuaternionFloatingJointTest, GetJointLimits) {
 }
 
 TEST_F(QuaternionFloatingJointTest, Damping) {
-  EXPECT_EQ(joint_->angular_damping(), kAngularDamping);
-  EXPECT_EQ(joint_->translational_damping(), kTranslationalDamping);
+  EXPECT_EQ(joint_->default_angular_damping(), kAngularDamping);
+  EXPECT_EQ(joint_->default_translational_damping(), kTranslationalDamping);
   EXPECT_EQ(
       joint_->default_damping_vector(),
       (Vector6d() << kAngularDamping, kAngularDamping, kAngularDamping,
        kTranslationalDamping, kTranslationalDamping, kTranslationalDamping)
           .finished());
+
+  // Ensure the deprecated versions are correct until removal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(joint_->angular_damping(), kAngularDamping);
+  EXPECT_EQ(joint_->translational_damping(), kTranslationalDamping);
+  EXPECT_EQ(
+      joint_->damping_vector(),
+      (Vector6d() << kAngularDamping, kAngularDamping, kAngularDamping,
+       kTranslationalDamping, kTranslationalDamping, kTranslationalDamping)
+          .finished());
+#pragma GCC diagnostic pop
 }
 
 // Context-dependent value access.
@@ -182,6 +194,10 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
   EXPECT_EQ(joint_->GetDampingVector(*context_), damping);
   EXPECT_NO_THROW(joint_->SetDampingVector(context_.get(), different_damping));
   EXPECT_EQ(joint_->GetDampingVector(*context_), different_damping);
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint_->SetDampingVector(context_.get(), Vector6d::Constant(-1)),
+               std::exception);
 }
 
 // Tests API to apply torques to joint.
@@ -241,9 +257,10 @@ TEST_F(QuaternionFloatingJointTest, Clone) {
             joint_->acceleration_lower_limits());
   EXPECT_EQ(joint_clone.acceleration_upper_limits(),
             joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.angular_damping(), joint_->angular_damping());
-  EXPECT_EQ(joint_clone.translational_damping(),
-            joint_->translational_damping());
+  EXPECT_EQ(joint_clone.default_angular_damping(),
+            joint_->default_angular_damping());
+  EXPECT_EQ(joint_clone.default_translational_damping(),
+            joint_->default_translational_damping());
   EXPECT_EQ(joint_clone.get_default_quaternion().coeffs(),
             joint_->get_default_quaternion().coeffs());
   EXPECT_EQ(joint_clone.get_default_position(), joint_->get_default_position());
@@ -260,14 +277,14 @@ TEST_F(QuaternionFloatingJointTest, SetVelocityAndAccelerationLimits) {
   // Does not match num_velocities().
   EXPECT_THROW(mutable_joint_->set_velocity_limits(VectorX<double>(3),
                                                    VectorX<double>()),
-               std::runtime_error);
+               std::exception);
   EXPECT_THROW(mutable_joint_->set_velocity_limits(VectorX<double>(),
                                                    VectorX<double>(3)),
-               std::runtime_error);
+               std::exception);
   // Lower limit is larger than upper limit.
   EXPECT_THROW(mutable_joint_->set_velocity_limits(Vector6d::Constant(2),
                                                    Vector6d::Constant(0)),
-               std::runtime_error);
+               std::exception);
 
   // Check for acceleration limits.
   mutable_joint_->set_acceleration_limits(Vector6d::Constant(new_lower),
@@ -277,14 +294,14 @@ TEST_F(QuaternionFloatingJointTest, SetVelocityAndAccelerationLimits) {
   // Does not match num_velocities().
   EXPECT_THROW(mutable_joint_->set_acceleration_limits(VectorX<double>(3),
                                                        VectorX<double>()),
-               std::runtime_error);
+               std::exception);
   EXPECT_THROW(mutable_joint_->set_acceleration_limits(VectorX<double>(),
                                                        VectorX<double>(3)),
-               std::runtime_error);
+               std::exception);
   // Lower limit is larger than upper limit.
   EXPECT_THROW(mutable_joint_->set_acceleration_limits(Vector6d::Constant(2),
                                                        Vector6d::Constant(0)),
-               std::runtime_error);
+               std::exception);
 }
 
 TEST_F(QuaternionFloatingJointTest, CanRotateOrTranslate) {

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/systems/framework/context.h"
@@ -120,12 +121,22 @@ TEST_F(RevoluteJointTest, GetJointLimits) {
 TEST_F(RevoluteJointTest, Damping) {
   std::unique_ptr<internal::MultibodyTree<double>> model = MakeModel();
   auto& joint = model->GetMutableJointByName<RevoluteJoint>("Joint1");
-  EXPECT_EQ(joint.damping(), kDamping);
+  EXPECT_EQ(joint.default_damping(), kDamping);
   EXPECT_EQ(joint.default_damping_vector(), Vector1d(kDamping));
   const double new_damping = 2.0 * kDamping;
   joint.set_default_damping(new_damping);
-  EXPECT_EQ(joint.damping(), new_damping);
+  EXPECT_EQ(joint.default_damping(), new_damping);
   EXPECT_EQ(joint.default_damping_vector(), Vector1d(new_damping));
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint.set_default_damping(-1), std::exception);
+
+  // Ensure the deprecated versions are correct until removal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(joint.damping(), new_damping);
+  EXPECT_EQ(joint.damping_vector(), Vector1d(new_damping));
+#pragma GCC diagnostic pop
 }
 
 // Context-dependent value access.
@@ -151,6 +162,11 @@ TEST_F(RevoluteJointTest, ContextDependentAccess) {
   EXPECT_NO_THROW(joint1_->SetDamping(context_.get(), kDamping));
   EXPECT_EQ(joint1_->GetDamping(*context_), kDamping);
   EXPECT_EQ(joint1_->GetDampingVector(*context_), Vector1d(kDamping));
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint1_->SetDamping(context_.get(), -1), std::exception);
+  EXPECT_THROW(joint1_->SetDampingVector(context_.get(), Vector1d(-1)),
+               std::exception);
 }
 
 // Tests API to apply torques to a joint.
@@ -214,7 +230,7 @@ TEST_F(RevoluteJointTest, Clone) {
             joint1_->acceleration_lower_limits());
   EXPECT_EQ(joint1_clone.acceleration_upper_limits(),
             joint1_->acceleration_upper_limits());
-  EXPECT_EQ(joint1_clone.damping(), joint1_->damping());
+  EXPECT_EQ(joint1_clone.default_damping(), joint1_->default_damping());
   EXPECT_EQ(joint1_clone.get_default_angle(), joint1_->get_default_angle());
 }
 
@@ -229,14 +245,14 @@ TEST_F(RevoluteJointTest, SetVelocityAndAccelerationLimits) {
   // Does not match num_velocities().
   EXPECT_THROW(mutable_joint1_->set_velocity_limits(VectorX<double>(1),
                                                     VectorX<double>()),
-               std::runtime_error);
+               std::exception);
   EXPECT_THROW(mutable_joint1_->set_velocity_limits(VectorX<double>(),
                                                     VectorX<double>(1)),
-               std::runtime_error);
+               std::exception);
   // Lower limit is larger than upper limit.
   EXPECT_THROW(mutable_joint1_->set_velocity_limits(Vector1<double>(2),
                                                     Vector1<double>(0)),
-               std::runtime_error);
+               std::exception);
 
   // Check for acceleration limits.
   mutable_joint1_->set_acceleration_limits(Vector1<double>(new_lower),
@@ -246,14 +262,14 @@ TEST_F(RevoluteJointTest, SetVelocityAndAccelerationLimits) {
   // Does not match num_velocities().
   EXPECT_THROW(mutable_joint1_->set_acceleration_limits(VectorX<double>(1),
                                                         VectorX<double>()),
-               std::runtime_error);
+               std::exception);
   EXPECT_THROW(mutable_joint1_->set_acceleration_limits(VectorX<double>(),
                                                         VectorX<double>(1)),
-               std::runtime_error);
+               std::exception);
   // Lower limit is larger than upper limit.
   EXPECT_THROW(mutable_joint1_->set_acceleration_limits(Vector1<double>(2),
                                                         Vector1<double>(0)),
-               std::runtime_error);
+               std::exception);
 }
 
 TEST_F(RevoluteJointTest, CanRotateOrTranslate) {

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -121,11 +121,11 @@ TEST_F(RevoluteJointTest, Damping) {
   std::unique_ptr<internal::MultibodyTree<double>> model = MakeModel();
   auto& joint = model->GetMutableJointByName<RevoluteJoint>("Joint1");
   EXPECT_EQ(joint.damping(), kDamping);
-  EXPECT_EQ(joint.damping_vector(), Vector1d(kDamping));
+  EXPECT_EQ(joint.default_damping_vector(), Vector1d(kDamping));
   const double new_damping = 2.0 * kDamping;
   joint.set_default_damping(new_damping);
   EXPECT_EQ(joint.damping(), new_damping);
-  EXPECT_EQ(joint.damping_vector(), Vector1d(new_damping));
+  EXPECT_EQ(joint.default_damping_vector(), Vector1d(new_damping));
 }
 
 // Context-dependent value access.
@@ -138,6 +138,19 @@ TEST_F(RevoluteJointTest, ContextDependentAccess) {
   // Angular rate access:
   joint1_->set_angular_rate(context_.get(), some_value);
   EXPECT_EQ(joint1_->get_angular_rate(*context_), some_value);
+
+  // Damping.
+  EXPECT_EQ(joint1_->GetDamping(*context_), kDamping);
+  EXPECT_EQ(joint1_->GetDampingVector(*context_), Vector1d(kDamping));
+
+  EXPECT_NO_THROW(
+      joint1_->SetDampingVector(context_.get(), Vector1d(some_value)));
+  EXPECT_EQ(joint1_->GetDamping(*context_), some_value);
+  EXPECT_EQ(joint1_->GetDampingVector(*context_), Vector1d(some_value));
+
+  EXPECT_NO_THROW(joint1_->SetDamping(context_.get(), kDamping));
+  EXPECT_EQ(joint1_->GetDamping(*context_), kDamping);
+  EXPECT_EQ(joint1_->GetDampingVector(*context_), Vector1d(kDamping));
 }
 
 // Tests API to apply torques to a joint.
@@ -162,6 +175,21 @@ TEST_F(RevoluteJointTest, AddInTorques) {
   auto F2 = forces2.body_forces().cbegin();
   for (auto& F1 : forces1.body_forces())
     EXPECT_TRUE(F1.IsApprox(*F2++, kEpsilon));
+}
+
+// Tests API to add in damping forces.
+TEST_F(RevoluteJointTest, AddInDampingForces) {
+  const double angular_velocity = 0.1;
+  const double damping = 0.2 * kDamping;
+
+  const Vector1d damping_force_expected(-damping * angular_velocity);
+
+  joint1_->set_angular_rate(context_.get(), angular_velocity);
+  joint1_->SetDamping(context_.get(), damping);
+
+  MultibodyForces<double> forces(tree());
+  joint1_->AddInDamping(*context_, &forces);
+  EXPECT_EQ(forces.generalized_forces(), damping_force_expected);
 }
 
 TEST_F(RevoluteJointTest, Clone) {

--- a/multibody/tree/test/rpy_floating_joint_test.cc
+++ b/multibody/tree/test/rpy_floating_joint_test.cc
@@ -122,13 +122,25 @@ TEST_F(RpyFloatingJointTest, GetJointLimits) {
 }
 
 TEST_F(RpyFloatingJointTest, Damping) {
-  EXPECT_EQ(joint_->angular_damping(), kAngularDamping);
-  EXPECT_EQ(joint_->translational_damping(), kTranslationalDamping);
+  EXPECT_EQ(joint_->default_angular_damping(), kAngularDamping);
+  EXPECT_EQ(joint_->default_translational_damping(), kTranslationalDamping);
   EXPECT_EQ(
       joint_->default_damping_vector(),
       (Vector6d() << kAngularDamping, kAngularDamping, kAngularDamping,
        kTranslationalDamping, kTranslationalDamping, kTranslationalDamping)
           .finished());
+
+  // Ensure the deprecated versions are correct until removal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(joint_->angular_damping(), kAngularDamping);
+  EXPECT_EQ(joint_->translational_damping(), kTranslationalDamping);
+  EXPECT_EQ(
+      joint_->damping_vector(),
+      (Vector6d() << kAngularDamping, kAngularDamping, kAngularDamping,
+       kTranslationalDamping, kTranslationalDamping, kTranslationalDamping)
+          .finished());
+#pragma GCC diagnostic pop
 }
 
 // Context-dependent value access.
@@ -185,6 +197,10 @@ TEST_F(RpyFloatingJointTest, ContextDependentAccess) {
   EXPECT_EQ(joint_->GetDampingVector(*context_), damping);
   EXPECT_NO_THROW(joint_->SetDampingVector(context_.get(), different_damping));
   EXPECT_EQ(joint_->GetDampingVector(*context_), different_damping);
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint_->SetDampingVector(context_.get(), Vector6d::Constant(-1)),
+               std::exception);
 }
 
 // Tests API to apply torques to joint.
@@ -243,9 +259,10 @@ TEST_F(RpyFloatingJointTest, Clone) {
             joint_->acceleration_lower_limits());
   EXPECT_EQ(joint_clone.acceleration_upper_limits(),
             joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.angular_damping(), joint_->angular_damping());
-  EXPECT_EQ(joint_clone.translational_damping(),
-            joint_->translational_damping());
+  EXPECT_EQ(joint_clone.default_angular_damping(),
+            joint_->default_angular_damping());
+  EXPECT_EQ(joint_clone.default_translational_damping(),
+            joint_->default_translational_damping());
   EXPECT_EQ(joint_clone.get_default_angles(), joint_->get_default_angles());
   EXPECT_EQ(joint_clone.get_default_translation(),
             joint_->get_default_translation());

--- a/multibody/tree/test/rpy_floating_joint_test.cc
+++ b/multibody/tree/test/rpy_floating_joint_test.cc
@@ -125,7 +125,7 @@ TEST_F(RpyFloatingJointTest, Damping) {
   EXPECT_EQ(joint_->angular_damping(), kAngularDamping);
   EXPECT_EQ(joint_->translational_damping(), kTranslationalDamping);
   EXPECT_EQ(
-      joint_->damping_vector(),
+      joint_->default_damping_vector(),
       (Vector6d() << kAngularDamping, kAngularDamping, kAngularDamping,
        kTranslationalDamping, kTranslationalDamping, kTranslationalDamping)
           .finished());
@@ -174,6 +174,17 @@ TEST_F(RpyFloatingJointTest, ContextDependentAccess) {
   joint_->Lock(context_.get());
   EXPECT_EQ(joint_->get_angular_velocity(*context_), Vector3d(0., 0., 0.));
   EXPECT_EQ(joint_->get_translational_velocity(*context_), Vector3d::Zero());
+
+  // Damping.
+  const Vector6d damping =
+      (Vector6d() << kAngularDamping, kAngularDamping, kAngularDamping,
+       kTranslationalDamping, kTranslationalDamping, kTranslationalDamping)
+          .finished();
+  const Vector6d different_damping =
+      (Vector6d() << 2.3, 2.3, 2.3, 4.5, 4.5, 4.5).finished();
+  EXPECT_EQ(joint_->GetDampingVector(*context_), damping);
+  EXPECT_NO_THROW(joint_->SetDampingVector(context_.get(), different_damping));
+  EXPECT_EQ(joint_->GetDampingVector(*context_), different_damping);
 }
 
 // Tests API to apply torques to joint.
@@ -185,6 +196,30 @@ TEST_F(RpyFloatingJointTest, AddInOneForce) {
   // not supported, this method should throw.
   EXPECT_THROW(joint_->AddInOneForce(*context_, 0, some_value, &forces),
                std::exception);
+}
+
+// Tests API to add in damping forces.
+TEST_F(RpyFloatingJointTest, AddInDampingForces) {
+  const Vector3d angular_velocity(0.1, 0.2, 0.3);
+  const Vector3d translational_veloctiy(0.4, 0.5, 0.6);
+  const double angular_damping = 3 * kAngularDamping;
+  const double translational_damping = 4 * kTranslationalDamping;
+
+  const Vector6d damping_forces_expected =
+      (Vector6d() << -angular_damping * angular_velocity,
+       -translational_damping * translational_veloctiy)
+          .finished();
+
+  joint_->set_angular_velocity(context_.get(), angular_velocity);
+  joint_->set_translational_velocity(context_.get(), translational_veloctiy);
+  joint_->SetDampingVector(context_.get(),
+                           (Vector6d() << Vector3d::Constant(angular_damping),
+                            Vector3d::Constant(translational_damping))
+                               .finished());
+
+  MultibodyForces<double> forces(tree());
+  joint_->AddInDamping(*context_, &forces);
+  EXPECT_EQ(forces.generalized_forces(), damping_forces_expected);
 }
 
 TEST_F(RpyFloatingJointTest, Clone) {

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -107,8 +107,15 @@ TEST_F(ScrewJointTest, GetJointLimits) {
 }
 
 TEST_F(ScrewJointTest, Damping) {
-  EXPECT_EQ(joint_->damping(), kDamping);
+  EXPECT_EQ(joint_->default_damping(), kDamping);
   EXPECT_EQ(joint_->default_damping_vector(), Vector1d(kDamping));
+
+  // Ensure the deprecated versions are correct until removal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(joint_->damping(), kDamping);
+  EXPECT_EQ(joint_->damping_vector(), Vector1d(kDamping));
+#pragma GCC diagnostic pop
 }
 
 // Context-dependent value access.
@@ -149,6 +156,11 @@ TEST_F(ScrewJointTest, ContextDependentAccess) {
   EXPECT_NO_THROW(joint_->SetDamping(context_.get(), kDamping));
   EXPECT_EQ(joint_->GetDamping(*context_), kDamping);
   EXPECT_EQ(joint_->GetDampingVector(*context_), Vector1d(kDamping));
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint_->SetDamping(context_.get(), -1), std::exception);
+  EXPECT_THROW(joint_->SetDampingVector(context_.get(), Vector1d(-1)),
+               std::exception);
 }
 
 // Tests API to apply torques to individual dof of joint. Ensures that adding
@@ -212,7 +224,7 @@ TEST_F(ScrewJointTest, Clone) {
             joint_->acceleration_lower_limits());
   EXPECT_EQ(joint_clone.acceleration_upper_limits(),
             joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.damping(), joint_->damping());
+  EXPECT_EQ(joint_clone.default_damping(), joint_->default_damping());
   EXPECT_EQ(joint_clone.get_default_rotation(), joint_->get_default_rotation());
   EXPECT_EQ(joint_clone.get_default_translation(),
             joint_->get_default_translation());

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -115,8 +115,15 @@ TEST_F(UniversalJointTest, GetJointLimits) {
 }
 
 TEST_F(UniversalJointTest, Damping) {
-  EXPECT_EQ(joint_->damping(), kDamping);
+  EXPECT_EQ(joint_->default_damping(), kDamping);
   EXPECT_EQ(joint_->default_damping_vector(), Vector2d::Constant(kDamping));
+
+  // Ensure the deprecated versions are correct until removal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(joint_->damping(), kDamping);
+  EXPECT_EQ(joint_->damping_vector(), Vector2d::Constant(kDamping));
+#pragma GCC diagnostic pop
 }
 
 // Context-dependent value access.
@@ -138,6 +145,10 @@ TEST_F(UniversalJointTest, ContextDependentAccess) {
   EXPECT_EQ(joint_->GetDampingVector(*context_), Vector2d::Constant(kDamping));
   EXPECT_NO_THROW(joint_->SetDampingVector(context_.get(), some_value));
   EXPECT_EQ(joint_->GetDampingVector(*context_), some_value);
+
+  // Expect to throw on invalid damping values.
+  EXPECT_THROW(joint_->SetDampingVector(context_.get(), Vector2d::Constant(-1)),
+               std::exception);
 }
 
 // Tests API to apply torques to individual dof of joint.
@@ -200,7 +211,7 @@ TEST_F(UniversalJointTest, Clone) {
             joint_->acceleration_lower_limits());
   EXPECT_EQ(joint_clone.acceleration_upper_limits(),
             joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.damping(), joint_->damping());
+  EXPECT_EQ(joint_clone.default_damping(), joint_->default_damping());
   EXPECT_EQ(joint_clone.get_default_angles(), joint_->get_default_angles());
 }
 

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -92,7 +92,7 @@ TEST_F(WeldJointTest, GetJointLimits) {
 }
 
 TEST_F(WeldJointTest, Damping) {
-  EXPECT_EQ(joint_->damping_vector().size(), 0);
+  EXPECT_EQ(joint_->default_damping_vector().size(), 0);
 }
 
 TEST_F(WeldJointTest, JointLocking) {

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -25,7 +25,7 @@ std::unique_ptr<Joint<ToScalar>> UniversalJoint<T>::TemplatedDoCloneToScalar(
   // Make the Joint<T> clone.
   auto joint_clone = std::make_unique<UniversalJoint<ToScalar>>(
       this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
-      this->damping());
+      this->default_damping());
   joint_clone->set_position_limits(this->position_lower_limits(),
                                    this->position_upper_limits());
   joint_clone->set_velocity_limits(this->velocity_lower_limits(),

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -65,8 +65,8 @@ class UniversalJoint final : public Joint<T> {
   /// The additional parameters are:
   /// @param[in] damping
   ///   Viscous damping coefficient, in N⋅m⋅s, used to model losses within the
-  ///   joint. See documentation of damping() for details on modelling of the
-  ///   damping torque.
+  ///   joint. See documentation of default_damping() for details on modelling
+  ///   of the damping torque.
   /// @throws std::exception if damping is negative.
   UniversalJoint(const std::string& name, const Frame<T>& frame_on_parent,
                  const Frame<T>& frame_on_child, double damping = 0)
@@ -89,11 +89,17 @@ class UniversalJoint final : public Joint<T> {
 
   const std::string& type_name() const override;
 
-  /// Returns `this` joint's damping constant in N⋅m⋅s. The damping torque
-  /// (in N⋅m) is modeled as `τᵢ = -damping⋅ωᵢ, i = 1, 2` i.e. opposing motion,
-  /// with ωᵢ the angular rates about the i-th axis for `this` joint (see
-  /// get_angular_rates())and τᵢ the torque on child body B about the same i-th
-  /// axis.
+  /// Returns `this` joint's default damping constant in N⋅m⋅s. The damping
+  /// torque (in N⋅m) is modeled as `τᵢ = -damping⋅ωᵢ, i = 1, 2` i.e. opposing
+  /// motion, with ωᵢ the angular rates about the i-th axis for `this` joint
+  /// (see get_angular_rates())and τᵢ the torque on child body B about the same
+  /// i-th axis.
+  double default_damping() const {
+    // N.B. Both damping coefficients are set to the same value for this joint.
+    return this->default_damping_vector()[0];
+  }
+
+  DRAKE_DEPRECATED("2024-06-01", "Use `default_damping()` instead.")
   double damping() const {
     // N.B. Both damping coefficients are set to the same value for this joint.
     return this->default_damping_vector()[0];
@@ -198,7 +204,8 @@ class UniversalJoint final : public Joint<T> {
   /// Joint<T> override called through public NVI, Joint::AddInDamping().
   /// Therefore arguments were already checked to be valid.
   /// This method adds into `forces` a dissipative torque according to the
-  /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see damping()).
+  /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see
+  /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const override {
     Eigen::Ref<VectorX<T>> tau =

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -96,7 +96,7 @@ class UniversalJoint final : public Joint<T> {
   /// axis.
   double damping() const {
     // N.B. Both damping coefficients are set to the same value for this joint.
-    return this->damping_vector()[0];
+    return this->default_damping_vector()[0];
   }
 
   /// @name Context-dependent value access
@@ -205,7 +205,7 @@ class UniversalJoint final : public Joint<T> {
         get_mobilizer()->get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     const Vector2<T>& theta_dot = get_angular_rates(context);
-    tau = -damping() * theta_dot;
+    tau = -this->GetDampingVector(context)[0] * theta_dot;
   }
 
  private:


### PR DESCRIPTION
Closes #14405

This PR gives the full system parameter treatment to joint damping. The new APIs:
```
const VectorX<T>& Joint::GetDampingVector(const Context<T>& context) const
void Joint::SetDampingVector(Context<T>* context, const VectorX<T>& context) const
```
are introduced so that all joint types get a damping parameter. In addition, I added sugar for
single-dof joints:
```
const T& RevoluteJoint::GetDamping(const Context<T>& context) const;
void RevoluteJoint::SetDamping(Context<T>* context, const T& damping) const;
```
ditto for `PrismaticJoint` and `ScrewJoint`.

Also python bindings for all of these.

cc @nepfaff @wrangelvid @RussTedrake

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20947)
<!-- Reviewable:end -->
