### PR TITLE
[WIP] Updates default contact approximation to use the SAP solver

### DIFF
--- a/examples/multibody/deformable/bubble_gripper.cc
+++ b/examples/multibody/deformable/bubble_gripper.cc
@@ -74,8 +74,9 @@ int do_main() {
   MultibodyPlantConfig plant_config;
   DRAKE_DEMAND(FLAGS_discrete_time_step > 0.0);
   plant_config.time_step = FLAGS_discrete_time_step;
-  /* Deformable simulation only works with SAP solver. */
-  plant_config.discrete_contact_approximation = "sap";
+  /* Deformable simulation only works with approximations that use the SAP
+   solver. */
+  plant_config.discrete_contact_approximation = "similar";
 
   auto [plant, scene_graph] = AddMultibodyPlant(plant_config, &builder);
 
@@ -137,8 +138,10 @@ int do_main() {
 
   /* Minimally required proximity properties for deformable bodies: A valid
    Coulomb friction coefficient. */
+  const double hunt_crossley_dissipation = 20.0;
   ProximityProperties deformable_proximity_props;
-  AddContactMaterial({}, {}, surface_friction, &deformable_proximity_props);
+  AddContactMaterial(hunt_crossley_dissipation, {}, surface_friction,
+                     &deformable_proximity_props);
 
   /* The mesh we render in the camera sim. */
   PerceptionProperties perception_properties;

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -307,7 +307,8 @@ MultibodyPlant<T>::MultibodyPlant(double time_step)
   DRAKE_DEMAND(discrete_contact_approximation_ ==
                DiscreteContactApproximation::kTamsi);
   DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_solver == "");
-  DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_approximation == "");
+  DRAKE_DEMAND(MultibodyPlantConfig{}.discrete_contact_approximation ==
+               "similar");
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant_config.h
+++ b/multibody/plant/multibody_plant_config.h
@@ -86,7 +86,7 @@ struct MultibodyPlantConfig {
   /// discrete_contact_solver, see set_discrete_contact_solver(). If both
   /// discrete_contact_solver and discrete_contact_approximation are empty, the
   /// default model (and solver) is TAMSI.
-  std::string discrete_contact_approximation{""};
+  std::string discrete_contact_approximation{"similar"};
 
   // TODO(amcastro-tri): Change default to zero, or simply eliminate.
   /// Non-negative dimensionless number typically in the range [0.0, 1.0],


### PR DESCRIPTION
This PR effectively makes SAP our default contact solver.
Towards #19322.
This does not address #21225 just yet (though we could).