### PR TITLE
[workspace] Upgrade crate_universe to latest

### DIFF
--- a/tools/workspace/clarabel_cpp_internal/repository.bzl
+++ b/tools/workspace/clarabel_cpp_internal/repository.bzl
@@ -9,8 +9,8 @@ def clarabel_cpp_internal_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "oxfordcontrol/Clarabel.cpp",
-        commit = "v0.6.0",
-        sha256 = "281b1cbbe7e15520ad17a74d91f0ef9d83161ee79c0ff1954187f78c4516c8ec",  # noqa
+        commit = "v0.9.0",
+        sha256 = "4dfff59667623bf4264ba27f25eef08bda64899a4e443f8d1993d5d5a9a36ab0",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             ":patches/extern_c.patch",


### PR DESCRIPTION
Towards #21507

This also covers `clarabel_cpp_internal needs upgrade from v0.6.0 to v0.9.0`