### PR TITLE
[multibody] Change "InPlace" functions to return void

### DIFF
--- a/multibody/contact_solvers/sap/test/sap_ball_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_ball_constraint_test.cc
@@ -179,12 +179,12 @@ GTEST_TEST(SapBallConstraint, AccumulateSpatialImpulses) {
   // Expected spatial impulse on B.
   const SpatialForce<double> F_Bo_W =
       (SpatialForce<double>(Vector3d::Zero(), gamma))
-          .ShiftInPlace(-kinematics.p_BQ_W());
+          .Shift(-kinematics.p_BQ_W());
 
   // Expected spatial impulse on A.
   const SpatialForce<double> F_Ao_W =
       (SpatialForce<double>(Vector3d::Zero(), -gamma))
-          .ShiftInPlace(-kinematics.p_AP_W());
+          .Shift(-kinematics.p_AP_W());
 
   const SpatialForce<double> F0(Vector3d(1., 2., 3), Vector3d(4., 5., 6));
   SpatialForce<double> Faccumulated = F0;  // Initialize to non-zero value.

--- a/multibody/contact_solvers/sap/test/sap_fixed_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_fixed_constraint_test.cc
@@ -242,16 +242,16 @@ GTEST_TEST(SapFixedConstraint, AccumulateSpatialImpulses) {
   // Expected spatial impulse on B.
   const SpatialForce<double> F_Bo_W =
       SpatialForce<double>(Vector3d::Zero(), gamma0)
-          .ShiftInPlace(Vector3d(0.25, 0, 0)) +
+          .Shift(Vector3d(0.25, 0, 0)) +
       SpatialForce<double>(Vector3d::Zero(), gamma1)
-          .ShiftInPlace(Vector3d(0.5, 0, 0.5));
+          .Shift(Vector3d(0.5, 0, 0.5));
 
   // Expected spatial impulse on A.
   const SpatialForce<double> F_Ao_W =
       SpatialForce<double>(Vector3d::Zero(), -gamma0)
-          .ShiftInPlace(Vector3d(-0.25, 0, 0)) +
+          .Shift(Vector3d(-0.25, 0, 0)) +
       SpatialForce<double>(Vector3d::Zero(), -gamma1)
-          .ShiftInPlace(Vector3d(-0.5, 0, -0.5));
+          .Shift(Vector3d(-0.5, 0, -0.5));
 
   const SpatialForce<double> F0(Vector3d(1, 2, 3), Vector3d(4, 5, 6));
   SpatialForce<double> Faccumulated = F0;  // Initialize to non-zero value.

--- a/multibody/math/spatial_acceleration.h
+++ b/multibody/math/spatial_acceleration.h
@@ -86,17 +86,15 @@ class SpatialAcceleration : public SpatialVector<SpatialAcceleration, T> {
   /// `this` is A_MB_E (frame B's spatial acceleration measured in a frame M and
   /// expressed in a frame E). On return `this` is modified to A_MC_E (frame C's
   /// spatial acceleration measured in frame M and expressed in frame E).
+  /// The components of A_MC_E are calculated as: <pre>
+  ///   α_MC_E = α_MB_E           (angular acceleration of `this` is unchanged).
+  ///  a_MCo_E = a_MBo_E + α_MB_E x p_BoCo_E + ω_MB_E x (ω_MB_E x p_BoCo_E)
+  /// </pre>
   /// @param[in] offset which is the position vector p_BoCo_E from Bo (frame B's
   /// origin) to Co (frame C's origin), expressed in frame E. p_BoCo_E must have
   /// the same expressed-in frame E as `this` spatial acceleration.
   /// @param[in] angular_velocity_of_this_frame which is ω_MB_E, frame B's
   /// angular velocity measured in frame W and expressed in frame E.
-  /// @retval A_MC_E reference to `this` spatial acceleration which has been
-  /// modified to be frame C's spatial acceleration measured in frame M and
-  /// expressed in frame E. The components of A_MC_E are calculated as: <pre>
-  ///   α_MC_E = α_MB_E           (angular acceleration of `this` is unchanged).
-  ///  a_MCo_E = a_MBo_E + α_MB_E x p_BoCo_E + ω_MB_E x (ω_MB_E x p_BoCo_E)
-  /// </pre>
   /// @see Shift() to shift spatial acceleration without modifying `this`.
   /// Use ComposeWithMovingFrameAcceleration() if frame C is moving on frame B.
   ///
@@ -128,9 +126,8 @@ class SpatialAcceleration : public SpatialVector<SpatialAcceleration, T> {
   ///   DtM(p_BoCo) = DtB(p_BoCo) + ω_MB x p_BoCo
   ///               =          0  + ω_MB x p_BoCo
   /// </pre>
-  SpatialAcceleration<T>& ShiftInPlace(
-      const Vector3<T>& offset,
-      const Vector3<T>& angular_velocity_of_this_frame) {
+  void ShiftInPlace(const Vector3<T>& offset,
+                    const Vector3<T>& angular_velocity_of_this_frame) {
     const Vector3<T>& p_BoCo_E = offset;
     const Vector3<T>& w_MB_E = angular_velocity_of_this_frame;
     // Frame B's angular acceleration measured in frame M, expressed in frame M.
@@ -139,7 +136,6 @@ class SpatialAcceleration : public SpatialVector<SpatialAcceleration, T> {
     Vector3<T>& a_MCo_E = this->translational();
     a_MCo_E += (alpha_MB_E.cross(p_BoCo_E)
             +   w_MB_E.cross(w_MB_E.cross(p_BoCo_E)));
-    return *this;
   }
 
   /// Shifts a %SpatialAcceleration from a frame B to a frame C, where both
@@ -159,8 +155,9 @@ class SpatialAcceleration : public SpatialVector<SpatialAcceleration, T> {
   SpatialAcceleration<T> Shift(
       const Vector3<T>& offset,
       const Vector3<T>& angular_velocity_of_this_frame) const {
-    return SpatialAcceleration<T>(*this).ShiftInPlace(
-        offset, angular_velocity_of_this_frame);
+    SpatialAcceleration<T> result(*this);
+    result.ShiftInPlace(offset, angular_velocity_of_this_frame);
+    return result;
   }
 
   /// (Advanced) Given `this` spatial acceleration A_MB of a frame B measured

--- a/multibody/math/spatial_force.h
+++ b/multibody/math/spatial_force.h
@@ -75,24 +75,21 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
   /// another fixed on frame B. On entry, `this` is F_Bp_E (spatial force on
   /// point Bp of frame B, expressed in a frame E). On return `this` is modified
   /// to F_Bq_E (spatial force on point Bq of frame B, expressed in frame E).
-  /// @param[in] offset which is the position vector p_BpBq_E from point Bp
-  /// (fixed on frame B) to point Bq (fixed on frame B), expressed in frame E.
-  /// p_BpBq_E must have the same expressed-in frame E as `this` spatial force.
-  /// @retval F_Bq_E reference to `this` spatial force which has been modified
-  /// to be the spatial force on point Bq of B, expressed in frame E.
   /// The components of F_Bq_E are calculated as: <pre>
   ///    τ_B  = τ_B -  p_BpBq x f_Bp    (the torque 𝛕 stored in `this` changes).
   ///  f_Bq_E = f_Bp_E              (the force 𝐟 stored in `this` is unchanged).
   /// </pre>
-  /// Note: There are related functions that shift spatial momentum and spatial
+  /// @param[in] offset which is the position vector p_BpBq_E from point Bp
+  /// (fixed on frame B) to point Bq (fixed on frame B), expressed in frame E.
+  /// p_BpBq_E must have the same expressed-in frame E as `this` spatial force.
+  /// @note There are related functions that shift spatial momentum and spatial
   /// velocity (see SpatialMomentum::Shift() and SpatialVelocity:Shift()).
   /// @see Member function Shift() to shift one spatial force without modifying
   /// `this` and static functions ShiftInPlace() and Shift() to shift multiple
   /// spatial forces (with or without modifying the input parameter
   /// spatial_forces).
-  SpatialForce<T>& ShiftInPlace(const Vector3<T>& offset) {
+  void ShiftInPlace(const Vector3<T>& offset) {
     this->rotational() -= offset.cross(this->translational());
-    return *this;
     // Note: this operation is linear. [Jain 2010], (§1.5, page 15) uses the
     // "rigid body transformation operator" to write this as:
     //   F_Bq = Φ(-p_BpBq) F_Bp
@@ -152,7 +149,9 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
   /// spatial forces (with or without modifying the input parameter
   /// spatial_forces).
   SpatialForce<T> Shift(const Vector3<T>& offset) const {
-    return SpatialForce<T>(*this).ShiftInPlace(offset);  // offset = p_BpBq_E
+    SpatialForce<T> result(*this);
+    result.ShiftInPlace(offset);  // offset = p_BpBq_E
+    return result;
   }
 
   /// Shifts a matrix of spatial forces from one point fixed on frame B to

--- a/multibody/math/spatial_momentum.h
+++ b/multibody/math/spatial_momentum.h
@@ -88,25 +88,22 @@ class SpatialMomentum : public SpatialVector<SpatialMomentum, T> {
   explicit SpatialMomentum(const Eigen::MatrixBase<Derived>& L) : Base(L) {}
 
   /// In-place shift of a %SpatialMomentum from an about-point P to an
-  /// about-point Q, On entry, `this` is L_MSP_E (system S's spatial momentum
+  /// about-point Q. On entry, `this` is L_MSP_E (system S's spatial momentum
   /// about point P, measured in a frame M and expressed in a frame E). On
   /// return `this` is modified to L_MSQ_E (S's spatial momentum about point Q,
   /// measured in frame M and expressed in frame E).
-  /// @param[in] offset which is the position vector p_PQ_E from point P to
-  /// point Q, with the same expressed-in frame E as `this` spatial momentum.
-  /// @retval L_MSQ_E reference to `this` spatial momentum which has been
-  /// modified to be system S's spatial momentum about point Q, measured in
-  /// frame M and expressed in frame E. The components of L_MSQ_E are: <pre>
+  /// The components of L_MSQ_E are: <pre>
   ///   l_MS_E = l_MS_E         (translational momentum of `this` is unchanged).
   ///  h_MSQ_E = h_MSP_E + p_QP_E x l_MS_E
   ///          = h_MSP_E - p_PQ_E x l_MS_E
   /// </pre>
-  /// Note: Spatial momenta shift similar to spatial force (see SpatialForce)
+  /// @param[in] offset which is the position vector p_PQ_E from point P to
+  /// point Q, with the same expressed-in frame E as `this` spatial momentum.
+  /// @note Spatial momenta shift similar to spatial force (see SpatialForce)
   /// and in a related/different way for spatial velocity (see SpatialVelocity).
   /// @see Shift() to shift spatial momentum without modifying `this`.
-  SpatialMomentum<T>& ShiftInPlace(const Vector3<T>& offset) {
+  void ShiftInPlace(const Vector3<T>& offset) {
     this->rotational() -= offset.cross(this->translational());
-    return *this;
     // Note: this operation is linear. [Jain 2010], (§2.1, page 22) uses the
     // "rigid body transformation operator" to write this as:
     //  L_MSQ = Φ(-p_PQ) L_MSP
@@ -134,7 +131,9 @@ class SpatialMomentum : public SpatialVector<SpatialMomentum, T> {
   /// `this` whereas ShiftInPlace() does modify `this`.
   /// @see ShiftInPlace() for more information and how L_MSQ_E is calculated.
   SpatialMomentum<T> Shift(const Vector3<T>& offset) const {
-    return SpatialMomentum<T>(*this).ShiftInPlace(offset);
+    SpatialMomentum<T> result(*this);
+    result.ShiftInPlace(offset);
+    return result;
   }
 
   /// Calculates twice (2x) a body B's kinetic energy measured in a frame M.

--- a/multibody/math/spatial_velocity.h
+++ b/multibody/math/spatial_velocity.h
@@ -71,19 +71,16 @@ class SpatialVelocity : public SpatialVector<SpatialVelocity, T> {
   /// is V_MB_E (frame B's spatial velocity measured in a frame M and expressed
   /// in a frame E). On return `this` is modified to V_MC_E (frame C's spatial
   /// velocity measured in frame M and expressed in frame E).
-  /// @param[in] offset which is the position vector p_BoCo_E from frame B's
-  /// origin to frame C's origin, expressed in frame E. p_BoCo_E must have
-  /// the same expressed-in frame E as `this` spatial velocity.
-  /// @retval V_MC_E reference to `this` spatial velocity which has been
-  /// modified to be frame C's spatial velocity measured in frame M and
-  /// expressed in frame E. The components of V_MC_E are calculated as: <pre>
+  /// The components of V_MC_E are calculated as: <pre>
   ///  ω_MC_E = ω_MB_E                (angular velocity of `this` is unchanged).
   ///  v_MC_E = v_MB_E + ω_MB_E x p_BoCo_E     (translational velocity changes).
   /// </pre>
+  /// @param[in] offset which is the position vector p_BoCo_E from frame B's
+  /// origin to frame C's origin, expressed in frame E. p_BoCo_E must have
+  /// the same expressed-in frame E as `this` spatial velocity.
   /// @see Shift() to shift spatial velocity without modifying `this`.
-  SpatialVelocity<T>& ShiftInPlace(const Vector3<T>& offset) {
+  void ShiftInPlace(const Vector3<T>& offset) {
     this->translational() += this->rotational().cross(offset);
-    return *this;
     // Note: this operation is linear. [Jain 2010], (§1.4, page 12) uses the
     // "rigid body transformation operator" to write this as:
     //    V_MC = Φᵀ(p_BoCo) V_MB    where Φᵀ(p) is the linear operator:
@@ -109,7 +106,9 @@ class SpatialVelocity : public SpatialVector<SpatialVelocity, T> {
   /// `this` whereas ShiftInPlace() does modify `this`.
   /// @see ShiftInPlace() for more information and how V_MC_E is calculated.
   SpatialVelocity<T> Shift(const Vector3<T>& offset) const {
-    return SpatialVelocity<T>(*this).ShiftInPlace(offset);
+    SpatialVelocity<T> result(*this);
+    result.ShiftInPlace(offset);
+    return result;
   }
 
   /// Compose `this` spatial velocity (measured in some frame M) with the

--- a/multibody/tree/articulated_body_inertia.h
+++ b/multibody/tree/articulated_body_inertia.h
@@ -228,9 +228,7 @@ class ArticulatedBodyInertia {
   /// @param[in] p_QR_E Vector from the original about point Q to the new
   ///                   about point R, expressed in the same frame E `this`
   ///                   articulated body inertia is expressed in.
-  /// @returns A reference to `this` articulated body inertia for articulated
-  ///          body A but now computed about a new point R.
-  ArticulatedBodyInertia<T>& ShiftInPlace(const Vector3<T>& p_QR_E) {
+  void ShiftInPlace(const Vector3<T>& p_QR_E) {
     // We want to compute P_AR_E = Φ(P_RQ_E) P_AQ_E Φ(p_RQ_E)ᵀ. This can be
     // done efficiently using block multiplication.
     //
@@ -270,8 +268,6 @@ class ArticulatedBodyInertia {
 
     // Overwrite F (in the lower left) with Fp. M doesn't change.
     F = Fp;
-
-    return *this;
   }
 
   /// Given `this` articulated body inertia `P_AQ_E` for some articulated body
@@ -287,7 +283,9 @@ class ArticulatedBodyInertia {
   /// @retval P_AR_E This same articulated body inertia for articulated body
   ///         A but now computed about a new point R.
   ArticulatedBodyInertia<T> Shift(const Vector3<T>& p_QR_E) const {
-    return ArticulatedBodyInertia<T>(*this).ShiftInPlace(p_QR_E);
+    ArticulatedBodyInertia<T> result(*this);
+    result.ShiftInPlace(p_QR_E);
+    return result;
   }
 
   /// Adds in to this articulated body inertia `P_AQ_E` for an articulated body

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2176,11 +2176,11 @@ SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
   // Otherwise, shift from Wo (world origin) to Fo (frame_F's origin).
   const RigidTransform<T> X_WF = frame_F.CalcPoseInWorld(context);
   const Vector3<T>& p_WoFo_W = X_WF.translation();
-  SpatialInertia<T> M_SFo_W = M_SWo_W.Shift(p_WoFo_W);
+  const SpatialInertia<T> M_SFo_W = M_SWo_W.Shift(p_WoFo_W);
 
   // Re-express spatial inertia from frame W to frame F.
   const RotationMatrix<T> R_FW = (X_WF.rotation()).inverse();
-  return M_SFo_W.ReExpressInPlace(R_FW);  // Returns M_SFo_F.
+  return M_SFo_W.ReExpress(R_FW);  // Returns M_SFo_F.
 }
 
 template <typename T>
@@ -2317,11 +2317,11 @@ SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
   }
 
   // Form spatial momentum about Wo (origin of world frame W), expressed in W.
-  SpatialMomentum<T> L_WS_W =
+  const SpatialMomentum<T> L_WS_W =
       CalcBodiesSpatialMomentumInWorldAboutWo(context, body_indexes);
 
   // Shift the spatial momentum from Wo to point P.
-  return L_WS_W.ShiftInPlace(p_WoP_W);
+  return L_WS_W.Shift(p_WoP_W);
 }
 
 template <typename T>
@@ -2355,7 +2355,10 @@ SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
     // Shift L_WBo_W from about Bo to about Wo and accumulate the sum.
     const RigidTransform<T>& X_WB = pc.get_X_WB(mobod_index);
     const Vector3<T>& p_WoBo_W = X_WB.translation();
-    L_WS_W += L_WBo_W.ShiftInPlace(-p_WoBo_W);
+    // After ShiftInPlace, L_WBo_W is changed to L_WBWo_W, which is B's
+    // spatial momentum about point Wo, measured and expressed in frame W.
+    L_WBo_W.ShiftInPlace(-p_WoBo_W);  // After this, L_WBo_W is now L_WBWo_W.
+    L_WS_W += L_WBo_W;  // Actually is `L_WS_W += L_WBWo_W`.
   }
 
   return L_WS_W;

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -618,12 +618,10 @@ class RotationalInertia {
   /// concisely, we compute `I_BP_A = R_AE * I_BP_E * (R_AE)ᵀ`.
   ///
   /// @param[in] R_AE RotationMatrix relating frames A and E.
-  /// @return A reference to `this` rotational inertia about-point P, but
-  ///         with `this` now expressed in frame A (instead of frame E).
   /// @throws std::exception for Debug builds if the rotational inertia that
   /// is re-expressed-in frame A violates CouldBePhysicallyValid().
   /// @see ReExpress().
-  RotationalInertia<T>& ReExpressInPlace(const math::RotationMatrix<T>& R_AE);
+  void ReExpressInPlace(const math::RotationMatrix<T>& R_AE);
 
   /// Re-expresses `this` rotational inertia `I_BP_E` to `I_BP_A`
   /// i.e., re-expresses body B's rotational inertia from frame E to frame A.
@@ -634,7 +632,9 @@ class RotationalInertia {
   /// @see ReExpressInPlace()
   [[nodiscard]] RotationalInertia<T> ReExpress(
       const math::RotationMatrix<T>& R_AE) const {
-    return RotationalInertia(*this).ReExpressInPlace(R_AE);
+    RotationalInertia result(*this);
+    result.ReExpressInPlace(R_AE);
+    return result;
   }
 
   /// @name Shift methods
@@ -651,20 +651,15 @@ class RotationalInertia {
   /// Shifts `this` rotational inertia for a body (or composite body) B
   /// from about-point Bcm (B's center of mass) to about-point Q.
   /// I.e., shifts `I_BBcm_E` to `I_BQ_E` (both are expressed-in frame E).
+  /// On return, `this` is modified to be shifted from about-point Bcm to
+  /// about-point Q.
   /// @param mass The mass of body (or composite body) B.
   /// @param p_BcmQ_E Position vector from Bcm to Q, expressed-in frame E.
-  /// @return A reference to `this` rotational inertia expressed-in frame E,
-  ///         but with `this` shifted from about-point Bcm to about-point Q.
-  ///         i.e., returns I_BQ_E,  B's rotational inertia about-point Bcm
-  ///         expressed-in frame E.
   /// @throws std::exception for Debug builds if the rotational inertia that
   /// is shifted to about-point Q violates CouldBePhysicallyValid().
   /// @remark Negating the position vector p_BcmQ_E has no affect on the result.
-  RotationalInertia<T>& ShiftFromCenterOfMassInPlace(
-      const T& mass,
-      const Vector3<T>& p_BcmQ_E) {
+  void ShiftFromCenterOfMassInPlace(const T& mass, const Vector3<T>& p_BcmQ_E) {
     *this += RotationalInertia(mass, p_BcmQ_E);
-    return *this;
   }
 
   /// Calculates the rotational inertia that results from shifting `this`
@@ -679,27 +674,23 @@ class RotationalInertia {
   /// @remark Negating the position vector p_BcmQ_E has no affect on the result.
   [[nodiscard]] RotationalInertia<T> ShiftFromCenterOfMass(
       const T& mass, const Vector3<T>& p_BcmQ_E) const {
-    return RotationalInertia(*this).
-           ShiftFromCenterOfMassInPlace(mass, p_BcmQ_E);
+    RotationalInertia result(*this);
+    result.ShiftFromCenterOfMassInPlace(mass, p_BcmQ_E);
+    return result;
   }
 
   /// Shifts `this` rotational inertia for a body (or composite body) B
   /// from about-point Q to about-point `Bcm` (B's center of mass).
   /// I.e., shifts `I_BQ_E` to `I_BBcm_E` (both are expressed-in frame E).
+  /// On return, `this` is shifted from about-point Q to about-point `Bcm`.
   /// @param mass The mass of body (or composite body) B.
   /// @param p_QBcm_E Position vector from Q to `Bcm`, expressed-in frame E.
-  /// @return A reference to `this` rotational inertia expressed-in frame E,
-  ///         but with `this` shifted from about-point Q to about-point `Bcm`,
-  ///         i.e., returns `I_BBcm_E`, B's rotational inertia about-point `Bcm`
-  ///         expressed-in frame E.
   /// @throws std::exception for Debug builds if the rotational inertia that
   /// is shifted to about-point `Bcm` violates CouldBePhysicallyValid().
   /// @remark Negating the position vector `p_QBcm_E` has no affect on the
   /// result.
-  RotationalInertia<T>& ShiftToCenterOfMassInPlace(const T& mass,
-                                                   const Vector3<T>& p_QBcm_E) {
+  void ShiftToCenterOfMassInPlace(const T& mass, const Vector3<T>& p_QBcm_E) {
     *this -= RotationalInertia(mass, p_QBcm_E);
-    return *this;
   }
 
   /// Calculates the rotational inertia that results from shifting `this`
@@ -716,19 +707,19 @@ class RotationalInertia {
   /// result.
   [[nodiscard]] RotationalInertia<T> ShiftToCenterOfMass(
       const T& mass, const Vector3<T>& p_QBcm_E) const {
-    return RotationalInertia(*this).ShiftToCenterOfMassInPlace(mass, p_QBcm_E);
+    RotationalInertia result(*this);
+    result.ShiftToCenterOfMassInPlace(mass, p_QBcm_E);
+    return result;
   }
 
   /// Shifts `this` rotational inertia for a body (or composite body) B
   /// from about-point P to about-point Q via Bcm (B's center of mass).
   /// I.e., shifts `I_BP_E` to `I_BQ_E` (both are expressed-in frame E).
+  /// On return, `this` is modified to be shifted from about-point P to
+  /// about-point Q.
   /// @param mass The mass of body (or composite body) B.
   /// @param p_PBcm_E Position vector from P to Bcm, expressed-in frame E.
   /// @param p_QBcm_E Position vector from Q to Bcm, expressed-in frame E.
-  /// @return A reference to `this` rotational inertia expressed-in frame E,
-  ///         but with `this` shifted from about-point P to about-point Q,
-  ///         i.e., returns I_BQ_E, B's rotational inertia about-point Q
-  ///         expressed-in frame E.
   /// @throws std::exception for Debug builds if the rotational inertia that
   /// is shifted to about-point Q violates CouldBePhysicallyValid().
   /// @remark Negating either (or both) position vectors p_PBcm_E and p_QBcm_E
@@ -736,13 +727,11 @@ class RotationalInertia {
   /// @remark This method is more efficient (by 6 multiplications) than first
   ///         shifting to the center of mass, then shifting away, e.g., as
   ///         (ShiftToCenterOfMassInPlace()).ShiftFromCenterOfMassInPlace();
-  RotationalInertia<T>& ShiftToThenAwayFromCenterOfMassInPlace(
-      const T& mass,
-      const Vector3<T>& p_PBcm_E,
-      const Vector3<T>& p_QBcm_E) {
+  void ShiftToThenAwayFromCenterOfMassInPlace(const T& mass,
+                                              const Vector3<T>& p_PBcm_E,
+                                              const Vector3<T>& p_QBcm_E) {
     *this += mass * ShiftUnitMassBodyToThenAwayFromCenterOfMass(p_PBcm_E,
                                                                 p_QBcm_E);
-    return *this;
   }
 
   /// Calculates the rotational inertia that results from shifting `this`
@@ -760,8 +749,9 @@ class RotationalInertia {
   [[nodiscard]] RotationalInertia<T> ShiftToThenAwayFromCenterOfMass(
       const T& mass, const Vector3<T>& p_PBcm_E,
       const Vector3<T>& p_QBcm_E) const {
-    return RotationalInertia(*this).ShiftToThenAwayFromCenterOfMassInPlace(
-        mass, p_PBcm_E, p_QBcm_E);
+    RotationalInertia result(*this);
+    result.ShiftToThenAwayFromCenterOfMassInPlace(mass, p_PBcm_E, p_QBcm_E);
+    return result;
   }
   ///@}
 
@@ -1147,7 +1137,7 @@ std::ostream& operator<<(std::ostream& out, const RotationalInertia<T>& I);
 // instructions. Both compilers were fully able to inline the Eigen methods here
 // so there are no loops or function calls.)
 template <typename T>
-RotationalInertia<T>& RotationalInertia<T>::ReExpressInPlace(
+void RotationalInertia<T>::ReExpressInPlace(
     const math::RotationMatrix<T>& R_AE) {
   const Matrix3<T>& R = R_AE.matrix();
 
@@ -1191,7 +1181,6 @@ RotationalInertia<T>& RotationalInertia<T>::ReExpressInPlace(
   // If both `this` and `R_AE` were valid upon entry to this method, the
   // returned rotational inertia should be valid.  Otherwise, it may not be.
   DRAKE_ASSERT_VOID(ThrowIfNotPhysicallyValid(__func__));
-  return *this;
 }
 
 }  // namespace multibody

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -379,39 +379,40 @@ SpatialInertia<T>& SpatialInertia<T>::operator+=(
 }
 
 template <typename T>
-SpatialInertia<T>& SpatialInertia<T>::ShiftFromCenterOfMassInPlace(
+void SpatialInertia<T>::ShiftFromCenterOfMassInPlace(
     const Vector3<T>& p_ScmP_E) {
   DRAKE_ASSERT(p_PScm_E_ == Vector3<T>::Zero());
   G_SP_E_.ShiftFromCenterOfMassInPlace(p_ScmP_E);
   p_PScm_E_ = -p_ScmP_E;
-  return *this;  // On entry, `this` is M_SScm_E. On return, `this` is M_SP_E.
+  // On entry, `this` is M_SScm_E. On return, `this` is M_SP_E.
 }
 
 template <typename T>
 SpatialInertia<T> SpatialInertia<T>::ShiftFromCenterOfMass(
     const Vector3<T>& p_ScmP_E) const {
-  return SpatialInertia(*this).ShiftFromCenterOfMassInPlace(p_ScmP_E);
+  SpatialInertia result(*this);
+  result.ShiftFromCenterOfMassInPlace(p_ScmP_E);
+  return result;
 }
 
 template <typename T>
-SpatialInertia<T>& SpatialInertia<T>::ShiftToCenterOfMassInPlace() {
+void SpatialInertia<T>::ShiftToCenterOfMassInPlace() {
   G_SP_E_.ShiftToCenterOfMassInPlace(p_PScm_E_);
   p_PScm_E_ = Vector3<T>::Zero();
-  return *this;  // On entry, `this` is M_SP_E. On return, `this` is M_SScm_E.
+  // On entry, `this` is M_SP_E. On return, `this` is M_SScm_E.
 }
 
 template <typename T>
-SpatialInertia<T>& SpatialInertia<T>::ShiftInPlace(const Vector3<T>& p_PQ_E) {
+void SpatialInertia<T>::ShiftInPlace(const Vector3<T>& p_PQ_E) {
   const Vector3<T> p_QScm_E = p_PScm_E_ - p_PQ_E;
   // The following two lines apply the parallel axis theorem (in place) so that:
   //  G_SQ = G_SP + px_QScm² - px_PScm²
   G_SP_E_.ShiftFromCenterOfMassInPlace(p_QScm_E);
   G_SP_E_.ShiftToCenterOfMassInPlace(p_PScm_E_);
   p_PScm_E_ = p_QScm_E;
-  // Note: It would be a implementation bug if a shift starts with a valid
+  // Note: It would be an implementation bug if a shift starts with a valid
   // spatial inertia and the shift produces an invalid spatial inertia.
   // Hence, no need to use DRAKE_ASSERT_VOID(CheckInvariants()).
-  return *this;
 }
 
 template <typename T>

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -751,13 +751,12 @@ class SpatialInertia {
   /// taken about a point P and expressed in frame E, this method computes the
   /// same inertia re-expressed in another frame A.
   /// This operation is performed in-place modifying the original object.
+  /// On return, `this` is now re-expressed in frame A, that is, `M_SP_A`.
   /// @param[in] R_AE Rotation matrix from frame E to frame A.
-  /// @returns A reference to `this` rotational inertia about the same point P
-  ///          but now re-expressed in frame A, that is, `M_SP_A`.
-  SpatialInertia<T>& ReExpressInPlace(const math::RotationMatrix<T>& R_AE) {
+  void ReExpressInPlace(const math::RotationMatrix<T>& R_AE) {
     p_PScm_E_ = R_AE * p_PScm_E_;    // Now p_PScm_A
     G_SP_E_.ReExpressInPlace(R_AE);  // Now I_SP_A
-    return *this;                    // Now M_SP_A
+    // Now M_SP_A
   }
 
   /// Given `this` spatial inertia `M_SP_E` for some body or composite body S,
@@ -768,7 +767,9 @@ class SpatialInertia {
   ///                re-expressed in frame A.
   /// @see ReExpressInPlace() for details.
   SpatialInertia<T> ReExpress(const math::RotationMatrix<T>& R_AE) const {
-    return SpatialInertia(*this).ReExpressInPlace(R_AE);
+    SpatialInertia result(*this);
+    result.ReExpressInPlace(R_AE);
+    return result;
   }
 
   /// Given `this` spatial inertia `M_SP_E` for some body or composite body S,
@@ -777,6 +778,7 @@ class SpatialInertia {
   /// spatial inertia about a new point Q. The result still is expressed in
   /// frame E.
   /// This operation is performed in-place modifying the original object.
+  /// On return, `this` is now computed about a new point Q.
   /// @see Shift() which does not modify this object.
   ///
   /// For details see Section 2.1.2, p. 20 of [Jain 2010].
@@ -784,9 +786,7 @@ class SpatialInertia {
   /// @param[in] p_PQ_E position vector from the original about-point P to the
   ///                   new about-point Q, expressed in the same frame E that
   ///                   `this` spatial inertia is expressed in.
-  /// @returns A reference to `this` spatial inertia for body or composite body
-  ///          S but now computed about a new point Q.
-  SpatialInertia<T>& ShiftInPlace(const Vector3<T>& p_PQ_E);
+  void ShiftInPlace(const Vector3<T>& p_PQ_E);
 
   /// Given `this` spatial inertia `M_SP_E` for some body or composite body S,
   /// computed about point P, and expressed in frame E, this method uses
@@ -801,7 +801,9 @@ class SpatialInertia {
   /// @retval M_SQ_E    This same spatial inertia for body or composite body S
   ///                   but computed about a new point Q.
   SpatialInertia<T> Shift(const Vector3<T>& p_PQ_E) const {
-    return SpatialInertia(*this).ShiftInPlace(p_PQ_E);
+    SpatialInertia result(*this);
+    result.ShiftInPlace(p_PQ_E);
+    return result;
   }
 
   /// Multiplies `this` spatial inertia `M_Bo_E` of a body B about its frame
@@ -935,11 +937,9 @@ class SpatialInertia {
   // about-point Scm (S's center of mass) to about-point P. In other words,
   // shifts `M_SScm_E` to `M_SP_E` (both are expressed-in frame E).
   // @param[in] p_ScmP_E Position vector from Scm to P, expressed-in frame E.
-  // @return A reference to M_SP_E, `this` spatial inertia that has been shifted
-  // from about-point Scm to about-point P, expressed in frame E.
   // @pre On entry, the about-point for `this` SpatialInertia is Scm. Hence, on
   // entry the position vector p_PScm underlying `this` is the zero vector.
-  SpatialInertia<T>& ShiftFromCenterOfMassInPlace(const Vector3<T>& p_ScmP_E);
+  void ShiftFromCenterOfMassInPlace(const Vector3<T>& p_ScmP_E);
 
   // Calculates the spatial inertia that results from shifting `this` spatial
   // inertia for a body (or composite body) S from about-point Scm (S's center
@@ -955,12 +955,10 @@ class SpatialInertia {
   // Shifts `this` spatial inertia for a body (or composite body) S from
   // about-point P to about-point Scm (S's center of mass). In other words,
   // shifts `M_SP_E` to `M_SScm_E` (both are expressed-in frame E).
-  // @returns A reference to M_SScm_E, `this` spatial inertia that has been
-  // shifted from about-point P to about-point Scm, expressed in frame E.
   // @note On return, the about-point for `this` SpatialInertia is Scm. Hence,
   // on return the position vector p_PScm underlying `this` is the zero vector.
   // @see SpatialInertia::ShiftToCenterOfMass(), ShiftFromCenterOfMassInPlace().
-  SpatialInertia<T>& ShiftToCenterOfMassInPlace();
+  void ShiftToCenterOfMassInPlace();
 
   // Calculates the spatial inertia that results from shifting `this` spatial
   // inertia for a body (or composite body) S from about-point P to
@@ -971,7 +969,9 @@ class SpatialInertia {
   // on return the position vector p_PScm underlying `this` is the zero vector.
   // @see SpatialInertia::ShiftToCenterOfMassInPlace(), ShiftFromCenterOfMass().
   [[nodiscard]] SpatialInertia<T> ShiftToCenterOfMass() const {
-    return SpatialInertia<T>(*this).ShiftToCenterOfMassInPlace();
+    SpatialInertia<T> result(*this);
+    result.ShiftToCenterOfMassInPlace();
+    return result;
   }
 
   // Returns principal semi-diameters (half-lengths), associated principal axes

--- a/multibody/tree/unit_inertia.cc
+++ b/multibody/tree/unit_inertia.cc
@@ -223,14 +223,14 @@ UnitInertia<T> UnitInertia<T>::SolidTetrahedronAboutPoint(
   const Vector3<T> p_B0B1 = p1 - p0;  // Position from vertex B0 to vertex B1.
   const Vector3<T> p_B0B2 = p2 - p0;  // Position from vertex B0 to vertex B2.
   const Vector3<T> p_B0B3 = p3 - p0;  // Position from vertex B0 to vertex B3.
-  UnitInertia<T> G_BB0 =
+  const UnitInertia<T> G_BB0 =
       UnitInertia<T>::SolidTetrahedronAboutVertex(p_B0B1, p_B0B2, p_B0B3);
 
   // Shift unit inertia from about point B0 to about point A.
   const Vector3<T> p_B0Bcm = 0.25 * (p_B0B1 + p_B0B2 + p_B0B3);
   const Vector3<T>& p_AB0 = p0;  // Alias with monogram notation to clarify.
   const Vector3<T> p_ABcm = p_AB0 + p_B0Bcm;
-  RotationalInertia<T>& I_BA = G_BB0.ShiftToThenAwayFromCenterOfMassInPlace(
+  const RotationalInertia<T> I_BA = G_BB0.ShiftToThenAwayFromCenterOfMass(
       /* mass = */ 1, p_B0Bcm, p_ABcm);
   return UnitInertia<T>(I_BA);  // Returns G_BA (B's unit inertia about A).
 }

--- a/multibody/tree/unit_inertia.h
+++ b/multibody/tree/unit_inertia.h
@@ -104,9 +104,8 @@ class UnitInertia : public RotationalInertia<T> {
 
   /// Re-express a unit inertia in a different frame, performing the operation
   /// in place and modifying the original object. @see ReExpress() for details.
-  UnitInertia<T>& ReExpressInPlace(const math::RotationMatrix<T>& R_AE) {
+  void ReExpressInPlace(const math::RotationMatrix<T>& R_AE) {
     RotationalInertia<T>::ReExpressInPlace(R_AE);
-    return *this;
   }
 
   /// Given `this` unit inertia `G_BP_E` of a body B about a point P and
@@ -123,15 +122,13 @@ class UnitInertia : public RotationalInertia<T> {
   /// mass (or centroid) `Bcm` and expressed in a frame E, this method shifts
   /// this inertia using the parallel axis theorem to be computed about a
   /// point Q. This operation is performed in place, modifying the original
-  /// object which is no longer a central inertia.
+  /// object which is no longer a central inertia. On return, `this` is
+  /// modified to be taken about point Q so can be written as `G_BQ_E`.
   /// @param[in] p_BcmQ_E A vector from the body's centroid `Bcm` to point Q
   ///                     expressed in the same frame E in which `this`
   ///                     inertia is expressed.
-  /// @returns A reference to `this` unit inertia, which has now been taken
-  ///          about point Q so can be written as `G_BQ_E`.
-  UnitInertia<T>& ShiftFromCenterOfMassInPlace(const Vector3<T>& p_BcmQ_E) {
+  void ShiftFromCenterOfMassInPlace(const Vector3<T>& p_BcmQ_E) {
     RotationalInertia<T>::operator+=(PointMass(p_BcmQ_E));
-    return *this;
   }
 
   /// Shifts this central unit inertia to a different point, and returns the
@@ -143,20 +140,21 @@ class UnitInertia : public RotationalInertia<T> {
   ///                the centroid `Bcm`.
   [[nodiscard]] UnitInertia<T> ShiftFromCenterOfMass(
       const Vector3<T>& p_BcmQ_E) const {
-    return UnitInertia<T>(*this).ShiftFromCenterOfMassInPlace(p_BcmQ_E);
+    UnitInertia<T> result(*this);
+    result.ShiftFromCenterOfMassInPlace(p_BcmQ_E);
+    return result;
   }
 
   /// For the unit inertia `G_BQ_E` of a body or composite body B computed about
   /// a point Q and expressed in a frame E, this method shifts this inertia
   /// using the parallel axis theorem to be computed about the center of mass
   /// `Bcm` of B. This operation is performed in place, modifying the original
-  /// object.
+  /// object. On return, `this` is modified to be taken about point `Bcm` so can
+  /// be written as `G_BBcm_E`, or `G_Bcm_E`.
   ///
   /// @param[in] p_QBcm_E A position vector from the about point Q to the body's
   ///                     centroid `Bcm` expressed in the same frame E in which
   ///                     `this` inertia is expressed.
-  /// @returns A reference to `this` unit inertia, which has now been taken
-  ///          about point `Bcm` so can be written as `G_BBcm_E`, or `G_Bcm_E`.
   ///
   /// @warning This operation could result in a non-physical rotational inertia.
   /// The shifted inertia is obtained by subtracting the point mass unit inertia
@@ -166,9 +164,8 @@ class UnitInertia : public RotationalInertia<T> {
   /// the unit inertia of the unit mass at point `Bcm` is larger than `G_BQ_E`.
   /// Use with care.
   // TODO(mitiguy) Issue #6147.  If invalid inertia, should throw exception.
-  UnitInertia<T>& ShiftToCenterOfMassInPlace(const Vector3<T>& p_QBcm_E) {
+  void ShiftToCenterOfMassInPlace(const Vector3<T>& p_QBcm_E) {
     RotationalInertia<T>::MinusEqualsUnchecked(PointMass(p_QBcm_E));
-    return *this;
   }
 
   /// For the unit inertia `G_BQ_E` of a body or composite body B computed about
@@ -185,7 +182,9 @@ class UnitInertia : public RotationalInertia<T> {
   /// Use with care. See ShiftToCenterOfMassInPlace() for details.
   [[nodiscard]] UnitInertia<T> ShiftToCenterOfMass(
       const Vector3<T>& p_QBcm_E) const {
-    return UnitInertia<T>(*this).ShiftToCenterOfMassInPlace(p_QBcm_E);
+    UnitInertia<T> result(*this);
+    result.ShiftToCenterOfMassInPlace(p_QBcm_E);
+    return result;
   }
 
   /// @name            Unit inertia for common 3D objects


### PR DESCRIPTION
Closes #21436, as a broader swipe at the same respelling.

---

Here's a tiny demo program that mimics the problem (see also [godbolt](https://godbolt.org/z/a7cEq91qx)):

```c++
#include <Eigen/Dense>

using Eigen::Vector3d;
using Vector6d = Eigen::Matrix<double, 6, 1>;

struct SpatialVelocity {
  Vector6d V_;

  const Vector3d& rotational() const {
    return *reinterpret_cast<const Vector3d*>(V_.data());
  }
  Vector3d& rotational() {
    return *reinterpret_cast<Vector3d*>(V_.data());
  }
  const Vector3d& translational() const {
    return *reinterpret_cast<const Vector3d*>(V_.data() + 3);
  }
  Vector3d& translational() {
    return *reinterpret_cast<Vector3d*>(V_.data() + 3);
  }

  SpatialVelocity& ShiftInPlace(const Vector3d& offset) {
    this->translational() += this->rotational().cross(offset);
    return *this;
  }

  SpatialVelocity Shift(const Vector3d& offset) const {
#ifndef FIXED
    return SpatialVelocity(*this).ShiftInPlace(offset);
#else
    SpatialVelocity result(*this);
    result.ShiftInPlace(offset);
    return result;
#endif
  }
};

Vector3d foo(const SpatialVelocity& x) {
  return x.Shift(Vector3d{1, 2, 3}).translational();
}
```

Here's the change in machine code for the demo:

```diff
--- master.asm	2024-05-15 16:41:13.018629991 -0700
+++ pr.asm	2024-05-15 16:41:19.778720632 -0700
@@ -1,27 +1,25 @@
 foo(SpatialVelocity const&):
         movsd   xmm1, QWORD PTR [rsi]
         movsd   xmm2, QWORD PTR [rsi+8]
         mov     rax, rdi
         movsd   xmm0, QWORD PTR .LC0[rip]
         addsd   xmm1, xmm1
         mulsd   xmm0, xmm2
         subsd   xmm1, xmm2
         movapd  xmm2, XMMWORD PTR [rsi+16]
         addsd   xmm1, QWORD PTR [rsi+40]
         movhpd  xmm2, QWORD PTR [rsi]
         mulpd   xmm2, XMMWORD PTR .LC1[rip]
         unpcklpd        xmm0, xmm0
-        movsd   QWORD PTR [rsp-16], xmm1
-        mov     rdx, QWORD PTR [rsp-16]
         movhpd  xmm0, QWORD PTR [rsi+16]
         subpd   xmm0, xmm2
         movupd  xmm2, XMMWORD PTR [rsi+24]
-        mov     QWORD PTR [rdi+16], rdx
+        movsd   QWORD PTR [rdi+16], xmm1
         addpd   xmm0, xmm2
         movups  XMMWORD PTR [rdi], xmm0
         ret
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21438)
<!-- Reviewable:end -->
