### PR TITLE
[tools] Disable legacy_create_init by default

### DIFF
--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -13,12 +13,21 @@ load(
     "drake_py_unittest",
 )
 
+py_library(
+    name = "module_py",
+    srcs = ["__init__.py"],
+    deps = ["//tools:module_py"],
+)
+
 # TODO(jwnimmer-tri) This probably deserves to live in drake/common, since it
 # should probably be widely used, but we'll wait until we have more evidence
 # before promoting it.
 drake_py_library(
     name = "find_data",
     srcs = ["find_data.py"],
+    deps = [
+        ":module_py",
+    ],
 )
 
 drake_py_library(
@@ -26,6 +35,9 @@ drake_py_library(
     srcs = ["util.py"],
     data = ["//:.bazelproject"],
     visibility = ["//visibility:private"],
+    deps = [
+        ":module_py",
+    ],
 )
 
 drake_py_binary(
@@ -37,6 +49,7 @@ drake_py_binary(
     ],
     deps = [
         ":find_data",
+        ":module_py",
         ":util",
     ],
 )
@@ -46,6 +59,9 @@ drake_py_library(
     testonly = 1,
     srcs = ["clang_format.py"],
     data = ["//:.clang-format"],
+    deps = [
+        ":module_py",
+    ],
 )
 
 drake_py_binary(
@@ -54,6 +70,7 @@ drake_py_binary(
     srcs = ["clang_format_lint.py"],
     deps = [
         ":clang_format",
+        ":module_py",
     ],
 )
 
@@ -61,14 +78,20 @@ drake_py_binary(
     name = "drakelint",
     testonly = 1,
     srcs = ["drakelint.py"],
-    deps = [":formatter"],
+    deps = [
+        ":formatter",
+        ":module_py",
+    ],
 )
 
 drake_py_binary(
     name = "bzlcodestyle",
     srcs = ["bzlcodestyle.py"],
     main = "bzlcodestyle.py",
-    deps = ["@pycodestyle"],
+    deps = [
+        ":module_py",
+        "@pycodestyle",
+    ],
 )
 
 drake_py_library(
@@ -85,6 +108,7 @@ drake_py_binary(
     main = "clang_format_includes.py",
     deps = [
         ":formatter",
+        ":module_py",
         ":util",
     ],
 )
@@ -93,12 +117,18 @@ drake_py_binary(
     name = "install_lint_reporter",
     testonly = 1,
     srcs = ["install_lint_reporter.py"],
+    deps = [
+        ":module_py",
+    ],
 )
 
 drake_py_binary(
     name = "library_lint_reporter",
     testonly = 1,
     srcs = ["library_lint_reporter.py"],
+    deps = [
+        ":module_py",
+    ],
 )
 
 # === test ===

--- a/tools/lint/__init__.py
+++ b/tools/lint/__init__.py
@@ -1,0 +1,1 @@
+# Empty Python module `__init__`, required to make this a module.

--- a/tools/lint/install_lint.bzl
+++ b/tools/lint/install_lint.bzl
@@ -52,7 +52,7 @@ def install_lint(
         py_test_isolated(
             name = "install_lint",
             size = "small",
-            srcs = ["@drake//tools/lint:install_lint_reporter.py"],
+            srcs = ["@drake//tools/lint:install_lint_reporter"],
             main = "@drake//tools/lint:install_lint_reporter.py",
             args = args,
             data = data,

--- a/tools/lint/library_lint.bzl
+++ b/tools/lint/library_lint.bzl
@@ -141,7 +141,7 @@ def library_lint(
     py_test_isolated(
         name = "library_lint",
         size = "small",
-        srcs = ["@drake//tools/lint:library_lint_reporter.py"],
+        srcs = ["@drake//tools/lint:library_lint_reporter"],
         main = "@drake//tools/lint:library_lint_reporter.py",
         args = library_lint_reporter_args,
         data = library_lint_reporter_data,

--- a/tools/lint/python_lint.bzl
+++ b/tools/lint/python_lint.bzl
@@ -14,6 +14,7 @@ def _python_lint(name_prefix, files, ignore, disallow_executable):
         name = name_prefix + "_pycodestyle",
         size = "small",
         srcs = ["@pycodestyle//:pycodestyle"],
+        deps = ["@drake//tools/lint:module_py"],
         data = files,
         args = ignore_args + locations,
         main = "@pycodestyle//:pycodestyle.py",

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -56,6 +56,7 @@ def _py_target_isolated(
         main = None,
         isolate = True,
         visibility = None,
+        legacy_create_init = False,
         **kwargs):
     # See #8041 for more details.
     # TODO(eric.cousineau): See if we can remove these shims once we stop
@@ -81,6 +82,7 @@ def _py_target_isolated(
             srcs = srcs,
             main = main,
             visibility = visibility,
+            legacy_create_init = legacy_create_init,
             **kwargs
         )
 
@@ -104,6 +106,7 @@ def _py_target_isolated(
             srcs = srcs,
             main = main,
             visibility = visibility,
+            legacy_create_init = legacy_create_init,
             **kwargs
         )
 


### PR DESCRIPTION
Update linters' BUILD rules to match.

This fixes some backcompat problems with Bazel 7.1.0.

---

Towards #21123.  (Follow-up to #21054, in a way.)

FYI Anzu CI has succeeded on this PR already.

We've had in mind to opt-out of `legacy_create_init` for a while.  I don't know exactly why Bazel 7.1 is being picky about it now, but that's fine -- we should just turn it off in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21126)
<!-- Reviewable:end -->
