### PR TITLE
[multibody] Move out-of-class tree topology default comparisons to class definitions.

### DIFF
--- a/multibody/tree/multibody_tree_topology.cc
+++ b/multibody/tree/multibody_tree_topology.cc
@@ -4,14 +4,6 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-bool FrameTopology::operator==(const FrameTopology& other) const = default;
-
-bool MobilizerTopology::operator==(const MobilizerTopology& other) const =
-    default;
-
-bool JointActuatorTopology::operator==(
-    const JointActuatorTopology& other) const = default;
-
 bool MultibodyTreeTopology::operator==(
     const MultibodyTreeTopology& other) const {
   if (is_valid_ != other.is_valid_) return false;

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -114,7 +114,7 @@ struct FrameTopology {
 
   // Returns `true` if all members of `this` topology are exactly equal to the
   // members of `other`.
-  bool operator==(const FrameTopology& other) const;
+  bool operator==(const FrameTopology& other) const = default;
 
   // Index in the MultibodyPlant.
   FrameIndex index{0};
@@ -161,7 +161,7 @@ struct MobilizerTopology {
 
   // Returns `true` if all members of `this` topology are exactly equal to the
   // members of `other`.
-  bool operator==(const MobilizerTopology& other) const;
+  bool operator==(const MobilizerTopology& other) const = default;
 
   // Returns `true` if this Mobilizer connects these Frames.
   bool connects_frames(FrameIndex frame1, FrameIndex frame2) const {
@@ -212,7 +212,7 @@ struct MobilizerTopology {
 struct JointActuatorTopology {
   // Returns `true` if all members of `this` topology are exactly equal to the
   // members of `other`.
-  bool operator==(const JointActuatorTopology& other) const;
+  bool operator==(const JointActuatorTopology& other) const = default;
 
   // Unique index in the MultibodyTree.
   JointActuatorIndex index{0};


### PR DESCRIPTION
Fix for the nightly build error: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-x86-monterey-unprovisioned-clang-wheel-nightly-release/404/

It seems the clang used on that unprovisioned build doesn't have full support for [p2085r0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2085r0.html), so I've moved the out-of-class default comparisons into class definitions.