### PR TITLE
Option to specify AABBs when calculating pairwise intersections for GCS.

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -1280,7 +1280,24 @@ void DefineGeometryOptimization(py::module m) {
       },
       py::arg("convex_sets_A"), py::arg("convex_sets_B"),
       py::arg("continuous_revolute_joints"), py::arg("preprocess_bbox") = true,
-      doc.CalcPairwiseIntersections.doc_4args);
+      doc.CalcPairwiseIntersections
+          .doc_4args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox);
+  m.def(
+      "CalcPairwiseIntersections",
+      [](const std::vector<ConvexSet*>& convex_sets_A,
+          const std::vector<ConvexSet*>& convex_sets_B,
+          const std::vector<int>& continuous_revolute_joints,
+          const std::vector<Hyperrectangle>& bboxes_A,
+          const std::vector<Hyperrectangle>& bboxes_B) {
+        return CalcPairwiseIntersections(CloneConvexSets(convex_sets_A),
+            CloneConvexSets(convex_sets_B), continuous_revolute_joints,
+            bboxes_A, bboxes_B);
+      },
+      py::arg("convex_sets_A"), py::arg("convex_sets_B"),
+      py::arg("continuous_revolute_joints"), py::arg("bboxes_A"),
+      py::arg("bboxes_B"),
+      doc.CalcPairwiseIntersections
+          .doc_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B);
   m.def(
       "CalcPairwiseIntersections",
       [](const std::vector<ConvexSet*>& convex_sets,
@@ -1291,7 +1308,20 @@ void DefineGeometryOptimization(py::module m) {
       },
       py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
       py::arg("preprocess_bbox") = true,
-      doc.CalcPairwiseIntersections.doc_3args);
+      doc.CalcPairwiseIntersections
+          .doc_3args_convex_sets_continuous_revolute_joints_preprocess_bbox);
+  m.def(
+      "CalcPairwiseIntersections",
+      [](const std::vector<ConvexSet*>& convex_sets,
+          const std::vector<int>& continuous_revolute_joints,
+          const std::vector<Hyperrectangle>& bboxes) {
+        return CalcPairwiseIntersections(
+            CloneConvexSets(convex_sets), continuous_revolute_joints, bboxes);
+      },
+      py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
+      py::arg("bboxes") = std::vector<Hyperrectangle>{},
+      doc.CalcPairwiseIntersections
+          .doc_3args_convex_sets_continuous_revolute_joints_bboxes);
   // NOLINTNEXTLINE(readability/fn_size)
 }
 

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -1368,16 +1368,40 @@ class TestCspaceFreePolytope(unittest.TestCase):
         sets_A = [mut.VPolytope(np.array([[0, 4]])),
                   mut.VPolytope(np.array([[2, 6]]))]
         sets_B = [mut.VPolytope(np.array([[1, 5]]) - (2 * np.pi))]
-        out = mut.CalcPairwiseIntersections(convex_sets_A=sets_A,
-                                            convex_sets_B=sets_B,
-                                            continuous_revolute_joints=[0],
-                                            preprocess_bbox=True)
-        self.assertIsInstance(out, list)
-        self.assertEqual(len(out), 2)
-        self.assertIsInstance(out[0], tuple)
-        out2 = mut.CalcPairwiseIntersections(convex_sets=sets_A,
-                                             continuous_revolute_joints=[0],
-                                             preprocess_bbox=True)
-        self.assertIsInstance(out, list)
-        self.assertEqual(len(out), 2)
-        self.assertIsInstance(out[0], tuple)
+        bboxes_A = [mut.Hyperrectangle.MaybeCalcAxisAlignedBoundingBox(s)
+                    for s in sets_A]
+        bboxes_B = [mut.Hyperrectangle.MaybeCalcAxisAlignedBoundingBox(s)
+                    for s in sets_B]
+        for bbox_A in bboxes_A:
+            self.assertTrue(bbox_A is not None)
+        for bbox_B in bboxes_B:
+            self.assertTrue(bbox_B is not None)
+        outputs = []
+        outputs.append(
+                mut.CalcPairwiseIntersections(convex_sets_A=sets_A,
+                                              convex_sets_B=sets_B,
+                                              continuous_revolute_joints=[0],
+                                              preprocess_bbox=True))
+        outputs.append(
+                mut.CalcPairwiseIntersections(convex_sets_A=sets_A,
+                                              convex_sets_B=sets_B,
+                                              continuous_revolute_joints=[0],
+                                              bboxes_A=bboxes_A,
+                                              bboxes_B=bboxes_B))
+        for out in outputs:
+            self.assertIsInstance(out, list)
+            self.assertEqual(len(out), 2)
+            self.assertIsInstance(out[0], tuple)
+        outputs2 = []
+        outputs2.append(
+                mut.CalcPairwiseIntersections(convex_sets=sets_A,
+                                              continuous_revolute_joints=[0],
+                                              preprocess_bbox=True))
+        outputs2.append(
+                mut.CalcPairwiseIntersections(convex_sets=sets_A,
+                                              continuous_revolute_joints=[0],
+                                              bboxes=bboxes_A))
+        for out in outputs2:
+            self.assertIsInstance(out, list)
+            self.assertEqual(len(out), 2)
+            self.assertIsInstance(out[0], tuple)

--- a/geometry/optimization/geodesic_convexity.h
+++ b/geometry/optimization/geodesic_convexity.h
@@ -15,6 +15,7 @@ of robots.
 #include <vector>
 
 #include "drake/geometry/optimization/convex_set.h"
+#include "drake/geometry/optimization/hyperrectangle.h"
 #include "drake/geometry/optimization/intersection.h"
 #include "drake/solvers/mathematical_program.h"
 
@@ -144,10 +145,10 @@ computed between `convex_sets_A` and `convex_sets_B`.
 @param continuous_revolute_joints is a list of joint indices corresponding to
 continuous revolute joints.
 @param preprocess_bbox is a flag for whether the function should precompute
-axis-aligned bounding boxes for every set. This can speed up the pairwise
-intersection checks, by determining some sets to be disjoint without needing
-to solve an optimization problem. However, it does require some overhead to
-compute those bounding boxes.
+axis-aligned bounding boxes (AABBs) for every set. This can speed up the
+pairwise intersection checks, by determining some sets to be disjoint without
+needing to solve an optimization problem. However, it does require some overhead
+to compute those bounding boxes.
 
 @throws if `continuous_revolute_joints` has repeated entries, or if any entry
 is outside the interval [0, ambient_dimension), where ambient_dimension is the
@@ -159,12 +160,33 @@ std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const std::vector<int>& continuous_revolute_joints,
     bool preprocess_bbox = true);
 
+/** Overload of `CalcPairwiseIntersections` allowing the user to supply axis-
+aligned bounding boxes if they're known a priori, to save on computation time.
+
+@param bboxes_A is a vector of Hyperrectangles, allowing the user to manually
+pass in the AABBs of each set in `convex_sets_A` to avoid recomputation.
+@param bboxes_B serves the same role to `convex_sets_B` as `bboxes_A` does to
+`convex_sets_A`.
+
+@warning The function does not check that the entries of bboxes_A are indeed the
+AABBs corresponding to the sets in `convex_sets_A` (and likewise for bboxes_B).
+
+@throws if `convex_sets_A.size() != bboxes_A.size()`
+@throws if `convex_sets_B.size() != bboxes_B.size()`
+@throws if not all entries of `convex_sets_A`, `convex_sets_B`, `bboxes_A`, and
+`bboxes_B` have the same ambient dimension. */
+std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
+    const ConvexSets& convex_sets_A, const ConvexSets& convex_sets_B,
+    const std::vector<int>& continuous_revolute_joints,
+    const std::vector<geometry::optimization::Hyperrectangle>& bboxes_A,
+    const std::vector<geometry::optimization::Hyperrectangle>& bboxes_B);
+
 /** Convenience overload to compute pairwise intersections within a list of
 convex sets. Equivalent to calling CalcPairwiseIntersections(convex_sets,
 convex_sets, continuous_revolute_joints).
 
-@param convex_sets_A is a vector of convex sets. Pairwise intersections will be
-computed within `convex_sets_A`.
+@param convex_sets is a vector of convex sets. Pairwise intersections will be
+computed within `convex_sets`.
 @param continuous_revolute_joints is a list of joint indices corresponding to
 continuous revolute joints.
 @param preprocess_bbox is a flag for whether the function should precompute
@@ -174,13 +196,30 @@ to solve an optimization problem.
 
 @throws if `continuous_revolute_joints` has repeated entries, or if any entry
 is outside the interval [0, ambient_dimension), where ambient_dimension is the
-ambient dimension of the convex sets in `convex_sets_A` and `convex_sets_B`.
-@throws if `convex_sets_A` is empty.
+ambient dimension of the convex sets in `convex_sets`.
+@throws if `convex_sets` is empty.
 */
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets,
     const std::vector<int>& continuous_revolute_joints,
     bool preprocess_bbox = true);
+
+/** Overload of `CalcPairwiseIntersections` allowing the user to supply axis-
+aligned bounding boxes if they're known a priori, to save on computation time.
+
+@param bboxes is a vector of Hyperrectangles, allowing the user to manually pass
+in the AABBs of each set in `convex_sets` to avoid recomputation.
+
+@warning The function does not check that the entries are indeed the AABBs
+corresponding to the sets in `convex_sets`.
+
+@throws if `convex_sets.size() != bboxes.size()`
+@throws if not all entries of `convex_sets` and `bboxes` have the same
+ambient dimension.*/
+std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
+    const ConvexSets& convex_sets,
+    const std::vector<int>& continuous_revolute_joints,
+    const std::vector<geometry::optimization::Hyperrectangle>& bboxes);
 
 }  // namespace optimization
 }  // namespace geometry


### PR DESCRIPTION
Per our discussion in #21593, this adds an additional argument to `GeodesicConvexity::CalcPairwiseIntersections` that takes in axis-aligned bounding boxes. If the user computes the AABBs themselves, they can be reused, saving time on recomputation.

+@sadraddini for feature review, please

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21718)
<!-- Reviewable:end -->
