### PR TITLE
[examples] Copy quadrotor.urdf to drake_models

### DIFF
--- a/examples/quadrotor/BUILD.bazel
+++ b/examples/quadrotor/BUILD.bazel
@@ -24,8 +24,7 @@ filegroup(
     name = "models",
     srcs = [
         ":glob_models",
-        "@drake_models//:skydio_2/skydio_2_1000_poly.mtl",
-        "@drake_models//:skydio_2/skydio_2_1000_poly.obj",
+        "@drake_models//:skydio_2",
     ],
 )
 

--- a/examples/quadrotor/quadrotor.urdf
+++ b/examples/quadrotor/quadrotor.urdf
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+<!-- This model file is deprecated and should not be used in new code.
+Instead, use the drake_models/skydio_2/quadrotor.urdf.
+TODO(jwnimmer-tri) Delete this on 2024-05-01. -->
 <!-- Mesh file and approximate numbers are from Abe Bachrach at Skdio.  -->
 <robot name="quadrotor">
   <!--

--- a/examples/quadrotor/quadrotor_geometry.cc
+++ b/examples/quadrotor/quadrotor_geometry.cc
@@ -44,7 +44,7 @@ QuadrotorGeometry::QuadrotorGeometry(
   multibody::Parser parser(&mbp, scene_graph);
 
   const auto model_instance_indices = parser.AddModelsFromUrl(
-      "package://drake/examples/quadrotor/quadrotor.urdf");
+      "package://drake_models/skydio_2/quadrotor.urdf");
   mbp.Finalize();
 
   // Identify the single quadrotor body and its frame.

--- a/examples/quadrotor/quadrotor_plant.h
+++ b/examples/quadrotor/quadrotor_plant.h
@@ -14,7 +14,7 @@ namespace quadrotor {
 
 /// The Quadrotor - an underactuated aerial vehicle. This version of the
 /// Quadrotor is implemented to match the dynamics of the plant specified in
-/// the `quadrotor.urdf` model file.
+/// the `package://drake_models/skydio_2/quadrotor.urdf` model file.
 ///
 /// @system
 /// name: QuadrotorPlant

--- a/examples/quadrotor/run_quadrotor_dynamics.cc
+++ b/examples/quadrotor/run_quadrotor_dynamics.cc
@@ -37,7 +37,7 @@ class Quadrotor : public systems::Diagram<T> {
         multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
     multibody::Parser parser(&plant);
     parser.AddModelsFromUrl(
-        "package://drake/examples/quadrotor/quadrotor.urdf");
+        "package://drake_models/skydio_2/quadrotor.urdf");
     parser.AddModelsFromUrl(
         "package://drake/examples/quadrotor/warehouse.sdf");
     plant.Finalize();

--- a/examples/quadrotor/test/quadrotor_dynamics_test.cc
+++ b/examples/quadrotor/test/quadrotor_dynamics_test.cc
@@ -110,7 +110,7 @@ class MultibodyQuadrotor: public Diagram<double> {
     auto owned_plant = std::make_unique<MultibodyPlant<double>>(0.0);
     plant_ = owned_plant.get();
     Parser(plant_).AddModelsFromUrl(
-        "package://drake/examples/quadrotor/quadrotor.urdf");
+        "package://drake_models/skydio_2/quadrotor.urdf");
     plant_->Finalize();
     body_ = &plant_->GetBodyByName("base_link");
     DiagramBuilder<double> builder;

--- a/tools/workspace/drake_models/repository.bzl
+++ b/tools/workspace/drake_models/repository.bzl
@@ -6,8 +6,8 @@ def drake_models_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/models",
-        commit = "db9c78f538fb1cd519098a6d6422c3f179415eb6",
-        sha256 = "f3a630b78671f52412e2b5b54dc4ac26c855a88af8c49df0e2f9a9d36f20b570",  # noqa
+        commit = "d2b82d335c4f19aa9b515b483c9d5e6dff0c8997",
+        sha256 = "6b7390b95bc7ab50c6bbbf05a07efa727965485d71c8c5b34998cfec44dbbc27",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
We'll remove the file from Drake after the next release, to provide a smoother glide path for `underactuated.csail.mit.edu` which is being taught this spring.

---

Even though this model is "deprecated", I'm not going to mark it as such in that section of the release notes.  Instead, it'll just be part of the broader "model files move" announcement.

Towards #13942.

Twin PR: https://github.com/RobotLocomotion/models/pull/55

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21238)
<!-- Reviewable:end -->
