### PR TITLE
Bind the tolerance argument when constructing a VPolytope from an HPolyhedron.

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -467,8 +467,8 @@ void DefineGeometryOptimization(py::module m) {
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&>(),
             py::arg("vertices"), cls_doc.ctor.doc_vertices)
-        .def(py::init<const HPolyhedron&>(), py::arg("H"),
-            cls_doc.ctor.doc_hpolyhedron)
+        .def(py::init<const HPolyhedron&, double>(), py::arg("H"),
+            py::arg("tol") = 1e-9, cls_doc.ctor.doc_hpolyhedron)
         .def(py::init<const QueryObject<double>&, GeometryId,
                  std::optional<FrameId>>(),
             py::arg("query_object"), py::arg("geometry_id"),

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -495,7 +495,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertAlmostEqual(v_box.CalcVolume(), 8, 1E-10)
         v_unit_box = mut.VPolytope.MakeUnitBox(dim=3)
         self.assertTrue(v_unit_box.PointInSet([0, 0, 0]))
-        v_from_h = mut.VPolytope(H=mut.HPolyhedron.MakeUnitBox(dim=3))
+        v_from_h = mut.VPolytope(
+            H=mut.HPolyhedron.MakeUnitBox(dim=3), tol=1e-9)
         self.assertTrue(v_from_h.PointInSet([0, 0, 0]))
         # Test creating a vpolytope from a non-minimal set of vertices
         # 2D: Random points inside a circle

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -113,7 +113,7 @@ VPolytope::VPolytope(const QueryObject<double>& query_object,
   vertices_ = X_EG * vertices;
 }
 
-VPolytope::VPolytope(const HPolyhedron& hpoly, const double tol)
+VPolytope::VPolytope(const HPolyhedron& hpoly, double tol)
     : ConvexSet(hpoly.ambient_dimension(), true) {
   // First, assert that the HPolyhedron is bounded (since a VPolytope cannot
   // be used to represent an unbounded set).

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -54,7 +54,7 @@ class VPolytope final : public ConvexSet, private ShapeReifier {
   @throws std::runtime_error if H is unbounded or if Qhull terminates with an
   error.
   @pydrake_mkdoc_identifier{hpolyhedron} */
-  explicit VPolytope(const HPolyhedron& H, const double tol = 1e-9);
+  explicit VPolytope(const HPolyhedron& H, double tol = 1e-9);
 
   /** Constructs the polytope from a SceneGraph geometry.
   @pydrake_mkdoc_identifier{scenegraph} */


### PR DESCRIPTION
For some reason, the tolerance argument wasn't bound in the constructor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21536)
<!-- Reviewable:end -->
