### PR TITLE
[math] Rename fast_pose_composition sources for git history

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -330,7 +330,12 @@ drake_cc_library(
 
 drake_cc_library(
     name = "fast_pose_composition_functions",
-    srcs = ["fast_pose_composition_functions.cc"],
+    srcs = [
+        # TODO(jeremy.nimmer) For now, this filename is inconsistent with its
+        # library name. We will soon combine the two "fast pose" targets into
+        # one, using consistent naming.
+        "fast_pose_composition_functions_wrapper.cc",
+    ],
     hdrs = ["fast_pose_composition_functions.h"],
     interface_deps = [],
     deps = [":fast_pose_composition_functions_avx2_fma"],

--- a/math/fast_pose_composition_functions_wrapper.cc
+++ b/math/fast_pose_composition_functions_wrapper.cc
@@ -1,4 +1,6 @@
+// clang-format off
 #include "drake/math/fast_pose_composition_functions.h"
+// clang-format on
 
 #include <algorithm>
 #include <cassert>


### PR DESCRIPTION
We are going to combine both `fast_pose_composition_functions*.cc` implementations in a single file, using highway to dispatch to a target at runtime.  That means only one the two git histories of the `*.cc` files can survive.  I think we should keep the SIMD git history in preference to the portable-C git history, so we need to move the non-wanted file out of the way in preparation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21621)
<!-- Reviewable:end -->
