### PR TITLE
Set shard_count for slow test

### DIFF
--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -171,6 +171,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "gcs_trajectory_optimization_test",
+    shard_count = 8,
     deps = [
         ":gcs_trajectory_optimization",
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
Clarabel is slower than Mosek, which results in the more extensive memory check test to time out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21172)
<!-- Reviewable:end -->
