### PR TITLE
[workspace] Patch rules_rust for Bazel 7 compatibility

### DIFF
--- a/tools/workspace/rules_rust/patches/import_cycle.patch
+++ b/tools/workspace/rules_rust/patches/import_cycle.patch
@@ -1,0 +1,19 @@
+[rules_rust] Break a circular dependency
+
+https://github.com/bazelbuild/rules_rust/issues/2383 claims that this
+is already fixed, but clearly it is not.
+
+--- util/import/BUILD.bazel
++++ util/import/BUILD.bazel
+@@ -20,10 +20,7 @@
+ 
+ alias(
+     name = "import",
+-    actual = select({
+-        ":use_fake_import_macro": ":fake_import_macro_impl",
+-        "//conditions:default": ":import_macro_label",
+-    }),
++    actual = ":fake_import_macro_impl",
+     visibility = ["//visibility:public"],
+ )
+ 

--- a/tools/workspace/rules_rust/repository.bzl
+++ b/tools/workspace/rules_rust/repository.bzl
@@ -13,6 +13,8 @@ def rules_rust_repository(
         repository = "bazelbuild/rules_rust",  # License: Apache-2.0
         commit = "0.40.0",
         sha256 = "1e6e8ea8675bd8e19ecca7996dca75c40b3e75a9ca208cfd12c1ca9a3554a6d8",  # noqa
-        patches = extra_patches,
+        patches = [
+            ":patches/import_cycle.patch",
+        ] + (extra_patches or []),
         mirrors = mirrors,
     )


### PR DESCRIPTION
The full extent of https://github.com/bazelbuild/rules_rust/issues/2383 is not actually fixed, so we need to work around it here.

Towards #21103 and #21054.

The manual testing recipe here is `bazel test //... --config=lint` on Ubuntu when using Bazel 7.0.  On master, it barfs an error about a BUILD file cycle[1]; with this PR, it passes.

One good way to try that is to use `bazelisk.py test //... --config=lint` via [bazelisk.py](https://github.com/bazelbuild/bazelisk/blob/master/bazelisk.py) to use a temporary bazel version, by changing the `.bazeliskrc` to point to 7.0.2 like we have in #21003.

The intent behind landing this patch now (ahead of Drake's full Bazel 7 transition), is to make it easier to test out Bazel 7 in downstream CI, and to make any commit-revert war over #21103 as minimal as possible.  The unprovisioned job in #21103 has evidence that Bazel 7 will be happy in CI.

---

[1]

```
ERROR: .../external/rules_rust/util/import/BUILD.bazel:21:6:
  in alias rule @@rules_rust//util/import:import: cycle in dependency graph:
    //lcmtypes:py/install_lint
...
    @@clarabel_cpp_internal//:clarabel_cpp
...
    @@crate__autocfg-1.1.0//:autocfg
.-> @@rules_rust//util/import:import
|   @@rules_rust//util/import:import_macro_label
|   @@rules_rust//util/import:import_macro
|   @@rules_rust//util/import:import_macro_impl
`-- @@rules_rust//util/import:import
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21104)
<!-- Reviewable:end -->
