### PR TITLE
[examples] Fix bad habit in manipulation station

### DIFF
--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -295,21 +295,13 @@ MakeD415CameraModel(const std::string& renderer_name) {
 
 template <typename T>
 ManipulationStation<T>::ManipulationStation(double time_step)
-    : owned_plant_(std::make_unique<MultibodyPlant<T>>(time_step)),
-      owned_scene_graph_(std::make_unique<SceneGraph<T>>()),
+    : builder_(std::make_unique<systems::DiagramBuilder<T>>()),
       // Given the controller does not compute accelerations, it is irrelevant
-      // whether the plant is continuous or discrete. We make it
-      // discrete to avoid warnings about joint limits.
+      // whether the plant is continuous or discrete. We make it discrete to
+      // avoid warnings about joint limits.
       owned_controller_plant_(std::make_unique<MultibodyPlant<T>>(1.0)) {
-  // This class holds the unique_ptrs explicitly for plant and scene_graph
-  // until Finalize() is called (when they are moved into the Diagram). Grab
-  // the raw pointers, which should stay valid for the lifetime of the Diagram.
-  plant_ = owned_plant_.get();
-  scene_graph_ = owned_scene_graph_.get();
-  plant_->RegisterAsSourceForSceneGraph(scene_graph_);
-  scene_graph_->set_name("scene_graph");
-  plant_->set_name("plant");
-
+  std::tie(plant_, scene_graph_) =
+      multibody::AddMultibodyPlantSceneGraph(builder_.get(), time_step);
   this->set_name("manipulation_station");
 }
 
@@ -659,16 +651,8 @@ void ManipulationStation<T>::Finalize(
     }
   }
 
-  systems::DiagramBuilder<T> builder;
-
-  builder.AddSystem(std::move(owned_plant_));
-  builder.AddSystem(std::move(owned_scene_graph_));
-
-  builder.Connect(
-      plant_->get_geometry_poses_output_port(),
-      scene_graph_->get_source_pose_port(plant_->get_source_id().value()));
-  builder.Connect(scene_graph_->get_query_output_port(),
-                  plant_->get_geometry_query_input_port());
+  DRAKE_DEMAND(builder_ != nullptr);
+  systems::DiagramBuilder<T>& builder = *builder_;
 
   const int num_iiwa_positions =
       plant_->num_positions(iiwa_model_.model_instance);

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -13,6 +13,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
 
 namespace drake {
 namespace examples {
@@ -510,9 +511,8 @@ class ManipulationStation : public systems::Diagram<T> {
   void AddDefaultIiwa(const IiwaCollisionModel collision_model);
   void AddDefaultWsg(const SchunkCollisionModel schunk_model);
 
-  // These are only valid until Finalize() is called.
-  std::unique_ptr<multibody::MultibodyPlant<T>> owned_plant_;
-  std::unique_ptr<geometry::SceneGraph<T>> owned_scene_graph_;
+  // This is only valid until Finalize() is called.
+  std::unique_ptr<systems::DiagramBuilder<T>> builder_;
 
   // These are valid for the lifetime of this system.
   std::unique_ptr<multibody::MultibodyPlant<T>> owned_controller_plant_;


### PR DESCRIPTION
Manually connecting the MbP to a SG is error-prone and not future-proof.  Our examples should not do it, since we don't want users to do it either.

Towards #20545.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21531)
<!-- Reviewable:end -->
