### PR TITLE
Incorporates margin in the compuation of hydroelastic fields

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -869,6 +869,23 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "pressure_field_invariants",
+    testonly = 1,
+    srcs = ["test/pressure_field_invariants.cc"],
+    hdrs = ["test/pressure_field_invariants.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":mesh_field",
+        ":triangle_surface_mesh",
+        ":volume_mesh",
+        ":volume_to_surface_mesh",
+        "//common:essential",
+        "//math:geometric_transform",
+        "@gtest//:without_main",
+    ],
+)
+
+drake_cc_library(
     name = "sorted_triplet",
     srcs = ["sorted_triplet.cc"],
     hdrs = ["sorted_triplet.h"],
@@ -1276,6 +1293,7 @@ drake_cc_googletest(
     deps = [
         ":make_box_field",
         ":make_box_mesh",
+        ":pressure_field_invariants",
         ":volume_to_surface_mesh",
     ],
 )
@@ -1294,6 +1312,7 @@ drake_cc_googletest(
     deps = [
         ":make_capsule_field",
         ":make_capsule_mesh",
+        ":pressure_field_invariants",
         ":volume_to_surface_mesh",
     ],
 )
@@ -1369,6 +1388,7 @@ drake_cc_googletest(
     deps = [
         ":make_cylinder_field",
         ":make_cylinder_mesh",
+        ":pressure_field_invariants",
         ":volume_to_surface_mesh",
     ],
 )
@@ -1386,6 +1406,7 @@ drake_cc_googletest(
     deps = [
         ":make_ellipsoid_field",
         ":make_ellipsoid_mesh",
+        ":pressure_field_invariants",
         ":volume_to_surface_mesh",
     ],
 )
@@ -1405,6 +1426,7 @@ drake_cc_googletest(
     deps = [
         ":make_mesh_field",
         ":make_mesh_from_vtk",
+        ":pressure_field_invariants",
         "//common:find_resource",
         "//common/test_utilities",
     ],
@@ -1427,6 +1449,7 @@ drake_cc_googletest(
     deps = [
         ":make_sphere_field",
         ":make_sphere_mesh",
+        ":pressure_field_invariants",
         ":volume_to_surface_mesh",
     ],
 )

--- a/geometry/proximity/make_box_field.cc
+++ b/geometry/proximity/make_box_field.cc
@@ -15,10 +15,12 @@ namespace internal {
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeBoxPressureField(const Box& box,
                                                  const VolumeMesh<T>* mesh_B,
-                                                 const T hydroelastic_modulus) {
+                                                 const T hydroelastic_modulus,
+                                                 const double margin) {
   DRAKE_DEMAND(hydroelastic_modulus > T(0));
   const Vector3<double> half_size = box.size() / 2.0;
   const double min_half_size = half_size.minCoeff();
+  DRAKE_DEMAND(min_half_size > margin);
 
   // TODO(DamrongGuoy): Switch to a better implementation in the future. The
   //  current implementation has a number of limitations:
@@ -46,7 +48,7 @@ VolumeMeshFieldLinear<T, T> MakeBoxPressureField(const Box& box,
     T signed_distance = grad_B.dot(r_BV - r_BN);
     // Map signed_distance ∈ [-min_half_size, 0] to extent e ∈ [0, 1],
     // -min_half_size ⇝ 1, 0 ⇝ 0.
-    T extent = -signed_distance / T(min_half_size);
+    T extent = (-signed_distance - margin) / T(min_half_size - margin);
     pressure_values.push_back(hydroelastic_modulus * extent);
   }
 

--- a/geometry/proximity/make_box_field.h
+++ b/geometry/proximity/make_box_field.h
@@ -10,28 +10,36 @@ namespace internal {
 
 /*
  Generates a linear approximation of a pressure field inside the given box as
- represented by the given volume mesh. The pressure at a point is defined
- as E * e(x) where e ∈ [0,1] is the extent -- a measure of penetration into
- the volume, and E is the given `hydroelastic_modulus`. The pressure is zero on
- the boundary with maximum E in the interior.
+ represented by the given volume mesh. The pressure at a point is defined as E *
+ e(x) where e ∈ [0,1] is the extent -- a measure of penetration into the volume,
+ and E is the given `hydroelastic_modulus`. The extent is defined as e(x) =
+ (d-δ)/(H-δ), with d the (positive) distance from point x to the nearest face on
+ the box, δ the `margin` and H the minimum half size of the box. Therefore the
+ zero level set of this pressure field is a distance δ within the box. The
+ gradient points in the direction opposite to the normal of the nearest face to
+ x and has magnitude E/(H-δ).
  @param box              The box with its canonical frame B.
  @param mesh_B           A pointer to a tetrahedral mesh of the box. It is
                          aliased in the returned pressure field and must remain
                          alive as long as the field. The position vectors of
                          mesh vertices are expressed in the box's frame B.
  @param hydroelastic_modulus  Scale extent to pressure.
+ @param margin           The magnitude of the margin δ.
  @return                 The pressure field defined on the tetrahedral mesh.
  @pre                    `hydroelastic_modulus` is strictly positive.
                          `mesh_B` represents the box well (the space enclosed
                          by the mesh should be exactly the same space as the
                          box specification). `mesh_B` has enough resolution
                          to approximate the pressure field.
+@pre                     The minimum half size of the box is strictly larger
+                         than `margin`.
  @tparam_nonsymbolic_scalar
  */
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeBoxPressureField(const Box& box,
                                                  const VolumeMesh<T>* mesh_B,
-                                                 const T hydroelastic_modulus);
+                                                 const T hydroelastic_modulus,
+                                                 double margin = 0.0);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/make_capsule_field.h
+++ b/geometry/proximity/make_capsule_field.h
@@ -30,6 +30,14 @@ namespace internal {
  | geometry/proximity/images/capsule_mesh_medial_axis_isosurfaces.png |
  | Isosurfaces of the capsule pressure field. |
 
+ With r the distance to the capsule's medial axis, the extent is defined as e(r)
+ = 1 - r/(R-δ), where R is the radius of the capsule and δ the margin. The
+ pressure field is then defined as p(r) = E * e(r), with E the hydroelastic
+ modulus. The zero level set of this pressure field lies on a capsule of the
+ same length (Capsule::length(), the length of the cylindrical region) and
+ radius equal to R-δ. The maximum pressure field is E at the medial axis, i.e.
+ the line segment connecting the first two vertices of the input mesh.
+
  @param[in] capsule      The capsule with its canonical frame C.
  @param[in,out] mesh_C   A pointer to a tetrahedral mesh of the capsule. It
                          is aliased in the returned pressure field and must
@@ -37,6 +45,7 @@ namespace internal {
                          vectors of mesh vertices are expressed in the
                          capsule's frame C.
  @param[in] hydroelastic_modulus  Scale extent to pressure.
+ @param[in] margin       The margin δ.
  @return                 The pressure field defined on the tetrahedral mesh.
  @pre                    `hydroelastic_modulus` is strictly positive.
                          `mesh_C` is non-null.
@@ -46,8 +55,9 @@ namespace internal {
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeCapsulePressureField(
     const Capsule& capsule, const VolumeMesh<T>* mesh_C,
-    const T hydroelastic_modulus) {
+    const T hydroelastic_modulus, const double margin = 0) {
   DRAKE_DEMAND(hydroelastic_modulus > T(0));
+  DRAKE_DEMAND(capsule.radius() > margin);
   DRAKE_DEMAND(mesh_C != nullptr);
   // We only partially check the precondition of the mesh (see @pre). The first
   // two vertices should always be the endpoints of the capsule's medial axis.
@@ -57,7 +67,19 @@ VolumeMeshFieldLinear<T, T> MakeCapsulePressureField(
   DRAKE_DEMAND(mesh_C->vertex(1) ==
                Eigen::Vector3d(0, 0, -capsule.length() / 2));
 
-  std::vector<T> pressure_values(mesh_C->num_vertices(), 0.0);
+  // Pressure gradient along the radial direction (in either the sphere or the
+  // cylinder).
+  const T pressure_gradient =
+      hydroelastic_modulus / (capsule.radius() - margin);
+
+  // Compute pressure at the surface by linearly extrapolating to a distance
+  // equal to the margin. The extrapolation is exact since the field is linear
+  // along the radial coordinate (in either the spherical or cylindrical
+  // regions).
+  const T surface_pressure = -margin * pressure_gradient;
+
+  // All vertices are on the surface except the first two (overwritten below).
+  std::vector<T> pressure_values(mesh_C->num_vertices(), surface_pressure);
 
   // Only the inner vertices lying on the medial axis (vertex 0 and 1) have
   // non-zero pressure values.

--- a/geometry/proximity/make_cylinder_field.cc
+++ b/geometry/proximity/make_cylinder_field.cc
@@ -16,8 +16,10 @@ namespace internal {
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
     const Cylinder& cylinder, const VolumeMesh<T>* mesh_C,
-    const T hydroelastic_modulus) {
+    const T hydroelastic_modulus, double margin) {
   DRAKE_DEMAND(hydroelastic_modulus > T(0));
+  DRAKE_DEMAND(cylinder.radius() > margin);
+  DRAKE_DEMAND(cylinder.length() > 2 * margin);
   const double radius = cylinder.radius();
   const double length = cylinder.length();
   const double min_half_size = std::min(radius, length / 2.0);
@@ -54,20 +56,22 @@ VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
     const T signed_distance = signed_distance_functor(fcl_cylinder).distance;
     // Map signed_distance ∈ [-min_half_size, 0] to extent e ∈ [0, 1],
     // -min_half_size ⇝ 1, 0 ⇝ 0.
-    const T extent = -signed_distance / T(min_half_size);
+    const T extent = (-signed_distance - margin) / T(min_half_size - margin);
     using std::min;
-    // Bound the pressure values in [0, E], where E is the elastic modulus.
+    // Bound the pressure values in [-margin, E], where E is the elastic
+    // modulus.
     pressure_values.push_back(
         min(hydroelastic_modulus * extent, hydroelastic_modulus));
   }
 
-  // Make sure the boundary vertices have zero pressure. Numerical rounding
-  // can cause the boundary vertices to be slightly off the boundary surface
-  // of the cylinder.
+  const T min_pressure =
+      -hydroelastic_modulus * margin / (min_half_size - margin);
+
+  // Enforce the exact minimum value at the boundary.
   std::vector<int> boundary_vertices =
       CollectUniqueVertices(IdentifyBoundaryFaces(mesh_C->tetrahedra()));
   for (int bv : boundary_vertices) {
-    pressure_values[bv] = T(0.);
+    pressure_values[bv] = min_pressure;
   }
 
   return VolumeMeshFieldLinear<T, T>(std::move(pressure_values), mesh_C,

--- a/geometry/proximity/make_cylinder_field.h
+++ b/geometry/proximity/make_cylinder_field.h
@@ -10,10 +10,14 @@ namespace internal {
 
 /*
  Generates a piecewise-linear pressure field inside the given cylinder as
- represented by the given volume mesh. The pressure at a point is defined
- as E * e(x) where e ∈ [0,1] is the extent -- a measure of penetration into
- the volume, and E is the given `hydroelastic_modulus`. The pressure is zero on
- the boundary with maximum E in the interior.
+ represented by the given volume mesh. The pressure at a point is defined as E *
+ e(x) where e is the extent -- a measure of penetration into the volume, and E
+ is the given `hydroelastic_modulus`. For a point x inside the `cylinder`, the
+ extent is defined as e(x) = (d(x)-δ)/(H-δ), with d(x) the (positive) distance
+ to the boundary, δ the `margin` and H = min(R, L/2), where R and L are the
+ radius and length of the `cylinder` respectively. With the extent defined, the
+ pressure at a point x is computed as p(x) = E⋅e(x). The pressure has maximum
+ value E in the interior and minimum value at the boundary p = -E⋅δ/(H-δ).
 
  For hydroelastics, a desirable mesh (`mesh_C` parameter) for this field can
  be created by MakeCylinderMeshWithMa(), which has these properties:
@@ -40,16 +44,18 @@ namespace internal {
                          vectors of mesh vertices are expressed in the
                          cylinder's frame C.
  @param[in] hydroelastic_modulus  Scale extent to pressure.
+ @param margin           The magnitude of the margin δ.
  @return                 The pressure field defined on the tetrahedral mesh.
  @pre                    `hydroelastic_modulus` is strictly positive.
                          `mesh_C` represents the cylinder and has enough
                          resolution to represent the pressure field.
+ @pre                    R > δ and L > 2δ.
  @tparam_nonsymbolic_scalar
  */
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
     const Cylinder& cylinder, const VolumeMesh<T>* mesh_C,
-    const T hydroelastic_modulus);
+    const T hydroelastic_modulus, double margin = 0);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/make_mesh_field.cc
+++ b/geometry/proximity/make_mesh_field.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/proximity/make_mesh_field.h"
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <utility>
@@ -43,9 +44,11 @@ TriangleSurfaceMesh<double> ConvertVolumeToSurfaceMeshDouble(
 
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeVolumeMeshPressureField(
-    const VolumeMesh<T>* mesh_M, const T& hydroelastic_modulus) {
+    const VolumeMesh<T>* mesh_M, const T& hydroelastic_modulus, double margin) {
   DRAKE_DEMAND(hydroelastic_modulus > T(0));
   DRAKE_DEMAND(mesh_M != nullptr);
+  using std::max;
+
   std::vector<int> boundary_vertices;
   // The subscript _d is for the scalar type double.
   TriangleSurfaceMesh<double> surface_d =
@@ -55,7 +58,7 @@ VolumeMeshFieldLinear<T, T> MakeVolumeMeshPressureField(
   //  cause a vertex on the boundary to have a non-zero value. Consider
   //  initializing pressure_values to zeros and skip the computation for
   //  boundary vertices.
-  std::vector<T> pressure_values;
+  std::vector<T> values;
   T max_value(std::numeric_limits<double>::lowest());
   // First round, it's actually unsigned distance, not pressure values yet.
   const Bvh<Obb, TriangleSurfaceMesh<double>> bvh(surface_d);
@@ -63,16 +66,15 @@ VolumeMeshFieldLinear<T, T> MakeVolumeMeshPressureField(
   for (int v = 0; v < ssize(mesh_M->vertices()); ++v) {
     if (boundary_iter != boundary_vertices.end() && *boundary_iter == v) {
       ++boundary_iter;
-      pressure_values.push_back(0);
+      values.push_back(0);
       continue;
     }
     const Vector3<T>& p_MV = mesh_M->vertex(v);
     const Vector3<double> p_MV_d = ExtractDoubleOrThrow(p_MV);
-    T pressure = internal::CalcDistanceToSurfaceMesh(p_MV_d, surface_d, bvh);
-    pressure_values.push_back(pressure);
-    if (max_value < pressure) {
-      max_value = pressure;
-    }
+    const T distance =
+        internal::CalcDistanceToSurfaceMesh(p_MV_d, surface_d, bvh);
+    values.push_back(distance);
+    max_value = max(distance, max_value);
   }
 
   if (max_value <= T(0)) {
@@ -82,11 +84,14 @@ VolumeMeshFieldLinear<T, T> MakeVolumeMeshPressureField(
         "all mesh vertices is non-positive. Perhaps "
         "the mesh lacks interior vertices.");
   }
-  for (T& p : pressure_values) {
-    p = hydroelastic_modulus * p / max_value;
+
+  DRAKE_DEMAND(max_value > margin);
+
+  for (T& p : values) {
+    p = hydroelastic_modulus * (p - margin) / (max_value - margin);
   }
 
-  return {std::move(pressure_values), mesh_M, MeshGradientMode::kOkOrThrow};
+  return {std::move(values), mesh_M, MeshGradientMode::kOkOrThrow};
 }
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(

--- a/geometry/proximity/make_mesh_field.h
+++ b/geometry/proximity/make_mesh_field.h
@@ -10,32 +10,25 @@ namespace internal {
 /* Creates a pressure field on a tetrahedral volume mesh of a (possibly
  non-convex) shape. This function complements MakeConvexPressureField().
 
- We use distance to surface to approximate strain, so we calculate the
- fraction of a vertex's depth to the maximum depth among all vertices in
- the volume.  Using distance this way can produce bad gradients since a
- distance field is non-smooth, and this is not the same as the extent-field
- method in [Elandt2019] which uses Laplace's equation to calculate a smooth
- "temperature gradient" for the strain field.
-
- We will use a smoother field in the future. For now, mathematically the value
- of the pressure field P(v) at vertex v is:
-
-   P(v) = hydroelastic_modulus * dist(v, ∂M) / dist(v*, ∂M)
-
- where:
- ∂M is the boundary of the volume mesh M,
- dist(v, ∂M) = inf |v − w| : w ∈ ∂M (distance to the boundary),
- v* = arg max dist(v, ∂M) : v ∈ M
+ Given the distance field ϕ(x) (defined positive inside the object), we define
+ the extent function as in the Elastic Foundation Model, i.e. e(x) =
+ (-ϕ(x)-δ)/(H-δ), where the elastic foundation depth H is defined as the maximum
+ distance ϕ(x) over the volume of the mesh (actually the maximum ϕ(xᵢ) over all
+ mesh vertices xᵢ). δ is the margin. The pressure field is then defined as p(x)
+ = E⋅e(x). Therefore the zero pressure level set is located at a distance δ from
+ the surface, and the maximum pressure is p = E.
 
  @param[in] mesh_M   A pointer to a tetrahedral mesh.
                      It is aliased in the returned pressure field and must
                      remain alive as long as the field.
  @param[in] hydroelastic_modulus   Scale penetration extent to pressure.
                      Its unit is Pascals. See [Elandt2019].
+ @param[in] margin   Margin δ.
  @return             The pressure field defined on the tetrahedral mesh.
 
  @pre                `hydroelastic_modulus` is strictly positive.
                      `mesh_M` is non-null.
+ @pre               H > δ.
 
  @throw  std::exception if the mesh has no interior vertices.
 
@@ -50,7 +43,8 @@ namespace internal {
  */
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeVolumeMeshPressureField(
-    const VolumeMesh<T>* mesh_M, const T& hydroelastic_modulus);
+    const VolumeMesh<T>* mesh_M, const T& hydroelastic_modulus,
+    double margin = 0);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -134,7 +134,10 @@ ComputeContactSurface(
 
 /*
  Computes the ContactSurface formed by a soft half space and the given rigid
- mesh.
+ mesh. Pressure is defined as p = −(ϕ + δ)⋅g, where ϕ is the signed distance to
+ the half space, δ is a margin value and g is a pressure scale (see below).
+ Therefore the zero pressure level set is located at ϕ = -δ and the surface has
+ the pressure value p = −δ⋅g.
 
  The definition of the half space is implicit in the call -- it is the type
  defined by the HalfSpace class, thus, only its id, its pose in a common frame
@@ -155,6 +158,8 @@ ComputeContactSurface(
                             mesh is defined in -- and the world frame W.
  @param[in] representation  The preferred representation of each contact
                             polygon.
+ @param[in] margin          The margin amount δ.
+
  @returns `nullptr` if there is no collision, otherwise the ContactSurface
           between geometries S and R. Each triangle in the contact surface is a
           piece of a triangle in the input `mesh_R`; the normals of the former
@@ -169,7 +174,7 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     GeometryId id_R, const TriangleSurfaceMesh<double>& mesh_R,
     const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_R,
     const math::RigidTransform<T>& X_WR,
-    HydroelasticContactRepresentation representation);
+    HydroelasticContactRepresentation representation, double margin = 0);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/test/make_box_field_test.cc
+++ b/geometry/proximity/test/make_box_field_test.cc
@@ -6,7 +6,10 @@
 #include <gtest/gtest.h>
 
 #include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/test/pressure_field_invariants.h"
 #include "drake/geometry/proximity/volume_to_surface_mesh.h"
+
+using Eigen::Vector3d;
 
 namespace drake {
 namespace geometry {
@@ -49,6 +52,22 @@ GTEST_TEST(MakeBoxFieldTest, MakeBoxPressureField) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_EQ(pressure, 0.0);
   }
+}
+
+GTEST_TEST(MakeBoxFieldTest, WithMargin) {
+  const double kElasticModulus = 1.0e5;
+  const double kMargin = 0.12;
+  // Box dimensions are set to avoid symmetry.
+  const Box box(1.0, 2.0, 3.0);
+  const double elastic_foundation_depth = 0.5;  // The minimum half size.
+  const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+  const VolumeMeshFieldLinear<double, double> field_no_margin =
+      MakeBoxPressureField<double>(box, &mesh, kElasticModulus);
+  const VolumeMeshFieldLinear<double, double> field_with_margin =
+      MakeBoxPressureField<double>(box, &mesh, kElasticModulus, kMargin);
+  VerifyInvariantsOfThePressureFieldWithMargin(
+      field_no_margin, field_with_margin, kMargin, elastic_foundation_depth,
+      kElasticModulus);
 }
 
 GTEST_TEST(MakeBoxFieldTest, MakeBoxPressureFieldInMeshWithMedialAxis) {

--- a/geometry/proximity/test/make_capsule_field_test.cc
+++ b/geometry/proximity/test/make_capsule_field_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/make_capsule_mesh.h"
+#include "drake/geometry/proximity/test/pressure_field_invariants.h"
 
 namespace drake {
 namespace geometry {
@@ -78,6 +79,28 @@ TEST_P(MakeCapsuleFieldTest, CheckMinMaxBoundaryValue) {
       MakeCapsulePressureField<double>(capsule, &mesh, kElasticModulus);
 
   CheckMinMaxBoundaryValue(pressure_field, kElasticModulus);
+}
+
+GTEST_TEST(MakeCapsuleFieldTest, WithMargin) {
+  const double kElasticModulus = 1.0e5;
+  const double kMargin = 0.12;
+  const double radius = 0.5;
+  const double length = 2.0;
+  const double elastic_foundation_depth = radius;
+  // Number of vertices per circular rim of the capsule.
+  const int n = 8;  // Coarse capsule, enough for coverage.
+  const double resolution_hint = 2.0 * M_PI * radius / n;
+  const Capsule capsule(radius, length);
+  const VolumeMesh<double> mesh =
+      MakeCapsuleVolumeMesh<double>(capsule, resolution_hint);
+  const VolumeMeshFieldLinear<double, double> field_no_margin =
+      MakeCapsulePressureField<double>(capsule, &mesh, kElasticModulus);
+  const VolumeMeshFieldLinear<double, double> field_with_margin =
+      MakeCapsulePressureField<double>(capsule, &mesh, kElasticModulus,
+                                       kMargin);
+  VerifyInvariantsOfThePressureFieldWithMargin(
+      field_no_margin, field_with_margin, kMargin, elastic_foundation_depth,
+      kElasticModulus);
 }
 
 }  // namespace

--- a/geometry/proximity/test/make_cylinder_field_test.cc
+++ b/geometry/proximity/test/make_cylinder_field_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/make_cylinder_mesh.h"
+#include "drake/geometry/proximity/test/pressure_field_invariants.h"
 
 namespace drake {
 namespace geometry {
@@ -18,9 +19,13 @@ using Eigen::Vector3d;
 //  make_`shape`_field_test.cc for box, sphere, ellipsoid, etc.
 void CheckMinMaxBoundaryValue(
     const VolumeMeshFieldLinear<double, double>& pressure_field,
-    const double hydroelastic_modulus) {
+    double hydroelastic_modulus, double expected_min_pressure = 0) {
   // We pick the relative error 1e-14 of the elastic modulus empirically.
   const double tolerance = 1e-14 * hydroelastic_modulus;
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+  // N.B. The slop is zero, thus exact comparison, when the expected minimum
+  // pressure is zero.
+  const double min_pressure_slop = kEps * std::abs(expected_min_pressure);
   // Check that all vertices have their pressure values within the range of
   // zero to hydroelastic_modulus, and their minimum and maximum values are
   // indeed zero and hydroelastic_modulus respectively.
@@ -29,7 +34,7 @@ void CheckMinMaxBoundaryValue(
   for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     ASSERT_LE(pressure, hydroelastic_modulus + tolerance);
-    ASSERT_GE(pressure, 0.0);
+    ASSERT_GE(pressure, expected_min_pressure - min_pressure_slop);
     if (pressure > max_pressure) {
       max_pressure = pressure;
     }
@@ -37,7 +42,7 @@ void CheckMinMaxBoundaryValue(
       min_pressure = pressure;
     }
   }
-  EXPECT_EQ(min_pressure, 0.0);
+  EXPECT_NEAR(min_pressure, expected_min_pressure, min_pressure_slop);
   EXPECT_NEAR(max_pressure, hydroelastic_modulus, tolerance);
 
   // Check that all boundary vertices have zero pressure.
@@ -45,7 +50,7 @@ void CheckMinMaxBoundaryValue(
       IdentifyBoundaryFaces(pressure_field.mesh().tetrahedra()));
   for (int v : boundary_vertex_indices) {
     double pressure = pressure_field.EvaluateAtVertex(v);
-    ASSERT_EQ(pressure, 0.0);
+    EXPECT_NEAR(pressure, expected_min_pressure, min_pressure_slop);
   }
 
   // This test only applies to a mesh that has a vertex at the center of
@@ -115,6 +120,23 @@ GTEST_TEST(MakeCylinderFieldTest, MakeCylinderPressureFieldWithMaShort) {
       MakeCylinderPressureField<double>(cylinder, &mesh, kElasticModulus);
 
   CheckMinMaxBoundaryValue(pressure_field, kElasticModulus);
+}
+
+GTEST_TEST(MakeCylinderFieldTest, WithMargin) {
+  const double kElasticModulus = 1.0e5;
+  const double kMargin = 0.12;
+  const Cylinder cylinder(1., 3.);
+  const double elastic_foundation_depth = 1.0;  // min half-size.
+  const VolumeMesh<double> mesh =
+      MakeCylinderVolumeMeshWithMa<double>(cylinder, 0.25);
+  const VolumeMeshFieldLinear<double, double> field_no_margin =
+      MakeCylinderPressureField<double>(cylinder, &mesh, kElasticModulus);
+  const VolumeMeshFieldLinear<double, double> field_with_margin =
+      MakeCylinderPressureField<double>(cylinder, &mesh, kElasticModulus,
+                                        kMargin);
+  VerifyInvariantsOfThePressureFieldWithMargin(
+      field_no_margin, field_with_margin, kMargin, elastic_foundation_depth,
+      kElasticModulus);
 }
 
 }  // namespace

--- a/geometry/proximity/test/make_ellipsoid_field_test.cc
+++ b/geometry/proximity/test/make_ellipsoid_field_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/make_ellipsoid_mesh.h"
+#include "drake/geometry/proximity/test/pressure_field_invariants.h"
 
 namespace drake {
 namespace geometry {
@@ -18,7 +19,13 @@ using Eigen::Vector3d;
 //  make_`shape`_field_test.cc for box, sphere, ellipsoid, etc.
 void CheckMinMaxBoundaryValue(
     const VolumeMeshFieldLinear<double, double>& pressure_field,
-    const double hydroelastic_modulus) {
+    double hydroelastic_modulus, double expected_min_pressure = 0) {
+  // We pick the relative error 1e-14 of the elastic modulus empirically.
+  const double tolerance = 1e-14 * hydroelastic_modulus;
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+  // N.B. The slop is zero, thus exact comparison, when the expected minimum
+  // pressure is zero.
+  const double min_pressure_slop = kEps * std::abs(expected_min_pressure);
   // Check that all vertices have their pressure values within the range of
   // zero to hydroelastic_modulus, and their minimum and maximum values are
   // indeed zero and hydroelastic_modulus respectively.
@@ -26,8 +33,8 @@ void CheckMinMaxBoundaryValue(
   double min_pressure = std::numeric_limits<double>::max();
   for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
-    EXPECT_LE(pressure, hydroelastic_modulus);
-    EXPECT_GE(pressure, 0.0);
+    ASSERT_LE(pressure, hydroelastic_modulus + tolerance);
+    ASSERT_GE(pressure, expected_min_pressure - min_pressure_slop);
     if (pressure > max_pressure) {
       max_pressure = pressure;
     }
@@ -35,29 +42,26 @@ void CheckMinMaxBoundaryValue(
       min_pressure = pressure;
     }
   }
-  EXPECT_EQ(min_pressure, 0.0);
-  EXPECT_EQ(max_pressure, hydroelastic_modulus);
+  EXPECT_NEAR(min_pressure, expected_min_pressure, min_pressure_slop);
+  EXPECT_NEAR(max_pressure, hydroelastic_modulus, tolerance);
 
-  // Check that all boundary vertices have zero pressure.
-  std::vector<int> boundary_vertex_indices = CollectUniqueVertices(
-      IdentifyBoundaryFaces(pressure_field.mesh().tetrahedra()));
-  for (int v : boundary_vertex_indices) {
-    double pressure = pressure_field.EvaluateAtVertex(v);
-    EXPECT_EQ(pressure, 0.0);
-  }
-
-  // Check that the center (0,0,0) of the shape has the max_pressure.
-  // This test assumes that the mesh has a vertex at the origin of its
-  // canonical frame.
+  // This test only applies to a mesh that has a vertex at the center of
+  // the geometric shape, where we check that the center vertex has the
+  // max_pressure.
   int center_vertex = 0;
+  bool has_center_vertex = false;
   for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     if (pressure_field.mesh().vertex(v) == Vector3d::Zero()) {
       center_vertex = v;
+      has_center_vertex = true;
       break;
     }
   }
-  ASSERT_EQ(Vector3d::Zero(), pressure_field.mesh().vertex(center_vertex));
-  EXPECT_EQ(max_pressure, pressure_field.EvaluateAtVertex(center_vertex));
+  if (has_center_vertex) {
+    ASSERT_EQ(Vector3d::Zero(), pressure_field.mesh().vertex(center_vertex));
+    EXPECT_NEAR(max_pressure, pressure_field.EvaluateAtVertex(center_vertex),
+                tolerance);
+  }
 }
 
 GTEST_TEST(MakeEllipsoidFieldTest, MakeEllipsoidPressureField) {
@@ -79,6 +83,31 @@ GTEST_TEST(MakeEllipsoidFieldTest, MakeEllipsoidPressureField) {
       MakeEllipsoidPressureField<double>(ellipsoid, &mesh, kElasticModulus);
 
   CheckMinMaxBoundaryValue(pressure_field, kElasticModulus);
+}
+
+GTEST_TEST(MakeEllipsoidFieldTest, WithMargin) {
+  const double kElasticModulus = 1.0e5;
+  const double kMargin = 0.012;
+  // For an ellipsoid with bounding box 10cm x 16cm x 6cm, its semi-axes are
+  // 5cm, 8cm, and 3cm long.
+  const Ellipsoid ellipsoid(0.05, 0.08, 0.03);
+  const double elastic_foundation_depth = 0.03;  // the min half-axis.
+  // Use resolution_hint 4cm to get a medium mesh with some boundary vertices
+  // not exactly on the surface of the ellipsoid due to numerical roundings.
+  // We do not want to use the coarsest mesh (octahedron) since all vertices
+  // are exactly on the coordinate axes.
+  const VolumeMesh<double> mesh = MakeEllipsoidVolumeMesh<double>(
+      ellipsoid, 0.04, TessellationStrategy::kDenseInteriorVertices);
+  const VolumeMeshFieldLinear<double, double> field_no_margin =
+      MakeEllipsoidPressureField<double>(ellipsoid, &mesh, kElasticModulus);
+  const VolumeMeshFieldLinear<double, double> field_with_margin =
+      MakeEllipsoidPressureField<double>(ellipsoid, &mesh, kElasticModulus,
+                                         kMargin);
+  const double relative_tolerance =
+      2.0 * std::numeric_limits<double>::epsilon();
+  VerifyInvariantsOfThePressureFieldWithMargin(
+      field_no_margin, field_with_margin, kMargin, elastic_foundation_depth,
+      kElasticModulus, relative_tolerance);
 }
 
 }  // namespace

--- a/geometry/proximity/test/make_mesh_field_test.cc
+++ b/geometry/proximity/test/make_mesh_field_test.cc
@@ -5,6 +5,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/make_mesh_from_vtk.h"
+#include "drake/geometry/proximity/test/pressure_field_invariants.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -44,6 +45,24 @@ TYPED_TEST(MakeVolumeMeshPressureFieldTest, PressureOnNonConvexMesh) {
     static_assert(std::is_same_v<T, AutoDiffXd>);
     EXPECT_EQ(field.EvaluateAtVertex(0).value(), kHydroelasticModulus.value());
   }
+}
+
+GTEST_TEST(MakeVolumeMeshPressureFieldTest, WithMargin) {
+  const double kHydroelasticModulus = 1.0e5;
+  const double kMargin = 0.012;
+  // Max distance consistent with non_convex_mesh.vtk. This value might need to
+  // be updated if that file changes.
+  const double elastic_foundation_depth = 0.1;
+  const VolumeMesh<double> non_convex_mesh = MakeVolumeMeshFromVtk<double>(
+      Mesh(FindResourceOrThrow("drake/geometry/test/non_convex_mesh.vtk")));
+  const VolumeMeshFieldLinear<double, double> field_no_margin =
+      MakeVolumeMeshPressureField(&non_convex_mesh, kHydroelasticModulus);
+  const VolumeMeshFieldLinear<double, double> field_with_margin =
+      MakeVolumeMeshPressureField(&non_convex_mesh, kHydroelasticModulus,
+                                  kMargin);
+  VerifyInvariantsOfThePressureFieldWithMargin(
+      field_no_margin, field_with_margin, kMargin, elastic_foundation_depth,
+      kHydroelasticModulus);
 }
 
 // Tests that an input mesh without interior vertices will throw. For

--- a/geometry/proximity/test/make_sphere_field_test.cc
+++ b/geometry/proximity/test/make_sphere_field_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/test/pressure_field_invariants.h"
 
 namespace drake {
 namespace geometry {
@@ -78,6 +79,22 @@ GTEST_TEST(MakeSphereFieldTest, MakeSpherePressureField) {
       MakeSpherePressureField<double>(sphere, &mesh, kElasticModulus);
 
   CheckMinMaxBoundaryValue(pressure_field, kElasticModulus);
+}
+
+GTEST_TEST(MakeSphereFieldTest, WithMargin) {
+  const double kElasticModulus = 1.0e5;
+  const double kMargin = 0.12;
+  const Sphere sphere(2.0);
+  const double elastic_foundation_depth = 2.0;  // The sphere's radius.
+  auto mesh = MakeSphereVolumeMesh<double>(
+      sphere, 0.5, TessellationStrategy::kSingleInteriorVertex);
+  const VolumeMeshFieldLinear<double, double> field_no_margin =
+      MakeSpherePressureField<double>(sphere, &mesh, kElasticModulus);
+  const VolumeMeshFieldLinear<double, double> field_with_margin =
+      MakeSpherePressureField<double>(sphere, &mesh, kElasticModulus, kMargin);
+  VerifyInvariantsOfThePressureFieldWithMargin(
+      field_no_margin, field_with_margin, kMargin, elastic_foundation_depth,
+      kElasticModulus);
 }
 
 }  // namespace

--- a/geometry/proximity/test/pressure_field_invariants.cc
+++ b/geometry/proximity/test/pressure_field_invariants.cc
@@ -1,0 +1,63 @@
+#include "drake/geometry/proximity/test/pressure_field_invariants.h"
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/proximity/volume_to_surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+void VerifyInvariantsOfThePressureFieldWithMargin(
+    const VolumeMeshFieldLinear<double, double>& field_no_margin,
+    const VolumeMeshFieldLinear<double, double>& field_with_margin,
+    double margin, double elastic_foundation_depth, double hydroelastic_modulus,
+    double relative_tolerance) {
+  // Assert that both fields are defined on the same mesh.
+  DRAKE_DEMAND(&field_no_margin.mesh() == &field_with_margin.mesh());
+  const VolumeMesh<double>& mesh = field_no_margin.mesh();
+
+  const std::vector<int> boundary_vertices =
+      CollectUniqueVertices(IdentifyBoundaryFaces(mesh.tetrahedra()));
+
+  // Verify that pressure at the boundary is constant and equal to p̃₀ =
+  // −δ/(H−δ)⋅E .
+  const double expected_boundary_pressure =
+      -margin / (elastic_foundation_depth - margin) * hydroelastic_modulus;
+  const double tolerance =
+      relative_tolerance * std::abs(expected_boundary_pressure);
+  for (int v : boundary_vertices) {
+    const double p_with_margin = field_with_margin.EvaluateAtVertex(v);
+    // Pressure with margin at the boundary must be negative.
+    ASSERT_LT(p_with_margin, 0);
+    ASSERT_NEAR(p_with_margin, expected_boundary_pressure, tolerance);
+  }
+
+  // Build the set of interior vertices.
+  std::vector<int> all_vertices(mesh.num_vertices());
+  std::iota(all_vertices.begin(), all_vertices.end(), 0);
+  std::vector<int> interior_vertices;
+  std::set_difference(all_vertices.begin(), all_vertices.end(),
+                      boundary_vertices.begin(), boundary_vertices.end(),
+                      std::back_inserter(interior_vertices));
+
+  // For interior vertices only, verify the linear relationship between the
+  // pressure fields without and with margin.
+  const double expected_slope =
+      elastic_foundation_depth / (elastic_foundation_depth - margin);
+  for (int v : interior_vertices) {
+    const double p_no_margin = field_no_margin.EvaluateAtVertex(v);
+    const double p_with_margin = field_with_margin.EvaluateAtVertex(v);
+    const double slope =
+        (p_with_margin - expected_boundary_pressure) / p_no_margin;
+    ASSERT_NEAR(slope, expected_slope, relative_tolerance);
+  }
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/pressure_field_invariants.h
+++ b/geometry/proximity/test/pressure_field_invariants.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <limits>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* This function compares two "elastic foundation" pressure fields defined on a
+same mesh.
+
+For pressure fields computed using an elastic foundation model, pressure
+relates to the distance to the surface by:
+ p = (−ϕ−δ)/(H−δ)⋅E
+where ϕ is the signed distance to the surface, δ the margin, E the hydroelastic
+modulus, and H is a characteristic length that depends on the geometry.
+
+Denoting with `p` the pressure with no margin (δ = 0) and with `p̃` the pressure
+computed with a positive margin value, there is a simple, linear relationship
+between `p` and `p̃`:
+    p̃ = s⋅p + p̃₀
+where p̃₀ = −δ/(H−δ)⋅E is the value that the pressure field with margin takes at
+the boundary of the geometry, and s = H/(H−δ) > 1 is the "slope" of this linear
+relation ship.
+
+For such pressure fields, this function verifies the invariants:
+ 1. The two fields are defined on the same mesh.
+ 2. Pressure on the surface is uniform and equal to p̃₀`.
+ 3. The linear relationship slope is uniform and equal to s.
+
+@param[in] field_no_margin The pressure field for δ = 0.
+@param[in] field_with_margin The pressure field for δ > 0.
+@param[in] margin The margin value δ.
+@param[in] elastic_foundation_depth The Elastic Foundation depth H.
+@param[in] hydroelastic_modulus The hydroelastic modulus E.
+@param[in] relative_tolerance Relative dimensionless tolerance used to perform
+floating point comparisons.
+
+@pre The two fields are defined on the same mesh. */
+void VerifyInvariantsOfThePressureFieldWithMargin(
+    const VolumeMeshFieldLinear<double, double>& field_no_margin,
+    const VolumeMeshFieldLinear<double, double>& field_with_margin,
+    double margin, double elastic_foundation_depth, double hydroelastic_modulus,
+    double relative_tolerance = std::numeric_limits<double>::epsilon());
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Part of the larger PR #21528.

This PR focuses solely on the internal functions that define the pressure fields. 
This way we can delay public APIs and contracts to follow up PRs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21726)
<!-- Reviewable:end -->
