### PR TITLE
Remove temporary DRAKE_DEMANDs

### DIFF
--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -251,16 +251,8 @@ std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
             MakeContactConfiguration(pair), std::move(J),
             make_sap_parameters()));
       } else {
-        ContactConfiguration<T> contact_configuration =
-            MakeContactConfiguration(pair);
-        DRAKE_DEMAND(
-            !std::isnan(ExtractDoubleOrThrow(contact_configuration.vn)));
-        DRAKE_DEMAND(
-            !std::isnan(ExtractDoubleOrThrow(contact_configuration.fe)));
-        DRAKE_DEMAND(
-            !std::isnan(ExtractDoubleOrThrow(contact_configuration.phi)));
         problem->AddConstraint(std::make_unique<SapHuntCrossleyConstraint<T>>(
-            std::move(contact_configuration), std::move(J),
+            MakeContactConfiguration(pair), std::move(J),
             make_hunt_crossley_parameters()));
       }
     } else {


### PR DESCRIPTION

We added a number of DRAKE_DEMANDs in SapDriver::AddContactConstraints() during a transition period in PR #20913. In that PR we explicitly loaded NANs to mark not yet supported configurations (in this case deformables + HuntCrossley contact constraints). Now that the feature is complete and those configurations are supported, these DEMANDs can go away.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21469)
<!-- Reviewable:end -->
