### PR TITLE
Fix Segmentation Fault in GcsTrajectoryOptimization::AddRegions

### DIFF
--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -278,8 +278,8 @@ Subgraph::Subgraph(
   A.setFromTriplets(tripletList.begin(), tripletList.end());
   for (int idx = 0; idx < ssize(edges_between_regions); ++idx) {
     // Add edge.
-    Vertex* u = vertices_[edges_between_regions[idx].first];
-    Vertex* v = vertices_[edges_between_regions[idx].second];
+    Vertex* u = vertices_.at(edges_between_regions[idx].first);
+    Vertex* v = vertices_.at(edges_between_regions[idx].second);
     Edge* uv_edge = traj_opt_.AddEdge(u, v);
 
     edges_.emplace_back(uv_edge);

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -518,6 +518,8 @@ class GcsTrajectoryOptimization final {
   component of the affine map τ_uv in equation (11) of "Non-Euclidean Motion
   Planning with Graphs of Geodesically-Convex Sets", and per the discussion in
   Subsection VI A, τ_uv has no rotation component.
+  @throws std::exception if any index referenced in `edges_between_regions` is
+  outside the range [0, ssize(regions)).
   */
   Subgraph& AddRegions(
       const geometry::optimization::ConvexSets& regions,

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -2320,6 +2320,14 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, ContinuityConstraintSymbolic) {
   }
 }
 
+GTEST_TEST(GcsTrajectoryOptimizationTest, EdgeIndexChecking) {
+  GcsTrajectoryOptimization gcs(1);
+  auto sets = MakeConvexSets(Point(Vector1d(43.0)));
+  std::vector<std::pair<int, int>> edges;
+  edges.emplace_back(0, 1);
+  EXPECT_THROW(gcs.AddRegions(sets, edges, 1), std::exception);
+}
+
 }  // namespace
 }  // namespace trajectory_optimization
 }  // namespace planning


### PR DESCRIPTION
If the user manually specifies the edges between regions and provides an index which is out-of-range, GcsTrajectoryOptimization segfaults. This PR adds a test that reveals the problem, and switches to indexing with `.at(...)` to prevent the segmentation fault.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21658)
<!-- Reviewable:end -->
