### PR TITLE
DeformableModel allows scalar conversion

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -922,6 +922,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_geometry_poses_output_port",
             &Class::get_geometry_poses_output_port, py_rvp::reference_internal,
             cls_doc.get_geometry_poses_output_port.doc)
+        .def("get_deformable_body_configuration_output_port",
+            &Class::get_deformable_body_configuration_output_port,
+            py_rvp::reference_internal,
+            cls_doc.get_deformable_body_configuration_output_port.doc)
         .def("geometry_source_is_registered",
             &Class::geometry_source_is_registered,
             cls_doc.geometry_source_is_registered.doc)
@@ -1595,9 +1599,7 @@ PYBIND11_MODULE(plant, m) {
             [](const Class* self, geometry::GeometryId geometry_id) {
               return self->GetBodyId(geometry_id);
             },
-            py::arg("geometry_id"), cls_doc.GetBodyId.doc_1args_geometry_id)
-        .def("vertex_positions_port", &Class::vertex_positions_port,
-            py_rvp::reference_internal, cls_doc.vertex_positions_port.doc);
+            py::arg("geometry_id"), cls_doc.GetBodyId.doc_1args_geometry_id);
   }
   // Deformable identifier.
   {

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -3257,8 +3257,9 @@ class TestPlant(unittest.TestCase):
 
         # Post-finalize operations.
         self.assertIsInstance(
-            dut.vertex_positions_port(), OutputPort_[float])
-        builder.Connect(dut.vertex_positions_port(),
+            plant.get_deformable_body_configuration_output_port(),
+            OutputPort_[float])
+        builder.Connect(plant.get_deformable_body_configuration_output_port(),
                         scene_graph.get_source_configuration_port(
                             plant.get_source_id()))
         self.assertEqual(dut.GetDiscreteStateIndex(body_id), 1)

--- a/examples/multibody/deformable/bubble_gripper.cc
+++ b/examples/multibody/deformable/bubble_gripper.cc
@@ -238,7 +238,7 @@ int do_main() {
    the source configuration port in SceneGraph when deformable bodies are
    present in the plant. */
   builder.Connect(
-      deformable_model->vertex_positions_port(),
+      plant.get_deformable_body_configuration_output_port(),
       scene_graph.get_source_configuration_port(plant.get_source_id().value()));
 
   /* Set the width between the fingers for open and closed states as well as the

--- a/examples/multibody/deformable/deformable_torus.cc
+++ b/examples/multibody/deformable/deformable_torus.cc
@@ -248,8 +248,6 @@ int do_main() {
     owned_deformable_model->AddExternalForce(std::move(suction_force));
   }
 
-  const DeformableModel<double>* deformable_model =
-      owned_deformable_model.get();
   plant.AddPhysicalModel(std::move(owned_deformable_model));
 
   /* All rigid and deformable models have been added. Finalize the plant. */
@@ -259,7 +257,7 @@ int do_main() {
    the source configuration port in SceneGraph when deformable bodies are
    present in the plant. */
   builder.Connect(
-      deformable_model->vertex_positions_port(),
+      plant.get_deformable_body_configuration_output_port(),
       scene_graph.get_source_configuration_port(plant.get_source_id().value()));
 
   /* Add a visualizer that emits LCM messages for visualization. */

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -88,9 +88,10 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "dummy_model",
+    name = "dummy_physical_model",
     testonly = 1,
-    hdrs = ["test/dummy_model.h"],
+    srcs = ["dummy_physical_model.cc"],
+    hdrs = ["dummy_physical_model.h"],
     visibility = ["//visibility:private"],
     deps = [
         ":multibody_plant_core",
@@ -1052,6 +1053,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "deformable_model_test",
     deps = [
+        ":multibody_plant_config_functions",
         ":multibody_plant_core",
         "//common/test_utilities:expect_throws_message",
         "//systems/framework:diagram_builder",
@@ -1172,7 +1174,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "multibody_plant_scalar_conversion_test",
     deps = [
-        ":dummy_model",
+        ":dummy_physical_model",
         ":plant",
     ],
 )
@@ -1211,7 +1213,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "discrete_update_manager_test",
     deps = [
-        ":dummy_model",
+        ":dummy_physical_model",
         ":multibody_plant_config_functions",
         ":multibody_plant_core",
         "//common/test_utilities:eigen_matrix_compare",
@@ -1228,7 +1230,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "physical_model_test",
     deps = [
-        ":dummy_model",
+        ":dummy_physical_model",
         ":multibody_plant_core",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",

--- a/multibody/plant/constraint_specs.h
+++ b/multibody/plant/constraint_specs.h
@@ -133,6 +133,7 @@ struct WeldConstraintSpec {
 // @pre each entry in `vertices` refers to a valid vertex index in deformable
 // body A.
 struct DeformableRigidFixedConstraintSpec {
+  bool operator==(const DeformableRigidFixedConstraintSpec&) const = default;
   DeformableBodyId body_A;    // Index of the deformable body A.
   BodyIndex body_B;           // Index of the rigid body B.
   std::vector<int> vertices;  // Indices of the Pᵢ in the deformable body A.

--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -549,7 +549,8 @@ void DeformableDriver<T>::AppendDeformableRigidFixedConstraintKinematics(
   const MultibodyTreeTopology& tree_topology =
       manager_->internal_tree().get_topology();
   const auto& configurations =
-      deformable_model_->vertex_positions_port()
+      manager_->plant()
+          .get_deformable_body_configuration_output_port()
           .template Eval<geometry::GeometryConfigurationVector<T>>(context);
   for (DeformableBodyIndex index(0); index < deformable_model_->num_bodies();
        ++index) {

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -27,9 +27,24 @@ using fem::DeformableBodyConfig;
 using fem::MaterialModel;
 
 template <typename T>
-DeformableModel<T>::DeformableModel(MultibodyPlant<T>* plant) : plant_(plant) {
-  DRAKE_DEMAND(plant_ != nullptr);
-  DRAKE_DEMAND(!plant_->is_finalized());
+DeformableModel<T>::DeformableModel(MultibodyPlant<T>* plant)
+    : PhysicalModel<T>(plant) {
+  /* Declare the deformable body configuration output port. This port copies the
+   discrete states of all deformable body configurations and put it into a
+   format that's easier for downstream parsing. */
+  configuration_output_port_index_ =
+      this->DeclareAbstractOutputPort(
+              "deformable_body_configuration",
+              []() {
+                return AbstractValue::Make<
+                    geometry::GeometryConfigurationVector<T>>();
+              },
+              [this](const systems::Context<T>& context,
+                     AbstractValue* output) {
+                this->CopyVertexPositions(context, output);
+              },
+              {systems::System<double>::xd_ticket()})
+          .get_index();
 }
 
 template <typename T>
@@ -37,48 +52,54 @@ DeformableBodyId DeformableModel<T>::RegisterDeformableBody(
     std::unique_ptr<geometry::GeometryInstance> geometry_instance,
     const fem::DeformableBodyConfig<T>& config, double resolution_hint) {
   this->ThrowIfSystemResourcesDeclared(__func__);
+  ThrowIfNotDouble(__func__);
+  if constexpr (std::is_same_v<T, double>) {
+    /* Register the geometry with SceneGraph. */
+    SceneGraph<T>& scene_graph = this->mutable_scene_graph();
+    SourceId source_id = this->plant()->get_source_id().value();
+    /* All deformable bodies are registered with the world frame at the moment.
+     */
+    const FrameId world_frame_id = scene_graph.world_frame_id();
 
-  /* Register the geometry with SceneGraph. */
-  SceneGraph<T>& scene_graph = this->mutable_scene_graph(plant_);
-  SourceId source_id = plant_->get_source_id().value();
-  /* All deformable bodies are registered with the world frame at the moment. */
-  const FrameId world_frame_id = scene_graph.world_frame_id();
-  // TODO(xuchenhan-tri): Consider allowing users to opt out of illustration
-  // property for the deformable body if that's ever useful.
-  /* If the geometry doesn't have illustration properties, add an empty one so
-   that it can at least be visualized. */
-  if (geometry_instance->illustration_properties() == nullptr) {
-    geometry_instance->set_illustration_properties(
-        geometry::IllustrationProperties{});
+    // TODO(xuchenhan-tri): Consider allowing users to opt out of illustration
+    // property for the deformable body if that's ever useful.
+    /* If the geometry doesn't have illustration properties, add an empty one so
+     that it can at least be visualized. */
+    if (geometry_instance->illustration_properties() == nullptr) {
+      geometry_instance->set_illustration_properties(
+          geometry::IllustrationProperties{});
+    }
+    GeometryId geometry_id = scene_graph.RegisterDeformableGeometry(
+        source_id, world_frame_id, std::move(geometry_instance),
+        resolution_hint);
+    /* Record the reference positions. */
+    const geometry::SceneGraphInspector<T>& inspector =
+        scene_graph.model_inspector();
+    const geometry::VolumeMesh<double>* mesh_G =
+        inspector.GetReferenceMesh(geometry_id);
+    DRAKE_DEMAND(mesh_G != nullptr);
+    const math::RigidTransform<double>& X_WG =
+        inspector.GetPoseInFrame(geometry_id);
+    geometry::VolumeMesh<double> mesh_W = *mesh_G;
+    mesh_W.TransformVertices(X_WG);
+    VectorX<T> reference_position(3 * mesh_W.num_vertices());
+    for (int v = 0; v < mesh_W.num_vertices(); ++v) {
+      reference_position.template segment<3>(3 * v) = mesh_W.vertex(v);
+    }
+
+    const DeformableBodyId body_id = DeformableBodyId::get_new_id();
+    /* Build FEM model for the deformable body. */
+    BuildLinearVolumetricModel(body_id, mesh_W, config);
+
+    /* Do the book-keeping. */
+    reference_positions_.emplace(body_id, std::move(reference_position));
+    body_id_to_geometry_id_.emplace(body_id, geometry_id);
+    geometry_id_to_body_id_.emplace(geometry_id, body_id);
+    body_ids_.emplace_back(body_id);
+    body_id_to_density_prefinalize_.emplace(body_id, config.mass_density());
+    return body_id;
   }
-  GeometryId geometry_id = scene_graph.RegisterDeformableGeometry(
-      source_id, world_frame_id, std::move(geometry_instance), resolution_hint);
-
-  /* Record the reference positions. */
-  const geometry::SceneGraphInspector<T>& inspector =
-      scene_graph.model_inspector();
-  const geometry::VolumeMesh<double>* mesh_G =
-      inspector.GetReferenceMesh(geometry_id);
-  DRAKE_DEMAND(mesh_G != nullptr);
-  const math::RigidTransform<T>& X_WG = inspector.GetPoseInFrame(geometry_id);
-  geometry::VolumeMesh<double> mesh_W = *mesh_G;
-  mesh_W.TransformVertices(X_WG);
-  VectorX<T> reference_position(3 * mesh_W.num_vertices());
-  for (int v = 0; v < mesh_W.num_vertices(); ++v) {
-    reference_position.template segment<3>(3 * v) = mesh_W.vertex(v);
-  }
-
-  const DeformableBodyId body_id = DeformableBodyId::get_new_id();
-  /* Build FEM model for the deformable body. */
-  BuildLinearVolumetricModel(body_id, mesh_W, config);
-
-  /* Do the book-keeping. */
-  reference_positions_.emplace(body_id, std::move(reference_position));
-  body_id_to_geometry_id_.emplace(body_id, geometry_id);
-  geometry_id_to_body_id_.emplace(geometry_id, body_id);
-  body_ids_.emplace_back(body_id);
-  body_id_to_density_prefinalize_.emplace(body_id, config.mass_density());
-  return body_id;
+  DRAKE_UNREACHABLE();
 }
 
 template <typename T>
@@ -117,9 +138,10 @@ MultibodyConstraintId DeformableModel<T>::AddFixedConstraint(
     DeformableBodyId body_A_id, const RigidBody<T>& body_B,
     const math::RigidTransform<double>& X_BA, const geometry::Shape& shape,
     const math::RigidTransform<double>& X_BG) {
+  ThrowIfNotDouble(__func__);
   this->ThrowIfSystemResourcesDeclared(__func__);
   ThrowUnlessRegistered(__func__, body_A_id);
-  if (&plant_->get_body(body_B.index()) != &body_B) {
+  if (&this->plant()->get_body(body_B.index()) != &body_B) {
     throw std::logic_error(
         fmt::format("The rigid body with name {} is not registered with the "
                     "MultibodyPlant owning the deformable model.",
@@ -145,17 +167,17 @@ MultibodyConstraintId DeformableModel<T>::AddFixedConstraint(
       scene_graph.get_query_output_port().Eval<geometry::QueryObject<double>>(
           *context);
   /* The deformable mesh in its geometry frame. */
-  const geometry::VolumeMesh<T>* mesh_A =
-      this->mutable_scene_graph(plant_).model_inspector().GetReferenceMesh(
+  const geometry::VolumeMesh<double>* mesh_A =
+      this->mutable_scene_graph().model_inspector().GetReferenceMesh(
           GetGeometryId(body_A_id));
   int vertex_index = 0;
-  for (const Vector3<T>& p_APi : mesh_A->vertices()) {
+  for (const Vector3<double>& p_APi : mesh_A->vertices()) {
     /* Note that `shape` is also registered in the A frame in the throw-away
      scene graph. */
-    const std::vector<geometry::SignedDistanceToPoint<T>> signed_distances =
-        query.ComputeSignedDistanceToPoint(p_APi);
+    const std::vector<geometry::SignedDistanceToPoint<double>>
+        signed_distances = query.ComputeSignedDistanceToPoint(p_APi);
     DRAKE_DEMAND(ssize(signed_distances) == 1);
-    const T& signed_distance = signed_distances[0].distance;
+    const double signed_distance = signed_distances[0].distance;
     if (signed_distance <= 0.0) {
       spec.vertices.push_back(vertex_index);
       /* Qi is conincident with Pi. */
@@ -188,6 +210,7 @@ template <typename T>
 void DeformableModel<T>::AddExternalForce(
     std::unique_ptr<ForceDensityField<T>> force_density) {
   this->ThrowIfSystemResourcesDeclared(__func__);
+  ThrowIfNotDouble(__func__);
   force_densities_.push_back(std::move(force_density));
 }
 
@@ -248,7 +271,66 @@ DeformableBodyId DeformableModel<T>::GetBodyId(
 }
 
 template <typename T>
-void DeformableModel<T>::BuildLinearVolumetricModel(
+std::unique_ptr<PhysicalModel<double>> DeformableModel<T>::CloneToDouble(
+    MultibodyPlant<double>* plant) const {
+  auto result = std::make_unique<DeformableModel<double>>(plant);
+  /* If this plant is not double, then it's necessarily empty because we don't
+   allow non-empty models yet. In that case, return an empty double model. */
+  if constexpr (!std::is_same_v<T, double>) {
+    DRAKE_DEMAND(this->is_empty());
+  } else {
+    /* Here we step through every member field one by one, in the exact order
+     they are declared in the header, so that a reader could mindlessly compare
+     this function to the private fields, and check that every single field got
+     a mention.
+     For each field, this function will either:
+     1. Copy the field directly.
+     2. Place a disclaimer comment why that field does not need to be copied. */
+
+    result->reference_positions_ = reference_positions_;
+    result->discrete_state_indexes_ = discrete_state_indexes_;
+    result->body_id_to_geometry_id_ = body_id_to_geometry_id_;
+    result->geometry_id_to_body_id_ = geometry_id_to_body_id_;
+    for (const auto& [deformable_id, fem_model] : fem_models_) {
+      result->fem_models_.emplace(deformable_id, fem_model->Clone());
+    }
+    for (const auto& force_density : force_densities_) {
+      result->force_densities_.emplace_back(force_density->Clone());
+    }
+    result->body_index_to_force_densities_ = body_index_to_force_densities_;
+    result->body_id_to_constraint_ids_ = body_id_to_constraint_ids_;
+    /* `body_id_to_density_prefinalize_` is only used pre-finalize, and it
+     should be empty since the source plant is finalized. */
+    DRAKE_DEMAND(body_id_to_density_prefinalize_.empty());
+    result->body_id_to_density_prefinalize_ = body_id_to_density_prefinalize_;
+    result->body_id_to_index_ = body_id_to_index_;
+    result->body_ids_ = body_ids_;
+    result->fixed_constraint_specs_ = fixed_constraint_specs_;
+    result->configuration_output_port_index_ = configuration_output_port_index_;
+  }
+
+  return result;
+}
+
+template <typename T>
+std::unique_ptr<PhysicalModel<AutoDiffXd>>
+DeformableModel<T>::CloneToAutoDiffXd(MultibodyPlant<AutoDiffXd>* plant) const {
+  DRAKE_THROW_UNLESS(is_empty());
+  return std::make_unique<DeformableModel<AutoDiffXd>>(plant);
+}
+
+template <typename T>
+std::unique_ptr<PhysicalModel<symbolic::Expression>>
+DeformableModel<T>::CloneToSymbolic(
+    MultibodyPlant<symbolic::Expression>* plant) const {
+  DRAKE_THROW_UNLESS(is_empty());
+  return std::make_unique<DeformableModel<symbolic::Expression>>(plant);
+}
+
+template <typename T>
+template <typename T1>
+typename std::enable_if_t<std::is_same_v<T1, double>, void>
+DeformableModel<T>::BuildLinearVolumetricModel(
     DeformableBodyId id, const geometry::VolumeMesh<double>& mesh,
     const fem::DeformableBodyConfig<T>& config) {
   if (fem_models_.find(id) != fem_models_.end()) {
@@ -272,8 +354,9 @@ void DeformableModel<T>::BuildLinearVolumetricModel(
 }
 
 template <typename T>
-template <template <typename, int> class Model>
-void DeformableModel<T>::BuildLinearVolumetricModelHelper(
+template <template <typename, int> class Model, typename T1>
+typename std::enable_if_t<std::is_same_v<T1, double>, void>
+DeformableModel<T>::BuildLinearVolumetricModelHelper(
     DeformableBodyId id, const geometry::VolumeMesh<double>& mesh,
     const fem::DeformableBodyConfig<T>& config) {
   constexpr int kNaturalDimension = 3;
@@ -315,9 +398,21 @@ void DeformableModel<T>::BuildLinearVolumetricModelHelper(
 }
 
 template <typename T>
-void DeformableModel<T>::DoDeclareSystemResources(MultibodyPlant<T>* plant) {
-  /* Ensure that the owning plant is the one declaring system resources. */
-  DRAKE_DEMAND(plant == plant_);
+void DeformableModel<T>::DoDeclareSystemResources() {
+  if (!is_empty()) {
+    if (this->plant()->get_discrete_contact_solver() !=
+        DiscreteContactSolver::kSap) {
+      throw std::runtime_error(
+          "DeformableModel is only supported by the SAP contact solver. "
+          "Please use `kSap`, `kLagged`, or `kSimilar` as the discrete contact "
+          "approximation for the MultibodyPlant containing deformable bodies.");
+    }
+    if (!this->plant()->is_discrete()) {
+      throw std::runtime_error(
+          "Deformable body simulation is only supported "
+          "with discrete time MultibodyPlant.");
+    }
+  }
   /* Declare discrete states. */
   for (const auto& [deformable_id, fem_model] : fem_models_) {
     std::unique_ptr<fem::FemState<T>> default_fem_state =
@@ -328,24 +423,9 @@ void DeformableModel<T>::DoDeclareSystemResources(MultibodyPlant<T>* plant) {
     model_state.segment(num_dofs, num_dofs) =
         default_fem_state->GetVelocities();
     model_state.tail(num_dofs) = default_fem_state->GetAccelerations();
-    discrete_state_indexes_.emplace(
-        deformable_id, this->DeclareDiscreteState(plant, model_state));
+    discrete_state_indexes_.emplace(deformable_id,
+                                    this->DeclareDiscreteState(model_state));
   }
-
-  /* Declare the vertex position output port. */
-  vertex_positions_port_index_ =
-      this->DeclareAbstractOutputPort(
-              plant, "vertex_positions",
-              []() {
-                return AbstractValue::Make<
-                    geometry::GeometryConfigurationVector<T>>();
-              },
-              [this](const systems::Context<T>& context,
-                     AbstractValue* output) {
-                this->CopyVertexPositions(context, output);
-              },
-              {systems::System<double>::xd_ticket()})
-          .get_index();
 
   std::sort(body_ids_.begin(), body_ids_.end());
   for (DeformableBodyIndex i(0); i < static_cast<int>(body_ids_.size()); ++i) {
@@ -364,7 +444,7 @@ void DeformableModel<T>::DoDeclareSystemResources(MultibodyPlant<T>* plant) {
   /* Add gravity to each body. */
   for (const auto& [deformable_id, fem_model] : fem_models_) {
     const T& density = body_id_to_density_prefinalize_.at(deformable_id);
-    const Vector3<T>& gravity = plant->gravity_field().gravity_vector();
+    const Vector3<T>& gravity = this->plant()->gravity_field().gravity_vector();
     auto gravity_force =
         std::make_unique<GravityForceField<T>>(gravity, density);
     DeformableBodyIndex index = body_id_to_index_.at(deformable_id);
@@ -377,7 +457,7 @@ void DeformableModel<T>::DoDeclareSystemResources(MultibodyPlant<T>* plant) {
    them. */
   for (std::unique_ptr<ForceDensityField<T>>& force_density :
        force_densities_) {
-    force_density->DeclareSystemResources(plant_);
+    force_density->DeclareSystemResources(this->mutable_plant());
   }
 }
 
@@ -398,16 +478,27 @@ void DeformableModel<T>::CopyVertexPositions(const systems::Context<T>& context,
 }
 
 template <typename T>
-void DeformableModel<T>::ThrowUnlessRegistered(const char* source_method,
+void DeformableModel<T>::ThrowUnlessRegistered(const char* function_name,
                                                DeformableBodyId id) const {
   if (fem_models_.find(id) == fem_models_.end()) {
-    throw std::logic_error(std::string(source_method) +
-                           "(): No deformable body with id " + to_string(id) +
-                           " has been registered.");
+    throw std::logic_error(
+        fmt::format("{}(): No deformable body with id {} has been registered.",
+                    function_name, id));
+  }
+}
+
+template <typename T>
+void DeformableModel<T>::ThrowIfNotDouble(const char* function_name) const {
+  if (!std::is_same_v<T, double>) {
+    throw std::logic_error(
+        fmt::format("Calls to {}() with a DeformableModel of type T != double "
+                    "are not allowed.",
+                    function_name));
   }
 }
 
 }  // namespace multibody
 }  // namespace drake
 
-template class drake::multibody::DeformableModel<double>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::multibody::DeformableModel)

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -62,6 +62,8 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
                                  corresponds to a typical edge length in the
                                  resulting mesh for a primitive shape.
    @pre resolution_hint > 0.
+   @throws std::exception if `this` %DeformableModel is not of scalar type
+   double.
    @throws std::exception if Finalize() has been called on the multibody plant
    owning this deformable model. */
   DeformableBodyId RegisterDeformableBody(
@@ -126,6 +128,8 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
            Sphere.
    @throws std::exception if Finalize() has been called on the multibody plant
            owning this deformable model.
+   @throws std::exception if `this` %DeformableModel is not of scalar type
+           double.
    @throws std::exception if no constraint is added (i.e. no vertex of the
            deformable body is inside the given `shape` with the given poses). */
   MultibodyConstraintId AddFixedConstraint(
@@ -142,6 +146,8 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
 
   /** Registers an external force density field that applies external force to
    all deformable bodies.
+   @throws std::exception if `this` %DeformableModel is not of scalar type
+           double.
    @throws std::exception if Finalize() has been called on the multibody plant
            owning this deformable model. */
   void AddExternalForce(std::unique_ptr<ForceDensityField<T>> external_force);
@@ -222,38 +228,67 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
     return body_id_to_constraint_ids_.at(id);
   }
 
-  /** Returns the output port of the vertex positions for all registered
-   deformable bodies.
-   @throws std::exception if MultibodyPlant::Finalize() has not been called yet.
-  */
-  const systems::OutputPort<T>& vertex_positions_port() const {
-    this->ThrowIfSystemResourcesNotDeclared(__func__);
-    return plant_->get_output_port(vertex_positions_port_index_);
+  /** Returns the output port index of the vertex positions port for all
+   registered deformable bodies. */
+  const systems::OutputPortIndex& configuration_output_port_index() const {
+    return configuration_output_port_index_;
   }
 
+  /** Returns true if there's no deformable body or external force registered to
+   `this` %DeformableModel. */
+  bool is_empty() const {
+    return body_ids_.empty() && force_densities_.empty();
+  }
+
+  bool is_cloneable_to_double() const final { return true; }
+
+  /** Returns true if and only if this %DeformableModel is empty. */
+  bool is_cloneable_to_autodiff() const final { return is_empty(); }
+
+  /** Returns true if and only if this %DeformableModel is empty. */
+  bool is_cloneable_to_symbolic() const final { return is_empty(); }
+
  private:
+  /* Allow different specializations to access each other's private data for
+   scalar conversion. */
+  template <typename U>
+  friend class DeformableModel;
+
   PhysicalModelPointerVariant<T> DoToPhysicalModelPointerVariant() const final {
     return PhysicalModelPointerVariant<T>(this);
   }
 
-  // TODO(xuchenhan-tri): Implement CloneToDouble() and CloneToAutoDiffXd()
-  // and the corresponding is_cloneable methods.
+  std::unique_ptr<PhysicalModel<double>> CloneToDouble(
+      MultibodyPlant<double>* plant) const final;
 
-  void DoDeclareSystemResources(MultibodyPlant<T>* plant) final;
+  /* Since %DeformableModel is only cloneable to AutoDiffXd if the model is
+   empty, the clone simply returns an empty model. */
+  std::unique_ptr<PhysicalModel<AutoDiffXd>> CloneToAutoDiffXd(
+      MultibodyPlant<AutoDiffXd>* plant) const final;
+
+  /* Since %DeformableModel is only cloneable to symbolic if the model is
+   empty, the clone simply returns an empty model. */
+  std::unique_ptr<PhysicalModel<symbolic::Expression>> CloneToSymbolic(
+      MultibodyPlant<symbolic::Expression>* plant) const final;
+
+  void DoDeclareSystemResources() final;
 
   /* Builds a FEM model for the body with `id` with linear tetrahedral elements
    and a single quadrature point. The reference positions as well as the
    connectivity of the elements are given by `mesh`, and physical properties
    such as the material model of the body are given by `config`.
    @throws exception if an FEM model corresponding to `id` already exists. */
-  void BuildLinearVolumetricModel(DeformableBodyId id,
-                                  const geometry::VolumeMesh<double>& mesh,
-                                  const fem::DeformableBodyConfig<T>& config);
+  template <typename T1 = T>
+  typename std::enable_if_t<std::is_same_v<T1, double>, void>
+  BuildLinearVolumetricModel(DeformableBodyId id,
+                             const geometry::VolumeMesh<double>& mesh,
+                             const fem::DeformableBodyConfig<T>& config);
 
-  template <template <class, int> class Model>
-  void BuildLinearVolumetricModelHelper(
-      DeformableBodyId id, const geometry::VolumeMesh<double>& mesh,
-      const fem::DeformableBodyConfig<T>& config);
+  template <template <class, int> class Model, typename T1 = T>
+  typename std::enable_if_t<std::is_same_v<T1, double>, void>
+  BuildLinearVolumetricModelHelper(DeformableBodyId id,
+                                   const geometry::VolumeMesh<double>& mesh,
+                                   const fem::DeformableBodyConfig<T>& config);
 
   /* Copies the vertex positions of all deformable bodies to the output port
    value which is guaranteed to be of type GeometryConfigurationVector. */
@@ -262,11 +297,15 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
 
   /* Helper to throw a useful message if a deformable body with the given `id`
    doesn't exist. */
-  void ThrowUnlessRegistered(const char* source_method,
+  void ThrowUnlessRegistered(const char* function_name,
                              DeformableBodyId id) const;
 
-  /* The MultibodyPlant that owns `this` DeformableModel. */
-  MultibodyPlant<T>* plant_{nullptr};
+  /* Helper to throw a useful message if the given `function_name` is called on
+   a DeformableModel that doesn't have scalar type double. */
+  void ThrowIfNotDouble(const char* function_name) const;
+
+  /* Data members. WARNING: if you add a field here be sure to update
+   CloneToDouble() to make sure all fields are copied. */
   /* The positions of each vertex of deformable body at reference configuration.
    */
   std::unordered_map<DeformableBodyId, VectorX<T>> reference_positions_;
@@ -279,7 +318,7 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
       geometry_id_to_body_id_;
   std::unordered_map<DeformableBodyId, std::unique_ptr<fem::FemModel<T>>>
       fem_models_;
-  /*The collection all external forces. */
+  /* The collection all external forces. */
   std::vector<std::unique_ptr<ForceDensityField<T>>> force_densities_;
   /* body_index_to_force_densities_[i] is the collection of pointers to external
    forces applied to body i. */
@@ -293,7 +332,7 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
   std::vector<DeformableBodyId> body_ids_;
   std::map<MultibodyConstraintId, internal::DeformableRigidFixedConstraintSpec>
       fixed_constraint_specs_;
-  systems::OutputPortIndex vertex_positions_port_index_;
+  systems::OutputPortIndex configuration_output_port_index_;
 };
 
 }  // namespace multibody

--- a/multibody/plant/dummy_physical_model.cc
+++ b/multibody/plant/dummy_physical_model.cc
@@ -1,0 +1,45 @@
+#include "drake/multibody/plant/dummy_physical_model.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+void DummyPhysicalModel<T>::DoDeclareSystemResources() {
+  /* Declares the single group of discrete state. */
+  VectorX<T> model_state(num_dofs_);
+  int dof_offset = 0;
+  for (size_t i = 0; i < discrete_states_.size(); ++i) {
+    const VectorX<T>& s = discrete_states_[i];
+    model_state.segment(dof_offset, s.size()) = s;
+    dof_offset += s.size();
+  }
+  discrete_state_index_ = this->DeclareDiscreteState(model_state);
+
+  /* Declare output ports. */
+  abstract_output_port_ = &this->DeclareAbstractOutputPort(
+      "dummy_abstract_output_port",
+      [=]() {
+        return AbstractValue::Make(model_state);
+      },
+      [this](const systems::Context<T>& context, AbstractValue* output) {
+        VectorX<T>& data = output->get_mutable_value<VectorX<T>>();
+        data = context.get_discrete_state(discrete_state_index_).get_value();
+      },
+      {systems::System<T>::xd_ticket()});
+  vector_output_port_ = &this->DeclareVectorOutputPort(
+      "dummy_vector_output_port", systems::BasicVector<T>(num_dofs_),
+      [this](const systems::Context<T>& context,
+             systems::BasicVector<T>* output) {
+        Eigen::VectorBlock<VectorX<T>> data = output->get_mutable_value();
+        data = context.get_discrete_state(discrete_state_index_).get_value();
+      },
+      {systems::System<T>::xd_ticket()});
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::DummyPhysicalModel)

--- a/multibody/plant/dummy_physical_model.h
+++ b/multibody/plant/dummy_physical_model.h
@@ -1,34 +1,35 @@
 #pragma once
+
 #include <memory>
 #include <vector>
 
-#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/common/default_scalars.h"
 #include "drake/multibody/plant/physical_model.h"
 #include "drake/systems/framework/scalar_conversion_traits.h"
 
 namespace drake {
 namespace multibody {
+
+template <typename T>
+class MultibodyPlant;
+
 namespace internal {
-namespace test {
-using systems::BasicVector;
-using systems::Context;
-using systems::DiscreteStateIndex;
-using systems::OutputPortIndex;
-// TODO(xuchenhan-tri): Rename this class to DummyPhysicalModel.
+
 /* A dummy manager class derived from PhysicalModel for testing
  purpose. This dummy manager declares a single group of discrete state that
  concatenates the state added through `AppendDiscreteState()`. It also declares
  a vector output port that reports this additional state and an abstract output
  port that reports the same state.
- @tparam_nonsymbolic_scalar */
+ @tparam_default_scalar */
 template <typename T>
-class DummyModel final : public PhysicalModel<T> {
+class DummyPhysicalModel final : public PhysicalModel<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DummyModel);
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DummyPhysicalModel);
 
-  DummyModel() = default;
+  explicit DummyPhysicalModel(MultibodyPlant<T>* plant)
+      : PhysicalModel<T>(plant) {}
 
-  ~DummyModel() final = default;
+  ~DummyPhysicalModel() final = default;
 
   /* Appends additional entries to the single group of discrete state with the
    given `model_value`. */
@@ -57,7 +58,7 @@ class DummyModel final : public PhysicalModel<T> {
   /* Allow different specializations to access each other's private data for
    cloning to a different scalar type. */
   template <typename U>
-  friend class DummyModel;
+  friend class DummyPhysicalModel;
 
   /* A dummy stub for PhysicalModelPointerVariant. Here we return a
    std::monostate() as a proxy for an empty model so that a manager's
@@ -66,21 +67,31 @@ class DummyModel final : public PhysicalModel<T> {
     return std::monostate();
   }
 
-  std::unique_ptr<PhysicalModel<double>> CloneToDouble() const final {
-    return CloneToScalar<double>();
+  std::unique_ptr<PhysicalModel<double>> CloneToDouble(
+      MultibodyPlant<double>* plant) const final {
+    return CloneImpl<double>(plant);
   }
 
-  std::unique_ptr<PhysicalModel<AutoDiffXd>> CloneToAutoDiffXd() const final {
-    return CloneToScalar<AutoDiffXd>();
+  std::unique_ptr<PhysicalModel<AutoDiffXd>> CloneToAutoDiffXd(
+      MultibodyPlant<AutoDiffXd>* plant) const final {
+    return CloneImpl<AutoDiffXd>(plant);
+  }
+
+  std::unique_ptr<PhysicalModel<symbolic::Expression>> CloneToSymbolic(
+      MultibodyPlant<symbolic::Expression>* plant) const final {
+    return CloneImpl<symbolic::Expression>(plant);
   }
 
   bool is_cloneable_to_double() const final { return true; }
 
   bool is_cloneable_to_autodiff() const final { return true; }
 
+  bool is_cloneable_to_symbolic() const final { return true; }
+
   template <typename ScalarType>
-  std::unique_ptr<PhysicalModel<ScalarType>> CloneToScalar() const {
-    auto clone = std::make_unique<DummyModel<ScalarType>>();
+  std::unique_ptr<PhysicalModel<ScalarType>> CloneImpl(
+      MultibodyPlant<ScalarType>* plant) const {
+    auto clone = std::make_unique<DummyPhysicalModel<ScalarType>>(plant);
     clone->num_dofs_ = this->num_dofs_;
     clone->discrete_states_.resize(this->discrete_states_.size());
     for (size_t i = 0; i < discrete_states_.size(); ++i) {
@@ -95,44 +106,18 @@ class DummyModel final : public PhysicalModel<T> {
    dummy discrete state: one abstract output port with underlying value type
    VectorX<T> and one plain-old vector port. We can verify the two ports report
    the same results as a sanity check. */
-  void DoDeclareSystemResources(MultibodyPlant<T>* plant) final {
-    /* Declares the single group of discrete state. */
-    VectorX<T> model_state(num_dofs_);
-    int dof_offset = 0;
-    for (size_t i = 0; i < discrete_states_.size(); ++i) {
-      const VectorX<T>& s = discrete_states_[i];
-      model_state.segment(dof_offset, s.size()) = s;
-      dof_offset += s.size();
-    }
-    discrete_state_index_ = this->DeclareDiscreteState(plant, model_state);
-
-    /* Declare output ports. */
-    abstract_output_port_ = &this->DeclareAbstractOutputPort(
-        plant, "dummy_abstract_output_port",
-        [=]() {
-          return AbstractValue::Make(model_state);
-        },
-        [this](const Context<T>& context, AbstractValue* output) {
-          VectorX<T>& data = output->get_mutable_value<VectorX<T>>();
-          data = context.get_discrete_state(discrete_state_index_).get_value();
-        },
-        {systems::System<T>::xd_ticket()});
-    vector_output_port_ = &this->DeclareVectorOutputPort(
-        plant, "dummy_vector_output_port", BasicVector<T>(num_dofs_),
-        [this](const Context<T>& context, BasicVector<T>* output) {
-          auto data = output->get_mutable_value();
-          data = context.get_discrete_state(discrete_state_index_).get_value();
-        },
-        {systems::System<T>::xd_ticket()});
-  }
+  void DoDeclareSystemResources() final;
 
   std::vector<VectorX<T>> discrete_states_{};
   int num_dofs_{0};
   const systems::OutputPort<T>* abstract_output_port_{nullptr};
   const systems::OutputPort<T>* vector_output_port_{nullptr};
-  DiscreteStateIndex discrete_state_index_;
+  systems::DiscreteStateIndex discrete_state_index_;
 };
-}  // namespace test
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::DummyPhysicalModel)

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -403,7 +403,7 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
     // called because `FinalizePlantOnly()` has to allocate system resources
     // requested by physical models.
     for (auto& model : other.physical_models_) {
-      auto cloned_model = model->template CloneToScalar<T>();
+      auto cloned_model = model->template CloneToScalar<T>(this);
       // TODO(xuchenhan-tri): Rework physical model and discrete update manager
       //  to eliminate the requirement on the order that they are called with
       //  respect to Finalize().
@@ -3101,7 +3101,7 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
   // Let external model managers declare their state, cache and ports in
   // `this` MultibodyPlant.
   for (auto& physical_model : physical_models_) {
-    physical_model->DeclareSystemResources(this);
+    physical_model->DeclareSystemResources();
   }
 }
 
@@ -3617,6 +3617,26 @@ template <typename T>
 const systems::InputPort<T>& MultibodyPlant<T>::get_geometry_query_input_port()
     const {
   return systems::System<T>::get_input_port(geometry_query_port_);
+}
+
+template <typename T>
+const OutputPort<T>&
+MultibodyPlant<T>::get_deformable_body_configuration_output_port() const {
+  // TODO(xuchenhan-tri): enforce that there's only ever going to be one
+  // DeformableModel as part of #21355.
+  for (const std::unique_ptr<PhysicalModel<T>>& physical_model :
+       physical_models_) {
+    if (std::holds_alternative<const DeformableModel<T>*>(
+            physical_model->ToPhysicalModelPointerVariant())) {
+      const DeformableModel<T>* deformable_model =
+          std::get<const DeformableModel<T>*>(
+              physical_model->ToPhysicalModelPointerVariant());
+      DRAKE_DEMAND(deformable_model != nullptr);
+      return systems::System<T>::get_output_port(
+          deformable_model->configuration_output_port_index());
+    }
+  }
+  throw std::runtime_error("No deformable body in the plant.");
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -279,6 +279,7 @@ output_ports:
   model_instance_name[i]</em>_generalized_contact_forces'
 - <em style="color:gray">model_instance_name[i]</em>_net_actuation
 - <span style="color:green">geometry_pose</span>
+- <span style="color:green">deformable_body_configuration</span>
 @endsystem
 
 The ports whose names begin with <em style="color:gray">
@@ -1081,6 +1082,16 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// Returns the output port of frames' poses to communicate with a
   /// SceneGraph.
   const systems::OutputPort<T>& get_geometry_poses_output_port() const;
+
+  // TODO(xuchenhan-tri): Remove the throw condition once DeformableModel is
+  //  added by default as part of #21355.
+  /// Returns the output port for vertex positions (configurations), measured
+  /// and expressed in the World frame, of the deformable bodies in `this` plant
+  /// as a GeometryConfigurationVector.
+  /// @throws std::exception if `this` %MultibodyPlant doesn't have a
+  /// DeformableModel. See AddPhysicalModel().
+  const systems::OutputPort<T>& get_deformable_body_configuration_output_port()
+      const;
   /// @} <!-- Input and output ports -->
 
   /// @anchor mbp_construction

--- a/multibody/plant/physical_model.cc
+++ b/multibody/plant/physical_model.cc
@@ -8,14 +8,15 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
-std::unique_ptr<PhysicalModel<double>> PhysicalModel<T>::CloneToDouble() const {
+std::unique_ptr<PhysicalModel<double>> PhysicalModel<T>::CloneToDouble(
+    MultibodyPlant<double>*) const {
   throw std::logic_error(
       "Scalar conversion to double is not supported by this PhysicalModel.");
 }
 
 template <typename T>
-std::unique_ptr<PhysicalModel<AutoDiffXd>> PhysicalModel<T>::CloneToAutoDiffXd()
-    const {
+std::unique_ptr<PhysicalModel<AutoDiffXd>> PhysicalModel<T>::CloneToAutoDiffXd(
+    MultibodyPlant<AutoDiffXd>*) const {
   throw std::logic_error(
       "Scalar conversion to AutoDiffXd is not supported by this "
       "PhysicalModel.");
@@ -23,7 +24,7 @@ std::unique_ptr<PhysicalModel<AutoDiffXd>> PhysicalModel<T>::CloneToAutoDiffXd()
 
 template <typename T>
 std::unique_ptr<PhysicalModel<symbolic::Expression>>
-PhysicalModel<T>::CloneToSymbolic() const {
+PhysicalModel<T>::CloneToSymbolic(MultibodyPlant<symbolic::Expression>*) const {
   throw std::logic_error(
       "Scalar conversion to symbolic::Expression is not supported by this "
       "PhysicalModel.");
@@ -45,39 +46,64 @@ bool PhysicalModel<T>::is_cloneable_to_symbolic() const {
 }
 
 template <typename T>
-geometry::SceneGraph<T>& PhysicalModel<T>::mutable_scene_graph(
-    MultibodyPlant<T>* plant) {
-  return internal::MultibodyPlantModelAttorney<T>::mutable_scene_graph(plant);
+void PhysicalModel<T>::ThrowIfSystemResourcesDeclared(
+    const char* function_name) const {
+  if (owning_plant_ == nullptr) {
+    throw std::logic_error(
+        fmt::format("Calls to {}() after system resources have been declared "
+                    "are not allowed.",
+                    function_name));
+  }
+}
+
+template <typename T>
+void PhysicalModel<T>::ThrowIfSystemResourcesNotDeclared(
+    const char* function_name) const {
+  if (owning_plant_ != nullptr) {
+    throw std::logic_error(
+        fmt::format("Calls to {}() before system resources have been declared "
+                    "are not allowed.",
+                    function_name));
+  }
+}
+
+template <typename T>
+geometry::SceneGraph<T>& PhysicalModel<T>::mutable_scene_graph() {
+  DRAKE_THROW_UNLESS(owning_plant_ != nullptr);
+  return internal::MultibodyPlantModelAttorney<T>::mutable_scene_graph(
+      owning_plant_);
 }
 
 template <typename T>
 systems::DiscreteStateIndex PhysicalModel<T>::DeclareDiscreteState(
-    MultibodyPlant<T>* plant, const VectorX<T>& model_value) {
+    const VectorX<T>& model_value) {
+  DRAKE_THROW_UNLESS(owning_plant_ != nullptr);
   return internal::MultibodyPlantModelAttorney<T>::DeclareDiscreteState(
-      plant, model_value);
+      owning_plant_, model_value);
 }
 
 template <typename T>
 systems::LeafOutputPort<T>& PhysicalModel<T>::DeclareAbstractOutputPort(
-    MultibodyPlant<T>* plant, std::string name,
+    std::string name,
     typename systems::LeafOutputPort<T>::AllocCallback alloc_function,
     typename systems::LeafOutputPort<T>::CalcCallback calc_function,
     std::set<systems::DependencyTicket> prerequisites_of_calc) {
+  DRAKE_THROW_UNLESS(owning_plant_ != nullptr);
   return internal::MultibodyPlantModelAttorney<T>::DeclareAbstractOutputPort(
-      plant, std::move(name), std::move(alloc_function),
+      owning_plant_, std::move(name), std::move(alloc_function),
       std::move(calc_function), std::move(prerequisites_of_calc));
 }
 
 template <typename T>
 systems::LeafOutputPort<T>& PhysicalModel<T>::DeclareVectorOutputPort(
-    MultibodyPlant<T>* plant, std::string name,
-    const systems::BasicVector<T>& model_vector,
+    std::string name, const systems::BasicVector<T>& model_vector,
     typename systems::LeafOutputPort<T>::CalcVectorCallback
         vector_calc_function,
     std::set<systems::DependencyTicket> prerequisites_of_calc) {
+  DRAKE_THROW_UNLESS(owning_plant_ != nullptr);
   return internal::MultibodyPlantModelAttorney<T>::DeclareVectorOutputPort(
-      plant, std::move(name), model_vector, std::move(vector_calc_function),
-      std::move(prerequisites_of_calc));
+      owning_plant_, std::move(name), model_vector,
+      std::move(vector_calc_function), std::move(prerequisites_of_calc));
 }
 
 }  // namespace multibody

--- a/multibody/plant/physical_model.h
+++ b/multibody/plant/physical_model.h
@@ -33,6 +33,7 @@ template <typename T>
 using PhysicalModelPointerVariant =
     std::variant<const DeformableModel<T>*, std::monostate>;
 
+// TODO(xuchenhan-tri): Move PhysicalModel into internal namespace.
 /** (Internal) PhysicalModel provides the functionalities to extend the type of
  physical model of MultibodyPlant. Developers can derive from this
  PhysicalModel to incorporate additional model elements coupled with the
@@ -56,24 +57,54 @@ class PhysicalModel : public internal::ScalarConvertibleComponent<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PhysicalModel);
 
-  PhysicalModel() = default;
+  // TODO(xuchenhan-tri): We should also check that `owning_plant` is not
+  // finalized yet. We can't do that just yet because
+  // MultibodyPlant::is_finalized() currently lies and report true even when
+  // Finalize() is not yet called (e.g. during scalar conversion).
+  /** Constructs a PhysicalModel owned by the given `owning_plant`. The lifespan
+   of the `owning_plant` must outlast `this` PhysicalModel. This PhysicalModel
+   declares System resources from the `owning_plant` in the call to
+   `DeclareSystemResources()` through the call to `MultibodyPlant::Finalize()`.
+   @pre owning_plant != nullptr. */
+  explicit PhysicalModel(MultibodyPlant<T>* owning_plant)
+      : owning_plant_(owning_plant) {
+    DRAKE_DEMAND(owning_plant != nullptr);
+  }
 
   ~PhysicalModel() override = default;
 
-  /** Creates a clone of the concrete PhysicalModel object with the scalar type
-   `ScalarType`. The clone should be a deep copy of the original PhysicalModel
-   with the exception of members overwritten in `DeclareSystemResources()`. This
-   method is meant to be called by the scalar-converting copy constructor of
-   MultibodyPlant only.
-   @tparam_default_scalar */
+  /** (Internal only) Creates a clone of `this` concrete PhysicalModel object
+   with the scalar type `ScalarType` to be owned by the given `plant`. The clone
+   should be a deep copy of the original PhysicalModel with the exception of
+   members overwritten in `DeclareSystemResources()`. This method is meant to be
+   called by the scalar-converting copy constructor of MultibodyPlant only and
+   thus is only called from a finalized MultibodyPlant.
+   @tparam_default_scalar
+   @throw std::exception if plant is nullptr.
+   @throw std::exception if the owning plant of `this` PhysicalModel is
+   not finalized.
+   @param[in] plant pointer to the MultibodyPlant owning the clone. This needs
+   to be a mutable pointer because the constructor of the clone requires a
+   mutable pointer to the owning plant.
+   @note `DeclareSystemResources()` is not called on the clone and needs to be
+   called from the plant owning the clone. */
   template <typename ScalarType>
-  std::unique_ptr<PhysicalModel<ScalarType>> CloneToScalar() const {
+  std::unique_ptr<PhysicalModel<ScalarType>> CloneToScalar(
+      MultibodyPlant<ScalarType>* plant) const {
+    DRAKE_THROW_UNLESS(plant != nullptr);
+    /* The plant owning `this` PhysicalModel must be finalized and consequently
+     the plant back pointer is nulled out. */
+    if (this->plant() != nullptr) {
+      throw std::logic_error(
+          "The owning plant of the PhysicalModel to be cloned must be "
+          "finalized.");
+    }
     if constexpr (std::is_same_v<ScalarType, double>) {
-      return CloneToDouble();
+      return CloneToDouble(plant);
     } else if constexpr (std::is_same_v<ScalarType, AutoDiffXd>) {
-      return CloneToAutoDiffXd();
+      return CloneToAutoDiffXd(plant);
     } else if constexpr (std::is_same_v<ScalarType, symbolic::Expression>) {
-      return CloneToSymbolic();
+      return CloneToSymbolic(plant);
     }
     DRAKE_UNREACHABLE();
   }
@@ -90,15 +121,14 @@ class PhysicalModel : public internal::ScalarConvertibleComponent<T> {
    symbolic::Expression as a scalar type must override this to return true. */
   bool is_cloneable_to_symbolic() const override;
 
-  /** MultibodyPlant calls this from within Finalize() to declare additional
-   system resources. This method is only meant to be called by MultibodyPlant.
-   We pass in a MultibodyPlant pointer so that derived PhysicalModels can use
-   specific MultibodyPlant cache tickets.
-   @pre plant != nullptr. */
-  void DeclareSystemResources(MultibodyPlant<T>* plant) {
-    DRAKE_DEMAND(plant != nullptr);
-    DoDeclareSystemResources(plant);
-    system_resources_declared_ = true;
+  /** (Internal only) MultibodyPlant calls this from within Finalize() to
+   declare additional system resources. This method is only meant to be called
+   by MultibodyPlant. The pointer to the owning plant is nulled after call to
+   this function. */
+  void DeclareSystemResources() {
+    DRAKE_DEMAND(owning_plant_ != nullptr);
+    DoDeclareSystemResources();
+    owning_plant_ = nullptr;
   }
 
   /** Returns (a const pointer to) the specific model variant of `this`
@@ -109,6 +139,11 @@ class PhysicalModel : public internal::ScalarConvertibleComponent<T> {
   }
 
  protected:
+  /* Returns the back pointer to the MultibodyPlant owning `this`
+   PhysicalModel pre-finalize and nullptr post-finalize. */
+  const MultibodyPlant<T>* plant() const { return owning_plant_; }
+  MultibodyPlant<T>* mutable_plant() { return owning_plant_; }
+
   /* Derived classes must override this function to return their specific model
    variant. */
   virtual PhysicalModelPointerVariant<T> DoToPhysicalModelPointerVariant()
@@ -118,76 +153,66 @@ class PhysicalModel : public internal::ScalarConvertibleComponent<T> {
    type must implement this so that it creates a copy of the object with double
    as the scalar type. It should copy all members except for those overwritten
    in `DeclareSystemResources()`. */
-  virtual std::unique_ptr<PhysicalModel<double>> CloneToDouble() const;
+  virtual std::unique_ptr<PhysicalModel<double>> CloneToDouble(
+      MultibodyPlant<double>* plant) const;
 
   /* Derived classes that support making a clone that uses AutoDiffXd as a
    scalar type must implement this so that it creates a copy of the object with
    AutoDiffXd as the scalar type. It should copy all members except for those
    overwritten in `DeclareSystemResources()`. */
-  virtual std::unique_ptr<PhysicalModel<AutoDiffXd>> CloneToAutoDiffXd() const;
+  virtual std::unique_ptr<PhysicalModel<AutoDiffXd>> CloneToAutoDiffXd(
+      MultibodyPlant<AutoDiffXd>* plant) const;
 
   /* Derived classes that support making a clone that uses symbolic::Expression
    as a scalar type must implement this so that it creates a copy of the object
    with symbolic::Expression as the scalar type. It should copy all members
    except for those overwritten in `DeclareSystemResources()`. */
-  virtual std::unique_ptr<PhysicalModel<symbolic::Expression>> CloneToSymbolic()
-      const;
+  virtual std::unique_ptr<PhysicalModel<symbolic::Expression>> CloneToSymbolic(
+      MultibodyPlant<symbolic::Expression>* plant) const;
 
   /* Derived class must override this to declare system resources for its
    specific model. */
-  virtual void DoDeclareSystemResources(MultibodyPlant<T>* plant) = 0;
+  virtual void DoDeclareSystemResources() = 0;
 
   /* Helper method for throwing an exception within public methods that should
    not be called after system resources are declared. The invoking method should
    pass its name so that the error message can include that detail. */
-  void ThrowIfSystemResourcesDeclared(const char* source_method) const {
-    if (system_resources_declared_) {
-      throw std::logic_error(
-          "Calls to '" + std::string(source_method) +
-          "()' after system resources have been declared are not allowed.");
-    }
-  }
+  void ThrowIfSystemResourcesDeclared(const char* function_name) const;
 
   /* Helper method for throwing an exception within public methods that should
    not be called before system resources are declared. The invoking method
    should pass its name so that the error message can include that detail. */
-  void ThrowIfSystemResourcesNotDeclared(const char* source_method) const {
-    if (!system_resources_declared_) {
-      throw std::logic_error(
-          "Calls to '" + std::string(source_method) +
-          "()' before system resources have been declared are not allowed.");
-    }
-  }
+  void ThrowIfSystemResourcesNotDeclared(const char* function_name) const;
 
   /* Returns the SceneGraph with which the given `plant` has been registered.
-   @pre plant != nullptr.
    @pre Finalize() has not been called on `plant`.
    @pre `plant` has been registered with some SceneGraph. */
-  geometry::SceneGraph<T>& mutable_scene_graph(MultibodyPlant<T>* plant);
+  geometry::SceneGraph<T>& mutable_scene_graph();
 
-  /* Protected LeafSystem methods exposed through MultibodyPlant. */
-  static systems::DiscreteStateIndex DeclareDiscreteState(
-      MultibodyPlant<T>* plant, const VectorX<T>& model_value);
+  /* Protected LeafSystem methods exposed through MultibodyPlant.
+   @throws std::exception if called after DeclareSystemResources() has finished.
+  */
+  systems::DiscreteStateIndex DeclareDiscreteState(
+      const VectorX<T>& model_value);
 
-  static systems::LeafOutputPort<T>& DeclareAbstractOutputPort(
-      MultibodyPlant<T>* plant, std::string name,
+  systems::LeafOutputPort<T>& DeclareAbstractOutputPort(
+      std::string name,
       typename systems::LeafOutputPort<T>::AllocCallback alloc_function,
       typename systems::LeafOutputPort<T>::CalcCallback calc_function,
       std::set<systems::DependencyTicket> prerequisites_of_calc = {
           systems::System<T>::all_sources_ticket()});
 
-  static systems::LeafOutputPort<T>& DeclareVectorOutputPort(
-      MultibodyPlant<T>* plant, std::string name,
-      const systems::BasicVector<T>& model_vector,
+  systems::LeafOutputPort<T>& DeclareVectorOutputPort(
+      std::string name, const systems::BasicVector<T>& model_vector,
       typename systems::LeafOutputPort<T>::CalcVectorCallback
           vector_calc_function,
       std::set<systems::DependencyTicket> prerequisites_of_calc = {
           systems::System<T>::all_sources_ticket()});
 
  private:
-  /* Flag to track whether the system resources requested by `this`
-   PhysicalModel have been declared. */
-  bool system_resources_declared_{false};
+  /* Back pointer to the MultibodyPlant owning `this` PhysicalModel. Only valid
+   pre-finalize and nulled out post-finalize. */
+  MultibodyPlant<T>* owning_plant_{nullptr};
 };
 
 }  // namespace multibody

--- a/multibody/plant/test/deformable_boundary_condition_test.cc
+++ b/multibody/plant/test/deformable_boundary_condition_test.cc
@@ -84,7 +84,7 @@ class DeformableIntegrationTest : public ::testing::Test {
     /* Connect visualizer. Useful for when this test is used for debugging. */
     geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
 
-    builder.Connect(model_->vertex_positions_port(),
+    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
                     scene_graph_->get_source_configuration_port(
                         plant_->get_source_id().value()));
 

--- a/multibody/plant/test/deformable_collision_filter_test.cc
+++ b/multibody/plant/test/deformable_collision_filter_test.cc
@@ -95,7 +95,7 @@ class DeformableCollisionFilterTest : public ::testing::Test {
 
     plant_->Finalize();
 
-    builder.Connect(model_->vertex_positions_port(),
+    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
                     scene_graph_->get_source_configuration_port(
                         plant_->get_source_id().value()));
 

--- a/multibody/plant/test/deformable_contact_results_test.cc
+++ b/multibody/plant/test/deformable_contact_results_test.cc
@@ -55,7 +55,6 @@ GTEST_TEST(CompliantContactManagerTest, ContactResultsWithDeformable) {
                                   point_proximity_properties);
 
   auto deformable_model = std::make_unique<DeformableModel<double>>(&plant);
-  const DeformableModel<double>* model = deformable_model.get();
   /* Add a deformable sphere that collides with the ground but not with any
    other rigid bodies. */
   auto deformable_geometry = std::make_unique<GeometryInstance>(
@@ -73,7 +72,7 @@ GTEST_TEST(CompliantContactManagerTest, ContactResultsWithDeformable) {
   plant.AddPhysicalModel(std::move(deformable_model));
   plant.Finalize();
   builder.Connect(
-      model->vertex_positions_port(),
+      plant.get_deformable_body_configuration_output_port(),
       scene_graph.get_source_configuration_port(plant.get_source_id().value()));
 
   auto diagram = builder.Build();

--- a/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_kinematics_test.cc
@@ -166,7 +166,7 @@ class DeformableDriverContactKinematicsTest
     driver_ = manager_->deformable_driver();
     DRAKE_DEMAND(driver_ != nullptr);
 
-    builder.Connect(model_->vertex_positions_port(),
+    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
                     scene_graph_->get_source_configuration_port(
                         plant_->get_source_id().value()));
     diagram_ = builder.Build();
@@ -238,7 +238,7 @@ class DeformableDriverContactKinematicsTest
     driver_ = manager_->deformable_driver();
     DRAKE_DEMAND(driver_ != nullptr);
 
-    builder.Connect(model_->vertex_positions_port(),
+    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
                     scene_graph_->get_source_configuration_port(
                         plant_->get_source_id().value()));
     diagram_ = builder.Build();
@@ -633,7 +633,7 @@ GTEST_TEST(DeformableDriverContactKinematicsWithBcTest,
   ASSERT_NE(driver, nullptr);
 
   builder.Connect(
-      model->vertex_positions_port(),
+      plant.get_deformable_body_configuration_output_port(),
       scene_graph.get_source_configuration_port(plant.get_source_id().value()));
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
@@ -691,7 +691,7 @@ GTEST_TEST(DeformableDriverConstraintParticipation, ConstraintWithoutContact) {
   // TODO(xuchenhan-tri): AddMultibodyPlant and AddMultibodyPlantSceneGraph
   // should connect this port automatically.
   builder.Connect(
-      model->vertex_positions_port(),
+      plant.get_deformable_body_configuration_output_port(),
       scene_graph.get_source_configuration_port(plant.get_source_id().value()));
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();

--- a/multibody/plant/test/deformable_driver_contact_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_test.cc
@@ -90,7 +90,7 @@ class DeformableDriverContactTest : public ::testing::Test {
     driver_ = manager_->deformable_driver();
     DRAKE_DEMAND(driver_ != nullptr);
 
-    builder.Connect(model_->vertex_positions_port(),
+    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
                     scene_graph_->get_source_configuration_port(
                         plant_->get_source_id().value()));
     diagram_ = builder.Build();

--- a/multibody/plant/test/deformable_driver_test.cc
+++ b/multibody/plant/test/deformable_driver_test.cc
@@ -50,7 +50,7 @@ class DeformableDriverTest : public ::testing::Test {
     driver_ = manager_->deformable_driver();
     DRAKE_DEMAND(driver_ != nullptr);
 
-    builder.Connect(model_->vertex_positions_port(),
+    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
                     scene_graph_->get_source_configuration_port(
                         plant_->get_source_id().value()));
     diagram_ = builder.Build();

--- a/multibody/plant/test/deformable_fixed_constraint_test.cc
+++ b/multibody/plant/test/deformable_fixed_constraint_test.cc
@@ -119,7 +119,7 @@ class DeformableFixedConstraintTest : public ::testing::Test {
     /* Connect visualizer. Useful for when this test is used for debugging. */
     geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
 
-    builder.Connect(model_->vertex_positions_port(),
+    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
                     scene_graph_->get_source_configuration_port(
                         plant_->get_source_id().value()));
 

--- a/multibody/plant/test/deformable_integration_test.cc
+++ b/multibody/plant/test/deformable_integration_test.cc
@@ -101,7 +101,7 @@ class DeformableIntegrationTest : public ::testing::Test {
     /* Connect visualizer. Useful for when this test is used for debugging. */
     geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
 
-    builder.Connect(model_->vertex_positions_port(),
+    builder.Connect(plant_->get_deformable_body_configuration_output_port(),
                     scene_graph_->get_source_configuration_port(
                         plant_->get_source_id().value()));
 
@@ -224,7 +224,7 @@ TEST_F(DeformableIntegrationTest, SteadyState) {
   F_Ac_W_expected.SetZero();
   GeometryId deformable_geometry_id = model_->GetGeometryId(body_id_);
   const VectorXd& vertex_positions =
-      model_->vertex_positions_port()
+      plant_->get_deformable_body_configuration_output_port()
           .template Eval<geometry::GeometryConfigurationVector<double>>(
               plant_context)
           .value(deformable_geometry_id);

--- a/multibody/plant/test/deformable_model_test.cc
+++ b/multibody/plant/test/deformable_model_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/multibody_plant_config_functions.h"
 #include "drake/systems/framework/diagram_builder.h"
 
 namespace drake {
@@ -16,6 +17,7 @@ using geometry::GeometryInstance;
 using geometry::SceneGraph;
 using geometry::SceneGraphInspector;
 using geometry::Sphere;
+using math::RigidTransform;
 using math::RigidTransformd;
 using std::make_unique;
 using systems::BasicVector;
@@ -24,8 +26,10 @@ class DeformableModelTest : public ::testing::Test {
  protected:
   void SetUp() override {
     constexpr double kDt = 0.01;
-    std::tie(plant_, scene_graph_) =
-        AddMultibodyPlantSceneGraph(&builder_, kDt);
+    MultibodyPlantConfig plant_config;
+    plant_config.time_step = kDt;
+    plant_config.discrete_contact_approximation = "sap";
+    std::tie(plant_, scene_graph_) = AddMultibodyPlant(plant_config, &builder_);
     auto deformable_model = make_unique<DeformableModel<double>>(plant_);
     deformable_model_ptr_ = deformable_model.get();
     plant_->AddPhysicalModel(std::move(deformable_model));
@@ -40,10 +44,17 @@ class DeformableModelTest : public ::testing::Test {
   /* Registers a deformable sphere with the given initial pose in world. */
   DeformableBodyId RegisterSphere(double resolution_hint,
                                   RigidTransformd X_WS = RigidTransformd()) {
+    return RegisterSphere(deformable_model_ptr_, resolution_hint, X_WS);
+  }
+
+  template <typename T>
+  DeformableBodyId RegisterSphere(DeformableModel<T>* model,
+                                  double resolution_hint,
+                                  RigidTransformd X_WS = RigidTransformd()) {
     auto geometry =
         make_unique<GeometryInstance>(X_WS, make_unique<Sphere>(1), "sphere");
-    DeformableBodyId body_id = deformable_model_ptr_->RegisterDeformableBody(
-        std::move(geometry), default_body_config_, resolution_hint);
+    DeformableBodyId body_id = model->RegisterDeformableBody(
+        std::move(geometry), fem::DeformableBodyConfig<T>{}, resolution_hint);
     return body_id;
   }
 };
@@ -244,10 +255,10 @@ TEST_F(DeformableModelTest, VertexPositionsOutputPort) {
   std::unique_ptr<systems::Context<double>> context =
       plant_->CreateDefaultContext();
   std::unique_ptr<AbstractValue> output_value =
-      deformable_model_ptr_->vertex_positions_port().Allocate();
+      plant_->get_deformable_body_configuration_output_port().Allocate();
   /* Compute the configuration for each geometry in the model. */
-  deformable_model_ptr_->vertex_positions_port().Calc(*context,
-                                                      output_value.get());
+  plant_->get_deformable_body_configuration_output_port().Calc(
+      *context, output_value.get());
   const geometry::GeometryConfigurationVector<double>& configurations =
       output_value->get_value<geometry::GeometryConfigurationVector<double>>();
 
@@ -422,6 +433,140 @@ TEST_F(DeformableModelTest, ExternalForces) {
       EXPECT_EQ(force->EvaluateAt(*plant_context, p_WQ), scale * 3.14 * p_WQ);
     }
   }
+}
+
+TEST_F(DeformableModelTest, CloneBeforeFinalizeThrows) {
+  MultibodyPlant<double> double_plant(0.01);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      deformable_model_ptr_->CloneToScalar<double>(&double_plant),
+      ".*owning plant.*must be finalized.*");
+  plant_->Finalize();
+  EXPECT_NO_THROW(deformable_model_ptr_->CloneToScalar<double>(&double_plant));
+}
+
+/* Test that cloning to other scalar types is allowed when the model is empty.
+ */
+TEST_F(DeformableModelTest, EmptyClone) {
+  /* The plants for the cloned models. */
+  MultibodyPlant<double> double_plant(0.01);
+  MultibodyPlant<AutoDiffXd> autodiff_plant(0.01);
+  MultibodyPlant<symbolic::Expression> symbolic_plant(0.01);
+  /* Plant owning the cloned from models need to be finalized. */
+  plant_->Finalize();
+  EXPECT_TRUE(deformable_model_ptr_->is_empty());
+
+  EXPECT_TRUE(deformable_model_ptr_->is_cloneable_to_double());
+  EXPECT_TRUE(deformable_model_ptr_->is_cloneable_to_autodiff());
+  EXPECT_TRUE(deformable_model_ptr_->is_cloneable_to_symbolic());
+
+  /* double -> double */
+  EXPECT_NO_THROW(deformable_model_ptr_->CloneToScalar<double>(&double_plant));
+  /* double -> autodiff */
+  EXPECT_NO_THROW(
+      deformable_model_ptr_->CloneToScalar<AutoDiffXd>(&autodiff_plant));
+  /* double -> symbolic */
+  EXPECT_NO_THROW(deformable_model_ptr_->CloneToScalar<symbolic::Expression>(
+      &symbolic_plant));
+}
+
+/* Test that, for a non-empty model, only cloning to double is allowed. */
+TEST_F(DeformableModelTest, NonEmptyClone) {
+  /* The plants for the cloned models. */
+  MultibodyPlant<double> double_plant(0.01);
+  MultibodyPlant<AutoDiffXd> autodiff_plant(0.01);
+  MultibodyPlant<symbolic::Expression> symbolic_plant(0.01);
+  /* Make the model non-empty. */
+  DeformableBodyId body_id = RegisterSphere(0.5);
+  const RigidBody<double>& rigid_body =
+      plant_->AddRigidBody("box", SpatialInertia<double>::NaN());
+  geometry::Box box(1.0, 1.0, 1.0);
+  const RigidTransformd X_BA(Vector3d(-2, 0, 0));
+  const RigidTransformd X_BG(Vector3d(-1, 0, 0));
+  const MultibodyConstraintId constraint_id =
+      deformable_model_ptr_->AddFixedConstraint(body_id, rigid_body, X_BA, box,
+                                                X_BG);
+
+  EXPECT_FALSE(deformable_model_ptr_->is_empty());
+  /* Plant owning the cloned from models need to be finalized. */
+  plant_->Finalize();
+
+  EXPECT_TRUE(deformable_model_ptr_->is_cloneable_to_double());
+  EXPECT_FALSE(deformable_model_ptr_->is_cloneable_to_autodiff());
+  EXPECT_FALSE(deformable_model_ptr_->is_cloneable_to_symbolic());
+
+  std::unique_ptr<PhysicalModel<double>> double_clone;
+  /* double -> double */
+  EXPECT_NO_THROW(double_clone = deformable_model_ptr_->CloneToScalar<double>(
+                      &double_plant));
+  /* double -> autodiff */
+  EXPECT_THROW(
+      deformable_model_ptr_->CloneToScalar<AutoDiffXd>(&autodiff_plant),
+      std::exception);
+  /* double -> symbolic */
+  EXPECT_THROW(deformable_model_ptr_->CloneToScalar<symbolic::Expression>(
+                   &symbolic_plant),
+               std::exception);
+
+  /* Now verify the double clone is indeed a copy of the original. */
+  const DeformableModel<double>* double_clone_ptr =
+      dynamic_cast<const DeformableModel<double>*>(double_clone.get());
+  ASSERT_NE(double_clone_ptr, nullptr);
+  EXPECT_EQ(double_clone_ptr->num_bodies(),
+            deformable_model_ptr_->num_bodies());
+  /* We don't compare the result of GetDiscreteStateIndex and GetExternalForces
+   since they are set during DeclareSystemResources(). */
+  EXPECT_EQ(double_clone_ptr->GetFemModel(body_id).num_dofs(),
+            deformable_model_ptr_->GetFemModel(body_id).num_dofs());
+  EXPECT_EQ(double_clone_ptr->GetReferencePositions(body_id),
+            deformable_model_ptr_->GetReferencePositions(body_id));
+  /* We don't compare the result of any function that involves
+   DeformableBodyIndex because it's set during DeclareSystemResources(). */
+  const geometry::GeometryId geometry_id =
+      deformable_model_ptr_->GetGeometryId(body_id);
+  EXPECT_EQ(double_clone_ptr->GetGeometryId(body_id),
+            deformable_model_ptr_->GetGeometryId(body_id));
+  EXPECT_EQ(double_clone_ptr->GetBodyId(geometry_id),
+            deformable_model_ptr_->GetBodyId(geometry_id));
+  EXPECT_EQ(double_clone_ptr->HasConstraint(body_id),
+            deformable_model_ptr_->HasConstraint(body_id));
+  EXPECT_EQ(double_clone_ptr->fixed_constraint_spec(constraint_id),
+            deformable_model_ptr_->fixed_constraint_spec(constraint_id));
+  EXPECT_EQ(double_clone_ptr->fixed_constraint_ids(body_id),
+            deformable_model_ptr_->fixed_constraint_ids(body_id));
+  EXPECT_EQ(double_clone_ptr->configuration_output_port_index(),
+            deformable_model_ptr_->configuration_output_port_index());
+}
+
+/* An empty DeformableModel doesn't get in the way of a TAMSI plant. */
+TEST_F(DeformableModelTest, EmptyDeformableModelWorksWithTamsi) {
+  plant_->set_discrete_contact_approximation(
+      multibody::DiscreteContactApproximation::kTamsi);
+  EXPECT_TRUE(deformable_model_ptr_->is_empty());
+  EXPECT_NO_THROW(plant_->Finalize());
+}
+
+/* If a DeformableModel is not empty, we require the owning plant to use the SAP
+ solver. */
+TEST_F(DeformableModelTest, NonEmptyDeformableModelOnlyWorksWithSap) {
+  plant_->set_discrete_contact_approximation(
+      multibody::DiscreteContactApproximation::kTamsi);
+  RegisterSphere(0.5);
+  EXPECT_FALSE(deformable_model_ptr_->is_empty());
+  DRAKE_EXPECT_THROWS_MESSAGE(plant_->Finalize(),
+                              ".*DeformableModel is only supported by.*SAP.*");
+}
+
+TEST_F(DeformableModelTest, RegistrationNotAllowedForNonDoubleModel) {
+  MultibodyPlant<AutoDiffXd> autodiff_plant(0.01);
+  DeformableModel<AutoDiffXd> autodiff_deformable_model(&autodiff_plant);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      RegisterSphere(&autodiff_deformable_model, 0.5),
+      ".*RegisterDeformableBody.*T != double.*not allowed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      autodiff_deformable_model.AddExternalForce(
+          std::make_unique<GravityForceField<AutoDiffXd>>(Vector3d(0, 0, -10),
+                                                          1.0)),
+      ".*AddExternalForce.*T != double.*not allowed.*");
 }
 
 }  // namespace

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -4,9 +4,9 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/autodiff.h"
 #include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/dummy_physical_model.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/plant/multibody_plant_config_functions.h"
-#include "drake/multibody/plant/test/dummy_model.h"
 #include "drake/multibody/plant/test_utilities/multibody_plant_remodeling.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/systems/analysis/simulator.h"
@@ -106,13 +106,13 @@ class DummyDiscreteUpdateManager final : public DiscreteUpdateManager<T> {
   }
 
   /* Extracts information about the additional discrete state that
-   DummyModel declares if one exists in the owning MultibodyPlant. */
+   DummyPhysicalModel declares if one exists in the owning MultibodyPlant. */
   void DoExtractModelInfo() final {
     /* For unit testing we verify there is a single physical model of type
-     DummyModel. */
+     DummyPhysicalModel. */
     DRAKE_DEMAND(this->plant().physical_models().size() == 1);
-    const auto* dummy_model =
-        dynamic_cast<const DummyModel<T>*>(this->plant().physical_models()[0]);
+    const auto* dummy_model = dynamic_cast<const DummyPhysicalModel<T>*>(
+        this->plant().physical_models()[0]);
     DRAKE_DEMAND(dummy_model != nullptr);
     additional_state_index_ = dummy_model->discrete_state_index();
   }
@@ -195,7 +195,7 @@ class DiscreteUpdateManagerTest : public ::testing::Test {
   void SetUp() override {
     // To avoid unnecessary warnings/errors, use a non-zero spatial inertia.
     plant_.AddRigidBody("rigid body", SpatialInertia<double>::MakeUnitary());
-    auto dummy_model = std::make_unique<DummyModel<double>>();
+    auto dummy_model = std::make_unique<DummyPhysicalModel<double>>(&plant_);
     dummy_model_ = dummy_model.get();
     plant_.AddPhysicalModel(std::move(dummy_model));
     dummy_model_->AppendDiscreteState(dummy_discrete_state());
@@ -216,7 +216,7 @@ class DiscreteUpdateManagerTest : public ::testing::Test {
   MultibodyPlant<double> plant_{kDt};
   // A PhysicalModel to illustrate how physical models and discrete update
   // managers interact.
-  DummyModel<double>* dummy_model_{nullptr};
+  DummyPhysicalModel<double>* dummy_model_{nullptr};
   // The discrete update manager under test.
   DummyDiscreteUpdateManager<double>* dummy_manager_{nullptr};
 };
@@ -274,8 +274,8 @@ TEST_F(DiscreteUpdateManagerTest, ScalarConversion) {
   auto simulator =
       systems::Simulator<AutoDiffXd>(*autodiff_plant, std::move(context));
   ASSERT_EQ(autodiff_plant->physical_models().size(), 1);
-  const DummyModel<AutoDiffXd>* model =
-      dynamic_cast<const DummyModel<AutoDiffXd>*>(
+  const DummyPhysicalModel<AutoDiffXd>* model =
+      dynamic_cast<const DummyPhysicalModel<AutoDiffXd>*>(
           autodiff_plant->physical_models()[0]);
   ASSERT_NE(model, nullptr);
 

--- a/multibody/plant/test/physical_model_test.cc
+++ b/multibody/plant/test/physical_model_test.cc
@@ -1,7 +1,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/plant/dummy_physical_model.h"
 #include "drake/multibody/plant/multibody_plant.h"
-#include "drake/multibody/plant/test/dummy_model.h"
 
 namespace drake {
 namespace multibody {
@@ -19,7 +19,7 @@ class PhysicalModelTest : public ::testing::Test {
  protected:
   void SetUp() override {
     // TODO(xuchenhan-tri): Add a test with more than one physical model.
-    auto dummy_model = std::make_unique<DummyModel<double>>();
+    auto dummy_model = std::make_unique<DummyPhysicalModel<double>>(&plant_);
     dummy_model_ = dummy_model.get();
     plant_.AddPhysicalModel(std::move(dummy_model));
     // An artificial scenario where the state is added in multiple passes.
@@ -36,8 +36,9 @@ class PhysicalModelTest : public ::testing::Test {
     return VectorXd::Ones(kState2Dofs) * kState2Value;
   }
 
-  MultibodyPlant<double> plant_{kDt};         // A discrete MbP.
-  DummyModel<double>* dummy_model_{nullptr};  // The PhysicalModel under test.
+  MultibodyPlant<double> plant_{kDt};  // A discrete MbP.
+  DummyPhysicalModel<double>* dummy_model_{
+      nullptr};  // The PhysicalModel under test.
 };
 
 // Tests that the state and output ports are properly set up.
@@ -61,7 +62,7 @@ TEST_F(PhysicalModelTest, DiscreteStateAndOutputPorts) {
 TEST_F(PhysicalModelTest, PostFinalizeStateAdditionNotAllowed) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       dummy_model_->AppendDiscreteState(dummy_state1()),
-      "Calls to 'AppendDiscreteState\\(\\)' after system resources have been "
+      "Calls to.*AppendDiscreteState.*after system resources have been "
       "declared are not allowed.");
 }
 }  // namespace


### PR DESCRIPTION
Towards #21355. Part of #21357.

Cloning to double is always allowed. Cloning to non-double scalar types is only allowed when the DeformableModel is empty.

Move the deformable configuration port accessor from DeformableModel to MultibodyPlant to help facilitate AddMultibodyPlantSceneGraph in the future. In particular, the port is allocated pre-finalize now.

Instead of offering a pointer to the owning MbP at DeclareSystemResources, PhysicalModel now takes a mutable pointer to the prefinalized owning pointer at construction and nulls the pointer at DeclareSystemResources.

Change DummyModel into DummyPhysicalModel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21409)
<!-- Reviewable:end -->
