### PR TITLE
Change the type of F in LinearMatrixInequalityConstraint.

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_evaluators.cc
+++ b/bindings/pydrake/solvers/solvers_py_evaluators.cc
@@ -423,11 +423,11 @@ void BindEvaluatorsAndBindings(py::module m) {
       std::shared_ptr<LinearMatrixInequalityConstraint>>(m,
       "LinearMatrixInequalityConstraint",
       doc.LinearMatrixInequalityConstraint.doc)
-      .def(py::init([](const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
-                        double symmetry_tolerance) {
-        return std::make_unique<LinearMatrixInequalityConstraint>(
-            F, symmetry_tolerance);
-      }),
+      .def(py::init(
+               [](std::vector<Eigen::MatrixXd> F, double symmetry_tolerance) {
+                 return std::make_unique<LinearMatrixInequalityConstraint>(
+                     std::move(F), symmetry_tolerance);
+               }),
           py::arg("F"), py::arg("symmetry_tolerance") = 1E-10,
           doc.LinearMatrixInequalityConstraint.ctor.doc)
       .def("F", &LinearMatrixInequalityConstraint::F,

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1144,10 +1144,10 @@ void BindMathematicalProgram(py::module m) {
               .doc_2args_e_minor_indices)
       .def(
           "AddLinearMatrixInequalityConstraint",
-          [](MathematicalProgram* self,
-              const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
+          [](MathematicalProgram* self, std::vector<Eigen::MatrixXd> F,
               const Eigen::Ref<const VectorXDecisionVariable>& vars) {
-            return self->AddLinearMatrixInequalityConstraint(F, vars);
+            return self->AddLinearMatrixInequalityConstraint(
+                std::move(F), vars);
           },
           py::arg("F"), py::arg("vars"),
           doc.MathematicalProgram.AddLinearMatrixInequalityConstraint.doc)

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -698,17 +698,16 @@ void LinearMatrixInequalityConstraint::DoEval(
 }
 
 LinearMatrixInequalityConstraint::LinearMatrixInequalityConstraint(
-    const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
-    double symmetry_tolerance)
+    std::vector<Eigen::MatrixXd> F, double symmetry_tolerance)
     : Constraint(F.empty() ? 0 : F.front().rows(),
                  F.empty() ? 0 : F.size() - 1),
-      F_(F.begin(), F.end()),
-      matrix_rows_(F.empty() ? 0 : F.front().rows()) {
-  DRAKE_DEMAND(!F.empty());
+      F_{std::move(F)},
+      matrix_rows_(F_.empty() ? 0 : F_.front().rows()) {
+  DRAKE_DEMAND(!F_.empty());
   set_bounds(Eigen::VectorXd::Zero(matrix_rows_),
              Eigen::VectorXd::Constant(
                  matrix_rows_, std::numeric_limits<double>::infinity()));
-  for (const auto& Fi : F) {
+  for (const auto& Fi : F_) {
     DRAKE_ASSERT(Fi.rows() == matrix_rows_);
     DRAKE_ASSERT(math::IsSymmetric(Fi, symmetry_tolerance));
   }

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -1031,9 +1031,8 @@ class LinearMatrixInequalityConstraint : public Constraint {
    * @param symmetry_tolerance  The precision to determine if the input matrices
    * Fi are all symmetric. @see math::IsSymmetric().
    */
-  LinearMatrixInequalityConstraint(
-      const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
-      double symmetry_tolerance = 1E-10);
+  LinearMatrixInequalityConstraint(std::vector<Eigen::MatrixXd> F,
+                                   double symmetry_tolerance = 1E-10);
 
   ~LinearMatrixInequalityConstraint() override {}
 

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -1181,9 +1181,9 @@ Binding<LinearMatrixInequalityConstraint> MathematicalProgram::AddConstraint(
 
 Binding<LinearMatrixInequalityConstraint>
 MathematicalProgram::AddLinearMatrixInequalityConstraint(
-    const vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
+    vector<Eigen::MatrixXd> F,
     const Eigen::Ref<const VectorXDecisionVariable>& vars) {
-  auto constraint = make_shared<LinearMatrixInequalityConstraint>(F);
+  auto constraint = make_shared<LinearMatrixInequalityConstraint>(std::move(F));
   return AddConstraint(constraint, vars);
 }
 

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2630,17 +2630,16 @@ class MathematicalProgram {
    * Adds a linear matrix inequality constraint to the program.
    */
   Binding<LinearMatrixInequalityConstraint> AddLinearMatrixInequalityConstraint(
-      const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
-      const VariableRefList& vars) {
+      std::vector<Eigen::MatrixXd> F, const VariableRefList& vars) {
     return AddLinearMatrixInequalityConstraint(
-        F, ConcatenateVariableRefList(vars));
+        std::move(F), ConcatenateVariableRefList(vars));
   }
 
   /**
    * Adds a linear matrix inequality constraint to the program.
    */
   Binding<LinearMatrixInequalityConstraint> AddLinearMatrixInequalityConstraint(
-      const std::vector<Eigen::Ref<const Eigen::MatrixXd>>& F,
+      std::vector<Eigen::MatrixXd> F,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -664,6 +664,10 @@ GTEST_TEST(testConstraint, testLinearMatrixInequalityConstraint) {
   F2 << 1, 2, 2, 1;
   LinearMatrixInequalityConstraint cnstr({F0, F1, F2});
 
+  EXPECT_TRUE(CompareMatrices(cnstr.F()[0], F0));
+  EXPECT_TRUE(CompareMatrices(cnstr.F()[1], F1));
+  EXPECT_TRUE(CompareMatrices(cnstr.F()[2], F2));
+
   // [4, 3]
   // [3, 4] is positive semidefinite
   Eigen::VectorXd y;

--- a/solvers/test/csdp_test_examples.cc
+++ b/solvers/test/csdp_test_examples.cc
@@ -105,10 +105,9 @@ TrivialSDP2::TrivialSDP2()
   F1 << 1, 2, 2, 3;
   Eigen::Matrix2d F2;
   F2 << 2, 0, 0, 4;
-  prog_->AddConstraint(
-      std::make_shared<LinearMatrixInequalityConstraint>(
-          std::vector<Eigen::Ref<const Eigen::MatrixXd>>{F0, F1, F2}),
-      Vector2<symbolic::Variable>(y_, X1_(0, 0)));
+  prog_->AddConstraint(std::make_shared<LinearMatrixInequalityConstraint>(
+                           std::vector<Eigen::MatrixXd>{F0, F1, F2}),
+                       Vector2<symbolic::Variable>(y_, X1_(0, 0)));
   prog_->AddLinearEqualityConstraint(X1_(0, 0) + 2 * X1_(1, 1) + 3 * y_, 1);
   prog_->AddLinearCost(-y_);
 }

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -857,8 +857,7 @@ GTEST_TEST(TestMathematicalProgram, TestBadBindingVariable) {
   f.setConstant(2);
   lb.setConstant(0);
   ub.setConstant(1);
-  Eigen::Matrix3d twiceA = 2 * A;
-  vector<Eigen::Ref<const MatrixXd>> F{A, twiceA};
+  vector<MatrixXd> F{A, 2 * A};
   shared_ptr<EvaluatorBase> func = MakeFunctionEvaluator(Movable());
 
   // Test each constraint type.
@@ -1155,7 +1154,7 @@ GTEST_TEST(TestMathematicalProgram, AddEmptyConstraint) {
 
   auto binding7 =
       prog.AddConstraint(std::make_shared<LinearMatrixInequalityConstraint>(
-                             std::vector<Eigen::Ref<const Eigen::MatrixXd>>(
+                             std::vector<Eigen::MatrixXd>(
                                  {Eigen::MatrixXd(0, 0), Eigen::MatrixXd(0, 0),
                                   Eigen::MatrixXd(0, 0)})),
                          x);


### PR DESCRIPTION
Use std::vector<Eigen::MatrixXd> instead of std::vector<Eigen::Ref<const Eigen::MatrixXd>> as the latter can produce memory garbage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21152)
<!-- Reviewable:end -->
