### PR TITLE
Mujoco parser: support new 'autolimits' compiler attribute

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -162,6 +162,40 @@ class MujocoParser {
     return RigidTransformd(X_default.rotation(), pos);
   }
 
+  // Returns true if limits were parsed.
+  bool ParseLimits(XMLElement* node, const char* range_attr_name,
+                   const char* limited_attr_name, Vector2d* limits) {
+    std::string limited_attr;
+    if (!ParseStringAttribute(node, limited_attr_name, &limited_attr)) {
+      limited_attr = "auto";
+    }
+
+    bool has_range = ParseVectorAttribute(node, range_attr_name, limits);
+
+    bool limited{false};
+    if (limited_attr == "true") {
+      limited = true;
+    } else if (limited_attr == "false") {
+      limited = false;
+    } else if (limited_attr == "auto") {
+      if (autolimits_) {
+        limited = has_range;
+      } else if (has_range) {
+        // From the mujoco docs: In this mode [autolimits == false], it is an
+        // error to specify a range without a limit.
+        Error(*node, fmt::format("The '{}' attribute was specified but "
+                                 "'autolimits' is disabled.",
+                                 range_attr_name));
+      }
+    } else {
+      Error(*node,
+            fmt::format("The '{}' attribute must be one of 'true', 'false', "
+                        "or 'auto'.",
+                        limited_attr_name));
+    }
+    return limited;
+  }
+
   void ParseMotor(XMLElement* node) {
     std::string name;
     if (!ParseStringAttribute(node, "name", &name)) {
@@ -179,58 +213,55 @@ class MujocoParser {
       return;
     }
 
-    // Parse effort limits.
+    // Parse effort limits. For a motor, force limits are the same as control
+    // limits, so we take the min of the two.
     double effort_limit = std::numeric_limits<double>::infinity();
-    bool ctrl_limited = node->BoolAttribute("ctrllimited", false);
+    Vector2d ctrl_range(0.0, 0.0), force_range(0.0, 0.0);
+    bool ctrl_limited =
+        ParseLimits(node, "ctrlrange", "ctrllimited", &ctrl_range);
+    bool force_limited =
+        ParseLimits(node, "forcerange", "forcelimited", &force_range);
+
     if (ctrl_limited) {
-      Vector2d ctrl_range;
-      if (ParseVectorAttribute(node, "ctrlrange", &ctrl_range)) {
-        if (ctrl_range[0] > ctrl_range[1]) {
-          Warning(
-              *node,
-              fmt::format(
-                  "The motor '{}' specified a ctrlrange attribute where lower "
-                  "limit > upper limit; these limits will be ignored.",
-                  name));
-        } else {
-          effort_limit = std::max(ctrl_range[1], -ctrl_range[0]);
-          if (ctrl_range[0] != ctrl_range[1]) {
-            Warning(
-                *node,
-                fmt::format("The motor '{}' specified a ctrlrange attribute "
-                            "where lower limit != upper limit.  Asymmetrical "
-                            "effort limits are not supported yet, so the "
-                            "larger of the values {} will be used.",
-                            name, effort_limit));
-          }
+      if (ctrl_range[0] > ctrl_range[1]) {
+        Warning(
+            *node,
+            fmt::format(
+                "The motor '{}' specified a ctrlrange attribute where lower "
+                "limit > upper limit; these limits will be ignored.",
+                name));
+      } else {
+        effort_limit = std::max(ctrl_range[1], -ctrl_range[0]);
+        if (-ctrl_range[0] != ctrl_range[1]) {
+          Warning(*node,
+                  fmt::format("The motor '{}' specified a ctrlrange attribute "
+                              "where lower limit != -upper limit. Asymmetrical "
+                              "effort limits are not supported yet, so the "
+                              "larger of the values {} will be used.",
+                              name, effort_limit));
         }
       }
     }
-    bool force_limited = node->BoolAttribute("forcelimited", false);
     if (force_limited) {
       // For a motor, force limits are the same as control limits, so we take
       // the min of the two.
-      Vector2d force_range;
-      if (ParseVectorAttribute(node, "forcerange", &force_range)) {
-        if (force_range[0] > force_range[1]) {
-          Warning(
-              *node,
-              fmt::format(
-                  "The motor '{}' specified a forcerange attribute where lower "
-                  "limit > upper limit; these limits will be ignored.",
-                  name));
-        } else {
-          effort_limit =
-              std::min(effort_limit, std::max(force_range[1], -force_range[0]));
-          if (force_range[0] != force_range[1]) {
-            Warning(
-                *node,
-                fmt::format("The motor '{}' specified a forcerange attribute "
-                            "where lower limit != upper limit.  Asymmetrical "
-                            "effort limits are not supported yet, so the "
-                            "larger of the values {} will be used.",
-                            name, std::max(force_range[1], -force_range[0])));
-          }
+      if (force_range[0] > force_range[1]) {
+        Warning(
+            *node,
+            fmt::format(
+                "The motor '{}' specified a forcerange attribute where lower "
+                "limit > upper limit; these limits will be ignored.",
+                name));
+      } else {
+        effort_limit =
+            std::min(effort_limit, std::max(force_range[1], -force_range[0]));
+        if (-force_range[0] != force_range[1]) {
+          Warning(*node,
+                  fmt::format("The motor '{}' specified a forcerange attribute "
+                              "where lower limit != -upper limit. Asymmetrical "
+                              "effort limits are not supported yet, so the "
+                              "larger of the values {} will be used.",
+                              name, std::max(force_range[1], -force_range[0])));
         }
       }
     }
@@ -306,9 +337,8 @@ class MujocoParser {
       type = "hinge";
     }
 
-    bool limited = node->BoolAttribute("limited", false);
     Vector2d range(0.0, 0.0);
-    ParseVectorAttribute(node, "range", &range);
+    bool limited = ParseLimits(node, "range", "limited", &range);
 
     if (type == "free") {
       if (damping != 0.0) {
@@ -1155,6 +1185,7 @@ class MujocoParser {
   }
 
   void ParseCompiler(XMLElement* node) {
+    autolimits_ = node->BoolAttribute("autolimits", true);
     WarnUnsupportedAttribute(*node, "boundmass");
     WarnUnsupportedAttribute(*node, "boundinertia");
     WarnUnsupportedAttribute(*node, "settotalmass");
@@ -1245,7 +1276,9 @@ class MujocoParser {
         // Ok. No attribute to set.
         break;
     }
+    WarnUnsupportedAttribute(*node, "exactmeshinertia");
     WarnUnsupportedAttribute(*node, "inertiagrouprange");
+    WarnUnsupportedElement(*node, "lengthrange");
   }
 
   void ParseContact(XMLElement* node) {
@@ -1577,6 +1610,7 @@ class MujocoParser {
   MultibodyPlant<double>* plant_;
   ModelInstanceIndex model_instance_{};
   std::filesystem::path main_mjcf_path_{};
+  bool autolimits_{true};
   enum Angle { kRadian, kDegree };
   Angle angle_{kDegree};
   std::map<std::string, XMLElement*> default_geometry_{};

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -28,6 +28,7 @@ using ::testing::MatchesRegex;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
+using Eigen::VectorXd;
 using drake::internal::DiagnosticPolicy;
 using geometry::FrameId;
 using geometry::GeometryId;
@@ -37,6 +38,9 @@ using geometry::SceneGraphInspector;
 using math::RigidTransformd;
 using math::RollPitchYawd;
 using math::RotationMatrixd;
+
+const double kInf = std::numeric_limits<double>::infinity();
+
 
 class MujocoParserTest : public test::DiagnosticPolicyTestBase {
  public:
@@ -1254,10 +1258,10 @@ TEST_F(MujocoParserTest, Joint) {
           X_WB, 1e-14));
   EXPECT_TRUE(
       CompareMatrices(plant_.GetJointByName("default").position_lower_limits(),
-                      Vector1d{-std::numeric_limits<double>::infinity()}));
+                      Vector1d{-M_PI / 9.0}));
   EXPECT_TRUE(
       CompareMatrices(plant_.GetJointByName("default").position_upper_limits(),
-                      Vector1d{std::numeric_limits<double>::infinity()}));
+                      Vector1d{M_PI / 12.0}));
 
   const RevoluteJoint<double>& hinge1_joint =
       plant_.GetJointByName<RevoluteJoint>("hinge1");
@@ -1312,6 +1316,88 @@ TEST_F(MujocoParserTest, JointErrors) {
       ".*a free joint is defined.*"));
   EXPECT_THAT(TakeError(), MatchesRegex(
       ".*Unknown joint type.*"));
+}
+
+std::string MakeAutoLimitsXML(
+  bool auto_limits, const std::string& motor_limit_prefix) {
+    return fmt::format(R"""(
+  <mujoco model="test">
+    <compiler autolimits="{0}" angle="radian"/>
+    <worldbody>
+      <body>
+        <joint type="hinge" name="hinge0" limited="true"/>
+        <joint type="hinge" name="hinge1" range="-1 1"/>
+        <joint type="hinge" name="hinge2" range="-2 2" limited="auto"/>
+        <joint type="hinge" name="hinge3" range="-3 3" limited="true"/>
+        <joint type="hinge" name="hinge4" range="-4 4" limited="false"/>
+        <joint type="hinge" name="hinge6" range="-5 5" limited="bad"/>
+      </body>
+    </worldbody>
+    <actuator>
+      <!-- Drake does not allow effort limits to be zero. -->
+      <!-- <motor joint="hinge0" {1}limited="true"/> -->
+      <motor joint="hinge1" {1}range="-1 1"/>
+      <motor joint="hinge2" {1}range="-2 2" {1}limited="auto"/>
+      <motor joint="hinge3" {1}range="-3 3" {1}limited="true"/>
+      <motor joint="hinge4" {1}range="-4 4" {1}limited="false"/>
+      <motor joint="hinge6" {1}range="-5 5" {1}limited="bad"/>
+    </actuator>
+  </mujoco>
+  )""", auto_limits, motor_limit_prefix);
+}
+
+TEST_F(MujocoParserTest, AutoLimitsTrue) {
+  const std::string kXml = MakeAutoLimitsXML(true, "ctrl");
+  AddModelFromString(kXml, "test");
+  plant_.Finalize();
+  EXPECT_EQ(plant_.num_positions(), 6);
+  VectorXd expected_limits(6);
+  expected_limits << 0.0, 1.0, 2.0, 3.0, kInf, kInf;
+  EXPECT_TRUE(
+      CompareMatrices(plant_.GetPositionLowerLimits(), -expected_limits));
+  EXPECT_TRUE(
+      CompareMatrices(plant_.GetPositionUpperLimits(), expected_limits));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*The 'limited' attribute must be one of.*"));
+  EXPECT_TRUE(CompareMatrices(
+    plant_.GetEffortLowerLimits(), -expected_limits.tail<5>()));
+  EXPECT_TRUE(CompareMatrices(
+    plant_.GetEffortUpperLimits(), expected_limits.tail<5>()));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*The 'ctrllimited' attribute must be one of.*"));
+}
+
+TEST_F(MujocoParserTest, AutoLimitsFalse) {
+  const std::string kXml = MakeAutoLimitsXML(false, "force");
+  AddModelFromString(kXml, "test");
+  plant_.Finalize();
+  EXPECT_EQ(plant_.num_positions(), 6);
+  VectorXd expected_limits(6);
+  expected_limits << 0.0, kInf, kInf, 3.0, kInf, kInf;
+  EXPECT_TRUE(
+      CompareMatrices(plant_.GetPositionLowerLimits(), -expected_limits));
+  EXPECT_TRUE(
+      CompareMatrices(plant_.GetPositionUpperLimits(), expected_limits));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*The 'range' attribute was specified.*but "
+                           "'autolimits' is disabled."));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*The 'range' attribute was specified.*but "
+                           "'autolimits' is disabled."));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*The 'limited' attribute must be one of.*"));
+  EXPECT_TRUE(CompareMatrices(
+    plant_.GetEffortLowerLimits(), -expected_limits.tail<5>()));
+  EXPECT_TRUE(CompareMatrices(
+    plant_.GetEffortUpperLimits(), expected_limits.tail<5>()));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*The 'forcerange' attribute was specified.*but "
+                           "'autolimits' is disabled."));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*The 'forcerange' attribute was specified.*but "
+                           "'autolimits' is disabled."));
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*The 'forcelimited' attribute must be one of.*"));
 }
 
 TEST_F(MujocoParserTest, InertialErrors) {
@@ -1430,7 +1516,7 @@ TEST_F(MujocoParserTest, Motor) {
     <motor joint="hinge0"/>
     <!-- intentionally asymmetric effort limits to cover the warning code -->
     <motor name="motor1" joint="hinge1" ctrllimited="true" ctrlrange="-1 2"/>
-    <motor name="motor2" joint="hinge2" ctrllimited="true" ctrlrange="-2 2"
+    <motor name="motor2" joint="hinge2" ctrllimited="true" ctrlrange="-3 2"
            forcelimited="true" forcerange="-.5 .4"/>
     <!-- malformed limits will be ignored -->
     <motor name="motor3" joint="hinge3" ctrllimited="true" ctrlrange="2 1"


### PR DESCRIPTION
The mjcf specs recently added 'autolimits' as a compiler option and then make a (minor) breaking change to the default values. https://mujoco.readthedocs.io/en/stable/changelog.html#version-3-0-0-october-18-2023

This PR updates Drake's parser to the latest standard.

+@rpoyner-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21205)
<!-- Reviewable:end -->
