### PR TITLE
Fixup InverseDynamics to use the actuation matrix.

### DIFF
--- a/systems/controllers/test_utilities/compute_torque.h
+++ b/systems/controllers/test_utilities/compute_torque.h
@@ -23,7 +23,8 @@ VectorX<double> ComputeTorque(
   // Compute inverse dynamics.
   multibody::MultibodyForces<double> external_forces(plant);
   plant.CalcForceElementsContribution(*context, &external_forces);
-  return plant.CalcInverseDynamics(*context, vd_d, external_forces);
+  Eigen::MatrixXd B_inv = plant.MakeActuationMatrix().inverse();
+  return B_inv * plant.CalcInverseDynamics(*context, vd_d, external_forces);
 }
 
 }  // namespace controllers_test


### PR DESCRIPTION
Clarifies that the output of the inverse dynamics controller is actuation input, not generalized forces, and uses the actuation matrix to achieve this. Previously, by connecting the output of the InverseDynamics system to an actuation input port, we implicitly assumed that the actuator matrix was the identity matrix. If the actuators were in a different order than the joints (generalized forces), then our method produced the wrong actuator inputs.

cc @Michaelszeng

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20971)
<!-- Reviewable:end -->
