### PR TITLE
[pydrake] Add repr for SpatialInertia.Zero

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -763,6 +763,8 @@ class TestPlant(unittest.TestCase):
             Class)
         # Test operators.
         zero = Class(Ixx=0.0, Iyy=0.0, Izz=0.0)
+        if T != Expression:
+            self.assertTrue(zero.IsZero())
         self.assertIsInstance(dut + zero, Class)
         self.assertIsInstance(dut - zero, Class)
         self.assertIsInstance(dut * T(1.0), Class)
@@ -852,7 +854,9 @@ class TestPlant(unittest.TestCase):
         SpatialForce = SpatialForce_[T]
         SpatialVelocity = SpatialVelocity_[T]
         SpatialMomentum = SpatialMomentum_[T]
-        SpatialInertia.Zero()
+        zero = SpatialInertia.Zero()
+        if T != Expression:
+            self.assertTrue(zero.IsZero())
         SpatialInertia.NaN()
         with catch_drake_warnings(expected_count=1) as w:
             SpatialInertia()
@@ -921,6 +925,13 @@ class TestPlant(unittest.TestCase):
             spatial_inertia * SpatialAcceleration(), SpatialForce)
         self.assertIsInstance(
             spatial_inertia * SpatialVelocity(), SpatialMomentum)
+        self.assertIn("<pydrake.multibody.tree.SpatialInertia",
+                      repr(spatial_inertia))
+        if T == float:
+            # This one is used as a default argument, so it's important that we
+            # print it out in full.
+            self.assertEqual(repr(SpatialInertia.Zero()),
+                             "SpatialInertia.Zero()")
         assert_pickle(
             self, spatial_inertia, SpatialInertia.CopyToFullMatrix6, T=T)
         spatial_inertia.SetNaN()

--- a/bindings/pydrake/multibody/tree_py_inertia.cc
+++ b/bindings/pydrake/multibody/tree_py_inertia.cc
@@ -1,3 +1,5 @@
+#include "pybind11/eval.h"
+
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
@@ -95,6 +97,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("SetToNaN", &Class::SetToNaN, cls_doc.SetToNaN.doc)
         .def("SetZero", &Class::SetZero, cls_doc.SetZero.doc)
         .def("IsNaN", &Class::IsNaN, cls_doc.IsNaN.doc)
+        .def("IsZero", &Class::IsZero, cls_doc.IsZero.doc)
         // TODO(jwnimmer-tri) Need to bind cast<>.
         .def("CalcPrincipalMomentsOfInertia",
             &Class::CalcPrincipalMomentsOfInertia,
@@ -281,6 +284,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("CopyToFullMatrix6", &Class::CopyToFullMatrix6,
             cls_doc.CopyToFullMatrix6.doc)
         .def("IsNaN", &Class::IsNaN, cls_doc.IsNaN.doc)
+        .def("IsZero", &Class::IsZero, cls_doc.IsZero.doc)
         .def("SetNaN", &Class::SetNaN, cls_doc.SetNaN.doc)
         .def("ReExpress", &Class::ReExpress, py::arg("R_AE"),
             cls_doc.ReExpress.doc)
@@ -288,6 +292,15 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(py::self += py::self)
         .def(py::self * SpatialAcceleration<T>())
         .def(py::self * SpatialVelocity<T>())
+        .def("__repr__",
+            [](const Class& self) -> py::object {
+              if constexpr (std::is_same_v<T, double>) {
+                if (self.IsZero()) {
+                  return py::str("SpatialInertia.Zero()");
+                }
+              }
+              return py::eval("object.__repr__")(self);
+            })
         .def(py::pickle(
             [](const Class& self) {
               return py::make_tuple(

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -572,7 +572,18 @@ class SpatialInertia {
   boolean<T> IsNaN() const {
     using std::isnan;
     return isnan(mass_) || G_SP_E_.IsNaN() ||
-        any_of(p_PScm_E_, [](auto x){ return isnan(x); });
+           any_of(p_PScm_E_, [](const auto& x) {
+             return isnan(x);
+           });
+  }
+
+  /// Returns `true` if all of the elements in this spatial inertia are zero
+  /// and `false` otherwise.
+  boolean<T> IsZero() const {
+    return (mass_ == 0.0) && G_SP_E_.IsZero() &&
+           all_of(p_PScm_E_, [](const auto& x) {
+             return (x == 0.0);
+           });
   }
 
   /// Performs a number of checks to verify that this is a physically valid

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -60,17 +60,20 @@ GTEST_TEST(SpatialInertia, ZeroFactory) {
   EXPECT_EQ(I.get_com(), Vector3d::Zero());
   EXPECT_EQ(I.get_unit_inertia().get_moments(), Vector3d::Zero());
   EXPECT_EQ(I.get_unit_inertia().get_products(), Vector3d::Zero());
+  EXPECT_TRUE(I.IsZero());
 }
 
 GTEST_TEST(SpatialInertia, NaNFactory) {
   auto I = SpatialInertia<double>::NaN();
-  ASSERT_TRUE(I.IsNaN());
+  EXPECT_TRUE(I.IsNaN());
+  EXPECT_FALSE(I.IsZero());
 }
 
 GTEST_TEST(SpatialInertia, MakeUnitary) {
   const double expected_mass = 1;
   const SpatialInertia<double> M = SpatialInertia<double>::MakeUnitary();
   EXPECT_TRUE(M.IsPhysicallyValid());
+  EXPECT_FALSE(M.IsZero());
   EXPECT_EQ(M.get_mass(), expected_mass);
   EXPECT_EQ(M.get_com(), Vector3<double>::Zero());
   const Vector3<double> M_unit_moments = M.get_unit_inertia().get_moments();


### PR DESCRIPTION
This fixes hex addresses in our docs, towards #13987.

Examples of the docs spam: https://github.com/RobotLocomotion/RobotLocomotion.github.io/commit/3545db73dacc5a8bf075352f168bf9182fc6b7b7

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21515)
<!-- Reviewable:end -->
