### PR TITLE
Disable unused dependency trackers for better performance

### DIFF
--- a/systems/framework/context.cc
+++ b/systems/framework/context.cc
@@ -154,16 +154,46 @@ std::unique_ptr<Context<T>> Context<T>::CloneWithoutPointers(
 
 template <typename T>
 void Context<T>::init_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
+  // Don't propagate notifications through variables we don't have.
+  if (xc->num_q() == 0) {
+    get_mutable_tracker(DependencyTicket(internal::kQTicket))
+        .suppress_notifications();
+  }
+  if (xc->num_v() == 0) {
+    get_mutable_tracker(DependencyTicket(internal::kVTicket))
+        .suppress_notifications();
+  }
+  if (xc->num_z() == 0) {
+    get_mutable_tracker(DependencyTicket(internal::kZTicket))
+        .suppress_notifications();
+  }
+  if (xc->size() == 0) {  // i.e. nq+nv+nz
+    get_mutable_tracker(DependencyTicket(internal::kXcTicket))
+        .suppress_notifications();
+  }
+
   do_access_mutable_state().set_continuous_state(std::move(xc));
 }
 
 template <typename T>
 void Context<T>::init_discrete_state(std::unique_ptr<DiscreteValues<T>> xd) {
+  // Don't propagate notifications through variables we don't have.
+  if (xd->num_groups() == 0) {
+    get_mutable_tracker(DependencyTicket(internal::kXdTicket))
+        .suppress_notifications();
+  }
+
   do_access_mutable_state().set_discrete_state(std::move(xd));
 }
 
 template <typename T>
 void Context<T>::init_abstract_state(std::unique_ptr<AbstractValues> xa) {
+  // Don't propagate notifications through variables we don't have.
+  if (xa->size() == 0) {
+    get_mutable_tracker(DependencyTicket(internal::kXaTicket))
+        .suppress_notifications();
+  }
+
   do_access_mutable_state().set_abstract_state(std::move(xa));
 }
 

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -542,7 +542,9 @@ class Context : public ContextBase {
   _all_ state-dependent computations so requiring out of date notifications
   to be made for all such computations. If you don't mean to change the
   whole state, use more focused methods to modify only a portion of the
-  state. See class documentation for more information. */
+  state. See class documentation for more information.
+  @warning You _must not_ use the returned reference to modify the size,
+  number, or types of state variables. */
   State<T>& get_mutable_state();
 
   /** Returns a mutable reference to the continuous component of the state,
@@ -559,7 +561,9 @@ class Context : public ContextBase {
 
   /** Returns a mutable reference to the discrete component of the state,
   which may be of size zero. Sends out of date notifications for all
-  discrete-state-dependent computations. */
+  discrete-state-dependent computations.
+  @warning You _must not_ use the returned reference to modify the size or
+  number of discrete state variables. */
   DiscreteValues<T>& get_mutable_discrete_state();
 
   /** Returns a mutable reference to the _only_ discrete state vector.
@@ -585,7 +589,9 @@ class Context : public ContextBase {
 
   /** Returns a mutable reference to the abstract component of the state,
   which may be of size zero. Sends out of date notifications for all
-  abstract-state-dependent computations. */
+  abstract-state-dependent computations.
+  @warning You _must not_ use the returned reference to modify the size,
+  number, or types of abstract state variables. */
   AbstractValues& get_mutable_abstract_state();
 
   // TODO(sherm1) Invalidate only dependents of this one abstract variable.
@@ -606,7 +612,9 @@ class Context : public ContextBase {
   date notifications for all parameter-dependent computations. If you don't
   mean to change all the parameters, use the indexed methods to modify only
   some of the parameters so that fewer computations are invalidated and
-  fewer notifications need be sent. */
+  fewer notifications need be sent.
+  @warning You _must not_ use the returned reference to modify the size,
+  number, or types of parameters. */
   Parameters<T>& get_mutable_parameters();
 
   // TODO(sherm1) Invalidate only dependents of this one parameter.

--- a/systems/framework/dependency_tracker.cc
+++ b/systems/framework/dependency_tracker.cc
@@ -26,10 +26,10 @@ void DependencyTracker::NoteValueChange(int64_t change_event) const {
   DRAKE_ASSERT(change_event > 0);
 
   ++num_value_change_notifications_received_;
-  if (last_change_event_ == change_event) {
+  if (last_change_event_ == change_event || suppress_notifications_) {
     ++num_ignored_notifications_;
     DRAKE_LOGGER_DEBUG(
-        "... ignoring repeated value change notification same change event.");
+        "... ignoring repeated or suppressed value change notification.");
     return;
   }
   last_change_event_ = change_event;
@@ -52,10 +52,10 @@ void DependencyTracker::NotePrerequisiteChange(
   DRAKE_ASSERT(HasPrerequisite(prerequisite));  // Expensive.
 
   ++num_prerequisite_notifications_received_;
-  if (last_change_event_ == change_event) {
+  if (last_change_event_ == change_event || suppress_notifications_) {
     ++num_ignored_notifications_;
     DRAKE_LOGGER_DEBUG(
-        "{}... ignoring repeated prereq change notification same change event.",
+        "{}... ignoring repeated or suppressed prereq change notification.",
         Indent(depth));
     return;
   }

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -176,6 +176,20 @@ class DependencyTracker {
     return cache_value_;
   }
 
+  /** (Internal use only) Instructs this tracker to suppress notifications to
+  downstream subscribers. This can be used by the framework during Context
+  allocation to disable built-in trackers that have nothing to track. For
+  example, if there are no q's we can improve performance and avoid spurious
+  notifications to q-subscribers like configuration_tracker by disabling q's
+  tracker. */
+  void suppress_notifications() {
+    suppress_notifications_ = true;
+  }
+
+  /** Returns true if suppress_notifications() has been called on this
+  tracker. */
+  bool notifications_are_suppressed() const { return suppress_notifications_; }
+
   /** Notifies `this` %DependencyTracker that its managed value was directly
   modified or made available for mutable access. That is, this is the
   _initiating_ event of a value modification. All of our downstream
@@ -353,6 +367,7 @@ class DependencyTracker {
       clone->cache_value_ = nullptr;
     clone->subscribers_.resize(num_subscribers(), nullptr);
     clone->prerequisites_.resize(num_prerequisites(), nullptr);
+    clone->suppress_notifications_ = suppress_notifications_;
     return clone;
   }
 
@@ -409,6 +424,8 @@ class DependencyTracker {
 
   std::vector<const DependencyTracker*> subscribers_;
   std::vector<const DependencyTracker*> prerequisites_;
+
+  bool suppress_notifications_{false};
 
   // Used for short-circuiting repeated notifications. Does not otherwise change
   // the result; hence mutable is OK. All legitimate change events must be

--- a/systems/framework/discrete_values.h
+++ b/systems/framework/discrete_values.h
@@ -76,6 +76,8 @@ class DiscreteValues {
   /// Adds an additional group that owns the given @p datum, which must be
   /// non-null. Returns the assigned group number, counting up from 0 for the
   /// first group.
+  /// @warning Do not use this method to add groups to a %DiscreteValues
+  /// object that is owned by an existing Context.
   int AppendGroup(std::unique_ptr<BasicVector<T>> datum) {
     if (datum == nullptr) {
       throw std::logic_error(

--- a/systems/framework/state.h
+++ b/systems/framework/state.h
@@ -20,9 +20,9 @@ namespace systems {
 ///
 /// A %State `x` contains three types of state variables:
 ///
-/// - ContinuousState `xc`
-/// - DiscreteState   `xd`
-/// - AbstractState   `xa`
+/// - Continuous state `xc`
+/// - Discrete state   `xd`
+/// - Abstract state   `xa`
 ///
 /// @tparam_default_scalar
 template <typename T>
@@ -34,6 +34,13 @@ class State {
   State();
   virtual ~State();
 
+  // TODO(sherm1) Consider making set_{continuous,discrete,abstract}_state()
+  //  functions private with attorney access only to make it impossible for
+  //  users to attempt resizing State within an existing Context.
+
+  /// (Advanced) Defines the continuous state variables for this %State.
+  /// @warning Do not use this function to resize continuous state in a
+  /// %State that is owned by an existing Context.
   void set_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
     DRAKE_DEMAND(xc != nullptr);
     continuous_state_ = std::move(xc);
@@ -49,6 +56,9 @@ class State {
     return *continuous_state_.get();
   }
 
+  /// (Advanced) Defines the discrete state variables for this %State.
+  /// @warning Do not use this function to resize discrete state in a
+  /// %State that is owned by an existing Context.
   void set_discrete_state(std::unique_ptr<DiscreteValues<T>> xd) {
     DRAKE_DEMAND(xd != nullptr);
     discrete_state_ = std::move(xd);
@@ -74,6 +84,9 @@ class State {
     return xd.get_mutable_vector(index);
   }
 
+  /// (Advanced) Defines the abstract state variables for this %State.
+  /// @warning Do not use this function to resize or change types of abstract
+  /// state variables in a %State that is owned by an existing Context.
   void set_abstract_state(std::unique_ptr<AbstractValues> xa) {
     DRAKE_DEMAND(xa != nullptr);
     abstract_state_ = std::move(xa);

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -138,8 +138,10 @@ class DiagramContextTest : public ::testing::Test {
   // Some tests below need to know which of the subsystems above have particular
   // resources. They use kNumSystems to identify the "parent" subsystem which
   // inherits all the resources of its children.
+  static std::set<int> has_continuous_state() { return {2, 3, kNumSystems}; }
   static std::set<int> has_discrete_state() { return {4, kNumSystems}; }
   static std::set<int> has_abstract_state() { return {5, kNumSystems}; }
+  static std::set<int> has_state() { return {2, 3, 4, 5, kNumSystems}; }
   static std::set<int> has_numeric_parameter() { return {6, kNumSystems}; }
   static std::set<int> has_abstract_parameter() { return {7, kNumSystems}; }
   static std::set<int> has_parameter() { return {6, 7, kNumSystems}; }
@@ -346,9 +348,9 @@ TEST_F(DiagramContextTest, MutableStateNotifications) {
 
   // Changing the whole state should affect all the substates.
   context_->get_mutable_state();  // Return value ignored.
-  VerifyNotifications("get_mutable_state: x",
+  VerifyNotifications("get_mutable_state: x", has_state(),
                       SystemBase::all_state_ticket(), &x_before);
-  VerifyNotifications("get_mutable_state: xc",
+  VerifyNotifications("get_mutable_state: xc", has_continuous_state(),
                       SystemBase::xc_ticket(), &xc_before);
   VerifyNotifications("get_mutable_state: xd", has_discrete_state(),
                       SystemBase::xd_ticket(), &xd_before);
@@ -357,10 +359,11 @@ TEST_F(DiagramContextTest, MutableStateNotifications) {
 
   // Changing continuous state should affect only x and xc.
   context_->get_mutable_continuous_state();  // Return value ignored.
-  VerifyNotifications("get_mutable_continuous_state: x",
+  VerifyNotifications("get_mutable_continuous_state: x", has_continuous_state(),
                       SystemBase::all_state_ticket(), &x_before);
   VerifyNotifications("get_mutable_continuous_state: xc",
-                      SystemBase::xc_ticket(), &xc_before);
+                      has_continuous_state(), SystemBase::xc_ticket(),
+                      &xc_before);
   VerifyNotifications("get_mutable_continuous_state: xd", {},  // None.
                       SystemBase::xd_ticket(), &xd_before);
   VerifyNotifications("get_mutable_continuous_state: xa", {},  // None.
@@ -368,9 +371,11 @@ TEST_F(DiagramContextTest, MutableStateNotifications) {
 
   context_->get_mutable_continuous_state_vector();  // Return value ignored.
   VerifyNotifications("get_mutable_continuous_state_vector: x",
-                      SystemBase::all_state_ticket(), &x_before);
+                      has_continuous_state(), SystemBase::all_state_ticket(),
+                      &x_before);
   VerifyNotifications("get_mutable_continuous_state_vector: xc",
-                      SystemBase::xc_ticket(), &xc_before);
+                      has_continuous_state(), SystemBase::xc_ticket(),
+                      &xc_before);
   VerifyNotifications("get_mutable_continuous_state_vector: xd", {},  // None.
                       SystemBase::xd_ticket(), &xd_before);
   VerifyNotifications("get_mutable_continuous_state_vector: xa", {},  // None.
@@ -379,9 +384,9 @@ TEST_F(DiagramContextTest, MutableStateNotifications) {
   const Eigen::Vector2d new_xc1(3.25, 5.5);
   context_->SetContinuousState(VectorX<double>(new_xc1));
   VerifyContinuousStateValue(new_xc1);
-  VerifyNotifications("SetContinuousState: x",
+  VerifyNotifications("SetContinuousState: x", has_continuous_state(),
                       SystemBase::all_state_ticket(), &x_before);
-  VerifyNotifications("SetContinuousState: xc",
+  VerifyNotifications("SetContinuousState: xc", has_continuous_state(),
                       SystemBase::xc_ticket(), &xc_before);
   VerifyNotifications("SetContinuousState: xd", {},  // None.
                       SystemBase::xd_ticket(), &xd_before);
@@ -399,9 +404,9 @@ TEST_F(DiagramContextTest, MutableStateNotifications) {
   // Make sure notifications got delivered.
   VerifyNotifications("SetTimeAndContinuousState: t",
                       SystemBase::time_ticket(), &t_before);
-  VerifyNotifications("SetTimeAndContinuousState: x",
+  VerifyNotifications("SetTimeAndContinuousState: x", has_continuous_state(),
                       SystemBase::all_state_ticket(), &x_before);
-  VerifyNotifications("SetTimeAndContinuousState: xc",
+  VerifyNotifications("SetTimeAndContinuousState: xc", has_continuous_state(),
                       SystemBase::xc_ticket(), &xc_before);
   VerifyNotifications("SetTimeAndContinuousState: xd", {},  // None.
                       SystemBase::xd_ticket(), &xd_before);
@@ -580,10 +585,11 @@ TEST_F(DiagramContextTest, MutableEverythingNotifications) {
   VerifyNotifications("SetTimeStateAndParametersFrom: pa",
                       has_abstract_parameter(),
                       SystemBase::pa_ticket(), &pa_before);
-  VerifyNotifications("SetTimeStateAndParametersFrom: x",
+  VerifyNotifications("SetTimeStateAndParametersFrom: x", has_state(),
                       SystemBase::all_state_ticket(), &x_before);
   VerifyNotifications("SetTimeStateAndParametersFrom: xc",
-                      SystemBase::xc_ticket(), &xc_before);
+                      has_continuous_state(), SystemBase::xc_ticket(),
+                      &xc_before);
   VerifyNotifications("SetTimeStateAndParametersFrom: xd", has_discrete_state(),
                       SystemBase::xd_ticket(), &xd_before);
   VerifyNotifications("SetTimeStateAndParametersFrom: xa", has_abstract_state(),


### PR DESCRIPTION
This PR prevents "out of date" notifications for state variable changes from being propagated in systems that don't have the requisite state variables.

There are just two changes:
- We add a "suppress_notifications" flag to DependencyTracker that prevents further propagation of notifications to subscribers
- At Context allocation, we suppress notifications from dependency trackers for non-existent state variables.

This prevents, for example, a "continuous state variables changed" notification from affecting configuration_ticket in a system that has only discrete state variables (as is commonly the case for MultibodyPlant).

The diagram_context_test & dependency_tracker_test are updated to reflect the new expectations for notification propagation.
The cache implementation document is updated to reflect the change.

Fixes #21133

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21134)
<!-- Reviewable:end -->
