### PR TITLE
geometry::Mesh support for in-memory via data: URLs

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -400,6 +400,7 @@ drake_cc_library(
     deps = [
         "//common:nice_type_name",
         "//common:overloaded",
+        "//common:string_container",
         "//geometry/proximity:make_convex_hull_mesh_impl",
         "//geometry/proximity:meshing_utilities",
         "//geometry/proximity:obj_to_surface_mesh",

--- a/geometry/proximity/make_convex_hull_mesh_impl.cc
+++ b/geometry/proximity/make_convex_hull_mesh_impl.cc
@@ -117,7 +117,8 @@ struct VertexCloud {
 void ReadObjVertices(const fs::path filename, double scale,
                      std::vector<Vector3d>* vertices) {
   const auto [tinyobj_vertices, _1, _2] = geometry::internal::ReadObjFile(
-      std::string(filename), scale, /* triangulate = */ false);
+      std::string(filename), scale, /* triangulate = */ false,
+      /* only_vertices = */ true);
   *vertices = std::move(*tinyobj_vertices);
 }
 

--- a/geometry/proximity/make_convex_hull_mesh_impl.cc
+++ b/geometry/proximity/make_convex_hull_mesh_impl.cc
@@ -1,7 +1,9 @@
 #include "drake/geometry/proximity/make_convex_hull_mesh_impl.h"
 
 #include <algorithm>
+#include <fstream>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -112,12 +114,13 @@ struct VertexCloud {
   Vector3d interior_point;
 };
 
-/* Returns the scaled vertices from the named obj file.
- @pre `filename` references an obj file. */
-void ReadObjVertices(const fs::path filename, double scale,
-                     std::vector<Vector3d>* vertices) {
-  const auto [tinyobj_vertices, _1, _2] = geometry::internal::ReadObjFile(
-      std::string(filename), scale, /* triangulate = */ false,
+/* Returns the scaled vertices from the stream containing obj file data.
+ @pre `data_stream` contains obj geometry data. */
+void ReadObjVertices(std::istream* data_stream, double scale,
+                     std::vector<Vector3d>* vertices,
+                     std::string_view description) {
+  const auto [tinyobj_vertices, _1, _2] = geometry::internal::ReadObjStream(
+      data_stream, scale, /* triangulate = */ false, description,
       /* only_vertices = */ true);
   *vertices = std::move(*tinyobj_vertices);
 }
@@ -188,7 +191,7 @@ void ReadGltfVertices(const fs::path filename, double scale,
  @throws if the vertices span a severely degenerate space in R3 (e.g.,
          co-linear or coincident). */
 Vector3d FindNormal(const std::vector<Vector3d>& vertices,
-                    const fs::path filename) {
+                    const std::string_view description) {
   // Note: this isn't an exhaustive search. We assign i = 0 and then
   // sequentially search for j and k. This may fail but possibly succeed for
   // a different value of i. That risk seems small. Any mesh that depends on
@@ -206,9 +209,8 @@ Vector3d FindNormal(const std::vector<Vector3d>& vertices,
   if (v == ssize(vertices)) {
     throw std::runtime_error(
         fmt::format("MakeConvexHull failed because all vertices in the mesh "
-                    "were within a "
-                    "sphere with radius 1e-12 for file: {}.",
-                    filename.string()));
+                    "were within a sphere with radius 1e-12 for geometry: {}.",
+                    description));
   }
   a.normalize();
 
@@ -226,43 +228,38 @@ Vector3d FindNormal(const std::vector<Vector3d>& vertices,
     throw std::runtime_error(fmt::format(
         "MakeConvexHull failed because all vertices in the mesh appear to be "
         "co-linear for file: {}.",
-        filename.string()));
+        description));
   }
   return n_candidate.normalized();
 }
 
-/* Simply reads the vertices from an OBJ, VTK or glTF file referred to by name.
- */
-VertexCloud ReadVertices(const fs::path filename, double scale) {
-  std::string extension = filename.extension();
-  std::transform(extension.begin(), extension.end(), extension.begin(),
-                 [](unsigned char c) {
-                   return std::tolower(c);
-                 });
-
+VertexCloud ReadVertices(std::istream* data_stream, std::string_view extension,
+                         double scale, std::string_view description) {
   VertexCloud cloud;
   if (extension == ".obj") {
-    ReadObjVertices(filename, scale, &cloud.vertices);
+    ReadObjVertices(data_stream, scale, &cloud.vertices, description);
   } else if (extension == ".vtk") {
-    ReadVtkVertices(filename, scale, &cloud.vertices);
+    DRAKE_UNREACHABLE();
+    // ReadVtkVertices(data_stream, scale, &cloud.vertices, description);
   } else if (extension == ".gltf") {
-    ReadGltfVertices(filename, scale, &cloud.vertices);
+    DRAKE_UNREACHABLE();
+    // ReadGltfVertices(data_stream, scale, &cloud.vertices, description);
   } else {
     throw std::runtime_error(
         fmt::format("MakeConvexHull only applies to obj, vtk, and gltf "
-                    "meshes; given file: {}.",
-                    filename.string()));
+                    "meshes; given geometry data: {}.",
+                    description));
   }
 
   if (cloud.vertices.size() < 3) {
-    throw std::runtime_error(
-        fmt::format("MakeConvexHull() cannot be used on a mesh with fewer "
-                    "than three vertices; found {} vertices in file: {}.",
-                    cloud.vertices.size(), filename.string()));
+    throw std::runtime_error(fmt::format(
+        "MakeConvexHull() cannot be used on a mesh with fewer "
+        "than three vertices; found {} vertices in geometry data: {}.",
+        cloud.vertices.size(), description));
   }
 
   /* Characterizes planarity. */
-  cloud.n = FindNormal(cloud.vertices, filename);
+  cloud.n = FindNormal(cloud.vertices, description);
   double d = cloud.n.dot(cloud.vertices[0]);
   cloud.interior_point = cloud.vertices[0];
   /* Assume planarity and look for evidence to the contrary. */
@@ -284,11 +281,73 @@ VertexCloud ReadVertices(const fs::path filename, double scale) {
   return cloud;
 }
 
-}  // namespace
+// TODO(SeanCurtis-TRI): Once we have support for reading all mesh types from
+// a stream, remove this function and replace its single invocation with opening
+// the file into a std::ifstream which gets passed to the *other*
+// ReadVertices().
+/* Simply reads the vertices from an OBJ, VTK or glTF file referred to by name.
+ */
+VertexCloud ReadVertices(const fs::path filename, double scale) {
+  std::string extension = filename.extension();
+  std::transform(extension.begin(), extension.end(), extension.begin(),
+                 [](unsigned char c) {
+                   return std::tolower(c);
+                 });
 
-PolygonSurfaceMesh<double> MakeConvexHull(const std::filesystem::path mesh_file,
-                                          double scale) {
-  VertexCloud cloud = ReadVertices(mesh_file, scale);
+  VertexCloud cloud;
+  if (extension == ".obj") {
+    std::ifstream f(filename);
+    if (!f.good()) {
+      throw std::runtime_error(fmt::format(
+          "MakeConvexHull can't create convex hull from geometry file; file "
+          "isn't accessible. '{}'.",
+          filename.string()));
+    }
+    ReadObjVertices(&f, scale, &cloud.vertices, filename.string());
+  } else if (extension == ".vtk") {
+    ReadVtkVertices(filename, scale, &cloud.vertices);
+  } else if (extension == ".gltf") {
+    ReadGltfVertices(filename, scale, &cloud.vertices);
+  } else {
+    throw std::runtime_error(
+        fmt::format("MakeConvexHull only applies to obj, vtk, and gltf "
+                    "meshes; given file: {}.",
+                    filename.string()));
+  }
+
+  if (cloud.vertices.size() < 3) {
+    throw std::runtime_error(
+        fmt::format("MakeConvexHull() cannot be used on a mesh with fewer "
+                    "than three vertices; found {} vertices in file: {}.",
+                    cloud.vertices.size(), filename.string()));
+  }
+
+  /* Characterizes planarity. */
+  cloud.n = FindNormal(cloud.vertices, filename.string());
+  double d = cloud.n.dot(cloud.vertices[0]);
+  cloud.interior_point = cloud.vertices[0];
+  /* Assume planarity and look for evidence to the contrary. */
+  cloud.is_planar = true;
+  for (int vi = 1; vi < ssize(cloud.vertices); ++vi) {
+    const Vector3d& v = cloud.vertices[vi];
+    cloud.interior_point += v;
+    const double dist = std::abs(cloud.n.dot(v) - d);
+    if (dist > 1e-12) {
+      cloud.is_planar = false;
+      break;
+    }
+  }
+
+  if (cloud.is_planar) {
+    /* We define the interior point as simply the mean point. */
+    cloud.interior_point /= ssize(cloud.vertices);
+  }
+  return cloud;
+}
+
+PolygonSurfaceMesh<double> MakeConvexHull(VertexCloud* cloud_ptr) {
+  DRAKE_DEMAND(cloud_ptr != nullptr);
+  VertexCloud& cloud = *cloud_ptr;
 
   // The default mapping from qhull to convex hull mesh is simply a copy.
   std::function<Vector3d(double, double, double)> map_hull_vertex =
@@ -368,6 +427,54 @@ PolygonSurfaceMesh<double> MakeConvexHull(const std::filesystem::path mesh_file,
                      ordered_vertices.end());
   }
   return PolygonSurfaceMesh(std::move(face_data), std::move(vertices_M));
+}
+
+}  // namespace
+
+PolygonSurfaceMesh<double> MakeConvexHullFromUrl(std::string_view geometry_url,
+                                                 double scale) {
+  if (geometry_url.starts_with("file://")) {
+    return MakeConvexHull(geometry_url.substr(7), scale);
+  } else if (geometry_url.starts_with("data:model/")) {
+    // TODO(SeanCurtis-TRI): We need common/url.h so we can encode a URL with
+    // various common methods like getting the protocol, etc.
+
+    // data:model/{},[data ASCII].
+    auto pos = geometry_url.find(',', 11);
+    if (pos == std::string::npos) {
+      throw std::runtime_error(fmt::format(
+          "Can't compute convex hull for badly formatted data URL: '{}'.",
+          geometry_url));
+    }
+    DRAKE_DEMAND(pos != std::string::npos);
+    const std::string_view mime_type(&geometry_url[11], pos - 11);
+    if (mime_type == "obj") {
+      std::istringstream ss(std::string(geometry_url.substr(pos)));
+      VertexCloud cloud = ReadVertices(&ss, ".obj", scale, "[in-memory OBJ]");
+      return MakeConvexHull(&cloud);
+    } else if (mime_type == "gltf+json") {
+      throw std::runtime_error(
+          "Unimplemented: computation of convex hull for glTF from a data "
+          "URL.");
+    } else if (mime_type == "vtk") {
+      throw std::runtime_error(
+          "Unimplemented: computation of convex hull for volume .vtk from a "
+          "data URL.");
+    } else {
+      throw std::runtime_error(fmt::format(
+          "Can't compute convex hull for unrecognized model mime type: '{}'.",
+          mime_type));
+    }
+  }
+  throw std::runtime_error(
+      fmt::format("Can't compute convex hull for unsupported url: '{}...'.",
+                  geometry_url.substr(15)));
+}
+
+PolygonSurfaceMesh<double> MakeConvexHull(const std::filesystem::path mesh_file,
+                                          double scale) {
+  VertexCloud cloud = ReadVertices(mesh_file, scale);
+  return MakeConvexHull(&cloud);
 }
 
 }  // namespace internal

--- a/geometry/proximity/make_convex_hull_mesh_impl.h
+++ b/geometry/proximity/make_convex_hull_mesh_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <string>
 
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
 
@@ -8,19 +9,40 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-/* Creates a polygonal mesh representing the convex hull of the vertices
- contained in the named `mesh_file` (scaled with the given `scale` value).
+/* @group Convex Hull for Meshes
 
- @param mesh_file   A path to a valid mesh file to bound.
- @param scale       All vertices will be multiplied by this value prior to
-                    computation.
+ These functions create a convex hull (represented by a PolygonSurfaceMesh) for
+ mesh data. The functions differ in where the mesh data comes from. Otherwise,
+ their parameters and semantics (documented here) are the same.
 
- @throws if `mesh_file` references anything but an .obj, .vtk volume mesh, or
-         .gltf.
- @throws if the referenced mesh data is degenerate (insufficient number of
-            vertices, co-linear or coincident vertices, etc.) All of the
-            vertices lying on a plane is *not* degenerate.
- @throws if there is an unforeseen error in computing the convex hull. */
+ The convex hull is build upon *all* of the vertex values in the mesh data
+ (regardless of how the mesh is organized or even if it includes vertices that
+ are not otherwise incorporated in faces).
+
+ The vertex positions can be scaled uniformly around the origin of the mesh
+ data's canonical frame.
+
+ These functions throw an exception if:
+   - the mesh data comes from an unsupported format,
+   - the mesh data is ill formed,
+   - the referenced mesh data is degenerate (insufficient number of vertices,
+     co-linear or coincident vertices, etc.) All of the vertices lying on a
+     plane is *not* degenerate, or
+   - there is an unforeseen error in computing the convex hull. */
+//@{
+
+/* The mesh data is specified by a URL. Supports a file:// URL for all supported
+ mesh types and a data: URL only for OBJ files (i.e., the prefix must be
+ "data:model/obj," and the subsequent data stream should be the ASCII contents
+ of an obj file). (Future versions will provide support for other supported
+ file types.) */
+PolygonSurfaceMesh<double> MakeConvexHullFromUrl(std::string_view geometry_url,
+                                                 double scale);
+
+// TODO(SeanCurtis-TRI): Consider nuking this in favor of the URL flavor.
+/* The mesh data is specified by a path to an on-disk file of supported type.
+ Equivalent to calling MakeConvexHullFromUrl() with the path encoded in a file
+ URL. */
 PolygonSurfaceMesh<double> MakeConvexHull(const std::filesystem::path mesh_file,
                                           double scale);
 

--- a/geometry/read_obj.cc
+++ b/geometry/read_obj.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/read_obj.h"
 
+#include <fstream>
+
 #include <fmt/format.h>
 #include <tiny_obj_loader.h>
 
@@ -47,6 +49,10 @@ std::vector<Eigen::Vector3d> TinyObjToFclVertices(
 
   return vertices;
 }
+
+// TODO(SeanCurtis-TRI) The limitation on an obj with a single object is not a
+// good limitation for this code. It is arbitrary and makes this code less
+// useful. Remove the limitation.
 
 //
 // Returns the `mesh`'s faces re-encoded in a format consistent with what
@@ -96,44 +102,47 @@ std::vector<int> TinyObjToFclFaces(const tinyobj::mesh_t& mesh) {
 
 std::tuple<std::shared_ptr<std::vector<Eigen::Vector3d>>,
            std::shared_ptr<std::vector<int>>, int>
-ReadObjFile(const std::string& filename, double scale, bool triangulate) {
+ReadObjStream(std::istream* data_stream, double scale, bool triangulate,
+              std::string_view description, bool vertices_only) {
   tinyobj::attrib_t attrib;
   std::vector<tinyobj::shape_t> shapes;
   std::vector<tinyobj::material_t> materials;
   std::string warn;
   std::string err;
 
-  // Tinyobj doesn't infer the search directory from the directory containing
-  // the obj file. We have to provide that directory; of course, this assumes
-  // that the material library reference is relative to the obj directory.
-  const size_t pos = filename.find_last_of('/');
-  const std::string obj_folder = filename.substr(0, pos + 1);
-  const char* mtl_basedir = obj_folder.c_str();
+  // We're not reading materials.
+  tinyobj::MaterialReader* null_reader = nullptr;
 
   bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err,
-                              filename.c_str(), mtl_basedir, triangulate);
+                              data_stream, null_reader, triangulate);
   if (!ret || !err.empty()) {
-    throw std::runtime_error("Error parsing file '" + filename + "' : " + err);
+    throw std::runtime_error(
+        fmt::format("Error parsing OBJ '{}': {}", description, err));
   }
   if (!warn.empty()) {
-    drake::log()->warn("Warning parsing file '{}' : {}", filename, warn);
-  }
-
-  if (shapes.size() == 0) {
-    throw std::runtime_error(
-        fmt::format("The file parsed contains no objects; only OBJs with "
-                    "a single object are supported. The file could be "
-                    "corrupt, empty, or not an OBJ file. File name: '{}'",
-                    filename));
-  } else if (shapes.size() > 1) {
-    throw std::runtime_error(
-        fmt::format("The OBJ file contains multiple objects; only OBJs with "
-                    "a single object are supported: File name: '{}'",
-                    filename));
+    drake::log()->warn("Warning while parsing OBJ '{}' : {}", description,
+                       warn);
   }
 
   auto vertices = std::make_shared<std::vector<Eigen::Vector3d>>(
       TinyObjToFclVertices(attrib, scale));
+
+  if (vertices_only) {
+    return {vertices, std::make_shared<std::vector<int>>(), 0};
+  }
+
+  if (shapes.size() == 0) {
+    throw std::runtime_error(
+        fmt::format("The OBJ data parsed contains no objects; only OBJs with "
+                    "a single object are supported. The file could be "
+                    "corrupt, empty, or not an OBJ file. File name: '{}'",
+                    description));
+  } else if (shapes.size() > 1) {
+    throw std::runtime_error(
+        fmt::format("The OBJ file contains multiple objects; only OBJs with "
+                    "a single object are supported: File name: '{}'",
+                    description));
+  }
 
   // We will have `faces.size()` larger than the number of faces. For each
   // face_i, the vector `faces` contains both the number and indices of its
@@ -149,6 +158,16 @@ ReadObjFile(const std::string& filename, double scale, bool triangulate) {
       std::make_shared<std::vector<int>>(TinyObjToFclFaces(shapes[0].mesh));
   return {vertices, faces, num_faces};
 }
+
+std::tuple<std::shared_ptr<std::vector<Eigen::Vector3d>>,
+           std::shared_ptr<std::vector<int>>, int>
+ReadObjFile(const std::string& filename, double scale, bool triangulate,
+            bool vertices_only) {
+  std::ifstream f(filename);
+  DRAKE_DEMAND(f.good());
+  return ReadObjStream(&f, scale, triangulate, filename, vertices_only);
+}
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/read_obj.h
+++ b/geometry/read_obj.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <istream>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -10,31 +11,67 @@
 namespace drake {
 namespace geometry {
 namespace internal {
-/** Reads the OBJ file with the given `filename` into a collection of data. It
- * includes the vertex positions, face encodings (see TinyObjToFclFaces), and
- * number of faces.
- * @param filename The name of the obj file.
- * @param scale Scale to coordinates.
- * @param triangulate Whether triangulate polygon face in .obj or not. Refer to
- * LoadObj function in
- * https://github.com/tinyobjloader/tinyobjloader/blob/master/tiny_obj_loader.h
- * for more details.
- * @return (vertices, faces, num_faces) vertices[i] is the i'th vertex in the
- * mesh. faces is interpreted as
- *
- * faces = { n0, v0_0,v0_1,...,v0_n0-1,
- *           n1, v1_0,v1_1,...,v1_n1-1,
- *           n2, v2_0,v2_1,...,v2_n2-1,
- *           ...}
- *
- * where n_i is the number of vertices of face_i, vi_j is the index in
- * `vertices` for a vertex on face i. Note that the size of faces is larger than
- * num_faces.
- *
- */
+
+/* Reads the OBJ file data from the given `data_stream` into a collection of
+ data. It includes the vertex positions, face encodings (see TinyObjToFclFaces()
+ in the .cc file), and number of faces.
+
+ @param data_stream    The stream containing the obj file data.
+ @param scale          Scale to coordinates.
+ @param triangulate    Whether triangulate polygon face in .obj or not. Refer to
+                       LoadObj function in
+ https://github.com/tinyobjloader/tinyobjloader/blob/master/tiny_obj_loader.h
+                       for more details.
+ @param description    A label associated with the OBJ file data to be used in
+                       error messages. Could be, for example, the file name from
+                       which the stream comes.
+ @param vertices_only  If true, only the vertex data will be populated; faces
+                       and num_faces will be "empty".
+ @return (vertices, faces, num_faces) vertices[i] is the i'th vertex in the
+ mesh. faces is interpreted as
+
+ faces = { n0, v0_0,v0_1,...,v0_n0-1,
+           n1, v1_0,v1_1,...,v1_n1-1,
+           n2, v2_0,v2_1,...,v2_n2-1,
+           ...}
+
+ where n_i is the number of vertices of face_i, vi_j is the index in
+ `vertices` for a vertex on face i. Note that the size of faces is larger than
+ num_faces. */
 std::tuple<std::shared_ptr<std::vector<Eigen::Vector3d>>,
            std::shared_ptr<std::vector<int>>, int>
-ReadObjFile(const std::string& filename, double scale, bool triangulate);
+ReadObjStream(std::istream* data_stream, double scale, bool triangulate,
+              std::string_view description, bool vertices_only = false);
+
+// TODO(SeanCurtis-TRI): This isn't called any more. Possibly simply remove it
+// or replace both with a single instance that simply takes a URL.
+/* Reads the OBJ file with the given `filename` into a collection of data. It
+ includes the vertex positions, face encodings (see TinyObjToFclFaces), and
+ number of faces.
+
+ @param filename       The name of the obj file.
+ @param scale          Scale to coordinates.
+ @param triangulate    Whether triangulate polygon face in .obj or not. Refer to
+                       LoadObj function in
+ https://github.com/tinyobjloader/tinyobjloader/blob/master/tiny_obj_loader.h
+                       for more details.
+ @param vertices_only  If true, only the vertex data will be populated; faces
+                       and num_faces will be "empty".
+ @return (vertices, faces, num_faces) vertices[i] is the i'th vertex in the
+ mesh. faces is interpreted as
+
+ faces = { n0, v0_0,v0_1,...,v0_n0-1,
+           n1, v1_0,v1_1,...,v1_n1-1,
+           n2, v2_0,v2_1,...,v2_n2-1,
+           ...}
+
+ where n_i is the number of vertices of face_i, vi_j is the index in
+ `vertices` for a vertex on face i. Note that the size of faces is larger than
+ num_faces. */
+std::tuple<std::shared_ptr<std::vector<Eigen::Vector3d>>,
+           std::shared_ptr<std::vector<int>>, int>
+ReadObjFile(const std::string& filename, double scale, bool triangulate,
+            bool vertices_only = false);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -461,10 +461,41 @@ class Mesh final : public Shape {
                                 considering revisiting the model itself. */
   explicit Mesh(const std::string& filename, double scale = 1.0);
 
+  /** Constructs a mesh shape specification from the mesh data provided
+   (interpreted as specified by `data_format`). Optionally uniformly scaled by
+   the given `scale` factor.
+
+   The data must be the file contents of a ".obj" (Wavefront OBJ) file. The
+   other @ref geometry_file_formats "generally-supported file formats" cannot
+   be used this way, yet. The `data_format` string must be the
+   dot-prefixed extension normally associated with the data format (e.g.,
+   ".obj" for Wavefront Obj and, when finally supported, ".gltf" for glTF files,
+   etc.).
+
+   @note If `data` references external files, those files will be ignored. If
+   those files are necessary to successfully use the data, an exception will
+   be thrown.
+   <!-- TODO(SeanCurtis-TRI): Allow specification of a directory for resolving
+    those paths? -->
+
+   @param data_format  A declaration of the format of the data (encoded as the
+                       extension normally used for the file format). Format must
+                       be exact: prefixed "." and all lower case.
+   @param data         The ASCII contents of the mesh file format.
+   @param scale        An optional scale to the mesh geometry. */
+  Mesh(std::string_view data_format, std::string data, double scale = 1.0);
+
   ~Mesh() final;
 
-  const std::string& filename() const { return filename_; }
-  /** Returns the extension of the mesh filename -- all lower case and including
+  /* If constructed with the file path constructor, returns the filename;
+   otherwise returns an empty string. */
+  const std::string& filename() const;
+
+  /* If constructed with the geometry data constructor, returns the data;
+   otherwise returns an empty string. */
+  const std::string& data() const;
+
+  /** Returns the extension of the mesh data -- all lower case and including
    the dot. In other words /foo/bar/mesh.obj and /foo/bar/mesh.OBJ would both
    report the ".obj" extension. The "extension" portion of the filename is
    defined as in std::filesystem::path::extension(). */
@@ -490,9 +521,10 @@ class Mesh final : public Shape {
   VariantShapeConstPtr get_variant_this() const final;
 
   // NOTE: Cannot be const to support default copy/move semantics.
-  std::string filename_;
+  std::string data_;
   std::string extension_;
   double scale_{};
+  bool is_file_{};
   // Allows the deferred computation of the hull on an otherwise const Mesh.
   mutable std::shared_ptr<PolygonSurfaceMesh<double>> hull_{nullptr};
 };

--- a/geometry/test/read_obj_test.cc
+++ b/geometry/test/read_obj_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace drake {
 namespace geometry {
@@ -29,72 +30,101 @@ void CheckVertices(
 }
 
 GTEST_TEST(ReadObjFile, QuadCube) {
-  // TODO(hongkai.dai): add the test with triangulate=true.
-  for (const double scale : {1., 0.5, 1.5}) {
-    const auto [vertices, faces, num_faces] =
-        ReadObjFile(FindResourceOrThrow("drake/geometry/test/quad_cube.obj"),
-                    scale, false /*triangulate */);
-    EXPECT_EQ(vertices->size(), 8);
-    EXPECT_EQ(num_faces, 6);
-    Eigen::Matrix<double, 8, 3> vertices_expected;
-    // clang-format off
-    vertices_expected << -1, -1, -1,
-                         -1, -1, 1,
-                         -1, 1, 1,
-                         -1, 1, -1,
-                         1, 1, -1,
-                         1, -1, -1,
-                         1, -1, 1,
-                         1, 1, 1;
-    // clang-format on
-    vertices_expected *= scale;
-    CheckVertices(vertices, vertices_expected.transpose(), 0.);
-    // Each face has 4 vertices, hence the size of faces is num_faces * (1 + 4).
-    // The point on the same face will have one coordinate with the same value.
-    EXPECT_EQ(faces->size(), num_faces * 5);
-    for (int i = 0; i < num_faces; ++i) {
-      bool found_coord = false;
-      for (int coord = 0; coord < 3; ++coord) {
-        bool coord_same_value = true;
-        for (int vert = 2; vert <= 4; ++vert) {
-          if ((*vertices)[(*faces)[5 * i + vert]](coord) !=
-              (*vertices)[(*faces)[5 * i + 1]](coord)) {
-            coord_same_value = false;
+  // For quads, we expect to see a difference in face counts (and composition).
+  for (const bool triangulate : {true, false}) {
+    for (const double scale : {1., 0.5, 1.5}) {
+      const auto [vertices, faces, num_faces] =
+          ReadObjFile(FindResourceOrThrow("drake/geometry/test/quad_cube.obj"),
+                      scale, triangulate);
+      EXPECT_EQ(vertices->size(), 8);
+      Eigen::Matrix<double, 8, 3> vertices_expected;
+      // clang-format off
+      vertices_expected << -1, -1, -1,
+                          -1, -1, 1,
+                          -1, 1, 1,
+                          -1, 1, -1,
+                          1, 1, -1,
+                          1, -1, -1,
+                          1, -1, 1,
+                          1, 1, 1;
+      // clang-format on
+      vertices_expected *= scale;
+      CheckVertices(vertices, vertices_expected.transpose(), 0.);
+
+      // The number and composition of the faces depend on triangulation. Each
+      // face will have the same number of vertices: V. So, the size of the
+      // `faces` data structure will be the expected_face_count * (1 + V).
+      // The faces are all perpendicular to one of the frame's axes, so the
+      // vertices of each face will have one measure all equal.
+      const int expected_face_count = triangulate ? 12 : 6;
+      const int face_vertex_count = triangulate ? 3 : 4;
+      const int face_stride = 1 + face_vertex_count;
+
+      EXPECT_EQ(num_faces, expected_face_count);
+      EXPECT_EQ(faces->size(), num_faces * face_stride);
+      for (int i = 0; i < num_faces; ++i) {
+        bool found_coord = false;
+        for (int coord = 0; coord < 3; ++coord) {
+          bool coord_same_value = true;
+          for (int vert = 2; vert <= face_vertex_count; ++vert) {
+            if ((*vertices)[(*faces)[face_stride * i + vert]](coord) !=
+                (*vertices)[(*faces)[face_stride * i + 1]](coord)) {
+              coord_same_value = false;
+              break;
+            }
+          }
+          if (coord_same_value) {
+            found_coord = true;
             break;
           }
         }
-        if (coord_same_value) {
-          found_coord = true;
-          break;
-        }
+        EXPECT_TRUE(found_coord);
       }
-      EXPECT_TRUE(found_coord);
     }
   }
 }
 
+// A simple test to exercise the streaming-variant of ReadObjFile. We know that
+// the file-variant simply delegates to this API, so this test merely serves
+// as a regression test on the API.
+GTEST_TEST(ReadObjStreamTest, Regression) {
+  std::istringstream ss(R"""(
+    v 0 0 0
+    v 0 1 0
+    v 1 0 0
+    v 1 1 0
+    f 1 2 3 4
+  )""");
+  const auto [vertices, faces, num_faces] =
+      ReadObjStream(&ss, 2.0, true, "test");
+  EXPECT_EQ(vertices->size(), 4);
+  EXPECT_EQ(faces->size(), 8);  // Two encoded triangles, 4 indices per tri.
+}
+
 GTEST_TEST(ReadObjFile, Octahedron) {
-  // TODO(hongkai.dai): add the test with triangulate=true. With triangulation,
-  // the vertices and faces should be the same as triangulate=false.
-  for (const double scale : {1., 0.5, 1.5}) {
-    const auto [vertices, faces, num_faces] =
-        ReadObjFile(FindResourceOrThrow("drake/geometry/test/octahedron.obj"),
-                    scale, false /*triangulate */);
-    EXPECT_EQ(vertices->size(), 6u);
-    Eigen::Matrix<double, 6, 3> vertices_expected;
-    // clang-format off
+  // The octahedron is already triangulated. We expect the same result whether
+  // triangulate is true or false.
+  for (const bool triangulate : {true, false}) {
+    for (const double scale : {1., 0.5, 1.5}) {
+      const auto [vertices, faces, num_faces] =
+          ReadObjFile(FindResourceOrThrow("drake/geometry/test/octahedron.obj"),
+                      scale, triangulate);
+      EXPECT_EQ(vertices->size(), 6u);
+      Eigen::Matrix<double, 6, 3> vertices_expected;
+      // clang-format off
     vertices_expected << 1, -1, 0,
                          1, 1, 0,
                          -1, 1, 0,
                          -1, -1, 0,
                          0, 0, std::sqrt(2),
                          0, 0, -std::sqrt(2);
-    // clang-format on
-    vertices_expected *= scale;
-    CheckVertices(vertices, vertices_expected.transpose(), 1E-5);
-    EXPECT_EQ(num_faces, 8);
-    // Each face has 3 vertices, so faces.size() = num_faces * (1 + 3).
-    EXPECT_EQ(faces->size(), num_faces * 4);
+      // clang-format on
+      vertices_expected *= scale;
+      CheckVertices(vertices, vertices_expected.transpose(), 1E-5);
+      EXPECT_EQ(num_faces, 8);
+      // Each face has 3 vertices, so faces.size() = num_faces * (1 + 3).
+      EXPECT_EQ(faces->size(), num_faces * 4);
+    }
   }
 }
 
@@ -135,6 +165,53 @@ GTEST_TEST(ReadObjFile, NonconvexMesh) {
     }
   }
 }
+
+// When requesting only vertices, we get only vertices. In fact, we can get the
+// vertices from an obj that would ordinarily throw if we asked for the face
+// data (see BadObjectCount, below).
+GTEST_TEST(ReadObjStream, VertexOnly) {
+  std::istringstream ss(R"""(
+    v 0 0 0
+    v 0 1 0
+    v 1 0 0
+    v 1 1 0
+  )""");
+  const auto [vertices, faces, num_faces] =
+      ReadObjStream(&ss, 2.0, false, "test", /* vertex_only= */ true);
+  EXPECT_EQ(vertices->size(), 4);
+  EXPECT_EQ(faces->size(), 0);
+  EXPECT_EQ(num_faces, 0);
+}
+
+// Test the error conditions in which we have zero or more than one object in
+// the obj file.
+GTEST_TEST(ReadObjStream, BadObjectCount) {
+  {
+    std::istringstream ss(R"""(
+    v 0 0 0
+    v 0 1 0
+    v 1 0 0
+    v 1 1 0
+  )""");
+    DRAKE_EXPECT_THROWS_MESSAGE(ReadObjStream(&ss, 2.0, false, "test"),
+                                ".*no objects.*");
+  }
+  {
+    std::istringstream ss(R"""(
+    v 0 0 0
+    v 0 1 0
+    v 1 0 0
+    v 1 1 0
+    o one
+    f 1 2 3
+    o two
+    f 2 3 4
+  )""");
+    DRAKE_EXPECT_THROWS_MESSAGE(ReadObjStream(&ss, 2.0, false, "test"),
+                                ".*multiple objects.*");
+  }
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
This draft PR introduces a new constructor on `geometry::Mesh`.

It explores the implications of using an in-memory geometry representation in addition to the on-ddisk representation. It follows one dependency tendril down (the ability to create a convex hull from the `Mesh`.