### PR TITLE
[workspace] Simplify CSDP warning suppressions

### DIFF
--- a/tools/workspace/csdp_internal/package.BUILD.bazel
+++ b/tools/workspace/csdp_internal/package.BUILD.bazel
@@ -55,10 +55,8 @@ cc_library(
         "includes/csdp/parameters.h",
     ],
     copts = [
-        "-Wno-deprecated-non-prototype",
-        "-Wno-unknown-pragmas",
-        "-Wno-unused-variable",
         "-fvisibility=hidden",
+        "-w",
         # CSDP calls exit() for error handling. That doesn't suit our needs for
         # embedding it within Drake, so we'll redirect calls to exit() to our
         # own setjmp/longjmp handler instead.


### PR DESCRIPTION
The recently added flag `-Wno-deprecated-non-prototype` causes console spam with Ubuntu's Clang:

```
INFO: From Compiling lib/op_at.c:
warning: unknown warning option '-Wno-deprecated-non-prototype'; did you mean '-Wno-deprecated-coroutine'? [-Wunknown-warning-option]
1 warning generated.
```

+@SeanCurtis-TRI for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21334)
<!-- Reviewable:end -->
