### PR TITLE
[multibody] Remove unnecessary MbP includes

### DIFF
--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -17,6 +17,7 @@
 #include "drake/multibody/fem/fem_model.h"
 #include "drake/multibody/fem/velocity_newmark_scheme.h"
 #include "drake/multibody/plant/contact_properties.h"
+#include "drake/multibody/plant/discrete_update_manager.h"
 #include "drake/multibody/plant/force_density_field.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/context.h"

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -20,6 +20,7 @@
 #include "drake/math/random_rotation.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/hydroelastics/hydroelastic_engine.h"
+#include "drake/multibody/plant/discrete_update_manager.h"
 #include "drake/multibody/plant/externally_applied_spatial_force.h"
 #include "drake/multibody/plant/geometry_contact_data.h"
 #include "drake/multibody/plant/hydroelastic_traction_calculator.h"

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -16,7 +16,6 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_deprecated.h"
-#include "drake/common/nice_type_name.h"
 #include "drake/common/random.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/rigid_transform.h"
@@ -24,19 +23,21 @@
 #include "drake/multibody/plant/constraint_specs.h"
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/coulomb_friction.h"
-#include "drake/multibody/plant/discrete_update_manager.h"
 #include "drake/multibody/plant/dummy_physical_model.h"
 #include "drake/multibody/plant/multibody_plant_config.h"
 #include "drake/multibody/plant/physical_model_collection.h"
-#include "drake/multibody/topology/multibody_graph.h"
 #include "drake/multibody/tree/force_element.h"
+#include "drake/multibody/tree/frame.h"
+#include "drake/multibody/tree/joint.h"
+#include "drake/multibody/tree/joint_actuator.h"
+#include "drake/multibody/tree/multibody_forces.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
 #include "drake/multibody/tree/rigid_body.h"
+#include "drake/multibody/tree/uniform_gravity_field_element.h"
 #include "drake/multibody/tree/weld_joint.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/scalar_conversion_traits.h"
 
 namespace drake {
 namespace multibody {
@@ -112,14 +113,18 @@ struct ContactByPenaltyMethodParameters {
   std::optional<double> gravity;
 };
 
-// Forward declaration.
+// Forward declarations for discrete_update_manager.h.
+template <typename>
+class DiscreteUpdateManager;
+// Forward declarations for geometry_contact_data.h.
+template <typename>
+struct GeometryContactData;
+// Forward declarations for plant_model_attorney.h.
 template <typename>
 class MultibodyPlantModelAttorney;
+// Forward declarations for multibody_plant_discrete_update_manager_attorney.h.
 template <typename>
 class MultibodyPlantDiscreteUpdateManagerAttorney;
-
-template <typename T>
-struct GeometryContactData;  // Defined in geometry_contact_data.h.
 
 }  // namespace internal
 


### PR DESCRIPTION
Towards #21623 and therefore also #20545.

The primary upside here is that changes to `discrete_update_manager.h` only rebuild a dozen files in the plant folder, rather than everything in Drake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21625)
<!-- Reviewable:end -->
