### PR TITLE
Option to manually specify edges (and offsets) in GcsTrajectoryOptimization::AddEdges.

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -474,7 +474,9 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             cls_doc.RemoveSubgraph.doc)
         .def("AddEdges", &Class::AddEdges, py_rvp::reference_internal,
             py::arg("from_subgraph"), py::arg("to_subgraph"),
-            py::arg("subspace") = py::none(), cls_doc.AddEdges.doc)
+            py::arg("subspace") = py::none(),
+            py::arg("edges_between_regions") = py::none(),
+            py::arg("edge_offsets") = py::none(), cls_doc.AddEdges.doc)
         .def("AddTimeCost", &Class::AddTimeCost, py::arg("weight") = 1.0,
             cls_doc.AddTimeCost.doc)
         .def("AddPathLengthCost",

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -272,7 +272,11 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertEqual(len(regions.Edges()), 0)
 
         self.assertIn(regions, gcs.GetSubgraphs())
-        edges = gcs.AddEdges(source, regions)
+        edges = gcs.AddEdges(from_subgraph=source,
+                             to_subgraph=regions,
+                             subspace=None,
+                             edges_between_regions=None,
+                             edge_offsets=None)
         self.assertIn(edges, gcs.GetEdgesBetweenSubgraphs())
         self.assertEqual(len(edges.Edges()), 1)
         self.assertEqual(edges.Edges()[0].u(), source.Vertices()[0])

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -416,7 +416,11 @@ class GcsTrajectoryOptimization final {
     EdgesBetweenSubgraphs(const Subgraph& from_subgraph,
                           const Subgraph& to_subgraph,
                           const geometry::optimization::ConvexSet* subspace,
-                          GcsTrajectoryOptimization* traj_opt);
+                          GcsTrajectoryOptimization* traj_opt,
+                          std::optional<const std::vector<std::pair<int, int>>>
+                              edges_between_regions = std::nullopt,
+                          std::optional<const std::vector<Eigen::VectorXd>>
+                              edge_offsets = std::nullopt);
 
     /* Convenience accessor, for brevity. */
     int num_positions() const { return traj_opt_.num_positions(); }
@@ -508,9 +512,8 @@ class GcsTrajectoryOptimization final {
   @param name is the name of the subgraph. If the passed name is an empty
   string, a default name will be provided.
   @param edge_offsets is an optional list of vectors. If defined, the list must
-  contain the same number of entries as edges_between_regions. In other words,
-  if defined, there must be one edge offset for each specified edge. For each
-  pair of sets listed in edges_between_regions, the first set is translated (in
+  contain the same number of entries as `edges_between_regions`. For each pair
+  of sets listed in `edges_between_regions`, the first set is translated (in
   configuration space) by the corresponding vector in edge_offsets before
   computing the constraints associated to that edge. This is used to add edges
   between sets that "wrap around" 2π along some dimension, due to, e.g., a
@@ -570,14 +573,36 @@ class GcsTrajectoryOptimization final {
   added, and the subspace is added as a constraint on the connecting control
   points. Subspaces of type point or HPolyhedron are supported since other sets
   require constraints that are not yet supported by the GraphOfConvexSets::Edge
-  constraint, e.g., set containment of a HyperEllipsoid is formulated via
+  constraint, e.g., set containment of a Hyperellipsoid is formulated via
   LorentzCone constraints. Workaround: Create a subgraph of zero order with the
   subspace as the region and connect it between the two subgraphs. This works
-  because GraphOfConvexSet::Vertex , supports arbitrary instances of ConvexSets.
+  because GraphOfConvexSet::Vertex supports arbitrary instances of ConvexSets.
+  @param edges_between_regions can be used to manually specify which edges
+  should be added, avoiding the intersection checks. It should be a list of
+  tuples `(i,j)`, where an edge will be added from the `i`th index region in
+  `from_subgraph` to the `j`th index region in `to_subgraph`.
+  @param edge_offsets is an optional list of vectors. If defined, the list must
+  contain the same number of entries as `edges_between_regions`, and the order
+  must match. In other words, if defined, there must be one edge offset for each
+  specified edge, and they must be at the same index. For each pair of sets
+  listed in `edges_between_regions`, the first set is translated (in
+  configuration space) by the corresponding vector in edge_offsets before
+  computing the constraints associated to that edge. This is used to add edges
+  between sets that "wrap around" 2π along some dimension, due to, e.g., a
+  continuous revolute joint. This edge offset corresponds to the translation
+  component of the affine map τ_uv in equation (11) of "Non-Euclidean Motion
+  Planning with Graphs of Geodesically-Convex Sets", and per the discussion in
+  Subsection VI A, τ_uv has no rotation component.
+  @throws std::exception if `edge_offsets` is provided, but `edge_offsets.size()
+  != edges_between_regions.size()`.
   */
   EdgesBetweenSubgraphs& AddEdges(
       const Subgraph& from_subgraph, const Subgraph& to_subgraph,
-      const geometry::optimization::ConvexSet* subspace = nullptr);
+      const geometry::optimization::ConvexSet* subspace = nullptr,
+      std::optional<const std::vector<std::pair<int, int>>>
+          edges_between_regions = std::nullopt,
+      std::optional<const std::vector<Eigen::VectorXd>> edge_offsets =
+          std::nullopt);
 
   /** Adds a minimum time cost to all regions in the whole graph. The cost is
   the sum of the time scaling variables.

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -2322,10 +2322,96 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, ContinuityConstraintSymbolic) {
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, EdgeIndexChecking) {
   GcsTrajectoryOptimization gcs(1);
-  auto sets = MakeConvexSets(Point(Vector1d(43.0)));
-  std::vector<std::pair<int, int>> edges;
-  edges.emplace_back(0, 1);
-  EXPECT_THROW(gcs.AddRegions(sets, edges, 1), std::exception);
+  auto sets_bad = MakeConvexSets(Point(Vector1d(43.0)));
+  std::vector<std::pair<int, int>> edges_bad_1;
+  edges_bad_1.emplace_back(0, 1);
+  EXPECT_THROW(gcs.AddRegions(sets_bad, edges_bad_1, 1), std::exception);
+
+  auto sets_good_1 = MakeConvexSets(Hyperrectangle(Vector1d(0), Vector1d(2)));
+  auto sets_good_2 = MakeConvexSets(Hyperrectangle(Vector1d(1), Vector1d(3)));
+  auto& subgraph1 = gcs.AddRegions(sets_good_1, 1);
+  auto& subgraph2 = gcs.AddRegions(sets_good_2, 1);
+  std::vector<std::pair<int, int>> edges_bad_2;
+  edges_bad_2.emplace_back(0, 1);
+  EXPECT_THROW(gcs.AddEdges(subgraph1, subgraph2, nullptr, edges_bad_2),
+               std::exception);
+}
+
+GTEST_TEST(GcsTrajectoryOptimizationTest, ManuallySpecifyEdges) {
+  std::vector<int> continuous_revolute_joints = {0};
+  GcsTrajectoryOptimization gcs(1, continuous_revolute_joints);
+  auto sets1 = MakeConvexSets(Hyperrectangle(Vector1d(0), Vector1d(1)),
+                              Hyperrectangle(Vector1d(1.25), Vector1d(3)));
+  auto sets2 = MakeConvexSets(
+      Hyperrectangle(Vector1d(0.5), Vector1d(1.5)),
+      Hyperrectangle(Vector1d(1.25 + 2 * M_PI), Vector1d(2.5 + 2 * M_PI)));
+  auto& subgraph1 = gcs.AddRegions(sets1, 1, 1e-6);
+  auto& subgraph2 = gcs.AddRegions(sets2, 1, 1e-6);
+
+  auto& start = gcs.AddRegions(MakeConvexSets(Point(Vector1d(0))), 0);
+  auto& goal = gcs.AddRegions(MakeConvexSets(Point(Vector1d(2))), 0);
+
+  // sets1 is the intervals [0, 1] and [1.25, 3]
+  // sets2 is the intervals [0.5, 1.5] and [1.25 + 2π, 2.5 + 2π]
+  // So there's an edge (0, 0) with a zero offset, an edge (1, 0) with a zero
+  // offset, and an edge (1, 1) with a 2π offset.
+  std::vector<std::pair<int, int>> edges_start_1, edges_1_2, edges_2_goal;
+  std::vector<VectorXd> offsets_start_1, offsets_1_2, offsets_2_goal;
+  edges_start_1.emplace_back(0, 0);
+  offsets_start_1.emplace_back(Vector1d(0));
+
+  edges_1_2.emplace_back(0, 0);
+  offsets_1_2.emplace_back(Vector1d(0));
+  edges_1_2.emplace_back(1, 0);
+  offsets_1_2.emplace_back(Vector1d(0));
+  edges_1_2.emplace_back(1, 1);
+  offsets_1_2.emplace_back(Vector1d(2 * M_PI));
+
+  edges_2_goal.emplace_back(1, 0);
+  offsets_2_goal.emplace_back(Vector1d(-2 * M_PI));
+
+  // We consider edges start -> subgraph1 -> subgraph2 -> goal, plus the edges
+  // within subgraph2. (Subgraph1 is disconnected.) There's one edge from the
+  // start to subgraph 1, no edges within subgraph 1, 3 edges between subgraph 1
+  // and subgraph 2, 2 edges within subgraph 2, and 1 edge from subgraph 2 to
+  // the goal, for a total of 7.
+  const int expected_num_edges = 7;
+
+  // Add edges without offsets. This makes the problem infeasible.
+  gcs.AddEdges(start, subgraph1, nullptr, edges_start_1);
+  gcs.AddEdges(subgraph1, subgraph2, nullptr, edges_1_2);
+  gcs.AddEdges(subgraph2, goal, nullptr, edges_2_goal);
+  EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), expected_num_edges);
+  auto [traj_fail, result_fail] = gcs.SolvePath(start, goal);
+  unused(traj_fail);
+  EXPECT_FALSE(result_fail.is_success());
+
+  // Add edges with the offset. (We remove and re-add the middle twosubgraphs to
+  // clear the edges.)
+  gcs.RemoveSubgraph(subgraph1);
+  gcs.RemoveSubgraph(subgraph2);
+  auto& new_subgraph1 = gcs.AddRegions(sets1, 1, 1e-6);
+  auto& new_subgraph2 = gcs.AddRegions(sets2, 1, 1e-6);
+  gcs.AddEdges(start, new_subgraph1, nullptr, edges_start_1, offsets_start_1);
+  gcs.AddEdges(new_subgraph1, new_subgraph2, nullptr, edges_1_2, offsets_1_2);
+  gcs.AddEdges(new_subgraph2, goal, nullptr, edges_2_goal, offsets_2_goal);
+  EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), expected_num_edges);
+  auto [traj_succeed, result_succeed] = gcs.SolvePath(start, goal);
+  unused(traj_succeed);
+  EXPECT_TRUE(result_succeed.is_success());
+
+  // Throw if edges and offsets have mismatched lengths.
+  offsets_2_goal.emplace_back(Vector1d(0));
+  EXPECT_THROW(
+      gcs.AddEdges(new_subgraph2, goal, nullptr, edges_2_goal, offsets_2_goal),
+      std::exception);
+
+  // Throw if offsets has wrong dimension.
+  offsets_2_goal.resize(0);
+  offsets_2_goal.emplace_back(Vector2d(0, 0));
+  EXPECT_THROW(
+      gcs.AddEdges(new_subgraph2, goal, nullptr, edges_2_goal, offsets_2_goal),
+      std::exception);
 }
 
 }  // namespace


### PR DESCRIPTION
If the user already knows which regions overlap, then it's unnecessary for GCS to compute pairwise intersections. This allows the user to pass in an adjacency list of edges in the graph, bypassing the potentially costly recomputations. This functionality already exists for `GcsTrajectoryOptimization::AddRegions`, so it makes sense to add it for the `AddEdges` method as well.

Closes #21704
+@sadraddini for feature review?
cc @wrangelvid

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21723)
<!-- Reviewable:end -->
