### PR TITLE
[geometry] Fix pass-by-value style for POD optionals

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -517,8 +517,7 @@ void DoScalarIndependentDefinitions(py::module m) {
       doc.MakePhongIllustrationProperties.doc);
 
   m.def("AddContactMaterial",
-      py::overload_cast<const std::optional<double>&,
-          const std::optional<double>&,
+      py::overload_cast<std::optional<double>, std::optional<double>,
           const std::optional<multibody::CoulombFriction<double>>&,
           ProximityProperties*>(&AddContactMaterial),
       py::arg("dissipation"), py::arg("point_stiffness"), py::arg("friction"),
@@ -528,9 +527,8 @@ void DoScalarIndependentDefinitions(py::module m) {
   // named arguments to disambiguate which arguments get which values.
   m.def(
       "AddContactMaterial",
-      [](ProximityProperties* properties,
-          const std::optional<double>& dissipation,
-          const std::optional<double>& point_stiffness,
+      [](ProximityProperties* properties, std::optional<double> dissipation,
+          std::optional<double> point_stiffness,
           const std::optional<multibody::CoulombFriction<double>>& friction) {
         AddContactMaterial(dissipation, point_stiffness, friction, properties);
       },

--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -290,7 +290,7 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.GetTrackedCameraPose.doc)
         .def("SetTransform",
             py::overload_cast<std::string_view, const math::RigidTransformd&,
-                const std::optional<double>&>(&Class::SetTransform),
+                std::optional<double>>(&Class::SetTransform),
             py::arg("path"), py::arg("X_ParentPath"),
             py::arg("time_in_recording") = std::nullopt,
             cls_doc.SetTransform.doc_RigidTransform)
@@ -305,19 +305,19 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.GetRealtimeRate.doc)
         .def("SetProperty",
             py::overload_cast<std::string_view, std::string, bool,
-                const std::optional<double>&>(&Class::SetProperty),
+                std::optional<double>>(&Class::SetProperty),
             py::arg("path"), py::arg("property"), py::arg("value"),
             py::arg("time_in_recording") = std::nullopt,
             cls_doc.SetProperty.doc_bool)
         .def("SetProperty",
             py::overload_cast<std::string_view, std::string, double,
-                const std::optional<double>&>(&Class::SetProperty),
+                std::optional<double>>(&Class::SetProperty),
             py::arg("path"), py::arg("property"), py::arg("value"),
             py::arg("time_in_recording") = std::nullopt,
             cls_doc.SetProperty.doc_double)
         .def("SetProperty",
             py::overload_cast<std::string_view, std::string,
-                const std::vector<double>&, const std::optional<double>&>(
+                const std::vector<double>&, std::optional<double>>(
                 &Class::SetProperty),
             py::arg("path"), py::arg("property"), py::arg("value"),
             py::arg("time_in_recording") = std::nullopt,

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -2549,12 +2549,14 @@ void Meshcat::SetCamera(OrthographicCamera camera, std::string path) {
 
 void Meshcat::SetTransform(std::string_view path,
                            const RigidTransformd& X_ParentPath,
-                           const std::optional<double>& time) {
-  if (recording_ && time) {
-    animation_->SetTransform(animation_->frame(*time), std::string(path),
-                             X_ParentPath);
+                           std::optional<double> time_in_recording) {
+  if (recording_ && time_in_recording.has_value()) {
+    const double time = *time_in_recording;
+    const int frame = animation_->frame(time);
+    animation_->SetTransform(frame, std::string(path), X_ParentPath);
   }
-  if (!recording_ || !time || set_visualizations_while_recording_) {
+  if (!recording_ || !time_in_recording.has_value() ||
+      set_visualizations_while_recording_) {
     impl().SetTransform(path, X_ParentPath);
   }
 }
@@ -2577,22 +2579,28 @@ double Meshcat::GetRealtimeRate() const {
 }
 
 void Meshcat::SetProperty(std::string_view path, std::string property,
-                          bool value, const std::optional<double>& time) {
-  if (recording_ && time) {
-    animation_->SetProperty(animation_->frame(*time), std::string(path),
-                            property, value);
+                          bool value, std::optional<double> time_in_recording) {
+  if (recording_ && time_in_recording.has_value()) {
+    const double time = *time_in_recording;
+    const int frame = animation_->frame(time);
+    animation_->SetProperty(frame, std::string(path), property, value);
   }
-  if (!recording_ || !time || set_visualizations_while_recording_) {
+  if (!recording_ || !time_in_recording.has_value() ||
+      set_visualizations_while_recording_) {
     impl().SetProperty(path, std::move(property), value);
   }
 }
 
 void Meshcat::SetProperty(std::string_view path, std::string property,
-                          double value, const std::optional<double>& time) {
-  if (recording_ && time) {
-    animation_->SetProperty(animation_->frame(*time), std::string(path),
-                            property, value);
+                          double value,
+                          std::optional<double> time_in_recording) {
+  if (recording_ && time_in_recording.has_value()) {
+    const double time = *time_in_recording;
+    const int frame = animation_->frame(time);
+    animation_->SetProperty(frame, std::string(path), property, value);
   }
+  // TODO(jwnimmer-tri) Why isn't time_in_recording part of this guard?
+  // That's inconsistent with everywhere else and seems like a bug.
   if (!recording_ || set_visualizations_while_recording_) {
     impl().SetProperty(path, std::move(property), value);
   }
@@ -2600,11 +2608,14 @@ void Meshcat::SetProperty(std::string_view path, std::string property,
 
 void Meshcat::SetProperty(std::string_view path, std::string property,
                           const std::vector<double>& value,
-                          const std::optional<double>& time) {
-  if (recording_ && time) {
-    animation_->SetProperty(animation_->frame(*time), std::string(path),
-                            property, value);
+                          std::optional<double> time_in_recording) {
+  if (recording_ && time_in_recording.has_value()) {
+    const double time = *time_in_recording;
+    const int frame = animation_->frame(time);
+    animation_->SetProperty(frame, std::string(path), property, value);
   }
+  // TODO(jwnimmer-tri) Why isn't time_in_recording part of this guard?
+  // That's inconsistent with everywhere else and seems like a bug.
   if (!recording_ || set_visualizations_while_recording_) {
     impl().SetProperty(path, std::move(property), value);
   }

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -515,9 +515,9 @@ class Meshcat {
 
   @pydrake_mkdoc_identifier{RigidTransform}
   */
-  void SetTransform(
-      std::string_view path, const math::RigidTransformd& X_ParentPath,
-      const std::optional<double>& time_in_recording = std::nullopt);
+  void SetTransform(std::string_view path,
+                    const math::RigidTransformd& X_ParentPath,
+                    std::optional<double> time_in_recording = std::nullopt);
 
   /** Set the homogeneous transform for a given path in the scene tree relative
   to its parent path. An object's pose is the concatenation of all of the
@@ -578,9 +578,8 @@ class Meshcat {
 
   @pydrake_mkdoc_identifier{bool}
   */
-  void SetProperty(
-      std::string_view path, std::string property, bool value,
-      const std::optional<double>& time_in_recording = std::nullopt);
+  void SetProperty(std::string_view path, std::string property, bool value,
+                   std::optional<double> time_in_recording = std::nullopt);
 
   /** Sets a single named property of the object at the given path. For example,
   @verbatim
@@ -600,9 +599,8 @@ class Meshcat {
 
   @pydrake_mkdoc_identifier{double}
   */
-  void SetProperty(
-      std::string_view path, std::string property, double value,
-      const std::optional<double>& time_in_recording = std::nullopt);
+  void SetProperty(std::string_view path, std::string property, double value,
+                   std::optional<double> time_in_recording = std::nullopt);
 
   /** Sets a single named property of the object at the given path. For example,
   @verbatim
@@ -622,10 +620,9 @@ class Meshcat {
 
   @pydrake_mkdoc_identifier{vector_double}
   */
-  void SetProperty(
-      std::string_view path, std::string property,
-      const std::vector<double>& value,
-      const std::optional<double>& time_in_recording = std::nullopt);
+  void SetProperty(std::string_view path, std::string property,
+                   const std::vector<double>& value,
+                   std::optional<double> time_in_recording = std::nullopt);
 
   /** Sets the *environment* texture. For objects with physically-based
    rendering (PBR) material properties (e.g., metallic surfaces), this defines

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -82,8 +82,8 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
 }  // namespace internal
 
 void AddContactMaterial(
-    const std::optional<double>& dissipation,
-    const std::optional<double>& point_stiffness,
+    std::optional<double> dissipation,
+    std::optional<double> point_stiffness,
     const std::optional<multibody::CoulombFriction<double>>& friction,
     ProximityProperties* properties) {
   DRAKE_DEMAND(properties != nullptr);

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -115,8 +115,8 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
  * @pre `properties` is not nullptr.
  */
 void AddContactMaterial(
-    const std::optional<double>& dissipation,
-    const std::optional<double>& point_stiffness,
+    std::optional<double> dissipation,
+    std::optional<double> point_stiffness,
     const std::optional<multibody::CoulombFriction<double>>& friction,
     ProximityProperties* properties);
 


### PR DESCRIPTION
Towards #21279.

The style guide [requires that `optional<POD>` be passed by-value](https://drake.mit.edu/styleguide/cppguide.html#Pass_By_Value_Primitives) so that the ABI can use registers to pass it instead of the stack.

While we're here, also fix the mismatch argument names between header and cc files and add TODOs for apparently missing checks.

+@DamrongGuoy for feature review, please.
+@sammy-tri for platform review per schedule, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21356)
<!-- Reviewable:end -->
