### PR TITLE
[multibody] Rework ContactResults for performance and safety

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -935,6 +935,7 @@ drake_cc_googletest(
     deps = [
         ":contact_results",
         ":multibody_plant_core",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 

--- a/multibody/plant/contact_results.cc
+++ b/multibody/plant/contact_results.cc
@@ -6,71 +6,20 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
-ContactResults<T>::ContactResults() {
-  // Make this hold pointers at first (see comment on
-  // hydroelastic_contact_info_).
-  hydroelastic_contact_info_ = std::vector<const HydroelasticContactInfo<T>*>();
-}
-
-template <typename T>
-ContactResults<T>::ContactResults(const ContactResults<T>& contact_results) {
-  *this = contact_results;
-}
-
-template <typename T>
-ContactResults<T>& ContactResults<T>::operator=(
-    const ContactResults<T>& contact_results) {
-  // Make the type a vector of const pointers if we can.
-  if (contact_results.num_hydroelastic_contacts() == 0) {
-    hydroelastic_contact_info_ =
-        std::vector<const HydroelasticContactInfo<T>*>();
-  } else {
-    // If this currently holds pointers, we need to change the type.
-    if (hydroelastic_contact_vector_ownership_mode() == kAliasedPointers) {
-      hydroelastic_contact_info_ =
-          std::vector<std::unique_ptr<HydroelasticContactInfo<T>>>();
-    }
-
-    // Copy the HydroelasticContactInfo data.
-    std::vector<std::unique_ptr<HydroelasticContactInfo<T>>>&
-        hydroelastic_contact_vector =
-            hydroelastic_contact_vector_of_unique_ptrs();
-    hydroelastic_contact_vector.resize(
-        contact_results.num_hydroelastic_contacts());
-    for (int i = 0; i < contact_results.num_hydroelastic_contacts(); ++i) {
-      const HydroelasticContactInfo<T>& contact_info =
-          contact_results.hydroelastic_contact_info(i);
-      hydroelastic_contact_vector[i] =
-          std::make_unique<HydroelasticContactInfo<T>>(contact_info);
-    }
-  }
-
-  point_pairs_info_ = contact_results.point_pairs_info_;
-  deformable_contact_info_ = contact_results.deformable_contact_info_;
-  plant_ = contact_results.plant_;
-
-  return *this;
-}
-
-template <typename T>
 ContactResults<T>::ContactResults(
     std::vector<PointPairContactInfo<T>>&& point_pair,
     std::vector<HydroelasticContactInfo<T>>&& hydroelastic,
-    std::vector<DeformableContactInfo<T>>&& deformable)
-    : point_pairs_info_(std::move(point_pair)),
-      deformable_contact_info_(std::move(deformable)) {
-  // TODO(jwnimmer-tri) The variant-based member field representation forces us
-  // into this outrageous allocation loop. A future rewrite of this class will
-  // use a simple full-vector move here, instead.
-  auto& destination = hydroelastic_contact_info_.template emplace<1>();
-  destination.reserve(hydroelastic.size());
-  for (const HydroelasticContactInfo<T>& item : hydroelastic) {
-    destination.push_back(std::make_unique<HydroelasticContactInfo<T>>(item));
-  }
-}
+    std::vector<DeformableContactInfo<T>>&& deformable,
+    std::shared_ptr<const void>&& backing_store)
+    : data_(std::make_shared<Data>(
+          Data{std::move(point_pair), std::move(hydroelastic),
+               std::move(deformable), std::move(backing_store)})) {}
 
 template <typename T>
 ContactResults<T>::~ContactResults() = default;
+
+// TODO(jwnimmer-tri) The order of these definitions does not match the header
+// file. We should shuffle them around to match.
 
 template <typename T>
 const MultibodyPlant<T>* ContactResults<T>::plant() const {
@@ -78,91 +27,54 @@ const MultibodyPlant<T>* ContactResults<T>::plant() const {
 }
 
 template <typename T>
-void ContactResults<T>::set_plant(const MultibodyPlant<T>* plant) {
-  DRAKE_THROW_UNLESS(plant != nullptr);
-  plant_ = plant;
-}
-
-template <typename T>
-void ContactResults<T>::Clear() {
-  point_pairs_info_.clear();
-  if (hydroelastic_contact_vector_ownership_mode() == kAliasedPointers) {
-    hydroelastic_contact_vector_of_pointers().clear();
-  } else {
-    hydroelastic_contact_vector_of_unique_ptrs().clear();
-  }
-  deformable_contact_info_.clear();
-  plant_ = nullptr;
-}
-
-template <typename T>
 const PointPairContactInfo<T>& ContactResults<T>::point_pair_contact_info(
     int i) const {
   DRAKE_THROW_UNLESS(i >= 0 && i < num_point_pair_contacts());
-  return point_pairs_info_[i];
+  DRAKE_ASSERT(data_ != nullptr);
+  return data_->point_pair[i];
 }
 
 template <typename T>
 const HydroelasticContactInfo<T>& ContactResults<T>::hydroelastic_contact_info(
     int i) const {
   DRAKE_THROW_UNLESS(i >= 0 && i < num_hydroelastic_contacts());
-  if (hydroelastic_contact_vector_ownership_mode() == kAliasedPointers) {
-    return *hydroelastic_contact_vector_of_pointers()[i];
-  } else {
-    return *hydroelastic_contact_vector_of_unique_ptrs()[i];
-  }
+  DRAKE_ASSERT(data_ != nullptr);
+  return data_->hydroelastic[i];
 }
 
 template <typename T>
 const DeformableContactInfo<T>& ContactResults<T>::deformable_contact_info(
     int i) const {
   DRAKE_THROW_UNLESS(i >= 0 && i < num_deformable_contacts());
-  return deformable_contact_info_[i];
+  DRAKE_ASSERT(data_ != nullptr);
+  return data_->deformable[i];
 }
 
-template <typename T>
-void ContactResults<T>::AddContactInfo(
-    const HydroelasticContactInfo<T>* hydroelastic_contact_info) {
-  DRAKE_DEMAND(hydroelastic_contact_vector_ownership_mode() ==
-               kAliasedPointers);
-  hydroelastic_contact_vector_of_pointers().push_back(
-      hydroelastic_contact_info);
-}
-
-template <typename T>
-int ContactResults<T>::num_hydroelastic_contacts() const {
-  if (hydroelastic_contact_vector_ownership_mode() == kAliasedPointers) {
-    return static_cast<int>(hydroelastic_contact_vector_of_pointers().size());
-  } else {
-    return static_cast<int>(
-        hydroelastic_contact_vector_of_unique_ptrs().size());
-  }
-}
-
+// TODO(jwnimmer-tri) For a function intended as a performance hack, this is
+// sure doing a lot of copying. We should consider deprecating this for removal.
 template <typename T>
 ContactResults<T> ContactResults<T>::SelectHydroelastic(
     std::function<bool(const HydroelasticContactInfo<T>&)> selector) const {
-  ContactResults<T> selected_alias_pointers;
-  if (this->plant() != nullptr) {
-    selected_alias_pointers.set_plant(this->plant());
+  if (num_hydroelastic_contacts() == 0) {
+    return *this;
   }
-  int num_hydroelastic_contacts = this->num_hydroelastic_contacts();
-  for (int i = 0; i < num_hydroelastic_contacts; ++i) {
-    const HydroelasticContactInfo<T>& contact_info =
-        this->hydroelastic_contact_info(i);
-    if (selector(contact_info)) {
-      selected_alias_pointers.AddContactInfo(&contact_info);
-    }
-  }
-  // Deep copy of the selected hydroelastic contact info.
-  ContactResults<T> output_unique_pointers = selected_alias_pointers;
-  // Deep copy of the point pair contact info.
-  output_unique_pointers.point_pairs_info_ = this->point_pairs_info_;
-  // Deep copy of the deformable contact info.
-  output_unique_pointers.deformable_contact_info_ =
-      this->deformable_contact_info_;
+  DRAKE_DEMAND(data_ != nullptr);
+  std::vector<HydroelasticContactInfo<T>> selected;
+  std::copy_if(data_->hydroelastic.begin(), data_->hydroelastic.end(),
+               std::back_inserter(selected), selector);
+  ContactResults<T> result(
+      std::vector<PointPairContactInfo<T>>(data_->point_pair),
+      std::move(selected),
+      std::vector<DeformableContactInfo<T>>(data_->deformable),
+      std::shared_ptr<const void>(data_->backing_store));
+  result.plant_ = this->plant_;
+  return result;
+}
 
-  return output_unique_pointers;
+template <typename T>
+void ContactResults<T>::set_plant(const MultibodyPlant<T>* plant) {
+  DRAKE_THROW_UNLESS(plant != nullptr);
+  plant_ = plant;
 }
 
 }  // namespace multibody

--- a/multibody/plant/contact_results.h
+++ b/multibody/plant/contact_results.h
@@ -1,14 +1,11 @@
 #pragma once
 
+#include <functional>
 #include <memory>
-#include <utility>
-#include <variant>
 #include <vector>
 
-#include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/eigen_types.h"
 #include "drake/common/ssize.h"
 #include "drake/multibody/plant/deformable_contact_info.h"
 #include "drake/multibody/plant/hydroelastic_contact_info.h"
@@ -22,43 +19,46 @@ template <typename T>
 class MultibodyPlant;
 #endif
 
-/**
- A container class storing the contact results information for each contact
- pair for a given state of the simulation. Note that copying this data structure
- is expensive when `num_hydroelastic_contacts() > 0` because a deep copy is
- performed.
+/** A container class storing the contact results information for each contact
+ pair for a given state of the simulation.
 
- @tparam_default_scalar
- */
+ This class is immutable, so can be efficiently copied and moved.
+
+ @tparam_default_scalar */
 template <typename T>
 class ContactResults {
  public:
-  ContactResults();
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactResults);
 
-  ContactResults(const ContactResults&);
-  ContactResults(ContactResults&&) = default;
-  ContactResults& operator=(const ContactResults&);
-  ContactResults& operator=(ContactResults&&) = default;
+  /** Constructs an empty %ContactResults. */
+  ContactResults() = default;
 
-  /** Constructs a ContactResults with the given values. */
+  /** Constructs a %ContactResults with the given contact infos.
+
+  (Advanced) The optional `backing_store` argument allows the caller to keep
+  alive type-erased shared_ptr data that is referenced by the contact infos.
+  This object will hold the `backing_store` until this object is destroyed. */
   explicit ContactResults(
       std::vector<PointPairContactInfo<T>>&& point_pair,
       std::vector<HydroelasticContactInfo<T>>&& hydroelastic = {},
-      std::vector<DeformableContactInfo<T>>&& deformable = {});
+      std::vector<DeformableContactInfo<T>>&& deformable = {},
+      std::shared_ptr<const void>&& backing_store = {});
 
   ~ContactResults();
 
   /** Returns the number of point pair contacts. */
   int num_point_pair_contacts() const {
-    return static_cast<int>(point_pairs_info_.size());
+    return (data_ != nullptr) ? ssize(data_->point_pair) : 0;
   }
 
   /** Returns the number of hydroelastic contacts. */
-  int num_hydroelastic_contacts() const;
+  int num_hydroelastic_contacts() const {
+    return (data_ != nullptr) ? ssize(data_->hydroelastic) : 0;
+  }
 
   /** Returns the number of deformable contacts. */
   int num_deformable_contacts() const {
-    return ssize(deformable_contact_info_);
+    return (data_ != nullptr) ? ssize(data_->deformable) : 0;
   }
 
   /** Retrieves the ith PointPairContactInfo instance. The input index i
@@ -80,14 +80,15 @@ class ContactResults {
   result will be non-null, but default-constructed results might have nulls. */
   const MultibodyPlant<T>* plant() const;
 
-  /** Returns ContactResults with only HydroelasticContactInfo instances
-   satisfying the selection criterion and with all PointPairContactInfo
-   instances.
+  /** Returns a selective copy of this object. Only HydroelasticContactInfo
+   instances satisfying the selection criterion are copied; all other contacts
+   (point_pair and deformable) are unconditionally copied.
 
    @param selector Boolean predicate that returns true to select which
                    HydroelasticContactInfo.
 
-   @note It uses deep copy. */
+   @note It uses deep copy (unless the operation is trivially identifiable as
+    being vacuous, e.g., when num_hydroelastic_contacts() == 0). */
   ContactResults<T> SelectHydroelastic(
       std::function<bool(const HydroelasticContactInfo<T>&)> selector) const;
 
@@ -96,85 +97,16 @@ class ContactResults {
 #ifndef DRAKE_DOXYGEN_CXX
   /* Sets the plant that produced these contact results. */
   void set_plant(const MultibodyPlant<T>* plant);
-
-  /* Clears the set of contact information for when the old data becomes
-   invalid. This includes clearing the `plant` back to nullptr. */
-  void Clear();
-
-  /* Adds a new contact pair result to `this`. */
-  void AddContactInfo(const PointPairContactInfo<T>& point_pair_info) {
-    point_pairs_info_.push_back(point_pair_info);
-  }
-
-  /* Adds a new hydroelastic contact to `this`, assuming that `this` is not the
-   result of a copy operation (AddContactInfo() asserts that is the case). The
-   pointer must remain valid for the lifetime of this object. */
-  void AddContactInfo(
-      const HydroelasticContactInfo<T>* hydroelastic_contact_info);
-
-  /* Adds a new deformable contact result to `this`. */
-  void AddContactInfo(DeformableContactInfo<T> deformable_contact_info) {
-    deformable_contact_info_.push_back(std::move(deformable_contact_info));
-  }
 #endif
 
  private:
-  enum OwnershipMode { kAliasedPointers, kOwnsCopies };
-
-  OwnershipMode hydroelastic_contact_vector_ownership_mode() const {
-    return std::holds_alternative<
-               std::vector<const HydroelasticContactInfo<T>*>>(
-               hydroelastic_contact_info_)
-               ? kAliasedPointers
-               : kOwnsCopies;
-  }
-
-  const std::vector<const HydroelasticContactInfo<T>*>&
-  hydroelastic_contact_vector_of_pointers() const {
-    return std::get<std::vector<const HydroelasticContactInfo<T>*>>(
-        hydroelastic_contact_info_);
-  }
-
-  std::vector<const HydroelasticContactInfo<T>*>&
-  hydroelastic_contact_vector_of_pointers() {
-    return std::get<std::vector<const HydroelasticContactInfo<T>*>>(
-        hydroelastic_contact_info_);
-  }
-
-  const std::vector<std::unique_ptr<HydroelasticContactInfo<T>>>&
-  hydroelastic_contact_vector_of_unique_ptrs() const {
-    return std::get<std::vector<std::unique_ptr<HydroelasticContactInfo<T>>>>(
-        hydroelastic_contact_info_);
-  }
-
-  std::vector<std::unique_ptr<HydroelasticContactInfo<T>>>&
-  hydroelastic_contact_vector_of_unique_ptrs() {
-    return std::get<std::vector<std::unique_ptr<HydroelasticContactInfo<T>>>>(
-        hydroelastic_contact_info_);
-  }
-
-  std::vector<PointPairContactInfo<T>> point_pairs_info_;
-
-  /* We use a variant type to keep from copying already owned data (from a
-   cache), i.e., the HydroelasticContactInfo, into this data structure, if
-   possible. By default, the variant stores the first type, i.e.,
-   std::vector<const HydroelasticContactInfo<T>*>. If this data structure is
-   copied, however, the variant changes to instead store the second type, a
-   vector of unique pointers. In that case, all of the underlying
-   HydroelasticContactInfo objects are copied and
-   AddContactInfo(const HydroelasticContactInfo*) can no longer be called on the
-   copy (see assertion in AddContactInfo).
-
-   Note that we jump through these hoops because storing ContactResults into
-   a cache entry requires that it be placed into a Value<ContactResults>, which
-   in turn requires that ContactResults be copyable.
-   */
-  std::variant<std::vector<const HydroelasticContactInfo<T>*>,
-               std::vector<std::unique_ptr<HydroelasticContactInfo<T>>>>
-      hydroelastic_contact_info_;
-
-  std::vector<DeformableContactInfo<T>> deformable_contact_info_;
-
+  struct Data {
+    std::vector<PointPairContactInfo<T>> point_pair;
+    std::vector<HydroelasticContactInfo<T>> hydroelastic;
+    std::vector<DeformableContactInfo<T>> deformable;
+    std::shared_ptr<const void> backing_store;
+  };
+  std::shared_ptr<const Data> data_{nullptr};
   const MultibodyPlant<T>* plant_{nullptr};
 };
 

--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -668,12 +668,11 @@ void DeformableDriver<T>::AppendDeformableRigidFixedConstraintKinematics(
 
 template <typename T>
 void DeformableDriver<T>::CalcDeformableContactInfo(
-    const systems::Context<T>& context,
+    const DeformableContact<T>& deformable_contact,
+    const DiscreteContactData<DiscreteContactPair<T>>& contact_pairs,
+    const ContactSolverResults<T>& solver_results,
     std::vector<DeformableContactInfo<T>>* contact_info) const {
   DRAKE_DEMAND(contact_info != nullptr);
-
-  const DeformableContact<T>& deformable_contact =
-      EvalDeformableContact(context);
 
   const std::vector<DeformableContactSurface<T>>& contact_surfaces =
       deformable_contact.contact_surfaces();
@@ -681,11 +680,6 @@ void DeformableDriver<T>::CalcDeformableContactInfo(
 
   contact_info->clear();
   contact_info->reserve(num_surfaces);
-
-  const DiscreteContactData<DiscreteContactPair<T>>& contact_pairs =
-      manager_->EvalDiscreteContactPairs(context);
-  const contact_solvers::internal::ContactSolverResults<T>& solver_results =
-      manager_->EvalContactSolverResults(context);
 
   const VectorX<T>& fn = solver_results.fn;
   const VectorX<T>& ft = solver_results.ft;
@@ -1014,7 +1008,7 @@ void DeformableDriver<T>::CalcDeformableContact(
 template <typename T>
 const DeformableContact<T>& DeformableDriver<T>::EvalDeformableContact(
     const Context<T>& context) const {
-  return manager_->EvalGeometryContactData(context).deformable;
+  return manager_->EvalGeometryContactData(context).get().deformable;
 }
 
 template <typename T>

--- a/multibody/plant/deformable_driver.h
+++ b/multibody/plant/deformable_driver.h
@@ -8,6 +8,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/contact_solver_results.h"
 #include "drake/multibody/contact_solvers/sap/partial_permutation.h"
 #include "drake/multibody/contact_solvers/sap/sap_fixed_constraint.h"
 #include "drake/multibody/contact_solvers/schur_complement.h"
@@ -156,11 +157,12 @@ class DeformableDriver : public ScalarConvertibleComponent<T> {
       std::vector<contact_solvers::internal::FixedConstraintKinematics<T>>*
           result) const;
 
-  /* Computes the contact information for all deformable bodies for the given
-   `context`.
+  /* Computes the contact information for all deformable bodies.
    @pre contact_info != nullptr. */
   void CalcDeformableContactInfo(
-      const systems::Context<T>& context,
+      const geometry::internal::DeformableContact<T>& deformable_contact,
+      const DiscreteContactData<DiscreteContactPair<T>>& contact_pairs,
+      const contact_solvers::internal::ContactSolverResults<T>& solver_results,
       std::vector<DeformableContactInfo<T>>* contact_info) const;
 
   /* Evaluates FemState at the next time step for each deformable body and

--- a/multibody/plant/geometry_contact_data.cc
+++ b/multibody/plant/geometry_contact_data.cc
@@ -1,4 +1,49 @@
 #include "drake/multibody/plant/geometry_contact_data.h"
 
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+void GeometryContactData<T>::Clear() {
+  data_.reset();
+}
+
+template <typename T>
+NestedGeometryContactData<T>& GeometryContactData<T>::Allocate() {
+  data_ = std::make_shared<NestedGeometryContactData<T>>();
+  return const_cast<NestedGeometryContactData<T>&>(*data_);
+}
+
+template <typename T>
+std::shared_ptr<const NestedGeometryContactData<T>>
+GeometryContactData<T>::Share() const {
+  return (data_ != nullptr)
+             // When our shared_ptr<Data> already exists, then we can just
+             // return a copy of it (which just bumps the use_count).
+             ? data_
+             // Otherwise, we'll return a shared_ptr that doesn't actually
+             // manage anything (i.e., equivalent to a raw pointer), and which
+             // points to static const storage.
+             : std::shared_ptr<const NestedGeometryContactData<T>>(
+                   /* managed object = */ std::shared_ptr<const void>{},
+                   /* stored pointer = */ &get_empty_ref());
+}
+
+template <typename T>
+const NestedGeometryContactData<T>& GeometryContactData<T>::get_empty_ref() {
+  static const never_destroyed<NestedGeometryContactData<T>> result;
+  return result.access();
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    struct ::drake::multibody::internal::GeometryContactData);
+    struct ::drake::multibody::internal::NestedGeometryContactData);
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::GeometryContactData);

--- a/multibody/plant/geometry_contact_data.h
+++ b/multibody/plant/geometry_contact_data.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
@@ -20,29 +21,66 @@ it's always empty.
 When T != double, the class is specialized to omit member data that is
 incompatible with such scalars.
 
+This class is almost never used directly, rather via the GeometryContactData
+reference-counted wrapper.
+
 @tparam_default_scalar */
 template <typename T>
-struct GeometryContactData {
+struct NestedGeometryContactData {
   std::vector<geometry::PenetrationAsPointPair<T>> point_pairs;
   std::vector<geometry::ContactSurface<T>> surfaces;
   geometry::internal::DeformableContact<T> deformable;
 };
 
-/* Full specialization of HydroelasticContactInfo for T = AutoDiffXd.
+/* Full specialization of NestedGeometryContactData for T = AutoDiffXd.
 This omits DeformableContact data. */
 template <>
-struct GeometryContactData<AutoDiffXd> {
+struct NestedGeometryContactData<AutoDiffXd> {
   using T = AutoDiffXd;
   std::vector<geometry::PenetrationAsPointPair<T>> point_pairs;
   std::vector<geometry::ContactSurface<T>> surfaces;
 };
 
-/* Full specialization of HydroelasticContactInfo for T = Expression.
+/* Full specialization of NestedGeometryContactData for T = Expression.
 This omits ContactSurface and DeformableContact data. */
 template <>
-struct GeometryContactData<symbolic::Expression> {
+struct NestedGeometryContactData<symbolic::Expression> {
   using T = symbolic::Expression;
   std::vector<geometry::PenetrationAsPointPair<T>> point_pairs;
+};
+
+/* A reference-counted, immutable wrapper around NestedGeometryContactData, for
+use with AbstractValue type erasure.
+
+@tparam_default_scalar */
+template <typename T>
+class GeometryContactData {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryContactData);
+  GeometryContactData() = default;
+
+  /* Returns a reference to the nested data. If there isn't any nested data,
+  a completely empty nested object will be returned. */
+  const NestedGeometryContactData<T>& get() const {
+    return (data_ != nullptr) ? *data_ : get_empty_ref();
+  }
+
+  /* Set this object back to its default-constructed, empty state. */
+  void Clear();
+
+  /* Resets this to fresh storage and returns a mutable reference to it. */
+  NestedGeometryContactData<T>& Allocate();
+
+  /* Returns a shared_ptr to the data. Note that this aliases the *current* data
+  storage. Future calls that Allocate() and then mutate have no effect on this
+  return value. */
+  std::shared_ptr<const NestedGeometryContactData<T>> Share() const;
+
+ private:
+  /* Returns a forever-valid reference (to static storage) that is empty. */
+  static const NestedGeometryContactData<T>& get_empty_ref();
+
+  std::shared_ptr<const NestedGeometryContactData<T>> data_{nullptr};
 };
 
 }  // namespace internal
@@ -50,4 +88,7 @@ struct GeometryContactData<symbolic::Expression> {
 }  // namespace drake
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    struct ::drake::multibody::internal::GeometryContactData);
+    struct ::drake::multibody::internal::NestedGeometryContactData);
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::GeometryContactData);

--- a/multibody/plant/hydroelastic_contact_forces_continuous_cache_data.h
+++ b/multibody/plant/hydroelastic_contact_forces_continuous_cache_data.h
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "drake/multibody/math/spatial_force.h"
-#include "drake/multibody/plant/hydroelastic_contact_info.h"
 
 namespace drake {
 namespace multibody {
@@ -20,9 +19,13 @@ struct HydroelasticContactForcesContinuousCacheData {
   // (indexed by MobodIndex) in the MultibodyPlant.
   std::vector<SpatialForce<T>> F_BBo_W_array;
 
-  // Information used for contact reporting collected through the evaluation
-  // of the hydroelastic model.
-  std::vector<HydroelasticContactInfo<T>> contact_info;
+  // The i'th element of this vector is congruent with the i'th element of the
+  // vector of `surfaces` in its related GeometryContactData. Together, this
+  // i'th force and i'th surface pair up to form the HydroelasticContactInfo for
+  // a hydroelastic contact. See HydroelasticContactInfo::F_Ac_W() for full
+  // documentation on the semantics (but in short: it's the force on the body
+  // associated with the i'th surface).
+  std::vector<SpatialForce<T>> F_Ac_W_array;
 };
 
 }  // namespace internal

--- a/multibody/plant/hydroelastic_contact_info.cc
+++ b/multibody/plant/hydroelastic_contact_info.cc
@@ -4,6 +4,38 @@
 
 namespace drake {
 namespace multibody {
+namespace {
+
+using geometry::ContactSurface;
+
+// If `other` is already shared, then we can alias it. Otherwise, we need to
+// clone the bare pointer so that it can be shared from now on.
+template <typename T>
+std::shared_ptr<const ContactSurface<T>> ConstructSharedSurface(
+    const std::shared_ptr<const ContactSurface<T>>& other) {
+  DRAKE_DEMAND(other != nullptr);
+  return (other.use_count() > 0)
+             ? other
+             : std::make_shared<const ContactSurface<T>>(*other);
+}
+
+}  // namespace
+
+template <typename T>
+HydroelasticContactInfo<T>::HydroelasticContactInfo(
+    const HydroelasticContactInfo& other)
+    : contact_surface_(ConstructSharedSurface(other.contact_surface_)),
+      F_Ac_W_(other.F_Ac_W_) {}
+
+template <typename T>
+HydroelasticContactInfo<T>& HydroelasticContactInfo<T>::operator=(
+    const HydroelasticContactInfo& other) {
+  if (this != &other) {
+    contact_surface_ = ConstructSharedSurface(other.contact_surface_);
+    F_Ac_W_ = other.F_Ac_W_;
+  }
+  return *this;
+}
 
 template <typename T>
 HydroelasticContactInfo<T>::~HydroelasticContactInfo() = default;

--- a/multibody/plant/hydroelastic_contact_info.h
+++ b/multibody/plant/hydroelastic_contact_info.h
@@ -2,16 +2,19 @@
 
 #include <memory>
 #include <utility>
-#include <variant>
+
+// Remove 2024-11-01 with deprecation.
 #include <vector>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/unused.h"
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/multibody/math/spatial_algebra.h"
+
+// Remove 2024-11-01 with deprecation.
+#include "drake/common/unused.h"
 #include "drake/multibody/plant/hydroelastic_quadrature_point_data.h"
 
 namespace drake {
@@ -39,97 +42,80 @@ namespace multibody {
 template <typename T>
 class HydroelasticContactInfo {
  public:
-  /** @name                 Construction
-   The constructors below adhere to a number of invariants. The
-   geometry::ContactSurface defines contact between two geometries M and N (via
-   contact_surface().id_M() and contact_surface().id_N(), respectively).
+  /** Constructs this structure using the given contact surface and spatial
+   force.
+
+   The geometry::ContactSurface defines contact between two geometries M and N
+   (via contact_surface().id_M() and contact_surface().id_N(), respectively).
    %HydroelasticContactInfo further associates geometries M and N with the
    bodies to which they are rigidly fixed, A and B, respectively. It is the
-   responsibility of the caller of these constructors to ensure that the
+   responsibility of the caller of this constructor to ensure that the
    parameters satisfy the documented invariants, see below. Similarly, the
    spatial force `F_Ac_W` must be provided as indicated by the monogram notation
    in use, that is, it is the spatial force on body A, at the contact surface's
-   centroid C, and expressed in the world frame. */
-  // @{
-
-  /**
-   @anchor hydro_contact_info_non_owning_ctor
-   Constructs this structure using the given contact surface, traction field,
-   and slip field. This constructor does not own the ContactSurface; it points
-   to a ContactSurface that another owns, see contact_surface().
+   centroid C, and expressed in the world frame.
 
    @param[in] contact_surface Contact surface between two geometries M and N,
      see geometry::ContactSurface::id_M() and geometry::ContactSurface::id_N().
+     This must point to immutable data (i.e., data that will never change),
+     and must not be nullptr.
    @param[in] F_Ac_W Spatial force applied on body A, at contact surface
      centroid C, and expressed in the world frame W. The position `p_WC` of C in
      the world frame W can be obtained with
-     `ContactSurface::centroid()`.
-   @param[in] quadrature_point_data Ignored data that will be discarded, kept
-     here as an argument only for backwards compatibility.  */
-  HydroelasticContactInfo(const geometry::ContactSurface<T>* contact_surface,
-                          const SpatialForce<T>& F_Ac_W,
-                          std::vector<HydroelasticQuadraturePointData<T>>&&
-                              quadrature_point_data = {})
-      : contact_surface_(contact_surface), F_Ac_W_(F_Ac_W) {
-    unused(quadrature_point_data);
-    DRAKE_DEMAND(contact_surface != nullptr);
+     `ContactSurface::centroid()`. */
+  HydroelasticContactInfo(
+      std::shared_ptr<const geometry::ContactSurface<T>> contact_surface,
+      const SpatialForce<T>& F_Ac_W)
+      : contact_surface_(std::move(contact_surface)), F_Ac_W_(F_Ac_W) {
+    DRAKE_THROW_UNLESS(contact_surface_ != nullptr);
   }
 
-  /** This constructor takes ownership of `contact_surface` via a
-   std::unique_ptr, instead of aliasing a pre-existing contact surface. In all
-   other respects, it is identical to the @ref
-   hydro_contact_info_non_owning_ctor "other overload" that takes
-   `contact_surface` by raw pointer.  */
+  /** (Advanced) Constructs by aliasing the given contact_surface, without any
+   expensive reference counting. It is the responsibility of the caller to
+   ensure that the given contact_surface outlives this object. Copying or
+   moving this object will result in a deep copy of the surface. */
+  HydroelasticContactInfo(const geometry::ContactSurface<T>* contact_surface,
+                          const SpatialForce<T>& F_Ac_W)
+      // Delegate to the prior constructor, by using a shared_ptr with no
+      // managed object.
+      : HydroelasticContactInfo(
+            std::shared_ptr<const geometry::ContactSurface<T>>(
+                /* managed object = */ std::shared_ptr<const void>{},
+                /* stored pointer = */ contact_surface),
+            F_Ac_W) {}
+
+  DRAKE_DEPRECATED("2024-11-01", "Do not pass quadrature_point_data.")
+  HydroelasticContactInfo(
+      const geometry::ContactSurface<T>* contact_surface,
+      const SpatialForce<T>& F_Ac_W,
+      std::vector<HydroelasticQuadraturePointData<T>>&& quadrature_point_data)
+      : HydroelasticContactInfo(contact_surface, F_Ac_W) {
+    unused(quadrature_point_data);
+  }
+
+  DRAKE_DEPRECATED("2024-11-01", "Do not pass quadrature_point_data.")
   HydroelasticContactInfo(
       std::unique_ptr<geometry::ContactSurface<T>> contact_surface,
       const SpatialForce<T>& F_Ac_W,
-      std::vector<HydroelasticQuadraturePointData<T>>&& quadrature_point_data =
-          {})
-      : contact_surface_(std::move(contact_surface)), F_Ac_W_(F_Ac_W) {
+      std::vector<HydroelasticQuadraturePointData<T>>&& quadrature_point_data)
+      : HydroelasticContactInfo(std::move(contact_surface), F_Ac_W) {
     unused(quadrature_point_data);
-    DRAKE_DEMAND(std::get<std::unique_ptr<geometry::ContactSurface<T>>>(
-                     contact_surface_) != nullptr);
-  }
-  // @}
-
-  /// @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
-  /// MoveAssignable.
-  //@{
-
-  /** Clones this data structure, making deep copies of all underlying data.
-   @note The new object will contain a cloned ContactSurface even if the
-         original was constructed using a raw pointer referencing an existing
-         ContactSurface.
-   */
-  HydroelasticContactInfo(const HydroelasticContactInfo& info) { *this = info; }
-
-  /** Clones this object in the same manner as the copy constructor.
-   @see HydroelasticContactInfo(const HydroelasticContactInfo&)
-   */
-  HydroelasticContactInfo& operator=(const HydroelasticContactInfo& info) {
-    contact_surface_ =
-        std::make_unique<geometry::ContactSurface<T>>(info.contact_surface());
-    F_Ac_W_ = info.F_Ac_W_;
-    return *this;
   }
 
-  HydroelasticContactInfo(HydroelasticContactInfo&&) = default;
-  HydroelasticContactInfo& operator=(HydroelasticContactInfo&&) = default;
-
-  //@}
+  /** @name Implements CopyConstructible, CopyAssignable */
+  /** @{ */
+  HydroelasticContactInfo(const HydroelasticContactInfo&);
+  HydroelasticContactInfo& operator=(const HydroelasticContactInfo&);
+  // The move operators would offer no real performance advantage over copying,
+  // so we don't provide either of the move overloads.
+  /** @} */
 
   ~HydroelasticContactInfo();
 
   /** Returns a reference to the ContactSurface data structure. Note that
    the mesh and gradient vector fields are expressed in the world frame. */
   const geometry::ContactSurface<T>& contact_surface() const {
-    if (std::holds_alternative<const geometry::ContactSurface<T>*>(
-            contact_surface_)) {
-      return *std::get<const geometry::ContactSurface<T>*>(contact_surface_);
-    } else {
-      return *std::get<std::unique_ptr<geometry::ContactSurface<T>>>(
-          contact_surface_);
-    }
+    return *contact_surface_;
   }
 
   DRAKE_DEPRECATED(
@@ -149,9 +135,8 @@ class HydroelasticContactInfo {
 
  private:
   // Note that the mesh of the contact surface is defined in the world frame.
-  std::variant<const geometry::ContactSurface<T>*,
-               std::unique_ptr<geometry::ContactSurface<T>>>
-      contact_surface_;
+  // This is never nullptr.
+  std::shared_ptr<const geometry::ContactSurface<T>> contact_surface_;
 
   // The spatial force applied at the centroid (Point C) of the surface mesh.
   SpatialForce<T> F_Ac_W_;

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -148,9 +148,9 @@ class SpheresStackTest : public SpheresStack, public ::testing::Test {
     const GeometryContactData<double>& geometry_contact_data =
         EvalGeometryContactData(*plant_context_);
     const std::vector<PenetrationAsPointPair<double>>& point_pairs =
-        geometry_contact_data.point_pairs;
+        geometry_contact_data.get().point_pairs;
     const std::vector<geometry::ContactSurface<double>>& surfaces =
-        geometry_contact_data.surfaces;
+        geometry_contact_data.get().surfaces;
     const int num_point_pairs = point_pairs.size();
     ASSERT_EQ(surfaces.size(), 1u);
     const int num_hydro_pairs = surfaces[0].num_faces();
@@ -442,14 +442,14 @@ TEST_F(SpheresStackTest,
   SetupRigidGroundCompliantSphereAndNonHydroSphere();
 
   const std::vector<PenetrationAsPointPair<double>>& point_pairs =
-      EvalGeometryContactData(*plant_context_).point_pairs;
+      EvalGeometryContactData(*plant_context_).get().point_pairs;
   const int num_point_pairs = point_pairs.size();
   EXPECT_EQ(num_point_pairs, 1);
   const DiscreteContactData<DiscreteContactPair<double>>& pairs =
       contact_manager_->EvalDiscreteContactPairs(*plant_context_);
 
   const std::vector<geometry::ContactSurface<double>>& surfaces =
-      EvalGeometryContactData(*plant_context_).surfaces;
+      EvalGeometryContactData(*plant_context_).get().surfaces;
   ASSERT_EQ(surfaces.size(), 1);
   EXPECT_EQ(pairs.size(), surfaces[0].num_faces() + num_point_pairs);
 }

--- a/multibody/plant/test/contact_results_test.cc
+++ b/multibody/plant/test/contact_results_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/limit_malloc.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
 namespace drake {
@@ -41,6 +42,18 @@ class ContactResultsTest : public ::testing::Test {
         std::move(deformable_contact_point_data));
   }
 
+  std::vector<PointPairContactInfo<double>> MakePointPair() const {
+    return {point_pair_info_};
+  }
+
+  std::vector<HydroelasticContactInfo<double>> MakeHydroelastic() const {
+    return {*my_hydroelastic_contact_info_};
+  }
+
+  std::vector<DeformableContactInfo<double>> MakeDeformable() const {
+    return {*deformable_contact_info_};
+  }
+
  protected:
   const MultibodyPlant<double> plant_{/* time_step */ 0.01};
   const PointPairContactInfo<double> point_pair_info_{
@@ -68,29 +81,71 @@ TEST_F(ContactResultsTest, Default) {
   EXPECT_EQ(default_contact_results.plant(), nullptr);
 }
 
-// Tests the set, access, and clear operations. For the access and clear
-// operations, the code has two branches that:
-//   1. use alias pointers for hydroealstic_contact_info_
-//   2. use unique pointers for hydroelastic_contact_info_ (happens after
-//      assignment or copy constructor).
-TEST_F(ContactResultsTest, SetAccessClear) {
-  // Set
-  // It will use alias pointer to my_hydroelastic_contact_info_.
-  ContactResults<double> contact_results;
-  contact_results.set_plant(&plant_);
-  contact_results.AddContactInfo(point_pair_info_);
-  contact_results.AddContactInfo(my_hydroelastic_contact_info_.get());
-  contact_results.AddContactInfo(*deformable_contact_info_);
+TEST_F(ContactResultsTest, VectorConstructor) {
+  // Call the vector-of-infos constructor.
+  const ContactResults<double> dut{MakePointPair(), MakeHydroelastic(),
+                                   MakeDeformable()};
 
-  // Access
+  // Spot check the basic counts.
+  EXPECT_EQ(dut.num_point_pair_contacts(), 1);
+  EXPECT_EQ(dut.num_hydroelastic_contacts(), 1);
+  EXPECT_EQ(dut.num_deformable_contacts(), 1);
+  EXPECT_EQ(dut.plant(), nullptr);
+
+  // Spot check one field on each sub-info.
+  EXPECT_EQ(dut.point_pair_contact_info(0).bodyB_index(),
+            point_pair_info_.bodyB_index());
+  EXPECT_EQ(dut.hydroelastic_contact_info(0).F_Ac_W().get_coeffs(),
+            F_.get_coeffs());
+  EXPECT_EQ(dut.deformable_contact_info(0).id_B(), id_B_);
+}
+
+TEST_F(ContactResultsTest, BackingStore) {
+  // We'll use this storage to interrogate exactly what contact results does
+  // with its `backing_store` constructor argument.
+  auto storage = std::make_shared<std::string>("Hello");
+  auto weak = std::weak_ptr<const void>(storage);
+
+  // We'll construct the dut into a unique_ptr so that we can call the
+  // destructor to cover any effects it has that differ from assignment.
+  auto dut = std::make_unique<ContactResults<double>>(
+      MakePointPair(), MakeHydroelastic(), MakeDeformable(),
+      /* backing_store = */ std::move(storage));
+
+  // Nothing hereafter should use new heap allocations.
+  drake::test::LimitMalloc guard({.max_num_allocations = 0});
+
+  // The contact results should be keeping the storage alive.
+  EXPECT_EQ(storage.get(), nullptr);
+  EXPECT_FALSE(weak.expired());
+
+  // The copy will likewise keep the storage alive.
+  ContactResults<double> copy{*dut};
+  EXPECT_FALSE(weak.expired());
+
+  // Clear the original object.
+  dut.reset();
+  EXPECT_FALSE(weak.expired());
+
+  // Clear the copy. Now the storage is finally deleted.
+  copy = ContactResults<double>{};
+  EXPECT_TRUE(weak.expired());
+}
+
+TEST_F(ContactResultsTest, Accessors) {
+  ContactResults<double> contact_results{MakePointPair(), MakeHydroelastic(),
+                                         MakeDeformable()};
+  contact_results.set_plant(&plant_);
+
+  // Check all accessors.
   EXPECT_EQ(contact_results.plant(), &plant_);
   EXPECT_EQ(contact_results.num_point_pair_contacts(), 1);
   EXPECT_EQ(contact_results.num_hydroelastic_contacts(), 1);
   EXPECT_EQ(contact_results.num_deformable_contacts(), 1);
   EXPECT_EQ(contact_results.point_pair_contact_info(0).bodyA_index(),
             point_pair_info_.bodyA_index());
-  EXPECT_EQ(&contact_results.hydroelastic_contact_info(0),
-            my_hydroelastic_contact_info_.get());
+  EXPECT_EQ(contact_results.hydroelastic_contact_info(0).F_Ac_W().get_coeffs(),
+            my_hydroelastic_contact_info_->F_Ac_W().get_coeffs());
   EXPECT_EQ(contact_results.deformable_contact_info(0).id_A(), id_A_);
   EXPECT_EQ(contact_results.deformable_contact_info(0).id_B(), id_B_);
   EXPECT_EQ(contact_results.deformable_contact_info(0).F_Ac_W().translational(),
@@ -100,73 +155,74 @@ TEST_F(ContactResultsTest, SetAccessClear) {
   EXPECT_EQ(contact_results.deformable_contact_info(0).contact_point_data(),
             deformable_contact_info_->contact_point_data());
 
-  // `copy` will use unique pointers for hydroelastic_contact_info_.
+  // Quick sanity check after a copy, too.
   ContactResults<double> copy(contact_results);
   EXPECT_EQ(copy.num_point_pair_contacts(), 1);
   EXPECT_EQ(copy.num_hydroelastic_contacts(), 1);
-  EXPECT_NE(&copy.hydroelastic_contact_info(0),
-            my_hydroelastic_contact_info_.get());
   EXPECT_EQ(copy.num_deformable_contacts(), 1);
-
-  // Clear
-  // Test the alias-pointer variant.
-  contact_results.Clear();
-  EXPECT_EQ(contact_results.plant(), nullptr);
-  EXPECT_EQ(contact_results.num_point_pair_contacts(), 0);
-  EXPECT_EQ(contact_results.num_hydroelastic_contacts(), 0);
-  EXPECT_EQ(contact_results.num_deformable_contacts(), 0);
-  // Test the unique-pointer variant.
-  copy.Clear();
-  EXPECT_EQ(copy.num_hydroelastic_contacts(), 0);
 }
 
 // This is just a coverage test of the assignment operator. It doesn't try to
 // verify the results of assignment operator rigorously. It only checks that
 // the three member variables are valid without looking at their values.
-//
-// The operator manages two variants of hydroelastic_contact_info_, which
-// can be a vector of aliased pointers or a vector of unique pointers.
-// We check the pointer values as returned by the
-// hydroelastic_contact_info(int) function to distinguish the two cases.
-TEST_F(ContactResultsTest, AssignHydroelasticContactInfo) {
+TEST_F(ContactResultsTest, Assignment) {
   // Assign empty RHS to LHS.
   {
     ContactResults<double> lhs;
-    const ContactResults<double> rhs_empty;
-    lhs = rhs_empty;
+    const ContactResults<double> rhs;
+    lhs = rhs;
     EXPECT_EQ(lhs.num_hydroelastic_contacts(), 0);
     EXPECT_EQ(lhs.num_point_pair_contacts(), 0);
     EXPECT_EQ(lhs.num_deformable_contacts(), 0);
     EXPECT_EQ(lhs.plant(), nullptr);
   }
-  // Assign non-empty RHS to LHS.
-  // LHS will create unique pointers of copies of hydroelastic contacts.
+
+  // Assign non-empty RHS to empty LHS.
   {
     ContactResults<double> lhs;
-    ContactResults<double> rhs_non_empty;
-    rhs_non_empty.set_plant(&plant_);
-    rhs_non_empty.AddContactInfo(point_pair_info_);
-    rhs_non_empty.AddContactInfo(my_hydroelastic_contact_info_.get());
-    rhs_non_empty.AddContactInfo(*deformable_contact_info_);
+    ContactResults<double> rhs{MakePointPair(), MakeHydroelastic(),
+                               MakeDeformable()};
+    rhs.set_plant(&plant_);
 
-    lhs = rhs_non_empty;
+    lhs = rhs;
     EXPECT_EQ(lhs.num_hydroelastic_contacts(), 1);
     EXPECT_EQ(lhs.num_point_pair_contacts(), 1);
     EXPECT_EQ(lhs.num_deformable_contacts(), 1);
     EXPECT_EQ(lhs.plant(), &plant_);
-    // Confirm that the assignment operator copies the content to
-    // a different memory address.
-    EXPECT_NE(&lhs.hydroelastic_contact_info(0),
-              &rhs_non_empty.hydroelastic_contact_info(0));
+  }
+
+  // Assign empty RHS to non-empty LHS.
+  {
+    ContactResults<double> lhs{MakePointPair(), MakeHydroelastic(),
+                               MakeDeformable()};
+    lhs.set_plant(&plant_);
+    ContactResults<double> rhs;
+
+    lhs = rhs;
+    EXPECT_EQ(lhs.num_hydroelastic_contacts(), 0);
+    EXPECT_EQ(lhs.num_point_pair_contacts(), 0);
+    EXPECT_EQ(lhs.num_deformable_contacts(), 0);
+    EXPECT_EQ(lhs.plant(), nullptr);
   }
 }
 
+TEST_F(ContactResultsTest, HydroelasticNoHeapOperations) {
+  // Set up contact results using a bare pointer to the contact surface. After
+  // vector memory is reserved, this should only allocate once more to create
+  // the nested Data structure. The contact surface is NOT copied.
+  std::vector<HydroelasticContactInfo<double>> hydroelastic;
+  hydroelastic.reserve(1);
+  drake::test::LimitMalloc guard({.max_num_allocations = 1});
+  hydroelastic.emplace_back(contact_surface_.get(), F_);
+  const ContactResults<double> dut(std::vector<PointPairContactInfo<double>>{},
+                                   std::move(hydroelastic));
+  const ContactResults<double> copy1(dut);
+  const ContactResults<double> copy2(copy1);
+}
+
 TEST_F(ContactResultsTest, SelectHydroelastic) {
-  ContactResults<double> contact_results;
-  contact_results.set_plant(&plant_);
-  contact_results.AddContactInfo(point_pair_info_);
-  contact_results.AddContactInfo(my_hydroelastic_contact_info_.get());
-  contact_results.AddContactInfo(*deformable_contact_info_);
+  const ContactResults<double> contact_results{
+      MakePointPair(), MakeHydroelastic(), MakeDeformable()};
 
   const ContactResults<double> no_hydro_contacts =
       contact_results.SelectHydroelastic(
@@ -192,28 +248,6 @@ TEST_F(ContactResultsTest, SelectHydroelastic) {
   // Verify the deep copy by checking for different memory address.
   EXPECT_NE(&one_hydro_contact.hydroelastic_contact_info(0),
             my_hydroelastic_contact_info_.get());
-}
-
-TEST_F(ContactResultsTest, VectorConstructor) {
-  // Call the vector-of-infos constructor.
-  const ContactResults<double> dut{
-      std::vector<PointPairContactInfo<double>>{point_pair_info_},
-      std::vector<HydroelasticContactInfo<double>>{
-          *my_hydroelastic_contact_info_},
-      std::vector<DeformableContactInfo<double>>{*deformable_contact_info_}};
-
-  // Spot check the basic counts.
-  EXPECT_EQ(dut.num_point_pair_contacts(), 1);
-  EXPECT_EQ(dut.num_hydroelastic_contacts(), 1);
-  EXPECT_EQ(dut.num_deformable_contacts(), 1);
-  EXPECT_EQ(dut.plant(), nullptr);
-
-  // Spot check one field on each sub-info.
-  EXPECT_EQ(dut.point_pair_contact_info(0).bodyB_index(),
-            point_pair_info_.bodyB_index());
-  EXPECT_EQ(dut.hydroelastic_contact_info(0).F_Ac_W().get_coeffs(),
-            F_.get_coeffs());
-  EXPECT_EQ(dut.deformable_contact_info(0).id_B(), id_B_);
 }
 
 }  // namespace multibody


### PR DESCRIPTION
Towards #21623 by removing the reliance on cache entry lifetimes for bare pointer aliasing, and therefore towards #20545.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21694)
<!-- Reviewable:end -->
