### PR TITLE
Bind CalcPrincipalSemiDiametersAndPoseForSolidEllipsoid

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -838,10 +838,8 @@ class TestPlant(unittest.TestCase):
         # work.
         if T != Expression:
             self.assertTrue(spatial_inertia.IsPhysicallyValid())
-        (
-            semi_diameters,
-            transform
-        ) = spatial_inertia.CalcPrincipalSemiDiametersAndPoseForSolidEllipsoid()  # noqa
+        (semi_diameters, transform) = spatial_inertia \
+            .CalcPrincipalSemiDiametersAndPoseForSolidEllipsoid()
         self.assertIsInstance(semi_diameters, np.ndarray)
         self.assertIsInstance(transform, RigidTransform)
         self.assertIsInstance(spatial_inertia.CopyToFullMatrix6(), np.ndarray)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -838,6 +838,12 @@ class TestPlant(unittest.TestCase):
         # work.
         if T != Expression:
             self.assertTrue(spatial_inertia.IsPhysicallyValid())
+        (
+            semi_diameters,
+            transform
+        ) = spatial_inertia.CalcPrincipalSemiDiametersAndPoseForSolidEllipsoid()  # noqa
+        self.assertIsInstance(semi_diameters, np.ndarray)
+        self.assertIsInstance(transform, RigidTransform)
         self.assertIsInstance(spatial_inertia.CopyToFullMatrix6(), np.ndarray)
         self.assertIsInstance(
             spatial_inertia.ReExpress(R_AE=RotationMatrix()), SpatialInertia)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1460,6 +1460,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.CalcRotationalInertia.doc)
         .def("IsPhysicallyValid", &Class::IsPhysicallyValid,
             cls_doc.IsPhysicallyValid.doc)
+        .def("CalcPrincipalSemiDiametersAndPoseForSolidEllipsoid",
+            &Class::CalcPrincipalSemiDiametersAndPoseForSolidEllipsoid,
+            cls_doc.CalcPrincipalSemiDiametersAndPoseForSolidEllipsoid.doc)
         .def("CopyToFullMatrix6", &Class::CopyToFullMatrix6,
             cls_doc.CopyToFullMatrix6.doc)
         .def("IsNaN", &Class::IsNaN, cls_doc.IsNaN.doc)


### PR DESCRIPTION
This adds a binding for [SpatialInertia::CalcPrincipalSemiDiametersAndPoseForSolidEllipsoid](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_spatial_inertia.html#aba6d2ff81ae140bb2c4249933a51597c).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21149)
<!-- Reviewable:end -->
