### PR TITLE
[multibody] HydroelasticContactInfo<Expression> is empty

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -91,10 +91,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
     constexpr auto& cls_doc = doc.HydroelasticContactInfo;
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "HydroelasticContactInfo", param, cls_doc.doc);
-    cls  // BR
-        .def("contact_surface", &Class::contact_surface,
-            cls_doc.contact_surface.doc)
-        .def("F_Ac_W", &Class::F_Ac_W, cls_doc.F_Ac_W.doc);
+    if constexpr (!std::is_same_v<T, symbolic::Expression>) {
+      cls  // BR
+          .def("contact_surface", &Class::contact_surface,
+              cls_doc.contact_surface.doc)
+          .def("F_Ac_W", &Class::F_Ac_W, cls_doc.F_Ac_W.doc);
+    }
     DefCopyAndDeepCopy(&cls);
     AddValueInstantiation<Class>(m);
   }

--- a/geometry/proximity/polygon_surface_mesh.cc
+++ b/geometry/proximity/polygon_surface_mesh.cc
@@ -37,6 +37,22 @@ void PolygonSurfaceMesh<T>::TransformVertices(const RigidTransform<T>& X_NM) {
 }
 
 template <typename T>
+void PolygonSurfaceMesh<T>::ReverseFaceWinding() {
+  for (const int f_index : poly_indices_) {
+    const int v_count = face_data_[f_index];
+    /* The indices before and after the first and last entries.  */
+    int f_0 = f_index;
+    int f_n = f_index + v_count + 1;
+    for (int i = 0; i < v_count / 2; ++i) {
+      std::swap(face_data_[++f_0], face_data_[--f_n]);
+    }
+  }
+  for (auto& n : face_normals_) {
+    n = -n;
+  }
+}
+
+template <typename T>
 std::pair<Vector3<T>, Vector3<T>> PolygonSurfaceMesh<T>::CalcBoundingBox()
     const {
   Vector3<T> min_extent =

--- a/geometry/proximity/polygon_surface_mesh.h
+++ b/geometry/proximity/polygon_surface_mesh.h
@@ -191,34 +191,8 @@ class PolygonSurfaceMesh {
    initial frame M to the new frame N. */
   void TransformVertices(const math::RigidTransform<T>& X_NM);
 
-  // TODO(SeanCurtis-TRI): ContactResultsToLcm and HydroelasticContactInfo
-  //  ostensibly support symbolic::Expression. However, the ContactSurface that
-  //  they both interact with *doesn't*. Their unit tests blindly assume that
-  //  there is full scalar support. ContactSurface calls ReverseFaceWinding so,
-  //  for the offending unit tests to maintain the illusion of support, this
-  //  must be defined in the header so they can compile and link -- although,
-  //  the resulting ContactSurface<symbolic::Expression> is only a partial
-  //  implementation and can't do any interesting math, this allows the tests
-  //  to create the type they need. Ideally, the tests wouldn't be expressed
-  //  in a way that suggests non-existent support is otherwise possible.
-  //  Alternatively, there's a question about whether ContactSurface should be
-  //  calling this method *at all*. Choosing that it's not necessary would
-  //  likewise enable this implementation to move to the .cc file.
   /** (Internal use only) Reverses the ordering of all the faces' indices. */
-  void ReverseFaceWinding() {
-    for (const int f_index : poly_indices_) {
-      const int v_count = face_data_[f_index];
-      /* The indices before and after the first and last entries.  */
-      int f_0 = f_index;
-      int f_n = f_index + v_count + 1;
-      for (int i = 0; i < v_count / 2; ++i) {
-        std::swap(face_data_[++f_0], face_data_[--f_n]);
-      }
-    }
-    for (auto& n : face_normals_) {
-      n = -n;
-    }
-  }
+  void ReverseFaceWinding();
 
   /** Returns the number of polygonal elements in the mesh. */
   int num_faces() const { return static_cast<int>(poly_indices_.size()); }

--- a/geometry/proximity/triangle_surface_mesh.cc
+++ b/geometry/proximity/triangle_surface_mesh.cc
@@ -6,6 +6,16 @@ namespace drake {
 namespace geometry {
 
 template <typename T>
+void TriangleSurfaceMesh<T>::ReverseFaceWinding() {
+  for (auto& f : triangles_) {
+    f.ReverseWinding();
+  }
+  for (auto& n : face_normals_) {
+    n = -n;
+  }
+}
+
+template <typename T>
 void TriangleSurfaceMesh<T>::SetAllPositions(
     const Eigen::Ref<const VectorX<T>>& p_MVs) {
   if (p_MVs.size() != 3 * num_vertices()) {

--- a/geometry/proximity/triangle_surface_mesh.h
+++ b/geometry/proximity/triangle_surface_mesh.h
@@ -203,14 +203,7 @@ class TriangleSurfaceMesh {
   /** (Internal use only) Reverses the ordering of all the triangles' indices
    -- see SurfaceTriangle::ReverseWinding().
    */
-  void ReverseFaceWinding() {
-    for (auto& f : triangles_) {
-      f.ReverseWinding();
-    }
-    for (auto& n : face_normals_) {
-      n = -n;
-    }
-  }
+  void ReverseFaceWinding();
 
   /** Returns the number of triangles in the mesh.
    */

--- a/geometry/query_results/contact_surface.cc
+++ b/geometry/query_results/contact_surface.cc
@@ -10,6 +10,91 @@ using std::unique_ptr;
 using std::vector;
 
 template <typename T>
+ContactSurface<T>::ContactSurface(
+    GeometryId id_M, GeometryId id_N, MeshVariant mesh_W, FieldVariant e_MN,
+    std::unique_ptr<std::vector<Vector3<T>>> grad_eM_W,
+    std::unique_ptr<std::vector<Vector3<T>>> grad_eN_W, int)
+    : id_M_(id_M),
+      id_N_(id_N),
+      mesh_W_(std::move(mesh_W)),
+      e_MN_(std::move(e_MN)),
+      grad_eM_W_(std::move(grad_eM_W)),
+      grad_eN_W_(std::move(grad_eN_W)) {
+  // If defined the gradient values must map 1-to-1 onto elements.
+  if (is_triangle()) {
+    DRAKE_THROW_UNLESS(grad_eM_W_ == nullptr ||
+                       static_cast<int>(grad_eM_W_->size()) ==
+                           tri_mesh_W().num_elements());
+    DRAKE_THROW_UNLESS(grad_eN_W_ == nullptr ||
+                       static_cast<int>(grad_eN_W_->size()) ==
+                           tri_mesh_W().num_elements());
+  } else {
+    DRAKE_THROW_UNLESS(grad_eM_W_ == nullptr ||
+                       static_cast<int>(grad_eM_W_->size()) ==
+                           poly_mesh_W().num_elements());
+    DRAKE_THROW_UNLESS(grad_eN_W_ == nullptr ||
+                       static_cast<int>(grad_eN_W_->size()) ==
+                           poly_mesh_W().num_elements());
+  }
+  if constexpr (scalar_predicate<T>::is_bool) {
+    if (id_N_ < id_M_) SwapMAndN();
+  }
+}
+
+template <typename T>
+void ContactSurface<T>::SwapMAndN() {
+  std::swap(id_M_, id_N_);
+
+  // TODO(SeanCurtis-TRI): Determine if this work is necessary. It is neither
+  // documented nor tested that the face winding is guaranteed to be one way
+  // or the other. Alternatively, this should be documented and tested.
+  std::visit(
+      [](auto&& mesh) {
+        mesh->ReverseFaceWinding();
+      },
+      mesh_W_);
+
+  // Note: the scalar field does not depend on the order of M and N.
+  std::swap(grad_eM_W_, grad_eN_W_);
+}
+
+template <typename T>
+ContactSurface<T>::ContactSurface(const ContactSurface& surface) {
+  *this = surface;
+}
+
+template <typename T>
+ContactSurface<T>& ContactSurface<T>::operator=(const ContactSurface& surface) {
+  if (&surface == this) return *this;
+
+  id_M_ = surface.id_M_;
+  id_N_ = surface.id_N_;
+  if (surface.is_triangle()) {
+    mesh_W_ = std::make_unique<TriangleSurfaceMesh<T>>(surface.tri_mesh_W());
+    // We can't simply copy the mesh fields; the copies must contain pointers
+    // to the new mesh. So, we use CloneAndSetMesh() instead.
+    e_MN_ = surface.tri_e_MN().CloneAndSetMesh(&tri_mesh_W());
+  } else {
+    mesh_W_ = std::make_unique<PolygonSurfaceMesh<T>>(surface.poly_mesh_W());
+    // We can't simply copy the mesh fields; the copies must contain pointers
+    // to the new mesh. So, we use CloneAndSetMesh() instead.
+    e_MN_ = surface.poly_e_MN().CloneAndSetMesh(&poly_mesh_W());
+  }
+
+  if (surface.grad_eM_W_) {
+    grad_eM_W_ = std::make_unique<std::vector<Vector3<T>>>(*surface.grad_eM_W_);
+  }
+  if (surface.grad_eN_W_) {
+    grad_eN_W_ = std::make_unique<std::vector<Vector3<T>>>(*surface.grad_eN_W_);
+  }
+
+  return *this;
+}
+
+template <typename T>
+ContactSurface<T>::~ContactSurface() {}
+
+template <typename T>
 const Vector3<T>& ContactSurface<T>::EvaluateGradE_M_W(int index) const {
   if (grad_eM_W_ == nullptr) {
     throw std::runtime_error(

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -186,105 +186,110 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
 
   message.num_hydroelastic_contacts =
       contact_results.num_hydroelastic_contacts();
-  message.hydroelastic_contacts.resize(message.num_hydroelastic_contacts);
+  // When T = Expression, we skip this because HydroelasticContactInfo is
+  // empty.
+  if constexpr (scalar_predicate<T>::is_bool) {
+    message.hydroelastic_contacts.resize(message.num_hydroelastic_contacts);
+    for (int i = 0; i < contact_results.num_hydroelastic_contacts(); ++i) {
+      const HydroelasticContactInfo<T>& hydroelastic_contact_info =
+          contact_results.hydroelastic_contact_info(i);
+      const geometry::ContactSurface<T>& contact_surface =
+          hydroelastic_contact_info.contact_surface();
 
-  for (int i = 0; i < contact_results.num_hydroelastic_contacts(); ++i) {
-    const HydroelasticContactInfo<T>& hydroelastic_contact_info =
-        contact_results.hydroelastic_contact_info(i);
-    const geometry::ContactSurface<T>& contact_surface =
-        hydroelastic_contact_info.contact_surface();
+      lcmt_hydroelastic_contact_surface_for_viz& surface_message =
+          message.hydroelastic_contacts[i];
 
-    lcmt_hydroelastic_contact_surface_for_viz& surface_message =
-        message.hydroelastic_contacts[i];
+      // Get the two body names.
+      const FullBodyName& name1 =
+          geometry_id_to_body_name_map_.at(contact_surface.id_M());
+      surface_message.body1_name = name1.body;
+      surface_message.model1_name = name1.model;
+      surface_message.geometry1_name = name1.geometry;
+      surface_message.body1_unique = name1.body_name_is_unique;
+      surface_message.collision_count1 = name1.geometry_count;
 
-    // Get the two body names.
-    const FullBodyName& name1 =
-        geometry_id_to_body_name_map_.at(contact_surface.id_M());
-    surface_message.body1_name = name1.body;
-    surface_message.model1_name = name1.model;
-    surface_message.geometry1_name = name1.geometry;
-    surface_message.body1_unique = name1.body_name_is_unique;
-    surface_message.collision_count1 = name1.geometry_count;
+      const FullBodyName& name2 =
+          geometry_id_to_body_name_map_.at(contact_surface.id_N());
+      surface_message.body2_name = name2.body;
+      surface_message.model2_name = name2.model;
+      surface_message.geometry2_name = name2.geometry;
+      surface_message.body2_unique = name2.body_name_is_unique;
+      surface_message.collision_count2 = name2.geometry_count;
 
-    const FullBodyName& name2 =
-        geometry_id_to_body_name_map_.at(contact_surface.id_N());
-    surface_message.body2_name = name2.body;
-    surface_message.model2_name = name2.model;
-    surface_message.geometry2_name = name2.geometry;
-    surface_message.body2_unique = name2.body_name_is_unique;
-    surface_message.collision_count2 = name2.geometry_count;
+      // Resultant force quantities.
+      assign_double(surface_message.centroid_W, contact_surface.centroid());
+      assign_double(surface_message.force_C_W,
+                    hydroelastic_contact_info.F_Ac_W().translational());
+      assign_double(surface_message.moment_C_W,
+                    hydroelastic_contact_info.F_Ac_W().rotational());
 
-    // Resultant force quantities.
-    assign_double(surface_message.centroid_W, contact_surface.centroid());
-    assign_double(surface_message.force_C_W,
-                  hydroelastic_contact_info.F_Ac_W().translational());
-    assign_double(surface_message.moment_C_W,
-                  hydroelastic_contact_info.F_Ac_W().rotational());
+      // Write all quadrature points on the contact surface.
+      const std::vector<HydroelasticQuadraturePointData<T>>&
+          quadrature_point_data =
+              hydroelastic_contact_info.quadrature_point_data();
+      surface_message.num_quadrature_points = quadrature_point_data.size();
+      surface_message.quadrature_point_data.resize(
+          surface_message.num_quadrature_points);
 
-    // Write all quadrature points on the contact surface.
-    const std::vector<HydroelasticQuadraturePointData<T>>&
-        quadrature_point_data =
-            hydroelastic_contact_info.quadrature_point_data();
-    surface_message.num_quadrature_points = quadrature_point_data.size();
-    surface_message.quadrature_point_data.resize(
-        surface_message.num_quadrature_points);
+      for (int j = 0; j < surface_message.num_quadrature_points; ++j) {
+        lcmt_hydroelastic_quadrature_per_point_data_for_viz& quad_data_message =
+            surface_message.quadrature_point_data[j];
+        assign_double(quad_data_message.p_WQ, quadrature_point_data[j].p_WQ);
+        assign_double(quad_data_message.vt_BqAq_W,
+                      quadrature_point_data[j].vt_BqAq_W);
+        assign_double(quad_data_message.traction_Aq_W,
+                      quadrature_point_data[j].traction_Aq_W);
+      }
 
-    for (int j = 0; j < surface_message.num_quadrature_points; ++j) {
-      lcmt_hydroelastic_quadrature_per_point_data_for_viz& quad_data_message =
-          surface_message.quadrature_point_data[j];
-      assign_double(quad_data_message.p_WQ, quadrature_point_data[j].p_WQ);
-      assign_double(quad_data_message.vt_BqAq_W,
-                    quadrature_point_data[j].vt_BqAq_W);
-      assign_double(quad_data_message.traction_Aq_W,
-                    quadrature_point_data[j].traction_Aq_W);
+      // Now build the mesh.
+      const int num_vertices = contact_surface.num_vertices();
+      surface_message.num_vertices = num_vertices;
+      surface_message.p_WV.resize(num_vertices);
+      surface_message.pressure.resize(num_vertices);
+
+      if (contact_surface.is_triangle()) {
+        const auto& mesh_W = contact_surface.tri_mesh_W();
+        const auto& e_MN_W = contact_surface.tri_e_MN();
+
+        // Write vertices and per vertex pressure values.
+        for (int v = 0; v < num_vertices; ++v) {
+          const Vector3d p_WV = ExtractDoubleOrThrow(mesh_W.vertex(v));
+          surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
+          surface_message.pressure[v] =
+              ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
+        }
+
+        // Write faces.
+        surface_message.poly_data_int_count = mesh_W.num_triangles() * 4;
+        surface_message.poly_data.resize(surface_message.poly_data_int_count);
+        int index = -1;
+        for (int t = 0; t < mesh_W.num_triangles(); ++t) {
+          const geometry::SurfaceTriangle& tri = mesh_W.element(t);
+          surface_message.poly_data[++index] = 3;
+          surface_message.poly_data[++index] = tri.vertex(0);
+          surface_message.poly_data[++index] = tri.vertex(1);
+          surface_message.poly_data[++index] = tri.vertex(2);
+        }
+      } else {
+        // TODO(DamrongGuoy) Make sure the unit tests cover this specific code
+        //  path. It is currently uncovered.
+        const auto& mesh_W = contact_surface.poly_mesh_W();
+        const auto& e_MN_W = contact_surface.poly_e_MN();
+
+        // Write vertices and per vertex pressure values.
+        for (int v = 0; v < num_vertices; ++v) {
+          const Vector3d p_WV = ExtractDoubleOrThrow(mesh_W.vertex(v));
+          surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
+          surface_message.pressure[v] =
+              ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
+        }
+
+        surface_message.poly_data_int_count = mesh_W.face_data().size();
+        surface_message.poly_data = mesh_W.face_data();
+      }
     }
-
-    // Now build the mesh.
-    const int num_vertices = contact_surface.num_vertices();
-    surface_message.num_vertices = num_vertices;
-    surface_message.p_WV.resize(num_vertices);
-    surface_message.pressure.resize(num_vertices);
-
-    if (contact_surface.is_triangle()) {
-      const auto& mesh_W = contact_surface.tri_mesh_W();
-      const auto& e_MN_W = contact_surface.tri_e_MN();
-
-      // Write vertices and per vertex pressure values.
-      for (int v = 0; v < num_vertices; ++v) {
-        const Vector3d p_WV = ExtractDoubleOrThrow(mesh_W.vertex(v));
-        surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
-        surface_message.pressure[v] =
-            ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
-      }
-
-      // Write faces.
-      surface_message.poly_data_int_count = mesh_W.num_triangles() * 4;
-      surface_message.poly_data.resize(surface_message.poly_data_int_count);
-      int index = -1;
-      for (int t = 0; t < mesh_W.num_triangles(); ++t) {
-        const geometry::SurfaceTriangle& tri = mesh_W.element(t);
-        surface_message.poly_data[++index] = 3;
-        surface_message.poly_data[++index] = tri.vertex(0);
-        surface_message.poly_data[++index] = tri.vertex(1);
-        surface_message.poly_data[++index] = tri.vertex(2);
-      }
-    } else {
-      // TODO(DamrongGuoy) Make sure the unit tests cover this specific code
-      //  path. It is currently uncovered.
-      const auto& mesh_W = contact_surface.poly_mesh_W();
-      const auto& e_MN_W = contact_surface.poly_e_MN();
-
-      // Write vertices and per vertex pressure values.
-      for (int v = 0; v < num_vertices; ++v) {
-        const Vector3d p_WV = ExtractDoubleOrThrow(mesh_W.vertex(v));
-        surface_message.p_WV[v] = {p_WV.x(), p_WV.y(), p_WV.z()};
-        surface_message.pressure[v] =
-            ExtractDoubleOrThrow(e_MN_W.EvaluateAtVertex(v));
-      }
-
-      surface_message.poly_data_int_count = mesh_W.face_data().size();
-      surface_message.poly_data = mesh_W.face_data();
-    }
+  } else {
+    DRAKE_DEMAND(contact_results.num_hydroelastic_contacts() == 0);
   }
 }
 

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -498,7 +498,8 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
    number of faces discretizing the contact surface. */
   void CalcHydroelasticContactInfo(
       const systems::Context<T>& context,
-      std::vector<HydroelasticContactInfo<T>>* contact_info) const;
+      std::vector<HydroelasticContactInfo<T>>* contact_info) const
+    requires scalar_predicate<T>::is_bool;
 
   /* Eval version of CalcHydroelasticContactInfo() . */
   const std::vector<HydroelasticContactInfo<T>>& EvalHydroelasticContactInfo(

--- a/multibody/plant/geometry_contact_data.h
+++ b/multibody/plant/geometry_contact_data.h
@@ -14,6 +14,10 @@ consumed by MultibodyPlant. Depending on MbP's contact model and the proximity
 properties in the scene graph, one or the other vector might be guaranteed to be
 empty; e.g., even in kPoint only mode we still have a field named `surfaces` but
 it's always empty.
+
+When T = Expression, the class is specialized to omit some member data, because
+ContactSurface doesn't support Expression.
+
 @tparam_default_scalar */
 template <typename T>
 struct GeometryContactData {
@@ -21,6 +25,17 @@ struct GeometryContactData {
   std::vector<geometry::ContactSurface<T>> surfaces;
   // TODO(jwnimmer-tri) It seems to me like DeformableContact<T> should be
   // computed and cached here as well.
+};
+
+/* Full specialization of HydroelasticContactInfo for T = Expression. */
+template <>
+class GeometryContactData<symbolic::Expression> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryContactData);
+  GeometryContactData() = default;
+
+  using T = symbolic::Expression;
+  std::vector<geometry::PenetrationAsPointPair<T>> point_pairs;
 };
 
 }  // namespace internal

--- a/multibody/plant/hydroelastic_contact_info.h
+++ b/multibody/plant/hydroelastic_contact_info.h
@@ -31,6 +31,9 @@ namespace multibody {
  `contact_surface().id_M()` and `contact_surface().id_N()`) are attached to
  bodies A and B, respectively.
 
+ When T = Expression, the class is specialized to not contain any member data,
+ because ContactSurface doesn't support Expression.
+
  @tparam_default_scalar
  */
 template <typename T>
@@ -124,8 +127,8 @@ class HydroelasticContactInfo {
 
   ~HydroelasticContactInfo();
 
-  /// Returns a reference to the ContactSurface data structure. Note that
-  /// the mesh and gradient vector fields are expressed in the world frame.
+  /** Returns a reference to the ContactSurface data structure. Note that
+   the mesh and gradient vector fields are expressed in the world frame. */
   const geometry::ContactSurface<T>& contact_surface() const {
     if (std::holds_alternative<const geometry::ContactSurface<T>*>(
             contact_surface_)) {
@@ -136,17 +139,17 @@ class HydroelasticContactInfo {
     }
   }
 
-  /// Gets the intermediate data, including tractions, computed by the
-  /// quadrature process.
+  /** Gets the intermediate data, including tractions, computed by the
+   quadrature process. */
   const std::vector<HydroelasticQuadraturePointData<T>>& quadrature_point_data()
       const {
     return quadrature_point_data_;
   }
 
-  /// Gets the spatial force applied on body A, at the centroid point C of the
-  /// surface mesh M, and expressed in the world frame W. The position `p_WC` of
-  /// the centroid point C in the world frame W can be obtained with
-  /// `contact_surface().centroid()`.
+  /** Gets the spatial force applied on body A, at the centroid point C of the
+   surface mesh M, and expressed in the world frame W. The position `p_WC` of
+   the centroid point C in the world frame W can be obtained with
+   `contact_surface().centroid()`. */
   const SpatialForce<T>& F_Ac_W() const { return F_Ac_W_; }
 
  private:
@@ -161,6 +164,17 @@ class HydroelasticContactInfo {
   // The traction and slip velocity evaluated at each quadrature point.
   std::vector<HydroelasticQuadraturePointData<T>> quadrature_point_data_;
 };
+
+#ifndef __MKDOC_PY__
+/** Full specialization of HydroelasticContactInfo for T = Expression, with
+ no member data. */
+template <>
+class HydroelasticContactInfo<symbolic::Expression> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HydroelasticContactInfo);
+  HydroelasticContactInfo() = default;
+};
+#endif
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2607,7 +2607,9 @@ void MultibodyPlant<T>::CalcGeometryContactData(
     GeometryContactData<T>* result) const {
   this->ValidateContext(context);
   result->point_pairs.clear();
-  result->surfaces.clear();
+  if constexpr (scalar_predicate<T>::is_bool) {
+    result->surfaces.clear();
+  }
   if (num_collision_geometries() == 0) {
     return;
   }

--- a/multibody/plant/tamsi_driver.cc
+++ b/multibody/plant/tamsi_driver.cc
@@ -339,36 +339,45 @@ void TamsiDriver<T>::CalcAndAddSpatialContactForcesFromContactResults(
     spatial_contact_forces->at(bodyB.mobod_index()) += F_Bo_W;
   }
 
-  // Add contribution from hydroelastic contact.
-  for (int i = 0; i < contact_results.num_hydroelastic_contacts(); ++i) {
-    const HydroelasticContactInfo<T>& info =
-        contact_results.hydroelastic_contact_info(i);
+  // Add contribution from hydroelastic contact. When T = Expression, we skip
+  // this because HydroelasticContactInfo is empty.
+  if constexpr (scalar_predicate<T>::is_bool) {
+    for (int i = 0; i < contact_results.num_hydroelastic_contacts(); ++i) {
+      const HydroelasticContactInfo<T>& info =
+          contact_results.hydroelastic_contact_info(i);
 
-    const GeometryId geometryM_id = info.contact_surface().id_M();
-    const GeometryId geometryN_id = info.contact_surface().id_N();
-    const BodyIndex bodyA_index = manager().FindBodyByGeometryId(geometryM_id);
-    const BodyIndex bodyB_index = manager().FindBodyByGeometryId(geometryN_id);
-    const RigidBody<T>& bodyA = plant().get_body(bodyA_index);
-    const RigidBody<T>& bodyB = plant().get_body(bodyB_index);
+      const GeometryId geometryM_id = info.contact_surface().id_M();
+      const GeometryId geometryN_id = info.contact_surface().id_N();
+      const BodyIndex bodyA_index =
+          manager().FindBodyByGeometryId(geometryM_id);
+      const BodyIndex bodyB_index =
+          manager().FindBodyByGeometryId(geometryN_id);
+      const RigidBody<T>& bodyA = plant().get_body(bodyA_index);
+      const RigidBody<T>& bodyB = plant().get_body(bodyB_index);
 
-    // Spatial contact force at the centroid of the contact surface.
-    const SpatialForce<T>& F_Ac_W = info.F_Ac_W();
-    const Vector3<T>& p_WC = info.contact_surface().centroid();
+      // Spatial contact force at the centroid of the contact surface.
+      const SpatialForce<T>& F_Ac_W = info.F_Ac_W();
+      const Vector3<T>& p_WC = info.contact_surface().centroid();
 
-    // Contact spatial force on body A.
-    const RigidTransform<T>& X_WA = plant().EvalBodyPoseInWorld(context, bodyA);
-    const Vector3<T>& p_WA = X_WA.translation();
-    const Vector3<T> p_CA_W = p_WA - p_WC;
-    const SpatialForce<T> F_Ao_W = F_Ac_W.Shift(p_CA_W);
+      // Contact spatial force on body A.
+      const RigidTransform<T>& X_WA =
+          plant().EvalBodyPoseInWorld(context, bodyA);
+      const Vector3<T>& p_WA = X_WA.translation();
+      const Vector3<T> p_CA_W = p_WA - p_WC;
+      const SpatialForce<T> F_Ao_W = F_Ac_W.Shift(p_CA_W);
 
-    // Contact spatial force on body B.
-    const RigidTransform<T>& X_WB = plant().EvalBodyPoseInWorld(context, bodyB);
-    const Vector3<T>& p_WB = X_WB.translation();
-    const Vector3<T> p_CB_W = p_WB - p_WC;
-    const SpatialForce<T> F_Bo_W = -F_Ac_W.Shift(p_CB_W);
+      // Contact spatial force on body B.
+      const RigidTransform<T>& X_WB =
+          plant().EvalBodyPoseInWorld(context, bodyB);
+      const Vector3<T>& p_WB = X_WB.translation();
+      const Vector3<T> p_CB_W = p_WB - p_WC;
+      const SpatialForce<T> F_Bo_W = -F_Ac_W.Shift(p_CB_W);
 
-    spatial_contact_forces->at(bodyA.mobod_index()) += F_Ao_W;
-    spatial_contact_forces->at(bodyB.mobod_index()) += F_Bo_W;
+      spatial_contact_forces->at(bodyA.mobod_index()) += F_Ao_W;
+      spatial_contact_forces->at(bodyB.mobod_index()) += F_Bo_W;
+    }
+  } else {
+    DRAKE_DEMAND(contact_results.num_hydroelastic_contacts() == 0);
   }
 }
 


### PR DESCRIPTION
Towards #21597 and therefore also #20545.

The large chunks of code moved from h to cc file are unchanged.

The breaking change is that any users who were calling any accessor functions (e.g., the `F_Ac_W()` getter) with T=Expression will fail to compile now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21618)
<!-- Reviewable:end -->
