### PR TITLE
[tools] Fix buildifier_test to not scribble in runfiles

### DIFF
--- a/tools/lint/test/buildifier_test.py
+++ b/tools/lint/test/buildifier_test.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import subprocess
 import unittest
 
@@ -18,14 +19,14 @@ class BuildifierTest(unittest.TestCase):
         return "\n\n".join(result) + "\n"
 
     def _call_buildifier(self, testdata_contents, args):
-        testdata_filename = "tmp/BUILD.bazel"
-        if not os.path.exists("tmp"):
-            os.mkdir("tmp")
-        with open(testdata_filename, "w") as testdata_file:
-            testdata_file.write(testdata_contents)
-        command = ["tools/lint/buildifier"] + args + [testdata_filename]
+        tmpdir = Path(os.environ["TEST_TMPDIR"])
+        build_path = tmpdir / "BUILD.bazel"
+        build_path.write_text(testdata_contents, encoding="utf-8")
+        buildifier = Path("tools/lint/buildifier").absolute()
+        command = [buildifier] + args + ["BUILD.bazel"]
         process = subprocess.Popen(
-            command, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            command, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            cwd=tmpdir)
         stdout, _ = process.communicate()
         return process.returncode, stdout.decode('utf8')
 
@@ -42,11 +43,11 @@ class BuildifierTest(unittest.TestCase):
         self.assertEqual(returncode, 1, output)
         self.assertListEqual(output.splitlines(), [
             "ERROR: buildifier: the required formatting is incorrect",
-            ("ERROR: tmp/BUILD.bazel:1: "
+            ("ERROR: BUILD.bazel:1: "
              "error: the required formatting is incorrect"),
-            ("ERROR: tmp/BUILD.bazel:1: note: "
-             "fix via bazel-bin/tools/lint/buildifier tmp/BUILD.bazel"),
-            ("ERROR: tmp/BUILD.bazel:1: note: "
+            ("ERROR: BUILD.bazel:1: note: "
+             "fix via bazel-bin/tools/lint/buildifier BUILD.bazel"),
+            ("ERROR: BUILD.bazel:1: note: "
              "if that program does not exist, "
              "you might need to compile it first: "
              "bazel build //tools/lint/..."),


### PR DESCRIPTION
Unit tests should never write to cwd, rather always to TEST_TMPDIR.

Towards #20731.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21451)
<!-- Reviewable:end -->
