### PR TITLE
[multibody] Deny set_contact_surface_representation post-Finalize

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2136,8 +2136,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// %MultibodyPlant. See geometry::HydroelasticContactRepresentation for
   /// available options. See GetDefaultContactSurfaceRepresentation() for
   /// explanation of default values.
+  /// @throws std::exception if called post-finalize.
   void set_contact_surface_representation(
       geometry::HydroelasticContactRepresentation representation) {
+    DRAKE_MBP_THROW_IF_FINALIZED();
     contact_surface_representation_ = representation;
   }
 


### PR DESCRIPTION
Changing this value in the middle of a simulation fails to properly invalidate the contact surface cache entries. Rather than try to fix that (which would be extremely complicated), instead we fail-fast. The contact surface representation (triangle vs polygon) must now be configured pre-Finalize.

Towards #20545.

(I'm not using deprecation here because computing wrong answers is one of the better reasons to break users, and because we will not be able to support post-Finalize changes as we work on #20545.  This function is never called from Anzu.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21559)
<!-- Reviewable:end -->
