### PR TITLE
[planning] Improve direct transcription error messages

### DIFF
--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -166,6 +166,7 @@ drake_cc_googletest(
         "//solvers:solve",
         "//systems/primitives:symbolic_vector_system",
         "//systems/primitives:trajectory_linear_system",
+        "//systems/primitives:zero_order_hold",
     ],
 )
 

--- a/planning/trajectory_optimization/direct_transcription.cc
+++ b/planning/trajectory_optimization/direct_transcription.cc
@@ -151,11 +151,18 @@ class DirectTranscriptionConstraint : public solvers::Constraint {
   const double fixed_time_step_{0};
 };
 
-double get_period(const System<double>* system, std::string message) {
+double get_period(const System<double>* system) {
+  if (system->num_abstract_states() > 0) {
+    throw std::logic_error(
+        "DirectTranscription cannot operate on systems with abstract state.");
+  }
   std::optional<PeriodicEventData> periodic_data =
       system->GetUniquePeriodicDiscreteUpdateAttribute();
   if (!periodic_data.has_value()) {
-    throw std::invalid_argument(message);
+    throw std::logic_error(
+        "This constructor is for discrete-time systems with a single unique "
+        "update period. For continuous-time systems, you must use a different "
+        "constructor that specifies the time steps.");
   }
   DRAKE_DEMAND(periodic_data->offset_sec() == 0.0);
   return periodic_data->period_sec();
@@ -164,6 +171,7 @@ double get_period(const System<double>* system, std::string message) {
 int get_input_port_size(
     const System<double>* system,
     std::variant<InputPortSelection, InputPortIndex> input_port_index) {
+  DRAKE_THROW_UNLESS(system != nullptr);
   if (system->get_input_port_selection(input_port_index)) {
     return system->get_input_port_selection(input_port_index)->size();
   } else {
@@ -179,12 +187,7 @@ DirectTranscription::DirectTranscription(
     const std::variant<InputPortSelection, InputPortIndex>& input_port_index)
     : MultipleShooting(get_input_port_size(system, input_port_index),
                        context.num_total_states(), num_time_samples,
-                       get_period(system,
-                                  "This constructor is for discrete-time "
-                                  "systems.  For continuous-time "
-                                  "systems, you must use a different "
-                                  "constructor that specifies the "
-                                  "time steps.")),
+                       get_period(system)),
       discrete_time_system_(true) {
   ValidateSystem(*system, context, input_port_index);
 

--- a/planning/trajectory_optimization/test/direct_transcription_test.cc
+++ b/planning/trajectory_optimization/test/direct_transcription_test.cc
@@ -19,6 +19,7 @@
 #include "drake/systems/primitives/linear_system.h"
 #include "drake/systems/primitives/symbolic_vector_system.h"
 #include "drake/systems/primitives/trajectory_linear_system.h"
+#include "drake/systems/primitives/zero_order_hold.h"
 
 namespace drake {
 namespace planning {
@@ -124,7 +125,7 @@ GTEST_TEST(DirectTranscriptionTest, DiscreteTimeConstraintTest) {
   CubicPolynomialSystem<double> system(kTimeStep);
 
   const auto context = system.CreateDefaultContext();
-  int kNumSampleTimes = 3;
+  const int kNumSampleTimes = 3;
 
   // The continuous-time constructor throws.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -169,7 +170,7 @@ GTEST_TEST(DirectTranscriptionTest, ContinuousTimeConstraintTest) {
       Vector1<Expression>{sin(x)}, Vector0<Expression>{});
 
   const auto context = system.CreateDefaultContext();
-  int kNumSampleTimes = 3;
+  const int kNumSampleTimes = 3;
 
   // The discrete-time constructor throws.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -211,7 +212,7 @@ GTEST_TEST(DirectTranscriptionTest, DiscreteTimeSymbolicConstraintTest) {
   std::unique_ptr<AffineSystem<double>> system = MakeAffineSystem(kTimeStep);
 
   const auto context = system->CreateDefaultContext();
-  int kNumSampleTimes = 3;
+  const int kNumSampleTimes = 3;
   DirectTranscription dirtran(system.get(), *context, kNumSampleTimes);
   auto& prog = dirtran.prog();
 
@@ -252,7 +253,7 @@ GTEST_TEST(DirectTranscriptionTest, ContinuousTimeSymbolicConstraintTest) {
   std::unique_ptr<AffineSystem<double>> system = MakeAffineSystem(0.0);
 
   const auto context = system->CreateDefaultContext();
-  int kNumSampleTimes = 3;
+  const int kNumSampleTimes = 3;
   const double kTimeStep = 0.1;
   DirectTranscription dirtran(system.get(), *context, kNumSampleTimes,
                               TimeStep{kTimeStep});
@@ -390,7 +391,7 @@ GTEST_TEST(DirectTranscriptionTest, DiscreteTimeLinearSystemTest) {
   LinearSystem<double> system(A, B, C, D, kTimeStep);
 
   const auto context = system.CreateDefaultContext();
-  int kNumSampleTimes = 3;
+  const int kNumSampleTimes = 3;
   DirectTranscription dirtran(&system, *context, kNumSampleTimes);
   auto& prog = dirtran.prog();
 
@@ -452,7 +453,7 @@ GTEST_TEST(DirectTranscriptionTest, TimeVaryingLinearSystemTest) {
     // system is continuous time.
     TrajectoryLinearSystem<double> system(A, B, C, D);
     const auto context = system.CreateDefaultContext();
-    int kNumSampleTimes = 3;
+    const int kNumSampleTimes = 3;
     DRAKE_EXPECT_THROWS_MESSAGE(
         DirectTranscription(&system, *context, kNumSampleTimes),
         ".*is for discrete-time systems.*");
@@ -462,7 +463,7 @@ GTEST_TEST(DirectTranscriptionTest, TimeVaryingLinearSystemTest) {
   TrajectoryLinearSystem<double> system(A, B, C, D, kTimeStep);
 
   const auto context = system.CreateDefaultContext();
-  int kNumSampleTimes = 3;
+  const int kNumSampleTimes = 3;
   DirectTranscription dirtran(&system, *context, kNumSampleTimes);
   auto& prog = dirtran.prog();
 
@@ -553,6 +554,26 @@ GTEST_TEST(DirectTranscriptionTest, LinearSystemWParamsTest) {
               prog.GetInitialGuess(dirtran.state(i + 1)[0]) -
                   kGain * prog.GetInitialGuess(dirtran.state(i)[0]));
   }
+}
+
+GTEST_TEST(DirectTranscriptionTest, RejectAbstractState) {
+  const double kTimeStep = 1.0;
+  const int kNumSampleTimes = 3;
+
+  // A trivial system, but with abstract state.
+  const systems::ZeroOrderHold<double> system(kTimeStep, Value<int>(0));
+  const auto context = system.CreateDefaultContext();
+
+  // The discrete-time constructor throws.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DirectTranscription(&system, *context, kNumSampleTimes),
+      ".*abstract.*state.*");
+
+  // The continuous-time constructor throws.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DirectTranscription(&system, *context, kNumSampleTimes,
+                          TimeStep(kTimeStep)),
+      ".*abstract.*state.*");
 }
 
 // TODO(russt): Add tests for ReconstructTrajectory methods once their output is


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/pull/21623 (which will add abstract state, and trip the old error message which was not helpful in this situation), and therefore towards https://github.com/RobotLocomotion/drake/issues/20545.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21688)
<!-- Reviewable:end -->
