### PR TITLE
[multibody] SpanningForest structure and documentation

### DIFF
--- a/multibody/topology/BUILD.bazel
+++ b/multibody/topology/BUILD.bazel
@@ -37,6 +37,7 @@ drake_cc_library(
     srcs = [
         "link_joint_graph.cc",
         "spanning_forest.cc",
+        "spanning_forest_mobod.cc",
     ],
     hdrs = [
         "forest.h",
@@ -48,9 +49,14 @@ drake_cc_library(
         "link_joint_graph_link.h",
         "link_joint_graph_loop_constraint.h",
         "spanning_forest.h",
+        "spanning_forest_inlines.h",
+        "spanning_forest_loop_constraint.h",
+        "spanning_forest_mobod.h",
+        "spanning_forest_tree.h",
     ],
     deps = [
         "//common:copyable_unique_ptr",
+        "//common:unused",
         "//multibody/tree:multibody_tree_indexes",
     ],
 )

--- a/multibody/topology/forest.h
+++ b/multibody/topology/forest.h
@@ -12,7 +12,10 @@ reasonable. */
 // Don't alpha-sort these internal includes; the order matters.
 // clang-format off
 #include "drake/multibody/topology/spanning_forest.h"
-// TODO(sherm1) More to come.
+#include "drake/multibody/topology/spanning_forest_mobod.h"
+#include "drake/multibody/topology/spanning_forest_tree.h"
+#include "drake/multibody/topology/spanning_forest_loop_constraint.h"
+#include "drake/multibody/topology/spanning_forest_inlines.h"
 // clang-format on
 
 #undef DRAKE_MULTIBODY_TOPOLOGY_FOREST_INCLUDED

--- a/multibody/topology/link_joint_graph.h
+++ b/multibody/topology/link_joint_graph.h
@@ -350,18 +350,18 @@ class LinkJointGraph {
   MobodIndex link_to_mobod(BodyIndex index) const;  // See below
 
   /** After the SpanningForest has been built, returns groups of Links that are
-  welded together, which we call "Link Composites". Each group may be modeled
+  welded together, which we call "LinkComposites". Each group may be modeled
   in the Forest with a single mobilized body or multiple mobilized bodies
   depending on modeling options, but that doesn't change anything here. The
-  first entry in each Link Composite is the "active link", the one whose
-  (non-weld) Joint moves the whole Link Composite due to its modeling in the
+  first entry in each LinkComposite is the "active link", the one whose
+  (non-weld) Joint moves the whole LinkComposite due to its modeling in the
   Spanning Forest. The rest of the Links in the composite are listed in no
   particular order.
 
-  The 0th Link Composite is always present and its first entry is World
+  The 0th LinkComposite is always present and its first entry is World
   (Link 0), even if nothing else is welded to World. Otherwise, composites
   are present here if they contain two or more welded Links; Links that aren't
-  welded to any other Links are not included here at all. Link Composites
+  welded to any other Links are not included here at all. LinkComposites
   are discovered as a side effect of Forest-building; there is no cost to
   accessing them here. */
   const std::vector<std::vector<BodyIndex>>& link_composites() const {
@@ -428,7 +428,7 @@ class LinkJointGraph {
                                   JointIndex primary_joint_index);
 
   // The World Link must already be in the graph but there are no Link
-  // Composites yet. This creates the 0th Link Composite and puts World in it.
+  // Composites yet. This creates the 0th LinkComposite and puts World in it.
   void CreateWorldLinkComposite();
 
   LoopConstraintIndex AddLoopClosingWeldConstraint(BodyIndex primary_link_index,

--- a/multibody/topology/link_joint_graph_joint.h
+++ b/multibody/topology/link_joint_graph_joint.h
@@ -110,8 +110,6 @@ class LinkJointGraph::Joint {
       how_modeled_ = old_to_new[std::get<MobodIndex>(how_modeled_)];
   }
 
-  struct IgnoredLoopJoint {};
-
   JointIndex index_;
   std::string name_;
   ModelInstanceIndex model_instance_;
@@ -130,10 +128,7 @@ class LinkJointGraph::Joint {
   // - LinkCompositeIndex: not modeled because this is a weld interior to
   //     the indicated composite and we are combining so that one Mobod serves
   //     the whole composite.
-  // - IgnoredLoopJoint: not modeled because we intentionally ignored the Joint
-  //     (used with the IgnoreLoopJoints modeling option)
-  std::variant<std::monostate, MobodIndex, LinkCompositeIndex, IgnoredLoopJoint>
-      how_modeled_;
+  std::variant<std::monostate, MobodIndex, LinkCompositeIndex> how_modeled_;
 };
 
 }  // namespace internal

--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -2,7 +2,10 @@
 #include <queue>
 #include <stack>
 #include <utility>
+#include <vector>
 
+#include "drake/common/drake_assert.h"
+#include "drake/common/unused.h"
 #include "drake/multibody/topology/forest.h"
 
 namespace drake {
@@ -36,7 +39,8 @@ SpanningForest& SpanningForest::operator=(SpanningForest&& source) {
 }
 
 void SpanningForest::FixInternalPointers() {
-  // TODO(sherm1) Nothing yet, see #20225.
+  // Only Tree currently has a back pointer.
+  for (auto& tree : data_.trees) tree.forest_ = this;
 }
 
 // Clear() leaves this with nothing, not even a Mobod for World.
@@ -47,18 +51,211 @@ void SpanningForest::Clear() {
   data_.graph = saved_graph;
 }
 
-// This is the algorithm that takes an arbitrary link-joint graph and models
-// it as a spanning forest of mobilized bodies plus loop-closing constraints.
-// TODO(sherm1) Just a stub for now.
+// TODO(sherm1) The following describes the full algorithm but the code
+//  currently just has stubs. See PR #20225 for the implementation.
+
+/* This is the algorithm that takes an arbitrary link-joint graph and models
+it as a spanning forest of mobilized bodies plus loop-closing constraints.
+
+@note An assumption that affects some implementation choices: in a large system,
+most links will be either (1) welded to World or to each other to create complex
+objects, or (2) free bodies representing manipulands. The number of articulated
+links representing a robot or robots will be modest in comparison. Hence we
+want to handle welded and free links efficiently.
+
+The algorithm has three phases:
+  1 Produce the best tree structures we can. For example, when breaking
+    loops we want to minimize the maximum branch length for better numerics,
+    but we can't allow massless terminal bodies unless they are welded to
+    a massful body. Welded-together Links form a LinkComposite which can
+    (optionally) be modeled using a single mobilized body.
+  2 Reorder the forest nodes (mobilized bodies) depth first for optimal
+    computation. Each tree will consist only of consecutively-numbered nodes.
+  3 Assign joint coordinates q and velocities v sequentially according
+    to the depth-first ordering.
+
+  During execution of this algorithm, we opportunistically collect information
+  that can be used for fast queries at run time, both for the graph and the
+  forest. For example: Which Links are welded together (LinkComposites)?
+  Which Mobods are welded together (WeldedMobod groups)? Which of
+  those are anchored to World? Which Tree does a given Mobod belong to? How
+  many coordinates are inboard or outboard of a Mobod?
+
+ForestBuildingOptions (global or per-model instance) determine
+  - whether we produce a mobilized body for _each_ Link or just for each
+    _group_ of welded-together Links (a LinkComposite), and
+  - what kind of Joint we use to mobilize unconnected root Links: 0 dof fixed,
+    6 dof roll-pitch-yaw floating, or 6 dof quaternion floating.
+
+Here is an expansion of the above three phases:
+
+1. Construct a forest with good topology
+   - Add the World mobilized body to the forest at level 0.
+   - Add missing Joints to World if needed for (a) Static Links,
+     and (b) Links marked "MustBeBaseBody". (Links can be static due
+     to individual LinkFlags or membership in a static model instance.)
+   - ExtendTrees(all existing base bodies)   (see algorithm below)
+   - While there are unprocessed _jointed_ (articulated) Links
+       - Choose an unprocessed Link L and model it with a new Mobod B that is
+         to be the root node (base body) of a new tree. L is chosen by picking
+         the "best" base Link according to some policy.
+         (Heuristic: pick one that never appears as a child of a Joint.)
+       - ExtendTrees(B)  (just this one tree; see algorithm below)
+   - While there are unprocessed _unjointed_ Links (single bodies)
+       - Each of these can be the base body of a new one-Mobod tree
+       - If a Link is in a "use fixed base" model instance, weld it to World.
+         If we're combining welded links it just joins the World LinkComposite
+         and does not form a new Tree.
+       - Otherwise add a floating Joint to World (rpy or quaternion depending
+         on options) and start a new Tree.
+       - Note that any unjointed _static_ Link, or a Link in a static model
+         instance, had a weld joint added in the second step above so was
+         processed in the first call to ExtendTrees().
+
+   Algorithm ExtendTrees(tree_base_bodies):
+       - Extend each tree one level at a time.
+       - Process all level 1 (base) Links directly jointed to World.
+       - Then process all level 2 Links jointed to level 1 Links, etc.
+       - Composites are (optionally) modeled with a single Mobod (one level).
+       - If we encounter a Link that has already been processed there is a
+         loop. Split the Link onto primary and shadow Mobods and add a loop
+         constraint to weld them back together.
+
+2. Reorder depth first
+   - Determine the depth first re-ordering of the mobilized bodies.
+   - Use that reordering to update the SpanningForest in place.
+
+3. Assign coordinates q and velocities v
+   - Each tree gets a consecutive set of q's and a consecutive set of v's,
+     doled out following the depth-first ordering of the trees.
+   - Build maps from q and v to corresponding Mobod (includes fast q,v->Tree
+     also).
+*/
 void SpanningForest::BuildForest() {
   Clear();  // In case we're reusing this forest.
 
-  // Model the World (Link 0) with mobilized body 0. This also starts the
-  // 0th Link Composite in the graph.
-  // TODO(sherm1) No Mobods here yet.
+  // Model the World (Link 0) with mobilized body 0. This also starts the 0th
+  // LinkComposite in the graph and the 0th Welded Mobods group in the Forest.
+  data_.mobods.emplace_back(MobodIndex(0), BodyIndex(0));
+  data_.welded_mobods.emplace_back(std::vector{MobodIndex(0)});
+  data_.mobods[MobodIndex(0)].welded_mobods_index_ = WeldedMobodsIndex(0);
   data_.graph->set_primary_mobod_for_link(BodyIndex(0), MobodIndex(0),
                                           JointIndex{});
   data_.graph->CreateWorldLinkComposite();
+
+  data_.forest_height = 1;  // Just World so far.
+
+  // Decide on forward/reverse mobilizers; combine composite links onto a single
+  // Mobod; choose links to serve as base (root) bodies and add 6dof mobilizers
+  // for them; split loops; add shadow bodies and weld constraints.
+  ChooseForestTopology();
+
+  // Determine the desired depth-first ordering and apply it.
+  const std::vector<MobodIndex> old_to_new = CreateDepthFirstReordering();
+  FixupForestToUseNewNumbering(old_to_new);
+
+  // Dole out the q's and v's, depth-first.
+  AssignCoordinates();
+}
+
+void SpanningForest::ChooseForestTopology() {
+  // Stub; see #20225.
+
+  // Fill in World info that will be calculated in the implementation.
+  Mobod& world = data_.mobods[MobodIndex(0)];
+  world.nq_outboard_ = 0;  // Nothing other than World.
+  world.nv_outboard_ = 0;
+  // World isn't part of a tree but gets counted here.
+  world.num_subtree_mobods_ = 1;
+}
+
+/* Given the forest of mobilized bodies numbered in some arbitrary
+order, reorder them depth-first. (The arbitrary numbering was produced by the
+construction algorithm which may, for example, prefer to balance chain
+lengths when breaking loops.) Considering the result as a forest of trees
+rooted at their base bodies, the new numbering has the property that all mobods
+in tree i have lower indexes than any mobod in tree i+1. And within a tree,
+all mobods in the leftmost branch have lower numbers than any mobod in the
+next branch. */
+std::vector<MobodIndex> SpanningForest::CreateDepthFirstReordering() const {
+  DRAKE_DEMAND(ssize(mobods()) == 1);  // Just World in this stub.
+  const std::vector<MobodIndex> old_to_new{MobodIndex(0)};  // 0 maps to 0.
+  // Stub; see #20225.
+  return old_to_new;
+}
+
+/* Applies the given mapping to renumber all Mobods and references to them
+within the forest and its owning graph. */
+void SpanningForest::FixupForestToUseNewNumbering(
+    const std::vector<MobodIndex>& old_to_new) {
+  // Stub; see #20225.
+  unused(old_to_new);
+}
+
+/* Dole out the q's and v's to each of the Mobods, following the depth-first
+ordering. */
+void SpanningForest::AssignCoordinates() {
+  // Stub; see #20225.
+}
+
+// TODO(sherm1) Remove this.
+// To permit testing the APIs of Tree and LoopConstraint before the implementing
+// code is merged, we'll stub a forest that looks like this:
+//
+//            -> mobod1 => mobod2
+//     World                 ^
+//            -> mobod3 .....|  loop constraint
+//
+// There are two trees and a loop constraint where mobod3 is primary and
+// mobod2 is the shadow. The two joints to World have 1 dof, the "=>" joint
+// is a weld with 0 dofs.
+//
+// Note that there are no graph elements corresponding to any of this stuff
+// in the stub; we're just testing SpanningForest APIs here which don't care.
+// This will not be a well-formed forest for other purposes!
+void SpanningForest::AddStubTreeAndLoopConstraint() {
+  // Add three dummy Mobods.
+  data_.mobods.reserve(4);  // Prevent invalidation of the references.
+  auto& mobod1 =
+      data_.mobods.emplace_back(MobodIndex(1), BodyIndex(1), JointIndex(1),
+                                1 /* level */, false /* is_reversed */);
+  auto& mobod2 =
+      data_.mobods.emplace_back(MobodIndex(2), BodyIndex(2), JointIndex(2),
+                                2 /* level */, false /* is_reversed */);
+  auto& mobod3 =
+      data_.mobods.emplace_back(MobodIndex(3), BodyIndex(3), JointIndex(3),
+                                1 /* level */, false /* is_reversed */);
+
+  // Assign depth-first coordinates.
+  mobod1.q_start_ = 0;
+  mobod1.nq_ = 1;
+  mobod1.v_start_ = 0;
+  mobod1.nv_ = 1;
+  mobod2.q_start_ = 1;
+  mobod2.nq_ = 0;
+  mobod2.v_start_ = 1;
+  mobod2.nv_ = 0;
+  mobod3.q_start_ = 1;
+  mobod3.nq_ = 1;
+  mobod3.v_start_ = 1;
+  mobod3.nv_ = 1;
+
+  // Make the trees.
+  data_.trees.reserve(2);
+  auto& tree0 = data_.trees.emplace_back(this, TreeIndex(0), MobodIndex(1));
+  tree0.last_mobod_ = MobodIndex(2);
+  tree0.height_ = 2;
+  auto& tree1 = data_.trees.emplace_back(this, TreeIndex(1), MobodIndex(3));
+  tree1.last_mobod_ = MobodIndex(3);
+  tree1.height_ = 1;
+
+  mobod1.tree_index_ = tree0.index();
+  mobod2.tree_index_ = tree0.index();
+  mobod3.tree_index_ = tree1.index();
+
+  // Add the loop constraint.
+  data_.loop_constraints.emplace_back(LoopConstraintIndex(0), MobodIndex(3),
+                                      MobodIndex(2));
 }
 
 SpanningForest::Data::Data() = default;

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -23,13 +23,127 @@ namespace internal {
 
 using WeldedMobodsIndex = TypeSafeIndex<class WeldedMobodsTag>;
 
+// TODO(sherm1) The following describes the aspirational SpanningForest but
+//  the code so far has only stubs. See PR #20225 for the implementation.
+
 /** SpanningForest models a LinkJointGraph via a set of spanning trees and
-loop-closing constraints. */
-// TODO(sherm1) Just a skeleton here; much more to come.
+loop-closing constraints. This is a directed forest, with edges ordered from
+inboard (closer to World) to outboard. The nodes are mobilized bodies (Mobods)
+representing a body and its inboard mobilizer. While building the Forest we also
+study the original LinkJointGraph and update it to reflect:
+  - how each of its elements was modeled,
+  - any new elements that needed to be added for the model, and
+  - which Links are welded together into composites.
+
+Welded-together Links have no relative motion so should be excluded from mutual
+collision computations and can (optionally) be modeled with a single mobilized
+body.
+
+Problem statement
+
+We're given a disjoint collection of directed, possibly cyclic, graphs whose
+nodes represent links and whose parent->child directed edges represent joints.
+Some graphs contain edges to World, others are free-floating. The task here is
+to efficiently convert the input graph collection into a single directed
+_acyclic_ graph considered as a forest of directed trees. The nodes of the trees
+are _mobilized bodies_ (Mobods), each of which has a unique edge ("mobilizer")
+connecting it to its _inboard_ (closer to World) mobilized body, and directed
+inboard->outboard. Each tree spans one of the input graphs and is given an edge
+to World if there wasn't one already. Links are cut to break cycles, with each
+half getting its own Mobod. The forest is augmented with weld constraints
+that will act on the two Mobods to reconnect the Link halves. The resulting
+forest (with its associated welds) is to be optimized for computation speed and
+numerical accuracy, consistent with user preferences.
+
+Input links and joints can be annotated with properties that may affect how we
+build the forest. For example, a joint may be fixed (a weld) indicating that its
+connected links can be combined. Links may be massless in which case they can't
+be terminal nodes of a tree unless they are also welded to something massful.
+Users may also have modeling preferences, such as which nodes should be used to
+connect free-floating input graphs to World, and how they should be connected
+(e.g. fixed or floating base).
+
+These are the properties the resulting forest _must_ have:
+  - All nodes (Mobods) have a path from World.
+  - Massless bodies never appear as terminal nodes in the forest
+  - Mobod nodes are numbered depth-first.
+  - Position and velocity coordinates q and v are assigned to the edges
+    (mobilizers) with the same depth-first ordering.
+  - Excluding World, the trees partition the Mobods and each tree contains a
+    consecutively-numbered subset of Mobods and their coordinates.
+  - Specific user modeling instructions are obeyed.
+
+And these additional properties are highly desirable:
+  - The maximum branch length is minimized when breaking cycles.
+  - Input parent->child edge directions are preserved as inboard->outboard
+    directions when possible without increasing the maximum branch length.
+  - Welded-together links are combined into a single Mobod (optionally).
+
+Discussion
+
+A LinkJointGraph consists of Links (user-defined rigid bodies) and Joints in a
+directed, possibly cyclic graph. Link 0 is designated as the World and is
+modeled by Mobod 0 in the Forest. Each Joint connects a "parent" Link to a
+"child" Link. The parent->child ordering is arbitrary but sets the user's
+expected sign conventions for the Joint coordinates. Those must be preserved,
+even though inboard->outboard ordering may differ from parent->child (even if
+there are no loops). We distinguish "moving" (or "articulated") Joints from
+"weld" (0 dof) Joints; every moving Joint is modeled by a mobilizer, but welds
+may be eliminated by creating LinkComposites that require only a single
+mobilizer for a group of Links.
+
+The SpanningForest contains a Mobod node corresponding to each Link or
+LinkComposite (group of welded-together Links). A mobilizer connects each Mobod
+to an inboard Mobod (except for World). An additional "shadow" Link and its
+Mobod is created whenever a loop is broken by cutting a Link, and a
+LoopConstraint is added to reconnect the primary Link to its shadow. Every
+moving Joint will map to a Mobod and there will be additional floating or weld
+mobilizers added as needed to connect tree root nodes (a.k.a. "base bodies") to
+World.
+
+When extra bodies, mobilizers, and constraints are needed to construct the
+Forest, corresponding _ephemeral_ Links, Joints, and LoopConstraints are added
+to the LinkJointGraph so a user can view the Forest as an extended
+LinkJointGraph (the original graph is retained). For example, added 6dof
+mobilizers can be viewed as though they had been floating Joints in the
+LinkJointGraph.
+
+We sort the mobilized bodies into depth-first order, beginning with the 0th
+Mobod corresponding to World. The data structures are designed to support fast
+computation directly so that the information here does not need to be duplicated
+elsewhere.
+
+Things we get for free (O(1)) here as a side effect of building the Forest:
+  - access the mobilized bodies (Mobods) in depth-first order
+  - access Trees also in depth-first order and find out which Mobods belong
+      to a given Tree and what range of coordinates belongs to each Tree or
+      subtree
+  - ask a Mobod which Tree it is in, and which coordinates it uses
+  - find out which groups of Mobods are welded together (so have no relative
+    motion)
+  - ask a Mobod which WeldedMobods grouping it belongs to, if any
+  - ask a coordinate (q or v) which Mobod or Tree it belongs to
+  - ask for the max height of a Tree or the level of a particular Mobod
+  - determine which Mobods are anchored to World, directly or indirectly
+  - find out which Mobod(s) represents a given Link
+  - find out which Mobod (if any) represents a given Joint (welds internal
+    to LinkComposites are not modeled)
+  - find all the Links that follow a particular Mobod (for composites)
+  - find out what (ephemeral) Links, Joints, and LoopConstraints appear in the
+      Forest but not the source Graph.
+
+Supported operations at minimal cost:
+  - find the path from World to a given Link or Mobod
+  - find the closest common ancestor of a pair of Links or Mobods.
+*/
 class SpanningForest {
  public:
   // Constructors and assignment are private; only LinkJointGraph may access.
   // These can't be default because there are back pointers to clean up.
+
+  class Mobod;  // Defined in separate headers.
+  class Tree;
+  class LoopConstraint;
 
   /** Returns a reference to the graph that owns this forest (as set during
   construction). */
@@ -41,6 +155,54 @@ class SpanningForest {
   /** Returns `true` if this forest is up to date with respect to its owning
   graph. */
   bool is_valid() const { return graph().forest_is_valid(); }
+
+  /** All the mobilized bodies, in depth-first order. World comes first,
+  then every Mobod in tree 0, then every Mobod in tree 1, etc. Free bodies
+  that weren't explicitly connected to World by a Joint come last. */
+  const std::vector<Mobod>& mobods() const { return data_.mobods; }
+
+  /** Provides convenient access to a particular Mobod. Requires a MobodIndex,
+  not a plain integer.
+  @pre mobod_index is in range */
+  inline const Mobod& mobods(MobodIndex mobod_index) const;
+
+  /** The mobilized body (Mobod) corresponding to the World Link.
+  @pre The forest is valid. */
+  // Internal use only: this is valid during BuildForest() also.
+  const Mobod& world_mobod() const { return mobods(MobodIndex(0)); }
+
+  /** Constraints we added to close loops we had to cut. */
+  const std::vector<LoopConstraint>& loop_constraints() const {
+    return data_.loop_constraints;
+  }
+
+  /** Provides convenient access to a particular LoopConstraint. Requires a
+  LoopConstraintIndex, not a plain integer. */
+  inline const LoopConstraint& loop_constraints(
+      LoopConstraintIndex index) const;
+
+  /** The partitioning of the forest of mobilized bodies into trees. Each Tree
+  has a base (root) mobilized body that is connected directly to the World
+  Mobod (which may represent a LinkComposite). World is not considered to
+  be part of any Tree; it is the root of the Forest. */
+  const std::vector<Tree>& trees() const { return data_.trees; }
+
+  /** Provides convenient access to a particular Tree. Requires a TreeIndex,
+  not a plain integer.
+  @pre tree_index is in range */
+  inline const Tree& trees(TreeIndex tree_index) const;
+
+  /** When this %SpanningForest is valid (i.e., after BuildForest() returns)
+  this is the height of the forest, defined as the height of the tallest
+  Tree, plus 1 for World. Returns zero for an invalid forest. */
+  // Internal use only: During BuildForest() this will track the largest
+  // height seen so far.
+  int height() const { return data_.forest_height; }
+
+  // TODO(sherm1) Remove this.
+  // (Testing stub only) Add enough fake elements to the forest to allow
+  // testing of the Tree and LoopConstraint APIs.
+  void AddStubTreeAndLoopConstraint();
 
  private:
   friend class LinkJointGraph;
@@ -84,6 +246,21 @@ class SpanningForest {
   // construction. The owning LinkJointGraph remains unchanged.
   void Clear();
 
+  // Produce the optimal forest, but with suboptimal node ordering.
+  void ChooseForestTopology();
+
+  // Determine proposed depth-first reordering. Index the `old_to_new` result
+  // using the original MobodIndex to obtain the new MobodIndex.
+  // @retval old_to_new
+  std::vector<MobodIndex> CreateDepthFirstReordering() const;
+
+  // Update the forest to reorder the Mobods into depth-first order, and
+  // update the as-modeled information in the graph to match.
+  void FixupForestToUseNewNumbering(const std::vector<MobodIndex>& old_to_new);
+
+  // Once we have a depth-first ordering we can assign q's and v's.
+  void AssignCoordinates();
+
   struct Data {
     // These are all default but definitions deferred to .cc file so
     // that all the local classes are defined (Mac requirement).
@@ -96,7 +273,41 @@ class SpanningForest {
 
     LinkJointGraph* graph{};  // The graph we're modeling.
 
-    // TODO(sherm1) More to come
+    // A valid SpanningForest always has at least one mobilized body: World.
+    std::vector<Mobod> mobods;
+
+    // If we had to break any loops we'll add constraints to re-close them.
+    std::vector<LoopConstraint> loop_constraints;
+
+    // How the forest is partitioned into trees.
+    std::vector<Tree> trees;
+
+    // This is zero for an invalid forest, starts at 1 during BuildForest()
+    // to count World, then adds in the height of the tallest tree seen so
+    // far. Upon return from BuildForest() the forest is marked valid and
+    // this contains the height of the tallest tree, plus 1.
+    int forest_height{0};
+
+    // Welded Mobod groups. These are disjoint sets of Mobods that have no
+    // relative motion due to _modeled_ weld Joints (and _not_ due to weld
+    // constraints). (If we are building LinkComposites, there won't be any
+    // Mobods welded together because we'll make all welded-together Links
+    // follow a single Mobod.) The World Mobod group is always present and comes
+    // first even if nothing is welded to it. Other Mobods appear here only if
+    // they are welded to at least one other Mobod. The indexes here must be
+    // renumbered by FixupForestToUseNewNumbering().
+    std::vector<std::vector<MobodIndex>> welded_mobods;
+
+    // Map from mobilizer coordinates to their associated mobilized bodies.
+    // These are filled in late with the post-renumbered MobodIndex values so
+    // should NOT be renumbered by FixupForestToUseNewNumbering().
+    std::vector<MobodIndex> q_to_mobod;  // size is nq (total number of q's)
+    std::vector<MobodIndex> v_to_mobod;  // size is nv (total number of v's)
+
+    // This policy is expressed as a "less than" comparator of the type used by
+    // std::priority_queue. It should return true if the left argument is a
+    // worse choice than the right argument, according to the policy.
+    std::function<bool(const BodyIndex&, const BodyIndex&)> base_body_policy;
   } data_;
 };
 

--- a/multibody/topology/spanning_forest_inlines.h
+++ b/multibody/topology/spanning_forest_inlines.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_FOREST_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/forest.h".
+#endif
+
+#include <vector>
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+// SpanningForest definitions deferred until Mobod defined.
+
+inline auto SpanningForest::mobods(MobodIndex mobod_index) const
+    -> const Mobod& {
+  DRAKE_ASSERT(mobod_index.is_valid() && mobod_index < ssize(mobods()));
+  return mobods()[mobod_index];
+}
+
+// SpanningForest definitions deferred until Tree available.
+
+inline auto SpanningForest::trees(TreeIndex tree_index) const -> const Tree& {
+  DRAKE_ASSERT(tree_index.is_valid() && tree_index < ssize(trees()));
+  return trees()[tree_index];
+}
+
+// SpanningForest definitions deferred until LoopConstraint defined.
+
+inline auto SpanningForest::loop_constraints(LoopConstraintIndex index) const
+    -> const LoopConstraint& {
+  DRAKE_ASSERT(index.is_valid() && index < ssize(loop_constraints()));
+  return loop_constraints()[index];
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/spanning_forest_loop_constraint.h
+++ b/multibody/topology/spanning_forest_loop_constraint.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_FOREST_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/forest.h".
+#endif
+
+#include <vector>
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+/** Weld constraints added during modeling to close loops. */
+class SpanningForest::LoopConstraint {
+ public:
+  /** (Internal use only) Copy/Move constructor & assignment. */
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LoopConstraint)
+
+  /** (Internal use only) Created in SpanningForest::BuildForest() when loops
+  are cut. */
+  LoopConstraint(LoopConstraintIndex loop_constraint_index,
+                 MobodIndex primary_mobod_index, MobodIndex shadow_mobod_index)
+      : loop_constraint_index_(loop_constraint_index),
+        primary_mobod_index_(primary_mobod_index),
+        shadow_mobod_index_(shadow_mobod_index) {
+    DRAKE_DEMAND(loop_constraint_index.is_valid() &&
+                 primary_mobod_index.is_valid() &&
+                 shadow_mobod_index.is_valid());
+    DRAKE_DEMAND(primary_mobod_index != shadow_mobod_index);
+  }
+
+  /** Returns the index assigned to this LoopConstraint. */
+  LoopConstraintIndex index() const { return loop_constraint_index_; }
+
+  /** Returns the primary Mobod associated with the cut Link. This will
+  be the parent of the implementing weld constraint. */
+  MobodIndex primary_mobod() const { return primary_mobod_index_; }
+
+  /** Returns the shadow Mobod associated with the cut Link. This will
+  be the child of the implementing weld constraint. */
+  MobodIndex shadow_mobod() const { return shadow_mobod_index_; }
+
+ private:
+  friend class SpanningForest;
+
+  void FixupAfterReordering(const std::vector<MobodIndex>& old_to_new) {
+    primary_mobod_index_ = old_to_new[primary_mobod_index_];
+    shadow_mobod_index_ = old_to_new[shadow_mobod_index_];
+  }
+
+  LoopConstraintIndex loop_constraint_index_;
+
+  MobodIndex primary_mobod_index_;
+  MobodIndex shadow_mobod_index_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/spanning_forest_mobod.cc
+++ b/multibody/topology/spanning_forest_mobod.cc
@@ -1,0 +1,80 @@
+// NOLINTNEXTLINE(build/include): prevent complaint re spanning_forest_mobod.h
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/multibody/topology/forest.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Constructor for the World mobilized body.
+SpanningForest::Mobod::Mobod(MobodIndex mobod_index, BodyIndex world_link)
+    : level_(0),
+      index_(mobod_index),
+      q_start_(0),
+      nq_(0),
+      v_start_(0),
+      nv_(0),
+      nq_inboard_(0),
+      nv_inboard_(0) {
+  DRAKE_DEMAND(mobod_index.is_valid() && world_link.is_valid());
+  DRAKE_DEMAND(world_link == 0 && mobod_index == 0);
+  follower_links_.push_back(world_link);
+}
+
+// Constructor for mobilized bodies other than World.
+SpanningForest::Mobod::Mobod(MobodIndex mobod_index, BodyIndex link_index,
+                             JointIndex joint_index, int level,
+                             bool is_reversed)
+    : joint_index_(joint_index),
+      use_reverse_mobilizer_(is_reversed),
+      level_(level),
+      index_(mobod_index) {
+  DRAKE_DEMAND(mobod_index.is_valid() && link_index.is_valid() &&
+               joint_index.is_valid());
+  DRAKE_DEMAND(mobod_index != 0 && link_index != 0 && level > 0);
+  follower_links_.push_back(link_index);
+}
+
+void SpanningForest::Mobod::FixupAfterReordering(
+    const std::vector<MobodIndex>& old_to_new) {
+  index_ = old_to_new[index_];
+  if (!is_world()) inboard_mobod_ = old_to_new[inboard_mobod_];
+  RenumberMobodIndexVector(old_to_new, &outboard_mobods_);
+}
+
+void SpanningForest::Mobod::Swap(Mobod& other) {
+  std::swap(follower_links_, other.follower_links_);
+  std::swap(joint_index_, other.joint_index_);
+  std::swap(use_reverse_mobilizer_, other.use_reverse_mobilizer_);
+  std::swap(level_, other.level_);
+  std::swap(index_, other.index_);
+  std::swap(inboard_mobod_, other.inboard_mobod_);
+  std::swap(outboard_mobods_, other.outboard_mobods_);
+  std::swap(tree_index_, other.tree_index_);
+  std::swap(welded_mobods_index_, other.welded_mobods_index_);
+  std::swap(q_start_, other.q_start_);
+  std::swap(nq_, other.nq_);
+  std::swap(v_start_, other.v_start_);
+  std::swap(nv_, other.nv_);
+  std::swap(nq_inboard_, other.nq_inboard_);
+  std::swap(nv_inboard_, other.nv_inboard_);
+  std::swap(nq_outboard_, other.nq_outboard_);
+  std::swap(nv_outboard_, other.nv_outboard_);
+  std::swap(num_subtree_mobods_, other.num_subtree_mobods_);
+}
+
+void SpanningForest::Mobod::RenumberMobodIndexVector(
+    const std::vector<MobodIndex>& old_to_new,
+    std::vector<MobodIndex>* to_be_renumbered) {
+  for (MobodIndex& index : *to_be_renumbered) {
+    if (!index.is_valid()) continue;
+    DRAKE_ASSERT(index < old_to_new.size());
+    index = old_to_new[index];
+  }
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/spanning_forest_mobod.h
+++ b/multibody/topology/spanning_forest_mobod.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_FOREST_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/forest.h".
+#endif
+
+#include <utility>
+#include <vector>
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+/** Everything you might want to know about a mobilized body. */
+class SpanningForest::Mobod {
+ public:
+  /** (Internal use only) Copy/Move constructor & assignment. */
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Mobod)
+
+  /** (Internal use only) This constructor is just for World, the only %Mobod
+  with no mobilizer. (Or you can consider it welded to the universe at the
+  World origin.) */
+  Mobod(MobodIndex mobod_index, BodyIndex world_link);
+
+  /** (Internal use only) The general constructor for any non-World %Mobod. */
+  Mobod(MobodIndex mobod_index, BodyIndex link_index, JointIndex joint_index,
+        int level, bool is_reversed);
+
+  /** Returns `true` if this %Mobod is the World body, that is, the one with
+  MobodIndex 0. Returns `false` for anything else, even if this %Mobod is
+  welded to World. */
+  bool is_world() const { return level_ == 0; }
+
+  /** A %Mobod is a "base body" if its inboard mobilizer connects it directly to
+  World. That means it is at level 1 in the Forest. */
+  bool is_base_body() const { return level_ == 1; }
+
+  /** A %Mobod is "anchored" if it is the World %Mobod or if it is a %Mobod
+  directly or indirectly connected to the World %Mobod by Weld mobilizers.
+  All such %Mobods are part of the 0th WeldedMobods group. */
+  bool is_anchored() const {
+    return welded_mobods_index_.is_valid() &&
+           welded_mobods_index_ == WeldedMobodsIndex(0);
+  }
+
+  /** Returns true if there is no %Mobod that claims this one as its
+  inboard %Mobod.
+  @note Even if this %Mobod is not a leaf of its tree, it could still
+  be the case that there are no outboard degrees of freedom if all the
+  outboard joints are welds (recursively). That isn't taken into account here;
+  use nq_outboard() for that information.
+  @see nq_outboard() */
+  bool is_leaf_mobod() const { return outboard_mobods_.empty(); }
+
+  /** Returns true if the inboard/outboard relation here is opposite the
+  parent/child relation of the Joint that this Mobod is modeling. */
+  bool is_reversed() const { return use_reverse_mobilizer_; }
+
+  /** Returns true if this %Mobod's inboard mobilizer has no degrees of
+  freedom (or if this is World). */
+  bool is_weld() const { return nq() == 0; }
+
+  /** Returns the index of this %Mobod within the SpanningForest. World has
+  index 0 and the rest are in depth-first order. */
+  MobodIndex index() const { return index_; }
+
+  /** Returns the index of this %Mobod's unique inboard %Mobod. The index is
+  invalid if this is the World %Mobod. The inboard %Mobod's level()
+  is one less that this %Mobod's level(). */
+  MobodIndex inboard() const { return inboard_mobod_; }
+
+  /** Returns the indices of all %Mobods for which this %Mobod serves as the
+  inboard body. Each of the outboard %Mobods has a level() one higher than this
+  %Mobod's level(). */
+  const std::vector<MobodIndex>& outboards() const { return outboard_mobods_; }
+
+  /** Returns the index of the Link mobilized by this %Mobod. If this %Mobod
+  models a LinkComposite (collection of welded-together Links), this is the
+  "active" Link of that composite, the one whose (non-Weld) Joint connects
+  the whole LinkComposite to its inboard %Mobod.
+  @see joint() */
+  BodyIndex link() const { return follower_links()[0]; }
+
+  /** Returns all the Links that are mobilized by this %Mobod. If this %Mobod
+  represents a LinkComposite, the first Link returned is the "active" Link as
+  returned by link(). There is always at least one Link. */
+  const std::vector<BodyIndex>& follower_links() const {
+    DRAKE_ASSERT(!follower_links_.empty());
+    return follower_links_;
+  }
+
+  /** Returns the Joint represented by this %Mobod. If this %Mobod represents
+  a LinkComposite (which has internal weld Joints), the Joint returned here
+  is the "active" Joint that connects the Composite's active Link to a Link
+  that follows this %Mobod's inboard %Mobod in the forest. The returned
+  index is invalid if and only if this is the World %Mobod. */
+  JointIndex joint() const { return joint_index_; }
+
+  /** Returns the index of the Tree of which this %Mobod is a member. The
+  index is invalid if and only if this is the World %Mobod. */
+  TreeIndex tree() const { return tree_index_; }
+
+  /** Returns the index of the WeldedMobods group of which this %Mobod is a
+  part, if any. If this is the World %Mobod, we always return
+  WeldedMobodIndex(0). Otherwise, the returned index is invalid if there are no
+  %Mobods welded to this one. */
+  WeldedMobodsIndex welded_mobods_group() const { return welded_mobods_index_; }
+
+  /** Returns the level of this %Mobod within the SpanningForest. World is
+  level 0, the root (base body) of each Tree is level 1, %Mobods connected to
+  the base body are level 2, etc. */
+  int level() const { return level_; }
+
+  /** Starting offset within the contiguous q vector. */
+  int q_start() const { return q_start_; }
+
+  /** The number of position coordinates q used by this %Mobod's mobilizer. */
+  int nq() const { return nq_; }
+
+  /** Starting offset within the contiguous v vector. */
+  int v_start() const { return v_start_; }
+
+  /** The number of velocity coordinates v used by this %Mobod's mobilizer. */
+  int nv() const { return nv_; }
+
+  /** The count of generalized position coordinates q on the path between this
+  and World. Includes this %Mobod's qs. */
+  int nq_inboard() const { return nq_inboard_; }
+
+  /** The count of generalized velocity coordinates v on the path between this
+  and World. Includes this %Mobod's vs. */
+  int nv_inboard() const { return nv_inboard_; }
+
+  /** The count of generalized position coordinates q in the outboard subtree
+  that has this %Mobod as its root. Does _not_ include this %Mobod's qs. */
+  int nq_outboard() const { return nq_outboard_; }
+
+  /** The count of generalized velocity coordinates v in the outboard subtree
+  that has this %Mobod as its root. Does _not_ include this %Mobod's vs. */
+  int nv_outboard() const { return nv_outboard_; }
+
+  /** The number of %Mobods in the subtree with this %Mobod as its root,
+  including this %Mobod in the count. These are numbered consecutively starting
+  with this %Mobod's index, so the indices of the subtree %Mobods are [i, i+n)
+  where i is this %Mobod's index and n is the return value of this method. */
+  int num_subtree_mobods() const { return num_subtree_mobods_; }
+
+  /** Returns the velocity coordinates for the subtree rooted at this %Mobod,
+  _including_ this %Mobod's velocities. Because velocities are assigned
+  depth-first, all the velocities in a subtree are consecutive so we need only
+  return the index of the first one and the number of velocities. We return the
+  pair {i, n} where i is the index of this %Mobod's first velocity coordinate
+  vᵢ and n is the number of subtree velocity coordinates. So the subtree
+  coordinates are [vᵢ..vᵢ₊ₙ).
+  @see outboard_velocities() */
+  std::pair<int, int> subtree_velocities() const {
+    return std::make_pair(v_start(), nv() + nv_outboard());
+  }
+
+  /** Returns the velocity coordinates v that are outboard of this %Mobod,
+  _not including_ its own velocities. This is the same as subtree_velocities()
+  but with this Mobod's velocities removed.
+  @see subtree_velocities(). */
+  std::pair<int, int> outboard_velocities() const {
+    return std::make_pair(v_start() + nv(), nv_outboard());
+  }
+
+ private:
+  friend class SpanningForest;
+
+  // Update all MobodIndex entries to use the new numbering.
+  void FixupAfterReordering(const std::vector<MobodIndex>& old_to_new);
+
+  // Switch the contents of `this` and `other` mobilized bodies.
+  void Swap(Mobod& other);
+
+  // Given a mapping from old MobodIndex to new MobodIndex, repair an
+  // existing vector of old MobodIndexes to use the new numbering. Any invalid
+  // indexes are left untouched.
+  static void RenumberMobodIndexVector(
+      const std::vector<MobodIndex>& old_to_new,
+      std::vector<MobodIndex>* to_be_renumbered);
+
+  // CAREFUL: if you add any members here, update Swap!
+
+  // Links represented by this Mobod. The first one is always present and is
+  // the active Link if we're mobilizing a LinkComposite.
+  std::vector<BodyIndex> follower_links_;
+
+  // Corresponding Joint (user or modeling joint). If this Mobod represents
+  // a LinkComposite, this is the Joint that mobilizes the whole Composite.
+  JointIndex joint_index_;
+
+  // For an already-existing Joint, must we use a reverse mobilizer? If true,
+  // we know tree inboard/outboard order is opposite graph parent/child order.
+  bool use_reverse_mobilizer_{false};
+
+  int level_{-1};  // Path length from World to this Mobod.
+
+  // These references must be renumbered when we reorder the mobods.
+  MobodIndex index_;          // Index of this mobilized body.
+  MobodIndex inboard_mobod_;  // Tree parent at level-1 (invalid for World)
+  std::vector<MobodIndex> outboard_mobods_;  // Tree children at level+1
+
+  TreeIndex tree_index_;                   // Which Tree is this Mobod part of?
+  WeldedMobodsIndex welded_mobods_index_;  // Part of a WeldedMobods group?
+
+  // Coordinate assignments (done last). For welds (and for World), q/v_start
+  // is still set to where coordinates would have started if there were any,
+  // with nq/v==0.
+  int q_start_{-1};  // within the full q vector
+  int nq_{-1};
+  int v_start_{-1};  // within the full v vector
+  int nv_{-1};
+
+  // Positioning within the coordinates of the containing tree. For World there
+  // are zero inboard, num_positions and num_velocities outboard.
+  int nq_inboard_{-1};  // Coordinates along the path to World.
+  int nv_inboard_{-1};
+  int nq_outboard_{-1};  // All coordinates outboard of this Mobod.
+  int nv_outboard_{-1};
+
+  // Number of Mobods in the subtree for which this is the root.
+  int num_subtree_mobods_{-1};
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/spanning_forest_tree.h
+++ b/multibody/topology/spanning_forest_tree.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_FOREST_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/forest.h".
+#endif
+
+#include <vector>
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+/** Everything you might want to know about an individual tree in the forest.
+A Tree consists of consecutively numbered Mobod nodes in depth-first order.
+The first node is its base Mobod (root node) and the last node is its
+"rightmost" terminal Mobod (assuming you draw the tree with the root at the
+bottom, and children consistently left-to-right). Duplication is avoided by
+keeping a back pointer to the owning SpanningForest. */
+class SpanningForest::Tree {
+ public:
+  /** (Internal use only) Copy/Move constructor & assignment. Back pointer
+  requires fixup afterwards. */
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Tree)
+
+  /** (Internal use only) Trees are constructed during BuildForest(). Note
+  that we know the base_mobod at construction but can't know the last_mobod
+  until much later. */
+  Tree(const SpanningForest* forest, TreeIndex index, MobodIndex base_mobod)
+      : forest_(forest), index_(index), base_mobod_(base_mobod), height_(1) {}
+
+  /** The TreeIndex of this Tree within the SpanningForest. */
+  TreeIndex index() const { return index_; }
+
+  /** The length of the longest branch of this %Tree, counting the base (root)
+  body of the %Tree but not counting World. */
+  int height() const { return height_; }
+
+  /** The level-1 Mobod that is the base (root) Mobod of this %Tree. This is
+  the lowest-numbered Mobod in this %Tree. */
+  MobodIndex base_mobod() const { return base_mobod_; }
+
+  /** The highest-numbered Mobod that is part of this %Tree. The Mobods in
+  this tree are numbered consecutively from base_mobod() to last_mobod(). */
+  MobodIndex last_mobod() const { return last_mobod_; }
+
+  /** An iterator pointing to the base_mobod(), suitable for range iteration. */
+  const SpanningForest::Mobod* begin() const {
+    return &forest_->mobods()[base_mobod_];
+  }
+
+  /** An iterator pointing one entry past the last_mobod(), suitable for range
+  iteration. Don't dereference this! */
+  const SpanningForest::Mobod* end() const {
+    return &forest_->mobods()[last_mobod_] + 1;
+  }
+
+  /** The Mobod whose index is returned by base_mobod(). */
+  const SpanningForest::Mobod& front() const {
+    return forest_->mobods()[base_mobod_];
+  }
+
+  /** The Mobod whose index is returned by last_mobod(). */
+  const SpanningForest::Mobod& back() const {
+    return forest_->mobods()[last_mobod_];
+  }
+
+  /** The number of Mobods in this %Tree, counting the base (root) body.
+  (World is not considered to be part of any %Tree.) */
+  int num_mobods() const { return last_mobod_ - base_mobod_ + 1; }
+
+  /** The lowest numbered generalized position coordinate q assigned to
+  this %Tree. */
+  int q_start() const { return front().q_start(); }
+
+  /** The lowest numbered generalized velocity coordinate v assigned to
+  this %Tree. */
+  int v_start() const { return front().v_start(); }
+
+  /** The number of generalized position coordinates q assigned to
+  this %Tree. They are numbered sequentially from q_start() to
+  q_start() + nq() - 1. */
+  int nq() const {
+    // We depend on Weld Mobods to set their q_start to where it
+    // would be if they had qs.
+    const int last_q_plus_1 = back().q_start() + back().nq();
+    return last_q_plus_1 - q_start();
+  }
+
+  /** The number of generalized velocity coordinates v assigned to
+  this %Tree. They are numbered sequentially from v_start() to
+  v_start() + nv() - 1. */
+  int nv() const {
+    // We depend on Weld Mobods to set their v_start to where it
+    // would be if they had vs.
+    const int last_v_plus_1 = back().v_start() + back().nv();
+    return last_v_plus_1 - v_start();
+  }
+
+ private:
+  friend class SpanningForest;
+
+  // Update all MobodIndex entries to use the new numbering.
+  void FixupAfterReordering(const std::vector<MobodIndex>& old_to_new) {
+    base_mobod_ = old_to_new[base_mobod_];
+    // last_mobod_ is always set using the new ordering
+  }
+
+  const SpanningForest* forest_{nullptr};  // The containing forest.
+
+  TreeIndex index_;
+  MobodIndex base_mobod_;  // The tree's root node that connects it to World.
+  MobodIndex last_mobod_;  // The tree's highest numbered node.
+  int height_{-1};         // 1 if just base body.
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -23,11 +23,21 @@ namespace {
 // A default-constructed LinkJointGraph contains a predefined World
 // Link, and can generate a valid SpanningForest containing just a World
 // Mobod. The LinkJointGraph should be properly updated to have
-// a single link composite and proper modeling info.
+// a single LinkComposite and proper modeling info.
 GTEST_TEST(SpanningForest, WorldOnlyTest) {
   LinkJointGraph graph;
+  const SpanningForest& forest = graph.forest();
 
-  // World is predefined.
+  // Check that the internal forest is wired correctly but not valid yet.
+  EXPECT_EQ(&forest.graph(), &graph);
+  EXPECT_FALSE(graph.forest_is_valid());
+  EXPECT_FALSE(forest.is_valid());
+  EXPECT_EQ(forest.height(), 0);
+  EXPECT_TRUE(forest.mobods().empty());
+  EXPECT_TRUE(forest.trees().empty());
+  EXPECT_TRUE(forest.loop_constraints().empty());
+
+  // The default-constructed graph should contain only World.
   EXPECT_EQ(ssize(graph.links()), 1);
   EXPECT_TRUE(graph.joints().empty());
   EXPECT_EQ(graph.world_link().name(), "world");
@@ -35,15 +45,118 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   const BodyIndex world_link_index = graph.world_link().index();
   EXPECT_EQ(world_link_index, BodyIndex(0));
 
+  // Now build a forest representing the World-only graph.
   graph.BuildForest();
   EXPECT_TRUE(graph.forest_is_valid());
-  const SpanningForest& forest = graph.forest();
-  EXPECT_EQ(&forest.graph(), &graph);
   EXPECT_TRUE(forest.is_valid());
+  const SpanningForest::Mobod& world = forest.mobods(MobodIndex(0));
+  EXPECT_EQ(&world, &forest.world_mobod());
+  const MobodIndex world_mobod_index = forest.world_mobod().index();
+  EXPECT_EQ(world_mobod_index, MobodIndex(0));
   EXPECT_EQ(graph.link_to_mobod(world_link_index), MobodIndex(0));
   EXPECT_EQ(ssize(graph.link_composites()), 1);
   EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0))), 1);
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0))[0], world_link_index);
+
+  // Check that the World-only forest makes sense.
+  EXPECT_EQ(ssize(forest.mobods()), 1);
+  EXPECT_TRUE(forest.trees().empty());  // World isn't part of a tree.
+  EXPECT_TRUE(forest.loop_constraints().empty());
+  EXPECT_EQ(forest.height(), 1);
+
+  // Exercise the Mobod API to check the World Mobod for reasonableness.
+  EXPECT_TRUE(world.is_world());
+  EXPECT_FALSE(world.is_base_body());
+  EXPECT_TRUE(world.is_anchored());
+  EXPECT_TRUE(world.is_leaf_mobod());
+  EXPECT_FALSE(world.is_reversed());  // Not meaningful though.
+  EXPECT_TRUE(world.is_weld());       // Defined as having no inboard dofs.
+  EXPECT_FALSE(world.inboard().is_valid());
+  EXPECT_TRUE(world.outboards().empty());
+  EXPECT_EQ(world.link(), world_link_index);
+  EXPECT_EQ(ssize(world.follower_links()), 1);
+  EXPECT_EQ(world.follower_links()[0], world_link_index);
+  EXPECT_FALSE(world.joint().is_valid());
+  EXPECT_FALSE(world.tree().is_valid());
+  EXPECT_EQ(world.welded_mobods_group(), WeldedMobodsIndex(0));
+  EXPECT_EQ(world.level(), 0);
+  EXPECT_EQ(world.q_start(), 0);
+  EXPECT_EQ(world.nq(), 0);
+  EXPECT_EQ(world.v_start(), 0);
+  EXPECT_EQ(world.nv(), 0);
+  EXPECT_EQ(world.nq_inboard(), 0);
+  EXPECT_EQ(world.nv_inboard(), 0);
+  EXPECT_EQ(world.nq_outboard(), 0);
+  EXPECT_EQ(world.nv_outboard(), 0);
+  EXPECT_EQ(world.num_subtree_mobods(), 1);
+  EXPECT_EQ(world.subtree_velocities(), (std::pair{0, 0}));
+  EXPECT_EQ(world.outboard_velocities(), (std::pair{0, 0}));
+
+  // Check that if we clear the graph, the forest returns to its invalid
+  // condition as above.
+  graph.Clear();
+  EXPECT_EQ(&forest.graph(), &graph);  // Still wired right.
+  EXPECT_FALSE(graph.forest_is_valid());
+  EXPECT_FALSE(forest.is_valid());
+  EXPECT_EQ(forest.height(), 0);
+  EXPECT_TRUE(forest.mobods().empty());
+  EXPECT_TRUE(forest.trees().empty());
+  EXPECT_TRUE(forest.loop_constraints().empty());
+}
+
+GTEST_TEST(SpanningForest, TreeAndLoopConstraintAPIs) {
+  LinkJointGraph graph;
+  const SpanningForest& forest = graph.forest();
+  graph.BuildForest();
+
+  // This stub exists solely to enable these API tests until the implementing
+  // code is merged. Here's the forest we're expecting:
+  //            -> mobod1 => mobod2
+  //     World                 ^
+  //            -> mobod3 .....|  loop constraint
+  // There are two 1-dof "->" joints and one 0-dof "=>" weld.
+  // TODO(sherm1) Make the same forest legitimately.
+  const_cast<SpanningForest&>(forest).AddStubTreeAndLoopConstraint();
+
+  EXPECT_EQ(ssize(forest.trees()), 2);
+  EXPECT_EQ(ssize(forest.mobods()), 4);
+  EXPECT_EQ(ssize(forest.loop_constraints()), 1);
+
+  // Not much to check for the loop constraint.
+  const auto& loop_constraint = forest.loop_constraints(LoopConstraintIndex(0));
+  EXPECT_EQ(loop_constraint.index(), LoopConstraintIndex(0));
+  EXPECT_EQ(loop_constraint.primary_mobod(), MobodIndex(3));
+  EXPECT_EQ(loop_constraint.shadow_mobod(), MobodIndex(2));
+
+  const SpanningForest::Tree& tree0 = forest.trees(TreeIndex(0));
+  EXPECT_EQ(tree0.index(), TreeIndex(0));
+  EXPECT_EQ(tree0.height(), 2);
+  EXPECT_EQ(tree0.base_mobod(), MobodIndex(1));
+  EXPECT_EQ(tree0.last_mobod(), MobodIndex(2));
+  EXPECT_EQ(tree0.begin()->index(), MobodIndex(1));
+  EXPECT_EQ(tree0.end() - tree0.begin(), 2);
+  EXPECT_EQ(tree0.front().index(), MobodIndex(1));
+  EXPECT_EQ(tree0.back().index(), MobodIndex(2));
+  EXPECT_EQ(tree0.num_mobods(), 2);
+  EXPECT_EQ(tree0.q_start(), 0);
+  EXPECT_EQ(tree0.v_start(), 0);
+  EXPECT_EQ(tree0.nq(), 1);
+  EXPECT_EQ(tree0.nv(), 1);
+
+  const SpanningForest::Tree& tree1 = forest.trees(TreeIndex(1));
+  EXPECT_EQ(tree1.index(), TreeIndex(1));
+  EXPECT_EQ(tree1.height(), 1);
+  EXPECT_EQ(tree1.base_mobod(), MobodIndex(3));
+  EXPECT_EQ(tree1.last_mobod(), MobodIndex(3));
+  EXPECT_EQ(tree1.begin()->index(), MobodIndex(3));
+  EXPECT_EQ(tree1.end() - tree1.begin(), 1);
+  EXPECT_EQ(tree1.front().index(), MobodIndex(3));
+  EXPECT_EQ(tree1.back().index(), MobodIndex(3));
+  EXPECT_EQ(tree1.num_mobods(), 1);
+  EXPECT_EQ(tree1.q_start(), 1);
+  EXPECT_EQ(tree1.v_start(), 1);
+  EXPECT_EQ(tree1.nq(), 1);
+  EXPECT_EQ(tree1.nv(), 1);
 }
 
 }  // namespace


### PR DESCRIPTION
This is the third installment towards #20225, following PR #21142.

git_cloc says half the added lines of code here are comments:
- A large class-doc block describes SpanningForest and what you can do with it.
- A large internal block describes the multi-stage algorithm used to create a SpanningForest from a LinkJointGraph.
- The APIs for SpanningForest sub-objects (Mobod, LoopConstraint, Tree) are fully documented.

These comments describe the full implementation (in #20225), but the code here is stubbed. I'd like to get the comments reviewed for readability, clarity, logical flaws and so on. IMO it is too much to ask to review both the long text discussion and the hairy implementation code (and those require different frames of mind), so the code will come in a follow on PR. This one seems big enough already!

The code added here includes:
- Most of the remaining structure of the SpanningTree class (several small files)
- A little bit of stub code that shows the structure of the BuildForest() algorithm but not the contents
- Tests for the minimal functionality that is actually present; some have to be deferred until we can build a forest. 

MultibodyPlant continues to use its old topology code unchanged. There are no user-visible changes here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21120)
<!-- Reviewable:end -->
