### PR TITLE
Construct HPolyhedron from Feasible Set of Linear Program

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -255,6 +255,8 @@ void DefineGeometryOptimization(py::module m) {
             cls_doc.ctor.doc_3args_query_object_geometry_id_reference_frame)
         .def(py::init<const VPolytope&, double>(), py::arg("vpoly"),
             py::arg("tol") = 1E-9, cls_doc.ctor.doc_2args_vpoly_tol)
+        .def(py::init<const solvers::MathematicalProgram&>(), py::arg("prog"),
+            cls_doc.ctor.doc_1args_prog)
         .def("A", &HPolyhedron::A, cls_doc.A.doc)
         .def("b", &HPolyhedron::b, cls_doc.b.doc)
         .def("ContainedIn", &HPolyhedron::ContainedIn, py::arg("other"),

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -285,6 +285,13 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(hpoly.ambient_dimension(), 3)
         self.assertEqual(hpoly.A().shape, (4, 3))
 
+        prog = MathematicalProgram()
+        x = prog.NewContinuousVariables(1)
+        prog.AddLinearConstraint(x[0] >= 0)
+        hpoly = mut.HPolyhedron(prog=prog)
+        self.assertEqual(hpoly.ambient_dimension(), 1)
+        self.assertEqual(hpoly.A().shape, (1, 1))
+
     def test_hyper_ellipsoid(self):
         mut.Hyperellipsoid()
         ellipsoid = mut.Hyperellipsoid(A=self.A, center=self.b)

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -82,6 +82,7 @@ drake_cc_library(
     ],
     deps = [
         "//geometry:read_obj",
+        "//solvers:aggregate_costs_constraints",
         "//solvers:choose_best_solver",
         "//solvers:clarabel_solver",
         "//solvers:get_program_type",

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -21,7 +21,9 @@
 #include "drake/geometry/optimization/vpolytope.h"
 #include "drake/math/matrix_util.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/constraint.h"
+#include "drake/solvers/get_program_type.h"
 #include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/solve.h"
 
@@ -104,6 +106,16 @@ bool IsRedundant(const Eigen::Ref<const MatrixXd>& c, double d,
   return !(polyhedron_is_empty || -result.get_optimal_cost() > d + tol);
 }
 
+/* Returns a trivially-infeasible HPolyhedron of a given dimension. */
+HPolyhedron ConstructInfeasibleHPolyhedron(int dimension) {
+  MatrixXd A_infeasible(2, dimension);
+  A_infeasible.setZero();
+  A_infeasible(0, 0) = 1;
+  A_infeasible(1, 0) = -1;
+  Eigen::Vector2d b_infeasible(-1, 0);
+  return HPolyhedron(A_infeasible, b_infeasible);
+}
+
 }  // namespace
 
 HPolyhedron::HPolyhedron() : ConvexSet(0, false) {}
@@ -141,15 +153,7 @@ HPolyhedron::HPolyhedron(const VPolytope& vpoly, double tol)
           "a HPolyhedron.");
     } else {
       // Just create an infeasible HPolyhedron.
-      Eigen::MatrixXd A = Eigen::MatrixXd::Zero(2, vpoly.ambient_dimension());
-      Eigen::VectorXd b = Eigen::VectorXd::Zero(2);
-      // x <= 1
-      A(0, 0) = 1;
-      b[0] = 1;
-      // -x <= -2, equivalent to x >= 2
-      A(1, 0) = -1;
-      b[1] = -2;
-      *this = HPolyhedron(A, b);
+      *this = ConstructInfeasibleHPolyhedron(vpoly.ambient_dimension());
       return;
     }
   }
@@ -279,6 +283,107 @@ HPolyhedron::HPolyhedron(const VPolytope& vpoly, double tol)
     b_(facet_count) = -facet.outerplane().offset();
     ++facet_count;
   }
+}
+
+HPolyhedron::HPolyhedron(const MathematicalProgram& prog)
+    : ConvexSet(prog.num_vars(), false) {
+  // Preconditions
+  DRAKE_THROW_UNLESS(prog.num_vars() > 0);
+  DRAKE_THROW_UNLESS(prog.GetAllConstraints().size() > 0);
+  DRAKE_THROW_UNLESS(solvers::GetProgramType(prog) ==
+                     solvers::ProgramType::kLP);
+
+  // Get linear equality constraints.
+  std::vector<Eigen::Triplet<double>> A_triplets;
+  std::vector<double> b;
+  int A_row_count = 0;
+  std::vector<int> unused_linear_eq_y_start_indices;
+  int unused_num_rows_added = 0;
+  solvers::internal::ParseLinearEqualityConstraints(
+      prog, &A_triplets, &b, &A_row_count, &unused_linear_eq_y_start_indices,
+      &unused_num_rows_added);
+
+  // Linear equality constraints Ax = b are parsed in the form Ax <= b. So we
+  // add in the reverse of the constraint, Ax >= b, encoded as -Ax <= -b. This
+  // is implemented by taking each triplet (i, j, v) and adding in
+  // (i + N, j, -v), where N is the number of rows of A before we start adding
+  // new triplets.
+  const int num_equality_triplets = A_triplets.size();
+  const int& num_equality_constraints = A_row_count;
+  for (int i = 0; i < num_equality_triplets; ++i) {
+    const Eigen::Triplet<double>& triplet = A_triplets.at(i);
+    A_triplets.emplace_back(triplet.row() + num_equality_constraints,
+                            triplet.col(), -triplet.value());
+  }
+  // We also set b := [b; -b].
+  for (int i = 0; i < num_equality_constraints; ++i) {
+    b.push_back(-1 * b[i]);
+  }
+  A_row_count *= 2;
+
+  // Get linear inequality constraints.
+  std::vector<std::vector<std::pair<int, int>>>
+      unused_linear_constraint_dual_indices;
+  solvers::internal::ParseLinearConstraints(
+      prog, &A_triplets, &b, &A_row_count,
+      &unused_linear_constraint_dual_indices, &unused_num_rows_added);
+
+  // Check that none of the linear inequality constraints are trivially
+  // infeasible by requiring a variable be at least ∞ or at most -∞. If this is
+  // the case, return a trivially infeasible HPolyhedron. Constraints that
+  // violate this condition may not be returned by ParseLinearConstraints.
+  for (const auto& binding : prog.linear_constraints()) {
+    if (binding.evaluator()->lower_bound().maxCoeff() == kInf ||
+        binding.evaluator()->upper_bound().minCoeff() == -kInf) {
+      *this = ConstructInfeasibleHPolyhedron(prog.num_vars());
+      return;
+    }
+  }
+
+  // Get bounding box constraints.
+  VectorXd lb;
+  VectorXd ub;
+  solvers::AggregateBoundingBoxConstraints(prog, &lb, &ub);
+
+  for (int i = 0; i < lb.size(); ++i) {
+    // If lb[i] == Infinity or ub[i] == -Infinity, we have a trivial
+    // infeasibility, so we make a trivially infeasible HPolyhedron by just
+    // including the constraints x <= -1, x >= 0, where x is the first decision
+    // variable.
+    if (lb[i] == kInf || ub[i] == -kInf) {
+      *this = ConstructInfeasibleHPolyhedron(prog.num_vars());
+      return;
+    } else {
+      A_triplets.emplace_back(A_row_count, i, 1);
+      b.push_back(ub[i]);
+      ++A_row_count;
+      A_triplets.emplace_back(A_row_count, i, -1);
+      b.push_back(-lb[i]);
+      ++A_row_count;
+    }
+  }
+  // Form the A and b matrices of the HPolyhedron.
+  Eigen::SparseMatrix<double, Eigen::RowMajor> A_sparse(A_row_count,
+                                                        prog.num_vars());
+  A_sparse.setFromTriplets(A_triplets.begin(), A_triplets.end());
+
+  // Identify the rows that do not contain any infinities, as the rows to keep.
+  // Since we have filtered out infinities that render the problem infeasible
+  // above, these correspond to inequalities that are trivially satisfied by all
+  // vectors x, and need not be included in the HPolyhedron.
+  std::vector<int> rows_to_keep;
+  rows_to_keep.reserve(A_sparse.rows());
+  for (int i = 0; i < ssize(b); ++i) {
+    if (abs(b[i]) < kInf) {
+      rows_to_keep.push_back(i);
+    }
+  }
+
+  VectorXd b_eigen(b.size());
+  b_eigen = VectorXd::Map(b.data(), b.size());
+
+  *this = HPolyhedron(A_sparse.toDense()(rows_to_keep, Eigen::all),
+                      b_eigen(rows_to_keep));
 }
 
 HPolyhedron::~HPolyhedron() = default;

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -51,6 +51,14 @@ class HPolyhedron final : public ConvexSet, private ShapeReifier {
   @throws std::exception if vpoly is empty and zero dimensional. */
   explicit HPolyhedron(const VPolytope& vpoly, double tol = 1e-9);
 
+  /** Constructs a new HPolyhedron describing the feasible set of a linear
+  program `prog`. The `i`th dimension in this representation corresponds
+  to the `i`th decision variable of `prog`. Note that if `prog` is infeasible,
+  then the constructed HPolyhedron will be empty.
+  @throws std::exception if prog has constraints which are not of type linear
+  inequality, linear equality, or bounding box. */
+  explicit HPolyhedron(const solvers::MathematicalProgram& prog);
+
   // TODO(russt): Add a method/constructor that would create the geometry using
   // SceneGraph's AABB or OBB representation (for arbitrary objects) pending
   // #15121.


### PR DESCRIPTION
This PR implements a new constructor for `HPolyhedron`, that takes in a `MathematicalProgram`, asserts that it indeed represents an LP, and sets up a single HPolyhedron representation of the entire feasible set.

cc @shrutigarg914 

+@hongkai-dai for feature review, please!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21027)
<!-- Reviewable:end -->
