### PR TITLE
Remove repack_deb --version

### DIFF
--- a/tools/release_engineering/repack_deb.py
+++ b/tools/release_engineering/repack_deb.py
@@ -150,10 +150,6 @@ def main():
     parser.add_argument(
         '--output-dir', metavar='DIR', default=output_default,
         help=f'directory to place *.deb output (default: {output_default})')
-    # TODO(mwoehlke-kitware) remove this once CI no longer uses it.
-    parser.add_argument(
-        '--version', type=str, required=False, default=None,
-        help='ignored; for compatibility only')
     args = parser.parse_args()
     args.tgz = os.path.realpath(args.tgz)
     args.output_dir = os.path.realpath(args.output_dir)


### PR DESCRIPTION
Remove --version argument from repack_deb. It was previously deprecated in #21364, and CI was subsequently modified (RobotLocomotion/drake-ci#284) to stop passing it, therefore it is now dead code and can be safely dropped.

Relates to #18145, and since this is the last known bit of clean-up from the changes for that, closes  #18145.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21378)
<!-- Reviewable:end -->
