### PR TITLE
Fix Segmentation Fault in GraphOfConvexSets::SolveShortestPath

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -458,6 +458,7 @@ drake_cc_googletest(
         "//solvers:ipopt_solver",
         "//solvers:linear_system_solver",
         "//solvers:mosek_solver",
+        "//solvers:scs_solver",
     ],
 )
 

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -1320,8 +1320,14 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
           path_vertex_ids.pop_back();
           new_path.pop_back();
           // Since this code requires result.is_success() to be true, we should
-          // always have a path. We assert that..
-          DRAKE_ASSERT(path_vertex_ids.size() > 0);
+          // always have a path. We assert that...
+          if (path_vertex_ids.size() == 0) {
+            throw std::runtime_error(
+                "Cannot find a valid solution path, even though "
+                "result.is_success() is true. This could be due to tighter "
+                "constraint tolerances on the rounding solution than the "
+                "relaxation solution.");
+          }
           continue;
         }
         Eigen::VectorXd candidate_flows(candidate_edges.size());

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -1332,10 +1332,12 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
           // always have a path. We assert that...
           if (path_vertex_ids.size() == 0) {
             throw std::runtime_error(
-                "Cannot find a valid solution path, even though "
-                "result.is_success() is true. This could be due to tighter "
-                "constraint tolerances on the rounding solution than the "
-                "relaxation solution.");
+                "GCS rounding failed. The convex relaxation returned a "
+                "feasible solution, but there is (definitely) no path from the "
+                "source to the target using only edges with flows > "
+                "options.flow_tolerance. You can set "
+                "options.max_rounded_paths=0 to disable rounding and return "
+                "the solution to the relaxation instead.");
           }
           continue;
         }

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -21,6 +21,7 @@
 #include "drake/solvers/ipopt_solver.h"
 #include "drake/solvers/linear_system_solver.h"
 #include "drake/solvers/mosek_solver.h"
+#include "drake/solvers/scs_solver.h"
 #include "drake/solvers/solver_options.h"
 
 namespace drake {
@@ -2835,6 +2836,37 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
               AllOf(HasSubstr("x = [1.00 2.00]"), HasSubstr("x = [0.00]")));
   EXPECT_THAT(g.GetGraphvizString(result, false, 2, true),
               AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-05]")));
+}
+
+GTEST_TEST(ShortestPathTest, InaccurateRelaxationSolve) {
+  // If the convex relaxation is solved inaccurately, infeasibility may go
+  // undetected. Previously, this could lead the randomized rounding process to
+  // fail quietly, eventually leading to a segmentation fault or other memory
+  // error.
+  Point p1(Vector1d(0.0));
+  Point p2(Vector1d(1.0));
+
+  GraphOfConvexSets g;
+
+  auto v1 = g.AddVertex(p1);
+  auto v2 = g.AddVertex(p1);
+  auto v3 = g.AddVertex(p2);
+  auto v4 = g.AddVertex(p2);
+
+  g.AddEdge(v1, v2);
+  g.AddEdge(v3, v4);
+
+  // Prevent the solver from detecting infeasibility.
+  GraphOfConvexSetsOptions options;
+  options.convex_relaxation = true;
+  options.max_rounded_paths = 100;
+
+  options.solver_options.SetOption(solvers::ScsSolver::id(), "max_iters", 1);
+  solvers::ScsSolver scs;
+  options.solver = &scs;
+
+  DRAKE_EXPECT_THROWS_MESSAGE(g.SolveShortestPath(*v1, *v4, options),
+                              ".*even though result.is_success.*");
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -2900,7 +2900,7 @@ GTEST_TEST(ShortestPathTest, InaccurateRelaxationSolve) {
   options.solver = &scs;
 
   DRAKE_EXPECT_THROWS_MESSAGE(g.SolveShortestPath(*v1, *v4, options),
-                              ".*even though result.is_success.*");
+                              ".*no path from the source to the target.*");
 }
 
 }  // namespace optimization


### PR DESCRIPTION
Suppose one solves a GCS problem using the relax-and-round strategy. If the relaxation is feasible (or at least, not shown to be infeasible by the solver, which I have caused in practice by using loose tolerances), but the mixed-integer problem is indeed infeasible, then there is a bug in the rounding procedure causing a segfault (or various other memory errors), due to running out of feasible paths.

It has a `DRAKE_ASSERT`, but this will not help someone using a release build. (Indeed, I found the bug by accident, and it took quite a while to both identify what I was doing wrong, and where in Drake the problem was even coming from.) I've added an informative error message, and a test case exposing this bug.

Tagging with priority high since this can segfault and it's on drake master.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21662)
<!-- Reviewable:end -->
