### PR TITLE
mujoco parser assigns unique names to default geometries

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -917,7 +917,7 @@ class MujocoParser {
                                             *geom.shape, geom.name,
                                             geom.friction);
         }
-        num_geometries++;
+        ++num_geometries;
       }
     }
 

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -477,11 +477,6 @@ class MujocoParser {
                                const std::string& child_class = "") {
     MujocoGeometry geom;
 
-    if (!ParseStringAttribute(node, "name", &geom.name)) {
-      // Use "geom#" as the default body name.
-      geom.name = fmt::format("geom{}", num_geom);
-    }
-
     std::string class_name;
     if (!ParseStringAttribute(node, "class", &class_name)) {
       class_name = child_class.empty() ? "main" : child_class;
@@ -490,6 +485,13 @@ class MujocoParser {
       // TODO(russt): Add a test case covering childclass/default nesting once
       // the body element is supported.
       ApplyDefaultAttributes(*default_geometry_.at(class_name), node);
+    }
+
+    // Per the MuJoCo documentation, the name is not part of the defaults. This
+    // is consistent with Drake requiring that geometry names are unique.
+    if (!ParseStringAttribute(node, "name", &geom.name)) {
+      // Use "geom#" as the default body name.
+      geom.name = fmt::format("geom{}", num_geom);
     }
 
     geom.X_BG = ParseTransform(node);
@@ -901,10 +903,10 @@ class MujocoParser {
 
   void ParseWorldBody(XMLElement* node) {
     if (plant_->geometry_source_is_registered()) {
-      std::vector<MujocoGeometry> geometries;
+      int num_geometries = 0;
       for (XMLElement* link_node = node->FirstChildElement("geom"); link_node;
            link_node = link_node->NextSiblingElement("geom")) {
-        auto geom = ParseGeometry(link_node, geometries.size(), false);
+        auto geom = ParseGeometry(link_node, num_geometries, false);
         if (!geom.shape) continue;
         if (geom.register_visual) {
           plant_->RegisterVisualGeometry(plant_->world_body(), geom.X_BG,
@@ -915,6 +917,7 @@ class MujocoParser {
                                             *geom.shape, geom.name,
                                             geom.friction);
         }
+        num_geometries++;
       }
     }
 

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -321,6 +321,29 @@ TEST_F(MujocoParserTest, GeometryTypes) {
   CheckShape("box_from_sub", "Box");
 }
 
+// Confirm that multiple instances of the same geometry defaults get unique
+// names.
+TEST_F(MujocoParserTest, UniqueGeometryNames) {
+  std::string xml = R"""(
+<mujoco model="test">
+  <default class="default_box">
+    <geom type="box" size="0.1 0.2 0.3"/>
+  </default>
+  <worldbody>
+    <geom class="default_box"/>
+    <geom class="default_box"/>
+  </worldbody>
+</mujoco>
+)""";
+
+  AddModelFromString(xml, "test");
+  const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
+  EXPECT_NO_THROW(inspector.GetGeometryIdByName(
+      inspector.world_frame_id(), Role::kProximity, "geom0"));
+  EXPECT_NO_THROW(inspector.GetGeometryIdByName(
+      inspector.world_frame_id(), Role::kProximity, "geom1"));
+}
+
 TEST_F(MujocoParserTest, UnrecognizedGeometryTypes) {
   std::string xml = R"""(
 <mujoco model="test">


### PR DESCRIPTION
Previously, we failed when parsing https://github.com/google-deepmind/mujoco_menagerie/blob/d1e7d678c986788c8597e88111b4d94f000cf31e/aloha/scene.xml with a message of the form "already has a geometry named geom0".

+@rpoyner-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21045)
<!-- Reviewable:end -->
