### PR TITLE
[multibody topology] Use std::swap() instead of bespoke Swap()

### DIFF
--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -293,7 +293,7 @@ void SpanningForest::FixupForestToUseNewNumbering(
     while (current_mobod.index() != new_index) {
       /* Move current_mobod to its final location; replace with whatever was
       there before. */
-      current_mobod.Swap(data_.mobods[current_mobod.index()]);
+      std::swap(current_mobod, data_.mobods[current_mobod.index()]);
     }
   }
 

--- a/multibody/topology/spanning_forest_mobod.cc
+++ b/multibody/topology/spanning_forest_mobod.cc
@@ -45,28 +45,6 @@ void SpanningForest::Mobod::FixupAfterReordering(
   RenumberMobodIndexVector(old_to_new, &outboard_mobods_);
 }
 
-void SpanningForest::Mobod::Swap(Mobod& other) {
-  std::swap(follower_link_ordinals_, other.follower_link_ordinals_);
-  std::swap(joint_ordinal_, other.joint_ordinal_);
-  std::swap(use_reverse_mobilizer_, other.use_reverse_mobilizer_);
-  std::swap(level_, other.level_);
-  std::swap(index_, other.index_);
-  std::swap(inboard_mobod_, other.inboard_mobod_);
-  std::swap(outboard_mobods_, other.outboard_mobods_);
-  std::swap(tree_index_, other.tree_index_);
-  std::swap(welded_mobods_index_, other.welded_mobods_index_);
-  std::swap(q_start_, other.q_start_);
-  std::swap(nq_, other.nq_);
-  std::swap(v_start_, other.v_start_);
-  std::swap(nv_, other.nv_);
-  std::swap(has_quaternion_, other.has_quaternion_);
-  std::swap(nq_inboard_, other.nq_inboard_);
-  std::swap(nv_inboard_, other.nv_inboard_);
-  std::swap(nq_outboard_, other.nq_outboard_);
-  std::swap(nv_outboard_, other.nv_outboard_);
-  std::swap(num_subtree_mobods_, other.num_subtree_mobods_);
-}
-
 void SpanningForest::Mobod::RenumberMobodIndexVector(
     const std::vector<MobodIndex>& old_to_new,
     std::vector<MobodIndex>* to_be_renumbered) {

--- a/multibody/topology/spanning_forest_mobod.h
+++ b/multibody/topology/spanning_forest_mobod.h
@@ -183,17 +183,12 @@ class SpanningForest::Mobod {
   // Update all MobodIndex entries to use the new numbering.
   void FixupAfterReordering(const std::vector<MobodIndex>& old_to_new);
 
-  // Switch the contents of `this` and `other` mobilized bodies.
-  void Swap(Mobod& other);
-
   // Given a mapping from old MobodIndex to new MobodIndex, repair an
   // existing vector of old MobodIndexes to use the new numbering. Any invalid
   // indexes are left untouched.
   static void RenumberMobodIndexVector(
       const std::vector<MobodIndex>& old_to_new,
       std::vector<MobodIndex>* to_be_renumbered);
-
-  // CAREFUL: if you add any members here, update Swap!
 
   // Links represented by this Mobod. The first one is always present and is
   // the active Link if we're mobilizing a LinkComposite.


### PR DESCRIPTION
This removes the bespoke `Mobod::Swap()` since the standard library `std::swap()` works just as well.

Thanks to @SeanCurtis-TRI for pointing out that since Mobods have move semantics, no silly shenanigans are required for swapping.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21762)
<!-- Reviewable:end -->
