### PR TITLE
Removes the GCS trajectory optimization test from kcov builds

### DIFF
--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -172,6 +172,9 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "gcs_trajectory_optimization_test",
     shard_count = 12,
+    # Even with many shards, the SimpleEnv2D suite has a couple of test cases
+    # that routinely time out under coverage tests, all by themselves.
+    tags = ["no_kcov"],
     deps = [
         ":gcs_trajectory_optimization",
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
Two of the SimpleEnv2D unit tests have proven consistently problematic under coverage tests. So, we'll simply omit the whole thing to save the bother.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21556)
<!-- Reviewable:end -->
