### PR TITLE
Update geometry/optimization to use Mesh/Convex::convex_hull()

### DIFF
--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -295,31 +295,6 @@ GTEST_TEST(VPolytopeTest, NonconvexMesh) {
   EXPECT_TRUE(V.PointInSet(V.MaybeGetFeasiblePoint().value()));
 }
 
-// Confirm that VPolytope will complain about non-obj mesh/convex shapes even
-// if SceneGraph stops complaining. Likewise confirm that GetVertices complains.
-GTEST_TEST(VPolytopeTest, UnsupportedMeshTypes) {
-  const Convex convex("bad_extension.stl");
-  const Mesh mesh("bad_extension.stl");
-
-  for (const auto* shape : std::vector<const Shape*>{&convex, &mesh}) {
-    const RigidTransformd X_WG;
-    // We can't add proximity properties; ProximityEngine would reject it.
-    const bool add_proximity_properties = false;
-    auto [scene_graph, geom_id] =
-        MakeSceneGraphWithShape(*shape, X_WG, add_proximity_properties);
-    auto context = scene_graph->CreateDefaultContext();
-    auto query = scene_graph->get_query_output_port().Eval<QueryObject<double>>(
-        *context);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        VPolytope(query, geom_id),
-        "VPolytope can only use mesh shapes .* '.*bad_extension.stl'.");
-  }
-
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      GetVertices(convex),
-      "GetVertices\\(\\) can only use mesh shapes .* '.*bad_extension.stl'.");
-}
-
 GTEST_TEST(VPolytopeTest, UnitBox6DTest) {
   VPolytope V = VPolytope::MakeUnitBox(6);
   EXPECT_EQ(V.ambient_dimension(), 6);
@@ -821,7 +796,7 @@ GTEST_TEST(VPolytopeTest, GetMinimalRepresentationTest) {
 }
 
 // Confirm that WriteObj generates an Obj file that can be read back in to
-// obtain the same VPolytope. All of the geometry work is done by qhull; this
+// obtain the same VPolytope. All of the geometry work is done by Convex; this
 // test simply covers the data flow.
 GTEST_TEST(VPolytopeTest, WriteObjTest) {
   VPolytope V = VPolytope::MakeUnitBox(3);

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -80,39 +80,13 @@ MatrixXd OrderCounterClockwise(const MatrixXd& vertices) {
   return sorted_vertices;
 }
 
-MatrixXd GetConvexHullFromObjFile(const std::string& filename,
-                                  const std::string& extension, double scale,
-                                  std::string_view prefix) {
-  if (extension != ".obj") {
-    throw std::runtime_error(fmt::format(
-        "{} can only use mesh shapes (i.e.., Convex, Mesh) with a .obj file "
-        "type; given '{}'.",
-        prefix, filename));
-  }
-  const auto [tinyobj_vertices, faces, num_faces] =
-      internal::ReadObjFile(filename, scale, /* triangulate = */ false);
-  unused(faces);
-  unused(num_faces);
-  orgQhull::Qhull qhull;
-  const int dim = 3;
-  std::vector<double> tinyobj_vertices_flat(tinyobj_vertices->size() * dim);
-  for (int i = 0; i < ssize(*tinyobj_vertices); ++i) {
-    for (int j = 0; j < dim; ++j) {
-      tinyobj_vertices_flat[dim * i + j] = (*tinyobj_vertices)[i](j);
-    }
-  }
-  qhull.runQhull("", dim, tinyobj_vertices->size(),
-                 tinyobj_vertices_flat.data(), "");
-  if (qhull.qhullStatus() != 0) {
-    throw std::runtime_error(
-        fmt::format("Qhull terminated with status {} and  message:\n{}",
-                    qhull.qhullStatus(), qhull.qhullMessage()));
-  }
-  Matrix3Xd vertices(3, qhull.vertexCount());
-  int vertex_count = 0;
-  for (const auto& qhull_vertex : qhull.vertexList()) {
-    vertices.col(vertex_count++) =
-        Eigen::Map<Vector3d>(qhull_vertex.point().toStdVector().data());
+// Extract the vertices from a convex hull. The result is a (3, V) matrix where
+// `hull` has V vertices. The hull should come from an invocation of either
+// Mesh::convex_hull() or Convex::convex_hull().
+MatrixXd GetConvexHullVertices(const PolygonSurfaceMesh<double>& hull) {
+  Matrix3Xd vertices(3, hull.num_vertices());
+  for (int vi = 0; vi < hull.num_vertices(); ++vi) {
+    vertices.col(vi) = hull.vertex(vi);
   }
   return vertices;
 }
@@ -650,20 +624,17 @@ void VPolytope::ImplementGeometry(const Box& box, void* data) {
 void VPolytope::ImplementGeometry(const Convex& convex, void* data) {
   DRAKE_ASSERT(data != nullptr);
   Matrix3Xd* vertex_data = static_cast<Matrix3Xd*>(data);
-  *vertex_data = GetConvexHullFromObjFile(convex.filename(), convex.extension(),
-                                          convex.scale(), "VPolytope");
+  *vertex_data = GetConvexHullVertices(convex.convex_hull());
 }
 
 void VPolytope::ImplementGeometry(const Mesh& mesh, void* data) {
   DRAKE_ASSERT(data != nullptr);
   Matrix3Xd* vertex_data = static_cast<Matrix3Xd*>(data);
-  *vertex_data = GetConvexHullFromObjFile(mesh.filename(), mesh.extension(),
-                                          mesh.scale(), "VPolytope");
+  *vertex_data = GetConvexHullVertices(mesh.convex_hull());
 }
 
 MatrixXd GetVertices(const Convex& convex) {
-  return GetConvexHullFromObjFile(convex.filename(), convex.extension(),
-                                  convex.scale(), "GetVertices()");
+  return GetConvexHullVertices(convex.convex_hull());
 }
 
 }  // namespace optimization


### PR DESCRIPTION
This removes the need for the custom test on supported file types. VPolytope is no longer responsible for computing the convex hull.