### PR TITLE
[tools] Enable -Werror=missing-declarations

### DIFF
--- a/bindings/pydrake/autodiffutils/autodiffutils_py_everything.cc
+++ b/bindings/pydrake/autodiffutils/autodiffutils_py_everything.cc
@@ -2,6 +2,7 @@
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
+#include "drake/bindings/pydrake/autodiffutils/autodiffutils_py.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/math_operators_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -4,6 +4,7 @@
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
+#include "drake/bindings/pydrake/common/submodules_py.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/common/schema_py.cc
+++ b/bindings/pydrake/common/schema_py.cc
@@ -5,6 +5,7 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
+#include "drake/bindings/pydrake/common/submodules_py.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"

--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -3,6 +3,7 @@
 #include "pybind11/eval.h"
 
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
+#include "drake/bindings/pydrake/common/submodules_py.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -9,6 +9,7 @@
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/geometry/geometry_py.h"
 #include "drake/geometry/collision_filter_declaration.h"
 #include "drake/geometry/collision_filter_manager.h"
 #include "drake/geometry/geometry_frame.h"

--- a/bindings/pydrake/geometry/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry/geometry_py_hydro.cc
@@ -5,6 +5,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/geometry/geometry_py.h"
 #include "drake/geometry/proximity/make_convex_hull_mesh.h"
 #include "drake/geometry/proximity/polygon_surface_mesh_field.h"
 #include "drake/geometry/proximity/triangle_surface_mesh_field.h"

--- a/bindings/pydrake/geometry/geometry_py_meshes.cc
+++ b/bindings/pydrake/geometry/geometry_py_meshes.cc
@@ -4,6 +4,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/geometry/geometry_py.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -7,6 +7,7 @@
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/geometry/geometry_py.h"
 #include "drake/geometry/render/light_parameter.h"
 #include "drake/geometry/render/render_engine.h"
 #include "drake/geometry/render/render_label.h"

--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/geometry/geometry_py.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/scene_graph_config.h"

--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -7,6 +7,7 @@
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/type_safe_index_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/geometry/geometry_py.h"
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/meshcat_animation.h"

--- a/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
@@ -1,5 +1,6 @@
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/manipulation/manipulation_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/manipulation/kuka_iiwa/build_iiwa_control.h"
 #include "drake/manipulation/kuka_iiwa/iiwa_command_receiver.h"

--- a/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
@@ -1,5 +1,6 @@
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/manipulation/manipulation_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/manipulation/schunk_wsg/build_schunk_wsg_control.h"
 #include "drake/manipulation/schunk_wsg/schunk_wsg_constants.h"

--- a/bindings/pydrake/manipulation/manipulation_py_util.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_util.cc
@@ -1,5 +1,6 @@
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/manipulation/manipulation_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/manipulation/util/zero_force_driver.h"
 #include "drake/manipulation/util/zero_force_driver_functions.h"

--- a/bindings/pydrake/math/math_py_matmul.cc
+++ b/bindings/pydrake/math/math_py_matmul.cc
@@ -1,5 +1,6 @@
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
+#include "drake/bindings/pydrake/math/math_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 

--- a/bindings/pydrake/math/math_py_operators.cc
+++ b/bindings/pydrake/math/math_py_operators.cc
@@ -1,4 +1,5 @@
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
+#include "drake/bindings/pydrake/math/math_py.h"
 #include "drake/bindings/pydrake/math_operators_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"

--- a/bindings/pydrake/multibody/benchmarks_py.cc
+++ b/bindings/pydrake/multibody/benchmarks_py.cc
@@ -14,6 +14,8 @@ using systems::LeafSystem;
 // TODO(eric.cousineau): Bind additional scalar types.
 using T = double;
 
+namespace {
+
 void init_acrobot(py::module m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::multibody::benchmarks::acrobot;
@@ -38,6 +40,8 @@ void init_all(py::module m) {
   py::exec("from pydrake.multibody.benchmarks.acrobot import *", py::globals(),
       vars);
 }
+
+}  // namespace
 
 PYBIND11_MODULE(benchmarks, m) {
   init_acrobot(m.def_submodule("acrobot"));

--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -1,4 +1,5 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/multibody/inverse_kinematics_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/inverse_kinematics/differential_inverse_kinematics.h"
 #include "drake/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h"

--- a/bindings/pydrake/multibody/tree_py_inertia.cc
+++ b/bindings/pydrake/multibody/tree_py_inertia.cc
@@ -4,6 +4,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/multibody/tree_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/tree/geometry_spatial_inertia.h"
 #include "drake/multibody/tree/rotational_inertia.h"

--- a/bindings/pydrake/planning/planning_py_graph_algorithms.cc
+++ b/bindings/pydrake/planning/planning_py_graph_algorithms.cc
@@ -1,4 +1,5 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/planning/graph_algorithms/max_clique_solver_base.h"
 #include "drake/planning/graph_algorithms/max_clique_solver_via_greedy.h"

--- a/bindings/pydrake/planning/planning_py_iris_from_clique_cover.cc
+++ b/bindings/pydrake/planning/planning_py_iris_from_clique_cover.cc
@@ -1,4 +1,5 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/planning/graph_algorithms/max_clique_solver_base.h"
 #include "drake/planning/iris/iris_from_clique_cover.h"

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -1,5 +1,6 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/geometry/optimization_pybind.h"
+#include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 #include "drake/geometry/optimization/convex_set.h"

--- a/bindings/pydrake/planning/planning_py_visibility_graph.cc
+++ b/bindings/pydrake/planning/planning_py_visibility_graph.cc
@@ -1,4 +1,5 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/planning/visibility_graph.h"
 

--- a/bindings/pydrake/planning/planning_py_zmp_planner.cc
+++ b/bindings/pydrake/planning/planning_py_zmp_planner.cc
@@ -1,4 +1,5 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/planning/locomotion/zmp_planner.h"
 

--- a/bindings/pydrake/solvers/solvers_py_augmented_lagrangian.cc
+++ b/bindings/pydrake/solvers/solvers_py_augmented_lagrangian.cc
@@ -1,6 +1,7 @@
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/solvers/solvers_py.h"
 #include "drake/solvers/augmented_lagrangian.h"
 
 namespace drake {

--- a/bindings/pydrake/solvers/solvers_py_branch_and_bound.cc
+++ b/bindings/pydrake/solvers/solvers_py_branch_and_bound.cc
@@ -1,6 +1,7 @@
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/solvers/solvers_py.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 #include "drake/solvers/branch_and_bound.h"
 

--- a/bindings/pydrake/solvers/solvers_py_evaluators.cc
+++ b/bindings/pydrake/solvers/solvers_py_evaluators.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/solvers/solvers_py.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 #include "drake/solvers/binding.h"
 #include "drake/solvers/constraint.h"
@@ -138,8 +139,6 @@ void DefTesting(py::module m) {
       .def("AcceptBindingCost", [](const Binding<Cost>&) {})
       .def("AcceptBindingConstraint", [](const Binding<Constraint>&) {});
 }
-
-}  // namespace
 
 void BindEvaluatorsAndBindings(py::module m) {
   constexpr auto& doc = pydrake_doc.drake.solvers;
@@ -769,6 +768,8 @@ void BindEvaluatorsAndBindings(py::module m) {
 
   RegisterBinding<VisualizationCallback>(&m);
 }  // NOLINT(readability/fn_size)
+
+}  // namespace
 
 namespace internal {
 void DefineSolversEvaluators(py::module m) {

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/solvers/solvers_py.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 #include "drake/solvers/choose_best_solver.h"
 #include "drake/solvers/common_solver_option.h"
@@ -266,7 +267,6 @@ class PySolverInterface : public py::wrapper<solvers::SolverInterface> {
         ExplainUnsatisfiedProgramAttributes, prog);
   }
 };
-}  // namespace
 
 void BindSolverInterfaceAndFlags(py::module m) {
   constexpr auto& doc = pydrake_doc.drake.solvers;
@@ -1665,6 +1665,8 @@ void BindFreeFunctions(py::module m) {
           py::arg("solver_options") = py::none(), doc.Solve.doc_3args)
       .def("GetProgramType", &solvers::GetProgramType, doc.GetProgramType.doc);
 }
+
+}  // namespace
 
 namespace internal {
 void DefineSolversMathematicalProgram(py::module m) {

--- a/bindings/pydrake/symbolic/symbolic_py_monolith.cc
+++ b/bindings/pydrake/symbolic/symbolic_py_monolith.cc
@@ -7,6 +7,7 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/math_operators_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/symbolic/symbolic_py.h"
 #include "drake/bindings/pydrake/symbolic/symbolic_py_unapply.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 #include "drake/common/symbolic/decompose.h"

--- a/common/drake_assert_and_throw.cc
+++ b/common/drake_assert_and_throw.cc
@@ -79,9 +79,13 @@ void AssertionFailed(const char* condition, const char* func, const char* file,
 // Assertion configuration has process-wide scope.  Changes here will affect
 // all assertions within the current process.
 //
-// This method is intended ONLY for use by pydrake bindings, and thus is not
-// declared in any header file, to discourage anyone from using it.
-extern "C" void drake_set_assertion_failure_to_throw_exception() {
+// This method is intended ONLY for use by pydrake bindings, and thus is
+// declared here in the cc file (not in any header file), to discourage
+// anyone from using it.
+extern "C" void drake_set_assertion_failure_to_throw_exception();
+
+// Define the function (separate from declaration) to avoid compiler warnings.
+void drake_set_assertion_failure_to_throw_exception() {
   drake::internal::AssertionConfig::singleton()
       .assertion_failures_are_exceptions = true;
 }

--- a/common/proto/call_python.cc
+++ b/common/proto/call_python.cc
@@ -26,6 +26,7 @@ PythonRemoteVariable::PythonRemoteVariable()
 
 namespace internal {
 
+namespace {
 // Copies `size` bytes at `data` into `message->data`.
 void CopyBytes(const void* bytes, const int size,
                lcmt_call_python_data* message) {
@@ -33,6 +34,7 @@ void CopyBytes(const void* bytes, const int size,
   message->data.resize(size);
   std::memcpy(message->data.data(), bytes, size);
 }
+}  // namespace
 
 void ToPythonRemoteData(const PythonRemoteVariable& variable,
                         lcmt_call_python_data* message) {

--- a/common/symbolic/codegen.cc
+++ b/common/symbolic/codegen.cc
@@ -229,6 +229,7 @@ void CodeGenDenseMeta(const string& function_name, const int parameter_size,
         << parameter_size << "}, {" << rows << ", " << cols << "}}; }\n";
 }
 
+namespace {
 void CodeGenSparseData(const string& function_name,
                        const vector<Variable>& parameters,
                        const int outer_index_size, const int non_zeros,
@@ -284,6 +285,7 @@ void CodeGenSparseMeta(const string& function_name, const int parameter_size,
       outer_indices, inner_indices);
 }
 
+}  // namespace
 }  // namespace internal
 
 std::string CodeGen(

--- a/common/symbolic/expression/expression_cell.cc
+++ b/common/symbolic/expression/expression_cell.cc
@@ -839,6 +839,7 @@ Expression ExpressionMul::Substitute(const Substitution& s) const {
                     });
 }
 
+namespace {
 // Computes ∂/∂x pow(f, g).
 Expression DifferentiatePow(const Expression& f, const Expression& g,
                             const Variable& x) {
@@ -862,6 +863,7 @@ Expression DifferentiatePow(const Expression& f, const Expression& g,
   return pow(f, g - 1) *
          (g * f.Differentiate(x) + log(f) * f * g.Differentiate(x));
 }
+}  // namespace
 
 Expression ExpressionMul::Differentiate(const Variable& x) const {
   // ∂/∂x (c   * f₁^g₁  * f₂^g₂        * ... * fₙ^gₙ

--- a/common/symbolic/expression/formula_cell.h
+++ b/common/symbolic/expression/formula_cell.h
@@ -455,6 +455,8 @@ bool is_relational(const FormulaCell& f);
 bool is_conjunction(const FormulaCell& f);
 /** Checks if @p f is a disjunction (∨). */
 bool is_disjunction(const FormulaCell& f);
+/** Checks if @p f is N-ary. */
+bool is_nary(const FormulaCell& f);
 /** Checks if @p f is a negation (¬). */
 bool is_negation(const FormulaCell& f);
 /** Checks if @p f is a Forall formula (∀). */

--- a/common/symbolic/replace_bilinear_terms.cc
+++ b/common/symbolic/replace_bilinear_terms.cc
@@ -15,6 +15,7 @@ using std::unordered_map;
 
 using MapVarToIndex = unordered_map<Variable::Id, int>;
 
+namespace {
 /*
  * Returns the map that maps x(i).get_id() to i.
  */
@@ -32,6 +33,7 @@ MapVarToIndex ConstructVarToIndexMap(
   }
   return map;
 }
+}  // namespace
 
 Expression ReplaceBilinearTerms(
     const Expression& e, const Eigen::Ref<const VectorX<symbolic::Variable>>& x,

--- a/common/symbolic/trigonometric_polynomial.cc
+++ b/common/symbolic/trigonometric_polynomial.cc
@@ -504,34 +504,5 @@ symbolic::RationalFunction SubstituteStereographicProjection(
       one_minus_t_square);
 }
 
-symbolic::RationalFunction SubstituteStereographicProjection(
-    const symbolic::Expression& e,
-    const std::unordered_map<symbolic::Variable, symbolic::Variable>& subs) {
-  // First substitute all cosθ and sinθ with cos_var and sin_var.
-  SinCosSubstitution sin_cos_subs;
-  symbolic::Variables sin_cos_vars;
-  std::vector<SinCos> sin_cos_vec;
-  sin_cos_vec.reserve(subs.size());
-  VectorX<symbolic::Variable> t_vars(subs.size());
-  int var_count = 0;
-  for (const auto& [theta, t] : subs) {
-    const SinCos sin_cos(Variable("s_" + theta.get_name()),
-                         Variable("c_" + theta.get_name()),
-                         SinCosSubstitutionType::kAngle);
-    sin_cos_subs.emplace(theta, sin_cos);
-    sin_cos_vars.insert(sin_cos.c);
-    sin_cos_vars.insert(sin_cos.s);
-    sin_cos_vec.push_back(sin_cos);
-    t_vars(var_count) = t;
-    var_count++;
-  }
-  const symbolic::Expression e_multilinear = Substitute(e, sin_cos_subs);
-
-  // Now rewrite e_multilinear as a polynomial of sin and cos.
-  const symbolic::Polynomial e_poly{e_multilinear, sin_cos_vars};
-
-  return SubstituteStereographicProjection(e_poly, sin_cos_vec, t_vars);
-}
-
 }  // namespace symbolic
 }  // namespace drake

--- a/common/test/lib_is_real.cc
+++ b/common/test/lib_is_real.cc
@@ -1,3 +1,7 @@
 // This is a dummy source file and function to create `lib_is_real.so` for
 // `find_loaded_library_test`.
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
 void lib_is_real_dummy_function() {}
+#pragma GCC diagnostic pop

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -24,6 +24,7 @@
 namespace drake {
 namespace examples {
 namespace allegro_hand {
+namespace {
 
 using drake::multibody::MultibodyPlant;
 
@@ -123,6 +124,7 @@ void DoMain() {
   simulator.AdvanceTo(FLAGS_simulation_time);
 }
 
+}  // namespace
 }  // namespace allegro_hand
 }  // namespace examples
 }  // namespace drake

--- a/examples/cubic_polynomial/region_of_attraction.cc
+++ b/examples/cubic_polynomial/region_of_attraction.cc
@@ -19,6 +19,7 @@
 #include "drake/systems/framework/vector_system.h"
 
 namespace drake {
+namespace {
 
 using std::cout;
 using std::endl;
@@ -92,6 +93,7 @@ void ComputeRegionOfAttraction() {
   // Check that ρ ≃ 1.0.
   DRAKE_DEMAND(std::abs(result.GetSolution(rho) - 1.0) < 1e-6);
 }
+}  // namespace
 }  // namespace drake
 
 int main(int argc, char* argv[]) {

--- a/examples/multibody/cylinder_with_multicontact/populate_cylinder_plant.cc
+++ b/examples/multibody/cylinder_with_multicontact/populate_cylinder_plant.cc
@@ -18,6 +18,7 @@ using geometry::HalfSpace;
 using geometry::Sphere;
 using math::RigidTransformd;
 
+namespace {
 void AddCylinderWithMultiContact(
     MultibodyPlant<double>* plant, const RigidBody<double>& body,
     double radius, double length, const CoulombFriction<double>& friction,
@@ -54,6 +55,7 @@ void AddCylinderWithMultiContact(
                                   "visual_bottom_" + std::to_string(i), red);
   }
 }
+}  // namespace
 
 void PopulateCylinderPlant(double radius, double length, double mass,
                            const CoulombFriction<double>& surface_friction,

--- a/examples/planar_gripper/planar_gripper_common.cc
+++ b/examples/planar_gripper/planar_gripper_common.cc
@@ -75,13 +75,14 @@ void WeldGripperFrames(MultibodyPlant<T>* plant) {
 // Explicit instantiations.
 template void WeldGripperFrames(MultibodyPlant<double>* plant);
 
-/// Build a keyframe matrix for joints in joint_ordering by extracting the
-/// appropriate columns from all_keyframes. The interpretation of columns in
-/// joint_keyframes are ordered as in joint_ordering.
-/// @pre There are as many strings in headers as there are columns in
-/// all_keyframes.
-/// @pre Every string in joint_ordering is expected to be unique.
-/// @pre Every string in joint_ordering is expected to be found in headers.
+namespace {
+// Build a keyframe matrix for joints in joint_ordering by extracting the
+// appropriate columns from all_keyframes. The interpretation of columns in
+// joint_keyframes are ordered as in joint_ordering.
+// @pre There are as many strings in headers as there are columns in
+// all_keyframes.
+// @pre Every string in joint_ordering is expected to be unique.
+// @pre Every string in joint_ordering is expected to be found in headers.
 MatrixX<double> MakeKeyframes(MatrixX<double> all_keyframes,
                               std::vector<std::string> joint_ordering,
                               std::vector<std::string> headers) {
@@ -105,6 +106,7 @@ MatrixX<double> MakeKeyframes(MatrixX<double> all_keyframes,
   }
   return joint_keyframes;
 }
+}  // namespace
 
 std::pair<MatrixX<double>, std::map<std::string, int>> ParseKeyframes(
     const std::string& name, EigenPtr<Vector3<double>> brick_initial_pose) {

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -38,6 +38,7 @@ namespace drake {
 namespace examples {
 namespace scene_graph {
 namespace contact_surface {
+namespace {
 
 using Eigen::Vector3d;
 using Eigen::Vector4d;
@@ -445,6 +446,7 @@ int do_main() {
   return 0;
 }
 
+}  // namespace
 }  // namespace contact_surface
 }  // namespace scene_graph
 }  // namespace examples

--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -12,6 +12,7 @@
 namespace drake {
 namespace geometry {
 namespace internal {
+namespace {
 
 // Turn clang-formatting off so it doesn't interfere with the long lines.
 // clang-format off
@@ -272,6 +273,7 @@ void ReportContactSurfaces() {
   }
 }
 
+}  // namespace
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -693,7 +693,7 @@ class GraphOfConvexSets {
 
   DRAKE_DEPRECATED(
       "2024-10-01",
-      "result should be of type const solvers::MathematicalProgramResult*.");
+      "result should be of type const solvers::MathematicalProgramResult*.")
   std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result,
       const geometry::optimization::GcsGraphvizOptions& options =

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -45,6 +45,7 @@ namespace drake {
 namespace examples {
 namespace scene_graph {
 namespace contact_surface {
+namespace {
 
 using Eigen::Vector3d;
 using Eigen::Vector4d;
@@ -430,6 +431,7 @@ int do_main() {
   return 0;
 }
 
+}  // namespace
 }  // namespace contact_surface
 }  // namespace scene_graph
 }  // namespace examples

--- a/geometry/proximity/make_box_mesh.cc
+++ b/geometry/proximity/make_box_mesh.cc
@@ -14,6 +14,7 @@ namespace internal {
 using Eigen::Vector3d;
 using std::unordered_set;
 
+namespace {
 /* Subdivides a virtual cube to have up to six tetrahedra such that they
  share the diagonal v0v6 (see ordering below). We allow repeated vertices in
  the virtual cube and will skip tetrahedra with repeated vertices.
@@ -61,6 +62,7 @@ std::vector<VolumeElement> SplitToTetrahedra(int v0, int v1, int v2, int v3,
   }
   return elements;
 }
+}  // namespace
 
 template <typename T>
 VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box) {

--- a/multibody/contact_solvers/conex_supernodal_solver.cc
+++ b/multibody/contact_solvers/conex_supernodal_solver.cc
@@ -179,6 +179,8 @@ void ConexSuperNodalSolver::CliqueAssembler::SetDenseData() {
   }
 }
 
+namespace {
+
 std::pair<int, int> FindPositionInClique(int element,
                                          const vector<vector<int>>& clique) {
   int i = 0;
@@ -207,11 +209,6 @@ void SortTheCliques(std::vector<std::vector<int>>* path) {
     std::sort((*path)[i].begin(), (*path)[i].end());
   }
 }
-
-// The destructor is defined in the source so we can use an incomplete
-// definition when storing unique pointers of CliqueAssembler within a
-// std::vector.
-ConexSuperNodalSolver::~ConexSuperNodalSolver() {}
 
 // Helper struct for assembling the input to the conex supernodal solver. The
 // variable "cliques" contains the nodes of a "supernodal elimination tree,"
@@ -339,6 +336,13 @@ SparsityData GetEliminationOrdering(
   data.separators = separators_full;
   return clique_data;
 }
+
+}  // namespace
+
+// The destructor is defined in the source so we can use an incomplete
+// definition when storing unique pointers of CliqueAssembler within a
+// std::vector.
+ConexSuperNodalSolver::~ConexSuperNodalSolver() {}
 
 void ConexSuperNodalSolver::Initialize(
     const vector<vector<int>>& cliques, int num_jacobian_row_blocks,

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.cc
@@ -63,6 +63,8 @@ AngleBetweenVectorsConstraint::AngleBetweenVectorsConstraint(
   }
 }
 
+namespace {
+
 void EvalConstraintGradient(
     const systems::Context<double>& context,
     const MultibodyPlant<double>& plant, const Frame<double>& frameA,
@@ -125,6 +127,8 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
                            R_AB, x, y);
   }
 }
+
+}  // namespace
 
 void AngleBetweenVectorsConstraint::DoEval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {

--- a/multibody/inverse_kinematics/com_in_polyhedron_constraint.cc
+++ b/multibody/inverse_kinematics/com_in_polyhedron_constraint.cc
@@ -64,6 +64,8 @@ ComInPolyhedronConstraint::ComInPolyhedronConstraint(
   }
 }
 
+namespace {
+
 void EvalConstraintGradient(
     const systems::Context<double>& context,
     const MultibodyPlant<double>& plant,
@@ -120,6 +122,8 @@ void DoEvalGeneric(
                            y);
   }
 }
+
+}  // namespace
 
 void ComInPolyhedronConstraint::DoEval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {

--- a/multibody/inverse_kinematics/com_position_constraint.cc
+++ b/multibody/inverse_kinematics/com_position_constraint.cc
@@ -57,6 +57,8 @@ ComPositionConstraint::ComPositionConstraint(
   // on the generalized positions in model_instances.
 }
 
+namespace {
+
 // We can explicitly evaluate the gradient of the constraint with
 // MultibodyPlant<double>, using the Jacobian function in MBP<double>.
 void EvalConstraintGradient(
@@ -110,6 +112,8 @@ void DoEvalGeneric(
                            plant.get_frame(expressed_frame_index), p_EC, x, y);
   }
 }
+
+}  // namespace
 
 void ComPositionConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                    Eigen::VectorXd* y) const {

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.cc
@@ -14,8 +14,8 @@ namespace multibody {
 
 using Eigen::SparseMatrix;
 
-namespace internal {
-DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
+namespace {
+DifferentialInverseKinematicsResult DoDifferentialInverseKinematicsImpl(
     const Eigen::Ref<const VectorX<double>>& q_current,
     const Eigen::Ref<const VectorX<double>>& v_current,
     const math::RigidTransform<double>& X_WE,
@@ -51,7 +51,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
       J_WE_E_with_flags.topRows(num_cart_constraints), parameters, N, Nplus);
 }
 
-}  // namespace internal
+}  // namespace
 
 std::ostream& operator<<(std::ostream& os,
                          const DifferentialInverseKinematicsStatus value) {
@@ -289,7 +289,7 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
     }
     Nplus = plant.MakeQDotToVelocityMap(context);
   }
-  return internal::DoDifferentialInverseKinematics(
+  return DoDifferentialInverseKinematicsImpl(
       plant.GetPositions(context), plant.GetVelocities(context), X_AE, J_AE,
       SpatialVelocity<double>(V_AE_desired), parameters, N, Nplus);
 }

--- a/multibody/inverse_kinematics/distance_constraint_utilities.cc
+++ b/multibody/inverse_kinematics/distance_constraint_utilities.cc
@@ -55,15 +55,6 @@ void CalcDistanceDerivatives(const MultibodyPlant<AutoDiffXd>&,
   *distance = distance_autodiff.value();
 }
 
-void CalcDistanceDerivatives(const MultibodyPlant<double>&,
-                             const systems::Context<double>&,
-                             const Frame<double>&, const Frame<double>&,
-                             const Eigen::Vector3d&, double distance_in,
-                             const Eigen::Vector3d&,
-                             const Eigen::Ref<const VectorX<double>>&,
-                             double* distance_out) {
-  *distance_out = distance_in;
-}
 template <typename T, typename S>
 VectorX<S> Distances(const MultibodyPlant<T>& plant,
                      systems::Context<T>* context,

--- a/multibody/inverse_kinematics/gaze_target_constraint.cc
+++ b/multibody/inverse_kinematics/gaze_target_constraint.cc
@@ -69,6 +69,8 @@ GazeTargetConstraint::GazeTargetConstraint(
   }
 }
 
+namespace {
+
 void EvalConstraintGradient(
     const systems::Context<double>& context,
     const MultibodyPlant<double>& plant, const Frame<double>& frameA,
@@ -127,6 +129,8 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
                            y);
   }
 }
+
+}  // namespace
 
 void GazeTargetConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                   Eigen::VectorXd* y) const {

--- a/multibody/inverse_kinematics/global_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.cc
@@ -582,6 +582,7 @@ GlobalInverseKinematics::BodySphereInOneOfPolytopes(
   return z;
 }
 
+namespace {
 // Approximate a quadratic constraint (which could be formulated as a Lorentz
 // cone constraint) xᵀx ≤ c² by
 // -c ≤ xᵢ ≤ c
@@ -611,6 +612,7 @@ void ApproximateBoundedNormByLinearConstraints(
   prog->AddLinearConstraint(x(0) - x(1) + x(2), -sqrt3_c, sqrt3_c);
   prog->AddLinearConstraint(x(0) - x(1) - x(2), -sqrt3_c, sqrt3_c);
 }
+}  // namespace
 
 void GlobalInverseKinematics::AddJointLimitConstraint(
     BodyIndex body_index, double joint_lower_bound, double joint_upper_bound,

--- a/multibody/inverse_kinematics/point_to_line_distance_constraint.cc
+++ b/multibody/inverse_kinematics/point_to_line_distance_constraint.cc
@@ -72,6 +72,8 @@ PointToLineDistanceConstraint::PointToLineDistanceConstraint(
   DRAKE_DEMAND(n_B2.norm() > 100 * kEps);
 }
 
+namespace {
+
 template <typename T>
 void EvalPointToLineDistanceConstraintGradient(
     const systems::Context<T>&, const MultibodyPlant<T>&, const Frame<T>&,
@@ -122,6 +124,8 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
                                             frame_line, p_B1P, p_QP_B2,
                                             project_matrix, x, y);
 }
+
+}  // namespace
 
 void PointToLineDistanceConstraint::DoEval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {

--- a/multibody/inverse_kinematics/point_to_point_distance_constraint.cc
+++ b/multibody/inverse_kinematics/point_to_point_distance_constraint.cc
@@ -57,6 +57,8 @@ PointToPointDistanceConstraint::PointToPointDistanceConstraint(
   DRAKE_DEMAND(distance_upper >= distance_lower);
 }
 
+namespace {
+
 template <typename T>
 void EvalPointToPointDistanceConstraintGradient(
     const systems::Context<T>&, const MultibodyPlant<T>&, const Frame<T>&,
@@ -97,6 +99,8 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
   EvalPointToPointDistanceConstraintGradient(*context, plant, frame1, frame2,
                                              p_B2P2, p_P1P2_B1, x, y);
 }
+
+}  // namespace
 
 void PointToPointDistanceConstraint::DoEval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd* y) const {

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -78,6 +78,8 @@ PositionConstraint::PositionConstraint(
     : PositionConstraint(plant, frameA, std::nullopt, p_AQ_lower, p_AQ_upper,
                          frameB, p_BQ, plant_context) {}
 
+namespace {
+
 void EvalConstraintGradient(
     const systems::Context<double>& context,
     const MultibodyPlant<double>& plant, const Frame<double>& frameAbar,
@@ -113,6 +115,8 @@ void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
                            X_AAbar * p_AbarQ, p_BQ, x, y);
   }
 }
+
+}  // namespace
 
 void PositionConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                                 Eigen::VectorXd* y) const {

--- a/multibody/optimization/sliding_friction_complementarity_constraint.cc
+++ b/multibody/optimization/sliding_friction_complementarity_constraint.cc
@@ -276,6 +276,10 @@ void SlidingFrictionComplementarityNonlinearConstraint::DoEval(
       "symbolic variables yet.");
 }
 
+}  // namespace internal
+
+namespace {
+
 solvers::Binding<internal::SlidingFrictionComplementarityNonlinearConstraint>
 AddSlidingFrictionComplementarityConstraint(
     const ContactWrenchEvaluator* contact_wrench_evaluator,
@@ -300,7 +304,8 @@ AddSlidingFrictionComplementarityConstraint(
       internal::SlidingFrictionComplementarityNonlinearConstraint>(constraint,
                                                                    bound_vars);
 }
-}  // namespace internal
+
+}  // namespace
 
 std::pair<solvers::Binding<
               internal::SlidingFrictionComplementarityNonlinearConstraint>,
@@ -313,7 +318,7 @@ AddSlidingFrictionComplementarityExplicitContactConstraint(
     const Eigen::Ref<const VectorX<symbolic::Variable>>& lambda_vars,
     solvers::MathematicalProgram* prog) {
   const auto sliding_friction_complementarity_constraint =
-      internal::AddSlidingFrictionComplementarityConstraint(
+      AddSlidingFrictionComplementarityConstraint(
           contact_wrench_evaluator, complementarity_tolerance, q_vars, v_vars,
           lambda_vars, prog);
   solvers::Binding<StaticFrictionConeConstraint>
@@ -338,7 +343,7 @@ AddSlidingFrictionComplementarityImplicitContactConstraint(
     const Eigen::Ref<const VectorX<symbolic::Variable>>& lambda_vars,
     solvers::MathematicalProgram* prog) {
   const auto sliding_friction_complementarity_constraint =
-      internal::AddSlidingFrictionComplementarityConstraint(
+      AddSlidingFrictionComplementarityConstraint(
           contact_wrench_evaluator, complementarity_tolerance, q_vars, v_vars,
           lambda_vars, prog);
   const auto static_friction_complementarity_constraint =

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -170,6 +170,7 @@ std::optional<MultibodyConstraintId> ParseBallConstraint(
   return plant->AddBallConstraint(*body_A, p_AP, *body_B, p_BQ);
 }
 
+namespace {
 // See ParseCollisionFilterGroupCommon at header for documentation
 void CollectCollisionFilterGroup(
     const DiagnosticPolicy& diagnostic,
@@ -237,6 +238,7 @@ void CollectCollisionFilterGroup(
     resolver->AddPair(diagnostic, group_name, target_name, model_instance);
   }
 }
+}  // namespace
 
 void ParseCollisionFilterGroupCommon(
     const DiagnosticPolicy& diagnostic,

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -492,7 +492,7 @@ class GcsTrajectoryOptimization final {
 
   DRAKE_DEPRECATED(
       "2024-10-01",
-      "result should be of type const solvers::MathematicalProgramResult*.");
+      "result should be of type const solvers::MathematicalProgramResult*.")
   std::string GetGraphvizString(
       const std::optional<solvers::MathematicalProgramResult>& result,
       const geometry::optimization::GcsGraphvizOptions& options = {}) const {
@@ -540,7 +540,7 @@ class GcsTrajectoryOptimization final {
 
   DRAKE_DEPRECATED(
       "2024-10-01",
-      "edge_offsets should be of type const std::vector<Eigen::VectorXd>*.");
+      "edge_offsets should be of type const std::vector<Eigen::VectorXd>*.")
   Subgraph& AddRegions(
       const geometry::optimization::ConvexSets& regions,
       const std::vector<std::pair<int, int>>& edges_between_regions, int order,
@@ -625,7 +625,7 @@ class GcsTrajectoryOptimization final {
   DRAKE_DEPRECATED("2024-10-01",
                    "edges_between_regions should be of type const "
                    "std::vector<std::pair<int, int>>*, and edge_offsets should "
-                   "be of type const std::vector<Eigen::VectorXd>*.");
+                   "be of type const std::vector<Eigen::VectorXd>*.")
   EdgesBetweenSubgraphs& AddEdges(
       const Subgraph& from_subgraph, const Subgraph& to_subgraph,
       const geometry::optimization::ConvexSet* subspace,

--- a/planning/trajectory_optimization/multiple_shooting.cc
+++ b/planning/trajectory_optimization/multiple_shooting.cc
@@ -381,26 +381,6 @@ Formula MultipleShooting::SubstitutePlaceholderVariables(
   return f.Substitute(ConstructPlaceholderVariableSubstitution(interval_index));
 }
 
-solvers::MathematicalProgramResult Solve(const MultipleShooting& trajopt) {
-  const solvers::MathematicalProgram& prog = trajopt.prog();
-  return Solve(prog);
-}
-
-solvers::MathematicalProgramResult Solve(
-    const MultipleShooting& trajopt,
-    const Eigen::Ref<const Eigen::VectorXd>& initial_guess) {
-  const solvers::MathematicalProgram& prog = trajopt.prog();
-  return solvers::Solve(prog, initial_guess);
-}
-
-solvers::MathematicalProgramResult Solve(
-    const MultipleShooting& trajopt,
-    const std::optional<Eigen::VectorXd>& initial_guess,
-    const std::optional<solvers::SolverOptions>& solver_options) {
-  const solvers::MathematicalProgram& prog = trajopt.prog();
-  return Solve(prog, initial_guess, solver_options);
-}
-
 }  // namespace trajectory_optimization
 }  // namespace planning
 }  // namespace drake

--- a/solvers/aggregate_costs_constraints.cc
+++ b/solvers/aggregate_costs_constraints.cc
@@ -255,11 +255,6 @@ void AggregateDuplicateVariables(const Eigen::SparseMatrix<double>& A,
   vars_new->conservativeResize(unique_var_count);
 }
 
-const Binding<QuadraticCost>* FindNonconvexQuadraticCost(
-    const std::vector<Binding<QuadraticCost>>& quadratic_costs) {
-  return internal::FindNonconvexQuadraticCost(quadratic_costs);
-}
-
 namespace internal {
 const Binding<QuadraticCost>* FindNonconvexQuadraticCost(
     const std::vector<Binding<QuadraticCost>>& quadratic_costs) {

--- a/solvers/branch_and_bound.cc
+++ b/solvers/branch_and_bound.cc
@@ -13,9 +13,11 @@
 
 namespace drake {
 namespace solvers {
-/** Determines if the mathematical program has binary variables.
- */
-bool MathProgHasBinaryVariables(const MathematicalProgram& prog) {
+
+namespace {
+/* Determines if the mathematical program has binary variables. */
+[[maybe_unused]] bool MathProgHasBinaryVariables(
+    const MathematicalProgram& prog) {
   for (int i = 0; i < prog.num_vars(); ++i) {
     if (prog.decision_variable(i).get_type() ==
         symbolic::Variable::Type::BINARY) {
@@ -24,6 +26,7 @@ bool MathProgHasBinaryVariables(const MathematicalProgram& prog) {
   }
   return false;
 }
+}  // namespace
 
 MixedIntegerBranchAndBoundNode::MixedIntegerBranchAndBoundNode(
     const MathematicalProgram& prog,
@@ -266,16 +269,6 @@ int MixedIntegerBranchAndBoundNode::NumExploredNodesInSubtree() const {
     ret += right_child_->NumExploredNodesInSubtree();
   }
   return ret;
-}
-
-bool IsVariableInList(const std::list<symbolic::Variable>& variable_list,
-                      const symbolic::Variable& variable) {
-  for (const auto& var : variable_list) {
-    if (var.equal_to(variable)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 void MixedIntegerBranchAndBoundNode::FixBinaryVariable(

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -535,18 +535,18 @@ std::ostream& LinearEqualityConstraint::DoDisplay(
   return DisplayConstraint(*this, os, "LinearEqualityConstraint", vars, true);
 }
 
-namespace internal {
+namespace {
 Eigen::SparseMatrix<double> ConstructSparseIdentity(int rows) {
   Eigen::SparseMatrix<double> mat(rows, rows);
   mat.setIdentity();
   return mat;
 }
-}  // namespace internal
+}  // namespace
 
 BoundingBoxConstraint::BoundingBoxConstraint(
     const Eigen::Ref<const Eigen::VectorXd>& lb,
     const Eigen::Ref<const Eigen::VectorXd>& ub)
-    : LinearConstraint(internal::ConstructSparseIdentity(lb.rows()), lb, ub) {}
+    : LinearConstraint(ConstructSparseIdentity(lb.rows()), lb, ub) {}
 
 template <typename DerivedX, typename ScalarY>
 void BoundingBoxConstraint::DoEvalGeneric(const Eigen::MatrixBase<DerivedX>& x,

--- a/solvers/csdp_solver_error_handling.cc
+++ b/solvers/csdp_solver_error_handling.cc
@@ -17,7 +17,11 @@ extern "C" {
 
 // The library code in CSDP calls the C exit() function. Since no library
 // should do that, our CSDP package.BUILD.bazel rule uses the preprocessor
-// to re-route that call into this function instead.
+// to re-route that call into this function instead. We put the declaration
+// here (instead of a header file) because CSDP doesn't need such a header.
+void drake_csdp_cpp_wrapper_exit(int);
+
+// Define the function (separate from declaration) to avoid compiler warnings.
 void drake_csdp_cpp_wrapper_exit(int) {
   std::jmp_buf& env = drake::solvers::internal::get_per_thread_csdp_jmp_buf();
   std::longjmp(env, 1);

--- a/solvers/mixed_integer_rotation_constraint_internal.cc
+++ b/solvers/mixed_integer_rotation_constraint_internal.cc
@@ -102,7 +102,8 @@ std::vector<Eigen::Vector3d> ComputeBoxEdgesAndSphereIntersection(
   return intersections;
 }
 
-/**
+namespace {
+/*
  * Compute the outward unit length normal of the triangle, with the three
  * vertices being `pt0`, `pt1` and `pt2`.
  * @param pt0 A vertex of the triangle, in the first orthant (+++).
@@ -133,6 +134,7 @@ void ComputeTriangleOutwardNormal(const Eigen::Vector3d& pt0,
   *d = pt0.dot(*n);
   DRAKE_DEMAND((n->array() >= 0).all());
 }
+}  // namespace
 
 bool AreAllVerticesCoPlanar(const std::vector<Eigen::Vector3d>& pts,
                             Eigen::Vector3d* n, double* d) {

--- a/solvers/mosek_solver_internal.cc
+++ b/solvers/mosek_solver_internal.cc
@@ -13,6 +13,7 @@
 namespace drake {
 namespace solvers {
 namespace internal {
+namespace {
 // Given a vector of triplets (which might contain duplicated entries in the
 // matrix), returns the vector of rows, columns and values.
 void ConvertTripletsToVectors(
@@ -37,6 +38,7 @@ void ConvertTripletsToVectors(
     }
   }
 }
+}  // namespace
 
 size_t MatrixVariableEntry::get_next_id() {
   static never_destroyed<std::atomic<int>> next_id(0);

--- a/solvers/rotation_constraint.cc
+++ b/solvers/rotation_constraint.cc
@@ -76,35 +76,6 @@ void AddBoundingBoxConstraintsImpliedByRollPitchYawLimits(
     prog->AddBoundingBoxConstraint(0, 1, R(2, 2));
 }
 
-void AddBoundingBoxConstraintsImpliedByRollPitchYawLimitsToBinary(
-    MathematicalProgram* prog,
-    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& B,
-    RollPitchYawLimits limits) {
-  if ((limits & kPitch_NegPI_2_to_PI_2) && (limits & kYaw_NegPI_2_to_PI_2))
-    prog->AddBoundingBoxConstraint(1, 1, B(0, 0));
-
-  if ((limits & kPitch_NegPI_2_to_PI_2) && (limits & kYaw_0_to_PI))
-    prog->AddBoundingBoxConstraint(1, 1, B(1, 0));
-
-  if (limits & kPitch_0_to_PI) prog->AddBoundingBoxConstraint(0, 0, B(2, 0));
-
-  if ((limits & kRoll_NegPI_2_to_PI_2) && (limits & kYaw_NegPI_2_to_PI_2) &&
-      (limits & kPitch_0_to_PI) && (limits & kRoll_0_to_PI) &&
-      (limits & kYaw_0_to_PI))
-    prog->AddBoundingBoxConstraint(1, 1, B(1, 1));
-
-  if ((limits & kPitch_NegPI_2_to_PI_2) && (limits & kRoll_0_to_PI))
-    prog->AddBoundingBoxConstraint(1, 1, B(2, 1));
-
-  if ((limits & kRoll_0_to_PI) && (limits & kYaw_0_to_PI) &&
-      (limits & kRoll_NegPI_2_to_PI_2) && (limits & kYaw_NegPI_2_to_PI_2) &&
-      (limits & kPitch_0_to_PI))
-    prog->AddBoundingBoxConstraint(1, 1, B(0, 2));
-
-  if ((limits & kPitch_NegPI_2_to_PI_2) && (limits & kRoll_NegPI_2_to_PI_2))
-    prog->AddBoundingBoxConstraint(1, 1, B(2, 2));
-}
-
 void AddRotationMatrixSpectrahedralSdpConstraint(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R) {

--- a/solvers/sdpa_free_format.cc
+++ b/solvers/sdpa_free_format.cc
@@ -79,6 +79,7 @@ void SdpaFreeFormat::DeclareXforPositiveSemidefiniteConstraints(
   }
 }
 
+namespace {
 void AddTermToTriplets(const EntryInX& entry_in_X, double coeff,
                        std::vector<Eigen::Triplet<double>>* triplets) {
   if (entry_in_X.row_index_in_block == entry_in_X.column_index_in_block) {
@@ -94,6 +95,7 @@ void AddTermToTriplets(const EntryInX& entry_in_X, double coeff,
         entry_in_X.X_start_row + entry_in_X.row_index_in_block, coeff / 2);
   }
 }
+}  // namespace
 
 void SdpaFreeFormat::AddLinearEqualityConstraint(
     const std::vector<double>& coeff_prog_vars,

--- a/solvers/test/optimization_examples.cc
+++ b/solvers/test/optimization_examples.cc
@@ -90,6 +90,7 @@ std::set<CostForm> quadratic_cost_form() {
   return std::set<CostForm>{CostForm::kNonSymbolic, CostForm::kSymbolic};
 }
 
+namespace {
 double EvaluateSolutionCost(const MathematicalProgram& prog,
                             const MathematicalProgramResult& result) {
   double cost{0};
@@ -98,6 +99,7 @@ double EvaluateSolutionCost(const MathematicalProgram& prog,
   }
   return cost;
 }
+}  // namespace
 
 /*
  * Expect that the optimal cost stored by the solver in the MathematicalProgram

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -16,6 +16,7 @@ CXX_FLAGS = [
     "-Werror=deprecated",
     "-Werror=deprecated-declarations",
     "-Werror=ignored-qualifiers",
+    "-Werror=missing-declarations",
     "-Werror=old-style-cast",
     "-Werror=overloaded-virtual",
     "-Werror=shadow",
@@ -73,6 +74,7 @@ GCC_FLAGS = CXX_FLAGS + [
 # The GCC_CC_TEST_FLAGS will be enabled for all cc_test rules in the project
 # when building with gcc.
 GCC_CC_TEST_FLAGS = [
+    "-Wno-missing-declarations",
     "-Wno-unused-parameter",
 ]
 


### PR DESCRIPTION
While helping buildcop, I saw some console warnings scrolling by.  On Ubuntu, we aim to not have any console warnings in CI, so when we see them we either need to promote them to errors so that they get noticed (when the warnings are helpful) or suppress them entirely (when the warnings are noise).

For GCC, the general idea of `Wmissing-declarations` is to find linker-global functions (i.e, public code) whose definition did not have a preceding declaration.  This can either mean that:
- (1) The developer forgot to `#include` the header file.
- (2) The code should have been linker-private (anonymous namespace) instead of linker-global (internal namespace).
- (3) Rare corner case: purposefully calling a function without using its header file.

For Clang, the general idea is much narrower; e.g., it finds uses of `DRAKE_DEPRECATED()` that have a semicolon immediately afterward (which means that the macro call is a no-op).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21775)
<!-- Reviewable:end -->
