### PR TITLE
[geometry] Introduce SceneGraphConfig

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -47,6 +47,7 @@ drake_cc_package_library(
         ":read_obj",
         ":rgba",
         ":scene_graph",
+        ":scene_graph_config",
         ":scene_graph_inspector",
         ":shape_specification",
         ":shape_to_string",
@@ -300,6 +301,16 @@ drake_cc_library(
     deps = [
         ":geometry_roles",
         "//multibody/plant:coulomb_friction",
+    ],
+)
+
+drake_cc_library(
+    name = "scene_graph_config",
+    srcs = ["scene_graph_config.cc"],
+    hdrs = ["scene_graph_config.h"],
+    deps = [
+        ":proximity_properties",
+        "//common:name_value",
     ],
 )
 
@@ -935,6 +946,15 @@ drake_cc_googletest(
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
         "//geometry/proximity:make_sphere_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "scene_graph_config_test",
+    deps = [
+        ":scene_graph_config",
+        "//common/test_utilities:expect_throws_message",
+        "//common/yaml",
     ],
 )
 

--- a/geometry/scene_graph_config.cc
+++ b/geometry/scene_graph_config.cc
@@ -1,0 +1,103 @@
+#include "drake/geometry/scene_graph_config.h"
+
+#include <functional>
+
+#include "drake/geometry/proximity_properties.h"
+#include "drake/multibody/plant/coulomb_friction.h"
+
+namespace drake {
+namespace geometry {
+
+namespace {
+
+// Conditions, that if not met, could trigger an exception.
+// TODO(#21167) NaN values are not consistently accounted for.
+enum Condition {
+  kPositiveFinite,
+  kNonNegativeFinite,
+  kPositive,
+  kNonNegative,
+};
+
+// Check the value (if present) of `name`d `property` for `condition`. If the
+// value is present and the condition is not met, throw an exception with a
+// nice message.
+void ThrowUnlessAbsentOr(
+    std::string_view name,
+    std::optional<double> property,
+    Condition condition) {
+  if (!property.has_value()) { return; }
+  double value = *property;
+  std::string_view condition_name;
+  bool should_throw{false};
+  switch (condition) {
+    case kPositiveFinite: {
+      should_throw = (!std::isfinite(value) || value <= 0.0);
+      condition_name = "positive, finite";
+      break;
+    }
+    case kNonNegativeFinite: {
+      should_throw = (!std::isfinite(value) || value < 0.0);
+      condition_name = "non-negative, finite";
+      break;
+    }
+    case kPositive: {
+      should_throw = (value <= 0.0);
+      condition_name = "positive";
+      break;
+    }
+    case kNonNegative: {
+      should_throw = (value < 0.0);
+      condition_name = "non-negative";
+      break;
+    }
+  }
+  if (should_throw) {
+    throw std::logic_error(fmt::format(
+        "Invalid scene graph configuration: '{}' ({}) must be a {} value.",
+        name, value, condition_name));
+  }
+}
+
+}  // namespace
+
+void DefaultProximityProperties::ValidateOrThrow() const {
+  // This will throw if the type is invalid.
+  internal::GetHydroelasticTypeFromString(compliance_type);
+
+// Use a macro to capture both property name and value.
+#define DRAKE_ENFORCE(prop, cond) ThrowUnlessAbsentOr(#prop, prop, cond)
+  DRAKE_ENFORCE(hydroelastic_modulus, kPositive);
+  DRAKE_ENFORCE(resolution_hint, kPositiveFinite);
+  DRAKE_ENFORCE(slab_thickness, kPositiveFinite);
+
+  DRAKE_ENFORCE(dynamic_friction, kNonNegative);
+  DRAKE_ENFORCE(static_friction, kNonNegative);
+  DRAKE_ENFORCE(hunt_crossley_dissipation, kNonNegative);
+  DRAKE_ENFORCE(relaxation_time, kNonNegativeFinite);
+  DRAKE_ENFORCE(point_stiffness, kPositive);
+#undef DRAKE_ENFORCE
+
+  // Require either both friction quantities or neither.
+  if (static_friction.has_value() != dynamic_friction.has_value()) {
+    auto value_or_nullopt = [](auto x) {
+      return x ? fmt::to_string(*x) : "nullopt";
+    };
+    throw std::logic_error(fmt::format(
+        "Invalid scene graph configuration: either both 'static_friction' ({})"
+        " and 'dynamic_friction' ({}) must have a value, or neither.",
+        value_or_nullopt(static_friction), value_or_nullopt(dynamic_friction)));
+  }
+  if (static_friction.has_value()) {
+    // The constructor throws nice messages if its invariants fail.
+    multibody::CoulombFriction coulomb{*static_friction, *dynamic_friction};
+  }
+}
+
+void SceneGraphConfig::ValidateOrThrow() const {
+  default_proximity_properties.ValidateOrThrow();
+}
+
+}  // namespace geometry
+}  // namespace drake
+

--- a/geometry/scene_graph_config.h
+++ b/geometry/scene_graph_config.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "drake/common/name_value.h"
+
+namespace drake {
+namespace geometry {
+
+
+// TODO(rpoyner-tri): adjust doc when implementation is ready.
+// TODO(rpoyner-tri): ref hydro user quick start doc when available.
+/** (FUTURE) These properties will be used as defaults when the geometry as
+added via API calls or parsed from model files doesn't say anything more
+specific.  @see @ref hug_title, @ref hug_properties,
+@ref stribeck_approximation. */
+struct DefaultProximityProperties {
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(compliance_type));
+    a->Visit(DRAKE_NVP(compliance_type_rigid_fallback));
+    a->Visit(DRAKE_NVP(hydroelastic_modulus));
+    a->Visit(DRAKE_NVP(resolution_hint));
+    a->Visit(DRAKE_NVP(slab_thickness));
+    a->Visit(DRAKE_NVP(dynamic_friction));
+    a->Visit(DRAKE_NVP(static_friction));
+    a->Visit(DRAKE_NVP(hunt_crossley_dissipation));
+    a->Visit(DRAKE_NVP(relaxation_time));
+    a->Visit(DRAKE_NVP(point_stiffness));
+    ValidateOrThrow();
+  }
+  /** @name Hydroelastic Contact Properties
+
+  These properties affect hydroelastic contact only. For more detail, including
+  limits of the numeric parameters, @see
+  geometry::AddRigidHydroelasticProperties,
+  geometry::AddCompliantHydroelasticProperties,
+  geometry::AddCompliantHydroelasticPropertiesForHalfSpace.
+
+  For more context, @see @ref hug_properties. */
+  /// @{
+  /** There are three valid options for `compliance_type`:
+  - "undefined": hydroelastic contact will not be used.
+  - "rigid": the default hydroelastic compliance type will be rigid; note that
+     rigid-rigid contact is not supported by the hydroelastic contact model,
+     but is supported by point contact (multibody::ContactModel::kPoint or
+     multibody::ContactModel::kHydroelasticWithFallback).
+  - "compliant": the default hydroelastic compliance type will be compliant;
+    note that `compliance_type_rigid_fallback` offers a caveat for shapes
+    that do not currently have compliant hydroelastic representations. */
+  std::string compliance_type{"undefined"};
+
+  /** If default compliance_type is "compliant" but the shape does not have a
+  compliant hydroelastic representation (currently only for non-convex surface
+  meshes), then the compliance type will fall back to "rigid". */
+  bool compliance_type_rigid_fallback{true};
+
+  /** A measure of material stiffness, in units of Pascals. */
+  std::optional<double> hydroelastic_modulus{1e7};
+
+  /** Controls how finely primitive geometries are tessellated, units of
+  meters. */
+  std::optional<double> resolution_hint{0.5};
+
+  /** For a halfspace, the thickness of compliant material to model, in units
+  of meters. */
+  std::optional<double> slab_thickness{10.0};
+  /// @}
+
+  /** @name General Contact Properties
+
+  These properties affect contact in general. For more detail, including limits
+  of the numeric parameters, @see geometry::AddContactMaterial,
+  multibody::CoulombFriction, @ref mbp_contact_modeling, @ref
+  mbp_dissipation_model. */
+  /// @{
+  /** To be valid, either both friction values must be populated, or
+  neither. Friction quantities are unitless. */
+  std::optional<double> dynamic_friction{0.5};
+  /** @see dynamic_friction. */
+  std::optional<double> static_friction{0.5};
+
+  /** Controls energy damping from contact, for contact models *other than*
+  multibody::DiscreteContactApproximation::kSap. Units are seconds per
+  meter. */
+  std::optional<double> hunt_crossley_dissipation;
+
+  /** Controls energy damping from contact, *only for*
+  multibody::DiscreteContactApproximation::kSap. Units are seconds. */
+  std::optional<double> relaxation_time;
+  /// @}
+
+  /** @name Point Contact Properties
+
+  These properties point contact only. For complete descriptions of
+  the numeric parameters, @see geometry::AddContactMaterial. */
+  /// @{
+  /** A measure of material stiffness, in units of Newtons per meter. */
+  std::optional<double> point_stiffness;
+  /// @}
+
+  /** Throws if the values are inconsistent. */
+  void ValidateOrThrow() const;
+};
+
+// TODO(rpoyner-tri): document SceneGraph integration when ready.
+/** (FUTURE) The set of configurable properties on a SceneGraph. */
+struct SceneGraphConfig {
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(default_proximity_properties));
+  }
+
+  // TODO(rpoyner-tri): ref hydro user quick start doc when available.
+  /** Provides SceneGraph-wide contact material values to use when none have
+  been otherwise specified. */
+  DefaultProximityProperties default_proximity_properties;
+
+  /** Throws if the values are inconsistent. */
+  void ValidateOrThrow() const;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/scene_graph_config_test.cc
+++ b/geometry/test/scene_graph_config_test.cc
@@ -1,0 +1,188 @@
+#include "drake/geometry/scene_graph_config.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/yaml/yaml_io.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+using yaml::LoadYamlString;
+using yaml::SaveYamlString;
+
+const char* const kExampleConfig = R"""(
+default_proximity_properties:
+  compliance_type: compliant
+  compliance_type_rigid_fallback: false
+  hydroelastic_modulus: 2.0
+  resolution_hint: 3.0
+  slab_thickness: 4.0
+  dynamic_friction: 5.0
+  static_friction: 6.0
+  hunt_crossley_dissipation: 7.0
+  relaxation_time: 8.0
+  point_stiffness: 9.0
+)""";
+
+GTEST_TEST(SceneGraphConfigTest, YamlTest) {
+  const auto config = LoadYamlString<SceneGraphConfig>(kExampleConfig);
+  const auto& props = config.default_proximity_properties;
+  EXPECT_EQ(props.compliance_type, "compliant");
+  EXPECT_FALSE(props.compliance_type_rigid_fallback);
+  EXPECT_EQ(props.hydroelastic_modulus, 2);
+  EXPECT_EQ(props.resolution_hint, 3);
+  EXPECT_EQ(props.slab_thickness, 4);
+  EXPECT_EQ(props.dynamic_friction, 5);
+  EXPECT_EQ(props.static_friction, 6);
+  EXPECT_EQ(props.hunt_crossley_dissipation, 7);
+  EXPECT_EQ(props.relaxation_time, 8);
+  EXPECT_EQ(props.point_stiffness, 9);
+  EXPECT_EQ("\n" + SaveYamlString(config), kExampleConfig);
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidDefault) {
+  const SceneGraphConfig kDefault;
+  EXPECT_NO_THROW(kDefault.ValidateOrThrow());
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidateCompliance) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+  props.compliance_type = "nope";
+  DRAKE_EXPECT_THROWS_MESSAGE(config.ValidateOrThrow(),
+                              "Unknown hydroelastic_type: 'nope'");
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidateModulus) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+  props.hydroelastic_modulus = 0;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'hydroelastic_modulus' \\(0\\) must be a positive value.");
+  props.hydroelastic_modulus = std::numeric_limits<double>::quiet_NaN();
+  // TODO(#21167) document a disposition for NaN.
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidateRezHint) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+  props.resolution_hint = 0;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'resolution_hint' \\(0\\) must be a positive, finite value.");
+  props.resolution_hint = std::numeric_limits<double>::quiet_NaN();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'resolution_hint' \\(nan\\) must be a positive, finite value.");
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidateSlabThickness) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+  props.slab_thickness = 0;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'slab_thickness' \\(0\\) must be a positive, finite value.");
+  props.slab_thickness = std::numeric_limits<double>::quiet_NaN();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'slab_thickness' \\(nan\\) must be a positive, finite value.");
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidateDynamicFriction) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+  props.dynamic_friction = -1;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'dynamic_friction' \\(-1\\) must be a non-negative value.");
+  props.dynamic_friction = std::numeric_limits<double>::quiet_NaN();
+  // TODO(#21167) document a disposition for NaN.
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidateStaticFriction) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+  props.static_friction = -1;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'static_friction' \\(-1\\) must be a non-negative value.");
+  props.static_friction = std::numeric_limits<double>::quiet_NaN();
+  // TODO(#21167) document a disposition for NaN.
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidateHuntCrossley) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+  props.hunt_crossley_dissipation = -1;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'hunt_crossley_dissipation' \\(-1\\) must be a non-negative"
+      " value.");
+  props.hunt_crossley_dissipation = std::numeric_limits<double>::quiet_NaN();
+  // TODO(#21167) document a disposition for NaN.
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidateRelaxationTime) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+  props.relaxation_time = -1;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'relaxation_time' \\(-1\\) must be a non-negative, finite value.");
+  props.relaxation_time = std::numeric_limits<double>::quiet_NaN();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'relaxation_time' \\(nan\\) must be a non-negative, finite value.");
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidatePointStiffness) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+  props.point_stiffness = -1;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " 'point_stiffness' \\(-1\\) must be a positive value.");
+  props.point_stiffness = std::numeric_limits<double>::quiet_NaN();
+  // TODO(#21167) document a disposition for NaN.
+}
+
+GTEST_TEST(SceneGraphConfigTest, ValidateCoulombFriction) {
+  SceneGraphConfig config;
+  auto& props = config.default_proximity_properties;
+
+  // This configuration fails a pre-condition of CoulombFriction. We do not
+  // test them all here; it has its own tests.
+  props.static_friction = 0;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "The given dynamic friction \\(0.5\\) is greater than"
+      " the given static friction \\(0\\); dynamic friction must be"
+      " less than or equal to static friction.");
+
+  // This configuration fails a pre-condition of DefaultProximityProperties.
+  props.static_friction.reset();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      config.ValidateOrThrow(),
+      "Invalid scene graph configuration:"
+      " either both 'static_friction' \\(nullopt\\) and"
+      " 'dynamic_friction' \\(0.5\\) must have a value, or neither.");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Introduce some public API vocabulary toward implementing easier configuration of hydroelastic contact.

This (so far) is just an island and not yet integrated; future patches will connect it to SceneGraph and implement new functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21129)
<!-- Reviewable:end -->
