### PR TITLE
[multibody] Consolidate MbP geometry contact caching

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -110,6 +110,7 @@ drake_cc_library(
         "deformable_model.h",
         "discrete_update_manager.h",
         "dummy_physical_model.h",
+        "geometry_contact_data.h",
         "make_discrete_update_manager.h",
         "multibody_plant.h",
         "multibody_plant_discrete_update_manager_attorney.h",

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -279,11 +279,10 @@ DiscreteUpdateManager<T>::EvalContactSolverResults(
 }
 
 template <typename T>
-const std::vector<geometry::ContactSurface<T>>&
-DiscreteUpdateManager<T>::EvalContactSurfaces(
+const GeometryContactData<T>& DiscreteUpdateManager<T>::EvalGeometryContactData(
     const systems::Context<T>& context) const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalContactSurfaces(
-      plant(), context);
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::EvalGeometryContactData(plant(), context);
 }
 
 template <typename T>
@@ -503,7 +502,7 @@ void DiscreteUpdateManager<T>::AppendContactResultsForPointContact(
   DRAKE_DEMAND(contact_results != nullptr);
 
   const std::vector<PenetrationAsPointPair<T>>& point_pairs =
-      plant().EvalPointPairPenetrations(context);
+      EvalGeometryContactData(context).point_pairs;
   const DiscreteContactData<DiscreteContactPair<T>>& contact_pairs =
       EvalDiscreteContactPairs(context);
   const contact_solvers::internal::ContactSolverResults<T>& solver_results =
@@ -572,9 +571,8 @@ void DiscreteUpdateManager<T>::CalcHydroelasticContactInfo(
     const systems::Context<T>& context,
     std::vector<HydroelasticContactInfo<T>>* contact_info) const {
   DRAKE_DEMAND(contact_info != nullptr);
-
   const std::vector<ContactSurface<T>>& all_surfaces =
-      EvalContactSurfaces(context);
+      EvalGeometryContactData(context).surfaces;
 
   contact_info->clear();
   // Reserve memory here to keep from repeatedly allocating heap storage in the
@@ -759,50 +757,15 @@ void DiscreteUpdateManager<T>::CalcDiscreteContactPairs(
 }
 
 template <typename T>
-int DiscreteUpdateManager<T>::CalcNumberOfPointContacts(
-    const systems::Context<T>& context) const {
-  const auto contact_model = plant().get_contact_model();
-  // N.B. num_point_pairs = 0 when:
-  //   1. There are legitimately no point pairs or,
-  //   2. the point pair model is not even in use.
-  // We guard for case (2) since EvalPointPairPenetrations() cannot be called
-  // when point contact is not used and would otherwise throw an exception.
-  int num_point_pairs = 0;
-  if (contact_model == ContactModel::kPoint ||
-      contact_model == ContactModel::kHydroelasticWithFallback) {
-    num_point_pairs = plant().EvalPointPairPenetrations(context).size();
-  }
-  return num_point_pairs;
-}
-
-template <typename T>
-int DiscreteUpdateManager<T>::CalcNumberOfHydroContactPoints(
-    const systems::Context<T>& context) const {
-  const auto contact_model = plant().get_contact_model();
-  int num_hydro_pairs = 0;
-  // N.B. For discrete hydro we use a first order quadrature rule. As such,
-  // the per-face quadrature point is the face's centroid and the weight is 1.
-  // This is compatible with a mesh that is triangle or polygon. If we attempted
-  // higher order quadrature, polygons would have to be decomposed into smaller
-  // n-gons which can receive an appropriate set of quadrature points.
-  if (contact_model == ContactModel::kHydroelastic ||
-      contact_model == ContactModel::kHydroelasticWithFallback) {
-    const std::vector<geometry::ContactSurface<T>>& surfaces =
-        EvalContactSurfaces(context);
-    for (const auto& s : surfaces) {
-      // One quadrature point per face.
-      num_hydro_pairs += s.num_faces();
-    }
-  }
-  return num_hydro_pairs;
-}
-
-template <typename T>
 void DiscreteUpdateManager<T>::AppendDiscreteContactPairsForPointContact(
     const systems::Context<T>& context,
     DiscreteContactData<DiscreteContactPair<T>>* contact_pairs) const {
-  const int num_point_contacts = CalcNumberOfPointContacts(context);
-  if (num_point_contacts == 0) return;
+  const std::vector<PenetrationAsPointPair<T>>& point_pairs =
+      EvalGeometryContactData(context).point_pairs;
+  const int num_point_contacts = point_pairs.size();
+  if (num_point_contacts == 0) {
+    return;
+  }
 
   contact_pairs->Reserve(num_point_contacts, 0, 0);
   const geometry::SceneGraphInspector<T>& inspector =
@@ -820,8 +783,6 @@ void DiscreteUpdateManager<T>::AppendDiscreteContactPairsForPointContact(
   Matrix3X<T> Jv_AcBc_W(3, nv);
 
   // Fill in the point contact pairs.
-  const std::vector<PenetrationAsPointPair<T>>& point_pairs =
-      plant().EvalPointPairPenetrations(context);
   for (int point_pair_index = 0; point_pair_index < num_point_contacts;
        ++point_pair_index) {
     const PenetrationAsPointPair<T>& pair = point_pairs[point_pair_index];
@@ -969,8 +930,21 @@ template <typename T>
 void DiscreteUpdateManager<T>::AppendDiscreteContactPairsForHydroelasticContact(
     const systems::Context<T>& context,
     DiscreteContactData<DiscreteContactPair<T>>* contact_pairs) const {
-  const int num_hydro_contacts = CalcNumberOfHydroContactPoints(context);
-  if (num_hydro_contacts == 0) return;
+  const std::vector<geometry::ContactSurface<T>>& surfaces =
+      EvalGeometryContactData(context).surfaces;
+  // N.B. For discrete hydro we use a first order quadrature rule. As such,
+  // the per-face quadrature point is the face's centroid and the weight is 1.
+  // This is compatible with a mesh that is triangle or polygon. If we attempted
+  // higher order quadrature, polygons would have to be decomposed into smaller
+  // n-gons which can receive an appropriate set of quadrature points.
+  int num_hydro_contacts = 0;
+  for (const auto& s : surfaces) {
+    // One quadrature point per face.
+    num_hydro_contacts += s.num_faces();
+  }
+  if (num_hydro_contacts == 0) {
+    return;
+  }
 
   contact_pairs->Reserve(0, num_hydro_contacts, 0);
   const geometry::SceneGraphInspector<T>& inspector =
@@ -986,9 +960,6 @@ void DiscreteUpdateManager<T>::AppendDiscreteContactPairsForHydroelasticContact(
   Matrix3X<T> Jv_WAc_W(3, nv);
   Matrix3X<T> Jv_WBc_W(3, nv);
   Matrix3X<T> Jv_AcBc_W(3, nv);
-
-  const std::vector<geometry::ContactSurface<T>>& surfaces =
-      EvalContactSurfaces(context);
 
   const int num_surfaces = surfaces.size();
   for (int surface_index = 0; surface_index < num_surfaces; ++surface_index) {

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -20,6 +20,7 @@
 #include "drake/multibody/plant/deformable_model.h"
 #include "drake/multibody/plant/discrete_contact_data.h"
 #include "drake/multibody/plant/discrete_contact_pair.h"
+#include "drake/multibody/plant/geometry_contact_data.h"
 #include "drake/multibody/plant/hydroelastic_contact_info.h"
 #include "drake/multibody/plant/scalar_convertible_component.h"
 #include "drake/multibody/tree/multibody_tree.h"
@@ -300,7 +301,7 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   /* N.B. Keep the spelling and order of declarations here identical to the
    MultibodyPlantDiscreteUpdateManagerAttorney spelling and order of same. */
 
-  const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
+  const GeometryContactData<T>& EvalGeometryContactData(
       const systems::Context<T>& context) const;
 
   void AddJointLimitsPenaltyForces(const systems::Context<T>& context,
@@ -458,10 +459,6 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   void CalcDiscreteContactPairs(
       const systems::Context<T>& context,
       DiscreteContactData<DiscreteContactPair<T>>* result) const;
-
-  int CalcNumberOfPointContacts(const systems::Context<T>& context) const;
-
-  int CalcNumberOfHydroContactPoints(const systems::Context<T>& context) const;
 
   /* Helper function for CalcDiscreteContactPairs() that computes all contact
    pairs from hydroelastic contact, if any. */

--- a/multibody/plant/geometry_contact_data.h
+++ b/multibody/plant/geometry_contact_data.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/geometry/query_results/contact_surface.h"
+#include "drake/geometry/query_results/penetration_as_point_pair.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* This contains the geometric contact information coming out of SceneGraph, as
+consumed by MultibodyPlant. Depending on MbP's contact model and the proximity
+properties in the scene graph, one or the other vector might be guaranteed to be
+empty; e.g., even in kPoint only mode we still have a field named `surfaces` but
+it's always empty.
+@tparam_default_scalar */
+template <typename T>
+struct GeometryContactData {
+  std::vector<geometry::PenetrationAsPointPair<T>> point_pairs;
+  std::vector<geometry::ContactSurface<T>> surfaces;
+  // TODO(jwnimmer-tri) It seems to me like DeformableContact<T> should be
+  // computed and cached here as well.
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -21,6 +21,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/hydroelastics/hydroelastic_engine.h"
 #include "drake/multibody/plant/externally_applied_spatial_force.h"
+#include "drake/multibody/plant/geometry_contact_data.h"
 #include "drake/multibody/plant/hydroelastic_traction_calculator.h"
 #include "drake/multibody/plant/make_discrete_update_manager.h"
 #include "drake/multibody/plant/slicing_and_indexing.h"
@@ -30,6 +31,7 @@
 #include "drake/multibody/tree/quaternion_floating_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/revolute_spring.h"
+
 namespace drake {
 namespace multibody {
 
@@ -68,6 +70,7 @@ using drake::multibody::SpatialForce;
 using drake::multibody::internal::AccelerationKinematicsCache;
 using drake::multibody::internal::ArticulatedBodyForceCache;
 using drake::multibody::internal::ArticulatedBodyInertiaCache;
+using drake::multibody::internal::GeometryContactData;
 using drake::multibody::internal::PositionKinematicsCache;
 using drake::multibody::internal::VelocityKinematicsCache;
 using systems::BasicVector;
@@ -1937,19 +1940,6 @@ void MultibodyPlant<T>::EstimatePointContactParameters(
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcPointPairPenetrations(
-    const systems::Context<T>& context,
-    std::vector<PenetrationAsPointPair<T>>* output) const {
-  this->ValidateContext(context);
-  if (num_collision_geometries() > 0) {
-    const auto& query_object = EvalGeometryQueryInput(context, __func__);
-    *output = query_object.ComputePointPairPenetration();
-  } else {
-    output->clear();
-  }
-}
-
-template <typename T>
 void MultibodyPlant<T>::CopyContactResultsOutput(
     const systems::Context<T>& context,
     ContactResults<T>* contact_results) const {
@@ -2028,7 +2018,7 @@ void MultibodyPlant<T>::AppendContactResultsPointPairContinuous(
   DRAKE_DEMAND(!is_discrete());
 
   const std::vector<PenetrationAsPointPair<T>>& point_pairs =
-      EvalPointPairPenetrations(context);
+      EvalGeometryContactData(context).point_pairs;
 
   const internal::PositionKinematicsCache<T>& pc =
       EvalPositionKinematics(context);
@@ -2218,7 +2208,7 @@ void MultibodyPlant<T>::CalcHydroelasticContactForcesContinuous(
   if (num_collision_geometries() == 0) return;
 
   const std::vector<ContactSurface<T>>& all_surfaces =
-      EvalContactSurfaces(context);
+      EvalGeometryContactData(context).surfaces;
 
   // Reserve memory here to keep from repeatedly allocating heap storage in the
   // loop below.
@@ -2612,53 +2602,57 @@ VectorX<T> MultibodyPlant<T>::AssembleDesiredStateInput(
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcContactSurfaces(
+void MultibodyPlant<T>::CalcGeometryContactData(
     const drake::systems::Context<T>& context,
-    std::vector<ContactSurface<T>>* contact_surfaces) const {
+    GeometryContactData<T>* result) const {
   this->ValidateContext(context);
-  DRAKE_DEMAND(contact_surfaces != nullptr);
-
+  result->point_pairs.clear();
+  result->surfaces.clear();
+  if (num_collision_geometries() == 0) {
+    return;
+  }
   const auto& query_object = EvalGeometryQueryInput(context, __func__);
-
-  *contact_surfaces =
-      query_object.ComputeContactSurfaces(get_contact_surface_representation());
-}
-
-template <>
-void MultibodyPlant<symbolic::Expression>::CalcContactSurfaces(
-    const Context<symbolic::Expression>&,
-    std::vector<geometry::ContactSurface<symbolic::Expression>>*) const {
-  throw std::logic_error(
-      "This method doesn't support T = symbolic::Expression.");
+  switch (contact_model_) {
+    case ContactModel::kPoint: {
+      result->point_pairs = query_object.ComputePointPairPenetration();
+      return;
+    }
+    case ContactModel::kHydroelastic: {
+      if constexpr (scalar_predicate<T>::is_bool) {
+        result->surfaces = query_object.ComputeContactSurfaces(
+            get_contact_surface_representation());
+        return;
+      } else {
+        // TODO(SeanCurtis-TRI): Special case the QueryObject scalar support
+        //  such that it works as long as there are no collisions.
+        throw std::logic_error(
+            "MultibodyPlant::CalcGeometryContactData(): This method doesn't "
+            "support T=Expression once collision geometries have been added.");
+      }
+    }
+    case ContactModel::kHydroelasticWithFallback: {
+      if constexpr (scalar_predicate<T>::is_bool) {
+        query_object.ComputeContactSurfacesWithFallback(
+            get_contact_surface_representation(), &result->surfaces,
+            &result->point_pairs);
+        return;
+      } else {
+        // TODO(SeanCurtis-TRI): Special case the QueryObject scalar support
+        //  such that it works as long as there are no collisions.
+        throw std::logic_error(
+            "MultibodyPlant::CalcGeometryContactData(): This method doesn't "
+            "support T=Expression once collision geometries have been added.");
+      }
+    }
+  }
+  DRAKE_UNREACHABLE();
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcHydroelasticWithFallback(
-    const drake::systems::Context<T>& context,
-    internal::HydroelasticWithFallbackCacheData<T>* data) const {
-  this->ValidateContext(context);
-  DRAKE_DEMAND(data != nullptr);
-
-  if (num_collision_geometries() > 0) {
-    const auto& query_object = EvalGeometryQueryInput(context, __func__);
-    data->contact_surfaces.clear();
-    data->point_pairs.clear();
-
-    query_object.ComputeContactSurfacesWithFallback(
-        get_contact_surface_representation(), &data->contact_surfaces,
-        &data->point_pairs);
-  }
-}
-
-template <>
-void MultibodyPlant<symbolic::Expression>::CalcHydroelasticWithFallback(
-    const drake::systems::Context<symbolic::Expression>&,
-    internal::HydroelasticWithFallbackCacheData<symbolic::Expression>*) const {
-  // TODO(SeanCurtis-TRI): Special case the AutoDiff scalar such that it works
-  //  as long as there are no collisions -- akin to CalcPointPairPenetrations().
-  throw std::domain_error(
-      "MultibodyPlant<T>::CalcHydroelasticWithFallback(): This method doesn't "
-      "support T = drake::symbolic::Expression.");
+const GeometryContactData<T>& MultibodyPlant<T>::EvalGeometryContactData(
+    const Context<T>& context) const {
+  return this->get_cache_entry(cache_indices_.geometry_contact_data)
+      .template Eval<GeometryContactData<T>>(context);
 }
 
 template <typename T>
@@ -3205,27 +3199,13 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
   // all_rigid_body_parameters, etc.
 
   // TODO(SeanCurtis-TRI): When SG caches the results of these queries itself,
-  //  (https://github.com/RobotLocomotion/drake/issues/12767), remove these
-  //  cache entries.
-  auto& hydroelastic_with_fallback_cache_entry = this->DeclareCacheEntry(
-      std::string("Hydroelastic contact with point-pair fallback"),
-      &MultibodyPlant::CalcHydroelasticWithFallback,
-      {this->configuration_ticket()});
-  cache_indices_.hydroelastic_with_fallback =
-      hydroelastic_with_fallback_cache_entry.cache_index();
-
-  // Cache entry for point contact queries.
-  auto& point_pairs_cache_entry =
-      this->DeclareCacheEntry(std::string("Point pair penetrations."),
-                              &MultibodyPlant<T>::CalcPointPairPenetrations,
-                              {this->configuration_ticket()});
-  cache_indices_.point_pairs = point_pairs_cache_entry.cache_index();
-
-  // Cache entry for hydroelastic contact surfaces.
-  auto& contact_surfaces_cache_entry = this->DeclareCacheEntry(
-      std::string("Hydroelastic contact surfaces."),
-      &MultibodyPlant<T>::CalcContactSurfaces, {this->configuration_ticket()});
-  cache_indices_.contact_surfaces = contact_surfaces_cache_entry.cache_index();
+  //  (https://github.com/RobotLocomotion/drake/issues/12767), remove this
+  //  cache entry.
+  auto& geometry_contact_data_cache_entry = this->DeclareCacheEntry(
+      std::string("GeometryContactData"),
+      &MultibodyPlant::CalcGeometryContactData, {this->configuration_ticket()});
+  cache_indices_.geometry_contact_data =
+      geometry_contact_data_cache_entry.cache_index();
 
   // Cache entry for HydroelasticContactForcesContinuous.
   const bool use_hydroelastic =
@@ -3544,6 +3524,27 @@ MultibodyPlant<T>::EvalBodySpatialAccelerationInWorld(
   this->ValidateContext(context);
   const AccelerationKinematicsCache<T>& ac = this->EvalForwardDynamics(context);
   return ac.get_A_WB(body_B.mobod_index());
+}
+
+// Deprecated for removal on 2024-10-01.
+template <typename T>
+const std::vector<geometry::PenetrationAsPointPair<T>>&
+MultibodyPlant<T>::EvalPointPairPenetrations(
+    const systems::Context<T>& context) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
+  switch (contact_model_) {
+    case ContactModel::kPoint:
+    case ContactModel::kHydroelasticWithFallback: {
+      return EvalGeometryContactData(context).point_pairs;
+    }
+    case ContactModel::kHydroelastic: {
+      throw std::logic_error(
+          "Attempting to evaluate point pair contact for contact model that "
+          "doesn't use it");
+    }
+  }
+  DRAKE_UNREACHABLE();
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -43,9 +43,9 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
                                     std::move(prerequisites_of_calc));
   }
 
-  static const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
+  static const GeometryContactData<T>& EvalGeometryContactData(
       const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
-    return plant.EvalContactSurfaces(context);
+    return plant.EvalGeometryContactData(context);
   }
 
   static void AddJointLimitsPenaltyForces(const MultibodyPlant<T>& plant,

--- a/multibody/plant/test/compliant_contact_manager_tester.h
+++ b/multibody/plant/test/compliant_contact_manager_tester.h
@@ -28,10 +28,10 @@ class CompliantContactManagerTester {
   }
 
   template <typename T>
-  static const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
+  static const GeometryContactData<T>& EvalGeometryContactData(
       const CompliantContactManager<T>& manager,
-      const drake::systems::Context<T>& context) {
-    return manager.EvalContactSurfaces(context);
+      const systems::Context<T>& context) {
+    return manager.EvalGeometryContactData(context);
   }
 
   // N.B. Actuation input is always included, regardless of solver choice.

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -567,7 +567,7 @@ class FilteredContactResultsTest
 // Test that contact results are properly reported. MultibodyPlant will not
 // report contact results between bodies that are either anchored or with all of
 // their dofs locked. However, geometry query data from SceneGraph (e.g
-// data from MbP::EvalPointPairPenetrations() and MbP::EvalContactSurfaces())
+// data from MbP::CalcGeometryContactData())
 // are not automatically filtered. Thus contact results must store a reference
 // of either the point pair or hydroelastic contact surface that corresponds to
 // that result. We verify that contact results for point contact contain correct

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -2038,6 +2038,9 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   }
 }
 
+// Deprecated for removal on 2024-10-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(MultibodyPlantTest, AutoDiffCalcPointPairPenetrations) {
   PendulumParameters parameters;
   unique_ptr<MultibodyPlant<double>> pendulum = MakePendulumPlant(parameters);
@@ -2057,6 +2060,7 @@ GTEST_TEST(MultibodyPlantTest, AutoDiffCalcPointPairPenetrations) {
   DRAKE_EXPECT_NO_THROW(
       autodiff_pendulum->EvalPointPairPenetrations(*autodiff_context.get()));
 }
+#pragma GCC diagnostic pop
 
 GTEST_TEST(MultibodyPlantTest, LinearizePendulum) {
   const double kTolerance = 5 * std::numeric_limits<double>::epsilon();


### PR DESCRIPTION
There is nowhere in the plant or its helpers that only ever needs a subset of the geometry contacts. Putting all of the contact geometry into a single struct is an order of magnitude simpler.

---

Towards #21597 and therefore also #20545.

Originally, I had planned on consolidating this all the way up into the SceneGraph as an output port (#21568), but this smaller first step is probably best.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21608)
<!-- Reviewable:end -->
