### PR TITLE
Python bind CalcCenterOfMassTranslationalVelocity/Acceleration()

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -335,6 +335,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 &Class::CalcCenterOfMassPositionInWorld),
             py::arg("context"), py::arg("model_instances"),
             cls_doc.CalcCenterOfMassPositionInWorld.doc_2args)
+        .def("CalcCenterOfMassTranslationalVelocityInWorld",
+            overload_cast_explicit<Vector3<T>, const Context<T>&>(
+                &Class::CalcCenterOfMassTranslationalVelocityInWorld),
+            py::arg("context"),
+            cls_doc.CalcCenterOfMassTranslationalVelocityInWorld.doc_1args)
+        .def("CalcCenterOfMassTranslationalVelocityInWorld",
+            overload_cast_explicit<Vector3<T>, const Context<T>&,
+                const std::vector<ModelInstanceIndex>&>(
+                &Class::CalcCenterOfMassTranslationalVelocityInWorld),
+            py::arg("context"), py::arg("model_instances"),
+            cls_doc.CalcCenterOfMassTranslationalVelocityInWorld.doc_2args)
         .def(
             "CalcSpatialInertia",
             [](const Class* self, const Context<T>& context,

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -346,6 +346,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 &Class::CalcCenterOfMassTranslationalVelocityInWorld),
             py::arg("context"), py::arg("model_instances"),
             cls_doc.CalcCenterOfMassTranslationalVelocityInWorld.doc_2args)
+        .def("CalcCenterOfMassTranslationalAccelerationInWorld",
+            overload_cast_explicit<Vector3<T>, const Context<T>&>(
+                &Class::CalcCenterOfMassTranslationalAccelerationInWorld),
+            py::arg("context"),
+            cls_doc.CalcCenterOfMassTranslationalAccelerationInWorld.doc_1args)
+        .def("CalcCenterOfMassTranslationalAccelerationInWorld",
+            overload_cast_explicit<Vector3<T>, const Context<T>&,
+                const std::vector<ModelInstanceIndex>&>(
+                &Class::CalcCenterOfMassTranslationalAccelerationInWorld),
+            py::arg("context"), py::arg("model_instances"),
+            cls_doc.CalcCenterOfMassTranslationalAccelerationInWorld.doc_2args)
         .def(
             "CalcSpatialInertia",
             [](const Class* self, const Context<T>& context,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1208,6 +1208,13 @@ class TestPlant(unittest.TestCase):
             context=context, model_instances=[instance])
         self.assertTupleEqual(p_com.shape, (3, ))
 
+        v_com = plant.CalcCenterOfMassTranslationalVelocityInWorld(
+            context=context)
+        self.assertTupleEqual(v_com.shape, (3, ))
+        v_com = plant.CalcCenterOfMassTranslationalVelocityInWorld(
+            context=context, model_instances=[instance])
+        self.assertTupleEqual(v_com.shape, (3, ))
+
         M_WWo_W = plant.CalcSpatialInertia(
             context=context, frame_F=world_frame,
             body_indexes=[BodyIndex(0)])

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1215,6 +1215,13 @@ class TestPlant(unittest.TestCase):
             context=context, model_instances=[instance])
         self.assertTupleEqual(v_com.shape, (3, ))
 
+        a_com = plant.CalcCenterOfMassTranslationalAccelerationInWorld(
+            context=context)
+        self.assertTupleEqual(a_com.shape, (3, ))
+        a_com = plant.CalcCenterOfMassTranslationalAccelerationInWorld(
+            context=context, model_instances=[instance])
+        self.assertTupleEqual(a_com.shape, (3, ))
+
         M_WWo_W = plant.CalcSpatialInertia(
             context=context, frame_F=world_frame,
             body_indexes=[BodyIndex(0)])

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1215,12 +1215,33 @@ class TestPlant(unittest.TestCase):
             context=context, model_instances=[instance])
         self.assertTupleEqual(v_com.shape, (3, ))
 
-        a_com = plant.CalcCenterOfMassTranslationalAccelerationInWorld(
-            context=context)
-        self.assertTupleEqual(a_com.shape, (3, ))
-        a_com = plant.CalcCenterOfMassTranslationalAccelerationInWorld(
-            context=context, model_instances=[instance])
-        self.assertTupleEqual(a_com.shape, (3, ))
+        # Test center of mass translational acceleration for entire plant.
+        if T == Expression and plant.time_step() != 0:
+            # Discrete time dynamics are not supported for symbolic scalars.
+            with self.assertRaises(Exception) as cm:
+                a_com = plant.CalcCenterOfMassTranslationalAccelerationInWorld(
+                    context=context)
+            self.assertIn(
+                "This method doesn't support T = Expression",
+                str(cm.exception))
+        else:
+            a_com = plant.CalcCenterOfMassTranslationalAccelerationInWorld(
+                context=context)
+            self.assertTupleEqual(a_com.shape, (3, ))
+
+        # Test center of mass translational acceleration for model_instances.
+        if T == Expression and plant.time_step() != 0:
+            # Discrete time dynamics are not supported for symbolic scalars.
+            with self.assertRaises(Exception) as cm:
+                a_com = plant.CalcCenterOfMassTranslationalAccelerationInWorld(
+                    context=context, model_instances=[instance])
+            self.assertIn(
+                "This method doesn't support T = Expression",
+                str(cm.exception))
+        else:
+            a_com = plant.CalcCenterOfMassTranslationalAccelerationInWorld(
+                context=context, model_instances=[instance])
+            self.assertTupleEqual(a_com.shape, (3, ))
 
         M_WWo_W = plant.CalcSpatialInertia(
             context=context, frame_F=world_frame,


### PR DESCRIPTION
PR #21710 created C++ code for the new function Multibody::CalcCenterOfMassTranslationalAccelerationInWorld(), which is work towards issue #14269.

This PR creates Python bindings for this new function along with the older C++ function Multibody::CalcCenterOfMassTranslationalVelocityInWorld() (which is missing Python bindings).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21730)
<!-- Reviewable:end -->
