### PR TITLE
Box overlap stats

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -17,6 +17,7 @@
 #include "drake/geometry/geometry_properties.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_version.h"
+#include "drake/geometry/proximity/boxes_overlap.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/shape_specification.h"
 
@@ -535,6 +536,11 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::arg("properties"), py::arg("dissipation") = std::nullopt,
       py::arg("point_stiffness") = std::nullopt,
       py::arg("friction") = std::nullopt, doc.AddContactMaterial.doc);
+
+  // XXX HACK
+  m.def(
+      "ReportBoxOverlapStatistics",
+      []() { geometry::internal::ReportStatistics(); }, "XXX HACK");
 }
 
 // Test-only code.

--- a/bindings/pydrake/geometry/test/common_test.py
+++ b/bindings/pydrake/geometry/test/common_test.py
@@ -497,3 +497,6 @@ class TestGeometryCore(unittest.TestCase):
         self.assertEqual(cone.b(), 5.6)
         assert_pickle(self, cone, lambda shape: [
                       shape.height(), shape.a(), shape.b()])
+
+    def test_hackery(self):
+        mut.ReportBoxOverlapStatistics()

--- a/geometry/proximity/boxes_overlap.cc
+++ b/geometry/proximity/boxes_overlap.cc
@@ -1,8 +1,22 @@
 #include "drake/geometry/proximity/boxes_overlap.h"
 
+#include <span>
+
+#include <fmt/core.h>
+
 namespace drake {
 namespace geometry {
 namespace internal {
+
+namespace {
+static constexpr int kAxisA0 = 0;
+static constexpr int kAxisB0 = kAxisA0 + 3;
+static constexpr int kAxisCross0 = kAxisB0 + 3;
+static constexpr int kOverlap = kAxisCross0 + 9;
+static constexpr int kEnd = kOverlap + 1;
+
+static int64_t counters[kEnd] = {0};
+}  // namespace
 
 using Eigen::Matrix3d;
 using Eigen::Vector3d;
@@ -28,22 +42,29 @@ bool BoxesOverlap(const Vector3d& half_size_a, const Vector3d& half_size_b,
   }
 
   // First category of cases separating along a's axes.
+  int stats_index = kAxisA0;
   for (int i = 0; i < 3; ++i) {
     if (abs(t[i]) > half_size_a[i] + half_size_b.dot(abs_r.block<1, 3>(i, 0))) {
+      ++counters[stats_index];
       return false;
     }
+    ++stats_index;
   }
 
   // Second category of cases separating along b's axes.
+  DRAKE_ASSERT(stats_index == kAxisB0);
   for (int i = 0; i < 3; ++i) {
     if (abs(t.dot(r.block<3, 1>(0, i))) >
         half_size_b[i] + half_size_a.dot(abs_r.block<3, 1>(0, i))) {
+      ++counters[stats_index];
       return false;
     }
+    ++stats_index;
   }
 
   // Third category of cases separating along the axes formed from the cross
   // products of a's and b's axes.
+  DRAKE_ASSERT(stats_index == kAxisCross0);
   int i1 = 1;
   for (int i = 0; i < 3; ++i) {
     const int i2 = (i1 + 1) % 3;  // Calculate common sub expressions.
@@ -53,14 +74,33 @@ bool BoxesOverlap(const Vector3d& half_size_a, const Vector3d& half_size_b,
       if (abs(t[i2] * r(i1, j) - t[i1] * r(i2, j)) >
           half_size_a[i1] * abs_r(i2, j) + half_size_a[i2] * abs_r(i1, j) +
               half_size_b[j1] * abs_r(i, j2) + half_size_b[j2] * abs_r(i, j1)) {
+        ++counters[stats_index];
         return false;
       }
       j1 = j2;
+      ++stats_index;
     }
     i1 = i2;
   }
 
+  DRAKE_ASSERT(stats_index == kOverlap);
+  ++counters[stats_index];
   return true;
+}
+
+void ReportStatistics() {
+  std::span counts{counters};
+  auto chunk = [&counts](int begin, int end) {
+    return fmt::join(counts.subspan(begin, end - begin), ", ");
+  };
+  fmt::print(R"""(
+A axis separation returns: [{}]
+B axis separation returns: [{}]
+Cross product axis separation returns [{}]
+Overlap returns [{}]
+)""",
+             chunk(kAxisA0, kAxisB0), chunk(kAxisB0, kAxisCross0),
+             chunk(kAxisCross0, kOverlap), chunk(kOverlap, kEnd));
 }
 
 }  // namespace internal

--- a/geometry/proximity/boxes_overlap.h
+++ b/geometry/proximity/boxes_overlap.h
@@ -21,6 +21,8 @@ bool BoxesOverlap(const Vector3<double>& half_size_a,
                   const Vector3<double>& half_size_b,
                   const math::RigidTransformd& X_AB);
 
+void ReportStatistics();
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/test/boxes_overlap_test.cc
+++ b/geometry/proximity/test/boxes_overlap_test.cc
@@ -284,6 +284,7 @@ TEST_F(BoxesOverlapTest, AllCases) {
           fmt::format("A{}-B{} colliding", axes[a_axis], axes[b_axis])));
     }
   }
+  ReportStatistics();
 }
 
 }  // namespace


### PR DESCRIPTION
Shameless hackery to collect branch statistics on geometry::internal::BoxesOverlap().

Only saving them here in case we need to argue about the resulting statistics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21598)
<!-- Reviewable:end -->
