### PR TITLE
[tools] Fix github.bzl for extracting attachments without a prefix

### DIFF
--- a/tools/workspace/github.bzl
+++ b/tools/workspace/github.bzl
@@ -533,11 +533,18 @@ def setup_github_release_attachments(repository_ctx):
             for pattern in patterns
         ]
         if filename in extract:
-            repository_ctx.download_and_extract(
-                urls,
-                stripPrefix = strip_prefix.get(filename, None),
-                sha256 = _sha256(sha256),
-            )
+            maybe_strip_prefix = strip_prefix.get(filename, None)
+            if maybe_strip_prefix != None:
+                repository_ctx.download_and_extract(
+                    urls,
+                    stripPrefix = maybe_strip_prefix,
+                    sha256 = _sha256(sha256),
+                )
+            else:
+                repository_ctx.download_and_extract(
+                    urls,
+                    sha256 = _sha256(sha256),
+                )
         else:
             repository_ctx.download(
                 urls,


### PR DESCRIPTION
Unlike most other functions in Bazel, we can't pass `None` to `stripPrefix` to select the default behavior (of no stripping). We actually need to omit the kwarg name entirely. Adjust `github_release_attachments()` logic to hide this irregularity, to allow for extracting attachments that don't need any prefix stripped away.

Towards #20935.

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21111)
<!-- Reviewable:end -->
