### PR TITLE
[planning] Remove duplicate sort from SceneGraphCollisionChecker

### DIFF
--- a/planning/scene_graph_collision_checker.cc
+++ b/planning/scene_graph_collision_checker.cc
@@ -1,6 +1,5 @@
 #include "drake/planning/scene_graph_collision_checker.h"
 
-#include <algorithm>
 #include <functional>
 #include <set>
 #include <utility>
@@ -173,14 +172,9 @@ RobotClearance SceneGraphCollisionChecker::DoCalcContextRobotClearance(
   // Compute the (sorted) list of SceneGraph distances.
   const double max_influence_distance =
       influence_distance + GetLargestPadding();
-  std::vector<SignedDistancePair<double>> signed_distance_pairs =
+  const std::vector<SignedDistancePair<double>> signed_distance_pairs =
       query_object.ComputeSignedDistancePairwiseClosestPoints(
           max_influence_distance);
-  std::sort(signed_distance_pairs.begin(), signed_distance_pairs.end(),
-            [](const auto& item0, const auto& item1) {
-              return (item0.id_A < item1.id_A) ||
-                     ((item0.id_A == item1.id_A) && (item0.id_B < item1.id_B));
-            });
 
   // For each signed distance pair we're computing ϕ and
   // ∂ϕ/∂qᵣ = ∂ϕ/∂p_BAᵀ⋅∂p_BA/∂qᵣ (as documented in RobotClearance). In this


### PR DESCRIPTION
Following #21698, the existing sort in `SceneGraphCollisionChecker` is no longer required.

+@hongkai-dai for review, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21702)
<!-- Reviewable:end -->
