### PR TITLE
[geometry] Avoid slowdown of SceneGraph::GetDirectFeedthroughs()

### DIFF
--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -176,7 +176,11 @@ SceneGraph<T>::SceneGraph()
       this->DeclareAbstractParameter(Value<SceneGraphConfig>());
 
   query_port_index_ =
-      this->DeclareAbstractOutputPort("query", &SceneGraph::CalcQueryObject)
+      this->DeclareAbstractOutputPort(
+              "query", &SceneGraph::CalcQueryObject,
+              {this->all_input_ports_ticket(),
+               this->abstract_parameter_ticket(
+                   systems::AbstractParameterIndex(geometry_state_index_))})
           .get_index();
 
   auto& pose_update_cache_entry = this->DeclareCacheEntry(
@@ -198,9 +202,13 @@ SceneGraph<T>::SceneGraph(const SceneGraphConfig& config)
 }
 
 template <typename T>
+int64_t SceneGraph<T>::scalar_conversion_count_{0};
+
+template <typename T>
 template <typename U>
 SceneGraph<T>::SceneGraph(const SceneGraph<U>& other)
     : SceneGraph() {
+  ++scalar_conversion_count_;
   hub_.mutable_config() = other.hub_.config();
   hub_.mutable_model() =
       GeometryState<T>(other.hub_.model());

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -1165,6 +1165,10 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // The cache indices for the pose and configuration update cache entries.
   systems::CacheIndex pose_update_index_{};
   systems::CacheIndex configuration_update_index_{};
+
+  // (Testing only) a global count of calls to the scalar converting
+  // constructor.
+  static int64_t scalar_conversion_count_;
 };
 
 }  // namespace geometry

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -102,6 +102,11 @@ class SceneGraphTester {
       const SceneGraph<T>& scene_graph, systems::Context<T>* context) {
     return scene_graph.mutable_geometry_state(context);
   }
+
+  template <typename T>
+  static int64_t ScalarConversionCount() {
+    return SceneGraph<T>::scalar_conversion_count_;
+  }
 };
 
 namespace {
@@ -274,11 +279,15 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
 }
 
 // Confirms that the direct feedthrough logic is correct -- there is total
-// direct feedthrough.
+// direct feedthrough. Also confirm that feedthrough was calculated without the
+// need to fall back on SystemSymbolicInspector, and hence populate the
+// internal augmented model cache for T=Expression.
 TEST_F(SceneGraphTest, DirectFeedThrough) {
   scene_graph_.RegisterSource();
+  int64_t tare = SceneGraphTester::ScalarConversionCount<Expression>();
   EXPECT_EQ(scene_graph_.GetDirectFeedthroughs().size(),
             scene_graph_.num_input_ports() * scene_graph_.num_output_ports());
+  EXPECT_EQ(SceneGraphTester::ScalarConversionCount<Expression>(), tare);
 }
 
 // Test the functionality that accumulates the values from the input ports.


### PR DESCRIPTION
Use an explicit list of dependency tickets in SceneGraph to avoid a pile of useless reifications of proximity geometry. The useless work is triggered if the base class LeafSystem::GetDirectFeedthroughs() implementation falls back on its technique of making a SystemSymbolicInspector, which needs to build an Expression-typed SceneGraph context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21630)
<!-- Reviewable:end -->
