### PR TITLE
Enhance documentation and tests for center of mass functions; clarify relationship to forward dynamics

### DIFF
--- a/multibody/plant/test/multibody_plant_com_test.cc
+++ b/multibody/plant/test/multibody_plant_com_test.cc
@@ -30,6 +30,22 @@ GTEST_TEST(EmptyMultibodyPlantCenterOfMassTest, CalcCenterOfMassPosition) {
       plant.CalcCenterOfMassTranslationalVelocityInWorld(*context_),
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): This MultibodyPlant "
       "only contains the world_body\\(\\) so its center of mass is undefined.");
+
+  const Frame<double>& frame_W = plant.world_frame();
+  Eigen::MatrixXd Js_v_WScm_W(3, plant.num_velocities());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.CalcJacobianCenterOfMassTranslationalVelocity(
+          *context_, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WScm_W),
+      "CalcJacobianCenterOfMassTranslationalVelocity\\(\\): "
+      "This MultibodyPlant only contains the world_body\\(\\) so "
+      "its center of mass is undefined.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.CalcBiasCenterOfMassTranslationalAcceleration(
+          *context_, JacobianWrtVariable::kV, frame_W, frame_W),
+      "CalcBiasCenterOfMassTranslationalAcceleration\\(\\): "
+      "This MultibodyPlant only contains the world_body\\(\\) so "
+      "its center of mass is undefined.");
 }
 
 class MultibodyPlantCenterOfMassTest : public ::testing::Test {

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -3059,8 +3059,8 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   DRAKE_THROW_UNLESS(Js_v_ACcm_E->cols() == num_columns);
   if (num_bodies() <= 1) {
     throw std::runtime_error(
-        "CalcJacobianCenterOfMassTranslationalVelocity(): this "
-        "MultibodyPlant contains only world_body() so its center of mass "
+        "CalcJacobianCenterOfMassTranslationalVelocity(): This "
+        "MultibodyPlant only contains the world_body() so its center of mass "
         "is undefined.");
   }
 
@@ -3174,8 +3174,8 @@ MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
 
   if (num_bodies() <= 1) {
     throw std::runtime_error(
-        "CalcBiasCenterOfMassTranslationalAcceleration(): this "
-        "MultibodyPlant contains only world_body() so its center of mass "
+        "CalcBiasCenterOfMassTranslationalAcceleration(): This "
+        "MultibodyPlant only contains the world_body() so its center of mass "
         "is undefined.");
   }
 

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -514,6 +514,9 @@ class RigidBody : public MultibodyElement<T> {
   /// @param[in] context The context contains the state of the model.
   /// @retval a_WBcm_W The translational acceleration of Bcm (this rigid body's
   /// center of mass) in the world frame W, expressed in W.
+  /// @note When cached values are out of sync with the state stored in context,
+  /// this method performs an expensive forward dynamics computation, whereas
+  /// once evaluated, successive calls to this method are inexpensive.
   Vector3<T> CalcCenterOfMassTranslationalAccelerationInWorld(
       const systems::Context<T>& context) const;
 


### PR DESCRIPTION
Work to enhance documentation and tests after PR #21599 recently merged.
Note: PR #21599 is work towards issue #14269.

This PR has the following.
1.  Better comments before each TEST_F function in multibody_plant_kinematics_test.cc
2.  Remove antiquated TODO(Mitiguy) commented-out block of code.
3.  Fix varios typos.

4.  Improve exception messages for the center of mass functions MultibodyPlant::CalcJacobianCenterOfMassTranslationalVelocity() and 
MultibodyPlant::CalcBiasCenterOfMassTranslationalAcceleration() so they match similar exceptions messages in other center of mass functions.  Adds tests for those two exceptions messages (these tests were missing).

5. Most importantly, added the following comment in rigidy_body.h to 
RigidBody:: CalcCenterOfMassTranslationalAccelerationInWorld()
  /// @note When cached values are out of sync with the state stored in context,
  /// this method performs an expensive forward dynamics computation, whereas
  /// once evaluated, successive calls to this method are inexpensive.

It is important to realize that calling MultibodyPlant::CalcSpatialAccelerationsFromVdot() does affect the results of 
RigidBody:: CalcCenterOfMassTranslationalAccelerationInWorld(),
as that calculation is always associated with a forward dynamics analysis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21703)
<!-- Reviewable:end -->
