### PR TITLE
 MultibodyPlant adds DeformableModel by default

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1121,10 +1121,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_adjacent_bodies_collision_filters",
             &Class::get_adjacent_bodies_collision_filters,
             cls_doc.get_adjacent_bodies_collision_filters.doc)
-        .def("AddPhysicalModel", &Class::AddPhysicalModel, py::arg("model"),
-            cls_doc.AddPhysicalModel.doc)
-        .def("physical_models", &Class::physical_models,
-            py_rvp::reference_internal, cls_doc.physical_models.doc)
+        .def("deformable_model", &Class::deformable_model,
+            py_rvp::reference_internal, cls_doc.deformable_model.doc)
+        .def("mutable_deformable_model", &Class::mutable_deformable_model,
+            py_rvp::reference_internal, cls_doc.mutable_deformable_model.doc)
         .def("set_penetration_allowance", &Class::set_penetration_allowance,
             py::arg("penetration_allowance") = 0.001,
             cls_doc.set_penetration_allowance.doc)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -3270,7 +3270,7 @@ class TestPlant(unittest.TestCase):
     def test_deformable_model(self):
         builder = DiagramBuilder_[float]()
         plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 1.0e-3)
-        dut = DeformableModel(plant)
+        dut = plant.mutable_deformable_model()
         self.assertEqual(dut.num_bodies(), 0)
         # Add a deformable body to the model.
         deformable_body_config = DeformableBodyConfig_[float]()
@@ -3292,24 +3292,18 @@ class TestPlant(unittest.TestCase):
         # Verify that a body has been added to the model.
         self.assertEqual(dut.num_bodies(), 1)
         self.assertIsInstance(dut.GetReferencePositions(body_id), np.ndarray)
-        # Add the model to the plant.
-        plant.AddPhysicalModel(dut)
-        registered_models = plant.physical_models()
-        self.assertEqual(len(registered_models), 1)
-        self.assertEqual(registered_models[0].num_bodies(), 1)
+
+        deformable_model = plant.deformable_model()
+        self.assertEqual(deformable_model.num_bodies(), 1)
         # Turn on SAP and finalize.
         plant.set_discrete_contact_approximation(
             DiscreteContactApproximation.kSap)
         plant.Finalize()
 
-        # Post-finalize operations.
         self.assertIsInstance(
             plant.get_deformable_body_configuration_output_port(),
             OutputPort_[float])
-        builder.Connect(plant.get_deformable_body_configuration_output_port(),
-                        scene_graph.get_source_configuration_port(
-                            plant.get_source_id()))
-        self.assertEqual(dut.GetDiscreteStateIndex(body_id), 1)
+        self.assertEqual(deformable_model.GetDiscreteStateIndex(body_id), 1)
 
         diagram = builder.Build()
         # Ensure we can simulate this system.

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -1170,7 +1170,6 @@ drake_cc_googletest(
     name = "multibody_plant_scalar_conversion_test",
     shard_count = 4,
     deps = [
-        ":multibody_plant_core",
         ":plant",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -28,24 +28,7 @@ using fem::MaterialModel;
 
 template <typename T>
 DeformableModel<T>::DeformableModel(MultibodyPlant<T>* plant)
-    : PhysicalModel<T>(plant) {
-  /* Declare the deformable body configuration output port. This port copies the
-   discrete states of all deformable body configurations and put it into a
-   format that's easier for downstream parsing. */
-  configuration_output_port_index_ =
-      this->DeclareAbstractOutputPort(
-              "deformable_body_configuration",
-              []() {
-                return AbstractValue::Make<
-                    geometry::GeometryConfigurationVector<T>>();
-              },
-              [this](const systems::Context<T>& context,
-                     AbstractValue* output) {
-                this->CopyVertexPositions(context, output);
-              },
-              {systems::System<double>::xd_ticket()})
-          .get_index();
-}
+    : PhysicalModel<T>(plant) {}
 
 template <typename T>
 DeformableModel<T>::~DeformableModel() = default;
@@ -309,7 +292,9 @@ std::unique_ptr<PhysicalModel<double>> DeformableModel<T>::CloneToDouble(
     result->body_id_to_index_ = body_id_to_index_;
     result->body_ids_ = body_ids_;
     result->fixed_constraint_specs_ = fixed_constraint_specs_;
-    result->configuration_output_port_index_ = configuration_output_port_index_;
+    /* `configuration_output_port_index_` is set in `DeclareSceneGraphPorts()`;
+     because callers to `PhysicalModel::CloneToScalar` are required to
+     subsequently call `DeclareSceneGraphPorts`. */
   }
 
   return result;
@@ -318,7 +303,6 @@ std::unique_ptr<PhysicalModel<double>> DeformableModel<T>::CloneToDouble(
 template <typename T>
 std::unique_ptr<PhysicalModel<AutoDiffXd>>
 DeformableModel<T>::CloneToAutoDiffXd(MultibodyPlant<AutoDiffXd>* plant) const {
-  DRAKE_THROW_UNLESS(is_empty());
   return std::make_unique<DeformableModel<AutoDiffXd>>(plant);
 }
 
@@ -326,7 +310,6 @@ template <typename T>
 std::unique_ptr<PhysicalModel<symbolic::Expression>>
 DeformableModel<T>::CloneToSymbolic(
     MultibodyPlant<symbolic::Expression>* plant) const {
-  DRAKE_THROW_UNLESS(is_empty());
   return std::make_unique<DeformableModel<symbolic::Expression>>(plant);
 }
 
@@ -462,6 +445,26 @@ void DeformableModel<T>::DoDeclareSystemResources() {
        force_densities_) {
     force_density->DeclareSystemResources(this->mutable_plant());
   }
+}
+
+template <typename T>
+void DeformableModel<T>::DoDeclareSceneGraphPorts() {
+  /* Declare the deformable body configuration output port. This port copies
+   the discrete states of all deformable body configurations and puts them into
+   a format that's easier for downstream parsing. */
+  configuration_output_port_index_ =
+      this->DeclareAbstractOutputPort(
+              "deformable_body_configuration",
+              []() {
+                return AbstractValue::Make<
+                    geometry::GeometryConfigurationVector<T>>();
+              },
+              [this](const systems::Context<T>& context,
+                     AbstractValue* output) {
+                this->CopyVertexPositions(context, output);
+              },
+              {systems::System<double>::xd_ticket()})
+          .get_index();
 }
 
 template <typename T>

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -1234,21 +1234,17 @@ void DiscreteUpdateManager<T>::ExtractConcreteModel(
     const DeformableModel<T>* model) {
   if constexpr (std::is_same_v<T, double>) {
     DRAKE_DEMAND(model != nullptr);
-    // TODO(xuchenhan-tri): Demote this to a DRAKE_DEMAND when we check for
-    //  duplicated model with MbP::AddPhysicalModel.
-    if (deformable_driver_ != nullptr) {
-      throw std::logic_error(
-          fmt::format("{}: A deformable model has already been registered. "
-                      "Repeated registration is not allowed.",
-                      __func__));
+    DRAKE_DEMAND(deformable_driver_ == nullptr);
+    if (model->num_bodies() > 0) {
+      deformable_driver_ =
+          std::make_unique<DeformableDriver<double>>(model, this);
     }
-    deformable_driver_ =
-        std::make_unique<DeformableDriver<double>>(model, this);
   } else {
-    unused(model);
-    throw std::logic_error(
-        "Only T = double is supported for the simulation of deformable "
-        "bodies.");
+    if (!model->is_empty()) {
+      throw std::logic_error(
+          "Only T = double is supported for the simulation of deformable "
+          "bodies.");
+    }
   }
 }
 

--- a/multibody/plant/dummy_physical_model.cc
+++ b/multibody/plant/dummy_physical_model.cc
@@ -40,6 +40,15 @@ void DummyPhysicalModel<T>::DoDeclareSystemResources() {
       {systems::System<T>::xd_ticket()});
 }
 
+template <typename T>
+void DummyPhysicalModel<T>::DoDeclareSceneGraphPorts() {
+  scene_graph_output_port_ = &this->DeclareVectorOutputPort(
+      "dummy_scene_graph_port", systems::BasicVector<T>(1),
+      [](const systems::Context<T>&, systems::BasicVector<T>* output) {
+        output->set_value(VectorX<T>::Constant(1, 42.0));
+      });
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/dummy_physical_model.h
+++ b/multibody/plant/dummy_physical_model.h
@@ -49,10 +49,26 @@ class DummyPhysicalModel final : public PhysicalModel<T> {
     return *vector_output_port_;
   }
 
+  /* Returns the output port for SceneGraph communication if one is declared.
+   Throws a std::exception otherwise. */
+  const systems::OutputPort<T>& GetSceneGraphPortOrThrow() const {
+    if (scene_graph_output_port_ == nullptr) {
+      throw std::runtime_error(
+          "The SceneGraph output port has not been declared.");
+    }
+    return *scene_graph_output_port_;
+  }
+
   systems::DiscreteStateIndex discrete_state_index() const {
     this->ThrowIfSystemResourcesNotDeclared(__func__);
     return discrete_state_index_;
   }
+
+  bool is_cloneable_to_double() const final { return true; }
+
+  bool is_cloneable_to_autodiff() const final { return true; }
+
+  bool is_cloneable_to_symbolic() const final { return true; }
 
  private:
   /* Allow different specializations to access each other's private data for
@@ -82,12 +98,6 @@ class DummyPhysicalModel final : public PhysicalModel<T> {
     return CloneImpl<symbolic::Expression>(plant);
   }
 
-  bool is_cloneable_to_double() const final { return true; }
-
-  bool is_cloneable_to_autodiff() const final { return true; }
-
-  bool is_cloneable_to_symbolic() const final { return true; }
-
   template <typename ScalarType>
   std::unique_ptr<PhysicalModel<ScalarType>> CloneImpl(
       MultibodyPlant<ScalarType>* plant) const {
@@ -108,10 +118,15 @@ class DummyPhysicalModel final : public PhysicalModel<T> {
    the same results as a sanity check. */
   void DoDeclareSystemResources() final;
 
+  /* Declares a dummy output port that always returns a constant double, 42.0.
+   */
+  void DoDeclareSceneGraphPorts() final;
+
   std::vector<VectorX<T>> discrete_states_{};
   int num_dofs_{0};
   const systems::OutputPort<T>* abstract_output_port_{nullptr};
   const systems::OutputPort<T>* vector_output_port_{nullptr};
+  const systems::OutputPort<T>* scene_graph_output_port_{nullptr};
   systems::DiscreteStateIndex discrete_state_index_;
 };
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -330,6 +330,7 @@ MultibodyPlant<T>::MultibodyPlant(
   visual_geometries_.emplace_back();  // Entries for the "world" body.
   collision_geometries_.emplace_back();
 
+  AddDeformableModel();
   DeclareSceneGraphPorts();
 }
 
@@ -385,22 +386,12 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
     time_step_ = other.time_step_;
     // discrete_update_manager_ is copied below after FinalizePlantOnly().
 
-    // Copy over physical_models_.
+    // Copy over physical models.
     // Note: The physical models must be cloned before `FinalizePlantOnly()` is
     // called because `FinalizePlantOnly()` has to allocate system resources
     // requested by physical models.
-    for (auto& model : other.physical_models_) {
-      auto cloned_model = model->template CloneToScalar<T>(this);
-      // TODO(xuchenhan-tri): Rework physical model and discrete update manager
-      //  to eliminate the requirement on the order that they are called with
-      //  respect to Finalize().
-
-      // AddPhysicalModel can't be called here because it's post-finalize. We
-      // have to manually disable scalars that the cloned physical model do not
-      // support.
-      RemoveUnsupportedScalars(*cloned_model);
-      physical_models_.emplace_back(std::move(cloned_model));
-    }
+    physical_models_ = other.physical_models_->template CloneToScalar<T>(this);
+    this->RemoveUnsupportedScalars(*physical_models_);
 
     coupler_constraints_specs_ = other.coupler_constraints_specs_;
     distance_constraints_specs_ = other.distance_constraints_specs_;
@@ -1562,22 +1553,19 @@ void MultibodyPlant<T>::SetDiscreteUpdateManager(
 }
 
 template <typename T>
-void MultibodyPlant<T>::AddPhysicalModel(
-    std::unique_ptr<PhysicalModel<T>> model) {
-  // TODO(xuchenhan-tri): Guard against the same type of model being registered
-  //  more than once.
+internal::DummyPhysicalModel<T>& MultibodyPlant<T>::AddDummyModel(
+    std::unique_ptr<internal::DummyPhysicalModel<T>> model) {
   DRAKE_MBP_THROW_IF_FINALIZED();
-  DRAKE_DEMAND(model != nullptr);
-  auto& added_model = physical_models_.emplace_back(std::move(model));
-  RemoveUnsupportedScalars(*added_model);
+  DRAKE_THROW_UNLESS(model->plant() == this);
+  return physical_models_->AddDummyModel(std::move(model));
 }
 
 template <typename T>
 std::vector<const PhysicalModel<T>*> MultibodyPlant<T>::physical_models()
     const {
   std::vector<const PhysicalModel<T>*> result;
-  for (const std::unique_ptr<PhysicalModel<T>>& model : physical_models_) {
-    result.emplace_back(model.get());
+  for (const auto& model : physical_models_->owned_models()) {
+    result.push_back(model.get());
   }
   return result;
 }
@@ -3215,9 +3203,7 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
 
   // Let external model managers declare their state, cache and ports in
   // `this` MultibodyPlant.
-  for (auto& physical_model : physical_models_) {
-    physical_model->DeclareSystemResources();
-  }
+  physical_models_->DeclareSystemResources();
 }
 
 template <typename T>
@@ -3501,6 +3487,7 @@ void MultibodyPlant<T>::DeclareSceneGraphPorts() {
               "geometry_pose", &MultibodyPlant<T>::CalcGeometryPoseOutput,
               {this->configuration_ticket()})
           .get_index();
+  physical_models_->DeclareSceneGraphPorts();
 }
 
 template <typename T>
@@ -3767,21 +3754,11 @@ const systems::InputPort<T>& MultibodyPlant<T>::get_geometry_query_input_port()
 template <typename T>
 const OutputPort<T>&
 MultibodyPlant<T>::get_deformable_body_configuration_output_port() const {
-  // TODO(xuchenhan-tri): enforce that there's only ever going to be one
-  // DeformableModel as part of #21355.
-  for (const std::unique_ptr<PhysicalModel<T>>& physical_model :
-       physical_models_) {
-    if (std::holds_alternative<const DeformableModel<T>*>(
-            physical_model->ToPhysicalModelPointerVariant())) {
-      const DeformableModel<T>* deformable_model =
-          std::get<const DeformableModel<T>*>(
-              physical_model->ToPhysicalModelPointerVariant());
-      DRAKE_DEMAND(deformable_model != nullptr);
-      return this->get_output_port(
-          deformable_model->configuration_output_port_index());
-    }
-  }
-  throw std::runtime_error("No deformable body in the plant.");
+  const DeformableModel<T>* deformable_model =
+      physical_models_->deformable_model();
+  DRAKE_DEMAND(deformable_model != nullptr);
+  return systems::System<T>::get_output_port(
+      deformable_model->configuration_output_port_index());
 }
 
 template <typename T>
@@ -3846,6 +3823,17 @@ void MultibodyPlant<T>::set_gravity_enabled(ModelInstanceIndex model_instance,
 }
 
 template <typename T>
+DeformableModel<T>& MultibodyPlant<T>::AddDeformableModel() {
+  // TODO(xuchenhan-tri): We should verify that the plant is not finalized yet.
+  // Right now, we can do exactly just that yet because is_finalized() returns
+  // true iff the MultibodyTree is finalized. There's no easy way to confirm
+  // that a plant is not yet finalized when the tree is already finalized.
+  DRAKE_DEMAND(physical_models_->deformable_model() == nullptr);
+  return physical_models_->AddDeformableModel(
+      std::make_unique<DeformableModel<T>>(this));
+}
+
+template <typename T>
 T MultibodyPlant<T>::StribeckModel::ComputeFrictionCoefficient(
     const T& speed_BcAc, const CoulombFriction<double>& friction) const {
   DRAKE_ASSERT(speed_BcAc >= 0);
@@ -3888,6 +3876,9 @@ AddMultibodyPlantSceneGraphResult<T> AddMultibodyPlantSceneGraph(
                        plant_ptr->get_source_id().value()));
   builder->Connect(scene_graph_ptr->get_query_output_port(),
                    plant_ptr->get_geometry_query_input_port());
+  builder->Connect(plant_ptr->get_deformable_body_configuration_output_port(),
+                   scene_graph_ptr->get_source_configuration_port(
+                       plant_ptr->get_source_id().value()));
   return {plant_ptr, scene_graph_ptr};
 }
 

--- a/multibody/plant/physical_model.cc
+++ b/multibody/plant/physical_model.cc
@@ -49,6 +49,21 @@ bool PhysicalModel<T>::is_cloneable_to_symbolic() const {
 }
 
 template <typename T>
+void PhysicalModel<T>::DeclareSystemResources() {
+  DRAKE_DEMAND(owning_plant_ != nullptr);
+  DoDeclareSystemResources();
+  owning_plant_ = nullptr;
+}
+
+template <typename T>
+void PhysicalModel<T>::DeclareSceneGraphPorts() {
+  ThrowIfSystemResourcesDeclared(__func__);
+  /* Note that DoDeclareSceneGraphPorts throws an exception when a port (with
+   the same name) is declared for the second time. */
+  DoDeclareSceneGraphPorts();
+}
+
+template <typename T>
 void PhysicalModel<T>::ThrowIfSystemResourcesDeclared(
     const char* function_name) const {
   if (owning_plant_ == nullptr) {

--- a/multibody/plant/physical_model_collection.cc
+++ b/multibody/plant/physical_model_collection.cc
@@ -12,7 +12,7 @@ DeformableModel<T>& PhysicalModelCollection<T>::AddDeformableModel(
     std::unique_ptr<DeformableModel<T>> model) {
   DRAKE_THROW_UNLESS(deformable_model_ == nullptr);
   DRAKE_THROW_UNLESS(model != nullptr);
-  DRAKE_THROW_UNLESS(model->plant() == plant());
+  ThrowForIncompatibleModel(*model);
   deformable_model_ = model.get();
   owned_models_.emplace_back(std::move(model));
   return *deformable_model_;
@@ -23,7 +23,7 @@ DummyPhysicalModel<T>& PhysicalModelCollection<T>::AddDummyModel(
     std::unique_ptr<DummyPhysicalModel<T>> model) {
   DRAKE_THROW_UNLESS(dummy_model_ == nullptr);
   DRAKE_THROW_UNLESS(model != nullptr);
-  DRAKE_THROW_UNLESS(model->plant() == plant());
+  ThrowForIncompatibleModel(*model);
   dummy_model_ = model.get();
   owned_models_.emplace_back(std::move(model));
   return *dummy_model_;
@@ -63,7 +63,25 @@ void PhysicalModelCollection<T>::DeclareSystemResources() {
   for (auto& model : owned_models_) {
     model->DeclareSystemResources();
   }
-  owning_plant_ = nullptr;
+  system_resources_declared_ = true;
+}
+
+template <typename T>
+void PhysicalModelCollection<T>::DeclareSceneGraphPorts() {
+  DRAKE_THROW_UNLESS(!system_resources_declared_);
+  for (std::unique_ptr<PhysicalModel<T>>& model : owned_models_) {
+    model->DeclareSceneGraphPorts();
+  }
+}
+
+template <typename T>
+void PhysicalModelCollection<T>::ThrowForIncompatibleModel(
+    const PhysicalModel<T>& model) const {
+  if (!owned_models_.empty() &&
+      model.plant() != owned_models_.back()->plant()) {
+    throw std::runtime_error(
+        "The given model belongs to a different MultibodyPlant.");
+  }
 }
 
 }  // namespace internal

--- a/multibody/plant/test/deformable_boundary_condition_test.cc
+++ b/multibody/plant/test/deformable_boundary_condition_test.cc
@@ -54,11 +54,11 @@ class DeformableIntegrationTest : public ::testing::Test {
     systems::DiagramBuilder<double> builder;
     std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
 
-    auto deformable_model = make_unique<DeformableModel<double>>(plant_);
-    body_id_ = RegisterDeformableBall(deformable_model.get(), "deformable");
-    deformable_model->SetWallBoundaryCondition(body_id_, p_WQ_, n_W_);
-    model_ = deformable_model.get();
-    plant_->AddPhysicalModel(std::move(deformable_model));
+    DeformableModel<double>& deformable_model =
+        plant_->mutable_deformable_model();
+    body_id_ = RegisterDeformableBall(&deformable_model, "deformable");
+    deformable_model.SetWallBoundaryCondition(body_id_, p_WQ_, n_W_);
+    model_ = &plant_->deformable_model();
     // N.B. Deformables are only supported with the SAP solver.
     // Thus for testing we choose one arbitrary contact approximation that uses
     // the SAP solver.
@@ -84,10 +84,6 @@ class DeformableIntegrationTest : public ::testing::Test {
     /* Connect visualizer. Useful for when this test is used for debugging. */
     geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
 
-    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
-                    scene_graph_->get_source_configuration_port(
-                        plant_->get_source_id().value()));
-
     diagram_ = builder.Build();
   }
 
@@ -99,7 +95,7 @@ class DeformableIntegrationTest : public ::testing::Test {
 
   SceneGraph<double>* scene_graph_{nullptr};
   MultibodyPlant<double>* plant_{nullptr};
-  DeformableModel<double>* model_{nullptr};
+  const DeformableModel<double>* model_{nullptr};
   const CompliantContactManager<double>* manager_{nullptr};
   const DeformableDriver<double>* driver_{nullptr};
   unique_ptr<systems::Diagram<double>> diagram_{nullptr};

--- a/multibody/plant/test/deformable_collision_filter_test.cc
+++ b/multibody/plant/test/deformable_collision_filter_test.cc
@@ -32,13 +32,12 @@ class DeformableCollisionFilterTest : public ::testing::Test {
     systems::DiagramBuilder<double> builder;
     std::tie(plant_, scene_graph_) =
         AddMultibodyPlantSceneGraph(&builder, 0.01);
-    auto deformable_model = std::make_unique<DeformableModel<double>>(plant_);
+    DeformableModel<double>& deformable_model =
+        plant_->mutable_deformable_model();
     DeformableBodyId deformable_body_id =
-        RegisterDeformableOctahedron(deformable_model.get(), "deformable");
+        RegisterDeformableOctahedron(&deformable_model, "deformable");
     deformable_geometry_id_ =
-        deformable_model->GetGeometryId(deformable_body_id);
-    model_ = deformable_model.get();
-    plant_->AddPhysicalModel(std::move(deformable_model));
+        deformable_model.GetGeometryId(deformable_body_id);
     // N.B. Deformables are only supported with the SAP solver.
     // Thus for testing we choose one arbitrary contact approximation that uses
     // the SAP solver.
@@ -95,10 +94,6 @@ class DeformableCollisionFilterTest : public ::testing::Test {
 
     plant_->Finalize();
 
-    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
-                    scene_graph_->get_source_configuration_port(
-                        plant_->get_source_id().value()));
-
     diagram_ = builder.Build();
   }
 
@@ -141,7 +136,6 @@ class DeformableCollisionFilterTest : public ::testing::Test {
 
   SceneGraph<double>* scene_graph_{nullptr};
   MultibodyPlant<double>* plant_{nullptr};
-  DeformableModel<double>* model_{nullptr};
   GeometryId deformable_geometry_id_;
   GeometryId welded_geometry_id_;
   GeometryId free_geometry_id_;

--- a/multibody/plant/test/deformable_contact_results_test.cc
+++ b/multibody/plant/test/deformable_contact_results_test.cc
@@ -53,8 +53,7 @@ GTEST_TEST(CompliantContactManagerTest, ContactResultsWithDeformable) {
   plant.RegisterCollisionGeometry(body2, RigidTransformd(Vector3d(-5, -5, 5)),
                                   geometry::Box(1, 1, 1), "point contact box",
                                   point_proximity_properties);
-
-  auto deformable_model = std::make_unique<DeformableModel<double>>(&plant);
+  DeformableModel<double>& deformable_model = plant.mutable_deformable_model();
   /* Add a deformable sphere that collides with the ground but not with any
    other rigid bodies. */
   auto deformable_geometry = std::make_unique<GeometryInstance>(
@@ -67,13 +66,9 @@ GTEST_TEST(CompliantContactManagerTest, ContactResultsWithDeformable) {
       std::move(deformable_proximity_props));
   multibody::fem::DeformableBodyConfig<double> body_config;
   constexpr double kRezHint = 10.0;
-  deformable_model->RegisterDeformableBody(std::move(deformable_geometry),
-                                           body_config, kRezHint);
-  plant.AddPhysicalModel(std::move(deformable_model));
+  deformable_model.RegisterDeformableBody(std::move(deformable_geometry),
+                                          body_config, kRezHint);
   plant.Finalize();
-  builder.Connect(
-      plant.get_deformable_body_configuration_output_port(),
-      scene_graph.get_source_configuration_port(plant.get_source_id().value()));
 
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();

--- a/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
@@ -103,11 +103,11 @@ class DeformableDriverContactKinematicsTest
     systems::DiagramBuilder<double> builder;
     constexpr double kDt = 0.01;
     std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
-    auto deformable_model = make_unique<DeformableModel<double>>(plant_);
-    deformable_body_id_ = RegisterDeformableOctahedron(deformable_model.get(),
-                                                       "deformable", X_WF_);
-    model_ = deformable_model.get();
-    plant_->AddPhysicalModel(std::move(deformable_model));
+    DeformableModel<double>& deformable_model =
+        plant_->mutable_deformable_model();
+    deformable_body_id_ =
+        RegisterDeformableOctahedron(&deformable_model, "deformable", X_WF_);
+    model_ = &plant_->deformable_model();
 
     /* Define proximity properties for all rigid geometries. */
     geometry::ProximityProperties rigid_proximity_props;
@@ -146,12 +146,13 @@ class DeformableDriverContactKinematicsTest
       /* The pose of the deformable body in the rigid body's frame, X_BF, is
        equal to X_WF because X_WB is identity. */
       const RigidTransformd X_BF = X_WF_;
-      model_->AddFixedConstraint(deformable_body_id_,
-                                 plant_->get_body(rigid_body_index_), X_BF,
-                                 geometry::Box(10, 10, 1), X_BR);
+      deformable_model.AddFixedConstraint(deformable_body_id_,
+                                          plant_->get_body(rigid_body_index_),
+                                          X_BF, geometry::Box(10, 10, 1), X_BR);
     } else {
-      model_->AddFixedConstraint(deformable_body_id_, plant_->world_body(),
-                                 X_WF_, geometry::Box(10, 10, 1), X_BR);
+      deformable_model.AddFixedConstraint(deformable_body_id_,
+                                          plant_->world_body(), X_WF_,
+                                          geometry::Box(10, 10, 1), X_BR);
     }
 
     // N.B. Deformables are only supported with the SAP solver.
@@ -166,9 +167,6 @@ class DeformableDriverContactKinematicsTest
     driver_ = manager_->deformable_driver();
     DRAKE_DEMAND(driver_ != nullptr);
 
-    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
-                    scene_graph_->get_source_configuration_port(
-                        plant_->get_source_id().value()));
     diagram_ = builder.Build();
     context_ = diagram_->CreateDefaultContext();
 
@@ -220,16 +218,16 @@ class DeformableDriverContactKinematicsTest
     MultibodyPlantConfig config{.time_step = kDt,
                                 .discrete_contact_approximation = "sap"};
     std::tie(plant_, scene_graph_) = AddMultibodyPlant(config, &builder);
-    auto deformable_model = make_unique<DeformableModel<double>>(plant_);
-    deformable_body_id_ = RegisterDeformableOctahedron(deformable_model.get(),
-                                                       "deformable", X_WF_);
+    DeformableModel<double>& deformable_model =
+        plant_->mutable_deformable_model();
+    deformable_body_id_ =
+        RegisterDeformableOctahedron(&deformable_model, "deformable", X_WF_);
     /* Sets up a second deformable body so that its top half intersects the
      bottom half of the first deformable body. */
     deformable_body_id2_ = RegisterDeformableOctahedron(
-        deformable_model.get(), "deformable2",
+        &deformable_model, "deformable2",
         X_WF_ * RigidTransformd(Vector3d(0, 0, -1.25)));
-    model_ = deformable_model.get();
-    plant_->AddPhysicalModel(std::move(deformable_model));
+    model_ = &plant_->deformable_model();
 
     plant_->Finalize();
     auto contact_manager = make_unique<CompliantContactManager<double>>();
@@ -238,9 +236,6 @@ class DeformableDriverContactKinematicsTest
     driver_ = manager_->deformable_driver();
     DRAKE_DEMAND(driver_ != nullptr);
 
-    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
-                    scene_graph_->get_source_configuration_port(
-                        plant_->get_source_id().value()));
     diagram_ = builder.Build();
     context_ = diagram_->CreateDefaultContext();
 
@@ -506,7 +501,7 @@ class DeformableDriverContactKinematicsTest
   MultibodyPlant<double>* plant_{nullptr};
   SceneGraph<double>* scene_graph_{nullptr};
   std::unique_ptr<systems::Diagram<double>> diagram_;
-  DeformableModel<double>* model_{nullptr};
+  const DeformableModel<double>* model_{nullptr};
   const CompliantContactManager<double>* manager_{nullptr};
   const DeformableDriver<double>* driver_{nullptr};
   std::unique_ptr<Context<double>> context_;
@@ -595,14 +590,12 @@ GTEST_TEST(DeformableDriverContactKinematicsWithBcTest,
   systems::DiagramBuilder<double> builder;
   constexpr double kDt = 0.01;
   auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, kDt);
-  auto deformable_model = make_unique<DeformableModel<double>>(&plant);
+  DeformableModel<double>& deformable_model = plant.mutable_deformable_model();
   DeformableBodyId body_id = RegisterDeformableOctahedron(
-      deformable_model.get(), "deformable", RigidTransformd::Identity());
-  DeformableModel<double>* model = deformable_model.get();
+      &deformable_model, "deformable", RigidTransformd::Identity());
   /* Put the bottom vertex under bc. */
-  model->SetWallBoundaryCondition(body_id, Vector3d(0, 0, -0.5),
-                                  Vector3d(0, 0, 1));
-  plant.AddPhysicalModel(std::move(deformable_model));
+  deformable_model.SetWallBoundaryCondition(body_id, Vector3d(0, 0, -0.5),
+                                            Vector3d(0, 0, 1));
 
   /* Define proximity properties for all rigid geometries. */
   geometry::ProximityProperties rigid_proximity_props;
@@ -632,9 +625,6 @@ GTEST_TEST(DeformableDriverContactKinematicsWithBcTest,
   const DeformableDriver<double>* driver = manager->deformable_driver();
   ASSERT_NE(driver, nullptr);
 
-  builder.Connect(
-      plant.get_deformable_body_configuration_output_port(),
-      scene_graph.get_source_configuration_port(plant.get_source_id().value()));
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
 
@@ -645,7 +635,7 @@ GTEST_TEST(DeformableDriverContactKinematicsWithBcTest,
   EXPECT_GT(contact_pairs.size(), 0);
   const PartialPermutation& vertex_permutation =
       DeformableDriverTest::EvalVertexPermutation(
-          *driver, plant_context, model->GetGeometryId(body_id));
+          *driver, plant_context, deformable_model.GetGeometryId(body_id));
   /* We know that the octahedron created as the coarsest sphere indexes the
    bottom vertex as 6 (see RegisterDeformableOctahedron). */
   const int bottom_vertex_permuted_index = vertex_permutation.permuted_index(6);
@@ -668,14 +658,12 @@ GTEST_TEST(DeformableDriverConstraintParticipation, ConstraintWithoutContact) {
   systems::DiagramBuilder<double> builder;
   constexpr double kDt = 0.01;
   auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, kDt);
-  auto deformable_model = make_unique<DeformableModel<double>>(&plant);
+  DeformableModel<double>& deformable_model = plant.mutable_deformable_model();
   DeformableBodyId body_id = RegisterDeformableOctahedron(
-      deformable_model.get(), "deformable", RigidTransformd::Identity());
-  DeformableModel<double>* model = deformable_model.get();
-  plant.AddPhysicalModel(std::move(deformable_model));
+      &deformable_model, "deformable", RigidTransformd::Identity());
   /* Use a large box geometry to ensure that all deformable vertices are placed
    under fixed constraints. */
-  model->AddFixedConstraint(
+  deformable_model.AddFixedConstraint(
       body_id, plant.world_body(), RigidTransformd::Identity(),
       geometry::Box(10, 10, 10), RigidTransformd::Identity());
   // N.B. Deformables are only supported with the SAP solver.
@@ -688,11 +676,6 @@ GTEST_TEST(DeformableDriverConstraintParticipation, ConstraintWithoutContact) {
   plant.SetDiscreteUpdateManager(std::move(contact_manager));
   const DeformableDriver<double>* driver = manager->deformable_driver();
   ASSERT_NE(driver, nullptr);
-  // TODO(xuchenhan-tri): AddMultibodyPlant and AddMultibodyPlantSceneGraph
-  // should connect this port automatically.
-  builder.Connect(
-      plant.get_deformable_body_configuration_output_port(),
-      scene_graph.get_source_configuration_port(plant.get_source_id().value()));
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
 

--- a/multibody/plant/test/deformable_driver_contact_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_test.cc
@@ -51,19 +51,19 @@ class DeformableDriverContactTest : public ::testing::Test {
   void SetUp() override {
     systems::DiagramBuilder<double> builder;
     std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
-    auto deformable_model = make_unique<DeformableModel<double>>(plant_);
+    DeformableModel<double>& deformable_model =
+        plant_->mutable_deformable_model();
     /* Move the first deformable up so that the bottom half of it intersects the
-     * rigid box. */
+     rigid box. */
     const RigidTransformd X_WD0(Vector3d(0, 0, 1.25));
-    body_id0_ = RegisterDeformableOctahedron(X_WD0, deformable_model.get(),
-                                             "deformable0");
+    body_id0_ =
+        RegisterDeformableOctahedron(X_WD0, &deformable_model, "deformable0");
     /* Move the second deformable down so that the top half of it intersects the
-     * rigid box. */
+     rigid box. */
     const RigidTransformd X_WD1(Vector3d(0, 0, -1.25));
-    body_id1_ = RegisterDeformableOctahedron(X_WD1, deformable_model.get(),
-                                             "deformable1");
-    model_ = deformable_model.get();
-    plant_->AddPhysicalModel(std::move(deformable_model));
+    body_id1_ =
+        RegisterDeformableOctahedron(X_WD1, &deformable_model, "deformable1");
+    model_ = &plant_->deformable_model();
     // N.B. Deformables are only supported with the SAP solver.
     // Thus for testing we choose one arbitrary contact approximation that uses
     // the SAP solver.
@@ -90,9 +90,6 @@ class DeformableDriverContactTest : public ::testing::Test {
     driver_ = manager_->deformable_driver();
     DRAKE_DEMAND(driver_ != nullptr);
 
-    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
-                    scene_graph_->get_source_configuration_port(
-                        plant_->get_source_id().value()));
     diagram_ = builder.Build();
     context_ = diagram_->CreateDefaultContext();
   }
@@ -180,7 +177,7 @@ class DeformableDriverContactTest : public ::testing::Test {
   MultibodyPlant<double>* plant_{nullptr};
   SceneGraph<double>* scene_graph_{nullptr};
   std::unique_ptr<systems::Diagram<double>> diagram_;
-  DeformableModel<double>* model_{nullptr};
+  const DeformableModel<double>* model_{nullptr};
   const CompliantContactManager<double>* manager_{nullptr};
   const DeformableDriver<double>* driver_{nullptr};
   std::unique_ptr<Context<double>> context_;

--- a/multibody/plant/test/deformable_driver_test.cc
+++ b/multibody/plant/test/deformable_driver_test.cc
@@ -31,11 +31,11 @@ class DeformableDriverTest : public ::testing::Test {
   void SetUp() override {
     systems::DiagramBuilder<double> builder;
     std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
-    auto deformable_model = make_unique<DeformableModel<double>>(plant_);
+    DeformableModel<double>& deformable_model =
+        plant_->mutable_deformable_model();
     constexpr double kRezHint = 0.5;
-    body_id_ = RegisterSphere(deformable_model.get(), kRezHint);
-    model_ = deformable_model.get();
-    plant_->AddPhysicalModel(std::move(deformable_model));
+    body_id_ = RegisterSphere(&deformable_model, kRezHint);
+    model_ = &deformable_model;
     const RigidBody<double>& body = plant_->AddRigidBody(
         "rigid_body", SpatialInertia<double>::SolidSphereWithMass(1.0, 1.0));
     // N.B. Deformables are only supported with the SAP solver.
@@ -49,10 +49,6 @@ class DeformableDriverTest : public ::testing::Test {
     plant_->SetDiscreteUpdateManager(std::move(contact_manager));
     driver_ = manager_->deformable_driver();
     DRAKE_DEMAND(driver_ != nullptr);
-
-    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
-                    scene_graph_->get_source_configuration_port(
-                        plant_->get_source_id().value()));
     diagram_ = builder.Build();
     diagram_context_ = diagram_->CreateDefaultContext();
     plant_context_ =

--- a/multibody/plant/test/deformable_fixed_constraint_test.cc
+++ b/multibody/plant/test/deformable_fixed_constraint_test.cc
@@ -76,13 +76,13 @@ class DeformableFixedConstraintTest : public ::testing::Test {
     plant_config.discrete_contact_approximation = "sap";
     std::tie(plant_, scene_graph_) = AddMultibodyPlant(plant_config, &builder);
 
-    auto deformable_model = make_unique<DeformableModel<double>>(plant_);
+    DeformableModel<double>& deformable_model =
+        plant_->mutable_deformable_model();
     /* Initialize the deformable body close to its equilibrium pose. */
     const RigidTransformd X_WD = RigidTransformd(Vector3d(0, 0, -0.2));
-    deformable_body_id_ = RegisterDeformableOctahedron(deformable_model.get(),
-                                                       X_WD, 0.1, "deformable");
-    model_ = deformable_model.get();
-    plant_->AddPhysicalModel(std::move(deformable_model));
+    deformable_body_id_ = RegisterDeformableOctahedron(&deformable_model, X_WD,
+                                                       0.1, "deformable");
+    model_ = &deformable_model;
 
     rigid_body_index_ =
         plant_
@@ -100,8 +100,8 @@ class DeformableFixedConstraintTest : public ::testing::Test {
     /* Pose the deformable body in the rigid body's frame so that all vertices
      except the top vertex are under fixed constraint. */
     const RigidTransformd X_RD(Vector3d(0, 0, 0.09));
-    model_->AddFixedConstraint(deformable_body_id_, box_body, X_RD, box,
-                               RigidTransformd::Identity());
+    deformable_model.AddFixedConstraint(deformable_body_id_, box_body, X_RD,
+                                        box, RigidTransformd::Identity());
 
     /* Initialize the static box to the top of the deformable octahedron so that
      the top (with largest z coordinate in the world frame) vertex is fixed to
@@ -112,23 +112,20 @@ class DeformableFixedConstraintTest : public ::testing::Test {
     /* Pose the deformable body in the static rigid body's frame so that the
      bottom top is under fixed constraint. */
     const RigidTransformd X_SD(Vector3d(0, 0, -0.19));
-    model_->AddFixedConstraint(deformable_body_id_, plant_->world_body(), X_SD,
-                               box, RigidTransformd::Identity());
+    deformable_model.AddFixedConstraint(deformable_body_id_,
+                                        plant_->world_body(), X_SD, box,
+                                        RigidTransformd::Identity());
     plant_->Finalize();
 
     /* Connect visualizer. Useful for when this test is used for debugging. */
     geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
-
-    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
-                    scene_graph_->get_source_configuration_port(
-                        plant_->get_source_id().value()));
 
     diagram_ = builder.Build();
   }
 
   SceneGraph<double>* scene_graph_{nullptr};
   MultibodyPlant<double>* plant_{nullptr};
-  DeformableModel<double>* model_{nullptr};
+  const DeformableModel<double>* model_{nullptr};
   const CompliantContactManager<double>* manager_{nullptr};
   std::unique_ptr<systems::Diagram<double>> diagram_{nullptr};
   BodyIndex rigid_body_index_;

--- a/multibody/plant/test/deformable_integration_test.cc
+++ b/multibody/plant/test/deformable_integration_test.cc
@@ -63,11 +63,10 @@ class DeformableIntegrationTest : public ::testing::Test {
     systems::DiagramBuilder<double> builder;
     std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
 
-    auto deformable_model = make_unique<DeformableModel<double>>(plant_);
-    body_id_ =
-        RegisterDeformableOctahedron(deformable_model.get(), "deformable");
-    model_ = deformable_model.get();
-    plant_->AddPhysicalModel(std::move(deformable_model));
+    DeformableModel<double>& deformable_model =
+        plant_->mutable_deformable_model();
+    body_id_ = RegisterDeformableOctahedron(&deformable_model, "deformable");
+    model_ = &deformable_model;
     // N.B. Deformables are only supported with the SAP solver.
     // Thus for testing we choose one arbitrary contact approximation that uses
     // the SAP solver.
@@ -101,10 +100,6 @@ class DeformableIntegrationTest : public ::testing::Test {
     /* Connect visualizer. Useful for when this test is used for debugging. */
     geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
 
-    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
-                    scene_graph_->get_source_configuration_port(
-                        plant_->get_source_id().value()));
-
     diagram_ = builder.Build();
   }
 
@@ -126,7 +121,7 @@ class DeformableIntegrationTest : public ::testing::Test {
 
   SceneGraph<double>* scene_graph_{nullptr};
   MultibodyPlant<double>* plant_{nullptr};
-  DeformableModel<double>* model_{nullptr};
+  const DeformableModel<double>* model_{nullptr};
   const CompliantContactManager<double>* manager_{nullptr};
   const DeformableDriver<double>* driver_{nullptr};
   unique_ptr<systems::Diagram<double>> diagram_{nullptr};

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -59,6 +59,19 @@ constexpr double kDummyTau = 6.0;
 constexpr double kDummyVdot = 7.0;
 constexpr double kDt = 0.1;
 
+/* Returns a pointer to the DummyPhysicalModel owned by the given
+ MultibodyPlant. Returns the nullptr if no DummyPhysicalModel exists. */
+template <typename T>
+const DummyPhysicalModel<T>* GetDummyModel(const MultibodyPlant<T>& plant) {
+  for (const auto* model : plant.physical_models()) {
+    const auto* dummy_model = dynamic_cast<const DummyPhysicalModel<T>*>(model);
+    if (dummy_model != nullptr) {
+      return dummy_model;
+    }
+  }
+  return nullptr;
+}
+
 /* A dummy manager class derived from DiscreteUpdateManager for testing
  purpose. It implements the interface in DiscreteUpdateManager by filling in
  dummy data.
@@ -112,11 +125,7 @@ class DummyDiscreteUpdateManager final : public DiscreteUpdateManager<T> {
   /* Extracts information about the additional discrete state that
    DummyPhysicalModel declares if one exists in the owning MultibodyPlant. */
   void DoExtractModelInfo() final {
-    /* For unit testing we verify there is a single physical model of type
-     DummyPhysicalModel. */
-    DRAKE_DEMAND(this->plant().physical_models().size() == 1);
-    const auto* dummy_model = dynamic_cast<const DummyPhysicalModel<T>*>(
-        this->plant().physical_models()[0]);
+    const DummyPhysicalModel<T>* dummy_model = GetDummyModel(this->plant());
     DRAKE_DEMAND(dummy_model != nullptr);
     additional_state_index_ = dummy_model->discrete_state_index();
   }
@@ -201,7 +210,7 @@ class DiscreteUpdateManagerTest : public ::testing::Test {
     plant_.AddRigidBody("rigid body", SpatialInertia<double>::MakeUnitary());
     auto dummy_model = std::make_unique<DummyPhysicalModel<double>>(&plant_);
     dummy_model_ = dummy_model.get();
-    plant_.AddPhysicalModel(std::move(dummy_model));
+    plant_.AddDummyModel(std::move(dummy_model));
     dummy_model_->AppendDiscreteState(dummy_discrete_state());
     plant_.Finalize();
     // MultibodyPlant::num_velocities() only reports the number of rigid
@@ -277,10 +286,7 @@ TEST_F(DiscreteUpdateManagerTest, ScalarConversion) {
   auto context = autodiff_plant->CreateDefaultContext();
   auto simulator =
       systems::Simulator<AutoDiffXd>(*autodiff_plant, std::move(context));
-  ASSERT_EQ(autodiff_plant->physical_models().size(), 1);
-  const DummyPhysicalModel<AutoDiffXd>* model =
-      dynamic_cast<const DummyPhysicalModel<AutoDiffXd>*>(
-          autodiff_plant->physical_models()[0]);
+  const DummyPhysicalModel<AutoDiffXd>* model = GetDummyModel(*autodiff_plant);
   ASSERT_NE(model, nullptr);
 
   const int time_steps = 2;

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -111,6 +111,9 @@ void CompareMultibodyPlantPortIndices(const MultibodyPlant<T>& plant_t,
   EXPECT_EQ(plant_t.get_geometry_pose_output_port().get_index(),
             plant_u.get_geometry_pose_output_port().get_index());
   EXPECT_EQ(
+      plant_t.get_deformable_body_configuration_output_port().get_index(),
+      plant_u.get_deformable_body_configuration_output_port().get_index());
+  EXPECT_EQ(
       plant_t.get_state_output_port(default_model_instance()).get_index(),
       plant_u.get_state_output_port(default_model_instance()).get_index());
   EXPECT_EQ(
@@ -205,13 +208,12 @@ class DoubleOnlyDiscreteUpdateManager final
 // scalar types.
 GTEST_TEST(ScalarConversionTest, ExternalComponent) {
   MultibodyPlant<double> plant(0.1);
-  std::unique_ptr<PhysicalModel<double>> dummy_physical_model =
+  std::unique_ptr<internal::DummyPhysicalModel<double>> dummy_physical_model =
       std::make_unique<internal::DummyPhysicalModel<double>>(&plant);
-  // The dummy model supports all scalar types.
   EXPECT_TRUE(dummy_physical_model->is_cloneable_to_double());
   EXPECT_TRUE(dummy_physical_model->is_cloneable_to_autodiff());
   EXPECT_TRUE(dummy_physical_model->is_cloneable_to_symbolic());
-  plant.AddPhysicalModel(std::move(dummy_physical_model));
+  plant.AddDummyModel(std::move(dummy_physical_model));
   plant.Finalize();
 
   // double -> AutoDiffXd

--- a/multibody/plant/test/physical_model_test.cc
+++ b/multibody/plant/test/physical_model_test.cc
@@ -21,11 +21,10 @@ class PhysicalModelTest : public ::testing::Test {
     // TODO(xuchenhan-tri): Add a test with more than one physical model.
     auto dummy_model = std::make_unique<DummyPhysicalModel<double>>(&plant_);
     dummy_model_ = dummy_model.get();
-    plant_.AddPhysicalModel(std::move(dummy_model));
+    plant_.AddDummyModel(std::move(dummy_model));
     // An artificial scenario where the state is added in multiple passes.
     dummy_model_->AppendDiscreteState(dummy_state1());
     dummy_model_->AppendDiscreteState(dummy_state2());
-    plant_.Finalize();
   }
 
   static VectorXd dummy_state1() {
@@ -43,6 +42,7 @@ class PhysicalModelTest : public ::testing::Test {
 
 // Tests that the state and output ports are properly set up.
 TEST_F(PhysicalModelTest, DiscreteStateAndOutputPorts) {
+  plant_.Finalize();
   auto context = plant_.CreateDefaultContext();
   const VectorXd additional_state =
       dummy_model_->get_vector_output_port().Eval(*context);
@@ -58,13 +58,42 @@ TEST_F(PhysicalModelTest, DiscreteStateAndOutputPorts) {
   EXPECT_TRUE(CompareMatrices(additional_state, state_through_abstract_port));
 }
 
+TEST_F(PhysicalModelTest, DeclareSceneGraphPorts) {
+  DRAKE_EXPECT_THROWS_MESSAGE(dummy_model_->GetSceneGraphPortOrThrow(),
+                              ".*SceneGraph.*port.*not.*declared.*");
+  dummy_model_->DeclareSceneGraphPorts();
+  plant_.Finalize();
+  const systems::OutputPort<double>* scene_graph_port{nullptr};
+  EXPECT_NO_THROW(scene_graph_port = &dummy_model_->GetSceneGraphPortOrThrow());
+  auto context = plant_.CreateDefaultContext();
+  const VectorXd& output_vector = scene_graph_port->Eval(*context);
+  EXPECT_EQ(output_vector, VectorXd::Constant(1, 42.0));
+}
+
 // Tests that adding new state after Finalize is not allowed.
 TEST_F(PhysicalModelTest, PostFinalizeStateAdditionNotAllowed) {
+  plant_.Finalize();
   DRAKE_EXPECT_THROWS_MESSAGE(
       dummy_model_->AppendDiscreteState(dummy_state1()),
       "Calls to.*AppendDiscreteState.*after system resources have been "
       "declared are not allowed.");
 }
+
+TEST_F(PhysicalModelTest, PostFinalizePortDeclarationNotAllowed) {
+  plant_.Finalize();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dummy_model_->DeclareSceneGraphPorts(),
+      ".*DeclareSceneGraphPorts.* after system resources have been declared.*");
+}
+
+GTEST_TEST(PhysicalModelPortTest, DeformableModelDeclareSceneGraphPorts) {
+  /* The constructor of MultibodyPlant constructs the deformable model and
+   declares its scene graph ports. */
+  MultibodyPlant<double> plant(0.01);
+  const DeformableModel<double>& deformable_model = plant.deformable_model();
+  EXPECT_TRUE(deformable_model.configuration_output_port_index().is_valid());
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace internal


### PR DESCRIPTION
In addition, AddMultibodyPlantSceneGraph connects the deformable related SceneGraph ports automatically.

Closes #21355 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21357)
<!-- Reviewable:end -->
