### PR TITLE
[openusd_internal] Patch pegtl namespace calculation

### DIFF
--- a/tools/install/libdrake/test/exported_symbols_test.py
+++ b/tools/install/libdrake/test/exported_symbols_test.py
@@ -158,7 +158,7 @@ class ExportedSymbolsTest(unittest.TestCase):
         bad_rows = sorted(bad_rows, key=lambda x: (x.Type, x.Name))
 
         # Report the first few errors.
-        for row in bad_rows[:25]:
+        for row in bad_rows[:25000]:
             print(f"{row.Type} {row.Bind} {row.Vis}")
             print(f" {self._demangle(row.Name)}")
             print(f" {row.Name}")

--- a/tools/workspace/openusd_internal/patches/pegtl_namespace.patch
+++ b/tools/workspace/openusd_internal/patches/pegtl_namespace.patch
@@ -1,0 +1,31 @@
+[openusd_internal] Fix macro expansion for TAO_PEGTL_NAMESPACE
+
+This patch allows the drake vendoring of namespaces to work
+properly. This patch could be upstreamed.
+
+--- pxr/base/tf/pxrPEGTL/pegtl.h
++++ pxr/base/tf/pxrPEGTL/pegtl.h
+@@ -49,7 +49,9 @@ SOFTWARE.
+ #include "pxr/pxr.h"
+ 
+ #if PXR_USE_NAMESPACES
+-#define TAO_PEGTL_NAMESPACE PXR_INTERNAL_NS ## _pegtl
++#define _impl_PASTE2(x, y) x ## y
++#define _impl_PASTE(x, y) _impl_PASTE2(x, y)
++#define TAO_PEGTL_NAMESPACE _impl_PASTE(PXR_INTERNAL_NS, _pegtl)
+ #else
+ #define TAO_PEGTL_NAMESPACE pxr_pegtl
+ #endif
+--- pxr/base/tf/pxrPEGTL/pxr-pegtl.patch
++++ pxr/base/tf/pxrPEGTL/pxr-pegtl.patch
+@@ -26,7 +26,9 @@ index b14aebed2..e6b8962d7 100644
+ +#include "pxr/pxr.h"
+ +
+ +#if PXR_USE_NAMESPACES
+-+#define TAO_PEGTL_NAMESPACE PXR_INTERNAL_NS ## _pegtl
+++#define _impl_PASTE2(x, y) x ## y
+++#define _impl_PASTE(x, y) _impl_PASTE2(x, y)
+++#define TAO_PEGTL_NAMESPACE _impl_PASTE(PXR_INTERNAL_NS, _pegtl)
+ +#else
+ +#define TAO_PEGTL_NAMESPACE pxr_pegtl
+ +#endif

--- a/tools/workspace/openusd_internal/repository.bzl
+++ b/tools/workspace/openusd_internal/repository.bzl
@@ -22,6 +22,7 @@ def openusd_internal_repository(
             ":patches/namespace.patch",
             ":patches/no_gnu_ext.patch",
             ":patches/onetbb.patch",
+            ":patches/pegtl_namespace.patch",
             ":patches/usd_sdf_noboost.patch",
             ":patches/weakptrfacade_cxx20.patch",
         ],


### PR DESCRIPTION
This patch allows the drake_vendor namespace modifications to be reflected in TAO_PEGTL_NAMESPACE, which in turn allows the resulting symbols to be matched by allow lists in exported_symbols_test.

This is yet another installment, and not the last, in the openusd_internal symbol-hiding saga.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21549)
<!-- Reviewable:end -->
