### PR TITLE
[tools] Bump minimum supported versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,8 +101,8 @@ endif()
 # The minimum compiler versions should match those listed in both
 # doc/_pages/from_source.md and tools/workspace/cc/repository.bzl.
 set(MINIMUM_APPLE_CLANG_VERSION 14)
-set(MINIMUM_CLANG_VERSION 12)
-set(MINIMUM_GNU_VERSION 9.3)
+set(MINIMUM_CLANG_VERSION 14)
+set(MINIMUM_GNU_VERSION 11)
 
 if(CMAKE_C_COMPILER_ID STREQUAL AppleClang)
   if(CMAKE_C_COMPILER_VERSION VERSION_LESS ${MINIMUM_APPLE_CLANG_VERSION})

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 # This needs to be in WORKSPACE or a repository rule for native.bazel_version
 # to actually be defined. The minimum_bazel_version value should match the
 # version passed to the find_package(Bazel) call in the root CMakeLists.txt.
-versions.check(minimum_bazel_version = "5.1")
+versions.check(minimum_bazel_version = "6.0")
 
 # The cargo_universe programs are only used by Drake's new_release tooling, not
 # by any compilation rules. As such, we can put it directly into the WORKSPACE

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -14,7 +14,7 @@ officially supports:
 
 | Operating System ⁽¹⁾               | Architecture | Python ⁽²⁾ | Bazel | CMake | C/C++ Compiler ⁽³⁾           | Java                          |
 |------------------------------------|--------------|------------|-------|-------|------------------------------|-------------------------------|
-| Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 6.4   | 3.22  | GCC 11 (default) or Clang 12 | OpenJDK 11                    |
+| Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 6.4   | 3.22  | GCC 11 (default) or Clang 14 | OpenJDK 11                    |
 | macOS Monterey (12)                | x86_64       | 3.12       | 6.4   | 3.25  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
 | macOS Ventura (13)                 | arm64        | 3.12       | 6.4   | 3.26  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
 | macOS Sonoma (14)                  | arm64        | 3.12       | 6.4   | 3.28  | Apple LLVM 15 (Xcode 15)     | AdoptOpenJDK 16 (HotSpot JVM) |

--- a/tools/ubuntu-jammy.bazelrc
+++ b/tools/ubuntu-jammy.bazelrc
@@ -1,4 +1,5 @@
 # Options for explicitly using Clang.
+# Keep this in sync with doc/_pages/from_source.md.
 common:clang --repo_env=CC=clang-14
 common:clang --repo_env=CXX=clang++-14
 build:clang --action_env=CC=clang-14

--- a/tools/ubuntu-noble.bazelrc
+++ b/tools/ubuntu-noble.bazelrc
@@ -1,4 +1,5 @@
 # Options for explicitly using Clang.
+# Keep this in sync with doc/_pages/from_source.md.
 common:clang --repo_env=CC=clang-14
 common:clang --repo_env=CXX=clang++-14
 build:clang --action_env=CC=clang-14


### PR DESCRIPTION
GCC >= 11 (now that Focal is gone).
Clang >= 14 (now that Focal is gone).
Bazel >= 6.0 (amends cdeb0c61, which broke bazel < 6).

Remove some legacy cc_toolchain code for earlier bazel versions, that no longer works on Bazel >= 7 on macOS.

Towards #21103 and #21054.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21107)
<!-- Reviewable:end -->
