### PR TITLE
[multibody] Add MultibodyPlant::EvalSceneGraphInspector

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -959,7 +959,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("num_collision_geometries", &Class::num_collision_geometries,
             cls_doc.num_collision_geometries.doc)
         .def("CollectRegisteredGeometries", &Class::CollectRegisteredGeometries,
-            py::arg("bodies"), cls_doc.CollectRegisteredGeometries.doc);
+            py::arg("bodies"), cls_doc.CollectRegisteredGeometries.doc)
+        .def("EvalSceneGraphInspector", &Class::EvalSceneGraphInspector,
+            py::arg("context"), py_rvp::reference,
+            // Keep alive, ownership: `return` keeps `context` alive.
+            py::keep_alive<0, 2>(), cls_doc.EvalSceneGraphInspector.doc);
     // Port accessors.
     cls  // BR
         .def("get_actuation_input_port",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -3068,6 +3068,7 @@ class TestPlant(unittest.TestCase):
         # bodies to be coincident, and thus collide.
         context = diagram.CreateDefaultContext()
         sg_context = diagram.GetMutableSubsystemContext(scene_graph, context)
+        plant_context = diagram.GetMutableSubsystemContext(plant, context)
         query_object = scene_graph.get_query_output_port().Eval(sg_context)
         # Implicitly require that this should be size 1.
         point_pair, = query_object.ComputePointPairPenetration()
@@ -3083,7 +3084,7 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(signed_distance_to_point[1],
                               SignedDistanceToPoint_[T])
         # Test SceneGraphInspector
-        inspector = query_object.inspector()
+        inspector = plant.EvalSceneGraphInspector(context=plant_context)
 
         self.assertEqual(inspector.num_geometries(), 4)
         self.assertEqual(inspector.num_geometries(),

--- a/multibody/contact_solvers/test/multibody_sim_driver.cc
+++ b/multibody/contact_solvers/test/multibody_sim_driver.cc
@@ -107,16 +107,11 @@ std::vector<double> MultibodySimDriver::GetDynamicFrictionCoefficients(
 
 const geometry::SceneGraphInspector<double>& MultibodySimDriver::GetInspector()
     const {
-  const geometry::SceneGraphInspector<double>* inspector{nullptr};
   if (initialized_) {
-    const auto& query_object =
-        plant_->get_geometry_query_input_port()
-            .Eval<geometry::QueryObject<double>>(*plant_context_);
-    inspector = &query_object.inspector();
+    return plant_->EvalSceneGraphInspector(*plant_context_);
   } else {
-    inspector = &scene_graph_->model_inspector();
+    return scene_graph_->model_inspector();
   }
-  return *inspector;
 }
 
 }  // namespace test

--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -380,11 +380,8 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
    Finally Jv_v_AcBc_C = R_WC.transpose() * Jv_v_AcBc_W.
    The set of dofs for body A and body B are mutually exclusive. */
 
-  const geometry::QueryObject<T>& query_object =
-      manager_->plant()
-          .get_geometry_query_input_port()
-          .template Eval<geometry::QueryObject<T>>(context);
-  const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
+  const geometry::SceneGraphInspector<T>& inspector =
+      manager_->plant().EvalSceneGraphInspector(context);
   const DeformableContact<T>& deformable_contact =
       EvalDeformableContact(context);
   const std::vector<DeformableContactSurface<T>>& contact_surfaces =

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -802,11 +802,8 @@ void DiscreteUpdateManager<T>::AppendDiscreteContactPairsForPointContact(
   if (num_point_contacts == 0) return;
 
   contact_pairs->Reserve(num_point_contacts, 0, 0);
-  const geometry::QueryObject<T>& query_object =
-      plant()
-          .get_geometry_query_input_port()
-          .template Eval<geometry::QueryObject<T>>(context);
-  const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
+  const geometry::SceneGraphInspector<T>& inspector =
+      plant().EvalSceneGraphInspector(context);
   const std::vector<std::vector<int>>& per_tree_unlocked_indices =
       EvalJointLockingCache(context).unlocked_velocity_indices_per_tree;
   const MultibodyTreeTopology& topology = internal_tree().get_topology();
@@ -973,11 +970,8 @@ void DiscreteUpdateManager<T>::AppendDiscreteContactPairsForHydroelasticContact(
   if (num_hydro_contacts == 0) return;
 
   contact_pairs->Reserve(0, num_hydro_contacts, 0);
-  const geometry::QueryObject<T>& query_object =
-      plant()
-          .get_geometry_query_input_port()
-          .template Eval<geometry::QueryObject<T>>(context);
-  const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
+  const geometry::SceneGraphInspector<T>& inspector =
+      plant().EvalSceneGraphInspector(context);
   const std::vector<std::vector<int>>& per_tree_unlocked_indices =
       EvalJointLockingCache(context).unlocked_velocity_indices_per_tree;
   const MultibodyTreeTopology& topology = internal_tree().get_topology();

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -53,6 +53,7 @@ using geometry::GeometrySet;
 using geometry::PenetrationAsPointPair;
 using geometry::ProximityProperties;
 using geometry::SceneGraph;
+using geometry::SceneGraphInspector;
 using geometry::SourceId;
 using geometry::render::RenderLabel;
 using systems::InputPort;
@@ -1022,6 +1023,16 @@ geometry::GeometrySet MultibodyPlant<T>::CollectRegisteredGeometries(
 }
 
 template <typename T>
+const SceneGraphInspector<T>& MultibodyPlant<T>::EvalSceneGraphInspector(
+    const systems::Context<T>& context) const {
+  // TODO(jwnimmer-tri) The "geometry_query" input port is invalidated anytime
+  // the configuration_ticket changes, but really we only need to invalidate the
+  // inspector when the scene graph topology or properties change. If we find
+  // this is a performance bottleneck, this is something we could clean up.
+  return EvalGeometryQueryInput(context, __func__).inspector();
+}
+
+template <typename T>
 std::vector<const RigidBody<T>*> MultibodyPlant<T>::GetBodiesWeldedTo(
     const RigidBody<T>& body) const {
   const std::set<BodyIndex> island =
@@ -1436,8 +1447,7 @@ bool MultibodyPlant<T>::IsValidGeometryInput(
 
 template <typename T>
 std::pair<T, T> MultibodyPlant<T>::GetPointContactParameters(
-    geometry::GeometryId id,
-    const geometry::SceneGraphInspector<T>& inspector) const {
+    geometry::GeometryId id, const SceneGraphInspector<T>& inspector) const {
   const geometry::ProximityProperties* prop =
       inspector.GetProximityProperties(id);
   DRAKE_DEMAND(prop != nullptr);
@@ -1453,8 +1463,7 @@ std::pair<T, T> MultibodyPlant<T>::GetPointContactParameters(
 
 template <typename T>
 const CoulombFriction<double>& MultibodyPlant<T>::GetCoulombFriction(
-    geometry::GeometryId id,
-    const geometry::SceneGraphInspector<T>& inspector) const {
+    geometry::GeometryId id, const SceneGraphInspector<T>& inspector) const {
   const geometry::ProximityProperties* prop =
       inspector.GetProximityProperties(id);
   DRAKE_DEMAND(prop != nullptr);
@@ -2036,9 +2045,7 @@ void MultibodyPlant<T>::AppendContactResultsContinuousPointPair(
   const internal::VelocityKinematicsCache<T>& vc =
       EvalVelocityKinematics(context);
 
-  const geometry::QueryObject<T>& query_object =
-      EvalGeometryQueryInput(context, __func__);
-  const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
+  const SceneGraphInspector<T>& inspector = EvalSceneGraphInspector(context);
 
   for (size_t icontact = 0; icontact < point_pairs.size(); ++icontact) {
     const auto& pair = point_pairs[icontact];
@@ -2232,8 +2239,7 @@ void MultibodyPlant<T>::CalcHydroelasticContactForces(
   internal::HydroelasticTractionCalculator<T> traction_calculator(
       friction_model_.stiction_tolerance());
 
-  const auto& query_object = EvalGeometryQueryInput(context, __func__);
-  const geometry::SceneGraphInspector<T>& inspector = query_object.inspector();
+  const SceneGraphInspector<T>& inspector = EvalSceneGraphInspector(context);
 
   for (const ContactSurface<T>& surface : all_surfaces) {
     const GeometryId geometryM_id = surface.id_M();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -692,15 +692,12 @@ const geometry::SceneGraphInspector<T>& inspector =
     scene_graph.model_inspector();
 @endcode
 After context creation, an inspector can be retrieved from the state
-stored in the context by the plant's geometry query input port:
+stored in the context:
 @code
-// For a MultibodyPlant<T> instance called mbp and a
-// Context<T> called context.
-const geometry::QueryObject<T>& query_object =
-    mbp.get_geometry_query_input_port()
-        .template Eval<geometry::QueryObject<T>>(context);
+// For a MultibodyPlant<T> instance called mbp and a Context<T> called
+// context.
 const geometry::SceneGraphInspector<T>& inspector =
-    query_object.inspector();
+    mbp.EvalSceneGraphInspector(context);
 @endcode
 Once an inspector is available, proximity properties can be retrieved as:
 @code
@@ -2044,6 +2041,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     }
     return it->second;
   }
+
+  /// Returns the inspector from the `context` for the SceneGraph associated
+  /// with this plant, via this plant's "geometry_query" input port. (In the
+  /// future, the inspector might come from a different context source that
+  /// is more efficient than the "geometry_query" input port.)
+  const geometry::SceneGraphInspector<T>& EvalSceneGraphInspector(
+      const systems::Context<T>& context) const;
   /// @} <!-- Geometry -->
 
   /// @anchor mbp_contact_modeling

--- a/multibody/plant/test/hydroelastic_traction_test.cc
+++ b/multibody/plant/test/hydroelastic_traction_test.cc
@@ -286,13 +286,11 @@ class MultibodyPlantHydroelasticTractionTests
   void UpdateCalculatorData() {
     // Get the bodies that the two geometries are affixed to. We'll call these
     // A and B.
-    const auto& query_object =
-        plant_->get_geometry_query_input_port()
-            .template Eval<geometry::QueryObject<double>>(*plant_context_);
+    const auto& inspector = plant_->EvalSceneGraphInspector(*plant_context_);
     const geometry::FrameId frameM_id =
-        query_object.inspector().GetFrameId(contact_surface_->id_M());
+        inspector.GetFrameId(contact_surface_->id_M());
     const geometry::FrameId frameN_id =
-        query_object.inspector().GetFrameId(contact_surface_->id_N());
+        inspector.GetFrameId(contact_surface_->id_N());
     const RigidBody<double>& bodyA = *plant_->GetBodyFromFrameId(frameM_id);
     const RigidBody<double>& bodyB = *plant_->GetBodyFromFrameId(frameN_id);
 


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/20545.

Distinguishing between property changes (only) vs configuration or contact changes is important for performance and caching. Refactor the plant to only directly touch the query object when doing a configuration-dependent query. Use the new inspector sugar when only properties are being accessed.

Note that this does not change any input ports or add any cache entries, so no changes to cache dependency tickets are required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21563)
<!-- Reviewable:end -->
