### PR TITLE
Adds CommonSolverOption::kStandaloneReproductionFileName

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -426,6 +426,9 @@ void BindSolverInterfaceAndFlags(py::module m) {
           doc.SolverOptions.get_print_file_name.doc)
       .def("get_print_to_console", &SolverOptions::get_print_to_console,
           doc.SolverOptions.get_print_to_console.doc)
+      .def("get_standalone_reproduction_file_name",
+          &SolverOptions::get_standalone_reproduction_file_name,
+          doc.SolverOptions.get_standalone_reproduction_file_name.doc)
       .def("__repr__", [](const SolverOptions&) -> std::string {
         // This is a minimal implementation that serves to avoid displaying
         // memory addresses in pydrake docs and help strings. In the future,
@@ -438,7 +441,10 @@ void BindSolverInterfaceAndFlags(py::module m) {
       .value("kPrintFileName", CommonSolverOption::kPrintFileName,
           doc.CommonSolverOption.kPrintFileName.doc)
       .value("kPrintToConsole", CommonSolverOption::kPrintToConsole,
-          doc.CommonSolverOption.kPrintToConsole.doc);
+          doc.CommonSolverOption.kPrintToConsole.doc)
+      .value("kStandaloneReproductionFileName",
+          CommonSolverOption::kStandaloneReproductionFileName,
+          doc.CommonSolverOption.kStandaloneReproductionFileName.doc);
 }
 
 void BindMathematicalProgram(py::module m) {

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1300,11 +1300,17 @@ class TestMathematicalProgram(unittest.TestCase):
         options_object.SetOption(mp.CommonSolverOption.kPrintToConsole, 1)
         options_object.SetOption(
             mp.CommonSolverOption.kPrintFileName, "foo.txt")
+        options_object.SetOption(
+            mp.CommonSolverOption.kStandaloneReproductionFileName,
+            "reproduction.py")
         options = options_object.GetOptions(solver_id)
         self.assertDictEqual(
             options, {"double_key": 1.0, "int_key": 2, "string_key": "3"})
         self.assertEqual(options_object.get_print_to_console(), True)
         self.assertEqual(options_object.get_print_file_name(), "foo.txt")
+        self.assertEqual(
+            options_object.get_standalone_reproduction_file_name(),
+            "reproduction.py")
 
         prog.SetSolverOptions(options_object)
         prog_options = prog.GetSolverOptions(solver_id)

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1796,6 +1796,7 @@ drake_cc_googletest(
         ":second_order_cone_program_examples",
         ":semidefinite_program_examples",
         ":sos_examples",
+        "//common:temp_directory",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/solvers/clarabel_solver.cc
+++ b/solvers/clarabel_solver.cc
@@ -1,5 +1,6 @@
 #include "drake/solvers/clarabel_solver.h"
 
+#include <fstream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -7,6 +8,7 @@
 #include <Clarabel>
 #include <Eigen/Eigen>
 
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/name_value.h"
 #include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"
@@ -294,6 +296,111 @@ void SetBoundingBoxDualSolution(
   }
 }
 
+void WriteClarabelReproduction(
+    std::string filename, const Eigen::SparseMatrix<double>& P,
+    const Eigen::Map<Eigen::VectorXd>& q_vec,
+    const Eigen::SparseMatrix<double>& A,
+    const Eigen::Map<Eigen::VectorXd>& b_vec,
+    const std::vector<clarabel::SupportedConeT<double>>& cones) {
+  std::ofstream out_file(filename);
+  if (!out_file.is_open()) {
+    log()->error(
+        "Failed to open kStandaloneReproductionFileName {} for writing; no "
+        "reproduction will be generated.");
+    return;
+  }
+
+  auto write_csc = [&](const Eigen::SparseMatrix<double>& mat,
+                       const std::string& name) {
+    if (mat.nonZeros() == 0) {
+      out_file << fmt::format("{} = sparse.csc_matrix(({}, {}))", name,
+                              P.rows(), P.cols())
+               << std::endl;
+      return;
+    }
+    std::vector<double> data;
+    std::vector<int> rows;
+    std::vector<int> cols;
+    data.reserve(mat.nonZeros());
+    rows.reserve(mat.nonZeros());
+    cols.reserve(mat.nonZeros());
+    for (int k = 0; k < mat.outerSize(); ++k) {
+      for (Eigen::SparseMatrix<double>::InnerIterator it(mat, k); it; ++it) {
+        data.push_back(it.value());
+        rows.push_back(it.row());
+        cols.push_back(it.col());
+      }
+    }
+    out_file << fmt::format(R"""(
+data = [{}]
+rows = [{}]
+cols = [{}]
+{} = sparse.csc_matrix((data, (rows, cols)))
+)""",
+                            fmt::join(data, ", "), fmt::join(rows, ", "),
+                            fmt::join(cols, ", "), name);
+  };
+
+  out_file << fmt::format(
+      R"""(
+import clarabel
+import numpy as np
+from scipy import sparse
+
+q = [{}]
+b = [{}]
+)""",
+      fmt::join(q_vec.data(), q_vec.data() + q_vec.size(), ", "),
+      fmt::join(b_vec.data(), b_vec.data() + b_vec.size(), ", "));
+  write_csc(P, "P");
+  write_csc(A, "A");
+  out_file << "cones = [" << std::endl;
+
+  for (const clarabel::SupportedConeT<double>& cone : cones) {
+    switch (cone.tag) {
+      case clarabel::SupportedConeT<double>::Tag::ZeroConeT:
+        out_file << "  clarabel.ZeroConeT(" << cone.nvars() << "),"
+                 << std::endl;
+        break;
+      case clarabel::SupportedConeT<double>::Tag::NonnegativeConeT:
+        out_file << "  clarabel.NonnegativeConeT(" << cone.nvars() << "),"
+                 << std::endl;
+        break;
+      case clarabel::SupportedConeT<double>::Tag::SecondOrderConeT:
+        out_file << "  clarabel.SecondOrderConeT(" << cone.nvars() << "),"
+                 << std::endl;
+        break;
+      case clarabel::SupportedConeT<double>::Tag::PSDTriangleConeT:
+        {
+          const clarabel::PSDTriangleConeT<double>* psd_cone =
+              static_cast<const clarabel::PSDTriangleConeT<double>*>(&cone);
+          out_file << "  clarabel.PSDTriangleConeT(" << psd_cone->dimension()
+                  << ")," << std::endl;
+        }
+        break;
+      case clarabel::SupportedConeT<double>::Tag::ExponentialConeT:
+        out_file << "  clarabel.ExponentialConeT()," << std::endl;
+        break;
+      default:
+        log()->error(
+            "WriteClarabelReproduction: Found unsupported cone type; "
+            "reproduction will likely be invalid.");
+    }
+  }
+
+  // TODO(russt): write solver options.
+  out_file << R"""(]
+
+settings = clarabel.DefaultSettings()
+solver = clarabel.DefaultSolver(P, q, A, b, cones, settings)
+solver.solve()
+)""";
+
+  log()->info("Clarabel reproduction successfully written to {}.", filename);
+
+  out_file.close();
+}
+
 }  // namespace
 
 bool ClarabelSolver::is_available() {
@@ -456,6 +563,11 @@ void ClarabelSolver::DoSolve(const MathematicalProgram& prog,
   const SettingsConverter settings_converter(merged_options);
   clarabel::DefaultSettings<double> settings = settings_converter.settings();
 
+  std::string repro_file_name =
+      merged_options.get_standalone_reproduction_file_name();
+  if (!repro_file_name.empty()) {
+    WriteClarabelReproduction(repro_file_name, P, q_vec, A, b_vec, cones);
+  }
   clarabel::DefaultSolver<double> solver(P, q_vec, A, b_vec, cones, settings);
 
   solver.solve();

--- a/solvers/common_solver_option.cc
+++ b/solvers/common_solver_option.cc
@@ -13,6 +13,9 @@ std::ostream& operator<<(std::ostream& os,
     case CommonSolverOption::kPrintToConsole:
       os << "kPrintToConsole";
       return os;
+    case CommonSolverOption::kStandaloneReproductionFileName:
+      os << "kStandaloneReproductionFileName";
+      return os;
     default:
       DRAKE_UNREACHABLE();
   }

--- a/solvers/common_solver_option.h
+++ b/solvers/common_solver_option.h
@@ -27,6 +27,16 @@ enum class CommonSolverOption {
    * console.
    */
   kPrintToConsole,
+  /** Some of our solver interfaces support writing a standalone (e.g. it does
+   * not depend on Drake) minimal reproduction of the problem to a file. This is
+   * especially useful for sending bug reports upstream to the developers of the
+   * solver. To enable this, use e.g.
+   * SolverOptions::SetOption(kStandaloneReproductionFileName,
+   * "reproduction.txt"). To disable, use
+   * SolverOptions::SetOption(kStandaloneReproductionFileName, ""), where the
+   * empty string "" indicates that no file should be written.
+   */
+  kStandaloneReproductionFileName,
 };
 
 std::ostream& operator<<(std::ostream& os,

--- a/solvers/solver_options.cc
+++ b/solvers/solver_options.cc
@@ -62,6 +62,15 @@ void SolverOptions::SetOption(CommonSolverOption key, OptionValue value) {
       common_solver_options_[key] = std::move(value);
       return;
     }
+    case CommonSolverOption::kStandaloneReproductionFileName: {
+      if (!std::holds_alternative<std::string>(value)) {
+        throw std::runtime_error(fmt::format(
+            "SolverOptions::SetOption support {} only with std::string value.",
+            key));
+      }
+      common_solver_options_[key] = std::move(value);
+      return;
+    }
   }
   DRAKE_UNREACHABLE();
 }
@@ -110,6 +119,17 @@ bool SolverOptions::get_print_to_console() const {
   if (iter != common_solver_options_.end()) {
     const int value = std::get<int>(iter->second);
     result = static_cast<bool>(value);
+  }
+  return result;
+}
+
+std::string SolverOptions::get_standalone_reproduction_file_name() const {
+  // N.B. SetOption sanity checks the value; we don't need to re-check here.
+  std::string result;
+  auto iter = common_solver_options_.find(
+      CommonSolverOption::kStandaloneReproductionFileName);
+  if (iter != common_solver_options_.end()) {
+    result = std::get<std::string>(iter->second);
   }
   return result;
 }

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -124,6 +124,10 @@ class SolverOptions {
    * the option has not been set. */
   bool get_print_to_console() const;
 
+  /** Returns the kStandaloneReproductionFileName set via CommonSolverOption, or
+   * else an empty string if the option has not been set. */
+  std::string get_standalone_reproduction_file_name() const;
+
   template <typename T>
   const std::unordered_map<std::string, T>& GetOptions(
       const SolverId& solver_id) const {

--- a/solvers/test/clarabel_solver_test.cc
+++ b/solvers/test/clarabel_solver_test.cc
@@ -1,7 +1,11 @@
 #include "drake/solvers/clarabel_solver.h"
 
+#include <fstream>
+
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/solvers/mathematical_program.h"
@@ -17,7 +21,11 @@
 namespace drake {
 namespace solvers {
 namespace test {
+
 const double kTol = 1E-5;
+
+using testing::HasSubstr;
+
 GTEST_TEST(LinearProgramTest, TestGeneralLP) {
   // Test a linear program with only equality constraint.
   // min x(0) + 2 * x(1)
@@ -439,6 +447,42 @@ GTEST_TEST(TestOptions, SetMaxIter) {
     result = solver.Solve(dut.prog(), std::nullopt, solver_options);
     EXPECT_FALSE(result.is_success());
     EXPECT_EQ(result.get_solution_result(), SolutionResult::kIterationLimit);
+  }
+}
+
+GTEST_TEST(TestOptions, StandaloneReproduction) {
+  MathematicalProgram prog;
+  const auto x = prog.NewContinuousVariables<3>("x");
+  prog.AddLinearEqualityConstraint(x(0) + x(1) == 1);
+  prog.AddLorentzConeConstraint(Vector2<symbolic::Expression>(x(0), x(1)));
+  prog.AddExponentialConeConstraint(
+      Vector3<symbolic::Expression>(x(2), x(0), x(1)));
+  const auto Y = prog.NewSymmetricContinuousVariables<2>("Y");
+  prog.AddPositiveSemidefiniteConstraint(Y);
+
+  ClarabelSolver solver;
+  if (solver.available()) {
+    SolverOptions solver_options;
+    const std::string repro_file_name =
+        temp_directory() + "/reproduction.py";
+    solver_options.SetOption(
+        CommonSolverOption::kStandaloneReproductionFileName, repro_file_name);
+    solver.Solve(prog, std::nullopt, solver_options);
+
+    // Read in the reproduction file.
+    std::ifstream input_stream(repro_file_name);
+    ASSERT_TRUE(input_stream.is_open());
+    std::stringstream buffer;
+    buffer << input_stream.rdbuf();
+    std::string repro_str = buffer.str();
+
+    EXPECT_THAT(repro_str, HasSubstr("import clarabel"));
+    EXPECT_THAT(repro_str, HasSubstr("ZeroConeT"));
+    EXPECT_THAT(repro_str, HasSubstr("NonnegativeConeT"));
+    EXPECT_THAT(repro_str, HasSubstr("SecondOrderConeT"));
+    EXPECT_THAT(repro_str, HasSubstr("PSDTriangleConeT"));
+    EXPECT_THAT(repro_str, HasSubstr("ExponentialConeT"));
+    EXPECT_THAT(repro_str, HasSubstr("solve"));
   }
 }
 

--- a/solvers/test/solver_options_test.cc
+++ b/solvers/test/solver_options_test.cc
@@ -12,6 +12,7 @@ GTEST_TEST(SolverOptionsTest, SetGetOption) {
   EXPECT_EQ(to_string(dut), "{SolverOptions empty}");
   EXPECT_EQ(dut.get_print_file_name(), "");
   EXPECT_EQ(dut.get_print_to_console(), false);
+  EXPECT_EQ(dut.get_standalone_reproduction_file_name(), "");
 
   const SolverId id1("id1");
   const SolverId id2("id2");
@@ -25,11 +26,13 @@ GTEST_TEST(SolverOptionsTest, SetGetOption) {
 
   dut.SetOption(CommonSolverOption::kPrintFileName, "foo.txt");
   dut.SetOption(CommonSolverOption::kPrintToConsole, 1);
+  dut.SetOption(CommonSolverOption::kStandaloneReproductionFileName, "bar.py");
 
   EXPECT_EQ(to_string(dut),
             "{SolverOptions,"
             " CommonSolverOption::kPrintFileName=foo.txt,"
             " CommonSolverOption::kPrintToConsole=1,"
+            " CommonSolverOption::kStandaloneReproductionFileName=bar.py,"
             " id1:some_before=1.2,"
             " id1:some_double=1.1,"
             " id1:some_int=2,"
@@ -37,6 +40,7 @@ GTEST_TEST(SolverOptionsTest, SetGetOption) {
             " id2:some_string=foo}");
   EXPECT_EQ(dut.get_print_file_name(), "foo.txt");
   EXPECT_EQ(dut.get_print_to_console(), true);
+  EXPECT_EQ(dut.get_standalone_reproduction_file_name(), "bar.py");
 
   const std::unordered_map<CommonSolverOption,
                            std::variant<double, int, std::string>>


### PR DESCRIPTION
and adds support for it to ClarabelSolver.

+@jwnimmer-tri for feature review, please.
Our slack discussion was [here](https://drakedevelopers.slack.com/archives/C0557S260N8/p1713492966311459?thread_ts=1709046236.828909&cid=C0557S260N8).

I was encouraged to finish this because bumping to the latest Drake (which had bumped Clarabel) broke one of my simple examples in underactuated again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21607)
<!-- Reviewable:end -->
