### PR TITLE
[framework] Add ExecuteForcedEvents() to System API

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -398,6 +398,9 @@ struct Impl {
         .def("ExecuteInitializationEvents",
             &System<T>::ExecuteInitializationEvents, py::arg("context"),
             doc.System.ExecuteInitializationEvents.doc)
+        .def("ExecuteForcedEvents", &System<T>::ExecuteForcedEvents,
+            py::arg("context"), py::arg("publish") = true,
+            doc.System.ExecuteForcedEvents.doc)
         .def("GetUniquePeriodicDiscreteUpdateAttribute",
             &System<T>::GetUniquePeriodicDiscreteUpdateAttribute,
             doc.System.GetUniquePeriodicDiscreteUpdateAttribute.doc)

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -671,6 +671,14 @@ class TestCustom(unittest.TestCase):
         self.assertFalse(system.called_reset)
         self.assertFalse(system.called_system_reset)
 
+        # Test ExecuteForcedEvents.
+        system = TrivialSystem()
+        context = system.CreateDefaultContext()
+        system.ExecuteForcedEvents(context=context, publish=True)
+        self.assertTrue(system.called_forced_publish)
+        self.assertTrue(system.called_forced_discrete)
+        self.assertTrue(system.called_forced_unrestricted)
+
         # Test witness function error messages.
         system = TrivialSystem()
         system.getwitness_result = None

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -483,16 +483,15 @@ void System<T>::GetInitializationEvents(
 
 template <typename T>
 void System<T>::ExecuteInitializationEvents(Context<T>* context) const {
-  auto discrete_updates = AllocateDiscreteVariables();
-  auto state = context->CloneState();
   auto init_events = AllocateCompositeEventCollection();
+  GetInitializationEvents(*context, init_events.get());
 
   // NOTE: The execution order here must match the code in
   // Simulator::Initialize().
-  GetInitializationEvents(*context, init_events.get());
 
   // Do unrestricted updates first.
   if (init_events->get_unrestricted_update_events().HasEvents()) {
+    auto state = context->CloneState();
     const EventStatus status = CalcUnrestrictedUpdate(
         *context, init_events->get_unrestricted_update_events(), state.get());
     status.ThrowOnFailure(__func__);
@@ -501,6 +500,7 @@ void System<T>::ExecuteInitializationEvents(Context<T>* context) const {
   }
   // Do restricted (discrete variable) updates next.
   if (init_events->get_discrete_update_events().HasEvents()) {
+    auto discrete_updates = AllocateDiscreteVariables();
     const EventStatus status = CalcDiscreteVariableUpdate(
         *context, init_events->get_discrete_update_events(),
         discrete_updates.get());
@@ -512,6 +512,39 @@ void System<T>::ExecuteInitializationEvents(Context<T>* context) const {
   if (init_events->get_publish_events().HasEvents()) {
     const EventStatus status =
         Publish(*context, init_events->get_publish_events());
+    status.ThrowOnFailure(__func__);
+  }
+}
+
+template <typename T>
+void System<T>::ExecuteForcedEvents(Context<T>* context,
+                                    bool publish) const {
+  // NOTE: The execution order here must match the code in
+  // Simulator::Initialize().
+
+  // Do unrestricted updates first.
+  if (get_forced_unrestricted_update_events().HasEvents()) {
+    auto state = context->CloneState();
+    const EventStatus status = CalcUnrestrictedUpdate(
+        *context, get_forced_unrestricted_update_events(), state.get());
+    status.ThrowOnFailure(__func__);
+    ApplyUnrestrictedUpdate(get_forced_unrestricted_update_events(),
+                            state.get(), context);
+  }
+  // Do restricted (discrete variable) updates next.
+  if (get_forced_discrete_update_events().HasEvents()) {
+    auto discrete_updates = AllocateDiscreteVariables();
+    const EventStatus status = CalcDiscreteVariableUpdate(
+        *context, get_forced_discrete_update_events(),
+        discrete_updates.get());
+    status.ThrowOnFailure(__func__);
+    ApplyDiscreteVariableUpdate(get_forced_discrete_update_events(),
+                                discrete_updates.get(), context);
+  }
+  // Do any publishes last.
+  if (publish && get_forced_publish_events().HasEvents()) {
+    const EventStatus status =
+        Publish(*context, get_forced_publish_events());
     status.ThrowOnFailure(__func__);
   }
 }

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -756,9 +756,29 @@ class System : public SystemBase {
   also processes other events associated with time zero. Also, "reached
   termination" returns are ignored here.
 
+  @param[in,out] context The Context supplied to the handlers and modified
+                         in place on return.
+
   @throws std::exception if it invokes an event handler that returns status
                          indicating failure. */
   void ExecuteInitializationEvents(Context<T>* context) const;
+
+  /** This method triggers all of the forced events registered with this
+  %System (which might be a Diagram). Ordering and status return handling
+  mimic the Simulator: unrestricted events are processed first, then
+  discrete update events, then publish events. "Reached termination" status
+  returns are ignored.
+
+  An option is provided to suppress publish events. This can be useful, for
+  example, to update state in a Diagram without triggering a visualization.
+
+  @param[in,out] context The Context supplied to the handlers and modified
+                         in place on return.
+
+  @throws std::exception if it invokes an event handler that returns status
+                         indicating failure. */
+  void ExecuteForcedEvents(Context<T>* context,
+                           bool publish = true) const;
 
   /** Determines whether there exists a unique periodic timing (offset and
   period) that triggers one or more discrete update events (and, if so, returns

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -12,6 +12,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/random.h"
+#include "drake/common/string_map.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -2775,6 +2776,17 @@ class EventSugarTestSystem : public LeafSystem<double> {
     return num_second_unrestricted_update_;
   }
 
+  string_map<int> GetCounts() const {
+    return string_map<int>{
+        {"u1", num_unrestricted_update()},
+        {"u2", num_second_unrestricted_update()},
+        {"d1", num_discrete_update()},
+        {"d2", num_second_discrete_update()},
+        {"p1", num_publish()},
+        {"p2", num_second_publish_handler_publishes()}
+    };
+  }
+
  private:
   EventStatus MyPublishHandler(const Context<double>& context) const {
     MySuccessfulPublishHandler(context);
@@ -2909,12 +2921,10 @@ GTEST_TEST(EventSugarTest, HandlersGetCalled) {
   EXPECT_TRUE(status.succeeded());
   dut.ForcedPublish(*context);
 
-  EXPECT_EQ(dut.num_publish(), 5);
-  EXPECT_EQ(dut.num_second_publish_handler_publishes(), 1);
-  EXPECT_EQ(dut.num_discrete_update(), 5);
-  EXPECT_EQ(dut.num_second_discrete_update(), 1);
-  EXPECT_EQ(dut.num_unrestricted_update(), 5);
-  EXPECT_EQ(dut.num_second_unrestricted_update(), 1);
+  EXPECT_EQ(
+      dut.GetCounts(),
+      (string_map<int>{
+          {"u1", 5}, {"u2", 1}, {"d1", 5}, {"d2", 1}, {"p1", 5}, {"p2", 1}}));
 }
 
 // Verify that user-initiated event APIs throw on handler failure.
@@ -2974,6 +2984,45 @@ GTEST_TEST(EventSugarTest, ForcedEventsDontThrowWhenNoFailure) {
   EXPECT_NO_THROW(successful.ExecuteInitializationEvents(&*successful_context));
   EXPECT_NO_THROW(
       terminating.ExecuteInitializationEvents(&*terminating_context));
+}
+
+GTEST_TEST(EventSugarTest, ForceEventsCanBeTriggered) {
+  EventSugarTestSystem successful(EventStatus::kSucceeded);
+  EventSugarTestSystem terminating(EventStatus::kReachedTermination);
+  EventSugarTestSystem failing(EventStatus::kFailed);
+  failing.set_name("should_fail");
+  auto successful_context = successful.CreateDefaultContext();
+  auto terminating_context = terminating.CreateDefaultContext();
+  auto failing_context = failing.CreateDefaultContext();
+
+  successful.ExecuteForcedEvents(&*successful_context);
+  EXPECT_EQ(
+      successful.GetCounts(),
+      (string_map<int>{
+          {"u1", 1}, {"u2", 1}, {"d1", 1}, {"d2", 1}, {"p1", 1}, {"p2", 1}}));
+
+  // Do that again but without the publish events.
+  successful.ExecuteForcedEvents(&*successful_context, /*publish=*/ false);
+  EXPECT_EQ(
+      successful.GetCounts(),
+      (string_map<int>{
+          {"u1", 2}, {"u2", 2}, {"d1", 2}, {"d2", 2}, {"p1", 1}, {"p2", 1}}));
+
+  // A "reached termination" return should be ignored.
+  terminating.ExecuteForcedEvents(&*terminating_context);
+  EXPECT_EQ(
+      terminating.GetCounts(),
+      (string_map<int>{
+          {"u1", 1}, {"u2", 1}, {"d1", 1}, {"d2", 1}, {"p1", 1}, {"p2", 1}}));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      failing.ExecuteForcedEvents(&*failing_context),
+      "ExecuteForcedEvents.*event handler.*"
+      "EventSugarTestSystem.*should_fail.*failed.*Something bad happened.*");
+  EXPECT_EQ(
+      failing.GetCounts(),
+      (string_map<int>{  // 1st (u1) fails, halts processing.
+          {"u1", 1}, {"u2", 0}, {"d1", 0}, {"d2", 0}, {"p1", 0}, {"p2", 0}}));
 }
 
 // A System that does not override the default implicit time derivatives


### PR DESCRIPTION
Adds `ExecuteForcedEvents()` to trigger all the forced events in a System (or Diagram) and write any modified variables back to a Context.

This is like the existing `System::ExecuteInitializationEvents()`, but for Forced triggers rather than Initialization triggers. `ExecuteForcedEvents()` sequences the events in the same way as the Simulator does: unrestricted events, then discrete events, then publish events. There is an option to suppress publish events.

Unit tests and python bindings are included.

Resolves #21659

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21664)
<!-- Reviewable:end -->
