### PR TITLE
[geometry] Add Shape::Visit

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -397,6 +397,7 @@ drake_cc_library(
     ],
     deps = [
         "//common:nice_type_name",
+        "//common:overloaded",
         "//geometry/proximity:make_convex_hull_mesh_impl",
         "//geometry/proximity:meshing_utilities",
         "//geometry/proximity:obj_to_surface_mesh",
@@ -1014,6 +1015,7 @@ drake_cc_googletest(
     deps = [
         ":shape_specification",
         "//common:find_resource",
+        "//common:overloaded",
         "//common/test_utilities",
     ],
 )

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <variant>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
@@ -36,16 +37,15 @@ class Sphere;
 //
 // When you add a new subclass of Shape to Drake, you must:
 //
-// 1. Add a virtual function ImplementGeometry() for the new shape in
+// 1. Adjust the VariantShapeConstPtr typedef to list the new subclass.
+//
+// 2. Add a virtual function ImplementGeometry() for the new shape in
 //    ShapeReifier that invokes the ThrowUnsupportedGeometry method, and add to
 //    the test for it in shape_specification_test.cc.
 //
-// 2. Implement ImplementGeometry in derived ShapeReifiers to continue support
-//    if desired, otherwise ensure unimplemented functions are not hidden in new
-//    derivations of ShapeReifier with `using`, for example, `using
-//    ShapeReifier::ImplementGeometry`. Existing subclasses should already have
-//    this. Otherwise, you might get a runtime error; we do not have an
-//    automatic way to enforce them at compile time.
+// 3. Grep Drake for the line `using ShapeReifier::ImplementGeometry;` (a trick
+//    that selects a default-throw implementation) and choose which (if any) of
+//    those reifiers you want to add support for this new shape into.
 
 /** The abstract base class for all shape specifications. Concrete subclasses
   exist for specific shapes (e.g., Box, Mesh, etc.).
@@ -76,6 +76,33 @@ class Shape {
   /** Returns a string representation of this shape. */
   std::string to_string() const { return do_to_string(); }
 
+  /** Calls the given `visitor` function with `*this` as the sole argument, but
+  with `*this` downcast to be the shape's concrete subclass. For example, if
+  this shape is a %Box then calls `visitor(static_cast<const Box&>(*this))`.
+  @tparam ReturnType The return type to coerce return values into. When not
+  `void`, anything returned by the visitor must be implicitly convertible to
+  this type. When `void`, the return type will be whatever the Vistor's call
+  operator returns by default.
+
+  To see examples of how this is used, you can check the Drake source code,
+  e.g., check the implementation of CalcVolume() for one example. */
+  template <typename ReturnType = void, typename Visitor>
+  decltype(auto) Visit(Visitor&& visitor) const {
+    if constexpr (std::is_same_v<ReturnType, void>) {
+      return std::visit(
+          [&visitor](auto* shape) {
+            return visitor(*shape);
+          },
+          get_variant_this());
+    } else {
+      return std::visit(
+          [&visitor](auto* shape) -> ReturnType {
+            return visitor(*shape);
+          },
+          get_variant_this());
+    }
+  }
+
  protected:
   /** (Internal use only) Constructor for use by derived classes.
   All subclasses of Shape must be marked `final`. */
@@ -102,6 +129,21 @@ class Shape {
 
   /** (Internal use only) NVI for to_string(). */
   virtual std::string do_to_string() const = 0;
+
+  /** (Internal use only) All concrete subclasses, as const pointers. */
+  using VariantShapeConstPtr = std::variant<  //
+      const Box*,                             //
+      const Capsule*,                         //
+      const Convex*,                          //
+      const Cylinder*,                        //
+      const Ellipsoid*,                       //
+      const HalfSpace*,                       //
+      const Mesh*,                            //
+      const MeshcatCone*,                     //
+      const Sphere*>;
+
+  /** (Internal use only) NVI-like helper function for Visit(). */
+  virtual VariantShapeConstPtr get_variant_this() const = 0;
 };
 
 /** Definition of a box. The box is centered on the origin of its canonical
@@ -146,6 +188,7 @@ class Box final : public Shape {
   std::unique_ptr<Shape> DoClone() const final;
   std::string_view do_type_name() const final;
   std::string do_to_string() const final;
+  VariantShapeConstPtr get_variant_this() const final;
 
   Vector3<double> size_;
 };
@@ -180,6 +223,7 @@ class Capsule final : public Shape {
   std::unique_ptr<Shape> DoClone() const final;
   std::string_view do_type_name() const final;
   std::string do_to_string() const final;
+  VariantShapeConstPtr get_variant_this() const final;
 
   double radius_{};
   double length_{};
@@ -246,6 +290,7 @@ class Convex final : public Shape {
   std::unique_ptr<Shape> DoClone() const final;
   std::string_view do_type_name() const final;
   std::string do_to_string() const final;
+  VariantShapeConstPtr get_variant_this() const final;
 
   std::string filename_;
   std::string extension_;
@@ -279,6 +324,7 @@ class Cylinder final : public Shape {
   std::unique_ptr<Shape> DoClone() const final;
   std::string_view do_type_name() const final;
   std::string do_to_string() const final;
+  VariantShapeConstPtr get_variant_this() const final;
 
   double radius_{};
   double length_{};
@@ -321,6 +367,7 @@ class Ellipsoid final : public Shape {
   std::unique_ptr<Shape> DoClone() const final;
   std::string_view do_type_name() const final;
   std::string do_to_string() const final;
+  VariantShapeConstPtr get_variant_this() const final;
 
   Vector3<double> radii_;
 };
@@ -361,6 +408,7 @@ class HalfSpace final : public Shape {
   std::unique_ptr<Shape> DoClone() const final;
   std::string_view do_type_name() const final;
   std::string do_to_string() const final;
+  VariantShapeConstPtr get_variant_this() const final;
 };
 
 // TODO(DamrongGuoy): Update documentation when mesh is fully supported (i.e.,
@@ -440,6 +488,7 @@ class Mesh final : public Shape {
   std::unique_ptr<Shape> DoClone() const final;
   std::string_view do_type_name() const final;
   std::string do_to_string() const final;
+  VariantShapeConstPtr get_variant_this() const final;
 
   // NOTE: Cannot be const to support default copy/move semantics.
   std::string filename_;
@@ -488,6 +537,7 @@ class MeshcatCone final : public Shape {
   std::unique_ptr<Shape> DoClone() const final;
   std::string_view do_type_name() const final;
   std::string do_to_string() const final;
+  VariantShapeConstPtr get_variant_this() const final;
 
   double height_{};
   double a_{};
@@ -514,6 +564,7 @@ class Sphere final : public Shape {
   std::unique_ptr<Shape> DoClone() const final;
   std::string_view do_type_name() const final;
   std::string do_to_string() const final;
+  VariantShapeConstPtr get_variant_this() const final;
 
   double radius_{};
 };

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -257,6 +257,7 @@ drake_cc_library(
     hdrs = ["geometry_spatial_inertia.h"],
     deps = [
         ":spatial_inertia",
+        "//common:overloaded",
         "//geometry:shape_specification",
         "//geometry/proximity:make_mesh_from_vtk",
         "//geometry/proximity:obj_to_surface_mesh",


### PR DESCRIPTION
Code that needs to operate on concrete Shape subclasses can now do so without needing to implement an entire Reifier.

Two samples are included in this PR.  For more examples of how this would be used, refer to the WIP commits at https://github.com/jwnimmer-tri/drake/commits/shape-visit/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21181)
<!-- Reviewable:end -->
