### PR TITLE
[py symbolic] Loosen test of np.tan

### DIFF
--- a/bindings/pydrake/symbolic/test/symbolic_test.py
+++ b/bindings/pydrake/symbolic/test/symbolic_test.py
@@ -793,7 +793,7 @@ class TestSymbolicExpression(unittest.TestCase):
         numpy_compare.assert_equal(sym.pow(v_x, v_y), v_x ** v_y)
         numpy_compare.assert_equal(sym.sin(v_x), np.sin(v_x))
         numpy_compare.assert_equal(sym.cos(v_x), np.cos(v_x))
-        numpy_compare.assert_equal(sym.tan(v_x), np.tan(v_x))
+        numpy_compare.assert_float_allclose(sym.tan(v_x), np.tan(v_x))
         numpy_compare.assert_equal(sym.asin(v_x), np.arcsin(v_x))
         numpy_compare.assert_equal(sym.acos(v_x), np.arccos(v_x))
         numpy_compare.assert_equal(sym.atan(v_x), np.arctan(v_x))


### PR DESCRIPTION
On the Ubuntu 24.04 version of numpy, `np.tan(1.0)` differs by 1 ulp compared to Ubuntu 22.04 and earlier.

Towards #21335.

Note that the Noble CI job here still shows 2 failures, but notably the failure on _this_ test case is no longer there (as compared to [the baseline](https://drake-jenkins.csail.mit.edu/view/Linux%20Noble%20Unprovisioned/job/linux-noble-unprovisioned-gcc-bazel-experimental-release/7/)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21395)
<!-- Reviewable:end -->
