### PR TITLE
[geometry] Calculate signed distance from point to closed meshes

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -156,6 +156,24 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "calc_signed_distance_to_surface_mesh",
+    srcs = ["calc_signed_distance_to_surface_mesh.cc"],
+    hdrs = ["calc_signed_distance_to_surface_mesh.h"],
+    internal = True,
+    visibility = ["//geometry:__pkg__"],
+    deps = [
+        ":bv",
+        ":bvh",
+        ":triangle_surface_mesh",
+        "//common:essential",
+    ],
+    implementation_deps = [
+        ":distance_to_point_callback",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
     name = "collision_filter",
     srcs = ["collision_filter.cc"],
     hdrs = ["collision_filter.h"],
@@ -1071,6 +1089,17 @@ drake_cc_googletest(
     deps = [
         ":calc_distance_to_surface_mesh",
         ":make_box_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "calc_signed_distance_to_surface_mesh_test",
+    deps = [
+        ":calc_signed_distance_to_surface_mesh",
+        ":volume_mesh",
+        ":volume_to_surface_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/proximity/calc_signed_distance_to_surface_mesh.cc
+++ b/geometry/proximity/calc_signed_distance_to_surface_mesh.cc
@@ -1,0 +1,230 @@
+#include "drake/geometry/proximity/calc_signed_distance_to_surface_mesh.h"
+
+#include <array>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/distance_to_point_callback.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+
+namespace {
+
+// TODO(DamrongGuoy): Consider the techniques in the following paper to speed
+//  up the search for closest features:
+//  S. Curtis; R. Tamstorf; D. Manocha. Fast collision detection for
+//  deformable models using representative-triangles. I3D '08: Proceedings of
+//  the 2008 symposium on Interactive 3D graphics and games.
+
+class BvhVisitor {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BvhVisitor);
+
+  static SquaredDistanceToTriangle CalcSquaredDistance(
+      const Vector3d& p_MQ, const TriangleSurfaceMesh<double>& mesh_M,
+      const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_M,
+      const FeatureNormalSet& normal_set_M) {
+    BvhVisitor visitor{p_MQ, mesh_M, normal_set_M};
+    visitor.Visit(bvh_M.root_node());
+    return visitor.closest_info_;
+  }
+
+ private:
+  BvhVisitor(const Vector3d& p_MQ, const TriangleSurfaceMesh<double>& mesh_M,
+             const FeatureNormalSet& normal_set_M)
+      : p_MQ_{p_MQ}, mesh_M_{mesh_M}, normal_set_M_{normal_set_M} {}
+
+  void Visit(const Bvh<Obb, TriangleSurfaceMesh<double>>::NodeType& node_M) {
+    // Evaluate distance to this node's bounding box B, expressed in frame B.
+    const RigidTransformd& X_MB = node_M.bv().pose();
+    const Vector3d p_BQ = X_MB.inverse() * p_MQ_;
+    // Cb and grad_B are the closest point and signed-distance gradient to the
+    // query point Q with respect to the surface of the bounding box B.
+    const auto [p_BCb, grad_B, _] =
+        point_distance::DistanceToPoint<double>::ComputeDistanceToBox<3>(
+            node_M.bv().half_width(), p_BQ);
+    // phi_BQ is the signed distance of Q from the bounding box B.
+    const double phi_BQ = grad_B.dot(p_BQ - p_BCb);
+
+    // Check for possible pruning.
+    if (phi_BQ > 0) {
+      // The query point is outside box B, so we can get the lower bound.
+      const double squared_distance_from_node = phi_BQ * phi_BQ;
+      // Use the lower bound to possibly prune this subtree.
+      if (squared_distance_from_node >= closest_info_.squared_distance) {
+        return;
+      }
+    }
+
+    if (node_M.is_leaf()) {
+      for (int i = 0; i < node_M.num_element_indices(); ++i) {
+        const int triangle_index = node_M.element_index(i);
+        const SquaredDistanceToTriangle squared_distance =
+            CalcSquaredDistanceToTriangle(p_MQ_, triangle_index, mesh_M_,
+                                          normal_set_M_);
+        if (squared_distance.squared_distance <
+            closest_info_.squared_distance) {
+          closest_info_ = squared_distance;
+        }
+      }
+      return;
+    }
+
+    // We couldn't prune the subtree, recursively search both children.
+    this->Visit(node_M.left());
+    this->Visit(node_M.right());
+  }
+
+ private:
+  const Vector3<double>& p_MQ_;
+  const TriangleSurfaceMesh<double>& mesh_M_;
+  const FeatureNormalSet& normal_set_M_;
+
+  SquaredDistanceToTriangle closest_info_;
+};
+
+}  // namespace
+
+FeatureNormalSet::FeatureNormalSet(const TriangleSurfaceMesh<double>& mesh_M)
+    : vertex_normals_(mesh_M.num_vertices(), Vector3d::Zero()) {
+  const std::vector<Vector3d>& vertices = mesh_M.vertices();
+  // We can compute a tolerance for a knife edge based on a minimum dihedral
+  // angle θ between adjacent faces using the following formula:
+  // ‖nᵢ + nⱼ‖² = 2(1-cos(θ)), where nᵢ and nⱼ are the face normals of the
+  // two adjacent faces.
+  //     The case for "pointy" vertices is more complex and requires more
+  // assumptions and guesswork. Empirically, the pointy vertices have the
+  // same approximate magnitude as for the edge tolerance, but we won't get
+  // into deriving the tolerance for simplicity's sake.
+  constexpr double kToleranceSquaredNorm = 3e-6;
+
+  // Accumulate data from the mesh. They are not normal vectors yet. We will
+  // normalize them afterward.
+  for (int f = 0; f < mesh_M.num_triangles(); ++f) {
+    const Vector3d& face_normal = mesh_M.face_normal(f);
+    const SurfaceTriangle& tri = mesh_M.triangles()[f];
+    const int v[3] = {tri.vertex(0), tri.vertex(1), tri.vertex(2)};
+    const Vector3d unit_edge_vector[3] = {
+        (vertices[v[1]] - vertices[v[0]]).normalized(),
+        (vertices[v[2]] - vertices[v[1]]).normalized(),
+        (vertices[v[0]] - vertices[v[2]]).normalized()};
+
+    // Accumulate angle*normal for each vertex of the triangle.
+    for (int i = 0; i < 3; ++i) {
+      const double angle =
+          std::acos(unit_edge_vector[i].dot(-unit_edge_vector[(i + 2) % 3]));
+      vertex_normals_[v[i]] += angle * face_normal;
+    }
+    // Accumulate normal for each edge of the triangle.
+    for (int i = 0; i < 3; ++i) {
+      const auto edge = MakeSortedPair(v[i], v[(i + 1) % 3]);
+      auto it = edge_normals_.find(edge);
+      if (it == edge_normals_.end()) {
+        edge_normals_[edge] = face_normal;
+      } else {
+        it->second += face_normal;
+        if (it->second.squaredNorm() < kToleranceSquaredNorm) {
+          throw std::runtime_error(
+              "FeatureNormalSet: Cannot compute an edge normal because "
+              "the two triangles sharing the edge make a very sharp edge.");
+        }
+        it->second.normalize();
+      }
+    }
+  }
+  for (auto& v_normal : vertex_normals_) {
+    if (v_normal.squaredNorm() < kToleranceSquaredNorm) {
+      throw std::runtime_error(
+          "FeatureNormalSet: Cannot compute a vertex normal because "
+          "the triangles sharing the vertex form a very pointy needle.");
+    }
+    v_normal.normalize();
+  }
+}
+
+SquaredDistanceToTriangle CalcSquaredDistanceToTriangle(
+    const Vector3<double>& p_MQ, int triangle_index,
+    const TriangleSurfaceMesh<double>& mesh_M,
+    const FeatureNormalSet& normal_set_M) {
+  // Barycentric coordinates of the projection of Q on the plane of the
+  // triangle.
+  Vector3d b_Q = mesh_M.CalcBarycentric(p_MQ, triangle_index);
+
+  // We've defined nearest feature with priority: vertex, edge, face. However,
+  // it's simple to determine if the answer is face -- all barycentric
+  // coordinates are strictly positive. If that is not the case, we'll resolve
+  // vertex vs. edge below.
+  if (b_Q(0) > 0 && b_Q(1) > 0 && b_Q(2) > 0) {
+    // The projection of Q onto the plane of the triangle is in the triangle,
+    // so the nearest point is at the projection.
+    const Vector3d p_MN =
+        mesh_M.CalcCartesianFromBarycentric(triangle_index, b_Q);
+    return {(p_MQ - p_MN).squaredNorm(), p_MN,
+            mesh_M.face_normal(triangle_index)};
+  }
+
+  const SurfaceTriangle& triangle = mesh_M.triangles()[triangle_index];
+  const std::array<Vector3d, 3> p_MV = {mesh_M.vertex(triangle.vertex(0)),
+                                        mesh_M.vertex(triangle.vertex(1)),
+                                        mesh_M.vertex(triangle.vertex(2))};
+
+  // The closest point is either in an edge or at a vertex. We will search
+  // the three edges.
+  SquaredDistanceToTriangle result;
+  // Iterate over three edges, call each edge AB.
+  int prev_i = 2;
+  for (int i = 0; i < 3; ++i) {
+    const Vector3d p_MA = p_MV[prev_i];
+    const Vector3d p_MB = p_MV[i];
+    const Vector3d p_AB_M = p_MB - p_MA;
+    // t = 0 when the projection is at A, and t = 1 at B.
+    const double t = p_AB_M.dot(p_MQ - p_MA) / p_AB_M.squaredNorm();
+    // N is the nearest point in the line segment.
+    Vector3d p_MN;
+    Vector3d normal_M;
+    if (t <= 0) {
+      p_MN = p_MA;
+      normal_M = normal_set_M.vertex_normal(triangle.vertex(prev_i));
+    } else if (t >= 1) {
+      p_MN = p_MB;
+      normal_M = normal_set_M.vertex_normal(triangle.vertex(i));
+    } else {
+      p_MN = (1.0 - t) * p_MA + t * p_MB;
+      normal_M = normal_set_M.edge_normal(
+          {triangle.vertex(prev_i), triangle.vertex(i)});
+    }
+
+    const double d_squared = (p_MQ - p_MN).squaredNorm();
+    if (d_squared < result.squared_distance) {
+      result = SquaredDistanceToTriangle({d_squared, p_MN, normal_M});
+    }
+    prev_i = i;
+  }
+  return result;
+}
+
+SignedDistanceToSurfaceMesh CalcSignedDistanceToSurfaceMesh(
+    const Vector3<double>& p_MQ, const TriangleSurfaceMesh<double>& mesh_M,
+    const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_M,
+    const FeatureNormalSet& feature_normals_M) {
+  SquaredDistanceToTriangle closest =
+      BvhVisitor::CalcSquaredDistance(p_MQ, mesh_M, bvh_M, feature_normals_M);
+  // N is the nearest point.
+  const Vector3d p_MN = closest.closest_point;
+  const Vector3d p_NQ_M = p_MQ - p_MN;
+  const double sign = p_NQ_M.dot(closest.feature_normal) >= 0 ? 1 : -1;
+  const double unsigned_distance = std::sqrt(closest.squared_distance);
+  return {.signed_distance = sign * unsigned_distance,
+          .nearest_point = p_MN,
+          .gradient = unsigned_distance == 0 ? closest.feature_normal
+                                             : sign * p_NQ_M.normalized()};
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/calc_signed_distance_to_surface_mesh.h
+++ b/geometry/proximity/calc_signed_distance_to_surface_mesh.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <limits>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/sorted_pair.h"
+#include "drake/common/ssize.h"
+#include "drake/geometry/proximity/bvh.h"
+#include "drake/geometry/proximity/obb.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// TODO(DamrongGuoy) Consider moving FeatureNormalSet into its own file if it
+//  is useful for other applications.
+
+// TODO(DamrongGuoy): Add to the document of ComputeSignedDistanceToPoint()
+//  in QueryObject the discussion that extremely sharp features can make
+//  FeatureNormalSet throw exceptions.
+
+/* %FeatureNormalSet provides outward normal vectors at vertices and edges of a
+ triangle surface mesh. The normal at a vertex is the angle-weighted average of
+ the face normals of the triangles sharing the vertex. The normal at an edge is
+ the equal-weight average of the face normals of the two triangles sharing the
+ edge.
+
+ The following paper shows that normals computed in this way are most suitable
+ for the inside-outside test of a point closest to a vertex or an edge.
+
+ J.A. Baerentzen; H. Aanaes. Signed distance computation using the angle
+ weighted pseudonormal. IEEE Transactions on Visualization and Computer
+ Graphics (Volume: 11, Issue: 3, May-June 2005).
+
+ @throws std::exception if the mesh has very sharp features.
+ They make calculation of the vertex normals and edge normals too sensitive
+ to numerical rounding.
+     Think of the simplest possible knife model of two adjacent triangles
+ sharing a single edge. The two triangles would have a small angle between
+ them, creating a "sharp edge".  If the edge is too sharp, the mesh will be
+ rejected.  We have a generous tolerance -- the angle can be less than a
+ degree -- but it would be better to stay well away from impractically sharp
+ edges.
+     There is an analogous situation with vertices, where a vertex
+ creates a pointy, needle-like region on the mesh. The skinny "needles"
+ have the same problem as the thin knife edges. Presence of these
+ "needles" may lead to the mesh being rejected.  */
+class FeatureNormalSet {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FeatureNormalSet);
+
+  // Computes and stores the normals at the vertices and the edges of the given
+  // surface mesh expressed in frame M.
+  //
+  // @pre  The mesh is watertight and a closed manifold. Otherwise, the
+  //       computed normals are incorrect.
+  explicit FeatureNormalSet(const TriangleSurfaceMesh<double>& mesh_M);
+
+  // Returns the normal at a vertex `v` as the angle-weighted average of face
+  // normals of triangles sharing the vertex. The weight of a triangle is the
+  // angle at vertex `v` in that triangle.
+  //
+  // The returned normal vector is expressed in the mesh's frame.
+  //
+  // @param v  the vertex index into the mesh
+  //
+  // @throws std::exception if v < 0 or v >= number of vertices in the mesh
+  const Vector3<double>& vertex_normal(int v) const {
+    DRAKE_THROW_UNLESS(0 <= v && v < ssize(vertex_normals_));
+    return vertex_normals_[v];
+  }
+
+  // Returns the normal at an edge `uv` as the average normal from the two
+  // triangles sharing the edge. Both triangles have equal weight.
+  //
+  // The returned normal vector is expressed in the mesh's frame.
+  //
+  // @param uv   the edge between vertices u and v, as represented by the
+  //             sorted indices of vertices.
+  //
+  // @throws std::exception if the edge `uv` is not in the mesh.
+  const Vector3<double>& edge_normal(const SortedPair<int>& uv) const {
+    auto it = edge_normals_.find(uv);
+    DRAKE_THROW_UNLESS(it != edge_normals_.end());
+    return it->second;
+  }
+
+ private:
+  std::vector<Vector3<double>> vertex_normals_{};
+  std::unordered_map<SortedPair<int>, Vector3<double>> edge_normals_{};
+};
+
+/* %SquaredDistanceToTriangle stores information about squared distance from
+ a query point Q to a triangle for the inside-outside test.  */
+struct SquaredDistanceToTriangle {
+  double squared_distance{std::numeric_limits<double>::infinity()};
+  // The point in the triangle closest to the query point Q.
+  Vector3<double> closest_point;
+  // The normal at the closest feature (vertex, edge, or triangle).
+  Vector3<double> feature_normal;
+};
+
+/* Calculates the squared distance and the closest point from the query point
+ Q to a triangle in a mesh.
+
+ It also provides the normal at the closest point suitable for the
+ inside-outside test (see FeatureNormalSet) as follows:
+ - return the vertex normal if the closest point is at a vertex, otherwise
+ - return the edge normal if the closest point is in an edge, otherwise
+ - return the face normal of the triangle.  */
+SquaredDistanceToTriangle CalcSquaredDistanceToTriangle(
+    const Vector3<double>& p_MQ, int triangle_index,
+    const TriangleSurfaceMesh<double>& mesh_M,
+    const FeatureNormalSet& normal_set_M);
+
+struct SignedDistanceToSurfaceMesh {
+  double signed_distance;
+  Vector3<double> nearest_point;
+  // The gradient is not continuous when the query point is at a vertex or in
+  // an edge shared by triangles with different face normals.
+  // The gradient is also discontinuous at the query point with multiple
+  // nearest points.
+  Vector3<double> gradient;
+};
+
+// TODO(DamrongGuoy): Explain the precondition of the meshes for
+//  CalcSignedDistanceToSurfaceMesh in ComputeSignedDistanceToPoint()
+//  in QueryObject.
+
+/* Calculates the signed distance, the nearest point, and the signed-distance
+ gradient from the query point Q to the surface mesh. It accelerates the
+ computation using a BVH. It determines the sign using the given
+ FeatureNormalSet of the mesh.
+
+ @param p_MQ  position of the query point expressed in frame M of the
+              surface mesh.
+ @param mesh_M   the surface mesh expressed in frame M.
+ @param bvh_M    the BVH of the surface mesh, expressed in frame M.
+ @param feature_normals_M  provides angle-weighted average normals at
+                           vertices and equal-weight average normals at
+                           edges of the surface mesh, expressed in frame M.
+
+ @pre  The surface mesh is a closed manifold without duplicate vertices or
+ self-intersection, and every triangle's face winding gives an outward-pointing
+ face normal. Non-compliant meshes will introduce regions in which the query
+ point will report the wrong sign (and, therefore, the wrong gradient) due to a
+ misclassification of being inside or outside. This leads to discontinuities in
+ the distance field across the boundaries of these regions; the distance sign
+ will flip while the magnitude of the distance value is arbitrarily far away
+ from zero. For open meshes, the same principle holds. The open mesh, which has
+ no true concept of "inside", will nevertheless report some query points as
+ being inside.
+
+ @note If p_MQ is on the surface, the returned signed distance is zero,
+ the nearest point is p_MQ itself, and the gradient is the normal
+ at the vertex, edge or triangle on which p_MQ lies.
+
+ @note If p_MQ has multiple nearest points, the returned nearest point
+ and the gradient are chosen and computed from one of them. The selection
+ is deterministic but arbitrary because we use the given BVH to select the
+ first closest point. The search order depends on the structure of
+ the BVH.
+
+ The following table characterizes all possible cases. The sign is positive,
+ negative, or zero when the query point is outside, inside, or on the
+ surface respectively. The nearest point N could lie in a triangle, an edge,
+ or a vertex. The gradient depends on the sign of the distance.
+
+  |   sign   |  location of  |    gradient    |
+  |          | nearest point |                |
+  | :------: | :-----------: | :------------: |
+  | positive |   triangle    | (Q-N) / ‖Q-N‖  |
+  | positive |     edge      | (Q-N) / ‖Q-N‖  |
+  | positive |    vertex     | (Q-N) / ‖Q-N‖  |
+  | negative |   triangle    | (N-Q) / ‖N-Q‖  |
+  | negative |     edge      | (N-Q) / ‖N-Q‖  |
+  | negative |    vertex     | (N-Q) / ‖N-Q‖  |
+  |   zero   |   triangle    |  face normal   |
+  |   zero   |     edge      |  edge normal   |
+  |   zero   |    vertex     | vertex normal  |
+  __*Table 1*__: Possible cases of signed distances and gradients according
+  to the location of the nearest point.  */
+SignedDistanceToSurfaceMesh CalcSignedDistanceToSurfaceMesh(
+    const Vector3<double>& p_MQ, const TriangleSurfaceMesh<double>& mesh_M,
+    const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_M,
+    const FeatureNormalSet& feature_normals_M);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/calc_signed_distance_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/calc_signed_distance_to_surface_mesh_test.cc
@@ -1,0 +1,425 @@
+#include "drake/geometry/proximity/calc_signed_distance_to_surface_mesh.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_to_surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RollPitchYawd;
+
+class FeatureNormalSetTest : public ::testing::Test {
+ public:
+  FeatureNormalSetTest()
+      :  // Surface mesh of a tetrahedron, expressed in the mesh's frame M.
+         //
+         //              Mz
+         //              ┆
+         //           v3 ●
+         //              ┆
+         //              ┆      v2
+         //           v0 ●┄┄┄┄┄┄┄●┄┄┄ My
+         //             ╱
+         //            ╱
+         //        v1 ●
+         //         ╱
+         //        Mx
+         //
+        mesh_M_(
+            // The triangles have outward face winding.
+            {SurfaceTriangle{0, 2, 1}, SurfaceTriangle{0, 1, 3},
+             SurfaceTriangle{0, 3, 2}, SurfaceTriangle{1, 2, 3}},
+            {Vector3d::Zero(), Vector3d::UnitX(), Vector3d::UnitY(),
+             Vector3d::UnitZ()}) {}
+
+ protected:
+  const TriangleSurfaceMesh<double> mesh_M_;
+  const double kEps{std::numeric_limits<double>::epsilon()};
+};
+
+TEST_F(FeatureNormalSetTest, EdgeNormalIsAverageFaceNormal) {
+  const FeatureNormalSet dut(mesh_M_);
+  // Edge v1v2 is shared by face 0 (v0,v2,v1) and face 3 (v1, v2,v3).
+  const Vector3d kExpectEdgeNormal =
+      (mesh_M_.face_normal(0) + mesh_M_.face_normal(3)).normalized();
+  EXPECT_TRUE(
+      CompareMatrices(dut.edge_normal({1, 2}), kExpectEdgeNormal, kEps));
+}
+
+TEST_F(FeatureNormalSetTest, VertexNormalIsAngleWeightedAverage) {
+  const FeatureNormalSet dut(mesh_M_);
+  // Vertex v1 is shared by face 0 (v0,v2,v1), face 1 (v0,v1,v3), and
+  // face 3 (v1,v2,v3).  We expect vertex_normal() of v1 to be their
+  // angle-weighted average normal.
+  //
+  //   face      triangle        angle at v1 in the triangle
+  //    0      {v0, v2, v1}                π/4
+  //    1      {v0, v1, v3}                π/4
+  //    3      {v1, v2, v3}                π/3
+  const Vector3d kExpectVertexNormal =
+      (M_PI_4 * mesh_M_.face_normal(0) + M_PI_4 * mesh_M_.face_normal(1) +
+       (M_PI / 3) * mesh_M_.face_normal(3))
+          .normalized();
+  EXPECT_TRUE(CompareMatrices(dut.vertex_normal(1), kExpectVertexNormal, kEps));
+}
+
+// Test the exception when the mesh has two triangles that make a "sharp knife"
+// with a very small dihedral angle.
+GTEST_TEST(FeatureNormalSet, ThrowSharpKnife) {
+  // This is a "flatten" tetrahedron with all four vertices on the same plane.
+  // Its surface mesh has zero dihedral angle.
+  //
+  //              Mz
+  //              ┆
+  //              ┆       v2
+  //           v0 ●┄┄┄┄┄┄┄●┄┄┄ My
+  //             ╱       ╱
+  //            ╱       ╱
+  //        v1 ●┄┄┄┄┄┄┄● v3
+  //         ╱
+  //        Mx
+  //
+  const VolumeMesh<double> one_flat_tetrahedron_M(
+      {VolumeElement(0, 1, 2, 3)}, {Vector3d::Zero(), Vector3d::UnitX(),
+                                    Vector3d::UnitY(), Vector3d(1, 1, 0)});
+  const TriangleSurfaceMesh<double> mesh_M =
+      ConvertVolumeToSurfaceMesh(one_flat_tetrahedron_M);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      FeatureNormalSet{mesh_M},
+      "FeatureNormalSet: Cannot compute an edge normal.*");
+}
+
+// Test the exception when the mesh has a "pointy, needle-like" vertex.
+GTEST_TEST(FeatureNormalSet, ThrowPointyNeedleVertex) {
+  // This scaling factor will creat a "needle" with aspect ratio 1:100.
+  const double kSmallBase = 1e-2;
+  // The apex vertex v3 becomes very pointy as the base triangle v0v1v2
+  // shrinks.
+  //
+  //              Mz
+  //              ┆
+  //           v3 ●
+  //              ┆
+  //              ┆
+  //              ┆
+  //              ┆
+  //              ┆   v2
+  //           v0 ●┄┄┄●┄┄┄ My
+  //             ╱
+  //         v1 ●
+  //          ╱
+  //        Mx
+  //
+  const VolumeMesh<double> needle_tetrahedron_M(
+      {VolumeElement(0, 1, 2, 3)},
+      {Vector3d::Zero(), kSmallBase * Vector3d::UnitX(),
+       kSmallBase * Vector3d::UnitY(), Vector3d::UnitZ()});
+  const TriangleSurfaceMesh<double> mesh_M =
+      ConvertVolumeToSurfaceMesh(needle_tetrahedron_M);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      FeatureNormalSet{mesh_M},
+      "FeatureNormalSet: Cannot compute a vertex normal.*");
+}
+
+class CalcSquaredDistanceToTriangleTest : public ::testing::Test {
+ public:
+  CalcSquaredDistanceToTriangleTest()
+      :  // We will test the code in a general frame M of the mesh, but first
+         // we define the vertices in a convenient frame F like this:
+         //
+         //              Fz
+         //              ┆
+         //           v3 ● 0.1
+         //              ┆
+         //              ┆
+         //           v1 ●┄┄┄┄┄┄┄0.1┄┄┄┄ Fy
+         //             ╱
+         //            ╱
+         //        v2 ●┄┄┄┄┄┄┄● v0
+         //         ╱
+         //        Fx
+         //
+        p_FV0_(0.1, 0.1, 0),
+        p_FV1_(0, 0, 0),
+        p_FV2_(0.1, 0, 0),
+        p_FV3_(0, 0, 0.1),
+        // A transform that expresses the convenient frame F in a general
+        // frame M of the mesh.
+        X_MF_(RollPitchYawd(M_PI, M_PI_2, M_PI_4), Vector3d(0.5, 1, 2)),
+        mesh_M_(
+            std::vector<SurfaceTriangle>{
+                {0, 2, 1}, {0, 1, 3}, {0, 3, 2}, {1, 2, 3}},
+            {X_MF_ * p_FV0_, X_MF_ * p_FV1_, X_MF_ * p_FV2_, X_MF_ * p_FV3_}),
+        normal_set_M_{mesh_M_} {}
+
+ protected:
+  const Vector3d p_FV0_;
+  const Vector3d p_FV1_;
+  const Vector3d p_FV2_;
+  const Vector3d p_FV3_;
+  const RigidTransformd X_MF_;
+  const TriangleSurfaceMesh<double> mesh_M_;
+  const FeatureNormalSet normal_set_M_;
+  const double kEps{std::numeric_limits<double>::epsilon() * (1 << 4)};
+};
+
+TEST_F(CalcSquaredDistanceToTriangleTest, Inside) {
+  // The query point Q projects to N inside the triangle.
+  //
+  //                   Fy
+  //                   ┆
+  //                   0.1          v0
+  //                   ┆           ╱│
+  //                   ┆        ╱   │
+  //                   ┆     ╱      │
+  //                   ┆  ╱  ● N    │
+  //                  v1┄┄┄┄┄┄┄┄┄┄┄┄0.1┄┄┄┄┄┄┄┄ Fx
+  //                                v2
+  //
+  // Q is 15 meters above the triangle in frame F.
+  const Vector3d p_MQ = X_MF_ * Vector3d(0.04, 0.02, 15);
+  // The projection N is the closest point.
+  const Vector3d p_MN = X_MF_ * Vector3d(0.04, 0.02, 0);
+  // The face normal in frame F.
+  const Vector3d nhat_F = -Vector3d::UnitZ();
+  const Vector3d nhat_M = X_MF_.rotation() * nhat_F;
+
+  const SquaredDistanceToTriangle dut =
+      CalcSquaredDistanceToTriangle(p_MQ, 0, mesh_M_, normal_set_M_);
+  EXPECT_NEAR(dut.squared_distance, (p_MQ - p_MN).squaredNorm(), kEps);
+  EXPECT_TRUE(CompareMatrices(dut.closest_point, p_MN, kEps));
+  EXPECT_TRUE(CompareMatrices(dut.feature_normal, nhat_M, kEps));
+}
+
+TEST_F(CalcSquaredDistanceToTriangleTest, OutsideNearEdge) {
+  // The query point Q projects to Q' outside the triangle nearest to
+  // the edge v1v2.  N is the closest point on the edge v1v2.
+  // The area between the two rays is the region of such projections.
+  //
+  //                   Fy
+  //                   ┆
+  //                   0.1          v0
+  //                   ┆           ╱│
+  //                   ┆        ╱   │
+  //                   ┆     ╱      │
+  //                   ┆  ╱  N      │
+  //                  v1┄┄┄┄●┄┄┄┄┄┄┄v2┄┄┄┄┄┄┄┄ Fx
+  //                   ↓    ● Q'    ↓
+  //                   ↓            ↓
+  //                   ↓            ↓
+  //
+  // Q is 10 meters below the triangle in frame F.
+  const Vector3d p_MQ = X_MF_ * Vector3d(0.04, -0.02, -10);
+  // Q projects onto the plane of the triangle at Q'(0.04, -0.02, 0) in frame
+  // F. The projection Q' is outside the triangle and projects onto the
+  // edge v1v2 at the closest point N(0.04, 0, 0) in frame F.
+  const Vector3d p_MN = X_MF_ * Vector3d(0.04, 0, 0);
+
+  const SquaredDistanceToTriangle dut =
+      CalcSquaredDistanceToTriangle(p_MQ, 0, mesh_M_, normal_set_M_);
+  EXPECT_NEAR(dut.squared_distance, (p_MQ - p_MN).squaredNorm(), kEps);
+  EXPECT_TRUE(CompareMatrices(dut.closest_point, p_MN, kEps));
+  EXPECT_TRUE(CompareMatrices(dut.feature_normal,
+                              normal_set_M_.edge_normal({1, 2}), kEps));
+}
+
+TEST_F(CalcSquaredDistanceToTriangleTest, OutsideNearVertex) {
+  // Q' is the projection of the query point Q onto the plane of the
+  // triangle.  Q' is outside the triangle nearest to vertex v1.
+  // The area between the two rays is the region of such projections.
+  //
+  //                   Fy
+  //                   ┆
+  //                   0.1          v0
+  //      ↖            ┆           ╱│
+  //         ↖         ┆        ╱   │
+  //            ↖      ┆     ╱      │
+  //               ↖   ┆  ╱         │
+  //                  v1 ┄┄┄┄┄┄┄┄┄┄┄v2┄┄┄┄┄┄┄┄ Fx
+  //       Q'          ↓
+  //                   ↓
+  //                   ↓
+  //                   ↓
+  //
+  // Q is 5 meters above the triangle in frame F.
+  const Vector3d p_MQ = X_MF_ * Vector3d(-0.08, -0.02, 5);
+  const SquaredDistanceToTriangle dut =
+      CalcSquaredDistanceToTriangle(p_MQ, 0, mesh_M_, normal_set_M_);
+
+  EXPECT_NEAR(dut.squared_distance, (p_MQ - mesh_M_.vertex(1)).squaredNorm(),
+              kEps);
+  EXPECT_TRUE(CompareMatrices(dut.closest_point, mesh_M_.vertex(1), kEps));
+  EXPECT_TRUE(CompareMatrices(dut.feature_normal,
+                              normal_set_M_.vertex_normal(1), kEps));
+}
+
+// The document of CalcSignedDistanceToSurfaceMesh() shows a table of many
+// possible cases; however, we will test only a representative subset as
+// shown in the following table. We pick them for code coverage. If the
+// implementation changes, we might change the tests accordingly.
+// We also test a few special cases when there are multiple nearest points.
+//
+//  |   sign   | unique nearest|  location of  |      gradient      |
+//  |          | point N       | nearest point |                    |
+//  | :------: | :-----------: | :-----------: | :----------------: |
+//  | positive |      yes      |   triangle    | (Q-N).normalized() |
+//  | negative |      yes      |     edge      | (N-Q).normalized() |
+//  |   zero   |      yes      |    vertex     |    vertex normal   |
+//  | :------: | :-----------: | :-----------: | :----------------: |
+//  | positive |      no       |   triangle    | (Q-N).normalized() |
+//  | positive |      no       |    vertex     | (Q-N).normalized() |
+class CalcSignedDistanceToSurfaceMeshTest : public ::testing::Test {
+ public:
+  CalcSignedDistanceToSurfaceMeshTest()
+      :  // These coordinates are simply ones and zeros, but they define
+         // complicated normals at vertices, edges, and faces of the mesh.
+         // The main numerics in the code involves dot products with
+         // the normals.
+        p_MV0_{0, 0, 0},
+        p_MV1_{1, 0, 0},
+        p_MV2_{0, 1, 0},
+        p_MV3_{0, 0, 1},
+        p_MV4_{-1, -1, 0},
+        // We use two tetrahedra v0v1v3v4 and v0v3v2v4 to create a
+        // non-convex polytope and convert it to a triangle
+        // surface mesh for testing. Defining two tetrahedra is more
+        // convenient than defining six triangles.
+        //
+        //                       Mz
+        //                       ┆     -Mx
+        //            v4      v3 ●     ╱
+        //              ●┄┄┄┄┄┄┄┄┆┄┄┄┄+
+        //             ╱         ┆   ╱
+        //            ╱          ┆  ╱
+        //           ╱           ┆ ╱
+        //          ╱         v0 ┆╱            v2
+        //  -My ┄┄┄+┄┄┄┄┄┄┄┄┄┄┄┄┄●┄┄┄┄┄┄┄┄┄┄┄┄┄●┄┄┄ My
+        //                      ╱
+        //                     ╱
+        //                    ╱
+        //                   ╱
+        //               v1 ●
+        //                 ╱
+        //                Mx
+        //
+        mesh_M_(ConvertVolumeToSurfaceMesh(VolumeMesh<double>(
+            {VolumeElement{0, 1, 3, 4}, VolumeElement{0, 3, 2, 4}},
+            {p_MV0_, p_MV1_, p_MV2_, p_MV3_, p_MV4_}))),
+        bvh_M_(mesh_M_),
+        mesh_normal_M_(mesh_M_) {}
+
+ protected:
+  const Vector3d p_MV0_;
+  const Vector3d p_MV1_;
+  const Vector3d p_MV2_;
+  const Vector3d p_MV3_;
+  const Vector3d p_MV4_;
+  const TriangleSurfaceMesh<double> mesh_M_;
+  const Bvh<Obb, TriangleSurfaceMesh<double>> bvh_M_;
+  const FeatureNormalSet mesh_normal_M_;
+  const double kEps{std::numeric_limits<double>::epsilon() * (1 << 4)};
+};
+
+// Positive signed distance with nearest point in a triangle.
+TEST_F(CalcSignedDistanceToSurfaceMeshTest, PositiveTriangle) {
+  const Vector3d p_MC = mesh_M_.element_centroid(0);
+  const Vector3d n_M = mesh_M_.face_normal(0);
+  // We don't know which one is face 0, but we know that a small
+  // translation from its centroid along its outward face normal keeps
+  // the nearest point at its centroid. All triangles, except the
+  // triangles v0v3v1 and v0v2v3, have no limit on such translation distance.
+  // Each of the two triangles limits the translation distance to 1/3 before
+  // the nearest point switches, so we can use 1/4 safely.
+  const Vector3d p_MQ = p_MC + 0.25 * n_M;
+  const SignedDistanceToSurfaceMesh d =
+      CalcSignedDistanceToSurfaceMesh(p_MQ, mesh_M_, bvh_M_, mesh_normal_M_);
+  EXPECT_TRUE(CompareMatrices(d.nearest_point, p_MC, kEps));
+  EXPECT_NEAR(d.signed_distance, 0.25, kEps);
+  EXPECT_TRUE(CompareMatrices(d.gradient, n_M, kEps));
+}
+
+// Negative signed distance with nearest point in an edge. This case needs
+// the concave edge v0v3.
+TEST_F(CalcSignedDistanceToSurfaceMeshTest, NegativeEdge) {
+  const Vector3d kMidPointEdgeV0V3 = (p_MV0_ + p_MV3_) / 2;
+  // Set up the query point Q by a small translation from the midpoint of
+  // the concave edge v0v3 in an inward direction perpendicular to the edge.
+  // Any small translation with negative X, negative Y, and zero Z
+  // would work.
+  const Vector3d p_MQ = kMidPointEdgeV0V3 + Vector3d(-0.01, -0.02, 0);
+  const SignedDistanceToSurfaceMesh d =
+      CalcSignedDistanceToSurfaceMesh(p_MQ, mesh_M_, bvh_M_, mesh_normal_M_);
+  EXPECT_TRUE(CompareMatrices(d.nearest_point, kMidPointEdgeV0V3, kEps));
+  EXPECT_NEAR(d.signed_distance, -(d.nearest_point - p_MQ).norm(), kEps);
+  EXPECT_TRUE(
+      CompareMatrices(d.gradient, (d.nearest_point - p_MQ).normalized(), kEps));
+}
+
+// Zero signed distance with nearest point at a vertex.
+TEST_F(CalcSignedDistanceToSurfaceMeshTest, ZeroVertex) {
+  // Test the non-convex vertex v3.
+  const Vector3d p_MQ = p_MV3_;
+  const SignedDistanceToSurfaceMesh d =
+      CalcSignedDistanceToSurfaceMesh(p_MQ, mesh_M_, bvh_M_, mesh_normal_M_);
+  EXPECT_TRUE(CompareMatrices(d.nearest_point, p_MV3_, kEps));
+  EXPECT_NEAR(d.signed_distance, 0, kEps);
+  // Sanity check that vertex 3 in the mesh is indeed at p_MV3_, so we can
+  // query the mesh_normal_M_. We are assuming that when we called
+  // ConvertVolumeToSurfaceMesh() in the constructor, it preserved the vertices.
+  ASSERT_EQ(mesh_M_.vertex(3), p_MV3_);
+  EXPECT_TRUE(
+      CompareMatrices(d.gradient, mesh_normal_M_.vertex_normal(3), kEps));
+}
+
+// Nearest points in multiple triangles.
+TEST_F(CalcSignedDistanceToSurfaceMeshTest, MultipleTriangles) {
+  // Q is equally far from two faces v0v3v1 and v0v2v3 on XZ-plane and
+  // YZ-plane respectively.
+  const Vector3d p_MQ(0.1, 0.1, 0.1);
+  // The nearest point N1 is in triangle v0v3v1 in XZ-plane.
+  const Vector3d p_MN1(0.1, 0, 0.1);
+  // The nearest point N2 is in triangle v0v2v3 in YZ-plane.
+  const Vector3d p_MN2(0, 0.1, 0.1);
+  // Both N1 and N2 are 0.1 meters from Q.
+  const double kExpectDistance = 0.1;
+  const SignedDistanceToSurfaceMesh d =
+      CalcSignedDistanceToSurfaceMesh(p_MQ, mesh_M_, bvh_M_, mesh_normal_M_);
+  EXPECT_NEAR(d.signed_distance, kExpectDistance, kEps);
+  EXPECT_TRUE(CompareMatrices(d.nearest_point, p_MN1, kEps) ||
+              CompareMatrices(d.nearest_point, p_MN2, kEps));
+  EXPECT_TRUE(
+      CompareMatrices(d.gradient, (p_MQ - d.nearest_point).normalized(), kEps));
+}
+
+// Nearest points at multiple vertices. This case needs a non-convex mesh.
+TEST_F(CalcSignedDistanceToSurfaceMeshTest, MultipleVertices) {
+  // Q is equally far from two vertices v1 and v2 on X-axis and Y-axis
+  // respectively.
+  const Vector3d p_MQ(1.5, 1.5, 0);
+  const double dist1 = (p_MQ - p_MV1_).norm();
+  const double dist2 = (p_MQ - p_MV2_).norm();
+  // Sanity check that v1 and v2 are at the same distance from Q.
+  ASSERT_EQ(dist1, dist2);
+  const SignedDistanceToSurfaceMesh d =
+      CalcSignedDistanceToSurfaceMesh(p_MQ, mesh_M_, bvh_M_, mesh_normal_M_);
+  EXPECT_TRUE(CompareMatrices(d.nearest_point, p_MV1_, kEps) ||
+              CompareMatrices(d.nearest_point, p_MV2_, kEps));
+  EXPECT_NEAR(d.signed_distance, dist1, kEps);
+  EXPECT_TRUE(
+      CompareMatrices(d.gradient, (p_MQ - d.nearest_point).normalized(), kEps));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Support:
- #21471
- #21323
- #3220

Another PR will use it in ProximityEngine for ComputeSignedDistanceToPoint for non-convex Mesh() and convex hull Convex() of both .vtk files (tetrahedral meshes) and .obj files (triangle meshes).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21566)
<!-- Reviewable:end -->
