### PR TITLE
Always use the convex hull for Convex shapes

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -403,6 +403,7 @@ drake_cc_library(
         "//geometry/proximity:make_convex_hull_mesh_impl",
         "//geometry/proximity:meshing_utilities",
         "//geometry/proximity:obj_to_surface_mesh",
+        "//geometry/proximity:polygon_to_triangle_mesh",
     ],
 )
 

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -554,6 +554,7 @@ drake_cc_library(
     ],
     implementation_deps = [
         ":obj_to_surface_mesh",
+        ":polygon_to_triangle_mesh",
         ":triangle_surface_mesh",
         "//common:default_scalars",
         "//common:essential",
@@ -1375,6 +1376,7 @@ drake_cc_googletest(
     deps = [
         ":make_convex_mesh",
         ":obj_to_surface_mesh",
+        ":polygon_to_triangle_mesh",
         ":proximity_utilities",
         ":volume_to_surface_mesh",
         "//common:find_resource",

--- a/geometry/proximity/make_convex_mesh.cc
+++ b/geometry/proximity/make_convex_mesh.cc
@@ -7,6 +7,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
+#include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
 
 namespace drake {
 namespace geometry {
@@ -96,7 +97,7 @@ VolumeMesh<T> MakeConvexVolumeMesh(
 template <typename T>
 VolumeMesh<T> MakeConvexVolumeMesh(const Convex& convex) {
   return MakeConvexVolumeMesh<T>(
-      ReadObjToTriangleSurfaceMesh(convex.filename(), convex.scale()));
+      internal::MakeTriangleFromPolygonMesh(convex.GetConvexHull()));
 }
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -712,21 +712,29 @@ GTEST_TEST(ShapeTest, Volume) {
   EXPECT_NEAR(CalcVolume(MeshcatCone(4, 2, 3)), 8.0 * M_PI, 1e-14);
   EXPECT_NEAR(CalcVolume(Sphere(3)), 36.0 * M_PI, 1e-13);
 
+  // The convex hull of the cube with a hole, should have the same volume as
+  // a cube without the hole.
+  const std::string holey_cube_obj =
+      FindResourceOrThrow("drake/geometry/test/cube_with_hole.obj");
+  EXPECT_NEAR(CalcVolume(Convex(holey_cube_obj, 1.0)), 8.0, 1e-14);
   const std::string cube_obj =
       FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
-  EXPECT_NEAR(CalcVolume(Convex(cube_obj, 1.0)), 8.0, 1e-14);
   EXPECT_NEAR(CalcVolume(Mesh(cube_obj, 1.0)), 8.0, 1e-14);
 
-  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex("fakename.obj", 1.0)),
-                              "Cannot open file.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh("fakename.obj", 1.0)),
+  // Error thrown in ReadObjFile() (read_obj.cc). Note: this passes the tinyobj
+  // error along -- those terminate in new lines and has to be handled in the
+  // matching expression explicitly.
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex("fakename.obj")),
+                              ".*Cannot open file[^]*");
+  // Error thrown in ReadObjToTriangleSurfaceMesh() (obj_to_surface_mesh.cc).
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh("fakename.obj")),
                               "Cannot open file.*");
 
-  // We only support obj but should eventually support vtk.
   const std::string non_obj = "only_extension_matters.not_obj";
-  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex(non_obj, 1.0)),
-                              ".*only supports .obj files.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh(non_obj, 1.0)),
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex(non_obj)),
+                              ".*only applies to obj, vtk.*");
+  // We only support obj but should eventually support vtk.
+  DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh(non_obj)),
                               ".*only supports .obj files.*");
 }
 


### PR DESCRIPTION
The Convex is documented with the semantics that where decalre Convex, the mesh is merely the specification of the source of vertices and the actual geometry *is* the convex hull.

This corrects a couple of calculations that mistakenly used the underlying mesh and not the convex hull.

- `CalcVolume(Convex)` now explicitly uses the convex hull.
- `MakeConvexVolumeMesh()` likewise is limited to Convex shapes.

See #21147 for the definition of `Convex`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21779)
<!-- Reviewable:end -->
