### PR TITLE
[multibody] Add ContactResults non-default constructor

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -108,7 +108,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "ContactResults", param, cls_doc.doc);
     cls  // BR
-        .def(py::init<>(), cls_doc.ctor.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def("num_point_pair_contacts", &Class::num_point_pair_contacts,
             cls_doc.num_point_pair_contacts.doc)
         .def("point_pair_contact_info", &Class::point_pair_contact_info,

--- a/multibody/plant/contact_results.cc
+++ b/multibody/plant/contact_results.cc
@@ -53,6 +53,23 @@ ContactResults<T>& ContactResults<T>::operator=(
 }
 
 template <typename T>
+ContactResults<T>::ContactResults(
+    std::vector<PointPairContactInfo<T>>&& point_pair,
+    std::vector<HydroelasticContactInfo<T>>&& hydroelastic,
+    std::vector<DeformableContactInfo<T>>&& deformable)
+    : point_pairs_info_(std::move(point_pair)),
+      deformable_contact_info_(std::move(deformable)) {
+  // TODO(jwnimmer-tri) The variant-based member field representation forces us
+  // into this outrageous allocation loop. A future rewrite of this class will
+  // use a simple full-vector move here, instead.
+  auto& destination = hydroelastic_contact_info_.template emplace<1>();
+  destination.reserve(hydroelastic.size());
+  for (const HydroelasticContactInfo<T>& item : hydroelastic) {
+    destination.push_back(std::make_unique<HydroelasticContactInfo<T>>(item));
+  }
+}
+
+template <typename T>
 ContactResults<T>::~ContactResults() = default;
 
 template <typename T>

--- a/multibody/plant/contact_results.h
+++ b/multibody/plant/contact_results.h
@@ -34,10 +34,18 @@ template <typename T>
 class ContactResults {
  public:
   ContactResults();
+
   ContactResults(const ContactResults&);
   ContactResults(ContactResults&&) = default;
   ContactResults& operator=(const ContactResults&);
   ContactResults& operator=(ContactResults&&) = default;
+
+  /** Constructs a ContactResults with the given values. */
+  explicit ContactResults(
+      std::vector<PointPairContactInfo<T>>&& point_pair,
+      std::vector<HydroelasticContactInfo<T>>&& hydroelastic = {},
+      std::vector<DeformableContactInfo<T>>&& deformable = {});
+
   ~ContactResults();
 
   /** Returns the number of point pair contacts. */

--- a/multibody/plant/test/contact_results_test.cc
+++ b/multibody/plant/test/contact_results_test.cc
@@ -29,7 +29,7 @@ class ContactResultsTest : public ::testing::Test {
         std::move(surface_mesh), std::move(field));
     my_hydroelastic_contact_info_ =
         std::make_unique<HydroelasticContactInfo<double>>(
-            contact_surface_.get(), SpatialForce<double>{},
+            contact_surface_.get(), F_,
             std::vector<HydroelasticQuadraturePointData<double>>{});
     id_A_ = GeometryId::get_new_id();
     id_B_ = GeometryId::get_new_id();
@@ -38,8 +38,7 @@ class ContactResultsTest : public ::testing::Test {
     deformable_contact_point_data.emplace_back(
         Vector3d(11, 22, 33), 42, Vector3d(44, 55, 66), Vector3d(77, 88, 99));
     deformable_contact_info_ = std::make_unique<DeformableContactInfo<double>>(
-        id_A_, id_B_, PolygonSurfaceMesh<double>(),
-        SpatialForce<double>(Vector3d(1, 2, 3), Vector3d(4, 5, 6)),
+        id_A_, id_B_, PolygonSurfaceMesh<double>(), F_,
         std::move(deformable_contact_point_data));
   }
 
@@ -55,6 +54,7 @@ class ContactResultsTest : public ::testing::Test {
       PenetrationAsPointPair<double>{}};
   GeometryId id_A_;
   GeometryId id_B_;
+  SpatialForce<double> F_{Vector3d(1, 2, 3), Vector3d(4, 5, 6)};
   std::unique_ptr<DeformableContactInfo<double>> deformable_contact_info_;
   std::unique_ptr<ContactSurface<double>> contact_surface_;
   std::unique_ptr<HydroelasticContactInfo<double>>
@@ -193,6 +193,28 @@ TEST_F(ContactResultsTest, SelectHydroelastic) {
   // Verify the deep copy by checking for different memory address.
   EXPECT_NE(&one_hydro_contact.hydroelastic_contact_info(0),
             my_hydroelastic_contact_info_.get());
+}
+
+TEST_F(ContactResultsTest, VectorConstructor) {
+  // Call the vector-of-infos constructor.
+  const ContactResults<double> dut{
+      std::vector<PointPairContactInfo<double>>{point_pair_info_},
+      std::vector<HydroelasticContactInfo<double>>{
+          *my_hydroelastic_contact_info_},
+      std::vector<DeformableContactInfo<double>>{*deformable_contact_info_}};
+
+  // Spot check the basic counts.
+  EXPECT_EQ(dut.num_point_pair_contacts(), 1);
+  EXPECT_EQ(dut.num_hydroelastic_contacts(), 1);
+  EXPECT_EQ(dut.num_deformable_contacts(), 1);
+  EXPECT_EQ(dut.plant(), nullptr);
+
+  // Spot check one field on each sub-info.
+  EXPECT_EQ(dut.point_pair_contact_info(0).bodyB_index(),
+            point_pair_info_.bodyB_index());
+  EXPECT_EQ(dut.hydroelastic_contact_info(0).F_Ac_W().get_coeffs(),
+            F_.get_coeffs());
+  EXPECT_EQ(dut.deformable_contact_info(0).id_B(), id_B_);
 }
 
 }  // namespace multibody


### PR DESCRIPTION
Users need a way to populate contact results without calling internal functions. We are going to remove the internal functions soon, so now is a good time to add the missing API.

Towards removing `AddContactInfo()` as part of https://github.com/RobotLocomotion/drake/pull/21623, and therefore towards https://github.com/RobotLocomotion/drake/issues/20545.  (Our dear friends in Anzu have decided to call the internal-use-only `ContactResults::AddContactInfo()` function, so we need a replacement before I remove it.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21685)
<!-- Reviewable:end -->
