### PR TITLE
Static constructor for CompositeTrajectory that automatically aligns segment timings.

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -539,6 +539,9 @@ class TestTrajectories(unittest.TestCase):
         self.assertIsInstance(traj.segment(segment_index=1),
                               PiecewisePolynomial)
 
+        traj = CompositeTrajectory.AlignAndConcatenate(segments=[pp1, pp2])
+        self.assertIsInstance(traj, CompositeTrajectory)
+
     @numpy_compare.check_all_types
     def test_quaternion_slerp(self, T):
         AngleAxis = AngleAxis_[T]

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -582,7 +582,19 @@ struct Impl {
           }),
               py::arg("segments"), cls_doc.ctor.doc)
           .def("segment", &Class::segment, py::arg("segment_index"),
-              py_rvp::reference_internal, cls_doc.segment.doc);
+              py_rvp::reference_internal, cls_doc.segment.doc)
+          .def_static(
+              "AlignAndConcatenate",
+              [](std::vector<const Trajectory<T>*> py_segments) {
+                std::vector<copyable_unique_ptr<Trajectory<T>>> segments;
+                segments.reserve(py_segments.size());
+                for (const Trajectory<T>* py_segment : py_segments) {
+                  segments.emplace_back(
+                      py_segment ? py_segment->Clone() : nullptr);
+                }
+                return CompositeTrajectory<T>::AlignAndConcatenate(segments);
+              },
+              py::arg("segments"), cls_doc.AlignAndConcatenate.doc);
       DefCopyAndDeepCopy(&cls);
     }
 

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -67,6 +67,8 @@ drake_cc_library(
         "composite_trajectory.h",
     ],
     deps = [
+        ":path_parameterized_trajectory",
+        ":piecewise_polynomial",
         ":piecewise_trajectory",
     ],
 )

--- a/common/trajectories/composite_trajectory.h
+++ b/common/trajectories/composite_trajectory.h
@@ -24,6 +24,7 @@ class CompositeTrajectory final : public trajectories::PiecewiseTrajectory<T> {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CompositeTrajectory);
 
   /** Constructs a composite trajectory from a list of Trajectories.
+  @pre ∀i, `segments[i].get() != nullptr`.
   @pre ∀i, `segments[i+1].start_time() == segments[i].end_time()`.
   @pre ∀i, `segments[i].rows() == segments[0].rows()` and segments[i].cols() ==
   segments[0].cols()`. */
@@ -51,6 +52,14 @@ class CompositeTrajectory final : public trajectories::PiecewiseTrajectory<T> {
     DRAKE_DEMAND(segment_index < this->get_number_of_segments());
     return *segments_[segment_index];
   }
+
+  /** Constructs a composite trajectory from a list of trajectories whose start
+  and end times may not coincide, by translating their start and end times.
+  @pre ∀i, `segments[i].get() != nullptr`.
+  @pre ∀i, `segments[i].rows() == segments[0].rows()` and segments[i].cols() ==
+  segments[0].cols()`. */
+  static CompositeTrajectory<T> AlignAndConcatenate(
+      const std::vector<copyable_unique_ptr<Trajectory<T>>>& segments);
 
  private:
   bool do_has_derivative() const final;

--- a/common/trajectories/test/composite_trajectory_test.cc
+++ b/common/trajectories/test/composite_trajectory_test.cc
@@ -96,6 +96,42 @@ GTEST_TEST(CompositeTrajectoryTest, Empty) {
   DRAKE_EXPECT_THROWS_MESSAGE(traj.cols(), ".*no segments.*");
 }
 
+GTEST_TEST(CompositeTrajectoryTest, NullSegment) {
+  std::vector<copyable_unique_ptr<Trajectory<double>>> segments;
+  // Create a null copyable_unique_ptr.
+  segments.emplace_back(copyable_unique_ptr<Trajectory<double>>());
+  EXPECT_THROW(CompositeTrajectory<double>{segments}, std::exception);
+  EXPECT_THROW(CompositeTrajectory<double>::AlignAndConcatenate(segments),
+               std::exception);
+}
+
+GTEST_TEST(CompositeTrajectoryTest, RetimeAndConcatenate) {
+  Eigen::Matrix<double, 2, 3> points;
+  // clang-format off
+  points << 1, 0, 0,
+            0, 0, 1;
+  // clang-format on
+
+  std::vector<copyable_unique_ptr<Trajectory<double>>> segments(2);
+  segments[0] = std::make_unique<BezierCurve<double>>(2, 3, points);
+
+  points.col(0) = points.col(2);
+  points.col(1) << 3, 10;
+  segments[1] = std::make_unique<BezierCurve<double>>(4, 5, points);
+
+  EXPECT_THROW(CompositeTrajectory<double>{segments}, std::exception);
+
+  CompositeTrajectory<double> traj =
+      CompositeTrajectory<double>::AlignAndConcatenate(segments);
+
+  EXPECT_EQ(traj.start_time(), 2);
+  EXPECT_EQ(traj.end_time(), 4);
+  EXPECT_EQ(traj.value(2), segments[0]->value(2));
+  EXPECT_EQ(traj.value(3), segments[0]->value(3));
+  EXPECT_EQ(traj.value(3), segments[1]->value(4));
+  EXPECT_EQ(traj.value(4), segments[1]->value(5));
+}
+
 }  // namespace
 }  // namespace trajectories
 }  // namespace drake


### PR DESCRIPTION
I have a scenario where I'm generating multiple trajectories (by solving KinematicTrajectoryOptimization problems), and then want to stitch them together into a single long trajectory. However, the start and end times might not line up, so the CompositeTrajectory constructor throws. This provides a convenient class to retime the start and end of each segment, so they align properly.

Not sure who makes sense for this PR -- feel free to assign anyone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21656)
<!-- Reviewable:end -->
