### PR TITLE
[Mujoco parser] Don't call CalcSpatialInertia unless needed

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -665,7 +665,9 @@ drake_cc_googletest(
         "//geometry:test_obj_files",
         "//geometry:test_stl_files",
         "@mujoco_menagerie_internal//:google_robot",
+        "@mujoco_menagerie_internal//:hello_robot_stretch",
         "@mujoco_menagerie_internal//:kuka_iiwa_14",
+        "@mujoco_menagerie_internal//:rethink_robotics_sawyer",
     ] + _DM_CONTROL_MUJOCO_FILES,
     deps = [
         ":detail_mujoco_parser",

--- a/tools/workspace/mujoco_menagerie_internal/package.BUILD.bazel
+++ b/tools/workspace/mujoco_menagerie_internal/package.BUILD.bazel
@@ -20,9 +20,31 @@ filegroup(
 )
 
 filegroup(
+    name = "hello_robot_stretch",
+    srcs = [
+        "hello_robot_stretch/stretch.xml",
+        "hello_robot_stretch/LICENSE",
+    ] + glob([
+        "hello_robot_stretch/assets/*.obj",
+        "hello_robot_stretch/assets/*.png",
+        "hello_robot_stretch/assets/*.stl",
+    ]),
+)
+
+filegroup(
     name = "kuka_iiwa_14",
     srcs = [
         "kuka_iiwa_14/iiwa14.xml",
         "kuka_iiwa_14/LICENSE",
     ] + glob(["kuka_iiwa_14/assets/*.obj"]),
+)
+
+filegroup(
+    name = "rethink_robotics_sawyer",
+    srcs = [
+        "rethink_robotics_sawyer/sawyer.xml",
+        "rethink_robotics_sawyer/LICENSE",
+    ] + glob([
+        "rethink_robotics_sawyer/assets/*.obj",
+    ]),
 )


### PR DESCRIPTION
Resolves #21648.

This defers the call to CalcSpatialInertia until/unless it is actually needed. If inertia values are specified for the body in the xml file, then we don't call CalcSpatialInertia. This allows us to successfully parse models where CalcSpatialInertia fails on the obj, but the calculation was not needed.

Adds the Rethink Robotics Sawyer (Apache 2.0) model to the detail_mujoco_parser_test; parsing fails on this model without the fix in this PR.

+@SeanCurtis-tri for feature review, please. (Rico is platform tomorrow).  I will open a separate issue for the (seemingly very common) failures in CalcSpatialInertia from obj.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21665)
<!-- Reviewable:end -->
