### PR TITLE
ModelVisualizer draw all MultibodyPlant frames when requested

### DIFF
--- a/bindings/pydrake/visualization/BUILD.bazel
+++ b/bindings/pydrake/visualization/BUILD.bazel
@@ -173,6 +173,7 @@ drake_py_unittest(
         ":model_visualizer",
         "//manipulation/util:test_models",
         "//multibody/benchmarks/acrobot:models",
+        "//multibody/parsing:test_models",
     ],
     deps = [
         ":model_visualizer",

--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -22,6 +22,7 @@ from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.meshcat import JointSliders
 from pydrake.multibody.tree import (
     FixedOffsetFrame,
+    FrameIndex,
     default_model_instance,
 )
 from pydrake.planning import RobotDiagramBuilder
@@ -264,21 +265,15 @@ class ModelVisualizer:
             raise RuntimeError("Finalize has already been called.")
 
         if self._visualize_frames:
-            # Find all the frames and draw them.
-            # The frames are drawn using the parsed length.
-            # The world frame is drawn thicker than the rest.
-            inspector = self._builder.scene_graph().model_inspector()
-            for frame_id in inspector.GetAllFrameIds():
-                world_id = self._builder.scene_graph().world_frame_id()
-                radius = self._triad_radius * (
-                    3 if frame_id == world_id else 1
-                    )
+            # Find all the frames (except the world frame) and draw them.
+            # The frames are drawn using the configured length.
+            for i in range(1, self._builder.plant().num_frames()):
                 AddFrameTriadIllustration(
                     plant=self._builder.plant(),
                     scene_graph=self._builder.scene_graph(),
-                    frame_id=frame_id,
+                    frame_index=FrameIndex(i),
                     length=self._triad_length,
-                    radius=radius,
+                    radius=self._triad_radius,
                     opacity=self._triad_opacity,
                 )
 

--- a/bindings/pydrake/visualization/_triad.py
+++ b/bindings/pydrake/visualization/_triad.py
@@ -10,7 +10,11 @@ from pydrake.geometry import (
 )
 from pydrake.math import RigidTransform
 from pydrake.multibody.plant import MultibodyPlant
-from pydrake.multibody.tree import Frame, RigidBody
+from pydrake.multibody.tree import (
+    Frame,
+    FrameIndex,
+    RigidBody,
+)
 
 
 def AddFrameTriadIllustration(
@@ -18,9 +22,10 @@ def AddFrameTriadIllustration(
     scene_graph: SceneGraph,
     body: RigidBody = None,
     frame: Frame = None,
+    frame_index: FrameIndex = None,
     frame_id: FrameId = None,
     plant: MultibodyPlant = None,
-    name: str = "frame",
+    name: str = None,
     length: float = 0.3,
     radius: float = 0.005,
     opacity: float = 0.9,
@@ -29,22 +34,28 @@ def AddFrameTriadIllustration(
     """
     Adds illustration geometry representing the given frame using an RGB triad,
     with the x-axis drawn in red, the y-axis in green and the z-axis in blue.
-    The given frame can be either a geometry FrameId, a multibody RigidBody, or
-    a multibody Frame.
+    The given frame can be either a geometry FrameId, a multibody RigidBody,
+    a multibody FrameIndex or a multibody Frame.
+
+    Note: exactly one of body=, frame=, frame_index= or frame_id= must be
+    provided.
+
+    Note: body frames and frames fixed to bodies are colored differently (body
+    frames are brighter).
 
     Args:
       scene_graph: the SceneGraph where geometry will be added.
-      body: when provided, illustrates the frame of the given body;
-        exactly one of body=, frame=, or frame_id= must be provided.
-      frame: when provided, illustrates the frame from a plant;
-        exactly one of body=, frame=, or frame_id= must be provided.
+      body: when provided, illustrates the frame of the given body.
+      frame: when provided, illustrates the frame from a plant.
+      frame_index: when provided, illustrates the indexed frame from a plant.
+        `plant` must not be None.
       frame_id: when provided, illustrates the given geometry.FrameId
-        registered with the given plant and scene_graph;
-        exactly one of body=, frame=, or frame_id= must be provided.
+        registered with the given plant and scene_graph.
       plant: MultibodyPlant associated with the given frame_id;
-        required if frame_id= is being used. If body= or frame= is supplied,
-        they must belong to this plant.
-      name: the added geometries will have names "{name} x-axis", etc.
+        required if frame_index= or frame_id= is being used. If body= or frame=
+        is supplied, they must belong to this plant.
+      name: the added geometries will have names "_frames::{name}::x-axis",
+        etc. If None, the name is inferred from the indicated frame.
       length: the length of each axis in meters.
       radius: the radius of each axis in meters.
       opacity: the opacity each axis, between 0.0 and 1.0.
@@ -54,16 +65,23 @@ def AddFrameTriadIllustration(
     Returns:
       The newly-added geometry ids for (x, y, z) respectively.
     """
-    if sum([body is not None, frame is not None, frame_id is not None]) != 1:
-        raise ValueError(
-            "Must provide exactly one of body=, frame=, or frame_id=")
+    if sum([body is not None, frame is not None, frame_index is not None,
+            frame_id is not None]) != 1:
+        raise ValueError("Must provide exactly one of body=, frame=, "
+                         "frame_index=, or frame_id=")
     if X_FT is None:
         X_FT = RigidTransform()
     resolved_plant_arg = "body="
+    if frame_index is not None:
+        if plant is None:
+            raise ValueError(
+                "When using frame_index=, the plant cannot be None.")
+        frame = plant.get_frame(frame_index)
     if frame is not None:
         body = frame.body()
         X_FT = frame.GetFixedPoseInBodyFrame() @ X_FT
-        resolved_plant_arg = "frame="
+        resolved_plant_arg = ("frame=" if frame_index is None
+                              else "frame_index=")
     if body is not None:
         if plant is not None:
             if plant is not body.GetParentPlant():
@@ -73,12 +91,18 @@ def AddFrameTriadIllustration(
         else:
             plant = body.GetParentPlant()
         frame_id = plant.GetBodyFrameIdOrThrow(body.index())
+    if frame is None:
+        assert frame_id is not None
+        frame = plant.GetBodyFromFrameId(frame_id).body_frame()
+    if name is None:
+        name = f"{frame.name()}({int(frame.model_instance())})"
+    brightness = 1 if frame.is_body_frame() else 0.5
 
     source_id = plant.get_source_id()
     eye = np.eye(3)
     result = []
     for i, char in enumerate(("x", "y", "z")):
-        geom_name = f"{name} {char}-axis"
+        geom_name = f"_frames::{name}::{char}-axis"
         # p_TG centers the cylinder halfway along the i'th axis.
         p_TG = 0.5 * length * eye[i]
         # R_TG rotates the canonical cylinder (aligned with +z) to align with
@@ -87,7 +111,8 @@ def AddFrameTriadIllustration(
         R_TG = AngleAxis(angle=np.pi/2, axis=eye[1-i])
         X_FG = X_FT @ RigidTransform(R_TG, p_TG)
         geom = GeometryInstance(X_FG, Cylinder(radius, length), geom_name)
-        phong = MakePhongIllustrationProperties(np.append(eye[i], [opacity]))
+        phong = MakePhongIllustrationProperties(np.append(eye[i] * brightness,
+                                                [opacity]))
         geom.set_illustration_properties(phong)
         geometry_id = scene_graph.RegisterGeometry(source_id, frame_id, geom)
         result.append(geometry_id)

--- a/bindings/pydrake/visualization/test/model_visualizer_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_test.py
@@ -1,5 +1,6 @@
 import copy
 import inspect
+import os
 import subprocess
 import textwrap
 import time
@@ -248,3 +249,56 @@ class TestModelVisualizer(unittest.TestCase):
         actual = mut.ModelVisualizer._get_constructor_defaults()
         for name in ("length", "radius", "opacity"):
             self.assertEqual(actual[f"triad_{name}"], expected[name].default)
+
+    def test_visualize_all_frames(self):
+        """ Confirm that *all* frames get added. """
+        dut = mut.ModelVisualizer(visualize_frames=True)
+        dut.parser().AddModels(file_type=".urdf", file_contents="""
+<?xml version="1.0"?>
+<robot name="test_model">
+    <link name="box">
+        <inertial>
+        <mass value="1"/>
+        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        </inertial>
+        <visual>
+        <geometry>
+            <box size=".1 .2 .3"/>
+        </geometry>
+        </visual>
+    </link>
+    <frame name="offset_frame" link="box" xyz="0.25 0 0" rpy="0 0 0"/>
+</robot>
+""")
+        dut.Run(loop_once=True)
+
+        meshcat = dut.meshcat()
+        self.assertTrue(meshcat.HasPath("/drake/illustration/test_model"))
+        # Body frame.
+        self.assertTrue(meshcat.HasPath("/drake/illustration/test_model/box"
+                                        "/_frames/box(2)/x-axis"))
+        self.assertTrue(meshcat.HasPath("/drake/illustration/test_model/box"
+                                        "/_frames/box(2)/y-axis"))
+        self.assertTrue(meshcat.HasPath("/drake/illustration/test_model/box"
+                                        "/_frames/box(2)/z-axis"))
+        # Offset frame.
+        self.assertTrue(meshcat.HasPath("/drake/illustration/test_model/box"
+                                        "/_frames/offset_frame(2)/x-axis"))
+        self.assertTrue(meshcat.HasPath("/drake/illustration/test_model/box"
+                                        "/_frames/offset_frame(2)/y-axis"))
+        self.assertTrue(meshcat.HasPath("/drake/illustration/test_model/box"
+                                        "/_frames/offset_frame(2)/z-axis"))
+
+    def test_visualize_all_frames_nested_models(self):
+        """When parsing SDFormat with nested models, we can get multiple
+        __model__ frames associated with the same body. It should still
+        process the frames and not complain about repeated geometry names.
+        """
+        sdf_file = FindResourceOrThrow(
+            "drake/multibody/parsing/test/sdf_parser_test/"
+            "model_with_directly_nested_models.sdf")
+
+        dut = mut.ModelVisualizer(visualize_frames=True)
+        dut.AddModels(filename=sdf_file)
+        dut.Run(loop_once=True)
+        # Note: reaching here without throwing is enough.

--- a/bindings/pydrake/visualization/test/triad_test.py
+++ b/bindings/pydrake/visualization/test/triad_test.py
@@ -21,6 +21,7 @@ class TestTriad(unittest.TestCase):
         self._frame = builder.plant().AddFrame(
             FixedOffsetFrame(
                 "frame", builder.plant().GetFrameByName("Link2"), self._X_PF))
+        self._frame_index = self._frame.index()
         robot = builder.Build()
         self._plant = robot.plant()
         self._scene_graph = robot.scene_graph()
@@ -65,7 +66,8 @@ class TestTriad(unittest.TestCase):
             geom_id = [x, y, z][i]
             frame_name = inspect.GetName(inspect.GetFrameId(geom_id))
             self.assertEqual(frame_name, "acrobot::Link2")
-            self.assertEqual(inspect.GetName(geom_id), f"foo {char}-axis")
+            self.assertEqual(inspect.GetName(geom_id),
+                             f"_frames::foo::{char}-axis")
             self.assertEqual(inspect.GetShape(geom_id).length(), 0.2)
             self.assertEqual(inspect.GetShape(geom_id).radius(), 0.001)
             props = inspect.GetIllustrationProperties(geom_id)
@@ -78,6 +80,26 @@ class TestTriad(unittest.TestCase):
         x, y, z = mut.AddFrameTriadIllustration(
             scene_graph=self._scene_graph,
             frame=self._frame,
+            length=0.2,
+            X_FT=X_FT)
+
+        # Check the geometry pose of each axis.
+        inspect = self._scene_graph.model_inspector()
+        X_PT = self._X_PF @ X_FT
+        self._assert_equal_transform(
+            inspect.GetPoseInFrame(x), X_PT @ self._axis_offsets["x"])
+        self._assert_equal_transform(
+            inspect.GetPoseInFrame(y), X_PT @ self._axis_offsets["y"])
+        self._assert_equal_transform(
+            inspect.GetPoseInFrame(z), X_PT @ self._axis_offsets["z"])
+
+    def test_via_frame_index(self):
+        # Illustrate our custom added frame.
+        X_FT = RigidTransform([0.1, 0.2, 0.3])
+        x, y, z = mut.AddFrameTriadIllustration(
+            plant=self._plant,
+            scene_graph=self._scene_graph,
+            frame_index=self._frame_index,
             length=0.2,
             X_FT=X_FT)
 

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -515,8 +515,10 @@ drake_cc_library(
         "meshcat_types_internal.h",
     ],
     interface_deps = [
+        ":geometry_ids",
         ":meshcat_animation",
         ":rgba",
+        ":scene_graph_inspector",
         ":shape_specification",
         "//common:essential",
         "//common:name_value",
@@ -606,7 +608,11 @@ drake_cc_googletest(
         "//geometry/render:test_models",
     ],
     deps = [
+        ":geometry_instance",
         ":meshcat",
+        ":scene_graph",
+        ":shape_specification",
+        "//math:geometric_transform",
         "@nlohmann_internal//:nlohmann",
     ],
 )

--- a/geometry/meshcat_internal.cc
+++ b/geometry/meshcat_internal.cc
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 #include <uuid.h>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_export.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/never_destroyed.h"
@@ -166,6 +167,20 @@ std::vector<std::shared_ptr<const FileStorage::Handle>> UnbundleGltfAssets(
   }
   return assets;
 }
+
+template <typename T>
+std::string TransformGeometryName(
+    GeometryId geom_id, const SceneGraphInspector<T>& inspector) {
+  std::string geometry_name = inspector.GetName(geom_id);
+  size_t pos = 0;
+  while ((pos = geometry_name.find("::", pos)) != std::string::npos) {
+    geometry_name.replace(pos++, 2, "/");
+  }
+  return geometry_name;
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&TransformGeometryName<T>))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/meshcat_internal.h
+++ b/geometry/meshcat_internal.h
@@ -7,7 +7,9 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/meshcat_file_storage_internal.h"
+#include "drake/geometry/scene_graph_inspector.h"
 
 namespace drake {
 namespace geometry {
@@ -71,6 +73,28 @@ original file has disappeared in the meantime.
 [[nodiscard]] std::vector<std::shared_ptr<const FileStorage::Handle>>
 UnbundleGltfAssets(const std::filesystem::path& gltf_filename,
                    std::string* gltf_contents, FileStorage* storage);
+
+/* Converts a geometry name into a meshcat path. So, a geometry named
+`my_scope::Mesh` becomes my_scope/Mesh.
+
+Note: This replaces all "::" pairs, even if there are multiple instances in
+sequence, or it is at the beginning or end of a sequence.
+
+We may produce strings of the form: "a//b", "/a", or "b/". We assume these are
+not problematic for the following reasons:
+
+  - "a//b" - meshcat treats multiple '/' in a row as a single '/'.
+  - "b/" - meshcat elides trailing '/'.
+  - "/a" - although this may *look* like an absolute path, our basic assumption
+           is that the transformed geometry name will be concatenated to a
+           longer path (so it will never accidentally be used in a way that
+           would be interpreted as an absolute path).
+
+(Examples of the slash elision can be seen in meshcat_manual_test.cc -- the
+sphere and cylinder shapes.) */
+template <typename T>
+std::string TransformGeometryName(GeometryId geom_id,
+                                  const SceneGraphInspector<T>& inspector);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -11,6 +11,7 @@
 #include "drake/common/extract_double.h"
 #include "drake/common/overloaded.h"
 #include "drake/geometry/meshcat_graphviz.h"
+#include "drake/geometry/meshcat_internal.h"
 #include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
 #include "drake/geometry/proximity/volume_to_surface_mesh.h"
 #include "drake/geometry/utilities.h"
@@ -194,12 +195,10 @@ void MeshcatVisualizer<T>::SetObjects(
         continue;
       }
 
-      // Note: We use the frame_path/id instead of instance.GetName(geom_id),
-      // which is a garbled mess of :: and _ and a memory address by default
-      // when coming from MultibodyPlant.
-      // TODO(russt): Use the geometry names if/when they are cleaned up.
-      const std::string path =
-          fmt::format("{}/{}", frame_path, geom_id.get_value());
+      // We'll turn scoped names into meshcat paths.
+      const std::string geometry_name =
+          internal::TransformGeometryName(geom_id, inspector);
+      const std::string path = fmt::format("{}/{}", frame_path, geometry_name);
       const Rgba rgba = properties.GetPropertyOrDefault("phong", "diffuse",
                                                         params_.default_color);
 

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -53,14 +53,21 @@ int do_main() {
   double x = start_x;
 
   Vector3d sphere_home{++x, 0, 0};
-  meshcat->SetObject("sphere", Sphere(0.25), Rgba(1.0, 0, 0, 1));
-  meshcat->SetTransform("sphere", RigidTransformd(sphere_home));
+  // The weird name for the sphere is to confirm that meshcat collapses
+  // redundant slashes. We'll subsequently refer to it without the slash to
+  // make sure they're equivalent.
+  meshcat->SetObject("sphere//scoped_name", Sphere(0.25), Rgba(1.0, 0, 0, 1));
+  meshcat->SetTransform("sphere/scoped_name", RigidTransformd(sphere_home));
   // Note: this isn't the preferred means for setting opacity, but it is the
   // simplest way to exercise chained property names.
-  meshcat->SetProperty("sphere/<object>", "material.opacity", 0.5);
-  meshcat->SetProperty("sphere/<object>", "material.transparent", true);
+  meshcat->SetProperty("sphere/scoped_name/<object>", "material.opacity", 0.5);
+  meshcat->SetProperty("sphere/scoped_name/<object>", "material.transparent",
+                       true);
 
-  meshcat->SetObject("cylinder", Cylinder(0.25, 0.5), Rgba(0.0, 1.0, 0, 1));
+  // The weird name for the cylinder is to confirm that meshcat elides terminal
+  // slashes. We'll subsequently refer to it without the slash to make sure
+  // they're equivalent.
+  meshcat->SetObject("cylinder/", Cylinder(0.25, 0.5), Rgba(0.0, 1.0, 0, 1));
   meshcat->SetTransform("cylinder", RigidTransformd(Vector3d{++x, 0, 0}));
 
   // For animation, we'll aim the camera between the cylinder and ellipsoid.
@@ -279,10 +286,12 @@ Ignore those for now; we'll need to circle back and fix them later.
                "geometries:\n";
   MeshcatAnimation animation;
   std::cout << "- the red sphere should move up and down in z.\n";
-  animation.SetTransform(0, "sphere", RigidTransformd(sphere_home));
-  animation.SetTransform(20, "sphere",
+  animation.SetTransform(0, "sphere/scoped_name",
+                         RigidTransformd(sphere_home));
+  animation.SetTransform(20, "sphere/scoped_name",
                          RigidTransformd(sphere_home + Vector3d::UnitZ()));
-  animation.SetTransform(40, "sphere", RigidTransformd(sphere_home));
+  animation.SetTransform(40, "sphere/scoped_name",
+                         RigidTransformd(sphere_home));
 
   std::cout << "- the blue box should spin clockwise about the +z axis.\n";
   animation.SetTransform(

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -7,6 +7,7 @@
 #include <msgpack.hpp>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/meshcat_internal.h"
 #include "drake/geometry/meshcat_types_internal.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -18,6 +19,7 @@ namespace drake {
 namespace geometry {
 namespace {
 
+using internal::TransformGeometryName;
 using multibody::AddMultibodyPlantSceneGraph;
 
 // The tests in this file require a dependency on MultibodyPlant.  One could
@@ -138,7 +140,8 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Roles) {
         plant_->GetBodyByName("iiwa_link_7").index());
     for (GeometryId geom_id : inspector.GetGeometries(iiwa_link_7, role)) {
       EXPECT_TRUE(meshcat_->HasPath(
-          fmt::format("visualizer/iiwa14/iiwa_link_7/{}", geom_id)));
+          fmt::format("visualizer/iiwa14/iiwa_link_7/{}",
+                      TransformGeometryName(geom_id, inspector))));
     }
     meshcat_->Delete();
   }
@@ -399,8 +402,9 @@ GTEST_TEST(MeshcatVisualizerTest, HydroGeometry) {
     // tell us whether or not hydro was used -- the normal representation is
     // just the ellipse axes (very small); the hydro representation is all
     // of the tessellated faces (very large).
-    const std::string data = meshcat->GetPackedObject(fmt::format(
-        "/drake/{}/two_bodies/body1/{}", prefix, sphere1.get_value()));
+    const std::string data = meshcat->GetPackedObject(
+        fmt::format("/drake/{}/two_bodies/body1/{}", prefix,
+                    TransformGeometryName(sphere1, inspector)));
     if (show_hydroelastic) {
       EXPECT_GT(data.size(), 5000);
       // The BufferGeometry has explicitly declared its material to be flat
@@ -455,8 +459,9 @@ GTEST_TEST(MeshcatVisualizerTest, ConvexHull) {
   // Read back the mesh shape. The message would have type _meshfile_object if
   // the obj had been sent. If, however, the generated convex hull is sent, the
   // type will be BufferGeometry.
-  const std::string data = meshcat->GetPackedObject(fmt::format(
-      "/drake/{}/box/box/{}", params.prefix, box_id.get_value()));
+  const std::string data = meshcat->GetPackedObject(
+      fmt::format("/drake/{}/box/box/{}", params.prefix,
+                  TransformGeometryName(box_id, inspector)));
   EXPECT_THAT(data, testing::HasSubstr("BufferGeometry"));
 }
 
@@ -552,8 +557,8 @@ GTEST_TEST(MeshcatVisualizerTest, AcceptingProperty) {
       auto context = diagram->CreateDefaultContext();
 
       // Publish geometry. Check whether the shape was published.
-      const std::string geom_path =
-          fmt::format("prefix/box/box/{}", geom_id.get_value());
+      const std::string geom_path = fmt::format(
+          "prefix/box/box/{}", TransformGeometryName(geom_id, inspector));
       const bool should_show =
           (accepting == "prefix") ||
           (include_unspecified_accepting && accepting.empty());
@@ -624,8 +629,8 @@ GTEST_TEST(MeshcatVisualizerTest, AlphaSliderCheckResults) {
       inspector.GetGeometries(body_frame, Role::kIllustration);
   DRAKE_DEMAND(geom_ids.size() == 1);
   const GeometryId geom_id = *geom_ids.begin();
-  const std::string geom_path =
-      fmt::format("visualizer/box/box/{}", geom_id.get_value());
+  const std::string geom_path = fmt::format(
+      "visualizer/box/box/{}", TransformGeometryName(geom_id, inspector));
 
   // Create the visualizer.
   MeshcatVisualizerParams params;


### PR DESCRIPTION
Rather than visualizing the frames registered with scene graph, it visualizes all frames with a fixed offset w.r.t. the corresponding body.

In support of that, some further changes have been made:

- MeshcatVisualizer now makes use of geometry *name* and geometry id to produce paths.
- AddFrameTriadIllustration() takes a new "brightness" parameters to use brightness as a means to distinguish different kinds of frames.

Closes #19983.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21318)
<!-- Reviewable:end -->
