### PR TITLE
[multibody] Clean up internal plant continuous time naming

### DIFF
--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -300,9 +300,9 @@ void DiscreteUpdateManager<T>::CalcForceElementsContribution(
 
 template <typename T>
 const internal::JointLockingCacheData<T>&
-DiscreteUpdateManager<T>::EvalJointLockingCache(
+DiscreteUpdateManager<T>::EvalJointLocking(
     const systems::Context<T>& context) const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalJointLockingCache(
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalJointLocking(
       plant(), context);
 }
 
@@ -660,7 +660,7 @@ void DiscreteUpdateManager<T>::CalcHydroelasticContactInfo(
 
   const MultibodyTreeTopology& topology = internal_tree().get_topology();
   const std::vector<std::vector<int>>& per_tree_unlocked_indices =
-      EvalJointLockingCache(context).unlocked_velocity_indices_per_tree;
+      EvalJointLocking(context).unlocked_velocity_indices_per_tree;
 
   // Update contact info to include the correct contact forces.
   for (int surface_index = 0; surface_index < num_surfaces; ++surface_index) {
@@ -808,7 +808,7 @@ void DiscreteUpdateManager<T>::AppendDiscreteContactPairsForPointContact(
           .template Eval<geometry::QueryObject<T>>(context);
   const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
   const std::vector<std::vector<int>>& per_tree_unlocked_indices =
-      EvalJointLockingCache(context).unlocked_velocity_indices_per_tree;
+      EvalJointLocking(context).unlocked_velocity_indices_per_tree;
   const MultibodyTreeTopology& topology = internal_tree().get_topology();
   const Eigen::VectorBlock<const VectorX<T>> v = plant().GetVelocities(context);
   const Frame<T>& frame_W = plant().world_frame();
@@ -979,7 +979,7 @@ void DiscreteUpdateManager<T>::AppendDiscreteContactPairsForHydroelasticContact(
           .template Eval<geometry::QueryObject<T>>(context);
   const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
   const std::vector<std::vector<int>>& per_tree_unlocked_indices =
-      EvalJointLockingCache(context).unlocked_velocity_indices_per_tree;
+      EvalJointLocking(context).unlocked_velocity_indices_per_tree;
   const MultibodyTreeTopology& topology = internal_tree().get_topology();
   const Eigen::VectorBlock<const VectorX<T>> v = plant().GetVelocities(context);
   const Frame<T>& frame_W = plant().world_frame();

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -309,7 +309,7 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   void CalcForceElementsContribution(const drake::systems::Context<T>& context,
                                      MultibodyForces<T>* forces) const;
 
-  const internal::JointLockingCacheData<T>& EvalJointLockingCache(
+  const internal::JointLockingCacheData<T>& EvalJointLocking(
       const systems::Context<T>& context) const;
 
   VectorX<T> AssembleActuationInput(const systems::Context<T>& context) const;

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -44,15 +44,15 @@ namespace internal {
 // Data stored in the cache entry for the hydroelastic with fallback contact
 // model.
 template <typename T>
-struct HydroelasticFallbackCacheData {
+struct HydroelasticWithFallbackCacheData {
   std::vector<geometry::ContactSurface<T>> contact_surfaces;
   std::vector<geometry::PenetrationAsPointPair<T>> point_pairs;
 };
 
 // Structure used in the calculation of hydroelastic contact forces.
 template <typename T>
-struct HydroelasticContactInfoAndBodySpatialForces {
-  explicit HydroelasticContactInfoAndBodySpatialForces(int num_bodies) {
+struct HydroelasticContactForcesContinuousCacheData {
+  explicit HydroelasticContactForcesContinuousCacheData(int num_bodies) {
     F_BBo_W_array.resize(num_bodies);
   }
 
@@ -2867,7 +2867,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// A user can request the set of all free bodies with a call to
   /// GetFloatingBaseBodies(). Alternatively, a user can query whether a
   /// RigidBody is free (floating) or not with RigidBody::is_floating().
-  /// For many applications, a user might need to work with indexes in the
+  /// For many applications, a user might need to work with indices in the
   /// multibody state vector. For such applications,
   /// RigidBody::floating_positions_start() and
   /// RigidBody::floating_velocities_start_in_v() offer the additional level of
@@ -2884,7 +2884,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// underscores to the name until it is unique.
   /// @{
 
-  /// Returns the set of body indexes corresponding to the free (floating)
+  /// Returns the set of body indices corresponding to the free (floating)
   /// bodies in the model, in no particular order.
   /// @throws std::exception if called pre-finalize, see Finalize().
   std::unordered_set<BodyIndex> GetFloatingBaseBodies() const;
@@ -3141,13 +3141,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     this->ValidateContext(context);
     switch (contact_model_) {
       case ContactModel::kPoint:
-        return this->get_cache_entry(cache_indexes_.point_pairs)
+        return this->get_cache_entry(cache_indices_.point_pairs)
             .template Eval<std::vector<geometry::PenetrationAsPointPair<T>>>(
                 context);
       case ContactModel::kHydroelasticWithFallback: {
         const auto& data =
-            this->get_cache_entry(cache_indexes_.hydro_fallback)
-                .template Eval<internal::HydroelasticFallbackCacheData<T>>(
+            this->get_cache_entry(cache_indices_.hydroelastic_with_fallback)
+                .template Eval<internal::HydroelasticWithFallbackCacheData<T>>(
                     context);
         return data.point_pairs;
       }
@@ -4205,7 +4205,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// positions for `user_to_joint_index_map[1]`, etc. Similarly for the
   /// selected velocities vₛ.
   ///
-  /// @throws std::exception if there are repeated indexes in
+  /// @throws std::exception if there are repeated indices in
   /// `user_to_joint_index_map`.
   MatrixX<double> MakeStateSelectorMatrix(
       const std::vector<JointIndex>& user_to_joint_index_map) const {
@@ -4244,7 +4244,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// The vector u of actuation values is of size num_actuated_dofs(). For a
   /// given JointActuator, `u[JointActuator::input_start()]` stores the value
   /// for the external actuation corresponding to that actuator. `tau_u` on the
-  /// other hand is indexed by generalized velocity indexes according to
+  /// other hand is indexed by generalized velocity indices according to
   /// `Joint::velocity_start()`.
   /// @warning B is a permutation matrix. While making a permutation has
   /// `O(n)` complexity, making a full B matrix has `O(n²)` complexity. For most
@@ -4497,7 +4497,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Returns a list of all joint indices. The vector is ordered by
-  /// monotonically increasing @ref JointIndex, but the indexes will in
+  /// monotonically increasing @ref JointIndex, but the indices will in
   /// general not be consecutive due to joints that were removed.
   const std::vector<JointIndex>& GetJointIndices() const {
     return internal_tree().GetJointIndices();
@@ -4510,7 +4510,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Returns a list of all joint actuator indices. The vector is ordered by
-  /// monotonically increasing @ref JointActuatorIndex, but the indexes will in
+  /// monotonically increasing @ref JointActuatorIndex, but the indices will in
   /// general not be consecutive due to actuators that were removed.
   const std::vector<JointActuatorIndex>& GetJointActuatorIndices() const {
     return internal_tree().GetJointActuatorIndices();
@@ -4989,19 +4989,23 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   friend class internal::MultibodyPlantModelAttorney<T>;
   friend class internal::MultibodyPlantDiscreteUpdateManagerAttorney<T>;
 
-  // This struct stores in one single place all indexes related to
+  // This struct stores in one single place all indices related to
   // MultibodyPlant specific cache entries. These are initialized at Finalize()
   // when the plant declares its cache entries.
-  struct CacheIndexes {
-    systems::CacheIndex contact_info_and_body_spatial_forces;
-    systems::CacheIndex contact_results;
+  struct CacheIndices {
     systems::CacheIndex contact_surfaces;
-    systems::CacheIndex generalized_contact_forces_continuous;
-    systems::CacheIndex hydro_fallback;
+    systems::CacheIndex hydroelastic_with_fallback;
     systems::CacheIndex point_pairs;
-    systems::CacheIndex spatial_contact_forces_continuous;
     systems::CacheIndex discrete_contact_pairs;
-    systems::CacheIndex joint_locking_data;
+    systems::CacheIndex joint_locking;
+
+    // This is only valid for a continuous-time, hydroelastic-contact plant.
+    systems::CacheIndex hydroelastic_contact_forces_continuous;
+
+    // These are only valid for a continuous-time plant.
+    systems::CacheIndex contact_results_continuous;
+    systems::CacheIndex spatial_contact_forces_continuous;
+    systems::CacheIndex generalized_contact_forces_continuous;
   };
 
   // This struct stores in one single place all indices related to
@@ -5163,8 +5167,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   //  - Externally applied spatial forces.
   //  - Joint limits.
   // @pre The plant is continuous.
-  void CalcNonContactForces(const drake::systems::Context<T>& context,
-                            MultibodyForces<T>* forces) const;
+  void CalcNonContactForcesContinuous(const drake::systems::Context<T>& context,
+                                      MultibodyForces<T>* forces) const;
 
   // Collects up forces from input ports (actuator, generalized, and spatial
   // forces) and contact forces (from compliant contact models). Does not
@@ -5200,13 +5204,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // Data will be resized on output according to the documentation for
   // JointLockingCacheData.
-  void CalcJointLockingCache(const systems::Context<T>& context,
-                             internal::JointLockingCacheData<T>* data) const;
+  void CalcJointLocking(const systems::Context<T>& context,
+                        internal::JointLockingCacheData<T>* data) const;
 
-  // Eval version of the method CalcJointLockingCache().
-  const internal::JointLockingCacheData<T>& EvalJointLockingCache(
+  // Eval version of the method CalcJointLocking().
+  const internal::JointLockingCacheData<T>& EvalJointLocking(
       const systems::Context<T>& context) const {
-    return this->get_cache_entry(cache_indexes_.joint_locking_data)
+    return this->get_cache_entry(cache_indices_.joint_locking)
         .template Eval<internal::JointLockingCacheData<T>>(context);
   }
 
@@ -5224,13 +5228,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     switch (contact_model_) {
       case ContactModel::kHydroelasticWithFallback: {
         const auto& data =
-            this->get_cache_entry(cache_indexes_.hydro_fallback)
-                .template Eval<internal::HydroelasticFallbackCacheData<T>>(
+            this->get_cache_entry(cache_indices_.hydroelastic_with_fallback)
+                .template Eval<internal::HydroelasticWithFallbackCacheData<T>>(
                     context);
         return data.contact_surfaces;
       }
       case ContactModel::kHydroelastic:
-        return this->get_cache_entry(cache_indexes_.contact_surfaces)
+        return this->get_cache_entry(cache_indices_.contact_surfaces)
             .template Eval<std::vector<geometry::ContactSurface<T>>>(context);
       default:
         throw std::logic_error(
@@ -5243,7 +5247,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // between ContactSurfaces and point pair contacts.
   void CalcHydroelasticWithFallback(
       const drake::systems::Context<T>& context,
-      internal::HydroelasticFallbackCacheData<T>* data) const;
+      internal::HydroelasticWithFallbackCacheData<T>* data) const;
 
   // Helper method to fill in the ContactResults given the current context when
   // the model is continuous.
@@ -5255,27 +5259,20 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // for the point pair model, given the current context. Called by
   // CalcContactResultsContinuous.
   // @param[in,out] contact_results is appended to
-  void AppendContactResultsContinuousPointPair(
+  void AppendContactResultsPointPairContinuous(
       const systems::Context<T>& context,
       ContactResults<T>* contact_results) const;
 
   // Helper method to fill in `contact_results` with hydroelastic forces as a
   // function of the state stored in `context`.
   // @param[in,out] contact_results is appended to
-  void AppendContactResultsContinuousHydroelastic(
+  void AppendContactResultsHydroelasticContinuous(
       const systems::Context<T>& context,
       ContactResults<T>* contact_results) const;
 
   // Evaluate contact results.
   const ContactResults<T>& EvalContactResults(
-      const systems::Context<T>& context) const {
-    if (this->is_discrete()) {
-      return discrete_update_manager_->EvalContactResults(context);
-    } else {
-      return this->get_cache_entry(cache_indexes_.contact_results)
-          .template Eval<ContactResults<T>>(context);
-    }
-  }
+      const systems::Context<T>& context) const;
 
   // Calc method for the reaction forces output port.
   // A joint constraints the motion between a frame Jp on a "parent" P and a
@@ -5375,6 +5372,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const drake::systems::Context<T>& context,
       std::vector<SpatialForce<T>>* F_BBo_W_array) const;
 
+  // Eval version of CalcSpatialContactForcesContinuous().
+  const std::vector<SpatialForce<T>>& EvalSpatialContactForcesContinuous(
+      const systems::Context<T>& context) const;
+
   // Method to compute spatial contact forces for continuous plants.
   // @note This version does *not* zero out the forces in @p F_BBo_W_array.
   // @see CalcSpatialContactForcesContinuous() for the version of this method
@@ -5383,25 +5384,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const drake::systems::Context<T>& context,
       std::vector<SpatialForce<T>>* F_BBo_W_array) const;
 
-  // Eval() version of the method CalcSpatialContactForcesContinuous().
-  const std::vector<SpatialForce<T>>& EvalSpatialContactForcesContinuous(
-      const systems::Context<T>& context) const {
-    return this
-        ->get_cache_entry(cache_indexes_.spatial_contact_forces_continuous)
-        .template Eval<std::vector<SpatialForce<T>>>(context);
-  }
-
   // Method to compute generalized contact forces for continuous plants.
   void CalcGeneralizedContactForcesContinuous(
       const drake::systems::Context<T>& context, VectorX<T>* tau_contact) const;
 
-  // Eval() version of the method CalcGeneralizedContactForcesContinuous().
+  // Eval version of CalcGeneralizedContactForcesContinuous().
   const VectorX<T>& EvalGeneralizedContactForcesContinuous(
-      const systems::Context<T>& context) const {
-    return this
-        ->get_cache_entry(cache_indexes_.generalized_contact_forces_continuous)
-        .template Eval<VectorX<T>>(context);
-  }
+      const systems::Context<T>& context) const;
 
   // Calc method to output per model instance vector of generalized contact
   // forces.
@@ -5428,27 +5417,20 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // (Advanced) Helper method to compute contact forces in the normal direction
   // using a penalty method.
-  void CalcAndAddContactForcesByPenaltyMethod(
+  void CalcAndAddPointContactForcesContinuous(
       const systems::Context<T>& context,
       std::vector<SpatialForce<T>>* F_BBo_W_array) const;
 
-  // Helper method to compute contact forces using the hydroelastic model.
-  // F_BBo_W_array is indexed by MobodIndex and it gets overwritten on
-  // output. F_BBo_W_array must be of size num_bodies() or an exception is
-  // thrown.
-  void CalcHydroelasticContactForces(
+  // Helper method to compute continuous-time contact forces using the
+  // hydroelastic model for continuous plants.
+  void CalcHydroelasticContactForcesContinuous(
       const systems::Context<T>& context,
-      internal::HydroelasticContactInfoAndBodySpatialForces<T>* F_BBo_W_array)
-      const;
+      internal::HydroelasticContactForcesContinuousCacheData<T>* output) const;
 
   // Eval version of CalcHydroelasticContactForces().
-  const internal::HydroelasticContactInfoAndBodySpatialForces<T>&
-  EvalHydroelasticContactForces(const systems::Context<T>& context) const {
-    return this
-        ->get_cache_entry(cache_indexes_.contact_info_and_body_spatial_forces)
-        .template Eval<
-            internal::HydroelasticContactInfoAndBodySpatialForces<T>>(context);
-  }
+  const internal::HydroelasticContactForcesContinuousCacheData<T>&
+  EvalHydroelasticContactForcesContinuous(
+      const systems::Context<T>& context) const;
 
   // Helper method to apply penalty forces that enforce joint limits.
   // At each joint with joint limits this penalty method applies a force law of
@@ -5629,7 +5611,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // scalar-converted scene graph).
   geometry::SceneGraph<T>* scene_graph_{nullptr};
 
-  // Input/Output port indexes:
+  // Input/Output port indices:
 
   // A vector containing actuation ports for each model instance indexed by
   // ModelInstanceIndex. Every model instance has a corresponding port even
@@ -5718,8 +5700,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   std::map<MultibodyConstraintId, internal::WeldConstraintSpec>
       weld_constraints_specs_;
 
-  // All MultibodyPlant cache indexes are stored in cache_indexes_.
-  CacheIndexes cache_indexes_;
+  // All MultibodyPlant cache indices are stored in cache_indices_.
+  CacheIndices cache_indices_;
 
   // All MultibodyPlant parameter indices are stored in parameter_indices_.
   ParameterIndices parameter_indices_;
@@ -5874,13 +5856,14 @@ std::pair<T, T> CombinePointContactParameters(const T& k1, const T& k2,
 // Forward-declare specializations, prior to DRAKE_DECLARE... below.
 // See the .cc file for an explanation why we specialize these methods.
 template <>
-void MultibodyPlant<symbolic::Expression>::CalcHydroelasticContactForces(
-    const systems::Context<symbolic::Expression>&,
-    internal::HydroelasticContactInfoAndBodySpatialForces<
-        symbolic::Expression>*) const;
+void MultibodyPlant<symbolic::Expression>::
+    CalcHydroelasticContactForcesContinuous(
+        const systems::Context<symbolic::Expression>&,
+        internal::HydroelasticContactForcesContinuousCacheData<
+            symbolic::Expression>*) const;
 template <>
 void MultibodyPlant<symbolic::Expression>::
-    AppendContactResultsContinuousHydroelastic(
+    AppendContactResultsHydroelasticContinuous(
         const systems::Context<symbolic::Expression>&,
         ContactResults<symbolic::Expression>*) const;
 template <>
@@ -5890,7 +5873,7 @@ void MultibodyPlant<symbolic::Expression>::CalcContactSurfaces(
 template <>
 void MultibodyPlant<symbolic::Expression>::CalcHydroelasticWithFallback(
     const systems::Context<symbolic::Expression>&,
-    internal::HydroelasticFallbackCacheData<symbolic::Expression>*) const;
+    internal::HydroelasticWithFallbackCacheData<symbolic::Expression>*) const;
 #endif
 
 }  // namespace multibody

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -110,9 +110,9 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.geometry_id_to_body_index_;
   }
 
-  static const internal::JointLockingCacheData<T>& EvalJointLockingCache(
+  static const internal::JointLockingCacheData<T>& EvalJointLocking(
       const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
-    return plant.EvalJointLockingCache(context);
+    return plant.EvalJointLocking(context);
   }
 
   static const std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>&

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -816,7 +816,7 @@ void SapDriver<T>::CalcContactProblemCache(
   // Make a reduced version of the original contact problem using joint locking
   // data.
   const internal::JointLockingCacheData<T>& joint_locking_data =
-      manager().EvalJointLockingCache(context);
+      manager().EvalJointLocking(context);
   const std::vector<int>& locked_indices =
       joint_locking_data.locked_velocity_indices;
   const std::vector<std::vector<int>>& locked_indices_per_tree =
@@ -933,7 +933,7 @@ void SapDriver<T>::CalcSapSolverResults(
   // Eliminate known DoFs.
   if (has_locked_dofs) {
     const auto& unlocked_indices =
-        manager().EvalJointLockingCache(context).unlocked_velocity_indices;
+        manager().EvalJointLocking(context).unlocked_velocity_indices;
     v0 = SelectRows(v0, unlocked_indices);
   }
 

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -139,7 +139,7 @@ void TamsiDriver<T>::CalcContactSolverResults(
 
   // Joint locking: quick exit if everything is locked.
   const auto& indices =
-      manager().EvalJointLockingCache(context).unlocked_velocity_indices;
+      manager().EvalJointLocking(context).unlocked_velocity_indices;
   if (indices.empty()) {
     // Everything is locked! Return a result that indicates no velocity, but
     // reports normal forces.

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -32,9 +32,9 @@ class MultibodyPlantTester {
  public:
   MultibodyPlantTester() = delete;
 
-  static const internal::JointLockingCacheData<double>& EvalJointLockingCache(
+  static const internal::JointLockingCacheData<double>& EvalJointLocking(
       const MultibodyPlant<double>& plant, const Context<double>& context) {
-    return plant.EvalJointLockingCache(context);
+    return plant.EvalJointLocking(context);
   }
 
   template <typename T>
@@ -131,7 +131,7 @@ TEST_P(JointLockingTest, JointLockingIndicesTest) {
   // No joints/bodies are locked, all joint/body velocity indices should exist.
   {
     const internal::JointLockingCacheData<double>& cache =
-        MultibodyPlantTester::EvalJointLockingCache(*plant_, *context_);
+        MultibodyPlantTester::EvalJointLocking(*plant_, *context_);
     const std::vector<int>& unlocked_velocity_indices =
         cache.unlocked_velocity_indices;
     const std::vector<int>& locked_velocity_indices =
@@ -187,7 +187,7 @@ TEST_P(JointLockingTest, JointLockingIndicesTest) {
   {
     body3_body4.Lock(context_.get());
     const internal::JointLockingCacheData<double>& cache =
-        MultibodyPlantTester::EvalJointLockingCache(*plant_, *context_);
+        MultibodyPlantTester::EvalJointLocking(*plant_, *context_);
     const std::vector<int>& unlocked_velocity_indices =
         cache.unlocked_velocity_indices;
     const std::vector<int>& locked_velocity_indices =
@@ -243,7 +243,7 @@ TEST_P(JointLockingTest, JointLockingIndicesTest) {
     body1.Lock(context_.get());
 
     const internal::JointLockingCacheData<double>& cache =
-        MultibodyPlantTester::EvalJointLockingCache(*plant_, *context_);
+        MultibodyPlantTester::EvalJointLocking(*plant_, *context_);
     const std::vector<int>& unlocked_velocity_indices =
         cache.unlocked_velocity_indices;
     const std::vector<int>& locked_velocity_indices =

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -38,10 +38,11 @@ class MultibodyPlantTester {
  public:
   MultibodyPlantTester() = delete;
 
-  static const std::vector<SpatialForce<double>>& EvalHydroelasticContactForces(
+  static const std::vector<SpatialForce<double>>&
+  EvalHydroelasticContactForcesContinuous(
       const MultibodyPlant<double>& plant,
       const systems::Context<double>& context) {
-    return plant.EvalHydroelasticContactForces(context).F_BBo_W_array;
+    return plant.EvalHydroelasticContactForcesContinuous(context).F_BBo_W_array;
   }
 
   static BodyIndex FindBodyByGeometryId(const MultibodyPlant<double>& plant,
@@ -291,8 +292,8 @@ TEST_F(HydroelasticModelTests, ContactForce) {
   auto calc_force = [this](double penetration) -> double {
     SetPose(penetration);
     const auto& F_BBo_W_array =
-        MultibodyPlantTester::EvalHydroelasticContactForces(*plant_,
-                                                            *plant_context_);
+        MultibodyPlantTester::EvalHydroelasticContactForcesContinuous(
+            *plant_, *plant_context_);
     const SpatialForce<double>& F_BBo_W = F_BBo_W_array[body_->mobod_index()];
     return F_BBo_W.translational()[2];  // Normal force.
   };
@@ -337,8 +338,8 @@ TEST_F(HydroelasticModelTests, ContactDynamics) {
   const double penetration = 0.02;
   SetPose(penetration);
   const auto& F_BBo_W_array =
-      MultibodyPlantTester::EvalHydroelasticContactForces(*plant_,
-                                                          *plant_context_);
+      MultibodyPlantTester::EvalHydroelasticContactForcesContinuous(
+          *plant_, *plant_context_);
   const SpatialForce<double>& F_BBo_W = F_BBo_W_array[body_->mobod_index()];
   // Contact force by hydroelastics.
   const Vector3<double> fhydro_BBo_W = F_BBo_W.translational();


### PR DESCRIPTION
Towards #20545: before we can fix the discrete time dependencies, we need to be very clear about which parts are _not_ used in discrete time plants.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21533)
<!-- Reviewable:end -->
