### PR TITLE
Add Optional Sparsity Groups to MakeSemidefiniteRelaxation

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -12,8 +12,16 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc.drake.solvers;
 
-  m.def("MakeSemidefiniteRelaxation", &solvers::MakeSemidefiniteRelaxation,
-      py::arg("prog"), doc.MakeSemidefiniteRelaxation.doc);
+  m.def("MakeSemidefiniteRelaxation",
+      py::overload_cast<const MathematicalProgram&>(
+          &solvers::MakeSemidefiniteRelaxation),
+      py::arg("prog"), doc.MakeSemidefiniteRelaxation.doc_1args);
+  m.def("MakeSemidefiniteRelaxation",
+      py::overload_cast<const MathematicalProgram&,
+          const std::vector<symbolic::Variables>&>(
+          &solvers::MakeSemidefiniteRelaxation),
+      py::arg("prog"), py::arg("variable_groups"),
+      doc.MakeSemidefiniteRelaxation.doc_2args);
 }
 
 }  // namespace internal

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -32,11 +32,13 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         x_vars = Variables(x)
         y_vars = Variables(y)
 
-        A = np.array([[0.5, 0.7], [-.2, 0.4], [-2.3, -4.5]])
+        A = np.array([[0.5, 0.7],
+                      [-.2, 0.4],
+                      [-2.3, -4.5]])
         lb = np.array([1.3, -.24, 0.25])
         ub = np.array([5.6, 0.1, 1.4])
         prog.AddLinearConstraint(A, lb, ub, x)
-        prog.AddQuadraticConstraint(A, lb, 0, 5, y)
+        prog.AddQuadraticConstraint(A@A.T, lb, 0, 5, y)
         relaxation = MakeSemidefiniteRelaxation(prog, [x_vars, y_vars])
 
         self.assertEqual(relaxation.num_vars(), 6 + 10)

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -5,6 +5,7 @@ from pydrake.solvers import (
     MakeSemidefiniteRelaxation,
     MathematicalProgram,
 )
+from pydrake.symbolic import Variables
 
 
 class TestSemidefiniteRelaxation(unittest.TestCase):
@@ -20,5 +21,26 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         self.assertEqual(relaxation.num_vars(), 6)
         self.assertEqual(len(relaxation.positive_semidefinite_constraints()),
                          1)
-        self.assertEqual(len(relaxation.bounding_box_constraints()), 1)
+        self.assertEqual(len(relaxation.linear_equality_constraints()), 1)
         self.assertEqual(len(relaxation.linear_constraints()), 2)
+
+    def test_MakeSemidefiniteRelaxationWithGroups(self):
+        prog = MathematicalProgram()
+        x = prog.NewContinuousVariables(2, "x")
+        y = prog.NewContinuousVariables(3, "y")
+
+        x_vars = Variables(x)
+        y_vars = Variables(y)
+
+        A = np.array([[0.5, 0.7], [-.2, 0.4], [-2.3, -4.5]])
+        lb = np.array([1.3, -.24, 0.25])
+        ub = np.array([5.6, 0.1, 1.4])
+        prog.AddLinearConstraint(A, lb, ub, x)
+        prog.AddQuadraticConstraint(A, lb, 0, 5, y)
+        relaxation = MakeSemidefiniteRelaxation(prog, [x_vars, y_vars])
+
+        self.assertEqual(relaxation.num_vars(), 6 + 10)
+        self.assertEqual(len(relaxation.positive_semidefinite_constraints()),
+                         2)
+        self.assertEqual(len(relaxation.linear_equality_constraints()), 2)
+        self.assertEqual(len(relaxation.linear_constraints()), 2+1)

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -16,7 +16,7 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         lb = np.array([1.3, -.24, 0.25])
         ub = np.array([5.6, 0.1, 1.4])
         prog.AddLinearConstraint(A, lb, ub, y)
-        relaxation = MakeSemidefiniteRelaxation(prog)
+        relaxation = MakeSemidefiniteRelaxation(prog=prog)
 
         self.assertEqual(relaxation.num_vars(), 6)
         self.assertEqual(len(relaxation.positive_semidefinite_constraints()),
@@ -39,10 +39,14 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         ub = np.array([5.6, 0.1, 1.4])
         prog.AddLinearConstraint(A, lb, ub, x)
         prog.AddQuadraticConstraint(A@A.T, lb, 0, 5, y)
-        relaxation = MakeSemidefiniteRelaxation(prog, [x_vars, y_vars])
+        relaxation = MakeSemidefiniteRelaxation(
+            prog=prog, variable_groups=[x_vars, y_vars])
 
-        self.assertEqual(relaxation.num_vars(), 6 + 10)
+        # The semidefinite variables have 4 and 3 rows respectively,
+        # with the "1" variable double counted. Therefore, there are
+        # 5 choose 2 + 4 choose 2 - 1 variables.
+        self.assertEqual(relaxation.num_vars(), 10 + 6 - 1)
         self.assertEqual(len(relaxation.positive_semidefinite_constraints()),
                          2)
-        self.assertEqual(len(relaxation.linear_equality_constraints()), 2)
+        self.assertEqual(len(relaxation.linear_equality_constraints()), 1)
         self.assertEqual(len(relaxation.linear_constraints()), 2+1)

--- a/math/matrix_util.h
+++ b/math/matrix_util.h
@@ -211,9 +211,9 @@ template <typename Derived>
 MatrixX<typename Derived::Scalar> ExtractPrincipalSubmatrix(
     const Eigen::MatrixBase<Derived>& mat, const std::set<int>& indices) {
   DRAKE_THROW_UNLESS(!indices.empty());
-  // Stores the contiguous intervals of the index set of the minor. These
-  // intervals include the first index but exclude the last, i.e.
-  // [intervals[i][0], intervals[i][1]).
+  // Stores the contiguous intervals of the index set of the principal
+  // submatrix. These intervals include the first index but exclude the last,
+  // i.e. [intervals[i][0], intervals[i][1]).
   std::vector<std::pair<int, int>> intervals;
   auto it = indices.begin();
   int interval_start{*it};

--- a/solvers/semidefinite_relaxation.cc
+++ b/solvers/semidefinite_relaxation.cc
@@ -373,10 +373,10 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
           groups_to_superset.at(group),
           DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(
               container_program, relaxation.get(), group_number));
-//      std::cout << fmt::format("X=\n{}",
-//                               fmt_eigen(supersets_to_psd_variables.at(
-//                                   groups_to_superset.at(group))))
-//                << std::endl;
+            std::cout << fmt::format("X=\n{}",
+                                     fmt_eigen(supersets_to_psd_variables.at(
+                                         groups_to_superset.at(group))))
+                      << std::endl;
     }
     ++group_number;
   }
@@ -412,7 +412,7 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     throw std::runtime_error(
         "There is a non-convex cost or constraint in the program whose "
         "variables do not overlap with any variable groups. Therefore, these "
-        "costs or constraints would not be converted to convex semidefinite "
+        "costs or constraints would not be converted to convex, semidefinite "
         "constraints and so the returned program would not be convex. Consider "
         "further specifying the variable groups.");
   }

--- a/solvers/semidefinite_relaxation.cc
+++ b/solvers/semidefinite_relaxation.cc
@@ -396,46 +396,6 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     }
   }
 
-  // Now constrain the semidefinite variables to agree where they overlap. Since
-  // the variables are not necessarily in the same order in matrix, we need to
-  // do some permuting stuff.
-  //  for (auto it = variable_groups.begin(); it != variable_groups.end(); it++)
-  //  {
-  //    const Variables& superset1{groups_to_superset.at(*it)};
-  //    const MathematicalProgram& prog1{groups_to_container_programs.at(*it)};
-  //    if (prog1.GetAllConstraints().empty() && prog1.GetAllCosts().empty()) {
-  //      continue;
-  //    }
-  //    const MatrixX<Variable> X1{supersets_to_psd_variables.at(superset1)};
-  //    for (auto it2 = std::next(it); it2 != variable_groups.end(); it2++) {
-  //      const Variables& superset2{groups_to_superset.at(*it2)};
-  //      const MathematicalProgram&
-  //      prog2{groups_to_container_programs.at(*it2)}; if
-  //      (prog2.GetAllConstraints().empty() && prog2.GetAllCosts().empty()) {
-  //        continue;
-  //      }
-  //      const Variables common_variables = intersect(superset1, superset2);
-  //      if (!common_variables.empty()) {
-  //        const MatrixX<Variable>
-  //        X2{supersets_to_psd_variables.at(superset2)}; for (auto var_it1 =
-  //        common_variables.begin();
-  //             var_it1 != common_variables.end(); var_it1++) {
-  //          const int i1 = prog1.FindDecisionVariableIndex(*var_it1);
-  //          const int i2 = prog2.FindDecisionVariableIndex(*var_it1);
-  //          for (auto var_it2 = var_it1; var_it2 != common_variables.end();
-  //               var_it2++) {
-  //            const int j1 = prog1.FindDecisionVariableIndex(*var_it2);
-  //            const int j2 = prog2.FindDecisionVariableIndex(*var_it2);
-  //            // TODO(Alexandre.Amice): If this repeated allocation becomes a
-  //            // problem, then
-  //            relaxation->AddLinearEqualityConstraint(X1(i1, j1) == X2(i2,
-  //            j2));
-  //          }
-  //        }
-  //      }
-  //    }
-  //  }
-
   if (CheckProgramRequireSemidefiniteRelaxation(*relaxation)) {
     throw std::runtime_error(
         "There is a non-convex cost or constraint in the program whose "

--- a/solvers/semidefinite_relaxation.cc
+++ b/solvers/semidefinite_relaxation.cc
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <functional>
 #include <initializer_list>
-#include <iostream>
 #include <limits>
 #include <map>
 #include <optional>
@@ -29,7 +28,10 @@ using symbolic::Variables;
 namespace {
 
 const double kInf = std::numeric_limits<double>::infinity();
+// TODO(Alexandre.Amice) Move all these methods to
+// semidefinite_relaxation_internal
 
+// Validate that we can compute the semidefinite relaxation of prog.
 void ValidateProgramIsSupported(const MathematicalProgram& prog) {
   std::string unsupported_message{};
   const ProgramAttributes supported_attributes(
@@ -47,8 +49,9 @@ void ValidateProgramIsSupported(const MathematicalProgram& prog) {
   }
 }
 
-bool CheckProgramRequireSemidefiniteRelaxation(
-    const MathematicalProgram& prog) {
+// Check whether the program prog has any non-convex quadratic costs or
+// constraints.
+bool CheckProgramHasNonConvexQuadratics(const MathematicalProgram& prog) {
   return std::any_of(prog.quadratic_costs().begin(),
                      prog.quadratic_costs().end(),
                      [](const auto& cost) {
@@ -61,72 +64,39 @@ bool CheckProgramRequireSemidefiniteRelaxation(
                      });
 }
 
-// Constructs the semidefinite relaxation of the program prog and adds it to
-// relaxation. We assume that the program attributes of prog are already
-// validated and that relaxation already contains all the variables and
-// constraints of prog. The variable one is already constrained to be equal to
-// one. This is passed so it can be re-used across semidefinite variables in the
-// sparse version of MakeSemidefiniteRelaxation. Returns the X matrix of the
-// semidefinite relaxation.
-MatrixXDecisionVariable DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(
-    const MathematicalProgram& prog, const Variable& one,
-    MathematicalProgram* relaxation,
-    std::optional<int> group_number = std::nullopt) {
-  // Build a symmetric matrix X of decision variables using the original
-  // program variables (so that GetSolution, etc, works using the original
-  // variables).
-  relaxation->AddDecisionVariables(prog.decision_variables());
-  MatrixX<Variable> X(prog.num_vars() + 1, prog.num_vars() + 1);
-  // X = xxᵀ; x = [prog.decision_vars(); 1].
-  std::string name =
-      group_number.has_value() ? fmt::format("Y{}", group_number.value()) : "Y";
-  X.topLeftCorner(prog.num_vars(), prog.num_vars()) =
-      relaxation->NewSymmetricContinuousVariables(prog.num_vars(), name);
-  // We sort the variables so that the matrix X is ordered in a predictable way.
-  // This makes it easier when using the sparsity groups to make the
-  // semidefinite matrices agree.
-  VectorX<Variable> sorted_variables = prog.decision_variables();
-  std::sort(sorted_variables.data(),
-            sorted_variables.data() + sorted_variables.size(),
-            std::less<Variable>{});
-  X.topRightCorner(prog.num_vars(), 1) = sorted_variables;
-  X.bottomLeftCorner(1, prog.num_vars()) = sorted_variables.transpose();
-
-  std::map<Variable, int> variables_to_sorted_indices;
-  int ctr = 0;
-  for (const auto& v : sorted_variables) {
-    variables_to_sorted_indices[v] = ctr++;
+// Given a mapping from decision variables in a program to indices, return all
+// the indices corresponding to the variable vars. This method is useful as in
+// DoMakeSemidefiniteRelaxation, we sort the decision variables in the
+// semidefinite variables (and hence the implied constraints).s
+std::vector<int> FindDecisionVariableIndices(
+    const std::map<Variable, int>& variables_to_sorted_indices,
+    const VectorXDecisionVariable& vars) {
+  std::vector<int> indices;
+  indices.reserve(vars.rows());
+  for (const auto& v : vars) {
+    indices.emplace_back(variables_to_sorted_indices.at(v));
   }
-  // We create a new map mapping decision variables to the sorted variables,
-  // since prog.FindDecisionVariableIndices would now find the wrong index for
-  // our needs.
-  auto FindDecisionVariableIndices =
-      [&variables_to_sorted_indices](const VectorXDecisionVariable& vars) {
-        std::vector<int> indices;
-        indices.reserve(vars.rows());
-        for (const auto& v : vars) {
-          indices.emplace_back(variables_to_sorted_indices.at(v));
-        }
-        return indices;
-      };
+  return indices;
+}
 
-  // X(-1,-1) = 1.
-  X(prog.num_vars(), prog.num_vars()) = one;
-
-  // X ≽ 0.
-  relaxation->AddPositiveSemidefiniteConstraint(X);
-
-  auto x = X.col(prog.num_vars());
-
+// Iterate over the quadratic costs and constraints in prog, remove them if
+// present in the relaxation, and add an equivalent linear cost or constraint on
+// the semidefinite variable X. The map variables_to_sorted_indices maps the
+// decision variables in prog to their index in the last column of X.
+void DoLinearizeQuadraticCostsAndConstraints(
+    const MathematicalProgram& prog, const MatrixXDecisionVariable& X,
+    const std::map<Variable, int>& variables_to_sorted_indices,
+    MathematicalProgram* relaxation) {
   // Returns the {a, vars} in relaxation, such that a' vars = 0.5*tr(QY). This
   // assumes Q=Q', which is ensured by QuadraticCost and QuadraticConstraint.
-  auto half_trace_QY = [&X, &FindDecisionVariableIndices](
+  auto half_trace_QY = [&X, &variables_to_sorted_indices](
                            const Eigen::MatrixXd& Q,
-                           const VectorXDecisionVariable& prog_vars)
+                           const VectorXDecisionVariable& binding_vars)
       -> std::pair<VectorXd, VectorX<Variable>> {
-    const int N = prog_vars.size();
+    const int N = binding_vars.size();
     const int num_vars = N * (N + 1) / 2;
-    const std::vector<int> indices = FindDecisionVariableIndices(prog_vars);
+    const std::vector<int> indices =
+        FindDecisionVariableIndices(variables_to_sorted_indices, binding_vars);
 
     VectorXd a = VectorXd::Zero(num_vars);
     VectorX<Variable> y(num_vars);
@@ -175,120 +145,129 @@ MatrixXDecisionVariable DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(
                                     binding.evaluator()->lower_bound(),
                                     binding.evaluator()->upper_bound(), vars);
   }
+}
 
-  // Now add the implied linear constraints.
-  {
-    // Now assemble one big Ay <= b matrix from all bounding box constraints
-    // and linear constraints
-    // TODO(bernhardpg): Consider special-casing linear equality constraints
-    // that are added as bounding box or linear constraints with lb == ub
-    int num_constraints = 0;
-    int nnz = 0;
-    for (const auto& binding : prog.bounding_box_constraints()) {
-      for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
-        if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
-          ++num_constraints;
-        }
-        if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
-          ++num_constraints;
-        }
+// Aggregate all the finite linear constraints in the program into a single
+// expression Ay ≤ b, which can be expressed as [A, -b][y; 1] ≤ 0.
+// We add the implied linear constraint [A,-b]X[A,-b]ᵀ ≤ 0 on the variable X to
+// the relaxation. The map variables_to_sorted_indices maps the
+// decision variables in prog to their index in the last column of X.
+void DoAddImpliedLinearConstraints(
+    const MathematicalProgram& prog, const MatrixXDecisionVariable& X,
+    const std::map<Variable, int>& variables_to_sorted_indices,
+    MathematicalProgram* relaxation) {
+  // Assemble one big Ay <= b matrix from all bounding box constraints
+  // and linear constraints
+  // TODO(bernhardpg): Consider special-casing linear equality constraints
+  // that are added as bounding box or linear constraints with lb == ub
+  int num_constraints = 0;
+  int nnz = 0;
+  for (const auto& binding : prog.bounding_box_constraints()) {
+    for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
+      if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
+        ++num_constraints;
       }
-      nnz += binding.evaluator()->get_sparse_A().nonZeros();
-    }
-    for (const auto& binding : prog.linear_constraints()) {
-      for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
-        if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
-          ++num_constraints;
-        }
-        if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
-          ++num_constraints;
-        }
-      }
-      nnz += binding.evaluator()->get_sparse_A().nonZeros();
-    }
-
-    std::vector<Triplet<double>> A_triplets;
-    A_triplets.reserve(nnz);
-    SparseMatrix<double> A(num_constraints, prog.num_vars());
-    VectorXd b(num_constraints);
-
-    int constraint_idx = 0;
-    for (const auto& binding : prog.bounding_box_constraints()) {
-      const std::vector<int> indices =
-          FindDecisionVariableIndices(binding.variables());
-      for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
-        if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
-          A_triplets.push_back(
-              Triplet<double>(constraint_idx, indices[i], -1.0));
-          b(constraint_idx++) = -binding.evaluator()->lower_bound()[i];
-        }
-        if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
-          A_triplets.push_back(
-              Triplet<double>(constraint_idx, indices[i], 1.0));
-          b(constraint_idx++) = binding.evaluator()->upper_bound()[i];
-        }
+      if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
+        ++num_constraints;
       }
     }
-
-    for (const auto& binding : prog.linear_constraints()) {
-      const std::vector<int> indices =
-          FindDecisionVariableIndices(binding.variables());
-      // TODO(hongkai-dai): Consider using the SparseMatrix iterators.
-      for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
-        if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
-          for (int j = 0; j < binding.evaluator()->num_vars(); ++j) {
-            if (binding.evaluator()->get_sparse_A().coeff(i, j) != 0) {
-              A_triplets.push_back(Triplet<double>(
-                  constraint_idx, indices[j],
-                  -binding.evaluator()->get_sparse_A().coeff(i, j)));
-            }
-          }
-          b(constraint_idx++) = -binding.evaluator()->lower_bound()[i];
-        }
-        if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
-          for (int j = 0; j < binding.evaluator()->num_vars(); ++j) {
-            if (binding.evaluator()->get_sparse_A().coeff(i, j) != 0) {
-              A_triplets.push_back(Triplet<double>(
-                  constraint_idx, indices[j],
-                  binding.evaluator()->get_sparse_A().coeff(i, j)));
-            }
-          }
-          b(constraint_idx++) = binding.evaluator()->upper_bound()[i];
-        }
+    nnz += binding.evaluator()->get_sparse_A().nonZeros();
+  }
+  for (const auto& binding : prog.linear_constraints()) {
+    for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
+      if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
+        ++num_constraints;
+      }
+      if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
+        ++num_constraints;
       }
     }
-    A.setFromTriplets(A_triplets.begin(), A_triplets.end());
-
-    // 0 ≤ (Ay-b)(Ay-b)ᵀ, implemented with
-    // -bbᵀ ≤ AYAᵀ - b(Ay)ᵀ - (Ay)bᵀ.
-    // TODO(russt): Avoid the symbolic computation here.
-    // TODO(russt): Avoid the dense matrix.
-    const MatrixX<Expression> AYAT =
-        A * X.topLeftCorner(prog.num_vars(), prog.num_vars()) * A.transpose();
-    std::cout << fmt::format(
-                     "X.topLeftCorner(prog.num_vars(), prog.num_vars())=\n{}",
-                     fmt_eigen(
-                         X.topLeftCorner(prog.num_vars(), prog.num_vars())))
-              << std::endl;
-    const VectorX<Variable> y = x.head(prog.num_vars());
-
-    const VectorX<Expression> rhs_flat_tril =
-        math::ToLowerTriangularColumnsFromMatrix(
-            AYAT - b * (A * y).transpose() - A * y * b.transpose());
-    const VectorXd bbT_flat_tril =
-        math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
-
-    relaxation->AddLinearConstraint(
-        rhs_flat_tril, bbT_flat_tril,
-        VectorXd::Constant(bbT_flat_tril.size(), kInf));
+    nnz += binding.evaluator()->get_sparse_A().nonZeros();
   }
 
+  std::vector<Triplet<double>> A_triplets;
+  A_triplets.reserve(nnz);
+  SparseMatrix<double> A(num_constraints, prog.num_vars());
+  VectorXd b(num_constraints);
+
+  int constraint_idx = 0;
+  for (const auto& binding : prog.bounding_box_constraints()) {
+    const std::vector<int> indices = FindDecisionVariableIndices(
+        variables_to_sorted_indices, binding.variables());
+    for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
+      if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
+        A_triplets.push_back(Triplet<double>(constraint_idx, indices[i], -1.0));
+        b(constraint_idx++) = -binding.evaluator()->lower_bound()[i];
+      }
+      if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
+        A_triplets.push_back(Triplet<double>(constraint_idx, indices[i], 1.0));
+        b(constraint_idx++) = binding.evaluator()->upper_bound()[i];
+      }
+    }
+  }
+
+  for (const auto& binding : prog.linear_constraints()) {
+    const std::vector<int> indices = FindDecisionVariableIndices(
+        variables_to_sorted_indices, binding.variables());
+    // TODO(hongkai-dai): Consider using the SparseMatrix iterators.
+    for (int i = 0; i < binding.evaluator()->num_constraints(); ++i) {
+      if (std::isfinite(binding.evaluator()->lower_bound()[i])) {
+        for (int j = 0; j < binding.evaluator()->num_vars(); ++j) {
+          if (binding.evaluator()->get_sparse_A().coeff(i, j) != 0) {
+            A_triplets.push_back(Triplet<double>(
+                constraint_idx, indices[j],
+                -binding.evaluator()->get_sparse_A().coeff(i, j)));
+          }
+        }
+        b(constraint_idx++) = -binding.evaluator()->lower_bound()[i];
+      }
+      if (std::isfinite(binding.evaluator()->upper_bound()[i])) {
+        for (int j = 0; j < binding.evaluator()->num_vars(); ++j) {
+          if (binding.evaluator()->get_sparse_A().coeff(i, j) != 0) {
+            A_triplets.push_back(Triplet<double>(
+                constraint_idx, indices[j],
+                binding.evaluator()->get_sparse_A().coeff(i, j)));
+          }
+        }
+        b(constraint_idx++) = binding.evaluator()->upper_bound()[i];
+      }
+    }
+  }
+  A.setFromTriplets(A_triplets.begin(), A_triplets.end());
+
+  // 0 ≤ (Ay-b)(Ay-b)ᵀ, implemented with
+  // -bbᵀ ≤ AYAᵀ - b(Ay)ᵀ - (Ay)bᵀ.
+  // TODO(russt): Avoid the symbolic computation here.
+  // TODO(russt): Avoid the dense matrix.
+  const MatrixX<Expression> AYAT =
+      A * X.topLeftCorner(prog.num_vars(), prog.num_vars()) * A.transpose();
+  const VectorX<Variable> y = X.col(prog.num_vars()).head(prog.num_vars());
+
+  const VectorX<Expression> rhs_flat_tril =
+      math::ToLowerTriangularColumnsFromMatrix(AYAT - b * (A * y).transpose() -
+                                               A * y * b.transpose());
+  const VectorXd bbT_flat_tril =
+      math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
+
+  relaxation->AddLinearConstraint(
+      rhs_flat_tril, bbT_flat_tril,
+      VectorXd::Constant(bbT_flat_tril.size(), kInf));
+}
+
+// For every equality constraint Ay = b in prog, add the implied linear equality
+// constraint [A, -b]X = 0 on the semidefinite relaxation variable X to the
+// relaxation. The map variables_to_sorted_indices maps the decision variables
+// in prog to their index in the last column of X.
+void DoAddImpliedLinearEqualityConstraints(
+    const MathematicalProgram& prog, const MatrixXDecisionVariable& X,
+    const std::map<Variable, int>& variables_to_sorted_indices,
+    MathematicalProgram* relaxation) {
   // Linear equality constraints.
   // Ay = b => (Ay-b)yᵀ = Ayyᵀ - byᵀ = 0.
   for (const auto& binding : prog.linear_equality_constraints()) {
     const int N = binding.variables().size();
-    const std::vector<int> indices =
-        FindDecisionVariableIndices(binding.variables());
+    const std::vector<int> indices = FindDecisionVariableIndices(
+        variables_to_sorted_indices, binding.variables());
     VectorX<Variable> vars(N + 1);
     // Add the constraints one column at a time:
     // Ayx_j - bx_j = 0.
@@ -297,18 +276,68 @@ MatrixXDecisionVariable DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(
     Ab.leftCols(N) = binding.evaluator()->GetDenseA();
     Ab.col(N) = -binding.evaluator()->lower_bound();
     // We don't need to do the last column of X.
-    for (int j = 0; j < static_cast<int>(x.size()) - 1; ++j) {
+    for (int j = 0; j < static_cast<int>(X.cols()) - 1; ++j) {
       for (int i = 0; i < N; ++i) {
         vars[i] = X(indices[i], j);
       }
-      vars[N] = x[j];
+      vars[N] = X(prog.num_vars(), j);
       relaxation->AddLinearEqualityConstraint(
           Ab, VectorXd::Zero(binding.evaluator()->num_constraints()), vars);
     }
   }
-  return X;
 }
 
+// Constructs the semidefinite relaxation of the program prog and adds it to
+// relaxation. We assume that the program attributes of prog are already
+// validated and that relaxation already contains all the variables and
+// constraints of prog. The variable one is already constrained to be equal to
+// one. This is passed so it can be re-used across semidefinite variables in the
+// sparse version of MakeSemidefiniteRelaxation. Returns the X matrix of the
+// semidefinite relaxation.
+MatrixXDecisionVariable DoMakeSemidefiniteRelaxation(
+    const MathematicalProgram& prog, const Variable& one,
+    MathematicalProgram* relaxation,
+    std::optional<int> group_number = std::nullopt) {
+  // Build a symmetric matrix X of decision variables using the original
+  // program variables (so that GetSolution, etc, works using the original
+  // variables).
+  relaxation->AddDecisionVariables(prog.decision_variables());
+  MatrixX<Variable> X(prog.num_vars() + 1, prog.num_vars() + 1);
+  // X = xxᵀ; x = [prog.decision_vars(); 1].
+  std::string name =
+      group_number.has_value() ? fmt::format("Y{}", group_number.value()) : "Y";
+  X.topLeftCorner(prog.num_vars(), prog.num_vars()) =
+      relaxation->NewSymmetricContinuousVariables(prog.num_vars(), name);
+  // We sort the variables so that the matrix X is ordered in a predictable way.
+  // This makes it easier when using the sparsity groups to make the
+  // semidefinite matrices agree.
+  VectorX<Variable> sorted_variables = prog.decision_variables();
+  std::sort(sorted_variables.data(),
+            sorted_variables.data() + sorted_variables.size(),
+            std::less<Variable>{});
+  X.topRightCorner(prog.num_vars(), 1) = sorted_variables;
+  X.bottomLeftCorner(1, prog.num_vars()) = sorted_variables.transpose();
+
+  std::map<Variable, int> variables_to_sorted_indices;
+  int ctr = 0;
+  for (const auto& v : sorted_variables) {
+    variables_to_sorted_indices[v] = ctr++;
+  }
+
+  // X(-1,-1) = 1.
+  X(prog.num_vars(), prog.num_vars()) = one;
+
+  // X ≽ 0.
+  relaxation->AddPositiveSemidefiniteConstraint(X);
+
+  DoLinearizeQuadraticCostsAndConstraints(prog, X, variables_to_sorted_indices,
+                                          relaxation);
+  DoAddImpliedLinearConstraints(prog, X, variables_to_sorted_indices,
+                                relaxation);
+  DoAddImpliedLinearEqualityConstraints(prog, X, variables_to_sorted_indices,
+                                        relaxation);
+  return X;
+}
 }  // namespace
 
 std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
@@ -318,8 +347,7 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
   const Variable one("one");
   relaxation->AddDecisionVariables(Vector1<Variable>(one));
   relaxation->AddLinearEqualityConstraint(one, 1);
-  DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(prog, one,
-                                                         relaxation.get());
+  DoMakeSemidefiniteRelaxation(prog, one, relaxation.get());
   return relaxation;
 }
 
@@ -372,15 +400,14 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
   int group_number = 0;
   for (const auto& [group, container_program] : groups_to_container_programs) {
     groups_to_psd_variables.emplace(
-        group, DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(
-                   container_program, one, relaxation.get(), group_number));
+        group, DoMakeSemidefiniteRelaxation(container_program, one,
+                                            relaxation.get(), group_number));
     ++group_number;
   }
 
   // Now constrain the semidefinite variables to agree where they overlap.
   for (auto it = groups_to_psd_variables.begin();
        it != groups_to_psd_variables.end(); it++) {
-    std::cout << fmt::format("X={}\n", fmt_eigen(it->second)) << std::endl;
     for (auto it2 = std::next(it); it2 != groups_to_psd_variables.end();
          it2++) {
       const Variables common_variables = intersect(it->first, it2->first);
@@ -405,7 +432,7 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     }
   }
 
-  if (CheckProgramRequireSemidefiniteRelaxation(*relaxation)) {
+  if (CheckProgramHasNonConvexQuadratics(*relaxation)) {
     throw std::runtime_error(
         "There is a non-convex cost or constraint in the program whose "
         "variables do not overlap with any variable groups. Therefore, these "

--- a/solvers/semidefinite_relaxation.cc
+++ b/solvers/semidefinite_relaxation.cc
@@ -29,7 +29,7 @@ namespace {
 
 const double kInf = std::numeric_limits<double>::infinity();
 // TODO(AlexandreAmice) Move all these methods to
-// semidefinite_relaxation_internal
+// semidefinite_relaxation_internal.
 
 // Validate that we can compute the semidefinite relaxation of prog.
 void ValidateProgramIsSupported(const MathematicalProgram& prog) {
@@ -319,9 +319,9 @@ MatrixXDecisionVariable DoMakeSemidefiniteRelaxation(
   X.bottomLeftCorner(1, prog.num_vars()) = sorted_variables.transpose();
 
   std::map<Variable, int> variables_to_sorted_indices;
-  int ctr = 0;
+  int i = 0;
   for (const auto& v : sorted_variables) {
-    variables_to_sorted_indices[v] = ctr++;
+    variables_to_sorted_indices[v] = i++;
   }
 
   // X(-1,-1) = 1.
@@ -415,12 +415,12 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
 
   // Now constrain the semidefinite variables to agree where they overlap.
   for (auto it = groups_to_psd_variables.begin();
-       it != groups_to_psd_variables.end(); it++) {
+       it != groups_to_psd_variables.end(); ++it) {
     for (auto it2 = std::next(it); it2 != groups_to_psd_variables.end();
-         it2++) {
+         ++it2) {
       const Variables common_variables = intersect(it->first, it2->first);
       if (!common_variables.empty()) {
-        auto GetSubmatrixOfVariables =
+        auto get_submatrix_of_variables =
             [&common_variables](const MatrixXDecisionVariable& X) {
               std::set<int> submatrix_indices;
               for (const auto& v : common_variables) {
@@ -434,8 +434,8 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
               return math::ExtractPrincipalSubmatrix(X, submatrix_indices);
             };
         relaxation->AddLinearEqualityConstraint(
-            GetSubmatrixOfVariables(it->second) ==
-            GetSubmatrixOfVariables(it2->second));
+            get_submatrix_of_variables(it->second) ==
+            get_submatrix_of_variables(it2->second));
       }
     }
   }

--- a/solvers/semidefinite_relaxation.cc
+++ b/solvers/semidefinite_relaxation.cc
@@ -316,7 +316,7 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
 
 std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     const MathematicalProgram& prog,
-    std::vector<symbolic::Variables> variable_groups) {
+    const std::vector<symbolic::Variables>& variable_groups) {
   auto relaxation = prog.Clone();
   std::map<symbolic::Variables, solvers::MathematicalProgram>
       groups_to_container_programs;

--- a/solvers/semidefinite_relaxation.cc
+++ b/solvers/semidefinite_relaxation.cc
@@ -110,6 +110,9 @@ MatrixXDecisionVariable DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(
   relaxation->AddDecisionVariables(Vector1<Variable>(one));
   relaxation->AddLinearEqualityConstraint(X(prog.num_vars(), prog.num_vars()),
                                           1);
+  std::cout << fmt::format("relaxation has {} linear equality constraints",
+                               relaxation->linear_equality_constraints().size())
+                << std::endl;
 
   // X ≽ 0.
   relaxation->AddPositiveSemidefiniteConstraint(X);
@@ -290,6 +293,9 @@ MatrixXDecisionVariable DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(
     Ab.leftCols(N) = binding.evaluator()->GetDenseA();
     Ab.col(N) = -binding.evaluator()->lower_bound();
     // We don't need to do the last column of X.
+    std::cout << "ADDING {} equality constraints = "
+              << static_cast<int>(x.size()) - 1 << std::endl;
+    std::cout << fmt::format("x =  {} ", fmt_eigen(x)) << std::endl;
     for (int j = 0; j < static_cast<int>(x.size()) - 1; ++j) {
       for (int i = 0; i < N; ++i) {
         vars[i] = X(indices[i], j);
@@ -297,6 +303,9 @@ MatrixXDecisionVariable DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(
       vars[N] = x[j];
       relaxation->AddLinearEqualityConstraint(
           Ab, VectorXd::Zero(binding.evaluator()->num_constraints()), vars);
+      std::cout << fmt::format("relaxation has {} linear equality constraints",
+                               relaxation->linear_equality_constraints().size())
+                << std::endl;
     }
   }
   return X;
@@ -317,6 +326,9 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     const MathematicalProgram& prog,
     std::vector<symbolic::Variables> variable_groups) {
   auto relaxation = prog.Clone();
+  std::cout << fmt::format("relaxation after CLONE has {} linear equality constraints",
+                               relaxation->linear_equality_constraints().size())
+                << std::endl;
   std::map<symbolic::Variables, solvers::MathematicalProgram>
       groups_to_container_programs;
   std::map<symbolic::Variables, symbolic::Variables> groups_to_superset;
@@ -373,10 +385,10 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
           groups_to_superset.at(group),
           DoAddSemidefiniteVariableAndImpliedCostsAndConstraints(
               container_program, relaxation.get(), group_number));
-            std::cout << fmt::format("X=\n{}",
-                                     fmt_eigen(supersets_to_psd_variables.at(
-                                         groups_to_superset.at(group))))
-                      << std::endl;
+      std::cout << fmt::format("X=\n{}",
+                               fmt_eigen(supersets_to_psd_variables.at(
+                                   groups_to_superset.at(group))))
+                << std::endl;
     }
     ++group_number;
   }
@@ -404,6 +416,9 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
         relaxation->AddLinearEqualityConstraint(
             GetSubmatrixOfVariables(it->second) ==
             GetSubmatrixOfVariables(it2->second));
+        std::cout << fmt::format("relaxation has {} linear equality constraints",
+                               relaxation->linear_equality_constraints().size())
+                << std::endl;
       }
     }
   }

--- a/solvers/semidefinite_relaxation.cc
+++ b/solvers/semidefinite_relaxation.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 #include "drake/math/matrix_util.h"
 #include "drake/solvers/program_attribute.h"

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -44,6 +44,9 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
  * single program, and their semidefinite variables are made to agree where the
  * variable groups overlap.
  *
+ * The returned program will always have the same number of PSD variables as
+ * variable groups.
+ *
  * Costs and constraints whose variables are not a subset of any of the groups
  * are not relaxed and are simply added to the aggregated program. If these
  * costs and constraints are non-convex, then this method will throw.

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "drake/solvers/mathematical_program.h"
 
@@ -30,6 +31,17 @@ namespace solvers {
  */
 std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     const MathematicalProgram& prog);
+
+/** Constructs a new MathematicalProgram which represents the semidefinite
+ * programming convex relaxation of the (likely nonconvex) program `prog`.
+ *
+ * @param prog
+ * @param variable_groups
+ * @return
+ */
+std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
+    const MathematicalProgram& prog,
+    std::vector<symbolic::Variables> variable_groups);
 
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -35,8 +35,20 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
 /** Constructs a new MathematicalProgram which represents the semidefinite
  * programming convex relaxation of the (likely nonconvex) program `prog`.
  *
+ * For each group in @p variable groups , this method will jointly relax into a
+ * semidefinite program all the costs and constraints whose variables intersect
+ * with the group. Each of these semidefinite relaxations are aggregated into a
+ * single program, and their semidefinite variables are made to agree where they
+ * overlap.
+ *
+ * Costs and constraints whose variables do not overlap with any of the groups
+ * are not relaxed and are simply added to the aggregated program. If these
+ * costs and constraints are non-convex, then this method will throw.
+ *
  * @param prog
  * @param variable_groups
+ * @throw Runtime error if there is a non-convex cost or constraint whose
+ * variables do not intersect with any of the variable groups.
  * @return
  */
 std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -35,7 +35,7 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
 /** A version of MakeSemidefiniteRelaxation that allows for specifying the
  * sparsity of the relaxation.
  *
- * For each group in @p variable group, the costs and constraints whose
+ * For each group in @p variable_groups, the costs and constraints whose
  * variables are a subset of the group will be jointly relaxed into a single,
  * dense semidefinite program in the same manner as
  * MakeSemidefiniteRelaxation(prog).
@@ -49,7 +49,7 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
  *
  * Costs and constraints whose variables are not a subset of any of the groups
  * are not relaxed and are simply added to the aggregated program. If these
- * costs and constraints are non-convex, then this method will throw
+ * costs and constraints are non-convex, then this method will throw.
  *
  * As an example, consider the following program.
  * min x₂ᵀ * Q * x₂ subject to

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -48,11 +48,8 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
  * are not relaxed and are simply added to the aggregated program. If these
  * costs and constraints are non-convex, then this method will throw.
  *
- * @param prog
- * @param variable_groups
- * @throw Runtime error if there is a non-convex cost or constraint whose
+ * @throw std::exception if there is a non-convex cost or constraint whose
  * variables do not intersect with any of the variable groups.
- * @return
  */
 std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     const MathematicalProgram& prog,

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -64,12 +64,21 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
  * [U₁,  U₂,  x₁]   [W₁,  W₂, x₂]
  * [U₂,  U₃,  x₂],  [W₂,  W₃, x₃]
  * [x₁ᵀ, x₂ᵀ,  1]   [x₂ᵀ, x₃ᵀ, 1]
+ *
  * The first semidefinite variable would be associated to the semidefinite
  * relaxation of the subprogram:
  * min x₁ᵀ * Q * x₁ subject to
  * x₁ + x₂ ≤ 1
  * And the implied constraints from x₁ + x₂ ≤ 1 would be added to the first
- * semidefinite variable.
+ * semidefinite variable. These implied constraints are additional constraints
+ * that can be placed on the matrix
+ * [U₁,  U₂,  x₁]
+ * [U₂,  U₃,  x₂]
+ * [x₁ᵀ, x₂ᵀ,  1]
+ * which are redundant in the non-convex program, but are not redundant in the
+ * semidefinite relaxation. See
+ * https://underactuated.mit.edu/optimization.html#sdp_relaxation for references
+ * and examples.
  *
  * The second semidefinite variable would be associated to the semidefinite
  * relaxation of the subprogram:
@@ -82,7 +91,7 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
  * groups, it will be added to the overall relaxation, but will not be used to
  * generate implied constraints on any semidefinite variable.
  *
- * The total relaxation would also include an equality constraint that U₃ == W₃
+ * The total relaxation would also include an equality constraint that U₃ == W₁
  * so that the quadratic relaxation of x₂ is consistent between the two
  * semidefinite variables.
  *

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -35,11 +35,14 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
 /** Constructs a new MathematicalProgram which represents the semidefinite
  * programming convex relaxation of the (likely nonconvex) program `prog`.
  *
- * For each group in @p variable groups , this method will jointly relax into a
+ * For each group in @p variable groups, this method will jointly relax into a
  * semidefinite program all the costs and constraints whose variables intersect
  * with the group. Each of these semidefinite relaxations are aggregated into a
  * single program, and their semidefinite variables are made to agree where they
  * overlap.
+ *
+ * If a variable group does not intersect any of the costs and constraints, a
+ * semidefinite variable is not created for these variables.
  *
  * Costs and constraints whose variables do not overlap with any of the groups
  * are not relaxed and are simply added to the aggregated program. If these
@@ -53,7 +56,7 @@ std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
  */
 std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     const MathematicalProgram& prog,
-    std::vector<symbolic::Variables> variable_groups);
+    const std::vector<symbolic::Variables>& variable_groups);
 
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -32,19 +32,19 @@ namespace solvers {
 std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     const MathematicalProgram& prog);
 
-/** Constructs a new MathematicalProgram which represents the semidefinite
- * programming convex relaxation of the (likely nonconvex) program `prog`.
+/** A version of MakeSemidefiniteRelaxation that allows for specifying the
+ * sparsity of the relaxation.
  *
- * For each group in @p variable groups, this method will jointly relax into a
- * semidefinite program all the costs and constraints whose variables intersect
- * with the group. Each of these semidefinite relaxations are aggregated into a
- * single program, and their semidefinite variables are made to agree where they
- * overlap.
+ * For each group in @p variable group, the costs and constraints whose
+ * variables are a subset of the group will be jointly relaxed into a single,
+ * dense semidefinite program in the same manner as
+ * MakeSemidefiniteRelaxation(prog).
  *
- * If a variable group does not intersect any of the costs and constraints, a
- * semidefinite variable is not created for these variables.
+ * Each of these semidefinite relaxations are aggregated into a
+ * single program, and their semidefinite variables are made to agree where the
+ * variable groups overlap.
  *
- * Costs and constraints whose variables do not overlap with any of the groups
+ * Costs and constraints whose variables are not a subset of any of the groups
  * are not relaxed and are simply added to the aggregated program. If these
  * costs and constraints are non-convex, then this method will throw.
  *

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -48,8 +48,6 @@ void SetRelaxationInitialGuess(std::map<Variable, double> expected_values,
     }
     x_expected(n - 1) = 1;
     const MatrixXd X_expected = x_expected * x_expected.transpose();
-    std::cout << fmt::format("X_expected =\n{}", fmt_eigen(X_expected))
-              << std::endl;
     relaxation->SetInitialGuess(X_var, X_expected);
   }
 }
@@ -490,6 +488,9 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest,
                 .evaluator()
                 ->matrix_rows(),
             3);
+  // No costs are added.
+  EXPECT_EQ(relaxation->linear_costs().size(), 0);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 0);
 
   const std::map<Variable, double> test_point{
       {x_(0), 1.1}, {x_(1), 0.24}, {x_(2), -2.2}, {y_(0), -0.7}, {y_(1), -3.1}};
@@ -512,14 +513,15 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest,
   Eigen::MatrixXd X1_y0_y1(2, 2);
   // clang-format off
   X0_y0_y1 << relaxation->GetInitialGuess(X0(1, 1)),
-              relaxation->GetInitialGuess(X0(1, 2)),
-              relaxation->GetInitialGuess(X0(1, 2)),
-              relaxation->GetInitialGuess(X0(2, 2));
+      relaxation->GetInitialGuess(X0(1, 2)),
+      relaxation->GetInitialGuess(X0(1, 2)),
+      relaxation->GetInitialGuess(X0(2, 2));
 
   X1_y0_y1 << relaxation->GetInitialGuess(X1(0, 0)),
-              relaxation->GetInitialGuess(X1(0, 1)),
-              relaxation->GetInitialGuess(X1(0, 1)),
-              relaxation->GetInitialGuess(X1(1, 1));
+      relaxation->GetInitialGuess(X1(0, 1)),
+      relaxation->GetInitialGuess(X1(0, 1)),
+      relaxation->GetInitialGuess(X1(1, 1));
+  // clang-format on
   EXPECT_TRUE(CompareMatrices(X0_y0_y1, X1_y0_y1));
   const Variables overlap_variables{X0(1, 1), X0(1, 2), X0(2, 2),
                                     X1(0, 0), X1(0, 1), X1(1, 1)};
@@ -528,10 +530,9 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest,
                               Eigen::Vector3d::Zero()));
 }
 
- TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearCost) {
+TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearCost) {
   const std::map<Variable, double> test_point{
-      {x_(0), 1.1}, {x_(1), 0.24}, {x_(2), -2.2}, {y_(0), -0.7}, {y_(1),
-      -3.1}};
+      {x_(0), 1.1}, {x_(1), 0.24}, {x_(2), -2.2}, {y_(0), -0.7}, {y_(1), -3.1}};
 
   prog_.AddLinearCost(x_[0] + x_[2] + y_[1]);
 
@@ -544,50 +545,59 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest,
   // variables that do not get relaxed are [y(0), y(1)]. So there are (5
   // choose 2) + 2 variables in the program.
   EXPECT_EQ(relaxation->num_vars(), 2 + NChoose2(5));
-  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(),
-            1);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
   EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
                 .evaluator()
                 ->matrix_rows(),
             4);
   EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1);
   EXPECT_EQ(relaxation->GetAllConstraints().size(), 2);
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
   SetRelaxationInitialGuess(test_point, relaxation.get());
-  EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
-                  relaxation->linear_costs()[0])[0],
-              test_point.at(x_(0)) + test_point.at(x_(2)) + test_point.at(y_(1)), 1e-12);
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(relaxation->linear_costs()[0])[0],
+      test_point.at(x_(0)) + test_point.at(x_(2)) + test_point.at(y_(1)),
+      1e-12);
 
-  // Relax an overlapping set of variables which both have the cost as a subset. The cost should only be added once.
+  // Relax an overlapping set of variables which both have the cost as a subset.
+  // The cost should only be added once.
   const Variables x_vars_plus_y1{x_(0), x_(1), x_(2), y_(1)};
-  relaxation = MakeSemidefiniteRelaxation(prog_, std::vector<Variables>{x_vars_plus_y1, x0_x2_y1_vars_});
+  relaxation = MakeSemidefiniteRelaxation(
+      prog_, std::vector<Variables>{x_vars_plus_y1, x0_x2_y1_vars_});
 
   EXPECT_EQ(relaxation->linear_costs().size(), 1);
   EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
-  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and [x(0), x(2), y(1), 1]. The remaining
-  // variable that does not get relaxed is [y(0)]. So there are (6 choose 2) + (5 choose 2) + 1 - 4 variables in the program.
+  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and [x(0),
+  // x(2), y(1), 1]. The remaining variable that does not get relaxed is [y(0)].
+  // So there are (6 choose 2) + (5 choose 2) + 1 - 4 variables in the program.
   EXPECT_EQ(relaxation->num_vars(), NChoose2(6) + NChoose2(5) + 1 - 4);
   EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
                 .evaluator()
-                ->matrix_rows(), 5);
+                ->matrix_rows(),
+            5);
   EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
                 .evaluator()
-                ->matrix_rows(), 4);
+                ->matrix_rows(),
+            4);
   EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
   EXPECT_EQ(relaxation->linear_equality_constraints().size(), 2);
   EXPECT_EQ(relaxation->GetAllConstraints().size(), 4);
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
 
   SetRelaxationInitialGuess(test_point, relaxation.get());
-  EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
-                  relaxation->linear_costs()[0])[0],
-             test_point.at(x_(0)) + test_point.at(x_(2)) + test_point.at(y_(1)), 1e-12);
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(relaxation->linear_costs()[0])[0],
+      test_point.at(x_(0)) + test_point.at(x_(2)) + test_point.at(y_(1)),
+      1e-12);
 }
 
- TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticCost) {
+TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticCost) {
   const std::map<Variable, double> test_point{
-      {x_(0), 0.1}, {x_(1), -3.24}, {x_(2), 4.2}, {y_(0), -1.7}, {y_(1),
-      -7.7}};
+      {x_(0), 0.1}, {x_(1), -3.24}, {x_(2), 4.2}, {y_(0), -1.7}, {y_(1), -7.7}};
 
-  prog_.AddQuadraticCost(x_[0] * x_[1]);
+  auto cost = prog_.AddQuadraticCost(x_[0] * x_[1]);
 
   // Only relaxes the x_ variables.
   auto relaxation =
@@ -598,797 +608,763 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest,
   // variables that do not get relaxed are [y(0), y(1)]. So there are (5
   // choose 2) + 2 variables in the program.
   EXPECT_EQ(relaxation->num_vars(), 2 + NChoose2(5));
-  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(),
-            1);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
   EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
                 .evaluator()
                 ->matrix_rows(),
             4);
   EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1);
   EXPECT_EQ(relaxation->GetAllConstraints().size(), 2);
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
   SetRelaxationInitialGuess(test_point, relaxation.get());
-  EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
-                  relaxation->linear_costs()[0])[0],
-              test_point.at(x_(0)) * test_point.at(x_(1)), 1e-12);
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(relaxation->linear_costs()[0])[0],
+      test_point.at(x_(0)) * test_point.at(x_(1)), 1e-12);
 
   // Relax an overlapping set of variables. The cost should only be added once.
   const Variables y_vars_plus_x0_x1{x_(0), x_(1), y_(0), y_(1)};
-  relaxation = MakeSemidefiniteRelaxation(prog_, std::vector<Variables>{x_vars_, y_vars_plus_x0_x1});
+  relaxation = MakeSemidefiniteRelaxation(
+      prog_, std::vector<Variables>{x_vars_, y_vars_plus_x0_x1});
 
   // Both variable groups contain the quadratic cost, but the cost should only
   // get added once.
   EXPECT_EQ(relaxation->linear_costs().size(), 1);
   EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
-  // The variables which get relaxed are [x(0), x(1), x(2), 1] and [x(0), x(1), y(0), y(1), 1]. The remaining
-  // variable that does not get relaxed is [x(2)]. So there are (5 choose 2) + (6 choose 2) + 1 - 4 variables in the program.
-  EXPECT_EQ(relaxation->num_vars(), NChoose2(5)+ NChoose2(6) + 1-4);
+  // The variables which get relaxed are [x(0), x(1), x(2), 1] and [x(0), x(1),
+  // y(0), y(1), 1]. The remaining variable that does not get relaxed is [x(2)].
+  // So there are (5 choose 2) + (6 choose 2) + 1 - 4 variables in the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(5) + NChoose2(6) + 1 - 4);
   EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
                 .evaluator()
-                ->matrix_rows(),4);
+                ->matrix_rows(),
+            4);
   EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
                 .evaluator()
-                ->matrix_rows(),5);
+                ->matrix_rows(),
+            5);
   EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
   EXPECT_EQ(relaxation->linear_equality_constraints().size(), 2);
   EXPECT_EQ(relaxation->GetAllConstraints().size(), 4);
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(relaxation->linear_costs()[0])[0],
+      test_point.at(x_(0)) * test_point.at(x_(1)), 1e-12);
+
+  // Now we test that a convex quadratic cost isn't relaxed to a linear cost if
+  // there is no semidefinite variable which contains the variables of the cost.
+  prog_.RemoveCost(cost);
+  cost = prog_.AddQuadraticCost(y_(0) * y_(0));
+  relaxation =
+      MakeSemidefiniteRelaxation(prog_, std::vector<Variables>{x_vars_});
+
+  // The variables which get relaxed are [x(0), x(1), x(2), 1]. The remaining
+  // variable that does not get relaxed is [y(0), y(1)]. So there are
+  // (5 choose 2) + 2 variables in the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(5) + 2);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(),
+            4);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2);
+  // The only cost is a single quadratic cost.
+  EXPECT_EQ(relaxation->quadratic_costs().size(), 1);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
   SetRelaxationInitialGuess(test_point, relaxation.get());
   EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
-                  relaxation->linear_costs()[0])[0],
-              test_point.at(x_(0)) * test_point.at(x_(1)), 1e-12);
-  // Add a quadratic cost that isn't relaxed.
+                  relaxation->quadratic_costs()[0])[0],
+              test_point.at(y_(0)) * test_point.at(y_(0)), 1e-12);
 }
-//
-// TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticConstraint) {
-//  const std::map<Variable, double> test_point{
-//      {x_(0), 0.3}, {x_(1), -1.9}, {x_(2), -1.4}, {y_(0), -2.3}, {y_(1),
-//      -6.3}};
-//
-//  // An indefinite Q for the x_ variables.
-//  // clang-format off
-//  const Matrix3d Qx{{-3.3,  -0.8,  -0.5},
-//                    {-1.1,  -1.7, -10.3},
-//                    { 2.4,   0.3,   1.9}};
-//  // clang-format on
-//  const Vector3d bx(-0.2, -3.1, 2.7);
-//  const double lbx = -.7, ubx = 1.5;
-//  prog_.AddQuadraticConstraint(Qx, bx, lbx, ubx, x_);
-//
-//  // A PSD Q for the y_ variables. Q is PSD since it is diagonally dominant.
-//  // clang-format off
-//  const Matrix2d Qy{{1.7,  -0.8},
-//                    {-0.8,   4.6}};
-//  // clang-format on
-//  const Vector2d by(-1.3, -0.4);
-//  const double lby = 1.1, uby = 4.7;
-//  prog_.AddQuadraticConstraint(
-//      Qy, by, lby, uby, y_,
-//      QuadraticConstraint::HessianType::kPositiveSemidefinite);
-//
-//  // Relaxes the x_ and y_ variables separately.
-//  auto relaxation_partition =
-//      MakeSemidefiniteRelaxation(prog_, partition_group_);
-//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-//
-//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-//  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
-//  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in
-//  the
-//  // program.
-//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-//            2);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-//                .evaluator()
-//                ->matrix_rows(),
-//            4);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-//                .evaluator()
-//                ->matrix_rows(),
-//            3);
-//  // The two constraints that the "1" in the psd variables are equal to 1.
-//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 2);
-//  // 2 original quadratic constraints.
-//  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 2);
-//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 2 + 2);
-//  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
-//                        test_point.at(x_(2)));
-//  EXPECT_NEAR(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition->linear_constraints()[0])[0],
-//      (0.5 * x_test.transpose() * Qx * x_test + bx.transpose() * x_test)[0],
-//      1e-12);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
-//                .evaluator()
-//                ->lower_bound()[0],
-//            lbx);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
-//                .evaluator()
-//                ->upper_bound()[0],
-//            ubx);
-//
-//  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
-//  EXPECT_NEAR(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition->linear_constraints()[1])[0],
-//      (0.5 * y_test.transpose() * Qy * y_test + by.transpose() * y_test)[0],
-//      1e-12);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
-//                .evaluator()
-//                ->lower_bound()[0],
-//            lby);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
-//                .evaluator()
-//                ->upper_bound()[0],
-//            uby);
-//
-//  // Now add a quadratic constraint which intersects both variable groups.
-//  This
-//  // will add 1 linear constraint to each semidefinite variable group, a
-//  linear
-//  // equality constraint on the two semidefinite variables enforcing
-//  agreement.
-//  // clang-format off
-//  const Matrix2d Q_overlap{{2.3, -4.1},
-//                           {-7.6,  1.9}};
-//  // clang-format on
-//  const Vector2d b_overlap{-1.2, 7.3};
-//  const double lb_overlap = 0.1, ub_overlap = 2.2;
-//  VectorXDecisionVariable overlap_vars(2);
-//  // These are intentionally placed out of order with respect to the sorting
-//  // that happens DoAddSemidefiniteVariableAndImpliedCostsAndConstraints in
-//  overlap_vars << y_(1), x_(0);
-//  prog_.AddQuadraticConstraint(Q_overlap, b_overlap, lb_overlap, ub_overlap,
-//                               overlap_vars);
-//  relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
-//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-//
-//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-//  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and
-//  // [x(0), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
-//  // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
-//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-//            2);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-//                .evaluator()
-//                ->matrix_rows(),
-//            5);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-//                .evaluator()
-//                ->matrix_rows(),
-//            4);
-//  // The two constraints that the "1" in the psd variables are equal to 1 plus
-//  // the one constraints that the minors indexed by [x(0), y(1)] are equal.
-//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 3);
-//  // Check that the linear equality constraints are the claimed ones.
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition->linear_equality_constraints()[0]),
-//      Eigen::VectorXd::Ones(1)));
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition->linear_equality_constraints()[1]),
-//      Eigen::VectorXd::Ones(1)));
-//  auto psd_agree_constraint =
-//      relaxation_partition->linear_equality_constraints()[2];
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
-//      Eigen::VectorXd::Zero(
-//          psd_agree_constraint.evaluator()->num_constraints())));
-//
-//  // The first two quadratic constraints each become linear constraints. The
-//  // third quadratic constraints gets converted to a linear constraint in each
-//  // relaxation of the subgroups.
-//  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 4);
-//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 3 + 4);
-//  VectorXd overlap_test_vec1(4);
-//  overlap_test_vec1 << test_point.at(x_(0)), test_point.at(x_(1)),
-//      test_point.at(x_(2)), test_point.at(y_(1));
-//
-//  // The first quadratic constraint should be the Qx quadratic constraint.
-//  Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(4, 4);
-//  Q.topLeftCorner(Qx.rows(), Qx.rows()) = Qx;
-//  Eigen::VectorXd b(4);
-//  b << bx, 0;
-//  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-//                  relaxation_partition->linear_constraints()[0])[0],
-//              (0.5 * overlap_test_vec1.transpose() * Q * overlap_test_vec1 +
-//               b.transpose() * overlap_test_vec1)[0],
-//              1e-12);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
-//                .evaluator()
-//                ->lower_bound()[0],
-//            lbx);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
-//                .evaluator()
-//                ->upper_bound()[0],
-//            ubx);
-//  // The second quadratic constraint should be Q_overlap quadratic constraint.
-//  Q.setZero();
-//  Q(0, 0) = Q_overlap(1, 1);
-//  Q(0, 3) = Q_overlap(1, 0);
-//  Q(3, 0) = Q_overlap(0, 1);
-//  Q(3, 3) = Q_overlap(0, 0);
-//  b.setZero();
-//  b(0) = b_overlap(1);
-//  b(3) = b_overlap(0);
-//  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-//                  relaxation_partition->linear_constraints()[1])[0],
-//              (0.5 * overlap_test_vec1.transpose() * Q * overlap_test_vec1 +
-//               b.transpose() * overlap_test_vec1)[0],
-//              1e-12);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
-//                .evaluator()
-//                ->lower_bound()[0],
-//            lb_overlap);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
-//                .evaluator()
-//                ->upper_bound()[0],
-//            ub_overlap);
-//
-//  VectorXd overlap_test_vec2(3);
-//  overlap_test_vec2 << test_point.at(x_(0)), test_point.at(y_(0)),
-//      test_point.at(y_(1));
-//  // The third quadratic constraint should be the Qy quadratic constraint.
-//  Q = Eigen::MatrixXd::Zero(3, 3);
-//  Q.bottomRightCorner(Qy.rows(), Qy.rows()) = Qy;
-//  b = Eigen::VectorXd::Zero(3);
-//  b << 0, by;
-//  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-//                  relaxation_partition->linear_constraints()[2])[0],
-//              (0.5 * overlap_test_vec2.transpose() * Q * overlap_test_vec2 +
-//               b.transpose() * overlap_test_vec2)[0],
-//              1e-12);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[2]
-//                .evaluator()
-//                ->lower_bound()[0],
-//            lby);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[2]
-//                .evaluator()
-//                ->upper_bound()[0],
-//            uby);
-//  // The fourth quadratic constraint should be Q_overlap quadratic constraint.
-//  Q.setZero();
-//  Q(0, 0) = Q_overlap(1, 1);
-//  Q(0, 2) = Q_overlap(1, 0);
-//  Q(2, 0) = Q_overlap(0, 1);
-//  Q(2, 2) = Q_overlap(0, 0);
-//  b.setZero();
-//  b(0) = b_overlap(1);
-//  b(2) = b_overlap(0);
-//  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-//                  relaxation_partition->linear_constraints()[3])[0],
-//              (0.5 * overlap_test_vec2.transpose() * Q * overlap_test_vec2 +
-//               b.transpose() * overlap_test_vec2)[0],
-//              1e-12);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
-//                .evaluator()
-//                ->lower_bound()[0],
-//            lb_overlap);
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
-//                .evaluator()
-//                ->upper_bound()[0],
-//            ub_overlap);
-//}
-//
-// TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearConstraint) {
-//  const std::map<Variable, double> test_point{
-//      {x_(0), 1.1}, {x_(1), 0.27}, {x_(2), -1.2}, {y_(0), -0.99},
-//      {y_(1), 9.1}};
-//
-//  MatrixXd Ax(2, 3);
-//  // clang-format off
-//  Ax << 2,     0, 3.1,
-//        -1, -1.7, 2.1;
-//  // clang-format on
-//  const Vector2d lbx(1.3, -kInf);
-//  const Vector2d ubx(kInf, 0.1);
-//  prog_.AddLinearConstraint(Ax, lbx, ubx, x_);
-//
-//  MatrixXd Ay(3, 2);
-//  // clang-format off
-//  Ay << 1.1,   2.7,
-//        0.27, -9.1,
-//        -1.2, -0.99;
-//  // clang-format on
-//  const Vector3d lby(1.3, -kInf, kInf);
-//  const Vector3d uby(kInf, 0.1, 7.2);
-//  prog_.AddLinearConstraint(Ay, lby, uby, y_);
-//
-//  // Relaxes the x_ and y_ variables separately.
-//  auto relaxation_partition =
-//      MakeSemidefiniteRelaxation(prog_, partition_group_);
-//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-//  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
-//  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in
-//  the
-//  // program.
-//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-//            2);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-//                .evaluator()
-//                ->matrix_rows(),
-//            4);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-//                .evaluator()
-//                ->matrix_rows(),
-//            3);
-//  // The two constraints that the "1" in the psd variables are equal to 1.
-//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 2);
-//  // 2 original linear constraints, and each of these adds one product
-//  // constraint.
-//  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 2 + 2);
-//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 2 + 4);
-//
-//  // First 2 linear constraints are lbx ≤ Ax * x ≤ ubx, and lby ≤ Ay * y ≤
-//  uby. EXPECT_TRUE(CompareMatrices(
-//      Ax,
-//      relaxation_partition->linear_constraints()[0].evaluator()->GetDenseA()));
-//  EXPECT_TRUE(CompareMatrices(lbx,
-//  relaxation_partition->linear_constraints()[0]
-//                                       .evaluator()
-//                                       ->lower_bound()));
-//  EXPECT_TRUE(CompareMatrices(ubx,
-//  relaxation_partition->linear_constraints()[0]
-//                                       .evaluator()
-//                                       ->upper_bound()));
-//  EXPECT_TRUE(CompareMatrices(
-//      Ay,
-//      relaxation_partition->linear_constraints()[1].evaluator()->GetDenseA()));
-//  EXPECT_TRUE(CompareMatrices(lby,
-//  relaxation_partition->linear_constraints()[1]
-//                                       .evaluator()
-//                                       ->lower_bound()));
-//  EXPECT_TRUE(CompareMatrices(uby,
-//  relaxation_partition->linear_constraints()[1]
-//                                       .evaluator()
-//                                       ->upper_bound()));
-//  // Third linear (in the new decision variables) constraint is 0 ≤
-//  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on x_ constraints
-//  // stacked.
-//  VectorXd b(2);  // all of the finite lower/upper bounds.
-//  b << -lbx[0], ubx[1];
-//  MatrixXd A(2, 3);
-//  A << -Ax.row(0), Ax.row(1);
-//  int expected_size = (b.size() * (b.size() + 1)) / 2;
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[2]
-//                .evaluator()
-//                ->num_constraints(),
-//            expected_size);
-//  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
-//                        test_point.at(x_(2)));
-//  VectorXd value = relaxation_partition->EvalBindingAtInitialGuess(
-//      relaxation_partition->linear_constraints()[2]);
-//  MatrixXd expected_mat =
-//      (A * x_test - b) * (A * x_test - b).transpose() - b * b.transpose();
-//  VectorXd expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
-//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  value =
-//      relaxation_partition->linear_constraints()[2].evaluator()->lower_bound();
-//  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
-//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//
-//  // Fourth linear (in the new decision variables) constraint is 0 ≤
-//  // (A*y-b)(A*y-b)ᵀ, where A and b represent all of the on y_ constraints
-//  // stacked.
-//  b.resize(3);  // all of the finite lower/upper bounds.
-//  b << -lby[0], uby[1], uby[2];
-//  A.resize(3, 2);
-//  A << -Ay.row(0), Ay.row(1), Ay.row(2);
-//  expected_size = (b.size() * (b.size() + 1)) / 2;
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
-//                .evaluator()
-//                ->num_constraints(),
-//            expected_size);
-//  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
-//  value = relaxation_partition->EvalBindingAtInitialGuess(
-//      relaxation_partition->linear_constraints()[3]);
-//  expected_mat =
-//      (A * y_test - b) * (A * y_test - b).transpose() - b * b.transpose();
-//  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
-//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  value =
-//      relaxation_partition->linear_constraints()[3].evaluator()->lower_bound();
-//  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
-//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//
-//  // Now add a linear constraint which intersects both variable groups. This
-//  // will add 2 linear constraints to each semidefinite variable group, and 1
-//  // linear equality constraint on the two semidefinite variables enforcing
-//  // agreement on the overlap.
-//  MatrixXd A_overlap(1, 2);
-//  // clang-format off
-//  A_overlap << -1.9, 2.7;
-//  // clang-format on
-//  const Vector1d lb_overlap(1.7);
-//  const Vector1d ub_overlap(2.3);
-//  VectorXDecisionVariable overlap_vars(2);
-//  overlap_vars << x_(1), y_(1);
-//  prog_.AddLinearConstraint(A_overlap, lb_overlap, ub_overlap, overlap_vars);
-//  relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
-//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-//
-//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-//  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and
-//  // [x(1), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
-//  // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
-//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-//            2);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-//                .evaluator()
-//                ->matrix_rows(),
-//            5);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-//                .evaluator()
-//                ->matrix_rows(),
-//            4);
-//  // The two constraints that the "1" in the psd variables are equal to 1 plus
-//  // the one constraints that the minors indexed by [x(1), y(1)] are equal.
-//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 3);
-//  // Check that the linear equality constraints are the claimed ones.
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition->linear_equality_constraints()[0]),
-//      Eigen::VectorXd::Ones(1)));
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition->linear_equality_constraints()[1]),
-//      Eigen::VectorXd::Ones(1)));
-//  auto psd_agree_constraint =
-//      relaxation_partition->linear_equality_constraints()[2];
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
-//      Eigen::VectorXd::Zero(
-//          psd_agree_constraint.evaluator()->num_constraints())));
-//
-//  // 3 original linear constraints, and each semidefinite relaxation has the
-//  // product constraints.
-//  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 3 + 2);
-//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 3 + 5);
-//
-//  // First 3 linear constraints are lbx ≤ Ax * x ≤ ubx, and lby ≤ Ay * y ≤ uby
-//  // and lb_overlap ≤ A_overlap * overlap_vars ≤ ub_overlap.
-//  EXPECT_TRUE(CompareMatrices(
-//      Ax,
-//      relaxation_partition->linear_constraints()[0].evaluator()->GetDenseA()));
-//  EXPECT_TRUE(CompareMatrices(lbx,
-//  relaxation_partition->linear_constraints()[0]
-//                                       .evaluator()
-//                                       ->lower_bound()));
-//  EXPECT_TRUE(CompareMatrices(ubx,
-//  relaxation_partition->linear_constraints()[0]
-//                                       .evaluator()
-//                                       ->upper_bound()));
-//  EXPECT_TRUE(CompareMatrices(
-//      Ay,
-//      relaxation_partition->linear_constraints()[1].evaluator()->GetDenseA()));
-//  EXPECT_TRUE(CompareMatrices(lby,
-//  relaxation_partition->linear_constraints()[1]
-//                                       .evaluator()
-//                                       ->lower_bound()));
-//  EXPECT_TRUE(CompareMatrices(uby,
-//  relaxation_partition->linear_constraints()[1]
-//                                       .evaluator()
-//                                       ->upper_bound()));
-//  EXPECT_TRUE(CompareMatrices(
-//      A_overlap,
-//      relaxation_partition->linear_constraints()[2].evaluator()->GetDenseA()));
-//  EXPECT_TRUE(
-//      CompareMatrices(lb_overlap,
-//      relaxation_partition->linear_constraints()[2]
-//                                      .evaluator()
-//                                      ->lower_bound()));
-//  EXPECT_TRUE(
-//      CompareMatrices(ub_overlap,
-//      relaxation_partition->linear_constraints()[2]
-//                                      .evaluator()
-//                                      ->upper_bound()));
-//
-//  // Fourth linear (in the new decision variables) constraint is 0 ≤
-//  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on x_ and the overlap
-//  // constraints stacked.
-//  b.resize(4);  // all of the finite lower/upper bounds.
-//  b << -lbx[0], ubx[1], -lb_overlap[0], ub_overlap[0];
-//  A.resize(4, 4);
-//  // clang-format off
-//  A << -Ax.row(0), 0,
-//        Ax.row(1), 0,
-//        0, -A_overlap(0, 0), 0, -A_overlap(0, 1),
-//        0,  A_overlap(0, 0), 0,  A_overlap(0, 1);
-//  // clang-format on
-//  expected_size = (b.size() * (b.size() + 1)) / 2;
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
-//                .evaluator()
-//                ->num_constraints(),
-//            expected_size);
-//  VectorXd test_vec(4);
-//  test_vec << test_point.at(x_(0)), test_point.at(x_(1)),
-//  test_point.at(x_(2)),
-//      test_point.at(y_(1));
-//  value = relaxation_partition->EvalBindingAtInitialGuess(
-//      relaxation_partition->linear_constraints()[3]);
-//  expected_mat =
-//      (A * test_vec - b) * (A * test_vec - b).transpose() - b * b.transpose();
-//  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
-//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  value =
-//      relaxation_partition->linear_constraints()[3].evaluator()->lower_bound();
-//  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
-//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//
-//  // Fifth linear (in the new decision variables) constraint is 0 ≤
-//  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on y_ and the overlap
-//  // constraints stacked.
-//  b.resize(5);  // all of the finite lower/upper bounds.
-//  b << -lby[0], uby[1], uby[2], -lb_overlap[0], ub_overlap[0];
-//  A.resize(5, 3);
-//  // clang-format off
-//  A << 0,              -Ay.row(0),
-//       0,               Ay.row(1),
-//       0,               Ay.row(2),
-//       -A_overlap(0, 0), 0, -A_overlap(0, 1),
-//        A_overlap(0, 0), 0,  A_overlap(0, 1);
-//  // clang-format on
-//  expected_size = (b.size() * (b.size() + 1)) / 2;
-//  EXPECT_EQ(relaxation_partition->linear_constraints()[4]
-//                .evaluator()
-//                ->num_constraints(),
-//            expected_size);
-//  test_vec.resize(3);
-//  test_vec << test_point.at(x_(1)), test_point.at(y_(0)),
-//  test_point.at(y_(1));
-//
-//  value = relaxation_partition->EvalBindingAtInitialGuess(
-//      relaxation_partition->linear_constraints()[4]);
-//  expected_mat =
-//      (A * test_vec - b) * (A * test_vec - b).transpose() - b * b.transpose();
-//  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
-//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  value =
-//      relaxation_partition->linear_constraints()[4].evaluator()->lower_bound();
-//  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
-//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//}
-//
-// TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearEqualityConstraint)
-// {
-//  const std::map<Variable, double> test_point{
-//      {x_(0), -0.6}, {x_(1), 3.8}, {x_(2), 4.7}, {y_(0), 9.9}, {y_(1), 3.4}};
-//
-//  // clang-format off
-//  const Matrix3d Ax{{0.8, -2.3, 0.7},
-//                    {-2.1, 2.9, 2.2},
-//                    {-2.8, 0.5, 5.2}};
-//  // clang-format on
-//  const Vector3d bx(3.58, -4.26, -2.61);
-//  prog_.AddLinearEqualityConstraint(Ax, bx, x_);
-//
-//  MatrixXd Ay(3, 2);
-//  // clang-format off
-//  Ay << -0.08, 1.62,
-//         5.17, -6.47,
-//         0.93, -2.97;
-//  // clang-format on
-//  const Vector3d by(4.6, -0.1, 0.7);
-//  const Vector3d uby(kInf, 0.1, 7.2);
-//  prog_.AddLinearEqualityConstraint(Ay, by, y_);
-//
-//  // Relaxes the x_ and y_ variables separately.
-//  auto relaxation_partition =
-//      MakeSemidefiniteRelaxation(prog_, partition_group_);
-//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-//  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
-//  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in
-//  the
-//  // program.
-//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-//            2);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-//                .evaluator()
-//                ->matrix_rows(),
-//            4);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-//                .evaluator()
-//                ->matrix_rows(),
-//            3);
-//  // The two constraints that the "1" in the psd variables are equal to 1.
-//  // Additionally, the relaxation of each groups causes one extra product
-//  // constraint for each of the column of the resulting PSD matrices.
-//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(),
-//            2 + 4 + 3);
-//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 9);
-//
-//  int cur_constraint = 0;
-//  // The first two constraints are the linear constraints inherited from
-//  prog_. auto CompareLinearEqualityConstraintsAtIdx = [&](const int idx) {
-//    EXPECT_TRUE(CompareMatrices(
-//        relaxation_partition->linear_equality_constraints()[idx]
-//            .evaluator()
-//            ->GetDenseA(),
-//        prog_.linear_equality_constraints()[idx].evaluator()->GetDenseA()));
-//    EXPECT_TRUE(CompareMatrices(
-//        relaxation_partition->linear_equality_constraints()[idx]
-//            .evaluator()
-//            ->lower_bound(),
-//        prog_.linear_equality_constraints()[idx].evaluator()->lower_bound()));
-//  };
-//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-//  ASSERT_EQ(cur_constraint, 2);
-//
-//  // This next set of equality constraints are due to the relaxation of the x_
-//  // variables.
-//  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
-//                        test_point.at(x_(2)));
-//  VectorXd expected;
-//  VectorXd value;
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition
-//              ->linear_equality_constraints()[cur_constraint++]),
-//      Eigen::VectorXd::Ones(1)));
-//  int start = cur_constraint;
-//  for (; cur_constraint < start + 3; ++cur_constraint) {
-//    // Linear constraints are (Ax*x_ - bx)*x_i = 0.
-//    expected = (Ax * x_test - bx) * x_test[cur_constraint - start];
-//    value = relaxation_partition->EvalBindingAtInitialGuess(
-//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  }
-//  ASSERT_EQ(cur_constraint, 6);
-//
-//  // This set of equality constraints are due to the relaxation of the y_
-//  // variables.
-//  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition
-//              ->linear_equality_constraints()[cur_constraint++]),
-//      Eigen::VectorXd::Ones(1)));
-//  start = cur_constraint;
-//  for (; cur_constraint < start + 2; ++cur_constraint) {
-//    // Linear constraints are (Ax*x_ - b)*x_i = 0.
-//    expected = (Ay * y_test - by) * y_test[cur_constraint - start];
-//    value = relaxation_partition->EvalBindingAtInitialGuess(
-//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  }
-//  // At this point, we should have tested all the linear equality constraints.
-//  ASSERT_EQ(cur_constraint,
-//            relaxation_partition->linear_equality_constraints().size());
-//
-//  // Now add a linear equality constraint which intersects both variable
-//  groups.
-//  // This will add 2 linear constraints to each semidefinite variable group,
-//  and
-//  // 1 linear equality constraint on the two semidefinite variables enforcing
-//  // agreement on the overlap.
-//  MatrixXd A_overlap(1, 2);
-//  // clang-format off
-//  A_overlap << -7.9, 2.4;
-//  // clang-format on
-//  const Vector1d b_overlap(0.7);
-//  VectorXDecisionVariable overlap_vars(2);
-//  overlap_vars << x_(2), y_(0);
-//  prog_.AddLinearEqualityConstraint(A_overlap, b_overlap, overlap_vars);
-//
-//  relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
-//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-//
-//  // The variables which get relaxed are [x(0), x(1), x(2), y(0), 1] and
-//  // [x(2), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
-//  // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
-//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-//            2);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-//                .evaluator()
-//                ->matrix_rows(),
-//            5);
-//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-//                .evaluator()
-//                ->matrix_rows(),
-//            4);
-//  // Three linear equality constraints in the original program, then two
-//  // constraints that the "1" in the psd variables are equal to 1.
-//  Additionally,
-//  // the relaxation of each groups causes one extra product constraint for
-//  each
-//  // linear equality constraint and for each of the column of the resulting
-//  PSD
-//  // matrices minus 1. Finally, one more equality constraint for the agreement
-//  // of the PSD matrices.
-//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(),
-//            3 + 2 + 2 * 4 + 2 * 3 + 1);
-//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 20);
-//  cur_constraint = 0;
-//
-//  // The first three constraints are the linear constraints inherited from
-//  // prog_.
-//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-//  ASSERT_EQ(cur_constraint, 3);
-//
-//  // This next set of equality constraints are due to the relaxation of [x(0),
-//  // x(1), x(2), y(0), 1].
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition
-//              ->linear_equality_constraints()[cur_constraint++]),
-//      Eigen::VectorXd::Ones(1)));
-//  const Vector2d overlap_test(test_point.at(x_(2)), test_point.at(y_(0)));
-//
-//  VectorXd partition1_vec_test(4);
-//  partition1_vec_test << test_point.at(x_(0)), test_point.at(x_(1)),
-//      test_point.at(x_(2)), test_point.at(y_(0));
-//
-//  start = cur_constraint;
-//  for (; cur_constraint < start + 4; ++cur_constraint) {
-//    // Linear constraints are (Ax*x_ - bx)*x_i = 0.
-//    expected = (Ax * x_test - bx) * partition1_vec_test[cur_constraint -
-//    start]; value = relaxation_partition->EvalBindingAtInitialGuess(
-//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  }
-//  start = cur_constraint;
-//  for (; cur_constraint < start + 4; ++cur_constraint) {
-//    // Linear constraints are (A_overlap*[x_(2), y_(0)] - b_overlap)*x_i = 0.
-//    expected = (A_overlap * overlap_test - b_overlap) *
-//               partition1_vec_test[cur_constraint - start];
-//    value = relaxation_partition->EvalBindingAtInitialGuess(
-//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  }
-//  ASSERT_EQ(cur_constraint, 12);
-//
-//  // This next set of equality constraints are due to the relaxation of [x(2),
-//  // y(0), y(1), 1].
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(
-//          relaxation_partition
-//              ->linear_equality_constraints()[cur_constraint++]),
-//      Eigen::VectorXd::Ones(1)));
-//
-//  VectorXd partition2_vec_test(3);
-//  partition2_vec_test << test_point.at(x_(2)), test_point.at(y_(0)),
-//      test_point.at(y_(1));
-//
-//  start = cur_constraint;
-//  for (; cur_constraint < start + 3; ++cur_constraint) {
-//    // Linear constraints are (Ay*y_ - by)*partition2_vec_test_i = 0.
-//    expected = (Ay * y_test - by) * partition2_vec_test[cur_constraint -
-//    start]; value = relaxation_partition->EvalBindingAtInitialGuess(
-//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  }
-//  start = cur_constraint;
-//  for (; cur_constraint < start + 3; ++cur_constraint) {
-//    // Linear constraints are (A_overlap*[x_(2), y_(0)] -
-//    // b_overlap)*partition2_vec_test_i = 0.
-//    expected = (A_overlap * overlap_test - b_overlap) *
-//               partition2_vec_test[cur_constraint - start];
-//    value = relaxation_partition->EvalBindingAtInitialGuess(
-//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-//  }
-//
-//  ASSERT_EQ(cur_constraint, 19);
-//  auto psd_agree_constraint =
-//      relaxation_partition->linear_equality_constraints()[cur_constraint++];
-//  EXPECT_TRUE(CompareMatrices(
-//      relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
-//      Eigen::VectorXd::Zero(
-//          psd_agree_constraint.evaluator()->num_constraints())));
-//  // All linear equality constraints have been checked.
-//  ASSERT_EQ(cur_constraint,
-//            relaxation_partition->linear_equality_constraints().size());
-//}
+
+TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticConstraint) {
+  const std::map<Variable, double> test_point{
+      {x_(0), 0.3}, {x_(1), -1.9}, {x_(2), -1.4}, {y_(0), -2.3}, {y_(1), -6.3}};
+
+  // An indefinite Q for the (x_(0), x_(2)) variables.
+  // clang-format off
+  const Matrix2d Qx{{-3.3, -0.8},
+                    {-1.1, -1.7}};
+  // clang-format on
+  const Vector2d bx(-0.2, -3.1);
+  const double lbx = -.7, ubx = 1.5;
+  // These are intentionally placed out of order with respect to the
+  // ordering that happens in MakeSemidefiniteRelaxation.
+  VectorX<Variable> out_of_order_x_vars(2);
+  out_of_order_x_vars << x_(2), x_(0);
+  prog_.AddQuadraticConstraint(Qx, bx, lbx, ubx, out_of_order_x_vars);
+
+  // A convex quadratic constraint for the y_ variables. Q is PSD since it is
+  // diagonally dominant.
+  // clang-format off
+  const Matrix2d Qy{{1.7, -0.8},
+                    {-0.8, 4.6}};
+  // clang-format on
+  const Vector2d by(-1.3, -0.4);
+  const double lby = -kInf, uby = 4.7;
+  prog_.AddQuadraticConstraint(
+      Qy, by, lby, uby, y_,
+      QuadraticConstraint::HessianType::kPositiveSemidefinite);
+
+  // Relaxes the x_ and y_ variables separately.
+  auto relaxation = MakeSemidefiniteRelaxation(
+      prog_, std::vector<Variables>{x_vars_, y_vars_});
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 0);
+  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
+  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) - 1 variables in
+  // the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(5) + NChoose2(4) - 1);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(),
+            4);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
+                .evaluator()
+                ->matrix_rows(),
+            3);
+  // The constraints that the "1" in the psd variables is equal to 1.
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1);
+  // 2 original quadratic constraints.
+  EXPECT_EQ(relaxation->linear_constraints().size(), 2);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2 + 1 + 2);
+  const Vector2d x_test(test_point.at(x_(2)), test_point.at(x_(0)));
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(
+          relaxation->linear_constraints()[0])[0],
+      (0.5 * x_test.transpose() * Qx * x_test + bx.transpose() * x_test)[0],
+      1e-12);
+  EXPECT_EQ(relaxation->linear_constraints()[0].evaluator()->lower_bound()[0],
+            lbx);
+  EXPECT_EQ(relaxation->linear_constraints()[0].evaluator()->upper_bound()[0],
+            ubx);
+
+  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(
+          relaxation->linear_constraints()[1])[0],
+      (0.5 * y_test.transpose() * Qy * y_test + by.transpose() * y_test)[0],
+      1e-12);
+  EXPECT_EQ(relaxation->linear_constraints()[1].evaluator()->lower_bound()[0],
+            lby);
+  EXPECT_EQ(relaxation->linear_constraints()[1].evaluator()->upper_bound()[0],
+            uby);
+
+  // These variable groups are both supersets of both the quadratic constraints.
+  // Ensure that the quadratic constraints are added on each variable group, and
+  // that the linear equality constraints between the variable groups are added.
+  std::vector<Variables> groups{
+      Variables{x_(0), x_(2), y_(0), y_(1)},
+      Variables{x_(0), x_(1), x_(2), y_(0), y_(1)},
+  };
+  relaxation = MakeSemidefiniteRelaxation(prog_, groups);
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 0);
+  // The variables which get relaxed are [x_(0), x_(2), y_(0), y_(1), 1] and
+  // [x_(0), x_(1), x_(2), y_(0), y_(1), 1]. The variables [x_(0), x_(2), y_(0),
+  // y_(1), 1] get double counted So there are (6 choose 2) + (7 choose 2) - 5
+  // variables in the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(6) + NChoose2(7) - 5);
+  // One linear equality constraints from the 1 variables being equal to 1 and
+  // one linear equality constraint that the minors corresponding [x_(0), x_(2),
+  // y_(0), y_(1)] are the same in the two psd variables.
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 2);
+  // Two psd constraints.
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(),
+            6);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
+                .evaluator()
+                ->matrix_rows(),
+            5);
+  // Both quadratic constraints get added to both variable groups as linear
+  // constraints.
+  EXPECT_EQ(relaxation->linear_constraints().size(), 4);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2 + 2 + 4);
+
+  // Check the linear constraints.
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(
+          relaxation->linear_constraints()[0])[0],
+      (0.5 * x_test.transpose() * Qx * x_test + bx.transpose() * x_test)[0],
+      1e-12);
+  EXPECT_EQ(relaxation->linear_constraints()[0].evaluator()->lower_bound()[0],
+            lbx);
+  EXPECT_EQ(relaxation->linear_constraints()[0].evaluator()->upper_bound()[0],
+            ubx);
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(
+          relaxation->linear_constraints()[1])[0],
+      (0.5 * y_test.transpose() * Qy * y_test + by.transpose() * y_test)[0],
+      1e-12);
+  EXPECT_EQ(relaxation->linear_constraints()[1].evaluator()->lower_bound()[0],
+            lby);
+  EXPECT_EQ(relaxation->linear_constraints()[1].evaluator()->upper_bound()[0],
+            uby);
+
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(
+          relaxation->linear_constraints()[2])[0],
+      (0.5 * x_test.transpose() * Qx * x_test + bx.transpose() * x_test)[0],
+      1e-12);
+  EXPECT_EQ(relaxation->linear_constraints()[2].evaluator()->lower_bound()[0],
+            lbx);
+  EXPECT_EQ(relaxation->linear_constraints()[2].evaluator()->upper_bound()[0],
+            ubx);
+  EXPECT_NEAR(
+      relaxation->EvalBindingAtInitialGuess(
+          relaxation->linear_constraints()[3])[0],
+      (0.5 * y_test.transpose() * Qy * y_test + by.transpose() * y_test)[0],
+      1e-12);
+  EXPECT_EQ(relaxation->linear_constraints()[3].evaluator()->lower_bound()[0],
+            lby);
+  EXPECT_EQ(relaxation->linear_constraints()[3].evaluator()->upper_bound()[0],
+            uby);
+
+  // Now do the relaxation so that both variable group relaxes the first
+  // quadratic constraint, but neither variable group relaxes the second
+  // quadratic constraint.
+  relaxation = MakeSemidefiniteRelaxation(
+      prog_, std::vector<Variables>{x_vars_, x0_x2_y1_vars_});
+
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 0);
+  // The variables which get relaxed are [x_(0), x_(1), x_(2), 1] and
+  // [x_(0), x_(2), y_(1), 1]. The variable y_(0) is not part of any group and
+  // [x_(0), x_(2), 1] get double counted So there are (5 choose 2) + (5
+  // choose 2) + 1 - 3 variables in the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(5) + NChoose2(5) + 1 - 3);
+  // One linear equality constraints from the 1 variables being equal to 1 and
+  // one linear equality constraint that the minors corresponding [x_(0), x_(2)]
+  // are the same in the two psd variables.
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 2);
+  // Two psd constraints.
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(),
+            4);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
+                .evaluator()
+                ->matrix_rows(),
+            4);
+  // The first quadratic constraints get added to both variable groups as a
+  // linear constraint.
+  EXPECT_EQ(relaxation->linear_constraints().size(), 2);
+  // The second quadratic constraint does not get relaxed.
+  EXPECT_EQ(relaxation->quadratic_constraints().size(), 1);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2 + 2 + 2 + 1);
+}
+
+TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearConstraint) {
+  const std::map<Variable, double> test_point{
+      {x_(0), 1.1}, {x_(1), 0.27}, {x_(2), -1.2}, {y_(0), -0.99}, {y_(1), 9.1}};
+
+  MatrixXd Ax(2, 3);
+  // clang-format off
+  Ax << 2, 0, 3.1,
+      -1, -1.7, 2.1;
+  // clang-format on
+  const Vector2d lbx(1.3, -kInf);
+  const Vector2d ubx(kInf, 0.1);
+  VectorX<Variable> x_out_of_order(3);
+  x_out_of_order << x_(1), x_(0), x_(2);
+  prog_.AddLinearConstraint(Ax, lbx, ubx, x_out_of_order);
+
+  MatrixXd Ay(3, 2);
+  // clang-format off
+  Ay << 1.1, 2.7,
+      0.27, -9.1,
+      -1.2, -0.99;
+  // clang-format on
+  const Vector3d lby(1.3, -kInf, kInf);
+  const Vector3d uby(kInf, 0.1, 7.2);
+  VectorX<Variable> y_out_of_order(2);
+  y_out_of_order << y_(1), y_(0);
+  prog_.AddLinearConstraint(Ay, lby, uby, y_out_of_order);
+
+  // Relaxes the x_ and y_ variables separately.
+  auto relaxation = MakeSemidefiniteRelaxation(
+      prog_, std::vector<Variables>{x_vars_, y_vars_});
+
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 0);
+  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
+  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) - 1 variables in
+  // the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(5) + NChoose2(4) - 1);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(),
+            4);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
+                .evaluator()
+                ->matrix_rows(),
+            3);
+  // The constraint that the "1" in the psd variables is equal to 1.
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1);
+  // Each variable group is a superset of only 1 of the original linear
+  // constraints, each of which gets relaxed into one product constraint.
+  // Therefore, there are 4 total linear constraints.
+  EXPECT_EQ(relaxation->linear_constraints().size(), 4);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2 + 1 + 4);
+
+  // First 2 linear constraints are lbx ≤ Ax * x ≤ ubx, and lby ≤ Ay * y ≤ uby.
+  EXPECT_TRUE(CompareMatrices(
+      Ax, relaxation->linear_constraints()[0].evaluator()->GetDenseA()));
+  EXPECT_TRUE(CompareMatrices(
+      lbx, relaxation->linear_constraints()[0].evaluator()->lower_bound()));
+  EXPECT_TRUE(CompareMatrices(
+      ubx, relaxation->linear_constraints()[0].evaluator()->upper_bound()));
+  EXPECT_TRUE(CompareMatrices(
+      Ay, relaxation->linear_constraints()[1].evaluator()->GetDenseA()));
+  EXPECT_TRUE(CompareMatrices(
+      lby, relaxation->linear_constraints()[1].evaluator()->lower_bound()));
+  EXPECT_TRUE(CompareMatrices(
+      uby, relaxation->linear_constraints()[1].evaluator()->upper_bound()));
+  // Third linear (in the new decision variables) constraint is 0 ≤
+  // (A*x_-b)(A*x_-b)ᵀ, where A and b represent all of the on x_ constraints
+  // stacked.
+  VectorXd b(2);  // all of the finite lower/upper bounds.
+  b << -lbx[0], ubx[1];
+  MatrixXd A(2, 3);
+  A << -Ax.row(0), Ax.row(1);
+  int expected_size = (b.size() * (b.size() + 1)) / 2;
+  EXPECT_EQ(relaxation->linear_constraints()[2].evaluator()->num_constraints(),
+            expected_size);
+  const Vector3d x_test(test_point.at(x_(1)), test_point.at(x_(0)),
+                        test_point.at(x_(2)));
+  VectorXd value = relaxation->EvalBindingAtInitialGuess(
+      relaxation->linear_constraints()[2]);
+  MatrixXd expected_mat =
+      (A * x_test - b) * (A * x_test - b).transpose() - b * b.transpose();
+  VectorXd expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
+  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  value = relaxation->linear_constraints()[2].evaluator()->lower_bound();
+  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
+  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+
+  // Fourth linear (in the new decision variables) constraint is 0 ≤
+  // (A*y-b)(A*y-b)ᵀ, where A and b represent all of the on y_ constraints
+  // stacked.
+  b.resize(3);  // all of the finite lower/upper bounds.
+  b << -lby[0], uby[1], uby[2];
+  A.resize(3, 2);
+  A << -Ay.row(0), Ay.row(1), Ay.row(2);
+  expected_size = (b.size() * (b.size() + 1)) / 2;
+  EXPECT_EQ(relaxation->linear_constraints()[3].evaluator()->num_constraints(),
+            expected_size);
+  const Vector2d y_test(test_point.at(y_(1)), test_point.at(y_(0)));
+  value = relaxation->EvalBindingAtInitialGuess(
+      relaxation->linear_constraints()[3]);
+  expected_mat =
+      (A * y_test - b) * (A * y_test - b).transpose() - b * b.transpose();
+  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
+  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  value = relaxation->linear_constraints()[3].evaluator()->lower_bound();
+  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
+  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+
+  // We add a third linear constraint and use variable groups which overlap on
+  // this third constraint only.
+  MatrixXd A_overlap(1, 2);
+  // clang-format off
+  A_overlap << -1.9, 2.7;
+  // clang-format on
+  const Vector1d lb_overlap(1.7);
+  const Vector1d ub_overlap(2.3);
+  VectorX<Variable> overlap_vars(2);
+  overlap_vars << x_(1), y_(1);
+  prog_.AddLinearConstraint(A_overlap, lb_overlap, ub_overlap, overlap_vars);
+  std::vector<Variables> groups{Variables{x_(0), x_(1), x_(2), y_(1)},
+                                Variables{x_(1), y_(0), y_(1)}};
+  relaxation = MakeSemidefiniteRelaxation(prog_, groups);
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 0);
+  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and
+  // [x(1), y(0), y(1), 1]. These two groups of variables overlap in 3 places.
+  // So there are (6 choose 2) + (5 choose 2) - 3 variables in the program
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(6) + NChoose2(5) - 3);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(),
+            5);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
+                .evaluator()
+                ->matrix_rows(),
+            4);
+  // The constraint that the "1" in the psd variables are equal to 1 plus
+  // the one constraints that the minors indexed by [x(1), y(1)] are equal.
+  //  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 2);
+  //  Check that the linear equality constraints are the claimed ones.
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 2);
+  EXPECT_TRUE(CompareMatrices(relaxation->EvalBindingAtInitialGuess(
+                                  relaxation->linear_equality_constraints()[0]),
+                              Eigen::VectorXd::Ones(1)));
+  auto psd_agree_constraint = relaxation->linear_equality_constraints()[1];
+  EXPECT_TRUE(CompareMatrices(
+      relaxation->EvalBindingAtInitialGuess(psd_agree_constraint),
+      Eigen::VectorXd::Zero(
+          psd_agree_constraint.evaluator()->num_constraints())));
+
+  // 3 original linear constraints and 2 big linear constraints for the product
+  // constraints.
+  EXPECT_EQ(relaxation->linear_constraints().size(), 3 + 2);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2 + 2 + 5);
+
+  // First 3 linear constraints are lbx ≤ Ax * x ≤ ubx, and lby ≤ Ay * y ≤ uby
+  // and lb_overlap ≤ A_overlap * overlap_vars ≤ ub_overlap.
+  int constraint_ind = 0;
+  EXPECT_TRUE(
+      CompareMatrices(Ax, relaxation->linear_constraints()[constraint_ind]
+                              .evaluator()
+                              ->GetDenseA()));
+  EXPECT_TRUE(
+      CompareMatrices(lbx, relaxation->linear_constraints()[constraint_ind]
+                               .evaluator()
+                               ->lower_bound()));
+  EXPECT_TRUE(
+      CompareMatrices(ubx, relaxation->linear_constraints()[constraint_ind]
+                               .evaluator()
+                               ->upper_bound()));
+  ++constraint_ind;
+  EXPECT_TRUE(
+      CompareMatrices(Ay, relaxation->linear_constraints()[constraint_ind]
+                              .evaluator()
+                              ->GetDenseA()));
+  EXPECT_TRUE(
+      CompareMatrices(lby, relaxation->linear_constraints()[constraint_ind]
+                               .evaluator()
+                               ->lower_bound()));
+  EXPECT_TRUE(
+      CompareMatrices(uby, relaxation->linear_constraints()[constraint_ind]
+                               .evaluator()
+                               ->upper_bound()));
+  ++constraint_ind;
+  EXPECT_TRUE(CompareMatrices(A_overlap,
+                              relaxation->linear_constraints()[constraint_ind]
+                                  .evaluator()
+                                  ->GetDenseA()));
+  EXPECT_TRUE(CompareMatrices(lb_overlap,
+                              relaxation->linear_constraints()[constraint_ind]
+                                  .evaluator()
+                                  ->lower_bound()));
+  EXPECT_TRUE(CompareMatrices(ub_overlap,
+                              relaxation->linear_constraints()[constraint_ind]
+                                  .evaluator()
+                                  ->upper_bound()));
+  ++constraint_ind;
+  ASSERT_EQ(constraint_ind, 3);
+
+  // Fourth linear (in the new decision variables) constraint is 0 ≤
+  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on x_ and the overlap
+  // constraints stacked.
+  b.resize(4);  // all of the finite lower/upper bounds.
+  b << -lbx[0], ubx[1], -lb_overlap[0], ub_overlap[0];
+  A.resize(4, 4);
+  // We need to reshuffle to columns of Ax, as they are out of order.
+  // clang-format off
+  A << -Ax(0,1), -Ax(0,0),         -Ax(0,2), 0, // NOLINT
+        Ax(1,1),  Ax(1,0),          Ax(1,2), 0, // NOLINT
+        0,        -A_overlap(0, 0), 0,      -A_overlap(0, 1), // NOLINT
+        0,        A_overlap(0, 0),  0,       A_overlap(0, 1); // NOLINT
+  // clang-format on
+  expected_size = (b.size() * (b.size() + 1)) / 2;
+  EXPECT_EQ(relaxation->linear_constraints()[constraint_ind]
+                .evaluator()
+                ->num_constraints(),
+            expected_size);
+  VectorXd test_vec(4);
+  test_vec << test_point.at(x_(0)), test_point.at(x_(1)), test_point.at(x_(2)),
+      test_point.at(y_(1));
+  value = relaxation->EvalBindingAtInitialGuess(
+      relaxation->linear_constraints()[constraint_ind]);
+  expected_mat =
+      (A * test_vec - b) * (A * test_vec - b).transpose() - b * b.transpose();
+  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
+  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  value = relaxation->linear_constraints()[constraint_ind]
+              .evaluator()
+              ->lower_bound();
+  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
+  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  ++constraint_ind;
+
+  // Fifth linear (in the new decision variables) constraint is 0 ≤
+  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on y_ and the overlap
+  // constraints stacked.
+  b.resize(5);  // all of the finite lower/upper bounds.
+  b << -lby[0], uby[1], uby[2], -lb_overlap[0], ub_overlap[0];
+  A.resize(5, 3);
+  // We need to reshuffle to columns of Ay, as they are out of order.
+  // NOLINTBEGIN
+  // clang-format off
+  A << 0,               -Ay(0,1), -Ay(0,0), // NOLINT
+       0,                Ay(1,1),  Ay(1,0), // NOLINT
+       0,                Ay(2,1),  Ay(2,0), // NOLINT
+      -A_overlap(0, 0),  0,       -A_overlap(0, 1), // NOLINT
+       A_overlap(0, 0),  0,        A_overlap(0, 1); // NOLINT
+  // clang-format on
+
+  expected_size = (b.size() * (b.size() + 1)) / 2;
+  EXPECT_EQ(relaxation->linear_constraints()[constraint_ind]
+                .evaluator()
+                ->num_constraints(),
+            expected_size);
+  test_vec.resize(3);
+  test_vec << test_point.at(x_(1)), test_point.at(y_(0)), test_point.at(y_(1));
+
+  value = relaxation->EvalBindingAtInitialGuess(
+      relaxation->linear_constraints()[constraint_ind]);
+  expected_mat =
+      (A * test_vec - b) * (A * test_vec - b).transpose() - b * b.transpose();
+  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
+  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  value = relaxation->linear_constraints()[constraint_ind]
+              .evaluator()
+              ->lower_bound();
+  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
+  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  ++constraint_ind;
+  ASSERT_EQ(constraint_ind, 5);
+}
+
+TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearEqualityConstraint) {
+  const std::map<Variable, double> test_point{
+      {x_(0), -0.6}, {x_(1), 3.8}, {x_(2), 4.7}, {y_(0), 9.9}, {y_(1), 3.4}};
+
+  // clang-format off
+  const Matrix3d Ax{{0.8, -2.3, 0.7},
+                    {-2.1, 2.9, 2.2},
+                    {-2.8, 0.5, 5.2}};
+  // clang-format on
+  const Vector3d bx(3.58, -4.26, -2.61);
+  prog_.AddLinearEqualityConstraint(Ax, bx, x_);
+
+  MatrixXd Ay(3, 2);
+  // clang-format off
+  Ay << -0.08, 1.62,
+         5.17, -6.47,
+         0.93, -2.97;
+  // clang-format on
+  const Vector3d by(4.6, -0.1, 0.7);
+  const Vector3d uby(kInf, 0.1, 7.2);
+  prog_.AddLinearEqualityConstraint(Ay, by, y_);
+
+  // Relaxes the x_ and y_ variables separately.
+  auto relaxation = MakeSemidefiniteRelaxation(
+      prog_, std::vector<Variables>{x_vars_, y_vars_});
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 0);
+  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
+  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) - 1 variables in
+  // the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(5) + NChoose2(4) - 1);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(),
+            4);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
+                .evaluator()
+                ->matrix_rows(),
+            3);
+  // The  constraint that the "1" in the psd variables is equal to 1.
+  // Additionally, the relaxation of each groups causes one extra product
+  // constraint for each of the column of the resulting PSD matrices.
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1 + 4 + 3);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2 + 8);
+
+  int cur_constraint = 0;
+  // The first two constraints are the linear constraints inherited from prog_.
+  auto CompareLinearEqualityConstraintsAtIdx = [&](const int idx) {
+    EXPECT_TRUE(CompareMatrices(
+        relaxation->linear_equality_constraints()[idx].evaluator()->GetDenseA(),
+        prog_.linear_equality_constraints()[idx].evaluator()->GetDenseA()));
+    EXPECT_TRUE(CompareMatrices(
+        relaxation->linear_equality_constraints()[idx]
+            .evaluator()
+            ->lower_bound(),
+        prog_.linear_equality_constraints()[idx].evaluator()->lower_bound()));
+  };
+  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+  ASSERT_EQ(cur_constraint, 2);
+
+  // This equality constraint is due to "1" being equal to 1.
+  EXPECT_TRUE(CompareMatrices(
+      relaxation->EvalBindingAtInitialGuess(
+          relaxation->linear_equality_constraints()[cur_constraint++]),
+      Eigen::VectorXd::Ones(1)));
+
+  // This next set of equality constraints are due to the relaxation of the x_
+  // variables.
+  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
+                        test_point.at(x_(2)));
+  VectorXd expected;
+  VectorXd value;
+  int start = cur_constraint;
+  for (; cur_constraint < start + 3; ++cur_constraint) {
+    // Linear constraints are (Ax*x_ - bx)*x_i = 0.
+    expected = (Ax * x_test - bx) * x_test[cur_constraint - start];
+    value = relaxation->EvalBindingAtInitialGuess(
+        relaxation->linear_equality_constraints()[cur_constraint]);
+    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  }
+  ASSERT_EQ(cur_constraint, 6);
+
+  // This set of equality constraints are due to the relaxation of the y_
+  // variables.
+  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
+  start = cur_constraint;
+  for (; cur_constraint < start + 2; ++cur_constraint) {
+    // Linear constraints are (Ay*y_ - b)*y_i = 0.
+    expected = (Ay * y_test - by) * y_test[cur_constraint - start];
+    value = relaxation->EvalBindingAtInitialGuess(
+        relaxation->linear_equality_constraints()[cur_constraint]);
+    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  }
+  // At this point, we should have tested all the linear equality constraints.
+  ASSERT_EQ(cur_constraint, relaxation->linear_equality_constraints().size());
+
+  // Now construct variable groups and equality constraints which overlap.
+  MatrixXd A_overlap(1, 2);
+  // clang-format off
+  A_overlap << -7.9, 2.4;
+  // clang-format on
+  const Vector1d b_overlap(0.7);
+  VectorXDecisionVariable overlap_vars(2);
+  // These variables are not sorted according to their id intentionally.
+  overlap_vars << y_(0), x_(2);
+  const Vector2d overlap_test_vec{test_point.at(y_(0)), test_point.at(x_(2))};
+  prog_.AddLinearEqualityConstraint(A_overlap, b_overlap, overlap_vars);
+
+  MatrixXd A_overlap_sorted(A_overlap.rows(), A_overlap.cols());
+  A_overlap_sorted << A_overlap(0, 1), A_overlap(0, 0);
+  VectorXDecisionVariable overlap_vars_sorted(2);
+  overlap_vars_sorted << x_(2), y_(0);
+  const Vector2d overlap_test_vec_sorted(test_point.at(x_(2)),
+                                         test_point.at(y_(0)));
+  // Make sure the sorted and non-sorted version of this constraint are the
+  // same.
+  EXPECT_TRUE(
+      CompareMatrices(A_overlap * overlap_test_vec - b_overlap,
+                      A_overlap_sorted * overlap_test_vec_sorted - b_overlap));
+
+  std::vector<Variables> groups{Variables{x_(0), x_(1), x_(2), y_(0)},
+                                Variables{x_(2), y_(0), y_(1)}};
+  VectorXd group_1_test_vec(4);
+  group_1_test_vec << test_point.at(x_(0)), test_point.at(x_(1)),
+      test_point.at(x_(2)), test_point.at(y_(0));
+  VectorXd group_2_test_vec(3);
+  group_2_test_vec << test_point.at(x_(2)), test_point.at(y_(0)),
+      test_point.at(y_(1));
+
+  relaxation = MakeSemidefiniteRelaxation(prog_, groups);
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  cur_constraint = 0;
+
+  // The variables which get relaxed are [x(0), x(1), x(2), y(0), 1] and
+  // [x(2), y(0), y(1), 1]. These two groups of variables overlap in 3 places.
+  // So there are (6 choose 2) + (5 choose 2) - 3 variables in the program
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(6) + NChoose2(5) - 3);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(),
+            5);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
+                .evaluator()
+                ->matrix_rows(),
+            4);
+  // Three linear equality constraints in the original program, then one
+  // constraint that the "1" in the psd variables are equal to 1. Additionally,
+  // the relaxation of each groups causes one extra product constraint for each
+  // linear equality constraint and for each of the column of the
+  // resulting PSD  matrices minus 1. Finally, one more equality constraint for
+  // the agreement of the PSD matrices.
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(),
+            3 + 1 + 2 * 4 + 2 * 3 + 1);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(),
+            relaxation->positive_semidefinite_constraints().size() +
+                relaxation->linear_equality_constraints().size());
+
+  // The first three constraints are the linear constraints inherited from
+  // prog_.
+  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+  ASSERT_EQ(cur_constraint, 3);
+
+  // This next set of equality constraints are due to the relaxation of
+  // [x(0), x(1), x(2), y(0), 1].
+  EXPECT_TRUE(CompareMatrices(
+      relaxation->EvalBindingAtInitialGuess(
+          relaxation->linear_equality_constraints()[cur_constraint++]),
+      Eigen::VectorXd::Ones(1)));
+
+  start = cur_constraint;
+  for (; cur_constraint < start + 4; ++cur_constraint) {
+    // Linear constraints are (Ax*x_ - bx)*x_i = 0.
+    expected = (Ax * x_test - bx) * group_1_test_vec[cur_constraint - start];
+    value = relaxation->EvalBindingAtInitialGuess(
+        relaxation->linear_equality_constraints()[cur_constraint]);
+    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  }
+  start = cur_constraint;
+  for (; cur_constraint < start + 4; ++cur_constraint) {
+    // Linear constraints are (A_overlap*[x_(2), y_(0)] - b_overlap)*[x(0),
+    // x(1), x(2), y(0)] = 0.
+    expected = (A_overlap_sorted * overlap_test_vec_sorted - b_overlap) *
+               group_1_test_vec[cur_constraint - start];
+    value = relaxation->EvalBindingAtInitialGuess(
+        relaxation->linear_equality_constraints()[cur_constraint]);
+    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  }
+  ASSERT_EQ(cur_constraint, 12);
+
+  // This next set of equality constraints are due to the relaxation of
+  // [x(2), y(0), y(1), 1].
+  start = cur_constraint;
+  for (; cur_constraint < start + 3; ++cur_constraint) {
+    // Linear constraints are (Ay*y_ - by)*[x(2), y(0), y(1)]. = 0.
+    expected = (Ay * y_test - by) * group_2_test_vec[cur_constraint - start];
+    value = relaxation->EvalBindingAtInitialGuess(
+        relaxation->linear_equality_constraints()[cur_constraint]);
+    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  }
+  start = cur_constraint;
+  for (; cur_constraint < start + 3; ++cur_constraint) {
+    // Linear constraints are (A_overlap*[x_(2), y_(0)] -
+    // b_overlap)*[x_(2), y_(0), y_(1)] = 0.
+    expected = (A_overlap_sorted * overlap_test_vec_sorted - b_overlap) *
+               group_2_test_vec[cur_constraint - start];
+    value = relaxation->EvalBindingAtInitialGuess(
+        relaxation->linear_equality_constraints()[cur_constraint]);
+    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+  }
+  ASSERT_EQ(cur_constraint, 18);
+
+  auto psd_agree_constraint =
+      relaxation->linear_equality_constraints()[cur_constraint++];
+  EXPECT_TRUE(CompareMatrices(
+      relaxation->EvalBindingAtInitialGuess(psd_agree_constraint),
+      Eigen::VectorXd::Zero(
+          psd_agree_constraint.evaluator()->num_constraints())));
+  // All linear equality constraints have been checked.
+  ASSERT_EQ(cur_constraint, relaxation->linear_equality_constraints().size());
+}
 
 }  // namespace internal
 }  // namespace solvers

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -328,6 +328,31 @@ GTEST_TEST(MakeSemidefiniteRelaxationTest, QuadraticConstraint2) {
             1.0);
 }
 
+ class MakeSemidefiniteRelaxationVariableGroupTest: public ::testing::Test {
+ protected:
+  void SetUp() override {
+    x_ = prog_.NewIndeterminates<3>();
+    y_ = prog_.NewIndeterminates<2>();
+    partition_group_.emplace_back(x_);
+    partition_group_.emplace_back(y_);
+//    overlap_group_.emplace_back(
+//        {x_(1), y_(0)}, {x_(2), y_(0)}
+//        );
+  }
+
+  MathematicalProgram prog_;
+  VectorIndeterminate<3> x_;
+  VectorIndeterminate<2> y_;
+
+  // A grouping of the variables that partitions the variables of the program.
+  std::vector<symbolic::Variables> partition_group_;
+  // A grouping of the variables which overlaps.
+  std::vector<symbolic::Variables> overlap_group_;
+
+
+};
+
+
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -32,8 +32,9 @@ void SetRelaxationInitialGuess(const Eigen::Ref<const VectorXd>& y_expected,
   relaxation->SetInitialGuess(X, X_expected);
 }
 
-void SetRelaxationInitialGuess(std::map<Variable, double> expected_values,
-                               MathematicalProgram* relaxation) {
+void SetRelaxationInitialGuess(
+    const std::map<Variable, double>& expected_values,
+    MathematicalProgram* relaxation) {
   for (const auto& [var, val] : expected_values) {
     relaxation->SetInitialGuess(var, val);
   }
@@ -304,7 +305,7 @@ GTEST_TEST(MakeSemidefiniteRelaxationTest, NonConvexQuadraticConstraint) {
   Matrix2d Q;
   Q << 1, 2, 3, 4;
   const Vector2d b(0.2, 0.4);
-  const double lb = -.4, ub = 0.5;
+  const double lb = -0.4, ub = 0.5;
   prog.AddQuadraticConstraint(Q, b, lb, ub, y);
   auto relaxation = MakeSemidefiniteRelaxation(prog);
 
@@ -691,7 +692,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticConstraint) {
                     {-1.1, -1.7}};
   // clang-format on
   const Vector2d bx(-0.2, -3.1);
-  const double lbx = -.7, ubx = 1.5;
+  const double lbx = -0.7, ubx = 1.5;
   // These are intentionally placed out of order with respect to the
   // ordering that happens in MakeSemidefiniteRelaxation.
   VectorX<Variable> out_of_order_x_vars(2);

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -443,8 +443,9 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, EmptyVariableGroup) {
       ".*non-convex.*");
 }
 
-// Checks that the number of semidefinite variables is always the same as the
-// number of variable groups.
+// Checks that the number of semidefinite matrix variables is always the same as
+// the number of variable groups and that the number of rows of each
+// semidefinite matrix variable is the size of the corresponding group + 1.
 TEST_F(MakeSemidefiniteRelaxationVariableGroupTest,
        EmptyProgramWithVariableGroups) {
   // Only relaxes the x_ variables.

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -1108,7 +1108,6 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearConstraint) {
   b << -lby[0], uby[1], uby[2], -lb_overlap[0], ub_overlap[0];
   A.resize(5, 3);
   // We need to reshuffle to columns of Ay, as they are out of order.
-  // NOLINTBEGIN
   // clang-format off
   A << 0,               -Ay(0,1), -Ay(0,0), // NOLINT
        0,                Ay(1,1),  Ay(1,0), // NOLINT

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -1,10 +1,7 @@
 #include "drake/solvers/semidefinite_relaxation.h"
 
-#include <iostream>
-
 #include <gtest/gtest.h>
 
-#include "drake/common/ssize.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/matrix_util.h"
@@ -1063,8 +1060,8 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearConstraint) {
   // clang-format off
   A << -Ax.row(0), 0,
         Ax.row(1), 0,
-        0, -A_overlap(0,0), 0, -A_overlap(0,1),
-        0,  A_overlap(0,0), 0,  A_overlap(0,1);
+        0, -A_overlap(0, 0), 0, -A_overlap(0, 1),
+        0,  A_overlap(0, 0), 0,  A_overlap(0, 1);
   // clang-format on
   expected_size = (b.size() * (b.size() + 1)) / 2;
   EXPECT_EQ(relaxation_partition->linear_constraints()[3]
@@ -1095,8 +1092,8 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearConstraint) {
   A << 0,              -Ay.row(0),
        0,               Ay.row(1),
        0,               Ay.row(2),
-       -A_overlap(0,0), 0, -A_overlap(0,1),
-        A_overlap(0,0), 0,  A_overlap(0,1);
+       -A_overlap(0, 0), 0, -A_overlap(0, 1),
+        A_overlap(0, 0), 0,  A_overlap(0, 1);
   // clang-format on
   expected_size = (b.size() * (b.size() + 1)) / 2;
   EXPECT_EQ(relaxation_partition->linear_constraints()[4]
@@ -1237,11 +1234,9 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearEqualityConstraint) {
   VectorXDecisionVariable overlap_vars(2);
   overlap_vars << x_(2), y_(0);
   prog_.AddLinearEqualityConstraint(A_overlap, b_overlap, overlap_vars);
-  std::cout << "SECOND ONE HERE" << std::endl;
 
   relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
   SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-  std::cout << *relaxation_partition << std::endl;
 
   // The variables which get relaxed are [x(0), x(1), x(2), y(0), 1] and
   // [x(2), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
@@ -1261,8 +1256,8 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearEqualityConstraint) {
   // constraints that the "1" in the psd variables are equal to 1. Additionally,
   // the relaxation of each groups causes one extra product constraint for each
   // linear equality constraint and for each of the column of the resulting PSD
-  // matrices minus 1. Finally, one more equality constraint for the agreement of the
-  // PSD matrices.
+  // matrices minus 1. Finally, one more equality constraint for the agreement
+  // of the PSD matrices.
   EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(),
             3 + 2 + 2 * 4 + 2 * 3 + 1);
   EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 20);
@@ -1338,15 +1333,14 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearEqualityConstraint) {
     EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
   }
 
-  std::cout << "cur constraint idx = " << cur_constraint << std::endl;
   ASSERT_EQ(cur_constraint, 19);
-
   auto psd_agree_constraint =
       relaxation_partition->linear_equality_constraints()[cur_constraint++];
   EXPECT_TRUE(CompareMatrices(
       relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
       Eigen::VectorXd::Zero(
           psd_agree_constraint.evaluator()->num_constraints())));
+  // All linear equality constraints have been checked.
   ASSERT_EQ(cur_constraint,
             relaxation_partition->linear_equality_constraints().size());
 }

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -611,8 +611,6 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticCost) {
                   relaxation_overlap->linear_costs()[1])[0],
               test_points.at(x_(2)) * test_points.at(y_(1)), 1e-12);
 
-  std::cout << *relaxation_overlap << std::endl;
-
   // Check that the equality constraint on the relaxation matrices is correct.
   auto psd_agree_constraint =
       relaxation_overlap->linear_equality_constraints()[2];

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -335,9 +335,12 @@ GTEST_TEST(MakeSemidefiniteRelaxationTest, QuadraticConstraint2) {
     y_ = prog_.NewIndeterminates<2>();
     partition_group_.emplace_back(x_);
     partition_group_.emplace_back(y_);
-//    overlap_group_.emplace_back(
-//        {x_(1), y_(0)}, {x_(2), y_(0)}
-//        );
+    overlap_group_.emplace_back(
+        std::initializer_list<symbolic::Variable>({x_(1), y_(0)})
+        );
+    overlap_group_.emplace_back(
+        std::initializer_list<symbolic::Variable>({x_(0), y_(1)})
+        );
   }
 
   MathematicalProgram prog_;
@@ -348,10 +351,22 @@ GTEST_TEST(MakeSemidefiniteRelaxationTest, QuadraticConstraint2) {
   std::vector<symbolic::Variables> partition_group_;
   // A grouping of the variables which overlaps.
   std::vector<symbolic::Variables> overlap_group_;
-
-
 };
 
+TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, NoCostNorConstraints) {
+  const auto relaxation_empty = MakeSemidefiniteRelaxation(prog_, std::vector<symbolic::Variables>());
+
+
+
+  // X is 3x3 symmetric.
+  EXPECT_EQ(relaxation->num_vars(), 6);
+  // X ≽ 0.
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  // X(-1,-1) = 1.
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1);
+
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2);
+}
 
 }  // namespace internal
 }  // namespace solvers

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -48,6 +48,8 @@ void SetRelaxationInitialGuess(std::map<Variable, double> expected_values,
     }
     x_expected(n - 1) = 1;
     const MatrixXd X_expected = x_expected * x_expected.transpose();
+    std::cout << fmt::format("X_expected =\n{}", fmt_eigen(X_expected))
+              << std::endl;
     relaxation->SetInitialGuess(X_var, X_expected);
   }
 }
@@ -359,26 +361,26 @@ class MakeSemidefiniteRelaxationVariableGroupTest : public ::testing::Test {
   void SetUp() override {
     x_ = prog_.NewContinuousVariables<3>("x");
     y_ = prog_.NewContinuousVariables<2>("y");
-    partition_group_.emplace_back(x_);
-    partition_group_.emplace_back(y_);
-    overlap_group_.emplace_back(
-        std::initializer_list<symbolic::Variable>({x_(0), y_(0)}));
-    overlap_group_.emplace_back(
-        std::initializer_list<symbolic::Variable>({x_(1), y_(0), y_(1)}));
+
+    x_vars_ = Variables(x_);
+    y_vars_ = Variables(y_);
+    x0_y0_y1_vars_ = Variables{x_(0), y_(0), y_(1)};
+    x0_x2_y1_vars_ = Variables{x_(0), x_(2), y_(1)};
   }
 
   MathematicalProgram prog_;
   VectorIndeterminate<3> x_;
   VectorIndeterminate<2> y_;
 
-  // A grouping of the variables that partitions the variables of the program.
-  std::vector<Variables> partition_group_;
-  // A grouping of the variables which overlaps.
-  std::vector<Variables> overlap_group_;
+  Variables x_vars_;
+  Variables y_vars_;
+  Variables x0_y0_y1_vars_;
+  Variables x0_x2_y1_vars_;
 };
 
-// This test checks that constraints and costs which do not intersect any
-// variable group do not get relaxed into semidefinite variables.
+// This test checks that constraints and costs which are not a subset of any
+// variable group do not get relaxed. Also checks that non-convex quadratics
+// that are not relaxed throw errors.
 TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, EmptyVariableGroup) {
   // Make prog_ a convex program.
   prog_.AddLinearCost(y_[0]);
@@ -392,15 +394,17 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, EmptyVariableGroup) {
       QuadraticConstraint::HessianType::kPositiveSemidefinite);
 
   // Since prog_ is convex and we have no variable groups, then the relaxation
-  // should be exactly the original program.
+  // should be exactly the original program, with one more variable representing
+  // the "1" homogenization variable.
   const auto relaxation_empty =
       MakeSemidefiniteRelaxation(prog_, std::vector<Variables>());
 
-  // The relaxation has the exact same variables as the original program.
+  // The relaxation has includes same variables as the original program, as well
+  // as the "1" homogenization variable.
   Variables relax_vars{relaxation_empty->decision_variables()};
   Variables prog_vars{prog_.decision_variables()};
-  EXPECT_TRUE(relax_vars.IsSubsetOf(prog_vars) &&
-              prog_vars.IsSubsetOf(relax_vars));
+  EXPECT_TRUE(prog_vars.IsSubsetOf(relax_vars));
+  EXPECT_EQ(prog_vars.size() + 1, relax_vars.size());
 
   // The relaxation has the same costs.
   EXPECT_EQ(relaxation_empty->linear_costs().size(),
@@ -409,15 +413,17 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, EmptyVariableGroup) {
             prog_.quadratic_costs().size());
   EXPECT_EQ(relaxation_empty->GetAllCosts().size(), prog_.GetAllCosts().size());
 
-  // The relaxation has the same constraints.
+  // The relaxation has the same constraints except for the 1 homogenization
+  // constraint.
   EXPECT_EQ(relaxation_empty->linear_constraints().size(),
             prog_.linear_constraints().size());
   EXPECT_EQ(relaxation_empty->linear_equality_constraints().size(),
-            prog_.linear_equality_constraints().size());
+            prog_.linear_equality_constraints().size() + 1);
   EXPECT_EQ(relaxation_empty->quadratic_constraints().size(),
             prog_.quadratic_constraints().size());
+  // This confirms that we don't have any PSD constraints.
   EXPECT_EQ(relaxation_empty->GetAllConstraints().size(),
-            prog_.GetAllConstraints().size());
+            prog_.GetAllConstraints().size() + 1);
 
   // Now add a non-convex quadratic cost and expect a throw.
   auto non_convex_quadratic_cost = prog_.AddQuadraticCost(x_[0] * y_[1], false);
@@ -425,6 +431,11 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, EmptyVariableGroup) {
       MakeSemidefiniteRelaxation(prog_, std::vector<Variables>()),
       ".*non-convex.*");
   prog_.RemoveCost(non_convex_quadratic_cost);
+
+  // Make sure that after removing the non-convex cost, we can construct the
+  // relaxation successfully. This ensures that the next test does not throw for
+  // the wrong reason (i.e. forgot to delete the non-convex quadratic cost).
+  EXPECT_NO_THROW(MakeSemidefiniteRelaxation(prog_, std::vector<Variables>()));
 
   // Now add a non-convex quadratic constraint and expect a throw.
   auto non_convex_quadratic_constraint = prog_.AddQuadraticConstraint(
@@ -434,916 +445,950 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, EmptyVariableGroup) {
       ".*non-convex.*");
 }
 
-TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearCost) {
-  const std::map<Variable, double> test_point{
-      {x_(0), 1.1}, {x_(1), 0.24}, {x_(2), -2.2}, {y_(0), -0.7}, {y_(1), -3.1}};
-
-  prog_.AddLinearCost(x_[0] + x_[1]);
-
-  auto relaxation_partition =
-      MakeSemidefiniteRelaxation(prog_, partition_group_);
+// Checks that the number of semidefinite variables is always the same as the
+// number of variable groups.
+TEST_F(MakeSemidefiniteRelaxationVariableGroupTest,
+       EmptyProgramWithVariableGroups) {
   // Only relaxes the x_ variables.
-  EXPECT_EQ(relaxation_partition->linear_costs().size(), 1);
-  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 1);
+  auto relaxation = MakeSemidefiniteRelaxation(prog_, std::vector{x_vars_});
   // The variables which get relaxed are [x(0), x(1), x(2), 1]. The remaining
   // variables that do not get relaxed are [y(0), y(1)]. So there are (5
   // choose 2) + 2 variables in the program.
-  EXPECT_EQ(relaxation_partition->num_vars(), 2 + NChoose2(5));
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-            1);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
+  EXPECT_EQ(relaxation->num_vars(), 2 + NChoose2(5));
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
                 .evaluator()
                 ->matrix_rows(),
             4);
-  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 1);
-  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2);
-  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-                  relaxation_partition->linear_costs()[0])[0],
-              test_point.at(x_(0)) + test_point.at(x_(1)), 1e-12);
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2);
+  const Eigen::MatrixX<Variable> X = Eigen::Map<const MatrixX<Variable>>(
+      relaxation->positive_semidefinite_constraints()[0].variables().data(),
+      x_.size() + 1, x_.size() + 1);
+  for (int i = 0; i < x_.size(); ++i) {
+    EXPECT_TRUE(X(i, X.cols() - 1).equal_to(x_[i]));
+  }
 
-  auto relaxation_overlap = MakeSemidefiniteRelaxation(prog_, overlap_group_);
-
-  // Both variable groups intersect the linear cost, but the cost should only
-  // get added once so we still only have 1 PSD variable.
-  EXPECT_EQ(relaxation_overlap->linear_costs().size(), 1);
-  EXPECT_EQ(relaxation_overlap->GetAllCosts().size(), 1);
-  // The variables which get relaxed are [x(0), x(1), y(0), 1]. The remaining
-  // variables that do not get relaxed are [x(2), y(1)]. So there are (5 choose
-  // 2) + 2 variables in the program.
-  EXPECT_EQ(relaxation_overlap->num_vars(), NChoose2(5) + 2);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[0]
-                .evaluator()
-                ->matrix_rows(),
-            overlap_group_[0].size() + 2);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints().size(), 1);
-  EXPECT_EQ(relaxation_overlap->linear_equality_constraints().size(), 1);
-  EXPECT_EQ(relaxation_overlap->GetAllConstraints().size(), 2);
-
-  SetRelaxationInitialGuess(test_point, relaxation_overlap.get());
-  EXPECT_NEAR(relaxation_overlap->EvalBindingAtInitialGuess(
-                  relaxation_overlap->linear_costs()[0])[0],
-              test_point.at(x_(0)) + test_point.at(x_(1)), 1e-12);
-
-  // Add a linear cost that intersects the second of the variable groups.
-  prog_.AddLinearCost(y_[1]);
-  relaxation_overlap = MakeSemidefiniteRelaxation(prog_, overlap_group_);
-  // Both variable groups intersect the first linear cost and one of the groups
-  // intersects the second cost, we should get two PSD variables, one relaxing
-  // [x(0), x(1), y(0), 1] and another relaxing [x(0), x(1), y(0), y(1), 1].
-  // There is the remaining x(2) variable that is not relaxed.
-  EXPECT_EQ(relaxation_overlap->linear_costs().size(), 2);
-  EXPECT_EQ(relaxation_overlap->num_vars(),
-            NChoose2(5) + NChoose2(6) + 1 -
-            3 /* x(0), x(1) and y(0) are double counted so subtract 3*/);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints().size(), 2);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[0]
+  relaxation =
+      MakeSemidefiniteRelaxation(prog_, std::vector{x0_y0_y1_vars_, y_vars_});
+  // The variables which get relaxed are [x(0), y(0), y(1), 1] and [y(0), y(1),
+  // 1]. The remaining variables that do not get relaxed are [x(1), x(2)]. The
+  // variables [y(0), y(1), 1] get double counted So there are (5 choose 2) + (4
+  // choose 2) + 2 - 3 variables in the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(5) + NChoose2(4) + 2 - 3);
+  // One linear equality constraints from the 1 variables being equal to 1 and
+  // one linear equality constraint that the minors corresponding [y0, y1] are
+  // the same in the two psd variables.
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 2);
+  // Two psd constraints.
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
                 .evaluator()
                 ->matrix_rows(),
             4);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[1]
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
                 .evaluator()
                 ->matrix_rows(),
-            5);
-  // The two equality constraints that the "1" in the psd variables is equal to
-  // 1, plus the equality constraint of the psd matrices.
-  EXPECT_EQ(relaxation_overlap->linear_equality_constraints().size(), 3);
-  EXPECT_EQ(relaxation_overlap->GetAllConstraints().size(), 3 + 2);
+            3);
 
-  SetRelaxationInitialGuess(test_point, relaxation_overlap.get());
-  EXPECT_NEAR(relaxation_overlap->EvalBindingAtInitialGuess(
-                  relaxation_overlap->linear_costs()[0])[0],
-              test_point.at(x_(0)) + test_point.at(x_(1)), 1e-12);
-  EXPECT_NEAR(relaxation_overlap->EvalBindingAtInitialGuess(
-                  relaxation_overlap->linear_costs()[1])[0],
-              test_point.at(y_(1)), 1e-12);
+  const std::map<Variable, double> test_point{
+      {x_(0), 1.1}, {x_(1), 0.24}, {x_(2), -2.2}, {y_(0), -0.7}, {y_(1), -3.1}};
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  // Check the equality constraints are correct. The first one is that "1"
+  // equals 1.
+  EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
+                  relaxation->linear_equality_constraints()[0])[0],
+              1, 1e-12);
+  // The second one is that the submatrices corresponding to [y0, y1] are the
+  // same.
+  auto constraint = relaxation->linear_equality_constraints()[1];
+  const Eigen::MatrixX<Variable> X0 = Eigen::Map<const MatrixX<Variable>>(
+      relaxation->positive_semidefinite_constraints()[0].variables().data(),
+      x0_y0_y1_vars_.size() + 1, x0_y0_y1_vars_.size() + 1);
+  const Eigen::MatrixX<Variable> X1 = Eigen::Map<const MatrixX<Variable>>(
+      relaxation->positive_semidefinite_constraints()[1].variables().data(),
+      y_vars_.size() + 1, y_vars_.size() + 1);
+  Eigen::MatrixXd X0_y0_y1(2, 2);
+  Eigen::MatrixXd X1_y0_y1(2, 2);
+  // clang-format off
+  X0_y0_y1 << relaxation->GetInitialGuess(X0(1, 1)),
+              relaxation->GetInitialGuess(X0(1, 2)),
+              relaxation->GetInitialGuess(X0(1, 2)),
+              relaxation->GetInitialGuess(X0(2, 2));
 
-  // Check that the equality constraint on the relaxation matrices is correct.
-  auto psd_agree_constraint =
-      relaxation_overlap->linear_equality_constraints()[2];
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_overlap->EvalBindingAtInitialGuess(psd_agree_constraint),
-      Eigen::VectorXd::Zero(
-          psd_agree_constraint.evaluator()->num_constraints())));
+  X1_y0_y1 << relaxation->GetInitialGuess(X1(0, 0)),
+              relaxation->GetInitialGuess(X1(0, 1)),
+              relaxation->GetInitialGuess(X1(0, 1)),
+              relaxation->GetInitialGuess(X1(1, 1));
+  EXPECT_TRUE(CompareMatrices(X0_y0_y1, X1_y0_y1));
+  const Variables overlap_variables{X0(1, 1), X0(1, 2), X0(2, 2),
+                                    X1(0, 0), X1(0, 1), X1(1, 1)};
+  EXPECT_EQ(Variables{constraint.variables()}, overlap_variables);
+  EXPECT_TRUE(CompareMatrices(relaxation->EvalBindingAtInitialGuess(constraint),
+                              Eigen::Vector3d::Zero()));
 }
 
-TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticCost) {
-  const std::map<Variable, double> test_points{
-      {x_(0), 0.1}, {x_(1), -3.24}, {x_(2), 4.2}, {y_(0), -1.7}, {y_(1), -7.7}};
+ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearCost) {
+  const std::map<Variable, double> test_point{
+      {x_(0), 1.1}, {x_(1), 0.24}, {x_(2), -2.2}, {y_(0), -0.7}, {y_(1),
+      -3.1}};
+
+  prog_.AddLinearCost(x_[0] + x_[2] + y_[1]);
+
+  // Only relaxes the x_ variables.
+  auto relaxation =
+      MakeSemidefiniteRelaxation(prog_, std::vector<Variables>{x0_x2_y1_vars_});
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
+  // The variables which get relaxed are [x(0), x(1), x(2), 1]. The remaining
+  // variables that do not get relaxed are [y(0), y(1)]. So there are (5
+  // choose 2) + 2 variables in the program.
+  EXPECT_EQ(relaxation->num_vars(), 2 + NChoose2(5));
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(),
+            1);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(),
+            4);
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2);
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
+                  relaxation->linear_costs()[0])[0],
+              test_point.at(x_(0)) + test_point.at(x_(2)) + test_point.at(y_(1)), 1e-12);
+
+  // Relax an overlapping set of variables which both have the cost as a subset. The cost should only be added once.
+  const Variables x_vars_plus_y1{x_(0), x_(1), x_(2), y_(1)};
+  relaxation = MakeSemidefiniteRelaxation(prog_, std::vector<Variables>{x_vars_plus_y1, x0_x2_y1_vars_});
+
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
+  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and [x(0), x(2), y(1), 1]. The remaining
+  // variable that does not get relaxed is [y(0)]. So there are (6 choose 2) + (5 choose 2) + 1 - 4 variables in the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(6) + NChoose2(5) + 1 - 4);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
+                .evaluator()
+                ->matrix_rows(), 5);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
+                .evaluator()
+                ->matrix_rows(), 4);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 2);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 4);
+
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
+                  relaxation->linear_costs()[0])[0],
+             test_point.at(x_(0)) + test_point.at(x_(2)) + test_point.at(y_(1)), 1e-12);
+}
+
+ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticCost) {
+  const std::map<Variable, double> test_point{
+      {x_(0), 0.1}, {x_(1), -3.24}, {x_(2), 4.2}, {y_(0), -1.7}, {y_(1),
+      -7.7}};
 
   prog_.AddQuadraticCost(x_[0] * x_[1]);
 
-  auto relaxation_partition =
-      MakeSemidefiniteRelaxation(prog_, partition_group_);
   // Only relaxes the x_ variables.
-  EXPECT_EQ(relaxation_partition->linear_costs().size(), 1);
-  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 1);
+  auto relaxation =
+      MakeSemidefiniteRelaxation(prog_, std::vector<Variables>{x_vars_});
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
   // The variables which get relaxed are [x(0), x(1), x(2), 1]. The remaining
-  // variables that do not get relaxed are [y(0), y(1)]. So there are (4
+  // variables that do not get relaxed are [y(0), y(1)]. So there are (5
   // choose 2) + 2 variables in the program.
-  EXPECT_EQ(relaxation_partition->num_vars(), 2 + NChoose2(5));
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
+  EXPECT_EQ(relaxation->num_vars(), 2 + NChoose2(5));
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(),
             1);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
                 .evaluator()
                 ->matrix_rows(),
             4);
-  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 1);
-  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2);
-  SetRelaxationInitialGuess(test_points, relaxation_partition.get());
-  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-                  relaxation_partition->linear_costs()[0])[0],
-              test_points.at(x_(0)) * test_points.at(x_(1)), 1e-12);
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 1);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 2);
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
+                  relaxation->linear_costs()[0])[0],
+              test_point.at(x_(0)) * test_point.at(x_(1)), 1e-12);
 
-  auto relaxation_overlap = MakeSemidefiniteRelaxation(prog_, overlap_group_);
+  // Relax an overlapping set of variables. The cost should only be added once.
+  const Variables y_vars_plus_x0_x1{x_(0), x_(1), y_(0), y_(1)};
+  relaxation = MakeSemidefiniteRelaxation(prog_, std::vector<Variables>{x_vars_, y_vars_plus_x0_x1});
 
-  // Both variable groups intersect the linear cost, but the cost should only
-  // get added once so we still only have 1 PSD variable.
-  EXPECT_EQ(relaxation_overlap->linear_costs().size(), 1);
-  EXPECT_EQ(relaxation_overlap->GetAllCosts().size(), 1);
-  // The variables which get relaxed are [x(0), x(1), y(0), 1]. The remaining
-  // variables that do not get relaxed are [x(2), y(1)]. So there are (5 choose
-  // 2) + 2 variables in the program.
-  EXPECT_EQ(relaxation_overlap->num_vars(), NChoose2(5) + 2);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[0]
+  // Both variable groups contain the quadratic cost, but the cost should only
+  // get added once.
+  EXPECT_EQ(relaxation->linear_costs().size(), 1);
+  EXPECT_EQ(relaxation->GetAllCosts().size(), 1);
+  // The variables which get relaxed are [x(0), x(1), x(2), 1] and [x(0), x(1), y(0), y(1), 1]. The remaining
+  // variable that does not get relaxed is [x(2)]. So there are (5 choose 2) + (6 choose 2) + 1 - 4 variables in the program.
+  EXPECT_EQ(relaxation->num_vars(), NChoose2(5)+ NChoose2(6) + 1-4);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[0]
                 .evaluator()
-                ->matrix_rows(),
-            overlap_group_[0].size() + 2);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints().size(), 1);
-  EXPECT_EQ(relaxation_overlap->linear_equality_constraints().size(), 1);
-  EXPECT_EQ(relaxation_overlap->GetAllConstraints().size(), 2);
-  SetRelaxationInitialGuess(test_points, relaxation_overlap.get());
-  EXPECT_NEAR(relaxation_overlap->EvalBindingAtInitialGuess(
-                  relaxation_overlap->linear_costs()[0])[0],
-              test_points.at(x_(0)) * test_points.at(x_(1)), 1e-12);
-
-  //  Add a quadratic cost that intersects the second of the variable groups.
-  prog_.AddQuadraticCost(x_[2] * y_[1]);
-  relaxation_overlap = MakeSemidefiniteRelaxation(prog_, overlap_group_);
-  // Both variable groups intersect the first linear cost and one of the groups
-  // intersects the second cost, we should get two PSD variables, one relaxing
-  // [x(0), x(1), y(0), 1] and another relaxing
-  // [x(0), x(1), x(2), y(0), y(1), 1].
-  EXPECT_EQ(relaxation_overlap->linear_costs().size(), 2);
-  EXPECT_EQ(relaxation_overlap->num_vars(),
-            NChoose2(5) + NChoose2(7) -
-            3 /* x(0), x(1) and y(0) are double counted so subtract 2*/);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints().size(), 2);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[0]
+                ->matrix_rows(),4);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints()[1]
                 .evaluator()
-                ->matrix_rows(),
-            4);
-  EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[1]
-                .evaluator()
-                ->matrix_rows(),
-            6);
-  // The two equality constraints that the "1" in the psd variables are equal to
-  // 1, plus the PSD variables overlapping in
-  EXPECT_EQ(relaxation_overlap->linear_equality_constraints().size(), 3);
-  EXPECT_EQ(relaxation_overlap->GetAllConstraints().size(), 3 + 2);
-
-  SetRelaxationInitialGuess(test_points, relaxation_overlap.get());
-  EXPECT_NEAR(relaxation_overlap->EvalBindingAtInitialGuess(
-                  relaxation_overlap->linear_costs()[0])[0],
-              test_points.at(x_(0)) * test_points.at(x_(1)), 1e-12);
-  EXPECT_NEAR(relaxation_overlap->EvalBindingAtInitialGuess(
-                  relaxation_overlap->linear_costs()[1])[0],
-              test_points.at(x_(2)) * test_points.at(y_(1)), 1e-12);
-
-  // Check that the equality constraint on the relaxation matrices is correct.
-  auto psd_agree_constraint =
-      relaxation_overlap->linear_equality_constraints()[2];
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_overlap->EvalBindingAtInitialGuess(psd_agree_constraint),
-      Eigen::VectorXd::Zero(
-          psd_agree_constraint.evaluator()->num_constraints())));
+                ->matrix_rows(),5);
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 2);
+  EXPECT_EQ(relaxation->linear_equality_constraints().size(), 2);
+  EXPECT_EQ(relaxation->GetAllConstraints().size(), 4);
+  SetRelaxationInitialGuess(test_point, relaxation.get());
+  EXPECT_NEAR(relaxation->EvalBindingAtInitialGuess(
+                  relaxation->linear_costs()[0])[0],
+              test_point.at(x_(0)) * test_point.at(x_(1)), 1e-12);
+  // Add a quadratic cost that isn't relaxed.
 }
-
-TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticConstraint) {
-  const std::map<Variable, double> test_point{
-      {x_(0), 0.3}, {x_(1), -1.9}, {x_(2), -1.4}, {y_(0), -2.3}, {y_(1), -6.3}};
-
-  // An indefinite Q for the x_ variables.
-  // clang-format off
-  const Matrix3d Qx{{-3.3,  -0.8,  -0.5},
-                    {-1.1,  -1.7, -10.3},
-                    { 2.4,   0.3,   1.9}};
-  // clang-format on
-  const Vector3d bx(-0.2, -3.1, 2.7);
-  const double lbx = -.7, ubx = 1.5;
-  prog_.AddQuadraticConstraint(Qx, bx, lbx, ubx, x_);
-
-  // A PSD Q for the y_ variables. Q is PSD since it is diagonally dominant.
-  // clang-format off
-  const Matrix2d Qy{{1.7,  -0.8},
-                    {-0.8,   4.6}};
-  // clang-format on
-  const Vector2d by(-1.3, -0.4);
-  const double lby = 1.1, uby = 4.7;
-  prog_.AddQuadraticConstraint(
-      Qy, by, lby, uby, y_,
-      QuadraticConstraint::HessianType::kPositiveSemidefinite);
-
-  // Relaxes the x_ and y_ variables separately.
-  auto relaxation_partition =
-      MakeSemidefiniteRelaxation(prog_, partition_group_);
-  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-
-  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
-  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in the
-  // program.
-  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-            2);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-                .evaluator()
-                ->matrix_rows(),
-            4);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-                .evaluator()
-                ->matrix_rows(),
-            3);
-  // The two constraints that the "1" in the psd variables are equal to 1.
-  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 2);
-  // 2 original quadratic constraints.
-  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 2);
-  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 2 + 2);
-  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
-                        test_point.at(x_(2)));
-  EXPECT_NEAR(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition->linear_constraints()[0])[0],
-      (0.5 * x_test.transpose() * Qx * x_test + bx.transpose() * x_test)[0],
-      1e-12);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
-                .evaluator()
-                ->lower_bound()[0],
-            lbx);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
-                .evaluator()
-                ->upper_bound()[0],
-            ubx);
-
-  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
-  EXPECT_NEAR(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition->linear_constraints()[1])[0],
-      (0.5 * y_test.transpose() * Qy * y_test + by.transpose() * y_test)[0],
-      1e-12);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
-                .evaluator()
-                ->lower_bound()[0],
-            lby);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
-                .evaluator()
-                ->upper_bound()[0],
-            uby);
-
-  // Now add a quadratic constraint which intersects both variable groups. This
-  // will add 1 linear constraint to each semidefinite variable group, a linear
-  // equality constraint on the two semidefinite variables enforcing agreement.
-  // clang-format off
-  const Matrix2d Q_overlap{{2.3, -4.1},
-                           {-7.6,  1.9}};
-  // clang-format on
-  const Vector2d b_overlap{-1.2, 7.3};
-  const double lb_overlap = 0.1, ub_overlap = 2.2;
-  VectorXDecisionVariable overlap_vars(2);
-  // These are intentionally placed out of order with respect to the sorting
-  // that happens DoAddSemidefiniteVariableAndImpliedCostsAndConstraints in
-  overlap_vars << y_(1), x_(0);
-  prog_.AddQuadraticConstraint(Q_overlap, b_overlap, lb_overlap, ub_overlap,
-                               overlap_vars);
-  relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
-  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-
-  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and
-  // [x(0), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
-  // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
-  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-            2);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-                .evaluator()
-                ->matrix_rows(),
-            5);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-                .evaluator()
-                ->matrix_rows(),
-            4);
-  // The two constraints that the "1" in the psd variables are equal to 1 plus
-  // the one constraints that the minors indexed by [x(0), y(1)] are equal.
-  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 3);
-  // Check that the linear equality constraints are the claimed ones.
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition->linear_equality_constraints()[0]),
-      Eigen::VectorXd::Ones(1)));
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition->linear_equality_constraints()[1]),
-      Eigen::VectorXd::Ones(1)));
-  auto psd_agree_constraint =
-      relaxation_partition->linear_equality_constraints()[2];
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
-      Eigen::VectorXd::Zero(
-          psd_agree_constraint.evaluator()->num_constraints())));
-
-  // The first two quadratic constraints each become linear constraints. The
-  // third quadratic constraints gets converted to a linear constraint in each
-  // relaxation of the subgroups.
-  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 4);
-  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 3 + 4);
-  VectorXd overlap_test_vec1(4);
-  overlap_test_vec1 << test_point.at(x_(0)), test_point.at(x_(1)),
-      test_point.at(x_(2)), test_point.at(y_(1));
-
-  // The first quadratic constraint should be the Qx quadratic constraint.
-  Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(4, 4);
-  Q.topLeftCorner(Qx.rows(), Qx.rows()) = Qx;
-  Eigen::VectorXd b(4);
-  b << bx, 0;
-  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-                  relaxation_partition->linear_constraints()[0])[0],
-              (0.5 * overlap_test_vec1.transpose() * Q * overlap_test_vec1 +
-               b.transpose() * overlap_test_vec1)[0],
-              1e-12);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
-                .evaluator()
-                ->lower_bound()[0],
-            lbx);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
-                .evaluator()
-                ->upper_bound()[0],
-            ubx);
-  // The second quadratic constraint should be Q_overlap quadratic constraint.
-  Q.setZero();
-  Q(0, 0) = Q_overlap(1, 1);
-  Q(0, 3) = Q_overlap(1, 0);
-  Q(3, 0) = Q_overlap(0, 1);
-  Q(3, 3) = Q_overlap(0, 0);
-  b.setZero();
-  b(0) = b_overlap(1);
-  b(3) = b_overlap(0);
-  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-                  relaxation_partition->linear_constraints()[1])[0],
-              (0.5 * overlap_test_vec1.transpose() * Q * overlap_test_vec1 +
-               b.transpose() * overlap_test_vec1)[0],
-              1e-12);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
-                .evaluator()
-                ->lower_bound()[0],
-            lb_overlap);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
-                .evaluator()
-                ->upper_bound()[0],
-            ub_overlap);
-
-  VectorXd overlap_test_vec2(3);
-  overlap_test_vec2 << test_point.at(x_(0)), test_point.at(y_(0)),
-      test_point.at(y_(1));
-  // The third quadratic constraint should be the Qy quadratic constraint.
-  Q = Eigen::MatrixXd::Zero(3, 3);
-  Q.bottomRightCorner(Qy.rows(), Qy.rows()) = Qy;
-  b = Eigen::VectorXd::Zero(3);
-  b << 0, by;
-  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-                  relaxation_partition->linear_constraints()[2])[0],
-              (0.5 * overlap_test_vec2.transpose() * Q * overlap_test_vec2 +
-               b.transpose() * overlap_test_vec2)[0],
-              1e-12);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[2]
-                .evaluator()
-                ->lower_bound()[0],
-            lby);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[2]
-                .evaluator()
-                ->upper_bound()[0],
-            uby);
-  // The fourth quadratic constraint should be Q_overlap quadratic constraint.
-  Q.setZero();
-  Q(0, 0) = Q_overlap(1, 1);
-  Q(0, 2) = Q_overlap(1, 0);
-  Q(2, 0) = Q_overlap(0, 1);
-  Q(2, 2) = Q_overlap(0, 0);
-  b.setZero();
-  b(0) = b_overlap(1);
-  b(2) = b_overlap(0);
-  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
-                  relaxation_partition->linear_constraints()[3])[0],
-              (0.5 * overlap_test_vec2.transpose() * Q * overlap_test_vec2 +
-               b.transpose() * overlap_test_vec2)[0],
-              1e-12);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
-                .evaluator()
-                ->lower_bound()[0],
-            lb_overlap);
-  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
-                .evaluator()
-                ->upper_bound()[0],
-            ub_overlap);
-}
-
-TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearConstraint) {
-  const std::map<Variable, double> test_point{
-      {x_(0), 1.1}, {x_(1), 0.27}, {x_(2), -1.2}, {y_(0), -0.99}, {y_(1), 9.1}};
-
-  MatrixXd Ax(2, 3);
-  // clang-format off
-  Ax << 2,     0, 3.1,
-        -1, -1.7, 2.1;
-  // clang-format on
-  const Vector2d lbx(1.3, -kInf);
-  const Vector2d ubx(kInf, 0.1);
-  prog_.AddLinearConstraint(Ax, lbx, ubx, x_);
-
-  MatrixXd Ay(3, 2);
-  // clang-format off
-  Ay << 1.1,   2.7,
-        0.27, -9.1,
-        -1.2, -0.99;
-  // clang-format on
-  const Vector3d lby(1.3, -kInf, kInf);
-  const Vector3d uby(kInf, 0.1, 7.2);
-  prog_.AddLinearConstraint(Ay, lby, uby, y_);
-
-  // Relaxes the x_ and y_ variables separately.
-  auto relaxation_partition =
-      MakeSemidefiniteRelaxation(prog_, partition_group_);
-  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
-  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in the
-  // program.
-  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-            2);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-                .evaluator()
-                ->matrix_rows(),
-            4);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-                .evaluator()
-                ->matrix_rows(),
-            3);
-  // The two constraints that the "1" in the psd variables are equal to 1.
-  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 2);
-  // 2 original linear constraints, and each of these adds one product
-  // constraint.
-  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 2 + 2);
-  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 2 + 4);
-
-  // First 2 linear constraints are lbx ≤ Ax * x ≤ ubx, and lby ≤ Ay * y ≤ uby.
-  EXPECT_TRUE(CompareMatrices(
-      Ax,
-      relaxation_partition->linear_constraints()[0].evaluator()->GetDenseA()));
-  EXPECT_TRUE(CompareMatrices(lbx, relaxation_partition->linear_constraints()[0]
-                                       .evaluator()
-                                       ->lower_bound()));
-  EXPECT_TRUE(CompareMatrices(ubx, relaxation_partition->linear_constraints()[0]
-                                       .evaluator()
-                                       ->upper_bound()));
-  EXPECT_TRUE(CompareMatrices(
-      Ay,
-      relaxation_partition->linear_constraints()[1].evaluator()->GetDenseA()));
-  EXPECT_TRUE(CompareMatrices(lby, relaxation_partition->linear_constraints()[1]
-                                       .evaluator()
-                                       ->lower_bound()));
-  EXPECT_TRUE(CompareMatrices(uby, relaxation_partition->linear_constraints()[1]
-                                       .evaluator()
-                                       ->upper_bound()));
-  // Third linear (in the new decision variables) constraint is 0 ≤
-  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on x_ constraints
-  // stacked.
-  VectorXd b(2);  // all of the finite lower/upper bounds.
-  b << -lbx[0], ubx[1];
-  MatrixXd A(2, 3);
-  A << -Ax.row(0), Ax.row(1);
-  int expected_size = (b.size() * (b.size() + 1)) / 2;
-  EXPECT_EQ(relaxation_partition->linear_constraints()[2]
-                .evaluator()
-                ->num_constraints(),
-            expected_size);
-  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
-                        test_point.at(x_(2)));
-  VectorXd value = relaxation_partition->EvalBindingAtInitialGuess(
-      relaxation_partition->linear_constraints()[2]);
-  MatrixXd expected_mat =
-      (A * x_test - b) * (A * x_test - b).transpose() - b * b.transpose();
-  VectorXd expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
-  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  value =
-      relaxation_partition->linear_constraints()[2].evaluator()->lower_bound();
-  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
-  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-
-  // Fourth linear (in the new decision variables) constraint is 0 ≤
-  // (A*y-b)(A*y-b)ᵀ, where A and b represent all of the on y_ constraints
-  // stacked.
-  b.resize(3);  // all of the finite lower/upper bounds.
-  b << -lby[0], uby[1], uby[2];
-  A.resize(3, 2);
-  A << -Ay.row(0), Ay.row(1), Ay.row(2);
-  expected_size = (b.size() * (b.size() + 1)) / 2;
-  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
-                .evaluator()
-                ->num_constraints(),
-            expected_size);
-  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
-  value = relaxation_partition->EvalBindingAtInitialGuess(
-      relaxation_partition->linear_constraints()[3]);
-  expected_mat =
-      (A * y_test - b) * (A * y_test - b).transpose() - b * b.transpose();
-  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
-  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  value =
-      relaxation_partition->linear_constraints()[3].evaluator()->lower_bound();
-  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
-  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-
-  // Now add a linear constraint which intersects both variable groups. This
-  // will add 2 linear constraints to each semidefinite variable group, and 1
-  // linear equality constraint on the two semidefinite variables enforcing
-  // agreement on the overlap.
-  MatrixXd A_overlap(1, 2);
-  // clang-format off
-  A_overlap << -1.9, 2.7;
-  // clang-format on
-  const Vector1d lb_overlap(1.7);
-  const Vector1d ub_overlap(2.3);
-  VectorXDecisionVariable overlap_vars(2);
-  overlap_vars << x_(1), y_(1);
-  prog_.AddLinearConstraint(A_overlap, lb_overlap, ub_overlap, overlap_vars);
-  relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
-  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-
-  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and
-  // [x(1), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
-  // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
-  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-            2);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-                .evaluator()
-                ->matrix_rows(),
-            5);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-                .evaluator()
-                ->matrix_rows(),
-            4);
-  // The two constraints that the "1" in the psd variables are equal to 1 plus
-  // the one constraints that the minors indexed by [x(1), y(1)] are equal.
-  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 3);
-  // Check that the linear equality constraints are the claimed ones.
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition->linear_equality_constraints()[0]),
-      Eigen::VectorXd::Ones(1)));
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition->linear_equality_constraints()[1]),
-      Eigen::VectorXd::Ones(1)));
-  auto psd_agree_constraint =
-      relaxation_partition->linear_equality_constraints()[2];
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
-      Eigen::VectorXd::Zero(
-          psd_agree_constraint.evaluator()->num_constraints())));
-
-  // 3 original linear constraints, and each semidefinite relaxation has the
-  // product constraints.
-  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 3 + 2);
-  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 3 + 5);
-
-  // First 3 linear constraints are lbx ≤ Ax * x ≤ ubx, and lby ≤ Ay * y ≤ uby
-  // and lb_overlap ≤ A_overlap * overlap_vars ≤ ub_overlap.
-  EXPECT_TRUE(CompareMatrices(
-      Ax,
-      relaxation_partition->linear_constraints()[0].evaluator()->GetDenseA()));
-  EXPECT_TRUE(CompareMatrices(lbx, relaxation_partition->linear_constraints()[0]
-                                       .evaluator()
-                                       ->lower_bound()));
-  EXPECT_TRUE(CompareMatrices(ubx, relaxation_partition->linear_constraints()[0]
-                                       .evaluator()
-                                       ->upper_bound()));
-  EXPECT_TRUE(CompareMatrices(
-      Ay,
-      relaxation_partition->linear_constraints()[1].evaluator()->GetDenseA()));
-  EXPECT_TRUE(CompareMatrices(lby, relaxation_partition->linear_constraints()[1]
-                                       .evaluator()
-                                       ->lower_bound()));
-  EXPECT_TRUE(CompareMatrices(uby, relaxation_partition->linear_constraints()[1]
-                                       .evaluator()
-                                       ->upper_bound()));
-  EXPECT_TRUE(CompareMatrices(
-      A_overlap,
-      relaxation_partition->linear_constraints()[2].evaluator()->GetDenseA()));
-  EXPECT_TRUE(
-      CompareMatrices(lb_overlap, relaxation_partition->linear_constraints()[2]
-                                      .evaluator()
-                                      ->lower_bound()));
-  EXPECT_TRUE(
-      CompareMatrices(ub_overlap, relaxation_partition->linear_constraints()[2]
-                                      .evaluator()
-                                      ->upper_bound()));
-
-  // Fourth linear (in the new decision variables) constraint is 0 ≤
-  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on x_ and the overlap
-  // constraints stacked.
-  b.resize(4);  // all of the finite lower/upper bounds.
-  b << -lbx[0], ubx[1], -lb_overlap[0], ub_overlap[0];
-  A.resize(4, 4);
-  // clang-format off
-  A << -Ax.row(0), 0,
-        Ax.row(1), 0,
-        0, -A_overlap(0, 0), 0, -A_overlap(0, 1),
-        0,  A_overlap(0, 0), 0,  A_overlap(0, 1);
-  // clang-format on
-  expected_size = (b.size() * (b.size() + 1)) / 2;
-  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
-                .evaluator()
-                ->num_constraints(),
-            expected_size);
-  VectorXd test_vec(4);
-  test_vec << test_point.at(x_(0)), test_point.at(x_(1)), test_point.at(x_(2)),
-      test_point.at(y_(1));
-  value = relaxation_partition->EvalBindingAtInitialGuess(
-      relaxation_partition->linear_constraints()[3]);
-  expected_mat =
-      (A * test_vec - b) * (A * test_vec - b).transpose() - b * b.transpose();
-  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
-  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  value =
-      relaxation_partition->linear_constraints()[3].evaluator()->lower_bound();
-  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
-  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-
-  // Fifth linear (in the new decision variables) constraint is 0 ≤
-  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on y_ and the overlap
-  // constraints stacked.
-  b.resize(5);  // all of the finite lower/upper bounds.
-  b << -lby[0], uby[1], uby[2], -lb_overlap[0], ub_overlap[0];
-  A.resize(5, 3);
-  // clang-format off
-  A << 0,              -Ay.row(0),
-       0,               Ay.row(1),
-       0,               Ay.row(2),
-       -A_overlap(0, 0), 0, -A_overlap(0, 1),
-        A_overlap(0, 0), 0,  A_overlap(0, 1);
-  // clang-format on
-  expected_size = (b.size() * (b.size() + 1)) / 2;
-  EXPECT_EQ(relaxation_partition->linear_constraints()[4]
-                .evaluator()
-                ->num_constraints(),
-            expected_size);
-  test_vec.resize(3);
-  test_vec << test_point.at(x_(1)), test_point.at(y_(0)), test_point.at(y_(1));
-
-  value = relaxation_partition->EvalBindingAtInitialGuess(
-      relaxation_partition->linear_constraints()[4]);
-  expected_mat =
-      (A * test_vec - b) * (A * test_vec - b).transpose() - b * b.transpose();
-  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
-  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  value =
-      relaxation_partition->linear_constraints()[4].evaluator()->lower_bound();
-  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
-  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-}
-
-TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearEqualityConstraint) {
-  const std::map<Variable, double> test_point{
-      {x_(0), -0.6}, {x_(1), 3.8}, {x_(2), 4.7}, {y_(0), 9.9}, {y_(1), 3.4}};
-
-  // clang-format off
-  const Matrix3d Ax{{0.8, -2.3, 0.7},
-                    {-2.1, 2.9, 2.2},
-                    {-2.8, 0.5, 5.2}};
-  // clang-format on
-  const Vector3d bx(3.58, -4.26, -2.61);
-  prog_.AddLinearEqualityConstraint(Ax, bx, x_);
-
-  MatrixXd Ay(3, 2);
-  // clang-format off
-  Ay << -0.08, 1.62,
-         5.17, -6.47,
-         0.93, -2.97;
-  // clang-format on
-  const Vector3d by(4.6, -0.1, 0.7);
-  const Vector3d uby(kInf, 0.1, 7.2);
-  prog_.AddLinearEqualityConstraint(Ay, by, y_);
-
-  // Relaxes the x_ and y_ variables separately.
-  auto relaxation_partition =
-      MakeSemidefiniteRelaxation(prog_, partition_group_);
-  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
-  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
-  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in the
-  // program.
-  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-            2);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-                .evaluator()
-                ->matrix_rows(),
-            4);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-                .evaluator()
-                ->matrix_rows(),
-            3);
-  // The two constraints that the "1" in the psd variables are equal to 1.
-  // Additionally, the relaxation of each groups causes one extra product
-  // constraint for each of the column of the resulting PSD matrices.
-  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(),
-            2 + 4 + 3);
-  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 9);
-
-  int cur_constraint = 0;
-  // The first two constraints are the linear constraints inherited from prog_.
-  auto CompareLinearEqualityConstraintsAtIdx = [&](const int idx) {
-    EXPECT_TRUE(CompareMatrices(
-        relaxation_partition->linear_equality_constraints()[idx]
-            .evaluator()
-            ->GetDenseA(),
-        prog_.linear_equality_constraints()[idx].evaluator()->GetDenseA()));
-    EXPECT_TRUE(CompareMatrices(
-        relaxation_partition->linear_equality_constraints()[idx]
-            .evaluator()
-            ->lower_bound(),
-        prog_.linear_equality_constraints()[idx].evaluator()->lower_bound()));
-  };
-  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-  ASSERT_EQ(cur_constraint, 2);
-
-  // This next set of equality constraints are due to the relaxation of the x_
-  // variables.
-  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
-                        test_point.at(x_(2)));
-  VectorXd expected;
-  VectorXd value;
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition
-              ->linear_equality_constraints()[cur_constraint++]),
-      Eigen::VectorXd::Ones(1)));
-  int start = cur_constraint;
-  for (; cur_constraint < start + 3; ++cur_constraint) {
-    // Linear constraints are (Ax*x_ - bx)*x_i = 0.
-    expected = (Ax * x_test - bx) * x_test[cur_constraint - start];
-    value = relaxation_partition->EvalBindingAtInitialGuess(
-        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  }
-  ASSERT_EQ(cur_constraint, 6);
-
-  // This set of equality constraints are due to the relaxation of the y_
-  // variables.
-  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition
-              ->linear_equality_constraints()[cur_constraint++]),
-      Eigen::VectorXd::Ones(1)));
-  start = cur_constraint;
-  for (; cur_constraint < start + 2; ++cur_constraint) {
-    // Linear constraints are (Ax*x_ - b)*x_i = 0.
-    expected = (Ay * y_test - by) * y_test[cur_constraint - start];
-    value = relaxation_partition->EvalBindingAtInitialGuess(
-        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  }
-  // At this point, we should have tested all the linear equality constraints.
-  ASSERT_EQ(cur_constraint,
-            relaxation_partition->linear_equality_constraints().size());
-
-  // Now add a linear equality constraint which intersects both variable groups.
-  // This will add 2 linear constraints to each semidefinite variable group, and
-  // 1 linear equality constraint on the two semidefinite variables enforcing
-  // agreement on the overlap.
-  MatrixXd A_overlap(1, 2);
-  // clang-format off
-  A_overlap << -7.9, 2.4;
-  // clang-format on
-  const Vector1d b_overlap(0.7);
-  VectorXDecisionVariable overlap_vars(2);
-  overlap_vars << x_(2), y_(0);
-  prog_.AddLinearEqualityConstraint(A_overlap, b_overlap, overlap_vars);
-
-  relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
-  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
-
-  // The variables which get relaxed are [x(0), x(1), x(2), y(0), 1] and
-  // [x(2), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
-  // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
-  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
-            2);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
-                .evaluator()
-                ->matrix_rows(),
-            5);
-  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
-                .evaluator()
-                ->matrix_rows(),
-            4);
-  // Three linear equality constraints in the original program, then two
-  // constraints that the "1" in the psd variables are equal to 1. Additionally,
-  // the relaxation of each groups causes one extra product constraint for each
-  // linear equality constraint and for each of the column of the resulting PSD
-  // matrices minus 1. Finally, one more equality constraint for the agreement
-  // of the PSD matrices.
-  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(),
-            3 + 2 + 2 * 4 + 2 * 3 + 1);
-  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 20);
-  cur_constraint = 0;
-
-  // The first three constraints are the linear constraints inherited from
-  // prog_.
-  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
-  ASSERT_EQ(cur_constraint, 3);
-
-  // This next set of equality constraints are due to the relaxation of [x(0),
-  // x(1), x(2), y(0), 1].
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition
-              ->linear_equality_constraints()[cur_constraint++]),
-      Eigen::VectorXd::Ones(1)));
-  const Vector2d overlap_test(test_point.at(x_(2)), test_point.at(y_(0)));
-
-  VectorXd partition1_vec_test(4);
-  partition1_vec_test << test_point.at(x_(0)), test_point.at(x_(1)),
-      test_point.at(x_(2)), test_point.at(y_(0));
-
-  start = cur_constraint;
-  for (; cur_constraint < start + 4; ++cur_constraint) {
-    // Linear constraints are (Ax*x_ - bx)*x_i = 0.
-    expected = (Ax * x_test - bx) * partition1_vec_test[cur_constraint - start];
-    value = relaxation_partition->EvalBindingAtInitialGuess(
-        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  }
-  start = cur_constraint;
-  for (; cur_constraint < start + 4; ++cur_constraint) {
-    // Linear constraints are (A_overlap*[x_(2), y_(0)] - b_overlap)*x_i = 0.
-    expected = (A_overlap * overlap_test - b_overlap) *
-               partition1_vec_test[cur_constraint - start];
-    value = relaxation_partition->EvalBindingAtInitialGuess(
-        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  }
-  ASSERT_EQ(cur_constraint, 12);
-
-  // This next set of equality constraints are due to the relaxation of [x(2),
-  // y(0), y(1), 1].
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(
-          relaxation_partition
-              ->linear_equality_constraints()[cur_constraint++]),
-      Eigen::VectorXd::Ones(1)));
-
-  VectorXd partition2_vec_test(3);
-  partition2_vec_test << test_point.at(x_(2)), test_point.at(y_(0)),
-      test_point.at(y_(1));
-
-  start = cur_constraint;
-  for (; cur_constraint < start + 3; ++cur_constraint) {
-    // Linear constraints are (Ay*y_ - by)*partition2_vec_test_i = 0.
-    expected = (Ay * y_test - by) * partition2_vec_test[cur_constraint - start];
-    value = relaxation_partition->EvalBindingAtInitialGuess(
-        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  }
-  start = cur_constraint;
-  for (; cur_constraint < start + 3; ++cur_constraint) {
-    // Linear constraints are (A_overlap*[x_(2), y_(0)] -
-    // b_overlap)*partition2_vec_test_i = 0.
-    expected = (A_overlap * overlap_test - b_overlap) *
-               partition2_vec_test[cur_constraint - start];
-    value = relaxation_partition->EvalBindingAtInitialGuess(
-        relaxation_partition->linear_equality_constraints()[cur_constraint]);
-    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
-  }
-
-  ASSERT_EQ(cur_constraint, 19);
-  auto psd_agree_constraint =
-      relaxation_partition->linear_equality_constraints()[cur_constraint++];
-  EXPECT_TRUE(CompareMatrices(
-      relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
-      Eigen::VectorXd::Zero(
-          psd_agree_constraint.evaluator()->num_constraints())));
-  // All linear equality constraints have been checked.
-  ASSERT_EQ(cur_constraint,
-            relaxation_partition->linear_equality_constraints().size());
-}
+//
+// TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticConstraint) {
+//  const std::map<Variable, double> test_point{
+//      {x_(0), 0.3}, {x_(1), -1.9}, {x_(2), -1.4}, {y_(0), -2.3}, {y_(1),
+//      -6.3}};
+//
+//  // An indefinite Q for the x_ variables.
+//  // clang-format off
+//  const Matrix3d Qx{{-3.3,  -0.8,  -0.5},
+//                    {-1.1,  -1.7, -10.3},
+//                    { 2.4,   0.3,   1.9}};
+//  // clang-format on
+//  const Vector3d bx(-0.2, -3.1, 2.7);
+//  const double lbx = -.7, ubx = 1.5;
+//  prog_.AddQuadraticConstraint(Qx, bx, lbx, ubx, x_);
+//
+//  // A PSD Q for the y_ variables. Q is PSD since it is diagonally dominant.
+//  // clang-format off
+//  const Matrix2d Qy{{1.7,  -0.8},
+//                    {-0.8,   4.6}};
+//  // clang-format on
+//  const Vector2d by(-1.3, -0.4);
+//  const double lby = 1.1, uby = 4.7;
+//  prog_.AddQuadraticConstraint(
+//      Qy, by, lby, uby, y_,
+//      QuadraticConstraint::HessianType::kPositiveSemidefinite);
+//
+//  // Relaxes the x_ and y_ variables separately.
+//  auto relaxation_partition =
+//      MakeSemidefiniteRelaxation(prog_, partition_group_);
+//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
+//
+//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
+//  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
+//  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in
+//  the
+//  // program.
+//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
+//            2);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
+//                .evaluator()
+//                ->matrix_rows(),
+//            4);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
+//                .evaluator()
+//                ->matrix_rows(),
+//            3);
+//  // The two constraints that the "1" in the psd variables are equal to 1.
+//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 2);
+//  // 2 original quadratic constraints.
+//  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 2);
+//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 2 + 2);
+//  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
+//                        test_point.at(x_(2)));
+//  EXPECT_NEAR(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition->linear_constraints()[0])[0],
+//      (0.5 * x_test.transpose() * Qx * x_test + bx.transpose() * x_test)[0],
+//      1e-12);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
+//                .evaluator()
+//                ->lower_bound()[0],
+//            lbx);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
+//                .evaluator()
+//                ->upper_bound()[0],
+//            ubx);
+//
+//  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
+//  EXPECT_NEAR(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition->linear_constraints()[1])[0],
+//      (0.5 * y_test.transpose() * Qy * y_test + by.transpose() * y_test)[0],
+//      1e-12);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
+//                .evaluator()
+//                ->lower_bound()[0],
+//            lby);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
+//                .evaluator()
+//                ->upper_bound()[0],
+//            uby);
+//
+//  // Now add a quadratic constraint which intersects both variable groups.
+//  This
+//  // will add 1 linear constraint to each semidefinite variable group, a
+//  linear
+//  // equality constraint on the two semidefinite variables enforcing
+//  agreement.
+//  // clang-format off
+//  const Matrix2d Q_overlap{{2.3, -4.1},
+//                           {-7.6,  1.9}};
+//  // clang-format on
+//  const Vector2d b_overlap{-1.2, 7.3};
+//  const double lb_overlap = 0.1, ub_overlap = 2.2;
+//  VectorXDecisionVariable overlap_vars(2);
+//  // These are intentionally placed out of order with respect to the sorting
+//  // that happens DoAddSemidefiniteVariableAndImpliedCostsAndConstraints in
+//  overlap_vars << y_(1), x_(0);
+//  prog_.AddQuadraticConstraint(Q_overlap, b_overlap, lb_overlap, ub_overlap,
+//                               overlap_vars);
+//  relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
+//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
+//
+//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
+//  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and
+//  // [x(0), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
+//  // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
+//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
+//            2);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
+//                .evaluator()
+//                ->matrix_rows(),
+//            5);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
+//                .evaluator()
+//                ->matrix_rows(),
+//            4);
+//  // The two constraints that the "1" in the psd variables are equal to 1 plus
+//  // the one constraints that the minors indexed by [x(0), y(1)] are equal.
+//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 3);
+//  // Check that the linear equality constraints are the claimed ones.
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition->linear_equality_constraints()[0]),
+//      Eigen::VectorXd::Ones(1)));
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition->linear_equality_constraints()[1]),
+//      Eigen::VectorXd::Ones(1)));
+//  auto psd_agree_constraint =
+//      relaxation_partition->linear_equality_constraints()[2];
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
+//      Eigen::VectorXd::Zero(
+//          psd_agree_constraint.evaluator()->num_constraints())));
+//
+//  // The first two quadratic constraints each become linear constraints. The
+//  // third quadratic constraints gets converted to a linear constraint in each
+//  // relaxation of the subgroups.
+//  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 4);
+//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 3 + 4);
+//  VectorXd overlap_test_vec1(4);
+//  overlap_test_vec1 << test_point.at(x_(0)), test_point.at(x_(1)),
+//      test_point.at(x_(2)), test_point.at(y_(1));
+//
+//  // The first quadratic constraint should be the Qx quadratic constraint.
+//  Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(4, 4);
+//  Q.topLeftCorner(Qx.rows(), Qx.rows()) = Qx;
+//  Eigen::VectorXd b(4);
+//  b << bx, 0;
+//  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
+//                  relaxation_partition->linear_constraints()[0])[0],
+//              (0.5 * overlap_test_vec1.transpose() * Q * overlap_test_vec1 +
+//               b.transpose() * overlap_test_vec1)[0],
+//              1e-12);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
+//                .evaluator()
+//                ->lower_bound()[0],
+//            lbx);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[0]
+//                .evaluator()
+//                ->upper_bound()[0],
+//            ubx);
+//  // The second quadratic constraint should be Q_overlap quadratic constraint.
+//  Q.setZero();
+//  Q(0, 0) = Q_overlap(1, 1);
+//  Q(0, 3) = Q_overlap(1, 0);
+//  Q(3, 0) = Q_overlap(0, 1);
+//  Q(3, 3) = Q_overlap(0, 0);
+//  b.setZero();
+//  b(0) = b_overlap(1);
+//  b(3) = b_overlap(0);
+//  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
+//                  relaxation_partition->linear_constraints()[1])[0],
+//              (0.5 * overlap_test_vec1.transpose() * Q * overlap_test_vec1 +
+//               b.transpose() * overlap_test_vec1)[0],
+//              1e-12);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
+//                .evaluator()
+//                ->lower_bound()[0],
+//            lb_overlap);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[1]
+//                .evaluator()
+//                ->upper_bound()[0],
+//            ub_overlap);
+//
+//  VectorXd overlap_test_vec2(3);
+//  overlap_test_vec2 << test_point.at(x_(0)), test_point.at(y_(0)),
+//      test_point.at(y_(1));
+//  // The third quadratic constraint should be the Qy quadratic constraint.
+//  Q = Eigen::MatrixXd::Zero(3, 3);
+//  Q.bottomRightCorner(Qy.rows(), Qy.rows()) = Qy;
+//  b = Eigen::VectorXd::Zero(3);
+//  b << 0, by;
+//  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
+//                  relaxation_partition->linear_constraints()[2])[0],
+//              (0.5 * overlap_test_vec2.transpose() * Q * overlap_test_vec2 +
+//               b.transpose() * overlap_test_vec2)[0],
+//              1e-12);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[2]
+//                .evaluator()
+//                ->lower_bound()[0],
+//            lby);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[2]
+//                .evaluator()
+//                ->upper_bound()[0],
+//            uby);
+//  // The fourth quadratic constraint should be Q_overlap quadratic constraint.
+//  Q.setZero();
+//  Q(0, 0) = Q_overlap(1, 1);
+//  Q(0, 2) = Q_overlap(1, 0);
+//  Q(2, 0) = Q_overlap(0, 1);
+//  Q(2, 2) = Q_overlap(0, 0);
+//  b.setZero();
+//  b(0) = b_overlap(1);
+//  b(2) = b_overlap(0);
+//  EXPECT_NEAR(relaxation_partition->EvalBindingAtInitialGuess(
+//                  relaxation_partition->linear_constraints()[3])[0],
+//              (0.5 * overlap_test_vec2.transpose() * Q * overlap_test_vec2 +
+//               b.transpose() * overlap_test_vec2)[0],
+//              1e-12);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
+//                .evaluator()
+//                ->lower_bound()[0],
+//            lb_overlap);
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
+//                .evaluator()
+//                ->upper_bound()[0],
+//            ub_overlap);
+//}
+//
+// TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearConstraint) {
+//  const std::map<Variable, double> test_point{
+//      {x_(0), 1.1}, {x_(1), 0.27}, {x_(2), -1.2}, {y_(0), -0.99},
+//      {y_(1), 9.1}};
+//
+//  MatrixXd Ax(2, 3);
+//  // clang-format off
+//  Ax << 2,     0, 3.1,
+//        -1, -1.7, 2.1;
+//  // clang-format on
+//  const Vector2d lbx(1.3, -kInf);
+//  const Vector2d ubx(kInf, 0.1);
+//  prog_.AddLinearConstraint(Ax, lbx, ubx, x_);
+//
+//  MatrixXd Ay(3, 2);
+//  // clang-format off
+//  Ay << 1.1,   2.7,
+//        0.27, -9.1,
+//        -1.2, -0.99;
+//  // clang-format on
+//  const Vector3d lby(1.3, -kInf, kInf);
+//  const Vector3d uby(kInf, 0.1, 7.2);
+//  prog_.AddLinearConstraint(Ay, lby, uby, y_);
+//
+//  // Relaxes the x_ and y_ variables separately.
+//  auto relaxation_partition =
+//      MakeSemidefiniteRelaxation(prog_, partition_group_);
+//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
+//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
+//  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
+//  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in
+//  the
+//  // program.
+//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
+//            2);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
+//                .evaluator()
+//                ->matrix_rows(),
+//            4);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
+//                .evaluator()
+//                ->matrix_rows(),
+//            3);
+//  // The two constraints that the "1" in the psd variables are equal to 1.
+//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 2);
+//  // 2 original linear constraints, and each of these adds one product
+//  // constraint.
+//  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 2 + 2);
+//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 2 + 4);
+//
+//  // First 2 linear constraints are lbx ≤ Ax * x ≤ ubx, and lby ≤ Ay * y ≤
+//  uby. EXPECT_TRUE(CompareMatrices(
+//      Ax,
+//      relaxation_partition->linear_constraints()[0].evaluator()->GetDenseA()));
+//  EXPECT_TRUE(CompareMatrices(lbx,
+//  relaxation_partition->linear_constraints()[0]
+//                                       .evaluator()
+//                                       ->lower_bound()));
+//  EXPECT_TRUE(CompareMatrices(ubx,
+//  relaxation_partition->linear_constraints()[0]
+//                                       .evaluator()
+//                                       ->upper_bound()));
+//  EXPECT_TRUE(CompareMatrices(
+//      Ay,
+//      relaxation_partition->linear_constraints()[1].evaluator()->GetDenseA()));
+//  EXPECT_TRUE(CompareMatrices(lby,
+//  relaxation_partition->linear_constraints()[1]
+//                                       .evaluator()
+//                                       ->lower_bound()));
+//  EXPECT_TRUE(CompareMatrices(uby,
+//  relaxation_partition->linear_constraints()[1]
+//                                       .evaluator()
+//                                       ->upper_bound()));
+//  // Third linear (in the new decision variables) constraint is 0 ≤
+//  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on x_ constraints
+//  // stacked.
+//  VectorXd b(2);  // all of the finite lower/upper bounds.
+//  b << -lbx[0], ubx[1];
+//  MatrixXd A(2, 3);
+//  A << -Ax.row(0), Ax.row(1);
+//  int expected_size = (b.size() * (b.size() + 1)) / 2;
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[2]
+//                .evaluator()
+//                ->num_constraints(),
+//            expected_size);
+//  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
+//                        test_point.at(x_(2)));
+//  VectorXd value = relaxation_partition->EvalBindingAtInitialGuess(
+//      relaxation_partition->linear_constraints()[2]);
+//  MatrixXd expected_mat =
+//      (A * x_test - b) * (A * x_test - b).transpose() - b * b.transpose();
+//  VectorXd expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
+//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  value =
+//      relaxation_partition->linear_constraints()[2].evaluator()->lower_bound();
+//  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
+//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//
+//  // Fourth linear (in the new decision variables) constraint is 0 ≤
+//  // (A*y-b)(A*y-b)ᵀ, where A and b represent all of the on y_ constraints
+//  // stacked.
+//  b.resize(3);  // all of the finite lower/upper bounds.
+//  b << -lby[0], uby[1], uby[2];
+//  A.resize(3, 2);
+//  A << -Ay.row(0), Ay.row(1), Ay.row(2);
+//  expected_size = (b.size() * (b.size() + 1)) / 2;
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
+//                .evaluator()
+//                ->num_constraints(),
+//            expected_size);
+//  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
+//  value = relaxation_partition->EvalBindingAtInitialGuess(
+//      relaxation_partition->linear_constraints()[3]);
+//  expected_mat =
+//      (A * y_test - b) * (A * y_test - b).transpose() - b * b.transpose();
+//  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
+//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  value =
+//      relaxation_partition->linear_constraints()[3].evaluator()->lower_bound();
+//  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
+//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//
+//  // Now add a linear constraint which intersects both variable groups. This
+//  // will add 2 linear constraints to each semidefinite variable group, and 1
+//  // linear equality constraint on the two semidefinite variables enforcing
+//  // agreement on the overlap.
+//  MatrixXd A_overlap(1, 2);
+//  // clang-format off
+//  A_overlap << -1.9, 2.7;
+//  // clang-format on
+//  const Vector1d lb_overlap(1.7);
+//  const Vector1d ub_overlap(2.3);
+//  VectorXDecisionVariable overlap_vars(2);
+//  overlap_vars << x_(1), y_(1);
+//  prog_.AddLinearConstraint(A_overlap, lb_overlap, ub_overlap, overlap_vars);
+//  relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
+//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
+//
+//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
+//  // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and
+//  // [x(1), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
+//  // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
+//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
+//            2);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
+//                .evaluator()
+//                ->matrix_rows(),
+//            5);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
+//                .evaluator()
+//                ->matrix_rows(),
+//            4);
+//  // The two constraints that the "1" in the psd variables are equal to 1 plus
+//  // the one constraints that the minors indexed by [x(1), y(1)] are equal.
+//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(), 3);
+//  // Check that the linear equality constraints are the claimed ones.
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition->linear_equality_constraints()[0]),
+//      Eigen::VectorXd::Ones(1)));
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition->linear_equality_constraints()[1]),
+//      Eigen::VectorXd::Ones(1)));
+//  auto psd_agree_constraint =
+//      relaxation_partition->linear_equality_constraints()[2];
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
+//      Eigen::VectorXd::Zero(
+//          psd_agree_constraint.evaluator()->num_constraints())));
+//
+//  // 3 original linear constraints, and each semidefinite relaxation has the
+//  // product constraints.
+//  EXPECT_EQ(relaxation_partition->linear_constraints().size(), 3 + 2);
+//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 3 + 5);
+//
+//  // First 3 linear constraints are lbx ≤ Ax * x ≤ ubx, and lby ≤ Ay * y ≤ uby
+//  // and lb_overlap ≤ A_overlap * overlap_vars ≤ ub_overlap.
+//  EXPECT_TRUE(CompareMatrices(
+//      Ax,
+//      relaxation_partition->linear_constraints()[0].evaluator()->GetDenseA()));
+//  EXPECT_TRUE(CompareMatrices(lbx,
+//  relaxation_partition->linear_constraints()[0]
+//                                       .evaluator()
+//                                       ->lower_bound()));
+//  EXPECT_TRUE(CompareMatrices(ubx,
+//  relaxation_partition->linear_constraints()[0]
+//                                       .evaluator()
+//                                       ->upper_bound()));
+//  EXPECT_TRUE(CompareMatrices(
+//      Ay,
+//      relaxation_partition->linear_constraints()[1].evaluator()->GetDenseA()));
+//  EXPECT_TRUE(CompareMatrices(lby,
+//  relaxation_partition->linear_constraints()[1]
+//                                       .evaluator()
+//                                       ->lower_bound()));
+//  EXPECT_TRUE(CompareMatrices(uby,
+//  relaxation_partition->linear_constraints()[1]
+//                                       .evaluator()
+//                                       ->upper_bound()));
+//  EXPECT_TRUE(CompareMatrices(
+//      A_overlap,
+//      relaxation_partition->linear_constraints()[2].evaluator()->GetDenseA()));
+//  EXPECT_TRUE(
+//      CompareMatrices(lb_overlap,
+//      relaxation_partition->linear_constraints()[2]
+//                                      .evaluator()
+//                                      ->lower_bound()));
+//  EXPECT_TRUE(
+//      CompareMatrices(ub_overlap,
+//      relaxation_partition->linear_constraints()[2]
+//                                      .evaluator()
+//                                      ->upper_bound()));
+//
+//  // Fourth linear (in the new decision variables) constraint is 0 ≤
+//  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on x_ and the overlap
+//  // constraints stacked.
+//  b.resize(4);  // all of the finite lower/upper bounds.
+//  b << -lbx[0], ubx[1], -lb_overlap[0], ub_overlap[0];
+//  A.resize(4, 4);
+//  // clang-format off
+//  A << -Ax.row(0), 0,
+//        Ax.row(1), 0,
+//        0, -A_overlap(0, 0), 0, -A_overlap(0, 1),
+//        0,  A_overlap(0, 0), 0,  A_overlap(0, 1);
+//  // clang-format on
+//  expected_size = (b.size() * (b.size() + 1)) / 2;
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[3]
+//                .evaluator()
+//                ->num_constraints(),
+//            expected_size);
+//  VectorXd test_vec(4);
+//  test_vec << test_point.at(x_(0)), test_point.at(x_(1)),
+//  test_point.at(x_(2)),
+//      test_point.at(y_(1));
+//  value = relaxation_partition->EvalBindingAtInitialGuess(
+//      relaxation_partition->linear_constraints()[3]);
+//  expected_mat =
+//      (A * test_vec - b) * (A * test_vec - b).transpose() - b * b.transpose();
+//  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
+//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  value =
+//      relaxation_partition->linear_constraints()[3].evaluator()->lower_bound();
+//  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
+//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//
+//  // Fifth linear (in the new decision variables) constraint is 0 ≤
+//  // (A*x-b)(A*x-b)ᵀ, where A and b represent all of the on y_ and the overlap
+//  // constraints stacked.
+//  b.resize(5);  // all of the finite lower/upper bounds.
+//  b << -lby[0], uby[1], uby[2], -lb_overlap[0], ub_overlap[0];
+//  A.resize(5, 3);
+//  // clang-format off
+//  A << 0,              -Ay.row(0),
+//       0,               Ay.row(1),
+//       0,               Ay.row(2),
+//       -A_overlap(0, 0), 0, -A_overlap(0, 1),
+//        A_overlap(0, 0), 0,  A_overlap(0, 1);
+//  // clang-format on
+//  expected_size = (b.size() * (b.size() + 1)) / 2;
+//  EXPECT_EQ(relaxation_partition->linear_constraints()[4]
+//                .evaluator()
+//                ->num_constraints(),
+//            expected_size);
+//  test_vec.resize(3);
+//  test_vec << test_point.at(x_(1)), test_point.at(y_(0)),
+//  test_point.at(y_(1));
+//
+//  value = relaxation_partition->EvalBindingAtInitialGuess(
+//      relaxation_partition->linear_constraints()[4]);
+//  expected_mat =
+//      (A * test_vec - b) * (A * test_vec - b).transpose() - b * b.transpose();
+//  expected = math::ToLowerTriangularColumnsFromMatrix(expected_mat);
+//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  value =
+//      relaxation_partition->linear_constraints()[4].evaluator()->lower_bound();
+//  expected = math::ToLowerTriangularColumnsFromMatrix(-b * b.transpose());
+//  EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//}
+//
+// TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearEqualityConstraint)
+// {
+//  const std::map<Variable, double> test_point{
+//      {x_(0), -0.6}, {x_(1), 3.8}, {x_(2), 4.7}, {y_(0), 9.9}, {y_(1), 3.4}};
+//
+//  // clang-format off
+//  const Matrix3d Ax{{0.8, -2.3, 0.7},
+//                    {-2.1, 2.9, 2.2},
+//                    {-2.8, 0.5, 5.2}};
+//  // clang-format on
+//  const Vector3d bx(3.58, -4.26, -2.61);
+//  prog_.AddLinearEqualityConstraint(Ax, bx, x_);
+//
+//  MatrixXd Ay(3, 2);
+//  // clang-format off
+//  Ay << -0.08, 1.62,
+//         5.17, -6.47,
+//         0.93, -2.97;
+//  // clang-format on
+//  const Vector3d by(4.6, -0.1, 0.7);
+//  const Vector3d uby(kInf, 0.1, 7.2);
+//  prog_.AddLinearEqualityConstraint(Ay, by, y_);
+//
+//  // Relaxes the x_ and y_ variables separately.
+//  auto relaxation_partition =
+//      MakeSemidefiniteRelaxation(prog_, partition_group_);
+//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
+//  EXPECT_EQ(relaxation_partition->GetAllCosts().size(), 0);
+//  // The variables which get relaxed are [x(0), x(1), x(2), 1] and
+//  // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in
+//  the
+//  // program.
+//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
+//            2);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
+//                .evaluator()
+//                ->matrix_rows(),
+//            4);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
+//                .evaluator()
+//                ->matrix_rows(),
+//            3);
+//  // The two constraints that the "1" in the psd variables are equal to 1.
+//  // Additionally, the relaxation of each groups causes one extra product
+//  // constraint for each of the column of the resulting PSD matrices.
+//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(),
+//            2 + 4 + 3);
+//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 9);
+//
+//  int cur_constraint = 0;
+//  // The first two constraints are the linear constraints inherited from
+//  prog_. auto CompareLinearEqualityConstraintsAtIdx = [&](const int idx) {
+//    EXPECT_TRUE(CompareMatrices(
+//        relaxation_partition->linear_equality_constraints()[idx]
+//            .evaluator()
+//            ->GetDenseA(),
+//        prog_.linear_equality_constraints()[idx].evaluator()->GetDenseA()));
+//    EXPECT_TRUE(CompareMatrices(
+//        relaxation_partition->linear_equality_constraints()[idx]
+//            .evaluator()
+//            ->lower_bound(),
+//        prog_.linear_equality_constraints()[idx].evaluator()->lower_bound()));
+//  };
+//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+//  ASSERT_EQ(cur_constraint, 2);
+//
+//  // This next set of equality constraints are due to the relaxation of the x_
+//  // variables.
+//  const Vector3d x_test(test_point.at(x_(0)), test_point.at(x_(1)),
+//                        test_point.at(x_(2)));
+//  VectorXd expected;
+//  VectorXd value;
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition
+//              ->linear_equality_constraints()[cur_constraint++]),
+//      Eigen::VectorXd::Ones(1)));
+//  int start = cur_constraint;
+//  for (; cur_constraint < start + 3; ++cur_constraint) {
+//    // Linear constraints are (Ax*x_ - bx)*x_i = 0.
+//    expected = (Ax * x_test - bx) * x_test[cur_constraint - start];
+//    value = relaxation_partition->EvalBindingAtInitialGuess(
+//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
+//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  }
+//  ASSERT_EQ(cur_constraint, 6);
+//
+//  // This set of equality constraints are due to the relaxation of the y_
+//  // variables.
+//  const Vector2d y_test(test_point.at(y_(0)), test_point.at(y_(1)));
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition
+//              ->linear_equality_constraints()[cur_constraint++]),
+//      Eigen::VectorXd::Ones(1)));
+//  start = cur_constraint;
+//  for (; cur_constraint < start + 2; ++cur_constraint) {
+//    // Linear constraints are (Ax*x_ - b)*x_i = 0.
+//    expected = (Ay * y_test - by) * y_test[cur_constraint - start];
+//    value = relaxation_partition->EvalBindingAtInitialGuess(
+//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
+//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  }
+//  // At this point, we should have tested all the linear equality constraints.
+//  ASSERT_EQ(cur_constraint,
+//            relaxation_partition->linear_equality_constraints().size());
+//
+//  // Now add a linear equality constraint which intersects both variable
+//  groups.
+//  // This will add 2 linear constraints to each semidefinite variable group,
+//  and
+//  // 1 linear equality constraint on the two semidefinite variables enforcing
+//  // agreement on the overlap.
+//  MatrixXd A_overlap(1, 2);
+//  // clang-format off
+//  A_overlap << -7.9, 2.4;
+//  // clang-format on
+//  const Vector1d b_overlap(0.7);
+//  VectorXDecisionVariable overlap_vars(2);
+//  overlap_vars << x_(2), y_(0);
+//  prog_.AddLinearEqualityConstraint(A_overlap, b_overlap, overlap_vars);
+//
+//  relaxation_partition = MakeSemidefiniteRelaxation(prog_, partition_group_);
+//  SetRelaxationInitialGuess(test_point, relaxation_partition.get());
+//
+//  // The variables which get relaxed are [x(0), x(1), x(2), y(0), 1] and
+//  // [x(2), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
+//  // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
+//  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
+//            2);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
+//                .evaluator()
+//                ->matrix_rows(),
+//            5);
+//  EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[1]
+//                .evaluator()
+//                ->matrix_rows(),
+//            4);
+//  // Three linear equality constraints in the original program, then two
+//  // constraints that the "1" in the psd variables are equal to 1.
+//  Additionally,
+//  // the relaxation of each groups causes one extra product constraint for
+//  each
+//  // linear equality constraint and for each of the column of the resulting
+//  PSD
+//  // matrices minus 1. Finally, one more equality constraint for the agreement
+//  // of the PSD matrices.
+//  EXPECT_EQ(relaxation_partition->linear_equality_constraints().size(),
+//            3 + 2 + 2 * 4 + 2 * 3 + 1);
+//  EXPECT_EQ(relaxation_partition->GetAllConstraints().size(), 2 + 20);
+//  cur_constraint = 0;
+//
+//  // The first three constraints are the linear constraints inherited from
+//  // prog_.
+//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+//  CompareLinearEqualityConstraintsAtIdx(cur_constraint++);
+//  ASSERT_EQ(cur_constraint, 3);
+//
+//  // This next set of equality constraints are due to the relaxation of [x(0),
+//  // x(1), x(2), y(0), 1].
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition
+//              ->linear_equality_constraints()[cur_constraint++]),
+//      Eigen::VectorXd::Ones(1)));
+//  const Vector2d overlap_test(test_point.at(x_(2)), test_point.at(y_(0)));
+//
+//  VectorXd partition1_vec_test(4);
+//  partition1_vec_test << test_point.at(x_(0)), test_point.at(x_(1)),
+//      test_point.at(x_(2)), test_point.at(y_(0));
+//
+//  start = cur_constraint;
+//  for (; cur_constraint < start + 4; ++cur_constraint) {
+//    // Linear constraints are (Ax*x_ - bx)*x_i = 0.
+//    expected = (Ax * x_test - bx) * partition1_vec_test[cur_constraint -
+//    start]; value = relaxation_partition->EvalBindingAtInitialGuess(
+//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
+//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  }
+//  start = cur_constraint;
+//  for (; cur_constraint < start + 4; ++cur_constraint) {
+//    // Linear constraints are (A_overlap*[x_(2), y_(0)] - b_overlap)*x_i = 0.
+//    expected = (A_overlap * overlap_test - b_overlap) *
+//               partition1_vec_test[cur_constraint - start];
+//    value = relaxation_partition->EvalBindingAtInitialGuess(
+//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
+//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  }
+//  ASSERT_EQ(cur_constraint, 12);
+//
+//  // This next set of equality constraints are due to the relaxation of [x(2),
+//  // y(0), y(1), 1].
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(
+//          relaxation_partition
+//              ->linear_equality_constraints()[cur_constraint++]),
+//      Eigen::VectorXd::Ones(1)));
+//
+//  VectorXd partition2_vec_test(3);
+//  partition2_vec_test << test_point.at(x_(2)), test_point.at(y_(0)),
+//      test_point.at(y_(1));
+//
+//  start = cur_constraint;
+//  for (; cur_constraint < start + 3; ++cur_constraint) {
+//    // Linear constraints are (Ay*y_ - by)*partition2_vec_test_i = 0.
+//    expected = (Ay * y_test - by) * partition2_vec_test[cur_constraint -
+//    start]; value = relaxation_partition->EvalBindingAtInitialGuess(
+//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
+//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  }
+//  start = cur_constraint;
+//  for (; cur_constraint < start + 3; ++cur_constraint) {
+//    // Linear constraints are (A_overlap*[x_(2), y_(0)] -
+//    // b_overlap)*partition2_vec_test_i = 0.
+//    expected = (A_overlap * overlap_test - b_overlap) *
+//               partition2_vec_test[cur_constraint - start];
+//    value = relaxation_partition->EvalBindingAtInitialGuess(
+//        relaxation_partition->linear_equality_constraints()[cur_constraint]);
+//    EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
+//  }
+//
+//  ASSERT_EQ(cur_constraint, 19);
+//  auto psd_agree_constraint =
+//      relaxation_partition->linear_equality_constraints()[cur_constraint++];
+//  EXPECT_TRUE(CompareMatrices(
+//      relaxation_partition->EvalBindingAtInitialGuess(psd_agree_constraint),
+//      Eigen::VectorXd::Zero(
+//          psd_agree_constraint.evaluator()->num_constraints())));
+//  // All linear equality constraints have been checked.
+//  ASSERT_EQ(cur_constraint,
+//            relaxation_partition->linear_equality_constraints().size());
+//}
 
 }  // namespace internal
 }  // namespace solvers

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -52,7 +52,7 @@ void SetRelaxationInitialGuess(std::map<Variable, double> expected_values,
   }
 }
 
-int Nchoose2(int n) {
+int NChoose2(int n) {
   return (n * (n - 1)) / 2;
 }
 
@@ -448,7 +448,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearCost) {
   // The variables which get relaxed are [x(0), x(1), x(2), 1]. The remaining
   // variables that do not get relaxed are [y(0), y(1)]. So there are (5
   // choose 2) + 2 variables in the program.
-  EXPECT_EQ(relaxation_partition->num_vars(), 2 + Nchoose2(5));
+  EXPECT_EQ(relaxation_partition->num_vars(), 2 + NChoose2(5));
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
             1);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
@@ -471,7 +471,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearCost) {
   // The variables which get relaxed are [x(0), x(1), y(0), 1]. The remaining
   // variables that do not get relaxed are [x(2), y(1)]. So there are (5 choose
   // 2) + 2 variables in the program.
-  EXPECT_EQ(relaxation_overlap->num_vars(), Nchoose2(5) + 2);
+  EXPECT_EQ(relaxation_overlap->num_vars(), NChoose2(5) + 2);
   EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[0]
                 .evaluator()
                 ->matrix_rows(),
@@ -494,8 +494,8 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearCost) {
   // There is the remaining x(2) variable that is not relaxed.
   EXPECT_EQ(relaxation_overlap->linear_costs().size(), 2);
   EXPECT_EQ(relaxation_overlap->num_vars(),
-            Nchoose2(5) + Nchoose2(6) + 1 -
-                3 /* x(0), x(1) and y(0) are double counted so subtract 3*/);
+            NChoose2(5) + NChoose2(6) + 1 -
+            3 /* x(0), x(1) and y(0) are double counted so subtract 3*/);
   EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints().size(), 2);
   EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[0]
                 .evaluator()
@@ -541,7 +541,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticCost) {
   // The variables which get relaxed are [x(0), x(1), x(2), 1]. The remaining
   // variables that do not get relaxed are [y(0), y(1)]. So there are (4
   // choose 2) + 2 variables in the program.
-  EXPECT_EQ(relaxation_partition->num_vars(), 2 + Nchoose2(5));
+  EXPECT_EQ(relaxation_partition->num_vars(), 2 + NChoose2(5));
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
             1);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
@@ -564,7 +564,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticCost) {
   // The variables which get relaxed are [x(0), x(1), y(0), 1]. The remaining
   // variables that do not get relaxed are [x(2), y(1)]. So there are (5 choose
   // 2) + 2 variables in the program.
-  EXPECT_EQ(relaxation_overlap->num_vars(), Nchoose2(5) + 2);
+  EXPECT_EQ(relaxation_overlap->num_vars(), NChoose2(5) + 2);
   EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[0]
                 .evaluator()
                 ->matrix_rows(),
@@ -586,8 +586,8 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticCost) {
   // [x(0), x(1), x(2), y(0), y(1), 1].
   EXPECT_EQ(relaxation_overlap->linear_costs().size(), 2);
   EXPECT_EQ(relaxation_overlap->num_vars(),
-            Nchoose2(5) + Nchoose2(7) -
-                3 /* x(0), x(1) and y(0) are double counted so subtract 2*/);
+            NChoose2(5) + NChoose2(7) -
+            3 /* x(0), x(1) and y(0) are double counted so subtract 2*/);
   EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints().size(), 2);
   EXPECT_EQ(relaxation_overlap->positive_semidefinite_constraints()[0]
                 .evaluator()
@@ -653,7 +653,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticConstraint) {
   // The variables which get relaxed are [x(0), x(1), x(2), 1] and
   // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in the
   // program.
-  EXPECT_EQ(relaxation_partition->num_vars(), Nchoose2(5) + Nchoose2(4));
+  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
             2);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
@@ -722,7 +722,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, QuadraticConstraint) {
   // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and
   // [x(0), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
   // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
-  EXPECT_EQ(relaxation_partition->num_vars(), Nchoose2(6) + Nchoose2(5) - 2);
+  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
             2);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
@@ -878,7 +878,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearConstraint) {
   // The variables which get relaxed are [x(0), x(1), x(2), 1] and
   // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in the
   // program.
-  EXPECT_EQ(relaxation_partition->num_vars(), Nchoose2(5) + Nchoose2(4));
+  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
             2);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
@@ -984,7 +984,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearConstraint) {
   // The variables which get relaxed are [x(0), x(1), x(2), y(1), 1] and
   // [x(1), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
   // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
-  EXPECT_EQ(relaxation_partition->num_vars(), Nchoose2(6) + Nchoose2(5) - 2);
+  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
             2);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
@@ -1145,7 +1145,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearEqualityConstraint) {
   // The variables which get relaxed are [x(0), x(1), x(2), 1] and
   // [y(0), y(1), 1]. So there are (5 choose 2) + (4 choose 2) variables in the
   // program.
-  EXPECT_EQ(relaxation_partition->num_vars(), Nchoose2(5) + Nchoose2(4));
+  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(5) + NChoose2(4));
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
             2);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]
@@ -1241,7 +1241,7 @@ TEST_F(MakeSemidefiniteRelaxationVariableGroupTest, LinearEqualityConstraint) {
   // The variables which get relaxed are [x(0), x(1), x(2), y(0), 1] and
   // [x(2), y(0), y(1), 1]. These two groups of variables overlap in 2 places.
   // So there are (6 choose 2) + (5 choose 2) - 2 variables in the program
-  EXPECT_EQ(relaxation_partition->num_vars(), Nchoose2(6) + Nchoose2(5) - 2);
+  EXPECT_EQ(relaxation_partition->num_vars(), NChoose2(6) + NChoose2(5) - 2);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints().size(),
             2);
   EXPECT_EQ(relaxation_partition->positive_semidefinite_constraints()[0]

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -265,7 +265,7 @@ GTEST_TEST(MakeSemidefiniteRelaxationTest, LinearEqualityConstraint) {
 
   for (int i = 2; i < 4; ++i) {
     // Linear constraints are (Ay - b)*y_i = 0.
-    expected = (A * y_test - b) * y_test[i-2];
+    expected = (A * y_test - b) * y_test[i - 2];
     value = relaxation->EvalBindingAtInitialGuess(
         relaxation->linear_equality_constraints()[i]);
     EXPECT_TRUE(CompareMatrices(value, expected, 1e-12));
@@ -301,8 +301,6 @@ GTEST_TEST(MakeSemidefiniteRelaxationTest, NonConvexQuadraticConstraint) {
   EXPECT_EQ(relaxation->linear_constraints()[0].evaluator()->upper_bound()[0],
             ub);
 }
-
-
 
 // This test checks that repeated variables in a quadratic constraint are
 // handled correctly.


### PR DESCRIPTION
Add the ability to specify which groups of variables are jointly relaxed in MakeSemidefiniteRelaxation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21043)
<!-- Reviewable:end -->
