### PR TITLE
Improve GCS graphviz

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -930,13 +930,13 @@ void DefineGeometryOptimization(py::module m) {
                 bool show_costs, bool scientific, int precision,
                 const std::optional<
                     std::vector<const GraphOfConvexSets::Edge*>>& active_path) {
-              GcsGraphvizOptions options;
-              options.show_slacks = show_slacks;
-              options.show_vars = show_vars;
-              options.show_flows = show_flows;
-              options.show_costs = show_costs;
-              options.scientific = scientific;
-              options.precision = precision;
+              const GcsGraphvizOptions options{
+                  .show_slacks = show_slacks,
+                  .show_vars = show_vars,
+                  .show_flows = show_flows,
+                  .show_costs = show_costs,
+                  .scientific = scientific,
+                  .precision = precision};
               return self.GetGraphvizString(result, options, active_path);
             },
             py::arg("result") =

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -930,8 +930,7 @@ void DefineGeometryOptimization(py::module m) {
                 bool show_costs, bool scientific, int precision,
                 const std::optional<
                     std::vector<const GraphOfConvexSets::Edge*>>& active_path) {
-              const GcsGraphvizOptions options{
-                  .show_slacks = show_slacks,
+              const GcsGraphvizOptions options{.show_slacks = show_slacks,
                   .show_vars = show_vars,
                   .show_flows = show_flows,
                   .show_costs = show_costs,

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -715,35 +715,34 @@ void DefineGeometryOptimization(py::module m) {
         cls_doc.preprocessing_solver.doc);
   }
 
-  // GcsGraphvizOptions
+    // GcsGraphvizOptions
   {
-    const auto& cls_doc = doc.GcsGraphvizOptions;
+    const auto &cls_doc = doc.GcsGraphvizOptions;
     py::class_<GcsGraphvizOptions> gcs_options(m, "GcsGraphvizOptions");
     gcs_options.def(py::init<>())
         .def_readwrite("show_slacks", &GcsGraphvizOptions::show_slacks,
-            cls_doc.show_slacks.doc)
-        .def_readwrite(
-            "show_vars", &GcsGraphvizOptions::show_vars, cls_doc.show_vars.doc)
+                       cls_doc.show_slacks.doc)
+        .def_readwrite("show_vars", &GcsGraphvizOptions::show_vars,
+                       cls_doc.show_vars.doc)
         .def_readwrite("show_flows", &GcsGraphvizOptions::show_flows,
-            cls_doc.show_flows.doc)
+                       cls_doc.show_flows.doc)
         .def_readwrite("show_costs", &GcsGraphvizOptions::show_costs,
-            cls_doc.show_costs.doc)
+                       cls_doc.show_costs.doc)
         .def_readwrite("scientific", &GcsGraphvizOptions::scientific,
-            cls_doc.scientific.doc)
-        .def_readwrite(
-            "precision", &GcsGraphvizOptions::precision, cls_doc.precision.doc)
-        .def("__repr__", [](const GcsGraphvizOptions& self) {
-          return py::str(
-              "GcsGraphvizOptions("
-              "show_slacks={}, "
-              "show_vars={}, "
-              "show_flows={}, "
-              "show_costs={}, "
-              "scientific={}, "
-              "precision={}"
-              ")")
+                       cls_doc.scientific.doc)
+        .def_readwrite("precision", &GcsGraphvizOptions::precision,
+                       cls_doc.precision.doc)
+        .def("__repr__", [](const GcsGraphvizOptions &self) {
+          return py::str("GcsGraphvizOptions("
+                         "show_slacks={}, "
+                         "show_vars={}, "
+                         "show_flows={}, "
+                         "show_costs={}, "
+                         "scientific={}, "
+                         "precision={}"
+                         ")")
               .format(self.show_slacks, self.show_vars, self.show_flows,
-                  self.show_costs, self.scientific, self.precision);
+                      self.show_costs, self.scientific, self.precision);
         });
   }
 

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -909,6 +909,7 @@ void DefineGeometryOptimization(py::module m) {
         .def("GetGraphvizString", &GraphOfConvexSets::GetGraphvizString,
             py::arg("result") = std::nullopt, py::arg("show_slacks") = true,
             py::arg("precision") = 3, py::arg("scientific") = false,
+            py::arg("active_path") = std::nullopt,
             cls_doc.GetGraphvizString.doc)
         .def("SolveShortestPath",
             overload_cast_explicit<solvers::MathematicalProgramResult,

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -715,6 +715,38 @@ void DefineGeometryOptimization(py::module m) {
         cls_doc.preprocessing_solver.doc);
   }
 
+  // GcsGraphvizOptions
+  {
+    const auto& cls_doc = doc.GcsGraphvizOptions;
+    py::class_<GcsGraphvizOptions> gcs_options(m, "GcsGraphvizOptions");
+    gcs_options.def(py::init<>())
+        .def_readwrite("show_slacks", &GcsGraphvizOptions::show_slacks,
+            cls_doc.show_slacks.doc)
+        .def_readwrite(
+            "show_vars", &GcsGraphvizOptions::show_vars, cls_doc.show_vars.doc)
+        .def_readwrite("show_flows", &GcsGraphvizOptions::show_flows,
+            cls_doc.show_flows.doc)
+        .def_readwrite("show_costs", &GcsGraphvizOptions::show_costs,
+            cls_doc.show_costs.doc)
+        .def_readwrite("scientific", &GcsGraphvizOptions::scientific,
+            cls_doc.scientific.doc)
+        .def_readwrite(
+            "precision", &GcsGraphvizOptions::precision, cls_doc.precision.doc)
+        .def("__repr__", [](const GcsGraphvizOptions& self) {
+          return py::str(
+              "GcsGraphvizOptions("
+              "show_slacks={}, "
+              "show_vars={}, "
+              "show_flows={}, "
+              "show_costs={}, "
+              "scientific={}, "
+              "precision={}"
+              ")")
+              .format(self.show_slacks, self.show_vars, self.show_flows,
+                  self.show_costs, self.scientific, self.precision);
+        });
+  }
+
   // GraphOfConvexSets
   {
     const std::unordered_set<GraphOfConvexSets::Transcription>
@@ -907,10 +939,9 @@ void DefineGeometryOptimization(py::module m) {
             &GraphOfConvexSets::ClearAllPhiConstraints,
             cls_doc.ClearAllPhiConstraints.doc)
         .def("GetGraphvizString", &GraphOfConvexSets::GetGraphvizString,
-            py::arg("result") = std::nullopt, py::arg("show_slacks") = true,
-            py::arg("precision") = 3, py::arg("scientific") = false,
-            py::arg("show_vars") = true, py::arg("show_costs") = true,
-            py::arg("show_flows") = true, py::arg("active_path") = std::nullopt,
+            py::arg("result") = std::nullopt,
+            py::arg("options") = GcsGraphvizOptions(),
+            py::arg("active_path") = std::nullopt,
             cls_doc.GetGraphvizString.doc)
         .def("SolveShortestPath",
             overload_cast_explicit<solvers::MathematicalProgramResult,

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -717,34 +717,13 @@ void DefineGeometryOptimization(py::module m) {
 
   // GcsGraphvizOptions
   {
-    const auto& cls_doc = doc.GcsGraphvizOptions;
-    py::class_<GcsGraphvizOptions> gcs_options(m, "GcsGraphvizOptions");
-    gcs_options.def(py::init<>())
-        .def_readwrite("show_slacks", &GcsGraphvizOptions::show_slacks,
-            cls_doc.show_slacks.doc)
-        .def_readwrite(
-            "show_vars", &GcsGraphvizOptions::show_vars, cls_doc.show_vars.doc)
-        .def_readwrite("show_flows", &GcsGraphvizOptions::show_flows,
-            cls_doc.show_flows.doc)
-        .def_readwrite("show_costs", &GcsGraphvizOptions::show_costs,
-            cls_doc.show_costs.doc)
-        .def_readwrite("scientific", &GcsGraphvizOptions::scientific,
-            cls_doc.scientific.doc)
-        .def_readwrite(
-            "precision", &GcsGraphvizOptions::precision, cls_doc.precision.doc)
-        .def("__repr__", [](const GcsGraphvizOptions& self) {
-          return py::str(
-              "GcsGraphvizOptions("
-              "show_slacks={}, "
-              "show_vars={}, "
-              "show_flows={}, "
-              "show_costs={}, "
-              "scientific={}, "
-              "precision={}"
-              ")")
-              .format(self.show_slacks, self.show_vars, self.show_flows,
-                  self.show_costs, self.scientific, self.precision);
-        });
+    using Class = GcsGraphvizOptions;
+    constexpr auto& cls_doc = doc.GcsGraphvizOptions;
+    py::class_<Class> cls(m, "GcsGraphvizOptions", cls_doc.doc);
+    cls.def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, cls_doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
   }
 
   // GraphOfConvexSets

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -715,34 +715,35 @@ void DefineGeometryOptimization(py::module m) {
         cls_doc.preprocessing_solver.doc);
   }
 
-    // GcsGraphvizOptions
+  // GcsGraphvizOptions
   {
-    const auto &cls_doc = doc.GcsGraphvizOptions;
+    const auto& cls_doc = doc.GcsGraphvizOptions;
     py::class_<GcsGraphvizOptions> gcs_options(m, "GcsGraphvizOptions");
     gcs_options.def(py::init<>())
         .def_readwrite("show_slacks", &GcsGraphvizOptions::show_slacks,
-                       cls_doc.show_slacks.doc)
-        .def_readwrite("show_vars", &GcsGraphvizOptions::show_vars,
-                       cls_doc.show_vars.doc)
+            cls_doc.show_slacks.doc)
+        .def_readwrite(
+            "show_vars", &GcsGraphvizOptions::show_vars, cls_doc.show_vars.doc)
         .def_readwrite("show_flows", &GcsGraphvizOptions::show_flows,
-                       cls_doc.show_flows.doc)
+            cls_doc.show_flows.doc)
         .def_readwrite("show_costs", &GcsGraphvizOptions::show_costs,
-                       cls_doc.show_costs.doc)
+            cls_doc.show_costs.doc)
         .def_readwrite("scientific", &GcsGraphvizOptions::scientific,
-                       cls_doc.scientific.doc)
-        .def_readwrite("precision", &GcsGraphvizOptions::precision,
-                       cls_doc.precision.doc)
-        .def("__repr__", [](const GcsGraphvizOptions &self) {
-          return py::str("GcsGraphvizOptions("
-                         "show_slacks={}, "
-                         "show_vars={}, "
-                         "show_flows={}, "
-                         "show_costs={}, "
-                         "scientific={}, "
-                         "precision={}"
-                         ")")
+            cls_doc.scientific.doc)
+        .def_readwrite(
+            "precision", &GcsGraphvizOptions::precision, cls_doc.precision.doc)
+        .def("__repr__", [](const GcsGraphvizOptions& self) {
+          return py::str(
+              "GcsGraphvizOptions("
+              "show_slacks={}, "
+              "show_vars={}, "
+              "show_flows={}, "
+              "show_costs={}, "
+              "scientific={}, "
+              "precision={}"
+              ")")
               .format(self.show_slacks, self.show_vars, self.show_flows,
-                      self.show_costs, self.scientific, self.precision);
+                  self.show_costs, self.scientific, self.precision);
         });
   }
 
@@ -940,6 +941,30 @@ void DefineGeometryOptimization(py::module m) {
         .def("GetGraphvizString", &GraphOfConvexSets::GetGraphvizString,
             py::arg("result") = std::nullopt,
             py::arg("options") = GcsGraphvizOptions(),
+            py::arg("active_path") = std::nullopt,
+            cls_doc.GetGraphvizString.doc)
+        .def(
+            "GetGraphvizString",
+            [](const GraphOfConvexSets& self,
+                const std::optional<solvers::MathematicalProgramResult>& result,
+                bool show_slacks, bool show_vars, bool show_flows,
+                bool show_costs, bool scientific, int precision,
+                const std::optional<
+                    std::vector<const GraphOfConvexSets::Edge*>>& active_path) {
+              GcsGraphvizOptions options;
+              options.show_slacks = show_slacks;
+              options.show_vars = show_vars;
+              options.show_flows = show_flows;
+              options.show_costs = show_costs;
+              options.scientific = scientific;
+              options.precision = precision;
+              return self.GetGraphvizString(result, options, active_path);
+            },
+            py::arg("result") =
+                std::optional<solvers::MathematicalProgramResult>(std::nullopt),
+            py::arg("show_slacks") = true, py::arg("show_vars") = true,
+            py::arg("show_flows") = true, py::arg("show_costs") = true,
+            py::arg("scientific") = false, py::arg("precision") = 3,
             py::arg("active_path") = std::nullopt,
             cls_doc.GetGraphvizString.doc)
         .def("SolveShortestPath",

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -909,7 +909,8 @@ void DefineGeometryOptimization(py::module m) {
         .def("GetGraphvizString", &GraphOfConvexSets::GetGraphvizString,
             py::arg("result") = std::nullopt, py::arg("show_slacks") = true,
             py::arg("precision") = 3, py::arg("scientific") = false,
-            py::arg("active_path") = std::nullopt,
+            py::arg("show_vars") = true, py::arg("show_costs") = true,
+            py::arg("show_flows") = true, py::arg("active_path") = std::nullopt,
             cls_doc.GetGraphvizString.doc)
         .def("SolveShortestPath",
             overload_cast_explicit<solvers::MathematicalProgramResult,

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -806,9 +806,15 @@ class TestGeometryOptimization(unittest.TestCase):
                                     result=result,
                                     tolerance=0.1)), 1)
 
-        options = mut.GcsGraphvizOptions()
+        graphviz_options = mut.GcsGraphvizOptions()
+        graphviz_options.show_slacks = True
+        graphviz_options.show_vars = True
+        graphviz_options.show_flows = True
+        graphviz_options.show_costs = True
+        graphviz_options.scientific = False
+        graphviz_options.precision = 3
         self.assertIn("source", spp.GetGraphvizString(
-            result=result, options=options, active_path=[edge0]))
+            result=result, options=graphviz_options, active_path=[edge0]))
 
         # Vertex
         self.assertAlmostEqual(

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -807,7 +807,9 @@ class TestGeometryOptimization(unittest.TestCase):
                                     tolerance=0.1)), 1)
 
         self.assertIn("source", spp.GetGraphvizString(
-            result=result, show_slacks=True, precision=2, scientific=False))
+            result=result, show_slacks=True, precision=2, scientific=False,
+            show_vars=True, show_costs=True, show_flows=True,
+            active_edge=[edge0]))
 
         # Vertex
         self.assertAlmostEqual(

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -819,6 +819,19 @@ class TestGeometryOptimization(unittest.TestCase):
                 result=result, options=graphviz_options, active_path=[edge0]
             ),
         )
+        self.assertIn(
+            "source",
+            spp.GetGraphvizString(
+                result=result,
+                show_slacks=True,
+                show_vars=True,
+                show_flows=True,
+                show_costs=True,
+                scientific=True,
+                precision=3,
+                active_path=[edge0],
+            ),
+        )
 
         # Vertex
         self.assertAlmostEqual(

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -813,8 +813,12 @@ class TestGeometryOptimization(unittest.TestCase):
         graphviz_options.show_costs = True
         graphviz_options.scientific = False
         graphviz_options.precision = 3
-        self.assertIn("source", spp.GetGraphvizString(
-            result=result, options=graphviz_options, active_path=[edge0]))
+        self.assertIn(
+            "source",
+            spp.GetGraphvizString(
+                result=result, options=graphviz_options, active_path=[edge0]
+            ),
+        )
 
         # Vertex
         self.assertAlmostEqual(

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -806,10 +806,9 @@ class TestGeometryOptimization(unittest.TestCase):
                                     result=result,
                                     tolerance=0.1)), 1)
 
+        options = mut.GcsGraphvizOptions()
         self.assertIn("source", spp.GetGraphvizString(
-            result=result, show_slacks=True, precision=2, scientific=False,
-            show_vars=True, show_costs=True, show_flows=True,
-            active_edge=[edge0]))
+            result=result, options=options, active_path=[edge0]))
 
         # Vertex
         self.assertAlmostEqual(

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -438,8 +438,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("continuous_revolute_joints", &Class::continuous_revolute_joints,
             cls_doc.continuous_revolute_joints.doc)
         .def("GetGraphvizString", &Class::GetGraphvizString,
-            py::arg("result") = std::nullopt, py::arg("show_slack") = true,
-            py::arg("precision") = 3, py::arg("scientific") = false,
+            py::arg("result") = std::nullopt,
+            py::arg("options") = geometry::optimization::GcsGraphvizOptions(),
             cls_doc.GetGraphvizString.doc)
         .def(
             "AddRegions",

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -442,6 +442,31 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py::arg("options") = geometry::optimization::GcsGraphvizOptions(),
             cls_doc.GetGraphvizString.doc)
         .def(
+            "GetGraphvizString",
+            [](const geometry::optimization::GraphOfConvexSets& self,
+                const std::optional<solvers::MathematicalProgramResult>& result,
+                bool show_slacks, bool show_vars, bool show_flows,
+                bool show_costs, bool scientific, int precision,
+                const std::optional<std::vector<
+                    const geometry::optimization::GraphOfConvexSets::Edge*>>&
+                    active_path) {
+              geometry::optimization::GcsGraphvizOptions options;
+              options.show_slacks = show_slacks;
+              options.show_vars = show_vars;
+              options.show_flows = show_flows;
+              options.show_costs = show_costs;
+              options.scientific = scientific;
+              options.precision = precision;
+              return self.GetGraphvizString(result, options, active_path);
+            },
+            py::arg("result") =
+                std::optional<solvers::MathematicalProgramResult>(std::nullopt),
+            py::arg("show_slacks") = true, py::arg("show_vars") = true,
+            py::arg("show_flows") = true, py::arg("show_costs") = true,
+            py::arg("scientific") = false, py::arg("precision") = 3,
+            py::arg("active_path") = std::nullopt,
+            cls_doc.GetGraphvizString.doc)
+        .def(
             "AddRegions",
             [](Class& self,
                 const std::vector<geometry::optimization::ConvexSet*>& regions,

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -443,13 +443,10 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             cls_doc.GetGraphvizString.doc)
         .def(
             "GetGraphvizString",
-            [](const geometry::optimization::GraphOfConvexSets& self,
+            [](const GcsTrajectoryOptimization& self,
                 const std::optional<solvers::MathematicalProgramResult>& result,
                 bool show_slacks, bool show_vars, bool show_flows,
-                bool show_costs, bool scientific, int precision,
-                const std::optional<std::vector<
-                    const geometry::optimization::GraphOfConvexSets::Edge*>>&
-                    active_path) {
+                bool show_costs, bool scientific, int precision) {
               geometry::optimization::GcsGraphvizOptions options;
               options.show_slacks = show_slacks;
               options.show_vars = show_vars;
@@ -457,14 +454,13 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
               options.show_costs = show_costs;
               options.scientific = scientific;
               options.precision = precision;
-              return self.GetGraphvizString(result, options, active_path);
+              return self.GetGraphvizString(result, options);
             },
             py::arg("result") =
                 std::optional<solvers::MathematicalProgramResult>(std::nullopt),
             py::arg("show_slacks") = true, py::arg("show_vars") = true,
             py::arg("show_flows") = true, py::arg("show_costs") = true,
             py::arg("scientific") = false, py::arg("precision") = 3,
-            py::arg("active_path") = std::nullopt,
             cls_doc.GetGraphvizString.doc)
         .def(
             "AddRegions",

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -586,8 +586,22 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertTrue(traj.end_time() - traj.start_time() >= 10)
 
         self.assertIsInstance(
-            gcs.GetGraphvizString(result=result,
-                                  options=GcsGraphvizOptions()), str)
+            gcs.GetGraphvizString(result=result, options=GcsGraphvizOptions()), str
+        )
+
+        self.assertIsInstance(
+            gcs.GetGraphvizString(
+                result=result,
+                show_slacks=True,
+                show_vars=True,
+                show_flows=True,
+                show_costs=True,
+                scientific=True,
+                precision=3,
+                active_path=[],
+            ),
+            str,
+        )
 
         # In the follwoing, we test adding the bindings for nonlinear
         # constraints.

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -586,7 +586,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertTrue(traj.end_time() - traj.start_time() >= 10)
 
         self.assertIsInstance(
-            gcs.GetGraphvizString(result=result, options=GcsGraphvizOptions()), str
+            gcs.GetGraphvizString(result=result, options=GcsGraphvizOptions()),
+            str
         )
 
         self.assertIsInstance(

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -585,8 +585,10 @@ class TestTrajectoryOptimization(unittest.TestCase):
                                              goal2[:, None], 6)
         self.assertTrue(traj.end_time() - traj.start_time() >= 10)
 
+        graphviz_options = GcsGraphvizOptions()
+        graphviz_options.show_costs = False
         self.assertIsInstance(
-            gcs.GetGraphvizString(result=result, options=GcsGraphvizOptions()),
+            gcs.GetGraphvizString(result=result, options=graphviz_options),
             str
         )
 
@@ -596,10 +598,9 @@ class TestTrajectoryOptimization(unittest.TestCase):
                 show_slacks=True,
                 show_vars=True,
                 show_flows=True,
-                show_costs=True,
+                show_costs=False,
                 scientific=True,
                 precision=3,
-                active_path=[],
             ),
             str,
         )

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -19,6 +19,7 @@ from pydrake.geometry.optimization import (
     ConvexSet,
     GraphOfConvexSetsOptions,
     GraphOfConvexSets,
+    GcsGraphvizOptions,
     HPolyhedron,
     Point,
     VPolytope,
@@ -586,9 +587,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
 
         self.assertIsInstance(
             gcs.GetGraphvizString(result=result,
-                                  show_slack=True,
-                                  precision=3,
-                                  scientific=False), str)
+                                  options=GcsGraphvizOptions()), str)
 
         # In the follwoing, we test adding the bindings for nonlinear
         # constraints.

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -452,12 +452,14 @@ void GraphOfConvexSets::ClearAllPhiConstraints() {
 
 std::string GraphOfConvexSets::GetGraphvizString(
     const std::optional<solvers::MathematicalProgramResult>& result,
-    bool show_slacks, int precision, bool scientific) const {
+    bool show_slacks, int precision, bool scientific,
+    const std::optional<std::vector<const Edge*>>& active_path) const {
   // TODO(bernhardpg): Make show_flows an argument
   const bool show_flows = true;
   const bool show_vars = false;
   const bool show_costs = true;
 
+  // This function converts a 0.0 to 00 and 1.0 to FF
   auto floatToHex = [](float value) -> std::string {
     if (value < 0.0f || value > 1.0f) return "Out of range";
     std::ostringstream ss;
@@ -518,12 +520,21 @@ std::string GraphOfConvexSets::GetGraphvizString(
         graphviz << ",\n";
         graphviz << "ϕ = " << result->GetSolution(e->phi()) << ",\n";
         graphviz << "\"";
-        // Set edge alpha according to flow values
         graphviz << ", color=" << "\"#000000"
                  << floatToHex(result->GetSolution(e->phi()));
       }
     }
     graphviz << "\"];\n";
+  }
+
+  if (active_path) {
+    for (const auto& e : *active_path) {
+      graphviz << "v" << e->u().id() << " -> v" << e->v().id();
+      graphviz << " [label=\"" << e->name() << " = active\"";
+      graphviz << ", color=" << "\"#ff0000\"";
+      graphviz << ", style=\"dashed\"";
+      graphviz << "];\n";
+    }
   }
   graphviz << "}\n";
   return graphviz.str();

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -454,12 +454,16 @@ std::string GraphOfConvexSets::GetGraphvizString(
     const std::optional<solvers::MathematicalProgramResult>& result,
     const GcsGraphvizOptions& options,
     const std::optional<std::vector<const Edge*>>& active_path) const {
-  // This function converts a 0.0 to 00 and 1.0 to FF
+  // This function converts the range (0.0, 1.0) to Hex strings in the range
+  // (20, FF).
+  const int kMaxHexValue = 255;
+  const int kMinHexValue = 32;
   auto floatToHex = [](float value) -> std::string {
     if (value < 0.0f || value > 1.0f) return "Out of range";
     std::ostringstream ss;
     ss << std::hex << std::uppercase << std::setw(2) << std::setfill('0')
-       << static_cast<int>(value * 255);
+       << static_cast<int>(value * (kMaxHexValue - kMinHexValue) +
+                           kMinHexValue);
     return ss.str();
   };
 
@@ -515,8 +519,8 @@ std::string GraphOfConvexSets::GetGraphvizString(
         graphviz << "\"";
         // Note: This must be last, because it also sets the color parameter
         // of the edge (and hence must close the name within quote-marks)
-        graphviz << ", color="
-                 << "\"#000000" << floatToHex(result->GetSolution(e->phi()));
+        graphviz << ", color=" << "\"#000000"
+                 << floatToHex(result->GetSolution(e->phi()));
       }
     }
     graphviz << "\"];\n";
@@ -526,8 +530,7 @@ std::string GraphOfConvexSets::GetGraphvizString(
     for (const auto& e : *active_path) {
       graphviz << "v" << e->u().id() << " -> v" << e->v().id();
       graphviz << " [label=\"" << e->name() << " = active\"";
-      graphviz << ", color="
-               << "\"#ff0000\"";
+      graphviz << ", color=" << "\"#ff0000\"";
       graphviz << ", style=\"dashed\"";
       graphviz << "];\n";
     }

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -515,8 +515,8 @@ std::string GraphOfConvexSets::GetGraphvizString(
         graphviz << "\"";
         // Note: This must be last, because it also sets the color parameter
         // of the edge (and hence must close the name within quote-marks)
-        graphviz << ", color=" << "\"#000000"
-                 << floatToHex(result->GetSolution(e->phi()));
+        graphviz << ", color="
+                 << "\"#000000" << floatToHex(result->GetSolution(e->phi()));
       }
     }
     graphviz << "\"];\n";
@@ -526,7 +526,8 @@ std::string GraphOfConvexSets::GetGraphvizString(
     for (const auto& e : *active_path) {
       graphviz << "v" << e->u().id() << " -> v" << e->v().id();
       graphviz << " [label=\"" << e->name() << " = active\"";
-      graphviz << ", color=" << "\"#ff0000\"";
+      graphviz << ", color="
+               << "\"#ff0000\"";
       graphviz << ", style=\"dashed\"";
       graphviz << "];\n";
     }

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -475,8 +475,7 @@ std::string GraphOfConvexSets::GetGraphvizString(
     graphviz << "v" << v_id << " [label=\"" << v->name();
     if (result) {
       if (show_vars) {
-        graphviz << "\n x = [" << result->GetSolution(v->x()).transpose()
-                 << "]";
+        graphviz << "\nx = [" << result->GetSolution(v->x()).transpose() << "]";
       }
       if (show_costs) {
         graphviz << "\ncost = " << v->GetSolutionCost(*result);
@@ -489,8 +488,8 @@ std::string GraphOfConvexSets::GetGraphvizString(
     graphviz << "v" << e->u().id() << " -> v" << e->v().id();
     graphviz << " [label=\"" << e->name();
     if (result) {
-      graphviz << "\n";
       if (show_costs) {
+        graphviz << "\n";
         if (e->ell_.size() > 0) {
           // SolveConvexRestriction does not yet return the rewritten costs.
           if (result->get_decision_variable_index()->contains(
@@ -502,8 +501,7 @@ std::string GraphOfConvexSets::GetGraphvizString(
         }
       }
       if (show_slacks) {
-        graphviz << ",\n";
-        graphviz << "ϕ = " << result->GetSolution(e->phi()) << ",\n";
+        graphviz << "\n";
         if (result->get_decision_variable_index()->contains(
                 e->y_[0].get_id())) {
           graphviz << "ϕ xᵤ = [" << e->GetSolutionPhiXu(*result).transpose()
@@ -513,9 +511,11 @@ std::string GraphOfConvexSets::GetGraphvizString(
         }
       }
       if (show_flows) {
-        graphviz << ",\n";
-        graphviz << "ϕ = " << result->GetSolution(e->phi()) << ",\n";
+        graphviz << "\n";
+        graphviz << "ϕ = " << result->GetSolution(e->phi());
         graphviz << "\"";
+        // Note: This must be last, because it also sets the color parameter of
+        // the edge (and hence must close the name within quote-marks)
         graphviz << ", color=" << "\"#000000"
                  << floatToHex(result->GetSolution(e->phi()));
       }

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -482,9 +482,9 @@ std::string GraphOfConvexSets::GetGraphvizString(
       }
       if (show_costs) {
         graphviz << "\ncost = " << v->GetSolutionCost(*result);
-        graphviz << "\"]\n";
       }
     }
+    graphviz << "\"]\n";
   }
   for (const auto& [e_id, e] : edges_) {
     unused(e_id);

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -452,13 +452,9 @@ void GraphOfConvexSets::ClearAllPhiConstraints() {
 
 std::string GraphOfConvexSets::GetGraphvizString(
     const std::optional<solvers::MathematicalProgramResult>& result,
-    bool show_slacks, int precision, bool scientific,
+    bool show_slacks, int precision, bool scientific, bool show_vars,
+    bool show_costs, bool show_flows,
     const std::optional<std::vector<const Edge*>>& active_path) const {
-  // TODO(bernhardpg): Make show_flows an argument
-  const bool show_flows = true;
-  const bool show_vars = false;
-  const bool show_costs = true;
-
   // This function converts a 0.0 to 00 and 1.0 to FF
   auto floatToHex = [](float value) -> std::string {
     if (value < 0.0f || value > 1.0f) return "Out of range";

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -450,13 +450,13 @@ void GraphOfConvexSets::ClearAllPhiConstraints() {
   }
 }
 
-// TODO(russt): We could get fancy and dim the color of the nodes/edges
-// according to phi, using e.g. https://graphviz.org/docs/attr-types/color/ .
 std::string GraphOfConvexSets::GetGraphvizString(
     const std::optional<solvers::MathematicalProgramResult>& result,
     bool show_slacks, int precision, bool scientific) const {
-  // TODO(bernhardpg): Make only_flows an argument
-  const bool only_flows = true;
+  // TODO(bernhardpg): Make show_flows an argument
+  const bool show_flows = true;
+  const bool show_vars = false;
+  const bool show_costs = true;
 
   auto floatToHex = [](float value) -> std::string {
     if (value < 0.0f || value > 1.0f) return "Out of range";
@@ -475,13 +475,16 @@ std::string GraphOfConvexSets::GetGraphvizString(
   graphviz << "labelloc=t;\n";
   for (const auto& [v_id, v] : vertices_) {
     graphviz << "v" << v_id << " [label=\"" << v->name();
-    if (result && !only_flows) {
-      graphviz << "\n x = [" << result->GetSolution(v->x()).transpose() << "]";
+    if (result) {
+      if (show_vars) {
+        graphviz << "\n x = [" << result->GetSolution(v->x()).transpose()
+                 << "]";
+      }
+      if (show_costs) {
+        graphviz << "\ncost = " << v->GetSolutionCost(*result);
+        graphviz << "\"]\n";
+      }
     }
-    // TODO(bernhardpg): This next line must be moved/cleaned up for
-    // a Drake PR
-    graphviz << "\ncost = " << v->GetSolutionCost(*result);
-    graphviz << "\"]\n";
   }
   for (const auto& [e_id, e] : edges_) {
     unused(e_id);
@@ -489,14 +492,16 @@ std::string GraphOfConvexSets::GetGraphvizString(
     graphviz << " [label=\"" << e->name();
     if (result) {
       graphviz << "\n";
-      if (e->ell_.size() > 0) {
-        // SolveConvexRestriction does not yet return the rewritten costs.
-        if (result->get_decision_variable_index()->contains(
-                e->ell_[0].get_id())) {
-          graphviz << "cost = " << e->GetSolutionCost(*result);
+      if (show_costs) {
+        if (e->ell_.size() > 0) {
+          // SolveConvexRestriction does not yet return the rewritten costs.
+          if (result->get_decision_variable_index()->contains(
+                  e->ell_[0].get_id())) {
+            graphviz << "cost = " << e->GetSolutionCost(*result);
+          }
+        } else {
+          graphviz << "cost = 0";
         }
-      } else {
-        graphviz << "cost = 0";
       }
       if (show_slacks) {
         graphviz << ",\n";
@@ -509,13 +514,16 @@ std::string GraphOfConvexSets::GetGraphvizString(
                    << "]";
         }
       }
+      if (show_flows) {
+        graphviz << ",\n";
+        graphviz << "ϕ = " << result->GetSolution(e->phi()) << ",\n";
+        graphviz << "\"";
+        // Set edge alpha according to flow values
+        graphviz << ", color=" << "\"#000000"
+                 << floatToHex(result->GetSolution(e->phi()));
+      }
     }
-    graphviz << ",\n";
-    graphviz << "ϕ = " << result->GetSolution(e->phi()) << ",\n";
-    graphviz << "\"";
-    graphviz << ", color=" << "\"#000000"
-             << floatToHex(result->GetSolution(e->phi())) << "\"";
-    graphviz << "];\n";
+    graphviz << "\"];\n";
   }
   graphviz << "}\n";
   return graphviz.str();

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -519,8 +519,8 @@ std::string GraphOfConvexSets::GetGraphvizString(
         graphviz << "\"";
         // Note: This must be last, because it also sets the color parameter
         // of the edge (and hence must close the name within quote-marks)
-        graphviz << ", color=" << "\"#000000"
-                 << floatToHex(result->GetSolution(e->phi()));
+        graphviz << ", color="
+                 << "\"#000000" << floatToHex(result->GetSolution(e->phi()));
       }
     }
     graphviz << "\"];\n";
@@ -530,7 +530,8 @@ std::string GraphOfConvexSets::GetGraphvizString(
     for (const auto& e : *active_path) {
       graphviz << "v" << e->u().id() << " -> v" << e->v().id();
       graphviz << " [label=\"" << e->name() << " = active\"";
-      graphviz << ", color=" << "\"#ff0000\"";
+      graphviz << ", color="
+               << "\"#ff0000\"";
       graphviz << ", style=\"dashed\"";
       graphviz << "];\n";
     }

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -455,6 +455,9 @@ void GraphOfConvexSets::ClearAllPhiConstraints() {
 std::string GraphOfConvexSets::GetGraphvizString(
     const std::optional<solvers::MathematicalProgramResult>& result,
     bool show_slacks, int precision, bool scientific) const {
+  // TODO(bernhardpg): Make only_flows an argument
+  const bool only_flows = true;
+
   // Note: We use stringstream instead of fmt in order to control the
   // formatting of the Eigen output and double output in a consistent way.
   std::stringstream graphviz;
@@ -464,9 +467,12 @@ std::string GraphOfConvexSets::GetGraphvizString(
   graphviz << "labelloc=t;\n";
   for (const auto& [v_id, v] : vertices_) {
     graphviz << "v" << v_id << " [label=\"" << v->name();
-    if (result) {
+    if (result && !only_flows) {
       graphviz << "\n x = [" << result->GetSolution(v->x()).transpose() << "]";
     }
+    // TODO(bernhardpg): This next line must be moved/cleaned up for
+    // a Drake PR
+    graphviz << "\ncost = " << v->GetSolutionCost(*result);
     graphviz << "\"]\n";
   }
   for (const auto& [e_id, e] : edges_) {

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -458,6 +458,14 @@ std::string GraphOfConvexSets::GetGraphvizString(
   // TODO(bernhardpg): Make only_flows an argument
   const bool only_flows = true;
 
+  auto floatToHex = [](float value) -> std::string {
+    if (value < 0.0f || value > 1.0f) return "Out of range";
+    std::ostringstream ss;
+    ss << std::hex << std::uppercase << std::setw(2) << std::setfill('0')
+       << static_cast<int>(value * 255);
+    return ss.str();
+  };
+
   // Note: We use stringstream instead of fmt in order to control the
   // formatting of the Eigen output and double output in a consistent way.
   std::stringstream graphviz;
@@ -502,7 +510,12 @@ std::string GraphOfConvexSets::GetGraphvizString(
         }
       }
     }
-    graphviz << "\"];\n";
+    graphviz << ",\n";
+    graphviz << "ϕ = " << result->GetSolution(e->phi()) << ",\n";
+    graphviz << "\"";
+    graphviz << ", color=" << "\"#000000"
+             << floatToHex(result->GetSolution(e->phi())) << "\"";
+    graphviz << "];\n";
   }
   graphviz << "}\n";
   return graphviz.str();

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -23,6 +23,24 @@ namespace geometry {
 namespace optimization {
 
 struct GraphOfConvexSetsOptions {
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. Note:
+  This only serializes options that are YAML built-in types.  */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(convex_relaxation));
+    a->Visit(DRAKE_NVP(max_rounded_paths));
+    a->Visit(DRAKE_NVP(preprocessing));
+    a->Visit(DRAKE_NVP(max_rounding_trials));
+    a->Visit(DRAKE_NVP(flow_tolerance));
+    a->Visit(DRAKE_NVP(rounding_seed));
+    // N.B. We skip the DRAKE_NVP(solver), DRAKE_NVP(restriction_solver), and
+    // DRAKE_NVP(preprocessing_solver), because it cannot be serialized.
+    // TODO(#20967) Serialize the DRAKE_NVP(solver_options).
+    // TODO(#20967) Serialize the DRAKE_NVP(restriction_solver_options).
+    // TODO(#20967) Serialize the DRAKE_NVP(preprocessing_solver_options).
+  }
+
   /** Flag to solve the relaxed version of the problem.  As discussed in the
   paper, we know that this relaxation cannot solve the original NP-hard problem
   for all instances, but there are also many instances for which the convex
@@ -107,53 +125,9 @@ struct GraphOfConvexSetsOptions {
   not from the many smaller preprocessing optimizations. */
   std::optional<solvers::SolverOptions> preprocessing_solver_options{
       std::nullopt};
-
-  /** Passes this object to an Archive.
-  Refer to @ref yaml_serialization "YAML Serialization" for background. Note:
-  This only serializes options that are YAML built-in types.  */
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(convex_relaxation));
-    a->Visit(DRAKE_NVP(max_rounded_paths));
-    a->Visit(DRAKE_NVP(preprocessing));
-    a->Visit(DRAKE_NVP(max_rounding_trials));
-    a->Visit(DRAKE_NVP(flow_tolerance));
-    a->Visit(DRAKE_NVP(rounding_seed));
-    // N.B. We skip the DRAKE_NVP(solver), DRAKE_NVP(restriction_solver), and
-    // DRAKE_NVP(preprocessing_solver), because it cannot be serialized.
-    // TODO(#20967) Serialize the DRAKE_NVP(solver_options).
-    // TODO(#20967) Serialize the DRAKE_NVP(restriction_solver_options).
-    // TODO(#20967) Serialize the DRAKE_NVP(preprocessing_solver_options).
-  }
 };
 
 struct GcsGraphvizOptions {
-  /** Determines whether the values of the intermediate (slack) variables are
-  also displayed in the graph. */
-  bool show_slacks{true};
-
-  /** Determines whether the solution values for decision variables in each set
-   * are shown. */
-  bool show_vars{true};
-
-  /** Determines whether the flow value results are shown. The flow values are
-   * shown both with a numeric value and through the transparency value on the
-   * edge, where a flow of 0.0 will correspond to an (almost) invisible edge,
-   * and a flow of 1.0 will display as a fully black edge. */
-  bool show_flows{true};
-
-  /** Determines whether the cost value results are shown. This will show both
-   * edge and vertex costs. */
-  bool show_costs{true};
-
-  /** Sets the floating point formatting to scientific (if true) or fixed (if
-   * false). */
-  bool scientific{false};
-
-  /** Sets the floating point precision (how many digits are generated) of the
-   * annotations. */
-  int precision{3};
-
   /** Passes this object to an Archive.
   Refer to @ref yaml_serialization "YAML Serialization" for background. */
   template <typename Archive>
@@ -165,6 +139,32 @@ struct GcsGraphvizOptions {
     a->Visit(DRAKE_NVP(scientific));
     a->Visit(DRAKE_NVP(precision));
   }
+
+  /** Determines whether the values of the intermediate (slack) variables are
+  also displayed in the graph. */
+  bool show_slacks{true};
+
+  /** Determines whether the solution values for decision variables in each set
+  are shown. */
+  bool show_vars{true};
+
+  /** Determines whether the flow value results are shown. The flow values are
+  shown both with a numeric value and through the transparency value on the
+  edge, where a flow of 0.0 will correspond to an (almost) invisible edge,
+  and a flow of 1.0 will display as a fully black edge. */
+  bool show_flows{true};
+
+  /** Determines whether the cost value results are shown. This will show both
+  edge and vertex costs. */
+  bool show_costs{true};
+
+  /** Sets the floating point formatting to scientific (if true) or fixed (if
+  false). */
+  bool scientific{false};
+
+  /** Sets the floating point precision (how many digits are generated) of the
+  annotations. */
+  int precision{3};
 };
 
 /**
@@ -667,8 +667,7 @@ class GraphOfConvexSets {
   /** Removes all constraints added to any edge with AddPhiConstraint. */
   void ClearAllPhiConstraints();
 
-  /**
-  Returns a Graphviz string describing the graph vertices and edges. If
+  /** Returns a Graphviz string describing the graph vertices and edges. If
   `results` is supplied, then the graph will be annotated with the solution
   values, according to `options`.
   @param result the optional result from a solver.
@@ -676,7 +675,7 @@ class GraphOfConvexSets {
   @param active_path optionally highlights a given path in the graph. The path
   is displayed as dashed edges in red, displayed in addition to the original
   graph edges.
-   */
+  */
   std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result =
           std::nullopt,

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -153,6 +153,18 @@ struct GcsGraphvizOptions {
   /** Sets the floating point precision (how many digits are generated) of the
    * annotations. */
   int precision{3};
+
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(show_slacks));
+    a->Visit(DRAKE_NVP(show_vars));
+    a->Visit(DRAKE_NVP(show_flows));
+    a->Visit(DRAKE_NVP(show_costs));
+    a->Visit(DRAKE_NVP(scientific));
+    a->Visit(DRAKE_NVP(precision));
+  }
 };
 
 /**

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -128,30 +128,30 @@ struct GraphOfConvexSetsOptions {
 };
 
 struct GcsGraphvizOptions {
-  /** Determines whether the values of the intermediate
-  (slack) variables are also displayed in the graph. */
+  /** Determines whether the values of the intermediate (slack) variables are
+  also displayed in the graph. */
   bool show_slacks{true};
 
-  /** Determines whether the solution values for decision variables
-  in each set are shown. */
+  /** Determines whether the solution values for decision variables in each set
+   * are shown. */
   bool show_vars{true};
 
-  /** Determines whether the flow value results are shown. The
-  flow values are shown both with a numeric value and through the transparency
-  value on the edge, where a flow of 0.0 will correspond to an invisible edge,
-  and a flow of 1.0 will display as a fully black edge. */
+  /** Determines whether the flow value results are shown. The flow values are
+   * shown both with a numeric value and through the transparency value on the
+   * edge, where a flow of 0.0 will correspond to an invisible edge, and a flow
+   * of 1.0 will display as a fully black edge. */
   bool show_flows{true};
 
-  /** Determines whether the cost value results are shown. This
-  will show both edge and vertex costs. */
+  /** Determines whether the cost value results are shown. This will show both
+   * edge and vertex costs. */
   bool show_costs{true};
 
-  /** Sets the floating point formatting to scientific (if true)
-  or fixed (if false). */
+  /** Sets the floating point formatting to scientific (if true) or fixed (if
+   * false). */
   bool scientific{false};
 
-  /** Sets the floating point precision (how many digits are
-  generated) of the annotations. */
+  /** Sets the floating point precision (how many digits are generated) of the
+   * annotations. */
   int precision{3};
 };
 

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -138,8 +138,8 @@ struct GcsGraphvizOptions {
 
   /** Determines whether the flow value results are shown. The flow values are
    * shown both with a numeric value and through the transparency value on the
-   * edge, where a flow of 0.0 will correspond to an invisible edge, and a flow
-   * of 1.0 will display as a fully black edge. */
+   * edge, where a flow of 0.0 will correspond to an (almost) invisible edge,
+   * and a flow of 1.0 will display as a fully black edge. */
   bool show_flows{true};
 
   /** Determines whether the cost value results are shown. This will show both

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -632,6 +632,14 @@ class GraphOfConvexSets {
   values.
   @param show_slacks determines whether the values of the intermediate
   (slack) variables are also displayed in the graph.
+  @param show_vars determines whether the solution values for decision variables
+  in each set are shown.
+  @param show_flows determines whether the flow value results are shown. The
+  flow values are shown both with a numeric value and through the transparency
+  value on the edge, where a flow of 0.0 will correspond to an invisible edge,
+  and a flow of 1.0 will display as a fully black edge.
+  @param show_costs determines whether the cost value results are shown. This
+  will show both edge and vertex costs
   @param precision sets the floating point precision (how many digits are
   generated) of the annotations.
   @param scientific sets the floating point formatting to scientific (if true)
@@ -642,6 +650,7 @@ class GraphOfConvexSets {
       const std::optional<solvers::MathematicalProgramResult>& result =
           std::nullopt,
       bool show_slacks = true, int precision = 3, bool scientific = false,
+      bool show_vars = true, bool show_costs = true, bool show_flows = true,
       const std::optional<std::vector<const Edge*>>& active_path =
           std::nullopt) const;
 

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -673,8 +673,10 @@ class GraphOfConvexSets {
   values, according to `options`.
   @param result the optional result from a solver.
   @param options the struct containing various options for visualization.
-  @param active_path optionally highlights a path in the graph. The path is
-  displayed addition to the edges as additional red edges in the graph. */
+  @param active_path optionally highlights a given path in the graph. The path
+  is displayed as dashed edges in red, displayed in addition to the original
+  graph edges.
+   */
   std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result =
           std::nullopt,

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -636,12 +636,14 @@ class GraphOfConvexSets {
   generated) of the annotations.
   @param scientific sets the floating point formatting to scientific (if true)
   or fixed (if false).
+  @param active_path highlights a path in the graph with red edges.
   */
   std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result =
           std::nullopt,
-      bool show_slacks = true, int precision = 3,
-      bool scientific = false) const;
+      bool show_slacks = true, int precision = 3, bool scientific = false,
+      const std::optional<std::vector<const Edge*>>& active_path =
+          std::nullopt) const;
 
   /** Formulates and solves the mixed-integer convex formulation of the
   shortest path problem on the graph, as discussed in detail in

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -127,6 +127,34 @@ struct GraphOfConvexSetsOptions {
   }
 };
 
+struct GcsGraphvizOptions {
+  /** Determines whether the values of the intermediate
+  (slack) variables are also displayed in the graph. */
+  bool show_slacks{true};
+
+  /** Determines whether the solution values for decision variables
+  in each set are shown. */
+  bool show_vars{true};
+
+  /** Determines whether the flow value results are shown. The
+  flow values are shown both with a numeric value and through the transparency
+  value on the edge, where a flow of 0.0 will correspond to an invisible edge,
+  and a flow of 1.0 will display as a fully black edge. */
+  bool show_flows{true};
+
+  /** Determines whether the cost value results are shown. This
+  will show both edge and vertex costs. */
+  bool show_costs{true};
+
+  /** Sets the floating point formatting to scientific (if true)
+  or fixed (if false). */
+  bool scientific{false};
+
+  /** Sets the floating point precision (how many digits are
+  generated) of the annotations. */
+  int precision{3};
+};
+
 /**
 GraphOfConvexSets (GCS) implements the design pattern and optimization problems
 first introduced in the paper "Shortest Paths in Graphs of Convex Sets".
@@ -627,30 +655,18 @@ class GraphOfConvexSets {
   /** Removes all constraints added to any edge with AddPhiConstraint. */
   void ClearAllPhiConstraints();
 
-  /** Returns a Graphviz string describing the graph vertices and edges.  If
+  /**
+  Returns a Graphviz string describing the graph vertices and edges. If
   `results` is supplied, then the graph will be annotated with the solution
-  values.
-  @param show_slacks determines whether the values of the intermediate
-  (slack) variables are also displayed in the graph.
-  @param show_vars determines whether the solution values for decision variables
-  in each set are shown.
-  @param show_flows determines whether the flow value results are shown. The
-  flow values are shown both with a numeric value and through the transparency
-  value on the edge, where a flow of 0.0 will correspond to an invisible edge,
-  and a flow of 1.0 will display as a fully black edge.
-  @param show_costs determines whether the cost value results are shown. This
-  will show both edge and vertex costs
-  @param precision sets the floating point precision (how many digits are
-  generated) of the annotations.
-  @param scientific sets the floating point formatting to scientific (if true)
-  or fixed (if false).
-  @param active_path highlights a path in the graph with red edges.
-  */
+  values, according to `options`.
+  @param result the optional result from a solver.
+  @param options the struct containing various options for visualization.
+  @param active_path optionally highlights a path in the graph. The path is
+  displayed addition to the edges as additional red edges in the graph. */
   std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result =
           std::nullopt,
-      bool show_slacks = true, int precision = 3, bool scientific = false,
-      bool show_vars = true, bool show_costs = true, bool show_flows = true,
+      const GcsGraphvizOptions& options = GcsGraphvizOptions(),
       const std::optional<std::vector<const Edge*>>& active_path =
           std::nullopt) const;
 

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -2915,6 +2915,8 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   options.preprocessing = true;
   options.convex_relaxation = true;
 
+  GcsGraphvizOptions viz_options;
+
   // Note: Testing the entire string against a const string is too fragile,
   // since the VertexIds are Identifier<> and increment on a global counter.
   EXPECT_THAT(g.GetGraphvizString(),
@@ -2934,46 +2936,42 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
               AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ =")));
 
   // No slack variables.
-  EXPECT_THAT(g.GetGraphvizString(result, /*show_slacks=*/false),
+  viz_options.show_slacks = false;
+  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
               AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ ="),
                     Not(HasSubstr("ϕ xᵤ =")), Not(HasSubstr("ϕ xᵥ ="))));
 
   // Precision and scientific.
-  EXPECT_THAT(
-      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
-                          /*scientific=*/false),
-      AllOf(HasSubstr("x = [1.00 2.00]"), HasSubstr("x = [0.00]")));
-  EXPECT_THAT(
-      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
-                          /*scientific=*/true),
-      AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-05]")));
+  viz_options.precision = 2;
+  viz_options.scientific = false;
+  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+              AllOf(HasSubstr("x = [1.00 2.00]"), HasSubstr("x = [0.00]")));
+
+  viz_options.scientific = true;
+  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+              AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-05]")));
 
   // No vertex vars
-  EXPECT_THAT(
-      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
-                          /*scientific=*/false, /*show_vars=*/false),
-      AllOf(Not(HasSubstr("x ="))));
+  viz_options.show_vars = false;
+  viz_options.scientific = false;
+  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+              AllOf(Not(HasSubstr("x ="))));
 
   // No cost
-  EXPECT_THAT(
-      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
-                          /*scientific=*/false, /*show_vars=*/false,
-                          /*show_costs=*/false),
-      AllOf(Not(HasSubstr("cost ="))));
+  viz_options.show_costs = false;
+  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+              AllOf(Not(HasSubstr("cost ="))));
 
   // No flows
-  EXPECT_THAT(
-      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
-                          /*scientific=*/false, /*show_vars=*/false,
-                          /*show_costs=*/false, /*show_flows*/ false),
-      Not(AllOf(HasSubstr("ϕ ="))));
+  viz_options.show_flows = false;
+  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+              Not(AllOf(HasSubstr("ϕ ="))));
 
   // Show active path
+  viz_options.show_flows = false;
+  viz_options.show_costs = false;
   EXPECT_THAT(
-      g.GetGraphvizString(result, /*show_slacks=*/false,
-                          /*precision=*/2, /*scientific=*/false,
-                          /*show_vars=*/false, /*show_costs=*/false,
-                          /*show_flows*/ false, std::vector<const Edge*>{edge}),
+      g.GetGraphvizString(result, viz_options, std::vector<const Edge*>{edge}),
       AllOf(HasSubstr("color=")));
 }
 

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -2901,6 +2901,27 @@ GTEST_TEST(ShortestPathTest, SavvaBoxExample) {
   }
 }
 
+GTEST_TEST(GcsGraphvizOptionsTest, Serialize) {
+  GcsGraphvizOptions options;
+  options.show_slacks = false;
+  options.show_vars = false;
+  options.show_flows = false;
+  options.show_costs = false;
+  options.scientific = true;
+  options.precision = 5;
+
+  const std::string serialized = yaml::SaveYamlString(options);
+  const auto deserialized =
+      yaml::LoadYamlString<GcsGraphvizOptions>(serialized);
+
+  EXPECT_EQ(deserialized.show_slacks, options.show_slacks);
+  EXPECT_EQ(deserialized.show_vars, options.show_vars);
+  EXPECT_EQ(deserialized.show_flows, options.show_flows);
+  EXPECT_EQ(deserialized.show_costs, options.show_costs);
+  EXPECT_EQ(deserialized.scientific, options.scientific);
+  EXPECT_EQ(deserialized.precision, options.precision);
+}
+
 GTEST_TEST(ShortestPathTest, Graphviz) {
   GraphOfConvexSets g;
   auto source = g.AddVertex(Point(Vector2d{1.0, 2.}), "source");

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -2943,6 +2943,7 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   EXPECT_THAT(g.GetGraphvizString(),
               AllOf(HasSubstr("source"), HasSubstr("target"),
                     HasSubstr("source_to_target")));
+
   auto result = g.SolveShortestPath(*source, *target, options);
   EXPECT_THAT(g.GetGraphvizString(result),
               AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ ="),
@@ -2954,7 +2955,8 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   // Note: The cost here only comes from the cost=0 on other_to_target until
   // SolveConvexRestriction provides the rewritten costs.
   EXPECT_THAT(g.GetGraphvizString(result),
-              AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ =")));
+              AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ ="),
+                    HasSubstr("color=\"#00000020\"]")));
 
   // No slack variables.
   viz_options.show_slacks = false;

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -2905,7 +2905,7 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   GraphOfConvexSets g;
   auto source = g.AddVertex(Point(Vector2d{1.0, 2.}), "source");
   auto target = g.AddVertex(Point(Vector1d{1e-5}), "target");
-  g.AddEdge(source, target, "source_to_target")->AddCost(1.23);
+  auto edge = g.AddEdge(source, target, "source_to_target")->AddCost(1.23);
   auto other = g.AddVertex(Point(Vector1d{4.0}), "other");
   g.AddEdge(source, other, "source_to_other")->AddCost(3.45);
   g.AddEdge(other, target, "other_to_target");  // No cost from other to target.
@@ -2934,14 +2934,40 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
 
   // No slack variables.
   EXPECT_THAT(
-      g.GetGraphvizString(result, false),
+      g.GetGraphvizString(result, show_slacks = false),
       AllOf(HasSubstr("x ="), HasSubstr("cost ="), Not(HasSubstr("ϕ =")),
             Not(HasSubstr("ϕ xᵤ =")), Not(HasSubstr("ϕ xᵥ ="))));
+
   // Precision and scientific.
-  EXPECT_THAT(g.GetGraphvizString(result, false, 2, false),
+  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
+                                  scientific = false),
               AllOf(HasSubstr("x = [1.00 2.00]"), HasSubstr("x = [0.00]")));
-  EXPECT_THAT(g.GetGraphvizString(result, false, 2, true),
+  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
+                                  scientific = true),
               AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-05]")));
+
+  // No vertex vars
+  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
+                                  scientific = false, show_vars = false),
+              AllOf(Not(HasSubstr("x ="))));
+
+  // No cost
+  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
+                                  scientific = false, show_vars = false,
+                                  show_costs = false),
+              AllOf(Not(HasSubstr("cost ="))));
+
+  // No flows
+  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
+                                  scientific = false, show_vars = false,
+                                  show_costs = false),
+              Not(AllOf(HasSubstr("ϕ ="))));
+
+  // Show active path
+  EXPECT_THAT(g.GetGraphvizString(
+      result, show_slacks = false, precision = 2, scientific = false,
+      show_vars = false, show_costs = false, active_path = std::vector{edge},
+      AllOf(HasSubstr("color="))));
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -2947,7 +2947,9 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   auto result = g.SolveShortestPath(*source, *target, options);
   EXPECT_THAT(g.GetGraphvizString(result),
               AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ ="),
-                    HasSubstr("ϕ xᵤ ="), HasSubstr("ϕ xᵥ =")));
+                    HasSubstr("ϕ xᵤ ="), HasSubstr("ϕ xᵥ ="),
+                    Not(HasSubstr("color=\"#ff0000\"")),
+                    HasSubstr("color=\"#00000020\"]")));
 
   // With a rounded result.
   options.max_rounded_paths = 1;
@@ -2987,15 +2989,16 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
 
   // No flows
   viz_options.show_flows = false;
-  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
-              Not(AllOf(HasSubstr("ϕ ="))));
+  EXPECT_THAT(
+      g.GetGraphvizString(result, viz_options),
+      AllOf(Not(HasSubstr("ϕ =")), Not(HasSubstr("color=\"#00000020\"]"))));
 
   // Show active path
   viz_options.show_flows = false;
   viz_options.show_costs = false;
   EXPECT_THAT(
       g.GetGraphvizString(result, viz_options, std::vector<const Edge*>{edge}),
-      AllOf(HasSubstr("color=")));
+      AllOf(HasSubstr("color=\"#ff0000\"")));
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -2905,7 +2905,8 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   GraphOfConvexSets g;
   auto source = g.AddVertex(Point(Vector2d{1.0, 2.}), "source");
   auto target = g.AddVertex(Point(Vector1d{1e-5}), "target");
-  auto edge = g.AddEdge(source, target, "source_to_target")->AddCost(1.23);
+  Edge* edge = g.AddEdge(source, target, "source_to_target");
+  edge->AddCost(1.23);
   auto other = g.AddVertex(Point(Vector1d{4.0}), "other");
   g.AddEdge(source, other, "source_to_other")->AddCost(3.45);
   g.AddEdge(other, target, "other_to_target");  // No cost from other to target.
@@ -2933,41 +2934,47 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
               AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ =")));
 
   // No slack variables.
-  EXPECT_THAT(
-      g.GetGraphvizString(result, show_slacks = false),
-      AllOf(HasSubstr("x ="), HasSubstr("cost ="), Not(HasSubstr("ϕ =")),
-            Not(HasSubstr("ϕ xᵤ =")), Not(HasSubstr("ϕ xᵥ ="))));
+  EXPECT_THAT(g.GetGraphvizString(result, /*show_slacks=*/false),
+              AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ ="),
+                    Not(HasSubstr("ϕ xᵤ =")), Not(HasSubstr("ϕ xᵥ ="))));
 
   // Precision and scientific.
-  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
-                                  scientific = false),
-              AllOf(HasSubstr("x = [1.00 2.00]"), HasSubstr("x = [0.00]")));
-  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
-                                  scientific = true),
-              AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-05]")));
+  EXPECT_THAT(
+      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
+                          /*scientific=*/false),
+      AllOf(HasSubstr("x = [1.00 2.00]"), HasSubstr("x = [0.00]")));
+  EXPECT_THAT(
+      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
+                          /*scientific=*/true),
+      AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-05]")));
 
   // No vertex vars
-  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
-                                  scientific = false, show_vars = false),
-              AllOf(Not(HasSubstr("x ="))));
+  EXPECT_THAT(
+      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
+                          /*scientific=*/false, /*show_vars=*/false),
+      AllOf(Not(HasSubstr("x ="))));
 
   // No cost
-  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
-                                  scientific = false, show_vars = false,
-                                  show_costs = false),
-              AllOf(Not(HasSubstr("cost ="))));
+  EXPECT_THAT(
+      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
+                          /*scientific=*/false, /*show_vars=*/false,
+                          /*show_costs=*/false),
+      AllOf(Not(HasSubstr("cost ="))));
 
   // No flows
-  EXPECT_THAT(g.GetGraphvizString(result, show_slacks = false, precision = 2,
-                                  scientific = false, show_vars = false,
-                                  show_costs = false),
-              Not(AllOf(HasSubstr("ϕ ="))));
+  EXPECT_THAT(
+      g.GetGraphvizString(result, /*show_slacks=*/false, /*precision=*/2,
+                          /*scientific=*/false, /*show_vars=*/false,
+                          /*show_costs=*/false, /*show_flows*/ false),
+      Not(AllOf(HasSubstr("ϕ ="))));
 
   // Show active path
-  EXPECT_THAT(g.GetGraphvizString(
-      result, show_slacks = false, precision = 2, scientific = false,
-      show_vars = false, show_costs = false, active_path = std::vector{edge},
-      AllOf(HasSubstr("color="))));
+  EXPECT_THAT(
+      g.GetGraphvizString(result, /*show_slacks=*/false,
+                          /*precision=*/2, /*scientific=*/false,
+                          /*show_vars=*/false, /*show_costs=*/false,
+                          /*show_flows*/ false, std::vector<const Edge*>{edge}),
+      AllOf(HasSubstr("color=")));
 }
 
 }  // namespace optimization

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -483,8 +483,7 @@ class GcsTrajectoryOptimization final {
   std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result =
           std::nullopt,
-      const geometry::optimization::GcsGraphvizOptions& options =
-          geometry::optimization::GcsGraphvizOptions()) const {
+      const geometry::optimization::GcsGraphvizOptions& options = {}) const {
     return gcs_.GetGraphvizString(result, options);
   }
 

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -483,9 +483,9 @@ class GcsTrajectoryOptimization final {
   std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result =
           std::nullopt,
-      bool show_slack = true, int precision = 3,
-      bool scientific = false) const {
-    return gcs_.GetGraphvizString(result, show_slack, precision, scientific);
+      const geometry::optimization::GcsGraphvizOptions& options =
+          geometry::optimization::GcsGraphvizOptions()) const {
+    return gcs_.GetGraphvizString(result, options);
   }
 
   /** Creates a Subgraph with the given regions and indices.


### PR DESCRIPTION
Adds a few features to the GCS Graphviz code when a `result` is passed, and additionally make it possible to turn on/off the visualization of different quantities.j

Changes:
- `show_vars`: Decide to show vertex var results
- `show_costs`: Decide to show costs AND also plot vertex costs (these were not currently shown)
- `show_flows`: Plots the flow values as `\phi = ..` and also dims the edge based on the flow value
- `active_path`: If provided, the graph will show the path in red on the graph. This is useful when debugging workflows with multiple different paths through the graph, to quickly be able to show a path in the graph.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21530)
<!-- Reviewable:end -->
