### PR TITLE
Clarify some contracts relating to System::SetDefaultContext()

### DIFF
--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -76,13 +76,6 @@ MultibodyTreeSystem<T>::MultibodyTreeSystem(
 }
 
 template <typename T>
-void MultibodyTreeSystem<T>::SetDefaultState(const Context<T>& context,
-                                             State<T>* state) const {
-  LeafSystem<T>::SetDefaultState(context, state);
-  tree_->SetDefaultState(context, state);
-}
-
-template <typename T>
 void MultibodyTreeSystem<T>::SetDefaultParameters(
     const Context<T>& context, Parameters<T>* parameters) const {
   LeafSystem<T>::SetDefaultParameters(context, parameters);
@@ -130,6 +123,13 @@ void MultibodyTreeSystem<T>::SetDefaultParameters(
         .get_force_element(force_element_index)
         .SetDefaultParameters(parameters);
   }
+}
+
+template <typename T>
+void MultibodyTreeSystem<T>::SetDefaultState(const Context<T>& context,
+                                             State<T>* state) const {
+  LeafSystem<T>::SetDefaultState(context, state);
+  tree_->SetDefaultState(context, state);
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -334,16 +334,16 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   }
   //@}
 
-  // TODO(sherm1) Shouldn't require overriding the default method; need
-  // a DoLeafSetDefaultState().
-  void SetDefaultState(const systems::Context<T>& context,
-                       systems::State<T>* state) const override;
-
   // Override of LeafSystem::SetDefaultParameters. For all parameters declared
   // by various MultibodyElement subclasses, sets numeric and abstract
   // parameters to default values stored in their class members.
   void SetDefaultParameters(const systems::Context<T>& context,
                             systems::Parameters<T>* parameters) const final;
+
+  // TODO(sherm1) Shouldn't require overriding the default method; need
+  // a DoLeafSetDefaultState().
+  void SetDefaultState(const systems::Context<T>& context,
+                       systems::State<T>* state) const override;
 
  private:
   // This is only meaningful in continuous mode.

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -102,25 +102,6 @@ Diagram<T>::DoAllocateCompositeEventCollection() const {
 }
 
 template <typename T>
-void Diagram<T>::SetDefaultState(const Context<T>& context,
-                                 State<T>* state) const {
-  this->ValidateContext(context);
-  auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
-  DRAKE_DEMAND(diagram_context != nullptr);
-
-  this->ValidateCreatedForThisSystem(state);
-  auto diagram_state = dynamic_cast<DiagramState<T>*>(state);
-  DRAKE_DEMAND(diagram_state != nullptr);
-
-  // Set default state of each constituent system.
-  for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
-    auto& subcontext = diagram_context->GetSubsystemContext(i);
-    auto& substate = diagram_state->get_mutable_substate(i);
-    registered_systems_[i]->SetDefaultState(subcontext, &substate);
-  }
-}
-
-template <typename T>
 void Diagram<T>::SetDefaultParameters(const Context<T>& context,
                                       Parameters<T>* params) const {
   this->ValidateContext(context);
@@ -171,6 +152,25 @@ void Diagram<T>::SetDefaultParameters(const Context<T>& context,
     subparameters.set_system_id(subcontext.get_system_id());
 
     registered_systems_[i]->SetDefaultParameters(subcontext, &subparameters);
+  }
+}
+
+template <typename T>
+void Diagram<T>::SetDefaultState(const Context<T>& context,
+                                 State<T>* state) const {
+  this->ValidateContext(context);
+  auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
+  DRAKE_DEMAND(diagram_context != nullptr);
+
+  this->ValidateCreatedForThisSystem(state);
+  auto diagram_state = dynamic_cast<DiagramState<T>*>(state);
+  DRAKE_DEMAND(diagram_state != nullptr);
+
+  // Set default state of each constituent system.
+  for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
+    auto& subcontext = diagram_context->GetSubsystemContext(i);
+    auto& substate = diagram_state->get_mutable_substate(i);
+    registered_systems_[i]->SetDefaultState(subcontext, &substate);
   }
 }
 

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -116,11 +116,11 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   std::multimap<int, int> GetDirectFeedthroughs() const final;
 
-  void SetDefaultState(const Context<T>& context,
-                       State<T>* state) const override;
-
   void SetDefaultParameters(const Context<T>& context,
                             Parameters<T>* params) const override;
+
+  void SetDefaultState(const Context<T>& context,
+                       State<T>* state) const override;
 
   void SetRandomState(const Context<T>& context, State<T>* state,
                       RandomGenerator* generator) const override;

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -142,6 +142,27 @@ std::unique_ptr<ContextBase> LeafSystem<T>::DoAllocateContext() const {
 }
 
 template <typename T>
+void LeafSystem<T>::SetDefaultParameters(
+    const Context<T>& context, Parameters<T>* parameters) const {
+  this->ValidateContext(context);
+  this->ValidateCreatedForThisSystem(parameters);
+  for (int i = 0; i < parameters->num_numeric_parameter_groups(); i++) {
+    BasicVector<T>& p = parameters->get_mutable_numeric_parameter(i);
+    auto model_vector = model_numeric_parameters_.CloneVectorModel<T>(i);
+    if (model_vector != nullptr) {
+      p.SetFrom(*model_vector);
+    } else {
+      p.SetFromVector(VectorX<T>::Constant(p.size(), 1.0));
+    }
+  }
+  for (int i = 0; i < parameters->num_abstract_parameters(); i++) {
+    AbstractValue& p = parameters->get_mutable_abstract_parameter(i);
+    auto model_value = model_abstract_parameters_.CloneModel(i);
+    p.SetFrom(*model_value);
+  }
+}
+
+template <typename T>
 void LeafSystem<T>::SetDefaultState(
     const Context<T>& context, State<T>* state) const {
   this->ValidateContext(context);
@@ -168,27 +189,6 @@ void LeafSystem<T>::SetDefaultState(
 
   AbstractValues& xa = state->get_mutable_abstract_state();
   xa.SetFrom(AbstractValues(model_abstract_states_.CloneAllModels()));
-}
-
-template <typename T>
-void LeafSystem<T>::SetDefaultParameters(
-    const Context<T>& context, Parameters<T>* parameters) const {
-  this->ValidateContext(context);
-  this->ValidateCreatedForThisSystem(parameters);
-  for (int i = 0; i < parameters->num_numeric_parameter_groups(); i++) {
-    BasicVector<T>& p = parameters->get_mutable_numeric_parameter(i);
-    auto model_vector = model_numeric_parameters_.CloneVectorModel<T>(i);
-    if (model_vector != nullptr) {
-      p.SetFrom(*model_vector);
-    } else {
-      p.SetFromVector(VectorX<T>::Constant(p.size(), 1.0));
-    }
-  }
-  for (int i = 0; i < parameters->num_abstract_parameters(); i++) {
-    AbstractValue& p = parameters->get_mutable_abstract_parameter(i);
-    auto model_value = model_abstract_parameters_.CloneModel(i);
-    p.SetFrom(*model_value);
-  }
 }
 
 template <typename T>

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -68,13 +68,6 @@ class LeafSystem : public System<T> {
 
   std::unique_ptr<ContextBase> DoAllocateContext() const final;
 
-  /** Default implementation: sets all continuous state to the model vector
-  given in DeclareContinuousState (or zero if no model vector was given) and
-  discrete states to zero. Overrides must not change the number of state
-  variables. */
-  void SetDefaultState(const Context<T>& context,
-                       State<T>* state) const override;
-
   /** Default implementation: sets all numeric parameters to the model vector
   given to DeclareNumericParameter, or else if no model was provided sets
   the numeric parameter to one.  It sets all abstract parameters to the
@@ -82,6 +75,13 @@ class LeafSystem : public System<T> {
   the number of parameters. */
   void SetDefaultParameters(const Context<T>& context,
                             Parameters<T>* parameters) const override;
+
+  /** Default implementation: sets all continuous state to the model vector
+  given in DeclareContinuousState (or zero if no model vector was given) and
+  discrete states to zero. Overrides must not change the number of state
+  variables. */
+  void SetDefaultState(const Context<T>& context,
+                       State<T>* state) const override;
 
   std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const final;
 

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -105,6 +105,12 @@ template <typename T>
 void System<T>::SetDefaultContext(Context<T>* context) const {
   this->ValidateContext(context);
 
+  // Set the default parameters, checking that the number of parameters does
+  // not change.
+  const int num_params = context->num_numeric_parameter_groups();
+  SetDefaultParameters(*context, &context->get_mutable_parameters());
+  DRAKE_DEMAND(num_params == context->num_numeric_parameter_groups());
+
   // Set the default state, checking that the number of state variables does
   // not change.
   const int n_xc = context->num_continuous_states();
@@ -116,12 +122,6 @@ void System<T>::SetDefaultContext(Context<T>* context) const {
   DRAKE_DEMAND(n_xc == context->num_continuous_states());
   DRAKE_DEMAND(n_xd == context->num_discrete_state_groups());
   DRAKE_DEMAND(n_xa == context->num_abstract_states());
-
-  // Set the default parameters, checking that the number of parameters does
-  // not change.
-  const int num_params = context->num_numeric_parameter_groups();
-  SetDefaultParameters(*context, &context->get_mutable_parameters());
-  DRAKE_DEMAND(num_params == context->num_numeric_parameter_groups());
 }
 
 template <typename T>

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -163,15 +163,22 @@ class System : public SystemBase {
   sets its default values using SetDefaultContext(). */
   std::unique_ptr<Context<T>> CreateDefaultContext() const;
 
-  /** Assigns default values to all elements of the state. Overrides must not
-  change the number of state variables. */
-  virtual void SetDefaultState(const Context<T>& context,
-                               State<T>* state) const = 0;
-
   /** Assigns default values to all parameters. Overrides must not
-  change the number of parameters. */
+  change the number of parameters.
+
+  @warning `parameters` *may be* a mutable view into `context`. Don't assume
+  that evaluating `context` will be independent of writing to `parameters`. */
   virtual void SetDefaultParameters(const Context<T>& context,
                                     Parameters<T>* parameters) const = 0;
+
+  /** Assigns default values to all elements of the state. Overrides must not
+  change the number of state variables. The context's default parameters will
+  have already been set.
+
+  @warning `state` *may be* a mutable view into `context`. Don't assume that
+  evaluating `context` will be independent of writing to `state`. */
+  virtual void SetDefaultState(const Context<T>& context,
+                               State<T>* state) const = 0;
 
   /** Sets Context fields to their default values.  User code should not
   override. */

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -38,11 +38,21 @@ const int kSize = 3;
 template <typename T>
 class TestSystemBase : public System<T> {
  public:
-  TestSystemBase() : System<T>(SystemScalarConverter{}) {}
+  // @param num_numeric_param_groups
+  //    The number of parameter groups to be allocated. Each group has one
+  //    numeric value.
+  // @param num_continuous_states
+  //    The size of q. If overriding AllocateTimeDerivatives(), this value
+  //    should match the number of derivatives returned by that function.
+  explicit TestSystemBase(int num_numeric_params_groups = 0,
+                          int num_continuous_states = 0)
+      : System<T>(SystemScalarConverter{}),
+        num_numeric_param_groups_(num_numeric_params_groups),
+        num_continuous_states_(num_continuous_states) {}
 
-  void SetDefaultState(const Context<T>&, State<T>*) const final {}
+  void SetDefaultParameters(const Context<T>&, Parameters<T>*) const override {}
 
-  void SetDefaultParameters(const Context<T>&, Parameters<T>*) const final {}
+  void SetDefaultState(const Context<T>&, State<T>*) const override {}
 
   void AddTriggeredWitnessFunctionToCompositeEventCollection(
       Event<T>*, CompositeEventCollection<T>*) const final {
@@ -83,6 +93,27 @@ class TestSystemBase : public System<T> {
   std::unique_ptr<ContextBase> DoAllocateContext() const final {
     auto context = std::make_unique<LeafContext<T>>();
     this->InitializeContextBase(context.get());
+
+    if (num_numeric_param_groups_ > 0) {
+      // Each parameter group has a single numeric parameter of zero.
+      std::vector<std::unique_ptr<BasicVector<T>>> numeric_params;
+      for (int g = 0; g < num_numeric_param_groups_; ++g) {
+        numeric_params.emplace_back(
+            std::make_unique<BasicVector<T>>(std::initializer_list<T>{0.0}));
+      }
+      auto parameters =
+          std::make_unique<Parameters<T>>(std::move(numeric_params));
+      parameters->set_system_id(this->get_system_id());
+      context->init_parameters(std::move(parameters));
+      DRAKE_DEMAND(context->get_parameters().num_numeric_parameter_groups() ==
+                   num_numeric_param_groups_);
+    }
+
+    // Allocate requested continuous state variables.
+    auto state = std::make_unique<ContinuousState<T>>(
+        std::make_unique<BasicVector<T>>(num_continuous_states_));
+    context->init_continuous_state(std::move(state));
+
     return context;
   }
 
@@ -160,6 +191,11 @@ class TestSystemBase : public System<T> {
     ADD_FAILURE() << "A test called a method that was expected to be unused.";
     return {};
   }
+
+  // The numbers of numeric parameter groups or continuous states created when
+  // allocating a context.
+  int num_numeric_param_groups_{};
+  int num_continuous_states_{};
 };
 
 // A shell System to test the default implementations.
@@ -656,6 +692,45 @@ TEST_F(SystemTest, IsDifferentialEquationSystem) {
   EXPECT_FALSE(system_.IsDifferentialEquationSystem());
 }
 
+// System used to test some contracts about setting default values in a Context
+// (as documented on the SetDefaultInvocationContract test).
+class TestDefaultSystem final : public TestSystemBase<double> {
+ public:
+  TestDefaultSystem()
+      : TestSystemBase<double>(/* num_numeric_params_groups= */ 1,
+                               /* num_continuous_states= */ 1) {
+    this->set_name("TestDefaultSystem");
+  }
+
+  void SetDefaultParameters(const Context<double>& context,
+                            Parameters<double>* parameters) const final {
+    DRAKE_DEMAND(context.get_parameters().num_numeric_parameter_groups() == 1);
+    BasicVector<double>& param = parameters->get_mutable_numeric_parameter(0);
+    param[0] = kMagicValue;
+  }
+
+  // The state simply copies the parameter value over. If the default parameters
+  // have been evaluated *first*, then the continuous state should contain the
+  // magic number.
+  void SetDefaultState(const Context<double>& context,
+                       State<double>* state) const final {
+    const BasicVector<double>& param =
+        context.get_parameters().get_numeric_parameter(0);
+    state->get_mutable_continuous_state().get_mutable_vector()[0] = param[0];
+  }
+
+  constexpr static double kMagicValue = 17.5;
+};
+
+// Confirms the documented contract that the default parameters always get set
+// before default state.
+GTEST_TEST(SystemDefaultTest, SetDefaultInvocationContract) {
+  TestDefaultSystem system;
+  auto context = system.CreateDefaultContext();
+  EXPECT_EQ(context->get_state().get_continuous_state()[0],
+            TestDefaultSystem::kMagicValue);
+}
+
 template <typename T>
 using TestTypedVector = MyVector<T, 1>;
 
@@ -965,7 +1040,10 @@ class ComputationTestSystem final : public TestSystemBase<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ComputationTestSystem)
 
-  ComputationTestSystem() {
+  // Requesting three continuous states to match AllocateTimeDerivatives().
+  ComputationTestSystem()
+      : TestSystemBase<double>(/* num_numeric_params_groups= */ 0,
+                               /* num_continuous_states= */ 3) {
     DeclareInputPort("u0", kVectorValued, 1);
   }
 
@@ -1009,7 +1087,6 @@ class ComputationTestSystem final : public TestSystemBase<double> {
   // Derivatives can depend on time. Here x = (-1, -2, -3) * t.
   void DoCalcTimeDerivatives(const Context<double>& context,
                              ContinuousState<double>* derivatives) const final {
-    unused(context);
     EXPECT_EQ(derivatives->size(), 3);
     const double t = context.get_time();
     (*derivatives)[0] = -1 * t;


### PR DESCRIPTION
`System::SetDefaultContext()` calls `SetDefaultState()` and `SetDefaultParameters()` by passing a `const Context&` and a mutable `State` or `Parameters`. However, that mutable output parameter was actually a view into the `const Context`.

This *undocumented* relationship between the two parameters is dangerous. The relationship should either be documented or
ended. Here we opt to document (supported by a suitable regression test).

Furthermore, `SetDefaultContext()` doesn't document the order in which state and parameters are set. In this case, we document that the default parameter values have been set prior to setting the default state (and provide regression tests).

Related to #20948 (We'll need to evaluate kinematics while writing default state, so we need to make sure the default parameters are in place.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21245)
<!-- Reviewable:end -->
