### PR TITLE
Add MathematicalProgram::RemoveDecisionVariable.

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1581,6 +1581,9 @@ for every column of ``prog_var_vals``. )""")
           doc.MathematicalProgram.SetVariableScaling.doc)
       .def("ClearVariableScaling", &MathematicalProgram::ClearVariableScaling,
           doc.MathematicalProgram.ClearVariableScaling.doc)
+      .def("RemoveDecisionVariable",
+          &MathematicalProgram::RemoveDecisionVariable, py::arg("var"),
+          doc.MathematicalProgram.RemoveDecisionVariable.doc)
       .def("RemoveCost", &MathematicalProgram::RemoveCost, py::arg("cost"),
           doc.MathematicalProgram.RemoveCost.doc)
       .def("RemoveConstraint", &MathematicalProgram::RemoveConstraint,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1363,6 +1363,14 @@ class TestMathematicalProgram(unittest.TestCase):
         scaling = prog.GetVariableScaling()
         self.assertEqual(len(scaling), 0)
 
+    def test_remove_decision_variable(self):
+        prog = mp.MathematicalProgram()
+        x = prog.NewContinuousVariables(3)
+        x1_index = prog.FindDecisionVariableIndex(x[1])
+        x1_index_removed = prog.RemoveDecisionVariable(x[1])
+        self.assertEqual(x1_index, x1_index_removed)
+        self.assertEqual(prog.num_vars(), 2)
+
     def test_remove_cost(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(3)

--- a/common/test_utilities/symbolic_test_util.h
+++ b/common/test_utilities/symbolic_test_util.h
@@ -22,6 +22,7 @@
 /// ASSERT_PRED2(ExprEqual, e1, e2);
 /// @endcode
 #include <algorithm>
+#include <tuple>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -37,6 +38,11 @@ namespace test {
 
 [[nodiscard]] inline bool VarEqual(const Variable& v1, const Variable& v2) {
   return v1.equal_to(v2);
+}
+
+[[nodiscard]] inline bool TupleVarEqual(
+    const std::tuple<Variable, Variable>& vars) {
+  return VarEqual(std::get<0>(vars), std::get<1>(vars));
 }
 
 [[nodiscard]] inline bool VarNotEqual(const Variable& v1,

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -372,7 +372,6 @@ drake_cc_library(
         ":solver_options",
         "//common:autodiff",
         "//common:essential",
-        "//common:nice_type_name",
         "//common:polynomial",
         "//common/symbolic:expression",
         "//common/symbolic:monomial_util",

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -372,6 +372,7 @@ drake_cc_library(
         ":solver_options",
         "//common:autodiff",
         "//common:essential",
+        "//common:nice_type_name",
         "//common:polynomial",
         "//common/symbolic:expression",
         "//common/symbolic:monomial_util",

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -18,12 +18,10 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_eigen.h"
-#include "drake/common/nice_type_name.h"
 #include "drake/common/ssize.h"
 #include "drake/common/symbolic/decompose.h"
 #include "drake/common/symbolic/latex.h"
 #include "drake/common/symbolic/monomial_util.h"
-#include "drake/common/text_logging.h"
 #include "drake/math/matrix_util.h"
 #include "drake/solvers/binding.h"
 #include "drake/solvers/decision_variable.h"
@@ -1863,56 +1861,13 @@ template <typename C>
 [[nodiscard]] bool IsVariableBound(const symbolic::Variable& var,
                                    const MathematicalProgram& prog,
                                    std::string* binding_description) {
-  if (IsVariableBound(var, prog.generic_costs(), binding_description)) {
+  if (IsVariableBound(var, prog.GetAllCosts(), binding_description)) {
     return true;
   }
-  if (IsVariableBound(var, prog.quadratic_costs(), binding_description)) {
+  if (IsVariableBound(var, prog.GetAllConstraints(), binding_description)) {
     return true;
   }
-  if (IsVariableBound(var, prog.linear_costs(), binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.l2norm_costs(), binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.generic_constraints(), binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.linear_constraints(), binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.linear_equality_constraints(),
-                      binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.bounding_box_constraints(),
-                      binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.quadratic_constraints(), binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.lorentz_cone_constraints(),
-                      binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.rotated_lorentz_cone_constraints(),
-                      binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.positive_semidefinite_constraints(),
-                      binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.linear_matrix_inequality_constraints(),
-                      binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.exponential_cone_constraints(),
-                      binding_description)) {
-    return true;
-  }
-  if (IsVariableBound(var, prog.linear_complementarity_constraints(),
+  if (IsVariableBound(var, prog.visualization_callbacks(),
                       binding_description)) {
     return true;
   }
@@ -1940,7 +1895,7 @@ int MathematicalProgram::RemoveDecisionVariable(const symbolic::Variable& var) {
   for (auto& [variable_id, variable_index] : decision_variable_index_) {
     // Decrement the index of the variable after `var`.
     if (variable_index > var_index) {
-      variable_index--;
+      --variable_index;
     }
   }
   // Remove the variable from decision_variables_.

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -3619,6 +3619,17 @@ class MathematicalProgram {
   //@}
 
   /**
+   * Remove `var` from this program's decision variable.
+   * @note after removing the variable, the indices of some remaining variables
+   * inside this MathematicalProgram will change.
+   * @return the index of `var` in this optimization program. return -1 if `var`
+   * is not a decision variable.
+   * @throw exception if `var` is bound with any cost or constraint.
+   * @throw exception if `var` is not a decision variable of the program.
+   */
+  int RemoveDecisionVariable(const symbolic::Variable& var);
+
+  /**
    * @anchor remove_cost_constraint
    * @name    Remove costs or constraints
    * Removes costs or constraints from this program. If this program contains

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -4425,13 +4425,22 @@ GTEST_TEST(TestMathematicalProgram, RemoveDecisionVariableError) {
   // Remove a variable associated with a cost.
   prog.AddLinearCost(x(0));
   DRAKE_EXPECT_THROWS_MESSAGE(prog.RemoveDecisionVariable(x(0)),
-                              ".* is associated with a LinearCost..*");
+                              ".* is associated with a LinearCost.*");
 
   // Remove a variable associated with a constraint.
   prog.AddLinearConstraint(x(0) + x(1) <= 1);
+  DRAKE_EXPECT_THROWS_MESSAGE(prog.RemoveDecisionVariable(x(1)),
+                              ".* is associated with a LinearConstraint[^]*");
+
+  // Remove a variable associated with a visualization callback.
+  prog.AddVisualizationCallback(
+      [](const Eigen::VectorXd& vars) {
+        drake::log()->info("{}", vars(0));
+      },
+      Vector1<symbolic::Variable>(x(2)));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      prog.RemoveDecisionVariable(x(1)),
-      ".* is associated with a LinearConstraint\n.*\n.");
+      prog.RemoveDecisionVariable(x(2)),
+      ".* is associated with a VisualizationCallback[^]*");
 }
 
 GTEST_TEST(TestMathematicalProgram, TestToLatex) {

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -4378,6 +4378,62 @@ GTEST_TEST(TestMathematicalProgram, TestToString) {
   EXPECT_THAT(s, testing::HasSubstr("3"));
 }
 
+GTEST_TEST(TestMathematicalProgram, RemoveDecisionVariable) {
+  // A program where x(1) is not associated with any cost/constraint.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>();
+  prog.AddLinearCost(x(0) + x(2));
+  prog.AddBoundingBoxConstraint(0, 2, x(0));
+  prog.AddLinearConstraint(x(0) + 2 * x(2) <= 1);
+  prog.SetInitialGuess(x, Eigen::Vector3d(0, 1, 2));
+  prog.SetVariableScaling(x(1), 3);
+  prog.SetVariableScaling(x(0), 0.5);
+  prog.SetVariableScaling(x(2), 4);
+
+  const int x1_index = prog.FindDecisionVariableIndex(x(1));
+  const int x1_index_removed = prog.RemoveDecisionVariable(x(1));
+  EXPECT_EQ(x1_index, x1_index_removed);
+  EXPECT_EQ(prog.num_vars(), 2);
+  EXPECT_EQ(prog.FindDecisionVariableIndex(x(0)), 0);
+  EXPECT_EQ(prog.FindDecisionVariableIndex(x(2)), 1);
+  EXPECT_EQ(prog.decision_variables().size(), 2);
+  EXPECT_EQ(prog.decision_variables()(0).get_id(), x(0).get_id());
+  EXPECT_EQ(prog.decision_variables()(1).get_id(), x(2).get_id());
+  EXPECT_TRUE(CompareMatrices(prog.initial_guess(), Eigen::Vector2d(0, 2)));
+  const auto& var_scaling = prog.GetVariableScaling();
+  EXPECT_EQ(var_scaling.size(), 2);
+  EXPECT_EQ(var_scaling.at(prog.FindDecisionVariableIndex(x(0))), 0.5);
+  EXPECT_EQ(var_scaling.at(prog.FindDecisionVariableIndex(x(2))), 4);
+}
+
+GTEST_TEST(TestMathematicalProgram, RemoveDecisionVariableError) {
+  // Test RemoveDecisionVariable with erroneous input.
+  // Remove an indeterminate.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>("x");
+  auto y = prog.NewIndeterminates<2>("y");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      prog.RemoveDecisionVariable(y(0)),
+      ".*is not a decision variable of this MathematicalProgram.");
+
+  // Remove a variable not in Mathematical program.
+  const symbolic::Variable dummy("dummy");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      prog.RemoveDecisionVariable(dummy),
+      ".*is not a decision variable of this MathematicalProgram.");
+
+  // Remove a variable associated with a cost.
+  prog.AddLinearCost(x(0));
+  DRAKE_EXPECT_THROWS_MESSAGE(prog.RemoveDecisionVariable(x(0)),
+                              ".* is associated with a LinearCost..*");
+
+  // Remove a variable associated with a constraint.
+  prog.AddLinearConstraint(x(0) + x(1) <= 1);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      prog.RemoveDecisionVariable(x(1)),
+      ".* is associated with a LinearConstraint\n.*\n.");
+}
+
 GTEST_TEST(TestMathematicalProgram, TestToLatex) {
   MathematicalProgram prog;
   std::string empty_prog = prog.ToLatex();


### PR DESCRIPTION
Remove a decision variable from the MathematicalProgram. The decision variable cannot be bound with any cost/constraint.

Towards #20842 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21392)
<!-- Reviewable:end -->
