### PR TITLE
Set constraint type in IpoptSolver.

### DIFF
--- a/solvers/ipopt_solver_internal.h
+++ b/solvers/ipopt_solver_internal.h
@@ -103,6 +103,9 @@ class DRAKE_NO_EXPORT IpoptSolver_NLP : public Ipopt::TNLP {
       Ipopt::Number obj_value, const Ipopt::IpoptData* ip_data,
       Ipopt::IpoptCalculatedQuantities* ip_cq);
 
+  virtual bool get_constraints_linearity(
+      Ipopt::Index m, Ipopt::TNLP::LinearityType* const_types);
+
   const Ipopt::SolverReturn& status() const { return status_; }
   const Eigen::VectorXd& z_L() const { return z_L_; }
   const Eigen::VectorXd& z_U() const { return z_U_; }


### PR DESCRIPTION
Overloads the get_constraints_linearity() function in IPOPT. But IPOPT doesn't call this function, it is only called by BONMIN.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21501)
<!-- Reviewable:end -->
