### PR TITLE
Revert "[tools] Add empty file to allow CI wheel builds on Focal"

### DIFF
--- a/doc/_pages/buildcop.md
+++ b/doc/_pages/buildcop.md
@@ -172,7 +172,7 @@ Check once per week that caching is still enabled, there are currently two cache
 servers that need to be confirmed.  Open each of the following jobs and search
 for ``REMOTE_CACHE_KEY`` and confirm it has a value:
 
-- [https://drake-jenkins.csail.mit.edu/job/linux-focal-clang-bazel-continuous-release/lastBuild/consoleFull](https://drake-jenkins.csail.mit.edu/job/linux-focal-clang-bazel-continuous-release/lastBuild/consoleFull)
+- [https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-continuous-release/lastBuild/consoleFull](https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-continuous-release/lastBuild/consoleFull)
 - [https://drake-jenkins.csail.mit.edu/job/mac-arm-ventura-clang-bazel-continuous-release/lastBuild/consoleFull](https://drake-jenkins.csail.mit.edu/job/mac-arm-ventura-clang-bazel-continuous-release/lastBuild/consoleFull)
 
 Message indicating a problem:

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -151,7 +151,7 @@ build (click on "Console Output" then "Full Log") and search for the text
 To schedule an "experimental" build of a [wheel package](/pip.html),
 comment on an open pull request using one or more of these commands:
 
-* ``@drake-jenkins-bot linux-focal-unprovisioned-gcc-wheel-experimental-release please``
+* ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-wheel-experimental-release please``
 * ``@drake-jenkins-bot mac-arm-ventura-unprovisioned-clang-wheel-experimental-release please``
 * ``@drake-jenkins-bot mac-x86-monterey-unprovisioned-clang-wheel-experimental-release please``
 

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -127,7 +127,7 @@ the main body of the document:
 2. Launch the staging builds for that git commit sha:
    1. Open the following seven Jenkins jobs (e.g., each in its own
       new browser tab):
-      - [Linux Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-focal-unprovisioned-gcc-wheel-staging-release/)
+      - [Linux Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-wheel-staging-release/)
       - [macOS x86 Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-x86-monterey-unprovisioned-clang-wheel-staging-release/)
       - [macOS arm Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-ventura-unprovisioned-clang-wheel-staging-release/)
       - [Jammy Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-bazel-staging-packaging/)

--- a/tools/ubuntu-focal.bazelrc
+++ b/tools/ubuntu-focal.bazelrc
@@ -1,2 +1,0 @@
-# Placeholder to support Focal Wheel builds
-# TODO (betsymcphail) Remove this file when wheel builds move to Jammy


### PR DESCRIPTION
Reverts RobotLocomotion/drake#21020

Closes #21007

Wheels are building on Jammy, the Focal workaround can be removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21069)
<!-- Reviewable:end -->
