### PR TITLE
[setup] Install bazelisk on Ubuntu arm64

### DIFF
--- a/setup/ubuntu/source_distribution/install_bazel.sh
+++ b/setup/ubuntu/source_distribution/install_bazel.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# Install Bazel as /usr/bin/bazel on Ubuntu.
+# On Ubuntu, installs either Bazel or Bazelisk at /usr/bin/bazel.
+#
 # This script does not accept any command line arguments.
 
 set -euo pipefail
@@ -54,17 +55,20 @@ EOF
 )
 
 # Install bazel.
-# Keep this version number in sync with the drake/.bazeliskrc version number.
 if [[ $(arch) = "aarch64" ]]; then
   # Check if bazel is already installed.
   if [[ "$(which bazel)" ]]; then
-    echo "Bazel is already installed." >&2
+    echo "Bazel(isk) is already installed." >&2
   else
-    echo "WARNING: On Ubuntu arm64 systems, Drake's install_prereqs does not" \
-    "automatically install Bazel on your behalf. You will need to install" \
-    "Bazel yourself. See https://bazel.build for instructions." >&2
+    # TODO(jeremy.nimmer) Once there's a bazelisk 1.20 that incorporates pr563,
+    # we should switch to using that here.
+    dpkg_install_from_wget \
+      bazelisk 1.19.0-9-g58a850f \
+      https://drake-mirror.csail.mit.edu/github/bazelbuild/bazelisk/pr563/bazelisk_1.19.0-9-g58a850f_arm64.deb \
+      5501a44ba1f51298d186e4e66966b0556d03524381a967667696f032e292d719
   fi
 else
+  # Keep this version number in sync with the drake/.bazeliskrc version number.
   dpkg_install_from_wget \
     bazel 7.0.2 \
     https://github.com/bazelbuild/bazel/releases/download/7.0.2/bazel_7.0.2-linux-x86_64.deb \

--- a/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
@@ -24,4 +24,12 @@ EOF
 
 # Prefetch the bazelisk download of bazel.
 # This is especially helpful for the "Provisioned" images in CI.
-(cd "${workspace_dir}" && ./third_party/com_github_bazelbuild_bazelisk/bazelisk.py version) > /dev/null
+if [[ $(arch) = "aarch64" ]]; then
+  # Per ./install_bazel.sh, on arm we use bazelisk as our bazel so we should
+  # prefetch using that spelling.
+  cd "${workspace_dir}" && bazel version
+else
+  # Per ./install_bazel.sh, on non-arm there is no system-wide bazelisk so we
+  # need to use a local copy.
+  cd "${workspace_dir}" && ./third_party/com_github_bazelbuild_bazelisk/bazelisk.py version
+fi


### PR DESCRIPTION
Towards #13514.

You can see the [build log](https://drake-jenkins.csail.mit.edu/job/linux-arm-jammy-unprovisioned-gcc-bazel-experimental-release/17/consoleFull) for what this accomplishes.  There are build (loading) errors but that's a _good_ thing -- previously, we couldn't even run a build at all.

We need to have some Bazel installed in order to build on `arm64`.  Since Bazel doesn't provide `.deb` files for that architecture, instead we'll have Drake install a `*.deb` file for `bazelisk`, which I've compiled and uploaded to S3 for us to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21201)
<!-- Reviewable:end -->
