### PR TITLE
[parsing] Add a missed test for CollsionFilterGroupResolver

### DIFF
--- a/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
+++ b/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
@@ -117,6 +117,14 @@ TEST_F(CollisionFilterGroupResolverTest, DuplicateGroupDefinitions) {
 TEST_F(CollisionFilterGroupResolverTest, OutOfParseBodyGlobal) {
   // The world body and bodies in the default model are always outside of any
   // parse operation.
+
+  // The resolver knows (by the minimum model index rule) that these models are
+  // out of bounds.
+  ASSERT_LT(plant_.GetModelInstanceByName("DefaultModelInstance"),
+            resolver_.minimum_model_instance_index());
+  ASSERT_LT(plant_.GetModelInstanceByName("WorldModelInstance"),
+            resolver_.minimum_model_instance_index());
+
   AddBody("stuff", {});
   resolver_.AddGroup(diagnostic_policy_, "a", {
       "DefaultModelInstance::stuff",


### PR DESCRIPTION
This clause was missed in #17241.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21148)
<!-- Reviewable:end -->
