### PR TITLE
[examples] Add bell pepper to hardware_sim

### DIFF
--- a/examples/hardware_sim/BUILD.bazel
+++ b/examples/hardware_sim/BUILD.bazel
@@ -20,6 +20,7 @@ filegroup(
         "//examples/pendulum:models",
         "@drake_models//:iiwa_description",
         "@drake_models//:manipulation_station",
+        "@drake_models//:veggies",
         "@drake_models//:wsg_50_description",
     ],
     visibility = ["//:__pkg__"],

--- a/examples/hardware_sim/example_scenarios.yaml
+++ b/examples/hardware_sim/example_scenarios.yaml
@@ -1,7 +1,8 @@
 # This file is licensed under the MIT-0 License.
 # See LICENSE-MIT-0.txt in the current directory.
 
-# This demo simulation shows an IIWA arm with an attached WSG gripper.
+# This demo simulation shows an IIWA arm with an attached WSG gripper,
+# nearby a table with a pepper atop it.
 Demo:
   scene_graph_config:
     default_proximity_properties:
@@ -48,6 +49,16 @@ Demo:
   - add_weld:
       parent: wsg_on_iiwa
       child: wsg::body
+  - add_model:
+      name: bell_pepper
+      file: package://drake_models/veggies/yellow_bell_pepper_no_stem_low.sdf
+      default_free_body_pose:
+        flush_bottom_center__z_up:
+          base_frame: amazon_table::amazon_table
+          # We pose the pepper in the air above the table so that it won't start
+          # in penetration. After the simulation starts, it will fall and come
+          # to rest on the table.
+          translation: [0, 0.10, 0.20]
   lcm_buses:
     driver_traffic:
       # Use a non-default LCM url to communicate with the robot.


### PR DESCRIPTION
This is a nice example of the syntax for posing a free body, towards #19651.

(It also serves as a more useful test case for #21512.)

![image](https://github.com/RobotLocomotion/drake/assets/17596505/6cc1673d-3112-489e-9112-3f39a107ce25)

(Note that due to https://github.com/RobotLocomotion/drake/issues/16538#issuecomment-2019190414 you can't see the contact force arrow unless you look under the table.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21558)
<!-- Reviewable:end -->
