### PR TITLE
[sap] Avoid factoring ununitialized memory

### DIFF
--- a/multibody/contact_solvers/sap/dense_supernodal_solver.cc
+++ b/multibody/contact_solvers/sap/dense_supernodal_solver.cc
@@ -7,13 +7,8 @@ namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
-int SafeGetCols(const BlockSparseMatrix<double>* J) {
-  DRAKE_THROW_UNLESS(J != nullptr);
-  return J->cols();
-}
-
 template <typename T>
-const T& SafeGetReference(std::string_view variable_name, const T* ptr) {
+const T& SafeDeference(std::string_view variable_name, const T* ptr) {
   if (ptr == nullptr) {
     throw std::runtime_error(
         fmt::format("Condition '{} != nullptr' failed.", variable_name));
@@ -23,9 +18,9 @@ const T& SafeGetReference(std::string_view variable_name, const T* ptr) {
 
 DenseSuperNodalSolver::DenseSuperNodalSolver(
     const std::vector<MatrixX<double>>* A, const BlockSparseMatrix<double>* J)
-    : A_(SafeGetReference("A", A)),
-      J_(SafeGetReference("J", J)),
-      H_(SafeGetCols(J), SafeGetCols(J)),
+    : A_(SafeDeference("A", A)),
+      J_(SafeDeference("J", J)),
+      H_(Eigen::MatrixXd::Zero(J->cols(), J->cols())),
       Hldlt_(H_) {
   const int nv = [this]() {
     int size = 0;


### PR DESCRIPTION
Hotfix for #21421:

```
[ RUN      ] DenseSuperNodalSolver.InterfaceTest
==20== Conditional jump or move depends on uninitialised value(s)
==20==    at 0x14A588: Eigen::LDLT<Eigen::Ref<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0, Eigen::OuterStride<-1> >, 1>& Eigen::LDLT<Eigen::Ref<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0, Eigen::OuterStride<-1> >, 1>::compute<Eigen::Matrix<double, -1, -1, 0, -1, -1> >(Eigen::EigenBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&) (LDLT.h:517)
==20==    by 0x14A1A7: Eigen::LDLT<Eigen::Ref<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0, Eigen::OuterStride<-1> >, 1>::LDLT<Eigen::Matrix<double, -1, -1, 0, -1, -1> >(Eigen::EigenBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> >&) (LDLT.h:137)
==20==    by 0x149A53: drake::multibody::contact_solvers::internal::DenseSuperNodalSolver::DenseSuperNodalSolver(std::vector<Eigen::Matrix<double, -1, -1, 0, -1, -1>, std::allocator<Eigen::Matrix<double, -1, -1, 0, -1, -1> > > const*, drake::multibody::contact_solvers::internal::BlockSparseMatrix<double> const*) (dense_supernodal_solver.cc:29)
==20==    by 0x11D5B2: drake::multibody::contact_solvers::internal::DenseSuperNodalSolver_InterfaceTest_Test::TestBody() (dense_supernodal_solver_test.cc:129)
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21430)
<!-- Reviewable:end -->
