### PR TITLE
[parsing] Deprecate parser.collision_filter_groups() API

### DIFF
--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/diagnostic_policy.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/multibody/parsing/collision_filter_groups.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -191,11 +192,15 @@ class Parser final {
   /// @see the Parser class documentation for more detail.
   bool GetAutoRenaming() const { return enable_auto_rename_; }
 
-  /// Get a reference to the accumulated set of collision filter definitions
-  /// seen by this parser. Collision filter group data is only ever an output
-  /// of parsing, not an input.
-  const CollisionFilterGroups& collision_filter_groups() const {
+  /// Gets the accumulated set of collision filter definitions seen by this
+  /// parser.
+  CollisionFilterGroups GetCollisionFilterGroups() const {
     return collision_filter_groups_;
+  }
+
+  DRAKE_DEPRECATED("2024-10-01", "Use GetCollisionFilterGroups() instead.")
+  CollisionFilterGroups collision_filter_groups() const {
+    return GetCollisionFilterGroups();
   }
 
   /// Parses the input file named in @p file_name and adds all of its model(s)

--- a/multibody/parsing/test/parser_manual_test.cc
+++ b/multibody/parsing/test/parser_manual_test.cc
@@ -56,7 +56,7 @@ int do_main(int argc, char* argv[]) {
     ::exit(EXIT_FAILURE);
   }
 
-  const auto& filters = parser.collision_filter_groups();
+  const auto& filters = parser.GetCollisionFilterGroups();
   drake::log()->info("{}", filters);
   drake::log()->info("Parsed {} models.", models.size());
   return models.empty();

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -360,7 +360,7 @@ GTEST_TEST(ProcessModelDirectivesTest, CollisionFilterGroupSmokeTest) {
   expected_report.AddExclusionPair(
       {"nested::across_sub_models", "nested_group"});
   expected_report.AddExclusionPair({"nested_members", "nested_members"});
-  EXPECT_EQ(parser->collision_filter_groups(), expected_report);
+  EXPECT_EQ(parser->GetCollisionFilterGroups(), expected_report);
 }
 
 // Test collision filter groups in ModelDirectives.


### PR DESCRIPTION
Its replacement will get an improved implementation in the near future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21562)
<!-- Reviewable:end -->
