### PR TITLE
Improve the error message for IK with collision.

### DIFF
--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -352,6 +352,7 @@ drake_cc_googletest(
     deps = [
         ":inverse_kinematics_core",
         ":inverse_kinematics_test_utilities",
+        "//common/test_utilities:expect_throws_message",
         "//math:geometric_transform",
         "//solvers:solve",
     ],


### PR DESCRIPTION
If the IK constructor doesn't take in the plant context, or takes in the wrong plant context, and imposes distance related constraint, then warn the user about the plant_context in the constructor.

Resolves #21541

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21554)
<!-- Reviewable:end -->
