### PR TITLE
[GcsTrajOpt] Add nonlinear derivative bounds

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -380,6 +380,10 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             subgraph_doc.AddPathLengthCost.doc_1args_weight)
         .def("AddVelocityBounds", &Class::Subgraph::AddVelocityBounds,
             py::arg("lb"), py::arg("ub"), subgraph_doc.AddVelocityBounds.doc)
+        .def("AddNonlinearDerivativeBounds",
+            &Class::Subgraph::AddNonlinearDerivativeBounds, py::arg("lb"),
+            py::arg("ub"), py::arg("derivative_order"),
+            subgraph_doc.AddNonlinearDerivativeBounds.doc)
         .def("AddPathContinuityConstraints",
             &Class::Subgraph::AddPathContinuityConstraints,
             py::arg("continuity_order"),
@@ -393,6 +397,10 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("AddVelocityBounds",
             &Class::EdgesBetweenSubgraphs::AddVelocityBounds, py::arg("lb"),
             py::arg("ub"), subgraph_edges_doc.AddVelocityBounds.doc)
+        .def("AddNonlinearDerivativeBounds",
+            &Class::EdgesBetweenSubgraphs::AddNonlinearDerivativeBounds,
+            py::arg("lb"), py::arg("ub"), py::arg("derivative_order"),
+            subgraph_edges_doc.AddNonlinearDerivativeBounds.doc)
         .def("AddZeroDerivativeConstraints",
             &Class::EdgesBetweenSubgraphs::AddZeroDerivativeConstraints,
             py::arg("derivative_order"),
@@ -459,6 +467,10 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py::arg("weight") = 1.0, cls_doc.AddPathLengthCost.doc_1args_weight)
         .def("AddVelocityBounds", &Class::AddVelocityBounds, py::arg("lb"),
             py::arg("ub"), cls_doc.AddVelocityBounds.doc)
+        .def("AddNonlinearDerivativeBounds",
+            &Class::AddNonlinearDerivativeBounds, py::arg("lb"), py::arg("ub"),
+            py::arg("derivative_order"),
+            cls_doc.AddNonlinearDerivativeBounds.doc)
         .def("AddPathContinuityConstraints",
             &Class::AddPathContinuityConstraints, py::arg("continuity_order"),
             cls_doc.AddPathContinuityConstraints.doc)

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -585,6 +585,32 @@ class TestTrajectoryOptimization(unittest.TestCase):
                                   precision=3,
                                   scientific=False), str)
 
+        # In the follwoing, we test adding the bindings for nonlinear
+        # constraints.
+        max_acceleration = np.ones((2, 1))
+        max_jerk = 7.5 * np.ones((2, 1))
+
+        # Add global acceleration bounds.
+        gcs.AddNonlinearDerivativeBounds(
+            lb=-max_acceleration, ub=max_acceleration, derivative_order=2)
+
+        # Add the jerk bounds to each subgraph.
+        main1.AddNonlinearDerivativeBounds(
+            lb=-max_jerk, ub=max_jerk, derivative_order=3)
+        main2.AddNonlinearDerivativeBounds(
+            lb=-max_jerk, ub=max_jerk, derivative_order=3)
+
+        # Add half of the maximum acceleration and jerk bounds at the subspace
+        # point and region.
+        main1_to_main2_pt.AddVelocityBounds(
+            lb=-max_acceleration / 2, ub=max_acceleration / 2)
+        main1_to_main2_region.AddVelocityBounds(
+            lb=-max_acceleration / 2, ub=max_acceleration / 2)
+
+        main1_to_main2_pt.AddVelocityBounds(lb=-max_jerk / 2, ub=max_jerk / 2)
+        main1_to_main2_region.AddVelocityBounds(
+            lb=-max_jerk / 2, ub=max_jerk / 2)
+
     def test_gcs_trajectory_optimization_wraparound(self):
         gcs_wraparound = GcsTrajectoryOptimization(
             num_positions=1, continuous_revolute_joints=[0])

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -131,6 +131,7 @@ constraints.  The users should be able to write constraints against
 "placeholder" decision variables on the vertices and edges, but these get
 translated in non-trivial ways to the underlying program.
 
+@anchor nonconvex_graph_of_convex_sets
 <b>Advanced Usage: Guiding Non-convex Optimization with the
 %GraphOfConvexSets</b>
 

--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -180,6 +180,7 @@ drake_cc_googletest(
         "//common/trajectories:piecewise_polynomial",
         "//solvers:gurobi_solver",
         "//solvers:mosek_solver",
+        "//solvers:snopt_solver",
     ],
 )
 

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -13,6 +13,7 @@
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/intersection.h"
 #include "drake/geometry/optimization/point.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/matrix_util.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/planar_joint.h"
@@ -46,6 +47,8 @@ using geometry::optimization::Point;
 using geometry::optimization::internal::ComputeOffsetContinuousRevoluteJoints;
 using geometry::optimization::internal::GetMinimumAndMaximumValueAlongDimension;
 using geometry::optimization::internal::ThrowsForInvalidContinuousJointsList;
+using math::ExtractValue;
+using math::InitializeAutoDiff;
 using multibody::Joint;
 using multibody::JointIndex;
 using multibody::MultibodyPlant;
@@ -72,6 +75,67 @@ using VertexId = GraphOfConvexSets::VertexId;
 using EdgeId = GraphOfConvexSets::EdgeId;
 
 const double kInf = std::numeric_limits<double>::infinity();
+
+/* Implements a constraint of the form
+  0 <= - M * dᴺr(s) / dsᴺ - hᴺ * lb <= inf,
+  0 <= - M * dᴺr(s) / dsᴺ + hᴺ * ub <= inf,
+  where
+  N := derivative order,
+  h = x[num_control_points],
+  dᴺr(s) / dsᴺ = M * x[0:num_control_points-1].
+
+  This constraint is enforced along one dimension of the Bézier curve, hence
+  must be called for each dimension separately.
+*/
+class NonlinearDerivativeConstraint : public solvers::Constraint {
+ public:
+  NonlinearDerivativeConstraint(const Eigen::SparseMatrix<double>& M, double lb,
+                                double ub, int derivative_order)
+      : Constraint(2 * M.rows(), M.cols() + 1,
+                   Eigen::VectorXd::Zero(2 * M.rows()),
+                   Eigen::VectorXd::Constant(
+                       2 * M.rows(), std::numeric_limits<double>::infinity())),
+        M_(M),
+        lb_(Eigen::VectorXd::Constant(M.rows(), lb)),
+        ub_(Eigen::VectorXd::Constant(M.rows(), ub)),
+        derivative_order_(derivative_order),
+        num_control_points_(M.cols()) {
+    DRAKE_DEMAND(derivative_order > 1);
+  }
+
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              Eigen::VectorXd* y) const {
+    AutoDiffVecXd y_t;
+    Eval(InitializeAutoDiff(x), &y_t);
+    *y = ExtractValue(y_t);
+  }
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              AutoDiffVecXd* y) const {
+    // x is the stack [r_control.row(i); h].
+    AutoDiffXd pow_h = pow(x[num_control_points_], derivative_order_);
+
+    // Precompute Matrix Product.
+    AutoDiffVecXd Mx = M_ * x.head(num_control_points_);
+
+    y->head(M_.rows()) = Mx - pow_h * lb_;
+    y->tail(M_.rows()) = -Mx + pow_h * ub_;
+  }
+
+  void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
+              VectorX<symbolic::Expression>*) const {
+    throw std::runtime_error(
+        "NonlinearDerivativeConstraint does not support evaluation with "
+        "Expression.");
+  }
+
+ private:
+  const Eigen::SparseMatrix<double> M_;
+  const Eigen::VectorXd lb_;
+  const Eigen::VectorXd ub_;
+  const int derivative_order_;
+  const int num_control_points_;
+};
 
 Subgraph::Subgraph(
     const ConvexSets& regions,
@@ -272,6 +336,100 @@ void Subgraph::AddVelocityBounds(const Eigen::Ref<const VectorXd>& lb,
       vars << GetControlPoints(*v).row(i).transpose(), GetTimeScaling(*v);
       v->AddConstraint(Binding<LinearConstraint>(lb_constraint, vars));
       v->AddConstraint(Binding<LinearConstraint>(ub_constraint, vars));
+    }
+  }
+}
+
+void Subgraph::AddNonlinearDerivativeBounds(
+    const Eigen::Ref<const Eigen::VectorXd>& lb,
+    const Eigen::Ref<const Eigen::VectorXd>& ub, int derivative_order) {
+  DRAKE_THROW_UNLESS(lb.size() == num_positions());
+  DRAKE_THROW_UNLESS(ub.size() == num_positions());
+
+  if (derivative_order > order()) {
+    throw std::runtime_error(
+        "Derivative order must be less than or equal to the set order.");
+  }
+
+  if (derivative_order == 1) {
+    throw std::runtime_error(
+        "Use AddVelocityBounds instead of AddNonlinearDerivativeBounds with "
+        "derivative_order=1; velocity bounds are linear.");
+  }
+
+  if (derivative_order < 1) {
+    throw std::runtime_error("Derivative order must be greater than 1.");
+  }
+
+  // The nonlinear derivative dᴺq(t) / dtᴺ = dᴺr(s) / dsᴺ / hᴺ, with h >= 0,
+  // can be written as hᴺ * lb <= dᴺr(s) / dsᴺ <= hᴺ * ub, and constrained as:
+  // 0 <=   dᴺr(s) / dsᴺ - hᴺ * lb <= inf,
+  // 0 <= - dᴺr(s) / dsᴺ + hᴺ * ub <= inf.
+
+  // The nonlinear constraint will be enforced in the restriction and MIP
+  // of GCS, while a convex surrogate in the relaxation transcription will
+  // guide the rounding process.
+
+  // Since hᴺ is the source of nonlinearities, we will replace it with:
+  // h₀ᴺ⁻¹h
+  // Then we will get the following linear constraint:
+  // 0 <=   dᴺr(s) / dsᴺ - h₀ᴺ⁻¹h * lb <= inf
+  // 0 <= - dᴺr(s) / dsᴺ + h₀ᴺ⁻¹h * ub <= inf.
+
+  // For simplicity sake, we will set h₀ to zero until we come up with a
+  // reasonable heuristic, e.g. based on the maximum length of the convex set.
+  const double h0 = 1.0;
+
+  // This leverages the convex hull property of the B-splines: if all of the
+  // control points satisfy these convex constraints and the curve is inside
+  // the convex hull of these constraints, then the curve satisfies the
+  // constraints for all t.
+
+  // The relevant derivatives of the Bezier curve come in the form:
+  // rdot_control.row(i).T = M.T * r_control.row(i).T, so we loop over the
+  // positions, rather than over the control points.
+  solvers::VectorXDecisionVariable vars(order_ + 2);
+  SparseMatrix<double> M_transpose =
+      r_trajectory_.AsLinearInControlPoints(derivative_order).transpose();
+
+  // Lower bound: 0 <=   (dᴺr(s) / dsᴺ).row(i) - h₀ᴺ⁻¹h * lb[i] <= inf,
+  // Upper bound: 0 <= - (dᴺr(s) / dsᴺ).row(i) + h₀ᴺ⁻¹h * ub[i] <= inf.
+
+  int rdot_control_points = order_ + 1 - derivative_order;
+  const VectorXd kVecInf = VectorXd::Constant(2 * rdot_control_points, kInf);
+  const VectorXd kVecZero = VectorXd::Zero(2 * rdot_control_points);
+  Eigen::MatrixXd H(
+      2 * rdot_control_points,
+      order_ + 2);  // number of control points for one row of r(s) + 1
+  H.block(0, 0, M_transpose.rows(), M_transpose.cols()) = M_transpose;
+  H.block(M_transpose.rows(), 0, M_transpose.rows(), M_transpose.cols()) =
+      -M_transpose;
+
+  for (int i = 0; i < num_positions(); ++i) {
+    // Update the bounds for each position.
+    H.block(0, order_ + 1, rdot_control_points, 1) = VectorXd::Constant(
+        rdot_control_points, -std::pow(h0, derivative_order - 1) * lb[i]);
+    H.block(rdot_control_points, order_ + 1, rdot_control_points, 1) =
+        VectorXd::Constant(rdot_control_points,
+                           std::pow(h0, derivative_order - 1) * ub[i]);
+
+    const auto normalized_path_derivative_constraint =
+        std::make_shared<LinearConstraint>(H.sparseView(), kVecZero, kVecInf);
+
+    const auto nonlinear_derivative_constraint =
+        std::make_shared<NonlinearDerivativeConstraint>(
+            M_transpose, lb[i], ub[i], derivative_order);
+    for (Vertex* v : vertices_) {
+      vars << GetControlPoints(*v).row(i).transpose(), GetTimeScaling(*v);
+      // Add convex surrogate.
+      v->AddConstraint(Binding<LinearConstraint>(
+                           normalized_path_derivative_constraint, vars),
+                       {GraphOfConvexSets::Transcription::kRelaxation});
+      // Add nonlinear constraint.
+      v->AddConstraint(Binding<NonlinearDerivativeConstraint>(
+                           nonlinear_derivative_constraint, vars),
+                       {GraphOfConvexSets::Transcription::kMIP,
+                        GraphOfConvexSets::Transcription::kRestriction});
     }
   }
 }
@@ -624,13 +782,24 @@ void EdgesBetweenSubgraphs::AddVelocityBounds(
   }
 }
 
-void EdgesBetweenSubgraphs::AddZeroDerivativeConstraints(int derivative_order) {
+void EdgesBetweenSubgraphs::AddNonlinearDerivativeBounds(
+    const Eigen::Ref<const Eigen::VectorXd>& lb,
+    const Eigen::Ref<const Eigen::VectorXd>& ub, int derivative_order) {
+  DRAKE_THROW_UNLESS(lb.size() == num_positions());
+  DRAKE_THROW_UNLESS(ub.size() == num_positions());
+
   if (derivative_order < 1) {
     throw std::runtime_error("Derivative order must be greater than 1.");
   }
 
-  if (from_subgraph_.order() < derivative_order &&
-      to_subgraph_.order() < derivative_order) {
+  if (derivative_order == 1) {
+    throw std::runtime_error(
+        "Use AddVelocityBounds instead of AddNonlinearDerivativeBounds with "
+        "derivative_order=1; velocity bounds are linear.");
+  }
+
+  if (derivative_order > from_subgraph_.order() &&
+      derivative_order > to_subgraph_.order()) {
     throw std::runtime_error(fmt::format(
         "Cannot add derivative bounds to subgraph edges where both subgraphs "
         "have less than derivative order.\n From subgraph order: {}\n To "
@@ -638,10 +807,127 @@ void EdgesBetweenSubgraphs::AddZeroDerivativeConstraints(int derivative_order) {
         from_subgraph_.order(), to_subgraph_.order(), derivative_order));
   }
 
-  // We have d^Nq(t)/dt^N = d^Nr(s)/(ds^N * h^N) and h >= 0, which is nonlinear.
+  // See see Subgraph::AddNonlinearDerivativeBounds for details on how the
+  // nonlinear derivative constraints are formulated.
+
+  // We will enforce the derivative bounds on the last control point of the u
+  // set and on the first control point of the v set unless one of the sets
+  // order is less than the derivative order.
+  const VectorXd kVecInf = VectorXd::Constant(2, kInf);
+  const VectorXd kVecZero = VectorXd::Zero(2);
+  const double h0 = 1.0;
+
+  if (from_subgraph_.order() >= derivative_order) {
+    // Add derivative bounds to the last control point of the u set.
+    // See BezierCurve::AsLinearInControlPoints().
+
+    solvers::VectorXDecisionVariable vars(from_subgraph_.order() + 2);
+    SparseMatrix<double> M_transpose =
+        ur_trajectory_.AsLinearInControlPoints(derivative_order)
+            .col(from_subgraph_.order() - derivative_order)
+            .transpose();
+
+    Eigen::MatrixXd H(
+        2 /* we are only constraining the last point in the u set */,
+        from_subgraph_.order() +
+            2 /* number of control points for one row of r(s) + 1*/);
+    H.block(0, 0, 1, from_subgraph_.order() + 1) = M_transpose;
+    H.block(1, 0, 1, from_subgraph_.order() + 1) = -M_transpose;
+
+    for (int i = 0; i < num_positions(); ++i) {
+      // Lower bound: 0 <=   (dᴺr(s=1.0) / dsᴺ).row(i) - h₀ᴺ⁻¹ h * lb[i] <= inf,
+      // Upper bound: 0 <= - (dᴺr(s=1.0) / dsᴺ).row(i) + h₀ᴺ⁻¹ h * ub[i] <= inf.
+      H(0, from_subgraph_.order() + 1) =
+          -std::pow(h0, derivative_order - 1) * lb[i];
+      H(1, from_subgraph_.order() + 1) =
+          std::pow(h0, derivative_order - 1) * ub[i];
+      const auto convex_derivative_constraint =
+          std::make_shared<LinearConstraint>(H.sparseView(), kVecZero, kVecInf);
+
+      const auto nonlinear_derivative_constraint =
+          std::make_shared<NonlinearDerivativeConstraint>(
+              M_transpose, lb[i], ub[i], derivative_order);
+      for (Edge* edge : edges_) {
+        vars << GetControlPointsU(*edge).row(i).transpose(),
+            GetTimeScalingU(*edge);
+        // Add convex surrogate.
+        edge->AddConstraint(
+            Binding<LinearConstraint>(convex_derivative_constraint, vars),
+            {GraphOfConvexSets::Transcription::kRelaxation});
+        // Add nonlinear constraint.
+        edge->AddConstraint(Binding<NonlinearDerivativeConstraint>(
+                                nonlinear_derivative_constraint, vars),
+                            {GraphOfConvexSets::Transcription::kMIP,
+                             GraphOfConvexSets::Transcription::kRestriction});
+      }
+    }
+  }
+
+  if (to_subgraph_.order() >= derivative_order) {
+    // Add velocity bounds to the first control point of the v set.
+    // See BezierCurve::AsLinearInControlPoints().
+
+    solvers::VectorXDecisionVariable vars(to_subgraph_.order() + 2);
+    SparseMatrix<double> M_transpose =
+        vr_trajectory_.AsLinearInControlPoints(derivative_order)
+            .col(0)
+            .transpose();
+
+    Eigen::MatrixXd H(
+        2 /* we are only constraining the last point in the v set */,
+        to_subgraph_.order() +
+            2 /* number of control points for one row of r(s) + 1*/);
+    H.block(0, 0, 1, to_subgraph_.order() + 1) = M_transpose;
+    H.block(1, 0, 1, to_subgraph_.order() + 1) = -M_transpose;
+
+    for (int i = 0; i < num_positions(); ++i) {
+      // Lower bound: 0 <=   (dᴺr(s=0.0) / dsᴺ).row(i) - h₀ᴺ⁻¹h * lb[i] <= inf,
+      // Upper bound: 0 <= - (dᴺr(s=0.0) / dsᴺ).row(i) + h₀ᴺ⁻¹h * ub[i] <= inf.
+      H(0, to_subgraph_.order() + 1) =
+          -std::pow(h0, derivative_order - 1) * lb[i];
+      H(1, to_subgraph_.order() + 1) =
+          std::pow(h0, derivative_order - 1) * ub[i];
+      const auto convex_derivative_constraint =
+          std::make_shared<LinearConstraint>(H.sparseView(), kVecZero, kVecInf);
+
+      const auto nonlinear_derivative_constraint =
+          std::make_shared<NonlinearDerivativeConstraint>(
+              M_transpose, lb[i], ub[i], derivative_order);
+      for (Edge* edge : edges_) {
+        vars << GetControlPointsV(*edge).row(i).transpose(),
+            GetTimeScalingU(*edge);
+        // Add convex surrogate.
+        edge->AddConstraint(
+            Binding<LinearConstraint>(convex_derivative_constraint, vars),
+            {GraphOfConvexSets::Transcription::kRelaxation});
+        // Add nonlinear constraint.
+        edge->AddConstraint(Binding<NonlinearDerivativeConstraint>(
+                                nonlinear_derivative_constraint, vars),
+                            {GraphOfConvexSets::Transcription::kMIP,
+                             GraphOfConvexSets::Transcription::kRestriction});
+      }
+    }
+  }
+}
+
+void EdgesBetweenSubgraphs::AddZeroDerivativeConstraints(int derivative_order) {
+  if (derivative_order < 1) {
+    throw std::runtime_error("Derivative order must be greater than 1.");
+  }
+
+  if (derivative_order > from_subgraph_.order() &&
+      derivative_order > to_subgraph_.order()) {
+    throw std::runtime_error(fmt::format(
+        "Cannot add derivative bounds to subgraph edges where both subgraphs "
+        "have less than derivative order.\n From subgraph order: {}\n To "
+        "subgraph order: {}\n Derivative order: {}",
+        from_subgraph_.order(), to_subgraph_.order(), derivative_order));
+  }
+
+  // We have dᴺq(t) / dtᴺ = dᴺr(s)/(dsᴺ * hᴺ) and h >= 0, which is nonlinear.
   // To constraint zero velocity we can set the numerator to zero, which is
   // convex:
-  // d^Nr(s)/ds^N = 0.
+  // dᴺr(s) / dsᴺ = 0.
 
   const Vector1d kVecZero = Vector1d::Zero();
 
@@ -654,7 +940,7 @@ void EdgesBetweenSubgraphs::AddZeroDerivativeConstraints(int derivative_order) {
             .transpose();
 
     // Equality constraint.
-    // (d^Nr(s)/ds^N).row(i) = 0.
+    // (dᴺr(s) / dsᴺ).row(i) = 0.
     const auto zero_derivative_constraint =
         std::make_shared<LinearEqualityConstraint>(M_transpose, kVecZero);
     for (int i = 0; i < num_positions(); ++i) {
@@ -674,7 +960,7 @@ void EdgesBetweenSubgraphs::AddZeroDerivativeConstraints(int derivative_order) {
             .col(0)
             .transpose();
     // Equality constraint:
-    // (d^Nr(s)/ds^N).row(i) = 0.
+    // (dᴺr(s) / dsᴺ).row(i) = 0.
     const auto zero_derivative_constraint =
         std::make_shared<LinearEqualityConstraint>(M_transpose, kVecZero);
 
@@ -820,6 +1106,12 @@ Subgraph& GcsTrajectoryOptimization::AddRegions(
     }
   }
 
+  for (auto& [lb, ub, derivative_order] : global_nonlinear_derivative_bounds_) {
+    if (order >= derivative_order) {
+      subgraph->AddNonlinearDerivativeBounds(lb, ub, derivative_order);
+    }
+  }
+
   // Add global continuity constraints to the subgraph.
   for (int continuity_order : global_continuity_constraints_) {
     if (order >= continuity_order) {
@@ -953,6 +1245,20 @@ void GcsTrajectoryOptimization::AddVelocityBounds(
     }
   }
   global_velocity_bounds_.push_back({lb, ub});
+}
+
+void GcsTrajectoryOptimization::AddNonlinearDerivativeBounds(
+    const Eigen::Ref<const Eigen::VectorXd>& lb,
+    const Eigen::Ref<const Eigen::VectorXd>& ub, int derivative_order) {
+  DRAKE_THROW_UNLESS(lb.size() == num_positions());
+  DRAKE_THROW_UNLESS(ub.size() == num_positions());
+  // Add nonlinear derivative bounds to each subgraph.
+  for (std::unique_ptr<Subgraph>& subgraph : subgraphs_) {
+    if (subgraph->order() >= derivative_order) {
+      subgraph->AddNonlinearDerivativeBounds(lb, ub, derivative_order);
+    }
+  }
+  global_nonlinear_derivative_bounds_.push_back({lb, ub, derivative_order});
 }
 
 void GcsTrajectoryOptimization::AddPathContinuityConstraints(

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -171,6 +172,32 @@ class GcsTrajectoryOptimization final {
     void AddVelocityBounds(const Eigen::Ref<const Eigen::VectorXd>& lb,
                            const Eigen::Ref<const Eigen::VectorXd>& ub);
 
+    /** Adds a nonlinear derivative constraints to the subgraph `lb` ≤
+    dᴺq(t) / dtᴺ ≤ `ub`.
+
+    This adds a nonlinear constraint to the restriction and MIP
+    GraphOfConvexSets::Transcription, while adding a convex surrogate to the
+    relaxation. For more details, see @ref nonconvex_graph_of_convex_sets
+    "Guiding Non-convex Optimization with the GraphOfConvexSets".
+
+    The nonlinear constraint involves the derivative dᴺq(t) / dtᴺ
+    which is decomposed as dᴺr(s) / dsᴺ / hᴺ. The convex surrogate replaces the
+    nonlinear component hᴺ with h₀ᴺ⁻¹h, where h₀ is the characteristic time of
+    the set. For now, h₀ is set to 1.0 for all sets.
+
+    @param lb is the lower bound of the derivative.
+    @param ub is the upper bound of the derivative.
+    @param derivative_order is the order of the derivative to be constrained.
+
+    @throws std::exception if subgraph order is less than the derivative order.
+    @throws std::exception if the derivative order <= 1, since the linear
+      velocity bounds are preferred.
+    @throws std::exception if lb or ub are not of size num_positions().
+    */
+    void AddNonlinearDerivativeBounds(
+        const Eigen::Ref<const Eigen::VectorXd>& lb,
+        const Eigen::Ref<const Eigen::VectorXd>& ub, int derivative_order);
+
     /** Enforces derivative continuity constraints on the subgraph.
      @param continuity_order is the order of the continuity constraint.
 
@@ -258,6 +285,33 @@ class GcsTrajectoryOptimization final {
     */
     void AddVelocityBounds(const Eigen::Ref<const Eigen::VectorXd>& lb,
                            const Eigen::Ref<const Eigen::VectorXd>& ub);
+
+    /** Adds a nonlinear derivative constraints to the control point connecting
+    the subgraphs `lb` ≤ dᴺq(t) / dtᴺ ≤ `ub`.
+
+    This adds a nonlinear constraint to the restriction and MIP
+    GraphOfConvexSets::Transcription, while adding a convex surrogate to the
+    relaxation. For more details, see @ref nonconvex_graph_of_convex_sets
+    "Guiding Non-convex Optimization with the GraphOfConvexSets".
+
+    The nonlinear constraint involves the derivative dᴺq(t) / dtᴺ
+    which is decomposed as dᴺr(s) / dsᴺ / hᴺ. The convex surrogate replaces the
+    nonlinear component hᴺ with h₀ᴺ⁻¹h, where h₀ is the characteristic time of
+    the set. For now, h₀ is set to 1.0 for all sets.
+
+    @param lb is the lower bound of the derivative.
+    @param ub is the upper bound of the derivative.
+    @param derivative_order is the order of the derivative to be constrained.
+
+    @throws std::exception if both subgraphs order is less than the desired
+    derivative order.
+    @throws std::exception if the derivative order <= 1, since the linear
+      velocity bounds are preferred.
+    @throws std::exception if lb or ub are not of size num_positions().
+    */
+    void AddNonlinearDerivativeBounds(
+        const Eigen::Ref<const Eigen::VectorXd>& lb,
+        const Eigen::Ref<const Eigen::VectorXd>& ub, int derivative_order);
 
     /** Enforces zero derivatives on the control point connecting the subgraphs.
 
@@ -513,6 +567,30 @@ class GcsTrajectoryOptimization final {
   void AddVelocityBounds(const Eigen::Ref<const Eigen::VectorXd>& lb,
                          const Eigen::Ref<const Eigen::VectorXd>& ub);
 
+  /** Adds a nonlinear derivative constraints to the entire graph `lb` ≤
+  dᴺq(t) / dtᴺ ≤ `ub`.
+
+  This adds a nonlinear constraint to the restriction and MIP
+  GraphOfConvexSets::Transcription, while adding a convex surrogate to the
+  relaxation. For more details, see @ref nonconvex_graph_of_convex_sets
+  "Guiding Non-convex Optimization with the GraphOfConvexSets".
+
+  The nonlinear constraint involves the derivative dᴺq(t) / dtᴺ
+  which is decomposed as dᴺr(s) / dsᴺ / hᴺ. The convex surrogate replaces the
+  nonlinear component hᴺ with h₀ᴺ⁻¹h, where h₀ is the characteristic time of
+  the set. For now, h₀ is set to 1.0 for all sets.
+
+
+  @param lb is the lower bound of the derivative.
+  @param ub is the upper bound of the derivative.
+  @param derivative_order is the order of the derivative to be constrained.
+
+  @throws std::exception if lb or ub are not of size num_positions().
+  */
+  void AddNonlinearDerivativeBounds(const Eigen::Ref<const Eigen::VectorXd>& lb,
+                                    const Eigen::Ref<const Eigen::VectorXd>& ub,
+                                    int derivative_order);
+
   /** Enforces derivative continuity constraints on the entire graph.
   @param continuity_order is the order of the continuity constraint.
 
@@ -683,6 +761,8 @@ class GcsTrajectoryOptimization final {
   std::vector<Eigen::MatrixXd> global_path_length_costs_;
   std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>
       global_velocity_bounds_{};
+  std::vector<std::tuple<Eigen::VectorXd, Eigen::VectorXd, int>>
+      global_nonlinear_derivative_bounds_{};
   std::vector<int> global_continuity_constraints_{};
 };
 

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -19,6 +19,7 @@
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/mosek_solver.h"
+#include "drake/solvers/snopt_solver.h"
 
 namespace drake {
 namespace planning {
@@ -54,6 +55,11 @@ bool GurobiOrMosekSolverUnavailableDuringMemoryCheck() {
            solvers::MosekSolver::is_enabled() &&
            solvers::GurobiSolver::is_available() &&
            solvers::GurobiSolver::is_enabled());
+}
+
+bool SnoptSolverUnavailable() {
+  return !(solvers::SnoptSolver::is_available() &&
+           solvers::SnoptSolver::is_enabled());
 }
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, Basic) {
@@ -431,10 +437,10 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, DerivativeBoundsOnEdges) {
   // We need to duplicate the race track regions to sandwich the duck regions.
   auto& race_track_1 = gcs.AddRegions(
       MakeConvexSets(HPolyhedron::MakeBox(Vector2d(0, -5), Vector2d(305, 5))),
-      5);
+      6, 0.0, 500.0);
   auto& race_track_2 = gcs.AddRegions(
       MakeConvexSets(HPolyhedron::MakeBox(Vector2d(0, -5), Vector2d(305, 5))),
-      5);
+      6, 0.0, 500.0);
   // Bob's car can only drive straight. So he can drive at 50 m/s forward in x,
   // but not in y.
   race_track_1.AddVelocityBounds(Vector2d(0, 0), Vector2d(kMaxSpeed, 0));
@@ -472,7 +478,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, DerivativeBoundsOnEdges) {
   gcs.AddTimeCost();
 
   // Nonregression bound on the complexity of the underlying GCS MICP.
-  EXPECT_LT(gcs.EstimateComplexity(), 185);
+  EXPECT_LT(gcs.EstimateComplexity(), 210);
 
   auto [traj, result] = gcs.SolvePath(source, target);
 
@@ -524,6 +530,52 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, DerivativeBoundsOnEdges) {
   EXPECT_TRUE(CompareMatrices(
       traj.EvalDerivative(stopped_at_ducks_time + kDuckDelay, 2),
       Vector2d(0, 0), 1e-6));
+
+  // Bob has been racing all day long, and his car ran out of battery. He still
+  // wants to race, but the only available car is a tow truck 🛻!
+  const double kMaxAcceleration = 3.0;  // m/s^2
+
+  // Bob's truck can only drive straight.
+  race_track_1.AddNonlinearDerivativeBounds(Vector2d(-kMaxAcceleration, 0),
+                                            Vector2d(kMaxAcceleration, 0), 2);
+  race_track_2.AddNonlinearDerivativeBounds(Vector2d(-kMaxAcceleration, 0),
+                                            Vector2d(kMaxAcceleration, 0), 2);
+
+  if (SnoptSolverUnavailable()) return;
+  GraphOfConvexSetsOptions options;
+  solvers::SnoptSolver snopt;
+  options.solver = &snopt;
+  options.max_rounded_paths = 3;
+  auto [traj_truck, result_truck] = gcs.SolvePath(source, target, options);
+
+  EXPECT_TRUE(result_truck.is_success());
+  EXPECT_EQ(traj_truck.rows(), 2);
+  EXPECT_EQ(traj_truck.cols(), 1);
+  EXPECT_TRUE(
+      CompareMatrices(traj_truck.value(traj_truck.start_time()), start, 1e-6));
+  EXPECT_TRUE(
+      CompareMatrices(traj_truck.value(traj_truck.end_time()), goal, 1e-6));
+
+  // Let's make sure the truck remained within the acceleration bounds.
+  for (double t = traj_truck.start_time(); t < traj_truck.end_time();
+       t += kTimeStep) {
+    EXPECT_TRUE(traj_truck.EvalDerivative(t, 2).cwiseAbs()(0) <=
+                kMaxAcceleration + 1e-6);
+  }
+
+  // The truck should have taken longer to reach the finish line.
+  EXPECT_GT(traj_truck.end_time() - traj_truck.start_time(),
+            traj.end_time() - traj.start_time());
+
+  // Ensure the race car was indeed accelerating faster than the truck.
+  bool racecar_accelerating_faster = false;
+  for (double t = traj.start_time(); t < traj.end_time(); t += kTimeStep) {
+    if (traj.EvalDerivative(t, 2).cwiseAbs()(0) > kMaxAcceleration + 1e-6) {
+      racecar_accelerating_faster = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(racecar_accelerating_faster);
 }
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, RemoveSubgraph) {
@@ -622,6 +674,9 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidDerivativeBounds) {
   auto& regions2 =
       gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension)), 0);
 
+  auto& regions3 =
+      gcs.AddRegions(MakeConvexSets(HPolyhedron::MakeUnitBox(kDimension)), 3);
+
   auto& regions1_to_regions2 = gcs.AddEdges(regions1, regions2);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -632,7 +687,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidDerivativeBounds) {
   DRAKE_EXPECT_NO_THROW(
       gcs.AddVelocityBounds(Vector2d::Zero(), Vector2d::Zero()));
 
-  // lower and upper bound must have the same dimension as the graph.
+  // Lower and upper bound must have the same dimension as the graph.
   DRAKE_EXPECT_THROWS_MESSAGE(
       regions1.AddVelocityBounds(Vector3d::Zero(), Vector2d::Zero()),
       ".*size.*.num_positions.*");
@@ -662,6 +717,49 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidDerivativeBounds) {
       "order: 0\n Derivative order: 1");
   DRAKE_EXPECT_THROWS_MESSAGE(
       regions1_to_regions2.AddZeroDerivativeConstraints(2),
+      "Cannot add derivative bounds to subgraph edges where both subgraphs "
+      "have less than derivative order.\n From subgraph order: 0\n To subgraph "
+      "order: 0\n Derivative order: 2");
+
+  // Test the nonlinear derivative bounds.
+  // Prefer velocity bounds since they are linear.
+  DRAKE_EXPECT_THROWS_MESSAGE(regions3.AddNonlinearDerivativeBounds(
+                                  Vector2d::Zero(), Vector2d::Zero(), 1),
+                              "Use AddVelocityBounds instead.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(regions1_to_regions2.AddNonlinearDerivativeBounds(
+                                  Vector2d::Zero(), Vector2d::Zero(), 1),
+                              "Use AddVelocityBounds instead.*");
+
+  // The zeroth order derivative is not a proper derivative.
+  DRAKE_EXPECT_THROWS_MESSAGE(regions3.AddNonlinearDerivativeBounds(
+                                  Vector2d::Zero(), Vector2d::Zero(), 0),
+                              "Derivative order must be greater than 1.");
+  DRAKE_EXPECT_THROWS_MESSAGE(regions1_to_regions2.AddNonlinearDerivativeBounds(
+                                  Vector2d::Zero(), Vector2d::Zero(), 0),
+                              "Derivative order must be greater than 1.");
+
+  // Lower and upper bound must have the same dimension as the graph.
+  DRAKE_EXPECT_THROWS_MESSAGE(regions3.AddNonlinearDerivativeBounds(
+                                  Vector3d::Zero(), Vector2d::Zero(), 2),
+                              ".*size.*.num_positions.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(regions1_to_regions2.AddNonlinearDerivativeBounds(
+                                  Vector3d::Zero(), Vector2d::Zero(), 2),
+                              ".*size.*.num_positions.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      gcs.AddNonlinearDerivativeBounds(Vector2d::Zero(), Vector3d::Zero(), 2),
+      ".*size.*.num_positions.*");
+
+  // Can't add derivative bounds to a subgraph with an order lower than the
+  // derivative order.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      regions3.AddNonlinearDerivativeBounds(Vector2d::Zero(), Vector2d::Zero(),
+                                            4),
+      "Derivative order must be less than or equal to the set order.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      regions1_to_regions2.AddNonlinearDerivativeBounds(Vector2d::Zero(),
+                                                        Vector2d::Zero(), 2),
       "Cannot add derivative bounds to subgraph edges where both subgraphs "
       "have less than derivative order.\n From subgraph order: 0\n To subgraph "
       "order: 0\n Derivative order: 2");
@@ -1208,6 +1306,99 @@ TEST_F(SimpleEnv2D, GlobalContinuityConstraints) {
   }
 }
 
+TEST_F(SimpleEnv2D, DerivativeConstraints) {
+  const int kDimension = 2;
+  const double kNumSamples = 1e3;
+  const double kMaxSpeed = 2.0;
+  const double kMaxAcceleration = 1.0;
+  const double kMaxJerk = 7.5;
+
+  GcsTrajectoryOptimization gcs(kDimension);
+  EXPECT_EQ(gcs.num_positions(), kDimension);
+
+  Vector2d start(0.2, 0.2), goal(4.8, 4.8);
+  auto& regions = gcs.AddRegions(regions_, 6, 1e-5);
+  auto& source = gcs.AddRegions(MakeConvexSets(Point(start)), 0, 0.0, 0.0);
+  auto& target = gcs.AddRegions(MakeConvexSets(Point(goal)), 0, 0.0, 0.0);
+
+  gcs.AddEdges(source, regions);
+  gcs.AddEdges(regions, target);
+
+  gcs.AddTimeCost();
+
+  // Add velocity bounds.
+  gcs.AddVelocityBounds(Vector2d(-kMaxSpeed, -kMaxSpeed),
+                        Vector2d(kMaxSpeed, kMaxSpeed));
+
+  // Solve the problem and check the derivative bounds.
+  // The velocities should be bounded, while the acceleration and jerk is
+  // expected to be violated.
+  GraphOfConvexSetsOptions options;
+  options.max_rounded_paths = 5;
+  if (GurobiOrMosekSolverUnavailableDuringMemoryCheck()) return;
+
+  auto [traj_velocity_bounded, result_velocity_bounded] =
+      gcs.SolvePath(source, target, options);
+
+  EXPECT_TRUE(result_velocity_bounded.is_success());
+  EXPECT_TRUE(CompareMatrices(
+      traj_velocity_bounded.value(traj_velocity_bounded.start_time()), start,
+      1e-6));
+  EXPECT_TRUE(CompareMatrices(
+      traj_velocity_bounded.value(traj_velocity_bounded.end_time()), goal,
+      1e-6));
+
+  bool exceeded_acceleration_bounds = false;
+  bool exceeded_jerk_bounds = false;
+  double dt =
+      (traj_velocity_bounded.end_time() - traj_velocity_bounded.start_time()) /
+      kNumSamples;
+  for (double t = traj_velocity_bounded.start_time();
+       t < traj_velocity_bounded.end_time(); t += dt) {
+    EXPECT_LT(traj_velocity_bounded.EvalDerivative(t, 1).cwiseAbs().maxCoeff(),
+              kMaxSpeed + 1e-6);
+    if (traj_velocity_bounded.EvalDerivative(t, 2).cwiseAbs().maxCoeff() >
+        kMaxAcceleration + 1e-6) {
+      exceeded_acceleration_bounds = true;
+    }
+    if (traj_velocity_bounded.EvalDerivative(t, 3).cwiseAbs().maxCoeff() >
+        kMaxJerk + 1e-6) {
+      exceeded_jerk_bounds = true;
+    }
+  }
+  EXPECT_TRUE(exceeded_acceleration_bounds);
+  EXPECT_TRUE(exceeded_jerk_bounds);
+
+  // Add nonlinear acceleration and jerk bounds.
+  gcs.AddNonlinearDerivativeBounds(
+      Vector2d(-kMaxAcceleration, -kMaxAcceleration),
+      Vector2d(kMaxAcceleration, kMaxAcceleration), 2);
+  gcs.AddNonlinearDerivativeBounds(Vector2d(-kMaxJerk, -kMaxJerk),
+                                   Vector2d(kMaxJerk, kMaxJerk), 3);
+
+  // Nonregression bound on the complexity of the underlying GCS MICP.
+  EXPECT_LT(gcs.EstimateComplexity(), 2.5e3);
+
+  if (SnoptSolverUnavailable()) return;
+  solvers::SnoptSolver snopt;
+  options.restriction_solver = &snopt;
+  auto [traj, result] = gcs.SolvePath(source, target, options);
+
+  EXPECT_TRUE(result.is_success());
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.start_time()), start, 1e-6));
+  EXPECT_TRUE(CompareMatrices(traj.value(traj.end_time()), goal, 1e-6));
+
+  // Check that the velocity, acceleration, and jerk are bounded.
+  dt = (traj.end_time() - traj.start_time()) / kNumSamples;
+  for (double t = traj.start_time(); t < traj.end_time(); t += dt) {
+    EXPECT_LT(traj.EvalDerivative(t, 1).cwiseAbs().maxCoeff(),
+              kMaxSpeed + 1e-6);
+    EXPECT_LT(traj.EvalDerivative(t, 2).cwiseAbs().maxCoeff(),
+              kMaxAcceleration + 1e-6);
+    EXPECT_LT(traj.EvalDerivative(t, 3).cwiseAbs().maxCoeff(), kMaxJerk + 1e-6);
+  }
+}
+
 TEST_F(SimpleEnv2D, DurationDelay) {
   /* The durations bounds in a subgraph can be used to enforce delays.*/
   const int kDimension = 2;
@@ -1375,7 +1566,7 @@ TEST_F(SimpleEnv2D, IntermediatePoint) {
   EXPECT_EQ(gcs.num_positions(), kDimension);
 
   Vector2d start(0.2, 0.2), goal(4.8, 4.8), intermediate(2.3, 3.5);
-  const double kSpeed = 1.0;
+  const double kSpeed = 2.0;
 
   // Both a Point and an HPolytope are valid subspaces.
   Point subspace_point(intermediate);
@@ -1405,12 +1596,15 @@ TEST_F(SimpleEnv2D, IntermediatePoint) {
   auto& main1_to_main2_region = gcs.AddEdges(main1, main2, &subspace_region);
   auto& main2_to_target = gcs.AddEdges(main2, target);
 
-  // Add zero velocity constraints to the source, target and the intermediate
-  // point and region.
+  // Add zero velocity constraints to the source, and target.
   source_to_main.AddVelocityBounds(Vector2d::Zero(), Vector2d::Zero());
-  main1_to_main2_pt.AddVelocityBounds(Vector2d::Zero(), Vector2d::Zero());
-  main1_to_main2_region.AddVelocityBounds(Vector2d::Zero(), Vector2d::Zero());
   main2_to_target.AddVelocityBounds(Vector2d::Zero(), Vector2d::Zero());
+
+  // Add half of the velocity limit to the intermediate point and region.
+  main1_to_main2_pt.AddVelocityBounds(Vector2d(-kSpeed / 2, -kSpeed / 2),
+                                      Vector2d(kSpeed / 2, kSpeed / 2));
+  main1_to_main2_region.AddVelocityBounds(Vector2d(-kSpeed / 2, -kSpeed / 2),
+                                          Vector2d(kSpeed / 2, kSpeed / 2));
 
   // We can add different costs and constraints to the individual subgraphs.
   main1.AddPathLengthCost(5);
@@ -1440,6 +1634,36 @@ TEST_F(SimpleEnv2D, IntermediatePoint) {
   EXPECT_TRUE(result.is_success());
   EXPECT_TRUE(CompareMatrices(traj.value(traj.start_time()), start, 1e-6));
   EXPECT_TRUE(CompareMatrices(traj.value(traj.end_time()), goal, 1e-6));
+
+  const double kMaxAcceleration = 1.0;
+  const double kMaxJerk = 7.5;
+
+  // Add accelertation and jerk bounds to the whole graph.
+  gcs.AddNonlinearDerivativeBounds(
+      Vector2d(-kMaxAcceleration, -kMaxAcceleration),
+      Vector2d(kMaxAcceleration, kMaxAcceleration), 2);
+  gcs.AddNonlinearDerivativeBounds(Vector2d(-kMaxJerk, -kMaxJerk),
+                                   Vector2d(kMaxJerk, kMaxJerk), 3);
+
+  // Add half of the acceleration and jerk bounds to the intermediate point and
+  // region.
+  main1_to_main2_pt.AddNonlinearDerivativeBounds(
+      Vector2d(-kMaxAcceleration / 2, -kMaxAcceleration / 2),
+      Vector2d(kMaxAcceleration / 2, kMaxAcceleration / 2), 2);
+  main1_to_main2_region.AddNonlinearDerivativeBounds(
+      Vector2d(-kMaxAcceleration / 2, -kMaxAcceleration / 2),
+      Vector2d(kMaxAcceleration / 2, kMaxAcceleration / 2), 2);
+
+  if (SnoptSolverUnavailable()) return;
+  solvers::SnoptSolver snopt;
+  options.restriction_solver = &snopt;
+  auto [traj_nonlinear, result_nonlinear] =
+      gcs.SolvePath(source, target, options);
+  EXPECT_TRUE(result_nonlinear.is_success());
+  EXPECT_TRUE(CompareMatrices(traj_nonlinear.value(traj_nonlinear.start_time()),
+                              start, 1e-6));
+  EXPECT_TRUE(CompareMatrices(traj_nonlinear.value(traj_nonlinear.end_time()),
+                              goal, 1e-6));
 }
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, EdgesFromWrappedJoints) {


### PR DESCRIPTION
This adds nonlinear derivative bounds to subgraphs and edges between subgraphs in GCS TrajOpt.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21459)
<!-- Reviewable:end -->
