### PR TITLE
[meshcat] Change mechanism for proximity geometry transparency

### DIFF
--- a/bindings/pydrake/visualization/_meldis.py
+++ b/bindings/pydrake/visualization/_meldis.py
@@ -170,7 +170,8 @@ class _ViewerApplet:
     """Displays lcmt_viewer_load_robot and lcmt_viewer_draw into MeshCat."""
 
     def __init__(self, *, meshcat, path, alpha_slider_name,
-                 should_accept_link=None, start_visible=True):
+                 should_accept_link=None, start_visible=True,
+                 initial_alpha_value=1):
         """Constructs an applet.
 
         If should_accept_link is given, only links where
@@ -183,6 +184,7 @@ class _ViewerApplet:
         self._load_message = None
         self._load_message_mesh_checksum = None
         self._alpha_slider = _Slider(meshcat, alpha_slider_name)
+        self._alpha_slider._value = initial_alpha_value
         if should_accept_link is not None:
             self._should_accept_link = should_accept_link
         else:
@@ -753,7 +755,8 @@ class Meldis:
         proximity_viewer = _ViewerApplet(meshcat=self.meshcat,
                                          path="/Collision Geometry",
                                          alpha_slider_name="Collision α",
-                                         start_visible=False)
+                                         start_visible=False,
+                                         initial_alpha_value=0.5)
         self._subscribe(channel="DRAKE_VIEWER_LOAD_ROBOT_PROXIMITY",
                         message_type=lcmt_viewer_load_robot,
                         handler=proximity_viewer.on_viewer_load)

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -47,6 +47,7 @@ MeshcatVisualizer<T>::MeshcatVisualizer(std::shared_ptr<Meshcat> meshcat,
           .get_index();
 
   if (params_.enable_alpha_slider) {
+    alpha_value_ = params_.initial_alpha_slider_value;
     meshcat_->AddSlider(alpha_slider_name_, 0.02, 1.0, 0.02, alpha_value_);
   }
 }

--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -21,6 +21,7 @@ struct MeshcatVisualizerParams {
     a->Visit(DRAKE_NVP(prefix));
     a->Visit(DRAKE_NVP(delete_on_initialization_event));
     a->Visit(DRAKE_NVP(enable_alpha_slider));
+    a->Visit(DRAKE_NVP(initial_alpha_slider_value));
     a->Visit(DRAKE_NVP(visible_by_default));
     a->Visit(DRAKE_NVP(show_hydroelastic));
     a->Visit(DRAKE_NVP(include_unspecified_accepting));
@@ -53,6 +54,12 @@ struct MeshcatVisualizerParams {
 
   /** Determines whether to enable the alpha slider for geometry display. */
   bool enable_alpha_slider{false};
+
+  /** Initial alpha slider value. This value should lie in the range [0, 1].
+   Furthermore, the slider value is *quantized* which means the value used here
+   will be replaced with the nearest quantized value supported by the slider
+   implementation. */
+  double initial_alpha_slider_value{1.0};
 
   /** Determines whether our meshcat path should be default to being visible. */
   bool visible_by_default{true};

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -512,12 +512,18 @@ GTEST_TEST(MeshcatVisualizerTest, AcceptingProperty) {
   }
 }
 
-// Full system acceptance test of setting alpha slider values.
+// Full system acceptance test of setting alpha slider values (including the
+// initial value).
 TEST_F(MeshcatVisualizerWithIiwaTest, AlphaSlidersSystemCheck) {
-  MeshcatVisualizerParams params;
-  params.enable_alpha_slider = true;
+  // Note: due to the quantizing effect of the slider, we can't set an
+  // arbitrary value for the initial slider value and expect a perfect match.
+  // Only values that are integer multiples of 0.02 will work.
+  const MeshcatVisualizerParams params{.enable_alpha_slider = true,
+                                       .initial_alpha_slider_value = 0.5};
   SetUpDiagram(params);
   systems::Simulator<double> simulator(*diagram_);
+
+  EXPECT_EQ(meshcat_->GetSliderValue("visualizer α"), 0.5);
 
   // Simulate for a moment and publish to populate the visualizer.
   simulator.AdvanceTo(0.1);

--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -101,6 +101,8 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionDefault) {
             config.delete_on_initialization_event);
   EXPECT_EQ(meshcat_params.at(2).enable_alpha_slider,
             config.enable_alpha_sliders);
+  EXPECT_EQ(meshcat_params.at(2).initial_alpha_slider_value,
+            config.initial_proximity_alpha);
   EXPECT_EQ(meshcat_params.at(2).visible_by_default, false);
   EXPECT_EQ(meshcat_params.at(2).show_hydroelastic, true);
   EXPECT_EQ(meshcat_params.at(2).include_unspecified_accepting, true);
@@ -137,6 +139,15 @@ GTEST_TEST(VisualizationConfigFunctionsTest, ParamConversionSpecial) {
   EXPECT_EQ(meshcat_params.at(0).default_color, Rgba(0.25, 0.25, 0.25, 0.25));
   EXPECT_EQ(meshcat_params.at(0).prefix, "illustration");
   EXPECT_EQ(meshcat_params.at(0).enable_alpha_slider, true);
+
+  // Testing non-default value for initial_proximity_alpha requires
+  // publishing proximity.
+  const VisualizationConfig proximity_alpha_config{
+      .publish_proximity = true, .initial_proximity_alpha = 0.25};
+  const std::vector<MeshcatVisualizerParams> meshcat_params2 =
+      ConvertVisualizationConfigToMeshcatParams(proximity_alpha_config);
+  EXPECT_EQ(meshcat_params2.at(2).role, Role::kProximity);
+  EXPECT_EQ(meshcat_params2.at(2).initial_alpha_slider_value, 0.25);
 }
 
 // Tests everything disabled.

--- a/visualization/visualization_config.h
+++ b/visualization/visualization_config.h
@@ -23,6 +23,7 @@ struct VisualizationConfig {
     a->Visit(DRAKE_NVP(default_illustration_color));
     a->Visit(DRAKE_NVP(publish_proximity));
     a->Visit(DRAKE_NVP(default_proximity_color));
+    a->Visit(DRAKE_NVP(initial_proximity_alpha));
     a->Visit(DRAKE_NVP(publish_contacts));
     a->Visit(DRAKE_NVP(publish_inertia));
     a->Visit(DRAKE_NVP(enable_meshcat_creation));
@@ -52,7 +53,14 @@ struct VisualizationConfig {
 
   /** The color to apply to any proximity geometry that hasn't defined one.
   The vector must be of size three (rgb) or four (rgba). */
-  geometry::Rgba default_proximity_color{1, 0, 0, 0.5};
+  geometry::Rgba default_proximity_color{0.8, 0, 0, 1.0};
+
+  /** The initial value of the proximity alpha slider.
+   Note: the effective transparency of the proximity geometry is the slider
+   value multiplied by the alpha value of `default_proximity_color`. To have
+   access to the full range of opacity, the color's alpha value should be one
+   and the slider should be used to change it. */
+  double initial_proximity_alpha{0.5};
 
   /** Whether to show body inertia. */
   bool publish_inertia{true};

--- a/visualization/visualization_config_functions.cc
+++ b/visualization/visualization_config_functions.cc
@@ -192,6 +192,7 @@ std::vector<MeshcatVisualizerParams> ConvertVisualizationConfigToMeshcatParams(
     proximity.delete_on_initialization_event =
         config.delete_on_initialization_event;
     proximity.enable_alpha_slider = config.enable_alpha_sliders;
+    proximity.initial_alpha_slider_value = config.initial_proximity_alpha;
     proximity.visible_by_default = false;
     proximity.show_hydroelastic = true;
     result.push_back(proximity);


### PR DESCRIPTION
When using `VisualizationConfig`, the default color for proximity geometries was 100% red with 50% alpha.

In rendering, it's generally a bad idea to define albedo (aka diffuse) color at 100%, and bad for red particularly. This has been backed off to 80% red.

By defining the *color* to be 50% transparent, the alpha slider for proximity can no longer make it opaque.

This changes the default configuration to have the same effect (red proximity geometries with 50% transparency), but defaults the *color* to be opaque and configures the slider to be at 50% so full opacity is now available.

The old behavior can be achieved by changing the default_proximity_color back to [1, 0, 0, 0.5] and the initial_proximity_alpha to 1.

Resolves #20984

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21015)
<!-- Reviewable:end -->
