### PR TITLE
[geometry] Port MeshcatAnimation to string_view

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -461,19 +461,18 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("path"), py::arg("X_ParentPath"), cls_doc.SetTransform.doc)
         .def("SetProperty",
             // Note: overload_cast and overload_cast_explicit did not work here.
-            static_cast<void (Class::*)(int, const std::string&,
-                const std::string&, bool)>(&Class::SetProperty),
+            static_cast<void (Class::*)(int, std::string_view, std::string_view,
+                bool)>(&Class::SetProperty),
             py::arg("frame"), py::arg("path"), py::arg("property"),
             py::arg("value"), cls_doc.SetProperty.doc_bool)
         .def("SetProperty",
-            static_cast<void (Class::*)(int, const std::string&,
-                const std::string&, double)>(&Class::SetProperty),
+            static_cast<void (Class::*)(int, std::string_view, std::string_view,
+                double)>(&Class::SetProperty),
             py::arg("frame"), py::arg("path"), py::arg("property"),
             py::arg("value"), cls_doc.SetProperty.doc_double)
         .def("SetProperty",
-            static_cast<void (Class::*)(int, const std::string&,
-                const std::string&, const std::vector<double>&)>(
-                &Class::SetProperty),
+            static_cast<void (Class::*)(int, std::string_view, std::string_view,
+                const std::vector<double>&)>(&Class::SetProperty),
             py::arg("frame"), py::arg("path"), py::arg("property"),
             py::arg("value"), cls_doc.SetProperty.doc_vector_double);
     // Note: We don't bind get_key_frame and get_javascript_type (at least

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -482,6 +482,7 @@ drake_cc_library(
     srcs = ["meshcat_animation.cc"],
     hdrs = ["meshcat_animation.h"],
     deps = [
+        "//common:string_container",
         "//math:geometric_transform",
     ],
 )

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -2553,7 +2553,7 @@ void Meshcat::SetTransform(std::string_view path,
   if (recording_ && time_in_recording.has_value()) {
     const double time = *time_in_recording;
     const int frame = animation_->frame(time);
-    animation_->SetTransform(frame, std::string(path), X_ParentPath);
+    animation_->SetTransform(frame, path, X_ParentPath);
   }
   if (!recording_ || !time_in_recording.has_value() ||
       set_visualizations_while_recording_) {
@@ -2583,7 +2583,7 @@ void Meshcat::SetProperty(std::string_view path, std::string property,
   if (recording_ && time_in_recording.has_value()) {
     const double time = *time_in_recording;
     const int frame = animation_->frame(time);
-    animation_->SetProperty(frame, std::string(path), property, value);
+    animation_->SetProperty(frame, path, property, value);
   }
   if (!recording_ || !time_in_recording.has_value() ||
       set_visualizations_while_recording_) {
@@ -2597,7 +2597,7 @@ void Meshcat::SetProperty(std::string_view path, std::string property,
   if (recording_ && time_in_recording.has_value()) {
     const double time = *time_in_recording;
     const int frame = animation_->frame(time);
-    animation_->SetProperty(frame, std::string(path), property, value);
+    animation_->SetProperty(frame, path, property, value);
   }
   // TODO(jwnimmer-tri) Why isn't time_in_recording part of this guard?
   // That's inconsistent with everywhere else and seems like a bug.
@@ -2612,7 +2612,7 @@ void Meshcat::SetProperty(std::string_view path, std::string property,
   if (recording_ && time_in_recording.has_value()) {
     const double time = *time_in_recording;
     const int frame = animation_->frame(time);
-    animation_->SetProperty(frame, std::string(path), property, value);
+    animation_->SetProperty(frame, path, property, value);
   }
   // TODO(jwnimmer-tri) Why isn't time_in_recording part of this guard?
   // That's inconsistent with everywhere else and seems like a bug.

--- a/geometry/meshcat_animation.cc
+++ b/geometry/meshcat_animation.cc
@@ -8,7 +8,7 @@ MeshcatAnimation::MeshcatAnimation(double frames_per_second)
 
 MeshcatAnimation::~MeshcatAnimation() = default;
 
-void MeshcatAnimation::SetTransform(int frame, const std::string& path,
+void MeshcatAnimation::SetTransform(int frame, std::string_view path,
                                     const math::RigidTransformd& X_ParentPath) {
   std::vector<double> position(3);
   Eigen::Vector3d::Map(&position[0]) = X_ParentPath.translation();
@@ -18,46 +18,89 @@ void MeshcatAnimation::SetTransform(int frame, const std::string& path,
   SetProperty(frame, path, "quaternion", "quaternion", quaternion);
 }
 
-void MeshcatAnimation::SetProperty(int frame, const std::string& path,
-                                   const std::string& property, bool value) {
+void MeshcatAnimation::SetProperty(int frame, std::string_view path,
+                                   std::string_view property, bool value) {
   SetProperty(frame, path, property, "boolean", value);
 }
 
-void MeshcatAnimation::SetProperty(int frame, const std::string& path,
-                                   const std::string& property, double value) {
+void MeshcatAnimation::SetProperty(int frame, std::string_view path,
+                                   std::string_view property, double value) {
   SetProperty(frame, path, property, "number", value);
 }
 
-void MeshcatAnimation::SetProperty(int frame, const std::string& path,
-                                   const std::string& property,
+void MeshcatAnimation::SetProperty(int frame, std::string_view path,
+                                   std::string_view property,
                                    const std::vector<double>& value) {
   SetProperty(frame, path, property, "vector", value);
 }
 
-std::string MeshcatAnimation::get_javascript_type(
-    const std::string& path, const std::string& property) const {
-  if (path_tracks_.find(path) == path_tracks_.end() ||
-      path_tracks_.at(path).find(property) == path_tracks_.at(path).end()) {
-    return "";
+const MeshcatAnimation::TypedTrack* MeshcatAnimation::GetTypedTrack(
+    std::string_view path, std::string_view property) const {
+  const auto path_iter = path_tracks_.find(path);
+  if (path_iter == path_tracks_.end()) {
+    return nullptr;
   }
-  return path_tracks_.at(path).at(property).js_type;
+  const PropertyTracks& property_tracks = path_iter->second;
+  const auto prop_iter = property_tracks.find(property);
+  if (prop_iter == property_tracks.end()) {
+    return nullptr;
+  }
+  return &prop_iter->second;
+}
+
+MeshcatAnimation::TypedTrack& MeshcatAnimation::GetOrCreateTypedTrack(
+    std::string_view path, std::string_view property) {
+  PropertyTracks& property_tracks =
+      path_tracks_.emplace(path, PropertyTracks{}).first->second;
+  TypedTrack& typed_track =
+      property_tracks.emplace(property, TypedTrack{}).first->second;
+  return typed_track;
 }
 
 template <typename T>
-void MeshcatAnimation::SetProperty(int frame, const std::string& path,
-                                   const std::string& property,
-                                   const std::string& js_type, const T& value) {
-  TypedTrack& tt = path_tracks_[path][property];
-  if (std::holds_alternative<std::monostate>(tt.track)) {
-    tt.track = Track<T>();
-    tt.js_type = js_type;
-  } else if (tt.js_type != js_type) {
+std::optional<T> MeshcatAnimation::get_key_frame(
+    int frame, std::string_view path, std::string_view property) const {
+  const TypedTrack* const typed_track = GetTypedTrack(path, property);
+  if (typed_track != nullptr) {
+    const auto* const track = std::get_if<Track<T>>(&typed_track->track);
+    if (track != nullptr) {
+      const auto frame_iter = track->find(frame);
+      if (frame_iter != track->end()) {
+        return frame_iter->second;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+template std::optional<bool> MeshcatAnimation::get_key_frame(
+    int, std::string_view, std::string_view) const;
+template std::optional<double> MeshcatAnimation::get_key_frame(
+    int, std::string_view, std::string_view) const;
+template std::optional<std::vector<double>> MeshcatAnimation::get_key_frame(
+    int, std::string_view, std::string_view) const;
+
+std::string MeshcatAnimation::get_javascript_type(
+    std::string_view path, std::string_view property) const {
+  const TypedTrack* const typed_track = GetTypedTrack(path, property);
+  return (typed_track == nullptr) ? std::string{} : typed_track->js_type;
+}
+
+template <typename T>
+void MeshcatAnimation::SetProperty(int frame, std::string_view path,
+                                   std::string_view property,
+                                   std::string_view js_type, const T& value) {
+  TypedTrack& typed_track = GetOrCreateTypedTrack(path, property);
+  if (std::holds_alternative<std::monostate>(typed_track.track)) {
+    typed_track.track = Track<T>();
+    typed_track.js_type = js_type;
+  } else if (typed_track.js_type != js_type) {
     throw std::runtime_error(fmt::format(
         "{} property {} already has a track with javascript type {} != {}",
-        path, property, tt.js_type, js_type));
+        path, property, typed_track.js_type, js_type));
   }
   // get<T> will also throw bad_variant_access if the types don't match.
-  std::get<Track<T>>(tt.track)[frame] = value;
+  std::get<Track<T>>(typed_track.track)[frame] = value;
 }
 
 }  // namespace geometry

--- a/geometry/meshcat_animation.h
+++ b/geometry/meshcat_animation.h
@@ -3,9 +3,11 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
+#include "drake/common/string_map.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
@@ -114,7 +116,7 @@ class MeshcatAnimation {
                          path have already been set to an incorrect type.
 
   */
-  void SetTransform(int frame, const std::string& path,
+  void SetTransform(int frame, std::string_view path,
                     const math::RigidTransformd& X_ParentPath);
 
   /** Sets a single named property of the object at the given `path` at the
@@ -130,8 +132,8 @@ class MeshcatAnimation {
 
   @pydrake_mkdoc_identifier{bool}
   */
-  void SetProperty(int frame, const std::string& path,
-                   const std::string& property, bool value);
+  void SetProperty(int frame, std::string_view path, std::string_view property,
+                   bool value);
 
   /** Sets a single named property of the object at the given `path` at the
   specified `frame` in the animation. @see Meshcat::SetProperty.
@@ -146,8 +148,8 @@ class MeshcatAnimation {
 
   @pydrake_mkdoc_identifier{double}
   */
-  void SetProperty(int frame, const std::string& path,
-                   const std::string& property, double value);
+  void SetProperty(int frame, std::string_view path, std::string_view property,
+                   double value);
 
   /** Sets a single named property of the object at the given `path` at the
   specified `frame` in the animation. @see Meshcat::SetProperty.
@@ -162,8 +164,7 @@ class MeshcatAnimation {
 
   @pydrake_mkdoc_identifier{vector_double}
   */
-  void SetProperty(int frame, const std::string& path,
-                   const std::string& property,
+  void SetProperty(int frame, std::string_view path, std::string_view property,
                    const std::vector<double>& value);
 
   // TODO(russt): Consider ColorKeyframeTrack.js and/or StringKeyframeTrack.js
@@ -179,39 +180,19 @@ class MeshcatAnimation {
 
   /** Returns the value information for a particular path/property at a
   particular frame if a value of type T has been set, otherwise returns
-  std::nullopt. This method is intended primarily for testing. */
+  std::nullopt. This method is intended primarily for testing.
+  @tparam T One of `bool`, `double`, or `vector<double>` */
   template <typename T>
-  std::optional<T> get_key_frame(int frame, const std::string& path,
-                                 const std::string& property) const {
-    if (path_tracks_.find(path) == path_tracks_.end() ||
-        path_tracks_.at(path).find(property) == path_tracks_.at(path).end()) {
-      return std::nullopt;
-    }
-    const TypedTrack& tt = path_tracks_.at(path).at(property);
-    if (!std::holds_alternative<Track<T>>(tt.track)) {
-      return std::nullopt;
-    }
-    const Track<T>& t = std::get<Track<T>>(tt.track);
-    if (t.find(frame) == t.end()) {
-      return std::nullopt;
-    }
-    return t.at(frame);
-  }
+  std::optional<T> get_key_frame(int frame, std::string_view path,
+                                 std::string_view property) const;
 
   /** Returns the javascript type for a particular path/property, or the empty
   string if nothing has been set. This method is intended primarily for
   testing. */
-  std::string get_javascript_type(const std::string& path,
-                                  const std::string& property) const;
+  std::string get_javascript_type(std::string_view path,
+                                  std::string_view property) const;
 
  private:
-  // Implements the SetProperty methods.
-  // js_type must match three.js getTrackTypeForValueTypeName implementation.
-  template <typename T>
-  void SetProperty(int frame, const std::string& path,
-                   const std::string& property, const std::string& js_type,
-                   const T& value);
-
   // A map of frame => value.
   template <typename T>
   using Track = std::map<int, T>;
@@ -225,13 +206,24 @@ class MeshcatAnimation {
   };
 
   // A map of property name => tracks.
-  using PropertyTracks = std::map<std::string, TypedTrack>;
+  using PropertyTracks = string_map<TypedTrack>;
 
   // A map of path => property tracks.
-  using PathTracks = std::map<std::string, PropertyTracks>;
+  using PathTracks = string_map<PropertyTracks>;
 
   // TODO(russt): Narrow this access to restore encapsulation.
   friend class Meshcat;
+
+  const TypedTrack* GetTypedTrack(std::string_view path,
+                                  std::string_view property) const;
+  TypedTrack& GetOrCreateTypedTrack(std::string_view path,
+                                    std::string_view property);
+
+  // Implements the SetProperty methods.
+  // js_type must match three.js getTrackTypeForValueTypeName implementation.
+  template <typename T>
+  void SetProperty(int frame, std::string_view path, std::string_view property,
+                   std::string_view js_type, const T& value);
 
   // A map of path name => property tracks.
   PathTracks path_tracks_{};


### PR DESCRIPTION
Towards #21279.  (The conversion calls in Meshcat using `std::string()` wrappers are already awkward in the current code, and that awkwardness will explode as we start to add animation support to even more functions in Meshcat.)

Also move a function body from h to cc as required by the styleguide.

+@sammy-tri for both reviews per schedule, please.

\CC @DamrongGuoy FYI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21358)
<!-- Reviewable:end -->
