### PR TITLE
Reorder SpatialVelocity::Shift to avoid issues with ARM

### DIFF
--- a/multibody/math/spatial_velocity.h
+++ b/multibody/math/spatial_velocity.h
@@ -109,7 +109,9 @@ class SpatialVelocity : public SpatialVector<SpatialVelocity, T> {
   /// `this` whereas ShiftInPlace() does modify `this`.
   /// @see ShiftInPlace() for more information and how V_MC_E is calculated.
   SpatialVelocity<T> Shift(const Vector3<T>& offset) const {
-    return SpatialVelocity<T>(*this).ShiftInPlace(offset);
+    auto ret = SpatialVelocity<T>(*this);
+    ret.ShiftInPlace(offset);
+    return ret;
   }
 
   /// Compose `this` spatial velocity (measured in some frame M) with the


### PR DESCRIPTION
The method `Shift` from `SpatialVelocity` seems to have unexpected behavior in some specific situations when running under `arm64`. This seemed to be the root cause of several tests failing, even tho the actual tests for `math/spatial_velocity` wouldn't fail.

The way this has been found was through some failing test cases in `//multibody/plant:energy_and_power_test` (for example [this](https://github.com/RobotLocomotion/drake/blob/master/multibody/plant/test/energy_and_power_test.cc#L172) one). The failure would come from the correct results coming out from the simulation, but the expected value wrongly calculated. By debugging and comparing results between the `x86` and `arm64` runs, the value of the variable `v_QW` in [this](https://github.com/RobotLocomotion/drake/blob/master/multibody/plant/test/energy_and_power_test.cc#L159) line was found different between architectures.
I couldn't figure out if there is a compiler optimization/reorder of operations going on (although this would still happen when building in debug) but something interesting to note is that calculating the same value once again (meaning, duplicating the line) would cause different results. The variable that then is used along the tests would hold a wrong value, whereas the duplicated one would hold the expected value and no other call to the same operation over the same `SpatialVelocity` would cause any other unexpected behavior. Another option would be an issue with lifetime, since we're mixing a temporal, with a change to a reference and then returning by value, but that wouldn't explain why it works for `x86` and even more, why it works as expected when called repeatedly.

The proposed solution solves several tests in the codebase (again, for arm64) but there's no really foundation on why the previous approach wouldn't work, so any feedback is welcomed.

The lists of tests that, at least locally, get solved by this change are:
- `//multibody/plant:box_test`
- `//multibody/plant:compliant_contact_manager_test`
- `//multibody/plant:energy_and_power_test`
- `//multibody/plant:inclined_plane_test`
- `//multibody/plant:multibody_plant_com_test`
- `//multibody/plant:multibody_plant_jacobians_test`
- `//multibody/plant:multibody_plant_reaction_forces_test`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21436)
<!-- Reviewable:end -->
