### PR TITLE
[planning] Revise CollisionChecker parallel edge checks

### DIFF
--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -28,6 +28,8 @@ using common_robotics_utilities::openmp_helpers::GetContextOmpThreadNum;
 using common_robotics_utilities::parallelism::DegreeOfParallelism;
 using common_robotics_utilities::parallelism::ParallelForBackend;
 using common_robotics_utilities::parallelism::StaticParallelForIndexLoop;
+using common_robotics_utilities::parallelism::StaticParallelForRangeLoop;
+using common_robotics_utilities::parallelism::ThreadWorkRange;
 using geometry::GeometryId;
 using geometry::QueryObject;
 using geometry::SceneGraphInspector;
@@ -710,9 +712,11 @@ bool CollisionChecker::CheckEdgeCollisionFreeParallel(
     // extensions/connections will result in a colliding configuration, so
     // failing fast on a colliding q2 helps reduce the work of checking
     // colliding edges.
-    // There is also no need to special case checking q1, since it will be the
-    // first configuration checked in the loop.
     if (!CheckConfigCollisionFree(q2)) {
+      return false;
+    }
+    // Special case q1 as well, so it gets checked before parallel dispatch.
+    if (!CheckConfigCollisionFree(q1)) {
       return false;
     }
 
@@ -721,20 +725,30 @@ bool CollisionChecker::CheckEdgeCollisionFreeParallel(
         static_cast<int>(std::max(1.0, std::ceil(distance / edge_step_size())));
     std::atomic<bool> edge_valid(true);
 
-    const auto step_work = [&](const int thread_num, const int64_t step) {
-      if (edge_valid.load()) {
-        const double ratio =
-            static_cast<double>(step) / static_cast<double>(num_steps);
-        const Eigen::VectorXd qinterp =
-            InterpolateBetweenConfigurations(q1, q2, ratio);
-        if (!CheckConfigCollisionFree(qinterp, thread_num)) {
-          edge_valid.store(false);
+    const auto step_range_work = [&](const ThreadWorkRange& work_range) {
+      for (int64_t step = work_range.GetRangeStart();
+           step < work_range.GetRangeEnd(); ++step) {
+        if (edge_valid.load()) {
+          // If no collision has been found, check the next step.
+          const double ratio =
+              static_cast<double>(step) / static_cast<double>(num_steps);
+          const Eigen::VectorXd qinterp =
+              InterpolateBetweenConfigurations(q1, q2, ratio);
+          if (!CheckConfigCollisionFree(qinterp, work_range.GetThreadNum())) {
+            // If we have encountered a collision, record it and end early.
+            edge_valid.store(false);
+            break;
+          }
+        } else {
+          // If another thread encountered a collision, end early as well.
+          break;
         }
       }
     };
 
-    StaticParallelForIndexLoop(DegreeOfParallelism(number_of_threads), 0,
-                               num_steps, step_work,
+    // Note that the range starts at 1, not 0, as we have already checked q1.
+    StaticParallelForRangeLoop(DegreeOfParallelism(number_of_threads), 1,
+                               num_steps, step_range_work,
                                ParallelForBackend::BEST_AVAILABLE);
 
     return edge_valid.load();
@@ -813,31 +827,46 @@ EdgeMeasure CollisionChecker::MeasureEdgeCollisionFreeParallel(
     std::atomic<double> alpha;
     // Start by assuming the whole edge is fine; we'll whittle away at it.
     alpha.store(1.0);
-    std::mutex alpha_mutex;
 
-    const auto step_work = [&](const int thread_num, const int64_t step) {
-      const double ratio =
-          static_cast<double>(step) / static_cast<double>(num_steps);
-      // If this step fails, this is the alpha which we would report.
-      const double possible_alpha =
-          static_cast<double>(step - 1) / static_cast<double>(num_steps);
-      if (possible_alpha < alpha.load()) {
-        const Eigen::VectorXd qinterp =
-            InterpolateBetweenConfigurations(q1, q2, ratio);
-        if (!CheckConfigCollisionFree(qinterp, thread_num)) {
-          std::lock_guard<std::mutex> update_lock(alpha_mutex);
-          // Between the initial decision to interpolate and check collisions
-          // and now, another thread may have proven a *lower* alpha is invalid;
-          // check again before setting *this* as the lowest known invalid step.
-          if (possible_alpha < alpha.load()) {
-            alpha.store(possible_alpha);
+    const auto step_range_work = [&](const ThreadWorkRange& work_range) {
+      for (int64_t step = work_range.GetRangeStart();
+           step < work_range.GetRangeEnd(); ++step) {
+        const double ratio =
+            static_cast<double>(step) / static_cast<double>(num_steps);
+        // If this step fails, this is the alpha which we would report.
+        const double possible_alpha =
+            static_cast<double>(step - 1) / static_cast<double>(num_steps);
+
+        if (possible_alpha < alpha.load()) {
+          // If no lower alpha has been found, check the next configuration.
+          const Eigen::VectorXd qinterp =
+              InterpolateBetweenConfigurations(q1, q2, ratio);
+          if (!CheckConfigCollisionFree(qinterp, work_range.GetThreadNum())) {
+            // Between the initial decision to interpolate and check collisions
+            // and now, another thread may have proven a *lower* alpha is
+            // invalid; we need an atomic min of our current alpha and the
+            // stored alpha.
+            // This is a manual implementation of the behavior of
+            // std::atomic<T>::fetch_min from C++26, and can be replaced with
+            // fetch_min once available.
+            double stored_alpha = alpha.load();
+            while (possible_alpha < stored_alpha) {
+              if (alpha.compare_exchange_weak(stored_alpha, possible_alpha)) {
+                break;
+              }
+            }
+            // Stop because we have found a colliding configuration.
+            break;
           }
+        } else {
+          // A different thread has already found a lower alpha, so we can stop.
+          break;
         }
       }
     };
 
-    StaticParallelForIndexLoop(DegreeOfParallelism(number_of_threads), 0,
-                               num_steps + 1, step_work,
+    StaticParallelForRangeLoop(DegreeOfParallelism(number_of_threads), 0,
+                               num_steps + 1, step_range_work,
                                ParallelForBackend::BEST_AVAILABLE);
 
     return EdgeMeasure(distance, alpha.load());

--- a/planning/edge_measure.h
+++ b/planning/edge_measure.h
@@ -19,7 +19,7 @@ namespace planning {
      free. This is the *only* time completely_free() reports `true`.
  - 0 ≤ α < 1:
      A collision was detected between q1 and q2. α is the *largest*
-     interpolation value such that an edge from q to qα can be considered
+     interpolation value such that an edge from q1 to qα can be considered
      collision free (where qα = interpolate(q1, q2, α)). partially_free()
      reports `true`.
  - α is undefined:


### PR DESCRIPTION
From discussion with @tomstewart-woven and @aochiai, `CollisionChecker`'s parallel edge checks can be improved by using the range-based parallel-for loops rather than the naive index-based versions. Using the range-based loops means less work is performed once a colliding configuration is found, since it allows the entire rest of a thread's range to be skipped.

Also contains two other revisions:
- `MeasureEdgeCollisionFreeParallel` now uses an implementation of the behavior of `std::atomic<T>::fetch_min` instead of separate `std:atomic<double>` + `std::mutex`.
- `CheckEdgeCollisionFreeParallel` now special-cases the `q1` check so that it is performed before parallel dispatch.

+@jwnimmer-tri for review, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21645)
<!-- Reviewable:end -->
