### PR TITLE
Revert "[workspace] Adjust apple_support for Bazel 7 compatibility"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,10 +7,6 @@ load("//tools/workspace:default.bzl", "add_default_workspace")
 
 add_default_workspace()
 
-load("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure")
-
-apple_cc_configure()
-
 # Add some special heuristic logic for using CLion with Drake.
 load("//tools/clion:repository.bzl", "drake_clion_environment")
 

--- a/cmake/WORKSPACE.in
+++ b/cmake/WORKSPACE.in
@@ -22,7 +22,3 @@ _BAZEL_WORKSPACE_EXCLUDES = split_cmake_list("@BAZEL_WORKSPACE_EXCLUDES@")
 add_default_workspace(
     repository_excludes = ["python"] + _BAZEL_WORKSPACE_EXCLUDES,
 )
-
-load("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure")
-
-apple_cc_configure()

--- a/tools/cc_toolchain/BUILD.bazel
+++ b/tools/cc_toolchain/BUILD.bazel
@@ -26,10 +26,7 @@ config_setting(
 filegroup(
     name = "toolchain_deps",
     data = select({
-        ":apple": [
-            "@local_config_apple_cc//:cc_wrapper",
-            "@local_config_cc//:cc_wrapper",
-        ],
+        ":apple": ["@local_config_cc//:cc_wrapper"],
         "//conditions:default": [],
     }),
     visibility = ["//common:__pkg__"],


### PR DESCRIPTION
Dear @jwnimmer-tri,

 The on-call build cop, @BetsyMcPhail, believes that your PR #21110 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/job/linux-jammy-unprovisioned-gcc-bazel-continuous-mirror-to-s3/457/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21114)
<!-- Reviewable:end -->
