### PR TITLE
Adds support for sparse A,B,C,D matrices in AffineSystem.

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -466,6 +466,7 @@ drake_py_unittest(
         ":test_util_py",
         "//bindings/pydrake:trajectories_py",
         "//bindings/pydrake/common/test_utilities:numpy_compare_py",
+        "//bindings/pydrake/common/test_utilities:scipy_stub_py",
     ],
 )
 

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -79,10 +79,23 @@ PYBIND11_MODULE(primitives, m) {
                  const Eigen::Ref<const MatrixXd>&,
                  const Eigen::Ref<const MatrixXd>&,
                  const Eigen::Ref<const VectorXd>&, double>(),
-            py::arg("A") = Eigen::MatrixXd(), py::arg("B") = Eigen::MatrixXd(),
+            py::arg("A"), py::arg("B") = Eigen::MatrixXd(),
             py::arg("f0") = Eigen::VectorXd(), py::arg("C") = Eigen::MatrixXd(),
             py::arg("D") = Eigen::MatrixXd(), py::arg("y0") = Eigen::VectorXd(),
-            py::arg("time_period") = 0.0, doc.AffineSystem.ctor.doc_7args)
+            py::arg("time_period") = 0.0, doc.AffineSystem.ctor.doc_dense)
+        .def(py::init<const Eigen::SparseMatrix<double>&,
+                 const Eigen::SparseMatrix<double>&,
+                 const Eigen::Ref<const VectorXd>&,
+                 const Eigen::SparseMatrix<double>&,
+                 const Eigen::SparseMatrix<double>&,
+                 const Eigen::Ref<const VectorXd>&, double>(),
+            py::arg("A") = Eigen::SparseMatrix<double>(),
+            py::arg("B") = Eigen::SparseMatrix<double>(),
+            py::arg("f0") = Eigen::VectorXd(),
+            py::arg("C") = Eigen::SparseMatrix<double>(),
+            py::arg("D") = Eigen::SparseMatrix<double>(),
+            py::arg("y0") = Eigen::VectorXd(), py::arg("time_period") = 0.0,
+            doc.AffineSystem.ctor.doc_sparse)
         // TODO(eric.cousineau): Fix these to return references instead of
         // copies.
         .def("A", overload_cast_explicit<const MatrixXd&>(&AffineSystem<T>::A),
@@ -99,11 +112,42 @@ PYBIND11_MODULE(primitives, m) {
         .def("y0",
             overload_cast_explicit<const VectorXd&>(&AffineSystem<T>::y0),
             doc.AffineSystem.y0.doc)
-        .def("UpdateCoefficients", &AffineSystem<T>::UpdateCoefficients,
-            py::arg("A") = Eigen::MatrixXd(), py::arg("B") = Eigen::MatrixXd(),
+        .def("get_sparse_A", &AffineSystem<T>::get_sparse_A,
+            doc.AffineSystem.get_sparse_A.doc)
+        .def("get_sparse_B", &AffineSystem<T>::get_sparse_B,
+            doc.AffineSystem.get_sparse_B.doc)
+        .def("get_sparse_C", &AffineSystem<T>::get_sparse_C,
+            doc.AffineSystem.get_sparse_C.doc)
+        .def("get_sparse_D", &AffineSystem<T>::get_sparse_D,
+            doc.AffineSystem.get_sparse_D.doc)
+        .def("UpdateCoefficients",
+            overload_cast_explicit<void,
+                const Eigen::Ref<const Eigen::MatrixXd>&,
+                const Eigen::Ref<const Eigen::MatrixXd>&,
+                const Eigen::Ref<const Eigen::VectorXd>&,
+                const Eigen::Ref<const Eigen::MatrixXd>&,
+                const Eigen::Ref<const Eigen::MatrixXd>&,
+                const Eigen::Ref<const Eigen::VectorXd>&>(
+                &AffineSystem<T>::UpdateCoefficients),
+            py::arg("A"), py::arg("B") = Eigen::MatrixXd(),
             py::arg("f0") = Eigen::VectorXd(), py::arg("C") = Eigen::MatrixXd(),
             py::arg("D") = Eigen::MatrixXd(), py::arg("y0") = Eigen::VectorXd(),
-            doc.AffineSystem.UpdateCoefficients.doc)
+            doc.AffineSystem.UpdateCoefficients.doc_dense)
+        .def("UpdateCoefficients",
+            overload_cast_explicit<void, const Eigen::SparseMatrix<double>&,
+                const Eigen::SparseMatrix<double>&,
+                const Eigen::Ref<const Eigen::VectorXd>&,
+                const Eigen::SparseMatrix<double>&,
+                const Eigen::SparseMatrix<double>&,
+                const Eigen::Ref<const Eigen::VectorXd>&>(
+                &AffineSystem<T>::UpdateCoefficients),
+            py::arg("A") = Eigen::SparseMatrix<double>(),
+            py::arg("B") = Eigen::SparseMatrix<double>(),
+            py::arg("f0") = Eigen::VectorXd(),
+            py::arg("C") = Eigen::SparseMatrix<double>(),
+            py::arg("D") = Eigen::SparseMatrix<double>(),
+            py::arg("y0") = Eigen::VectorXd(),
+            doc.AffineSystem.UpdateCoefficients.doc_sparse)
         // Wrap a few methods from the TimeVaryingAffineSystem parent class.
         // TODO(russt): Move to TimeVaryingAffineSystem if/when that class is
         // wrapped.

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -32,6 +32,7 @@ drake_cc_package_library(
         ":matrix_util",
         ":quadratic_form",
         ":soft_min_max",
+        ":sparse_and_dense_matrix",
         ":vector3_util",
         ":wrap_to",
     ],
@@ -285,6 +286,16 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:essential",
     ],
+)
+
+drake_cc_library(
+    name = "sparse_and_dense_matrix",
+    srcs = ["sparse_and_dense_matrix.cc"],
+    hdrs = ["sparse_and_dense_matrix.h"],
+    interface_deps = [
+        "//common:essential",
+    ],
+    deps = [],
 )
 
 drake_cc_library(
@@ -583,6 +594,15 @@ drake_cc_googletest(
         ":soft_min_max",
         "//common/test_utilities:eigen_matrix_compare",
         "@eigen",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sparse_and_dense_matrix_test",
+    tags = ["cpu:4"],
+    deps = [
+        ":sparse_and_dense_matrix",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/math/sparse_and_dense_matrix.cc
+++ b/math/sparse_and_dense_matrix.cc
@@ -1,9 +1,9 @@
-#include "drake/solvers/sparse_and_dense_matrix.h"
+#include "drake/math/sparse_and_dense_matrix.h"
 
 #include <utility>
 
 namespace drake {
-namespace solvers {
+namespace math {
 namespace internal {
 SparseAndDenseMatrix::SparseAndDenseMatrix(
     const Eigen::SparseMatrix<double>& sparse)
@@ -54,5 +54,5 @@ bool SparseAndDenseMatrix::is_dense_constructed() const {
 }
 
 }  // namespace internal
-}  // namespace solvers
+}  // namespace math
 }  // namespace drake

--- a/math/sparse_and_dense_matrix.h
+++ b/math/sparse_and_dense_matrix.h
@@ -8,12 +8,11 @@
 #include "drake/common/drake_copyable.h"
 
 namespace drake {
-namespace solvers {
+namespace math {
 namespace internal {
 /*
- * This class is typically used in cost and constraint class to store a sparse
- * matrix and an optional dense matrix. It also provides setter/getter for the
- * matrix.
+ * This class is used to store a sparse matrix and an optional dense matrix. It
+ * also provides setter/getter for the matrix.
  */
 class SparseAndDenseMatrix {
  public:
@@ -52,5 +51,5 @@ class SparseAndDenseMatrix {
   mutable std::mutex mutex_;
 };
 }  // namespace internal
-}  // namespace solvers
+}  // namespace math
 }  // namespace drake

--- a/math/test/sparse_and_dense_matrix_test.cc
+++ b/math/test/sparse_and_dense_matrix_test.cc
@@ -1,4 +1,4 @@
-#include "drake/solvers/sparse_and_dense_matrix.h"
+#include "drake/math/sparse_and_dense_matrix.h"
 
 #include <limits>
 #include <thread>
@@ -8,7 +8,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
-namespace solvers {
+namespace math {
 namespace internal {
 namespace {
 
@@ -108,5 +108,5 @@ GTEST_TEST(SparseAndDenseMatrix, IsFinite) {
 }
 }  // namespace
 }  // namespace internal
-}  // namespace solvers
+}  // namespace math
 }  // namespace drake

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -79,7 +79,6 @@ drake_cc_package_library(
         ":solver_type",
         ":solver_type_converter",
         ":sos_basis_generator",
-        ":sparse_and_dense_matrix",
         ":unrevised_lemke_solver",
     ],
 )
@@ -184,10 +183,10 @@ drake_cc_library(
     interface_deps = [
         ":decision_variable",
         ":evaluator_base",
-        ":sparse_and_dense_matrix",
         "//common:essential",
         "//common:polynomial",
         "//common/symbolic:expression",
+        "//math:sparse_and_dense_matrix",
     ],
     deps = [
         "//common/symbolic:latex",
@@ -217,7 +216,7 @@ drake_cc_library(
     interface_deps = [
         ":decision_variable",
         ":evaluator_base",
-        ":sparse_and_dense_matrix",
+        "//math:sparse_and_dense_matrix",
     ],
     deps = [
         ":constraint",
@@ -508,16 +507,6 @@ drake_cc_library(
     hdrs = ["program_attribute.h"],
     interface_deps = [
         "//common:hash",
-    ],
-    deps = [],
-)
-
-drake_cc_library(
-    name = "sparse_and_dense_matrix",
-    srcs = ["sparse_and_dense_matrix.cc"],
-    hdrs = ["sparse_and_dense_matrix.h"],
-    interface_deps = [
-        "//common:essential",
     ],
     deps = [],
 )
@@ -2039,15 +2028,6 @@ drake_cc_googletest(
         ":augmented_lagrangian",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:gradient",
-    ],
-)
-
-drake_cc_googletest(
-    name = "sparse_and_dense_matrix_test",
-    tags = ["cpu:4"],
-    deps = [
-        ":sparse_and_dense_matrix",
-        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -19,10 +19,10 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/symbolic/expression.h"
+#include "drake/math/sparse_and_dense_matrix.h"
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/evaluator_base.h"
 #include "drake/solvers/function.h"
-#include "drake/solvers/sparse_and_dense_matrix.h"
 
 namespace drake {
 namespace solvers {
@@ -699,7 +699,7 @@ class LinearConstraint : public Constraint {
 
   std::string DoToLatex(const VectorX<symbolic::Variable>&, int) const override;
 
-  internal::SparseAndDenseMatrix A_;
+  math::internal::SparseAndDenseMatrix A_;
 
  private:
   template <typename DerivedX, typename ScalarY>

--- a/solvers/cost.h
+++ b/solvers/cost.h
@@ -11,9 +11,9 @@
 #include <Eigen/SparseCore>
 
 #include "drake/common/drake_deprecated.h"
+#include "drake/math/sparse_and_dense_matrix.h"
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/evaluator_base.h"
-#include "drake/solvers/sparse_and_dense_matrix.h"
 
 namespace drake {
 namespace solvers {
@@ -363,7 +363,7 @@ class L2NormCost : public Cost {
   std::string DoToLatex(const VectorX<symbolic::Variable>&, int) const override;
 
  private:
-  internal::SparseAndDenseMatrix A_;
+  math::internal::SparseAndDenseMatrix A_;
   Eigen::VectorXd b_;
 };
 

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -62,6 +62,7 @@ drake_cc_library(
     hdrs = ["affine_system.h"],
     interface_deps = [
         "//common/symbolic:expression",
+        "//math:sparse_and_dense_matrix",
         "//systems/framework",
     ],
     deps = [

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -6,6 +6,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic/expression.h"
+#include "drake/math/sparse_and_dense_matrix.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -209,12 +210,24 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
   /// time_period=0.0 to denote a continuous time system.  @default 0.0
   ///
   /// Subclasses must use the protected constructor, not this one.
+  /// @pydrake_mkdoc_identifier{dense}
   explicit AffineSystem(
-      const Eigen::Ref<const Eigen::MatrixXd>& A = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
       const Eigen::Ref<const Eigen::MatrixXd>& B = Eigen::MatrixXd(),
       const Eigen::Ref<const Eigen::VectorXd>& f0 = Eigen::VectorXd(),
       const Eigen::Ref<const Eigen::MatrixXd>& C = Eigen::MatrixXd(),
       const Eigen::Ref<const Eigen::MatrixXd>& D = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::VectorXd>& y0 = Eigen::VectorXd(),
+      double time_period = 0.0);
+
+  /// SparseMatrix version of the constructor.
+  /// @pydrake_mkdoc_identifier{sparse}
+  explicit AffineSystem(
+      const Eigen::SparseMatrix<double>& A = Eigen::SparseMatrix<double>(),
+      const Eigen::SparseMatrix<double>& B = Eigen::SparseMatrix<double>(),
+      const Eigen::Ref<const Eigen::VectorXd>& f0 = Eigen::VectorXd(),
+      const Eigen::SparseMatrix<double>& C = Eigen::SparseMatrix<double>(),
+      const Eigen::SparseMatrix<double>& D = Eigen::SparseMatrix<double>(),
       const Eigen::Ref<const Eigen::VectorXd>& y0 = Eigen::VectorXd(),
       double time_period = 0.0);
 
@@ -236,33 +249,59 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
 
   /// @name Helper getter methods.
   /// @{
-  const Eigen::MatrixXd& A() const { return A_; }
-  const Eigen::MatrixXd& B() const { return B_; }
+  const Eigen::MatrixXd& A() const { return A_.GetAsDense(); }
+  const Eigen::MatrixXd& B() const { return B_.GetAsDense(); }
   const Eigen::VectorXd& f0() const { return f0_; }
-  const Eigen::MatrixXd& C() const { return C_; }
-  const Eigen::MatrixXd& D() const { return D_; }
+  const Eigen::MatrixXd& C() const { return C_.GetAsDense(); }
+  const Eigen::MatrixXd& D() const { return D_.GetAsDense(); }
   const Eigen::VectorXd& y0() const { return y0_; }
+
+  const Eigen::SparseMatrix<double>& get_sparse_A() const {
+    return A_.get_as_sparse();
+  }
+  const Eigen::SparseMatrix<double>& get_sparse_B() const {
+    return B_.get_as_sparse();
+  }
+  const Eigen::SparseMatrix<double>& get_sparse_C() const {
+    return C_.get_as_sparse();
+  }
+  const Eigen::SparseMatrix<double>& get_sparse_D() const {
+    return D_.get_as_sparse();
+  }
   /// @}
 
   /// @name Implementations of TimeVaryingAffineSystem<T>'s pure virtual
   /// methods.
   /// @{
-  MatrixX<T> A(const T&) const final { return MatrixX<T>(A_); }
-  MatrixX<T> B(const T&) const final { return MatrixX<T>(B_); }
+  MatrixX<T> A(const T&) const final { return MatrixX<T>(A_.GetAsDense()); }
+  MatrixX<T> B(const T&) const final { return MatrixX<T>(B_.GetAsDense()); }
   VectorX<T> f0(const T&) const final { return VectorX<T>(f0_); }
-  MatrixX<T> C(const T&) const final { return MatrixX<T>(C_); }
-  MatrixX<T> D(const T&) const final { return MatrixX<T>(D_); }
+  MatrixX<T> C(const T&) const final { return MatrixX<T>(C_.GetAsDense()); }
+  MatrixX<T> D(const T&) const final { return MatrixX<T>(D_.GetAsDense()); }
   VectorX<T> y0(const T&) const final { return VectorX<T>(y0_); }
   /// @}
 
   /// Updates the coefficients of the affine system. The new coefficients must
   /// have the same size as existing coefficients.
-  void UpdateCoefficients(const Eigen::Ref<const Eigen::MatrixXd>& A,
-                          const Eigen::Ref<const Eigen::MatrixXd>& B,
-                          const Eigen::Ref<const Eigen::VectorXd>& f0,
-                          const Eigen::Ref<const Eigen::MatrixXd>& C,
-                          const Eigen::Ref<const Eigen::MatrixXd>& D,
-                          const Eigen::Ref<const Eigen::VectorXd>& y0);
+  /// @pydrake_mkdoc_identifier{dense}
+  void UpdateCoefficients(
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::MatrixXd>& B = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::VectorXd>& f0 = Eigen::VectorXd(),
+      const Eigen::Ref<const Eigen::MatrixXd>& C = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::MatrixXd>& D = Eigen::MatrixXd(),
+      const Eigen::Ref<const Eigen::VectorXd>& y0 = Eigen::VectorXd());
+
+  /// Updates the SparseMatrix coefficients of the affine system. The new
+  /// coefficients must have the same size as existing coefficients.
+  /// @pydrake_mkdoc_identifier{sparse}
+  void UpdateCoefficients(
+      const Eigen::SparseMatrix<double>& A = Eigen::SparseMatrix<double>(),
+      const Eigen::SparseMatrix<double>& B = Eigen::SparseMatrix<double>(),
+      const Eigen::Ref<const Eigen::VectorXd>& f0 = Eigen::VectorXd(),
+      const Eigen::SparseMatrix<double>& C = Eigen::SparseMatrix<double>(),
+      const Eigen::SparseMatrix<double>& D = Eigen::SparseMatrix<double>(),
+      const Eigen::Ref<const Eigen::VectorXd>& y0 = Eigen::VectorXd());
 
  protected:
   /// Constructor that specifies scalar-type conversion support.
@@ -278,6 +317,14 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
                const Eigen::Ref<const Eigen::MatrixXd>& D,
                const Eigen::Ref<const Eigen::VectorXd>& y0, double time_period);
 
+  AffineSystem(SystemScalarConverter converter,
+               const Eigen::SparseMatrix<double>& A,
+               const Eigen::SparseMatrix<double>& B,
+               const Eigen::Ref<const Eigen::VectorXd>& f0,
+               const Eigen::SparseMatrix<double>& C,
+               const Eigen::SparseMatrix<double>& D,
+               const Eigen::Ref<const Eigen::VectorXd>& y0, double time_period);
+
  private:
   void CalcOutputY(const Context<T>& context,
                    BasicVector<T>* output_vector) const final;
@@ -289,12 +336,15 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
   EventStatus CalcDiscreteUpdate(const Context<T>& context,
                                  DiscreteValues<T>* updates) const final;
 
-  Eigen::MatrixXd A_;
-  Eigen::MatrixXd B_;
+  void SpecifyOutputPortDependencies();
+
+  math::internal::SparseAndDenseMatrix A_;
+  math::internal::SparseAndDenseMatrix B_;
   Eigen::VectorXd f0_;
-  Eigen::MatrixXd C_;
-  Eigen::MatrixXd D_;
+  math::internal::SparseAndDenseMatrix C_;
+  math::internal::SparseAndDenseMatrix D_;
   Eigen::VectorXd y0_;
+
   bool has_meaningful_C_{};
   bool has_meaningful_D_{};
 };


### PR DESCRIPTION
Towards properly supporting MatrixGain for sparse matrix multiplicatoin of the actuation matrix in #20971.

This PR relocates sparse_and_dense_matrix from solvers into math with no changes (apart from the namespace), and uses it in AffineSystem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21591)
<!-- Reviewable:end -->
