### PR TITLE
Updates hydroelastic field computation for the ellipsoid and meshes.

### DIFF
--- a/geometry/proximity/make_mesh_field.cc
+++ b/geometry/proximity/make_mesh_field.cc
@@ -71,8 +71,11 @@ VolumeMeshFieldLinear<T, T> MakeVolumeMeshPressureField(
     }
     const Vector3<T>& p_MV = mesh_M->vertex(v);
     const Vector3<double> p_MV_d = ExtractDoubleOrThrow(p_MV);
+    // N.B. For small margin values, we can approximate the distance to the
+    // inflated surface as the distance to the original surface plus the margin.
+    // This correction only applies to interior vertices.
     const T distance =
-        internal::CalcDistanceToSurfaceMesh(p_MV_d, surface_d, bvh);
+        internal::CalcDistanceToSurfaceMesh(p_MV_d, surface_d, bvh) + margin;
     values.push_back(distance);
     max_value = max(distance, max_value);
   }

--- a/geometry/proximity/make_mesh_field.h
+++ b/geometry/proximity/make_mesh_field.h
@@ -10,13 +10,29 @@ namespace internal {
 /* Creates a pressure field on a tetrahedral volume mesh of a (possibly
  non-convex) shape. This function complements MakeConvexPressureField().
 
- Given the distance field ϕ(x) (defined positive inside the object), we define
+ @note Unlike all other functions that compute pressure fields, this one in
+ particular works on generally non-convex geometries. For all the other (convex)
+ cases, `mesh_M` is meant to represent the "inflated" geometry by amount defined
+ by `margin`. For this method however, `mesh_M` must correspond to the
+ non-inflated geometry (the original mesh). This is a requirement since the
+ distance function required in the computation of the pressure field might not
+ be well defined for "inflated" meshes. Inflated meshes might contain cracks
+ that, while negligible in the computation of forces, can affect the topology in
+ ways that change the distance computation significantly.
+
+ @note For interior vertices, this function estimates the distance field ϕ*(x)
+ on the inflated mesh from the distance field ϕ(x) on the non-inflated mesh as
+ ϕ*(x) = ϕ(x) + δ, with δ the margin value. This estimation is extending an
+ amount δ the line connecting point x and its closest point on the boundary of
+ the non-inflated mesh. For boundary vertices, the distance is ϕ*(x) = 0.
+
+ Given the distance field ϕ*(x) (defined positive inside the object), we define
  the extent function as in the Elastic Foundation Model, i.e. e(x) =
- (-ϕ(x)-δ)/(H-δ), where the elastic foundation depth H is defined as the maximum
- distance ϕ(x) over the volume of the mesh (actually the maximum ϕ(xᵢ) over all
- mesh vertices xᵢ). δ is the margin. The pressure field is then defined as p(x)
- = E⋅e(x). Therefore the zero pressure level set is located at a distance δ from
- the surface, and the maximum pressure is p = E.
+ (-ϕ*(x)-δ)/(H-δ), where the elastic foundation depth H is defined as the
+ maximum distance ϕ*(x) over the volume of the mesh (actually the maximum ϕ*(xᵢ)
+ over all mesh vertices xᵢ). The pressure field is then defined as p(x) =
+ E⋅e(x). Therefore the zero pressure level set is located at a distance ϕ* = δ
+ from the surface, and the maximum pressure is p = E.
 
  @param[in] mesh_M   A pointer to a tetrahedral mesh.
                      It is aliased in the returned pressure field and must

--- a/geometry/proximity/test/make_mesh_field_test.cc
+++ b/geometry/proximity/test/make_mesh_field_test.cc
@@ -53,6 +53,16 @@ GTEST_TEST(MakeVolumeMeshPressureFieldTest, WithMargin) {
   // Max distance consistent with non_convex_mesh.vtk. This value might need to
   // be updated if that file changes.
   const double elastic_foundation_depth = 0.1;
+
+  // MakeVolumeMeshPressureField() is used to generate fields with margin but,
+  // unlike all other convex geometries, it is meant to work on the original
+  // non-inflated mesh. For interior vertices, it approximates distances d̃ in
+  // the inflated mesh from distances d in the non-inflated mesh as d̃ = d + δ,
+  // with δ the margin. Therefore if H is the elastic foundation depth of the
+  // non-inflated mesh, H̃ = H + δ is the elastic foundation depth in the
+  // inflated mesh.
+  const double inflated_elastic_foundation_depth =
+      elastic_foundation_depth + kMargin;
   const VolumeMesh<double> non_convex_mesh = MakeVolumeMeshFromVtk<double>(
       Mesh(FindResourceOrThrow("drake/geometry/test/non_convex_mesh.vtk")));
   const VolumeMeshFieldLinear<double, double> field_no_margin =
@@ -61,8 +71,8 @@ GTEST_TEST(MakeVolumeMeshPressureFieldTest, WithMargin) {
       MakeVolumeMeshPressureField(&non_convex_mesh, kHydroelasticModulus,
                                   kMargin);
   VerifyInvariantsOfThePressureFieldWithMargin(
-      field_no_margin, field_with_margin, kMargin, elastic_foundation_depth,
-      kHydroelasticModulus);
+      field_no_margin, field_with_margin, kMargin,
+      inflated_elastic_foundation_depth, kHydroelasticModulus);
 }
 
 // Tests that an input mesh without interior vertices will throw. For


### PR DESCRIPTION
Additional experimentation and testing revealed better ways to compute the pressure fields for these gometries.

**For the elliposoid field**, a convex geometry, the inititial method to compute pressure field would become singular if the margin was equal or larger than the minimum semi-axis lenght. This is obviously wrong. For convex geometries inflation and pressure field defintion must be valid for any value of the margin. 
The new filed then pairs up in #21773 with an inflated ellipsoid of semi-axis aᵢ+δ so that the zero-level pressure field exactly matches the original geometry.

**For the mesh field**, being non-convex, the inflation process might lead to cracks that, though negligible for the computation of forces, introduce topological gaps that completely change the computation of the distance function used to define the pressure field. We resolve this in #21773 by defining the pressure field on the original mesh (with good topology) and "warping" it to the inflated mesh. Thereofre this requires the new field computatioin to reason about this warping with an approximation of the distance field in the inflate mesh from the distance field on the non-inflated mesh.

A mouthful really, but the changes are quite simple to implement. Testing in Anzu even shows that we can even deal with very thin geometry, which is even far beyond any of our original expectations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21777)
<!-- Reviewable:end -->
