### PR TITLE
In internal code, change mobilizer set_angle() to SetAngle().

### DIFF
--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -135,7 +135,7 @@ class PlanarJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const PlanarJoint<T>& set_rotation(systems::Context<T>* context,
                                      const T& theta) const {
-    get_mobilizer()->set_angle(context, theta);
+    get_mobilizer()->SetAngle(context, theta);
     return *this;
   }
 
@@ -153,7 +153,7 @@ class PlanarJoint final : public Joint<T> {
                                  const Vector2<T>& p_FoMo_F,
                                  const T& theta) const {
     get_mobilizer()->set_translations(context, p_FoMo_F);
-    get_mobilizer()->set_angle(context, theta);
+    get_mobilizer()->SetAngle(context, theta);
     return *this;
   }
 

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -66,7 +66,7 @@ const T& PlanarMobilizer<T>::get_angle(
 }
 
 template <typename T>
-const PlanarMobilizer<T>& PlanarMobilizer<T>::set_angle(
+const PlanarMobilizer<T>& PlanarMobilizer<T>::SetAngle(
     systems::Context<T>* context, const T& angle) const {
   auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -88,8 +88,8 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
    @param[in] context The context of the model this mobilizer belongs to.
    @param[in] angle The desired angle in radians.
    @returns a constant reference to `this` mobilizer. */
-  const PlanarMobilizer<T>& set_angle(systems::Context<T>* context,
-                                      const T& angle) const;
+  const PlanarMobilizer<T>& SetAngle(systems::Context<T>* context,
+                                     const T& angle) const;
 
   /* Retrieves from `context` the rate of change, in meters per second, of
    `this` mobilizer's translations (see get_translations()).

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -180,7 +180,7 @@ class RevoluteJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const RevoluteJoint<T>& set_angle(
       Context<T>* context, const T& angle) const {
-    get_mobilizer()->set_angle(context, angle);
+    get_mobilizer()->SetAngle(context, angle);
     return *this;
   }
 

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -36,7 +36,7 @@ const T& RevoluteMobilizer<T>::get_angle(
 }
 
 template <typename T>
-const RevoluteMobilizer<T>& RevoluteMobilizer<T>::set_angle(
+const RevoluteMobilizer<T>& RevoluteMobilizer<T>::SetAngle(
     systems::Context<T>* context, const T& angle) const {
   auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -79,7 +79,7 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   //                    belongs to.
   // @param[in] angle The desired angle in radians.
   // @returns a constant reference to `this` mobilizer.
-  const RevoluteMobilizer<T>& set_angle(
+  const RevoluteMobilizer<T>& SetAngle(
       systems::Context<T>* context, const T& angle) const;
 
   // Gets the rate of change, in radians per second, of `this` mobilizer's

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -172,7 +172,7 @@ class ScrewJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const ScrewJoint<T>& set_rotation(systems::Context<T>* context,
                                      const T& theta) const {
-    get_mobilizer()->set_angle(context, theta);
+    get_mobilizer()->SetAngle(context, theta);
     return *this;
   }
 

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -60,7 +60,7 @@ const T& ScrewMobilizer<T>::get_angle(
 }
 
 template <typename T>
-const ScrewMobilizer<T>& ScrewMobilizer<T>::set_angle(
+const ScrewMobilizer<T>& ScrewMobilizer<T>::SetAngle(
     systems::Context<T>* context, const T& angle) const {
   auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -119,8 +119,8 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
    @param[in] context The context of the model this mobilizer belongs to.
    @param[in] angle The desired angle in radians.
    @returns a constant reference to `this` mobilizer. */
-  const ScrewMobilizer<T>& set_angle(systems::Context<T>* context,
-                                     const T& angle) const;
+  const ScrewMobilizer<T>& SetAngle(systems::Context<T>* context,
+                                    const T& angle) const;
 
   /* Retrieves from `context` the rate of change, in meters per second, of
    `this` mobilizer's translation (see get_translation()).

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -58,9 +58,9 @@ TEST_F(PlanarMobilizerTest, StateAccess) {
   EXPECT_EQ(mobilizer_->get_translations(*context_), some_values1);
   mobilizer_->set_translations(context_.get(), some_values2);
   EXPECT_EQ(mobilizer_->get_translations(*context_), some_values2);
-  mobilizer_->set_angle(context_.get(), some_values3);
+  mobilizer_->SetAngle(context_.get(), some_values3);
   EXPECT_EQ(mobilizer_->get_angle(*context_), some_values3);
-  mobilizer_->set_angle(context_.get(), some_values4);
+  mobilizer_->SetAngle(context_.get(), some_values4);
   EXPECT_EQ(mobilizer_->get_angle(*context_), some_values4);
 
   // Verify we can set a planar mobilizer velocities given the model's context.
@@ -82,7 +82,7 @@ TEST_F(PlanarMobilizerTest, ZeroState) {
   // Set the state to some arbitrary non-zero value.
   mobilizer_->set_translations(context_.get(), some_values1);
   mobilizer_->SetTranslationRates(context_.get(), some_values2);
-  mobilizer_->set_angle(context_.get(), some_values3);
+  mobilizer_->SetAngle(context_.get(), some_values3);
   mobilizer_->SetAngularRate(context_.get(), some_values4);
   EXPECT_EQ(mobilizer_->get_translations(*context_), some_values1);
   EXPECT_EQ(mobilizer_->get_translation_rates(*context_), some_values2);
@@ -183,7 +183,7 @@ TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerTransform) {
   const Vector2d translations(1, 0.5);
   const double angle = 1.5;
   mobilizer_->set_translations(context_.get(), translations);
-  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->SetAngle(context_.get(), angle);
   const RigidTransformd X_FM(
       mobilizer_->CalcAcrossMobilizerTransform(*context_));
 
@@ -202,7 +202,7 @@ TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
   const double angle = 1.6;
   const Vector3d velocity(2.5, 2.1, 3.1);
   mobilizer_->set_translations(context_.get(), translations);
-  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->SetAngle(context_.get(), angle);
   const SpatialVelocity<double> V_FM =
       mobilizer_->CalcAcrossMobilizerSpatialVelocity(*context_, velocity);
 
@@ -220,7 +220,7 @@ TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerSpatialAcceleration) {
   const double angle_rate = 3;
   const Vector3d acceleration(3.5, 4, 4.5);
   mobilizer_->set_translations(context_.get(), translations);
-  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->SetAngle(context_.get(), angle);
   mobilizer_->SetTranslationRates(context_.get(), translation_rates);
   mobilizer_->SetAngularRate(context_.get(), angle_rate);
 
@@ -240,7 +240,7 @@ TEST_F(PlanarMobilizerTest, ProjectSpatialForce) {
   const Vector2d translations(1, 0.5);
   const double angle = 1.5;
   mobilizer_->set_translations(context_.get(), translations);
-  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->SetAngle(context_.get(), angle);
 
   const Vector3d torque_Mo_F(1.0, 2.0, 3.0);
   const Vector3d force_Mo_F(1.0, 2.0, 3.0);
@@ -289,7 +289,7 @@ TEST_F(PlanarMobilizerTest, KinematicMapping) {
 TEST_F(PlanarMobilizerTest, MapUsesN) {
   // Set an arbitrary "non-zero" state.
   const Vector2d some_values(1.5, 2.5);
-  mobilizer_->set_angle(context_.get(), 3.5);
+  mobilizer_->SetAngle(context_.get(), 3.5);
   mobilizer_->set_translations(context_.get(), some_values);
 
   // Set arbitrary v and MapVelocityToQDot.
@@ -308,7 +308,7 @@ TEST_F(PlanarMobilizerTest, MapUsesN) {
 TEST_F(PlanarMobilizerTest, MapUsesNplus) {
   // Set an arbitrary "non-zero" state.
   const Vector2d some_values(1.5, 2.5);
-  mobilizer_->set_angle(context_.get(), 3.5);
+  mobilizer_->SetAngle(context_.get(), 3.5);
   mobilizer_->set_translations(context_.get(), some_values);
 
   // Set arbitrary qdot and MapQDotToVelocity.

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -58,9 +58,9 @@ TEST_F(RevoluteMobilizerTest, StateAccess) {
   const double some_value1 = 1.5;
   const double some_value2 = std::sqrt(2);
   // Verify we can set a revolute mobilizer position given the model's context.
-  mobilizer_->set_angle(context_.get(), some_value1);
+  mobilizer_->SetAngle(context_.get(), some_value1);
   EXPECT_EQ(mobilizer_->get_angle(*context_), some_value1);
-  mobilizer_->set_angle(context_.get(), some_value2);
+  mobilizer_->SetAngle(context_.get(), some_value2);
   EXPECT_EQ(mobilizer_->get_angle(*context_), some_value2);
 
   // Verify we can set a revolute mobilizer position rate given the model's
@@ -75,7 +75,7 @@ TEST_F(RevoluteMobilizerTest, ZeroState) {
   const double some_value1 = 1.5;
   const double some_value2 = std::sqrt(2);
   // Set the state to some arbitrary non-zero value.
-  mobilizer_->set_angle(context_.get(), some_value1);
+  mobilizer_->SetAngle(context_.get(), some_value1);
   EXPECT_EQ(mobilizer_->get_angle(*context_), some_value1);
   mobilizer_->SetAngularRate(context_.get(), some_value2);
   EXPECT_EQ(mobilizer_->get_angular_rate(*context_), some_value2);
@@ -139,7 +139,7 @@ TEST_F(RevoluteMobilizerTest, RandomState) {
 
 TEST_F(RevoluteMobilizerTest, CalcAcrossMobilizerTransform) {
   const double angle = 1.5;
-  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->SetAngle(context_.get(), angle);
   const RigidTransformd X_FM(
       mobilizer_->CalcAcrossMobilizerTransform(*context_));
 
@@ -228,7 +228,7 @@ TEST_F(RevoluteMobilizerTest, KinematicMapping) {
 
 TEST_F(RevoluteMobilizerTest, MapUsesN) {
   // Set an arbitrary "non-zero" state.
-  mobilizer_->set_angle(context_.get(), 1.5);
+  mobilizer_->SetAngle(context_.get(), 1.5);
 
   // Set arbitrary v and MapVelocityToQDot
   Vector1d v(2.5);
@@ -245,7 +245,7 @@ TEST_F(RevoluteMobilizerTest, MapUsesN) {
 
 TEST_F(RevoluteMobilizerTest, MapUsesNplus) {
   // Set an arbitrary "non-zero" state.
-  mobilizer_->set_angle(context_.get(), 1.5);
+  mobilizer_->SetAngle(context_.get(), 1.5);
 
   // Set arbitrary qdot and MapQDotToVelocity
   Vector1d qdot(2.5);

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -84,10 +84,10 @@ TEST_F(ScrewMobilizerTest, StateAccess) {
 
   const double angle_z_first{1.0 * 180.0 / M_PI};
 
-  mobilizer_->set_angle(context_.get(), angle_z_first);
+  mobilizer_->SetAngle(context_.get(), angle_z_first);
   EXPECT_EQ(mobilizer_->get_angle(*context_), angle_z_first);
 
-  mobilizer_->set_angle(context_.get(), angle_z_second);
+  mobilizer_->SetAngle(context_.get(), angle_z_second);
   EXPECT_EQ(mobilizer_->get_angle(*context_), angle_z_second);
 
   const double velocity_z_first{1.0};
@@ -120,7 +120,7 @@ TEST_F(ScrewMobilizerTest, ZeroState) {
   const double velocity_z{angular_velocity_z * kScrewPitch / (2.0 * M_PI)};
 
   // Set the state to some arbitrary non-zero value.
-  mobilizer_->set_angle(context_.get(), angle_z);
+  mobilizer_->SetAngle(context_.get(), angle_z);
   mobilizer_->SetAngularRate(context_.get(), angular_velocity_z);
   EXPECT_EQ(mobilizer_->get_angle(*context_), angle_z);
   EXPECT_EQ(mobilizer_->get_angular_rate(*context_), angular_velocity_z);
@@ -199,7 +199,7 @@ TEST_F(ScrewMobilizerTest, RandomState) {
 
 TEST_F(ScrewMobilizerTest, CalcAcrossMobilizerTransform) {
   const double angle = 1.5;
-  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->SetAngle(context_.get(), angle);
   const RigidTransformd X_FM(
       mobilizer_->CalcAcrossMobilizerTransform(*context_));
 
@@ -217,7 +217,7 @@ TEST_F(ScrewMobilizerTest, CalcAcrossMobilizerTransform) {
 TEST_F(ScrewMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
   const double angle = 1.5;
   const Vector1d angular_velocity(0.1);
-  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->SetAngle(context_.get(), angle);
   const SpatialVelocity<double> V_FM =
       mobilizer_->CalcAcrossMobilizerSpatialVelocity(*context_,
                                                      angular_velocity);
@@ -234,7 +234,7 @@ TEST_F(ScrewMobilizerTest, CalcAcrossMobilizerSpatialAcceleration) {
   const double angle = 1.5;
   const double angle_rate = 3;
   const Vector1d angle_acceleration(4.5);
-  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->SetAngle(context_.get(), angle);
   mobilizer_->SetAngularRate(context_.get(), angle_rate);
 
   const SpatialAcceleration<double> A_FM =
@@ -253,7 +253,7 @@ TEST_F(ScrewMobilizerTest, ProjectSpatialForce) {
   const double translation(0.5);
   const double angle = 1.5;
   mobilizer_->SetTranslation(context_.get(), translation);
-  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->SetAngle(context_.get(), angle);
 
   const Vector3d torque_Mo_F(1.0, 2.0, 3.0);
   const Vector3d force_Mo_F(1.0, 2.0, 3.0);
@@ -313,7 +313,7 @@ TEST_F(ScrewMobilizerTest, KinematicMapping) {
 TEST_F(ScrewMobilizerTest, MapUsesN) {
   // Set an arbitrary "non-zero" state.
   const double angle_z{1.0 * 180.0 / M_PI};
-  mobilizer_->set_angle(context_.get(), angle_z);
+  mobilizer_->SetAngle(context_.get(), angle_z);
 
   // Set arbitrary v and MapVelocityToQDot.
   Vector1d v(1.5);
@@ -331,7 +331,7 @@ TEST_F(ScrewMobilizerTest, MapUsesN) {
 TEST_F(ScrewMobilizerTest, MapUsesNplus) {
   // Set an arbitrary "non-zero" state.
   const double angle_z{1.0 * 180.0 / M_PI};
-  mobilizer_->set_angle(context_.get(), angle_z);
+  mobilizer_->SetAngle(context_.get(), angle_z);
 
   // Set arbitrary qdot and MapQDotToVelocity.
   Vector1d qdot(1.5);

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -544,8 +544,8 @@ class PendulumKinematicTests : public PendulumTests {
   /// drake::multibody::benchmarks::Acrobot.
   void VerifyMassMatrixViaInverseDynamics(
       double shoulder_angle, double elbow_angle) {
-    shoulder_mobilizer_->set_angle(context_.get(), shoulder_angle);
-    elbow_mobilizer_->set_angle(context_.get(), elbow_angle);
+    shoulder_mobilizer_->SetAngle(context_.get(), shoulder_angle);
+    elbow_mobilizer_->SetAngle(context_.get(), elbow_angle);
 
     Matrix2d H;
     tree().CalcMassMatrixViaInverseDynamics(*context_, &H);
@@ -561,8 +561,8 @@ class PendulumKinematicTests : public PendulumTests {
       double shoulder_angle, double elbow_angle) {
     const double kTolerance = 5 * kEpsilon;
 
-    shoulder_mobilizer_->set_angle(context_.get(), shoulder_angle);
-    elbow_mobilizer_->set_angle(context_.get(), elbow_angle);
+    shoulder_mobilizer_->SetAngle(context_.get(), shoulder_angle);
+    elbow_mobilizer_->SetAngle(context_.get(), elbow_angle);
 
     double shoulder_rate, elbow_rate;
     Vector2d C;
@@ -644,7 +644,7 @@ class PendulumKinematicTests : public PendulumTests {
 
     // ======================================================================
     // Compute position kinematics.
-    shoulder_mobilizer_->set_angle(context_.get(), shoulder_angle);
+    shoulder_mobilizer_->SetAngle(context_.get(), shoulder_angle);
     elbow_joint_->set_angle(context_.get(), elbow_angle);
     tree().CalcPositionKinematicsCache(*context_, &pc);
 
@@ -782,7 +782,7 @@ class PendulumKinematicTests : public PendulumTests {
 
     // ======================================================================
     // Compute position kinematics.
-    shoulder_mobilizer_->set_angle(context_.get(), shoulder_angle);
+    shoulder_mobilizer_->SetAngle(context_.get(), shoulder_angle);
     elbow_joint_->set_angle(context_.get(), elbow_angle);
     tree().CalcPositionKinematicsCache(*context_, &pc);
 
@@ -846,7 +846,7 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
   EXPECT_EQ(elbow_joint_->get_angle(*context_), 0.0);
 
   // Test mobilizer's setter/getters.
-  shoulder_mobilizer_->set_angle(context_.get(), M_PI);
+  shoulder_mobilizer_->SetAngle(context_.get(), M_PI);
   EXPECT_EQ(shoulder_mobilizer_->get_angle(*context_), M_PI);
   shoulder_mobilizer_->SetZeroState(*context_,
                                     &context_->get_mutable_state());
@@ -861,7 +861,7 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
     for (double ielbow = 0; ielbow < num_angles; ++ielbow) {
       const double elbow_angle = -M_PI + ielbow * kDeltaAngle;
 
-      shoulder_mobilizer_->set_angle(context_.get(), shoulder_angle);
+      shoulder_mobilizer_->SetAngle(context_.get(), shoulder_angle);
       EXPECT_EQ(shoulder_mobilizer_->get_angle(*context_), shoulder_angle);
       elbow_joint_->set_angle(context_.get(), elbow_angle);
       EXPECT_EQ(elbow_joint_->get_angle(*context_), elbow_angle);
@@ -943,7 +943,7 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
 
       // ======================================================================
       // Compute position kinematics.
-      shoulder_mobilizer_->set_angle(context_.get(), shoulder_angle);
+      shoulder_mobilizer_->SetAngle(context_.get(), shoulder_angle);
       elbow_joint_->set_angle(context_.get(), elbow_angle);
       tree().CalcPositionKinematicsCache(*context_, &pc);
 
@@ -1187,8 +1187,8 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
               Vector1<double>::Constant(w_UL) /* angular velocity */);
 
           // Update position kinematics.
-          shoulder_mobilizer_autodiff.set_angle(context_autodiff.get(),
-                                                shoulder_angle);
+          shoulder_mobilizer_autodiff.SetAngle(context_autodiff.get(),
+                                               shoulder_angle);
           elbow_joint_autodiff.set_angle(context_autodiff.get(), elbow_angle);
           tree_autodiff.CalcPositionKinematicsCache(*context_autodiff, &pc);
 
@@ -1261,11 +1261,11 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
           // Since in this case the only force is that of gravity, the time
           // derivative of the total potential energy must equal the total
           // conservative power.
-          shoulder_mobilizer_->set_angle(
+          shoulder_mobilizer_->SetAngle(
               context_.get(), shoulder_angle.value());
           shoulder_mobilizer_->SetAngularRate(
               context_.get(), shoulder_angle.derivatives()[0]);
-          elbow_mobilizer_->set_angle(
+          elbow_mobilizer_->SetAngle(
               context_.get(), elbow_angle.value());
           elbow_mobilizer_->SetAngularRate(
               context_.get(), elbow_angle.derivatives()[0]);
@@ -1286,8 +1286,8 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
   const int kEpsilonFactor = 3;
   const double kTolerance = kEpsilonFactor * kEpsilon;
 
-  shoulder_mobilizer_->set_angle(context_.get(), M_PI / 4.0);
-  elbow_mobilizer_->set_angle(context_.get(), M_PI / 4.0);
+  shoulder_mobilizer_->SetAngle(context_.get(), M_PI / 4.0);
+  elbow_mobilizer_->SetAngle(context_.get(), M_PI / 4.0);
 
   // Set of points Qi measured and expressed in the lower link's frame L.
   Matrix3X<double> p_LQi_set(3, 3);
@@ -1351,8 +1351,8 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
 }
 
 TEST_F(PendulumKinematicTests, PointsHaveTheWrongSize) {
-  shoulder_mobilizer_->set_angle(context_.get(), M_PI / 4.0);
-  elbow_mobilizer_->set_angle(context_.get(), M_PI / 4.0);
+  shoulder_mobilizer_->SetAngle(context_.get(), M_PI / 4.0);
+  elbow_mobilizer_->SetAngle(context_.get(), M_PI / 4.0);
 
   // Create a set of points with the wrong number of rows (it must be 3).
   // The values do not matter for this test, just the size.


### PR DESCRIPTION
PR #21468 is a step towards resolving issue #21284.
It changes internal Multibody/tree/ mobilizer usage of set_angle() to SetAngle().

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21468)
<!-- Reviewable:end -->
