### PR TITLE
[lint] Allow running buildifier via `bazel run`

### DIFF
--- a/tools/lint/buildifier.py
+++ b/tools/lint/buildifier.py
@@ -112,6 +112,10 @@ def main(workspace_name="drake"):
             sys.exit(1)
         argv.extend(found)
 
+    # Make cwd be what the user expected, not the runfiles tree.
+    if "BUILD_WORKING_DIRECTORY" in os.environ:
+        os.chdir(os.environ["BUILD_WORKING_DIRECTORY"])
+
     # Provide helpful diagnostics when in check mode.  Buildifier's -mode=check
     # uses exitcode 0 even when lint exists; we use whether or not its output
     # was empty to tell whether there was lint.
@@ -133,13 +137,6 @@ def main(workspace_name="drake"):
                       one_file)
         print("NOTE: see https://drake.mit.edu/bazel.html#buildifier")
         return 1
-
-    # In fix mode, disallow running from within the Bazel sandbox.
-    if "-mode=diff" not in argv and "--mode=diff" not in argv:
-        if os.getcwd().endswith(".runfiles/drake"):
-            print("ERROR: do not use 'bazel run' for buildifier in fix mode")
-            print("ERROR: use bazel-bin/tools/lint/buildifier instead")
-            return 1
 
     # In fix or diff mode, just let buildifier do its thing.
     return subprocess.call(tool_cmds + argv)

--- a/tools/lint/test/buildifier_test.py
+++ b/tools/lint/test/buildifier_test.py
@@ -52,12 +52,3 @@ class BuildifierTest(unittest.TestCase):
              "bazel build //tools/lint/..."),
             "NOTE: see https://drake.mit.edu/bazel.html#buildifier"
         ])
-
-    def test_mode_fix(self):
-        returncode, output = self._call_buildifier(
-            self._make_build_testdata(add_error=False),
-            ["-mode=fix"])
-        self.assertEqual(returncode, 1, output)
-        self.assertIn(
-            "do not use 'bazel run' for buildifier in fix mode",
-            output)


### PR DESCRIPTION
When we wrote this back in the days of Bazel 0.12 or whatever, I don't think `BUILD_WORKING_DIRECTORY` existed (or at least, we didn't know about it).

Towards #20731 -- the deleted test fails under bzlmod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21329)
<!-- Reviewable:end -->
