### PR TITLE
Support relative frames in DifferentialInverseKinematicsIntegrator

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -202,6 +202,17 @@ void DefineIkDifferential(py::module m) {
     py::class_<Class, LeafSystem<double>>(
         m, "DifferentialInverseKinematicsIntegrator", cls_doc.doc)
         .def(py::init<const multibody::MultibodyPlant<double>&,
+                 const multibody::Frame<double>&,
+                 const multibody::Frame<double>&, double,
+                 const DifferentialInverseKinematicsParameters&,
+                 const systems::Context<double>*, bool>(),
+            // Keep alive, reference: `self` keeps `robot` alive.
+            py::keep_alive<1, 2>(), py::arg("robot"), py::arg("frame_A"),
+            py::arg("frame_E"), py::arg("time_step"), py::arg("parameters"),
+            py::arg("robot_context") = nullptr,
+            py::arg("log_only_when_result_state_changes") = true,
+            cls_doc.ctor.doc_7args)
+        .def(py::init<const multibody::MultibodyPlant<double>&,
                  const multibody::Frame<double>&, double,
                  const DifferentialInverseKinematicsParameters&,
                  const systems::Context<double>*, bool>(),
@@ -210,7 +221,7 @@ void DefineIkDifferential(py::module m) {
             py::arg("time_step"), py::arg("parameters"),
             py::arg("robot_context") = nullptr,
             py::arg("log_only_when_result_state_changes") = true,
-            cls_doc.ctor.doc)
+            cls_doc.ctor.doc_6args)
         .def("SetPositions", &Class::SetPositions, py::arg("context"),
             py::arg("positions"), cls_doc.SetPositions.doc)
         .def("ForwardKinematics", &Class::ForwardKinematics, py::arg("context"),

--- a/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
@@ -139,18 +139,34 @@ class TestPlanner(unittest.TestCase):
         Parser(plant).AddModels(file_name)
         plant.Finalize()
 
-        context = plant.CreateDefaultContext()
+        robot_context = plant.CreateDefaultContext()
         frame = plant.GetFrameByName("Link2")
         time_step = 0.1
         parameters = mut.DifferentialInverseKinematicsParameters(2, 2)
 
         integrator = mut.DifferentialInverseKinematicsIntegrator(
             robot=plant,
+            frame_A=plant.world_frame(),
             frame_E=frame,
             time_step=time_step,
             parameters=parameters,
-            robot_context=context,
+            robot_context=robot_context,
             log_only_when_result_state_changes=True)
+
+        context = integrator.CreateDefaultContext()
+        X_AE = integrator.ForwardKinematics(context=context)
 
         integrator.get_mutable_parameters().set_time_step(0.2)
         self.assertEqual(integrator.get_parameters().get_time_step(), 0.2)
+
+        integrator2 = mut.DifferentialInverseKinematicsIntegrator(
+            robot=plant,
+            frame_E=frame,
+            time_step=time_step,
+            parameters=parameters,
+            robot_context=robot_context,
+            log_only_when_result_state_changes=True)
+
+        context2 = integrator2.CreateDefaultContext()
+        X_WE = integrator2.ForwardKinematics(context2)
+        self.assertTrue(X_AE.IsExactlyEqualTo(X_WE))

--- a/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h
@@ -55,6 +55,7 @@ class DifferentialInverseKinematicsIntegrator
   /** Constructs the system.
 
   @param robot A MultibodyPlant describing the robot.
+  @param frame_A Reference frame (inertial or non-inertial).
   @param frame_E End-effector frame.
   @param time_step the discrete time step of the (Euler) integration.
   @param parameters Collection of various problem specific constraints and
@@ -71,6 +72,40 @@ class DifferentialInverseKinematicsIntegrator
   IsDifferenceEquationSystem() to return `true`.
 
   Note: All references must remain valid for the lifetime of this system.
+  @pre frame_E != frame_A.
+  */
+  DifferentialInverseKinematicsIntegrator(
+      const MultibodyPlant<double>& robot,
+      const Frame<double>& frame_A,
+      const Frame<double>& frame_E,
+      double time_step,
+      // Note: parameters last so they could be optional in the future.
+      const DifferentialInverseKinematicsParameters& parameters,
+      const systems::Context<double>* robot_context = nullptr,
+      bool log_only_when_result_state_changes = true);
+
+  /** Constructs the system.
+
+  @param robot A MultibodyPlant describing the robot.
+  @param frame_E End-effector frame.
+  @param time_step the discrete time step of the (Euler) integration.
+  @param parameters Collection of various problem specific constraints and
+  constants.  The `time_step` parameter will be set to @p time_step.
+  @param robot_context Optional Context of the MultibodyPlant.  The position
+  values of this context will be overwritten during integration; you only need
+  to pass this in if the robot has any non-default parameters.  @default
+  `robot.CreateDefaultContext()`.
+  @param log_only_when_result_state_changes is a boolean that determines whether
+  the system will log on every differential IK failure, or only when the failure
+  state changes.  When the value is `true`, it will cause the system to have an
+  additional discrete state variable to store the most recent
+  DifferentialInverseKinematicsStatus.  Set this to `false` if you want
+  IsDifferenceEquationSystem() to return `true`.
+
+  In this overload, the reference frame, A, is taken to be the world frame.
+
+  Note: All references must remain valid for the lifetime of this system.
+  @pre frame_E != robot.world_frame().
   */
   DifferentialInverseKinematicsIntegrator(
       const MultibodyPlant<double>& robot,
@@ -86,7 +121,7 @@ class DifferentialInverseKinematicsIntegrator
   void SetPositions(systems::Context<double>* context,
                     const Eigen::Ref<const Eigen::VectorXd>& positions) const;
 
-  /** Provides X_WE as a function of the joint position set in `context`. */
+  /** Provides X_AE as a function of the joint position set in `context`. */
   math::RigidTransformd ForwardKinematics(
       const systems::Context<double>& context) const;
 
@@ -120,10 +155,12 @@ class DifferentialInverseKinematicsIntegrator
       systems::DiscreteValues<double>* values) const;
 
   const MultibodyPlant<double>& robot_;
+  const Frame<double>& frame_A_;
   const Frame<double>& frame_E_;
   DifferentialInverseKinematicsParameters parameters_;
   const double time_step_{0.0};
   const systems::CacheEntry* robot_context_cache_entry_{};
+  systems::InputPortIndex X_AE_desired_index_{};
   systems::InputPortIndex X_WE_desired_index_{};
   systems::InputPortIndex robot_state_index_{};
   systems::InputPortIndex use_robot_state_index_{};


### PR DESCRIPTION
Adds support for passing a relative frame A into the constructor. Deprecates the X_WE_desired input port in favor of the more general X_AE_desired input port.

Resolves #19580.

+@iantheengineer for feature review, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20973)
<!-- Reviewable:end -->
