### PR TITLE
Revert "[workspace] Build OpenUSD in macOS CI"

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -151,7 +151,7 @@ config_setting(
 # We are exploring adding USD support to Drake. For the moment, it is opt-in.
 # See https://github.com/PixarAnimationStudios/OpenUSD for details.
 # Use `--define=WITH_USD=ON` on the bazel command line to enable it.
-# (In CI, --config=everything also enables it.)
+# (In CI, --config=everything also enables it on Ubuntu.)
 config_setting(
     name = "with_usd",
     values = {"define": "WITH_USD=ON"},

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -85,6 +85,3 @@ build:everything --define=WITH_MOSEK=ON
 build:snopt --define=WITH_SNOPT=ON
 build:packaging --define=WITH_SNOPT=ON
 build:everything --define=WITH_SNOPT=ON
-
-# In CI (but only in CI), we want to test the opt-in USD build support.
-build:everything --define=WITH_USD=ON

--- a/tools/ubuntu-jammy.bazelrc
+++ b/tools/ubuntu-jammy.bazelrc
@@ -6,3 +6,7 @@ build:clang --action_env=CC=clang-14
 build:clang --action_env=CXX=clang++-14
 build:clang --host_action_env=CC=clang-14
 build:clang --host_action_env=CXX=clang++-14
+
+# In CI (but only in CI), we want to test the opt-in USD build support.
+# TODO(jwnimmer-tri) We should try to enable USD by default on all platforms.
+build:everything --define=WITH_USD=ON

--- a/tools/ubuntu-noble.bazelrc
+++ b/tools/ubuntu-noble.bazelrc
@@ -6,3 +6,7 @@ build:clang --action_env=CC=clang-14
 build:clang --action_env=CXX=clang++-14
 build:clang --host_action_env=CC=clang-14
 build:clang --host_action_env=CXX=clang++-14
+
+# In CI (but only in CI), we want to test the opt-in USD build support.
+# TODO(jwnimmer-tri) We should try to enable USD by default on all platforms.
+build:everything --define=WITH_USD=ON


### PR DESCRIPTION
Reverts 35ca15439c6d63a3c60310df391ea2f34d00145f.

Something here is incompatible with Bazel 7.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21118)
<!-- Reviewable:end -->
