### PR TITLE
[workspace] Remove vestigial jupyter package

### DIFF
--- a/setup/mac/source_distribution/requirements-test-only.txt
+++ b/setup/mac/source_distribution/requirements-test-only.txt
@@ -1,5 +1,4 @@
 flask
-jupyter
 six
 u-msgpack-python
 websockets

--- a/tools/jupyter/test/jupyter_notebook_test.py
+++ b/tools/jupyter/test/jupyter_notebook_test.py
@@ -1,9 +1,11 @@
 import subprocess
+import sys
 import unittest
 
 
 class TestJupyterNotebook(unittest.TestCase):
     def test_help(self):
         """Ensures that `jupyter notebook` is installed (#12042)."""
-        status = subprocess.call(args=["jupyter", "notebook", "--help"])
+        status = subprocess.call(
+            args=[sys.executable, "-m", "notebook", "--help"])
         self.assertEqual(status, 0)


### PR DESCRIPTION
- https://jupyter.org/install#jupyter-notebook
- https://pypi.org/project/jupyter/ (very old...)
- https://pypi.org/project/notebook/ (what we want...)

Note that `notebook` is already installed via binary_distribution/requirements.txt.

Via https://github.com/RobotLocomotion/drake/pull/21013#pullrequestreview-1912144495

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21085)
<!-- Reviewable:end -->
