### PR TITLE
[tools,doc] Remove most mac-x86

### DIFF
--- a/doc/_pages/code_review_checklist.md
+++ b/doc/_pages/code_review_checklist.md
@@ -103,7 +103,7 @@ changes, be sure to opt-in to a pre-merge macOS build.
 [Schedule an on-demand build](/jenkins.html#scheduling-an-on-demand-build) using an "everything"
 flavor, for example:
 
-* ``@drake-jenkins-bot mac-x86-monterey-clang-bazel-experimental-everything-release please``
+* ``@drake-jenkins-bot mac-arm-ventura-clang-bazel-experimental-everything-release please``
 
 # Have you run linting tools?
 

--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -99,7 +99,6 @@ Older packages for specific dates are available by replacing ``latest`` with an
 8-digit date, e.g., ``20230112`` for January 12th, 2023.
 
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-20230112-jammy.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-20230112-jammy.tar.gz)
-* https://drake-packages.csail.mit.edu/drake/nightly/drake-20230112-mac.tar.gz (for x86_64)
 * https://drake-packages.csail.mit.edu/drake/nightly/drake-20230112-mac-arm64.tar.gz (for arm64)
 
 Users of macOS must download using a command-line tool such as ``curl`` instead

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -15,7 +15,6 @@ officially supports:
 | Operating System ⁽¹⁾               | Architecture | Python ⁽²⁾ | Bazel | CMake | C/C++ Compiler ⁽³⁾           | Java                          |
 |------------------------------------|--------------|------------|-------|-------|------------------------------|-------------------------------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 7.0   | 3.22  | GCC 11 (default) or Clang 14 | OpenJDK 11                    |
-| macOS Monterey (12)                | x86_64       | 3.12       | 7.0   | 3.25  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
 | macOS Ventura (13)                 | arm64        | 3.12       | 7.0   | 3.26  | Apple LLVM 14 (Xcode 14)     | AdoptOpenJDK 16 (HotSpot JVM) |
 | macOS Sonoma (14)                  | arm64        | 3.12       | 7.0   | 3.28  | Apple LLVM 15 (Xcode 15)     | AdoptOpenJDK 16 (HotSpot JVM) |
 
@@ -37,7 +36,7 @@ setup steps.
 
 ⁽²⁾ CPython is the only Python implementation supported.
 
-⁽³⁾ Drake requires a compiler running in C++17 or C++20 mode.
+⁽³⁾ Drake requires a compiler running in C++20 (or greater) mode.
 
 # Getting Drake
 

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -23,9 +23,8 @@ officially supports:
 |------------------------------------|--------------|------------|-----------------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10 ⁽³⁾   | March 2026      |
 | Ubuntu 24.04 LTS (Noble Numbat)    | TBD ⁽⁵⁾      | TBD ⁽⁵⁾    | March 2028      |
-| macOS Monterey (12)                | x86_64       | 3.12       | October 2023    |
-| macOS Ventura (13)                 | arm64        | 3.12       | October 2024    |
-| macOS Sonoma (14)                  | arm64        | 3.12       | October 2025    |
+| macOS Ventura (13)                 | arm64 ⁽⁶⁾    | 3.12       | October 2024    |
+| macOS Sonoma (14)                  | arm64 ⁽⁶⁾    | 3.12       | October 2025    |
 
 "Official support" means that we have Continuous Integration test coverage to
 notice regressions, so if it doesn't work for you then please file a bug report.
@@ -56,6 +55,9 @@ timeline for changing which Python versions are supported.
 Refer to [OS Support](/stable.html#os-support) for details.
 
 ⁽⁵⁾ We aim to support Ubuntu 24.04 within two months of its release.
+
+⁽⁶⁾ For the stable release pip wheel builds only, we also support the x86_64
+architecture for macOS.
 
 Additionally, if you are compiling your own C++ code against Drake's C++ code
 and are using Drake's pre-compiled binaries, then you must use the same

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -53,7 +53,7 @@ where ``<job-name>`` is the name of an
 
 For example:
 
-* ``@drake-jenkins-bot mac-x86-monterey-clang-bazel-experimental-release please.``
+* ``@drake-jenkins-bot mac-arm-ventura-clang-bazel-experimental-release please``
 * ``@drake-jenkins-bot linux-jammy-clang-bazel-experimental-valgrind-memcheck please``
 
 A list of Jenkins bot commands that cover the full set of continuous, nightly
@@ -112,7 +112,7 @@ most likely fail. To test new prerequisites, you should first request
 unprovisioned experimental builds, e.g.:
 
 * ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-bazel-experimental-release please``
-* ``@drake-jenkins-bot mac-x86-monterey-unprovisioned-clang-bazel-experimental-release please.``
+* ``@drake-jenkins-bot mac-arm-ventura-unprovisioned-clang-bazel-experimental-release please``
 
 After this has passed, go through normal review. Once normal review is done,
 add `@BetsyMcPhail` for review and request that the provisioned instances be
@@ -128,7 +128,6 @@ more of these commands:
 
 * ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-bazel-experimental-packaging please``
 * ``@drake-jenkins-bot mac-arm-ventura-unprovisioned-clang-bazel-experimental-packaging please``
-* ``@drake-jenkins-bot mac-x86-monterey-unprovisioned-clang-bazel-experimental-packaging please``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
 to schedule a build of one of the [Packaging](https://drake-jenkins.csail.mit.edu/view/Packaging/)

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -111,8 +111,7 @@ the main body of the document:
       ignore)
    3. Open the latest builds from the following builds:
       1. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-jammy-unprovisioned-gcc-bazel-nightly-packaging/>
-      2. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-x86-monterey-unprovisioned-clang-bazel-nightly-packaging/>
-      3. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-arm-ventura-unprovisioned-clang-bazel-nightly-packaging/>
+      2. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-arm-ventura-unprovisioned-clang-bazel-nightly-packaging/>
    4. Check the logs for those packaging builds and find the URLs they posted
       to (open the latest build, go to "View as plain text", and search for
       ``drake/nightly/drake-20``), and find the date.  It will be ``YYYYMMDD``
@@ -125,13 +124,12 @@ the main body of the document:
       source code:
       [download_release_candidate.py](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/download_release_candidate.py).)
 2. Launch the staging builds for that git commit sha:
-   1. Open the following seven Jenkins jobs (e.g., each in its own
+   1. Open the following Jenkins jobs (e.g., each in its own
       new browser tab):
       - [Linux Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-wheel-staging-release/)
       - [macOS x86 Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-x86-monterey-unprovisioned-clang-wheel-staging-release/)
       - [macOS arm Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-ventura-unprovisioned-clang-wheel-staging-release/)
       - [Jammy Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-bazel-staging-packaging/)
-      - [macOS x86 Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-x86-monterey-unprovisioned-clang-bazel-staging-packaging/)
       - [macOS arm Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-ventura-unprovisioned-clang-bazel-staging-packaging/)
    2. In the upper right, click "log in" (unless you're already logged in). This
       will use your GitHub credentials.
@@ -174,10 +172,10 @@ the main body of the document:
       appropriate edits as follows:
       * The version number
    5. Click the box labeled "Attach binaries by dropping them here or selecting
-      them." and then choose for upload the 39 release files from
+      them." and then choose for upload the **30** release files from
       ``/tmp/drake-release/v1.N.0/...``:
-      - 12: 4 `.tar.gz` + 8 checksums
-      - 6: 2 `.deb` + 4 checksums
+      - 6: 2 `.tar.gz` + 4 checksums
+      - 3: 1 `.deb` + 2 checksums
       - 9: 3 linux `.whl` + 6 checksums
       - 6: 2 macOS x86 `.whl` + 4 checksums
       - 6: 2 macOS arm `.whl` + 4 checksums

--- a/tools/release_engineering/download_release_candidate.py
+++ b/tools/release_engineering/download_release_candidate.py
@@ -145,7 +145,6 @@ def _download_binaries(*, timestamp, staging, version):
                 f"drake-{version[1:]}-jammy.tar.gz",
                 # TODO(jwnimmer-tri) This package is not yet available.
                 # f"drake-{version[1:]}-noble.tar.gz",
-                f"drake-{version[1:]}-mac.tar.gz",
                 f"drake-{version[1:]}-mac-arm64.tar.gz",
             ],
         }
@@ -158,7 +157,6 @@ def _download_binaries(*, timestamp, staging, version):
                 f"drake-{timestamp}-jammy.tar.gz",
                 # TODO(jwnimmer-tri) This package is not yet available.
                 # f"drake-{timestamp}-noble.tar.gz",
-                f"drake-{timestamp}-mac.tar.gz",
                 f"drake-{timestamp}-mac-arm64.tar.gz",
             ],
         }


### PR DESCRIPTION
Phase 2 of https://github.com/RobotLocomotion/drake/issues/21140.

- All mac-x86 packaging jobs have been removed, only wheel remains.
- Release playbook: fix up the release artifiact count, the focal drop missed updating some of these.  Current `master` on v1.27.0 had 33 artifacts, with the changes here 30 will be downloaded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21160)
<!-- Reviewable:end -->
