### PR TITLE
[setup] Install bazelisk instead of bazel

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,3 +1,3 @@
-# Keep this version number in sync with the Ubuntu deb installed by
-# drake/setup/ubuntu/source_distribution/install_bazel.sh.
+# When bazelisk in use (as is typical, per Drake install_prereqs), this dotfile
+# specifies which version of Bazel should be used to build and test Drake.
 USE_BAZEL_VERSION=7.0.2

--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -12,7 +12,8 @@ hood.
 
 Follow Drake's
 [platform-specific setup instructions](/from_source.html#mandatory-platform-specific-instructions)
-to install Bazel.
+to install bazelisk at ``/usr/bin/bazel``, which will then automatically
+download the correct version of Bazel necessary for the build.
 
 # Drake clone and platform setup
 

--- a/doc/_pages/developers.md
+++ b/doc/_pages/developers.md
@@ -71,11 +71,6 @@ have these exact versions on your system when (re)running
 ``install_prereqs.sh``. In general, later minor versions for more stable
 packages (e.g. CMake, compilers) should not prove to be too much of an issue.
 
-For less stable packages, such as Bazel, later minor versions may cause
-breakages. If you are on Ubuntu, please rerun ``install_prereqs.sh`` as it can
-downgrade Bazel. If on Mac, there is no easy mechanism to downgrade with
-Homebrew; however, we generally try to stay on top of Bazel versions.
-
 If you have tried and are unable to configure your system by
 [following the instructions for source installation](/from_source.html)
 please do not hesitate to [ask for help](/getting_help.html).

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -35,11 +35,11 @@ while [ "${1:-}" != "" ]; do
     --with-doc-only)
       source_distribution_args+=(--with-doc-only)
       ;;
-    # Install Bazel from a deb package.
+    # Install bazelisk from a deb package.
     --with-bazel)
       source_distribution_args+=(--with-bazel)
       ;;
-    # Do NOT install bazel.
+    # Do NOT install bazelisk.
     --without-bazel)
       source_distribution_args+=(--without-bazel)
       ;;

--- a/setup/ubuntu/source_distribution/install_bazelisk.sh
+++ b/setup/ubuntu/source_distribution/install_bazelisk.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# On Ubuntu, installs either Bazel or Bazelisk at /usr/bin/bazel.
+# On Ubuntu, installs bazelisk at /usr/bin/bazel{,isk}.
 #
 # This script does not accept any command line arguments.
 
@@ -45,32 +45,23 @@ dpkg_install_from_wget() {
   rm "${tmpdeb}"
 }
 
-# Install bazel package dependencies (these may duplicate dependencies of
-# drake).
-apt-get install ${maybe_yes} --no-install-recommends $(cat <<EOF
-g++
-unzip
-zlib1g-dev
-EOF
-)
+# If bazel.deb is already installed, we'll need to remove it first because
+# the Debian package of bazelisk will take over the `/usr/bin/bazel` path.
+apt-get remove bazel || true
 
-# Install bazel.
+# Install bazelisk.
+#
+# TODO(jeremy.nimmer) Once there's a bazelisk >= 1.20 that incorporates
+# https://github.com/bazelbuild/bazelisk/pull/563, we should switch to
+# official release downloads instead of our Drake-custom Debian packages.
 if [[ $(arch) = "aarch64" ]]; then
-  # Check if bazel is already installed.
-  if [[ "$(which bazel)" ]]; then
-    echo "Bazel(isk) is already installed." >&2
-  else
-    # TODO(jeremy.nimmer) Once there's a bazelisk 1.20 that incorporates pr563,
-    # we should switch to using that here.
-    dpkg_install_from_wget \
-      bazelisk 1.19.0-9-g58a850f \
-      https://drake-mirror.csail.mit.edu/github/bazelbuild/bazelisk/pr563/bazelisk_1.19.0-9-g58a850f_arm64.deb \
-      5501a44ba1f51298d186e4e66966b0556d03524381a967667696f032e292d719
-  fi
-else
-  # Keep this version number in sync with the drake/.bazeliskrc version number.
   dpkg_install_from_wget \
-    bazel 7.0.2 \
-    https://github.com/bazelbuild/bazel/releases/download/7.0.2/bazel_7.0.2-linux-x86_64.deb \
-    f336e7287de99e2d03953a1b2182785a94936dec6e4c1b4158457c41c509acd7
+    bazelisk 1.19.0-9-g58a850f \
+    https://drake-mirror.csail.mit.edu/github/bazelbuild/bazelisk/pr563/bazelisk_1.19.0-9-g58a850f_arm64.deb \
+    5501a44ba1f51298d186e4e66966b0556d03524381a967667696f032e292d719
+else
+  dpkg_install_from_wget \
+    bazelisk 1.19.0-9-g58a850f \
+    https://drake-mirror.csail.mit.edu/github/bazelbuild/bazelisk/pr563/bazelisk_1.19.0-9-g58a850f_amd64.deb \
+    c2bfd15d6c3422ae540cda9facc0ac395005e2701c09dbb15d40447b53e831d4
 fi

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -25,11 +25,11 @@ while [ "${1:-}" != "" ]; do
     --with-doc-only)
       with_doc_only=1
       ;;
-    # Install Bazel from a deb package.
+    # Install bazelisk from a deb package.
     --with-bazel)
       with_bazel=1
       ;;
-    # Do NOT install Bazel.
+    # Do NOT install bazelisk.
     --without-bazel)
       with_bazel=0
       ;;
@@ -113,7 +113,7 @@ if [[ "${with_doc_only}" -eq 1 ]]; then
 fi
 
 if [[ "${with_bazel}" -eq 1 ]]; then
-  source "${BASH_SOURCE%/*}/install_bazel.sh"
+  source "${BASH_SOURCE%/*}/install_bazelisk.sh"
 fi
 
 if [[ "${with_clang}" -eq 1 ]]; then

--- a/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
@@ -24,12 +24,4 @@ EOF
 
 # Prefetch the bazelisk download of bazel.
 # This is especially helpful for the "Provisioned" images in CI.
-if [[ $(arch) = "aarch64" ]]; then
-  # Per ./install_bazel.sh, on arm we use bazelisk as our bazel so we should
-  # prefetch using that spelling.
-  cd "${workspace_dir}" && bazel version
-else
-  # Per ./install_bazel.sh, on non-arm there is no system-wide bazelisk so we
-  # need to use a local copy.
-  cd "${workspace_dir}" && ./third_party/com_github_bazelbuild_bazelisk/bazelisk.py version
-fi
+(cd "${workspace_dir}" && bazel version)


### PR DESCRIPTION
This removes Drake's forcing of a specific version of Bazel being installed system-wide.  This is easier for users, and will make Bazel upgrades easier in CI (no more need for Unprovisioned jobs).

(Note that on macOS we've already been using bazelisk by default for several years; this is an Ubuntu-only change.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21321)
<!-- Reviewable:end -->
