### PR TITLE
Add getters to underlying edges

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -354,6 +354,11 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
                 geometry::optimization::GraphOfConvexSets::Vertex*>&>(
                 &Class::Subgraph::Vertices),
             py_rvp::reference_internal, subgraph_doc.Vertices.doc)
+        .def("Edges",
+            overload_cast_explicit<const std::vector<
+                geometry::optimization::GraphOfConvexSets::Edge*>&>(
+                &Class::Subgraph::Edges),
+            py_rvp::reference_internal, subgraph_doc.Edges.doc)
         .def(
             "regions",
             [](Class::Subgraph* self) {
@@ -390,6 +395,11 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         doc.GcsTrajectoryOptimization.EdgesBetweenSubgraphs;
     py::class_<Class::EdgesBetweenSubgraphs>(
         gcs_traj_opt, "EdgesBetweenSubgraphs", subgraph_edges_doc.doc)
+        .def("Edges",
+            overload_cast_explicit<const std::vector<
+                geometry::optimization::GraphOfConvexSets::Edge*>&>(
+                &Class::EdgesBetweenSubgraphs::Edges),
+            py_rvp::reference_internal, subgraph_edges_doc.Edges.doc)
         .def("AddVelocityBounds",
             &Class::EdgesBetweenSubgraphs::AddVelocityBounds, py::arg("lb"),
             py::arg("ub"), subgraph_edges_doc.AddVelocityBounds.doc)

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -441,6 +441,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertIsInstance(main2.regions()[0], HPolyhedron)
         self.assertIsInstance(main2.Vertices(), list)
         self.assertIsInstance(main2.Vertices()[0], GraphOfConvexSets.Vertex)
+        self.assertIsInstance(main2.Edges(), list)
+        self.assertIsInstance(main2.Edges()[0], GraphOfConvexSets.Edge)
 
         # Add two start and goal regions.
         start1 = np.array([0.2, 0.2])
@@ -485,12 +487,18 @@ class TestTrajectoryOptimization(unittest.TestCase):
         main1_to_main2_pt = gcs.AddEdges(main1, main2, subspace=subspace_point)
         self.assertIsInstance(main1_to_main2_pt,
                               GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+        self.assertIsInstance(main1_to_main2_pt.Edges(), list)
+        self.assertIsInstance(main1_to_main2_pt.Edges()[0],
+                              GraphOfConvexSets.Edge)
 
         main1_to_main2_region = gcs.AddEdges(main1,
                                              main2,
                                              subspace=subspace_region)
         self.assertIsInstance(main1_to_main2_region,
                               GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+        self.assertIsInstance(main1_to_main2_region.Edges(), list)
+        self.assertIsInstance(main1_to_main2_region.Edges()[0],
+                              GraphOfConvexSets.Edge)
 
         # Add half of the maximum velocity constraint at the subspace point
         # and region.

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -93,6 +93,15 @@ class GcsTrajectoryOptimization final {
       return vertices_;
     }
 
+    /** Returns constant reference to a vector of mutable pointers to the
+    edges stored in the subgraph.
+    For advanced use only. Callers must not update `u` or `v` of any returned
+    Edge.*/
+    const std::vector<geometry::optimization::GraphOfConvexSets::Edge*>&
+    Edges() {
+      return edges_;
+    }
+
     /** Returns pointers to the vertices stored in the subgraph.
     The order of the vertices is the same as the order the regions were added.
     @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.} */
@@ -260,6 +269,13 @@ class GcsTrajectoryOptimization final {
     continuity is enforced by default.
     */
     void AddPathContinuityConstraints(int continuity_order);
+
+    /** Returns constant reference to a vector of mutable pointers to the
+    edges between the subgraphs.*/
+    const std::vector<geometry::optimization::GraphOfConvexSets::Edge*>&
+    Edges() {
+      return edges_;
+    }
 
    private:
     EdgesBetweenSubgraphs(const Subgraph& from_subgraph,

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -456,6 +456,39 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, VelocityBoundsOnEdges) {
                       Vector2d(0, 0), 1e-6));
 }
 
+GTEST_TEST(GcsTrajectoryOptimizationTest, GetEdges) {
+  const int kDimension = 2;
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  auto& graph1 =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension),
+                                    HPolyhedron::MakeUnitBox(kDimension)),
+                     1);
+  auto& graph2 =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension),
+                                    HPolyhedron::MakeUnitBox(kDimension)),
+                     1);
+  auto& graph1_to_graph2 = gcs.AddEdges(graph1, graph2);
+
+  // The edges in the subgraphs 1 and 2 and the edges between the subgraphs
+  // should be registered in the underlying graph of convex sets.
+  const auto all_edges = gcs.graph_of_convex_sets().Edges();
+
+  for (const auto& edge : graph1.Edges()) {
+    EXPECT_TRUE(std::find(all_edges.begin(), all_edges.end(), edge) !=
+                all_edges.end());
+  }
+  for (const auto& edge : graph2.Edges()) {
+    EXPECT_TRUE(std::find(all_edges.begin(), all_edges.end(), edge) !=
+                all_edges.end());
+  }
+  for (const auto& edge : graph1_to_graph2.Edges()) {
+    EXPECT_TRUE(std::find(all_edges.begin(), all_edges.end(), edge) !=
+                all_edges.end());
+  }
+}
+
 GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidPositions) {
   /* Positions passed into GcsTrajectoryOptimization must be greater than 0.*/
   DRAKE_EXPECT_THROWS_MESSAGE(GcsTrajectoryOptimization(0),


### PR DESCRIPTION
This exposes the edges associated to a specific `Subgraph` and `EdgesBetweenSubgraphs` objects, as discussed in #20186.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20980)
<!-- Reviewable:end -->
