### PR TITLE
Use string::{starts,ends}_with() from C++20

### DIFF
--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -111,10 +111,6 @@ namespace {
 // A valid resource root will always contain this file.
 const char* const kSentinelRelpath = "drake/.drake-find_resource-sentinel";
 
-bool StartsWith(const string& str, const string& prefix) {
-  return str.compare(0, prefix.size(), prefix) == 0;
-}
-
 // Returns true iff the path is relative (not absolute nor empty).
 bool IsRelativePath(const string& path) {
   return !path.empty() && (path[0] != '/');
@@ -238,7 +234,7 @@ Result FindResource(const string& resource_path) {
                     resource_path));
   }
   const string prefix("drake/");
-  if (!StartsWith(resource_path, prefix)) {
+  if (!resource_path.starts_with(prefix)) {
     return Result::make_error(
         resource_path,
         fmt::format("Drake resource_path '{}' does not start with {}.",

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -45,15 +45,6 @@ using tinyxml2::XMLNode;
 
 namespace {
 
-// TODO(rpoyner-tri): replace with std::string_view::ends_with once c++20
-// features are available.
-bool EndsWith(std::string_view value, std::string_view ending) {
-  if (ending.size() > value.size()) {
-    return false;
-  }
-  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
-}
-
 // Any attributes from `default` that are not specified in `node` will be added
 // to `node`.
 void ApplyDefaultAttributes(const XMLElement& default_node, XMLElement* node) {
@@ -1295,7 +1286,7 @@ class MujocoParser {
         // geometry name to model_instance_name::geometry_name (in
         // MultibodyPlant::GetScopedName). Cope with that change here.
         const std::string candidate_name = inspector.GetName(id);
-        if (EndsWith(candidate_name, name)) {
+        if (candidate_name.ends_with(name)) {
           return id;
         }
       }

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -146,12 +146,6 @@ std::pair<ModelInstanceIndex, std::string> GetResolvedModelInstanceAndLocalName(
 
   return {resolved_model_instance, unscoped_local_name};
 }
-// Returns true if `str` starts with `prefix`. The length of `prefix` has to be
-// strictly less than the size of `str`.
-bool StartsWith(const std::string_view str, const std::string_view prefix) {
-  return prefix.size() < str.size() &&
-         std::equal(str.begin(), str.begin() + prefix.size(), prefix.begin());
-}
 
 // Calculates the scoped name of a body relative to the model instance @p
 // relative_to_model_instance. If the body is a direct child of the model,
@@ -183,7 +177,7 @@ std::string GetRelativeBodyName(
     // descendent of the model relative to which we are computing the name.
     const std::string required_prefix =
         relative_to_model_absolute_name + std::string(sdf::kScopeDelimiter);
-    DRAKE_DEMAND(StartsWith(nested_model_absolute_name, required_prefix));
+    DRAKE_DEMAND(nested_model_absolute_name.starts_with(required_prefix));
 
     const std::string nested_model_relative_name =
         nested_model_absolute_name.substr(required_prefix.size());


### PR DESCRIPTION
Remove/replace some home-made implementations in favor new library methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21062)
<!-- Reviewable:end -->
