### PR TITLE
Silence various compiler warnings in CI logs

### DIFF
--- a/tools/workspace/common_robotics_utilities/package.BUILD.bazel
+++ b/tools/workspace/common_robotics_utilities/package.BUILD.bazel
@@ -49,6 +49,7 @@ cc_library(
         "include/common_robotics_utilities/zlib_helpers.hpp",
     ],
     includes = ["include"],
+    copts = ["-w"],
     linkstatic = True,
     deps = [
         "@eigen",

--- a/tools/workspace/conex_internal/vendor.bzl
+++ b/tools/workspace/conex_internal/vendor.bzl
@@ -50,6 +50,11 @@ def conex_cc_library(
     ]
     strip_include_prefix = "drake_vendor"
 
+    # Mac clang is angry about this.
+    copts = copts or []
+    if "-Wno-unused-but-set-variable" not in copts:
+        copts.append("-Wno-unused-but-set-variable")
+
     # Compile the static library.
     cc_library_vendored(
         name = name,

--- a/tools/workspace/csdp_internal/package.BUILD.bazel
+++ b/tools/workspace/csdp_internal/package.BUILD.bazel
@@ -55,6 +55,7 @@ cc_library(
         "includes/csdp/parameters.h",
     ],
     copts = [
+        "-Wno-deprecated-non-prototype",
         "-Wno-unknown-pragmas",
         "-Wno-unused-variable",
         "-fvisibility=hidden",

--- a/tools/workspace/qhull_internal/package.BUILD.bazel
+++ b/tools/workspace/qhull_internal/package.BUILD.bazel
@@ -60,6 +60,7 @@ cc_library(
     hdrs = _HDRS_C,
     copts = [
         "-fvisibility=hidden",
+        "-w",
     ],
     includes = ["src"],
     srcs = _SRCS_C,


### PR DESCRIPTION
  - Drake code:
    - antiquated use of `move` instead of `std::move` restored to standard.
    - Initialization of scalar corrected (no need for braces).
  - Externals
    - qhull_internal c-code has unused but initialized variables.
    - common_robotics_utilities has an unnecessary lambda capture
    - csdp has a host of C-functions definitions without prototypes
     (mac uniquely barks about that)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21292)
<!-- Reviewable:end -->
