### PR TITLE
[render_gl] Disable multithreaded tests on Ubuntu 24.04

### DIFF
--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -310,6 +310,8 @@ drake_cc_googletest_linux_only(
     data = [
         "//geometry/render:test_models",
     ],
+    # TODO(#21420) This test is currently broken on Ubuntu 24.04 ("Noble").
+    enable_condition = "//tools:ubuntu_jammy",
     tags = vtk_test_tags() + [
         # We launch up to 3 child tasks.
         "cpu:4",

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "//tools/skylark:drake_cc.bzl",
     "drake_cc_binary",
     "drake_cc_googletest",
+    "drake_cc_googletest_linux_only",
     "drake_cc_library",
     "drake_cc_package_library",
 )
@@ -575,20 +576,15 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_googletest(
+drake_cc_googletest_linux_only(
     name = "rgbd_sensor_async_gl_test",
     timeout = "moderate",
-    args = select({
-        "//tools/cc_toolchain:apple": [
-            # The GL render engine is not available on macOS.
-            "--gtest_filter=-*",
-        ],
-        "//conditions:default": [],
-    }),
     data = [
         ":test/rgbd_sensor_async_gl_test.dmd.yaml",
         "@drake_models//:manipulation_station",
     ],
+    # TODO(#21420) This test is currently broken on Ubuntu 24.04 ("Noble").
+    enable_condition = "//tools:ubuntu_jammy",
     tags = vtk_test_tags() + [
         # Similar to #7520, the GL vendor's libraries are not sufficiently
         # instrumented for compatibility with TSan.

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -157,4 +157,14 @@ config_setting(
     values = {"define": "WITH_USD=ON"},
 )
 
+config_setting(
+    name = "ubuntu_jammy",
+    values = {"define": "UBUNTU_VERSION=22.04"},
+)
+
+config_setting(
+    name = "ubuntu_noble",
+    values = {"define": "UBUNTU_VERSION=24.04"},
+)
+
 add_lint_tests()

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -954,9 +954,12 @@ def drake_cc_googletest_linux_only(
         deps = [],
         linkopts = [],
         tags = [],
-        visibility = ["//visibility:private"]):
+        timeout = None,
+        visibility = ["//visibility:private"],
+        enable_condition = "@drake//tools/skylark:linux"):
     """Declares a platform-specific drake_cc_googletest. When not building on
-    Linux, the deps and linkopts are nulled out.
+    Linux, the deps and linkopts are nulled out. When only a subset of linuxen
+    are supported, the enable_condition can be used to narrow even further.
 
     Because this test is not cross-platform, the visibility defaults to
     private.
@@ -971,13 +974,13 @@ def drake_cc_googletest_linux_only(
         testonly = True,
         tags = ["manual"],
         deps = select({
-            "@drake//tools/skylark:linux": deps + [
+            enable_condition: deps + [
                 "@gtest//:without_main",
             ],
             "//conditions:default": [],
         }),
         linkopts = select({
-            "@drake//tools/skylark:linux": linkopts,
+            enable_condition: linkopts,
             "//conditions:default": [],
         }),
         alwayslink = True,
@@ -988,17 +991,18 @@ def drake_cc_googletest_linux_only(
     # We need to use a dummy header file to disable the default 'srcs = ...'
     # inference from drake_cc_googletest.
     generate_file(
-        name = "_{}_empty.h".format(name),
+        name = "_{}_empty.cc".format(name),
         content = "",
         visibility = ["//visibility:private"],
     )
     drake_cc_googletest(
         name = name,
-        srcs = ["_{}_empty.h".format(name)],
+        srcs = ["_{}_empty.cc".format(name)],
         tags = tags + ["nolint"],
+        timeout = timeout,
         data = data,
         deps = select({
-            "@drake//tools/skylark:linux": [":_{}_compile".format(name)],
+            enable_condition: [":_{}_compile".format(name)],
             "//conditions:default": [],
         }),
         visibility = visibility,

--- a/tools/ubuntu-jammy.bazelrc
+++ b/tools/ubuntu-jammy.bazelrc
@@ -10,3 +10,5 @@ build:clang --host_action_env=CXX=clang++-15
 # In CI (but only in CI), we want to test the opt-in USD build support.
 # TODO(jwnimmer-tri) We should try to enable USD by default on all platforms.
 build:everything --define=WITH_USD=ON
+
+build --define=UBUNTU_VERSION=22.04

--- a/tools/ubuntu-noble.bazelrc
+++ b/tools/ubuntu-noble.bazelrc
@@ -10,3 +10,5 @@ build:clang --host_action_env=CXX=clang++-15
 # In CI (but only in CI), we want to test the opt-in USD build support.
 # TODO(jwnimmer-tri) We should try to enable USD by default on all platforms.
 build:everything --define=WITH_USD=ON
+
+build --define=UBUNTU_VERSION=24.04


### PR DESCRIPTION
Towards #21335.

See #21420 for a description of the problem. We're temporarily disabling the tests in order to spin up CI, and will circle back later with changes to re-enable.

Making tests conditional on the platform requires some new skylark:
- The "linux only" gains an "enable condition" which can narrow further.
- Add rcfile definitions for our two linux platforms to opt-in.
- Allow setting a test timeout on a linux-only test, which requires switching our stub file from h to cc to avoid confusing the private headers helper macro with an unknown kwarg.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21455)
<!-- Reviewable:end -->
