### PR TITLE
[workspace] Create a virtual environment for MacOS Python deps.

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -67,4 +67,9 @@ if ! command -v pip3.12 &>/dev/null; then
   exit 2
 fi
 
-pip3.12 install --break-system-packages -r "${BASH_SOURCE%/*}/requirements.txt"
+# Create a virtual environment to isolate the Drake Python depdendency tree 
+# from the system Python so we don't need to include --break-system-packages.
+# For more info, read https://github.com/RobotLocomotion/drake/pull/21013#issuecomment-1970181733.
+python3.12 -m venv "${HOME}/.drake_venv"
+source "${HOME}/.drake_venv/bin/activate"
+pip3.12 install -r "${BASH_SOURCE%/*}/requirements.txt"

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -54,8 +54,13 @@ if ! command -v pip3.12 &>/dev/null; then
   exit 2
 fi
 
-pip3.12 install --break-system-packages -r "${BASH_SOURCE%/*}/requirements.txt"
+# Create a virtual environment to isolate the Drake Python depdendency tree 
+# from the system Python so we don't need to include --break-system-packages.
+# For more info, https://github.com/RobotLocomotion/drake/pull/21013#issuecomment-1970181733.
+python3.12 -m venv "${HOME}/.drake_venv"
+source "${HOME}/.drake_venv/bin/activate"
+pip3.12 install -r "${BASH_SOURCE%/*}/requirements.txt"
 
 if [[ "${with_test_only}" -eq 1 ]]; then
-  pip3.12 install --break-system-packages -r "${BASH_SOURCE%/*}/requirements-test-only.txt"
+  pip3.12 install -r "${BASH_SOURCE%/*}/requirements-test-only.txt"
 fi


### PR DESCRIPTION
This Pull Request creates a virtual environment for Python dependencies on MacOS so that we can remove the `--break-system-packages` argument to the `pip install` invocation. It fixes: https://github.com/RobotLocomotion/drake/issues/8392

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21269)
<!-- Reviewable:end -->
