### PR TITLE
[doc] Update Linux link for buildcop cache server check

### DIFF
--- a/doc/_pages/buildcop.md
+++ b/doc/_pages/buildcop.md
@@ -172,7 +172,7 @@ Check once per week that caching is still enabled, there are currently two cache
 servers that need to be confirmed.  Open each of the following jobs and search
 for ``REMOTE_CACHE_KEY`` and confirm it has a value:
 
-- [https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-continuous-release/lastBuild/consoleFull](https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-continuous-release/lastBuild/consoleFull)
+- [https://drake-jenkins.csail.mit.edu/job/linux-noble-clang-bazel-continuous-release/lastBuild/consoleFull](https://drake-jenkins.csail.mit.edu/job/linux-noble-clang-bazel-continuous-release/lastBuild/consoleFull)
 - [https://drake-jenkins.csail.mit.edu/job/mac-arm-ventura-clang-bazel-continuous-release/lastBuild/consoleFull](https://drake-jenkins.csail.mit.edu/job/mac-arm-ventura-clang-bazel-continuous-release/lastBuild/consoleFull)
 
 Message indicating a problem:


### PR DESCRIPTION
The Linux Bazel Continuous Release job was changed from Jammy to Noble, update the buildcop cache server check documentation to reference the Noble job.

Follow-up to #21475

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21518)
<!-- Reviewable:end -->
