### PR TITLE
Prevent segfaults in `VPolytope` by checking square matrix

### DIFF
--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -336,6 +336,11 @@ VPolytope::VPolytope(const HPolyhedron& hpoly, const double tol)
   int ii = 0;
   for (const auto& facet : qhull.facetList()) {
     auto incident_hyperplanes = facet.vertices();
+    // A temporary fix that makes sure that vertex_A is a square matrix, as
+    // otherwise partialPivLu can segfault. This randomly occurs when Gurobi
+    // is used as a solver, see bug issue #21055 for details.
+    DRAKE_THROW_UNLESS(
+      incident_hyperplanes.count() == hpoly.ambient_dimension());
     MatrixXd vertex_A(incident_hyperplanes.count(), hpoly.ambient_dimension());
     for (int jj = 0; jj < incident_hyperplanes.count(); jj++) {
       std::vector<double> hyperplane =

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -339,8 +339,8 @@ VPolytope::VPolytope(const HPolyhedron& hpoly, const double tol)
     // A temporary fix that makes sure that vertex_A is a square matrix, as
     // otherwise partialPivLu can segfault. This randomly occurs when Gurobi
     // is used as a solver, see bug issue #21055 for details.
-    DRAKE_THROW_UNLESS(
-      incident_hyperplanes.count() == hpoly.ambient_dimension());
+    DRAKE_THROW_UNLESS(incident_hyperplanes.count() ==
+                       hpoly.ambient_dimension());
     MatrixXd vertex_A(incident_hyperplanes.count(), hpoly.ambient_dimension());
     for (int jj = 0; jj < incident_hyperplanes.count(); jj++) {
       std::vector<double> hyperplane =


### PR DESCRIPTION
This is a temporary fix for the bug in #21055, so that exceptions can be caught instead of the program segfaulting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21060)
<!-- Reviewable:end -->
