### PR TITLE
[systems] Drop "instantaneous" from realtime rate calculator

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -711,7 +711,7 @@ drake_cc_library(
         "//common:essential",
         "//geometry/proximity:polygon_to_triangle_mesh",
         "//math:geometric_transform",
-        "//systems/analysis:instantaneous_realtime_rate_calculator",
+        "//systems/analysis:realtime_rate_calculator",
         "//systems/framework:context",
         "//systems/framework:diagram_builder",
         "//systems/framework:leaf_system",

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -11,7 +11,7 @@
 #include "drake/geometry/meshcat_visualizer_params.h"
 #include "drake/geometry/rgba.h"
 #include "drake/geometry/scene_graph.h"
-#include "drake/systems/analysis/instantaneous_realtime_rate_calculator.h"
+#include "drake/systems/analysis/realtime_rate_calculator.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -204,8 +204,7 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
 
   /* TODO(#16486): ideally this mutable state will go away once it is safe to
   run Meshcat multithreaded */
-  mutable systems::internal::InstantaneousRealtimeRateCalculator
-      realtime_rate_calculator_{};
+  mutable systems::internal::RealtimeRateCalculator realtime_rate_calculator_;
 
   /* The name of the alpha slider, if any. */
   std::string alpha_slider_name_;

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -26,11 +26,11 @@ drake_cc_package_library(
         ":implicit_euler_integrator",
         ":implicit_integrator",
         ":initial_value_problem",
-        ":instantaneous_realtime_rate_calculator",
         ":integrator_base",
         ":lyapunov",
         ":monte_carlo",
         ":radau_integrator",
+        ":realtime_rate_calculator",
         ":region_of_attraction",
         ":runge_kutta2_integrator",
         ":runge_kutta3_integrator",
@@ -301,10 +301,10 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "instantaneous_realtime_rate_calculator",
-    srcs = ["instantaneous_realtime_rate_calculator.cc"],
+    name = "realtime_rate_calculator",
+    srcs = ["realtime_rate_calculator.cc"],
     hdrs = [
-        "instantaneous_realtime_rate_calculator.h",
+        "realtime_rate_calculator.h",
     ],
     deps = [
         "//common:timer",
@@ -636,9 +636,9 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "instantaneous_realtime_rate_calculator_test",
+    name = "realtime_rate_calculator_test",
     deps = [
-        ":instantaneous_realtime_rate_calculator",
+        ":realtime_rate_calculator",
     ],
 )
 

--- a/systems/analysis/realtime_rate_calculator.cc
+++ b/systems/analysis/realtime_rate_calculator.cc
@@ -1,4 +1,4 @@
-#include "drake/systems/analysis/instantaneous_realtime_rate_calculator.h"
+#include "drake/systems/analysis/realtime_rate_calculator.h"
 
 #include <utility>
 
@@ -7,8 +7,7 @@ namespace systems {
 namespace internal {
 
 std::optional<double>
-InstantaneousRealtimeRateCalculator::UpdateAndRecalculate(
-    double current_sim_time) {
+RealtimeRateCalculator::UpdateAndRecalculate(double current_sim_time) {
   std::optional<double> realtime_rate;
   if (prev_sim_time_.has_value()) {
     const double wall_delta{timer_->Tick()};
@@ -23,7 +22,7 @@ InstantaneousRealtimeRateCalculator::UpdateAndRecalculate(
   return realtime_rate;
 }
 
-void InstantaneousRealtimeRateCalculator::InjectMockTimer(
+void RealtimeRateCalculator::InjectMockTimer(
     std::unique_ptr<Timer> mock_timer) {
   timer_ = std::move(mock_timer);
 }

--- a/systems/analysis/realtime_rate_calculator.h
+++ b/systems/analysis/realtime_rate_calculator.h
@@ -9,10 +9,10 @@ namespace drake {
 namespace systems {
 namespace internal {
 /* Utility class that computes the realtime rate achieved between time steps. */
-class InstantaneousRealtimeRateCalculator {
+class RealtimeRateCalculator {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InstantaneousRealtimeRateCalculator);
-  InstantaneousRealtimeRateCalculator() = default;
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RealtimeRateCalculator);
+  RealtimeRateCalculator() = default;
 
   /* Computes the realtime rate which is the ratio of the amount of simulator
    time to real world time that has passed between invocations.

--- a/systems/analysis/test/realtime_rate_calculator_test.cc
+++ b/systems/analysis/test/realtime_rate_calculator_test.cc
@@ -1,4 +1,4 @@
-#include "drake/systems/analysis/instantaneous_realtime_rate_calculator.h"
+#include "drake/systems/analysis/realtime_rate_calculator.h"
 
 #include <gtest/gtest.h>
 
@@ -6,8 +6,7 @@ namespace drake {
 namespace systems {
 namespace {
 
-
-using internal::InstantaneousRealtimeRateCalculator;
+using internal::RealtimeRateCalculator;
 
 class MockTimer final : public Timer {
  public:
@@ -15,10 +14,10 @@ class MockTimer final : public Timer {
   double Tick() final { return 0.1; }
 };
 
-// Tests that the InstantaneousRealtimeRateCalculator calculates the correct
+// Tests that the RealtimeRateCalculator calculates the correct
 // results including startup and rewinding time.
-GTEST_TEST(InstantaneousRealtimeRateCalculatorTest, BasicTest) {
-  InstantaneousRealtimeRateCalculator calculator{};
+GTEST_TEST(RealtimeRateCalculatorTest, BasicTest) {
+  RealtimeRateCalculator calculator{};
   calculator.InjectMockTimer(std::make_unique<MockTimer>());
   // First (seed) call returns nullopt.
   EXPECT_FALSE(calculator.UpdateAndRecalculate(0.0).has_value());
@@ -36,8 +35,7 @@ GTEST_TEST(InstantaneousRealtimeRateCalculatorTest, BasicTest) {
   // return 0.0 realtime rate.
   EXPECT_DOUBLE_EQ(calculator.UpdateAndRecalculate(0.1).value(), 0.0);
 
-  // InstantaneousRealtimeRateCalculator should reset properly on call
-  // to Reset().
+  // RealtimeRateCalculator should reset properly on call to Reset().
   calculator.Reset();
 
   // First call to UpdateAndRecalculate() after Reset() returns nullopt


### PR DESCRIPTION
We anticipate adding smoothing logic (#16486), so the name will become misleading soon.  We'll rename it in this PR before modifying the logic too heavily in a future PR, so that we keep the history intact.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21474)
<!-- Reviewable:end -->
