### PR TITLE
[workspace] Upgrade drake_models to latest commit

### DIFF
--- a/tools/install/bazel/repo_template.bzl
+++ b/tools/install/bazel/repo_template.bzl
@@ -142,14 +142,15 @@ _fmt_repository = repository_rule(
 )
 
 def _drake_models_impl(repo_ctx):
-    repo_ctx.file(
-        "BUILD.bazel",
-        _BUILD_FILE_CONTENTS["external-drake_models-BUILD.bazel"],
-    )
     repo_ctx.download_and_extract(
         url = ["@@MODELS_URLS@@"],
         sha256 = "@@MODELS_SHA256@@",
         stripPrefix = "@@MODELS_STRIP_PREFIX@@",
+    )
+    repo_ctx.delete("MODULE.bazel")
+    repo_ctx.file(
+        "BUILD.bazel",
+        _BUILD_FILE_CONTENTS["external-drake_models-BUILD.bazel"],
     )
 
 _drake_models_repository = repository_rule(

--- a/tools/workspace/drake_models/repository.bzl
+++ b/tools/workspace/drake_models/repository.bzl
@@ -6,8 +6,8 @@ def drake_models_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/models",
-        commit = "accdf59bc4227b4be8a9867b63058083003d1168",
-        sha256 = "b0dc30fc1d3410afdd66d5d7b5370c5df1a814d66197f0934103c7e89b191739",  # noqa
+        commit = "d0fe1a427a6bd39040ff3a77aaf6ddcc4d62a8fe",
+        sha256 = "0a19e498d654e39dcf7e8f9144d06b3bbdd01a639cdc653a7d41cdc6d9ad5319",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Companion PR: https://github.com/RobotLocomotion/models/pull/33.

To check that this is satisfactory, we can run the following command:

```
bazel run //tools:model_visualizer -- package://drake_models/tri_homecart/homecart.dmd.yaml
````

The display should be the same on master versus this PR, except that the lighting comes out more nicely.  All of the shapes should still be facing the same way, and all of the textures (metal vs wood) should be the same.

Towards #20932.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21039)
<!-- Reviewable:end -->
