### PR TITLE
Adds DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN macro.

### DIFF
--- a/common/drake_copyable.h
+++ b/common/drake_copyable.h
@@ -88,3 +88,27 @@ that in a unit test.
       "This assertion is never false; its only purpose is to "  \
       "generate 'use of deleted function: operator=' errors "   \
       "when Classname is a template.");
+
+/** DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN declares the special member functions
+for copy-construction, copy-assignment, move-construction, and move-assignment.
+Use this macro when these functions are available, but require non-default
+implementations. (Use DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN instead if you can
+use the compiler-generated default implementations.) Drake's Doxygen is
+customized to render the declarations in detail, with appropriate comments
+assuming _unsurprising_ behavior of your hand-written functions. Invoke this
+macro in the public section of the class declaration, e.g.:
+<pre>
+class Foo {
+ public:
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(Foo)
+
+  // ...
+};
+</pre>
+Then the matching definitions should be placed in the associated .cc file.
+*/
+#define DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(Classname) \
+  Classname(const Classname&);                            \
+  Classname& operator=(const Classname&);                 \
+  Classname(Classname&&);                                 \
+  Classname& operator=(Classname&&);

--- a/common/test/drake_copyable_test.cc
+++ b/common/test/drake_copyable_test.cc
@@ -1,6 +1,10 @@
 #include "drake/common/drake_copyable.h"
 
+#include <utility>
+
 #include <gtest/gtest.h>
+
+#include "drake/common/unused.h"
 
 namespace drake {
 namespace {
@@ -13,28 +17,95 @@ namespace {
 //
 // Therefore, if DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN failed to default those
 // operations, then this unit test would no longer compile (under Clang).
-class Example {
+class ExampleDefault {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Example);
-  Example() = default;
-  ~Example() {}
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ExampleDefault);
+  ExampleDefault() = default;
+  ~ExampleDefault() = default;
 };
 
-GTEST_TEST(DrakeCopyableTest, CopyConstruct) {
-  Example foo;
-  Example bar(foo);
+GTEST_TEST(DrakeCopyableTest, DefaultCopyConstruct) {
+  ExampleDefault foo;
+  ExampleDefault bar(foo);
+  unused(bar);
 }
 
-GTEST_TEST(DrakeCopyableTest, CopyAssign) {
-  Example foo, bar;
+GTEST_TEST(DrakeCopyableTest, DefaultCopyAssign) {
+  ExampleDefault foo, bar;
   bar = foo;
+  unused(bar);
+}
+
+GTEST_TEST(DrakeCopyableTest, DefaultMoveConstruct) {
+  ExampleDefault foo;
+  ExampleDefault bar(std::move(foo));
+  unused(bar);
+}
+
+GTEST_TEST(DrakeCopyableTest, DefaultMoveAssign) {
+  ExampleDefault foo, bar;
+  bar = std::move(foo);
+  unused(bar);
 }
 
 // Confirm that private (and by association, protected) access for this macro
 // is permitted.  If not, this class would fail to compile.
-class ExamplePrivate {
+class ExampleDefaultPrivate {
  private:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ExamplePrivate);
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ExampleDefaultPrivate);
+};
+
+// When we can't use the default implementations, but are still able to provide
+// the same functionality with custom implementations,
+// DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN is used instead to provide uniform
+// declarations and documentation. We're just checking here that it provides
+// the right declarations.
+
+class ExampleDeclare {
+ public:
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(ExampleDeclare);
+  ExampleDeclare() = default;
+  ~ExampleDeclare() = default;
+};
+
+ExampleDeclare::ExampleDeclare(const ExampleDeclare&) {}
+ExampleDeclare& ExampleDeclare::operator=(const ExampleDeclare&) {
+  return *this;
+}
+ExampleDeclare::ExampleDeclare(ExampleDeclare&&) {}
+ExampleDeclare& ExampleDeclare::operator=(ExampleDeclare&&) {
+  return *this;
+}
+
+GTEST_TEST(DrakeCopyableTest, DeclareCopyConstruct) {
+  ExampleDeclare foo;
+  ExampleDeclare bar(foo);
+  unused(bar);
+}
+
+GTEST_TEST(DrakeCopyableTest, DeclareCopyAssign) {
+  ExampleDeclare foo, bar;
+  bar = foo;
+  unused(bar);
+}
+
+GTEST_TEST(DrakeCopyableTest, DeclareMoveConstruct) {
+  ExampleDeclare foo;
+  ExampleDeclare bar(std::move(foo));
+  unused(bar);
+}
+
+GTEST_TEST(DrakeCopyableTest, DeclareMoveAssign) {
+  ExampleDeclare foo, bar;
+  bar = std::move(foo);
+  unused(bar);
+}
+
+// Confirm that private (and by association, protected) access for this macro
+// is permitted.  If not, this class would fail to compile.
+class ExampleDeclarePrivate {
+ private:
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(ExampleDeclarePrivate);
 };
 
 }  // namespace

--- a/doc/doxygen_cxx/Doxyfile_CXX.in
+++ b/doc/doxygen_cxx/Doxyfile_CXX.in
@@ -326,10 +326,10 @@ X& operator=(X&&) = default; \
 PREDEFINED            += DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(X):=" \
 /** \name Implements CopyConstructible, CopyAssignable, MoveConstructible, MoveAssignable */ \
 /** \{ */ \
-X(const X&) = default; \
-X& operator=(const X&) = default; \
-X(X&&) = default; \
-X& operator=(X&&) = default; \
+X(const X&); \
+X& operator=(const X&); \
+X(X&&); \
+X& operator=(X&&); \
 /** \} */"
 PREDEFINED            += "DRAKE_DEPRECATED(removal_date,message):= \
 /** (Deprecated.) \deprecated message <br> \

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -18,18 +18,11 @@ for resources like mesh files. This class can also download remote packages from
 the internet on an as-needed basis via AddRemote(). */
 class PackageMap final {
  public:
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(PackageMap)
+
   /** A constructor that initializes a default map containing only the top-level
   `drake` manifest. See PackageMap::MakeEmpty() to create an empty map. */
   PackageMap();
-
-  /** @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
-  MoveAssignable */
-  //@{
-  PackageMap(const PackageMap&);
-  PackageMap& operator=(const PackageMap&);
-  PackageMap(PackageMap&&);
-  PackageMap& operator=(PackageMap&&);
-  //@}
 
   ~PackageMap();
 

--- a/multibody/topology/link_joint_graph.h
+++ b/multibody/topology/link_joint_graph.h
@@ -84,32 +84,13 @@ In general during SpanningForest building:
 separate LinkIndex type since these are necessarily the same. */
 class LinkJointGraph {
  public:
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(LinkJointGraph)
+
   class Link;  // Defined in separate headers.
   class Joint;
   class LoopConstraint;
 
   struct JointType;  // Defined below.
-
-  // This Doxygen text is intended to mimic the text generated for
-  // DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN. There is some extra information
-  // but the formatting is consistent.
-
-  // clang-format off
-  // NOLINTNEXTLINE(whitespace/line_length)
-  /** @name Implements CopyConstructible, CopyAssignable, MoveConstructible, MoveAssignable */
-  // clang-format on
-  /**@{*/
-  /** Copies both the graph and the forest if there is one. */
-  LinkJointGraph(const LinkJointGraph&);
-  /** Assigns both the graph and the forest if there is one. */
-  LinkJointGraph& operator=(const LinkJointGraph&);
-  /** Move construction leaves the source as though it had just been
-  default constructed. */
-  LinkJointGraph(LinkJointGraph&&);
-  /** Move assignment leaves the source as though it had just been
-  default constructed. */
-  LinkJointGraph& operator=(LinkJointGraph&&);
-  /**@}*/
 
   /** Default construction defines well-known joint types and World. */
   LinkJointGraph();

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -334,10 +334,7 @@ class SpanningForest {
 
   // The caller (only LinkJointGraph) must provide a new back pointer after copy
   // or move so these can't be default.
-  SpanningForest(const SpanningForest& source);
-  SpanningForest(SpanningForest&& source);
-  SpanningForest& operator=(const SpanningForest& source);
-  SpanningForest& operator=(SpanningForest&& source);
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(SpanningForest)
 
   // LinkJointGraph uses this to fix the graph back pointer after copy or move.
   void SetNewOwner(LinkJointGraph* graph) {


### PR DESCRIPTION
Adds a macro to use when all the copy & move builtins are defined for a class and behave normally, but can't use the compiler-generated defaults. This provides uniform documentation like we get for DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN.

(Per review discussion in #21349)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21419)
<!-- Reviewable:end -->
