### PR TITLE
[geometry] ComputeSignedDistanceToPoint from meshes

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -156,24 +156,6 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "calc_signed_distance_to_surface_mesh",
-    srcs = ["calc_signed_distance_to_surface_mesh.cc"],
-    hdrs = ["calc_signed_distance_to_surface_mesh.h"],
-    internal = True,
-    visibility = ["//geometry:__pkg__"],
-    deps = [
-        ":bv",
-        ":bvh",
-        ":triangle_surface_mesh",
-        "//common:essential",
-    ],
-    implementation_deps = [
-        ":distance_to_point_callback",
-        "//math:geometric_transform",
-    ],
-)
-
-drake_cc_library(
     name = "collision_filter",
     srcs = ["collision_filter.cc"],
     hdrs = ["collision_filter.h"],
@@ -288,14 +270,27 @@ drake_cc_library(
 
 drake_cc_library(
     name = "distance_to_point_callback",
-    srcs = ["distance_to_point_callback.cc"],
-    hdrs = ["distance_to_point_callback.h"],
+    srcs = [
+        "calc_signed_distance_to_surface_mesh.cc",
+        "distance_to_point_callback.cc",
+        "mesh_distance_boundary.cc",
+    ],
+    hdrs = [
+        "calc_signed_distance_to_surface_mesh.h",
+        "distance_to_point_callback.h",
+        "mesh_distance_boundary.h",
+    ],
     internal = True,
     visibility = [
         "//geometry:__pkg__",
     ],
     deps = [
+        ":bv",
+        ":bvh",
         ":proximity_utilities",
+        ":triangle_surface_mesh",
+        ":volume_mesh",
+        ":volume_to_surface_mesh",
         "//common:default_scalars",
         "//common:drake_export",
         "//common:essential",
@@ -1102,7 +1097,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "calc_signed_distance_to_surface_mesh_test",
     deps = [
-        ":calc_signed_distance_to_surface_mesh",
+        ":distance_to_point_callback",
         ":volume_mesh",
         ":volume_to_surface_mesh",
         "//common/test_utilities:eigen_matrix_compare",
@@ -1250,6 +1245,7 @@ drake_cc_googletest(
     deps = [
         ":characterization_utilities",
         ":distance_to_point_callback",
+        ":make_box_mesh",
     ],
 )
 
@@ -1526,6 +1522,13 @@ drake_cc_googletest(
         ":volume_mesh",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_distance_boundary_test",
+    deps = [
+        "distance_to_point_callback",
     ],
 )
 

--- a/geometry/proximity/calc_signed_distance_to_surface_mesh.cc
+++ b/geometry/proximity/calc_signed_distance_to_surface_mesh.cc
@@ -90,8 +90,11 @@ class BvhVisitor {
 
 }  // namespace
 
-FeatureNormalSet::FeatureNormalSet(const TriangleSurfaceMesh<double>& mesh_M)
-    : vertex_normals_(mesh_M.num_vertices(), Vector3d::Zero()) {
+std::variant<FeatureNormalSet, std::string> FeatureNormalSet::MaybeCreate(
+    const TriangleSurfaceMesh<double>& mesh_M) {
+  std::vector<Vector3<double>> vertex_normals(mesh_M.num_vertices(),
+                                              Vector3d::Zero());
+  std::unordered_map<SortedPair<int>, Vector3<double>> edge_normals;
   const std::vector<Vector3d>& vertices = mesh_M.vertices();
   // We can compute a tolerance for a knife edge based on a minimum dihedral
   // angle θ between adjacent faces using the following formula:
@@ -118,33 +121,33 @@ FeatureNormalSet::FeatureNormalSet(const TriangleSurfaceMesh<double>& mesh_M)
     for (int i = 0; i < 3; ++i) {
       const double angle =
           std::acos(unit_edge_vector[i].dot(-unit_edge_vector[(i + 2) % 3]));
-      vertex_normals_[v[i]] += angle * face_normal;
+      vertex_normals[v[i]] += angle * face_normal;
     }
     // Accumulate normal for each edge of the triangle.
     for (int i = 0; i < 3; ++i) {
       const auto edge = MakeSortedPair(v[i], v[(i + 1) % 3]);
-      auto it = edge_normals_.find(edge);
-      if (it == edge_normals_.end()) {
-        edge_normals_[edge] = face_normal;
+      auto it = edge_normals.find(edge);
+      if (it == edge_normals.end()) {
+        edge_normals[edge] = face_normal;
       } else {
         it->second += face_normal;
         if (it->second.squaredNorm() < kToleranceSquaredNorm) {
-          throw std::runtime_error(
-              "FeatureNormalSet: Cannot compute an edge normal because "
-              "the two triangles sharing the edge make a very sharp edge.");
+          return "FeatureNormalSet: Cannot compute an edge normal because "
+                 "the two triangles sharing the edge make a very sharp edge.";
         }
         it->second.normalize();
       }
     }
   }
-  for (auto& v_normal : vertex_normals_) {
+  for (auto& v_normal : vertex_normals) {
     if (v_normal.squaredNorm() < kToleranceSquaredNorm) {
-      throw std::runtime_error(
-          "FeatureNormalSet: Cannot compute a vertex normal because "
-          "the triangles sharing the vertex form a very pointy needle.");
+      return "FeatureNormalSet: Cannot compute a vertex normal because "
+             "the triangles sharing the vertex form a very pointy needle.";
     }
     v_normal.normalize();
   }
+
+  return FeatureNormalSet(std::move(vertex_normals), std::move(edge_normals));
 }
 
 SquaredDistanceToTriangle CalcSquaredDistanceToTriangle(

--- a/geometry/proximity/calc_signed_distance_to_surface_mesh.h
+++ b/geometry/proximity/calc_signed_distance_to_surface_mesh.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <limits>
+#include <string>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -35,31 +37,32 @@ namespace internal {
 
  J.A. Baerentzen; H. Aanaes. Signed distance computation using the angle
  weighted pseudonormal. IEEE Transactions on Visualization and Computer
- Graphics (Volume: 11, Issue: 3, May-June 2005).
-
- @throws std::exception if the mesh has very sharp features.
- They make calculation of the vertex normals and edge normals too sensitive
- to numerical rounding.
-     Think of the simplest possible knife model of two adjacent triangles
- sharing a single edge. The two triangles would have a small angle between
- them, creating a "sharp edge".  If the edge is too sharp, the mesh will be
- rejected.  We have a generous tolerance -- the angle can be less than a
- degree -- but it would be better to stay well away from impractically sharp
- edges.
-     There is an analogous situation with vertices, where a vertex
- creates a pointy, needle-like region on the mesh. The skinny "needles"
- have the same problem as the thin knife edges. Presence of these
- "needles" may lead to the mesh being rejected.  */
+ Graphics (Volume: 11, Issue: 3, May-June 2005).  */
 class FeatureNormalSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FeatureNormalSet);
 
-  // Computes and stores the normals at the vertices and the edges of the given
-  // surface mesh expressed in frame M.
+  // Computes the normals at the vertices and the edges of the given surface
+  // mesh expressed in frame M.
   //
   // @pre  The mesh is watertight and a closed manifold. Otherwise, the
   //       computed normals are incorrect.
-  explicit FeatureNormalSet(const TriangleSurfaceMesh<double>& mesh_M);
+  //
+  // @returns the computed feature normals or an error message if the mesh has
+  // extremely sharp features. They make calculation of the vertex normals and
+  // edge normals too sensitive to numerical rounding.
+  //     Think of the simplest possible knife model of two adjacent triangles
+  // sharing a single edge. The two triangles would have a small angle between
+  // them, creating a "sharp edge".  If the edge is too sharp, the mesh will be
+  // rejected.  We have a generous tolerance -- the angle can be less than a
+  // degree -- but it would be better to stay well away from impractically sharp
+  // edges.
+  //     There is an analogous situation with vertices, where a vertex
+  // creates a pointy, needle-like region on the mesh. The skinny "needles"
+  // have the same problem as the thin knife edges. Presence of these
+  // "needles" may lead to the mesh being rejected.
+  static std::variant<FeatureNormalSet, std::string> MaybeCreate(
+      const TriangleSurfaceMesh<double>& mesh_M);
 
   // Returns the normal at a vertex `v` as the angle-weighted average of face
   // normals of triangles sharing the vertex. The weight of a triangle is the
@@ -91,6 +94,12 @@ class FeatureNormalSet {
   }
 
  private:
+  FeatureNormalSet(
+      std::vector<Vector3<double>>&& vertex_normals,
+      std::unordered_map<SortedPair<int>, Vector3<double>>&& edge_normals)
+      : vertex_normals_(std::move(vertex_normals)),
+        edge_normals_(std::move(edge_normals)) {}
+
   std::vector<Vector3<double>> vertex_normals_{};
   std::unordered_map<SortedPair<int>, Vector3<double>> edge_normals_{};
 };

--- a/geometry/proximity/distance_to_point_callback.cc
+++ b/geometry/proximity/distance_to_point_callback.cc
@@ -1,7 +1,11 @@
 #include "drake/geometry/proximity/distance_to_point_callback.h"
 
+#include <string>
+#include <variant>
+
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_bool.h"
+#include "drake/geometry/proximity/calc_signed_distance_to_surface_mesh.h"
 
 namespace drake {
 namespace geometry {
@@ -153,22 +157,6 @@ void ComputeDistanceToPrimitive(const fcl::Capsuled& capsule,
     *grad_W = X_WG.rotation() * grad_G;
   }
 }
-
-// clang-format off
-#define INSTANTIATE_DISTANCE_TO_PRIMITIVE(Shape, S)                         \
-template void ComputeDistanceToPrimitive<S>(                                \
-    const fcl::Shape&, const math::RigidTransform<S>&, const Vector3<S>&,   \
-    Vector3<S>*, S*, Vector3<S>*)
-// clang-format on
-
-// INSTANTIATE_DISTANCE_TO_PRIMITIVE(Sphered, double);
-// INSTANTIATE_DISTANCE_TO_PRIMITIVE(Sphered, AutoDiffXd);
-// INSTANTIATE_DISTANCE_TO_PRIMITIVE(Halfspaced, double);
-// INSTANTIATE_DISTANCE_TO_PRIMITIVE(Halfspaced, AutoDiffXd);
-// INSTANTIATE_DISTANCE_TO_PRIMITIVE(Capsuled, double);
-// INSTANTIATE_DISTANCE_TO_PRIMITIVE(Capsuled, AutoDiffXd);
-
-#undef INSTANTIATE_DISTANCE_TO_PRIMITIVE
 
 template <typename T>
 SignedDistanceToPoint<T> DistanceToPoint<T>::operator()(const fcl::Boxd& box) {
@@ -381,6 +369,22 @@ SignedDistanceToPoint<T> DistanceToPoint<T>::operator()(
 }
 
 template <typename T>
+SignedDistanceToPoint<T> DistanceToPoint<T>::operator()(
+    const MeshDistanceBoundary& mesh_G) {
+  const Vector3<double> p_GQ = ExtractDoubleOrThrow(X_WG_.inverse() * p_WQ_);
+  if (!std::holds_alternative<FeatureNormalSet>(mesh_G.feature_normal())) {
+    throw std::runtime_error("DistanceToPoint from meshes: " +
+                             std::get<std::string>(mesh_G.feature_normal()));
+  }
+  const SignedDistanceToSurfaceMesh d = CalcSignedDistanceToSurfaceMesh(
+      p_GQ, mesh_G.tri_mesh(), mesh_G.tri_bvh(),
+      std::get<FeatureNormalSet>(mesh_G.feature_normal()));
+  return SignedDistanceToPoint<T>{geometry_id_, d.nearest_point,
+                                  d.signed_distance,
+                                  X_WG_.rotation() * Vector3<T>(d.gradient)};
+}
+
+template <typename T>
 template <int dim, typename U>
 int DistanceToPoint<T>::ExtremalAxis(const Vector<U, dim>& p,
                                      const Vector<double, dim>& bounds) {
@@ -489,30 +493,16 @@ DistanceToPoint<T>::ComputeDistanceToBox(const Vector<double, dim>& h,
   return std::make_tuple(p_GN_G, grad_G, is_Q_on_edge_or_vertex);
 }
 
-bool ScalarSupport<double>::is_supported(fcl::NODE_TYPE node_type) {
-  switch (node_type) {
-    case fcl::GEOM_BOX:
-    case fcl::GEOM_CAPSULE:
-    case fcl::GEOM_CYLINDER:
-    case fcl::GEOM_ELLIPSOID:
-    case fcl::GEOM_HALFSPACE:
-    case fcl::GEOM_SPHERE:
-      return true;
-    default:
-      return false;
-  }
-}
-
 template <typename T>
 bool Callback(fcl::CollisionObjectd* object_A_ptr,
               fcl::CollisionObjectd* object_B_ptr,
               // NOLINTNEXTLINE
-              void* callback_data, double& threshold) {
+              void* callback_data, double& threshold_out) {
   auto& data = *static_cast<CallbackData<T>*>(callback_data);
 
   // Three things:
-  //   1. We repeatedly set max_distance in each call to the callback because we
-  //   can't initialize it. The cost is negligible but maximizes any culling
+  //   1. We repeatedly set `threshold_out` in each call to the callback because
+  //   we can't initialize it. The cost is negligible but maximizes any culling
   //   benefit.
   //   2. Due to how FCL is implemented, passing a value <= 0 will cause results
   //   to be omitted because the bounding box test only considers *separating*
@@ -524,7 +514,7 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
   //   bounding box test in which this is used doesn't produce a code via
   //   calculation; it is a perfect, hard-coded zero.
   const double kEps = std::numeric_limits<double>::epsilon() / 10;
-  threshold = std::max(data.threshold, kEps);
+  threshold_out = std::max(data.threshold, kEps);
 
   // We use `const` to prevent modification of the collision objects.
   const fcl::CollisionObjectd* geometry_object =
@@ -549,6 +539,16 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
         distance = distance_to_point(
             *static_cast<const fcl::Capsuled*>(collision_geometry));
         break;
+      // Both drake::geometry::Mesh and Convex use fcl::GEOM_CONVEX.
+      case fcl::GEOM_CONVEX:
+        if (data.mesh_boundaries.contains(geometry_id)) {
+          distance = distance_to_point(data.mesh_boundaries.at(geometry_id));
+        } else {
+          // Unsupported mesh types. Returning false tells fcl to continue
+          // to other objects.
+          return false;
+        }
+        break;
       case fcl::GEOM_CYLINDER:
         distance = distance_to_point(
             *static_cast<const fcl::Cylinderd*>(collision_geometry));
@@ -566,7 +566,8 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
             *static_cast<const fcl::Sphered*>(collision_geometry));
         break;
       default:
-        // Returning false tells fcl to continue to other objects.
+        // Unsupported shapes.  Returning false tells fcl to continue to
+        // other objects.
         return false;
     }
 

--- a/geometry/proximity/mesh_distance_boundary.cc
+++ b/geometry/proximity/mesh_distance_boundary.cc
@@ -1,0 +1,25 @@
+#include "drake/geometry/proximity/mesh_distance_boundary.h"
+
+#include "drake/geometry/proximity/bvh.h"
+#include "drake/geometry/proximity/calc_signed_distance_to_surface_mesh.h"
+#include "drake/geometry/proximity/obb.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/geometry/proximity/volume_to_surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+MeshDistanceBoundary::MeshDistanceBoundary(const VolumeMesh<double>& mesh_M)
+    : tri_mesh_M_{ConvertVolumeToSurfaceMesh(mesh_M)},
+      tri_bvh_M_{tri_mesh_M_},
+      feature_normal_M_{FeatureNormalSet::MaybeCreate(tri_mesh_M_)} {}
+
+MeshDistanceBoundary::MeshDistanceBoundary(TriangleSurfaceMesh<double>&& mesh_M)
+    : tri_mesh_M_(std::move(mesh_M)),
+      tri_bvh_M_{tri_mesh_M_},
+      feature_normal_M_{FeatureNormalSet::MaybeCreate(tri_mesh_M_)} {}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/mesh_distance_boundary.h
+++ b/geometry/proximity/mesh_distance_boundary.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/calc_signed_distance_to_surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+class MeshDistanceBoundary {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MeshDistanceBoundary);
+
+  // This version does not take ownership of the volume mesh. It creates and
+  // stores associated data without the volume mesh itself.
+  //
+  // @param mesh_M  the tetrahedral mesh whose vertex positions are expressed
+  //                in frame M.
+  explicit MeshDistanceBoundary(const VolumeMesh<double>& mesh_M);
+
+  // This version takes ownership of the surface mesh.
+  explicit MeshDistanceBoundary(TriangleSurfaceMesh<double>&& mesh_M);
+
+  const TriangleSurfaceMesh<double>& tri_mesh() const { return tri_mesh_M_; }
+  const Bvh<Obb, TriangleSurfaceMesh<double>>& tri_bvh() const {
+    return tri_bvh_M_;
+  }
+  const std::variant<FeatureNormalSet, std::string>& feature_normal() const {
+    return feature_normal_M_;
+  }
+
+ private:
+  // The boundary surface of the volume mesh expressed in the same frame M of
+  // the volume mesh.
+  TriangleSurfaceMesh<double> tri_mesh_M_;
+
+  // BVH of the surface mesh expressed in the same frame M of the volume mesh.
+  Bvh<Obb, TriangleSurfaceMesh<double>> tri_bvh_M_;
+
+  // Contains either the normals for the mesh's edges and vertices, expressed
+  // in frame M of the mesh, or an error message explaining why no such
+  // normals could be computed.
+  std::variant<FeatureNormalSet, std::string> feature_normal_M_;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/characterization_utilities.cc
+++ b/geometry/proximity/test/characterization_utilities.cc
@@ -254,9 +254,8 @@ void ShapeConfigurations<T>::ImplementGeometry(const HalfSpace&, void*) {
 
 template <typename T>
 void ShapeConfigurations<T>::ImplementGeometry(const Mesh&, void*) {
-  throw std::logic_error(
-      "We're assuming that Mesh is Convex; implement this when Mesh is "
-      "represented as its own thing");
+  const Box box = CharacterizeResultTest<double>::box();
+  ImplementGeometry(box, nullptr);
 }
 
 template <typename T>
@@ -350,9 +349,9 @@ void MakeFclShape::ImplementGeometry(const HalfSpace&, void*) {
 }
 
 void MakeFclShape::ImplementGeometry(const Mesh&, void*) {
-  throw std::logic_error(
-      "We're assuming that Mesh is Convex; implement this when Mesh is "
-      "represented as its own thing");
+  // For these tests, we use the same box mesh for Mesh and Convex. Therefore,
+  // the fcl representation of the Mesh type is simply that of the Convex type.
+  ImplementGeometry(Convex("ignored for this test", 1.0), nullptr);
 }
 
 void MakeFclShape::ImplementGeometry(const Sphere& sphere, void*) {
@@ -369,7 +368,7 @@ class ProximityEngineTester {
   }
 };
 
-::testing::AssertionResult MeshIsConvex() {
+::testing::AssertionResult MeshIsConvexInFcl() {
   // Create a small obj in a temp directory.
   const std::string obj_path = temp_directory() + "/tri.obj";
   {
@@ -390,7 +389,7 @@ class ProximityEngineTester {
   // fcl::Convex.
   ProximityEngine<double> engine;
   const GeometryId id = GeometryId::get_new_id();
-  engine.AddDynamicGeometry(Convex(obj_path, 1.0), {}, id);
+  engine.AddDynamicGeometry(Mesh(obj_path, 1.0), {}, id);
   if (ProximityEngineTester::IsFclConvexType(engine, id)) {
     return ::testing::AssertionSuccess();
   }
@@ -704,8 +703,7 @@ HalfSpace CharacterizeResultTest<T>::half_space(bool) {
 
 template <typename T>
 Mesh CharacterizeResultTest<T>::mesh(bool) {
-  throw std::logic_error(
-      "Mesh will be supported when it is no longer represented as a Convex");
+  return Mesh("ignored for this test", 1.0);
 }
 
 template <typename T>

--- a/geometry/proximity/test/characterization_utilities.h
+++ b/geometry/proximity/test/characterization_utilities.h
@@ -243,7 +243,7 @@ class DRAKE_NO_EXPORT MakeFclShape : public ShapeReifier {
 };
 
 /* Reports if the Mesh shape is represented as a Convex shape under the hood. */
-::testing::AssertionResult MeshIsConvex();
+::testing::AssertionResult MeshIsConvexInFcl();
 
 /* Creates a transform to align two planes. The planes are defined by a
  (point, normal) pair -- the point lies on the plane and the normal is

--- a/geometry/proximity/test/distance_to_point_characterize_test.cc
+++ b/geometry/proximity/test/distance_to_point_characterize_test.cc
@@ -4,6 +4,8 @@
 #include <gtest/gtest.h>
 
 #include "drake/geometry/proximity/distance_to_point_callback.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/mesh_distance_boundary.h"
 #include "drake/geometry/proximity/test/characterization_utilities.h"
 #include "drake/geometry/query_results/signed_distance_to_point.h"
 #include "drake/math/rigid_transform.h"
@@ -33,8 +35,15 @@ class PointDistanceCallback : public DistanceCallback<T> {
     DRAKE_DEMAND(obj_A->collisionGeometry()->getNodeType() == fcl::GEOM_SPHERE);
     const GeometryId point_id = EncodedData(*obj_A).id();
     const Vector3<T> p_WQ = X_WGs->at(point_id).translation();
+    std::unordered_map<GeometryId, MeshDistanceBoundary> mesh_data;
+    // Both drake::Convex and drake::Mesh are represented as fcl::GEOM_CONVEX.
+    if (obj_B->collisionGeometry().get()->getNodeType() == fcl::GEOM_CONVEX) {
+      mesh_data.emplace(EncodedData(*obj_B).id(),
+                        MeshDistanceBoundary(MakeBoxVolumeMeshWithMa<double>(
+                            CharacterizeResultTest<T>::box())));
+    }
     CallbackData<T> data(obj_A, std::numeric_limits<double>::infinity(), p_WQ,
-                         X_WGs, &results_);
+                         X_WGs, &mesh_data, &results_);
     double max_distance = std::numeric_limits<double>::infinity();
     return Callback<T>(obj_A, obj_B, &data, max_distance);
   }
@@ -104,7 +113,7 @@ class CharacterizePointDistanceResultTest : public CharacterizeResultTest<T> {
  However, this single test will detect when that condition is no longer true
  and call for implementation of *-Mesh tests. */
 GTEST_TEST(CharacterizePointDistanceResultTest, MeshMesh) {
-  ASSERT_TRUE(MeshIsConvex());
+  ASSERT_TRUE(MeshIsConvexInFcl());
 }
 
 class DoubleTest : public CharacterizePointDistanceResultTest<double>,
@@ -116,10 +125,11 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Values(
         QueryInstance(kPoint, kBox, 2e-15),
         QueryInstance(kPoint, kCapsule, 4e-15),
-        QueryInstance(kPoint, kConvex, kIgnores),
+        QueryInstance(kPoint, kConvex, 5e-15),
         QueryInstance(kPoint, kCylinder, 3e-15),
         QueryInstance(kPoint, kEllipsoid, 3e-5),
         QueryInstance(kPoint, kHalfSpace, 5e-15),
+        QueryInstance(kPoint, kMesh, 5e-15),
         QueryInstance(kPoint, kSphere, 4e-15)),
     QueryInstanceName);
 // clang-format on

--- a/geometry/proximity/test/distance_to_shape_characterize_test.cc
+++ b/geometry/proximity/test/distance_to_shape_characterize_test.cc
@@ -78,7 +78,7 @@ class CharacterizeShapeDistanceResultTest : public CharacterizeResultTest<T> {
  However, this single test will detect when that condition is no longer true
  and call for implementation of *-Mesh tests. */
 GTEST_TEST(CharacterizeShapeDistanceResultTest, MeshMesh) {
-  ASSERT_TRUE(MeshIsConvex());
+  ASSERT_TRUE(MeshIsConvexInFcl());
 }
 
 class DoubleTest : public CharacterizeShapeDistanceResultTest<double>,

--- a/geometry/proximity/test/mesh_distance_boundary_test.cc
+++ b/geometry/proximity/test/mesh_distance_boundary_test.cc
@@ -1,0 +1,64 @@
+#include "drake/geometry/proximity/mesh_distance_boundary.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/proximity/volume_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+
+GTEST_TEST(MeshDistanceBoundary, FromVolumeMesh) {
+  const VolumeMesh<double> mesh_M({VolumeElement{0, 1, 2, 3}},
+                                  {Vector3d::Zero(), Vector3d::UnitX(),
+                                   Vector3d::UnitY(), Vector3d::UnitZ()});
+  const MeshDistanceBoundary dut(mesh_M);
+
+  // Check that data was populated. The actual value depends on other code.
+  EXPECT_EQ(dut.tri_mesh().num_triangles(), 4);
+  EXPECT_FALSE(dut.tri_bvh().root_node().is_leaf());
+  EXPECT_TRUE(std::holds_alternative<FeatureNormalSet>(dut.feature_normal()));
+}
+
+GTEST_TEST(MeshDistanceBoundary, FromSurfaceMesh) {
+  //              Mz
+  //              ┆
+  //           v3 ●
+  //              ┆
+  //              ┆
+  //              ┆
+  //              ┆
+  //              ┆             v2
+  //           v0 ●┄┄┄┄┄┄┄┄┄┄┄┄┄●┄┄┄ My
+  //             ╱┆
+  //            ╱ ┆
+  //           ╱  ┆
+  //          ╱   ┆
+  //      v1 ●
+  //        ╱
+  //       Mx
+  //
+  // It's not const because MeshDistanceBoundary will take ownership of the
+  // mesh.
+  TriangleSurfaceMesh<double> mesh_M{
+      {// The triangle windings give outward normals.
+       SurfaceTriangle{0, 2, 1}, SurfaceTriangle{0, 1, 3},
+       SurfaceTriangle{0, 3, 2}, SurfaceTriangle{1, 2, 3}},
+      {Vector3d::Zero(), Vector3d::UnitX(), Vector3d::UnitY(),
+       Vector3d::UnitZ()}};
+
+  const MeshDistanceBoundary dut(std::move(mesh_M));
+
+  // Check that data was populated. The actual value depends on other code.
+  EXPECT_EQ(dut.tri_mesh().num_triangles(), 4);
+  EXPECT_FALSE(dut.tri_bvh().root_node().is_leaf());
+  EXPECT_TRUE(std::holds_alternative<FeatureNormalSet>(dut.feature_normal()));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
@@ -61,7 +61,7 @@ class CharacterizePointPairResultTest : public CharacterizeResultTest<T> {
  However, this single test will detect when that condition is no longer true
  and call for implementation of *-Mesh tests. */
 GTEST_TEST(CharacterizePointPairResultTest, MeshMesh) {
-  ASSERT_TRUE(MeshIsConvex());
+  ASSERT_TRUE(MeshIsConvexInFcl());
 }
 
 class DoubleTest : public CharacterizePointPairResultTest<double>,

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -696,7 +696,6 @@ class QueryObject {
   // TODO(DamrongGuoy): Improve and refactor documentation of
   // ComputeSignedDistanceToPoint(). Move the common sections into Signed
   // Distance Queries. Update documentation as we add more functionality.
-  // Right now it only supports spheres and boxes.
   /**
    Computes the signed distances and gradients to a query point from each
    geometry in the scene.
@@ -733,7 +732,7 @@ class QueryObject {
 
    |   Scalar   |   %Box  | %Capsule | %Convex | %Cylinder | %Ellipsoid | %HalfSpace |  %Mesh  | %Sphere |
    | :--------: | :-----: | :------: | :-----: | :-------: | :--------: | :--------: | :-----: | :-----: |
-   |   double   |  2e-15  |   4e-15  |    ᵃ    |   3e-15   |    3e-5ᵇ   |    5e-15   |    ᵃ    |  4e-15  |
+   |   double   |  2e-15  |   4e-15  |  5e-15  |   3e-15   |    3e-5ᵇ   |    5e-15   | 5e-15ᶜ  |  4e-15  |
    | AutoDiffXd |  1e-15  |   4e-15  |    ᵃ    |     ᵃ     |      ᵃ     |    5e-15   |    ᵃ    |  3e-15  |
    | Expression |   ᵃ     |    ᵃ     |    ᵃ    |     ᵃ     |      ᵃ     |      ᵃ     |    ᵃ    |    ᵃ    |
    __*Table 8*__: Worst observed error (in m) for 2mm penetration/separation
@@ -747,6 +746,34 @@ class QueryObject {
        the projection of the query point on the ellipsoid; the closer that point
        is to the high curvature area, the bigger the effect. It is not
        immediately clear how much worse the answer will get.
+   - ᶜ Only supports OBJ and tetrahedral VTK meshes. Unsupported meshes are
+       simply ignored; no results are reported for that geometry. For OBJ meshes
+       the surface mesh must satisfy specific requirements (see below). Unlike
+       the other Shapes, witness points and gradients can be discontinuous on a
+       mesh's exterior if it is non-convex.
+
+   @pre The %Mesh of a triangular surface mesh must be a closed manifold
+   without duplicate vertices or self-intersection, and every triangle's face
+   winding gives an outward-pointing face normal.  Drake does not currently
+   validate the input mesh with respect to these properties. Instead, it does a
+   good-faith computation assuming the properties, possibly returning incorrect
+   results. Non-compliant meshes will introduce regions in which the query
+   point will report the wrong sign (and, therefore, the wrong gradient) due
+   to a misclassification of being inside or outside. This leads to
+   discontinuities in the distance field across the boundaries of these
+   regions; the distance sign will flip while the magnitude of the distance
+   value is arbitrarily far away from zero. For open meshes, the same principle
+   holds. The open mesh, which has no true concept of "inside", will
+   nevertheless report some query points as being inside.
+
+   @pre The %Mesh of a tetrahedral volume mesh has positive-volume tetrahedra,
+   no duplicate vertices, no self-intersection, and any two tetrahedra
+   intersect in a common triangular face, edge, or vertex or not at all.
+   A "tetrahedron soup" is, in general, non-compliant to this condition.
+   Violating meshes will introduce areas inside the volumes that are
+   incorrectly treated as boundary surfaces. The query points near such
+   problematic areas will report the wrong nearest points, distances,
+   and gradients.
 
    @note For a sphere G, the signed distance function φᵢ(p) has an undefined
    gradient vector at the center of the sphere--every point on the sphere's
@@ -788,7 +815,10 @@ class QueryObject {
                               SignedDistanceToPoint. The ordering of the
                               results is guaranteed to be consistent -- for
                               fixed geometry poses, the results will remain the
-                              same. */
+                              same.
+
+   @throws std::exception if there are meshes with extremely sharp features
+   where the calculation of feature normals become unstable. */
   std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(
       const Vector3<T>& p_WQ,
       const double threshold = std::numeric_limits<double>::infinity()) const;

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -466,7 +466,10 @@ class HalfSpace final : public Shape {
  queries for more details. The notable cases where the actual mesh topology is
  used includes:
 
-   - Specifying the %Mesh as rigid hydroelastic.
+   - Computing signed distances from the %Mesh to query points (when it
+     references a .obj file or a tetrahedral .vtk file).
+   - Specifying the %Mesh as rigid hydroelastic (when it references a triangle
+     .obj file or a tetrahedral .vtk file).
    - Specifying the %Mesh as compliant hydroelastic (when it references a
      tetrahedral .vtk file).
    - Specifying the %Mesh as deformable (when it references a tetrahedral .vtk


### PR DESCRIPTION
Fix #21323.

We need two tasks:

- [x] #21566 
- [X] ComputeSignedDistanceToPoint from meshes in ProximityEngine (draft [branch](https://github.com/DamrongGuoy/drake/tree/draft0_ProxEng_mesh_signed_distance))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21471)
<!-- Reviewable:end -->
