### PR TITLE
[tools] Disable code coverage on benchmarks

### DIFF
--- a/tools/performance/defs.bzl
+++ b/tools/performance/defs.bzl
@@ -55,7 +55,7 @@ def drake_cc_googlebench_binary(
                 # runtime errors.)
                 "--benchmark_min_time=0s",
             ] + (test_args or []),
-            tags = (test_tags or []) + ["nolint"],
+            tags = (test_tags or []) + ["nolint", "no_kcov"],
         )
 
 def drake_py_experiment_binary(name, *, googlebench_binary, **kwargs):


### PR DESCRIPTION
Similar in spirit to #21620, motivated by [timeout last night](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-jammy-gcc-bazel-nightly-coverage/268/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21652)
<!-- Reviewable:end -->
