### PR TITLE
[pydrake] Remove vestigial build details

### DIFF
--- a/bindings/pydrake/examples/gym/BUILD.bazel
+++ b/bindings/pydrake/examples/gym/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@python//:version.bzl", "PYTHON_VERSION")
 load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
 load("//tools/install:install.bzl", "install")
 load(
@@ -98,11 +97,6 @@ drake_py_test(
     srcs = ["train_cart_pole.py"],
     args = ["--test"],
     main = "train_cart_pole.py",
-    # DrakeGym is only supported for Python >= 3.10.
-    tags = ["manual"] if PYTHON_VERSION in [
-        "3.8",
-        "3.9",
-    ] else [],
     deps = [
         ":cart_pole_binaries",
         "@gymnasium_py",
@@ -115,11 +109,6 @@ drake_py_test(
     srcs = ["play_cart_pole.py"],
     args = ["--test"],
     main = "play_cart_pole.py",
-    # DrakeGym is only supported for Python >= 3.10.
-    tags = ["manual"] if PYTHON_VERSION in [
-        "3.8",
-        "3.9",
-    ] else [],
     deps = [
         ":cart_pole_binaries",
         "@gymnasium_py",

--- a/bindings/pydrake/gym/BUILD.bazel
+++ b/bindings/pydrake/gym/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@python//:version.bzl", "PYTHON_VERSION")
 load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
 load("//tools/install:install.bzl", "install")
 load(
@@ -48,11 +47,6 @@ drake_py_library(
 # to prevent this from being a circular dependency.
 drake_py_unittest(
     name = "drake_gym_test",
-    # DrakeGym is only supported for Python >= 3.10.
-    tags = ["manual"] if PYTHON_VERSION in [
-        "3.8",
-        "3.9",
-    ] else [],
     deps = [
         ":gym",
         ":mock_torch_py",


### PR DESCRIPTION
We no longer support Ubuntu 20.04 Focal, so we don't need to guard our CI against too-old Python versions.

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21690)
<!-- Reviewable:end -->
