### PR TITLE
Fix -Wpessimizing-move

### DIFF
--- a/multibody/plant/slicing_and_indexing.cc
+++ b/multibody/plant/slicing_and_indexing.cc
@@ -144,7 +144,7 @@ contact_solvers::internal::MatrixBlock<T> ExcludeCols(
   }
 
   return contact_solvers::internal::MatrixBlock<T>(
-      std::move(ExcludeCols(M.MakeDenseMatrix(), indices)));
+      ExcludeCols(M.MakeDenseMatrix(), indices));
 }
 
 template <typename T>

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -76,13 +76,13 @@ GCC_CC_TEST_FLAGS = [
 ]
 
 GCC_VERSION_SPECIFIC_FLAGS = {
-    # TODO(#21337) Investigate and resolve what to do about these warnings
-    # long-term. Some of them seem like true positives (i.e., bugs in Drake).
     13: [
+        "-Werror=pessimizing-move",
+        # TODO(#21337) Investigate and resolve what to do about these warnings
+        # long-term. Some seem like true positives (i.e., bugs in Drake).
         "-Wno-array-bounds",
         "-Wno-dangling-reference",
         "-Wno-maybe-uninitialized",
-        "-Wno-pessimizing-move",
         "-Wno-stringop-overflow",
         "-Wno-stringop-overread",
         "-Wno-uninitialized",


### PR DESCRIPTION
Remove a counterproductive call to std::move. Enable (as an error) the warning that catches these.

Toward #21337.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21513)
<!-- Reviewable:end -->
