### PR TITLE
[planning] RobotDiagramBuilder skips deprecated ports

### DIFF
--- a/planning/test/robot_diagram_test.cc
+++ b/planning/test/robot_diagram_test.cc
@@ -118,6 +118,44 @@ GTEST_TEST(RobotDiagramBuilderTest, NoDefaultExportCustomSystems) {
   }
 }
 
+// All exported ports must be non-deprecated.
+GTEST_TEST(RobotDiagramBuilderTest, NoExportDeprecatedPorts) {
+  std::unique_ptr<RobotDiagramBuilder<double>> dut = MakeSampleDut();
+  auto diagram = dut->Build();
+  for (int i = 0; i < diagram->num_input_ports(); ++i) {
+    const auto& diagram_port = diagram->get_input_port(i);
+    const std::string& diagram_port_name = diagram_port.get_name();
+    if (diagram_port_name.starts_with("plant_")) {
+      const auto& leaf_port =
+          diagram->plant().GetInputPort(diagram_port_name.substr(6));
+      EXPECT_EQ(leaf_port.get_deprecation(), std::nullopt)
+          << leaf_port.get_name();
+    } else if (diagram_port_name.starts_with("scene_graph_")) {
+      const auto& leaf_port =
+          diagram->scene_graph().GetInputPort(diagram_port_name.substr(12));
+      EXPECT_EQ(leaf_port.get_deprecation(), std::nullopt)
+          << leaf_port.get_name();
+    } else {
+      GTEST_FAIL() << diagram_port_name;
+    }
+  }
+  for (int i = 0; i < diagram->num_output_ports(); ++i) {
+    const auto& diagram_port = diagram->get_output_port(i);
+    const std::string& diagram_port_name = diagram_port.get_name();
+    if (diagram_port_name.starts_with("plant_")) {
+      const auto& leaf_port =
+          diagram->plant().GetOutputPort(diagram_port_name.substr(6));
+      EXPECT_EQ(leaf_port.get_deprecation(), std::nullopt);
+    } else if (diagram_port_name.starts_with("scene_graph_")) {
+      const auto& leaf_port =
+          diagram->scene_graph().GetOutputPort(diagram_port_name.substr(12));
+      EXPECT_EQ(leaf_port.get_deprecation(), std::nullopt);
+    } else {
+      GTEST_FAIL() << diagram_port_name;
+    }
+  }
+}
+
 GTEST_TEST(RobotDiagramBuilderTest, Lifecycle) {
   std::unique_ptr<RobotDiagramBuilder<double>> dut = MakeSampleDut();
 

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -935,7 +935,9 @@ const OutputPort<T>& System<T>::GetOutputPort(
   std::vector<std::string_view> port_names;
   port_names.reserve(num_output_ports());
   for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
-    port_names.push_back(get_output_port_base(i).get_name());
+    const OutputPortBase& port_base = this->GetOutputPortBaseOrThrow(
+        __func__, i, /* warn_deprecated = */ false);
+    port_names.push_back(port_base.get_name());
   }
   if (port_names.empty()) {
     port_names.push_back("it has no output ports");


### PR DESCRIPTION
Also add a missing warning suppression in the framework when preparing an error message.

---

Without this, the building step always spams the console with deprecation warnings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21783)
<!-- Reviewable:end -->
