### PR TITLE
CalcSpatialInertia handles Convex correctly

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -265,6 +265,7 @@ drake_cc_library(
         "//geometry:shape_specification",
         "//geometry/proximity:make_mesh_from_vtk",
         "//geometry/proximity:obj_to_surface_mesh",
+        "//geometry/proximity:polygon_to_triangle_mesh",
         "//geometry/proximity:triangle_surface_mesh",
         "//geometry/proximity:volume_to_surface_mesh",
     ],
@@ -687,6 +688,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "geometry_spatial_inertia_test",
     data = [
+        "//geometry:test_obj_files",
         "//geometry:test_vtk_files",
         "//multibody/parsing:test_models",
     ],

--- a/multibody/tree/geometry_spatial_inertia.h
+++ b/multibody/tree/geometry_spatial_inertia.h
@@ -22,11 +22,6 @@ namespace multibody {
  @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>&,double)
  "see below".
 
- Note: Spatial inertia calculations for the geometry::Convex type do not
- currently require that the underlying mesh actually be convex. Although certain
- collision calculations involving geometry::Convex may use the mesh's convex
- hull, this function uses the *actual* mesh.
-
  @retval M_BBo_B The spatial inertia of the hypothetical body implied by the
                  given `shape`.
  @throws std::exception if `shape` is an instance of geometry::HalfSpace or

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -72,7 +72,7 @@ constexpr double kTol = std::numeric_limits<double>::epsilon();
 // provide the same value as passing through the SpatialInertia APIs.
 // This supports that goal as a regression test.
 
-GTEST_TEST(GeometrySpatialInertaTest, Box) {
+GTEST_TEST(GeometrySpatialInertiaTest, Box) {
   const double Lx = 1;
   const double Ly = 2;
   const double Lz = 3;
@@ -83,7 +83,7 @@ GTEST_TEST(GeometrySpatialInertaTest, Box) {
                                    M_BBo_B, /* tolerance = */ 0.0));
 }
 
-GTEST_TEST(GeometrySpatialInertaTest, Capsule) {
+GTEST_TEST(GeometrySpatialInertiaTest, Capsule) {
   const double r = 1.5;
   const double L = 2;
   const geometry::Capsule capsule(r, L);
@@ -96,7 +96,7 @@ GTEST_TEST(GeometrySpatialInertaTest, Capsule) {
 
 // Note: Convex can be found below in the MeshTypes test.
 
-GTEST_TEST(GeometrySpatialInertaTest, Cylinder) {
+GTEST_TEST(GeometrySpatialInertiaTest, Cylinder) {
   const double r = 1.5;
   const double L = 2;
   const geometry::Cylinder cylinder(r, L);
@@ -107,7 +107,7 @@ GTEST_TEST(GeometrySpatialInertaTest, Cylinder) {
                                    M_BBo_B, /* tolerance = */ 0.0));
 }
 
-GTEST_TEST(GeometrySpatialInertaTest, Ellipsoid) {
+GTEST_TEST(GeometrySpatialInertiaTest, Ellipsoid) {
   const double a = 1.5;
   const double b = 2.5;
   const double c = 3.5;
@@ -118,26 +118,47 @@ GTEST_TEST(GeometrySpatialInertaTest, Ellipsoid) {
                                    M_BBo_B, /* tolerance = */ 0.0));
 }
 
-GTEST_TEST(GeometrySpatialInertaTest, HalfSpace) {
+GTEST_TEST(GeometrySpatialInertiaTest, HalfSpace) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       CalcSpatialInertia(geometry::HalfSpace(), kDensity), ".*HalfSpace.*");
 }
 
 // Note: Mesh can be found below in the MeshTypes test.
 
-GTEST_TEST(GeometrySpatialInertaTest, MeshcatCone) {
+GTEST_TEST(GeometrySpatialInertiaTest, MeshcatCone) {
   const geometry::MeshcatCone cone(1, 2, 3);
   DRAKE_EXPECT_THROWS_MESSAGE(CalcSpatialInertia(cone, kDensity),
                               ".*MeshcatCone.*");
 }
 
-GTEST_TEST(GeometrySpatialInertaTest, Sphere) {
+GTEST_TEST(GeometrySpatialInertiaTest, Sphere) {
   const double r = 1.5;
   const geometry::Sphere sphere(r);
   const SpatialInertia<double> M_BBo_B =
       SpatialInertia<double>::SolidSphereWithDensity(kDensity, r);
   EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(sphere, kDensity),
                                    M_BBo_B, /* tolerance = */ 0.0));
+}
+
+// Confirm that Convex shapes use the convex hull. This doesn't fully test all
+// parameters -- see the Administrivia test below for those. This simply looks
+// for evidence that the convex hull is used.
+GTEST_TEST(GeometrySpatialInertiaTest, Convex) {
+  // A cube with edge length 2, but with a hole cut through it. We'll double the
+  // measure to confirm the scale factor contributes.
+  const std::string cube_path =
+      FindResourceOrThrow("drake/geometry/test/cube_with_hole.obj");
+  const SpatialInertia<double> M_BBo_B =
+      SpatialInertia<double>::SolidBoxWithDensity(kDensity, 4, 4, 4);
+  // The inertia of the convex hull matches an equivalent box.
+  EXPECT_TRUE(SpatialInertiasEqual(
+      CalcSpatialInertia(geometry::Convex(cube_path, 2), kDensity), M_BBo_B,
+      /* tolerance = */ 1e-15));
+  // The inertia of the *mesh* doesn't match that of its convex hull.
+  EXPECT_FALSE(SpatialInertiasEqual(
+      CalcSpatialInertia(geometry::Convex(cube_path, 2), kDensity),
+      CalcSpatialInertia(geometry::Mesh(cube_path, 2), kDensity),
+      /* tolerance = */ 1e-1));
 }
 
 // Exercises the common code paths for Mesh and Convex (i.e., "MeshTypes").
@@ -177,9 +198,15 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
 
     EXPECT_NO_THROW(CalcSpatialInertia(unit_scale_obj, kDensity));
     EXPECT_NO_THROW(CalcSpatialInertia(unit_scale_vtk, kDensity));
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        CalcSpatialInertia(nonexistent, kDensity),
-        ".*only supports .obj or .*.vtk .* given '.*nonexistent.stl'.*");
+    if constexpr (std::is_same_v<MeshType, geometry::Mesh>) {
+      // For MeshType = Convex, we won't achieve *this* error message in
+      // CalcSpatialInertia; we'll fail in the underlying computation of the
+      // convex hull for an unsupported file type (which is tested elsewhere).
+      // So, we'll skip *this* test for Convex.
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          CalcSpatialInertia(nonexistent, kDensity),
+          ".*only supports .obj or .*.vtk .* given '.*nonexistent.stl'.*");
+      }
   }
 
   {


### PR DESCRIPTION
`CalcSpatialInertia()` was trying to operate directly on the mesh file, counter to the documented contract that a `Convex` shape is *always* its convex hull.

Updates mujoco parser to use the convex hull's spatial inertia when attempts to compute *a* physically valid spatial inertia for a mesh fails. Note: the warning stays (but is updated). The mujoco parser likewise posts a warning when the mesh is replaced by its convex hull.

Resolves #21681

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21693)
<!-- Reviewable:end -->
