### PR TITLE
Unwrap gcs trajs with continous revolute joints to continous Euclidean space

### DIFF
--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -173,10 +173,10 @@ drake_cc_googletest(
     name = "gcs_trajectory_optimization_test",
     deps = [
         ":gcs_trajectory_optimization",
-        "//common/trajectories:piecewise_polynomial",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+        "//common/trajectories:piecewise_polynomial",
         "//solvers:gurobi_solver",
         "//solvers:mosek_solver",
     ],

--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -173,6 +173,7 @@ drake_cc_googletest(
     name = "gcs_trajectory_optimization_test",
     deps = [
         ":gcs_trajectory_optimization",
+        "//common/trajectories:piecewise_polynomial",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -1158,7 +1158,8 @@ GcsTrajectoryOptimization::NormalizeSegmentTimes(
       start_time += 1.0;
     } else {
       throw std::runtime_error(
-          "All segments in the gcs trajectory must be of type "
+          "NormalizeSegmentTimes: All segments in the gcs trajectory "
+          "must be of type "
           "BezierCurve<double>.");
     }
   }
@@ -1202,7 +1203,8 @@ GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
         dynamic_cast<const BezierCurve<double>*>(&traj_segment);
     if (bezier_segment == nullptr) {
       throw std::runtime_error(
-          "All segments in the gcs_trajectory must be of type "
+          "UnwrapToContinuousTrajectory: All segments in the gcs_trajectory "
+          "must be of type "
           "BezierCurve<double>.");
     }
     Eigen::MatrixXd new_control_points = bezier_segment->control_points();

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -1158,7 +1158,8 @@ GcsTrajectoryOptimization::NormalizeSegmentTimes(
       start_time += 1.0;
     } else {
       throw std::runtime_error(
-          "All segments must be of type BezierCurve<double>.");
+          "All segments in the gcs trajectory must be of type "
+          "BezierCurve<double>.");
     }
   }
   return CompositeTrajectory<double>(normalized_bezier_curves);
@@ -1170,22 +1171,24 @@ bool IsMultipleOf2Pi(double value) {
 }
 
 // Unwrap the angle to the range [2π * round, 2π * (round+1)).
-double UnWrapAngle(const double angle, const int round) {
+double UnwrapAngle(const double angle, const int round) {
   return (round - std::floor(angle / (2 * M_PI))) * 2 * M_PI + angle;
 }
 }  // namespace
 
 trajectories::CompositeTrajectory<double>
-GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
     const trajectories::CompositeTrajectory<double>& gcs_trajectory,
     std::vector<int> continuous_revolute_joints,
     std::optional<std::vector<int>> starting_rounds) {
-  DRAKE_THROW_UNLESS(gcs_trajectory.get_number_of_segments() > 0);
   if (starting_rounds.has_value()) {
     DRAKE_THROW_UNLESS(starting_rounds->size() ==
                        continuous_revolute_joints.size());
   }
   std::vector<copyable_unique_ptr<Trajectory<double>>> unwrapped_trajectories;
+  int dim = gcs_trajectory.rows();
+  geometry::optimization::internal::ThrowsForInvalidContinuousJointsList(
+      dim, continuous_revolute_joints);
   Eigen::VectorXd last_segment_finish;
   for (int i = 0; i < gcs_trajectory.get_number_of_segments(); ++i) {
     const auto& traj_segment = gcs_trajectory.segment(i);
@@ -1207,15 +1210,16 @@ GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
         for (int j = 0; j < ssize(continuous_revolute_joints); ++j) {
           const int joint_index = continuous_revolute_joints.at(j);
           const int start_round = starting_rounds->at(j);
-          // This value will be subtracted from the old_start to get the shift.
+          // This value will be subtracted from the old_start to get the
+          // shift.
           const double joint_shift =
               old_start(joint_index) -
-              UnWrapAngle(old_start(joint_index), start_round);
+              UnwrapAngle(old_start(joint_index), start_round);
           DRAKE_DEMAND(IsMultipleOf2Pi(joint_shift));
           shift.push_back(joint_shift);
         }
       } else {
-        shift.push_back(0.0);
+        shift = std::vector<double>(ssize(continuous_revolute_joints), 0);
       }
     } else {
       DRAKE_DEMAND(last_segment_finish.rows() == gcs_trajectory.rows());
@@ -1236,7 +1240,7 @@ GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
       const int joint_index = continuous_revolute_joints[j];
       // Shift all the columns of the control points by the shift.
       new_control_points.row(joint_index) -=
-          Eigen::VectorXd::Constant(old_control_points.cols(), shift[j]);
+          Eigen::VectorXd::Constant(old_control_points.cols(), shift.at(j));
     }
     last_segment_finish = new_control_points.rightCols(1);
     unwrapped_trajectories.emplace_back(std::make_unique<BezierCurve<double>>(
@@ -1262,9 +1266,9 @@ std::vector<int> GetContinuousRevoluteJointIndices(
       }
       continue;
     }
-    // The second possibility we check for is a planar joint. If it is (and the
-    // angle component has no joint limits), we only add the third entry of the
-    // position vector, corresponding to theta.
+    // The second possibility we check for is a planar joint. If it is (and
+    // the angle component has no joint limits), we only add the third entry
+    // of the position vector, corresponding to theta.
     if (joint.type_name() == "planar") {
       if (joint.position_lower_limits()[2] ==
               -std::numeric_limits<float>::infinity() &&
@@ -1274,8 +1278,8 @@ std::vector<int> GetContinuousRevoluteJointIndices(
       }
       continue;
     }
-    // TODO(cohnt): Determine if other joint types (e.g. UniversalJoint) can be
-    // handled appropriately with wraparound edges, and if so, return their
+    // TODO(cohnt): Determine if other joint types (e.g. UniversalJoint) can
+    // be handled appropriately with wraparound edges, and if so, return their
     // indices as well.
   }
   return indices;

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -607,6 +607,37 @@ class GcsTrajectoryOptimization final {
   static trajectories::CompositeTrajectory<double> NormalizeSegmentTimes(
       const trajectories::CompositeTrajectory<double>& trajectory);
 
+  /** Unwraps a trajectory with continuous revolute joints into a continuous
+   trajectory in the Euclidean space. It gets rid of the integer multiples of 2π
+   on the continuous revolute joints between the segments that correspond to the
+   edge offsets between gcs regions. This is useful in finding a trajectory that
+   can be commanded to a robot with continuous revolute joints.
+   @param gcs_trajectory The trajectory to unwrap.
+   @param continuous_revolute_joints The indices of the continuous revolute
+   joints.
+   @param starting_rounds A vector of integers that sets the starting rounds for
+   each continuous revolute joint. Given integer k, the initial position of the
+   corresponding joint will be wrapped into [2kπ, 2(k+1)π). If the starting
+   rounds are not set, the unwrapping will start from the initial position of
+   the @p trajectory.
+
+   @returns an unwrapped (continous in Euclidean space) CompositeTrajectory.
+
+   @throws std::exception if
+   starting_rounds.size()!=continuous_revolute_joints.size().
+   @throws std::exception if the gcs_trajectory is not continous on the manifold
+   defined by the continuous_revolute_joints, i.e., the shift between two
+   consecutive segments is not an integer multiple of 2π.
+   @throws std::exception if all the segments are not of type BezierCurve.
+   Other types are not supported yet. Note that currently the output of
+   GcsTrajectoryOptimization::SolvePath() is a CompositeTrajectory of
+   BezierCurves.
+    */
+  static trajectories::CompositeTrajectory<double> UnWrapToContinousTrajectory(
+      const trajectories::CompositeTrajectory<double>& gcs_trajectory,
+      std::vector<int> continuous_revolute_joints,
+      std::optional<std::vector<int>> starting_rounds = std::nullopt);
+
  private:
   const int num_positions_;
   const std::vector<int> continuous_revolute_joints_;

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -608,10 +608,14 @@ class GcsTrajectoryOptimization final {
       const trajectories::CompositeTrajectory<double>& trajectory);
 
   /** Unwraps a trajectory with continuous revolute joints into a continuous
-   trajectory in the Euclidean space. It gets rid of the integer multiples of 2π
-   on the continuous revolute joints between the segments that correspond to the
-   edge offsets between gcs regions. This is useful in finding a trajectory that
-   can be commanded to a robot with continuous revolute joints.
+   trajectory in the Euclidean space. Trajectories produced by
+   GcsTrajectoryOptimization for robotic systems with continuous revolute joints
+   may include apparent discontinuities, where a multiple of 2π is
+   instantaneously added to a joint value at the boundary between two adjacent
+   segments of the trajectory. This function removes such discontinuities by
+   adding or subtracting the appropriate multiple of 2π, "unwrapping" the
+   trajectory into a continuous representation suitable for downstream tasks
+   that do not take the joint wraparound into account.
    @param gcs_trajectory The trajectory to unwrap.
    @param continuous_revolute_joints The indices of the continuous revolute
    joints.
@@ -625,6 +629,8 @@ class GcsTrajectoryOptimization final {
 
    @throws std::exception if
    starting_rounds.size()!=continuous_revolute_joints.size().
+   @throws std::exception if continuous_revolute_joints contain repeated indices
+   and/or indices outside the range [0, gcs_trajectory.rows()).
    @throws std::exception if the gcs_trajectory is not continous on the manifold
    defined by the continuous_revolute_joints, i.e., the shift between two
    consecutive segments is not an integer multiple of 2π.
@@ -633,7 +639,7 @@ class GcsTrajectoryOptimization final {
    GcsTrajectoryOptimization::SolvePath() is a CompositeTrajectory of
    BezierCurves.
     */
-  static trajectories::CompositeTrajectory<double> UnWrapToContinousTrajectory(
+  static trajectories::CompositeTrajectory<double> UnwrapToContinousTrajectory(
       const trajectories::CompositeTrajectory<double>& gcs_trajectory,
       std::vector<int> continuous_revolute_joints,
       std::optional<std::vector<int>> starting_rounds = std::nullopt);

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -620,10 +620,10 @@ class GcsTrajectoryOptimization final {
    @param continuous_revolute_joints The indices of the continuous revolute
    joints.
    @param starting_rounds A vector of integers that sets the starting rounds for
-   each continuous revolute joint. Given integer k, the initial position of the
-   corresponding joint will be wrapped into [2kπ, 2(k+1)π). If the starting
-   rounds are not set, the unwrapping will start from the initial position of
-   the @p trajectory.
+   each continuous revolute joint. Given integer k for the starting_round of a
+   joint, its initial position will be wrapped into [2πk , 2π(k+1)). If the
+   starting rounds are not provided, the initial position of @p trajectory will
+   be unchanged.
 
    @returns an unwrapped (continous in Euclidean space) CompositeTrajectory.
 
@@ -631,9 +631,10 @@ class GcsTrajectoryOptimization final {
    starting_rounds.size()!=continuous_revolute_joints.size().
    @throws std::exception if continuous_revolute_joints contain repeated indices
    and/or indices outside the range [0, gcs_trajectory.rows()).
-   @throws std::exception if the gcs_trajectory is not continous on the manifold
-   defined by the continuous_revolute_joints, i.e., the shift between two
-   consecutive segments is not an integer multiple of 2π.
+   @throws std::exception if the gcs_trajectory is not continuous on the
+   manifold defined by the continuous_revolute_joints, i.e., the shift between
+   two consecutive segments is not an integer multiple of 2π (within a tolerance
+   of 1e-10 radians).
    @throws std::exception if all the segments are not of type BezierCurve.
    Other types are not supported yet. Note that currently the output of
    GcsTrajectoryOptimization::SolvePath() is a CompositeTrajectory of

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -860,7 +860,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidSubspace) {
       "Subspace must be a Point or HPolyhedron.");
 }
 
-GTEST_TEST(GcsTrajectoryOptimizationTest, UnWrapToContinousTrajectory) {
+GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
   std::vector<copyable_unique_ptr<trajectories::Trajectory<double>>> segments;
   Eigen::MatrixXd control_points_1(3, 3), control_points_2(3, 3),
       control_points_3(3, 3);
@@ -884,7 +884,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnWrapToContinousTrajectory) {
   const auto traj = trajectories::CompositeTrajectory<double>(segments);
   std::vector<int> continuous_revolute_joints = {1, 2};
   const auto unwrapped_traj =
-      GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
           traj, continuous_revolute_joints);
   const double eps = 1e-8;
   double middle_time_1 = unwrapped_traj.get_segment_times()[1];
@@ -898,7 +898,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnWrapToContinousTrajectory) {
                               unwrapped_traj.value(middle_time_2 + eps), 1e-6));
   std::vector<int> start_rounds = {-1, 0};
   const auto unwrapped_traj_with_start =
-      GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
           traj, continuous_revolute_joints, start_rounds);
   // Check if the start is unwrapped to the correct value.
   EXPECT_TRUE(CompareMatrices(unwrapped_traj_with_start.value(0.0),
@@ -911,7 +911,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnWrapToContinousTrajectory) {
       unwrapped_traj_with_start.value(middle_time_2 + eps), 1e-6));
   // Check for invalid start_rounds
   const std::vector<int> invalid_start_rounds = {-1, 0, 1};
-  EXPECT_THROW(GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+  EXPECT_THROW(GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
                    traj, continuous_revolute_joints, invalid_start_rounds),
                std::runtime_error);
   // Check for discontinuity for continuous revolute joints
@@ -926,13 +926,14 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnWrapToContinousTrajectory) {
   // unwrapping will fail.
   continuous_revolute_joints = {0, 1};
   DRAKE_EXPECT_THROWS_MESSAGE(
-      GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
           traj_not_continous_on_revolute_manifold, continuous_revolute_joints),
       ".*is not a multiple of 2π at segment.*");
 }
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, NotBezierCurveError) {
   std::vector<copyable_unique_ptr<trajectories::Trajectory<double>>> segments;
+  auto empty_traj = trajectories::CompositeTrajectory<double>(segments);
   auto traj_1 = trajectories::PiecewisePolynomial<double>::FirstOrderHold(
       std::vector<double>{0, 1},
       std::vector<Eigen::MatrixXd>{Eigen::MatrixXd::Zero(1, 2),
@@ -944,9 +945,9 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, NotBezierCurveError) {
   segments.emplace_back(traj_1.Clone());
   segments.emplace_back(traj_2.Clone());
   const auto traj = trajectories::CompositeTrajectory<double>(segments);
-  std::vector<int> continuous_revolute_joints = {1};
+  std::vector<int> continuous_revolute_joints = {0};
   DRAKE_EXPECT_THROWS_MESSAGE(
-      GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
           traj, continuous_revolute_joints),
       ".*BezierCurve<double>.*");
 }

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -6,6 +6,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/geometry/optimization/geodesic_convexity.h"
 #include "drake/geometry/optimization/graph_of_convex_sets.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
@@ -857,6 +858,97 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidSubspace) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       gcs.AddEdges(regions1, regions2, &vertices_subspace),
       "Subspace must be a Point or HPolyhedron.");
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, UnWrapToContinousTrajectory) {
+  std::vector<copyable_unique_ptr<trajectories::Trajectory<double>>> segments;
+  Eigen::MatrixXd control_points_1(3, 3), control_points_2(3, 3),
+      control_points_3(3, 3);
+  // clang-format off
+  control_points_1 << 0, 1.0, 2.0,
+                      1.0 - 8 * M_PI, 2.0 - 8 * M_PI, 3.0 - 8 * M_PI,
+                      2.0 + 4 * M_PI, 1.0 + 4 * M_PI, 4.0 + 4 * M_PI;
+  control_points_2 << 2.0 , 2.5, 4.0,
+                      3.0 + 2 * M_PI, 1.0 + 2 * M_PI, 0.0 + 2 * M_PI,
+                      4.0 - 6 * M_PI, 3.0 - 6 * M_PI, 2.0 - 6 * M_PI;
+  control_points_3 << 4.0, -2.0, 0.0,
+                      0.0, 1.0, 2.0,
+                      2.0, 3.0, 4.0;
+  // clang-format on
+  segments.emplace_back(std::make_unique<trajectories::BezierCurve<double>>(
+      0.0, 1.0, control_points_1));
+  segments.emplace_back(std::make_unique<trajectories::BezierCurve<double>>(
+      1.0, 4.0, control_points_2));
+  segments.emplace_back(std::make_unique<trajectories::BezierCurve<double>>(
+      4.0, 6.0, control_points_3));
+  const auto traj = trajectories::CompositeTrajectory<double>(segments);
+  std::vector<int> continuous_revolute_joints = {1, 2};
+  const auto unwrapped_traj =
+      GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+          traj, continuous_revolute_joints);
+  const double eps = 1e-8;
+  double middle_time_1 = unwrapped_traj.get_segment_times()[1];
+  double middle_time_2 = unwrapped_traj.get_segment_times()[2];
+  EXPECT_NEAR(middle_time_1, 1.0, eps);
+  EXPECT_NEAR(middle_time_2, 4.0, eps);
+  // Verify the unwrapped trajectory is continous at the middle times.
+  EXPECT_TRUE(CompareMatrices(unwrapped_traj.value(middle_time_1 - eps),
+                              unwrapped_traj.value(middle_time_1 + eps), 1e-6));
+  EXPECT_TRUE(CompareMatrices(unwrapped_traj.value(middle_time_2 - eps),
+                              unwrapped_traj.value(middle_time_2 + eps), 1e-6));
+  std::vector<int> start_rounds = {-1, 0};
+  const auto unwrapped_traj_with_start =
+      GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+          traj, continuous_revolute_joints, start_rounds);
+  // Check if the start is unwrapped to the correct value.
+  EXPECT_TRUE(CompareMatrices(unwrapped_traj_with_start.value(0.0),
+                              Eigen::Vector3d{0.0, 1.0 - 2 * M_PI, 2.0}, eps));
+  EXPECT_TRUE(CompareMatrices(
+      unwrapped_traj_with_start.value(middle_time_1 - eps),
+      unwrapped_traj_with_start.value(middle_time_1 + eps), 1e-6));
+  EXPECT_TRUE(CompareMatrices(
+      unwrapped_traj_with_start.value(middle_time_2 - eps),
+      unwrapped_traj_with_start.value(middle_time_2 + eps), 1e-6));
+  // Check for invalid start_rounds
+  const std::vector<int> invalid_start_rounds = {-1, 0, 1};
+  EXPECT_THROW(GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+                   traj, continuous_revolute_joints, invalid_start_rounds),
+               std::runtime_error);
+  // Check for discontinuity for continuous revolute joints
+  control_points_2 << 2.5, 2.5, 4.0, 3.0 + 2 * M_PI, 1.0 + 2 * M_PI,
+      0.0 + 2 * M_PI, 4.0 - 6 * M_PI, 3.0 - 6 * M_PI, 2.0 - 6 * M_PI;
+  segments[1] = std::make_unique<trajectories::BezierCurve<double>>(
+      1.0, 4.0, control_points_2);
+  const auto traj_not_continous_on_revolute_manifold =
+      trajectories::CompositeTrajectory<double>(segments);
+  // For joint 0, the trajectory is not continous: 2.0 (end of segment 0)--> 2.5
+  // (start of segment 1). If we treat joint 0 as continous revolute joint, the
+  // unwrapping will fail.
+  continuous_revolute_joints = {0, 1};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+          traj_not_continous_on_revolute_manifold, continuous_revolute_joints),
+      ".*is not a multiple of 2π at segment.*");
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, NotBezierCurveError) {
+  std::vector<copyable_unique_ptr<trajectories::Trajectory<double>>> segments;
+  auto traj_1 = trajectories::PiecewisePolynomial<double>::FirstOrderHold(
+      std::vector<double>{0, 1},
+      std::vector<Eigen::MatrixXd>{Eigen::MatrixXd::Zero(1, 2),
+                                   Eigen::MatrixXd::Ones(1, 2)});
+  auto traj_2 = trajectories::PiecewisePolynomial<double>::FirstOrderHold(
+      std::vector<double>{1, 2},
+      std::vector<Eigen::MatrixXd>{Eigen::MatrixXd::Zero(1, 2),
+                                   Eigen::MatrixXd::Ones(1, 2)});
+  segments.emplace_back(traj_1.Clone());
+  segments.emplace_back(traj_2.Clone());
+  const auto traj = trajectories::CompositeTrajectory<double>(segments);
+  std::vector<int> continuous_revolute_joints = {1};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      GcsTrajectoryOptimization::UnWrapToContinousTrajectory(
+          traj, continuous_revolute_joints),
+      ".*BezierCurve<double>.*");
 }
 
 /* This 2D environment has been presented in the GCS paper.

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -933,7 +933,6 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, NotBezierCurveError) {
   std::vector<copyable_unique_ptr<trajectories::Trajectory<double>>> segments;
-  auto empty_traj = trajectories::CompositeTrajectory<double>(segments);
   auto traj_1 = trajectories::PiecewisePolynomial<double>::FirstOrderHold(
       std::vector<double>{0, 1},
       std::vector<Eigen::MatrixXd>{Eigen::MatrixXd::Zero(1, 2),


### PR DESCRIPTION
GCS trajectories that are calculated from `GcsTrajectoryOptimization` with fully revolute joints are not continous in Euclidean space - they may have integer multiples of 2π jumps across the segments. We want continous trajectories in Euclidean space so we can, for example, send them to a robot driver.

This PR features a new static method `GcsTrajectoryOptimization::UnWrapToContinousTrajectory` with unit tests.

Example:
![image](https://github.com/RobotLocomotion/drake/assets/26656757/d9e6ceda-b0ed-4909-8e69-1e30f6639c7d)

+@cohnt for feature review

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21137)
<!-- Reviewable:end -->
