### PR TITLE
Primitives context checks

### DIFF
--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -50,6 +50,7 @@ void DiscreteDerivative<T>::set_input_history(
     const Eigen::Ref<const drake::VectorX<T>>& u_n_minus_1) const {
   DRAKE_DEMAND(u_n.size() == n_);
   DRAKE_DEMAND(u_n_minus_1.size() == n_);
+  this->ValidateCreatedForThisSystem(state);
 
   state->get_mutable_discrete_state(0).SetFromVector(u_n);
   state->get_mutable_discrete_state(1).SetFromVector(u_n_minus_1);
@@ -133,6 +134,7 @@ template <typename T>
 void StateInterpolatorWithDiscreteDerivative<T>::set_initial_state(
     systems::State<T>* state, const Eigen::Ref<const VectorX<T>>& position,
     const Eigen::Ref<const VectorX<T>>& velocity) const {
+  this->ValidateCreatedForThisSystem(state);
   // The derivative block implements y(t) = (u[n]-u[n-1])/h, so we want
   // u[n] = position, u[n-1] = u[n] - h*velocity
   derivative_->set_input_history(

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -88,6 +88,8 @@ class DiscreteDerivative final : public LeafSystem<T> {
   void set_input_history(
       systems::Context<T>* context, const Eigen::Ref<const VectorX<T>>& u_n,
       const Eigen::Ref<const VectorX<T>>& u_n_minus_1) const {
+    // N.B. The set_input_history(State* ...) overload is responsible for
+    // validating the state (context) belongs to the this System.
     set_input_history(&context->get_mutable_state(), u_n, u_n_minus_1);
   }
 
@@ -99,6 +101,7 @@ class DiscreteDerivative final : public LeafSystem<T> {
   /// to disable the suppression for this `context`.
   void set_input_history(systems::Context<T>* context,
                          const Eigen::Ref<const VectorX<T>>& u) const {
+    this->ValidateContext(context);
     set_input_history(&context->get_mutable_state(), u, u);
   }
 
@@ -195,6 +198,8 @@ class StateInterpolatorWithDiscreteDerivative final : public Diagram<T> {
   void set_initial_position(
       systems::Context<T>* context,
       const Eigen::Ref<const VectorX<T>>& position) const {
+    // N.B. The set_input_history(State* ...) overload is responsible for
+    // validating the state (context) belongs to the this System.
     set_initial_position(&context->get_mutable_state(), position);
   }
 
@@ -209,6 +214,8 @@ class StateInterpolatorWithDiscreteDerivative final : public Diagram<T> {
   void set_initial_state(systems::Context<T>* context,
                          const Eigen::Ref<const VectorX<T>>& position,
                          const Eigen::Ref<const VectorX<T>>& velocity) const {
+    // N.B. The set_input_history(State* ...) overload is responsible for
+    // validating the state (context) belongs to the this System.
     set_initial_state(&context->get_mutable_state(), position, velocity);
   }
 

--- a/systems/primitives/discrete_time_delay.h
+++ b/systems/primitives/discrete_time_delay.h
@@ -78,6 +78,7 @@ class DiscreteTimeDelay final : public LeafSystem<T> {
   /// block, sliding the delay buffer forward and placing the sampled input at
   /// the end. This emulates an update event and is mostly useful for testing.
   void SaveInputToBuffer(Context<T>* context) const {
+    this->ValidateContext(context);
     if (is_abstract()) {
       SaveInputAbstractValueToBuffer(*context, &context->get_mutable_state());
     } else {

--- a/systems/primitives/first_order_low_pass_filter.cc
+++ b/systems/primitives/first_order_low_pass_filter.cc
@@ -53,6 +53,7 @@ const VectorX<double>& FirstOrderLowPassFilter<T>::get_time_constants_vector()
 template <typename T>
 void FirstOrderLowPassFilter<T>::set_initial_output_value(
     Context<T>* context, const Eigen::Ref<const VectorX<T>>& z0) const {
+  this->ValidateContext(context);
   VectorBase<T>& state_vector = context->get_mutable_continuous_state_vector();
   // Asserts that the input value is a column vector of the appropriate size.
   DRAKE_DEMAND(z0.rows() == state_vector.size() && z0.cols() == 1);

--- a/systems/primitives/integrator.cc
+++ b/systems/primitives/integrator.cc
@@ -24,6 +24,7 @@ Integrator<T>::~Integrator() = default;
 template <typename T>
 void Integrator<T>::set_integral_value(
     Context<T>* context, const Eigen::Ref<const VectorX<T>>& value) const {
+  this->ValidateContext(context);
   VectorBase<T>& state_vector = context->get_mutable_continuous_state_vector();
   // Asserts that the input value is a column vector of the appropriate size.
   DRAKE_DEMAND(value.rows() == state_vector.size() && value.cols() == 1);

--- a/systems/primitives/multilayer_perceptron.cc
+++ b/systems/primitives/multilayer_perceptron.cc
@@ -184,12 +184,14 @@ MultilayerPerceptron<T>::MultilayerPerceptron(
 template <typename T>
 const VectorX<T>& MultilayerPerceptron<T>::GetParameters(
     const Context<T>& context) const {
+  this->ValidateContext(context);
   return context.get_numeric_parameter(0).value();
 }
 
 template <typename T>
 Eigen::VectorBlock<VectorX<T>> MultilayerPerceptron<T>::GetMutableParameters(
     Context<T>* context) const {
+  this->ValidateContext(context);
   return context->get_mutable_numeric_parameter(0).get_mutable_value();
 }
 
@@ -219,18 +221,21 @@ template <typename T>
 void MultilayerPerceptron<T>::SetParameters(
     Context<T>* context, const Eigen::Ref<const VectorX<T>>& params) const {
   DRAKE_DEMAND(params.rows() == num_parameters_);
+  this->ValidateContext(context);
   context->get_mutable_numeric_parameter(0).SetFromVector(params);
 }
 
 template <typename T>
 Eigen::Map<const MatrixX<T>> MultilayerPerceptron<T>::GetWeights(
     const Context<T>& context, int layer) const {
+  this->ValidateContext(context);
   return GetWeights(context.get_numeric_parameter(0).value(), layer);
 }
 
 template <typename T>
 Eigen::Map<const VectorX<T>> MultilayerPerceptron<T>::GetBiases(
     const Context<T>& context, int layer) const {
+  this->ValidateContext(context);
   return GetBiases(context.get_numeric_parameter(0).value(), layer);
 }
 
@@ -241,6 +246,7 @@ void MultilayerPerceptron<T>::SetWeights(
   DRAKE_DEMAND(layer >= 0 && layer < num_weights_);
   DRAKE_DEMAND(W.rows() == layers_[layer + 1]);
   DRAKE_DEMAND(W.cols() == layers_[layer]);
+  this->ValidateContext(context);
   BasicVector<T>& params = context->get_mutable_numeric_parameter(0);
   Eigen::Map<MatrixX<T>>(
       params.get_mutable_value().data() + weight_indices_[layer],
@@ -253,6 +259,7 @@ void MultilayerPerceptron<T>::SetBiases(
     const Eigen::Ref<const VectorX<T>>& b) const {
   DRAKE_DEMAND(layer >= 0 && layer < num_weights_);
   DRAKE_DEMAND(b.rows() == layers_[layer + 1]);
+  this->ValidateContext(context);
   context->get_mutable_numeric_parameter(0).get_mutable_value().segment(
       bias_indices_[layer], layers_[layer + 1]) = b;
 }

--- a/systems/primitives/random_source.cc
+++ b/systems/primitives/random_source.cc
@@ -100,6 +100,7 @@ RandomSource<T>::RandomSource(const RandomSource<U>& other)
 
 template <typename T>
 Seed RandomSource<T>::get_seed(const Context<double>& context) const {
+  this->ValidateContext(context);
   const auto& source = context.template get_abstract_state<SampleGenerator>(0);
   return source.seed();
 }

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -83,6 +83,7 @@ class ZeroOrderHold final : public LeafSystem<T> {
   /// into the state. This emulates an update event and is mostly useful for
   /// testing.
   void LatchInputPortToState(Context<T>* context) const {
+    this->ValidateContext(context);
     if (is_abstract()) {
       LatchInputAbstractValueToState(*context, &context->get_mutable_state());
     } else {


### PR DESCRIPTION
Certain public methods of various primitive systems use a context without checking its validity. This can lead to downstream errors, such as the one encountered in #20945. I've gone through all the primitive systems and added context validation to the cases where it's not being checked, but values from the context are being used.

Closes: #20945.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20958)
<!-- Reviewable:end -->
