### PR TITLE
Deprecate --version in repack_deb.py

### DIFF
--- a/tools/release_engineering/debian/changelog.in
+++ b/tools/release_engineering/debian/changelog.in
@@ -1,4 +1,4 @@
-drake ({debian_version}-1) experimental; urgency=low
+drake ({drake_version}-1) experimental; urgency=low
 
   * New upstream version, built from git sha {git_sha}
 

--- a/tools/release_engineering/repack_deb.py
+++ b/tools/release_engineering/repack_deb.py
@@ -61,11 +61,7 @@ def _run(args):
 
     version_tokens = version_txt.split()
     assert len(version_tokens) == 2, version_txt
-    yyyymmddhhmmss, git_sha = version_tokens
-    if args.version is not None:
-        debian_version = args.version
-    else:
-        debian_version = f'0.0.{yyyymmddhhmmss}'
+    drake_version, git_sha = version_tokens
 
     # Compute the new control.  The `packages_txt` will have one package-name
     # per line; transform this to an indented and comma separated list.
@@ -78,7 +74,7 @@ def _run(args):
     # Compute the new changelog.
     with open(deb_changelog_in, encoding='utf-8') as f:
         deb_changelog_contents = f.read().format(
-            debian_version=debian_version,
+            drake_version=drake_version,
             git_sha=git_sha,
             date=email.utils.formatdate(version_mtime),
         )
@@ -91,7 +87,7 @@ def _run(args):
         '/usr/bin/alien',
         '--to-deb',
         '--single',
-        f'--version={debian_version}',
+        f'--version={drake_version}',
         '--keep-version',
         # NOTE: the extracted permissions particularly for directories are not
         # appropriate, --fixperms results in debian/rules having `dh_fixperms`
@@ -137,7 +133,7 @@ def _run(args):
     # Create the deb.
     subprocess.check_call(['fakeroot', 'debian/rules', 'binary'],
                           cwd=package_dir)
-    shutil.move(f'{cwd}/drake-dev_{debian_version}-1_amd64.deb',
+    shutil.move(f'{cwd}/drake-dev_{drake_version}-1_amd64.deb',
                 f'{args.output_dir}/')
 
 
@@ -154,12 +150,10 @@ def main():
     parser.add_argument(
         '--output-dir', metavar='DIR', default=output_default,
         help=f'directory to place *.deb output (default: {output_default})')
+    # TODO(mwoehlke-kitware) remove this once CI no longer uses it.
     parser.add_argument(
         '--version', type=str, required=False, default=None,
-        help=(
-            'version number to package (e.g., "1.3.0"); if not specified the '
-            'date timestamp YYYYMMDD found in the foo.tar.gz file '
-            'drake/share/doc/drake/VERSION.TXT will be used'))
+        help='ignored; for compatibility only')
     args = parser.parse_args()
     args.tgz = os.path.realpath(args.tgz)
     args.output_dir = os.path.realpath(args.output_dir)


### PR DESCRIPTION
After recent changes, `VERSION.TXT` should always contain a meaningful and correct version number. Accordingly, we a) should stop assuming it is an unprefixed timestamp, and b) no longer need the ability to override `VERSION.TXT`, which allows for some modest simplification.

For now, the option is retained but ignored, because we will first need to change CI to stop passing it, after which it can be removed entirely.

Toward #18145.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21364)
<!-- Reviewable:end -->
