### PR TITLE
[multibody] Add dmd support for canonical frames for default poses

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -590,6 +590,9 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "detail_dmd_parser_test",
+    data = [
+        ":process_model_directives_test_models",
+    ],
     deps = [
         ":detail_dmd_parser",
         ":detail_sdf_parser",

--- a/multibody/parsing/model_directives.h
+++ b/multibody/parsing/model_directives.h
@@ -110,7 +110,9 @@ struct AddModel {
   std::map<std::string, Eigen::VectorXd> default_joint_positions;
   /// Map of body_name or frame_name => default free body pose. The name must
   /// be a name within the scope of the model added by this directive. The name
-  /// must not be scoped (i.e., no "foo::link", just "link").
+  /// must not be scoped (i.e., no "foo::link", just "link"). If the name is
+  /// empty, then the posed frame will be the body frame of the model's sole
+  /// body (and if the model has >1 body then it is an error).
   ///
   /// However, the schema::Transform associated with that named body/frame can
   /// define a `base_frame` referring to any frame that has been added prior to

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/yaml/yaml_io.h"
@@ -421,12 +422,23 @@ GTEST_TEST(ProcessModelDirectivesTest, DefaultPositions) {
                          make_parser(&plant).get());
   plant.Finalize();
 
+  const ModelInstanceIndex simple =
+      plant.GetModelInstanceByName("simple_model");
+  const ModelInstanceIndex simple_again =
+      plant.GetModelInstanceByName("simple_model_again");
+
   auto context = plant.CreateDefaultContext();
   const math::RigidTransformd X_WB(
       math::RollPitchYawd(5 * M_PI / 180, 6 * M_PI / 180, 7 * M_PI / 180),
       Eigen::Vector3d(1, 2, 3));
-  EXPECT_TRUE(plant.GetFreeBodyPose(*context, plant.GetBodyByName("base"))
-                  .IsNearlyEqualTo(X_WB, 1e-14));
+  EXPECT_TRUE(CompareMatrices(
+      plant.GetFreeBodyPose(*context, plant.GetBodyByName("base", simple))
+          .GetAsMatrix34(),
+      X_WB.GetAsMatrix34(), 1e-14));
+  EXPECT_TRUE(CompareMatrices(
+      plant.GetFreeBodyPose(*context, plant.GetBodyByName("base", simple_again))
+          .GetAsMatrix34(),
+      X_WB.GetAsMatrix34(), 1e-14));
   EXPECT_EQ(
       plant.GetJointByName<RevoluteJoint>("ShoulderJoint").get_angle(*context),
       0.1);

--- a/multibody/parsing/test/process_model_directives_test/default_positions.dmd.yaml
+++ b/multibody/parsing/test/process_model_directives_test/default_positions.dmd.yaml
@@ -7,9 +7,15 @@ directives:
     name: simple_model
     file: package://process_model_directives_test/simple_model.sdf
     default_free_body_pose:
-      base:
+      base: &simple_model_transform
         translation: [1, 2, 3]
         rotation: !Rpy { deg: [5, 6, 7] }
+
+- add_model:
+    name: simple_model_again
+    file: package://process_model_directives_test/simple_model.sdf
+    default_free_body_pose:
+      "": *simple_model_transform
 
 - add_model:
     name: joint_parsing_test


### PR DESCRIPTION
The use case here is to allow users to more easily add manipulands to a scene.

Under the status quo, to pose a manipuland the user must type in the URL for the model and then also some _valid_ frame name within that model.  That means looking inside the model file to figure out a good name, which _couples_ a detail inside the model file with the scenario that's using it.  If the user cares about the frame details then they are still welcome to do that, but in many cases the user is happy to just pose the body frame.

With this change, they can specify the empty string for the manipuland frame to be posed, which is then taken to refer to the body frame of the sole body.  For scenarios with dozens of models whose initial poses are just randomly sampled within some domain, this is much nicer semantics that simplifies scenario creation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21765)
<!-- Reviewable:end -->
