### PR TITLE
[setup] Prune some unused macOS dependencies

### DIFF
--- a/setup/mac/binary_distribution/Brewfile
+++ b/setup/mac/binary_distribution/Brewfile
@@ -1,11 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-tap 'robotlocomotion/director'
-
 cask 'adoptopenjdk' unless system '/usr/libexec/java_home --version 1.8+ --failfast &> /dev/null'
 
-brew 'cmake'
 brew 'eigen'
 brew 'gcc'
 brew 'fmt'
@@ -17,8 +14,5 @@ brew 'openblas'
 brew 'pkg-config'
 brew 'python@3.12'
 brew 'spdlog'
-brew 'xz'
-brew 'yaml-cpp'
-brew 'zeromq'
 
 mas 'Xcode', id: 497799835 unless File.exist? '/Applications/Xcode.app'

--- a/setup/mac/source_distribution/Brewfile
+++ b/setup/mac/source_distribution/Brewfile
@@ -2,4 +2,5 @@
 # vi: set ft=ruby :
 
 brew 'bazelisk'
+brew 'cmake'
 brew 'nasm'


### PR DESCRIPTION
No need to tap 'robotlocomotion' anymore.
Switch 'cmake' to a source prereq.
Drop unused 'xz' (vestigial from VTK).
Drop unused 'yaml-cpp' (now built from source).
Drop unused 'zeromq' (vestigial from meshcat).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21454)
<!-- Reviewable:end -->
