### PR TITLE
[geometry] Enforece deformable on deformable convention

### DIFF
--- a/geometry/proximity/deformable_contact_internal.cc
+++ b/geometry/proximity/deformable_contact_internal.cc
@@ -127,11 +127,19 @@ DeformableContact<double> Geometries::ComputeDeformableContact(
       const GeometryId deformable1_id = it1->first;
       DRAKE_ASSERT(collision_filter.HasGeometry(deformable1_id));
       if (collision_filter.CanCollideWith(deformable0_id, deformable1_id)) {
-        AddDeformableDeformableContactSurface(
-            *signed_distance_fields.at(deformable0_id),
-            it0->second.deformable_mesh(), deformable0_id,
-            *signed_distance_fields.at(deformable1_id),
-            it1->second.deformable_mesh(), deformable1_id, &result);
+        if (deformable1_id < deformable0_id) {
+          AddDeformableDeformableContactSurface(
+              *signed_distance_fields.at(deformable0_id),
+              it0->second.deformable_mesh(), deformable0_id,
+              *signed_distance_fields.at(deformable1_id),
+              it1->second.deformable_mesh(), deformable1_id, &result);
+        } else {
+          AddDeformableDeformableContactSurface(
+              *signed_distance_fields.at(deformable1_id),
+              it1->second.deformable_mesh(), deformable1_id,
+              *signed_distance_fields.at(deformable0_id),
+              it0->second.deformable_mesh(), deformable0_id, &result);
+        }
       }
     }
   }

--- a/geometry/proximity/deformable_field_intersection.cc
+++ b/geometry/proximity/deformable_field_intersection.cc
@@ -50,6 +50,7 @@ void AddDeformableDeformableContactSurface(
     const DeformableVolumeMeshWithBvh<double>& deformable1_mesh_W,
     GeometryId deformable1_id, DeformableContact<double>* deformable_contact) {
   DRAKE_DEMAND(deformable_contact != nullptr);
+  DRAKE_DEMAND(deformable1_id < deformable0_id);
 
   std::unique_ptr<PolygonSurfaceMesh<double>> contact_mesh_W;
   std::unique_ptr<PolygonSurfaceMeshFieldLinear<double, double>>

--- a/geometry/proximity/deformable_field_intersection.h
+++ b/geometry/proximity/deformable_field_intersection.h
@@ -34,7 +34,8 @@ namespace internal {
 
  @pre deformable0_sdf_W.mesh() refers to deformable0_mesh_W.mesh().
  @pre deformable1_sdf_W.mesh() refers to deformable1_mesh_W.mesh().
- @pre deformable_contact != nullptr.  */
+ @pre deformable_contact != nullptr.
+ @pre deformable1_id < deformable0_id  */
 void AddDeformableDeformableContactSurface(
     const VolumeMeshFieldLinear<double, double>& deformable0_sdf_W,
     const DeformableVolumeMeshWithBvh<double>& deformable0_mesh_W,

--- a/geometry/proximity/test/deformable_contact_internal_test.cc
+++ b/geometry/proximity/test/deformable_contact_internal_test.cc
@@ -496,71 +496,37 @@ TEST_F(DeformableDeformableContactTest, OneContactPair) {
       geometries_.ComputeDeformableContact(collision_filter_);
   ASSERT_EQ(contact_data.contact_surfaces().size(), 1);
 
-  // Set up the expected contact data by calling
-  // AddDeformableDeformableContactSurface() directly, as opposed to
-  // calling it through ComputeDeformableContact(). There are two possibilities
-  // of the ordering of id_A() and id_B() in the contact data.
-  // Here we set up both and choose later.
-  DeformableContact<double> expect01, expect10;
+  DeformableContact<double> expected;
   const DeformableGeometry& deformable0_geometry =
       GeometriesTester::get_deformable_geometry(geometries_, deformable0_id_);
   const DeformableGeometry& deformable1_geometry =
       GeometriesTester::get_deformable_geometry(geometries_, deformable1_id_);
-  // Set up expect01
-  {
-    expect01.RegisterDeformableGeometry(
-        deformable0_id_,
-        deformable0_geometry.deformable_mesh().mesh().num_vertices());
-    expect01.RegisterDeformableGeometry(
-        deformable1_id_,
-        deformable1_geometry.deformable_mesh().mesh().num_vertices());
-    AddDeformableDeformableContactSurface(
-        deformable0_geometry.CalcSignedDistanceField(),
-        deformable0_geometry.deformable_mesh(), deformable0_id_,
-        deformable1_geometry.CalcSignedDistanceField(),
-        deformable1_geometry.deformable_mesh(), deformable1_id_, &expect01);
-    ASSERT_EQ(expect01.contact_surfaces().size(), 1);
-  }
-  // Set up expect10
-  {
-    expect10.RegisterDeformableGeometry(
-        deformable1_id_,
-        deformable1_geometry.deformable_mesh().mesh().num_vertices());
-    expect10.RegisterDeformableGeometry(
-        deformable0_id_,
-        deformable0_geometry.deformable_mesh().mesh().num_vertices());
-    AddDeformableDeformableContactSurface(
-        deformable1_geometry.CalcSignedDistanceField(),
-        deformable1_geometry.deformable_mesh(), deformable1_id_,
-        deformable0_geometry.CalcSignedDistanceField(),
-        deformable0_geometry.deformable_mesh(), deformable0_id_, &expect10);
-    ASSERT_EQ(expect10.contact_surfaces().size(), 1);
-  }
+  expected.RegisterDeformableGeometry(
+      deformable0_id_,
+      deformable0_geometry.deformable_mesh().mesh().num_vertices());
+  expected.RegisterDeformableGeometry(
+      deformable1_id_,
+      deformable1_geometry.deformable_mesh().mesh().num_vertices());
+  AddDeformableDeformableContactSurface(
+      deformable1_geometry.CalcSignedDistanceField(),
+      deformable1_geometry.deformable_mesh(), deformable1_id_,
+      deformable0_geometry.CalcSignedDistanceField(),
+      deformable0_geometry.deformable_mesh(), deformable0_id_, &expected);
+  ASSERT_EQ(expected.contact_surfaces().size(), 1);
 
-  ASSERT_TRUE(
-      (contact_data.contact_surfaces().at(0).id_A() == deformable0_id_ &&
-       contact_data.contact_surfaces().at(0).id_B() == deformable1_id_) ||
-      (contact_data.contact_surfaces().at(0).id_A() == deformable1_id_ &&
-       contact_data.contact_surfaces().at(0).id_B() == deformable0_id_));
-
-  const DeformableContact<double>& expect =
-      (contact_data.contact_surfaces().at(0).id_A() ==
-           expect01.contact_surfaces().at(0).id_A() &&
-       contact_data.contact_surfaces().at(0).id_B() ==
-           expect01.contact_surfaces().at(0).id_B())
-          ? expect01
-          : expect10;
+  ASSERT_TRUE(contact_data.contact_surfaces().at(0).id_A() == deformable0_id_ &&
+              contact_data.contact_surfaces().at(0).id_B() == deformable1_id_);
 
   ASSERT_EQ(contact_data.contact_surfaces().size(),
-            expect.contact_surfaces().size());
+            expected.contact_surfaces().size());
   EXPECT_EQ(contact_data.contact_surfaces().at(0).id_A(),
-            expect.contact_surfaces().at(0).id_A());
+            expected.contact_surfaces().at(0).id_A());
   EXPECT_EQ(contact_data.contact_surfaces().at(0).id_B(),
-            expect.contact_surfaces().at(0).id_B());
+            expected.contact_surfaces().at(0).id_B());
   EXPECT_EQ(contact_data.contact_surfaces().at(0).num_contact_points(),
-            expect.contact_surfaces().at(0).num_contact_points());
+            expected.contact_surfaces().at(0).num_contact_points());
   EXPECT_TRUE(contact_data.contact_surfaces().at(0).contact_mesh_W().Equal(
-      expect.contact_surfaces().at(0).contact_mesh_W()));
+      expected.contact_surfaces().at(0).contact_mesh_W()));
 }
 
 // For n deformable geometries, ComputeDeformableContact() gives

--- a/geometry/query_results/deformable_contact.cc
+++ b/geometry/query_results/deformable_contact.cc
@@ -108,6 +108,7 @@ DeformableContactSurface<T>::DeformableContactSurface(
                  static_cast<int>(barycentric_coordinates_B_->size()));
     DRAKE_DEMAND(num_contact_points ==
                  static_cast<int>(contact_vertex_indexes_B_->size()));
+    DRAKE_DEMAND(id_A < id_B);
   }
   nhats_W_.reserve(num_contact_points);
   contact_points_W_.reserve(num_contact_points);

--- a/geometry/query_results/deformable_contact.h
+++ b/geometry/query_results/deformable_contact.h
@@ -122,7 +122,9 @@ class ContactParticipation {
  polygonal surface mesh. We call the centroids of the polygonal elements in this
  mesh "contact points". DeformableContactSurface stores this polygonal mesh as
  well as information about each contact point. We maintain the convention that
- geometry A is always deformable and geometry B may be deformable.
+ geometry A is always deformable and geometry B may be deformable. When both
+ geometries are deformable, we maintain the convention that the GeometryId of
+ geometry A is less than the GeometryId of geometry B.
  @tparam_double_only */
 template <typename T>
 class DeformableContactSurface {
@@ -158,6 +160,7 @@ class DeformableContactSurface {
       Barycentric coordinates of centroids of contact polygons with respect to
       their containing tetrahedra in mesh B if B is deformable. std::nullopt
       otherwise.
+   @pre id_A < id_B if both geometries are deformable.
    @pre contact_mesh_W.num_faces() == signed_distances.size().
    @pre contact_mesh_W.num_faces() == contact_vertex_indexes_A.size().
    @pre contact_mesh_W.num_faces() == barycentric_coordinates_A.size().
@@ -172,8 +175,12 @@ class DeformableContactSurface {
       std::optional<std::vector<Vector4<int>>> contact_vertex_indexes_B,
       std::optional<std::vector<Vector4<T>>> barycentric_coordinates_B);
 
+  /* Returns the GeometryId of geometry A. If `is_B_deformable()` is true, this
+   is guaranteed to be less than id_B(). */
   GeometryId id_A() const { return id_A_; }
 
+  /* Returns the GeometryId of geometry B. If `is_B_deformable()` is true, this
+   is guaranteed to be greater than id_A(). */
   GeometryId id_B() const { return id_B_; }
 
   const PolygonSurfaceMesh<T>& contact_mesh_W() const {


### PR DESCRIPTION
Maintain the convention that the deformable geometry with the smaller GeometryId is regarded as "geometry A" and the deformable geometry with the larger GeometryId is regarded as "geometry B" in DeformableContactSurface.

Fix #20613 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21165)
<!-- Reviewable:end -->
