### PR TITLE
SceneGraph provides the convex hull for visualization

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -263,6 +263,7 @@ drake_cc_library(
         ":kinematics_vector",
         ":proximity_engine",
         ":utilities",
+        "//geometry/proximity:make_convex_hull_mesh",
         "//geometry/render:render_engine",
         "//math:gradient",
     ],
@@ -353,6 +354,7 @@ drake_cc_library(
         ":shape_specification",
         "//common:copyable_unique_ptr",
         "//common:essential",
+        "//geometry/proximity:polygon_surface_mesh",
         "//geometry/proximity:volume_mesh",
         "//math:geometric_transform",
     ],
@@ -668,6 +670,7 @@ drake_cc_library(
         ":rgba",
         ":scene_graph",
         "//common:essential",
+        "//geometry/proximity:polygon_to_triangle_mesh",
         "//math:geometric_transform",
         "//systems/analysis:instantaneous_realtime_rate_calculator",
         "//systems/framework:context",
@@ -859,6 +862,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "geometry_state_test",
+    data = ["//geometry:test_obj_files"],
     deps = [
         ":geometry_state",
         "//common/test_utilities",

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -306,6 +306,9 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::GetAllDeformableGeometryIds(). */
   std::vector<GeometryId> GetAllDeformableGeometryIds() const;
 
+  /** Implementation of SceneGraphInspector::GetConvexHull(). */
+  const PolygonSurfaceMesh<double>* GetConvexHull(GeometryId id) const;
+
   /** Implementation of SceneGraphInspector::CollisionFiltered().  */
   bool CollisionFiltered(GeometryId id1, GeometryId id2) const;
 

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -12,6 +12,7 @@
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/internal_frame.h"
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
@@ -232,6 +233,17 @@ class InternalGeometry {
     return reference_mesh_.get();
   }
 
+  /* Sets the convex hull for this geometry. Passing `nullptr` clears the
+   convex hull. */
+  void set_convex_hull(std::unique_ptr<PolygonSurfaceMesh<double>> hull) {
+    convex_hull_ = std::move(hull);
+  }
+
+  /* Returns a pointer to the geometry's convex hull. */
+  const PolygonSurfaceMesh<double>* convex_hull() const {
+    return convex_hull_.get();
+  }
+
  private:
   // The specification for this instance's shape.
   copyable_unique_ptr<Shape> shape_spec_;
@@ -266,6 +278,10 @@ class InternalGeometry {
   // configuration. The vertex positions are expressed in the geometry's
   // frame, G. It's a nullptr if the geometry is rigid.
   copyable_unique_ptr<VolumeMesh<double>> reference_mesh_;
+
+  // An optional representation of the convex hull associated with this
+  // geometry.
+  copyable_unique_ptr<PolygonSurfaceMesh<double>> convex_hull_;
 };
 
 }  // namespace internal

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -54,6 +54,7 @@ drake_cc_package_library(
         ":obj_to_surface_mesh",
         ":plane",
         ":polygon_surface_mesh",
+        ":polygon_to_triangle_mesh",
         ":posed_half_space",
         ":sorted_triplet",
         ":tessellation_strategy",
@@ -760,6 +761,16 @@ drake_cc_library(
     deps = [
         ":mesh_traits",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
+    name = "polygon_to_triangle_mesh",
+    srcs = ["polygon_to_triangle_mesh.cc"],
+    hdrs = ["polygon_to_triangle_mesh.h"],
+    deps = [
+        ":polygon_surface_mesh",
+        ":triangle_surface_mesh",
     ],
 )
 
@@ -1484,6 +1495,14 @@ drake_cc_googletest(
         ":polygon_surface_mesh",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "polygon_to_triangle_mesh_test",
+    deps = [
+        ":polygon_to_triangle_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/geometry/proximity/polygon_to_triangle_mesh.cc
+++ b/geometry/proximity/polygon_to_triangle_mesh.cc
@@ -1,0 +1,42 @@
+#include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::Vector3d;
+
+TriangleSurfaceMesh<double> MakeTriangleFromPolygonMesh(
+    const PolygonSurfaceMesh<double>& poly_mesh) {
+  std::vector<Vector3<double>> vertices;
+  vertices.reserve(poly_mesh.num_vertices());
+  for (int v = 0; v < poly_mesh.num_vertices(); ++v) {
+    vertices.push_back(poly_mesh.vertex(v));
+  }
+
+  std::vector<SurfaceTriangle> tris;
+  // According to Euler's formula, the maximum number of possible triangles.
+  tris.reserve(2 * poly_mesh.num_vertices() - 4);
+  for (int p = 0; p < poly_mesh.num_faces(); ++p) {
+    // Create a triangle fan around vertex 0.
+    const SurfacePolygon& poly = poly_mesh.element(p);
+    const int v0 = poly.vertex(0);
+    int v1 = poly.vertex(1);
+    for (int v = 2; v < poly.num_vertices(); ++v) {
+      const int v2 = poly.vertex(v);
+      tris.emplace_back(v0, v1, v2);
+      v1 = v2;
+    }
+  }
+
+  return TriangleSurfaceMesh<double>(std::move(tris), std::move(vertices));
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/polygon_to_triangle_mesh.h
+++ b/geometry/proximity/polygon_to_triangle_mesh.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/** Creates a triangle mesh from a polygon mesh. The triangle mesh has the
+ exact same vertices as the polygon mesh. To whatever degree the polygon
+ mesh has duplicate vertices, the resulting triangle mesh will have the same.
+ The triangles will likewise mirror the winding present in the polygon mesh.
+
+ @pre Each polygon in poly_mesh is convex. */
+TriangleSurfaceMesh<double> MakeTriangleFromPolygonMesh(
+    const PolygonSurfaceMesh<double>& poly_mesh);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/polygon_to_triangle_mesh_test.cc
+++ b/geometry/proximity/test/polygon_to_triangle_mesh_test.cc
@@ -1,0 +1,95 @@
+#include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
+
+#include <set>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+
+/* MakeTriangleFromPolygonMesh() doesn't do much. It copies the vertices and
+ splits the triangles. Generally, it'll be immediately apparent if the
+ triangle mesh is wrong, because we render the triangle mesh in meshcat for
+ convex proximity geometries.
+
+ So, this test doesn't attempt to exhaustively confirm every mathematical
+ property of the result, but looks for evidence that things are right.
+
+ We create a polygon mesh of a cube with quad faces and confirm the triangle
+ mesh satisfies some minimum properties.*/
+GTEST_TEST(PolyToTriMeshTest, BasicSmokeTest) {
+  // clang-format off
+  const std::vector<Vector3d> vertices{
+    Vector3d(-1, -1, -1),
+    Vector3d(-1, 1, -1),
+    Vector3d(1, -1, -1),
+    Vector3d(1, 1, -1),
+    Vector3d(-1, -1, 1),
+    Vector3d(-1, 1, 1),
+    Vector3d(1, -1, 1),
+    Vector3d(1, 1, 1)
+  };
+  const PolygonSurfaceMesh<double> poly_cube({
+      4, 0, 1, 3, 2,
+      4, 0, 2, 6, 4,
+      4, 0, 4, 5, 1,
+      4, 7, 5, 4, 6,
+      4, 7, 6, 2, 3,
+      4, 7, 3, 1, 5
+  }, vertices);
+  // clang-format on
+
+  const TriangleSurfaceMesh<double> tri_cube =
+      MakeTriangleFromPolygonMesh(poly_cube);
+
+  // Vertices have been copied verbatim.
+  EXPECT_THAT(tri_cube.vertices(), testing::Eq(vertices));
+
+  // For each polygon, we have two triangles.
+  ASSERT_EQ(tri_cube.num_elements(), poly_cube.num_elements() * 2);
+
+  int t = 0;
+  for (int p = 0; p < poly_cube.num_elements(); ++p) {
+    const SurfacePolygon& poly = poly_cube.element(p);
+
+    // Vertices referenced by poly.
+    std::set<int> poly_verts;
+    for (int vi = 0; vi < poly.num_vertices(); ++vi) {
+      poly_verts.insert(poly.vertex(vi));
+    }
+
+    // Vertices referenced by pair of triangles and the triangle's normal
+    // should match the polygon's normal.
+    std::set<int> tri_verts;
+    for (int ti = 0; ti < 2; ++ti) {
+      const SurfaceTriangle& tri = tri_cube.element(t);
+      for (int vi = 0; vi < 3; ++vi) {
+        tri_verts.insert(tri.vertex(vi));
+      }
+      // Normals pointing in the same direction imply same winding.
+      EXPECT_TRUE(
+          CompareMatrices(poly_cube.face_normal(p), tri_cube.face_normal(t)));
+      ++t;
+    }
+
+    EXPECT_EQ(tri_verts, poly_verts);
+
+    /* Note: This doesn't confirm that the two triangles properly cover the
+     polygon. */
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -302,6 +302,13 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     collision_filter_.AddGeometry(id);
   }
 
+  bool NeedsConvexHull(const InternalGeometry& geometry) const {
+    // We only need convex hulls for rigid Mesh and Convex geometries.
+    return !geometry.is_deformable() &&
+           (geometry.shape().type_name() == "Mesh" ||
+            geometry.shape().type_name() == "Convex");
+  }
+
   void UpdateRepresentationForNewProperties(
       const InternalGeometry& geometry,
       const ProximityProperties& new_properties) {
@@ -1018,6 +1025,11 @@ template <typename T>
 void ProximityEngine<T>::AddDeformableGeometry(const VolumeMesh<double>& mesh,
                                                GeometryId id) {
   impl_->AddDeformableGeometry(mesh, id);
+}
+
+template <typename T>
+bool ProximityEngine<T>::NeedsConvexHull(const InternalGeometry& geo) const {
+  return impl_->NeedsConvexHull(geo);
 }
 
 template <typename T>

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -118,6 +118,9 @@ class ProximityEngine {
                   belongs. */
   void AddDeformableGeometry(const VolumeMesh<double>& mesh_W, GeometryId id);
 
+  /* Reports if the engine requires a convex hull for the given geometry. */
+  bool NeedsConvexHull(const InternalGeometry& geometry) const;
+
   /* Possibly updates the proximity representation of the given `geometry`
    based on the relationship between its _current_ proximity properties and the
    given _new_ proximity properties. The underlying representation may not

--- a/geometry/render/test/box.sdf
+++ b/geometry/render/test/box.sdf
@@ -19,13 +19,20 @@
           <izz>16.6666666</izz>
         </inertia>
       </inertial>
-      <visual name="box">
+      <visual name="visual">
         <geometry>
           <mesh>
             <uri>package://drake/geometry/render/test/meshes/box.obj</uri>
           </mesh>
         </geometry>
       </visual>
+      <collision name="collision">
+        <geometry>
+          <mesh>
+            <uri>package://drake/geometry/render/test/meshes/box.obj</uri>
+          </mesh>
+        </geometry>
+      </collision>
     </link>
     <static>1</static>
   </model>

--- a/geometry/scene_graph_inspector.cc
+++ b/geometry/scene_graph_inspector.cc
@@ -275,6 +275,12 @@ std::vector<GeometryId> SceneGraphInspector<T>::GetAllDeformableGeometryIds()
 }
 
 template <typename T>
+const PolygonSurfaceMesh<double>* SceneGraphInspector<T>::GetConvexHull(
+    GeometryId geometry_id) const {
+  return state_->GetConvexHull(geometry_id);
+}
+
+template <typename T>
 bool SceneGraphInspector<T>::CollisionFiltered(GeometryId geometry_id1,
                                                GeometryId geometry_id2) const {
   DRAKE_DEMAND(state_ != nullptr);

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -15,6 +15,7 @@
 #include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_version.h"
 #include "drake/geometry/internal_frame.h"
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/shape_specification.h"
@@ -400,6 +401,14 @@ class SceneGraphInspector {
   /** Returns all geometry ids that correspond to deformable geometries. The
    order is guaranteed to be stable and consistent.  */
   std::vector<GeometryId> GetAllDeformableGeometryIds() const;
+
+  /** Returns the convex hull associated with the given `geometry_id`, if it
+   exists.
+
+   The return value is guaranteed to be non-null if the geometry has proximity
+   properties and a convex representation in the ProximityEngine. No other
+   guarantees are provided. */
+  const PolygonSurfaceMesh<double>* GetConvexHull(GeometryId geometry_id) const;
 
   /** Reports true if the two geometries with given ids `geometry_id1` and
    `geometry_id2`, define a collision pair that has been filtered out.

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/internal_geometry.h"
 
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -8,6 +9,7 @@
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
 
 namespace drake {
 namespace geometry {
@@ -229,6 +231,25 @@ GTEST_TEST(InternalGeometryTest, Rename) {
     geometry.set_name(new_name);
   }
   EXPECT_EQ(geometry.name(), "new_name");
+}
+
+// Simple test for convex hull API: set, get, and clear.
+GTEST_TEST(InternalGeometryTest, ConvexHull) {
+  InternalGeometry geometry;
+
+  EXPECT_EQ(geometry.convex_hull(), nullptr);
+
+  geometry.set_convex_hull(std::make_unique<PolygonSurfaceMesh<double>>(
+      std::vector<int>{3, 0, 1, 2},
+      std::vector<Vector3d>{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}}));
+
+  ASSERT_NE(geometry.convex_hull(), nullptr);
+
+  EXPECT_EQ(geometry.convex_hull()->num_vertices(), 3);
+  EXPECT_EQ(geometry.convex_hull()->num_faces(), 1);
+
+  geometry.set_convex_hull(nullptr);
+  EXPECT_EQ(geometry.convex_hull(), nullptr);
 }
 
 }  // namespace

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -96,6 +96,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.GetPerceptionProperties(geometry_id);
   inspector.GetReferenceMesh(geometry_id);
   inspector.GetAllDeformableGeometryIds();
+  inspector.GetConvexHull(geometry_id);
   inspector.GetReferenceMesh(geometry_id);
   // Register an *additional* geometry and assign proximity properties to both
   // to prevent an exception being thrown.


### PR DESCRIPTION
 - GeometryState computes the convex hull (and reports it).
 - InternalGeometry stores the convex hull.
 - MeshcatVisualizer uses the convex hull when appropriate.
 - ProximityEngine reports if it would use a convex hull.
 - SceneGraphInspector reports possible convex hull.
 - New code converts from polygonal surface mesh to triangle surface mesh.
 - update box.sdf to include collision geometry.

resolves #20618

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21061)
<!-- Reviewable:end -->
