### PR TITLE
Fix UniformSample for Zero-Measure HPolyhedron

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -305,15 +305,19 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("other"), cls_doc.PontryaginDifference.doc)
         .def("UniformSample",
             overload_cast_explicit<Eigen::VectorXd, RandomGenerator*,
-                const Eigen::Ref<const Eigen::VectorXd>&, int>(
-                &HPolyhedron::UniformSample),
+                const Eigen::Ref<const Eigen::VectorXd>&, int,
+                const std::optional<Eigen::Ref<const Eigen::MatrixXd>>&,
+                double>(&HPolyhedron::UniformSample),
             py::arg("generator"), py::arg("previous_sample"),
-            py::arg("mixing_steps") = 10, cls_doc.UniformSample.doc_3args)
+            py::arg("mixing_steps") = 10, py::arg("subspace") = std::nullopt,
+            py::arg("tol") = 1e-8, cls_doc.UniformSample.doc_5args)
         .def("UniformSample",
-            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*, int>(
-                &HPolyhedron::UniformSample),
+            overload_cast_explicit<Eigen::VectorXd, RandomGenerator*, int,
+                const std::optional<Eigen::Ref<const Eigen::MatrixXd>>&,
+                double>(&HPolyhedron::UniformSample),
             py::arg("generator"), py::arg("mixing_steps") = 10,
-            cls_doc.UniformSample.doc_2args)
+            py::arg("subspace") = std::nullopt, py::arg("tol") = 1e-8,
+            cls_doc.UniformSample.doc_4args)
         .def_static("MakeBox", &HPolyhedron::MakeBox, py::arg("lb"),
             py::arg("ub"), cls_doc.MakeBox.doc)
         .def_static("MakeUnitBox", &HPolyhedron::MakeUnitBox, py::arg("dim"),

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -267,16 +267,32 @@ class HPolyhedron final : public ConvexSet, private ShapeReifier {
   point. The distribution of samples will converge to the true uniform
   distribution at a geometric rate in the total number of hit-and-run steps
   which is `mixing_steps` * the number of times this function is called.
+  If a `subspace` is provided, the random samples are constrained to lie in the
+  affine subspace through `previous_sample`, spanned by the columns of
+  `subspace`. To obtain uniform samples, subspace should have orthonormal,
+  columns. This enables drawing uniform samples from an HPolyhedron which is not
+  full-dimensional -- one can pass the basis of the affine hull of the
+  HPolyhedron, which can be computed with the AffineSubspace class. `tol` is a
+  numerical tolerance for checking if any halfspaces in the given HPolyhedron
+  are implied by the `subspace` definition (and therefore can be ignored by the
+  hit-and-run sampler).
+  @pre subspace.rows() == ambient_dimension().
   @throws std::exception if previous_sample is not in the set. */
   Eigen::VectorXd UniformSample(
       RandomGenerator* generator,
       const Eigen::Ref<const Eigen::VectorXd>& previous_sample,
-      int mixing_steps = 10) const;
+      int mixing_steps = 10,
+      const std::optional<Eigen::Ref<const Eigen::MatrixXd>>& subspace =
+          std::nullopt,
+      double tol = 1e-8) const;
 
   /** Variant of UniformSample that uses the ChebyshevCenter() as the
   previous_sample as a feasible point to start the Markov chain sampling. */
-  Eigen::VectorXd UniformSample(RandomGenerator* generator,
-                                int mixing_steps = 10) const;
+  Eigen::VectorXd UniformSample(
+      RandomGenerator* generator, int mixing_steps = 10,
+      const std::optional<Eigen::Ref<const Eigen::MatrixXd>>& subspace =
+          std::nullopt,
+      double tol = 1e-8) const;
 
   /** Constructs a polyhedron as an axis-aligned box from the lower and upper
   corners. */

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1394,6 +1394,43 @@ GTEST_TEST(HPolyhedronTest, UniformSampleTest3) {
   EXPECT_FALSE(CompareMatrices(A, B, kTol));
 }
 
+// Test that we can draw samples from not-full-dimensional HPolyhedra
+GTEST_TEST(HPolyhedronTest, UniformSampleTest4) {
+  Matrix<double, 2, 2> points;
+  // clang-format off
+  points << 0, 1,
+            0, 1;
+  // clang-format on
+  VPolytope V(points);
+  HPolyhedron H(V);
+  const double kTol = 1e-7;
+
+  // Verify that without passing in the basis of the affine hull,
+  // trying to draw a uniform sample just gives us previous_sample,
+  // since it is not full-dimensional.
+  std::optional<VectorXd> maybe_point = H.MaybeGetFeasiblePoint();
+  ASSERT_TRUE(maybe_point.has_value());
+  VectorXd point = maybe_point.value();
+
+  RandomGenerator generator(1234);
+  VectorXd point_A = H.UniformSample(&generator, point, 10);
+  EXPECT_TRUE(CompareMatrices(point, point_A, kTol));
+
+  // Compute the affine hull, and use this to draw samples.
+  AffineSubspace as(H);
+  MatrixXd basis = as.basis();
+  VectorXd point_B = H.UniformSample(&generator, point, 10, basis);
+  EXPECT_FALSE(CompareMatrices(point, point_B, kTol));
+
+  // Check that a subspace of incompatible shape throws. In this case,
+  // the subspace has four rows, which does not equal the ambient
+  // dimension of the HPolyhedron, which is two.
+  Matrix<double, 4, 1> bad_basis;
+  bad_basis << 0, 1, 2, 3;
+  EXPECT_THROW(H.UniformSample(&generator, point, 1, bad_basis),
+               std::exception);
+}
+
 GTEST_TEST(HPolyhedronTest, Serialize) {
   const HPolyhedron H = HPolyhedron::MakeL1Ball(3);
   const std::string yaml = yaml::SaveYamlString(H);


### PR DESCRIPTION
This allows you to draw samples from a measure-zero HPolyhedron, by passing in an appropriate basis of its affine hull.

Closes #21026.

Note that there's an issue with the python bindings, but hopefully, we can get started with feature review while I work on fixing that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21667)
<!-- Reviewable:end -->
