### PR TITLE
Create MultibodyPlant::CalcCenterOfMassTranslationalAccelerationInWorld().

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3558,7 +3558,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if mₛ ≤ 0, where mₛ is the mass of system S.
   /// @note The world_body() is ignored.  a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where
   /// mₛ = ∑ mᵢ is the mass of system S, mᵢ is the mass of the iᵗʰ body in
-  /// in model_instances, and aᵢ is the translational acceleration of Bᵢcm in
+  /// model_instances, and aᵢ is the translational acceleration of Bᵢcm in
   /// world W expressed in W (Bᵢcm is the center of mass of the iᵗʰ body).
   /// @note When cached values are out of sync with the state stored in context,
   /// this method performs an expensive forward dynamics computation, whereas

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3521,11 +3521,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
         context);
   }
 
-  /// Calculates the system's center of mass translational acceleration in the
-  /// world frame W.
+  /// For the system S contained in this %MultibodyPlant, calculates Scm's
+  /// translational acceleration in the world frame W expressed in W, where
+  /// Scm is the center of mass of S.
   /// @param[in] context The context contains the state of the model.
-  /// @retval a_WScm_W Scm's translational acceleration in world W, expressed in
-  /// W, where Scm is the center of mass of the system S stored by `this` plant.
+  /// @retval a_WScm_W Scm translational acceleration in world W expressed in W.
   /// @throws std::exception if `this` has no body except world_body().
   /// @throws std::exception if mₛ ≤ 0, where mₛ is the mass of system S.
   /// @note The world_body() is ignored.  a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where
@@ -3542,14 +3542,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// For the system S containing the selected model instances, calculates
-  /// a_WScm_W, Scm's translational acceleration in world W expressed in W,
+  /// Scm's translational acceleration in the world frame W expressed in W,
   /// where Scm is the center of mass of S.
   /// @param[in] context The context contains the state of the model.
   /// @param[in] model_instances Vector of selected model instances.  If a model
   /// instance is repeated in the vector (unusual), it is only counted once.
-  /// @retval a_WScm_W Scm's translational acceleration in the world frame W,
-  /// expressed in W, where Scm is the center of mass of the system S of
-  /// non-world bodies contained in model_instances.
+  /// @retval a_WScm_W Scm translational acceleration in world W expressed in W.
   /// @throws std::exception if model_instances is empty or only has world body.
   /// @throws std::exception if mₛ ≤ 0, where mₛ is the mass of system S.
   /// @note The world_body() is ignored.  a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3521,6 +3521,51 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
         context);
   }
 
+  /// Calculates the system's center of mass translational acceleration in the
+  /// world frame W.
+  /// @param[in] context The context contains the state of the model.
+  /// @retval a_WScm_W Scm's translational acceleration in world W, expressed in
+  /// W, where Scm is the center of mass of the system S stored by `this` plant.
+  /// @throws std::exception if `this` has no body except world_body().
+  /// @throws std::exception if mₛ ≤ 0, where mₛ is the mass of system S.
+  /// @note The world_body() is ignored.  a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where
+  /// mₛ = ∑ mᵢ is the mass of system S, mᵢ is the mass of the iᵗʰ body, and
+  /// aᵢ is the translational acceleration of Bcm in world W expressed in W
+  /// (Bcm is the center of mass of the iᵗʰ body).
+  /// @note When cached values are out of sync with the state stored in context,
+  /// this method performs an expensive forward dynamics computation, whereas
+  /// once evaluated, successive calls to this method are inexpensive.
+  Vector3<T> CalcCenterOfMassTranslationalAccelerationInWorld(
+      const systems::Context<T>& context) const {
+    return internal_tree().CalcCenterOfMassTranslationalAccelerationInWorld(
+        context);
+  }
+
+  /// For the system S containing the selected model instances, calculates
+  /// a_WScm_W, Scm's translational acceleration in world W expressed in W,
+  /// where Scm is the center of mass of S.
+  /// @param[in] context The context contains the state of the model.
+  /// @param[in] model_instances Vector of selected model instances.  If a model
+  /// instance is repeated in the vector (unusual), it is only counted once.
+  /// @retval a_WScm_W Scm's translational acceleration in the world frame W,
+  /// expressed in W, where Scm is the center of mass of the system S of
+  /// non-world bodies contained in model_instances.
+  /// @throws std::exception if model_instances is empty or only has world body.
+  /// @throws std::exception if mₛ ≤ 0, where mₛ is the mass of system S.
+  /// @note The world_body() is ignored.  a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where
+  /// mₛ = ∑ mᵢ is the mass of system S, mᵢ is the mass of the iᵗʰ body
+  /// contained in model_instances, and aᵢ is the translational acceleration of
+  /// Bcm in world W expressed in W (Bcm is the center of mass of the iᵗʰ body).
+  /// @note When cached values are out of sync with the state stored in context,
+  /// this method performs an expensive forward dynamics computation, whereas
+  /// once evaluated, successive calls to this method are inexpensive.
+  Vector3<T> CalcCenterOfMassTranslationalAccelerationInWorld(
+      const systems::Context<T>& context,
+      const std::vector<ModelInstanceIndex>& model_instances) const {
+    return internal_tree().CalcCenterOfMassTranslationalAccelerationInWorld(
+        context, model_instances);
+  }
+
   /// Calculates system center of mass translational velocity in world frame W.
   /// @param[in] context The context contains the state of the model.
   /// @param[in] model_instances Vector of selected model instances.  If a model

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3517,6 +3517,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// world W (Bcm is the center of mass of the iᵗʰ body).
   Vector3<T> CalcCenterOfMassTranslationalVelocityInWorld(
       const systems::Context<T>& context) const {
+    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    this->ValidateContext(context);
     return internal_tree().CalcCenterOfMassTranslationalVelocityInWorld(
         context);
   }
@@ -3525,7 +3527,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// translational acceleration in the world frame W expressed in W, where
   /// Scm is the center of mass of S.
   /// @param[in] context The context contains the state of the model.
-  /// @retval a_WScm_W Scm translational acceleration in world W expressed in W.
+  /// @retval a_WScm_W Scm's translational acceleration in the world frame W
+  /// expressed in the world frame W.
   /// @throws std::exception if `this` has no body except world_body().
   /// @throws std::exception if mₛ ≤ 0, where mₛ is the mass of system S.
   /// @note The world_body() is ignored.  a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where
@@ -3537,6 +3540,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// once evaluated, successive calls to this method are inexpensive.
   Vector3<T> CalcCenterOfMassTranslationalAccelerationInWorld(
       const systems::Context<T>& context) const {
+    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    this->ValidateContext(context);
     return internal_tree().CalcCenterOfMassTranslationalAccelerationInWorld(
         context);
   }
@@ -3547,7 +3552,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] context The context contains the state of the model.
   /// @param[in] model_instances Vector of selected model instances.  If a model
   /// instance is repeated in the vector (unusual), it is only counted once.
-  /// @retval a_WScm_W Scm translational acceleration in world W expressed in W.
+  /// @retval a_WScm_W Scm's translational acceleration in the world frame W
+  /// expressed in the world frame W.
   /// @throws std::exception if model_instances is empty or only has world body.
   /// @throws std::exception if mₛ ≤ 0, where mₛ is the mass of system S.
   /// @note The world_body() is ignored.  a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where
@@ -3560,6 +3566,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   Vector3<T> CalcCenterOfMassTranslationalAccelerationInWorld(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances) const {
+    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    this->ValidateContext(context);
     return internal_tree().CalcCenterOfMassTranslationalAccelerationInWorld(
         context, model_instances);
   }
@@ -3580,6 +3588,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   Vector3<T> CalcCenterOfMassTranslationalVelocityInWorld(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances) const {
+    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    this->ValidateContext(context);
     return internal_tree().CalcCenterOfMassTranslationalVelocityInWorld(
         context, model_instances);
   }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3455,8 +3455,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if `this` has no body except world_body().
   /// @throws std::exception if mₛ ≤ 0 (where mₛ is the mass of system S).
   /// @note The world_body() is ignored.  p_WoScm_W = ∑ (mᵢ pᵢ) / mₛ, where
-  /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body, and pᵢ is Bcm's position vector
-  /// from Wo expressed in frame W (Bcm is the center of mass of the iᵗʰ body).
+  /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body, and pᵢ is Bᵢcm's position from
+  /// Wo expressed in frame W (Bᵢcm is the center of mass of the iᵗʰ body).
   Vector3<T> CalcCenterOfMassPositionInWorld(
       const systems::Context<T>& context) const {
     this->ValidateContext(context);
@@ -3476,8 +3476,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if mₛ ≤ 0 (where mₛ is the mass of system S).
   /// @note The world_body() is ignored.  p_WoScm_W = ∑ (mᵢ pᵢ) / mₛ, where
   /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body contained in model_instances,
-  /// and pᵢ is Bcm's position vector from Wo expressed in frame W
-  /// (Bcm is the center of mass of the iᵗʰ body).
+  /// and pᵢ is Bᵢcm's position vector from Wo expressed in frame W
+  /// (Bᵢcm is the center of mass of the iᵗʰ body).
   Vector3<T> CalcCenterOfMassPositionInWorld(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances) const {
@@ -3513,8 +3513,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if `this` has no body except world_body().
   /// @throws std::exception if mₛ ≤ 0 (where mₛ is the mass of system S).
   /// @note The world_body() is ignored.  v_WScm_W = ∑ (mᵢ vᵢ) / mₛ, where
-  /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body, and vᵢ is Bcm's velocity in
-  /// world W (Bcm is the center of mass of the iᵗʰ body).
+  /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body, and vᵢ is Bᵢcm's velocity in
+  /// world W (Bᵢcm is the center of mass of the iᵗʰ body).
   Vector3<T> CalcCenterOfMassTranslationalVelocityInWorld(
       const systems::Context<T>& context) const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
@@ -3533,8 +3533,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if mₛ ≤ 0, where mₛ is the mass of system S.
   /// @note The world_body() is ignored.  a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where
   /// mₛ = ∑ mᵢ is the mass of system S, mᵢ is the mass of the iᵗʰ body, and
-  /// aᵢ is the translational acceleration of Bcm in world W expressed in W
-  /// (Bcm is the center of mass of the iᵗʰ body).
+  /// aᵢ is the translational acceleration of Bᵢcm in world W expressed in W
+  /// (Bᵢcm is the center of mass of the iᵗʰ body).
   /// @note When cached values are out of sync with the state stored in context,
   /// this method performs an expensive forward dynamics computation, whereas
   /// once evaluated, successive calls to this method are inexpensive.
@@ -3557,9 +3557,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if model_instances is empty or only has world body.
   /// @throws std::exception if mₛ ≤ 0, where mₛ is the mass of system S.
   /// @note The world_body() is ignored.  a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where
-  /// mₛ = ∑ mᵢ is the mass of system S, mᵢ is the mass of the iᵗʰ body
-  /// contained in model_instances, and aᵢ is the translational acceleration of
-  /// Bcm in world W expressed in W (Bcm is the center of mass of the iᵗʰ body).
+  /// mₛ = ∑ mᵢ is the mass of system S, mᵢ is the mass of the iᵗʰ body in
+  /// in model_instances, and aᵢ is the translational acceleration of Bᵢcm in
+  /// world W expressed in W (Bᵢcm is the center of mass of the iᵗʰ body).
   /// @note When cached values are out of sync with the state stored in context,
   /// this method performs an expensive forward dynamics computation, whereas
   /// once evaluated, successive calls to this method are inexpensive.
@@ -3583,8 +3583,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if mₛ ≤ 0 (where mₛ is the mass of system S).
   /// @note The world_body() is ignored.  v_WScm_W = ∑ (mᵢ vᵢ) / mₛ, where
   /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body contained in model_instances,
-  /// and vᵢ is Bcm's velocity in world W expressed in frame W
-  /// (Bcm is the center of mass of the iᵗʰ body).
+  /// and vᵢ is Bᵢcm's velocity in world W expressed in frame W
+  /// (Bᵢcm is the center of mass of the iᵗʰ body).
   Vector3<T> CalcCenterOfMassTranslationalVelocityInWorld(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances) const {
@@ -4382,8 +4382,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if model_instances is empty or only has world body.
   /// @note The world_body() is ignored.  J𝑠_v_ACcm_ = ∑ (mᵢ Jᵢ) / mₛ, where
   /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body contained in model_instances,
-  /// and Jᵢ is Bcm's translational velocity Jacobian in frame A, expressed in
-  /// frame E (Bcm is the center of mass of the iᵗʰ body).
+  /// and Jᵢ is Bᵢcm's translational velocity Jacobian in frame A, expressed in
+  /// frame E (Bᵢcm is the center of mass of the iᵗʰ body).
   void CalcJacobianCenterOfMassTranslationalVelocity(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances,

--- a/multibody/plant/test/multibody_plant_com_test.cc
+++ b/multibody/plant/test/multibody_plant_com_test.cc
@@ -31,6 +31,12 @@ GTEST_TEST(EmptyMultibodyPlantCenterOfMassTest, CalcCenterOfMassPosition) {
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): This MultibodyPlant "
       "only contains the world_body\\(\\) so its center of mass is undefined.");
 
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.CalcCenterOfMassTranslationalAccelerationInWorld(*context_),
+      "CalcCenterOfMassTranslationalAccelerationInWorld\\(\\): "
+      "This MultibodyPlant only contains the world_body\\(\\) so "
+      "its center of mass is undefined.");
+
   const Frame<double>& frame_W = plant.world_frame();
   Eigen::MatrixXd Js_v_WScm_W(3, plant.num_velocities());
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -143,6 +149,14 @@ class MultibodyPlantCenterOfMassTest : public ::testing::Test {
 
     const double kTolerance = 16 * std::numeric_limits<double>::epsilon();
     EXPECT_TRUE(CompareMatrices(v_WScm_W, v_WScm_W_expected, kTolerance));
+
+    // Calculate Scm's translational acceleration in frame W, expressed in W.
+    const Vector3<double> a_WScm_W =
+        plant_.CalcCenterOfMassTranslationalAccelerationInWorld(*context_);
+
+    // Verify previous calculation knowing that bodies are in free-fall.
+    const Vector3<double>& gravity = plant_.gravity_field().gravity_vector();
+    EXPECT_TRUE(CompareMatrices(a_WScm_W, gravity, kTolerance));
   }
 
  protected:
@@ -210,7 +224,7 @@ TEST_F(MultibodyPlantCenterOfMassTest, CalcTotalMass) {
   DRAKE_EXPECT_NO_THROW(plant_.CalcTotalMass(*context_, model_instances));
 }
 
-TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
+TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPositionEtc) {
   // Verify the plant's default center of mass position makes sense.
   Eigen::Vector3d p_WCcm = plant_.CalcCenterOfMassPositionInWorld(*context_);
   const math::RigidTransformd X_WS0 = math::RigidTransformd::Identity();
@@ -254,6 +268,12 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_.CalcCenterOfMassTranslationalAccelerationInWorld(*context_,
+                                                              model_instances),
+      "CalcCenterOfMassTranslationalAccelerationInWorld\\(\\): There must be "
+      "at least one non-world body contained in model_instances.");
+
   Eigen::MatrixXd Js_v_WCcm_W(3, plant_.num_velocities());
   const Frame<double>& frame_W = plant_.world_frame();
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -275,9 +295,15 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       "least one non-world body contained in model_instances.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_.CalcCenterOfMassTranslationalAccelerationInWorld(
+          *context_, world_model_instance_array),
+      "CalcCenterOfMassTranslationalAccelerationInWorld\\(\\): There must be "
+      "at least one non-world body contained in model_instances.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcJacobianCenterOfMassTranslationalVelocity(
-          *context_, model_instances, JacobianWrtVariable::kV, frame_W, frame_W,
-          &Js_v_WCcm_W),
+          *context_, world_model_instance_array, JacobianWrtVariable::kV,
+          frame_W, frame_W, &Js_v_WCcm_W),
       "CalcJacobianCenterOfMassTranslationalVelocity\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
@@ -290,9 +316,15 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       "least one non-world body contained in model_instances.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_.CalcCenterOfMassTranslationalAccelerationInWorld(
+          *context_, world_model_instance_array),
+      "CalcCenterOfMassTranslationalAccelerationInWorld\\(\\): There must be "
+      "at least one non-world body contained in model_instances.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcJacobianCenterOfMassTranslationalVelocity(
-          *context_, model_instances, JacobianWrtVariable::kV, frame_W, frame_W,
-          &Js_v_WCcm_W),
+          *context_, world_model_instance_array, JacobianWrtVariable::kV,
+          frame_W, frame_W, &Js_v_WCcm_W),
       "CalcJacobianCenterOfMassTranslationalVelocity\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
@@ -333,6 +365,12 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       "system's total mass must be greater than zero.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_.CalcCenterOfMassTranslationalAccelerationInWorld(*context_,
+                                                              model_instances),
+      "CalcCenterOfMassTranslationalAccelerationInWorld\\(\\): The "
+      "system's total mass must be greater than zero.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcJacobianCenterOfMassTranslationalVelocity(
           *context_, model_instances, JacobianWrtVariable::kV, frame_W, frame_W,
           &Js_v_WCcm_W),
@@ -358,6 +396,9 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       plant_.CalcCenterOfMassPositionInWorld(*context_, model_instances),
       std::exception);
   EXPECT_THROW(plant_.CalcCenterOfMassTranslationalVelocityInWorld(
+                   *context_, model_instances),
+               std::exception);
+  EXPECT_THROW(plant_.CalcCenterOfMassTranslationalAccelerationInWorld(
                    *context_, model_instances),
                std::exception);
   EXPECT_THROW(plant_.CalcJacobianCenterOfMassTranslationalVelocity(

--- a/multibody/plant/test/multibody_plant_com_test.cc
+++ b/multibody/plant/test/multibody_plant_com_test.cc
@@ -131,7 +131,7 @@ class MultibodyPlantCenterOfMassTest : public ::testing::Test {
     plant_.SetFreeBodySpatialVelocity(context_.get(), triangle, V_WT_W);
 
     // Denoting Scm as the center of mass of the system formed by Sphere1 and
-    // Triangle1, form Scm's translational velocity in frame W, expressed in W.
+    // Triangle1, form Scm's translational velocity in world W, expressed in W.
     const Vector3<double> v_WScm_W =
         plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_);
 
@@ -150,13 +150,15 @@ class MultibodyPlantCenterOfMassTest : public ::testing::Test {
     const double kTolerance = 16 * std::numeric_limits<double>::epsilon();
     EXPECT_TRUE(CompareMatrices(v_WScm_W, v_WScm_W_expected, kTolerance));
 
-    // Calculate Scm's translational acceleration in frame W, expressed in W.
+    // Calculate Scm's translational acceleration in world W, expressed in W.
     const Vector3<double> a_WScm_W =
         plant_.CalcCenterOfMassTranslationalAccelerationInWorld(*context_);
 
     // Verify previous calculation knowing that bodies are in free-fall.
+    // Note: kTolerance had to be changed to 8 * kTolerance to pass CI due to
+    // sole failure on mac-arm-ventura-clang-bazel-experimental-release-21710.
     const Vector3<double>& gravity = plant_.gravity_field().gravity_vector();
-    EXPECT_TRUE(CompareMatrices(a_WScm_W, gravity, kTolerance));
+    EXPECT_TRUE(CompareMatrices(a_WScm_W, gravity, 8 * kTolerance));
   }
 
  protected:

--- a/multibody/plant/test/multibody_plant_kinematics_test.cc
+++ b/multibody/plant/test/multibody_plant_kinematics_test.cc
@@ -499,6 +499,18 @@ TEST_F(TwoDOFPlanarPendulumTest, CalcCenterOfMassAccelerationForwardDynamics) {
           plant_, *context_, vdot, frame_B, p_BoBcm_B, frame_W, frame_W);
   EXPECT_TRUE(CompareMatrices(a_WBcm_W, A_WBcm_W_alternate.translational(),
                               kTolerance));
+
+  // Denoting Scm as the center of mass of the system consisting of A and B,
+  // calculate Scm's translational acceleration in world W, expressed in W.
+  const Vector3<double> a_WScm_W =
+      plant_.CalcCenterOfMassTranslationalAccelerationInWorld(*context_);
+
+  // Verify previous calculation with by-hand calculation of a_WScm_W.
+  const double mA = bodyA_->get_mass(*context_);
+  const double mB = bodyB_->get_mass(*context_);
+  const double mS = mA + mB;
+  Vector3<double> a_WScm_W_expected = (mA * a_WAcm_W + mB * a_WBcm_W) / mS;
+  EXPECT_TRUE(CompareMatrices(a_WScm_W, a_WScm_W_expected, kTolerance));
 }
 
 }  // namespace

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2339,7 +2339,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // Why? Acceleration calculations may require a dynamic analysis that will
   // issue a significantly less helpful exception message.
   // Sum over all the bodies in model_instances except the 0th body (which is
-  // the world body).
+  // the world body). Each body is counted only once even if its model instance
+  // is listed multiple times.
   T total_mass = 0;
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2088,7 +2088,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   // Reminder: Although it is not possible for a body to belong to multiple
   // model instances [as RigidBody::model_instance() returns a body's unique
   // model instance], it is possible for the same model instance to be added
-  // multiple times to std::vector<ModelInstanceIndex>& model_instances).  The
+  // multiple times to std::vector<ModelInstanceIndex>& model_instances). The
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
@@ -2244,7 +2244,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   // Reminder: Although it is not possible for a body to belong to multiple
   // model instances [as RigidBody::model_instance() returns a body's unique
   // model instance], it is possible for the same model instance to be added
-  // multiple times to std::vector<ModelInstanceIndex>& model_instances).  The
+  // multiple times to std::vector<ModelInstanceIndex>& model_instances). The
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
@@ -3221,7 +3221,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   // Reminder: Although it is not possible for a body to belong to multiple
   // model instances [as RigidBody::model_instance() returns a body's unique
   // model instance], it is possible for the same model instance to be added
-  // multiple times to std::vector<ModelInstanceIndex>& model_instances).  The
+  // multiple times to std::vector<ModelInstanceIndex>& model_instances). The
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2090,7 +2090,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   // model instance], it is possible for the same model instance to be added
   // multiple times to std::vector<ModelInstanceIndex>& model_instances).  The
   // code below ensures a body's contribution to the sum occurs only once.
-  // Duplicate model_instances in std::vector are considered a user error.
+  // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
@@ -2246,7 +2246,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   // model instance], it is possible for the same model instance to be added
   // multiple times to std::vector<ModelInstanceIndex>& model_instances).  The
   // code below ensures a body's contribution to the sum occurs only once.
-  // Duplicate model_instances in std::vector are considered a user error.
+  // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
@@ -2328,8 +2328,6 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances) const {
-  // Reminder: MultibodyTree always declares a world body and 2 model instances
-  // "world" and "default" so num_model_instances() should always be >= 2.
   if (num_bodies() <= 1) {
     std::string message = fmt::format("{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.", __func__);
@@ -2340,7 +2338,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // zero or negative, check if ∑ mᵢ ≤ 0 _before_ calculating ∑ mᵢ * aᵢ.
   // Why? Acceleration calculations may require a dynamic analysis that will
   // issue a significantly less helpful exception message.
-  // Sum over all the bodies except the 0th body (which is the world body).
+  // Sum over all the bodies in model_instances except the 0th body (which is
+  // the world body).
   T total_mass = 0;
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
@@ -2373,7 +2372,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // model instance], it is possible for the same model instance to be added
   // multiple times to std::vector<ModelInstanceIndex>& model_instances).
   // The code below ensures a body's contribution to the sum occurs only once.
-  // Duplicate model_instances in std::vector are considered a user error.
+  // Duplicate model_instances in std::vector are ignored.
   Vector3<T> sum_mi_ai = Vector3<T>::Zero();
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
@@ -3224,7 +3223,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   // model instance], it is possible for the same model instance to be added
   // multiple times to std::vector<ModelInstanceIndex>& model_instances).  The
   // code below ensures a body's contribution to the sum occurs only once.
-  // Duplicate model_instances in std::vector are considered a user error.
+  // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2283,6 +2283,129 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
 }
 
 template <typename T>
+Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
+    const systems::Context<T>& context) const {
+  if (num_bodies() <= 1) {
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
+    throw std::logic_error(message);
+  }
+
+  // To ensure a sensible exception message is issued if the system's mass is
+  // zero or negative, check if ∑ mᵢ ≤ 0 _before_ calculating ∑ mᵢ * aᵢ.
+  // Why? Acceleration calculations may require a dynamic analysis that will
+  // issue a significantly less helpful exception message.
+  // Sum over all the bodies except the 0th body (which is the world body).
+  T total_mass = 0;
+  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+    const RigidBody<T>& body = get_body(body_index);
+    const T& body_mass = body.get_mass(context);
+    total_mass += body_mass;  // total mass = ∑ mᵢ.
+  }
+
+  if (total_mass <= 0) {
+    std::string message = fmt::format(
+        "{}(): The system's total mass must "
+        "be greater than zero.",
+        __func__);
+    throw std::logic_error(message);
+  }
+
+  // Sum over all the bodies except the 0th body (which is the world body).
+  Vector3<T> sum_mi_ai = Vector3<T>::Zero();
+  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+    const RigidBody<T>& body = get_body(body_index);
+
+    // sum_mi_ai = ∑ mᵢ * ai_WBcm_W.
+    const T& body_mass = body.get_mass(context);
+    const Vector3<T> ai_WBcm_W =
+        body.CalcCenterOfMassTranslationalAccelerationInWorld(context);
+    sum_mi_ai += body_mass * ai_WBcm_W;
+  }
+
+  // For a system S with center of mass Scm, Scm's translational velocity in the
+  // world frame W is calculated as v_WScm_W = ∑ (mᵢ vᵢ)  / mₛ, where mₛ = ∑ mᵢ,
+  // mᵢ is the mass of the  iᵗʰ body, and vᵢ is Bcm's velocity in world frame W
+  // (Bcm is the center of mass of the iᵗʰ body).
+  return sum_mi_ai / total_mass;
+}
+
+template <typename T>
+Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
+    const systems::Context<T>& context,
+    const std::vector<ModelInstanceIndex>& model_instances) const {
+  // Reminder: MultibodyTree always declares a world body and 2 model instances
+  // "world" and "default" so num_model_instances() should always be >= 2.
+  if (num_bodies() <= 1) {
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
+    throw std::logic_error(message);
+  }
+
+  // To ensure a sensible exception message is issued if the system's mass is
+  // zero or negative, check if ∑ mᵢ ≤ 0 _before_ calculating ∑ mᵢ * aᵢ.
+  // Why? Acceleration calculations may require a dynamic analysis that will
+  // issue a significantly less helpful exception message.
+  // Sum over all the bodies except the 0th body (which is the world body).
+  T total_mass = 0;
+  int number_of_non_world_bodies_processed = 0;
+  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+    const RigidBody<T>& body = get_body(body_index);
+    if (std::find(model_instances.begin(), model_instances.end(),
+                  body.model_instance()) != model_instances.end()) {
+      const T& body_mass = body.get_mass(context);
+      total_mass += body_mass;  // total mass = ∑ mᵢ.
+      ++number_of_non_world_bodies_processed;
+    }
+  }
+
+  // Throw an exception if there are zero non-world bodies in model_instances.
+  if (number_of_non_world_bodies_processed == 0) {
+    std::string message = fmt::format(
+        "{}(): There must be at least one "
+        "non-world body contained in model_instances.",
+        __func__);
+    throw std::logic_error(message);
+  }
+
+  if (total_mass <= 0) {
+    std::string message = fmt::format(
+        "{}(): The system's total mass must "
+        "be greater than zero.",
+        __func__);
+    throw std::logic_error(message);
+  }
+
+  // Sum over all the bodies that are in model_instances except for the 0th body
+  // (which is the world body), and count each body's contribution only once.
+  // Reminder: Although it is not possible for a body to belong to multiple
+  // model instances [as RigidBody::model_instance() returns a body's unique
+  // model instance], it is possible for the same model instance to be added
+  // multiple times to std::vector<ModelInstanceIndex>& model_instances).
+  // The code below ensures a body's contribution to the sum occurs only once.
+  // Duplicate model_instances in std::vector are considered an upstream user
+  // error.
+  Vector3<T> sum_mi_ai = Vector3<T>::Zero();
+  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+    const RigidBody<T>& body = get_body(body_index);
+    if (std::find(model_instances.begin(), model_instances.end(),
+                  body.model_instance()) != model_instances.end()) {
+      // sum_mi_ai = ∑ mᵢ * ai_WBcm_W.
+      const T& body_mass = body.get_mass(context);
+      const Vector3<T> ai_WBcm_W =
+          body.CalcCenterOfMassTranslationalAccelerationInWorld(context);
+      sum_mi_ai += body_mass * ai_WBcm_W;
+    }
+  }
+
+  return sum_mi_ai / total_mass;
+}
+
+template <typename T>
 SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
     const systems::Context<T>& context,
     const Vector3<T>& p_WoP_W) const {

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2090,8 +2090,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   // model instance], it is possible for the same model instance to be added
   // multiple times to std::vector<ModelInstanceIndex>& model_instances).  The
   // code below ensures a body's contribution to the sum occurs only once.
-  // Duplicate model_instances in std::vector are considered an upstream user
-  // error.
+  // Duplicate model_instances in std::vector are considered a user error.
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
@@ -2247,8 +2246,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   // model instance], it is possible for the same model instance to be added
   // multiple times to std::vector<ModelInstanceIndex>& model_instances).  The
   // code below ensures a body's contribution to the sum occurs only once.
-  // Duplicate model_instances in std::vector are considered an upstream user
-  // error.
+  // Duplicate model_instances in std::vector are considered a user error.
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
@@ -2286,10 +2284,8 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
     const systems::Context<T>& context) const {
   if (num_bodies() <= 1) {
-    std::string message = fmt::format(
-        "{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.",
-        __func__);
+    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2306,10 +2302,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format(
-        "{}(): The system's total mass must "
-        "be greater than zero.",
-        __func__);
+    std::string message = fmt::format("{}(): The system's total mass must "
+                                      "be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2317,17 +2311,15 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   Vector3<T> sum_mi_ai = Vector3<T>::Zero();
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
-
-    // sum_mi_ai = ∑ mᵢ * ai_WBcm_W.
     const T& body_mass = body.get_mass(context);
     const Vector3<T> ai_WBcm_W =
         body.CalcCenterOfMassTranslationalAccelerationInWorld(context);
-    sum_mi_ai += body_mass * ai_WBcm_W;
+    sum_mi_ai += body_mass * ai_WBcm_W;  // sum_mi_ai = ∑ mᵢ * ai_WBcm_W.
   }
 
-  // For a system S with center of mass Scm, Scm's translational velocity in the
-  // world frame W is calculated as v_WScm_W = ∑ (mᵢ vᵢ)  / mₛ, where mₛ = ∑ mᵢ,
-  // mᵢ is the mass of the  iᵗʰ body, and vᵢ is Bcm's velocity in world frame W
+  // For a system S with center of mass Scm, Scm's translational acceleration in
+  // the world W is calculated as a_WScm_W = ∑ (mᵢ aᵢ) / mₛ, where mₛ = ∑ mᵢ,
+  // mᵢ is the mass of the  iᵗʰ body, and aᵢ is Bcm's acceleration in world W
   // (Bcm is the center of mass of the iᵗʰ body).
   return sum_mi_ai / total_mass;
 }
@@ -2339,10 +2331,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // Reminder: MultibodyTree always declares a world body and 2 model instances
   // "world" and "default" so num_model_instances() should always be >= 2.
   if (num_bodies() <= 1) {
-    std::string message = fmt::format(
-        "{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.",
-        __func__);
+    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2365,18 +2355,14 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
 
   // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
-    std::string message = fmt::format(
-        "{}(): There must be at least one "
-        "non-world body contained in model_instances.",
-        __func__);
+    std::string message = fmt::format("{}(): There must be at least one "
+        "non-world body contained in model_instances.", __func__);
     throw std::logic_error(message);
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format(
-        "{}(): The system's total mass must "
-        "be greater than zero.",
-        __func__);
+    std::string message = fmt::format("{}(): The system's total mass must "
+                                      "be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2387,18 +2373,16 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // model instance], it is possible for the same model instance to be added
   // multiple times to std::vector<ModelInstanceIndex>& model_instances).
   // The code below ensures a body's contribution to the sum occurs only once.
-  // Duplicate model_instances in std::vector are considered an upstream user
-  // error.
+  // Duplicate model_instances in std::vector are considered a user error.
   Vector3<T> sum_mi_ai = Vector3<T>::Zero();
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
-      // sum_mi_ai = ∑ mᵢ * ai_WBcm_W.
       const T& body_mass = body.get_mass(context);
       const Vector3<T> ai_WBcm_W =
           body.CalcCenterOfMassTranslationalAccelerationInWorld(context);
-      sum_mi_ai += body_mass * ai_WBcm_W;
+      sum_mi_ai += body_mass * ai_WBcm_W;  // sum_mi_ai = ∑ mᵢ * ai_WBcm_W.
     }
   }
 
@@ -3225,10 +3209,8 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
 
   // Reminder: MultibodyTree always declares a world body.
   if (num_bodies() <= 1) {
-    std::string message = fmt::format(
-        "{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.",
-        __func__);
+    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.", __func__);
     throw std::logic_error(message);
   }
 
@@ -3242,8 +3224,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   // model instance], it is possible for the same model instance to be added
   // multiple times to std::vector<ModelInstanceIndex>& model_instances).  The
   // code below ensures a body's contribution to the sum occurs only once.
-  // Duplicate model_instances in std::vector are considered an upstream user
-  // error.
+  // Duplicate model_instances in std::vector are considered a user error.
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
@@ -3274,7 +3255,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
     std::string message = fmt::format("{}(): There must be at least one "
-        "non-world body contained in model_instances.",  __func__);
+        "non-world body contained in model_instances.", __func__);
     throw std::logic_error(message);
   }
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1145,6 +1145,15 @@ class MultibodyTree {
       const std::vector<ModelInstanceIndex>& model_instances) const;
 
   // See MultibodyPlant method.
+  Vector3<T> CalcCenterOfMassTranslationalAccelerationInWorld(
+      const systems::Context<T>& context) const;
+
+  // See MultibodyPlant method.
+  Vector3<T> CalcCenterOfMassTranslationalAccelerationInWorld(
+      const systems::Context<T>& context,
+      const std::vector<ModelInstanceIndex>& model_instances) const;
+
+  // See MultibodyPlant method.
   SpatialMomentum<T> CalcSpatialMomentumInWorldAboutPoint(
       const systems::Context<T>& context, const Vector3<T>& p_WoP_W) const;
 


### PR DESCRIPTION
PR  #21710 create C++ code for the new function Multibody::CalcCenterOfMassTranslationalAccelerationInWorld(), which is work towards issue #14269.  

A future PR will create Python bindings for this new function along with existing C++ function Multibody::CalcCenterOfMassTranslationalVelocityInWorld() (which is missing Python bindings).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21710)
<!-- Reviewable:end -->
