### PR TITLE
[highway_internal] Patch crash bug in debug builds

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -73,11 +73,9 @@ drake_cc_library(
     srcs = ["boxes_overlap.cc"],
     hdrs = ["boxes_overlap.h"],
     copts = [
-        # Hard coding optimization keeps performance high in debug, but it also
-        # is necessary for highway to work; the critical function must be
-        # inlined. Without -O2, it might not be, leading to badness. If you are
+        # Hard coding optimization keeps performance high in debug.  If you are
         # a developer trying to debug these files, you might want to comment
-        # this out temporarily (and hope your platform is not the crash kind).
+        # this out temporarily.
         "-O2",
     ],
     deps = [

--- a/tools/workspace/highway_internal/patches/target_get_index_inline_always.patch
+++ b/tools/workspace/highway_internal/patches/target_get_index_inline_always.patch
@@ -1,0 +1,57 @@
+[highway_internal] Force GetIndex() method to always be inline
+
+Prior upstream work on the HWY_INLINE macro definition made it
+effectively no-op in non-MSVC debug builds.  In the specific case of
+ChosenTarget::GetIndex(), it must always be inline for correctness of
+the target configuration scheme.
+
+Introduce a new macro HWY_ALWAYS_INLINE and use it to repair the
+GetIndex() method.
+
+Note that the first change block below gives compatible definitions for
+an `#if MSVC` stanza. This is not strictly necessary for Drake, but
+keeps the patch itself compiler-neutral. The second change block is for
+all remaining compilers, and the third change block applies the repair.
+
+These changes should not be upstreamed to highway. The deeper issue is
+that highway currently relies on delicate handling of deliberate ODR
+violations. Analyzing and fixing ODR issues in highway is beyond the
+scope of work needed for Drake.
+
+--- hwy/base.h
++++ hwy/base.h
+@@ -91,7 +91,8 @@
+ 
+ #define HWY_FUNCTION __FUNCSIG__  // function name + template args
+ #define HWY_RESTRICT __restrict
+-#define HWY_INLINE __forceinline
++#define HWY_ALWAYS_INLINE __forceinline
++#define HWY_INLINE HWY_ALWAYS_INLINE
+ #define HWY_NOINLINE __declspec(noinline)
+ #define HWY_FLATTEN
+ #define HWY_NORETURN __declspec(noreturn)
+@@ -112,10 +113,11 @@
+ 
+ #define HWY_FUNCTION __PRETTY_FUNCTION__  // function name + template args
+ #define HWY_RESTRICT __restrict__
++#define HWY_ALWAYS_INLINE inline __attribute__((always_inline))
+ // force inlining without optimization enabled creates very inefficient code
+ // that can cause compiler timeout
+ #ifdef __OPTIMIZE__
+-#define HWY_INLINE inline __attribute__((always_inline))
++#define HWY_INLINE HWY_ALWAYS_INLINE
+ #else
+ #define HWY_INLINE inline
+ #endif
+
+--- hwy/targets.h
++++ hwy/targets.h
+@@ -315,7 +315,7 @@ struct ChosenTarget {
+   // of HWY_CHOSEN_TARGET_MASK_TARGETS defined in the translation unit that
+   // calls it, which may be different from others. This means we only enable
+   // those targets that were actually compiled in this module.
+-  size_t HWY_INLINE GetIndex() const {
++  size_t HWY_ALWAYS_INLINE GetIndex() const {
+     return hwy::Num0BitsBelowLS1Bit_Nonzero64(
+         static_cast<uint64_t>(LoadMask() & HWY_CHOSEN_TARGET_MASK_TARGETS));
+   }

--- a/tools/workspace/highway_internal/repository.bzl
+++ b/tools/workspace/highway_internal/repository.bzl
@@ -10,6 +10,7 @@ def highway_internal_repository(
         sha256 = "7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343",  # noqa
         patches = [
             ":patches/linkstatic.patch",
+            ":patches/target_get_index_inline_always.patch",
             ":patches/target_update_noinline.patch",
         ],
         mirrors = mirrors,


### PR DESCRIPTION
Add a local patch for `highway` to fix the bug that was crashing debug builds with the boxes overlap SIMD port. Also withdraw claims about that crashiness from a comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21751)
<!-- Reviewable:end -->
