### PR TITLE
Support deformable vs. deformable contact

### DIFF
--- a/geometry/query_results/deformable_contact.cc
+++ b/geometry/query_results/deformable_contact.cc
@@ -111,9 +111,13 @@ DeformableContactSurface<T>::DeformableContactSurface(
   }
   nhats_W_.reserve(num_contact_points);
   contact_points_W_.reserve(num_contact_points);
+  R_WCs_.reserve(num_contact_points);
+  const int kZAxis = 2;
   for (int i = 0; i < num_contact_points; ++i) {
     nhats_W_.emplace_back(contact_mesh_W_.face_normal(i));
     contact_points_W_.emplace_back(contact_mesh_W_.element_centroid(i));
+    R_WCs_.emplace_back(
+        math::RotationMatrix<T>::MakeFromOneUnitVector(-nhats_W_[i], kZAxis));
   }
 }
 

--- a/geometry/query_results/deformable_contact.h
+++ b/geometry/query_results/deformable_contact.h
@@ -7,6 +7,7 @@
 
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
+#include "drake/math/rotation_matrix.h"
 #include "drake/multibody/contact_solvers/sap/partial_permutation.h"
 
 namespace drake {
@@ -235,6 +236,14 @@ class DeformableContactSurface {
    `signed_distances()`.*/
   const std::vector<Vector3<T>>& nhats_W() const { return nhats_W_; }
 
+  /* Returns rotation matrices that transform the basis of frame W into the
+   basis of an arbitrary frame C. In this transformation, the z-axis of frame,
+   Cz, is aligned with the vector n̂. The vector n̂ represents the normal as
+   reported in `nhats_W()`. Cx and Cy are arbitrary but sufficient to form the
+   right-handed basis. The ordering of rotation matrices is the same as that in
+   `signed_distances()`. */
+  const std::vector<math::RotationMatrix<T>>& R_WCs() const { return R_WCs_; }
+
   bool is_B_deformable() const { return contact_vertex_indexes_B_.has_value(); }
 
  private:
@@ -249,6 +258,7 @@ class DeformableContactSurface {
   std::optional<std::vector<Vector4<int>>> contact_vertex_indexes_B_;
   std::optional<std::vector<Vector4<T>>> barycentric_coordinates_B_;
   std::vector<Vector3<T>> nhats_W_;
+  std::vector<math::RotationMatrix<T>> R_WCs_;
 };
 
 /* Data structure to hold contact information about all deformable geometries

--- a/geometry/query_results/test/deformable_contact_test.cc
+++ b/geometry/query_results/test/deformable_contact_test.cc
@@ -2,6 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/ssize.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
 namespace drake {
 namespace geometry {
 namespace internal {
@@ -63,6 +66,7 @@ GTEST_TEST(DeformableContactSurface, EmptySurface) {
   EXPECT_EQ(dut.barycentric_coordinates_A().size(), 0);
   EXPECT_EQ(dut.contact_vertex_indexes_A().size(), 0);
   EXPECT_EQ(dut.nhats_W().size(), 0);
+  EXPECT_EQ(dut.R_WCs().size(), 0);
   EXPECT_FALSE(dut.is_B_deformable());
 }
 
@@ -98,6 +102,11 @@ GTEST_TEST(DeformableContactSurface, Getters) {
   EXPECT_EQ(dut.barycentric_coordinates_A(), barycentric_centroids_A);
   EXPECT_EQ(dut.barycentric_coordinates_B(), barycentric_centroids_B);
   EXPECT_EQ(dut.nhats_W(), nhats_W);
+  EXPECT_EQ(dut.R_WCs().size(), dut.nhats_W().size());
+  const std::vector<math::RotationMatrix<double>>& R_WCs = dut.R_WCs();
+  for (int i = 0; i < ssize(R_WCs); ++i) {
+    EXPECT_TRUE(CompareMatrices(R_WCs[i].col(2), -nhats_W[i]));
+  }
 }
 
 GTEST_TEST(DeformableContact, RegisterGeometry) {
@@ -215,6 +224,7 @@ GTEST_TEST(DeformableContact, AddDeformableDeformableContactSurface) {
   EXPECT_EQ(s.barycentric_coordinates_B(), barycentric_centroids_B);
   EXPECT_EQ(s.contact_vertex_indexes_B(), contact_vertex_indexes_B);
   EXPECT_EQ(s.nhats_W().size(), 1);
+  EXPECT_EQ(s.R_WCs().size(), 1);
   EXPECT_TRUE(s.is_B_deformable());
 
   // Verify that contact participation is as expected.

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -1025,6 +1025,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "deformable_driver_contact_kinematics_test",
     deps = [
+        ":multibody_plant_config_functions",
         ":multibody_plant_core",
         "//common/test_utilities:eigen_matrix_compare",
         "//systems/framework:diagram_builder",

--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -223,6 +223,152 @@ void DeformableDriver<T>::AppendLinearDynamicsMatrix(
 }
 
 template <typename T>
+typename DeformableDriver<T>::ContactData
+DeformableDriver<T>::ComputeContactDataForDeformable(
+    const systems::Context<T>& context,
+    const geometry::internal::DeformableContactSurface<T>& surface,
+    bool is_A) const {
+  const geometry::GeometryId geometry_id =
+      is_A ? surface.id_A() : surface.id_B();
+  const DeformableBodyIndex body_index = deformable_model_->GetBodyIndex(
+      deformable_model_->GetBodyId(geometry_id));
+  const ContactParticipation& participation =
+      EvalConstraintParticipation(context, body_index);
+  const PartialPermutation& vertex_permutation =
+      EvalVertexPermutation(context, geometry_id);
+  const VectorX<T>& deformable_participating_v0 =
+      EvalParticipatingVelocities(context);
+  const Multiplexer<T>& mux = EvalParticipatingVelocityMultiplexer(context);
+  const Eigen::Ref<const VectorX<T>> body_participating_v0 =
+      mux.Demultiplex(deformable_participating_v0, body_index);
+  // TODO(xuchenhan-tri): This should be pre-computed and cached instead of
+  // recomputed for every deformable body in contact at every time step.
+  /* Retrieve the boundary condition information of the body to determine
+   which columns for the jacobian need to be zeroed out later. */
+  const DeformableBodyId body_id = deformable_model_->GetBodyId(geometry_id);
+  const FemModel<T>& fem_model = deformable_model_->GetFemModel(body_id);
+  const DirichletBoundaryCondition<T>& bc =
+      fem_model.dirichlet_boundary_condition();
+  /* The number of boundary conditions added to each vertex. */
+  std::vector<int> num_bcs(fem_model.num_nodes(), 0);
+  for (const auto& [node_index, node_state] : bc.index_to_boundary_state()) {
+    /* Note that we currently only allow zero boundary conditions. */
+    DRAKE_DEMAND(node_state.v == Vector3<T>::Zero());
+    DRAKE_DEMAND(node_state.a == Vector3<T>::Zero());
+    ++num_bcs[node_index];
+  }
+
+  ContactData result;
+  // For deformable objects, we use the centroid of the contact surface as the
+  // relative-to point in the configuration.
+  result.p_WG = surface.contact_mesh_W().centroid();
+  // TODO(xuchenhan-tri): Currently deformable bodies don't have names. When
+  // they do get names upon registration (in DeformableModel), update its
+  // body name here.
+  result.name = fmt::format("deformable id {}", geometry_id);
+  result.v_WGc.reserve(surface.num_contact_points());
+  result.jacobian.reserve(surface.num_contact_points());
+
+  /* The Jacobian block triplets to be filled in. There are at most 4 nonzero
+   blocks. */
+  std::vector<typename Block3x3SparseMatrix<T>::Triplet> triplets;
+  triplets.reserve(4);
+  for (int i = 0; i < surface.num_contact_points(); ++i) {
+    /* The contact Jacobian (w.r.t. v) of the velocity of the point affixed to
+     the geometry that coincides with the contact point C in the world frame,
+     expressed in the contact frame C. We scale it by -1 if the body corresponds
+     to body A in contact to get the correct sign. */
+    const double scale = is_A ? -1.0 : 1.0;
+    Block3x3SparseMatrix<T> scaled_Jv_v_WGc_C(
+        /* block rows */ 1,
+        /* block columns */ participation.num_vertices_in_contact());
+    const Vector4<int>& participating_vertices =
+        is_A ? surface.contact_vertex_indexes_A()[i]
+             : surface.contact_vertex_indexes_B()[i];
+    const Vector4<T>& b = is_A ? surface.barycentric_coordinates_A()[i]
+                               : surface.barycentric_coordinates_B()[i];
+    Vector3<T> v_WGc = Vector3<T>::Zero();
+    triplets.clear();
+    for (int v = 0; v < 4; ++v) {
+      const bool vertex_under_bc = num_bcs[participating_vertices(v)] > 0;
+      /* Map indexes to the permuted domain. */
+      const int permuted_vertex =
+          vertex_permutation.permuted_index(participating_vertices(v));
+      if (!vertex_under_bc) {
+        /* v_WAc = (b₀ * v₀ + b₁ * v₁ + b₂ * v₂ + b₃ * v₃) where v₀, v₁, v₂,
+         v₃ are the velocities of the vertices forming the tetrahedron
+         containing the contact point and the b's are their corresponding
+         barycentric weights. */
+        triplets.emplace_back(
+            0, permuted_vertex,
+            scale * b(v) * surface.R_WCs()[i].matrix().transpose());
+        v_WGc += b(v) *
+                 body_participating_v0.template segment<3>(3 * permuted_vertex);
+      }
+      /* If the vertex is under bc, the corresponding jacobian block is zero
+       because the vertex doesn't contribute to the contact velocity. */
+    }
+    scaled_Jv_v_WGc_C.SetFromTriplets(triplets);
+    result.v_WGc.emplace_back(v_WGc);
+    const TreeIndex tree_index(
+        manager_->internal_tree().get_topology().num_trees() + body_index);
+    result.jacobian.emplace_back(tree_index,
+                                 MatrixBlock<T>(std::move(scaled_Jv_v_WGc_C)));
+  }
+  return result;
+}
+
+template <typename T>
+typename DeformableDriver<T>::ContactData
+DeformableDriver<T>::ComputeContactDataForRigid(
+    const systems::Context<T>& context,
+    const geometry::internal::DeformableContactSurface<T>& surface) const {
+  ContactData result;
+  /* Rigid geometry is guaranteed to be body B in a deformable rigid contact. */
+  const geometry::GeometryId geometry_id = surface.id_B();
+  const BodyIndex body_index =
+      manager_->geometry_id_to_body_index().at(geometry_id);
+  const RigidBody<T>& rigid_body = manager_->plant().get_body(body_index);
+  result.name = rigid_body.name();
+  /* For rigid body, we use the origin of the body frame as the relative-to
+   point. */
+  result.p_WG =
+      manager_->plant()
+          .EvalBodyPoseInWorld(context, manager_->plant().get_body(body_index))
+          .translation();
+  const MultibodyTreeTopology& tree_topology =
+      manager_->internal_tree().get_topology();
+  const TreeIndex tree_index = tree_topology.body_to_tree_index(body_index);
+  /* If the body is welded to world, then everything is trivially zero (as
+   indicated by empty jacobian and velocity vectors). */
+  if (!tree_topology.tree_has_dofs(tree_index)) {
+    return result;
+  }
+
+  const Eigen::VectorBlock<const VectorX<T>> rigid_v0 =
+      manager_->plant().GetVelocities(context);
+  const Frame<T>& frame_W = manager_->plant().world_frame();
+  const int nv = manager_->plant().num_velocities();
+  Matrix3X<T> Jv_v_WGc_W(3, nv);
+  for (int i = 0; i < surface.num_contact_points(); ++i) {
+    // TODO(xuchenhan-tri): The computation of the contact Jacobian for all
+    // contact points associated with this contact surface can be done in a
+    // single pass down the kinematic path to world.
+    const Vector3<T>& p_WC = surface.contact_points_W()[i];
+    manager_->internal_tree().CalcJacobianTranslationalVelocity(
+        context, JacobianWrtVariable::kV, rigid_body.body_frame(), frame_W,
+        p_WC, frame_W, frame_W, &Jv_v_WGc_W);
+    result.v_WGc.emplace_back(Jv_v_WGc_W * rigid_v0);
+    Matrix3X<T> J = surface.R_WCs()[i].matrix().transpose() *
+                    Jv_v_WGc_W.middleCols(
+                        tree_topology.tree_velocities_start_in_v(tree_index),
+                        tree_topology.num_tree_velocities(tree_index));
+    result.jacobian.emplace_back(tree_index, MatrixBlock<T>(std::move(J)));
+  }
+  return result;
+}
+
+template <typename T>
 void DeformableDriver<T>::AppendDiscreteContactPairs(
     const systems::Context<T>& context,
     DiscreteContactData<DiscreteContactPair<T>>* result) const {
@@ -232,15 +378,7 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
      Jv_v_AcBc_W = Jv_v_WBc_W - Jv_v_WAc_W.
    That is the relative velocity at C is v_AcBc_W = Jv_v_AcBc_W * v.
    Finally Jv_v_AcBc_C = R_WC.transpose() * Jv_v_AcBc_W.
-   Currently, only deformable vs rigid contact is supported. Deformable
-   body is body A and rigid body is body B. Moreover, the set of dofs for
-   deformable bodies and rigid bodies are mutually exclusive, and
-   Jv_v_WAc_W = 0 for rigid dofs and Jv_v_WBc_W = 0 for deformable dofs. As a
-   result, we know the size of Jv_v_WBc_W up front. */
-  const int nv = manager_->plant().num_velocities();
-  Matrix3X<T> Jv_v_WBc_W(3, nv);
-  const MultibodyTreeTopology& tree_topology =
-      manager_->internal_tree().get_topology();
+   The set of dofs for body A and body B are mutually exclusive. */
 
   const geometry::QueryObject<T>& query_object =
       manager_->plant()
@@ -256,124 +394,61 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
        ++surface_index) {
     const DeformableContactSurface<T>& surface =
         contact_surfaces[surface_index];
+    /* Write the contact jacobian and velocity for all contact points for body
+     A. */
+    ContactData contact_data_A =
+        ComputeContactDataForDeformable(context, surface, true);
+    const Vector3<T>& p_WA = contact_data_A.p_WG;
+
+    ContactData contact_data_B =
+        surface.is_B_deformable()
+            ? ComputeContactDataForDeformable(context, surface, false)
+            : ComputeContactDataForRigid(context, surface);
+    const Vector3<T>& p_WB = contact_data_B.p_WG;
+
     const GeometryId id_A = surface.id_A();
     const GeometryId id_B = surface.id_B();
-
     /* Body A is guaranteed to be deformable. */
-    const DeformableBodyIndex index_A =
+    const int body_index_A =
         deformable_model_->GetBodyIndex(deformable_model_->GetBodyId(id_A));
-    const TreeIndex clique_index_A(tree_topology.num_trees() + index_A);
-    const ContactParticipation& participation =
-        EvalConstraintParticipation(context, index_A);
-    const PartialPermutation& vertex_permutation =
-        EvalVertexPermutation(context, id_A);
-    const VectorX<T>& deformable_participating_v0 =
-        EvalParticipatingVelocities(context);
-    const Eigen::VectorBlock<const VectorX<T>> rigid_v0 =
-        manager_->plant().GetVelocities(context);
-
-    /* Retrieve the boundary condition information of body A to determine
-     which columns for the jacobian need to be zero out later. */
-    const DeformableBodyId body_id_A = deformable_model_->GetBodyId(id_A);
-    const FemModel<T>& fem_model = deformable_model_->GetFemModel(body_id_A);
-    const DirichletBoundaryCondition<T>& bc =
-        fem_model.dirichlet_boundary_condition();
-    /* The number of boundary conditions added to each vertex. */
-    std::vector<int> num_bcs(fem_model.num_nodes(), 0);
-    for (const auto& it : bc.index_to_boundary_state()) {
-      /* Note that we currently only allow zero boundary conditions. */
-      DRAKE_DEMAND(it.second.v == Vector3<T>::Zero());
-      DRAKE_DEMAND(it.second.a == Vector3<T>::Zero());
-      const int vertex_index = it.first;
-      ++num_bcs[vertex_index];
-    }
-
-    /* For now, body B is guaranteed to be rigid. */
-    DRAKE_DEMAND(!surface.is_B_deformable());
-    const BodyIndex index_B = manager_->geometry_id_to_body_index().at(id_B);
-    const RigidBody<T>& body_B = manager_->plant().get_body(index_B);
-    const TreeIndex tree_index_B = tree_topology.body_to_tree_index(index_B);
-
-    /* By convention, deformable bodies are assigned object indexes after all
-     rigid bodies. */
+    /* Body B may be rigid or deformable. We first get its body index. */
+    const int body_index_B =
+        surface.is_B_deformable()
+            ? static_cast<int>(deformable_model_->GetBodyIndex(
+                  deformable_model_->GetBodyId(id_B)))
+            : static_cast<int>(manager_->geometry_id_to_body_index().at(id_B));
+    /* By convention, the object index of a rigid body is just its body index.
+     All deformable bodies come after all rigid bodies, and the object index of
+     a deformable body is its deformable body index + the number of rigid bodies
+     in the plant. */
     const int object_A =
-        index_A + manager_->plant().num_bodies();  // Deformable body.
-    const int object_B = index_B;                  // Rigid body.
+        body_index_A + manager_->plant().num_bodies();  // Deformable body.
+    const int object_B =
+        surface.is_B_deformable()
+            ? body_index_B + manager_->plant().num_bodies()  // Deformable body.
+            : body_index_B;                                  // Rigid body.
 
+    /* We reuse `jacobian_blocks` for the Jacobian blocks for each contact
+     point and clear the vector repeatedly in the loop over the contact points.
+    */
+    std::vector<typename DiscreteContactPair<T>::JacobianTreeBlock>
+        jacobian_blocks;
     for (int i = 0; i < surface.num_contact_points(); ++i) {
-      /* We have at most two blocks per contact. */
-      std::vector<typename DiscreteContactPair<T>::JacobianTreeBlock>
-          jacobian_blocks;
-      jacobian_blocks.reserve(2);
-      /* Contact solver assumes the normal points from A to B whereas the
-       surface's normal points from B to A. */
-      const Vector3<T>& nhat_W = -surface.nhats_W()[i];
-      constexpr int kZAxis = 2;
-      math::RotationMatrix<T> R_WC =
-          math::RotationMatrix<T>::MakeFromOneUnitVector(nhat_W, kZAxis);
-      const math::RotationMatrix<T> R_CW = R_WC.transpose();
-      /* Calculate the jacobian block for the body A. */
-      Block3x3SparseMatrix<T> negative_Jv_v_WAc_C(
-          1, participation.num_vertices_in_contact());
-      Vector4<int> participating_vertices =
-          surface.contact_vertex_indexes_A()[i];
-      const Vector4<T>& b = surface.barycentric_coordinates_A()[i];
-      std::vector<typename Block3x3SparseMatrix<T>::Triplet> triplets;
-      triplets.reserve(4);
-      Vector3<T> v_Ac_W = Vector3<T>::Zero();
-      for (int v = 0; v < 4; ++v) {
-        const bool vertex_under_bc = num_bcs[participating_vertices(v)] > 0;
-        /* Map indexes to the permuted domain. */
-        participating_vertices(v) =
-            vertex_permutation.permuted_index(participating_vertices(v));
-        if (!vertex_under_bc) {
-          /* v_WAc = (b₀ * v₀ + b₁ * v₁ + b₂ * v₂ + b₃ * v₃) where v₀, v₁, v₂,
-           v₃ are the velocities of the vertices forming the tetrahedron
-           containing the contact point and the b's are their corresponding
-           barycentric weights. */
-          triplets.emplace_back(0, participating_vertices(v),
-                                -b(v) * R_CW.matrix());
-          v_Ac_W += b(v) * deformable_participating_v0.template segment<3>(
-                               3 * participating_vertices(v));
-        }
-        negative_Jv_v_WAc_C.SetFromTriplets(triplets);
-        /* If the vertex is under bc, the corresponding jacobain block is zero
-         because the vertex doesn't contribute to the contact velocity. */
-      }
-      jacobian_blocks.emplace_back(
-          clique_index_A, MatrixBlock<T>(std::move(negative_Jv_v_WAc_C)));
+      jacobian_blocks.clear();
+      const Vector3<T>& v_WAc = contact_data_A.v_WGc[i];
+      jacobian_blocks.push_back(std::move(contact_data_A.jacobian[i]));
 
-      /* Calculate the jacobian block for the rigid body B if it's not static.
-       */
+      Vector3<T> v_WBc = Vector3<T>::Zero();
+      /* Empty contact data indicates that the body is welded and we don't need
+       to record the Jacobian. */
+      if (!contact_data_B.jacobian.empty()) {
+        v_WBc = contact_data_B.v_WGc[i];
+        jacobian_blocks.push_back(std::move(contact_data_B.jacobian[i]));
+      }
+
       const Vector3<T>& p_WC = surface.contact_points_W()[i];
-      Vector3<T> v_Bc_W = Vector3<T>::Zero();
-      if (tree_index_B.is_valid()) {
-        const RigidBody<T>& rigid_body = manager_->plant().get_body(index_B);
-        const Frame<T>& frame_W = manager_->plant().world_frame();
-        manager_->internal_tree().CalcJacobianTranslationalVelocity(
-            context, JacobianWrtVariable::kV, rigid_body.body_frame(), frame_W,
-            p_WC, frame_W, frame_W, &Jv_v_WBc_W);
-        v_Bc_W = Jv_v_WBc_W * rigid_v0;
-        Matrix3X<T> J =
-            R_CW.matrix() *
-            Jv_v_WBc_W.middleCols(
-                tree_topology.tree_velocities_start_in_v(tree_index_B),
-                tree_topology.num_tree_velocities(tree_index_B));
-        jacobian_blocks.emplace_back(tree_index_B,
-                                     MatrixBlock<T>(std::move(J)));
-      }
-
-      // Contact point position relative to deformable object A. For deformable
-      // objects, we'll use the centroid of the contact surface as the
-      // relative-to point in the configuration.
-      const Vector3<T>& p_WCentroid = surface.contact_mesh_W().centroid();
-      const Vector3<T> p_ACentroidC_W = p_WC - p_WCentroid;
-
-      // Contact point position relative to rigid body B.
-      const math::RigidTransform<T>& X_WB =
-          manager_->plant().EvalBodyPoseInWorld(
-              context, manager_->plant().get_body(index_B));
-      const Vector3<T>& p_WB = X_WB.translation();
+      // Contact point position relative to object A and B.
+      const Vector3<T> p_AC_W = p_WC - p_WA;
       const Vector3<T> p_BC_W = p_WC - p_WB;
 
       /* We set a large stiffness for the deformable body to approximate rigid
@@ -394,7 +469,9 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
       const T kA = surface.contact_mesh_W().area(i) * 1e8;
       const T default_rigid_k = std::numeric_limits<T>::infinity();
       const T kB =
-          GetPointContactStiffness(surface.id_B(), default_rigid_k, inspector);
+          surface.is_B_deformable()
+              ? kA
+              : GetPointContactStiffness(id_B, default_rigid_k, inspector);
       /* Combine stiffnesses k₁ (of geometry A) and k₂ (of geometry B) to get k
        according to the rule: 1/k = 1/k₁ + 1/k₂. */
       const T k = GetCombinedPointContactStiffness(kA, kB);
@@ -405,29 +482,26 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
           surface.id_A(), surface.id_B(), kA, kB, 0.0 /* Default value */,
           inspector);
 
-      // TODO(xuchenhan-tri): Currently deformable bodies don't have names. When
-      // they do get names upon registration (in DeformableModel), update its
-      // body name here.
-      const std::string body_A_name(
-          fmt::format("deformable body with geometry id {}", id_A));
-
       /* Dissipation time scale. Ignored, for instance, by the Tamsi model of
        contact approximation. See multibody::DiscreteContactApproximation for
        details about these contact models. We use dt as the default dissipation
        constant so that the contact is in near-rigid regime and the compliance
        is only used as stabilization. */
       const T tau = GetCombinedDissipationTimeConstant(
-          id_A, id_B, manager_->plant().time_step(), body_A_name, body_B.name(),
-          inspector);
+          id_A, id_B, manager_->plant().time_step(), contact_data_A.name,
+          contact_data_B.name, inspector);
       const double mu =
           GetCombinedDynamicCoulombFriction(id_A, id_B, inspector);
 
-      const Vector3<T>& nhat_BA_W = surface.nhats_W()[i];
       const T& phi0 = surface.signed_distances()[i];
       const T fn0 = -k * phi0;
       /* The normal (scalar) component of the contact velocity in the contact
        frame. */
-      const T v_AcBc_Cz = nhat_W.dot(v_Bc_W - v_Ac_W);
+      /* Contact solver assumes the normal points from A to B whereas the
+       surface's normal points from B to A. */
+      const Vector3<T> nhat_AB_W = -surface.nhats_W()[i];
+      const math::RotationMatrix<T>& R_WC = surface.R_WCs()[i];
+      const T v_AcBc_Cz = nhat_AB_W.dot(v_WBc - v_WAc);
       DiscreteContactPair<T> contact_pair{
           .jacobian = std::move(jacobian_blocks),
           .id_A = id_A,
@@ -436,9 +510,9 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
           .object_B = object_B,
           .R_WC = R_WC,
           .p_WC = p_WC,
-          .p_ApC_W = p_ACentroidC_W,
+          .p_ApC_W = p_AC_W,
           .p_BqC_W = p_BC_W,
-          .nhat_BA_W = nhat_BA_W,
+          .nhat_BA_W = -nhat_AB_W,
           .phi0 = phi0,
           .vn0 = v_AcBc_Cz,
           .fn0 = fn0,

--- a/multibody/plant/deformable_driver.h
+++ b/multibody/plant/deformable_driver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -199,6 +200,58 @@ class DeformableDriver : public ScalarConvertibleComponent<T> {
     systems::CacheIndex participating_velocities;
     systems::CacheIndex participating_free_motion_velocities;
   };
+
+  /* Struct to hold intermediate data from one of the two geometries in contact
+   when computing DiscreteContactPair. */
+  struct ContactData {
+    /* The world frame position of the relative-to point for reporting the
+     contact results. See DiscreteContactPair::p_ApC_W and
+     DiscreteContactPair::p_BqC_W. `p_WG` is coincident with P and Q (and as
+     they are all measured and expressed in the world frame, they will all
+     have the same values). */
+    Vector3<T> p_WG;
+    /* Contact Jacobians for the kinematic tree corresponding to the object
+     participating in the contact. `jacobian[i]` stores the contact Jacobian for
+     the i-th contact point. This is empty if the geometry is rigid and welded
+     to World. */
+    std::vector<typename DiscreteContactPair<T>::JacobianTreeBlock> jacobian;
+    /* Velocity (in the world frame) of the point Gc affixed to the geometry
+     that is coincident with the contact point C. `v_WGc[i]` stores the
+     world-frame velocity of the i-th contact point. This is empty if the
+     geometry is rigid and welded to World. */
+    std::vector<Vector3<T>> v_WGc;
+    /* Name of the geometry in contact. */
+    std::string name;
+  };
+
+  /* Computes the contact data for a deformable geometry G participating in
+   contact.
+   @param[in] context          Context of the MultibodyPlant owning this driver.
+   @param[in] contact_surface  The contact surface between two geometries with
+                               one of the geometries being geometry G.
+   @param[in] is_A             True if geometry G is labeled as geometry A in
+                               the given `contact_surface`. See class
+                               documentation for
+                               geometry::internal::DeformableContactSurface for
+                               details. */
+  ContactData ComputeContactDataForDeformable(
+      const systems::Context<T>& context,
+      const geometry::internal::DeformableContactSurface<T>& contact_surface,
+      bool is_A) const;
+
+  /* Computes the contact data for a rigid geometry G participating in contact.
+   @param[in] context          Context of the MultibodyPlant owning this driver.
+   @param[in] contact_surface  The contact surface between two geometries with
+                               one of the geometries being geometry G.
+   @note Unlike ComputeContactDataForDeformable where we need to determine
+   whether geometry G is labeled as geometry A or B in DeformableContactSurface,
+   by convention, a rigid geometry is always labeled as geometry B in
+   DeformableContactSurface if it participates in deformable contact. */
+  ContactData ComputeContactDataForRigid(
+      const systems::Context<T>& context,
+      const geometry::internal::DeformableContactSurface<T>& contact_surface)
+      const;
+
   /* Copies the state of the deformable body with `id` in the given `context`
    to the `fem_state`.
    @pre fem_state != nullptr and has size compatible with the state of the

--- a/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
@@ -6,6 +7,7 @@
 #include "drake/multibody/plant/compliant_contact_manager.h"
 #include "drake/multibody/plant/deformable_driver.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/systems/framework/diagram_builder.h"
 
 using drake::geometry::GeometryId;
@@ -32,6 +34,7 @@ namespace multibody {
 namespace internal {
 
 constexpr double kTolerance = 1e-14;
+constexpr double kMu = 1.0;
 
 /* Registers a deformable octrahedron with the given `name` and pose in the
  world to the given `model`.
@@ -55,7 +58,7 @@ DeformableBodyId RegisterDeformableOctahedron(DeformableModel<double>* model,
   auto geometry = make_unique<GeometryInstance>(X_WF, make_unique<Sphere>(1.0),
                                                 std::move(name));
   geometry::ProximityProperties props;
-  geometry::AddContactMaterial({}, {}, CoulombFriction<double>(1.0, 1.0),
+  geometry::AddContactMaterial({}, {}, CoulombFriction<double>(kMu, kMu),
                                &props);
   geometry->set_proximity_properties(std::move(props));
   fem::DeformableBodyConfig<double> body_config;
@@ -68,28 +71,35 @@ DeformableBodyId RegisterDeformableOctahedron(DeformableModel<double>* model,
 
 /* Test fixture to test DeformableDriver::AppendDiscreteContactPairs and
  DeformableDriver::AppendDeformableRigidFixedConstraintKinematics.
- In particular, this fixture sets up a deformable octahedron centered at world
- origin with 8 elements, 7 vertices, and 21 dofs. To test contact kinematics,
- we add a rigid rectangle so that its top face intersects the bottom half of the
- deformable octahedron. The rigid rectangle can be configured to be dynamic or
- static to provide coverage for the cases with one and two Jacobian blocks. We
- compare rotation matrix from world to the contact frame and contact velocities
- to expected values. Similarly, to test fixed constraint kinematics, we add
- fixed constraint between the rigid body and the vertex of the deformable body
- inside the rigid geometry. We then compare the constraint velocities to
- expected values. */
+ In particular, this fixture sets up environments where the contact/constraint
+ information can easily be computed by hand. We then compare the result computed
+ by DeformableDriver and the hand-calculated result to confirm correctness. */
 class DeformableDriverContactKinematicsTest
     : public ::testing::TestWithParam<bool> {
  protected:
   void SetUp() {}
 
-  /* Sets up the scene described in the class documentation. The rigid body is
-   dynamic if `dynamic_rigid_body` is true. Otherwise, a collision geometry
-   bound to the world body with the same shape is added. The pose/configuration
-   of the bodies are set so that the contact normals are all equal to -Fz, for
-   an arbitrarily chosen frame F. Velocities of the body are set so that the
-   contact velocity in the C frame is (0, 0, -1). */
-  void MakeScene(bool dynamic_rigid_body) {
+  /* Sets up a deformable octahedron centered at world origin with 8 elements, 7
+  vertices, and 21 dofs. To test contact kinematics, we add a rigid box so
+  that its top face intersects the bottom half of the deformable octahedron. The
+  rigid rectangle can be configured to be dynamic or static to provide coverage
+  for the cases with one and two Jacobian blocks. We compare rotation matrix
+  from world to the contact frame and contact velocities to expected values. The
+  pose/configuration of the bodies are set so that the contact normals are all
+  equal to -Fz, for an arbitrarily chosen frame F. Velocities of the body are
+  set so that the contact velocity in the C frame is (0, 0, -1).
+
+  Similarly, to test fixed constraint kinematics, we add fixed constraint
+  between the rigid body and the vertex of the deformable body inside the rigid
+  geometry. We then compare the constraint velocities to expected values.
+
+  This setup provides coverage for deformable vs. rigid contact as well as
+  fixed constraints between deformable bodies and rigid bodies.
+
+  @param[in] dynamic_rigid_body
+  The rigid body is dynamic if `dynamic_rigid_body` is true. Otherwise, a
+  collision geometry bound to the world body with the same shape is added. */
+  void MakeDeformableRigidScene(bool dynamic_rigid_body) {
     systems::DiagramBuilder<double> builder;
     constexpr double kDt = 0.01;
     std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
@@ -193,10 +203,148 @@ class DeformableDriverContactKinematicsTest
     }
   }
 
-  /* Verifies contact kinematics data are as expected.
+  /* Sets up a deformable octahedron centered at world origin with 8 elements, 7
+  vertices, and 21 dofs. To test contact kinematics for deformable vs.
+  deformable contact, we add another deformable octahedron so that that its top
+  half intersects the bottom half of the first deformable octahedron. We compare
+  rotation matrix from world to the contact frame and contact velocities to
+  expected values. The configuration of the deformable bodies are set so that
+  the contact normals are all equal to -Fz, for an arbitrarily chosen frame F.
+  Velocities of the body are set so that the contact velocity in the C frame is
+  (0, 0, -1). */
+  void MakeDeformableDeformableScene() {
+    systems::DiagramBuilder<double> builder;
+    constexpr double kDt = 0.01;
+    // N.B. Deformables are only supported with the SAP solver. Thus for testing
+    // we choose one arbitrary contact approximation that uses the SAP solver.
+    MultibodyPlantConfig config{.time_step = kDt,
+                                .discrete_contact_approximation = "sap"};
+    std::tie(plant_, scene_graph_) = AddMultibodyPlant(config, &builder);
+    auto deformable_model = make_unique<DeformableModel<double>>(plant_);
+    deformable_body_id_ = RegisterDeformableOctahedron(deformable_model.get(),
+                                                       "deformable", X_WF_);
+    /* Sets up a second deformable body so that its top half intersects the
+     bottom half of the first deformable body. */
+    deformable_body_id2_ = RegisterDeformableOctahedron(
+        deformable_model.get(), "deformable2",
+        X_WF_ * RigidTransformd(Vector3d(0, 0, -1.25)));
+    model_ = deformable_model.get();
+    plant_->AddPhysicalModel(std::move(deformable_model));
+
+    plant_->Finalize();
+    auto contact_manager = make_unique<CompliantContactManager<double>>();
+    manager_ = contact_manager.get();
+    plant_->SetDiscreteUpdateManager(std::move(contact_manager));
+    driver_ = manager_->deformable_driver();
+    DRAKE_DEMAND(driver_ != nullptr);
+
+    builder.Connect(model_->vertex_positions_port(),
+                    scene_graph_->get_source_configuration_port(
+                        plant_->get_source_id().value()));
+    diagram_ = builder.Build();
+    context_ = diagram_->CreateDefaultContext();
+
+    /* Set the velocity of the first deformable body so that it's (0, 0, -0.5)
+     when expressed in the F frame. */
+    const Vector3d v_WD1_F = Vector3d(0, 0, -0.5);
+    SetVelocity(deformable_body_id_, X_WF_.rotation() * v_WD1_F);
+    /* Set the velocity of the second deformable body so that it's (0, 0, 0.5)
+     when expressed in the F frame. */
+    const Vector3d v_WD2_F = Vector3d(0, 0, 0.5);
+    SetVelocity(deformable_body_id2_, X_WF_.rotation() * v_WD2_F);
+  }
+
+  /* Verifies contact kinematics data in the deformable vs. deformable contact
+   scene are as expected. */
+  void ValidateDeformableDeformableContactPairs() {
+    /* Each discrete contact pair should create a contact kinematics pair. */
+    const Context<double>& plant_context =
+        plant_->GetMyContextFromRoot(*context_);
+    DiscreteContactData<DiscreteContactPair<double>> contact_pairs;
+    driver_->AppendDiscreteContactPairs(plant_context, &contact_pairs);
+    const int num_contact_points = GetNumContactPoints(plant_context);
+    ASSERT_EQ(contact_pairs.size(), num_contact_points);
+    const DeformableContactSurface<double>& contact_surface =
+        driver_->EvalDeformableContact(plant_context).contact_surfaces()[0];
+
+    /* The contact surfaces are parallel to the xy-plane in frame F and the
+     contact normal points from the geometry A into geometry B. We know that
+     in deformable vs. deformable contact, the geometry with the smaller
+     GeometryId is always treated as geometry A. Pairing that with the fact that
+     the deformable body registered first has the smaller GeometryId, we know
+     that the normal is point from the first deformable body to the second
+     deformable body. */
+    const Vector3d nhat_AB_F(0, 0, -1);
+    const Vector3d nhat_AB_W = X_WF_.rotation() * nhat_AB_F;
+    constexpr int kZAxis = 2;
+    const math::RotationMatrixd expected_R_WC =
+        math::RotationMatrixd::MakeFromOneUnitVector(nhat_AB_W, kZAxis);
+    /* Velocities of the participating deformable dofs. */
+    const VectorXd v = driver_->EvalParticipatingVelocities(plant_context);
+    const Vector3d expected_v_D1D2_C(0, 0, -1);
+    for (int i = 0; i < num_contact_points; ++i) {
+      const DiscreteContactPair<double>& contact_pair = contact_pairs[i];
+      /* Test Jacobian by verifying J*v = vc. */
+      ASSERT_EQ(contact_pair.jacobian.size(), 2);
+      const Matrix3X<double> J0 = contact_pair.jacobian[0].J.MakeDenseMatrix();
+      const Matrix3X<double> J1 = contact_pair.jacobian[1].J.MakeDenseMatrix();
+      Matrix3X<double> J(3, J0.cols() + J1.cols());
+      J << J0, J1;
+      ASSERT_EQ(v.size(), J.cols());
+      EXPECT_TRUE(CompareMatrices(J * v, expected_v_D1D2_C, kTolerance));
+      /* Test object index and geometry Id. */
+      const DeformableBodyIndex body_index =
+          model_->GetBodyIndex(deformable_body_id_);
+      const int object_A = body_index + plant_->num_bodies();
+      EXPECT_EQ(contact_pair.object_A, object_A);
+      const DeformableBodyIndex body_index2 =
+          model_->GetBodyIndex(deformable_body_id2_);
+      const int object_B = body_index2 + plant_->num_bodies();
+      EXPECT_EQ(contact_pair.object_B, object_B);
+      EXPECT_EQ(contact_pair.id_A, model_->GetGeometryId(deformable_body_id_));
+      EXPECT_EQ(contact_pair.id_B, model_->GetGeometryId(deformable_body_id2_));
+      /* Test normal and rotation matrix. */
+      EXPECT_TRUE(
+          CompareMatrices(contact_pair.nhat_BA_W, -nhat_AB_W, kTolerance));
+      EXPECT_TRUE(contact_pair.R_WC.IsNearlyEqualTo(expected_R_WC, kTolerance));
+      /* Test contact point position in world frame and its position relative to
+       the bodies in contact. */
+      const Vector3d& expected_p_WC = contact_surface.contact_points_W()[i];
+      const Vector3d expected_p_ApC_W =
+          expected_p_WC - contact_surface.contact_mesh_W().centroid();
+      /* For both deformable geomtries, the relative-to point are both the
+       centroid of the contact mesh. */
+      const Vector3d& expected_p_BqC_W = expected_p_ApC_W;
+      EXPECT_EQ(contact_pair.p_WC, expected_p_WC);
+      EXPECT_EQ(contact_pair.p_ApC_W, expected_p_ApC_W);
+      EXPECT_EQ(contact_pair.p_BqC_W, expected_p_BqC_W);
+      /* Test penetration distances are copied over. Here we simply confirm that
+       the the sign is correct in the copy. The correctness of the sign distance
+       computation is tested in the geometry module. */
+      EXPECT_LT(contact_pair.phi0, 0.0);
+      /* Test contact parameters (stiffness, damping, dissipation time scale and
+       friction coefficient). */
+      const double expected_k = 1e8 * contact_surface.contact_mesh_W().area(i) /
+                                2.0;  // see implementation notes for why this
+                                      // is the expected stiffness.
+      EXPECT_DOUBLE_EQ(contact_pair.stiffness, expected_k);
+      EXPECT_EQ(contact_pair.damping, 0.0);
+      EXPECT_EQ(contact_pair.dissipation_time_scale, 0.02 /* 2 * dt*/);
+      EXPECT_EQ(contact_pair.friction_coefficient, kMu);
+      /* Test normal force and velocity. */
+      EXPECT_NEAR(contact_pair.vn0, expected_v_D1D2_C(2), kTolerance);
+      EXPECT_DOUBLE_EQ(contact_pair.fn0, -expected_k * contact_pair.phi0);
+      /* Test surface index and face index*/
+      EXPECT_EQ(contact_pair.surface_index, 0);
+      EXPECT_EQ(contact_pair.face_index, i);
+    }
+  }
+
+  /* Verifies contact kinematics data in the deformable vs. rigid contact scene
+   are as expected.
    @param[in] dynamic_rigid_body  True if a rigid body is registered in the
    setup (instead of a static body with a collision geometry). */
-  void ValidateContactKinematics(bool dynamic_rigid_body) {
+  void ValidateDeformableRigidContactKinematics(bool dynamic_rigid_body) {
     /* Each discrete contact pair should create a contact kinematics pair. */
     const Context<double>& plant_context =
         plant_->GetMyContextFromRoot(*context_);
@@ -303,10 +451,10 @@ class DeformableDriverContactKinematicsTest
     EXPECT_EQ(constraint_kinematic.p_PQs_W, Vector3d::Zero());
   }
 
-  /* Verifies that all vertices on the bottom side of the deformable octahedron
-   participates in constraints. That is, all vertices, with the exception of
-   v5, are participating in constraint. */
   void ValidateConstraintParticipation() {
+    /* Verifies that all vertices on the bottom side of the deformable
+     octahedron participates in constraints. That is, all vertices, with the
+     exception of v5, are participating in constraint. */
     const DeformableBodyIndex body_index =
         model_->GetBodyIndex(deformable_body_id_);
     const ContactParticipation& participation =
@@ -325,9 +473,33 @@ class DeformableDriverContactKinematicsTest
      |        5         |        6         |       no          |
      |        6         |        5         |       yes         |
     */
-    std::vector<int> expected_vertex_permutation{0, 1, 2, 3, 4, 6, 5};
-    EXPECT_EQ(participation.CalcVertexPermutation().permutation(),
-              expected_vertex_permutation);
+    EXPECT_THAT(participation.CalcVertexPermutation().permutation(),
+                testing::ElementsAre(0, 1, 2, 3, 4, 6, 5));
+    if (deformable_body_id2_.is_valid()) {
+      /* Verifies that all vertices on the top side of the deformable
+       octahedron participates in constraints. That is, all vertices, with the
+       exception of v6, are participating in constraint. */
+      const DeformableBodyIndex body_index2 =
+          model_->GetBodyIndex(deformable_body_id2_);
+      const ContactParticipation& participation2 =
+          driver_->EvalConstraintParticipation(
+              plant_->GetMyContextFromRoot(*context_), body_index2);
+      EXPECT_EQ(participation.num_vertices_in_contact(), 6);
+      /*
+       |   Original       |   Permuted       |   Participating   |
+       |   vertex index   |   vertex index   |   in contact      |
+       | :--------------: | :--------------: | :---------------: |
+       |        0         |        0         |       yes         |
+       |        1         |        1         |       yes         |
+       |        2         |        2         |       yes         |
+       |        3         |        3         |       yes         |
+       |        4         |        4         |       yes         |
+       |        5         |        5         |       yes         |
+       |        6         |        6         |       no          |
+      */
+      EXPECT_THAT(participation2.CalcVertexPermutation().permutation(),
+                  testing::ElementsAre(0, 1, 2, 3, 4, 5, 6));
+    }
   }
 
   const math::RigidTransformd X_WF_{RollPitchYawd(1, 2, 3), Vector3d(4, 5, 6)};
@@ -339,6 +511,9 @@ class DeformableDriverContactKinematicsTest
   const DeformableDriver<double>* driver_{nullptr};
   std::unique_ptr<Context<double>> context_;
   DeformableBodyId deformable_body_id_;
+  /* A second deformable body is added in the deformable vs. deformable contact
+   scene. This id is invalid in the deformable vs. rigid scene. */
+  DeformableBodyId deformable_body_id2_;
   BodyIndex rigid_body_index_;
   GeometryId rigid_geometry_id_;
 
@@ -378,16 +553,27 @@ class DeformableDriverContactKinematicsTest
 
 namespace {
 
-TEST_P(DeformableDriverContactKinematicsTest, ConstraintKinematics) {
+/* Tests deformable vs. rigid contact as well as fixed constraints between
+ deformable and rigid bodies. */
+TEST_P(DeformableDriverContactKinematicsTest,
+       DeformableRigidConstraintKinematics) {
   const bool dynamic = GetParam();
-  MakeScene(dynamic);
-  ValidateContactKinematics(dynamic);
+  MakeDeformableRigidScene(dynamic);
+  ValidateDeformableRigidContactKinematics(dynamic);
   ValidateFixedConstraintKinematics(dynamic);
   ValidateConstraintParticipation();
 }
 
 INSTANTIATE_TEST_SUITE_P(All, DeformableDriverContactKinematicsTest,
                          ::testing::Values(true, false));
+
+/* Tests deformable vs. deformable contact. */
+TEST_F(DeformableDriverContactKinematicsTest,
+       DeformableDeformableContactKinematics) {
+  MakeDeformableDeformableScene();
+  ValidateDeformableDeformableContactPairs();
+  ValidateConstraintParticipation();
+}
 
 }  // namespace
 


### PR DESCRIPTION
Refactor ContactData computation to facilitate using code from deformable vs. rigid contact.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21187)
<!-- Reviewable:end -->
