### PR TITLE
[GCS] Support use_in_transcription in AddCost.

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -743,13 +743,18 @@ void DefineGeometryOptimization(py::module m) {
         .def("set", &GraphOfConvexSets::Vertex::set, py_rvp::reference_internal,
             vertex_doc.set.doc)
         .def("AddCost",
-            py::overload_cast<const symbolic::Expression&>(
+            py::overload_cast<const symbolic::Expression&,
+                const std::unordered_set<GraphOfConvexSets::Transcription>&>(
                 &GraphOfConvexSets::Vertex::AddCost),
-            py::arg("e"), vertex_doc.AddCost.doc_expression)
+            py::arg("e"), py::arg("use_in_transcription") = all_transcriptions,
+            vertex_doc.AddCost.doc_expression)
         .def("AddCost",
-            py::overload_cast<const solvers::Binding<solvers::Cost>&>(
+            py::overload_cast<const solvers::Binding<solvers::Cost>&,
+                const std::unordered_set<GraphOfConvexSets::Transcription>&>(
                 &GraphOfConvexSets::Vertex::AddCost),
-            py::arg("binding"), vertex_doc.AddCost.doc_binding)
+            py::arg("binding"),
+            py::arg("use_in_transcription") = all_transcriptions,
+            vertex_doc.AddCost.doc_binding)
         .def("AddConstraint",
             overload_cast_explicit<solvers::Binding<solvers::Constraint>,
                 const symbolic::Formula&,
@@ -766,6 +771,7 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("use_in_transcription") = all_transcriptions,
             vertex_doc.AddConstraint.doc_binding)
         .def("GetCosts", &GraphOfConvexSets::Vertex::GetCosts,
+            py::arg("used_in_transcription") = all_transcriptions,
             vertex_doc.GetCosts.doc)
         .def("GetConstraints", &GraphOfConvexSets::Vertex::GetConstraints,
             py::arg("used_in_transcription") = all_transcriptions,
@@ -806,13 +812,18 @@ void DefineGeometryOptimization(py::module m) {
                 -> const VectorX<symbolic::Variable> { return self.xv(); },
             edge_doc.xv.doc)
         .def("AddCost",
-            py::overload_cast<const symbolic::Expression&>(
+            py::overload_cast<const symbolic::Expression&,
+                const std::unordered_set<GraphOfConvexSets::Transcription>&>(
                 &GraphOfConvexSets::Edge::AddCost),
-            py::arg("e"), edge_doc.AddCost.doc_expression)
+            py::arg("e"), py::arg("use_in_transcription") = all_transcriptions,
+            edge_doc.AddCost.doc_expression)
         .def("AddCost",
-            py::overload_cast<const solvers::Binding<solvers::Cost>&>(
+            py::overload_cast<const solvers::Binding<solvers::Cost>&,
+                const std::unordered_set<GraphOfConvexSets::Transcription>&>(
                 &GraphOfConvexSets::Edge::AddCost),
-            py::arg("binding"), edge_doc.AddCost.doc_binding)
+            py::arg("binding"),
+            py::arg("use_in_transcription") = all_transcriptions,
+            edge_doc.AddCost.doc_binding)
         .def("AddConstraint",
             overload_cast_explicit<solvers::Binding<solvers::Constraint>,
                 const symbolic::Formula&,
@@ -834,6 +845,7 @@ void DefineGeometryOptimization(py::module m) {
             &GraphOfConvexSets::Edge::ClearPhiConstraints,
             edge_doc.ClearPhiConstraints.doc)
         .def("GetCosts", &GraphOfConvexSets::Edge::GetCosts,
+            py::arg("used_in_transcription") = all_transcriptions,
             edge_doc.GetCosts.doc)
         .def("GetConstraints", &GraphOfConvexSets::Edge::GetConstraints,
             py::arg("used_in_transcription") = all_transcriptions,

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -815,13 +815,18 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(source.name(), "source")
         self.assertIsInstance(source.x()[0], Variable)
         self.assertIsInstance(source.set(), mut.Point)
-        var, binding = source.AddCost(e=1.0+source.x()[0])
+        var, binding = source.AddCost(
+            e=1.0+source.x()[0],
+            use_in_transcription={kMIP, kRelaxation, kRestriction})
         self.assertIsInstance(var, Variable)
         self.assertIsInstance(binding, Binding[Cost])
-        var, binding = source.AddCost(binding=binding)
+        var, binding = source.AddCost(
+            binding=binding,
+            use_in_transcription={kMIP, kRelaxation, kRestriction})
         self.assertIsInstance(var, Variable)
         self.assertIsInstance(binding, Binding[Cost])
-        self.assertEqual(len(source.GetCosts()), 2)
+        self.assertEqual(len(source.GetCosts(
+            used_in_transcription={kMIP, kRelaxation, kRestriction})), 2)
         binding = source.AddConstraint(f=(source.x()[0] <= 1.0))
         self.assertIsInstance(binding, Binding[Constraint])
         binding = source.AddConstraint(
@@ -882,13 +887,19 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertIsInstance(edge0.phi(), Variable)
         self.assertIsInstance(edge0.xu()[0], Variable)
         self.assertIsInstance(edge0.xv()[0], Variable)
-        var, binding = edge0.AddCost(e=1.0+edge0.xu()[0])
+        var, binding = edge0.AddCost(
+            e=1.0+edge0.xu()[0],
+            use_in_transcription={kMIP, kRelaxation, kRestriction})
         self.assertIsInstance(var, Variable)
         self.assertIsInstance(binding, Binding[Cost])
-        var, binding = edge0.AddCost(binding=binding)
+        var, binding = edge0.AddCost(
+            binding=binding,
+            use_in_transcription={kMIP, kRelaxation, kRestriction})
         self.assertIsInstance(var, Variable)
         self.assertIsInstance(binding, Binding[Cost])
-        self.assertEqual(len(edge0.GetCosts()), 2)
+        self.assertEqual(len(edge0.GetCosts(
+            used_in_transcription={kMIP, kRelaxation, kRestriction}
+            )), 2)
         binding = edge0.AddConstraint(f=(edge0.xu()[0] == edge0.xv()[0]))
         self.assertIsInstance(binding, Binding[Constraint])
         binding = edge0.AddConstraint(

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -215,15 +215,21 @@ class GraphOfConvexSets {
     @verbatim
     min g(x) ⇒ min ℓ, s.t. ℓ ≥ g(x)
     @endverbatim
+    @param use_in_transcription specifies the components of the problem to
+    which the constraint should be added.
     @note Linear costs lead to negative costs if decision variables are not
     properly constrained. Users may want to check that the solution does not
     contain negative costs.
     @returns the pair <ℓ, g(x)>.
     @throws std::exception if e.GetVariables() is not a subset of x().
-    @pydrake_mkdoc_identifier{expression}
+    @throws std::exception if no transcription is specified.
+     @pydrake_mkdoc_identifier{expression}
     */
     std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
-        const symbolic::Expression& e);
+        const symbolic::Expression& e,
+        const std::unordered_set<Transcription>& use_in_transcription = {
+            Transcription::kMIP, Transcription::kRelaxation,
+            Transcription::kRestriction});
 
     /** Adds a cost to this vertex.  @p binding must contain *only* elements of
     x() as variables. For technical reasons relating to being able to "turn-off"
@@ -232,15 +238,21 @@ class GraphOfConvexSets {
     @verbatim
     min g(x) ⇒ min ℓ, s.t. ℓ ≥ g(x)
     @endverbatim
+    @param use_in_transcription specifies the components of the problem to
+    which the constraint should be added.
     @note Linear costs lead to negative costs if decision variables are not
     properly constrained. Users may want to check that the solution does not
     contain negative costs.
     @returns the pair <ℓ, g(x)>.
     @throws std::exception if binding.variables() is not a subset of x().
+    @throws std::exception if no transcription is specified.
     @pydrake_mkdoc_identifier{binding}
     */
     std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
-        const solvers::Binding<solvers::Cost>& binding);
+        const solvers::Binding<solvers::Cost>& binding,
+        const std::unordered_set<Transcription>& use_in_transcription = {
+            Transcription::kMIP, Transcription::kRelaxation,
+            Transcription::kRestriction});
 
     /** Adds a constraint to this vertex.
     @param f must contain *only* elements of x() as variables.
@@ -272,10 +284,15 @@ class GraphOfConvexSets {
             Transcription::kMIP, Transcription::kRelaxation,
             Transcription::kRestriction});
 
-    /** Returns all costs on this vertex. */
-    const std::vector<solvers::Binding<solvers::Cost>>& GetCosts() const {
-      return costs_;
-    }
+    /** Returns costs on this vertex.
+    @param used_in_transcription specifies the components of the problem from
+    which the constraint should be retrieved.
+    @throws std::exception if no transcription is specified.
+    */
+    std::vector<solvers::Binding<solvers::Cost>> GetCosts(
+        const std::unordered_set<Transcription>& used_in_transcription = {
+            Transcription::kMIP, Transcription::kRelaxation,
+            Transcription::kRestriction}) const;
 
     /** Returns constraints on this vertex.
     @param used_in_transcription specifies the components of the problem from
@@ -319,7 +336,9 @@ class GraphOfConvexSets {
     const VectorX<symbolic::Variable> placeholder_x_{};
     // Note: ell_[i] is associated with costs_[i].
     solvers::VectorXDecisionVariable ell_{};
-    std::vector<solvers::Binding<solvers::Cost>> costs_{};
+    std::vector<std::pair<solvers::Binding<solvers::Cost>,
+                          std::unordered_set<Transcription>>>
+        costs_{};
     std::vector<std::pair<solvers::Binding<solvers::Constraint>,
                           std::unordered_set<Transcription>>>
         constraints_;
@@ -394,15 +413,21 @@ class GraphOfConvexSets {
     @verbatim
     min g(xu, xv) ⇒ min ℓ, s.t. ℓ ≥ g(xu,xv)
     @endverbatim
+    @param use_in_transcription specifies the components of the problem to
+    which the constraint should be added.
     @note Linear costs lead to negative costs if decision variables are not
     properly constrained. Users may want to check that the solution does not
     contain negative costs.
     @returns the pair <ℓ, g(xu, xv)>.
     @throws std::exception if e.GetVariables() is not a subset of xu() ∪ xv().
+    @throws std::exception if no transcription is specified.
     @pydrake_mkdoc_identifier{expression}
     */
     std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
-        const symbolic::Expression& e);
+        const symbolic::Expression& e,
+        const std::unordered_set<Transcription>& use_in_transcription = {
+            Transcription::kMIP, Transcription::kRelaxation,
+            Transcription::kRestriction});
 
     /** Adds a cost to this edge.  @p binding must contain *only* elements of
     xu() and xv() as variables. For technical reasons relating to being able to
@@ -411,16 +436,22 @@ class GraphOfConvexSets {
     @verbatim
     min g(xu, xv) ⇒ min ℓ, s.t. ℓ ≥ g(xu,xv)
     @endverbatim
+    @param use_in_transcription specifies the components of the problem to
+    which the constraint should be added.
     @note Linear costs lead to negative costs if decision variables are not
     properly constrained. Users may want to check that the solution does not
     contain negative costs.
     @returns the pair <ℓ, g(xu, xv)>.
     @throws std::exception if binding.variables() is not a subset of xu() ∪
     xv().
+    @throws std::exception if no transcription is specified.
     @pydrake_mkdoc_identifier{binding}
     */
     std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
-        const solvers::Binding<solvers::Cost>& binding);
+        const solvers::Binding<solvers::Cost>& binding,
+        const std::unordered_set<Transcription>& use_in_transcription = {
+            Transcription::kMIP, Transcription::kRelaxation,
+            Transcription::kRestriction});
 
     /** Adds a constraint to this edge.
     @param f must contain *only* elements of xu() and xv() as variables.
@@ -467,10 +498,15 @@ class GraphOfConvexSets {
     /** Removes any constraints added with AddPhiConstraint. */
     void ClearPhiConstraints();
 
-    /** Returns all costs on this edge. */
-    const std::vector<solvers::Binding<solvers::Cost>>& GetCosts() const {
-      return costs_;
-    }
+    /** Returns costs on this edge.
+    @param used_in_transcription specifies the components of the problem from
+    which the constraint should be retrieved.
+    @throws std::exception if no transcription is specified.
+    */
+    std::vector<solvers::Binding<solvers::Cost>> GetCosts(
+        const std::unordered_set<Transcription>& used_in_transcription = {
+            Transcription::kMIP, Transcription::kRelaxation,
+            Transcription::kRestriction}) const;
 
     /** Returns constraints on this edge.
     @param used_in_transcription specifies the components of the problem from
@@ -521,7 +557,9 @@ class GraphOfConvexSets {
     std::unordered_map<symbolic::Variable, symbolic::Variable> x_to_yz_{};
     // Note: ell_[i] is associated with costs_[i].
     solvers::VectorXDecisionVariable ell_{};
-    std::vector<solvers::Binding<solvers::Cost>> costs_{};
+    std::vector<std::pair<solvers::Binding<solvers::Cost>,
+                          std::unordered_set<Transcription>>>
+        costs_{};
     std::vector<std::pair<solvers::Binding<solvers::Constraint>,
                           std::unordered_set<Transcription>>>
         constraints_;


### PR DESCRIPTION
PR #21179 introduced the ability for constraints in GCS to be applied to subsets of the possible transcriptions. This PR is the follow-up which provides the same functionality when adding costs.

+@wrangelvid for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21650)
<!-- Reviewable:end -->
