### PR TITLE
[systems] Fix VectorSystem terrible computational performance

### DIFF
--- a/bindings/pydrake/multibody/jupyter_widgets.py
+++ b/bindings/pydrake/multibody/jupyter_widgets.py
@@ -49,7 +49,8 @@ class JointSliders(VectorSystem):
             update_period_sec: Specifies how often the window update() method
                          gets called.
         """
-        VectorSystem.__init__(self, 0, robot.num_positions())
+        VectorSystem.__init__(self, 0, robot.num_positions(),
+                              direct_feedthrough=False)
 
         # The widgets themselves have undeclared state.  For now, we accept it,
         # and simply disable caching on the output port.

--- a/bindings/pydrake/systems/test/_resample_log_interp1d_test.py
+++ b/bindings/pydrake/systems/test/_resample_log_interp1d_test.py
@@ -14,7 +14,8 @@ class SimpleContinuousTimeSystem(VectorSystem):
         self.output_size = 1
         VectorSystem.__init__(self,
                               0,                 # Zero inputs.
-                              self.output_size)  # One output.
+                              self.output_size,  # One output.
+                              False)             # No direct feedthrough.
         self.DeclareContinuousState(1)           # One state variable.
 
     # xdot(t) = -x(t) + x^3(t)
@@ -31,7 +32,8 @@ class MultiDimensionalTimeSystem(VectorSystem):
         self.output_size = 3
         VectorSystem.__init__(self,
                               0,                 # Zero inputs.
-                              self.output_size)  # One output.
+                              self.output_size,  # One output.
+                              False)             # No direct feedthrough.
         self.DeclareContinuousState(1)           # One state variable.
 
     # dx/dt = 2 * t -> x(t) = t^2 + const.

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.value import Value
 from pydrake.symbolic import Expression
 from pydrake.systems.analysis import (
@@ -98,7 +99,7 @@ class CustomVectorSystem(VectorSystem):
         # VectorSystem only supports pure Continuous or pure Discrete.
         # Dimensions:
         #   1 Input, 2 States, 3 Outputs.
-        VectorSystem.__init__(self, 1, 3)
+        VectorSystem.__init__(self, 1, 3, direct_feedthrough=True)
         self._is_discrete = is_discrete
         if self._is_discrete:
             self.DeclareDiscreteState(2)
@@ -121,6 +122,12 @@ class CustomVectorSystem(VectorSystem):
         self.ValidateContext(context)
         x_n[:] = x + 2*u
         self.has_called.append("discrete")
+
+
+# Remove 2024-11-01.
+class VectorSystemDeprecated(VectorSystem):
+    def __init__(self):
+        VectorSystem.__init__(self, 0, 0)
 
 
 # Wraps `Adder`.
@@ -734,6 +741,11 @@ class TestCustom(unittest.TestCase):
         xa_index = dut.DeclareAbstractState(Value(1))
         xa_port = dut.DeclareStateOutputPort(name="xa", state_index=xa_index)
         self.assertEqual(xa_port.get_name(), "xa")
+
+    def test_vector_system_deprecated(self):
+        # Remove 2024-11-01.
+        with catch_drake_warnings(expected_count=1):
+            VectorSystemDeprecated()
 
     def test_vector_system_overrides(self):
         dt = 0.5

--- a/bindings/pydrake/systems/test/pyplot_visualizer_test.py
+++ b/bindings/pydrake/systems/test/pyplot_visualizer_test.py
@@ -57,7 +57,8 @@ class SimpleContinuousTimeSystem(VectorSystem):
     def __init__(self):
         VectorSystem.__init__(self,
                               0,        # Zero inputs.
-                              1)        # One output.
+                              1,        # One output.
+                              False)    # No direct feedthrough.
         self.DeclareContinuousState(1)  # One state variable.
 
     # xdot(t) = -x(t) + x^3(t)

--- a/examples/cubic_polynomial/backward_reachability.cc
+++ b/examples/cubic_polynomial/backward_reachability.cc
@@ -40,8 +40,9 @@ using BoundingBox = std::pair<Bound, Bound>;
 template <typename T>
 class CubicSystem : public systems::VectorSystem<T> {
  public:
-  CubicSystem() : systems::VectorSystem<T>(0, 0) {
-    // 0 inputs, 0 outputs, 1 continuous state.
+  CubicSystem()
+      // Zero inputs, zero outputs, no feedthrough, 1 continuous state.
+      : systems::VectorSystem<T>(0, 0, false) {
     this->DeclareContinuousState(1);
   }
 

--- a/examples/cubic_polynomial/region_of_attraction.cc
+++ b/examples/cubic_polynomial/region_of_attraction.cc
@@ -35,8 +35,9 @@ template <typename T>
 class CubicPolynomialSystem : public systems::VectorSystem<T> {
  public:
   CubicPolynomialSystem()
-      : systems::VectorSystem<T>(0, 0) {  // Zero inputs, zero outputs.
-    this->DeclareContinuousState(1);      // One state variable.
+      // Zero inputs, zero outputs, no feedthrough.
+      : systems::VectorSystem<T>(0, 0, false) {
+    this->DeclareContinuousState(1);  // One state variable.
   }
 
  private:

--- a/manipulation/schunk_wsg/schunk_wsg_constants.h
+++ b/manipulation/schunk_wsg/schunk_wsg_constants.h
@@ -76,7 +76,8 @@ class MultibodyForceToWsgForceSystem : public systems::VectorSystem<T> {
  public:
   MultibodyForceToWsgForceSystem()
       : systems::VectorSystem<T>(
-            systems::SystemTypeTag<MultibodyForceToWsgForceSystem>{}, 2, 1) {}
+            systems::SystemTypeTag<MultibodyForceToWsgForceSystem>{}, 2, 1,
+            /* direct_feedthrough = */ true) {}
 
   // Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>

--- a/systems/analysis/test/lyapunov_test.cc
+++ b/systems/analysis/test/lyapunov_test.cc
@@ -21,8 +21,9 @@ using symbolic::Expression;
 class CubicPolynomialSystem : public systems::VectorSystem<double> {
  public:
   CubicPolynomialSystem()
-      : systems::VectorSystem<double>(0, 0) {  // Zero inputs, zero outputs.
-    this->DeclareContinuousState(1);           // One state variable.
+      // Zero inputs, zero outputs, no feedthrough, one state variable.
+      : systems::VectorSystem<double>(0, 0, false) {
+    this->DeclareContinuousState(1);
   }
 
  private:

--- a/systems/analysis/test/monte_carlo_test.cc
+++ b/systems/analysis/test/monte_carlo_test.cc
@@ -86,7 +86,11 @@ GTEST_TEST(RandomSimulationTest, WithRandomSimulator) {
 // SetRandomState().
 class RandomContextSystem : public VectorSystem<double> {
  public:
-  RandomContextSystem() : VectorSystem(0, 1) { this->DeclareDiscreteState(1); }
+  RandomContextSystem()
+      : VectorSystem(0, 1,
+                     /* direct_feedthrough = */ false) {
+    this->DeclareDiscreteState(1);
+  }
 
  private:
   void SetRandomState(const Context<double>& context, State<double>* state,
@@ -199,7 +203,9 @@ GTEST_TEST(MonteCarloSimulationTest, BasicTest) {
 // throws.
 class ThrowingRandomContextSystem : public VectorSystem<double> {
  public:
-  ThrowingRandomContextSystem() : VectorSystem(0, 1) {
+  ThrowingRandomContextSystem()
+      : VectorSystem(0, 1,
+                     /* direct_feedthrough = */ false) {
     this->DeclareDiscreteState(1);
   }
 

--- a/systems/framework/test/thread_sanitizer_test.cc
+++ b/systems/framework/test/thread_sanitizer_test.cc
@@ -20,7 +20,7 @@ namespace {
 // Simple system to use in thread-safety testing.
 class TestVectorSystem : public VectorSystem<double> {
  public:
-  TestVectorSystem() : VectorSystem(0, 1) {
+  TestVectorSystem() : VectorSystem(0, 1, /* direct_feedthrough = */ false) {
     // Discrete state is initialized to zero.
     this->DeclareDiscreteState(1);
   }

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -9,6 +9,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/never_destroyed.h"
@@ -50,7 +51,7 @@ class VectorSystem : public LeafSystem<T> {
   ///
   /// The `direct_feedthrough` specifies whether the input port direct feeds
   /// through to the output port.  (See SystemBase::GetDirectFeedthroughs().)
-  /// When not provided, assumes true (the output is direct feedthrough).
+  /// When nullopt, assumes true (the output is direct feedthrough).
   /// When false, the DoCalcVectorOutput `input` will be empty (zero-sized).
   ///
   /// Does *not* declare scalar-type conversion support (AutoDiff, etc.).  To
@@ -58,9 +59,9 @@ class VectorSystem : public LeafSystem<T> {
   /// (For that, see @ref system_scalar_conversion at the example titled
   /// "Example using drake::systems::VectorSystem as the base class".)
   VectorSystem(int input_size, int output_size,
-               std::optional<bool> direct_feedthrough = std::nullopt)
+               std::optional<bool> direct_feedthrough)
       : VectorSystem(SystemScalarConverter{}, input_size, output_size,
-                     direct_feedthrough) {}
+                     direct_feedthrough.value_or(true)) {}
 
   /// Creates a system with one input port and one output port of the given
   /// sizes, when the sizes are non-zero.  Either size can be zero, in which
@@ -69,7 +70,7 @@ class VectorSystem : public LeafSystem<T> {
   ///
   /// The `direct_feedthrough` specifies whether the input port direct feeds
   /// through to the output port.  (See SystemBase::GetDirectFeedthroughs().)
-  /// When not provided, infers feedthrough from the symbolic form if
+  /// When nullopt, infers feedthrough from the symbolic form if
   /// available, or else assumes true (the output is direct feedthrough).
   /// When false, the DoCalcVectorOutput `input` will be empty (zero-sized).
   ///
@@ -81,8 +82,9 @@ class VectorSystem : public LeafSystem<T> {
   /// related to scalar-type conversion support, especially the example titled
   /// "Example using drake::systems::VectorSystem as the base class".
   VectorSystem(SystemScalarConverter converter, int input_size, int output_size,
-               std::optional<bool> direct_feedthrough = std::nullopt)
-      : LeafSystem<T>(std::move(converter)) {
+               std::optional<bool> direct_feedthrough)
+    : LeafSystem<T>(std::move(converter)),
+      direct_feedthrough_(direct_feedthrough) {
     if (input_size > 0) {
       this->DeclareInputPort(kUseDefaultName, kVectorValued, input_size);
     }
@@ -109,6 +111,21 @@ class VectorSystem : public LeafSystem<T> {
     this->DeclareForcedDiscreteUpdateEvent(
         &VectorSystem<T>::CalcDiscreteUpdate);
   }
+
+  DRAKE_DEPRECATED("2024-11-01",
+                   "The direct_feedthrough argument is now required.")
+  VectorSystem(int input_size, int output_size)
+      : VectorSystem(input_size, output_size, std::nullopt) {}
+
+  DRAKE_DEPRECATED(
+      "2024-11-01",
+      "The direct_feedthrough argument is now required. "
+      "To match the prior default, pass std::nullopt but beware that inferring "
+      "feedthrough from symbolic form is incredibly computationally expensive "
+      "and should generally be avoided.")
+  VectorSystem(SystemScalarConverter converter, int input_size, int output_size)
+      : VectorSystem(std::move(converter), input_size, output_size,
+                     std::nullopt) {}
 
   /// Causes the vector-valued input port to become up-to-date, and returns
   /// the port's value as an %Eigen vector.  If the system has zero inputs,
@@ -212,6 +229,8 @@ class VectorSystem : public LeafSystem<T> {
           (context.MaybeGetFixedInputPortValue(0) != nullptr);
       if (is_symbolic && is_fixed_input) {
         should_eval_input = true;
+      } else if (direct_feedthrough_.has_value()) {
+        should_eval_input = direct_feedthrough_.value();
       } else {
         should_eval_input = this->HasAnyDirectFeedthrough();
       }
@@ -333,6 +352,8 @@ class VectorSystem : public LeafSystem<T> {
   // DoCalcVectorDiscreteVariableUpdates().
   EventStatus CalcDiscreteUpdate(const Context<T>& context,
                                  DiscreteValues<T>* discrete_state) const;
+
+  const std::optional<bool> direct_feedthrough_;
 };
 
 }  // namespace systems

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -512,6 +512,7 @@ drake_cc_googletest(
     deps = [
         ":first_order_low_pass_filter",
         "//common:unused",
+        "//common/test_utilities:limit_malloc",
         "//systems/framework",
         "//systems/framework/test_utilities",
     ],

--- a/systems/primitives/barycentric_system.cc
+++ b/systems/primitives/barycentric_system.cc
@@ -12,7 +12,8 @@ template <typename T>
 BarycentricMeshSystem<T>::BarycentricMeshSystem(
     math::BarycentricMesh<T> mesh,
     const Eigen::Ref<const MatrixX<T>>& output_values)
-    : VectorSystem<T>(mesh.get_input_size(), output_values.rows()),
+    : VectorSystem<T>(mesh.get_input_size(), output_values.rows(),
+                      /* direct_feedthrough = */ true),
       mesh_(std::move(mesh)),
       output_values_(output_values) {
   DRAKE_DEMAND(output_values_.rows() > 0);

--- a/systems/primitives/first_order_low_pass_filter.cc
+++ b/systems/primitives/first_order_low_pass_filter.cc
@@ -19,7 +19,8 @@ template <typename T>
 FirstOrderLowPassFilter<T>::FirstOrderLowPassFilter(
     const VectorX<double>& time_constants)
     : VectorSystem<T>(SystemTypeTag<FirstOrderLowPassFilter>{},
-                      time_constants.size(), time_constants.size()),
+                      time_constants.size(), time_constants.size(),
+                      /* direct_feedthrough = */ false),
       time_constants_(time_constants) {
   DRAKE_DEMAND(time_constants.size() > 0);
   DRAKE_DEMAND((time_constants.array() > 0).all());

--- a/systems/primitives/gain.cc
+++ b/systems/primitives/gain.cc
@@ -13,7 +13,9 @@ Gain<T>::Gain(double k, int size) : Gain(Eigen::VectorXd::Ones(size) * k) {}
 
 template <typename T>
 Gain<T>::Gain(const Eigen::VectorXd& k)
-    : VectorSystem<T>(SystemTypeTag<Gain>{}, k.size(), k.size()), k_(k) {}
+    : VectorSystem<T>(SystemTypeTag<Gain>{}, k.size(), k.size(),
+                      /* direct_feedthrough = */ true),
+      k_(k) {}
 
 template <typename T>
 template <typename U>

--- a/systems/primitives/integrator.cc
+++ b/systems/primitives/integrator.cc
@@ -9,7 +9,8 @@ namespace systems {
 
 template <typename T>
 Integrator<T>::Integrator(int size)
-    : VectorSystem<T>(SystemTypeTag<Integrator>{}, size, size) {
+    : VectorSystem<T>(SystemTypeTag<Integrator>{}, size, size,
+                      /* direct_feedthrough = */ false) {
   this->DeclareContinuousState(size);
 }
 

--- a/systems/primitives/test/first_order_low_pass_filter_test.cc
+++ b/systems/primitives/test/first_order_low_pass_filter_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/limit_malloc.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
@@ -79,6 +80,14 @@ TEST_F(FirstOrderLowPassFilterTest, Output) {
   continuous_state().get_mutable_vector().SetAtIndex(1, 42.0);
   expected << 0.0, 42.0, 0.0;
   EXPECT_EQ(expected, filter_->get_output_port().Eval(*context_));
+}
+
+// Computing the output doesn't thrash the heap.
+TEST_F(FirstOrderLowPassFilterTest, OutputPerformance) {
+  SetUpSingleTimeConstantFilter();
+
+  drake::test::LimitMalloc guard({.max_num_allocations = 0});
+  filter_->get_output_port().Eval(*context_);
 }
 
 // Verifies the correctness of the time derivatives implementation.

--- a/systems/sensors/rotary_encoders.cc
+++ b/systems/sensors/rotary_encoders.cc
@@ -42,7 +42,8 @@ RotaryEncoders<T>::RotaryEncoders(int input_port_size,
                                   const std::vector<int>& input_vector_indices,
                                   const std::vector<int>& ticks_per_revolution)
     : VectorSystem<T>(SystemTypeTag<RotaryEncoders>{}, input_port_size,
-                      input_vector_indices.size() /* output_port_size */),
+                      /* output_port_size = */ input_vector_indices.size(),
+                      /* direct_feedthrough = */ true),
       num_encoders_(input_vector_indices.size()),
       indices_(input_vector_indices),
       ticks_per_revolution_(ticks_per_revolution) {


### PR DESCRIPTION
Output ports were performing scalar conversion during inner loops.  This showed up as a hot spot in our simulations.  This is embarassing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21707)
<!-- Reviewable:end -->
