### PR TITLE
Meshcat::SetObject() reports files a Mesh uses

### DIFF
--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -351,7 +351,6 @@ class TestMeldis(unittest.TestCase):
         with open(mtl_filename, "w") as f:
             f.write("newmtl test_mat\n")
             f.write("Kd 1 0 0")
-        old_hashes = applet._load_deduplicator._path_hashes.copy()
         applet.on_viewer_load(load_message)
         self.assertDictEqual(applet._load_deduplicator._path_hashes, {})
         applet.on_viewer_draw(draw_message)

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -318,6 +318,7 @@ class MeshcatShapeReifier : public ShapeReifier {
   struct Output {
     internal::LumpedObjectData& lumped;
     std::vector<std::shared_ptr<const FileStorage::Handle>>& assets;
+    std::set<std::filesystem::path>& asset_paths;
   };
 
   using ShapeReifier::ImplementGeometry;
@@ -340,6 +341,9 @@ class MeshcatShapeReifier : public ShapeReifier {
       drake::log()->warn("Meshcat: Could not open mesh filename {}", filename);
       return;
     }
+
+    output.asset_paths.emplace(
+        std::filesystem::path(filename).lexically_normal());
 
     // We simply dump the binary contents of the file into the data field of the
     // message.  The javascript meshcat takes care of the rest.
@@ -378,6 +382,7 @@ class MeshcatShapeReifier : public ShapeReifier {
       // Read .mtl file into geometry.mtl_library.
       if (std::optional<std::string> maybe_mtl_data =
               ReadFile(basedir / mtllib)) {
+        output.asset_paths.emplace((basedir / mtllib).lexically_normal());
         meshfile_object.mtl_library = std::move(*maybe_mtl_data);
 
         // Scan .mtl file for map_ lines.  For each, load the file and add
@@ -400,6 +405,7 @@ class MeshcatShapeReifier : public ShapeReifier {
           std::ifstream map_stream(basedir / map,
                                    std::ios::binary | std::ios::ate);
           if (map_stream.is_open()) {
+            output.asset_paths.emplace((basedir / map).lexically_normal());
             int map_size = map_stream.tellg();
             map_stream.seekg(0, std::ios::beg);
             std::vector<uint8_t> map_data;
@@ -424,8 +430,8 @@ class MeshcatShapeReifier : public ShapeReifier {
             filename, mtllib, (basedir / mtllib).string());
       }
     } else if (format == "gltf") {
-      output.assets =
-          internal::UnbundleGltfAssets(filename, &mesh_data, &file_storage_);
+      output.assets = internal::UnbundleGltfAssets(
+          filename, &mesh_data, &file_storage_, &output.asset_paths);
       auto& meshfile_object =
           lumped.object.emplace<internal::MeshfileObjectData>();
       meshfile_object.uuid = uuid_generator_.GenerateRandom();
@@ -870,7 +876,10 @@ class Meshcat::Impl {
   }
 
   // This function is public via the PIMPL.
-  void SetObject(std::string_view path, const Shape& shape, const Rgba& rgba) {
+  std::set<std::filesystem::path> SetObject(std::string_view path,
+                                            const Shape& shape,
+                                            const Rgba& rgba) {
+    std::set<std::filesystem::path> asset_paths;
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
     internal::SetObjectData data;
@@ -884,13 +893,14 @@ class Meshcat::Impl {
     MeshcatShapeReifier reifier(&uuid_generator_, &file_storage_, rgba);
     std::vector<std::shared_ptr<const FileStorage::Handle>> assets;
     MeshcatShapeReifier::Output reifier_output{.lumped = data.object,
-                                               .assets = assets};
+                                               .assets = assets,
+                                               .asset_paths = asset_paths};
     shape.Reify(&reifier, &reifier_output);
 
     if (std::holds_alternative<std::monostate>(data.object.object)) {
       // Then this shape is not supported, and I should not send the message,
       // nor add the object to the tree.
-      return;
+      return asset_paths;
     }
     if (std::holds_alternative<internal::MeshData>(data.object.object)) {
       auto& meshfile_object = std::get<internal::MeshData>(data.object.object);
@@ -938,6 +948,8 @@ class Meshcat::Impl {
       e.object().emplace() = std::move(message);
       e.object()->assets = std::move(assets);
     });
+
+    return asset_paths;
   }
 
   // This function is public via the PIMPL.
@@ -2427,9 +2439,10 @@ void Meshcat::Flush() const {
   impl().Flush();
 }
 
-void Meshcat::SetObject(std::string_view path, const Shape& shape,
-                        const Rgba& rgba) {
-  impl().SetObject(path, shape, rgba);
+std::set<std::filesystem::path> Meshcat::SetObject(std::string_view path,
+                                                   const Shape& shape,
+                                                   const Rgba& rgba) {
+  return impl().SetObject(path, shape, rgba);
 }
 
 void Meshcat::SetObject(std::string_view path,

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -175,12 +176,18 @@ class Meshcat {
   @param shape a Shape that specifies the geometry of the object.
   @param rgba an Rgba that specifies the (solid) color of the object.
   @note If `shape` is a mesh, the file referred to can be either an .obj file
-  or an _embedded_ .gltf file (it has all geometry data and texture data
-  contained within the single .gltf file).
+  or a .gltf file.
+  @returns A set of all on-disk assets associated with the `shape` that Meshcat
+  makes available to a meshcat client. This may include more files than the
+  client actually uses. This will be empty for every Shape except for Mesh.
+  The Convex shape will send the convex hull polytope directly; the client will
+  never know about the convex hull's originating file.
   @pydrake_mkdoc_identifier{shape}
   */
-  void SetObject(std::string_view path, const Shape& shape,
-                 const Rgba& rgba = Rgba(.9, .9, .9, 1.));
+  std::set<std::filesystem::path> SetObject(std::string_view path,
+                                            const Shape& shape,
+                                            const Rgba& rgba = Rgba(.9, .9, .9,
+                                                                    1.));
 
   // TODO(russt): SetObject with texture map.
 

--- a/geometry/meshcat_internal.cc
+++ b/geometry/meshcat_internal.cc
@@ -127,9 +127,10 @@ std::shared_ptr<const FileStorage::Handle> LoadGltfUri(
 
 std::vector<std::shared_ptr<const FileStorage::Handle>> UnbundleGltfAssets(
     const fs::path& gltf_filename, std::string* gltf_contents,
-    FileStorage* storage) {
+    FileStorage* storage, std::set<std::filesystem::path>* asset_paths) {
   DRAKE_DEMAND(gltf_contents != nullptr);
   DRAKE_DEMAND(storage != nullptr);
+  DRAKE_DEMAND(asset_paths != nullptr);
   std::vector<std::shared_ptr<const FileStorage::Handle>> assets;
   json gltf;
   try {
@@ -154,6 +155,8 @@ std::vector<std::shared_ptr<const FileStorage::Handle>> UnbundleGltfAssets(
         std::shared_ptr<const FileStorage::Handle> asset =
             LoadGltfUri(gltf_filename, array_hint, uri, storage);
         if (asset != nullptr) {
+          asset_paths->emplace(
+              (gltf_filename.parent_path() / uri).lexically_normal());
           item["uri"] = FileStorage::GetCasUrl(*asset);
           assets.push_back(std::move(asset));
           edited = true;

--- a/geometry/meshcat_internal.h
+++ b/geometry/meshcat_internal.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -67,10 +68,15 @@ original file has disappeared in the meantime.
 
 @param[in,out] storage The database where assets should be stored.
 
+@param[in, out] asset_paths The paths to the on-disk assets (.bin and image
+files) stored in the file storage. This does not include the glTF file as it
+is not stored.
+
 @returns The handles for all assets cited by `gltf_contents`. */
 [[nodiscard]] std::vector<std::shared_ptr<const FileStorage::Handle>>
 UnbundleGltfAssets(const std::filesystem::path& gltf_filename,
-                   std::string* gltf_contents, FileStorage* storage);
+                   std::string* gltf_contents, FileStorage* storage,
+                   std::set<std::filesystem::path>* asset_paths);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/test/meshcat_internal_test.cc
+++ b/geometry/test/meshcat_internal_test.cc
@@ -55,8 +55,9 @@ GTEST_TEST(UnbundleGltfAssetsTest, DataUri) {
 
   // Unbundle it.
   FileStorage storage;
+  std::set<std::filesystem::path> asset_paths;
   std::vector<std::shared_ptr<const FileStorage::Handle>> assets =
-      UnbundleGltfAssets(gltf_filename, &gltf_contents, &storage);
+      UnbundleGltfAssets(gltf_filename, &gltf_contents, &storage, &asset_paths);
 
   // The contents got smaller due to unbundling (but not too small).
   DRAKE_DEMAND(orig_size >= 4096);
@@ -68,6 +69,8 @@ GTEST_TEST(UnbundleGltfAssetsTest, DataUri) {
       FindResourceOrThrow("drake/geometry/render/test/meshes/cube2.bin")));
   ASSERT_EQ(assets.size(), 1);
   EXPECT_EQ(assets.front()->sha256, expected_sha256);
+  // The created .bin file.
+  EXPECT_EQ(asset_paths.size(), 1);
 
   // Make sure the new URI seems correct.
   EXPECT_THAT(json::parse(gltf_contents)["buffers"][0]["uri"],
@@ -93,10 +96,13 @@ GTEST_TEST(UnbundleGltfAssetsTest, DataUriBad) {
   std::string gltf_contents = MakeGltfWithUri(uri);
   const std::string orig = gltf_contents;
   FileStorage storage;
-  auto assets = UnbundleGltfAssets("foo.gltf", &gltf_contents, &storage);
+  std::set<std::filesystem::path> asset_paths;
+  auto assets =
+      UnbundleGltfAssets("foo.gltf", &gltf_contents, &storage, &asset_paths);
   EXPECT_EQ(assets.size(), 0);
   EXPECT_EQ(storage.size(), 0);
   EXPECT_EQ(gltf_contents, orig);
+  EXPECT_EQ(asset_paths.size(), 0);
 }
 
 GTEST_TEST(UnbundleGltfAssetsTest, RelativeUri) {
@@ -107,14 +113,17 @@ GTEST_TEST(UnbundleGltfAssetsTest, RelativeUri) {
 
   // Unbundle it.
   FileStorage storage;
+  std::set<std::filesystem::path> asset_paths;
   std::vector<std::shared_ptr<const FileStorage::Handle>> assets =
-      UnbundleGltfAssets(gltf_filename, &gltf_contents, &storage);
+      UnbundleGltfAssets(gltf_filename, &gltf_contents, &storage, &asset_paths);
 
   // One asset was added to storage, identical to cube2.bin.
   const Sha256 expected_sha256 = Sha256::Checksum(ReadFileOrThrow(
       FindResourceOrThrow("drake/geometry/render/test/meshes/cube2.bin")));
   ASSERT_EQ(assets.size(), 1);
   EXPECT_EQ(assets.front()->sha256, expected_sha256);
+  // The referenced .bin file.
+  EXPECT_EQ(asset_paths.size(), 1);
 
   // Make sure the new URI seems correct.
   EXPECT_THAT(json::parse(gltf_contents)["buffers"][0]["uri"],
@@ -126,20 +135,26 @@ GTEST_TEST(UnbundleGltfAssetsTest, RelativeUriBad) {
   std::string gltf_contents = MakeGltfWithUri(uri);
   const std::string orig = gltf_contents;
   FileStorage storage;
-  auto assets = UnbundleGltfAssets("foo.gltf", &gltf_contents, &storage);
+  std::set<std::filesystem::path> asset_paths;
+  auto assets =
+      UnbundleGltfAssets("foo.gltf", &gltf_contents, &storage, &asset_paths);
   EXPECT_EQ(assets.size(), 0);
   EXPECT_EQ(storage.size(), 0);
   EXPECT_EQ(gltf_contents, orig);
+  EXPECT_EQ(asset_paths.size(), 0);
 }
 
 GTEST_TEST(UnbundleGltfAssetsTest, JsonParseError) {
   std::string gltf_contents = "Hello, world!";
   const std::string orig = gltf_contents;
   FileStorage storage;
-  auto assets = UnbundleGltfAssets("foo.gltf", &gltf_contents, &storage);
+  std::set<std::filesystem::path> asset_paths;
+  auto assets =
+      UnbundleGltfAssets("foo.gltf", &gltf_contents, &storage, &asset_paths);
   EXPECT_EQ(assets.size(), 0);
   EXPECT_EQ(storage.size(), 0);
   EXPECT_EQ(gltf_contents, orig);
+  EXPECT_EQ(asset_paths.size(), 0);
 }
 
 }  // namespace

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -308,40 +308,66 @@ GTEST_TEST(MeshcatTest, NumActive) {
 GTEST_TEST(MeshcatTest, SetObjectWithShape) {
   Meshcat meshcat;
   EXPECT_TRUE(meshcat.GetPackedObject("sphere").empty());
-  meshcat.SetObject("sphere", Sphere(0.25), Rgba(1.0, 0, 0, 1));
+  EXPECT_THAT(meshcat.SetObject("sphere", Sphere(0.25), Rgba(1, 0, 0, 1)),
+              ::testing::IsEmpty());
   EXPECT_FALSE(meshcat.GetPackedObject("sphere").empty());
-  meshcat.SetObject("cylinder", Cylinder(0.25, 0.5), Rgba(0.0, 1.0, 0, 1));
+  EXPECT_THAT(
+      meshcat.SetObject("cylinder", Cylinder(0.25, 0.5), Rgba(0, 1, 0, 1)),
+      ::testing::IsEmpty());
   EXPECT_FALSE(meshcat.GetPackedObject("cylinder").empty());
   // HalfSpaces are not supported yet; this should only log a warning.
-  meshcat.SetObject("halfspace", HalfSpace());
+  EXPECT_THAT(meshcat.SetObject("halfspace", HalfSpace()),
+              ::testing::IsEmpty());
   EXPECT_TRUE(meshcat.GetPackedObject("halfspace").empty());
-  meshcat.SetObject("box", Box(0.25, 0.25, 0.5), Rgba(0, 0, 1, 1));
+  EXPECT_THAT(meshcat.SetObject("box", Box(0.25, 0.25, 0.5), Rgba(0, 0, 1, 1)),
+              ::testing::IsEmpty());
   EXPECT_FALSE(meshcat.GetPackedObject("box").empty());
-  meshcat.SetObject("ellipsoid", Ellipsoid(0.25, 0.25, 0.5),
-                    Rgba(1.0, 0, 1, 1));
+  EXPECT_THAT(meshcat.SetObject("ellipsoid", Ellipsoid(0.25, 0.25, 0.5),
+                                Rgba(1, 0, 1, 1)),
+              ::testing::IsEmpty());
   EXPECT_FALSE(meshcat.GetPackedObject("ellipsoid").empty());
-  meshcat.SetObject("capsule", Capsule(0.25, 0.5));
+  EXPECT_THAT(meshcat.SetObject("capsule", Capsule(0.25, 0.5)),
+              ::testing::IsEmpty());
   EXPECT_FALSE(meshcat.GetPackedObject("capsule").empty());
-  meshcat.SetObject(
-      "mesh",
-      Mesh(FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj"),
-           0.25));
+
+  const std::filesystem::path obj_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj");
+  const std::set<std::filesystem::path> expected_obj_files{
+      obj_path, obj_path.parent_path() / "box.obj.mtl",
+      obj_path.parent_path() / "box.png"};
+  EXPECT_THAT(meshcat.SetObject("mesh", Mesh(obj_path.string(), 0.25)),
+              ::testing::ContainerEq(expected_obj_files));
   EXPECT_FALSE(meshcat.GetPackedObject("mesh").empty());
-  meshcat.SetObject(
-      "gltf",
-      Mesh(FindResourceOrThrow("drake/geometry/render/test/meshes/cube1.gltf"),
-           0.25));
+
+  const std::filesystem::path gltf_path = FindResourceOrThrow(
+      "drake/geometry/render/test/meshes/fully_textured_pyramid.gltf");
+  const std::set<std::filesystem::path> expected_gltf_files{
+      gltf_path,
+      gltf_path.parent_path() / "fully_textured_pyramid.bin",
+      gltf_path.parent_path() / "fully_textured_pyramid_emissive.png",
+      gltf_path.parent_path() / "fully_textured_pyramid_normal.png",
+      gltf_path.parent_path() / "fully_textured_pyramid_omr.png",
+      gltf_path.parent_path() / "fully_textured_pyramid_base_color.png",
+      gltf_path.parent_path() / "fully_textured_pyramid_emissive.ktx2",
+      gltf_path.parent_path() / "fully_textured_pyramid_normal.ktx2",
+      gltf_path.parent_path() / "fully_textured_pyramid_omr.ktx2",
+      gltf_path.parent_path() / "fully_textured_pyramid_base_color.ktx2"};
+  EXPECT_THAT(meshcat.SetObject("gltf", Mesh(gltf_path.string(), 0.25)),
+              ::testing::ContainerEq(expected_gltf_files));
   EXPECT_FALSE(meshcat.GetPackedObject("gltf").empty());
-  meshcat.SetObject(
-      "convex",
-      Convex(FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj"),
-             0.25));
+
+  EXPECT_THAT(
+      meshcat.SetObject("convex",
+                        Convex(FindResourceOrThrow(
+                                   "drake/geometry/render/test/meshes/box.obj"),
+                               0.25)),
+      ::testing::IsEmpty());
   EXPECT_FALSE(meshcat.GetPackedObject("convex").empty());
   // Bad filename (no extension).  Should only log a warning.
-  meshcat.SetObject("bad", Mesh("test"));
+  EXPECT_THAT(meshcat.SetObject("bad", Mesh("test")), ::testing::IsEmpty());
   EXPECT_TRUE(meshcat.GetPackedObject("bad").empty());
   // Bad filename (file doesn't exist).  Should only log a warning.
-  meshcat.SetObject("bad", Mesh("test.obj"));
+  EXPECT_THAT(meshcat.SetObject("bad", Mesh("test.obj")), ::testing::IsEmpty());
   EXPECT_TRUE(meshcat.GetPackedObject("bad").empty());
 }
 


### PR DESCRIPTION
The mesh file specified in a `Mesh` shape may actually depend on an arbitrary number of additional files on disk. When adding a `Shape` to `Meshcat`, `Meshcat` will report all of the files that it is making available to a meshcat client.

`Meldis` uses this API to learn about mesh files.

Closes #21194

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21300)
<!-- Reviewable:end -->
