### PR TITLE
[render_gl] Fix reading past end of glTF buffer

### DIFF
--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -1841,7 +1841,7 @@ class RenderEngineGl::GltfMeshExtractor {
        the vertex data buffer. */
       GLuint buffer_id;
       glCreateBuffers(1, &buffer_id);
-      glNamedBufferStorage(buffer_id, ssize(buffer.data),
+      glNamedBufferStorage(buffer_id, buffer_view.byteLength,
                            buffer.data.data() + offset, 0);
       index_buffers_[prim.indices] = {
           .buffer = buffer_id,


### PR DESCRIPTION
Hotfix for #21520.

https://drake-jenkins.csail.mit.edu/view/Production/job/linux-jammy-clang-bazel-nightly-thread-sanitizer/229/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21627)
<!-- Reviewable:end -->
