### PR TITLE
[optimization] Tidy up ConvexSet constructors for a single shape

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -232,6 +232,7 @@ drake_cc_library(
     testonly = 1,
     srcs = ["test_utilities.cc"],
     hdrs = ["test_utilities.h"],
+    visibility = ["//visibility:private"],
     deps = [
         ":convex_set",
         "//geometry:scene_graph",
@@ -543,6 +544,7 @@ drake_cc_googletest(
         ":convex_set",
         ":test_utilities",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -552,6 +554,7 @@ drake_cc_googletest(
         ":convex_set",
         ":test_utilities",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/optimization/cartesian_product.cc
+++ b/geometry/optimization/cartesian_product.cc
@@ -90,8 +90,14 @@ CartesianProduct::CartesianProduct(const QueryObject<double>& query_object,
                                    GeometryId geometry_id,
                                    std::optional<FrameId> reference_frame)
     : ConvexSet(3, false) {
-  Cylinder cylinder(1., 1.);
-  query_object.inspector().GetShape(geometry_id).Reify(this, &cylinder);
+  const Shape& shape = query_object.inspector().GetShape(geometry_id);
+  if (shape.type_name() != "Cylinder") {
+    throw std::logic_error(fmt::format(
+        "CartesianProduct(geometry_id={}, ...) cannot convert a {}, only a "
+        "Cylinder",
+        geometry_id, shape));
+  }
+  const Cylinder& cylinder = dynamic_cast<const Cylinder&>(shape);
 
   // Make the cylinder out of a circle (2D sphere) and a line segment (1D box).
   sets_.emplace_back(
@@ -372,11 +378,6 @@ double CartesianProduct::DoCalcVolume() const {
     }
   }
   return volume;
-}
-
-void CartesianProduct::ImplementGeometry(const Cylinder& cylinder, void* data) {
-  Cylinder* c = static_cast<Cylinder*>(data);
-  *c = cylinder;
 }
 
 }  // namespace optimization

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -29,7 +29,7 @@ Otherwise, if any set in the cartesian product is empty, the whole product
 is empty.
 
 @ingroup geometry_optimization */
-class CartesianProduct final : public ConvexSet, private ShapeReifier {
+class CartesianProduct final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CartesianProduct)
 
@@ -126,10 +126,6 @@ class CartesianProduct final : public ConvexSet, private ShapeReifier {
 
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
-
-  // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Cylinder& cylinder, void* data) final;
 
   // The member variables are not const in order to support move semantics.
   ConvexSets sets_{};

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -58,8 +58,13 @@ MinkowskiSum::MinkowskiSum(const QueryObject<double>& query_object,
                            GeometryId geometry_id,
                            std::optional<FrameId> reference_frame)
     : ConvexSet(3, false) {
-  Capsule capsule(1., 1.);
-  query_object.inspector().GetShape(geometry_id).Reify(this, &capsule);
+  const Shape& shape = query_object.inspector().GetShape(geometry_id);
+  if (shape.type_name() != "Capsule") {
+    throw std::logic_error(fmt::format(
+        "MinkowskiSum(geometry_id={}, ...) cannot convert a {}, only a Capsule",
+        geometry_id, shape));
+  }
+  const Capsule& capsule = dynamic_cast<const Capsule&>(shape);
 
   // Sphere at zero.
   sets_.emplace_back(
@@ -284,11 +289,6 @@ MinkowskiSum::DoToShapeWithPose() const {
   // TODO(russt): Consider handling Capsule as a (very) special case.
   throw std::runtime_error(
       "ToShapeWithPose is not implemented yet for MinkowskiSum.");
-}
-
-void MinkowskiSum::ImplementGeometry(const Capsule& capsule, void* data) {
-  Capsule* c = static_cast<Capsule*>(data);
-  *c = capsule;
 }
 
 }  // namespace optimization

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -21,7 +21,7 @@ have sets_.size() == 0) is treated as the singleton {0}, which is nonempty.
 This includes the zero-dimensional case.
 
 @ingroup geometry_optimization */
-class MinkowskiSum final : public ConvexSet, private ShapeReifier {
+class MinkowskiSum final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MinkowskiSum)
 
@@ -100,10 +100,6 @@ class MinkowskiSum final : public ConvexSet, private ShapeReifier {
 
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
-
-  // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Capsule& capsule, void* data) final;
 
   ConvexSets sets_{};  // Not marked const to support move semantics.
 };

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -17,7 +17,7 @@ singleton or unit set.
 This set is always nonempty, even in the zero-dimensional case.
 
 @ingroup geometry_optimization */
-class Point final : public ConvexSet, private ShapeReifier {
+class Point final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Point)
 
@@ -86,10 +86,6 @@ class Point final : public ConvexSet, private ShapeReifier {
       const final;
 
   double DoCalcVolume() const final { return 0.0; }
-
-  // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Sphere& sphere, void* data) final;
 
   Eigen::VectorXd x_;
 };

--- a/geometry/optimization/test/cartesian_product_test.cc
+++ b/geometry/optimization/test/cartesian_product_test.cc
@@ -27,6 +27,7 @@ using Eigen::Matrix;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
+using internal::MakeSceneGraphWithShape;
 using math::RigidTransformd;
 
 GTEST_TEST(CartesianProductTest, BasicTest) {
@@ -125,11 +126,8 @@ GTEST_TEST(CartesianProductTest, FromSceneGraph) {
   // Test SceneGraph constructor.
   const double kRadius = 0.2;
   const double kLength = 0.5;
-  auto [scene_graph, geom_id] =
-      internal::MakeSceneGraphWithShape(Cylinder(kRadius, kLength), X_WG);
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
+  auto [scene_graph, geom_id, context, query] =
+      MakeSceneGraphWithShape(Cylinder(kRadius, kLength), X_WG);
 
   CartesianProduct S(query, geom_id, std::nullopt);
   Matrix<double, 3, 4> in_G, out_G;
@@ -180,6 +178,13 @@ GTEST_TEST(CartesianProductTest, FromSceneGraph) {
 
   ASSERT_TRUE(S2.MaybeGetFeasiblePoint().has_value());
   EXPECT_TRUE(S2.PointInSet(S2.MaybeGetFeasiblePoint().value(), kTol));
+}
+
+GTEST_TEST(CartesianProductTest, FromSceneGraphBad) {
+  auto [scene_graph, geom_id, context, query] =
+      MakeSceneGraphWithShape(HalfSpace(), RigidTransformd());
+  DRAKE_EXPECT_THROWS_MESSAGE(CartesianProduct(query, geom_id),
+                              ".*CartesianProduct.*cannot.*HalfSpace.*");
 }
 
 GTEST_TEST(CartesianProductTest, TwoBoxes) {

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -92,11 +92,8 @@ GTEST_TEST(HPolyhedronTest, UnitBoxTest) {
   EXPECT_FALSE(CheckAddPointInSetConstraints(H, Vector3d(1.1, 1.2, 0.4)));
 
   // Test SceneGraph constructor.
-  auto [scene_graph, geom_id] =
+  auto [scene_graph, geom_id, context, query] =
       MakeSceneGraphWithShape(Box(2.0, 2.0, 2.0), RigidTransformd::Identity());
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
 
   HPolyhedron H_scene_graph(query, geom_id);
   EXPECT_TRUE(CompareMatrices(A, H_scene_graph.A()));
@@ -496,11 +493,8 @@ GTEST_TEST(HPolyhedronTest, L1BallTest) {
 GTEST_TEST(HPolyhedronTest, ArbitraryBoxTest) {
   RigidTransformd X_WG(RotationMatrixd::MakeZRotation(M_PI / 2.0),
                        Vector3d(-4.0, -5.0, -6.0));
-  auto [scene_graph, geom_id] =
+  auto [scene_graph, geom_id, context, query] =
       MakeSceneGraphWithShape(Box(1.0, 2.0, 3.0), X_WG);
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
   HPolyhedron H(query, geom_id);
 
   EXPECT_EQ(H.ambient_dimension(), 3);
@@ -553,10 +547,8 @@ GTEST_TEST(HPolyhedronTest, ArbitraryBoxTest) {
 GTEST_TEST(HPolyhedronTest, HalfSpaceTest) {
   RigidTransformd X_WG(RotationMatrixd::MakeYRotation(M_PI / 2.0),
                        Vector3d(-1.2, -2.1, -6.4));
-  auto [scene_graph, geom_id] = MakeSceneGraphWithShape(HalfSpace(), X_WG);
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
+  auto [scene_graph, geom_id, context, query] =
+      MakeSceneGraphWithShape(HalfSpace(), X_WG);
   HPolyhedron H(query, geom_id);
 
   EXPECT_EQ(H.ambient_dimension(), 3);

--- a/geometry/optimization/test/hyperellipsoid_test.cc
+++ b/geometry/optimization/test/hyperellipsoid_test.cc
@@ -49,11 +49,8 @@ GTEST_TEST(HyperellipsoidTest, UnitSphereTest) {
   EXPECT_TRUE(CompareMatrices(center, E.center()));
 
   // Test SceneGraph constructor.
-  auto [scene_graph, geom_id] =
+  auto [scene_graph, geom_id, context, query] =
       MakeSceneGraphWithShape(Sphere(1.0), RigidTransformd::Identity());
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
 
   Hyperellipsoid E_scene_graph(query, geom_id);
   EXPECT_TRUE(CompareMatrices(A, E_scene_graph.A()));
@@ -136,11 +133,8 @@ GTEST_TEST(HyperellipsoidTest, Move) {
 
 GTEST_TEST(HyperellipsoidTest, ScaledSphereTest) {
   const double radius = 0.1;
-  auto [scene_graph, geom_id] =
+  auto [scene_graph, geom_id, context, query] =
       MakeSceneGraphWithShape(Sphere(radius), RigidTransformd::Identity());
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
 
   Hyperellipsoid E(query, geom_id);
   EXPECT_TRUE(
@@ -170,12 +164,9 @@ GTEST_TEST(HyperellipsoidTest, ArbitraryEllipsoidTest) {
   EXPECT_TRUE(CompareMatrices(center, E.center()));
 
   // Test SceneGraph constructor.
-  auto [scene_graph, geom_id] = MakeSceneGraphWithShape(
+  auto [scene_graph, geom_id, context, query] = MakeSceneGraphWithShape(
       Ellipsoid(1.0 / D(0, 0), 1.0 / D(1, 1), 1.0 / D(2, 2)),
       RigidTransformd{R.inverse(), center});
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
 
   Hyperellipsoid E_scene_graph(query, geom_id);
   EXPECT_TRUE(CompareMatrices(A, E_scene_graph.A()));
@@ -417,11 +408,8 @@ GTEST_TEST(HyperellipsoidTest, MakeAxisAlignedTest) {
   Hyperellipsoid E = Hyperellipsoid::MakeAxisAligned(Vector3d{a, b, c}, center);
   EXPECT_EQ(E.ambient_dimension(), 3);
 
-  auto [scene_graph, geom_id] =
+  auto [scene_graph, geom_id, context, query] =
       MakeSceneGraphWithShape(Ellipsoid(a, b, c), RigidTransformd{center});
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
 
   Hyperellipsoid E_scene_graph(query, geom_id);
   EXPECT_TRUE(CompareMatrices(E.A(), E_scene_graph.A(), 1e-16));

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -157,11 +157,8 @@ GTEST_TEST(VPolytopeTest, UnitBoxTest) {
   }
 
   // Test SceneGraph constructor.
-  auto [scene_graph, geom_id] =
+  auto [scene_graph, geom_id, context, query] =
       MakeSceneGraphWithShape(Box(2.0, 2.0, 2.0), RigidTransformd::Identity());
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
 
   VPolytope V_scene_graph(query, geom_id);
   EXPECT_EQ(V.ambient_dimension(), 3);
@@ -173,11 +170,8 @@ GTEST_TEST(VPolytopeTest, UnitBoxTest) {
 GTEST_TEST(VPolytopeTest, ArbitraryBoxTest) {
   const RigidTransformd X_WG(math::RollPitchYawd(.1, .2, 3),
                              Vector3d(-4.0, -5.0, -6.0));
-  auto [scene_graph, geom_id] =
+  auto [scene_graph, geom_id, context, query] =
       MakeSceneGraphWithShape(Box(1.0, 2.0, 3.0), X_WG);
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
   VPolytope V(query, geom_id);
 
   EXPECT_EQ(V.ambient_dimension(), 3);
@@ -245,11 +239,8 @@ void CheckVertices(const Eigen::Ref<const Eigen::Matrix3Xd>& vertices,
 GTEST_TEST(VPolytopeTest, OctahedronTest) {
   const RigidTransformd X_WG(math::RollPitchYawd(.1, .2, 3),
                              Vector3d(-4.0, -5.0, -6.0));
-  auto [scene_graph, geom_id] = MakeSceneGraphWithShape(
+  auto [scene_graph, geom_id, context, query] = MakeSceneGraphWithShape(
       Convex(FindResourceOrThrow("drake/geometry/test/octahedron.obj")), X_WG);
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
   VPolytope V(query, geom_id);
   EXPECT_EQ(V.vertices().cols(), 6);
 
@@ -268,12 +259,9 @@ GTEST_TEST(VPolytopeTest, OctahedronTest) {
 }
 
 GTEST_TEST(VPolytopeTest, NonconvexMesh) {
-  auto [scene_graph, geom_id] = MakeSceneGraphWithShape(
+  auto [scene_graph, geom_id, context, query] = MakeSceneGraphWithShape(
       Mesh(FindResourceOrThrow("drake/geometry/test/non_convex_mesh.obj")),
       RigidTransformd{});
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
   VPolytope V(query, geom_id);
 
   // The non-convex mesh contains 5 vertices, but the convex hull contains only
@@ -305,11 +293,8 @@ GTEST_TEST(VPolytopeTest, UnsupportedMeshTypes) {
     const RigidTransformd X_WG;
     // We can't add proximity properties; ProximityEngine would reject it.
     const bool add_proximity_properties = false;
-    auto [scene_graph, geom_id] =
+    auto [scene_graph, geom_id, context, query] =
         MakeSceneGraphWithShape(*shape, X_WG, add_proximity_properties);
-    auto context = scene_graph->CreateDefaultContext();
-    auto query = scene_graph->get_query_output_port().Eval<QueryObject<double>>(
-        *context);
     DRAKE_EXPECT_THROWS_MESSAGE(
         VPolytope(query, geom_id),
         "VPolytope can only use mesh shapes .* '.*bad_extension.stl'.");
@@ -829,11 +814,8 @@ GTEST_TEST(VPolytopeTest, WriteObjTest) {
   const std::string filename = temp_directory() + "/vpolytope.obj";
   V.WriteObj(filename);
 
-  auto [scene_graph, geom_id] =
+  auto [scene_graph, geom_id, context, query] =
       MakeSceneGraphWithShape(Convex(filename, 1), RigidTransformd::Identity());
-  auto context = scene_graph->CreateDefaultContext();
-  auto query =
-      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
 
   VPolytope V_scene_graph(query, geom_id);
   CheckVertices(V.vertices(), V_scene_graph.vertices(), 1e-6);

--- a/geometry/optimization/test_utilities.cc
+++ b/geometry/optimization/test_utilities.cc
@@ -17,7 +17,8 @@ namespace optimization {
 namespace internal {
 using math::RigidTransformd;
 
-std::tuple<std::unique_ptr<SceneGraph<double>>, GeometryId>
+std::tuple<std::unique_ptr<SceneGraph<double>>, GeometryId,
+           std::unique_ptr<systems::Context<double>>, QueryObject<double>>
 MakeSceneGraphWithShape(const Shape& shape, const RigidTransformd& X_WG,
                         bool add_proximity_properties) {
   auto scene_graph = std::make_unique<SceneGraph<double>>();
@@ -28,8 +29,11 @@ MakeSceneGraphWithShape(const Shape& shape, const RigidTransformd& X_WG,
   }
   GeometryId geom_id =
       scene_graph->RegisterAnchoredGeometry(source_id, std::move(instance));
-  return std::tuple<std::unique_ptr<SceneGraph<double>>, GeometryId>(
-      std::move(scene_graph), geom_id);
+  auto context = scene_graph->CreateDefaultContext();
+  auto query =
+      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
+  return std::make_tuple(std::move(scene_graph), geom_id, std::move(context),
+                         std::move(query));
 }
 
 // Returns true iff the convex optimization can make the `point` be in the set.

--- a/geometry/optimization/test_utilities.h
+++ b/geometry/optimization/test_utilities.h
@@ -7,14 +7,20 @@
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/rigid_transform.h"
 
+// TODO(jwnimmer-tri) Test utilities belong either in a `test/` subdirectory
+// or a `test_utilities/` subdirectory. They should never live in a package-
+// level subdirectory alongside Drake library code.
+
 namespace drake {
 namespace geometry {
 namespace optimization {
 namespace internal {
 
 // Constructs a SceneGraph containing only the requested shape as geometry G,
-// anchored to the world frame at X_WG.
-std::tuple<std::unique_ptr<SceneGraph<double>>, GeometryId>
+// anchored to the world frame at X_WG. For convience, also returns a default
+// context and query object.
+std::tuple<std::unique_ptr<SceneGraph<double>>, GeometryId,
+           std::unique_ptr<systems::Context<double>>, QueryObject<double>>
 MakeSceneGraphWithShape(const Shape& shape, const math::RigidTransformd& X_WG,
                         bool add_proximity_properties = true);
 


### PR DESCRIPTION
When given an unsupported shape, provide an error message with the full details of the wrong-shape (e.g., dimensions) and what we expected. Remove gratuitous reifier inheritance for one kind of shape.

Refactor test utility for less boilerplate, and fix erroneous public visibility.

(This is part of a slow-moving PR train to rid ourselves of unnecessary reifier-related complexity.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21197)
<!-- Reviewable:end -->
