### PR TITLE
Implements PackageMap::ResolveUrl()

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -64,6 +64,8 @@ PYBIND11_MODULE(parsing, m) {
               return self.GetPath(package_name);
             },
             py::arg("package_name"), cls_doc.GetPath.doc)
+        .def("ResolveUrl", &Class::ResolveUrl, py::arg("url"),
+            cls_doc.ResolveUrl.doc)
         .def("PopulateFromFolder", &Class::PopulateFromFolder, py::arg("path"),
             cls_doc.PopulateFromFolder.doc)
         .def("PopulateFromEnvironment", &Class::PopulateFromEnvironment,

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -59,6 +59,10 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(dut.GetPath(package_name="root"), tmpdir)
         dut.AddPackageXml(filename=FindResourceOrThrow(
             "drake/multibody/parsing/test/box_package/package.xml"))
+        self.assertEqual(
+            dut.ResolveUrl(url="package://box_model/urdfs/box.urdf"),
+            FindResourceOrThrow(
+                "drake/multibody/parsing/test/box_package/urdfs/box.urdf"))
         dut2.Remove(package_name="root")
         self.assertEqual(dut2.size(), 0)
 

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -66,8 +66,14 @@ genrule(
 
 drake_cc_library(
     name = "package_map",
-    srcs = ["package_map.cc"],
-    hdrs = ["package_map.h"],
+    srcs = [
+        "detail_path_utils.cc",
+        "package_map.cc",
+    ],
+    hdrs = [
+        "detail_path_utils.h",
+        "package_map.h",
+    ],
     data = [
         ":drake_models.json",
         ":package_downloader.py",
@@ -80,6 +86,7 @@ drake_cc_library(
         "//common:name_value",
     ],
     deps = [
+        "//common:diagnostic_policy",
         "//common:find_cache",
         "//common:find_resource",
         "//common:find_runfiles",
@@ -100,7 +107,6 @@ drake_cc_library(
         "detail_collision_filter_group_resolver.cc",
         "detail_common.cc",
         "detail_ignition.cc",
-        "detail_path_utils.cc",
         "detail_tinyxml.cc",
         "detail_tinyxml2_diagnostic.cc",
     ],
@@ -108,7 +114,6 @@ drake_cc_library(
         "detail_collision_filter_group_resolver.h",
         "detail_common.h",
         "detail_ignition.h",
-        "detail_path_utils.h",
         "detail_strongly_connected_components.h",
         "detail_tinyxml.h",
         "detail_tinyxml2_diagnostic.h",

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -28,6 +28,7 @@
 #include "drake/common/sha256.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/yaml/yaml_io.h"
+#include "drake/multibody/parsing/detail_path_utils.h"
 
 namespace drake {
 namespace multibody {
@@ -761,6 +762,11 @@ const std::string& PackageMap::GetPath(
 
   // If this is a remote package and we haven't fetched it yet, do that now.
   return data.GetPathWithAutomaticFetching(package_name);
+}
+
+std::string PackageMap::ResolveUrl(const std::string& url) const {
+  drake::internal::DiagnosticPolicy diagnostic_policy;
+  return internal::ResolveUri(diagnostic_policy, url, *this, {});
 }
 
 void PackageMap::PopulateFromFolder(const std::string& path) {

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -60,6 +60,12 @@ class PackageMap final {
       const std::string& package_name,
       std::optional<std::string>* deprecated_message = nullptr) const;
 
+  /** Returns a resolved path for `url`. URL schemes are either `file://` for
+  local files or `package://` (or `model://`).
+
+  @throws std::exception if the url cannot be resolved. */
+  std::string ResolveUrl(const std::string& url) const;
+
   ///@}
 
   /** @name Functions for adding packages to the map */

--- a/multibody/parsing/test/detail_path_utils_test.cc
+++ b/multibody/parsing/test/detail_path_utils_test.cc
@@ -59,7 +59,7 @@ std::string ResolveBadUri(
 // exhaustive list of all ways a valid path can be unnormalized. Ultimately,
 // we're relying on std::filesystem to get the job done and these are just
 // indicators (representing common cases) that show it's actually happening.
-GTEST_TEST(ResoluveUriUncheckedTest, NormalizedPath) {
+GTEST_TEST(ResolveUriUncheckedTest, NormalizedPath) {
   // Use an empty package map.
   PackageMap package_map;
 

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -423,6 +423,33 @@ GTEST_TEST(PackageMapTest, TestStreamingToString) {
             4);
 }
 
+// ResolveUrl is just a thin wrapper around internal::ResolveUri (which is
+// tested elsewhere). This test is just to ensure that the wrapper is working.
+GTEST_TEST(PackageMapTest, TestResolveUrl) {
+  const string xml_filename = FindResourceOrThrow(
+      "drake/multibody/parsing/test/"
+      "package_map_test_packages/package_map_test_package_a/package.xml");
+  PackageMap package_map = PackageMap::MakeEmpty();
+  package_map.AddPackageXml(xml_filename);
+
+  const string filename = package_map.ResolveUrl(
+      "package://package_map_test_package_a/sdf/test_model.sdf");
+
+  const string expected_filename = FindResourceOrThrow(
+      "drake/multibody/parsing/test/package_map_test_packages/"
+      "package_map_test_package_a/sdf/test_model.sdf");
+
+  EXPECT_EQ(filename, expected_filename);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(package_map.ResolveUrl(
+      "package://bad_package_name/sdf/test_model.sdf"),
+      ".*unknown package.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(package_map.ResolveUrl(
+      "package://package_map_test_package_a/bad_filename.sdf"),
+      ".*does not exist.*");
+}
+
 // Tests that PackageMap is parsing deprecation messages
 GTEST_TEST(PackageMapTest, TestDeprecation) {
   const


### PR DESCRIPTION
Adds a new PackageMap sugar function that takes a string url as input and returns the resolved path.

Resolves #20255.

+@jwnimmer-tri for feature review, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21042)
<!-- Reviewable:end -->
