### PR TITLE
[math] Add RigidTransform (etc) factory methods without checks

### DIFF
--- a/bindings/pydrake/math/math_py_monolith.cc
+++ b/bindings/pydrake/math/math_py_monolith.cc
@@ -75,6 +75,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.ctor.doc_1args_pose)
         .def(py::init<const MatrixX<T>&>(), py::arg("pose"),
             cls_doc.ctor.doc_1args_constEigenMatrixBase)
+        .def_static("MakeUnchecked", &Class::MakeUnchecked, py::arg("pose"),
+            cls_doc.MakeUnchecked.doc)
         .def("set", &Class::set, py::arg("R"), py::arg("p"), cls_doc.set.doc)
         .def("SetFromIsometry3", &Class::SetFromIsometry3, py::arg("pose"),
             cls_doc.SetFromIsometry3.doc)
@@ -146,7 +148,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.operator_mul.doc_1args_constEigenMatrixBase)
         .def(py::pickle([](const Class& self) { return self.GetAsMatrix34(); },
             [](const Eigen::Matrix<T, 3, 4>& matrix) {
-              return Class(matrix);
+              return Class::MakeUnchecked(matrix);
             }));
     cls.attr("multiply") = WrapToMatchInputShape(cls.attr("multiply"));
     cls.attr("__matmul__") = cls.attr("multiply");
@@ -174,6 +176,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.ctor.doc_1args_theta_lambda)
         .def(py::init<const RollPitchYaw<T>&>(), py::arg("rpy"),
             cls_doc.ctor.doc_1args_rpy)
+        .def_static("MakeUnchecked", &Class::MakeUnchecked, py::arg("R"),
+            cls_doc.MakeUnchecked.doc)
         .def_static("MakeXRotation", &Class::MakeXRotation, py::arg("theta"),
             cls_doc.MakeXRotation.doc)
         .def_static("MakeYRotation", &Class::MakeYRotation, py::arg("theta"),
@@ -228,7 +232,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.ToQuaternion.doc_0args)
         .def("ToAngleAxis", &Class::ToAngleAxis, cls_doc.ToAngleAxis.doc)
         .def(py::pickle([](const Class& self) { return self.matrix(); },
-            [](const Matrix3<T>& matrix) { return Class(matrix); }));
+            [](const Matrix3<T>& matrix) {
+              return Class::MakeUnchecked(matrix);
+            }));
     cls.attr("multiply") = WrapToMatchInputShape(cls.attr("multiply"));
     cls.attr("__matmul__") = cls.attr("multiply");
     DefCopyAndDeepCopy(&cls);

--- a/bindings/pydrake/math/test/math_test.py
+++ b/bindings/pydrake/math/test/math_test.py
@@ -141,6 +141,7 @@ class TestMath(unittest.TestCase):
         check_equality(RigidTransform(pose=p_I), X_I_np)
         check_equality(RigidTransform(pose=X_I_np), X_I_np)
         check_equality(RigidTransform(pose=X_I_np[:3]), X_I_np)
+        check_equality(RigidTransform.MakeUnchecked(pose=X_I_np[:3]), X_I_np)
         # - Cast.
         self.check_cast(mut.RigidTransform_, T)
         # - Accessors, mutators, and general methods.
@@ -227,6 +228,8 @@ class TestMath(unittest.TestCase):
             self.assertIsInstance(roundtrip, RigidTransform)
         # Test pickling.
         assert_pickle(self, X_AB, RigidTransform.GetAsMatrix4, T=T)
+        X_AB = RigidTransform.MakeUnchecked(np.full((3, 4), math.inf))
+        assert_pickle(self, X_AB, RigidTransform.GetAsMatrix4, T=T)
 
     def test_legacy_unpickle(self):
         """Checks that data pickled as RotationMatrix_[float] in Drake v1.12.0
@@ -261,6 +264,8 @@ class TestMath(unittest.TestCase):
         numpy_compare.assert_float_equal(
                 RotationMatrix.Identity().matrix(), np.eye(3))
         R = RotationMatrix(R=np.eye(3))
+        numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
+        R = RotationMatrix.MakeUnchecked(R=np.eye(3))
         numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
         R = RotationMatrix(quaternion=Quaternion.Identity())
         numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
@@ -363,6 +368,8 @@ class TestMath(unittest.TestCase):
             self.assertAlmostEqual(roundtrip.pitch_angle(), 1)
             self.assertAlmostEqual(roundtrip.yaw_angle(), 0)
         # Test pickling.
+        assert_pickle(self, R_AB, RotationMatrix.matrix, T=T)
+        R_AB = RotationMatrix.MakeUnchecked(np.full((3, 3), math.inf))
         assert_pickle(self, R_AB, RotationMatrix.matrix, T=T)
 
     @numpy_compare.check_all_types

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -173,7 +173,7 @@ class RigidTransform {
   /// @note No attempt is made to orthogonalize the 3x3 rotation matrix part of
   /// `pose`.  As needed, use RotationMatrix::ProjectToRotationMatrix().
   /// @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
-  explicit RigidTransform(const Eigen::Matrix<T, 3, 4> pose) {
+  explicit RigidTransform(const Eigen::Matrix<T, 3, 4>& pose) {
     set_rotation(RotationMatrix<T>(pose.template block<3, 3>(0, 0)));
     set_translation(pose.template block<3, 1>(0, 3));
   }
@@ -251,6 +251,24 @@ class RigidTransform {
           "expression that can resolve to a Vector3 or 3x4 matrix or 4x4 "
           "matrix.");
     }
+  }
+
+  /// (Advanced) Constructs a %RigidTransform from a 3x4 matrix, without any
+  /// validity checks nor orthogonalization.
+  /// @param[in] pose 3x4 matrix that contains a 3x3 rotation matrix `R_AB` and
+  /// also a 3x1 position vector `p_AoBo_A` (the position vector from frame A's
+  /// origin to frame B's origin, expressed in frame A).
+  /// <pre>
+  ///  ┌                ┐
+  ///  │ R_AB  p_AoBo_A │
+  ///  └                ┘
+  /// </pre>
+  static RigidTransform<T> MakeUnchecked(const Eigen::Matrix<T, 3, 4>& pose) {
+    RigidTransform<T> result(internal::DoNotInitializeMemberFields{});
+    result.R_AB_ =
+        RotationMatrix<T>::MakeUnchecked(pose.template block<3, 3>(0, 0));
+    result.p_AoBo_A_ = pose.template block<3, 1>(0, 3);
+    return result;
   }
 
   /// Sets `this` %RigidTransform from a RotationMatrix and a position vector.

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -198,7 +198,8 @@ GTEST_TEST(RigidTransform, ConstructorAngleAxisPositionVector) {
   EXPECT_TRUE(X.translation() == position);
 }
 
-// Test constructing a RigidTransform from a 3x4 matrix.
+// Test constructing a RigidTransform from a 3x4 matrix, both via the
+// constructor and the MakeUnchecked factory function.
 GTEST_TEST(RigidTransform, ConstructorFromMatrix34) {
   const RotationMatrixd R = GetRotationMatrixB();
   const Vector3<double> position(4, 5, 6);
@@ -211,6 +212,10 @@ GTEST_TEST(RigidTransform, ConstructorFromMatrix34) {
     pose(2, 2) += 1E-5;  // Corrupt the last element of the rotation matrix.
     EXPECT_THROW(RigidTransformd XX(pose), std::exception);
   }
+
+  // The corrupt matrix survives MakeUnchecked() without error.
+  const auto X2 = RigidTransform<double>::MakeUnchecked(pose);
+  EXPECT_TRUE(CompareMatrices(X2.GetAsMatrix34(), pose));
 }
 
 // Test constructing a RigidTransform from a 4x4 matrix.


### PR DESCRIPTION
One might initially worry that `MakeUnchecked` is too dangerous of a tool to add to public API.  However, in practice nearly all users run a Release build of Drake, which means that the everyday constructors being used today are not checking for valid rotation matrices, either.  This isn't any more dangerous than the status quo.

Closes #21374.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21393)
<!-- Reviewable:end -->
