### PR TITLE
Enforce uniqueness of render buffers between RenderEngineGl instances

### DIFF
--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -985,6 +985,15 @@ unique_ptr<RenderEngine> RenderEngineGl::DoClone() const {
   });
   clone->opengl_context_->MakeCurrent();
 
+  // Note: changes in graphics drivers have led to artifacts where frame buffers
+  // are not necessarily shared across contexts. So, to be safe, we'll clear
+  // the clone's frame buffers (it will recreate them as needed). This should
+  // also benefit parallel rendering as two clones will no longer attempt to
+  // render to the same render targets.
+  for (auto& buffer : clone->frame_buffers_) {
+    buffer.clear();
+  }
+
   clone->InitGlState();
 
   // Update the vertex array objects on the shared vertex buffers.

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -1141,6 +1141,11 @@ TEST_F(RenderEngineGlTest, MeshTest) {
 //
 // If all of that is processed correctly, we should get a cube with a different
 // color on each face. We'll test for those colors.
+//
+// This test renders against an original engine and its clone (to confirm that
+// the render artifacts survive cloning). This has a secondary benefit of
+// detecting if anything happens to corrupt the relationship between original
+// and cloned context (see, e.g., #21326).
 TEST_F(RenderEngineGlTest, MultiMaterialObj) {
   struct Face {
     // The expected *illuminated* material color. The simple illumination model


### PR DESCRIPTION
Multiple RenderEngineGl instances share OpenGl objects in their shared context. Historically, this has included render buffers. A recent upgrade to NVidia drivers exposed this as problematic. Now, each clone is responsible for creating its own render targets.

Resolves #21326

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21466)
<!-- Reviewable:end -->
