### PR TITLE
[multibody] Fill in more LinkJointGraph functionality

### DIFF
--- a/multibody/topology/BUILD.bazel
+++ b/multibody/topology/BUILD.bazel
@@ -46,6 +46,7 @@ drake_cc_library(
         "link_joint_graph_inlines.h",
         "link_joint_graph_joint.h",
         "link_joint_graph_link.h",
+        "link_joint_graph_loop_constraint.h",
         "spanning_forest.h",
     ],
     deps = [
@@ -56,6 +57,14 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "link_joint_graph_test",
+    deps = [
+        ":multibody_topology",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "spanning_forest_test",
     deps = [
         ":multibody_topology",
         "//common/test_utilities:expect_throws_message",

--- a/multibody/topology/graph.h
+++ b/multibody/topology/graph.h
@@ -13,6 +13,7 @@ reasonable. */
 // clang-format off
 #include "drake/multibody/topology/link_joint_graph.h"
 #include "drake/multibody/topology/link_joint_graph_link.h"
+#include "drake/multibody/topology/link_joint_graph_loop_constraint.h"
 #include "drake/multibody/topology/link_joint_graph_joint.h"
 #include "drake/multibody/topology/link_joint_graph_inlines.h"
 // clang-format on

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -15,6 +15,7 @@ class SpanningForest;
 
 using JointTypeIndex = TypeSafeIndex<class JointTypeTag>;
 using LinkCompositeIndex = TypeSafeIndex<class LinkCompositeTag>;
+using LoopConstraintIndex = TypeSafeIndex<class LoopConstraintTag>;
 
 /** Link properties that can affect how the forest model gets built. Or-ing
 these also produces a LinkFlags object. */

--- a/multibody/topology/link_joint_graph_inlines.h
+++ b/multibody/topology/link_joint_graph_inlines.h
@@ -15,11 +15,35 @@ inline auto LinkJointGraph::links(BodyIndex link_index) const -> const Link& {
   return links().at(link_index);
 }
 
+inline auto LinkJointGraph::mutable_link(BodyIndex link_index) -> Link& {
+  return data_.links.at(link_index);
+}
+
+inline MobodIndex LinkJointGraph::link_to_mobod(BodyIndex index) const {
+  return links(index).mobod_;
+}
+
+inline void LinkJointGraph::set_primary_mobod_for_link(
+    BodyIndex link_index, MobodIndex primary_mobod_index,
+    JointIndex primary_joint_index) {
+  Link& link = mutable_link(link_index);
+  DRAKE_DEMAND(!link.mobod_.is_valid());
+  link.mobod_ = primary_mobod_index;
+  link.joint_ = primary_joint_index;
+}
+
 // LinkJointGraph definitions deferred until Joint defined.
 
 inline auto LinkJointGraph::joints(JointIndex joint_index) const
     -> const Joint& {
   return joints().at(joint_index);
+}
+
+// LinkJointGraph definitions deferred until LoopConstraint defined.
+
+inline auto LinkJointGraph::loop_constraints(
+    LoopConstraintIndex loop_constraint_index) const -> const LoopConstraint& {
+  return loop_constraints().at(loop_constraint_index);
 }
 
 }  // namespace internal

--- a/multibody/topology/link_joint_graph_joint.h
+++ b/multibody/topology/link_joint_graph_joint.h
@@ -127,7 +127,6 @@ class LinkJointGraph::Joint {
   // Meaning of the variants:
   // - monostate: not yet processed
   // - MobodIndex: modeled directly by a mobilizer
-  // - ConstraintIndex: modeled as a constraint (TBD)
   // - LinkCompositeIndex: not modeled because this is a weld interior to
   //     the indicated composite and we are combining so that one Mobod serves
   //     the whole composite.

--- a/multibody/topology/link_joint_graph_link.h
+++ b/multibody/topology/link_joint_graph_link.h
@@ -47,6 +47,11 @@ class LinkJointGraph::Link {
     return joints_as_child_;
   }
 
+  /** Returns indexes of all the LoopConstraints that connect to this %Link. */
+  const std::vector<LoopConstraintIndex>& loop_constraints() const {
+    return loop_constraints_;
+  }
+
   /** Returns `true` only if this is the World %Link. Static Links and Links
   in the World Composite are not included; see is_anchored() if you want to
   include everything that is fixed with respect to World. */
@@ -139,7 +144,12 @@ class LinkJointGraph::Link {
     joints_.push_back(joint);
   }
 
+  void add_loop_constraint(LoopConstraintIndex constraint) {
+    loop_constraints_.push_back(constraint);
+  }
+
   void clear_model(int num_user_joints) {
+    loop_constraints_.clear();
     mobod_ = {};
     joint_ = {};
     primary_link_ = {};
@@ -170,6 +180,8 @@ class LinkJointGraph::Link {
   std::vector<JointIndex> joints_as_parent_;
   std::vector<JointIndex> joints_as_child_;
   std::vector<JointIndex> joints_;  // All joints whether as parent or child.
+
+  std::vector<LoopConstraintIndex> loop_constraints_;
 
   MobodIndex mobod_;  // Which Mobod mobilizes this Link?
   JointIndex joint_;  // Which Joint connected us to the Mobod?

--- a/multibody/topology/link_joint_graph_loop_constraint.h
+++ b/multibody/topology/link_joint_graph_loop_constraint.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#ifndef DRAKE_MULTIBODY_TOPOLOGY_GRAPH_INCLUDED
+#error Do not include this file. Use "drake/multibody/topology/graph.h".
+#endif
+
+#include <string>
+
+namespace drake {
+namespace multibody {
+// TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
+namespace internal {
+
+/** A weld constraint used to close a topological loop (cycle) in the input
+graph after modeling as a forest. The parent/child ordering sets the sign
+convention for the constraint multipliers. Added welds between a primary %Link
+and one of its shadow Links always make the primary %Link the parent. */
+class LinkJointGraph::LoopConstraint {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LoopConstraint)
+
+  LoopConstraint(LoopConstraintIndex index, std::string name,
+                 ModelInstanceIndex model_instance,
+                 BodyIndex primary_link_index, BodyIndex shadow_link_index)
+      : index_(index),
+        name_(name),
+        model_instance_(model_instance),
+        primary_link_index_(primary_link_index),
+        shadow_link_index_(shadow_link_index) {}
+
+  LoopConstraintIndex index() const { return index_; }
+
+  ModelInstanceIndex model_instance() const { return model_instance_; }
+
+  const std::string& name() const { return name_; }
+
+  BodyIndex primary_link() const { return primary_link_index_; }
+  BodyIndex shadow_link() const { return shadow_link_index_; }
+
+ private:
+  LoopConstraintIndex index_;
+  std::string name_;
+  ModelInstanceIndex model_instance_;
+  BodyIndex primary_link_index_;
+  BodyIndex shadow_link_index_;
+
+  // TODO(sherm1) Record the ephemeral MultibodyPlant Constraint here, e.g.:
+  //  MultibodyConstraintId plant_constraint_id_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -52,6 +52,13 @@ void SpanningForest::Clear() {
 // TODO(sherm1) Just a stub for now.
 void SpanningForest::BuildForest() {
   Clear();  // In case we're reusing this forest.
+
+  // Model the World (Link 0) with mobilized body 0. This also starts the
+  // 0th Link Composite in the graph.
+  // TODO(sherm1) No Mobods here yet.
+  data_.graph->set_primary_mobod_for_link(BodyIndex(0), MobodIndex(0),
+                                          JointIndex{});
+  data_.graph->CreateWorldLinkComposite();
 }
 
 SpanningForest::Data::Data() = default;

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -21,8 +21,7 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-using WeldedMobodsIndex = TypeSafeIndex<class CompositeMobodTag>;
-using LoopConstraintIndex = TypeSafeIndex<class LoopConstraintTag>;
+using WeldedMobodsIndex = TypeSafeIndex<class WeldedMobodsTag>;
 
 /** SpanningForest models a LinkJointGraph via a set of spanning trees and
 loop-closing constraints. */

--- a/multibody/topology/test/link_joint_graph_test.cc
+++ b/multibody/topology/test/link_joint_graph_test.cc
@@ -4,14 +4,25 @@
 
 #include <string>
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
-#include "drake/multibody/topology/forest.h"
+
+// Tests here are limited to those that can be done without a definition
+// for the SpanningForest class which is only forward declared. (We can still
+// build a forest here and see its effects on the LinkJointGraph, but we
+// can't look into the forest.) See spanning_forest_test.cc for
+// tests that require looking at the SpanningForest details.
 
 namespace drake {
 namespace multibody {
 namespace internal {
+
+using std::pair;
+
+// Built-in joint types are "weld", "quaternion_floating", "rpy_floating".
+// We'll register other types in some of the tests below.
 
 // This class is a friend of subclasses that have private constructors and
 // member functions so that we can test those APIs standalone.
@@ -42,6 +53,13 @@ class LinkJointGraphTester {
   static JointFlags set_joint_flags(JointFlags to_set,
                                     LinkJointGraph::Joint* joint) {
     return joint->set_flags(to_set);
+  }
+
+  static LoopConstraintIndex AddLoopClosingWeldConstraint(
+      BodyIndex primary_link_index, BodyIndex shadow_link_index,
+      LinkJointGraph* graph) {
+    return graph->AddLoopClosingWeldConstraint(primary_link_index,
+                                               shadow_link_index);
   }
 
   static std::vector<BodyIndex> static_links(const LinkJointGraph& graph) {
@@ -146,10 +164,9 @@ GTEST_TEST(LinkJointGraph, CopyMoveAssignTest) {
 
   // These first checks don't use copy/move/assign but are here to make it
   // clear what we have before we start with those.
-  EXPECT_EQ(&graph.forest().graph(), &graph);
-  EXPECT_FALSE(graph.forest_is_valid() || graph.forest().is_valid());
+  EXPECT_FALSE(graph.forest_is_valid());
   graph.BuildForest();
-  EXPECT_TRUE(graph.forest_is_valid() && graph.forest().is_valid());
+  EXPECT_TRUE(graph.forest_is_valid());
   graph.AddLink("link1", ModelInstanceIndex(19));  // Should invalidate forest.
   EXPECT_FALSE(graph.forest_is_valid());
   graph.BuildForest();  // Update the forest.
@@ -176,7 +193,6 @@ GTEST_TEST(LinkJointGraph, CopyMoveAssignTest) {
   EXPECT_TRUE(graph_copy.HasLinkNamed("link1", ModelInstanceIndex(19)));
   EXPECT_TRUE(graph_copy.forest_is_valid());
   EXPECT_NE(graph_copy_forest_ptr, original_graph_forest_ptr);
-  EXPECT_EQ(&graph_copy.forest().graph(), &graph_copy);
   EXPECT_NE(&graph_copy.links()[1], &original_link1);
 
   LinkJointGraph graph_assign;
@@ -184,7 +200,6 @@ GTEST_TEST(LinkJointGraph, CopyMoveAssignTest) {
   EXPECT_TRUE(graph_assign.HasLinkNamed("link1", ModelInstanceIndex(19)));
   EXPECT_TRUE(graph_assign.forest_is_valid());
   EXPECT_NE(&graph_assign.forest(), &graph.forest());
-  EXPECT_EQ(&graph_assign.forest().graph(), &graph_assign);
   EXPECT_NE(&graph_assign.links()[1], &original_link1);
 
   EXPECT_TRUE(graph.forest_is_valid());  // Unchanged by assign-from.
@@ -218,7 +233,7 @@ GTEST_TEST(LinkJointGraph, CopyMoveAssignTest) {
 // A default-constructed LinkJointGraph should contain a predefined World
 // Link, predefined joint types, and be suitable for generating a matching
 // SpanningForest.
-GTEST_TEST(LinkJointGraph, EmptyTest) {
+GTEST_TEST(LinkJointGraph, WorldOnlyTest) {
   LinkJointGraph graph;
 
   // World is predefined.
@@ -226,45 +241,58 @@ GTEST_TEST(LinkJointGraph, EmptyTest) {
   EXPECT_TRUE(graph.joints().empty());
   EXPECT_EQ(graph.world_link().name(), "world");
   EXPECT_EQ(graph.world_link().model_instance(), world_model_instance());
-  EXPECT_EQ(graph.world_link().index(), BodyIndex(0));
+  const BodyIndex world_link_index = graph.world_link().index();
+  EXPECT_EQ(world_link_index, BodyIndex(0));
 
   // Topologically important joint types are predefined.
   EXPECT_EQ(ssize(graph.joint_types()), 3);
   const LinkJointGraph::JointType& weld_type =
       graph.joint_types(LinkJointGraph::weld_joint_type_index());
-  EXPECT_EQ(weld_type.type_name, "weld");
+  EXPECT_EQ(weld_type.name, "weld");
   EXPECT_EQ(weld_type.nq, 0);
   EXPECT_EQ(weld_type.nv, 0);
   EXPECT_EQ(weld_type.has_quaternion, false);
   const LinkJointGraph::JointType& quaternion_floating_type =
       graph.joint_types(LinkJointGraph::quaternion_floating_joint_type_index());
-  EXPECT_EQ(quaternion_floating_type.type_name, "quaternion_floating");
+  EXPECT_EQ(quaternion_floating_type.name, "quaternion_floating");
   EXPECT_EQ(quaternion_floating_type.nq, 7);
   EXPECT_EQ(quaternion_floating_type.nv, 6);
   EXPECT_EQ(quaternion_floating_type.has_quaternion, true);
   const LinkJointGraph::JointType& rpy_floating_type =
       graph.joint_types(LinkJointGraph::rpy_floating_joint_type_index());
-  EXPECT_EQ(rpy_floating_type.type_name, "rpy_floating");
+  EXPECT_EQ(rpy_floating_type.name, "rpy_floating");
   EXPECT_EQ(rpy_floating_type.nq, 6);
   EXPECT_EQ(rpy_floating_type.nv, 6);
   EXPECT_EQ(rpy_floating_type.has_quaternion, false);
 
   EXPECT_FALSE(graph.forest_is_valid());
 
+  // With no forest built, there are no composites.
+  EXPECT_TRUE(graph.link_composites().empty());
+
   graph.BuildForest();
   const SpanningForest& forest = graph.forest();
-  EXPECT_EQ(&forest.graph(), &graph);
   EXPECT_TRUE(graph.forest_is_valid());
+
+  // With the forest built, we can access more information about the graph.
+  // "Find" and "Get" methods require that the forest is valid.
+  EXPECT_TRUE(graph.world_link().is_anchored());
+  EXPECT_EQ(graph.link_to_mobod(world_link_index), MobodIndex(0));
+  EXPECT_EQ(ssize(graph.link_composites()), 1);
+  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0))), 1);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0))[0], world_link_index);
 
   // Check that Clear() puts the graph back to default-constructed condition.
   // First add some junk to the graph.
   graph.RegisterJointType("revolute", 1, 1);
   const BodyIndex dummy_index =
       graph.AddLink("dummy", default_model_instance());
+  graph.AddJoint("joint0", default_model_instance(), "revolute", world_index(),
+                 dummy_index);
   EXPECT_TRUE(graph.HasLinkNamed("dummy", default_model_instance()));
   EXPECT_EQ(dummy_index, BodyIndex(1));
   EXPECT_EQ(ssize(graph.links()), 2);
-  EXPECT_EQ(ssize(graph.joints()), 0);
+  EXPECT_EQ(ssize(graph.joints()), 1);
   EXPECT_EQ(ssize(graph.joint_types()), 4);
   // Now get rid of that junk.
   graph.Clear();
@@ -276,7 +304,6 @@ GTEST_TEST(LinkJointGraph, EmptyTest) {
   // Make sure Clear() saved the existing forest.
   const SpanningForest& same_forest = graph.forest();
   EXPECT_EQ(&same_forest, &forest);
-  EXPECT_EQ(&forest.graph(), &graph);
   EXPECT_FALSE(graph.forest_is_valid());
   graph.BuildForest();  // OK to build even with just World in graph.
   EXPECT_TRUE(graph.forest_is_valid());
@@ -332,7 +359,7 @@ GTEST_TEST(LinkJointGraph, InternalListsAreBuiltCorrectly) {
 }
 
 // Check operation of the public members of the Link subclass.
-GTEST_TEST(LinkJoinGraph, LinkTest) {
+GTEST_TEST(LinkJoinGraph, LinkAPITest) {
   LinkJointGraph::Link link5 = LinkJointGraphTester::MakeLink(
       BodyIndex(5), "link5", ModelInstanceIndex(7), LinkFlags::kMustBeBaseBody);
   EXPECT_EQ(link5.index(), BodyIndex(5));
@@ -364,7 +391,7 @@ GTEST_TEST(LinkJoinGraph, LinkTest) {
 }
 
 // Check operation of the public members of the Joint subclass.
-GTEST_TEST(LinkJointGraph, JointTest) {
+GTEST_TEST(LinkJointGraph, JointAPITest) {
   const BodyIndex parent_index(1);
   const BodyIndex child_index(2);
   const BodyIndex other_body_index(3);  // Not connected by joint3.
@@ -393,6 +420,186 @@ GTEST_TEST(LinkJointGraph, JointTest) {
   EXPECT_EQ(joint3.other_link_index(child_index), parent_index);
   LinkJointGraphTester::set_joint_flags(JointFlags::kDefault, &joint3);
   EXPECT_FALSE(joint3.must_be_modeled());
+}
+
+// Verify that we can define a serial chain, some static and floating links,
+// and some simple composites, and correctly reject improper attempts. We're
+// mostly testing the LinkJointGraph API here; see spanning_forest_test.cc
+// for validation of the generated forest for a similar graph.
+GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
+  LinkJointGraph graph;
+
+  const JointTypeIndex revolute_index =
+      graph.RegisterJointType("revolute", 1, 1);
+  EXPECT_EQ(ssize(graph.joint_types()), 4);  // built-in types plus "revolute"
+
+  EXPECT_FALSE(graph.IsJointTypeRegistered("prismatic"));
+  EXPECT_THROW(graph.joint_types(JointTypeIndex(99)), std::exception);
+
+  // Verify that the revolute joint was correctly registered.
+  EXPECT_TRUE(graph.IsJointTypeRegistered("revolute"));
+  const LinkJointGraph::JointType& revolute_joint_type =
+      graph.joint_types(revolute_index);
+  EXPECT_EQ(revolute_joint_type.name, "revolute");
+  EXPECT_EQ(revolute_joint_type.nq, 1);
+  EXPECT_EQ(revolute_joint_type.nv, 1);
+  EXPECT_FALSE(revolute_joint_type.has_quaternion);
+
+  // We'll add the chain to this model instance.
+  const ModelInstanceIndex model_instance(5);
+
+  // Put static bodies in this model instance.
+  const ModelInstanceIndex static_model_instance(100);
+
+  // We cannot register any link to the world model instance.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddLink("InvalidLink", world_model_instance()),
+      fmt::format("AddLink\\(\\): Model instance index {} is reserved.*",
+                  world_model_instance()));
+
+  BodyIndex parent = graph.AddLink("link1", model_instance);
+  graph.AddJoint("pin1", model_instance, "revolute", world_index(), parent);
+  for (int i = 2; i <= 5; ++i) {
+    BodyIndex child = graph.AddLink("link" + std::to_string(i), model_instance);
+    graph.AddJoint("pin" + std::to_string(i), model_instance, "revolute",
+                   parent, child);
+    parent = child;
+  }
+
+  // Later these will be used to distinguish user elements from ephemeral ones.
+  // For now just make sure they are getting updated properly.
+  EXPECT_EQ(graph.num_user_links(), 6);  // Includes World.
+  EXPECT_EQ(graph.num_user_joints(), 5);
+
+  // Check that the links see their joints.
+  const LinkJointGraph::Link& link4 = graph.links(BodyIndex(4));
+  EXPECT_EQ(link4.joints(),
+            (std::vector<JointIndex>{JointIndex(3), JointIndex(4)}));
+  EXPECT_EQ(link4.joints_as_parent(), std::vector<JointIndex>{JointIndex(4)});
+  EXPECT_EQ(link4.joints_as_child(), std::vector<JointIndex>{JointIndex(3)});
+
+  // Just for testing, we'll tell the graph that we added a loop-closing
+  // weld constraint, and check that it properly updates the relevant links.
+  // (This is a private function normally used only by SpanningForest as it
+  // breaks loops; users can't add constraints to the graph.)
+  const LinkJointGraph::Link& link5 = graph.links(BodyIndex(5));
+  const LoopConstraintIndex constraint0_index =
+      LinkJointGraphTester::AddLoopClosingWeldConstraint(
+          link4.index(),  // primary link
+          link5.index(),  // shadow link
+          &graph);
+  EXPECT_EQ(constraint0_index, LoopConstraintIndex(0));
+  EXPECT_EQ(ssize(graph.loop_constraints()), 1);
+  const LinkJointGraph::LoopConstraint& constraint0 =
+      graph.loop_constraints(constraint0_index);
+  EXPECT_EQ(constraint0.index(), constraint0_index);
+  EXPECT_EQ(constraint0.name(), link5.name());  // Inherits the shadow's name.
+  EXPECT_EQ(constraint0.model_instance(), model_instance);
+  EXPECT_EQ(constraint0.primary_link(), link4.index());
+  EXPECT_EQ(constraint0.shadow_link(), link5.index());
+  // See if the involved links agree with the graph.
+  EXPECT_EQ(link4.loop_constraints(),
+            std::vector<LoopConstraintIndex>{constraint0_index});
+  EXPECT_EQ(link5.loop_constraints(),
+            std::vector<LoopConstraintIndex>{constraint0_index});
+
+  // Out of range should throw.
+  EXPECT_THROW(graph.loop_constraints(LoopConstraintIndex(99)), std::exception);
+
+  // We cannot duplicate the name of a Link or Joint.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddLink("link3", model_instance),
+      "AddLink.*already a link named.*link3.*model instance.*5.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("pin3", model_instance, "revolute", BodyIndex(1),
+                     BodyIndex(2)),
+      "AddJoint.*already a joint named.*pin3.*model instance.*5.*");
+
+  // We cannot add a redundant joint.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("other", model_instance, "revolute", BodyIndex(1),
+                     BodyIndex(2)),
+      "AddJoint\\(\\):.*already has joint.*pin2.*instance 5.*"
+      " connecting.*link1.*link2.*adding joint.*other.*instance 5.*"
+      " connecting.*link1.*link2.*is not allowed.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("reverse", model_instance, "revolute", BodyIndex(2),
+                     BodyIndex(1)),
+      "AddJoint\\(\\):.*already has joint.*pin2.*instance 5.*"
+      " connecting.*link1.*link2.*adding joint.*reverse.*instance 5.*"
+      " connecting.*link2.*link1.*is not allowed.");
+
+  // We cannot add an unregistered joint type.
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.AddJoint("screw1", model_instance, "screw",
+                                             BodyIndex(1), BodyIndex(2)),
+                              "AddJoint\\(\\): Unrecognized type.*");
+
+  // Invalid parent/child Link throws.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("another_pin", model_instance, "revolute", BodyIndex(1),
+                     BodyIndex(9)),
+      "AddJoint\\(\\): child link index 9 for joint '.*' is out of range.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("another_pin", model_instance, "revolute", BodyIndex(9),
+                     BodyIndex(1)),
+      "AddJoint\\(\\): parent link index 9 for joint '.*' is out of range.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("joint_to_self", model_instance, "revolute", BodyIndex(5),
+                     BodyIndex(5)),
+      "AddJoint\\(\\): Joint.*joint_to_self.*instance 5.*would connect.*link5.*"
+      "to itself.");
+
+  // Sanity check sizes.
+  EXPECT_EQ(ssize(graph.links()), 6);  // This includes the world Link.
+  EXPECT_EQ(ssize(graph.joints()), 5);
+
+  // Verify we can get bodies/joints.
+  EXPECT_EQ(graph.links(BodyIndex(3)).name(), "link3");
+  EXPECT_EQ(graph.joints(JointIndex(3)).name(), "pin4");
+  EXPECT_THROW(graph.links(BodyIndex(9)), std::exception);
+  EXPECT_THROW(graph.joints(JointIndex(9)), std::exception);
+
+  // Verify we can query if a Link/Joint is in the graph.
+  const ModelInstanceIndex kInvalidModelInstance(666);
+  EXPECT_TRUE(graph.HasLinkNamed("link3", model_instance));
+  EXPECT_FALSE(graph.HasLinkNamed("link3", kInvalidModelInstance));
+  EXPECT_FALSE(graph.HasLinkNamed("invalid_link_name", model_instance));
+  EXPECT_TRUE(graph.HasJointNamed("pin3", model_instance));
+  EXPECT_FALSE(graph.HasJointNamed("pin3", kInvalidModelInstance));
+  EXPECT_FALSE(graph.HasJointNamed("invalid_joint_name", model_instance));
+
+  // We can add a Static Link with no Joint, or attach it to World with an
+  // explicit Weld, but we can't use any other kind of Joint to World.
+  graph.AddLink("static6", static_model_instance);
+  const BodyIndex static7_index =
+      graph.AddLink("static7", static_model_instance);
+  const BodyIndex static8_index =
+      graph.AddLink("static8", model_instance, LinkFlags::kStatic);
+  graph.AddJoint("static7_weld", model_instance,  // OK
+                 "weld", graph.world_link().index(), static7_index);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.AddJoint("static8_pin", model_instance, "revolute",
+                     graph.world_link().index(), static8_index),
+      "AddJoint\\(\\): can't connect.*'static8' to World.*revolute.*"
+      "only a weld.*");
+
+  // Now add a free link and a free-floating pair.
+  graph.AddLink("free9", model_instance);
+
+  const BodyIndex link10_index = graph.AddLink("link10", model_instance);
+  const BodyIndex base11_index =
+      graph.AddLink("base11", model_instance, LinkFlags::kMustBeBaseBody);
+  const JointIndex joint_10_11_index = graph.AddJoint(
+      "weld", model_instance, "weld", link10_index, base11_index);
+
+  EXPECT_EQ(graph.MaybeGetJointBetween(link10_index, base11_index),
+            joint_10_11_index);
+  EXPECT_EQ(graph.MaybeGetJointBetween(base11_index, link10_index),
+            joint_10_11_index);
+  EXPECT_FALSE(
+      graph.MaybeGetJointBetween(world_index(), link10_index).is_valid());
 }
 
 }  // namespace

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -1,0 +1,52 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/multibody/topology/forest.h"
+/* clang-format on */
+
+#include <string>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+// Tests here are those that require definition of SpanningForest, including
+// tests of LinkJointGraph interactions with its SpanningForest. See
+// link_joint_graph_test.cc for tests that need only LinkJointGraph
+// definitions.
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+namespace {
+
+// A default-constructed LinkJointGraph contains a predefined World
+// Link, and can generate a valid SpanningForest containing just a World
+// Mobod. The LinkJointGraph should be properly updated to have
+// a single link composite and proper modeling info.
+GTEST_TEST(SpanningForest, WorldOnlyTest) {
+  LinkJointGraph graph;
+
+  // World is predefined.
+  EXPECT_EQ(ssize(graph.links()), 1);
+  EXPECT_TRUE(graph.joints().empty());
+  EXPECT_EQ(graph.world_link().name(), "world");
+  EXPECT_EQ(graph.world_link().model_instance(), world_model_instance());
+  const BodyIndex world_link_index = graph.world_link().index();
+  EXPECT_EQ(world_link_index, BodyIndex(0));
+
+  graph.BuildForest();
+  EXPECT_TRUE(graph.forest_is_valid());
+  const SpanningForest& forest = graph.forest();
+  EXPECT_EQ(&forest.graph(), &graph);
+  EXPECT_TRUE(forest.is_valid());
+  EXPECT_EQ(graph.link_to_mobod(world_link_index), MobodIndex(0));
+  EXPECT_EQ(ssize(graph.link_composites()), 1);
+  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0))), 1);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0))[0], world_link_index);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
This is the second installment towards #20225, following PR #20806.

Introduces more of the LinkJointGraph functionality and adds tests. MultibodyPlant continues to use its old topology code unchanged. There are no user-visible changes yet.

Additions here:
- AddJoint() and related functions
- Defines the LoopConstraint subclass and minimal related infrastructure.
- Introduces Link Composite API
- Adds a _tiny_ bit more BuildForest() functionality: make the World composite
- Splits tests into ones that need only LinkJointGraph definitions and those that also need SpanningForest

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21142)
<!-- Reviewable:end -->
