### PR TITLE
Add support for LorentzConeConstraint and RotatedLorentzConeConstraint in GraphOfConvexSets edges and vertices

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -752,7 +752,8 @@ void GraphOfConvexSets::AddPerspectiveConstraint(
     }
   } else if (RotatedLorentzConeConstraint* rc =
                  dynamic_cast<RotatedLorentzConeConstraint*>(constraint)) {
-    // z = Ax + b => z = Ax + b phi = [b A] [phi; x]
+    // z ∈ K for z = Ax + b becomes
+    // z ∈ K for z = Ax + bϕ = [b A] [ϕ; x]
     MatrixXd A_cone = MatrixXd::Zero(rc->A().rows(), vars.size());
     A_cone.block(0, 0, rc->A().rows(), 1) = rc->b();
     A_cone.block(0, 1, rc->A().rows(), rc->A().cols()) = rc->A_dense();

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -44,6 +44,7 @@ using solvers::LinearConstraint;
 using solvers::LinearCost;
 using solvers::LinearEqualityConstraint;
 using solvers::LInfNormCost;
+using solvers::LorentzConeConstraint;
 using solvers::MathematicalProgram;
 using solvers::MathematicalProgramResult;
 using solvers::MatrixXDecisionVariable;
@@ -750,14 +751,14 @@ void GraphOfConvexSets::AddPerspectiveConstraint(
         }
       }
     }
-  } else if (LorentzConeConstraint* rc =
+  } else if (LorentzConeConstraint* lcc =
                  dynamic_cast<LorentzConeConstraint*>(constraint)) {
     // z ∈ K for z = Ax + b becomes
     // z ∈ K for z = Ax + bϕ = [b A] [ϕ; x]
-    MatrixXd A_cone = MatrixXd::Zero(rc->A().rows(), vars.size());
-    A_cone.block(0, 0, rc->A().rows(), 1) = rc->b();
-    A_cone.block(0, 1, rc->A().rows(), rc->A().cols()) = rc->A_dense();
-    prog->AddLorentzConeConstraint(A_cone, VectorXd::Zero(rc->A().rows()),
+    MatrixXd A_cone = MatrixXd::Zero(lcc->A().rows(), vars.size());
+    A_cone.block(0, 0, lcc->A().rows(), 1) = lcc->b();
+    A_cone.block(0, 1, lcc->A().rows(), lcc->A().cols()) = lcc->A_dense();
+    prog->AddLorentzConeConstraint(A_cone, VectorXd::Zero(lcc->A().rows()),
                                    vars);
   } else if (RotatedLorentzConeConstraint* rc =
                  dynamic_cast<RotatedLorentzConeConstraint*>(constraint)) {

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -750,6 +750,14 @@ void GraphOfConvexSets::AddPerspectiveConstraint(
         }
       }
     }
+  } else if (RotatedLorentzConeConstraint* rc =
+                 dynamic_cast<RotatedLorentzConeConstraint*>(constraint)) {
+    // z = Ax + b => z = Ax + b phi = [b A] [phi; x]
+    MatrixXd A_cone = MatrixXd::Zero(rc->A().rows(), vars.size());
+    A_cone.block(0, 0, rc->A().rows(), 1) = rc->b();
+    A_cone.block(0, 1, rc->A().rows(), rc->A().cols()) = rc->A_dense();
+    prog->AddRotatedLorentzConeConstraint(A_cone,
+                                          VectorXd::Zero(rc->A().rows()), vars);
   } else {
     throw std::runtime_error(
         fmt::format("ShortestPathProblem::Edge does not support this "

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -750,6 +750,15 @@ void GraphOfConvexSets::AddPerspectiveConstraint(
         }
       }
     }
+  } else if (LorentzConeConstraint* rc =
+                 dynamic_cast<LorentzConeConstraint*>(constraint)) {
+    // z ∈ K for z = Ax + b becomes
+    // z ∈ K for z = Ax + bϕ = [b A] [ϕ; x]
+    MatrixXd A_cone = MatrixXd::Zero(rc->A().rows(), vars.size());
+    A_cone.block(0, 0, rc->A().rows(), 1) = rc->b();
+    A_cone.block(0, 1, rc->A().rows(), rc->A().cols()) = rc->A_dense();
+    prog->AddLorentzConeConstraint(A_cone, VectorXd::Zero(rc->A().rows()),
+                                   vars);
   } else if (RotatedLorentzConeConstraint* rc =
                  dynamic_cast<RotatedLorentzConeConstraint*>(constraint)) {
     // z ∈ K for z = Ax + b becomes

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -755,6 +755,8 @@ void GraphOfConvexSets::AddPerspectiveConstraint(
                  dynamic_cast<LorentzConeConstraint*>(constraint)) {
     // z ∈ K for z = Ax + b becomes
     // z ∈ K for z = Ax + bϕ = [b A] [ϕ; x]
+    // (Notice that this is the same as for a RotatedLorentzConeConstraint,
+    // as it does not depend on whether the cone is rotated or not).
     MatrixXd A_cone = MatrixXd::Zero(lcc->A().rows(), vars.size());
     A_cone.block(0, 0, lcc->A().rows(), 1) = lcc->b();
     A_cone.block(0, 1, lcc->A().rows(), lcc->A().cols()) = lcc->A_dense();
@@ -764,6 +766,8 @@ void GraphOfConvexSets::AddPerspectiveConstraint(
                  dynamic_cast<RotatedLorentzConeConstraint*>(constraint)) {
     // z ∈ K for z = Ax + b becomes
     // z ∈ K for z = Ax + bϕ = [b A] [ϕ; x]
+    // (Notice that this is the same as for a LorentzConeConstraint,
+    // as it does not depend on whether the cone is rotated or not).
     MatrixXd A_cone = MatrixXd::Zero(rc->A().rows(), vars.size());
     A_cone.block(0, 0, rc->A().rows(), 1) = rc->b();
     A_cone.block(0, 1, rc->A().rows(), rc->A().cols()) = rc->A_dense();

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1164,8 +1164,8 @@ TEST_F(ThreeBoxes, RotatedLorentzConeConstraint) {
   const float kTol = 1e-6;
   EXPECT_GE(res[0] * res[1] + kTol,
             std::pow(res[2], 2) + std::pow(res[3], 2) + 1.0);
-  EXPECT_TRUE(res[0] >= 0);
-  EXPECT_TRUE(res[1] >= 0);
+  EXPECT_GE(res[0], 0);
+  EXPECT_GE(res[1], 0);
 }
 
 TEST_F(ThreeBoxes, SolveConvexRestriction) {

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1142,7 +1142,7 @@ TEST_F(ThreeBoxes, LinearConstraint3) {
 }
 
 TEST_F(ThreeBoxes, LorentzConeConstraint) {
-  // x_u[0] >= x_u[1] ** 2 + x_v[0] ** 2 + x_v[1] ** 2 + 1
+  // x_u[0] >= sqrt(x_u[1] ** 2 + x_v[0] ** 2 + x_v[1] ** 2 + 1)
   Eigen::MatrixXd A(5, 4);
   A.topLeftCorner(4, 4) = Eigen::MatrixXd::Identity(4, 4);
   A.bottomLeftCorner(1, 4).setZero();

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1141,6 +1141,31 @@ TEST_F(ThreeBoxes, LinearConstraint3) {
   CheckConvexRestriction(result);
 }
 
+TEST_F(ThreeBoxes, LorentzConeConstraint) {
+  // x_u[0] >= x_u[1] ** 2 + x_v[0] ** 2 + x_v[1] ** 2 + 1
+  Eigen::MatrixXd A(5, 4);
+  A.topLeftCorner(4, 4) = Eigen::MatrixXd::Identity(4, 4);
+  A.bottomLeftCorner(1, 4).setZero();
+  Eigen::VectorXd b(5);
+  b << 0.0, 0.0, 0.0, 0.0, 1.0;
+
+  auto constraint = std::make_shared<solvers::LorentzConeConstraint>(A, b);
+  e_on_->AddConstraint(
+      solvers::Binding(constraint, {e_on_->xu(), e_on_->xv()}));
+  e_off_->AddConstraint(
+      solvers::Binding(constraint, {e_off_->xu(), e_off_->xv()}));
+
+  auto result = g_.SolveShortestPath(*source_, *target_, options_);
+  ASSERT_TRUE(result.is_success());
+
+  Eigen::VectorXd res(4);
+  res << source_->GetSolution(result), target_->GetSolution(result);
+  const float kTol = 1e-6;
+  EXPECT_GE(res[0] + kTol, std::pow(res[1], 2) + std::pow(res[2], 2) +
+                               std::pow(res[3], 2) + 1.0);
+  EXPECT_GE(res[0], 0);
+}
+
 TEST_F(ThreeBoxes, RotatedLorentzConeConstraint) {
   // x_u[0] * x_u[1] >= x_v[0] ** 2 + x_v[1] ** 2 + 1
   Eigen::MatrixXd A(5, 4);


### PR DESCRIPTION
Implements support for `RotatedLorentzConeConstriants` in GCS edges and vertices.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21001)
<!-- Reviewable:end -->
