### PR TITLE
[workspace] Patch gflags for Bazel 7 compatibility

### DIFF
--- a/tools/workspace/gflags/patches/bazel7.patch
+++ b/tools/workspace/gflags/patches/bazel7.patch
@@ -1,0 +1,52 @@
+[gflags] Adjust cc_library to use includes= (vs include_prefix=)
+
+In certain cases, this seems to make Bazel 7.0 happier. It doesn't
+show up in Drake CI, but does in Anzu CI.
+
+We should upstream this patch.
+
+--- bazel/gflags.bzl
++++ bazel/gflags.bzl
+@@ -4,7 +4,7 @@
+     native.genrule(
+         name = "gflags_declare_h",
+         srcs = ["src/gflags_declare.h.in"],
+-        outs = ["gflags_declare.h"],
++        outs = ["gen/gflags/gflags_declare.h"],
+         cmd  = ("awk '{ " +
+                 "gsub(/@GFLAGS_NAMESPACE@/, \"" + namespace[0] + "\"); " +
+                 "gsub(/@(HAVE_STDINT_H|HAVE_SYS_TYPES_H|HAVE_INTTYPES_H|GFLAGS_INTTYPES_FORMAT_C99)@/, \"1\"); " +
+@@ -17,7 +17,7 @@
+         native.genrule(
+             name = gflags_ns_h_file.replace('.', '_'),
+             srcs = ["src/gflags_ns.h.in"],
+-            outs = [gflags_ns_h_file],
++            outs = ["gen/gflags/" + gflags_ns_h_file],
+             cmd  = ("awk '{ " +
+                     "gsub(/@ns@/, \"" + ns + "\"); " +
+                     "gsub(/@NS@/, \"" + ns.upper() + "\"); " +
+@@ -27,7 +27,7 @@
+     native.genrule(
+         name = "gflags_h",
+         srcs = ["src/gflags.h.in"],
+-        outs = ["gflags.h"],
++        outs = ["gen/gflags/gflags.h"],
+         cmd  = ("awk '{ " +
+                 "gsub(/@GFLAGS_ATTRIBUTE_UNUSED@/, \"\"); " +
+                 "gsub(/@INCLUDE_GFLAGS_NS_H@/, \"" + '\n'.join(["#include \\\"gflags/{}\\\"".format(hdr) for hdr in gflags_ns_h_files]) + "\"); " +
+@@ -36,7 +36,7 @@
+     native.genrule(
+         name = "gflags_completions_h",
+         srcs = ["src/gflags_completions.h.in"],
+-        outs = ["gflags_completions.h"],
++        outs = ["gen/gflags/gflags_completions.h"],
+         cmd  = "awk '{ gsub(/@GFLAGS_NAMESPACE@/, \"" + namespace[0] + "\"); print; }' $(<) > $(@)"
+     )
+     hdrs = [":gflags_h", ":gflags_declare_h", ":gflags_completions_h"]
+@@ -99,5 +99,5 @@
+         copts      = copts,
+         linkopts   = linkopts,
+         visibility = ["//visibility:public"],
+-        include_prefix = 'gflags'
++        includes = ["gen"],
+     )

--- a/tools/workspace/gflags/repository.bzl
+++ b/tools/workspace/gflags/repository.bzl
@@ -8,5 +8,8 @@ def gflags_repository(
         repository = "gflags/gflags",
         commit = "v2.2.2",
         sha256 = "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf",  # noqa
+        patches = [
+            ":patches/bazel7.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
Towards #21054.

FYI https://bazel.build/reference/be/c-cpp#cc_library.include_prefix

It is not entirely clear to me why `include_prefix` is causing trouble here.  With Bazel 7 and some mix of bzlmod and workspaces, sometimes it seems like "which package am I?" just gets bent out of shape.  In any case, a very straightfoward spelling of "generate files using the names you want to be known by" seems to make everything happy again.

I'll also xref https://github.com/gflags/gflags/issues/339 here -- when we upstream this, I think it would resolve that issue, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21106)
<!-- Reviewable:end -->
