### PR TITLE
[tools] De-duplicate clang-format settings

### DIFF
--- a/bindings/pydrake/.clang-format
+++ b/bindings/pydrake/.clang-format
@@ -15,9 +15,6 @@ PointerAlignment: Left
 # inline (inside a of class) or are empty.
 AllowShortFunctionsOnASingleLine: Inline
 
-# Compress lambdas onto a single line iff they are empty.
-AllowShortLambdasOnASingleLine: Empty
-
 # Specify the #include statement order.  This implements the order mandated by
 # the Google C++ Style Guide: related header, C headers, C++ headers, library
 # headers, and finally the project headers.

--- a/bindings/pydrake/test/dot_clang_format_test.py
+++ b/bindings/pydrake/test/dot_clang_format_test.py
@@ -6,15 +6,49 @@ class TestDotfile(unittest.TestCase):
         self.maxDiff = None
 
     def test_dotfile_consistency(self):
-        # Drake's bindings/pydrake/.clang-format file should be a prologue atop
-        # the root .clang-format file.
-        with open(".clang-format") as f:
+        # Slurp both files.
+        with open(".clang-format", encoding="utf-8") as f:
             root_contents = f.readlines()
-        with open("bindings/pydrake/.clang-format") as f:
+        with open("bindings/pydrake/.clang-format", encoding="utf-8") as f:
             bindings_contents = f.readlines()
 
         # The bindings file should be longer.
         self.assertGreater(len(bindings_contents), len(root_contents))
+
+        # Some settings are explicitly set in both the root dotfile and the
+        # bindings dotfile. To assist our diffing of the two files, we'll
+        # remove them from our model of the root dotfile.
+        set_in_both = [
+            "AllowShortLambdasOnASingleLine",
+        ]
+        for setting in set_in_both:
+            needle = f"{setting}: "
+            matches = [
+                i
+                for i, one_line in enumerate(root_contents)
+                if one_line.startswith(needle)
+            ]
+            self.assertEqual(len(matches), 1, msg=setting)
+            setting_i = matches[0]
+            # Remove the setting line and the blank line after.
+            del root_contents[setting_i]
+            self.assertEqual(root_contents[setting_i], "\n")
+            del root_contents[setting_i]
+            # Remove the preceding comment block.
+            comment_i = setting_i - 1
+            while root_contents[comment_i].startswith("#"):
+                del root_contents[comment_i]
+                comment_i -= 1
+
+        # Sanity check that it was actually in the bindings dotfile.
+        for setting in set_in_both:
+            needle = f"{setting}: "
+            matches = [
+                i
+                for i, one_line in enumerate(bindings_contents)
+                if one_line.startswith(needle)
+            ]
+            self.assertEqual(len(matches), 1, msg=setting)
 
         # The bindings config only ever appends to the root settings.
         self.assertMultiLineEqual(


### PR DESCRIPTION
In future versions of clang-format, duplicate settings are flagged as an error (instead of simply overriding the prior value).

Towards #19295.