### PR TITLE
Fix a bug in computing OrientationCost.

### DIFF
--- a/multibody/inverse_kinematics/orientation_cost.cc
+++ b/multibody/inverse_kinematics/orientation_cost.cc
@@ -40,12 +40,12 @@ OrientationCost::~OrientationCost() = default;
 
 void OrientationCost::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
                              Eigen::VectorXd* y) const {
-  // OrientationConstraint computes tr(R_AB) = 1 - 2cosθ
-  // So 1 - cosθ = (1 + tr(R_AB))/2
+  // OrientationConstraint computes tr(R_AB) = 1 + 2cosθ
+  // So 1 - cosθ = (3 - tr(R_AB))/2
   y->resize(1);
   Eigen::VectorXd trace_R_AB(1);
   constraint_.Eval(x, &trace_R_AB);
-  (*y)[0] = c_ * (1.0 + trace_R_AB[0]) / 2.0;
+  (*y)[0] = c_ * (3.0 - trace_R_AB[0]) / 2.0;
 }
 
 void OrientationCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
@@ -53,7 +53,7 @@ void OrientationCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   y->resize(1);
   VectorX<AutoDiffXd> trace_R_AB(1);
   constraint_.Eval(x, &trace_R_AB);
-  (*y)[0] = c_ * (1.0 + trace_R_AB[0]) / 2.0;
+  (*y)[0] = c_ * (3.0 - trace_R_AB[0]) / 2.0;
 }
 
 void OrientationCost::DoEval(

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
@@ -352,8 +352,7 @@ TEST_F(TwoFreeBodiesTest, OrientationCost) {
 
   const math::RotationMatrix<double> R_AB =
       (X_WAbar.rotation() * R_AbarA).inverse() * X_WBbar.rotation() * R_BbarB;
-  const double theta =
-      math::wrap_to(R_AB.ToAngleAxis().angle(), -M_PI / 2.0, M_PI / 2.0);
+  const double theta = R_AB.ToAngleAxis().angle();
   EXPECT_NEAR(ik_.prog().EvalBindingAtInitialGuess(binding)[0],
               c * (1.0 - cos(theta)), 1e-12);
 }

--- a/multibody/inverse_kinematics/test/orientation_cost_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_cost_test.cc
@@ -98,8 +98,7 @@ GTEST_TEST(OrientationCostTest, TwoFreeBodies) {
   RotationMatrix<double> R_AB = R_AbarA.inverse() * R_BbarB;  // because A == B.
   // We use the explicit formula in the Cost implementation; we test this
   // against Eigen's conversion from matrices to AngleAxis:
-  double theta =
-      math::wrap_to(R_AB.ToAngleAxis().angle(), -M_PI / 2.0, M_PI / 2.0);
+  double theta = R_AB.ToAngleAxis().angle();
   CheckCases(*cost, *cost_ad, q, c * (1.0 - cos(theta)));
 
   // X_WA, X_WB are arbitrary non-identity transforms.
@@ -113,7 +112,7 @@ GTEST_TEST(OrientationCostTest, TwoFreeBodies) {
 
   R_AB =
       (X_WAbar.rotation() * R_AbarA).inverse() * X_WBbar.rotation() * R_BbarB;
-  theta = math::wrap_to(R_AB.ToAngleAxis().angle(), -M_PI / 2.0, M_PI / 2.0);
+  theta = R_AB.ToAngleAxis().angle();
   CheckCases(*cost, *cost_ad, q, c * (1.0 - cos(theta)));
 }
 


### PR DESCRIPTION
The previous implementation has cost c * (1 + cos(theta)), where theta is the rotation angle. Namely the previous (wrong implementation) would achieve minimum at theta = 180 degree.The fixed implementation has cost c * (1 - cos(theta)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21785)
<!-- Reviewable:end -->
