### PR TITLE
Bind EvalBodySpatialAccelerationInWorld

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -486,6 +486,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("context"), py::arg("body"),
             cls_doc.EvalBodyPoseInWorld.doc)
         .def(
+            "EvalBodySpatialAccelerationInWorld",
+            [](const Class* self, const Context<T>& context,
+                const RigidBody<T>& body_B) {
+              return self->EvalBodySpatialAccelerationInWorld(context, body_B);
+            },
+            py::arg("context"), py::arg("body"),
+            cls_doc.EvalBodySpatialAccelerationInWorld.doc)
+        .def(
             "EvalBodySpatialVelocityInWorld",
             [](const Class* self, const Context<T>& context,
                 const RigidBody<T>& body_B) {

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1220,6 +1220,21 @@ class TestPlant(unittest.TestCase):
             X_WB.GetAsMatrix4(),
             numpy_compare.to_float(X_WB_desired.GetAsMatrix4()))
 
+        # Compute spatial accelerations for base.
+        if T == Expression and plant.time_step() != 0:
+            # N.B. Discrete time dynamics are not supported for symbolic
+            # scalars.
+            with self.assertRaises(ValueError) as cm:
+                A_base = plant.EvalBodySpatialAccelerationInWorld(
+                    context, base)
+            self.assertIn(
+                "This method doesn't support T = drake::symbolic::Expression",
+                str(cm.exception))
+        else:
+            A_base = plant.EvalBodySpatialAccelerationInWorld(context, base)
+            self.assert_sane(A_base.rotational(), nonzero=False)
+            self.assert_sane(A_base.translational(), nonzero=False)
+
         # Set a spatial velocity for the base.
         v_WB = SpatialVelocity(w=[1, 2, 3], v=[4, 5, 6])
         plant.SetFreeBodySpatialVelocity(


### PR DESCRIPTION
Adds a binding for [MultibodyPlant::EvalBodySpatialAccelerationInWorld](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html#a725008fd74cc0c6c30e938eeaaf902e2).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21161)
<!-- Reviewable:end -->
