### PR TITLE
Require MOSEK and Gurobi during memory check

### DIFF
--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -178,6 +178,8 @@ drake_cc_googletest(
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
         "//common/trajectories:piecewise_polynomial",
+        "//solvers:gurobi_solver",
+        "//solvers:mosek_solver",
     ],
 )
 


### PR DESCRIPTION
Even with a shard_count, the memory checking CI takes 15-30 minutes on certain test cases. Requiring both MOSEK and Gurobi to be enabled brings the total test down to about a minute. See the results below with the bazel configurations:

Without the guard in this PR:
| Enabled Bazel Configurations  | Runtime    |
| ----------------------------- | ---------- |
| Memcheck and MOSEK and Gurobi | 2 minutes  |
| Memcheck and Gurobi           | 5 minutes  |
| Memcheck and MOSEK            | 8 minutes  |
| Memcheck                      | 15 minutes |

With the guard on:
| Enabled Bazel Configurations  | Runtime   |
| ----------------------------- | --------- |
| Memcheck and MOSEK and Gurobi | 2 minutes |
| Memcheck and Gurobi           | 36 s      |
| Memcheck and MOSEK            | 226 s     |
| Memcheck                      | 178 s     |
| MOSEK and Gurobi              | 17 s      |
| Gurobi                        | 24 s      |
| MOSEK                         | 30 s      |
| NOTHING                       | 25 s      |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21177)
<!-- Reviewable:end -->
