### PR TITLE
[py visualization] Avoid runpy warning due to import order

### DIFF
--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -63,3 +63,7 @@ from .visualization import *
 from .math import *
 # - Ensure symbolic.Polynomial wins (#18353).
 from .symbolic import Polynomial
+
+# Ensure that the command-line modules appear in the pydrake API reference.
+import pydrake.visualization.meldis
+import pydrake.visualization.model_visualizer

--- a/bindings/pydrake/visualization/visualization_py.cc
+++ b/bindings/pydrake/visualization/visualization_py.cc
@@ -19,8 +19,8 @@ Bindings for Visualization.
   internal::DefineVisualizationImageSystems(m);
   internal::DefineVisualizationSliders(m);
 
-  py::module::import("pydrake.visualization.meldis");
-  py::module::import("pydrake.visualization.model_visualizer");
+  py::module::import("pydrake.visualization._meldis");
+  py::module::import("pydrake.visualization._model_visualizer");
   ExecuteExtraPythonCode(m, true);
 }
 


### PR DESCRIPTION
When downstream code invokes meldis (or similar) using runpy, they would see this warning: `RuntimeWarning: 'pydrake.visualization.meldis' found in sys.modules after import of package 'pydrake.visualization', but prior to execution of 'pydrake.visualization.meldis'; this may result in unpredictable behaviour`.

We can avoid that by importing the command-line modules during all.py instead of during their parent module's import.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20968)
<!-- Reviewable:end -->
