### PR TITLE
[ClarabelSolver] Don't declare zero-dimensional cones

### DIFF
--- a/solvers/clarabel_solver.cc
+++ b/solvers/clarabel_solver.cc
@@ -498,8 +498,10 @@ void ClarabelSolver::DoSolve(const MathematicalProgram& prog,
   internal::ParseLinearEqualityConstraints(
       prog, &A_triplets, &b, &A_row_count, &linear_eq_y_start_indices,
       &num_linear_equality_constraints_rows);
-  cones.push_back(
-      clarabel::ZeroConeT<double>(num_linear_equality_constraints_rows));
+  if (num_linear_equality_constraints_rows > 0) {
+    cones.push_back(
+        clarabel::ZeroConeT<double>(num_linear_equality_constraints_rows));
+  }
 
   // Parse bounding box constraints.
   // bbcon_dual_indices[i][j][0] (resp. bbcon_dual_indices[i][j][1]) is the dual
@@ -522,8 +524,10 @@ void ClarabelSolver::DoSolve(const MathematicalProgram& prog,
   internal::ParseLinearConstraints(prog, &A_triplets, &b, &A_row_count,
                                    &linear_constraint_dual_indices,
                                    &num_linear_constraint_rows);
-  cones.push_back(
-      clarabel::NonnegativeConeT<double>(num_linear_constraint_rows));
+  if (num_linear_constraint_rows > 0) {
+    cones.push_back(
+        clarabel::NonnegativeConeT<double>(num_linear_constraint_rows));
+  }
 
   // Parse Lorentz cone and rotated Lorentz cone constraint
   std::vector<int> second_order_cone_length;

--- a/solvers/test/clarabel_solver_test.cc
+++ b/solvers/test/clarabel_solver_test.cc
@@ -459,6 +459,7 @@ GTEST_TEST(TestOptions, StandaloneReproduction) {
   MathematicalProgram prog;
   const auto x = prog.NewContinuousVariables<3>("x");
   prog.AddLinearEqualityConstraint(x(0) + x(1) == 1);
+  prog.AddLinearConstraint(x(0) + x(1) + x(2) >= 0);
   prog.AddLorentzConeConstraint(Vector2<symbolic::Expression>(x(0), x(1)));
   prog.AddExponentialConeConstraint(
       Vector3<symbolic::Expression>(x(2), x(0), x(1)));


### PR DESCRIPTION
In https://github.com/oxfordcontrol/Clarabel.rs/issues/119, they asked about why we declare a `NonnegativeConeT(0)`. I guess it's not wrong, but it's certainly inelegant. This PR avoids writing the zero-dimensional cones.

+@hongkai-dai for feature review, please.