### PR TITLE
Fixes bug in IrisInConfigurationSpaceFromCliqueCover

### DIFF
--- a/planning/iris/iris_from_clique_cover.cc
+++ b/planning/iris/iris_from_clique_cover.cc
@@ -214,6 +214,7 @@ std::queue<HPolyhedron> IrisWorker(
       log()->info(
           "Iris builder thread {} failed to compute an ellipse for a clique.",
           builder_id, e.what());
+      current_clique = computed_cliques->pop();
       continue;
     }
 

--- a/planning/iris/iris_from_clique_cover.cc
+++ b/planning/iris/iris_from_clique_cover.cc
@@ -346,8 +346,8 @@ void IrisInConfigurationSpaceFromCliqueCover(
   Eigen::VectorXd last_polytope_sample = domain.UniformSample(generator);
 
   // Override options which are set too aggressively.
-  const int minimum_clique_size =
-      std::max(options.minimum_clique_size, checker.plant().num_positions());
+  const int minimum_clique_size = std::max(options.minimum_clique_size,
+                                           checker.plant().num_positions() + 1);
 
   int num_points_per_visibility_round = std::max(
       options.num_points_per_visibility_round, 2 * minimum_clique_size);
@@ -421,7 +421,7 @@ void IrisInConfigurationSpaceFromCliqueCover(
     // worst case.
     sets->reserve(sets->size() +
                   ComputeMaxNumberOfCliquesInGreedyCliqueCover(
-                      visibility_graph.cols(), options.minimum_clique_size) /
+                      visibility_graph.cols(), minimum_clique_size) /
                       2);
 
     // Now solve the max clique cover and build new sets.
@@ -430,9 +430,8 @@ void IrisInConfigurationSpaceFromCliqueCover(
     // off the queue by the set builder workers to build the sets.
     AsyncQueue<VectorX<bool>> computed_cliques;
     if (options.parallelism.num_threads() == 1) {
-      ComputeGreedyTruncatedCliqueCover(options.minimum_clique_size,
-                                        *max_clique_solver, &visibility_graph,
-                                        &computed_cliques);
+      ComputeGreedyTruncatedCliqueCover(minimum_clique_size, *max_clique_solver,
+                                        &visibility_graph, &computed_cliques);
       std::queue<HPolyhedron> new_set_queue =
           IrisWorker(checker, points, 0, options, &computed_cliques,
                      false /* No need to disable meshcat */);
@@ -445,7 +444,7 @@ void IrisInConfigurationSpaceFromCliqueCover(
       // Compute truncated clique cover.
       std::future<void> clique_future{
           std::async(std::launch::async, ComputeGreedyTruncatedCliqueCover,
-                     options.minimum_clique_size, std::ref(*max_clique_solver),
+                     minimum_clique_size, std::ref(*max_clique_solver),
                      &visibility_graph, &computed_cliques)};
 
       // We will use one thread to build cliques and the remaining threads to

--- a/planning/iris/iris_from_clique_cover.cc
+++ b/planning/iris/iris_from_clique_cover.cc
@@ -156,7 +156,7 @@ void ComputeGreedyTruncatedCliqueCover(
     last_clique_size = max_clique.template cast<int>().sum();
     log()->debug("Last Clique Size = {}", last_clique_size);
     num_points_left -= last_clique_size;
-    if (last_clique_size > minimum_clique_size) {
+    if (last_clique_size >= minimum_clique_size) {
       computed_cliques->push(max_clique);
       ++num_cliques;
       MakeFalseRowsAndColumns(max_clique, adjacency_matrix);

--- a/planning/iris/test/iris_from_clique_cover_test.cc
+++ b/planning/iris/test/iris_from_clique_cover_test.cc
@@ -151,8 +151,10 @@ GTEST_TEST(IrisInConfigurationSpaceFromCliqueCover, BoxConfigurationSpaceTest) {
 
   RandomGenerator generator(0);
 
-  // Checking that ellipsoid program can no longer stop the set builders by
-  // forcing ellipsoid program to fail.
+  // This checks that errors in finding the minimum volume circumscribed
+  // ellipsoid does not lead to an infinite loop or program crash. Setting this
+  // tolerance very high has the effect of rejecting every clique as being in an
+  // affine subspace.
   options.rank_tol_for_minimum_volume_circumscribed_ellipsoid = 1e10;
   IrisInConfigurationSpaceFromCliqueCover(*checker, options, &generator, &sets,
                                           nullptr);

--- a/planning/iris/test/iris_from_clique_cover_test.cc
+++ b/planning/iris/test/iris_from_clique_cover_test.cc
@@ -246,6 +246,7 @@ class IrisInConfigurationSpaceFromCliqueCoverTestFixture
     params = CollisionCheckerParams();
 
     meshcat = geometry::GetTestEnvironmentMeshcat();
+    meshcat->Delete("/drake");
     meshcat->Set2dRenderMode(math::RigidTransformd(Eigen::Vector3d{0, 0, 1}),
                              -3.25, 3.25, -3.25, 3.25);
     meshcat->SetProperty("/Grid", "visible", true);
@@ -449,6 +450,34 @@ TEST_F(IrisInConfigurationSpaceFromCliqueCoverTestFixture,
   // of the random seed. (The probability of success is larger than 1-1e-9).
   EXPECT_GE(coverage_estimate, 0.8);
 
+  MaybePauseForUser();
+}
+
+// Tests that the minimum_clique_size correctly gets overridden
+TEST_F(IrisInConfigurationSpaceFromCliqueCoverTestFixture,
+       BoxWithCornerObstaclesMinCliqueSizeTest) {
+  options.parallelism = Parallelism(1);
+  options.minimum_clique_size = 1;
+  options.iteration_limit = 1;
+  options.num_points_per_visibility_round = 6;
+  // use default solver MaxCliqueSovlerViaGreedy
+  IrisInConfigurationSpaceFromCliqueCover(*checker, options, &generator, &sets,
+                                          nullptr);
+
+  EXPECT_EQ(ssize(sets), 0);
+
+  // Show the IrisFromCliqueCoverDecomposition
+  for (int i = 0; i < ssize(sets); ++i) {
+    // Choose a random color.
+    for (int j = 0; j < color.size(); ++j) {
+      color[j] = abs(gaussian(generator));
+    }
+    color.normalize();
+    VPolytope vregion = VPolytope(sets.at(i)).GetMinimalRepresentation();
+    Draw2dVPolytope(vregion,
+                    fmt::format("iris_from_clique_cover_min_cl_size{}", i),
+                    color, meshcat);
+  }
   MaybePauseForUser();
 }
 

--- a/planning/iris/test/iris_from_clique_cover_test.cc
+++ b/planning/iris/test/iris_from_clique_cover_test.cc
@@ -152,7 +152,7 @@ GTEST_TEST(IrisInConfigurationSpaceFromCliqueCover, BoxConfigurationSpaceTest) {
   RandomGenerator generator(0);
 
   // This checks that errors in finding the minimum volume circumscribed
-  // ellipsoid does not lead to an infinite loop or program crash. Setting this
+  // ellipsoid do not lead to an infinite loop or program crash. Setting this
   // tolerance very high has the effect of rejecting every clique as being in an
   // affine subspace.
   options.rank_tol_for_minimum_volume_circumscribed_ellipsoid = 1e10;

--- a/planning/iris/test/iris_from_clique_cover_test.cc
+++ b/planning/iris/test/iris_from_clique_cover_test.cc
@@ -138,6 +138,7 @@ GTEST_TEST(IrisInConfigurationSpaceFromCliqueCover, BoxConfigurationSpaceTest) {
   IrisFromCliqueCoverOptions options;
 
   options.num_points_per_coverage_check = 100;
+  options.num_points_per_visibility_round = 20;
   options.iteration_limit = 1;
   // Set a large bounding region to test the path where this is set in the
   // IrisOptions.
@@ -150,23 +151,19 @@ GTEST_TEST(IrisInConfigurationSpaceFromCliqueCover, BoxConfigurationSpaceTest) {
 
   RandomGenerator generator(0);
 
-  // checking that adversarial setting gets overridden and correctly returns no
-  // sets.
-  options.num_points_per_visibility_round = 1;
-  IrisInConfigurationSpaceFromCliqueCover(*checker, options, &generator, &sets,
-                                          nullptr);
-  EXPECT_EQ(ssize(sets), 0);
-
-  // checking that ellipsoid program can no longer stop the set builders by
-  // forcing it to fail
-  options.num_points_per_visibility_round = 20;
+  // Checking that ellipsoid program can no longer stop the set builders by
+  // forcing ellipsoid program to fail.
   options.rank_tol_for_minimum_volume_circumscribed_ellipsoid = 1e10;
   IrisInConfigurationSpaceFromCliqueCover(*checker, options, &generator, &sets,
                                           nullptr);
   EXPECT_EQ(ssize(sets), 0);
 
-  // reverting to normal settings, expect perfect coverage in a single plolytope
+  // Reverting to normal settings.
   options.rank_tol_for_minimum_volume_circumscribed_ellipsoid = 1e-6;
+  // Checking that the adversarial setting of 1 point visibility graphs gets
+  // overridden and correctly increases the number of samples. The result should
+  // be perfect coverage in a single polytope.
+  options.num_points_per_visibility_round = 1;
   IrisInConfigurationSpaceFromCliqueCover(*checker, options, &generator, &sets,
                                           nullptr);
   EXPECT_EQ(ssize(sets), 1);


### PR DESCRIPTION
The function IrisInConfigurationSpaceFromCliqueCover had ill defined behavior when a clique with a degenerate MinimumVolumeCircumscribedEllipsoid is encountered. The corresponding IrisWorker would get stuck attempting to build the set from the degenerate clique and repeatedly triggering the same runtime error without discarding the clique after one try. The fix is to pop the clique from the queue when the circumscribed ellipsoid fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21237)
<!-- Reviewable:end -->
