### PR TITLE
Add support for parsing symbolic L2 norm costs

### DIFF
--- a/bindings/pydrake/math/math_py_monolith.cc
+++ b/bindings/pydrake/math/math_py_monolith.cc
@@ -523,7 +523,8 @@ void DoScalarIndependentDefinitions(py::module m) {
   m  // BR
       .def("DecomposePSDmatrixIntoXtransposeTimesX",
           &DecomposePSDmatrixIntoXtransposeTimesX, py::arg("Y"),
-          py::arg("zero_tol"), doc.DecomposePSDmatrixIntoXtransposeTimesX.doc)
+          py::arg("zero_tol"), py::arg("return_empty_if_not_psd") = false,
+          doc.DecomposePSDmatrixIntoXtransposeTimesX.doc)
       .def("DecomposePositiveQuadraticForm", &DecomposePositiveQuadraticForm,
           py::arg("Q"), py::arg("b"), py::arg("c"), py::arg("tol") = 0,
           doc.DecomposePositiveQuadraticForm.doc)

--- a/bindings/pydrake/math/test/math_test.py
+++ b/bindings/pydrake/math/test/math_test.py
@@ -544,7 +544,8 @@ class TestMath(unittest.TestCase):
 
     def test_quadratic_form(self):
         Q = np.diag([1., 2., 3.])
-        X = mut.DecomposePSDmatrixIntoXtransposeTimesX(Q, 1e-8)
+        X = mut.DecomposePSDmatrixIntoXtransposeTimesX(
+            Y=Q, zero_tol=1e-8, return_empty_if_not_psd=False)
         np.testing.assert_array_almost_equal(X, np.sqrt(Q))
         b = np.zeros(3)
         c = 4.

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -812,6 +812,13 @@ void BindMathematicalProgram(py::module m) {
               &MathematicalProgram::AddL2NormCost),
           py::arg("A"), py::arg("b"), py::arg("vars"),
           doc.MathematicalProgram.AddL2NormCost.doc_3args_A_b_vars)
+      .def("AddL2NormCost",
+          overload_cast_explicit<Binding<L2NormCost>,
+              const symbolic::Expression&, double, double>(
+              &MathematicalProgram::AddL2NormCost),
+          py::arg("e"), py::arg("psd_tol") = 1e-8,
+          py::arg("coefficient_tol") = 1e-8,
+          doc.MathematicalProgram.AddL2NormCost.doc_expression)
       .def("AddL2NormCostUsingConicConstraint",
           &MathematicalProgram::AddL2NormCostUsingConicConstraint, py::arg("A"),
           py::arg("b"), py::arg("vars"),

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1059,9 +1059,15 @@ class TestMathematicalProgram(unittest.TestCase):
     def test_add_l2norm_cost(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2, 'x')
-        prog.AddL2NormCost(
-            A=np.array([[1, 2.], [3., 4]]), b=np.array([1., 2.]), vars=x)
+        A = np.array([[1, 2.], [3., 4]])
+        b = np.array([1., 2.])
+        prog.AddL2NormCost(A=A, b=b, vars=x)
         self.assertEqual(len(prog.l2norm_costs()), 1)
+        prog.AddL2NormCost(
+            e=np.linalg.norm(A@x+b), psd_tol=1e-8, coefficient_tol=1e-8)
+        self.assertEqual(len(prog.l2norm_costs()), 2)
+        prog.AddCost(e=np.linalg.norm(A@x+b))
+        self.assertEqual(len(prog.l2norm_costs()), 3)
 
     def test_add_l2norm_cost_using_conic_constraint(self):
         prog = mp.MathematicalProgram()

--- a/bindings/pydrake/symbolic/symbolic_py_monolith.cc
+++ b/bindings/pydrake/symbolic/symbolic_py_monolith.cc
@@ -1164,7 +1164,10 @@ void DefineSymbolicMonolith(py::module m) {
           doc.DecomposeAffineExpression.doc)
       .def("DecomposeLumpedParameters", &DecomposeLumpedParameters,
           py::arg("f"), py::arg("parameters"),
-          doc.DecomposeLumpedParameters.doc);
+          doc.DecomposeLumpedParameters.doc)
+      .def("DecomposeL2NormExpression", &DecomposeL2NormExpression,
+          py::arg("e"), py::arg("psd_tol") = 1e-8,
+          py::arg("coefficient_tol") = 1e-8, doc.DecomposeL2NormExpression.doc);
 
   // Bind free function in replace_bilinear_terms.
   m.def("ReplaceBilinearTerms", &ReplaceBilinearTerms, py::arg("e"),

--- a/bindings/pydrake/symbolic/test/symbolic_test.py
+++ b/bindings/pydrake/symbolic/test/symbolic_test.py
@@ -2077,6 +2077,17 @@ class TestDecomposeLumpedParameters(unittest.TestCase):
         numpy_compare.assert_equal(w0, [sym.Expression(x), sym.Expression(0)])
 
 
+class TestDecomposeL2NormExpression(unittest.TestCase):
+    def test(self):
+        x = sym.MakeVectorVariable(2, "x")
+        [is_l2norm, A, b, vars] = sym.DecomposeL2NormExpression(
+            e=np.linalg.norm(x), psd_tol=1e-8, coefficient_tol=1e-8)
+        self.assertTrue(is_l2norm)
+        numpy_compare.assert_equal(A, np.eye(2))
+        numpy_compare.assert_equal(b, [0, 0])
+        numpy_compare.assert_equal(vars, x)
+
+
 class TestUnapplyExpression(unittest.TestCase):
     def setUp(self):
         # For these kinds of expressions, the unapplied args should only ever

--- a/common/symbolic/BUILD.bazel
+++ b/common/symbolic/BUILD.bazel
@@ -181,8 +181,11 @@ drake_cc_library(
         "monomial.h",
         "polynomial.h",
     ],
-    deps = [
+    interface_deps = [
         ":expression",
+    ],
+    deps = [
+        "//math:quadratic_form",
     ],
 )
 

--- a/common/symbolic/decompose.cc
+++ b/common/symbolic/decompose.cc
@@ -9,6 +9,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/fmt_eigen.h"
+#include "drake/math/quadratic_form.h"
 
 namespace drake {
 namespace symbolic {
@@ -341,6 +342,53 @@ int DecomposeAffineExpression(
     }
   }
   return num_variable;
+}
+
+std::tuple<bool, Eigen::MatrixXd, Eigen::VectorXd, VectorX<Variable>>
+DecomposeL2NormExpression(const symbolic::Expression& e, double psd_tol,
+                          double coefficient_tol) {
+  DRAKE_THROW_UNLESS(psd_tol >= 0);
+  DRAKE_THROW_UNLESS(coefficient_tol >= 0);
+  Eigen::MatrixXd A;
+  Eigen::VectorXd b;
+  VectorX<Variable> vars;
+  if (e.get_kind() != ExpressionKind::Sqrt) {
+    return {false, A, b, vars};
+  }
+  const Expression& arg = get_argument(e);
+  if (!arg.is_polynomial()) {
+    return {false, A, b, vars};
+  }
+  const symbolic::Polynomial poly{arg};
+  const int total_degree{poly.TotalDegree()};
+  if (total_degree != 2) {
+    return {false, A, b, vars};
+  }
+  auto e_extracted = ExtractVariablesFromExpression(e);
+  vars = std::move(e_extracted.first);
+  const auto& map_var_to_index = e_extracted.second;
+
+  // First decompose into the form 0.5 * x' * Q * x + r' * x + s.
+  Eigen::MatrixXd Q(vars.size(), vars.size());
+  Eigen::VectorXd r(vars.size());
+  double s;
+  DecomposeQuadraticPolynomial(poly, map_var_to_index, &Q, &r, &s);
+  Q *= 0.5;
+
+  A = math::DecomposePSDmatrixIntoXtransposeTimesX(
+      Q, psd_tol, true /* return empty if not psd */);
+  if (A.rows() == 0) {
+    return {false, A, b, vars};
+  }
+  b = A.transpose().colPivHouseholderQr().solve(0.5 * r);
+  if ((A.transpose() * b - 0.5 * r).array().abs().maxCoeff() >
+      coefficient_tol) {
+    return {false, A, b, vars};
+  }
+  if (std::abs(s - b.dot(b)) > coefficient_tol) {
+    return {false, A, b, vars};
+  }
+  return {true, A, b, vars};
 }
 
 namespace {

--- a/common/symbolic/decompose.h
+++ b/common/symbolic/decompose.h
@@ -155,5 +155,30 @@ std::tuple<MatrixX<Expression>, VectorX<Expression>, VectorX<Expression>>
 DecomposeLumpedParameters(
     const Eigen::Ref<const VectorX<Expression>>& f,
     const Eigen::Ref<const VectorX<Variable>>& parameters);
+
+/** Decomposes an L2 norm @p e = |Ax+b|₂ into A, b, and the variable vector x
+(or returns false if the decomposition is not possible).
+
+In order for the decomposition to succeed, the following conditions must be met:
+1. e is a sqrt expression.
+2. e.get_argument() is a polynomial of degree 2, which can be expressed as a
+   quadratic form (Ax+b)ᵀ(Ax+b).
+
+@param e The symbolic affine expression
+@param psd_tol The tolerance for checking positive semidefiniteness.
+Eigenvalues less that this threshold are considered to be zero. Matrices with
+negative eigenvalues less than this threshold are considered to be not positive
+semidefinite, and will cause the decomposition to fail.
+@param coefficient_tol The absolute tolerance for checking that the
+coefficients of the expression inside the sqrt match the coefficients of
+|Ax+b|₂².
+
+@return [is_l2norm, A, b, vars] where is_l2norm is true iff the decomposition
+was successful, and if is_l2norm is true then |A*vars + b|₂ = e.
+*/
+std::tuple<bool, Eigen::MatrixXd, Eigen::VectorXd, VectorX<Variable>>
+DecomposeL2NormExpression(const symbolic::Expression& e, double psd_tol = 1e-8,
+                          double coefficient_tol = 1e-8);
+
 }  // namespace symbolic
 }  // namespace drake

--- a/math/matrix_util.h
+++ b/math/matrix_util.h
@@ -144,7 +144,7 @@ drake::VectorX<typename Derived::Scalar> ToLowerTriangularColumnsFromMatrix(
 }
 
 /// Checks if a matrix is symmetric (with tolerance @p symmetry_tolerance --
-/// @see IsSymmetric) and has all eigenvalues greater than @p
+/// see IsSymmetric) and has all eigenvalues greater than @p
 /// eigenvalue_tolerance.  @p eigenvalue_tolerance must be >= 0 -- where 0
 /// implies positive semi-definite (but is of course subject to all of the
 /// pitfalls of floating point).

--- a/math/quadratic_form.cc
+++ b/math/quadratic_form.cc
@@ -11,7 +11,8 @@
 namespace drake {
 namespace math {
 Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
-    const Eigen::Ref<const Eigen::MatrixXd>& Y, double zero_tol) {
+    const Eigen::Ref<const Eigen::MatrixXd>& Y, double zero_tol,
+    bool return_empty_if_not_psd) {
   if (Y.rows() != Y.cols()) {
     throw std::runtime_error("Y is not square.");
   }
@@ -31,6 +32,9 @@ Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
       int X_row_count = 0;
       for (int i = 0; i < es_Y.eigenvalues().rows(); ++i) {
         if (es_Y.eigenvalues()(i) < -zero_tol) {
+          if (return_empty_if_not_psd) {
+            return Eigen::MatrixXd::Zero(0, Y.cols());
+          }
           throw std::runtime_error(fmt::format(
               "Y is not positive semidefinite. It has an eigenvalue {} "
               "that is less than the tolerance {}.",
@@ -42,6 +46,9 @@ Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
       }
       return X.topRows(X_row_count);
     }
+  }
+  if (return_empty_if_not_psd) {
+    return Eigen::MatrixXd::Zero(0, Y.cols());
   }
   throw std::runtime_error("Y is not PSD.");
 }

--- a/math/quadratic_form.h
+++ b/math/quadratic_form.h
@@ -16,14 +16,21 @@ namespace math {
  * @param zero_tol We will need to check if some value (for example, the
  * absolute value of Y's eigenvalues) is smaller than zero_tol. If it is, then
  * we deem that value as 0.
+ * @param return_empty_if_not_psd If true, then return an empty matrix of size
+ * 0-by-Y.cols() if Y is not PSD (either the decomposition fails or the
+ * resulting eigenvalues are less that @p zero_tol). If false (the default),
+ * then throw an exception if Y is not PSD.  This option is particularly useful
+ * because it is brittle/expensive to test the exact success criteria before
+ * calling this function.
  * @retval X. The matrix X satisfies XᵀX = Y and X.rows() = rank(Y).
- * @pre 1. Y is positive semidefinite.
+ * @pre 1. Y is positive semidefinite or return_empty_if_not_psd = true.
  *      2. zero_tol is non-negative.
  * @throws std::exception when the pre-conditions are not satisfied.
  * @note We only use the lower triangular part of Y.
  */
 Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
-    const Eigen::Ref<const Eigen::MatrixXd>& Y, double zero_tol);
+    const Eigen::Ref<const Eigen::MatrixXd>& Y, double zero_tol,
+    bool return_empty_if_not_psd = false);
 
 /**
  * Rewrite a quadratic form xᵀQx + bᵀx + c to

--- a/math/test/quadratic_form_test.cc
+++ b/math/test/quadratic_form_test.cc
@@ -86,6 +86,13 @@ GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, negativeY) {
       DecomposePSDmatrixIntoXtransposeTimesX(-Eigen::Matrix3d::Identity(), 0),
       "Y is not positive semidefinite. It has an eigenvalue -1.* that is less"
       " than the tolerance -0.*.");
+
+  // If return_empty_if_not_psd is true, the function should return an empty
+  // matrix.
+  Eigen::MatrixXd X = DecomposePSDmatrixIntoXtransposeTimesX(
+      -Eigen::Matrix3d::Identity(), 0, true /* return_empty_if_not_psd */);
+  EXPECT_EQ(X.rows(), 0);
+  EXPECT_EQ(X.cols(), 3);
 }
 
 GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, indefiniteY) {
@@ -99,6 +106,13 @@ GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, indefiniteY) {
   // clang-format on
   EXPECT_THROW(DecomposePSDmatrixIntoXtransposeTimesX(Y, 0),
                std::runtime_error);
+
+  // If return_empty_if_not_psd is true, the function should return an empty
+  // matrix.
+  Eigen::MatrixXd X = DecomposePSDmatrixIntoXtransposeTimesX(
+      Y, 0, true /* return_empty_if_not_psd */);
+  EXPECT_EQ(X.rows(), 0);
+  EXPECT_EQ(X.cols(), 4);
 }
 
 GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, almost_psd_Y) {
@@ -111,6 +125,14 @@ GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, almost_psd_Y) {
   // detect Y is not PSD.
   EXPECT_THROW(DecomposePSDmatrixIntoXtransposeTimesX(Y, 0),
                std::runtime_error);
+
+  // If return_empty_if_not_psd is true, the function should return an empty
+  // matrix.
+  Eigen::MatrixXd X = DecomposePSDmatrixIntoXtransposeTimesX(
+      Y, 0, true /* return_empty_if_not_psd */);
+  EXPECT_EQ(X.rows(), 0);
+  EXPECT_EQ(X.cols(), 3);
+
   // With tolerance being 1E-10, it should regard Y as a PSD matrix.
   CheckDecomposePSDmatrixIntoXtransposeTimesX(Y, 2E-10, 1E-9);
 }

--- a/solvers/create_cost.cc
+++ b/solvers/create_cost.cc
@@ -95,8 +95,28 @@ Binding<PolynomialCost> ParsePolynomialCost(const symbolic::Expression& e) {
                        var_vec);
 }
 
+Binding<L2NormCost> ParseL2NormCost(const symbolic::Expression& e,
+                                    double psd_tol, double coefficient_tol) {
+  auto [is_l2norm, A, b, vars] =
+      DecomposeL2NormExpression(e, psd_tol, coefficient_tol);
+  if (!is_l2norm) {
+    throw runtime_error(fmt::format(
+        "Expression {} is not an L2 norm. ParseL2NormCost only supports "
+        "expressions that are the square root of a quadratic.",
+        e));
+  }
+  return CreateBinding(make_shared<L2NormCost>(A, b), vars);
+}
+
 Binding<Cost> ParseCost(const symbolic::Expression& e) {
   if (!e.is_polynomial()) {
+    // First try an L2-norm cost.
+    auto [is_l2norm, A, b, vars] = DecomposeL2NormExpression(e);
+    if (is_l2norm) {
+      return CreateBinding(make_shared<L2NormCost>(A, b), vars);
+    }
+
+    // Otherwise make an ExpressionCost.
     auto cost = make_shared<ExpressionCost>(e);
     return CreateBinding(cost, cost->vars());
   }

--- a/solvers/create_cost.h
+++ b/solvers/create_cost.h
@@ -32,9 +32,16 @@ Binding<QuadraticCost> ParseQuadraticCost(
 Binding<PolynomialCost> ParsePolynomialCost(const symbolic::Expression& e);
 
 /*
+ * Assist MathematicalProgram::AddL2NormCost(...)
+ */
+Binding<L2NormCost> ParseL2NormCost(const symbolic::Expression& e,
+                                    double psd_tol, double coefficient_tol);
+
+/*
  * Assist MathematicalProgram::AddCost(...).
  */
 Binding<Cost> ParseCost(const symbolic::Expression& e);
+
 
 // TODO(eric.cousineau): Remove this when functor cost is no longer exposed
 // externally, and must be explicitly called.

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -536,6 +536,11 @@ Binding<L2NormCost> MathematicalProgram::AddL2NormCost(
   return AddCost(std::make_shared<L2NormCost>(A, b), vars);
 }
 
+Binding<L2NormCost> MathematicalProgram::AddL2NormCost(
+    const symbolic::Expression& e, double psd_tol, double coefficient_tol) {
+  return AddCost(internal::ParseL2NormCost(e, psd_tol, coefficient_tol));
+}
+
 std::tuple<symbolic::Variable, Binding<LinearCost>,
            Binding<LorentzConeConstraint>>
 MathematicalProgram::AddL2NormCostUsingConicConstraint(

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1178,6 +1178,18 @@ class MathematicalProgram {
     return AddL2NormCost(A, b, ConcatenateVariableRefList(vars));
   }
 
+  /**
+   * Adds an L2 norm cost |Ax+b|₂ from a symbolic expression which can be
+   * decomposed into sqrt((Ax+b)'(Ax+b)). See
+   * symbolic::DecomposeL2NormExpression for details on the tolerance
+   * parameters.
+   * @throws std::exception if @p e cannot be decomposed into an L2 norm.
+   * @pydrake_mkdoc_identifier{expression}
+   */
+  Binding<L2NormCost> AddL2NormCost(const symbolic::Expression& e,
+                                    double psd_tol = 1e-8,
+                                    double coefficient_tol = 1e-8);
+
   // TODO(hongkai.dai) Decide whether to deprecate this.
   /**
    * Adds an L2 norm cost min |Ax+b|₂ as a linear cost min s

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3294,8 +3294,18 @@ GTEST_TEST(TestMathematicalProgram, AddL2NormCost) {
   auto obj2 = prog.AddL2NormCost(A, b, x);
   EXPECT_EQ(prog.l2norm_costs().size(), 2u);
 
+  symbolic::Expression e = (A * x + b).norm();
+  auto obj3 = prog.AddL2NormCost(e, 1e-8, 1e-8);
+  EXPECT_EQ(prog.l2norm_costs().size(), 3u);
+
+  // Test that the AddCost method correctly recognizes the L2norm.
+  auto obj4 = prog.AddCost(e);
+  EXPECT_EQ(prog.l2norm_costs().size(), 4u);
+
   prog.RemoveCost(obj1);
   prog.RemoveCost(obj2);
+  prog.RemoveCost(obj3);
+  prog.RemoveCost(obj4);
   EXPECT_EQ(prog.l2norm_costs().size(), 0u);
   EXPECT_FALSE(prog.required_capabilities().contains(
       ProgramAttribute::kL2NormCost));
@@ -3307,6 +3317,10 @@ GTEST_TEST(TestMathematicalProgram, AddL2NormCost) {
 
   auto new_prog = prog.Clone();
   EXPECT_EQ(new_prog->l2norm_costs().size(), 1u);
+
+  // AddL2NormCost(Expression) can throw.
+  e = (A*x + b).squaredNorm();
+  DRAKE_EXPECT_THROWS_MESSAGE(prog.AddL2NormCost(e), ".*is not an L2 norm.*");
 }
 
 GTEST_TEST(TestMathematicalProgram, AddQuadraticConstraint) {


### PR DESCRIPTION
In a recent underactuated pset, we found that *lots* of people wanted to pass e.g. np.linalg.norm(x1-x2) to the AddCost methods, and were stymied by a lack of support there. Asking them to instead suddenly understand how to create an L2NormCost, create the binding, and pass _that_ to (GCS's version of) AddCost was too much.

This PR adds DecomposeL2NormExpression, and uses it in prog.AddCost(expression). Consistent with the other Add*Cost methods, it also adds prog.AddL2NormCost(expression), with all of the specific tolerance arguments.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21394)
<!-- Reviewable:end -->
