### PR TITLE
Unit tests support matrix for discrete MultibodyPlant models

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -524,6 +524,7 @@ drake_cc_googletest(
         "//multibody/parsing",
         "//multibody/plant",
         "//multibody/plant:compliant_contact_manager_tester",
+        "//multibody/test_utilities:robot_model",
         "//visualization:visualization_config_functions",
     ],
 )

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -1166,9 +1166,13 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "multibody_plant_scalar_conversion_test",
+    shard_count = 4,
     deps = [
         ":multibody_plant_core",
         ":plant",
+        "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/test_utilities:robot_model",
     ],
 )
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2616,8 +2616,8 @@ void MultibodyPlant<symbolic::Expression>::CalcHydroelasticWithFallback(
   // TODO(SeanCurtis-TRI): Special case the AutoDiff scalar such that it works
   //  as long as there are no collisions -- akin to CalcPointPairPenetrations().
   throw std::domain_error(
-      fmt::format("This method doesn't support T = {}.",
-                  NiceTypeName::Get<symbolic::Expression>()));
+      "MultibodyPlant<T>::CalcHydroelasticWithFallback(): This method doesn't "
+      "support T = drake::symbolic::Expression.");
 }
 
 template <typename T>

--- a/multibody/plant/sap_driver.h
+++ b/multibody/plant/sap_driver.h
@@ -113,6 +113,11 @@ class SapDriver {
   void CalcActuation(const systems::Context<T>& context,
                      VectorX<T>* actuation) const;
 
+  // Evaluates a cache entry storing the SapContactProblem to be solved at the
+  // state stored in `context`.
+  const ContactProblemCache<T>& EvalContactProblemCache(
+      const systems::Context<T>& context) const;
+
  private:
   // Provide private access for unit testing only.
   friend class SapDriverTest;
@@ -262,10 +267,6 @@ class SapDriver {
   // contact impulses for reporting contact results.
   void CalcContactProblemCache(const systems::Context<T>& context,
                                ContactProblemCache<T>* cache) const;
-
-  // Eval version of CalcContactProblemCache()
-  const ContactProblemCache<T>& EvalContactProblemCache(
-      const systems::Context<T>& context) const;
 
   // Computes the discrete update from the state stored in the context. The
   // resulting next time step velocities and constraint impulses are stored in

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -3,10 +3,13 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/plant/discrete_contact_data.h"
 #include "drake/multibody/plant/discrete_update_manager.h"
 #include "drake/multibody/plant/dummy_physical_model.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/test_utilities/robot_model.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/revolute_spring.h"
@@ -16,6 +19,8 @@
 namespace drake {
 
 using multibody::RevoluteSpring;
+using multibody::test::RobotModel;
+using multibody::test::RobotModelConfig;
 using symbolic::Expression;
 using systems::Diagram;
 using systems::DiagramBuilder;
@@ -275,6 +280,121 @@ GTEST_TEST(ScalarConversionTest, CouplerConstraintSpec) {
       System<AutoDiffXd>::ToScalarType<double>(*plant_double_to_autodiff);
   EXPECT_EQ(plant_autodiff_to_double->num_constraints(),
             plant_double.num_constraints());
+}
+
+template <typename T>
+class DiscretePlantTest
+    : public ::testing::TestWithParam<
+          std::tuple<DiscreteContactApproximation, ContactModel,
+                     RobotModelConfig::ContactConfig>> {
+ public:
+  void SetUp() override {
+    const auto [contact_approximation, contact_model, contact_configuration] =
+        GetParam();
+    const RobotModelConfig robot_config{contact_configuration,
+                                        contact_approximation, contact_model};
+    auto model_double = std::make_unique<RobotModel<double>>(robot_config);
+    if constexpr (std::is_same_v<T, double>) {
+      model_ = std::move(model_double);
+    } else {
+      model_ = model_double->ToScalarType<T>();
+    }
+  }
+
+ protected:
+  std::unique_ptr<RobotModel<T>> model_;
+};
+
+template <typename T>
+std::string ParamInfoToString(
+    const testing::TestParamInfo<typename DiscretePlantTest<T>::ParamType>&
+        param_info) {
+  const auto [contact_approximation, contact_model, contact_configuration] =
+      param_info.param;
+  const RobotModelConfig robot_config{contact_configuration,
+                                      contact_approximation, contact_model};
+  std::stringstream s;
+  s << robot_config;
+  return s.str();
+}
+
+// Helper to make all parameter permutations for DiscretePlantTest.
+auto MakeAllPermutations() {
+  return ::testing::Combine(
+      ::testing::Values(DiscreteContactApproximation::kSimilar,
+                        DiscreteContactApproximation::kTamsi),
+      ::testing::Values(ContactModel::kPoint,
+                        ContactModel::kHydroelasticWithFallback),
+      ::testing::Values(RobotModelConfig::ContactConfig::kNoGeometry,
+                        RobotModelConfig::ContactConfig::kNoContactState,
+                        RobotModelConfig::ContactConfig::kInContactState));
+}
+
+using DiscretePlantTestDouble = DiscretePlantTest<double>;
+using DiscretePlantTestAutoDiff = DiscretePlantTest<AutoDiffXd>;
+using DiscretePlantTestExpression = DiscretePlantTest<symbolic::Expression>;
+
+INSTANTIATE_TEST_SUITE_P(SupportMatrixTests, DiscretePlantTestDouble,
+                         MakeAllPermutations(), ParamInfoToString<double>);
+
+TEST_P(DiscretePlantTestDouble, ForcedUpdate) {
+  const auto& diagram = model_->diagram();
+  auto updates = diagram.AllocateDiscreteVariables();
+  EXPECT_NO_THROW(diagram.CalcForcedDiscreteVariableUpdate(model_->context(),
+                                                           updates.get()));
+}
+
+INSTANTIATE_TEST_SUITE_P(SupportMatrixTests, DiscretePlantTestAutoDiff,
+                         MakeAllPermutations(), ParamInfoToString<AutoDiffXd>);
+
+TEST_P(DiscretePlantTestAutoDiff, ForcedUpdate) {
+  const auto& diagram = model_->diagram();
+  auto updates = diagram.AllocateDiscreteVariables();
+  EXPECT_NO_THROW(diagram.CalcForcedDiscreteVariableUpdate(model_->context(),
+                                                           updates.get()));
+}
+
+INSTANTIATE_TEST_SUITE_P(SupportMatrixTests, DiscretePlantTestExpression,
+                         MakeAllPermutations(),
+                         ParamInfoToString<symbolic::Expression>);
+
+TEST_P(DiscretePlantTestExpression, ForcedUpdate) {
+  const auto& diagram = model_->diagram();
+  auto updates = diagram.AllocateDiscreteVariables();
+  const auto [contact_approximation, contact_model, contact_configuration] =
+      GetParam();
+
+  // In summary, even though the exceptions below are caused at different
+  // levels, we do not support discrete updates when T = symbolic::Expression.
+  std::string failure_cause_message;
+  if (model_->plant().get_discrete_contact_solver() ==
+      DiscreteContactSolver::kSap) {
+    failure_cause_message =
+        "Discrete updates with the SAP solver are not supported for T = "
+        ".*Expression";
+  } else {
+    if (model_->plant().get_contact_model() ==
+        ContactModel::kHydroelasticWithFallback) {
+      failure_cause_message =
+          ".*CalcHydroelasticWithFallback.*: This method doesn't support T = "
+          ".*Expression.";
+    } else if (model_->plant().get_contact_model() == ContactModel::kPoint) {
+      if (contact_configuration ==
+          RobotModelConfig::ContactConfig::kInContactState) {
+        failure_cause_message =
+            "Penetration queries between shapes .* are not supported for "
+            "scalar type .*Expression. .*";
+      } else {
+        failure_cause_message = "This method doesn't support T = .*Expression.";
+      }
+    } else {
+      throw std::runtime_error("Update unit test to verify this case.");
+    }
+  }
+
+  DRAKE_EXPECT_THROWS_MESSAGE(diagram.CalcForcedDiscreteVariableUpdate(
+                                  model_->context(), updates.get()),
+                              failure_cause_message);
 }
 
 }  // namespace

--- a/multibody/test_utilities/BUILD.bazel
+++ b/multibody/test_utilities/BUILD.bazel
@@ -37,6 +37,24 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "robot_model",
+    testonly = 1,
+    srcs = ["robot_model.cc"],
+    hdrs = ["robot_model.h"],
+    data = [
+        "@drake_models//:dishes",
+        "@drake_models//:iiwa_description",
+    ],
+    deps = [
+        "//common/test_utilities:maybe_pause_for_user",
+        "//multibody/parsing",
+        "//multibody/plant",
+        "//multibody/plant:compliant_contact_manager_tester",
+        "//visualization:visualization_config_functions",
+    ],
+)
+
+drake_cc_library(
     name = "spatial_kinematics",
     testonly = 1,
     srcs = [],

--- a/multibody/test_utilities/robot_model.cc
+++ b/multibody/test_utilities/robot_model.cc
@@ -1,0 +1,285 @@
+#include "drake/multibody/test_utilities/robot_model.h"
+
+#include "drake/common/test_utilities/maybe_pause_for_user.h"
+
+namespace drake {
+namespace multibody {
+namespace test {
+
+std::ostream& operator<<(std::ostream& out, const RobotModelConfig& c) {
+  switch (c.contact_approximation) {
+    case DiscreteContactApproximation::kLagged: {
+      out << "Lagged";
+      break;
+    }
+    case DiscreteContactApproximation::kSimilar: {
+      out << "Similar";
+      break;
+    }
+    case DiscreteContactApproximation::kSap: {
+      out << "Sap";
+      break;
+    }
+    case DiscreteContactApproximation::kTamsi: {
+      out << "Tamsi";
+      break;
+    }
+  }
+
+  switch (c.contact_model) {
+    case ContactModel::kHydroelastic: {
+      out << "Hydro";
+      break;
+    }
+    case ContactModel::kHydroelasticWithFallback: {
+      out << "HydroWithFallback";
+      break;
+    }
+    case ContactModel::kPoint: {
+      out << "Point";
+      break;
+    }
+  }
+
+  switch (c.contact_configuration) {
+    case RobotModelConfig::ContactConfig::kNoGeometry: {
+      out << "NoGeometry";
+      break;
+    }
+    case RobotModelConfig::ContactConfig::kNoContactState: {
+      out << "NoContactState";
+      break;
+    }
+    case RobotModelConfig::ContactConfig::kInContactState: {
+      out << "InContactState";
+      break;
+    }
+  }
+
+  return out;
+}
+
+template <typename T>
+RobotModel<T>::RobotModel(const RobotModelConfig& config,
+                          bool add_visualization)
+  requires std::is_same_v<T, double>
+{  // NOLINT(whitespace/braces)
+  systems::DiagramBuilder<double> builder;
+  auto items = AddMultibodyPlantSceneGraph(&builder, kTimeStep);
+  plant_ = &items.plant;
+
+  Parser parser(plant_);
+  robot_model_instance_ = parser.AddModelsFromUrl(
+      "package://drake_models/iiwa_description/sdf/iiwa7_no_collision.sdf")[0];
+  parser.AddModelsFromUrl("package://drake_models/dishes/plate_8in.sdf");
+
+  // Weld the robot's base to the world.
+  plant_->WeldFrames(plant_->world_frame(),
+                     plant_->GetBodyByName("iiwa_link_0").body_frame(),
+                     math::RigidTransformd::Identity());
+
+  // Ground geometry.
+  geometry::ProximityProperties proximity_properties;
+  geometry::AddContactMaterial(kHcDissipation, kStiffness,
+                               CoulombFriction<double>(kMu, kMu),
+                               &proximity_properties);
+  proximity_properties.AddProperty(geometry::internal::kMaterialGroup,
+                                   geometry::internal::kRelaxationTime,
+                                   kRelaxationTime / 2);
+  plant_->RegisterCollisionGeometry(
+      plant_->world_body(),
+      math::RigidTransformd(Eigen::Vector3d(0.0, 0.0, -0.05)),
+      geometry::Box(2.0, 2.0, 0.1), "ground_collision", proximity_properties);
+
+  // Add simple contact geometry at the end effector.
+  plant_->RegisterCollisionGeometry(
+      plant_->GetBodyByName("iiwa_link_7"),
+      math::RigidTransformd(Eigen::Vector3d(0.0, 0.0, 0.07)),
+      geometry::Sphere(0.05), "iiwa_link_7_collision", proximity_properties);
+
+  plant_->set_contact_model(config.contact_model);
+  plant_->set_discrete_contact_approximation(config.contact_approximation);
+  plant_->Finalize();
+
+  // Remove proximity roles if geometry is not requested.
+  if (config.contact_configuration ==
+      RobotModelConfig::ContactConfig::kNoGeometry) {
+    const auto& inspector = items.scene_graph.model_inspector();
+    for (const auto id :
+         inspector.GetAllGeometryIds(geometry::Role::kProximity)) {
+      items.scene_graph.RemoveRole(*plant_->get_source_id(), id,
+                                   geometry::Role::kProximity);
+    }
+  }
+
+  // Make and add a manager so that we have access to it and its driver.
+  if (plant_->get_discrete_contact_solver() == DiscreteContactSolver::kSap) {
+    auto owned_contact_manager = std::make_unique<
+        multibody::internal::CompliantContactManager<double>>();
+    manager_ = owned_contact_manager.get();
+    plant_->SetDiscreteUpdateManager(std::move(owned_contact_manager));
+    driver_ = &multibody::internal::CompliantContactManagerTester::sap_driver(
+        *manager_);
+  }
+
+  // We add a visualizer for visual inspection of the model in this test.
+  if (add_visualization) {
+    visualization::AddDefaultVisualization(&builder);
+  }
+
+  diagram_ = builder.Build();
+
+  // Create context.
+  context_ = diagram_->CreateDefaultContext();
+  plant_context_ =
+      &diagram_->GetMutableSubsystemContext(*plant_, context_.get());
+  SetPlateInitialState();
+
+  switch (config.contact_configuration) {
+    case RobotModelConfig::ContactConfig::kNoGeometry: {
+      SetRobotState(RobotZeroState());
+      break;
+    }
+    case RobotModelConfig::ContactConfig::kNoContactState: {
+      SetRobotState(RobotZeroState());
+      break;
+    }
+    case RobotModelConfig::ContactConfig::kInContactState: {
+      SetRobotState(RobotStateWithOneContactStiction());
+      break;
+    }
+  }
+
+  // Fix input ports.
+  const VectorX<double> tau =
+      VectorX<double>::Zero(plant_->num_actuated_dofs());
+  plant_->get_actuation_input_port().FixValue(plant_context_, tau);
+}
+
+template <typename T>
+template <typename U>
+std::unique_ptr<RobotModel<U>> RobotModel<T>::ToScalarType() const {
+  auto converted_model = std::make_unique<RobotModel<U>>();
+
+  // Scalar-convert the model.
+  converted_model->diagram_ = dynamic_pointer_cast<systems::Diagram<U>>(
+      diagram_->template ToScalarType<U>());
+  converted_model->plant_ = const_cast<MultibodyPlant<U>*>(
+      &converted_model->diagram_
+           ->template GetDowncastSubsystemByName<MultibodyPlant<U>>(
+               plant_->get_name()));
+
+  // Make and add a manager so that we have access to it and its driver.
+  if (plant_->get_discrete_contact_solver() == DiscreteContactSolver::kSap &&
+      !std::is_same_v<U, symbolic::Expression>) {
+    auto owned_contact_manager_ad =
+        std::make_unique<multibody::internal::CompliantContactManager<U>>();
+    converted_model->manager_ = owned_contact_manager_ad.get();
+    converted_model->plant_->SetDiscreteUpdateManager(
+        std::move(owned_contact_manager_ad));
+    converted_model->driver_ =
+        &multibody::internal::CompliantContactManagerTester::sap_driver(
+            *converted_model->manager_);
+  }
+
+  // Create context.
+  converted_model->context_ = converted_model->diagram_->CreateDefaultContext();
+  converted_model->context_->SetTimeStateAndParametersFrom(*context_);
+  converted_model->plant_context_ =
+      &converted_model->diagram_->GetMutableSubsystemContext(
+          *converted_model->plant_, converted_model->context_.get());
+
+  // Fix input ports.
+  const VectorX<U> tau_ad = VectorX<U>::Zero(plant_->num_actuated_dofs());
+  converted_model->plant_->get_actuation_input_port().FixValue(
+      converted_model->plant_context_, tau_ad);
+
+  return converted_model;
+}
+
+template <typename T>
+std::unique_ptr<RobotModel<AutoDiffXd>> RobotModel<T>::ToAutoDiffXd() const {
+  return ToScalarType<AutoDiffXd>();
+}
+
+template <typename T>
+void RobotModel<T>::ForcedPublish() {
+  diagram_->ForcedPublish(*context_);
+}
+
+template <typename T>
+void RobotModel<T>::SetState(const VectorX<T>& x) {
+  plant_->SetPositionsAndVelocities(plant_context_, x);
+}
+
+template <typename T>
+void RobotModel<T>::SetRobotState(const VectorX<T>& x) {
+  plant_->SetPositionsAndVelocities(plant_context_, robot_model_instance_, x);
+}
+
+template <typename T>
+VectorX<T> RobotModel<T>::GetState() const {
+  return plant_->GetPositionsAndVelocities(*plant_context_);
+}
+
+template <typename T>
+const multibody::contact_solvers::internal::SapContactProblem<T>&
+RobotModel<T>::EvalContactProblem(const VectorX<T>& x0)
+  requires(!std::is_same_v<T, symbolic::Expression>)
+{  // NOLINT(whitespace/braces)
+  DRAKE_DEMAND(plant_->get_discrete_contact_solver() ==
+               DiscreteContactSolver::kSap);
+  SetState(x0);
+  const auto& problem_cache = driver_->EvalContactProblemCache(*plant_context_);
+  // There are no locked dofs. Sanity check.
+  DRAKE_DEMAND(problem_cache.sap_problem_locked == nullptr);
+  return *problem_cache.sap_problem;
+}
+
+template <typename T>
+Eigen::VectorXd RobotModel<T>::RobotStateWithOneContactStiction() {
+  return (VectorX<double>(14) << 0, 1.17, 0, -1.33, 0, 0.58, 0,  // q
+          0, 0, 0, 0, 0, 0, 0                                    // v
+          )
+      .finished();
+}
+
+template <typename T>
+Eigen::VectorXd RobotModel<T>::RobotStateWithOneOneContactSliding() {
+  return (VectorX<double>(14) << 0, 1.17, 0, -1.33, 0, 0.58, 0,  // q
+          0, -0.1, 0, -0.2, 0, 0, 0                              // v
+          )
+      .finished();
+}
+
+template <typename T>
+Eigen::VectorXd RobotModel<T>::RobotZeroState() {
+  return VectorX<double>::Zero(14);
+}
+
+template <typename T>
+void RobotModel<T>::SetPlateInitialState() {
+  plant_->SetFreeBodyPose(plant_context_, plant_->GetBodyByName("plate_8in"),
+                          math::RigidTransform<T>{Vector3<T>(0.5, 0.5, 0.5)});
+}
+
+void VisualizeRobotModel() {
+  // Visualize the contact configuration.
+  RobotModelConfig config{
+      .contact_configuration = RobotModelConfig::ContactConfig::kInContactState,
+  };
+  RobotModel<double> model(config, true /* add viz */);
+
+  model.ForcedPublish();
+  common::MaybePauseForUser();
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    (&RobotModel<T>::template ToScalarType<U>))
+
+}  // namespace test
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::test::RobotModel)

--- a/multibody/test_utilities/robot_model.h
+++ b/multibody/test_utilities/robot_model.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+#include "drake/geometry/proximity_properties.h"
+#include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/compliant_contact_manager.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/sap_driver.h"
+#include "drake/multibody/plant/test/compliant_contact_manager_tester.h"
+#include "drake/visualization/visualization_config_functions.h"
+
+namespace drake {
+namespace multibody {
+namespace test {
+
+// Options for RobotModel.
+struct RobotModelConfig {
+  enum class ContactConfig {
+    // The model is loaded with no geometry, in an arbitrary state.
+    // In particular, the state from RobotModel::RobotZeroState().
+    kNoGeometry,
+    // Full model with geometry, in a state with no contact.
+    // In particular, the state from RobotModel::RobotZeroState().
+    kNoContactState,
+    // Full model with geometry, in a state with contact.
+    // In particular, the state from
+    // RobotModel::RobotStateWithOneContactStiction().
+    kInContactState,
+  };
+
+  // Model specifics related to the geometry and contact state.
+  ContactConfig contact_configuration{ContactConfig::kInContactState};
+
+  // Specifies the discrete approximation of contact.
+  DiscreteContactApproximation contact_approximation{
+      DiscreteContactApproximation::kSimilar};
+
+  // Specifies the geometric modeling of contact.
+  ContactModel contact_model{ContactModel::kHydroelasticWithFallback};
+};
+
+// Provides a string description of a robot model configuration.
+// It can be used to provide the suffix for gtest parameters.
+std::ostream& operator<<(std::ostream& out, const RobotModelConfig& c);
+
+// Helper class to create an interesting SapContactProblem with problem data
+// a function of the parameters of differentiation, in this case the initial
+// state. This allows to exercise the entire numeric pipeline with gradients
+// propagating through complex terms such as the mass matrix, contact Jacobians
+// and even contact data.
+//
+// In particular, we load the model of an IIWA7 arm and a free floating plate.
+// Having a robot and a free floating body helps to stress test the sparsity
+// treatment within the solver.
+template <typename T>
+class RobotModel {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RobotModel);
+
+  // Creates an empty model.
+  RobotModel() = default;
+
+  // This constructor is provided to make a RobotModel<double>. Use the scalar
+  // conversion methods provided by this class to obtain models on other scalar
+  // types.
+  explicit RobotModel(const RobotModelConfig& config,
+                      bool add_visualization = false)
+    requires std::is_same_v<T, double>;
+
+  const MultibodyPlant<T>& plant() const { return *plant_; }
+  const systems::Diagram<T>& diagram() const { return *diagram_; }
+  const systems::Context<T>& context() const { return *context_; }
+
+  int num_velocities() const { return plant_->num_velocities(); }
+
+  template <typename U>
+  std::unique_ptr<RobotModel<U>> ToScalarType() const;
+
+  std::unique_ptr<RobotModel<AutoDiffXd>> ToAutoDiffXd() const;
+
+  // Helper to invoke ForcedPublish() on the underlying system at the current
+  // state stored by this model.
+  void ForcedPublish();
+
+  // Helper to set the full state of the model, including robot and plate.
+  void SetState(const VectorX<T>& x);
+
+  // Helper to set the state of the robot only.
+  void SetRobotState(const VectorX<T>& x);
+
+  // Returns a vector with the full state of the model.
+  VectorX<T> GetState() const;
+
+  // Helper that uses the underlying SapDriver to evaluate the SapContactProblem
+  // at x0. Not available when T = symbolic::Expression.
+  const multibody::contact_solvers::internal::SapContactProblem<T>&
+  EvalContactProblem(const VectorX<T>& x0)
+    requires(!std::is_same_v<T, symbolic::Expression>);
+
+  // Makes a state in which the robot's end effector touches the ground.
+  // Velocities are zero.
+  static Eigen::VectorXd RobotStateWithOneContactStiction();
+
+  // Makes a state in which the robot's end effector touches the ground.
+  // Velocities are non-zero.
+  static Eigen::VectorXd RobotStateWithOneOneContactSliding();
+
+  // Returns the robot's "zero state".
+  static Eigen::VectorXd RobotZeroState();
+
+ private:
+  // Friendship to give ToScalarType() access to private members.
+  template <typename U>
+  friend class RobotModel;
+
+  // We set the initial state of the plate to be away from the robot and away
+  // from the ground so that there  is no contact. This is to stress test the
+  // sparsity treatment withing the SAP solver, which removes non-participating
+  // DOFs from the problem, and solves a reduced problem instead.
+  void SetPlateInitialState();
+
+  std::unique_ptr<systems::Diagram<T>> diagram_;
+  MultibodyPlant<T>* plant_{nullptr};
+  std::unique_ptr<systems::Context<T>> context_;
+  systems::Context<T>* plant_context_{nullptr};
+  // N.B. manager_ and driver_ will be available for testing only when using the
+  // SAP solver for T != symbolic::Expression.
+  multibody::internal::CompliantContactManager<T>* manager_{nullptr};
+  const multibody::internal::SapDriver<T>* driver_{nullptr};
+  ModelInstanceIndex robot_model_instance_;
+
+  // Parameters of the problem.
+  const double kTimeStep{0.001};      // Discrete time step of the plant.
+  const double kStiffness{1.0e4};     // In N/m.
+  const double kHcDissipation{0.2};   // In s/m.
+  const double kMu{0.5};              // Coefficient of friction.
+  const double kRelaxationTime{0.1};  // In s.
+};
+
+// Publishes a default robot model for manual inspection via visualization. To
+// see the model, run the test as a command-line executable, instead of as a
+// bazel test.
+void VisualizeRobotModel();
+
+}  // namespace test
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::test::RobotModel)


### PR DESCRIPTION
Updates the multibody plant scalar conversion tests to reflect the current state of the support matrix for discrete models.

An important conclusion is that for TAMSI (and SAP), we do not support discrete updates when `T = Symbolic` at all. We (meaning I really) were expecting this to be supported when num_contacts=0, but it turns out that the proximity engine does not even allow queres on symbolic, regardelss the state of the system.

cc'ing @jwnimmer-tri. I know we talked about a Python script instead, but I already had this and it's not an extra large of lines (~150) to put together in C++ if I reuse the code from #21431

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21441)
<!-- Reviewable:end -->
