### PR TITLE
[workspace] Fix MOSEK TBB glob on linuxaarch64

### DIFF
--- a/tools/workspace/mosek/package.BUILD.bazel
+++ b/tools/workspace/mosek/package.BUILD.bazel
@@ -11,7 +11,11 @@ package(default_visibility = ["//visibility:private"])
 # Find the TBB shared library with the major.minor-style version number.
 # This will be the spelling with the actual object code.
 _TBB_MAJMIN_GLOB = glob([
+    # This is the spelling for linux64x86.
     "bin/libtbb.so.*.*",
+    # This is the spelling for linuxaarch64.
+    "bin/libtbb_debug.so.*.*",
+    # This is the spelling for osxaarch64 and osx64x86.
     "bin/libtbb.*.*.dylib",
 ])
 
@@ -20,7 +24,11 @@ len(_TBB_MAJMIN_GLOB) == 1 or fail("Glob failure: " + str(glob(["**"])))
 # Find the TBB shared library with the major-only-style version number.
 # This will be the spelling that's a symlink to the major.minor spelling.
 _TBB_MAJ_GLOB = glob([
+    # This is the spelling for linux64x86.
     "bin/libtbb.so.*",
+    # This is the spelling for linuxaarch64.
+    "bin/libtbb_debug.so.*",
+    # This is the spelling for osxaarch64 and osx64x86.
     "bin/libtbb.*.dylib",
 ], exclude = _TBB_MAJMIN_GLOB)
 


### PR DESCRIPTION
The [build log](https://drake-jenkins.csail.mit.edu/job/linux-arm-jammy-unprovisioned-gcc-bazel-experimental-release/18/) of this PR on arm64 shows no more MOSEK errors.  Compare with [build log of existing conditions](https://drake-jenkins.csail.mit.edu/job/linux-arm-jammy-unprovisioned-gcc-bazel-experimental-release/17/) to see what this is fixing.

Towards #13514.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21206)
<!-- Reviewable:end -->
