### PR TITLE
[geometry] Give HydroelasticType a kCompliant alias

### DIFF
--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -9,6 +9,7 @@
 
 #include <optional>
 #include <ostream>
+#include <string>
 
 #include "drake/common/fmt_ostream.h"
 #include "drake/geometry/geometry_roles.h"
@@ -79,12 +80,20 @@ extern const char* const kSlabThickness;   ///< Slab thickness property name
 //  consider the stiff object as effectively rigid and simplify the computation.
 //  In this case, the object would get two representations.
 /* Classification of the type of representation a shape has for the
- hydroelastic contact model: rigid or soft.  */
+ hydroelastic contact model: rigid or compliant.  */
 enum class HydroelasticType {
   kUndefined,
   kRigid,
-  kSoft
+  kCompliant,
+
+  // Legacy alias. TODO(#17147) Remove this alias.
+  kSoft = kCompliant,
 };
+
+/* Conversion functions between hydroelastic type and string. */
+HydroelasticType GetHydroelasticTypeFromString(
+    std::string_view hydroelastic_type);
+std::string GetStringFromHydroelasticType(HydroelasticType hydroelastic_type);
 
 /* Streaming operator for writing hydroelastic type to output stream.  */
 std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity_properties.h"
 
+#include <sstream>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -170,6 +172,25 @@ GTEST_TEST(ProximityPropertiesTest, AddHalfSpaceSoftProperties) {
                                  AddCompliantHydroelasticPropertiesForHalfSpace(
                                      1., modulus, p);
                                });
+}
+
+GTEST_TEST(ProximityPropertiesTest, HydroelasticTypeTest) {
+  std::vector<std::pair<const char*, HydroelasticType>> known_values{
+      std::pair("undefined", HydroelasticType::kUndefined),
+      std::pair("rigid", HydroelasticType::kRigid),
+      std::pair("compliant", HydroelasticType::kSoft),
+  };
+
+  for (const auto& [name, value] : known_values) {
+    EXPECT_EQ(internal::GetHydroelasticTypeFromString(name), value);
+    EXPECT_EQ(internal::GetStringFromHydroelasticType(value), name);
+    std::stringstream ss;
+    ss << value;
+    EXPECT_EQ(ss.str(), name);
+  }
+
+  DRAKE_EXPECT_THROWS_MESSAGE(internal::GetHydroelasticTypeFromString("foobar"),
+                              ".*Unknown.*foobar.*");
 }
 
 }  // namespace


### PR DESCRIPTION
kSoft was probably uncontroversial when it was chosen, but no longer aligns with our public API and documentation language. Introduce an alias kCompliant, and add enum<=>string conversions that use the "compliant" language.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21065)
<!-- Reviewable:end -->
