### PR TITLE
[math] Implement AngleAxis -> RotationMatrix from scratch

### DIFF
--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -102,13 +102,45 @@ class RotationMatrix {
   /// R that is built from `theta_lambda` fails IsValid(R).  For example, an
   /// exception is thrown if `lambda` is zero or contains a NaN or infinity.
   explicit RotationMatrix(const Eigen::AngleAxis<T>& theta_lambda) {
-    // TODO(mitiguy) Consider adding an optional second argument if `lambda` is
-    // known to be normalized apriori or calling site does not want
-    // normalization.
-    const Vector3<T>& lambda = theta_lambda.axis();
-    const T norm = lambda.norm();
+    using std::cos;
+    using std::sin;
+    // TODO(mitiguy) Consider adding an optional second argument if lambda is
+    // known to be normalized apriori or the caller does not want normalization.
     const T& theta = theta_lambda.angle();
-    set(Eigen::AngleAxis<T>(theta, lambda / norm).toRotationMatrix());
+    const Vector3<T>& lambda = theta_lambda.axis();
+    // We won't use AngleAxis<T>::toRotationMatrix because somtimes it is
+    // miscompiled by Clang 15. Instead, we'll follow the derivation here:
+    // https://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToMatrix/index.htm
+    const T norm = lambda.norm();
+    const T x = lambda.x() / norm;
+    const T y = lambda.y() / norm;
+    const T z = lambda.z() / norm;
+    const T s = sin(theta);
+    const T c = cos(theta);
+    const T t = 1 - c;
+    const T sx = s * x;
+    const T sy = s * y;
+    const T sz = s * z;
+    const T tx = t * x;
+    const T ty = t * y;
+    const T tz = t * z;
+    const T txx = tx * x;
+    const T tyy = ty * y;
+    const T tzz = tz * z;
+    const T txy = tx * y;
+    const T txz = tx * z;
+    const T tyz = ty * z;
+    Matrix3<T> R;
+    R.coeffRef(0, 0) = txx + c;
+    R.coeffRef(1, 1) = tyy + c;
+    R.coeffRef(2, 2) = tzz + c;
+    R.coeffRef(0, 1) = txy - sz;
+    R.coeffRef(1, 0) = txy + sz;
+    R.coeffRef(0, 2) = txz + sy;
+    R.coeffRef(2, 0) = txz - sy;
+    R.coeffRef(1, 2) = tyz - sx;
+    R.coeffRef(2, 1) = tyz + sx;
+    set(R);
   }
 
   /// Constructs a %RotationMatrix from an %RollPitchYaw.  In other words,


### PR DESCRIPTION
The implementation inside Eigen uses expression templates for some elementwise operations, which ends up tickling a bug in Clang 15's codegen back-end which leaves R(2, 0) as uninitialized memory.  (See [demo on godbolt](https://godbolt.org/).)

Writing the math using elementary flops keeps the codegen happy.

Note that the codegen bug only occurs in a Release build (`-O2`) with assertions enabled.  Drake's binary releases are not affected (assertions not enabled, and we don't use Clang for release binaries anyway).  Switching to `-O1` or `-O0` or leaving assertions disabled both will avoid the codegen bug.

Follow-up from #21339.
Closes #21363.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21365)
<!-- Reviewable:end -->
