### PR TITLE
[meshcat] Drake-generated meshes render faceted in meshcat

### DIFF
--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1027,6 +1027,7 @@ class Meshcat::Impl {
     material->wireframeLineWidth = wireframe_line_width;
     material->vertexColors = false;
     material->side = side;
+    material->flatShading = true;
     data.object.material = std::move(material);
 
     internal::MeshData mesh;
@@ -1074,6 +1075,7 @@ class Meshcat::Impl {
     material->wireframeLineWidth = wireframe_line_width;
     material->vertexColors = true;
     material->side = side;
+    material->flatShading = true;
     data.object.material = std::move(material);
 
     internal::MeshData mesh;

--- a/geometry/meshcat_types_internal.h
+++ b/geometry/meshcat_types_internal.h
@@ -96,6 +96,18 @@ struct MaterialData {
   // is 1.
   std::optional<double> wireframeLineWidth;
 
+  // Explicitly controls the rendered smoothness of a surface. Set it to `true`
+  // to force the geometry to be rendered as faceted. If omitted, meshcat will
+  // apply its default behavior.
+  //
+  // Note: this only meaningfully applies to the most common surface materials.
+  // So, limit the material `type` to be one of: MeshPhongMaterial,
+  // MeshLambertMaterial, MeshStandardMaterial, MeshPhysicalMaterial,
+  // MeshNormalMaterial, MeshMatcapMaterial, and SpriteMaterial. In practice,
+  // this is *not* a limiting requirement as we wouldn't really look to use any
+  // other materials.
+  std::optional<bool> flatShading;
+
   template <typename Packer>
   // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
   void msgpack_pack(Packer& o) const {
@@ -108,6 +120,7 @@ struct MaterialData {
     if (transparent) ++n;
     if (wireframe) ++n;
     if (wireframeLineWidth) ++n;
+    if (flatShading) ++n;
     o.pack_map(n);
     PACK_MAP_VAR(o, uuid);
     PACK_MAP_VAR(o, type);
@@ -144,6 +157,10 @@ struct MaterialData {
     if (wireframeLineWidth) {
       o.pack("wireframeLineWidth");
       o.pack(*wireframeLineWidth);
+    }
+    if (flatShading) {
+      o.pack("flatShading");
+      o.pack(*flatShading);
     }
   }
 

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -404,6 +404,10 @@ GTEST_TEST(MeshcatVisualizerTest, HydroGeometry) {
         "/drake/{}/two_bodies/body1/{}", prefix, sphere1.get_value()));
     if (show_hydroelastic) {
       EXPECT_GT(data.size(), 5000);
+      // The BufferGeometry has explicitly declared its material to be flat
+      // shaded. The encoding includes the property name and the value \xC3 for
+      // true. (False is \xC2.)
+      EXPECT_THAT(data, testing::HasSubstr("flatShading\xC3")) << data;
     } else {
       EXPECT_LT(data.size(), 1000);
     }


### PR DESCRIPTION
When `Meshcat` sends a Drake-generated mesh (as indicated by a call to a `SetTriangleMesh()` variant), that mesh's material is configured to render the mesh faceted.

The default behavior of smoothing them is unhelpful. Meshes of strongly angular objects (e.g., boxes) have their creases smoothed over. It can be difficult to fully understand the topology of the generated mesh with smoothing.

The types of meshes that will be affected:

  - meshes representing hydroelastic proximity geometries.
  - The hydroelastic contact surfaces
  - Convex hulls (see issue #20618)

Resolves #20983

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21021)
<!-- Reviewable:end -->
