### PR TITLE
Workaround test error in coverage build (kcov 339)

### DIFF
--- a/common/symbolic/expression/test/formula_test.cc
+++ b/common/symbolic/expression/test/formula_test.cc
@@ -29,6 +29,7 @@ using std::numeric_limits;
 using test::IsMemcpyMovable;
 
 namespace symbolic {
+namespace kcov339_avoidance_magic {
 namespace {
 
 using std::map;
@@ -1431,5 +1432,6 @@ TEST_F(SymbolicFormulaTest, EvaluateFormulasIncludingRandomVariables) {
 }
 
 }  // namespace
+}  // namespace kcov339_avoidance_magic
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
Add a dummy namespace to perturb the ELF header

Fixes CI failure https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-jammy-gcc-bazel-nightly-coverage/184/

See #17978

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21280)
<!-- Reviewable:end -->
