### PR TITLE
Deprecate QuaternionFloatingJoint::get_position(), set_position() for get_translation(), set_translation(), etc.

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2300,7 +2300,10 @@ class TestPlant(unittest.TestCase):
                 joint.SetOrientation(context=context,
                                      R_FM=RotationMatrix_[T]())
                 joint.get_translation(context=context)
-                joint.set_translation(context=context, p_FM=[0, 0, 0])
+                joint.SetTranslation(context=context, p_FM=[0, 0, 0])
+                # Deprecated RpyFloatingJoint.set_translationposition().
+                with catch_drake_warnings(expected_count=1):
+                    joint.set_translation(context=context, p_FM=[0, 0, 0])
                 joint.GetPose(context=context)
                 joint.SetPose(context=context, X_FM=RigidTransform_[T]())
                 joint.get_angular_velocity(context=context)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2196,6 +2196,8 @@ class TestPlant(unittest.TestCase):
                 # Warn on deprecated QuaternionFloatingJoint.get_position().
                 with catch_drake_warnings(expected_count=1):
                     joint.get_position(context=context)
+                joint.GetPose(context=context)
+                # Warn on deprecated QuaternionFloatingJoint.get_pose().
                 joint.get_pose(context=context)
                 joint.get_angular_velocity(context=context)
                 joint.get_translational_velocity(context=context)
@@ -2209,7 +2211,10 @@ class TestPlant(unittest.TestCase):
                 # Warn deprecated QuaternionFloatingJoint.set_position().
                 with catch_drake_warnings(expected_count=1):
                     joint.set_position(context=context, p_FM=[0, 0, 0])
-                joint.set_pose(context=context, X_FM=RigidTransform_[T]())
+                joint.SetPose(context=context, X_FM=RigidTransform_[T]())
+                # Warn deprecated QuaternionFloatingJoint.set_pose().
+                with catch_drake_warnings(expected_count=1):
+                    joint.set_pose(context=context, X_FM=RigidTransform_[T]())
                 joint.set_angular_velocity(context=context, w_FM=[0, 0, 0])
                 joint.set_translational_velocity(context=context,
                                                  v_FM=[0, 0, 0])

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2206,7 +2206,7 @@ class TestPlant(unittest.TestCase):
                 # Deprecate QuaternionFloatingJoint.set_quaternion().
                 with catch_drake_warnings(expected_count=1):
                     joint.set_quaternion(context=context,
-                                         R_FM=RotationMatrix_[T]())
+                                         q_FM=Quaternion_[T]())
                 joint.SetOrientation(context=context, R=RotationMatrix_[T]())
                 # Deprecate QuaternionFloatingJoint.SetFromRotationMatrix().
                 with catch_drake_warnings(expected_count=1):

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2198,7 +2198,8 @@ class TestPlant(unittest.TestCase):
                     joint.get_position(context=context)
                 joint.GetPose(context=context)
                 # Warn on deprecated QuaternionFloatingJoint.get_pose().
-                joint.get_pose(context=context)
+                with catch_drake_warnings(expected_count=1):
+                    joint.get_pose(context=context)
                 joint.get_angular_velocity(context=context)
                 joint.get_translational_velocity(context=context)
                 joint.set_quaternion(context=context, q_FM=Quaternion_[T]())
@@ -2207,7 +2208,7 @@ class TestPlant(unittest.TestCase):
                 with catch_drake_warnings(expected_count=1):
                     joint.SetFromRotationMatrix(context=context,
                                                 R_FM=RotationMatrix_[T]())
-                joint.set_translation(context=context, translation=[0, 0, 0])
+                joint.set_translation(context=context, p_FM=[0, 0, 0])
                 # Warn deprecated QuaternionFloatingJoint.set_position().
                 with catch_drake_warnings(expected_count=1):
                     joint.set_position(context=context, p_FM=[0, 0, 0])

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2202,7 +2202,7 @@ class TestPlant(unittest.TestCase):
                 joint.set_quaternion(context=context, q_FM=Quaternion_[T]())
                 joint.SetFromRotationMatrix(context=context,
                                             R_FM=RotationMatrix_[T]())
-                joint.set_translation(context=context, position=[0, 0, 0])
+                joint.set_translation(context=context, translation=[0, 0, 0])
                 # Warn on deprecated QuaternionFloatingJoint.set_position().
                 with catch_drake_warnings(expected_count=1):
                     joint.set_position(context=context, p_FM=[0, 0, 0])

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2208,7 +2208,7 @@ class TestPlant(unittest.TestCase):
                 with catch_drake_warnings(expected_count=1):
                     joint.SetFromRotationMatrix(context=context,
                                                 R_FM=RotationMatrix_[T]())
-                joint.set_translation(context=context, p_FM=[0, 0, 0])
+                joint.SetTranslation(context=context, p_FM=[0, 0, 0])
                 # Warn deprecated QuaternionFloatingJoint.set_position().
                 with catch_drake_warnings(expected_count=1):
                     joint.set_position(context=context, p_FM=[0, 0, 0])

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2202,7 +2202,11 @@ class TestPlant(unittest.TestCase):
                     joint.get_pose(context=context)
                 joint.get_angular_velocity(context=context)
                 joint.get_translational_velocity(context=context)
-                joint.set_quaternion(context=context, q_FM=Quaternion_[T]())
+                joint.SetQuaternion(context=context, q_FM=Quaternion_[T]())
+                # Deprecate QuaternionFloatingJoint.set_quaternion().
+                with catch_drake_warnings(expected_count=1):
+                    joint.set_quaternion(context=context,
+                                         R_FM=RotationMatrix_[T]())
                 joint.SetOrientation(context=context, R=RotationMatrix_[T]())
                 # Deprecate QuaternionFloatingJoint.SetFromRotationMatrix().
                 with catch_drake_warnings(expected_count=1):

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2193,7 +2193,7 @@ class TestPlant(unittest.TestCase):
                     self.assertIn("2024-06-01", str(w[0].message))
                 joint.get_quaternion(context=context)
                 joint.get_translation(context=context)
-                # Warn on deprecated QuaternionFloatingJoint.set_position().
+                # Warn on deprecated QuaternionFloatingJoint.get_position().
                 with catch_drake_warnings(expected_count=1):
                     joint.get_position(context=context)
                 joint.get_pose(context=context)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2203,7 +2203,7 @@ class TestPlant(unittest.TestCase):
                 joint.SetFromRotationMatrix(context=context,
                                             R_FM=RotationMatrix_[T]())
                 joint.set_translation(context=context, translation=[0, 0, 0])
-                # Warn on deprecated QuaternionFloatingJoint.set_position().
+                # Warn deprecated QuaternionFloatingJoint.set_position().
                 with catch_drake_warnings(expected_count=1):
                     joint.set_position(context=context, p_FM=[0, 0, 0])
                 joint.set_pose(context=context, X_FM=RigidTransform_[T]())
@@ -2215,10 +2215,16 @@ class TestPlant(unittest.TestCase):
                     q_FM=Quaternion_[Expression]())
                 joint.set_random_quaternion_distribution_to_uniform()
                 joint.get_default_quaternion()
-                joint.get_default_position()
+                joint.get_default_translation()
+                # Deprecated QuaternionFloatingJoint.get_default_position().
+                with catch_drake_warnings(expected_count=1):
+                    joint.get_default_position()
                 joint.get_default_pose()
                 joint.set_default_quaternion(q_FM=Quaternion_[float]())
-                joint.set_default_position(p_FM=[0, 0, 0])
+                joint.set_default_translation(translation=[0, 0, 0])
+                # Deprecated QuaternionFloatingJoint.set_default_position().
+                with catch_drake_warnings(expected_count=1):
+                    joint.set_default_position(p_FM=[0, 0, 0])
                 # Check that the base class supports these for this joint.
                 joint.SetDefaultPose(X_FM=RigidTransform_[float]())
                 joint.SetDefaultPosePair(q_FM=Quaternion_[float](),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2200,8 +2200,11 @@ class TestPlant(unittest.TestCase):
                 joint.get_angular_velocity(context=context)
                 joint.get_translational_velocity(context=context)
                 joint.set_quaternion(context=context, q_FM=Quaternion_[T]())
-                joint.SetFromRotationMatrix(context=context,
-                                            R_FM=RotationMatrix_[T]())
+                joint.SetOrientation(context=context, R=RotationMatrix_[T]())
+                # Deprecate QuaternionFloatingJoint.SetFromRotationMatrix().
+                with catch_drake_warnings(expected_count=1):
+                    joint.SetFromRotationMatrix(context=context,
+                                                R_FM=RotationMatrix_[T]())
                 joint.set_translation(context=context, translation=[0, 0, 0])
                 # Warn deprecated QuaternionFloatingJoint.set_position().
                 with catch_drake_warnings(expected_count=1):
@@ -2210,7 +2213,11 @@ class TestPlant(unittest.TestCase):
                 joint.set_angular_velocity(context=context, w_FM=[0, 0, 0])
                 joint.set_translational_velocity(context=context,
                                                  v_FM=[0, 0, 0])
-                joint.set_random_position_distribution(p_FM=[0, 0, 0])
+                joint.set_random_translation_distribution(
+                    translation=[0, 0, 0])
+                # Deprecate set_random_position_distribution().
+                with catch_drake_warnings(expected_count=1):
+                    joint.set_random_position_distribution(p_FM=[0, 0, 0])
                 joint.set_random_quaternion_distribution(
                     q_FM=Quaternion_[Expression]())
                 joint.set_random_quaternion_distribution_to_uniform()

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2192,14 +2192,20 @@ class TestPlant(unittest.TestCase):
                     self.assertEqual(joint.translational_damping(), damping)
                     self.assertIn("2024-06-01", str(w[0].message))
                 joint.get_quaternion(context=context)
-                joint.get_position(context=context)
+                joint.get_translation(context=context)
+                # Warn on deprecated QuaternionFloatingJoint.set_position().
+                with catch_drake_warnings(expected_count=1):
+                    joint.get_position(context=context)
                 joint.get_pose(context=context)
                 joint.get_angular_velocity(context=context)
                 joint.get_translational_velocity(context=context)
                 joint.set_quaternion(context=context, q_FM=Quaternion_[T]())
                 joint.SetFromRotationMatrix(context=context,
                                             R_FM=RotationMatrix_[T]())
-                joint.set_position(context=context, p_FM=[0, 0, 0])
+                joint.set_translation(context=context, position=[0, 0, 0])
+                # Warn on deprecated QuaternionFloatingJoint.set_position().
+                with catch_drake_warnings(expected_count=1):
+                    joint.set_position(context=context, p_FM=[0, 0, 0])
                 joint.set_pose(context=context, X_FM=RigidTransform_[T]())
                 joint.set_angular_velocity(context=context, w_FM=[0, 0, 0])
                 joint.set_translational_velocity(context=context,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2226,6 +2226,7 @@ class TestPlant(unittest.TestCase):
                 # Deprecated QuaternionFloatingJoint.get_default_position().
                 with catch_drake_warnings(expected_count=1):
                     joint.get_default_position()
+                # Deprecated QuaternionFloatingJoint.get_default_pose().
                 joint.get_default_pose()
                 joint.set_default_quaternion(q_FM=Quaternion_[float]())
                 joint.set_default_translation(translation=[0, 0, 0])

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -715,8 +715,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.SetFromRotationMatrix.doc_deprecated);
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
     cls                     // BR
-        .def("set_translation", &Class::set_translation, py::arg("context"),
-            py::arg("p_FM"), cls_doc.set_translation.doc);
+        .def("SetTranslation", &Class::SetTranslation, py::arg("context"),
+            py::arg("p_FM"), cls_doc.SetTranslation.doc);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls  // BR

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -762,11 +762,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_default_position",
             WrapDeprecated(cls_doc.get_default_position.doc_deprecated,
                 &Class::get_default_position),
-            cls_doc.get_default_position.doc_deprecated);
+            cls_doc.get_default_position.doc_deprecated)
+        .def("get_default_pose", &Class::get_default_pose,
+            cls_doc.get_default_pose.doc_deprecated);
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
     cls                     // BR
-        .def("get_default_pose", &Class::get_default_pose,
-            cls_doc.get_default_pose.doc)
         .def("set_default_quaternion", &Class::set_default_quaternion,
             py::arg("q_FM"), cls_doc.set_default_quaternion.doc)
         .def("set_default_translation", &Class::set_default_translation,

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -890,8 +890,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("R_FM"), cls_doc.SetOrientation.doc)
         .def("get_translation", &Class::get_translation, py::arg("context"),
             cls_doc.get_translation.doc)
-        .def("set_translation", &Class::set_translation, py::arg("context"),
-            py::arg("p_FM"), cls_doc.set_translation.doc)
+        .def("SetTranslation", &Class::SetTranslation, py::arg("context"),
+            py::arg("p_FM"), cls_doc.SetTranslation.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("set_translation",
+            WrapDeprecated(cls_doc.set_translation.doc_deprecated,
+                &Class::set_translation),
+            py::arg("context"), py::arg("p_FM"),
+            cls_doc.set_translation.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+    cls                     // BR
         .def(
             "GetPose", &Class::GetPose, py::arg("context"), cls_doc.GetPose.doc)
         .def("SetPose", &Class::SetPose, py::arg("context"), py::arg("X_FM"),

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -681,8 +681,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.default_translational_damping.doc)
         .def("get_quaternion", &Class::get_quaternion, py::arg("context"),
             cls_doc.get_quaternion.doc)
-        .def("get_position", &Class::get_position, py::arg("context"),
-            cls_doc.get_position.doc)
+        .def("get_translation", &Class::get_translation, py::arg("context"),
+            cls_doc.get_translation.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("get_position",
+            WrapDeprecated(
+                cls_doc.get_position.doc_deprecated, &Class::get_position),
+            py::arg("context"), cls_doc.get_position.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declaration
+    cls                     // BR
         .def("get_pose", &Class::get_pose, py::arg("context"),
             cls_doc.get_pose.doc)
         .def("get_angular_velocity", &Class::get_angular_velocity,
@@ -694,8 +703,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("SetFromRotationMatrix", &Class::SetFromRotationMatrix,
             py::arg("context"), py::arg("R_FM"),
             cls_doc.SetFromRotationMatrix.doc)
-        .def("set_position", &Class::set_position, py::arg("context"),
-            py::arg("p_FM"), cls_doc.set_position.doc)
+        .def("set_translation", &Class::set_translation, py::arg("context"),
+            py::arg("translation"), cls_doc.set_translation.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("set_position",
+            WrapDeprecated(
+                cls_doc.set_position.doc_deprecated, &Class::set_position),
+            py::arg("context"), py::arg("p_FM"),
+            cls_doc.set_position.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+    cls                     // BR
         .def("set_pose", &Class::set_pose, py::arg("context"), py::arg("X_FM"),
             cls_doc.set_pose.doc)
         .def("set_angular_velocity", &Class::set_angular_velocity,

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -709,8 +709,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls  // BR
         .def("set_position",
-            WrapDeprecated(cls_doc.set_position.doc_deprecated,
-                &Class::set_position),
+            WrapDeprecated(
+                cls_doc.set_position.doc_deprecated, &Class::set_position),
             py::arg("context"), py::arg("p_FM"),
             cls_doc.set_position.doc_deprecated);
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -700,9 +700,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("context"), cls_doc.get_translational_velocity.doc)
         .def("set_quaternion", &Class::set_quaternion, py::arg("context"),
             py::arg("q_FM"), cls_doc.set_quaternion.doc)
-        .def("SetFromRotationMatrix", &Class::SetFromRotationMatrix,
+        .def("SetOrientation", &Class::SetOrientation, py::arg("context"),
+            py::arg("R"), cls_doc.SetOrientation.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("SetFromRotationMatrix",
+            WrapDeprecated(cls_doc.SetFromRotationMatrix.doc_deprecated,
+                &Class::SetFromRotationMatrix),
             py::arg("context"), py::arg("R_FM"),
-            cls_doc.SetFromRotationMatrix.doc)
+            cls_doc.SetFromRotationMatrix.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+    cls                     // BR
         .def("set_translation", &Class::set_translation, py::arg("context"),
             py::arg("translation"), cls_doc.set_translation.doc);
 #pragma GCC diagnostic push
@@ -723,9 +732,20 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("set_translational_velocity", &Class::set_translational_velocity,
             py::arg("context"), py::arg("v_FM"),
             cls_doc.set_translational_velocity.doc)
+        .def("set_random_translation_distribution",
+            &Class::set_random_translation_distribution, py::arg("translation"),
+            cls_doc.set_random_translation_distribution.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
         .def("set_random_position_distribution",
-            &Class::set_random_position_distribution, py::arg("p_FM"),
-            cls_doc.set_random_position_distribution.doc)
+            WrapDeprecated(
+                cls_doc.set_random_position_distribution.doc_deprecated,
+                &Class::set_random_position_distribution),
+            py::arg("p_FM"),
+            cls_doc.set_random_position_distribution.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+    cls                     // BR
         .def("set_random_quaternion_distribution",
             &Class::set_random_quaternion_distribution, py::arg("q_FM"),
             cls_doc.set_random_quaternion_distribution.doc)
@@ -757,8 +777,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("set_default_position",
             WrapDeprecated(cls_doc.set_default_position.doc_deprecated,
                 &Class::set_default_position),
-            py::arg("p_FM"),
-            cls_doc.set_default_position.doc_deprecated);
+            py::arg("p_FM"), cls_doc.set_default_position.doc_deprecated);
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
   }
 

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -709,8 +709,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls  // BR
         .def("set_position",
-            WrapDeprecated(
-                cls_doc.set_position.doc_deprecated, &Class::set_position),
+            WrapDeprecated(cls_doc.set_position.doc_deprecated,
+                &Class::set_position),
             py::arg("context"), py::arg("p_FM"),
             cls_doc.set_position.doc_deprecated);
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -682,18 +682,21 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_quaternion", &Class::get_quaternion, py::arg("context"),
             cls_doc.get_quaternion.doc)
         .def("get_translation", &Class::get_translation, py::arg("context"),
-            cls_doc.get_translation.doc);
+            cls_doc.get_translation.doc)
+        .def("GetPose", &Class::GetPose, py::arg("context"),
+            cls_doc.GetPose.doc);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls  // BR
         .def("get_position",
             WrapDeprecated(
                 cls_doc.get_position.doc_deprecated, &Class::get_position),
-            py::arg("context"), cls_doc.get_position.doc_deprecated);
+            py::arg("context"), cls_doc.get_position.doc_deprecated)
+        .def("get_pose",
+            WrapDeprecated(cls_doc.get_pose.doc_deprecated, &Class::get_pose),
+            py::arg("context"), cls_doc.get_pose.doc_deprecated);
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declaration
     cls                     // BR
-        .def("get_pose", &Class::get_pose, py::arg("context"),
-            cls_doc.get_pose.doc)
         .def("get_angular_velocity", &Class::get_angular_velocity,
             py::arg("context"), cls_doc.get_angular_velocity.doc)
         .def("get_translational_velocity", &Class::get_translational_velocity,
@@ -713,7 +716,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
     cls                     // BR
         .def("set_translation", &Class::set_translation, py::arg("context"),
-            py::arg("translation"), cls_doc.set_translation.doc);
+            py::arg("p_FM"), cls_doc.set_translation.doc);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls  // BR
@@ -721,11 +724,15 @@ void DoScalarDependentDefinitions(py::module m, T) {
             WrapDeprecated(
                 cls_doc.set_position.doc_deprecated, &Class::set_position),
             py::arg("context"), py::arg("p_FM"),
-            cls_doc.set_position.doc_deprecated);
+            cls_doc.set_position.doc_deprecated)
+        .def("set_pose",
+            WrapDeprecated(cls_doc.set_pose.doc_deprecated, &Class::set_pose),
+            py::arg("context"), py::arg("X_FM"),
+            cls_doc.set_pose.doc_deprecated);
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
     cls                     // BR
-        .def("set_pose", &Class::set_pose, py::arg("context"), py::arg("X_FM"),
-            cls_doc.set_pose.doc)
+        .def("SetPose", &Class::SetPose, py::arg("context"), py::arg("X_FM"),
+            cls_doc.SetPose.doc)
         .def("set_angular_velocity", &Class::set_angular_velocity,
             py::arg("context"), py::arg("w_FM"),
             cls_doc.set_angular_velocity.doc)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -734,14 +734,32 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.set_random_quaternion_distribution_to_uniform.doc)
         .def("get_default_quaternion", &Class::get_default_quaternion,
             cls_doc.get_default_quaternion.doc)
-        .def("get_default_position", &Class::get_default_position,
-            cls_doc.get_default_position.doc)
+        .def("get_default_translation", &Class::get_default_translation,
+            cls_doc.get_default_translation.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("get_default_position",
+            WrapDeprecated(cls_doc.get_default_position.doc_deprecated,
+                &Class::get_default_position),
+            cls_doc.get_default_position.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+    cls                     // BR
         .def("get_default_pose", &Class::get_default_pose,
             cls_doc.get_default_pose.doc)
         .def("set_default_quaternion", &Class::set_default_quaternion,
             py::arg("q_FM"), cls_doc.set_default_quaternion.doc)
-        .def("set_default_position", &Class::set_default_position,
-            py::arg("p_FM"), cls_doc.set_default_position.doc);
+        .def("set_default_translation", &Class::set_default_translation,
+            py::arg("translation"), cls_doc.set_default_translation.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("set_default_position",
+            WrapDeprecated(cls_doc.set_default_position.doc_deprecated,
+                &Class::set_default_position),
+            py::arg("p_FM"),
+            cls_doc.set_default_position.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
   }
 
   // RevoluteJoint

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -701,10 +701,19 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("context"), cls_doc.get_angular_velocity.doc)
         .def("get_translational_velocity", &Class::get_translational_velocity,
             py::arg("context"), cls_doc.get_translational_velocity.doc)
-        .def("set_quaternion", &Class::set_quaternion, py::arg("context"),
-            py::arg("q_FM"), cls_doc.set_quaternion.doc)
-        .def("SetOrientation", &Class::SetOrientation, py::arg("context"),
-            py::arg("R"), cls_doc.SetOrientation.doc);
+        .def("SetQuaternion", &Class::SetQuaternion, py::arg("context"),
+            py::arg("q_FM"), cls_doc.SetQuaternion.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("set_quaternion",
+            WrapDeprecated(
+                cls_doc.set_quaternion.doc_deprecated, &Class::set_quaternion),
+            py::arg("context"), py::arg("q_FM"),
+            cls_doc.set_quaternion.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+    cls.def("SetOrientation", &Class::SetOrientation, py::arg("context"),
+        py::arg("R"), cls_doc.SetOrientation.doc);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls  // BR

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -608,7 +608,7 @@ void ManipulationStation<T>::Finalize(
       const Vector3<symbolic::Expression> xyz{x(), y(), z()};
       for (const auto& body_index : object_ids_) {
         const multibody::RigidBody<T>& body = plant_->get_body(body_index);
-        plant_->SetFreeBodyRandomPositionDistribution(body, xyz);
+        plant_->SetFreeBodyRandomTranslationDistribution(body, xyz);
         plant_->SetFreeBodyRandomRotationDistributionToUniform(body);
       }
       break;
@@ -623,7 +623,7 @@ void ManipulationStation<T>::Finalize(
       const Vector3<symbolic::Expression> xyz{x(), y(), z()};
       for (const auto& body_index : object_ids_) {
         const multibody::RigidBody<T>& body = plant_->get_body(body_index);
-        plant_->SetFreeBodyRandomPositionDistribution(body, xyz);
+        plant_->SetFreeBodyRandomTranslationDistribution(body, xyz);
         plant_->SetFreeBodyRandomRotationDistributionToUniform(body);
       }
       break;
@@ -638,7 +638,7 @@ void ManipulationStation<T>::Finalize(
       const Vector3<symbolic::Expression> xyz{x(), y(), z()};
       for (const auto& body_index : object_ids_) {
         const multibody::RigidBody<T>& body = plant_->get_body(body_index);
-        plant_->SetFreeBodyRandomPositionDistribution(body, xyz);
+        plant_->SetFreeBodyRandomTranslationDistribution(body, xyz);
       }
       break;
     }

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
@@ -183,7 +183,7 @@ GTEST_TEST(InverseKinematicsTest, ConstructorLockedJoints) {
   // Leave joint1 unlocked.
 
   // Lock body2's floating joint to an un-normalized initial value.
-  joint2.set_quaternion(&*context, Eigen::Quaternion<double>(0, 3.0, 0, 0));
+  joint2.SetQuaternion(&*context, Eigen::Quaternion<double>(0, 3.0, 0, 0));
   joint2.Lock(&*context);
 
   // Set limits on joint3, but do not lock it.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3158,13 +3158,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                                       state);
   }
 
-  // TODO(sherm1) Rename this SetFreeBodyRandomTranslationDistribution()
-
   /// Sets the distribution used by SetRandomState() to populate the free
   /// body's x-y-z `position` with respect to World.
   /// @throws std::exception if `body` is not a free body in the model.
   /// @throws std::exception if called pre-finalize.
-  void SetFreeBodyRandomPositionDistribution(
+  void SetFreeBodyRandomTranslationDistribution(
       const RigidBody<T>& body, const Vector3<symbolic::Expression>& position) {
     this->mutable_tree().SetFreeBodyRandomTranslationDistributionOrThrow(
         body, position);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3168,6 +3168,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
         body, position);
   }
 
+  DRAKE_DEPRECATED(
+      "2024-08-01",
+      "Use MultibodyPlant::SetFreeBodyRandomTranslationDistribution()")
+  void SetFreeBodyRandomPositionDistribution(
+      const RigidBody<T>& body, const Vector3<symbolic::Expression>& position) {
+    return SetFreeBodyRandomTranslationDistribution(body, position);
+  }
+
   /// Sets the distribution used by SetRandomState() to populate the free
   /// body's `rotation` with respect to World.
   /// @throws std::exception if `body` is not a free body in the model.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3159,13 +3159,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Sets the distribution used by SetRandomState() to populate the free
-  /// body's x-y-z `position` with respect to World.
+  /// body's x-y-z `translation` with respect to World.
   /// @throws std::exception if `body` is not a free body in the model.
   /// @throws std::exception if called pre-finalize.
   void SetFreeBodyRandomTranslationDistribution(
-      const RigidBody<T>& body, const Vector3<symbolic::Expression>& position) {
+      const RigidBody<T>& body,
+      const Vector3<symbolic::Expression>& translation) {
     this->mutable_tree().SetFreeBodyRandomTranslationDistributionOrThrow(
-        body, position);
+        body, translation);
   }
 
   DRAKE_DEPRECATED(

--- a/multibody/plant/test/floating_body_test.cc
+++ b/multibody/plant/test/floating_body_test.cc
@@ -94,7 +94,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
                               -3.5 * v0_WB_expected, kEpsilon,
                               MatrixCompareType::relative));
 
-  // Unit test QuaternionFloatingMobilizer::SetFromRotationMatrix().
+  // Unit test QuaternionFloatingMobilizer::SetOrientation().
   const Vector3d axis = (1.5 * Vector3d::UnitX() + 2.0 * Vector3d::UnitY() +
                          3.0 * Vector3d::UnitZ())
                             .normalized();

--- a/multibody/plant/test/floating_body_test.cc
+++ b/multibody/plant/test/floating_body_test.cc
@@ -109,12 +109,12 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
   // Unit test QuaternionFloatingMobilizer quaternion setters/getters.
   const math::RotationMatrixd R_WB_test2(AngleAxisd(M_PI / 5.0, axis));
   const Quaterniond q_WB_test2 = R_WB_test2.ToQuaternion();
-  mobilizer.set_quaternion(&context, q_WB_test2);
+  mobilizer.SetQuaternion(&context, q_WB_test2);
   EXPECT_TRUE(CompareMatrices(mobilizer.get_quaternion(context).coeffs(),
                               q_WB_test2.coeffs(), kEpsilon,
                               MatrixCompareType::relative));
   const Vector3d p_WB_test(1, 2, 3);
-  mobilizer.set_translation(&context, p_WB_test);
+  mobilizer.SetTranslation(&context, p_WB_test);
   EXPECT_TRUE(CompareMatrices(mobilizer.get_translation(context), p_WB_test,
                               kEpsilon, MatrixCompareType::relative));
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3528,6 +3528,11 @@ GTEST_TEST(SetRandomTest, FloatingBodies) {
                                     2.0 + uniform(generator),
                                     3.0 + uniform(generator));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  plant.SetFreeBodyRandomPositionDistribution(body, xyz);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+
   plant.SetFreeBodyRandomTranslationDistribution(body, xyz);
   plant.SetFreeBodyRandomRotationDistributionToUniform(body);
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3528,7 +3528,7 @@ GTEST_TEST(SetRandomTest, FloatingBodies) {
                                     2.0 + uniform(generator),
                                     3.0 + uniform(generator));
 
-  plant.SetFreeBodyRandomPositionDistribution(body, xyz);
+  plant.SetFreeBodyRandomTranslationDistribution(body, xyz);
   plant.SetFreeBodyRandomRotationDistributionToUniform(body);
 
   auto context = plant.CreateDefaultContext();

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -134,7 +134,7 @@ class BallRpyJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const BallRpyJoint<T>& set_angles(Context<T>* context,
                                     const Vector3<T>& angles) const {
-    get_mobilizer()->set_angles(context, angles);
+    get_mobilizer()->SetAngles(context, angles);
     return *this;
   }
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1085,8 +1085,8 @@ void MultibodyTree<T>::SetFreeBodyPoseOrThrow(
   const QuaternionFloatingMobilizer<T>& mobilizer =
       GetFreeBodyMobilizerOrThrow(body);
   const RotationMatrix<T>& R_WB = X_WB.rotation();
-  mobilizer.set_quaternion(context, R_WB.ToQuaternion(), state);
-  mobilizer.set_translation(context, X_WB.translation(), state);
+  mobilizer.SetQuaternion(context, R_WB.ToQuaternion(), state);
+  mobilizer.SetTranslation(context, X_WB.translation(), state);
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1031,7 +1031,7 @@ void MultibodyTree<T>::SetDefaultFreeBodyPose(
   DRAKE_DEMAND(quaternion_floating_joint != nullptr);
   quaternion_floating_joint->set_default_quaternion(
       X_WB.rotation().ToQuaternion());
-  quaternion_floating_joint->set_default_position(X_WB.translation());
+  quaternion_floating_joint->set_default_translation(X_WB.translation());
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1051,7 +1051,7 @@ class MultibodyTree {
       const RigidBody<T>& body, const SpatialVelocity<T>& V_WB,
       const systems::Context<T>& context, systems::State<T>* state) const;
 
-  // See MultibodyPlant::SetFreeBodyRandomPositionDistribution.
+  // See MultibodyPlant::SetFreeBodyRandomTranslationDistribution.
   void SetFreeBodyRandomTranslationDistributionOrThrow(
       const RigidBody<T>& body,
       const Vector3<symbolic::Expression>& position);

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1054,7 +1054,7 @@ class MultibodyTree {
   // See MultibodyPlant::SetFreeBodyRandomTranslationDistribution.
   void SetFreeBodyRandomTranslationDistributionOrThrow(
       const RigidBody<T>& body,
-      const Vector3<symbolic::Expression>& position);
+      const Vector3<symbolic::Expression>& translation);
 
   // See MultibodyPlant::SetFreeBodyRandomRotationDistribution.
   void SetFreeBodyRandomRotationDistributionOrThrow(

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -153,7 +153,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   }
 
   /// Returns the position vector p_FoMo_F from Fo (inboard frame F's origin)
-  /// to Mo (outboard frame M's origin), expressed in the inboard frame F.
+  /// to Mo (outboard frame M's origin), expressed in inboard frame F.
   /// @param[in] context contains the state of the multibody system.
   /// @note Class documentation describes inboard frame F and outboard frame F.
   Vector3<T> get_translation(const systems::Context<T>& context) const {
@@ -354,12 +354,16 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return Quaternion<double>(q_FM[0], q_FM[1], q_FM[2], q_FM[3]);
   }
 
-  // TODO(sherm1) Rename this get_default_translation()
-
-  /// Gets the default position `p_FM` for `this` joint.
-  /// @returns The default position `p_FM` of `this` joint.
-  Vector3<double> get_default_position() const {
+  /// Returns the default position p_FoMo_F from Fo (inboard frame F's origin)
+  /// to Mo (outboard frame M's origin), expressed in inboard frame F.
+  Vector3<double> get_default_translation() const {
     return this->default_positions().template tail<3>();
+  }
+
+  DRAKE_DEPRECATED("2024-07-01",
+      "Use QuaternionFloatingJoint::get_default_translation()")
+  Vector3<double> get_default_position() const {
+    return get_default_translation();
   }
 
   // TODO(sherm1) Deprecate this and remove it since the base class
@@ -369,7 +373,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @returns The default pose `X_FM` of `this` joint.
   math::RigidTransform<double> get_default_pose() const {
     return math::RigidTransform(get_default_quaternion(),
-                                get_default_position());
+                                get_default_translation());
   }
 
   /// @}
@@ -391,15 +395,19 @@ class QuaternionFloatingJoint final : public Joint<T> {
     this->set_default_positions(default_positions);
   }
 
-  // TODO(sherm1) Rename this set_default_translation()
-
-  /// Sets the default position `p_FM` of this joint.
-  /// @param[in] p_FM
-  ///   The desired default position of the joint.
-  void set_default_position(const Vector3<double>& p_FM) {
+  /// Sets the default position vector for `this` joint.
+  /// @param[in] translation position vector p_FoMo_F from Fo (inboard frame F's
+  /// origin) to Mo (outboard frame M's origin), expressed in frame F.
+  void set_default_translation(const Vector3<double>& translation) {
     VectorX<double> default_positions = this->default_positions();
-    default_positions.template tail<3>() = p_FM;
+    default_positions.template tail<3>() = translation;
     this->set_default_positions(default_positions);
+  }
+
+  DRAKE_DEPRECATED("2024-07-01",
+      "Use QuaternionFloatingJoint::set_default_translation()")
+  void set_default_position(const Vector3<double>& p_FM) {
+    set_default_translation(p_FM);
   }
   /// @}
 

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -374,11 +374,9 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return get_default_translation();
   }
 
-  // TODO(sherm1) Deprecate this and remove it since the base class
-  //  now provides GetDefaultPose().
-
-  /// Gets the default pose `X_FM` for `this` joint.
-  /// @returns The default pose `X_FM` of `this` joint.
+  DRAKE_DEPRECATED("2024-07-01",
+                   "Removed since functionality already provided by base class "
+                   "Joint::GetDefaultPose()")
   math::RigidTransform<double> get_default_pose() const {
     return math::RigidTransform(get_default_quaternion(),
                                 get_default_translation());

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -156,7 +156,8 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// to Mo (outboard frame M's origin), expressed in inboard frame F.
   /// @param[in] context contains the state of the multibody system.
   /// @note Class documentation describes inboard frame F and outboard frame M.
-  /// @retval Position vector p_FM from frame F's origin to frame M's origin.
+  /// @retval p_FM The position vector from Fo (frame F's origin) to Mo (frame
+  /// M's origin), expressed in frame F.
   Vector3<T> get_translation(const systems::Context<T>& context) const {
     return get_mobilizer().get_translation(context);
   }
@@ -226,7 +227,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return *this;
   }
 
-  /// Sets the quaternion in `context` so this Joint's orientation is consistent
+  /// Sets the quaternion in `context` so this joint's orientation is consistent
   /// with the given `R_FM` rotation matrix.
   /// @param[in,out] context
   ///   A Context for the MultibodyPlant this joint belongs to.
@@ -320,7 +321,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @name Random distribution setters
   /// @{
 
-  /// For `this` joint, sets the random distribution that the translation of
+  /// For this joint, sets the random distribution that the translation of this
   /// this joint will be randomly sampled from. If a quaternion distribution has
   /// already been set with stochastic variables, it will remain so. Otherwise
   /// the quaternion will be set to this joint's has a zero orientation.

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -155,28 +155,32 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// Returns the position vector p_FoMo_F from Fo (inboard frame F's origin)
   /// to Mo (outboard frame M's origin), expressed in inboard frame F.
   /// @param[in] context contains the state of the multibody system.
-  /// @note Class documentation describes inboard frame F and outboard frame F.
+  /// @note Class documentation describes inboard frame F and outboard frame M.
+  /// @retval Position vector p_FM from frame F's origin to frame M's origin.
   Vector3<T> get_translation(const systems::Context<T>& context) const {
     return get_mobilizer().get_translation(context);
   }
 
-  DRAKE_DEPRECATED("2024-07-01",
+  DRAKE_DEPRECATED("2024-08-01",
       "Use QuaternionFloatingJoint::get_translation()")
   Vector3<T> get_position(const systems::Context<T>& context) const {
     return get_translation(context);
   }
 
-  // TODO(sherm1) Rename this GetPose()
-
   /// Returns the pose `X_FM` of the outboard frame M as measured and expressed
   /// in the inboard frame F. Refer to the documentation for this class for
   /// details.
-  /// @param[in] context
-  ///   A Context for the MultibodyPlant this joint belongs to.
+  /// @param[in] context A Context for the MultibodyPlant this joint belongs to.
   /// @retval X_FM The pose of frame M in frame F.
-  math::RigidTransform<T> get_pose(const systems::Context<T>& context) const {
+  math::RigidTransform<T> GetPose(const systems::Context<T>& context) const {
     return math::RigidTransform<T>(get_quaternion(context),
                                    get_translation(context));
+  }
+
+  DRAKE_DEPRECATED("2024-08-01",
+      "Use QuaternionFloatingJoint::GetPose()")
+  math::RigidTransform<T> get_pose(const systems::Context<T>& context) const {
+    return GetPose(context);
   }
 
   /// Retrieves from `context` the angular velocity `w_FM` of the child frame
@@ -211,10 +215,10 @@ class QuaternionFloatingJoint final : public Joint<T> {
 
   /// Sets `context` so that the orientation of frame M in F is given by the
   /// input quaternion `q_FM`.
-  /// @param[out] context
+  /// @param[in,out] context
   ///   A Context for the MultibodyPlant this joint belongs to.
   /// @param[in] q_FM
-  ///   The desired orientation of M in F to be stored in `context`.
+  ///   Quaternion relating frames F and M to be stored in `context`.
   /// @returns a constant reference to `this` joint.
   const QuaternionFloatingJoint<T>& set_quaternion(
       systems::Context<T>* context, const Quaternion<T>& q_FM) const {
@@ -222,60 +226,68 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return *this;
   }
 
-  /// For `this` joint, stores the rotation matrix `R` in `context`.
-  /// @param[out] context contains the state of the multibody system.
-  /// @param[in] R rotation matrix R_FM relating the inboard frame F and the
-  /// outboard frame M.
+  /// Sets the quaternion in `context` so this Joint's orientation is consistent
+  /// with the given `R_FM` rotation matrix.
+  /// @param[in,out] context
+  ///   A Context for the MultibodyPlant this joint belongs to.
+  /// @param[in] R_FM
+  ///   The rotation matrix relating the orientation of frame F and frame M.
   /// @returns a constant reference to `this` joint.
   const QuaternionFloatingJoint<T>& SetOrientation(
-      systems::Context<T>* context, const math::RotationMatrix<T>& R) const {
-    get_mobilizer().SetOrientation(context, R);
+      systems::Context<T>* context, const math::RotationMatrix<T>& R_FM) const {
+    get_mobilizer().SetOrientation(context, R_FM);
     return *this;
   }
 
-  DRAKE_DEPRECATED("2024-07-01",
+  DRAKE_DEPRECATED("2024-08-01",
       "Use QuaternionFloatingJoint::SetOrientation()")
   const QuaternionFloatingJoint<T>& SetFromRotationMatrix(
       systems::Context<T>* context, const math::RotationMatrix<T>& R_FM) const {
     return SetOrientation(context, R_FM);
   }
 
-  /// For `this` joint, stores the position vector `translation` in `context`.
-  /// @param[out] context contains the state of the multibody system.
-  /// @param[in] translation position vector p_FoMo_F from Fo (inboard frame F's
+  /// For this joint, stores the position vector `p_FM` in `context`.
+  /// @param[in,out] context
+  ///   A Context for the MultibodyPlant this joint belongs to.
+  /// @param[in] p_FM position vector p_FoMo_F from Fo (inboard frame F's
   /// origin) to Mo (outboard frame M's origin), expressed in frame F.
   /// @returns a constant reference to `this` joint.
   const QuaternionFloatingJoint<T>& set_translation(
-      systems::Context<T>* context, const Vector3<T>& translation) const {
-    get_mobilizer().set_translation(context, translation);
+      systems::Context<T>* context, const Vector3<T>& p_FM) const {
+    get_mobilizer().set_translation(context, p_FM);
     return *this;
   }
 
-  DRAKE_DEPRECATED("2024-07-01",
+  DRAKE_DEPRECATED("2024-08-01",
       "Use QuaternionFloatingJoint::set_translation()")
   const QuaternionFloatingJoint<T>& set_position(systems::Context<T>* context,
                                                  const Vector3<T>& p_FM) const {
     return set_translation(context, p_FM);
   }
 
-  // TODO(sherm1) Rename this SetPose()
-
   /// Sets `context` to store `X_FM` the pose of frame M measured and expressed
-  /// in frame F.
-  /// @param[out] context
+  ///   in frame F.
+  /// @param[in,out] context
   ///   A Context for the MultibodyPlant this joint belongs to.
   /// @param[in] X_FM
-  ///   The desired pose of frame M in F to be stored in `context`.
+  ///   The desired pose of frame M in frame F to be stored in `context`.
   /// @returns a constant reference to `this` joint.
-  const QuaternionFloatingJoint<T>& set_pose(
+  const QuaternionFloatingJoint<T>& SetPose(
       systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const {
     set_translation(context, X_FM.translation());
     return SetOrientation(context, X_FM.rotation());
   }
 
+  DRAKE_DEPRECATED("2024-08-01",
+      "Use QuaternionFloatingJoint::SetPose()")
+  const QuaternionFloatingJoint<T>& set_pose(
+      systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const {
+    return SetPose(context, X_FM);
+  }
+
   /// Sets in `context` the state for `this` joint so that the angular velocity
   /// of the child frame M in the parent frame F is `w_FM`.
-  /// @param[out] context
+  /// @param[in,out] context
   ///   A Context for the MultibodyPlant this joint belongs to.
   /// @param[in] w_FM
   ///   A vector in ℝ³ with the angular velocity of the child frame M in the
@@ -290,7 +302,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
 
   /// Sets in `context` the state for `this` joint so that the translational
   /// velocity of the child frame M's origin in the parent frame F is `v_FM`.
-  /// @param[out] context
+  /// @param[in,out] context
   ///   A Context for the MultibodyPlant this joint belongs to.
   /// @param[in] w_FM
   ///   A vector in ℝ³ with the translational velocity of the child frame M's
@@ -308,19 +320,17 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @name Random distribution setters
   /// @{
 
-  /// For `this` joint, sets the random distribution that translation will be
-  /// randomly sampled from. If a quaternion distribution has already been set
-  /// with stochastic variables, it will remain so. Otherwise the quaternion
-  /// will be set to this joint's zero configuration. See get_translation() for
-  /// details on the position representation.
-  /// with stochastic variables, it will remain so. Otherwise the quaternion
-  /// will be set so its orientation will be zero.
+  /// For `this` joint, sets the random distribution that the translation of
+  /// this joint will be randomly sampled from. If a quaternion distribution has
+  /// already been set with stochastic variables, it will remain so. Otherwise
+  /// the quaternion will be set to this joint's has a zero orientation.
+  /// See get_translation() for details on the translation representation.
   void set_random_translation_distribution(
-      const Vector3<symbolic::Expression>& translation) {
-    get_mutable_mobilizer()->set_random_translation_distribution(translation);
+      const Vector3<symbolic::Expression>& p_FM) {
+    get_mutable_mobilizer()->set_random_translation_distribution(p_FM);
   }
 
-  DRAKE_DEPRECATED("2024-07-01",
+  DRAKE_DEPRECATED("2024-08-01",
       "Use QuaternionFloatingJoint::set_random_translation_distribution()")
   void set_random_position_distribution(
       const Vector3<symbolic::Expression>& p_FM) {
@@ -362,19 +372,20 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return Quaternion<double>(q_FM[0], q_FM[1], q_FM[2], q_FM[3]);
   }
 
-  /// Returns the default position p_FoMo_F from Fo (inboard frame F's origin)
-  /// to Mo (outboard frame M's origin), expressed in inboard frame F.
+  /// Returns this joint's default position p_FoMo_F from Fo (inboard frame F's
+  /// origin) to Mo (outboard frame M's origin), expressed in inboard frame F.
+  /// @retval This joint's default position vector p_FM.
   Vector3<double> get_default_translation() const {
     return this->default_positions().template tail<3>();
   }
 
-  DRAKE_DEPRECATED("2024-07-01",
+  DRAKE_DEPRECATED("2024-08-01",
       "Use QuaternionFloatingJoint::get_default_translation()")
   Vector3<double> get_default_position() const {
     return get_default_translation();
   }
 
-  DRAKE_DEPRECATED("2024-07-01",
+  DRAKE_DEPRECATED("2024-08-01",
                    "Removed since functionality already provided by base class "
                    "Joint::GetDefaultPose()")
   math::RigidTransform<double> get_default_pose() const {
@@ -401,16 +412,16 @@ class QuaternionFloatingJoint final : public Joint<T> {
     this->set_default_positions(default_positions);
   }
 
-  /// Sets the default position vector for `this` joint.
-  /// @param[in] translation position vector p_FoMo_F from Fo (inboard frame F's
+  /// Sets this joint's default position vector `p_FM`.
+  /// @param[in] p_FM position vector p_FoMo_F from Fo (inboard frame F's
   /// origin) to Mo (outboard frame M's origin), expressed in frame F.
-  void set_default_translation(const Vector3<double>& translation) {
+  void set_default_translation(const Vector3<double>& p_FM) {
     VectorX<double> default_positions = this->default_positions();
-    default_positions.template tail<3>() = translation;
+    default_positions.template tail<3>() = p_FM;
     this->set_default_positions(default_positions);
   }
 
-  DRAKE_DEPRECATED("2024-07-01",
+  DRAKE_DEPRECATED("2024-08-01",
       "Use QuaternionFloatingJoint::set_default_translation()")
   void set_default_position(const Vector3<double>& p_FM) {
     set_default_translation(p_FM);

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -322,9 +322,9 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @{
 
   /// For this joint, sets the random distribution that the translation of this
-  /// this joint will be randomly sampled from. If a quaternion distribution has
+  /// joint will be randomly sampled from. If a quaternion distribution has
   /// already been set with stochastic variables, it will remain so. Otherwise
-  /// the quaternion will be set to this joint's has a zero orientation.
+  /// the quaternion will be set to this joint's zero orientation.
   /// See get_translation() for details on the translation representation.
   void set_random_translation_distribution(
       const Vector3<symbolic::Expression>& p_FM) {
@@ -373,9 +373,10 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return Quaternion<double>(q_FM[0], q_FM[1], q_FM[2], q_FM[3]);
   }
 
-  /// Returns this joint's default position p_FoMo_F from Fo (inboard frame F's
-  /// origin) to Mo (outboard frame M's origin), expressed in inboard frame F.
-  /// @retval This joint's default position vector p_FM.
+  /// Returns this joint's default translation as the position vector p_FoMo_F
+  /// from Fo (inboard frame F's origin) to Mo (outboard frame M's origin),
+  /// expressed in inboard frame F.
+  /// @retval This joint's default translation as the position vector p_FM.
   Vector3<double> get_default_translation() const {
     return this->default_positions().template tail<3>();
   }

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -221,10 +221,17 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @param[in] q_FM
   ///   Quaternion relating frames F and M to be stored in `context`.
   /// @returns a constant reference to `this` joint.
+  const QuaternionFloatingJoint<T>& SetQuaternion(
+      systems::Context<T>* context, const Quaternion<T>& q_FM) const {
+    get_mobilizer().SetQuaternion(context, q_FM);
+    return *this;
+  }
+
+  DRAKE_DEPRECATED("2024-08-01",
+      "Use QuaternionFloatingJoint::SetQuaternion()")
   const QuaternionFloatingJoint<T>& set_quaternion(
       systems::Context<T>* context, const Quaternion<T>& q_FM) const {
-    get_mobilizer().set_quaternion(context, q_FM);
-    return *this;
+    return SetQuaternion(context, q_FM);
   }
 
   /// Sets the quaternion in `context` so this joint's orientation is consistent
@@ -255,7 +262,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const QuaternionFloatingJoint<T>& SetTranslation(
       systems::Context<T>* context, const Vector3<T>& p_FM) const {
-    get_mobilizer().set_translation(context, p_FM);
+    get_mobilizer().SetTranslation(context, p_FM);
     return *this;
   }
 

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -249,6 +249,8 @@ class QuaternionFloatingJoint final : public Joint<T> {
     return *this;
   }
 
+  DRAKE_DEPRECATED("2024-07-01",
+      "Use QuaternionFloatingJoint::set_translation()")
   const QuaternionFloatingJoint<T>& set_position(systems::Context<T>* context,
                                                  const Vector3<T>& p_FM) const {
     return set_translation(context, p_FM);

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -253,17 +253,17 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @param[in] p_FM position vector p_FoMo_F from Fo (inboard frame F's
   /// origin) to Mo (outboard frame M's origin), expressed in frame F.
   /// @returns a constant reference to `this` joint.
-  const QuaternionFloatingJoint<T>& set_translation(
+  const QuaternionFloatingJoint<T>& SetTranslation(
       systems::Context<T>* context, const Vector3<T>& p_FM) const {
     get_mobilizer().set_translation(context, p_FM);
     return *this;
   }
 
   DRAKE_DEPRECATED("2024-08-01",
-      "Use QuaternionFloatingJoint::set_translation()")
+      "Use QuaternionFloatingJoint::SetTranslation()")
   const QuaternionFloatingJoint<T>& set_position(systems::Context<T>* context,
                                                  const Vector3<T>& p_FM) const {
-    return set_translation(context, p_FM);
+    return SetTranslation(context, p_FM);
   }
 
   /// Sets `context` to store `X_FM` the pose of frame M measured and expressed
@@ -275,7 +275,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const QuaternionFloatingJoint<T>& SetPose(
       systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const {
-    set_translation(context, X_FM.translation());
+    SetTranslation(context, X_FM.translation());
     return SetOrientation(context, X_FM.rotation());
   }
 

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -142,8 +142,7 @@ void QuaternionFloatingMobilizer<T>::set_random_translation_distribution(
 }
 
 template <typename T>
-void QuaternionFloatingMobilizer<
-    T>::set_random_quaternion_distribution(
+void QuaternionFloatingMobilizer<T>::set_random_quaternion_distribution(
         const Eigen::Quaternion<symbolic::Expression>& q_FM) {
   Vector<symbolic::Expression, kNq> positions;
   if (this->get_random_state_distribution()) {

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -84,16 +84,16 @@ Vector3<T> QuaternionFloatingMobilizer<T>::get_translation(
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-QuaternionFloatingMobilizer<T>::set_quaternion(
+QuaternionFloatingMobilizer<T>::SetQuaternion(
     systems::Context<T>* context, const Quaternion<T>& q_FM) const {
   DRAKE_DEMAND(context != nullptr);
-  set_quaternion(*context, q_FM, &context->get_mutable_state());
+  SetQuaternion(*context, q_FM, &context->get_mutable_state());
   return *this;
 }
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-QuaternionFloatingMobilizer<T>::set_quaternion(
+QuaternionFloatingMobilizer<T>::SetQuaternion(
     const systems::Context<T>&, const Quaternion<T>& q_FM,
     systems::State<T>* state) const {
   DRAKE_DEMAND(state != nullptr);
@@ -108,16 +108,15 @@ QuaternionFloatingMobilizer<T>::set_quaternion(
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-QuaternionFloatingMobilizer<T>::set_translation(systems::Context<T>* context,
-                                                const Vector3<T>& p_FM) const {
+QuaternionFloatingMobilizer<T>::SetTranslation(systems::Context<T>* context,
+                                               const Vector3<T>& p_FM) const {
   DRAKE_DEMAND(context != nullptr);
-  set_translation(*context, p_FM, &context->get_mutable_state());
-  return *this;
+  return SetTranslation(*context, p_FM, &context->get_mutable_state());
 }
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-QuaternionFloatingMobilizer<T>::set_translation(
+QuaternionFloatingMobilizer<T>::SetTranslation(
     const systems::Context<T>&, const Vector3<T>& p_FM,
     systems::State<T>* state) const {
   DRAKE_DEMAND(state != nullptr);

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -91,12 +91,12 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   // @param[in] q_FM
   //   The desired orientation of M in F to be stored in `context`.
   // @returns a constant reference to `this` mobilizer.
-  const QuaternionFloatingMobilizer<T>& set_quaternion(
+  const QuaternionFloatingMobilizer<T>& SetQuaternion(
       systems::Context<T>* context, const Quaternion<T>& q_FM) const;
 
-  // Alternative signature to set_quaternion(context, q_FM) to set `state` to
+  // Alternative signature to SetQuaternion(context, q_FM) to set `state` to
   // store the orientation of M in F given by the quaternion `q_FM`.
-  const QuaternionFloatingMobilizer<T>& set_quaternion(
+  const QuaternionFloatingMobilizer<T>& SetQuaternion(
       const systems::Context<T>& context,
       const Quaternion<T>& q_FM, systems::State<T>* state) const;
 
@@ -113,12 +113,12 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   // @param[in] p_FM
   //   The desired position of frame M in F to be stored in `context`.
   // @returns a constant reference to `this` mobilizer.
-  const QuaternionFloatingMobilizer<T>& set_translation(
+  const QuaternionFloatingMobilizer<T>& SetTranslation(
       systems::Context<T>* context, const Vector3<T>& p_FM) const;
 
-  // Alternative signature to set_translation(context, p_FM) to set `state` to
+  // Alternative signature to SetTranslation(context, p_FM) to set `state` to
   // store the position `p_FM` of M in F.
-  const QuaternionFloatingMobilizer<T>& set_translation(
+  const QuaternionFloatingMobilizer<T>& SetTranslation(
       const systems::Context<T>& context, const Vector3<T>& p_FM,
       systems::State<T>* state) const;
 
@@ -137,7 +137,7 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   const QuaternionFloatingMobilizer<T>& SetOrientation(
       systems::Context<T>* context, const math::RotationMatrix<T>& R_FM) const {
     const Eigen::Quaternion<T> q_FM = R_FM.ToQuaternion();
-    return set_quaternion(context, q_FM);
+    return SetQuaternion(context, q_FM);
   }
 
   // Returns the angular velocity `w_FM` of frame M in F stored in `context`.

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -50,7 +50,7 @@ Vector3<T> RpyBallMobilizer<T>::get_angles(
 }
 
 template <typename T>
-const RpyBallMobilizer<T>& RpyBallMobilizer<T>::set_angles(
+const RpyBallMobilizer<T>& RpyBallMobilizer<T>::SetAngles(
     systems::Context<T>* context, const Vector3<T>& angles) const {
   auto q = this->GetMutablePositions(context);
   q = angles;

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -105,7 +105,7 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   //   θ₂, described in this class's documentation, at entries angles(0),
   //   angles(1) and angles(2), respectively.
   // @returns a constant reference to this mobilizer.
-  const RpyBallMobilizer<T>& set_angles(
+  const RpyBallMobilizer<T>& SetAngles(
       systems::Context<T>* context,
       const Vector3<T>& angles) const;
 

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -166,7 +166,7 @@ class RpyFloatingJoint final : public Joint<T> {
 
   /** Sets the `context` so that the generalized coordinates corresponding to
   the roll-pitch-yaw rotation angles of this joint equals `angles`.
-  @param[in] context
+  @param[in,out] context
     A Context for the MultibodyPlant this joint belongs to.
   @param[in] angles
     Angles in radians to be stored in `context` ordered as θr, θp, θy.
@@ -181,7 +181,7 @@ class RpyFloatingJoint final : public Joint<T> {
 
   /** Sets the roll-pitch-yaw angles in `context` so this Joint's orientation
   is consistent with the given `R_FM` rotation matrix.
-  @param[in] context
+  @param[in,out] context
     A Context for the MultibodyPlant this joint belongs to.
   @param[in] R_FM
     The rotation matrix giving the orientation of frame M in frame F.
@@ -205,7 +205,7 @@ class RpyFloatingJoint final : public Joint<T> {
 
   /** Sets `context` to store the translation (position vector) `p_FM` of frame
   M's origin Mo measured and expressed in frame F.
-  @param[out] context
+  @param[in,out] context
     A Context for the MultibodyPlant this joint belongs to.
   @param[in] p_FM
     The desired position of frame M's origin in frame F, to be stored in
@@ -230,10 +230,10 @@ class RpyFloatingJoint final : public Joint<T> {
 
   /** Sets `context` to store `X_FM` the pose of frame M measured and expressed
   in frame F.
-  @param[out] context
+  @param[in,out] context
     A Context for the MultibodyPlant this joint belongs to.
   @param[in] X_FM
-    The desired pose of frame M in F to be stored in `context`.
+    The desired pose of frame M in frame F to be stored in `context`.
   @warning See class documentation for discussion of singular configurations.
   @returns a constant reference to `this` joint. */
   const RpyFloatingJoint<T>& SetPose(
@@ -246,7 +246,6 @@ class RpyFloatingJoint final : public Joint<T> {
 
   /** Retrieves from `context` the angular velocity `w_FM` of the child frame
   M in the parent frame F, expressed in F.
-
   @param[in] context
     A Context for the MultibodyPlant this joint belongs to.
   @retval w_FM
@@ -259,7 +258,7 @@ class RpyFloatingJoint final : public Joint<T> {
 
   /** Sets in `context` the state for this joint so that the angular velocity
   of the child frame M in the parent frame F is `w_FM`.
-  @param[out] context
+  @param[in,out] context
     A Context for the MultibodyPlant this joint belongs to.
   @param[in] w_FM
     A vector in ℝ³ with the angular velocity of the child frame M in the
@@ -287,7 +286,7 @@ class RpyFloatingJoint final : public Joint<T> {
 
   /** Sets in `context` the state for this joint so that the translational
   velocity of the child frame M's origin in the parent frame F is `v_FM`.
-  @param[out] context
+  @param[in,out] context
     A Context for the MultibodyPlant this joint belongs to.
   @param[in] v_FM
     A vector in ℝ³ with the translational velocity of the child frame M's

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -175,7 +175,7 @@ class RpyFloatingJoint final : public Joint<T> {
   @see get_angles() for details */
   const RpyFloatingJoint<T>& set_angles(Context<T>* context,
                                         const Vector3<T>& angles) const {
-    get_mobilizer().set_angles(context, angles);
+    get_mobilizer().SetAngles(context, angles);
     return *this;
   }
 
@@ -189,8 +189,7 @@ class RpyFloatingJoint final : public Joint<T> {
   @returns a constant reference to this joint. */
   const RpyFloatingJoint<T>& SetOrientation(
       systems::Context<T>* context, const math::RotationMatrix<T>& R_FM) const {
-    set_angles(context, math::RollPitchYaw(R_FM).vector());
-    return *this;
+    return set_angles(context, math::RollPitchYaw(R_FM).vector());
   }
 
   /** Returns the translation (position vector) `p_FM` of the child frame M's
@@ -213,7 +212,7 @@ class RpyFloatingJoint final : public Joint<T> {
   @returns a constant reference to this joint. */
   const RpyFloatingJoint<T>& SetTranslation(systems::Context<T>* context,
                                             const Vector3<T>& p_FM) const {
-    get_mobilizer().set_translation(context, p_FM);
+    get_mobilizer().SetTranslation(context, p_FM);
     return *this;
   }
 
@@ -246,8 +245,8 @@ class RpyFloatingJoint final : public Joint<T> {
   const RpyFloatingJoint<T>& SetPose(
       systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const {
     const math::RotationMatrix<T>& R_FM = X_FM.rotation();
-    get_mobilizer().set_angles(context, math::RollPitchYaw<T>(R_FM).vector());
-    get_mobilizer().set_translation(context, X_FM.translation());
+    get_mobilizer().SetAngles(context, math::RollPitchYaw<T>(R_FM).vector());
+    get_mobilizer().SetTranslation(context, X_FM.translation());
     return *this;
   }
 

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -211,10 +211,17 @@ class RpyFloatingJoint final : public Joint<T> {
     The desired position of frame M's origin in frame F, to be stored in
     `context`.
   @returns a constant reference to this joint. */
-  const RpyFloatingJoint<T>& set_translation(systems::Context<T>* context,
-                                             const Vector3<T>& p_FM) const {
+  const RpyFloatingJoint<T>& SetTranslation(systems::Context<T>* context,
+                                            const Vector3<T>& p_FM) const {
     get_mobilizer().set_translation(context, p_FM);
     return *this;
+  }
+
+  DRAKE_DEPRECATED("2024-08-01",
+      "Use RpyFloatingJoint::SetTranslation()")
+  const RpyFloatingJoint<T>& set_translation(systems::Context<T>* context,
+                                             const Vector3<T>& p_FM) const {
+    return SetTranslation(context, p_FM);
   }
 
   /** Returns the pose `X_FM` of the outboard frame M as measured and expressed

--- a/multibody/tree/rpy_floating_mobilizer.cc
+++ b/multibody/tree/rpy_floating_mobilizer.cc
@@ -93,7 +93,7 @@ Vector3<T> RpyFloatingMobilizer<T>::get_translational_velocity(
 }
 
 template <typename T>
-const RpyFloatingMobilizer<T>& RpyFloatingMobilizer<T>::set_angles(
+const RpyFloatingMobilizer<T>& RpyFloatingMobilizer<T>::SetAngles(
     systems::Context<T>* context, const Vector3<T>& angles) const {
   auto q = this->GetMutablePositions(context).template head<3>();
   q = angles;
@@ -102,8 +102,8 @@ const RpyFloatingMobilizer<T>& RpyFloatingMobilizer<T>::set_angles(
 
 template <typename T>
 const RpyFloatingMobilizer<T>&
-RpyFloatingMobilizer<T>::set_translation(systems::Context<T>* context,
-                                         const Vector3<T>& p_FM) const {
+RpyFloatingMobilizer<T>::SetTranslation(systems::Context<T>* context,
+                                        const Vector3<T>& p_FM) const {
   auto q = this->GetMutablePositions(context).template tail<3>();
   q = p_FM;
   return *this;
@@ -131,8 +131,8 @@ template <typename T>
 const RpyFloatingMobilizer<T>&
 RpyFloatingMobilizer<T>::SetFromRigidTransform(
     systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const {
-  set_angles(context, math::RollPitchYaw<T>(X_FM.rotation()).vector());
-  set_translation(context, X_FM.translation());
+  SetAngles(context, math::RollPitchYaw<T>(X_FM.rotation()).vector());
+  SetTranslation(context, X_FM.translation());
   return *this;
 }
 

--- a/multibody/tree/rpy_floating_mobilizer.h
+++ b/multibody/tree/rpy_floating_mobilizer.h
@@ -152,7 +152,7 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   //   θ₀, θ₁, θ₂, described in this class's documentation, at entries
   //   angles(0), angles(1) and angles(2), respectively.
   // @returns a constant reference to this mobilizer.
-  const RpyFloatingMobilizer<T>& set_angles(
+  const RpyFloatingMobilizer<T>& SetAngles(
       systems::Context<T>* context, const Vector3<T>& angles) const;
 
   // Stores in context the position p_FM of M in F.
@@ -162,7 +162,7 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   // @param[in] p_FM
   //   Position of F in M.
   // @returns a constant reference to this mobilizer.
-  const RpyFloatingMobilizer<T>& set_translation(
+  const RpyFloatingMobilizer<T>& SetTranslation(
       systems::Context<T>* context, const Vector3<T>& p_FM) const;
 
   // Sets the distribution governing the random samples of the rpy angles

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -146,7 +146,7 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
     //   C's angular velocity in A expressed in A,
     //   Co's translational velocity in A expressed in A.
     joint_->SetOrientation(&context, R_AC);
-    joint_->set_translation(&context, p_AoCo_A);
+    joint_->SetTranslation(&context, p_AoCo_A);
     joint_->set_angular_velocity(&context, w_AC_A);
     joint_->set_translational_velocity(&context, v_ACo_A);
 

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -145,7 +145,7 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
     //   Co's position from Ao expressed in frame A,
     //   C's angular velocity in A expressed in A,
     //   Co's translational velocity in A expressed in A.
-    joint_->SetFromRotationMatrix(&context, R_AC);
+    joint_->SetOrientation(&context, R_AC);
     joint_->set_translation(&context, p_AoCo_A);
     joint_->set_angular_velocity(&context, w_AC_A);
     joint_->set_translational_velocity(&context, v_ACo_A);
@@ -677,7 +677,7 @@ TEST_F(LinearBushingRollPitchYawTester, TestGimbalLock) {
   // Use the mobilizer to set frame C's pose and motion in frame A.
   const RotationMatrixd R_AC(rpy_gimbal_lock);
   systems::Context<double>& context = *(context_.get());
-  joint_->SetFromRotationMatrix(&context, R_AC);
+  joint_->SetOrientation(&context, R_AC);
   joint_->set_translation(&context, p_zero);
   joint_->set_angular_velocity(&context, w_zero);
   joint_->set_translational_velocity(&context, v_zero);

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -678,7 +678,7 @@ TEST_F(LinearBushingRollPitchYawTester, TestGimbalLock) {
   const RotationMatrixd R_AC(rpy_gimbal_lock);
   systems::Context<double>& context = *(context_.get());
   joint_->SetOrientation(&context, R_AC);
-  joint_->set_translation(&context, p_zero);
+  joint_->SetTranslation(&context, p_zero);
   joint_->set_angular_velocity(&context, w_zero);
   joint_->set_translational_velocity(&context, v_zero);
 

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -146,7 +146,7 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
     //   C's angular velocity in A expressed in A,
     //   Co's translational velocity in A expressed in A.
     joint_->SetFromRotationMatrix(&context, R_AC);
-    joint_->set_position(&context, p_AoCo_A);
+    joint_->set_translation(&context, p_AoCo_A);
     joint_->set_angular_velocity(&context, w_AC_A);
     joint_->set_translational_velocity(&context, v_ACo_A);
 
@@ -678,7 +678,7 @@ TEST_F(LinearBushingRollPitchYawTester, TestGimbalLock) {
   const RotationMatrixd R_AC(rpy_gimbal_lock);
   systems::Context<double>& context = *(context_.get());
   joint_->SetFromRotationMatrix(&context, R_AC);
-  joint_->set_position(&context, p_zero);
+  joint_->set_translation(&context, p_zero);
   joint_->set_angular_velocity(&context, w_zero);
   joint_->set_translational_velocity(&context, v_zero);
 

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -191,8 +191,7 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
   joint_->SetOrientation(context_.get(), RotationMatrixd::Identity());
   joint_->SetTranslation(context_.get(), Vector3d::Zero());  // Zero out pose.
   joint_->SetPose(context_.get(), transform_A);
-  // We expect a bit of roundoff error due to transforming between quaternion
-  // and rotation matrix representations.
+  // Expect roundoff error in converting the quaternion to a rotation matrix.
   EXPECT_TRUE(
       joint_->GetPose(*context_).IsNearlyEqualTo(transform_A, kTolerance));
 

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -269,7 +269,12 @@ TEST_F(QuaternionFloatingJointTest, Clone) {
             joint_->default_translational_damping());
   EXPECT_EQ(joint_clone.get_default_quaternion().coeffs(),
             joint_->get_default_quaternion().coeffs());
+  EXPECT_EQ(joint_clone.get_default_translation(),
+            joint_->get_default_translation());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_EQ(joint_clone.get_default_position(), joint_->get_default_position());
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 }
 
 TEST_F(QuaternionFloatingJointTest, SetVelocityAndAccelerationLimits) {

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -170,7 +170,7 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
       joint_->get_quaternion(*context_), quaternion_A, kTolerance));
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
-  joint_->set_translation(context_.get(), position);
+  joint_->SetTranslation(context_.get(), position);
   EXPECT_EQ(joint_->get_translation(*context_), position);
 
 #pragma GCC diagnostic push
@@ -181,13 +181,15 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  joint_->set_translation(context_.get(), Vector3d::Zero());  // Zero out pose.
+  joint_->SetOrientation(context_.get(), RotationMatrixd::Identity());
+  joint_->SetTranslation(context_.get(), Vector3d::Zero());  // Zero out pose.
   joint_->set_pose(context_.get(), transform_A);
   EXPECT_TRUE(
       joint_->get_pose(*context_).IsNearlyEqualTo(transform_A, kTolerance));
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
-  joint_->set_translation(context_.get(), Vector3d::Zero());  // Zero out pose.
+  joint_->SetOrientation(context_.get(), RotationMatrixd::Identity());
+  joint_->SetTranslation(context_.get(), Vector3d::Zero());  // Zero out pose.
   joint_->SetPose(context_.get(), transform_A);
   // We expect a bit of roundoff error due to transforming between quaternion
   // and rotation matrix representations.

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -154,13 +154,20 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
   const RigidTransformd transform_A(quaternion_A, position);
   const RotationMatrixd rotation_matrix_B(quaternion_B);
 
-  // Position access:
+  // Position access (orientation and translation):
   joint_->set_quaternion(context_.get(), quaternion_A);
   EXPECT_EQ(joint_->get_quaternion(*context_).coeffs(), quaternion_A.coeffs());
 
+  joint_->SetOrientation(context_.get(), rotation_matrix_B);
+  EXPECT_TRUE(math::AreQuaternionsEqualForOrientation(
+      joint_->get_quaternion(*context_), quaternion_B, kTolerance));
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   joint_->SetFromRotationMatrix(context_.get(), rotation_matrix_B);
   EXPECT_TRUE(math::AreQuaternionsEqualForOrientation(
       joint_->get_quaternion(*context_), quaternion_B, kTolerance));
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   joint_->set_translation(context_.get(), position);
   EXPECT_EQ(joint_->get_translation(*context_), position);
@@ -382,7 +389,11 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
 
   mutable_joint_->set_random_quaternion_distribution(
       math::UniformlyRandomQuaternion<symbolic::Expression>(&generator));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   mutable_joint_->set_random_position_distribution(position_distribution);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+  mutable_joint_->set_random_translation_distribution(position_distribution);
   tree().SetRandomState(*context_, &context_->get_mutable_state(),
                            &generator);
   // We expect arbitrary non-zero values for the random state.
@@ -391,7 +402,12 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
   // Set position and quaternion distributions back to 0.
   mutable_joint_->set_random_quaternion_distribution(
       Eigen::Quaternion<symbolic::Expression>::Identity());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   mutable_joint_->set_random_position_distribution(
+      Eigen::Matrix<symbolic::Expression, 3, 1>::Zero());
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+  mutable_joint_->set_random_translation_distribution(
       Eigen::Matrix<symbolic::Expression, 3, 1>::Zero());
   tree().SetRandomState(*context_, &context_->get_mutable_state(),
                            &generator);

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -164,9 +164,10 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  joint_->SetFromRotationMatrix(context_.get(), rotation_matrix_B);
+  const RotationMatrixd rotation_matrix_A(quaternion_A);
+  joint_->SetFromRotationMatrix(context_.get(), rotation_matrix_A);
   EXPECT_TRUE(math::AreQuaternionsEqualForOrientation(
-      joint_->get_quaternion(*context_), quaternion_B, kTolerance));
+      joint_->get_quaternion(*context_), quaternion_A, kTolerance));
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   joint_->set_translation(context_.get(), position);
@@ -174,24 +175,24 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  joint_->set_position(context_.get(), position);
-  EXPECT_EQ(joint_->get_position(*context_), position);
+  joint_->set_position(context_.get(), Vector3d(0.3, 0.2, 0.1));
+  EXPECT_EQ(joint_->get_position(*context_), Vector3d(0.3, 0.2, 0.1));
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
-  joint_->set_translation(context_.get(), Vector3d::Zero());  // Zero out pose.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  joint_->set_translation(context_.get(), Vector3d::Zero());  // Zero out pose.
   joint_->set_pose(context_.get(), transform_A);
   EXPECT_TRUE(
       joint_->get_pose(*context_).IsNearlyEqualTo(transform_A, kTolerance));
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
+  joint_->set_translation(context_.get(), Vector3d::Zero());  // Zero out pose.
   joint_->SetPose(context_.get(), transform_A);
   // We expect a bit of roundoff error due to transforming between quaternion
   // and rotation matrix representations.
   EXPECT_TRUE(
       joint_->GetPose(*context_).IsNearlyEqualTo(transform_A, kTolerance));
-
 
   // Angular velocity access:
   joint_->set_angular_velocity(context_.get(), angular_velocity);
@@ -389,10 +390,6 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
   tree().SetRandomState(*context_, &context_->get_mutable_state(),
                            &generator);
   EXPECT_TRUE(joint_->GetPose(*context_).IsExactlyIdentity());
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  EXPECT_TRUE(joint_->get_pose(*context_).IsExactlyIdentity());
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   // Set the position distribution to arbitrary values.
   Eigen::Matrix<symbolic::Expression, 3, 1> position_distribution;
@@ -411,10 +408,6 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
                            &generator);
   // We expect arbitrary non-zero values for the random state.
   EXPECT_FALSE(joint_->GetPose(*context_).IsExactlyIdentity());
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  EXPECT_FALSE(joint_->get_pose(*context_).IsExactlyIdentity());
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   // Set position and quaternion distributions back to 0.
   mutable_joint_->set_random_quaternion_distribution(
@@ -430,10 +423,6 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
                            &generator);
   // We expect zero values for pose.
   EXPECT_TRUE(joint_->GetPose(*context_).IsExactlyIdentity());
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  EXPECT_TRUE(joint_->get_pose(*context_).IsExactlyIdentity());
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   // Set the quaternion distribution using built in uniform sampling.
   mutable_joint_->set_random_quaternion_distribution_to_uniform();
@@ -441,10 +430,6 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
                            &generator);
   // We expect arbitrary non-zero pose.
   EXPECT_FALSE(joint_->GetPose(*context_).IsExactlyIdentity());
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  EXPECT_FALSE(joint_->get_pose(*context_).IsExactlyIdentity());
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 }
 
 }  // namespace

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -179,11 +179,19 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   joint_->set_translation(context_.get(), Vector3d::Zero());  // Zero out pose.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   joint_->set_pose(context_.get(), transform_A);
+  EXPECT_TRUE(
+      joint_->get_pose(*context_).IsNearlyEqualTo(transform_A, kTolerance));
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+
+  joint_->SetPose(context_.get(), transform_A);
   // We expect a bit of roundoff error due to transforming between quaternion
   // and rotation matrix representations.
   EXPECT_TRUE(
-      joint_->get_pose(*context_).IsNearlyEqualTo(transform_A, kTolerance));
+      joint_->GetPose(*context_).IsNearlyEqualTo(transform_A, kTolerance));
+
 
   // Angular velocity access:
   joint_->set_angular_velocity(context_.get(), angular_velocity);
@@ -380,7 +388,12 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
   // Default behavior is to set to zero.
   tree().SetRandomState(*context_, &context_->get_mutable_state(),
                            &generator);
+  EXPECT_TRUE(joint_->GetPose(*context_).IsExactlyIdentity());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_TRUE(joint_->get_pose(*context_).IsExactlyIdentity());
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+
   // Set the position distribution to arbitrary values.
   Eigen::Matrix<symbolic::Expression, 3, 1> position_distribution;
   for (int i = 0; i < 3; i++) {
@@ -397,7 +410,11 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
   tree().SetRandomState(*context_, &context_->get_mutable_state(),
                            &generator);
   // We expect arbitrary non-zero values for the random state.
+  EXPECT_FALSE(joint_->GetPose(*context_).IsExactlyIdentity());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_FALSE(joint_->get_pose(*context_).IsExactlyIdentity());
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   // Set position and quaternion distributions back to 0.
   mutable_joint_->set_random_quaternion_distribution(
@@ -412,14 +429,22 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
   tree().SetRandomState(*context_, &context_->get_mutable_state(),
                            &generator);
   // We expect zero values for pose.
+  EXPECT_TRUE(joint_->GetPose(*context_).IsExactlyIdentity());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_TRUE(joint_->get_pose(*context_).IsExactlyIdentity());
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   // Set the quaternion distribution using built in uniform sampling.
   mutable_joint_->set_random_quaternion_distribution_to_uniform();
   tree().SetRandomState(*context_, &context_->get_mutable_state(),
                            &generator);
   // We expect arbitrary non-zero pose.
+  EXPECT_FALSE(joint_->GetPose(*context_).IsExactlyIdentity());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_FALSE(joint_->get_pose(*context_).IsExactlyIdentity());
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 }
 
 }  // namespace

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -154,9 +154,15 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
   const RigidTransformd transform_A(quaternion_A, position);
   const RotationMatrixd rotation_matrix_B(quaternion_B);
 
-  // Position access (orientation and translation):
-  joint_->set_quaternion(context_.get(), quaternion_A);
+  // Test configuration (orientation and translation).
+  joint_->SetQuaternion(context_.get(), quaternion_A);
   EXPECT_EQ(joint_->get_quaternion(*context_).coeffs(), quaternion_A.coeffs());
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  joint_->set_quaternion(context_.get(), quaternion_B);
+  EXPECT_EQ(joint_->get_quaternion(*context_).coeffs(), quaternion_B.coeffs());
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   joint_->SetOrientation(context_.get(), rotation_matrix_B);
   EXPECT_TRUE(math::AreQuaternionsEqualForOrientation(

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -162,10 +162,16 @@ TEST_F(QuaternionFloatingJointTest, ContextDependentAccess) {
   EXPECT_TRUE(math::AreQuaternionsEqualForOrientation(
       joint_->get_quaternion(*context_), quaternion_B, kTolerance));
 
+  joint_->set_translation(context_.get(), position);
+  EXPECT_EQ(joint_->get_translation(*context_), position);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   joint_->set_position(context_.get(), position);
   EXPECT_EQ(joint_->get_position(*context_), position);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
-  joint_->set_position(context_.get(), Vector3d::Zero());  // Zero out pose.
+  joint_->set_translation(context_.get(), Vector3d::Zero());  // Zero out pose.
   joint_->set_pose(context_.get(), transform_A);
   // We expect a bit of roundoff error due to transforming between quaternion
   // and rotation matrix representations.

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -50,12 +50,12 @@ TEST_F(QuaternionFloatingMobilizerTest, CanRotateOrTranslate) {
 TEST_F(QuaternionFloatingMobilizerTest, StateAccess) {
   const Quaterniond quaternion_value(
       RollPitchYawd(M_PI / 3, -M_PI / 3, M_PI / 5).ToQuaternion());
-  mobilizer_->set_quaternion(context_.get(), quaternion_value);
+  mobilizer_->SetQuaternion(context_.get(), quaternion_value);
   EXPECT_EQ(mobilizer_->get_quaternion(*context_).coeffs(),
             quaternion_value.coeffs());
 
   const Vector3d translation_value(1.0, 2.0, 3.0);
-  mobilizer_->set_translation(context_.get(), translation_value);
+  mobilizer_->SetTranslation(context_.get(), translation_value);
   EXPECT_EQ(mobilizer_->get_translation(*context_), translation_value);
 
   // Set mobilizer orientation using a rotation matrix.
@@ -71,7 +71,7 @@ TEST_F(QuaternionFloatingMobilizerTest, ZeroState) {
   // Set an arbitrary "non-zero" state.
   const Quaterniond quaternion_value(
       RollPitchYawd(M_PI / 3, -M_PI / 3, M_PI / 5).ToQuaternion());
-  mobilizer_->set_quaternion(context_.get(), quaternion_value);
+  mobilizer_->SetQuaternion(context_.get(), quaternion_value);
   EXPECT_EQ(mobilizer_->get_quaternion(*context_).coeffs(),
             quaternion_value.coeffs());
 
@@ -141,10 +141,10 @@ TEST_F(QuaternionFloatingMobilizerTest, RandomState) {
 TEST_F(QuaternionFloatingMobilizerTest, KinematicMapping) {
   const Quaterniond Q_WB(
       RollPitchYawd(M_PI / 3, -M_PI / 3, M_PI / 5).ToQuaternion());
-  mobilizer_->set_quaternion(context_.get(), Q_WB);
+  mobilizer_->SetQuaternion(context_.get(), Q_WB);
 
   const Vector3d p_WB(1.0, 2.0, 3.0);
-  mobilizer_->set_translation(context_.get(), p_WB);
+  mobilizer_->SetTranslation(context_.get(), p_WB);
 
   ASSERT_EQ(mobilizer_->num_positions(), 7);
   ASSERT_EQ(mobilizer_->num_velocities(), 6);
@@ -167,10 +167,10 @@ TEST_F(QuaternionFloatingMobilizerTest, KinematicMapping) {
 
 TEST_F(QuaternionFloatingMobilizerTest, CheckExceptionMessage) {
   const Quaterniond quaternion(0, 0, 0, 0);
-  mobilizer_->set_quaternion(context_.get(), quaternion);
+  mobilizer_->SetQuaternion(context_.get(), quaternion);
 
   const Vector3d translation(0, 0, 0);
-  mobilizer_->set_translation(context_.get(), translation);
+  mobilizer_->SetTranslation(context_.get(), translation);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       mobilizer_->CalcAcrossMobilizerTransform(*context_),
@@ -182,10 +182,10 @@ TEST_F(QuaternionFloatingMobilizerTest, MapUsesN) {
   // Set an arbitrary "non-zero" state.
   const Quaterniond Q_WB(
       RollPitchYawd(M_PI / 3, -M_PI / 3, M_PI / 5).ToQuaternion());
-  mobilizer_->set_quaternion(context_.get(), Q_WB);
+  mobilizer_->SetQuaternion(context_.get(), Q_WB);
 
   const Vector3d p_WB(1.0, 2.0, 3.0);
-  mobilizer_->set_translation(context_.get(), p_WB);
+  mobilizer_->SetTranslation(context_.get(), p_WB);
 
   EXPECT_FALSE(mobilizer_->is_velocity_equal_to_qdot());
 
@@ -208,10 +208,10 @@ TEST_F(QuaternionFloatingMobilizerTest, MapUsesNplus) {
   // Set an arbitrary "non-zero" state.
   const Quaterniond Q_WB(
       RollPitchYawd(M_PI / 3, -M_PI / 3, M_PI / 5).ToQuaternion());
-  mobilizer_->set_quaternion(context_.get(), Q_WB);
+  mobilizer_->SetQuaternion(context_.get(), Q_WB);
 
   const Vector3d p_WB(1.0, 2.0, 3.0);
-  mobilizer_->set_translation(context_.get(), p_WB);
+  mobilizer_->SetTranslation(context_.get(), p_WB);
 
   // Set arbitrary qdot and MapQDotToVelocity
   VectorX<double> qdot(7);

--- a/multibody/tree/test/rpy_ball_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_ball_mobilizer_test.cc
@@ -51,7 +51,7 @@ TEST_F(RpyBallMobilizerTest, CanRotateOrTranslate) {
 // Verifies methods to mutate and access the context.
 TEST_F(RpyBallMobilizerTest, StateAccess) {
   const Vector3d rpy_value(M_PI / 3, -M_PI / 3, M_PI / 5);
-  mobilizer_->set_angles(context_.get(), rpy_value);
+  mobilizer_->SetAngles(context_.get(), rpy_value);
   EXPECT_EQ(mobilizer_->get_angles(*context_), rpy_value);
 
   // Set mobilizer orientation using a rotation matrix.
@@ -66,7 +66,7 @@ TEST_F(RpyBallMobilizerTest, StateAccess) {
 TEST_F(RpyBallMobilizerTest, ZeroState) {
   // Set an arbitrary "non-zero" state.
   const Vector3d rpy_value(M_PI / 3, -M_PI / 3, M_PI / 5);
-  mobilizer_->set_angles(context_.get(), rpy_value);
+  mobilizer_->SetAngles(context_.get(), rpy_value);
   EXPECT_EQ(mobilizer_->get_angles(*context_), rpy_value);
 
   // Set the "zero state" for this mobilizer, which does happen to be that of
@@ -81,7 +81,7 @@ TEST_F(RpyBallMobilizerTest, ZeroState) {
 // inverse of N(q).
 TEST_F(RpyBallMobilizerTest, KinematicMapping) {
   const Vector3d rpy(M_PI / 3, -M_PI / 3, M_PI / 5);
-  mobilizer_->set_angles(context_.get(), rpy);
+  mobilizer_->SetAngles(context_.get(), rpy);
 
   ASSERT_EQ(mobilizer_->num_positions(), 3);
   ASSERT_EQ(mobilizer_->num_velocities(), 3);
@@ -109,7 +109,7 @@ TEST_F(RpyBallMobilizerTest, KinematicMapping) {
 TEST_F(RpyBallMobilizerTest, MapUsesN) {
   // Set an arbitrary "non-zero" state.
   const Vector3d rpy_value(M_PI / 3, -M_PI / 3, M_PI / 5);
-  mobilizer_->set_angles(context_.get(), rpy_value);
+  mobilizer_->SetAngles(context_.get(), rpy_value);
 
   EXPECT_FALSE(mobilizer_->is_velocity_equal_to_qdot());
 
@@ -130,7 +130,7 @@ TEST_F(RpyBallMobilizerTest, MapUsesN) {
 TEST_F(RpyBallMobilizerTest, MapUsesNplus) {
   // Set an arbitrary "non-zero" state.
   const Vector3d rpy_value(M_PI / 3, -M_PI / 3, M_PI / 5);
-  mobilizer_->set_angles(context_.get(), rpy_value);
+  mobilizer_->SetAngles(context_.get(), rpy_value);
 
   // Set arbitrary qdot and MapQDotToVelocity.
   const Vector3<double> qdot = (Vector3<double>() << 1, 2, 3).finished();
@@ -149,7 +149,7 @@ TEST_F(RpyBallMobilizerTest, MapUsesNplus) {
 TEST_F(RpyBallMobilizerTest, SingularityError) {
   // Set state in singularity
   const Vector3d rpy_value(M_PI / 3, M_PI / 2, M_PI / 5);
-  mobilizer_->set_angles(context_.get(), rpy_value);
+  mobilizer_->SetAngles(context_.get(), rpy_value);
 
   // Set arbitrary qdot and MapVelocityToQDot.
   const Vector3<double> v = (Vector3<double>() << 1, 2, 3).finished();

--- a/multibody/tree/test/rpy_floating_joint_test.cc
+++ b/multibody/tree/test/rpy_floating_joint_test.cc
@@ -164,11 +164,17 @@ TEST_F(RpyFloatingJointTest, ContextDependentAccess) {
   EXPECT_TRUE(
       CompareMatrices(joint_->get_angles(*context_), angles_B, kTolerance));
 
-  joint_->set_translation(context_.get(), translation);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  joint_->set_translation(context_.get(), Vector3d(0.3, 0.2, 0.1));
+  EXPECT_EQ(joint_->get_translation(*context_), Vector3d(0.3, 0.2, 0.1));
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+
+  joint_->SetTranslation(context_.get(), translation);
   EXPECT_EQ(joint_->get_translation(*context_), translation);
 
   joint_->set_angles(context_.get(), Vector3d::Zero());  // Zero out pose.
-  joint_->set_translation(context_.get(), Vector3d::Zero());
+  joint_->SetTranslation(context_.get(), Vector3d::Zero());
   joint_->SetPose(context_.get(), transform_A);
   // We expect a bit of roundoff error due to transforming between rpy
   // and rotation matrix representations.

--- a/multibody/tree/test/rpy_floating_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_floating_mobilizer_test.cc
@@ -37,8 +37,8 @@ class RpyFloatingMobilizerTest : public MobilizerTester {
   // Helper to set the this fixture's context to an arbitrary non-zero state
   // comprised of arbitrary_rpy() and arbitrary_translation().
   void SetArbitraryNonZeroState() {
-    mobilizer_->set_angles(context_.get(), arbitrary_rpy().vector());
-    mobilizer_->set_translation(context_.get(), arbitrary_translation());
+    mobilizer_->SetAngles(context_.get(), arbitrary_rpy().vector());
+    mobilizer_->SetTranslation(context_.get(), arbitrary_translation());
   }
 
   RollPitchYawd arbitrary_rpy() const {
@@ -230,7 +230,7 @@ TEST_F(RpyFloatingMobilizerTest, MapVelocityToQdotAndBack) {
 // inverse of N(q).
 TEST_F(RpyFloatingMobilizerTest, KinematicMapping) {
   RollPitchYawd rpy(M_PI / 3, -M_PI / 3, M_PI / 5);
-  mobilizer_->set_angles(context_.get(), rpy.vector());
+  mobilizer_->SetAngles(context_.get(), rpy.vector());
 
   ASSERT_EQ(mobilizer_->num_positions(), 6);
   ASSERT_EQ(mobilizer_->num_velocities(), 6);
@@ -287,7 +287,7 @@ TEST_F(RpyFloatingMobilizerTest, MapUsesNplus) {
 TEST_F(RpyFloatingMobilizerTest, SingularityError) {
   // Set state in singularity
   const Vector3d rpy_value(M_PI / 3, M_PI / 2, M_PI / 5);
-  mobilizer_->set_angles(context_.get(), rpy_value);
+  mobilizer_->SetAngles(context_.get(), rpy_value);
 
   // Set arbitrary qdot and MapVelocityToQDot.
   const Vector6<double> v = (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();

--- a/multibody/tree/test/universal_mobilizer_test.cc
+++ b/multibody/tree/test/universal_mobilizer_test.cc
@@ -95,11 +95,11 @@ TEST_F(UniversalMobilizerTest, DefaultPosition) {
 
   EXPECT_EQ(mobilizer_->get_angles(*context_), Vector2d::Zero());
 
-  Vector2d new_defualt(.4, .5);
-  mutable_mobilizer->set_default_position(new_defualt);
+  Vector2d new_default(.4, .5);
+  mutable_mobilizer->set_default_position(new_default);
   mobilizer_->set_default_state(*context_, &context_->get_mutable_state());
 
-  EXPECT_EQ(mobilizer_->get_angles(*context_), new_defualt);
+  EXPECT_EQ(mobilizer_->get_angles(*context_), new_default);
 }
 
 TEST_F(UniversalMobilizerTest, RandomState) {


### PR DESCRIPTION
Better consistency between QuaternionFloatingJoint and RpyFloatingJointClasses.

Deprecate the following in the QuaternionFloatingJoint class in favor of new names.
get_position() - > get_translation().
set_position() -> SetTranslation().
get_default_position() -> get_default_translation().
set_default_position() -> set_default_translation().
SetFromRotationMatrix()  ->  SetOrientation().
set_quaternion()  ->  SetQuaternion().
get_pose() -> GetPose().
set_pose() -> SetPose().
set_random_position_distribution()  ->  set_random_translation_distribution().

Deprecate the following in the RpyFloatingJoint class in favor of new names.
set_translation() -> SetTranslation().
set_orientation() -> SetOrientation().

MutibodyPlant::SetFreeBodyRandomPositionDistribution() -> SetFreeBodyRandomTranslationDistribution().
get_default_pose():   deprecate for deletion;    the Joint base class provides GetDefaultPose().

Update some of the underlying internal code with proper cases.
QuaternionFloatingMobilizer::set_quaternion() -> SetQuaternion().
QuaternionFloatingMobilizer::set_translation() -> SetTranslation().

RpyFloatingMobilizer::set_angles() -> SetAngles().
RpyFloatingMobilizer::set_translation() -> SetTranslation().

RpyBallMobilizer::set_angles() -> RpyBallMobilizer::SetAngles().

Resolves #20942

Integrate these changes into ANZU by ANZU PR [#12443](https://github.shared-services.aws.tri.global/robotics/anzu/pull/12443)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21169)
<!-- Reviewable:end -->
