### PR TITLE
[tools] Fix kcoverage vs jupyter runfiles

### DIFF
--- a/tools/jupyter/jupyter_bazel.py
+++ b/tools/jupyter/jupyter_bazel.py
@@ -7,6 +7,7 @@ from jupyter_core.command import main as _jupyter_main
 # http://nbconvert.readthedocs.io/en/latest/execute_api.html
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
+from python import runfiles
 
 _ISSUE_12536_NOTES = """
 
@@ -33,9 +34,12 @@ class _ExecutePreprocessorNoWidgets(ExecutePreprocessor):
         return super().preprocess_cell(*args, **kwargs)
 
 
-def _jupyter_bazel_notebook_main(notebook_path, argv):
+def _jupyter_bazel_notebook_main(notebook_respath, argv):
     # This should *ONLY* be called by targets generated via `jupyter_py_*`
     # rules.
+    manifest = runfiles.Create()
+    notebook_path = manifest.Rlocation(notebook_respath)
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--test", action="store_true", help="Run as a test (non-interactive)")

--- a/tools/jupyter/jupyter_py.bzl
+++ b/tools/jupyter/jupyter_py.bzl
@@ -9,15 +9,11 @@ load("//tools/workspace:generate_file.bzl", "generate_file")
 _JUPYTER_PY_TEMPLATE = """
 import sys
 
-from python import runfiles
-
 from drake.tools.jupyter.jupyter_bazel import _jupyter_bazel_notebook_main
 
 
 def main():
-    manifest = runfiles.Create()
-    notebook_path = manifest.Rlocation({notebook_respath})
-    _jupyter_bazel_notebook_main(notebook_path, sys.argv[1:])
+    _jupyter_bazel_notebook_main({notebook_respath}, sys.argv[1:])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When testing a Jupyter notebook, the `exe = os.path.realpath(exe)` adjustment in kcoverage.py defeats the ability of the codegen'd main program to find its runfiles.

We work around this by moving the runfiles resolution from the generated main to the library main. Bazel's py_binary trampoline loads the main library from the proper runfiles path, which allows runfiles to be found again.

This is a hotfix for f472c414.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21350)
<!-- Reviewable:end -->
