### PR TITLE
Fall Back To Indefinite Hessian when LDLT fails.

### DIFF
--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -511,18 +511,18 @@ std::ostream& LinearConstraint::DoDisplay(
   return DisplayConstraint(*this, os, "LinearConstraint", vars, false);
 }
 
-std::string LinearConstraint::DoToLatex(const VectorX<symbolic::Variable>& vars,
-                                        int precision) const {
+std::string LinearConstraint::DoToLatex(
+    const VectorX<symbolic::Variable>& vars, int precision) const {
   if (num_constraints() == 1) {
     return fmt::format(
         "{}{}{}", ToLatexLowerBound(*this, precision),
         symbolic::ToLatex((A_.get_as_sparse() * vars)[0], precision),
         ToLatexUpperBound(*this, precision));
   }
-  return fmt::format("{}{} {}{}", ToLatexLowerBound(*this, precision),
-                     symbolic::ToLatex(GetDenseA(), precision),
-                     symbolic::ToLatex(vars),
-                     ToLatexUpperBound(*this, precision));
+  return fmt::format(
+      "{}{} {}{}", ToLatexLowerBound(*this, precision),
+      symbolic::ToLatex(GetDenseA(), precision), symbolic::ToLatex(vars),
+      ToLatexUpperBound(*this, precision));
 }
 
 std::ostream& LinearEqualityConstraint::DoDisplay(
@@ -677,8 +677,8 @@ void PositiveSemidefiniteConstraint::DoEval(
 
 std::string PositiveSemidefiniteConstraint::DoToLatex(
     const VectorX<symbolic::Variable>& vars, int precision) const {
-  Eigen::Map<const MatrixX<symbolic::Variable>> S(vars.data(), matrix_rows(),
-                                                  matrix_rows());
+  Eigen::Map<const MatrixX<symbolic::Variable>> S(
+      vars.data(), matrix_rows(), matrix_rows());
   return fmt::format("{} \\succeq 0", symbolic::ToLatex(S.eval(), precision));
 }
 

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -166,7 +166,8 @@ void QuadraticConstraint::UpdateHessianType(
     // Fall back to an indefinite Hessian type if we cannot determine the
     // Hessian type.
     drake::log()->warn(
-        "Unable to determine Hessian type of the Quadratic Constraint. Falling "
+        "UpdateHessianType(): Unable to determine Hessian type of the "
+        "Quadratic Constraint. Falling "
         "back to indefinite Hessian type.");
     hessian_type_ = HessianType::kIndefinite;
   } else {

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -10,6 +10,7 @@
 
 #include "drake/common/symbolic/decompose.h"
 #include "drake/common/symbolic/latex.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/matrix_util.h"
 
@@ -98,11 +99,11 @@ std::string ToLatexConstraint(const Constraint& constraint,
                               int precision) {
   VectorX<symbolic::Expression> y(constraint.num_constraints());
   constraint.Eval(vars, &y);
-  return fmt::format(
-      "{}{}{}", ToLatexLowerBound(constraint, precision),
-      constraint.num_constraints() == 1 ? symbolic::ToLatex(y[0], precision)
-                                        : symbolic::ToLatex(y, precision),
-      ToLatexUpperBound(constraint, precision));
+  return fmt::format("{}{}{}", ToLatexLowerBound(constraint, precision),
+                     constraint.num_constraints() == 1
+                         ? symbolic::ToLatex(y[0], precision)
+                         : symbolic::ToLatex(y, precision),
+                     ToLatexUpperBound(constraint, precision));
 }
 
 }  // namespace
@@ -168,9 +169,7 @@ void QuadraticConstraint::UpdateHessianType(
         "Unable to determine Hessian type of the Quadratic Constraint. Falling "
         "back to indefinite Hessian type.");
     hessian_type_ = HessianType::kIndefinite;
-  }
-
-  else {
+  } else {
     if (ldlt_solver.isPositive()) {
       hessian_type_ = HessianType::kPositiveSemidefinite;
     } else if (ldlt_solver.isNegative()) {
@@ -511,18 +510,18 @@ std::ostream& LinearConstraint::DoDisplay(
   return DisplayConstraint(*this, os, "LinearConstraint", vars, false);
 }
 
-std::string LinearConstraint::DoToLatex(
-    const VectorX<symbolic::Variable>& vars, int precision) const {
+std::string LinearConstraint::DoToLatex(const VectorX<symbolic::Variable>& vars,
+                                        int precision) const {
   if (num_constraints() == 1) {
     return fmt::format(
         "{}{}{}", ToLatexLowerBound(*this, precision),
         symbolic::ToLatex((A_.get_as_sparse() * vars)[0], precision),
         ToLatexUpperBound(*this, precision));
   }
-  return fmt::format(
-      "{}{} {}{}", ToLatexLowerBound(*this, precision),
-      symbolic::ToLatex(GetDenseA(), precision), symbolic::ToLatex(vars),
-      ToLatexUpperBound(*this, precision));
+  return fmt::format("{}{} {}{}", ToLatexLowerBound(*this, precision),
+                     symbolic::ToLatex(GetDenseA(), precision),
+                     symbolic::ToLatex(vars),
+                     ToLatexUpperBound(*this, precision));
 }
 
 std::ostream& LinearEqualityConstraint::DoDisplay(
@@ -677,8 +676,8 @@ void PositiveSemidefiniteConstraint::DoEval(
 
 std::string PositiveSemidefiniteConstraint::DoToLatex(
     const VectorX<symbolic::Variable>& vars, int precision) const {
-  Eigen::Map<const MatrixX<symbolic::Variable>> S(
-      vars.data(), matrix_rows(), matrix_rows());
+  Eigen::Map<const MatrixX<symbolic::Variable>> S(vars.data(), matrix_rows(),
+                                                  matrix_rows());
   return fmt::format("{} \\succeq 0", symbolic::ToLatex(S.eval(), precision));
 }
 

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -161,12 +161,23 @@ void QuadraticConstraint::UpdateHessianType(
   }
   Eigen::LDLT<Eigen::MatrixXd> ldlt_solver;
   ldlt_solver.compute(Q_);
-  if (ldlt_solver.isPositive()) {
-    hessian_type_ = HessianType::kPositiveSemidefinite;
-  } else if (ldlt_solver.isNegative()) {
-    hessian_type_ = HessianType::kNegativeSemidefinite;
-  } else {
+  if (ldlt_solver.info() != Eigen::Success) {
+    // Fall back to an indefinite Hessian type if we cannot determine the
+    // Hessian type.
+    drake::log()->warn(
+        "Unable to determine Hessian type of the Quadratic Constraint. Falling "
+        "back to indefinite Hessian type.");
     hessian_type_ = HessianType::kIndefinite;
+  }
+
+  else {
+    if (ldlt_solver.isPositive()) {
+      hessian_type_ = HessianType::kPositiveSemidefinite;
+    } else if (ldlt_solver.isNegative()) {
+      hessian_type_ = HessianType::kNegativeSemidefinite;
+    } else {
+      hessian_type_ = HessianType::kIndefinite;
+    }
   }
 }
 
@@ -500,18 +511,18 @@ std::ostream& LinearConstraint::DoDisplay(
   return DisplayConstraint(*this, os, "LinearConstraint", vars, false);
 }
 
-std::string LinearConstraint::DoToLatex(
-    const VectorX<symbolic::Variable>& vars, int precision) const {
+std::string LinearConstraint::DoToLatex(const VectorX<symbolic::Variable>& vars,
+                                        int precision) const {
   if (num_constraints() == 1) {
     return fmt::format(
         "{}{}{}", ToLatexLowerBound(*this, precision),
         symbolic::ToLatex((A_.get_as_sparse() * vars)[0], precision),
         ToLatexUpperBound(*this, precision));
   }
-  return fmt::format(
-      "{}{} {}{}", ToLatexLowerBound(*this, precision),
-      symbolic::ToLatex(GetDenseA(), precision), symbolic::ToLatex(vars),
-      ToLatexUpperBound(*this, precision));
+  return fmt::format("{}{} {}{}", ToLatexLowerBound(*this, precision),
+                     symbolic::ToLatex(GetDenseA(), precision),
+                     symbolic::ToLatex(vars),
+                     ToLatexUpperBound(*this, precision));
 }
 
 std::ostream& LinearEqualityConstraint::DoDisplay(
@@ -666,8 +677,8 @@ void PositiveSemidefiniteConstraint::DoEval(
 
 std::string PositiveSemidefiniteConstraint::DoToLatex(
     const VectorX<symbolic::Variable>& vars, int precision) const {
-  Eigen::Map<const MatrixX<symbolic::Variable>> S(
-      vars.data(), matrix_rows(), matrix_rows());
+  Eigen::Map<const MatrixX<symbolic::Variable>> S(vars.data(), matrix_rows(),
+                                                  matrix_rows());
   return fmt::format("{} \\succeq 0", symbolic::ToLatex(S.eval(), precision));
 }
 

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -108,7 +108,7 @@ GTEST_TEST(TestConstraint, LinearConstraintInfiniteEntries) {
   DRAKE_EXPECT_THROWS_MESSAGE(LinearConstraint(A_sparse_bad, lb, ub),
                               ".*IsFinite().*");
   DRAKE_EXPECT_THROWS_MESSAGE(LinearConstraint(A_sparse_bad.toDense(), lb, ub),
-               ".*allFinite().*");
+                              ".*allFinite().*");
 }
 
 GTEST_TEST(TestConstraint, LinearEqualityConstraintSparse) {
@@ -143,10 +143,8 @@ GTEST_TEST(TestConstraint, LinearEqualityConstraintInfiniteEntries) {
   A_sparse_bad.setFromTriplets(A_triplets.begin(), A_triplets.end());
   Eigen::Vector2d bound(0, 1);
   Eigen::Vector3d bound_bad(0, 1, kInf);
-  EXPECT_THROW(LinearEqualityConstraint(A_sparse_bad, bound),
-               std::exception);
-  EXPECT_THROW(LinearEqualityConstraint(A_sparse, bound_bad),
-               std::exception);
+  EXPECT_THROW(LinearEqualityConstraint(A_sparse_bad, bound), std::exception);
+  EXPECT_THROW(LinearEqualityConstraint(A_sparse, bound_bad), std::exception);
   EXPECT_THROW(LinearEqualityConstraint(A_sparse_bad.toDense(), bound),
                std::exception);
   EXPECT_THROW(LinearEqualityConstraint(A_sparse.toDense(), bound_bad),
@@ -321,6 +319,26 @@ GTEST_TEST(testConstraint, testQuadraticConstraintHessian) {
   // Construct a constraint with psd Hessian and lower bound being -inf.
   QuadraticConstraint constraint3(Eigen::Matrix2d::Identity(), b, -kInf, 1);
   EXPECT_TRUE(constraint3.is_convex());
+}
+
+GTEST_TEST(testConstraint, QudraticConstraintLDLtFailute) {
+  Eigen::Matrix2d Q;
+  Eigen::Vector2d b;
+  // This matrix has eigenvalues 0.5 and -0.5 and so is indefinite. However, if
+  // we use Eigen's LDLT to determine whether the matrix is definiteness of this
+  // matrix, the LDLT construction fails due to numerical issues.
+  // clang-format off
+  Q << 0, 0.5,
+       0.5, 0;
+  // clang-format on
+  b << 0, 0;
+  QuadraticConstraint constraint4(Q, b, -kInf, 1);
+
+  Eigen::LDLT<Eigen::MatrixXd> ldlt_solver;
+  ldlt_solver.compute(Q);
+  // Check that the LDLT solver fails.
+  EXPECT_EQ(ldlt_solver.info(), Eigen::NumericalIssue);
+  EXPECT_FALSE(constraint4.is_convex());
 }
 
 void TestLorentzConeEvalConvex(const Eigen::Ref<const Eigen::MatrixXd>& A,

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -332,13 +332,21 @@ GTEST_TEST(testConstraint, QudraticConstraintLDLtFailute) {
        0.5, 0;
   // clang-format on
   b << 0, 0;
-  QuadraticConstraint constraint4(Q, b, -kInf, 1);
 
   Eigen::LDLT<Eigen::MatrixXd> ldlt_solver;
   ldlt_solver.compute(Q);
-  // Check that the LDLT solver fails.
+  // Check that the LDLT solver fails. If Eigen were to update in such a way
+  // that the LDLT construction were to succeed, then this test would become
+  // irrelevant and thus we could either remove it, or would need to find a new
+  // Q matrix which causes the LDLT to fail.
   EXPECT_EQ(ldlt_solver.info(), Eigen::NumericalIssue);
-  EXPECT_FALSE(constraint4.is_convex());
+
+  // The construction of the constraint calls UpdateHessian() which currently
+  // calls Eigen's LDLT solver which fails on this simplex example.
+  QuadraticConstraint constraint(Q, b, -kInf, 1);
+  EXPECT_FALSE(constraint.is_convex());
+  EXPECT_EQ(constraint.hessian_type(),
+            QuadraticConstraint::HessianType::kIndefinite);
 }
 
 void TestLorentzConeEvalConvex(const Eigen::Ref<const Eigen::MatrixXd>& A,

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -325,8 +325,8 @@ GTEST_TEST(testConstraint, QudraticConstraintLDLtFailute) {
   Eigen::Matrix2d Q;
   Eigen::Vector2d b;
   // This matrix has eigenvalues 0.5 and -0.5 and so is indefinite. However, if
-  // we use Eigen's LDLT to determine whether the matrix is definiteness of this
-  // matrix, the LDLT construction fails due to numerical issues.
+  // we use Eigen's LDLT to determine the definiteness of this matrix, the
+  // LDLT construction fails due to numerical issues.
   // clang-format off
   Q << 0, 0.5,
        0.5, 0;


### PR DESCRIPTION
When deciding the Hessian type of Quadratic Constraint, we use Eigen's LDLT method. If this computation fails, the Hessian type was being mis-identified as PositiveSemidefinite. We now correctly fall back to kIndefinite in these circumstances.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21411)
<!-- Reviewable:end -->
