### PR TITLE
[multibody] Adds RemoveJoint()

### DIFF
--- a/bindings/pydrake/examples/gym/named_view_helpers.py
+++ b/bindings/pydrake/examples/gym/named_view_helpers.py
@@ -23,7 +23,7 @@ def MakeNamedViewPositions(plant,
                            view_name,
                            add_suffix_if_single_position=False):
     names = [None] * plant.num_positions()
-    for ind in range(plant.num_joints()):
+    for ind in plant.GetJointIndices():
         joint = plant.get_joint(JointIndex(ind))
         if joint.num_positions() == 1 and not add_suffix_if_single_position:
             names[joint.position_start()] = joint.name()
@@ -44,7 +44,7 @@ def MakeNamedViewVelocities(plant,
                             view_name,
                             add_suffix_if_single_velocity=False):
     names = [None] * plant.num_velocities()
-    for ind in range(plant.num_joints()):
+    for ind in plant.GetJointIndices():
         joint = plant.get_joint(JointIndex(ind))
         if joint.num_velocities() == 1 and not add_suffix_if_single_velocity:
             names[joint.velocity_start()] = joint.name()

--- a/bindings/pydrake/multibody/jupyter_widgets.py
+++ b/bindings/pydrake/multibody/jupyter_widgets.py
@@ -74,7 +74,7 @@ class JointSliders(VectorSystem):
         self._default_position = robot.GetPositions(context)
 
         k = 0
-        for i in range(0, robot.num_joints()):
+        for i in robot.GetJointIndices():
             joint = robot.get_joint(JointIndex(i))
             low = joint.position_lower_limits()
             upp = joint.position_upper_limits()
@@ -214,7 +214,7 @@ def MakeJointSlidersThatPublishOnCallback(
 
     slider_widgets = []
     slider_num = 0
-    for i in range(plant.num_joints()):
+    for i in plant.GetJointIndices():
         joint = plant.get_joint(JointIndex(i))
         low = joint.position_lower_limits()
         upp = joint.position_upper_limits()

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -220,6 +220,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("joint"), py_rvp::reference_internal,
             cls_doc.AddJoint.doc_1args)
+        .def("RemoveJoint", &Class::RemoveJoint, py::arg("joint"),
+            cls_doc.RemoveJoint.doc)
         .def("AddJointActuator", &Class::AddJointActuator,
             py_rvp::reference_internal, py::arg("name"), py::arg("joint"),
             py::arg("effort_limit") = std::numeric_limits<double>::infinity(),
@@ -726,6 +728,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("num_frames", &Class::num_frames, cls_doc.num_frames.doc)
         .def("get_body", &Class::get_body, py::arg("body_index"),
             py_rvp::reference_internal, cls_doc.get_body.doc)
+        .def("has_joint", &Class::has_joint, py::arg("joint_index"),
+            cls_doc.has_joint.doc)
         .def("get_joint", &Class::get_joint, py::arg("joint_index"),
             py_rvp::reference_internal, cls_doc.get_joint.doc)
         .def("get_mutable_joint", &Class::get_mutable_joint,
@@ -750,8 +754,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.set_gravity_enabled.doc)
         .def("is_gravity_enabled", &Class::is_gravity_enabled,
             py::arg("model_instance"), cls_doc.is_gravity_enabled.doc)
-        .def("GetJointIndices", &Class::GetJointIndices,
-            py::arg("model_instance"), cls_doc.GetJointIndices.doc)
+        .def("GetJointIndices",
+            overload_cast_explicit<const std::vector<JointIndex>&>(
+                &Class::GetJointIndices),
+            cls_doc.GetJointIndices.doc_0args)
+        .def("GetJointIndices",
+            overload_cast_explicit<std::vector<JointIndex>, ModelInstanceIndex>(
+                &Class::GetJointIndices),
+            py::arg("model_instance"), cls_doc.GetJointIndices.doc_1args)
         .def("GetJointActuatorIndices",
             overload_cast_explicit<const std::vector<JointActuatorIndex>&>(
                 &Class::GetJointActuatorIndices),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -288,7 +288,36 @@ class TestPlant(unittest.TestCase):
             plant.has_joint_actuator(actuator_index=actuator_index))
         plant.Finalize()
         self.assertEqual(
-            plant.GetJointActuatorIndices(model_instance=instance), [])
+            plant.GetJointActuatorIndices(), [])
+
+    @numpy_compare.check_all_types
+    def test_joint_remodeling(self, T):
+        """
+        Tests joint  APIs related to remodeling: `RemoveJoint`,
+        `has_joint` and the 0 argument `GetJointIndices()`.
+        """
+        plant = MultibodyPlant_[T](0)
+        instance = plant.AddModelInstance("instance")
+        body = plant.AddRigidBody(
+            name="body", model_instance=instance)
+        joint = plant.AddJoint(
+            PrismaticJoint_[T](
+                "joint",
+                plant.world_frame(),
+                body.body_frame(),
+                [0, 0, 1]))
+        joint_index = joint.index()
+        self.assertEqual(
+            plant.GetJointIndices(), [joint_index])
+        self.assertTrue(
+            plant.has_joint(joint_index=joint_index))
+        plant.RemoveJoint(joint=joint)
+        self.assertFalse(
+            plant.has_joint(joint_index=joint_index))
+        plant.Finalize()
+        # 6 dof joint will be added for the now free body.
+        self.assertEqual(
+            plant.GetJointIndices(), [JointIndex(1)])
 
     def test_multibody_plant_config(self):
         MultibodyPlantConfig()

--- a/manipulation/util/robot_plan_interpolator.cc
+++ b/manipulation/util/robot_plan_interpolator.cc
@@ -47,7 +47,7 @@ RobotPlanInterpolator::RobotPlanInterpolator(const std::string& model_path,
   // Search for any bodies with no parent.  We'll weld those to the world.
   std::set<BodyIndex> parent_bodies;
   std::set<BodyIndex> child_bodies;
-  for (JointIndex i(0); i < plant_.num_joints(); ++i) {
+  for (JointIndex i : plant_.GetJointIndices()) {
     const multibody::Joint<double>& joint = plant_.get_joint(i);
     if (joint.parent_body().index() == plant_.world_body().index()) {
       // Nothing to weld, we're connected to the world.

--- a/manipulation/util/robot_plan_utils.cc
+++ b/manipulation/util/robot_plan_utils.cc
@@ -16,9 +16,8 @@ std::vector<std::string> GetJointNames(
     const multibody::MultibodyPlant<T>& plant) {
   std::map<int, std::string> position_names;
   const int num_positions = plant.num_positions();
-  for (int i = 0; i < plant.num_joints(); ++i) {
-    const multibody::Joint<T>& joint =
-        plant.get_joint(multibody::JointIndex(i));
+  for (multibody::JointIndex i : plant.GetJointIndices()) {
+    const multibody::Joint<T>& joint = plant.get_joint(i);
     if (joint.num_positions() == 0) {
       continue;
     }

--- a/manipulation/util/test/robot_plan_interpolator_test.cc
+++ b/manipulation/util/test/robot_plan_interpolator_test.cc
@@ -87,9 +87,8 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   plan.plan.resize(num_time_steps, default_robot_state);
 
   std::vector<std::string> joint_names;
-  for (int i = 0; i < dut.plant().num_joints(); ++i) {
-    const multibody::Joint<double>& joint =
-        dut.plant().get_joint(multibody::JointIndex(i));
+  for (multibody::JointIndex i : dut.plant().GetJointIndices()) {
+    const multibody::Joint<double>& joint = dut.plant().get_joint(i);
     if (joint.num_positions() != 1) {
       continue;
     }

--- a/multibody/inverse_kinematics/global_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.cc
@@ -30,8 +30,7 @@ std::map<BodyIndex, JointIndex> GetBodyToJointMap(
   // First loop through each joint, stores the map from the child body to the
   // joint.
   std::map<BodyIndex, JointIndex> body_to_joint_map;
-  for (JointIndex joint_index{0}; joint_index < plant.num_joints();
-       ++joint_index) {
+  for (JointIndex joint_index : plant.GetJointIndices()) {
     body_to_joint_map.emplace(plant.get_joint(joint_index).child_body().index(),
                               joint_index);
   }
@@ -626,8 +625,7 @@ void GlobalInverseKinematics::AddJointLimitConstraint(
         "the bounds on R_WB and p_WB directly.");
   }
   const Joint<double>* joint{nullptr};
-  for (JointIndex joint_index{0}; joint_index < plant_.num_joints();
-       ++joint_index) {
+  for (JointIndex joint_index : plant_.GetJointIndices()) {
     if (plant_.get_joint(joint_index).child_body().index() == body_index) {
       joint = &(plant_.get_joint(joint_index));
       break;

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -70,7 +70,7 @@ InverseKinematics::InverseKinematics(
   // Obey joint locking. Joint locking trumps joint limits.
   const Eigen::VectorXd current_positions = plant.GetPositions(context());
   VectorX<bool> is_locked = VectorX<bool>::Constant(nq, false);
-  for (JointIndex i{0}; i < plant.num_joints(); ++i) {
+  for (JointIndex i : plant.GetJointIndices()) {
     const Joint<double>& joint = plant.get_joint(i);
     if (joint.is_locked(context())) {
       const int start = joint.position_start();

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -69,7 +69,7 @@ std::map<int, std::string> GetPositionNames(
 
   // Map all joints into the positions-to-name result.
   std::map<int, std::string> result;
-  for (JointIndex i{0}; i < plant->num_joints(); ++i) {
+  for (JointIndex i : plant->GetJointIndices()) {
     const Joint<T>& joint = plant->get_joint(i);
     for (int j = 0; j < joint.num_positions(); ++j) {
       const int position_index = joint.position_start() + j;

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -24,10 +24,12 @@
 #include "drake/multibody/plant/hydroelastic_traction_calculator.h"
 #include "drake/multibody/plant/make_discrete_update_manager.h"
 #include "drake/multibody/plant/slicing_and_indexing.h"
+#include "drake/multibody/tree/door_hinge.h"
 #include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/multibody/tree/prismatic_spring.h"
 #include "drake/multibody/tree/quaternion_floating_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
-
+#include "drake/multibody/tree/revolute_spring.h"
 namespace drake {
 namespace multibody {
 
@@ -680,7 +682,7 @@ std::string MultibodyPlant<T>::GetTopologyGraphvizString() const {
     graphviz += "}\n";
   }
   // Add the graph edges (via the joints).
-  for (JointIndex joint_index(0); joint_index < num_joints(); ++joint_index) {
+  for (JointIndex joint_index : GetJointIndices()) {
     const Joint<T>& joint = get_joint(joint_index);
     graphviz += fmt::format(
         "body{} -> body{} [label=\"{} [{}]\"];\n", joint.child_body().index(),
@@ -775,6 +777,51 @@ void MultibodyPlant<T>::SetFreeBodyRandomRotationDistributionToUniform(
   RandomGenerator generator;
   auto q_FM = math::UniformlyRandomQuaternion<symbolic::Expression>(&generator);
   SetFreeBodyRandomRotationDistribution(body, q_FM);
+}
+
+template <typename T>
+void MultibodyPlant<T>::RemoveJoint(const Joint<T>& joint) {
+  // Check for non-zero number of user-added force elements. (There is always 1
+  // force element, the gravity field added when the tree is constructed.)
+  if (num_force_elements() > 1) {
+    throw std::logic_error(fmt::format(
+        "{}: This plant has {} user-added force elements. This plant must have "
+        "0 user-added force elements in order to remove joint with index {}.",
+        __func__, num_force_elements() - 1, joint.index()));
+  }
+
+  // Check for non-zero number of user-added constraints.
+  if (num_constraints() > 0) {
+    throw std::logic_error(fmt::format(
+        "{}: This plant has {} user-added constraints. This plant must have "
+        "0 user-added constraints in order to remove joint with index {}.",
+        __func__, num_constraints(), joint.index()));
+  }
+
+  // Check for dependent JointActuators in the plant. Throw if any actuator
+  // depends on the joint to be removed.
+  // TODO(#21415): Find a way to make checking an element for dependency on a
+  // Joint more robust and uniform across all MultibodyElements and constraints.
+  std::vector<std::string> dependent_elements;
+
+  // Check JointActuators.
+  for (JointActuatorIndex index : GetJointActuatorIndices()) {
+    const JointActuator<T>& actuator = get_joint_actuator(index);
+    if (actuator.joint().index() == joint.index()) {
+      dependent_elements.push_back(
+          fmt::format("JointActuator(name: {}, index: {})", actuator.name(),
+                      actuator.index()));
+    }
+  }
+
+  if (dependent_elements.size() > 0) {
+    throw std::logic_error(fmt::format(
+        "{}: joint with index {} has the following dependent model elements "
+        "which must be removed prior to joint removal: [{}].",
+        __func__, joint.index(), fmt::join(dependent_elements, ", ")));
+  }
+
+  this->mutable_tree().RemoveJoint(joint);
 }
 
 template <typename T>
@@ -971,9 +1018,11 @@ std::vector<BodyIndex> MultibodyPlant<T>::GetBodiesKinematicallyAffectedBy(
     const std::vector<JointIndex>& joint_indexes) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   for (const JointIndex& joint : joint_indexes) {
-    if (!joint.is_valid() || joint >= num_joints()) {
-      throw std::logic_error(fmt::format(
-          "{}: No joint with index {} has been registered.", __func__, joint));
+    if (!has_joint(joint)) {
+      throw std::logic_error(
+          fmt::format("{}: No joint with index {} has been registered or it "
+                      "has been removed.",
+                      __func__, joint));
     }
     if (get_joint(joint).num_velocities() == 0) {
       throw std::logic_error(
@@ -1184,7 +1233,7 @@ void MultibodyPlant<T>::Finalize() {
 
 template <typename T>
 void MultibodyPlant<T>::SetUpJointLimitsParameters() {
-  for (JointIndex joint_index(0); joint_index < num_joints(); ++joint_index) {
+  for (JointIndex joint_index : GetJointIndices()) {
     // Currently MultibodyPlant applies these "compliant" joint limit forces
     // using an explicit Euler strategy. Stability analysis of the explicit
     // Euler applied to the harmonic oscillator (the model used for these
@@ -1401,7 +1450,7 @@ void MultibodyPlant<T>::ApplyDefaultCollisionFilters() {
     // Disallow collisions between adjacent bodies. Adjacency is implied by the
     // existence of a joint between bodies, except in the case of 6-dof joints
     // or joints in which the parent body is `world`.
-    for (JointIndex j{0}; j < num_joints(); ++j) {
+    for (JointIndex j : GetJointIndices()) {
       const Joint<T>& joint = get_joint(j);
       const RigidBody<T>& child = joint.child_body();
       const RigidBody<T>& parent = joint.parent_body();
@@ -1533,7 +1582,7 @@ VectorX<T> MultibodyPlant<T>::GetDefaultPositions() const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   VectorX<T> q;
   q.setConstant(num_positions(), std::numeric_limits<double>::quiet_NaN());
-  for (JointIndex i{0}; i < num_joints(); ++i) {
+  for (JointIndex i : GetJointIndices()) {
     const Joint<T>& joint = get_joint(i);
     q.segment(joint.position_start(), joint.num_positions()) =
         joint.default_positions();
@@ -1556,7 +1605,7 @@ void MultibodyPlant<T>::SetDefaultPositions(
     const Eigen::Ref<const Eigen::VectorXd>& q) {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_THROW_UNLESS(q.size() == num_positions());
-  for (JointIndex i{0}; i < num_joints(); ++i) {
+  for (JointIndex i : GetJointIndices()) {
     Joint<T>& joint = get_mutable_joint(i);
     joint.set_default_positions(
         q.segment(joint.position_start(), joint.num_positions()));
@@ -1586,8 +1635,8 @@ std::vector<std::string> MultibodyPlant<T>::GetPositionNames(
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   std::vector<std::string> names(num_positions());
 
-  for (int joint_index = 0; joint_index < num_joints(); ++joint_index) {
-    const Joint<T>& joint = get_joint(JointIndex(joint_index));
+  for (JointIndex joint_index : GetJointIndices()) {
+    const Joint<T>& joint = get_joint(joint_index);
     const std::string prefix =
         add_model_instance_prefix
             ? fmt::format("{}_", GetModelInstanceName(joint.model_instance()))
@@ -1649,8 +1698,8 @@ std::vector<std::string> MultibodyPlant<T>::GetVelocityNames(
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   std::vector<std::string> names(num_velocities());
 
-  for (int joint_index = 0; joint_index < num_joints(); ++joint_index) {
-    const Joint<T>& joint = get_joint(JointIndex(joint_index));
+  for (JointIndex joint_index : GetJointIndices()) {
+    const Joint<T>& joint = get_joint(joint_index);
     const std::string prefix =
         add_model_instance_prefix
             ? fmt::format("{}_", GetModelInstanceName(joint.model_instance()))
@@ -2593,7 +2642,7 @@ void MultibodyPlant<T>::CalcJointLockingCache(
 
   int unlocked_cursor = 0;
   int locked_cursor = 0;
-  for (JointIndex joint_index(0); joint_index < num_joints(); ++joint_index) {
+  for (JointIndex joint_index : GetJointIndices()) {
     const Joint<T>& joint = get_joint(joint_index);
     if (joint.is_locked(context)) {
       for (int k = 0; k < joint.num_velocities(); ++k) {
@@ -3528,7 +3577,7 @@ void MultibodyPlant<T>::CalcReactionForces(
 
   // Map mobilizer reaction forces to joint reaction forces and perform the
   // necessary frame conversions.
-  for (JointIndex joint_index(0); joint_index < num_joints(); ++joint_index) {
+  for (JointIndex joint_index : GetJointIndices()) {
     const Joint<T>& joint = get_joint(joint_index);
     const internal::MobilizerIndex mobilizer_index =
         internal_tree().get_joint_mobilizer(joint_index);
@@ -3584,7 +3633,7 @@ void MultibodyPlant<T>::CalcReactionForces(
     // Re-express in the joint's child frame Jc.
     const RotationMatrix<T> R_WJc = frame_Jc.CalcRotationMatrixInWorld(context);
     const RotationMatrix<T> R_JcW = R_WJc.inverse();
-    F_CJc_Jc_array->at(joint_index) = R_JcW * F_CJc_W;
+    F_CJc_Jc_array->at(joint.ordinal()) = R_JcW * F_CJc_W;
   }
 }
 

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -317,8 +317,7 @@ void SapDriver<T>::AddLimitConstraints(const systems::Context<T>& context,
   const double stiffness = 1.0e12;
   const double dissipation_time_scale = dt;
 
-  for (JointIndex joint_index(0); joint_index < plant().num_joints();
-       ++joint_index) {
+  for (JointIndex joint_index : plant().GetJointIndices()) {
     const Joint<T>& joint = plant().get_joint(joint_index);
     // We only support limits for 1 DOF joints for which we know that q̇ = v.
     if (joint.num_positions() == 1 && joint.num_velocities() == 1) {

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -496,6 +496,8 @@ GTEST_TEST(DiscreteUpdateManagerCacheEntry, ContactSolverResults) {
 /* Tests that actuation forces are accumulated using the correct indexing from
  JointActuaton::input_start() */
 TEST_F(MultibodyPlantRemodeling, RemoveJointActuator) {
+  BuildModel();
+  DoRemoval(true /* remove actuator */, false /* do not remove joint */);
   // Set gravity vector to zero so there is no force element contribution.
   plant_->mutable_gravity_field().set_gravity_vector(Vector3d::Zero());
 

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -127,7 +127,7 @@ class KukaIiwaModelForwardDynamicsTests : public test::KukaIiwaModelTests {
 // the computation for an arbitrary set of robot states.
 TEST_F(KukaIiwaModelForwardDynamicsTests, ForwardDynamicsTest) {
   // Joint angles and velocities.
-  VectorX<double> q(kNumJoints - 1), qdot(kNumJoints - 1);
+  VectorX<double> q(kNumRevoluteJoints), qdot(kNumRevoluteJoints);
   double q30 = M_PI / 6, q45 = M_PI / 4, q60 = M_PI / 3;
 
   // Test 1: Static configuration.
@@ -171,8 +171,7 @@ GTEST_TEST(MultibodyPlantForwardDynamics, AtlasRobot) {
 
   // Create a context and store an arbitrary configuration.
   std::unique_ptr<Context<double>> context = plant.CreateDefaultContext();
-  for (JointIndex joint_index(0); joint_index < plant.num_joints();
-       ++joint_index) {
+  for (JointIndex joint_index : plant.GetJointIndices()) {
     const Joint<double>& joint = plant.get_joint(joint_index);
     // This model only has weld, revolute, and floating joints. Set the revolute
     // joints to an arbitrary angle.

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -74,7 +74,7 @@ void CalcJacobianViaPartialDerivativesOfPositionWithRespectToQ(
 TEST_F(KukaIiwaModelTests, FixtureInvariants) {
   // Sanity check basic invariants.
   // Seven dofs for the arm plus floating base.
-  EXPECT_EQ(plant_->num_joints(), kNumJoints);
+  EXPECT_EQ(plant_->num_joints(), kNumRevoluteJoints + kNumFloatingJoints);
   EXPECT_EQ(plant_->num_positions(), kNumPositions);
   EXPECT_EQ(plant_->num_velocities(), kNumVelocities);
 }

--- a/multibody/plant/test/multibody_plant_mass_matrix_test.cc
+++ b/multibody/plant/test/multibody_plant_mass_matrix_test.cc
@@ -108,8 +108,7 @@ TEST_F(MultibodyPlantMassMatrixTests, AtlasRobot) {
 
   // Create a context and store an arbitrary configuration.
   std::unique_ptr<Context<double>> context = plant_.CreateDefaultContext();
-  for (JointIndex joint_index(0); joint_index < plant_.num_joints();
-       ++joint_index) {
+  for (JointIndex joint_index : plant_.GetJointIndices()) {
     const Joint<double>& joint = plant_.get_joint(joint_index);
     // This model has weld, revolute, and floating joints. Set the revolute
     // joints to an arbitrary angle.
@@ -133,8 +132,7 @@ TEST_F(MultibodyPlantMassMatrixTests, AtlasRobotWithFixedJoints) {
 
   // Create a context and store an arbitrary configuration.
   std::unique_ptr<Context<double>> context = plant_.CreateDefaultContext();
-  for (JointIndex joint_index(0); joint_index < plant_.num_joints();
-       ++joint_index) {
+  for (JointIndex joint_index : plant_.GetJointIndices()) {
     const Joint<double>& joint = plant_.get_joint(joint_index);
     // This model has weld, revolute, and floating joints. Set the revolute
     // joints to an arbitrary angle.
@@ -155,8 +153,7 @@ TEST_F(MultibodyPlantMassMatrixTests, IiwaWithWeldedGripper) {
 
   // Create a context and store an arbitrary configuration.
   std::unique_ptr<Context<double>> context = plant_.CreateDefaultContext();
-  for (JointIndex joint_index(0); joint_index < plant_.num_joints();
-       ++joint_index) {
+  for (JointIndex joint_index : plant_.GetJointIndices()) {
     const Joint<double>& joint = plant_.get_joint(joint_index);
     // This model only has weld, prismatic, and revolute joints.
     if (joint.type_name() == RevoluteJoint<double>::kTypeName) {

--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -16,6 +16,7 @@
 #include "drake/multibody/plant/compliant_contact_manager.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/quaternion_floating_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/systems/analysis/implicit_euler_integrator.h"
 #include "drake/systems/analysis/simulator.h"
@@ -359,7 +360,7 @@ class LadderTest : public ::testing::TestWithParam<LadderTestConfig> {
         plant_->get_reaction_forces_output_port()
             .Eval<std::vector<SpatialForce<double>>>(*plant_context);
     ASSERT_EQ(reaction_forces.size(), 2u);
-    const SpatialForce<double>& F_Bl_Bl = reaction_forces[pin_->index()];
+    const SpatialForce<double>& F_Bl_Bl = reaction_forces[pin_->ordinal()];
     const RigidTransformd X_WBl =
         ladder_lower_->EvalPoseInWorld(*plant_context);
     const SpatialForce<double> F_Bl_W = X_WBl.rotation() * F_Bl_Bl;
@@ -459,7 +460,7 @@ class LadderTest : public ::testing::TestWithParam<LadderTestConfig> {
     const Vector3d p_WBucm = X_WBu * p_BuBucm;
     // Reaction forces at X_WBu in W.
     const SpatialForce<double>& F_Bu_W =
-        X_WBu.rotation() * reaction_forces[joint_->index()];
+        X_WBu.rotation() * reaction_forces[joint_->ordinal()];
     // Apart from reaction forces, two forces act on the upper half:
     // Contact force fc_x and gravity.
     const Vector3d f_Bu_expected(fc_x, 0.0, weight / 2.0);
@@ -710,7 +711,7 @@ class SpinningRodTest : public ::testing::Test {
         plant_->get_reaction_forces_output_port()
             .Eval<std::vector<SpatialForce<double>>>(*context_);
     ASSERT_EQ(reaction_forces.size(), 1u);
-    const SpatialForce<double>& F_BJb_Jb = reaction_forces[pin_->index()];
+    const SpatialForce<double>& F_BJb_Jb = reaction_forces[pin_->ordinal()];
 
     // Verify that the value of the reaction force includes the centripetal
     // component (along Jb's y axis) and the weight component (along Jb's z
@@ -801,7 +802,7 @@ class WeldedBoxesTest : public ::testing::Test {
     //   2. Moreover, A is coincident with the world and its origin is located
     //      at A's center of mass Acm.
     // Therefore the reaction at weld1 corresponds to F_Acm_W.
-    const SpatialForce<double>& F_Acm_W = reaction_forces[weld1_->index()];
+    const SpatialForce<double>& F_Acm_W = reaction_forces[weld1_->ordinal()];
 
     // Verify the reaction force balances the weight of the two boxes.
     const double box_weight = kBoxMass * kGravity;
@@ -819,7 +820,7 @@ class WeldedBoxesTest : public ::testing::Test {
     //   2. There is no rotation between B and the world frame.
     //   3. Frame B's origin is located at B's center of mass Bcm.
     // Therefore the reaction at weld2 corresponds to F_Bcm_W.
-    const SpatialForce<double>& F_Bcm_W = reaction_forces[weld2_->index()];
+    const SpatialForce<double>& F_Bcm_W = reaction_forces[weld2_->ordinal()];
     const Vector3d f_Bcm_W_expected = box_weight * Vector3d::UnitZ();
     const Vector3d t_Bcm_W_expected = Vector3d::Zero();
     EXPECT_EQ(F_Bcm_W.translational(), f_Bcm_W_expected);
@@ -849,6 +850,154 @@ TEST_F(WeldedBoxesTest, ReactionForcesContinuous) {
   ASSERT_FALSE(plant_->is_discrete());
   VerifyBodyReactionForces();
 }
+
+class WeldedAndFloatingTest : public ::testing::TestWithParam<bool> {
+ public:
+  void SetUp() {
+    const bool replace_joints = GetParam();
+
+    plant_ = std::make_unique<MultibodyPlant<double>>(0.01);
+
+    // Create four rigid bodies.
+    const RigidBody<double>& sphere0 = plant_->AddRigidBody(
+        "sphere0",
+        SpatialInertia<double>::SolidSphereWithMass(kBodyMasses[0], 1.0));
+    const RigidBody<double>& sphere1 = plant_->AddRigidBody(
+        "sphere1",
+        SpatialInertia<double>::SolidSphereWithMass(kBodyMasses[1], 1.0));
+    const RigidBody<double>& sphere2 = plant_->AddRigidBody(
+        "sphere2",
+        SpatialInertia<double>::SolidSphereWithMass(kBodyMasses[2], 1.0));
+    const RigidBody<double>& sphere3 = plant_->AddRigidBody(
+        "sphere3",
+        SpatialInertia<double>::SolidSphereWithMass(kBodyMasses[3], 1.0));
+
+    // Make sphere0 and sphere1 floating and weld sphere2 and sphere3 to world.
+    floating0_ = &plant_->AddJoint<QuaternionFloatingJoint>(
+        "floating0", plant_->world_body(), {}, sphere0, {});
+    floating1_ = &plant_->AddJoint<QuaternionFloatingJoint>(
+        "floating1", plant_->world_body(), {}, sphere1, {});
+    weld2_ =
+        &plant_->AddJoint<WeldJoint>("weld2", plant_->world_body(), {}, sphere2,
+                                     {}, RigidTransformd::Identity());
+    weld3_ =
+        &plant_->AddJoint<WeldJoint>("weld3", plant_->world_body(), {}, sphere3,
+                                     {}, RigidTransformd::Identity());
+
+    // If specified, replace the floating joints with welds.
+    if (replace_joints) {
+      plant_->RemoveJoint(*floating0_);
+      plant_->RemoveJoint(*floating1_);
+      floating0_ = nullptr;
+      floating1_ = nullptr;
+      weld0_ = &plant_->AddJoint<WeldJoint>("weld0", plant_->world_body(), {},
+                                            sphere0, {},
+                                            RigidTransformd::Identity());
+      weld1_ = &plant_->AddJoint<WeldJoint>("weld1", plant_->world_body(), {},
+                                            sphere1, {},
+                                            RigidTransformd::Identity());
+    }
+    plant_->mutable_gravity_field().set_gravity_vector(
+        Vector3d(0.0, 0.0, -kGravity));
+    plant_->Finalize();
+    plant_context_ = plant_->CreateDefaultContext();
+  }
+
+ protected:
+  std::unique_ptr<MultibodyPlant<double>> plant_;
+  std::unique_ptr<Context<double>> plant_context_;
+  const QuaternionFloatingJoint<double>* floating0_{nullptr};
+  const QuaternionFloatingJoint<double>* floating1_{nullptr};
+  const WeldJoint<double>* weld0_{nullptr};
+  const WeldJoint<double>* weld1_{nullptr};
+  const WeldJoint<double>* weld2_{nullptr};
+  const WeldJoint<double>* weld3_{nullptr};
+  // Mass of each body in Kg.
+  const std::array<double, 4> kBodyMasses{1.0, 2.0, 3.0, 4.0};
+  // We round off gravity for simpler numbers.
+  const double kGravity{10.0};  // [m/s²]
+};
+
+TEST_P(WeldedAndFloatingTest, ReactionForcesOrdinalIndexing) {
+  const bool replace_joints = GetParam();
+  const auto& reaction_forces =
+      plant_->get_reaction_forces_output_port()
+          .Eval<std::vector<SpatialForce<double>>>(*plant_context_);
+
+  ASSERT_EQ(reaction_forces.size(), 4);
+  ASSERT_EQ(plant_->num_joints(), 4);
+
+  if (replace_joints) {
+    // Replace the floating joints with welds. This should shift indices around.
+    // We confirm that reaction forces are using the correct indexing from the
+    // joints.
+
+    // Floating joints were replaced with weld joints.
+    EXPECT_FALSE(plant_->HasJointNamed("floating0"));
+    EXPECT_FALSE(plant_->HasJointNamed("floating1"));
+    EXPECT_FALSE(plant_->has_joint(JointIndex(0)));
+    EXPECT_FALSE(plant_->has_joint(JointIndex(1)));
+    EXPECT_TRUE(plant_->HasJointNamed("weld0"));
+    EXPECT_TRUE(plant_->HasJointNamed("weld1"));
+
+    // Because we removed and replaced the floating joints after all four
+    // joints were originally added, they receive joint indices 4 and 5. The
+    // ordinals should have been updated during the removal, so the joints
+    // should be ordered as: ["weld2", "weld3", "weld0", "weld1"] and reaction
+    // forces should correspond to that order.
+    const std::vector<const Joint<double>*> joints{weld0_, weld1_, weld2_,
+                                                   weld3_};
+    const std::vector<JointIndex> expected_indices{
+        JointIndex(4), JointIndex(5), JointIndex(2), JointIndex(3)};
+    const std::vector<int> expected_ordinals{2, 3, 0, 1};
+    for (int i = 0; i < 4; ++i) {
+      EXPECT_EQ(joints[i]->index(), expected_indices[i]);
+      EXPECT_EQ(joints[i]->ordinal(), expected_ordinals[i]);
+
+      // All joints are welded, so we expect the reaction forces to
+      // oppose gravity on the bodies.
+      const SpatialForce<double>& F_Bcm_W =
+          reaction_forces[joints[i]->ordinal()];
+      EXPECT_EQ(F_Bcm_W.translational(),
+                kBodyMasses[i] * kGravity * Vector3d::UnitZ());
+
+      EXPECT_EQ(F_Bcm_W.rotational(), Vector3d::Zero());
+    }
+
+  } else {
+    // Do not replace the floating joints.
+
+    // Joints will have assigned continguous indices and ordinals in the
+    // order they were created.
+    const std::vector<const Joint<double>*> joints{floating0_, floating1_,
+                                                   weld2_, weld3_};
+    const std::vector<JointIndex> expected_indices{
+        JointIndex(0), JointIndex(1), JointIndex(2), JointIndex(3)};
+    const std::vector<int> expected_ordinals{0, 1, 2, 3};
+    for (int i = 0; i < 4; ++i) {
+      EXPECT_EQ(joints[i]->index(), expected_indices[i]);
+      EXPECT_EQ(joints[i]->ordinal(), expected_ordinals[i]);
+
+      const SpatialForce<double>& F_Bcm_W =
+          reaction_forces[joints[i]->ordinal()];
+      if (i < 2) {
+        // Joints for bodies 0 and 1 are floating, so we expect no reaction
+        // forces.
+        EXPECT_EQ(F_Bcm_W.translational(), Vector3d::Zero());
+        EXPECT_EQ(F_Bcm_W.rotational(), Vector3d::Zero());
+      } else {
+        // Joints for bodies 2 and 3 are welded, so we expect the reation
+        // forces to oppose gravity on the bodies.
+        EXPECT_EQ(F_Bcm_W.translational(),
+                  kBodyMasses[i] * kGravity * Vector3d::UnitZ());
+        EXPECT_EQ(F_Bcm_W.rotational(), Vector3d::Zero());
+      }
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ReactionForcesTests, WeldedAndFloatingTest,
+                         testing::ValuesIn({false, true}));
 
 }  // namespace
 }  // namespace multibody

--- a/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
+++ b/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
@@ -157,8 +157,7 @@ class MultibodyPlantReflectedInertiaTests : public ::testing::Test {
 
   void SetArbitraryState(const MultibodyPlant<double>& plant,
                          Context<double>* context) {
-    for (JointIndex joint_index(0); joint_index < plant.num_joints();
-         ++joint_index) {
+    for (JointIndex joint_index : plant.GetJointIndices()) {
       const Joint<double>& joint = plant.get_joint(joint_index);
       // This model only has weld, prismatic, and revolute joints.
       if (joint.type_name() == "revolute") {
@@ -323,14 +322,14 @@ TEST_F(MultibodyPlantReflectedInertiaTests, CalcKineticEnergyAndMomentum) {
   // Have the plant compute its kinetic energy.
   double energy_plant = plant_ri_.CalcKineticEnergy(*context_ri_);
 
-  const double kTolerance = 16.0 * std::numeric_limits<double>::epsilon();
-
-  EXPECT_NEAR(energy_mass_matrix, energy_plant, kTolerance);
+  EXPECT_DOUBLE_EQ(energy_mass_matrix, energy_plant);
 
   // Verify that the spatial momentum for plant_ and plant_ri are equal.
   // Reminder: Although kinetic energy and mass matrix account for reflected
   // inertia, angular momentum does not account for reflected inertia as it
   // depends on internal mechanics of the gear (e.g., number of gear stages).
+
+  const double kTolerance = 16.0 * std::numeric_limits<double>::epsilon();
 
   // Form the systems' spatial momentum in world W about Wo, expressed in W.
   const Vector3<double> p_WoWo_W = Vector3<double>::Zero();

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -35,8 +35,10 @@
 #include "drake/multibody/plant/externally_applied_spatial_force.h"
 #include "drake/multibody/plant/test_utilities/multibody_plant_remodeling.h"
 #include "drake/multibody/test_utilities/add_fixed_objects_to_plant.h"
+#include "drake/multibody/tree/door_hinge.h"
 #include "drake/multibody/tree/planar_joint.h"
 #include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/multibody/tree/prismatic_spring.h"
 #include "drake/multibody/tree/quaternion_floating_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/revolute_spring.h"
@@ -1698,7 +1700,7 @@ GTEST_TEST(MultibodyPlantTest, GetBodiesKinematicallyAffectedBy) {
   // Test throw condition: unregistered joint.
   std::vector<JointIndex> joint100{JointIndex(100)};
   DRAKE_EXPECT_THROWS_MESSAGE(plant.GetBodiesKinematicallyAffectedBy(joint100),
-                              ".*No joint with index.*registered.");
+                              ".*No joint with index.*registered.*removed.");
 }
 
 // Regression test for unhelpful error message -- see #14641.
@@ -2715,7 +2717,7 @@ GTEST_TEST(KukaModel, JointIndexes) {
   // We expect the last joint to be the one WeldJoint fixing the model to the
   // world, since we added it last above with the call to WeldFrames().
   // We verify this assumption.
-  ASSERT_EQ(weld.index(), plant.num_joints() - 1);
+  ASSERT_EQ(weld.index(), plant.GetJointIndices().back());
 
   // Verify we can get the weld joint by name.
   // As documented, a WeldJoint added with WeldFrames() will be named as:
@@ -2729,38 +2731,42 @@ GTEST_TEST(KukaModel, JointIndexes) {
   EXPECT_EQ(weld.num_positions(), 0);
   EXPECT_EQ(weld.num_velocities(), 0);
 
-  // MultibodyPlant orders the state x with the vector q of generalized
-  // positions followed by the vector v of generalized velocities.
-  for (JointIndex joint_index(0);
-       joint_index < plant.num_joints() - 1 /* Skip "weld" joint. */;
-       ++joint_index) {
+  // We know all joints in our model, besides the last joint welding the
+  // model to the world, are revolute joints with the name `iiwa_joint_X`,
+  // where X = [1, 7]. MultibodyPlant gives no guarantees about correlation of
+  // joint indices and state indices. The mapping can be obtained via
+  // MultibodyPlant::StateSelectorMatrix(). However, for this simple model we
+  // know that state indices will be assigned in the same order as joint
+  // indices.
+  std::vector<int> q_starts;
+  std::vector<int> v_starts;
+  for (JointIndex joint_index : plant.GetJointIndices()) {
+    // Skip "weld" joint.
+    if (joint_index == weld.index()) continue;
     const Joint<double>& joint = plant.get_joint(joint_index);
-    // Start index in the vector q of generalized positions.
-    const int expected_q_start = joint_index;
-    // Start index in the vector v of generalized velocities.
-    const int expected_v_start = joint_index;
+
     const int expected_num_v = 1;
     const int expected_num_q = 1;
     EXPECT_EQ(joint.num_positions(), expected_num_q);
-    EXPECT_EQ(joint.position_start(), expected_q_start);
     EXPECT_EQ(joint.num_velocities(), expected_num_v);
-    EXPECT_EQ(joint.velocity_start(), expected_v_start);
+    EXPECT_EQ(joint.position_start(), joint.velocity_start());
+    q_starts.push_back(joint.position_start());
+    v_starts.push_back(joint.velocity_start());
 
     // Confirm that the mutable accessor returns the same object.
     Joint<double>& mutable_joint = plant.get_mutable_joint(joint_index);
     EXPECT_EQ(&mutable_joint, &joint);
   }
+  EXPECT_THAT(q_starts, testing::ElementsAre(0, 1, 2, 3, 4, 5, 6));
+  EXPECT_THAT(v_starts, testing::ElementsAre(0, 1, 2, 3, 4, 5, 6));
 
   // Verify that the indexes above point to the right entries in the state
   // stored in the context.
   auto context = plant.CreateDefaultContext();
 
-  for (JointIndex joint_index(1); /* Skip "weld_base_to_world". */
-       joint_index < plant.num_joints(); ++joint_index) {
-    // We know all joints in our model, besides the first joint welding the
-    // model to the world, are revolute joints.
+  for (int joint_number : {1, 2, 3, 4, 5, 6, 7}) {
     const auto& joint = plant.GetJointByName<RevoluteJoint>(
-        "iiwa_joint_" + std::to_string(joint_index));
+        "iiwa_joint_" + std::to_string(joint_number));
 
     // We simply set each entry in the state with the value of its index.
     joint.set_angle(context.get(), joint.position_start());
@@ -2801,6 +2807,8 @@ GTEST_TEST(KukaModel, ActuationMatrix) {
 }
 
 TEST_F(MultibodyPlantRemodeling, MakeActuationMatrix) {
+  BuildModel();
+  DoRemoval(true /* remove actuator */, false /* do not remove joint */);
   FinalizeAndBuild();
 
   // Actuator with index 1 has been removed.
@@ -2823,6 +2831,8 @@ TEST_F(MultibodyPlantRemodeling, MakeActuationMatrix) {
 }
 
 TEST_F(MultibodyPlantRemodeling, MakeActuatorSelectorMatrix) {
+  BuildModel();
+  DoRemoval(true /* remove actuator */, false /* do not remove joint */);
   FinalizeAndBuild();
 
   // Actuator with index 1 ("actuator1") has been removed.
@@ -2846,6 +2856,8 @@ TEST_F(MultibodyPlantRemodeling, MakeActuatorSelectorMatrix) {
 }
 
 TEST_F(MultibodyPlantRemodeling, AddJointActuationForces) {
+  BuildModel();
+  DoRemoval(true /* remove actuator */, false /* do not remove joint */);
   FinalizeAndBuild();
 
   // Actuator with index 1 has been removed.
@@ -2862,6 +2874,187 @@ TEST_F(MultibodyPlantRemodeling, AddJointActuationForces) {
   MultibodyPlantTester::AddJointActuationForces(*plant_, *plant_context_,
                                                 &forces);
   EXPECT_TRUE(CompareMatrices(forces, forces_expected));
+}
+
+TEST_F(MultibodyPlantRemodeling, RemoveJoint) {
+  BuildModel();
+  DoRemoval(true /* remove actuator */, true /* remove joint */);
+  // Before finalize we remove `joint1`. This makes body1 a free
+  // body, but it will not have a joint until after finalize.
+  EXPECT_EQ(plant_->num_joints(), 2);
+  EXPECT_TRUE(plant_->has_joint(JointIndex(0)));
+  EXPECT_FALSE(plant_->has_joint(JointIndex(1)));
+  EXPECT_TRUE(plant_->has_joint(JointIndex(2)));
+  EXPECT_TRUE(plant_->HasJointNamed("joint0"));
+  EXPECT_FALSE(plant_->HasJointNamed("joint1"));
+  EXPECT_TRUE(plant_->HasJointNamed("joint2"));
+  EXPECT_THAT(plant_->GetJointIndices(),
+              testing::ElementsAre(JointIndex(0), JointIndex(2)));
+
+  // Validate that ordinals are assigned and updated contiguously.
+  const Joint<double>& joint0 = plant_->get_joint(JointIndex(0));
+  const Joint<double>& joint2 = plant_->get_joint(JointIndex(2));
+  EXPECT_EQ(joint0.ordinal(), 0);
+  EXPECT_EQ(joint2.ordinal(), 1);
+
+  FinalizeAndBuild();
+
+  // After finalize, `body1` is given a 6-dof joint.
+  // The newly added joint should get the next available joint index.
+  EXPECT_EQ(plant_->num_joints(), 3);
+  EXPECT_TRUE(plant_->has_joint(JointIndex(0)));
+  EXPECT_FALSE(plant_->has_joint(JointIndex(1)));
+  EXPECT_TRUE(plant_->has_joint(JointIndex(2)));
+  EXPECT_TRUE(plant_->has_joint(JointIndex(3)));
+  EXPECT_TRUE(plant_->HasJointNamed("joint0"));
+  EXPECT_FALSE(plant_->HasJointNamed("joint1"));
+  EXPECT_TRUE(plant_->HasJointNamed("joint2"));
+  EXPECT_TRUE(plant_->HasJointNamed("body1"));
+  EXPECT_THAT(
+      plant_->GetJointIndices(),
+      testing::ElementsAre(JointIndex(0), JointIndex(2), JointIndex(3)));
+
+  const QuaternionFloatingJoint<double>& body1_floating_joint =
+      plant_->GetJointByName<QuaternionFloatingJoint>("body1");
+  EXPECT_EQ(body1_floating_joint.index(), JointIndex(3));
+
+  EXPECT_EQ(joint0.ordinal(), 0);
+  EXPECT_EQ(joint2.ordinal(), 1);
+  EXPECT_EQ(body1_floating_joint.ordinal(), 2);
+
+  // Confirm that removed joint logic is preserved after cloning.
+  std::unique_ptr<MultibodyPlant<double>> clone =
+      systems::System<double>::Clone(*plant_);
+  EXPECT_EQ(clone->num_joints(), 3);
+  EXPECT_TRUE(clone->has_joint(JointIndex(0)));
+  EXPECT_FALSE(clone->has_joint(JointIndex(1)));
+  EXPECT_TRUE(clone->has_joint(JointIndex(2)));
+  EXPECT_TRUE(clone->has_joint(JointIndex(3)));
+  EXPECT_TRUE(clone->HasJointNamed("joint0"));
+  EXPECT_FALSE(clone->HasJointNamed("joint1"));
+  EXPECT_TRUE(clone->HasJointNamed("joint2"));
+  EXPECT_TRUE(clone->HasJointNamed("body1"));
+  EXPECT_THAT(
+      clone->GetJointIndices(),
+      testing::ElementsAre(JointIndex(0), JointIndex(2), JointIndex(3)));
+  EXPECT_EQ(clone->get_joint(JointIndex(0)).ordinal(), 0);
+  EXPECT_EQ(clone->get_joint(JointIndex(2)).ordinal(), 1);
+  EXPECT_EQ(clone->get_joint(JointIndex(3)).ordinal(), 2);
+}
+
+TEST_F(MultibodyPlantRemodeling, RemoveAndReplaceJoint) {
+  BuildModel();
+  DoRemoval(true /* remove actuator */, true /* remove joint */);
+  constexpr int num_replacements = 100;
+  // Exercise replacement of the joint multiple times. Each time will result
+  // in a new joint index, it's ordinal should remain the same.
+  for (int i = 1; i < num_replacements; ++i) {
+    const RevoluteJoint<double>& joint1 = plant_->AddJoint<RevoluteJoint>(
+        "joint1", plant_->GetBodyByName("body0"), {},
+        plant_->GetBodyByName("body1"), {}, Vector3d::UnitZ());
+    EXPECT_EQ(joint1.index(), JointIndex(2 + i));
+    EXPECT_EQ(joint1.ordinal(), 2);
+    plant_->RemoveJoint(joint1);
+  }
+
+  // Replace the joint with a different joint type.
+  const WeldJoint<double>& joint1 = plant_->AddJoint<WeldJoint>(
+      "joint1", plant_->GetBodyByName("body0"), {},
+      plant_->GetBodyByName("body1"), {}, RigidTransformd::Identity());
+  EXPECT_EQ(joint1.index(), JointIndex(2 + num_replacements));
+
+  // Check expected plant invariants.
+  EXPECT_EQ(plant_->num_joints(), 3);
+  EXPECT_TRUE(plant_->has_joint(JointIndex(0)));
+  EXPECT_TRUE(plant_->has_joint(JointIndex(2)));
+  EXPECT_TRUE(plant_->has_joint(JointIndex(2 + num_replacements)));
+  EXPECT_TRUE(plant_->HasJointNamed("joint0"));
+  EXPECT_TRUE(plant_->HasJointNamed("joint1"));
+  EXPECT_TRUE(plant_->HasJointNamed("joint2"));
+  EXPECT_THAT(plant_->GetJointIndices(),
+              testing::ElementsAre(JointIndex(0), JointIndex(2),
+                                   JointIndex(2 + num_replacements)));
+  // Validate that ordinals are assigned and updated contiguously.
+  const Joint<double>& joint0 = plant_->get_joint(JointIndex(0));
+  const Joint<double>& joint2 = plant_->get_joint(JointIndex(2));
+  EXPECT_EQ(joint0.ordinal(), 0);
+  EXPECT_EQ(joint2.ordinal(), 1);
+  EXPECT_EQ(joint1.ordinal(), 2);
+
+  FinalizeAndBuild();
+
+  // Check the same invariants post finalize.
+  EXPECT_EQ(plant_->num_joints(), 3);
+  EXPECT_TRUE(plant_->has_joint(JointIndex(0)));
+  EXPECT_TRUE(plant_->has_joint(JointIndex(2)));
+  EXPECT_TRUE(plant_->has_joint(JointIndex(2 + num_replacements)));
+  EXPECT_TRUE(plant_->HasJointNamed("joint0"));
+  EXPECT_TRUE(plant_->HasJointNamed("joint1"));
+  EXPECT_TRUE(plant_->HasJointNamed("joint2"));
+  EXPECT_THAT(plant_->GetJointIndices(),
+              testing::ElementsAre(JointIndex(0), JointIndex(2),
+                                   JointIndex(2 + num_replacements)));
+  EXPECT_EQ(joint0.ordinal(), 0);
+  EXPECT_EQ(joint2.ordinal(), 1);
+  EXPECT_EQ(joint1.ordinal(), 2);
+}
+
+TEST_F(MultibodyPlantRemodeling, RemoveJointWithActuator) {
+  BuildModel();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DoRemoval(false /* do not remove actuator */, true /* remove joint */),
+      "RemoveJoint: joint with index.*has the following dependent model "
+      "elements which must be removed prior to joint removal.*JointActuator.*");
+}
+
+TEST_F(MultibodyPlantRemodeling, RemoveJointWithCoupler) {
+  BuildModel();
+  // Add a coupler constraint between joint0 and joint1 before removal.
+  plant_->AddCouplerConstraint(plant_->GetJointByName<RevoluteJoint>("joint0"),
+                               plant_->GetJointByName<RevoluteJoint>("joint1"),
+                               2.0 /* gear ratio */, 1.0 /* offset */);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DoRemoval(true /* remove actuator */, true /* remove joint */),
+      "RemoveJoint: This plant has 1 user-added constraints. This plant must "
+      "have 0 user-added constraints in order to remove joint with index.*");
+}
+
+TEST_F(MultibodyPlantRemodeling, RemoveJointWithDoorHinge) {
+  BuildModel();
+  // Add a DoorHinge with joint1 before removal.
+  plant_->AddForceElement<DoorHinge>(
+      plant_->GetJointByName<RevoluteJoint>("joint1"), DoorHingeConfig());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DoRemoval(true /* remove actuator */, true /* remove joint */),
+      "RemoveJoint: This plant has 1 user-added force elements. This plant "
+      "must have 0 user-added force elements in order to remove joint with "
+      "index.*");
+}
+
+TEST_F(MultibodyPlantRemodeling, RemoveJointWithRevoluteSpring) {
+  BuildModel();
+  // Add a RevoluteSpring with joint1 before removal.
+  plant_->AddForceElement<RevoluteSpring>(
+      plant_->GetJointByName<RevoluteJoint>("joint1"), 0 /* nominal angle */,
+      10 /* stiffness */);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DoRemoval(true /* remove actuator */, true /* remove joint */),
+      "RemoveJoint: This plant has 1 user-added force elements. This plant "
+      "must have 0 user-added force elements in order to remove joint with "
+      "index.*");
+}
+
+TEST_F(MultibodyPlantRemodeling, RemoveJointWithPrismaticSpring) {
+  BuildModel<PrismaticJoint>();
+  // Add a PrismaticSpring with joint1 before removal.
+  plant_->AddForceElement<PrismaticSpring>(
+      plant_->GetJointByName<PrismaticJoint>("joint1"), 0 /* nominal angle */,
+      10 /* stiffness */);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DoRemoval(true /* remove actuator */, true /* remove joint */),
+      "RemoveJoint: This plant has 1 user-added force elements. This plant "
+      "must have 0 user-added force elements in order to remove joint with "
+      "index.*");
 }
 
 // Unit test fixture for a model of Kuka Iiwa arm parametrized on the periodic
@@ -2889,7 +3082,7 @@ class KukaArmTest : public ::testing::TestWithParam<double> {
     // We expect the last joint to be the one WeldJoint fixing the model to the
     // world, since we added it last above with the call to WeldFrames().
     // We verify this assumption.
-    ASSERT_EQ(weld.index(), plant_->num_joints() - 1);
+    ASSERT_EQ(weld.index(), plant_->GetJointIndices().back());
 
     context_ = plant_->CreateDefaultContext();
   }
@@ -2901,18 +3094,18 @@ class KukaArmTest : public ::testing::TestWithParam<double> {
   // MultibodyTree::get_multibody_state_vector() and its mutable counterpart.
   void SetState(const VectorX<double>& xc) {
     const int nq = plant_->num_positions();
-    for (JointIndex joint_index(0);
-         joint_index < plant_->num_joints() - 1 /* Skip "weld" joint. */;
-         ++joint_index) {
-      // We know all joints in our model, besides the first joint welding the
-      // model to the world, are revolute joints.
+    const JointIndex weld_index = plant_->GetJointIndices().back();
+    for (JointIndex joint_index : plant_->GetJointIndices()) {
+      // Skip "weld" joint.
+      if (joint_index == weld_index) continue;
+
       const auto& joint = plant_->GetJointByName<RevoluteJoint>(
-          "iiwa_joint_" + std::to_string(joint_index + 1));
+          plant_->get_joint(joint_index).name());
 
       // For this simple model we do know the order in which variables are
       // stored in the state vector.
-      const double angle = xc[joint_index];
-      const double angle_rate = xc[nq + joint_index];
+      const double angle = xc[joint.ordinal()];
+      const double angle_rate = xc[nq + joint.ordinal()];
 
       // We simply set each entry in the state with the value of its index.
       joint.set_angle(context_.get(), angle);

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -172,8 +172,7 @@ class KukaIiwaArmTests : public ::testing::Test {
     VectorXd v0(plant.num_velocities());
     VectorXd q0(plant.num_positions());
 
-    for (JointIndex joint_index(0); joint_index < plant.num_joints();
-         ++joint_index) {
+    for (JointIndex joint_index : plant.GetJointIndices()) {
       const Joint<double>& joint = plant.get_joint(joint_index);
 
       if (joint.num_velocities() == 1) {  // skip welds in the model.
@@ -288,8 +287,7 @@ class KukaIiwaArmTests : public ::testing::Test {
   // Set arbitrary state, though within joint limits.
   void SetArbitraryState(const MultibodyPlant<double>& plant,
                          Context<double>* context) {
-    for (JointIndex joint_index(0); joint_index < plant.num_joints();
-         ++joint_index) {
+    for (JointIndex joint_index : plant.GetJointIndices()) {
       const Joint<double>& joint = plant.get_joint(joint_index);
       // This model only has weld, prismatic, and revolute joints.
       if (joint.type_name() == "revolute") {
@@ -456,8 +454,7 @@ TEST_F(KukaIiwaArmTests, LimitConstraints) {
   int num_constraints = 0;  // count number of constraints visited.
   // The manager adds limit constraints in the order joints are specified.
   // Therefore we verify the limit constraint for each joint.
-  for (JointIndex joint_index(0); joint_index < plant_.num_joints();
-       ++joint_index) {
+  for (JointIndex joint_index : plant_.GetJointIndices()) {
     const Joint<double>& joint = plant_.get_joint(joint_index);
     if (joint.num_velocities() == 1) {
       const int v_index = joint.velocity_start();

--- a/multibody/plant/test/sap_driver_test.cc
+++ b/multibody/plant/test/sap_driver_test.cc
@@ -510,6 +510,8 @@ GTEST_TEST(SapDriverTest, ConstraintActiveStatus) {
 }
 
 TEST_F(MultibodyPlantRemodeling, AddPdControllerConstraints) {
+  BuildModel();
+  DoRemoval(true /* remove actuator */, false /* do not remove joint */);
   // Set up actuators with pd controllers.
   for (JointActuatorIndex actuator_index : plant_->GetJointActuatorIndices()) {
     JointActuator<double>& actuator =

--- a/multibody/plant/test_utilities/multibody_plant_remodeling.cc
+++ b/multibody/plant/test_utilities/multibody_plant_remodeling.cc
@@ -1,7 +1,7 @@
 #include "drake/multibody/plant/test_utilities/multibody_plant_remodeling.h"
 
 #include "drake/multibody/plant/multibody_plant_config_functions.h"
-#include "drake/multibody/tree/revolute_joint.h"
+#include "drake/multibody/tree/prismatic_joint.h"
 
 namespace drake {
 namespace multibody {
@@ -10,7 +10,8 @@ using Eigen::Vector3d;
 using systems::DiagramBuilder;
 using systems::Simulator;
 
-void MultibodyPlantRemodeling::SetUp() {
+template <template <typename> class JointType>
+void MultibodyPlantRemodeling::BuildModel() {
   builder_ = std::make_unique<DiagramBuilder<double>>();
   MultibodyPlantConfig config = {.time_step = kTimeStep,
                                  .discrete_contact_approximation = "sap"};
@@ -19,24 +20,32 @@ void MultibodyPlantRemodeling::SetUp() {
   plant_->AddRigidBody("body0", SpatialInertia<double>::MakeUnitary());
   plant_->AddRigidBody("body1", SpatialInertia<double>::MakeUnitary());
   plant_->AddRigidBody("body2", SpatialInertia<double>::MakeUnitary());
-  plant_->AddJoint<RevoluteJoint>("joint0", plant_->world_body(), {},
-                                  plant_->GetBodyByName("body0"), {},
-                                  Vector3d::UnitZ());
-  plant_->AddJoint<RevoluteJoint>("joint1", plant_->GetBodyByName("body0"), {},
-                                  plant_->GetBodyByName("body1"), {},
-                                  Vector3d::UnitZ());
-  plant_->AddJoint<RevoluteJoint>("joint2", plant_->GetBodyByName("body1"), {},
-                                  plant_->GetBodyByName("body2"), {},
-                                  Vector3d::UnitZ());
-  plant_->AddJointActuator("actuator0",
-                           plant_->GetJointByName<RevoluteJoint>("joint0"), 1);
-  plant_->AddJointActuator("actuator1",
-                           plant_->GetJointByName<RevoluteJoint>("joint1"), 1);
-  plant_->AddJointActuator("actuator2",
-                           plant_->GetJointByName<RevoluteJoint>("joint2"), 1);
+  plant_->template AddJoint<JointType>("joint0", plant_->world_body(), {},
+                                       plant_->GetBodyByName("body0"), {},
+                                       Vector3d::UnitZ());
+  plant_->template AddJoint<JointType>("joint1", plant_->GetBodyByName("body0"),
+                                       {}, plant_->GetBodyByName("body1"), {},
+                                       Vector3d::UnitZ());
+  plant_->template AddJoint<JointType>("joint2", plant_->GetBodyByName("body1"),
+                                       {}, plant_->GetBodyByName("body2"), {},
+                                       Vector3d::UnitZ());
+  plant_->AddJointActuator(
+      "actuator0", plant_->template GetJointByName<JointType>("joint0"), 1);
+  plant_->AddJointActuator(
+      "actuator1", plant_->template GetJointByName<JointType>("joint1"), 1);
+  plant_->AddJointActuator(
+      "actuator2", plant_->template GetJointByName<JointType>("joint2"), 1);
+}
 
-  // Remove an actuator in the middle of the array.
-  plant_->RemoveJointActuator(plant_->GetJointActuatorByName("actuator1"));
+void MultibodyPlantRemodeling::DoRemoval(bool remove_actuator,
+                                         bool remove_joint) {
+  if (remove_actuator) {
+    plant_->RemoveJointActuator(plant_->GetJointActuatorByName("actuator1"));
+  }
+
+  if (remove_joint) {
+    plant_->RemoveJoint(plant_->GetJointByName("joint1"));
+  }
 }
 
 void MultibodyPlantRemodeling::FinalizeAndBuild() {
@@ -49,5 +58,9 @@ void MultibodyPlantRemodeling::FinalizeAndBuild() {
   plant_context_ =
       &plant_->GetMyMutableContextFromRoot(&simulator_->get_mutable_context());
 }
+
+template void MultibodyPlantRemodeling::BuildModel<RevoluteJoint>();
+template void MultibodyPlantRemodeling::BuildModel<PrismaticJoint>();
+
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/test_utilities/multibody_plant_remodeling.h
+++ b/multibody/plant/test_utilities/multibody_plant_remodeling.h
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/revolute_joint.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -24,10 +25,17 @@ namespace multibody {
 class MultibodyPlantRemodeling : public ::testing::Test {
  public:
   // This fixture sets up a plant with a serial chain of 3 bodies connected by
-  // revolute joints. An actuator is added to each joint. Then the actuator
-  // controlling `joint1` is removed.
-  void SetUp() override;
+  // joints of the type specified by the type parameter `JointType`. An actuator
+  // is added to each joint.
+  template <template <typename> class JointType = RevoluteJoint>
+  void BuildModel();
 
+  // Must be called afer BuildModel. Removes elements from the plant.
+  // If `remove_actuator` is true, actuator1 will be removed.
+  // If `remove_joint` is true, joint1 will be removed.
+  void DoRemoval(bool remove_actuator, bool remove_joint);
+
+  // Must be called after BuildModel.
   // Finalize the plant, build the diagram and initialize `simulator_`
   void FinalizeAndBuild();
 

--- a/multibody/topology/multibody_graph.h
+++ b/multibody/topology/multibody_graph.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -86,6 +87,10 @@ class MultibodyGraph {
                       const std::string& type, BodyIndex parent_body_index,
                       BodyIndex child_body_index);
 
+  // Removes the Joint with index `joint_index` from the graph.
+  // @throws std::exception if has_joint(joint_index) == false.
+  void RemoveJoint(JointIndex joint_index);
+
   /* Returns the body that corresponds to the world. This body added via the
   first call to AddRigidBody().
   @throws std::exception iff AddRigidBody() was not called even once yet. */
@@ -128,13 +133,16 @@ class MultibodyGraph {
   @see AddRigidBody(), world_index(), world_body_name(). */
   int num_bodies() const;
 
-  /** Returns the number joints added with AddJoint(). */
+  /** Returns the number joints. */
   int num_joints() const;
 
   /* Gets a RigidBody by index. The world body has index world_index().
   @throws std::exception iff `index` does not correspond to a body in this
   graph. */
   const RigidBody& get_body(BodyIndex index) const;
+
+  /* Returns whether this graph contains a joint with index `joint_index`. */
+  bool has_joint(JointIndex joint_index) const;
 
   /* Gets a Joint by index.
   @throws std::exception iff `index` does not correspond to a joint in this
@@ -209,7 +217,12 @@ class MultibodyGraph {
   // bodies_ includes the world body at world_index() with name
   // world_body_name().
   std::vector<RigidBody> bodies_;
-  std::vector<Joint> joints_;
+  // Stores the joints in the graph at their JointIndex. If a nullopt value is
+  // found at index i, then the joint with index i was removed from the graph.
+  std::vector<std::optional<Joint>> joints_;
+
+  // Keeps track of the number of non-nullopt entries in `joints_`
+  int num_joints_{0};
 
   std::unordered_map<std::string, JointTypeIndex> joint_type_name_to_index_;
 
@@ -237,10 +250,6 @@ class MultibodyGraph::RigidBody {
   /* @returns its name, unique within model_instance(). */
   const std::string& name() const { return name_; }
 
-  /* Returns the total number of joints that have `this` body as either the
-  parent or child body in a Joint. */
-  int num_joints() const;
-
   /* @returns all the joints that connect to `this` body. */
   const std::vector<JointIndex>& joints() const { return joints_; }
 
@@ -254,6 +263,8 @@ class MultibodyGraph::RigidBody {
 
   // Notes that this body is connected by `joint`.
   void add_joint(JointIndex joint) { joints_.push_back(joint); }
+
+  void RemoveJoint(JointIndex joint) { std::erase(joints_, joint); }
 
   BodyIndex index_;
   std::string name_;

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -178,6 +178,18 @@ class Joint : public MultibodyElement<T> {
   /// Returns this element's unique index.
   JointIndex index() const { return this->template index_impl<JointIndex>(); }
 
+  /// Returns this element's unique ordinal. The joint's ordinal is a unique
+  /// index into contiguous containers that have an entry for each Joint, such
+  /// as the vector valued reaction forces (see
+  /// MultibodyPlant::get_reaction_forces_output_port()). The ordinal value will
+  /// be updated (if needed) when joints are removed from the parent plant so
+  /// that the set of ordinal values is a bijection with [0, num_joints()).
+  /// Ordinals are assigned in the order that joints are added to the plant,
+  /// thus a set of joints sorted by ordinal has the same ordering as if it were
+  /// sorted by JointIndex. If joints have been removed from the plant, do *not*
+  /// use index() to access contiguous containers with entries per Joint.
+  int ordinal() const { return this->ordinal_impl(); }
+
   /// Returns the name of this joint.
   const std::string& name() const { return name_; }
 

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -92,6 +92,12 @@ class MultibodyElement {
     return ElementIndexType{index_};
   }
 
+  /// Returns this element's unique ordinal.
+  int ordinal_impl() const {
+    DRAKE_ASSERT(ordinal_ >= 0);
+    return ordinal_;
+  }
+
   /// Returns a constant reference to the parent MultibodyTree that
   /// owns this element.
   const internal::MultibodyTree<T>& get_parent_tree() const {
@@ -153,6 +159,8 @@ class MultibodyElement {
     parent_tree_ = tree;
   }
 
+  void set_ordinal(int ordinal) { ordinal_ = ordinal; }
+
   void set_model_instance(ModelInstanceIndex model_instance) {
     model_instance_ = model_instance;
   }
@@ -174,6 +182,17 @@ class MultibodyElement {
   // The default index value is *invalid*. This must be set to a valid index
   // value before the element is released to the wild.
   int64_t index_{-1};
+
+  // Keeps track of the index into contiguous containers that have an entry
+  // for each of a concrete MultibodyElement type (Joint, RigidBody, etc.)
+  // Ordinals should be updated upon element removal so that the ordinals always
+  // form a contiguous sequence from 0 to N-1, where N is the number of a
+  // particular element type. Default ordinal value is *invalid*. Concrete
+  // MultibodyElements may choose to not expose this ordinal if not needed (e.g.
+  // if MultibodyPlant does not expose any port that has an entry per concrete
+  // MultibodyElement type.) This must be set to a valid ordinal value before
+  // the element is released to the wild.
+  int ordinal_{-1};
 
   // The default model instance id is *invalid*. This must be set to a
   // valid index value before the element is released to the wild.

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -241,6 +241,7 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
   RegisterJointInGraph(*joint);
 
   joint->set_parent_tree(this, joints_.next_index());
+  joint->set_ordinal(joints_.num_elements());
   JointType<T>* result = joint.get();
   joints_.Add(std::move(joint));
   return *result;
@@ -408,6 +409,7 @@ template <typename FromScalar>
 Joint<T>* MultibodyTree<T>::CloneJointAndAdd(const Joint<FromScalar>& joint) {
   auto joint_clone = joint.CloneToScalar(this);
   joint_clone->set_parent_tree(this, joint.index());
+  joint_clone->set_ordinal(joint.ordinal());
   joint_clone->set_model_instance(joint.model_instance());
   return &joints_.Add(std::move(joint_clone));
 }

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -6,6 +6,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
@@ -118,6 +119,24 @@ const RigidBody<T>& MultibodyTree<T>::AddRigidBody(
   }
 
   return AddRigidBody(name, default_model_instance(), M_BBo_B);
+}
+
+template <typename T>
+void MultibodyTree<T>::RemoveJoint(const Joint<T>& joint) {
+  DRAKE_MBT_THROW_IF_FINALIZED();
+  joint.HasThisParentTreeOrThrow(this);
+  JointIndex joint_index = joint.index();
+  joints_.Remove(joint_index);
+  multibody_graph_.RemoveJoint(joint_index);
+
+  // Update the ordinals for all joints with higher indices than the
+  // one being removed.
+  for (JointIndex index : joints_.indices()) {
+    if (index > joint_index) {
+      Joint<T>& mutable_joint = joints_.get_mutable_element(index);
+      mutable_joint.set_ordinal(mutable_joint.ordinal() - 1);
+    }
+  }
 }
 
 template <typename T>
@@ -690,9 +709,7 @@ void MultibodyTree<T>::CreateJointImplementations() {
   // implementation will therefore change the tree topology. Since topology
   // changes are NOT allowed after Finalize(), joint implementations MUST be
   // assembled BEFORE the tree's topology is finalized.
-  const int num_joints_pre_floating_joints = num_joints();
-  joint_to_mobilizer_.resize(num_joints_pre_floating_joints);
-  for (JointIndex i{0}; i < num_joints_pre_floating_joints; ++i) {
+  for (JointIndex i : GetJointIndices()) {
     auto& joint = joints_.get_mutable_element(i);
     Mobilizer<T>* mobilizer =
         internal::JointImplementationBuilder<T>::Build(&joint, this);
@@ -722,17 +739,12 @@ void MultibodyTree<T>::CreateJointImplementations() {
     // Loop must terminate since there are only a finite number of joints.
     while (HasJointNamed(floating_joint_name, body.model_instance()))
       floating_joint_name = "_" + floating_joint_name;
-
     // The joint's model instance will be the same as body's.
-    this->AddJoint<QuaternionFloatingJoint>(floating_joint_name, world_body(),
-                                            {}, body, {});
-  }
-
-  joint_to_mobilizer_.resize(num_joints());
-  for (JointIndex i{num_joints_pre_floating_joints}; i < num_joints(); ++i) {
-    auto& joint = joints_.get_mutable_element(i);
+    const Joint<T>& joint = this->AddJoint<QuaternionFloatingJoint>(
+        floating_joint_name, world_body(), {}, body, {});
+    Joint<T>& mutable_joint = joints_.get_mutable_element(joint.index());
     Mobilizer<T>* mobilizer =
-        internal::JointImplementationBuilder<T>::Build(&joint, this);
+        internal::JointImplementationBuilder<T>::Build(&mutable_joint, this);
     mobilizer->set_model_instance(joint.model_instance());
     // Record the joint to mobilizer map.
     joint_to_mobilizer_[joint.index()] = mobilizer->index();
@@ -837,7 +849,7 @@ void MultibodyTree<T>::FinalizeInternals() {
 
   // For all floating bodies, route their future default poses queries through
   // its joint representation.
-  for (JointIndex i{0}; i < num_joints(); ++i) {
+  for (JointIndex i : GetJointIndices()) {
     auto& joint = joints_.get_mutable_element(i);
     const RigidBody<T>& body = joint.child_body();
     if (body.is_floating()) {
@@ -861,9 +873,21 @@ void MultibodyTree<T>::Finalize() {
   // MultibodyPlant APIs and therefore registered in the graph. This accounts
   // for the QuaternionFloatingJoint added for each free body that was not
   // explicitly given a parent joint. It is important that this loop happens
-  // AFTER finalizing the tree.
-  for (JointIndex i{multibody_graph_.num_joints()}; i < num_joints(); ++i) {
-    RegisterJointInGraph(get_joint(i));
+  // AFTER finalizing the tree. Because addition and removal of joints is
+  // mirrored in the graph, the indices assigned by the graph should match 1:1
+  // with the indices of the joints in this tree.
+  for (JointIndex i : GetJointIndices()) {
+    if (!multibody_graph_.has_joint(i)) {
+      RegisterJointInGraph(get_joint(i));
+      // sanity check.
+      DRAKE_DEMAND(multibody_graph_.has_joint(i));
+      DRAKE_DEMAND(get_joint(i).parent_body().index().is_valid() &&
+                   multibody_graph_.get_joint(i).parent_body() ==
+                       get_joint(i).parent_body().index());
+      DRAKE_DEMAND(get_joint(i).child_body().index().is_valid() &&
+                   multibody_graph_.get_joint(i).child_body() ==
+                       get_joint(i).child_body().index());
+    }
   }
 }
 
@@ -3623,10 +3647,12 @@ MatrixX<double> MultibodyTree<T>::MakeActuatorSelectorMatrix(
     const std::vector<JointIndex>& user_to_joint_index_map) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
 
-  std::vector<JointActuatorIndex> joint_to_actuator_index(num_joints());
+  // Map of joint ordinal to actuator index for all actuators.
+  std::vector<std::optional<JointActuatorIndex>> joint_to_actuator_index(
+      num_joints());
   for (JointActuatorIndex actuator_index : GetJointActuatorIndices()) {
     const auto& actuator = get_joint_actuator(actuator_index);
-    joint_to_actuator_index[actuator.joint().index()] = actuator_index;
+    joint_to_actuator_index[actuator.joint().ordinal()] = actuator_index;
   }
 
   // Build a list of actuators in the order given by user_to_joint_index_map,
@@ -3635,14 +3661,14 @@ MatrixX<double> MultibodyTree<T>::MakeActuatorSelectorMatrix(
   for (JointIndex joint_index : user_to_joint_index_map) {
     const auto& joint = get_joint(joint_index);
 
-    // If the map has an invalid index then this joint does not have an
-    // actuator.
-    if (!joint_to_actuator_index[joint_index].is_valid()) {
-      throw std::logic_error(
-          "Joint '" + joint.name() + "' does not have an actuator.");
+    // If the joint does not have an actuator.
+    if (!joint_to_actuator_index.at(joint.ordinal()).has_value()) {
+      throw std::logic_error("Joint '" + joint.name() +
+                             "' does not have an actuator.");
     }
 
-    user_to_actuator_index_map.push_back(joint_to_actuator_index[joint_index]);
+    user_to_actuator_index_map.push_back(
+        joint_to_actuator_index.at(joint.ordinal()).value());
   }
 
   return MakeActuatorSelectorMatrix(user_to_actuator_index_map);
@@ -3653,7 +3679,7 @@ VectorX<double> MultibodyTree<T>::GetPositionLowerLimits() const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   Eigen::VectorXd q_lower = Eigen::VectorXd::Constant(
       num_positions(), -std::numeric_limits<double>::infinity());
-  for (JointIndex i{0}; i < num_joints(); ++i) {
+  for (JointIndex i : GetJointIndices()) {
     const auto& joint = get_joint(i);
     q_lower.segment(joint.position_start(), joint.num_positions()) =
         joint.position_lower_limits();
@@ -3666,7 +3692,7 @@ VectorX<double> MultibodyTree<T>::GetPositionUpperLimits() const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   Eigen::VectorXd q_upper = Eigen::VectorXd::Constant(
       num_positions(), std::numeric_limits<double>::infinity());
-  for (JointIndex i{0}; i < num_joints(); ++i) {
+  for (JointIndex i : GetJointIndices()) {
     const auto& joint = get_joint(i);
     q_upper.segment(joint.position_start(), joint.num_positions()) =
         joint.position_upper_limits();
@@ -3679,7 +3705,7 @@ VectorX<double> MultibodyTree<T>::GetVelocityLowerLimits() const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   Eigen::VectorXd v_lower = Eigen::VectorXd::Constant(
       num_velocities(), -std::numeric_limits<double>::infinity());
-  for (JointIndex i{0}; i < num_joints(); ++i) {
+  for (JointIndex i : GetJointIndices()) {
     const auto& joint = get_joint(i);
     v_lower.segment(joint.velocity_start(), joint.num_velocities()) =
         joint.velocity_lower_limits();
@@ -3692,7 +3718,7 @@ VectorX<double> MultibodyTree<T>::GetVelocityUpperLimits() const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   Eigen::VectorXd v_upper = Eigen::VectorXd::Constant(
       num_velocities(), std::numeric_limits<double>::infinity());
-  for (JointIndex i{0}; i < num_joints(); ++i) {
+  for (JointIndex i : GetJointIndices()) {
     const auto& joint = get_joint(i);
     v_upper.segment(joint.velocity_start(), joint.num_velocities()) =
         joint.velocity_upper_limits();
@@ -3705,7 +3731,7 @@ VectorX<double> MultibodyTree<T>::GetAccelerationLowerLimits() const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   Eigen::VectorXd vd_lower = Eigen::VectorXd::Constant(
       num_velocities(), -std::numeric_limits<double>::infinity());
-  for (JointIndex i{0}; i < num_joints(); ++i) {
+  for (JointIndex i : GetJointIndices()) {
     const auto& joint = get_joint(i);
     vd_lower.segment(joint.velocity_start(), joint.num_velocities()) =
         joint.acceleration_lower_limits();
@@ -3718,7 +3744,7 @@ VectorX<double> MultibodyTree<T>::GetAccelerationUpperLimits() const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   Eigen::VectorXd vd_upper = Eigen::VectorXd::Constant(
       num_velocities(), std::numeric_limits<double>::infinity());
-  for (JointIndex i{0}; i < num_joints(); ++i) {
+  for (JointIndex i : GetJointIndices()) {
     const auto& joint = get_joint(i);
     vd_upper.segment(joint.velocity_start(), joint.num_velocities()) =
         joint.acceleration_upper_limits();

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -436,6 +436,9 @@ class MultibodyTree {
       const std::optional<math::RigidTransform<double>>& X_BM,
       Args&&... args);
 
+  // See MultibodyPlant documentation.
+  void RemoveJoint(const Joint<T>& joint);
+
   // Creates and adds a JointActuator model for an actuator acting on a given
   // `joint`.
   // This method returns a constant reference to the actuator just added, which
@@ -602,6 +605,11 @@ class MultibodyTree {
   }
 
   // See MultibodyPlant method.
+  bool has_joint(JointIndex joint_index) const {
+    return joints_.has_element(joint_index);
+  }
+
+  // See MultibodyPlant method.
   const Joint<T>& get_joint(JointIndex joint_index) const {
     return joints_.get_element(joint_index);
   }
@@ -760,6 +768,11 @@ class MultibodyTree {
   std::vector<BodyIndex> GetBodyIndices(ModelInstanceIndex model_instance)
   const;
 
+  // See MultibodyPlant method.
+  const std::vector<JointIndex>& GetJointIndices() const {
+    return joints_.indices();
+  }
+
   // Returns a list of joint indices associated with `model_instance`.
   std::vector<JointIndex> GetJointIndices(ModelInstanceIndex model_instance)
   const;
@@ -858,8 +871,8 @@ class MultibodyTree {
   // Returns the mobilizer model for joint with index `joint_index`. The index
   // is invalid if the joint is not modeled with a mobilizer.
   MobilizerIndex get_joint_mobilizer(JointIndex joint_index) const {
-    DRAKE_DEMAND(joint_index < num_joints());
-    return joint_to_mobilizer_[joint_index];
+    DRAKE_DEMAND(has_joint(joint_index));
+    return joint_to_mobilizer_.at(joint_index);
   }
 
   // @name Model instance accessors
@@ -2232,6 +2245,11 @@ class MultibodyTree {
             tree_clone->owned_force_elements_[0].get());
     DRAKE_DEMAND(tree_clone->gravity_field_ != nullptr);
 
+    // Fill the `joints_` collection with nulls. This is to preserve the
+    // removed index structure of the ElementCollection when adding the clone's
+    // joints.
+    tree_clone->joints_.ResizeToMatch(joints_);
+
     // Since Joint<T> objects are implemented from basic element objects like
     // RigidBody, Mobilizer, ForceElement and Constraint, they are cloned last
     // so that the clones of their dependencies are guaranteed to be available.
@@ -2250,7 +2268,7 @@ class MultibodyTree {
     }
 
     // Register the cloned Joints with the multibody_graph_.
-    for (JointIndex index(0); index < num_joints(); ++index) {
+    for (JointIndex index : GetJointIndices()) {
       tree_clone->RegisterJointInGraph(tree_clone->get_joint(index));
     }
 
@@ -3033,7 +3051,7 @@ class MultibodyTree {
   // joint_index, mobilizer_index = joint_to_mobilizer_[joint_index] maps to the
   // mobilizer model of the joint, or an invalid index if the joint is modeled
   // with constraints instead.
-  std::vector<MobilizerIndex> joint_to_mobilizer_;
+  std::unordered_map<JointIndex, MobilizerIndex> joint_to_mobilizer_;
 
   // Maps the default body poses of all floating bodies AND bodies touched by
   // MultibodyPlant::SetDefaultFreeBodyPose(). During Finalize(), the default

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -88,11 +88,8 @@ void MultibodyTreeSystem<T>::SetDefaultParameters(
         .SetDefaultParameters(parameters);
   }
   // Joints.
-  for (JointIndex joint_index(0); joint_index < tree_->num_joints();
-       ++joint_index) {
-    internal_tree()
-        .get_joint(joint_index)
-        .SetDefaultParameters(parameters);
+  for (JointIndex joint_index : tree_->GetJointIndices()) {
+    internal_tree().get_joint(joint_index).SetDefaultParameters(parameters);
   }
   // JointActuators.
   for (JointActuatorIndex joint_actuator_index :
@@ -151,8 +148,7 @@ void MultibodyTreeSystem<T>::DeclareMultibodyElementParameters() {
         .DeclareParameters(this);
   }
   // Joints.
-  for (JointIndex joint_index(0); joint_index < tree_->num_joints();
-       ++joint_index) {
+  for (JointIndex joint_index : tree_->GetJointIndices()) {
     mutable_tree().get_mutable_joint(joint_index).DeclareParameters(this);
   }
   // JointActuators.

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -162,7 +162,7 @@ std::vector<int> CalcUncontrolledDofsThatKinematicallyAffectTheRobot(
   // don't kinematically affect our robot. Then at the end, we'll return the
   // complement of this set.
   std::vector<const Joint<double>*> controlled_or_unaffecting;
-  for (JointIndex joint_i{0}; joint_i < plant.num_joints(); ++joint_i) {
+  for (JointIndex joint_i : plant.GetJointIndices()) {
     const Joint<double>& joint = plant.get_joint(joint_i);
     // Skip these (or else GetBodiesKinematicallyAffectedBy will throw).
     if (joint.num_positions() == 0) {

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -1326,8 +1326,8 @@ GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
 std::vector<int> GetContinuousRevoluteJointIndices(
     const multibody::MultibodyPlant<double>& plant) {
   std::vector<int> indices;
-  for (int i = 0; i < plant.num_joints(); ++i) {
-    const Joint<double>& joint = plant.get_joint(JointIndex(i));
+  for (JointIndex i : plant.GetJointIndices()) {
+    const Joint<double>& joint = plant.get_joint(i);
     // The first possibility we check for is a revolute joint with no joint
     // limits.
     if (joint.type_name() == "revolute") {


### PR DESCRIPTION
Adds the functionality to remove a joint from a MultibodyPlant pre-finalize and related functionality.

After removal of joints, the set of joint indices for valid joints is no longer contiguous from 0 to `num_joints()`.
Typically legacy code has used numerical loops to cover looping over all joints:
```
for (JointIndex i{0}; i < plant.num_joints(); ++i)
```
Now instead we must use:
```
for (JointIndex index : plant.GetJointIndices())
```

Joint indices have also been used to index ports that have a one entry per-joint (e.g. reaction forces). After removal,
it is no longer valid to use indices, so we introduce a new concept `Joint::port_index()` which will always give the correct index into a input/output port vector for a joint, regardless of whether removal is present.

Note to feature reviewer:
I've split this into two commits, the first containing all of the main implementation (APIs, docs, feature implementation, etc) and the second commit containing just cleanup of parts of Drake that are affected by this change (e.g. the looping mentioned above, etc). This should hopefully ease the review.

### Note for release
This isn't really a breaking change (since no one is removing joints yet) but it makes iterating over the joint indices a dispreferred technique since it won't survive future uses of RemoveJoint(). Please consider mentioning the correct method in the breaking change section. 


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21397)
<!-- Reviewable:end -->
