### PR TITLE
[wheel] Disable IPOPT on macOS x86_64

### DIFF
--- a/tools/macos-arch-i386.bazelrc
+++ b/tools/macos-arch-i386.bazelrc
@@ -2,3 +2,6 @@
 
 # N.B. Ensure this is consistent with `execute.bzl`.
 build --action_env=PATH=/usr/local/bin:/usr/bin:/bin
+
+# Releases on macOS x86_64 no longer contain IPOPT.
+build:packaging --define=NO_IPOPT=ON

--- a/tools/wheel/image/dependencies/projects.cmake
+++ b/tools/wheel/image/dependencies/projects.cmake
@@ -27,7 +27,7 @@ set(lapack_md5 "d70fc27a8bdebe00481c97c728184f09")
 list(APPEND ALL_PROJECTS lapack)
 
 # ipopt (requires mumps)
-if(APPLE)
+if(APPLE_ARM64)
     set(mumps_version 5.4.1)  # Latest available in Ubuntu.
     set(mumps_url
         "http://archive.ubuntu.com/ubuntu/pool/universe/m/mumps/mumps_${mumps_version}.orig.tar.gz"

--- a/tools/wheel/test/tests/sanity-test.py
+++ b/tools/wheel/test/tests/sanity-test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import numpy
+import platform
 import pydrake.all
 
 # Basic sanity checks.
@@ -18,4 +19,7 @@ prog.AddLinearConstraint(x[0] >= 1)
 prog.AddLinearConstraint(x[1] >= 1)
 prog.AddQuadraticCost(numpy.eye(2), numpy.zeros(2), x)
 solver = pydrake.all.IpoptSolver()
-assert solver.Solve(prog, None, None).is_success(), 'IPOPT is not usable'
+if platform.system() == 'Darwin' and platform.machine() == 'x86_64':
+    assert not solver.available(), 'IPOPT is supposed to be disabled'
+else:
+    assert solver.Solve(prog, None, None).is_success(), 'IPOPT is not usable'


### PR DESCRIPTION
Until Homebrew offers standalone MUMPS (https://github.com/RobotLocomotion/drake/issues/20429), it's too much build hassle to enable IPOPT on macOS x86_64.  (With no Bazel caching, the iteration time is too slow.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21346)
<!-- Reviewable:end -->
