### PR TITLE
add Meshcat .stl support

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -544,6 +544,7 @@ drake_cc_binary(
     srcs = ["test/meshcat_manual_test.cc"],
     data = [
         ":environment_maps",
+        ":test_stl_files",
         "//examples/kuka_iiwa_arm:models",
         "//examples/scene_graph:models",
         "//geometry/render:test_models",

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -449,13 +449,13 @@ class MeshcatShapeReifier : public ShapeReifier {
 
       // TODO(SeanCurtis-TRI): Provide test showing that .dae works.
 
-      if (format != "obj" && format != "dae") {
+      if (format != "obj" && format != "dae" && format != "stl") {
         // Note: We send the data along to meshcat regardless relying on meshcat
         // to ignore the mesh and move on. The *path* will still exist.
         static const logging::Warn one_time(
             "Drake's Meshcat only supports Mesh/Convex specifications which "
-            "use .obj, .gltf, or .dae files. Mesh specifications using other "
-            "mesh types (e.g., .stl, etc.) will not be visualized.");
+            "use .obj, .gltf, .dae, or .stl files. Mesh specifications using "
+            "other mesh types will not be visualized.");
       }
       auto geometry = std::make_unique<internal::MeshFileGeometryData>();
       geometry->uuid = uuid_generator_.GenerateRandom();

--- a/geometry/meshcat_types_internal.h
+++ b/geometry/meshcat_types_internal.h
@@ -274,10 +274,9 @@ struct MeshFileGeometryData : public GeometryData {
     o.pack("_meshfile_geometry");
     PACK_MAP_VAR(o, uuid);
     PACK_MAP_VAR(o, format);
-    if(format=="obj" || format=="dae") {
+    if (format == "obj" || format == "dae") {
       PACK_MAP_VAR(o, data);
-    }
-    else if(format=="stl") {
+    } else if (format == "stl") {
       // 0x12 means Uint8Array in three.js
       msgpack::type::ext data_ext(0x12, data.c_str(), data.size());
       o.pack("data");

--- a/geometry/meshcat_types_internal.h
+++ b/geometry/meshcat_types_internal.h
@@ -274,7 +274,15 @@ struct MeshFileGeometryData : public GeometryData {
     o.pack("_meshfile_geometry");
     PACK_MAP_VAR(o, uuid);
     PACK_MAP_VAR(o, format);
-    PACK_MAP_VAR(o, data);
+    if(format=="obj" || format=="dae") {
+      PACK_MAP_VAR(o, data);
+    }
+    else if(format=="stl") {
+      // 0x12 means Uint8Array in three.js
+      msgpack::type::ext data_ext(0x12, data.c_str(), data.size());
+      o.pack("data");
+      o.pack(data_ext);
+    }
   }
 };
 

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -49,7 +49,7 @@ int do_main() {
   // For every items we add to the initial array, decrement start_x by one half
   // to keep things centered.
   // Use ++x as the x-position of new items.
-  const double start_x = -8.5;
+  const double start_x = -9.0;
   double x = start_x;
 
   Vector3d sphere_home{++x, 0, 0};
@@ -83,6 +83,13 @@ int do_main() {
   meshcat->SetObject("obj_as_mesh", Mesh(polytope_with_hole, 0.25),
                      Rgba(0.8, 0.4, 0.1, 1.0));
   meshcat->SetTransform("obj_as_mesh", RigidTransformd(Vector3d{x, 1, 0}));
+
+  const std::string quad_cube =
+      FindResourceOrThrow("drake/geometry/test/quad_cube.stl");
+  meshcat->SetObject("obj_as_stl_mesh", Mesh(quad_cube, 0.25),
+                     Rgba(1, 1, 0, 1.0));
+  meshcat->SetTransform("obj_as_stl_mesh",
+                        RigidTransformd(Vector3d{++x, 0, 0}));
 
   meshcat->SetObject("capsule", Capsule(0.25, 0.5), Rgba(0, 1, 1, 1));
   meshcat->SetTransform("capsule", RigidTransformd(Vector3d{++x, 0, 0}));
@@ -253,6 +260,7 @@ Ignore those for now; we'll need to circle back and fix them later.
   - an orange polytopes (with a similary shaped textured polytope behind it).
     The textured shape has a hole through. The orange polytope is its convex
     hull.
+  - a yellow cube
   - a teal capsule (long axis in z)
   - a red cone (expanding in +z, twice as wide in y than in x)
   - a shiny, green, dented cube (created with a PBR material)


### PR DESCRIPTION
Meshcat does not transmit .stl mesh properly, see https://github.com/RobotLocomotion/drake/blob/e7c06bfc444c9abd89233f675f2450876c911f1e/geometry/meshcat.cc#L440-L448

I change the _meshfile_geometry.data's pack type, using ext Uint8Array when transmit stl mesh. see also https://github.com/meshcat-dev/meshcat-python/blob/785bc9d5ba6f8a8bb79ee8b25f523805946c1fbd/src/meshcat/geometry.py#L474

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21268)
<!-- Reviewable:end -->
