### PR TITLE
[tools] Add empty file to allow CI wheel builds on Focal

### DIFF
--- a/tools/ubuntu-focal.bazelrc
+++ b/tools/ubuntu-focal.bazelrc
@@ -1,0 +1,2 @@
+# Placeholder to support Focal Wheel builds
+# TODO (betsymcphail) Remove this file when wheel builds move to Jammy


### PR DESCRIPTION
This file was removed in #20964 but is still needed to run wheel builds on Focal.  This can be removed when #21007 is resolved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21020)
<!-- Reviewable:end -->
