### PR TITLE
CMake builds: Treat SyntaxWarning as a warning not an error

### DIFF
--- a/CTestCustom.cmake.in
+++ b/CTestCustom.cmake.in
@@ -19,6 +19,7 @@ string(ASCII 27 ESC)
 list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
   "^DEBUG: "
   ": DrakeDeprecationWarning: "
+  ": SyntaxWarning: invalid escape sequence "
   "^WARNING: "
   ": warning: "
   ":[0-9]+: Failure$"


### PR DESCRIPTION
Fixes failing CI jobs:

- https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-arm-sonoma-clang-cmake-nightly-everything-release/85/
- https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-arm-sonoma-clang-cmake-nightly-release/86/
- https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-arm-ventura-clang-cmake-nightly-everything-release/292/
- https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-arm-ventura-clang-cmake-nightly-release/294/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21102)
<!-- Reviewable:end -->
