### PR TITLE
Adds patch to prevent UB when running on ARM

### DIFF
--- a/multibody/math/spatial_acceleration.h
+++ b/multibody/math/spatial_acceleration.h
@@ -326,9 +326,9 @@ class SpatialAcceleration : public SpatialVector<SpatialAcceleration, T> {
 template <typename T>
 inline SpatialAcceleration<T> operator+(const SpatialAcceleration<T>& A1_E,
                                         const SpatialAcceleration<T>& A2_E) {
-  // Although this operator+() function simply calls an associated
-  // SpatialVector operator+=() function, it is needed for documentation.
-  return SpatialAcceleration<T>(A1_E) += A2_E;
+  // Although this implementation calls the base class operator, it is needed
+  // for documentation.
+  return SpatialVector<SpatialAcceleration, T>::operator+(A1_E, A2_E);
 }
 
 /// Subtracts spatial accelerations by simply subtracting their 6 underlying
@@ -342,9 +342,9 @@ inline SpatialAcceleration<T> operator+(const SpatialAcceleration<T>& A1_E,
 template <typename T>
 inline SpatialAcceleration<T> operator-(const SpatialAcceleration<T>& A1_E,
                                         const SpatialAcceleration<T>& A2_E) {
-  // Although this operator-() function simply calls an associated
-  // SpatialVector operator-=() function, it is needed for documentation.
-  return SpatialAcceleration<T>(A1_E) -= A2_E;
+  // Although this implementation calls the base class operator, it is needed
+  // for documentation.
+  return SpatialVector<SpatialAcceleration, T>::operator-(A1_E, A2_E);
 }
 
 }  // namespace multibody

--- a/multibody/math/spatial_force.h
+++ b/multibody/math/spatial_force.h
@@ -216,9 +216,9 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
 template <typename T>
 inline SpatialForce<T> operator+(const SpatialForce<T>& F1_E,
                                  const SpatialForce<T>& F2_E) {
-  // Although this operator+() function simply calls an associated
-  // SpatialVector operator+=() function, it is needed for documentation.
-  return SpatialForce<T>(F1_E) += F2_E;
+  // Although this implementation calls the base class operator, it is needed
+  // for documentation.
+  return SpatialVector<SpatialForce, T>::operator+(F1_E, F2_E);
 }
 
 /// Subtracts spatial forces by simply subtracting their 6 underlying elements.
@@ -232,9 +232,9 @@ inline SpatialForce<T> operator+(const SpatialForce<T>& F1_E,
 template <typename T>
 inline SpatialForce<T> operator-(const SpatialForce<T>& F1_E,
                                  const SpatialForce<T>& F2_E) {
-  // Although this operator-() function simply calls an associated
-  // SpatialVector operator-=() function, it is needed for documentation.
-  return SpatialForce<T>(F1_E) -= F2_E;
+  // Although this implementation calls the base class operator, it is needed
+  // for documentation.
+  return SpatialVector<SpatialForce, T>::operator-(F1_E, F2_E);
 }
 
 }  // namespace multibody

--- a/multibody/math/spatial_momentum.h
+++ b/multibody/math/spatial_momentum.h
@@ -172,9 +172,9 @@ class SpatialMomentum : public SpatialVector<SpatialMomentum, T> {
 template <typename T>
 inline SpatialMomentum<T> operator+(const SpatialMomentum<T>& L1_E,
                                     const SpatialMomentum<T>& L2_E) {
-  // Although this operator+() function simply calls an associated
-  // SpatialVector operator+=() function, it is needed for documentation.
-  return SpatialMomentum<T>(L1_E) += L2_E;
+  // Although this implementation calls the base class operator, it is needed
+  // for documentation.
+  return SpatialVector<SpatialMomentum, T>::operator+(L1_E, L2_E);
 }
 
 /// Subtracts spatial momenta by simply subtracting their 6 underlying elements.
@@ -186,9 +186,9 @@ inline SpatialMomentum<T> operator+(const SpatialMomentum<T>& L1_E,
 template <typename T>
 inline SpatialMomentum<T> operator-(const SpatialMomentum<T>& L1_E,
                                     const SpatialMomentum<T>& L2_E) {
-  // Although this operator-() function simply calls an associated
-  // SpatialVector operator-=() function, it is needed for documentation.
-  return SpatialMomentum<T>(L1_E) -= L2_E;
+  // Although this implementation calls the base class operator, it is needed
+  // for documentation.
+  return SpatialVector<SpatialMomentum, T>::operator+(L1_E, L2_E);
 }
 
 }  // namespace multibody

--- a/multibody/math/spatial_vector.h
+++ b/multibody/math/spatial_vector.h
@@ -184,7 +184,7 @@ class SpatialVector {
   /// absolute values in (this - other).
   decltype(T() < T()) IsApprox(
       const SpatialQuantity& other,
-      double tolerance = std::numeric_limits<double>::epsilon()) const {
+      double tolerance = 2 * std::numeric_limits<double>::epsilon()) const {
     return IsNearlyEqualWithinAbsoluteTolerance(other, tolerance, tolerance);
   }
 
@@ -241,7 +241,7 @@ class SpatialVector {
   /// SpatialVelocity, SpatialAcceleration, SpatialForce, or SpatialMomentum).
   friend SpatialQuantity operator+(const SpatialQuantity& V1_E,
                                    const SpatialQuantity& V2_E) {
-    return SpatialQuantity(V1_E) += V2_E;
+    return SpatialQuantity(V1_E.get_coeffs() + V2_E.get_coeffs());
   }
 
   /// Subtracts two spatial vectors by simply subtracting their 6 underlying
@@ -254,13 +254,13 @@ class SpatialVector {
   /// SpatialVelocity, SpatialAcceleration, SpatialForce, or SpatialMomentum).
   friend SpatialQuantity operator-(const SpatialQuantity& V1,
                                    const SpatialQuantity& V2) {
-    return SpatialQuantity(V1) -= V2;
+    return SpatialQuantity(V1.get_coeffs() - V2.get_coeffs());
   }
 
   /// Multiplication of a spatial vector V from the left by a scalar `s`.
   /// @relates SpatialVector.
   friend SpatialQuantity operator*(const T& s, const SpatialQuantity& V) {
-    return SpatialQuantity(V) *= s;
+    return SpatialQuantity(V.get_coeffs() * s);
   }
 
   /// Multiplication of a spatial vector V from the right by a scalar `s`.

--- a/multibody/math/spatial_vector.h
+++ b/multibody/math/spatial_vector.h
@@ -184,7 +184,7 @@ class SpatialVector {
   /// absolute values in (this - other).
   decltype(T() < T()) IsApprox(
       const SpatialQuantity& other,
-      double tolerance = 2 * std::numeric_limits<double>::epsilon()) const {
+      double tolerance = std::numeric_limits<double>::epsilon()) const {
     return IsNearlyEqualWithinAbsoluteTolerance(other, tolerance, tolerance);
   }
 

--- a/multibody/math/spatial_velocity.h
+++ b/multibody/math/spatial_velocity.h
@@ -203,9 +203,9 @@ class SpatialVelocity : public SpatialVector<SpatialVelocity, T> {
 template <typename T>
 inline SpatialVelocity<T> operator+(
     const SpatialVelocity<T>& V1_E, const SpatialVelocity<T>& V2_E) {
-  // Although this operator+() function simply calls an associated
-  // SpatialVector operator+=() function, it is needed for documentation.
-  return SpatialVelocity<T>(V1_E) += V2_E;
+  // Although this implementation calls the base class operator, it is needed
+  // for documentation.
+  return SpatialVector<SpatialVelocity, T>::operator+(V1_E, V2_E);
 }
 
 /// Subtracts spatial velocities by simply subtracting their 6 underlying
@@ -235,9 +235,9 @@ inline SpatialVelocity<T> operator+(
 template <typename T>
 inline SpatialVelocity<T> operator-(
     const SpatialVelocity<T>& V1_E, const SpatialVelocity<T>& V2_E) {
-  // Although this operator-() function simply calls an associated
-  // SpatialVector operator-=() function, it is needed for documentation.
-  return SpatialVelocity<T>(V1_E) -= V2_E;
+  // Although this implementation calls the base class operator, it is needed
+  // for documentation.
+  return SpatialVector<SpatialVelocity, T>::operator-(V1_E, V2_E);
 }
 
 template <typename T>


### PR DESCRIPTION
Addresses #21706 

Changes the implementation of some `operator<op>` in the spatial algebra package to avoid UB when the operator relies on the `operator<op>=` of the base class if running on ARM.

Additionally, relaxes the tolerance used for `IsApprox`, making the `spatial_algebra_test` pass on ARM.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21712)
<!-- Reviewable:end -->
