### PR TITLE
Implements MultibodyPlant::GetConstraintIds()

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -267,6 +267,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("force_element"), py_rvp::reference_internal,
             cls_doc.AddForceElement.doc)
+        .def("GetConstraintIds", &Class::GetConstraintIds,
+            cls_doc.GetConstraintIds.doc)
         .def("SetConstraintActiveStatus", &Class::SetConstraintActiveStatus,
             py::arg("context"), py::arg("id"), py::arg("status"),
             cls_doc.SetConstraintActiveStatus.doc)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2678,6 +2678,14 @@ class TestPlant(unittest.TestCase):
         # We are done creating the model.
         plant.Finalize()
 
+        # Test GetConstraintIds()
+        ids = plant.GetConstraintIds()
+        # Confirm that indices and [distance_id, ball_id, weld_id, coupler_id]
+        # are the same up to a permutation.
+        self.assertTrue(
+            collections.Counter(ids) == collections.Counter(
+                [distance_id, ball_id, weld_id, coupler_id]))
+
         # Default context.
         context = plant.CreateDefaultContext()
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -447,7 +447,7 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
 template <typename T>
 std::vector<MultibodyConstraintId> MultibodyPlant<T>::GetConstraintIds() const {
   std::vector<MultibodyConstraintId> ids;
-  // This list must be kept up to date with the types of user - addable
+  // This list must be kept up to date with the types of user-addable
   // constraints. See #21415 for a potentially more robust / sustainable
   // solution.
   for (const auto& [id, _] : coupler_constraints_specs_) {

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -445,6 +445,27 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
 }
 
 template <typename T>
+std::vector<MultibodyConstraintId> MultibodyPlant<T>::GetConstraintIds() const {
+  std::vector<MultibodyConstraintId> ids;
+  // This list must be kept up to date with the types of user - addable
+  // constraints. See #21415 for a potentially more robust / sustainable
+  // solution.
+  for (const auto& [id, _] : coupler_constraints_specs_) {
+    ids.push_back(id);
+  }
+  for (const auto& [id, _] : distance_constraints_specs_) {
+    ids.push_back(id);
+  }
+  for (const auto& [id, _] : ball_constraints_specs_) {
+    ids.push_back(id);
+  }
+  for (const auto& [id, _] : weld_constraints_specs_) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+template <typename T>
 bool MultibodyPlant<T>::GetConstraintActiveStatus(
     const systems::Context<T>& context, MultibodyConstraintId id) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1556,6 +1556,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
            num_ball_constraints() + num_weld_constraints();
   }
 
+  /// Returns a list of all constraint identifiers. The returned vector becomes
+  /// invalid after any calls to Add*Constraint() or RemoveConstraint().
+  std::vector<MultibodyConstraintId> GetConstraintIds() const;
+
   /// Returns the total number of coupler constraints specified by the user.
   int num_coupler_constraints() const {
     return ssize(coupler_constraints_specs_);

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -4139,6 +4139,44 @@ GTEST_TEST(MultibodyPlantTest, AutoDiffAcrobotParameters) {
                               MatrixCompareType::relative));
 }
 
+GTEST_TEST(MultibodyPlantTests, GetConstraintIds) {
+  // Set up a plant with 3 constraints with arbitrary parameters.
+  MultibodyPlant<double> plant(0.01);
+
+  EXPECT_EQ(plant.GetConstraintIds().size(), 0);
+
+  // N.B. This feature is only supported by the SAP solver. Therefore we
+  // arbitrarily choose one model approximation that uses the SAP solver.
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  const RigidBody<double>& body_A =
+      plant.AddRigidBody("body_A", SpatialInertia<double>::NaN());
+  const RigidBody<double>& body_B =
+      plant.AddRigidBody("body_B", SpatialInertia<double>::NaN());
+  const RevoluteJoint<double>& world_A =
+      plant.AddJoint<RevoluteJoint>("world_A", plant.world_body(), std::nullopt,
+                                    body_A, std::nullopt, Vector3d::UnitZ());
+  const RevoluteJoint<double>& A_B = plant.AddJoint<RevoluteJoint>(
+      "A_B", body_A, std::nullopt, body_B, std::nullopt, Vector3d::UnitZ());
+  MultibodyConstraintId coupler_id =
+      plant.AddCouplerConstraint(world_A, A_B, 2.3);
+  MultibodyConstraintId distance_id = plant.AddDistanceConstraint(
+      body_A, Vector3d(1.0, 2.0, 3.0), body_B, Vector3d(4.0, 5.0, 6.0), 2.0);
+  MultibodyConstraintId ball_id = plant.AddBallConstraint(
+      body_A, Vector3d(-1.0, -2.0, -3.0), body_B, Vector3d(-4.0, -5.0, -6.0));
+  MultibodyConstraintId weld_id = plant.AddWeldConstraint(
+      body_A, RigidTransformd(), body_B, RigidTransformd());
+
+  std::vector<MultibodyConstraintId> ids = plant.GetConstraintIds();
+  // The order of the constraints is not guaranteed.
+  EXPECT_THAT(ids, testing::UnorderedElementsAre(coupler_id, distance_id,
+                                                 ball_id, weld_id));
+
+  plant.RemoveConstraint(coupler_id);
+  plant.RemoveConstraint(ball_id);
+  ids = plant.GetConstraintIds();
+  EXPECT_THAT(ids, testing::UnorderedElementsAre(distance_id, weld_id));
+}
+
 GTEST_TEST(MultibodyPlantTests, ConstraintActiveStatus) {
   // Set up a plant with 3 constraints with arbitrary parameters.
   MultibodyPlant<double> plant(0.01);


### PR DESCRIPTION
Resolves #21482. At minimum, this enables one to remove constraints from the plant that might have been added during parsing, without using internal methods (which are not bound in pydrake).

+@amcastro-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21483)
<!-- Reviewable:end -->
