### PR TITLE
[workspace] Add boost_internal

### DIFF
--- a/tools/workspace/boost_internal/BUILD.bazel
+++ b/tools/workspace/boost_internal/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/boost_internal/repository.bzl
+++ b/tools/workspace/boost_internal/repository.bzl
@@ -1,0 +1,24 @@
+load("//tools/workspace:github.bzl", "github_release_attachments")
+
+def boost_internal_repository(
+        name,
+        mirrors = None):
+    github_release_attachments(
+        name = name,
+        repository = "boostorg/boost",
+        commit = "boost-1.84.0",
+        attachments = {
+            "boost-1.84.0.tar.xz": "2e64e5d79a738d0fa6fb546c6e5c2bd28f88d268a2a080546f74e5ff98f29d0e",  # noqa
+        },
+        extract = [
+            "boost-1.84.0.tar.xz",
+        ],
+        strip_prefix = {
+            "boost-1.84.0.tar.xz": "boost-1.84.0",
+        },
+        build_file = "@com_github_nelhage_rules_boost_internal//:boost.BUILD",
+        mirrors = mirrors,
+        repo_mapping = {
+            "@com_github_nelhage_rules_boost": "@com_github_nelhage_rules_boost_internal",  # noqa
+        },
+    )

--- a/tools/workspace/com_github_nelhage_rules_boost_internal/BUILD.bazel
+++ b/tools/workspace/com_github_nelhage_rules_boost_internal/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/com_github_nelhage_rules_boost_internal/patches/iostreams.patch
+++ b/tools/workspace/com_github_nelhage_rules_boost_internal/patches/iostreams.patch
@@ -1,0 +1,32 @@
+[com_github_nelhage_rules_boost] Disable iostreams deps
+
+OpenUSD uses :multi_index which depends on :serialization which
+depends on :iostreams which depends on some compression libraries.
+
+In Drake, we don't expect to use any of those compression features,
+so we'll cut away the extra dependencies for simplicity.
+
+Since this is a Drake-specific customization, we don't plan on
+upstreaming this patch.
+
+
+--- boost.BUILD
++++ boost.BUILD
+@@ -1131,10 +1131,13 @@
+         ":type",
+         ":type_traits",
+         ":utility",
+-        "@com_github_facebook_zstd//:zstd",
+-        "@org_bzip_bzip2//:bz2lib",
+-        "@org_lzma_lzma//:lzma",
+-        "@zlib",
++    ],
++    exclude_src = [
++        "libs/iostreams/src/bzip2.cpp",
++        "libs/iostreams/src/gzip.cpp",
++        "libs/iostreams/src/lzma.cpp",
++        "libs/iostreams/src/zlib.cpp",
++        "libs/iostreams/src/zstd.cpp",
+     ],
+ )
+ 

--- a/tools/workspace/com_github_nelhage_rules_boost_internal/repository.bzl
+++ b/tools/workspace/com_github_nelhage_rules_boost_internal/repository.bzl
@@ -1,0 +1,15 @@
+load("//tools/workspace:github.bzl", "github_archive")
+
+def com_github_nelhage_rules_boost_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "nelhage/rules_boost",
+        commit = "f621ad7bec2abf5a597ed1271fd823d2761943b2",
+        sha256 = "eb2cadbeb990785d8004d7063cac5fba72518cee7bdd2b9f7597affdced7524e",  # noqa
+        patches = [
+            ":patches/iostreams.patch",
+        ],
+        mirrors = mirrors,
+    )

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -4,6 +4,7 @@ load("//tools/workspace/abseil_cpp_internal:repository.bzl", "abseil_cpp_interna
 load("//tools/workspace/bazelisk:repository.bzl", "bazelisk_repository")
 load("//tools/workspace/bazel_skylib:repository.bzl", "bazel_skylib_repository")  # noqa
 load("//tools/workspace/blas:repository.bzl", "blas_repository")
+load("//tools/workspace/boost_internal:repository.bzl", "boost_internal_repository")  # noqa
 load("//tools/workspace/build_bazel_apple_support:repository.bzl", "build_bazel_apple_support_repository")  # noqa
 load("//tools/workspace/buildifier:repository.bzl", "buildifier_repository")
 load("//tools/workspace/cc:repository.bzl", "cc_repository")
@@ -12,6 +13,7 @@ load("//tools/workspace/clang_cindex_python3_internal:repository.bzl", "clang_ci
 load("//tools/workspace/clarabel_cpp_internal:repository.bzl", "clarabel_cpp_internal_repository")  # noqa
 load("//tools/workspace/clp_internal:repository.bzl", "clp_internal_repository")  # noqa
 load("//tools/workspace/coinutils_internal:repository.bzl", "coinutils_internal_repository")  # noqa
+load("//tools/workspace/com_github_nelhage_rules_boost_internal:repository.bzl", "com_github_nelhage_rules_boost_internal_repository")  # noqa
 load("//tools/workspace/com_jidesoft_jide_oss:repository.bzl", "com_jidesoft_jide_oss_repository")  # noqa
 load("//tools/workspace/common_robotics_utilities:repository.bzl", "common_robotics_utilities_repository")  # noqa
 load("//tools/workspace/commons_io:repository.bzl", "commons_io_repository")
@@ -122,6 +124,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         bazel_skylib_repository(name = "bazel_skylib", mirrors = mirrors)
     if "blas" not in excludes:
         blas_repository(name = "blas")
+    if "boost_internal" not in excludes:
+        boost_internal_repository(name = "boost_internal", mirrors = mirrors)
     if "build_bazel_apple_support" not in excludes:
         build_bazel_apple_support_repository(name = "build_bazel_apple_support", mirrors = mirrors)  # noqa
     if "buildifier" not in excludes:
@@ -140,6 +144,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         coinutils_internal_repository(name = "coinutils_internal", mirrors = mirrors)  # noqa
     if "com_jidesoft_jide_oss" not in excludes:
         com_jidesoft_jide_oss_repository(name = "com_jidesoft_jide_oss", mirrors = mirrors)  # noqa
+    if "com_github_nelhage_rules_boost_internal" not in excludes:
+        com_github_nelhage_rules_boost_internal_repository(name = "com_github_nelhage_rules_boost_internal", mirrors = mirrors)  # noqa
     if "common_robotics_utilities" not in excludes:
         common_robotics_utilities_repository(name = "common_robotics_utilities", mirrors = mirrors)  # noqa
     if "commons_io" not in excludes:

--- a/tools/workspace/github.bzl
+++ b/tools/workspace/github.bzl
@@ -400,6 +400,8 @@ def github_release_attachments(
         repository = None,
         commit = None,
         attachments = None,
+        extract = None,
+        strip_prefix = None,
         build_file = None,
         mirrors = None,
         upgrade_advice = None,
@@ -418,6 +420,13 @@ def github_release_attachments(
         commit: required commit is the tag name to download.
         attachments: required dict whose keys are the filenames (attachment
             names) to download and values are the expected SHA-256 checksums.
+        extract: optional list of the filenames (attachment names) that should
+            be downloaded and extracted (e.g., `*.tgz` files), as opposed to
+            only downloaded.
+        strip_prefix: optional dict whose keys are the filenames (attachment
+            names) and values indicate a prefix to strip during extraction.
+            Note that this is only relevant for filenames that are also listed
+            under `extract`.
         build_file: required build file is the BUILD file label to use for
             building this external. As a Drake-specific abbreviation, when
             provided as a relative label (e.g., ":package.BUILD.bazel"), it
@@ -450,6 +459,8 @@ def github_release_attachments(
         repository = repository,
         commit = commit,
         attachments = attachments,
+        extract = extract,
+        strip_prefix = strip_prefix,
         build_file = build_file,
         mirrors = mirrors,
         upgrade_advice = upgrade_advice,
@@ -478,6 +489,8 @@ _github_release_attachments_real = repository_rule(
         "attachments": attr.string_dict(
             mandatory = True,
         ),
+        "extract": attr.string_list(),
+        "strip_prefix": attr.string_dict(),
         "build_file": attr.label(
             mandatory = True,
         ),
@@ -502,6 +515,8 @@ def setup_github_release_attachments(repository_ctx):
     repository = repository_ctx.attr.repository
     commit = repository_ctx.attr.commit
     attachments = repository_ctx.attr.attachments
+    extract = getattr(repository_ctx.attr, "extract", list())
+    strip_prefix = getattr(repository_ctx.attr, "strip_prefix", dict())
     mirrors = repository_ctx.attr.mirrors
     upgrade_advice = getattr(repository_ctx.attr, "upgrade_advice", "")
     patterns = mirrors.get("github_release_attachments")
@@ -517,11 +532,18 @@ def setup_github_release_attachments(repository_ctx):
             )
             for pattern in patterns
         ]
-        repository_ctx.download(
-            urls,
-            output = filename,
-            sha256 = _sha256(sha256),
-        )
+        if filename in extract:
+            repository_ctx.download_and_extract(
+                urls,
+                stripPrefix = strip_prefix.get(filename, None),
+                sha256 = _sha256(sha256),
+            )
+        else:
+            repository_ctx.download(
+                urls,
+                output = filename,
+                sha256 = _sha256(sha256),
+            )
         downloads.append(dict(
             urls = urls,
             sha256 = sha256,
@@ -537,6 +559,7 @@ def setup_github_release_attachments(repository_ctx):
         repository = repository,
         commit = commit,
         attachments = attachments,
+        strip_prefix = strip_prefix,
         downloads = downloads,
         upgrade_advice = upgrade_advice,
     )

--- a/tools/workspace/metadata.py
+++ b/tools/workspace/metadata.py
@@ -43,6 +43,7 @@ def read_repository_metadata(repositories=None):
         # NOTE: At this time, we are skipping the rust_toolchain repositories;
         # see TODO in tools/workspace/rust_toolchain/repository.bzl.
         repositories.add("bazel_skylib")
+        repositories.add("com_github_nelhage_rules_boost_internal")
 
     # Make sure all of the repository_rule results are up-to-date.
     subprocess.check_call(["bazel", "fetch", "//..."])

--- a/tools/workspace/openusd_internal/BUILD.bazel
+++ b/tools/workspace/openusd_internal/BUILD.bazel
@@ -28,10 +28,6 @@ sh_test(
         "//conditions:default": ["empty.sh"],
     }),
     args = ["--help"],
-    tags = [
-        # TODO(jwnimmer-tri) Re-enable this once we fix Boost problems.
-        "manual",
-    ],
 )
 
 add_lint_tests()

--- a/tools/workspace/openusd_internal/defs.bzl
+++ b/tools/workspace/openusd_internal/defs.bzl
@@ -39,8 +39,22 @@ def pxr_library(
     ]
     deps = attrs["LIBRARIES"] + [
         ":pxr_h",
+        "@boost_internal//:any",
+        "@boost_internal//:functional",
+        "@boost_internal//:function",
+        "@boost_internal//:intrusive_ptr",
+        "@boost_internal//:mpl",
+        "@boost_internal//:multi_index",
+        "@boost_internal//:noncopyable",
+        "@boost_internal//:none",
+        "@boost_internal//:numeric_conversion",
+        "@boost_internal//:optional",
+        "@boost_internal//:preprocessor",
+        "@boost_internal//:ptr_container",
+        "@boost_internal//:smart_ptr",
+        "@boost_internal//:variant",
+        "@boost_internal//:vmd",
         "@onetbb_internal//:tbb",
-        # TODO(jwnimmer-tri) We also need to list some @boost here.
     ]
     cc_library(
         name = name,


### PR DESCRIPTION
Also add `com_github_nelhage_rules_boost_internal` for its BUILD file.

These two repositories are not enabled by default. They are only used when `--WITH_USD=ON` is enabled.

Towards #20898. Amends #20923.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21037)
<!-- Reviewable:end -->
