### PR TITLE
Discard gradients in a SAP contact problem

### DIFF
--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -79,6 +79,7 @@ drake_cc_library(
     hdrs = ["contact_configuration.h"],
     deps = [
         "//common:essential",
+        "//math:autodiff",
         "//math:geometric_transform",
         "//multibody/plant:discrete_contact_pair",
     ],

--- a/multibody/contact_solvers/block_3x3_sparse_matrix.h
+++ b/multibody/contact_solvers/block_3x3_sparse_matrix.h
@@ -100,6 +100,8 @@ class Block3x3SparseMatrix {
   /* Returns the matrix as an Eigen dense matrix. Useful for debugging. */
   MatrixX<T> MakeDenseMatrix() const;
 
+  bool operator==(const Block3x3SparseMatrix<T>&) const = default;
+
  private:
   /* We store the non-zero blocks in the matrix in a row-major fashion. Within
    each row, the blocks are sorted in increasing column indices.
@@ -114,6 +116,7 @@ class Block3x3SparseMatrix {
   /* Index into `row_data_`. For a given `index`,
    row_data_[index.row][index.flat] retrieves the corresponding triplet. */
   struct Index {
+    bool operator==(const Index&) const = default;
     int row;
     int flat;
   };

--- a/multibody/contact_solvers/contact_configuration.h
+++ b/multibody/contact_solvers/contact_configuration.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/common/eigen_types.h"
+#include "drake/math/autodiff.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/plant/discrete_contact_pair.h"
 
@@ -16,6 +17,34 @@ namespace internal {
 // also denoted with C, defined by its orientation in the world frame W.
 template <typename T>
 struct ContactConfiguration {
+  /* When T = double, this method returns a copy of `this` object.
+     When T = AutoDiffXd this method returns a copy where gradients were
+     discarded. */
+  ContactConfiguration<double> ToDouble() const {
+    return ContactConfiguration<double>{
+        .objectA = objectA,
+        .p_ApC_W = math::DiscardGradient(p_ApC_W),
+        .objectB = objectB,
+        .p_BqC_W = math::DiscardGradient(p_BqC_W),
+        .phi = ExtractDoubleOrThrow(phi),
+        .vn = ExtractDoubleOrThrow(vn),
+        .fe = ExtractDoubleOrThrow(fe),
+        .R_WC =
+            math::RotationMatrix<double>(math::DiscardGradient(R_WC.matrix()))};
+  }
+
+  bool operator==(const ContactConfiguration& other) const {
+    if (objectA != other.objectA) return false;
+    if (p_ApC_W != other.p_ApC_W) return false;
+    if (objectB != other.objectB) return false;
+    if (p_BqC_W != other.p_BqC_W) return false;
+    if (phi != other.phi) return false;
+    if (vn != other.vn) return false;
+    if (fe != other.fe) return false;
+    if (!R_WC.IsExactlyEqualTo(other.R_WC)) return false;
+    return true;
+  }
+
   // Index to a physical object A.
   int objectA;
 

--- a/multibody/contact_solvers/matrix_block.h
+++ b/multibody/contact_solvers/matrix_block.h
@@ -101,6 +101,8 @@ class MatrixBlock {
    testing. */
   MatrixX<T> MakeDenseMatrix() const;
 
+  bool operator==(const MatrixBlock<T>&) const = default;
+
  private:
   friend MatrixBlock<T> StackMatrixBlocks<T>(
       const std::vector<MatrixBlock<T>>& blocks);

--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -59,6 +59,19 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "expect_equal",
+    testonly = 1,
+    srcs = ["expect_equal.cc"],
+    hdrs = ["expect_equal.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":sap_constraint",
+        "//common:essential",
+        "@gtest//:without_main",
+    ],
+)
+
+drake_cc_library(
     name = "partial_permutation",
     srcs = ["partial_permutation.cc"],
     hdrs = ["partial_permutation.h"],
@@ -104,6 +117,7 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//common:essential",
+        "//math:autodiff",
         "//multibody/contact_solvers:matrix_block",
     ],
 )
@@ -184,6 +198,7 @@ drake_cc_library(
         ":sap_constraint_jacobian",
         "//common:default_scalars",
         "//common:essential",
+        "//math:autodiff",
     ],
 )
 
@@ -331,6 +346,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_constraint",
     ],
 )
@@ -360,6 +376,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_ball_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_ball_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",
@@ -370,6 +387,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_coupler_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_coupler_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",
@@ -380,6 +398,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_distance_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_distance_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",
@@ -390,16 +409,19 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_fixed_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_fixed_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
 drake_cc_googletest(
     name = "sap_holonomic_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_holonomic_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",
@@ -410,6 +432,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_hunt_crossley_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_hunt_crossley_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",
@@ -422,6 +445,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_limit_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_limit_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",
@@ -432,6 +456,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_pd_controller_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_pd_controller_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",
@@ -442,6 +467,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_friction_cone_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_friction_cone_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",
@@ -457,6 +483,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "sap_weld_constraint_test",
     deps = [
+        ":expect_equal",
         ":sap_weld_constraint",
         ":validate_constraint_gradients",
         "//common:pointer_cast",

--- a/multibody/contact_solvers/sap/expect_equal.cc
+++ b/multibody/contact_solvers/sap/expect_equal.cc
@@ -1,0 +1,27 @@
+#include "drake/multibody/contact_solvers/sap/expect_equal.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+void ExpectBaseIsEqual(const SapConstraint<double>& c1,
+                       const SapConstraint<double>& c2) {
+  EXPECT_EQ(c1.num_constraint_equations(), c2.num_constraint_equations());
+  EXPECT_EQ(c1.num_cliques(), c2.num_cliques());
+  EXPECT_EQ(c1.first_clique(), c2.first_clique());
+  EXPECT_EQ(c1.first_clique_jacobian().MakeDenseMatrix(),
+            c2.first_clique_jacobian().MakeDenseMatrix());
+  if (c1.num_cliques() == 2) {
+    EXPECT_EQ(c1.second_clique(), c2.second_clique());
+    EXPECT_EQ(c1.second_clique_jacobian().MakeDenseMatrix(),
+              c2.second_clique_jacobian().MakeDenseMatrix());
+  }
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/expect_equal.h
+++ b/multibody/contact_solvers/sap/expect_equal.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "drake/multibody/contact_solvers/sap/sap_constraint.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+/// For unit testing only, this function compares that all members in c1 are an
+/// exact bitwise copy of members in c2, including the constraint Jacobian.
+/// Tests are performed with EXPECT_EQ from <gtest/gtest.h>.
+void ExpectBaseIsEqual(const SapConstraint<double>& c1,
+                       const SapConstraint<double>& c2);
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/sap_ball_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_ball_constraint.cc
@@ -5,6 +5,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
+#include "drake/math/autodiff.h"
 
 namespace drake {
 namespace multibody {
@@ -91,6 +92,18 @@ void SapBallConstraint<T>::DoAccumulateSpatialImpulses(
     *F += gamma_Bq_W.Shift(-kinematics().p_BQ_W());
     return;
   }
+}
+
+template <typename T>
+std::unique_ptr<SapConstraint<double>> SapBallConstraint<T>::DoToDouble()
+    const {
+  SapConstraintJacobian<double> J = this->jacobian().ToDouble();
+  SapBallConstraint<double>::Kinematics k(
+      kinematics_.objectA(), math::DiscardGradient(kinematics_.p_WP()),
+      math::DiscardGradient(kinematics_.p_AP_W()), kinematics_.objectB(),
+      math::DiscardGradient(kinematics_.p_WQ()),
+      math::DiscardGradient(kinematics_.p_BQ_W()), std::move(J));
+  return std::make_unique<SapBallConstraint<double>>(std::move(k));
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_ball_constraint.h
+++ b/multibody/contact_solvers/sap/sap_ball_constraint.h
@@ -90,6 +90,8 @@ class SapBallConstraint final : public SapHolonomicConstraint<T> {
     const Vector3<T>& p_BQ_W() const { return p_BQ_W_; }
     const SapConstraintJacobian<T>& jacobian() const { return J_; }
 
+    bool operator==(const Kinematics&) const = default;
+
    private:
     /* Index to a physical object A. */
     int objectA_;
@@ -159,6 +161,7 @@ class SapBallConstraint final : public SapHolonomicConstraint<T> {
     return std::unique_ptr<SapBallConstraint<T>>(
         new SapBallConstraint<T>(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final;
 
   Kinematics kinematics_;
 };

--- a/multibody/contact_solvers/sap/sap_constraint.h
+++ b/multibody/contact_solvers/sap/sap_constraint.h
@@ -253,6 +253,13 @@ class SapConstraint {
   /* Polymorphic deep-copy into a new instance. */
   std::unique_ptr<SapConstraint<T>> Clone() const { return DoClone(); }
 
+  /* When T = double, this method is equivalent to Clone() and returns a
+   deep-copy of `this` jacobian. When T = AutoDiffXd this method returns a copy
+   where gradients were discarded. */
+  std::unique_ptr<SapConstraint<double>> ToDouble() const {
+    return DoToDouble();
+  }
+
   /* Creates a "reduced" clone of this constraint by removing known DoFs from
    the constraint's Jacobian. That is, the newly reduced constraint will have
    this constraint's Jacobian excluding columns for known DoFs. The following
@@ -332,6 +339,10 @@ class SapConstraint {
   /* Clone() implementation. Derived classes must override to provide
    polymorphic deep-copy into a new instance. */
   virtual std::unique_ptr<SapConstraint<T>> DoClone() const = 0;
+
+  /* ToDouble() implementation. Derived classes must override to provide
+   polymorphic scalar conversion. */
+  virtual std::unique_ptr<SapConstraint<double>> DoToDouble() const = 0;
   // @}
 
  private:

--- a/multibody/contact_solvers/sap/sap_constraint_jacobian.cc
+++ b/multibody/contact_solvers/sap/sap_constraint_jacobian.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_constraint_jacobian.h"
 
+#include "drake/math/autodiff.h"
+
 namespace drake {
 namespace multibody {
 namespace contact_solvers {
@@ -62,6 +64,23 @@ SapConstraintJacobian<T> SapConstraintJacobian<T>::LeftMultiplyByTranspose(
   MatrixX<T> ATJ_second_clique = A.transpose() * J_second_clique;
   return SapConstraintJacobian<T>(clique(0), std::move(ATJ_first_clique),
                                   clique(1), std::move(ATJ_second_clique));
+}
+
+template <typename T>
+SapConstraintJacobian<double> SapConstraintJacobian<T>::ToDouble() const {
+  const MatrixBlock<T>& first_block = clique_jacobian(0);
+  DRAKE_THROW_UNLESS(first_block.is_dense());
+  MatrixX<double> J_first_clique =
+      math::DiscardGradient(first_block.MakeDenseMatrix());
+  if (num_cliques() == 1) {
+    return SapConstraintJacobian<double>(clique(0), std::move(J_first_clique));
+  }
+  const MatrixBlock<T>& second_block = clique_jacobian(1);
+  DRAKE_THROW_UNLESS(second_block.is_dense());
+  MatrixX<double> J_second_clique =
+      math::DiscardGradient(second_block.MakeDenseMatrix());
+  return SapConstraintJacobian<double>(clique(0), std::move(J_first_clique),
+                                       clique(1), std::move(J_second_clique));
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_constraint_jacobian.h
+++ b/multibody/contact_solvers/sap/sap_constraint_jacobian.h
@@ -15,7 +15,11 @@ namespace internal {
 template <typename T>
 struct CliqueJacobian {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CliqueJacobian);
+
   CliqueJacobian(int c, MatrixBlock<T>&& b) : clique(c), block(std::move(b)) {}
+
+  bool operator==(const CliqueJacobian<T>&) const = default;
+
   int clique;
   MatrixBlock<T> block;
 };
@@ -108,6 +112,16 @@ class SapConstraintJacobian {
    @pre blocks_are_dense() is true. */
   SapConstraintJacobian<T> LeftMultiplyByTranspose(
       const Eigen::Ref<const MatrixX<T>>& A) const;
+
+  // TODO(amcastro-tri): implement support for non-dense blocks.
+  /* When T = double, this method returns a copy of `this` jacobian.
+   When T = AutoDiffXd this method returns a copy where gradients were
+   discarded.
+   @warning Only dense clique jacobians are supported.
+   @throws std::exception if any of the Jacobian blocks is not dense. */
+  SapConstraintJacobian<double> ToDouble() const;
+
+  bool operator==(const SapConstraintJacobian<T>&) const = default;
 
  private:
   // Blocks for each block. Up to two entries only.

--- a/multibody/contact_solvers/sap/sap_contact_problem.cc
+++ b/multibody/contact_solvers/sap/sap_contact_problem.cc
@@ -6,6 +6,7 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/ssize.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/contact_solvers/block_sparse_matrix.h"
 #include "drake/multibody/contact_solvers/sap/contact_problem_graph.h"
 #include "drake/multibody/plant/slicing_and_indexing.h"
@@ -49,6 +50,26 @@ std::unique_ptr<SapContactProblem<T>> SapContactProblem<T>::Clone() const {
   for (int i = 0; i < num_constraints(); ++i) {
     const SapConstraint<T>& c = get_constraint(i);
     clone->AddConstraint(c.Clone());
+  }
+  return clone;
+}
+
+template <typename T>
+std::unique_ptr<SapContactProblem<double>> SapContactProblem<T>::ToDouble()
+    const {
+  const double time_step = ExtractDoubleOrThrow(time_step_);
+  std::vector<MatrixX<double>> A;
+  A.reserve(A_.size());
+  for (int i = 0; i < ssize(A_); ++i) {
+    A.push_back(math::DiscardGradient(A_[i]));
+  }
+  VectorX<double> v_star = math::DiscardGradient(v_star_);
+  auto clone = std::make_unique<SapContactProblem<double>>(
+      time_step, std::move(A), std::move(v_star));
+  clone->set_num_objects(num_objects());
+  for (int i = 0; i < num_constraints(); ++i) {
+    const SapConstraint<T>& c = get_constraint(i);
+    clone->AddConstraint(c.ToDouble());
   }
   return clone;
 }

--- a/multibody/contact_solvers/sap/sap_contact_problem.h
+++ b/multibody/contact_solvers/sap/sap_contact_problem.h
@@ -4,6 +4,7 @@
 #include <set>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/sap/contact_problem_graph.h"
@@ -92,6 +93,11 @@ class SapContactProblem {
 
   /* Returns a deep-copy of `this` instance. */
   std::unique_ptr<SapContactProblem<T>> Clone() const;
+
+  /* When T = double, this method returns the result of Clone().
+     When T = AutoDiffXd this method returns a deep copy where gradients were
+     discarded. */
+  std::unique_ptr<SapContactProblem<double>> ToDouble() const;
 
   /* Makes a "reduced" contact problem given the DOFs specified in
     `known_free_motion_dofs` are known to equal the free-motion velocities.

--- a/multibody/contact_solvers/sap/sap_coupler_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_coupler_constraint.cc
@@ -86,6 +86,23 @@ void SapCouplerConstraint<T>::DoAccumulateGeneralizedImpulses(
   }
 }
 
+template <typename T>
+std::unique_ptr<SapConstraint<double>> SapCouplerConstraint<T>::DoToDouble()
+    const {
+  SapCouplerConstraint<double>::Kinematics k{
+      kinematics_.clique0,
+      kinematics_.clique_dof0,
+      kinematics_.clique_nv0,
+      ExtractDoubleOrThrow(kinematics_.q0),
+      kinematics_.clique1,
+      kinematics_.clique_dof1,
+      kinematics_.clique_nv1,
+      ExtractDoubleOrThrow(kinematics_.q1),
+      ExtractDoubleOrThrow(kinematics_.gear_ratio),
+      ExtractDoubleOrThrow(kinematics_.offset)};
+  return std::make_unique<SapCouplerConstraint<double>>(std::move(k));
+}
+
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody

--- a/multibody/contact_solvers/sap/sap_coupler_constraint.h
+++ b/multibody/contact_solvers/sap/sap_coupler_constraint.h
@@ -42,6 +42,8 @@ class SapCouplerConstraint final : public SapHolonomicConstraint<T> {
   /* Struct to store the kinematics of the the constraint in its current
    configuration, when it gets constructed. */
   struct Kinematics {
+    bool operator==(const Kinematics&) const = default;
+
     /* Index of clique 0. */
     int clique0;
     /* Clique local index of dof 0. */
@@ -107,6 +109,7 @@ class SapCouplerConstraint final : public SapHolonomicConstraint<T> {
     return std::unique_ptr<SapCouplerConstraint<T>>(
         new SapCouplerConstraint<T>(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final;
 
   Kinematics kinematics_;
 };

--- a/multibody/contact_solvers/sap/sap_distance_constraint.h
+++ b/multibody/contact_solvers/sap/sap_distance_constraint.h
@@ -12,6 +12,9 @@ namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
+template <typename T>
+class SapDistanceConstraint;
+
 /* Implements a SAP (compliant) distance constraint between two points. With
  finite compliance, this constraint can be used to model a linear spring between
  two points.
@@ -46,6 +49,8 @@ class SapDistanceConstraint final : public SapHolonomicConstraint<T> {
 
     /* Stiffness k and damping c. */
     ComplianceParameters(T stiffness, T damping);
+
+    bool operator==(const ComplianceParameters&) const = default;
 
     const T& stiffness() const { return stiffness_; }
 
@@ -113,6 +118,8 @@ class SapDistanceConstraint final : public SapHolonomicConstraint<T> {
     const SapConstraintJacobian<T>& jacobian() const { return J_; }
     const Vector3<T>& p_hat_W() const { return p_hat_W_; }
 
+    bool operator==(const Kinematics&) const = default;
+
    private:
     /* Index to a physical object A. */
     int objectA_;
@@ -158,6 +165,8 @@ class SapDistanceConstraint final : public SapHolonomicConstraint<T> {
     return parameters_;
   }
 
+  const Kinematics& kinematics() const { return kinematics_; }
+
  private:
   /* Private copy construction is enabled to use in the implementation of
      DoClone(). */
@@ -198,6 +207,8 @@ class SapDistanceConstraint final : public SapHolonomicConstraint<T> {
     return std::unique_ptr<SapDistanceConstraint<T>>(
         new SapDistanceConstraint<T>(*this));
   }
+
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final;
 
   Kinematics kinematics_;
   ComplianceParameters parameters_;

--- a/multibody/contact_solvers/sap/sap_fixed_constraint.h
+++ b/multibody/contact_solvers/sap/sap_fixed_constraint.h
@@ -191,6 +191,13 @@ class SapFixedConstraint final : public SapHolonomicConstraint<T> {
         new SapFixedConstraint<T>(*this));
   }
 
+  // We do not yet support scalar conversion for constraints used for
+  // deformables.
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final {
+    throw std::runtime_error(
+        "SapFixedConstraint: Scalar conversion to double not supported.");
+  }
+
   int num_constrained_point_pairs_{};
   VectorX<T> p_APs_W_;
   std::optional<VectorX<T>> p_BQs_W_;

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
@@ -231,6 +231,18 @@ void SapFrictionConeConstraint<T>::DoAccumulateSpatialImpulses(
   }
 }
 
+template <typename T>
+std::unique_ptr<SapConstraint<double>>
+SapFrictionConeConstraint<T>::DoToDouble() const {
+  const typename SapFrictionConeConstraint<T>::Parameters& p = parameters_;
+  SapFrictionConeConstraint<double>::Parameters p_to_double{
+      ExtractDoubleOrThrow(p.mu), ExtractDoubleOrThrow(p.stiffness),
+      ExtractDoubleOrThrow(p.dissipation_time_scale), p.beta, p.sigma};
+  return std::make_unique<SapFrictionConeConstraint<double>>(
+      configuration().ToDouble(), this->jacobian().ToDouble(),
+      std::move(p_to_double));
+}
+
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.h
@@ -167,6 +167,8 @@ class SapFrictionConeConstraint final : public SapConstraint<T> {
   /* Numerical parameters that define the constraint. Refer to this class's
    documentation for details. */
   struct Parameters {
+    bool operator==(const Parameters&) const = default;
+
     /* Coefficient of friction μ, dimensionless. It must be non-negative. */
     T mu{0.0};
     /* Contact stiffness k, in N/m. It must be strictly positive. */
@@ -229,6 +231,7 @@ class SapFrictionConeConstraint final : public SapConstraint<T> {
     return std::unique_ptr<SapFrictionConeConstraint<T>>(
         new SapFrictionConeConstraint<T>(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final;
 
   // no-op for this constraint.
   void DoAccumulateGeneralizedImpulses(int, const Eigen::Ref<const VectorX<T>>&,

--- a/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
+#include "drake/math/autodiff.h"
 
 namespace drake {
 namespace multibody {
@@ -182,6 +183,20 @@ void SapHolonomicConstraint<T>::DoCalcCostHessian(
       (*G)(i, i) = R_inv(i);
     }
   }
+}
+
+template <typename T>
+std::unique_ptr<SapConstraint<double>> SapHolonomicConstraint<T>::DoToDouble()
+    const {
+  const typename SapHolonomicConstraint<T>::Parameters& p = parameters_;
+  SapHolonomicConstraint<double>::Parameters p_to_double(
+      math::DiscardGradient(p.impulse_lower_limits()),
+      math::DiscardGradient(p.impulse_upper_limits()),
+      math::DiscardGradient(p.stiffnesses()),
+      math::DiscardGradient(p.relaxation_times()), p.beta());
+  return std::make_unique<SapHolonomicConstraint<double>>(
+      math::DiscardGradient(constraint_function()), this->jacobian().ToDouble(),
+      math::DiscardGradient(bias()), std::move(p_to_double));
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_holonomic_constraint.h
+++ b/multibody/contact_solvers/sap/sap_holonomic_constraint.h
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/math/autodiff.h"
 #include "drake/multibody/contact_solvers/sap/sap_constraint.h"
 
 namespace drake {
@@ -174,6 +175,8 @@ class SapHolonomicConstraint : public SapConstraint<T> {
       return impulse_lower_limits_.size();
     }
 
+    bool operator==(const Parameters&) const = default;
+
    private:
     VectorX<T> impulse_lower_limits_;
     VectorX<T> impulse_upper_limits_;
@@ -258,6 +261,7 @@ class SapHolonomicConstraint : public SapConstraint<T> {
     return std::unique_ptr<SapHolonomicConstraint<T>>(
         new SapHolonomicConstraint<T>(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const override;
 
   VectorX<T> g_;
   VectorX<T> bias_;

--- a/multibody/contact_solvers/sap/sap_hunt_crossley_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_hunt_crossley_constraint.cc
@@ -283,6 +283,23 @@ void SapHuntCrossleyConstraint<T>::DoAccumulateSpatialImpulses(
   }
 }
 
+template <typename T>
+std::unique_ptr<SapConstraint<double>>
+SapHuntCrossleyConstraint<T>::DoToDouble() const {
+  SapConstraintJacobian<double> J = this->jacobian().ToDouble();
+  const auto& p = parameters();
+  SapHuntCrossleyConstraint<double>::Parameters parameters{
+      p.model,
+      ExtractDoubleOrThrow(p.friction),
+      ExtractDoubleOrThrow(p.stiffness),
+      ExtractDoubleOrThrow(p.dissipation),
+      p.stiction_tolerance,
+      p.sigma};
+  ContactConfiguration<double> configuration = configuration_.ToDouble();
+  return std::make_unique<SapHuntCrossleyConstraint<double>>(
+      std::move(configuration), std::move(J), std::move(parameters));
+}
+
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody

--- a/multibody/contact_solvers/sap/sap_hunt_crossley_constraint.h
+++ b/multibody/contact_solvers/sap/sap_hunt_crossley_constraint.h
@@ -116,6 +116,8 @@ class SapHuntCrossleyConstraint final : public SapConstraint<T> {
   /* Numerical parameters that define the constraint. Refer to this class's
    documentation for details. */
   struct Parameters {
+    bool operator==(const Parameters& other) const = default;
+
     /* Convex approximation, see [Castro et al., 2023]. */
     SapHuntCrossleyApproximation model{SapHuntCrossleyApproximation::kSimilar};
     /* Coefficient of friction μ, dimensionless. It must be non-negative. */
@@ -192,6 +194,7 @@ class SapHuntCrossleyConstraint final : public SapConstraint<T> {
     return std::unique_ptr<SapHuntCrossleyConstraint<T>>(
         new SapHuntCrossleyConstraint<T>(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final;
 
   // no-op for this constraint.
   void DoAccumulateGeneralizedImpulses(int, const Eigen::Ref<const VectorX<T>>&,

--- a/multibody/contact_solvers/sap/sap_limit_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_limit_constraint.cc
@@ -174,6 +174,23 @@ void SapLimitConstraint<T>::DoAccumulateGeneralizedImpulses(
   if (qu < kInf) (*tau)(clique_dof_) -= gamma(i);     // Upper.
 }
 
+template <typename T>
+std::unique_ptr<SapConstraint<double>> SapLimitConstraint<T>::DoToDouble()
+    const {
+  const typename SapLimitConstraint<T>::Parameters& p = parameters_;
+  SapLimitConstraint<double>::Parameters p_to_double(
+      ExtractDoubleOrThrow(p.lower_limit()),
+      ExtractDoubleOrThrow(p.upper_limit()),
+      ExtractDoubleOrThrow(p.stiffness()),
+      ExtractDoubleOrThrow(p.dissipation_time_scale()), p.beta());
+  // N.B. Limit constraints always act on a single clique.
+  const int clique = this->first_clique();
+  const int clique_nv = this->num_velocities(0);
+  return std::make_unique<SapLimitConstraint<double>>(
+      clique, clique_dof(), clique_nv, ExtractDoubleOrThrow(position()),
+      std::move(p_to_double));
+}
+
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody

--- a/multibody/contact_solvers/sap/sap_limit_constraint.h
+++ b/multibody/contact_solvers/sap/sap_limit_constraint.h
@@ -154,6 +154,8 @@ class SapLimitConstraint final : public SapConstraint<T> {
     const T& dissipation_time_scale() const { return dissipation_time_scale_; }
     double beta() const { return beta_; }
 
+    bool operator==(const Parameters&) const = default;
+
    private:
     T lower_limit_;
     T upper_limit_;
@@ -190,6 +192,22 @@ class SapLimitConstraint final : public SapConstraint<T> {
   /* Returns the position provided at construction. */
   const T& position() const { return q0_; }
 
+  /* Returns the value of the constraint function computed at construction. At
+   construction, Parameters can specify limits that are infinite (-∞ for lower
+   and ∞ for upper), indicating there is no limit. Therefore, this constraint
+   will implement a constraint function that can have size two (both limits
+   finite), size one (one of the limits is infinite) or even zero (both limits
+   are infinite). Therefore the returned vector stores the value of the
+   constraint function as:
+     1. the first entry contains the value of the lower limit constraint
+        function iff the lower limit is finite.
+     2. The next entry contains the value of the upper limit constraint
+        function iff the upper limit is finite.
+   There is no information in the returned value on which limits were included.
+   That information however is known to the client code that provided the
+   initial constraint parameters. */
+  const VectorX<T>& constraint_function() const { return g_; }
+
  private:
   /* Private copy construction is enabled to use in the implementation of
     DoClone(). */
@@ -222,6 +240,7 @@ class SapLimitConstraint final : public SapConstraint<T> {
     return std::unique_ptr<SapLimitConstraint<T>>(
         new SapLimitConstraint<T>(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final;
   void DoAccumulateGeneralizedImpulses(
       int c, const Eigen::Ref<const VectorX<T>>& gamma,
       EigenPtr<VectorX<T>> tau) const final;

--- a/multibody/contact_solvers/sap/sap_pd_controller_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_pd_controller_constraint.cc
@@ -149,6 +149,27 @@ SapConstraintJacobian<T> SapPdControllerConstraint<T>::MakeConstraintJacobian(
   return SapConstraintJacobian<T>(c.clique, std::move(J));
 }
 
+template <typename T>
+std::unique_ptr<SapConstraint<double>>
+SapPdControllerConstraint<T>::DoToDouble() const {
+  const typename SapPdControllerConstraint<T>::Parameters& p = parameters_;
+  const typename SapPdControllerConstraint<T>::Configuration& c =
+      configuration_;
+  SapPdControllerConstraint<double>::Parameters p_to_double(
+      ExtractDoubleOrThrow(p.Kp()), ExtractDoubleOrThrow(p.Kd()),
+      ExtractDoubleOrThrow(p.effort_limit()));
+  SapPdControllerConstraint<double>::Configuration c_to_double{
+      c.clique,
+      c.clique_dof,
+      c.clique_nv,
+      ExtractDoubleOrThrow(c.q0),
+      ExtractDoubleOrThrow(c.qd),
+      ExtractDoubleOrThrow(c.vd),
+      ExtractDoubleOrThrow(c.u0)};
+  return std::make_unique<SapPdControllerConstraint<double>>(
+      std::move(c_to_double), std::move(p_to_double));
+}
+
 }  // namespace internal
 }  // namespace contact_solvers
 }  // namespace multibody

--- a/multibody/contact_solvers/sap/sap_pd_controller_constraint.h
+++ b/multibody/contact_solvers/sap/sap_pd_controller_constraint.h
@@ -116,6 +116,8 @@ class SapPdControllerConstraint final : public SapConstraint<T> {
     const T& Kd() const { return Kd_; }
     const T& effort_limit() const { return effort_limit_; }
 
+    bool operator==(const Parameters&) const = default;
+
    private:
     T Kp_;            // Proportional gain.
     T Kd_;            // Derivative gain.
@@ -125,6 +127,8 @@ class SapPdControllerConstraint final : public SapConstraint<T> {
   /* Struct to store the current configuration of the the constraint, when it
   gets constructed. */
   struct Configuration {
+    bool operator==(const Configuration&) const = default;
+
     /* Clique index. */
     int clique;
     /* PD controlled dof within the given clique, and value in [0, clique_nv).*/
@@ -168,6 +172,7 @@ class SapPdControllerConstraint final : public SapConstraint<T> {
     return std::unique_ptr<SapPdControllerConstraint<T>>(
         new SapPdControllerConstraint<T>(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final;
   void DoAccumulateGeneralizedImpulses(
       int c, const Eigen::Ref<const VectorX<T>>& gamma,
       EigenPtr<VectorX<T>> tau) const final;

--- a/multibody/contact_solvers/sap/sap_weld_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_weld_constraint.cc
@@ -43,6 +43,21 @@ SapWeldConstraint<T>::Kinematics::Kinematics(int objectA,
 }
 
 template <typename T>
+bool SapWeldConstraint<T>::Kinematics::operator==(
+    const Kinematics& other) const {
+  if (objectA() != other.objectA()) return false;
+  if (!X_WP().IsExactlyEqualTo(other.X_WP())) return false;
+  if (p_AP_W() != other.p_AP_W()) return false;
+  if (objectB() != other.objectB()) return false;
+  if (!X_WQ().IsExactlyEqualTo(other.X_WQ())) return false;
+  if (p_BQ_W() != other.p_BQ_W()) return false;
+  if (jacobian() != other.jacobian()) return false;
+  if (p_PoQo_W() != other.p_PoQo_W()) return false;
+  if (a_PQ_W() != other.a_PQ_W()) return false;
+  return true;
+}
+
+template <typename T>
 SapWeldConstraint<T>::SapWeldConstraint(Kinematics kinematics)
     : SapHolonomicConstraint<T>(
           MakeSapHolonomicConstraintKinematics(kinematics),
@@ -222,6 +237,23 @@ void SapWeldConstraint<T>::DoAccumulateSpatialImpulses(
     *F += gamma_BBm_W.Shift(-p_BoBm_W);
     return;
   }
+}
+
+template <typename T>
+std::unique_ptr<SapConstraint<double>> SapWeldConstraint<T>::DoToDouble()
+    const {
+  const typename SapWeldConstraint<T>::Kinematics& k = kinematics_;
+  auto discard_gradient = [](const RigidTransform<T>& X) {
+    return RigidTransform<double>(
+        RotationMatrix<double>(math::DiscardGradient(X.rotation().matrix())),
+        math::DiscardGradient(X.translation()));
+  };
+  SapWeldConstraint<double>::Kinematics k_to_double(
+      k.objectA(), discard_gradient(k.X_WP()),
+      math::DiscardGradient(k.p_AP_W()), k.objectB(),
+      discard_gradient(k.X_WQ()), math::DiscardGradient(k.p_BQ_W()),
+      k.jacobian().ToDouble());
+  return std::make_unique<SapWeldConstraint<double>>(std::move(k_to_double));
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap/sap_weld_constraint.h
+++ b/multibody/contact_solvers/sap/sap_weld_constraint.h
@@ -99,6 +99,8 @@ class SapWeldConstraint final : public SapHolonomicConstraint<T> {
     const Vector3<T>& p_PoQo_W() const { return p_PoQo_W_; }
     const Vector3<T>& a_PQ_W() const { return a_PQ_W_; }
 
+    bool operator==(const Kinematics& other) const;
+
    private:
     /* Index to a physical object A. */
     int objectA_;
@@ -172,6 +174,7 @@ class SapWeldConstraint final : public SapHolonomicConstraint<T> {
     return std::unique_ptr<SapWeldConstraint<T>>(
         new SapWeldConstraint<T>(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final;
 
   Kinematics kinematics_;
 };

--- a/multibody/contact_solvers/sap/test/sap_ball_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_ball_constraint_test.cc
@@ -7,6 +7,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/contact_solvers/sap/expect_equal.h"
 #include "drake/multibody/contact_solvers/sap/validate_constraint_gradients.h"
 
 using drake::math::RotationMatrix;
@@ -51,6 +52,12 @@ typename SapBallConstraint<T>::Kinematics MakeArbitraryKinematics(
                     : SapConstraintJacobian<T>(clique0, J32, clique1, J34);
   return typename SapBallConstraint<T>::Kinematics{
       objectA, p_WP, p_AP_W, objectB, p_WQ, p_BQ_W, J_PQ_W};
+}
+
+void ExpectEqual(const SapBallConstraint<double>& c1,
+                 const SapBallConstraint<double>& c2) {
+  ExpectBaseIsEqual(c1, c2);
+  EXPECT_EQ(c1.kinematics(), c2.kinematics());
 }
 
 GTEST_TEST(SapBallConstraint, SingleCliqueConstraint) {
@@ -124,13 +131,15 @@ GTEST_TEST(SapBallConstraint, SingleCliqueConstraintClone) {
   // clone is a deep-copy of the original constraint.
   auto clone = dynamic_pointer_cast<SapBallConstraint<double>>(c.Clone());
   ASSERT_NE(clone, nullptr);
-  EXPECT_EQ(clone->num_objects(), 2);
-  EXPECT_EQ(clone->num_constraint_equations(), 3);
-  EXPECT_EQ(clone->num_cliques(), 1);
-  EXPECT_EQ(clone->first_clique(), kinematics.jacobian().clique(0));
-  EXPECT_THROW(clone->second_clique(), std::exception);
-  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
-  EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
+  ExpectEqual(c, *clone);
+
+  // Test ToDouble.
+  SapBallConstraint<AutoDiffXd> c_ad(
+      MakeArbitraryKinematics<AutoDiffXd>(num_cliques));
+  auto clone_from_ad =
+      dynamic_pointer_cast<SapBallConstraint<double>>(c_ad.ToDouble());
+  ASSERT_NE(clone_from_ad, nullptr);
+  ExpectEqual(c, *clone_from_ad);
 }
 
 GTEST_TEST(SapBallConstraint, TwoCliquesConstraintClone) {
@@ -141,13 +150,15 @@ GTEST_TEST(SapBallConstraint, TwoCliquesConstraintClone) {
 
   auto clone = dynamic_pointer_cast<SapBallConstraint<double>>(c.Clone());
   ASSERT_NE(clone, nullptr);
-  EXPECT_EQ(clone->num_objects(), 2);
-  EXPECT_EQ(clone->num_constraint_equations(), 3);
-  EXPECT_EQ(clone->num_cliques(), 2);
-  EXPECT_EQ(clone->first_clique(), kinematics.jacobian().clique(0));
-  EXPECT_EQ(clone->second_clique(), kinematics.jacobian().clique(1));
-  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
-  EXPECT_EQ(clone->second_clique_jacobian().MakeDenseMatrix(), J34);
+  ExpectEqual(c, *clone);
+
+  // Test ToDouble.
+  SapBallConstraint<AutoDiffXd> c_ad(
+      MakeArbitraryKinematics<AutoDiffXd>(num_cliques));
+  auto clone_from_ad =
+      dynamic_pointer_cast<SapBallConstraint<double>>(c_ad.ToDouble());
+  ASSERT_NE(clone_from_ad, nullptr);
+  ExpectEqual(c, *clone_from_ad);
 }
 
 GTEST_TEST(SapBallConstraint, AccumulateSpatialImpulses) {

--- a/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
@@ -91,6 +91,10 @@ class TestConstraint final : public SapConstraint<T> {
     return std::unique_ptr<TestConstraint<T>>(new TestConstraint<T>(*this));
   }
 
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final {
+    throw std::runtime_error("DoToDouble() not needed for these unit tests.");
+  }
+
   T param_{0.0};
 };
 

--- a/multibody/contact_solvers/sap/test/sap_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_test.cc
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/multibody/contact_solvers/sap/expect_equal.h"
+
 using Eigen::MatrixXd;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
@@ -59,6 +61,9 @@ class TestConstraint final : public SapConstraint<double> {
   std::unique_ptr<SapConstraint<double>> DoClone() const final {
     return std::unique_ptr<TestConstraint>(new TestConstraint(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final {
+    return this->Clone();
+  }
 };
 
 GTEST_TEST(SapConstraint, SingleCliqueConstraint) {
@@ -103,23 +108,21 @@ GTEST_TEST(SapConstraint, TwoCliquesConstraintWrongArguments) {
 GTEST_TEST(SapConstraint, SingleCliqueConstraintClone) {
   TestConstraint c(12, J32);
   std::unique_ptr<SapConstraint<double>> clone = c.Clone();
-  EXPECT_EQ(clone->num_constraint_equations(), 3);
-  EXPECT_EQ(clone->num_cliques(), 1);
-  EXPECT_EQ(clone->first_clique(), 12);
-  EXPECT_THROW(clone->second_clique(), std::exception);
-  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
-  EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
+  ASSERT_NE(clone, nullptr);
+  ExpectBaseIsEqual(c, *clone);
+  std::unique_ptr<SapConstraint<double>> c_to_double = c.ToDouble();
+  ASSERT_NE(c_to_double, nullptr);
+  ExpectBaseIsEqual(c, *c_to_double);
 }
 
 GTEST_TEST(SapConstraint, TwoCliquesConstraintClone) {
   TestConstraint c(11, 7, J32, J34);
   std::unique_ptr<SapConstraint<double>> clone = c.Clone();
-  EXPECT_EQ(clone->num_constraint_equations(), 3);
-  EXPECT_EQ(clone->num_cliques(), 2);
-  EXPECT_EQ(clone->first_clique(), 11);
-  EXPECT_EQ(clone->second_clique(), 7);
-  EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J32);
-  EXPECT_EQ(clone->second_clique_jacobian().MakeDenseMatrix(), J34);
+  ASSERT_NE(clone, nullptr);
+  ExpectBaseIsEqual(c, *clone);
+  std::unique_ptr<SapConstraint<double>> c_to_double = c.ToDouble();
+  ASSERT_NE(c_to_double, nullptr);
+  ExpectBaseIsEqual(c, *c_to_double);
 }
 
 }  // namespace

--- a/multibody/contact_solvers/sap/test/sap_fixed_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_fixed_constraint_test.cc
@@ -5,6 +5,7 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/pointer_cast.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/contact_solvers/sap/validate_constraint_gradients.h"
 
@@ -143,6 +144,10 @@ GTEST_TEST(SapFixedConstraint, SingleCliqueConstraintClone) {
   EXPECT_THROW(clone->second_clique(), std::exception);
   EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J66);
   EXPECT_THROW(clone->second_clique_jacobian(), std::exception);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      c.ToDouble(),
+      "SapFixedConstraint: Scalar conversion to double not supported.");
 }
 
 GTEST_TEST(SapFixedConstraint, TwoCliquesConstraintClone) {
@@ -161,6 +166,10 @@ GTEST_TEST(SapFixedConstraint, TwoCliquesConstraintClone) {
   EXPECT_EQ(clone->second_clique(), kinematics.J.clique(1));
   EXPECT_EQ(clone->first_clique_jacobian().MakeDenseMatrix(), J66);
   EXPECT_EQ(clone->second_clique_jacobian().MakeDenseMatrix(), J62);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      c.ToDouble(),
+      "SapFixedConstraint: Scalar conversion to double not supported.");
 }
 
 GTEST_TEST(SapFixedConstraint, AccumulateGeneralizedImpulses) {

--- a/multibody/contact_solvers/sap/test/sap_model_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_model_test.cc
@@ -100,6 +100,10 @@ class SpringConstraint final : public SapConstraint<T> {
     return std::unique_ptr<SpringConstraint<T>>(new SpringConstraint<T>(*this));
   }
 
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final {
+    throw std::runtime_error("DoToDouble() not used in these unit tests.");
+  }
+
   VectorX<T> x0_;  // Previous time step configuration.
   T k_{0.0};       // Stiffness, in N/m.
   T tau_d_{0.0};   // Dissipation time scale, in seconds.
@@ -300,6 +304,10 @@ class DummyConstraint final : public SapConstraint<T> {
  private:
   std::unique_ptr<SapConstraint<T>> DoClone() const final {
     return std::unique_ptr<DummyConstraint<T>>(new DummyConstraint<T>(*this));
+  }
+
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final {
+    throw std::runtime_error("DoToDouble() not used in these unit tests.");
   }
 
   VectorX<T> R_;

--- a/multibody/contact_solvers/sap/test/sap_solver_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_test.cc
@@ -784,6 +784,9 @@ class LimitConstraint final : public SapConstraint<T> {
   std::unique_ptr<SapConstraint<T>> DoClone() const final {
     return std::unique_ptr<LimitConstraint<T>>(new LimitConstraint<T>(*this));
   }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final {
+    throw std::runtime_error("DoToDouble() not used in these unit tests.");
+  }
 
   VectorX<T> R_;     // Regularization.
   VectorX<T> vhat_;  // Bias.
@@ -1104,6 +1107,9 @@ class ConstantForceConstraint final : public SapConstraint<double> {
   std::unique_ptr<SapConstraint<double>> DoClone() const final {
     return std::unique_ptr<ConstantForceConstraint>(
         new ConstantForceConstraint(*this));
+  }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final {
+    throw std::runtime_error("DoToDouble() not used in these unit tests.");
   }
 
   const VectorXd g_;  // Constant impulse.

--- a/multibody/plant/test/sap_driver_contact_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_contact_constraints_test.cc
@@ -32,23 +32,6 @@ using Eigen::VectorXd;
 
 namespace drake {
 namespace multibody {
-namespace contact_solvers {
-namespace internal {
-bool operator==(const ContactConfiguration<double>& c1,
-                const ContactConfiguration<double>& c2) {
-  if (c1.objectA != c2.objectA) return false;
-  if (c1.p_ApC_W != c2.p_ApC_W) return false;
-  if (c1.objectB != c2.objectB) return false;
-  if (c1.p_BqC_W != c2.p_BqC_W) return false;
-  if (c1.phi != c2.phi) return false;
-  if (c1.fe != c2.fe) return false;
-  if (c1.vn != c2.vn) return false;
-  if (!c1.R_WC.IsExactlyEqualTo(c2.R_WC)) return false;
-  return true;
-}
-}  // namespace internal
-}  // namespace contact_solvers
-
 namespace internal {
 
 // Friend class used to provide access to a selection of private functions in

--- a/multibody/plant/test/sap_driver_pd_controller_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_pd_controller_constraints_test.cc
@@ -31,23 +31,6 @@ using Configuration = SapPdControllerConstraint<double>::Configuration;
 
 namespace drake {
 namespace multibody {
-
-namespace contact_solvers {
-namespace internal {
-// N.B. What namespace this operator is in is important for ADL.
-bool operator==(const Configuration& a, const Configuration& b) {
-  if (a.clique != b.clique) return false;
-  if (a.clique_dof != b.clique_dof) return false;
-  if (a.clique_nv != b.clique_nv) return false;
-  if (a.q0 != b.q0) return false;
-  if (a.qd != b.qd) return false;
-  if (a.vd != b.vd) return false;
-  if (a.u0 != b.u0) return false;
-  return true;
-}
-}  // namespace internal
-}  // namespace contact_solvers
-
 namespace internal {
 
 // Friend class used to provide access to a selection of private functions in


### PR DESCRIPTION
Towards the support of gradients through SAP, see https://github.com/RobotLocomotion/drake/issues/21370.

We will use AutoDiffXd to compute gradients through Featherstone dynamics and geometry. However the SAP solver will only solve a  problem on `T = double` and propagate gradients analytically.

Therefore we need the ability to discard gradients and convert a `SapContactProblem` to `T = double`.
This PR implements that, essentially a clone method. 
Most of this PR goes into implementing this clone function (DoToDouble()) on each constraint, plus testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21417)
<!-- Reviewable:end -->
