### PR TITLE
Remove/deprecate default value in CalcSpatialInertia(TriangleSurfaceMesh, density = 1).

### DIFF
--- a/multibody/parsing/detail_mesh_parser.cc
+++ b/multibody/parsing/detail_mesh_parser.cc
@@ -128,8 +128,8 @@ std::optional<ModelInstanceIndex> AddModelFromMesh(
   const ModelInstanceIndex model_instance =
       plant.AddModelInstance(model_instance_name);
 
-  const SpatialInertia<double> M_BBo_B =
-      CalcSpatialInertia(*named_mesh.mesh, 1000.0 /* kg/m3 */);
+  const SpatialInertia<double> M_BBo_B = CalcSpatialInertia(
+      *named_mesh.mesh, 1000.0 /* water density ≈ 1000 kg/m³ */);
   const RigidBody<double>& body =
       plant.AddRigidBody(candidate_name, model_instance, M_BBo_B);
 

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -433,13 +433,19 @@ class MujocoParser {
         M_GG_G_ = mesh_inertia_->at(name_);
       } else {
         try {  // TODO(21666), remove the try-catch.
-          M_GG_G_ = CalcSpatialInertia(mesh, 1.0 /* density */);
+          // Below: density = 1 kg/m³ is used to calculate a spatial inertia.
+          // Later, after InertiaCalculator::Calc(), spatial inertia may be
+          // scaled with a proper density (e.g., water density ≈ 1000 kg/m³).
+          M_GG_G_ = CalcSpatialInertia(mesh, 1.0 /* air density ≈ 1 kg/m³ */);
         } catch (const std::exception& e) {
           // As with mujoco, failure leads to using the convex hull.
           // https://github.com/google-deepmind/mujoco/blob/df7ea3ed3350164d0f111c12870e46bc59439a96/src/user/user_mesh.cc#L1379-L1382
+          // Below: density = 1 kg/m³ is used to calculate a spatial inertia.
+          // Later, after InertiaCalculator::Calc(), spatial inertia may be
+          // scaled with a proper density (e.g., water density ≈ 1000 kg/m³).
           M_GG_G_ = CalcSpatialInertia(
               geometry::Convex(mesh.filename(), mesh.scale()),
-              1.0 /* density */);
+              1.0 /* air density ≈ 1 kg/m³ */);
           used_convex_hull_fallback_ = true;
         }
         mesh_inertia_->insert_or_assign(name_, M_GG_G_);
@@ -451,7 +457,10 @@ class MujocoParser {
     }
 
     void DefaultImplementGeometry(const geometry::Shape& shape) final {
-      M_GG_G_ = CalcSpatialInertia(shape, 1.0 /* density */);
+      // Below: density = 1 kg/m³ is used to calculate a spatial inertia.
+      // Later, after InertiaCalculator::Calc(), spatial inertia may be
+      // scaled with a proper density (e.g., water density ≈ 1000 kg/m³).
+      M_GG_G_ = CalcSpatialInertia(shape, 1.0 /* air density ≈ 1 kg/m³ */);
     }
 
    private:
@@ -812,7 +821,7 @@ class MujocoParser {
       }
       double mass{};
       if (!ParseScalarAttribute(node, "mass", &mass)) {
-        double density{1000};
+        double density{1000};  /* water density ≈ 1000 kg/m³ */
         ParseScalarAttribute(node, "density", &density);
         // M_GG_G_one was calculated with ρ₁ = 1 which produced mass m₁. Actual
         // density is ρₐ. We have the following ratio: mₐ / m₁ = ρₐ / ρ₁.

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -440,7 +440,8 @@ class MujocoParser {
           // As with mujoco, failure leads to using the convex hull.
           // https://github.com/google-deepmind/mujoco/blob/df7ea3ed3350164d0f111c12870e46bc59439a96/src/user/user_mesh.cc#L1379-L1382
           M_GG_G_unitDensity = CalcSpatialInertia(
-              geometry::Convex(mesh.filename(), mesh.scale()), 1 /* density */);
+              geometry::Convex(mesh.filename(), mesh.scale()),
+              1.0 /* density */);
           used_convex_hull_fallback_ = true;
         }
         mesh_inertia_->insert_or_assign(name_, M_GG_G_unitDensity);

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -402,8 +402,8 @@ class MujocoParser {
     WarnUnsupportedAttribute(*node, "user");
   }
 
-  // Computes spatial inertia for a shape assuming a density of 1 kg/m³ (≈ air).
-  // Later: A calling function is responsible for scaling the spatial inertia's
+  // Computes a shape's spatial inertia assuming a density of 1 kg/m³ (≈ air).
+  // Note: A calling function is responsible for scaling the spatial inertia's
   // underlying mass and rotational inertia, e.g, with a parser-specified mass
   // or density or a fallback density of 1000 kg/m³ (≈ water density).
   class UnitDensityInertiaCalculator final : public geometry::ShapeReifier {
@@ -412,7 +412,7 @@ class MujocoParser {
     // The reifier aliases the pre-computed mesh spatial inertias. When looking
     // up mesh inertias, it uses the mujoco geometry _name_ and not the
     // mesh filename.
-    UnitDensityInertiaCalculator(F
+    UnitDensityInertiaCalculator(
         std::string name,
         std::map<std::string, SpatialInertia<double>>* mesh_inertia)
         : name_(std::move(name)), mesh_inertia_(mesh_inertia) {

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -7,6 +7,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -402,26 +403,35 @@ class MujocoParser {
     WarnUnsupportedAttribute(*node, "user");
   }
 
-  // Computes a shape's spatial inertia assuming a density of 1 kg/m³ (≈ air).
-  // Note: A calling function is responsible for scaling the spatial inertia's
-  // underlying mass and rotational inertia, e.g, with a parser-specified mass
-  // or density or a fallback density of 1000 kg/m³ (≈ water density).
-  class UnitDensityInertiaCalculator final : public geometry::ShapeReifier {
+  // Computes and stores a shape's volume, centroid, and unit inertia. These
+  // quantities are useful for subsequently forming a spatial inertia e.g., with
+  // a user or parser specified mass or density (or a fallback default density).
+  class InertiaCalculator final : public geometry::ShapeReifier {
    public:
-    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UnitDensityInertiaCalculator);
+    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InertiaCalculator);
     // The reifier aliases the pre-computed mesh spatial inertias. When looking
     // up mesh inertias, it uses the mujoco geometry _name_ and not the
     // mesh filename.
-    UnitDensityInertiaCalculator(
+    InertiaCalculator(
         std::string name,
         std::map<std::string, SpatialInertia<double>>* mesh_inertia)
         : name_(std::move(name)), mesh_inertia_(mesh_inertia) {
       DRAKE_DEMAND(mesh_inertia != nullptr);
     }
 
-    SpatialInertia<double> Calc(const geometry::Shape& shape) {
+    // Returns the tuple [volume, p_GoGcm_G, G_GGcm_G], where for a geometry G,
+    // volume is G's volume, p_GoGcm_G is the position from G's origin point Go
+    // to its centroid Gcm expressed in the G frame, and G_GoGcm_G is G's unit
+    // inertia about Gcm expressed in the G frame.
+    // Note: if G has uniform density, Gcm is G's center of mass.
+    std::tuple<double, Vector3d, UnitInertia<double>> Calc(
+        const geometry::Shape& shape) {
       shape.Reify(this);
-      return M_GG_G_unitDensity;
+      const double& volume = M_GGcm_G_unitDensity.get_mass();
+      const Vector3<double>& p_GoGcm_G = M_GGcm_G_unitDensity.get_com();
+      const UnitInertia<double>& G_GGcm_G =
+          M_GGcm_G_unitDensity.get_unit_inertia();
+      return {volume, p_GoGcm_G, G_GGcm_G};
     }
 
     bool used_convex_hull_fallback() const {
@@ -432,35 +442,39 @@ class MujocoParser {
 
     void ImplementGeometry(const geometry::Mesh& mesh, void*) final {
       if (mesh_inertia_->contains(name_)) {
-        M_GG_G_unitDensity = mesh_inertia_->at(name_);
+        M_GGcm_G_unitDensity = mesh_inertia_->at(name_);
       } else {
         try {  // TODO(21666), remove the try-catch.
-          M_GG_G_unitDensity = CalcSpatialInertia(mesh, 1.0 /* density */);
+          M_GGcm_G_unitDensity = CalcSpatialInertia(mesh, 1.0 /* density */);
         } catch (const std::exception& e) {
           // As with mujoco, failure leads to using the convex hull.
           // https://github.com/google-deepmind/mujoco/blob/df7ea3ed3350164d0f111c12870e46bc59439a96/src/user/user_mesh.cc#L1379-L1382
-          M_GG_G_unitDensity = CalcSpatialInertia(
+          M_GGcm_G_unitDensity = CalcSpatialInertia(
               geometry::Convex(mesh.filename(), mesh.scale()),
               1.0 /* density */);
           used_convex_hull_fallback_ = true;
         }
-        mesh_inertia_->insert_or_assign(name_, M_GG_G_unitDensity);
+        mesh_inertia_->insert_or_assign(name_, M_GGcm_G_unitDensity);
       }
     }
 
     void ImplementGeometry(const geometry::HalfSpace&, void*) final {
-      // Do nothing; leave M_GG_G_unitDensity default initialized.
+      // Do nothing; leave M_GGcm_G_unitDensity default initialized.
     }
 
     void DefaultImplementGeometry(const geometry::Shape& shape) final {
-      M_GG_G_unitDensity = CalcSpatialInertia(shape, 1.0 /* density */);
+      M_GGcm_G_unitDensity = CalcSpatialInertia(shape, 1.0 /* density */);
     }
 
    private:
     std::string name_;
     std::map<std::string, SpatialInertia<double>>* mesh_inertia_{nullptr};
     bool used_convex_hull_fallback_{false};
-    SpatialInertia<double> M_GG_G_unitDensity{SpatialInertia<double>::NaN()};
+    // Note: The spatial inertia below uses unit density (1 kg/m³ ≈ air density)
+    // so the shape's mass value is equal to its volume value. To be clear,
+    // unit density is a mathematical trick so CalcSpatialInertia() stores
+    // a mass value = volume (which is not a physically meaningful mass value).
+    SpatialInertia<double> M_GGcm_G_unitDensity{SpatialInertia<double>::NaN()};
   };
 
   SpatialInertia<double> ParseInertial(XMLElement* node) {
@@ -793,9 +807,8 @@ class MujocoParser {
     WarnUnsupportedAttribute(*node, "user");
 
     if (compute_inertia) {
-      UnitDensityInertiaCalculator calculator(mesh, &mesh_inertia_);
-      const SpatialInertia<double> M_GG_G_unitDensity =
-          calculator.Calc(*geom.shape);
+      InertiaCalculator calculator(mesh, &mesh_inertia_);
+      const auto [volume, p_GGcm_G, G_GGcm_G] = calculator.Calc(*geom.shape);
       if (calculator.used_convex_hull_fallback()) {
         // When the Mujoco parser falls back to using a convex hull, it prints
         // a warning. We ape that behavior to provide a similar experience.
@@ -817,14 +830,10 @@ class MujocoParser {
       if (!ParseScalarAttribute(node, "mass", &mass)) {
         double density{1000};  /* fallback default ≈ water density */
         ParseScalarAttribute(node, "density", &density);
-        // M_GG_G_unitDensity was calculated with ρ₁ = 1 which produced mass m₁.
-        // Actual density is ρₐ. We have the following ratio: mₐ / m₁ = ρₐ / ρ₁.
-        // So, mₐ = m₁⋅(ρₐ / ρ₁) = m₁⋅(ρₐ / 1) = m₁⋅ρₐ.
-        mass = M_GG_G_unitDensity.get_mass() * density;
+        mass = volume * density;
       }
-      SpatialInertia<double> M_GG_G(mass, M_GG_G_unitDensity.get_com(),
-                                    M_GG_G_unitDensity.get_unit_inertia());
-      geom.M_GBo_B = M_GG_G.ReExpress(geom.X_BG.rotation())
+      SpatialInertia<double> M_GGcm_G(mass, p_GGcm_G, G_GGcm_G);
+      geom.M_GBo_B = M_GGcm_G.ReExpress(geom.X_BG.rotation())
                          .Shift(-geom.X_BG.translation());
     }
     return geom;

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -836,7 +836,7 @@ class MujocoParser {
       }
       SpatialInertia<double> M_GGo_G(mass, p_GoGcm_G, G_GGo_G);
 
-      // Shift spatial inertia from Go to Bo.
+      // Shift spatial inertia from Go to Bo and express it in the B frame.
       const math::RotationMatrix<double>& R_BG = geom.X_BG.rotation();
       const Vector3<double>& p_BoGo_B = geom.X_BG.translation();
       geom.M_GBo_B = M_GGo_G.ReExpress(R_BG).Shift(-p_BoGo_B);

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -429,6 +429,8 @@ class MujocoParser {
     std::tuple<double, Vector3d, UnitInertia<double>> Calc(
         const geometry::Shape& shape) {
       shape.Reify(this);
+      // For unit density (1 kg/m³), the value of mass is equal to the value of
+      // volume.
       const double& volume = M_GGo_G_unitDensity.get_mass();
       const Vector3<double>& p_GoGcm_G = M_GGo_G_unitDensity.get_com();
       const UnitInertia<double>& G_GGo_G =
@@ -472,11 +474,11 @@ class MujocoParser {
     std::string name_;
     std::map<std::string, SpatialInertia<double>>* mesh_inertia_{nullptr};
     bool used_convex_hull_fallback_{false};
-    // Note: The spatial inertia below uses unit density so the shape's volume
-    // value is equal to its mass value. To be clear, unit density is a
-    // mathematical trick (1 kg/m³ ≈ air density is an unreasonable *physical*
-    // value) that causes CalcSpatialInertia() to report a mass value equal to
-    // volume.
+    // Note: The spatial inertia below uses unit density so that the shape's
+    // volume value is equal to its mass value. To be clear, unit density is a
+    // mathematical trick to use CalcSpatialInertia() to report volume and not
+    // a reasonable *physical* default value; 1 kg/m³ is approximately air's
+    // density.
     SpatialInertia<double> M_GGo_G_unitDensity{SpatialInertia<double>::NaN()};
   };
 

--- a/multibody/parsing/test/detail_mesh_parser_test.cc
+++ b/multibody/parsing/test/detail_mesh_parser_test.cc
@@ -237,8 +237,8 @@ TEST_F(MeshParserTest, CorrectMass) {
       SpatialInertia<double>::SolidBoxWithDensity(density, 2, 2, 2);
   const SpatialInertia<double> I_BBo_B =
       body.CalcSpatialInertiaInBodyFrame(*context);
-  // For unit scale, we'd expect tolerance to be satisifed around 1e-15; with
-  // a mass of 1e3 kg/m³, we have to scale the tolerance accordingly.
+  // For unit scale, we'd expect tolerance to be satisfied around 1e-15; with
+  // a mass of 1000 kg/m³, we have to scale the tolerance accordingly.
   EXPECT_TRUE(CompareMatrices(I_BBo_B.CopyToFullMatrix6(),
                               I_BBo_B_expected.CopyToFullMatrix6(), 1e-12));
 }

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -785,14 +785,14 @@ TEST_F(BoxMeshTest, MeshFileScaleViaDefault) {
   TestBoxMesh(box_obj_, mesh_asset, defaults, 2.0);
 }
 
-// CalcSpatialInertia cannot necessarily compute a physical spatial inertia for
-// meshes which don't adhere to its requirements. The parser detects this and
-// provides a fallback so that it doesn't choke.
+// CalcSpatialInertia() cannot necessarily compute a physical spatial inertia
+// for meshes which don't adhere to its requirements. The parser detects this
+// and provides a fallback so that it doesn't choke.
 // Per #21666 the failure is reported by throwing, in the future it will be
 // via some non-throwing protocol.
 TEST_F(MujocoParserTest, BadMeshSpatialInertiaFallback) {
   // This obj is known to produce a non-physical spatial inertia in
-  // CalcSpatialInertia.
+  // CalcSpatialInertia().
   const RlocationOrError rlocation = FindRunfile(
       "mujoco_menagerie_internal/hello_robot_stretch/assets/base_link_0.obj");
   ASSERT_EQ(rlocation.error, "");
@@ -802,8 +802,9 @@ TEST_F(MujocoParserTest, BadMeshSpatialInertiaFallback) {
   // is fixed, it will be some other mechanism. Evolve *this* test to match
   // that API, but otherwise keep this confirmation that the mesh in question
   // truly is "bad".
-  DRAKE_EXPECT_THROWS_MESSAGE(CalcSpatialInertia(bad_mesh, 1.0),
-                              ".*IsPhysicallyValid[\\s\\S]*");
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcSpatialInertia(
+      bad_mesh, 1.0 /* air density ≈ 1 kg/m³ */),
+          ".*IsPhysicallyValid[\\s\\S]*");
 
   std::string xml = fmt::format(R"""(
 <mujoco model="test">

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -802,8 +802,7 @@ TEST_F(MujocoParserTest, BadMeshSpatialInertiaFallback) {
   // is fixed, it will be some other mechanism. Evolve *this* test to match
   // that API, but otherwise keep this confirmation that the mesh in question
   // truly is "bad".
-  DRAKE_EXPECT_THROWS_MESSAGE(CalcSpatialInertia(
-      bad_mesh, 1.0 /* air density ≈ 1 kg/m³ */),
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcSpatialInertia(bad_mesh, 1.0),
           ".*IsPhysicallyValid[\\s\\S]*");
 
   std::string xml = fmt::format(R"""(

--- a/multibody/tree/geometry_spatial_inertia.h
+++ b/multibody/tree/geometry_spatial_inertia.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/multibody/tree/spatial_inertia.h"
@@ -49,7 +50,14 @@ SpatialInertia<double> CalcSpatialInertia(const geometry::Shape& shape,
  is meaningless.
  @pydrake_mkdoc_identifier{mesh} */
 SpatialInertia<double> CalcSpatialInertia(
-    const geometry::TriangleSurfaceMesh<double>& mesh, double density = 1.0);
+    const geometry::TriangleSurfaceMesh<double>& mesh, double density);
+
+DRAKE_DEPRECATED(
+    "2025-01-01",
+    "In the function CalcSpatialInertia(), the density argument's default "
+    "value of 1.0 was removed. Provide a sensible density value.")
+SpatialInertia<double> CalcSpatialInertia(
+    const geometry::TriangleSurfaceMesh<double>& mesh);
 
 // TODO(SeanCurtis-TRI): Add CalcSpatialinertia(VolumeMesh).
 

--- a/multibody/tree/geometry_spatial_inertia.h
+++ b/multibody/tree/geometry_spatial_inertia.h
@@ -53,7 +53,7 @@ SpatialInertia<double> CalcSpatialInertia(
     const geometry::TriangleSurfaceMesh<double>& mesh, double density);
 
 DRAKE_DEPRECATED(
-    "2025-01-01",
+    "2024-11-01",
     "In the function CalcSpatialInertia(), the density argument's default "
     "value of 1.0 was removed. Provide a sensible density value.")
 SpatialInertia<double> CalcSpatialInertia(

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -200,7 +200,7 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
     EXPECT_NO_THROW(CalcSpatialInertia(unit_scale_vtk, kDensity));
     if constexpr (std::is_same_v<MeshType, geometry::Mesh>) {
       // For MeshType = Convex, we won't achieve *this* error message in
-      // CalcSpatialInertia; we'll fail in the underlying computation of the
+      // CalcSpatialInertia(); we'll fail in the underlying computation of the
       // convex hull for an unsupported file type (which is tested elsewhere).
       // So, we'll skip *this* test for Convex.
       DRAKE_EXPECT_THROWS_MESSAGE(


### PR DESCRIPTION
In geometry_spatial_inertia.h, delete the nonsensical default density value = 1 kg/m³ (air density ≈ 1 kg/m³) in the function
```
SpatialInertia<double> CalcSpatialInertia(
    const geometry::TriangleSurfaceMesh<double>& mesh, double density = 1 );
```
Note: Since this default value is not used in Drake C++ code and the default value is absent in Drake's Python bindings, this change is unlikely to affect caller code (there does not seem to be any in ANZU).  The deprecation does not affect Python, only C++.  

Note: Removing this default value makes this function's density argument signature match the overload in geometry_spatial_inertia.h.

Resolves issue #21728.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21738)
<!-- Reviewable:end -->
