### PR TITLE
[geometry] Introduce internal::ApplyProximityDefaults

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -264,6 +264,7 @@ drake_cc_library(
         ":kinematics_vector",
         ":mesh_deformation_interpolator",
         ":proximity_engine",
+        ":scene_graph_config",
         ":utilities",
         "//geometry/proximity:make_convex_hull_mesh",
         "//geometry/render:render_engine",

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -24,6 +24,7 @@
 #include "drake/geometry/proximity_engine.h"
 #include "drake/geometry/render/render_camera.h"
 #include "drake/geometry/render/render_engine.h"
+#include "drake/geometry/scene_graph_config.h"
 #include "drake/geometry/utilities.h"
 
 namespace drake {
@@ -664,6 +665,27 @@ class GeometryState {
    instance already instantiated on AutoDiffXd, it is equivalent to cloning
    the instance.  */
   std::unique_ptr<GeometryState<AutoDiffXd>> ToAutoDiffXd() const;
+
+  //@}
+
+  /** @name Default proximity properties */
+  //@{
+
+  /** Applies the default proximity values in `defaults` to the proximity
+   properties of every currently registered geometry that has a proximity
+   role. For detailed semantics, see the 2-argument overload.
+  */
+  void ApplyProximityDefaults(const DefaultProximityProperties& defaults);
+
+  /** Applies the default proximity values in `defaults` to the proximity
+   properties of the geometry with the given geometry_id as appropriate. For a
+   given property, no value will be written if (a) `defaults` contains no value
+   for it, or (b) a value has previously been set for that property.
+
+   @pre geometry_id indicates a geometry with an assigned proximity role.
+  */
+  void ApplyProximityDefaults(const DefaultProximityProperties& defaults,
+                              GeometryId geometry_id);
 
   //@}
 


### PR DESCRIPTION
This is progress toward simpler hydroelastic configuration. More patches will follow to complete the integration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21272)
<!-- Reviewable:end -->
