### PR TITLE
[workspace] Upgrade boost_internal from boost-1.84.0 to boost-1.85.0

### DIFF
--- a/tools/workspace/boost_internal/repository.bzl
+++ b/tools/workspace/boost_internal/repository.bzl
@@ -6,15 +6,15 @@ def boost_internal_repository(
     github_release_attachments(
         name = name,
         repository = "boostorg/boost",
-        commit = "boost-1.84.0",
+        commit = "boost-1.85.0",
         attachments = {
-            "boost-1.84.0.tar.xz": "2e64e5d79a738d0fa6fb546c6e5c2bd28f88d268a2a080546f74e5ff98f29d0e",  # noqa
+            "boost-1.85.0-cmake.tar.xz": "0a9cc56ceae46986f5f4d43fe0311d90cf6d2fa9028258a95cab49ffdacf92ad",  # noqa
         },
         extract = [
-            "boost-1.84.0.tar.xz",
+            "boost-1.85.0-cmake.tar.xz",
         ],
         strip_prefix = {
-            "boost-1.84.0.tar.xz": "boost-1.84.0",
+            "boost-1.85.0-cmake.tar.xz": "boost-1.85.0",
         },
         build_file = "@com_github_nelhage_rules_boost_internal//:boost.BUILD",
         mirrors = mirrors,


### PR DESCRIPTION
Towards #21372 

The semi-automated upgrade script failed as described in #21388, so these updates were made by hand.

Note that the archive names now have a `-cmake` suffix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21389)
<!-- Reviewable:end -->
