### PR TITLE
[examples] Fix some smoke test path snafus

### DIFF
--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -224,9 +224,14 @@ drake_cc_binary(
 drake_py_binary(
     name = "optimizer_demo",
     srcs = ["optimizer_demo.py"],
+    add_test_rule = True,
     data = [
         ":spong_sim_main_cc",
         ":test/example_stochastic_scenario.yaml",
+    ],
+    test_rule_args = [
+        "--ensemble_size=3",
+        "--num_evaluations=3",
     ],
     deps = [
         ":acrobot_io",
@@ -421,17 +426,6 @@ drake_cc_googletest(
         ":acrobot_plant",
         "//common/test_utilities:eigen_matrix_compare",
         "//multibody/parsing",
-    ],
-)
-
-sh_test(
-    name = "optimizer_demo_smoke_test",
-    srcs = ["test/optimizer_demo_smoke_test.sh"],
-    data = [
-        ":optimizer_demo",
-    ],
-    tags = [
-        "no_memcheck",  # This wraps python; python is memcheck-exempt.
     ],
 )
 

--- a/examples/acrobot/test/optimizer_demo_smoke_test.sh
+++ b/examples/acrobot/test/optimizer_demo_smoke_test.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-${TEST_SRCDIR}/drake/examples/acrobot/optimizer_demo \
-              --ensemble_size=3 --num_evaluations=3

--- a/examples/allegro_hand/joint_control/BUILD.bazel
+++ b/examples/allegro_hand/joint_control/BUILD.bazel
@@ -64,6 +64,9 @@ drake_py_unittest(
         ":run_twisting_mug",
     ],
     flaky = True,
+    deps = [
+        "@rules_python//python/runfiles",
+    ],
 )
 
 add_lint_tests(enable_clang_format_lint = False)

--- a/examples/allegro_hand/joint_control/test/run_twisting_mug_test.py
+++ b/examples/allegro_hand/joint_control/test/run_twisting_mug_test.py
@@ -9,6 +9,8 @@ import sys
 import time
 import unittest
 
+from python.runfiles import Create as CreateRunfiles
+
 
 def _unique_lcm_url(path):
     """Returns a unique LCM url given a path."""
@@ -19,20 +21,20 @@ def _unique_lcm_url(path):
 
 class TestRunTwistingMug(unittest.TestCase):
 
+    def _find_resource(self, basename):
+        respath = f"drake/examples/allegro_hand/joint_control/{basename}"
+        runfiles = CreateRunfiles()
+        result = runfiles.Rlocation(respath)
+        self.assertTrue(result, respath)
+        self.assertTrue(os.path.exists(result), respath)
+        return result
+
     def setUp(self):
-        # Fail-fast if these are not set.
-        self._test_srcdir = os.environ["TEST_SRCDIR"]
         self._test_tmpdir = os.environ["TEST_TMPDIR"]
 
         # Find the two binaries under test.
-        self._sim = os.path.join(
-            self._test_srcdir, "drake/examples/allegro_hand/joint_control",
-            "allegro_single_object_simulation")
-        self._control = os.path.join(
-            self._test_srcdir, "drake/examples/allegro_hand/joint_control",
-            "run_twisting_mug")
-        assert os.path.exists(self._sim)
-        assert os.path.exists(self._control)
+        self._sim = self._find_resource("allegro_single_object_simulation")
+        self._control = self._find_resource("run_twisting_mug")
 
         # Let the sim and controller talk to (only) each other.
         self._env = dict(**os.environ)


### PR DESCRIPTION
Hard-coding paths to runfiles is incompatible with bzlmod. We should always use `python.runfiles`, or (in the case of acrobot) just use our simple `add_test_rule` pattern.

Towards #20731.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21452)
<!-- Reviewable:end -->
