### PR TITLE
Implements DiscreteTimeIntegrator primitive

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -11,6 +11,7 @@
 #include "drake/systems/primitives/demultiplexer.h"
 #include "drake/systems/primitives/discrete_derivative.h"
 #include "drake/systems/primitives/discrete_time_delay.h"
+#include "drake/systems/primitives/discrete_time_integrator.h"
 #include "drake/systems/primitives/first_order_low_pass_filter.h"
 #include "drake/systems/primitives/gain.h"
 #include "drake/systems/primitives/integrator.h"
@@ -160,6 +161,17 @@ PYBIND11_MODULE(primitives, m) {
             py::arg("abstract_model_value"),
             doc.DiscreteTimeDelay.ctor
                 .doc_3args_update_sec_delay_time_steps_abstract_model_value);
+
+    DefineTemplateClassWithDefault<DiscreteTimeIntegrator<T>, LeafSystem<T>>(m,
+        "DiscreteTimeIntegrator", GetPyParam<T>(),
+        doc.DiscreteTimeIntegrator.doc)
+        .def(py::init<int, double>(), py::arg("size"), py::arg("time_step"),
+            doc.DiscreteTimeIntegrator.ctor.doc)
+        .def("set_integral_value",
+            &DiscreteTimeIntegrator<T>::set_integral_value, py::arg("context"),
+            py::arg("value"), doc.DiscreteTimeIntegrator.set_integral_value.doc)
+        .def("time_step", &DiscreteTimeIntegrator<T>::time_step,
+            doc.DiscreteTimeIntegrator.time_step.doc);
 
     DefineTemplateClassWithDefault<DiscreteDerivative<T>, LeafSystem<T>>(
         m, "DiscreteDerivative", GetPyParam<T>(), doc.DiscreteDerivative.doc)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -28,6 +28,7 @@ from pydrake.systems.primitives import (
     Demultiplexer, Demultiplexer_,
     DiscreteDerivative, DiscreteDerivative_,
     DiscreteTimeDelay, DiscreteTimeDelay_,
+    DiscreteTimeIntegrator_,
     FirstOrderLowPassFilter,
     FirstOrderTaylorApproximation,
     Gain, Gain_,
@@ -91,6 +92,7 @@ class TestGeneral(unittest.TestCase):
         self._check_instantiations(Demultiplexer_)
         self._check_instantiations(DiscreteDerivative_)
         self._check_instantiations(DiscreteTimeDelay_)
+        self._check_instantiations(DiscreteTimeIntegrator_)
         self._check_instantiations(Gain_)
         self._check_instantiations(Integrator_)
         self._check_instantiations(LinearSystem_)
@@ -113,6 +115,20 @@ class TestGeneral(unittest.TestCase):
         self._check_instantiations(VectorLogSink_)
         self._check_instantiations(WrapToSystem_)
         self._check_instantiations(ZeroOrderHold_)
+
+    @numpy_compare.check_all_types
+    def test_discrete_time_integrator(self, T):
+        time_step = 0.1
+        integrator = DiscreteTimeIntegrator_[T](size=2, time_step=time_step)
+        self.assertEqual(integrator.time_step(), time_step)
+        context = integrator.CreateDefaultContext()
+        x = np.array([1., 2.])
+        integrator.set_integral_value(context=context, value=x)
+        u = np.array([3., 4.])
+        integrator.get_input_port(0).FixValue(context, u)
+        x_next = integrator.EvalUniquePeriodicDiscreteUpdate(
+            context).get_vector()._get_value_copy()
+        numpy_compare.assert_float_equal(x_next, x + time_step * u)
 
     def test_linear_affine_system(self):
         # Just make sure linear system is spelled correctly.

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":demultiplexer",
         ":discrete_derivative",
         ":discrete_time_delay",
+        ":discrete_time_integrator",
         ":first_order_low_pass_filter",
         ":gain",
         ":integrator",
@@ -127,6 +128,15 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:essential",
         "//common:value",
+        "//systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "discrete_time_integrator",
+    srcs = ["discrete_time_integrator.cc"],
+    hdrs = ["discrete_time_integrator.h"],
+    deps = [
         "//systems/framework",
     ],
 )
@@ -477,6 +487,17 @@ drake_cc_googletest(
         ":affine_system",
         ":discrete_time_delay",
         ":sine",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/analysis:simulator",
+        "//systems/framework",
+        "//systems/framework/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "discrete_time_integrator_test",
+    deps = [
+        ":discrete_time_integrator",
         "//common/test_utilities:eigen_matrix_compare",
         "//systems/analysis:simulator",
         "//systems/framework",

--- a/systems/primitives/discrete_time_integrator.cc
+++ b/systems/primitives/discrete_time_integrator.cc
@@ -1,0 +1,55 @@
+#include "drake/systems/primitives/discrete_time_integrator.h"
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+DiscreteTimeIntegrator<T>::DiscreteTimeIntegrator(int size, double time_step)
+    : LeafSystem<T>(SystemTypeTag<DiscreteTimeIntegrator>{}),
+      time_step_{time_step} {
+  DRAKE_THROW_UNLESS(size > 0);
+  DRAKE_THROW_UNLESS(time_step > 0);
+  this->DeclareVectorInputPort("u", size);
+  auto state_index = this->DeclareDiscreteState(size);
+  this->DeclarePeriodicDiscreteUpdateEvent(time_step, 0.0,
+                                           &DiscreteTimeIntegrator::Update);
+  this->DeclareStateOutputPort("y", state_index);
+}
+
+template <typename T>
+template <typename U>
+DiscreteTimeIntegrator<T>::DiscreteTimeIntegrator(
+    const DiscreteTimeIntegrator<U>& other)
+    : DiscreteTimeIntegrator<T>(other.get_input_port().size(),
+                                other.time_step()) {}
+
+template <typename T>
+DiscreteTimeIntegrator<T>::~DiscreteTimeIntegrator() = default;
+
+template <typename T>
+void DiscreteTimeIntegrator<T>::set_integral_value(
+    Context<T>* context, const Eigen::Ref<const VectorX<T>>& value) const {
+  this->ValidateContext(context);
+  BasicVector<T>& state_vector = context->get_mutable_discrete_state_vector();
+  // Asserts that the input value is a column vector of the appropriate size.
+  DRAKE_THROW_UNLESS(value.rows() == state_vector.size());
+  state_vector.SetFromVector(value);
+}
+
+template <typename T>
+void DiscreteTimeIntegrator<T>::Update(const Context<T>& context,
+                                       DiscreteValues<T>* next_state) const {
+  const VectorX<T>& state = context.get_discrete_state_vector().value();
+  next_state->set_value(state +
+                        time_step_ * this->get_input_port().Eval(context));
+}
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiscreteTimeIntegrator)

--- a/systems/primitives/discrete_time_integrator.h
+++ b/systems/primitives/discrete_time_integrator.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+/** A discrete-time integrator for a vector input, using explicit Euler
+integration.
+
+@system
+name: DiscreteTimeIntegrator
+input_ports:
+- u
+output_ports:
+- y
+@endsystem
+
+The discrete state space dynamics of %DiscreteTimeIntegrator with
+time step `h` is:
+```
+xₙ₊₁ = xₙ + h uₙ  // update
+yₙ = xₙ           // output
+x₀ = xᵢₙᵢₜ        // initialize
+```
+where xᵢₙᵢₜ = 0 by default. Use set_integral_value() to set xₙ in the context.
+The output at time `t` is `xₙ` where `n = ceil(t/h)`.  See @ref
+discrete_systems.
+
+@tparam_default_scalar
+@ingroup primitive_systems
+*/
+template <typename T>
+class DiscreteTimeIntegrator final : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteTimeIntegrator)
+
+  /// Constructs an %DiscreteTimeIntegrator system.
+  /// @param size number of elements in the signal to be processed.
+  /// @param time_step the discrete time step.
+  /// @pre size > 0. time_step > 0.
+  DiscreteTimeIntegrator(int size, double time_step);
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit DiscreteTimeIntegrator(const DiscreteTimeIntegrator<U>&);
+
+  ~DiscreteTimeIntegrator() final;
+
+  /// Sets the value of the integral modifying the state in the context.
+  /// @p value must be a column vector of the appropriate size.
+  void set_integral_value(Context<T>* context,
+                          const Eigen::Ref<const VectorX<T>>& value) const;
+
+  /// Returns the time_step used by the integrator.
+  double time_step() const { return time_step_; }
+
+ private:
+  void Update(const Context<T>& context, DiscreteValues<T>* next_state) const;
+
+  double time_step_{};
+};
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiscreteTimeIntegrator)

--- a/systems/primitives/integrator.h
+++ b/systems/primitives/integrator.h
@@ -7,7 +7,7 @@
 namespace drake {
 namespace systems {
 
-/// An integrator for a continuous vector input.
+/// A continuous-time integrator for a vector input.
 ///
 /// @system
 /// name: Integrator
@@ -56,3 +56,6 @@ class Integrator final : public VectorSystem<T> {
 
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::Integrator)

--- a/systems/primitives/test/discrete_time_integrator_test.cc
+++ b/systems/primitives/test/discrete_time_integrator_test.cc
@@ -1,0 +1,74 @@
+#include "drake/systems/primitives/discrete_time_integrator.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+GTEST_TEST(DiscreteTimeIntegratorTest, BasicTest) {
+  const double kTimeStep = 0.1;
+  DiscreteTimeIntegrator<double> integrator(3, kTimeStep);
+  EXPECT_EQ(integrator.get_input_port().size(), 3);
+  EXPECT_EQ(integrator.get_output_port().size(), 3);
+
+  EXPECT_EQ(integrator.time_step(), kTimeStep);
+  std::optional<PeriodicEventData> data =
+      integrator.GetUniquePeriodicDiscreteUpdateAttribute();
+  EXPECT_TRUE(data.has_value());
+  EXPECT_EQ(data->period_sec(), kTimeStep);
+
+  auto context = integrator.CreateDefaultContext();
+  EXPECT_TRUE(CompareMatrices(integrator.get_output_port().Eval(*context),
+                              Eigen::Vector3d::Zero(), 1e-14));
+
+  const Eigen::Vector3d x{1.0, 2.0, 3.0};
+  integrator.set_integral_value(context.get(), x);
+  EXPECT_TRUE(CompareMatrices(x, context->get_discrete_state_vector().value()));
+  EXPECT_TRUE(
+      CompareMatrices(integrator.get_output_port().Eval(*context), x, 1e-14));
+
+  const Eigen::Vector3d u{4.0, 5.0, 6.0};
+  integrator.get_input_port().FixValue(context.get(), u);
+  EXPECT_TRUE(CompareMatrices(
+      x + kTimeStep * u,
+      integrator.EvalUniquePeriodicDiscreteUpdate(*context).value(), 1e-14));
+}
+
+GTEST_TEST(DiscreteTimeIntegratorTest, Simulation) {
+  const double kTimeStep = 0.1;
+  DiscreteTimeIntegrator<double> integrator(2, kTimeStep);
+
+  Simulator<double> simulator(integrator);
+  Context<double>& context = simulator.get_mutable_context();
+
+  const Eigen::Vector2d u{1.2, 2.3};
+  integrator.get_input_port().FixValue(&context, u);
+  EXPECT_TRUE(CompareMatrices(integrator.get_output_port().Eval(context),
+                              Eigen::Vector2d::Zero(), 1e-14));
+
+  // From the docs: the output at time `t` is `xₙ` where `n = ceil(t/h)`.
+  // Test the output at t = 0.5 * h.
+  simulator.AdvanceTo(kTimeStep / 2);
+  EXPECT_TRUE(CompareMatrices(integrator.get_output_port().Eval(context),
+                              kTimeStep * u, 1e-14));
+
+  // Test the output at t = h.
+  simulator.AdvanceTo(kTimeStep);
+  EXPECT_TRUE(CompareMatrices(integrator.get_output_port().Eval(context),
+                              kTimeStep * u, 1e-14));
+}
+
+GTEST_TEST(DiscreteTimeIntegratorTest, ScalarConversion) {
+  DiscreteTimeIntegrator<double> integrator(1, 0.1);
+  EXPECT_TRUE(is_autodiffxd_convertible(integrator));
+  EXPECT_TRUE(is_symbolic_convertible(integrator));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Note: unfortunately, there is already an
multibody::fem::internal::DiscreteTimeIntegrator. My thinking is that, while not ideal, this is ok because that class in internal.

+@sherm1 for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21222)
<!-- Reviewable:end -->
