### PR TITLE
[geometry] Port the remaining convex set types to Shape::Visit

### DIFF
--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -22,7 +22,7 @@ class VPolytope;
 By convention, we treat a zero-dimensional HPolyhedron as nonempty.
 
 @ingroup geometry_optimization */
-class HPolyhedron final : public ConvexSet, private ShapeReifier {
+class HPolyhedron final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HPolyhedron);
 
@@ -374,13 +374,6 @@ class HPolyhedron final : public ConvexSet, private ShapeReifier {
   // using the AH polytope representation to project it to 3D."
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
-
-  // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Box& box, void* data) final;
-  void ImplementGeometry(const HalfSpace&, void* data) final;
-  // TODO(russt): Support ImplementGeometry(const Convex& convex, ...);
-  // it is already supported by VPolytope.
 
   void CheckInvariants() const;
 

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -30,7 +30,7 @@ A hyperellipsoid can never be empty -- it always contains its center. This
 includes the zero-dimensional case.
 
 @ingroup geometry_optimization */
-class Hyperellipsoid final : public ConvexSet, private ShapeReifier {
+class Hyperellipsoid final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Hyperellipsoid);
 
@@ -183,11 +183,6 @@ class Hyperellipsoid final : public ConvexSet, private ShapeReifier {
   double DoCalcVolume() const final;
 
   void CheckInvariants() const;
-
-  // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Ellipsoid& ellipsoid, void* data) final;
-  void ImplementGeometry(const Sphere& sphere, void* data) final;
 
   Eigen::MatrixXd A_{};
   Eigen::VectorXd center_{};

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -31,7 +31,7 @@ and vertices_.cols() are zero, we treat this as no points in {0}, which is
 empty.
 
 @ingroup geometry_optimization */
-class VPolytope final : public ConvexSet, private ShapeReifier {
+class VPolytope final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VPolytope);
 
@@ -141,12 +141,6 @@ class VPolytope final : public ConvexSet, private ShapeReifier {
       std::optional<double> tol) const final;
 
   double DoCalcVolume() const final;
-
-  // Implement support shapes for the ShapeReifier interface.
-  using ShapeReifier::ImplementGeometry;
-  void ImplementGeometry(const Box& box, void* data) final;
-  void ImplementGeometry(const Convex& convex, void* data) final;
-  void ImplementGeometry(const Mesh& mesh, void* data) final;
 
   Eigen::MatrixXd vertices_;
 };


### PR DESCRIPTION
This is part of a slow-moving PR train to rid ourselves of unnecessary reifier-related complexity.  The idea is to make the control flow (and return values) more obvious, instead of routing through obscure private virtual functions with static casts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21210)
<!-- Reviewable:end -->
