### PR TITLE
Implement support for slack variables on edges in GraphOfConvexSets

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -424,6 +424,14 @@ class GraphOfConvexSets {
     */
     const VectorX<symbolic::Variable>& xv() const { return v_->x(); }
 
+    /** Creates continuous slack variables for this edge, appending them to
+    an internal vector of existing slack variables. These slack variables
+    can be used in any cost or constraint on this edge only, and allows for
+    modeling more complex costs and constraints.
+     */
+    solvers::VectorXDecisionVariable NewSlackVariables(int rows,
+                                                       const std::string& name);
+
     /** Adds a cost to this edge, described by a symbolic::Expression @p e
     containing *only* elements of xu() and xv() as variables.  For technical
     reasons relating to being able to "turn-off" the cost on inactive edges, all
@@ -578,6 +586,7 @@ class GraphOfConvexSets {
     std::vector<std::pair<solvers::Binding<solvers::Cost>,
                           std::unordered_set<Transcription>>>
         costs_{};
+    solvers::VectorXDecisionVariable slacks_{};
     std::vector<std::pair<solvers::Binding<solvers::Constraint>,
                           std::unordered_set<Transcription>>>
         constraints_;

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1823,6 +1823,107 @@ TEST_F(ThreeBoxes, PositiveSemidefiniteConstraint2) {
   EXPECT_TRUE(sink_->GetSolution(result).hasNaN());
 }
 
+TEST_F(ThreeBoxes, NewSlackVariablesConstruction) {
+  auto s = e_on_->NewSlackVariables(3, "s");
+  ASSERT_EQ(s.size(), 3);
+
+  auto t = e_off_->NewSlackVariables(6, "t");
+  ASSERT_EQ(t.size(), 6);
+}
+
+TEST_F(ThreeBoxes, NewSlackVariablesCost) {
+  // We minimize the cost 1/x for each coordinate x, y in the source
+  // vertex, which we formulate with a slack variable and a
+  // RotatedLorentzConeConstraint as:
+  // min 1/x
+  // ⇔ min s st. s ≥ 1/x
+  // ⇔ min s st. s * x ≥ 1
+  // ⇔ min s st. [s; x; 1] ∈ RotatedLorentzCone
+  auto x = e_on_->xu()[0];
+  auto s = e_on_->NewSlackVariables(1, "s")[0];
+  e_on_->AddCost(s);
+  Eigen::MatrixXd A(3, 2);
+  // clang-format off
+  A << 1, 0,
+       0, 1,
+       0, 0;
+  // clang-format on
+  Eigen::VectorXd b(3);
+  b << 0, 0, 1;
+  auto constraint =
+      std::make_shared<solvers::RotatedLorentzConeConstraint>(A, b);
+
+  solvers::VectorXDecisionVariable z_1(2);
+  z_1 << s, x;
+  e_on_->AddConstraint(solvers::Binding(constraint, z_1));
+
+  auto y = e_on_->xu()[1];
+  auto t = e_on_->NewSlackVariables(1, "t")[0];
+  e_on_->AddCost(t);
+  solvers::VectorXDecisionVariable z_2(2);
+  z_2 << t, y;
+  e_on_->AddConstraint(solvers::Binding(constraint, z_2));
+
+  // We minimize the cost max(1/x, 1/y) for the x and y coordinate in the
+  // target vertex, which we formulate with a slack variable and two
+  // RotatedLorentzConeConstraints as:
+  // min max(1/x, 1/y)
+  // ⇔ min k st. k ≥ 1/x, k ≥ 1/y
+  // ⇔ min k st. k * x ≥ 1, k * y ≥ 1
+  // ⇔ min k st. [k; x; 1] ∈ RotatedLorentzCone, [k; y; 1] ∈ RotatedLorentzCone,
+  auto k = e_on_->NewSlackVariables(1, "k")[0];
+  e_on_->AddCost(k);
+
+  auto target_x = e_on_->xv()[0];
+  auto target_y = e_on_->xv()[1];
+
+  // Add a small cost on the point in the target, so that these are kept
+  // at -1 unless another cost affects them.
+  e_on_->AddCost(1e-4 * target_x + 1e-4 * target_y);
+
+  solvers::VectorXDecisionVariable target_z_1(2);
+  target_z_1 << k, target_x;
+  e_on_->AddConstraint(solvers::Binding(constraint, target_z_1));
+
+  solvers::VectorXDecisionVariable target_z_2(2);
+  target_z_2 << k, target_y;
+  e_on_->AddConstraint(solvers::Binding(constraint, target_z_1));
+
+  // First we solve the convex relaxation
+  auto result = g_.SolveShortestPath(*source_, *target_, options_);
+  ASSERT_TRUE(result.is_success());
+
+  auto source_res = source_->GetSolution(result);
+  // Both coordinates should be pushed towards 1
+  ASSERT_TRUE(source_res.isApproxToConstant(1.0, 1e-5));
+
+  auto target_res = target_->GetSolution(result);
+  // We expect that the cost will only push one of the coordinates to the
+  // positive side of the set.
+  ASSERT_NEAR(target_res.maxCoeff(), 1, 1e-5);
+
+  // The other one should still be kept at -1 due to the linear cost added
+  // above.
+  ASSERT_NEAR(target_res.minCoeff(), -1, 1e-5);
+
+  // Next we solve a ConvexRestriction.
+  auto restriction_result = g_.SolveConvexRestriction({e_on_});
+  ASSERT_TRUE(restriction_result.is_success());
+
+  auto restriction_source_res = source_->GetSolution(restriction_result);
+  // Both coordinates should be pushed towards 1
+  ASSERT_TRUE(restriction_source_res.isApproxToConstant(1.0, 1e-4));
+
+  auto restriction_target_res = target_->GetSolution(restriction_result);
+  // We expect that the cost will only push one of the coordinates to the
+  // positive side of the set.
+  ASSERT_NEAR(restriction_target_res.maxCoeff(), 1, 1e-4);
+
+  // The other one should still be kept at -1 due to the linear cost added
+  // above.
+  ASSERT_NEAR(restriction_target_res.minCoeff(), -1, 1e-4);
+}
+
 TEST_F(ThreeBoxes, RotatedLorentzConeConstraint) {
   Eigen::MatrixXd A(5, 4);
   // clang-format off


### PR DESCRIPTION
This addresses https://github.com/RobotLocomotion/drake/issues/21003.

The unit tests implement the two examples from the issue above.

**Note 1:** I named the function `NewSlackVariables`. It could alternatively be called `NewContinuousSlackVariables` to be closer to the naming conventions of the member functions in `MathematicalProgram`.

**Note 2:** I could also add another helper function called `NewSlackVariable` (or `NewContinuousSlackVariable`) (singular, in addition to plural) if we think that would be natural. I imagine that for most use-cases, most people will only add one slack variable at a time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21403)
<!-- Reviewable:end -->
