### PR TITLE
[gcs] Enable adding constraints to the relaxed, rounded or both problems

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -655,19 +655,19 @@ void DefineGeometryOptimization(py::module m) {
               self.solver_options = std::move(solver_options);
             }),
             cls_doc.solver_options.doc)
-        .def_property("rounding_solver_options",
+        .def_property("restriction_solver_options",
             py::cpp_function(
                 [](GraphOfConvexSetsOptions& self) {
-                  return &(self.rounding_solver_options);
+                  return &(self.restriction_solver_options);
                 },
                 py_rvp::reference_internal),
             py::cpp_function(
                 [](GraphOfConvexSetsOptions& self,
-                    solvers::SolverOptions rounding_solver_options) {
-                  self.rounding_solver_options =
-                      std::move(rounding_solver_options);
+                    solvers::SolverOptions restriction_solver_options) {
+                  self.restriction_solver_options =
+                      std::move(restriction_solver_options);
                 }),
-            cls_doc.rounding_solver_options.doc)
+            cls_doc.restriction_solver_options.doc)
         .def("__repr__", [](const GraphOfConvexSetsOptions& self) {
           return py::str(
               "GraphOfConvexSetsOptions("
@@ -678,21 +678,31 @@ void DefineGeometryOptimization(py::module m) {
               "flow_tolerance={}, "
               "rounding_seed={}, "
               "solver={}, "
+              "restriction_solver={}, "
               "solver_options={}, "
-              "rounding_solver_options={}, "
+              "restriction_solver_options={}, "
               ")")
               .format(self.convex_relaxation, self.preprocessing,
                   self.max_rounded_paths, self.max_rounding_trials,
                   self.flow_tolerance, self.rounding_seed, self.solver,
-                  self.solver_options, self.rounding_solver_options);
+                  self.restriction_solver, self.solver_options,
+                  self.restriction_solver_options);
         });
 
     DefReadWriteKeepAlive(&gcs_options, "solver",
         &GraphOfConvexSetsOptions::solver, cls_doc.solver.doc);
+    DefReadWriteKeepAlive(&gcs_options, "restriction_solver",
+        &GraphOfConvexSetsOptions::restriction_solver,
+        cls_doc.restriction_solver.doc);
   }
 
   // GraphOfConvexSets
   {
+    const std::unordered_set<GraphOfConvexSets::Transcription>
+        all_transcriptions = {GraphOfConvexSets::Transcription::kMIP,
+            GraphOfConvexSets::Transcription::kRelaxation,
+            GraphOfConvexSets::Transcription::kRestriction};
+
     const auto& cls_doc = doc.GraphOfConvexSets;
     py::class_<GraphOfConvexSets> graph_of_convex_sets(
         m, "GraphOfConvexSets", cls_doc.doc);
@@ -701,6 +711,18 @@ void DefineGeometryOptimization(py::module m) {
         graph_of_convex_sets, "VertexId", doc.GraphOfConvexSets.VertexId.doc);
     BindIdentifier<GraphOfConvexSets::EdgeId>(
         graph_of_convex_sets, "EdgeId", doc.GraphOfConvexSets.EdgeId.doc);
+
+    // Transcription
+    constexpr auto& enum_doc = doc.GraphOfConvexSets.Transcription;
+    py::enum_<GraphOfConvexSets::Transcription> enum_py(
+        graph_of_convex_sets, "Transcription", enum_doc.doc);
+    enum_py  // BR
+        .value(
+            "kMIP", GraphOfConvexSets::Transcription::kMIP, enum_doc.kMIP.doc)
+        .value("kRelaxation", GraphOfConvexSets::Transcription::kRelaxation,
+            enum_doc.kRelaxation.doc)
+        .value("kRestriction", GraphOfConvexSets::Transcription::kRestriction,
+            enum_doc.kRestriction.doc);
 
     // Vertex
     const auto& vertex_doc = doc.GraphOfConvexSets.Vertex;
@@ -730,17 +752,23 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("binding"), vertex_doc.AddCost.doc_binding)
         .def("AddConstraint",
             overload_cast_explicit<solvers::Binding<solvers::Constraint>,
-                const symbolic::Formula&>(
+                const symbolic::Formula&,
+                const std::unordered_set<GraphOfConvexSets::Transcription>&>(
                 &GraphOfConvexSets::Vertex::AddConstraint),
-            py::arg("f"), vertex_doc.AddConstraint.doc_formula)
+            py::arg("f"), py::arg("use_in_transcription") = all_transcriptions,
+            vertex_doc.AddConstraint.doc_formula)
         .def("AddConstraint",
             overload_cast_explicit<solvers::Binding<solvers::Constraint>,
-                const solvers::Binding<solvers::Constraint>&>(
+                const solvers::Binding<solvers::Constraint>&,
+                const std::unordered_set<GraphOfConvexSets::Transcription>&>(
                 &GraphOfConvexSets::Vertex::AddConstraint),
-            py::arg("binding"), vertex_doc.AddCost.doc_binding)
+            py::arg("binding"),
+            py::arg("use_in_transcription") = all_transcriptions,
+            vertex_doc.AddConstraint.doc_binding)
         .def("GetCosts", &GraphOfConvexSets::Vertex::GetCosts,
             vertex_doc.GetCosts.doc)
         .def("GetConstraints", &GraphOfConvexSets::Vertex::GetConstraints,
+            py::arg("used_in_transcription") = all_transcriptions,
             vertex_doc.GetConstraints.doc)
         .def("GetSolutionCost", &GraphOfConvexSets::Vertex::GetSolutionCost,
             py::arg("result"), vertex_doc.GetSolutionCost.doc)
@@ -787,14 +815,19 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("binding"), edge_doc.AddCost.doc_binding)
         .def("AddConstraint",
             overload_cast_explicit<solvers::Binding<solvers::Constraint>,
-                const symbolic::Formula&>(
+                const symbolic::Formula&,
+                const std::unordered_set<GraphOfConvexSets::Transcription>&>(
                 &GraphOfConvexSets::Edge::AddConstraint),
-            py::arg("f"), edge_doc.AddConstraint.doc_formula)
+            py::arg("f"), py::arg("use_in_transcription") = all_transcriptions,
+            edge_doc.AddConstraint.doc_formula)
         .def("AddConstraint",
             overload_cast_explicit<solvers::Binding<solvers::Constraint>,
-                const solvers::Binding<solvers::Constraint>&>(
+                const solvers::Binding<solvers::Constraint>&,
+                const std::unordered_set<GraphOfConvexSets::Transcription>&>(
                 &GraphOfConvexSets::Edge::AddConstraint),
-            py::arg("binding"), edge_doc.AddCost.doc_binding)
+            py::arg("binding"),
+            py::arg("use_in_transcription") = all_transcriptions,
+            edge_doc.AddConstraint.doc_binding)
         .def("AddPhiConstraint", &GraphOfConvexSets::Edge::AddPhiConstraint,
             py::arg("phi_value"), edge_doc.AddPhiConstraint.doc)
         .def("ClearPhiConstraints",
@@ -803,6 +836,7 @@ void DefineGeometryOptimization(py::module m) {
         .def("GetCosts", &GraphOfConvexSets::Edge::GetCosts,
             edge_doc.GetCosts.doc)
         .def("GetConstraints", &GraphOfConvexSets::Edge::GetConstraints,
+            py::arg("used_in_transcription") = all_transcriptions,
             edge_doc.GetConstraints.doc)
         .def("GetSolutionCost", &GraphOfConvexSets::Edge::GetSolutionCost,
             py::arg("result"), edge_doc.GetSolutionCost.doc)

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -26,6 +26,7 @@ namespace optimization {
 
 using Edge = GraphOfConvexSets::Edge;
 using EdgeId = GraphOfConvexSets::EdgeId;
+using Transcription = GraphOfConvexSets::Transcription;
 using Vertex = GraphOfConvexSets::Vertex;
 using VertexId = GraphOfConvexSets::VertexId;
 
@@ -67,6 +68,9 @@ MathematicalProgramResult Solve(const MathematicalProgram& prog,
   MathematicalProgramResult result;
   if (options.solver) {
     options.solver->Solve(prog, {}, options.solver_options, &result);
+
+    // TODO(wrangelvid): Call the MixedIntegerBranchAndBound solver when
+    // asking to solve the MIP without a solver that supports it.
   } else {
     std::unique_ptr<solvers::SolverInterface> solver{};
     try {
@@ -140,16 +144,41 @@ std::pair<Variable, Binding<Cost>> Vertex::AddCost(
   return std::pair<Variable, Binding<Cost>>(ell_[n], costs_.back());
 }
 
-Binding<Constraint> Vertex::AddConstraint(const symbolic::Formula& f) {
-  return AddConstraint(solvers::internal::ParseConstraint(f));
+Binding<Constraint> Vertex::AddConstraint(
+    const symbolic::Formula& f,
+    const std::unordered_set<GraphOfConvexSets::Transcription>&
+        use_in_transcription) {
+  return AddConstraint(solvers::internal::ParseConstraint(f),
+                       use_in_transcription);
 }
 
-Binding<Constraint> Vertex::AddConstraint(const Binding<Constraint>& binding) {
+Binding<Constraint> Vertex::AddConstraint(
+    const Binding<Constraint>& binding,
+    const std::unordered_set<GraphOfConvexSets::Transcription>&
+        use_in_transcription) {
   DRAKE_THROW_UNLESS(ambient_dimension() > 0);
   DRAKE_THROW_UNLESS(
       Variables(binding.variables()).IsSubsetOf(Variables(placeholder_x_)));
-  constraints_.emplace_back(binding);
+  DRAKE_THROW_UNLESS(use_in_transcription.size() > 0);
+  constraints_.push_back({binding, use_in_transcription});
   return binding;
+}
+
+std::vector<solvers::Binding<solvers::Constraint>> Vertex::GetConstraints(
+    const std::unordered_set<GraphOfConvexSets::Transcription>&
+        used_in_transcription) const {
+  DRAKE_THROW_UNLESS(used_in_transcription.size() > 0);
+  std::vector<solvers::Binding<solvers::Constraint>> constraints;
+  // Add all constraints that are used in the transcription.
+  for (const auto& [binding, transcriptions] : constraints_) {
+    if (std::any_of(transcriptions.begin(), transcriptions.end(),
+                    [&used_in_transcription](const auto& elem) {
+                      return used_in_transcription.contains(elem);
+                    })) {
+      constraints.push_back(binding);
+    }
+  }
+  return constraints;
 }
 
 double Vertex::GetSolutionCost(const MathematicalProgramResult& result) const {
@@ -220,16 +249,41 @@ std::pair<Variable, Binding<Cost>> Edge::AddCost(const Binding<Cost>& binding) {
   return std::pair<Variable, Binding<Cost>>(ell_[n], costs_.back());
 }
 
-Binding<Constraint> Edge::AddConstraint(const symbolic::Formula& f) {
-  return AddConstraint(solvers::internal::ParseConstraint(f));
+Binding<Constraint> Edge::AddConstraint(
+    const symbolic::Formula& f,
+    const std::unordered_set<GraphOfConvexSets::Transcription>&
+        use_in_transcription) {
+  return AddConstraint(solvers::internal::ParseConstraint(f),
+                       use_in_transcription);
 }
 
-Binding<Constraint> Edge::AddConstraint(const Binding<Constraint>& binding) {
+Binding<Constraint> Edge::AddConstraint(
+    const Binding<Constraint>& binding,
+    const std::unordered_set<GraphOfConvexSets::Transcription>&
+        use_in_transcription) {
   const int total_ambient_dimension = allowed_vars_.size();
   DRAKE_THROW_UNLESS(total_ambient_dimension > 0);
   DRAKE_THROW_UNLESS(Variables(binding.variables()).IsSubsetOf(allowed_vars_));
-  constraints_.emplace_back(binding);
+  DRAKE_THROW_UNLESS(use_in_transcription.size() > 0);
+  constraints_.push_back({binding, use_in_transcription});
   return binding;
+}
+
+std::vector<solvers::Binding<solvers::Constraint>> Edge::GetConstraints(
+    const std::unordered_set<GraphOfConvexSets::Transcription>&
+        used_in_transcription) const {
+  DRAKE_THROW_UNLESS(used_in_transcription.size() > 0);
+  std::vector<solvers::Binding<solvers::Constraint>> constraints;
+  // Add all constraints that are used in the transcription.
+  for (const auto& [binding, transcriptions] : constraints_) {
+    if (std::any_of(transcriptions.begin(), transcriptions.end(),
+                    [&used_in_transcription](const auto& elem) {
+                      return used_in_transcription.contains(elem);
+                    })) {
+      constraints.push_back(binding);
+    }
+  }
+  return constraints;
 }
 
 void Edge::AddPhiConstraint(bool phi_value) {
@@ -908,31 +962,38 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     }
 
     // Edge constraints.
-    for (const Binding<Constraint>& b : e->constraints_) {
-      const VectorXDecisionVariable& old_vars = b.variables();
-      VectorXDecisionVariable vars(old_vars.size() + 1);
-      // vars = [phi; yz_vars]
-      vars[0] = phi;
-      for (int j = 0; j < old_vars.size(); ++j) {
-        vars[j + 1] = e->x_to_yz_.at(old_vars[j]);
-      }
+    for (const auto& [b, transcriptions] : e->constraints_) {
+      if ((*options.convex_relaxation &&
+           transcriptions.contains(Transcription::kRelaxation)) ||
+          (!*options.convex_relaxation &&
+           transcriptions.contains(Transcription::kMIP))) {
+        const VectorXDecisionVariable& old_vars = b.variables();
+        VectorXDecisionVariable vars(old_vars.size() + 1);
+        // vars = [phi; yz_vars]
+        vars[0] = phi;
+        for (int j = 0; j < old_vars.size(); ++j) {
+          vars[j + 1] = e->x_to_yz_.at(old_vars[j]);
+        }
 
-      // Note: The use of perspective functions here does not check (nor assume)
-      // that the constraints describe a bounded set.  The boundedness is
-      // ensured by the intersection of these constraints with the convex sets
-      // (on the vertices).
-      AddPerspectiveConstraint(&prog, b, vars);
+        // Note: The use of perspective functions here does not check (nor
+        // assume) that the constraints describe a bounded set.  The boundedness
+        // is ensured by the intersection of these constraints with the convex
+        // sets (on the vertices).
+        AddPerspectiveConstraint(&prog, b, vars);
+      }
     }
   }
   if (!has_edges_out_of_source) {
     MathematicalProgramResult result;
-    log()->info("Source vertex {} has no outgoing edges.", source_id);
+    log()->info("Source vertex {} ({}) has no outgoing edges.", source.name(),
+                source_id);
     result.set_solution_result(SolutionResult::kInfeasibleConstraints);
     return result;
   }
   if (!has_edges_into_target) {
     MathematicalProgramResult result;
-    log()->info("Target vertex {} has no incoming edges.", target_id);
+    log()->info("Target vertex {} ({}) has no incoming edges.", target.name(),
+                target_id);
     result.set_solution_result(SolutionResult::kInfeasibleConstraints);
     return result;
   }
@@ -1071,26 +1132,31 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     }
 
     // Vertex constraints.
-    for (const Binding<Constraint>& b : v->constraints_) {
-      const VectorXDecisionVariable& old_vars = b.variables();
+    for (const auto& [b, transcriptions] : v->constraints_) {
+      if ((*options.convex_relaxation &&
+           transcriptions.contains(Transcription::kRelaxation)) ||
+          (!*options.convex_relaxation &&
+           transcriptions.contains(Transcription::kMIP))) {
+        const VectorXDecisionVariable& old_vars = b.variables();
 
-      for (const Edge* e : cost_edges) {
-        VectorXDecisionVariable vars(old_vars.size() + 1);
-        // vars = [phi; yz_vars]
-        if (*options.convex_relaxation) {
-          vars[0] = relaxed_phi.at(e->id());
-        } else {
-          vars[0] = e->phi_;
-        }
-        for (int ii = 0; ii < old_vars.size(); ++ii) {
-          vars[ii + 1] = e->x_to_yz_.at(old_vars[ii]);
-        }
+        for (const Edge* e : cost_edges) {
+          VectorXDecisionVariable vars(old_vars.size() + 1);
+          // vars = [phi; yz_vars]
+          if (*options.convex_relaxation) {
+            vars[0] = relaxed_phi.at(e->id());
+          } else {
+            vars[0] = e->phi_;
+          }
+          for (int ii = 0; ii < old_vars.size(); ++ii) {
+            vars[ii + 1] = e->x_to_yz_.at(old_vars[ii]);
+          }
 
-        // Note: The use of perspective functions here does not check (nor
-        // assume) that the constraints describe a bounded set.  The boundedness
-        // is ensured by the intersection of these constraints with the convex
-        // sets (on the vertices).
-        AddPerspectiveConstraint(&prog, b, vars);
+          // Note: The use of perspective functions here does not check (nor
+          // assume) that the constraints describe a bounded set.  The
+          // boundedness is ensured by the intersection of these constraints
+          // with the convex sets (on the vertices).
+          AddPerspectiveConstraint(&prog, b, vars);
+        }
       }
     }
   }
@@ -1101,7 +1167,9 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
       "preprocessing={}{}.",
       result.get_solver_id().name(), *options.convex_relaxation,
       *options.preprocessing,
-      *options.max_rounded_paths > 0 ? " and rounding" : " and no rounding");
+      *options.convex_relaxation && *options.max_rounded_paths > 0
+          ? " and rounding"
+          : " and no rounding");
 
   bool found_rounded_result = false;
   // Implements the rounding scheme put forth in Section 4.2 of
@@ -1110,11 +1178,6 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
   if (*options.convex_relaxation && *options.max_rounded_paths > 0 &&
       result.is_success()) {
     DRAKE_THROW_UNLESS(options.max_rounding_trials > 0);
-    GraphOfConvexSetsOptions rounding_options = options;
-    if (rounding_options.rounding_solver_options) {
-      rounding_options.solver_options =
-          *rounding_options.rounding_solver_options;
-    }
 
     RandomGenerator generator(options.rounding_seed);
     std::uniform_real_distribution<double> uniform;
@@ -1182,7 +1245,7 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
 
       // Optimize path
       MathematicalProgramResult rounded_result =
-          SolveConvexRestriction(new_path, rounding_options);
+          SolveConvexRestriction(new_path, options);
 
       // Check path quality.
       if (rounded_result.is_success() &&
@@ -1190,6 +1253,10 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
            rounded_result.get_optimal_cost() <
                best_rounded_result.get_optimal_cost())) {
         best_rounded_result = rounded_result;
+      } else {
+        // In the event that all rounded results are infeasible, we still want
+        // to propagate the solver id for logging.
+        best_rounded_result.set_solver_id(rounded_result.get_solver_id());
       }
     }
     if (best_rounded_result.is_success()) {
@@ -1197,8 +1264,10 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
       found_rounded_result = true;
     } else {
       result.set_solution_result(SolutionResult::kIterationLimit);
+      result.set_solver_id(best_rounded_result.get_solver_id());
     }
-    log()->info("Finished {} rounding trials.", num_trials);
+    log()->info("Finished {} rounding trials with {}.", num_trials,
+                result.get_solver_id().name());
   }
   if (!found_rounded_result) {
     // Push the placeholder variables and excluded edge variables into the
@@ -1376,6 +1445,8 @@ void RewriteForConvexSolver(MathematicalProgram* prog) {
   std::unordered_set<Binding<Cost>> to_remove;
 
   for (const auto& binding : prog->l2norm_costs()) {
+    // N.B. This code is currently only unit tested in
+    // gcs_trajectory_optimization_test, not graph_of_convex_sets_test.
     const int m = binding.evaluator()->get_sparse_A().rows();
     const int n = binding.evaluator()->get_sparse_A().cols();
     auto slack = prog->NewContinuousVariables<1>("slack");
@@ -1441,12 +1512,6 @@ void RewriteForConvexSolver(MathematicalProgram* prog) {
   for (const auto& b : to_remove) {
     prog->RemoveCost(b);
   }
-
-  if (!mosek.AreProgramAttributesSatisfied(*prog)) {
-    throw std::runtime_error(fmt::format(
-        "SolveConvexRestriction failed to generate a convex problem: {}",
-        mosek.ExplainUnsatisfiedProgramAttributes(*prog)));
-  }
 }
 
 }  // namespace
@@ -1454,6 +1519,15 @@ void RewriteForConvexSolver(MathematicalProgram* prog) {
 MathematicalProgramResult GraphOfConvexSets::SolveConvexRestriction(
     const std::vector<const Edge*>& active_edges,
     const GraphOfConvexSetsOptions& options) const {
+  // Use the restriction solver and options if they are provided.
+  GraphOfConvexSetsOptions restriction_options = options;
+  if (restriction_options.restriction_solver) {
+    restriction_options.solver = restriction_options.restriction_solver;
+  }
+  if (restriction_options.restriction_solver_options) {
+    restriction_options.solver_options =
+        *restriction_options.restriction_solver_options;
+  }
   MathematicalProgram prog;
 
   std::set<const Vertex*, VertexIdComparator> vertices;
@@ -1478,8 +1552,10 @@ MathematicalProgramResult GraphOfConvexSets::SolveConvexRestriction(
       prog.AddCost(b);
     }
     // Vertex constraints.
-    for (const Binding<Constraint>& b : v->constraints_) {
-      prog.AddConstraint(b);
+    for (const auto& [b, transcriptions] : v->constraints_) {
+      if (transcriptions.contains(Transcription::kRestriction)) {
+        prog.AddConstraint(b);
+      }
     }
   }
 
@@ -1489,14 +1565,15 @@ MathematicalProgramResult GraphOfConvexSets::SolveConvexRestriction(
       prog.AddCost(b);
     }
     // Edge constraints.
-    for (const Binding<Constraint>& b : e->constraints_) {
-      prog.AddConstraint(b);
+    for (const auto& [b, transcriptions] : e->constraints_) {
+      if (transcriptions.contains(Transcription::kRestriction)) {
+        prog.AddConstraint(b);
+      }
     }
   }
 
   RewriteForConvexSolver(&prog);
-
-  MathematicalProgramResult result = Solve(prog, options);
+  MathematicalProgramResult result = Solve(prog, restriction_options);
 
   // TODO(russt): Add the dual variables back in for the rewritten costs.
 

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -50,6 +50,7 @@ using symbolic::Variables;
 
 using Edge = GraphOfConvexSets::Edge;
 using EdgeId = GraphOfConvexSets::EdgeId;
+using Transcription = GraphOfConvexSets::Transcription;
 using Vertex = GraphOfConvexSets::Vertex;
 using VertexId = GraphOfConvexSets::VertexId;
 
@@ -79,7 +80,9 @@ GTEST_TEST(GraphOfConvexSetsOptionsTest, Serialize) {
   solvers::MosekSolver mosek_solver;
   options.solver = &mosek_solver;
   options.solver_options = solvers::SolverOptions();
-  options.rounding_solver_options = solvers::SolverOptions();
+  solvers::IpoptSolver ipopt_solver;
+  options.restriction_solver = &ipopt_solver;
+  options.restriction_solver_options = solvers::SolverOptions();
   const std::string serialized = yaml::SaveYamlString(options);
   const auto deserialized =
       yaml::LoadYamlString<GraphOfConvexSetsOptions>(serialized);
@@ -91,8 +94,9 @@ GTEST_TEST(GraphOfConvexSetsOptionsTest, Serialize) {
   EXPECT_EQ(deserialized.rounding_seed, options.rounding_seed);
   // The non-built-in types are not serialized.
   EXPECT_EQ(deserialized.solver, nullptr);
+  EXPECT_EQ(deserialized.restriction_solver, nullptr);
   EXPECT_EQ(deserialized.solver_options, solvers::SolverOptions());
-  EXPECT_FALSE(deserialized.rounding_solver_options.has_value());
+  EXPECT_FALSE(deserialized.restriction_solver_options.has_value());
 }
 
 GTEST_TEST(GraphOfConvexSetsTest, AddVertex) {
@@ -310,6 +314,14 @@ TEST_F(TwoPoints, AddConstraint) {
   auto b1 = e_->AddConstraint(Binding(constraint, e_->xu()));
   auto u_b0 = u_->AddConstraint(u_->x() == pu_.x());
   auto u_b1 = u_->AddConstraint(Binding(constraint, u_->x()));
+  // If no transcription is specified, the constraint won't be added.
+  EXPECT_THROW(e_->AddConstraint(e_->xv().head<2>() == e_->xu(), {}),
+               std::exception);
+  EXPECT_THROW(e_->AddConstraint(Binding(constraint, e_->xu()), {}),
+               std::exception);
+  EXPECT_THROW(u_->AddConstraint(u_->x() == pu_.x(), {}), std::exception);
+  EXPECT_THROW(u_->AddConstraint(Binding(constraint, u_->x()), {}),
+               std::exception);
 
   // Confirm that they are down-castable.
   auto linear_equality =
@@ -324,18 +336,241 @@ TEST_F(TwoPoints, AddConstraint) {
   EXPECT_TRUE(linear != nullptr);
 
   // Confirm that they are all accessible.
-  const auto& edge_constraints = e_->GetConstraints();
-  EXPECT_EQ(edge_constraints[0], b0);
-  EXPECT_EQ(edge_constraints[1], b1);
-  const auto& vertex_constraints = u_->GetConstraints();
-  EXPECT_EQ(vertex_constraints[0], u_b0);
-  EXPECT_EQ(vertex_constraints[1], u_b1);
+  const auto& all_edge_constraints = e_->GetConstraints();
+  EXPECT_EQ(all_edge_constraints.size(), 2);
+  EXPECT_EQ(all_edge_constraints[0], b0);
+  EXPECT_EQ(all_edge_constraints[1], b1);
+  const auto& all_vertex_constraints = u_->GetConstraints();
+  EXPECT_EQ(all_vertex_constraints.size(), 2);
+  EXPECT_EQ(all_vertex_constraints[0], u_b0);
+  EXPECT_EQ(all_vertex_constraints[1], u_b1);
+
+  // By default Edge::AddConstraint or Vertex::AddConstraint is adding the
+  // binding to all transcriptions.
+  for (const auto& transcription :
+       {Transcription::kMIP, Transcription::kRelaxation,
+        Transcription::kRestriction}) {
+    const auto& edge_constraints = e_->GetConstraints({transcription});
+    EXPECT_EQ(edge_constraints.size(), 2);
+    EXPECT_EQ(edge_constraints[0], b0);
+    EXPECT_EQ(edge_constraints[1], b1);
+    const auto& vertex_constraints = u_->GetConstraints({transcription});
+    EXPECT_EQ(vertex_constraints.size(), 2);
+    EXPECT_EQ(vertex_constraints[0], u_b0);
+    EXPECT_EQ(vertex_constraints[1], u_b1);
+  }
+  // If no transcription is specified, nothing will be returned.
+  EXPECT_THROW(e_->GetConstraints({}), std::exception);
+  EXPECT_THROW(u_->GetConstraints({}), std::exception);
 
   symbolic::Variable other_var("x");
   DRAKE_EXPECT_THROWS_MESSAGE(e_->AddConstraint(other_var == 1),
                               ".*IsSubsetOf.*");
   DRAKE_EXPECT_THROWS_MESSAGE(u_->AddConstraint(other_var == 1),
                               ".*IsSubsetOf.*");
+}
+
+// Verifies that the correct solver is used for the MIP, relaxation and the
+// restriction.
+TEST_F(TwoPoints, ReportCorrectSolverId) {
+  e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
+  GraphOfConvexSetsOptions options;
+  // Define a different solver for the restriction.
+  solvers::ClarabelSolver clarabel;
+  options.solver = &clarabel;
+  solvers::ClpSolver clp;
+  options.restriction_solver = &clp;
+  options.convex_relaxation = true;
+  options.preprocessing = false;
+
+  // When solving the convex relaxation with no rounded paths, we expect the
+  // options.solver to be used.
+  options.max_rounded_paths = 0;
+  auto result = g_.SolveShortestPath(*u_, *v_, options);
+  EXPECT_TRUE(result.is_success());
+  EXPECT_EQ(result.get_solver_id(), options.solver->solver_id());
+
+  // The convex restriction should use the restriction solver.
+  result = g_.SolveConvexRestriction({e_}, options);
+  EXPECT_TRUE(result.is_success());
+  EXPECT_EQ(result.get_solver_id(), options.restriction_solver->solver_id());
+
+  // With the rounding on, the reported solver should be the restriciton solver
+  options.max_rounded_paths = 1;
+  result = g_.SolveShortestPath(*u_, *v_, options);
+  EXPECT_TRUE(result.is_success());
+  EXPECT_EQ(result.get_solver_id(), options.restriction_solver->solver_id());
+
+  // Even if we add a constraint that makes only the rounding fail, the
+  // reported solver should still be the restriction solver.
+  u_->AddConstraint(u_->x()[0] == 0.0, {Transcription::kRestriction});
+  result = g_.SolveShortestPath(*u_, *v_, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solver_id(), options.restriction_solver->solver_id());
+
+  // Adding infeasible constraints to the relaxation should fail the relaxation,
+  // hence solving the restriction will never be reached and the reported solver
+  // should be the solver used in the relaxation.
+  e_->AddConstraint(e_->xv()[0] == 0.0, {Transcription::kRelaxation});
+  result = g_.SolveShortestPath(*u_, *v_, options);
+  EXPECT_FALSE(result.is_success());
+  EXPECT_EQ(result.get_solver_id(), options.solver->solver_id());
+
+  // Since we haven't added any infeasible constraints to the MIP transcription,
+  // we expect the solve to be successful and the reported solver to be the MIP
+  // solver.
+  if (solvers::MosekSolver::is_available() &&
+      solvers::MosekSolver::is_enabled()) {
+    solvers::MosekSolver mosek;
+    options.solver = &mosek;
+    options.convex_relaxation = false;
+    result = g_.SolveShortestPath(*u_, *v_, options);
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.get_solver_id(), options.solver->solver_id());
+  }
+}
+
+// Verify that assigning a transcription to a constraint adds it to the correct
+// problem. This test will be split into multiple cases.
+TEST_F(TwoPoints, VerifyTranscriptionAssignmentBaseline) {
+  // We will be adding a few feasible constraints to all transcriptions, even
+  // though there are redundant with the set constraint. It is expected that
+  // solving the individual problems will be successful.
+  e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
+  e_->AddConstraint(e_->xv()[0] == 3.0,
+                    {Transcription::kMIP, Transcription::kRelaxation,
+                     Transcription::kRestriction});
+  u_->AddConstraint(u_->x()[0] == 1.0,
+                    {Transcription::kMIP, Transcription::kRelaxation,
+                     Transcription::kRestriction});
+
+  GraphOfConvexSetsOptions options;
+  options.preprocessing = false;
+
+  // The convex relaxation should be successful.
+  options.convex_relaxation = true;
+  options.max_rounded_paths = 0;
+  EXPECT_TRUE(g_.SolveShortestPath(*u_, *v_, options).is_success());
+
+  // The restriction, also in the rounding, should be successful.
+  options.convex_relaxation = true;
+  options.max_rounded_paths = 1;
+  EXPECT_TRUE(g_.SolveConvexRestriction({e_}, options).is_success());
+  EXPECT_TRUE(g_.SolveShortestPath(*u_, *v_, options).is_success());
+
+  // The MIP should be successful as well.
+  options.convex_relaxation = false;
+  if (MixedIntegerSolverAvailable()) {
+    EXPECT_TRUE(g_.SolveShortestPath(*u_, *v_, options).is_success());
+  }
+}
+
+TEST_F(TwoPoints, VerifyTranscriptionAssignmentkMIP) {
+  // We will be adding a few feasible constraints to all transcriptions, even
+  // though there are redundant with the set constraint.
+  // Further, we will add an infeasible constraint to the relaxation and the
+  // restriction, but not the MIP.
+  e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
+  e_->AddConstraint(e_->xv()[0] == 3.0,
+                    {Transcription::kMIP, Transcription::kRelaxation,
+                     Transcription::kRestriction});
+  u_->AddConstraint(u_->x()[0] == 1.0,
+                    {Transcription::kMIP, Transcription::kRelaxation,
+                     Transcription::kRestriction});
+
+  GraphOfConvexSetsOptions options;
+  options.preprocessing = false;
+
+  // The MIP should be successful.
+  e_->AddConstraint(e_->xv()[0] == 0.0,
+                    {Transcription::kRelaxation, Transcription::kRestriction});
+  u_->AddConstraint(u_->x()[0] == 0.0,
+                    {Transcription::kRelaxation, Transcription::kRestriction});
+  if (MixedIntegerSolverAvailable()) {
+    options.convex_relaxation = false;
+    EXPECT_TRUE(g_.SolveShortestPath(*u_, *v_, options).is_success());
+  }
+  // Ensure the relaxation fails.
+  options.convex_relaxation = true;
+  options.max_rounded_paths = 0;
+  EXPECT_FALSE(g_.SolveShortestPath(*u_, *v_, options).is_success());
+
+  // Ensure the restriction fails.
+  EXPECT_FALSE(g_.SolveConvexRestriction({e_}, options).is_success());
+}
+
+TEST_F(TwoPoints, VerifyTranscriptionAssignmentkRelaxation) {
+  // We will be adding a few feasible constraints to all transcriptions, even
+  // though there are redundant with the set constraint.
+  // Further, we will add an infeasible constraint to the MIP and the
+  // restriction, but not the relaxation.
+  e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
+  e_->AddConstraint(e_->xv()[0] == 3.0,
+                    {Transcription::kMIP, Transcription::kRelaxation,
+                     Transcription::kRestriction});
+  u_->AddConstraint(u_->x()[0] == 1.0,
+                    {Transcription::kMIP, Transcription::kRelaxation,
+                     Transcription::kRestriction});
+
+  GraphOfConvexSetsOptions options;
+  options.preprocessing = false;
+
+  // The relaxation should be successful.
+  e_->AddConstraint(e_->xv()[0] == 0.0,
+                    {Transcription::kMIP, Transcription::kRestriction});
+  u_->AddConstraint(u_->x()[0] == 0.0,
+                    {Transcription::kMIP, Transcription::kRestriction});
+  options.convex_relaxation = true;
+  options.max_rounded_paths = 0;
+  EXPECT_TRUE(g_.SolveShortestPath(*u_, *v_, options).is_success());
+
+  // Ensure the mip fails.
+  if (MixedIntegerSolverAvailable()) {
+    options.convex_relaxation = false;
+    EXPECT_FALSE(g_.SolveShortestPath(*u_, *v_, options).is_success());
+  }
+
+  // Ensure the restriction fails.
+  EXPECT_FALSE(g_.SolveConvexRestriction({e_}, options).is_success());
+
+  // Ensure the restriction called in the rounding fails.
+  options.convex_relaxation = true;
+  options.max_rounded_paths = 1;
+  EXPECT_FALSE(g_.SolveShortestPath(*u_, *v_, options).is_success());
+}
+TEST_F(TwoPoints, VerifyTranscriptionAssignmentkRestriction) {
+  // We will be adding a few feasible constraints to all transcriptions, even
+  // though there are redundant with the set constraint.
+  // Further, we will add an infeasible constraint to the MIP and the
+  // relaxation, but not the restriction.
+  e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
+  e_->AddConstraint(e_->xv()[0] == 3.0,
+                    {Transcription::kMIP, Transcription::kRelaxation,
+                     Transcription::kRestriction});
+  u_->AddConstraint(u_->x()[0] == 1.0,
+                    {Transcription::kMIP, Transcription::kRelaxation,
+                     Transcription::kRestriction});
+
+  GraphOfConvexSetsOptions options;
+  options.preprocessing = false;
+
+  // The restriction should be successful.
+  e_->AddConstraint(e_->xv()[0] == 0.0,
+                    {Transcription::kMIP, Transcription::kRelaxation});
+  u_->AddConstraint(u_->x()[0] == 0.0,
+                    {Transcription::kMIP, Transcription::kRelaxation});
+  EXPECT_TRUE(g_.SolveConvexRestriction({e_}, options).is_success());
+
+  // Ensure the mip fails.
+  if (MixedIntegerSolverAvailable()) {
+    options.convex_relaxation = false;
+    EXPECT_FALSE(g_.SolveShortestPath(*u_, *v_, options).is_success());
+  }
+
+  // Ensure the and relaxation fails.
+  options.convex_relaxation = true;
+  options.max_rounded_paths = 0;
+  EXPECT_FALSE(g_.SolveShortestPath(*u_, *v_, options).is_success());
 }
 
 GTEST_TEST(GraphOfConvexSetsTest, TwoNullPointsConstraint) {
@@ -1011,6 +1246,232 @@ TEST_F(ThreeBoxes, IpoptTest) {
   options_.convex_relaxation = true;
   auto result = g_.SolveShortestPath(*source_, *target_, options_);
   ASSERT_TRUE(result.is_success());
+}
+
+TEST_F(ThreeBoxes, NonConvexRounding) {
+  /* Consider the following problem:
+  - Each of the sets source, target and sink are unit boxes in 2D.
+  - They further constrain the feasible set to be in between the border of the
+    unit box and the exterior of the unit circle.
+  - In addition, the point in the source region must be in the upper left
+    quadrant, the point in the target region must be in the upper right quadrant
+    and the point in the sink region must be in the lower left quadrant.
+    The quadrants are padded by 0.1 to exclude 0.0 from the feasible set.
+  - We wish to minimize the squared L2 norm of the difference between the
+    points. We expect that source to target will be the shortest path since the
+    optimal difference is zero, while the distance between source and sink will
+    be greater than one.
+
+        Source                            Target
+  ┌────────────┐                     ┌────────────┐
+  │xxxxx___    │                     │    ___xxxxx│
+  │xxx/    \   │        e_on         │   /    \xxx│
+  │xx|      |  │  ────────────────►  │  |      |xx│
+  │  |      |  │                     │  |      |  │
+  │   \____/   │                     │   \____/   │
+  │            │                     │            │
+  └────────────┘                     └────────────┘
+
+        │
+        │  e_off
+        │
+        │
+        │
+        ▼
+      Sink
+  ┌────────────┐
+  │    ____    │
+  │   /    \   │
+  │  |      |  │
+  │  |      |xx│
+  │   \____/xxx│
+  │       xxxxx│
+  └────────────┘
+
+  We will approach this by formulating a convex surrogate of the problem and
+  solving the non-convex problem in the rounding stage.
+  */
+
+  // Add minimum distance cost.
+  e_on_->AddCost((e_on_->xu() - e_on_->xv()).squaredNorm());
+  e_off_->AddCost((e_off_->xu() - e_off_->xv()).squaredNorm());
+
+  /* Source: The relaxation of the problem simply requires the point to be
+  strictly in the top left corner.
+
+    Relaxation        Rounding
+  ┌────────────┐   ┌────────────┐
+  │xxx         │   │xxxxx___    │
+  │xxx         │   │xxx/    \   │
+  │            │   │xx|      |  │
+  │            │   │  |      |  │
+  │            │   │   \____/   │
+  │            │   │            │
+  └────────────┘   └────────────┘
+  */
+  std::vector<solvers::Binding<solvers::Constraint>> constraints_relaxation;
+  std::vector<solvers::Binding<solvers::Constraint>> constraints_restriction;
+
+  constraints_relaxation.push_back(source_->AddConstraint(
+      source_->x()[0] <= -0.5, {Transcription::kRelaxation}));
+  constraints_relaxation.push_back(source_->AddConstraint(
+      source_->x()[1] >= 0.5, {Transcription::kRelaxation}));
+
+  constraints_restriction.push_back(source_->AddConstraint(
+      pow(source_->x()[0], 2) + pow(source_->x()[1], 2) >= 1.0,
+      {Transcription::kRestriction}));
+  constraints_restriction.push_back(source_->AddConstraint(
+      source_->x()[0] <= -0.1, {Transcription::kRestriction}));
+  constraints_restriction.push_back(source_->AddConstraint(
+      source_->x()[1] >= 0.1, {Transcription::kRestriction}));
+
+  // Verify the constraints in the relaxation only contain the relaxed
+  // constraints, but not the resctriction constraints.
+  for (const auto& constraint :
+       source_->GetConstraints({Transcription::kRelaxation})) {
+    EXPECT_TRUE(std::find(constraints_relaxation.begin(),
+                          constraints_relaxation.end(),
+                          constraint) != constraints_relaxation.end());
+    EXPECT_FALSE(std::find(constraints_restriction.begin(),
+                           constraints_restriction.end(),
+                           constraint) != constraints_restriction.end());
+  }
+
+  // Verify the constraints in the restriction only contain the appropiate
+  // constraints, but not the relaxed constraints.
+  for (const auto& constraint :
+       source_->GetConstraints({Transcription::kRestriction})) {
+    EXPECT_FALSE(std::find(constraints_relaxation.begin(),
+                           constraints_relaxation.end(),
+                           constraint) != constraints_relaxation.end());
+    EXPECT_TRUE(std::find(constraints_restriction.begin(),
+                          constraints_restriction.end(),
+                          constraint) != constraints_restriction.end());
+  }
+
+  /* Target: The relaxation of the problem simply requires the point to be
+  strictly in the top right corner.
+
+    Relaxation        Rounding
+  ┌────────────┐   ┌────────────┐
+  │         xxx│   │    ___xxxxx│
+  │         xxx│   │   /    \xxx│
+  │            │   │  |      |xx│
+  │            │   │  |      |  │
+  │            │   │   \____/   │
+  │            │   │            │
+  └────────────┘   └────────────┘
+  */
+  constraints_relaxation.push_back(target_->AddConstraint(
+      target_->x()[0] >= 0.5, {Transcription::kRelaxation}));
+  constraints_relaxation.push_back(target_->AddConstraint(
+      target_->x()[1] >= 0.5, {Transcription::kRelaxation}));
+
+  constraints_restriction.push_back(target_->AddConstraint(
+      pow(target_->x()[0], 2) + pow(target_->x()[1], 2) >= 1.0,
+      {Transcription::kRestriction}));
+  constraints_restriction.push_back(target_->AddConstraint(
+      target_->x()[0] >= 0.1, {Transcription::kRestriction}));
+  constraints_restriction.push_back(target_->AddConstraint(
+      target_->x()[1] >= 0.1, {Transcription::kRestriction}));
+
+  // Verify the constraints in the relaxation only contain the relaxed
+  // constraints, but not the restriction constraints.
+  for (const auto& constraint :
+       target_->GetConstraints({Transcription::kRelaxation})) {
+    EXPECT_TRUE(std::find(constraints_relaxation.begin(),
+                          constraints_relaxation.end(),
+                          constraint) != constraints_relaxation.end());
+    EXPECT_FALSE(std::find(constraints_restriction.begin(),
+                           constraints_restriction.end(),
+                           constraint) != constraints_restriction.end());
+  }
+
+  // Verify the constraints in the restriction only contain the appropiate
+  // constraints, but not the relaxed constraints.
+  for (const auto& constraint :
+       target_->GetConstraints({Transcription::kRestriction})) {
+    EXPECT_FALSE(std::find(constraints_relaxation.begin(),
+                           constraints_relaxation.end(),
+                           constraint) != constraints_relaxation.end());
+    EXPECT_TRUE(std::find(constraints_restriction.begin(),
+                          constraints_restriction.end(),
+                          constraint) != constraints_restriction.end());
+  }
+
+  /* Sink: The relaxation of the problem simply requires the point to be
+  strictly in the bottom right corner.
+
+    Relaxation        Rounding
+  ┌────────────┐   ┌────────────┐
+  │            │   │    ____    │
+  │            │   │   /    \   │
+  │            │   │  |      |  │
+  │            │   │  |      |xx│
+  │         xxx│   │   \____/xxx│
+  │         xxx│   │       xxxxx│
+  └────────────┘   └────────────┘
+  */
+
+  constraints_relaxation.push_back(
+      sink_->AddConstraint(sink_->x()[0] >= 0.5, {Transcription::kRelaxation}));
+  constraints_relaxation.push_back(sink_->AddConstraint(
+      sink_->x()[1] <= -0.5, {Transcription::kRelaxation}));
+
+  constraints_restriction.push_back(
+      sink_->AddConstraint(pow(sink_->x()[0], 2) + pow(sink_->x()[1], 2) >= 1.0,
+                           {Transcription::kRestriction}));
+  constraints_restriction.push_back(sink_->AddConstraint(
+      sink_->x()[0] >= 0.1, {Transcription::kRestriction}));
+  constraints_restriction.push_back(sink_->AddConstraint(
+      sink_->x()[1] <= -0.1, {Transcription::kRestriction}));
+
+  // Verify the constraints in the relaxation only contain the relaxed
+  // constraints, but not the restriction constraints.
+  for (const auto& constraint :
+       sink_->GetConstraints({Transcription::kRelaxation})) {
+    EXPECT_TRUE(std::find(constraints_relaxation.begin(),
+                          constraints_relaxation.end(),
+                          constraint) != constraints_relaxation.end());
+    EXPECT_FALSE(std::find(constraints_restriction.begin(),
+                           constraints_restriction.end(),
+                           constraint) != constraints_restriction.end());
+  }
+
+  // Verify the constraints in the restriction only contain the appropiate
+  // constraints, but not the relaxed constraints.
+  for (const auto& constraint :
+       sink_->GetConstraints({Transcription::kRestriction})) {
+    EXPECT_FALSE(std::find(constraints_relaxation.begin(),
+                           constraints_relaxation.end(),
+                           constraint) != constraints_relaxation.end());
+    EXPECT_TRUE(std::find(constraints_restriction.begin(),
+                          constraints_restriction.end(),
+                          constraint) != constraints_restriction.end());
+  }
+
+  // Since all constraints were added to the relaxation and restriction
+  // transcription, we expect kMIP to be empty.
+  EXPECT_EQ(source_->GetConstraints({Transcription::kMIP}).size(), 0);
+  EXPECT_EQ(target_->GetConstraints({Transcription::kMIP}).size(), 0);
+  EXPECT_EQ(sink_->GetConstraints({Transcription::kMIP}).size(), 0);
+
+  solvers::IpoptSolver ipopt;
+  options_.restriction_solver = &ipopt;
+  options_.convex_relaxation = true;
+  options_.max_rounded_paths = 2;
+  auto result = g_.SolveShortestPath(*source_, *target_, options_);
+  ASSERT_TRUE(result.is_success());
+  // Make sure it used the correct solver.
+  EXPECT_EQ(result.get_solver_id(), solvers::IpoptSolver::id());
+
+  const double kExpectedDistance = 0.2;
+  const double distance =
+      (source_->GetSolution(result) - target_->GetSolution(result)).norm();
+  EXPECT_NEAR(distance, kExpectedDistance, 1e-6);
+
+  // Verify that the solution includes source to target.
+  EXPECT_TRUE(sink_->GetSolution(result).hasNaN());
 }
 
 TEST_F(ThreeBoxes, LinearEqualityConstraint) {
@@ -1756,7 +2217,7 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
 
   if (solvers::MosekSolver::is_available() &&
       solvers::MosekSolver::is_enabled()) {
-    // Test rounding_solver_options by setting the maximum iterations to 0,
+    // Test restriction_solver_options by setting the maximum iterations to 0,
     // which is equivalent to not solving the rounding problem. Thus it should
     // fail.
     solvers::MosekSolver mosek_solver;
@@ -1765,15 +2226,15 @@ GTEST_TEST(ShortestPathTest, RoundedSolution) {
     options.preprocessing = false;
     options.max_rounded_paths = 10;
 
-    options.rounding_solver_options = SolverOptions();
-    options.rounding_solver_options->SetOption(
+    options.restriction_solver_options = SolverOptions();
+    options.restriction_solver_options->SetOption(
         solvers::MosekSolver::id(), "MSK_IPAR_INTPNT_MAX_ITERATIONS", 0);
 
     auto failed_result = spp.SolveShortestPath(*source, *target, options);
     EXPECT_FALSE(failed_result.is_success());
 
     // Without the convex relaxation, the solver should ignore the
-    // rounding_solver_options and succeed.
+    // restriction_solver_options and succeed.
     options.convex_relaxation = false;
     auto successful_result = spp.SolveShortestPath(*source, *target, options);
     EXPECT_TRUE(successful_result.is_success());


### PR DESCRIPTION
A user can now decide to add a constraint to the relaxed, rounded or both problems.
I also cleaned up two minor logging issues:
- When the pre-processing step finds that a source/target is not connected, it returns the vertex name in addition to the id.
- The if statement in the logging step to display if we are rounding or not was not quite correct.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21179)
<!-- Reviewable:end -->
