### PR TITLE
[parsing] Fix name clash of collision filter groups

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -155,6 +155,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:serialize_pybind",
+        "//bindings/pydrake/common:sorted_pair_pybind",
     ],
     cc_srcs = ["parsing_py.cc"],
     package_info = PACKAGE_INFO,

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -1,5 +1,6 @@
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
+#include "drake/bindings/pydrake/common/sorted_pair_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/parsing/package_map.h"
@@ -23,6 +24,24 @@ PYBIND11_MODULE(parsing, m) {
   constexpr auto& doc = pydrake_doc.drake.multibody;
 
   py::module::import("pydrake.common.schema");
+
+  // CollisionFilterGroups
+  {
+    using Class = CollisionFilterGroups;
+    constexpr auto& cls_doc = doc.CollisionFilterGroups;
+    auto cls = py::class_<Class>(m, "CollisionFilterGroups", cls_doc.doc);
+    cls  // BR
+        .def(py::init<>(), cls_doc.ctor.doc)
+        .def("AddGroup", &Class::AddGroup, py::arg("name"), py::arg("members"),
+            cls_doc.AddGroup.doc)
+        .def("AddExclusionPair", &Class::AddExclusionPair, py::arg("pair"),
+            cls_doc.AddExclusionPair.doc)
+        .def("empty", &Class::empty, cls_doc.empty.doc)
+        .def("groups", &Class::groups, cls_doc.groups.doc)
+        .def("exclusion_pairs", &Class::exclusion_pairs,
+            cls_doc.exclusion_pairs.doc)
+        .def("__str__", &Class::to_string, cls_doc.to_string.doc);
+  }
 
   // PackageMap
   {
@@ -121,7 +140,9 @@ PYBIND11_MODULE(parsing, m) {
         .def("SetAutoRenaming", &Class::SetAutoRenaming, py::arg("value"),
             cls_doc.SetAutoRenaming.doc)
         .def("GetAutoRenaming", &Class::GetAutoRenaming,
-            cls_doc.GetAutoRenaming.doc);
+            cls_doc.GetAutoRenaming.doc)
+        .def("GetCollisionFilterGroups", &Class::GetCollisionFilterGroups,
+            cls_doc.GetCollisionFilterGroups.doc);
   }
 
   // Model Directives

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -7,6 +7,7 @@ from pydrake.multibody.parsing import (
     AddModel,
     AddModelInstance,
     AddWeld,
+    CollisionFilterGroups,
     FlattenModelDirectives,
     GetScopedFrameByName,
     GetScopedFrameByNameMaybe,
@@ -36,6 +37,18 @@ from pydrake.multibody.plant import (
 
 
 class TestParsing(unittest.TestCase):
+
+    def test_collision_filter_groups(self):
+        dut = CollisionFilterGroups()
+        dut.AddGroup(name="a", members={"b", "c"})
+        dut.AddExclusionPair(pair=("d", "e"))
+        self.assertFalse(dut.empty())
+        groups = dut.groups()
+        self.assertEqual(len(groups), 1)
+        pairs = dut.exclusion_pairs()
+        self.assertEqual(len(pairs), 1)
+        report = str(dut)
+        self.assertNotEqual(len(report), 0)
 
     def test_package_map(self):
         # Simple coverage test for constructors.
@@ -203,6 +216,12 @@ class TestParsing(unittest.TestCase):
         parser.SetAutoRenaming(value=True)
         results = parser.AddModelsFromString(model, 'urdf')
         self.assertTrue(plant.HasModelInstanceNamed('robot_1'))
+
+    def test_get_collision_filter_groups(self):
+        plant = MultibodyPlant(time_step=0.01)
+        parser = Parser(plant=plant)
+        groups = parser.GetCollisionFilterGroups()
+        self.assertTrue(groups.empty())
 
     def test_model_instance_info(self):
         """Checks that ModelInstanceInfo bindings exist."""

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -105,14 +105,18 @@ drake_cc_library(
     srcs = ["collision_filter_groups.cc"],
     hdrs = ["collision_filter_groups.h"],
     visibility = ["//visibility:public"],
-    deps = [
+    interface_deps = [
+        "//common:copyable_unique_ptr",
         "//common:essential",
         "//common:sorted_pair",
     ],
+    deps = [
+        ":detail_collision_filter_groups_impl",
+    ],
 )
+
 # For simplicity in dependency management (e.g., prevent exposing `sdformat`),
 # we make all `detail_*` libraries private. For more info, see #7451.
-
 drake_cc_library(
     name = "detail_misc",
     srcs = [
@@ -134,6 +138,7 @@ drake_cc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":collision_filter_groups",
+        ":detail_collision_filter_groups_impl",
         ":package_map",
         "//common:diagnostic_policy",
         "//common:essential",
@@ -143,6 +148,26 @@ drake_cc_library(
         "//multibody/tree:scoped_name",
         "@sdformat_internal//:sdformat",
         "@tinyxml2_internal//:tinyxml2",
+    ],
+)
+
+drake_cc_library(
+    name = "detail_collision_filter_groups_impl",
+    srcs = [
+        "detail_collision_filter_groups_impl.cc",
+        "detail_instanced_name.cc",
+    ],
+    hdrs = [
+        "detail_collision_filter_groups_impl.h",
+        "detail_instanced_name.h",
+    ],
+    internal = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        "//common:essential",
+        "//common:sorted_pair",
+        "//multibody/tree:multibody_tree_indexes",
+        "//multibody/tree:scoped_name",
     ],
 )
 
@@ -492,6 +517,7 @@ drake_cc_googletest(
     data = [
         ":test_models",
         "//multibody/benchmarks/acrobot:models",
+        "@drake_models//:iiwa_description",
     ] + _DM_CONTROL_MUJOCO_FILES,
     deps = [
         ":parser",
@@ -728,6 +754,18 @@ drake_cc_googletest(
     name = "collision_filter_groups_test",
     deps = [
         ":collision_filter_groups",
+        ":detail_collision_filter_groups_impl",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_instanced_name_test",
+    data = [
+        ":test_models",
+    ],
+    deps = [
+        ":detail_collision_filter_groups_impl",
+        "//common/test_utilities",
     ],
 )
 

--- a/multibody/parsing/collision_filter_groups.cc
+++ b/multibody/parsing/collision_filter_groups.cc
@@ -1,45 +1,71 @@
 #include "drake/multibody/parsing/collision_filter_groups.h"
 
-#include <utility>
+#include <memory>
 
-#include <fmt/format.h>
+#include "drake/multibody/parsing/detail_collision_filter_groups_impl.h"
 
 namespace drake {
 namespace multibody {
 
-bool CollisionFilterGroups::operator==(const CollisionFilterGroups& rhs) const {
-  return std::tie(groups_, pairs_) == std::tie(rhs.groups_, rhs.pairs_);
+using internal::CollisionFilterGroupsImpl;
+
+CollisionFilterGroups::CollisionFilterGroups()
+    : impl_(std::make_unique<CollisionFilterGroupsImpl<std::string>>()) {}
+CollisionFilterGroups::~CollisionFilterGroups() = default;
+
+CollisionFilterGroups::CollisionFilterGroups(const CollisionFilterGroups&) =
+    default;
+CollisionFilterGroups& CollisionFilterGroups::operator=(
+    const CollisionFilterGroups&) = default;
+
+// Move operations must be careful to preserve the non-null invariant.
+CollisionFilterGroups::CollisionFilterGroups(CollisionFilterGroups&& other) {
+  impl_ = std::move(other.impl_);
+  other.impl_ = std::make_unique<CollisionFilterGroupsImpl<std::string>>();
+}
+CollisionFilterGroups& CollisionFilterGroups::operator=(
+    CollisionFilterGroups&& other) {
+  std::swap(impl_, other.impl_);
+  return *this;
 }
 
-void CollisionFilterGroups::AddGroup(std::string_view name,
-                                     const std::set<std::string> members) {
-  std::string name_str(name);
-  DRAKE_DEMAND(!groups_.contains(name_str));
-  groups_.insert({name_str, std::move(members)});
+// The "internal use only" move constructor.
+CollisionFilterGroups::CollisionFilterGroups(
+    CollisionFilterGroupsImpl<std::string>&& impl)
+    : impl_(std::make_unique<CollisionFilterGroupsImpl<std::string>>(
+          std::move(impl))) {}
+
+bool CollisionFilterGroups::operator==(
+    const CollisionFilterGroups& that) const {
+  return *impl_ == *that.impl_;
+}
+
+void CollisionFilterGroups::AddGroup(const std::string& name,
+                                     const std::set<std::string>& members) {
+  impl_->AddGroup(name, members);
 }
 
 void CollisionFilterGroups::AddExclusionPair(
-    const SortedPair<std::string> pair) {
-  pairs_.insert(std::move(pair));
+    const SortedPair<std::string>& pair) {
+  impl_->AddExclusionPair(pair);
 }
 
 bool CollisionFilterGroups::empty() const {
-  return groups_.empty() && pairs_.empty();
+  return impl_->empty();
 }
 
-std::ostream& operator<<(std::ostream& os, const CollisionFilterGroups& g) {
-  os << "\nCollision filter groups:\n";
-  for (const auto&  [name, members] : g.groups()) {
-    os << fmt::format("    {}\n", name);
-    for (const auto& member : members) {
-      os << fmt::format("        {}\n", member);
-    }
-  }
-  os << "Collision filter exclusion pairs:\n";
-  for (const auto& pair : g.exclusion_pairs()) {
-    os << fmt::format("    {}, {}\n", pair.first(), pair.second());
-  }
-  return os;
+const std::map<std::string, std::set<std::string>>&
+CollisionFilterGroups::groups() const {
+  return impl_->groups();
+}
+
+const std::set<SortedPair<std::string>>&
+CollisionFilterGroups::exclusion_pairs() const {
+  return impl_->exclusion_pairs();
+}
+
+std::string CollisionFilterGroups::to_string() const {
+  return impl_->to_string();
 }
 
 }  // namespace multibody

--- a/multibody/parsing/collision_filter_groups.h
+++ b/multibody/parsing/collision_filter_groups.h
@@ -3,32 +3,39 @@
 #include <map>
 #include <set>
 #include <string>
-#include <string_view>
+#include <utility>
 
+#include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/fmt.h"
 #include "drake/common/sorted_pair.h"
 
 namespace drake {
 namespace multibody {
 
+namespace internal {
+template <typename T>
+class CollisionFilterGroupsImpl;
+}  // namespace internal
+
 /** This is storage for parsed collision filter groups and group pairs. This
 data may be useful to users needing to compose further collision filters in
 code, without having to restate the data already captured in model files.
 
-The contents of this object will be made up of fully-qualified scoped names of
-collision filter groups and bodies.
+The contents of this object will be made up of names of collision filter groups
+and bodies. By convention, the name strings are treated as scoped names.
 
 Note that this object enforces few invariants on the data. In the expected
 workflow, the parser will add groups and exclusion pairs found during
-parsing. The only condition checked here is that a group with a given
-fully-qualified name is only added once.
+parsing. The only condition checked here is that a group with a given name is
+only added once.
 */
 class CollisionFilterGroups {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterGroups)
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterGroups)
 
-  CollisionFilterGroups() = default;
+  CollisionFilterGroups();
+  ~CollisionFilterGroups();
 
   bool operator==(const CollisionFilterGroups&) const;
 
@@ -37,8 +44,7 @@ class CollisionFilterGroups {
   @param members the fully-qualified scoped names of the member bodies.
   @pre name is not already a defined group in this object.
   */
-  void AddGroup(std::string_view name,
-                const std::set<std::string> members);
+  void AddGroup(const std::string& name, const std::set<std::string>& members);
 
   /** Adds an exclusion pair between two collision filter groups.
   @param pair a pair of fully-qualified scoped names of groups.
@@ -46,36 +52,34 @@ class CollisionFilterGroups {
   a rule where all members of the group exclude each other. Adding an already
   defined pair does nothing.
   */
-  void AddExclusionPair(const SortedPair<std::string> pair);
+  void AddExclusionPair(const SortedPair<std::string>& pair);
 
   /** @returns true iff both groups() and exclusion_pairs() are empty. */
   bool empty() const;
 
   /** @returns the groups stored by prior calls to AddGroup(). */
-  const std::map<std::string, std::set<std::string>>& groups() const {
-    return groups_;
-  }
+  const std::map<std::string, std::set<std::string>>& groups() const;
 
   /** @returns the pairs stored by prior calls to AddExclusionPair(). */
-  const std::set<SortedPair<std::string>>& exclusion_pairs() const {
-    return pairs_;
-  }
+  const std::set<SortedPair<std::string>>& exclusion_pairs() const;
+
+  /** @returns a multi-line human-readable representation of this' contents. */
+  std::string to_string() const;
+
+#ifndef DRAKE_DOXYGEN_CXX
+  /* (Internal use only) Internal move-constructor for efficiency. */
+  explicit CollisionFilterGroups(
+      internal::CollisionFilterGroupsImpl<std::string>&&);
+#endif
 
  private:
-  std::map<std::string, std::set<std::string>> groups_;
-  std::set<SortedPair<std::string>> pairs_;
+  // To reduce implementation complexity, the impl_ pointer must never be null.
+  // Otherwise, every method would need to check for null and implement
+  // alternative behavior.
+  copyable_unique_ptr<internal::CollisionFilterGroupsImpl<std::string>> impl_;
 };
-
-/** Emits a multi-line, human-readable report of CollisionFilterGroups
-content. */
-std::ostream& operator<<(std::ostream& os, const CollisionFilterGroups& g);
 
 }  // namespace multibody
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::multibody::CollisionFilterGroups>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::multibody, CollisionFilterGroups, x, x.to_string())

--- a/multibody/parsing/detail_collision_filter_group_resolver.cc
+++ b/multibody/parsing/detail_collision_filter_group_resolver.cc
@@ -15,9 +15,8 @@ using drake::internal::DiagnosticPolicy;
 using geometry::GeometrySet;
 
 CollisionFilterGroupResolver::CollisionFilterGroupResolver(
-    MultibodyPlant<double>* plant,
-    CollisionFilterGroups* group_output)
-    : plant_(plant), group_output_(group_output) {
+    MultibodyPlant<double>* plant)
+    : plant_(plant) {
   DRAKE_DEMAND(plant != nullptr);
   minimum_model_instance_index_ =
       ModelInstanceIndex(plant->num_model_instances());
@@ -129,7 +128,8 @@ void CollisionFilterGroupResolver::AddPair(
   pairs_.insert({name_a, name_b});
 }
 
-void CollisionFilterGroupResolver::Resolve(const DiagnosticPolicy& diagnostic) {
+CollisionFilterGroupsImpl<InstancedName> CollisionFilterGroupResolver::Resolve(
+    const DiagnosticPolicy& diagnostic) {
   DRAKE_DEMAND(!is_resolved_);
   is_resolved_ = true;
 
@@ -204,24 +204,47 @@ void CollisionFilterGroupResolver::Resolve(const DiagnosticPolicy& diagnostic) {
     }
   }
 
-  // Save the groups to report at API level.
-  for (const auto& [name, members] : groups_) {
-    group_output_->AddGroup(name, members.body_names);
-  }
-
-  // Now that the groups are complete, evaluate the pairs into plant rules, and
-  // save them for later reporting.
+  // Now that the groups are complete, evaluate the pairs into plant
+  // rules. Remove any pairs with broken names.
+  std::set<SortedPair<std::string>> bad_pairs;
   for (const auto& pair : pairs_) {
     const auto& [name_a, name_b] = pair;
     const GroupData* set_a = FindGroup(diagnostic, name_a);
     const GroupData* set_b = FindGroup(diagnostic, name_b);
     if (set_a == nullptr || set_b == nullptr) {
+      bad_pairs.insert(pair);
       continue;
     }
     plant_->ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
         {name_a, set_a->geometries}, {name_b, set_b->geometries});
-    group_output_->AddExclusionPair(pair);
   }
+  for (const auto& pair : bad_pairs) {
+    pairs_.erase(pair);
+  }
+
+  // Return the info, so the Parser can report back to users.
+  CollisionFilterGroupsImpl<std::string> result;
+  for (const auto& [name, members] : groups_) {
+    result.AddGroup(name, members.body_names);
+  }
+  for (const auto& pair : pairs_) {
+    result.AddExclusionPair(pair);
+  }
+  return result.template Convert<InstancedName>(
+      [this](const std::string& input) {
+        InstancedName instanced_name;
+        auto scoped = ScopedName::Parse(input);
+        if (plant_->HasModelInstanceNamed(scoped.get_namespace())) {
+          instanced_name.index =
+              plant_->GetModelInstanceByName(scoped.get_namespace());
+        } else {
+          // If we fail this demand, we forgot to remove bad data before
+          // building the `result`.
+          DRAKE_DEMAND(scoped.get_namespace().empty());
+        }
+        instanced_name.name = scoped.get_element();
+        return instanced_name;
+      });
 }
 
 std::string CollisionFilterGroupResolver::FullyQualify(

--- a/multibody/parsing/detail_collision_filter_group_resolver.h
+++ b/multibody/parsing/detail_collision_filter_group_resolver.h
@@ -10,7 +10,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/sorted_pair.h"
 #include "drake/geometry/geometry_set.h"
-#include "drake/multibody/parsing/collision_filter_groups.h"
+#include "drake/multibody/parsing/detail_collision_filter_groups_impl.h"
 #include "drake/multibody/parsing/detail_strongly_connected_components.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
@@ -60,11 +60,9 @@ class CollisionFilterGroupResolver {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CollisionFilterGroupResolver)
 
-  // Both parameters are aliased, and must outlive the resolver.
+  // The plant parameter is aliased, and must outlive the resolver.
   // @pre plant is not nullptr.
-  // @pre group_output is not nullptr.
-  CollisionFilterGroupResolver(MultibodyPlant<double>* plant,
-                               CollisionFilterGroups* group_output);
+  explicit CollisionFilterGroupResolver(MultibodyPlant<double>* plant);
 
   ~CollisionFilterGroupResolver();
 
@@ -118,9 +116,10 @@ class CollisionFilterGroupResolver {
       std::optional<ModelInstanceIndex> model_instance);
 
   // Resolves group pairs to rules. Emits diagnostics for undefined groups.
-  //
-  // @pre cannot have be previously invoked on this instance.
-  void Resolve(const drake::internal::DiagnosticPolicy& diagnostic);
+  // @pre cannot have been previously invoked on this instance.
+  // @returns the collision filter groups found after resolution.
+  CollisionFilterGroupsImpl<InstancedName> Resolve(
+      const drake::internal::DiagnosticPolicy& diagnostic);
 
  private:
   struct GroupData {
@@ -140,7 +139,6 @@ class CollisionFilterGroupResolver {
                                     ModelInstanceIndex model_instance) const;
 
   MultibodyPlant<double>* const plant_;
-  CollisionFilterGroups* const group_output_;
 
   std::map<std::string, GroupData> groups_;
   std::set<SortedPair<std::string>> pairs_;

--- a/multibody/parsing/detail_collision_filter_groups_impl.cc
+++ b/multibody/parsing/detail_collision_filter_groups_impl.cc
@@ -1,0 +1,102 @@
+#include "drake/multibody/parsing/detail_collision_filter_groups_impl.h"
+
+#include <sstream>
+
+#include "drake/common/fmt.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+CollisionFilterGroupsImpl<T>::CollisionFilterGroupsImpl() = default;
+
+template <typename T>
+CollisionFilterGroupsImpl<T>::~CollisionFilterGroupsImpl() = default;
+
+template <typename T>
+bool CollisionFilterGroupsImpl<T>::operator==(
+    const CollisionFilterGroupsImpl&) const = default;
+
+template <typename T>
+void CollisionFilterGroupsImpl<T>::AddGroup(const T& name,
+                                            const std::set<T>& members) {
+  DRAKE_THROW_UNLESS(!groups_.contains(name));
+  groups_.insert({name, members});
+}
+
+template <typename T>
+void CollisionFilterGroupsImpl<T>::AddExclusionPair(const SortedPair<T>& pair) {
+  pairs_.insert(pair);
+}
+
+template <typename T>
+std::string CollisionFilterGroupsImpl<T>::to_string() const {
+  std::stringstream ss;
+  ss << "\nCollision filter groups:\n";
+  for (const auto& [name, members] : groups()) {
+    ss << fmt::format("    {}\n", name);
+    for (const auto& member : members) {
+      ss << fmt::format("        {}\n", member);
+    }
+  }
+  ss << "Collision filter exclusion pairs:\n";
+  for (const auto& pair : exclusion_pairs()) {
+    ss << fmt::format("    {}, {}\n", pair.first(), pair.second());
+  }
+  return ss.str();
+}
+
+template <typename T>
+void CollisionFilterGroupsImpl<T>::Merge(
+    const CollisionFilterGroupsImpl& source) {
+  for (const auto& [group_name, members] : source.groups()) {
+    this->AddGroup(group_name, members);
+  }
+  for (const auto& exclusion_pair : source.exclusion_pairs()) {
+    this->AddExclusionPair(exclusion_pair);
+  }
+}
+
+template <typename T>
+template <typename U>
+auto CollisionFilterGroupsImpl<T>::Convert(
+    const std::function<U(const T&)>& name_converter) const
+    -> CollisionFilterGroupsImpl<U> {
+  CollisionFilterGroupsImpl<U> result;
+  for (const auto& [group_name, members] : groups()) {
+    std::set<U> result_members;
+    for (const auto& member : members) {
+      result_members.insert(name_converter(member));
+    }
+    result.AddGroup(name_converter(group_name), result_members);
+  }
+  for (const auto& [a, b] : exclusion_pairs()) {
+    result.AddExclusionPair({name_converter(a), name_converter(b)});
+  }
+  return result;
+}
+
+// Instantiations used by the parser.
+template class CollisionFilterGroupsImpl<std::string>;
+template class CollisionFilterGroupsImpl<InstancedName>;
+template auto CollisionFilterGroupsImpl<std::string>::Convert(
+    const std::function<InstancedName(const std::string&)>& name_converter)
+    const -> CollisionFilterGroupsImpl<InstancedName>;
+template auto CollisionFilterGroupsImpl<InstancedName>::Convert(
+    const std::function<std::string(const InstancedName&)>& name_converter)
+    const -> CollisionFilterGroupsImpl<std::string>;
+
+// Instantiations used by our unit test.
+template class CollisionFilterGroupsImpl<double>;
+template class CollisionFilterGroupsImpl<int>;
+template auto CollisionFilterGroupsImpl<int>::Convert(
+    const std::function<double(const int&)>& name_converter) const
+    -> CollisionFilterGroupsImpl<double>;
+template auto CollisionFilterGroupsImpl<double>::Convert(
+    const std::function<int(const double&)>& name_converter) const
+    -> CollisionFilterGroupsImpl<int>;
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_collision_filter_groups_impl.h
+++ b/multibody/parsing/detail_collision_filter_groups_impl.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/sorted_pair.h"
+#include "drake/multibody/parsing/detail_instanced_name.h"
+#include "drake/multibody/tree/scoped_name.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* Implementation of multibody::CollisionFilterGroups. See that class for full
+documentation.
+
+@tparam T the type used for naming groups and members, which must be either
+`std::string` or `InstancedName`. (For the purposes of our own unit test, we
+also allow `int` and `double` but those are not actually used by the Parser.)
+
+Internal to the parser, we use CollisionFilterGroupsImpl<InstanceName> so that
+we can defend against model instance renames. When the user asks for the groups,
+we copy it to a CollisionFilterGroupsImpl<std::string> for their convenience. */
+template <typename T>
+class CollisionFilterGroupsImpl {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterGroupsImpl)
+
+  CollisionFilterGroupsImpl();
+  ~CollisionFilterGroupsImpl();
+
+  bool operator==(const CollisionFilterGroupsImpl&) const;  // = default;
+
+  void AddGroup(const T& name, const std::set<T>& members);
+
+  void AddExclusionPair(const SortedPair<T>& pair);
+
+  bool empty() const { return groups_.empty() && pairs_.empty(); }
+
+  const std::map<T, std::set<T>>& groups() const { return groups_; }
+
+  const std::set<SortedPair<T>>& exclusion_pairs() const { return pairs_; }
+
+  std::string to_string() const;
+
+  /* Merge two collision filter groups into one. This function is NOT part of
+  the public-facing CollisionFilterGroups API; it's an internal detail.
+  @param source a groups object to be merged into `this`.
+  @pre The group names in `*this` and source must be disjoint sets. */
+  void Merge(const CollisionFilterGroupsImpl& source);
+
+  /* Copies this from type <T> to type <U>. This function is NOT part of the
+  public-facing CollisionFilterGroups API; it's an internal detail. */
+  template <typename U>
+  auto Convert(const std::function<U(const T&)>& name_converter) const
+      -> CollisionFilterGroupsImpl<U>;
+
+ private:
+  std::map<T, std::set<T>> groups_;
+  std::set<SortedPair<T>> pairs_;
+};
+
+/* Copies `other` from type <InstancedName> to type <std::string>, using
+the given plant to lookup model instance names. */
+template <typename MultibodyPlantDeferred>
+CollisionFilterGroupsImpl<std::string> ConvertInstancedNamesToStrings(
+    const CollisionFilterGroupsImpl<InstancedName>& other,
+    const MultibodyPlantDeferred& plant) {
+  auto name_converter = [&plant](const InstancedName& instanced_name) {
+    return instanced_name.index.has_value()
+               ? std::string{ScopedName::Join(plant.GetModelInstanceName(
+                                                  *instanced_name.index),
+                                              instanced_name.name)
+                                 .get_full()}
+               : instanced_name.name;
+  };
+  return other.template Convert<std::string>(name_converter);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_FORMATTER_AS(typename T, drake::multibody::internal,
+                   CollisionFilterGroupsImpl<T>, x, x.to_string())

--- a/multibody/parsing/detail_composite_parse.cc
+++ b/multibody/parsing/detail_composite_parse.cc
@@ -14,13 +14,16 @@ std::unique_ptr<CompositeParse> CompositeParse::MakeCompositeParse(
 }
 
 CompositeParse::CompositeParse(Parser* parser)
-    : resolver_(&parser->plant(), &parser->collision_filter_groups_),
+    : parser_(parser),
+      resolver_(&parser->plant()),
       options_({parser->GetAutoRenaming()}),
       workspace_(options_, parser->package_map(), parser->diagnostic_policy_,
                  &parser->plant(), &resolver_, SelectParser) {}
 
-CompositeParse::~CompositeParse() {
-  resolver_.Resolve(workspace_.diagnostic);
+CompositeParse::~CompositeParse() = default;
+
+void CompositeParse::Finish() {
+  parser_->ResolveCollisionFilterGroupsFromCompositeParse(&resolver_);
 }
 
 }  // namespace internal

--- a/multibody/parsing/detail_composite_parse.h
+++ b/multibody/parsing/detail_composite_parse.h
@@ -21,6 +21,11 @@ class CompositeParse {
   // Build and return a new composite parse object.
   static std::unique_ptr<CompositeParse> MakeCompositeParse(Parser* parser);
 
+  // Prior to destroying this object, users of this class should call Finish()
+  // exactly once, to complete our interaction with the Parser. This operation
+  // can throw an exception, so must NOT be done during stack unwinding.
+  void Finish();
+
   ~CompositeParse();
 
   // @returns a const reference to a workspace. Note that some objects pointed
@@ -31,6 +36,7 @@ class CompositeParse {
  private:
   explicit CompositeParse(Parser* parser);
 
+  Parser* const parser_;
   CollisionFilterGroupResolver resolver_;
   const ParsingOptions options_;
   const ParsingWorkspace workspace_;

--- a/multibody/parsing/detail_instanced_name.cc
+++ b/multibody/parsing/detail_instanced_name.cc
@@ -1,0 +1,38 @@
+#include "drake/multibody/parsing/detail_instanced_name.h"
+
+#include <cstring>
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Apple Xcode fails to correctly implement <=> for either
+// std::optional (prior to 15.3) or std::string (prior to 15.2
+// maybe?), so the default implementation of <=> here gets
+// "implicitly deleted", leading to a train of compile errors. So,
+// until Ventura support ends, write an explicit implementation
+// instead.
+//
+// TODO(rpoyner-tri): replace explicit implementation with compiler
+// default once macOS Ventura support ends.
+std::strong_ordering InstancedName::operator<=>(
+    const InstancedName& that) const {
+  if (index.has_value() && that.index.has_value()) {
+    if (auto cmp = (*index <=> *that.index); cmp != 0) {
+      return cmp;
+    }
+  }
+  if (auto cmp = (index.has_value() <=> that.index.has_value()); cmp != 0) {
+    return cmp;
+  }
+  return std::strcmp(name.c_str(), that.name.c_str()) <=> 0;
+}
+
+std::string InstancedName::to_string() const {
+  return fmt::format(
+      "[{}, {}]", index.has_value() ? fmt::to_string(*index) : "nullopt", name);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/detail_instanced_name.h
+++ b/multibody/parsing/detail_instanced_name.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <compare>
+#include <optional>
+#include <string>
+
+#include "drake/common/fmt.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Describes a name as found during parsing, together with index of the model
+// where it was found. It purposely does not record the model by name, since
+// model renaming via the plant could invalidate such names.
+struct InstancedName {
+  std::optional<ModelInstanceIndex> index;  // Empty means global name.
+  std::string name;
+
+  bool operator==(const InstancedName&) const = default;
+  // TODO(rpoyner-tri): replace explicit implementation with compiler
+  // default once macOS Ventura support ends.
+  std::strong_ordering operator<=>(const InstancedName& that) const;
+
+  std::string to_string() const;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake::multibody::internal, InstancedName, x,
+                   x.to_string())

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -2,10 +2,13 @@
 
 #include <optional>
 #include <set>
+#include <utility>
 
 #include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
+#include "drake/multibody/parsing/detail_collision_filter_groups_impl.h"
 #include "drake/multibody/parsing/detail_common.h"
 #include "drake/multibody/parsing/detail_composite_parse.h"
+#include "drake/multibody/parsing/detail_instanced_name.h"
 #include "drake/multibody/parsing/detail_parsing_workspace.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
 #include "drake/multibody/parsing/detail_select_parser.h"
@@ -16,10 +19,20 @@ namespace multibody {
 using drake::internal::DiagnosticDetail;
 using drake::internal::DiagnosticPolicy;
 using internal::CollisionFilterGroupResolver;
+using internal::CollisionFilterGroupsImpl;
 using internal::DataSource;
+using internal::InstancedName;
 using internal::ParserInterface;
 using internal::ParsingWorkspace;
 using internal::SelectParser;
+
+// Storage for internals that need to have the same lifetime as a Parser
+// instance, but avoid adding internal namespace details to parser.h.
+struct Parser::ParserInternalData {
+  // Collision filter groups that use InstancedName. This representation is
+  // invariant with respect to model renaming via the plant.
+  CollisionFilterGroupsImpl<InstancedName> collision_filter_groups_storage_;
+};
 
 Parser::Parser(MultibodyPlant<double>* plant,
                geometry::SceneGraph<double>* scene_graph)
@@ -32,7 +45,7 @@ Parser::Parser(MultibodyPlant<double>* plant,
 Parser::Parser(MultibodyPlant<double>* plant,
                geometry::SceneGraph<double>* scene_graph,
                std::string_view model_name_prefix)
-    : plant_(plant) {
+    : plant_(plant), data_(new Parser::ParserInternalData) {
   DRAKE_THROW_UNLESS(plant != nullptr);
 
   if (!model_name_prefix.empty()) {
@@ -54,14 +67,23 @@ Parser::Parser(MultibodyPlant<double>* plant,
   diagnostic_policy_.SetActionForWarnings(warnings_maybe_strict);
 }
 
+Parser::~Parser() {}
+
+CollisionFilterGroups Parser::GetCollisionFilterGroups() const {
+  return CollisionFilterGroups(ConvertInstancedNamesToStrings(
+      data_->collision_filter_groups_storage_, *plant_));
+}
+
 std::vector<ModelInstanceIndex> Parser::AddModels(
     const std::filesystem::path& file_name) {
   const std::string filename_string{file_name.string()};
   DataSource data_source(DataSource::kFilename, &filename_string);
   ParserInterface& parser = SelectParser(diagnostic_policy_, file_name);
   auto composite = internal::CompositeParse::MakeCompositeParse(this);
-  return parser.AddAllModels(data_source, model_name_prefix_,
-                             composite->workspace());
+  auto result = parser.AddAllModels(data_source, model_name_prefix_,
+                                    composite->workspace());
+  composite->Finish();
+  return result;
 }
 
 std::vector<ModelInstanceIndex> Parser::AddModelsFromUrl(
@@ -80,8 +102,25 @@ std::vector<ModelInstanceIndex> Parser::AddModelsFromString(
   const std::string pseudo_name(data_source.GetStem() + "." + file_type);
   ParserInterface& parser = SelectParser(diagnostic_policy_, pseudo_name);
   auto composite = internal::CompositeParse::MakeCompositeParse(this);
-  return parser.AddAllModels(data_source, model_name_prefix_,
-                             composite->workspace());
+  auto result = parser.AddAllModels(data_source, model_name_prefix_,
+                                    composite->workspace());
+  composite->Finish();
+  return result;
+}
+
+void Parser::ResolveCollisionFilterGroupsFromCompositeParse(
+    internal::CollisionFilterGroupResolver* resolver) {
+  DRAKE_DEMAND(resolver != nullptr);
+
+  const CollisionFilterGroupsImpl<internal::InstancedName> groups =
+      resolver->Resolve(diagnostic_policy_);
+
+  // Merge the groups found during a composite parse into the accumulated groups
+  // held by this parser.
+  data_->collision_filter_groups_storage_.Merge(groups);
+
+  // Deprecated 2024-10-01: copy the merged groups to the legacy data object.
+  collision_filter_groups_ = GetCollisionFilterGroups();
 }
 
 }  // namespace multibody

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -16,6 +17,7 @@ namespace drake {
 namespace multibody {
 
 namespace internal {
+class CollisionFilterGroupResolver;
 class CompositeParse;
 }  // namespace internal
 
@@ -173,6 +175,8 @@ class Parser final {
   ///   when empty, no scoping will be added.
   Parser(MultibodyPlant<double>* plant, std::string_view model_name_prefix);
 
+  ~Parser();
+
   /// Gets a mutable reference to the plant that will be modified by this
   /// parser.
   MultibodyPlant<double>& plant() { return *plant_; }
@@ -194,9 +198,14 @@ class Parser final {
 
   /// Gets the accumulated set of collision filter definitions seen by this
   /// parser.
-  CollisionFilterGroups GetCollisionFilterGroups() const {
-    return collision_filter_groups_;
-  }
+  ///
+  /// There are two kinds of names in the returned data: group names and body
+  /// names. Both may occur within scoped names indicating the model instance
+  /// where they are defined. Note that the model instance names used in the
+  /// returned data will reflect the current names in plant() at the time this
+  /// accessor is called (see MultibodyPlant::RenameModelInstance()), but the
+  /// local group and body names will be the names seen during parsing.
+  CollisionFilterGroups GetCollisionFilterGroups() const;
 
   DRAKE_DEPRECATED(
       "2024-10-01",
@@ -246,15 +255,21 @@ class Parser final {
  private:
   friend class internal::CompositeParse;
 
+  // This is called back from CompositeParse::Finish().
+  void ResolveCollisionFilterGroupsFromCompositeParse(
+      internal::CollisionFilterGroupResolver* resolver);
+
   bool is_strict_{false};
   bool enable_auto_rename_{false};
   PackageMap package_map_;
   drake::internal::DiagnosticPolicy diagnostic_policy_;
   MultibodyPlant<double>* const plant_;
-  CollisionFilterGroups collision_filter_groups_;
   std::optional<std::string> model_name_prefix_;
+  struct ParserInternalData;
+  std::unique_ptr<ParserInternalData> data_;
+  // Support for deprecated API: 2024-10-01.
+  CollisionFilterGroups collision_filter_groups_;
 };
 
 }  // namespace multibody
 }  // namespace drake
-

--- a/multibody/parsing/process_model_directives.cc
+++ b/multibody/parsing/process_model_directives.cc
@@ -179,6 +179,7 @@ void ProcessModelDirectives(const ModelDirectives& directives,
   if (added_models) {
     added_models->insert(added_models->end(), models.begin(), models.end());
   }
+  composite->Finish();
 }
 
 std::vector<ModelInstanceInfo> ProcessModelDirectives(

--- a/multibody/parsing/test/detail_dmd_parser_test.cc
+++ b/multibody/parsing/test/detail_dmd_parser_test.cc
@@ -51,7 +51,7 @@ class DmdParserTest : public test::DiagnosticPolicyTestBase {
 
   std::vector<ModelInstanceInfo> ParseModelDirectives(
       const ModelDirectives& directives) {
-    internal::CollisionFilterGroupResolver resolver{&plant_, &group_output_};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
     const ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                              &plant_,  &resolver,    TestingSelect};
     auto result =
@@ -65,7 +65,6 @@ class DmdParserTest : public test::DiagnosticPolicyTestBase {
   PackageMap package_map_;
   DiagnosticPolicy diagnostic_;
   MultibodyPlant<double> plant_{0.01};
-  CollisionFilterGroups group_output_;
 };
 
 /* Make an SDF containing a "ball" body (with an attached frame) and a dummy

--- a/multibody/parsing/test/detail_instanced_name_test.cc
+++ b/multibody/parsing/test/detail_instanced_name_test.cc
@@ -1,0 +1,46 @@
+#include "drake/multibody/parsing/detail_instanced_name.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+// TODO(rpoyner-tri): replace explicit spaceship implementation with compiler
+// default once macOS Ventura support ends. Once it is gone, this test (and
+// perhaps this whole file) can go too.
+GTEST_TEST(InstancedNameTest, ExplicitSpaceship) {
+  InstancedName empty;
+  InstancedName global_a{{}, "a"};
+  InstancedName global_b{{}, "b"};
+  InstancedName one_a{ModelInstanceIndex(1), "a"};
+  InstancedName one_b{ModelInstanceIndex(1), "b"};
+  InstancedName two_a{ModelInstanceIndex(2), "a"};
+  InstancedName two_b{ModelInstanceIndex(2), "b"};
+
+  std::vector ordered{
+    empty, global_a, global_b, one_a, one_b, two_a, two_b};
+
+  for (int ii = 0; ii < ssize(ordered); ++ii) {
+    for (int jj = 0; jj < ssize(ordered); ++jj) {
+      SCOPED_TRACE(fmt::format("compare at ({}, {})", ii, jj));
+      EXPECT_EQ(ordered[ii] <=> ordered[jj], ii <=> jj);
+    }
+  }
+}
+
+GTEST_TEST(InstanceNameTest, ToString) {
+  InstancedName empty;
+  EXPECT_EQ(empty.to_string(), "[nullopt, ]");
+  InstancedName global_a{{}, "a"};
+  EXPECT_EQ(global_a.to_string(), "[nullopt, a]");
+  InstancedName one_a{ModelInstanceIndex(1), "a"};
+  EXPECT_EQ(one_a.to_string(), "[1, a]");
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/detail_make_model_name_test.cc
+++ b/multibody/parsing/test/detail_make_model_name_test.cc
@@ -21,8 +21,7 @@ class MakeModelNameTest : public testing::Test {
   PackageMap package_map_;
   DiagnosticPolicy policy_;
   MultibodyPlant<double> plant_{0.0};
-  CollisionFilterGroups group_output_;
-  CollisionFilterGroupResolver resolver_{&plant_, &group_output_};
+  CollisionFilterGroupResolver resolver_{&plant_};
   ParsingWorkspace workspace_{options_, package_map_, policy_,
     &plant_, &resolver_, NoSelect};
 };

--- a/multibody/parsing/test/detail_mesh_parser_test.cc
+++ b/multibody/parsing/test/detail_mesh_parser_test.cc
@@ -33,7 +33,7 @@ class MeshParserTest : public test::DiagnosticPolicyTestBase {
       const std::string& file_name, const std::string& model_name,
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
-    internal::CollisionFilterGroupResolver resolver{&plant_, &group_output_};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_, &plant_,
                        &resolver, TestingSelect};
     // The wrapper simply delegates to AddModelFromMesh(), so we're testing
@@ -49,7 +49,7 @@ class MeshParserTest : public test::DiagnosticPolicyTestBase {
       const std::string& file_name,
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
-    internal::CollisionFilterGroupResolver resolver{&plant_, &group_output_};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_, &plant_,
                        &resolver, TestingSelect};
     // The wrapper is responsible for building the vector from whatever a call
@@ -68,7 +68,6 @@ class MeshParserTest : public test::DiagnosticPolicyTestBase {
   PackageMap package_map_;
   MultibodyPlant<double> plant_{0.0};
   SceneGraph<double> scene_graph_;
-  CollisionFilterGroups group_output_;
 };
 
 // Tests the name generation logic for model instances and bodies. This
@@ -198,7 +197,7 @@ TEST_F(MeshParserTest, ErrorModes) {
   {
     const std::string data("Just some text");
     const DataSource data_source{DataSource::kContents, &data};
-    internal::CollisionFilterGroupResolver resolver{&plant_, &group_output_};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_, &plant_,
                        &resolver, TestingSelect};
     DRAKE_EXPECT_THROWS_MESSAGE(

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -51,7 +51,7 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
   std::optional<ModelInstanceIndex> AddModelFromFile(
       const std::string& file_name,
       const std::string& model_name) {
-    internal::CollisionFilterGroupResolver resolver{&plant_, &group_output_};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, NoSelect};
     auto result = wrapper_.AddModel(
@@ -63,7 +63,7 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
   std::optional<ModelInstanceIndex> AddModelFromString(
       const std::string& file_contents,
       const std::string& model_name) {
-    internal::CollisionFilterGroupResolver resolver{&plant_, &group_output_};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, NoSelect};
     auto result = wrapper_.AddModel(
@@ -75,7 +75,7 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
   std::vector<ModelInstanceIndex> AddAllModelsFromFile(
       const std::string& file_name,
       const std::optional<std::string>& parent_model_name) {
-    internal::CollisionFilterGroupResolver resolver{&plant_, &group_output_};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, NoSelect};
     auto result = wrapper_.AddAllModels(
@@ -87,7 +87,7 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
   std::vector<ModelInstanceIndex> AddAllModelsFromString(
       const std::string& file_contents,
       const std::optional<std::string>& parent_model_name) {
-    internal::CollisionFilterGroupResolver resolver{&plant_, & group_output_};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_, &resolver, NoSelect};
     auto result = wrapper_.AddAllModels(
@@ -107,7 +107,6 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
   PackageMap package_map_;
   MultibodyPlant<double> plant_{0.1};
   SceneGraph<double> scene_graph_;
-  CollisionFilterGroups group_output_;
   MujocoParserWrapper wrapper_;
 
   std::string box_obj_{std::filesystem::canonical(FindResourceOrThrow(
@@ -154,8 +153,7 @@ GTEST_TEST(MujocoParserExtraTest, Visualize) {
   ParsingOptions options;
   PackageMap package_map;
   MujocoParserWrapper wrapper;
-  CollisionFilterGroups group_output_;
-  internal::CollisionFilterGroupResolver resolver{&plant, &group_output_};
+  internal::CollisionFilterGroupResolver resolver{&plant};
   internal::DiagnosticPolicy diagnostic_policy;
   ParsingWorkspace w{
       options,

--- a/multibody/parsing/test/detail_select_parser_test.cc
+++ b/multibody/parsing/test/detail_select_parser_test.cc
@@ -15,8 +15,7 @@ using testing::MatchesRegex;
 class SelectParserTest : public test::DiagnosticPolicyTestBase {
  protected:
   MultibodyPlant<double> plant_{0.0};
-  CollisionFilterGroups group_output_;
-  CollisionFilterGroupResolver resolver_{&plant_, &group_output_};
+  CollisionFilterGroupResolver resolver_{&plant_};
   ParsingOptions options_;
   ParsingWorkspace w_{options_, {}, diagnostic_policy_, &plant_,
                       &resolver_, SelectParser};

--- a/multibody/parsing/test/detail_usd_parser_test.cc
+++ b/multibody/parsing/test/detail_usd_parser_test.cc
@@ -28,7 +28,7 @@ class UsdParserTest : public test::DiagnosticPolicyTestBase {
             : filename.string();
     const DataSource source{DataSource::kFilename, &source_filename};
     const std::optional<std::string> parent_model_name;
-    internal::CollisionFilterGroupResolver resolver{&plant_, &group_output_};
+    internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
                        &plant_,  &resolver,    NoSelect};
     UsdParser dut;
@@ -48,7 +48,6 @@ class UsdParserTest : public test::DiagnosticPolicyTestBase {
   PackageMap package_map_;
   MultibodyPlant<double> plant_{0.01};
   SceneGraph<double> scene_graph_;
-  CollisionFilterGroups group_output_;
 };
 
 TEST_F(UsdParserTest, NoSuchFile) {

--- a/multibody/parsing/test/parser_manual_test.cc
+++ b/multibody/parsing/test/parser_manual_test.cc
@@ -56,7 +56,7 @@ int do_main(int argc, char* argv[]) {
     ::exit(EXIT_FAILURE);
   }
 
-  const auto& filters = parser.GetCollisionFilterGroups();
+  const auto filters = parser.GetCollisionFilterGroups();
   drake::log()->info("{}", filters);
   drake::log()->info("Parsed {} models.", models.size());
   return models.empty();


### PR DESCRIPTION
This patch fixes a name clash of collision filter groups when loading the same model multiple times using auto-renaming and plant.RenameModel().

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21529)
<!-- Reviewable:end -->
