### PR TITLE
Don't (yet) require semicolons on statement-like macros

### DIFF
--- a/common/default_scalars.h
+++ b/common/default_scalars.h
@@ -79,7 +79,7 @@
     SomeType) \
 template SomeType<double>; \
 template SomeType<::drake::AutoDiffXd>; \
-template SomeType<::drake::symbolic::Expression>
+template SomeType<::drake::symbolic::Expression>;
 
 /// Defines template instantiations for Drake's default nonsymbolic scalars.
 /// This should only be used in .cc files, never in .h files.
@@ -87,7 +87,7 @@ template SomeType<::drake::symbolic::Expression>
   DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS( \
       SomeType) \
 template SomeType<double>; \
-template SomeType<::drake::AutoDiffXd>
+template SomeType<::drake::AutoDiffXd>;
 
 /// Declares that template instantiations exist for Drake's default scalars.
 /// This should only be used in .h files, never in .cc files.
@@ -95,7 +95,7 @@ template SomeType<::drake::AutoDiffXd>
     SomeType) \
 extern template SomeType<double>; \
 extern template SomeType<::drake::AutoDiffXd>; \
-extern template SomeType<::drake::symbolic::Expression>
+extern template SomeType<::drake::symbolic::Expression>;
 
 /// Declares that template instantiations exist for Drake's default nonsymbolic
 /// scalars.  This should only be used in .h files, never in .cc files.
@@ -103,7 +103,7 @@ extern template SomeType<::drake::symbolic::Expression>
   DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS( \
       SomeType) \
 extern template SomeType<double>; \
-extern template SomeType<::drake::AutoDiffXd>
+extern template SomeType<::drake::AutoDiffXd>;
 
 /// @}
 
@@ -204,7 +204,7 @@ static constexpr auto Function_Femplates __attribute__((used)) = \
     Make_Function_Pointers_Pack1< \
         double, \
         ::drake::AutoDiffXd, \
-        ::drake::symbolic::Expression>()
+        ::drake::symbolic::Expression>();
 
 /// Defines template instantiations for Drake's default nonsymbolic scalars.
 /// This should only be used in .cc files, never in .h files.
@@ -227,6 +227,6 @@ constexpr auto Make_Function_Pointers_Nonsym_Pack1() { \
 static constexpr auto Function_Templates_Nonsym __attribute__((used)) = \
     Make_Function_Pointers_Nonsym_Pack1< \
         double, \
-        ::drake::AutoDiffXd>()
+        ::drake::AutoDiffXd>();
 
 /// @}

--- a/common/drake_copyable.h
+++ b/common/drake_copyable.h
@@ -34,7 +34,7 @@ class Foo {
   Classname(const Classname&) = delete;            \
   void operator=(const Classname&) = delete;       \
   Classname(Classname&&) = delete;                 \
-  void operator=(Classname&&) = delete
+  void operator=(Classname&&) = delete;
 
 /** DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN defaults the special member
 functions for copy-construction, copy-assignment, move-construction, and
@@ -87,7 +87,7 @@ that in a unit test.
       &DrakeDefaultCopyAndMoveAndAssign_DoAssign,               \
       "This assertion is never false; its only purpose is to "  \
       "generate 'use of deleted function: operator=' errors "   \
-      "when Classname is a template.")
+      "when Classname is a template.");
 
 /** DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN declares the special member functions
 for copy-construction, copy-assignment, move-construction, and move-assignment.
@@ -111,4 +111,4 @@ Then the matching definitions should be placed in the associated .cc file.
   Classname(const Classname&);                            \
   Classname& operator=(const Classname&);                 \
   Classname(Classname&&);                                 \
-  Classname& operator=(Classname&&)
+  Classname& operator=(Classname&&);


### PR DESCRIPTION
The lack of semicolons after these macros is deprecated and we plan to re-enforce this requirement in a future release (after 2024-08-01). Macros that will require trailing semicolons at call sites are:

DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS

---

Amends #21603.  If this merges, I'll go back and change the notes tag on that PR to "none" instead of "breaking".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21634)
<!-- Reviewable:end -->
