### PR TITLE
Port to C++20 spaceship operators

### DIFF
--- a/common/ad/internal/standard_operations.h
+++ b/common/ad/internal/standard_operations.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <compare>
 #include <iosfwd>
 
 /* This file contains free function operators for Drake's AutoDiff type.
@@ -242,93 +243,23 @@ inline AutoDiff operator/(double a, const AutoDiff& b) {
 //@{
 
 /** Standard comparison operator. Discards the derivatives. */
-inline bool operator<(const AutoDiff& a, const AutoDiff& b) {
-  return a.value() < b.value();
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator<=(const AutoDiff& a, const AutoDiff& b) {
-  return a.value() <= b.value();
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator>(const AutoDiff& a, const AutoDiff& b) {
-  return a.value() > b.value();
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator>=(const AutoDiff& a, const AutoDiff& b) {
-  return a.value() >= b.value();
+inline std::partial_ordering operator<=>(const AutoDiff& a, const AutoDiff& b) {
+  return a.value() <=> b.value();
 }
 
 /** Standard comparison operator. Discards the derivatives. */
 inline bool operator==(const AutoDiff& a, const AutoDiff& b) {
-  return a.value() == b.value();
+  return (a <=> b) == 0;
 }
 
 /** Standard comparison operator. Discards the derivatives. */
-inline bool operator!=(const AutoDiff& a, const AutoDiff& b) {
-  return a.value() != b.value();
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator<(const AutoDiff& a, double b) {
-  return a.value() < b;
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator<=(const AutoDiff& a, double b) {
-  return a.value() <= b;
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator>(const AutoDiff& a, double b) {
-  return a.value() > b;
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator>=(const AutoDiff& a, double b) {
-  return a.value() >= b;
+inline std::partial_ordering operator<=>(const AutoDiff& a, double b) {
+  return a.value() <=> b;
 }
 
 /** Standard comparison operator. Discards the derivatives. */
 inline bool operator==(const AutoDiff& a, double b) {
-  return a.value() == b;
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator!=(const AutoDiff& a, double b) {
-  return a.value() != b;
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator<(double a, const AutoDiff& b) {
-  return a < b.value();
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator<=(double a, const AutoDiff& b) {
-  return a <= b.value();
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator>(double a, const AutoDiff& b) {
-  return a > b.value();
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator>=(double a, const AutoDiff& b) {
-  return a >= b.value();
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator==(double a, const AutoDiff& b) {
-  return a == b.value();
-}
-
-/** Standard comparison operator. Discards the derivatives. */
-inline bool operator!=(double a, const AutoDiff& b) {
-  return a != b.value();
+  return (a <=> b) == 0;
 }
 
 //@}

--- a/common/ad/test/standard_operations_cmp_test.cc
+++ b/common/ad/test/standard_operations_cmp_test.cc
@@ -7,16 +7,21 @@ namespace drake {
 namespace test {
 namespace {
 
-#define DRAKE_CHECK_CMP(cmp)                             \
-  EXPECT_EQ(0 cmp 1, AutoDiffDut{0} cmp AutoDiffDut{1}); \
-  EXPECT_EQ(1 cmp 0, AutoDiffDut{1} cmp AutoDiffDut{0}); \
-  EXPECT_EQ(1 cmp 1, AutoDiffDut{1} cmp AutoDiffDut{1}); \
-  EXPECT_EQ(0 cmp 1, AutoDiffDut{0} cmp 1); /* NOLINT */ \
-  EXPECT_EQ(1 cmp 0, AutoDiffDut{1} cmp 0); /* NOLINT */ \
-  EXPECT_EQ(1 cmp 1, AutoDiffDut{1} cmp 1); /* NOLINT */ \
-  EXPECT_EQ(0 cmp 1, 0 cmp AutoDiffDut{1});              \
-  EXPECT_EQ(1 cmp 0, 1 cmp AutoDiffDut{0});              \
-  EXPECT_EQ(1 cmp 1, 1 cmp AutoDiffDut{1})
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+#define DRAKE_CHECK_CMP(cmp)                                   \
+  EXPECT_EQ(0 cmp 1, AutoDiffDut{0} cmp AutoDiffDut{1});       \
+  EXPECT_EQ(1 cmp 0, AutoDiffDut{1} cmp AutoDiffDut{0});       \
+  EXPECT_EQ(1 cmp 1, AutoDiffDut{1} cmp AutoDiffDut{1});       \
+  EXPECT_EQ(0 cmp 1, AutoDiffDut{0} cmp 1); /* NOLINT */       \
+  EXPECT_EQ(1 cmp 0, AutoDiffDut{1} cmp 0); /* NOLINT */       \
+  EXPECT_EQ(1 cmp 1, AutoDiffDut{1} cmp 1); /* NOLINT */       \
+  EXPECT_EQ(0 cmp 1, 0 cmp AutoDiffDut{1});                    \
+  EXPECT_EQ(1 cmp 0, 1 cmp AutoDiffDut{0});                    \
+  EXPECT_EQ(1 cmp 1, 1 cmp AutoDiffDut{1});                    \
+  EXPECT_EQ(0 cmp kNaN, AutoDiffDut{0} cmp AutoDiffDut{kNaN}); \
+  EXPECT_EQ(0 cmp kNaN, AutoDiffDut{0} cmp kNaN); /* NOLINT */ \
+  EXPECT_EQ(0 cmp kNaN, 0 cmp AutoDiffDut{kNaN})
 
 TEST_F(StandardOperationsTest, CmpLt) {
   DRAKE_CHECK_CMP(<);  // NOLINT

--- a/common/identifier.h
+++ b/common/identifier.h
@@ -160,25 +160,18 @@ class Identifier {
   /** Reports if the id is valid. */
   bool is_valid() const { return value_ > 0; }
 
-  /** Compares one identifier with another of the same type for equality. This
-   is considered invalid for invalid ids and is strictly enforced in Debug
+  /** Compares one identifier with another of the same type for (in)equality.
+   This is considered invalid for invalid ids and is strictly enforced in Debug
    builds. */
   bool operator==(Identifier other) const {
     return this->get_value() == other.get_value();
   }
 
-  /** Compares one identifier with another of the same type for inequality. This
-   is considered invalid for invalid ids and is strictly enforced in Debug
-   builds. */
-  bool operator!=(Identifier other) const {
-    return this->get_value() != other.get_value();
-  }
-
   /** Compare two identifiers in order to define a total ordering among
    identifiers. This makes identifiers compatible with data structures which
    require total ordering (e.g., std::set).  */
-  bool operator<(Identifier other) const {
-    return this->get_value() < other.get_value();
+  auto operator<=>(Identifier other) const {
+    return get_value() <=> other.get_value();
   }
 
   /** Generates a new identifier for this id type. This new identifier will be

--- a/common/sha256.h
+++ b/common/sha256.h
@@ -40,6 +40,7 @@ class Sha256 final {
   std::string to_string() const;
 
   // Offer typical comparison operations.
+  // TODO(jwnimmer-tri) Rewrite as spaceship after we drop Ventura.
   bool operator==(const Sha256& other) const { return bytes_ == other.bytes_; }
   bool operator!=(const Sha256& other) const { return bytes_ != other.bytes_; }
   bool operator<(const Sha256& other) const { return bytes_ < other.bytes_; }

--- a/common/sorted_pair.h
+++ b/common/sorted_pair.h
@@ -124,6 +124,8 @@ struct SortedPair {
   T second_{};  // The second of the two objects, according to operator<.
 };
 
+// TODO(jwnimmer-tri) Rewrite the below using spaceship after we drop Ventura.
+
 /// Two pairs of the same type are equal iff their members are equal after
 /// sorting.
 template <class T>

--- a/common/symbolic/expression/expression_kind.h
+++ b/common/symbolic/expression/expression_kind.h
@@ -50,8 +50,8 @@ enum class ExpressionKind : std::uint16_t {
 };
 
 /** Total ordering between ExpressionKinds. */
-inline bool operator<(ExpressionKind k1, ExpressionKind k2) {
-  return static_cast<std::uint16_t>(k1) < static_cast<std::uint16_t>(k2);
+inline auto operator<=>(ExpressionKind k1, ExpressionKind k2) {
+  return static_cast<std::uint16_t>(k1) <=> static_cast<std::uint16_t>(k2);
 }
 
 }  // namespace symbolic

--- a/common/symbolic/expression/formula.cc
+++ b/common/symbolic/expression/formula.cc
@@ -26,10 +26,6 @@ using std::set;
 using std::shared_ptr;
 using std::string;
 
-bool operator<(FormulaKind k1, FormulaKind k2) {
-  return static_cast<int>(k1) < static_cast<int>(k2);
-}
-
 Formula::Formula(std::shared_ptr<const FormulaCell> ptr)
     : ptr_{std::move(ptr)} {}
 

--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -44,7 +44,9 @@ enum class FormulaKind {
 };
 
 // Total ordering between FormulaKinds
-bool operator<(FormulaKind k1, FormulaKind k2);
+inline auto operator<=>(FormulaKind k1, FormulaKind k2) {
+  return static_cast<int>(k1) <=> static_cast<int>(k2);
+}
 
 class FormulaCell;                  // In drake/common/formula_cell.h
 class FormulaFalse;                 // In drake/common/formula_cell.h

--- a/common/symbolic/expression/variables.cc
+++ b/common/symbolic/expression/variables.cc
@@ -70,15 +70,14 @@ bool Variables::IsStrictSupersetOf(const Variables& vars) const {
   return IsSupersetOf(vars);
 }
 
-bool operator==(const Variables& vars1, const Variables& vars2) {
-  return std::equal(vars1.vars_.begin(), vars1.vars_.end(), vars2.vars_.begin(),
-                    vars2.vars_.end(), std::equal_to<Variable>{});
-}
-
-bool operator<(const Variables& vars1, const Variables& vars2) {
-  return std::lexicographical_compare(vars1.vars_.begin(), vars1.vars_.end(),
-                                      vars2.vars_.begin(), vars2.vars_.end(),
-                                      std::less<Variable>{});
+std::strong_ordering operator<=>(const Variables& vars1,
+                                 const Variables& vars2) {
+  return std::lexicographical_compare_three_way(
+      vars1.vars_.begin(), vars1.vars_.end(),  // BR
+      vars2.vars_.begin(), vars2.vars_.end(),
+      [](const Variable& v1, const Variable& v2) {
+        return v1.get_id() <=> v2.get_id();
+      });
 }
 
 // NOLINTNEXTLINE(runtime/references) per C++ standard signature.

--- a/common/symbolic/expression/variables.h
+++ b/common/symbolic/expression/variables.h
@@ -4,6 +4,7 @@
 #error Do not include this file. Use "drake/common/symbolic/expression.h".
 #endif
 
+#include <compare>
 #include <cstddef>
 #include <functional>
 #include <initializer_list>
@@ -129,9 +130,12 @@ class Variables {
   /** Return true if @p vars is a strict superset of the Variables. */
   [[nodiscard]] bool IsStrictSupersetOf(const Variables& vars) const;
 
-  friend bool operator==(const Variables& vars1, const Variables& vars2);
+  friend bool operator==(const Variables& vars1, const Variables& vars2) {
+    return (vars1 <=> vars2) == 0;
+  }
 
-  friend bool operator<(const Variables& vars1, const Variables& vars2);
+  friend std::strong_ordering operator<=>(const Variables& vars1,
+                                          const Variables& vars2);
 
   friend std::ostream& operator<<(std::ostream&, const Variables& vars);
 

--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -144,29 +144,29 @@ GTEST_TEST(TypeSafeIndex, InvalidIndexComparisonOperators) {
 
   // Comparison operators.
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid == valid,
-                                      "Testing == with invalid LHS.+");
+                                      "Testing .+ with invalid LHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid == invalid,
-                                      "Testing == with invalid RHS.+");
+                                      "Testing .+ with invalid RHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid != valid,
-                                      "Testing != with invalid LHS.+");
+                                      "Testing .+ with invalid LHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid != invalid,
-                                      "Testing != with invalid RHS.+");
+                                      "Testing .+ with invalid RHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid < valid,
-                                      "Testing < with invalid LHS.+");
+                                      "Testing .+ with invalid LHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid < invalid,
-                                      "Testing < with invalid RHS.+");
+                                      "Testing .+ with invalid RHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid <= valid,
-                                      "Testing <= with invalid LHS.+");
+                                      "Testing .+ with invalid LHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid <= invalid,
-                                      "Testing <= with invalid RHS.+");
+                                      "Testing .+ with invalid RHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid > valid,
-                                      "Testing > with invalid LHS.+");
+                                      "Testing .+ with invalid LHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid > invalid,
-                                      "Testing > with invalid RHS.+");
+                                      "Testing .+ with invalid RHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(invalid >= valid,
-                                      "Testing >= with invalid LHS.+");
+                                      "Testing .+ with invalid LHS.+");
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(valid >= invalid,
-                                      "Testing >= with invalid RHS.+");
+                                      "Testing .+ with invalid RHS.+");
 }
 
 // Tests the prefix increment behavior.

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <compare>
 #include <limits>
 #include <string>
 #include <typeinfo>
@@ -352,7 +353,7 @@ class TypeSafeIndex {
   //
   // SFINAE prevents the latter.
 
-  /// Allow equality test with indices of this tag.
+  /// Allow (in)equality test with indices of this tag.
   bool operator==(const TypeSafeIndex<Tag>& other) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing == with invalid LHS."));
     DRAKE_ASSERT_VOID(
@@ -360,127 +361,45 @@ class TypeSafeIndex {
     return index_ == other.index_;
   }
 
-  /// Allow equality test with unsigned integers.
+  /// Allow (in)equality test with unsigned integers.
   template <typename U>
   typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
                             bool>
-  operator==(const U& value) const {
+  operator==(U value) const {
     DRAKE_ASSERT_VOID(AssertValid(index_, "Testing == with invalid index."));
-    return value <= static_cast<U>(kMaxIndex) &&
-           index_ == static_cast<int>(value);
+    if (value > kMaxIndex) {
+      return false;
+    }
+    return index_ == static_cast<int>(value);
   }
 
-  /// Prevent equality tests with indices of other tags.
+  /// Prevent (in)equality tests with indices of other tags.
   template <typename U>
   bool operator==(const TypeSafeIndex<U>& u) const = delete;
 
-  /// Allow inequality test with indices of this tag.
-  bool operator!=(const TypeSafeIndex<Tag>& other) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing != with invalid LHS."));
+  /// Allow comparison with indices of this tag.
+  auto operator<=>(const TypeSafeIndex<Tag>& other) const {
+    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing <=> with invalid LHS."));
     DRAKE_ASSERT_VOID(
-        AssertValid(other.index_, "Testing != with invalid RHS."));
-    return index_ != other.index_;
+        AssertValid(other.index_, "Testing <=> with invalid RHS."));
+    return index_ <=> other.index_;
   }
 
-  /// Allow inequality test with unsigned integers.
+  /// Allow comparison with unsigned integers.
   template <typename U>
   typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
-                            bool>
-  operator!=(const U& value) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing != with invalid index."));
-    return value > static_cast<U>(kMaxIndex) ||
-           index_ != static_cast<int>(value);
+                            std::strong_ordering>
+  operator<=>(U value) const {
+    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing <=> with invalid Index."));
+    if (value > kMaxIndex) {
+      return std::strong_ordering::less;
+    }
+    return index_ <=> static_cast<int>(value);
   }
 
-  /// Prevent inequality test with indices of other tags.
+  /// Prevent comparison with indices of other tags.
   template <typename U>
-  bool operator!=(const TypeSafeIndex<U>& u) const = delete;
-
-  /// Allow less than test with indices of this tag.
-  bool operator<(const TypeSafeIndex<Tag>& other) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing < with invalid LHS."));
-    DRAKE_ASSERT_VOID(AssertValid(other.index_, "Testing < with invalid RHS."));
-    return index_ < other.index_;
-  }
-
-  /// Allow less than test with unsigned integers.
-  template <typename U>
-  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
-                            bool>
-  operator<(const U& value) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing < with invalid index."));
-    return value > static_cast<U>(kMaxIndex) ||
-           index_ < static_cast<int>(value);
-  }
-
-  /// Prevent less than test with indices of other tags.
-  template <typename U>
-  bool operator<(const TypeSafeIndex<U>& u) const = delete;
-
-  /// Allow less than or equals test with indices of this tag.
-  bool operator<=(const TypeSafeIndex<Tag>& other) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing <= with invalid LHS."));
-    DRAKE_ASSERT_VOID(
-        AssertValid(other.index_, "Testing <= with invalid RHS."));
-    return index_ <= other.index_;
-  }
-
-  /// Allow less than or equals test with unsigned integers.
-  template <typename U>
-  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
-                            bool>
-  operator<=(const U& value) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing <= with invalid index."));
-    return value > static_cast<U>(kMaxIndex) ||
-           index_ <= static_cast<int>(value);
-  }
-
-  /// Prevent less than or equals test with indices of other tags.
-  template <typename U>
-  bool operator<=(const TypeSafeIndex<U>& u) const = delete;
-
-  /// Allow greater than test with indices of this tag.
-  bool operator>(const TypeSafeIndex<Tag>& other) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing > with invalid LHS."));
-    DRAKE_ASSERT_VOID(AssertValid(other.index_, "Testing > with invalid RHS."));
-    return index_ > other.index_;
-  }
-
-  /// Allow greater than test with unsigned integers.
-  template <typename U>
-  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
-                            bool>
-  operator>(const U& value) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing > with invalid index."));
-    return value <= static_cast<U>(kMaxIndex) &&
-           index_ > static_cast<int>(value);
-  }
-
-  /// Prevent greater than test with indices of other tags.
-  template <typename U>
-  bool operator>(const TypeSafeIndex<U>& u) const = delete;
-
-  /// Allow greater than or equals test with indices of this tag.
-  bool operator>=(const TypeSafeIndex<Tag>& other) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing >= with invalid LHS."));
-    DRAKE_ASSERT_VOID(
-        AssertValid(other.index_, "Testing >= with invalid RHS."));
-    return index_ >= other.index_;
-  }
-
-  /// Allow greater than or equals test with unsigned integers.
-  template <typename U>
-  typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>,
-                            bool>
-  operator>=(const U& value) const {
-    DRAKE_ASSERT_VOID(AssertValid(index_, "Testing >= with invalid index."));
-    return value <= static_cast<U>(kMaxIndex) &&
-           index_ >= static_cast<int>(value);
-  }
-
-  /// Prevent greater than or equals test with indices of other tags.
-  template <typename U>
-  bool operator>=(const TypeSafeIndex<U>& u) const = delete;
+  bool operator<=>(const TypeSafeIndex<U>& u) const = delete;
 
   ///@}
 
@@ -530,42 +449,6 @@ class TypeSafeIndex {
   // to fail.
   static constexpr int kMaxIndex = std::numeric_limits<int>::max();
 };
-
-template <typename Tag, typename U>
-typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
-operator==(const U& value, const TypeSafeIndex<Tag>& tag) {
-  return tag.operator==(value);
-}
-
-template <typename Tag, typename U>
-typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
-operator!=(const U& value, const TypeSafeIndex<Tag>& tag) {
-  return tag.operator!=(value);
-}
-
-template <typename Tag, typename U>
-typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
-operator<(const U& value, const TypeSafeIndex<Tag>& tag) {
-  return tag >= value;
-}
-
-template <typename Tag, typename U>
-typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
-operator<=(const U& value, const TypeSafeIndex<Tag>& tag) {
-  return tag > value;
-}
-
-template <typename Tag, typename U>
-typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
-operator>(const U& value, const TypeSafeIndex<Tag>& tag) {
-  return tag <= value;
-}
-
-template <typename Tag, typename U>
-typename std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, bool>
-operator>=(const U& value, const TypeSafeIndex<Tag>& tag) {
-  return tag < value;
-}
 
 }  // namespace drake
 

--- a/geometry/proximity/sorted_triplet.h
+++ b/geometry/proximity/sorted_triplet.h
@@ -66,6 +66,8 @@ struct SortedTriplet {
   std::array<T, 3> objects_{};
 };
 
+// TODO(jwnimmer-tri) Rewrite the below using spaceship after we drop Ventura.
+
 // Two triplets of the same type are equal iff their members are equal after
 // sorting.
 template <class T>

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -85,24 +85,10 @@ class RenderLabel {
                              reserved values.  */
   explicit RenderLabel(int value) : RenderLabel(value, true) {}
 
-  /** Compares this label with the `other` label. Reports true if they have the
-   same value.  */
-  bool operator==(const RenderLabel& other) const {
-    return value_ == other.value_;
-  }
-
-  /** Compares this label with the `other` label. Reports true if they have
-   different values.  */
-  bool operator!=(const RenderLabel& other) const {
-    return value_ != other.value_;
-  }
-
   /** Allows the labels to be compared to imply a total ordering -- facilitates
    use in data structures which require ordering (e.g., std::set). The ordering
    has no particular meaning for applications.  */
-  bool operator<(const RenderLabel& other) const {
-    return value_ < other.value_;
-  }
+  auto operator<=>(const RenderLabel& other) const = default;
 
   /** Implements the @ref hash_append concept. */
   template <class HashAlgorithm>


### PR DESCRIPTION
This ports about 75% of our comparisons to be spelled using https://en.cppreference.com/w/cpp/language/operator_comparison#Three-way_comparison, focusing especially on the code in `common`.

While reviewing, it might help to remember how `operator<=>` works:
- When it is defaulted (`= default`), you get all 6 comparison functions (i.e., both equality and ordering).
- When it is defined by hand, you only get the 4 comparison functions (ordering) so still need to write `operator==` (equality) yourself to get the last two.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21423)
<!-- Reviewable:end -->
