### PR TITLE
[pydrake] Add repr for Parallelism

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -132,7 +132,11 @@ void InitLowLevelModules(py::module m) {
         // Note that we can't bind Parallelism::None(), because `None`
         // is a reserved word in Python.
         .def_static("Max", &Class::Max, cls_doc.Max.doc)
-        .def("num_threads", &Class::num_threads, cls_doc.num_threads.doc);
+        .def("num_threads", &Class::num_threads, cls_doc.num_threads.doc)
+        .def("__repr__", [](const Class& self) {
+          const int num_threads = self.num_threads();
+          return fmt::format("Parallelism(num_threads={})", num_threads);
+        });
     DefCopyAndDeepCopy(&cls);
   }
 

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -56,6 +56,12 @@ class TestCommon(unittest.TestCase):
         self.assertEqual(mut.Parallelism(1).num_threads(), 1)
         self.assertEqual(mut.Parallelism(3).num_threads(), 3)
 
+        # Round-trip repr.
+        for rep in ["Parallelism(num_threads=1)",
+                    "Parallelism(num_threads=2)"]:
+            x = eval(rep, {"Parallelism": mut.Parallelism}, {})
+            self.assertEqual(repr(x), rep)
+
         # Floats are right out.
         with self.assertRaisesRegex(Exception, "types"):
             mut.Parallelism(0.5)


### PR DESCRIPTION
This fixes hex addresses in our docs, towards #13987.

Examples of the docs spam: https://github.com/RobotLocomotion/RobotLocomotion.github.io/commit/3545db73dacc5a8bf075352f168bf9182fc6b7b7

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21517)
<!-- Reviewable:end -->
