### PR TITLE
Add more tags to ignore to the new_release script

### DIFF
--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -76,7 +76,10 @@ _IGNORED_REPOSITORIES = [
 
 # For these repositories, ignore any tags that match the specified regex.
 _IGNORED_TAGS = {
+    "gymnasium_py": r"v[0-9.]+a[0-9]+",
     "libpng_internal": r"v[0-9.]+(alpha|beta)[0-9]+",
+    "msgpack_internal": r"c-[0-9.]+",
+    "ros_xacro_internal": r"xacro-[0-9.]+",
     "sdformat_internal": r"sdformat-prerelease_[0-9.]+",
 }
 
@@ -170,7 +173,7 @@ def _is_ignored_tag(commit, workspace):
         # we don't spam the user.
         return True
 
-    development_stages = ["alpha", "beta", "rc", "pre"]
+    development_stages = ["alpha", "beta", "pre", "rc", "unstable"]
     prerelease = any(stage in commit for stage in development_stages)
     if prerelease:
         # Heuristically looks like a pre-release; ignore it, but log it for the


### PR DESCRIPTION
Resolves  #21535

Prior to these updates, the output from the `new_release` script was:
```
abseil_cpp_internal needs upgrade from ed34153e0d9cd15f9b9eb45e86b457e0a495aeea to 0ccc51f9ddbb407d579f8158d5421fbf3eea0524
crate_universe may need upgrade
gymnasium_py needs upgrade from v0.29.1 to v1.0.0a2
gz_math_internal needs upgrade from gz-math7_7.4.0 to gz-math7_7.5.0
msgpack_internal needs upgrade from cpp-6.1.1 to c-6.0.2
mypy_internal needs upgrade from v1.10.0 to v1.10.1
pycodestyle needs upgrade from 2.11.1 to 2.12.0
ros_xacro_internal needs upgrade from 2.0.10 to xacro-1.7.5
rules_python needs upgrade from 0.33.0 to 0.33.2
rust_toolchain may need upgrade
sdformat_internal needs upgrade from sdformat14_14.2.0 to sdformat14_14.4.0
Skipping prerelease 1.13.0rc3 for sympy_py_internal
Skipping prerelease sympy-1.13.0rc3 for sympy_py_internal
Skipping prerelease sympy-1.13.0rc2 for sympy_py_internal
Skipping prerelease sympy-1.13.0rc1 for sympy_py_internal
typing_extensions_internal needs upgrade from 4.12.1 to 4.12.2
vtk_internal needs upgrade from 6bb2d8e2e06bd114707d75e2960f2f2a1493a5b9 to 67b5156276d0ddf234db58ee5faa7568a367755c
```

With the changes, the output is:
```
abseil_cpp_internal needs upgrade from ed34153e0d9cd15f9b9eb45e86b457e0a495aeea to 0ccc51f9ddbb407d579f8158d5421fbf3eea0524
crate_universe may need upgrade
gz_math_internal needs upgrade from gz-math7_7.4.0 to gz-math7_7.5.0
mypy_internal needs upgrade from v1.10.0 to v1.10.1
pycodestyle needs upgrade from 2.11.1 to 2.12.0
Skipping prerelease unstable for ros_xacro_internal
ros_xacro_internal needs upgrade from 2.0.10 to 2.0.11
rules_python needs upgrade from 0.33.0 to 0.33.2
rust_toolchain may need upgrade
sdformat_internal needs upgrade from sdformat14_14.2.0 to sdformat14_14.4.0
Skipping prerelease 1.13.0rc3 for sympy_py_internal
Skipping prerelease sympy-1.13.0rc3 for sympy_py_internal
Skipping prerelease sympy-1.13.0rc2 for sympy_py_internal
Skipping prerelease sympy-1.13.0rc1 for sympy_py_internal
typing_extensions_internal needs upgrade from 4.12.1 to 4.12.2
vtk_internal needs upgrade from 6bb2d8e2e06bd114707d75e2960f2f2a1493a5b9 to 2e9a7c71a29100eac41be37f4ade73b988db2a4d
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21635)
<!-- Reviewable:end -->
