### PR TITLE
[doc,tools] Adjust imports and libraries in prep for bzlmod

### DIFF
--- a/doc/build.py
+++ b/doc/build.py
@@ -11,7 +11,7 @@ import urllib.parse
 from python import runfiles
 import xml.etree.ElementTree as ET
 
-from drake.doc.defs import check_call, main
+from doc.defs import check_call, main
 
 
 def _build(*, out_dir, temp_dir, quick, modules):

--- a/doc/doxygen_cxx/build.py
+++ b/doc/doxygen_cxx/build.py
@@ -12,7 +12,7 @@ import sys
 
 from python import runfiles
 
-from drake.doc.defs import (
+from doc.defs import (
     check_call,
     main,
     perl_cleanup_html_output,

--- a/doc/doxygen_cxx/test/system_doxygen_test.py
+++ b/doc/doxygen_cxx/test/system_doxygen_test.py
@@ -2,7 +2,7 @@ import re
 from textwrap import dedent, indent
 import unittest
 
-import drake.doc.doxygen_cxx.system_doxygen as mut
+import doc.doxygen_cxx.system_doxygen as mut
 
 
 class TestSystemDoxygen(unittest.TestCase):

--- a/doc/pages.py
+++ b/doc/pages.py
@@ -7,7 +7,7 @@ For instructions, see https://drake.mit.edu/documentation_instructions.html.
 import os
 import tempfile
 
-from drake.doc.defs import (
+from doc.defs import (
     check_call,
     main,
     perl_cleanup_html_output,

--- a/doc/pydrake/build.py
+++ b/doc/pydrake/build.py
@@ -7,16 +7,16 @@ import os
 from os.path import join
 import sys
 
-from drake.doc.defs import (
+import pydrake._all_everything
+from pydrake.common import _MangledName
+
+from doc.defs import (
     check_call,
     main,
     perl_cleanup_html_output,
     symlink_input,
     verbose,
 )
-
-import pydrake._all_everything
-from pydrake.common import _MangledName
 
 
 def _get_submodules(name):

--- a/doc/pydrake/pydrake_sphinx_extension.py
+++ b/doc/pydrake/pydrake_sphinx_extension.py
@@ -26,9 +26,10 @@ import sphinx.domains.python as pydoc
 from sphinx.ext import autodoc
 from sphinx.util.nodes import nested_parse_with_titles
 
-from drake.doc.doxygen_cxx.system_doxygen import system_yaml_to_html
 from pydrake.common.cpp_template import TemplateBase
 from pydrake.common.deprecation import DrakeDeprecationWarning
+
+from doc.doxygen_cxx.system_doxygen import system_yaml_to_html
 
 
 def rindex(s, sub):

--- a/doc/styleguide/build.py
+++ b/doc/styleguide/build.py
@@ -7,7 +7,7 @@ import os
 from os.path import join
 import textwrap
 
-from drake.doc.defs import check_call, main, symlink_input
+from doc.defs import check_call, main, symlink_input
 
 
 def _add_title(*, temp_dir, filename, title):

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,18 +1,16 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_py.bzl", "drake_py_binary")
+load("//tools/skylark:drake_py.bzl", "drake_py_binary", "drake_py_library")
 load(
     "//tools/skylark:drake_runfiles_binary.bzl",
     "drake_runfiles_binary",
 )
-load("//tools/skylark:py.bzl", "py_binary", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 
-py_library(
+drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
     visibility = [":__subpackages__"],
-    deps = ["//:module_py"],
 )
 
 alias(

--- a/tools/install/BUILD.bazel
+++ b/tools/install/BUILD.bazel
@@ -2,27 +2,27 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
     "//tools/skylark:drake_py.bzl",
     "drake_py_binary",
+    "drake_py_library",
     "drake_py_unittest",
 )
-load("//tools/skylark:py.bzl", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 
-py_library(
+drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
     visibility = [":__subpackages__"],
     deps = ["//tools:module_py"],
 )
 
-py_library(
+drake_py_library(
     name = "otool",
     srcs = ["otool.py"],
     visibility = ["//:__subpackages__"],
     deps = [":module_py"],
 )
 
-py_library(
+drake_py_library(
     name = "install_test_helper",
     testonly = 1,
     srcs = ["install_test_helper.py"],

--- a/tools/install/dummy/BUILD.bazel
+++ b/tools/install/dummy/BUILD.bazel
@@ -8,9 +8,9 @@ load(
 )
 load(
     "//tools/skylark:drake_py.bzl",
+    "drake_py_library",
     "drake_py_unittest",
 )
-load("//tools/skylark:py.bzl", "py_library")
 
 package(default_visibility = ["//tools/install:__subpackages__"])
 
@@ -35,7 +35,7 @@ drake_transitive_installed_hdrs_filegroup(
     deps = [":dummy_private"],
 )
 
-py_library(
+drake_py_library(
     name = "dummy_py",
     testonly = 1,
     srcs = ["dummy.py"],

--- a/tools/install/installer.py
+++ b/tools/install/installer.py
@@ -22,7 +22,7 @@ import sys
 
 from subprocess import check_output, check_call
 
-from drake.tools.install import otool
+from tools.install import otool
 
 # Used for matching against libraries and extracting useful components.
 # N.B. On linux, dynamic libraries may have their version number as a suffix

--- a/tools/install/test/install_meta_test.py
+++ b/tools/install/test/install_meta_test.py
@@ -8,7 +8,7 @@ import unittest
 from subprocess import STDOUT, check_output
 import sys
 
-import drake.tools.install.installer as installer
+import tools.install.installer as installer
 
 # TODO(eric.cousineau): Expand on these tests, especially for nuanced things
 # like Python C extensions.

--- a/tools/install/test/installer_test.py
+++ b/tools/install/test/installer_test.py
@@ -4,7 +4,7 @@ import os
 from os.path import isdir, join
 import unittest
 
-from drake.tools.install.installer import Installer
+from tools.install.installer import Installer
 
 
 class TestInstall(unittest.TestCase):

--- a/tools/jupyter/BUILD.bazel
+++ b/tools/jupyter/BUILD.bazel
@@ -1,28 +1,27 @@
 load("//tools/jupyter:jupyter_py.bzl", "drake_jupyter_py_binary")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load(
-    "//tools/skylark:drake_py.bzl",
-    "drake_py_library",
-    "drake_py_unittest",
-)
+load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
+load("//tools/skylark:py.bzl", "py_library")
 
-drake_py_library(
-    name = "module_py",
-    srcs = ["__init__.py"],
-    deps = ["//tools:module_py"],
-)
+package(default_visibility = ["//visibility:private"])
 
-drake_py_library(
+# Note that we do NOT use drake_py_library here, so that our codegen via the
+# JUPYTER_PY_TEMPLATE file is as simple and portable as possible. Instead,
+# we'll use an `imports = ["."]` to establish a helpful `sys.path`.
+py_library(
     name = "jupyter_bazel_py",
     srcs = ["jupyter_bazel.py"],
+    imports = ["."],
     visibility = ["//visibility:public"],
-    deps = [":module_py"],
 )
 
-drake_py_library(
+# Note that we do NOT use drake_py_library here, so that this program is a
+# more representative demo of what and end user would experience. Instead,
+# we'll use an `imports = ["."]` to establish a helpful `sys.path`.
+py_library(
     name = "example_library",
     srcs = ["example_library.py"],
-    imports = [":module_py"],
+    imports = ["."],
 )
 
 drake_jupyter_py_binary(

--- a/tools/jupyter/__init__.py
+++ b/tools/jupyter/__init__.py
@@ -1,1 +1,0 @@
-# Empty Python module `__init__`, required to make this a module.

--- a/tools/jupyter/example.ipynb
+++ b/tools/jupyter/example.ipynb
@@ -16,7 +16,7 @@
     "import ipywidgets as widgets\n",
     "import numpy as np\n",
     "\n",
-    "from drake.tools.jupyter.example_library import my_func"
+    "from example_library import my_func"
    ]
   },
   {

--- a/tools/jupyter/jupyter_py.bzl
+++ b/tools/jupyter/jupyter_py.bzl
@@ -9,7 +9,7 @@ load("//tools/workspace:generate_file.bzl", "generate_file")
 _JUPYTER_PY_TEMPLATE = """
 import sys
 
-from drake.tools.jupyter.jupyter_bazel import _jupyter_bazel_notebook_main
+from jupyter_bazel import _jupyter_bazel_notebook_main
 
 
 def main():

--- a/tools/lcm_gen/BUILD.bazel
+++ b/tools/lcm_gen/BUILD.bazel
@@ -12,7 +12,7 @@ load(
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 # The library target for this tool.
-py_library(
+drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
     deps = ["//tools:module_py"],

--- a/tools/lcm_gen/test/lcm_gen_test.py
+++ b/tools/lcm_gen/test/lcm_gen_test.py
@@ -4,7 +4,7 @@ import unittest
 
 from python import runfiles
 
-from drake.tools.lcm_gen import (
+from tools.lcm_gen import (
     CppGen,
     Parser,
     PrimitiveType,

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -13,7 +13,7 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-py_library(
+drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
     deps = ["//tools:module_py"],

--- a/tools/lint/buildifier.py
+++ b/tools/lint/buildifier.py
@@ -12,8 +12,8 @@ import subprocess
 import sys
 from subprocess import Popen, PIPE, STDOUT
 
-from drake.tools.lint.find_data import find_data
-from drake.tools.lint.util import find_all_sources
+from tools.lint.find_data import find_data
+from tools.lint.util import find_all_sources
 
 # These match data=[] in our BUILD.bazel file.
 _BUILDIFIER = "external/buildifier/buildifier"

--- a/tools/lint/clang_format_includes.py
+++ b/tools/lint/clang_format_includes.py
@@ -8,8 +8,8 @@ import argparse
 import os
 import sys
 
-from drake.tools.lint.formatter import IncludeFormatter
-from drake.tools.lint.util import find_all_sources
+from tools.lint.formatter import IncludeFormatter
+from tools.lint.util import find_all_sources
 
 
 def main(workspace_name="drake"):

--- a/tools/lint/clang_format_lint.py
+++ b/tools/lint/clang_format_lint.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-import drake.tools.lint.clang_format as clang_format_lib
+import tools.lint.clang_format as clang_format_lib
 
 
 def _is_cxx(filename):

--- a/tools/lint/drakelint.py
+++ b/tools/lint/drakelint.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 
-from drake.tools.lint.formatter import IncludeFormatter
+from tools.lint.formatter import IncludeFormatter
 
 
 def _check_unguarded_openmp_uses(filename):

--- a/tools/lint/formatter.py
+++ b/tools/lint/formatter.py
@@ -5,7 +5,7 @@ import io
 import os
 from subprocess import Popen, PIPE, CalledProcessError
 
-import drake.tools.lint.clang_format as clang_format_lib
+import tools.lint.clang_format as clang_format_lib
 
 
 class FormatterBase:

--- a/tools/lint/python_lint.bzl
+++ b/tools/lint/python_lint.bzl
@@ -52,18 +52,6 @@ def python_lint(
             PYTHON_LINT_IGNORE_DEFAULT (as strings, with the 'E' or 'W').
         exclude: List of labels to exclude from linting, e.g., [:foo.py].
         extra_srcs: Source files that are not discoverable via rules.
-
-    Example:
-        BUILD:
-            load("//tools/lint:python_lint.bzl", "python_lint")
-            load("//tools/skylark:py.bzl", "py_library")
-
-            py_library(
-                name = "foo",
-                srcs = ["foo.py"],
-            )
-
-            python_lint()
     """
     if existing_rules == None:
         existing_rules = native.existing_rules().values()

--- a/tools/lint/test/find_data_test.py
+++ b/tools/lint/test/find_data_test.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from drake.tools.lint.find_data import find_data
+from tools.lint.find_data import find_data
 
 
 class FindDataTest(unittest.TestCase):

--- a/tools/lint/test/formatter_test.py
+++ b/tools/lint/test/formatter_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from drake.tools.lint.formatter import FormatterBase, IncludeFormatter
+from tools.lint.formatter import FormatterBase, IncludeFormatter
 
 
 class TestFormatterBase(unittest.TestCase):

--- a/tools/lint/test/util_test.py
+++ b/tools/lint/test/util_test.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from drake.tools.lint.util import find_all_sources
+from tools.lint.util import find_all_sources
 
 
 class UtilTest(unittest.TestCase):

--- a/tools/skylark/BUILD.bazel
+++ b/tools/skylark/BUILD.bazel
@@ -1,6 +1,5 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
-load("//tools/skylark:py.bzl", "py_binary")
+load("//tools/skylark:drake_py.bzl", "drake_py_binary", "drake_py_unittest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,7 +13,7 @@ config_setting(
     constraint_values = ["@platforms//os:osx"],
 )
 
-py_binary(
+drake_py_binary(
     name = "rewrite_osx_ar_hidden",
     srcs = ["rewrite_osx_ar_hidden.py"],
 )

--- a/tools/wheel/BUILD.bazel
+++ b/tools/wheel/BUILD.bazel
@@ -1,12 +1,12 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_py.bzl", "drake_py_binary")
+load("//tools/skylark:drake_py.bzl", "drake_py_binary", "drake_py_library")
 
 exports_files(
     glob(["**"]),
     visibility = ["//tools:__subpackages__"],
 )
 
-py_library(
+drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
     visibility = [":__subpackages__"],

--- a/tools/wheel/macos/change_lpath.py
+++ b/tools/wheel/macos/change_lpath.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import sys
 
-from drake.tools.install import otool
+from tools.install import otool
 
 
 def _chlpath(path, libs, old, new):

--- a/tools/wheel/macos/strip_rpath.py
+++ b/tools/wheel/macos/strip_rpath.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 import sys
 
-from drake.tools.install import otool
+from tools.install import otool
 
 
 def _filter_rpaths(paths, exclusions):

--- a/tools/wheel/wheel_builder/main.py
+++ b/tools/wheel/wheel_builder/main.py
@@ -4,14 +4,14 @@
 
 import sys
 
-from drake.tools.wheel.wheel_builder.common import do_main as main
+from tools.wheel.wheel_builder.common import do_main as main
 
 
 if __name__ == '__main__':
     if sys.platform == 'linux':
-        from drake.tools.wheel.wheel_builder import linux as platform
+        from tools.wheel.wheel_builder import linux as platform
     elif sys.platform == 'darwin':
-        from drake.tools.wheel.wheel_builder import macos as platform
+        from tools.wheel.wheel_builder import macos as platform
     else:
         platform = None
 

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -1,10 +1,14 @@
 load("//tools/install:check_licenses.bzl", "check_licenses")
 load("//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_py.bzl", "drake_py_binary", "drake_py_test")
-load("//tools/skylark:py.bzl", "py_library")
+load(
+    "//tools/skylark:drake_py.bzl",
+    "drake_py_binary",
+    "drake_py_library",
+    "drake_py_test",
+)
 
-py_library(
+drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
     visibility = [":__subpackages__"],

--- a/tools/workspace/mirror_to_s3.py
+++ b/tools/workspace/mirror_to_s3.py
@@ -24,7 +24,7 @@ import boto3
 import botocore
 import requests
 
-from drake.tools.workspace.metadata import read_repository_metadata
+from tools.workspace.metadata import read_repository_metadata
 
 
 BUCKET_NAME = 'drake-mirror'

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -48,7 +48,7 @@ from typing import Optional, Set
 import git
 import github3
 
-from drake.tools.workspace.metadata import read_repository_metadata
+from tools.workspace.metadata import read_repository_metadata
 
 logger = logging.getLogger('new_release')
 logger.setLevel(logging.INFO)

--- a/tools/workspace/openusd_internal/BUILD.bazel
+++ b/tools/workspace/openusd_internal/BUILD.bazel
@@ -1,7 +1,8 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:drake_py.bzl", "drake_py_binary")
 
-py_binary(
+drake_py_binary(
     name = "upgrade",
     srcs = ["upgrade.py"],
     data = [

--- a/tools/workspace/pybind11/BUILD.bazel
+++ b/tools/workspace/pybind11/BUILD.bazel
@@ -4,8 +4,12 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
-load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
-load("//tools/skylark:py.bzl", "py_binary", "py_library")
+load(
+    "//tools/skylark:drake_py.bzl",
+    "drake_py_binary",
+    "drake_py_library",
+    "drake_py_unittest",
+)
 load(
     "//tools/skylark:pybind.bzl",
     "generate_pybind_documentation_header",
@@ -19,13 +23,13 @@ exports_files(
     visibility = ["@pybind11//:__pkg__"],
 )
 
-py_library(
+drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
     deps = ["//tools/workspace:module_py"],
 )
 
-py_library(
+drake_py_library(
     name = "libclang_setup_py",
     srcs = ["libclang_setup.py"],
     visibility = ["//visibility:public"],
@@ -35,11 +39,9 @@ py_library(
     ],
 )
 
-py_binary(
+drake_py_binary(
     name = "mkdoc",
     srcs = ["mkdoc.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":libclang_setup_py",
@@ -48,7 +50,7 @@ py_binary(
     ],
 )
 
-py_library(
+drake_py_library(
     name = "mkdoc_comment_py",
     srcs = ["mkdoc_comment.py"],
     visibility = ["//visibility:public"],

--- a/tools/workspace/pybind11/mkdoc.py
+++ b/tools/workspace/pybind11/mkdoc.py
@@ -49,9 +49,8 @@ import sys
 from clang import cindex
 from clang.cindex import AccessSpecifier, CursorKind, TypeKind
 
-from drake.tools.workspace.pybind11.mkdoc_comment import process_comment
-
-from drake.tools.workspace.pybind11.libclang_setup import add_library_paths
+from tools.workspace.pybind11.libclang_setup import add_library_paths
+from tools.workspace.pybind11.mkdoc_comment import process_comment
 
 
 CLASS_KINDS = [

--- a/tools/workspace/pybind11/mkdoc_comment.py
+++ b/tools/workspace/pybind11/mkdoc_comment.py
@@ -38,7 +38,7 @@
 import re
 import textwrap
 
-from drake.doc.doxygen_cxx.system_doxygen import process_doxygen_to_sphinx
+from doc.doxygen_cxx.system_doxygen import process_doxygen_to_sphinx
 
 
 def process_comment(comment):

--- a/tools/workspace/pybind11/test/mkdoc_comment_test.py
+++ b/tools/workspace/pybind11/test/mkdoc_comment_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from drake.tools.workspace.pybind11.mkdoc_comment import process_comment
+from tools.workspace.pybind11.mkdoc_comment import process_comment
 
 
 class TestDocstring(unittest.TestCase):

--- a/tools/workspace/vendor_cxx_test.py
+++ b/tools/workspace/vendor_cxx_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from drake.tools.workspace.vendor_cxx import _rewrite_one_text
+from tools.workspace.vendor_cxx import _rewrite_one_text
 
 
 class TestVendorCxx(unittest.TestCase):


### PR DESCRIPTION
Re-spell imports to lose the "drake" part of the module namespace. The old spelling of imports is dispreferred and will not work with upcoming bzlmod.

For all Drake Python code, we should be using drake_py_library so that all Drake-specific settings are always in effect. (Earlier in bzlmod porting this was critically important; since then, I've changed some options so that it's less critical but we should anyway follow this hygiene so that we always have a single point of control for our build rules.)

Towards #20731.  See #21401 for prior art.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21453)
<!-- Reviewable:end -->
