### PR TITLE
Add bindings for systems/estimators and acrobot w/ encoders example

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -438,6 +438,7 @@ PYI_FILES = [
     "pydrake/symbolic.pyi",
     "pydrake/systems/analysis.pyi",
     "pydrake/systems/controllers.pyi",
+    "pydrake/systems/estimators.pyi",
     "pydrake/systems/framework.pyi",
     "pydrake/systems/lcm.pyi",
     "pydrake/systems/primitives.pyi",

--- a/bindings/pydrake/examples/examples_py_acrobot.cc
+++ b/bindings/pydrake/examples/examples_py_acrobot.cc
@@ -55,6 +55,19 @@ void DefineExamplesAcrobot(py::module m) {
           py_rvp::reference_internal, py::arg("context"),
           doc.AcrobotPlant.get_mutable_parameters.doc);
 
+  py::class_<AcrobotWEncoder<T>, Diagram<T>>(
+      m, "AcrobotWEncoder", doc.AcrobotWEncoder.doc)
+      .def(py::init<bool>(), py::arg("acrobot_state_as_second_output") = false,
+          doc.AcrobotWEncoder.ctor.doc)
+      .def("acrobot_plant", &AcrobotWEncoder<T>::acrobot_plant,
+          py_rvp::reference_internal, doc.AcrobotWEncoder.acrobot_plant.doc)
+      .def("get_mutable_acrobot_state",
+          &AcrobotWEncoder<T>::get_mutable_acrobot_state,
+          py_rvp::reference_internal, py::arg("context"),
+          // Keep alive, ownership: `return` keeps `context` alive.
+          py::keep_alive<0, 1>(),
+          doc.AcrobotWEncoder.get_mutable_acrobot_state.doc);
+
   py::class_<AcrobotSpongController<T>, LeafSystem<T>>(
       m, "AcrobotSpongController", doc.AcrobotSpongController.doc)
       .def(py::init<>(), doc.AcrobotSpongController.ctor.doc)

--- a/bindings/pydrake/examples/test/acrobot_test.py
+++ b/bindings/pydrake/examples/test/acrobot_test.py
@@ -7,6 +7,7 @@ from pydrake.examples import (
     AcrobotPlant,
     AcrobotSpongController,
     AcrobotState,
+    AcrobotWEncoder,
     SpongControllerParams,
 )
 from pydrake.geometry import SceneGraph
@@ -110,6 +111,18 @@ class TestAcrobot(unittest.TestCase):
         self.assertLessEqual(acrobot.EvalPotentialEnergy(context)
                              + acrobot.EvalKineticEnergy(context),
                              initial_total_energy)
+
+    def test_acrobot_w_encoder(self):
+        acrobot_w_encoder = AcrobotWEncoder()
+        self.assertEqual(acrobot_w_encoder.num_output_ports(), 1)
+        acrobot_w_encoder = AcrobotWEncoder(
+            acrobot_state_as_second_output=True)
+        self.assertEqual(acrobot_w_encoder.num_output_ports(), 2)
+        self.assertIsInstance(acrobot_w_encoder.acrobot_plant(), AcrobotPlant)
+        context = acrobot_w_encoder.CreateDefaultContext()
+        self.assertIsInstance(
+            acrobot_w_encoder.get_mutable_acrobot_state(context=context),
+            AcrobotState)
 
 
 class TestAcrobotSpongController(unittest.TestCase):

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -130,6 +130,20 @@ drake_pybind_library(
 )
 
 drake_pybind_library(
+    name = "estimators_py",
+    cc_deps = [
+        "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:wrap_pybind",
+    ],
+    cc_srcs = ["estimators_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":framework_py",
+        ":module_py",
+    ],
+)
+
+drake_pybind_library(
     name = "rendering_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
@@ -149,6 +163,7 @@ drake_pybind_library(
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
+        "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_pybind",
         "//bindings/pydrake/common:serialize_pybind",
@@ -163,6 +178,7 @@ drake_pybind_library(
         "sensors_py_image_io.cc",
         "sensors_py_lcm.cc",
         "sensors_py_rgbd.cc",
+        "sensors_py_rotary_encoders.cc",
     ],
     package_info = PACKAGE_INFO,
     py_deps = [
@@ -281,6 +297,7 @@ drake_py_library(
 PY_LIBRARIES_WITH_INSTALL = [
     ":analysis_py",
     ":controllers_py",
+    ":estimators_py",
     ":framework_py",
     ":lcm_py",
     ":primitives_py",
@@ -444,6 +461,15 @@ drake_py_unittest(
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",
         "//bindings/pydrake/multibody:tree_py",
+    ],
+)
+
+drake_py_unittest(
+    name = "estimators_test",
+    deps = [
+        ":estimators_py",
+        ":primitives_py",
+        "//bindings/pydrake/examples",
     ],
 )
 

--- a/bindings/pydrake/systems/all.py
+++ b/bindings/pydrake/systems/all.py
@@ -1,6 +1,7 @@
 from .analysis import *
 from .controllers import *
 from .drawing import *
+from .estimators import *
 from .framework import *
 from .lcm import *
 from .perception import *

--- a/bindings/pydrake/systems/estimators_py.cc
+++ b/bindings/pydrake/systems/estimators_py.cc
@@ -1,0 +1,69 @@
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/systems/estimators/kalman_filter.h"
+#include "drake/systems/estimators/luenberger_observer.h"
+
+namespace drake {
+namespace pydrake {
+
+PYBIND11_MODULE(estimators, m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::systems::estimators;
+  constexpr auto& doc = pydrake_doc.drake.systems.estimators;
+
+  using drake::systems::Context;
+  using drake::systems::LeafSystem;
+  using drake::systems::System;
+
+  py::module::import("pydrake.systems.framework");
+
+  {
+    using Class = LuenbergerObserver<double>;
+    constexpr auto& cls_doc = doc.LuenbergerObserver;
+    py::class_<Class, LeafSystem<double>>(m, "LuenbergerObserver", cls_doc.doc)
+        .def(py::init<const System<double>&, const Context<double>&,
+                 const Eigen::Ref<const Eigen::MatrixXd>&>(),
+            py::arg("observed_system"), py::arg("observed_system_context"),
+            py::arg("observer_gain"), cls_doc.ctor.doc)
+        .def("get_observed_system_input_input_port",
+            &Class::get_observed_system_input_input_port,
+            py_rvp::reference_internal,
+            cls_doc.get_observed_system_input_input_port.doc)
+        .def("get_observed_system_output_input_port",
+            &Class::get_observed_system_output_input_port,
+            py_rvp::reference_internal,
+            cls_doc.get_observed_system_output_input_port.doc)
+        .def("get_estimated_state_output_port",
+            &Class::get_estimated_state_output_port, py_rvp::reference_internal,
+            cls_doc.get_estimated_state_output_port.doc)
+        .def("observer_gain", &Class::observer_gain, py_rvp::reference_internal,
+            cls_doc.observer_gain.doc)
+        .def("L", &Class::L, py_rvp::reference_internal, cls_doc.L.doc);
+  }
+
+  m.def("SteadyStateKalmanFilter",
+      py::overload_cast<const Eigen::Ref<const Eigen::MatrixXd>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&>(&SteadyStateKalmanFilter),
+      py::arg("A"), py::arg("C"), py::arg("W"), py::arg("V"),
+      doc.SteadyStateKalmanFilter.doc_ACWV);
+
+  m.def("SteadyStateKalmanFilter",
+      py::overload_cast<std::unique_ptr<systems::LinearSystem<double>>,
+          const Eigen::Ref<const Eigen::MatrixXd>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&>(&SteadyStateKalmanFilter),
+      py::arg("system"), py::arg("W"), py::arg("V"),
+      doc.SteadyStateKalmanFilter.doc_linear_system);
+
+  m.def("SteadyStateKalmanFilter",
+      py::overload_cast<std::unique_ptr<System<double>>,
+          std::unique_ptr<Context<double>>,
+          const Eigen::Ref<const Eigen::MatrixXd>&,
+          const Eigen::Ref<const Eigen::MatrixXd>&>(&SteadyStateKalmanFilter),
+      py::arg("system"), py::arg("context"), py::arg("W"), py::arg("V"),
+      doc.SteadyStateKalmanFilter.doc_system);
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -18,6 +18,7 @@ PYBIND11_MODULE(sensors, m) {
   internal::DefineSensorsRgbd(m);
   internal::DefineSensorsCameraConfig(m);
   internal::DefineSensorsLcm(m);
+  internal::DefineSensorsRotaryEncoders(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/sensors_py.h
+++ b/bindings/pydrake/systems/sensors_py.h
@@ -29,6 +29,9 @@ void DefineSensorsLcm(py::module m);
 /* Defines bindings per sensors_py_rgbd.cc. */
 void DefineSensorsRgbd(py::module m);
 
+/* Defines bindings per sensors_py_rotary_encoders.cc. */
+void DefineSensorsRotaryEncoders(py::module m);
+
 /* PixelTypeList provides all of the enumerated PixelType values. */
 template <typename T, T kPixelType>
 using PixelTypeConstant = std::integral_constant<T, kPixelType>;

--- a/bindings/pydrake/systems/sensors_py_rotary_encoders.cc
+++ b/bindings/pydrake/systems/sensors_py_rotary_encoders.cc
@@ -1,0 +1,50 @@
+#include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/systems/sensors_py.h"
+#include "drake/systems/sensors/rotary_encoders.h"
+
+namespace drake {
+namespace pydrake {
+namespace internal {
+namespace {
+
+template <typename T>
+void DoScalarDependentDefinitions(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
+
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::systems::sensors;
+  constexpr auto& doc = pydrake_doc.drake.systems.sensors;
+
+  {
+    using Class = RotaryEncoders<T>;
+    constexpr auto& cls_doc = doc.RotaryEncoders;
+    DefineTemplateClassWithDefault<RotaryEncoders<T>, systems::VectorSystem<T>>(
+        m, "RotaryEncoders", param, doc.RotaryEncoders.doc)
+        .def(py::init<const std::vector<int>&>(),
+            py::arg("ticks_per_revolution"), cls_doc.ctor.doc_1args)
+        .def(py::init<int, const std::vector<int>&>(),
+            py::arg("input_port_size"), py::arg("input_vector_indices"),
+            cls_doc.ctor.doc_2args)
+        .def(py::init<int, const std::vector<int>&, const std::vector<int>&>(),
+            py::arg("input_port_size"), py::arg("input_vector_indices"),
+            py::arg("ticks_per_revolution"), cls_doc.ctor.doc_3args)
+        .def("set_calibration_offsets", &Class::set_calibration_offsets,
+            py::arg("context"), py::arg("calibration_offsets"),
+            cls_doc.set_calibration_offsets.doc)
+        .def("get_calibration_offsets", &Class::get_calibration_offsets,
+            py::arg("context"), py_rvp::copy,
+            cls_doc.get_calibration_offsets.doc);
+  }
+}
+
+}  // namespace
+
+void DefineSensorsRotaryEncoders(py::module m) {
+  type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
+      CommonScalarPack{});
+}
+
+}  // namespace internal
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/systems/test/estimators_test.py
+++ b/bindings/pydrake/systems/test/estimators_test.py
@@ -1,0 +1,47 @@
+import pydrake.systems.estimators as mut
+
+import unittest
+
+import numpy as np
+
+from pydrake.examples import PendulumPlant
+from pydrake.systems.primitives import LinearSystem
+
+
+class TestEstimators(unittest.TestCase):
+
+    def test_luenberger_observer(self):
+        plant = PendulumPlant()
+        context = plant.CreateDefaultContext()
+        L = np.eye(2)
+        observer = mut.LuenbergerObserver(
+            observed_system=plant,
+            observed_system_context=context,
+            observer_gain=L)
+        port = observer.get_observed_system_input_input_port()
+        self.assertEqual(port.size(), 1)
+        port = observer.get_observed_system_output_input_port()
+        self.assertEqual(port.size(), 2)
+        port = observer.get_estimated_state_output_port()
+        self.assertEqual(port.size(), 2)
+        np.testing.assert_array_equal(L, observer.observer_gain())
+        np.testing.assert_array_equal(L, observer.L())
+
+    def test_steady_state_kalman_filter(self):
+        A = np.array([[0., 1.], [-10., -0.1]])
+        C = np.eye(2)
+        W = np.eye(2)
+        V = np.eye(2)
+        L = mut.SteadyStateKalmanFilter(A=A, C=C, W=W, V=V)
+        self.assertEqual(L.shape, (2, 2))
+
+        plant = LinearSystem(A=A, C=C)
+        filter = mut.SteadyStateKalmanFilter(system=plant, W=W, V=V)
+        self.assertIsInstance(filter, mut.LuenbergerObserver)
+
+        plant = PendulumPlant()
+        context = plant.CreateDefaultContext()
+        plant.get_input_port().FixValue(context, [0.])
+        filter = mut.SteadyStateKalmanFilter(
+            system=plant, context=context, W=W, V=V)
+        self.assertIsInstance(filter, mut.LuenbergerObserver)

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -8,6 +8,7 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.common.value import AbstractValue, Value
 from pydrake.geometry import (
@@ -573,3 +574,26 @@ class TestSensors(unittest.TestCase):
             publish_period=0.125,
             start_time=0.0)
         self.assertIsNotNone(input_port)
+
+    @numpy_compare.check_all_types
+    def test_rotary_encoders(self, T):
+        encoders = mut.RotaryEncoders_[T](ticks_per_revolution=[100, 200])
+        self.assertEqual(encoders.get_input_port().size(), 2)
+
+        encoders = mut.RotaryEncoders_[T](
+            input_port_size=5, input_vector_indices=[0, 2])
+        self.assertEqual(encoders.get_input_port().size(), 5)
+
+        encoders = mut.RotaryEncoders_[T](
+            input_port_size=5,
+            input_vector_indices=[0, 2],
+            ticks_per_revolution=[100, 200])
+        self.assertEqual(encoders.get_input_port().size(), 5)
+
+        context = encoders.CreateDefaultContext()
+        offsets = [T(0.1), T(0.2)]
+        encoders.set_calibration_offsets(
+            context=context, calibration_offsets=offsets)
+        numpy_compare.assert_equal(
+            encoders.get_calibration_offsets(context=context),
+            offsets)

--- a/systems/estimators/kalman_filter.h
+++ b/systems/estimators/kalman_filter.h
@@ -33,6 +33,7 @@ namespace estimators {
 ///
 /// @throws std::exception if V is not positive definite.
 /// @ingroup estimator_systems
+/// @pydrake_mkdoc_identifier{ACWV}
 ///
 Eigen::MatrixXd SteadyStateKalmanFilter(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
@@ -53,6 +54,7 @@ Eigen::MatrixXd SteadyStateKalmanFilter(
 ///
 /// @throws std::exception if V is not positive definite.
 /// @ingroup estimator_systems
+/// @pydrake_mkdoc_identifier{linear_system}
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     std::unique_ptr<LinearSystem<double>> system,
     const Eigen::Ref<const Eigen::MatrixXd>& W,
@@ -85,6 +87,7 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
 ///
 /// @throws std::exception if V is not positive definite.
 /// @ingroup estimator_systems
+/// @pydrake_mkdoc_identifier{system}
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     std::unique_ptr<System<double>> system,
     std::unique_ptr<Context<double>> context,

--- a/systems/estimators/luenberger_observer.h
+++ b/systems/estimators/luenberger_observer.h
@@ -58,6 +58,7 @@ class LuenbergerObserver final: public LeafSystem<T> {
                      const Eigen::Ref<const Eigen::MatrixXd>& observer_gain);
 
   /// Constructs the observer, taking ownership of `observed_system`.
+  /// @exclude_from_pydrake_mkdoc{This constructor is not bound.}
   LuenbergerObserver(std::unique_ptr<System<T>> observed_system,
                      const Context<T>& observed_system_context,
                      const Eigen::Ref<const Eigen::MatrixXd>& observer_gain);

--- a/systems/primitives/pass_through.h
+++ b/systems/primitives/pass_through.h
@@ -37,7 +37,8 @@ namespace systems {
 /// - y
 /// @endsystem
 ///
-/// @tparam_default_scalar @ingroup primitive_systems
+/// @tparam_default_scalar
+/// @ingroup primitive_systems
 template <typename T>
 class PassThrough final : public LeafSystem<T> {
  public:

--- a/systems/sensors/rotary_encoders.cc
+++ b/systems/sensors/rotary_encoders.cc
@@ -99,7 +99,7 @@ void RotaryEncoders<T>::DoCalcVectorOutput(
 template <typename T>
 void RotaryEncoders<T>::set_calibration_offsets(
     Context<T>* context,
-    const Eigen::Ref<VectorX<T>>& calibration_offsets) const {
+    const Eigen::Ref<const VectorX<T>>& calibration_offsets) const {
   DRAKE_DEMAND(calibration_offsets.rows() == num_encoders_);
   context->get_mutable_numeric_parameter(0).set_value(calibration_offsets);
 }

--- a/systems/sensors/rotary_encoders.h
+++ b/systems/sensors/rotary_encoders.h
@@ -26,6 +26,7 @@ namespace sensors {
 /// - y0
 /// @endsystem
 ///
+/// @tparam_default_scalar
 /// @ingroup sensor_systems
 template <typename T>
 class RotaryEncoders final : public VectorSystem<T> {
@@ -56,7 +57,7 @@ class RotaryEncoders final : public VectorSystem<T> {
   /// Set the calibration offset parameters.
   void set_calibration_offsets(
       Context<T>* context,
-      const Eigen::Ref<VectorX<T>>& calibration_offsets) const;
+      const Eigen::Ref<const VectorX<T>>& calibration_offsets) const;
 
   /// Retrieve the calibration offset parameters.
   const VectorX<T>& get_calibration_offsets(const Context<T>& context) const;
@@ -81,3 +82,6 @@ class RotaryEncoders final : public VectorSystem<T> {
 }  // namespace sensors
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::sensors::RotaryEncoders)


### PR DESCRIPTION
This PR adds the missing bindings required to port the examples/acrobot/run_lqr_w_estimator.cc example to python.

+@joemasterjohn for feature review, please.
(I'm slowing landing the dev branches remaining from my teaching this spring)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21610)
<!-- Reviewable:end -->
