### PR TITLE
Work around test error in coverage builds (kcov 339)

### DIFF
--- a/systems/sensors/test/sim_rgbd_sensor_test.cc
+++ b/systems/sensors/test/sim_rgbd_sensor_test.cc
@@ -20,6 +20,7 @@ namespace drake {
 namespace systems {
 namespace sensors {
 namespace internal {
+namespace kcov339_avoidance_magic {
 namespace {
 
 // We need drake:: because there's also a systems::lcm namespace.
@@ -312,6 +313,7 @@ TEST_F(SimRgbdSensorTest, AddPublisherTestProperties) {
 }
 
 }  // namespace
+}  // namespace kcov339_avoidance_magic
 }  // namespace internal
 }  // namespace sensors
 }  // namespace systems


### PR DESCRIPTION
Add a dummy namespace to perturb the elf header.

Fixes CI failure: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-jammy-clang-bazel-nightly-coverage/138/

Follows pattern from: https://github.com/RobotLocomotion/drake/issues/17978

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/20997)
<!-- Reviewable:end -->
