### PR TITLE
Add tolerance argument to UnwrapToContinousTrajectory.

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -517,7 +517,7 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def_static("UnwrapToContinousTrajectory",
             &Class::UnwrapToContinousTrajectory, py::arg("gcs_trajectory"),
             py::arg("continuous_revolute_joints"),
-            py::arg("starting_rounds") = std::nullopt,
+            py::arg("starting_rounds") = std::nullopt, py::arg("tol") = 1e-8,
             cls_doc.UnwrapToContinousTrajectory.doc);
   }
 

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -644,7 +644,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         new_traj = GcsTrajectoryOptimization.UnwrapToContinousTrajectory(
             gcs_trajectory=traj,
             continuous_revolute_joints=[0],
-            starting_rounds=[43])
+            starting_rounds=[43],
+            tol=1e-8)
         diff = (new_traj.value(new_traj.start_time())
                 - traj.value(traj.start_time())) % (2 * np.pi)
         # Modulus may lead to the value being almost 2*pi, instead of zero.

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -805,6 +805,9 @@ class GcsTrajectoryOptimization final {
    @param gcs_trajectory The trajectory to unwrap.
    @param continuous_revolute_joints The indices of the continuous revolute
    joints.
+   @param tol The numerical tolerance used to determine if two subsequent
+   segments start and end at the same value modulo 2π for continuous revolute
+   joints.
    @param starting_rounds A vector of integers that sets the starting rounds for
    each continuous revolute joint. Given integer k for the starting_round of a
    joint, its initial position will be wrapped into [2πk , 2π(k+1)). If the
@@ -820,7 +823,7 @@ class GcsTrajectoryOptimization final {
    @throws std::exception if the gcs_trajectory is not continuous on the
    manifold defined by the continuous_revolute_joints, i.e., the shift between
    two consecutive segments is not an integer multiple of 2π (within a tolerance
-   of 1e-10 radians).
+   of `tol` radians).
    @throws std::exception if all the segments are not of type BezierCurve.
    Other types are not supported yet. Note that currently the output of
    GcsTrajectoryOptimization::SolvePath() is a CompositeTrajectory of
@@ -829,7 +832,8 @@ class GcsTrajectoryOptimization final {
   static trajectories::CompositeTrajectory<double> UnwrapToContinousTrajectory(
       const trajectories::CompositeTrajectory<double>& gcs_trajectory,
       std::vector<int> continuous_revolute_joints,
-      std::optional<std::vector<int>> starting_rounds = std::nullopt);
+      std::optional<std::vector<int>> starting_rounds = std::nullopt,
+      double tol = 1e-8);
 
  private:
   const int num_positions_;

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -1116,7 +1116,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
   std::vector<int> starting_rounds = {-1, 0};
   const auto unwrapped_traj_with_start =
       GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
-          traj, continuous_revolute_joints, starting_rounds);
+          traj, continuous_revolute_joints, starting_rounds, 1e-8);
   // Check if the start is unwrapped to the correct value.
   EXPECT_TRUE(CompareMatrices(unwrapped_traj_with_start.value(0.0),
                               Eigen::Vector3d{0.0, 1.0 - 2 * M_PI, 2.0},
@@ -1129,9 +1129,10 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
       unwrapped_traj_with_start.value(middle_time_2 + time_eps), pos_eps));
   // Check for invalid start_rounds
   const std::vector<int> invalid_start_rounds = {-1, 0, 1};
-  EXPECT_THROW(GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
-                   traj, continuous_revolute_joints, invalid_start_rounds),
-               std::runtime_error);
+  EXPECT_THROW(
+      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
+          traj, continuous_revolute_joints, invalid_start_rounds, 1e-8),
+      std::runtime_error);
   // Check for discontinuity for continuous revolute joints
   control_points_2 << 2.5, 2.5, 4.0, 3.0 + 2 * M_PI, 1.0 + 2 * M_PI,
       0.0 + 2 * M_PI, 4.0 - 6 * M_PI, 3.0 - 6 * M_PI, 2.0 - 6 * M_PI;
@@ -1147,6 +1148,13 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
       GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
           traj_not_continous_on_revolute_manifold, continuous_revolute_joints),
       ".*is not a multiple of 2π at segment.*");
+  // If we set the tolerance to be very large, no error will occur. We use a
+  // tolerance of 0.6, which is larger than the 0.5 gap between adjacent
+  // segments.
+  const double loose_tol = 0.6;
+  EXPECT_NO_THROW(GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
+      traj_not_continous_on_revolute_manifold, continuous_revolute_joints,
+      std::nullopt, loose_tol));
 }
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, NotBezierCurveError) {


### PR DESCRIPTION
Per our discussion in the weekly GCS standup, the default tolerance for this function is a bit too tight. I've set a looser default, and added it as an argument so users can further specify depending on their needs.

+@sadraddini for feature review, please!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21629)
<!-- Reviewable:end -->
