### PR TITLE
[render_vtk] Silence gltf basisu extension warnings by default

### DIFF
--- a/bindings/pydrake/common/serialize_pybind.h
+++ b/bindings/pydrake/common/serialize_pybind.h
@@ -168,15 +168,15 @@ class DefAttributesArchive {
   }
 
   // Partial specialization for List.
-  template <typename U>
-  static py::object CalcSchemaType(const std::vector<U>*) {
+  template <typename U, typename A>
+  static py::object CalcSchemaType(const std::vector<U, A>*) {
     auto u_type = CalcSchemaType(static_cast<U*>(nullptr));
     return GetTemplateClass("List")[u_type];
   }
 
   // Partial specialization for Dict.
-  template <typename U, typename V>
-  static py::object CalcSchemaType(const std::map<U, V>*) {
+  template <typename U, typename V, typename C, typename A>
+  static py::object CalcSchemaType(const std::map<U, V, C, A>*) {
     auto u_type = CalcSchemaType(static_cast<U*>(nullptr));
     auto v_type = CalcSchemaType(static_cast<V*>(nullptr));
     auto inner_types = py::make_tuple(u_type, v_type);

--- a/bindings/pydrake/geometry/BUILD.bazel
+++ b/bindings/pydrake/geometry/BUILD.bazel
@@ -121,6 +121,9 @@ drake_py_unittest(
 drake_py_unittest(
     name = "render_test",
     allow_network = ["render_gltf_client"],
+    data = [
+        "//geometry/render:test_models",
+    ],
     deps = [
         ":geometry",
         "//bindings/pydrake/common/test_utilities",

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -381,6 +381,17 @@ void DoScalarIndependentDefinitions(py::module m) {
   }
 
   {
+    using Class = geometry::GltfExtension;
+    constexpr auto& cls_doc = doc_geometry.GltfExtension;
+    py::class_<Class> cls(m, "GltfExtension", cls_doc.doc);
+    cls  // BR
+        .def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  {
     using Class = geometry::render::LightParameter;
     constexpr auto& cls_doc = doc.LightParameter;
     py::class_<Class> cls(m, "LightParameter", cls_doc.doc);

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:name_value",
+        "//common:string_container",
         "//geometry/render:light_parameter",
         "//geometry/render:render_label",
     ],

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -210,6 +210,9 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
  private:
   friend class RenderEngineVtkTester;
 
+  // Our diagnostic_ object's warning callback calls this function.
+  void HandleWarning(const drake::internal::DiagnosticDetail& detail) const;
+
   // Initializes the VTK pipelines.
   void InitializePipelines();
 

--- a/geometry/render_vtk/test/render_engine_vtk_params_test.cc
+++ b/geometry/render_vtk/test/render_engine_vtk_params_test.cc
@@ -8,14 +8,55 @@ namespace drake {
 namespace geometry {
 namespace {
 
+using yaml::LoadYamlString;
+using yaml::SaveYamlString;
+
+const char* const kExampleConfig = R"""(
+default_diffuse: [1.0, 0.5, 0.25, 1.0]
+default_clear_color: [0.25, 0.5, 1.0]
+lights:
+  - type: spot
+    color:
+      rgba: [0.5, 0.5, 0.5, 1.0]
+    attenuation_values: [1.0, 0.0, 0.0]
+    position: [1.0, 2.0, 3.0]
+    frame: world
+    intensity: 0.9
+    direction: [0.0, 0.0, 1.0]
+    cone_angle: 45.0
+environment_map:
+  skybox: false
+  texture: !EquirectangularMap
+    path: /path/to/environment_image.hdr
+exposure: 1.0
+cast_shadows: true
+shadow_map_size: 512
+gltf_extensions:
+  KHR_draco_mesh_compression:
+    warn_unimplemented: true
+)""";
+
+// Test deserialization/re-serialization of the basic configuration.
+GTEST_TEST(RenderEngineVtkParams, LoadSaveRoundTrip) {
+  using Params = RenderEngineVtkParams;
+  const auto config = LoadYamlString<Params>(kExampleConfig);
+  EXPECT_EQ("\n" + SaveYamlString(config), kExampleConfig);
+
+  // Sanity check a few values just to make sure something actually loaded.
+  EXPECT_EQ(config.default_clear_color[0], 0.25);
+  EXPECT_FALSE(config.environment_map.value().skybox);
+  EXPECT_EQ(config.lights.at(0).type, "spot");
+  EXPECT_EQ(config.gltf_extensions.size(), 1);
+}
+
 // Test serialization/deserialization of the basic configuration.
-GTEST_TEST(RenderEngineVtkParams, BasicSerialization) {
+GTEST_TEST(RenderEngineVtkParams, SaveLoadRoundTrip) {
   using Params = RenderEngineVtkParams;
   const Params original{.default_diffuse = Eigen::Vector4d{1.0, 0.5, 0.25, 1.0},
                         .default_clear_color = Eigen::Vector3d{0.25, 0.5, 1.0},
                         .lights = {{.type = "point"}}};
-  const std::string yaml = yaml::SaveYamlString<Params>(original);
-  const Params dut = yaml::LoadYamlString<Params>(yaml);
+  const std::string yaml = SaveYamlString<Params>(original);
+  const Params dut = LoadYamlString<Params>(yaml);
   EXPECT_EQ(dut.default_diffuse, original.default_diffuse);
   EXPECT_EQ(dut.default_clear_color, original.default_clear_color);
   ASSERT_EQ(dut.lights.size(), 1);
@@ -29,8 +70,8 @@ GTEST_TEST(RenderEngineVtkParams, SerializationWithEquirectangularMap) {
   const Params original{
       .environment_map = EnvironmentMap{
           .skybox = false, .texture = EquirectangularMap{.path = "local.hdr"}}};
-  const std::string yaml = yaml::SaveYamlString<Params>(original);
-  const Params dut = yaml::LoadYamlString<Params>(yaml);
+  const std::string yaml = SaveYamlString<Params>(original);
+  const Params dut = LoadYamlString<Params>(yaml);
   ASSERT_TRUE(dut.environment_map.has_value());
   EXPECT_FALSE(dut.environment_map->skybox);
   ASSERT_TRUE(


### PR DESCRIPTION
Add RenderVtkParams configuration for what to silence.

Fix serialize_pybind to admit the full vector and map template signatures.

Towards #20935.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21183)
<!-- Reviewable:end -->
