### PR TITLE
Parse Lorentz cone constraints from formula

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1027,6 +1027,14 @@ void BindMathematicalProgram(py::module m) {
           doc.MathematicalProgram.AddQuadraticConstraint.doc_4args)
       .def("AddLorentzConeConstraint",
           static_cast<Binding<LorentzConeConstraint> (MathematicalProgram::*)(
+              const symbolic::Formula&, LorentzConeConstraint::EvalType, double,
+              double)>(&MathematicalProgram::AddLorentzConeConstraint),
+          py::arg("f"),
+          py::arg("eval_type") = LorentzConeConstraint::EvalType::kConvexSmooth,
+          py::arg("psd_tol") = 1e-8, py::arg("coefficient_tol") = 1e-8,
+          doc.MathematicalProgram.AddLorentzConeConstraint.doc_formula)
+      .def("AddLorentzConeConstraint",
+          static_cast<Binding<LorentzConeConstraint> (MathematicalProgram::*)(
               const Eigen::Ref<const VectorX<drake::symbolic::Expression>>&,
               LorentzConeConstraint::EvalType)>(
               &MathematicalProgram::AddLorentzConeConstraint),

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1187,9 +1187,14 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddCost(z[0])
 
         # Add LorentzConeConstraints
+        prog.AddLorentzConeConstraint(
+            f=(z[0] >= np.linalg.norm(x)),
+            eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth,
+            psd_tol=1e-7,
+            coefficient_tol=1e-7)
         prog.AddLorentzConeConstraint(np.array([0*x[0]+1, x[0]-1, x[1]-1]))
         prog.AddLorentzConeConstraint(np.array([z[0], x[0], x[1]]))
-        self.assertEqual(len(prog.lorentz_cone_constraints()), 2)
+        self.assertEqual(len(prog.lorentz_cone_constraints()), 3)
 
         # Test result
         # The default initial guess is [0, 0, 0]. This initial guess is bad

--- a/common/symbolic/decompose.cc
+++ b/common/symbolic/decompose.cc
@@ -313,7 +313,7 @@ int DecomposeAffineExpression(
   *constant_term = 0;
   if (!e.is_polynomial()) {
     std::ostringstream oss;
-    oss << "Expression " << e << "is not a polynomial.\n";
+    oss << "Expression " << e << " is not a polynomial.\n";
     throw std::runtime_error(oss.str());
   }
   const symbolic::Polynomial poly{e};

--- a/common/symbolic/decompose.h
+++ b/common/symbolic/decompose.h
@@ -98,7 +98,10 @@ void DecomposeQuadraticPolynomial(
 @param[in] v A vector of affine expressions
 @param[out] A The matrix containing the linear coefficients.
 @param[out] b The vector containing all the constant terms.
-@param[out] vars All variables. */
+@param[out] vars All variables.
+
+@throws std::exception if the input expressions are not affine.
+*/
 void DecomposeAffineExpressions(
     const Eigen::Ref<const VectorX<symbolic::Expression>>& v,
     Eigen::MatrixXd* A, Eigen::VectorXd* b, VectorX<Variable>* vars);
@@ -128,7 +131,11 @@ that map_var_to_index[vi.get_ID()] = i.
 @param[out] coeffs A row vector. coeffs(i) = ci.
 @param[out] constant_term c0 in the equation above.
 @return num_variable. Number of variables in the expression. 2 * x(0) + 3 has 1
-variable, 2 * x(0) + 3 * x(1) - 2 * x(0) has 1 variable. */
+variable; 2 * x(0) + 3 * x(1) - 2 * x(0) has 1 variable, since the x(0) term
+cancels.
+
+@throws std::exception if the input expression is not affine.
+*/
 int DecomposeAffineExpression(
     const symbolic::Expression& e,
     const std::unordered_map<symbolic::Variable::Id, int>& map_var_to_index,

--- a/solvers/create_constraint.h
+++ b/solvers/create_constraint.h
@@ -205,6 +205,15 @@ ParseLinearEqualityConstraint(const Eigen::MatrixBase<DerivedV>& V,
  * Assist MathematicalProgram::AddLorentzConeConstraint(...).
  */
 [[nodiscard]] Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
+    const symbolic::Formula& f,
+    LorentzConeConstraint::EvalType eval_type =
+        LorentzConeConstraint::EvalType::kConvexSmooth,
+    double psd_tol = 1e-8, double coefficient_tol = 1e-8);
+
+/*
+ * Assist MathematicalProgram::AddLorentzConeConstraint(...).
+ */
+[[nodiscard]] Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const Eigen::Ref<const VectorX<symbolic::Expression>>& v,
     LorentzConeConstraint::EvalType eval_type =
         LorentzConeConstraint::EvalType::kConvexSmooth);

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -974,6 +974,13 @@ Binding<LorentzConeConstraint> MathematicalProgram::AddConstraint(
 }
 
 Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
+    const symbolic::Formula& f, LorentzConeConstraint::EvalType eval_type,
+    double psd_tol, double coefficient_tol) {
+  return AddConstraint(internal::ParseLorentzConeConstraint(
+      f, eval_type, psd_tol, coefficient_tol));
+}
+
+Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
     const Eigen::Ref<const VectorX<Expression>>& v,
     LorentzConeConstraint::EvalType eval_type) {
   return AddConstraint(internal::ParseLorentzConeConstraint(v, eval_type));

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2087,6 +2087,27 @@ class MathematicalProgram {
       const Binding<LorentzConeConstraint>& binding);
 
   /**
+   * Adds a Lorentz cone constraint of the form Ax+b >= |Cx+d|₂ from a symbolic
+   * formula with one side which can be decomposed into sqrt((Cx+d)'(Cx+d)).
+   *
+   * @param eval_type The evaluation type when evaluating the lorentz cone
+   * constraint in generic optimization. Refer to
+   * LorentzConeConstraint::EvalType for more details.
+   *
+   * See symbolic::DecomposeL2NormExpression for details on the tolerance
+   * parameters, @p psd_tol and @p coefficient_tol. Consider using the overload
+   * which takes a vector of expressions to avoid the numerical decomposition.
+   *
+   * @throws std::exception if @p f cannot be decomposed into a Lorentz cone.
+   * @pydrake_mkdoc_identifier{formula}
+   */
+  Binding<LorentzConeConstraint> AddLorentzConeConstraint(
+      const symbolic::Formula& f,
+      LorentzConeConstraint::EvalType eval_type =
+          LorentzConeConstraint::EvalType::kConvexSmooth, double psd_tol = 1e-8,
+                                    double coefficient_tol = 1e-8);
+
+  /**
    * Adds Lorentz cone constraint referencing potentially a subset of the
    * decision variables.
    * @param v An Eigen::Vector of symbolic::Expression. Constraining that


### PR DESCRIPTION
Now we can write, e.g.
```
prog.AddConstraint(y[0] >= np.linalg.norm(x))
```
and get a Lorentz cone constraint back out.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21612)
<!-- Reviewable:end -->
