### PR TITLE
Ignore brew installed packages

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -67,4 +67,4 @@ if ! command -v pip3.12 &>/dev/null; then
   exit 2
 fi
 
-pip3.12 install --break-system-packages -r "${BASH_SOURCE%/*}/requirements.txt"
+pip3.12 install --disable-pip-version-check --break-system-packages --ignore-installed -r "${BASH_SOURCE%/*}/requirements.txt"


### PR DESCRIPTION
Fixes setup bug where Pip attempts to install a downgraded Numpy (`<2`) on top of Brew's installed `numpy@2` on MacOS, which results in:
```
[1:08:03 AM]    Attempting uninstall: numpy
[1:08:03 AM]      Found existing installation: numpy 2.0.0
[1:08:03 AM]  ERROR: Cannot uninstall numpy 2.0.0, RECORD file not found. Hint: The package was installed by brew.
```
To reproduce the above error, simply run: `./setup/mac/install_prereqs.sh`.

This PR takes one viable approach by simply allowing Pip to disregard what Brew has already installed and install its own numpy version.
Currently I apply this change for all packages installed in the run of pip associated with the numpy install.
This can be updated to limit this call to only the numpy install.

I will note this is essentially the nuclear option here and could potentially cause slight increases in setup times if the overlap between Brew and pip is substantial.

Alternatively, we can use Pip's `--no-build-isolation` and virtual environments to build numpy in isolation from Brew's python similar to how [Spack does things](https://discuss.python.org/t/pip-build-isolation-without-installing-build-dependencies/52145/6)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21677)
<!-- Reviewable:end -->
