### PR TITLE
[multibody] Adds loop-breaking to MbP topology

### DIFF
--- a/multibody/topology/BUILD.bazel
+++ b/multibody/topology/BUILD.bazel
@@ -56,6 +56,7 @@ drake_cc_library(
     ],
     deps = [
         "//common:copyable_unique_ptr",
+        "//common:string_container",
         "//multibody/tree:multibody_tree_indexes",
     ],
 )

--- a/multibody/topology/link_joint_graph.cc
+++ b/multibody/topology/link_joint_graph.cc
@@ -3,6 +3,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/string_unordered_map.h"
 #include "drake/multibody/topology/forest.h"
 #include "drake/multibody/topology/graph.h"
 
@@ -63,21 +64,49 @@ void LinkJointGraph::Clear() {
   // Joint type names used here must match the kTypeName members of the
   // matching Drake Joint types. Order matters here so we match the
   // predefined joint type indices.
-  DRAKE_DEMAND(RegisterJointType("weld", 0, 0) == weld_joint_type_index());
+  DRAKE_DEMAND(RegisterJointType("weld", 0, 0) == weld_joint_traits_index());
   DRAKE_DEMAND(RegisterJointType("quaternion_floating", 7, 6, true) ==
-               quaternion_floating_joint_type_index());
+               quaternion_floating_joint_traits_index());
   DRAKE_DEMAND(RegisterJointType("rpy_floating", 6, 6) ==
-               rpy_floating_joint_type_index());
+               rpy_floating_joint_traits_index());
 
   // Define the World Link.
   const BodyIndex world_index = AddLink("world", world_model_instance());
   DRAKE_DEMAND(world_index == BodyIndex(0));
 }
 
-void LinkJointGraph::BuildForest() {
+void LinkJointGraph::SetGlobalForestBuildingOptions(
+    ForestBuildingOptions global_options) {
   InvalidateForest();
-  data_.forest->BuildForest();  // (Re)build
+  data_.global_forest_building_options = global_options;
+}
+
+// Note that we're implicitly assuming that model instance indices will be
+// reasonably small integers. They don't have to be contiguous but we're
+// allocating an array big enough to hold everything up to the largest index
+// we've seen. This enables O(1) access to an element's options during forest
+// building.
+void LinkJointGraph::SetForestBuildingOptions(ModelInstanceIndex instance_index,
+                                              ForestBuildingOptions options) {
+  InvalidateForest();
+  if (instance_index >= ssize(data_.model_instance_forest_building_options)) {
+    data_.model_instance_forest_building_options.resize(instance_index + 1,
+                                                        std::nullopt);
+  }
+  data_.model_instance_forest_building_options[instance_index] = options;
+}
+
+void LinkJointGraph::ResetForestBuildingOptions() {
+  InvalidateForest();
+  data_.global_forest_building_options = ForestBuildingOptions::kDefault;
+  data_.model_instance_forest_building_options.clear();
+}
+
+bool LinkJointGraph::BuildForest() {
+  InvalidateForest();
+  const bool dynamics_ok = data_.forest->BuildForest();  // (Re)build
   data_.forest_is_valid = true;
+  return dynamics_ok;
 }
 
 void LinkJointGraph::InvalidateForest() {
@@ -106,9 +135,9 @@ void LinkJointGraph::InvalidateForest() {
   data_.ephemeral_link_name_to_index.clear();
   data_.ephemeral_joint_name_to_index.clear();
 
-  // Remove all as-modeled information from the graph.
-  for (auto& link : data_.links) link.clear_model(data_.num_user_joints);
-  for (auto& joint : data_.joints) joint.clear_model();
+  // Remove all as-modeled information from the user's graph.
+  for (auto& link : data_.links) link.ClearModel(data_.num_user_joints);
+  for (auto& joint : data_.joints) joint.ClearModel();
   data_.link_composites.clear();
 }
 
@@ -174,36 +203,36 @@ BodyIndex LinkJointGraph::AddLink(const std::string& link_name,
   return link_index;
 }
 
-bool LinkJointGraph::HasLinkNamed(const std::string& name,
-                                  ModelInstanceIndex model_instance) const {
-  DRAKE_DEMAND(model_instance.is_valid());
+bool LinkJointGraph::HasLinkNamed(
+    std::string_view name, ModelInstanceIndex model_instance_index) const {
+  DRAKE_DEMAND(model_instance_index.is_valid());
 
   // Search linearly on the assumption that we won't often have lots of
   // Links with the same name in different model instances.  If this turns
   // out to be incorrect we can switch to a different data structure.
   const auto range = data_.link_name_to_index.equal_range(name);
   for (auto it = range.first; it != range.second; ++it) {
-    if (links(it->second).model_instance() == model_instance) return true;
+    if (links(it->second).model_instance() == model_instance_index) return true;
   }
 
   const auto model_range = data_.ephemeral_link_name_to_index.equal_range(name);
   for (auto it = model_range.first; it != model_range.second; ++it) {
-    if (links(it->second).model_instance() == model_instance) return true;
+    if (links(it->second).model_instance() == model_instance_index) return true;
   }
 
   return false;
 }
 
-bool LinkJointGraph::HasJointNamed(const std::string& name,
-                                   ModelInstanceIndex model_instance) const {
-  DRAKE_DEMAND(model_instance.is_valid());
+bool LinkJointGraph::HasJointNamed(
+    std::string_view name, ModelInstanceIndex model_instance_index) const {
+  DRAKE_DEMAND(model_instance_index.is_valid());
 
   // Search linearly on the assumption that we won't often have lots of
   // joints with the same name in different model instances.  If this turns
   // out to be incorrect we can switch to a different data structure.
   const auto range = data_.joint_name_to_index.equal_range(name);
   for (auto it = range.first; it != range.second; ++it) {
-    if (joints(it->second).model_instance() == model_instance) {
+    if (joints(it->second).model_instance() == model_instance_index) {
       return true;
     }
   }
@@ -211,7 +240,7 @@ bool LinkJointGraph::HasJointNamed(const std::string& name,
   const auto model_range =
       data_.ephemeral_joint_name_to_index.equal_range(name);
   for (auto it = model_range.first; it != model_range.second; ++it) {
-    if (joints(it->second).model_instance() == model_instance) {
+    if (joints(it->second).model_instance() == model_instance_index) {
       return true;
     }
   }
@@ -219,8 +248,8 @@ bool LinkJointGraph::HasJointNamed(const std::string& name,
   return false;
 }
 
-JointIndex LinkJointGraph::MaybeGetJointBetween(BodyIndex link1_index,
-                                                BodyIndex link2_index) const {
+std::optional<JointIndex> LinkJointGraph::MaybeGetJointBetween(
+    BodyIndex link1_index, BodyIndex link2_index) const {
   // Work with the Link that has the fewest joints. (If one of these is World
   // it is probably the other one!)
   const Link& link1 = links(link1_index);
@@ -236,16 +265,16 @@ JointIndex LinkJointGraph::MaybeGetJointBetween(BodyIndex link1_index,
     const Joint& joint = joints(joint_index);
     if (joint.connects(link_to_look_for)) return joint_index;
   }
-  return JointIndex{};
+  return std::nullopt;
 }
 
 JointIndex LinkJointGraph::AddJoint(const std::string& name,
-                                    ModelInstanceIndex model_instance,
+                                    ModelInstanceIndex model_instance_index,
                                     const std::string& type,
                                     BodyIndex parent_link_index,
                                     BodyIndex child_link_index,
                                     JointFlags flags) {
-  DRAKE_DEMAND(model_instance.is_valid());
+  DRAKE_DEMAND(model_instance_index.is_valid());
   DRAKE_DEMAND(parent_link_index.is_valid());
   DRAKE_DEMAND(child_link_index.is_valid());
 
@@ -264,44 +293,43 @@ JointIndex LinkJointGraph::AddJoint(const std::string& name,
     throw std::logic_error(fmt::format(
         "{}(): Joint '{}' (model instance {}) would connect link '{}' "
         "to itself.",
-        __func__, name, model_instance, links(parent_link_index).name()));
+        __func__, name, model_instance_index, links(parent_link_index).name()));
   }
 
-  if (HasJointNamed(name, model_instance)) {
+  if (HasJointNamed(name, model_instance_index)) {
     throw std::logic_error(
         fmt::format("{}(): There is already a joint named '{}' in "
                     "the model instance with index {}.",
-                    __func__, name, model_instance));
+                    __func__, name, model_instance_index));
   }
 
-  const JointTypeIndex type_index = GetJointTypeIndex(type);
-  if (!type_index.is_valid()) {
+  const std::optional<JointTraitsIndex> type_index = GetJointTraitsIndex(type);
+  if (!type_index.has_value()) {
     throw std::logic_error(fmt::format(
         "{}(): Unrecognized type '{}' for joint '{}' (model instance {}).",
-        __func__, type, name, model_instance));
+        __func__, type, name, model_instance_index));
   }
 
   // Static Links are implicitly welded to World. We'll permit an explicit
   // joint only if it is a weld.
   const Link& new_parent = links(parent_link_index);
   const Link& new_child = links(child_link_index);
-  const bool anchoring = (new_parent.is_world() && new_child.is_static()) ||
-                         (new_child.is_world() && new_parent.is_static());
-  if (anchoring && type_index != weld_joint_type_index()) {
+  const bool is_static = (new_parent.is_world() && link_is_static(new_child)) ||
+                         (new_child.is_world() && link_is_static(new_parent));
+  if (is_static && type_index != weld_joint_traits_index()) {
     const std::string static_link_name =
         new_parent.is_world() ? new_child.name() : new_parent.name();
-    throw std::runtime_error(
-        fmt::format("{}(): can't connect static link '{}' to World "
-                    "using a {} joint; only a weld is permitted. "
-                    "(Joint '{}' in model instance {}.)",
-                    __func__, static_link_name, type, name, model_instance));
+    throw std::logic_error(fmt::format(
+        "{}(): can't connect static link '{}' to World "
+        "using a {} joint; only a weld is permitted. "
+        "(Joint '{}' in model instance {}.)",
+        __func__, static_link_name, type, name, model_instance_index));
   }
 
   // We only allow one Joint between any given pair of Links.
-  if (JointIndex existing_joint_index =
-          MaybeGetJointBetween(parent_link_index, child_link_index);
-      existing_joint_index.is_valid()) {
-    const Joint& existing_joint = joints(existing_joint_index);
+  if (std::optional<JointIndex> existing_joint_index =
+          MaybeGetJointBetween(parent_link_index, child_link_index)) {
+    const Joint& existing_joint = joints(*existing_joint_index);
     const Link& existing_parent = links(existing_joint.parent_link());
     const Link& existing_child = links(existing_joint.child_link());
 
@@ -310,16 +338,17 @@ JointIndex LinkJointGraph::AddJoint(const std::string& name,
         "connecting link '{}' to link '{}'. Therefore adding joint '{}' "
         "(model instance {}) connecting link '{}' to link '{}' is not allowed.",
         __func__, existing_joint.name(), existing_joint.model_instance(),
-        existing_parent.name(), existing_child.name(), name, model_instance,
-        new_parent.name(), new_child.name()));
+        existing_parent.name(), existing_child.name(), name,
+        model_instance_index, new_parent.name(), new_child.name()));
   }
 
   // If we have a SpanningForest, it's no good now.
   InvalidateForest();
 
   const JointIndex joint_index(ssize(joints()));  // next available index
-  data_.joints.emplace_back(Joint(joint_index, name, model_instance, type_index,
-                                  parent_link_index, child_link_index, flags));
+  data_.joints.emplace_back(Joint(joint_index, name, model_instance_index,
+                                  *type_index, parent_link_index,
+                                  child_link_index, flags));
   data_.num_user_joints = ssize(joints());
   data_.joint_name_to_index.insert({name, joint_index});  // fast name lookup
 
@@ -330,7 +359,7 @@ JointIndex LinkJointGraph::AddJoint(const std::string& name,
   return joint_index;
 }
 
-JointTypeIndex LinkJointGraph::RegisterJointType(
+JointTraitsIndex LinkJointGraph::RegisterJointType(
     const std::string& joint_type_name, int nq, int nv, bool has_quaternion) {
   // Reject duplicate type name.
   const auto it = data_.joint_type_name_to_index.find(joint_type_name);
@@ -343,15 +372,15 @@ JointTypeIndex LinkJointGraph::RegisterJointType(
   DRAKE_DEMAND(0 <= nq && nq <= 7 && 0 <= nv && nv <= 6 && nv <= nq);
   DRAKE_DEMAND(!has_quaternion || nq >= 4);
 
-  const JointTypeIndex joint_type_index(data_.joint_types.size());
-  data_.joint_types.push_back({.name = joint_type_name,
-                               .nq = nq,
-                               .nv = nv,
-                               .has_quaternion = has_quaternion});
-  data_.joint_type_name_to_index[joint_type_name] = joint_type_index;
+  const JointTraitsIndex joint_traits_index(data_.joint_traits.size());
+  data_.joint_traits.push_back({.name = joint_type_name,
+                                .nq = nq,
+                                .nv = nv,
+                                .has_quaternion = has_quaternion});
+  data_.joint_type_name_to_index[joint_type_name] = joint_traits_index;
   DRAKE_DEMAND(data_.joint_type_name_to_index.size() ==
-               data_.joint_types.size());
-  return joint_type_index;
+               data_.joint_traits.size());
+  return joint_traits_index;
 }
 
 bool LinkJointGraph::IsJointTypeRegistered(
@@ -363,7 +392,7 @@ bool LinkJointGraph::IsJointTypeRegistered(
 void LinkJointGraph::CreateWorldLinkComposite() {
   DRAKE_DEMAND(link_composites().empty() && !links().empty());
   Link& world_link = data_.links[BodyIndex(0)];
-  DRAKE_DEMAND(!world_link.link_composite_index_.is_valid());
+  DRAKE_DEMAND(!world_link.link_composite_index_.has_value());
   data_.link_composites.emplace_back(std::vector{BodyIndex(0)});
   world_link.link_composite_index_ = LinkCompositeIndex(0);
 }
@@ -386,15 +415,66 @@ LoopConstraintIndex LinkJointGraph::AddLoopClosingWeldConstraint(
   return index;
 }
 
-JointTypeIndex LinkJointGraph::GetJointTypeIndex(
+std::optional<JointTraitsIndex> LinkJointGraph::GetJointTraitsIndex(
     const std::string& joint_type_name) const {
   const auto it = data_.joint_type_name_to_index.find(joint_type_name);
-  return it == data_.joint_type_name_to_index.end() ? JointTypeIndex()
-                                                    : it->second;
+  if (it == data_.joint_type_name_to_index.end()) return std::nullopt;
+  return it->second;
+}
+
+void LinkJointGraph::ChangeLinkFlags(BodyIndex link_index, LinkFlags flags) {
+  InvalidateForest();
+  mutable_link(link_index).set_flags(flags);
+}
+
+void LinkJointGraph::ChangeJointFlags(JointIndex joint_index,
+                                      JointFlags flags) {
+  InvalidateForest();
+  mutable_joint(joint_index).set_flags(flags);
+}
+
+void LinkJointGraph::ChangeJointType(JointIndex existing_joint_index,
+                                     const std::string& name_of_new_type) {
+  DRAKE_DEMAND(existing_joint_index.is_valid() &&
+               existing_joint_index < ssize(joints()));
+  const std::optional<JointTraitsIndex> new_traits_index =
+      GetJointTraitsIndex(name_of_new_type);
+  DRAKE_DEMAND(new_traits_index.has_value());
+
+  const Joint& joint = joints(existing_joint_index);
+
+  if (existing_joint_index >= num_user_joints()) {
+    throw std::logic_error(
+        fmt::format("{}(): can't change the type of ephemeral joint {}; only "
+                    "user-defined joints are changeable.",
+                    __func__, joint.name()));
+  }
+
+  // If this is a joint between a static link and world, it can only be a
+  // weld (see AddJoint()).
+  const Link& parent_link = links(joint.parent_link());
+  const Link& child_link = links(joint.child_link());
+  const bool is_static =
+      (parent_link.is_world() && link_is_static(child_link)) ||
+      (child_link.is_world() && link_is_static(parent_link));
+  if (is_static && new_traits_index != weld_joint_traits_index()) {
+    const std::string static_link_name =
+        parent_link.is_world() ? child_link.name() : parent_link.name();
+    throw std::logic_error(fmt::format(
+        "{}(): can't change type of joint {} (in model instance {}) from {} to "
+        "{} because it connects static link {} to World; only a weld is "
+        "permitted for a static link.",
+        __func__, joint.name(), joint.model_instance(),
+        joint_traits(joint.traits_index()).name, name_of_new_type,
+        static_link_name));
+  }
+
+  InvalidateForest();
+  mutable_joint(existing_joint_index).traits_index_ = *new_traits_index;
 }
 
 JointIndex LinkJointGraph::AddEphemeralJointToWorld(
-    JointTypeIndex type_index, BodyIndex child_link_index) {
+    JointTraitsIndex type_index, BodyIndex child_link_index) {
   const LinkJointGraph::Link& child = links(child_link_index);
   const JointIndex new_joint_index(ssize(joints()));
   const ModelInstanceIndex model_instance = child.model_instance();
@@ -428,9 +508,9 @@ LinkCompositeIndex LinkJointGraph::AddToLinkComposite(
   Link& new_link = mutable_link(new_link_index);
   DRAKE_DEMAND(!new_link.is_world());
 
-  LinkCompositeIndex existing_composite =
+  std::optional<LinkCompositeIndex> existing_composite =
       maybe_composite_link.link_composite_index_;
-  if (!existing_composite.is_valid()) {
+  if (!existing_composite.has_value()) {
     // We're starting a new LinkComposite. This must be the "active link"
     // for this Composite because we saw it first while building the Forest.
     existing_composite = maybe_composite_link.link_composite_index_ =
@@ -438,10 +518,43 @@ LinkCompositeIndex LinkJointGraph::AddToLinkComposite(
     data_.link_composites.emplace_back(
         std::vector<BodyIndex>{maybe_composite_link_index});
   }
-  data_.link_composites[existing_composite].push_back(new_link_index);
+  data_.link_composites[*existing_composite].push_back(new_link_index);
   new_link.link_composite_index_ = existing_composite;
 
-  return existing_composite;
+  return *existing_composite;
+}
+
+BodyIndex LinkJointGraph::AddShadowLink(BodyIndex primary_link_index,
+                                        JointIndex shadow_joint_index,
+                                        bool shadow_is_parent) {
+  /* Caution: this Link reference will be invalid after the emplace. */
+  const Link& primary_link = links(primary_link_index);
+  const int shadow_num = primary_link.num_shadows() + 1;
+  /* Name should be <primary_name>$<shadow_num> (unique within primary's model
+  instance). In the unlikely event that a user has names like this, we'll keep
+  prepending "_" to the body name until this one is unique. Nothing much depends
+  on the details of this name. */
+  std::string shadow_link_name =
+      fmt::format("{}${}", primary_link.name(), shadow_num);
+  while (HasLinkNamed(shadow_link_name, primary_link.model_instance()))
+    shadow_link_name = "_" + shadow_link_name;
+  const BodyIndex shadow_link_index(ssize(links()));
+  DRAKE_DEMAND(shadow_link_index >= num_user_links());  // A sanity check.
+  data_.ephemeral_link_name_to_index.insert(
+      {shadow_link_name, shadow_link_index});
+  data_.links.emplace_back(Link(shadow_link_index, shadow_link_name,
+                                primary_link.model_instance(),
+                                LinkFlags::kShadow));
+  Link& shadow_link = data_.links.back();
+  shadow_link.primary_link_ = primary_link_index;
+  if (shadow_is_parent) {
+    shadow_link.add_joint_as_parent(shadow_joint_index);
+  } else {
+    shadow_link.add_joint_as_child(shadow_joint_index);
+  }
+  mutable_link(primary_link_index).shadow_links_.push_back(shadow_link_index);
+
+  return shadow_link.index();
 }
 
 void LinkJointGraph::RenumberMobodIndexes(
@@ -458,10 +571,17 @@ std::tuple<BodyIndex, BodyIndex, bool> LinkJointGraph::FindInboardOutboardLinks(
       parent_link.mobod_index() == inboard_mobod_index) {
     return std::make_tuple(joint.parent_link(), joint.child_link(), false);
   }
-  const LinkJointGraph::Link& child_link = links(joint.child_link());
+  const Link& child_link = links(joint.child_link());
   DRAKE_DEMAND(child_link.mobod_index().is_valid() &&
                child_link.mobod_index() == inboard_mobod_index);
   return std::make_tuple(joint.child_link(), joint.parent_link(), true);
+}
+
+bool LinkJointGraph::link_is_static(const Link& link) const {
+  if (link.is_static()) return true;  // The flag is set.
+  return static_cast<bool>(
+      get_forest_building_options_in_use(link.model_instance()) &
+      ForestBuildingOptions::kStatic);
 }
 
 LinkJointGraph::Data::Data() = default;
@@ -479,23 +599,47 @@ LinkJointGraph::Link::Link(BodyIndex index, std::string name,
       flags_(flags) {
   DRAKE_DEMAND(index_.is_valid() && !name_.empty() &&
                model_instance_.is_valid());
+  // Shadow links overwrite this with their actual primary; everyone else
+  // is just a self-primary.
+  primary_link_ = index_;
+}
+
+void LinkJointGraph::Link::ClearModel(int num_user_joints) {
+  DRAKE_DEMAND(!is_shadow());  // Those should already have been removed.
+  DRAKE_DEMAND(primary_link_ == index_);  // True for any user link.
+
+  auto remove_ephemeral_joints =
+      [num_user_joints](std::vector<JointIndex>& joints) {
+        while (!joints.empty() && joints.back() >= num_user_joints)
+          joints.pop_back();
+      };
+
+  remove_ephemeral_joints(joints_as_parent_);
+  remove_ephemeral_joints(joints_as_child_);
+  remove_ephemeral_joints(joints_);
+
+  loop_constraints_.clear();  // Always ephemeral.
+  mobod_ = {};
+  joint_ = {};
+  shadow_links_.clear();
+  link_composite_index_ = {};
 }
 
 LinkJointGraph::Joint::Joint(JointIndex index, std::string name,
                              ModelInstanceIndex model_instance,
-                             JointTypeIndex joint_type_index,
+                             JointTraitsIndex joint_traits_index,
                              BodyIndex parent_link_index,
                              BodyIndex child_link_index, JointFlags flags)
     : index_(index),
       name_(std::move(name)),
       model_instance_(model_instance),
       flags_(flags),
-      type_index_(joint_type_index),
+      traits_index_(joint_traits_index),
       parent_link_index_(parent_link_index),
       child_link_index_(child_link_index) {
   DRAKE_DEMAND(index_.is_valid() && !name_.empty() &&
                model_instance_.is_valid());
-  DRAKE_DEMAND(type_index_.is_valid() && parent_link_index_.is_valid() &&
+  DRAKE_DEMAND(traits_index_.is_valid() && parent_link_index_.is_valid() &&
                child_link_index_.is_valid());
   DRAKE_DEMAND(parent_link_index_ != child_link_index_);
 }

--- a/multibody/topology/link_joint_graph.h
+++ b/multibody/topology/link_joint_graph.h
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <tuple>
@@ -16,6 +17,7 @@
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/ssize.h"
+#include "drake/common/string_unordered_map.h"
 #include "drake/multibody/topology/link_joint_graph_defs.h"
 
 namespace drake {
@@ -90,7 +92,13 @@ class LinkJointGraph {
   class Joint;
   class LoopConstraint;
 
-  struct JointType;  // Defined below.
+  /** This is all we need to know about joint types for topological purposes. */
+  struct JointTraits {
+    std::string name;
+    int nq{-1};
+    int nv{-1};
+    bool has_quaternion{false};  // If so, the first 4 qs are wxyz.
+  };
 
   /** Default construction defines well-known joint types and World. */
   LinkJointGraph();
@@ -103,10 +111,7 @@ class LinkJointGraph {
   instance that does not have its own forest building options set. Invalidates
   the current forest.
   @see SetForestBuildingOptions() */
-  void SetGlobalForestBuildingOptions(ForestBuildingOptions global_options) {
-    InvalidateForest();
-    data_.global_forest_building_options = global_options;
-  }
+  void SetGlobalForestBuildingOptions(ForestBuildingOptions global_options);
 
   /** Gets the forest building options to be used for elements of any model
   instance that does not have its own forest building options set. If no call
@@ -125,44 +130,44 @@ class LinkJointGraph {
   world_model_instance() and default_model_instance() respectively.
   @see SetGlobalForestBuildingOptions() */
   void SetForestBuildingOptions(ModelInstanceIndex model_instance,
-                                ForestBuildingOptions options) {
-    InvalidateForest();
-    data_.model_instance_forest_building_options[model_instance] = options;
-  }
+                                ForestBuildingOptions options);
 
   /** Gets the forest building options to be used for elements of the given
-  `model_instance`. Returns the options set explicitly for this
-  `model_instance`, if any. Otherwise, returns what
-  get_global_forest_building_options() returns. */
+  model instance. Returns the options set explicitly for this model instance,
+  if any. Otherwise, returns what get_global_forest_building_options() returns.
+  @pre `instance_index` is any valid index */
   ForestBuildingOptions get_forest_building_options_in_use(
-      ModelInstanceIndex model_instance) const {
-    DRAKE_DEMAND(model_instance.is_valid());
-    auto instance_options =
-        data_.model_instance_forest_building_options.find(model_instance);
-    return instance_options ==
-                   data_.model_instance_forest_building_options.end()
-               ? get_global_forest_building_options()  // Use global default.
-               : instance_options->second;
+      ModelInstanceIndex instance_index) const {
+    return get_model_instance_options(instance_index)
+        .value_or(get_global_forest_building_options());
   }
 
   /** Resets the global forest building options to kDefault and removes any
   per-model instance options that were set. */
-  void ResetForestBuildingOptions() {
-    InvalidateForest();
-    data_.global_forest_building_options = ForestBuildingOptions::kDefault;
-    data_.model_instance_forest_building_options.clear();
-  }
+  void ResetForestBuildingOptions();
 
   /** Models this LinkJointGraph as a spanning forest, records the result
   into this graph's SpanningForest object, and marks it valid. The currently-set
   forest building options are used. This is done unconditionally; if there
   was already a valid forest it is cleared and then rebuilt. If you don't want
   to rebuild unnecessarily, call forest_is_valid() first to check.
+
+  If there are massless links in the graph, it is possible that one of them
+  ends as the terminal link in a branch. In that case the resulting system will
+  have a singular mass matrix and be unsuited for dynamics. However, it can
+  still be used for kinematics, visualization, and some other analyses so the
+  forest is still considered valid. In that case we return `false` here and
+  a human-readable message explaining what happened is available in case you
+  want to report it.
+
+  @returns true if the resulting forest can be used for dynamics.
   @see forest_is_valid() to check whether the SpanningForest is already up
     to date with the graph's contents.
   @see forest() for access to the SpanningForest object.
+  @see forest().why_no_dynamics() for a human-readable explanation if
+    BuildForest() returned `false`.
   @see InvalidateForest() */
-  void BuildForest();
+  bool BuildForest();
 
   /** Invalidates this LinkJointGraph's SpanningForest and removes ephemeral
   "as-built" Link, Joint, and Constraint elements that were added to the graph
@@ -203,14 +208,16 @@ class LinkJointGraph {
   @param[in] model_instance
     The model instance to which this Link belongs.
   @param[in] flags
-    Optional LinkFlags requesting special handling for this Link.
+    Optional LinkFlags requesting special handling for this Link. Don't set
+    any flags marked "internal use only" (currently just `Shadow`).
   @note The World Link is always predefined with name "world" (case sensitive),
     model instance world_model_instance(), and index 0.
   @returns The unique BodyIndex for the added Link in the graph.
   @throws std::exception if `name` is duplicated within `model_instance`.
   @throws std::exception if an attempt is made to add a link into the World's
     model instance
-  @throws std::exception if the internal-only Shadow flag is set. */
+  @throws std::exception if the `flags` parameter has any internal-only flags
+    set (currently just `Shadow`). */
   BodyIndex AddLink(const std::string& name, ModelInstanceIndex model_instance,
                     LinkFlags flags = LinkFlags::kDefault);
 
@@ -244,7 +251,7 @@ class LinkJointGraph {
   @throws std::exception if a static Link is connected to World by anything
       other than a "weld" Joint. */
   JointIndex AddJoint(const std::string& name,
-                      ModelInstanceIndex model_instance,
+                      ModelInstanceIndex model_instance_index,
                       const std::string& type, BodyIndex parent_link_index,
                       BodyIndex child_link_index,
                       JointFlags flags = JointFlags::kDefault);
@@ -252,7 +259,7 @@ class LinkJointGraph {
   /** Returns the Link that corresponds to World (always predefined). */
   const Link& world_link() const;
 
-  /** Registers a joint type by name.
+  /** Registers a joint type by name and provides the joint traits for it.
   @param[in] joint_type_name
     A unique string identifying a joint type, such as "revolute" or
     "prismatic". Should match the MultibodyPlant name for the Joint it
@@ -265,31 +272,33 @@ class LinkJointGraph {
     of this type of Joint.
   @param[in] has_quaternion
     Whether the first four q values represent a quaternion (in w[xyz] order).
-  @retval joint_type_index
+  @retval joint_traits_index
     Unique index assigned to the new joint type.
   @throws std::exception if `joint_type_name` was already used for a
     previously registered joint type.
   @pre 0 ≤ nq ≤ 7, 0 ≤ nv ≤ 6, nv ≤ nq, !has_quaternion or nq ≥ 4.
 
-  @note LinkJointGraph is preloaded with Drake-specific Joint types it needs to
-  know about including "weld", "quaternion_floating", and "rpy_floating". */
-  JointTypeIndex RegisterJointType(const std::string& joint_type_name, int nq,
-                                   int nv, bool has_quaternion = false);
+  @note LinkJointGraph is preloaded with the traits for Drake-specific Joint
+  types it needs to know about including "weld", "quaternion_floating", and
+  "rpy_floating". */
+  JointTraitsIndex RegisterJointType(const std::string& joint_type_name, int nq,
+                                     int nv, bool has_quaternion = false);
 
   /** Returns `true` if the given `joint_type_name` was previously registered
   via a call to RegisterJointType(), or is one of the pre-registered names. */
   bool IsJointTypeRegistered(const std::string& joint_type_name) const;
 
-  /** Returns a reference to the vector of known and registered Joint types. */
-  const std::vector<JointType>& joint_types() const {
-    return data_.joint_types;
+  /** Returns a reference to the vector of traits for the known and registered
+  Joint types. */
+  const std::vector<JointTraits>& joint_traits() const {
+    return data_.joint_traits;
   }
 
-  /** Returns a reference to a particular JointType using one of the
+  /** Returns a reference to a particular JointTraits object using one of the
   predefined indices or an index returned by RegisterJointType(). Requires a
-  JointTypeIndex, not a plain integer.*/
-  const JointType& joint_types(JointTypeIndex index) const {
-    return joint_types().at(index);
+  JointTraitsIndex, not a plain integer.*/
+  const JointTraits& joint_traits(JointTraitsIndex index) const {
+    return joint_traits().at(index);
   }
 
   /** Returns a reference to the vector of Link objects. World is always the
@@ -305,11 +314,13 @@ class LinkJointGraph {
   const std::vector<Joint>& joints() const { return data_.joints; }
 
   /** Returns a reference to a particular Joint using the index returned by
-  AddJoint(). Joints added by BuildForest() are indexed last. Requires a
-  JointIndex, not a plain integer. */
+  AddJoint(). Ephemeral joints added by BuildForest() are indexed last. Requires
+  a JointIndex, not a plain integer. */
   inline const Joint& joints(JointIndex joint_index) const;
 
-  /** Returns a reference to the vector of LoopConstraint objects. */
+  /** Returns a reference to the vector of LoopConstraint objects. These are
+  always "ephemeral" (added during forest-building) so this will return empty
+  if there is no valid Forest. See the class comment for more information. */
   const std::vector<LoopConstraint>& loop_constraints() const {
     return data_.loop_constraints;
   }
@@ -319,17 +330,20 @@ class LinkJointGraph {
   inline const LoopConstraint& loop_constraints(
       LoopConstraintIndex constraint_index) const;
 
-  /** Links with this index or higher were added during modeling. */
+  /** Links with this index or higher are "ephemeral" (added during
+  forest-building). See the class comment for more information. */
   int num_user_links() const { return data_.num_user_links; }
 
-  /** Joints with this index or higher were added during modeling. */
+  /** Joints with this index or higher are "ephemeral" (added during
+  forest-building). See the class comment for more information. */
   int num_user_joints() const { return data_.num_user_joints; }
 
-  /** After the Forest has been built, returns the mobilized body (Mobod)
-  followed by this Link. If the Link is part of a composite, this will be the
-  mobilized body for the whole composite. If the Link was split into a primary
-  and shadows, this is the mobilized body followed by the primary. */
-  MobodIndex link_to_mobod(BodyIndex index) const;  // See below
+  /** After the SpanningForest has been built, returns the mobilized body
+  (Mobod) followed by this Link. If the Link is part of a composite, this will
+  be the mobilized body for the whole composite. If the Link was split into a
+  primary and shadows, this is the mobilized body followed by the primary. If
+  there is no valid Forest, the returned index will be invalid. */
+  MobodIndex link_to_mobod(BodyIndex index) const;
 
   /** After the SpanningForest has been built, returns groups of Links that are
   welded together, which we call "LinkComposites". Each group may be modeled
@@ -337,18 +351,23 @@ class LinkJointGraph {
   depending on modeling options, but that doesn't change anything here. The
   first entry in each LinkComposite is the "active link", the one whose
   (non-weld) Joint moves the whole LinkComposite due to its modeling in the
-  Spanning Forest. The rest of the Links in the composite are listed in no
+  SpanningForest. The rest of the Links in the composite are listed in no
   particular order.
 
-  The 0th LinkComposite is always present and its first entry is World
-  (Link 0), even if nothing else is welded to World. Otherwise, composites
-  are present here if they contain two or more welded Links; Links that aren't
-  welded to any other Links are not included here at all. LinkComposites
-  are discovered as a side effect of Forest-building; there is no cost to
-  accessing them here. */
+  The 0th LinkComposite is always present (if there is a valid SpanningForest)
+  and its first entry is World (Link 0), even if nothing else is welded to
+  World. Otherwise, composites are present here if they contain two or more
+  welded Links; Links that aren't welded to any other Links are not included
+  here at all. LinkComposites are discovered as a side effect of
+  forest-building; there is no cost to accessing them here.
+
+  If there is no valid Forest, the returned vector is empty. */
   const std::vector<std::vector<BodyIndex>>& link_composites() const {
     return data_.link_composites;
   }
+
+  /** Returns a reference to a particular LinkComposite. Requires a
+  LinkCompositeIndex, not a plain integer.*/
   const std::vector<BodyIndex>& link_composites(
       LinkCompositeIndex composite_link_index) const {
     return link_composites().at(composite_link_index);
@@ -356,47 +375,62 @@ class LinkJointGraph {
 
   /** @returns `true` if a Link named `name` was added to `model_instance`.
   @see AddLink().
-  @throws std::exception if `model_instance` is not a valid index. */
-  bool HasLinkNamed(const std::string& name,
-                    ModelInstanceIndex model_instance) const;
+  @throws std::exception if `model_instance_index` is not a valid index. */
+  bool HasLinkNamed(std::string_view name,
+                    ModelInstanceIndex model_instance_index) const;
 
   /** @returns `true` if a Joint named `name` was added to `model_instance`.
   @see AddJoint().
-  @throws std::exception if `model_instance` is not a valid index. */
-  bool HasJointNamed(const std::string& name,
-                     ModelInstanceIndex model_instance) const;
+  @throws std::exception if `model_instance_index` is not a valid index. */
+  bool HasJointNamed(std::string_view name,
+                     ModelInstanceIndex model_instance_index) const;
 
-  /** If there is a Joint connecting the given Links, returns its index.
-  Otherwise the returned index will be invalid. You can call this any time and
-  it will work with whatever Joints have been defined. But note that Links may
-  be split and additional Joints added during Forest building, so you may get a
-  different answer before and after modeling. Cost is O(j) where j=min(j₁,j₂)
-  with jᵢ the number of Joints attached to linkᵢ. */
-  JointIndex MaybeGetJointBetween(BodyIndex link1_index,
-                                  BodyIndex link2_index) const;
+  /** If there is a Joint connecting the given Links, returns its index. You can
+  call this any time and it will work with whatever Joints have been defined.
+  But note that Links may be split and additional Joints added during Forest
+  building, so you may get a different answer before and after modeling. Cost is
+  O(j) where j=min(j₁,j₂) with jᵢ the number of Joints attached to linkᵢ. */
+  std::optional<JointIndex> MaybeGetJointBetween(BodyIndex link1_index,
+                                                 BodyIndex link2_index) const;
+
+  /** Returns true if the given Link should be treated as massless. That
+  requires that the Link was marked TreatAsMassless and is not connected by
+  a Weld Joint to a massful Link or Composite. */
+  bool must_treat_as_massless(BodyIndex link_index) const;
+
+  /** (Internal use only) For testing -- invalidates the Forest. */
+  void ChangeLinkFlags(BodyIndex link_index, LinkFlags flags);
+
+  /** (Internal use only) For testing -- invalidates the Forest. */
+  void ChangeJointFlags(JointIndex joint_index, JointFlags flags);
+
+  /** (Internal use only) Changes the type of an existing user-defined Joint
+  without making any other changes. Invalidates the Forest, even if the new
+  type is the same as the current type.
+  @throws std::exception if called on an ephemeral (added) joint.
+  @throws std::exception if an attempt is made to change a static link's joint
+   to anything other than a weld.
+  @pre the joint index is in range and the type name is of a registered or
+    predefined joint type. */
+  void ChangeJointType(JointIndex existing_joint_index,
+                       const std::string& name_of_new_type);
 
   // Forest building requires these joint types so they are predefined.
 
-  /** The predefined index for the "weld" joint type. */
-  static JointTypeIndex weld_joint_type_index() { return JointTypeIndex(0); }
-
-  /** The predefined index for the "quaternion_floating" joint type. */
-  static JointTypeIndex quaternion_floating_joint_type_index() {
-    return JointTypeIndex(1);
+  /** The predefined index for the "weld" joint type's traits. */
+  static JointTraitsIndex weld_joint_traits_index() {
+    return JointTraitsIndex(0);
   }
 
-  /** The predefined index for the "rpy_floating" joint type. */
-  static JointTypeIndex rpy_floating_joint_type_index() {
-    return JointTypeIndex(2);
+  /** The predefined index for the "quaternion_floating" joint type's traits. */
+  static JointTraitsIndex quaternion_floating_joint_traits_index() {
+    return JointTraitsIndex(1);
   }
 
-  /** This is all we need to know about joint types for topological purposes. */
-  struct JointType {
-    std::string name;
-    int nq{-1};
-    int nv{-1};
-    bool has_quaternion{false};  // If so, the first 4 qs are wxyz.
-  };
+  /** The predefined index for the "rpy_floating" joint type's traits. */
+  static JointTraitsIndex rpy_floating_joint_traits_index() {
+    return JointTraitsIndex(2);
+  }
 
  private:
   friend class SpanningForest;
@@ -442,7 +476,7 @@ class LinkJointGraph {
   // Adds the ephemeral Joint for a floating or fixed base Link to mirror a
   // mobilizer added during BuildForest(). World is the parent and the given
   // base Link is the child for the new Joint.
-  JointIndex AddEphemeralJointToWorld(JointTypeIndex type_index,
+  JointIndex AddEphemeralJointToWorld(JointTraitsIndex type_index,
                                       BodyIndex child_link_index);
 
   // Adds the new Link to the LinkComposite of which maybe_composite_link is a
@@ -452,10 +486,24 @@ class LinkJointGraph {
   LinkCompositeIndex AddToLinkComposite(BodyIndex maybe_composite_link_index,
                                         BodyIndex new_link_index);
 
-  // Finds the assigned index for a joint type from the type name. Returns an
-  // invalid index if `joint_type_name` was not previously registered with a
-  // call to RegisterJointType().
-  JointTypeIndex GetJointTypeIndex(const std::string& joint_type_name) const;
+  // While building the Forest, adds a new Shadow link to the given Primary
+  // link, with the Shadow mobilized by the given joint. We'll derive a name for
+  // the Shadow from the Primary, create the link with appropriate bookkeeping,
+  // and add a LoopConstraint (a weld) between the Primary and Shadow. The
+  // Shadow link's Mobod is always terminal in the forest but the Shadow link
+  // may serve as the parent link for the joint if the sense of the joint is
+  // reversed from the implementing mobilizer. Note: A Drake weld constraint
+  // connects a "parent" link to a "child" link; that ordering determines the
+  // sign convention for its multipliers (forces). We always make the Primary
+  // the weld's parent link, and the Shadow its child.
+  BodyIndex AddShadowLink(BodyIndex primary_link_index,
+                          JointIndex shadow_joint_index, bool shadow_is_parent);
+
+  // Finds the assigned index for a joint's traits from the joint's type name.
+  // Returns nullopt if `joint_type_name` was not previously registered
+  // with a call to RegisterJointType().
+  std::optional<JointTraitsIndex> GetJointTraitsIndex(
+      const std::string& joint_type_name) const;
 
   // Links that were explicitly flagged LinkFlags::kStatic in AddLink().
   const std::vector<BodyIndex>& static_links() const {
@@ -467,6 +515,20 @@ class LinkJointGraph {
   // definition they are welded to World).
   const std::vector<BodyIndex>& non_static_must_be_base_body_links() const {
     return data_.non_static_must_be_base_body_links;
+  }
+
+  // A link is static if it is in a static model instance or if it has been
+  // explicitly marked static.
+  bool link_is_static(const Link& link) const;
+
+  // For any valid index: if in range, returns the stored model instance options
+  // (which will be nullopt if never set), otherwise nullopt.
+  std::optional<ForestBuildingOptions> get_model_instance_options(
+      ModelInstanceIndex instance_index) const {
+    DRAKE_ASSERT(instance_index.is_valid());
+    return instance_index < ssize(data_.model_instance_forest_building_options)
+               ? data_.model_instance_forest_building_options[instance_index]
+               : std::nullopt;
   }
 
   // Group data members so we can have the compiler generate most of the
@@ -481,7 +543,7 @@ class LinkJointGraph {
     Data& operator=(const Data&);
     Data& operator=(Data&&);
 
-    std::vector<JointType> joint_types;
+    std::vector<JointTraits> joint_traits;
 
     // The first entry in links is the World Link with BodyIndex(0) and name
     // world_link().name(). Ephemeral "as-built" links and joints are placed
@@ -506,15 +568,15 @@ class LinkJointGraph {
     std::map<ModelInstanceIndex, std::vector<BodyIndex>>
         model_instance_to_links;
 
-    // This must always have the same number of entries as joint_types_.
-    std::unordered_map<std::string, JointTypeIndex> joint_type_name_to_index;
+    // This must always have the same number of entries as joint_traits_.
+    string_unordered_map<JointTraitsIndex> joint_type_name_to_index;
 
     // The xxx_name_to_index_ structures are multimaps because
     // links/joints/actuators/etc may appear with the same name in different
     // model instances. The index values are still unique across the graph.
     // These include only user-supplied links and joints.
-    std::unordered_multimap<std::string, BodyIndex> link_name_to_index;
-    std::unordered_multimap<std::string, JointIndex> joint_name_to_index;
+    string_unordered_multimap<BodyIndex> link_name_to_index;
+    string_unordered_multimap<JointIndex> joint_name_to_index;
 
     // The 0th composite always exists and contains World (listed first)
     // and any links welded (recursively) to World. The other composites are
@@ -527,14 +589,14 @@ class LinkJointGraph {
     // These parallel {link,joint}_name_to_index except they hold mappings
     // for ephemeral links and joints added during forest-building. We keep
     // them separately so they are easy to get rid of.
-    std::unordered_multimap<std::string, BodyIndex>
-        ephemeral_link_name_to_index;
-    std::unordered_multimap<std::string, JointIndex>
-        ephemeral_joint_name_to_index;
+    string_unordered_multimap<BodyIndex> ephemeral_link_name_to_index;
+    string_unordered_multimap<JointIndex> ephemeral_joint_name_to_index;
 
     ForestBuildingOptions global_forest_building_options{
         ForestBuildingOptions::kDefault};
-    std::map<ModelInstanceIndex, ForestBuildingOptions>
+
+    // Indexed by ModelInstanceIndex.
+    std::vector<std::optional<ForestBuildingOptions>>
         model_instance_forest_building_options;
 
     // Contains a back pointer to the graph so needs fixup post copy or move.

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -4,6 +4,8 @@
 #error Do not include this file. Use "drake/multibody/topology/graph.h".
 #endif
 
+#include <cstdint>
+
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 
 namespace drake {
@@ -13,13 +15,13 @@ namespace internal {
 
 class SpanningForest;
 
-using JointTypeIndex = TypeSafeIndex<class JointTypeTag>;
+using JointTraitsIndex = TypeSafeIndex<class JointTraitsTag>;
 using LinkCompositeIndex = TypeSafeIndex<class LinkCompositeTag>;
 using LoopConstraintIndex = TypeSafeIndex<class LoopConstraintTag>;
 
 /** Link properties that can affect how the forest model gets built. Or-ing
 these also produces a LinkFlags object. */
-enum class LinkFlags : unsigned {
+enum class LinkFlags : uint32_t {
   kDefault = 0,
   kStatic = 1 << 0,           ///< Implicitly welded to World.
   kMustBeBaseBody = 1 << 1,   ///< Ensure connection to World if none.
@@ -29,7 +31,7 @@ enum class LinkFlags : unsigned {
 
 /** Joint properties that can affect how the SpanningForest gets built. Or-ing
 these also produces a JointFlags object. */
-enum class JointFlags : unsigned {
+enum class JointFlags : uint32_t {
   kDefault = 0,
   kMustBeModeled = 1 << 0  ///< Model explicitly even if ignorable weld.
 };
@@ -37,7 +39,7 @@ enum class JointFlags : unsigned {
 /** Options for how to build the SpanningForest. Or-ing these also produces a
 ForestBuildingOptions object. These can be provided as per-model instance
 options to locally override global options. */
-enum class ForestBuildingOptions : unsigned {
+enum class ForestBuildingOptions : uint32_t {
   kDefault = 0,
   kStatic = 1 << 0,                ///< Weld all links to World.
   kUseFixedBase = 1 << 1,          ///< Use welds rather than floating joints.

--- a/multibody/topology/link_joint_graph_inlines.h
+++ b/multibody/topology/link_joint_graph_inlines.h
@@ -32,6 +32,13 @@ inline void LinkJointGraph::set_primary_mobod_for_link(
   link.joint_ = primary_joint_index;
 }
 
+inline bool LinkJointGraph::must_treat_as_massless(BodyIndex link_index) const {
+  const Link& link = links(link_index);
+  // TODO(sherm1) If part of a Composite then this is only massless if the
+  //  entire Composite is composed of massless Links.
+  return link.treat_as_massless();
+}
+
 // LinkJointGraph definitions deferred until Joint defined.
 
 inline auto LinkJointGraph::joints(JointIndex joint_index) const

--- a/multibody/topology/link_joint_graph_joint.h
+++ b/multibody/topology/link_joint_graph_joint.h
@@ -34,10 +34,10 @@ class LinkJointGraph::Joint {
   BodyIndex child_link() const { return child_link_index_; }
 
   /** Returns `true` if this is a Weld %Joint. */
-  bool is_weld() const { return type_index() == weld_joint_type_index(); }
+  bool is_weld() const { return traits_index() == weld_joint_traits_index(); }
 
-  /** Returns the index of this %Joint's joint type. */
-  JointTypeIndex type_index() const { return type_index_; }
+  /** Returns the index of this %Joint's traits. */
+  JointTraitsIndex traits_index() const { return traits_index_; }
 
   /** Returns `true` if either the parent or child Link of this %Joint is
   the specified `link`. */
@@ -89,10 +89,10 @@ class LinkJointGraph::Joint {
   friend class LinkJointGraphTester;
 
   Joint(JointIndex index, std::string name, ModelInstanceIndex model_instance,
-        JointTypeIndex joint_type_index, BodyIndex parent_link_index,
+        JointTraitsIndex joint_traits_index, BodyIndex parent_link_index,
         BodyIndex child_link_index, JointFlags flags);
 
-  void clear_model() { how_modeled_ = std::monostate{}; }
+  void ClearModel() { how_modeled_ = std::monostate{}; }
 
   // (For testing) If `to_set` is JointFlags::kDefault sets the flags to
   // kDefault. Otherwise or's in the given flags to the current set. Returns
@@ -115,7 +115,7 @@ class LinkJointGraph::Joint {
   ModelInstanceIndex model_instance_;
   JointFlags flags_{JointFlags::kDefault};
 
-  JointTypeIndex type_index_;
+  JointTraitsIndex traits_index_;
   BodyIndex parent_link_index_;
   BodyIndex child_link_index_;
 

--- a/multibody/topology/link_joint_graph_link.h
+++ b/multibody/topology/link_joint_graph_link.h
@@ -4,6 +4,7 @@
 #error Do not include this file. Use "drake/multibody/topology/graph.h".
 #endif
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -62,8 +63,7 @@ class LinkJointGraph::Link {
   of the World Composite (that is, it is directly or indirectly welded to
   World). */
   bool is_anchored() const {
-    return is_world() || is_static() ||
-           (composite().is_valid() && composite() == LinkCompositeIndex(0));
+    return is_world() || is_static() || (composite() == LinkCompositeIndex(0));
   }
 
   /** Returns `true` if this %Link was added with LinkFlags::kStatic. */
@@ -110,9 +110,12 @@ class LinkJointGraph::Link {
   modeled by the Mobod returned by mobod_index(). */
   JointIndex inboard_joint_index() const { return joint_; }
 
-  /** Returns the index of the Composite this %Link is part of, if any.
-  Otherwise returns an invalid index. */
-  LinkCompositeIndex composite() const { return link_composite_index_; }
+  /** Returns the index of the LinkComposite this %Link is part of, if any.
+  World is always in LinkComposite 0; any other link is in a Composite only if
+  it is connected by a weld joint to another link. */
+  std::optional<LinkCompositeIndex> composite() const {
+    return link_composite_index_;
+  }
 
  private:
   friend class LinkJointGraph;
@@ -148,29 +151,18 @@ class LinkJointGraph::Link {
     loop_constraints_.push_back(constraint);
   }
 
-  void clear_model(int num_user_joints) {
-    loop_constraints_.clear();
-    mobod_ = {};
-    joint_ = {};
-    primary_link_ = {};
-    shadow_links_.clear();
-    link_composite_index_ = {};
-
-    auto remove_model_joints =
-        [num_user_joints](std::vector<JointIndex>& joints) {
-          while (!joints.empty() && joints.back() >= num_user_joints)
-            joints.pop_back();
-        };
-
-    remove_model_joints(joints_as_parent_);
-    remove_model_joints(joints_as_child_);
-    remove_model_joints(joints_);
-  }
+  // Removes any as-modeled information added to this user link during forest
+  // building. Forgets any connections with ephemeral links, joints, and
+  // constraints. Preserves only the as-constructed information: index, name,
+  // model instance, flags, and primary_link (= index for a user link).
+  // @pre this is a user link, not a shadow.
+  void ClearModel(int num_user_joints);
 
   BodyIndex index_;
   std::string name_;
   ModelInstanceIndex model_instance_;
   LinkFlags flags_{LinkFlags::kDefault};
+  BodyIndex primary_link_;  // Same as index_ unless this is a shadow link.
 
   // Members below here may contain as-modeled information that has to be
   // removed when the SpanningForest is cleared or rebuilt. The joint
@@ -186,10 +178,11 @@ class LinkJointGraph::Link {
   MobodIndex mobod_;  // Mobod that mobilizes this Link.
   JointIndex joint_;  // Joint that connects us to the Mobod (invalid if World).
 
-  BodyIndex primary_link_;  // Same as index_ if this is a primary link.
   std::vector<BodyIndex> shadow_links_;
 
-  LinkCompositeIndex link_composite_index_;  // Invalid if not in composite.
+  // World is always in a composite; other links are in a composite only
+  // if they are welded to another link.
+  std::optional<LinkCompositeIndex> link_composite_index_;
 };
 
 }  // namespace internal

--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -54,10 +54,9 @@ void SpanningForest::Clear() {
 //  subset of the algorithm described.
 //  What's here: the ability to model tree-structured graphs, add joints to
 //  world as needed, grow breadth-first and then renumber depth-first,
-//  assign coordinates.
-//  What's not here (see #20225): breaking loops, treat massless bodies
-//  specially, use a single Mobod for composites. The
-//  related options are allowed but ignored.
+//  assign coordinates, break loops.
+//  What's not here (see #20225): treat massless bodies specially, use a single
+//  Mobod for composites. The related options are allowed but ignored.
 
 /* This is the algorithm that takes an arbitrary link-joint graph and models
 it as a spanning forest of mobilized bodies plus loop-closing constraints.
@@ -145,7 +144,7 @@ numbering here for clarification.
    3.3 Precalculate for each Mobod the number of coordinates along its inboard
        path to World and in the outboard subtree for which it is the root.
 */
-void SpanningForest::BuildForest() {
+bool SpanningForest::BuildForest() {
   Clear();  // In case we're reusing this forest.
 
   SetBaseBodyChoicePolicy();
@@ -174,6 +173,8 @@ void SpanningForest::BuildForest() {
 
   /* Dole out the q's and v's, depth-first. (Phase 3) */
   AssignCoordinates();
+
+  return dynamics_ok();
 }
 
 void SpanningForest::ChooseForestTopology() {
@@ -320,12 +321,13 @@ void SpanningForest::AssignCoordinates() {
       mobod.nq_inboard_ = mobod.nv_inboard_ = 0;
       continue;
     }
-    const JointTypeIndex joint_type_index = joints(mobod.joint()).type_index();
-    const LinkJointGraph::JointType& joint_type =
-        graph().joint_types()[joint_type_index];
+    const JointTraitsIndex joint_traits_index =
+        joints(mobod.joint()).traits_index();
+    const LinkJointGraph::JointTraits& joint_traits =
+        graph().joint_traits()[joint_traits_index];
 
-    mobod.nq_ = joint_type.nq;
-    mobod.nv_ = joint_type.nv;
+    mobod.nq_ = joint_traits.nq;
+    mobod.nv_ = joint_traits.nv;
 
     /* Keep a running count of inboard coordinates. */
     DRAKE_DEMAND(mobod.inboard().is_valid());  // Non-World must have inboard.
@@ -397,7 +399,7 @@ void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
         links(next_base_link).model_instance();
     const JointIndex next_joint_index =
         mutable_graph().AddEphemeralJointToWorld(
-            base_joint_type_index(model_instance_index), next_base_link);
+            base_joint_traits_index(model_instance_index), next_base_link);
     ExtendTrees({next_joint_index}, &*num_unprocessed_links);
   }
 
@@ -414,11 +416,12 @@ void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
   for (BodyIndex unjointed_link : unjointed_links) {
     const ModelInstanceIndex model_instance_index =
         links(unjointed_link).model_instance();
-    const JointTypeIndex joint_type_to_use =
-        base_joint_type_index(model_instance_index);
+    const JointTraitsIndex joint_type_to_use =
+        base_joint_traits_index(model_instance_index);
     const JointIndex next_joint_index =
         mutable_graph().AddEphemeralJointToWorld(joint_type_to_use,
                                                  unjointed_link);
+
     AddNewMobod(unjointed_link, next_joint_index, world_mobod().index(),
                 false);  // Not reversed; World is parent
     /* No tree to extend here. */
@@ -481,9 +484,13 @@ void SpanningForest::ExtendTreesOneLevel(
         graph().FindInboardOutboardLinks(inboard_mobod_index,
                                          modeled_joint_index);
 
-    /* If the outboard link is already modeled, this is a loop joint. */
-    // TODO(sherm1) Loops are stubbed out here. (E.5)
-    DRAKE_THROW_UNLESS(!link_is_already_in_forest(modeled_outboard_link_index));
+    /* If the outboard link is already modeled, this is a loop-closing
+    joint (E.5). */
+    if (link_is_already_in_forest(modeled_outboard_link_index)) {
+      /* Invalidates references to Links, Joints, Mobods, LoopConstraints. */
+      HandleLoopClosure(modeled_joint_index);
+      continue;
+    }
 
     /* Note: invalidates references to Mobods. */
     AddNewMobod(modeled_outboard_link_index, modeled_joint_index,
@@ -492,9 +499,31 @@ void SpanningForest::ExtendTreesOneLevel(
     --(*num_unprocessed_links);
 
     const Link& modeled_outboard_link = links(modeled_outboard_link_index);
+    const Joint& modeled_joint = joints(modeled_joint_index);
 
-    // TODO(sherm1) Massless body check goes here. For now we assume we
-    //  can always stop after doing one level. (E.6)
+    /* If we just added a massless Mobod on an articulated (non-weld) joint,
+    we're in trouble if there are no outboard joints. In that case the forest
+    can't be used for dynamics. Record the first occurrence but continue
+    building the forest. */
+    if (!modeled_joint.is_weld() && modeled_outboard_link.treat_as_massless()) {
+      /* We just added an articulated massless body. If the only joint it has
+      is the one we just processed, it's terminal. */
+      if (ssize(modeled_outboard_link.joints()) == 1 && data_.dynamics_ok) {
+        const LinkJointGraph::JointTraits& modeled_joint_type =
+            graph().joint_traits(modeled_joint.traits_index());
+        data_.dynamics_ok = false;
+        data_.why_no_dynamics = fmt::format(
+            "Link {} on {} joint {} is a terminal, articulated, massless link. "
+            "The resulting multibody system will have a singular mass matrix "
+            "so cannot be used for dynamics.",
+            modeled_outboard_link.name(), modeled_joint_type.name,
+            modeled_joint.name());
+      }
+
+      // TODO(sherm1) If the massless body is non-terminal there is still hope
+      //  if we keep extending this branch. That's stubbed out here so for now
+      //  we assume we can always stop after doing one level. (E.6)
+    }
 
     /* We can stop here. Collect up the Joints for the next level and go on to
     the next Joint to model at this level. */
@@ -545,14 +574,14 @@ const SpanningForest::Mobod& SpanningForest::AddNewMobod(
 
   /* Build up both WeldedMobods group (in forest) and LinkComposite (in graph)
   if we have a Weld joint, starting a new group or composite as needed. */
-  if (joint.type_index() == LinkJointGraph::weld_joint_type_index()) {
-    if (!inboard_mobod.welded_mobods_index_.is_valid()) {
+  if (joint.traits_index() == LinkJointGraph::weld_joint_traits_index()) {
+    if (!inboard_mobod.welded_mobods_index_.has_value()) {
       inboard_mobod.welded_mobods_index_ =
           WeldedMobodsIndex(ssize(welded_mobods()));
       data_.welded_mobods.emplace_back(std::vector{inboard_mobod_index});
     }
     new_mobod.welded_mobods_index_ = inboard_mobod.welded_mobods_index_;
-    data_.welded_mobods[inboard_mobod.welded_mobods_index_].push_back(
+    data_.welded_mobods[*inboard_mobod.welded_mobods_index_].push_back(
         new_mobod_index);
 
     mutable_graph().AddToLinkComposite(inboard_mobod.link(),
@@ -576,10 +605,10 @@ void SpanningForest::ConnectLinksToWorld(
       }
     }
     if (!found_joint_to_world) {
-      const JointTypeIndex joint_type_index =
-          use_weld ? LinkJointGraph::weld_joint_type_index()
-                   : base_joint_type_index(link.model_instance());
-      mutable_graph().AddEphemeralJointToWorld(joint_type_index, link_index);
+      const JointTraitsIndex joint_traits_index =
+          use_weld ? LinkJointGraph::weld_joint_traits_index()
+                   : base_joint_traits_index(link.model_instance());
+      mutable_graph().AddEphemeralJointToWorld(joint_traits_index, link_index);
     }
   }
 }
@@ -613,6 +642,88 @@ void SpanningForest::SetBaseBodyChoicePolicy() {
     /* Both appear as child & parent Links equally often; take lowest index. */
     return left > right;
   };
+}
+
+void SpanningForest::HandleLoopClosure(JointIndex loop_joint_index) {
+  Joint& joint = mutable_graph().mutable_joint(loop_joint_index);
+  DRAKE_DEMAND(link_is_already_in_forest(joint.parent_link()) &&
+               link_is_already_in_forest(joint.child_link()));
+
+  /* If one of the two bodies is massless, that's no problem - we just have
+  to be sure to cut the massful one. The two branches will then each be
+  terminated with massful bodies (at 1/2 the mass each). However, if both
+  bodies are massless this forest can only be used for kinematics. */
+  const bool parent_is_massless =
+      graph().must_treat_as_massless(joint.parent_link());
+  const bool child_is_massless =
+      graph().must_treat_as_massless(joint.child_link());
+
+  /* Save an explanation the first time we are forced to end a branch with
+  a massless body. */
+  if (parent_is_massless && child_is_massless && data_.dynamics_ok) {
+    data_.dynamics_ok = false;
+    const Link& parent_link = links(joint.parent_link());
+    const Link& child_link = links(joint.child_link());
+    data_.why_no_dynamics = fmt::format(
+        "Loop breaks at joint {} between two massless links {} and {}. "
+        "That means these links are terminal bodies in the tree which "
+        "will produce a singular mass matrix. Hence this model cannot "
+        "be used for dynamics.\n",
+        joint.name(), parent_link.name(), child_link.name());
+  }
+
+  /* If the branches leading to each link are of unequal length, we prefer to
+  split the one on the longer branch to keep the branches more even. Otherwise
+  we prefer to split the child since that will preserve the joint's
+  parent->child order in the inboard->outboard order for the Mobod. */
+
+  bool split_parent = false;  // Prefer child.
+  if (!(child_is_massless || parent_is_massless)) {
+    const int child_level =
+        mobods(graph().link_to_mobod(joint.child_link())).level();
+    const int parent_level =
+        mobods(graph().link_to_mobod(joint.parent_link())).level();
+    if (parent_level > child_level) split_parent = true;
+  } else if (child_is_massless) {
+    split_parent = true;
+  }
+
+  AddShadowMobod(split_parent ? joint.parent_link() : joint.child_link(),
+                 joint.index());
+}
+
+/* We're going to add a shadow Link to the given primary Link and create a Mobod
+for the shadow appropriate for the given Joint. Then we'll add a weld constraint
+between the shadow and its primary. */
+const SpanningForest::Mobod& SpanningForest::AddShadowMobod(
+    BodyIndex primary_link_index, JointIndex shadow_joint_index) {
+  Joint& shadow_joint = mutable_graph().mutable_joint(shadow_joint_index);
+  DRAKE_DEMAND(shadow_joint.connects(primary_link_index));
+  const BodyIndex inboard_link_index =
+      shadow_joint.other_link_index(primary_link_index);
+
+  /* The Joint was written to connect inboard_link to primary_link but is
+  actually going to connect inboard_link to shadow_link. */
+  const bool is_reversed = shadow_joint.parent_link() != inboard_link_index;
+
+  const BodyIndex shadow_link_index = mutable_graph().AddShadowLink(
+      primary_link_index, shadow_joint_index, is_reversed);
+
+  const LoopConstraintIndex loop_constraint_index =
+      mutable_graph().AddLoopClosingWeldConstraint(primary_link_index,
+                                                   shadow_link_index);
+
+  const MobodIndex inboard_mobod_index =
+      links(inboard_link_index).mobod_index();
+  const Mobod& shadow_mobod = AddNewMobod(shadow_link_index, shadow_joint_index,
+                                          inboard_mobod_index, is_reversed);
+
+  const MobodIndex primary_mobod_index =
+      links(primary_link_index).mobod_index();
+  data_.loop_constraints.emplace_back(
+      loop_constraint_index, primary_mobod_index, shadow_mobod.index());
+
+  return shadow_mobod;
 }
 
 // TODO(sherm1) Remove this.

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -159,6 +159,15 @@ class SpanningForest {
   graph. */
   bool is_valid() const { return graph().forest_is_valid(); }
 
+  /** Returns `true` if this forest can be used for dynamics (the usual case).
+  Otherwise, the presence of a terminal massless body will make the resulting
+  mass matrix singular, restricting use to kinematic operations. */
+  bool dynamics_ok() const { return data_.dynamics_ok; }
+
+  /** If dynamics_ok() returns `false`, returns a human-readable message
+  explaining why. Otherwise returns the empty string. */
+  const std::string& why_no_dynamics() const { return data_.why_no_dynamics; }
+
   /** Provides convenient access to the owning graph's links. */
   const std::vector<Link>& links() const { return graph().links(); }
 
@@ -351,7 +360,11 @@ class SpanningForest {
   // to call _after_ it has cleaned out its own ephemeral elements and
   // out-of-date modeling information. New ephemeral elements and modeling info
   // will be written to the graph.
-  void BuildForest();
+  // @returns true if the forest can be used for anything
+  //          false if it can't be used for dynamics.
+  // @see LinkJointGraph::BuildForest() documentation for more about whether
+  //      the result can be used for dynamics.
+  bool BuildForest();
 
   // Restores this SpanningTree to the state it has immediately after
   // construction. The owning LinkJointGraph remains unchanged.
@@ -415,6 +428,24 @@ class SpanningForest {
   // Sets the comparison function to be used in making the "best" choice.
   void SetBaseBodyChoicePolicy();
 
+  // The not-yet-modeled Joint given by `loop_joint_index` connects two Links
+  // both of which are already modeled in the Forest. We will model the Joint by
+  // splitting off a shadow of one of the Links and mobilizing the shadow with a
+  // forward or reversed Mobilizer of the Joint's type. Then we add a Weld
+  // Constraint to attach the shadow to its primary. Some details:
+  //  - if one link is massless, split the other one
+  //  - if both are massless we have an invalid forest
+  //  - either or both Links may be composites; it is the mass properties
+  //    of the whole composite that determines masslessness.
+  void HandleLoopClosure(JointIndex loop_joint_index);
+
+  // Adds a shadow Link of the given primary and mobilizes the shadow with
+  // the given joint which was originally connected to the primary. Adds a
+  // weld constraint to reattach the shadow to the primary. The shadow and
+  // weld are added to the graph as ephemeral elements.
+  const Mobod& AddShadowMobod(BodyIndex primary_link_index,
+                              JointIndex shadow_joint_index);
+
   bool model_instance_is_static(ModelInstanceIndex index) const {
     return static_cast<bool>(options(index) & ForestBuildingOptions::kStatic);
   }
@@ -429,16 +460,17 @@ class SpanningForest {
                              ForestBuildingOptions::kUseRpyFloatingJoints);
   }
 
-  // Returns the appropriate joint type to use for this model instance when
-  // attaching a base body to World. Can be fixed or floating, and floating
-  // can be rpy or quaternion, depending on modeling options.
-  JointTypeIndex base_joint_type_index(
+  // Returns the index to the traits for the appropriate joint type to use for
+  // this model instance when attaching a base body to World. Can be fixed or
+  // floating, and floating can be rpy or quaternion, depending on modeling
+  // options.
+  JointTraitsIndex base_joint_traits_index(
       ModelInstanceIndex model_instance_index) const {
     if (use_fixed_base(model_instance_index))
-      return LinkJointGraph::weld_joint_type_index();
+      return LinkJointGraph::weld_joint_traits_index();
     return use_rpy_floating_joint(model_instance_index)
-               ? LinkJointGraph::rpy_floating_joint_type_index()
-               : LinkJointGraph::quaternion_floating_joint_type_index();
+               ? LinkJointGraph::rpy_floating_joint_traits_index()
+               : LinkJointGraph::quaternion_floating_joint_traits_index();
   }
 
   bool link_is_already_in_forest(BodyIndex link_index) const {
@@ -497,6 +529,11 @@ class SpanningForest {
     // std::priority_queue. It should return true if the left argument is a
     // worse choice than the right argument, according to the policy.
     std::function<bool(const BodyIndex&, const BodyIndex&)> base_body_policy;
+
+    // Set to false if we had to end a branch with a massless body.
+    bool dynamics_ok{true};
+    // Human-readable explanation for the above.
+    std::string why_no_dynamics;
   } data_;
 };
 

--- a/multibody/topology/spanning_forest_mobod.h
+++ b/multibody/topology/spanning_forest_mobod.h
@@ -4,6 +4,7 @@
 #error Do not include this file. Use "drake/multibody/topology/forest.h".
 #endif
 
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -40,8 +41,7 @@ class SpanningForest::Mobod {
   directly or indirectly connected to the World %Mobod by Weld mobilizers.
   All such %Mobods are part of the 0th WeldedMobods group. */
   bool is_anchored() const {
-    return welded_mobods_index_.is_valid() &&
-           welded_mobods_index_ == WeldedMobodsIndex(0);
+    return welded_mobods_index_ == WeldedMobodsIndex(0);
   }
 
   /** Returns true if there is no %Mobod that claims this one as its
@@ -103,9 +103,11 @@ class SpanningForest::Mobod {
 
   /** Returns the index of the WeldedMobods group of which this %Mobod is a
   part, if any. If this is the World %Mobod, we always return
-  WeldedMobodIndex(0). Otherwise, the returned index is invalid if there are no
-  %Mobods welded to this one. */
-  WeldedMobodsIndex welded_mobods_group() const { return welded_mobods_index_; }
+  WeldedMobodIndex(0). Otherwise, an index is returned only if there is
+  another %Mobod connected by a weld mobilizer to this %Mobod. */
+  std::optional<WeldedMobodsIndex> welded_mobods_group() const {
+    return welded_mobods_index_;
+  }
 
   /** Returns the level of this %Mobod within the SpanningForest. World is
   level 0, the root (base body) of each Tree is level 1, %Mobods connected to
@@ -206,8 +208,12 @@ class SpanningForest::Mobod {
   MobodIndex inboard_mobod_;  // Tree parent at level-1 (invalid for World)
   std::vector<MobodIndex> outboard_mobods_;  // Tree children at level+1
 
-  TreeIndex tree_index_;                   // Which Tree is this Mobod part of?
-  WeldedMobodsIndex welded_mobods_index_;  // Part of a WeldedMobods group?
+  TreeIndex tree_index_;  // Which Tree is this Mobod part of?
+
+  // The World Mobod is always in WeldedMobods group 0. Any other Mobod is
+  // in a WeldedMobods group only if it is actually connected by a Weld
+  // mobilizer to another Mobod.
+  std::optional<WeldedMobodsIndex> welded_mobods_index_;
 
   // Coordinate assignments (done last). For welds (and for World), q/v_start
   // is still set to where coordinates would have started if there were any,

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -3,8 +3,10 @@
 /* clang-format on */
 
 #include <string>
+#include <tuple>
 
 #include <fmt/format.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -48,7 +50,7 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_EQ(world_link_index, BodyIndex(0));
 
   // Now build a forest representing the World-only graph.
-  graph.BuildForest();
+  EXPECT_TRUE(graph.BuildForest());
   EXPECT_TRUE(graph.forest_is_valid());
   EXPECT_TRUE(forest.is_valid());
   EXPECT_EQ(&forest.graph(), &graph);
@@ -117,7 +119,7 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
 GTEST_TEST(SpanningForest, TreeAndLoopConstraintAPIs) {
   LinkJointGraph graph;
   const SpanningForest& forest = graph.forest();
-  graph.BuildForest();
+  EXPECT_TRUE(graph.BuildForest());
 
   // This stub exists solely to enable these API tests until the implementing
   // code is merged. Here's the forest we're expecting:
@@ -248,7 +250,7 @@ GTEST_TEST(SpanningForest, MultipleBranchesDefaultOptions) {
   EXPECT_EQ(&forest.joints(), &graph.joints());
 
   // Build with default options.
-  graph.BuildForest();
+  EXPECT_TRUE(graph.BuildForest());
   EXPECT_EQ(forest.options(), ForestBuildingOptions::kDefault);
   EXPECT_EQ(forest.options(left_instance), ForestBuildingOptions::kDefault);
   EXPECT_EQ(forest.options(right_instance), ForestBuildingOptions::kDefault);
@@ -376,7 +378,7 @@ GTEST_TEST(SpanningForest, MultipleBranchesBaseJointOptions) {
                                  ForestBuildingOptions::kUseRpyFloatingJoints);
   graph.SetForestBuildingOptions(right_instance,
                                  ForestBuildingOptions::kUseFixedBase);
-  graph.BuildForest();
+  EXPECT_TRUE(graph.BuildForest());
   EXPECT_EQ(forest.options(), ForestBuildingOptions::kDefault);
   EXPECT_EQ(forest.options(left_instance),
             ForestBuildingOptions::kUseRpyFloatingJoints);
@@ -469,11 +471,11 @@ GTEST_TEST(SpanningForest, BaseBodyChoicePolicy) {
                                                 {6, 7}, {8, 9}, {10, 9}};
   for (int i = 0; i < ssize(joints); ++i) {
     const auto joint = joints[i];
-    graph.AddJoint("joint_" + std::to_string(i), default_model_instance(),
+    graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
                    "revolute", BodyIndex(joint.first), BodyIndex(joint.second));
   }
 
-  graph.BuildForest();
+  EXPECT_TRUE(graph.BuildForest());
   const SpanningForest& forest = graph.forest();
   EXPECT_EQ(graph.num_user_joints(), 7);
   EXPECT_EQ(ssize(graph.joints()), 10);  // 3 ephemeral base joints
@@ -496,10 +498,10 @@ GTEST_TEST(SpanningForest, BaseBodyChoicePolicy) {
 /* Verify that we can build a good forest for a serial chain, some static and
 floating links, and some simple composites, obeying forest building options.
 
-Links can become static either by being tagged with a static model instance,
-or by having been specified with the Static link flag; we test both of those
+Links can become static either by being members of a static model instance,
+or by having been specified with the kStatic link flag; we test both of those
 here. Forest building should add a weld joint to World for every static link
-unless there is already an explicit weld; we'll check that here.
+unless there is already an explicit weld; we'll check that.
 
 LinkComposites are always computed and consist of subgraphs of links that are
 mutually welded together (directly or indirectly). Depending on forest building
@@ -557,12 +559,12 @@ SpanningForest 1 (don't combine LinkComposites)
   (1) World is always present and is first, and (2) the active link comes first
   in any LinkComposite.
 
-  TODO(sherm1) Rebuild with CombineLinkComposites options and check the result.
+TODO(sherm1) Retest with "combine composites" option on (currently stubbed).
 */
 GTEST_TEST(SpanningForest, SerialChainAndMore) {
   LinkJointGraph graph;
   graph.RegisterJointType("revolute", 1, 1);
-  EXPECT_EQ(ssize(graph.joint_types()), 4);  // Built-ins plus "revolute".
+  EXPECT_EQ(ssize(graph.joint_traits()), 4);  // Built-ins plus "revolute".
   EXPECT_TRUE(graph.IsJointTypeRegistered("revolute"));
   EXPECT_FALSE(graph.IsJointTypeRegistered("prismatic"));
 
@@ -584,10 +586,12 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   graph.AddLink("static6", static_model_instance);
   const BodyIndex static7_index =
       graph.AddLink("static7", static_model_instance);
-  graph.AddLink("static8", model_instance, LinkFlags::kStatic);
+  const BodyIndex static8_index =
+      graph.AddLink("static8", model_instance, LinkFlags::kStatic);
   // Manually adding a weld to World is allowable for a static Link.
-  graph.AddJoint("static7_weld", model_instance, "weld",
-                 graph.world_link().index(), static7_index);
+  const JointIndex static7_joint_index =
+      graph.AddJoint("static7_weld", model_instance, "weld",
+                     graph.world_link().index(), static7_index);
   // Now add a free link and a free-floating pair.
   graph.AddLink("free9", model_instance);
 
@@ -601,18 +605,41 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   graph.ResetForestBuildingOptions();  // Unnecessary; just being tidy.
   graph.SetForestBuildingOptions(static_model_instance,
                                  ForestBuildingOptions::kStatic);
-  graph.BuildForest();
+  EXPECT_TRUE(graph.BuildForest());
   const SpanningForest& forest = graph.forest();
+  EXPECT_TRUE(graph.forest_is_valid());
+
+  // Verify that ChangeJointType() rejects an attempt to change a static link's
+  // weld to something articulated. Also check that when it fails, it doesn't
+  // invalidate the currently-valid forest.
+
+  // static7 is in static_model_instance.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.ChangeJointType(static7_joint_index, "revolute"),
+      "ChangeJointType.*can't change type.*static7_weld.*instance 5.*"
+      "weld to revolute.*because.*connects static .*static7.*World.*");
+  EXPECT_TRUE(graph.forest_is_valid());
+
+  // static8 is explicitly flagged static but doesn't have a user-defined
+  // joint. Verify that ChangeJointType() refuses to operate on an ephemeral
+  // (added) joint.
+  const JointIndex static8_joint_index =
+      graph.links(static8_index).inboard_joint_index();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.ChangeJointType(static8_joint_index, "revolute"),
+      "ChangeJointType.*can't change the type.*ephemeral.*static8.* only "
+      "user-defined.*");
+  EXPECT_TRUE(graph.forest_is_valid());
 
   // Should have added four ephemeral joints to the graph.
   EXPECT_EQ(graph.num_user_joints(), 7);
   EXPECT_EQ(ssize(graph.joints()), 11);
   const JointIndex base11_joint_index(9);  // See above picture.
   const JointIndex free9_joint_index(10);
-  EXPECT_EQ(graph.joints(base11_joint_index).type_index(),
-            LinkJointGraph::quaternion_floating_joint_type_index());
-  EXPECT_EQ(graph.joints(free9_joint_index).type_index(),
-            LinkJointGraph::quaternion_floating_joint_type_index());
+  EXPECT_EQ(graph.joints(base11_joint_index).traits_index(),
+            LinkJointGraph::quaternion_floating_joint_traits_index());
+  EXPECT_EQ(graph.joints(free9_joint_index).traits_index(),
+            LinkJointGraph::quaternion_floating_joint_traits_index());
 
   const std::vector<BodyIndex> link_composites0{BodyIndex(0), BodyIndex(7),
                                                 BodyIndex(6), BodyIndex(8)};
@@ -684,6 +711,739 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_EQ(find_outv(11), pair(17, 0));
   EXPECT_FALSE(forest.mobods(MobodIndex(3)).is_base_body());  // Generic case
   EXPECT_EQ(find_outv(3), pair(3, 2));
+}
+
+/* Topological loops formed entirely by welds can be handled specially when
+we're combining LinkComposites onto single Mobods. We build a Forest containing
+a number of kinematic loops and subgraphs of welded bodies.
+
+TODO(sherm1) Combining composites is stubbed out but the first part of this
+ test is still relevant since the composites are still computed, though not
+ yet combined. More cases will follow.
+
+The input is given as three unconnected graphs. Joints are shown with
+parent->child direction. Double bars are welds, single bars are moving joints.
+Links {0-13} are shown in braces, joint numbers 0-13 are plain.
+
+    Link/Joint graph as input
+
+                                               ===> weld
+         12    11     9                        ---> revolute or prismatic
+    {0}<==={5}===>{7}--->{2}                   {1} link # in braces
+  World     ^      |10    |                    10  joint # plain
+          13‖      v      |8
+           {12}   {11}<---+
+
+        3        0      7      4
+    {3}--->{13}<==={1}--->{10}===>{6}
+            2‖      ^      5‖      ‖
+             v      ‖1      v      ‖6
+            {4}=====+      {8}<====+
+
+    {9}
+
+When we build the forest, we have to provide every link with a path to World.
+We'll first process the upper graph which already starts at World. Then we
+have to pick a base body for the next graph. Link {3} should be chosen since
+it appears only as a parent; it gets floating joint 14. Link {9} will also be
+a base body; it gets floating joint 15.
+
+There are three loops in this graph: {7-2-11}, {13-1-4}, and {10-6-8}. The
+forest-building algorithm will encounter them in that order. The last two loops
+are formed entirely of welds. When modeling in the mode where every Joint gets a
+Mobod all of these must be broken by adding shadow links. In each case the loop
+joint will be between two bodies at the same level in their tree, so the choice
+of which one to split should be made so that the parent->child orientation in
+the graph is preserved in the inboard->outboard order of the tree, requiring
+that the child Link is the one split. (It is easier to see the levels in the
+forest diagram below.) As a result, Link {11} will be split with shadow link
+{14*} on Joint 8, Link {1} gets shadow {15*} on weld Joint 1, and Link {8} gets
+shadow {16*} on weld Joint 6.
+
+Therefore we expect the following Composites, with the "World" Composite first:
+  {0, 5, 7, 12}, {13, 1, 4, 15*}, {10, 6, 8, 16*}
+Note that the _active_ Link (the one on a moving joint) is always listed first
+in a LinkComposite (World comes first in the World composite). The remaining
+non-composite links are {3}, {9}, {2}, {11}, and {14*}.
+
+Forest building should start with Link {5} since that is the only direct
+connection to World in the input ({3} and {9} get connected later). If we're
+giving every Link its own mobilizer (rather than making composites from
+welded-together ones) we expect this forest of 3 trees and 17 Mobods:
+
+      level 6                 12{16*} ....              ... loop constraint
+                                         .              {1} link # in braces
+      level 5                  11{6}  13{8}             10  mobod # plain
+
+      level 4  4{14*} ...        10{10}    . 15{15*}
+                        .                ..
+      level 3   3{2} 5{11}         9{1}..   14{4}
+
+      level 2      2{7}   6{12}        8{13}
+
+  base mobods          1{5}            7{3}            16{9}
+                          \             |               /
+        World              ............0{0}.............
+
+Note that the Mobod numbers shown here (and in all the tests) are _after_
+renumbering into depth first order, not the order in which the Mobods were
+assigned.
+
+Some of the Links are welded together. We call those LinkComposites even
+though each Link has its own Mobod. Those are:
+{0 5 7 12} {13 1 4 15} {10 6 8 16}
+The corresponding Mobods are in WeldedMobod groups:
+[0 1 2 6] [8 9 14 15] [10 11 13 12]
+
+TODO(sherm1) Retest with "combine composites" option on (currently stubbed). */
+GTEST_TEST(SpanningForest, WeldedSubgraphs) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+  graph.RegisterJointType("prismatic", 1, 1);
+  EXPECT_EQ(ssize(graph.joint_traits()), 5);  // Predefined+revolute+prismatic.
+
+  const ModelInstanceIndex model_instance(5);  // Arbitrary.
+
+  // Define the forest.
+  for (int i = 1; i <= 13; ++i)
+    graph.AddLink("link" + std::to_string(i), model_instance);
+
+  // clang-format off
+  // Add joints:            type   parent  child
+  std::vector<std::tuple<std::string, int, int>> joints{
+    {"weld", 1, 13}, {"weld", 4, 1}, {"weld", 13, 4},  // loop 1 4 13
+    {"revolute", 3, 13},
+    {"weld", 10, 6}, {"weld", 10, 8}, {"weld", 6, 8},  // loop 6 8 10
+    {"prismatic", 1, 10},
+    {"prismatic", 2, 11}, {"prismatic", 7, 2}, {"prismatic", 7, 11},  // loop
+                                                                      // 2 7 11
+    {"weld", 5, 7}, {"weld", 5, 0}, {"weld", 12, 5}
+  };
+  // clang-format on
+  for (int i = 0; i < ssize(joints); ++i) {
+    const auto& joint = joints[i];
+    graph.AddJoint("joint" + std::to_string(i), model_instance,
+                   std::get<0>(joint), BodyIndex(std::get<1>(joint)),
+                   BodyIndex(std::get<2>(joint)));
+  }
+
+  EXPECT_EQ(ssize(graph.links()), 14);  // Includes World.
+  EXPECT_EQ(ssize(graph.joints()), 14);
+
+  EXPECT_TRUE(graph.BuildForest());
+  const SpanningForest& forest = graph.forest();
+
+  EXPECT_EQ(graph.num_user_links(), 14);  // Same as before building.
+  EXPECT_EQ(graph.num_user_joints(), 14);
+  EXPECT_EQ(ssize(graph.links()), 17);   // +3 shadows.
+  EXPECT_EQ(ssize(graph.joints()), 16);  // +2 floating joints to world.
+  EXPECT_EQ(ssize(graph.loop_constraints()), 3);
+
+  // Check that the shadows are connected up properly. See the test comment
+  // above for why we expect these particular links to get split.
+  for (BodyIndex link(14); link <= 16; ++link)
+    EXPECT_TRUE(graph.links(link).is_shadow());
+  EXPECT_EQ(graph.links(BodyIndex(14)).primary_link(), 11);
+  EXPECT_EQ(graph.links(BodyIndex(11)).num_shadows(), 1);
+  EXPECT_EQ(graph.links(BodyIndex(15)).primary_link(), 1);
+  EXPECT_EQ(graph.links(BodyIndex(1)).num_shadows(), 1);
+  EXPECT_EQ(graph.links(BodyIndex(16)).primary_link(), 8);
+  EXPECT_EQ(graph.links(BodyIndex(8)).num_shadows(), 1);
+
+  // Check that we built the LinkComposites properly (see above).
+  EXPECT_EQ(ssize(graph.link_composites()), 3);
+  const std::vector<std::vector<int>> expected_links{
+      {0, 5, 7, 12}, {13, 1, 4, 15}, {10, 6, 8, 16}};
+  for (LinkCompositeIndex c(0); c < 3; ++c) {
+    for (int link = 0; link < ssize(expected_links[c]); ++link)
+      EXPECT_EQ(graph.link_composites(c)[link], expected_links[c][link]);
+  }
+
+  // Now let's verify that we got the expected SpanningForest. To understand,
+  // refer to the 6-level forest diagram above.
+  EXPECT_EQ(ssize(forest.mobods()), 17);
+  EXPECT_EQ(ssize(forest.loop_constraints()), 3);
+
+  // Expected level for each mobod in forest (index by MobodIndex).
+  std::array<int, 17> expected_level{0, 1, 2, 3, 4, 3, 2, 1, 2,
+                                     3, 4, 5, 6, 5, 3, 4, 1};
+  for (auto& mobod : forest.mobods())
+    EXPECT_EQ(mobod.level(), expected_level[mobod.index()]);
+
+  // ith entry gives the modeled Link or Joint for Mobod i (see picture above).
+  const std::array mobod2link{0, 5,  7, 2,  14, 11, 12, 3, 13,
+                              1, 10, 6, 16, 8,  4,  15, 9};
+  const std::array mobod2joint{-1, 12, 11, 9, 8, 10, 13, 14, 3,
+                               0,  7,  4,  6, 5, 2,  1,  15};
+  for (const SpanningForest::Mobod& mobod : forest.mobods()) {
+    EXPECT_EQ(mobod.link(), BodyIndex(mobod2link[mobod.index()]));
+    if (mobod.is_world()) continue;  // No joint for World mobod.
+    EXPECT_EQ(mobod.joint(), JointIndex(mobod2joint[mobod.index()]));
+  }
+
+  // Should get the same information from the graph.
+  for (BodyIndex link{0}; link < ssize(graph.links()); ++link) {
+    EXPECT_EQ(mobod2link[graph.link_to_mobod(link)], link);
+  }
+
+  // Check that we built the WeldedMobods groups properly (see above).
+  EXPECT_EQ(ssize(forest.welded_mobods()), 3);
+  const std::vector<std::vector<int>> expected_mobods{
+      {0, 1, 2, 6}, {8, 9, 14, 15}, {10, 11, 13, 12}};
+  for (WeldedMobodsIndex w(0); w < 3; ++w) {
+    for (int mobod = 0; mobod < ssize(expected_mobods[w]); ++mobod)
+      EXPECT_EQ(forest.welded_mobods(w)[mobod], expected_mobods[w][mobod]);
+  }
+}
+
+/* Ten links, 8 in a tree and 2 free ones. Internal link 8 is massless (should
+be no problem). Terminal links 2 and 4 are massless which will prevent dynamics
+unless they are welded to a massful link. We'll test with articulation and
+with a weld. Also we'll make a loop between massless 2 and massful 7 which
+should make it ok since both branches will end with half link 7.
+
+         Links     *=massless
+
+      1   2*
+        3      4*  7
+        8*       9
+            10          5   6
+
+     ............0............ */
+GTEST_TEST(SpanningForest, SimpleTrees) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+
+  // We'll add Links and Joints to this arbitrary model instance.
+  const ModelInstanceIndex model_instance(5);
+
+  // Define the graph.
+  const std::set<int> massless{2, 4, 8};
+  for (int i = 1; i <= 10; ++i) {
+    graph.AddLink("link" + std::to_string(i), model_instance,
+                  massless.contains(i) ? LinkFlags::kTreatAsMassless
+                                       : LinkFlags::kDefault);
+  }
+  const std::vector<std::pair<int, int>> joints{
+      {3, 1}, {3, 2}, {8, 3}, {10, 8}, {10, 9}, {9, 4}, {9, 7}};
+  for (int i = 0; i < 7; ++i) {
+    graph.AddJoint("joint" + std::to_string(i), model_instance, "revolute",
+                   BodyIndex(joints[i].first), BodyIndex(joints[i].second));
+  }
+
+  EXPECT_EQ(ssize(graph.links()), 11);  // this includes the world Link.
+  EXPECT_EQ(ssize(graph.joints()), 7);
+
+  // We should report that the resulting forest is unsuited for dynamics due
+  // to a terminal massless body. Specifically, it should complain about link
+  // 4 rather than link 2 since 4 is at a lower level and should be seen first.
+  EXPECT_FALSE(graph.BuildForest());
+  const SpanningForest& forest = graph.forest();
+  EXPECT_FALSE(forest.dynamics_ok());
+  EXPECT_THAT(
+      forest.why_no_dynamics(),
+      testing::MatchesRegex("Link link4 on revolute joint joint5.*terminal.*"
+                            "singular.*cannot be used for dynamics.*"));
+
+  // Change link 4's joint type to "weld". That should shift the complaint to
+  // link 2.
+  graph.ChangeJointType(JointIndex(5), "weld");
+  EXPECT_FALSE(graph.BuildForest());
+  EXPECT_FALSE(forest.dynamics_ok());
+  EXPECT_THAT(
+      forest.why_no_dynamics(),
+      testing::MatchesRegex("Link link2 on revolute joint joint1.*terminal.*"
+                            "singular.*cannot be used for dynamics.*"));
+
+  // Finally if we connect link 2 to a massful link forming a loop, we should
+  // get a dynamics-ready forest by splitting the massful link.
+  graph.AddJoint("loop_2_to_7", model_instance, "revolute", BodyIndex(2),
+                 BodyIndex(7));
+  EXPECT_TRUE(graph.BuildForest());
+  EXPECT_TRUE(forest.dynamics_ok());
+  EXPECT_TRUE(forest.why_no_dynamics().empty());
+  EXPECT_EQ(graph.num_user_links(), 11);
+  EXPECT_EQ(graph.num_user_joints(), 8);
+  EXPECT_EQ(ssize(graph.links()), 12);   // Now has a shadow link.
+  EXPECT_EQ(ssize(graph.joints()), 11);  // Added three floating joints.
+}
+
+/* Massless bodies should alter tree-building strategy.
+
+LinkJointGraph:
+  World -0-> {1} -1-> {2} -2-> {3}*
+                                |
+                                3
+                                v
+  World -4-> {5} -5-> {6} -6-> {4}*
+
+With all massful Links, loop should be broken at Joint 3 (between links
+{3} and {4} since that minimizes the maximum chain length. In that case we
+have trees {1234s} and {564} where {4s} is the shadow of {4}.
+
+If we make {3}* massless we'll have to extend the first chain
+to link {4} before breaking the loop at Joint 6, giving trees
+{1234} and {564s} ({4} is still split since it is the child of Joint 6).
+
+TODO(sherm1) With massless handling stubbed out, the algorithm will _not_
+ extend the first chain when it sees massless {3} so produces the same two
+ trees as the massful case above. As it happens, that's still a good forest.
+
+If we make _both_ {3}* and {4}* massless, modeling should start with {12} and
+{56} but then next extend the first tree to {12346s} because we can't stop at
+{3} or {4}. Joint 6 is the loop joint but the mobilizer has to be reversed so
+that we end with a massful shadow link {6s} rather than the massless {4}.
+
+TODO(sherm1) With massless handling stubbed out, we once again get the same
+ two trees but now the forest can't be used for dynamics due to terminal
+ massless bodies 4 and 4s.
+*/
+GTEST_TEST(SpanningForest, MasslessLinksChangeLoopBreaking) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+
+  // We'll add Links and Joints to this model instance.
+  const ModelInstanceIndex model_instance(5);
+
+  // Define the forest.
+  for (int i = 1; i <= 6; ++i) {
+    graph.AddLink("link" + std::to_string(i), model_instance);
+  }
+  const std::vector<std::pair<int, int>> joints{{0, 1}, {1, 2}, {2, 3}, {3, 4},
+                                                {0, 5}, {5, 6}, {6, 4}};
+  for (int i = 0; i < 7; ++i) {
+    graph.AddJoint("joint" + std::to_string(i), model_instance, "revolute",
+                   BodyIndex(joints[i].first), BodyIndex(joints[i].second));
+  }
+
+  EXPECT_EQ(ssize(graph.links()), 7);  // this includes the world Link.
+  EXPECT_EQ(ssize(graph.joints()), 7);
+
+  EXPECT_TRUE(graph.BuildForest());  // Using default options.
+  const SpanningForest& forest = graph.forest();
+
+  EXPECT_EQ(ssize(forest.trees()), 2);
+  EXPECT_EQ(forest.trees()[0].num_mobods(), 4);
+  EXPECT_EQ(forest.trees()[1].num_mobods(), 3);
+
+  graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kTreatAsMassless);
+  EXPECT_TRUE(graph.BuildForest());
+
+  EXPECT_EQ(ssize(forest.trees()), 2);
+  EXPECT_EQ(forest.trees()[0].num_mobods(), 4);
+  EXPECT_EQ(forest.trees()[1].num_mobods(), 3);
+
+  // TODO(sherm1) With both 3 and 4 massless and massless handling stubbed,
+  //  we'll end up with a no-dynamics model. Should not happen once this gets
+  //  un-stubbed.
+  graph.ChangeLinkFlags(BodyIndex(4), LinkFlags::kTreatAsMassless);
+  EXPECT_FALSE(graph.BuildForest());  // Indicates "no dynamics".
+
+  EXPECT_THAT(
+      forest.why_no_dynamics(),
+      testing::MatchesRegex("Loop.*joint3.*massless.*link3.*link4.*singular.*"
+                            "cannot be used for dynamics.*"));
+
+  EXPECT_EQ(ssize(forest.trees()), 2);
+  EXPECT_EQ(forest.trees()[0].num_mobods(), 3);
+  EXPECT_EQ(forest.trees()[1].num_mobods(), 4);
+}
+
+/* Here is a tricky case that should be handled correctly and without warnings.
+We have a short loop consisting of two massless base Links and a single massful
+Link. The massful Link should be split into two half-massful bodies which are
+sufficient to prevent both massless Links from being terminal.
+
+   LinkJointGraph                         SpanningForest
+     {1} = link 1                           Loop = loop constraint
+     joint #s are plain                     Mobod #s are plain
+
+          {3}            massful        2{3} - Loop ->  4{3s}
+
+      🡕 2     🡔 3                        🡑               🡑
+
+  {1}           {2}      massless       1{1}            3{2}
+
+   🡑 0           🡑 1                     🡑 T0            🡑 T1     T = tree
+                           ---->
+ ........{0}........                     ........ 0 ........
+        World                                   World
+
+On the left we show the Link and Joint numbers as input, on the right we show
+the Tree numbers and mobilized body numbers in proper depth-first order, with
+the corresponding links. Arrows show the parent->child and inboard->outboard
+directions. We expect to process Link 1 before Link 2 so we expect Tree 0 to
+contain links {1} and {3} before we discover the loop trying to extend Tree 1
+from link {2} via joint 3. In that case link {3} is at level 2 in the forest
+while link {2} is at level 1 so we must split {3} to get the two trees to be
+the same height. Link {3} is split so there is a shadow 3s, which has
+ephemeral link number {4} which is mobilized by Mobod 4 in Tree 1. */
+GTEST_TEST(SpanningForest, MasslessBodiesShareSplitLink) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+  graph.RegisterJointType("prismatic", 1, 1);
+  const ModelInstanceIndex model_instance(19);
+
+  graph.AddLink("massless_1", model_instance, LinkFlags::kTreatAsMassless);
+  graph.AddLink("massless_2", model_instance, LinkFlags::kTreatAsMassless);
+  graph.AddLink("link_3", model_instance);
+
+  graph.AddJoint("prismatic_0", model_instance, "prismatic", world_index(),
+                 BodyIndex(1));
+  graph.AddJoint("prismatic_1", model_instance, "prismatic", world_index(),
+                 BodyIndex(2));
+  graph.AddJoint("revolute_2", model_instance, "revolute", BodyIndex(1),
+                 BodyIndex(3));
+  graph.AddJoint("revolute_3", model_instance, "revolute", BodyIndex(2),
+                 BodyIndex(3));
+
+  EXPECT_EQ(ssize(graph.links()), 4);  // Before modeling (includes World).
+  EXPECT_EQ(graph.num_user_links(), 4);
+
+  EXPECT_TRUE(graph.BuildForest());  // Using default options.
+  const SpanningForest& forest = graph.forest();
+
+  EXPECT_EQ(ssize(graph.links()), 5);  // After modeling.
+  EXPECT_EQ(graph.num_user_links(), 4);
+  EXPECT_EQ(ssize(graph.loop_constraints()), 1);
+
+  const auto& shadow_link = graph.links(BodyIndex(4));
+  EXPECT_TRUE(shadow_link.is_shadow());
+  EXPECT_EQ(shadow_link.primary_link(), BodyIndex(3));
+  EXPECT_EQ(shadow_link.mobod_index(), MobodIndex(4));
+  EXPECT_EQ(shadow_link.inboard_joint_index(), JointIndex(3));
+  EXPECT_EQ(ssize(shadow_link.joints()), 1);
+  EXPECT_TRUE(shadow_link.joints_as_parent().empty());
+  EXPECT_EQ(shadow_link.joints_as_child()[0], JointIndex(3));
+  EXPECT_EQ(shadow_link.joints()[0], JointIndex(3));
+
+  EXPECT_EQ(graph.links(BodyIndex(3)).num_shadows(), 1);
+  EXPECT_EQ(graph.links(BodyIndex(2)).num_shadows(), 0);
+  EXPECT_EQ(graph.links(BodyIndex(4)).num_shadows(), 0);
+
+  EXPECT_EQ(ssize(forest.mobods()), 5);
+  EXPECT_EQ(ssize(forest.trees()), 2);
+  EXPECT_EQ(forest.trees(TreeIndex(0)).num_mobods(), 2);
+  EXPECT_EQ(forest.trees(TreeIndex(1)).num_mobods(), 2);
+}
+
+/* Here we have a floating double loop requiring two shadows of the same Link:
+
+     {2} ------> {5}           Link numbers are in {}
+      ^     3     | 6          Joint numbers are plain
+    0 |           v            Arrows show parent->child direction
+     {1}-->{3}-->{6}           All Links are massful
+    1 |  2     5  ^            All Joints are articulated (no welds)
+      v           | 7
+     {4} ------> {7}
+            4
+
+Because Link {1} is never used as a child, it will be the preferred base Link
+and get attached to World by a free Joint. The heuristic that tries to
+minimize branch length should grow the three branches from {1} like this:
+  {12}    {14}     {13}
+  {125}   {147}    {136}
+  {1256s} {1476ss} {136}
+  where 6s and 6ss are shadows 1 and 2 of Link 6.
+
+The expected as-modeled graph and spanning forest model are:
+
+            {2}--->{5}--->{8}                  [2]-->[3]-->[4]  branch 1
+           0 ^  3      6   . loop 0             ^           .
+  World      |             .            World   |           .
+   {0}----->{1}--->{3}--->{6}            [0]-->[1]-->[8]-->[9]  branch 3
+        8    |  2      5   . loop 1             |           .
+           1 v             .                    v           .
+            {4}--->{7}--->{9}                  [5]-->[6]-->[7]  branch 2
+                4      7
+
+            Links & Joints                     Mobilized bodies
+
+Notes:
+  - Joint numbering determines branch ordering in the tree so the
+    middle branch gets modeled last.
+  - Model Joint 8 is the added floating joint to World.
+  - Link {8} is {6s} (shadow 1 of Link {6}); {9} is {6ss} (shadow 2).
+  - Loop constraints (shown as . .) are always ordered so that the constraint's
+    "parent" is the primary link and "child" is the shadow link. Thus the order
+    here should be 6->8 and 6->9.
+  - Mobilized bodies (Mobods) are numbered depth-first.
+*/
+GTEST_TEST(SpanningForest, DoubleLoop) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+  graph.RegisterJointType("prismatic", 1, 1);
+  const ModelInstanceIndex model_instance(19);
+
+  for (int i = 1; i <= 7; ++i)
+    graph.AddLink("link" + std::to_string(i), model_instance);
+
+  const std::vector<std::pair<int, int>> joints{{1, 2}, {1, 4}, {1, 3}, {2, 5},
+                                                {4, 7}, {3, 6}, {5, 6}, {7, 6}};
+  for (int i = 0; i < 8; ++i) {
+    graph.AddJoint("joint_" + std::to_string(i), model_instance, "revolute",
+                   BodyIndex(joints[i].first), BodyIndex(joints[i].second));
+  }
+
+  EXPECT_EQ(ssize(graph.links()), 8);  // Before modeling (includes World).
+  EXPECT_EQ(ssize(graph.joints()), 8);
+  EXPECT_EQ(ssize(graph.loop_constraints()), 0);
+
+  EXPECT_TRUE(graph.BuildForest());  // Using default options.
+  const SpanningForest& forest = graph.forest();
+
+  EXPECT_EQ(ssize(graph.links()), 10);  // After modeling.
+  EXPECT_EQ(ssize(graph.joints()), 9);
+  EXPECT_EQ(ssize(graph.loop_constraints()), 2);
+  EXPECT_EQ(graph.num_user_links(), 8);
+  EXPECT_EQ(graph.num_user_joints(), 8);
+
+  const LinkJointGraph::Link& primary_link = graph.links(BodyIndex(6));
+  const LinkJointGraph::Link& shadow_link_1 = graph.links(BodyIndex(8));
+  const LinkJointGraph::Link& shadow_link_2 = graph.links(BodyIndex(9));
+
+  EXPECT_EQ(primary_link.name(), "link6");
+  EXPECT_EQ(shadow_link_1.name(), "link6$1");
+  EXPECT_EQ(shadow_link_2.name(), "link6$2");
+
+  EXPECT_EQ(primary_link.num_shadows(), 2);
+  EXPECT_TRUE(shadow_link_1.is_shadow());
+  EXPECT_TRUE(shadow_link_2.is_shadow());
+
+  EXPECT_EQ(graph.links(BodyIndex(5)).num_shadows(), 0);
+  EXPECT_EQ(graph.links(BodyIndex(7)).num_shadows(), 0);
+
+  EXPECT_EQ(ssize(forest.mobods()), 10);
+  EXPECT_EQ(ssize(forest.trees()), 1);
+  const SpanningForest::Tree& tree = forest.trees(TreeIndex(0));
+  EXPECT_EQ(tree.num_mobods(), 9);
+  EXPECT_EQ(tree.height(), 4);
+  EXPECT_EQ(tree.base_mobod(), MobodIndex(1));
+  EXPECT_EQ(tree.last_mobod(), MobodIndex(9));
+
+  // ith entry gives the modeled Link or Joint for Mobod i (see picture above).
+  const std::array mobod2link{0, 1, 2, 5, 8, 4, 7, 9, 3, 6};
+  const std::array mobod2joint{-1, 8, 0, 3, 6, 1, 4, 7, 2, 5};
+  for (const SpanningForest::Mobod& mobod : forest.mobods()) {
+    EXPECT_EQ(mobod.link(), BodyIndex(mobod2link[mobod.index()]));
+    if (mobod.is_world()) continue;  // No joint for World mobod.
+    EXPECT_EQ(mobod.joint(), JointIndex(mobod2joint[mobod.index()]));
+  }
+
+  const LinkJointGraph::LoopConstraint& loop0 =
+      graph.loop_constraints(LoopConstraintIndex(0));
+  const LinkJointGraph::LoopConstraint& loop1 =
+      graph.loop_constraints(LoopConstraintIndex(1));
+  EXPECT_EQ(loop0.index(), 0);
+  EXPECT_EQ(loop1.index(), 1);
+  EXPECT_EQ(loop0.model_instance(), model_instance);
+  EXPECT_EQ(loop1.model_instance(), model_instance);
+  EXPECT_EQ(loop0.primary_link(), BodyIndex(6));
+  EXPECT_EQ(loop0.shadow_link(), BodyIndex(8));
+  EXPECT_EQ(loop1.primary_link(), BodyIndex(6));
+  EXPECT_EQ(loop1.shadow_link(), BodyIndex(9));
+
+  // Added loop constraints should be named the same as their shadow Link.
+  EXPECT_EQ(loop0.name(), shadow_link_1.name());
+  EXPECT_EQ(loop1.name(), shadow_link_2.name());
+}
+
+/* For both link_composites and welded_mobods: the World composite must
+come first (even if nothing is welded to World). This graph's first branch has
+a composite that could be seen prior to the weld to World. We'll attempt
+to trick it into following that path by using a massless body, requiring it
+to extend the first branch to Link {2} before moving on to the next branch.
+But we want to see the {0,3} composite before the {1,2} composite.
+
+          +---> {1*} ===> {2}
+      {0} | 0         1                {Links} & Joints
+    World |                            ===> is a weld joint
+          +===> {3}                    * Link 1 is massless
+          | 2
+          |
+          +---> {4}
+            3
+*/
+GTEST_TEST(SpanningForest, WorldCompositeComesFirst) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+  const ModelInstanceIndex model_instance(5);  // arbitrary
+
+  graph.AddLink("massless_link_1", model_instance, LinkFlags::kTreatAsMassless);
+  graph.AddLink("link2", model_instance);
+  graph.AddLink("link3", model_instance);
+  graph.AddLink("link4", model_instance);
+
+  const auto& world = graph.links(BodyIndex(0));
+  const auto& massless_link = graph.links(BodyIndex(1));
+  const auto& link2 = graph.links(BodyIndex(2));
+  const auto& link3 = graph.links(BodyIndex(3));
+  const auto& link4 = graph.links(BodyIndex(4));
+
+  graph.AddJoint("joint0", model_instance, "revolute", world.index(),
+                 massless_link.index());
+  graph.AddJoint("joint1", model_instance, "weld", massless_link.index(),
+                 link2.index());
+  graph.AddJoint("joint2", model_instance, "weld", world.index(),
+                 link3.index());
+  graph.AddJoint("joint4", model_instance, "revolute", world.index(),
+                 link4.index());
+
+  EXPECT_TRUE(graph.BuildForest());  // Using default options.
+  const SpanningForest& forest = graph.forest();
+
+  EXPECT_EQ(ssize(graph.links()), 5);
+  EXPECT_EQ(ssize(forest.mobods()), 5);  // Because we're not combining.
+
+  // "Anchored" means "fixed to World" (by welds).
+  EXPECT_TRUE(world.is_anchored());
+  EXPECT_FALSE(massless_link.is_anchored());
+  EXPECT_FALSE(link2.is_anchored());
+  EXPECT_TRUE(link3.is_anchored());
+  EXPECT_FALSE(link4.is_anchored());
+
+  EXPECT_EQ(ssize(graph.link_composites()), 2);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)),
+            (std::vector<BodyIndex>{BodyIndex(0), BodyIndex(3)}));
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(1)),
+            (std::vector<BodyIndex>{BodyIndex(1), BodyIndex(2)}));
+
+  EXPECT_EQ(ssize(forest.welded_mobods()), 2);
+  EXPECT_EQ(forest.welded_mobods(WeldedMobodsIndex(0)),
+            (std::vector<MobodIndex>{MobodIndex(0), MobodIndex(3)}));
+  EXPECT_EQ(forest.welded_mobods(WeldedMobodsIndex(1)),
+            (std::vector<MobodIndex>{MobodIndex(1), MobodIndex(2)}));
+}
+
+/* We always preserve the user's parent->child order for a joint, even if we
+have to use a reversed mobilizer to do so. This requires some special handling
+when we introduce a shadow body -- the shadow _mobod_ is always outboard (in
+fact, terminal), but it might be the shadow of a _link_ that was the parent for
+the joint being modeled. This test verifies that all the relevant bookkeeping is
+done properly, both for the shadow body and the ephemeral Link we create for it
+in the LinkJointGraph.
+
+While we're here we'll verify that the shadow link naming policy works
+properly when some crazy user has named their links to look like shadows.
+
+ {} Link  [] Mobod  Ji Joint i
+ {3s} shadow of link 3
+ ---> revolute joint
+ No weld joints, no massless or floating links.
+
+          LinkJointGraph                      SpanningTree
+
+           J0        J2
+          +---->{1}------,                 +----->[1]{1}----->[2]{3}
+          |              V                 |                   .
+      {0} |             {3}            [0] |                   . Loop 0
+    World |              |                 |                   .
+          +---->{2}<-----'                 +----->[3]{2}----->[4]{3s}
+            J1       J3
+                                           Mobod 4 should be reversed since
+                                           joint 3 goes {3}->{2}
+
+After we verify the above, we'll change {3} to massless which will force
+us to split link {2} instead. In that case we won't need a reverse mobilizer:
+
+     Spanning Tree with {3*} massless
+
+     +----->[1]{1}----->[2]{3*}       Note depth-first numbering of Mobods.
+     |                    |
+ [0] |                    |
+     |                    v
+     +----->[4]{2} . . . [3]{2s}
+                   Loop 0
+*/
+GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+  graph.AddLink("link3$1", default_model_instance());  // Awkward name!
+  graph.AddLink("link2", default_model_instance());
+  graph.AddLink("link3", default_model_instance());
+  const std::vector<std::pair<int, int>> joints{{0, 1}, {0, 2}, {1, 3}, {3, 2}};
+  for (int i = 0; i < ssize(joints); ++i) {
+    const auto joint = joints[i];
+    graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
+                   "revolute", BodyIndex(joint.first), BodyIndex(joint.second));
+  }
+
+  EXPECT_TRUE(graph.BuildForest());
+  const SpanningForest& forest = graph.forest();
+  EXPECT_EQ(graph.num_user_joints(), 4);
+  EXPECT_EQ(ssize(graph.joints()), 4);
+  EXPECT_EQ(graph.num_user_links(), 4);
+  EXPECT_EQ(ssize(graph.links()), 5);  // Added a shadow.
+
+  // See right-hand graph above. We're expecting to split link 3 since that
+  // will produce equal-length branches.
+  const LinkJointGraph::Link& primary_link = graph.links(BodyIndex(3));
+  EXPECT_FALSE(primary_link.is_shadow());
+  EXPECT_EQ(primary_link.num_shadows(), 1);
+  EXPECT_EQ(primary_link.mobod_index(), MobodIndex(2));
+  EXPECT_EQ(primary_link.inboard_joint_index(), JointIndex(2));
+  EXPECT_EQ(primary_link.primary_link(), primary_link.index());
+  EXPECT_EQ(graph.link_to_mobod(primary_link.index()), MobodIndex(2));
+
+  // The original connectivity should be preserved.
+  EXPECT_EQ(primary_link.joints(), (std::vector{JointIndex(2), JointIndex(3)}));
+  EXPECT_EQ(primary_link.joints_as_child(), (std::vector{JointIndex(2)}));
+  EXPECT_EQ(primary_link.joints_as_parent(), (std::vector{JointIndex(3)}));
+
+  const LinkJointGraph::Link& shadow_link = graph.links(BodyIndex(4));
+  EXPECT_TRUE(shadow_link.is_shadow());
+  // Shadow 1 of link 3 should be "link3$1", but that name conflicts with a
+  // nutty user name so we have to disambiguate with underscores.
+  EXPECT_EQ(shadow_link.name(), "_link3$1");
+  EXPECT_EQ(shadow_link.num_shadows(), 0);
+  EXPECT_EQ(shadow_link.mobod_index(), MobodIndex(4));
+  EXPECT_EQ(shadow_link.inboard_joint_index(), JointIndex(3));
+  EXPECT_EQ(shadow_link.primary_link(), primary_link.index());
+  EXPECT_EQ(graph.link_to_mobod(shadow_link.index()), MobodIndex(4));
+
+  // The shadow link also reports its (ephemeral) connectivity. Although it
+  // is outboard of its mobilizer, it is the parent for the joint since that
+  // was the original orientation of joint 3.
+  EXPECT_EQ(shadow_link.joints(), (std::vector{JointIndex(3)}));
+  EXPECT_TRUE(shadow_link.joints_as_child().empty());
+  EXPECT_EQ(shadow_link.joints_as_parent(), (std::vector{JointIndex(3)}));
+
+  EXPECT_EQ(ssize(forest.mobods()), 5);
+  EXPECT_EQ(ssize(forest.trees()), 2);
+  EXPECT_EQ(forest.trees(TreeIndex(0)).base_mobod(), MobodIndex(1));
+  EXPECT_EQ(forest.trees(TreeIndex(0)).num_mobods(), 2);
+  EXPECT_EQ(forest.trees(TreeIndex(1)).base_mobod(), MobodIndex(3));
+  EXPECT_EQ(forest.trees(TreeIndex(1)).num_mobods(), 2);
+
+  // Check that only mobilizer 4 was reversed.
+  const std::vector<bool> expect_reversed{false, false, false, false, true};
+  for (auto joint : graph.joints()) {
+    const auto& mobod = forest.mobods(joint.mobod_index());
+    EXPECT_EQ(mobod.is_reversed(), expect_reversed[mobod.index()]);
+  }
+
+  // Now make link3 massless, rebuild, and check a few things.
+  graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kTreatAsMassless);
+  graph.BuildForest();
+  const LinkJointGraph::Link& new_primary_link = graph.links(BodyIndex(2));
+  const LinkJointGraph::Link& new_shadow_link = graph.links(BodyIndex(4));
+
+  EXPECT_EQ(ssize(forest.mobods()), 5);
+  EXPECT_EQ(ssize(forest.trees()), 2);
+  EXPECT_EQ(forest.trees(TreeIndex(0)).base_mobod(), MobodIndex(1));
+  EXPECT_EQ(forest.trees(TreeIndex(0)).num_mobods(), 3);
+  EXPECT_EQ(forest.trees(TreeIndex(1)).base_mobod(), MobodIndex(4));
+  EXPECT_EQ(forest.trees(TreeIndex(1)).num_mobods(), 1);
+
+  EXPECT_EQ(new_primary_link.mobod_index(), MobodIndex(4));
+  EXPECT_EQ(new_primary_link.num_shadows(), 1);
+  EXPECT_FALSE(new_primary_link.is_shadow());
+  EXPECT_EQ(new_primary_link.primary_link(), new_primary_link.index());
+
+  EXPECT_EQ(new_shadow_link.mobod_index(), MobodIndex(3));
+  EXPECT_EQ(new_shadow_link.num_shadows(), 0);
+  EXPECT_TRUE(new_shadow_link.is_shadow());
+  EXPECT_EQ(new_shadow_link.primary_link(), new_primary_link.index());
 }
 
 }  // namespace


### PR DESCRIPTION
This is the fifth installment in the PR train for #20225, following #21295.

What's here:
- Straightforward loop breaking using the "one-level-at-a-time" algorithm depicted [here](https://docs.google.com/presentation/d/1oYhX36T9JP5JZJMyRzVyh3FrkvqRCQSWZpKT0VPenFs).
- Status return indicating whether the resulting forest can be used for dynamics
- Unit tests for that
- ChangeJointType() (added for testing convenience now but could be useful later)

What's not here:
- Special handling of massless bodies to avoid terminal massless bodies
- Combining LinkComposites onto a single Mobod
- Some standalone graph-walking algorithms needed by MbP
-  Modifications to MbP to use this stuff

There are still no user-visible changes here and MbP still uses the old topology.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21349)
<!-- Reviewable:end -->
