### PR TITLE
Use map::contains() where we previously used count to simulate contains

### DIFF
--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -246,7 +246,7 @@ Polynomial<T> Polynomial<T>::EvaluatePartial(
     T new_coefficient = monomial.coefficient;
     std::vector<Term> new_terms;
     for (const Term& term : monomial.terms) {
-      if (var_values.count(term.var)) {
+      if (var_values.contains(term.var)) {
         new_coefficient *= pow(var_values.at(term.var), term.power);
       } else {
         new_terms.push_back(term);

--- a/common/symbolic/chebyshev_basis_element.cc
+++ b/common/symbolic/chebyshev_basis_element.cc
@@ -38,7 +38,7 @@ bool ChebyshevBasisElement::operator<(
 
 std::map<ChebyshevBasisElement, double> ChebyshevBasisElement::Differentiate(
     const Variable& var) const {
-  if (var_to_degree_map().count(var) == 0) {
+  if (!var_to_degree_map().contains(var)) {
     // Return an empty map (the differentiation result is 0) when @p var is not
     // a variable in @p this.
     return {};

--- a/common/symbolic/decompose.cc
+++ b/common/symbolic/decompose.cc
@@ -136,7 +136,7 @@ void DecomposeLinearExpressions(
                       fmt_eigen(vars.transpose())));  // e should be linear.
     }
     const Polynomial::MapType& map{p.monomial_to_coefficient_map()};
-    if (map.count(Monomial{}) > 0) {
+    if (map.contains(Monomial{})) {
       // e should not have a constant term.
       ThrowError(
           "non-linear", e.to_string(),
@@ -217,7 +217,7 @@ ExtractVariablesFromExpression(
   std::unordered_map<Variable::Id, int> map_var_to_index{};
   for (int i = 0; i < expressions.rows(); ++i) {
     for (const Variable& var : expressions(i).GetVariables()) {
-      if (map_var_to_index.count(var.get_id()) == 0) {
+      if (!map_var_to_index.contains(var.get_id())) {
         map_var_to_index.emplace(var.get_id(), var_vec.size());
         var_vec.push_back(var);
       }

--- a/common/symbolic/expression/environment.cc
+++ b/common/symbolic/expression/environment.cc
@@ -99,7 +99,7 @@ Environment::mapped_type& Environment::operator[](const key_type& key) {
 
 const Environment::mapped_type& Environment::operator[](
     const key_type& key) const {
-  if (map_.count(key) == 0) {
+  if (!map_.contains(key)) {
     ostringstream oss;
     oss << "Environment::operator[] was called on a const Environment "
         << "with a missing key \"" << key << "\".";

--- a/common/symbolic/expression/test/formula_test.cc
+++ b/common/symbolic/expression/test/formula_test.cc
@@ -626,16 +626,16 @@ TEST_F(SymbolicFormulaTest, AndWithBooleanVariableOperator) {
   // Checks if operator&& works Boolean variables as expected.
   const Formula f1{var_b1_ && var_b2_};
   ASSERT_TRUE(is_conjunction(f1));
-  EXPECT_EQ(get_operands(f1).count(b1_), 1);
-  EXPECT_EQ(get_operands(f1).count(b2_), 1);
+  EXPECT_TRUE(get_operands(f1).contains(b1_));
+  EXPECT_TRUE(get_operands(f1).contains(b2_));
 
   const Formula f2{var_b1_ && (y_ > 0)};
   ASSERT_TRUE(is_conjunction(f2));
-  EXPECT_EQ(get_operands(f2).count(b1_), 1);
+  EXPECT_TRUE(get_operands(f2).contains(b1_));
 
   const Formula f3{(x_ > 0) && var_b2_};
   ASSERT_TRUE(is_conjunction(f3));
-  EXPECT_EQ(get_operands(f3).count(b2_), 1);
+  EXPECT_TRUE(get_operands(f3).contains(b2_));
 }
 
 TEST_F(SymbolicFormulaTest, AndWithBooleanVariableEvaluate) {
@@ -715,16 +715,16 @@ TEST_F(SymbolicFormulaTest, OrWithBooleanVariableOperator) {
   // Checks if operator|| works with Boolean variables as expected.
   const Formula f1{var_b1_ || var_b2_};
   ASSERT_TRUE(is_disjunction(f1));
-  EXPECT_EQ(get_operands(f1).count(b1_), 1);
-  EXPECT_EQ(get_operands(f1).count(b2_), 1);
+  EXPECT_TRUE(get_operands(f1).contains(b1_));
+  EXPECT_TRUE(get_operands(f1).contains(b2_));
 
   const Formula f2{var_b1_ || (y_ > 0)};
   ASSERT_TRUE(is_disjunction(f2));
-  EXPECT_EQ(get_operands(f2).count(b1_), 1);
+  EXPECT_TRUE(get_operands(f2).contains(b1_));
 
   const Formula f3{(x_ > 0) || var_b2_};
   ASSERT_TRUE(is_disjunction(f3));
-  EXPECT_EQ(get_operands(f3).count(b2_), 1);
+  EXPECT_TRUE(get_operands(f3).contains(b2_));
 }
 
 TEST_F(SymbolicFormulaTest, OrWithBooleanVariableEvaluate) {
@@ -1066,19 +1066,19 @@ TEST_F(SymbolicFormulaTest, GetRhsExpression) {
 TEST_F(SymbolicFormulaTest, GetOperandsConjunction) {
   const set<Formula> formulas{get_operands(f1_ && f2_ && f3_ && f4_)};
   EXPECT_EQ(formulas.size(), 4u);
-  EXPECT_EQ(formulas.count(f1_), 1u);
-  EXPECT_EQ(formulas.count(f2_), 1u);
-  EXPECT_EQ(formulas.count(f3_), 1u);
-  EXPECT_EQ(formulas.count(f4_), 1u);
+  EXPECT_TRUE(formulas.contains(f1_));
+  EXPECT_TRUE(formulas.contains(f2_));
+  EXPECT_TRUE(formulas.contains(f3_));
+  EXPECT_TRUE(formulas.contains(f4_));
 }
 
 TEST_F(SymbolicFormulaTest, GetOperandsDisjunction) {
   const set<Formula> formulas{get_operands(f1_ || f2_ || f3_ || f4_)};
   EXPECT_EQ(formulas.size(), 4u);
-  EXPECT_EQ(formulas.count(f1_), 1u);
-  EXPECT_EQ(formulas.count(f2_), 1u);
-  EXPECT_EQ(formulas.count(f3_), 1u);
-  EXPECT_EQ(formulas.count(f4_), 1u);
+  EXPECT_TRUE(formulas.contains(f1_));
+  EXPECT_TRUE(formulas.contains(f2_));
+  EXPECT_TRUE(formulas.contains(f3_));
+  EXPECT_TRUE(formulas.contains(f4_));
 }
 
 TEST_F(SymbolicFormulaTest, GetOperand) {

--- a/common/symbolic/polynomial.cc
+++ b/common/symbolic/polynomial.cc
@@ -474,7 +474,7 @@ namespace {
 // returns `(2, xy)`.
 pair<int, Monomial> DifferentiateMonomial(const Monomial& m,
                                           const Variable& x) {
-  if (m.get_powers().count(x) == 0) {
+  if (!m.get_powers().contains(x)) {
     // x does not appear in m. Returns (0, 1).
     return make_pair(0, Monomial{});
   }

--- a/common/symbolic/polynomial_basis_element.cc
+++ b/common/symbolic/polynomial_basis_element.cc
@@ -17,7 +17,7 @@ std::map<Variable, int> ToVarToDegreeMap(
   DRAKE_DEMAND(vars.size() == exponents.size());
   std::map<Variable, int> powers;
   for (int i = 0; i < vars.size(); ++i) {
-    if (powers.count(vars[i]) > 0) {
+    if (powers.contains(vars[i])) {
       throw std::invalid_argument(fmt::format(
           "PolynomialBasisElement: {} is repeated", vars[i].get_name()));
     }

--- a/common/symbolic/test/monomial_util_test.cc
+++ b/common/symbolic/test/monomial_util_test.cc
@@ -30,7 +30,7 @@ void CheckCalcMonomialBasisOrderUpToOne(const drake::symbolic::Variables& t) {
   const auto basis_sorted = CalcMonomialBasisOrderUpToOne(t, true);
   EXPECT_EQ(basis_sorted.rows(), basis_size_expected);
   for (int i = 0; i < basis_sorted.rows(); ++i) {
-    EXPECT_EQ(basis_set.count(basis_sorted(i)), 1);
+    EXPECT_TRUE(basis_set.contains(basis_sorted(i)));
   }
   // Make sure that basis_sorted is actually in the graded lexicographic order.
   for (int i = 0; i < basis_sorted.rows() - 1; ++i) {

--- a/common/test/identifier_test.cc
+++ b/common/test/identifier_test.cc
@@ -171,15 +171,15 @@ TEST_F(IdentifierTests, PutInSet) {
   EXPECT_EQ(ids.size(), 0u);
   ids.insert(a1);
   EXPECT_EQ(ids.size(), 1u);
-  EXPECT_EQ(ids.count(a1), 1u);
+  EXPECT_TRUE(ids.contains(a1));
 
   ids.insert(a2);
   EXPECT_EQ(ids.size(), 2u);
-  EXPECT_EQ(ids.count(a2), 1u);
+  EXPECT_TRUE(ids.contains(a2));
 
   ids.insert(a1);
   EXPECT_EQ(ids.size(), 2u);
-  EXPECT_EQ(ids.count(a1), 1u);
+  EXPECT_TRUE(ids.contains(a1));
 }
 
 // Tests the streaming behavior.

--- a/common/test/polynomial_test.cc
+++ b/common/test/polynomial_test.cc
@@ -300,21 +300,21 @@ GTEST_TEST(PolynomialTest, GetVariables) {
   Polynomiald z = Polynomiald("z");
   Polynomiald::VarType z_var = z.GetSimpleVariable();
 
-  EXPECT_TRUE(x.GetVariables().count(x_var));
-  EXPECT_FALSE(x.GetVariables().count(y_var));
+  EXPECT_TRUE(x.GetVariables().contains(x_var));
+  EXPECT_FALSE(x.GetVariables().contains(y_var));
 
-  EXPECT_FALSE(Polynomiald().GetVariables().count(x_var));
+  EXPECT_FALSE(Polynomiald().GetVariables().contains(x_var));
 
-  EXPECT_TRUE((x + x).GetVariables().count(x_var));
+  EXPECT_TRUE((x + x).GetVariables().contains(x_var));
 
-  EXPECT_TRUE((x + y).GetVariables().count(x_var));
-  EXPECT_TRUE((x + y).GetVariables().count(y_var));
+  EXPECT_TRUE((x + y).GetVariables().contains(x_var));
+  EXPECT_TRUE((x + y).GetVariables().contains(y_var));
 
-  EXPECT_TRUE((x * y * y + z).GetVariables().count(x_var));
-  EXPECT_TRUE((x * y * y + z).GetVariables().count(y_var));
-  EXPECT_TRUE((x * y * y + z).GetVariables().count(z_var));
+  EXPECT_TRUE((x * y * y + z).GetVariables().contains(x_var));
+  EXPECT_TRUE((x * y * y + z).GetVariables().contains(y_var));
+  EXPECT_TRUE((x * y * y + z).GetVariables().contains(z_var));
 
-  EXPECT_FALSE(x.Derivative().GetVariables().count(x_var));
+  EXPECT_FALSE(x.Derivative().GetVariables().contains(x_var));
 }
 
 GTEST_TEST(PolynomialTest, Simplification) {

--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -602,7 +602,7 @@ GTEST_TEST(TypeSafeIndex, SortedPairIndexHashable) {
   AIndex a2(2);
   std::unordered_set<SortedPair<AIndex>> pairs;
   pairs.insert({a2, a1});
-  EXPECT_EQ(pairs.count(SortedPair<AIndex>(a1, a2)), 1);
+  EXPECT_TRUE(pairs.contains(SortedPair<AIndex>(a1, a2)));
 }
 
 }  // namespace

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -47,7 +47,7 @@ class YamlReadArchiveTest : public ::testing::TestWithParam<LoadYamlOptions> {
       throw std::logic_error("Bad contents parse " + contents);
     }
     const string_map<internal::Node>& mapping = loaded.GetMapping();
-    if (mapping.count("doc") != 1) {
+    if (!mapping.contains("doc")) {
       throw std::logic_error("Missing doc parse " + contents);
     }
     const internal::Node doc = mapping.at("doc");

--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -77,13 +77,13 @@ void RecursiveEmit(const internal::Node& node, YAML::EmitFromEvents* sink) {
         // member function in our header file), use it to specify output order;
         // otherwise, use alphabetical order.
         std::vector<std::string> key_order;
-        if (data.mapping.count(kKeyOrder)) {
+        if (data.mapping.contains(kKeyOrder)) {
           const internal::Node& key_order_node = data.mapping.at(kKeyOrder);
           // Use Accept()'s ordering.  (If EraseMatchingMaps has been called,
           // some of the keys may have disappeared.)
           for (const auto& item : key_order_node.GetSequence()) {
             const std::string& key = item.GetScalar();
-            if (data.mapping.count(key)) {
+            if (data.mapping.contains(key)) {
               key_order.push_back(key);
             }
           }

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -233,7 +233,7 @@ class GeometryProperties {
 
   /** Reports if the given named group is part of this property set.  */
   bool HasGroup(const std::string& group_name) const {
-    return values_.count(group_name) > 0;
+    return values_.contains(group_name);
   }
 
   /** Reports the number of property groups in this set.  */

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -282,13 +282,13 @@ class GeometrySet {
 
   // Reports if the given `frame_id` has been added to the group.
   bool contains(FrameId frame_id) const {
-    return frame_ids_.count(frame_id) > 0;
+    return frame_ids_.contains(frame_id);
   }
 
   // Reports if the given `geometry_id` has been *explicitly* added to the
   // group. It will *not* capture geometry ids affixed to added frames.
   bool contains(GeometryId geometry_id) const {
-    return geometry_ids_.count(geometry_id) > 0;
+    return geometry_ids_.contains(geometry_id);
   }
 
   std::unordered_set<FrameId> frame_ids_;

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -758,7 +758,7 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
                                         const GeometryFrame& frame) {
   FrameId frame_id = frame.id();
 
-  if (frames_.count(frame_id) > 0) {
+  if (frames_.contains(frame_id)) {
     throw std::logic_error(
         "Registering frame with an id that has already been registered: " +
         to_string(frame_id));
@@ -1249,7 +1249,7 @@ SignedDistancePair<T> GeometryState<T>::ComputeSignedDistancePairClosestPoints(
 template <typename T>
 void GeometryState<T>::AddRenderer(
     std::string name, std::unique_ptr<render::RenderEngine> renderer) {
-  if (render_engines_.count(name) > 0) {
+  if (render_engines_.contains(name)) {
     throw std::logic_error(fmt::format(
         "AddRenderer(): A renderer with the name '{}' already exists", name));
   }
@@ -1268,7 +1268,7 @@ void GeometryState<T>::AddRenderer(
       DRAKE_DEMAND(properties != nullptr);
       auto accepting_renderers = properties->GetPropertyOrDefault(
           "renderer", "accepting", set<string>{});
-      if (accepting_renderers.empty() || accepting_renderers.count(name) > 0) {
+      if (accepting_renderers.empty() || accepting_renderers.contains(name)) {
         const GeometryId id = id_geo_pair.first;
         accepted |= render_engine->RegisterVisual(
             id, geometry.shape(), *properties, RigidTransformd(geometry.X_FG()),
@@ -1285,7 +1285,7 @@ void GeometryState<T>::AddRenderer(
 
 template <typename T>
 void GeometryState<T>::RemoveRenderer(const std::string& name) {
-  if (render_engines_.count(name) == 0) {
+  if (!render_engines_.contains(name)) {
     throw std::logic_error(fmt::format(
         "RemoveRenderer(): A renderer with the name '{}' does not exist",
         name));
@@ -1444,7 +1444,7 @@ void GeometryState<T>::ValidateFrameIds(
 template <typename T>
 void GeometryState<T>::ValidateRegistrationAndSetTopology(
     SourceId source_id, FrameId frame_id, GeometryId geometry_id) {
-  if (geometries_.count(geometry_id) > 0) {
+  if (geometries_.contains(geometry_id)) {
     throw std::logic_error(
         "Registering geometry with an id that has already been registered: " +
         to_string(geometry_id));
@@ -1720,7 +1720,7 @@ bool GeometryState<T>::AddToCompatibleRenderersUnchecked(
 
   bool added_to_renderer{false};
   for (auto& [name, engine] : render_engines_) {
-    if (accepting_renderers.empty() || accepting_renderers.count(name) > 0) {
+    if (accepting_renderers.empty() || accepting_renderers.contains(name)) {
       added_to_renderer =
           engine->RegisterVisual(geometry.id(), geometry.shape(), properties,
                                  X_WG, geometry.is_dynamic()) ||

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -570,13 +570,13 @@ class GeometryState {
 
   /** Implementation of SceneGraph::HasRenderer().  */
   bool HasRenderer(const std::string& name) const {
-    return render_engines_.count(name) > 0;
+    return render_engines_.contains(name);
   }
 
   /** Implementation of QueryObject::GetRenderEngineByName.  */
   const render::RenderEngine* GetRenderEngineByName(
       const std::string& name) const {
-    if (render_engines_.count(name) > 0) {
+    if (render_engines_.contains(name)) {
       return render_engines_.at(name).get();
     }
     return nullptr;

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -112,7 +112,7 @@ class InternalFrame {
   /* Returns true if this frame considers the given `frame_id` to be a child.
    */
   bool has_child(FrameId frame_id) const {
-    return child_frames_.count(frame_id) > 0;
+    return child_frames_.contains(frame_id);
   }
 
   /* Adds the given `frame_id` to the set of frames that this frame considers
@@ -122,7 +122,7 @@ class InternalFrame {
   /* Returns true if this frame considers the given `geometry_id` to be rigidly
    affixed to it.  */
   bool has_child(GeometryId geometry_id) const {
-    return child_geometries_.count(geometry_id) > 0;
+    return child_geometries_.contains(geometry_id);
   }
 
   /* Adds the given `geometry_id` to the set of geometries that this frame
@@ -135,7 +135,7 @@ class InternalFrame {
    considers to be children.
    @pre the id _is_ a valid child of this frame.  */
   void remove_child(GeometryId geometry_id) {
-    DRAKE_ASSERT(child_geometries_.count(geometry_id) > 0);
+    DRAKE_ASSERT(child_geometries_.contains(geometry_id));
     child_geometries_.erase(geometry_id);
   }
 

--- a/geometry/optimization/cspace_free_box.cc
+++ b/geometry/optimization/cspace_free_box.cc
@@ -149,9 +149,9 @@ void CspaceFreeBox::GeneratePolynomialsToCertify(
       separating_planes_map;
   for (int i = 0; i < static_cast<int>(separating_planes().size()); ++i) {
     const auto& plane = separating_planes()[i];
-    if (ignored_collision_pairs.count(SortedPair<geometry::GeometryId>(
+    if (!ignored_collision_pairs.contains(SortedPair<geometry::GeometryId>(
             plane.positive_side_geometry->id(),
-            plane.negative_side_geometry->id())) == 0) {
+            plane.negative_side_geometry->id()))) {
       separating_planes_map.emplace(i, &plane);
     }
   }
@@ -230,7 +230,7 @@ CspaceFreeBox::ConstructPlaneSearchProgram(
     symbolic::Polynomial poly = rational.numerator();
 
     for (int i = 0; i < s_size; ++i) {
-      if (s_for_plane_indices_set.count(i) > 0) {
+      if (s_for_plane_indices_set.contains(i)) {
         gram_and_monomial_basis.AddSos(
             prog, gram_vars.segment(gram_var_count, num_gram_vars_per_sos),
             &lagrangians.mutable_s_box_lower()(i));

--- a/geometry/optimization/cspace_free_polytope.cc
+++ b/geometry/optimization/cspace_free_polytope.cc
@@ -124,7 +124,7 @@ CspaceFreePolytope::ConstructPlaneSearchProgram(
 
     // Set lagrangians.polytope, add sos constraints.
     for (int j = 0; j < d_minus_Cs.rows(); ++j) {
-      if (C_redundant_indices.count(j) == 0) {
+      if (!C_redundant_indices.contains(j)) {
         gram_and_monomial_basis.AddSos(
             prog, gram_vars.segment(gram_var_count, num_gram_vars_per_sos),
             &lagrangians.mutable_polytope()(j));
@@ -136,7 +136,7 @@ CspaceFreePolytope::ConstructPlaneSearchProgram(
     // Set lagrangians.s_lower and lagrangians.s_upper, add sos
     // constraints.
     for (int j = 0; j < s_size; ++j) {
-      if (s_lower_redundant_indices.count(j) == 0) {
+      if (!s_lower_redundant_indices.contains(j)) {
         gram_and_monomial_basis.AddSos(
             prog, gram_vars.segment(gram_var_count, num_gram_vars_per_sos),
             &lagrangians.mutable_s_lower()(j));
@@ -144,7 +144,7 @@ CspaceFreePolytope::ConstructPlaneSearchProgram(
       } else {
         lagrangians.mutable_s_lower()(j) = symbolic::Polynomial();
       }
-      if (s_upper_redundant_indices.count(j) == 0) {
+      if (!s_upper_redundant_indices.contains(j)) {
         gram_and_monomial_basis.AddSos(
             prog, gram_vars.segment(gram_var_count, num_gram_vars_per_sos),
             &lagrangians.mutable_s_upper()(j));
@@ -245,9 +245,9 @@ CspaceFreePolytope::FindSeparationCertificateGivenPolytope(
   std::vector<int> active_plane_indices;
   active_plane_indices.reserve(separating_planes().size());
   for (int i = 0; i < static_cast<int>(separating_planes().size()); ++i) {
-    if (ignored_collision_pairs.count(SortedPair<geometry::GeometryId>(
+    if (!ignored_collision_pairs.contains(SortedPair<geometry::GeometryId>(
             separating_planes()[i].positive_side_geometry->id(),
-            separating_planes()[i].negative_side_geometry->id())) == 0) {
+            separating_planes()[i].negative_side_geometry->id()))) {
       active_plane_indices.push_back(i);
     }
   }
@@ -361,7 +361,7 @@ CspaceFreePolytope::InitializePolytopeSearchProgram(
   // Add the indeterminates y if we need to certify non-polytopic collision
   // geometry
   for (const auto& plane : separating_planes()) {
-    if (ignored_collision_pairs.count(plane.geometry_pair()) == 0) {
+    if (!ignored_collision_pairs.contains(plane.geometry_pair())) {
       if (plane.positive_side_geometry->type() !=
               CIrisGeometryType::kPolytope ||
           plane.negative_side_geometry->type() !=
@@ -392,7 +392,7 @@ CspaceFreePolytope::InitializePolytopeSearchProgram(
     const auto& plane = separating_planes()[plane_index];
     const SortedPair<geometry::GeometryId> geometry_pair =
         plane.geometry_pair();
-    if (ignored_collision_pairs.count(geometry_pair) == 0) {
+    if (!ignored_collision_pairs.contains(geometry_pair)) {
       prog->AddDecisionVariables(plane.decision_variables);
       const auto& certificate =
           certificates_vec[plane_to_certificate_map.at(plane_index)];
@@ -505,7 +505,7 @@ CspaceFreePolytope::InitializePolytopeSearchProgram(
   for (const auto& plane : separating_planes()) {
     const SortedPair<geometry::GeometryId> geometry_pair(
         plane.positive_side_geometry->id(), plane.negative_side_geometry->id());
-    if (ignored_collision_pairs.count(geometry_pair) == 0) {
+    if (!ignored_collision_pairs.contains(geometry_pair)) {
       const auto it = certificates.find(geometry_pair);
       if (it == certificates.end()) {
         const auto& inspector = scene_graph().model_inspector();
@@ -624,7 +624,7 @@ void CspaceFreePolytope::SearchResult::SetSeparatingPlanes(
   // Check that a and b have the same keys.
   DRAKE_THROW_UNLESS(a.size() == b.size());
   for (const auto& [plane_index, a_poly] : a) {
-    DRAKE_THROW_UNLESS(b.count(plane_index) > 0);
+    DRAKE_THROW_UNLESS(b.contains(plane_index));
   }
   a_ = std::move(a);
   b_ = std::move(b);
@@ -810,7 +810,7 @@ CspaceFreePolytope::BinarySearch(
       const SortedPair<geometry::GeometryId> geometry_pair(
           plane.positive_side_geometry->id(),
           plane.negative_side_geometry->id());
-      if (ignored_collision_pairs.count(geometry_pair) == 0 &&
+      if (!ignored_collision_pairs.contains(geometry_pair) &&
           geometry_pair_scale_lower_bounds[i] >= scale) {
         ignored_collision_pairs_for_scale.insert(geometry_pair);
       }
@@ -1024,7 +1024,7 @@ CspaceFreePolytope::FindPolytopeGivenLagrangian(
       const SortedPair<geometry::GeometryId> geometry_pair(
           plane.positive_side_geometry->id(),
           plane.negative_side_geometry->id());
-      if (ignored_collision_pairs.count(geometry_pair) == 0) {
+      if (!ignored_collision_pairs.contains(geometry_pair)) {
         Vector3<symbolic::Polynomial> a;
         for (int i = 0; i < 3; ++i) {
           a(i) = result.GetSolution(plane.a(i));
@@ -1041,9 +1041,9 @@ CspaceFreePolytope::FindPolytopeGivenLagrangian(
            plane_index < static_cast<int>(separating_planes().size());
            ++plane_index) {
         const auto& plane = separating_planes()[plane_index];
-        if (ignored_collision_pairs.count(SortedPair<geometry::GeometryId>(
+        if (!ignored_collision_pairs.contains(SortedPair<geometry::GeometryId>(
                 plane.positive_side_geometry->id(),
-                plane.negative_side_geometry->id())) == 0) {
+                plane.negative_side_geometry->id()))) {
           certificates_result->emplace(
               plane_index,
               new_certificates_map.at(plane_index)

--- a/geometry/optimization/cspace_free_polytope_base.cc
+++ b/geometry/optimization/cspace_free_polytope_base.cc
@@ -207,7 +207,7 @@ void CspaceFreePolytopeBase::CalcSBoundsPolynomial(
 
 void CspaceFreePolytopeBase::SetIndicesOfSOnChainForBodyPair(
     const SortedPair<multibody::BodyIndex>& body_pair) {
-  if (map_body_pair_to_s_on_chain_.count(body_pair) == 0) {
+  if (!map_body_pair_to_s_on_chain_.contains(body_pair)) {
     const std::vector<multibody::internal::MobilizerIndex> mobilizer_indices =
         multibody::internal::FindMobilizersOnPath(rational_forward_kin_.plant(),
                                                   body_pair.first(),
@@ -350,7 +350,7 @@ VectorX<symbolic::Variable> CspaceFreePolytopeBase::GetSForPlane(
 
 int CspaceFreePolytopeBase::GetSeparatingPlaneIndex(
     const SortedPair<geometry::GeometryId>& pair) const {
-  return (map_geometries_to_separating_planes_.count(pair) == 0)
+  return (!map_geometries_to_separating_planes_.contains(pair))
              ? -1
              : map_geometries_to_separating_planes_.at(pair);
 }
@@ -365,7 +365,7 @@ int CspaceFreePolytopeBase::GetGramVarSizeForPolytopeSearchProgram(
   int ret = 0;
   for (const auto& plane_geometries : plane_geometries_vec) {
     const auto& plane = separating_planes()[plane_geometries.plane_index];
-    if (ignored_collision_pairs.count(plane.geometry_pair()) == 0) {
+    if (!ignored_collision_pairs.contains(plane.geometry_pair())) {
       const auto& monomial_basis_array_positive_side =
           this->map_body_to_monomial_basis_array().at(
               SortedPair<multibody::BodyIndex>(

--- a/geometry/optimization/dev/cspace_free_path.cc
+++ b/geometry/optimization/dev/cspace_free_path.cc
@@ -261,7 +261,7 @@ CspaceFreePath::SolveSeparationCertificateProgram(
 
 int CspaceFreePath::GetSeparatingPlaneIndex(
     const SortedPair<geometry::GeometryId>& pair) const {
-  return (map_geometries_to_separating_planes_.count(pair) == 0)
+  return (!map_geometries_to_separating_planes_.contains(pair))
              ? -1
              : map_geometries_to_separating_planes_.at(pair);
 }

--- a/geometry/optimization/dev/polynomial_positive_on_path.cc
+++ b/geometry/optimization/dev/polynomial_positive_on_path.cc
@@ -97,10 +97,8 @@ void ParametrizedPolynomialPositiveOnUnitInterval::
   for (int i = 0;
        i < psatz_variables_and_psd_constraints_.indeterminates().size(); ++i) {
     // Check that prog contains the indeterminates of this program.
-    DRAKE_DEMAND(
-        prog->indeterminates_index().count(
-            psatz_variables_and_psd_constraints_.indeterminates()(i).get_id()) >
-        0);
+    DRAKE_DEMAND(prog->indeterminates_index().contains(
+        psatz_variables_and_psd_constraints_.indeterminates()(i).get_id()));
   }
 
   prog->AddDecisionVariables(

--- a/geometry/optimization/dev/test/cspace_free_path_test.cc
+++ b/geometry/optimization/dev/test/cspace_free_path_test.cc
@@ -28,7 +28,7 @@ TEST_F(CIrisToyRobotTest, CspaceFreePathConstructor) {
       VectorX<symbolic::Variable> s_vars{
           tester.get_rational_forward_kin()->s()};
       for (int i = 0; i < s_vars.size(); ++i) {
-        EXPECT_GT(tester.get_path().count(s_vars(i)), 0);
+        EXPECT_TRUE(tester.get_path().contains(s_vars(i)));
 
         const symbolic::Polynomial& path_component{
             tester.get_path().at(s_vars(i))};

--- a/geometry/optimization/dev/test/cspace_free_path_with_mosek_test.cc
+++ b/geometry/optimization/dev/test/cspace_free_path_with_mosek_test.cc
@@ -102,10 +102,10 @@ void CheckSeparationBySamples(
          ++plane_index) {
       const auto& plane =
           tester.get_separating_planes()[plane_index];
-      if (ignored_collision_pairs.count(SortedPair<geometry::GeometryId>(
+      if (!ignored_collision_pairs.contains(SortedPair<geometry::GeometryId>(
               plane.positive_side_geometry->id(),
-              plane.negative_side_geometry->id())) == 0 &&
-          a.count(plane_index) > 0 && b.count(plane_index) > 0) {
+              plane.negative_side_geometry->id())) &&
+          a.contains(plane_index) && b.contains(plane_index)) {
         Eigen::Vector3d a_val;
         for (int j = 0; j < 3; ++j) {
           a_val(j) = a.at(plane_index)(j).Evaluate(env);

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -620,7 +620,7 @@ HPolyhedron HPolyhedron::ReduceInequalities(double tol) const {
   VectorXd b_new(A_new.rows());
   int i = 0;
   for (int j = 0; j < A_.rows(); ++j) {
-    if (redundant_indices.count(j) == 0) {
+    if (!redundant_indices.contains(j)) {
       A_new.row(i) = A_.row(j);
       b_new.row(i) = b_.row(j);
       ++i;

--- a/geometry/optimization/spectrahedron.cc
+++ b/geometry/optimization/spectrahedron.cc
@@ -46,7 +46,7 @@ Spectrahedron::Spectrahedron() : ConvexSet(0, false) {}
 Spectrahedron::Spectrahedron(const MathematicalProgram& prog)
     : ConvexSet(prog.num_vars(), false) {
   for (const ProgramAttribute& attr : prog.required_capabilities()) {
-    if (supported_attributes().count(attr) < 1) {
+    if (!supported_attributes().contains(attr)) {
       throw std::runtime_error(fmt::format(
           "Spectrahedron does not support MathematicalPrograms that require "
           "ProgramAttribute {}. If that attribute is convex, it might be "

--- a/geometry/optimization/test/c_iris_test_utilities.cc
+++ b/geometry/optimization/test/c_iris_test_utilities.cc
@@ -358,7 +358,7 @@ bool IsPolynomialSos(const symbolic::Polynomial& p, double tol) {
     // p = 0.
     return true;
   } else if (p.monomial_to_coefficient_map().size() == 1 &&
-             p.monomial_to_coefficient_map().count(symbolic::Monomial()) > 0) {
+             p.monomial_to_coefficient_map().contains(symbolic::Monomial())) {
     // p is a constant
     symbolic::Environment env;
     const double constant =

--- a/geometry/optimization/test/cspace_free_box_with_mosek_test.cc
+++ b/geometry/optimization/test/cspace_free_box_with_mosek_test.cc
@@ -402,7 +402,7 @@ TEST_F(CIrisToyRobotTest, FindSeparationCertificateGivenBoxFailure) {
       const SortedPair<geometry::GeometryId> geometry_pair{
           separating_plane.positive_side_geometry->id(),
           separating_plane.negative_side_geometry->id()};
-      if (ignored_collision_pairs.count(geometry_pair) == 0) {
+      if (!ignored_collision_pairs.contains(geometry_pair)) {
         auto it = certificates.find(geometry_pair);
         if (it == certificates.end()) {
           // Cannot find the separation certificate for this pair   of

--- a/geometry/optimization/test/cspace_free_internal_test.cc
+++ b/geometry/optimization/test/cspace_free_internal_test.cc
@@ -26,7 +26,7 @@ TEST_F(CIrisToyRobotTest, GetCollisionGeometries) {
         }
         EXPECT_EQ(geometry_ids.size(), geometry_ids_expected.size());
         for (const auto id : geometry_ids) {
-          EXPECT_GT(geometry_ids_expected.count(id), 0);
+          EXPECT_TRUE(geometry_ids_expected.contains(id));
         }
       };
 

--- a/geometry/optimization/test/cspace_free_polytope_with_mosek_test.cc
+++ b/geometry/optimization/test/cspace_free_polytope_with_mosek_test.cc
@@ -69,7 +69,7 @@ void CheckLagrangians(const VectorX<symbolic::Polynomial>& lagrangians,
                       const Eigen::MatrixXd& indeterminates_samples,
                       const VectorX<symbolic::Variable>& indeterminates) {
   for (int i = 0; i < lagrangians.rows(); ++i) {
-    if (redundant_indices.count(i) == 0) {
+    if (!redundant_indices.contains(i)) {
       CheckPositivePolynomialBySamples(lagrangians(i), indeterminates,
                                        indeterminates_samples.transpose());
     } else {
@@ -117,10 +117,10 @@ void CheckSeparationBySamples(
          ++plane_index) {
       const auto& plane =
           tester.cspace_free_polytope().separating_planes()[plane_index];
-      if (ignored_collision_pairs.count(SortedPair<geometry::GeometryId>(
+      if (!ignored_collision_pairs.contains(SortedPair<geometry::GeometryId>(
               plane.positive_side_geometry->id(),
-              plane.negative_side_geometry->id())) == 0 &&
-          a.count(plane_index) > 0 && b.count(plane_index) > 0) {
+              plane.negative_side_geometry->id())) &&
+          a.contains(plane_index) && b.contains(plane_index)) {
         Eigen::Vector3d a_val;
         for (int j = 0; j < 3; ++j) {
           a_val(j) = a.at(plane_index)(j).Evaluate(env);
@@ -504,10 +504,10 @@ TEST_F(CIrisToyRobotTest, FindSeparationCertificateGivenPolytopeSuccess) {
       EXPECT_TRUE(certificate.has_value());
       const auto& plane = tester.cspace_free_polytope()
                               .separating_planes()[certificate->plane_index];
-      EXPECT_EQ(ignored_collision_pairs.count(SortedPair<geometry::GeometryId>(
-                    plane.positive_side_geometry->id(),
-                    plane.negative_side_geometry->id())),
-                0);
+      EXPECT_FALSE(
+          ignored_collision_pairs.contains(SortedPair<geometry::GeometryId>(
+              plane.positive_side_geometry->id(),
+              plane.negative_side_geometry->id())));
 
       CheckSeparationBySamples(tester, *diagram_, s_samples, C, d,
                                {{certificate->plane_index, certificate->a}},
@@ -620,11 +620,11 @@ TEST_F(CIrisToyRobotTest, FindSeparationCertificateGivenPolytopeFailure) {
       const SortedPair<geometry::GeometryId> geometry_pair(
           plane.positive_side_geometry->id(),
           plane.negative_side_geometry->id());
-      EXPECT_EQ(inseparable_geometries.count(geometry_pair), 0);
+      EXPECT_FALSE(inseparable_geometries.contains(geometry_pair));
     }
   }
   for (const auto& [geometry_pair, certificate] : certificates_map) {
-    EXPECT_EQ(inseparable_geometries.count(geometry_pair), 0);
+    EXPECT_FALSE(inseparable_geometries.contains(geometry_pair));
   }
 }
 

--- a/geometry/optimization/test/spectrahedron_test.cc
+++ b/geometry/optimization/test/spectrahedron_test.cc
@@ -29,9 +29,8 @@ GTEST_TEST(SpectrahedronTest, DefaultCtor) {
 }
 
 GTEST_TEST(SpectrahedronTest, Attributes) {
-  EXPECT_GT(Spectrahedron::supported_attributes().count(
-                solvers::ProgramAttribute::kPositiveSemidefiniteConstraint),
-            0);
+  EXPECT_TRUE(Spectrahedron::supported_attributes().contains(
+      solvers::ProgramAttribute::kPositiveSemidefiniteConstraint));
 }
 
 GTEST_TEST(SpectrahedronTest, UnsupportedProgram) {

--- a/geometry/proximity/collision_filter.cc
+++ b/geometry/proximity/collision_filter.cc
@@ -182,7 +182,7 @@ void CollisionFilter::AddFilteredPair(GeometryId id_A, GeometryId id_B,
                                       bool is_invariant,
                                       FilterState* state_out) {
   FilterState& filter_state = *state_out;
-  DRAKE_DEMAND(filter_state.count(id_A) == 1 && filter_state.count(id_B) == 1);
+  DRAKE_DEMAND(filter_state.contains(id_A) && filter_state.contains(id_B));
 
   if (id_A == id_B) return;
   PairRelationship& pair_relation =
@@ -194,7 +194,7 @@ void CollisionFilter::AddFilteredPair(GeometryId id_A, GeometryId id_B,
 void CollisionFilter::RemoveFilteredPair(GeometryId id_A, GeometryId id_B,
                                          FilterState* state_out) {
   FilterState& filter_state = *state_out;
-  DRAKE_DEMAND(filter_state.count(id_A) == 1 && filter_state.count(id_B) == 1);
+  DRAKE_DEMAND(filter_state.contains(id_A) && filter_state.contains(id_B));
   if (id_A == id_B) return;
   PairRelationship& pair_relation =
       id_A < id_B ? filter_state[id_A][id_B] : filter_state[id_B][id_A];
@@ -263,7 +263,7 @@ void CollisionFilter::AddGeometry(GeometryId new_id,
                                   FilterState* filter_state_out,
                                   PairRelationship relationship) {
   FilterState& filter_state = *filter_state_out;
-  DRAKE_DEMAND(filter_state.count(new_id) == 0);
+  DRAKE_DEMAND(!filter_state.contains(new_id));
   GeometryMap& new_map = filter_state[new_id] = {};
   for (auto& [other_id, other_map] : filter_state) {
     /* Whichever id is *smaller* tracks the relationship with the other.
@@ -285,7 +285,7 @@ void CollisionFilter::AddGeometry(GeometryId new_id,
 void CollisionFilter::RemoveGeometry(GeometryId remove_id,
                                      FilterState* filter_state_out) {
   FilterState& filter_state = *filter_state_out;
-  DRAKE_DEMAND(filter_state.count(remove_id) == 1);
+  DRAKE_DEMAND(filter_state.contains(remove_id));
   filter_state.erase(remove_id);
   for (auto& [other_id, other_map] : filter_state) {
     /* remove_id will only be found in maps belonging to geometries with ids

--- a/geometry/proximity/collision_filter.h
+++ b/geometry/proximity/collision_filter.h
@@ -126,7 +126,7 @@ class CollisionFilter {
   }
 
   /* Reports if the given `id` has been added to this filter system. */
-  bool HasGeometry(GeometryId id) const { return filter_state_.count(id) > 0; }
+  bool HasGeometry(GeometryId id) const { return filter_state_.contains(id); }
 
  private:
   friend class CollisionFilterTest;

--- a/geometry/proximity/deformable_contact_internal.h
+++ b/geometry/proximity/deformable_contact_internal.h
@@ -46,14 +46,14 @@ class Geometries final : public ShapeReifier {
   /* Returns true if a rigid (non-deformable) geometry representation with the
    given `id` exists. */
   bool is_rigid(GeometryId id) const {
-    return rigid_geometries_.count(id) != 0 ||
-           rigid_geometries_pending_.count(id) != 0;
+    return rigid_geometries_.contains(id) ||
+           rigid_geometries_pending_.contains(id);
   }
 
   /* Returns true if a deformable geometry representation with the given `id`
    exists. */
   bool is_deformable(GeometryId id) const {
-    return deformable_geometries_.count(id) != 0;
+    return deformable_geometries_.contains(id);
   }
 
   /* Removes the geometry (if it has a deformable contact representation). No-op

--- a/geometry/proximity/detect_zero_simplex.cc
+++ b/geometry/proximity/detect_zero_simplex.cc
@@ -51,7 +51,7 @@ std::set<SortedTriplet<int>> GetInteriorFaceSet(
       SortedTriplet<int> face(tetrahedron.vertex(face_vertices[0]),
                               tetrahedron.vertex(face_vertices[1]),
                               tetrahedron.vertex(face_vertices[2]));
-      if (1 != boundary_face_set.count(face)) {
+      if (!boundary_face_set.contains(face)) {
         interior_face_set.insert(face);
       }
     }
@@ -83,7 +83,7 @@ std::set<SortedPair<int>> GetInteriorEdgeSet(const VolumeMesh<double>& mesh_M) {
     for (const auto& edge_vertices : tetrahedron_edges) {
       SortedPair<int> edge(tetrahedron.vertex(edge_vertices[0]),
                            tetrahedron.vertex(edge_vertices[1]));
-      if (1 != boundary_edge_set.count(edge)) {
+      if (!boundary_edge_set.contains(edge)) {
         interior_edge_set.insert(edge);
       }
     }
@@ -101,7 +101,7 @@ std::vector<int> DetectTetrahedronWithAllBoundaryVertices(
   auto is_all_vertices_on_boundary =
       [&boundary_vertex_set](const VolumeElement& tetrahedron) -> bool {
     for (int i = 0; i < 4; ++i) {
-      if (boundary_vertex_set.count(tetrahedron.vertex(i)) < 1) return false;
+      if (!boundary_vertex_set.contains(tetrahedron.vertex(i))) return false;
     }
     return true;
   };
@@ -124,9 +124,9 @@ std::vector<SortedTriplet<int>> DetectInteriorTriangleWithAllBoundaryVertices(
   std::vector<SortedTriplet<int>> null_interior_triangles;
   for (const SortedTriplet<int>& interior_triangle :
        GetInteriorFaceSet(mesh_M)) {
-    if (1 == boundary_vertex_set.count(interior_triangle.first()) &&
-        1 == boundary_vertex_set.count(interior_triangle.second()) &&
-        1 == boundary_vertex_set.count(interior_triangle.third())) {
+    if (boundary_vertex_set.contains(interior_triangle.first()) &&
+        boundary_vertex_set.contains(interior_triangle.second()) &&
+        boundary_vertex_set.contains(interior_triangle.third())) {
       null_interior_triangles.push_back(interior_triangle);
     }
   }
@@ -141,8 +141,8 @@ std::vector<SortedPair<int>> DetectInteriorEdgeWithAllBoundaryVertices(
 
   std::vector<SortedPair<int>> null_interior_edges;
   for (const SortedPair<int>& interior_edge : GetInteriorEdgeSet(mesh_M)) {
-    if (1 == boundary_vertex_set.count(interior_edge.first()) &&
-        1 == boundary_vertex_set.count(interior_edge.second())) {
+    if (boundary_vertex_set.contains(interior_edge.first()) &&
+        boundary_vertex_set.contains(interior_edge.second())) {
       null_interior_edges.push_back(interior_edge);
     }
   }

--- a/geometry/proximity/make_sphere_mesh.h
+++ b/geometry/proximity/make_sphere_mesh.h
@@ -309,7 +309,7 @@ std::pair<VolumeMesh<T>, std::vector<bool>> RefineUnitSphereMesh(
     for (const auto& v_pair : kEdges) {
       const SortedPair<int> key{t.vertex(v_pair.first),
                                 t.vertex(v_pair.second)};
-      if (edge_vertex_map.count(key) == 0) {
+      if (!edge_vertex_map.contains(key)) {
         // We haven't already split this edge; compute the vertex and determine
         // its boundary condition.
         const Vector3<T>& p_MA = mesh.vertex(key.first());
@@ -387,7 +387,7 @@ std::pair<VolumeMesh<T>, int> RefineUnitSphereMeshOnSurface(
       const SortedPair<int> key{t.vertex(v_pair.first),
                                 t.vertex(v_pair.second)};
       // TODO(SeanCurtis-TRI): Refactor edge refinement into a single method.
-      if (edge_vertex_map.count(key) == 0) {
+      if (!edge_vertex_map.contains(key)) {
         // We haven't already split this edge; compute the vertex and determine
         // its boundary condition.
         const Vector3<T>& p_MA = mesh.vertex(key.first());

--- a/geometry/proximity/test/bvh_test.cc
+++ b/geometry/proximity/test/bvh_test.cc
@@ -236,7 +236,7 @@ TYPED_TEST(BvhTest, TestBuildBvTree) {
       for (int i = 0; i < node.num_element_indices(); ++i) {
         EXPECT_GE(node.element_index(i), 0);
         EXPECT_LT(node.element_index(i), num_elements);
-        EXPECT_EQ(element_indices.count(node.element_index(i)), 0);
+        EXPECT_FALSE(element_indices.contains(node.element_index(i)));
         element_indices.insert(node.element_index(i));
       }
     }

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -287,7 +287,7 @@ GTEST_TEST(MeshFieldLinearTest, EvaluateCartesianWithAndWithoutGradient) {
        {Vector3d{1e-15, 1e-15, 1e-15}, Vector3d{0.1, 0.2, 0.3},
         Vector3d{-10.23, 27, 77}, Vector3d{321.3, -843.2, 202.02}}) {
     for (int e = 0; e < mesh_M.num_elements(); ++e) {
-      if (positive_set.count(e) == 1) {
+      if (positive_set.contains(e)) {
         // f⁺(x,y,z) =  3.5x - 2.7y + 0.7z + 1.23
         const double expect = f_p(p_MQ);
         const double tolerance = 1e-13 * abs(expect);

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -308,7 +308,7 @@ class SliceTest : public ::testing::TestWithParam<SliceFunctionType> {
     const auto& poly = slice_mesh_W.element(0);
     for (int i = 0; i < poly.num_vertices(); ++i) {
       const int v = poly.vertex(i);
-      if (slice_vertex_indices.count(v) > 0) continue;
+      if (slice_vertex_indices.contains(v)) continue;
       slice_vertex_indices.insert(v);
       // The slice polygon vertex S in the mesh frame F.
       const Vector3d p_FS = X_FW * slice_mesh_W.vertex(v);
@@ -356,7 +356,7 @@ class SliceTest : public ::testing::TestWithParam<SliceFunctionType> {
     // cache: cut_edges_. Make sure they line up.
     for (const auto& edge_vertex : edge_vertices) {
       const SortedPair<int>& computed_edge = edge_vertex.edge;
-      if (cut_edges_.count(computed_edge) == 0) {
+      if (!cut_edges_.contains(computed_edge)) {
         return {{},
                 ::testing::AssertionFailure() << fmt::format(
                     "We matched surface vertex {} to edge {}, but that can't "

--- a/geometry/proximity/volume_mesh_refiner.cc
+++ b/geometry/proximity/volume_mesh_refiner.cc
@@ -161,10 +161,9 @@ std::vector<int> VolumeMeshRefiner::GetTetrahedraOnTriangle(int v0, int v1,
     const std::unordered_set<int> tetrahedron_vertices{
         tetrahedra_[tetrahedron].vertex(0), tetrahedra_[tetrahedron].vertex(1),
         tetrahedra_[tetrahedron].vertex(2), tetrahedra_[tetrahedron].vertex(3)};
-    // TODO(DamrongGuoy): Use tetrahedron_vertices.contains(key) instead of
-    //  tetrahedron_vertices.count(key) when C++20 is available.
-    if (tetrahedron_vertices.count(v0) && tetrahedron_vertices.count(v1) &&
-        tetrahedron_vertices.count(v2)) {
+    if (tetrahedron_vertices.contains(v0) &&
+        tetrahedron_vertices.contains(v1) &&
+        tetrahedron_vertices.contains(v2)) {
       incident_tetrahedra.push_back(tetrahedron);
     }
   }
@@ -179,9 +178,8 @@ std::vector<int> VolumeMeshRefiner::GetTetrahedraOnEdge(int v0, int v1) const {
     const std::unordered_set<int> tetrahedron_vertices{
         tetrahedra_[tetrahedron].vertex(0), tetrahedra_[tetrahedron].vertex(1),
         tetrahedra_[tetrahedron].vertex(2), tetrahedra_[tetrahedron].vertex(3)};
-    // TODO(DamrongGuoy): Use tetrahedron_vertices.contains(key) instead of
-    //  tetrahedron_vertices.count(key) when C++20 is available.
-    if (tetrahedron_vertices.count(v0) && tetrahedron_vertices.count(v1)) {
+    if (tetrahedron_vertices.contains(v0) &&
+        tetrahedron_vertices.contains(v1)) {
       incident_tetrahedra.push_back(tetrahedron);
     }
   }

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -353,7 +353,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   // "AddDynamicGeometry() or AddAnchoredGeometry()") and has not been since
   // removed (via "RemoveGeometry()").
   bool IsRegisteredAsRigid(GeometryId id) {
-    return dynamic_objects_.count(id) > 0 || anchored_objects_.count(id) > 0;
+    return dynamic_objects_.contains(id) || anchored_objects_.contains(id);
   }
 
   // Removes a non-deformable geometry from this engine.

--- a/geometry/query_results/deformable_contact.h
+++ b/geometry/query_results/deformable_contact.h
@@ -380,7 +380,7 @@ class DeformableContact {
 
   /* Returns true iff a geometry with the given `id` has been registered. */
   bool IsRegistered(GeometryId id) const {
-    return contact_participations_.count(id) > 0;
+    return contact_participations_.contains(id);
   }
 
   /* Returns the number of vertices in the geometry with the given `id`.

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -84,14 +84,14 @@ bool RenderEngine::RemoveGeometry(GeometryId id) {
 }
 
 bool RenderEngine::has_geometry(GeometryId id) const {
-  return update_ids_.count(id) > 0 || anchored_ids_.count(id) > 0 ||
-         deformable_mesh_dofs_.count(id) > 0;
+  return update_ids_.contains(id) || anchored_ids_.contains(id) ||
+         deformable_mesh_dofs_.contains(id);
 }
 
 void RenderEngine::UpdateDeformableConfigurations(
     GeometryId id, const std::vector<VectorX<double>>& q_WGs,
     const std::vector<VectorX<double>>& nhats_W) {
-  if (deformable_mesh_dofs_.count(id) == 0) {
+  if (!deformable_mesh_dofs_.contains(id)) {
     throw std::runtime_error(fmt::format(
         "No deformable geometry with id {} has been registered.", id));
   }

--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -233,7 +233,7 @@ vector<RenderMesh> LoadRenderMeshesFromObj(
           // increment it without worry.
           ++material_uvs[mat_index];
         }
-        if (obj_vertex_to_new_vertex.count(obj_indices) == 0) {
+        if (!obj_vertex_to_new_vertex.contains(obj_indices)) {
           obj_vertex_to_new_vertex[obj_indices] =
               static_cast<int>(positions.size());
           /* Guarantee that the positions.size() == normals.size() == uvs.size()
@@ -298,7 +298,7 @@ vector<RenderMesh> LoadRenderMeshesFromObj(
     for (const auto& t : tri_indices) {
       const auto& tri = triangles[t];
       for (int i = 0; i < 3; ++i) {
-        if (vertex_index_full_to_part.count(tri[i]) == 0) {
+        if (!vertex_index_full_to_part.contains(tri[i])) {
           vertex_index_full_to_part[tri(i)] =
               static_cast<indices_uint_t>(vertex_index_full_to_part.size());
         }

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -26,9 +26,9 @@ class RenderEngineTester {
   }
 
   bool has_id(GeometryId id) const {
-    return engine_.update_ids_.count(id) > 0 ||
-           engine_.anchored_ids_.count(id) > 0 ||
-           engine_.deformable_mesh_dofs_.count(id) > 0;
+    return engine_.update_ids_.contains(id) ||
+           engine_.anchored_ids_.contains(id) ||
+           engine_.deformable_mesh_dofs_.contains(id);
   }
 
  private:
@@ -298,7 +298,7 @@ GTEST_TEST(RenderEngine, RigidGeometryRegistrationAndUpdate) {
     X_WG_all[id].set_translation(p_WG);
     engine.UpdatePoses(X_WG_all);
     EXPECT_EQ(engine.updated_ids().size(), 1);
-    ASSERT_EQ(engine.updated_ids().count(id), 1);
+    ASSERT_TRUE(engine.updated_ids().contains(id));
     EXPECT_TRUE(
         CompareMatrices(engine.updated_ids().at(id).translation(), p_WG));
     EXPECT_TRUE(CompareMatrices(engine.world_pose(id).GetAsMatrix34(),

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -909,7 +909,7 @@ void RenderEngineGl::DoUpdateVisualPose(GeometryId id,
 void RenderEngineGl::DoUpdateDeformableConfigurations(
     GeometryId id, const std::vector<VectorX<double>>& q_WGs,
     const std::vector<VectorX<double>>& nhats_W) {
-  DRAKE_DEMAND(deformable_meshes_.count(id) > 0);
+  DRAKE_DEMAND(deformable_meshes_.contains(id));
   std::vector<int>& gl_mesh_indices = deformable_meshes_.at(id);
   DRAKE_DEMAND(q_WGs.size() == gl_mesh_indices.size());
 
@@ -936,7 +936,7 @@ void RenderEngineGl::DoUpdateDeformableConfigurations(
 bool RenderEngineGl::DoRemoveGeometry(GeometryId id) {
   // Clean up the convenience look up table for deformable if the id is
   // associated with a deformable geometry.
-  if (deformable_meshes_.count(id) > 0) {
+  if (deformable_meshes_.contains(id)) {
     deformable_meshes_.erase(id);
   }
   // Now remove the instances associated with the id (stored in visuals_).
@@ -950,7 +950,7 @@ bool RenderEngineGl::DoRemoveGeometry(GeometryId id) {
         [this, &visited_families](GeometryId g_id, const auto& shader_data,
                                   RenderType render_type) {
           const ShaderId s_id = shader_data[render_type].shader_id();
-          if (visited_families.count(s_id) > 0) {
+          if (visited_families.contains(s_id)) {
             return;
           }
           visited_families.insert(s_id);
@@ -1257,7 +1257,7 @@ vector<int> RenderEngineGl::GetMeshes(const string& filename_in,
 
   const std::string file_key = GetPathKey(filename_in);
 
-  if (meshes_.count(file_key) == 0) {
+  if (!meshes_.contains(file_key)) {
     const vector<RenderMesh> meshes = LoadRenderMeshesFromObj(
         filename_in, PerceptionProperties(), parameters_.default_diffuse,
         drake::internal::DiagnosticPolicy());

--- a/geometry/render_gl/test/internal_buffer_dim_test.cc
+++ b/geometry/render_gl/test/internal_buffer_dim_test.cc
@@ -44,18 +44,18 @@ GTEST_TEST(BufferDimTest, HashableKey) {
 
   std::unordered_set<BufferDim> buffers;
 
-  EXPECT_EQ(buffers.count(buffer), 0);
+  EXPECT_FALSE(buffers.contains(buffer));
   buffers.insert(buffer);
-  EXPECT_EQ(buffers.count(buffer), 1);
-  EXPECT_EQ(buffers.count(same), 1);
+  EXPECT_TRUE(buffers.contains(buffer));
+  EXPECT_TRUE(buffers.contains(same));
   buffers.insert(same);
-  EXPECT_EQ(buffers.count(buffer), 1);
-  EXPECT_EQ(buffers.count(same), 1);
+  EXPECT_TRUE(buffers.contains(buffer));
+  EXPECT_TRUE(buffers.contains(same));
 
   // Show that different buffers aren't mistaken for `buffer`.
-  EXPECT_EQ(buffers.count(BufferDim(w, h + 1)), 0);
-  EXPECT_EQ(buffers.count(BufferDim(w + 1, h)), 0);
-  EXPECT_EQ(buffers.count(BufferDim(w + 1, h + 1)), 0);
+  EXPECT_FALSE(buffers.contains(BufferDim(w, h + 1)));
+  EXPECT_FALSE(buffers.contains(BufferDim(w + 1, h)));
+  EXPECT_FALSE(buffers.contains(BufferDim(w + 1, h + 1)));
 }
 
 }  // namespace

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
@@ -525,7 +525,7 @@ void RenderEngineGltfClient::DoUpdateVisualPose(
 }
 
 bool RenderEngineGltfClient::DoRemoveGeometry(GeometryId id) {
-  if (gltfs_.count(id) == 1) {
+  if (gltfs_.contains(id)) {
     gltfs_.erase(id);
     return true;
   } else {
@@ -573,7 +573,7 @@ bool RenderEngineGltfClient::ImplementGltf(
   std::map<int, Matrix4<double>> root_nodes = FindRootNodes(mesh_data);
   SetRootPoses(&mesh_data, root_nodes, data.X_WG, scale, true);
 
-  DRAKE_DEMAND(gltfs_.count(data.id) == 0);
+  DRAKE_DEMAND(!gltfs_.contains(data.id));
   gltfs_.insert({data.id,
                  {gltf_path, std::move(mesh_data), std::move(root_nodes), scale,
                   GetRenderLabelOrThrow(data.properties)}});

--- a/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -332,7 +332,7 @@ TEST_F(RenderEngineGltfClientGltfTest, RegisteringMeshes) {
   // Now look for proof that the gltf got added correctly.
   const std::map<GeometryId, Tester::GltfRecord>& gltfs =
       Tester::gltfs(engine_);
-  ASSERT_EQ(gltfs.count(gltf_id), 1);
+  ASSERT_TRUE(gltfs.contains(gltf_id));
   const Tester::GltfRecord& record = gltfs.at(gltf_id);
   EXPECT_EQ(record.scale, scale_);
   EXPECT_EQ(record.label, label_);

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -149,7 +149,7 @@ SourceId SceneGraph<T>::RegisterSource(const std::string& name) {
 
 template <typename T>
 bool SceneGraph<T>::SourceIsRegistered(SourceId id) const {
-  return input_source_ids_.count(id) > 0;
+  return input_source_ids_.contains(id);
 }
 
 template <typename T>
@@ -444,7 +444,7 @@ void SceneGraph<T>::SetDefaultParameters(const Context<T>& context,
 template <typename T>
 void SceneGraph<T>::MakeSourcePorts(SourceId source_id) {
   // This will fail only if the source generator starts recycling source ids.
-  DRAKE_ASSERT(input_source_ids_.count(source_id) == 0);
+  DRAKE_ASSERT(!input_source_ids_.contains(source_id));
   // Create and store the input ports for this source id.
   SourcePorts& source_ports = input_source_ids_[source_id];
   source_ports.pose_port =

--- a/geometry/test/geometry_properties_test.cc
+++ b/geometry/test/geometry_properties_test.cc
@@ -304,7 +304,7 @@ GTEST_TEST(GeometryProperties, PropertyIteration) {
   std::set<string> visited_properties;
   for (const auto& pair : properties.GetPropertiesInGroup(default_group)) {
     const string& name = pair.first;
-    EXPECT_GT(reference.count(name), 0);
+    EXPECT_TRUE(reference.contains(name));
     EXPECT_EQ(reference[name],
               properties.GetProperty<int>(default_group, name));
     visited_properties.insert(name);

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -2085,7 +2085,7 @@ TEST_F(GeometryStateTest, RemoveGeometry) {
             single_tree_dynamic_geometry_count() - 1);
 
   EXPECT_FALSE(gs_tester_.get_frames().at(f_id).has_child(g_id));
-  EXPECT_EQ(gs_tester_.get_geometries().count(g_id), 0);
+  EXPECT_FALSE(gs_tester_.get_geometries().contains(g_id));
 
   // Confirm that, post removal, updating poses still works.
   DRAKE_EXPECT_NO_THROW(gs_tester_.FinalizePoseUpdate());
@@ -3507,7 +3507,7 @@ TEST_F(GeometryStateTest, RemoveGeometryFromRenderer) {
           EXPECT_TRUE(render_engine_->has_geometry(id));
           // Should report in the renderer if it is *not* in the removed set.
           EXPECT_EQ(other_engine.has_geometry(id),
-                    removed_from_renderer.count(id) == 0);
+                    !removed_from_renderer.contains(id));
         }
       };
   set<GeometryId> removed_ids;
@@ -3583,7 +3583,7 @@ TEST_F(GeometryStateTest, RemoveFrameFromRenderer) {
           EXPECT_TRUE(render_engine_->has_geometry(id));
           // Should report in the renderer if it is *not* in the removed set.
           EXPECT_EQ(other_engine.has_geometry(id),
-                    removed_from_renderer.count(id) == 0);
+                    !removed_from_renderer.contains(id));
         }
       };
   set<GeometryId> removed_ids;
@@ -4334,7 +4334,7 @@ class RemoveRoleTests : public GeometryStateTestBase,
           // If this id is *not* in the set with the role removed, then it
           // _should_ report as having the role.
           EXPECT_EQ(gs_tester_.GetGeometry(id)->has_role(role),
-                    ids_without_role.count(id) == 0);
+                    !ids_without_role.contains(id));
         } else {
           EXPECT_TRUE(gs_tester_.GetGeometry(id)->has_role(role));
         }

--- a/geometry/test/kinematics_vector_test.cc
+++ b/geometry/test/kinematics_vector_test.cc
@@ -214,7 +214,7 @@ GTEST_TEST(KinematicsVector, FrameIdRange) {
   std::set<FrameId> actual_ids;
   for (FrameId id : poses.ids()) actual_ids.insert(id);
   EXPECT_EQ(ids.size(), actual_ids.size());
-  for (FrameId id : ids) EXPECT_EQ(actual_ids.count(id), 1);
+  for (FrameId id : ids) EXPECT_TRUE(actual_ids.contains(id));
 }
 
 }  // namespace test

--- a/geometry/test/utilities_test.cc
+++ b/geometry/test/utilities_test.cc
@@ -91,20 +91,20 @@ GTEST_TEST(GeometryUtilities, MapKeyRange) {
   int count = 0;
   for (int i : range) {
     ++count;
-    EXPECT_EQ(values.count(i), 1);
+    EXPECT_TRUE(values.contains(i));
   }
   EXPECT_EQ(count, values.size());
 
   std::set<int> read_values_set(range.begin(), range.end());
   EXPECT_EQ(read_values_set.size(), values.size());
   for (int i : read_values_set) {
-    EXPECT_EQ(values.count(i), 1);
+    EXPECT_TRUE(values.contains(i));
   }
 
   std::vector<int> read_values_vector(range.begin(), range.end());
   EXPECT_EQ(read_values_vector.size(), values.size());
   for (int i : read_values_vector) {
-    EXPECT_EQ(values.count(i), 1);
+    EXPECT_TRUE(values.contains(i));
   }
 }
 

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -102,7 +102,7 @@ class DummyRenderEngine : public render::RenderEngine, private ShapeReifier {
 
   /* Reports `true` if the given id is registered with `this` engine.  */
   bool is_registered(GeometryId id) const {
-    return registered_geometries_.count(id) > 0;
+    return registered_geometries_.contains(id);
   }
 
   // These six functions (and supporting members) facilitate testing while there

--- a/manipulation/kuka_iiwa/iiwa_driver_functions.cc
+++ b/manipulation/kuka_iiwa/iiwa_driver_functions.cc
@@ -26,7 +26,7 @@ void ApplyDriverConfig(
   DRAKE_THROW_UNLESS(builder != nullptr);
   const std::string& arm_name = model_instance_name;
   const std::string& hand_name = driver_config.hand_model_name;
-  if (models_from_directives.count(arm_name) == 0) {
+  if (!models_from_directives.contains(arm_name)) {
     throw std::runtime_error(fmt::format(
         "IiwaDriver could not find arm model directive '{}' to actuate",
         arm_name));
@@ -34,7 +34,7 @@ void ApplyDriverConfig(
   const ModelInstanceInfo& arm_model = models_from_directives.at(arm_name);
   std::optional<ModelInstanceInfo> hand_model;
   if (!hand_name.empty()) {
-    if (models_from_directives.count(hand_name) == 0) {
+    if (!models_from_directives.contains(hand_name)) {
       throw std::runtime_error(fmt::format(
           "IiwaDriver could not find hand model directive '{}' to actuate",
           hand_name));

--- a/manipulation/util/make_arm_controller_model.cc
+++ b/manipulation/util/make_arm_controller_model.cc
@@ -188,7 +188,7 @@ std::unique_ptr<MultibodyPlant<double>> MakeArmControllerModel(
     }
     std::vector<BodyIndex> sim_to_calc_inertia;
     for (const RigidBody<double>* sim_welded_body : sim_welded_bodies) {
-      if (sim_bodies_accounted_for.count(sim_welded_body->index()) > 0) {
+      if (sim_bodies_accounted_for.contains(sim_welded_body->index())) {
         continue;
       }
       sim_bodies_accounted_for.insert(sim_welded_body->index());

--- a/manipulation/util/robot_plan_interpolator.cc
+++ b/manipulation/util/robot_plan_interpolator.cc
@@ -60,7 +60,7 @@ RobotPlanInterpolator::RobotPlanInterpolator(const std::string& model_path,
 
   if (!parent_bodies.empty()) {
     for (const BodyIndex& child : child_bodies) {
-      if (parent_bodies.count(child)) {
+      if (parent_bodies.contains(child)) {
         parent_bodies.erase(child);
       }
     }

--- a/multibody/contact_solvers/block_sparse_cholesky_solver.cc
+++ b/multibody/contact_solvers/block_sparse_cholesky_solver.cc
@@ -123,7 +123,7 @@ BlockSparseCholeskySolver<BlockType>::FactorAndCalcSchurComplement(
   remaining_block_sizes.reserve(num_remaining_blocks);
   int remaining_index = 0;
   for (int i = 0; i < num_total_blocks; ++i) {
-    if (eliminated_blocks.count(i) == 0) {
+    if (!eliminated_blocks.contains(i)) {
       global_to_remaining[i] = remaining_index++;
       remaining_block_sizes.emplace_back(block_sizes[i]);
     }

--- a/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.cc
+++ b/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.cc
@@ -128,7 +128,7 @@ void BlockSparseLowerTriangularOrSymmetricMatrix<MatrixType, is_symmetric>::
   for (int j = 0; j < block_cols(); ++j) {
     /* Zero all blocks in the column except the diagonal if j is among the
      row/column indices to be zeroed out. */
-    if (indices_set.count(j) > 0) {
+    if (indices_set.contains(j)) {
       /* We want to keep the conditioning of the matrix in the ballpark of the
        original matrix (e.g. setting diagonal blocks to identity when the
        original values are the on order of millions is a bad idea), so we keep

--- a/multibody/contact_solvers/minimum_degree_ordering.cc
+++ b/multibody/contact_solvers/minimum_degree_ordering.cc
@@ -121,7 +121,7 @@ std::vector<int> ComputeMinimumDegreeOrdering(
     SimplifiedNode node = {
         .degree = nodes[n].degree,
         .index = nodes[n].index,
-        .priority = priority_elements.count(nodes[n].index) > 0 ? 0 : 1};
+        .priority = priority_elements.contains(nodes[n].index) ? 0 : 1};
     sorted_nodes.insert(node);
   }
 
@@ -152,7 +152,7 @@ std::vector<int> ComputeMinimumDegreeOrdering(
       const SimplifiedNode old_node = {
           .degree = node_i.degree,
           .index = node_i.index,
-          .priority = priority_elements.count(node_i.index) > 0 ? 0 : 1};
+          .priority = priority_elements.contains(node_i.index) ? 0 : 1};
       /* Pruning. */
       node_i.A = SetDifference(node_i.A, node_p.L);
       /* Convert p from a variable to an element in node i. Note that Lp was
@@ -240,7 +240,7 @@ std::vector<int> CalcAndConcatenateMdOrderingWithinGroup(
   std::vector<int> global_to_local(n);
 
   auto in_v1 = [&](int b) {
-    return v1.count(b) > 0;
+    return v1.contains(b);
   };
 
   for (int i = 0; i < n; ++i) {

--- a/multibody/inverse_kinematics/global_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.cc
@@ -106,7 +106,7 @@ GlobalInverseKinematics::GlobalInverseKinematics(
     const string body_R_name = body.name() + "_R";
     const string body_pos_name = body.name() + "_pos";
     p_WBo_[body_idx] = prog_.NewContinuousVariables<3>(body_pos_name);
-    if (weld_to_world_body_index_set.count(body_idx) > 0) {
+    if (weld_to_world_body_index_set.contains(body_idx)) {
       // This body is welded to the world.
       R_WB_[body_idx] = prog_.NewContinuousVariables<3, 3>(body_R_name);
     } else {
@@ -120,7 +120,7 @@ GlobalInverseKinematics::GlobalInverseKinematics(
     const RigidBody<double>& body = plant_.get_body(body_idx);
     // If the body is fixed to the world, then fix the decision variables on
     // the body position and orientation.
-    if (weld_to_world_body_index_set.count(body_idx) > 0) {
+    if (weld_to_world_body_index_set.contains(body_idx)) {
       // This body is welded to the world.
       const math::RigidTransformd X_WB = plant_.CalcRelativeTransform(
           *dummy_plant_context, plant_.world_frame(), body.body_frame());
@@ -275,7 +275,7 @@ void GlobalInverseKinematics::ReconstructGeneralizedPositionSolutionForBody(
   auto dummy_plant_context = plant_.CreateDefaultContext();
   const Joint<double>& joint = plant_.get_joint(body_to_joint_map.at(body_idx));
   const RigidBody<double>& parent = joint.parent_body();
-  if (weld_to_world_body_index_set.count(body_idx) == 0) {
+  if (!weld_to_world_body_index_set.contains(body_idx)) {
     // R_WP is the rotation matrix of parent frame to the world frame.
     const Matrix3d& R_WP = reconstruct_R_WB->at(parent.index());
     const RigidTransformd X_PJp =
@@ -778,7 +778,7 @@ void GlobalInverseKinematics::AddJointLimitConstraint(
             // This dummy_plant_context is used to compute the pose of a body
             // welded to the world.
             auto dummy_plant_context = plant_.CreateDefaultContext();
-            if (weld_to_world_body_index_set.count(BodyIndex{parent_idx}) > 0) {
+            if (weld_to_world_body_index_set.contains(BodyIndex{parent_idx})) {
               const RigidTransformd X_WP = plant_.CalcRelativeTransform(
                   *dummy_plant_context, plant_.world_frame(),
                   plant_.get_body(BodyIndex{parent_idx}).body_frame());

--- a/multibody/optimization/static_equilibrium_problem.cc
+++ b/multibody/optimization/static_equilibrium_problem.cc
@@ -36,7 +36,7 @@ StaticEquilibriumProblem::StaticEquilibriumProblem(
   contact_wrench_evaluators_and_lambda_.reserve(
       collision_candidate_pairs.size());
   for (const auto& collision_candidate_pair : collision_candidate_pairs) {
-    if (ignored_collision_pairs.count(collision_candidate_pair) == 0) {
+    if (!ignored_collision_pairs.contains(collision_candidate_pair)) {
       auto contact_wrench_evaluator =
           std::make_shared<ContactWrenchFromForceInWorldFrameEvaluator>(
               &plant_, context_,

--- a/multibody/parsing/detail_collision_filter_group_resolver.cc
+++ b/multibody/parsing/detail_collision_filter_group_resolver.cc
@@ -46,7 +46,7 @@ void CollisionFilterGroupResolver::AddGroup(
                                  full_group_name));
     return;
   }
-  if (groups_.count(full_group_name)) {
+  if (groups_.contains(full_group_name)) {
     diagnostic.Error(fmt::format("group '{}' has already been defined",
                                  full_group_name));
     return;
@@ -95,7 +95,7 @@ void CollisionFilterGroupResolver::AddGroup(
   for (const auto& insertion_group : member_group_names) {
     const auto full_insertion_group{
       FullyQualify(insertion_group, model_instance)};
-    if (!group_insertion_graph_.count(full_insertion_group)) {
+    if (!group_insertion_graph_.contains(full_insertion_group)) {
       group_insertion_graph_[full_insertion_group] = {};
     }
     group_insertion_graph_[full_insertion_group].insert(full_group_name);

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -289,7 +289,7 @@ class MujocoParser {
     if (!ParseStringAttribute(node, "class", &class_name)) {
       class_name = child_class.empty() ? "main" : child_class;
     }
-    if (default_joint_.count(class_name) > 0) {
+    if (default_joint_.contains(class_name)) {
       ApplyDefaultAttributes(*default_joint_.at(class_name), node);
     }
 
@@ -404,7 +404,7 @@ class MujocoParser {
     using geometry::ShapeReifier::ImplementGeometry;
 
     void ImplementGeometry(const geometry::Mesh&, void*) final {
-      DRAKE_DEMAND(mesh_inertia_.count(name_) == 1);
+      DRAKE_DEMAND(mesh_inertia_.contains(name_));
       M_GG_G_ = mesh_inertia_.at(name_);
     }
 
@@ -486,7 +486,7 @@ class MujocoParser {
     if (!ParseStringAttribute(node, "class", &class_name)) {
       class_name = child_class.empty() ? "main" : child_class;
     }
-    if (default_geometry_.count(class_name) > 0) {
+    if (default_geometry_.contains(class_name)) {
       // TODO(russt): Add a test case covering childclass/default nesting once
       // the body element is supported.
       ApplyDefaultAttributes(*default_geometry_.at(class_name), node);
@@ -620,7 +620,7 @@ class MujocoParser {
                                  geom.name));
           return geom;
       }
-      if (mesh_.count(mesh)) {
+      if (mesh_.contains(mesh)) {
         geom.shape = mesh_.at(mesh)->Clone();
       } else {
         Warning(
@@ -701,7 +701,7 @@ class MujocoParser {
 
     std::string material;
     if (ParseStringAttribute(node, "material", &material)) {
-      if (material_.count(material)) {
+      if (material_.contains(material)) {
         XMLElement* material_node = material_.at(material);
         // Note: there are many material attributes that we do not support yet,
         // nor perhaps ever. Consider warning about them here (currently, it
@@ -945,7 +945,7 @@ class MujocoParser {
          e = e->NextSiblingElement(elt_name)) {
       (*default_map)[class_name] = e;
       if (!parent_default.empty() &&
-          default_map->count(parent_default) > 0) {
+          default_map->contains(parent_default)) {
         ApplyDefaultAttributes(*default_map->at(parent_default), e);
       }
     }
@@ -1017,7 +1017,7 @@ class MujocoParser {
       if (!ParseStringAttribute(mesh_node, "class", &class_name)) {
         class_name = "main";
       }
-      if (default_mesh_.count(class_name) > 0) {
+      if (default_mesh_.contains(class_name)) {
         ApplyDefaultAttributes(*default_mesh_.at(class_name), mesh_node);
       }
       WarnUnsupportedAttribute(*mesh_node, "smoothnormal");

--- a/multibody/parsing/detail_strongly_connected_components.h
+++ b/multibody/parsing/detail_strongly_connected_components.h
@@ -76,10 +76,10 @@ StronglyConnectedComponents<T> FindStronglyConnectedComponents(
     ++index_counter;
     stack.push_back(node);
 
-    if (graph.count(node)) {
+    if (graph.contains(node)) {
       const auto& successors = graph.at(node);
       for (const auto& successor : successors) {
-        if (!lowlinks.count(successor)) {
+        if (!lowlinks.contains(successor)) {
           // Successor has not yet been visited; recurse on it.
           strongconnect(successor);
           lowlinks[node] = std::min(lowlinks[node], lowlinks[successor]);
@@ -108,7 +108,7 @@ StronglyConnectedComponents<T> FindStronglyConnectedComponents(
 
   for (const auto& item : graph) {
     const auto& node = item.first;
-    if (!lowlinks.count(node)) {
+    if (!lowlinks.contains(node)) {
       strongconnect(node);
     }
   }

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -388,7 +388,7 @@ std::optional<std::string> ParseGeometryName(
   }
 
   // Check if we need to salt it.
-  if (geometry_names->count(result) > 0) {
+  if (geometry_names->contains(result)) {
     for (int i = 1;; ++i) {
       if (i >= numeric_name_suffix_limit) {
         policy.Error(fmt::format("Too many geometries with identical name '{}'",
@@ -396,7 +396,7 @@ std::optional<std::string> ParseGeometryName(
         return {};
       }
       std::string guess = fmt::format("{}_{}", result, i);
-      if (geometry_names->count(guess) == 0) {
+      if (!geometry_names->contains(guess)) {
         if (explicitly_named) {
           policy.Warning(fmt::format(
               "{} name '{}' has already been used, renaming to '{}' instead",

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -1060,7 +1060,7 @@ TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
     const auto& names =
         material->GetProperty<std::set<std::string>>(group, property);
     EXPECT_EQ(names.size(), 1);
-    EXPECT_EQ(names.count("renderer1"), 1);
+    EXPECT_TRUE(names.contains("renderer1"));
   }
 
   // Case: Multiple <drake:accepting_renderer> tag.
@@ -1085,8 +1085,8 @@ TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
     const auto& names =
         material->GetProperty<std::set<std::string>>(group, property);
     EXPECT_EQ(names.size(), 2);
-    EXPECT_EQ(names.count("renderer1"), 1);
-    EXPECT_EQ(names.count("renderer2"), 1);
+    EXPECT_TRUE(names.contains("renderer1"));
+    EXPECT_TRUE(names.contains("renderer2"));
   }
 
   // Case: Missing names throws exception.

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -158,7 +158,7 @@ class SdfParserTest : public test::DiagnosticPolicyTestBase{
         CollisionPair names{m_name, n_name};
         auto contains =
             [&expected_filters](const CollisionPair& key) {
-              return expected_filters.count(key) > 0;
+              return expected_filters.contains(key);
             };
         EXPECT_EQ(inspector.CollisionFiltered(ids[m], ids[n]),
                   contains(names));

--- a/multibody/parsing/test/detail_strongly_connected_components_test.cc
+++ b/multibody/parsing/test/detail_strongly_connected_components_test.cc
@@ -141,8 +141,8 @@ GTEST_TEST(StronglyConnectedComponentsTest, DeepNest) {
   EXPECT_EQ(sccs.size(), depth);
 
   // Ordering is top-down; successors before sources.
-  EXPECT_EQ(sccs[0].count(depth - 1), 1);
-  EXPECT_EQ(sccs[depth - 1].count(0), 1);
+  EXPECT_TRUE(sccs[0].contains(depth - 1));
+  EXPECT_TRUE(sccs[depth - 1].contains(0));
 }
 
 }  // namespace

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -1133,14 +1133,14 @@ TEST_F(UrdfGeometryTest, AcceptingRenderers) {
       const auto& names =
           props.GetProperty<std::set<std::string>>(group, property);
       EXPECT_EQ(names.size(), 1);
-      EXPECT_EQ(names.count("renderer1"), 1);
+      EXPECT_TRUE(names.contains("renderer1"));
     } else if (instance.name() == "multi_renderer") {
       EXPECT_TRUE(props.HasProperty(group, property));
       const auto& names =
           props.GetProperty<std::set<std::string>>(group, property);
       EXPECT_EQ(names.size(), 2);
-      EXPECT_EQ(names.count("renderer1"), 1);
-      EXPECT_EQ(names.count("renderer2"), 1);
+      EXPECT_TRUE(names.contains("renderer1"));
+      EXPECT_TRUE(names.contains("renderer2"));
     } else {
       GTEST_FAIL() << "Encountered visual geometry not expected: "
                      << instance.name();

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -57,12 +57,12 @@ void VerifyMatch(const PackageMap& package_map,
   // packages.
   for (const auto& [package_name, count] : package_name_counts) {
     ASSERT_EQ(count, 1);
-    ASSERT_EQ(expected_packages.count(package_name), 1);
+    ASSERT_TRUE(expected_packages.contains(package_name));
   }
   // Confirm that every expected package is in the set of package names.
   for (const auto& [package_name, path] : expected_packages) {
     unused(path);
-    ASSERT_EQ(package_name_counts.count(package_name), 1);
+    ASSERT_TRUE(package_name_counts.contains(package_name));
   }
 }
 

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -70,7 +70,7 @@ void VerifyCollisionFilters(
       SCOPED_TRACE(fmt::format("{} vs {}", names.first(), names.second()));
       auto contains =
           [&expected_filters](const CollisionPair& key) {
-            return expected_filters.count(key) > 0;
+            return expected_filters.contains(key);
           };
       EXPECT_EQ(inspector.CollisionFiltered(ids[m], ids[n]),
                 contains(names));

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -230,7 +230,7 @@ GeometryId DeformableModel<T>::GetGeometryId(DeformableBodyId id) const {
 template <typename T>
 DeformableBodyId DeformableModel<T>::GetBodyId(
     geometry::GeometryId geometry_id) const {
-  if (geometry_id_to_body_id_.count(geometry_id) == 0) {
+  if (!geometry_id_to_body_id_.contains(geometry_id)) {
     throw std::runtime_error(
         fmt::format("The given GeometryId {} does not correspond to a "
                     "deformable body registered with this model.",

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -203,7 +203,7 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
   /** (Internal use only) Returns the true iff the deformable body with the
    given `id` has constraints associated with it. */
   bool HasConstraint(DeformableBodyId id) const {
-    return body_id_to_constraint_ids_.count(id) > 0;
+    return body_id_to_constraint_ids_.contains(id);
   }
 
   /** (Internal use only) Returns the fixed constraint specification
@@ -211,7 +211,7 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
    @throws if `id` is not a valid identifier for a fixed constraint. */
   const internal::DeformableRigidFixedConstraintSpec& fixed_constraint_spec(
       MultibodyConstraintId id) const {
-    DRAKE_THROW_UNLESS(fixed_constraint_specs_.count(id) > 0);
+    DRAKE_THROW_UNLESS(fixed_constraint_specs_.contains(id));
     return fixed_constraint_specs_.at(id);
   }
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -449,7 +449,7 @@ bool MultibodyPlant<T>::GetConstraintActiveStatus(
   this->ValidateContext(context);
   const std::map<MultibodyConstraintId, bool>& constraint_active_status =
       this->GetConstraintActiveStatus(context);
-  DRAKE_THROW_UNLESS(constraint_active_status.count(id) > 0);
+  DRAKE_THROW_UNLESS(constraint_active_status.contains(id));
   return constraint_active_status.at(id);
 }
 
@@ -461,7 +461,7 @@ void MultibodyPlant<T>::SetConstraintActiveStatus(systems::Context<T>* context,
   this->ValidateContext(context);
   std::map<MultibodyConstraintId, bool>& constraint_active_status =
       this->GetMutableConstraintActiveStatus(context);
-  DRAKE_THROW_UNLESS(constraint_active_status.count(id) > 0);
+  DRAKE_THROW_UNLESS(constraint_active_status.contains(id));
   constraint_active_status[id] = status;
 }
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1518,7 +1518,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws if `id` is not a valid identifier for a coupler constraint.
   const internal::CouplerConstraintSpec& get_coupler_constraint_specs(
       MultibodyConstraintId id) const {
-    DRAKE_THROW_UNLESS(coupler_constraints_specs_.count(id) > 0);
+    DRAKE_THROW_UNLESS(coupler_constraints_specs_.contains(id));
     return coupler_constraints_specs_.at(id);
   }
 
@@ -1527,7 +1527,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws if `id` is not a valid identifier for a distance constraint.
   const internal::DistanceConstraintSpec& get_distance_constraint_specs(
       MultibodyConstraintId id) const {
-    DRAKE_THROW_UNLESS(distance_constraints_specs_.count(id) > 0);
+    DRAKE_THROW_UNLESS(distance_constraints_specs_.contains(id));
     return distance_constraints_specs_.at(id);
   }
 
@@ -1536,7 +1536,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws if `id` is not a valid identifier for a ball constraint.
   const internal::BallConstraintSpec& get_ball_constraint_specs(
       MultibodyConstraintId id) const {
-    DRAKE_THROW_UNLESS(ball_constraints_specs_.count(id) > 0);
+    DRAKE_THROW_UNLESS(ball_constraints_specs_.contains(id));
     return ball_constraints_specs_.at(id);
   }
 
@@ -1545,7 +1545,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws if `id` is not a valid identifier for a weld constraint.
   const internal::WeldConstraintSpec& get_weld_constraint_specs(
       MultibodyConstraintId id) const {
-    DRAKE_THROW_UNLESS(weld_constraints_specs_.count(id) > 0);
+    DRAKE_THROW_UNLESS(weld_constraints_specs_.contains(id));
     return weld_constraints_specs_.at(id);
   }
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1459,8 +1459,8 @@ GTEST_TEST(MultibodyPlantTest, FilterAdjacentBodies) {
                                                   GeometryId id2) {
         auto pair1 = std::make_pair(id1, id2);
         auto pair2 = std::make_pair(id2, id1);
-        if (expected_pairs.count(pair1) == 0 &&
-            expected_pairs.count(pair2) == 0) {
+        if (!expected_pairs.contains(pair1) &&
+            !expected_pairs.contains(pair2)) {
           GTEST_FAIL() << "The pair " << id1 << ", " << id2
                        << " is not in the expected set";
         }
@@ -1746,7 +1746,7 @@ bool VerifyFeedthroughPorts(const MultibodyPlant<double>& plant) {
   // list of expected feedthrough ports.
   const std::multimap<int, int> feedthroughs = plant.GetDirectFeedthroughs();
   for (const auto& inout_pair : feedthroughs) {
-    if (ok_to_feedthrough.count(inout_pair.second) == 0)
+    if (!ok_to_feedthrough.contains(inout_pair.second))
       return false;  // Found a spurious feedthrough port.
   }
   return true;

--- a/multibody/rational/test/rational_forward_kinematics_test.cc
+++ b/multibody/rational/test/rational_forward_kinematics_test.cc
@@ -104,12 +104,12 @@ TEST_F(FinalizedIiwaTest, CalcBodyPose1) {
     EXPECT_GE(s_index, -1);
     EXPECT_LT(s_index, dut.s().rows());
     if (s_index >= 0) {
-      EXPECT_EQ(s_index_set.count(s_index), 0);
+      EXPECT_FALSE(s_index_set.contains(s_index));
     }
     s_index_set.emplace_hint(s_index_set.end(), s_index);
   }
   // There is one welded joint hence one of s_index is -1.
-  EXPECT_EQ(s_index_set.count(-1), 1);
+  EXPECT_TRUE(s_index_set.contains(-1));
 }
 
 TEST_F(FinalizedIiwaTest, CalcBodyPose2) {

--- a/multibody/topology/multibody_graph.cc
+++ b/multibody/topology/multibody_graph.cc
@@ -295,7 +295,7 @@ std::set<BodyIndex> MultibodyGraph::FindBodiesWeldedTo(
   // TODO(amcastro-tri): Consider storing within RigidBody the subgraph it
   //  belongs to if performance becomes an issue.
   auto predicate = [body_index](auto& subgraph) {
-    return subgraph.count(body_index) > 0;
+    return subgraph.contains(body_index);
   };
   auto subgraph_iter =
       std::find_if(subgraphs.begin(), subgraphs.end(), predicate);

--- a/multibody/topology/test/multibody_graph_test.cc
+++ b/multibody/topology/test/multibody_graph_test.cc
@@ -221,7 +221,7 @@ GTEST_TEST(MultibodyGraph, Weldedsubgraphs) {
 
   // The first subgraph must contain the world.
   const std::set<BodyIndex> world_subgraph = welded_subgraphs[0];
-  EXPECT_EQ(world_subgraph.count(world_index()), 1);
+  EXPECT_TRUE(world_subgraph.contains(world_index()));
 
   // Build the expected set of subgraphs.
   std::set<std::set<BodyIndex>> expected_subgraphs;

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -417,7 +417,7 @@ bool MultibodyTree<T>::HasJointActuatorNamed(
 
 template <typename T>
 bool MultibodyTree<T>::HasModelInstanceNamed(std::string_view name) const {
-  return model_instances_.names_map().count(name) > 0;
+  return model_instances_.names_map().contains(name);
 }
 
 template <typename T>
@@ -1007,7 +1007,7 @@ RigidTransform<T> MultibodyTree<T>::GetFreeBodyPoseOrThrow(
 template <typename T>
 void MultibodyTree<T>::SetDefaultFreeBodyPose(
     const RigidBody<T>& body, const RigidTransform<double>& X_WB) {
-  if (default_body_poses_.count(body.index()) == 0 ||
+  if (!default_body_poses_.contains(body.index()) ||
       std::holds_alternative<
           std::pair<Eigen::Quaternion<double>, Vector3<double>>>(
           default_body_poses_.at(body.index()))) {
@@ -1037,7 +1037,7 @@ template <typename T>
 std::pair<Eigen::Quaternion<double>, Vector3<double>>
 MultibodyTree<T>::GetDefaultFreeBodyPoseAsQuaternionVec3Pair(
     const RigidBody<T>& body) const {
-  if (default_body_poses_.count(body.index()) == 0) {
+  if (!default_body_poses_.contains(body.index())) {
     return std::make_pair(Eigen::Quaternion<double>::Identity(),
                           Vector3<double>::Zero());
   }

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -1013,7 +1013,7 @@ class MultibodyTreeTopology {
       DRAKE_DEMAND(body_index.is_valid() && body_index < num_rigid_bodies());
       // Skip bodies that are already traversed because the subtree with it
       // being the root has necessarily been traversed already.
-      if (outboard_bodies.count(body_index) == 0) {
+      if (!outboard_bodies.contains(body_index)) {
         const BodyNodeTopology& root =
             get_body_node(get_rigid_body(body_index).mobod_index);
         TraverseOutboardNodes(root, collect_body);

--- a/multibody/tree/uniform_gravity_field_element.h
+++ b/multibody/tree/uniform_gravity_field_element.h
@@ -60,7 +60,7 @@ class UniformGravityFieldElement : public ForceElement<T> {
     if (model_instance >= this->get_parent_tree().num_model_instances()) {
       throw std::logic_error("Model instance index is invalid.");
     }
-    return disabled_model_instances_.count(model_instance) == 0;
+    return !disabled_model_instances_.contains(model_instance);
   }
 
   /// Sets is_enabled() for `model_instance` to `is_enabled`.

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -327,7 +327,7 @@ GTEST_TEST(MakeModel, EnvironmentalFloatingBase) {
   const std::set<int> base_dofs = GetFloatingBaseDofs();
   const int start = floater.floating_positions_start();
   for (int i = start; i < start + 7; ++i) {
-    EXPECT_EQ(base_dofs.count(i), 1);
+    EXPECT_TRUE(base_dofs.contains(i));
   }
 }
 
@@ -538,7 +538,7 @@ GTEST_TEST(CollisionCheckerTest, RobotClearance) {
   const RobotClearance clearance = checker->CalcRobotClearance(q, 0);
   ASSERT_EQ(clearance.size(), 1);
   for (int i = 0; i < clearance.num_positions(); ++i) {
-    if (non_robot_dofs.count(i) > 0) {
+    if (non_robot_dofs.contains(i)) {
       EXPECT_EQ(clearance.jacobians()(i), 0);
     } else {
       EXPECT_EQ(clearance.jacobians()(i), i + 1);

--- a/solvers/aggregate_costs_constraints.cc
+++ b/solvers/aggregate_costs_constraints.cc
@@ -216,7 +216,7 @@ void AggregateDuplicateVariables(const Eigen::SparseMatrix<double>& A,
   std::unordered_map<symbolic::Variable::Id, int> vars_to_vars_new;
   int unique_var_count = 0;
   for (int i = 0; i < vars.rows(); ++i) {
-    const bool seen_already = vars_to_vars_new.count(vars(i).get_id());
+    const bool seen_already = vars_to_vars_new.contains(vars(i).get_id());
     if (!seen_already) {
       (*vars_new)(unique_var_count) = vars(i);
       vars_to_vars_new.emplace(vars(i).get_id(), unique_var_count);

--- a/solvers/get_program_type.cc
+++ b/solvers/get_program_type.cc
@@ -25,19 +25,19 @@ bool SatisfiesProgramType(const Requirements& requirements,
                           const ProgramAttributes& program_attributes) {
   // Check if program_attributes is a subset of acceptable_attributes
   for (const auto attribute : program_attributes) {
-    if (requirements.acceptable.count(attribute) == 0) {
+    if (!requirements.acceptable.contains(attribute)) {
       return false;
     }
   }
   // Check if program_attributes include must_include_attributes
   for (const auto& must_include_attr : requirements.must_include) {
-    if (program_attributes.count(must_include_attr) == 0) {
+    if (!program_attributes.contains(must_include_attr)) {
       return false;
     }
   }
   bool include_one_of = requirements.must_include_one_of.empty() ? true : false;
   for (const auto& include : requirements.must_include_one_of) {
-    if (program_attributes.count(include) > 0) {
+    if (program_attributes.contains(include)) {
       include_one_of = true;
       break;
     }
@@ -205,12 +205,11 @@ bool IsNLP(const MathematicalProgram& prog) {
   // 3. It has at least one of : generic costs, generic constraints, non-convex
   // quadratic cost, linear complementarity constraints, quadratic constraints.
   const bool has_generic_cost =
-      prog.required_capabilities().count(ProgramAttribute::kGenericCost) > 0;
+      prog.required_capabilities().contains(ProgramAttribute::kGenericCost);
   const bool has_nonconvex_quadratic_cost =
       !AllQuadraticCostsConvex(prog.quadratic_costs());
-  const bool has_generic_constraint =
-      prog.required_capabilities().count(ProgramAttribute::kGenericConstraint) >
-      0;
+  const bool has_generic_constraint = prog.required_capabilities().contains(
+      ProgramAttribute::kGenericConstraint);
   const bool has_quadratic_constraint =
       prog.required_capabilities().count(
           ProgramAttribute::kQuadraticConstraint) > 0;

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -1306,7 +1306,7 @@ void GurobiSolver::DoSolve(const MathematicalProgram& prog,
 
   // Default the option for number of threads based on an environment variable
   // (but only if the user hasn't set the option directly already).
-  if (merged_options.GetOptionsInt(id()).count("Threads") == 0) {
+  if (!merged_options.GetOptionsInt(id()).contains("Threads")) {
     if (char* num_threads_str = std::getenv("GUROBI_NUM_THREADS")) {
       const std::optional<int> num_threads = ParseInt(num_threads_str);
       if (num_threads.has_value()) {

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -2105,7 +2105,7 @@ void MathematicalProgram::CheckIsDecisionVariable(
     const VectorXDecisionVariable& vars) const {
   for (int i = 0; i < vars.rows(); ++i) {
     for (int j = 0; j < vars.cols(); ++j) {
-      if (decision_variable_index_.count(vars(i, j).get_id()) == 0) {
+      if (!decision_variable_index_.contains(vars(i, j).get_id())) {
         throw std::logic_error(fmt::format(
             "{} is not a decision variable of the mathematical program.",
             vars(i, j)));

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -90,7 +90,7 @@ symbolic::Polynomial MathematicalProgramResult::GetSolution(
     const symbolic::Polynomial& p) const {
   DRAKE_ASSERT(decision_variable_index_.has_value());
   for (const auto& indeterminate : p.indeterminates()) {
-    if (decision_variable_index_->count(indeterminate.get_id()) > 0) {
+    if (decision_variable_index_->contains(indeterminate.get_id())) {
       throw std::invalid_argument(
           fmt::format("GetSolution: {} is an indeterminate in the polynomial, "
                       "but result stores its value as a decision variable.",

--- a/solvers/mosek_solver_internal.cc
+++ b/solvers/mosek_solver_internal.cc
@@ -526,7 +526,7 @@ MSKrescodee MosekSolverProgram::AddBoundingBoxConstraints(
         // This variable is a Mosek matrix variable. The bound on this variable
         // is imposed as a linear constraint.
         DRAKE_DEMAND(
-            decision_variable_to_mosek_matrix_variable().count(var_index) > 0);
+            decision_variable_to_mosek_matrix_variable().contains(var_index));
         lower_bound_duals[i].type = DualVarType::kLinearConstraint;
         upper_bound_duals[i].type = DualVarType::kLinearConstraint;
         const int linear_constraint_index =
@@ -1285,7 +1285,7 @@ MapDecisionVariableToMosekVariable::MapDecisionVariableToMosekVariable(
   // Mosek.
   int nonmatrix_variable_count = 0;
   for (int i = 0; i < prog.num_vars(); ++i) {
-    if (decision_variable_to_mosek_matrix_variable.count(i) == 0) {
+    if (!decision_variable_to_mosek_matrix_variable.contains(i)) {
       decision_variable_to_mosek_nonmatrix_variable.emplace(
           i, nonmatrix_variable_count++);
     }

--- a/solvers/nlopt_solver.cc
+++ b/solvers/nlopt_solver.cc
@@ -187,7 +187,7 @@ void EvaluateVectorConstraint(unsigned m, double* result, unsigned n,
   const Eigen::VectorXd& upper_bound = c->upper_bound();
   size_t result_idx = 0;
   for (int i = 0; i < num_constraints; i++) {
-    if (!wrapped->active_constraints.count(i)) {
+    if (!wrapped->active_constraints.contains(i)) {
       continue;
     }
     if (wrapped->force_bounds && wrapped->force_upper &&
@@ -217,7 +217,7 @@ void EvaluateVectorConstraint(unsigned m, double* result, unsigned n,
           wrapped->prog->FindDecisionVariableIndex((*wrapped->vars)(i));
     }
     for (int i = 0; i < num_constraints; i++) {
-      if (!wrapped->active_constraints.count(i)) {
+      if (!wrapped->active_constraints.contains(i)) {
         continue;
       }
       double grad_sign = 1;

--- a/solvers/osqp_solver_common.cc
+++ b/solvers/osqp_solver_common.cc
@@ -48,7 +48,7 @@ bool CheckAttributes(const MathematicalProgram& prog,
     }
     return false;
   }
-  if (required_capabilities.count(ProgramAttribute::kQuadraticCost) == 0) {
+  if (!required_capabilities.contains(ProgramAttribute::kQuadraticCost)) {
     if (explanation) {
       *explanation =
           "OsqpSolver is unable to solve because a QuadraticCost is required"

--- a/solvers/program_attribute.cc
+++ b/solvers/program_attribute.cc
@@ -24,7 +24,7 @@ bool AreRequiredAttributesSupported(const ProgramAttributes& required,
   // tally any unsupported attributes to populate the message at the end.
   std::vector<ProgramAttribute> unsupported_enums;
   for (const auto& attribute : required) {
-    if (supported.count(attribute) == 0) {
+    if (!supported.contains(attribute)) {
       if (unsupported_message == nullptr) {
         return false;
       } else {

--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -1420,7 +1420,7 @@ void SnoptSolver::DoSolve(const MathematicalProgram& prog,
   // deliberately, set "Timing level" to zero if the user hasn't requested
   // another value.
   const std::string kTimingLevel = "Timing level";
-  if (int_options.count(kTimingLevel) == 0) {
+  if (!int_options.contains(kTimingLevel)) {
     int_options[kTimingLevel] = 0;
   }
 

--- a/solvers/solver_options.cc
+++ b/solvers/solver_options.cc
@@ -226,7 +226,7 @@ void CheckOptionKeysForSolverHelper(
     const std::unordered_set<std::string>& allowable_keys,
     const std::string& solver_name) {
   for (const auto& key_val : key_vals) {
-    if (allowable_keys.count(key_val.first) == 0) {
+    if (!allowable_keys.contains(key_val.first)) {
       throw std::invalid_argument(key_val.first +
                                   " is not allowed in the SolverOptions for " +
                                   solver_name + ".");

--- a/solvers/test/choose_best_solver_test.cc
+++ b/solvers/test/choose_best_solver_test.cc
@@ -48,7 +48,7 @@ class ChooseBestSolverTest : public ::testing::Test {
     EXPECT_EQ(solver_id, expected_solver_id);
 
     // Ensure GetKnownSolvers is comprehensive.
-    EXPECT_EQ(GetKnownSolvers().count(solver_id), 1);
+    EXPECT_TRUE(GetKnownSolvers().contains(solver_id));
   }
 
   void CheckMakeSolver(const SolverInterface& solver) const {
@@ -56,7 +56,7 @@ class ChooseBestSolverTest : public ::testing::Test {
     EXPECT_EQ(new_solver->solver_id(), solver.solver_id());
 
     // Ensure GetKnownSolvers is comprehensive.
-    EXPECT_EQ(GetKnownSolvers().count(solver.solver_id()), 1);
+    EXPECT_TRUE(GetKnownSolvers().contains(solver.solver_id()));
   }
 
   void CheckBestSolver(const std::vector<SolverInterface*>& solvers) {
@@ -116,7 +116,7 @@ void CheckGetAvailableSolvers(const MathematicalProgram& prog) {
   const std::vector<SolverId> available_ids = GetAvailableSolvers(prog_type);
   const auto known_solvers = GetKnownSolvers();
   for (const auto& available_id : available_ids) {
-    EXPECT_GT(known_solvers.count(available_id), 0);
+    EXPECT_TRUE(known_solvers.contains(available_id));
     std::unique_ptr<SolverInterface> solver = MakeSolver(available_id);
     EXPECT_TRUE(solver->available());
     EXPECT_TRUE(solver->enabled());
@@ -144,7 +144,7 @@ void CheckGetAvailableSolvers(const MathematicalProgram& prog) {
         // GetAvailableSolvers(kQuadraticCostConicConstraint).
         continue;
       } else {
-        EXPECT_GT(available_id_set.count(solver_id), 0);
+        EXPECT_TRUE(available_id_set.contains(solver_id));
       }
     }
   }

--- a/solvers/test/solver_base_test.cc
+++ b/solvers/test/solver_base_test.cc
@@ -55,10 +55,10 @@ class StubSolverBase final : public SolverBase {
     result->set_optimal_cost(1.0);
     Eigen::VectorXd x_val = x_init;
     const auto& options_double = options.GetOptionsDouble(id());
-    if (options_double.count("x0_solution")) {
+    if (options_double.contains("x0_solution")) {
       x_val[0] = options_double.find("x0_solution")->second;
     }
-    if (options_double.count("x1_solution")) {
+    if (options_double.contains("x1_solution")) {
       x_val[1] = options_double.find("x1_solution")->second;
     }
     result->set_x_val(x_val);

--- a/systems/framework/continuous_state.cc
+++ b/systems/framework/continuous_state.cc
@@ -112,17 +112,17 @@ void ContinuousState<T>::DemandInvariants() const {
   for (int i = 0; i < num_q(); ++i) {
     const T* element = &(generalized_position_->GetAtIndex(i));
     qvz_element_pointers.emplace(element);
-    DRAKE_DEMAND(state_element_pointers.count(element) == 1);
+    DRAKE_DEMAND(state_element_pointers.contains(element));
   }
   for (int i = 0; i < num_v(); ++i) {
     const T* element = &(generalized_velocity_->GetAtIndex(i));
     qvz_element_pointers.emplace(element);
-    DRAKE_DEMAND(state_element_pointers.count(element) == 1);
+    DRAKE_DEMAND(state_element_pointers.contains(element));
   }
   for (int i = 0; i < num_z(); ++i) {
     const T* element = &(misc_continuous_state_->GetAtIndex(i));
     qvz_element_pointers.emplace(element);
-    DRAKE_DEMAND(state_element_pointers.count(element) == 1);
+    DRAKE_DEMAND(state_element_pointers.contains(element));
   }
   DRAKE_DEMAND(static_cast<int>(qvz_element_pointers.size()) == num_total);
 }

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1144,7 +1144,7 @@ bool Diagram<T>::DiagramHasDirectFeedthrough(
     for (const auto& [sys_input, sys_output] : sys_feedthroughs) {
       if (sys_output == current_output_id.second) {
         const InputPortLocator curr_input_id(sys, sys_input);
-        if (target_input_ids.count(curr_input_id)) {
+        if (target_input_ids.contains(curr_input_id)) {
           // We've found a direct-feedthrough path to the input_port.
           return true;
         } else {

--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -36,7 +36,7 @@ DiagramBuilder<T>::~DiagramBuilder() {}
 template <typename T>
 void DiagramBuilder<T>::RemoveSystem(const System<T>& system) {
   ThrowIfAlreadyBuilt();
-  if (systems_.count(&system) == 0) {
+  if (!systems_.contains(&system)) {
     throw std::logic_error(fmt::format(
         "Cannot RemoveSystem on {} because it has not been added to this "
         "DiagramBuilder",
@@ -269,7 +269,7 @@ InputPortIndex DiagramBuilder<T>::DeclareInput(
   DRAKE_DEMAND(!port_name.empty());
 
   // Reject duplicate declarations.
-  if (diagram_input_indices_.count(port_name) != 0) {
+  if (diagram_input_indices_.contains(port_name)) {
     throw std::logic_error(
         fmt::format("Diagram already has an input port named {}", port_name));
   }
@@ -365,7 +365,7 @@ bool DiagramBuilder<T>::ConnectToSame(
   }
 
   // Check if `exemplar` was exported.
-  if (diagram_input_set_.count(exemplar_id) > 0) {
+  if (diagram_input_set_.contains(exemplar_id)) {
     for (size_t i = 0; i < input_port_ids_.size(); ++i) {
       if (input_port_ids_[i] == exemplar_id) {
         ConnectInput(input_port_names_[i], dest);
@@ -417,8 +417,8 @@ template <typename T>
 bool DiagramBuilder<T>::IsConnectedOrExported(const InputPort<T>& port) const {
   ThrowIfAlreadyBuilt();
   InputPortLocator id{&port.get_system(), port.get_index()};
-  if (this->connection_map_.count(id) > 0 ||
-      this->diagram_input_set_.count(id) > 0) {
+  if (this->connection_map_.contains(id) ||
+      this->diagram_input_set_.contains(id)) {
     return true;
   }
   return false;
@@ -461,7 +461,7 @@ template <typename T>
 void DiagramBuilder<T>::ThrowIfSystemNotRegistered(
     const System<T>* system) const {
   DRAKE_DEMAND(system != nullptr);
-  if (systems_.count(system) == 0) {
+  if (!systems_.contains(system)) {
     std::string registered_system_names{};
     for (const auto& sys : registered_systems_) {
       if (!registered_system_names.empty()) {
@@ -516,7 +516,7 @@ bool HasCycleRecurse(
     const std::map<PortIdentifier, std::set<PortIdentifier>>& edges,
     std::set<PortIdentifier>* visited,
     std::vector<PortIdentifier>* stack) {
-  DRAKE_ASSERT(visited->count(n) == 0);
+  DRAKE_ASSERT(!visited->contains(n));
   visited->insert(n);
 
   auto edge_iter = edges.find(n);
@@ -524,7 +524,7 @@ bool HasCycleRecurse(
     DRAKE_ASSERT(std::find(stack->begin(), stack->end(), n) == stack->end());
     stack->push_back(n);
     for (const auto& target : edge_iter->second) {
-      if (visited->count(target) == 0 &&
+      if (!visited->contains(target) &&
           HasCycleRecurse(target, edges, visited, stack)) {
         return true;
       } else if (std::find(stack->begin(), stack->end(), target) !=
@@ -588,7 +588,7 @@ void DiagramBuilder<T>::ThrowIfAlgebraicLoopsExist() const {
           subsystem_index, InputPortIndex{item.first}, system};
       const PortIdentifier output{
           subsystem_index, OutputPortIndex{item.second}, system};
-      if (nodes.count(input) > 0 && nodes.count(output) > 0) {
+      if (nodes.contains(input) && nodes.contains(output)) {
         edges[input].insert(output);
       }
     }
@@ -606,7 +606,7 @@ void DiagramBuilder<T>::ThrowIfAlgebraicLoopsExist() const {
   std::set<PortIdentifier> visited;
   std::vector<PortIdentifier> stack;
   for (const auto& node : nodes) {
-    if (visited.count(node) > 0) {
+    if (visited.contains(node)) {
       continue;
     }
     if (HasCycleRecurse(node, edges, &visited, &stack)) {
@@ -630,7 +630,7 @@ void DiagramBuilder<T>::ThrowIfAlgebraicLoopsExist() const {
 template <typename T>
 void DiagramBuilder<T>::CheckInvariants() const {
   auto has_system = [this](const System<T>* system) {
-    return std::count(systems_.begin(), systems_.end(), system) > 0;
+    return systems_.contains(system);
   };
 
   // The systems_ and registered_systems_ are identical sets.

--- a/systems/framework/system_scalar_converter.cc
+++ b/systems/framework/system_scalar_converter.cc
@@ -70,7 +70,7 @@ void SystemScalarConverter::RemoveUnlessAlsoSupportedBy(
   // (This would use erase_if, if we had it.)
   for (auto iter = funcs_.begin(); iter != funcs_.end(); ) {
     const Key& our_key = iter->first;
-    if (other.funcs_.count(our_key) == 0) {
+    if (!other.funcs_.contains(our_key)) {
       iter = funcs_.erase(iter);
     } else {
       ++iter;

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -751,7 +751,7 @@ TEST_F(DiagramBuilderSolePortsTest, SourceGainSink2) {
 
   const InputPortLocator in1_input{in1_, InputPortIndex{0}};
   const auto& connections = diagram->connection_map();
-  ASSERT_EQ(connections.count(in1_input), 1);
+  ASSERT_TRUE(connections.contains(in1_input));
   EXPECT_EQ(connections.find(in1_input)->second.first, out1_);
 }
 

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -236,7 +236,7 @@ class DiagramContextTest : public ::testing::Test {
     ASSERT_EQ(count_now.size(), kNumSystems + 1);
     ASSERT_EQ(before_count->size(), kNumSystems + 1);
     for (int i = 0; i <= kNumSystems; ++i) {
-      const int n = should_have_been_notified.count(i) ? 1 : 0;
+      const int n = should_have_been_notified.contains(i) ? 1 : 0;
       (*before_count)[i] += n;
       EXPECT_EQ(count_now[i], (*before_count)[i]) << which << " of system "
                                                   << i;

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -636,7 +636,7 @@ void CheckAllCacheValuesUpToDateExcept(
   for (CacheIndex i(0); i < cache.cache_size(); ++i) {
     if (!cache.has_cache_entry_value(i)) continue;
     const CacheEntryValue& entry = cache.get_cache_entry_value(i);
-    EXPECT_EQ(entry.is_out_of_date(), should_be_out_of_date.count(i) != 0) << i;
+    EXPECT_EQ(entry.is_out_of_date(), should_be_out_of_date.contains(i)) << i;
   }
 }
 

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -194,7 +194,7 @@ std::string ImageWriter::MakeFileName(const std::string& format,
                                       PixelType pixel_type, double time,
                                       const std::string& port_name,
                                       int count) const {
-  DRAKE_DEMAND(labels_.count(pixel_type) > 0);
+  DRAKE_DEMAND(labels_.contains(pixel_type));
 
   int64_t u_time = static_cast<int64_t>(time * 1e6 + 0.5);
   int m_time = static_cast<int>(time * 1e3 + 0.5);

--- a/tools/workspace/vtk_internal/patches/gltf_parser.patch
+++ b/tools/workspace/vtk_internal/patches/gltf_parser.patch
@@ -73,7 +73,7 @@ These changes *should* be upstreamed to VTK.
 +  {
 +    if (info.Index >= 0) uv_sets.insert(info.TexCoord);
 +  }
-+  if (uv_sets.count(-1) > 0) {
++  if (uv_sets.contains(-1)) {
 +    vtkErrorWithObjectMacro(parent,
 +                            "A material defined a texture index without "
 +                            "defining a texture coordinate set.");


### PR DESCRIPTION
This updates Drake's code base to be C++20 friendly. Various stl map and set types now directly support a `contains(x)` method. Previously, we would call `count(x)` and do some numerical comparison to determine if a key was found. Now, we're spelling it directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21051)
<!-- Reviewable:end -->
