### PR TITLE
[multibody topology] Handle merged composites

### DIFF
--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -26,10 +26,10 @@ using LoopConstraintIndex = TypeSafeIndex<class LoopConstraintTag>;
 these also produces a LinkFlags object. */
 enum class LinkFlags : uint32_t {
   kDefault = 0,
-  kStatic = 1 << 0,           ///< Implicitly welded to World.
-  kMustBeBaseBody = 1 << 1,   ///< Ensure connection to World if none.
-  kTreatAsMassless = 1 << 2,  ///< Can't be a terminal body in a tree.
-  kShadow = 1 << 3            ///< Link is a shadow (internal use only).
+  kStatic = 1 << 0,          ///< Implicitly welded to World.
+  kMustBeBaseBody = 1 << 1,  ///< Ensure connection to World if none.
+  kMassless = 1 << 2,        ///< Can't be a terminal body in a tree.
+  kShadow = 1 << 3           ///< Link is a shadow (internal use only).
 };
 
 /** Joint properties that can affect how the SpanningForest gets built. Or-ing
@@ -47,7 +47,7 @@ enum class ForestBuildingOptions : uint32_t {
   kStatic = 1 << 0,                ///< Weld all links to World.
   kUseFixedBase = 1 << 1,          ///< Use welds rather than floating joints.
   kUseRpyFloatingJoints = 1 << 2,  ///< For floating, use RPY not quaternion.
-  kCombineLinkComposites = 1 << 3  ///< Make a single Mobod for welded Links.
+  kMergeLinkComposites = 1 << 3    ///< Make a single Mobod for welded Links.
 };
 
 // These overloads make the above enums behave like bitmasks for the operations

--- a/multibody/topology/link_joint_graph_inlines.h
+++ b/multibody/topology/link_joint_graph_inlines.h
@@ -47,12 +47,14 @@ inline void LinkJointGraph::set_primary_mobod_for_link(
   link.joint_ = primary_joint_index;
 }
 
-inline bool LinkJointGraph::must_treat_as_massless(
+inline bool LinkJointGraph::link_and_its_composite_are_massless(
     LinkOrdinal link_ordinal) const {
   const Link& link = links(link_ordinal);
-  // TODO(sherm1) If part of a Composite then this is only massless if the
-  //  entire Composite is composed of massless Links.
-  return link.treat_as_massless();
+  if (!link.is_massless()) return false;
+
+  return link.composite().has_value()
+             ? link_composites(*link.composite()).is_massless
+             : true;
 }
 
 // LinkJointGraph definitions deferred until Joint defined.

--- a/multibody/topology/link_joint_graph_link.h
+++ b/multibody/topology/link_joint_graph_link.h
@@ -82,10 +82,12 @@ class LinkJointGraph::Link {
     return static_cast<bool>(flags_ & LinkFlags::kMustBeBaseBody);
   }
 
-  /** Returns `true` if this %Link was added with
-  LinkFlags::kTreatAsMassless. */
-  bool treat_as_massless() const {
-    return static_cast<bool>(flags_ & LinkFlags::kTreatAsMassless);
+  /** Returns `true` if this %Link was added with LinkFlags::kMassless.
+  However, this %Link may still be _effectively_ massful if it is welded
+  into a massful composite. See
+  LinkJointGraph::link_and_its_composite_are_massless() for the full story. */
+  bool is_massless() const {
+    return static_cast<bool>(flags_ & LinkFlags::kMassless);
   }
 
   /** Returns `true` if this is a shadow Link added by BuildForest(). */

--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -50,14 +50,6 @@ void SpanningForest::Clear() {
   data_.graph = saved_graph;
 }
 
-// TODO(sherm1) For review purposes, the code here implements only a
-//  subset of the algorithm described.
-//  What's here: the ability to model tree-structured graphs, add joints to
-//  world as needed, grow breadth-first and then renumber depth-first,
-//  assign coordinates, break loops, treat massless bodies specially.
-//  What's not here (see #20225): Use a single Mobod for composites. The related
-//  option is allowed but ignored.
-
 /* This is the algorithm that takes an arbitrary link-joint graph and models
 it as a spanning forest of mobilized bodies plus loop-closing constraints.
 
@@ -374,6 +366,10 @@ void SpanningForest::AssignCoordinates() {
 
 /* Phase 1 steps 1.4 and 1.5. */
 void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
+  // TODO(sherm1) Consider whether a LinkComposite that is treated as a single
+  //  body (i.e., follows just one Mobod) should be allowed to be a base body or
+  //  should wait along with the other unjointed Links.
+
   /* Partition the unmodeled links into jointed and unjointed. O(n) */
   std::vector<LinkOrdinal> jointed_links, unjointed_links;
   for (const auto& link : links()) {
@@ -411,14 +407,12 @@ void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
 
   /* Should be nothing left now except unjointed (single) Links. We'll attach
   with either a floating joint or a weld joint depending on modeling options.
-  It gets a new Mobod that serves as the base body of a new
+  If a weld and we're optimizing composites, the Link will just join the World
+  Mobod. Otherwise it gets a new Mobod that serves as the base body of a new
   Tree. Although static links and links belonging to a static model instance
   get welded to World at the start of forest building, it is still possible
   to need a weld here for a lone link that is in a "use fixed base" model
   instance (that's not technically a static link). (1.5) */
-  // TODO(sherm1) If the required joint here is a weld and we're optimizing
-  //  composites, the Link should just join the World Mobod and the joint is
-  //  unmodeled. Coming soon.
   DRAKE_DEMAND(*num_unprocessed_links == ssize(unjointed_links));
 
   for (LinkOrdinal unjointed_link : unjointed_links) {
@@ -431,9 +425,12 @@ void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
                                                  unjointed_link);
     const JointOrdinal next_joint_ordinal =
         graph().index_to_ordinal(next_joint_index);
-
-    AddNewMobod(unjointed_link, next_joint_ordinal, world_mobod().index(),
-                false);  // Not reversed; World is parent
+    if (should_merge_parent_and_child(joints(next_joint_ordinal))) {
+      JoinExistingMobod(&data_.mobods[0], unjointed_link, next_joint_ordinal);
+    } else {
+      AddNewMobod(unjointed_link, next_joint_ordinal, world_mobod().index(),
+                  false);  // Not reversed; World is parent
+    }
     /* No tree to extend here. */
   }
   *num_unprocessed_links -= ssize(unjointed_links);
@@ -446,168 +443,285 @@ void SpanningForest::ExtendTrees(const std::vector<JointIndex>& joints_to_model,
 
   /* E.1 - E.3 */
   while (!to_model.empty()) {
-    ExtendTreesOneLevel(to_model, &*num_unprocessed_links, &to_model_next);
+    ExtendTreesOneLevel(to_model, &to_model_next, &*num_unprocessed_links);
     std::swap(to_model, to_model_next);
   }
 }
 
 /* Grows each Tree by one level with two exceptions:
-   - If we're optimizing LinkComposites (welded-together Links following a
-     single Mobod), keep growing LinkComposites as far as possible since they
-     constitue only a single level in the tree.
-     TODO(sherm1) LinkComposite optimization is implemented in #20225 but not
-      yet here; will port in the next PR.
-   - If we encounter a "treat as massless" Link it can't be a terminal body
-     of a branch. In that case we keep growing that branch until we can end
-     with something massful. Note that an optimized LinkComposite can be
-     terminal if _any_ of its Links are massful. */
-void SpanningForest::ExtendTreesOneLevel(
-    const std::vector<JointIndex>& joints_to_model, int* num_unprocessed_links,
-    std::vector<JointIndex>* joints_to_model_next) {
-  DRAKE_DEMAND(!joints_to_model.empty());
-  DRAKE_DEMAND(num_unprocessed_links != nullptr);
-  DRAKE_DEMAND(joints_to_model_next != nullptr);
-  joints_to_model_next->clear();
+   1 If we're optimizing composites (by merging welded-together Links onto a
+     single Mobod), keep growing a LinkComposite as far as possible to build
+     the complete composite and model it with a single Mobod.
+   2 If we encounter a massless Link (or massless merged LinkComposite), we
+     don't want its Mobod to be a terminal body of a branch. In that case we
+     keep growing that branch until we can end with something massful. If we
+     fail, we have to mark this forest as unsuited for dynamics since its mass
+     matrix will be singular.
 
-  for (JointIndex joint_index : joints_to_model) {
-    const JointOrdinal joint_ordinal = graph().index_to_ordinal(joint_index);
-    const Joint& joint = joints(joint_ordinal);
-    if (joint.has_been_processed())
+Exception 1 preserves the goal of minimizing maximum branch length since we
+still only advance by one Mobod, regardless of how many merged Links that
+entails.
+
+Exception 2 sacrifices the even growth of branches in order to achieve the more
+critical goal of ending every branch with a massful body to avoid making the
+system mass matrix singular.
+
+Definitions used below
+----------------------
+- Given a link L, we denote the _merged_ LinkComposite it belongs to as L+.
+    If we're not merging (optimizing) LinkComposites, then L+ == L.
+- A joint connects two links, parent and child. Every joint of interest here
+    has at least one of its links already in the forest; that is its "inboard"
+    link I. The other link is the "outboard" link O and is usually not yet in
+    the forest.
+- A "merged joint" is a weld joint that connects two links that should be part
+    of the same merged LinkComposite. Merged joints do not have a corresponding
+    mobilizer in the forest; they are unmodeled.
+- Define Jₒₚₑₙ(L+) as the set of all not-yet-processed joints connected to any
+    link in L+. These are "open" in the sense that only inboard link I of the
+    joint is in L+; the other link O still needs to be dealt with. Open joints
+    define the next level to be added to the forest outboard of L+.
+
+
+Algorithm A(Jᵢₙ, &Jₒᵤₜ)
+-----------------------
+Inputs:  graph, partially built forest F, a set Jᵢₙ of unmodeled joints that
+         will extend F by one level (i.e. one joint per branch).
+Outputs: updated forest F, the set Jₒᵤₜ of as-yet-unmodeled joints to add at
+         the next level.
+
+Note: Every j ∈ Jᵢₙ has at least one of its two links (parent and child) already
+  modeled in the current forest F. On return, every j ∈ Jₒᵤₜ has at least one of
+  its links already modeled in the updated forest. In either case, if both
+  links are already in the forest then j is a loop joint.
+
+Jₒᵤₜ = {}
+For each jᵢₙ ∈ Jᵢₙ:
+  A.1 If jᵢₙ should be a merged joint (see above), then merge O+ with the
+      LinkComposite I+. Mark weld joint jᵢₙ as "unmodeled". We haven't yet
+      extended this branch by a level though, so we need to keep going.
+      Set Jₗₑᵥₑₗ = Jₒₚₑₙ(O+). Otherwise (jᵢₙ not a merged joint), set
+      Jₗₑᵥₑₗ = {jᵢₙ}.
+
+  For each jₗₑᵥₑₗ ∈ Jₗₑᵥₑₗ:
+    A.2 If both parent and child links of jₗₑᵥₑₗ are already in the forest,
+        jₗₑᵥₑₗ is a loop closing joint. Handle the loop. -> NEXT jₗₑᵥₑₗ
+    A.3 Otherwise, add a new Mobod M to the forest whose body models link O and
+        whose mobilizer models joint jₗₑᵥₑₗ.
+    A.4 Determine O+ (O or its composite) and make all links in O+ follow M.
+    A.5 If M is massful, set Jₒᵤₜ += Jₒₚₑₙ(O+). -> NEXT jₗₑᵥₑₗ
+    A.6 (M is massless) Examine the joints in Jₒₚₑₙ(O+). If there aren't any
+        open joints then we have to terminate this branch with a massless body
+        and note that the forest can't be used for dynamics. Make a note and a
+        suitable message. -> NEXT jₗₑᵥₑₗ
+    A.7 (M is massless, but Jₒₚₑₙ(O+) is not empty) If any one of those open
+        joints leads to an outboard link which is massful, we're fine.
+        Set Jₒᵤₜ += Jₒₚₑₙ(O+). -> NEXT jₗₑᵥₑₗ
+    A.8 (M is massless, and all outboard links in Jₒₚₑₙ(O+) are massless).
+        Recursively run this algorithm A(J'ᵢₙ, &J'ₒᵤₜ) with J'ᵢₙ=Jₒₚₑₙ(O+) to
+        extend this branch another level in the hope of encountering something
+        massful. Set Jₒᵤₜ += J'ₒᵤₜ. -> NEXT jₗₑᵥₑₗ
+*/
+void SpanningForest::ExtendTreesOneLevel(const std::vector<JointIndex>& J_in,
+                                         std::vector<JointIndex>* J_out,
+                                         int* num_unprocessed_links) {
+  DRAKE_DEMAND(!J_in.empty());
+  DRAKE_DEMAND(num_unprocessed_links != nullptr);
+  DRAKE_DEMAND(J_out != nullptr);
+  J_out->clear();
+
+  std::vector<JointIndex> J_level, J_open;  // Temps for use below.
+  for (JointIndex j_in_index : J_in) {
+    const JointOrdinal joint_in_ordinal = graph().index_to_ordinal(j_in_index);
+    const Joint& j_in = joints(joint_in_ordinal);
+    if (j_in.has_been_processed())
       continue;  // Already did this one from the other side.
 
-    const LinkOrdinal parent_link_ordinal =
-        graph().index_to_ordinal(joint.parent_link_index());
-    const LinkOrdinal child_link_ordinal =
-        graph().index_to_ordinal(joint.child_link_index());
+    /* Find the inboard Mobod that we're extending via j_in, which link
+    follows that Mobod (link I), which is the outboard link O, and are those
+    reversed from parent P and child C. */
+    const auto [inboard_mobod_index, inboard_link_ordinal,
+                outboard_link_ordinal, is_joint_in_reversed] =
+        FindInboardMobod(j_in);
 
-    /* At least one of the Joint's Links must have already been modeled.
-    (Could be both in the case of a loop.) */
-    const bool parent_is_modeled =
-        link_is_already_in_forest(parent_link_ordinal);
-    const bool child_is_modeled = link_is_already_in_forest(child_link_ordinal);
-    DRAKE_DEMAND(parent_is_modeled || child_is_modeled);
+    /* Step A.1 */
+    FindNextLevelJoints(inboard_mobod_index, {j_in_index}, &J_level,
+                        &*num_unprocessed_links);
 
-    const BodyIndex inboard_link_index = parent_is_modeled
-                                             ? joint.parent_link_index()
-                                             : joint.child_link_index();
+    for (JointIndex j_level_index : J_level) {
+      const JointOrdinal j_level_ordinal =
+          graph().index_to_ordinal(j_level_index);
+      const Joint& j_level = joints(j_level_ordinal);
+      DRAKE_DEMAND(!should_merge_parent_and_child(j_level));
 
-    /* Don't keep references to Mobods since we're growing the vector below. */
-    const MobodIndex inboard_mobod_index =
-        graph().link_to_mobod(inboard_link_index);
+      /* The inboard link returned here is guaranteed to be in the forest
+      already; in particular it follows the indicated inboard_mobod. The
+      outboard link usually isn't in the forest yet but can be. */
+      const auto [j_level_inboard_link_ordinal, j_level_outboard_link_ordinal,
+                  is_reversed] =
+          graph().FindInboardOutboardLinks(inboard_mobod_index,
+                                           j_level_ordinal);
 
-    const JointIndex modeled_joint_index = joint_index;  // For easier stubbing.
-    const JointOrdinal modeled_joint_ordinal =
-        graph().index_to_ordinal(modeled_joint_index);
-
-    // TODO(sherm1) Combining composites stubbed out here (E.4)
-
-    const Joint& modeled_joint = joints(modeled_joint_ordinal);
-
-    const auto [modeled_inboard_link_ordinal, modeled_outboard_link_ordinal,
-                is_reversed] =
-        graph().FindInboardOutboardLinks(inboard_mobod_index,
-                                         modeled_joint_ordinal);
-
-    /* If the outboard link is already modeled, this is a loop-closing
-    joint (E.5). */
-    if (link_is_already_in_forest(modeled_outboard_link_ordinal)) {
-      /* Invalidates references to Links, Joints, Mobods, LoopConstraints. */
-      HandleLoopClosure(modeled_joint_ordinal);
-      continue;
-    }
-
-    /* There isn't a loop and the outboard Link isn't part of a combined
-    LinkComposite so we can model it with a Mobod.
-    Note: this invalidates references to Mobods. */
-    AddNewMobod(modeled_outboard_link_ordinal, modeled_joint_ordinal,
-                inboard_mobod_index,
-                is_reversed);  // Is mobilizer reversed from Joint?
-    --(*num_unprocessed_links);
-
-    /* Now determine if we can stop here or if we have to keep extending
-    the branch we're on. If the Mobod we just added was a massless body
-    on an articulated (non-weld) mobilizer, we may need to extend "one more
-    level" from here. This can continue recursively if we run into
-    more massless Links. */
-    const Link& modeled_link = links(modeled_outboard_link_ordinal);
-    if (modeled_joint.is_weld() || !modeled_link.treat_as_massless()) {
-      /* We can stop here. Collect up the Joints for the next level and
-      go on to the next Joint to model at this level. */
-      for (JointIndex next_joint_index : modeled_link.joints()) {
-        const JointOrdinal next_joint_ordinal =
-            graph().index_to_ordinal(next_joint_index);
-        if (!joints(next_joint_ordinal).has_been_processed())
-          joints_to_model_next->push_back(next_joint_index);
+      /* If the outboard link is already modeled in the forest, this is a
+      loop-closing joint. (A.2). */
+      if (link_is_already_in_forest(j_level_outboard_link_ordinal)) {
+        /* Invalidates references to Links, Joints, Mobods, LoopConstraints. */
+        HandleLoopClosure(j_level_ordinal);
+        continue;
       }
-      continue;
-    }
 
-    /* The Link we just added to the branch is massless and articulated; we
-    don't want to terminate the branch with it. Three possibilities:
-    1 If it has outboard joints and at least one leads to a massful link,
-      we're fine and can end here knowing that the massless link will get
-      covered at the next level.
-    2 If the link has no outboard joints we're stuck and will just have to
-      declare this as a "no dynamics" model.
-    3 If all the outboard joints lead to massless links, we must not stop
-      here but instead need to move on to the next level in the hope that
-      we'll eventually run into something massful. */
-    std::vector<JointIndex> massless_link_unmodeled_joints;
-    bool has_outboard_massful_link = false;
-    for (JointIndex massless_link_joint_index : modeled_link.joints()) {
-      const JointOrdinal massless_link_joint_ordinal =
-          graph().index_to_ordinal(massless_link_joint_index);
-      if (joints(massless_link_joint_ordinal).has_been_processed()) continue;
-      massless_link_unmodeled_joints.push_back(massless_link_joint_index);
+      /* There isn't a loop and the outboard link isn't part of the same
+      merged LinkComposite as the inboard link. That means we are going to
+      need a new Mobod. Note: a reference to this Mobod could be invalidated
+      below; refer to it by its stable index instead. (A.3)*/
+      const MobodIndex new_mobod_index =
+          AddNewMobod(j_level_outboard_link_ordinal, j_level_ordinal,
+                      inboard_mobod_index, is_reversed)
+              .index();
+      --(*num_unprocessed_links);
 
-      if (!has_outboard_massful_link) {
-        const Joint& outboard_joint = joints(massless_link_joint_ordinal);
-        const Link& modeled_outboard_link =
-            links(modeled_outboard_link_ordinal);
-        const BodyIndex outboard_link_index =
-            outboard_joint.other_link_index(modeled_outboard_link.index());
-        has_outboard_massful_link =
-            !link_by_index(outboard_link_index).treat_as_massless();
+      /* We just put link O on the new Mobod. O might just be the active
+      link of a merged LinkComposite O+. If so we need to build O+ now and find
+      all its open joints. (A.4) */
+      J_open.clear();
+      const Link& j_level_outboard_link = links(j_level_outboard_link_ordinal);
+      FindNextLevelJoints(new_mobod_index, j_level_outboard_link.joints(),
+                          &J_open, &*num_unprocessed_links);
+
+      /* Now determine if we can stop here or if we have to keep extending
+      the branch we're on. If the Mobod we just added was a massless body
+      on an articulated (non-weld) mobilizer, we may need to extend "one more
+      level" from here. This can continue recursively if we run into
+      more massless Links. */
+      if (j_level.is_weld() ||
+          mobods(new_mobod_index).has_massful_follower_link()) {
+        /* We can stop here. Collect up the Joints for the next level and
+        go on to the next Joint to model at this level. (A.5) */
+        J_out->insert(J_out->end(), J_open.begin(), J_open.end());
+        continue;  // -> NEXT jₗₑᵥₑₗ
       }
-    }
 
-    /* Case 1: all good. */
-    if (has_outboard_massful_link) {
-      /* The outboard joints we just collected are the ones we should
-      process at the next level. */
-      joints_to_model_next->insert(joints_to_model_next->end(),
-                                   massless_link_unmodeled_joints.begin(),
-                                   massless_link_unmodeled_joints.end());
-      continue;
-    }
+      /* The Link or LinkComposite O+ we just added to the branch is massless
+      and articulated; we don't want to terminate the branch with it. We have
+      Jₒₚₑₙ(O+) in J_open. Three possibilities:
+      1 If Jₒₚₑₙ is empty we're stuck and will just have to declare this as a
+        "no dynamics" model.
+      2 If there is a joint in Jₒₚₑₙ that leads to a massful link, we'll
+        assume we're fine and can end here knowing that the massless Mobod will
+        get covered at the next level. (There could still be problems that
+        we can't detect here.)
+      3 If all the outboard joints in Jₒₚₑₙ lead to massless links, we must not
+        stop here but instead need to move on to the next level in the hope that
+        we'll eventually run into something massful. */
 
-    /* Case 2: we're not going to be able to do dynamics :(. */
-    if (massless_link_unmodeled_joints.empty()) {
-      /* If this is the first problem we've seen, record it. */
-      if (data_.dynamics_ok) {
-        const LinkJointGraph::JointTraits& modeled_joint_traits =
-            graph().joint_traits(modeled_joint.traits_index());
-        data_.dynamics_ok = false;
-        data_.why_no_dynamics = fmt::format(
-            "Link {} on {} joint {} is a terminal, articulated, massless "
-            "link. The resulting multibody system will have a singular "
-            "mass matrix so cannot be used for dynamics.",
-            modeled_link.name(), modeled_joint_traits.name,
-            modeled_joint.name());
+      /* Case 1: we're not going to be able to do dynamics. (A.6)*/
+      if (J_open.empty()) {
+        /* If this is the first problem we've seen, record it. */
+        if (data_.dynamics_ok) {
+          const LinkJointGraph::JointTraits& j_level_traits =
+              graph().joint_traits(j_level.traits_index());
+          data_.dynamics_ok = false;
+          data_.why_no_dynamics = fmt::format(
+              "Link {} on {} joint {} is a terminal, articulated, massless "
+              "link. The resulting multibody system will have a singular "
+              "mass matrix so cannot be used for dynamics.",
+              j_level_outboard_link.name(), j_level_traits.name,
+              j_level.name());
+        }
+        continue;  // -> NEXT jₗₑᵥₑₗ
       }
-      continue;
-    }
 
-    /* Case 3: there is still hope. The massless link does have some
-    not-yet-modeled joints, but they all lead to more massless links. Extend
-    further and collect up the outboard joints at the next level. */
-    std::vector<JointIndex> next_level_outboard_joints;
-    ExtendTreesOneLevel(massless_link_unmodeled_joints, &*num_unprocessed_links,
-                        &next_level_outboard_joints);
-    joints_to_model_next->insert(joints_to_model_next->end(),
-                                 next_level_outboard_joints.begin(),
-                                 next_level_outboard_joints.end());
+      /* Case 2: all good. (A.7) */
+      if (HasMassfulOutboardLink(new_mobod_index, J_open)) {
+        /* The outboard joints we just collected are the ones we should
+        process at the next level. */
+        J_out->insert(J_out->end(), J_open.begin(), J_open.end());
+        continue;  // -> NEXT jₗₑᵥₑₗ
+      }
+
+      /* Case 3: there is still hope. The massless link does have some
+      not-yet-modeled joints, but they all lead to more massless links. Extend
+      further and collect up the outboard joints at the next level. (A.8) */
+      std::vector<JointIndex> next_level_J_open;
+      ExtendTreesOneLevel(J_open, &next_level_J_open, &*num_unprocessed_links);
+      J_out->insert(J_out->end(), next_level_J_open.begin(),
+                    next_level_J_open.end());
+      // -> NEXT jₗₑᵥₑₗ
+    }
   }
+}
+
+std::tuple<MobodIndex, LinkOrdinal, LinkOrdinal, bool>
+SpanningForest::FindInboardMobod(const Joint& open_joint) const {
+  const LinkOrdinal parent_link_ordinal =
+      graph().index_to_ordinal(open_joint.parent_link_index());
+  const LinkOrdinal child_link_ordinal =
+      graph().index_to_ordinal(open_joint.child_link_index());
+  const Link& parent_link = links(parent_link_ordinal);
+  if (parent_link.mobod_index().is_valid()) {
+    return std::make_tuple(parent_link.mobod_index(), parent_link_ordinal,
+                           child_link_ordinal, false);
+  }
+  const Link& child_link = links(child_link_ordinal);
+  DRAKE_DEMAND(child_link.mobod_index().is_valid());
+  return std::make_tuple(child_link.mobod_index(), child_link_ordinal,
+                         parent_link_ordinal, true);
+}
+
+void SpanningForest::FindNextLevelJoints(MobodIndex inboard_mobod_index,
+                                         const std::vector<JointIndex>& J_in,
+                                         std::vector<JointIndex>* J_level,
+                                         int* num_unprocessed_links) {
+  DRAKE_DEMAND(J_level != nullptr && num_unprocessed_links != nullptr);
+  J_level->clear();
+
+  for (auto j_in_index : J_in) {
+    const Joint& j_in = joint_by_index(j_in_index);
+    if (j_in.has_been_processed()) continue;
+
+    if (!should_merge_parent_and_child(j_in)) {
+      J_level->push_back(j_in.index());
+      continue;
+    }
+
+    /* This has to be a merged joint with parent & child links part of the
+    same merged LinkComposite. We must grow the composite in the outboard
+    direction of the joint, which is the end that is _not_ already following
+    the inboard Mobod. */
+    const BodyIndex outboard_link_index =
+        FindOutboardLink(inboard_mobod_index, j_in);
+
+    /* Adds the outboard link O to the inboard composite and keeps collecting
+    the welded links of O+ to the composite recursively, while collecting up
+    all the further-outboard non-weld joints Jₒₚₑₙ(O+) into J_level. */
+    GrowCompositeMobod(&data_.mobods[inboard_mobod_index], outboard_link_index,
+                       j_in.ordinal(), &*J_level, &*num_unprocessed_links);
+  }
+}
+
+BodyIndex SpanningForest::FindOutboardLink(MobodIndex inboard_mobod_index,
+                                           const Joint& joint) const {
+  const Link& parent_link = link_by_index(joint.parent_link_index());
+  const Link& child_link = link_by_index(joint.child_link_index());
+  if (parent_link.mobod_index().is_valid() &&
+      parent_link.mobod_index() == inboard_mobod_index) {
+    return child_link.index();
+  }
+  DRAKE_DEMAND(child_link.mobod_index().is_valid() &&
+               child_link.mobod_index() == inboard_mobod_index);
+  return parent_link.index();
+}
+
+bool SpanningForest::HasMassfulOutboardLink(
+    MobodIndex inboard_mobod_index,
+    const std::vector<JointIndex>& joints) const {
+  for (JointIndex joint_index : joints) {
+    const Joint& joint = joint_by_index(joint_index);
+    const BodyIndex outboard_link_index =
+        FindOutboardLink(inboard_mobod_index, joint);
+    if (!link_by_index(outboard_link_index).is_massless()) return true;
+  }
+  return false;
 }
 
 /* See documentation in header before trying to decipher this. */
@@ -624,9 +738,11 @@ const SpanningForest::Mobod& SpanningForest::AddNewMobod(
   Mobod& new_mobod =
       data_.mobods.emplace_back(new_mobod_index, outboard_link_ordinal,
                                 joint_ordinal, inboard_level + 1, is_reversed);
-  Mobod& inboard_mobod = data_.mobods[inboard_mobod_index];
+  const Link& outboard_link = links(outboard_link_ordinal);
+  if (!outboard_link.is_massless()) new_mobod.has_massful_follower_link_ = true;
 
   /* If the inboard Mobod is World, start a new Tree. */
+  Mobod& inboard_mobod = data_.mobods[inboard_mobod_index];
   TreeIndex tree_index = inboard_mobod.tree();
   if (!tree_index.is_valid()) {
     DRAKE_DEMAND(inboard_mobod.is_world());  // Otherwise should have a tree.
@@ -641,7 +757,7 @@ const SpanningForest::Mobod& SpanningForest::AddNewMobod(
   tree.height_ = std::max(tree.height_, new_mobod.level_);
   data_.forest_height = std::max(data_.forest_height, tree.height_ + 1);
 
-  // Record connections in forest and graph.
+  /* Record connections in forest and graph. */
   new_mobod.inboard_mobod_ = inboard_mobod_index;
   inboard_mobod.outboard_mobods_.push_back(new_mobod_index);
   mutable_graph().set_primary_mobod_for_link(outboard_link_ordinal,
@@ -649,7 +765,9 @@ const SpanningForest::Mobod& SpanningForest::AddNewMobod(
   mutable_graph().set_mobod_for_joint(joint_ordinal, new_mobod_index);
 
   /* Build up both WeldedMobods group (in forest) and LinkComposite (in graph)
-  if we have a Weld joint, starting a new group or composite as needed. */
+  if we have a Weld joint, starting a new group or composite as needed.
+  Note that if we get here we are _not_ merging LinkComposites or we wouldn't
+  have asked for a new Mobod! */
   if (joint.traits_index() == LinkJointGraph::weld_joint_traits_index()) {
     if (!inboard_mobod.welded_mobods_index_.has_value()) {
       inboard_mobod.welded_mobods_index_ =
@@ -738,8 +856,9 @@ void SpanningForest::HandleLoopClosure(JointOrdinal loop_joint_ordinal) {
   terminated with massful bodies (at 1/2 the mass each). However, if both
   bodies are massless this forest can only be used for kinematics. */
   const bool parent_is_massless =
-      graph().must_treat_as_massless(parent_ordinal);
-  const bool child_is_massless = graph().must_treat_as_massless(child_ordinal);
+      graph().link_and_its_composite_are_massless(parent_ordinal);
+  const bool child_is_massless =
+      graph().link_and_its_composite_are_massless(child_ordinal);
 
   /* Save an explanation the first time we are forced to end a branch with
   a massless body. */
@@ -812,6 +931,80 @@ const SpanningForest::Mobod& SpanningForest::AddShadowMobod(
       loop_constraint_index, primary_mobod_index, shadow_mobod.index());
 
   return shadow_mobod;
+}
+
+const SpanningForest::Mobod& SpanningForest::JoinExistingMobod(
+    Mobod* inboard_mobod, LinkOrdinal follower_link_ordinal,
+    JointOrdinal weld_joint_ordinal) {
+  const Joint& weld_joint = joints(weld_joint_ordinal);
+  DRAKE_DEMAND(weld_joint.traits_index() ==
+               LinkJointGraph::weld_joint_traits_index());
+  const LinkCompositeIndex link_composite_index =
+      mutable_graph().AddToLinkComposite(inboard_mobod->link_ordinal(),
+                                         follower_link_ordinal);
+  mutable_graph().set_primary_mobod_for_link(
+      follower_link_ordinal, inboard_mobod->index(), weld_joint.index());
+  inboard_mobod->follower_link_ordinals_.push_back(follower_link_ordinal);
+  const Link& follower_link = links(follower_link_ordinal);
+  if (!follower_link.is_massless())
+    inboard_mobod->has_massful_follower_link_ = true;
+
+  /* We're not going to model this weld Joint since it is interior to
+  a LinkComposite. We need to note the composite it is part of. */
+  mutable_graph().AddUnmodeledJointToComposite(weld_joint_ordinal,
+                                               link_composite_index);
+  return *inboard_mobod;
+}
+
+void SpanningForest::GrowCompositeMobod(
+    Mobod* mobod, BodyIndex outboard_link_index,
+    JointOrdinal weld_joint_ordinal,
+    std::vector<JointIndex>* open_joint_indexes, int* num_unprocessed_links) {
+  /* If the outboard_link has already been processed we're looking at a loop
+  of welds within this LinkComposite. That's harmless: we just add the Joint
+  to the composite and move on. */
+  const LinkOrdinal outboard_link_ordinal =
+      graph().index_to_ordinal(outboard_link_index);
+  const Link& outboard_link = links(outboard_link_ordinal);
+  if (link_is_already_in_forest(outboard_link_ordinal)) {
+    const Link& inboard_link = links(mobod->link_ordinal());
+    DRAKE_DEMAND(outboard_link.composite() == inboard_link.composite());
+    mutable_graph().AddUnmodeledJointToComposite(weld_joint_ordinal,
+                                                 *outboard_link.composite());
+    return;
+  }
+
+  /* At this point we know the outboard_link has not been processed yet. Add
+  it to the composite's Mobod. */
+
+  JoinExistingMobod(&*mobod, outboard_link_ordinal, weld_joint_ordinal);
+  --(*num_unprocessed_links);
+
+  for (JointIndex joint_index : outboard_link.joints()) {
+    const JointOrdinal joint_ordinal = graph().index_to_ordinal(joint_index);
+    if (joint_ordinal == weld_joint_ordinal)
+      continue;  // That's the one we just did.
+    const Joint& joint = joints(joint_ordinal);
+
+    /* If any of outboard_link's other joints had been processed, outboard_link
+    would have already been in the forest. Hence all its non-merge joints
+    are open (unprocessed). */
+    DRAKE_DEMAND(!joint.has_been_processed());
+    if (!should_merge_parent_and_child(joint)) {
+      open_joint_indexes->push_back(joint_index);
+      continue;  // On to the next Joint.
+    }
+
+    /* We've found another unprocessed joint that needs merging onto this
+    composite. One of its links is the outboard_link (already in the forest
+    at this point). Find the other link. */
+    const BodyIndex other_link_index =
+        joint.other_link_index(outboard_link_index);
+
+    /* Recursively extend the Composite along the new merge-weld joint. */
+    GrowCompositeMobod(&*mobod, other_link_index, joint_ordinal,
+                       &*open_joint_indexes, &*num_unprocessed_links);
+  }
 }
 
 // TODO(sherm1) Remove this.

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -28,9 +29,6 @@ namespace internal {
 //  final PR in this train to satisfy the styleguide.
 
 using WeldedMobodsIndex = TypeSafeIndex<class WeldedMobodsTag>;
-
-// TODO(sherm1) The following describes the aspirational SpanningForest but
-//  some functionality is missing. See PR #20225 for the full implementation.
 
 /** SpanningForest models a LinkJointGraph via a set of spanning trees and
 loop-closing constraints. This is a directed forest, with edges ordered from
@@ -419,14 +417,47 @@ class SpanningForest {
                    int* num_unprocessed_links);
 
   // Grows the trees containing each of the given Joints by one level. The
-  // output parameter `joints_to_model_next` (cleared on entry) on return
+  // output parameter `J_out` (cleared on entry) on return
   // contains the set of Joints that should be modeled at the next level.
-  // @pre the pointers are non-null and joints_to_model is not empty. On return,
+  // @pre the pointers are non-null and `J_in` is not empty. On return,
   // num_unprocessed_links will have been decremented by the number of Links
   // that were modeled.
-  void ExtendTreesOneLevel(const std::vector<JointIndex>& joints_to_model,
-                           int* num_unprocessed_links,
-                           std::vector<JointIndex>* joints_to_model_next);
+  void ExtendTreesOneLevel(const std::vector<JointIndex>& J_in,
+                           std::vector<JointIndex>* J_out,
+                           int* num_unprocessed_links);
+
+  // Helper for ExtendTreesOneLevel(). We're given a joint that has at least
+  // one link already in the forest. That's the "inboard link" I and we want
+  // to know the inboard Mobod it follows. The other (usually unmodeled)
+  // link is the "outboard link" O. If both links are already in the forest
+  // we'll arbitrarily consider the parent link as I and child as O.
+  // Return tuple is: [I's mobod, I, O, is_reversed].
+  std::tuple<MobodIndex, LinkOrdinal, LinkOrdinal, bool> FindInboardMobod(
+      const Joint& open_joint) const;
+
+  // Helper for ExtendTreesOneLevel(). We're given a set of as-yet-unmodeled,
+  // "open" joints, each of which has one end already following the given Mobod.
+  // Returns a list of joints that represent the "next level" in the forest
+  // outboard of the given Mobod. For any joint that doesn't have to be a
+  // merged joint in a merged composite, that joint goes directly on the
+  // "next level" list. Otherwise, we have to extend the composite and find all
+  // the open joints where one end is part of the composite; those are the
+  // "next level".
+  void FindNextLevelJoints(MobodIndex inboard_mobod_index,
+                           const std::vector<JointIndex>& J_in,
+                           std::vector<JointIndex>* J_level,
+                           int* num_unprocessed_links);
+
+  // Given a Mobod and a Joint known to have one of its links already following
+  // that Mobod, find the other (outboard) link. */
+  BodyIndex FindOutboardLink(MobodIndex inboard_mobod_index,
+                             const Joint& joint) const;
+
+  // Helper for ExtendTreesOneLevel(). Given a Mobod and a set of joints known
+  // to have one of their links already following that Mobod, look at the other
+  // (outboard) link and return true if we find one that has mass.
+  bool HasMassfulOutboardLink(MobodIndex inboard_mobod_index,
+                              const std::vector<JointIndex>& joints) const;
 
   // After dealing with everything that had some path to World, deals with
   // remaining disconnected subgraphs and lone free bodies. On return,
@@ -506,6 +537,49 @@ class SpanningForest {
     DRAKE_ASSERT(data_.graph != nullptr);
     return *data_.graph;
   }
+
+  // Returns true if this model instance requests optimization (link merging)
+  // of composites, either explicitly or via inheritance from the global
+  // settings.
+  bool should_merge_link_composites(ModelInstanceIndex index) const {
+    return static_cast<bool>(options(index) &
+                             ForestBuildingOptions::kMergeLinkComposites);
+  }
+
+  // This implements our policy for when to optimize LinkComposites by merging
+  // their constituent Links onto a single Mobod. We're given a Joint
+  // connecting parent and child Links and need to decide whether the parent
+  // and child will follow a single Mobod or two different Mobods. If we
+  // decide to merge them, the Joint won't be modeled at all since it will be
+  // interior to the composite.
+  //
+  // To return true (merge), the following must all be true:
+  //   - The joint must be a weld, and
+  //   - the joint's model instance must request merging composites, and
+  //   - the joint has _not_ demanded that it be modeled.
+  bool should_merge_parent_and_child(const Joint& joint) const {
+    return joint.is_weld() && !joint.must_be_modeled() &&
+           should_merge_link_composites(joint.model_instance());
+  }
+
+  // Adds the follower Link to the LinkComposite that inboard_mobod is
+  // mobilizing and notes that the Joint is internal to that LinkComposite
+  // so is not modeled. Will create the LinkComposite if there was only one
+  // Link mobilized before.
+  const Mobod& JoinExistingMobod(Mobod* inboard_mobod,
+                                 LinkOrdinal follower_link_ordinal,
+                                 JointOrdinal weld_joint_ordinal);
+
+  // We're given an existing Mobod and a to-be-merged weld joint where that
+  // joint's inboard link is already following the Mobod. Greedily extend this
+  // Mobod recursively to merge all links that are merge-welded to the inboard
+  // link. As we encounter non-merge joints attached to this composite we append
+  // them to `open_joint_indexes` for processing next. Those constitute the
+  // "next level" outboard of this merged composite.
+  void GrowCompositeMobod(Mobod* inboard_mobod, BodyIndex outboard_link_index,
+                          JointOrdinal weld_joint_ordinal,
+                          std::vector<JointIndex>* open_joint_indexes,
+                          int* num_unprocessed_links);
 
   struct Data {
     // These are all default but definitions deferred to .cc file so

--- a/multibody/topology/spanning_forest_mobod.h
+++ b/multibody/topology/spanning_forest_mobod.h
@@ -83,12 +83,23 @@ class SpanningForest::Mobod {
   @see joint() */
   LinkOrdinal link_ordinal() const { return follower_link_ordinals()[0]; }
 
+  /** Returns true if _any_ of the follower links is massful, in which case
+  this Mobod is also massful. */
+  bool has_massful_follower_link() const { return has_massful_follower_link_; }
+
   /** Returns all the Links that are mobilized by this %Mobod. If this %Mobod
   represents a LinkComposite, the first Link returned is the "active" Link as
   returned by link(). There is always at least one Link. */
   const std::vector<LinkOrdinal>& follower_link_ordinals() const {
     DRAKE_ASSERT(!follower_link_ordinals_.empty());
     return follower_link_ordinals_;
+  }
+
+  bool HasFollower(LinkOrdinal link_ordinal) const {
+    DRAKE_DEMAND(link_ordinal.is_valid());
+    return std::find(follower_link_ordinals_.cbegin(),
+                     follower_link_ordinals_.cend(),
+                     link_ordinal) != follower_link_ordinals_.cend();
   }
 
   /** Returns the ordinal of the Joint represented by this %Mobod. If this
@@ -193,6 +204,9 @@ class SpanningForest::Mobod {
   // Links represented by this Mobod. The first one is always present and is
   // the active Link if we're mobilizing a LinkComposite.
   std::vector<LinkOrdinal> follower_link_ordinals_;
+
+  // Set to true if _any_ follower link has mass.
+  bool has_massful_follower_link_{false};
 
   // Corresponding Joint (user or modeling joint). If this Mobod represents
   // a LinkComposite, this is the Joint that mobilizes the whole Composite.

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -62,8 +62,9 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_EQ(world_mobod_index, MobodIndex(0));
   EXPECT_EQ(graph.link_to_mobod(world_link_index), MobodIndex(0));
   EXPECT_EQ(ssize(graph.link_composites()), 1);
-  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0))), 1);
-  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0))[0], world_link_index);
+  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0)).links), 1);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links[0],
+            world_link_index);
 
   // Check that the World-only forest makes sense.
   EXPECT_EQ(ssize(forest.mobods()), 1);
@@ -284,8 +285,8 @@ GTEST_TEST(SpanningForest, MultipleBranchesDefaultOptions) {
 
   // The only LinkComposite is the World composite and it is alone there.
   EXPECT_EQ(ssize(graph.link_composites()), 1);  // just World
-  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0))), 1);
-  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0))[0],
+  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0)).links), 1);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links[0],
             graph.world_link().index());
 
   EXPECT_EQ(ssize(forest.trees()), 3);
@@ -447,10 +448,10 @@ GTEST_TEST(SpanningForest, MultipleBranchesBaseJointOptions) {
 
   // There is only the World composite, but now tree1's base link is included.
   EXPECT_EQ(ssize(graph.link_composites()), 1);  // just World
-  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0))), 2);
-  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0))[0],
+  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0)).links), 2);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links[0],
             graph.world_link().index());
-  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0))[1],
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links[1],
             graph.links(tree1.front().link_ordinal()).index());
 
   // Similarly, there is only one WeldedMobods group, containing just World
@@ -560,8 +561,8 @@ The LinkJointGraph
     * link10 would be the preferred base link but link 11 "base11" is marked
       "must be base link" so we have to use a reversed mobilizer there
 
-SpanningForest 1 (don't combine LinkComposites)
------------------------------------------------
+SerialChain 1 (don't merge LinkComposites)
+------------------------------------------
   ≡> added weld joint       [mobods]
   6> added floating joint   {links}
 
@@ -587,7 +588,8 @@ SpanningForest 1 (don't combine LinkComposites)
   (1) World is always present and is first, and (2) the active link comes first
   in any LinkComposite.
 
-TODO(sherm1) Retest with "combine composites" option on (currently stubbed).
+We will also vary this graph in several ways and retest. The details are
+described in the code below.
 */
 GTEST_TEST(SpanningForest, SerialChainAndMore) {
   LinkJointGraph graph;
@@ -626,10 +628,11 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   const BodyIndex link10_index = graph.AddLink("link10", model_instance);
   const BodyIndex base11_index =
       graph.AddLink("base11", model_instance, LinkFlags::kMustBeBaseBody);
-  graph.AddJoint("weld", model_instance, "weld", link10_index, base11_index);
+  const JointIndex joint_10_11_index = graph.AddJoint(
+      "weld", model_instance, "weld", link10_index, base11_index);
 
-  // SpanningForest 1 (not combining welded Links onto one Mobod)
-  // ------------------------------------------------------------
+  // SerialChain 1 (not merging welded Links onto one Mobod)
+  // -------------------------------------------------------
   graph.ResetForestBuildingOptions();  // Unnecessary; just being tidy.
   graph.SetForestBuildingOptions(static_model_instance,
                                  ForestBuildingOptions::kStatic);
@@ -672,9 +675,13 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   const std::vector<BodyIndex> link_composites0{BodyIndex(0), BodyIndex(7),
                                                 BodyIndex(6), BodyIndex(8)};
   const std::vector<BodyIndex> link_composites1{BodyIndex(11), BodyIndex(10)};
-  const std::vector<std::vector<BodyIndex>> expected_link_composites{
-      link_composites0, link_composites1};
-  EXPECT_EQ(graph.link_composites(), expected_link_composites);
+
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
+            link_composites0);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(1)).links,
+            link_composites1);
+  EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(0)).is_massless);
+  EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(1)).is_massless);
 
   EXPECT_EQ(ssize(forest.mobods()), 12);
   EXPECT_EQ(ssize(forest.trees()), 6);
@@ -739,17 +746,112 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_EQ(find_outv(11), pair(17, 0));
   EXPECT_FALSE(forest.mobods(MobodIndex(3)).is_base_body());  // Generic case
   EXPECT_EQ(find_outv(3), pair(3, 2));
+
+  /* SerialChain 2 (merge link composites)
+  ----------------------------------------
+  If instead we ask to merge welded Links we should get a much smaller
+  forest:
+
+    tree      {world static7 static6 static8} [0]
+     0 [1-5]  ->link1->link2->link3->link4->link5
+     1 [6]    6>{base11<=link10} (added 6dof, unmodeled weld)
+     2 [7]    6>free9            (added 6dof, free bodies are always last)
+
+    Link Composites: {0 7 6 8} {11 10}  (no change)
+    Welded Mobods groups: [0]  (just the World group) */
+
+  graph.ResetForestBuildingOptions();  // Restore default options.
+  graph.SetGlobalForestBuildingOptions(
+      ForestBuildingOptions::kMergeLinkComposites);
+  graph.SetForestBuildingOptions(static_model_instance,
+                                 ForestBuildingOptions::kMergeLinkComposites |
+                                     ForestBuildingOptions::kStatic);
+  EXPECT_TRUE(graph.BuildForest());
+
+  // The graph shouldn't change from SpanningForest 1, but the forest will.
+  EXPECT_EQ(ssize(graph.joints()) - graph.num_user_joints(), 4);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
+            link_composites0);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(1)).links,
+            link_composites1);
+
+  EXPECT_EQ(ssize(forest.mobods()), 8);
+  EXPECT_EQ(ssize(forest.trees()), 3);
+  EXPECT_EQ(ssize(forest.welded_mobods()), 1);  // Just World.
+
+  /* SerialChain 3 (merge composites except for 10 & 11)
+  ------------------------------------------------------
+  We can optionally insist that a weld joint within a composite that would
+  otherwise be ignored is actually modeled with a weld mobilizer (useful if
+  you need to know reaction forces within that weld). We'll rebuild but
+  specifying that the joint between link10 and link11 must be modeled. That
+  should produce this forest:
+
+    tree      {world static7 static6 static8} [0]
+     0 [1-5]  ->link1->link2->link3->link4->link5
+     1 [6-7]  6>{base11<=link10} (added 6dof, weld is now modeled)
+     2 [8]    6>free9            (added 6dof, free bodies are always last)
+
+    Link Composites: {0 7 6 8} {11 10}  (no change)
+    Welded Mobods groups: [0] [6 7] */
+
+  // Now force one of the joints in a composite to be modeled (meaning it
+  // should get its own Mobod). This should split that composite into
+  // two Mobods, which should be noted as a Welded Mobods group.
+  graph.ChangeJointFlags(joint_10_11_index, JointFlags::kMustBeModeled);
+  // Built the forest with same options as used for 2a.
+  EXPECT_TRUE(graph.BuildForest());
+
+  EXPECT_EQ(ssize(forest.mobods()), 9);
+  EXPECT_EQ(ssize(forest.trees()), 3);
+  EXPECT_EQ(ssize(forest.welded_mobods()), 2);
+  const std::vector<MobodIndex> now_expected{MobodIndex(6), MobodIndex(7)};
+  EXPECT_EQ(forest.welded_mobods(WeldedMobodsIndex(1)), now_expected);
+
+  /* SerialChain 4 (merge composites and use a fixed base)
+  --------------------------------------------------------
+  Finally, we'll restore joint 10-11 to its default setting and build again but
+  this time with the kUseFixedBase option for model_instance.
+  That means we'll use weld joints rather than floating joints for links that
+  have no path to World in the input graph. Now we expect this forest:
+
+    tree        {world static7 static6 static8 base11 link10 free9} [0]
+      0  [1-5]  ->link1->link2->link3->link4->link5
+
+    Link Composites: {0 7 6 8 11 10 9}
+    Welded Mobods groups: [0]  (just World) */
+
+  // Put the joint back the way we found it.
+  graph.ChangeJointFlags(joint_10_11_index, JointFlags::kDefault);
+  graph.ResetForestBuildingOptions();  // Back to defaults.
+  graph.SetGlobalForestBuildingOptions(
+      ForestBuildingOptions::kMergeLinkComposites);
+  // Caution: we must specify all the forest building options we want for
+  // a model instance; it won't inherit any of the global ones if set.
+  graph.SetForestBuildingOptions(model_instance,
+                                 ForestBuildingOptions::kMergeLinkComposites |
+                                     ForestBuildingOptions::kUseFixedBase);
+  graph.SetForestBuildingOptions(static_model_instance,
+                                 ForestBuildingOptions::kMergeLinkComposites |
+                                     ForestBuildingOptions::kStatic);
+  EXPECT_TRUE(graph.BuildForest());
+
+  EXPECT_EQ(ssize(forest.mobods()), 6);
+  EXPECT_EQ(ssize(forest.trees()), 1);
+  EXPECT_EQ(ssize(forest.welded_mobods()), 1);  // Just World.
+  const std::vector<BodyIndex> expected_link_composite{
+      BodyIndex(0),  BodyIndex(7),  BodyIndex(6), BodyIndex(8),
+      BodyIndex(11), BodyIndex(10), BodyIndex(9)};
+  EXPECT_EQ(ssize(graph.link_composites()), 1);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
+            expected_link_composite);
 }
 
 /* Topological loops formed entirely by welds can be handled specially when
-we're combining LinkComposites onto single Mobods. We build a Forest containing
+we're merging LinkComposites onto single Mobods. We build a Forest containing
 a number of kinematic loops and subgraphs of welded bodies.
 
-TODO(sherm1) Combining composites is stubbed out but the first part of this
- test is still relevant since the composites are still computed, though not
- yet combined. More cases will follow.
-
-The input is given as three unconnected graphs. Joints are shown with
+The input is given as three unconnected subgraphs. Joints are shown with
 parent->child direction. Double bars are welds, single bars are moving joints.
 Links {0-13} are shown in braces, joint numbers 0-13 are plain.
 
@@ -823,7 +925,24 @@ though each Link has its own Mobod. Those are:
 The corresponding Mobods are in WeldedMobod groups:
 [0 1 2 6] [8 9 14 15] [10 11 13 12]
 
-TODO(sherm1) Retest with "combine composites" option on (currently stubbed). */
+Remodeling with composite link merging turned on should immediately create
+composite {0 5 7 12} on mobod 0, then see outboard links {2} and {11} as new
+base bodies and grow those two trees, discovering a loop at joint 8. As before,
+Link {11} gets split with a shadow link {14} for joint 8. Then it
+should choose link {3} as a base link and add floating joint 14, and grow that
+tree. Finally it makes free link {9} a base body. The forest should then look
+like this:
+
+
+      level 3                         6{10 6 8}
+      level 2      2{14}              5{13 1 4}
+  base mobods       1{2}    3{11}     4{3}        7{9}  (four trees)
+                      \       \        |           /
+        World          ...........0{0 5 7 12}......
+
+In this case we don't need to split the all-Weld loops since they are now
+just composite links {0 5 7 12} {13 1 4} {10 6 8}. There are no Welded
+Mobods (except World alone). */
 GTEST_TEST(SpanningForest, WeldedSubgraphs) {
   LinkJointGraph graph;
   graph.RegisterJointType("revolute", 1, 1);
@@ -883,8 +1002,9 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
   const std::vector<std::vector<int>> expected_links{
       {0, 5, 7, 12}, {13, 1, 4, 15}, {10, 6, 8, 16}};
   for (LinkCompositeIndex c(0); c < 3; ++c) {
+    EXPECT_FALSE(graph.link_composites(c).is_massless);
     for (int link = 0; link < ssize(expected_links[c]); ++link)
-      EXPECT_EQ(graph.link_composites(c)[link], expected_links[c][link]);
+      EXPECT_EQ(graph.link_composites(c).links[link], expected_links[c][link]);
   }
 
   // Now let's verify that we got the expected SpanningForest. To understand,
@@ -924,6 +1044,38 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
     for (int mobod = 0; mobod < ssize(expected_mobods[w]); ++mobod)
       EXPECT_EQ(forest.welded_mobods(w)[mobod], expected_mobods[w][mobod]);
   }
+
+  // Now merge composites so they get a single Mobod.
+  graph.SetGlobalForestBuildingOptions(
+      ForestBuildingOptions::kMergeLinkComposites);
+  EXPECT_TRUE(graph.BuildForest());
+
+  EXPECT_EQ(ssize(graph.links()), 15);  // Only one added shadow.
+  EXPECT_EQ(ssize(graph.link_composites()), 3);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
+            (std::vector<BodyIndex>{BodyIndex(0), BodyIndex(5), BodyIndex(7),
+                                    BodyIndex(12)}));
+  EXPECT_EQ(
+      graph.link_composites(LinkCompositeIndex(1)).links,
+      (std::vector<BodyIndex>{BodyIndex(13), BodyIndex(1), BodyIndex(4)}));
+  EXPECT_EQ(
+      graph.link_composites(LinkCompositeIndex(2)).links,
+      (std::vector<BodyIndex>{BodyIndex(10), BodyIndex(6), BodyIndex(8)}));
+  for (LinkCompositeIndex i(0); i < 3; ++i) {
+    EXPECT_FALSE(graph.link_composites(i).is_massless);
+  }
+
+  // Now let's verify that we got the expected SpanningForest. To understand,
+  // refer to the shorter (max level 3) diagram above.
+  EXPECT_EQ(ssize(forest.mobods()), 8);
+  std::array<int, 8> expected_level_merged{0, 1, 2, 1, 1, 2, 3, 1};
+  for (auto& mobod : forest.mobods()) {
+    EXPECT_EQ(mobod.level(), expected_level_merged[mobod.index()]);
+  }
+
+  EXPECT_EQ(ssize(forest.welded_mobods()), 1);  // just World
+  EXPECT_EQ(ssize(forest.welded_mobods(WeldedMobodsIndex(0))), 1);
+  EXPECT_EQ(forest.welded_mobods(WeldedMobodsIndex(0))[0], MobodIndex(0));
 }
 
 /* Ten links, 8 in a tree and 2 free ones. Internal link 8 is massless (should
@@ -950,9 +1102,9 @@ GTEST_TEST(SpanningForest, SimpleTrees) {
   // Define the graph.
   const std::set<int> massless{2, 4, 8};
   for (int i = 1; i <= 10; ++i) {
-    graph.AddLink("link" + std::to_string(i), model_instance,
-                  massless.contains(i) ? LinkFlags::kTreatAsMassless
-                                       : LinkFlags::kDefault);
+    graph.AddLink(
+        "link" + std::to_string(i), model_instance,
+        massless.contains(i) ? LinkFlags::kMassless : LinkFlags::kDefault);
   }
   const std::vector<std::pair<int, int>> joints{
       {3, 1}, {3, 2}, {8, 3}, {10, 8}, {10, 9}, {9, 4}, {9, 7}};
@@ -967,7 +1119,7 @@ GTEST_TEST(SpanningForest, SimpleTrees) {
   // We should report that the resulting forest is unsuited for dynamics due
   // to a terminal massless body. Specifically, it should complain about link
   // 4 rather than link 2 since 4 is at a lower level and should be seen first.
-  // (Tests Case 2 in ExtendTreesOneLevel())
+  // (Tests Case 1 in ExtendTreesOneLevel())
   EXPECT_FALSE(graph.BuildForest());
   const SpanningForest& forest = graph.forest();
   EXPECT_FALSE(forest.dynamics_ok());
@@ -977,7 +1129,9 @@ GTEST_TEST(SpanningForest, SimpleTrees) {
                             "singular.*cannot be used for dynamics.*"));
 
   // Change link 4's joint type to "weld". That should shift the complaint to
-  // link 2. (Tests Case 2 in ExtendTreesOneLevel())
+  // link 2. (Tests Case 1 in ExtendTreesOneLevel())
+  // Also, we should get a massful composite {4,9}, with 9 the active
+  // link (so must be listed first in the composite).
   graph.ChangeJointType(JointIndex(5), "weld");
   EXPECT_FALSE(graph.BuildForest());
   EXPECT_FALSE(forest.dynamics_ok());
@@ -985,6 +1139,11 @@ GTEST_TEST(SpanningForest, SimpleTrees) {
       forest.why_no_dynamics(),
       testing::MatchesRegex("Link link2 on revolute joint joint1.*terminal.*"
                             "singular.*cannot be used for dynamics.*"));
+  EXPECT_EQ(ssize(graph.link_composites()), 2);
+  const std::vector<BodyIndex>& composite94 =
+      graph.link_composites(LinkCompositeIndex(1)).links;
+  EXPECT_EQ(composite94, (std::vector<BodyIndex>{BodyIndex(9), BodyIndex(4)}));
+  EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(1)).is_massless);
 
   // Finally if we connect link 2 to a massful link forming a loop, we should
   // get a dynamics-ready forest by splitting the massful link.
@@ -1056,9 +1215,12 @@ GTEST_TEST(SpanningForest, MasslessLinksChangeLoopBreaking) {
             BodyIndex(7));
 
   // Changing just 3 to massless results in the same forest.
-  // (Tests Case 1 in ExtendTreesOneLevel())
-  graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kTreatAsMassless);
+  // (Tests Case 2 in ExtendTreesOneLevel())
+  graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kMassless);
   EXPECT_TRUE(graph.BuildForest());
+
+  // Check that links not in a composite still respond correctly.
+  EXPECT_TRUE(graph.link_and_its_composite_are_massless(LinkOrdinal(3)));
 
   EXPECT_EQ(ssize(graph.links()), 8);
   EXPECT_EQ(ssize(graph.joints()), 7);
@@ -1073,7 +1235,7 @@ GTEST_TEST(SpanningForest, MasslessLinksChangeLoopBreaking) {
 
   // Changing both 3 and 4 to massless breaks the loop at 6 instead of 4.
   // (Tests Case 3 in ExtendTreesOneLevel())
-  graph.ChangeLinkFlags(BodyIndex(4), LinkFlags::kTreatAsMassless);
+  graph.ChangeLinkFlags(BodyIndex(4), LinkFlags::kMassless);
   EXPECT_TRUE(graph.BuildForest());
 
   EXPECT_EQ(ssize(graph.links()), 8);
@@ -1103,7 +1265,8 @@ sufficient to prevent both massless Links from being terminal.
 
   {1}           {2}      massless       1{1}            3{2}
 
-   🡑 0           🡑 1                     🡑 T0            🡑 T1     T = tree
+   🡑 0           🡑 1                     🡑 T0            🡑 T1     T
+= tree
                            ---->
  ........{0}........                     ........ 0 ........
         World                                   World
@@ -1123,8 +1286,8 @@ GTEST_TEST(SpanningForest, MasslessBodiesShareSplitLink) {
   graph.RegisterJointType("prismatic", 1, 1);
   const ModelInstanceIndex model_instance(19);
 
-  graph.AddLink("massless_1", model_instance, LinkFlags::kTreatAsMassless);
-  graph.AddLink("massless_2", model_instance, LinkFlags::kTreatAsMassless);
+  graph.AddLink("massless_1", model_instance, LinkFlags::kMassless);
+  graph.AddLink("massless_2", model_instance, LinkFlags::kMassless);
   graph.AddLink("link_3", model_instance);
 
   graph.AddJoint("prismatic_0", model_instance, "prismatic", world_index(),
@@ -1309,7 +1472,7 @@ GTEST_TEST(SpanningForest, WorldCompositeComesFirst) {
   graph.RegisterJointType("revolute", 1, 1);
   const ModelInstanceIndex model_instance(5);  // arbitrary
 
-  graph.AddLink("massless_link_1", model_instance, LinkFlags::kTreatAsMassless);
+  graph.AddLink("massless_link_1", model_instance, LinkFlags::kMassless);
   graph.AddLink("link2", model_instance);
   graph.AddLink("link3", model_instance);
   graph.AddLink("link4", model_instance);
@@ -1333,7 +1496,7 @@ GTEST_TEST(SpanningForest, WorldCompositeComesFirst) {
   const SpanningForest& forest = graph.forest();
 
   EXPECT_EQ(ssize(graph.links()), 5);
-  EXPECT_EQ(ssize(forest.mobods()), 5);  // Because we're not combining.
+  EXPECT_EQ(ssize(forest.mobods()), 5);  // Because we're not merging.
 
   // "Anchored" means "fixed to World" (by welds).
   EXPECT_TRUE(world.is_anchored());
@@ -1343,16 +1506,34 @@ GTEST_TEST(SpanningForest, WorldCompositeComesFirst) {
   EXPECT_FALSE(link4.is_anchored());
 
   EXPECT_EQ(ssize(graph.link_composites()), 2);
-  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)),
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
             (std::vector<BodyIndex>{BodyIndex(0), BodyIndex(3)}));
-  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(1)),
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(1)).links,
             (std::vector<BodyIndex>{BodyIndex(1), BodyIndex(2)}));
+  EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(0)).is_massless);
+  EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(1)).is_massless);
 
   EXPECT_EQ(ssize(forest.welded_mobods()), 2);
   EXPECT_EQ(forest.welded_mobods(WeldedMobodsIndex(0)),
             (std::vector<MobodIndex>{MobodIndex(0), MobodIndex(3)}));
   EXPECT_EQ(forest.welded_mobods(WeldedMobodsIndex(1)),
             (std::vector<MobodIndex>{MobodIndex(1), MobodIndex(2)}));
+
+  // Remodel making single Mobods for composite links.
+  graph.SetGlobalForestBuildingOptions(
+      ForestBuildingOptions::kMergeLinkComposites);
+  EXPECT_TRUE(graph.BuildForest());
+
+  EXPECT_EQ(ssize(forest.mobods()), 3);  // Because we're merging.
+  EXPECT_EQ(forest.mobods(MobodIndex(0)).follower_link_ordinals(),
+            (std::vector<LinkOrdinal>{LinkOrdinal(0), LinkOrdinal(3)}));
+  EXPECT_EQ(forest.mobods(MobodIndex(1)).follower_link_ordinals(),
+            (std::vector<LinkOrdinal>{LinkOrdinal(1), LinkOrdinal(2)}));
+  EXPECT_EQ(forest.mobods(MobodIndex(2)).follower_link_ordinals(),
+            (std::vector<LinkOrdinal>{LinkOrdinal(4)}));
+
+  EXPECT_EQ(ssize(graph.link_composites()), 2);  // no change expected
+  EXPECT_EQ(ssize(forest.welded_mobods()), 1);   // just World now
 }
 
 /* We always preserve the user's parent->child order for a joint, even if we
@@ -1463,8 +1644,8 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
   }
 
   // Now make link3 massless, rebuild, and check a few things.
-  graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kTreatAsMassless);
-  graph.BuildForest();
+  graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kMassless);
+  EXPECT_TRUE(graph.BuildForest());
   const LinkJointGraph::Link& new_primary_link =
       graph.link_by_index(BodyIndex(2));
   const LinkJointGraph::Link& new_shadow_link =
@@ -1486,6 +1667,445 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
   EXPECT_EQ(new_shadow_link.num_shadows(), 0);
   EXPECT_TRUE(new_shadow_link.is_shadow());
   EXPECT_EQ(new_shadow_link.primary_link(), new_primary_link.index());
+}
+
+/* Here are some rare conditions we want to process correctly.
+
+A loop of massless links should be flagged as "no dynamics".
+
+           +---->{1*}------,
+           |               V
+      {4*} |              {2*}
+           |               |
+           +---->{3*}<-----'
+
+We should continue extending the forest along the branch {4}->{1} until we
+get back to {4} and realize we're forced to connect massless links {4} and {3}.
+
+But if we change link {4} to massful, that same procedure should rescue dynamics
+since we can end both branches with half of link {4}.
+
+We'll also try replacing massful link 4 with World and verify that still
+works the same way. We can split off an arbitrary-mass chunk of World to
+terminate the massless branch. */
+GTEST_TEST(SpanningForest, MasslessLoopAreDetected) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+  for (int i = 1; i <= 4; ++i) {
+    graph.AddLink("link" + std::to_string(i), default_model_instance(),
+                  LinkFlags::kMassless);
+  }
+
+  const std::vector<std::pair<int, int>> joints{{4, 1}, {4, 3}, {1, 2}, {2, 3}};
+  for (int i = 0; i < ssize(joints); ++i) {
+    graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
+                   "revolute", BodyIndex(joints[i].first),
+                   BodyIndex(joints[i].second));
+  }
+
+  EXPECT_FALSE(graph.BuildForest());
+  EXPECT_THAT(
+      graph.forest().why_no_dynamics(),
+      testing::MatchesRegex("Loop breaks.*joint1.*between two massless links.*"
+                            "link4.*link3.*cannot be used for dynamics.*"));
+
+  graph.ChangeLinkFlags(BodyIndex(1), LinkFlags::kDefault);  // Massful now.
+  EXPECT_TRUE(graph.BuildForest());
+
+  /* Make a new graph where World replaces body 4.
+         +---->{1*}------,
+         |               V
+   World |              {2*}
+    {0}  |               |
+         +---->{3*}<-----'
+  */
+  LinkJointGraph world_graph;
+  world_graph.RegisterJointType("revolute", 1, 1);
+  for (int i = 1; i <= 3; ++i) {
+    world_graph.AddLink("link" + std::to_string(i), default_model_instance(),
+                        LinkFlags::kMassless);
+  }
+
+  const std::vector<std::pair<int, int>> world_graph_joints{
+      {0, 1}, {0, 3}, {1, 2}, {2, 3}};
+  for (int i = 0; i < ssize(world_graph_joints); ++i) {
+    world_graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
+                         "revolute", BodyIndex(world_graph_joints[i].first),
+                         BodyIndex(world_graph_joints[i].second));
+  }
+
+  /* Check that we split World as expected. */
+  EXPECT_TRUE(world_graph.BuildForest());
+  EXPECT_EQ(world_graph.num_user_links(), 4);
+  EXPECT_EQ(ssize(world_graph.links()), 5);
+  EXPECT_EQ(ssize(world_graph.forest().mobods()), 5);
+  EXPECT_EQ(world_graph.world_link().num_shadows(), 1);
+  EXPECT_TRUE(world_graph.link_by_index(BodyIndex(4)).is_shadow());
+  EXPECT_EQ(world_graph.link_by_index(BodyIndex(4)).primary_link(),
+            BodyIndex(0));
+}
+
+/* Composite bodies should be treated the same as single bodies while
+building the trees a level at a time. We'll create a loop out of two
+trees, one composed of two-body composites and the other single bodies.
+Our loop-splitting algorithm should result in two trees of equal length in
+mobilized bodies though unequal in links.
+
+              0               1             2
+      +--> {1}==>{2} --> {3*}==>{4*} --> {5}==>{6}
+  {0} | 3             4              5          | 10   {Links} & Joints
+      |                                         v      * = massless
+      +--->   {7}  --->  {8}  --->  {9}  ---> {10}
+        6           7          8          9
+
+
+      +---> [1] ---> [2*] --> [3] ---> [4] {10}
+      |    {1,2}    {3,4}*   {5,6}      #
+  [0] |                                 # Weld            [Mobods]
+      |     {7}      {8}      {9}       V                 * = massless
+      +---> [5] ---> [6] ---> [7] ---> [8] {10s}
+
+Not that the presence of massless links {3} and {4} should have almost no
+consequence since they are followed by a massful body. However, the {3,4}
+link composite should be marked "massless".
+
+This test case also opportunistically uses this graph to test that copy, move,
+and assign work correctly. */
+GTEST_TEST(SpanningForest, LoopWithComposites) {
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+  const ModelInstanceIndex model_instance(19);
+
+  const std::set<int> massless{3, 4};
+  for (int i = 1; i <= 10; ++i) {
+    graph.AddLink(
+        "link" + std::to_string(i), model_instance,
+        massless.contains(i) ? LinkFlags::kMassless : LinkFlags::kDefault);
+  }
+
+  const std::vector<std::pair<int, int>> weld_joints{{1, 2}, {3, 4}, {5, 6}};
+  const std::vector<std::pair<int, int>> revolute_joints{
+      {0, 1}, {2, 3}, {4, 5}, {0, 7}, {7, 8}, {8, 9}, {9, 10}, {6, 10}};
+  for (int i = 0; i < ssize(weld_joints); ++i) {
+    graph.AddJoint("weld_joint_" + std::to_string(i), model_instance, "weld",
+                   BodyIndex(weld_joints[i].first),
+                   BodyIndex(weld_joints[i].second));
+  }
+  for (int i = 0; i < ssize(revolute_joints); ++i) {
+    const int j = ssize(weld_joints) + i;  // joint number
+    graph.AddJoint("revolute_joint_" + std::to_string(j), model_instance,
+                   "revolute", BodyIndex(revolute_joints[i].first),
+                   BodyIndex(revolute_joints[i].second));
+  }
+
+  // Before modeling
+  EXPECT_EQ(ssize(graph.links()), 11);  // counting World
+  EXPECT_EQ(ssize(graph.joints()), 11);
+  EXPECT_EQ(ssize(graph.loop_constraints()), 0);
+
+  graph.SetGlobalForestBuildingOptions(
+      ForestBuildingOptions::kMergeLinkComposites);
+  EXPECT_TRUE(graph.BuildForest());
+  const SpanningForest& forest = graph.forest();
+
+  // After modeling
+  EXPECT_EQ(ssize(graph.links()), 12);            // split one, added shadow
+  EXPECT_EQ(ssize(graph.joints()), 11);           // no change
+  EXPECT_EQ(ssize(graph.loop_constraints()), 1);  // welded shadow to primary
+  EXPECT_EQ(ssize(graph.link_composites()), 4);   // World + 3
+  std::array<bool, 4> expect_massless{false, false, true, false};
+  for (LinkCompositeIndex i{0}; i < 4; ++i) {
+    EXPECT_EQ(graph.link_composites(i).is_massless, expect_massless[i]);
+  }
+
+  EXPECT_EQ(ssize(forest.mobods()), 9);
+  EXPECT_EQ(ssize(forest.loop_constraints()), 1);
+  EXPECT_EQ(ssize(forest.trees()), 2);
+  EXPECT_EQ(ssize(forest.welded_mobods()), 1);  // just World
+
+  EXPECT_EQ(forest.mobods(MobodIndex(1)).follower_link_ordinals(),
+            (std::vector<LinkOrdinal>{LinkOrdinal(1), LinkOrdinal(2)}));
+  EXPECT_EQ(forest.mobods(MobodIndex(2)).follower_link_ordinals(),
+            (std::vector<LinkOrdinal>{LinkOrdinal(3), LinkOrdinal(4)}));
+  EXPECT_EQ(forest.mobods(MobodIndex(3)).follower_link_ordinals(),
+            (std::vector<LinkOrdinal>{LinkOrdinal(5), LinkOrdinal(6)}));
+
+  const SpanningForest::Tree tree0 = forest.trees(TreeIndex(0)),
+                             tree1 = forest.trees(TreeIndex(1));
+  EXPECT_EQ(tree0.num_mobods(), 4);
+  EXPECT_EQ(tree0.nq(), 4);
+  EXPECT_EQ(tree1.num_mobods(), 4);
+  EXPECT_EQ(tree1.nq(), 4);
+
+  // Sanity checks for graph copy, move, and assignment. These are mostly
+  // compiler-generated so we just need to test any field and that the
+  // bespoke backpointer adjustments get done correctly.
+
+  LinkJointGraph graph_copy(graph);
+  EXPECT_EQ(ssize(graph_copy.links()), 12);
+  EXPECT_TRUE(graph_copy.forest_is_valid());
+  const SpanningForest& copy_model = graph_copy.forest();
+  EXPECT_NE(&copy_model, &forest);
+  EXPECT_EQ(&copy_model.graph(), &graph_copy);  // backpointer
+
+  LinkJointGraph graph_assign;
+  graph_assign = graph;
+  EXPECT_EQ(ssize(graph_assign.links()), 12);
+  EXPECT_TRUE(graph_assign.forest_is_valid());
+  EXPECT_NE(&graph_assign.forest(), &forest);
+  EXPECT_EQ(&graph_assign.forest().graph(), &graph_assign);
+
+  LinkJointGraph graph_move(std::move(graph));
+  EXPECT_EQ(ssize(graph_move.links()), 12);
+  EXPECT_EQ(ssize(graph.links()), 1);  // Just world now.
+  EXPECT_EQ(&graph_move.forest(), &forest);
+  EXPECT_EQ(&graph_move.forest().graph(), &graph_move);
+  // graph is now default-constructed so still has a forest
+  EXPECT_NE(&graph.forest(), &forest);
+  EXPECT_FALSE(graph.forest_is_valid());
+  EXPECT_EQ(&graph.forest().graph(), &graph);
+
+  LinkJointGraph graph_move_assign;
+  graph_move_assign = std::move(graph_copy);
+  EXPECT_EQ(ssize(graph_move_assign.links()), 12);
+  EXPECT_TRUE(graph_move_assign.forest_is_valid());
+  EXPECT_EQ(&graph_move_assign.forest(), &copy_model);
+  EXPECT_EQ(&graph_move_assign.forest().graph(), &graph_move_assign);
+  // graph_copy is now default-constructed. Should have world and a
+  // new (empty) forest.
+  EXPECT_EQ(ssize(graph_copy.links()), 1);
+  EXPECT_NE(&graph_copy.forest(), &copy_model);
+  EXPECT_FALSE(graph_copy.forest_is_valid());
+  EXPECT_EQ(&graph_copy.forest().graph(), &graph_copy);
+}
+
+/* Make sure massless, merged composites are working correctly. They are
+supposed to behave the same way as individual massless bodies:
+  - They should use only a single Mobod, and be treated as a single level
+    along a branch for branch-length minimization purposes.
+  - If there is anything massful attached to the massless composite, we
+    assume that mass always moves with the composite so we don't need to
+    give up branch-length minimization. (Test 2 below)
+  - We should not break a loop in a way that leaves a branch with a
+    terminal massless composite. (Test 3 below)
+*/
+GTEST_TEST(SpanningForest, MasslessMergedComposites) {
+  LinkJointGraph graph;
+  const SpanningForest& forest = graph.forest();
+  graph.SetGlobalForestBuildingOptions(
+      ForestBuildingOptions::kMergeLinkComposites);
+  graph.RegisterJointType("revolute", 1, 1);
+  const ModelInstanceIndex model_instance(19);
+
+  /* (Test 1) Massless composite welded to World ends up on the World
+  LinkComposite and doesn't count as a level in its tree. All its links should
+  be at level 0, and branch-length balancing should ignore the composite.
+
+  Input graph:
+    {1} link, *=massless, joint numbers are plain
+    --> revolute  ==> weld
+
+           0        1        2
+         +---> {1} ---> {2} ---> {3}     {4:5:6} is a massless composite
+     {0} |                        | 5            but welded to World
+         | 6      7      3     4  v
+         +==>{4*}==>{5*}-->{7}-->{8}     Should cut {3} to leave two
+               ∥ 8                       branches of length 3:
+               v                          {1 2 3} and {7 8 3s}
+              {6*}
+
+  Expected Forest:
+    [1] mobod
+
+           + --> [1]{1} --> [2]{2} --> [3]{3}
+       [0] |                            # loop weld
+  {0 4 5 6}|                            #
+           + --> [4]{7} --> [5]{8} --> [6]{3s}
+  */
+
+  const std::set<int> massless{4, 5, 6};
+  for (int i = 1; i <= 8; ++i) {
+    graph.AddLink(
+        "link" + std::to_string(i), model_instance,
+        massless.contains(i) ? LinkFlags::kMassless : LinkFlags::kDefault);
+  }
+
+  const std::vector<std::pair<int, int>> revolute_joints{
+      {0, 1}, {1, 2}, {2, 3}, {5, 7}, {7, 8}, {3, 8}};
+  const std::vector<std::pair<int, int>> weld_joints{{0, 4}, {4, 5}, {4, 6}};
+
+  for (int i = 0; i < ssize(revolute_joints); ++i) {
+    graph.AddJoint("joint_" + std::to_string(i), model_instance, "revolute",
+                   BodyIndex(revolute_joints[i].first),
+                   BodyIndex(revolute_joints[i].second));
+  }
+  for (int i = 0; i < ssize(weld_joints); ++i) {
+    const int j = ssize(revolute_joints) + i;  // joint number
+    graph.AddJoint("joint_" + std::to_string(j), model_instance, "weld",
+                   BodyIndex(weld_joints[i].first),
+                   BodyIndex(weld_joints[i].second));
+  }
+
+  // Before modeling
+  EXPECT_EQ(ssize(graph.links()), 9);  // counting World
+  EXPECT_EQ(ssize(graph.joints()), 9);
+  EXPECT_EQ(ssize(graph.loop_constraints()), 0);
+
+  EXPECT_TRUE(graph.BuildForest());
+
+  // After modeling
+  EXPECT_EQ(ssize(graph.links()), 10);  // added shadow 3s {9}
+  EXPECT_EQ(ssize(graph.joints()), 9);
+  EXPECT_EQ(ssize(graph.loop_constraints()), 1);  // glue {3} back together
+  EXPECT_EQ(ssize(forest.mobods()), 7);
+
+  // The links are massless but part of the World composite, which is not.
+  for (LinkOrdinal link_ordinal(4); link_ordinal <= 6; ++link_ordinal)
+    EXPECT_FALSE(graph.link_and_its_composite_are_massless(link_ordinal));
+
+  // Check that links not in a composite still respond correctly.
+  EXPECT_FALSE(graph.link_and_its_composite_are_massless(LinkOrdinal(2)));
+
+  // Check for equal-height trees.
+  ASSERT_EQ(ssize(forest.trees()), 2);
+  EXPECT_EQ(forest.trees(TreeIndex(0)).height(), 3);
+  EXPECT_EQ(forest.trees(TreeIndex(1)).height(), 3);
+
+  const auto& shadow_link = graph.link_by_index(BodyIndex(9));
+  EXPECT_TRUE(shadow_link.is_shadow());
+  EXPECT_EQ(shadow_link.name(), "link3$1");
+  EXPECT_EQ(shadow_link.index(), BodyIndex(9));
+  EXPECT_EQ(shadow_link.primary_link(), BodyIndex(3));
+  EXPECT_EQ(shadow_link.mobod_index(), MobodIndex(6));
+  ASSERT_EQ(ssize(shadow_link.joints()), 1);
+  EXPECT_EQ(shadow_link.joints()[0], JointIndex(5));
+
+  ASSERT_EQ(ssize(graph.link_composites()), 1);  // just the world composite
+  EXPECT_EQ(
+      graph.link_composites(LinkCompositeIndex(0)).links,
+      (std::vector{BodyIndex(0), BodyIndex(4), BodyIndex(5), BodyIndex(6)}));
+
+  /* (Test 2) Change the type of joint 6 (connects {4} to World) from weld
+  to revolute. That should move massless composite {4:5:6} onto its own Mobod.
+  Since it is immediately followed by massful link {7}, it won't prevent
+  the Forest from being suited for dynamics. This should cause the loop to be
+  split at {8} now, resulting in Tree 0 having a height of 4 and Tree 1 a
+  height of 3. */
+  graph.ChangeJointType(JointIndex(6), "revolute");
+  EXPECT_TRUE(graph.BuildForest());
+
+  // The links are massless and so is their composite.
+  for (LinkOrdinal link_ordinal(4); link_ordinal <= 6; ++link_ordinal)
+    EXPECT_TRUE(graph.link_and_its_composite_are_massless(link_ordinal));
+
+  EXPECT_EQ(forest.trees(TreeIndex(0)).height(), 4);
+  EXPECT_EQ(forest.trees(TreeIndex(1)).height(), 3);
+  const auto& new_shadow_link = graph.link_by_index(BodyIndex(9));
+  EXPECT_TRUE(new_shadow_link.is_shadow());
+  EXPECT_EQ(new_shadow_link.name(), "link8$1");
+
+  for (BodyIndex i(4); i <= 6; ++i)
+    EXPECT_EQ(graph.link_by_index(i).mobod_index(), 5);  // Merged to one Mobod.
+
+  ASSERT_EQ(ssize(graph.link_composites()), 2);  // world and {4:5:6}
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(1)).links,
+            (std::vector{BodyIndex(4), BodyIndex(5), BodyIndex(6)}));
+
+  /* (Test 3) Change links 7 and 8 to be massless so that we have to continue
+  extending the branch after the massless composite to hunt down something
+  massful with which to end the branch in Tree 1. This should affect when we see
+  the loop so Tree 0 will have height 3 and Tree 1 height 4, with link 3
+  split. */
+  graph.ChangeLinkFlags(BodyIndex(7), LinkFlags::kMassless);
+  graph.ChangeLinkFlags(BodyIndex(8), LinkFlags::kMassless);
+  EXPECT_TRUE(graph.BuildForest());
+  const auto& newer_shadow_link = graph.link_by_index(BodyIndex(9));
+  EXPECT_TRUE(newer_shadow_link.is_shadow());
+  EXPECT_EQ(newer_shadow_link.name(), "link3$1");
+
+  EXPECT_EQ(forest.trees(TreeIndex(0)).height(), 3);
+  EXPECT_EQ(forest.trees(TreeIndex(1)).height(), 4);
+}
+
+/* A joint connects a parent link to a child link. In general, the joint,
+parent, and child can each be in different model instances. Each of those
+model instances can specify whether we should merge link composites onto
+a single Mobod or whether parent and child must each have their own Mobod.
+Our policy is that when a joint is a weld, we look only at that joint's
+model instance to determine whether that joint will merge parent and child
+onto a single Mobod.
+
+A few nuances:
+ - When an ephemeral joint is added, it is assigned the same model instance
+   as its child link. So in that case the choice is effectively determined by
+   the child's model instance. This affects static links since those are
+   attached to World with a weld and will end up in the World LinkComposite.
+ - There is a joint flag that should force the joint to be modeled (rather
+   than merged) regardless of its model instance's setting.
+ - If the joint's model instance has no specified forest building options,
+   it inherits them from the global forest building options. (That's tested
+   elsewhere.)
+
+We'll use this graph:
+
+         I4  I1  I5  I2              Ix model instance index x
+   World --> {1} ==> {2}
+                                     I3 is a static model instance
+             {3} I3                     so link {3} will be welded to World
+
+Each link is in the model instance whose index is the same as the link
+number. The joints are in I4 and I5 as shown. We'll fiddle with the forest
+building options and check the behavior.
+*/
+GTEST_TEST(SpanningForest, CheckMergingPolicy) {
+  LinkJointGraph graph;
+  const SpanningForest& forest = graph.forest();
+  graph.RegisterJointType("revolute", 1, 1);
+  for (int i = 1; i <= 3; ++i)
+    graph.AddLink("link" + std::to_string(i), ModelInstanceIndex(i));
+  graph.AddJoint("revolute_0", ModelInstanceIndex(4), "revolute", BodyIndex(0),
+                 BodyIndex(1));
+  graph.AddJoint("weld_1", ModelInstanceIndex(5), "weld", BodyIndex(1),
+                 BodyIndex(2));
+
+  graph.SetForestBuildingOptions(ModelInstanceIndex(3),
+                                 ForestBuildingOptions::kStatic);
+
+  // Baseline -- no merging. Every link gets a Mobod.
+  EXPECT_TRUE(graph.BuildForest());
+  EXPECT_EQ(ssize(forest.mobods()), 4);
+
+  // Only I5 should determine whether we merge {1} and {2}. Set the merge
+  // flag on everything else and verify it makes no difference.
+  graph.SetForestBuildingOptions(ModelInstanceIndex(1),
+                                 ForestBuildingOptions::kMergeLinkComposites);
+  graph.SetForestBuildingOptions(ModelInstanceIndex(2),
+                                 ForestBuildingOptions::kMergeLinkComposites);
+  graph.SetForestBuildingOptions(ModelInstanceIndex(4),
+                                 ForestBuildingOptions::kMergeLinkComposites);
+  EXPECT_TRUE(graph.BuildForest());
+  EXPECT_EQ(ssize(forest.mobods()), 4);
+
+  // If I5 says merge, we should have one fewer Mobod.
+  graph.SetForestBuildingOptions(ModelInstanceIndex(5),
+                                 ForestBuildingOptions::kMergeLinkComposites);
+  EXPECT_TRUE(graph.BuildForest());
+  EXPECT_EQ(ssize(forest.mobods()), 3);
+
+  // We're still getting a Mobod for the static link {3}. Let's merge that
+  // with World now.
+  graph.SetForestBuildingOptions(ModelInstanceIndex(3),
+                                 ForestBuildingOptions::kMergeLinkComposites |
+                                     ForestBuildingOptions::kStatic);
+  EXPECT_TRUE(graph.BuildForest());
+  EXPECT_EQ(ssize(forest.mobods()), 2);
+
+  // Finally, let's insist that the weld joint gets modeled. That should
+  // override the setting in its model instance and give us a separate
+  // Mobod for links 1 and 2.
+  graph.ChangeJointFlags(JointIndex(1), JointFlags::kMustBeModeled);
+  EXPECT_TRUE(graph.BuildForest());
+  EXPECT_EQ(ssize(forest.mobods()), 3);
 }
 
 }  // namespace


### PR DESCRIPTION
This is the 8th installment in the PR train for #20225, following #21731.

This is the last missing piece of basic topology functionality: the ability to merge welded-together links in the graph so that they follow only a single mobilized body in the forest.

What's here:
- Merge welded-together links ("link composites") onto a single mobilized body
- Proper handling of massless composites (logically like massless links)
- Lots of unit tests to verify behavior of merged composites
- A unit test of copy, move, and assign that got lost earlier

What's not here:
- Some standalone graph-walking algorithms needed by MbP
- RemoveLink()
- Modifications to MbP to use this stuff

There are no user-visible changes in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21755)
<!-- Reviewable:end -->
