### PR TITLE
Allow ModelVisualizer to consume render camera configuration

### DIFF
--- a/bindings/pydrake/visualization/model_visualizer.py
+++ b/bindings/pydrake/visualization/model_visualizer.py
@@ -97,7 +97,23 @@ def _main():
         "--environment_map", default=Path(), type=Path,
         help="Filesystem path to an image to be used as an environment map. "
              "It must be an image type normally used by your browser (e.g., "
-             ".jpg, .png, etc.). HDR images are not supported yet."
+             ".jpg, .png, etc.). HDR images are not supported yet. This image "
+             "will only be used in the browser window, not the renderer ir "
+             "--show_rgbd_sensor has been specified. Use --camera_config to "
+             "add an environment to the camera."
+    )
+    args_parser.add_argument(
+        "--camera_config", default=None, type=Path,
+        help="Filesystem path to a yaml file containing the RenderEngineVtk "
+             "parameters. If a single camera is defined, it is used. If "
+             "multiple, an arbitrary camera is used. Only used if "
+             "--show_rgbd_sensor is true. Note: not all values in the config "
+             "file will be applied: (1) X_PB is always ignored, because the "
+             "camera is affixed to the Meshcat browser camera. For various "
+             "reasons, if cast_shadows is set to True, the displayed render "
+             "window will always be square (with a size equal to the larger "
+             "dimension) and with the camera's focus pushed down and to the "
+             "left."
     )
 
     args_parser.add_argument(
@@ -145,7 +161,8 @@ def _main():
                                   triad_opacity=args.triad_opacity,
                                   browser_new=args.browser_new,
                                   pyplot=args.pyplot,
-                                  environment_map=args.environment_map)
+                                  environment_map=args.environment_map,
+                                  camera_config=args.camera_config)
     package_map = visualizer.package_map()
     package_map.PopulateFromRosPackagePath()
     for item in args.filename:

--- a/bindings/pydrake/visualization/test/model_visualizer_camera_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_camera_test.py
@@ -1,5 +1,8 @@
 import pydrake.visualization as mut
 
+import logging
+from pathlib import Path
+import tempfile
 import unittest
 
 import numpy as np
@@ -73,3 +76,63 @@ class TestModelVisualizerCamera(unittest.TestCase):
         numpy_compare.assert_allclose(X_WB.GetAsMatrix34(),
                                       X_WB_expected.GetAsMatrix34(),
                                       atol=1e-15)
+
+    def test_camera_with_config(self):
+        # There are various additional pieces of logic that *could* be tested.
+        # For example, making sure that the X_PB values in the config file
+        # get ignored (in lieu of configuring the render camera to track the
+        # viewer camera). We're not testing these because if there are errors,
+        # they would become apparent during use. (E.g., the renderer would stop
+        # tracking the viewer's camera). These tests serve as a regression test
+        # against *not* consuming a camera configuration or messages in the
+        # event that parsing fails.
+
+        # Create a config file which configures the camera differently from
+        # the default.
+        renderer_name = "__unique_test_renderer__"
+        scratch_dir = Path(tempfile.mkdtemp())
+        config_file = scratch_dir / "test_config.yaml"
+        with open(config_file, "w") as f:
+            f.write(f"""
+renderer_name: {renderer_name}
+renderer_class: RenderEngineVtk
+width: 512
+height: 256
+""")
+        # If we don't provide a configuration file, we don't get a renderer
+        # with the expected name.
+        dut = mut.ModelVisualizer(show_rgbd_sensor=True)
+        dut.Finalize()
+        scene_graph = dut._diagram.scene_graph()
+        self.assertTrue(scene_graph.HasRenderer("default"))
+        self.assertFalse(scene_graph.HasRenderer(renderer_name))
+
+        # Providing a configuration file uses that file.
+        dut = mut.ModelVisualizer(show_rgbd_sensor=True,
+                                  camera_config=config_file)
+        dut.Finalize()
+        scene_graph = dut._diagram.scene_graph()
+        self.assertFalse(scene_graph.HasRenderer("default"))
+        self.assertTrue(scene_graph.HasRenderer(renderer_name))
+
+        # Config without requesting an rgbd sensor has no effect.
+        dut = mut.ModelVisualizer(show_rgbd_sensor=False,
+                                  camera_config=config_file)
+        dut.Finalize()
+        scene_graph = dut._diagram.scene_graph()
+        self.assertFalse(scene_graph.HasRenderer("default"))
+        self.assertFalse(scene_graph.HasRenderer(renderer_name))
+
+        # Various kinds of config loading errors produce a default camera.
+        # We'll use IOError as representative by passing an invalid path.
+        dut = mut.ModelVisualizer(show_rgbd_sensor=True,
+                                  camera_config=config_file / ".bad")
+        with self.assertLogs("drake", logging.WARNING) as cm:
+            dut.Finalize()
+        self.assertEqual(len(cm.records), 1)
+        self.assertRegex(cm.records[0].getMessage(),
+                         "Error reading camera config file.*")
+
+        scene_graph = dut._diagram.scene_graph()
+        self.assertTrue(scene_graph.HasRenderer("default"))
+        self.assertFalse(scene_graph.HasRenderer(renderer_name))


### PR DESCRIPTION
The user can now pass a yaml file representing a CameraConfig file into model visualizer. This allows for more direct ability to configure render cameras.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21347)
<!-- Reviewable:end -->
