### PR TITLE
Enable removal of subgraphs

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -438,6 +438,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py_rvp::reference_internal, py::arg("regions"), py::arg("order"),
             py::arg("h_min") = 1e-6, py::arg("h_max") = 20,
             py::arg("name") = "", cls_doc.AddRegions.doc_5args)
+        .def("RemoveSubgraph", &Class::RemoveSubgraph, py::arg("subgraph"),
+            cls_doc.RemoveSubgraph.doc)
         .def("AddEdges", &Class::AddEdges, py_rvp::reference_internal,
             py::arg("from_subgraph"), py::arg("to_subgraph"),
             py::arg("subspace") = py::none(), cls_doc.AddEdges.doc)
@@ -466,6 +468,10 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py::arg("options") =
                 geometry::optimization::GraphOfConvexSetsOptions(),
             cls_doc.SolveConvexRestriction.doc)
+        .def("GetSubgraphs", &Class::GetSubgraphs, py_rvp::reference_internal,
+            cls_doc.GetSubgraphs.doc)
+        .def("GetEdgesBetweenSubgraphs", &Class::GetEdgesBetweenSubgraphs,
+            py_rvp::reference_internal, cls_doc.GetEdgesBetweenSubgraphs.doc)
         .def("graph_of_convex_sets", &Class::graph_of_convex_sets,
             py_rvp::reference_internal, cls_doc.graph_of_convex_sets.doc)
         .def_static("NormalizeSegmentTimes", &Class::NormalizeSegmentTimes,

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -268,11 +268,17 @@ class TestTrajectoryOptimization(unittest.TestCase):
         start = [-0.5, -0.5]
         end = [0.5, 0.5]
         source = gcs.AddRegions(regions=[Point(start)], order=0)
+        self.assertIn(source, gcs.GetSubgraphs())
         target = gcs.AddRegions(regions=[Point(end)], order=0)
+        self.assertIn(target, gcs.GetSubgraphs())
         regions = gcs.AddRegions(regions=[HPolyhedron.MakeUnitBox(2)],
                                  order=1, h_min=1.0)
-        gcs.AddEdges(source, regions)
-        gcs.AddEdges(regions, target)
+
+        self.assertIn(regions, gcs.GetSubgraphs())
+        self.assertIn(gcs.AddEdges(source, regions),
+                      gcs.GetEdgesBetweenSubgraphs())
+        self.assertIn(gcs.AddEdges(regions, target),
+                      gcs.GetEdgesBetweenSubgraphs())
         traj, result = gcs.SolvePath(source, target)
         self.assertTrue(result.is_success())
         self.assertEqual(traj.rows(), 2)
@@ -319,6 +325,22 @@ class TestTrajectoryOptimization(unittest.TestCase):
             restricted_traj.end_time()).squeeze()
         np.testing.assert_allclose(restricted_traj_start, start, atol=1e-6)
         np.testing.assert_allclose(restricted_traj_end, end, atol=1e-6)
+
+        # Test that removing all subgraphs, removes all vertices and edges.
+        self.assertEqual(len(gcs.graph_of_convex_sets().Vertices()),
+                         len(source.Vertices())
+                         + len(regions.Vertices())
+                         + len(target.Vertices()))
+        self.assertEqual(len(gcs.GetSubgraphs()), 3)
+        self.assertEqual(len(gcs.GetEdgesBetweenSubgraphs()), 2)
+        gcs.RemoveSubgraph(source)
+        gcs.RemoveSubgraph(regions)
+        gcs.RemoveSubgraph(target)
+        # We expect the underlying gcs problem to be empty.
+        self.assertFalse(len(gcs.graph_of_convex_sets().Vertices()))
+        self.assertFalse(len(gcs.graph_of_convex_sets().Edges()))
+        self.assertFalse(len(gcs.GetSubgraphs()))
+        self.assertFalse(len(gcs.GetEdgesBetweenSubgraphs()), 0)
 
     def test_gcs_trajectory_optimization_2d(self):
         """The following 2D environment has been presented in the GCS paper.
@@ -418,6 +440,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertEqual(main1.size(), len(vertices))
         self.assertIsInstance(main1.regions(), list)
         self.assertIsInstance(main1.regions()[0], HPolyhedron)
+        self.assertIn(main1, gcs.GetSubgraphs())
 
         # This adds the edges manually.
         # Doing this is much faster since it avoids computing
@@ -441,6 +464,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertIsInstance(main2.regions()[0], HPolyhedron)
         self.assertIsInstance(main2.Vertices(), list)
         self.assertIsInstance(main2.Vertices()[0], GraphOfConvexSets.Vertex)
+        self.assertIn(main2, gcs.GetSubgraphs())
 
         # Add two start and goal regions.
         start1 = np.array([0.2, 0.2])
@@ -460,6 +484,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertIsInstance(source.regions()[0], Point)
         self.assertIsInstance(source.Vertices(), list)
         self.assertIsInstance(source.Vertices()[0], GraphOfConvexSets.Vertex)
+        self.assertIn(source, gcs.GetSubgraphs())
 
         # Here we force a delay of 10 seconds at the goal.
         target = gcs.AddRegions(regions=[Point(goal1),
@@ -476,6 +501,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertIsInstance(target.regions()[0], Point)
         self.assertIsInstance(target.Vertices(), list)
         self.assertIsInstance(target.Vertices()[0], GraphOfConvexSets.Vertex)
+        self.assertIn(target, gcs.GetSubgraphs())
 
         # We connect the subgraphs main1 and main2 by constraining it to
         # go through either of the subspaces.
@@ -485,12 +511,14 @@ class TestTrajectoryOptimization(unittest.TestCase):
         main1_to_main2_pt = gcs.AddEdges(main1, main2, subspace=subspace_point)
         self.assertIsInstance(main1_to_main2_pt,
                               GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+        self.assertIn(main1_to_main2_pt, gcs.GetEdgesBetweenSubgraphs())
 
         main1_to_main2_region = gcs.AddEdges(main1,
                                              main2,
                                              subspace=subspace_region)
         self.assertIsInstance(main1_to_main2_region,
                               GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+        self.assertIn(main1_to_main2_region, gcs.GetEdgesBetweenSubgraphs())
 
         # Add half of the maximum velocity constraint at the subspace point
         # and region.
@@ -504,6 +532,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
         main2_to_target = gcs.AddEdges(main2, target)
         self.assertIsInstance(main2_to_target,
                               GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
+        self.assertIn(main2_to_target, gcs.GetEdgesBetweenSubgraphs())
 
         # Add final zero velocity constraints.
         main2_to_target.AddVelocityBounds(lb=np.zeros(dimension),

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -315,8 +315,8 @@ class GcsTrajectoryOptimization final {
         const geometry::optimization::GraphOfConvexSets::Edge& e) const;
 
     GcsTrajectoryOptimization& traj_opt_;
-    const int from_subgraph_order_;
-    const int to_subgraph_order_;
+    const Subgraph& from_subgraph_;
+    const Subgraph& to_subgraph_;
 
     trajectories::BezierCurve<double> ur_trajectory_;
     trajectories::BezierCurve<double> vr_trajectory_;
@@ -413,6 +413,13 @@ class GcsTrajectoryOptimization final {
   Subgraph& AddRegions(const geometry::optimization::ConvexSets& regions,
                        int order, double h_min = 0, double h_max = 20,
                        std::string name = "");
+
+  /** Remove a subgraph and all associated edges found in the subgraph and
+  to and from other subgraphs.
+  @pre The subgraph must have been created from a call to AddRegions() on this
+    object.
+  */
+  void RemoveSubgraph(const Subgraph& subgraph);
 
   /** Connects two subgraphs with directed edges.
   @param from_subgraph is the subgraph to connect from. Must have been created
@@ -574,6 +581,12 @@ class GcsTrajectoryOptimization final {
   Here we sum the total number of variable appearances in our costs and
   constraints as a rough approximation of the complexity of the subproblems. */
   double EstimateComplexity() const;
+
+  /** Returns a vector of all subgraphs. */
+  std::vector<Subgraph*> GetSubgraphs() const;
+
+  /** Returns a vector of all edges between subgraphs. */
+  std::vector<EdgesBetweenSubgraphs*> GetEdgesBetweenSubgraphs() const;
 
   /** Getter for the underlying GraphOfConvexSets. This is intended primarily
   for inspecting the resulting programs. */

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -71,8 +71,27 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, Basic) {
   auto& source = gcs.AddRegions(MakeConvexSets(Point(start)), 0);
   auto& target = gcs.AddRegions(MakeConvexSets(Point(goal)), 0);
 
-  gcs.AddEdges(source, regions);
-  gcs.AddEdges(regions, target);
+  // Verify that the subgraphs are present in gcs trajectory optimization.
+  auto all_subgraphs = gcs.GetSubgraphs();
+  EXPECT_NE(std::find(all_subgraphs.begin(), all_subgraphs.end(), &regions),
+            all_subgraphs.end());
+  EXPECT_NE(std::find(all_subgraphs.begin(), all_subgraphs.end(), &source),
+            all_subgraphs.end());
+  EXPECT_NE(std::find(all_subgraphs.begin(), all_subgraphs.end(), &target),
+            all_subgraphs.end());
+
+  auto& source_to_regions = gcs.AddEdges(source, regions);
+  auto& regions_to_target = gcs.AddEdges(regions, target);
+
+  // Verify that the edges between subgraphs are present in gcs trajectory
+  // optimization.
+  auto all_subgraph_edges = gcs.GetEdgesBetweenSubgraphs();
+  EXPECT_NE(std::find(all_subgraph_edges.begin(), all_subgraph_edges.end(),
+                      &source_to_regions),
+            all_subgraph_edges.end());
+  EXPECT_NE(std::find(all_subgraph_edges.begin(), all_subgraph_edges.end(),
+                      &regions_to_target),
+            all_subgraph_edges.end());
 
   auto [traj, result] = gcs.SolvePath(source, target);
   EXPECT_TRUE(result.is_success());
@@ -80,6 +99,22 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, Basic) {
   EXPECT_EQ(traj.cols(), 1);
   EXPECT_TRUE(CompareMatrices(traj.value(traj.start_time()), start, 1e-6));
   EXPECT_TRUE(CompareMatrices(traj.value(traj.end_time()), goal, 1e-6));
+
+  // If we would like to find another path for a different goal, we can remove
+  // the target subgraph and add a new one while keeping the remaining graph.
+  gcs.RemoveSubgraph(target);
+  Vector2d new_goal(0.5, -0.5);
+  auto& new_target = gcs.AddRegions(MakeConvexSets(Point(new_goal)), 0);
+  gcs.AddEdges(regions, new_target);
+
+  auto [new_traj, new_result] = gcs.SolvePath(source, new_target);
+  EXPECT_TRUE(new_result.is_success());
+  EXPECT_EQ(new_traj.rows(), 2);
+  EXPECT_EQ(new_traj.cols(), 1);
+  EXPECT_TRUE(
+      CompareMatrices(new_traj.value(new_traj.start_time()), start, 1e-6));
+  EXPECT_TRUE(
+      CompareMatrices(new_traj.value(new_traj.end_time()), new_goal, 1e-6));
 }
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, PathLengthCost) {
@@ -337,6 +372,34 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, MinimumTimeVsPathLength) {
   const double fastest_path_duration =
       fastest_path_traj.end_time() - fastest_path_traj.start_time();
   EXPECT_LT(fastest_path_duration, shortest_path_duration);
+
+  // Oh oh, it has been raining a lot! The street has been flooded and Bob
+  // can't take the scooter. We can remove the scooter regions from the graph
+  // and solve the path again.
+  gcs.RemoveSubgraph(scooter_regions);
+
+  auto [rain_path_traj, rain_path_result] = gcs.SolvePath(source, target);
+  EXPECT_TRUE(rain_path_result.is_success());
+  EXPECT_EQ(rain_path_traj.rows(), 2);
+  EXPECT_EQ(rain_path_traj.cols(), 1);
+  EXPECT_TRUE(CompareMatrices(rain_path_traj.value(rain_path_traj.start_time()),
+                              start, 1e-6));
+  EXPECT_TRUE(CompareMatrices(rain_path_traj.value(rain_path_traj.end_time()),
+                              goal, 1e-6));
+
+  // Since the scooter regions have been removed, Bob can only walk through the
+  // through the gravel.
+  std::vector<const geometry::optimization::GraphOfConvexSets::Edge*>
+      expected_walking_path_edges = {
+          walking_regions.Vertices()[0]->incoming_edges()[0],
+          walking_regions.Vertices()[0]->outgoing_edges()[0]};
+
+  std::vector<const geometry::optimization::GraphOfConvexSets::Edge*>
+      rain_path_edges = gcs.graph_of_convex_sets().GetSolutionPath(
+          *source.Vertices()[0], *target.Vertices()[0], rain_path_result, 1.0);
+  for (size_t i = 0; i < rain_path_edges.size(); i++) {
+    EXPECT_EQ(rain_path_edges[i], expected_walking_path_edges[i]);
+  }
 }
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, VelocityBoundsOnEdges) {
@@ -454,6 +517,51 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, VelocityBoundsOnEdges) {
   EXPECT_TRUE(
       CompareMatrices(traj_vel->value(stopped_at_ducks_time + kDuckDelay),
                       Vector2d(0, 0), 1e-6));
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, RemoveSubgraph) {
+  /*Ensure that removing a subgraph actually removes vertices/edges in the gcs*/
+  const int kDimension = 2;
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  auto& graph1 =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension),
+                                    HPolyhedron::MakeUnitBox(kDimension)),
+                     1);
+  auto& graph2 =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension),
+                                    HPolyhedron::MakeUnitBox(kDimension)),
+                     1);
+  gcs.AddEdges(graph1, graph2);
+
+  // We expect four vertices, since there are two regions per subgraph.
+  const int kExpectedVertices = 4;
+  EXPECT_EQ(gcs.graph_of_convex_sets().Vertices().size(), kExpectedVertices);
+  // The regions in the subgraph are connected via two edges and since they
+  // overlap, another four edges are added between the subgraphs.
+  const int kExpectedEdges = 2 * 2 + 4;
+  EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), kExpectedEdges);
+
+  // After removing both subgraphs, we expect no vertices or edges in the gcs.
+  gcs.RemoveSubgraph(graph1);
+  gcs.RemoveSubgraph(graph2);
+  EXPECT_EQ(gcs.graph_of_convex_sets().Vertices().size(), 0);
+  EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), 0);
+  EXPECT_EQ(gcs.GetSubgraphs().size(), 0);
+  EXPECT_EQ(gcs.GetEdgesBetweenSubgraphs().size(), 0);
+
+  // Create to remove a subgraph that hasn't been associated with the gcs
+  // instance. For that, we will create another gcs object with a separate
+  // subgraph and try to remove it from the previous instance.
+  GcsTrajectoryOptimization gcs2(kDimension);
+
+  auto& graph3 =
+      gcs2.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension),
+                                     HPolyhedron::MakeUnitBox(kDimension)),
+                      1);
+  DRAKE_EXPECT_THROWS_MESSAGE(gcs.RemoveSubgraph(graph3),
+                              ".* is not registered with `this`.*");
 }
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidPositions) {


### PR DESCRIPTION
Often we build very large and complicated graphs. Rather than having to rebuild it each to for a new start and goal configuration, we could make use of the existing graph by removing and creating a new subgraph and connecting it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21006)
<!-- Reviewable:end -->
