### PR TITLE
Generalize RenderEngineGl's geometries and instances

### DIFF
--- a/geometry/render_gl/internal_opengl_geometry.h
+++ b/geometry/render_gl/internal_opengl_geometry.h
@@ -22,6 +22,108 @@ namespace internal {
  assigning sequential values in enumerations).  */
 enum RenderType { kColor = 0, kLabel, kDepth, kTypeCount };
 
+/* Describes the data associated with a particular vertex attribute (for
+ defining an OpenGlGeometry instance). The data is ultimately stored in an
+ associated vertex buffer object (VBO). This struct merely communicates how to
+ identify and interpret the bytes in that buffer object. */
+struct VertexAttrib {
+  /* The index for this attribute as defined by the shaders. To match the
+   shaders this value must be 0 for position, 1 for normals, and 2 for uvs. */
+  int attribute_index{};
+  /* Number of values per element; e.g., 3 values per position, etc. */
+  int components_per_element{};
+  /* Offset into the corresponding buffer at which this data starts. */
+  int byte_offset{};
+  /* The byte distance between subsequent elements. Zero is a valid value;
+   OpenGL will assume compact representation and use a stride equal to
+   `components_per_element * sizeof("value_type"). */
+  int stride{};
+  /* The numeric type of the single values (e.g., GL_INT, GL_FLOAT, etc.). */
+  int numeric_type{};
+};
+
+/* The collection of vertex attributes for a single mesh. As with VertexAttrib
+ there should be a single vertex buffer object (VBO) associated with a
+ VertexSpec instance. Note, if a particular VertexAttrib is undefined, its
+ `components_per_element` will be zero. */
+struct VertexSpec {
+  VertexAttrib positions;
+  VertexAttrib normals;
+  VertexAttrib uvs;
+};
+
+/* @group Frames, Geometries, and Instances
+
+ There are a number of frames relating to how geometries are handled in
+ RenderEngineGl. What they are and how they relate can be confusing. This
+ discussion defines the frames, their relationships, and looks at the provenance
+ of the values in those relationships (with particular focus on what values are
+ stored in Drake entities and how they are used).
+
+   W: Drake's world frame.
+   G: Drake's geometry frame (this is what gets posed by SceneGraph). In this
+      file it is the instance's frame.
+   M: An OpenGl "model" frame. This is a conceptual frame relating the parts of
+      a prop. It is neither the instance frame nor the frame that OpenGlGeometry
+      vertex positions or normals are measured and expressed in. For example,
+      the underlying model data can be scaled (as with Mesh or Convex shapes) to
+      create the effective geometry instance. Also, the instance can be built of
+      multiple parts (the constituent pieces of a "prop") and those parts can
+      themselves be transformed relative to each other to build the model.
+   N: The frame in which the vertex positions and normals of an OpenGlGeometry
+      are measured and expressed.
+
+ Relationships between these frames:
+
+   While Drake mostly focuses on rigid transforms between frames (X_AB) and
+   relative orientations (R_AB), rendering needs to describe additional
+   relationships. So, in addition to the X_ and R_ prefixes, we also use the
+   P_, S_, T_, and N_ prefixes. All transforms noted here concatenate as 4x4
+   homogeneous matrices. In implementation, they may be replaced with an
+   alternative, functionally equivalent representation.
+
+     P_: A homogenous matrix representing translation. The same as a
+         RigidTransform consisting of only a translation.
+     S_: A *scale* matrix. A diagonal matrix with Sx, Sy, and Sz on the
+         diagonal.
+     T_: An affine transform which can include translation, rotation, and
+         anisotropic scale. T_AB = P_AB * R_AB * S_AB.
+     N_: The transform to apply to a mesh's normals to re-express them in
+         another frame. Given T_AB = P_AB * R_AB * S_AB, we can derive the
+         corresponding normal transform: N_AB = R_AB * S⁻¹_AB.
+
+   Immutable relationships defined when a Shape is registered with the engine:
+
+      S_GM: The scaling applied to the underlying "model" data to create the
+            requested Drake-specified geometry. This can be the explicitly
+            declared scale factor associated with a Mesh or Convex. It can also
+            be scale factors applied by Drake to map a canonical shape to a
+            particular size. For example, we store the mesh of a unit sphere,
+            but apply an arbitrary scale to model an ellipsoid; this scale
+            matrix contains that transformation.
+      S_MN: For some sources (e.g., glTF files), an OpenGlGeometry will have its
+            vertex data expressed in a different frame from that of the file (or
+            model). This is the scale between those two frames.
+      T_MN: The pose (not necessarily RigidTransform) of the vertex position
+            data associated with a single OpenGlGeometry instance (sometimes
+            referred to as a "part" or "node") in the conceptual frame of the
+            model.
+      T_GN: The transform for measuring and expressing the vertex position data
+            associated with an OpenGlGeometry in the instance's frame. Defined
+            as T_GN = S_GM * T_MN
+      N_GN: The transform for expressing the vertex normal data associated with
+            an OpenGlGeometry in the instance's frame.
+
+   Relationships that depend on the pose of the instance (as defined by
+   SceneGraph):
+
+      X_WG: The pose (RigidTransform) of the Drake geometry frame in Drake's
+            world frame. This is provided by SceneGraph and provided to
+            RenderEngineGl via UpdateVisualPose() and updates frequently.
+      T_WN: T_WG = X_WG * S_GN.
+      N_WN: N_WN = R_WG * N_GN.
+*/
+
 /* For a fixed OpenGL context, defines the definition of a mesh geometry. The
  geometry is defined by the handles to various objects in the OpenGL context.
  If the context is changed or otherwise invalidated, these handles will no
@@ -29,49 +131,20 @@ enum RenderType { kColor = 0, kLabel, kDepth, kTypeCount };
 
  The code that constructs instances is completely responsible for guaranteeing
  that the array and buffer values are valid in the OpenGl context and that the
- index buffer size is likewise sized correctly.  */
+ index buffer size is likewise sized correctly.
+
+ Each instance stores the the transforms necessary to express its vertex data
+ in the source model's frame. For primitives and obj files, these transforms
+ will be the identity. For meshes from other sources (e.g., glTF files), these
+ transforms may be non-identity.  */
 struct OpenGlGeometry {
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(OpenGlGeometry)
-
-  /* Default constructor; the resultant instance is considered "undefined".  */
-  OpenGlGeometry() = default;
-
-  /* Constructs an %OpenGlGeometry from the given "object names" OpenGl objects.
-   (See e.g.,
-   https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenFramebuffers.xhtml
-   for an example of where such an "object name" would come from.)
-
-   @param vertex_array_in       The handle to the OpenGl vertex array object
-                                containing the mesh's data.
-   @param vertex_buffer_in      The handle to the OpenGl vertex buffer
-                                containing mesh per-vertex data.
-   @param index_buffer_in       The handle to the OpenGl index buffer defining a
-                                set of triangles.
-   @param index_buffer_size_in  The number of indices in the index buffer.
-   @param v_count_in            The number of vertices in this mesh (and, by
-                                implication, the number of normals and texture
-                                coordinates).
-   @pre `index_buffer_size_in >= 0`.  */
-  OpenGlGeometry(GLuint vertex_array_in, GLuint vertex_buffer_in,
-                 GLuint index_buffer_in, int index_buffer_size_in,
-                 int v_count_in)
-      : vertex_array{vertex_array_in},
-        vertex_buffer{vertex_buffer_in},
-        index_buffer{index_buffer_in},
-        index_buffer_size{index_buffer_size_in},
-        v_count(v_count_in) {
-    if (index_buffer_size < 0) {
-      throw std::logic_error("Index buffer size must be non-negative");
-    }
-  }
-
   /* Reports true if `this` has been defined with "meaningful" values. In this
    case, "meaningful" is limited to "not default initialized". It can't know
    if the values are actually object identifiers in the current OpenGl context.
    */
   bool is_defined() const {
     return vertex_array != kInvalid && vertex_buffer != kInvalid &&
-           index_buffer != kInvalid;
+           index_buffer != kInvalid && v_count >= 0 && index_count >= 0;
   }
 
   /* Throws an exception with the given `message` if `this` hasn't been
@@ -82,17 +155,36 @@ struct OpenGlGeometry {
   }
 
   // TODO(SeanCurtis-TRI): This can't really be a struct; there are invariants
-  // that need to be maintained: vertex_buffer is sized according to v_count,
-  // vertex_array depends on vertex_buffer, uv_state needs to reflect the uv
-  // data in vertex_buffer, and index_buffer_size needs to be the actual size of
-  // index_buffer (in triangles).
+  // that need to be maintained: vertex_array depends on vertex_buffer,
+  // and index_count needs to be the actual number of indices stored in
+  // index_buffer.
   GLuint vertex_array{kInvalid};
   GLuint vertex_buffer{kInvalid};
   GLuint index_buffer{kInvalid};
-  int index_buffer_size{0};
 
   // The number of vertices encoded in `vertex_buffer`.
   int v_count{};
+
+  // Parameters for glDrawElements(). See
+  // https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDrawElements.xhtml
+  int index_count{-1};
+  // The numerical representation of the indices (e.g., u char, u short, u int).
+  GLenum type{};
+  // How the indices should be interpreted (e.g., triangles, triangle strip,
+  // points, etc.)
+  GLenum mode{};
+
+  /* The transform mapping vertex position to the model frame intrinsic to the
+   geometry definition. */
+  Eigen::Matrix4f T_MN{Eigen::Matrix4f::Identity()};
+  /* The transform mapping vertex normals to the model frame intrinsic to the
+   geometry definition. */
+  Eigen::Matrix3f N_MN{Eigen::Matrix3f::Identity()};
+
+  /* Stores the description of the geometry's vertex data so that the arrays
+   can be recreated upon cloning -- clones share the underlying buffer objects
+   but vertex arrays are *not* shared. */
+  VertexSpec spec;
 
   /* The value of an object (array, buffer) that should be considered invalid.
    */
@@ -106,16 +198,36 @@ struct OpenGlGeometry {
  will also turn the geometry "inside out".
 
  When rendering, the visual geometry will be scaled around G's origin and
- subsequently posed relative to W.  */
+ subsequently posed relative to W.
+
+ With each instance, we store the necessary immutable transforms and, when
+ updating the pose of the geometry (X_WG), update the final transforms that
+ depend on the instantaneous pose and immutable transforms (see below). */
 struct OpenGlInstance {
-  /* Constructs an instance from a geometry definition, a pose, a scale factor
-   and the instance's shader data for depth and label shaders.
-   @pre g_in references a defined OpenGlGeometry.
+  /* Constructs an instance from a geometry definition, transforms for the
+   geometry's vertex position and normals, and the instance's shader data for
+   depth and label shaders.
+
+   @param g_in        The index of the geometry `this` instantiates.
+   @param scale       The scale to apply to the underlying model geometry to
+                      create the drake geometry: S_GM.
+   @param geo         The geometry this is an instance of.
+   @param color_data  The shader data this instance uses for color images.
+   @param depth_data  The shader data this instance uses for depth images.
+   @param label_data  The shader data this instance uses for label images.
+
+   @pre g_in indexes into the geometry referenced by `geo`.
    @pre The shader program data has valid shader ids.  */
-  OpenGlInstance(int g_in, const math::RigidTransformd& pose_in,
-                 const Vector3<double>& scale_in, ShaderProgramData color_data,
+  OpenGlInstance(int g_in, const Eigen::Vector3f& scale,
+                 const OpenGlGeometry& geo, ShaderProgramData color_data,
                  ShaderProgramData depth_data, ShaderProgramData label_data)
-      : geometry(g_in), X_WG(pose_in), scale(scale_in) {
+      : geometry(g_in) {
+    const Eigen::DiagonalMatrix<float, 4> S_GM(
+        Eigen::Vector4f(scale.x(), scale.y(), scale.z(), 1.0));
+    T_GN = S_GM * geo.T_MN;
+    const Eigen::DiagonalMatrix<float, 3> N_GM(
+        Eigen::Vector3f(1.0 / scale.x(), 1.0 / scale.y(), 1.0 / scale.z()));
+    N_GN = N_GM * geo.N_MN;
     DRAKE_DEMAND(color_data.shader_id().is_valid());
     DRAKE_DEMAND(depth_data.shader_id().is_valid());
     DRAKE_DEMAND(label_data.shader_id().is_valid());
@@ -125,12 +237,23 @@ struct OpenGlInstance {
     DRAKE_DEMAND(geometry >= 0);
   }
 
-  // This is the index to the OpenGlGeometry stored by RenderEngineGl.
+  /* This is the index to the OpenGlGeometry stored by RenderEngineGl. */
   int geometry{};
-  // TODO(SeanCurtis-TRI) Change these quantities to be float-valued so they
-  //  can go directly into the shader without casting.
-  math::RigidTransformd X_WG;
-  Vector3<double> scale;
+
+  /* The immutable transform mapping vertex position to the instance frame.
+   Initialized in constructor. */
+  Eigen::Matrix4f T_GN;
+  /* The pose-dependent transform mapping vertex position to Drake World.
+   RenderEngineGl::DoUpdateVisualPose() is responsible for updating this.  */
+  Eigen::Matrix4f T_WN{Eigen::Matrix4f::Identity()};
+
+  /* The immutable transform mapping vertex normals to the instance frame.
+   Initialized in constructor. */
+  Eigen::Matrix3f N_GN;
+  /* The pose-dependent transform mapping vertex normals to Drake World.
+   RenderEngineGl::DoUpdateVisualPose() is responsible for updating this.  */
+  Eigen::Matrix3f N_WN{Eigen::Matrix3f::Identity()};
+
   std::array<ShaderProgramData, RenderType::kTypeCount> shader_data;
 };
 

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -21,6 +21,7 @@ namespace geometry {
 namespace render_gl {
 namespace internal {
 
+using Eigen::Matrix4f;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using geometry::internal::LoadRenderMeshesFromObj;
@@ -263,25 +264,8 @@ vec4 GetIlluminatedColor(vec4 diffuse) {
 
   void DoSetModelViewMatrix(const Eigen::Matrix4f& X_CW,
                             const Eigen::Matrix4f& T_WM,
-                            const Eigen::Matrix4f& X_WG,
-                            const Vector3d& scale) const override {
-    // For lighting, we need the normal and position of a fragment in the world
-    // frame. The pose of the fragment (from its corresponding vertices) comes
-    // simply from T_WM. But the normals require a different transform:
-    //
-    //   1. No translation.
-    //   2. Same rotation as vertex positions.
-    //   3. *Inverse* scale as vertex positions.
-    //
-    // If the scale isn't identity, the normal may not be unit length. We rely
-    // on the shader to normalize the scaled normals.
-    // This is the quantity historically referred to as gl_NormalMatrix
-    // (available to glsl in the "compatibility profile"). See
-    // https://www.cs.upc.edu/~robert/teaching/idi/GLSLangSpec.4.50.pdf.
-    const Eigen::DiagonalMatrix<float, 3, 3> S_GM_normal(
-        Vector3<float>(1.0 / scale(0), 1.0 / scale(1), 1.0 / scale(2)));
-    const Eigen::Matrix3f X_WM_Normal = X_WG.block<3, 3>(0, 0) * S_GM_normal;
-    glUniformMatrix3fv(T_WM_normals_loc_, 1, GL_FALSE, X_WM_Normal.data());
+                            const Eigen::Matrix3f& N_WM) const override {
+    glUniformMatrix3fv(T_WM_normals_loc_, 1, GL_FALSE, N_WM.data());
     glUniformMatrix4fv(T_WM_loc_, 1, GL_FALSE, T_WM.data());
 
     Eigen::Matrix4f X_WC = Eigen::Matrix4f::Identity();
@@ -902,12 +886,10 @@ bool RenderEngineGl::DoRegisterDeformableVisual(
 
 void RenderEngineGl::DoUpdateVisualPose(GeometryId id,
                                         const RigidTransformd& X_WG) {
-  for (auto& part : visuals_.at(id).parts) {
-    if (part.T_GN.has_value()) {
-      part.instance.X_WG = X_WG * part.T_GN.value();
-    } else {
-      part.instance.X_WG = X_WG;
-    }
+  const auto X_WG_f = X_WG.cast<float>();
+  for (auto& instance : visuals_.at(id).instances) {
+    instance.T_WN = X_WG_f.GetAsMatrix4() * instance.T_GN;
+    instance.N_WN = X_WG_f.rotation().matrix() * instance.N_GN;
   }
 }
 
@@ -947,7 +929,7 @@ bool RenderEngineGl::DoRemoveGeometry(GeometryId id) {
   // Now remove the instances associated with the id (stored in visuals_).
   auto iter = visuals_.find(id);
   if (iter != visuals_.end()) {
-    // Multiple parts may have the same shader. We don't want to attempt
+    // Multiple instances may have the same shader. We don't want to attempt
     // removing the geometry id from the corresponding family redundantly.
     std::unordered_set<ShaderId> visited_families;
     // Remove from the shader families to which it belongs!
@@ -963,8 +945,7 @@ bool RenderEngineGl::DoRemoveGeometry(GeometryId id) {
           auto num_removed = geometries.erase(g_id);
           DRAKE_DEMAND(num_removed == 1);
         };
-    for (const auto& part : iter->second.parts) {
-      const OpenGlInstance& instance = part.instance;
+    for (const auto& instance : iter->second.instances) {
       maybe_remove_from_family(id, instance.shader_data, RenderType::kColor);
       maybe_remove_from_family(id, instance.shader_data, RenderType::kDepth);
       maybe_remove_from_family(id, instance.shader_data, RenderType::kLabel);
@@ -1026,8 +1007,7 @@ void RenderEngineGl::RenderAt(const ShaderProgram& shader_program,
 
   for (const GeometryId& g_id :
        shader_families_.at(render_type).at(shader_program.shader_id())) {
-    for (const auto& part : visuals_.at(g_id).parts) {
-      const OpenGlInstance& instance = part.instance;
+    for (const auto& instance : visuals_.at(g_id).instances) {
       if (instance.shader_data.at(render_type).shader_id() !=
           shader_program.shader_id()) {
         continue;
@@ -1036,15 +1016,9 @@ void RenderEngineGl::RenderAt(const ShaderProgram& shader_program,
       glBindVertexArray(geometry.vertex_array);
 
       shader_program.SetInstanceParameters(instance.shader_data[render_type]);
-      // TODO(SeanCurtis-TRI): Consider storing the float-valued pose in the
-      //  OpenGl instance to avoid the conversion every time it is rendered.
-      //  Generally, this wouldn't expect much savings; an instance is only
-      //  rendered once per image type. So, for three image types, I'd cast
-      //  three times. Stored, I'd cast once.
-      shader_program.SetModelViewMatrix(X_CW, instance.X_WG, instance.scale);
+      shader_program.SetModelViewMatrix(X_CW, instance.T_WN, instance.N_WN);
 
-      glDrawElements(GL_TRIANGLES, geometry.index_buffer_size, GL_UNSIGNED_INT,
-                     0);
+      glDrawElements(geometry.mode, geometry.index_count, geometry.type, 0);
     }
   }
   // Unbind the vertex array back to the default of 0.
@@ -1182,10 +1156,13 @@ void RenderEngineGl::AddGeometryInstance(int geometry_index, void* user_data,
   DRAKE_DEMAND(color_data.has_value() && depth_data.has_value() &&
                label_data.has_value());
 
-  visuals_[data.id].parts.push_back(
-      {.instance = OpenGlInstance(geometry_index, data.X_WG, scale, *color_data,
-                                  *depth_data, *label_data),
-       .T_GN = std::nullopt});
+  visuals_[data.id].instances.push_back(
+      {geometry_index, scale.cast<float>(), geometries_.at(geometry_index),
+       *color_data, *depth_data, *label_data});
+
+  // For anchored geometry, we need to make sure the instance's values for
+  // T_WN and N_WN are initialized based on the initial pose, X_WG.
+  DoUpdateVisualPose(data.id, data.X_WG);
 
   shader_families_[RenderType::kColor][color_data->shader_id()].insert(data.id);
   shader_families_[RenderType::kDepth][depth_data->shader_id()].insert(data.id);
@@ -1283,6 +1260,40 @@ void RenderEngineGl::CacheConvexHullMesh(const Convex& convex,
   }
 }
 
+namespace {
+
+/* Creates and configures the vertex array object for the given vertex data
+ specification, assigning the resulting object to the given `geometry`.
+
+ Note: if geometry->spec->uvs.components_per_element == 0, then the texture
+ shader should never be assigned to the resulting OpenGlGeometry.
+
+ @pre There is a valid OpenGL context bound.
+ @pre geometry->vertex_buffer and geometry->index_buffer are names of valid
+ buffers.
+ @pre geometry->spec is properly configured. */
+void CreateVertexArray(OpenGlGeometry* geometry) {
+  glCreateVertexArrays(1, &geometry->vertex_array);
+
+  auto init_array = [&g = *geometry](const VertexAttrib& props) {
+    glVertexArrayVertexBuffer(g.vertex_array, props.attribute_index,
+                              g.vertex_buffer, props.byte_offset, props.stride);
+    glVertexArrayAttribFormat(g.vertex_array, props.attribute_index,
+                              props.components_per_element, props.numeric_type,
+                              GL_FALSE, 0);
+    glEnableVertexArrayAttrib(g.vertex_array, props.attribute_index);
+  };
+  init_array(geometry->spec.positions);
+  init_array(geometry->spec.normals);
+  if (geometry->spec.uvs.components_per_element > 0) {
+    init_array(geometry->spec.uvs);
+  }
+
+  // Bind index buffer object (IBO) with the vertex array object (VAO).
+  glVertexArrayElementBuffer(geometry->vertex_array, geometry->index_buffer);
+}
+
+}  // namespace
 void RenderEngineGl::CacheFileMeshesMaybe(const std::string& filename,
                                           RegistrationData* data) {
   if (Mesh(filename).extension() != ".obj") {
@@ -1437,7 +1448,9 @@ int RenderEngineGl::CreateGlGeometry(const RenderMesh& render_mesh,
   // Confirm that the context is allocated.
   DRAKE_ASSERT(opengl_context_->IsCurrent());
 
-  OpenGlGeometry geometry;
+  const int v_count = render_mesh.positions.rows();
+  OpenGlGeometry geometry{
+      .v_count = v_count, .type = GL_UNSIGNED_INT, .mode = GL_TRIANGLES};
 
   // Create the vertex buffer object (VBO).
   glCreateBuffers(1, &geometry.vertex_buffer);
@@ -1447,7 +1460,6 @@ int RenderEngineGl::CreateGlGeometry(const RenderMesh& render_mesh,
   // equal number of vertices, normals, and texture coordinates.
   DRAKE_DEMAND(render_mesh.positions.rows() == render_mesh.normals.rows());
   DRAKE_DEMAND(render_mesh.positions.rows() == render_mesh.uvs.rows());
-  const int v_count = render_mesh.positions.rows();
   vector<GLfloat> vertex_data;
   // 3 floats each for position and normal, 2 for texture coordinates.
   const int kFloatsPerPosition = 3;
@@ -1480,9 +1492,32 @@ int RenderEngineGl::CreateGlGeometry(const RenderMesh& render_mesh,
                        render_mesh.indices.size() * sizeof(GLuint),
                        render_mesh.indices.data(), 0);
 
-  geometry.index_buffer_size = render_mesh.indices.size();
+  geometry.index_count = render_mesh.indices.size();
 
   geometry.v_count = v_count;
+  // Now configure the vertex array object with vertex attributes.
+  const int p_offset = 0;
+  const int n_offset = v_count * kFloatsPerPosition * sizeof(GLfloat);
+  const int uv_offset =
+      v_count * (kFloatsPerPosition + kFloatsPerNormal) * sizeof(GLfloat);
+  // clang-format off
+  geometry.spec = VertexSpec{
+      .positions = {.attribute_index = 0,
+                    .components_per_element = kFloatsPerPosition,
+                    .byte_offset = p_offset,
+                    .stride = kFloatsPerPosition * sizeof(GLfloat),
+                    .numeric_type = GL_FLOAT},
+      .normals =   {.attribute_index = 1,
+                    .components_per_element = kFloatsPerNormal,
+                    .byte_offset = n_offset,
+                    .stride = kFloatsPerNormal * sizeof(GLfloat),
+                    .numeric_type = GL_FLOAT},
+      .uvs =       {.attribute_index = 2,
+                    .components_per_element = kFloatsPerUv,
+                    .byte_offset = uv_offset,
+                    .stride = kFloatsPerUv * sizeof(GLfloat),
+                    .numeric_type = GL_FLOAT}};
+  // clang-format on
   CreateVertexArray(&geometry);
 
   // Note: We won't need to call the corresponding glDeleteVertexArrays or
@@ -1495,62 +1530,13 @@ int RenderEngineGl::CreateGlGeometry(const RenderMesh& render_mesh,
   return index;
 }
 
-void RenderEngineGl::CreateVertexArray(OpenGlGeometry* geometry) const {
-  // Confirm that the context is allocated.
-  DRAKE_ASSERT(opengl_context_->IsCurrent());
-
-  glCreateVertexArrays(1, &geometry->vertex_array);
-
-  // 3 floats each for position and normal, 2 for texture coordinates.
-  const int kFloatsPerPosition = 3;
-  const int kFloatsPerNormal = 3;
-  const int kFloatsPerUv = 2;
-
-  std::size_t vbo_offset = 0;
-
-  const int position_attrib = 0;
-  glVertexArrayVertexBuffer(geometry->vertex_array, position_attrib,
-                            geometry->vertex_buffer, vbo_offset,
-                            kFloatsPerPosition * sizeof(GLfloat));
-  glVertexArrayAttribFormat(geometry->vertex_array, position_attrib,
-                            kFloatsPerPosition, GL_FLOAT, GL_FALSE, 0);
-  glEnableVertexArrayAttrib(geometry->vertex_array, position_attrib);
-  vbo_offset += geometry->v_count * kFloatsPerPosition * sizeof(GLfloat);
-
-  const int normal_attrib = 1;
-  glVertexArrayVertexBuffer(geometry->vertex_array, normal_attrib,
-                            geometry->vertex_buffer, vbo_offset,
-                            kFloatsPerNormal * sizeof(GLfloat));
-  glVertexArrayAttribFormat(geometry->vertex_array, normal_attrib,
-                            kFloatsPerNormal, GL_FLOAT, GL_FALSE, 0);
-  glEnableVertexArrayAttrib(geometry->vertex_array, normal_attrib);
-  vbo_offset += geometry->v_count * kFloatsPerNormal * sizeof(GLfloat);
-
-  const int uv_attrib = 2;
-  glVertexArrayVertexBuffer(geometry->vertex_array, uv_attrib,
-                            geometry->vertex_buffer, vbo_offset,
-                            kFloatsPerUv * sizeof(GLfloat));
-  glVertexArrayAttribFormat(geometry->vertex_array, uv_attrib, kFloatsPerUv,
-                            GL_FLOAT, GL_FALSE, 0);
-  glEnableVertexArrayAttrib(geometry->vertex_array, uv_attrib);
-  vbo_offset += geometry->v_count * kFloatsPerUv * sizeof(GLfloat);
-
-  const float float_count =
-      geometry->v_count *
-      (kFloatsPerPosition + kFloatsPerNormal + kFloatsPerUv);
-  DRAKE_DEMAND(vbo_offset == float_count * sizeof(GLfloat));
-
-  // Bind index buffer object (IBO) with the vertex array object (VAO).
-  glVertexArrayElementBuffer(geometry->vertex_array, geometry->index_buffer);
-}
-
 void RenderEngineGl::UpdateVertexArrays() {
   DRAKE_ASSERT(opengl_context_->IsCurrent());
   // Creating the vertex arrays requires the context to be bound.
   for (auto& geometry : geometries_) {
     // The only geometries in geometries_ should be fully defined.
     DRAKE_ASSERT(geometry.is_defined());
-    this->CreateVertexArray(&geometry);
+    CreateVertexArray(&geometry);
   }
 }
 

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -209,6 +209,11 @@ class RenderEngineGl final : public render::RenderEngine, private ShapeReifier {
   //
   // @param geometry_index   The index into geometries_ of the geometry used by
   //                         this instance.
+  // @param user_data        The type-erased RegistrationData pointer containing
+  //                         the data used during reification.
+  // @param scale            The quantity for scaling the geometry *model* data
+  //                         to the Drake geometry frame G. Used to construct
+  //                         S_GM.
   void AddGeometryInstance(int geometry_index, void* user_data,
                            const Vector3<double>& scale);
 
@@ -285,10 +290,6 @@ class RenderEngineGl final : public render::RenderEngine, private ShapeReifier {
   // This function is *not* threadsafe.
   int CreateGlGeometry(const geometry::internal::RenderMesh& mesh_data,
                        bool is_deformable = false);
-
-  // Given a geometry that has its buffers (and vertex counts assigned), ties
-  // all of the buffer data into the vertex array attributes.
-  void CreateVertexArray(OpenGlGeometry* geometry) const;
 
   // Updates the vertex arrays in all of the OpenGlGeometry instances owned by
   // this render engine.
@@ -396,7 +397,7 @@ class RenderEngineGl final : public render::RenderEngine, private ShapeReifier {
   // and allowed deviation within a small tolerance, then we could reuse them.
 
   // TODO(SeanCurtis-TRI): The relationships between OpenGlInstance,
-  // OpenGlGeometry, RenderGlMesh, Part, and Prop are probably overly opaque.
+  // OpenGlGeometry, RenderGlMesh, and Prop are probably overly opaque.
   // I need a succinct summary of how all of these moving pieces work together
   // with clear delineation of roles.
 
@@ -440,31 +441,14 @@ class RenderEngineGl final : public render::RenderEngine, private ShapeReifier {
                      RenderType::kTypeCount>
       frame_buffers_;
 
-  // A geometry is modeled with one or more "parts". A part consists of an
-  // instance N and its optional pose in the geometry frame G: T_GN. If the
-  // pose is not provided, then T_GN = I. Posing the instance using the
-  // geometry's world pose X_WG is simply: T_WN = X_WG * T_GN.
-  // For primitives and meshes from file types like obj, T_GN will always be
-  // nullopt. In those representations, the definition of the geometry is
-  // uniquely given in the geometry frame. But for other file types (e.g., glTF)
-  // geometry instances can be defined with arbitrary internal transforms. So,
-  // in those cases T_GN will contain the transform between the mesh definition
-  // and its instantiation within the file (and, therefore, in the geometry
-  // frame).
-  struct Part {
-    OpenGlInstance instance;
-    // TODO(SeanCurtis-TRI): When we get to glTF support, this will have to
-    // become Matrix4 along with the value in OpenGlInstance.
-    std::optional<math::RigidTransformd> T_GN;
-  };
-
-  // Some geometries are represented by multiple parts (such as when importing
-  // a complex .obj file). A "prop" is the collection of parts which constitute
+  // Each OpenGlInstance is associated with a single material. Some visuals
+  // may be comprised of multiple instances (such as might come from an Obj or
+  // glTF file). A "prop" is the collection of instances which constitute
   // one visual geometry associated with a GeometryId.
   //
-  // For simple Drake primitives, there will be a single "part".
+  // For simple Drake primitives, the prop consists of a single instance.
   struct Prop {
-    std::vector<Part> parts;
+    std::vector<OpenGlInstance> instances;
   };
 
   // Mapping from GeometryId to the visual data associated with that geometry.

--- a/geometry/render_gl/internal_shader_program.cc
+++ b/geometry/render_gl/internal_shader_program.cc
@@ -110,12 +110,8 @@ void ShaderProgram::SetProjectionMatrix(const Eigen::Matrix4f& T_DC) const {
 }
 
 void ShaderProgram::SetModelViewMatrix(const Eigen::Matrix4f& X_CW,
-                                       const RigidTransformd& X_WG,
-                                       const Vector3d& scale) const {
-  const Eigen::DiagonalMatrix<float, 4, 4> S_GM(
-      Vector4<float>(scale(0), scale(1), scale(2), 1.0));
-  const Eigen::Matrix4f X_WG_f = X_WG.GetAsMatrix4().cast<float>();
-  const Eigen::Matrix4f T_WM = X_WG_f * S_GM;
+                                       const Eigen::Matrix4f& T_WM,
+                                       const Eigen::Matrix3f& N_WM) const {
   const Eigen::Matrix4f T_CM = X_CW * T_WM;
   // Our camera frame C wrt the OpenGL's camera frame Cgl.
   // clang-format off
@@ -128,7 +124,7 @@ void ShaderProgram::SetModelViewMatrix(const Eigen::Matrix4f& X_CW,
   // clang-format on
   const Eigen::Matrix4f T_CglM = kT_CglC * T_CM;
   glUniformMatrix4fv(model_view_loc_, 1, GL_FALSE, T_CglM.data());
-  DoSetModelViewMatrix(X_CW, T_WM, X_WG_f, scale);
+  DoSetModelViewMatrix(X_CW, T_WM, N_WM);
 }
 
 GLint ShaderProgram::GetUniformLocation(const std::string& uniform_name) const {

--- a/geometry/render_gl/internal_shader_program.h
+++ b/geometry/render_gl/internal_shader_program.h
@@ -138,7 +138,7 @@ class ShaderProgram {
   void SetProjectionMatrix(const Eigen::Matrix4f& T_DC) const;
 
   /* Sets the OpenGl model view matrix (and allows the shader to do any other
-   (instance, camera)-dependent configuration). The model view matrix X_CM
+   (instance, camera)-dependent configuration). The model view matrix T_CM
    transforms a vertex from the model frame M to the camera frame C.
 
    This method invokes DoSetModelViewMatrix() with many of the component
@@ -152,12 +152,13 @@ class ShaderProgram {
    z-scale values along the diagonal).
 
    @param X_CW   The transform relating the world frame and the camera frame.
-   @param X_WG   The pose of the geometry frame relative to the world frame.
-   @param scale  The per-axis scale of the geometry (applied to the axes of the
-                 geometry frame).  */
+   @param T_WM   The transform to map the model's vertex positions into the
+                 world frame. Not necessarily a rigid transform.
+   @param N_WM   The transform to map the model's vertex normals into the
+                 world frame.  */
   void SetModelViewMatrix(const Eigen::Matrix4f& X_CW,
-                          const math::RigidTransformd& X_WG,
-                          const Eigen::Vector3d& scale) const;
+                          const Eigen::Matrix4f& T_WM,
+                          const Eigen::Matrix3f& N_WM) const;
 
   /* Provides the location of the named shader uniform parameter.
    @throws std::exception if the named uniform isn't part of the program. */
@@ -232,22 +233,21 @@ class ShaderProgram {
     return std::nullopt;
   }
 
-  /* Derived classes can set additional state based on a camera-instance pair.
-   See SetModelViewMatrix() docs for the explanation of the difference between
-   geometry frame G, model frame M, and input parameter `scale`.
+  /* Derived classes can set additional state based on model instance
+   transforms.
 
    @param X_CW     The relative transform between camera and world frames. This
                    camera frame is different than the Cgl frame used in the
                    actual model view matrix, C is the physical frame and Cgl
                    accounts for OpenGL conventions.
    @param T_WM     The transform relating the model and world frames. For a
-                   geometry with identity scale, it should be equal to X_WG.
-   @param X_WG     The pose of the geometry in the world frame.
-   @param scale    The per-axis scale of the geometry.  */
+                   model with no scale (and no poses of its constituent parts),
+                   this would be equal to the X_WG pose provided by SceneGraph.
+   @param N_WM     Derived from T_WM, it transforms the model's normals into the
+                   world frame.  */
   virtual void DoSetModelViewMatrix(const Eigen::Matrix4f& /* X_CW */,
                                     const Eigen::Matrix4f& /* T_WM */,
-                                    const Eigen::Matrix4f& /* X_WG */,
-                                    const Eigen::Vector3d& /* scale */) const {}
+                                    const Eigen::Matrix3f& /* N_WM */) const {}
 
  private:
   friend class ShaderProgramTest;

--- a/geometry/render_gl/test/internal_opengl_geometry_test.cc
+++ b/geometry/render_gl/test/internal_opengl_geometry_test.cc
@@ -12,60 +12,116 @@ namespace render_gl {
 namespace internal {
 namespace {
 
+using Eigen::DiagonalMatrix;
+using Eigen::Matrix3f;
+using Eigen::Matrix4f;
 using Eigen::Vector3d;
+using Eigen::Vector3f;
+using Eigen::Vector4f;
 using math::RigidTransformd;
 using render::RenderLabel;
 
 // Note: All values in these tests are effectively garbage. They are not really
 // names of OpenGL objects. These tests merely exercise the functionality of the
-// OpenGlGeometry class which does not actually depend on the object names to
-// actually refer to objects in an OpenGL context.
+// OpenGlGeometry class which does not depend on the object names to actually
+// refer to objects in an OpenGL context.
 
 GTEST_TEST(OpenGlGeometryTest, Construction) {
-  const OpenGlGeometry default_geometry;
-  EXPECT_EQ(default_geometry.vertex_array, OpenGlGeometry::kInvalid);
-  EXPECT_EQ(default_geometry.vertex_buffer, OpenGlGeometry::kInvalid);
-  EXPECT_EQ(default_geometry.index_buffer, OpenGlGeometry::kInvalid);
-  EXPECT_EQ(default_geometry.index_buffer_size, 0);
-  EXPECT_EQ(default_geometry.v_count, 0);
-
-  const OpenGlGeometry geometry{1, 2, 3, 4, 7};
+  // clang-format off
+  const Matrix4f T_MN = (Matrix4f() << 1,  2,  3,  4,
+                                       5,  6,  7,  8,
+                                       9,  10, 11, 12,
+                                       13, 14, 15, 16).finished();
+  const Matrix3f N_MN = (Matrix3f() << 21, 22, 23,
+                                       24, 25, 26,
+                                       27, 28, 29).finished();
+  // clang-format on
+  const OpenGlGeometry geometry{.vertex_array = 1,
+                                .vertex_buffer = 2,
+                                .index_buffer = 3,
+                                .v_count = 4,
+                                .index_count = 5,
+                                .type = 17,
+                                .mode = 18,
+                                .T_MN = T_MN,
+                                .N_MN = N_MN};
   EXPECT_EQ(geometry.vertex_array, 1);
   EXPECT_EQ(geometry.vertex_buffer, 2);
   EXPECT_EQ(geometry.index_buffer, 3);
-  EXPECT_EQ(geometry.index_buffer_size, 4);
-  EXPECT_EQ(geometry.v_count, 7);
-
-  DRAKE_EXPECT_THROWS_MESSAGE(OpenGlGeometry(1, 2, 3, -1, 1),
-                              "Index buffer size must be non-negative");
+  EXPECT_EQ(geometry.v_count, 4);
+  EXPECT_EQ(geometry.index_count, 5);
+  EXPECT_EQ(geometry.type, 17);
+  EXPECT_EQ(geometry.mode, 18);
+  EXPECT_TRUE(CompareMatrices(geometry.T_MN, T_MN));
+  EXPECT_TRUE(CompareMatrices(geometry.N_MN, N_MN));
 }
 
 GTEST_TEST(OpenGlGeometryTest, IsDefined) {
   const GLuint kInvalid = OpenGlGeometry::kInvalid;
 
-  EXPECT_TRUE(OpenGlGeometry(1, 2, 3, 4, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, 3, 4, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, 3, 4, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(1, 2, kInvalid, 4, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, kInvalid, 3, 4, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, kInvalid, 4, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, kInvalid, 4, 1).is_defined());
-  EXPECT_FALSE(OpenGlGeometry(kInvalid, kInvalid, kInvalid, 4, 1).is_defined());
+  auto make_geo = [](GLuint a, GLuint b, GLuint c, int d, int e) {
+    return OpenGlGeometry{.vertex_array = a,
+                          .vertex_buffer = b,
+                          .index_buffer = c,
+                          .v_count = d,
+                          .index_count = e};
+  };
+
+  EXPECT_TRUE(make_geo(1, 2, 3, 4, 5).is_defined());
+  EXPECT_FALSE(make_geo(kInvalid, 2, 3, 4, 5).is_defined());
+  EXPECT_FALSE(make_geo(1, kInvalid, 3, 4, 5).is_defined());
+  EXPECT_FALSE(make_geo(1, 2, kInvalid, 4, 5).is_defined());
+  EXPECT_FALSE(make_geo(1, 2, 3, kInvalid, 5).is_defined());
+  EXPECT_FALSE(make_geo(1, 2, 3, 4, kInvalid).is_defined());
+  EXPECT_FALSE(make_geo(kInvalid, kInvalid, 3, 4, 5).is_defined());
+  EXPECT_FALSE(make_geo(kInvalid, 2, kInvalid, 4, 5).is_defined());
+  EXPECT_FALSE(make_geo(1, kInvalid, kInvalid, 4, 5).is_defined());
+  EXPECT_FALSE(make_geo(kInvalid, kInvalid, kInvalid, 4, 5).is_defined());
 }
 
 GTEST_TEST(OpenGlGeometryTest, ThrowIfUndefined) {
-  const OpenGlGeometry valid{1, 2, 3, 4, 1};
+  const OpenGlGeometry valid{.vertex_array = 1,
+                             .vertex_buffer = 2,
+                             .index_buffer = 3,
+                             .v_count = 4,
+                             .index_count = 5};
   EXPECT_NO_THROW(valid.throw_if_undefined("test message"));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      OpenGlGeometry().throw_if_undefined("default is undefined"),
+      OpenGlGeometry{.vertex_array = 1}.throw_if_undefined(
+          "default is undefined"),
       "default is undefined");
 }
 
-GTEST_TEST(OpenGlInstanceTest, Construction) {
+// We don't explicitly test construction as it is intended to simply used
+// designated initializers. But we do want to test the validation.
+GTEST_TEST(OpenGlInstanceTest, Validity) {
+  // We need a geometry to reference, but we don't need valid transforms.
+  // clang-format off
+  const Matrix4f T_MN = (Matrix4f() << 1,  2,  3,  4,
+                                       5,  6,  7,  8,
+                                       9,  10, 11, 12,
+                                       13, 14, 15, 16).finished();
+  const Matrix3f N_MN = (Matrix3f() << 21, 22, 23,
+                                       24, 25, 26,
+                                       27, 28, 29).finished();
+  // clang-format on
+  const OpenGlGeometry geometry{.vertex_array = 1,
+                                .vertex_buffer = 2,
+                                .index_buffer = 3,
+                                .v_count = 4,
+                                .index_count = 7,
+                                .type = 17,
+                                .mode = 18,
+                                .T_MN = T_MN,
+                                .N_MN = N_MN};
+  const Vector4f scale(10, 20, 30, 1.0);
+  const Matrix4f T_GN_expected = DiagonalMatrix<float, 4>(scale) * T_MN;
+  const Vector3f scale_inv(1.0 / scale.x(), 1.0 / scale.y(), 1.0 / scale.z());
+  const Matrix3f N_GN_expected = DiagonalMatrix<float, 3>(scale_inv) * N_MN;
+
   // This is a dummy index that doesn't reference into any particular geometry.
   const int geometry_index = 2;
   const RigidTransformd X_WG{Vector3d{-1, -2, 3}};
-  const Vector3d scale{0.25, 0.5, 0.75};
   // We'll create a pretend block of depth data; simply a double value with no
   // real meaning.
   const ShaderProgramData depth_data{ShaderId::get_new_id(),
@@ -75,13 +131,12 @@ GTEST_TEST(OpenGlInstanceTest, Construction) {
   const ShaderProgramData color_data(ShaderId::get_new_id(),
                                      AbstractValue::Make(33));
 
-  const OpenGlInstance instance{geometry_index, X_WG,       scale,
-                                color_data,     depth_data, label_data};
+  const OpenGlInstance instance(geometry_index, scale.head<3>(), geometry,
+                                color_data, depth_data, label_data);
 
   EXPECT_EQ(instance.geometry, geometry_index);
-  EXPECT_TRUE(
-      CompareMatrices(instance.X_WG.GetAsMatrix34(), X_WG.GetAsMatrix34()));
-  EXPECT_TRUE(CompareMatrices(instance.scale, scale));
+  EXPECT_TRUE(CompareMatrices(instance.T_GN, T_GN_expected));
+  EXPECT_TRUE(CompareMatrices(instance.N_GN, N_GN_expected));
 
   EXPECT_EQ(
       instance.shader_data[RenderType::kDepth].value().get_value<double>(),

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -1785,11 +1785,11 @@ TEST_F(RenderEngineGlTest, ConvexGeometryReuse) {
   const RenderEngineGlTester::Prop& prop1 = tester.GetVisual(id1);
   const RenderEngineGlTester::Prop& prop2 = tester.GetVisual(id2);
 
-  EXPECT_EQ(prop1.parts.size(), 1);
-  EXPECT_EQ(prop1.parts.size(), prop2.parts.size());
+  EXPECT_EQ(prop1.instances.size(), 1);
+  EXPECT_EQ(prop1.instances.size(), prop2.instances.size());
   // Different instances nevertheless share the same geometry.
-  EXPECT_NE(&prop1.parts[0].instance, &prop2.parts[0].instance);
-  EXPECT_EQ(prop1.parts[0].instance.geometry, prop2.parts[0].instance.geometry);
+  EXPECT_NE(&prop1.instances[0], &prop2.instances[0]);
+  EXPECT_EQ(prop1.instances[0].geometry, prop2.instances[0].geometry);
 }
 
 // Confirms that when requesting the same mesh multiple times, only a single
@@ -1816,11 +1816,11 @@ TEST_F(RenderEngineGlTest, MeshGeometryReuse) {
   const RenderEngineGlTester::Prop& prop1 = tester.GetVisual(id1);
   const RenderEngineGlTester::Prop& prop2 = tester.GetVisual(id2);
 
-  EXPECT_EQ(prop1.parts.size(), 1);
-  EXPECT_EQ(prop1.parts.size(), prop2.parts.size());
+  EXPECT_EQ(prop1.instances.size(), 1);
+  EXPECT_EQ(prop1.instances.size(), prop2.instances.size());
   // Different instances nevertheless share the same geometry.
-  EXPECT_NE(&prop1.parts[0].instance, &prop2.parts[0].instance);
-  EXPECT_EQ(prop1.parts[0].instance.geometry, prop2.parts[0].instance.geometry);
+  EXPECT_NE(&prop1.instances[0], &prop2.instances[0]);
+  EXPECT_EQ(prop1.instances[0].geometry, prop2.instances[0].geometry);
 }
 
 // Confirm the properties of the fallback camera using the following

--- a/geometry/render_gl/test/internal_shader_program_test.cc
+++ b/geometry/render_gl/test/internal_shader_program_test.cc
@@ -70,10 +70,10 @@ class TestShader final : public ShaderProgram {
   // against these values to make sure the right values are passed as expected.
   void SetExpectedModelViewComponents(const Eigen::Matrix4f& X_CW,
                                       const Eigen::Matrix4f& T_WM,
-                                      const Eigen::Matrix4f& X_WG) {
+                                      const Eigen::Matrix3f& N_WM) {
     X_CW_expected_ = X_CW;
     T_WM_expected_ = T_WM;
-    X_WG_expected_ = X_WG;
+    N_WM_expected_ = N_WM;
   }
 
  private:
@@ -99,12 +99,11 @@ class TestShader final : public ShaderProgram {
   // the right value is passed to the right parameter.
   void DoSetModelViewMatrix(const Eigen::Matrix4f& X_CW,
                             const Eigen::Matrix4f& T_WM,
-                            const Eigen::Matrix4f& X_WG,
-                            const Eigen::Vector3d&) const override {
+                            const Eigen::Matrix3f& N_WM) const override {
     do_mv_matrix_called_ = true;
     EXPECT_TRUE(CompareMatrices(X_CW, X_CW_expected_));
     EXPECT_TRUE(CompareMatrices(T_WM, T_WM_expected_));
-    EXPECT_TRUE(CompareMatrices(X_WG, X_WG_expected_));
+    EXPECT_TRUE(CompareMatrices(N_WM, N_WM_expected_));
   }
 
   bool do_configure_uniforms_called_{false};
@@ -114,7 +113,7 @@ class TestShader final : public ShaderProgram {
 
   Eigen::Matrix4f X_CW_expected_;
   Eigen::Matrix4f T_WM_expected_;
-  Eigen::Matrix4f X_WG_expected_;
+  Eigen::Matrix3f N_WM_expected_;
   int magic_number_{};
 };
 
@@ -140,6 +139,7 @@ constexpr char kFragmentSource[] = R"""(
 
 }  // namespace
 
+using Eigen::Matrix3f;
 using Eigen::Matrix4f;
 using Eigen::Vector3d;
 using std::string;
@@ -441,11 +441,12 @@ TEST_F(ShaderProgramTest, SetModelViewMatrix) {
   const Vector3d scale(0.5, 2, 4);
   Matrix4f T_WM = X_WG.GetAsMatrix4().cast<float>();  // Except for the scale.
   for (int i = 0; i < 3; ++i) T_WM.col(i) *= scale(i);
+  Matrix3f N_WM = X_WG.rotation().matrix().cast<float>();
+  for (int i = 0; i < 3; ++i) N_WM.col(i) /= scale(i);
   ASSERT_FALSE(test_shader.DoSetModelViewMatrixCalled());
-  test_shader.SetExpectedModelViewComponents(X_CW, T_WM,
-                                             X_WG.GetAsMatrix4().cast<float>());
+  test_shader.SetExpectedModelViewComponents(X_CW, T_WM, N_WM);
   shader.Use();
-  shader.SetModelViewMatrix(X_CW, X_WG, scale);
+  shader.SetModelViewMatrix(X_CW, T_WM, N_WM);
   shader.Unuse();
   ASSERT_TRUE(test_shader.DoSetModelViewMatrixCalled());
 


### PR DESCRIPTION
Previously, RenderEngineGl would assume a great deal about the geometries and how they get posed in the world. This changes those assumptions:

- Geometry primitives are no longer assumed by RenderEngineGl::RenderAt().
  - Each OpenGlGeometry records the nature of its primitives and that is used at render time.
- The vertex attributes can be organized more generally in a dat array. I.e, rather than the previous hard-coded grouping, a source could choose to present them interleaved (this can happen in future glTF parsing).
  - Each OpenGlGeometry stores the interepretation of its vertex data as stored in the associated buffer object (to facilitate cloning).
- We no longer assume the OpenGlGeometry data is measured and expressed in a frame that only differs from Drake's geometry frame by an optional scale factor.
   - A single Drake "geometry" can be comprised of multiple OpenGlInstances each with their own poses. And the underlying geometry can also have the vertex information expressed in yet another frame.
   - OpenGlGeometry and OpenGlInstance pick up new frame semantics to track this more general articulation of geometry.
   - This led to a redundancy in RenderEngineGl::Part, and that struct has been removed.
   - Shader programs have been updated to accept the various model transforms directly, rather than attempting to compute them on the fly.

Relates #20185 and #21520.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21522)
<!-- Reviewable:end -->
