### PR TITLE
Add Python bindings for UnwrapToContinousTrajectory.

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -513,7 +513,12 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("graph_of_convex_sets", &Class::graph_of_convex_sets,
             py_rvp::reference_internal, cls_doc.graph_of_convex_sets.doc)
         .def_static("NormalizeSegmentTimes", &Class::NormalizeSegmentTimes,
-            py::arg("trajectory"), cls_doc.NormalizeSegmentTimes.doc);
+            py::arg("trajectory"), cls_doc.NormalizeSegmentTimes.doc)
+        .def_static("UnwrapToContinousTrajectory",
+            &Class::UnwrapToContinousTrajectory, py::arg("gcs_trajectory"),
+            py::arg("continuous_revolute_joints"),
+            py::arg("starting_rounds") = std::nullopt,
+            cls_doc.UnwrapToContinousTrajectory.doc);
   }
 
   m.def("GetContinuousRevoluteJointIndices", &GetContinuousRevoluteJointIndices,


### PR DESCRIPTION
Very quick PR -- just adding python bindings for a static method in GcsTrajectoryOptimization that didn't have them yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21622)
<!-- Reviewable:end -->
