### PR TITLE
[math] Use highway instead of intrinsics

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -323,7 +323,9 @@ drake_cc_library(
     }),
     internal = True,
     visibility = ["//visibility:private"],
-    deps = [],
+    deps = [
+        "@highway_internal//:hwy",
+    ],
 )
 
 drake_cc_library(

--- a/math/fast_pose_composition_functions_avx2_fma.cc
+++ b/math/fast_pose_composition_functions_avx2_fma.cc
@@ -4,7 +4,18 @@
 #include <cstdint>
 
 #include <cpuid.h>
-#include <immintrin.h>
+
+#pragma GCC diagnostic push
+// TODO(jwnimmer-tri) Ideally we would fix the old-style-cast warnings instead
+// of suppressing them, perhaps by submitting a patch upstream.
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+// By setting the next two HWY_... macros, we're saying that we don't want to
+// generate any SIMD code for pre-AVX2 CPUs, and that we're okay not using the
+// carry-less multiplication and crypto stuff.
+#define HWY_BASELINE_TARGETS HWY_AVX2
+#define HWY_DISABLE_PCLMUL_AES 1
+#include "hwy/highway.h"
+#pragma GCC diagnostic pop
 #else
 #include <iostream>
 #endif
@@ -19,6 +30,11 @@ namespace internal {
 
 #if defined(__AVX2__) && defined(__FMA__)
 namespace {
+
+// The hn namespace holds the CPU-specific function overloads. By defining it
+// using a substitute-able macro, we achieve per-CPU instruction selection.
+namespace hn = hwy::HWY_NAMESPACE;
+
 /* Reinterpret user-friendly class names to raw arrays of double.
 
 We make judicious use below of potentially-dangerous reinterpret_casts to
@@ -67,9 +83,7 @@ use both lowercase and uppercase letters for naming lanes. In variable names,
 we leave out the <> marker so the variable name would be just "abcd".
 
 The lower order lanes are spelled on the left, so for example if YMM0 = <abcd>
-then we have XMM0 = <ab>. Note that even though we spell lanes from lowest to
-highest, bitwise constants end up being written highest to lowest (as is typical
-for numbers) so we have blend(<abcd>, <ABCD>, 0b0101) as <AbCd>.
+then we have XMM0 = <ab>.
 
 Sometimes we don't need to give a name to a lane (because we don't care what its
 value is). In that case we use the canonical "_" to indicate "don't care", e.g.,
@@ -88,12 +102,15 @@ For inspecting the machine code, see Godbolt and in particular the LLVM-MCA tool
 
  https://godbolt.org/
 
-============================================================================= */
+For a Highway function reference, see:
 
-// Turns d into <dddd>.
-__m256d four(double d) {
-  return _mm256_set1_pd(d);
-}
+ https://google.github.io/highway/en/master/quick_reference.html#operations
+
+Be very careful when reading Highway docs to distinguish "lane" vs "block".
+A lane holds one scalar (e.g., a `double`); a block is 16-bytes worth of lanes,
+e.g., two doubles.
+
+============================================================================= */
 
 /* Composition of rotation matrices R_AC = R_AB * R_BC.
 
@@ -149,45 +166,83 @@ SIMD floating point instructions (3 multiplies and 6 fused-multiply-adds).
 
 It is OK if the result R_AC overlaps one or both of the inputs. */
 void ComposeRRAvx(const double* R_AB, const double* R_BC, double* R_AC) {
-  constexpr uint64_t yes = uint64_t(1ull << 63);
-  constexpr uint64_t no = uint64_t(0);
-  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
+  const hn::FixedTag<double, 4> tag;
 
-  // Load the input.
-  const __m256d abc_ = _mm256_loadu_pd(R_AB);      // (d is loaded but unused)
-  const __m256d def_ = _mm256_loadu_pd(R_AB + 3);  // (g is loaded but unused)
-  const __m256d ghi_ = _mm256_maskload_pd(R_AB + 6, mask);
-  const double A = R_BC[0];
-  const double B = R_BC[1];
-  const double C = R_BC[2];
-  const double D = R_BC[3];
-  const double E = R_BC[4];
-  const double F = R_BC[5];
-  const double G = R_BC[6];
-  const double H = R_BC[7];
-  const double I = R_BC[8];
+  const auto abc_ = hn::LoadU(tag, R_AB);      // (d is loaded but unused)
+  const auto def_ = hn::LoadU(tag, R_AB + 3);  // (g is loaded but unused)
+  const auto ghi_ = hn::LoadN(tag, R_AB + 6, 3);
 
-  // Column jkl:                                    j   k   l   _  =
-  __m256d jkl_ = _mm256_mul_pd(abc_, four(A));  //  aA  bA  cA  _
-  jkl_ = _mm256_fmadd_pd(def_, four(B), jkl_);  // +dB +eB +fB  _
-  jkl_ = _mm256_fmadd_pd(ghi_, four(C), jkl_);  // +gC +hC +iC  _
+  const auto AAA_ = hn::Set(tag, R_BC[0]);
+  const auto BBB_ = hn::Set(tag, R_BC[1]);
+  const auto CCC_ = hn::Set(tag, R_BC[2]);
+  const auto DDD_ = hn::Set(tag, R_BC[3]);
+  const auto EEE_ = hn::Set(tag, R_BC[4]);
+  const auto FFF_ = hn::Set(tag, R_BC[5]);
+  const auto GGG_ = hn::Set(tag, R_BC[6]);
+  const auto HHH_ = hn::Set(tag, R_BC[7]);
+  const auto III_ = hn::Set(tag, R_BC[8]);
 
-  // Column mno:                                    m   n   o   _  =
-  __m256d mno_ = _mm256_mul_pd(abc_, four(D));  //  aD  bD  cD  _
-  mno_ = _mm256_fmadd_pd(def_, four(E), mno_);  // +dE +eE +fE  _
-  mno_ = _mm256_fmadd_pd(ghi_, four(F), mno_);  // +gF +hF +iF  _
+  // Column jkl:                            j   k   l   _  =
+  auto jkl_ = hn::Mul(abc_, AAA_);      //  aA  bA  cA  _
+  jkl_ = hn::MulAdd(def_, BBB_, jkl_);  // +dB +eB +fB  _
+  jkl_ = hn::MulAdd(ghi_, CCC_, jkl_);  // +gC +hC +iC  _
 
-  // Column pqr:                                    p   q   r   _  =
-  __m256d pqr_ = _mm256_mul_pd(abc_, four(G));  //  aG  bG  cG  _
-  pqr_ = _mm256_fmadd_pd(def_, four(H), pqr_);  // +dH +eH +fH  _
-  pqr_ = _mm256_fmadd_pd(ghi_, four(I), pqr_);  // +gI +hI +iI  _
+  // Column mno:                            m   n   o   _  =
+  auto mno_ = hn::Mul(abc_, DDD_);      //  aD  bD  cD  _
+  mno_ = hn::MulAdd(def_, EEE_, mno_);  // +dE +eE +fE  _
+  mno_ = hn::MulAdd(ghi_, FFF_, mno_);  // +gF +hF +iF  _
+
+  // Column pqr:                            p   q   r   _  =
+  auto pqr_ = hn::Mul(abc_, GGG_);      //  aG  bG  cG  _
+  pqr_ = hn::MulAdd(def_, HHH_, pqr_);  // +dH +eH +fH  _
+  pqr_ = hn::MulAdd(ghi_, III_, pqr_);  // +gI +hI +iI  _
 
   // Store the output.
-  _mm256_storeu_pd(R_AC, jkl_);      // 4-wide write temporarily overwrites m
-  _mm256_storeu_pd(R_AC + 3, mno_);  // 4-wide write temporarily overwrites p
-  _mm256_maskstore_pd(R_AC + 6, mask, pqr_);  // 3-wide write to stay in bounds
+  hn::StoreU(jkl_, tag, R_AC);         // 4-wide write temporarily overwrites m
+  hn::StoreU(mno_, tag, R_AC + 3);     // 4-wide write temporarily overwrites p
+  hn::StoreN(pqr_, tag, R_AC + 6, 3);  // 3-wide write to stay in bounds
+}
 
-  // The compiler will generate a vzeroupper instruction if needed.
+/* Loads R_BA, transposed. Imagine R_BA as a array of doubles 'abcdefghi'. Upon
+return, the output arguments adg_, beh_, and cfi_ are filled with the like-named
+elements of R_BA. (As usual, underscore means undefined / don't care.) */
+template <typename Vec4>
+void LoadMatrix3Inv(const double* R_BA, Vec4* adg_, Vec4* beh_, Vec4* cfi_) {
+  const hn::FixedTag<double, 4> tag;
+  const auto abcd = hn::LoadU(tag, R_BA);
+  const auto defg = hn::LoadU(tag, R_BA + 3);
+  const auto efgh = hn::LoadU(tag, R_BA + 4);
+  const auto iiii = hn::Set(tag, R_BA[8]);
+
+  // Take special care in reading the below:
+  //
+  // - ConcatFooBar(hi, lo) composes two concatenated halves:
+  //   - the highest half worth of lanes comes from the Foo part of `hi`
+  //   - the lowest half worth of lanes comes from the Bar part of `lo`
+  //   Thus, ConcatUpperLower stacks the Upper half of `hi`
+  //                       on top of the Lower half of `lo`, and
+  //         ConcatUpperUpper stacks the Upper half of `hi`
+  //                       on top of the Upper half of `lo`.
+  //
+  // - InterleaveEven(a, b) interleaves the even-numbered names of `a` and `b`
+  //   (and discards the odd-numbered lanes), i.e., the odd-numbered lanes
+  //   of `a` are replaced the even-numbered lanes of `b`.
+  //
+  // - InterleaveEven(a, b) interleaves the odd-numbered names of `a` and `b`
+  //   (and discards the even-numbered lanes), i.e., the even-numbered lanes
+  //   of `b` are replaced the odd-numbered lanes of `a`.
+  //
+  const auto abgh = hn::ConcatUpperLower(tag, efgh, abcd);  // ..gh|ab.. => abgh
+  const auto adgf = hn::InterleaveEven(tag, abgh, defg);    // a.g.|d.f. => adgf
+  const auto behg = hn::InterleaveOdd(tag, abgh, defg);     // .b.h|.e.g => behg
+  const auto adcf = hn::InterleaveEven(abcd, defg);         // a.c.|d.f. => adcf
+  const auto cfii = hn::ConcatUpperUpper(tag, iiii, adcf);  // ..ii|..cf => cfii
+
+  // These don't generate any instructions, but are just a nice way to use
+  // variable names with and without the don't-care markers, for clarity.
+  *adg_ = adgf;
+  *beh_ = behg;
+  *cfi_ = cfii;
 }
 
 /* Composition of rotation matrices R_AC = R_BA⁻¹ * R_BC.
@@ -245,52 +300,44 @@ SIMD floating point instructions (3 multiplies and 6 fused-multiply-adds).
 
 It is OK if the result R_AC overlaps one or both of the inputs. */
 void ComposeRinvRAvx(const double* R_BA, const double* R_BC, double* R_AC) {
-  constexpr uint64_t yes = uint64_t(1ull << 63);
-  constexpr uint64_t no = uint64_t(0);
-  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
+  const hn::FixedTag<double, 4> tag;
 
-  // Load the input. Loads columns of R_AB (rows of the given R_BA) into
-  // registers via a series of loads, blends, and permutes.
-  const __m256d abcd = _mm256_loadu_pd(R_BA);
-  const __m256d efgh = _mm256_loadu_pd(R_BA + 4);
-  const __m256d eb_h = _mm256_blend_pd(abcd, efgh, 0b1101);
-  const __m256d beh_ = _mm256_permute_pd(eb_h, 0b0101);
-  const __m256d cdg_ = _mm256_permute2f128_pd(abcd, efgh, 0b00110001);
-  const __m256d adg_ = _mm256_blend_pd(abcd, cdg_, 0b1110);
-  const __m256d fghi = _mm256_loadu_pd(R_BA + 5);
-  const __m256d _fi_ = _mm256_permute_pd(fghi, 0b0100);
-  const __m256d cfi_ = _mm256_blend_pd(cdg_, _fi_, 0b0110);
-  const double A = R_BC[0];
-  const double B = R_BC[1];
-  const double C = R_BC[2];
-  const double D = R_BC[3];
-  const double E = R_BC[4];
-  const double F = R_BC[5];
-  const double G = R_BC[6];
-  const double H = R_BC[7];
-  const double I = R_BC[8];
+  // Load the columns of R_AB (rows of the given R_BA).
+  auto adg_ = hn::Undefined(tag);
+  auto beh_ = hn::Undefined(tag);
+  auto cfi_ = hn::Undefined(tag);
+  LoadMatrix3Inv(R_BA, &adg_, &beh_, &cfi_);
 
-  // Column jkl:                                    j   k   l   _  =
-  __m256d jkl_ = _mm256_mul_pd(adg_, four(A));  //  aA  dA  gA  _
-  jkl_ = _mm256_fmadd_pd(beh_, four(B), jkl_);  // +bB +eB +hB  _
-  jkl_ = _mm256_fmadd_pd(cfi_, four(C), jkl_);  // +cC +fC +iC  _
+  // Load R_BC.
+  const auto AAA_ = hn::Set(tag, R_BC[0]);
+  const auto BBB_ = hn::Set(tag, R_BC[1]);
+  const auto CCC_ = hn::Set(tag, R_BC[2]);
+  const auto DDD_ = hn::Set(tag, R_BC[3]);
+  const auto EEE_ = hn::Set(tag, R_BC[4]);
+  const auto FFF_ = hn::Set(tag, R_BC[5]);
+  const auto GGG_ = hn::Set(tag, R_BC[6]);
+  const auto HHH_ = hn::Set(tag, R_BC[7]);
+  const auto III_ = hn::Set(tag, R_BC[8]);
 
-  // Column mno:                                    m   n   o   _  =
-  __m256d mno_ = _mm256_mul_pd(adg_, four(D));  //  aD  dD  gD  _
-  mno_ = _mm256_fmadd_pd(beh_, four(E), mno_);  // +bE +eE +hE  _
-  mno_ = _mm256_fmadd_pd(cfi_, four(F), mno_);  // +cF +fF +iF  _
+  // Column jkl:                            j   k   l   _  =
+  auto jkl_ = hn::Mul(adg_, AAA_);      //  aA  dA  gA  _
+  jkl_ = hn::MulAdd(beh_, BBB_, jkl_);  // +bB +eB +hB  _
+  jkl_ = hn::MulAdd(cfi_, CCC_, jkl_);  // +cC +fC +iC  _
 
-  // Column pqr:                                    p   q   r   _  =
-  __m256d pqr_ = _mm256_mul_pd(adg_, four(G));  //  aG  dG  gG  _
-  pqr_ = _mm256_fmadd_pd(beh_, four(H), pqr_);  // +bH +eH +hH  _
-  pqr_ = _mm256_fmadd_pd(cfi_, four(I), pqr_);  // +cI +fI +iI  _
+  // Column mno:                            m   n   o   _  =
+  auto mno_ = hn::Mul(adg_, DDD_);      //  aD  dD  gD  _
+  mno_ = hn::MulAdd(beh_, EEE_, mno_);  // +bE +eE +hE  _
+  mno_ = hn::MulAdd(cfi_, FFF_, mno_);  // +cF +fF +iF  _
+
+  // Column pqr:                            p   q   r   _  =
+  auto pqr_ = hn::Mul(adg_, GGG_);      //  aG  dG  gG  _
+  pqr_ = hn::MulAdd(beh_, HHH_, pqr_);  // +bH +eH +hH  _
+  pqr_ = hn::MulAdd(cfi_, III_, pqr_);  // +cI +fI +iI  _
 
   // Store the output.
-  _mm256_storeu_pd(R_AC, jkl_);      // 4-wide write temporarily overwrites m
-  _mm256_storeu_pd(R_AC + 3, mno_);  // 4-wide write temporarily overwrites p
-  _mm256_maskstore_pd(R_AC + 6, mask, pqr_);  // 3-wide write to stay in bounds
-
-  // The compiler will generate a vzeroupper instruction if needed.
+  hn::StoreU(jkl_, tag, R_AC);         // 4-wide write temporarily overwrites m
+  hn::StoreU(mno_, tag, R_AC + 3);     // 4-wide write temporarily overwrites p
+  hn::StoreN(pqr_, tag, R_AC + 6, 3);  // 3-wide write to stay in bounds
 }
 
 /* Composition of transforms X_AC = X_AB * X_BC.
@@ -356,17 +403,17 @@ The <stu_> vector has the deepest pipeline, so we get it going first.
            + <def_> * <YYY_>
            + <ghi_> * <ZZZ_>
 
-  <jkl_> =   <adg_> * <AAA_>
-           + <beh_> * <BBB_>
-           + <cfi_> * <CCC_>
+  <jkl_> =   <abc_> * <AAA_>
+           + <def_> * <BBB_>
+           + <ghi_> * <CCC_>
 
-  <mno_> =   <adg_> * <DDD_>
-           + <beh_> * <EEE_>
-           + <cfi_> * <FFF_>
+  <mno_> =   <abc_> * <DDD_>
+           + <def_> * <EEE_>
+           + <ghi_> * <FFF_>
 
-  <pqr_> =   <adg_> * <GGG_>
-           + <beh_> * <HHH_>
-           + <cfi_> * <III_>
+  <pqr_> =   <abc_> * <GGG_>
+           + <def_> * <HHH_>
+           + <ghi_> * <III_>
 
 We load columns from left matrix and broadcast elements from right, performing
 4 operations in parallel but ignoring the 4th result. We must be careful not to
@@ -378,56 +425,53 @@ SIMD floating point instructions (3 multiplies and 9 fused-multiply-adds).
 
 It is OK if the result X_AC overlaps one or both of the inputs. */
 void ComposeXXAvx(const double* X_AB, const double* X_BC, double* X_AC) {
-  constexpr uint64_t yes = uint64_t(1ull << 63);
-  constexpr uint64_t no = uint64_t(0);
-  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
+  const hn::FixedTag<double, 4> tag;
 
   // Load the input.
-  const __m256d abc_ = _mm256_loadu_pd(X_AB);      // (d is loaded but unused)
-  const __m256d def_ = _mm256_loadu_pd(X_AB + 3);  // (g is loaded but unused)
-  const __m256d ghi_ = _mm256_loadu_pd(X_AB + 6);  // (x is loaded but unused)
-  const __m256d xyz_ = _mm256_maskload_pd(X_AB + 9, mask);
-  const double A = X_BC[0];
-  const double B = X_BC[1];
-  const double C = X_BC[2];
-  const double D = X_BC[3];
-  const double E = X_BC[4];
-  const double F = X_BC[5];
-  const double G = X_BC[6];
-  const double H = X_BC[7];
-  const double I = X_BC[8];
-  const double X = X_BC[9];
-  const double Y = X_BC[10];
-  const double Z = X_BC[11];
+  const auto abc_ = hn::LoadU(tag, X_AB);      // (d is loaded but unused)
+  const auto def_ = hn::LoadU(tag, X_AB + 3);  // (g is loaded but unused)
+  const auto ghi_ = hn::LoadU(tag, X_AB + 6);  // (x is loaded but unused)
+  const auto xyz_ = hn::LoadN(tag, X_AB + 9, 3);
 
-  // Column stu:                                    s   t   u   _  =
-  __m256d stu_ = xyz_;                          //  x   y   z   _
-  stu_ = _mm256_fmadd_pd(abc_, four(X), stu_);  // +aX +bX +cX  _
-  stu_ = _mm256_fmadd_pd(def_, four(Y), stu_);  // +dY +eY +fY  _
-  stu_ = _mm256_fmadd_pd(ghi_, four(Z), stu_);  // +gZ +hZ +iZ  _
+  const auto AAA_ = hn::Set(tag, X_BC[0]);
+  const auto BBB_ = hn::Set(tag, X_BC[1]);
+  const auto CCC_ = hn::Set(tag, X_BC[2]);
+  const auto DDD_ = hn::Set(tag, X_BC[3]);
+  const auto EEE_ = hn::Set(tag, X_BC[4]);
+  const auto FFF_ = hn::Set(tag, X_BC[5]);
+  const auto GGG_ = hn::Set(tag, X_BC[6]);
+  const auto HHH_ = hn::Set(tag, X_BC[7]);
+  const auto III_ = hn::Set(tag, X_BC[8]);
+  const auto XXX_ = hn::Set(tag, X_BC[9]);
+  const auto YYY_ = hn::Set(tag, X_BC[10]);
+  const auto ZZZ_ = hn::Set(tag, X_BC[11]);
 
-  // Column jkl:                                    j   k   l   _  =
-  __m256d jkl_ = _mm256_mul_pd(abc_, four(A));  //  aA  bA  cA  _
-  jkl_ = _mm256_fmadd_pd(def_, four(B), jkl_);  // +dB +eB +fB  _
-  jkl_ = _mm256_fmadd_pd(ghi_, four(C), jkl_);  // +gC +hC +iC  _
+  // Column stu:                            s   t   u   _  =
+  auto stu_ = xyz_;                     //  x   y   z   _
+  stu_ = hn::MulAdd(abc_, XXX_, stu_);  // +aX +bX +cX  _
+  stu_ = hn::MulAdd(def_, YYY_, stu_);  // +dY +eY +fY  _
+  stu_ = hn::MulAdd(ghi_, ZZZ_, stu_);  // +gZ +hZ +iZ  _
 
-  // Column mno:                                    m   n   o   _  =
-  __m256d mno_ = _mm256_mul_pd(abc_, four(D));  //  aD  bD  cD  _
-  mno_ = _mm256_fmadd_pd(def_, four(E), mno_);  // +dE +eE +fE  _
-  mno_ = _mm256_fmadd_pd(ghi_, four(F), mno_);  // +gF +hF +iF  _
+  // Column jkl:                            j   k   l   _  =
+  auto jkl_ = hn::Mul(abc_, AAA_);      //  aA  bA  cA  _
+  jkl_ = hn::MulAdd(def_, BBB_, jkl_);  // +dB +eB +fB  _
+  jkl_ = hn::MulAdd(ghi_, CCC_, jkl_);  // +gC +hC +iC  _
 
-  // Column pqr:                                    p   q   r   _  =
-  __m256d pqr_ = _mm256_mul_pd(abc_, four(G));  //  aG  bG  cG  _
-  pqr_ = _mm256_fmadd_pd(def_, four(H), pqr_);  // +dH +eH +fH  _
-  pqr_ = _mm256_fmadd_pd(ghi_, four(I), pqr_);  // +gI +hI +iI  _
+  // Column mno:                            m   n   o   _  =
+  auto mno_ = hn::Mul(abc_, DDD_);      //  aD  bD  cD  _
+  mno_ = hn::MulAdd(def_, EEE_, mno_);  // +dE +eE +fE  _
+  mno_ = hn::MulAdd(ghi_, FFF_, mno_);  // +gF +hF +iF  _
+
+  // Column pqr:                            p   q   r   _  =
+  auto pqr_ = hn::Mul(abc_, GGG_);      //  aG  bG  cG  _
+  pqr_ = hn::MulAdd(def_, HHH_, pqr_);  // +dH +eH +fH  _
+  pqr_ = hn::MulAdd(ghi_, III_, pqr_);  // +gI +hI +iI  _
 
   // Store the output.
-  _mm256_storeu_pd(X_AC, jkl_);      // 4-wide write temporarily overwrites m
-  _mm256_storeu_pd(X_AC + 3, mno_);  // 4-wide write temporarily overwrites p
-  _mm256_storeu_pd(X_AC + 6, pqr_);  // 4-wide write temporarily overwrites s
-  _mm256_maskstore_pd(X_AC + 9, mask, stu_);  // 3-wide write to stay in bounds
-
-  // The compiler will generate a vzeroupper instruction if needed.
+  hn::StoreU(jkl_, tag, X_AC);         // 4-wide write temporarily overwrites m
+  hn::StoreU(mno_, tag, X_AC + 3);     // 4-wide write temporarily overwrites p
+  hn::StoreU(pqr_, tag, X_AC + 6);     // 4-wide write temporarily overwrites s
+  hn::StoreN(stu_, tag, X_AC + 9, 3);  // 3-wide write to stay in bounds
 }
 
 /* Composition of transforms X_AC = X_BA⁻¹ * X_BC.
@@ -514,64 +558,57 @@ additions, and 3 subtractions) but we're doing 84 here and throwing away 21 of
 them. However, we only issue 13 SIMD floating point instructions (4 multiplies,
 8 fused-multiply-adds, and 1 subtraction). */
 void ComposeXinvXAvx(const double* X_BA, const double* X_BC, double* X_AC) {
-  constexpr uint64_t yes = uint64_t(1ull << 63);
-  constexpr uint64_t no = uint64_t(0);
-  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
+  const hn::FixedTag<double, 4> tag;
 
-  // Load the input. Loads columns of R_AB (rows of the given R_BA) into
-  // registers via a series of loads, blends, and permutes.
-  const __m256d abcd = _mm256_loadu_pd(X_BA);
-  const __m256d efgh = _mm256_loadu_pd(X_BA + 4);
-  const __m256d eb_h = _mm256_blend_pd(abcd, efgh, 0b1101);
-  const __m256d beh_ = _mm256_permute_pd(eb_h, 0b0101);
-  const __m256d cdg_ = _mm256_permute2f128_pd(abcd, efgh, 0b00110001);
-  const __m256d adg_ = _mm256_blend_pd(abcd, cdg_, 0b1110);
-  const __m256d fghi = _mm256_loadu_pd(X_BA + 5);
-  const __m256d _fi_ = _mm256_permute_pd(fghi, 0b0100);
-  const __m256d cfi_ = _mm256_blend_pd(cdg_, _fi_, 0b0110);
-  const __m256d _xyz = _mm256_loadu_pd(X_BA + 8);
-  const __m256d IXYZ = _mm256_loadu_pd(X_BC + 8);  // (_XYZ is a reserved word.)
-  const __m256d subtract_XYZ_xyz = IXYZ - _xyz;
-  const double A = X_BC[0];
-  const double B = X_BC[1];
-  const double C = X_BC[2];
-  const double D = X_BC[3];
-  const double E = X_BC[4];
-  const double F = X_BC[5];
-  const double G = X_BC[6];
-  const double H = X_BC[7];
-  const double I = X_BC[8];
+  // Load the columns of R_AB (rows of the given R_BA).
+  auto adg_ = hn::Undefined(tag);
+  auto beh_ = hn::Undefined(tag);
+  auto cfi_ = hn::Undefined(tag);
+  LoadMatrix3Inv(X_BA, &adg_, &beh_, &cfi_);
 
-  const double subXx = subtract_XYZ_xyz[1];
-  const double subYy = subtract_XYZ_xyz[2];
-  const double subZz = subtract_XYZ_xyz[3];
-  // Column stu:                                         s       t       u     =
-  __m256d stu_ = _mm256_mul_pd(adg_, four(subXx));  //  a(X-x)  d(X-x)  g(X-x)
-  stu_ = _mm256_fmadd_pd(beh_, four(subYy), stu_);  // +b(Y-y) +e(Y-y) +h(Y-y)
-  stu_ = _mm256_fmadd_pd(cfi_, four(subZz), stu_);  // +c(Z-z) +f(Z-z) +i(Z-z)
+  // Load both translations.
+  const auto _xyz = hn::LoadU(tag, X_BA + 8);
+  const auto IXYZ = hn::LoadU(tag, X_BC + 8);  // (_XYZ is a reserved word.)
+  const auto subtract_XYZ_xyz = IXYZ - _xyz;
+  const auto subXx = hn::BroadcastLane<1>(subtract_XYZ_xyz);
+  const auto subYy = hn::BroadcastLane<2>(subtract_XYZ_xyz);
+  const auto subZz = hn::BroadcastLane<3>(subtract_XYZ_xyz);
 
-  // Column jkl:                                    j   k   l   _  =
-  __m256d jkl_ = _mm256_mul_pd(adg_, four(A));  //  aA  dA  gA  _
-  jkl_ = _mm256_fmadd_pd(beh_, four(B), jkl_);  // +bB +eB +hB  _
-  jkl_ = _mm256_fmadd_pd(cfi_, four(C), jkl_);  // +cC +fC +iC  _
+  const auto AAA_ = hn::Set(tag, X_BC[0]);
+  const auto BBB_ = hn::Set(tag, X_BC[1]);
+  const auto CCC_ = hn::Set(tag, X_BC[2]);
+  const auto DDD_ = hn::Set(tag, X_BC[3]);
+  const auto EEE_ = hn::Set(tag, X_BC[4]);
+  const auto FFF_ = hn::Set(tag, X_BC[5]);
+  const auto GGG_ = hn::Set(tag, X_BC[6]);
+  const auto HHH_ = hn::Set(tag, X_BC[7]);
+  const auto III_ = hn::Set(tag, X_BC[8]);
 
-  // Column mno:                                    m   n   o  _  =
-  __m256d mno_ = _mm256_mul_pd(adg_, four(D));  //  aD  dD  gD _
-  mno_ = _mm256_fmadd_pd(beh_, four(E), mno_);  // +bE +eE +hE _
-  mno_ = _mm256_fmadd_pd(cfi_, four(F), mno_);  // +cF +fF +iF _
+  // Column stu:                             s       t       u     =
+  auto stu_ = hn::Mul(adg_, subXx);      //  a(X-x)  d(X-x)  g(X-x)
+  stu_ = hn::MulAdd(beh_, subYy, stu_);  // +b(Y-y) +e(Y-y) +h(Y-y)
+  stu_ = hn::MulAdd(cfi_, subZz, stu_);  // +c(Z-z) +f(Z-z) +i(Z-z)
 
-  // Column pqr:                                    p   q   r   _  =
-  __m256d pqr_ = _mm256_mul_pd(adg_, four(G));  //  aG  dG  gG  _
-  pqr_ = _mm256_fmadd_pd(beh_, four(H), pqr_);  // +bH +eH +hH  _
-  pqr_ = _mm256_fmadd_pd(cfi_, four(I), pqr_);  // +cI +fI +iI  _
+  // Column jkl:                            j   k   l   _  =
+  auto jkl_ = hn::Mul(adg_, AAA_);      //  aA  dA  gA  _
+  jkl_ = hn::MulAdd(beh_, BBB_, jkl_);  // +bB +eB +hB  _
+  jkl_ = hn::MulAdd(cfi_, CCC_, jkl_);  // +cC +fC +iC  _
+
+  // Column mno:                            m   n   o   _  =
+  auto mno_ = hn::Mul(adg_, DDD_);      //  aD  dD  gD  _
+  mno_ = hn::MulAdd(beh_, EEE_, mno_);  // +bE +eE +hE  _
+  mno_ = hn::MulAdd(cfi_, FFF_, mno_);  // +cF +fF +iF  _
+
+  // Column pqr:                            p   q   r   _  =
+  auto pqr_ = hn::Mul(adg_, GGG_);      //  aG  dG  gG  _
+  pqr_ = hn::MulAdd(beh_, HHH_, pqr_);  // +bH +eH +hH  _
+  pqr_ = hn::MulAdd(cfi_, III_, pqr_);  // +cI +fI +iI  _
 
   // Store the result.
-  _mm256_storeu_pd(X_AC, jkl_);      // 4-wide write temporarily overwrites m
-  _mm256_storeu_pd(X_AC + 3, mno_);  // 4-wide write temporarily overwrites p
-  _mm256_storeu_pd(X_AC + 6, pqr_);  // 4-wide write temporarily overwrites s
-  _mm256_maskstore_pd(X_AC + 9, mask, stu_);  // 3-wide write to stay in bounds
-
-  // The compiler will generate a vzeroupper instruction if needed.
+  hn::StoreU(jkl_, tag, X_AC);         // 4-wide write temporarily overwrites m
+  hn::StoreU(mno_, tag, X_AC + 3);     // 4-wide write temporarily overwrites p
+  hn::StoreU(pqr_, tag, X_AC + 6);     // 4-wide write temporarily overwrites s
+  hn::StoreN(stu_, tag, X_AC + 9, 3);  // 3-wide write to stay in bounds
 }
 
 }  // namespace

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -120,6 +120,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "abseil_cpp_internal",
     "conex_internal",
     "gflags",
+    "highway_internal",
     "libjpeg_turbo_internal",
 ]] + select({
     "//conditions:default": ["@csdp_internal//:install"],

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -35,6 +35,7 @@ load("//tools/workspace/gurobi:repository.bzl", "gurobi_repository")
 load("//tools/workspace/gymnasium_py:repository.bzl", "gymnasium_py_repository")  # noqa
 load("//tools/workspace/gz_math_internal:repository.bzl", "gz_math_internal_repository")  # noqa
 load("//tools/workspace/gz_utils_internal:repository.bzl", "gz_utils_internal_repository")  # noqa
+load("//tools/workspace/highway_internal:repository.bzl", "highway_internal_repository")  # noqa
 load("//tools/workspace/ipopt:repository.bzl", "ipopt_repository")
 load("//tools/workspace/ipopt_internal_fromsource:repository.bzl", "ipopt_internal_fromsource_repository")  # noqa
 load("//tools/workspace/ipopt_internal_pkgconfig:repository.bzl", "ipopt_internal_pkgconfig_repository")  # noqa
@@ -186,6 +187,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         gz_utils_internal_repository(name = "gz_utils_internal", mirrors = mirrors)  # noqa
     if "gymnasium_py" not in excludes:
         gymnasium_py_repository(name = "gymnasium_py", mirrors = mirrors)
+    if "highway_internal" not in excludes:
+        highway_internal_repository(name = "highway_internal", mirrors = mirrors)  # noqa
     if "ipopt" not in excludes:
         ipopt_repository(name = "ipopt")
     if "ipopt_internal_fromsource" not in excludes:

--- a/tools/workspace/highway_internal/BUILD.bazel
+++ b/tools/workspace/highway_internal/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//tools/install:install.bzl", "install_files")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+install_files(
+    name = "install",
+    dest = "share/doc/highway_internal",
+    files = [
+        "@highway_internal//:LICENSE",
+    ],
+    allowed_externals = [
+        "@highway_internal//:LICENSE",
+    ],
+    visibility = ["//tools/workspace:__pkg__"],
+)
+
+add_lint_tests()

--- a/tools/workspace/highway_internal/patches/linkstatic.patch
+++ b/tools/workspace/highway_internal/patches/linkstatic.patch
@@ -1,0 +1,17 @@
+[highway_internal] Link hidden and static
+
+In general, setting -fvisibility on C++ source code is problematic, but hwy
+upstream has been specifically engineered to allow it.
+
+This situation is unique to Drake, so we do not plan to upstream this
+patch.
+
+--- BUILD
++++ BUILD
+@@ -174,4 +174,5 @@
+     compatible_with = [],
+-    copts = COPTS,
++    copts = COPTS + ["-fvisibility=hidden"],
+     defines = DEFINES,
++    linkstatic = True,
+     local_defines = ["hwy_EXPORTS"],

--- a/tools/workspace/highway_internal/repository.bzl
+++ b/tools/workspace/highway_internal/repository.bzl
@@ -1,0 +1,15 @@
+load("//tools/workspace:github.bzl", "github_archive")
+
+def highway_internal_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "google/highway",
+        commit = "1.2.0",
+        sha256 = "7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343",  # noqa
+        patches = [
+            ":patches/linkstatic.patch",
+        ],
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
Related to #21526.

The proposition here is that the code more readable with this spelling, compared to the raw intrinsics.  See https://google.github.io/highway/en/master/quick_reference.html#operations for the list of functions / grammar.

Down the road, highway also offers macros to handle the runtime-cpu-dispatch automatically.  Not only would that let us get rid of our own dispatcher code here, but also highway's dispatcher is more advanced -- we could add support for a AVX512VL implementation without rewriting the code.  (LLVM MCA suggests that the AVX512VL spelling is ~20% faster than AVX2.)  There's also a possibility that we could turn on macOS SIMD as well, by only changing the configuration of the cpu dispatcher, with no changes to the bodies of these functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21571)
<!-- Reviewable:end -->
