### PR TITLE
[multibody] Allow setting DiffIK solver options

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -107,7 +107,9 @@ void DefineIkDifferential(py::module m) {
         .def("set_end_effector_translational_velocity_limits",
             &Class::set_end_effector_translational_velocity_limits,
             py::arg("lower"), py::arg("upper"),
-            cls_doc.set_end_effector_translational_velocity_limits.doc);
+            cls_doc.set_end_effector_translational_velocity_limits.doc)
+        .def("get_mutable_solver_options", &Class::get_mutable_solver_options,
+            py_rvp::reference_internal, cls_doc.get_mutable_solver_options.doc);
   }
 
   m.def(

--- a/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
@@ -9,6 +9,7 @@ from pydrake.common import FindResourceOrThrow
 from pydrake.math import RigidTransform
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
+from pydrake.solvers import SolverId
 
 
 class TestPlanner(unittest.TestCase):
@@ -60,6 +61,8 @@ class TestPlanner(unittest.TestCase):
         np.testing.assert_equal(
             params.get_end_effector_translational_velocity_limits()[1],
             [1, 2, 3])
+        params.get_mutable_solver_options().SetOption(
+            SolverId("dummy"), "dummy", 0.0)
 
         # Test a basic call for the API. These values intentionally have no
         # physical meaning.

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -173,6 +173,7 @@ drake_cc_googletest(
         "//common/test_utilities:expect_throws_message",
         "//manipulation/kuka_iiwa:iiwa_constants",
         "//multibody/parsing",
+        "//solvers:osqp_solver",
     ],
 )
 

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.cc
@@ -233,10 +233,10 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
 
   if (quadratic_cost) {
     solvers::OsqpSolver solver;
-    result = solver.Solve(prog, {}, {});
+    result = solver.Solve(prog, {}, parameters.get_solver_options());
   } else {
     solvers::ClpSolver solver;
-    result = solver.Solve(prog, {}, {});
+    result = solver.Solve(prog, {}, parameters.get_solver_options());
   }
 
   if (!result.is_success()) {

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.h
@@ -259,6 +259,21 @@ class DifferentialInverseKinematicsParameters {
    */
   void ClearLinearVelocityConstraints();
 
+  /**
+   * Provides const access to read the solver options.
+   */
+  const solvers::SolverOptions& get_solver_options() const {
+    return solver_options_;
+  }
+
+  /**
+   * Provides mutable access to change the solver options, e.g., to tune for
+   * speed vs accuracy.
+   */
+  solvers::SolverOptions& get_mutable_solver_options() {
+    return solver_options_;
+  }
+
  private:
   int num_positions_{0};
   int num_velocities_{0};
@@ -276,6 +291,7 @@ class DifferentialInverseKinematicsParameters {
       translational_velocity_bounds_{};
   std::vector<std::shared_ptr<solvers::LinearConstraint>>
       linear_velocity_constraints_;
+  solvers::SolverOptions solver_options_;
 };
 
 /**

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
@@ -15,6 +15,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/solvers/constraint.h"
+#include "drake/solvers/osqp_solver.h"
 
 namespace drake {
 namespace multibody {
@@ -175,6 +176,14 @@ TEST_F(DifferentialInverseKinematicsTest, PositiveTest) {
   result = DoDiffIKForSpatialVelocity(V_WE_W);
   drake::log()->info("result.status = {}", result.status);
   CheckPositiveResult(V_WE_W, result);
+
+  // Setting an impossibly tight solver option nixes the solution. This proves
+  // that we're passing through the custom solver options correctly.
+  params_->get_mutable_solver_options().SetOption(solvers::OsqpSolver::id(),
+                                                  "max_iter", 0);
+  result = DoDiffIKForSpatialVelocity(V_WE_W);
+  EXPECT_EQ(result.status,
+            DifferentialInverseKinematicsStatus::kNoSolutionFound);
 }
 
 TEST_F(DifferentialInverseKinematicsTest, OverConstrainedTest) {


### PR DESCRIPTION
This is a mitigation for #18711, so that downstream code can opt-in to determinism until the underlying problem is fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21433)
<!-- Reviewable:end -->
