### PR TITLE
[framework] Offer warn_deprecated=false option on port getters

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -457,10 +457,11 @@ Note: The above is for the C++ documentation. For Python, use
             py::keep_alive<0, 2>(), doc.System.GetMyMutableContextFromRoot.doc)
         // Utility methods.
         .def("get_input_port",
-            overload_cast_explicit<const InputPort<T>&, int>(
+            overload_cast_explicit<const InputPort<T>&, int, bool>(
                 &System<T>::get_input_port),
             py_rvp::reference_internal, py::arg("port_index"),
-            doc.System.get_input_port.doc_1args)
+            py::arg("warn_deprecated") = true,
+            doc.System.get_input_port.doc_2args)
         .def("get_input_port",
             overload_cast_explicit<const InputPort<T>&>(
                 &System<T>::get_input_port),
@@ -471,10 +472,11 @@ Note: The above is for the C++ documentation. For Python, use
         .def("HasInputPort", &System<T>::HasInputPort, py::arg("port_name"),
             doc.System.HasInputPort.doc)
         .def("get_output_port",
-            overload_cast_explicit<const OutputPort<T>&, int>(
+            overload_cast_explicit<const OutputPort<T>&, int, bool>(
                 &System<T>::get_output_port),
             py_rvp::reference_internal, py::arg("port_index"),
-            doc.System.get_output_port.doc_1args)
+            py::arg("warn_deprecated") = true,
+            doc.System.get_output_port.doc_2args)
         .def("get_output_port",
             overload_cast_explicit<const OutputPort<T>&>(
                 &System<T>::get_output_port),

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -87,12 +87,12 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(
             lhs.num_output_ports(), rhs.num_output_ports())
         for i in range(lhs.num_input_ports()):
-            lhs_port = lhs.get_input_port(i)
-            rhs_port = rhs.get_input_port(i)
+            lhs_port = lhs.get_input_port(i, warn_deprecated=False)
+            rhs_port = rhs.get_input_port(i, warn_deprecated=False)
             self.assertEqual(lhs_port.size(), rhs_port.size())
         for i in range(lhs.num_output_ports()):
-            lhs_port = lhs.get_output_port(i)
-            rhs_port = rhs.get_output_port(i)
+            lhs_port = lhs.get_output_port(i, warn_deprecated=False)
+            rhs_port = rhs.get_output_port(i, warn_deprecated=False)
             self.assertEqual(lhs_port.size(), rhs_port.size())
 
     def test_system_base_api(self):

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1116,8 +1116,11 @@ class System : public SystemBase {
   using SystemBase::num_output_ports;
 
   // TODO(sherm1) Make this an InputPortIndex.
-  /** Returns the typed input port at index @p port_index. */
-  const InputPort<T>& get_input_port(int port_index) const {
+  /** Returns the typed input port at index `port_index`.
+  @param warn_deprecated Whether or not to print a warning in case the port was
+  marked as deprecated. */
+  const InputPort<T>& get_input_port(int port_index,
+                                     bool warn_deprecated = true) const {
     // Profiling revealed that it is too expensive to do a dynamic_cast here.
     // A static_cast is safe as long as GetInputPortBaseOrThrow always returns
     // a satisfactory type. As of this writing, it only ever returns values
@@ -1125,8 +1128,7 @@ class System : public SystemBase {
     // has a check that port.get_system_interface() matches `this` which is a
     // System<T>, so we are safe.
     return static_cast<const InputPort<T>&>(
-        this->GetInputPortBaseOrThrow(__func__, port_index,
-                                      /* warn_deprecated = */ true));
+        this->GetInputPortBaseOrThrow(__func__, port_index, warn_deprecated));
   }
 
   /** Convenience method for the case of exactly one input port.
@@ -1159,8 +1161,11 @@ class System : public SystemBase {
   bool HasInputPort(const std::string& port_name) const;
 
   // TODO(sherm1) Make this an OutputPortIndex.
-  /** Returns the typed output port at index @p port_index. */
-  const OutputPort<T>& get_output_port(int port_index) const {
+  /** Returns the typed output port at index `port_index`.
+  @param warn_deprecated Whether or not to print a warning in case the port was
+  marked as deprecated. */
+  const OutputPort<T>& get_output_port(int port_index,
+                                       bool warn_deprecated = true) const {
     // Profiling revealed that it is too expensive to do a dynamic_cast here.
     // A static_cast is safe as long as GetInputPortBaseOrThrow always returns
     // a satisfactory type. As of this writing, it only ever returns values
@@ -1168,8 +1173,7 @@ class System : public SystemBase {
     // has a check that port.get_system_interface() matches `this` which is a
     // System<T>, so we are safe.
     return static_cast<const OutputPort<T>&>(
-        this->GetOutputPortBaseOrThrow(__func__, port_index,
-                                       /* warn_deprecated = */ true));
+        this->GetOutputPortBaseOrThrow(__func__, port_index, warn_deprecated));
   }
 
   /** Convenience method for the case of exactly one output port.

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -606,6 +606,15 @@ TEST_F(SystemTest, PortSelectionTest) {
             &system_.get_output_port(0));
 }
 
+TEST_F(SystemTest, GetPortTwoArgs) {
+  system_.DeclareInputPort("input", kVectorValued, 1);
+  system_.AddAbstractOutputPort();
+
+  // Sanity check that the second argument to port getters doesn't hurt.
+  EXPECT_NO_THROW(system_.get_input_port(0, /* warn_deprecated = */ false));
+  EXPECT_NO_THROW(system_.get_output_port(0, /* warn_deprecated = */ false));
+}
+
 // Tests the constraint list logic.
 TEST_F(SystemTest, SystemConstraintTest) {
   EXPECT_EQ(system_.num_constraints(), 0);


### PR DESCRIPTION
This is useful when code wants to scan all ports (and has its own, higher-layer deprecation handler logic).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21631)
<!-- Reviewable:end -->
