### PR TITLE
Fix rigid geometry registration for deformable contact

### DIFF
--- a/geometry/proximity/deformable_contact_geometries.cc
+++ b/geometry/proximity/deformable_contact_geometries.cc
@@ -81,10 +81,6 @@ DeformableGeometry::CalcSignedDistanceField() const {
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const HalfSpace&, const ProximityProperties&) {
-  throw std::logic_error(
-      "Half spaces are not currently supported for deformable contact; "
-      "registration is allowed, but an error will be thrown "
-      "during contact.");
   return {};
 }
 

--- a/geometry/proximity/deformable_contact_geometries.h
+++ b/geometry/proximity/deformable_contact_geometries.h
@@ -107,27 +107,21 @@ class RigidGeometry {
 
 /* Generic interface for handling rigid Shapes. By default, we support all
  shapes that are supported by rigid hydroelastic. Unsupported shapes (e.g. half
- space) can choose to opt out. Unsupported geometries will return a
- std::nullopt. The rigid mesh created upon a successful creation of
- RigidGeometry will be the same mesh as used for rigid hydroelastics. */
+ space) can choose to opt out. Geometries not supported by rigid hydroelastics
+ will return a std::nullopt. The rigid mesh created upon a successful creation
+ of RigidGeometry will be the same mesh as used for rigid hydroelastics. */
 template <typename Shape>
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Shape& shape, const ProximityProperties& props) {
   std::optional<internal::hydroelastic::RigidGeometry> hydro_rigid_geometry =
       internal::hydroelastic::MakeRigidRepresentation(shape, props);
   if (!hydro_rigid_geometry) {
-    static const logging::Warn log_once(
-        "Rigid {} shapes are not currently supported for deformable "
-        "contact; registration is allowed, but an error will be thrown "
-        "during contact.",
-        shape.type_name());
     return {};
   }
-  auto surface_mesh = std::make_unique<TriangleSurfaceMesh<double>>(
-      (*hydro_rigid_geometry).mesh());
-  auto rigid_mesh = std::make_unique<internal::hydroelastic::RigidMesh>(
-      std::move(surface_mesh));
-  return RigidGeometry(std::move(rigid_mesh));
+  /* We know that a mesh representation of the rigid geometry exists because we
+   explicitly opts out of half space below and all other shapes supported by
+   rigid hydroelastics has a mesh representation. */
+  return RigidGeometry(hydro_rigid_geometry->release_mesh());
 }
 
 /* Half space is not supported for deformable contact at the moment as we

--- a/geometry/proximity/deformable_contact_internal.cc
+++ b/geometry/proximity/deformable_contact_internal.cc
@@ -191,14 +191,11 @@ void Geometries::AddRigidGeometry(const ShapeType& shape,
     rigid_geometries_pending_.insert({data.id, std::move(instance)});
     return;
   }
-  /* Forward to hydroelastics to construct the geometry. */
-  std::optional<internal::hydroelastic::RigidGeometry> hydro_rigid_geometry =
-      internal::hydroelastic::MakeRigidRepresentation(shape, data.properties);
-  /* Unsupported geometries will be handle through the
-   `ThrowUnsupportedGeometry()` code path. */
-  DRAKE_DEMAND(hydro_rigid_geometry.has_value());
-  rigid_geometries_.insert(
-      {data.id, RigidGeometry(hydro_rigid_geometry->release_mesh())});
+  std::optional<RigidGeometry> rigid_geometry =
+      internal::deformable::MakeRigidRepresentation(shape, data.properties);
+  if (rigid_geometry) {
+    rigid_geometries_.insert({data.id, std::move(*rigid_geometry)});
+  }
 }
 
 void Geometries::FlushPendingRigidGeometry() {

--- a/geometry/proximity/deformable_contact_internal.h
+++ b/geometry/proximity/deformable_contact_internal.h
@@ -69,7 +69,8 @@ class Geometries final : public ShapeReifier {
       contact. The set of supported geometries is the set of all supported hydro
       rigid geometries minus half space. We use the same implementation that the
       hydro-rigid reifier is using for supported shapes.
-   This function is a no-op if the resolution_hint property is not specified.
+   This function is a no-op if the resolution_hint property is not specified and
+   logs a warning if the shape is not supported for deformable contact.
 
    @param shape         The shape to possibly represent.
    @param id            The unique identifier for the geometry.
@@ -131,7 +132,7 @@ class Geometries final : public ShapeReifier {
   void ImplementGeometry(const Sphere& sphere, void* user_data) override;
 
   /* Makes a rigid (non-deformable) geometry from a supported shape type using
-   the given `data`. */
+   the given `data`. Unsupported geometries are silently ignored*/
   template <typename ShapeType>
   void AddRigidGeometry(const ShapeType& shape, const ReifyData& data);
 

--- a/geometry/proximity/test/deformable_contact_geometries_test.cc
+++ b/geometry/proximity/test/deformable_contact_geometries_test.cc
@@ -197,11 +197,13 @@ GTEST_TEST(RigidGeometryTest, MakeRigidRepresentation) {
   ProximityProperties props;
   const double resolution_hint = 0.5;
   AddRigidHydroelasticProperties(resolution_hint, &props);
-  DRAKE_EXPECT_NO_THROW(MakeRigidRepresentation(sphere, props));
+  EXPECT_TRUE(MakeRigidRepresentation(sphere, props).has_value());
+
+  const MeshcatCone cone(1.0, 2.0, 3.0);
+  EXPECT_FALSE(MakeRigidRepresentation(cone, props).has_value());
 
   const HalfSpace half_space;
-  DRAKE_EXPECT_THROWS_MESSAGE(MakeRigidRepresentation(half_space, props),
-                              "Half space.*not.*supported.*");
+  EXPECT_FALSE(MakeRigidRepresentation(half_space, props).has_value());
 }
 
 }  // namespace

--- a/geometry/proximity/test/deformable_contact_internal_test.cc
+++ b/geometry/proximity/test/deformable_contact_internal_test.cc
@@ -112,8 +112,8 @@ GTEST_TEST(GeometriesTest, AddRigidGeometry) {
   EXPECT_TRUE(geometries.is_rigid(rigid_id));
   EXPECT_FALSE(geometries.is_deformable(rigid_id));
 
-  /* Trying to a rigid geometry without the resolution hint property is a no-op.
-   */
+  /* Trying to add a rigid geometry without the resolution hint property is a
+   no-op. */
   GeometryId g_id = GeometryId::get_new_id();
   ProximityProperties empty_props;
   geometries.MaybeAddRigidGeometry(Sphere(kRadius), g_id, empty_props,
@@ -121,6 +121,13 @@ GTEST_TEST(GeometriesTest, AddRigidGeometry) {
 
   EXPECT_FALSE(geometries.is_rigid(g_id));
   EXPECT_FALSE(geometries.is_deformable(g_id));
+
+  /* Trying to add an unsupported rigid geometry is a no-op. */
+  GeometryId half_space_id = GeometryId::get_new_id();
+  geometries.MaybeAddRigidGeometry(HalfSpace{}, half_space_id, props,
+                                   default_pose());
+  EXPECT_FALSE(geometries.is_rigid(half_space_id));
+  EXPECT_FALSE(geometries.is_deformable(half_space_id));
 }
 
 /* Test coverage for all unsupported shapes as rigid geometries: MeshcatCone and


### PR DESCRIPTION
When deformable bodies are present, we attempt to assign a mesh representation to all rigid geometries with a resolution hint so that they can interact with deformable geometries. Failing that, a geometry should not throw immediately throw but log a one-time warning instead and subsequently ignore interactions with deformable bodies.

This has always been the design intention, but previously the implementation incorrectly aborts in the (rare) presence of a half space with resolution hint property specified.