### PR TITLE
[GCSTrajOpt] Add zero derivative constraints

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -393,6 +393,10 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("AddVelocityBounds",
             &Class::EdgesBetweenSubgraphs::AddVelocityBounds, py::arg("lb"),
             py::arg("ub"), subgraph_edges_doc.AddVelocityBounds.doc)
+        .def("AddZeroDerivativeConstraints",
+            &Class::EdgesBetweenSubgraphs::AddZeroDerivativeConstraints,
+            py::arg("derivative_order"),
+            subgraph_edges_doc.AddZeroDerivativeConstraints.doc)
         .def("AddPathContinuityConstraints",
             &Class::EdgesBetweenSubgraphs::AddPathContinuityConstraints,
             py::arg("continuity_order"),

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -529,9 +529,9 @@ class TestTrajectoryOptimization(unittest.TestCase):
                               GcsTrajectoryOptimization.EdgesBetweenSubgraphs)
         self.assertIn(main2_to_target, gcs.GetEdgesBetweenSubgraphs())
 
-        # Add final zero velocity constraints.
-        main2_to_target.AddVelocityBounds(lb=np.zeros(dimension),
-                                          ub=np.zeros(dimension))
+        # Add final zero velocity and acceleration.
+        main2_to_target.AddZeroDerivativeConstraints(derivative_order=1)
+        main2_to_target.AddZeroDerivativeConstraints(derivative_order=2)
 
         # This weight matrix penalizes movement in the y direction three
         # times more than in the x direction only for the main2 subgraph.

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -624,6 +624,70 @@ void EdgesBetweenSubgraphs::AddVelocityBounds(
   }
 }
 
+void EdgesBetweenSubgraphs::AddZeroDerivativeConstraints(int derivative_order) {
+  if (derivative_order < 1) {
+    throw std::runtime_error("Derivative order must be greater than 1.");
+  }
+
+  if (from_subgraph_.order() < derivative_order &&
+      to_subgraph_.order() < derivative_order) {
+    throw std::runtime_error(fmt::format(
+        "Cannot add derivative bounds to subgraph edges where both subgraphs "
+        "have less than derivative order.\n From subgraph order: {}\n To "
+        "subgraph order: {}\n Derivative order: {}",
+        from_subgraph_.order(), to_subgraph_.order(), derivative_order));
+  }
+
+  // We have d^Nq(t)/dt^N = d^Nr(s)/(ds^N * h^N) and h >= 0, which is nonlinear.
+  // To constraint zero velocity we can set the numerator to zero, which is
+  // convex:
+  // d^Nr(s)/ds^N = 0.
+
+  const Vector1d kVecZero = Vector1d::Zero();
+
+  if (from_subgraph_.order() >= derivative_order) {
+    // Add derivative bounds to the last control point of the u set.
+    // See BezierCurve::AsLinearInControlPoints().
+    SparseMatrix<double> M_transpose =
+        ur_trajectory_.AsLinearInControlPoints(derivative_order)
+            .col(from_subgraph_.order() - derivative_order)
+            .transpose();
+
+    // Equality constraint.
+    // (d^Nr(s)/ds^N).row(i) = 0.
+    const auto zero_derivative_constraint =
+        std::make_shared<LinearEqualityConstraint>(M_transpose, kVecZero);
+    for (int i = 0; i < num_positions(); ++i) {
+      for (Edge* edge : edges_) {
+        edge->AddConstraint(Binding<LinearEqualityConstraint>(
+            zero_derivative_constraint,
+            GetControlPointsU(*edge).row(i).transpose()));
+      }
+    }
+  }
+
+  if (to_subgraph_.order() >= derivative_order) {
+    // Add derivative bounds to the first control point of the v set.
+    // See BezierCurve::AsLinearInControlPoints().
+    SparseMatrix<double> M_transpose =
+        vr_trajectory_.AsLinearInControlPoints(derivative_order)
+            .col(0)
+            .transpose();
+    // Equality constraint:
+    // (d^Nr(s)/ds^N).row(i) = 0.
+    const auto zero_derivative_constraint =
+        std::make_shared<LinearEqualityConstraint>(M_transpose, kVecZero);
+
+    for (int i = 0; i < num_positions(); ++i) {
+      for (Edge* edge : edges_) {
+        edge->AddConstraint(Binding<LinearEqualityConstraint>(
+            zero_derivative_constraint,
+            GetControlPointsV(*edge).row(i).transpose()));
+      }
+    }
+  }
+}
+
 void EdgesBetweenSubgraphs::AddPathContinuityConstraints(int continuity_order) {
   if (continuity_order == 0) {
     throw std::runtime_error(

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -259,6 +259,19 @@ class GcsTrajectoryOptimization final {
     void AddVelocityBounds(const Eigen::Ref<const Eigen::VectorXd>& lb,
                            const Eigen::Ref<const Eigen::VectorXd>& ub);
 
+    /** Enforces zero derivatives on the control point connecting the subgraphs.
+
+    For velocity, acceleration, jerk, etc. enforcing zero-derivative on the
+    trajectory q(t) is equivalent to enforcing zero-derivative on the trajectory
+    r(s). Hence this constraint is convex.
+    @param derivative_order is the order of the derivative to be constrained.
+
+    @throws std::exception if the derivative order < 1.
+    @throws std::exception if both subgraphs order is less than the desired
+    derivative order.
+    */
+    void AddZeroDerivativeConstraints(int derivative_order);
+
     /** Enforces derivative continuity constraints on the edges between the
     subgraphs.
      @param continuity_order is the order of the continuity constraint.


### PR DESCRIPTION
Constraining the velocity, acceleration, jerk, etc. to zero between the edges of subgraphs can be formulated as a convex equality constraint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21180)
<!-- Reviewable:end -->
