### PR TITLE
[tools] Add Noble scripts, copied from Jammy

### DIFF
--- a/tools/install/dockerhub/noble/.dockerignore
+++ b/tools/install/dockerhub/noble/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+Dockerfile
+README.md

--- a/tools/install/dockerhub/noble/Dockerfile
+++ b/tools/install/dockerhub/noble/Dockerfile
@@ -1,0 +1,18 @@
+# -*- mode: dockerfile -*-
+# vi: set ft=dockerfile :
+
+FROM ubuntu:jammy
+ADD drake-latest-jammy.tar.gz /opt
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update -qq \
+  && apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
+    $(cat /opt/drake/share/drake/setup/packages-jammy.txt) \
+# Make python and pip available to meet the requirements for deepnote.com:
+# https://docs.deepnote.com/environment/custom-environments#custom-image-requirements
+    python3-pip python-is-python3 \
+  && rm -rf /var/lib/apt/lists/* \
+# Bake model data into the image up-front, instead of fetching on demand.
+  && PYTHONPATH=/opt/drake/lib/python3.10/site-packages python3 -c \
+    'from pydrake.all import PackageMap; PackageMap().GetPath("drake_models")' \
+ENV PATH="/opt/drake/bin:${PATH}" \
+  PYTHONPATH="/opt/drake/lib/python3.10/site-packages:${PYTHONPATH}"

--- a/tools/install/dockerhub/noble/Dockerfile
+++ b/tools/install/dockerhub/noble/Dockerfile
@@ -1,18 +1,18 @@
 # -*- mode: dockerfile -*-
 # vi: set ft=dockerfile :
 
-FROM ubuntu:jammy
-ADD drake-latest-jammy.tar.gz /opt
+FROM ubuntu:noble
+ADD drake-latest-noble.tar.gz /opt
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update -qq \
   && apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
-    $(cat /opt/drake/share/drake/setup/packages-jammy.txt) \
+    $(cat /opt/drake/share/drake/setup/packages-noble.txt) \
 # Make python and pip available to meet the requirements for deepnote.com:
 # https://docs.deepnote.com/environment/custom-environments#custom-image-requirements
     python3-pip python-is-python3 \
   && rm -rf /var/lib/apt/lists/* \
 # Bake model data into the image up-front, instead of fetching on demand.
-  && PYTHONPATH=/opt/drake/lib/python3.10/site-packages python3 -c \
+  && PYTHONPATH=/opt/drake/lib/python3.11/site-packages python3 -c \
     'from pydrake.all import PackageMap; PackageMap().GetPath("drake_models")' \
 ENV PATH="/opt/drake/bin:${PATH}" \
-  PYTHONPATH="/opt/drake/lib/python3.10/site-packages:${PYTHONPATH}"
+  PYTHONPATH="/opt/drake/lib/python3.11/site-packages:${PYTHONPATH}"

--- a/tools/install/dockerhub/noble/README.md
+++ b/tools/install/dockerhub/noble/README.md
@@ -1,0 +1,21 @@
+# Docker Image for Docker Hub (Jammy)
+
+To create a Docker image similar to those hosted on
+[Docker Hub](https://hub.docker.com/r/robotlocomotion/drake), download the
+latest [binary package](https://drake.mit.edu/from_binary.html)
+`drake-latest-jammy.tar.gz` to this directory, and then run the following
+command:
+
+```bash
+docker build -t robotlocomotion/drake:jammy .
+```
+
+To start a Docker container with an interactive pseudo-terminal, run the
+following command:
+
+```bash
+docker run -it robotlocomotion/drake:jammy
+```
+
+The environment variables `PATH` and `PYTHONPATH` are preset to suitable values
+for using Drake, including, in particular, its Python bindings.

--- a/tools/install/dockerhub/noble/README.md
+++ b/tools/install/dockerhub/noble/README.md
@@ -1,20 +1,20 @@
-# Docker Image for Docker Hub (Jammy)
+# Docker Image for Docker Hub (Noble)
 
 To create a Docker image similar to those hosted on
 [Docker Hub](https://hub.docker.com/r/robotlocomotion/drake), download the
 latest [binary package](https://drake.mit.edu/from_binary.html)
-`drake-latest-jammy.tar.gz` to this directory, and then run the following
+`drake-latest-noble.tar.gz` to this directory, and then run the following
 command:
 
 ```bash
-docker build -t robotlocomotion/drake:jammy .
+docker build -t robotlocomotion/drake:noble .
 ```
 
 To start a Docker container with an interactive pseudo-terminal, run the
 following command:
 
 ```bash
-docker run -it robotlocomotion/drake:jammy
+docker run -it robotlocomotion/drake:noble
 ```
 
 The environment variables `PATH` and `PYTHONPATH` are preset to suitable values

--- a/tools/ubuntu-noble.bazelrc
+++ b/tools/ubuntu-noble.bazelrc
@@ -1,0 +1,11 @@
+# Use C++20 by default.
+build --cxxopt=-std=c++20
+build --host_cxxopt=-std=c++20
+
+# Options for explicitly using Clang.
+common:clang --repo_env=CC=clang-14
+common:clang --repo_env=CXX=clang++-14
+build:clang --action_env=CC=clang-14
+build:clang --action_env=CXX=clang++-14
+build:clang --host_action_env=CC=clang-14
+build:clang --host_action_env=CXX=clang++-14


### PR DESCRIPTION
This is the tools-side brother of #20929.

This is the second step toward supporting Ubuntu 24.04 ("Noble").

This PR doesn't actually do much yet, other than copy the files while preserving git history. The git hijinks are intricate enough that it makes sense to land this on its own, before changing any setup scripts to actually use it.

The one meaningful change is the final commit, which adjust some spellings in the Dockerfile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20955)
<!-- Reviewable:end -->
