### PR TITLE
Reinitialize polytope at start of iteration via A and b

### DIFF
--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -608,7 +608,8 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
     log()->info("IrisInConfigurationSpace iteration {}", iteration);
     int num_constraints = num_initial_constraints;
     bool seed_point_requirement = true;
-    HPolyhedron P_candidate = P;
+    HPolyhedron P_candidate = HPolyhedron(A.topRows(num_initial_constraints),
+                                          b.head(num_initial_constraints));
     DRAKE_ASSERT(best_volume > 0);
     // Find separating hyperplanes
 


### PR DESCRIPTION
This fixes issue #21170 by resetting the variable `P_candidate` to the polytope defined by the top `num_initial_constraints` rows of the `A` and `b` matrices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21246)
<!-- Reviewable:end -->
