### PR TITLE
[workspace] Fix "gfortran not found" error reporting

### DIFF
--- a/tools/workspace/gfortran/repository.bzl
+++ b/tools/workspace/gfortran/repository.bzl
@@ -2,9 +2,10 @@ load("//tools/workspace:execute.bzl", "execute_or_fail", "which")
 
 def _gfortran_impl(repo_ctx):
     # Find the compiler.
-    compiler = str(which(repo_ctx, "gfortran"))
+    compiler = which(repo_ctx, "gfortran")
     if not compiler:
         fail("Could not find gfortran")
+    compiler = str(compiler)
     repo_ctx.symlink(compiler, "gfortran-found")
 
     # Transcribe which version we found.


### PR DESCRIPTION
The `which()` function returns `None` on error. We need to check for that before converting to a string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21732)
<!-- Reviewable:end -->
