### PR TITLE
[tools] Skip kcov for non-small tests

### DIFF
--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -327,3 +327,23 @@ misleading. As of Ubuntu 22.04 and kcov 38, Python reports do not render
 coverage for multi-line statements properly. Statements that use delimiter
 pairs to span more than two lines, or statements that use string token pasting
 across multiple lines may be mistakenly shown as only partially executed.
+
+### Drake bazel rules and kcov
+
+Some Drake-specific bazel rules (e.g. `drake_cc_google_test`) use various
+heuristics to skip certain tests in `kcov` builds. This may hinder developers
+trying to use `kcov` locally on specific tests. For example:
+
+```
+bazel test --config=kcov //common:temp_directory_test
+```
+
+results in:
+```
+ERROR: No test targets were found, yet testing was requested
+```
+
+To force execution with kcov, add an empty `test_tag_filters` option:
+```
+bazel test --config=kcov --test_tag_filters= //common:temp_directory_test
+```

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -894,6 +894,12 @@ def drake_cc_googletest(
             "no_tsan",
             "no_ubsan",
         ]
+    else:
+        # kcov is only appropriate for small-sized unit tests. If a test needs
+        # a shard_count or a special timeout, we assume it is not small.
+        if "shard_count" in kwargs or "timeout" in kwargs:
+            new_tags = new_tags + ["no_kcov"]
+
     drake_cc_test(
         name = name,
         args = new_args,

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -193,6 +193,12 @@ def drake_py_unittest(
         fail("Changing srcs= is not allowed by drake_py_unittest." +
              " Use drake_py_test instead, if you need something weird.")
     srcs = ["test/%s.py" % name, helper]
+
+    # kcov is only appropriate for small-sized unit tests. If a test needs a
+    # shard_count or a special timeout, we assume it is not small.
+    if "shard_count" in kwargs or "timeout" in kwargs:
+        amend(kwargs, "tags", append = ["no_kcov"])
+
     drake_py_test(
         name = name,
         srcs = srcs,


### PR DESCRIPTION
This patch should mitigate some of the random timeouts occurring in kcov CI builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21620)
<!-- Reviewable:end -->
