### PR TITLE
[workspace] Adjust apple_support for Bazel 7 compatibility

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,10 @@ load("//tools/workspace:default.bzl", "add_default_workspace")
 
 add_default_workspace()
 
+load("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure")
+
+apple_cc_configure()
+
 # Add some special heuristic logic for using CLion with Drake.
 load("//tools/clion:repository.bzl", "drake_clion_environment")
 

--- a/cmake/WORKSPACE.in
+++ b/cmake/WORKSPACE.in
@@ -22,3 +22,7 @@ _BAZEL_WORKSPACE_EXCLUDES = split_cmake_list("@BAZEL_WORKSPACE_EXCLUDES@")
 add_default_workspace(
     repository_excludes = ["python"] + _BAZEL_WORKSPACE_EXCLUDES,
 )
+
+load("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure")
+
+apple_cc_configure()

--- a/tools/cc_toolchain/BUILD.bazel
+++ b/tools/cc_toolchain/BUILD.bazel
@@ -26,7 +26,10 @@ config_setting(
 filegroup(
     name = "toolchain_deps",
     data = select({
-        ":apple": ["@local_config_cc//:cc_wrapper"],
+        ":apple": [
+            "@local_config_apple_cc//:cc_wrapper",
+            "@local_config_cc//:cc_wrapper",
+        ],
         "//conditions:default": [],
     }),
     visibility = ["//common:__pkg__"],


### PR DESCRIPTION
For macOS users building from source, Bazel 7 now requires a snippet to be added directly to `WORKSPACE` (not our `default.bzl`), or to the `MODULE.bazel`. Downstream projects using `drake_bazel_external` on macOS will need to mimic this same change (or similar), per instructions at https://github.com/bazelbuild/apple_support#toolchain-setup.

This is required in order to compile our Objective-C dependencies.

Towards #21103 and #21054.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21110)
<!-- Reviewable:end -->
