### PR TITLE
[wheel] Pin numpy to 1.x

### DIFF
--- a/setup/mac/binary_distribution/requirements.txt
+++ b/setup/mac/binary_distribution/requirements.txt
@@ -1,6 +1,7 @@
 ipywidgets
 matplotlib
 notebook
+numpy < 2
 Pillow
 pydot
 PyYAML

--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -40,9 +40,12 @@ ln -s /usr/local/bin/python /usr/bin/python
 
 # TODO(jwnimmer-tri): Should these be version-pinned? What's the process for
 # keeping them up to date if they are?
+# TODO(#21577) We are not yet compatible with NumPy 2.0, so we need to upper-
+# bound its version number here. Once we support NumPy 2.0 correctly, we should
+# remove this limit.
 pip install \
     matplotlib \
-    numpy \
+    'numpy < 2' \
     pyyaml \
     semantic-version \
     setuptools \

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -7,9 +7,12 @@ from setuptools import setup, find_packages, glob
 DRAKE_VERSION = os.environ.get('DRAKE_VERSION', '0.0.0')
 
 # Required python packages that will be pip installed along with pydrake
+# TODO(#21577) We are not yet compatible with NumPy 2.0, so we need to upper-
+# bound its version number here. Once we support NumPy 2.0 correctly, we should
+# remove this limit.
 python_required = [
     'matplotlib',
-    'numpy',
+    'numpy < 2',
     'pydot',
     'PyYAML',
 ]


### PR DESCRIPTION
At the moment, pydrake fails during import with NumPy 2 (#21577).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21582)
<!-- Reviewable:end -->
