### PR TITLE
Remove compatibility shims for Focal

### DIFF
--- a/bindings/pydrake/common/cpp_param.py
+++ b/bindings/pydrake/common/cpp_param.py
@@ -142,32 +142,12 @@ class _Generic:
         return f"<Generic {self._name}>"
 
 
-def _has_pep585():
-    return sys.version_info[:2] >= (3, 9)
-
-
 def _dict_instantiator(params):
-    # Backport PEP-585 support into Python 3.8 and earlier.
-    if _has_pep585():
-        result = dict[params]
-    else:
-        result = typing.Dict[params]
-        # We need the result to be a callable type to match PEP-585 (i.e.,
-        # calling it must return a fresh `dict` object.)
-        result._inst = True
-    return result
+    return dict[params]
 
 
 def _list_instantiator(params):
-    # Backport PEP-585 support into Python 3.8 and earlier.
-    if _has_pep585():
-        result = list[params]
-    else:
-        result = typing.List[params]
-        # We need the result to be a callable type to match PEP-585 (i.e.,
-        # calling it must return a fresh `list` object.)
-        result._inst = True
-    return result
+    return list[params]
 
 
 def _optional_instantiator(params):

--- a/bindings/pydrake/common/test/cpp_template_test.py
+++ b/bindings/pydrake/common/test/cpp_template_test.py
@@ -93,11 +93,7 @@ class TestCppTemplate(unittest.TestCase):
 
         with self.assertRaises(TypeError) as cm:
             assert_pickle(self, template)
-        if sys.version_info[:2] >= (3, 8):
-            pickle_error = "cannot pickle 'module' object"
-        else:
-            pickle_error = "can't pickle module objects"
-        self.assertIn(pickle_error, str(cm.exception))
+        self.assertIn("cannot pickle 'module' object", str(cm.exception))
 
     def test_base_negative(self):
 

--- a/bindings/pydrake/common/test/serialize_pybind_test.py
+++ b/bindings/pydrake/common/test/serialize_pybind_test.py
@@ -99,15 +99,6 @@ class TestSerializePybind(unittest.TestCase):
         self.assertEqual(dut.some_map, {'new_key': 70})
         self.assertEqual(dut.some_variant, 80.0)
 
-        try:
-            # Use the PEP-585 types if supported (Python >= 3.9).
-            expected_vector_type = list[float]
-            expected_dict_type = dict[str, float]
-        except TypeError:
-            # Otherwise, use the Python 3.8 types.
-            expected_vector_type = typing.List[float]
-            expected_dict_type = typing.Dict[str, float]
-
         # Check all field types.
         fields = getattr(MyData2, "__fields__")
         self.assertSequenceEqual([(x.name, x.type) for x in fields], (
@@ -119,8 +110,8 @@ class TestSerializePybind(unittest.TestCase):
             ("some_string", str),
             ("some_eigen", np.ndarray),
             ("some_optional", typing.Optional[float]),
-            ("some_vector", expected_vector_type),
-            ("some_map", expected_dict_type),
+            ("some_vector", list[float]),
+            ("some_map", dict[str, float]),
             ("some_variant", typing.Union[float, MyData1])))
 
     def test_repr_using_serialize_no_docs(self):

--- a/bindings/pydrake/common/test/yaml_typed_test.py
+++ b/bindings/pydrake/common/test/yaml_typed_test.py
@@ -74,9 +74,8 @@ class OptionalStructNoDefault:
 
 @dc.dataclass
 class NumpyStruct:
-    # TODO(jwnimmer-tri) Once we drop support for Ubuntu 20.04 "Focal", then we
-    # can upgrade to numpy >= 1.21 as our minimum at which point we can use the
-    # numpy.typing module here to constrain the shape and/or dtype.
+    # TODO(jwnimmer-tri) We should use the numpy.typing module here to
+    # constrain the shape and/or dtype.
     value: np.ndarray = dc.field(
         default_factory=lambda: np.array([nan]))
 

--- a/bindings/pydrake/common/yaml.py
+++ b/bindings/pydrake/common/yaml.py
@@ -637,11 +637,9 @@ def _yaml_dump_typed_item(*, obj, schema):
 
     # Handle NumPy types.
     if schema == np.ndarray:
-        # TODO(jwnimmer-tri) Once we drop support for Ubuntu 20.04 "Focal",
-        # then we can upgrade to numpy >= 1.21 as our minimum at which point
-        # we can use the numpy.typing module here to statically specify a
-        # shape and/or dtype in the schema. Until then, we only support floats
-        # with no restrictions on the shape.
+        # TODO(jwnimmer-tri) We should use the numpy.typing module here to
+        # statically specify a shape and/or dtype in the schema. For now,
+        # we only support floats with no restrictions on the shape.
         assert obj.dtype == np.dtype(np.float64)
         list_value = obj.tolist()
         list_schema = float

--- a/bindings/pydrake/gym/_drake_gym_env.py
+++ b/bindings/pydrake/gym/_drake_gym_env.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Callable, Optional, Union
 import warnings
 
@@ -16,9 +15,6 @@ from pydrake.systems.framework import (
     System,
 )
 from pydrake.systems.sensors import ImageRgba8U
-
-
-assert sys.version_info >= (3, 10), "pydrake.gym requires Python 3.10 or newer"
 
 
 class DrakeGymEnv(gym.Env):

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -83,13 +83,7 @@ class CustomAdder(LeafSystem):
         # N.B. We cannot use `header_lines.append(...)` here; the property
         # getter returns a _copy_ of the lines, not a _reference_.
         params.header_lines += ["hello=world"]
-        if sys.version_info[:2] >= (3, 9):
-            params.options |= {"split": "I/O"}
-        else:
-            # TODO(jwnimmer-tri) Kill this spelling when we drop Ubuntu 20.04.
-            options = params.options
-            options.update({"split": "I/O"})
-            params.options = options
+        params.options |= {"split": "I/O"}
         return super().DoGetGraphvizFragment(params)
 
 

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -75,7 +75,7 @@ import pydrake.visualization.meldis
 #
 # TODO(mwoehlke-kitware): Remove this when Jammy's python3-u-msgpack has been
 # updated to 2.5.2 or later.
-if sys.version_info[:2] >= (3, 10) and not hasattr(umsgpack, 'Hashable'):
+if not hasattr(umsgpack, 'Hashable'):
     import collections
     setattr(umsgpack.collections, 'Hashable', collections.abc.Hashable)
 

--- a/common/overloaded.h
+++ b/common/overloaded.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <utility>
-#include <variant>
-
 /** @file
 The "overloaded" variant-visit pattern.
 
@@ -11,8 +8,8 @@ doesn't support it natively.  There is a commonly used two-line boilerplate
 that bridges this gap; see
 https://en.cppreference.com/w/cpp/utility/variant/visit
 
-This file should be included by classes that wish to use the variant visit
-pattern, i.e.:
+This file should be included by classes that wish to
+use the variant visit pattern, i.e.
 
 @code {.cpp}
   using MyVariant = std::variant<int, std::string>;
@@ -23,23 +20,6 @@ pattern, i.e.:
   }, v);
   EXPECT_EQ(result, "found an int");
 @endcode
-
-However, note that the prior example DOES NOT WORK yet in Drake. In order to
-support C++17 we must also (for now) use a polyfill for `std::visit<T>` which
-we've named `visit_overloaded<T>`, so within Drake we must spell it like this:
-
-@code {.cpp}
-  using MyVariant = std::variant<int, std::string>;
-  MyVariant v = 5;
-  std::string result = visit_overloaded<const char*>(overloaded{
-    [](const int arg) { return "found an int"; },
-    [](const std::string& arg) { return "found a string"; }
-  }, v);
-  EXPECT_EQ(result, "found an int");
-@endcode
-
-When we drop support for C++17, we'll be able to return back to the normal
-pattern.
 
 @warning This file must never be included by a header, only by a cc file.
          This is enforced by a lint rule in `tools/lint/drakelint.py`.
@@ -55,32 +35,11 @@ template <class... Ts>
 struct overloaded : Ts... {
   using Ts::operator()...;
 };
+
+// Even though Drake requires C++20, Clang versions prior to 17 do not implement
+// P1816 yet, so we need to write out a deduction guide. We can remove this once
+// Drake requires Clang 17 or newer (as well as the matching Apple Clang).
 template <class... Ts>
 overloaded(Ts...) -> overloaded<Ts...>;
-
-// NOTE:  The second line above can be removed when we are compiling with
-// >= C++20 on all platforms.
-
-// This is a polyfill for C++20's std::visit<Return>(visitor, variant) that we
-// need while we still support C++17. Once we drop C++17 (i.e., once we drop
-// Ubuntu 20.04), we should switch back to the conventional spelling and remove
-// this entire block of code.
-#if __cplusplus > 201703L
-// On reasonable platforms, we can just call std::visit.
-template <typename Return, typename Visitor, typename Variant>
-auto visit_overloaded(Visitor&& visitor, Variant&& variant) -> decltype(auto) {
-  return std::visit<Return>(std::forward<Visitor>(visitor),
-                            std::forward<Variant>(variant));
-}
-#else
-// On Focal, we need to do a polyfill.
-template <typename Return, typename Visitor, typename Variant>
-auto visit_overloaded(Visitor&& visitor, Variant&& variant) -> Return {
-  auto visitor_coerced = [&visitor]<typename Value>(Value&& value) -> Return {
-    return visitor(std::forward<Value>(value));
-  };
-  return std::visit(visitor_coerced, std::forward<Variant>(variant));
-}
-#endif
 
 }  // namespace

--- a/common/schema/rotation.cc
+++ b/common/schema/rotation.cc
@@ -19,7 +19,7 @@ Rotation::Rotation(const math::RollPitchYaw<double>& arg) {
 }
 
 bool Rotation::IsDeterministic() const {
-  return visit_overloaded<bool>(overloaded{
+  return std::visit<bool>(overloaded{
     [](const Identity&) {
       return true;
     },
@@ -65,7 +65,7 @@ Vector<Expression, Size> deg2rad(
 
 math::RotationMatrix<Expression> Rotation::ToSymbolic() const {
   using Result = math::RotationMatrix<Expression>;
-  return visit_overloaded<Result>(overloaded{
+  return std::visit<Result>(overloaded{
     [](const Identity&) {
       return Result{};
     },

--- a/common/schema/stochastic.cc
+++ b/common/schema/stochastic.cc
@@ -183,7 +183,7 @@ drake::VectorX<Expression> ToSymbolic(
 }
 
 bool IsDeterministic(const DistributionVariant& var) {
-  return visit_overloaded<bool>(overloaded{
+  return std::visit<bool>(overloaded{
     [](const double&) {
       return true;
     },
@@ -350,7 +350,7 @@ drake::VectorX<Expression> UniformVector<Size>::ToSymbolic() const {
 template <int Size>
 unique_ptr<DistributionVector> ToDistributionVector(
     const DistributionVectorVariant<Size>& vec) {
-  return visit_overloaded<unique_ptr<DistributionVector>>(overloaded{
+  return std::visit<unique_ptr<DistributionVector>>(overloaded{
     // NOLINTNEXTLINE(whitespace/line_length)
     [](const drake::Vector<double, Size>& arg) {
       return std::make_unique<DeterministicVector<Size>>(arg);
@@ -387,7 +387,7 @@ unique_ptr<DistributionVector> ToDistributionVector(
 
 template <int Size>
 bool IsDeterministic(const DistributionVectorVariant<Size>& vec) {
-  return visit_overloaded<bool>(overloaded{
+  return std::visit<bool>(overloaded{
     [](const drake::Vector<double, Size>&) {
       return true;
     },

--- a/common/test/overloaded_test.cc
+++ b/common/test/overloaded_test.cc
@@ -11,7 +11,7 @@ GTEST_TEST(OverloadedTest, CommentExampleTest) {
   // Test the exact text of the example in the file comment.
   using MyVariant = std::variant<int, std::string>;
   MyVariant v = 5;
-  std::string result = visit_overloaded<const char*>(overloaded{
+  std::string result = std::visit<const char*>(overloaded{
     [](const int arg) { return "found an int"; },
     [](const std::string& arg) { return "found a string"; }
   }, v);
@@ -24,7 +24,7 @@ GTEST_TEST(OverloadedTest, AutoTest) {
 
   // An 'auto' arm doesn't match if there's any explicit match,
   // no matter if it's earlier or later in the list.
-  std::string result = visit_overloaded<const char*>(overloaded{
+  std::string result = std::visit<const char*>(overloaded{
     [](const auto arg) { return "found an auto"; },
     [](const int arg) { return "found an int"; },
     [](const std::string& arg) { return "found a string"; },
@@ -33,7 +33,7 @@ GTEST_TEST(OverloadedTest, AutoTest) {
   EXPECT_EQ(result, "found an int");
 
   // An 'auto' arm matches if there's no explicit match.
-  result = visit_overloaded<const char*>(overloaded{
+  result = std::visit<const char*>(overloaded{
     [](const auto arg) { return "found an auto"; },
     [](const std::string& arg) { return "found a string"; },
   }, v);

--- a/common/value.h
+++ b/common/value.h
@@ -401,10 +401,6 @@ constexpr bool hash_template_argument_from_pretty_func(
   return true;
 }
 
-// Akin to C++17 std::void_t<>.
-template <typename...>
-using typehasher_void_t = void;
-
 // Traits type to ask whether T::NonTypeTemplateParameter exists.
 template <typename T, typename U = void>
 struct TypeHasherHasNonTypeTemplateParameter {
@@ -412,7 +408,7 @@ struct TypeHasherHasNonTypeTemplateParameter {
 };
 template <typename T>
 struct TypeHasherHasNonTypeTemplateParameter<
-    T, typehasher_void_t<typename T::NonTypeTemplateParameter>> {
+    T, std::void_t<typename T::NonTypeTemplateParameter>> {
   static constexpr bool value = true;
 };
 

--- a/common/yaml/yaml_node.cc
+++ b/common/yaml/yaml_node.cc
@@ -55,7 +55,7 @@ Node Node::MakeNull() {
 }
 
 NodeType Node::GetType() const {
-  return visit_overloaded<NodeType>(  // BR
+  return std::visit<NodeType>(  // BR
       overloaded{
           [](const ScalarData&) {
             return NodeType::kScalar;
@@ -130,7 +130,7 @@ bool operator==(const Node::MappingData& a, const Node::MappingData& b) {
 }
 
 std::string_view Node::GetTag() const {
-  return visit_overloaded<std::string_view>(  // BR
+  return std::visit<std::string_view>(  // BR
       overloaded{
           [](const std::string& tag) {
             return std::string_view{tag};
@@ -155,7 +155,7 @@ std::string_view Node::GetTag() const {
 }
 
 bool Node::IsTagImportant() const {
-  return visit_overloaded<bool>(  // BR
+  return std::visit<bool>(  // BR
       overloaded{
           [](const std::string&) {
             return false;
@@ -196,7 +196,7 @@ const std::optional<Node::Mark>& Node::GetMark() const {
 }
 
 const std::string& Node::GetScalar() const {
-  return *visit_overloaded<const std::string*>(
+  return *std::visit<const std::string*>(
       overloaded{
           [](const ScalarData& data) {
             return &data.scalar;
@@ -210,7 +210,7 @@ const std::string& Node::GetScalar() const {
 }
 
 const std::vector<Node>& Node::GetSequence() const {
-  return *visit_overloaded<const std::vector<Node>*>(
+  return *std::visit<const std::vector<Node>*>(
       overloaded{
           [](const SequenceData& data) {
             return &data.sequence;
@@ -224,7 +224,7 @@ const std::vector<Node>& Node::GetSequence() const {
 }
 
 void Node::Add(Node value) {
-  return visit_overloaded<void>(
+  return std::visit<void>(
       overloaded{
           [&value](SequenceData& data) {
             data.sequence.push_back(std::move(value));
@@ -238,7 +238,7 @@ void Node::Add(Node value) {
 }
 
 const string_map<Node>& Node::GetMapping() const {
-  return *visit_overloaded<const string_map<Node>*>(
+  return *visit<const string_map<Node>*>(
       overloaded{
           [](const MappingData& data) {
             return &data.mapping;
@@ -252,7 +252,7 @@ const string_map<Node>& Node::GetMapping() const {
 }
 
 void Node::Add(std::string key, Node value) {
-  return visit_overloaded<void>(
+  return std::visit<void>(
       overloaded{
           [&key, &value](MappingData& data) {
             const auto result =
@@ -278,7 +278,7 @@ void Node::Add(std::string key, Node value) {
 }
 
 Node& Node::At(std::string_view key) {
-  return *visit_overloaded<Node*>(
+  return *std::visit<Node*>(
       overloaded{
           [key](MappingData& data) {
             return &data.mapping.at(std::string{key});
@@ -292,7 +292,7 @@ Node& Node::At(std::string_view key) {
 }
 
 void Node::Remove(std::string_view key) {
-  return visit_overloaded<void>(
+  return std::visit<void>(
       overloaded{
           [key](MappingData& data) {
             auto erased = data.mapping.erase(std::string{key});

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -53,14 +53,6 @@ using internal::FileStorage;
 using math::RigidTransformd;
 using math::RotationMatrixd;
 
-// TODO(jwnimmer-tri) Use the C++ built-in ends_with when we drop C++17.
-bool EndsWith(std::string_view str, std::string_view suffix) {
-  if (str.size() < suffix.size()) {
-    return false;
-  }
-  return str.substr(str.size() - suffix.size()) == suffix;
-}
-
 template <typename Mapping>
 [[noreturn]] void ThrowThingNotFound(std::string_view thing,
                                      std::string_view name, Mapping thing_map) {
@@ -426,7 +418,7 @@ class MeshcatShapeReifier : public ShapeReifier {
     }
 
     // Set the scale.
-    visit_overloaded<void>(
+    std::visit<void>(
         overloaded{[](std::monostate) {},
                    [scale](auto& lumped_object) {
                      Eigen::Map<Eigen::Matrix4d> matrix(lumped_object.matrix);
@@ -2078,7 +2070,7 @@ class Meshcat::Impl {
             internal::GetMeshcatStaticResource(url_path)) {
       if (content->substr(0, 15) == "<!DOCTYPE html>") {
         response->writeHeader("Content-Type", "text/html; charset=utf-8");
-      } else if (EndsWith(url_path, ".js")) {
+      } else if (url_path.ends_with(".js")) {
         response->writeHeader("Content-Type", "text/javascript; charset=utf-8");
       }
       response->end(*content);

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -204,7 +204,7 @@ void MeshcatVisualizer<T>::SetObjects(
       if constexpr (std::is_same_v<T, double>) {
         if (params_.show_hydroelastic) {
           auto maybe_mesh = inspector.maybe_get_hydroelastic_mesh(geom_id);
-          visit_overloaded<void>(
+          std::visit<void>(
               overloaded{[](std::monostate) {},
                          [&](const TriangleSurfaceMesh<double>* mesh) {
                            DRAKE_DEMAND(mesh != nullptr);

--- a/geometry/render_gl/test/multithread_safety_test.cc
+++ b/geometry/render_gl/test/multithread_safety_test.cc
@@ -163,7 +163,7 @@ void AddShape(const Shape& shape, const Vector3d& p_WS,
               std::variant<Rgba, std::string> diffuse, RenderEngine* engine) {
   PerceptionProperties material;
   material.AddProperty("label", "id", render::RenderLabel::kDontCare);
-  visit_overloaded<void>(  // BR
+  std::visit<void>(  // BR
       overloaded{[&material](const Rgba& rgba) {
                    material.AddProperty("phong", "diffuse", rgba);
                  },

--- a/geometry/test/meshcat_websocket_client.py
+++ b/geometry/test/meshcat_websocket_client.py
@@ -49,7 +49,7 @@ asyncio.sleep = _patch_asyncio(_asyncio_sleep)
 #
 # TODO(mwoehlke-kitware): Remove this when Jammy's python3-u-msgpack has been
 # updated to 2.5.2 or later.
-if sys.version_info[:2] >= (3, 10) and not hasattr(umsgpack, 'Hashable'):
+if not hasattr(umsgpack, 'Hashable'):
     import collections
     setattr(umsgpack.collections, 'Hashable', collections.abc.Hashable)
 

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -107,7 +107,7 @@ std::map<int, std::string> GetPositionNames(
 VectorXd Broadcast(
     const char* diagnostic_name, double default_value, int num_positions,
     std::variant<std::monostate, double, VectorXd> value) {
-  return visit_overloaded<VectorXd>(overloaded{
+  return std::visit<VectorXd>(overloaded{
     [num_positions, default_value](std::monostate) {
       return VectorXd::Constant(num_positions, default_value);
     },

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1117,17 +1117,11 @@ void MultibodyPlant<T>::RenameModelInstance(ModelInstanceIndex model_instance,
     // alone.
     auto& inspector = scene_graph_->model_inspector();
 
-    // TODO(rpoyner-tri): replace with c++ built-in starts_with once we drop
-    // C++17 support.
-    auto starts_with = [](const std::string& str, const std::string& prefix) {
-      return str.compare(0, prefix.size(), prefix) == 0;
-    };
-
     const std::string old_prefix(old_name + "::");
     const std::string new_prefix(name + "::");
     auto maybe_make_new_name = [&](auto id) {
       std::string existing_name(inspector.GetName(id));
-      if (starts_with(existing_name, old_prefix)) {
+      if (existing_name.starts_with(old_prefix)) {
         // Replace old prefix with new prefix.
         return new_prefix + existing_name.substr(old_prefix.size());
       }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -571,7 +571,7 @@ Assign to auto, and use the named public fields:
   items.plant.DoFoo(...);
   items.scene_graph.DoBar(...);
 @endcode
-or taking advantage of C++17's structured binding
+or taking advantage of C++'s structured binding:
 @code
   auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
   ...
@@ -5925,7 +5925,7 @@ struct AddMultibodyPlantSceneGraphResult final {
   // Returns the N-th member referenced by this struct.
   // If N = 0, returns the reference to the MultibodyPlant.
   // If N = 1, returns the reference to the geometry::SceneGraph.
-  // Provided to support C++17's structured binding.
+  // Provided to support C++'s structured binding.
   template <std::size_t N>
   decltype(auto) get() const {
     if constexpr (N == 0)
@@ -6010,7 +6010,7 @@ void MultibodyPlant<symbolic::Expression>::CalcHydroelasticWithFallback(
 }  // namespace drake
 
 #ifndef DRAKE_DOXYGEN_CXX
-// Specializations provided to support C++17's structured binding for
+// Specializations provided to support C++'s structured binding for
 // AddMultibodyPlantSceneGraphResult.
 namespace std {
 // The GCC standard library defines tuple_size as class and struct which

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -418,7 +418,7 @@ GTEST_TEST(MultibodyPlantTest, AddMultibodyPlantSceneGraph) {
   MultibodyPlant<double>& plant_ref = pair;
   EXPECT_EQ(&plant_ref, plant);
 
-  // Check support for C++17's structured binding.
+  // Check support for C++ structured binding.
   auto [first_element, second_element] =
       AddMultibodyPlantSceneGraph(&builder, 0.0);
   // Verify the expected types.

--- a/multibody/tree/element_collection.cc
+++ b/multibody/tree/element_collection.cc
@@ -117,8 +117,6 @@ void ElementCollection<T, Element, Index>::Rename(Index index,
     names_map_.emplace(name, index);
     get_mutable_element(index).set_name(std::move(name));
   } else {
-    // Once we drop Ubuntu Focal (GCC 9), we can remove the annoying `unused()`.
-    unused(index, name);
     DRAKE_UNREACHABLE();
   }
 }

--- a/multibody/tree/scoped_name.cc
+++ b/multibody/tree/scoped_name.cc
@@ -32,22 +32,9 @@ ScopedName::ScopedName(std::string_view namespace_name,
   *this = std::move(*result);
 }
 
-namespace {
-// TODO(jwnimmer-tri) Use the C++ built-in starts_with when we drop C++17.
-bool StartsWith(std::string_view str, std::string_view prefix) {
-  return str.substr(0, prefix.size()) == prefix;
-}
-bool EndsWith(std::string_view str, std::string_view suffix) {
-  if (str.size() < suffix.size()) {
-    return false;
-  }
-  return str.substr(str.size() - suffix.size()) == suffix;
-}
-}  // namespace
-
 std::optional<ScopedName> ScopedName::Make(std::string_view namespace_name,
                                            std::string_view element_name) {
-  if (StartsWith(namespace_name, kDelim) || EndsWith(namespace_name, kDelim) ||
+  if (namespace_name.starts_with(kDelim) || namespace_name.ends_with(kDelim) ||
       element_name.empty() || HasScopeDelimiter(element_name)) {
     return std::nullopt;
   }
@@ -68,10 +55,10 @@ ScopedName ScopedName::Join(std::string_view name1, std::string_view name2) {
 
 ScopedName ScopedName::Parse(std::string scoped_name) {
   // Remove any leading or trailing "::".
-  while (EndsWith(scoped_name, kDelim)) {
+  while (scoped_name.ends_with(kDelim)) {
     scoped_name.resize(scoped_name.size() - kDelim.size());
   }
-  while (StartsWith(scoped_name, kDelim)) {
+  while (scoped_name.starts_with(kDelim)) {
     scoped_name = scoped_name.substr(kDelim.size());
   }
 

--- a/systems/analysis/radau_integrator.cc
+++ b/systems/analysis/radau_integrator.cc
@@ -23,9 +23,7 @@ RadauIntegrator<T, num_stages>::RadauIntegrator(const System<T>& system,
     Context<T>* context) : ImplicitIntegrator<T>(system, context) {
   A_.resize(num_stages, num_stages);
 
-  // TODO(edrumwri) Convert A_, c_, b_, and d_ to fixed-size when Drake supports
-  // "if constexpr" (C++17 feature). Lack of partial template function
-  // specialization makes turning those into fixed-sizes painful at the moment.
+  // TODO(edrumwri) Convert A_, c_, b_, and d_ to fixed-size via "if constexpr".
 
   if (num_stages == 2) {
     // Set the matrix coefficients (from [Hairer, 1996] Table 5.5).

--- a/systems/sensors/camera_config_functions.cc
+++ b/systems/sensors/camera_config_functions.cc
@@ -127,7 +127,7 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
   bool already_exists = !type_name.empty();
 
   if (already_exists) {
-    visit_overloaded<void>(
+    std::visit<void>(
         overloaded{
             [&type_name, &config](const std::string& class_name) {
               if (!class_name.empty() &&
@@ -152,7 +152,7 @@ void ValidateEngineAndMaybeAdd(const CameraConfig& config,
 
   if (already_exists) return;
 
-  visit_overloaded<void>(
+  std::visit<void>(
       overloaded{
           [&config, scene_graph](const std::string& class_name) {
             MakeEngineByClassName(class_name, config, scene_graph);

--- a/tools/performance/fixture_memory_yes.cc
+++ b/tools/performance/fixture_memory_yes.cc
@@ -10,12 +10,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/never_destroyed.h"
 
-// TODO(jwnimmer-tri) We can drop this compat macro once we drop support for
-// Ubuntu 20.04 Focal.
-#if (__GLIBC__ == 2) && (__GLIBC_MINOR__ < 33)
-#define mallinfo2 mallinfo
-#endif
-
 namespace {
 
 using benchmark::MemoryManager;

--- a/tools/workspace/pybind11/mkdoc.py
+++ b/tools/workspace/pybind11/mkdoc.py
@@ -737,7 +737,7 @@ def main():
     os.mkdir(tmpdir)
     glue_filename = os.path.join(tmpdir, "mkdoc_glue.h")
     with open(glue_filename, 'w') as glue_f:
-        # As the first line of the glue file, include a C++17 standard library
+        # As the first line of the glue file, include a C++ standard library
         # file to sanity check that it's working, before we start processing
         # the user headers.
         glue_f.write("#include <optional>\n")


### PR DESCRIPTION
This reverts commit 6b32a81c.

No release notes.  We'll use #20952 to announce this change, overall.

See also #20970 for one more C++20-related cleanup.

Requires:
- [x] #20954
- [x] #20961

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20965)
<!-- Reviewable:end -->
