### PR TITLE
Improve error message when calling iris clique cover without joint limits

### DIFF
--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -40,7 +40,10 @@ drake_cc_library(
 drake_cc_googletest(
     name = "iris_from_clique_cover_test",
     timeout = "moderate",
-    data = ["//multibody/parsing:test_models"],
+    data = [
+        "//examples/pendulum:models",
+        "//multibody/parsing:test_models",
+    ],
     # Running with multiple threads is an essential part of our test coverage.
     num_threads = 4,
     shard_count = 4,
@@ -55,6 +58,7 @@ drake_cc_googletest(
     ],
     deps = [
         ":iris_from_clique_cover",
+        "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:maybe_pause_for_user",
         "//geometry/test_utilities:meshcat_environment",
         "//multibody/parsing:parser",

--- a/planning/iris/iris_from_clique_cover.cc
+++ b/planning/iris/iris_from_clique_cover.cc
@@ -330,6 +330,13 @@ void IrisInConfigurationSpaceFromCliqueCover(
   DRAKE_THROW_UNLESS(options.coverage_termination_threshold > 0);
   DRAKE_THROW_UNLESS(options.iteration_limit > 0);
 
+  // Note: Even though the iris_options.bounding_region may be provided,
+  // IrisInConfigurationSpace (currently) requires finite joint limits.
+  DRAKE_THROW_UNLESS(
+      checker.plant().GetPositionLowerLimits().array().isFinite().all());
+  DRAKE_THROW_UNLESS(
+      checker.plant().GetPositionUpperLimits().array().isFinite().all());
+
   const HPolyhedron domain = options.iris_options.bounding_region.value_or(
       HPolyhedron::MakeBox(checker.plant().GetPositionLowerLimits(),
                            checker.plant().GetPositionUpperLimits()));


### PR DESCRIPTION
Previously the error was an unhelpful throw from HPolyhedron saying some set was unbounded (which is confusing for a method whose goal is to use complex logic to assemble new hpolyhedron). We can fail-fast on this one and give a much more clear/specific error message.

+@sammy-tri for both reviews, please.

cc @AlexandreAmice @wernerpe

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21207)
<!-- Reviewable:end -->
