### PR TITLE
[geometry] Meshcat has a default recording

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -438,7 +438,7 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.MeshcatAnimation;
     py::class_<Class> cls(m, "MeshcatAnimation", cls_doc.doc);
     cls  // BR
-        .def(py::init<double>(), py::arg("frames_per_second") = 32.0,
+        .def(py::init<double>(), py::arg("frames_per_second") = 64.0,
             cls_doc.ctor.doc)
         .def("frames_per_second", &Class::frames_per_second,
             cls_doc.frames_per_second.doc)

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -2386,7 +2386,8 @@ Meshcat::Meshcat(std::optional<int> port)
 
 Meshcat::Meshcat(const MeshcatParams& params)
     // Creates the server thread, bind to the port, etc.
-    : impl_{new Impl(params)} {
+    : impl_{new Impl(params)},
+      animation_{std::make_unique<MeshcatAnimation>(64.0)} {
   drake::log()->info("Meshcat listening for connections at {}", web_url());
 }
 
@@ -2711,24 +2712,21 @@ void Meshcat::StartRecording(double frames_per_second,
   set_visualizations_while_recording_ = set_visualizations_while_recording;
 }
 
+void Meshcat::StopRecording() {
+  recording_ = false;
+}
+
 void Meshcat::PublishRecording() {
   impl().SetAnimation(*animation_);
 }
 
 void Meshcat::DeleteRecording() {
-  if (animation_) {
-    // Reset the recording.
-    double frames_per_second = animation_->frames_per_second();
-    animation_ = std::make_unique<MeshcatAnimation>(frames_per_second);
-  }
+  // Reset the recording.
+  const double frames_per_second = animation_->frames_per_second();
+  animation_ = std::make_unique<MeshcatAnimation>(frames_per_second);
 }
 
 MeshcatAnimation& Meshcat::get_mutable_recording() {
-  if (!animation_) {
-    throw std::runtime_error(
-        "You must create a recording (via StartRecording) before calling "
-        "get_mutable_recording");
-  }
   return *animation_;
 }
 

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -838,7 +838,7 @@ class Meshcat {
 
   /** Sets a flag to pause/stop recording.  When stopped, publish events will
   not add frames to the animation. */
-  void StopRecording() { recording_ = false; }
+  void StopRecording();
 
   /** Sends the recording to Meshcat as an animation. The published animation
   only includes transforms and properties; the objects that they modify must be
@@ -852,15 +852,12 @@ class Meshcat {
   void DeleteRecording();
 
   /** Returns a mutable pointer to this Meshcat's unique MeshcatAnimation
-  object, if it exists, in which the frames will be recorded. This pointer can
-  be used to set animation properties (like autoplay, the loop mode, number of
-  repetitions, etc).
+  object, in which the frames will be recorded. This pointer can be used to set
+  animation properties (like autoplay, the loop mode, number of repetitions,
+  etc).
 
   The MeshcatAnimation object will only remain valid for the lifetime of `this`
-  or until DeleteRecording() is called.
-
-  @throws std::exception if meshcat does not have a recording.
-  */
+  or until DeleteRecording() is called. */
   MeshcatAnimation& get_mutable_recording();
 
   /* These remaining public methods are intended to primarily for testing. These

--- a/geometry/meshcat_animation.h
+++ b/geometry/meshcat_animation.h
@@ -32,7 +32,7 @@ class MeshcatAnimation {
   /** Constructs the animation object.
   @param frames_per_second a positive integer specifying the timing at which the
   frames are played back. */
-  explicit MeshcatAnimation(double frames_per_second = 32.0);
+  explicit MeshcatAnimation(double frames_per_second = 64.0);
 
   ~MeshcatAnimation();
 

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -964,7 +964,7 @@ GTEST_TEST(MeshcatTest, SetAnimation) {
       "animations": [{
           "path": "/drake/cylinder",
           "clip": {
-              "fps": 32.0,
+              "fps": 64.0,
               "name": "default",
               "tracks": [{
                   "name": ".visible",
@@ -984,7 +984,7 @@ GTEST_TEST(MeshcatTest, SetAnimation) {
       }, {
           "path": "/drake/ellipsoid/<object>",
           "clip": {
-              "fps": 32.0,
+              "fps": 64.0,
               "name": "default",
               "tracks": [{
                   "name": ".material.opacity",
@@ -1004,7 +1004,7 @@ GTEST_TEST(MeshcatTest, SetAnimation) {
       }, {
           "path": "/drake/sphere",
           "clip": {
-              "fps": 32.0,
+              "fps": 64.0,
               "name": "default",
               "tracks": [{
                   "name": ".position",
@@ -1049,10 +1049,23 @@ bool has_frame(const MeshcatAnimation& animation, int frame) {
       .has_value();
 }
 
+// The hard-coded default values for Meshcat's default recording and a newly-
+// started recording should match the MeshcatAnimation constructor's default.
+GTEST_TEST(MeshcatTest, RecordingDefaults) {
+  const double default_fps = MeshcatAnimation().frames_per_second();
+
+  Meshcat meshcat;
+  EXPECT_EQ(meshcat.get_mutable_recording().frames_per_second(), default_fps);
+
+  meshcat.StartRecording();
+  EXPECT_EQ(meshcat.get_mutable_recording().frames_per_second(), default_fps);
+}
+
 GTEST_TEST(MeshcatTest, Recording) {
   Meshcat meshcat;
-  DRAKE_EXPECT_THROWS_MESSAGE(meshcat.get_mutable_recording(),
-                              ".*You must create a recording.*");
+  EXPECT_NO_THROW(meshcat.get_mutable_recording());
+  EXPECT_NO_THROW(meshcat.StopRecording());
+  EXPECT_NO_THROW(meshcat.PublishRecording());
 
   const RigidTransformd X_ParentPath{RollPitchYawd(0.5, 0.26, -3),
                                      Vector3d{0.9, -2.0, 0.12}};

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -251,8 +251,6 @@ bool has_iiwa_frame(const MeshcatAnimation& animation, int frame) {
 TEST_F(MeshcatVisualizerWithIiwaTest, Recording) {
   MeshcatVisualizerParams params;
   SetUpDiagram(params);
-  DRAKE_EXPECT_THROWS_MESSAGE(visualizer_->get_mutable_recording(),
-                              ".*You must create a recording.*");
 
   // Publish once without recording and confirm that we don't have the iiwa
   // frame.


### PR DESCRIPTION
Having an occasionally-null recording is a segfault beacon. Either we need to add more nullptr checks and nice error messages, or just do the obvious thing and have a non-null default.

Closes #21352, and has some chance of making #21279 simpler.
 
+@DamrongGuoy for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21360)
<!-- Reviewable:end -->
