### PR TITLE
DrakeVisualizer uses driven mesh data

### DIFF
--- a/bindings/pydrake/visualization/_meldis.py
+++ b/bindings/pydrake/visualization/_meldis.py
@@ -782,6 +782,9 @@ class Meldis:
         self._subscribe(channel="DRAKE_VIEWER_DRAW_ILLUSTRATION",
                         message_type=lcmt_viewer_draw,
                         handler=illustration_viewer.on_viewer_draw)
+        self._subscribe(channel="DRAKE_VIEWER_DEFORMABLE_ILLUSTRATION",
+                        message_type=lcmt_viewer_link_data,
+                        handler=default_viewer.on_viewer_draw_deformable)
         self._poll(handler=illustration_viewer.on_poll)
 
         proximity_viewer = _ViewerApplet(meshcat=self.meshcat,
@@ -795,6 +798,9 @@ class Meldis:
         self._subscribe(channel="DRAKE_VIEWER_DRAW_PROXIMITY",
                         message_type=lcmt_viewer_draw,
                         handler=proximity_viewer.on_viewer_draw)
+        self._subscribe(channel="DRAKE_VIEWER_DEFORMABLE_PROXIMITY",
+                        message_type=lcmt_viewer_link_data,
+                        handler=default_viewer.on_viewer_draw_deformable)
         self._poll(handler=proximity_viewer.on_poll)
 
         contact = _ContactApplet(meshcat=self.meshcat)

--- a/examples/multibody/deformable/bubble_gripper.cc
+++ b/examples/multibody/deformable/bubble_gripper.cc
@@ -35,6 +35,7 @@ using drake::geometry::Mesh;
 using drake::geometry::PerceptionProperties;
 using drake::geometry::ProximityProperties;
 using drake::geometry::RenderEngineGlParams;
+using drake::geometry::Rgba;
 using drake::math::RigidTransformd;
 using drake::math::RollPitchYawd;
 using drake::math::RotationMatrixd;
@@ -220,6 +221,12 @@ int do_main() {
                       Vector3d(-0.17, 0, 0)),
       std::move(teddy_mesh), "teddy");
   teddy_instance->set_proximity_properties(deformable_proximity_props);
+  /* Give the teddy bear a brown color for illustration to better distinguish it
+   from the bubble gripper in the visualizer. */
+  IllustrationProperties teddy_illustration_props;
+  teddy_illustration_props.AddProperty("phong", "diffuse",
+                                       Rgba(0.82, 0.71, 0.55, 1.0));
+  teddy_instance->set_illustration_properties(teddy_illustration_props);
   deformable_model->RegisterDeformableBody(std::move(teddy_instance),
                                            teddy_config, 1.0);
   plant.AddPhysicalModel(std::move(owned_deformable_model));

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -177,7 +177,7 @@ lcmt_viewer_geometry_data MakeHydroMesh(GeometryId geometry_id,
 }
 
 /* Create an lcm message for a deformable mesh representation of the geometry
- described by `deformable_data`.
+ described by the input parameters.
 
  The geometry data message is marked as a MESH, but rather than having a
  path to a parseable file stored in it, the actual mesh data is stored.
@@ -185,13 +185,21 @@ lcmt_viewer_geometry_data MakeHydroMesh(GeometryId geometry_id,
  geometry is set to identity because the vertex positions are expressed in the
  world frame.
 
- When the Mesh shape specification supports in-memory mesh definitions, this
- can be rolled into ShapeToLcm and it will more fully share that class's code
- for handling color. */
+ @param[in] name              The name of the geometry.
+ @param[in] vertex_positions  The positions of the mesh vertices in the world
+                              frame.
+ @param[in] render_mesh       Describes the connectivity and the material of the
+                              mesh. Other information from render_mesh (e.g the
+                              uv coordinates and the normals) are unused.
+                              Currently only the diffuse color part of the
+                              material is used. Other information about the
+                              material is discarded.
+ @param[in] default_diffuse   The diffuse color of the geometry if no material
+                              is specified in `render_mesh`. */
 template <typename T>
 lcmt_viewer_geometry_data MakeDeformableSurfaceMesh(
-    const VectorX<T>& volume_vertex_positions,
-    const internal::DeformableMeshData& deformable_data, const Rgba& in_color) {
+    const std::string& name, const VectorX<T>& vertex_positions,
+    const internal::RenderMesh& render_mesh, const Rgba& default_diffuse) {
   lcmt_viewer_geometry_data geometry_data;
   // The pose is unused and set to identity.
   geometry_data.quaternion[0] = 1;
@@ -202,9 +210,16 @@ lcmt_viewer_geometry_data MakeDeformableSurfaceMesh(
   geometry_data.position[1] = 0;
   geometry_data.position[2] = 0;
 
-  geometry_data.string_data = deformable_data.name;
+  geometry_data.string_data = name;
 
-  EigenMapView(geometry_data.color) = in_color.rgba().cast<float>();
+  // Right now we only support a single diffuse color as the visualization
+  // material. Textures are not supported. If a material is specified in the
+  // given render mesh, use its diffuse color; otherwise use the default diffuse
+  // color.
+  const Rgba& diffuse_color = render_mesh.material.has_value()
+                                  ? render_mesh.material->diffuse
+                                  : default_diffuse;
+  EigenMapView(geometry_data.color) = diffuse_color.rgba().cast<float>();
 
   // We can define the mesh in the float data as:
   // V | T | v0 | v1 | ... vN | t0 | t1 | ... | tM
@@ -214,9 +229,11 @@ lcmt_viewer_geometry_data MakeDeformableSurfaceMesh(
   //   N: 3V, the number of floating point values for the V vertices.
   //   M: 3T, the number of vertex indices for the T triangles.
   geometry_data.type = geometry_data.MESH;
-
-  const int num_tris = deformable_data.surface_triangles.size();
-  const int num_verts = deformable_data.surface_to_volume_vertices.size();
+  const Eigen::Matrix<unsigned int, Eigen::Dynamic, 3, Eigen::RowMajor>&
+      triangles = render_mesh.indices;
+  const int num_tris = render_mesh.indices.rows();
+  const int num_verts = render_mesh.positions.rows();
+  DRAKE_DEMAND(3 * num_verts == vertex_positions.size());
   const int header_floats = 2;
   geometry_data.num_float_data = header_floats + 3 * num_tris + 3 * num_verts;
   geometry_data.float_data.resize(geometry_data.num_float_data);
@@ -233,18 +250,12 @@ lcmt_viewer_geometry_data MakeDeformableSurfaceMesh(
   int t_index = t_start_index - 1;
 
   for (int f = 0; f < num_tris; ++f) {
-    const Vector3<int>& face = deformable_data.surface_triangles[f];
     for (int fv = 0; fv < 3; ++fv) {
-      float_data[++t_index] = face[fv];
+      float_data[++t_index] = triangles(f, fv);
     }
   }
-  for (int i = 0; i < num_verts; ++i) {
-    // v_i is the index into the volume mesh
-    const int v_i = deformable_data.surface_to_volume_vertices[i];
-    for (int d = 0; d < 3; ++d) {
-      float_data[++v_index] =
-          ExtractDoubleOrThrow(volume_vertex_positions[3 * v_i + d]);
-    }
+  for (int i = 0; i < 3 * num_verts; ++i) {
+    float_data[++v_index] = ExtractDoubleOrThrow(vertex_positions[i]);
   }
   // v_index and t_index end with the index of the last element added, so one
   // less than the expected number, hence the "+ 1". So, the vertex index should
@@ -253,120 +264,6 @@ lcmt_viewer_geometry_data MakeDeformableSurfaceMesh(
   DRAKE_DEMAND(header_floats + 3 * num_verts == (v_index + 1));
   DRAKE_DEMAND(geometry_data.num_float_data == (t_index + 1));
   return geometry_data;
-}
-
-/* Analyzes the tetrahedral mesh topology of the deformble geometry with `g_id`
- to do the following:
-  1. Build a surface mesh from each volume mesh.
-  2. Create a mapping from surface vertex to volume vertex for each mesh.
-  3. Record the expected number of vertices referenced by each tet mesh.
- Store the results in DeformableMeshData.
- @pre g_id corresponds to a deformable geometry. */
-template <typename T>
-internal::DeformableMeshData MakeDeformableMeshData(
-    GeometryId g_id, const SceneGraphInspector<T>& inspector) {
-  /* For each tet mesh, extract all the border triangles. Those are the
-   triangles that are only referenced by a single tet. So, for every tet, we
-   examine its four constituent triangle and determine if any other tet
-   shares it. Any triangle that is only referenced once is a border triangle.
-   Each triangle has a unique key: a SortedTriplet (so the ordering of the
-   triangle vertex indices won't matter). The first time we see a triangle, we
-   add it to a map. The second time we see the triangle, we remove it. When
-   we're done, the keys in the map will be those triangles referenced only once.
-   The values in the map represent the triangle, with the vertex indices
-   ordered so that they point *out* of the tetrahedron. Therefore,
-   they will also point outside of the mesh. A typical tetrahedral element
-   looks like:
-
-       p2 *
-          |
-          |
-       p3 *---* p0
-         /
-        /
-    p1 *
-
-   The index order for a particular tetrahedron has the order [p0, p1, p2,
-   p3]. These local indices enumerate each of the tet triangles with
-   outward-pointing normals with respect to the right-hand rule. */
-  const array<array<int, 3>, 4> local_indices{
-      {{{1, 0, 2}}, {{3, 0, 1}}, {{3, 1, 2}}, {{2, 0, 3}}}};
-
-  const VolumeMesh<double>* mesh = inspector.GetReferenceMesh(g_id);
-  DRAKE_DEMAND(mesh != nullptr);
-
-  std::map<SortedTriplet<int>, array<int, 3>> border_triangles;
-  for (const VolumeElement& tet : mesh->tetrahedra()) {
-    for (const array<int, 3>& tet_triangle : local_indices) {
-      const array<int, 3> tri{tet.vertex(tet_triangle[0]),
-                              tet.vertex(tet_triangle[1]),
-                              tet.vertex(tet_triangle[2])};
-      const SortedTriplet triangle_key(tri[0], tri[1], tri[2]);
-      // Here we rely on the fact that at most two tets would share a common
-      // triangle.
-      if (auto itr = border_triangles.find(triangle_key);
-          itr != border_triangles.end()) {
-        border_triangles.erase(itr);
-      } else {
-        border_triangles[triangle_key] = tri;
-      }
-    }
-  }
-  /* Record the expected minimum number of vertex positions to be received.
-   For simplicity we choose a generous upper bound: the total number of
-   vertices in the tetrahedral mesh, even though we really only need the
-   positions of the vertices on the surface. */
-  // TODO(xuchenhan-tri) It might be worthwhile to make largest_index the
-  //  largest index that lies on the surface. Then, when we create our meshes,
-  //  if we intentionally construct them so that the surface vertices come
-  //  first, we will process a very compact representation.
-  const int volume_vertex_count = mesh->num_vertices();
-
-  /* Using a set because the vertices will be nicely ordered. Ideally, we'll
-   be extracting a subset of the vertex positions from the input port. We
-   optimize cache coherency if we march in a monotonically increasing pattern.
-   So, we'll map triangle vertex indices to volume vertex indices in a
-   strictly monotonically increasing relationship. */
-  set<int> unique_vertices;
-  for (const auto& [triangle_key, triangle] : border_triangles) {
-    unused(triangle_key);
-    for (int j = 0; j < 3; ++j) unique_vertices.insert(triangle[j]);
-  }
-
-  /* This is the *second* documented responsibility of this function: Populate
-   the mapping from surface to volume so that we can efficiently extract the
-   *surface* vertex positions from the *volume* vertex input. */
-  vector<int> surface_to_volume_vertices;
-  surface_to_volume_vertices.insert(surface_to_volume_vertices.begin(),
-                                    unique_vertices.begin(),
-                                    unique_vertices.end());
-
-  /* The border triangles all include indices into the volume vertices. To turn
-   them into surface triangles, they need to include indices into the surface
-   vertices. Create the volume index --> surface map to facilitate the
-   transformation. */
-  const int surface_vertex_count =
-      static_cast<int>(surface_to_volume_vertices.size());
-  map<int, int> volume_to_surface;
-  for (int j = 0; j < surface_vertex_count; ++j) {
-    volume_to_surface[surface_to_volume_vertices[j]] = j;
-  }
-
-  /* This is the *first* documented responsibility: Create the topology of the
-   surface triangle mesh for each volume mesh. Each triangle consists of three
-   indices into the set of *surface* vertex positions. */
-  vector<Vector3<int>> surface_triangles;
-  surface_triangles.reserve(border_triangles.size());
-  for (auto& [triangle_key, face] : border_triangles) {
-    unused(triangle_key);
-    surface_triangles.emplace_back(volume_to_surface[face[0]],
-                                   volume_to_surface[face[1]],
-                                   volume_to_surface[face[2]]);
-  }
-
-  // TODO(xuchenhan-tri): Read the color of the mesh from properties.
-  return {g_id, inspector.GetName(g_id), std::move(surface_to_volume_vertices),
-          std::move(surface_triangles), volume_vertex_count};
 }
 
 // Simple class for converting shape specifications into LCM-compatible shapes.
@@ -630,11 +527,6 @@ DrakeVisualizer<T>::DrakeVisualizer(lcm::DrakeLcmInterface* lcm,
                               &DrakeVisualizer<T>::CalcDynamicFrameData,
                               {this->nothing_ticket()})
           .cache_index();
-  deformable_data_cache_index_ =
-      this->DeclareCacheEntry("deformable_data",
-                              &DrakeVisualizer<T>::CalcDeformableMeshData,
-                              {this->nothing_ticket()})
-          .cache_index();
 }
 
 template <typename T>
@@ -657,15 +549,13 @@ EventStatus DrakeVisualizer<T>::SendGeometryMessage(
     SendLoadNonDeformableMessage(
         query_object.inspector(), params_, RefreshDynamicFrameData(context),
         ExtractDoubleOrThrow(context.get_time()), lcm_);
-    RefreshDeformableMeshData(context);
   }
 
   SendDrawNonDeformableMessage(query_object, params_,
                                EvalDynamicFrameData(context),
                                ExtractDoubleOrThrow(context.get_time()), lcm_);
   SendDeformableGeometriesMessage(
-      query_object, params_, EvalDeformableMeshData(context),
-      ExtractDoubleOrThrow(context.get_time()), lcm_);
+      query_object, params_, ExtractDoubleOrThrow(context.get_time()), lcm_);
 
   return EventStatus::Succeeded();
 }
@@ -678,9 +568,11 @@ void DrakeVisualizer<T>::SendLoadNonDeformableMessage(
     lcm::DrakeLcmInterface* lcm) {
   lcmt_viewer_load_robot message{};
 
-  // Add the world frame if it has geometries with the specified role.
-  const int anchored_count = inspector.NumGeometriesForFrameWithRole(
-      inspector.world_frame_id(), params.role);
+  // Add the world frame if it has rigid geometries with the specified role.
+  const int anchored_count =
+      inspector.NumGeometriesForFrameWithRole(inspector.world_frame_id(),
+                                              params.role) -
+      inspector.NumDeformableGeometriesWithRole(params.role);
   const int frame_count =
       static_cast<int>(dynamic_frames.size()) + (anchored_count > 0 ? 1 : 0);
 
@@ -801,30 +693,31 @@ void DrakeVisualizer<T>::SendDrawNonDeformableMessage(
 template <typename T>
 void DrakeVisualizer<T>::SendDeformableGeometriesMessage(
     const QueryObject<T>& query_object, const DrakeVisualizerParams& params,
-    const vector<internal::DeformableMeshData>& deformable_data, double time,
-    lcm::DrakeLcmInterface* lcm) {
+    double time, lcm::DrakeLcmInterface* lcm) {
   lcmt_viewer_link_data message{};
   message.name = "deformable_geometries";
   message.robot_num = 0;  // robot_num = 0 corresponds to world frame.
-  message.num_geom = deformable_data.size();
-  message.geom.resize(message.num_geom);
-  for (int i = 0; i < message.num_geom; ++i) {
-    const internal::DeformableMeshData& data = deformable_data[i];
-    const GeometryId g_id = data.geometry_id;
-    const VectorX<T>& vertex_positions =
-        query_object.GetConfigurationsInWorld(g_id);
-    if (vertex_positions.size() <= data.volume_vertex_count) {
-      throw std::logic_error(fmt::format(
-          "For mesh named '{}', The number of given vertex positions "
-          "({}) is smaller than the "
-          "minimum expected number of positions ({}).",
-          data.name, vertex_positions.size(), data.volume_vertex_count));
+  const SceneGraphInspector<T>& inspector = query_object.inspector();
+  const std::vector<GeometryId> deformable_geometries =
+      inspector.GetAllDeformableGeometryIds();
+  for (const auto& g_id : deformable_geometries) {
+    // If the geometry doesn't have the role that the visualizer wants to
+    // visualize, skip it.
+    if (inspector.GetProperties(g_id, params.role) == nullptr) {
+      continue;
     }
-    // TODO(xuchenhan-tri): We should use the color from the property of the
-    // geometry when available.
-    message.geom[i] =
-        MakeDeformableSurfaceMesh(vertex_positions, data, params.default_color);
+    const std::vector<internal::RenderMesh>& render_meshes =
+        inspector.GetDrivenRenderMeshes(g_id, params.role);
+    const std::vector<VectorX<T>> vertex_positions =
+        query_object.GetDrivenMeshConfigurationsInWorld(g_id, params.role);
+    DRAKE_DEMAND(ssize(vertex_positions) == ssize(render_meshes));
+    for (int j = 0; j < ssize(vertex_positions); ++j) {
+      message.geom.emplace_back(MakeDeformableSurfaceMesh(
+          inspector.GetName(g_id), vertex_positions[j], render_meshes[j],
+          params.default_color));
+    }
   }
+  message.num_geom = message.geom.size();
   std::string channel =
       MakeLcmChannelNameForRole("DRAKE_VIEWER_DEFORMABLE", params);
   lcm::Publish(lcm, channel, message, time);
@@ -879,40 +772,6 @@ void DrakeVisualizer<T>::PopulateDynamicFrameData(
                                     "::" + inspector.GetName(frame_id)});
     }
   }
-}
-
-template <typename T>
-void DrakeVisualizer<T>::CalcDeformableMeshData(
-    const Context<T>& context,
-    vector<internal::DeformableMeshData>* deformable_data) const {
-  DRAKE_DEMAND(deformable_data != nullptr);
-  deformable_data->clear();
-  const auto& query_object =
-      query_object_input_port().template Eval<QueryObject<T>>(context);
-  const auto& inspector = query_object.inspector();
-  const std::vector<GeometryId> deformable_geometries =
-      inspector.GetAllDeformableGeometryIds();
-  for (const auto g_id : deformable_geometries) {
-    deformable_data->emplace_back(MakeDeformableMeshData(g_id, inspector));
-  }
-}
-
-template <typename T>
-const vector<internal::DeformableMeshData>&
-DrakeVisualizer<T>::RefreshDeformableMeshData(const Context<T>& context) const {
-  // We'll need to make sure our knowledge of deformable data can get updated.
-  this->get_cache_entry(deformable_data_cache_index_)
-      .get_mutable_cache_entry_value(context)
-      .mark_out_of_date();
-
-  return EvalDeformableMeshData(context);
-}
-
-template <typename T>
-const vector<internal::DeformableMeshData>&
-DrakeVisualizer<T>::EvalDeformableMeshData(const Context<T>& context) const {
-  return this->get_cache_entry(deformable_data_cache_index_)
-      .template Eval<vector<internal::DeformableMeshData>>(context);
 }
 
 template <typename T>

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -33,24 +33,6 @@ struct DynamicFrameData {
   std::string name;
 };
 
-/* Helper data structure to hold the topology information necessary to visualize
- the surface of a volume mesh. */
-struct DeformableMeshData {
-  GeometryId geometry_id;
-  /* The name of the deformable mesh. Included in all lcm messages.  */
-  std::string name;
-  /* An *implicit* map from *surface* vertex indices to volume vertex indices.
-   The iᵗʰ surface vertex corresponds to the volume vertex with index
-   `surface_to_volume_vertices_[i]`.  */
-  std::vector<int> surface_to_volume_vertices;
-  /* Surface triangle mesh representing the topology of the volume mesh's
-   surfaces. Each triangle is encoded with three index values that are keys for
-   surface_to_volume_vertices. */
-  std::vector<Vector3<int>> surface_triangles;
-  /* The total number of vertices implied by the tetrahedra definitions.  */
-  int volume_vertex_count{};
-};
-
 /* If requested in @p params, adds a suffix to the provided LCM channel name,
  based on the geometry role. If a suffix is requested, the passed role
  parameter cannot be kUnassigned. See also DrakeVisualizerParams. */
@@ -117,7 +99,7 @@ std::string MakeLcmChannelNameForRole(const std::string& channel,
  | :--------: | :------: | :-----------: | :-------------: | :------------------- |
  |    phong   | no       | diffuse       |     Rgba        | The rgba value of the object surface. |
 
- <h4>Appearance of OBJ files</h4>
+ <h4>Appearance of OBJ files for non-deformable geometries</h4>
 
  Meshes represented by OBJ are special. The OBJ file can reference a material
  file (.mtl). If the mtl file is found by the receiving application, values in
@@ -281,7 +263,6 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
    configuration of all deformable geometries at a given time. */
   static void SendDeformableGeometriesMessage(
       const QueryObject<T>& query_object, const DrakeVisualizerParams& params,
-      const std::vector<internal::DeformableMeshData>& deformable_data,
       double time, lcm::DrakeLcmInterface* lcm);
 
   /* Identifies all of the frames with dynamic data and stores them (with
@@ -308,22 +289,6 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
       const SceneGraphInspector<T>& inspector,
       const DrakeVisualizerParams& params,
       std::vector<internal::DynamicFrameData>* frame_data);
-
-  /* Identifies all of the deformable geometries to be visualized and adds the
-   required visualization data to the `deformable_data`.
-   @note `deformable_data` is cleared before any data is added.
-   @note There are no guarantees on the order of the entries in
-        `deformable_data`. */
-  void CalcDeformableMeshData(
-      const systems::Context<T>& context,
-      std::vector<internal::DeformableMeshData>* deformable_data) const;
-
-  /* Recalculates and returns the cached deformable geometry data.  */
-  const std::vector<internal::DeformableMeshData>& RefreshDeformableMeshData(
-      const systems::Context<T>& context) const;
-
-  const std::vector<internal::DeformableMeshData>& EvalDeformableMeshData(
-      const systems::Context<T>& context) const;
 
   typename systems::LeafSystem<T>::GraphvizFragment DoGetGraphvizFragment(
       const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
@@ -361,9 +326,6 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
   /* The index of the cache entry that stores the dynamic frame data for
    non-deformable geometries. */
   systems::CacheIndex frame_data_cache_index_{};
-
-  /* The index of the cache entry that stores the deformable geometry data.  */
-  systems::CacheIndex deformable_data_cache_index_{};
 
   /* The parameters for the visualizer.  */
   DrakeVisualizerParams params_;

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -52,6 +52,10 @@ using systems::sensors::ImageRgba8U;
 
 namespace internal {
 
+DrivenMeshData::DrivenMeshData() = default;
+
+DrivenMeshData::~DrivenMeshData() = default;
+
 template <typename T>
 void DrivenMeshData::SetControlMeshPositions(
     const std::unordered_map<GeometryId, VectorX<T>>& q_WGs) {
@@ -170,6 +174,10 @@ GeometryState<T>::GeometryState()
   source_deformable_geometry_id_map_[self_source_] = {};
   source_frame_name_map_[self_source_] = {"world"};
   source_root_frame_map_[self_source_] = {world};
+
+  driven_mesh_data_[Role::kPerception] = {};
+  driven_mesh_data_[Role::kIllustration] = {};
+  driven_mesh_data_[Role::kProximity] = {};
 }
 
 namespace {
@@ -221,7 +229,7 @@ GeometryState<T>::GeometryState(const GeometryState<U>& source)
       frames_(source.frames_),
       geometries_(source.geometries_),
       frame_index_to_id_map_(source.frame_index_to_id_map_),
-      driven_perception_meshes_(source.driven_perception_meshes_),
+      driven_mesh_data_(source.driven_mesh_data_),
       geometry_engine_(
           std::move(source.geometry_engine_->template ToScalarType<T>())),
       render_engines_(source.render_engines_),
@@ -296,6 +304,15 @@ int GeometryState<T>::NumGeometriesWithRole(Role role) const {
   int count = 0;
   for (const auto& pair : geometries_) {
     if (pair.second.has_role(role)) ++count;
+  }
+  return count;
+}
+
+template <typename T>
+int GeometryState<T>::NumDeformableGeometriesWithRole(Role role) const {
+  int count = 0;
+  for (const auto& pair : geometries_) {
+    if (pair.second.has_role(role) && pair.second.is_deformable()) ++count;
   }
   return count;
 }
@@ -662,6 +679,21 @@ const VolumeMesh<double>* GeometryState<T>::GetReferenceMesh(
 }
 
 template <typename T>
+const std::vector<RenderMesh>& GeometryState<T>::GetDrivenRenderMeshes(
+    GeometryId id, Role role) const {
+  const InternalGeometry* geometry = GetGeometry(id);
+  DRAKE_THROW_UNLESS(role != Role::kUnassigned);
+  if (geometry == nullptr || !geometry->has_role(role) ||
+      !geometry->is_deformable()) {
+    throw std::logic_error(
+        fmt::format("Referenced geometry {} is not a registered deformable "
+                    "geometry with specified role {}",
+                    id, role));
+  }
+  return driven_mesh_data_.at(role).render_meshes(id);
+}
+
+template <typename T>
 bool GeometryState<T>::IsDeformableGeometry(GeometryId id) const {
   const InternalGeometry& geometry = GetValueOrThrow(id, geometries_);
   return geometry.is_deformable();
@@ -801,6 +833,30 @@ const VectorX<T>& GeometryState<T>::get_configurations_in_world(
         "get_pose_in_world() instead.");
   }
   return kinematics_data_.q_WGs.at(geometry_id);
+}
+
+template <typename T>
+std::vector<VectorX<T>> GeometryState<T>::GetDrivenMeshConfigurationsInWorld(
+    GeometryId geometry_id, Role role) const {
+  FindOrThrow(geometry_id, geometries_, [geometry_id]() {
+    return "No mesh configurations available for invalid geometry id: " +
+           to_string(geometry_id);
+  });
+  const auto& geometry = GetValueOrThrow(geometry_id, geometries_);
+  DRAKE_THROW_UNLESS(geometry.is_deformable());
+  DRAKE_THROW_UNLESS(geometry.has_role(role));
+  DRAKE_THROW_UNLESS(role != Role::kUnassigned);
+
+  auto calc_configuration = [&](const internal::DrivenMeshData& data) {
+    std::vector<VectorX<T>> result;
+    DRAKE_THROW_UNLESS(data.driven_meshes().contains(geometry_id));
+    for (const auto& mesh : data.driven_meshes().at(geometry_id)) {
+      result.emplace_back(mesh.GetDrivenVertexPositions());
+    }
+    return result;
+  };
+
+  return calc_configuration(driven_mesh_data_.at(role));
 }
 
 template <typename T>
@@ -1155,6 +1211,13 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
     default:
       DRAKE_UNREACHABLE();
   }
+
+  // If the geometry is deformable, we need to register its driven meshes. We
+  // always blindly throw out the old driven mesh data and replace it with a new
+  // driven mesh data.
+  if (geometry.is_deformable()) {
+    RegisterDrivenMesh(geometry_id, Role::kProximity);
+  }
 }
 
 template <typename T>
@@ -1176,7 +1239,7 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
   geometry.SetRole(std::move(properties));
 
   if (geometry.is_deformable()) {
-    RegisterDrivenPerceptionMesh(geometry_id);
+    RegisterDrivenMesh(geometry_id, Role::kPerception);
   }
 
   const bool added_to_renderer = AddToCompatibleRenderersUnchecked(geometry);
@@ -1223,6 +1286,10 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
   geometry_version_.modify_illustration();
 
   geometry.SetRole(std::move(properties));
+
+  if (geometry.is_deformable()) {
+    RegisterDrivenMesh(geometry_id, Role::kIllustration);
+  }
 }
 
 template <typename T>
@@ -1355,7 +1422,8 @@ void GeometryState<T>::AddRenderer(
         const GeometryId id = id_geo_pair.first;
         if (geometry.is_deformable()) {
           accepted |= render_engine->RegisterDeformableVisual(
-              id, driven_perception_meshes_.render_meshes(id), *properties);
+              id, driven_mesh_data_.at(Role::kPerception).render_meshes(id),
+              *properties);
         } else {
           accepted |= render_engine->RegisterVisual(
               id, geometry.shape(), *properties,
@@ -1870,43 +1938,52 @@ bool GeometryState<T>::AddDeformableToCompatibleRenderersUnchecked(
   for (auto& engine : *candidate_renderers) {
     added_to_renderer =
         engine->RegisterDeformableVisual(
-            id, driven_perception_meshes_.render_meshes(id), properties) ||
+            id, driven_mesh_data_.at(Role::kPerception).render_meshes(id),
+            properties) ||
         added_to_renderer;
   }
   return added_to_renderer;
 }
 
 template <typename T>
-void GeometryState<T>::RegisterDrivenPerceptionMesh(GeometryId geometry_id) {
+void GeometryState<T>::RegisterDrivenMesh(GeometryId geometry_id, Role role) {
   InternalGeometry& geometry = geometries_[geometry_id];
   DRAKE_DEMAND(geometry.is_deformable());
-  DRAKE_DEMAND(geometry.has_perception_role());
-  const PerceptionProperties& properties = *geometry.perception_properties();
+  DRAKE_DEMAND(role != Role::kUnassigned);
+  DRAKE_DEMAND(geometry.has_role(role));
+  const GeometryProperties& properties = *geometry.properties(role);
 
   const VolumeMesh<double>* control_mesh_ptr = geometry.reference_mesh();
   DRAKE_DEMAND(control_mesh_ptr != nullptr);
   const VolumeMesh<double>& control_mesh = *control_mesh_ptr;
 
-  const string render_meshes_file =
-      properties.GetPropertyOrDefault("deformable", "embedded_mesh", string{});
   std::vector<RenderMesh> render_meshes;
   std::vector<DrivenTriangleMesh> driven_meshes;
-  if (render_meshes_file.empty()) {
-    // If no render mesh is specified, use the surface triangle mesh of the
-    // control volume mesh as the render mesh.
-    driven_meshes.emplace_back(internal::MakeDrivenSurfaceMesh(control_mesh));
-    render_meshes.emplace_back(MakeRenderMeshFromTriangleSurfaceMesh(
-        driven_meshes.back().triangle_surface_mesh(), properties));
-  } else {
-    render_meshes =
-        internal::LoadRenderMeshesFromObj(render_meshes_file, properties, {});
-    for (const internal::RenderMesh& render_mesh : render_meshes) {
-      driven_meshes.emplace_back(MakeTriangleSurfaceMesh(render_mesh),
-                                 control_mesh);
+
+  if (role == Role::kPerception) {
+    // TODO(xuchenhan-tri): consider allowing embedded mesh for illustration
+    // similar to the driven perception mesh.
+    const string render_meshes_file = properties.GetPropertyOrDefault(
+        "deformable", "embedded_mesh", string{});
+    if (!render_meshes_file.empty()) {
+      render_meshes =
+          internal::LoadRenderMeshesFromObj(render_meshes_file, properties, {});
+      for (const internal::RenderMesh& render_mesh : render_meshes) {
+        driven_meshes.emplace_back(MakeTriangleSurfaceMesh(render_mesh),
+                                   control_mesh);
+      }
+      driven_mesh_data_[Role::kPerception].SetMeshes(
+          geometry_id, std::move(driven_meshes), std::move(render_meshes));
+      return;
     }
   }
-  driven_perception_meshes_.SetMeshes(geometry_id, std::move(driven_meshes),
-                                      std::move(render_meshes));
+
+  // Simply go with the surface mesh of the control mesh.
+  driven_meshes.emplace_back(internal::MakeDrivenSurfaceMesh(control_mesh));
+  render_meshes.emplace_back(MakeRenderMeshFromTriangleSurfaceMesh(
+      driven_meshes.back().triangle_surface_mesh(), properties));
+  driven_mesh_data_[role].SetMeshes(geometry_id, std::move(driven_meshes),
+                                    std::move(render_meshes));
 }
 
 template <typename T>
@@ -1960,7 +2037,7 @@ bool GeometryState<T>::RemovePerceptionRole(GeometryId geometry_id) {
   // perception meshes.
   RemoveFromAllRenderersUnchecked(geometry_id);
   if (IsDeformableGeometry(geometry_id)) {
-    driven_perception_meshes_.Remove(geometry_id);
+    driven_mesh_data_[Role::kPerception].Remove(geometry_id);
   }
   geometry->RemovePerceptionRole();
   return true;

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <optional>
 #include <set>
@@ -88,7 +89,9 @@ class DrivenMeshData {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DrivenMeshData);
 
-  DrivenMeshData() = default;
+  DrivenMeshData();
+
+  ~DrivenMeshData();
 
   // Updates the control mesh vertex positions for all driven meshes.
   // @param[in] q_WGs  q_WGs.at(id) contains control mesh vertex positions as a
@@ -214,6 +217,10 @@ class GeometryState {
 
   /** Implementation of SceneGraphInspector::NumGeometriesWithRole().  */
   int NumGeometriesWithRole(Role role) const;
+
+  /** Implementation of
+   SceneGraphInspector::NumDeformableGeometriesWithRole().  */
+  int NumDeformableGeometriesWithRole(Role role) const;
 
   /** Implementation of SceneGraphInspector::NumDynamicGeometries().  */
   int NumDynamicGeometries() const;
@@ -345,6 +352,11 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::GetReferenceMesh().  */
   const VolumeMesh<double>* GetReferenceMesh(GeometryId id) const;
 
+  /** Implementation of
+   SceneGraphInspector::GetDrivenRenderMeshes().  */
+  const std::vector<internal::RenderMesh>& GetDrivenRenderMeshes(
+      GeometryId id, Role role) const;
+
   /** Implementation of SceneGraphInspector::IsDeformableGeometry(). */
   bool IsDeformableGeometry(GeometryId id) const;
 
@@ -378,6 +390,10 @@ class GeometryState {
 
   /** Implementation of QueryObject::GetConfigurationsInWorld().  */
   const VectorX<T>& get_configurations_in_world(GeometryId geometry_id) const;
+
+  /** Implementation of QueryObject::GetDrivenMeshConfigurationsInWorld().  */
+  std::vector<VectorX<T>> GetDrivenMeshConfigurationsInWorld(
+      GeometryId geometry_id, Role role) const;
   //@}
 
   /** @name        State management
@@ -845,18 +861,23 @@ class GeometryState {
       const internal::InternalGeometry& geometry,
       std::vector<render::RenderEngine*>* candidate_renderers);
 
-  // Adds the driven mesh used for rendering the deformable geometry with the
-  // given `geometry_id`. The driven mesh is the surface triangle mesh of the
-  // control volume mesh unless the geometry's PerceptionProperties contain the
-  // ("deformable", "embedded_mesh") property containing a valid path to a
-  // surface mesh. In that case, that user-prescribed mesh will be the driven
-  // mesh.
-  // @throws std::exception if the ("deformable", "embedded_mesh") property is
-  // present and does not contain a path to a surface mesh that's completely
-  // contained within the control volume mesh.
+  // Adds the driven mesh for the deformable geometry with the given
+  // `geometry_id` for the given role. The nature of the driven mesh depends on
+  // the role and the geometry's properties for that role. Generally, it is
+  // simply the surface triangle mesh of the control volume mesh. However,
+  // the perception properties can define the ("deformable", "embedded_mesh")
+  // property containing a valid path to a surface mesh. In that case, that
+  // user-prescribed mesh will be the driven mesh.
+  // @throws std::exception if role is kPerception and the
+  // ("deformable", "embedded_mesh") property is present with a non-empty string
+  // value and that value does not contain a path to a surface mesh that's
+  // completely contained within the control volume mesh.
   // @pre The geometry associated with `geometry_id` is a deformable geometry
-  // registered with `this` GeometryState.
-  void RegisterDrivenPerceptionMesh(GeometryId geometry_id);
+  // registered with `this` GeometryState with the given `role`.
+  // @pre `role` is not Role::kUnassigned.
+  // @note if driven meshes are already registered for the given `geometry_id`,
+  // they will be replaced with the new driven mesh.
+  void RegisterDrivenMesh(GeometryId geometry_id, Role role);
 
   // Attempts to remove the geometry with the given id from *all* render
   // engines. The only GeometryState-level data structure modified is the
@@ -918,11 +939,13 @@ class GeometryState {
     return mutable_state->kinematics_data_;
   }
 
-  // Returns a mutable reference to the driven perception meshes in this
-  // GeometryState.
-  internal::DrivenMeshData& mutable_driven_perception_meshes() const {
+  // Returns a mutable reference to the driven meshes with the given role in
+  // this GeometryState.
+  // @pre role is not Role::kUnassigned.
+  internal::DrivenMeshData& mutable_driven_mesh_data(Role role) const {
+    DRAKE_DEMAND(role != Role::kUnassigned);
     GeometryState<T>* mutable_state = const_cast<GeometryState<T>*>(this);
-    return mutable_state->driven_perception_meshes_;
+    return mutable_state->driven_mesh_data_[role];
   }
 
   // Returns a mutable reference to the proximity engine in this GeometryState.
@@ -1009,9 +1032,9 @@ class GeometryState {
   // are two invariants.
   internal::KinematicsData<T> kinematics_data_;
 
-  // Mesh representations for deformable geometries with perception roles that
-  // move passively with the simulated control mesh.
-  internal::DrivenMeshData driven_perception_meshes_;
+  // Mesh representations for deformable geometries that move passively with the
+  // simulated control mesh, keyed by roles.
+  std::map<Role, internal::DrivenMeshData> driven_mesh_data_;
 
   // The underlying geometry engine. The topology of the engine does _not_
   // change with respect to time. But its values do. This straddles the two

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -54,6 +54,23 @@ bool InternalGeometry::has_role(Role role) const {
   DRAKE_UNREACHABLE();
 }
 
+const GeometryProperties* InternalGeometry::properties(Role role) const {
+  switch (role) {
+    case Role::kUnassigned:
+      return nullptr;
+    case Role::kProximity:
+      return proximity_properties();
+      break;
+    case Role::kIllustration:
+      return illustration_properties();
+      break;
+    case Role::kPerception:
+      return perception_properties();
+      break;
+  }
+  DRAKE_UNREACHABLE();
+}
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -188,6 +188,11 @@ class InternalGeometry {
   /* Reports if the geometry has a perception role. */
   bool has_perception_role() const { return perception_props_ != std::nullopt; }
 
+  /* Returns a pointer to the geometry's properties associated with the given
+   `role` (if they are defined). Nullptr otherwise. Always returns the nullptr
+   for Role::kUnassigned. */
+  const GeometryProperties* properties(Role role) const;
+
   /* Returns a pointer to the geometry's proximity properties (if they are
    defined. Nullptr otherwise.  */
   const ProximityProperties* proximity_properties() const {

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -95,6 +95,15 @@ const VectorX<T>& QueryObject<T>::GetConfigurationsInWorld(
 }
 
 template <typename T>
+std::vector<VectorX<T>> QueryObject<T>::GetDrivenMeshConfigurationsInWorld(
+    GeometryId geometry_id, Role role) const {
+  ThrowIfNotCallable();
+  FullConfigurationUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.GetDrivenMeshConfigurationsInWorld(geometry_id, role);
+}
+
+template <typename T>
 std::vector<PenetrationAsPointPair<T>>
 QueryObject<T>::ComputePointPairPenetration() const {
   ThrowIfNotCallable();

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -172,13 +172,25 @@ class QueryObject {
   const math::RigidTransform<T>& GetPoseInWorld(GeometryId geometry_id) const;
 
   /** Reports the configuration of the deformable geometry indicated by
-   `geometry_id` relative to the world frame.
+   `deformable_geometry_id` relative to the world frame.
    @sa GetPoseInWorld().
-   @throws std::exception if the geometry `geometry_id` is not valid or is not
-   a deformable geometry.  */
+   @throws std::exception if the geometry `deformable_geometry_id` is not valid
+   or is not a deformable geometry.  */
   const VectorX<T>& GetConfigurationsInWorld(
       GeometryId deformable_geometry_id) const;
 
+  // TODO(xuchenhan-tri): This should cross reference the concept of driven
+  // meshes when it is nicely written up somewhere (e.g., in the SceneGraph
+  // documentation).
+  /** Reports the configurations of the driven meshes associated with the given
+   role for the deformable geometry indicated by `deformable_geometry_id`
+   relative to the world frame if the deformable geometry has that role.
+   @throws std::exception if the geometry associated with
+   `deformable_geometry_id` is not a registered deformable geometry with
+   the given role.
+   @experimental */
+  std::vector<VectorX<T>> GetDrivenMeshConfigurationsInWorld(
+      GeometryId deformable_geometry_id, Role role) const;
   //@}
 
   /**

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -540,8 +540,6 @@ void SceneGraph<T>::CalcConfigurationUpdate(const Context<T>& context,
   // needed and is correct.
   internal::KinematicsData<T>& kinematics_data =
       state.mutable_kinematics_data();
-  internal::DrivenMeshData& driven_perception_meshes =
-      state.mutable_driven_perception_meshes();
   // Process all sources *except*:
   //   - the internal source and
   //   - sources with no deformable geometries.
@@ -568,11 +566,14 @@ void SceneGraph<T>::CalcConfigurationUpdate(const Context<T>& context,
     }
   }
 
-  driven_perception_meshes.SetControlMeshPositions(kinematics_data.q_WGs);
-  state.FinalizeConfigurationUpdate(kinematics_data,
-                                    driven_perception_meshes,
-                                    &state.mutable_proximity_engine(),
-                                    state.GetMutableRenderEngines());
+  for (const auto role : std::vector<Role>{
+           Role::kIllustration, Role::kPerception, Role::kProximity}) {
+    state.mutable_driven_mesh_data(role).SetControlMeshPositions(
+        kinematics_data.q_WGs);
+  }
+  state.FinalizeConfigurationUpdate(
+      kinematics_data, state.mutable_driven_mesh_data(Role::kPerception),
+      &state.mutable_proximity_engine(), state.GetMutableRenderEngines());
 }
 
 template <typename T>

--- a/geometry/scene_graph_inspector.cc
+++ b/geometry/scene_graph_inspector.cc
@@ -62,6 +62,12 @@ int SceneGraphInspector<T>::NumGeometriesWithRole(Role role) const {
 }
 
 template <typename T>
+int SceneGraphInspector<T>::NumDeformableGeometriesWithRole(Role role) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->NumDeformableGeometriesWithRole(role);
+}
+
+template <typename T>
 int SceneGraphInspector<T>::NumDynamicGeometries() const {
   DRAKE_DEMAND(state_ != nullptr);
   return state_->NumDynamicGeometries();
@@ -261,6 +267,14 @@ const VolumeMesh<double>* SceneGraphInspector<T>::GetReferenceMesh(
     GeometryId geometry_id) const {
   DRAKE_DEMAND(state_ != nullptr);
   return state_->GetReferenceMesh(geometry_id);
+}
+
+template <typename T>
+const std::vector<internal::RenderMesh>&
+SceneGraphInspector<T>::GetDrivenRenderMeshes(GeometryId geometry_id,
+                                              Role role) const {
+  DRAKE_DEMAND(state_ != nullptr);
+  return state_->GetDrivenRenderMeshes(geometry_id, role);
 }
 
 template <typename T>

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -18,6 +18,7 @@
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/render/render_mesh.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -137,6 +138,10 @@ class SceneGraphInspector {
   /** Reports the _total_ number of geometries in the scene graph with the
    indicated role.  */
   int NumGeometriesWithRole(Role role) const;
+
+  /** Reports the _total_ number of _deformable_ geometries in the scene graph
+   with the indicated role.  */
+  int NumDeformableGeometriesWithRole(Role role) const;
 
   /** Reports the total number of _dynamic_ geometries in the scene graph. This
    include all deformable geometries.  */
@@ -391,6 +396,22 @@ class SceneGraphInspector {
    @throws std::exception if `geometry_id` does not map to a registered
            geometry.  */
   const VolumeMesh<double>* GetReferenceMesh(GeometryId geometry_id) const;
+
+  // TODO(xuchenhan-tri): This should cross reference the concept of driven
+  // meshes when it is nicely written up somewhere (e.g., in the SceneGraph
+  // documentation).
+  /** Returns the render mesh representation of the driven meshes associated
+   with the given `role` of the geometry with the given `geometry_id`.
+
+   @param geometry_id      The identifier for the queried geometry.
+   @param role             The role whose driven mesh representations are
+                           acquired.
+   @throws std::exception  if `geometry_id` does not map to a registered
+                           deformable geometry with the given `role` or if
+                           `role` is Role::kUnassigned.
+   @experimental */
+  const std::vector<internal::RenderMesh>& GetDrivenRenderMeshes(
+      GeometryId geometry_id, Role role) const;
 
   /** Returns true if the geometry with the given `geometry_id` is deformable.
    @param geometry_id   The identifier for the queried geometry.

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -130,9 +130,8 @@ class GeometryStateTester {
     return state_->mutable_kinematics_data();
   }
 
-  const std::unordered_map<GeometryId, std::vector<DrivenTriangleMesh>>&
-  driven_perception_meshes() const {
-    return state_->driven_perception_meshes_.driven_meshes();
+  const internal::DrivenMeshData& driven_mesh_data(Role role) const {
+    return state_->driven_mesh_data_.at(role);
   }
 
   void SetFramePoses(SourceId source_id, const FramePoseVector<T>& poses,
@@ -153,10 +152,13 @@ class GeometryStateTester {
   }
 
   void FinalizeConfigurationUpdate() {
-    state_->driven_perception_meshes_.SetControlMeshPositions(
-        state_->kinematics_data_.q_WGs);
+    for (const auto role : std::vector<Role>{
+             Role::kPerception, Role::kIllustration, Role::kProximity}) {
+      state_->driven_mesh_data_[role].SetControlMeshPositions(
+          state_->kinematics_data_.q_WGs);
+    }
     state_->FinalizeConfigurationUpdate(
-        state_->kinematics_data_, state_->driven_perception_meshes_,
+        state_->kinematics_data_, state_->driven_mesh_data_[Role::kPerception],
         &state_->mutable_proximity_engine(), state_->GetMutableRenderEngines());
   }
 
@@ -1377,10 +1379,10 @@ TEST_F(GeometryStateTest, GetGeometryIds) {
 
 // Tests the GetNum*Geometry*Methods.
 TEST_F(GeometryStateTest, GetNumGeometryTests) {
-  SetUpSingleSourceTree(Assign::kProximity);
-  EXPECT_EQ(single_tree_rigid_geometry_count(),
+  SetUpWithRigidAndDeformableGeometries(Assign::kProximity);
+  EXPECT_EQ(total_geometry_count(),
             geometry_state_.get_num_geometries());
-  EXPECT_EQ(single_tree_rigid_geometry_count(),
+  EXPECT_EQ(total_geometry_count(),
             geometry_state_.NumGeometriesWithRole(Role::kProximity));
   EXPECT_EQ(0, geometry_state_.NumGeometriesWithRole(Role::kPerception));
   EXPECT_EQ(0, geometry_state_.NumGeometriesWithRole(Role::kIllustration));
@@ -1395,6 +1397,13 @@ TEST_F(GeometryStateTest, GetNumGeometryTests) {
     EXPECT_EQ(0, geometry_state_.NumGeometriesForFrameWithRole(
                      frames_[i], Role::kIllustration));
   }
+
+  EXPECT_EQ(1,
+            geometry_state_.NumDeformableGeometriesWithRole(Role::kProximity));
+  EXPECT_EQ(0,
+            geometry_state_.NumDeformableGeometriesWithRole(Role::kPerception));
+  EXPECT_EQ(
+      0, geometry_state_.NumDeformableGeometriesWithRole(Role::kIllustration));
 }
 
 // Tests GetGeometries(FrameId, Role).
@@ -2091,6 +2100,85 @@ TEST_F(GeometryStateTest, SetGeometryConfiguration) {
   gs_tester_.FinalizeConfigurationUpdate();
   geometry_state_.ComputeDeformableContact(&contacts);
   ASSERT_EQ(contacts.contact_surfaces().size(), 0);
+}
+
+// Tests GetDrivenMeshConfigurationsInWorld and GetDrivenRenderMeshes.
+// We register the coarsest possible sphere mesh for a deformable geometry, use
+// the fact that the mesh is an octahedron, and confirm the driven meshes are
+// correctly registered and retrieved.
+TEST_F(GeometryStateTest, DrivenMeshes) {
+  const SourceId s_id = NewSource("new source");
+  auto deformable_instance = make_unique<GeometryInstance>(
+      RigidTransformd::Identity(), make_unique<Sphere>(1.0),
+      "deformable sphere");
+  deformable_instance->set_proximity_properties(ProximityProperties());
+  deformable_instance->set_perception_properties(PerceptionProperties());
+  // Specify the diffuse color for illustration properties only. This diffuse
+  // color should be captured by the material of the corresponding driven
+  // RenderMesh. The RenderMeshes for the other roles will not have a material.
+  IllustrationProperties illustration_properties;
+  illustration_properties.AddProperty("phong", "diffuse",
+                                      Rgba(0.1, 0.2, 0.3, 0.4));
+  deformable_instance->set_illustration_properties(illustration_properties);
+  // Make sure the resolution hint is large enough so we end up with an
+  // octahedron.
+  const auto deformable_id = geometry_state_.RegisterDeformableGeometry(
+      s_id, InternalFrame::world_frame_id(), std::move(deformable_instance),
+      /* resolution_hint */ 2.0);
+
+  // Confirm that the driven mesh with each role is the surface of the
+  // octahedron.
+  for (const auto role : std::vector<Role>{
+           Role::kIllustration, Role::kPerception, Role::kProximity}) {
+    const std::vector<internal::RenderMesh>& render_meshes =
+        geometry_state_.GetDrivenRenderMeshes(deformable_id, role);
+    ASSERT_EQ(ssize(render_meshes), 1);
+    const auto& mesh = render_meshes[0];
+    // The octahedron has 6 vertices and 8 faces.
+    EXPECT_EQ(mesh.positions.rows(), 6);
+    EXPECT_EQ(mesh.indices.rows(), 8);
+    if (role == Role::kIllustration) {
+      // The illustration mesh should have the illustration properties.
+      EXPECT_EQ(mesh.material->diffuse, Rgba(0.1, 0.2, 0.3, 0.4));
+    } else {
+      EXPECT_FALSE(mesh.material.has_value());
+    }
+  }
+
+  const std::vector<VectorX<double>> reference_proximity_configuration =
+      geometry_state_.GetDrivenMeshConfigurationsInWorld(deformable_id,
+                                                         Role::kProximity);
+  ASSERT_EQ(reference_proximity_configuration.size(), 1);
+  for (const auto role : std::vector<Role>{
+           Role::kIllustration, Role::kPerception, Role::kProximity}) {
+    const std::vector<VectorX<double>> configuration =
+        geometry_state_.GetDrivenMeshConfigurationsInWorld(deformable_id, role);
+    EXPECT_EQ(configuration, reference_proximity_configuration);
+  }
+  // Scale the geometry by a factor of 2.0 and confirm that the driven meshes
+  // are also scaled.
+  const VectorX<double> reference_q_WG =
+      geometry_state_.get_configurations_in_world(deformable_id);
+  GeometryConfigurationVector<double> new_configurations;
+  new_configurations.set_value(deformable_id, 2.0 * reference_q_WG);
+  gs_tester_.SetGeometryConfiguration(s_id, new_configurations,
+                                      &gs_tester_.mutable_kinematics_data());
+  for (const auto role : std::vector<Role>{
+           Role::kIllustration, Role::kPerception, Role::kProximity}) {
+    const std::vector<VectorX<double>> configuration =
+        geometry_state_.GetDrivenMeshConfigurationsInWorld(deformable_id, role);
+    EXPECT_TRUE(CompareMatrices(configuration[0],
+                                reference_proximity_configuration[0]));
+  }
+
+  // Trying to get driven meshes for a non-existent role should throw.
+  geometry_state_.RemoveRole(s_id, deformable_id, Role::kIllustration);
+  EXPECT_THROW(
+      geometry_state_.GetDrivenRenderMeshes(deformable_id, Role::kIllustration),
+      std::exception);
+  EXPECT_THROW(geometry_state_.GetDrivenMeshConfigurationsInWorld(
+                   deformable_id, Role::kIllustration),
+               std::exception);
 }
 
 // Tests the RemoveGeometry() functionality. This action will have several
@@ -4050,38 +4138,44 @@ TEST_F(GeometryStateTest, DrivenMeshData) {
       RigidTransformd::Identity(), make_unique<Sphere>(sphere), "sphere");
   GeometryId g_id = geometry_state_.RegisterDeformableGeometry(
       s_id, InternalFrame::world_frame_id(), std::move(instance), kRezHint);
-  PerceptionProperties perception_properties;
-  geometry_state_.AssignRole(s_id, g_id, perception_properties);
-  // We expect one driven geometry that's the surface mesh of the control mesh.
-  EXPECT_TRUE(gs_tester_.driven_perception_meshes().contains(g_id));
-  EXPECT_EQ(gs_tester_.driven_perception_meshes().at(g_id).size(), 1);
-  EXPECT_EQ(
-      gs_tester_.driven_perception_meshes().at(g_id)[0].num_control_vertices(),
-      7);
-  EXPECT_EQ(gs_tester_.driven_perception_meshes()
-                .at(g_id)[0]
-                .triangle_surface_mesh()
-                .num_triangles(),
-            8);
+  geometry_state_.AssignRole(s_id, g_id, PerceptionProperties());
+  geometry_state_.AssignRole(s_id, g_id, IllustrationProperties());
+  geometry_state_.AssignRole(s_id, g_id, ProximityProperties());
 
-  // Remove the perception role and the driven mesh is removed along with it.
-  geometry_state_.RemoveRole(s_id, g_id, Role::kPerception);
-  EXPECT_FALSE(gs_tester_.driven_perception_meshes().contains(g_id));
+  {
+    // We expect one driven geometry that's the surface mesh of the control
+    // mesh.
+    for (const auto role : std::vector<Role>{
+             Role::kProximity, Role::kIllustration, Role::kPerception}) {
+      const internal::DrivenMeshData& data = gs_tester_.driven_mesh_data(role);
+      EXPECT_TRUE(data.driven_meshes().contains(g_id));
+      EXPECT_EQ(data.driven_meshes().at(g_id).size(), 1);
+      const auto& driven_mesh = data.driven_meshes().at(g_id)[0];
+      EXPECT_EQ(driven_mesh.num_control_vertices(), 7);
+      EXPECT_EQ(driven_mesh.triangle_surface_mesh().num_triangles(), 8);
+    }
 
-  // Add the perception role back with a specified render geometry consisting of
-  // two distinct meshes.
-  // Note that distinct RenderMesh instances are made if there are more than one
-  // material when loading the obj file.
-  const char mtl_file[] = "multi.mtl";
-  WriteFile(R"""(
+    // Remove the perception role and the driven mesh is removed along with it.
+    geometry_state_.RemoveRole(s_id, g_id, Role::kPerception);
+    const internal::DrivenMeshData& data =
+        gs_tester_.driven_mesh_data(Role::kPerception);
+    EXPECT_FALSE(data.driven_meshes().contains(g_id));
+  }
+
+  {
+    // Add the perception role back with a specified render geometry consisting
+    // of two distinct meshes. Note that distinct RenderMesh instances are made
+    // if there are more than one material when loading the obj file.
+    const char mtl_file[] = "multi.mtl";
+    WriteFile(R"""(
     newmtl test_material_1
     Kd 1.0 0.0 1.0
 
     newmtl test_material_2
     Kd 1.0 0.0 0.0
   )""",
-            mtl_file);
-  const std::string obj_path = WriteFile(fmt::format(R"""(
+              mtl_file);
+    const std::string obj_path = WriteFile(fmt::format(R"""(
         mtllib {}
         v 0 0 0
         v 0.1 0.1 0.1
@@ -4092,12 +4186,16 @@ TEST_F(GeometryStateTest, DrivenMeshData) {
         usemtl test_material_2
         f 2//1 3//1 1//1
         f 3//1 1//1 2//1)""",
-                                                     mtl_file),
-                                         "multi_mtl.obj");
-  perception_properties.AddProperty("deformable", "embedded_mesh", obj_path);
-  geometry_state_.AssignRole(s_id, g_id, perception_properties);
-  EXPECT_TRUE(gs_tester_.driven_perception_meshes().contains(g_id));
-  EXPECT_EQ(gs_tester_.driven_perception_meshes().at(g_id).size(), 2);
+                                                       mtl_file),
+                                           "multi_mtl.obj");
+    PerceptionProperties perception_properties;
+    perception_properties.AddProperty("deformable", "embedded_mesh", obj_path);
+    geometry_state_.AssignRole(s_id, g_id, perception_properties);
+    const internal::DrivenMeshData& data =
+        gs_tester_.driven_mesh_data(Role::kPerception);
+    EXPECT_TRUE(data.driven_meshes().contains(g_id));
+    EXPECT_EQ(data.driven_meshes().at(g_id).size(), 2);
+  }
 }
 
 // Confirms that an accepting renderer

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -53,6 +53,8 @@ GTEST_TEST(InternalGeometryTest, PropertyAssignment) {
         geometry.proximity_properties()->HasProperty("group1", "value"));
     EXPECT_TRUE(
         geometry.proximity_properties()->HasProperty("group2", "value"));
+    EXPECT_EQ(geometry.proximity_properties(),
+              geometry.properties(Role::kProximity));
   }
 
   {
@@ -71,6 +73,8 @@ GTEST_TEST(InternalGeometryTest, PropertyAssignment) {
         geometry.illustration_properties()->HasProperty("group1", "value"));
     EXPECT_TRUE(
         geometry.illustration_properties()->HasProperty("group2", "value"));
+    EXPECT_EQ(geometry.illustration_properties(),
+              geometry.properties(Role::kIllustration));
   }
 
   {
@@ -83,6 +87,8 @@ GTEST_TEST(InternalGeometryTest, PropertyAssignment) {
         geometry.SetRole(PerceptionProperties()),
         "Geometry already has perception role assigned");
     EXPECT_TRUE(geometry.has_perception_role());
+    EXPECT_EQ(geometry.perception_properties(),
+              geometry.properties(Role::kPerception));
   }
 }
 

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -166,6 +166,8 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   EXPECT_DEFAULT_ERROR(default_object.GetPoseInWorld(GeometryId::get_new_id()));
   EXPECT_DEFAULT_ERROR(
       default_object.GetConfigurationsInWorld(GeometryId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object.GetDrivenMeshConfigurationsInWorld(
+      GeometryId::get_new_id(), Role::kIllustration));
 
   // Penetration queries.
   EXPECT_DEFAULT_ERROR(default_object.ComputePointPairPenetration());

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -52,6 +52,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.GetAllGeometryIds();
   inspector.GetGeometryIds(GeometrySet{});
   inspector.NumGeometriesWithRole(Role::kUnassigned);
+  inspector.NumDeformableGeometriesWithRole(Role::kUnassigned);
   inspector.NumDynamicGeometries();
   inspector.NumAnchoredGeometries();
   inspector.GetCollisionCandidates();
@@ -81,6 +82,14 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
       source_id, frame_id,
       make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(1.0), "sphere"));
+  // Register a deformable geometry.
+  auto deformable_instance = make_unique<GeometryInstance>(
+      RigidTransformd::Identity(), make_unique<Sphere>(1.0), "sphere");
+  deformable_instance->set_illustration_properties(IllustrationProperties{});
+  const GeometryId deformable_geometry_id =
+      tester.mutable_state().RegisterDeformableGeometry(
+          source_id, internal::InternalFrame::world_frame_id(),
+          std::move(deformable_instance), 0.5);
   inspector.GetGeometryIdByName(frame_id, Role::kUnassigned, "sphere");
 
   // Geometries and their properties.
@@ -95,6 +104,8 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.GetIllustrationProperties(geometry_id);
   inspector.GetPerceptionProperties(geometry_id);
   inspector.GetReferenceMesh(geometry_id);
+  inspector.GetDrivenRenderMeshes(deformable_geometry_id, Role::kIllustration);
+  inspector.IsDeformableGeometry(geometry_id);
   inspector.GetAllDeformableGeometryIds();
   inspector.GetConvexHull(geometry_id);
   inspector.GetReferenceMesh(geometry_id);

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -43,6 +43,14 @@ DeformableBodyId DeformableModel<T>::RegisterDeformableBody(
   SourceId source_id = plant_->get_source_id().value();
   /* All deformable bodies are registered with the world frame at the moment. */
   const FrameId world_frame_id = scene_graph.world_frame_id();
+  // TODO(xuchenhan-tri): Consider allowing users to opt out of illustration
+  // property for the deformable body if that's ever useful.
+  /* If the geometry doesn't have illustration properties, add an empty one so
+   that it can at least be visualized. */
+  if (geometry_instance->illustration_properties() == nullptr) {
+    geometry_instance->set_illustration_properties(
+        geometry::IllustrationProperties{});
+  }
   GeometryId geometry_id = scene_graph.RegisterDeformableGeometry(
       source_id, world_frame_id, std::move(geometry_instance), resolution_hint);
 


### PR DESCRIPTION
To allow for that, implement
QueryObject::GetIllustrationMeshConfigurationsInWorld() that computes the current vertex positions in world for driven illustration meshes and SceneGraphInspector::GetDrivenIllustrationRenderMeshes() that computes the render mesh representation of the illustration driven meshes.

This PR also includes an update to the bubble gripper example demonstrating that we can now configure the diffuse color of deformable geometries for visualization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21298)
<!-- Reviewable:end -->
