### PR TITLE
[tools] Switch to bazel's deps vs implementation_deps semantics

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -287,8 +287,7 @@ drake_cc_library(
     hdrs = ["find_cache.h"],
     internal = True,
     visibility = ["//:__subpackages__"],
-    interface_deps = [],
-    deps = [
+    implementation_deps = [
         ":essential",
     ],
 )
@@ -297,8 +296,7 @@ drake_cc_library(
     name = "find_runfiles",
     srcs = ["find_runfiles.cc"],
     hdrs = ["find_runfiles.h"],
-    interface_deps = [],
-    deps = [
+    implementation_deps = [
         ":essential",
         "@bazel_tools//tools/cpp/runfiles",
     ],
@@ -322,10 +320,10 @@ drake_cc_library(
         "//tools/cc_toolchain:linux": ["-ldl"],
         "//conditions:default": [],
     }),
-    interface_deps = [
+    deps = [
         ":essential",
     ],
-    deps = [
+    implementation_deps = [
         ":drake_marker_shared_library",
         ":find_runfiles",
     ],
@@ -339,8 +337,7 @@ drake_cc_library(
         DRAKE_RESOURCE_SENTINEL,
     ],
     visibility = ["//tools/install/libdrake:__pkg__"],
-    interface_deps = [],
-    deps = [
+    implementation_deps = [
         ":find_resource",
     ],
 )
@@ -442,10 +439,10 @@ drake_cc_library(
     hdrs = [
         "nice_type_name.h",
     ],
-    interface_deps = [
+    deps = [
         ":essential",
     ],
-    deps = [
+    implementation_deps = [
         ":nice_type_name_override_header",
     ],
 )
@@ -479,12 +476,12 @@ drake_cc_library(
     name = "random",
     srcs = ["random.cc"],
     hdrs = ["random.h"],
-    interface_deps = [
+    deps = [
         ":copyable_unique_ptr",
         ":essential",
         ":extract_double",
     ],
-    deps = [
+    implementation_deps = [
         ":autodiff",
     ],
 )
@@ -503,10 +500,10 @@ drake_cc_library(
     name = "sha256",
     srcs = ["sha256.cc"],
     hdrs = ["sha256.h"],
-    interface_deps = [
+    deps = [
         ":essential",
     ],
-    deps = [
+    implementation_deps = [
         "@picosha2_internal//:picosha2",
     ],
 )
@@ -524,10 +521,9 @@ drake_cc_library(
     name = "temp_directory",
     srcs = ["temp_directory.cc"],
     hdrs = ["temp_directory.h"],
-    interface_deps = [
+    deps = [
         ":essential",
     ],
-    deps = [],
 )
 
 # This is a Drake-internal utility for use only as a direct dependency

--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -58,8 +58,7 @@ drake_cc_library(
     srcs = ["rpc_pipe_temp_directory.cc"],
     hdrs = ["rpc_pipe_temp_directory.h"],
     visibility = ["//visibility:private"],
-    interface_deps = [],
-    deps = [
+    implementation_deps = [
         "//common:essential",
     ],
 )

--- a/common/symbolic/BUILD.bazel
+++ b/common/symbolic/BUILD.bazel
@@ -181,10 +181,10 @@ drake_cc_library(
         "monomial.h",
         "polynomial.h",
     ],
-    interface_deps = [
+    deps = [
         ":expression",
     ],
-    deps = [
+    implementation_deps = [
         "//math:quadratic_form",
     ],
 )
@@ -276,11 +276,11 @@ drake_cc_library(
     name = "replace_bilinear_terms",
     srcs = ["replace_bilinear_terms.cc"],
     hdrs = ["replace_bilinear_terms.h"],
-    interface_deps = [
+    deps = [
         "//common:essential",
         "//common/symbolic:expression",
     ],
-    deps = [
+    implementation_deps = [
         "//common/symbolic:polynomial",
     ],
 )

--- a/common/symbolic/expression/BUILD.bazel
+++ b/common/symbolic/expression/BUILD.bazel
@@ -45,14 +45,14 @@ drake_cc_library(
         "variable.h",
         "variables.h",
     ],
-    interface_deps = [
+    deps = [
         "//common:drake_bool",
         "//common:essential",
         "//common:hash",
         "//common:random",
         "//common:reset_after_move",
     ],
-    deps = [
+    implementation_deps = [
         "@abseil_cpp_internal//absl/container:flat_hash_set",
         "@abseil_cpp_internal//absl/container:inlined_vector",
         "@fmt",

--- a/examples/hardware_sim/BUILD.bazel
+++ b/examples/hardware_sim/BUILD.bazel
@@ -30,19 +30,19 @@ drake_cc_library(
     name = "scenario",
     srcs = ["scenario.cc"],
     hdrs = ["scenario.h"],
-    interface_deps = [
+    deps = [
         "//common:name_value",
         "//lcm:drake_lcm_params",
         "//manipulation/kuka_iiwa:iiwa_driver",
         "//manipulation/schunk_wsg:schunk_wsg_driver",
         "//manipulation/util:zero_force_driver",
-        "//multibody/plant:multibody_plant_config",
         "//multibody/parsing:model_directives",
+        "//multibody/plant:multibody_plant_config",
         "//systems/analysis:simulator_config",
         "//systems/sensors:camera_config",
         "//visualization:visualization_config",
     ],
-    deps = [
+    implementation_deps = [
         "//common/yaml",
     ],
 )

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -62,7 +62,11 @@ drake_cc_library(
     hdrs = [
         "proximity_engine.h",
     ],
-    interface_deps = [
+    deps = [
+        ":geometry_ids",
+        ":geometry_roles",
+        ":internal_geometry",
+        ":shape_specification",
         "//common:default_scalars",
         "//common:sorted_pair",
         "//geometry/proximity:collision_filter",
@@ -71,12 +75,8 @@ drake_cc_library(
         "//geometry/proximity:make_mesh_from_vtk",
         "//geometry/query_results",
         "//math",
-        ":geometry_ids",
-        ":geometry_roles",
-        ":shape_specification",
-        ":internal_geometry",
     ],
-    deps = [
+    implementation_deps = [
         ":read_obj",
         ":utilities",
         "//geometry/proximity",
@@ -130,7 +130,7 @@ drake_cc_library(
     name = "drake_visualizer",
     srcs = ["drake_visualizer.cc"],
     hdrs = ["drake_visualizer.h"],
-    interface_deps = [
+    deps = [
         ":drake_visualizer_params",
         ":geometry_roles",
         ":geometry_version",
@@ -140,7 +140,7 @@ drake_cc_library(
         "//systems/framework:context",
         "//systems/framework:leaf_system",
     ],
-    deps = [
+    implementation_deps = [
         "//lcm:drake_lcm",
         "//lcmtypes:viewer",
         "//systems/lcm:lcm_system_graphviz",
@@ -165,12 +165,12 @@ drake_cc_library(
     hdrs = [
         "kinematics_vector.h",
     ],
-    interface_deps = [
+    deps = [
         ":geometry_ids",
         "//common:essential",
         "//math:geometric_transform",
     ],
-    deps = [
+    implementation_deps = [
         "//common:default_scalars",
         "//common:nice_type_name",
     ],
@@ -378,10 +378,10 @@ drake_cc_library(
     name = "read_obj",
     srcs = ["read_obj.cc"],
     hdrs = ["read_obj.h"],
-    interface_deps = [
+    deps = [
         "@eigen",
     ],
-    deps = [
+    implementation_deps = [
         "//common:essential",
         "@fmt",
         "@tinyobjloader_internal//:tinyobjloader",
@@ -392,12 +392,12 @@ drake_cc_library(
     name = "shape_specification",
     srcs = ["shape_specification.cc"],
     hdrs = ["shape_specification.h"],
-    interface_deps = [
+    deps = [
         "//common:essential",
         "//geometry/proximity:polygon_surface_mesh",
         "//math:geometric_transform",
     ],
-    deps = [
+    implementation_deps = [
         "//common:nice_type_name",
         "//common:overloaded",
         "//geometry/proximity:make_convex_hull_mesh_impl",
@@ -508,7 +508,7 @@ drake_cc_library(
         "meshcat_recording_internal.h",
         "meshcat_types_internal.h",
     ],
-    interface_deps = [
+    deps = [
         ":geometry_ids",
         ":meshcat_animation",
         ":rgba",
@@ -520,7 +520,7 @@ drake_cc_library(
         "//math:geometric_transform",
         "//perception:point_cloud",
     ],
-    deps = [
+    implementation_deps = [
         "//common:drake_export",
         "//common:find_resource",
         "//common:network_policy",

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -35,11 +35,11 @@ drake_cc_library(
     name = "geodesic_convexity",
     srcs = ["geodesic_convexity.cc"],
     hdrs = ["geodesic_convexity.h"],
-    interface_deps = [
+    deps = [
         "//solvers:mathematical_program",
         "//solvers:mathematical_program_result",
     ],
-    deps = [
+    implementation_deps = [
         "//geometry/optimization:convex_set",
         "//solvers:solve",
     ],
@@ -75,13 +75,13 @@ drake_cc_library(
         "spectrahedron.h",
         "vpolytope.h",
     ],
-    interface_deps = [
+    deps = [
         "//geometry:scene_graph",
+        "//math:matrix_util",
         "//solvers:mathematical_program",
         "//solvers:mathematical_program_result",
-        "//math:matrix_util",
     ],
-    deps = [
+    implementation_deps = [
         "//geometry:read_obj",
         "//solvers:aggregate_costs_constraints",
         "//solvers:choose_best_solver",

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -131,13 +131,13 @@ drake_cc_library(
     hdrs = ["calc_distance_to_surface_mesh.h"],
     internal = True,
     visibility = ["//visibility:private"],
-    interface_deps = [
+    deps = [
         ":bv",
         ":bvh",
         ":triangle_surface_mesh",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         ":distance_to_point_callback",
         "//math:geometric_transform",
     ],
@@ -414,11 +414,11 @@ drake_cc_library(
     name = "make_box_field",
     srcs = ["make_box_field.cc"],
     hdrs = ["make_box_field.h"],
-    interface_deps = [
+    deps = [
         ":mesh_field",
         "//geometry:shape_specification",
     ],
-    deps = [
+    implementation_deps = [
         ":distance_to_point_callback",
         "//common:default_scalars",
         "//common:essential",
@@ -430,13 +430,13 @@ drake_cc_library(
     name = "make_box_mesh",
     srcs = ["make_box_mesh.cc"],
     hdrs = ["make_box_mesh.h"],
-    interface_deps = [
+    deps = [
         ":triangle_surface_mesh",
         ":volume_mesh",
         ":volume_to_surface_mesh",
         "//geometry:shape_specification",
     ],
-    deps = [
+    implementation_deps = [
         ":proximity_utilities",
         "//common:default_scalars",
     ],
@@ -457,14 +457,14 @@ drake_cc_library(
     name = "make_capsule_mesh",
     srcs = ["make_capsule_mesh.cc"],
     hdrs = ["make_capsule_mesh.h"],
-    interface_deps = [
+    deps = [
         ":triangle_surface_mesh",
         ":volume_mesh",
         ":volume_to_surface_mesh",
         "//common:essential",
         "//geometry:shape_specification",
     ],
-    deps = [
+    implementation_deps = [
         ":meshing_utilities",
         ":proximity_utilities",
         "//common:default_scalars",
@@ -485,10 +485,10 @@ drake_cc_library(
     hdrs = ["make_convex_hull_mesh_impl.h"],
     internal = True,
     visibility = ["//geometry:__subpackages__"],
-    interface_deps = [
+    deps = [
         "//geometry/proximity:polygon_surface_mesh",
     ],
-    deps = [
+    implementation_deps = [
         ":volume_mesh",
         ":vtk_to_volume_mesh",
         "//common:essential",
@@ -507,11 +507,11 @@ drake_cc_library(
     name = "make_convex_hull_mesh",
     srcs = ["make_convex_hull_mesh.cc"],
     hdrs = ["make_convex_hull_mesh.h"],
-    interface_deps = [
-        "//geometry/proximity:polygon_surface_mesh",
-        "//geometry:shape_specification",
-    ],
     deps = [
+        "//geometry:shape_specification",
+        "//geometry/proximity:polygon_surface_mesh",
+    ],
+    implementation_deps = [
         ":make_convex_hull_mesh_impl",
     ],
 )
@@ -520,11 +520,11 @@ drake_cc_library(
     name = "make_convex_mesh",
     srcs = ["make_convex_mesh.cc"],
     hdrs = ["make_convex_mesh.h"],
-    interface_deps = [
+    deps = [
         ":volume_mesh",
         "//geometry:shape_specification",
     ],
-    deps = [
+    implementation_deps = [
         ":obj_to_surface_mesh",
         ":triangle_surface_mesh",
         "//common:default_scalars",
@@ -536,11 +536,11 @@ drake_cc_library(
     name = "make_cylinder_field",
     srcs = ["make_cylinder_field.cc"],
     hdrs = ["make_cylinder_field.h"],
-    interface_deps = [
+    deps = [
         ":mesh_field",
         "//geometry:shape_specification",
     ],
-    deps = [
+    implementation_deps = [
         ":distance_to_point_callback",
         ":volume_to_surface_mesh",
         "//common:default_scalars",
@@ -553,14 +553,14 @@ drake_cc_library(
     name = "make_cylinder_mesh",
     srcs = ["make_cylinder_mesh.cc"],
     hdrs = ["make_cylinder_mesh.h"],
-    interface_deps = [
+    deps = [
         ":triangle_surface_mesh",
         ":volume_mesh",
         ":volume_to_surface_mesh",
         "//common:essential",
         "//geometry:shape_specification",
     ],
-    deps = [
+    implementation_deps = [
         ":meshing_utilities",
         ":proximity_utilities",
         "//common:default_scalars",
@@ -744,11 +744,11 @@ drake_cc_library(
     name = "obj_to_surface_mesh",
     srcs = ["obj_to_surface_mesh.cc"],
     hdrs = ["obj_to_surface_mesh.h"],
-    interface_deps = [
+    deps = [
         ":triangle_surface_mesh",
         "//common:diagnostic_policy",
     ],
-    deps = [
+    implementation_deps = [
         "//common:essential",
         "@fmt",
         "@tinyobjloader_internal//:tinyobjloader",
@@ -916,11 +916,11 @@ drake_cc_library(
     hdrs = [
         "vtk_to_volume_mesh.h",
     ],
-    interface_deps = [
+    deps = [
         ":volume_mesh",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         "@fmt",
         "@vtk_internal//:vtkCommonCore",
         "@vtk_internal//:vtkCommonDataModel",

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -80,13 +80,13 @@ drake_cc_library(
     name = "render_material",
     srcs = ["render_material.cc"],
     hdrs = ["render_material.h"],
-    interface_deps = [
+    deps = [
         "//common:diagnostic_policy",
         "//common:essential",
         "//geometry:geometry_properties",
         "//geometry:rgba",
     ],
-    deps = [
+    implementation_deps = [
         "@tinyobjloader_internal//:tinyobjloader",
     ],
 )
@@ -95,7 +95,7 @@ drake_cc_library(
     name = "render_mesh",
     srcs = ["render_mesh.cc"],
     hdrs = ["render_mesh.h"],
-    interface_deps = [
+    deps = [
         ":render_material",
         "//common:diagnostic_policy",
         "//common:essential",
@@ -103,7 +103,7 @@ drake_cc_library(
         "//geometry:rgba",
         "//geometry/proximity:triangle_surface_mesh",
     ],
-    deps = [
+    implementation_deps = [
         "@tinyobjloader_internal//:tinyobjloader",
     ],
 )

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -96,11 +96,11 @@ drake_cc_library(
         "factory.h",
     ],
     visibility = ["//visibility:public"],
-    interface_deps = [
+    deps = [
         ":render_engine_gl_params",
         "//geometry/render:render_engine",
     ],
-    deps = select({
+    implementation_deps = select({
         "//tools/cc_toolchain:apple": [
             ":apple_only_no_factory",
         ],
@@ -172,11 +172,11 @@ drake_cc_library_linux_only(
     name = "internal_shape_meshes",
     srcs = ["internal_shape_meshes.cc"],
     hdrs = ["internal_shape_meshes.h"],
-    interface_deps = [
+    deps = [
         ":internal_opengl_context",
         "//geometry/render:render_mesh",
     ],
-    deps = [
+    implementation_deps = [
         "//common:essential",
         "@tinyobjloader_internal//:tinyobjloader",
     ],
@@ -186,11 +186,11 @@ drake_cc_library_linux_only(
     name = "internal_texture_library",
     srcs = ["internal_texture_library.cc"],
     hdrs = ["internal_texture_library.h"],
-    interface_deps = [
-        "//common:essential",
-        ":internal_opengl_context",
-    ],
     deps = [
+        ":internal_opengl_context",
+        "//common:essential",
+    ],
+    implementation_deps = [
         "//systems/sensors:image_io",
         "@vtk_internal//:vtkCommonCore",
         "@vtk_internal//:vtkCommonDataModel",

--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -29,11 +29,11 @@ drake_cc_library(
     srcs = ["factory.cc"],
     hdrs = ["factory.h"],
     visibility = ["//visibility:public"],
-    interface_deps = [
+    deps = [
         ":render_engine_gltf_client_params",
         "//geometry/render:render_engine",
     ],
-    deps = [
+    implementation_deps = [
         ":internal_render_engine_gltf_client",
         "//common:network_policy",
     ],
@@ -56,10 +56,10 @@ drake_cc_library(
     hdrs = ["internal_http_service.h"],
     internal = True,
     visibility = ["//visibility:private"],
-    interface_deps = [
+    deps = [
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         "@fmt",
     ],
 )
@@ -70,10 +70,10 @@ drake_cc_library(
     hdrs = ["internal_http_service_curl.h"],
     internal = True,
     visibility = ["//visibility:private"],
-    interface_deps = [
+    deps = [
         ":internal_http_service",
     ],
-    deps = [
+    implementation_deps = [
         "//common:unused",
         "@curl_internal//:libcurl",
         "@fmt",

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -38,11 +38,11 @@ drake_cc_library(
     srcs = ["factory.cc"],
     hdrs = ["factory.h"],
     visibility = ["//visibility:public"],
-    interface_deps = [
-        "//geometry/render:render_engine",
-        ":render_engine_vtk_params",
-    ],
     deps = [
+        ":render_engine_vtk_params",
+        "//geometry/render:render_engine",
+    ],
+    implementation_deps = [
         ":internal_render_engine_vtk",
     ],
 )

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -70,12 +70,12 @@ drake_cc_library(
     name = "drake_lcm",
     srcs = ["drake_lcm.cc"],
     hdrs = ["drake_lcm.h"],
-    interface_deps = [
+    deps = [
         ":drake_lcm_params",
         ":interface",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         "//common:network_policy",
         "@glib",
         "@lcm",
@@ -86,11 +86,11 @@ drake_cc_library(
     name = "lcm_log",
     srcs = ["drake_lcm_log.cc"],
     hdrs = ["drake_lcm_log.h"],
-    interface_deps = [
+    deps = [
         ":interface",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         "//common:string_container",
         "@lcm",
     ],

--- a/manipulation/kuka_iiwa/BUILD.bazel
+++ b/manipulation/kuka_iiwa/BUILD.bazel
@@ -99,7 +99,7 @@ drake_cc_library(
     name = "iiwa_driver_functions",
     srcs = ["iiwa_driver_functions.cc"],
     hdrs = ["iiwa_driver_functions.h"],
-    interface_deps = [
+    deps = [
         ":iiwa_driver",
         "//common:essential",
         "//multibody/parsing:model_instance_info",
@@ -107,7 +107,7 @@ drake_cc_library(
         "//systems/framework:diagram_builder",
         "//systems/lcm:lcm_buses",
     ],
-    deps = [
+    implementation_deps = [
         ":build_iiwa_control",
         "//manipulation/util:make_arm_controller_model",
         "//systems/primitives:shared_pointer_system",

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -82,14 +82,14 @@ drake_cc_library(
     name = "zero_force_driver_functions",
     srcs = ["zero_force_driver_functions.cc"],
     hdrs = ["zero_force_driver_functions.h"],
-    interface_deps = [
+    deps = [
         ":zero_force_driver",
         "//multibody/parsing:model_instance_info",
         "//multibody/plant",
         "//systems/framework:diagram_builder",
         "//systems/lcm:lcm_buses",
     ],
-    deps = [
+    implementation_deps = [
         "//systems/primitives:constant_vector_source",
     ],
 )

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -93,8 +93,8 @@ drake_cc_library(
     name = "continuous_algebraic_riccati_equation",
     srcs = ["continuous_algebraic_riccati_equation.cc"],
     hdrs = ["continuous_algebraic_riccati_equation.h"],
-    interface_deps = [],
-    deps = [
+    deps = [],
+    implementation_deps = [
         "//common:essential",
         "//common:is_approx_equal_abstol",
         # TODO(jwnimmer-tri) Move this code into //math to avoid the circular
@@ -165,7 +165,7 @@ drake_cc_library(
         "-O2",
     ],
     textual_hdrs = ["fast_pose_composition_functions_avx2_fma.cc"],
-    interface_deps = [
+    deps = [
         ":vector3_util",
         "//common:default_scalars",
         "//common:drake_bool",
@@ -175,7 +175,7 @@ drake_cc_library(
         "//common:unused",
         "//math:gradient",
     ],
-    deps = [
+    implementation_deps = [
         "//common:hwy_dynamic",
         "@highway_internal//:hwy",
     ],

--- a/multibody/contact_solvers/BUILD.bazel
+++ b/multibody/contact_solvers/BUILD.bazel
@@ -235,11 +235,11 @@ drake_cc_library(
     name = "conex_supernodal_solver",
     srcs = ["conex_supernodal_solver.cc"],
     hdrs = ["conex_supernodal_solver.h"],
-    interface_deps = [
+    deps = [
         ":supernodal_solver",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         "//common:drake_export",
         "@conex_internal//conex:supernodal_solver",
     ],

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -84,11 +84,11 @@ drake_cc_library(
         "@drake_models//:package.xml",
     ],
     visibility = ["//visibility:public"],
-    interface_deps = [
+    deps = [
         "//common:essential",
         "//common:name_value",
     ],
-    deps = [
+    implementation_deps = [
         "//common:diagnostic_policy",
         "//common:find_cache",
         "//common:find_resource",
@@ -106,12 +106,12 @@ drake_cc_library(
     srcs = ["collision_filter_groups.cc"],
     hdrs = ["collision_filter_groups.h"],
     visibility = ["//visibility:public"],
-    interface_deps = [
+    deps = [
         "//common:copyable_unique_ptr",
         "//common:essential",
         "//common:sorted_pair",
     ],
-    deps = [
+    implementation_deps = [
         ":detail_collision_filter_groups_impl",
     ],
 )
@@ -295,12 +295,12 @@ drake_cc_library(
     ],
     internal = True,
     visibility = ["//visibility:private"],
-    interface_deps = [
+    deps = [
         ":detail_misc",
         ":detail_parsing_workspace",
         "//multibody/plant",
     ],
-    deps = [
+    implementation_deps = [
         ":detail_make_model_name",
         "//common:find_runfiles",
         "//common:unused",
@@ -405,13 +405,13 @@ drake_cc_library(
         "detail_composite_parse.h",
     ],
     visibility = ["//visibility:public"],
-    interface_deps = [
+    deps = [
         ":collision_filter_groups",
         ":package_map",
         "//common:diagnostic_policy",
         "//multibody/plant",
     ],
-    deps = [
+    implementation_deps = [
         ":detail_parsing_workspace",
         ":detail_select_parser",
     ],
@@ -444,13 +444,13 @@ drake_cc_library(
     srcs = ["process_model_directives.cc"],
     hdrs = ["process_model_directives.h"],
     visibility = ["//visibility:public"],
-    interface_deps = [
+    deps = [
         ":model_directives",
         ":model_instance_info",
         ":parser",
         "//multibody/plant",
     ],
-    deps = [
+    implementation_deps = [
         ":detail_dmd_parser",
         ":detail_misc",
         ":detail_parsing_workspace",

--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -33,12 +33,12 @@ drake_cc_library(
     name = "point_cloud",
     srcs = ["point_cloud.cc"],
     hdrs = ["point_cloud.h"],
-    interface_deps = [
+    deps = [
         ":point_cloud_flags",
         "//common:essential",
         "//common:parallelism",
     ],
-    deps = [
+    implementation_deps = [
         "//common:unused",
         "@common_robotics_utilities",
         "@nanoflann_internal//:nanoflann",

--- a/planning/BUILD.bazel
+++ b/planning/BUILD.bazel
@@ -56,7 +56,7 @@ drake_cc_library(
         "collision_checker.h",
         "edge_measure.h",
     ],
-    interface_deps = [
+    deps = [
         ":body_shape_description",
         ":collision_checker_context",
         ":collision_checker_params",
@@ -69,7 +69,7 @@ drake_cc_library(
         "//geometry",
         "//multibody/plant",
     ],
-    deps = [
+    implementation_deps = [
         ":linear_distance_and_interpolation_provider",
         "@common_robotics_utilities",
     ],
@@ -109,11 +109,11 @@ drake_cc_library(
     name = "linear_distance_and_interpolation_provider",
     srcs = ["linear_distance_and_interpolation_provider.cc"],
     hdrs = ["linear_distance_and_interpolation_provider.h"],
-    interface_deps = [
+    deps = [
         ":distance_and_interpolation_provider",
         "//multibody/plant",
     ],
-    deps = [
+    implementation_deps = [
         "//common:essential",
         "@common_robotics_utilities",
     ],
@@ -166,11 +166,11 @@ drake_cc_library(
     name = "scene_graph_collision_checker",
     srcs = ["scene_graph_collision_checker.cc"],
     hdrs = ["scene_graph_collision_checker.h"],
-    interface_deps = [
+    deps = [
         ":collision_checker",
         ":collision_checker_params",
     ],
-    deps = [
+    implementation_deps = [
         ":robot_diagram",
         "//geometry",
         "//multibody/plant",
@@ -204,11 +204,11 @@ drake_cc_library(
     name = "visibility_graph",
     srcs = ["visibility_graph.cc"],
     hdrs = ["visibility_graph.h"],
-    interface_deps = [
+    deps = [
         ":collision_checker",
         "//common:parallelism",
     ],
-    deps = [
+    implementation_deps = [
         "@common_robotics_utilities",
     ],
 )

--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -21,18 +21,18 @@ drake_cc_library(
     name = "iris_from_clique_cover",
     srcs = ["iris_from_clique_cover.cc"],
     hdrs = ["iris_from_clique_cover.h"],
-    interface_deps = [
+    deps = [
+        "//geometry:meshcat",
         "//geometry/optimization:convex_set",
         "//geometry/optimization:iris",
-        "//geometry:meshcat",
-        "//planning/graph_algorithms:max_clique_solver_via_greedy",
-        "//planning/graph_algorithms:max_clique_solver_base",
-        "//solvers:gurobi_solver",
-        "//solvers:mosek_solver",
         "//planning:scene_graph_collision_checker",
         "//planning:visibility_graph",
+        "//planning/graph_algorithms:max_clique_solver_base",
+        "//planning/graph_algorithms:max_clique_solver_via_greedy",
+        "//solvers:gurobi_solver",
+        "//solvers:mosek_solver",
     ],
-    deps = [
+    implementation_deps = [
         "@common_robotics_utilities",
     ],
 )

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -88,10 +88,10 @@ drake_cc_library(
     name = "augmented_lagrangian",
     srcs = ["augmented_lagrangian.cc"],
     hdrs = ["augmented_lagrangian.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
     ],
-    deps = [
+    implementation_deps = [
         ":aggregate_costs_constraints",
     ],
 )
@@ -100,10 +100,10 @@ drake_cc_library(
     name = "integer_inequality_solver",
     srcs = ["integer_inequality_solver.cc"],
     hdrs = ["integer_inequality_solver.h"],
-    interface_deps = [
+    deps = [
         "@eigen",
     ],
-    deps = [
+    implementation_deps = [
         "//common:essential",
     ],
 )
@@ -112,11 +112,11 @@ drake_cc_library(
     name = "sos_basis_generator",
     srcs = ["sos_basis_generator.cc"],
     hdrs = ["sos_basis_generator.h"],
-    interface_deps = [
+    deps = [
         "//common/symbolic:expression",
         "//common/symbolic:polynomial",
     ],
-    deps = [
+    implementation_deps = [
         ":integer_inequality_solver",
     ],
 )
@@ -125,23 +125,22 @@ drake_cc_library(
     name = "binding",
     srcs = [],
     hdrs = ["binding.h"],
-    interface_deps = [
+    deps = [
         ":decision_variable",
         ":evaluator_base",
     ],
-    deps = [],
 )
 
 drake_cc_library(
     name = "choose_best_solver",
     srcs = ["choose_best_solver.cc"],
     hdrs = ["choose_best_solver.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         ":solver_id",
         ":solver_interface",
     ],
-    deps = [
+    implementation_deps = [
         ":clarabel_solver",
         ":clp_solver",
         ":csdp_solver",
@@ -164,14 +163,14 @@ drake_cc_library(
     name = "evaluator_base",
     srcs = ["evaluator_base.cc"],
     hdrs = ["evaluator_base.h"],
-    interface_deps = [
+    deps = [
+        ":function",
         "//common:essential",
         "//common:polynomial",
         "//common/symbolic:expression",
         "//math:autodiff",
-        ":function",
     ],
-    deps = [
+    implementation_deps = [
         "//common:nice_type_name",
         "//common/symbolic:latex",
     ],
@@ -181,7 +180,7 @@ drake_cc_library(
     name = "constraint",
     srcs = ["constraint.cc"],
     hdrs = ["constraint.h"],
-    interface_deps = [
+    deps = [
         ":decision_variable",
         ":evaluator_base",
         ":sparse_and_dense_matrix",
@@ -189,7 +188,7 @@ drake_cc_library(
         "//common:polynomial",
         "//common/symbolic:expression",
     ],
-    deps = [
+    implementation_deps = [
         "//common/symbolic:latex",
         "//common/symbolic:polynomial",
         "//math:gradient",
@@ -201,10 +200,10 @@ drake_cc_library(
     name = "minimum_value_constraint",
     srcs = ["minimum_value_constraint.cc"],
     hdrs = ["minimum_value_constraint.h"],
-    interface_deps = [
+    deps = [
         ":constraint",
     ],
-    deps = [
+    implementation_deps = [
         "//math:gradient",
         "//math:soft_min_max",
     ],
@@ -214,12 +213,12 @@ drake_cc_library(
     name = "cost",
     srcs = ["cost.cc"],
     hdrs = ["cost.h"],
-    interface_deps = [
+    deps = [
         ":decision_variable",
         ":evaluator_base",
         ":sparse_and_dense_matrix",
     ],
-    deps = [
+    implementation_deps = [
         ":constraint",
         "//common/symbolic:latex",
         "//math:gradient",
@@ -230,12 +229,12 @@ drake_cc_library(
     name = "create_constraint",
     srcs = ["create_constraint.cc"],
     hdrs = ["create_constraint.h"],
-    interface_deps = [
-        "//common/symbolic:expression",
+    deps = [
         ":binding",
         ":constraint",
+        "//common/symbolic:expression",
     ],
-    deps = [
+    implementation_deps = [
         "//common/symbolic:polynomial",
         "//math:quadratic_form",
     ],
@@ -245,12 +244,12 @@ drake_cc_library(
     name = "create_cost",
     srcs = ["create_cost.cc"],
     hdrs = ["create_cost.h"],
-    interface_deps = [
+    deps = [
         ":binding",
         ":cost",
         "//common/symbolic:expression",
     ],
-    deps = [
+    implementation_deps = [
         "//common:polynomial",
         "//common:unused",
         "//common/symbolic:polynomial",
@@ -261,30 +260,27 @@ drake_cc_library(
     name = "decision_variable",
     srcs = ["decision_variable.cc"],
     hdrs = ["decision_variable.h"],
-    interface_deps = [
+    deps = [
         "//common/symbolic:expression",
     ],
-    deps = [],
 )
 
 drake_cc_library(
     name = "function",
     srcs = [],
     hdrs = ["function.h"],
-    interface_deps = [
+    deps = [
         "//common:essential",
     ],
-    deps = [],
 )
 
 drake_cc_library(
     name = "get_program_type",
     srcs = ["get_program_type.cc"],
     hdrs = ["get_program_type.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
     ],
-    deps = [],
 )
 
 drake_cc_library(
@@ -313,20 +309,19 @@ drake_cc_library(
         "common_solver_option.h",
         "solver_options.h",
     ],
-    interface_deps = [
+    deps = [
         ":solver_id",
     ],
-    deps = [],
 )
 
 drake_cc_library(
     name = "indeterminate",
     srcs = ["indeterminate.cc"],
     hdrs = ["indeterminate.h"],
-    interface_deps = [
+    deps = [
         "//common/symbolic:expression",
     ],
-    deps = [
+    implementation_deps = [
         "//solvers:decision_variable",
     ],
 )
@@ -335,12 +330,12 @@ drake_cc_library(
     name = "solver_type_converter",
     srcs = ["solver_type_converter.cc"],
     hdrs = ["solver_type_converter.h"],
-    interface_deps = [
+    deps = [
         ":solver_id",
         ":solver_type",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         ":clp_solver",
         ":csdp_solver",
         ":equality_constrained_qp_solver",
@@ -361,7 +356,7 @@ drake_cc_library(
     name = "mathematical_program",
     srcs = ["mathematical_program.cc"],
     hdrs = ["mathematical_program.h"],
-    interface_deps = [
+    deps = [
         ":binding",
         ":create_constraint",
         ":create_cost",
@@ -377,7 +372,7 @@ drake_cc_library(
         "//common/symbolic:monomial_util",
         "//common/symbolic:polynomial",
     ],
-    deps = [
+    implementation_deps = [
         ":sos_basis_generator",
         "//common/symbolic:latex",
         "//math:matrix_util",
@@ -388,7 +383,7 @@ drake_cc_library(
     name = "mathematical_program_result",
     srcs = ["mathematical_program_result.cc"],
     hdrs = ["mathematical_program_result.h"],
-    interface_deps = [
+    deps = [
         ":binding",
         ":constraint",
         ":mathematical_program",
@@ -397,14 +392,13 @@ drake_cc_library(
         "//common:value",
         "//common/symbolic:expression",
     ],
-    deps = [],
 )
 
 drake_cc_library(
     name = "solver_interface",
     srcs = ["solver_interface.cc"],
     hdrs = ["solver_interface.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         ":mathematical_program_result",
         ":solution_result",
@@ -412,18 +406,17 @@ drake_cc_library(
         ":solver_options",
         "//common:essential",
     ],
-    deps = [],
 )
 
 drake_cc_library(
     name = "aggregate_costs_constraints",
     srcs = ["aggregate_costs_constraints.cc"],
     hdrs = ["aggregate_costs_constraints.h"],
-    interface_deps = [
+    deps = [
         ":binding",
         ":mathematical_program",
     ],
-    deps = [
+    implementation_deps = [
         "//math:eigen_sparse_triplet",
     ],
 )
@@ -432,12 +425,12 @@ drake_cc_library(
     name = "branch_and_bound",
     srcs = ["branch_and_bound.cc"],
     hdrs = ["branch_and_bound.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         ":mathematical_program_result",
         "//common:name_value",
     ],
-    deps = [
+    implementation_deps = [
         ":choose_best_solver",
         ":gurobi_solver",
         ":scs_solver",
@@ -448,10 +441,10 @@ drake_cc_library(
     name = "non_convex_optimization_util",
     srcs = ["non_convex_optimization_util.cc"],
     hdrs = ["non_convex_optimization_util.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
     ],
-    deps = [
+    implementation_deps = [
         ":solve",
         "//math:quadratic_form",
     ],
@@ -461,11 +454,11 @@ drake_cc_library(
     name = "integer_optimization_util",
     srcs = ["integer_optimization_util.cc"],
     hdrs = ["integer_optimization_util.h"],
-    interface_deps = [
+    deps = [
         ":binding",
         ":constraint",
     ],
-    deps = [
+    implementation_deps = [
         ":create_constraint",
     ],
 )
@@ -474,10 +467,9 @@ drake_cc_library(
     name = "rotation_constraint",
     srcs = ["rotation_constraint.cc"],
     hdrs = ["rotation_constraint.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
     ],
-    deps = [],
 )
 
 drake_cc_library(
@@ -490,11 +482,11 @@ drake_cc_library(
         "mixed_integer_rotation_constraint.h",
         "mixed_integer_rotation_constraint_internal.h",
     ],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         ":mixed_integer_optimization_util",
     ],
-    deps = [
+    implementation_deps = [
         ":integer_optimization_util",
         ":solve",
         "//common/symbolic:replace_bilinear_terms",
@@ -506,20 +498,18 @@ drake_cc_library(
     name = "program_attribute",
     srcs = ["program_attribute.cc"],
     hdrs = ["program_attribute.h"],
-    interface_deps = [
+    deps = [
         "//common:hash",
     ],
-    deps = [],
 )
 
 drake_cc_library(
     name = "sparse_and_dense_matrix",
     srcs = ["sparse_and_dense_matrix.cc"],
     hdrs = ["sparse_and_dense_matrix.h"],
-    interface_deps = [
+    deps = [
         "//common:essential",
     ],
-    deps = [],
 )
 
 drake_cc_library(
@@ -722,23 +712,22 @@ drake_cc_library(
     name = "solver_base",
     srcs = ["solver_base.cc"],
     hdrs = ["solver_base.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         ":solver_interface",
     ],
-    deps = [],
 )
 
 drake_cc_library(
     name = "solve",
     srcs = ["solve.cc"],
     hdrs = ["solve.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         ":mathematical_program_result",
         ":solver_base",
     ],
-    deps = [
+    implementation_deps = [
         ":choose_best_solver",
         "//common:nice_type_name",
     ],
@@ -750,11 +739,11 @@ drake_cc_library(
     name = "equality_constrained_qp_solver",
     srcs = ["equality_constrained_qp_solver.cc"],
     hdrs = ["equality_constrained_qp_solver.h"],
-    interface_deps = [
+    deps = [
         ":solver_base",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         ":mathematical_program",
     ],
 )
@@ -763,11 +752,11 @@ drake_cc_library(
     name = "linear_system_solver",
     srcs = ["linear_system_solver.cc"],
     hdrs = ["linear_system_solver.h"],
-    interface_deps = [
+    deps = [
         ":solver_base",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         ":mathematical_program",
     ],
 )
@@ -776,12 +765,12 @@ drake_cc_library(
     name = "unrevised_lemke_solver",
     srcs = ["unrevised_lemke_solver.cc"],
     hdrs = ["unrevised_lemke_solver.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         ":solver_base",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         "//common:default_scalars",
     ],
 )
@@ -790,12 +779,11 @@ drake_cc_library(
     name = "moby_lcp_solver",
     srcs = ["moby_lcp_solver.cc"],
     hdrs = ["moby_lcp_solver.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         ":solver_base",
         "//common:essential",
     ],
-    deps = [],
 )
 
 # External Solvers.
@@ -810,21 +798,21 @@ drake_cc_variant_library(
     srcs_enabled = ["gurobi_solver.cc"],
     srcs_disabled = ["no_gurobi.cc"],
     hdrs = ["gurobi_solver.h"],
-    interface_deps = [
+    deps = [
         ":solver_base",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":aggregate_costs_constraints",
         ":mathematical_program",
     ],
-    deps_enabled = [
+    implementation_deps_enabled = [
         ":gurobi_solver_internal",
-        "//math:eigen_sparse_triplet",
         "//common:find_resource",
         "//common:scope_exit",
         "//common:scoped_singleton",
-        "@gurobi//:gurobi_c",
+        "//math:eigen_sparse_triplet",
         "@fmt",
+        "@gurobi//:gurobi_c",
     ],
 )
 
@@ -833,8 +821,8 @@ drake_cc_optional_library(
     opt_in_condition = "//tools:with_gurobi",
     srcs = ["gurobi_solver_internal.cc"],
     hdrs = ["gurobi_solver_internal.h"],
-    interface_deps = [":mathematical_program_result"],
-    deps = [
+    deps = [":mathematical_program_result"],
+    implementation_deps = [
         ":aggregate_costs_constraints",
         ":mathematical_program",
         "//math:quadratic_form",
@@ -852,18 +840,18 @@ drake_cc_variant_library(
     srcs_enabled = ["mosek_solver.cc"],
     srcs_disabled = ["no_mosek.cc"],
     hdrs = ["mosek_solver.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program_result",
         ":solver_base",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":aggregate_costs_constraints",
         ":mathematical_program",
     ],
-    deps_enabled = [
+    implementation_deps_enabled = [
         ":mosek_solver_internal",
-        "//common:scoped_singleton",
         "//common:scope_exit",
+        "//common:scoped_singleton",
         "@mosek",
     ],
 )
@@ -873,8 +861,8 @@ drake_cc_optional_library(
     opt_in_condition = "//tools:with_mosek",
     srcs = ["mosek_solver_internal.cc"],
     hdrs = ["mosek_solver_internal.h"],
-    interface_deps = [":mathematical_program_result"],
-    deps = [
+    deps = [":mathematical_program_result"],
+    implementation_deps = [
         ":aggregate_costs_constraints",
         ":mathematical_program",
         "//math:quadratic_form",
@@ -892,13 +880,13 @@ drake_cc_variant_library(
     srcs_enabled = ["snopt_solver.cc"],
     srcs_disabled = ["no_snopt.cc"],
     hdrs = ["snopt_solver.h"],
-    interface_deps = [
+    deps = [
         ":solver_base",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":mathematical_program",
     ],
-    deps_enabled = [
+    implementation_deps_enabled = [
         "//common:scope_exit",
         "//math:autodiff",
         "@snopt//:snopt_cwrap",
@@ -912,17 +900,17 @@ drake_cc_variant_library(
     srcs_enabled = ["clp_solver.cc"],
     srcs_disabled = ["no_clp.cc"],
     hdrs = ["clp_solver.h"],
-    interface_deps = [
+    deps = [
         ":solver_base",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":aggregate_costs_constraints",
         ":mathematical_program",
     ],
-    deps_enabled = [
-        "@clp_internal//:clp",
+    implementation_deps_enabled = [
         "//common:unused",
         "//math:autodiff",
+        "@clp_internal//:clp",
     ],
 )
 
@@ -950,17 +938,17 @@ drake_cc_variant_library(
     hdrs = [
         "ipopt_solver.h",
     ],
-    interface_deps = [
+    deps = [
         ":solver_base",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":mathematical_program",
     ],
-    deps_enabled = [
+    implementation_deps_enabled = [
         ":ipopt_solver_internal",
-        "@ipopt",
         "//common:unused",
         "//math:autodiff",
+        "@ipopt",
     ],
 )
 
@@ -971,13 +959,13 @@ drake_cc_variant_library(
     srcs_enabled = ["nlopt_solver.cc"],
     srcs_disabled = ["no_nlopt.cc"],
     hdrs = ["nlopt_solver.h"],
-    interface_deps = [
+    deps = [
         ":solver_base",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":mathematical_program",
     ],
-    deps_enabled = [
+    implementation_deps_enabled = [
         "//math:autodiff",
         "@nlopt_internal//:nlopt",
     ],
@@ -990,14 +978,14 @@ drake_cc_variant_library(
     srcs_enabled = ["osqp_solver.cc"],
     srcs_disabled = ["no_osqp.cc"],
     hdrs = ["osqp_solver.h"],
-    interface_deps = [
+    deps = [
         ":solver_base",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":aggregate_costs_constraints",
         ":mathematical_program",
     ],
-    deps_enabled = [
+    implementation_deps_enabled = [
         "//math:eigen_sparse_triplet",
         "@osqp_internal//:osqp",
     ],
@@ -1010,16 +998,16 @@ drake_cc_variant_library(
     srcs_enabled = ["clarabel_solver.cc"],
     srcs_disabled = ["no_clarabel.cc"],
     hdrs = ["clarabel_solver.h"],
-    interface_deps = [
+    deps = [
         ":solver_base",
         "//common:essential",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":aggregate_costs_constraints",
         ":mathematical_program",
         "//math:quadratic_form",
     ],
-    deps_enabled = [
+    implementation_deps_enabled = [
         ":scs_clarabel_common",
         "//math:eigen_sparse_triplet",
         "//tools/workspace/clarabel_cpp_internal:serialize",
@@ -1044,16 +1032,16 @@ drake_cc_variant_library(
     srcs_enabled = ["scs_solver.cc"],
     srcs_disabled = ["no_scs.cc"],
     hdrs = ["scs_solver.h"],
-    interface_deps = [
+    deps = [
         ":solver_base",
         "//common:essential",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":aggregate_costs_constraints",
         ":mathematical_program",
         "//math:quadratic_form",
     ],
-    deps_enabled = [
+    implementation_deps_enabled = [
         ":scs_clarabel_common",
         "//common:scope_exit",
         "//math:eigen_sparse_triplet",
@@ -1065,21 +1053,20 @@ drake_cc_library(
     name = "sdpa_free_format",
     srcs = ["sdpa_free_format.cc"],
     hdrs = ["sdpa_free_format.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         "//common:type_safe_index",
     ],
-    deps = [],
 )
 
 drake_cc_library(
     name = "semidefinite_relaxation",
     srcs = ["semidefinite_relaxation.cc"],
     hdrs = ["semidefinite_relaxation.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
     ],
-    deps = [
+    implementation_deps = [
         ":semidefinite_relaxation_internal",
     ],
 )
@@ -1088,11 +1075,10 @@ drake_cc_library(
     name = "semidefinite_relaxation_internal",
     srcs = ["semidefinite_relaxation_internal.cc"],
     hdrs = ["semidefinite_relaxation_internal.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
         "//math:matrix_util",
     ],
-    deps = [],
 )
 
 drake_cc_optional_library(
@@ -1112,10 +1098,10 @@ drake_cc_optional_library(
     opt_out_condition = "//tools:no_csdp",
     srcs = ["csdp_cpp_wrapper.cc"],
     hdrs = ["csdp_cpp_wrapper.h"],
-    interface_deps = [
+    deps = [
         "@csdp_internal//:csdp",
     ],
-    deps = [
+    implementation_deps = [
         ":csdp_solver_error_handling",
     ],
 )
@@ -1125,11 +1111,10 @@ drake_cc_optional_library(
     opt_out_condition = "//tools:no_csdp",
     srcs = ["csdp_solver_internal.cc"],
     hdrs = ["csdp_solver_internal.h"],
-    interface_deps = [
+    deps = [
         ":csdp_cpp_wrapper",
         ":sdpa_free_format",
     ],
-    deps = [],
 )
 
 drake_cc_variant_library(
@@ -1139,15 +1124,15 @@ drake_cc_variant_library(
     srcs_enabled = ["csdp_solver.cc"],
     srcs_disabled = ["no_csdp.cc"],
     hdrs = ["csdp_solver.h"],
-    interface_deps = [
-        ":solver_base",
+    deps = [
         ":sdpa_free_format",
+        ":solver_base",
     ],
-    deps_always = [
+    implementation_deps_always = [
         ":mathematical_program",
         "//common:scope_exit",
     ],
-    deps_enabled = [
+    implementation_deps_enabled = [
         ":csdp_solver_internal",
     ],
 )
@@ -1156,10 +1141,10 @@ drake_cc_library(
     name = "mixed_integer_optimization_util",
     srcs = ["mixed_integer_optimization_util.cc"],
     hdrs = ["mixed_integer_optimization_util.h"],
-    interface_deps = [
+    deps = [
         ":mathematical_program",
     ],
-    deps = [
+    implementation_deps = [
         ":integer_optimization_util",
         "//math:gray_code",
     ],

--- a/solvers/defs.bzl
+++ b/solvers/defs.bzl
@@ -25,9 +25,9 @@ def drake_cc_variant_library(
         srcs_enabled,
         srcs_disabled,
         hdrs,
-        interface_deps,
-        deps_always,
-        deps_enabled,
+        deps,
+        implementation_deps_always,
+        implementation_deps_enabled,
         internal = False,
         visibility = None):
     """Declares a library with a uniform set of header files (typically just
@@ -35,7 +35,7 @@ def drake_cc_variant_library(
     on a configuration setting. This is how we turn on/off specific solver
     back-end implementations, e.g., `snopt_solver.cc` vs `no_snopt.cc`.
 
-    The same hdrs are used unconditionally. The interface_deps should list the
+    The same hdrs are used unconditionally. The deps should list the
     dependencies for the header file(s), and thus are also unconditional.
 
     Exactly one of opt_in_condition or opt_out_condition must be provided, to
@@ -46,11 +46,13 @@ def drake_cc_variant_library(
 
     The sources listed in srcs_always contain definitions that are appropriate
     whether or not a back-end is enabled. This usually contains things such as
-    the solver name, ID, and attribute support. The deps_always lists the
-    dependencies of these files.
+    the solver name, ID, and attribute support. The implementation_deps_always
+    lists the dependencies of these files.
 
     The sources listed in srcs_enabled contain the code of the fully-featured
-    implementation. The deps_enabled lists the dependencies of these srcs.
+    implementation. The implementation_deps_enabled lists the dependencies of
+    these files.
+
     The sources listed in srcs_disabled contain the alternative (stub)
     definitions that report failure (e.g., returning false or throwing).
 
@@ -69,10 +71,12 @@ def drake_cc_variant_library(
             opt_out_condition: srcs_always + srcs_disabled,
         }),
         hdrs = hdrs,
-        interface_deps = interface_deps,
-        deps = select({
-            opt_in_condition: deps_always + deps_enabled,
-            opt_out_condition: deps_always,
+        deps = deps,
+        implementation_deps = select({
+            opt_in_condition: (
+                implementation_deps_always + implementation_deps_enabled
+            ),
+            opt_out_condition: implementation_deps_always,
         }),
         internal = internal,
         visibility = visibility,
@@ -91,8 +95,8 @@ def drake_cc_optional_library(
         hdrs,
         copts = None,
         visibility = ["//visibility:private"],
-        interface_deps = None,
-        deps = None):
+        deps = None,
+        implementation_deps = None):
     """Declares a private library (package-local, not installed) guarded by a
     configuration setting. When the configuration is disabled, the library is
     totally empty (but still a valid library label). This is used for helper
@@ -132,12 +136,12 @@ def drake_cc_optional_library(
         }),
         tags = ["exclude_from_package"],
         visibility = visibility,
-        interface_deps = None if interface_deps == None else select({
-            opt_in_condition: interface_deps,
-            opt_out_condition: [],
-        }),
         deps = select({
             opt_in_condition: deps or [],
+            opt_out_condition: [],
+        }),
+        implementation_deps = None if implementation_deps == None else select({
+            opt_in_condition: implementation_deps,
             opt_out_condition: [],
         }),
     )

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -398,12 +398,12 @@ drake_cc_library(
     hdrs = [
         "batch_eval.h",
     ],
-    interface_deps = [
+    deps = [
         "//common:essential",
         "//common:parallelism",
         "//systems/framework:system",
     ],
-    deps = [
+    implementation_deps = [
         "@common_robotics_utilities",
     ],
 )
@@ -446,7 +446,7 @@ drake_cc_library(
     name = "simulator",
     srcs = ["simulator.cc"],
     hdrs = ["simulator.h"],
-    interface_deps = [
+    deps = [
         ":integrator_base",
         ":simulator_config",
         ":simulator_status",
@@ -455,7 +455,7 @@ drake_cc_library(
         "//systems/framework:context",
         "//systems/framework:system",
     ],
-    deps = [
+    implementation_deps = [
         ":runge_kutta3_integrator",
         ":simulator_python_internal_header",
     ],

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -522,7 +522,7 @@ drake_cc_library(
     name = "leaf_system",
     srcs = ["leaf_system.cc"],
     hdrs = ["leaf_system.h"],
-    interface_deps = [
+    deps = [
         ":abstract_value_cloner",
         ":leaf_context",
         ":leaf_output_port",
@@ -534,7 +534,7 @@ drake_cc_library(
         "//common:essential",
         "//common:unused",
     ],
-    deps = [
+    implementation_deps = [
         ":system_symbolic_inspector",
         ":value_checker",
         "//common:pointer_cast",
@@ -611,14 +611,14 @@ drake_cc_library(
     name = "diagram",
     srcs = ["diagram.cc"],
     hdrs = ["diagram.h"],
-    interface_deps = [
+    deps = [
         ":diagram_context",
         ":diagram_output_port",
         ":system",
         "//common:default_scalars",
         "//common:essential",
     ],
-    deps = [
+    implementation_deps = [
         ":abstract_value_cloner",
         "//common:pointer_cast",
         "//common:string_container",
@@ -629,13 +629,13 @@ drake_cc_library(
     name = "diagram_builder",
     srcs = ["diagram_builder.cc"],
     hdrs = ["diagram_builder.h"],
-    interface_deps = [
+    deps = [
         ":diagram",
         "//common:default_scalars",
         "//common:essential",
         "//common:string_container",
     ],
-    deps = [
+    implementation_deps = [
         "//common:pointer_cast",
     ],
 )
@@ -666,11 +666,11 @@ drake_cc_library(
     name = "system_symbolic_inspector",
     srcs = ["system_symbolic_inspector.cc"],
     hdrs = ["system_symbolic_inspector.h"],
-    interface_deps = [
-        "//common/symbolic:expression",
-        ":system",
-    ],
     deps = [
+        ":system",
+        "//common/symbolic:expression",
+    ],
+    implementation_deps = [
         "//common/symbolic:polynomial",
     ],
 )

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -49,12 +49,12 @@ drake_cc_library(
     name = "lcm_publisher_system",
     srcs = ["lcm_publisher_system.cc"],
     hdrs = ["lcm_publisher_system.h"],
-    interface_deps = [
+    deps = [
         ":serializer",
         "//lcm:interface",
         "//systems/framework:leaf_system",
     ],
-    deps = [
+    implementation_deps = [
         ":lcm_system_graphviz",
         "//lcm:drake_lcm",
     ],
@@ -77,12 +77,12 @@ drake_cc_library(
     name = "lcm_subscriber_system",
     srcs = ["lcm_subscriber_system.cc"],
     hdrs = ["lcm_subscriber_system.h"],
-    interface_deps = [
+    deps = [
         ":serializer",
         "//lcm:interface",
         "//systems/framework:leaf_system",
     ],
-    deps = [
+    implementation_deps = [
         ":lcm_system_graphviz",
         "//lcm:drake_lcm",
     ],
@@ -92,11 +92,11 @@ drake_cc_library(
     name = "lcm_interface_system",
     srcs = ["lcm_interface_system.cc"],
     hdrs = ["lcm_interface_system.h"],
-    interface_deps = [
+    deps = [
         "//lcm:drake_lcm_params",
         "//systems/framework:leaf_system",
     ],
-    deps = [
+    implementation_deps = [
         ":lcm_system_graphviz",
         "//lcm:drake_lcm",
     ],
@@ -140,13 +140,13 @@ drake_cc_library(
     name = "lcm_config_functions",
     srcs = ["lcm_config_functions.cc"],
     hdrs = ["lcm_config_functions.h"],
-    interface_deps = [
+    deps = [
         ":lcm_buses",
         ":lcm_interface_system",
         "//lcm:drake_lcm_params",
         "//systems/framework:diagram_builder",
     ],
-    deps = [
+    implementation_deps = [
         "//lcm:drake_lcm",
         "//systems/primitives:shared_pointer_system",
     ],

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -60,11 +60,11 @@ drake_cc_library(
     name = "affine_system",
     srcs = ["affine_system.cc"],
     hdrs = ["affine_system.h"],
-    interface_deps = [
+    deps = [
         "//common/symbolic:expression",
         "//systems/framework",
     ],
-    deps = [
+    implementation_deps = [
         "//common/symbolic:polynomial",
     ],
 )
@@ -176,12 +176,12 @@ drake_cc_library(
     name = "linear_system",
     srcs = ["linear_system.cc"],
     hdrs = ["linear_system.h"],
-    interface_deps = [
+    deps = [
         ":affine_system",
         "//common:essential",
         "//common/symbolic:expression",
     ],
-    deps = [
+    implementation_deps = [
         ":linear_system_internal",
         "//common/symbolic:polynomial",
         "//math:autodiff",
@@ -196,10 +196,9 @@ drake_cc_library(
     hdrs = ["linear_system_internal.h"],
     internal = True,
     visibility = ["//:__subpackages__"],
-    interface_deps = [
+    deps = [
         "//common:essential",
     ],
-    deps = [],
 )
 
 drake_cc_library(

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -102,7 +102,7 @@ drake_cc_library(
     name = "camera_config_functions",
     srcs = ["camera_config_functions.cc"],
     hdrs = ["camera_config_functions.h"],
-    interface_deps = [
+    deps = [
         ":camera_config",
         "//geometry:scene_graph",
         "//lcm:interface",
@@ -110,7 +110,7 @@ drake_cc_library(
         "//systems/framework:diagram_builder",
         "//systems/lcm:lcm_buses",
     ],
-    deps = [
+    implementation_deps = [
         ":camera_info",
         ":rgbd_sensor",
         ":rgbd_sensor_async",
@@ -191,14 +191,14 @@ drake_cc_library(
     install_hdrs_exclude = [
         "image_io_internal.h",
     ],
-    interface_deps = [
+    deps = [
         ":image",
         ":image_file_format",
         "//common:diagnostic_policy",
         "//common:essential",
         "//common:name_value",
     ],
-    deps = [
+    implementation_deps = [
         ":vtk_diagnostic_event_observer",
         ":vtk_image_reader_writer",
         "//common:drake_export",
@@ -247,12 +247,12 @@ drake_cc_library(
     hdrs = [
         "lcm_image_array_to_images.h",
     ],
-    interface_deps = [
+    deps = [
         ":image",
         "//common:essential",
         "//systems/framework:leaf_system",
     ],
-    deps = [
+    implementation_deps = [
         ":lcm_image_traits",
         ":vtk_image_reader_writer",
         "//lcmtypes:image_array",
@@ -326,12 +326,12 @@ drake_cc_library(
     name = "image_writer",
     srcs = ["image_writer.cc"],
     hdrs = ["image_writer.h"],
-    interface_deps = [
+    deps = [
         ":image",
         "//common:essential",
         "//systems/framework:leaf_system",
     ],
-    deps = [
+    implementation_deps = [
         ":image_io",
     ],
 )

--- a/tools/install/libdrake/header_lint.bzl
+++ b/tools/install/libdrake/header_lint.bzl
@@ -58,11 +58,11 @@ def _cc_check_allowed_headers_impl(ctx):
         error_messages = [
             "Dependency pollution has leaked into Drake's public headers:",
         ] + [
-            " {} is not allowed in interface_deps".format(item)
+            " {} is not allowed in deps".format(item)
             for item in depset(failures).to_list()
         ] + [
             "To resolve this problem, alter your drake_cc_library to either:",
-            " split up 'interface_deps = [...]' vs 'deps = [...]', or",
+            " split up 'deps = [...]' vs 'implementation_deps = [...]', or",
             " use 'internal = True'.",
             "Check the drake_cc_library documentation for details, or",
             " ask for help on drakedevelopers#build slack.",

--- a/tools/lint/buildifier-tables.json
+++ b/tools/lint/buildifier-tables.json
@@ -5,11 +5,17 @@
     "See": "https://github.com/bazelbuild/buildtools/blob/master/tables/tables.go"
   },
   "IsLabelArg": {
+    "implementation_deps": true,
+    "implementation_deps_always": true,
+    "implementation_deps_enabled": true
   },
   "LabelBlacklist": {
   },
   "IsSortableListArg": {
-    "allowed_externals": true
+    "allowed_externals": true,
+    "implementation_deps": true,
+    "implementation_deps_always": true,
+    "implementation_deps_enabled": true
   },
   "SortableWhitelist": {
     "install.data": true,
@@ -19,7 +25,11 @@
     "install_files.files": true
   },
   "NamePriority": {
-    "drake_cc_library.interface_deps": 3,
+    "drake_cc_library.implementation_deps": 5,
+    "drake_cc_library_linux_only.implementation_deps": 5,
+    "drake_cc_optional_library.implementation_deps": 5,
+    "drake_cc_variant_library.implementation_deps_always": 5,
+    "drake_cc_variant_library.implementation_deps_enabled": 5,
 
     "drake_cc_optional_library.opt_in_condition": -96,
     "drake_cc_optional_library.opt_out_condition": -96,
@@ -30,7 +40,6 @@
     "drake_cc_variant_library.srcs_always": -92,
     "drake_cc_variant_library.srcs_enabled": -91,
     "drake_cc_variant_library.srcs_disabled": -90,
-    "drake_cc_variant_library.interface_deps": 3,
     "drake_cc_variant_library.deps_always": 4,
     "drake_cc_variant_library.deps_enabled": 4,
 

--- a/visualization/BUILD.bazel
+++ b/visualization/BUILD.bazel
@@ -97,7 +97,7 @@ drake_cc_library(
     name = "visualization_config_functions",
     srcs = ["visualization_config_functions.cc"],
     hdrs = ["visualization_config_functions.h"],
-    interface_deps = [
+    deps = [
         ":visualization_config",
         "//geometry:drake_visualizer_params",
         "//geometry:scene_graph",
@@ -106,7 +106,7 @@ drake_cc_library(
         "//systems/framework:diagram_builder",
         "//systems/lcm:lcm_buses",
     ],
-    deps = [
+    implementation_deps = [
         ":inertia_visualizer",
         "//geometry:drake_visualizer",
         "//multibody/meshcat:contact_visualizer",


### PR DESCRIPTION
At some point Bazel said that interface_deps vs deps was going to be the way and the light for cc_library in the future, and then later they changed their mind. As of today, deps are the interface deps and implementation_deps are the implementation deps. Rewrite all of our BUILD files and macros to match the new spelling.

Update buildifier hints for better precision.

(See https://bazel.build/reference/be/c-cpp#cc_library.implementation_deps.)

This is one of a few prerequisite PRs to eventually make #21605 palatable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21701)
<!-- Reviewable:end -->
