### PR TITLE
[tools] Prepare for Noble

### DIFF
--- a/setup/ubuntu/binary_distribution/packages-noble.txt
+++ b/setup/ubuntu/binary_distribution/packages-noble.txt
@@ -10,7 +10,7 @@ libjchart2d-java
 liblapack3
 libmumps-seq-5.6
 libopengl0
-libpython3.11
+libpython3.12
 libspdlog-dev
 libx11-6
 ocl-icd-libopencl1

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -75,6 +75,20 @@ GCC_CC_TEST_FLAGS = [
     "-Wno-unused-parameter",
 ]
 
+GCC_VERSION_SPECIFIC_FLAGS = {
+    # TODO(#21337) Investigate and resolve what to do about these warnings
+    # long-term. Some of them seem like true positives (i.e., bugs in Drake).
+    13: [
+        "-Wno-array-bounds",
+        "-Wno-dangling-reference",
+        "-Wno-maybe-uninitialized",
+        "-Wno-pessimizing-move",
+        "-Wno-stringop-overflow",
+        "-Wno-stringop-overread",
+        "-Wno-uninitialized",
+    ],
+}
+
 def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
     """Returns both the rule_copts (plus rule_{cc}_copts iff under the
     specified compiler), and platform-specific copts.
@@ -93,6 +107,8 @@ def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
     elif COMPILER_ID == "GNU":
         extra_gcc_flags = GCC_CC_TEST_FLAGS if cc_test else []
         result = GCC_FLAGS + extra_gcc_flags + rule_copts + rule_gcc_copts
+        if COMPILER_VERSION_MAJOR in GCC_VERSION_SPECIFIC_FLAGS:
+            result += GCC_VERSION_SPECIFIC_FLAGS[COMPILER_VERSION_MAJOR]
     else:
         result = rule_copts
 

--- a/tools/workspace/nlohmann_internal/package.BUILD.bazel
+++ b/tools/workspace/nlohmann_internal/package.BUILD.bazel
@@ -14,6 +14,16 @@ cc_library(
         "single_include/nlohmann/json_fwd.hpp",
     ],
     strip_include_prefix = "single_include",
+    defines = [
+        # The nlohmann/json code has logic that tries to infer whether or not
+        # the compiler toolchain supports the spaceship operator (<=>).
+        # However, something it does is not quite correct and ends up failing
+        # with Ubuntu 24.04's current version of GCC 13. The problem might be
+        # https://github.com/nlohmann/json/issues/4197 but that doesn't seem
+        # quite like it, either. In any case, we don't particularly care about
+        # spaceship support so we can just force it to be off; problem solved.
+        "JSON_HAS_THREE_WAY_COMPARISON=0",
+    ],
     linkstatic = 1,
 )
 


### PR DESCRIPTION
Towards #21335.  (I locally developed & tested this in an Ubuntu 24.04 docker container. We don't have CI images ready for testing yet.)

Fix Python version in setup scripts; since the last time we prepped for Noble, the default Python switched from 3.11 to 3.12.  (FYI https://packages.ubuntu.com/noble/libpython3-dev.)

Add several GCC 13 error suppressions.  We'll need to circle back and deal with these later (#21337), but for now it's better to silence them so we can focus on any other build problems.

Override nlohmann/json spaceship probing. It's broken on GCC 13.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21338)
<!-- Reviewable:end -->
