### PR TITLE
[gcs] Use pointers for optional arguments

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -921,7 +921,12 @@ void DefineGeometryOptimization(py::module m) {
         .def("ClearAllPhiConstraints",
             &GraphOfConvexSets::ClearAllPhiConstraints,
             cls_doc.ClearAllPhiConstraints.doc)
-        .def("GetGraphvizString", &GraphOfConvexSets::GetGraphvizString,
+        .def("GetGraphvizString",
+            overload_cast_explicit<std::string,
+                const solvers::MathematicalProgramResult*,
+                const GcsGraphvizOptions&,
+                const std::vector<const GraphOfConvexSets::Edge*>*>(
+                &GraphOfConvexSets::GetGraphvizString),
             py::arg("result") = nullptr,
             py::arg("options") = GcsGraphvizOptions(),
             py::arg("active_path") = nullptr, cls_doc.GetGraphvizString.doc)

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -922,18 +922,16 @@ void DefineGeometryOptimization(py::module m) {
             &GraphOfConvexSets::ClearAllPhiConstraints,
             cls_doc.ClearAllPhiConstraints.doc)
         .def("GetGraphvizString", &GraphOfConvexSets::GetGraphvizString,
-            py::arg("result") = std::nullopt,
+            py::arg("result") = nullptr,
             py::arg("options") = GcsGraphvizOptions(),
-            py::arg("active_path") = std::nullopt,
-            cls_doc.GetGraphvizString.doc)
+            py::arg("active_path") = nullptr, cls_doc.GetGraphvizString.doc)
         .def(
             "GetGraphvizString",
             [](const GraphOfConvexSets& self,
-                const std::optional<solvers::MathematicalProgramResult>& result,
+                const solvers::MathematicalProgramResult* result,
                 bool show_slacks, bool show_vars, bool show_flows,
                 bool show_costs, bool scientific, int precision,
-                const std::optional<
-                    std::vector<const GraphOfConvexSets::Edge*>>& active_path) {
+                std::vector<const GraphOfConvexSets::Edge*>* active_path) {
               const GcsGraphvizOptions options{.show_slacks = show_slacks,
                   .show_vars = show_vars,
                   .show_flows = show_flows,
@@ -942,12 +940,10 @@ void DefineGeometryOptimization(py::module m) {
                   .precision = precision};
               return self.GetGraphvizString(result, options, active_path);
             },
-            py::arg("result") =
-                std::optional<solvers::MathematicalProgramResult>(std::nullopt),
-            py::arg("show_slacks") = true, py::arg("show_vars") = true,
-            py::arg("show_flows") = true, py::arg("show_costs") = true,
-            py::arg("scientific") = false, py::arg("precision") = 3,
-            py::arg("active_path") = std::nullopt,
+            py::arg("result") = nullptr, py::arg("show_slacks") = true,
+            py::arg("show_vars") = true, py::arg("show_flows") = true,
+            py::arg("show_costs") = true, py::arg("scientific") = false,
+            py::arg("precision") = 3, py::arg("active_path") = nullptr,
             cls_doc.GetGraphvizString.doc)
         .def("SolveShortestPath",
             overload_cast_explicit<solvers::MathematicalProgramResult,

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -437,7 +437,11 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("num_positions", &Class::num_positions, cls_doc.num_positions.doc)
         .def("continuous_revolute_joints", &Class::continuous_revolute_joints,
             cls_doc.continuous_revolute_joints.doc)
-        .def("GetGraphvizString", &Class::GetGraphvizString,
+        .def("GetGraphvizString",
+            overload_cast_explicit<std::string,
+                const solvers::MathematicalProgramResult*,
+                const geometry::optimization::GcsGraphvizOptions&>(
+                &Class::GetGraphvizString),
             py::arg("result") = nullptr,
             py::arg("options") = geometry::optimization::GcsGraphvizOptions(),
             cls_doc.GetGraphvizString.doc)
@@ -469,7 +473,7 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
                 const std::vector<geometry::optimization::ConvexSet*>& regions,
                 const std::vector<std::pair<int, int>>& edges_between_regions,
                 int order, double h_min, double h_max, std::string name,
-                const std::optional<std::vector<Eigen::VectorXd>> edge_offsets)
+                std::optional<std::vector<Eigen::VectorXd>> edge_offsets)
                 -> Class::Subgraph& {
               return self.AddRegions(CloneConvexSets(regions),
                   edges_between_regions, order, h_min, h_max, std::move(name),
@@ -516,8 +520,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             },
             py_rvp::reference_internal, py::arg("from_subgraph"),
             py::arg("to_subgraph"), py::arg("subspace") = py::none(),
-            py::arg("edges_between_regions") = nullptr,
-            py::arg("edge_offsets") = nullptr, cls_doc.AddEdges.doc)
+            py::arg("edges_between_regions") = py::none(),
+            py::arg("edge_offsets") = py::none(), cls_doc.AddEdges.doc_5args)
         .def("AddTimeCost", &Class::AddTimeCost, py::arg("weight") = 1.0,
             cls_doc.AddTimeCost.doc)
         .def("AddPathLengthCost",

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -521,7 +521,7 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py_rvp::reference_internal, py::arg("from_subgraph"),
             py::arg("to_subgraph"), py::arg("subspace") = py::none(),
             py::arg("edges_between_regions") = py::none(),
-            py::arg("edge_offsets") = py::none(), cls_doc.AddEdges.doc_5args)
+            py::arg("edge_offsets") = py::none(), cls_doc.AddEdges.doc)
         .def("AddTimeCost", &Class::AddTimeCost, py::arg("weight") = 1.0,
             cls_doc.AddTimeCost.doc)
         .def("AddPathLengthCost",

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -438,13 +438,13 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
         .def("continuous_revolute_joints", &Class::continuous_revolute_joints,
             cls_doc.continuous_revolute_joints.doc)
         .def("GetGraphvizString", &Class::GetGraphvizString,
-            py::arg("result") = std::nullopt,
+            py::arg("result") = nullptr,
             py::arg("options") = geometry::optimization::GcsGraphvizOptions(),
             cls_doc.GetGraphvizString.doc)
         .def(
             "GetGraphvizString",
             [](const GcsTrajectoryOptimization& self,
-                const std::optional<solvers::MathematicalProgramResult>& result,
+                const solvers::MathematicalProgramResult* result,
                 bool show_slacks, bool show_vars, bool show_flows,
                 bool show_costs, bool scientific, int precision) {
               geometry::optimization::GcsGraphvizOptions options;
@@ -456,28 +456,30 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
               options.precision = precision;
               return self.GetGraphvizString(result, options);
             },
-            py::arg("result") =
-                std::optional<solvers::MathematicalProgramResult>(std::nullopt),
-            py::arg("show_slacks") = true, py::arg("show_vars") = true,
-            py::arg("show_flows") = true, py::arg("show_costs") = true,
-            py::arg("scientific") = false, py::arg("precision") = 3,
-            cls_doc.GetGraphvizString.doc)
+            py::arg("result") = nullptr, py::arg("show_slacks") = true,
+            py::arg("show_vars") = true, py::arg("show_flows") = true,
+            py::arg("show_costs") = true, py::arg("scientific") = false,
+            py::arg("precision") = 3, cls_doc.GetGraphvizString.doc)
         .def(
             "AddRegions",
+            // Pybind does not support None arguments for pointers to built-in
+            // and STL types, so we must use optional.
+            // https://pybind11.readthedocs.io/en/stable/advanced/functions.html#allow-prohibiting-none-arguments
             [](Class& self,
                 const std::vector<geometry::optimization::ConvexSet*>& regions,
                 const std::vector<std::pair<int, int>>& edges_between_regions,
                 int order, double h_min, double h_max, std::string name,
-                std::optional<std::vector<Eigen::VectorXd>> edge_offsets)
+                const std::optional<std::vector<Eigen::VectorXd>> edge_offsets)
                 -> Class::Subgraph& {
               return self.AddRegions(CloneConvexSets(regions),
                   edges_between_regions, order, h_min, h_max, std::move(name),
-                  edge_offsets);
+                  edge_offsets ? std::addressof(edge_offsets.value())
+                               : nullptr);
             },
             py_rvp::reference_internal, py::arg("regions"),
             py::arg("edges_between_regions"), py::arg("order"),
             py::arg("h_min") = 1e-6, py::arg("h_max") = 20,
-            py::arg("name") = "", py::arg("edge_offsets") = std::nullopt,
+            py::arg("name") = "", py::arg("edge_offsets") = py::none(),
             cls_doc.AddRegions.doc_7args)
         .def(
             "AddRegions",
@@ -493,11 +495,29 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py::arg("name") = "", cls_doc.AddRegions.doc_5args)
         .def("RemoveSubgraph", &Class::RemoveSubgraph, py::arg("subgraph"),
             cls_doc.RemoveSubgraph.doc)
-        .def("AddEdges", &Class::AddEdges, py_rvp::reference_internal,
-            py::arg("from_subgraph"), py::arg("to_subgraph"),
-            py::arg("subspace") = py::none(),
-            py::arg("edges_between_regions") = py::none(),
-            py::arg("edge_offsets") = py::none(), cls_doc.AddEdges.doc)
+        .def(
+            "AddEdges",
+            // Pybind does not support None arguments for pointers to built-in
+            // and STL types, so we must use optional.
+            // https://pybind11.readthedocs.io/en/stable/advanced/functions.html#allow-prohibiting-none-arguments
+            [](Class& self, const Class::Subgraph& from_subgraph,
+                const Class::Subgraph& to_subgraph,
+                const geometry::optimization::ConvexSet* subspace,
+                const std::optional<std::vector<std::pair<int, int>>>
+                    edges_between_regions,
+                const std::optional<std::vector<Eigen::VectorXd>> edge_offsets)
+                -> Class::EdgesBetweenSubgraphs& {
+              return self.AddEdges(from_subgraph, to_subgraph, subspace,
+                  edges_between_regions
+                      ? std::addressof(edges_between_regions.value())
+                      : nullptr,
+                  edge_offsets ? std::addressof(edge_offsets.value())
+                               : nullptr);
+            },
+            py_rvp::reference_internal, py::arg("from_subgraph"),
+            py::arg("to_subgraph"), py::arg("subspace") = py::none(),
+            py::arg("edges_between_regions") = nullptr,
+            py::arg("edge_offsets") = nullptr, cls_doc.AddEdges.doc)
         .def("AddTimeCost", &Class::AddTimeCost, py::arg("weight") = 1.0,
             cls_doc.AddTimeCost.doc)
         .def("AddPathLengthCost",
@@ -546,6 +566,7 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
 
   m.def("GetContinuousRevoluteJointIndices", &GetContinuousRevoluteJointIndices,
       py::arg("plant"), doc.GetContinuousRevoluteJointIndices.doc);
+  // NOLINTNEXTLINE(readability/fn_size)
 }
 
 }  // namespace internal

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -472,9 +472,9 @@ void GraphOfConvexSets::ClearAllPhiConstraints() {
 }
 
 std::string GraphOfConvexSets::GetGraphvizString(
-    const std::optional<solvers::MathematicalProgramResult>& result,
+    const solvers::MathematicalProgramResult* result,
     const GcsGraphvizOptions& options,
-    const std::optional<std::vector<const Edge*>>& active_path) const {
+    const std::vector<const Edge*>* active_path) const {
   // This function converts the range (0.0, 1.0) to Hex strings in the range
   // (20, FF).
   const int kMaxHexValue = 255;

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -686,11 +686,9 @@ class GraphOfConvexSets {
   graph edges.
   */
   std::string GetGraphvizString(
-      const std::optional<solvers::MathematicalProgramResult>& result =
-          std::nullopt,
+      const solvers::MathematicalProgramResult* result = nullptr,
       const GcsGraphvizOptions& options = GcsGraphvizOptions(),
-      const std::optional<std::vector<const Edge*>>& active_path =
-          std::nullopt) const;
+      const std::vector<const Edge*>* active_path = nullptr) const;
 
   /** Formulates and solves the mixed-integer convex formulation of the
   shortest path problem on the graph, as discussed in detail in

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -694,27 +694,10 @@ class GraphOfConvexSets {
       "2024-10-01",
       "result should be of type const solvers::MathematicalProgramResult*.");
   std::string GetGraphvizString(
-      const std::optional<solvers::MathematicalProgramResult>& result) const {
-    return GetGraphvizString(result ? std::addressof(result.value()) : nullptr);
-  }
-
-  DRAKE_DEPRECATED(
-      "2024-10-01",
-      "result should be of type const solvers::MathematicalProgramResult*.");
-  std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result,
-      const geometry::optimization::GcsGraphvizOptions& options) const {
-    return GetGraphvizString(result ? std::addressof(result.value()) : nullptr,
-                             options);
-  }
-
-  DRAKE_DEPRECATED(
-      "2024-10-01",
-      "result should be of type const solvers::MathematicalProgramResult*.");
-  std::string GetGraphvizString(
-      const std::optional<solvers::MathematicalProgramResult>& result,
-      const geometry::optimization::GcsGraphvizOptions& options,
-      const std::optional<std::vector<const Edge*>>& active_path) const {
+      const geometry::optimization::GcsGraphvizOptions& options =
+          GcsGraphvizOptions(),
+      const std::optional<std::vector<const Edge*>>& active_path = {}) const {
     return GetGraphvizString(
         result ? std::addressof(result.value()) : nullptr, options,
         active_path ? std::addressof(active_path.value()) : nullptr);

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -677,7 +677,7 @@ class GraphOfConvexSets {
   void ClearAllPhiConstraints();
 
   /** Returns a Graphviz string describing the graph vertices and edges. If
-  `results` is supplied, then the graph will be annotated with the solution
+  `result` is supplied, then the graph will be annotated with the solution
   values, according to `options`.
   @param result the optional result from a solver.
   @param options the struct containing various options for visualization.
@@ -689,6 +689,36 @@ class GraphOfConvexSets {
       const solvers::MathematicalProgramResult* result = nullptr,
       const GcsGraphvizOptions& options = GcsGraphvizOptions(),
       const std::vector<const Edge*>* active_path = nullptr) const;
+
+  DRAKE_DEPRECATED(
+      "2024-10-01",
+      "result should be of type const solvers::MathematicalProgramResult*.");
+  std::string GetGraphvizString(
+      const std::optional<solvers::MathematicalProgramResult>& result) const {
+    return GetGraphvizString(result ? std::addressof(result.value()) : nullptr);
+  }
+
+  DRAKE_DEPRECATED(
+      "2024-10-01",
+      "result should be of type const solvers::MathematicalProgramResult*.");
+  std::string GetGraphvizString(
+      const std::optional<solvers::MathematicalProgramResult>& result,
+      const geometry::optimization::GcsGraphvizOptions& options) const {
+    return GetGraphvizString(result ? std::addressof(result.value()) : nullptr,
+                             options);
+  }
+
+  DRAKE_DEPRECATED(
+      "2024-10-01",
+      "result should be of type const solvers::MathematicalProgramResult*.");
+  std::string GetGraphvizString(
+      const std::optional<solvers::MathematicalProgramResult>& result,
+      const geometry::optimization::GcsGraphvizOptions& options,
+      const std::optional<std::vector<const Edge*>>& active_path) const {
+    return GetGraphvizString(
+        result ? std::addressof(result.value()) : nullptr, options,
+        active_path ? std::addressof(active_path.value()) : nullptr);
+  }
 
   /** Formulates and solves the mixed-integer convex formulation of the
   shortest path problem on the graph, as discussed in detail in

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/geometry/optimization/convex_set.h"

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -3292,6 +3292,11 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   std::vector<const Edge*> active_edges{edge};
   EXPECT_THAT(g.GetGraphvizString(&result, viz_options, &active_edges),
               AllOf(HasSubstr("color=\"#ff0000\"")));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_THAT(g.GetGraphvizString(result, viz_options, active_edges),
+              AllOf(HasSubstr("color=\"#ff0000\"")));
+#pragma GCC diagnostic pop
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -3238,7 +3238,7 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
                     HasSubstr("source_to_target")));
 
   auto result = g.SolveShortestPath(*source, *target, options);
-  EXPECT_THAT(g.GetGraphvizString(result),
+  EXPECT_THAT(g.GetGraphvizString(&result),
               AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ ="),
                     HasSubstr("ϕ xᵤ ="), HasSubstr("ϕ xᵥ ="),
                     Not(HasSubstr("color=\"#ff0000\"")),
@@ -3249,49 +3249,49 @@ GTEST_TEST(ShortestPathTest, Graphviz) {
   result = g.SolveShortestPath(*source, *target, options);
   // Note: The cost here only comes from the cost=0 on other_to_target until
   // SolveConvexRestriction provides the rewritten costs.
-  EXPECT_THAT(g.GetGraphvizString(result),
+  EXPECT_THAT(g.GetGraphvizString(&result),
               AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ ="),
                     HasSubstr("color=\"#00000020\"]")));
 
   // No slack variables.
   viz_options.show_slacks = false;
-  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+  EXPECT_THAT(g.GetGraphvizString(&result, viz_options),
               AllOf(HasSubstr("x ="), HasSubstr("cost ="), HasSubstr("ϕ ="),
                     Not(HasSubstr("ϕ xᵤ =")), Not(HasSubstr("ϕ xᵥ ="))));
 
   // Precision and scientific.
   viz_options.precision = 2;
   viz_options.scientific = false;
-  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+  EXPECT_THAT(g.GetGraphvizString(&result, viz_options),
               AllOf(HasSubstr("x = [1.00 2.00]"), HasSubstr("x = [0.00]")));
 
   viz_options.scientific = true;
-  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+  EXPECT_THAT(g.GetGraphvizString(&result, viz_options),
               AllOf(HasSubstr("x = [1 2]"), HasSubstr("x = [1e-05]")));
 
   // No vertex vars
   viz_options.show_vars = false;
   viz_options.scientific = false;
-  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+  EXPECT_THAT(g.GetGraphvizString(&result, viz_options),
               AllOf(Not(HasSubstr("x ="))));
 
   // No cost
   viz_options.show_costs = false;
-  EXPECT_THAT(g.GetGraphvizString(result, viz_options),
+  EXPECT_THAT(g.GetGraphvizString(&result, viz_options),
               AllOf(Not(HasSubstr("cost ="))));
 
   // No flows
   viz_options.show_flows = false;
   EXPECT_THAT(
-      g.GetGraphvizString(result, viz_options),
+      g.GetGraphvizString(&result, viz_options),
       AllOf(Not(HasSubstr("ϕ =")), Not(HasSubstr("color=\"#00000020\"]"))));
 
   // Show active path
   viz_options.show_flows = false;
   viz_options.show_costs = false;
-  EXPECT_THAT(
-      g.GetGraphvizString(result, viz_options, std::vector<const Edge*>{edge}),
-      AllOf(HasSubstr("color=\"#ff0000\"")));
+  std::vector<const Edge*> active_edges{edge};
+  EXPECT_THAT(g.GetGraphvizString(&result, viz_options, &active_edges),
+              AllOf(HasSubstr("color=\"#ff0000\"")));
 }
 
 }  // namespace optimization

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -216,7 +216,7 @@ Subgraph::Subgraph(
     const std::vector<std::pair<int, int>>& edges_between_regions, int order,
     double h_min, double h_max, std::string name,
     GcsTrajectoryOptimization* traj_opt,
-    std::optional<const std::vector<VectorXd>> edge_offsets)
+    const std::vector<VectorXd>* edge_offsets)
     : regions_(regions),
       order_(order),
       h_min_(h_min),
@@ -225,7 +225,7 @@ Subgraph::Subgraph(
   DRAKE_THROW_UNLESS(order >= 0);
   DRAKE_THROW_UNLESS(!regions_.empty());
 
-  if (edge_offsets.has_value()) {
+  if (edge_offsets) {
     DRAKE_THROW_UNLESS(edge_offsets->size() == edges_between_regions.size());
   }
 
@@ -285,7 +285,7 @@ Subgraph::Subgraph(
     edges_.emplace_back(uv_edge);
 
     // Add path continuity constraints.
-    if (edge_offsets.has_value()) {
+    if (edge_offsets) {
       // In this case, we instead enforce the constraint
       // GetControlPoints(u).col(order) - GetControlPoints(v).col(0) =
       // -tau_uv.value(), via Ax = -edge_offsets.value()[idx], A = [I, -I],
@@ -686,12 +686,17 @@ symbolic::Variable Subgraph::GetTimeScaling(
 EdgesBetweenSubgraphs::EdgesBetweenSubgraphs(
     const Subgraph& from_subgraph, const Subgraph& to_subgraph,
     const ConvexSet* subspace, GcsTrajectoryOptimization* traj_opt,
-    std::optional<const std::vector<std::pair<int, int>>> edges_between_regions,
-    std::optional<const std::vector<Eigen::VectorXd>> edge_offsets)
+    const std::vector<std::pair<int, int>>* edges_between_regions,
+    const std::vector<Eigen::VectorXd>* edge_offsets)
     : traj_opt_(*traj_opt),
       from_subgraph_(from_subgraph),
       to_subgraph_(to_subgraph) {
-  if (edge_offsets.has_value()) {
+  if (edge_offsets) {
+    if (!edges_between_regions) {
+      throw std::runtime_error(
+          "If edge_offsets are specified, then edges_between_regions must also "
+          "be specified.");
+    }
     DRAKE_THROW_UNLESS(edge_offsets->size() == edges_between_regions->size());
   }
   // Formulate edge costs and constraints.
@@ -738,18 +743,17 @@ EdgesBetweenSubgraphs::EdgesBetweenSubgraphs(
   }
 
   std::vector<std::tuple<int, int, Eigen::VectorXd>> edge_data;
-  if (edges_between_regions.has_value()) {
-    edge_data.reserve(edges_between_regions.value().size());
-    for (int edge_idx = 0; edge_idx < ssize(edges_between_regions.value());
+  if (edges_between_regions) {
+    edge_data.reserve(edges_between_regions->size());
+    for (int edge_idx = 0; edge_idx < ssize(*edges_between_regions);
          ++edge_idx) {
-      int i = std::get<0>(edges_between_regions.value()[edge_idx]);
-      int j = std::get<1>(edges_between_regions.value()[edge_idx]);
+      int i = std::get<0>(edges_between_regions->at(edge_idx));
+      int j = std::get<1>(edges_between_regions->at(edge_idx));
       DRAKE_THROW_UNLESS(0 <= i && 0 <= j && i < from_subgraph_.size() &&
                          j < to_subgraph_.size());
       edge_data.emplace_back(i, j,
-                             edge_offsets.has_value()
-                                 ? edge_offsets->at(edge_idx)
-                                 : VectorXd::Zero(num_positions()));
+                             edge_offsets ? edge_offsets->at(edge_idx)
+                                          : VectorXd::Zero(num_positions()));
     }
   } else {
     // TODO(cohnt): Make the return type of CalcPairwiseIntersections match the
@@ -768,7 +772,7 @@ EdgesBetweenSubgraphs::EdgesBetweenSubgraphs(
       Eigen::VectorXd subspace_offset = sets_A_subspace_offset[i];
       if (!RegionsConnectThroughSubspace(*from_subgraph.regions()[i],
                                          *to_subgraph.regions()[j], *subspace,
-                                         edge_offset, subspace_offset)) {
+                                         &edge_offset, &subspace_offset)) {
         continue;
       }
     }
@@ -833,37 +837,35 @@ EdgesBetweenSubgraphs::~EdgesBetweenSubgraphs() = default;
 
 bool EdgesBetweenSubgraphs::RegionsConnectThroughSubspace(
     const ConvexSet& A, const ConvexSet& B, const ConvexSet& subspace,
-    std::optional<const VectorXd> maybe_set_B_offset,
-    std::optional<const VectorXd> maybe_subspace_offset) {
+    const VectorXd* maybe_set_B_offset, const VectorXd* maybe_subspace_offset) {
   DRAKE_THROW_UNLESS(A.ambient_dimension() > 0);
   DRAKE_THROW_UNLESS(A.ambient_dimension() == B.ambient_dimension());
   DRAKE_THROW_UNLESS(A.ambient_dimension() == subspace.ambient_dimension());
-  DRAKE_THROW_UNLESS(maybe_set_B_offset.has_value() ==
-                     maybe_subspace_offset.has_value());
-  if (maybe_set_B_offset.has_value()) {
-    DRAKE_THROW_UNLESS(maybe_set_B_offset.value().size() ==
-                       A.ambient_dimension());
-    DRAKE_THROW_UNLESS(maybe_subspace_offset.value().size() ==
-                       A.ambient_dimension());
+  // If the set_B offset is given, the subspace_offset must be given as well.
+  DRAKE_THROW_UNLESS((maybe_set_B_offset && maybe_subspace_offset) ||
+                     (!maybe_set_B_offset && !maybe_subspace_offset));
+  if (maybe_set_B_offset) {
+    DRAKE_THROW_UNLESS(maybe_set_B_offset->size() == A.ambient_dimension());
+    DRAKE_THROW_UNLESS(maybe_subspace_offset->size() == A.ambient_dimension());
   }
   if (std::optional<VectorXd> subspace_point = subspace.MaybeGetPoint()) {
     // If the subspace is a point, then the point must be in both A and B.
-    if (maybe_set_B_offset.has_value()) {
+    if (maybe_set_B_offset) {
       // Compute the value of the point such that it can be directly checked for
       // containment in A. We take its given value, and subtract the offset from
       // the set to the subspace.
       const VectorXd point_in_A_coords =
-          *subspace_point - maybe_subspace_offset.value();
+          *subspace_point - *maybe_subspace_offset;
       // Compute the value of the point such that it can be directly checked for
       // containment in B. We take the value of the point that can be checked
       // for A, and add the offset form A to B.
       const VectorXd point_in_B_coords =
-          point_in_A_coords + maybe_set_B_offset.value();
+          point_in_A_coords + *maybe_set_B_offset;
       return A.PointInSet(point_in_A_coords) && B.PointInSet(point_in_B_coords);
     } else {
       return A.PointInSet(*subspace_point) && B.PointInSet(*subspace_point);
     }
-  } else if (!maybe_set_B_offset.has_value()) {
+  } else if (!maybe_set_B_offset) {
     // Otherwise, we can formulate a problem to check if a point is contained in
     // A, B and the subspace.
     Intersection intersection(MakeConvexSets(A, B, subspace));
@@ -886,10 +888,10 @@ bool EdgesBetweenSubgraphs::RegionsConnectThroughSubspace(
         -MatrixXd::Identity(dimension, dimension);
     // y = x + B_offset as [I, -I][y; x] = [B_offset].
     prog.AddLinearEqualityConstraint(equality_constraint_matrix,
-                                     maybe_set_B_offset.value(), {x, y});
+                                     *maybe_set_B_offset, {x, y});
     // z = x + subspace_offset as [I, -I][z; x] = [subspace_offset]
     prog.AddLinearEqualityConstraint(equality_constraint_matrix,
-                                     maybe_subspace_offset.value(), {x, z});
+                                     *maybe_subspace_offset, {x, z});
 
     const auto result = Solve(prog);
     return result.is_success();
@@ -1365,8 +1367,8 @@ Subgraph& GcsTrajectoryOptimization::AddRegions(
     const ConvexSets& regions,
     const std::vector<std::pair<int, int>>& edges_between_regions, int order,
     double h_min, double h_max, std::string name,
-    std::optional<const std::vector<VectorXd>> edge_offsets) {
-  if (edge_offsets.has_value()) {
+    const std::vector<VectorXd>* edge_offsets) {
+  if (edge_offsets) {
     DRAKE_THROW_UNLESS(edge_offsets->size() == edges_between_regions.size());
   }
   if (name.empty()) {
@@ -1435,7 +1437,7 @@ Subgraph& GcsTrajectoryOptimization::AddRegions(const ConvexSets& regions,
 
   return GcsTrajectoryOptimization::AddRegions(regions, edges_between_regions,
                                                order, h_min, h_max,
-                                               std::move(name), edge_offsets);
+                                               std::move(name), &edge_offsets);
 }
 
 void GcsTrajectoryOptimization::RemoveSubgraph(const Subgraph& subgraph) {
@@ -1485,8 +1487,8 @@ void GcsTrajectoryOptimization::RemoveSubgraph(const Subgraph& subgraph) {
 EdgesBetweenSubgraphs& GcsTrajectoryOptimization::AddEdges(
     const Subgraph& from_subgraph, const Subgraph& to_subgraph,
     const ConvexSet* subspace,
-    std::optional<const std::vector<std::pair<int, int>>> edges_between_regions,
-    std::optional<const std::vector<Eigen::VectorXd>> edge_offsets) {
+    const std::vector<std::pair<int, int>>* edges_between_regions,
+    const std::vector<Eigen::VectorXd>* edge_offsets) {
   EdgesBetweenSubgraphs* subgraph_edge =
       new EdgesBetweenSubgraphs(from_subgraph, to_subgraph, subspace, this,
                                 edges_between_regions, edge_offsets);

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -215,8 +215,8 @@ Subgraph::Subgraph(
     const ConvexSets& regions,
     const std::vector<std::pair<int, int>>& edges_between_regions, int order,
     double h_min, double h_max, std::string name,
-    GcsTrajectoryOptimization* traj_opt,
-    const std::vector<VectorXd>* edge_offsets)
+    const std::vector<VectorXd>* edge_offsets,
+    GcsTrajectoryOptimization* traj_opt)
     : regions_(regions),
       order_(order),
       h_min_(h_min),
@@ -1376,7 +1376,7 @@ Subgraph& GcsTrajectoryOptimization::AddRegions(
   }
   Subgraph* subgraph =
       new Subgraph(regions, edges_between_regions, order, h_min, h_max,
-                   std::move(name), this, edge_offsets);
+                   std::move(name), edge_offsets, this);
 
   // Add global costs to the subgraph.
   for (double weight : global_time_costs_) {

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -747,8 +747,8 @@ EdgesBetweenSubgraphs::EdgesBetweenSubgraphs(
     edge_data.reserve(edges_between_regions->size());
     for (int edge_idx = 0; edge_idx < ssize(*edges_between_regions);
          ++edge_idx) {
-      int i = std::get<0>(edges_between_regions->at(edge_idx));
-      int j = std::get<1>(edges_between_regions->at(edge_idx));
+      int i = std::get<0>((*edges_between_regions)[edge_idx]);
+      int j = std::get<1>((*edges_between_regions)[edge_idx]);
       DRAKE_THROW_UNLESS(0 <= i && 0 <= j && i < from_subgraph_.size() &&
                          j < to_subgraph_.size());
       edge_data.emplace_back(i, j,

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -472,7 +472,7 @@ class GcsTrajectoryOptimization final {
   }
 
   /** Returns a Graphviz string describing the graph vertices and edges.  If
-  `results` is supplied, then the graph will be annotated with the solution
+  `result` is supplied, then the graph will be annotated with the solution
   values.
   @param show_slacks determines whether the values of the intermediate
   (slack) variables are also displayed in the graph.
@@ -485,6 +485,24 @@ class GcsTrajectoryOptimization final {
       const solvers::MathematicalProgramResult* result = nullptr,
       const geometry::optimization::GcsGraphvizOptions& options = {}) const {
     return gcs_.GetGraphvizString(result, options);
+  }
+
+  DRAKE_DEPRECATED(
+      "2024-10-01",
+      "result should be of type const solvers::MathematicalProgramResult*.");
+  std::string GetGraphvizString(
+      const std::optional<solvers::MathematicalProgramResult>& result) const {
+    return GetGraphvizString(result ? std::addressof(result.value()) : nullptr);
+  }
+
+  DRAKE_DEPRECATED(
+      "2024-10-01",
+      "result should be of type const solvers::MathematicalProgramResult*.");
+  std::string GetGraphvizString(
+      const std::optional<solvers::MathematicalProgramResult>& result,
+      const geometry::optimization::GcsGraphvizOptions& options) const {
+    return GetGraphvizString(result ? std::addressof(result.value()) : nullptr,
+                             options);
   }
 
   /** Creates a Subgraph with the given regions and indices.
@@ -524,6 +542,19 @@ class GcsTrajectoryOptimization final {
       const std::vector<std::pair<int, int>>& edges_between_regions, int order,
       double h_min = 0, double h_max = 20, std::string name = "",
       const std::vector<Eigen::VectorXd>* edge_offsets = nullptr);
+
+  DRAKE_DEPRECATED(
+      "2024-10-01",
+      "edge_offsets should be of type const std::vector<Eigen::VectorXd>*.");
+  Subgraph& AddRegions(
+      const geometry::optimization::ConvexSets& regions,
+      const std::vector<std::pair<int, int>>& edges_between_regions, int order,
+      double h_min, double h_max, std::string name,
+      const std::optional<std::vector<Eigen::VectorXd>>& edge_offsets) {
+    return AddRegions(
+        regions, edges_between_regions, order, h_min, h_max, name,
+        edge_offsets ? std::addressof(edge_offsets.value()) : nullptr);
+  }
 
   /** Creates a Subgraph with the given regions.
   This function will compute the edges between the regions based on the set
@@ -595,6 +626,37 @@ class GcsTrajectoryOptimization final {
       const geometry::optimization::ConvexSet* subspace = nullptr,
       const std::vector<std::pair<int, int>>* edges_between_regions = nullptr,
       const std::vector<Eigen::VectorXd>* edge_offsets = nullptr);
+
+  DRAKE_DEPRECATED("2024-10-01",
+                   "edges_between_regions should be of type const "
+                   "std::vector<std::pair<int, int>>*.");
+  EdgesBetweenSubgraphs& AddEdges(
+      const Subgraph& from_subgraph, const Subgraph& to_subgraph,
+      const geometry::optimization::ConvexSet* subspace,
+      const std::optional<std::vector<std::pair<int, int>>>&
+          edges_between_regions) {
+    return AddEdges(from_subgraph, to_subgraph, subspace,
+                    edges_between_regions
+                        ? std::addressof(edges_between_regions.value())
+                        : nullptr);
+  }
+
+  DRAKE_DEPRECATED("2024-10-01",
+                   "edges_between_regions should be of type const "
+                   "std::vector<std::pair<int, int>>*, and edge_offsets should "
+                   "be of type const std::vector<Eigen::VectorXd>*.");
+  EdgesBetweenSubgraphs& AddEdges(
+      const Subgraph& from_subgraph, const Subgraph& to_subgraph,
+      const geometry::optimization::ConvexSet* subspace,
+      const std::optional<std::vector<std::pair<int, int>>>&
+          edges_between_regions,
+      const std::optional<std::vector<Eigen::VectorXd>>& edge_offsets) {
+    return AddEdges(
+        from_subgraph, to_subgraph, subspace,
+        edges_between_regions ? std::addressof(edges_between_regions.value())
+                              : nullptr,
+        edge_offsets ? std::addressof(edge_offsets.value()) : nullptr);
+  }
 
   /** Adds a minimum time cost to all regions in the whole graph. The cost is
   the sum of the time scaling variables.

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -250,7 +250,7 @@ class GcsTrajectoryOptimization final {
              const std::vector<std::pair<int, int>>& regions_to_connect,
              int order, double h_min, double h_max, std::string name,
              GcsTrajectoryOptimization* traj_opt,
-             std::optional<const std::vector<Eigen::VectorXd>> edge_offsets);
+             const std::vector<Eigen::VectorXd>* edge_offsets);
 
     /* Convenience accessor, for brevity. */
     int num_positions() const { return traj_opt_.num_positions(); }
@@ -413,14 +413,12 @@ class GcsTrajectoryOptimization final {
         const;
 
    private:
-    EdgesBetweenSubgraphs(const Subgraph& from_subgraph,
-                          const Subgraph& to_subgraph,
-                          const geometry::optimization::ConvexSet* subspace,
-                          GcsTrajectoryOptimization* traj_opt,
-                          std::optional<const std::vector<std::pair<int, int>>>
-                              edges_between_regions = std::nullopt,
-                          std::optional<const std::vector<Eigen::VectorXd>>
-                              edge_offsets = std::nullopt);
+    EdgesBetweenSubgraphs(
+        const Subgraph& from_subgraph, const Subgraph& to_subgraph,
+        const geometry::optimization::ConvexSet* subspace,
+        GcsTrajectoryOptimization* traj_opt,
+        const std::vector<std::pair<int, int>>* edges_between_regions = nullptr,
+        const std::vector<Eigen::VectorXd>* edge_offsets = nullptr);
 
     /* Convenience accessor, for brevity. */
     int num_positions() const { return traj_opt_.num_positions(); }
@@ -434,9 +432,8 @@ class GcsTrajectoryOptimization final {
         const geometry::optimization::ConvexSet& A,
         const geometry::optimization::ConvexSet& B,
         const geometry::optimization::ConvexSet& subspace,
-        std::optional<const Eigen::VectorXd> maybe_set_B_offset = std::nullopt,
-        std::optional<const Eigen::VectorXd> maybe_subspace_offset =
-            std::nullopt);
+        const Eigen::VectorXd* maybe_set_B_offset = nullptr,
+        const Eigen::VectorXd* maybe_subspace_offset = nullptr);
 
     /* Extracts the control points variables from an edge. */
     Eigen::Map<const MatrixX<symbolic::Variable>> GetControlPointsU(
@@ -485,8 +482,7 @@ class GcsTrajectoryOptimization final {
   or fixed (if false).
   */
   std::string GetGraphvizString(
-      const std::optional<solvers::MathematicalProgramResult>& result =
-          std::nullopt,
+      const solvers::MathematicalProgramResult* result = nullptr,
       const geometry::optimization::GcsGraphvizOptions& options = {}) const {
     return gcs_.GetGraphvizString(result, options);
   }
@@ -527,8 +523,7 @@ class GcsTrajectoryOptimization final {
       const geometry::optimization::ConvexSets& regions,
       const std::vector<std::pair<int, int>>& edges_between_regions, int order,
       double h_min = 0, double h_max = 20, std::string name = "",
-      std::optional<const std::vector<Eigen::VectorXd>> edge_offsets =
-          std::nullopt);
+      const std::vector<Eigen::VectorXd>* edge_offsets = nullptr);
 
   /** Creates a Subgraph with the given regions.
   This function will compute the edges between the regions based on the set
@@ -598,10 +593,8 @@ class GcsTrajectoryOptimization final {
   EdgesBetweenSubgraphs& AddEdges(
       const Subgraph& from_subgraph, const Subgraph& to_subgraph,
       const geometry::optimization::ConvexSet* subspace = nullptr,
-      std::optional<const std::vector<std::pair<int, int>>>
-          edges_between_regions = std::nullopt,
-      std::optional<const std::vector<Eigen::VectorXd>> edge_offsets =
-          std::nullopt);
+      const std::vector<std::pair<int, int>>* edges_between_regions = nullptr,
+      const std::vector<Eigen::VectorXd>* edge_offsets = nullptr);
 
   /** Adds a minimum time cost to all regions in the whole graph. The cost is
   the sum of the time scaling variables.

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/trajectories/bezier_curve.h"
 #include "drake/common/trajectories/composite_trajectory.h"
 #include "drake/geometry/optimization/convex_set.h"

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -251,8 +251,8 @@ class GcsTrajectoryOptimization final {
     Subgraph(const geometry::optimization::ConvexSets& regions,
              const std::vector<std::pair<int, int>>& regions_to_connect,
              int order, double h_min, double h_max, std::string name,
-             GcsTrajectoryOptimization* traj_opt,
-             const std::vector<Eigen::VectorXd>* edge_offsets);
+             const std::vector<Eigen::VectorXd>* edge_offsets,
+             GcsTrajectoryOptimization* traj_opt);
 
     /* Convenience accessor, for brevity. */
     int num_positions() const { return traj_opt_.num_positions(); }

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -493,16 +493,8 @@ class GcsTrajectoryOptimization final {
       "2024-10-01",
       "result should be of type const solvers::MathematicalProgramResult*.");
   std::string GetGraphvizString(
-      const std::optional<solvers::MathematicalProgramResult>& result) const {
-    return GetGraphvizString(result ? std::addressof(result.value()) : nullptr);
-  }
-
-  DRAKE_DEPRECATED(
-      "2024-10-01",
-      "result should be of type const solvers::MathematicalProgramResult*.");
-  std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result,
-      const geometry::optimization::GcsGraphvizOptions& options) const {
+      const geometry::optimization::GcsGraphvizOptions& options = {}) const {
     return GetGraphvizString(result ? std::addressof(result.value()) : nullptr,
                              options);
   }
@@ -631,20 +623,6 @@ class GcsTrajectoryOptimization final {
 
   DRAKE_DEPRECATED("2024-10-01",
                    "edges_between_regions should be of type const "
-                   "std::vector<std::pair<int, int>>*.");
-  EdgesBetweenSubgraphs& AddEdges(
-      const Subgraph& from_subgraph, const Subgraph& to_subgraph,
-      const geometry::optimization::ConvexSet* subspace,
-      const std::optional<std::vector<std::pair<int, int>>>&
-          edges_between_regions) {
-    return AddEdges(from_subgraph, to_subgraph, subspace,
-                    edges_between_regions
-                        ? std::addressof(edges_between_regions.value())
-                        : nullptr);
-  }
-
-  DRAKE_DEPRECATED("2024-10-01",
-                   "edges_between_regions should be of type const "
                    "std::vector<std::pair<int, int>>*, and edge_offsets should "
                    "be of type const std::vector<Eigen::VectorXd>*.");
   EdgesBetweenSubgraphs& AddEdges(
@@ -652,7 +630,8 @@ class GcsTrajectoryOptimization final {
       const geometry::optimization::ConvexSet* subspace,
       const std::optional<std::vector<std::pair<int, int>>>&
           edges_between_regions,
-      const std::optional<std::vector<Eigen::VectorXd>>& edge_offsets) {
+      const std::optional<std::vector<Eigen::VectorXd>>& edge_offsets =
+          std::nullopt) {
     return AddEdges(
         from_subgraph, to_subgraph, subspace,
         edges_between_regions ? std::addressof(edges_between_regions.value())

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -24,6 +24,8 @@ problem introduced in the paper ["Motion Planning around Obstacles with Convex
 Optimization"](https://arxiv.org/abs/2205.04422) by Tobia Marcucci, Mark
 Petersen, David von Wrangel, Russ Tedrake.
 
+@experimental
+
 Instead of using the full time-scaling curve, this problem uses a single
 time-scaling variable for each region. This formulation yields continuous
 trajectories, which are not differentiable at the transition times between the

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -2333,7 +2333,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, EdgeIndexChecking) {
   auto& subgraph2 = gcs.AddRegions(sets_good_2, 1);
   std::vector<std::pair<int, int>> edges_bad_2;
   edges_bad_2.emplace_back(0, 1);
-  EXPECT_THROW(gcs.AddEdges(subgraph1, subgraph2, nullptr, edges_bad_2),
+  EXPECT_THROW(gcs.AddEdges(subgraph1, subgraph2, nullptr, &edges_bad_2),
                std::exception);
 }
 
@@ -2378,9 +2378,9 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, ManuallySpecifyEdges) {
   const int expected_num_edges = 7;
 
   // Add edges without offsets. This makes the problem infeasible.
-  gcs.AddEdges(start, subgraph1, nullptr, edges_start_1);
-  gcs.AddEdges(subgraph1, subgraph2, nullptr, edges_1_2);
-  gcs.AddEdges(subgraph2, goal, nullptr, edges_2_goal);
+  gcs.AddEdges(start, subgraph1, nullptr, &edges_start_1);
+  gcs.AddEdges(subgraph1, subgraph2, nullptr, &edges_1_2);
+  gcs.AddEdges(subgraph2, goal, nullptr, &edges_2_goal);
   EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), expected_num_edges);
   auto [traj_fail, result_fail] = gcs.SolvePath(start, goal);
   unused(traj_fail);
@@ -2392,9 +2392,9 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, ManuallySpecifyEdges) {
   gcs.RemoveSubgraph(subgraph2);
   auto& new_subgraph1 = gcs.AddRegions(sets1, 1, 1e-6);
   auto& new_subgraph2 = gcs.AddRegions(sets2, 1, 1e-6);
-  gcs.AddEdges(start, new_subgraph1, nullptr, edges_start_1, offsets_start_1);
-  gcs.AddEdges(new_subgraph1, new_subgraph2, nullptr, edges_1_2, offsets_1_2);
-  gcs.AddEdges(new_subgraph2, goal, nullptr, edges_2_goal, offsets_2_goal);
+  gcs.AddEdges(start, new_subgraph1, nullptr, &edges_start_1, &offsets_start_1);
+  gcs.AddEdges(new_subgraph1, new_subgraph2, nullptr, &edges_1_2, &offsets_1_2);
+  gcs.AddEdges(new_subgraph2, goal, nullptr, &edges_2_goal, &offsets_2_goal);
   EXPECT_EQ(gcs.graph_of_convex_sets().Edges().size(), expected_num_edges);
   auto [traj_succeed, result_succeed] = gcs.SolvePath(start, goal);
   unused(traj_succeed);
@@ -2402,16 +2402,16 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, ManuallySpecifyEdges) {
 
   // Throw if edges and offsets have mismatched lengths.
   offsets_2_goal.emplace_back(Vector1d(0));
-  EXPECT_THROW(
-      gcs.AddEdges(new_subgraph2, goal, nullptr, edges_2_goal, offsets_2_goal),
-      std::exception);
+  EXPECT_THROW(gcs.AddEdges(new_subgraph2, goal, nullptr, &edges_2_goal,
+                            &offsets_2_goal),
+               std::exception);
 
   // Throw if offsets has wrong dimension.
   offsets_2_goal.resize(0);
   offsets_2_goal.emplace_back(Vector2d(0, 0));
-  EXPECT_THROW(
-      gcs.AddEdges(new_subgraph2, goal, nullptr, edges_2_goal, offsets_2_goal),
-      std::exception);
+  EXPECT_THROW(gcs.AddEdges(new_subgraph2, goal, nullptr, &edges_2_goal,
+                            &offsets_2_goal),
+               std::exception);
 }
 
 }  // namespace


### PR DESCRIPTION
Per a discussion with @xuchenhan-tri in #21723 (and a similar one with @SeanCurtis-TRI in the Drake Developers Slack), we should use pointers instead of `std::optional` for optional arguments when we want to avoid data copying. This PR overhauls several methods of GcsTrajectoryOptimization (and one method of GraphOfConvexSets) where potentially large objects were being copied to use pointers.

Note that Pybind11 does not allow None arguments to be used for arguments of type `std::vector<T>*`, so I think we're stuck using `std::optional` for Python users? Alternatively, I could add additional function overloads?

I've tagged this as a breaking change since the argument types have changed (at least for C++ users).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21749)
<!-- Reviewable:end -->
