### PR TITLE
[multibody] Allow implicit PD gain tweaks post-finalize

### DIFF
--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -23,10 +23,12 @@ JointActuator<T>::~JointActuator() = default;
 
 template <typename T>
 void JointActuator<T>::set_controller_gains(PdControllerGains gains) {
-  if (topology_.actuator_index_start >= 0) {
-    throw std::runtime_error(
-        "JointActuator::set_controller_gains() must be called before "
-        "MultibodyPlant::Finalize(). ");
+  if (!pd_controller_gains_ && topology_.actuator_index_start >= 0) {
+    throw std::runtime_error(fmt::format(
+        "Cannot add PD gains on the actuator named '{}'. "
+        "The first call to JointActuator::set_controller_gains() must happen "
+        "before MultibodyPlant::Finalize().",
+        name()));
   }
   DRAKE_THROW_UNLESS(gains.p > 0);
   DRAKE_THROW_UNLESS(gains.d >= 0);

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -277,8 +277,7 @@ class JointActuator final : public MultibodyElement<T> {
   /// modeling of PD controlled actuators.
   ///@{
 
-  // TODO(amcastro-tri): Place gains in the context as parameters to allow
-  // changing them post-finalize.
+  // TODO(amcastro-tri): Place gains in the context as parameters.
   /// Set controller gains for this joint actuator.
   /// This enables the modeling of a simple PD controller of the form:
   ///   ũ = -Kp⋅(q − qd) - Kd⋅(v − vd) + u_ff
@@ -292,10 +291,15 @@ class JointActuator final : public MultibodyElement<T> {
   /// velocity are specified through
   /// MultibodyPlant::get_desired_state_input_port().
   ///
+  /// @pre The MultibodyPlant associated with this actuator has not yet
+  /// allocated a Context. In other words, although gains can be changed
+  /// post-Finalize, they cannot be changed during simulation.
+  ///
   /// @throws iff the proportional gain is not strictly positive or if the
   /// derivative gain is negative.
-  /// @throws iff the owning MultibodyPlant is finalized. See
-  /// MultibodyPlant::Finalize().
+  /// @throws iff the owning MultibodyPlant is finalized and no gains were set
+  /// pre-finalize. In other words, *editing* gains post-finalize is fine, but
+  /// *adding* gains post-finalize is an error. See MultibodyPlant::Finalize().
   void set_controller_gains(PdControllerGains gains);
 
   /// Returns `true` if controller gains have been specified with a call to

--- a/multibody/tree/test/joint_actuator_test.cc
+++ b/multibody/tree/test/joint_actuator_test.cc
@@ -100,6 +100,15 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
 
   EXPECT_THAT(tree.GetJointActuatorIndices(),
               testing::ElementsAre(actuator1.index(), actuator4.index()));
+
+  // Changing the gains post-Finalize doesn't throw.
+  EXPECT_NO_THROW(mutable_actuator1.set_controller_gains(gains));
+
+  // Trying to add new gains post-Finalize throws.
+  JointActuator<double>& mutable_actuator4 =
+      tree.get_mutable_joint_actuator(actuator4.index());
+  DRAKE_EXPECT_THROWS_MESSAGE(mutable_actuator4.set_controller_gains(gains),
+                              ".*add PD.*Finalize.*");
 }
 
 GTEST_TEST(JointActuatorTest, RemoveJointActuatorTest) {


### PR DESCRIPTION
The old contract seemed quite restrictive (and led to maze-of-twisty-passages sim setup code in anzu), yet seemed easy to make a lot more gentle.  I haven't checked whether this lets us unwind the bad code in Anzu, but since this is so easy to fix it seemed a good starting point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21741)
<!-- Reviewable:end -->
