### PR TITLE
Relaxed tolerance on tests to pass on ARM

### DIFF
--- a/geometry/optimization/test/affine_subspace_test.cc
+++ b/geometry/optimization/test/affine_subspace_test.cc
@@ -1239,7 +1239,7 @@ GTEST_TEST(AffineSubspaceTest, EqualityTest) {
   const AffineSubspace as4(basis2, translation1);
   const AffineSubspace as5(basis2, translation2);
 
-  const double kTol = 1e-15;
+  const double kTol = 1e-14;
 
   EXPECT_TRUE(as1.IsNearlyEqualTo(as2, kTol));
   EXPECT_TRUE(as2.IsNearlyEqualTo(as3, kTol));

--- a/geometry/optimization/test/hyperrectangle_test.cc
+++ b/geometry/optimization/test/hyperrectangle_test.cc
@@ -266,8 +266,8 @@ GTEST_TEST(HyperrectangleTest,
     const Eigen::Vector3d t_value{4, 2, 0.5};
     const auto test_point =
         1 / ((c.transpose() * t_value)[0] + d) * (A * x_value + b);
-    EXPECT_TRUE(
-        CompareMatrices(test_point, 1 / 5.0 * Eigen::Vector3d(8, 2, -3)));
+    EXPECT_TRUE(CompareMatrices(test_point, 1 / 5.0 * Eigen::Vector3d(8, 2, -3),
+                                std::numeric_limits<double>::epsilon()));
     EXPECT_EQ(
         PointInScaledSet(x, t, x_value, t_value, &prog, scaled_matrix_con),
         hyperrectangle.PointInSet(test_point));

--- a/geometry/proximity/test/contact_surface_utility_test.cc
+++ b/geometry/proximity/test/contact_surface_utility_test.cc
@@ -144,7 +144,7 @@ GTEST_TEST(TriMeshBuilderTest, AddingFeatures) {
             static_cast<int>(expected_pressures.size()));
   for (int v = 0; v < mesh_M->num_vertices(); ++v) {
     ASSERT_NEAR(surf_field_M->EvaluateAtVertex(v), expected_pressures[v],
-                10 * std::numeric_limits<double>::epsilon());
+                16 * std::numeric_limits<double>::epsilon());
     // NOTE: The TriMeshBuilder doesn't currently build a field with gradients,
     // so we won't test them.
   }

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -123,7 +123,7 @@ class PointShapeAutoDiffSignedDistanceTester {
     if (grad_W_squared_norm.derivatives().size() > 0) {
       auto grad_W_unit_length_derivative_compare =
           CompareMatrices(grad_W_squared_norm.derivatives(),
-                          Eigen::VectorXd::Zero(grad_size), tolerance_);
+                          Eigen::VectorXd::Zero(grad_size), 1.4 * tolerance_);
       if (!grad_W_unit_length_derivative_compare) {
         if (error) failure << "\n";
         error = true;
@@ -168,7 +168,7 @@ class PointShapeAutoDiffSignedDistanceTester {
  private:
   const Shape& shape_;
   const RigidTransformd X_WG_;
-  const double tolerance_{std::numeric_limits<double>::epsilon()};
+  const double tolerance_{1.4 * std::numeric_limits<double>::epsilon()};
 };
 
 // Simple smoke test for signed distance to Box. It does the following:

--- a/geometry/render_gl/test/internal_shape_meshes_test.cc
+++ b/geometry/render_gl/test/internal_shape_meshes_test.cc
@@ -466,7 +466,7 @@ GTEST_TEST(PrimitiveMeshTests, MakeSquarePatch) {
     }
     const Vector3d corner = Vector3d(0.5f, 0.5f, 0.0) * kMeasure;
     EXPECT_TRUE(CompareMatrices(min_pt, -corner, kEps));
-    EXPECT_TRUE(CompareMatrices(max_pt, corner, kEps));
+    EXPECT_TRUE(CompareMatrices(max_pt, corner, 8 * kEps));
 
     const auto expected_n = Vector3d::UnitZ().transpose();
     for (int v = 0; v < mesh_data.positions.rows(); ++v) {

--- a/math/test/linear_solve_test.cc
+++ b/math/test/linear_solve_test.cc
@@ -122,7 +122,7 @@ TestSolveLinearSystem(const Eigen::MatrixBase<DerivedA>& A,
             b.template cast<typename DerivedA::Scalar>());
       }
       EXPECT_TRUE(
-          CompareMatrices(ExtractValue(x_eigen), ExtractValue(x), 1.0e-14));
+          CompareMatrices(ExtractValue(x_eigen), ExtractValue(x), 1.0e-13));
       for (int i = 0; i < b.cols(); ++i) {
         EXPECT_TRUE(CompareMatrices(ExtractGradient(x_eigen.col(i)),
                                     ExtractGradient(x.col(i)), tol));
@@ -136,7 +136,7 @@ TestSolveLinearSystem(const Eigen::MatrixBase<DerivedA>& A,
           eigen_linear_solver(A.template cast<typename DerivedB::Scalar>());
       const auto x_eigen = eigen_linear_solver.solve(b);
       EXPECT_TRUE(
-          CompareMatrices(ExtractValue(x_eigen), ExtractValue(x), 1.0e-14));
+          CompareMatrices(ExtractValue(x_eigen), ExtractValue(x), 1.0e-13));
       for (int i = 0; i < b.cols(); ++i) {
         EXPECT_TRUE(CompareMatrices(ExtractGradient(x_eigen.col(i)),
                                     ExtractGradient(x.col(i)), tol));

--- a/multibody/math/spatial_vector.h
+++ b/multibody/math/spatial_vector.h
@@ -184,7 +184,7 @@ class SpatialVector {
   /// absolute values in (this - other).
   decltype(T() < T()) IsApprox(
       const SpatialQuantity& other,
-      double tolerance = std::numeric_limits<double>::epsilon()) const {
+      double tolerance = 2 * std::numeric_limits<double>::epsilon()) const {
     return IsNearlyEqualWithinAbsoluteTolerance(other, tolerance, tolerance);
   }
 

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -277,7 +277,7 @@ GTEST_TEST(TriangleSurfaceMassPropertiesTest, ExactPolyhedron) {
     // tolerance.
     EXPECT_TRUE(SpatialInertiasEqual(
         CalcSpatialInertia(mesh, kDensity),
-        SpatialInertia<double>(mass, p_BcmMcm, G_MMo_M), 8 * kTol));
+        SpatialInertia<double>(mass, p_BcmMcm, G_MMo_M), 16 * kTol));
   }
 }
 

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -12,7 +12,7 @@ namespace drake {
 namespace multibody {
 namespace {
 
-const double kTolerance = std::numeric_limits<double>::epsilon();
+const double kTolerance = 1.8 * std::numeric_limits<double>::epsilon();
 
 using Eigen::Vector3d;
 using math::RigidTransformd;

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -381,7 +381,7 @@ GTEST_TEST(RotationalInertia, ShiftToCenterOfMass) {
   const double Iyz = I_BP_Byz + mass * yBcm*zBcm;
   const RotationalInertia<double> expected_I_BBcm_B(
       Ixx, Iyy, Izz, Ixy, Ixz, Iyz);
-  EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(expected_I_BBcm_B, 2*kEpsilon));
+  EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(expected_I_BBcm_B, 4*kEpsilon));
 }
 
 // Test the method ShiftToThenAwayFromCenterOfMass for a body B's

--- a/solvers/unrevised_lemke_solver.h
+++ b/solvers/unrevised_lemke_solver.h
@@ -46,7 +46,7 @@ class UnrevisedLemkeSolver final : public SolverBase {
   template <class U>
   static U ComputeZeroTolerance(const MatrixX<U>& M) {
     return M.rows() * M.template lpNorm<Eigen::Infinity>() *
-           (2 * std::numeric_limits<double>::epsilon());
+           (2.2 * std::numeric_limits<double>::epsilon());
   }
 
   /// Checks whether a given candidate solution to the LCP Mz + q = w, z ≥ 0,

--- a/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
@@ -265,11 +265,11 @@ GTEST_TEST(FiniteHorizonLQRTest, AffineSystemTest) {
   // the in linear system in xbar=(x-x0), ubar=(u-0); and the LQR solution is
   // xbar'Sxbar, with x0=0.  However, in the finite-horizon version, all of the
   // affine terms must be correct to cancel each other out.
-  EXPECT_TRUE(CompareMatrices(result.S->value(t0), lqr_result.S, 2e-5));
+  EXPECT_TRUE(CompareMatrices(result.S->value(t0), lqr_result.S, 3.8e-5));
   EXPECT_TRUE(result.sx->value(t0).isZero(1e-5));
   EXPECT_TRUE(result.s0->value(t0).isZero(1e-5));
   // The LQR controller would be u0 - Kx, so Kx = lqr.K, k0 = -u0.
-  EXPECT_TRUE(CompareMatrices(result.K->value(t0), lqr_result.K, 2e-4));
+  EXPECT_TRUE(CompareMatrices(result.K->value(t0), lqr_result.K, 4e-4));
   EXPECT_TRUE(CompareMatrices(result.k0->value(t0), -udv, 1e-5));
 
   // Test that the System version also works.
@@ -281,7 +281,7 @@ GTEST_TEST(FiniteHorizonLQRTest, AffineSystemTest) {
   regulator->get_input_port(0).FixValue(regulator_context.get(), x);
   EXPECT_TRUE(
       CompareMatrices(regulator->get_output_port(0).Eval(*regulator_context),
-                      udv - lqr_result.K * x, 4e-5));
+                      udv - lqr_result.K * x, 7.5e-5));
 
   // Test that the square root method also works.
   options.use_square_root_method = true;


### PR DESCRIPTION
Given there are many tests that fail when run on ARM because of the tight floating point tolerance, this PR relaxes some of these tolerances arbitrarily just enough to pass on ARM.
The goal is not to increase all tolerances but to selectively relax those that fail on ARM, maintaining test strictness where possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21713)
<!-- Reviewable:end -->
