### PR TITLE
[tools] Allow XAUTHORITY in tests

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -27,8 +27,10 @@ build --test_summary=terse
 # config_setting rules for proprietary software are provided in //tools.
 build --test_tag_filters=-gurobi,-mosek,-snopt
 
-# Inject DISPLAY into test runner environment for tests that use X.
+# Allow user environment variables relating to host graphics configuration to
+# flow through to tests that use X.
 build --test_env=DISPLAY
+build --test_env=XAUTHORITY
 
 # Location of the Gurobi license key file, typically named "gurobi.lic".
 # Setting this --test_env for all configurations is deliberate to improve


### PR DESCRIPTION
I convinced myself this was necessary by doing manual hero testing using a 24.04 laptop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21422)
<!-- Reviewable:end -->
