### PR TITLE
[multibody] Use ContactResults for hydro forces in discrete plant unit test.

### DIFF
--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -9,8 +9,11 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/query_results/contact_surface.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/hydroelastic_contact_info.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -39,6 +42,11 @@ class MultibodyPlantTester {
       const MultibodyPlant<double>& plant,
       const systems::Context<double>& context) {
     return plant.EvalHydroelasticContactForces(context).F_BBo_W_array;
+  }
+
+  static BodyIndex FindBodyByGeometryId(const MultibodyPlant<double>& plant,
+                                        GeometryId id) {
+    return plant.FindBodyByGeometryId(id);
   }
 
   static const std::vector<SpatialForce<double>>&
@@ -202,26 +210,52 @@ class HydroelasticModelTests : public ::testing::Test {
                               Vector3<double>* p_WB_W) {
     DRAKE_DEMAND(F_BBo_W != nullptr);
     DRAKE_DEMAND(p_WB_W != nullptr);
-    *p_WB_W = Vector3<double>::Zero();
-    *F_BBo_W = SpatialForce<double>();
 
     Simulator<double> simulator(*diagram_);
     auto& diagram_context = simulator.get_mutable_context();
     auto& plant_context = plant_->GetMyMutableContextFromRoot(&diagram_context);
 
     // Set initial condition.
-    const RigidTransformd X_WB(Vector3d(0.0, 0.0, kSphereRadius));
-    plant_->SetFreeBodyPose(&plant_context, *body_, X_WB);
+    plant_->SetFreeBodyPose(&plant_context, *body_,
+                            RigidTransformd(Vector3d(0.0, 0.0, kSphereRadius)));
     diagram_->ForcedPublish(diagram_context);
 
     // Run simulation for long enough to reach the steady state.
     simulator.AdvanceTo(0.5);
 
-    const auto& F_BBo_W_array =
-        MultibodyPlantTester::EvalHydroelasticContactForces(*plant_,
-                                                            plant_context);
-    *F_BBo_W = F_BBo_W_array[body_->mobod_index()];
-    *p_WB_W = plant_->GetFreeBodyPose(plant_context, *body_).translation();
+    // Compute the position of the sphere in world.
+    const RigidTransformd& X_WB =
+        plant_->GetFreeBodyPose(plant_context, *body_);
+    *p_WB_W = X_WB.translation();
+
+    // Loop over each contact surface involving `body_` and sum the contact
+    // forces acting on `body_`.
+    F_BBo_W->SetZero();
+    const ContactResults<double>& results =
+        plant_->get_contact_results_output_port().Eval<ContactResults<double>>(
+            plant_context);
+
+    ASSERT_EQ(results.num_point_pair_contacts(), 0);
+
+    for (int i = 0; i < results.num_hydroelastic_contacts(); ++i) {
+      const HydroelasticContactInfo<double>& info =
+          results.hydroelastic_contact_info(i);
+      const geometry::ContactSurface<double>& surface = info.contact_surface();
+      const GeometryId geometryM_id = surface.id_M();
+      const GeometryId geometryN_id = surface.id_N();
+
+      const BodyIndex bodyA_index =
+          MultibodyPlantTester::FindBodyByGeometryId(*plant_, geometryM_id);
+      const BodyIndex bodyB_index =
+          MultibodyPlantTester::FindBodyByGeometryId(*plant_, geometryN_id);
+
+      const Vector3<double> p_CBo_W = *p_WB_W - surface.centroid();
+      if (bodyA_index == body_->index()) {
+        *F_BBo_W += info.F_Ac_W().Shift(p_CBo_W);
+      } else if (bodyB_index == body_->index()) {
+        *F_BBo_W -= info.F_Ac_W().Shift(p_CBo_W);
+      }
+    }
   }
 
   const double kFrictionCoefficient{0.5};  // [-]


### PR DESCRIPTION
Per this [slack conversation](https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1717686251170419) and related to #21533.

Replaces call to `EvalHydroelasticContactForces()` (which will be made continuous plant only in #21533) in a unit test using a discrete plant. Instead the total hydro contact force acting on the body is calculated using the forces reported by `ContactResults`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21539)
<!-- Reviewable:end -->
