### PR TITLE
[multibody topology] Update to support MbP's RemoveJoint feature

### DIFF
--- a/multibody/topology/link_joint_graph.cc
+++ b/multibody/topology/link_joint_graph.cc
@@ -117,6 +117,8 @@ void LinkJointGraph::InvalidateForest() {
     DRAKE_DEMAND(data_.ephemeral_link_name_to_index.empty());
     DRAKE_DEMAND(data_.ephemeral_joint_name_to_index.empty());
     DRAKE_DEMAND(data_.link_composites.empty());
+    DRAKE_DEMAND(data_.num_user_links == ssize(data_.links));
+    DRAKE_DEMAND(data_.num_user_joints == ssize(data_.joints));
     return;
   }
 
@@ -125,25 +127,40 @@ void LinkJointGraph::InvalidateForest() {
   data_.forest->Clear();
   data_.forest_is_valid = false;
 
-  // Remove any ephemeral elements from the graph.
-  data_.links.erase(data_.links.begin() + data_.num_user_links,
-                    data_.links.end());
-  data_.joints.erase(data_.joints.begin() + data_.num_user_joints,
-                     data_.joints.end());
+  // Remove any ephemeral elements from the graph. The corresponding indices
+  // will appear contiguously at the end of the index_to_ordinal vectors.
+
+  if (ssize(data_.links) > num_user_links()) {
+    data_.link_index_to_ordinal.erase(
+        data_.link_index_to_ordinal.begin() + (data_.max_user_link_index + 1),
+        data_.link_index_to_ordinal.end());
+    data_.ephemeral_link_name_to_index.clear();
+    data_.links.erase(data_.links.begin() + data_.num_user_links,
+                      data_.links.end());
+    DRAKE_DEMAND(ssize(links()) == data_.num_user_links);
+  }
+
+  if (ssize(data_.joints) > num_user_joints()) {
+    data_.joint_index_to_ordinal.erase(
+        data_.joint_index_to_ordinal.begin() + (data_.max_user_joint_index + 1),
+        data_.joint_index_to_ordinal.end());
+    data_.ephemeral_joint_name_to_index.clear();
+    data_.joints.erase(data_.joints.begin() + data_.num_user_joints,
+                       data_.joints.end());
+    DRAKE_DEMAND(ssize(joints()) == data_.num_user_joints);
+  }
+
   data_.loop_constraints.clear();  // All ephemeral.
 
-  data_.ephemeral_link_name_to_index.clear();
-  data_.ephemeral_joint_name_to_index.clear();
-
   // Remove all as-modeled information from the user's graph.
-  for (auto& link : data_.links) link.ClearModel(data_.num_user_joints);
+  for (auto& link : data_.links) link.ClearModel(data_.max_user_joint_index);
   for (auto& joint : data_.joints) joint.ClearModel();
   data_.link_composites.clear();
 }
 
 const LinkJointGraph::Link& LinkJointGraph::world_link() const {
   DRAKE_DEMAND(!links().empty());  // World is predefined at construction.
-  return links(BodyIndex(0));
+  return links(LinkOrdinal(0));
 }
 
 BodyIndex LinkJointGraph::AddLink(const std::string& link_name,
@@ -179,26 +196,32 @@ BodyIndex LinkJointGraph::AddLink(const std::string& link_name,
   // If we have a SpanningForest, it's no good now.
   InvalidateForest();
 
-  const BodyIndex link_index(ssize(links()));  // next available
+  const BodyIndex link_index(num_link_indexes());
+  const LinkOrdinal link_ordinal(ssize(links()));
+  data_.link_index_to_ordinal.push_back(link_ordinal);
+
   // provide fast name lookup
   data_.link_name_to_index.insert({link_name, link_index});
 
-  data_.links.emplace_back(Link(link_index, link_name, model_instance, flags));
+  data_.links.emplace_back(
+      Link(link_index, link_ordinal, link_name, model_instance, flags));
   data_.num_user_links = ssize(links());
+  data_.max_user_link_index = link_index;
 
   Link& new_link = data_.links.back();
 
   // These lists allow for efficient forest building but aren't otherwise
   // useful. Note that if a link goes on the static list it must be a base
   // body so we don't add it separately to the must_be_base_body list.
-  if (new_link.is_static()) {
-    data_.static_links.push_back(link_index);
+  if (new_link.is_static_flag_set()) {
+    data_.static_link_indexes.push_back(link_index);
   } else if (new_link.must_be_base_body()) {
-    data_.non_static_must_be_base_body_links.push_back(link_index);
+    data_.non_static_must_be_base_body_link_indexes.push_back(link_index);
   }
 
-  std::vector<BodyIndex>& links = data_.model_instance_to_links[model_instance];
-  links.push_back(link_index);
+  std::vector<BodyIndex>& links_in_instance =
+      data_.model_instance_to_link_indexes[model_instance];
+  links_in_instance.push_back(link_index);
 
   return link_index;
 }
@@ -212,12 +235,14 @@ bool LinkJointGraph::HasLinkNamed(
   // out to be incorrect we can switch to a different data structure.
   const auto range = data_.link_name_to_index.equal_range(name);
   for (auto it = range.first; it != range.second; ++it) {
-    if (links(it->second).model_instance() == model_instance_index) return true;
+    if (link_by_index(it->second).model_instance() == model_instance_index)
+      return true;
   }
 
   const auto model_range = data_.ephemeral_link_name_to_index.equal_range(name);
   for (auto it = model_range.first; it != model_range.second; ++it) {
-    if (links(it->second).model_instance() == model_instance_index) return true;
+    if (link_by_index(it->second).model_instance() == model_instance_index)
+      return true;
   }
 
   return false;
@@ -232,7 +257,7 @@ bool LinkJointGraph::HasJointNamed(
   // out to be incorrect we can switch to a different data structure.
   const auto range = data_.joint_name_to_index.equal_range(name);
   for (auto it = range.first; it != range.second; ++it) {
-    if (joints(it->second).model_instance() == model_instance_index) {
+    if (joint_by_index(it->second).model_instance() == model_instance_index) {
       return true;
     }
   }
@@ -240,7 +265,7 @@ bool LinkJointGraph::HasJointNamed(
   const auto model_range =
       data_.ephemeral_joint_name_to_index.equal_range(name);
   for (auto it = model_range.first; it != model_range.second; ++it) {
-    if (joints(it->second).model_instance() == model_instance_index) {
+    if (joint_by_index(it->second).model_instance() == model_instance_index) {
       return true;
     }
   }
@@ -252,8 +277,8 @@ std::optional<JointIndex> LinkJointGraph::MaybeGetJointBetween(
     BodyIndex link1_index, BodyIndex link2_index) const {
   // Work with the Link that has the fewest joints. (If one of these is World
   // it is probably the other one!)
-  const Link& link1 = links(link1_index);
-  const Link& link2 = links(link2_index);
+  const Link& link1 = link_by_index(link1_index);
+  const Link& link2 = link_by_index(link2_index);
   const auto [joint_list_ptr, link_to_look_for] =
       ssize(link1.joints()) <= ssize(link2.joints())
           ? std::make_pair(&link1.joints(), link2_index)
@@ -262,7 +287,7 @@ std::optional<JointIndex> LinkJointGraph::MaybeGetJointBetween(
   // We're doing a linear search under the assumption that at least one of
   // these Links won't have very many Joints.
   for (JointIndex joint_index : *joint_list_ptr) {
-    const Joint& joint = joints(joint_index);
+    const Joint& joint = joint_by_index(joint_index);
     if (joint.connects(link_to_look_for)) return joint_index;
   }
   return std::nullopt;
@@ -278,22 +303,25 @@ JointIndex LinkJointGraph::AddJoint(const std::string& name,
   DRAKE_DEMAND(parent_link_index.is_valid());
   DRAKE_DEMAND(child_link_index.is_valid());
 
-  if (parent_link_index >= ssize(links())) {
+  if (!has_link(parent_link_index) || link_is_ephemeral(parent_link_index)) {
     throw std::range_error(fmt::format(
-        "{}(): parent link index {} for joint '{}' is out of range.", __func__,
-        parent_link_index, name));
+        "{}(): parent link index {} for joint '{}' refers to a non-existent "
+        "or ephemeral link.",
+        __func__, parent_link_index, name));
   }
-  if (child_link_index >= ssize(links())) {
-    throw std::range_error(
-        fmt::format("{}(): child link index {} for joint '{}' is out of range.",
-                    __func__, child_link_index, name));
+  if (!has_link(child_link_index) || link_is_ephemeral(child_link_index)) {
+    throw std::range_error(fmt::format(
+        "{}(): child link index {} for joint '{}' refers to a non-existent "
+        "or ephemeral link.",
+        __func__, child_link_index, name));
   }
 
   if (parent_link_index == child_link_index) {
     throw std::logic_error(fmt::format(
         "{}(): Joint '{}' (model instance {}) would connect link '{}' "
         "to itself.",
-        __func__, name, model_instance_index, links(parent_link_index).name()));
+        __func__, name, model_instance_index,
+        link_by_index(parent_link_index).name()));
   }
 
   if (HasJointNamed(name, model_instance_index)) {
@@ -312,26 +340,27 @@ JointIndex LinkJointGraph::AddJoint(const std::string& name,
 
   // Static Links are implicitly welded to World. We'll permit an explicit
   // joint only if it is a weld.
-  const Link& new_parent = links(parent_link_index);
-  const Link& new_child = links(child_link_index);
+  const Link& new_parent = link_by_index(parent_link_index);
+  const Link& new_child = link_by_index(child_link_index);
   const bool is_static = (new_parent.is_world() && link_is_static(new_child)) ||
                          (new_child.is_world() && link_is_static(new_parent));
   if (is_static && type_index != weld_joint_traits_index()) {
     const std::string static_link_name =
         new_parent.is_world() ? new_child.name() : new_parent.name();
     throw std::logic_error(fmt::format(
-        "{}(): can't connect static link '{}' to World "
-        "using a {} joint; only a weld is permitted. "
-        "(Joint '{}' in model instance {}.)",
+        "{}(): can't connect static link '{}' to World using a {} joint; only "
+        "a weld is permitted. (Joint '{}' in model instance {}.)",
         __func__, static_link_name, type, name, model_instance_index));
   }
 
   // We only allow one Joint between any given pair of Links.
   if (std::optional<JointIndex> existing_joint_index =
           MaybeGetJointBetween(parent_link_index, child_link_index)) {
-    const Joint& existing_joint = joints(*existing_joint_index);
-    const Link& existing_parent = links(existing_joint.parent_link());
-    const Link& existing_child = links(existing_joint.child_link());
+    const Joint& existing_joint = joint_by_index(*existing_joint_index);
+    const Link& existing_parent =
+        link_by_index(existing_joint.parent_link_index());
+    const Link& existing_child =
+        link_by_index(existing_joint.child_link_index());
 
     throw std::logic_error(fmt::format(
         "{}(): This LinkJointGraph already has joint '{}' (model instance {}) "
@@ -345,18 +374,79 @@ JointIndex LinkJointGraph::AddJoint(const std::string& name,
   // If we have a SpanningForest, it's no good now.
   InvalidateForest();
 
-  const JointIndex joint_index(ssize(joints()));  // next available index
-  data_.joints.emplace_back(Joint(joint_index, name, model_instance_index,
-                                  *type_index, parent_link_index,
-                                  child_link_index, flags));
-  data_.num_user_joints = ssize(joints());
+  const JointIndex joint_index(num_joint_indexes());  // next available index
+  const JointOrdinal joint_ordinal(ssize(joints()));
+  data_.joint_index_to_ordinal.push_back(joint_ordinal);
   data_.joint_name_to_index.insert({name, joint_index});  // fast name lookup
+  data_.joints.emplace_back(Joint(joint_index, joint_ordinal, name,
+                                  model_instance_index, *type_index,
+                                  parent_link_index, child_link_index, flags));
+  data_.num_user_joints = ssize(joints());
+  data_.max_user_joint_index = joint_index;
 
   // Links need to know their joints.
-  mutable_link(parent_link_index).add_joint_as_parent(joint_index);
-  mutable_link(child_link_index).add_joint_as_child(joint_index);
+  mutable_link(index_to_ordinal(parent_link_index))
+      .add_joint_as_parent(joint_index);
+  mutable_link(index_to_ordinal(child_link_index))
+      .add_joint_as_child(joint_index);
 
   return joint_index;
+}
+
+void LinkJointGraph::RemoveJoint(JointIndex doomed_joint_index) {
+  DRAKE_DEMAND(doomed_joint_index.is_valid());
+
+  if (doomed_joint_index >= ssize(data_.joint_index_to_ordinal)) {
+    throw std::logic_error(fmt::format("{}(): Joint index {} is out of range.",
+                                       __func__, doomed_joint_index));
+  }
+  const std::optional<JointOrdinal> doomed_ordinal =
+      data_.joint_index_to_ordinal[doomed_joint_index];
+
+  if (!doomed_ordinal.has_value()) {
+    throw std::logic_error(
+        fmt::format("{}(): The joint that had index {} was already removed.",
+                    __func__, doomed_joint_index));
+  }
+
+  if (doomed_ordinal >= num_user_joints()) {
+    throw std::logic_error(fmt::format(
+        "{}(): Joint {} with index {} is an ephemeral joint (added during "
+        "forest modeling). You didn't add this joint and you can't remove it. "
+        "It will be removed by any change made to the graph that invalidates "
+        "the forest.",
+        __func__, joints(*doomed_ordinal).name(), doomed_joint_index));
+  }
+
+  // We're actually going to remove this joint so the forest is no good now.
+  InvalidateForest();
+
+  // Remove references to this Joint in the Links it connected.
+  const Joint& doomed_joint = joints(*doomed_ordinal);
+  const LinkOrdinal parent_ordinal =
+      index_to_ordinal(doomed_joint.parent_link_index());
+  const LinkOrdinal child_ordinal =
+      index_to_ordinal(doomed_joint.child_link_index());
+  mutable_link(parent_ordinal).RemoveJointReferences(doomed_joint_index);
+  mutable_link(child_ordinal).RemoveJointReferences(doomed_joint_index);
+
+  // Forget the index and the name, then erase the joint.
+  data_.joint_index_to_ordinal[doomed_joint_index] = std::nullopt;
+  std::erase_if(data_.joint_name_to_index, [&doomed_joint](const auto& item) {
+    const auto& [name, index] = item;
+    return index == doomed_joint.index() && name == doomed_joint.name();
+  });
+  data_.joints.erase(data_.joints.begin() + *doomed_ordinal);
+
+  // Update the ordinals for the joints following this one.
+  for (JointOrdinal new_ordinal = *doomed_ordinal;
+       new_ordinal < ssize(joints()); ++new_ordinal) {
+    Joint& joint = mutable_joint(new_ordinal);
+    DRAKE_DEMAND(joint.ordinal() == new_ordinal + 1);
+    joint.ordinal_ = new_ordinal;
+    data_.joint_index_to_ordinal[joint.index()] = new_ordinal;
+  }
+  data_.num_user_joints = ssize(joints());
 }
 
 JointTraitsIndex LinkJointGraph::RegisterJointType(
@@ -391,25 +481,26 @@ bool LinkJointGraph::IsJointTypeRegistered(
 
 void LinkJointGraph::CreateWorldLinkComposite() {
   DRAKE_DEMAND(link_composites().empty() && !links().empty());
-  Link& world_link = data_.links[BodyIndex(0)];
+  Link& world_link = data_.links[LinkOrdinal(0)];
   DRAKE_DEMAND(!world_link.link_composite_index_.has_value());
-  data_.link_composites.emplace_back(std::vector{BodyIndex(0)});
+  data_.link_composites.emplace_back(std::vector{world_link.index()});
   world_link.link_composite_index_ = LinkCompositeIndex(0);
 }
 
 LoopConstraintIndex LinkJointGraph::AddLoopClosingWeldConstraint(
-    BodyIndex primary_link_index, BodyIndex shadow_link_index) {
-  DRAKE_DEMAND(primary_link_index.is_valid() && shadow_link_index.is_valid());
-  DRAKE_DEMAND(primary_link_index != shadow_link_index);
-  Link& primary_link = mutable_link(primary_link_index);
-  Link& shadow_link = mutable_link(shadow_link_index);
+    LinkOrdinal primary_link_ordinal, LinkOrdinal shadow_link_ordinal) {
+  DRAKE_DEMAND(primary_link_ordinal.is_valid() &&
+               shadow_link_ordinal.is_valid());
+  DRAKE_DEMAND(primary_link_ordinal != shadow_link_ordinal);
+  Link& primary_link = mutable_link(primary_link_ordinal);
+  Link& shadow_link = mutable_link(shadow_link_ordinal);
   DRAKE_DEMAND(primary_link.model_instance() == shadow_link.model_instance());
   const LoopConstraintIndex index(ssize(loop_constraints()));
   // Use the shadow Link's name as the constraint name also.
   data_.loop_constraints.emplace_back(index, shadow_link.name(),
                                       shadow_link.model_instance(),
-                                      primary_link_index,  // parent
-                                      shadow_link_index);  // child
+                                      primary_link.index(),  // parent
+                                      shadow_link.index());  // child
   primary_link.add_loop_constraint(index);
   shadow_link.add_loop_constraint(index);
   return index;
@@ -424,26 +515,27 @@ std::optional<JointTraitsIndex> LinkJointGraph::GetJointTraitsIndex(
 
 void LinkJointGraph::ChangeLinkFlags(BodyIndex link_index, LinkFlags flags) {
   InvalidateForest();
-  mutable_link(link_index).set_flags(flags);
+  mutable_link(index_to_ordinal(link_index)).set_flags(flags);
 }
 
 void LinkJointGraph::ChangeJointFlags(JointIndex joint_index,
                                       JointFlags flags) {
   InvalidateForest();
-  mutable_joint(joint_index).set_flags(flags);
+  mutable_joint(index_to_ordinal(joint_index)).set_flags(flags);
 }
 
 void LinkJointGraph::ChangeJointType(JointIndex existing_joint_index,
                                      const std::string& name_of_new_type) {
-  DRAKE_DEMAND(existing_joint_index.is_valid() &&
-               existing_joint_index < ssize(joints()));
+  DRAKE_DEMAND(existing_joint_index.is_valid());
+  DRAKE_DEMAND(has_joint(existing_joint_index));
   const std::optional<JointTraitsIndex> new_traits_index =
       GetJointTraitsIndex(name_of_new_type);
   DRAKE_DEMAND(new_traits_index.has_value());
 
-  const Joint& joint = joints(existing_joint_index);
+  const JointOrdinal joint_ordinal = index_to_ordinal(existing_joint_index);
+  const Joint& joint = joints(joint_ordinal);
 
-  if (existing_joint_index >= num_user_joints()) {
+  if (joint_is_ephemeral(existing_joint_index)) {
     throw std::logic_error(
         fmt::format("{}(): can't change the type of ephemeral joint {}; only "
                     "user-defined joints are changeable.",
@@ -452,8 +544,8 @@ void LinkJointGraph::ChangeJointType(JointIndex existing_joint_index,
 
   // If this is a joint between a static link and world, it can only be a
   // weld (see AddJoint()).
-  const Link& parent_link = links(joint.parent_link());
-  const Link& child_link = links(joint.child_link());
+  const Link& parent_link = link_by_index(joint.parent_link_index());
+  const Link& child_link = link_by_index(joint.child_link_index());
   const bool is_static =
       (parent_link.is_world() && link_is_static(child_link)) ||
       (child_link.is_world() && link_is_static(parent_link));
@@ -470,13 +562,14 @@ void LinkJointGraph::ChangeJointType(JointIndex existing_joint_index,
   }
 
   InvalidateForest();
-  mutable_joint(existing_joint_index).traits_index_ = *new_traits_index;
+  mutable_joint(joint_ordinal).traits_index_ = *new_traits_index;
 }
 
 JointIndex LinkJointGraph::AddEphemeralJointToWorld(
-    JointTraitsIndex type_index, BodyIndex child_link_index) {
-  const LinkJointGraph::Link& child = links(child_link_index);
-  const JointIndex new_joint_index(ssize(joints()));
+    JointTraitsIndex traits_index, LinkOrdinal child_link_ordinal) {
+  const LinkJointGraph::Link& child = links(child_link_ordinal);
+  const JointIndex new_joint_index(num_joint_indexes());
+  const JointOrdinal new_joint_ordinal(ssize(joints()));
   const ModelInstanceIndex model_instance = child.model_instance();
 
   /* We'll try to name the new Joint the same as the base body it mobilizes.
@@ -490,22 +583,23 @@ JointIndex LinkJointGraph::AddEphemeralJointToWorld(
 
   // TODO(sherm1) Extract this code that is common with AddJoint().
   data_.ephemeral_joint_name_to_index.insert({joint_name, new_joint_index});
-  data_.joints.emplace_back(Joint(new_joint_index, joint_name, model_instance,
-                                  type_index, BodyIndex(0), child_link_index,
-                                  JointFlags::kDefault));
+  data_.joint_index_to_ordinal.push_back(new_joint_ordinal);
+  data_.joints.emplace_back(
+      Joint(new_joint_index, new_joint_ordinal, joint_name, model_instance,
+            traits_index, BodyIndex(0), child.index(), JointFlags::kDefault));
   // Links need to know their joints.
-  mutable_link(BodyIndex(0)).add_joint_as_parent(new_joint_index);
-  mutable_link(child_link_index).add_joint_as_child(new_joint_index);
+  mutable_link(LinkOrdinal(0)).add_joint_as_parent(new_joint_index);
+  mutable_link(child_link_ordinal).add_joint_as_child(new_joint_index);
 
   return new_joint_index;
 }
 
 LinkCompositeIndex LinkJointGraph::AddToLinkComposite(
-    BodyIndex maybe_composite_link_index, BodyIndex new_link_index) {
-  DRAKE_ASSERT(maybe_composite_link_index.is_valid() &&
-               new_link_index.is_valid());
-  Link& maybe_composite_link = mutable_link(maybe_composite_link_index);
-  Link& new_link = mutable_link(new_link_index);
+    LinkOrdinal maybe_composite_link_ordinal, LinkOrdinal new_link_ordinal) {
+  DRAKE_ASSERT(maybe_composite_link_ordinal.is_valid() &&
+               new_link_ordinal.is_valid());
+  Link& maybe_composite_link = mutable_link(maybe_composite_link_ordinal);
+  Link& new_link = mutable_link(new_link_ordinal);
   DRAKE_DEMAND(!new_link.is_world());
 
   std::optional<LinkCompositeIndex> existing_composite =
@@ -516,19 +610,20 @@ LinkCompositeIndex LinkJointGraph::AddToLinkComposite(
     existing_composite = maybe_composite_link.link_composite_index_ =
         LinkCompositeIndex(ssize(data_.link_composites));
     data_.link_composites.emplace_back(
-        std::vector<BodyIndex>{maybe_composite_link_index});
+        std::vector<BodyIndex>{maybe_composite_link.index()});
   }
-  data_.link_composites[*existing_composite].push_back(new_link_index);
+  data_.link_composites[*existing_composite].push_back(new_link.index());
   new_link.link_composite_index_ = existing_composite;
 
   return *existing_composite;
 }
 
-BodyIndex LinkJointGraph::AddShadowLink(BodyIndex primary_link_index,
-                                        JointIndex shadow_joint_index,
-                                        bool shadow_is_parent) {
+LinkOrdinal LinkJointGraph::AddShadowLink(LinkOrdinal primary_link_ordinal,
+                                          JointOrdinal shadow_joint_ordinal,
+                                          bool shadow_is_parent) {
   /* Caution: this Link reference will be invalid after the emplace. */
-  const Link& primary_link = links(primary_link_index);
+  const Link& primary_link = links(primary_link_ordinal);
+  const BodyIndex primary_link_index = primary_link.index();
   const int shadow_num = primary_link.num_shadows() + 1;
   /* Name should be <primary_name>$<shadow_num> (unique within primary's model
   instance). In the unlikely event that a user has names like this, we'll keep
@@ -538,23 +633,27 @@ BodyIndex LinkJointGraph::AddShadowLink(BodyIndex primary_link_index,
       fmt::format("{}${}", primary_link.name(), shadow_num);
   while (HasLinkNamed(shadow_link_name, primary_link.model_instance()))
     shadow_link_name = "_" + shadow_link_name;
-  const BodyIndex shadow_link_index(ssize(links()));
-  DRAKE_DEMAND(shadow_link_index >= num_user_links());  // A sanity check.
+  const BodyIndex shadow_link_index(num_link_indexes());
+  const LinkOrdinal shadow_link_ordinal(ssize(links()));
+  DRAKE_DEMAND(shadow_link_ordinal >= num_user_links());  // A sanity check.
+  data_.link_index_to_ordinal.push_back(shadow_link_ordinal);
   data_.ephemeral_link_name_to_index.insert(
       {shadow_link_name, shadow_link_index});
-  data_.links.emplace_back(Link(shadow_link_index, shadow_link_name,
-                                primary_link.model_instance(),
+  data_.links.emplace_back(Link(shadow_link_index, shadow_link_ordinal,
+                                shadow_link_name, primary_link.model_instance(),
                                 LinkFlags::kShadow));
+  /* Caution: primary_link reference is invalid now -- don't use it! */
   Link& shadow_link = data_.links.back();
   shadow_link.primary_link_ = primary_link_index;
+  const Joint& shadow_joint = joints(shadow_joint_ordinal);
   if (shadow_is_parent) {
-    shadow_link.add_joint_as_parent(shadow_joint_index);
+    shadow_link.add_joint_as_parent(shadow_joint.index());
   } else {
-    shadow_link.add_joint_as_child(shadow_joint_index);
+    shadow_link.add_joint_as_child(shadow_joint.index());
   }
-  mutable_link(primary_link_index).shadow_links_.push_back(shadow_link_index);
+  mutable_link(primary_link_ordinal).shadow_links_.push_back(shadow_link_index);
 
-  return shadow_link.index();
+  return shadow_link_ordinal;
 }
 
 void LinkJointGraph::RenumberMobodIndexes(
@@ -563,25 +662,46 @@ void LinkJointGraph::RenumberMobodIndexes(
   for (auto& joint : data_.joints) joint.renumber_mobod_indexes(old_to_new);
 }
 
-std::tuple<BodyIndex, BodyIndex, bool> LinkJointGraph::FindInboardOutboardLinks(
-    MobodIndex inboard_mobod_index, JointIndex joint_index) const {
-  const Joint& joint = joints(joint_index);
-  const Link& parent_link = links(joint.parent_link());
+std::tuple<LinkOrdinal, LinkOrdinal, bool>
+LinkJointGraph::FindInboardOutboardLinks(MobodIndex inboard_mobod_index,
+                                         JointOrdinal joint_ordinal) const {
+  const Joint& joint = joints(joint_ordinal);
+  const LinkOrdinal parent_link_ordinal =
+      index_to_ordinal(joint.parent_link_index());
+  const LinkOrdinal child_link_ordinal =
+      index_to_ordinal(joint.child_link_index());
+  const Link& parent_link = links(parent_link_ordinal);
   if (parent_link.mobod_index().is_valid() &&
       parent_link.mobod_index() == inboard_mobod_index) {
-    return std::make_tuple(joint.parent_link(), joint.child_link(), false);
+    return std::make_tuple(parent_link_ordinal, child_link_ordinal, false);
   }
-  const Link& child_link = links(joint.child_link());
+  const Link& child_link = links(child_link_ordinal);
   DRAKE_DEMAND(child_link.mobod_index().is_valid() &&
                child_link.mobod_index() == inboard_mobod_index);
-  return std::make_tuple(joint.child_link(), joint.parent_link(), true);
+  return std::make_tuple(child_link_ordinal, parent_link_ordinal, true);
 }
 
 bool LinkJointGraph::link_is_static(const Link& link) const {
-  if (link.is_static()) return true;  // The flag is set.
+  if (link.is_static_flag_set()) return true;
   return static_cast<bool>(
       get_forest_building_options_in_use(link.model_instance()) &
       ForestBuildingOptions::kStatic);
+}
+
+void LinkJointGraph::ThrowLinkWasRemoved(const char* func,
+                                         BodyIndex link_index) const {
+  throw std::logic_error(fmt::format(
+      "{}(): An attempt was made to access a link with index {} but that "
+      "link was removed.",
+      func, link_index));
+}
+
+void LinkJointGraph::ThrowJointWasRemoved(const char* func,
+                                          JointIndex joint_index) const {
+  throw std::logic_error(
+      fmt::format("{}(): An attempt was made to access a joint with index {} "
+                  "but that joint was removed.",
+                  func, joint_index));
 }
 
 LinkJointGraph::Data::Data() = default;
@@ -591,26 +711,29 @@ LinkJointGraph::Data::~Data() = default;
 auto LinkJointGraph::Data::operator=(const Data&) -> Data& = default;
 auto LinkJointGraph::Data::operator=(Data&&) -> Data& = default;
 
-LinkJointGraph::Link::Link(BodyIndex index, std::string name,
-                           ModelInstanceIndex model_instance, LinkFlags flags)
+LinkJointGraph::Link::Link(BodyIndex index, LinkOrdinal ordinal,
+                           std::string name, ModelInstanceIndex model_instance,
+                           LinkFlags flags)
     : index_(index),
+      ordinal_(ordinal),
       name_(std::move(name)),
       model_instance_(model_instance),
       flags_(flags) {
   DRAKE_DEMAND(index_.is_valid() && !name_.empty() &&
                model_instance_.is_valid());
+  DRAKE_DEMAND(ordinal_ <= static_cast<int>(index_));
   // Shadow links overwrite this with their actual primary; everyone else
   // is just a self-primary.
   primary_link_ = index_;
 }
 
-void LinkJointGraph::Link::ClearModel(int num_user_joints) {
+void LinkJointGraph::Link::ClearModel(JointIndex max_user_joint_index) {
   DRAKE_DEMAND(!is_shadow());  // Those should already have been removed.
   DRAKE_DEMAND(primary_link_ == index_);  // True for any user link.
 
   auto remove_ephemeral_joints =
-      [num_user_joints](std::vector<JointIndex>& joints) {
-        while (!joints.empty() && joints.back() >= num_user_joints)
+      [max_user_joint_index](std::vector<JointIndex>& joints) {
+        while (!joints.empty() && joints.back() > max_user_joint_index)
           joints.pop_back();
       };
 
@@ -625,12 +748,14 @@ void LinkJointGraph::Link::ClearModel(int num_user_joints) {
   link_composite_index_ = {};
 }
 
-LinkJointGraph::Joint::Joint(JointIndex index, std::string name,
+LinkJointGraph::Joint::Joint(JointIndex index, JointOrdinal ordinal,
+                             std::string name,
                              ModelInstanceIndex model_instance,
                              JointTraitsIndex joint_traits_index,
                              BodyIndex parent_link_index,
                              BodyIndex child_link_index, JointFlags flags)
     : index_(index),
+      ordinal_(ordinal),
       name_(std::move(name)),
       model_instance_(model_instance),
       flags_(flags),
@@ -642,6 +767,7 @@ LinkJointGraph::Joint::Joint(JointIndex index, std::string name,
   DRAKE_DEMAND(traits_index_.is_valid() && parent_link_index_.is_valid() &&
                child_link_index_.is_valid());
   DRAKE_DEMAND(parent_link_index_ != child_link_index_);
+  DRAKE_DEMAND(ordinal_ <= static_cast<int>(index_));
 }
 
 }  // namespace internal

--- a/multibody/topology/link_joint_graph.h
+++ b/multibody/topology/link_joint_graph.h
@@ -28,6 +28,12 @@ namespace internal {
 // TODO(sherm1) The class comment describes the complete functionality of
 //  PR #20225; only part of that code is actually here.
 
+// TODO(sherm1) During the PR train leading up to MbP using this code in Drake
+//  master, I'm using Doxygen comments /** despite the fact that this is
+//  currently just internal. That allows me to validate Doxygen syntax in
+//  anticipation of the API becoming public later. Change these to /* in the
+//  final PR in this train to satisfy the styleguide.
+
 /** Represents a graph consisting of Links (user-defined rigid bodies)
 interconnected by Joints.
 
@@ -117,7 +123,8 @@ class LinkJointGraph {
   instance that does not have its own forest building options set. If no call
   has yet been made to SetGlobalForestBuildingOptions(), returns
   ForestBuildingOptions::kDefault. */
-  ForestBuildingOptions get_global_forest_building_options() const {
+  [[nodiscard]] ForestBuildingOptions get_global_forest_building_options()
+      const {
     return data_.global_forest_building_options;
   }
 
@@ -136,7 +143,7 @@ class LinkJointGraph {
   model instance. Returns the options set explicitly for this model instance,
   if any. Otherwise, returns what get_global_forest_building_options() returns.
   @pre `instance_index` is any valid index */
-  ForestBuildingOptions get_forest_building_options_in_use(
+  [[nodiscard]] ForestBuildingOptions get_forest_building_options_in_use(
       ModelInstanceIndex instance_index) const {
     return get_model_instance_options(instance_index)
         .value_or(get_global_forest_building_options());
@@ -182,7 +189,7 @@ class LinkJointGraph {
   recent change to this LinkJointGraph or to the forest building options? If
   this returns `false` then a call to BuildForest() is required before you can
   make use of the SpanningForest. */
-  bool forest_is_valid() const { return data_.forest_is_valid; }
+  [[nodiscard]] bool forest_is_valid() const { return data_.forest_is_valid; }
 
   /** Returns a reference to this LinkJointGraph's SpanningForest
   object (without rebuilding). The forest is a data member of LinkJointGraph and
@@ -194,10 +201,7 @@ class LinkJointGraph {
   @warning If you retain this reference be aware that the contents are only
     meaningful when `forest_is_valid()` returns true. We do not promise
     anything about the contents otherwise. */
-  const SpanningForest& forest() const { return *data_.forest; }
-
-  // TODO(sherm1) Add editing functions like Remove{Link,Joint} and maybe
-  //  ReplaceJoint().
+  [[nodiscard]] const SpanningForest& forest() const { return *data_.forest; }
 
   /** Adds a new Link to the graph. Invalidates the SpanningForest; call
   BuildForest() to rebuild.
@@ -220,6 +224,26 @@ class LinkJointGraph {
     set (currently just `Shadow`). */
   BodyIndex AddLink(const std::string& name, ModelInstanceIndex model_instance,
                     LinkFlags flags = LinkFlags::kDefault);
+
+  // TODO(sherm1) Add this method;
+  //  void RemoveLink(BodyIndex doomed_link_index);
+
+  /** Returns true if the given `link_index` is in range and the corresponding
+  Link hasn't been removed. Can be a user or ephemeral Link. */
+  [[nodiscard]] bool has_link(BodyIndex link_index) const {
+    return link_index < num_link_indexes() &&
+           data_.link_index_to_ordinal[link_index].has_value();
+  }
+
+  /** Returns true if the given Link exists and is ephemeral. Ephemeral links
+  are present only if the SpanningForest is valid. */
+  [[nodiscard]] bool link_is_ephemeral(BodyIndex link_index) const {
+    if (has_link(link_index) && link_index > data_.max_user_link_index) {
+      DRAKE_ASSERT(index_to_ordinal(link_index) >= num_user_links());
+      return true;
+    }
+    return false;
+  }
 
   /** Adds a new Joint to the graph.
   @param[in] name
@@ -256,8 +280,34 @@ class LinkJointGraph {
                       BodyIndex child_link_index,
                       JointFlags flags = JointFlags::kDefault);
 
+  /** Removes a previously-added Joint and any references to it in the graph.
+  Invalidates the SpanningForest. Will repack and change ordinals for the
+  remaining Joints in the joints() vector, though all JointIndexes are
+  preserved. The `doomed_joint_index` given here will never be re-used.
+  @param[in] doomed_joint_index The JointIndex of an existing Joint.
+  @throws std::exception if the given index is out of range, refers to
+    an already-removed Joint, or refers to an ephemeral Joint. */
+  void RemoveJoint(JointIndex doomed_joint_index);
+
+  /** Returns true if the given `joint_index` is in range and the corresponding
+  Joint hasn't been removed. Can be a user or ephemeral Joint. */
+  [[nodiscard]] bool has_joint(JointIndex joint_index) const {
+    return joint_index < num_joint_indexes() &&
+           data_.joint_index_to_ordinal[joint_index].has_value();
+  }
+
+  /** Returns true if the given Joint exists and is ephemeral. Ephemeral joints
+  are present only if the SpanningForest is valid. */
+  [[nodiscard]] bool joint_is_ephemeral(JointIndex joint_index) const {
+    if (has_joint(joint_index) && joint_index > data_.max_user_joint_index) {
+      DRAKE_ASSERT(index_to_ordinal(joint_index) >= num_user_joints());
+      return true;
+    }
+    return false;
+  }
+
   /** Returns the Link that corresponds to World (always predefined). */
-  const Link& world_link() const;
+  [[nodiscard]] const Link& world_link() const;
 
   /** Registers a joint type by name and provides the joint traits for it.
   @param[in] joint_type_name
@@ -286,64 +336,83 @@ class LinkJointGraph {
 
   /** Returns `true` if the given `joint_type_name` was previously registered
   via a call to RegisterJointType(), or is one of the pre-registered names. */
-  bool IsJointTypeRegistered(const std::string& joint_type_name) const;
+  [[nodiscard]] bool IsJointTypeRegistered(
+      const std::string& joint_type_name) const;
 
   /** Returns a reference to the vector of traits for the known and registered
   Joint types. */
-  const std::vector<JointTraits>& joint_traits() const {
+  [[nodiscard]] const std::vector<JointTraits>& joint_traits() const {
     return data_.joint_traits;
   }
 
   /** Returns a reference to a particular JointTraits object using one of the
   predefined indices or an index returned by RegisterJointType(). Requires a
   JointTraitsIndex, not a plain integer.*/
-  const JointTraits& joint_traits(JointTraitsIndex index) const {
+  [[nodiscard]] const JointTraits& joint_traits(JointTraitsIndex index) const {
     return joint_traits().at(index);
   }
 
-  /** Returns a reference to the vector of Link objects. World is always the
-  first entry and is always present. */
-  const std::vector<Link>& links() const { return data_.links; }
+  /** Returns a reference to the vector of Link objects, contiguous and ordered
+  by ordinal (not by BodyIndex). World is always the first entry and is always
+  present. `ssize(links())` is the number of Links currently in this graph. */
+  [[nodiscard]] const std::vector<Link>& links() const { return data_.links; }
 
-  /** Returns a reference to a particular Link. The World Link is BodyIndex(0),
-  others use the index returned by AddLink(). Ephemeral links added by
-  BuildForest() are indexed last. Requires a BodyIndex, not a plain integer. */
-  inline const Link& links(BodyIndex link_index) const;
+  /** Returns a reference to a particular Link using its current ordinal
+  within the links() vector. Requires a LinkOrdinal, not a plain integer. */
+  [[nodiscard]] inline const Link& links(LinkOrdinal link_ordinal) const;
 
-  /** Returns a reference to the vector of Joint objects. */
-  const std::vector<Joint>& joints() const { return data_.joints; }
+  /** Returns a reference to a particular Link using the index returned by
+  AddLink(). The World Link is BodyIndex(0). Ephemeral links added by
+  BuildForest() are indexed last. Requires a BodyIndex, not a plain integer.
+  @throws std::exception if the index is out of range or if the selected Link
+    was removed. */
+  [[nodiscard]] inline const Link& link_by_index(BodyIndex link_index) const;
+
+  /** Returns a reference to the vector of Joint objects, contiguous and ordered
+  by ordinal (not by JointIndex). `ssize(joints())` is the number of Joints
+  currently in this graph. */
+  [[nodiscard]] const std::vector<Joint>& joints() const {
+    return data_.joints;
+  }
+
+  /** Returns a reference to a particular Joint using its current ordinal
+  within the joints() vector. Requires a JointOrdinal, not a plain integer. */
+  [[nodiscard]] inline const Joint& joints(JointOrdinal joint_ordinal) const;
 
   /** Returns a reference to a particular Joint using the index returned by
   AddJoint(). Ephemeral joints added by BuildForest() are indexed last. Requires
-  a JointIndex, not a plain integer. */
-  inline const Joint& joints(JointIndex joint_index) const;
+  a JointIndex, not a plain integer.
+  @throws std::exception if the index is out of range or if the selected Joint
+    was removed. */
+  [[nodiscard]] inline const Joint& joint_by_index(
+      JointIndex joint_index) const;
 
   /** Returns a reference to the vector of LoopConstraint objects. These are
   always "ephemeral" (added during forest-building) so this will return empty
   if there is no valid Forest. See the class comment for more information. */
-  const std::vector<LoopConstraint>& loop_constraints() const {
+  [[nodiscard]] const std::vector<LoopConstraint>& loop_constraints() const {
     return data_.loop_constraints;
   }
 
   /** Returns a reference to a particular LoopConstraint. Requires a
   LoopConstraintIndex, not a plain integer.*/
-  inline const LoopConstraint& loop_constraints(
+  [[nodiscard]] inline const LoopConstraint& loop_constraints(
       LoopConstraintIndex constraint_index) const;
 
   /** Links with this index or higher are "ephemeral" (added during
   forest-building). See the class comment for more information. */
-  int num_user_links() const { return data_.num_user_links; }
+  [[nodiscard]] int num_user_links() const { return data_.num_user_links; }
 
   /** Joints with this index or higher are "ephemeral" (added during
   forest-building). See the class comment for more information. */
-  int num_user_joints() const { return data_.num_user_joints; }
+  [[nodiscard]] int num_user_joints() const { return data_.num_user_joints; }
 
   /** After the SpanningForest has been built, returns the mobilized body
   (Mobod) followed by this Link. If the Link is part of a composite, this will
   be the mobilized body for the whole composite. If the Link was split into a
   primary and shadows, this is the mobilized body followed by the primary. If
   there is no valid Forest, the returned index will be invalid. */
-  MobodIndex link_to_mobod(BodyIndex index) const;
+  [[nodiscard]] MobodIndex link_to_mobod(BodyIndex index) const;
 
   /** After the SpanningForest has been built, returns groups of Links that are
   welded together, which we call "LinkComposites". Each group may be modeled
@@ -362,13 +431,14 @@ class LinkJointGraph {
   forest-building; there is no cost to accessing them here.
 
   If there is no valid Forest, the returned vector is empty. */
-  const std::vector<std::vector<BodyIndex>>& link_composites() const {
+  [[nodiscard]] const std::vector<std::vector<BodyIndex>>& link_composites()
+      const {
     return data_.link_composites;
   }
 
   /** Returns a reference to a particular LinkComposite. Requires a
   LinkCompositeIndex, not a plain integer.*/
-  const std::vector<BodyIndex>& link_composites(
+  [[nodiscard]] const std::vector<BodyIndex>& link_composites(
       LinkCompositeIndex composite_link_index) const {
     return link_composites().at(composite_link_index);
   }
@@ -376,27 +446,27 @@ class LinkJointGraph {
   /** @returns `true` if a Link named `name` was added to `model_instance`.
   @see AddLink().
   @throws std::exception if `model_instance_index` is not a valid index. */
-  bool HasLinkNamed(std::string_view name,
-                    ModelInstanceIndex model_instance_index) const;
+  [[nodiscard]] bool HasLinkNamed(
+      std::string_view name, ModelInstanceIndex model_instance_index) const;
 
   /** @returns `true` if a Joint named `name` was added to `model_instance`.
   @see AddJoint().
   @throws std::exception if `model_instance_index` is not a valid index. */
-  bool HasJointNamed(std::string_view name,
-                     ModelInstanceIndex model_instance_index) const;
+  [[nodiscard]] bool HasJointNamed(
+      std::string_view name, ModelInstanceIndex model_instance_index) const;
 
   /** If there is a Joint connecting the given Links, returns its index. You can
   call this any time and it will work with whatever Joints have been defined.
   But note that Links may be split and additional Joints added during Forest
   building, so you may get a different answer before and after modeling. Cost is
   O(j) where j=min(j₁,j₂) with jᵢ the number of Joints attached to linkᵢ. */
-  std::optional<JointIndex> MaybeGetJointBetween(BodyIndex link1_index,
-                                                 BodyIndex link2_index) const;
+  [[nodiscard]] std::optional<JointIndex> MaybeGetJointBetween(
+      BodyIndex link1_index, BodyIndex link2_index) const;
 
   /** Returns true if the given Link should be treated as massless. That
   requires that the Link was marked TreatAsMassless and is not connected by
   a Weld Joint to a massful Link or Composite. */
-  bool must_treat_as_massless(BodyIndex link_index) const;
+  [[nodiscard]] bool must_treat_as_massless(LinkOrdinal link_ordinal) const;
 
   /** (Internal use only) For testing -- invalidates the Forest. */
   void ChangeLinkFlags(BodyIndex link_index, LinkFlags flags);
@@ -418,17 +488,18 @@ class LinkJointGraph {
   // Forest building requires these joint types so they are predefined.
 
   /** The predefined index for the "weld" joint type's traits. */
-  static JointTraitsIndex weld_joint_traits_index() {
+  [[nodiscard]] static JointTraitsIndex weld_joint_traits_index() {
     return JointTraitsIndex(0);
   }
 
   /** The predefined index for the "quaternion_floating" joint type's traits. */
-  static JointTraitsIndex quaternion_floating_joint_traits_index() {
+  [[nodiscard]] static JointTraitsIndex
+  quaternion_floating_joint_traits_index() {
     return JointTraitsIndex(1);
   }
 
   /** The predefined index for the "rpy_floating" joint type's traits. */
-  static JointTraitsIndex rpy_floating_joint_traits_index() {
+  [[nodiscard]] static JointTraitsIndex rpy_floating_joint_traits_index() {
     return JointTraitsIndex(2);
   }
 
@@ -436,18 +507,52 @@ class LinkJointGraph {
   friend class SpanningForest;
   friend class LinkJointGraphTester;
 
-  inline Link& mutable_link(BodyIndex link_index);
+  [[nodiscard]] inline Link& mutable_link(LinkOrdinal link_ordinal);
 
-  inline Joint& mutable_joint(JointIndex joint_index);
+  [[nodiscard]] inline Joint& mutable_joint(JointOrdinal joint_ordinal);
+
+  // Returns the maximum number of link indices we may have (some of those
+  // may have been removed).
+  [[nodiscard]] int num_link_indexes() const {
+    return ssize(data_.link_index_to_ordinal);
+  }
+
+  // Returns the maximum number of joint indices we may have (some of those
+  // may have been removed).
+  [[nodiscard]] int num_joint_indexes() const {
+    return ssize(data_.joint_index_to_ordinal);
+  }
+
+  // Given a link index returns that link's ordinal.
+  // @pre the index refers to a link that exists and hasn't been removed.
+  [[nodiscard]] LinkOrdinal index_to_ordinal(BodyIndex link_index) const {
+    DRAKE_ASSERT(link_index.is_valid() &&
+                 link_index < ssize(data_.link_index_to_ordinal));
+    const std::optional<LinkOrdinal>& ordinal =
+        data_.link_index_to_ordinal[link_index];
+    DRAKE_ASSERT(ordinal.has_value());
+    return *ordinal;
+  }
+
+  // Given a joint index returns that joint's ordinal.
+  // @pre the index refers to a joint that exists and hasn't been removed.
+  [[nodiscard]] JointOrdinal index_to_ordinal(JointIndex joint_index) const {
+    DRAKE_ASSERT(joint_index.is_valid() &&
+                 joint_index < ssize(data_.joint_index_to_ordinal));
+    const std::optional<JointOrdinal>& ordinal =
+        data_.joint_index_to_ordinal[joint_index];
+    DRAKE_ASSERT(ordinal.has_value());
+    return *ordinal;
+  }
 
   // Tells this Link which Mobod it follows and which Joint corresponds to
   // that Mobod's inboard mobilizer.
-  void set_primary_mobod_for_link(BodyIndex link_index,
+  void set_primary_mobod_for_link(LinkOrdinal link_ordinal,
                                   MobodIndex primary_mobod_index,
                                   JointIndex primary_joint_index);
 
   // Tells this currently-unmodeled Joint that the given Mobod models it.
-  void set_mobod_for_joint(JointIndex joint_index, MobodIndex mobod_index);
+  void set_mobod_for_joint(JointOrdinal joint_ordinal, MobodIndex mobod_index);
 
   // The World Link must already be in the graph but there are no Link
   // Composites yet. This creates the 0th LinkComposite and puts World in it.
@@ -455,8 +560,8 @@ class LinkJointGraph {
 
   // Registers a loop-closing weld constraint between these Links and updates
   // the Links to know about it.
-  LoopConstraintIndex AddLoopClosingWeldConstraint(BodyIndex primary_link_index,
-                                                   BodyIndex shadow_link_index);
+  LoopConstraintIndex AddLoopClosingWeldConstraint(
+      LinkOrdinal primary_link_ordinal, LinkOrdinal shadow_link_ordinal);
 
   // Delegates to each MobodIndex-keeping element to renumber those indices
   // using the given map.
@@ -470,21 +575,21 @@ class LinkJointGraph {
   // Mobod). If that's the Joint's parent Link then parent->child and
   // inboard->outboard will match, otherwise the mobilizer must be reversed.
   // Returned tuple is: inboard link, outboard link, is_reversed.
-  std::tuple<BodyIndex, BodyIndex, bool> FindInboardOutboardLinks(
-      MobodIndex inboard_mobod_index, JointIndex joint_index) const;
+  std::tuple<LinkOrdinal, LinkOrdinal, bool> FindInboardOutboardLinks(
+      MobodIndex inboard_mobod_index, JointOrdinal joint_ordinal) const;
 
   // Adds the ephemeral Joint for a floating or fixed base Link to mirror a
   // mobilizer added during BuildForest(). World is the parent and the given
   // base Link is the child for the new Joint.
   JointIndex AddEphemeralJointToWorld(JointTraitsIndex type_index,
-                                      BodyIndex child_link_index);
+                                      LinkOrdinal child_link_ordinal);
 
   // Adds the new Link to the LinkComposite of which maybe_composite_link is a
   // member. If maybe_composite_link is not a member of any LinkComposite, then
   // we create a new LinkComposite with maybe_composite_link as the first
   // (and hence "active") Link.
-  LinkCompositeIndex AddToLinkComposite(BodyIndex maybe_composite_link_index,
-                                        BodyIndex new_link_index);
+  LinkCompositeIndex AddToLinkComposite(
+      LinkOrdinal maybe_composite_link_ordinal, LinkOrdinal new_link_ordinal);
 
   // While building the Forest, adds a new Shadow link to the given Primary
   // link, with the Shadow mobilized by the given joint. We'll derive a name for
@@ -496,8 +601,9 @@ class LinkJointGraph {
   // connects a "parent" link to a "child" link; that ordering determines the
   // sign convention for its multipliers (forces). We always make the Primary
   // the weld's parent link, and the Shadow its child.
-  BodyIndex AddShadowLink(BodyIndex primary_link_index,
-                          JointIndex shadow_joint_index, bool shadow_is_parent);
+  LinkOrdinal AddShadowLink(LinkOrdinal primary_link_ordinal,
+                            JointOrdinal shadow_joint_ordinal,
+                            bool shadow_is_parent);
 
   // Finds the assigned index for a joint's traits from the joint's type name.
   // Returns nullopt if `joint_type_name` was not previously registered
@@ -506,15 +612,16 @@ class LinkJointGraph {
       const std::string& joint_type_name) const;
 
   // Links that were explicitly flagged LinkFlags::kStatic in AddLink().
-  const std::vector<BodyIndex>& static_links() const {
-    return data_.static_links;
+  const std::vector<BodyIndex>& static_link_indexes() const {
+    return data_.static_link_indexes;
   }
 
   // Links that were flagged LinkFlags::kMustBeBaseBody in AddLink() but were
   // not also flagged kStatic (those are inherently base bodies since by
   // definition they are welded to World).
-  const std::vector<BodyIndex>& non_static_must_be_base_body_links() const {
-    return data_.non_static_must_be_base_body_links;
+  const std::vector<BodyIndex>& non_static_must_be_base_body_link_indexes()
+      const {
+    return data_.non_static_must_be_base_body_link_indexes;
   }
 
   // A link is static if it is in a static model instance or if it has been
@@ -530,6 +637,12 @@ class LinkJointGraph {
                ? data_.model_instance_forest_building_options[instance_index]
                : std::nullopt;
   }
+
+  [[noreturn]] void ThrowLinkWasRemoved(const char* func,
+                                        BodyIndex link_index) const;
+
+  [[noreturn]] void ThrowJointWasRemoved(const char* func,
+                                         JointIndex joint_index) const;
 
   // Group data members so we can have the compiler generate most of the
   // copy/move/assign methods for us while still permitting pointer fixup.
@@ -548,25 +661,39 @@ class LinkJointGraph {
     // The first entry in links is the World Link with BodyIndex(0) and name
     // world_link().name(). Ephemeral "as-built" links and joints are placed
     // at the end of these lists, following the user-supplied ones.
+    // Access these lists by _ordinal_ rather than _index_.
     std::vector<Link> links;
     std::vector<Joint> joints;
+
+    // Map link and joint indices to the corresponding ordinals for
+    // elements that have not been removed. Note that an element's index is
+    // persistent but its ordinal can change.
+    std::vector<std::optional<LinkOrdinal>> link_index_to_ordinal;
+    std::vector<std::optional<JointOrdinal>> joint_index_to_ordinal;
 
     // The first num_user_links etc. elements are user-supplied; the rest were
     // added during modeling.
     int num_user_links{0};
     int num_user_joints{0};
 
+    // Records the highest index assigned to a user element. Anything higher
+    // is an index temporarily assigned to ephemeral elements. Note that the
+    // highest-ordinal user link or joint does not necessarily have the
+    // highest-ever user index since higher ones might have been removed.
+    BodyIndex max_user_link_index;
+    JointIndex max_user_joint_index;
+
     // Loop Weld Constraints are only added during forest building; we don't
     // record any user constraints in the LinkJointGraph because they don't
     // affect how we build the forest.
     std::vector<LoopConstraint> loop_constraints;
 
-    std::vector<BodyIndex> static_links;
-    std::vector<BodyIndex> non_static_must_be_base_body_links;
+    std::vector<BodyIndex> static_link_indexes;
+    std::vector<BodyIndex> non_static_must_be_base_body_link_indexes;
 
     // Every user Link, organized by Model Instance.
     std::map<ModelInstanceIndex, std::vector<BodyIndex>>
-        model_instance_to_links;
+        model_instance_to_link_indexes;
 
     // This must always have the same number of entries as joint_traits_.
     string_unordered_map<JointTraitsIndex> joint_type_name_to_index;

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -15,6 +15,9 @@ namespace internal {
 
 class SpanningForest;
 
+using LinkOrdinal = TypeSafeIndex<class LinkOrdinalTag>;
+using JointOrdinal = TypeSafeIndex<class JointOrdinalTag>;
+
 using JointTraitsIndex = TypeSafeIndex<class JointTraitsTag>;
 using LinkCompositeIndex = TypeSafeIndex<class LinkCompositeTag>;
 using LoopConstraintIndex = TypeSafeIndex<class LoopConstraintTag>;

--- a/multibody/topology/link_joint_graph_inlines.h
+++ b/multibody/topology/link_joint_graph_inlines.h
@@ -4,6 +4,8 @@
 #error Do not include this file. Use "drake/multibody/topology/graph.h".
 #endif
 
+#include <optional>
+
 namespace drake {
 namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
@@ -11,29 +13,43 @@ namespace internal {
 
 // LinkJointGraph definitions deferred until Link defined.
 
-inline auto LinkJointGraph::links(BodyIndex link_index) const -> const Link& {
-  return links().at(link_index);
+inline const LinkJointGraph::Link& LinkJointGraph::links(
+    LinkOrdinal link_ordinal) const {
+  DRAKE_ASSERT(link_ordinal < ssize(links()));
+  return data_.links[link_ordinal];
 }
 
-inline auto LinkJointGraph::mutable_link(BodyIndex link_index) -> Link& {
-  return data_.links.at(link_index);
+inline const LinkJointGraph::Link& LinkJointGraph::link_by_index(
+    BodyIndex link_index) const {
+  const std::optional<LinkOrdinal>& ordinal =
+      data_.link_index_to_ordinal.at(link_index);
+  if (!ordinal.has_value()) ThrowLinkWasRemoved(__func__, link_index);
+  DRAKE_ASSERT(ordinal < ssize(links()));
+  return links(*ordinal);
+}
+
+inline LinkJointGraph::Link& LinkJointGraph::mutable_link(
+    LinkOrdinal link_ordinal) {
+  DRAKE_ASSERT(link_ordinal < ssize(links()));
+  return data_.links[link_ordinal];
 }
 
 inline MobodIndex LinkJointGraph::link_to_mobod(BodyIndex index) const {
-  return links(index).mobod_;
+  return link_by_index(index).mobod_;
 }
 
 inline void LinkJointGraph::set_primary_mobod_for_link(
-    BodyIndex link_index, MobodIndex primary_mobod_index,
+    LinkOrdinal link_ordinal, MobodIndex primary_mobod_index,
     JointIndex primary_joint_index) {
-  Link& link = mutable_link(link_index);
-  DRAKE_DEMAND(!link.mobod_.is_valid());
+  Link& link = mutable_link(link_ordinal);
+  DRAKE_ASSERT(!link.mobod_.is_valid());
   link.mobod_ = primary_mobod_index;
   link.joint_ = primary_joint_index;
 }
 
-inline bool LinkJointGraph::must_treat_as_massless(BodyIndex link_index) const {
-  const Link& link = links(link_index);
+inline bool LinkJointGraph::must_treat_as_massless(
+    LinkOrdinal link_ordinal) const {
+  const Link& link = links(link_ordinal);
   // TODO(sherm1) If part of a Composite then this is only massless if the
   //  entire Composite is composed of massless Links.
   return link.treat_as_massless();
@@ -41,26 +57,38 @@ inline bool LinkJointGraph::must_treat_as_massless(BodyIndex link_index) const {
 
 // LinkJointGraph definitions deferred until Joint defined.
 
-inline auto LinkJointGraph::joints(JointIndex joint_index) const
-    -> const Joint& {
-  return joints().at(joint_index);
+inline const LinkJointGraph::Joint& LinkJointGraph::joints(
+    JointOrdinal joint_ordinal) const {
+  DRAKE_ASSERT(joint_ordinal < ssize(joints()));
+  return data_.joints[joint_ordinal];
 }
 
-inline auto LinkJointGraph::mutable_joint(JointIndex joint_index) -> Joint& {
-  return data_.joints.at(joint_index);
+inline const LinkJointGraph::Joint& LinkJointGraph::joint_by_index(
+    JointIndex joint_index) const {
+  const std::optional<JointOrdinal>& ordinal =
+      data_.joint_index_to_ordinal.at(joint_index);
+  if (!ordinal.has_value()) ThrowJointWasRemoved(__func__, joint_index);
+  DRAKE_ASSERT(ordinal < ssize(joints()));
+  return joints(*ordinal);
 }
 
-inline void LinkJointGraph::set_mobod_for_joint(JointIndex joint_index,
+inline LinkJointGraph::Joint& LinkJointGraph::mutable_joint(
+    JointOrdinal joint_ordinal) {
+  DRAKE_ASSERT(joint_ordinal < ssize(joints()));
+  return data_.joints[joint_ordinal];
+}
+
+inline void LinkJointGraph::set_mobod_for_joint(JointOrdinal joint_ordinal,
                                                 MobodIndex mobod_index) {
-  Joint& joint = mutable_joint(joint_index);
-  DRAKE_DEMAND(joint.how_modeled_.index() == 0);  // I.e., empty.
+  Joint& joint = mutable_joint(joint_ordinal);
+  DRAKE_ASSERT(joint.how_modeled_.index() == 0);  // I.e., empty.
   joint.how_modeled_ = mobod_index;
 }
 
 // LinkJointGraph definitions deferred until LoopConstraint defined.
 
-inline auto LinkJointGraph::loop_constraints(
-    LoopConstraintIndex loop_constraint_index) const -> const LoopConstraint& {
+inline const LinkJointGraph::LoopConstraint& LinkJointGraph::loop_constraints(
+    LoopConstraintIndex loop_constraint_index) const {
   return loop_constraints().at(loop_constraint_index);
 }
 

--- a/multibody/topology/link_joint_graph_joint.h
+++ b/multibody/topology/link_joint_graph_joint.h
@@ -18,8 +18,13 @@ class LinkJointGraph::Joint {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Joint);
 
-  /** Returns this %Joint's unique index in the graph. */
+  /** Returns this %Joint's unique index in the graph. This is persistent after
+  the %Joint has been allocated. */
   JointIndex index() const { return index_; }
+
+  /** Returns the current value of this %Joint's ordinal (position in the
+  joints() vector). This can change as %Joints are removed. */
+  JointOrdinal ordinal() const { return ordinal_; }
 
   /** Returns this %Joint's model instance. */
   ModelInstanceIndex model_instance() const { return model_instance_; }
@@ -28,10 +33,10 @@ class LinkJointGraph::Joint {
   const std::string& name() const { return name_; }
 
   /** Returns the index of this %Joint's parent Link. */
-  BodyIndex parent_link() const { return parent_link_index_; }
+  BodyIndex parent_link_index() const { return parent_link_index_; }
 
   /** Returns the index of this %Joint's child Link. */
-  BodyIndex child_link() const { return child_link_index_; }
+  BodyIndex child_link_index() const { return child_link_index_; }
 
   /** Returns `true` if this is a Weld %Joint. */
   bool is_weld() const { return traits_index() == weld_joint_traits_index(); }
@@ -42,15 +47,15 @@ class LinkJointGraph::Joint {
   /** Returns `true` if either the parent or child Link of this %Joint is
   the specified `link`. */
   bool connects(BodyIndex link) const {
-    return link == parent_link() || link == child_link();
+    return link == parent_link_index() || link == child_link_index();
   }
 
   /** Returns `true` if this %Joint connects the two given Links. That is, if
   one of these is the parent Link and the other is the child Link, in either
   order. */
   bool connects(BodyIndex link1, BodyIndex link2) const {
-    return (parent_link() == link1 && child_link() == link2) ||
-           (parent_link() == link2 && child_link() == link1);
+    return (parent_link_index() == link1 && child_link_index() == link2) ||
+           (parent_link_index() == link2 && child_link_index() == link1);
   }
 
   // TODO(sherm1) Per Joe M an unchecked version of this could just do
@@ -60,8 +65,10 @@ class LinkJointGraph::Joint {
   /** Given one of the Links connected by this %Joint, returns the other one.
   @pre `link_index` is either the parent or child */
   BodyIndex other_link_index(BodyIndex link_index) const {
-    DRAKE_DEMAND((parent_link() == link_index) || (child_link() == link_index));
-    return parent_link() == link_index ? child_link() : parent_link();
+    DRAKE_DEMAND((parent_link_index() == link_index) ||
+                 (child_link_index() == link_index));
+    return parent_link_index() == link_index ? child_link_index()
+                                             : parent_link_index();
   }
 
   /** Returns `true` if this %Joint was added with
@@ -88,9 +95,10 @@ class LinkJointGraph::Joint {
   friend class LinkJointGraph;
   friend class LinkJointGraphTester;
 
-  Joint(JointIndex index, std::string name, ModelInstanceIndex model_instance,
-        JointTraitsIndex joint_traits_index, BodyIndex parent_link_index,
-        BodyIndex child_link_index, JointFlags flags);
+  Joint(JointIndex index, JointOrdinal ordinal, std::string name,
+        ModelInstanceIndex model_instance, JointTraitsIndex joint_traits_index,
+        BodyIndex parent_link_index, BodyIndex child_link_index,
+        JointFlags flags);
 
   void ClearModel() { how_modeled_ = std::monostate{}; }
 
@@ -110,7 +118,8 @@ class LinkJointGraph::Joint {
       how_modeled_ = old_to_new[std::get<MobodIndex>(how_modeled_)];
   }
 
-  JointIndex index_;
+  JointIndex index_;      // persistent
+  JointOrdinal ordinal_;  // can change
   std::string name_;
   ModelInstanceIndex model_instance_;
   JointFlags flags_{JointFlags::kDefault};

--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -68,10 +68,10 @@ links representing a robot or robots will be modest in comparison. Hence we
 want to handle welded and free links efficiently.
 
 The algorithm has three phases:
-  1 Produce the best tree structures we can. For example, when breaking
-    loops we want to minimize the maximum branch length for better numerics,
-    but we can't allow massless terminal bodies unless they are welded to
-    a massful body. Welded-together Links form a LinkComposite which can
+  1 Produce the best tree structures we can in one pass. For example, when
+    breaking loops we want to minimize the maximum branch length for better
+    numerics, but we can't allow massless terminal bodies unless they are welded
+    to a massful body. Welded-together Links form a LinkComposite which can
     (optionally) be modeled using a single mobilized body.
   2 Reorder the forest nodes (mobilized bodies) depth first for optimal
     computation. Each tree will consist only of consecutively-numbered nodes.
@@ -87,7 +87,7 @@ The algorithm has three phases:
 
 ForestBuildingOptions (global or per-model instance) determine
   - whether we produce a mobilized body for _each_ Link or just for each
-    _group_ of welded-together Links (a LinkComposite), and
+    _assembly_ of welded-together Links (a LinkComposite), and
   - what kind of Joint we use to mobilize unconnected root Links: 0 dof fixed,
     6 dof roll-pitch-yaw floating, or 6 dof quaternion floating.
 
@@ -152,10 +152,10 @@ bool SpanningForest::BuildForest() {
   /* Model the World (Link 0) with mobilized body 0. This also starts the 0th
   LinkComposite in the graph and the 0th Welded Mobods group in the Forest.
   (1.1) */
-  data_.mobods.emplace_back(MobodIndex(0), BodyIndex(0));
+  data_.mobods.emplace_back(MobodIndex(0), LinkOrdinal(0));
   data_.welded_mobods.emplace_back(std::vector{MobodIndex(0)});
   data_.mobods[MobodIndex(0)].welded_mobods_index_ = WeldedMobodsIndex(0);
-  mutable_graph().set_primary_mobod_for_link(BodyIndex(0), MobodIndex(0),
+  mutable_graph().set_primary_mobod_for_link(LinkOrdinal(0), MobodIndex(0),
                                              JointIndex{});
   mutable_graph().CreateWorldLinkComposite();
 
@@ -188,13 +188,14 @@ void SpanningForest::ChooseForestTopology() {
 
   /* Look through the model instances to see if any of them are static and if so
   weld all their bodies to World. (1.2a) */
-  for (const auto& [instance, links] : graph().data_.model_instance_to_links) {
+  for (const auto& [instance, link_indexes] :
+       graph().data_.model_instance_to_link_indexes) {
     if (!model_instance_is_static(instance)) continue;
-    ConnectLinksToWorld(links, true /* use weld joint */);
+    ConnectLinksToWorld(link_indexes, true /* use weld joint */);
   }
 
   /* Add welds for any links that were explicitly marked "static". (1.2b) */
-  ConnectLinksToWorld(graph().static_links(), true /* use weld joint */);
+  ConnectLinksToWorld(graph().static_link_indexes(), true /* use weld joint */);
 
   /* Every MustBeBaseBody Link must have a Joint directly connecting it to
   World. If there isn't one already, we'll add a "floating" joint of the
@@ -203,13 +204,13 @@ void SpanningForest::ChooseForestTopology() {
   For example, they can create cycles in the graph that need to be removed in
   the Forest. Note that Static Links were processed above and are not repeated
   on the must_be_base_body list even if they were so designated. (1.2c) */
-  ConnectLinksToWorld(graph().non_static_must_be_base_body_links(),
+  ConnectLinksToWorld(graph().non_static_must_be_base_body_link_indexes(),
                       false /* use floating joint */);
 
-  /* Now grow all the trees whose base bodies have joints to World (or to the
-  World LinkComposite). This includes: (a) Links which were explicitly jointed
-  to World by the user, (b) Static Links for which we just added weld joints,
-  and (c) MustBeBaseBody Links for which we just added floating joints. (1.3) */
+  /* Now grow all the trees whose base bodies have joints to World. This
+  includes: (a) Links which were explicitly jointed to World by the user,
+  (b) Static Links for which we just added weld joints, and (c) MustBeBaseBody
+  Links for which we just added floating joints. (1.3) */
   ExtendTrees(graph().world_link().joints(), &num_unprocessed_links);
 
   /* What's left unprocessed now (if anything) is a collection of disjoint
@@ -316,18 +317,23 @@ void SpanningForest::AssignCoordinates() {
   for (auto& mobod : data_.mobods) {
     mobod.q_start_ = next_q;
     mobod.v_start_ = next_v;
-    if (!mobod.joint().is_valid()) {
+    if (!mobod.joint_ordinal().is_valid()) {
       mobod.nq_ = mobod.nv_ = 0;  // Treat World as though welded.
       mobod.nq_inboard_ = mobod.nv_inboard_ = 0;
       continue;
     }
     const JointTraitsIndex joint_traits_index =
-        joints(mobod.joint()).traits_index();
+        joints(mobod.joint_ordinal()).traits_index();
     const LinkJointGraph::JointTraits& joint_traits =
         graph().joint_traits()[joint_traits_index];
 
     mobod.nq_ = joint_traits.nq;
     mobod.nv_ = joint_traits.nv;
+
+    if (joint_traits.has_quaternion) {
+      mobod.has_quaternion_ = true;
+      data_.quaternion_starts.push_back(mobod.q_start_);
+    }
 
     /* Keep a running count of inboard coordinates. */
     DRAKE_DEMAND(mobod.inboard().is_valid());  // Non-World must have inboard.
@@ -369,21 +375,21 @@ void SpanningForest::AssignCoordinates() {
 /* Phase 1 steps 1.4 and 1.5. */
 void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
   /* Partition the unmodeled links into jointed and unjointed. O(n) */
-  std::vector<BodyIndex> jointed_links, unjointed_links;
+  std::vector<LinkOrdinal> jointed_links, unjointed_links;
   for (const auto& link : links()) {
-    const BodyIndex link_index = link.index();
-    if (link_is_already_in_forest(link_index)) continue;
+    const LinkOrdinal link_ordinal = link.ordinal();
+    if (link_is_already_in_forest(link_ordinal)) continue;
     if (ssize(link.joints()) == 0) {
-      unjointed_links.push_back(link_index);
+      unjointed_links.push_back(link_ordinal);
     } else {
-      jointed_links.push_back(link_index);
+      jointed_links.push_back(link_ordinal);
     }
   }
 
   /* Use the active base body choice policy to create a priority queue of
   links that could be base bodies. Complexity is O(j) to create a
   priority_queue of j jointed links. */
-  std::priority_queue<BodyIndex, std::vector<BodyIndex>,
+  std::priority_queue<LinkOrdinal, std::vector<LinkOrdinal>,
                       decltype(data_.base_body_policy)>
       eligible_bases(data_.base_body_policy, std::move(jointed_links));
 
@@ -392,7 +398,7 @@ void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
   (1.4) Complexity is O(j log j). */
   while (*num_unprocessed_links > ssize(unjointed_links)) {
     DRAKE_DEMAND(!eligible_bases.empty());  // Must be something here!
-    const BodyIndex next_base_link = eligible_bases.top();
+    const LinkOrdinal next_base_link = eligible_bases.top();
     eligible_bases.pop();                                     // O(log j)
     if (link_is_already_in_forest(next_base_link)) continue;  // try another one
     const ModelInstanceIndex model_instance_index =
@@ -413,7 +419,7 @@ void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
   instance (that's not technically a static link). (1.5) */
   DRAKE_DEMAND(*num_unprocessed_links == ssize(unjointed_links));
 
-  for (BodyIndex unjointed_link : unjointed_links) {
+  for (LinkOrdinal unjointed_link : unjointed_links) {
     const ModelInstanceIndex model_instance_index =
         links(unjointed_link).model_instance();
     const JointTraitsIndex joint_type_to_use =
@@ -421,8 +427,9 @@ void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
     const JointIndex next_joint_index =
         mutable_graph().AddEphemeralJointToWorld(joint_type_to_use,
                                                  unjointed_link);
-
-    AddNewMobod(unjointed_link, next_joint_index, world_mobod().index(),
+    const JointOrdinal next_joint_ordinal =
+        graph().index_to_ordinal(next_joint_index);
+    AddNewMobod(unjointed_link, next_joint_ordinal, world_mobod().index(),
                 false);  // Not reversed; World is parent
     /* No tree to extend here. */
   }
@@ -455,51 +462,61 @@ void SpanningForest::ExtendTreesOneLevel(
   joints_to_model_next->clear();
 
   for (JointIndex joint_index : joints_to_model) {
-    const Joint& joint = joints(joint_index);
+    const JointOrdinal joint_ordinal = graph().index_to_ordinal(joint_index);
+    const Joint& joint = joints(joint_ordinal);
     if (joint.has_been_processed())
       continue;  // Already did this one from the other side.
+
+    const LinkOrdinal parent_link_ordinal =
+        graph().index_to_ordinal(joint.parent_link_index());
+    const LinkOrdinal child_link_ordinal =
+        graph().index_to_ordinal(joint.child_link_index());
 
     /* At least one of the Joint's Links must have already been modeled.
     (Could be both in the case of a loop.) */
     const bool parent_is_modeled =
-        link_is_already_in_forest(joint.parent_link());
-    const bool child_is_modeled = link_is_already_in_forest(joint.child_link());
+        link_is_already_in_forest(parent_link_ordinal);
+    const bool child_is_modeled = link_is_already_in_forest(child_link_ordinal);
     DRAKE_DEMAND(parent_is_modeled || child_is_modeled);
 
-    const BodyIndex inboard_link_index =
-        parent_is_modeled ? joint.parent_link() : joint.child_link();
+    const BodyIndex inboard_link_index = parent_is_modeled
+                                             ? joint.parent_link_index()
+                                             : joint.child_link_index();
 
     /* Don't keep references to Mobods since we're growing the vector below. */
     const MobodIndex inboard_mobod_index =
         graph().link_to_mobod(inboard_link_index);
 
     const JointIndex modeled_joint_index = joint_index;  // For easier stubbing.
+    const JointOrdinal modeled_joint_ordinal =
+        graph().index_to_ordinal(modeled_joint_index);
 
     // TODO(sherm1) Combining composites stubbed out here (E.4)
 
     /* The modeled_joint might connect to any Link of an inboard LinkComposite
-    that uses inboard_mobod. That's the Link we want as the inboard Link. */
-    const auto [modeled_inboard_link_index, modeled_outboard_link_index,
+    that follows inboard_mobod. That's the Link we want as inboard Link; not
+    the Composite's active Link. */
+    const auto [modeled_inboard_link_ordinal, modeled_outboard_link_ordinal,
                 is_reversed] =
         graph().FindInboardOutboardLinks(inboard_mobod_index,
-                                         modeled_joint_index);
+                                         modeled_joint_ordinal);
 
     /* If the outboard link is already modeled, this is a loop-closing
     joint (E.5). */
-    if (link_is_already_in_forest(modeled_outboard_link_index)) {
+    if (link_is_already_in_forest(modeled_outboard_link_ordinal)) {
       /* Invalidates references to Links, Joints, Mobods, LoopConstraints. */
-      HandleLoopClosure(modeled_joint_index);
+      HandleLoopClosure(modeled_joint_ordinal);
       continue;
     }
 
-    /* Note: invalidates references to Mobods. */
-    AddNewMobod(modeled_outboard_link_index, modeled_joint_index,
+    /* Note: this invalidates references to Mobods. */
+    AddNewMobod(modeled_outboard_link_ordinal, modeled_joint_ordinal,
                 inboard_mobod_index,
                 is_reversed);  // Is mobilizer reversed from Joint?
     --(*num_unprocessed_links);
 
-    const Link& modeled_outboard_link = links(modeled_outboard_link_index);
-    const Joint& modeled_joint = joints(modeled_joint_index);
+    const Link& modeled_outboard_link = links(modeled_outboard_link_ordinal);
+    const Joint& modeled_joint = joints(modeled_joint_ordinal);
 
     /* If we just added a massless Mobod on an articulated (non-weld) joint,
     we're in trouble if there are no outboard joints. In that case the forest
@@ -528,7 +545,7 @@ void SpanningForest::ExtendTreesOneLevel(
     /* We can stop here. Collect up the Joints for the next level and go on to
     the next Joint to model at this level. */
     for (JointIndex next_joint_index : modeled_outboard_link.joints()) {
-      if (!joints(next_joint_index).has_been_processed())
+      if (!joint_by_index(next_joint_index).has_been_processed())
         joints_to_model_next->push_back(next_joint_index);
     }
   }
@@ -536,9 +553,9 @@ void SpanningForest::ExtendTreesOneLevel(
 
 /* See documentation in header before trying to decipher this. */
 const SpanningForest::Mobod& SpanningForest::AddNewMobod(
-    BodyIndex outboard_link_index, JointIndex joint_index,
+    LinkOrdinal outboard_link_ordinal, JointOrdinal joint_ordinal,
     MobodIndex inboard_mobod_index, bool is_reversed) {
-  const Joint& joint = joints(joint_index);
+  const Joint& joint = joints(joint_ordinal);
 
   /* Careful -- don't hold Mobod references until _after_ we grow the vector. */
 
@@ -546,8 +563,8 @@ const SpanningForest::Mobod& SpanningForest::AddNewMobod(
   const int inboard_level = mobods(inboard_mobod_index).level();
   const MobodIndex new_mobod_index(ssize(mobods()));
   Mobod& new_mobod =
-      data_.mobods.emplace_back(new_mobod_index, outboard_link_index,
-                                joint_index, inboard_level + 1, is_reversed);
+      data_.mobods.emplace_back(new_mobod_index, outboard_link_ordinal,
+                                joint_ordinal, inboard_level + 1, is_reversed);
   Mobod& inboard_mobod = data_.mobods[inboard_mobod_index];
 
   /* If the inboard Mobod is World, start a new Tree. */
@@ -568,9 +585,9 @@ const SpanningForest::Mobod& SpanningForest::AddNewMobod(
   // Record connections in forest and graph.
   new_mobod.inboard_mobod_ = inboard_mobod_index;
   inboard_mobod.outboard_mobods_.push_back(new_mobod_index);
-  mutable_graph().set_primary_mobod_for_link(outboard_link_index,
-                                             new_mobod_index, joint_index);
-  mutable_graph().set_mobod_for_joint(joint_index, new_mobod_index);
+  mutable_graph().set_primary_mobod_for_link(outboard_link_ordinal,
+                                             new_mobod_index, joint.index());
+  mutable_graph().set_mobod_for_joint(joint_ordinal, new_mobod_index);
 
   /* Build up both WeldedMobods group (in forest) and LinkComposite (in graph)
   if we have a Weld joint, starting a new group or composite as needed. */
@@ -584,8 +601,8 @@ const SpanningForest::Mobod& SpanningForest::AddNewMobod(
     data_.welded_mobods[*inboard_mobod.welded_mobods_index_].push_back(
         new_mobod_index);
 
-    mutable_graph().AddToLinkComposite(inboard_mobod.link(),
-                                       outboard_link_index);
+    mutable_graph().AddToLinkComposite(inboard_mobod.link_ordinal(),
+                                       outboard_link_ordinal);
   }
 
   return new_mobod;
@@ -594,11 +611,13 @@ const SpanningForest::Mobod& SpanningForest::AddNewMobod(
 void SpanningForest::ConnectLinksToWorld(
     const std::vector<BodyIndex>& links_to_connect, bool use_weld) {
   for (const auto& link_index : links_to_connect) {
-    DRAKE_DEMAND(!link_is_already_in_forest(link_index));
-    const Link& link = links(link_index);
+    const LinkOrdinal link_ordinal = graph().index_to_ordinal(link_index);
+    DRAKE_DEMAND(!link_is_already_in_forest(link_ordinal));
+    const Link& link = links(link_ordinal);
     bool found_joint_to_world = false;
     for (const auto& joint_index : link.joints()) {
-      const Joint& joint = joints(joint_index);
+      const JointOrdinal joint_ordinal = graph().index_to_ordinal(joint_index);
+      const Joint& joint = joints(joint_ordinal);
       if (joint.connects(graph().world_link().index())) {
         found_joint_to_world = true;
         break;
@@ -608,7 +627,8 @@ void SpanningForest::ConnectLinksToWorld(
       const JointTraitsIndex joint_traits_index =
           use_weld ? LinkJointGraph::weld_joint_traits_index()
                    : base_joint_traits_index(link.model_instance());
-      mutable_graph().AddEphemeralJointToWorld(joint_traits_index, link_index);
+      mutable_graph().AddEphemeralJointToWorld(joint_traits_index,
+                                               link_ordinal);
     }
   }
 }
@@ -624,8 +644,8 @@ policy:
 void SpanningForest::SetBaseBodyChoicePolicy() {
   /* std::priority_queue puts the "largest" element on top, and this is its
   "less than" test. The worse choice must test "less than" the better one. */
-  data_.base_body_policy = [this](const BodyIndex& left,
-                                  const BodyIndex& right) -> bool {
+  data_.base_body_policy = [this](const LinkOrdinal& left,
+                                  const LinkOrdinal& right) -> bool {
     const Link& left_link = links(left);
     const Link& right_link = links(right);
     const int lnc = ssize(left_link.joints_as_child());
@@ -644,32 +664,36 @@ void SpanningForest::SetBaseBodyChoicePolicy() {
   };
 }
 
-void SpanningForest::HandleLoopClosure(JointIndex loop_joint_index) {
-  Joint& joint = mutable_graph().mutable_joint(loop_joint_index);
-  DRAKE_DEMAND(link_is_already_in_forest(joint.parent_link()) &&
-               link_is_already_in_forest(joint.child_link()));
+void SpanningForest::HandleLoopClosure(JointOrdinal loop_joint_ordinal) {
+  Joint& loop_joint = mutable_graph().mutable_joint(loop_joint_ordinal);
+  const LinkOrdinal parent_ordinal =
+      graph().index_to_ordinal(loop_joint.parent_link_index());
+  const LinkOrdinal child_ordinal =
+      graph().index_to_ordinal(loop_joint.child_link_index());
+
+  DRAKE_DEMAND(link_is_already_in_forest(parent_ordinal) &&
+               link_is_already_in_forest(child_ordinal));
 
   /* If one of the two bodies is massless, that's no problem - we just have
   to be sure to cut the massful one. The two branches will then each be
   terminated with massful bodies (at 1/2 the mass each). However, if both
   bodies are massless this forest can only be used for kinematics. */
   const bool parent_is_massless =
-      graph().must_treat_as_massless(joint.parent_link());
-  const bool child_is_massless =
-      graph().must_treat_as_massless(joint.child_link());
+      graph().must_treat_as_massless(parent_ordinal);
+  const bool child_is_massless = graph().must_treat_as_massless(child_ordinal);
 
   /* Save an explanation the first time we are forced to end a branch with
   a massless body. */
   if (parent_is_massless && child_is_massless && data_.dynamics_ok) {
     data_.dynamics_ok = false;
-    const Link& parent_link = links(joint.parent_link());
-    const Link& child_link = links(joint.child_link());
+    const Link& parent_link = links(parent_ordinal);
+    const Link& child_link = links(child_ordinal);
     data_.why_no_dynamics = fmt::format(
         "Loop breaks at joint {} between two massless links {} and {}. "
         "That means these links are terminal bodies in the tree which "
         "will produce a singular mass matrix. Hence this model cannot "
         "be used for dynamics.\n",
-        joint.name(), parent_link.name(), child_link.name());
+        loop_joint.name(), parent_link.name(), child_link.name());
   }
 
   /* If the branches leading to each link are of unequal length, we prefer to
@@ -680,46 +704,51 @@ void SpanningForest::HandleLoopClosure(JointIndex loop_joint_index) {
   bool split_parent = false;  // Prefer child.
   if (!(child_is_massless || parent_is_massless)) {
     const int child_level =
-        mobods(graph().link_to_mobod(joint.child_link())).level();
+        mobods(graph().link_to_mobod(loop_joint.child_link_index())).level();
     const int parent_level =
-        mobods(graph().link_to_mobod(joint.parent_link())).level();
+        mobods(graph().link_to_mobod(loop_joint.parent_link_index())).level();
     if (parent_level > child_level) split_parent = true;
   } else if (child_is_massless) {
     split_parent = true;
   }
 
-  AddShadowMobod(split_parent ? joint.parent_link() : joint.child_link(),
-                 joint.index());
+  AddShadowMobod(split_parent ? parent_ordinal : child_ordinal,
+                 loop_joint_ordinal);
 }
 
 /* We're going to add a shadow Link to the given primary Link and create a Mobod
 for the shadow appropriate for the given Joint. Then we'll add a weld constraint
 between the shadow and its primary. */
 const SpanningForest::Mobod& SpanningForest::AddShadowMobod(
-    BodyIndex primary_link_index, JointIndex shadow_joint_index) {
-  Joint& shadow_joint = mutable_graph().mutable_joint(shadow_joint_index);
-  DRAKE_DEMAND(shadow_joint.connects(primary_link_index));
+    LinkOrdinal primary_link_ordinal, JointOrdinal shadow_joint_ordinal) {
+  const Link& primary_link = links(primary_link_ordinal);
+  Joint& shadow_joint = mutable_graph().mutable_joint(shadow_joint_ordinal);
+  DRAKE_DEMAND(shadow_joint.connects(primary_link.index()));
   const BodyIndex inboard_link_index =
-      shadow_joint.other_link_index(primary_link_index);
+      shadow_joint.other_link_index(primary_link.index());
 
   /* The Joint was written to connect inboard_link to primary_link but is
   actually going to connect inboard_link to shadow_link. */
-  const bool is_reversed = shadow_joint.parent_link() != inboard_link_index;
+  const bool is_reversed =
+      shadow_joint.parent_link_index() != inboard_link_index;
 
-  const BodyIndex shadow_link_index = mutable_graph().AddShadowLink(
-      primary_link_index, shadow_joint_index, is_reversed);
+  const LinkOrdinal shadow_link_ordinal = mutable_graph().AddShadowLink(
+      primary_link_ordinal, shadow_joint_ordinal, is_reversed);
 
   const LoopConstraintIndex loop_constraint_index =
-      mutable_graph().AddLoopClosingWeldConstraint(primary_link_index,
-                                                   shadow_link_index);
+      mutable_graph().AddLoopClosingWeldConstraint(primary_link_ordinal,
+                                                   shadow_link_ordinal);
 
+  const LinkOrdinal inboard_link_ordinal =
+      graph().index_to_ordinal(inboard_link_index);
   const MobodIndex inboard_mobod_index =
-      links(inboard_link_index).mobod_index();
-  const Mobod& shadow_mobod = AddNewMobod(shadow_link_index, shadow_joint_index,
-                                          inboard_mobod_index, is_reversed);
+      links(inboard_link_ordinal).mobod_index();
+  const Mobod& shadow_mobod =
+      AddNewMobod(shadow_link_ordinal, shadow_joint_ordinal,
+                  inboard_mobod_index, is_reversed);
 
   const MobodIndex primary_mobod_index =
-      links(primary_link_index).mobod_index();
+      links(primary_link_ordinal).mobod_index();
   data_.loop_constraints.emplace_back(
       loop_constraint_index, primary_mobod_index, shadow_mobod.index());
 
@@ -745,13 +774,13 @@ void SpanningForest::AddStubTreeAndLoopConstraint() {
   /* Add three dummy Mobods. */
   data_.mobods.reserve(4);  // Prevent invalidation of the references.
   auto& mobod1 =
-      data_.mobods.emplace_back(MobodIndex(1), BodyIndex(1), JointIndex(1),
+      data_.mobods.emplace_back(MobodIndex(1), LinkOrdinal(1), JointOrdinal(1),
                                 1 /* level */, false /* is_reversed */);
   auto& mobod2 =
-      data_.mobods.emplace_back(MobodIndex(2), BodyIndex(2), JointIndex(2),
+      data_.mobods.emplace_back(MobodIndex(2), LinkOrdinal(2), JointOrdinal(2),
                                 2 /* level */, false /* is_reversed */);
   auto& mobod3 =
-      data_.mobods.emplace_back(MobodIndex(3), BodyIndex(3), JointIndex(3),
+      data_.mobods.emplace_back(MobodIndex(3), LinkOrdinal(3), JointOrdinal(3),
                                 1 /* level */, false /* is_reversed */);
 
   /* Assign depth-first coordinates. */

--- a/multibody/topology/spanning_forest_inlines.h
+++ b/multibody/topology/spanning_forest_inlines.h
@@ -19,13 +19,14 @@ inline auto SpanningForest::mobods(MobodIndex mobod_index) const
   return mobods()[mobod_index];
 }
 
-inline BodyIndex SpanningForest::mobod_to_link(MobodIndex mobod_index) const {
-  return mobods(mobod_index).link();
+inline LinkOrdinal SpanningForest::mobod_to_link_ordinal(
+    MobodIndex mobod_index) const {
+  return mobods(mobod_index).link_ordinal();
 }
 
-inline const std::vector<BodyIndex>& SpanningForest::mobod_to_links(
+inline const std::vector<LinkOrdinal>& SpanningForest::mobod_to_link_ordinals(
     MobodIndex mobod_index) const {
-  return mobods(mobod_index).follower_links();
+  return mobods(mobod_index).follower_link_ordinals();
 }
 
 inline TreeIndex SpanningForest::q_to_tree(int q_index) const {

--- a/multibody/topology/spanning_forest_mobod.cc
+++ b/multibody/topology/spanning_forest_mobod.cc
@@ -9,7 +9,8 @@ namespace multibody {
 namespace internal {
 
 // Constructor for the World mobilized body.
-SpanningForest::Mobod::Mobod(MobodIndex mobod_index, BodyIndex world_link)
+SpanningForest::Mobod::Mobod(MobodIndex mobod_index,
+                             LinkOrdinal world_link_ordinal)
     : level_(0),
       index_(mobod_index),
       q_start_(0),
@@ -18,23 +19,23 @@ SpanningForest::Mobod::Mobod(MobodIndex mobod_index, BodyIndex world_link)
       nv_(0),
       nq_inboard_(0),
       nv_inboard_(0) {
-  DRAKE_DEMAND(mobod_index.is_valid() && world_link.is_valid());
-  DRAKE_DEMAND(world_link == 0 && mobod_index == 0);
-  follower_links_.push_back(world_link);
+  DRAKE_DEMAND(mobod_index.is_valid() && world_link_ordinal.is_valid());
+  DRAKE_DEMAND(world_link_ordinal == 0 && mobod_index == 0);
+  follower_link_ordinals_.push_back(world_link_ordinal);
 }
 
 // Constructor for mobilized bodies other than World.
-SpanningForest::Mobod::Mobod(MobodIndex mobod_index, BodyIndex link_index,
-                             JointIndex joint_index, int level,
+SpanningForest::Mobod::Mobod(MobodIndex mobod_index, LinkOrdinal link_ordinal,
+                             JointOrdinal joint_ordinal, int level,
                              bool is_reversed)
-    : joint_index_(joint_index),
+    : joint_ordinal_(joint_ordinal),
       use_reverse_mobilizer_(is_reversed),
       level_(level),
       index_(mobod_index) {
-  DRAKE_DEMAND(mobod_index.is_valid() && link_index.is_valid() &&
-               joint_index.is_valid());
-  DRAKE_DEMAND(mobod_index != 0 && link_index != 0 && level > 0);
-  follower_links_.push_back(link_index);
+  DRAKE_DEMAND(mobod_index.is_valid() && link_ordinal.is_valid() &&
+               joint_ordinal.is_valid());
+  DRAKE_DEMAND(mobod_index != 0 && link_ordinal != 0 && level > 0);
+  follower_link_ordinals_.push_back(link_ordinal);
 }
 
 void SpanningForest::Mobod::FixupAfterReordering(
@@ -45,8 +46,8 @@ void SpanningForest::Mobod::FixupAfterReordering(
 }
 
 void SpanningForest::Mobod::Swap(Mobod& other) {
-  std::swap(follower_links_, other.follower_links_);
-  std::swap(joint_index_, other.joint_index_);
+  std::swap(follower_link_ordinals_, other.follower_link_ordinals_);
+  std::swap(joint_ordinal_, other.joint_ordinal_);
   std::swap(use_reverse_mobilizer_, other.use_reverse_mobilizer_);
   std::swap(level_, other.level_);
   std::swap(index_, other.index_);
@@ -58,6 +59,7 @@ void SpanningForest::Mobod::Swap(Mobod& other) {
   std::swap(nq_, other.nq_);
   std::swap(v_start_, other.v_start_);
   std::swap(nv_, other.nv_);
+  std::swap(has_quaternion_, other.has_quaternion_);
   std::swap(nq_inboard_, other.nq_inboard_);
   std::swap(nv_inboard_, other.nv_inboard_);
   std::swap(nq_outboard_, other.nq_outboard_);

--- a/multibody/topology/spanning_forest_mobod.h
+++ b/multibody/topology/spanning_forest_mobod.h
@@ -4,6 +4,7 @@
 #error Do not include this file. Use "drake/multibody/topology/forest.h".
 #endif
 
+#include <algorithm>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -22,11 +23,11 @@ class SpanningForest::Mobod {
   /** (Internal use only) This constructor is just for World, the only %Mobod
   with no mobilizer. (Or you can consider it welded to the universe at the
   World origin.) */
-  Mobod(MobodIndex mobod_index, BodyIndex world_link);
+  Mobod(MobodIndex mobod_index, LinkOrdinal world_link_ordinal);
 
   /** (Internal use only) The general constructor for any non-World %Mobod. */
-  Mobod(MobodIndex mobod_index, BodyIndex link_index, JointIndex joint_index,
-        int level, bool is_reversed);
+  Mobod(MobodIndex mobod_index, LinkOrdinal link_ordinal,
+        JointOrdinal joint_ordinal, int level, bool is_reversed);
 
   /** Returns `true` if this %Mobod is the World body, that is, the one with
   MobodIndex 0. Returns `false` for anything else, even if this %Mobod is
@@ -75,27 +76,27 @@ class SpanningForest::Mobod {
   %Mobod's level(). */
   const std::vector<MobodIndex>& outboards() const { return outboard_mobods_; }
 
-  /** Returns the index of the Link mobilized by this %Mobod. If this %Mobod
+  /** Returns the ordinal of the Link mobilized by this %Mobod. If this %Mobod
   models a LinkComposite (collection of welded-together Links), this is the
   "active" Link of that composite, the one whose (non-Weld) Joint connects
   the whole LinkComposite to its inboard %Mobod.
   @see joint() */
-  BodyIndex link() const { return follower_links()[0]; }
+  LinkOrdinal link_ordinal() const { return follower_link_ordinals()[0]; }
 
   /** Returns all the Links that are mobilized by this %Mobod. If this %Mobod
   represents a LinkComposite, the first Link returned is the "active" Link as
   returned by link(). There is always at least one Link. */
-  const std::vector<BodyIndex>& follower_links() const {
-    DRAKE_ASSERT(!follower_links_.empty());
-    return follower_links_;
+  const std::vector<LinkOrdinal>& follower_link_ordinals() const {
+    DRAKE_ASSERT(!follower_link_ordinals_.empty());
+    return follower_link_ordinals_;
   }
 
-  /** Returns the Joint represented by this %Mobod. If this %Mobod represents
-  a LinkComposite (which has internal weld Joints), the Joint returned here
-  is the "active" Joint that connects the Composite's active Link to a Link
-  that follows this %Mobod's inboard %Mobod in the forest. The returned
-  index is invalid if and only if this is the World %Mobod. */
-  JointIndex joint() const { return joint_index_; }
+  /** Returns the ordinal of the Joint represented by this %Mobod. If this
+  %Mobod represents a LinkComposite (which has internal weld Joints), the Joint
+  returned here is the "active" Joint that connects the Composite's active Link
+  to a Link that follows this %Mobod's inboard %Mobod in the forest. The
+  returned ordinal is invalid only if this is the World %Mobod. */
+  JointOrdinal joint_ordinal() const { return joint_ordinal_; }
 
   /** Returns the index of the Tree of which this %Mobod is a member. The
   index is invalid if and only if this is the World %Mobod. */
@@ -119,6 +120,11 @@ class SpanningForest::Mobod {
 
   /** The number of position coordinates q used by this %Mobod's mobilizer. */
   int nq() const { return nq_; }
+
+  /** True if the first four entries in q (beginning at q_start()) for this
+  %Mobod are a quaternion. If so, it is stored in wxyz order -- that is, the
+  scalar followed by the vector part. */
+  bool has_quaternion() const { return has_quaternion_; }
 
   /** Starting offset within the contiguous v vector. */
   int v_start() const { return v_start_; }
@@ -191,11 +197,11 @@ class SpanningForest::Mobod {
 
   // Links represented by this Mobod. The first one is always present and is
   // the active Link if we're mobilizing a LinkComposite.
-  std::vector<BodyIndex> follower_links_;
+  std::vector<LinkOrdinal> follower_link_ordinals_;
 
   // Corresponding Joint (user or modeling joint). If this Mobod represents
   // a LinkComposite, this is the Joint that mobilizes the whole Composite.
-  JointIndex joint_index_;
+  JointOrdinal joint_ordinal_;
 
   // For an already-existing Joint, must we use a reverse mobilizer? If true,
   // we know tree inboard/outboard order is opposite graph parent/child order.
@@ -222,6 +228,7 @@ class SpanningForest::Mobod {
   int nq_{-1};
   int v_start_{-1};  // within the full v vector
   int nv_{-1};
+  bool has_quaternion_{false};
 
   // Positioning within the coordinates of the containing tree. For World there
   // are zero inboard, num_positions and num_velocities outboard.

--- a/multibody/topology/test/link_joint_graph_test.cc
+++ b/multibody/topology/test/link_joint_graph_test.cc
@@ -28,21 +28,24 @@ using std::pair;
 // member functions so that we can test those APIs standalone.
 class LinkJointGraphTester {
  public:
-  static LinkJointGraph::Link MakeLink(BodyIndex index, std::string name,
+  static LinkJointGraph::Link MakeLink(BodyIndex index, LinkOrdinal ordinal,
+                                       std::string name,
                                        ModelInstanceIndex model_instance,
                                        LinkFlags flags) {
-    return LinkJointGraph::Link(index, std::move(name), model_instance, flags);
+    return LinkJointGraph::Link(index, ordinal, std::move(name), model_instance,
+                                flags);
   }
 
-  static LinkJointGraph::Joint MakeJoint(JointIndex index, std::string name,
+  static LinkJointGraph::Joint MakeJoint(JointIndex index, JointOrdinal ordinal,
+                                         std::string name,
                                          ModelInstanceIndex model_instance,
                                          JointTraitsIndex joint_traits_index,
                                          BodyIndex parent_link_index,
                                          BodyIndex child_link_index,
                                          JointFlags flags) {
-    return LinkJointGraph::Joint(index, std::move(name), model_instance,
-                                 joint_traits_index, parent_link_index,
-                                 child_link_index, flags);
+    return LinkJointGraph::Joint(index, ordinal, std::move(name),
+                                 model_instance, joint_traits_index,
+                                 parent_link_index, child_link_index, flags);
   }
 
   static LinkFlags set_link_flags(LinkFlags to_set,
@@ -56,19 +59,20 @@ class LinkJointGraphTester {
   }
 
   static LoopConstraintIndex AddLoopClosingWeldConstraint(
-      BodyIndex primary_link_index, BodyIndex shadow_link_index,
+      LinkOrdinal primary_link_ordinal, LinkOrdinal shadow_link_ordinal,
       LinkJointGraph* graph) {
-    return graph->AddLoopClosingWeldConstraint(primary_link_index,
-                                               shadow_link_index);
+    return graph->AddLoopClosingWeldConstraint(primary_link_ordinal,
+                                               shadow_link_ordinal);
   }
 
-  static std::vector<BodyIndex> static_links(const LinkJointGraph& graph) {
-    return graph.static_links();
-  }
-
-  static std::vector<BodyIndex> non_static_must_be_base_body_links(
+  static std::vector<BodyIndex> static_link_indexes(
       const LinkJointGraph& graph) {
-    return graph.non_static_must_be_base_body_links();
+    return graph.static_link_indexes();
+  }
+
+  static std::vector<BodyIndex> non_static_must_be_base_body_link_indexes(
+      const LinkJointGraph& graph) {
+    return graph.non_static_must_be_base_body_link_indexes();
   }
 };
 
@@ -329,9 +333,9 @@ GTEST_TEST(LinkJointGraph, AddLinkErrors) {
   const BodyIndex link2_index =
       graph.AddLink("link2", ModelInstanceIndex(3),
                     LinkFlags::kTreatAsMassless | LinkFlags::kMustBeBaseBody);
-  const LinkJointGraph::Link& link2 = graph.links(link2_index);
+  const LinkJointGraph::Link& link2 = graph.link_by_index(link2_index);
   EXPECT_TRUE(link2.treat_as_massless() && link2.must_be_base_body());
-  EXPECT_FALSE(link2.is_static() || link2.is_shadow());
+  EXPECT_FALSE(link2.is_static_flag_set() || link2.is_shadow());
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       graph.AddLink("link3", ModelInstanceIndex(3), LinkFlags::kShadow),
@@ -352,17 +356,19 @@ GTEST_TEST(LinkJointGraph, InternalListsAreBuiltCorrectly) {
                     LinkFlags::kStatic | LinkFlags::kMustBeBaseBody);
 
   // Links 1 and 3 are static.
-  EXPECT_EQ(LinkJointGraphTester::static_links(graph),
+  EXPECT_EQ(LinkJointGraphTester::static_link_indexes(graph),
             (std::vector<BodyIndex>{link1_index, link3_index}));
   // But only link 2 should be on the non-static must be base body list.
-  EXPECT_EQ(LinkJointGraphTester::non_static_must_be_base_body_links(graph),
-            std::vector<BodyIndex>{link2_index});
+  EXPECT_EQ(
+      LinkJointGraphTester::non_static_must_be_base_body_link_indexes(graph),
+      std::vector<BodyIndex>{link2_index});
 }
 
 // Check operation of the public members of the Link subclass.
 GTEST_TEST(LinkJoinGraph, LinkAPITest) {
   LinkJointGraph::Link link5 = LinkJointGraphTester::MakeLink(
-      BodyIndex(5), "link5", ModelInstanceIndex(7), LinkFlags::kMustBeBaseBody);
+      BodyIndex(5), LinkOrdinal(0), "link5", ModelInstanceIndex(7),
+      LinkFlags::kMustBeBaseBody);
   EXPECT_EQ(link5.index(), BodyIndex(5));
   EXPECT_EQ(link5.model_instance(), ModelInstanceIndex(7));
   EXPECT_EQ(link5.name(), "link5");
@@ -370,12 +376,12 @@ GTEST_TEST(LinkJoinGraph, LinkAPITest) {
   // Check flags.
   EXPECT_FALSE(link5.is_world());
   EXPECT_FALSE(link5.is_anchored());
-  EXPECT_FALSE(link5.is_static());
+  EXPECT_FALSE(link5.is_static_flag_set());
   EXPECT_FALSE(link5.treat_as_massless());
   EXPECT_FALSE(link5.is_shadow());
   EXPECT_TRUE(link5.must_be_base_body());
   LinkJointGraphTester::set_link_flags(LinkFlags::kStatic, &link5);
-  EXPECT_TRUE(link5.is_static());
+  EXPECT_TRUE(link5.is_static_flag_set());
   EXPECT_TRUE(link5.is_anchored());  // Static links are anchored to World.
   EXPECT_TRUE(link5.must_be_base_body());   // Unchanged.
   EXPECT_FALSE(link5.treat_as_massless());  // Unchanged.
@@ -397,14 +403,14 @@ GTEST_TEST(LinkJointGraph, JointAPITest) {
   const BodyIndex child_index(2);
   const BodyIndex other_body_index(3);  // Not connected by joint3.
   LinkJointGraph::Joint joint3 = LinkJointGraphTester::MakeJoint(
-      JointIndex(3), "joint3", ModelInstanceIndex(9),
+      JointIndex(3), JointOrdinal(0), "joint3", ModelInstanceIndex(9),
       LinkJointGraph::rpy_floating_joint_traits_index(), parent_index,
       child_index, JointFlags::kMustBeModeled);
   EXPECT_EQ(joint3.index(), JointIndex(3));
   EXPECT_EQ(joint3.model_instance(), ModelInstanceIndex(9));
   EXPECT_EQ(joint3.name(), "joint3");
-  EXPECT_EQ(joint3.parent_link(), parent_index);
-  EXPECT_EQ(joint3.child_link(), child_index);
+  EXPECT_EQ(joint3.parent_link_index(), parent_index);
+  EXPECT_EQ(joint3.child_link_index(), child_index);
   EXPECT_FALSE(joint3.is_weld());
   EXPECT_EQ(joint3.traits_index(),
             LinkJointGraph::rpy_floating_joint_traits_index());
@@ -435,7 +441,7 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   EXPECT_EQ(ssize(graph.joint_traits()), 4);  // built-in types plus "revolute"
 
   EXPECT_FALSE(graph.IsJointTypeRegistered("prismatic"));
-  EXPECT_THROW(graph.joint_traits(JointTraitsIndex(99)), std::exception);
+  EXPECT_THROW((void)graph.joint_traits(JointTraitsIndex(99)), std::exception);
 
   // Verify that the revolute joint was correctly registered.
   EXPECT_TRUE(graph.IsJointTypeRegistered("revolute"));
@@ -473,7 +479,7 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   EXPECT_EQ(graph.num_user_joints(), 5);
 
   // Check that the links see their joints.
-  const LinkJointGraph::Link& link4 = graph.links(BodyIndex(4));
+  const LinkJointGraph::Link& link4 = graph.link_by_index(BodyIndex(4));
   EXPECT_EQ(link4.joints(),
             (std::vector<JointIndex>{JointIndex(3), JointIndex(4)}));
   EXPECT_EQ(link4.joints_as_parent(), std::vector<JointIndex>{JointIndex(4)});
@@ -483,11 +489,11 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   // weld constraint, and check that it properly updates the relevant links.
   // (This is a private function normally used only by SpanningForest as it
   // breaks loops; users can't add constraints to the graph.)
-  const LinkJointGraph::Link& link5 = graph.links(BodyIndex(5));
+  const LinkJointGraph::Link& link5 = graph.link_by_index(BodyIndex(5));
   const LoopConstraintIndex constraint0_index =
       LinkJointGraphTester::AddLoopClosingWeldConstraint(
-          link4.index(),  // primary link
-          link5.index(),  // shadow link
+          link4.ordinal(),  // primary link
+          link5.ordinal(),  // shadow link
           &graph);
   EXPECT_EQ(constraint0_index, LoopConstraintIndex(0));
   EXPECT_EQ(ssize(graph.loop_constraints()), 1);
@@ -505,7 +511,8 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
             std::vector<LoopConstraintIndex>{constraint0_index});
 
   // Out of range should throw.
-  EXPECT_THROW(graph.loop_constraints(LoopConstraintIndex(99)), std::exception);
+  EXPECT_THROW((void)graph.loop_constraints(LoopConstraintIndex(99)),
+               std::exception);
 
   // We cannot duplicate the name of a Link or Joint.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -540,11 +547,13 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       graph.AddJoint("another_pin", model_instance, "revolute", BodyIndex(1),
                      BodyIndex(9)),
-      "AddJoint\\(\\): child link index 9 for joint '.*' is out of range.");
+      "AddJoint\\(\\): child link index 9 for joint '.*' refers.*"
+      "non-existent or ephemeral.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       graph.AddJoint("another_pin", model_instance, "revolute", BodyIndex(9),
                      BodyIndex(1)),
-      "AddJoint\\(\\): parent link index 9 for joint '.*' is out of range.");
+      "AddJoint\\(\\): parent link index 9 for joint '.*' refers.*"
+      "non-existent or ephemeral.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       graph.AddJoint("joint_to_self", model_instance, "revolute", BodyIndex(5),
@@ -557,10 +566,10 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   EXPECT_EQ(ssize(graph.joints()), 5);
 
   // Verify we can get bodies/joints.
-  EXPECT_EQ(graph.links(BodyIndex(3)).name(), "link3");
-  EXPECT_EQ(graph.joints(JointIndex(3)).name(), "pin4");
-  EXPECT_THROW(graph.links(BodyIndex(9)), std::exception);
-  EXPECT_THROW(graph.joints(JointIndex(9)), std::exception);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(3)).name(), "link3");
+  EXPECT_EQ(graph.joint_by_index(JointIndex(3)).name(), "pin4");
+  EXPECT_THROW((void)graph.link_by_index(BodyIndex(9)), std::exception);
+  EXPECT_THROW((void)graph.joint_by_index(JointIndex(9)), std::exception);
 
   // Verify we can query if a Link/Joint is in the graph.
   const ModelInstanceIndex kInvalidModelInstance(666);
@@ -601,6 +610,171 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
             joint_10_11_index);
   EXPECT_FALSE(
       graph.MaybeGetJointBetween(world_index(), link10_index).has_value());
+}
+
+GTEST_TEST(LinkJointGraph, RemoveJoint) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+  const ModelInstanceIndex model_instance(5);  // Arbitrary.
+
+  // Start with this graph:
+  // {1} ---> {2} ---> {3} ---> {4}
+  //      j0       j1       j2           indices
+  //       0        1        2           ordinals
+  for (int i = 1; i <= 4; ++i)
+    graph.AddLink("link" + std::to_string(i), model_instance);
+  for (int j = 0; j <= 2; ++j) {
+    graph.AddJoint("joint" + std::to_string(j), model_instance, "revolute",
+                   BodyIndex(j + 1), BodyIndex(j + 2));
+  }
+
+  for (int j = 0; j < 3; ++j)
+    EXPECT_EQ(graph.joint_by_index(JointIndex(j)).ordinal(), j);
+
+  EXPECT_EQ(ssize(graph.joints()), 3);
+  EXPECT_EQ(graph.num_user_joints(), 3);
+  EXPECT_TRUE(graph.has_joint(JointIndex(1)));
+  EXPECT_TRUE(graph.HasJointNamed("joint1", model_instance));
+
+  const LinkJointGraph::Link& link2 = graph.link_by_index(BodyIndex(2));
+  const LinkJointGraph::Link& link3 = graph.link_by_index(BodyIndex(3));
+
+  EXPECT_EQ(ssize(link2.joints()), 2);
+  EXPECT_EQ(ssize(link3.joints()), 2);
+  EXPECT_EQ(link2.joints_as_parent()[0], JointIndex(1));
+  EXPECT_EQ(link3.joints_as_child()[0], JointIndex(1));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.RemoveJoint(JointIndex(99)),
+                              "RemoveJoint..: Joint index 99.*out of range.*");
+
+  // Remove joint 1. Make sure all the bookkeeping is done right, including:
+  //   - Ordinal reassignment for later joints
+  //   - Joint counts are updated
+  //   - The index is no longer valid
+  //   - The name is forgotten
+  //   - Connected parent/child Links forget about the connection
+  graph.RemoveJoint(JointIndex(1));
+  // At this point we should have
+  // {1} ---> {2}      {3} ---> {4}
+  //      j0                j2           indices
+  //       0                 1           ordinals
+  EXPECT_EQ(graph.joint_by_index(JointIndex(0)).ordinal(), 0);
+  EXPECT_EQ(graph.joint_by_index(JointIndex(2)).ordinal(), 1);
+  EXPECT_EQ(ssize(graph.joints()), 2);
+  EXPECT_EQ(graph.num_user_joints(), 2);
+  EXPECT_FALSE(graph.has_joint(JointIndex(1)));
+  EXPECT_FALSE(graph.HasJointNamed("joint1", model_instance));
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.joint_by_index(JointIndex(1)),
+                              "joint_by_index.*joint.*1.*was removed.*");
+  EXPECT_EQ(ssize(link2.joints()), 1);
+  EXPECT_EQ(ssize(link3.joints()), 1);
+  EXPECT_TRUE(link2.joints_as_parent().empty());
+  EXPECT_EQ(link2.joints_as_child()[0], JointIndex(0));
+  EXPECT_TRUE(link3.joints_as_child().empty());
+  EXPECT_EQ(link3.joints_as_parent()[0], JointIndex(2));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.RemoveJoint(JointIndex(1)),
+                              "RemoveJoint..:.*index 1.*already removed.*");
+
+  graph.BuildForest();  // Adds 2 ephemeral joints: index 3,4 ordinal 2,3.
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(3)));
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(4)));
+  EXPECT_EQ(ssize(graph.joints()), 4);
+  EXPECT_EQ(graph.num_user_joints(), 2);
+
+  // Adding a new joint should wipe the ephemeral elements, whose indices
+  // are then available for reassignment (unlike user element indices).
+  const JointIndex replaced_index = graph.AddJoint(
+      "joint3", model_instance, "revolute", BodyIndex(2), BodyIndex(3));
+  EXPECT_EQ(replaced_index, JointIndex(3));
+
+  // At this point we should have
+  // {1} ---> {2} ---> {3} ---> {4}
+  //      j0       j3       j2           indices
+  //       0        2        1           ordinals
+  EXPECT_EQ(graph.joint_by_index(JointIndex(0)).ordinal(), 0);
+  EXPECT_EQ(graph.joint_by_index(JointIndex(2)).ordinal(), 1);
+  EXPECT_EQ(graph.joint_by_index(JointIndex(3)).ordinal(), 2);
+
+  EXPECT_EQ(ssize(graph.joints()), 3);
+  EXPECT_EQ(graph.num_user_joints(), 3);
+  EXPECT_TRUE(graph.has_joint(JointIndex(3)));
+  EXPECT_TRUE(graph.HasJointNamed("joint3", model_instance));
+
+  EXPECT_EQ(ssize(link2.joints()), 2);
+  EXPECT_EQ(ssize(link3.joints()), 2);
+  EXPECT_EQ(link2.joints_as_parent()[0], JointIndex(3));
+  EXPECT_EQ(link3.joints_as_child()[0], JointIndex(3));
+
+  // Now we'll build the forest and make sure
+  //  - RemoveJoint won't operate on ephemeral joints
+  //  - A failed RemoveJoint leaves the forest alone
+  //  - A successful RemoveJoint invalidates the forest
+  graph.BuildForest();
+  EXPECT_TRUE(graph.forest_is_valid());
+  EXPECT_EQ(ssize(graph.joints()), 4);  // 1 ephemeral joint: index 4 ordinal 3.
+  EXPECT_EQ(graph.num_user_joints(), 3);
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(4)));
+  EXPECT_EQ(graph.joint_by_index(JointIndex(4)).ordinal(), 3);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.RemoveJoint(JointIndex(4)),
+      "RemoveJoint..: Joint link1.*index 4.*ephemeral.*");
+  EXPECT_TRUE(graph.forest_is_valid());
+  EXPECT_TRUE(graph.has_joint(JointIndex(4)));
+  EXPECT_TRUE(graph.HasJointNamed("link1", model_instance));
+
+  graph.RemoveJoint(JointIndex(0));
+  // Now we have:
+  // {1}      {2} ---> {3} ---> {4}
+  //               j3       j2           indices
+  //                1        0           ordinals
+
+  EXPECT_FALSE(graph.forest_is_valid());
+  EXPECT_EQ(ssize(graph.joints()), 2);
+  EXPECT_EQ(graph.num_user_joints(), 2);
+  EXPECT_FALSE(graph.has_joint(JointIndex(4)));
+  EXPECT_FALSE(graph.HasJointNamed("link1", model_instance));
+  EXPECT_EQ(graph.joint_by_index(JointIndex(2)).ordinal(), 0);
+  EXPECT_EQ(graph.joint_by_index(JointIndex(3)).ordinal(), 1);
+  EXPECT_EQ(ssize(link2.joints()), 1);
+  EXPECT_EQ(ssize(link3.joints()), 2);
+  EXPECT_EQ(link2.joints_as_parent()[0], JointIndex(3));
+
+  graph.BuildForest();  // Adds 2 ephemeral joints: indices 4,5 ordinals 2,3.
+  EXPECT_EQ(ssize(graph.joints()), 4);
+  EXPECT_EQ(graph.num_user_joints(), 2);
+  for (JointIndex i(2); i <= 5; ++i) EXPECT_TRUE(graph.has_joint(i));
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(4)));
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(5)));
+  EXPECT_EQ(graph.joint_by_index(JointIndex(4)).ordinal(), 2);
+  EXPECT_EQ(graph.joint_by_index(JointIndex(5)).ordinal(), 3);
+
+  // Test the case of removing the highest-index user joint (3 in this case),
+  // then build the forest, then make sure that no ephemeral joint gets that
+  // last index. (There was a bug in this case before.)
+  graph.RemoveJoint(JointIndex(3));
+  // Now we have:
+  // {1}      {2}      {3} ---> {4}
+  //                        j2           indices
+  //                         0           ordinals
+  graph.BuildForest();  // Should add 3 ephemeral joints, indices 4,5,6.
+  EXPECT_EQ(ssize(graph.joints()), 4);
+  EXPECT_EQ(graph.num_user_joints(), 1);
+  EXPECT_FALSE(graph.has_joint(JointIndex(3)));
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(4)));
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(5)));
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(6)));
+
+  // Make sure an Invalidate/Rebuild gives us the same Forest.
+  graph.InvalidateForest();  // Just being explicit; BuildForest() calls it too.
+  graph.BuildForest();       // Indices for ephemerals should get reused.
+  EXPECT_EQ(ssize(graph.joints()), 4);
+  EXPECT_EQ(graph.num_user_joints(), 1);
+  EXPECT_FALSE(graph.has_joint(JointIndex(3)));
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(4)));
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(5)));
+  EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(6)));
 }
 
 }  // namespace

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -48,6 +48,8 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_EQ(graph.world_link().model_instance(), world_model_instance());
   const BodyIndex world_link_index = graph.world_link().index();
   EXPECT_EQ(world_link_index, BodyIndex(0));
+  const LinkOrdinal world_link_ordinal = graph.world_link().ordinal();
+  EXPECT_EQ(world_link_ordinal, LinkOrdinal(0));
 
   // Now build a forest representing the World-only graph.
   EXPECT_TRUE(graph.BuildForest());
@@ -70,11 +72,14 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_EQ(forest.height(), 1);
   EXPECT_EQ(ssize(forest.welded_mobods()), 1);
   EXPECT_EQ(forest.welded_mobods()[0][0], world_mobod_index);
-  EXPECT_EQ(forest.mobod_to_link(world_mobod_index), world_link_index);
-  EXPECT_EQ(ssize(forest.mobod_to_links(world_mobod_index)), 1);
-  EXPECT_EQ(forest.mobod_to_links(world_mobod_index)[0], world_link_index);
+  EXPECT_EQ(forest.mobod_to_link_ordinal(world_mobod_index),
+            world_link_ordinal);
+  EXPECT_EQ(ssize(forest.mobod_to_link_ordinals(world_mobod_index)), 1);
+  EXPECT_EQ(forest.mobod_to_link_ordinals(world_mobod_index)[0],
+            world_link_ordinal);
   EXPECT_EQ(forest.num_positions(), 0);
   EXPECT_EQ(forest.num_velocities(), 0);
+  EXPECT_TRUE(forest.quaternion_starts().empty());
 
   // Exercise the Mobod API to check the World Mobod for reasonableness.
   EXPECT_TRUE(world.is_world());
@@ -85,10 +90,10 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_TRUE(world.is_weld());       // Defined as having no inboard dofs.
   EXPECT_FALSE(world.inboard().is_valid());
   EXPECT_TRUE(world.outboards().empty());
-  EXPECT_EQ(world.link(), world_link_index);
-  EXPECT_EQ(ssize(world.follower_links()), 1);
-  EXPECT_EQ(world.follower_links()[0], world_link_index);
-  EXPECT_FALSE(world.joint().is_valid());
+  EXPECT_EQ(world.link_ordinal(), world_link_ordinal);
+  EXPECT_EQ(ssize(world.follower_link_ordinals()), 1);
+  EXPECT_EQ(world.follower_link_ordinals()[0], world_link_ordinal);
+  EXPECT_FALSE(world.joint_ordinal().is_valid());
   EXPECT_FALSE(world.tree().is_valid());
   EXPECT_EQ(world.welded_mobods_group(), WeldedMobodsIndex(0));
   EXPECT_EQ(world.level(), 0);
@@ -100,6 +105,7 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_EQ(world.nv_inboard(), 0);
   EXPECT_EQ(world.nq_outboard(), 0);
   EXPECT_EQ(world.nv_outboard(), 0);
+  EXPECT_FALSE(world.has_quaternion());
   EXPECT_EQ(world.num_subtree_mobods(), 1);
   EXPECT_EQ(world.subtree_velocities(), (std::pair{0, 0}));
   EXPECT_EQ(world.outboard_velocities(), (std::pair{0, 0}));
@@ -221,9 +227,21 @@ LinkJointGraph MakeMultiBranchGraph(ModelInstanceIndex left,
       {12, 3}, {3, 8}, {3, 7}, {8, 11}, {11, 13}, {11, 14}, {14, 15}};  // right
   for (int i = 0; i < ssize(joints); ++i) {
     const auto joint = joints[i];
-    graph.AddJoint("joint_" + std::to_string(i), link_to_instance[joint.second],
+    graph.AddJoint("joint" + std::to_string(i), link_to_instance[joint.second],
                    "revolute", BodyIndex(joint.first), BodyIndex(joint.second));
   }
+
+  // Remove and re-add a joint to mess up the numbering. It will now have
+  // JointIndex 12, and 7 should be unused.
+  EXPECT_TRUE(graph.has_joint(JointIndex(7)));
+  EXPECT_TRUE(graph.HasJointNamed("joint7", link_to_instance[7]));
+  graph.RemoveJoint(JointIndex(7));  // The joint between 3 & 8.
+  graph.AddJoint("joint7replaced", link_to_instance[7], "revolute",
+                 BodyIndex(3), BodyIndex(7));
+  EXPECT_FALSE(graph.has_joint(JointIndex(7)));
+  EXPECT_FALSE(graph.HasJointNamed("joint7", link_to_instance[7]));
+  EXPECT_TRUE(graph.has_joint(JointIndex(12)));
+  EXPECT_TRUE(graph.HasJointNamed("joint7replaced", link_to_instance[7]));
 
   // Make sure we got the graph we're expecting. Before building the forest
   // the only links and joints are the user-added ones.
@@ -275,6 +293,14 @@ GTEST_TEST(SpanningForest, MultipleBranchesDefaultOptions) {
   EXPECT_EQ(forest.num_positions(), 33);   // 12 revolute, 3 x 7 quat floating
   EXPECT_EQ(forest.num_velocities(), 30);  // 12 revolute, 3 x 6 floating
 
+  // Verify that we're tracking quaternions properly.
+  EXPECT_EQ(ssize(forest.quaternion_starts()), 3);  // One per floating joint.
+  EXPECT_EQ(forest.quaternion_starts(), (std::vector{0, 12, 26}));
+  EXPECT_FALSE(forest.mobods(MobodIndex(10)).has_quaternion());  // Arbitrary.
+  EXPECT_TRUE(forest.mobods(MobodIndex(1)).has_quaternion());
+  EXPECT_TRUE(forest.mobods(MobodIndex(7)).has_quaternion());
+  EXPECT_TRUE(forest.mobods(MobodIndex(15)).has_quaternion());
+
   // Check Mobod->Link and Link->Mobod mappings.
   const std::vector<pair<int, int>> mobod_link_map{
       {0, 0}, {1, 1}, {2, 4},   {3, 5},   {4, 6},   {5, 9},   {6, 10}, {7, 12},
@@ -282,12 +308,13 @@ GTEST_TEST(SpanningForest, MultipleBranchesDefaultOptions) {
   for (auto mobod_link : mobod_link_map) {
     EXPECT_EQ(graph.link_to_mobod(BodyIndex(mobod_link.second)),
               MobodIndex(mobod_link.first));
-    EXPECT_EQ(forest.mobod_to_link(MobodIndex(mobod_link.first)),
-              BodyIndex(mobod_link.second));
+    EXPECT_EQ(forest.mobod_to_link_ordinal(MobodIndex(mobod_link.first)),
+              LinkOrdinal(mobod_link.second));
     // Each Mobod has only a single Link that follows it.
-    EXPECT_EQ(ssize(forest.mobod_to_links(MobodIndex(mobod_link.first))), 1);
-    EXPECT_EQ(forest.mobod_to_links(MobodIndex(mobod_link.first))[0],
-              BodyIndex(mobod_link.second));
+    EXPECT_EQ(
+        ssize(forest.mobod_to_link_ordinals(MobodIndex(mobod_link.first))), 1);
+    EXPECT_EQ(forest.mobod_to_link_ordinals(MobodIndex(mobod_link.first))[0],
+              LinkOrdinal(mobod_link.second));
   }
   EXPECT_EQ(forest.height(), 7);
 
@@ -413,9 +440,9 @@ GTEST_TEST(SpanningForest, MultipleBranchesBaseJointOptions) {
   EXPECT_TRUE(tree1.front().is_anchored());
   EXPECT_FALSE(tree2.front().is_anchored());
 
-  EXPECT_FALSE(graph.links(tree0.front().link()).is_anchored());
-  EXPECT_TRUE(graph.links(tree1.front().link()).is_anchored());
-  EXPECT_FALSE(graph.links(tree2.front().link()).is_anchored());
+  EXPECT_FALSE(graph.links(tree0.front().link_ordinal()).is_anchored());
+  EXPECT_TRUE(graph.links(tree1.front().link_ordinal()).is_anchored());
+  EXPECT_FALSE(graph.links(tree2.front().link_ordinal()).is_anchored());
 
   // There is only the World composite, but now tree1's base link is included.
   EXPECT_EQ(ssize(graph.link_composites()), 1);  // just World
@@ -423,7 +450,7 @@ GTEST_TEST(SpanningForest, MultipleBranchesBaseJointOptions) {
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0))[0],
             graph.world_link().index());
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0))[1],
-            tree1.front().link());
+            graph.links(tree1.front().link_ordinal()).index());
 
   // Similarly, there is only one WeldedMobods group, containing just World
   // and tree1's base
@@ -624,7 +651,7 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   // joint. Verify that ChangeJointType() refuses to operate on an ephemeral
   // (added) joint.
   const JointIndex static8_joint_index =
-      graph.links(static8_index).inboard_joint_index();
+      graph.link_by_index(static8_index).inboard_joint_index();
   DRAKE_EXPECT_THROWS_MESSAGE(
       graph.ChangeJointType(static8_joint_index, "revolute"),
       "ChangeJointType.*can't change the type.*ephemeral.*static8.* only "
@@ -636,9 +663,9 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_EQ(ssize(graph.joints()), 11);
   const JointIndex base11_joint_index(9);  // See above picture.
   const JointIndex free9_joint_index(10);
-  EXPECT_EQ(graph.joints(base11_joint_index).traits_index(),
+  EXPECT_EQ(graph.joint_by_index(base11_joint_index).traits_index(),
             LinkJointGraph::quaternion_floating_joint_traits_index());
-  EXPECT_EQ(graph.joints(free9_joint_index).traits_index(),
+  EXPECT_EQ(graph.joint_by_index(free9_joint_index).traits_index(),
             LinkJointGraph::quaternion_floating_joint_traits_index());
 
   const std::vector<BodyIndex> link_composites0{BodyIndex(0), BodyIndex(7),
@@ -666,8 +693,8 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
 
   // Counts for generic middle Mobod.
   const SpanningForest::Mobod& mobod_for_link3 =
-      forest.mobods(graph.links(BodyIndex(3)).mobod_index());
-  EXPECT_EQ(mobod_for_link3.link(), BodyIndex(3));
+      forest.mobods(graph.link_by_index(BodyIndex(3)).mobod_index());
+  EXPECT_EQ(graph.links(mobod_for_link3.link_ordinal()).index(), BodyIndex(3));
   EXPECT_EQ(mobod_for_link3.q_start(), 2);
   EXPECT_EQ(mobod_for_link3.v_start(), 2);
   EXPECT_EQ(mobod_for_link3.nq(), 1);
@@ -680,7 +707,7 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
 
   // Counts for a Mobod with nq != nv.
   const SpanningForest::Mobod& mobod_for_base11 =
-      forest.mobods(graph.links(BodyIndex(11)).mobod_index());
+      forest.mobods(graph.link_by_index(BodyIndex(11)).mobod_index());
   EXPECT_EQ(mobod_for_base11.q_start(), 5);
   EXPECT_EQ(mobod_for_base11.v_start(), 5);
   EXPECT_EQ(mobod_for_base11.nq(), 7);
@@ -842,13 +869,13 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
   // Check that the shadows are connected up properly. See the test comment
   // above for why we expect these particular links to get split.
   for (BodyIndex link(14); link <= 16; ++link)
-    EXPECT_TRUE(graph.links(link).is_shadow());
-  EXPECT_EQ(graph.links(BodyIndex(14)).primary_link(), 11);
-  EXPECT_EQ(graph.links(BodyIndex(11)).num_shadows(), 1);
-  EXPECT_EQ(graph.links(BodyIndex(15)).primary_link(), 1);
-  EXPECT_EQ(graph.links(BodyIndex(1)).num_shadows(), 1);
-  EXPECT_EQ(graph.links(BodyIndex(16)).primary_link(), 8);
-  EXPECT_EQ(graph.links(BodyIndex(8)).num_shadows(), 1);
+    EXPECT_TRUE(graph.link_by_index(link).is_shadow());
+  EXPECT_EQ(graph.link_by_index(BodyIndex(14)).primary_link(), 11);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(11)).num_shadows(), 1);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(15)).primary_link(), 1);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(1)).num_shadows(), 1);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(16)).primary_link(), 8);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(8)).num_shadows(), 1);
 
   // Check that we built the LinkComposites properly (see above).
   EXPECT_EQ(ssize(graph.link_composites()), 3);
@@ -876,9 +903,11 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
   const std::array mobod2joint{-1, 12, 11, 9, 8, 10, 13, 14, 3,
                                0,  7,  4,  6, 5, 2,  1,  15};
   for (const SpanningForest::Mobod& mobod : forest.mobods()) {
-    EXPECT_EQ(mobod.link(), BodyIndex(mobod2link[mobod.index()]));
+    EXPECT_EQ(graph.links(mobod.link_ordinal()).index(),
+              BodyIndex(mobod2link[mobod.index()]));
     if (mobod.is_world()) continue;  // No joint for World mobod.
-    EXPECT_EQ(mobod.joint(), JointIndex(mobod2joint[mobod.index()]));
+    EXPECT_EQ(graph.joints(mobod.joint_ordinal()).index(),
+              JointIndex(mobod2joint[mobod.index()]));
   }
 
   // Should get the same information from the graph.
@@ -1022,16 +1051,31 @@ GTEST_TEST(SpanningForest, MasslessLinksChangeLoopBreaking) {
   EXPECT_TRUE(graph.BuildForest());  // Using default options.
   const SpanningForest& forest = graph.forest();
 
+  EXPECT_EQ(ssize(graph.links()), 8);  // Added a shadow.
+  EXPECT_EQ(ssize(graph.joints()), 7);
+  EXPECT_TRUE(graph.link_by_index(BodyIndex(7)).is_shadow());
+  EXPECT_EQ(graph.link_by_index(BodyIndex(7)).primary_link(), BodyIndex(4));
+
   EXPECT_EQ(ssize(forest.trees()), 2);
   EXPECT_EQ(forest.trees()[0].num_mobods(), 4);
   EXPECT_EQ(forest.trees()[1].num_mobods(), 3);
+  EXPECT_EQ(graph.links(forest.mobods(MobodIndex(4)).link_ordinal()).index(),
+            BodyIndex(7));
 
+  // Changing just 3 to massless results in the same forest.
   graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kTreatAsMassless);
   EXPECT_TRUE(graph.BuildForest());
 
+  EXPECT_EQ(ssize(graph.links()), 8);
+  EXPECT_EQ(ssize(graph.joints()), 7);
+  EXPECT_TRUE(graph.link_by_index(BodyIndex(7)).is_shadow());
+  EXPECT_EQ(graph.link_by_index(BodyIndex(7)).primary_link(), BodyIndex(4));
+
   EXPECT_EQ(ssize(forest.trees()), 2);
   EXPECT_EQ(forest.trees()[0].num_mobods(), 4);
   EXPECT_EQ(forest.trees()[1].num_mobods(), 3);
+  EXPECT_EQ(graph.links(forest.mobods(MobodIndex(4)).link_ordinal()).index(),
+            BodyIndex(7));
 
   // TODO(sherm1) With both 3 and 4 massless and massless handling stubbed,
   //  we'll end up with a no-dynamics model. Should not happen once this gets
@@ -1107,7 +1151,7 @@ GTEST_TEST(SpanningForest, MasslessBodiesShareSplitLink) {
   EXPECT_EQ(graph.num_user_links(), 4);
   EXPECT_EQ(ssize(graph.loop_constraints()), 1);
 
-  const auto& shadow_link = graph.links(BodyIndex(4));
+  const auto& shadow_link = graph.link_by_index(BodyIndex(4));
   EXPECT_TRUE(shadow_link.is_shadow());
   EXPECT_EQ(shadow_link.primary_link(), BodyIndex(3));
   EXPECT_EQ(shadow_link.mobod_index(), MobodIndex(4));
@@ -1117,9 +1161,9 @@ GTEST_TEST(SpanningForest, MasslessBodiesShareSplitLink) {
   EXPECT_EQ(shadow_link.joints_as_child()[0], JointIndex(3));
   EXPECT_EQ(shadow_link.joints()[0], JointIndex(3));
 
-  EXPECT_EQ(graph.links(BodyIndex(3)).num_shadows(), 1);
-  EXPECT_EQ(graph.links(BodyIndex(2)).num_shadows(), 0);
-  EXPECT_EQ(graph.links(BodyIndex(4)).num_shadows(), 0);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(3)).num_shadows(), 1);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(2)).num_shadows(), 0);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(4)).num_shadows(), 0);
 
   EXPECT_EQ(ssize(forest.mobods()), 5);
   EXPECT_EQ(ssize(forest.trees()), 2);
@@ -1172,7 +1216,6 @@ Notes:
 GTEST_TEST(SpanningForest, DoubleLoop) {
   LinkJointGraph graph;
   graph.RegisterJointType("revolute", 1, 1);
-  graph.RegisterJointType("prismatic", 1, 1);
   const ModelInstanceIndex model_instance(19);
 
   for (int i = 1; i <= 7; ++i)
@@ -1181,7 +1224,7 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
   const std::vector<std::pair<int, int>> joints{{1, 2}, {1, 4}, {1, 3}, {2, 5},
                                                 {4, 7}, {3, 6}, {5, 6}, {7, 6}};
   for (int i = 0; i < 8; ++i) {
-    graph.AddJoint("joint_" + std::to_string(i), model_instance, "revolute",
+    graph.AddJoint("joint" + std::to_string(i), model_instance, "revolute",
                    BodyIndex(joints[i].first), BodyIndex(joints[i].second));
   }
 
@@ -1198,9 +1241,9 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
   EXPECT_EQ(graph.num_user_links(), 8);
   EXPECT_EQ(graph.num_user_joints(), 8);
 
-  const LinkJointGraph::Link& primary_link = graph.links(BodyIndex(6));
-  const LinkJointGraph::Link& shadow_link_1 = graph.links(BodyIndex(8));
-  const LinkJointGraph::Link& shadow_link_2 = graph.links(BodyIndex(9));
+  const LinkJointGraph::Link& primary_link = graph.link_by_index(BodyIndex(6));
+  const LinkJointGraph::Link& shadow_link_1 = graph.link_by_index(BodyIndex(8));
+  const LinkJointGraph::Link& shadow_link_2 = graph.link_by_index(BodyIndex(9));
 
   EXPECT_EQ(primary_link.name(), "link6");
   EXPECT_EQ(shadow_link_1.name(), "link6$1");
@@ -1210,8 +1253,8 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
   EXPECT_TRUE(shadow_link_1.is_shadow());
   EXPECT_TRUE(shadow_link_2.is_shadow());
 
-  EXPECT_EQ(graph.links(BodyIndex(5)).num_shadows(), 0);
-  EXPECT_EQ(graph.links(BodyIndex(7)).num_shadows(), 0);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(5)).num_shadows(), 0);
+  EXPECT_EQ(graph.link_by_index(BodyIndex(7)).num_shadows(), 0);
 
   EXPECT_EQ(ssize(forest.mobods()), 10);
   EXPECT_EQ(ssize(forest.trees()), 1);
@@ -1225,9 +1268,11 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
   const std::array mobod2link{0, 1, 2, 5, 8, 4, 7, 9, 3, 6};
   const std::array mobod2joint{-1, 8, 0, 3, 6, 1, 4, 7, 2, 5};
   for (const SpanningForest::Mobod& mobod : forest.mobods()) {
-    EXPECT_EQ(mobod.link(), BodyIndex(mobod2link[mobod.index()]));
+    EXPECT_EQ(graph.links(mobod.link_ordinal()).index(),
+              BodyIndex(mobod2link[mobod.index()]));
     if (mobod.is_world()) continue;  // No joint for World mobod.
-    EXPECT_EQ(mobod.joint(), JointIndex(mobod2joint[mobod.index()]));
+    EXPECT_EQ(graph.joints(mobod.joint_ordinal()).index(),
+              JointIndex(mobod2joint[mobod.index()]));
   }
 
   const LinkJointGraph::LoopConstraint& loop0 =
@@ -1274,11 +1319,11 @@ GTEST_TEST(SpanningForest, WorldCompositeComesFirst) {
   graph.AddLink("link3", model_instance);
   graph.AddLink("link4", model_instance);
 
-  const auto& world = graph.links(BodyIndex(0));
-  const auto& massless_link = graph.links(BodyIndex(1));
-  const auto& link2 = graph.links(BodyIndex(2));
-  const auto& link3 = graph.links(BodyIndex(3));
-  const auto& link4 = graph.links(BodyIndex(4));
+  const auto& world = graph.link_by_index(BodyIndex(0));
+  const auto& massless_link = graph.link_by_index(BodyIndex(1));
+  const auto& link2 = graph.link_by_index(BodyIndex(2));
+  const auto& link3 = graph.link_by_index(BodyIndex(3));
+  const auto& link4 = graph.link_by_index(BodyIndex(4));
 
   graph.AddJoint("joint0", model_instance, "revolute", world.index(),
                  massless_link.index());
@@ -1377,7 +1422,7 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
 
   // See right-hand graph above. We're expecting to split link 3 since that
   // will produce equal-length branches.
-  const LinkJointGraph::Link& primary_link = graph.links(BodyIndex(3));
+  const LinkJointGraph::Link& primary_link = graph.link_by_index(BodyIndex(3));
   EXPECT_FALSE(primary_link.is_shadow());
   EXPECT_EQ(primary_link.num_shadows(), 1);
   EXPECT_EQ(primary_link.mobod_index(), MobodIndex(2));
@@ -1390,7 +1435,7 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
   EXPECT_EQ(primary_link.joints_as_child(), (std::vector{JointIndex(2)}));
   EXPECT_EQ(primary_link.joints_as_parent(), (std::vector{JointIndex(3)}));
 
-  const LinkJointGraph::Link& shadow_link = graph.links(BodyIndex(4));
+  const LinkJointGraph::Link& shadow_link = graph.link_by_index(BodyIndex(4));
   EXPECT_TRUE(shadow_link.is_shadow());
   // Shadow 1 of link 3 should be "link3$1", but that name conflicts with a
   // nutty user name so we have to disambiguate with underscores.
@@ -1425,8 +1470,10 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
   // Now make link3 massless, rebuild, and check a few things.
   graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kTreatAsMassless);
   graph.BuildForest();
-  const LinkJointGraph::Link& new_primary_link = graph.links(BodyIndex(2));
-  const LinkJointGraph::Link& new_shadow_link = graph.links(BodyIndex(4));
+  const LinkJointGraph::Link& new_primary_link =
+      graph.link_by_index(BodyIndex(2));
+  const LinkJointGraph::Link& new_shadow_link =
+      graph.link_by_index(BodyIndex(4));
 
   EXPECT_EQ(ssize(forest.mobods()), 5);
   EXPECT_EQ(ssize(forest.trees()), 2);


### PR DESCRIPTION
This is the sixth installment in the PR train for #20225, following #21349.

MultibodyPlant gained the ability to remove joints and supports that in the old multibody graph. This PR updates the new multibody topology code to match, so that #20225 still works with MbP using the new topology.

What's here:
- Distinguish index from ordinal for links and joints. Wherever possible the forest-building code is modified to work with ordinals rather than indices so that performance is unchanged.
- APIs for use by RemoveJoint() and related
- Some improvements to variable names for clarity
- Mark some APIs [[nodiscard]]
- Bonus: remembers where the quaternions are in the state
- Unit tests for new stuff

What's not here:
- Special handling of massless bodies to avoid terminal massless bodies
- Combining LinkComposites onto a single Mobod
- Some standalone graph-walking algorithms needed by MbP
- RemoveLink()
- Modifications to MbP to use this stuff

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21695)
<!-- Reviewable:end -->
