### PR TITLE
[multibody] Rename MbP output calc functions for uniformity

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -936,9 +936,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_geometry_query_input_port",
             &Class::get_geometry_query_input_port, py_rvp::reference_internal,
             cls_doc.get_geometry_query_input_port.doc)
-        .def("get_geometry_poses_output_port",
-            &Class::get_geometry_poses_output_port, py_rvp::reference_internal,
-            cls_doc.get_geometry_poses_output_port.doc)
+        .def("get_geometry_pose_output_port",
+            &Class::get_geometry_pose_output_port, py_rvp::reference_internal,
+            cls_doc.get_geometry_pose_output_port.doc)
         .def("get_deformable_body_configuration_output_port",
             &Class::get_deformable_body_configuration_output_port,
             py_rvp::reference_internal,
@@ -966,6 +966,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("context"), py_rvp::reference,
             // Keep alive, ownership: `return` keeps `context` alive.
             py::keep_alive<0, 2>(), cls_doc.EvalSceneGraphInspector.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("get_geometry_poses_output_port",
+            WrapDeprecated(
+                cls_doc.get_geometry_poses_output_port.doc_deprecated,
+                &Class::get_geometry_poses_output_port),
+            py_rvp::reference_internal,
+            cls_doc.get_geometry_poses_output_port.doc_deprecated);
+#pragma GCC diagnostic pop
     // Port accessors.
     cls  // BR
         .def("get_actuation_input_port",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -510,6 +510,11 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(
             plant.get_actuation_input_port(), InputPort)
         self.assertIsInstance(
+            plant.get_geometry_pose_output_port(), OutputPort)
+        with catch_drake_warnings(expected_count=1) as w:
+            self.assertIsInstance(
+                plant.get_geometry_poses_output_port(), OutputPort)
+        self.assertIsInstance(
             plant.get_net_actuation_output_port(), OutputPort)
         self.assertIsInstance(
             plant.get_net_actuation_output_port(model_instance), OutputPort)

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -867,8 +867,9 @@ void ManipulationStation<T>::Finalize(
   // TODO(SeanCurtis-TRI) It seems with the scene graph query object port
   // exported, this output port is superfluous/undesirable. This port
   // contains the FramePoseVector that connects MBP to SG. Definitely better
-  // to simply rely on the query object output port.
-  builder.ExportOutput(plant_->get_geometry_poses_output_port(),
+  // to simply rely on the query object output port. (Also the port name
+  // no longer matches what MbP provides.)
+  builder.ExportOutput(plant_->get_geometry_pose_output_port(),
                        "geometry_poses");
 
   builder.BuildInto(this);

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -82,7 +82,7 @@ int do_main() {
   DRAKE_DEMAND(acrobot.get_source_id().has_value());
 
   builder.Connect(
-      acrobot.get_geometry_poses_output_port(),
+      acrobot.get_geometry_pose_output_port(),
       scene_graph.get_source_pose_port(acrobot.get_source_id().value()));
 
   geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -84,7 +84,7 @@ int do_main() {
   DRAKE_DEMAND(pendulum.get_source_id().has_value());
 
   builder.Connect(
-      pendulum.get_geometry_poses_output_port(),
+      pendulum.get_geometry_pose_output_port(),
       scene_graph.get_source_pose_port(pendulum.get_source_id().value()));
 
   geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);

--- a/geometry/optimization/test/c_iris_test_utilities.cc
+++ b/geometry/optimization/test/c_iris_test_utilities.cc
@@ -120,15 +120,8 @@ CIrisToyRobotTest::CIrisToyRobotTest() {
 
 CIrisRobotPolytopicGeometryTest::CIrisRobotPolytopicGeometryTest() {
   systems::DiagramBuilder<double> builder;
-  plant_ = builder.AddSystem<multibody::MultibodyPlant<double>>(0.);
-  scene_graph_ = builder.AddSystem<geometry::SceneGraph<double>>();
-  plant_->RegisterAsSourceForSceneGraph(scene_graph_);
-
-  builder.Connect(scene_graph_->get_query_output_port(),
-                  plant_->get_geometry_query_input_port());
-  builder.Connect(
-      plant_->get_geometry_poses_output_port(),
-      scene_graph_->get_source_pose_port(plant_->get_source_id().value()));
+  std::tie(plant_, scene_graph_) =
+      multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
 
   ProximityProperties proximity_properties{};
   // C-IRIS doesn't care about robot dynamics. Use arbitrary material

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1940,16 +1940,15 @@ void MultibodyPlant<T>::EstimatePointContactParameters(
 }
 
 template <typename T>
-void MultibodyPlant<T>::CopyContactResultsOutput(
-    const systems::Context<T>& context,
-    ContactResults<T>* contact_results) const {
+void MultibodyPlant<T>::CalcContactResultsOutput(
+    const systems::Context<T>& context, ContactResults<T>* output) const {
   this->ValidateContext(context);
+  DRAKE_DEMAND(output != nullptr);
 
   // Guard against failure to acquire the geometry input deep in the call graph.
   ValidateGeometryInput(context, get_contact_results_output_port());
 
-  DRAKE_DEMAND(contact_results != nullptr);
-  *contact_results = EvalContactResults(context);
+  *output = EvalContactResults(context);
 }
 
 template <typename T>
@@ -2530,15 +2529,26 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcActuationOutput(const systems::Context<T>& context,
-                                            BasicVector<T>* actuation) const {
-  DRAKE_DEMAND(actuation != nullptr);
-  DRAKE_DEMAND(actuation->size() == num_actuated_dofs());
+void MultibodyPlant<T>::CalcNetActuationOutput(
+    const systems::Context<T>& context, BasicVector<T>* output) const {
+  DRAKE_DEMAND(output != nullptr);
+  DRAKE_DEMAND(output->size() == num_actuated_dofs());
   if (is_discrete()) {
-    actuation->SetFromVector(discrete_update_manager_->EvalActuation(context));
+    output->SetFromVector(discrete_update_manager_->EvalActuation(context));
   } else {
-    actuation->SetFromVector(AssembleActuationInput(context));
+    output->SetFromVector(AssembleActuationInput(context));
   }
+}
+
+template <typename T>
+void MultibodyPlant<T>::CalcInstanceNetActuationOutput(
+    ModelInstanceIndex model_instance, const systems::Context<T>& context,
+    systems::BasicVector<T>* output) const {
+  // The per-instance calc delegates to the full-model calc and then slices it.
+  const VectorX<T>& net_actuation =
+      get_net_actuation_output_port().Eval(context);
+  output->SetFromVector(
+      this->GetActuationFromArray(model_instance, net_actuation));
 }
 
 template <typename T>
@@ -2949,35 +2959,33 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
       this->DeclareVectorInputPort("actuation", num_actuated_dofs())
           .get_index();
 
-  // Net actuation ports.
+  // Output "net_actuation".
   // N.B. We intentionally declare a dependency on kinematics in the continuous
   // mode in anticipation for adding PD support in continuous mode.
+  output_port_indices_.net_actuation =
+      this->DeclareVectorOutputPort(
+              "net_actuation", num_actuated_dofs(),
+              &MultibodyPlant::CalcNetActuationOutput,
+              {state_ticket, this->all_input_ports_ticket(),
+               this->all_parameters_ticket()})
+          .get_index();
+
+  // Output "{model_instance_name}_net_actuation".
   output_port_indices_.instance_net_actuation.resize(num_model_instances());
-  for (ModelInstanceIndex model_instance_index(0);
-       model_instance_index < num_model_instances(); ++model_instance_index) {
-    const int instance_num_dofs = num_actuated_dofs(model_instance_index);
-    output_port_indices_.instance_net_actuation[model_instance_index] =
+  for (ModelInstanceIndex i(0); i < num_model_instances(); ++i) {
+    const std::string& model_instance_name = GetModelInstanceName(i);
+    output_port_indices_.instance_net_actuation[i] =
         this->DeclareVectorOutputPort(
-                GetModelInstanceName(model_instance_index) + "_net_actuation",
-                instance_num_dofs,
-                [this, model_instance_index](const systems::Context<T>& context,
-                                             systems::BasicVector<T>* result) {
-                  const VectorX<T>& net_actuation =
-                      get_net_actuation_output_port().Eval(context);
-                  result->SetFromVector(this->GetActuationFromArray(
-                      model_instance_index, net_actuation));
+                fmt::format("{}_net_actuation", model_instance_name),
+                num_actuated_dofs(i),
+                [this, i](const systems::Context<T>& context,
+                          systems::BasicVector<T>* output) {
+                  this->CalcInstanceNetActuationOutput(i, context, output);
                 },
                 {state_ticket, this->all_input_ports_ticket(),
                  this->all_parameters_ticket()})
             .get_index();
   }
-  output_port_indices_.net_actuation =
-      this->DeclareVectorOutputPort(
-              "net_actuation", num_actuated_dofs(),
-              &MultibodyPlant::CalcActuationOutput,
-              {state_ticket, this->all_input_ports_ticket(),
-               this->all_parameters_ticket()})
-          .get_index();
 
   // Declare per model instance desired states input ports.
   input_port_indices_.instance_desired_state.resize(num_model_instances());
@@ -3008,14 +3016,14 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
               Value<std::vector<ExternallyAppliedSpatialForce<T>>>())
           .get_index();
 
-  // Declare one output port for the entire state vector.
+  // Output "state".
   output_port_indices_.state =
       this->DeclareVectorOutputPort("state", num_multibody_states(),
-                                    &MultibodyPlant::CopyMultibodyStateOut,
+                                    &MultibodyPlant::CalcStateOutput,
                                     {this->all_state_ticket()})
           .get_index();
 
-  // Declare the output port for the poses of all bodies in the world.
+  // Output "body_poses".
   output_port_indices_.body_poses =
       this->DeclareAbstractOutputPort(
               "body_poses", std::vector<math::RigidTransform<T>>(num_bodies()),
@@ -3023,23 +3031,30 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
               {this->configuration_ticket()})
           .get_index();
 
-  // Declare the output port for the spatial velocities of all bodies in the
-  // world.
+  // Output "body_spatial_velocities".
   output_port_indices_.body_spatial_velocities =
       this->DeclareAbstractOutputPort(
-              // TODO(jwnimmer-tri) This port name does not match the docs.
-              "spatial_velocities",
+              "body_spatial_velocities",
               std::vector<SpatialVelocity<T>>(num_bodies()),
               &MultibodyPlant<T>::CalcBodySpatialVelocitiesOutput,
               {this->kinematics_ticket()})
           .get_index();
 
-  // Declare the output port for the spatial accelerations of all bodies in the
-  // world.
+  // Output "spatial_velocities" (deprecated).
+  {
+    this->DeprecateOutputPort(
+        this->DeclareAbstractOutputPort(
+            "spatial_velocities", std::vector<SpatialVelocity<T>>(num_bodies()),
+            &MultibodyPlant<T>::CalcBodySpatialVelocitiesOutput,
+            {this->kinematics_ticket()}),
+        "Use 'body_spatial_velocities' not 'spatial_velocities'. "
+        "The deprecated spelling will be removed on 2024-10-01.");
+  }
+
+  // Output "body_spatial_accelerations".
   output_port_indices_.body_spatial_accelerations =
       this->DeclareAbstractOutputPort(
-              // TODO(jwnimmer-tri) This port name does not match the docs.
-              "spatial_accelerations",
+              "body_spatial_accelerations",
               std::vector<SpatialAcceleration<T>>(num_bodies()),
               &MultibodyPlant<T>::CalcBodySpatialAccelerationsOutput,
               // Accelerations depend on both state and inputs.
@@ -3048,118 +3063,86 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
               {this->all_sources_ticket()})
           .get_index();
 
-  // Declare one output port for the entire generalized acceleration vector
-  // vdot (length is nv).
+  // Output "spatial_accelerations" (deprecated).
+  {
+    this->DeprecateOutputPort(
+        this->DeclareAbstractOutputPort(
+            "spatial_accelerations",
+            std::vector<SpatialAcceleration<T>>(num_bodies()),
+            &MultibodyPlant<T>::CalcBodySpatialAccelerationsOutput,
+            {this->all_sources_ticket()}),
+        "Use 'body_spatial_accelerations' not 'spatial_accelerations'. "
+        "The deprecated spelling will be removed on 2024-10-01.");
+  }
+
+  // Output "generalized_acceleration".
   output_port_indices_.generalized_acceleration =
       this->DeclareVectorOutputPort(
               "generalized_acceleration", num_velocities(),
-              [this](const systems::Context<T>& context,
-                     systems::BasicVector<T>* result) {
-                result->SetFromVector(
-                    this->EvalForwardDynamics(context).get_vdot());
-              },
+              &MultibodyPlant<T>::CalcGeneralizedAccelerationOutput,
               {this->acceleration_kinematics_cache_entry().ticket()})
           .get_index();
 
-  // Declare per model instance state and acceleration output ports.
+  // Output "{model_instance_name}_state".
   output_port_indices_.instance_state.resize(num_model_instances());
+  for (ModelInstanceIndex i(0); i < num_model_instances(); ++i) {
+    const std::string& model_instance_name = GetModelInstanceName(i);
+    output_port_indices_.instance_state[i] =
+        this->DeclareVectorOutputPort(
+                fmt::format("{}_state", model_instance_name),
+                num_multibody_states(i),
+                [this, i](const Context<T>& context, BasicVector<T>* output) {
+                  this->CalcInstanceStateOutput(i, context, output);
+                },
+                {this->all_state_ticket()})
+            .get_index();
+  }
+
+  // Output "{model_instance_name}_generalized_acceleration".
   output_port_indices_.instance_generalized_acceleration.resize(
       num_model_instances());
-  for (ModelInstanceIndex model_instance_index(0);
-       model_instance_index < num_model_instances(); ++model_instance_index) {
-    const std::string& instance_name =
-        GetModelInstanceName(model_instance_index);
-
-    const int instance_num_states =  // Might be zero.
-        num_multibody_states(model_instance_index);
-    auto copy_instance_state_out = [this, model_instance_index](
-                                       const Context<T>& context,
-                                       BasicVector<T>* result) {
-      this->CopyMultibodyStateOut(model_instance_index, context, result);
-    };
-    output_port_indices_.instance_state[model_instance_index] =
+  for (ModelInstanceIndex i(0); i < num_model_instances(); ++i) {
+    const std::string& model_instance_name = GetModelInstanceName(i);
+    output_port_indices_.instance_generalized_acceleration[i] =
         this->DeclareVectorOutputPort(
-                instance_name + "_state", instance_num_states,
-                copy_instance_state_out, {this->all_state_ticket()})
-            .get_index();
-
-    const int instance_num_velocities =  // Might be zero.
-        num_velocities(model_instance_index);
-    output_port_indices_
-        .instance_generalized_acceleration[model_instance_index] =
-        this->DeclareVectorOutputPort(
-                instance_name + "_generalized_acceleration",
-                instance_num_velocities,
-                [this, model_instance_index](const systems::Context<T>& context,
-                                             systems::BasicVector<T>* result) {
-                  const auto& vdot =
-                      this->EvalForwardDynamics(context).get_vdot();
-                  result->SetFromVector(
-                      this->GetVelocitiesFromArray(model_instance_index, vdot));
+                fmt::format("{}_generalized_acceleration", model_instance_name),
+                num_velocities(i),
+                [this, i](const Context<T>& context, BasicVector<T>* output) {
+                  this->CalcInstanceGeneralizedAccelerationOutput(i, context,
+                                                                  output);
                 },
                 {this->acceleration_kinematics_cache_entry().ticket()})
             .get_index();
   }
 
-  // Declare per model instance output port of generalized contact forces.
+  // Output "{model_instance_name}_generalized_contact_forces".
   output_port_indices_.instance_generalized_contact_forces.resize(
       num_model_instances());
-  for (ModelInstanceIndex model_instance_index(0);
-       model_instance_index < num_model_instances(); ++model_instance_index) {
-    const int instance_num_velocities = num_velocities(model_instance_index);
-
+  for (ModelInstanceIndex i(0); i < num_model_instances(); ++i) {
+    const std::string& model_instance_name = GetModelInstanceName(i);
+    std::set<systems::DependencyTicket> prerequisites_of_calc;
     if (is_discrete()) {
-      auto calc = [this, model_instance_index](
-                      const systems::Context<T>& context,
-                      systems::BasicVector<T>* result) {
-        // Guard against failure to acquire the geometry input deep in the call
-        // graph.
-        ValidateGeometryInput(
-            context,
-            get_generalized_contact_forces_output_port(model_instance_index));
-
-        DRAKE_DEMAND(discrete_update_manager_ != nullptr);
-        const contact_solvers::internal::ContactSolverResults<T>&
-            solver_results =
-                discrete_update_manager_->EvalContactSolverResults(context);
-        this->CopyGeneralizedContactForcesOut(solver_results,
-                                              model_instance_index, result);
-      };
-      output_port_indices_
-          .instance_generalized_contact_forces[model_instance_index] =
-          this->DeclareVectorOutputPort(
-                  GetModelInstanceName(model_instance_index) +
-                      "_generalized_contact_forces",
-                  instance_num_velocities, calc,
-                  {systems::System<T>::xd_ticket(),
-                   systems::System<T>::all_parameters_ticket()})
-              .get_index();
+      prerequisites_of_calc = {systems::System<T>::xd_ticket(),
+                               systems::System<T>::all_parameters_ticket()};
     } else {
       const auto& generalized_contact_forces_continuous_cache_entry =
           this->get_cache_entry(
               cache_indices_.generalized_contact_forces_continuous);
-      auto calc = [this, model_instance_index](
-                      const systems::Context<T>& context,
-                      systems::BasicVector<T>* result) {
-        // Guard against failure to acquire the geometry input deep in the call
-        // graph.
-        ValidateGeometryInput(
-            context,
-            get_generalized_contact_forces_output_port(model_instance_index));
-
-        result->SetFromVector(GetVelocitiesFromArray(
-            model_instance_index,
-            EvalGeneralizedContactForcesContinuous(context)));
-      };
-      output_port_indices_
-          .instance_generalized_contact_forces[model_instance_index] =
-          this->DeclareVectorOutputPort(
-                  GetModelInstanceName(model_instance_index) +
-                      "_generalized_contact_forces",
-                  instance_num_velocities, calc,
-                  {generalized_contact_forces_continuous_cache_entry.ticket()})
-              .get_index();
+      prerequisites_of_calc = {
+          generalized_contact_forces_continuous_cache_entry.ticket()};
     }
+    output_port_indices_.instance_generalized_contact_forces[i] =
+        this->DeclareVectorOutputPort(
+                fmt::format("{}_generalized_contact_forces",
+                            model_instance_name),
+                num_velocities(i),
+                [this, i](const systems::Context<T>& context,
+                          systems::BasicVector<T>* output) {
+                  this->CalcInstanceGeneralizedContactForcesOutput(i, context,
+                                                                   output);
+                },
+                prerequisites_of_calc)
+            .get_index();
   }
 
   // Joint reaction forces are a function of accelerations, which in turn depend
@@ -3167,11 +3150,11 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
   output_port_indices_.reaction_forces =
       this->DeclareAbstractOutputPort(
               "reaction_forces", std::vector<SpatialForce<T>>(num_joints()),
-              &MultibodyPlant<T>::CalcReactionForces,
+              &MultibodyPlant<T>::CalcReactionForcesOutput,
               {this->acceleration_kinematics_cache_entry().ticket()})
           .get_index();
 
-  // Contact results output port.
+  // Output port "contact_results".
   std::set<systems::DependencyTicket> contact_results_prerequisites = {
       state_ticket};
   if (is_discrete()) {
@@ -3181,7 +3164,7 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
   output_port_indices_.contact_results =
       this->DeclareAbstractOutputPort(
               "contact_results", ContactResults<T>(),
-              &MultibodyPlant<T>::CopyContactResultsOutput,
+              &MultibodyPlant<T>::CalcContactResultsOutput,
               contact_results_prerequisites)
           .get_index();
 
@@ -3308,40 +3291,39 @@ void MultibodyPlant<T>::DeclareParameters() {
 }
 
 template <typename T>
-void MultibodyPlant<T>::CopyMultibodyStateOut(
-    const Context<T>& context, BasicVector<T>* state_vector) const {
+void MultibodyPlant<T>::CalcStateOutput(const Context<T>& context,
+                                        BasicVector<T>* output) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   this->ValidateContext(context);
-  state_vector->SetFromVector(GetPositionsAndVelocities(context));
+  output->SetFromVector(GetPositionsAndVelocities(context));
 }
 
 template <typename T>
-void MultibodyPlant<T>::CopyMultibodyStateOut(
+void MultibodyPlant<T>::CalcInstanceStateOutput(
     ModelInstanceIndex model_instance, const Context<T>& context,
-    BasicVector<T>* state_vector) const {
+    BasicVector<T>* output) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   this->ValidateContext(context);
-  state_vector->SetFromVector(
-      GetPositionsAndVelocities(context, model_instance));
+  output->SetFromVector(GetPositionsAndVelocities(context, model_instance));
 }
 
 template <typename T>
-void MultibodyPlant<T>::CopyGeneralizedContactForcesOut(
-    const contact_solvers::internal::ContactSolverResults<T>& solver_results,
-    ModelInstanceIndex model_instance, BasicVector<T>* tau_vector) const {
+void MultibodyPlant<T>::CalcInstanceGeneralizedContactForcesOutput(
+    ModelInstanceIndex model_instance, const Context<T>& context,
+    BasicVector<T>* output) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
-  DRAKE_THROW_UNLESS(is_discrete());
-
-  // Vector of generalized contact forces for the entire plant's multibody
-  // system.
-  const VectorX<T>& tau_contact = solver_results.tau_contact;
-
-  // Generalized velocities and generalized forces are ordered in the same way.
-  // Thus we can call get_velocities_from_array().
-  const VectorX<T> instance_tau_contact =
-      GetVelocitiesFromArray(model_instance, tau_contact);
-
-  tau_vector->set_value(instance_tau_contact);
+  this->ValidateContext(context);
+  ValidateGeometryInput(
+      context, get_generalized_contact_forces_output_port(model_instance));
+  // Vector of generalized contact forces for the entire multibody system.
+  const VectorX<T>& tau_contact =
+      is_discrete()
+          ? discrete_update_manager_->EvalContactSolverResults(context)
+                .tau_contact
+          : EvalGeneralizedContactForcesContinuous(context);
+  // Generalized velocities and generalized forces are ordered in the same
+  // way. Thus we can call GetVelocitiesFromArray().
+  output->SetFromVector(GetVelocitiesFromArray(model_instance, tau_contact));
 }
 
 template <typename T>
@@ -3470,50 +3452,66 @@ void MultibodyPlant<T>::DeclareSceneGraphPorts() {
                                      Value<geometry::QueryObject<T>>{})
           .get_index();
   output_port_indices_.geometry_pose =
-      this->DeclareAbstractOutputPort("geometry_pose",
-                                      &MultibodyPlant<T>::CalcFramePoseOutput,
-                                      {this->configuration_ticket()})
+      this->DeclareAbstractOutputPort(
+              "geometry_pose", &MultibodyPlant<T>::CalcGeometryPoseOutput,
+              {this->configuration_ticket()})
           .get_index();
 }
 
 template <typename T>
 void MultibodyPlant<T>::CalcBodyPosesOutput(
     const Context<T>& context,
-    std::vector<math::RigidTransform<T>>* X_WB_all) const {
+    std::vector<math::RigidTransform<T>>* outupt) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   this->ValidateContext(context);
-  X_WB_all->resize(num_bodies());
+  outupt->resize(num_bodies());
   for (BodyIndex body_index(0); body_index < this->num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
-    X_WB_all->at(body_index) = EvalBodyPoseInWorld(context, body);
+    outupt->at(body_index) = EvalBodyPoseInWorld(context, body);
   }
 }
 
 template <typename T>
 void MultibodyPlant<T>::CalcBodySpatialVelocitiesOutput(
-    const Context<T>& context,
-    std::vector<SpatialVelocity<T>>* V_WB_all) const {
+    const Context<T>& context, std::vector<SpatialVelocity<T>>* output) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   this->ValidateContext(context);
-  V_WB_all->resize(num_bodies());
+  output->resize(num_bodies());
   for (BodyIndex body_index(0); body_index < this->num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
-    V_WB_all->at(body_index) = EvalBodySpatialVelocityInWorld(context, body);
+    output->at(body_index) = EvalBodySpatialVelocityInWorld(context, body);
   }
 }
 
 template <typename T>
 void MultibodyPlant<T>::CalcBodySpatialAccelerationsOutput(
     const Context<T>& context,
-    std::vector<SpatialAcceleration<T>>* A_WB_all) const {
+    std::vector<SpatialAcceleration<T>>* output) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   this->ValidateContext(context);
-  A_WB_all->resize(num_bodies());
+  output->resize(num_bodies());
   const AccelerationKinematicsCache<T>& ac = this->EvalForwardDynamics(context);
   for (BodyIndex body_index(0); body_index < this->num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
-    A_WB_all->at(body_index) = ac.get_A_WB(body.mobod_index());
+    output->at(body_index) = ac.get_A_WB(body.mobod_index());
   }
+}
+
+template <typename T>
+void MultibodyPlant<T>::CalcGeneralizedAccelerationOutput(
+    const Context<T>& context, BasicVector<T>* output) const {
+  output->SetFromVector(this->EvalForwardDynamics(context).get_vdot());
+}
+
+template <typename T>
+void MultibodyPlant<T>::CalcInstanceGeneralizedAccelerationOutput(
+    ModelInstanceIndex model_instance, const Context<T>& context,
+    BasicVector<T>* output) const {
+  // The per-instance calc delegates to the full-model calc and then slices it.
+  const VectorX<T>& generalized_acceleration =
+      get_generalized_acceleration_output_port().Eval(context);
+  output->SetFromVector(
+      this->GetVelocitiesFromArray(model_instance, generalized_acceleration));
 }
 
 template <typename T>
@@ -3550,8 +3548,8 @@ MultibodyPlant<T>::EvalPointPairPenetrations(
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcFramePoseOutput(const Context<T>& context,
-                                            FramePoseVector<T>* poses) const {
+void MultibodyPlant<T>::CalcGeometryPoseOutput(
+    const Context<T>& context, FramePoseVector<T>* output) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   this->ValidateContext(context);
   const internal::PositionKinematicsCache<T>& pc =
@@ -3562,7 +3560,7 @@ void MultibodyPlant<T>::CalcFramePoseOutput(const Context<T>& context,
   // frames do.
   // TODO(amcastro-tri): Make use of RigidBody::EvalPoseInWorld(context) once
   // caching lands.
-  poses->clear();
+  output->clear();
   for (const auto& it : body_index_to_frame_id_) {
     const BodyIndex body_index = it.first;
     if (body_index == world_index()) continue;
@@ -3570,18 +3568,18 @@ void MultibodyPlant<T>::CalcFramePoseOutput(const Context<T>& context,
 
     // NOTE: The GeometryFrames for each body were registered in the world
     // frame, so we report poses in the world frame.
-    poses->set_value(body_index_to_frame_id_.at(body_index),
-                     pc.get_X_WB(body.mobod_index()));
+    output->set_value(body_index_to_frame_id_.at(body_index),
+                      pc.get_X_WB(body.mobod_index()));
   }
 }
 
 template <typename T>
-void MultibodyPlant<T>::CalcReactionForces(
+void MultibodyPlant<T>::CalcReactionForcesOutput(
     const systems::Context<T>& context,
-    std::vector<SpatialForce<T>>* F_CJc_Jc_array) const {
+    std::vector<SpatialForce<T>>* output) const {
   this->ValidateContext(context);
-  DRAKE_DEMAND(F_CJc_Jc_array != nullptr);
-  DRAKE_DEMAND(ssize(*F_CJc_Jc_array) == num_joints());
+  DRAKE_DEMAND(output != nullptr);
+  DRAKE_DEMAND(ssize(*output) == num_joints());
 
   // Guard against failure to acquire the geometry input deep in the call graph.
   ValidateGeometryInput(context, get_reaction_forces_output_port());
@@ -3684,7 +3682,8 @@ void MultibodyPlant<T>::CalcReactionForces(
     // Re-express in the joint's child frame Jc.
     const RotationMatrix<T> R_WJc = frame_Jc.CalcRotationMatrixInWorld(context);
     const RotationMatrix<T> R_JcW = R_WJc.inverse();
-    F_CJc_Jc_array->at(joint.ordinal()) = R_JcW * F_CJc_W;
+    const SpatialForce<T> F_CJc_Jc = R_JcW * F_CJc_W;
+    output->at(joint.ordinal()) = F_CJc_Jc;
   }
 }
 
@@ -3709,8 +3708,9 @@ MultibodyPlant<T>::get_body_spatial_accelerations_output_port() const {
 }
 
 template <typename T>
-const OutputPort<T>& MultibodyPlant<T>::get_geometry_poses_output_port() const {
-  return this->get_output_port(output_port_indices_.geometry_pose);
+const OutputPort<T>& MultibodyPlant<T>::get_geometry_pose_output_port() const {
+  return systems::System<T>::get_output_port(
+      output_port_indices_.geometry_pose);
 }
 
 template <typename T>
@@ -3838,7 +3838,7 @@ AddMultibodyPlantSceneGraphResult<T> AddMultibodyPlantSceneGraph(
   auto* plant_ptr = builder->AddSystem(std::move(plant));
   auto* scene_graph_ptr = builder->AddSystem(std::move(scene_graph));
   plant_ptr->RegisterAsSourceForSceneGraph(scene_graph_ptr);
-  builder->Connect(plant_ptr->get_geometry_poses_output_port(),
+  builder->Connect(plant_ptr->get_geometry_pose_output_port(),
                    scene_graph_ptr->get_source_pose_port(
                        plant_ptr->get_source_id().value()));
   builder->Connect(scene_graph_ptr->get_query_output_port(),

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -620,7 +620,7 @@ will include:
 3. Call to Finalize(), user is done specifying the model.
 4. Connect geometry::SceneGraph::get_query_output_port() to
    get_geometry_query_input_port().
-5. Connect get_geometry_poses_output_port() to
+5. Connect get_geometry_pose_output_port() to
    geometry::SceneGraph::get_source_pose_port()
 
 Refer to the documentation provided in each of the methods above for further
@@ -879,8 +879,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_body_spatial_velocities_output_port() const;
 
   /// Returns the output port of all body spatial accelerations in the world
-  /// frame. You can obtain the spatial acceleration `A_WB` of a body B in the
-  /// world frame W with:
+  /// frame. You can obtain the spatial acceleration `A_WB` of a body B (for
+  /// point Bo, the body's origin) in the world frame W with:
   /// @code
   ///   const auto& A_WB_all =
   ///   plant.get_body_spatial_accelerations_output_port().
@@ -1071,7 +1071,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns the output port of frames' poses to communicate with a
   /// SceneGraph.
-  const systems::OutputPort<T>& get_geometry_poses_output_port() const;
+  const systems::OutputPort<T>& get_geometry_pose_output_port() const;
+
+  DRAKE_DEPRECATED(
+      "2024-10-01",
+      "Use get_geometry_pose_output_port() instead (note no 's' plural). "
+      "If you were only using this port to connect it to a SceneGraph, "
+      "instead should you should use the AddMultibodyPlantSceneGraph() or "
+      "AddMultibodyPlant(MultibodyPlantConfig) to add the plant and scene "
+      "graph to a DiagramBuilder, already wired up correctly.")
+  const systems::OutputPort<T>& get_geometry_poses_output_port() const {
+    return get_geometry_pose_output_port();
+  }
 
   // TODO(xuchenhan-tri): Remove the throw condition once DeformableModel is
   //  added by default as part of #21355.
@@ -5151,16 +5162,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // MultibodyPlant::get_actuation_input_port()).
   VectorX<T> AssembleActuationInput(const systems::Context<T>& context) const;
 
-  // Computes the net applied actuation through actuators. For continuous
-  // models (thus far) this only inludes values coming from the
-  // actuation_input_port. For discrete models, it includes actuator
-  // controllers, see @ref mbp_actuation. Similarly to AssembleActuationInput(),
-  // this function assembles actuation values into the vector `actuation`. The
-  // actuation value for a particular actuator can be found at offset
-  // JointActuator::input_start() in `actuation` (see
-  // MultibodyPlant::get_actuation_input_port()).
-  void CalcActuationOutput(const systems::Context<T>& context,
-                           systems::BasicVector<T>* actuation) const;
+  // Calc method for the "net_actuation" output port.
+  void CalcNetActuationOutput(const systems::Context<T>& context,
+                              systems::BasicVector<T>* output) const;
+
+  // Calc method for the "{model_instance_name}_net_actuation" output ports.
+  void CalcInstanceNetActuationOutput(ModelInstanceIndex model_instance,
+                                      const systems::Context<T>& context,
+                                      systems::BasicVector<T>* output) const;
 
   // For models with joint actuators with PD control, this method helps to
   // assemble desired states for the full model from the input ports for
@@ -5258,15 +5267,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const ContactResults<T>& EvalContactResults(
       const systems::Context<T>& context) const;
 
-  // Calc method for the reaction forces output port.
-  // A joint constraints the motion between a frame Jp on a "parent" P and a
-  // frame Jc on a "child" frame C. This generates reaction forces on bodies P
-  // and C in order to satisfy the kinematic constraint between Jp and Jc. This
-  // method computes the spatial force F_CJc_Jc on body C at frame Jc and
-  // expressed in frame Jc. See get_reaction_forces_output_port() for further
-  // details.
-  void CalcReactionForces(const systems::Context<T>& context,
-                          std::vector<SpatialForce<T>>* F_CJc_Jc) const;
+  // Calc method for the "reaction_forces" output port.
+  void CalcReactionForcesOutput(const systems::Context<T>& context,
+                                std::vector<SpatialForce<T>>* output) const;
 
   // Collect joint actuator forces and externally provided spatial and
   // generalized forces.
@@ -5316,36 +5319,44 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // one).
   void RegisterRigidBodyWithSceneGraph(const RigidBody<T>& body);
 
-  // Calc method for the multibody state vector output port. It only copies the
-  // multibody state [q, v], ignoring any miscellaneous state z if present.
-  void CopyMultibodyStateOut(const systems::Context<T>& context,
-                             systems::BasicVector<T>* state) const;
+  // Calc method for the "state" output port.
+  void CalcStateOutput(const systems::Context<T>& context,
+                       systems::BasicVector<T>* output) const;
 
-  // Calc method for the per-model-instance multibody state vector output port.
-  // It only copies the per-model-instance multibody state [q, v], ignoring any
-  // miscellaneous state z if present.
-  void CopyMultibodyStateOut(ModelInstanceIndex model_instance,
-                             const systems::Context<T>& context,
-                             systems::BasicVector<T>* state) const;
+  // Calc method for the "{model_instance_name}_output" output ports.
+  void CalcInstanceStateOutput(ModelInstanceIndex model_instance,
+                               const systems::Context<T>& context,
+                               systems::BasicVector<T>* output) const;
 
-  // Evaluates the pose X_WB of each body in the model and copies it into
-  // X_WB_all, indexed by BodyIndex.
-  void CalcBodyPosesOutput(
-      const systems::Context<T>& context,
-      std::vector<math::RigidTransform<T>>* X_WB_all) const;
+  // Calc method for the "{model_instance_name}_generalized_acceleration" output
+  // ports.
+  void CalcInstanceGeneralizedContactForcesOutput(
+      ModelInstanceIndex model_instance, const systems::Context<T>& context,
+      systems::BasicVector<T>* output) const;
 
-  // Evaluates the spatial velocity V_WB of each body in the model and copies it
-  // into V_WB_all, indexed by BodyIndex.
+  // Calc method for the "body_poses" output port.
+  void CalcBodyPosesOutput(const systems::Context<T>& context,
+                           std::vector<math::RigidTransform<T>>* output) const;
+
+  // Calc method for the "body_spatial_velocities" output port.
   void CalcBodySpatialVelocitiesOutput(
       const systems::Context<T>& context,
-      std::vector<SpatialVelocity<T>>* V_WB_all) const;
+      std::vector<SpatialVelocity<T>>* output) const;
 
-  // For each body B in the model, evaluates A_WB, B's spatial acceleration
-  // in the world frame W, expressed in W (for point Bo, the body's origin) and
-  // copies it into A_WB_all, indexed by BodyIndex.
+  // Calc method for the "body_spatial_accelerations" output port.
   void CalcBodySpatialAccelerationsOutput(
       const systems::Context<T>& context,
-      std::vector<SpatialAcceleration<T>>* A_WB_all) const;
+      std::vector<SpatialAcceleration<T>>* output) const;
+
+  // Calc method for the "generalized_acceleration" output port.
+  void CalcGeneralizedAccelerationOutput(const systems::Context<T>& context,
+                                         systems::BasicVector<T>* output) const;
+
+  // Calc method for the "{model_instance_name}_generalized_acceleration"
+  // output ports.
+  void CalcInstanceGeneralizedAccelerationOutput(
+      ModelInstanceIndex model_instance, const systems::Context<T>& context,
+      systems::BasicVector<T>* output) const;
 
   // Method to compute spatial contact forces for continuous plants.
   // @note This version zeros out the forces in @p F_BBo_W_array before adding
@@ -5376,21 +5387,17 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const VectorX<T>& EvalGeneralizedContactForcesContinuous(
       const systems::Context<T>& context) const;
 
-  // Calc method to output per model instance vector of generalized contact
-  // forces.
-  void CopyGeneralizedContactForcesOut(
-      const contact_solvers::internal::ContactSolverResults<T>&,
-      ModelInstanceIndex, systems::BasicVector<T>* tau_vector) const;
-
   // Helper method to declare output ports used by this plant to communicate
   // with a SceneGraph.
   void DeclareSceneGraphPorts();
 
-  void CalcFramePoseOutput(const systems::Context<T>& context,
-                           geometry::FramePoseVector<T>* poses) const;
+  // Calc method for the "geometry_pose" output port.
+  void CalcGeometryPoseOutput(const systems::Context<T>& context,
+                              geometry::FramePoseVector<T>* output) const;
 
-  void CopyContactResultsOutput(const systems::Context<T>& context,
-                                ContactResults<T>* contact_results) const;
+  // Calc method for the "contact_results" output port.
+  void CalcContactResultsOutput(const systems::Context<T>& context,
+                                ContactResults<T>* output) const;
 
   // (Advanced) Helper method to compute contact forces in the normal direction
   // using a penalty method.

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -117,6 +117,15 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
       V_WB_all[end_effector_link_->index()];
   EXPECT_EQ(V_WE.get_coeffs(), V_WE_from_port.get_coeffs());
 
+  // Also sanity check the deprecated port name (2024-10-01).
+  {
+    const auto& V_WB_all_deprecated =
+        plant_->GetOutputPort("spatial_velocities")
+            .Eval<std::vector<SpatialVelocity<double>>>(*context_);
+    EXPECT_EQ(V_WB_all_deprecated.at(end_effector_link_->index()).get_coeffs(),
+              V_WB_all.at(end_effector_link_->index()).get_coeffs());
+  }
+
   // Spatial velocity of link 3 measured in frame H and expressed in the
   // end-effector frame E.
   const Frame<double>& frame_E = end_effector_link_->body_frame();
@@ -354,6 +363,15 @@ TEST_F(KukaIiwaModelTests, CalcSpatialAcceleration) {
   const SpatialAcceleration<double>& A_WE_W_expected3 =
       A_WB_all[end_effector_link_->index()];
   EXPECT_EQ(A_WE_W.get_coeffs(), A_WE_W_expected3.get_coeffs());
+
+  // Also sanity check the deprecated port name (2024-10-01).
+  {
+    const auto& A_WB_all_deprecated =
+        plant_->GetOutputPort("spatial_accelerations")
+            .Eval<std::vector<SpatialAcceleration<double>>>(*context_);
+    EXPECT_EQ(A_WB_all_deprecated.at(end_effector_link_->index()).get_coeffs(),
+              A_WB_all.at(end_effector_link_->index()).get_coeffs());
+  }
 
   // Verify A_WH_W, frame_H's spatial acceleration in world W, expressed in W.
   // Do this by differentiating the spatial velocity V_WH_W.

--- a/multibody/plant/test/multibody_plant_query_object_connect_test.cc
+++ b/multibody/plant/test/multibody_plant_query_object_connect_test.cc
@@ -76,7 +76,7 @@ MultibodyPlant<double>& PopulateTestDiagram(DiagramBuilder<double>* builder,
     auto* scene_graph = builder->AddSystem<SceneGraph<double>>();
     plant->RegisterAsSourceForSceneGraph(scene_graph);
     builder->Connect(
-        plant->get_geometry_poses_output_port(),
+        plant->get_geometry_pose_output_port(),
         scene_graph->get_source_pose_port(plant->get_source_id().value()));
   }
 

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -108,8 +108,8 @@ void CompareMultibodyPlantPortIndices(const MultibodyPlant<T>& plant_t,
             plant_u.get_reaction_forces_output_port().get_index());
   EXPECT_EQ(plant_t.get_contact_results_output_port().get_index(),
             plant_u.get_contact_results_output_port().get_index());
-  EXPECT_EQ(plant_t.get_geometry_poses_output_port().get_index(),
-            plant_u.get_geometry_poses_output_port().get_index());
+  EXPECT_EQ(plant_t.get_geometry_pose_output_port().get_index(),
+            plant_u.get_geometry_pose_output_port().get_index());
   EXPECT_EQ(
       plant_t.get_state_output_port(default_model_instance()).get_index(),
       plant_u.get_state_output_port(default_model_instance()).get_index());

--- a/systems/rendering/multibody_position_to_geometry_pose.cc
+++ b/systems/rendering/multibody_position_to_geometry_pose.cc
@@ -58,7 +58,7 @@ void MultibodyPositionToGeometryPose<T>::Configure(bool input_multibody_state) {
   this->DeclareAbstractOutputPort(
       "geometry_pose",
       [this]() {
-        return this->plant_.get_geometry_poses_output_port().Allocate();
+        return this->plant_.get_geometry_pose_output_port().Allocate();
       },
       [this](const Context<T>& context, AbstractValue* output) {
         return this->CalcGeometryPose(context, output);
@@ -81,7 +81,7 @@ void MultibodyPositionToGeometryPose<T>::CalcGeometryPose(
       this->get_input_port().Eval(context).head(plant_.num_positions()));
 
   // Evaluate the plant's output port.
-  plant_.get_geometry_poses_output_port().Calc(*plant_context_, output);
+  plant_.get_geometry_pose_output_port().Calc(*plant_context_, output);
 }
 
 template class MultibodyPositionToGeometryPose<double>;

--- a/visualization/inertia_visualizer.cc
+++ b/visualization/inertia_visualizer.cc
@@ -100,7 +100,7 @@ const InertiaVisualizer<T>& InertiaVisualizer<T>::AddToBuilder(
   auto result =
       builder->template AddSystem<InertiaVisualizer<T>>(plant, scene_graph);
   result->set_name("inertia_visualizer");
-  builder->Connect(plant.get_geometry_poses_output_port(),
+  builder->Connect(plant.get_geometry_pose_output_port(),
                    result->get_input_port());
   builder->Connect(result->get_output_port(),
                    scene_graph->get_source_pose_port(result->source_id_));


### PR DESCRIPTION
The output port named foo_bar is calculated via a member function named CalcFooBarOutput, with the output argument named 'output'.

Always use member functions for output ports, not gratuitously long lambdas with actual logic hiding inside of them.

Move the documentation about a ports' semantics from the private calc functions where nobody can find it, to the Doxygen public exposition of the ports. (In most cases it was already there, so we just remove the copy-pasted information.)

Deprecate some mis-matched port names and port getter names.

---

Towards #21597 and therefore also #20545.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21609)
<!-- Reviewable:end -->
