### PR TITLE
[geometry] Remove now-unneeded fallback flag

### DIFF
--- a/geometry/scene_graph_config.h
+++ b/geometry/scene_graph_config.h
@@ -21,7 +21,6 @@ struct DefaultProximityProperties {
   template <typename Archive>
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(compliance_type));
-    a->Visit(DRAKE_NVP(compliance_type_rigid_fallback));
     a->Visit(DRAKE_NVP(hydroelastic_modulus));
     a->Visit(DRAKE_NVP(resolution_hint));
     a->Visit(DRAKE_NVP(slab_thickness));
@@ -48,15 +47,8 @@ struct DefaultProximityProperties {
      rigid-rigid contact is not supported by the hydroelastic contact model,
      but is supported by point contact (multibody::ContactModel::kPoint or
      multibody::ContactModel::kHydroelasticWithFallback).
-  - "compliant": the default hydroelastic compliance type will be compliant;
-    note that `compliance_type_rigid_fallback` offers a caveat for shapes
-    that do not currently have compliant hydroelastic representations. */
+  - "compliant": the default hydroelastic compliance type will be compliant. */
   std::string compliance_type{"undefined"};
-
-  /** If default compliance_type is "compliant" but the shape does not have a
-  compliant hydroelastic representation (currently only for non-convex surface
-  meshes), then the compliance type will fall back to "rigid". */
-  bool compliance_type_rigid_fallback{true};
 
   /** A measure of material stiffness, in units of Pascals. */
   std::optional<double> hydroelastic_modulus{1e7};

--- a/geometry/test/scene_graph_config_test.cc
+++ b/geometry/test/scene_graph_config_test.cc
@@ -15,7 +15,6 @@ using yaml::SaveYamlString;
 const char* const kExampleConfig = R"""(
 default_proximity_properties:
   compliance_type: compliant
-  compliance_type_rigid_fallback: false
   hydroelastic_modulus: 2.0
   resolution_hint: 3.0
   slab_thickness: 4.0
@@ -30,7 +29,6 @@ GTEST_TEST(SceneGraphConfigTest, YamlTest) {
   const auto config = LoadYamlString<SceneGraphConfig>(kExampleConfig);
   const auto& props = config.default_proximity_properties;
   EXPECT_EQ(props.compliance_type, "compliant");
-  EXPECT_FALSE(props.compliance_type_rigid_fallback);
   EXPECT_EQ(props.hydroelastic_modulus, 2);
   EXPECT_EQ(props.resolution_hint, 3);
   EXPECT_EQ(props.slab_thickness, 4);


### PR DESCRIPTION
This hackery was obviated by #21147.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21196)
<!-- Reviewable:end -->
