### PR TITLE
[fem] Remove quadrature template from constitutive models

### DIFF
--- a/multibody/fem/constitutive_model.h
+++ b/multibody/fem/constitutive_model.h
@@ -38,9 +38,6 @@ class ConstitutiveModel {
   using T = typename Traits::Scalar;
   using Data = typename Traits::Data;
 
-  /* The number of locations at which the constitutive relationship is
-   evaluated. */
-  static constexpr int num_locations = Data::num_locations;
   /* Is the constitutive model linear. */
   static constexpr bool is_linear = Traits::is_linear;
 
@@ -59,8 +56,7 @@ class ConstitutiveModel {
    Calculates the energy density in reference configuration in unit of J/m³,
    given the deformation gradient related quantities contained in `data`.
    @pre `Psi != nullptr`. */
-  void CalcElasticEnergyDensity(const Data& data,
-                                std::array<T, num_locations>* Psi) const {
+  void CalcElasticEnergyDensity(const Data& data, T* Psi) const {
     DRAKE_ASSERT(Psi != nullptr);
     derived().CalcElasticEnergyDensityImpl(data, Psi);
   }
@@ -68,8 +64,7 @@ class ConstitutiveModel {
   /* Calculates the First Piola stress in unit of Pa, given the deformation
    gradient related quantities contained in `data`.
    @pre `P != nullptr`. */
-  void CalcFirstPiolaStress(const Data& data,
-                            std::array<Matrix3<T>, num_locations>* P) const {
+  void CalcFirstPiolaStress(const Data& data, Matrix3<T>* P) const {
     DRAKE_ASSERT(P != nullptr);
     derived().CalcFirstPiolaStressImpl(data, P);
   }
@@ -97,9 +92,8 @@ class ConstitutiveModel {
                    |           |           |           |
                    -------------------------------------
   @pre `dPdF != nullptr`. */
-  void CalcFirstPiolaStressDerivative(
-      const Data& data,
-      std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const {
+  void CalcFirstPiolaStressDerivative(const Data& data,
+                                      Eigen::Matrix<T, 9, 9>* dPdF) const {
     DRAKE_ASSERT(dPdF != nullptr);
     derived().CalcFirstPiolaStressDerivativeImpl(data, dPdF);
   }
@@ -115,25 +109,22 @@ class ConstitutiveModel {
   /* Derived classes *must* shadow these methods to compute energy
    density, stress, and stress derivatives from the given `data`. The output
    argument is guaranteed to be non-null. */
-  void CalcElasticEnergyDensityImpl(const Data& data,
-                                    std::array<T, num_locations>* Psi) const {
+  void CalcElasticEnergyDensityImpl(const Data& data, T* Psi) const {
     throw std::logic_error(
         fmt::format("The derived class {} must provide a shadow definition of "
                     "CalcElasticEnergyDensityImpl() to be correct.",
                     NiceTypeName::Get(derived())));
   }
 
-  void CalcFirstPiolaStressImpl(
-      const Data& data, std::array<Matrix3<T>, num_locations>* P) const {
+  void CalcFirstPiolaStressImpl(const Data& data, Matrix3<T>* P) const {
     throw std::logic_error(
         fmt::format("The derived class {} must provide a shadow definition of "
                     "CalcFirstPiolaStressImpl() to be correct.",
                     NiceTypeName::Get(derived())));
   }
 
-  void CalcFirstPiolaStressDerivativeImpl(
-      const Data& data,
-      std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const {
+  void CalcFirstPiolaStressDerivativeImpl(const Data& data,
+                                          Eigen::Matrix<T, 9, 9>* dPdF) const {
     throw std::logic_error(
         fmt::format("The derived class {} must provide a shadow definition of "
                     "CalcFirstPiolaStressDerivativeImpl() to be correct.",

--- a/multibody/fem/corotated_model.cc
+++ b/multibody/fem/corotated_model.cc
@@ -12,67 +12,59 @@ namespace multibody {
 namespace fem {
 namespace internal {
 
-template <typename T, int num_locations>
-CorotatedModel<T, num_locations>::CorotatedModel(const T& youngs_modulus,
-                                                 const T& poissons_ratio)
+template <typename T>
+CorotatedModel<T>::CorotatedModel(const T& youngs_modulus,
+                                  const T& poissons_ratio)
     : E_(youngs_modulus), nu_(poissons_ratio) {
   const LameParameters<T> lame_params = CalcLameParameters(E_, nu_);
   mu_ = lame_params.mu;
   lambda_ = lame_params.lambda;
 }
 
-template <typename T, int num_locations>
-void CorotatedModel<T, num_locations>::CalcElasticEnergyDensityImpl(
-    const Data& data, std::array<T, num_locations>* Psi) const {
-  for (int i = 0; i < num_locations; ++i) {
-    const T& Jm1 = data.Jm1()[i];
-    const Matrix3<T>& F = data.deformation_gradient()[i];
-    const Matrix3<T>& R = data.R()[i];
-    /* Note that ‖F − R‖² is equivalent to the ∑(σᵢ−1)² term used in
-     [Stomakhin, 2012]. */
-    (*Psi)[i] = mu_ * (F - R).squaredNorm() + 0.5 * lambda_ * Jm1 * Jm1;
-  }
+template <typename T>
+void CorotatedModel<T>::CalcElasticEnergyDensityImpl(const Data& data,
+                                                     T* Psi) const {
+  const T& Jm1 = data.Jm1();
+  const Matrix3<T>& F = data.deformation_gradient();
+  const Matrix3<T>& R = data.R();
+  /* Note that ‖F − R‖² is equivalent to the ∑(σᵢ−1)² term used in
+   [Stomakhin, 2012]. */
+  (*Psi) = mu_ * (F - R).squaredNorm() + 0.5 * lambda_ * Jm1 * Jm1;
 }
 
-template <typename T, int num_locations>
-void CorotatedModel<T, num_locations>::CalcFirstPiolaStressImpl(
-    const Data& data, std::array<Matrix3<T>, num_locations>* P) const {
-  for (int i = 0; i < num_locations; ++i) {
-    const T& Jm1 = data.Jm1()[i];
-    const Matrix3<T>& F = data.deformation_gradient()[i];
-    const Matrix3<T>& R = data.R()[i];
-    const Matrix3<T>& JFinvT = data.JFinvT()[i];
-    (*P)[i] = 2.0 * mu_ * (F - R) + lambda_ * Jm1 * JFinvT;
-  }
+template <typename T>
+void CorotatedModel<T>::CalcFirstPiolaStressImpl(const Data& data,
+                                                 Matrix3<T>* P) const {
+  const T& Jm1 = data.Jm1();
+  const Matrix3<T>& F = data.deformation_gradient();
+  const Matrix3<T>& R = data.R();
+  const Matrix3<T>& JFinvT = data.JFinvT();
+  (*P) = 2.0 * mu_ * (F - R) + lambda_ * Jm1 * JFinvT;
 }
 
-template <typename T, int num_locations>
-void CorotatedModel<T, num_locations>::CalcFirstPiolaStressDerivativeImpl(
-    const Data& data,
-    std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const {
-  for (int i = 0; i < num_locations; ++i) {
-    const T& Jm1 = data.Jm1()[i];
-    const Matrix3<T>& F = data.deformation_gradient()[i];
-    const Matrix3<T>& R = data.R()[i];
-    const Matrix3<T>& S = data.S()[i];
-    const Matrix3<T>& JFinvT = data.JFinvT()[i];
-    const Vector<T, 3 * 3>& flat_JFinvT =
-        Eigen::Map<const Vector<T, 3 * 3>>(JFinvT.data(), 3 * 3);
-    auto& local_dPdF = (*dPdF)[i];
-    /* The contribution from derivatives of Jm1. */
-    local_dPdF.noalias() = lambda_ * flat_JFinvT * flat_JFinvT.transpose();
-    /* The contribution from derivatives of F. */
-    local_dPdF.diagonal().array() += 2.0 * mu_;
-    /* The contribution from derivatives of R. */
-    internal::AddScaledRotationalDerivative<T>(R, S, -2.0 * mu_, &local_dPdF);
-    /* The contribution from derivatives of JFinvT. */
-    internal::AddScaledCofactorMatrixDerivative<T>(F, lambda_ * Jm1,
-                                                   &local_dPdF);
-  }
+template <typename T>
+void CorotatedModel<T>::CalcFirstPiolaStressDerivativeImpl(
+    const Data& data, Eigen::Matrix<T, 9, 9>* dPdF) const {
+  const T& Jm1 = data.Jm1();
+  const Matrix3<T>& F = data.deformation_gradient();
+  const Matrix3<T>& R = data.R();
+  const Matrix3<T>& S = data.S();
+  const Matrix3<T>& JFinvT = data.JFinvT();
+  const Vector<T, 3 * 3>& flat_JFinvT =
+      Eigen::Map<const Vector<T, 3 * 3>>(JFinvT.data(), 3 * 3);
+  auto& local_dPdF = (*dPdF);
+  /* The contribution from derivatives of Jm1. */
+  local_dPdF.noalias() = lambda_ * flat_JFinvT * flat_JFinvT.transpose();
+  /* The contribution from derivatives of F. */
+  local_dPdF.diagonal().array() += 2.0 * mu_;
+  /* The contribution from derivatives of R. */
+  internal::AddScaledRotationalDerivative<T>(R, S, -2.0 * mu_, &local_dPdF);
+  /* The contribution from derivatives of JFinvT. */
+  internal::AddScaledCofactorMatrixDerivative<T>(F, lambda_ * Jm1, &local_dPdF);
 }
 
-template class CorotatedModel<double, 1>;
-template class CorotatedModel<AutoDiffXd, 1>;
+template class CorotatedModel<double>;
+template class CorotatedModel<AutoDiffXd>;
 
 }  // namespace internal
 }  // namespace fem

--- a/multibody/fem/corotated_model.h
+++ b/multibody/fem/corotated_model.h
@@ -11,32 +11,27 @@ namespace fem {
 namespace internal {
 
 /* Traits for CorotatedModel. */
-template <typename T, int num_locations>
+template <typename T>
 struct CorotatedModelTraits {
   using Scalar = T;
-  using Data = CorotatedModelData<T, num_locations>;
+  using Data = CorotatedModelData<T>;
   static constexpr int is_linear = false;
 };
 
 /* Implements the fixed corotated hyperelastic constitutive model as
  described in [Stomakhin, 2012].
  @tparam_nonsymbolic_scalar
- @tparam num_locations Number of locations at which the constitutive
- relationship is evaluated. We currently only provide one instantiation of this
- template with `num_locations = 1`, but more instantiations can easily be added
- when needed.
 
  [Stomakhin, 2012] Stomakhin, Alexey, et al. "Energetically consistent
  invertible elasticity." Proceedings of the 11th ACM SIGGRAPH/Eurographics
  conference on Computer Animation. 2012. */
-template <typename T, int num_locations>
+template <typename T>
 class CorotatedModel final
-    : public ConstitutiveModel<CorotatedModel<T, num_locations>,
-                               CorotatedModelTraits<T, num_locations>> {
+    : public ConstitutiveModel<CorotatedModel<T>, CorotatedModelTraits<T>> {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CorotatedModel);
 
-  using Traits = CorotatedModelTraits<T, num_locations>;
+  using Traits = CorotatedModelTraits<T>;
   using Data = typename Traits::Data;
 
   /* Constructs a CorotatedModel constitutive model with the
@@ -62,24 +57,20 @@ class CorotatedModel final
   const T& lame_first_parameter() const { return lambda_; }
 
  private:
-  friend ConstitutiveModel<CorotatedModel<T, num_locations>,
-                           CorotatedModelTraits<T, num_locations>>;
+  friend ConstitutiveModel<CorotatedModel<T>, CorotatedModelTraits<T>>;
 
   /* Shadows ConstitutiveModel::CalcElasticEnergyDensityImpl() as required by
    the CRTP base class. */
-  void CalcElasticEnergyDensityImpl(const Data& data,
-                                    std::array<T, num_locations>* Psi) const;
+  void CalcElasticEnergyDensityImpl(const Data& data, T* Psi) const;
 
   /* Shadows ConstitutiveModel::CalcFirstPiolaStressImpl() as required by the
    CRTP base class. */
-  void CalcFirstPiolaStressImpl(const Data& data,
-                                std::array<Matrix3<T>, num_locations>* P) const;
+  void CalcFirstPiolaStressImpl(const Data& data, Matrix3<T>* P) const;
 
   /* Shadows ConstitutiveModel::CalcFirstPiolaStressDerivativeImpl() as required
    by the CRTP base class. */
-  void CalcFirstPiolaStressDerivativeImpl(
-      const Data& data,
-      std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const;
+  void CalcFirstPiolaStressDerivativeImpl(const Data& data,
+                                          Eigen::Matrix<T, 9, 9>* dPdF) const;
 
   T E_;       // Young's modulus, N/m².
   T nu_;      // Poisson's ratio.

--- a/multibody/fem/corotated_model_data.cc
+++ b/multibody/fem/corotated_model_data.cc
@@ -8,28 +8,24 @@ namespace multibody {
 namespace fem {
 namespace internal {
 
-template <typename T, int num_locations>
-CorotatedModelData<T, num_locations>::CorotatedModelData() {
-  std::fill(R_.begin(), R_.end(), Matrix3<T>::Identity());
-  std::fill(S_.begin(), S_.end(), Matrix3<T>::Identity());
-  std::fill(Jm1_.begin(), Jm1_.end(), 0);
-  std::fill(JFinvT_.begin(), JFinvT_.end(), Matrix3<T>::Identity());
-}
-template <typename T, int num_locations>
-void CorotatedModelData<T, num_locations>::UpdateFromDeformationGradient() {
-  const std::array<Matrix3<T>, num_locations>& F = this->deformation_gradient();
-  for (int i = 0; i < num_locations; ++i) {
-    Matrix3<T>& local_R = R_[i];
-    Matrix3<T>& local_S = S_[i];
-    Matrix3<T>& local_JFinvT = JFinvT_[i];
-    internal::PolarDecompose<T>(F[i], &local_R, &local_S);
-    Jm1_[i] = F[i].determinant() - 1.0;
-    internal::CalcCofactorMatrix<T>(F[i], &local_JFinvT);
-  }
+template <typename T>
+CorotatedModelData<T>::CorotatedModelData() {
+  R_ = Matrix3<T>::Identity();
+  S_ = Matrix3<T>::Identity();
+  Jm1_ = 0;
+  JFinvT_ = Matrix3<T>::Identity();
 }
 
-template class CorotatedModelData<double, 1>;
-template class CorotatedModelData<AutoDiffXd, 1>;
+template <typename T>
+void CorotatedModelData<T>::UpdateFromDeformationGradient() {
+  const Matrix3<T>& F = this->deformation_gradient();
+  internal::PolarDecompose<T>(F, &R_, &S_);
+  Jm1_ = F.determinant() - 1.0;
+  internal::CalcCofactorMatrix<T>(F, &JFinvT_);
+}
+
+template class CorotatedModelData<double>;
+template class CorotatedModelData<AutoDiffXd>;
 
 }  // namespace internal
 }  // namespace fem

--- a/multibody/fem/corotated_model_data.h
+++ b/multibody/fem/corotated_model_data.h
@@ -16,11 +16,10 @@ namespace internal {
  (J = det(F)) used in evaluating the energy density and its derivatives.
  See DeformationGradientData for more about constitutive model data.
  @tparam_nonsymbolic_scalar
- @tparam num_locations Number of locations at which the deformation gradient
  dependent quantities are evaluated. */
-template <typename T, int num_locations>
+template <typename T>
 class CorotatedModelData
-    : public DeformationGradientData<CorotatedModelData<T, num_locations>> {
+    : public DeformationGradientData<CorotatedModelData<T>> {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CorotatedModelData);
 
@@ -28,21 +27,19 @@ class CorotatedModelData
   CorotatedModelData();
 
   /* Returns the rotation matrices from the polar decomposition of F = R*S. */
-  const std::array<Matrix3<T>, num_locations>& R() const { return R_; }
+  const Matrix3<T>& R() const { return R_; }
 
   /* Returns the symmetric matrices from the polar decomposition of F = R*S. */
-  const std::array<Matrix3<T>, num_locations>& S() const { return S_; }
+  const Matrix3<T>& S() const { return S_; }
 
   /* Returns the J-1 where J is the determinant of the deformation gradient. */
-  const std::array<T, num_locations>& Jm1() const { return Jm1_; }
+  const T& Jm1() const { return Jm1_; }
 
   /* Returns the JF⁻ᵀ. */
-  const std::array<Matrix3<T>, num_locations>& JFinvT() const {
-    return JFinvT_;
-  }
+  const Matrix3<T>& JFinvT() const { return JFinvT_; }
 
  private:
-  friend DeformationGradientData<CorotatedModelData<T, num_locations>>;
+  friend DeformationGradientData<CorotatedModelData<T>>;
 
   /* Shadows DeformationGradientData::UpdateFromDeformationGradient() as
    required by the CRTP base class. */
@@ -50,12 +47,12 @@ class CorotatedModelData
 
   /* Let F = RS be the polar decomposition of the deformation gradient where R
    is a rotation matrix and S is symmetric. */
-  std::array<Matrix3<T>, num_locations> R_;
-  std::array<Matrix3<T>, num_locations> S_;
+  Matrix3<T> R_;
+  Matrix3<T> S_;
   /* The determinant of F minus 1, or J - 1. */
-  std::array<T, num_locations> Jm1_;
+  T Jm1_;
   /* The cofactor matrix of F, or JF⁻ᵀ. */
-  std::array<Matrix3<T>, num_locations> JFinvT_;
+  Matrix3<T> JFinvT_;
 };
 
 }  // namespace internal

--- a/multibody/fem/deformation_gradient_data.h
+++ b/multibody/fem/deformation_gradient_data.h
@@ -22,11 +22,10 @@ class DeformationGradientData;
  model (`Foo`) there should be a corresponding `FooData` derived from
  DeformationGradientData.
 
- It stores the deformation gradients calculated at the prescribed "locations"
- (the number of which could depend on varying criteria, e.g., quadrature points,
- etc.). A derived class will further store derived quantities which solely
- depend on the stored deformation gradients (e.g., strain) that facilitate
- calculations of energy density, stress, and stress derivatives.
+ It stores the deformation gradients calculated at the prescribed location. A
+ derived class will further store derived quantities which solely depend on the
+ stored deformation gradients (e.g., strain) that facilitate calculations of
+ energy density, stress, and stress derivatives.
 
  As part of a derivation, the child `FooData` class must implement the method:
 
@@ -35,42 +34,29 @@ class DeformationGradientData;
  Note that this is not a virtual method but failure to implement the method
  correctly will lead to an exception about "undefined" methods when
  `UpdateData()` is invoked.
- @tparam_nonsymbolic_scalar T.
- @tparam num_locations_at_compile_time Number of locations at which the data are
- evaluated. */
-template <template <typename, int> class DerivedDeformationGradientData,
-          typename T, int num_locations_at_compile_time>
-class DeformationGradientData<
-    DerivedDeformationGradientData<T, num_locations_at_compile_time>> {
+ @tparam_nonsymbolic_scalar T. */
+template <template <typename> class DerivedDeformationGradientData, typename T>
+class DeformationGradientData<DerivedDeformationGradientData<T>> {
  public:
-  using Derived =
-      DerivedDeformationGradientData<T, num_locations_at_compile_time>;
-
-  /* The number of locations at which the data needs to be evaluated. */
-  static constexpr int num_locations = num_locations_at_compile_time;
+  using Derived = DerivedDeformationGradientData<T>;
 
   /* Updates the data with the given deformation gradients. The deformation
    gradient dependent quantities are also updated with the given
-   `deformation_gradient`.
-   @param deformation_gradient The up-to-date deformation gradients evaluated at
-   the prescribed locations. */
-  void UpdateData(std::array<Matrix3<T>, num_locations> deformation_gradient,
-                  std::array<Matrix3<T>, num_locations>
-                      previous_step_deformation_gradient) {
-    deformation_gradient_ = std::move(deformation_gradient);
-    previous_step_deformation_gradient_ =
-        std::move(previous_step_deformation_gradient);
+   deformation gradients evaluated at the current and previous time steps. */
+  void UpdateData(const Matrix3<T>& deformation_gradient,
+                  const Matrix3<T>& previous_step_deformation_gradient) {
+    deformation_gradient_ = deformation_gradient;
+    previous_step_deformation_gradient_ = previous_step_deformation_gradient;
     static_cast<Derived*>(this)->UpdateFromDeformationGradient();
   }
 
-  const std::array<Matrix3<T>, num_locations>& deformation_gradient() const {
+  const Matrix3<T>& deformation_gradient() const {
     return deformation_gradient_;
   }
 
   /* Returns the deformation gradient evaluated at all quadrature points at the
    previous time step t₀. */
-  const std::array<Matrix3<T>, num_locations>&
-  previous_step_deformation_gradient() const {
+  const Matrix3<T>& previous_step_deformation_gradient() const {
     return previous_step_deformation_gradient_;
   }
 
@@ -79,10 +65,9 @@ class DeformationGradientData<
 
   /* Constructs a DeformationGradientData with identity deformation gradients.
    */
-  DeformationGradientData() {
-    deformation_gradient_.fill(Matrix3<T>::Identity());
-    previous_step_deformation_gradient_.fill(Matrix3<T>::Identity());
-  }
+  DeformationGradientData()
+      : deformation_gradient_(Matrix3<T>::Identity()),
+        previous_step_deformation_gradient_(Matrix3<T>::Identity()) {}
 
   /* Derived classes *must* shadow this method to compute quantities derived
    from deformation gradients. `deformation_gradient()` will be up to date
@@ -95,8 +80,8 @@ class DeformationGradientData<
   }
 
  private:
-  std::array<Matrix3<T>, num_locations> deformation_gradient_;
-  std::array<Matrix3<T>, num_locations> previous_step_deformation_gradient_;
+  Matrix3<T> deformation_gradient_;
+  Matrix3<T> previous_step_deformation_gradient_;
 };
 
 }  // namespace internal

--- a/multibody/fem/linear_constitutive_model.cc
+++ b/multibody/fem/linear_constitutive_model.cc
@@ -11,9 +11,9 @@ namespace multibody {
 namespace fem {
 namespace internal {
 
-template <typename T, int num_locations>
-LinearConstitutiveModel<T, num_locations>::LinearConstitutiveModel(
-    const T& youngs_modulus, const T& poissons_ratio)
+template <typename T>
+LinearConstitutiveModel<T>::LinearConstitutiveModel(const T& youngs_modulus,
+                                                    const T& poissons_ratio)
     : E_(youngs_modulus), nu_(poissons_ratio) {
   const LameParameters<T> lame_params = CalcLameParameters(E_, nu_);
   mu_ = lame_params.mu;
@@ -46,38 +46,31 @@ LinearConstitutiveModel<T, num_locations>::LinearConstitutiveModel(
   }
 }
 
-template <typename T, int num_locations>
-void LinearConstitutiveModel<T, num_locations>::CalcElasticEnergyDensityImpl(
-    const Data& data, std::array<T, num_locations>* Psi) const {
-  for (int i = 0; i < num_locations; ++i) {
-    const auto& strain = data.strain()[i];
-    const auto& trace_strain = data.trace_strain()[i];
-    (*Psi)[i] = mu_ * strain.squaredNorm() +
-                0.5 * lambda_ * trace_strain * trace_strain;
-  }
+template <typename T>
+void LinearConstitutiveModel<T>::CalcElasticEnergyDensityImpl(const Data& data,
+                                                              T* Psi) const {
+  const auto& strain = data.strain();
+  const auto& trace_strain = data.trace_strain();
+  (*Psi) =
+      mu_ * strain.squaredNorm() + 0.5 * lambda_ * trace_strain * trace_strain;
 }
 
-template <typename T, int num_locations>
-void LinearConstitutiveModel<T, num_locations>::CalcFirstPiolaStressImpl(
-    const Data& data, std::array<Matrix3<T>, num_locations>* P) const {
-  for (int i = 0; i < num_locations; ++i) {
-    const auto& strain = data.strain()[i];
-    const auto& trace_strain = data.trace_strain()[i];
-    (*P)[i] =
-        2.0 * mu_ * strain + lambda_ * trace_strain * Matrix3<T>::Identity();
-  }
+template <typename T>
+void LinearConstitutiveModel<T>::CalcFirstPiolaStressImpl(const Data& data,
+                                                          Matrix3<T>* P) const {
+  const auto& strain = data.strain();
+  const auto& trace_strain = data.trace_strain();
+  (*P) = 2.0 * mu_ * strain + lambda_ * trace_strain * Matrix3<T>::Identity();
 }
 
-template <typename T, int num_locations>
-void LinearConstitutiveModel<T, num_locations>::
-    CalcFirstPiolaStressDerivativeImpl(
-        const Data&,
-        std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const {
-  dPdF->fill(dPdF_);
+template <typename T>
+void LinearConstitutiveModel<T>::CalcFirstPiolaStressDerivativeImpl(
+    const Data&, Eigen::Matrix<T, 9, 9>* dPdF) const {
+  *dPdF = dPdF_;
 }
 
-template class LinearConstitutiveModel<double, 1>;
-template class LinearConstitutiveModel<AutoDiffXd, 1>;
+template class LinearConstitutiveModel<double>;
+template class LinearConstitutiveModel<AutoDiffXd>;
 
 }  // namespace internal
 }  // namespace fem

--- a/multibody/fem/linear_constitutive_model.h
+++ b/multibody/fem/linear_constitutive_model.h
@@ -11,34 +11,28 @@ namespace fem {
 namespace internal {
 
 /* Traits for LinearConstitutiveModel. */
-template <typename T, int num_locations>
+template <typename T>
 struct LinearConstitutiveModelTraits {
   using Scalar = T;
-  using Data = LinearConstitutiveModelData<T, num_locations>;
+  using Data = LinearConstitutiveModelData<T>;
   static constexpr int is_linear = true;
 };
 
 /* Implements the infinitesimal-strain linear elasticity constitutive model as
  described in Section 7.4 of [Gonzalez, 2008].
  @tparam_nonsymbolic_scalar.
- @tparam num_locations Number of locations at which the constitutive
- relationship is evaluated. We currently only provide one instantiation of this
- template with `num_locations = 1`, but more instantiations can easily be added
- when needed.
 
 [Gonzalez, 2008] Gonzalez, Oscar, and Andrew M. Stuart. A first course in
 continuum mechanics. Cambridge University Press, 2008. */
-template <typename T, int num_locations>
+template <typename T>
 class LinearConstitutiveModel final
-    : public ConstitutiveModel<
-          LinearConstitutiveModel<T, num_locations>,
-          LinearConstitutiveModelTraits<T, num_locations>> {
+    : public ConstitutiveModel<LinearConstitutiveModel<T>,
+                               LinearConstitutiveModelTraits<T>> {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearConstitutiveModel);
 
-  using Base =
-      ConstitutiveModel<LinearConstitutiveModel<T, num_locations>,
-                        LinearConstitutiveModelTraits<T, num_locations>>;
+  using Base = ConstitutiveModel<LinearConstitutiveModel<T>,
+                                 LinearConstitutiveModelTraits<T>>;
   using Data = typename Base::Data;
 
   /* Constructs a LinearConstitutiveModel constitutive model with the
@@ -69,19 +63,16 @@ class LinearConstitutiveModel final
 
   /* Shadows ConstitutiveModel::CalcElasticEnergyDensityImpl() as required by
    the CRTP base class. */
-  void CalcElasticEnergyDensityImpl(const Data& data,
-                                    std::array<T, num_locations>* Psi) const;
+  void CalcElasticEnergyDensityImpl(const Data& data, T* Psi) const;
 
   /* Shadows ConstitutiveModel::CalcFirstPiolaStressImpl() as required by the
    CRTP base class. */
-  void CalcFirstPiolaStressImpl(const Data& data,
-                                std::array<Matrix3<T>, num_locations>* P) const;
+  void CalcFirstPiolaStressImpl(const Data& data, Matrix3<T>* P) const;
 
   /* Shadows ConstitutiveModel::CalcFirstPiolaStressDerivativeImpl() as required
    by the CRTP base class. */
-  void CalcFirstPiolaStressDerivativeImpl(
-      const Data& data,
-      std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const;
+  void CalcFirstPiolaStressDerivativeImpl(const Data& data,
+                                          Eigen::Matrix<T, 9, 9>* dPdF) const;
 
   T E_;       // Young's modulus, N/m².
   T nu_;      // Poisson's ratio.

--- a/multibody/fem/linear_constitutive_model_data.cc
+++ b/multibody/fem/linear_constitutive_model_data.cc
@@ -7,28 +7,25 @@ namespace multibody {
 namespace fem {
 namespace internal {
 
-template <typename T, int num_locations>
-LinearConstitutiveModelData<T, num_locations>::LinearConstitutiveModelData() {
+template <typename T>
+LinearConstitutiveModelData<T>::LinearConstitutiveModelData() {
   /* Initialize data members to be consistent with the deformation gradient
    which is initialized to the identity matrix. This achieves the same result
    as invoking `UpdateFromDeformationGradient()` but is slightly more
    efficient.*/
-  strain_.fill(Matrix3<T>::Zero());
-  trace_strain_.fill(0.0);
+  strain_ = Matrix3<T>::Zero();
+  trace_strain_ = 0.0;
 }
 
-template <typename T, int num_locations>
-void LinearConstitutiveModelData<
-    T, num_locations>::UpdateFromDeformationGradient() {
-  const std::array<Matrix3<T>, num_locations>& F = this->deformation_gradient();
-  for (int i = 0; i < num_locations; ++i) {
-    strain_[i] = 0.5 * (F[i] + F[i].transpose()) - Matrix3<T>::Identity();
-    trace_strain_[i] = strain_[i].trace();
-  }
+template <typename T>
+void LinearConstitutiveModelData<T>::UpdateFromDeformationGradient() {
+  const Matrix3<T>& F = this->deformation_gradient();
+  strain_ = 0.5 * (F + F.transpose()) - Matrix3<T>::Identity();
+  trace_strain_ = strain_.trace();
 }
 
-template class LinearConstitutiveModelData<double, 1>;
-template class LinearConstitutiveModelData<AutoDiffXd, 1>;
+template class LinearConstitutiveModelData<double>;
+template class LinearConstitutiveModelData<AutoDiffXd>;
 
 }  // namespace internal
 }  // namespace fem

--- a/multibody/fem/linear_constitutive_model_data.h
+++ b/multibody/fem/linear_constitutive_model_data.h
@@ -16,15 +16,10 @@ namespace internal {
 
  See LinearConstitutiveModel for how the data is used. See
  DeformationGradientData for more about constitutive model data.
- @tparam_nonsymbolic_scalar
- @tparam num_locations Number of locations at which the deformation gradient
- dependent quantities are evaluated. We currently only provide one instantiation
- of this template with `num_locations = 1`, but more instantiations can easily
- be added when needed. */
-template <typename T, int num_locations>
+ @tparam_nonsymbolic_scalar */
+template <typename T>
 class LinearConstitutiveModelData
-    : public DeformationGradientData<
-          LinearConstitutiveModelData<T, num_locations>> {
+    : public DeformationGradientData<LinearConstitutiveModelData<T>> {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearConstitutiveModelData);
 
@@ -34,28 +29,24 @@ class LinearConstitutiveModelData
   /* Returns the infinitesimal strains (E = 0.5 * (F + Fᵀ) - I) evaluated with
    the deformation gradient passed when DeformationGradientData::UpdateData()
    was last invoked. */
-  const std::array<Matrix3<T>, num_locations>& strain() const {
-    return strain_;
-  }
+  const Matrix3<T>& strain() const { return strain_; }
 
   /* Returns the traces of the infinitesimal strains (Tr(E)) evaluated with the
    deformation gradient passed when DeformationGradientData::UpdateData() was
    last invoked. */
-  const std::array<T, num_locations>& trace_strain() const {
-    return trace_strain_;
-  }
+  const T& trace_strain() const { return trace_strain_; }
 
  private:
-  friend DeformationGradientData<LinearConstitutiveModelData<T, num_locations>>;
+  friend DeformationGradientData<LinearConstitutiveModelData<T>>;
 
   /* Shadows DeformationGradientData::UpdateFromDeformationGradient() as
    required by the CRTP base class. */
   void UpdateFromDeformationGradient();
 
   /* The infinitesimal strain. */
-  std::array<Matrix3<T>, num_locations> strain_;
+  Matrix3<T> strain_;
   /* Trace of `strain_`. */
-  std::array<T, num_locations> trace_strain_;
+  T trace_strain_;
 };
 
 }  // namespace internal

--- a/multibody/fem/linear_corotated_model.cc
+++ b/multibody/fem/linear_corotated_model.cc
@@ -12,24 +12,22 @@ namespace multibody {
 namespace fem {
 namespace internal {
 
-template <typename T, int num_locations>
-LinearCorotatedModel<T, num_locations>::LinearCorotatedModel(
-    const T& youngs_modulus, const T& poissons_ratio)
+template <typename T>
+LinearCorotatedModel<T>::LinearCorotatedModel(const T& youngs_modulus,
+                                              const T& poissons_ratio)
     : E_(youngs_modulus), nu_(poissons_ratio) {
   const LameParameters<T> lame_params = CalcLameParameters(E_, nu_);
   mu_ = lame_params.mu;
   lambda_ = lame_params.lambda;
 }
 
-template <typename T, int num_locations>
-void LinearCorotatedModel<T, num_locations>::CalcElasticEnergyDensityImpl(
-    const Data& data, std::array<T, num_locations>* Psi) const {
-  for (int i = 0; i < num_locations; ++i) {
-    const Matrix3<T>& strain = data.strain()[i];
-    const T& trace_strain = data.trace_strain()[i];
-    (*Psi)[i] = mu_ * strain.squaredNorm() +
-                0.5 * lambda_ * trace_strain * trace_strain;
-  }
+template <typename T>
+void LinearCorotatedModel<T>::CalcElasticEnergyDensityImpl(const Data& data,
+                                                           T* Psi) const {
+  const Matrix3<T>& strain = data.strain();
+  const T& trace_strain = data.trace_strain();
+  (*Psi) =
+      mu_ * strain.squaredNorm() + 0.5 * lambda_ * trace_strain * trace_strain;
 }
 
 /* First Piola stress P is the derivative of energy density
@@ -44,15 +42,13 @@ void LinearCorotatedModel<T, num_locations>::CalcElasticEnergyDensityImpl(
      2μ * Rₐᵢ*εᵢᵦ + λ * εⱼⱼ * Rₐᵦ,
  which simplifies to
      2μRε + λtr(ε)R. */
-template <typename T, int num_locations>
-void LinearCorotatedModel<T, num_locations>::CalcFirstPiolaStressImpl(
-    const Data& data, std::array<Matrix3<T>, num_locations>* P) const {
-  for (int i = 0; i < num_locations; ++i) {
-    const Matrix3<T>& R0 = data.R0()[i];
-    const Matrix3<T>& strain = data.strain()[i];
-    const T& trace_strain = data.trace_strain()[i];
-    (*P)[i] = 2.0 * mu_ * R0 * strain + lambda_ * trace_strain * R0;
-  }
+template <typename T>
+void LinearCorotatedModel<T>::CalcFirstPiolaStressImpl(const Data& data,
+                                                       Matrix3<T>* P) const {
+  const Matrix3<T>& R0 = data.R0();
+  const Matrix3<T>& strain = data.strain();
+  const T& trace_strain = data.trace_strain();
+  (*P) = 2.0 * mu_ * R0 * strain + lambda_ * trace_strain * R0;
 }
 
 /*
@@ -84,32 +80,29 @@ void LinearCorotatedModel<T, num_locations>::CalcFirstPiolaStressImpl(
               |           |           |           |
               -------------------------------------
 */
-template <typename T, int num_locations>
-void LinearCorotatedModel<T, num_locations>::CalcFirstPiolaStressDerivativeImpl(
-    const Data& data,
-    std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const {
-  for (int q = 0; q < num_locations; ++q) {
-    const Matrix3<T>& R0 = data.R0()[q];
-    auto& local_dPdF = (*dPdF)[q];
-    /* Add in μ * δₐᵢδⱼᵦ. */
-    local_dPdF = mu_ * Eigen::Matrix<T, 9, 9>::Identity();
-    for (int i = 0; i < 3; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        for (int alpha = 0; alpha < 3; ++alpha) {
-          for (int beta = 0; beta < 3; ++beta) {
-            /* Add in  μ *  Rᵢᵦ Rₐⱼ +   λ * Rₐᵦ * Rᵢⱼ. */
-            local_dPdF(3 * j + i, 3 * beta + alpha) +=
-                mu_ * R0(i, beta) * R0(alpha, j) +
-                lambda_ * R0(alpha, beta) * R0(i, j);
-          }
+template <typename T>
+void LinearCorotatedModel<T>::CalcFirstPiolaStressDerivativeImpl(
+    const Data& data, Eigen::Matrix<T, 9, 9>* dPdF) const {
+  const Matrix3<T>& R0 = data.R0();
+  auto& local_dPdF = (*dPdF);
+  /* Add in μ * δₐᵢδⱼᵦ. */
+  local_dPdF = mu_ * Eigen::Matrix<T, 9, 9>::Identity();
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int alpha = 0; alpha < 3; ++alpha) {
+        for (int beta = 0; beta < 3; ++beta) {
+          /* Add in  μ *  Rᵢᵦ Rₐⱼ +   λ * Rₐᵦ * Rᵢⱼ. */
+          local_dPdF(3 * j + i, 3 * beta + alpha) +=
+              mu_ * R0(i, beta) * R0(alpha, j) +
+              lambda_ * R0(alpha, beta) * R0(i, j);
         }
       }
     }
   }
 }
 
-template class LinearCorotatedModel<double, 1>;
-template class LinearCorotatedModel<AutoDiffXd, 1>;
+template class LinearCorotatedModel<double>;
+template class LinearCorotatedModel<AutoDiffXd>;
 
 }  // namespace internal
 }  // namespace fem

--- a/multibody/fem/linear_corotated_model.h
+++ b/multibody/fem/linear_corotated_model.h
@@ -11,32 +11,28 @@ namespace fem {
 namespace internal {
 
 /* Traits for LinearCorotatedModel. */
-template <typename T, int num_locations>
+template <typename T>
 struct LinearCorotatedModelTraits {
   using Scalar = T;
-  using Data = LinearCorotatedModelData<T, num_locations>;
+  using Data = LinearCorotatedModelData<T>;
   static constexpr bool is_linear = true;
 };
 
 /* Implements the linear corotated constitutive model as described in
  [Han et al., 2023].
  @tparam_nonsymbolic_scalar
- @tparam num_locations Number of locations at which the constitutive
- relationship is evaluated. We currently only provide one instantiation of this
- template with `num_locations = 1`, but more instantiations can easily be added
- when needed.
 
  [Han et al., 2023] Han, Xuchen, Joseph Masterjohn, and Alejandro Castro. "A
  Convex Formulation of Frictional Contact between Rigid and Deformable Bodies."
  arXiv preprint arXiv:2303.08912 (2023). */
-template <typename T, int num_locations>
+template <typename T>
 class LinearCorotatedModel final
-    : public ConstitutiveModel<LinearCorotatedModel<T, num_locations>,
-                               LinearCorotatedModelTraits<T, num_locations>> {
+    : public ConstitutiveModel<LinearCorotatedModel<T>,
+                               LinearCorotatedModelTraits<T>> {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearCorotatedModel);
 
-  using Traits = LinearCorotatedModelTraits<T, num_locations>;
+  using Traits = LinearCorotatedModelTraits<T>;
   using Data = typename Traits::Data;
 
   /* Constructs a LinearCorotatedModel constitutive model with the
@@ -62,24 +58,21 @@ class LinearCorotatedModel final
   const T& lame_first_parameter() const { return lambda_; }
 
  private:
-  friend ConstitutiveModel<LinearCorotatedModel<T, num_locations>,
-                           LinearCorotatedModelTraits<T, num_locations>>;
+  friend ConstitutiveModel<LinearCorotatedModel<T>,
+                           LinearCorotatedModelTraits<T>>;
 
   /* Shadows ConstitutiveModel::CalcElasticEnergyDensityImpl() as required by
    the CRTP base class. */
-  void CalcElasticEnergyDensityImpl(const Data& data,
-                                    std::array<T, num_locations>* Psi) const;
+  void CalcElasticEnergyDensityImpl(const Data& data, T* Psi) const;
 
   /* Shadows ConstitutiveModel::CalcFirstPiolaStressImpl() as required by the
    CRTP base class. */
-  void CalcFirstPiolaStressImpl(const Data& data,
-                                std::array<Matrix3<T>, num_locations>* P) const;
+  void CalcFirstPiolaStressImpl(const Data& data, Matrix3<T>* P) const;
 
   /* Shadows ConstitutiveModel::CalcFirstPiolaStressDerivativeImpl() as required
    by the CRTP base class. */
-  void CalcFirstPiolaStressDerivativeImpl(
-      const Data& data,
-      std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const;
+  void CalcFirstPiolaStressDerivativeImpl(const Data& data,
+                                          Eigen::Matrix<T, 9, 9>* dPdF) const;
 
   T E_;       // Young's modulus, N/m².
   T nu_;      // Poisson's ratio.

--- a/multibody/fem/linear_corotated_model_data.h
+++ b/multibody/fem/linear_corotated_model_data.h
@@ -11,13 +11,10 @@ namespace fem {
 namespace internal {
 
 /* Data supporting calculations in LinearCorotatedModel.
- @tparam_nonsymbolic_scalar
- @tparam num_locations Number of locations at which the deformation gradient
- dependent quantities are evaluated. */
-template <typename T, int num_locations>
+ @tparam_nonsymbolic_scalar */
+template <typename T>
 class LinearCorotatedModelData
-    : public DeformationGradientData<
-          LinearCorotatedModelData<T, num_locations>> {
+    : public DeformationGradientData<LinearCorotatedModelData<T>> {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearCorotatedModelData);
 
@@ -26,29 +23,25 @@ class LinearCorotatedModelData
 
   /* Returns the rotation matrices from the polar decomposition of F₀ = R₀*S₀.
    */
-  const std::array<Matrix3<T>, num_locations>& R0() const { return R0_; }
+  const Matrix3<T>& R0() const { return R0_; }
 
   /* Returns the strain matrix 1/2 * (R₀ᵀ * F + Fᵀ * R₀) - I. */
-  const std::array<Matrix3<T>, num_locations>& strain() const {
-    return strain_;
-  }
+  const Matrix3<T>& strain() const { return strain_; }
 
   /* Returns the trace of strain. */
-  const std::array<T, num_locations>& trace_strain() const {
-    return trace_strain_;
-  }
+  const T& trace_strain() const { return trace_strain_; }
 
  private:
   /* Allow base class friend access to the private CalcFooImpl functions. */
-  friend DeformationGradientData<LinearCorotatedModelData<T, num_locations>>;
+  friend DeformationGradientData<LinearCorotatedModelData<T>>;
 
   /* Shadows DeformationGradientData::UpdateFromDeformationGradient() as
    required by the CRTP base class. */
   void UpdateFromDeformationGradient();
 
-  std::array<Matrix3<T>, num_locations> R0_;
-  std::array<Matrix3<T>, num_locations> strain_;
-  std::array<T, num_locations> trace_strain_;
+  Matrix3<T> R0_;
+  Matrix3<T> strain_;
+  T trace_strain_;
 };
 
 }  // namespace internal

--- a/multibody/fem/test/constitutive_model_test.cc
+++ b/multibody/fem/test/constitutive_model_test.cc
@@ -11,17 +11,15 @@ namespace fem {
 namespace internal {
 
 using Eigen::Matrix3d;
-constexpr int kNumLocations = 2;
 
 /* Minimal required data type to be used in the derived constitutive model
  traits. */
-template <typename T, int num_locations_at_compile_time>
-struct DummyData : public DeformationGradientData<
-                       DummyData<T, num_locations_at_compile_time>> {};
+template <typename T>
+struct DummyData : public DeformationGradientData<DummyData<T>> {};
 
 struct InvalidModelTraits {
   using Scalar = double;
-  using Data = DummyData<double, kNumLocations>;
+  using Data = DummyData<double>;
 };
 
 /* ConstitutiveModel requires derived classes to shadow the
@@ -35,25 +33,22 @@ class InvalidModel
 namespace {
 GTEST_TEST(ConstitutiveModelTest, InvalidModel) {
   const InvalidModel model;
-  const DummyData<double, kNumLocations> data;
-  std::array<double, DummyData<double, kNumLocations>::num_locations>
-      energy_density;
+  const DummyData<double> data;
+  double energy_density;
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.CalcElasticEnergyDensity(data, &energy_density),
       fmt::format("The derived class {} must provide a shadow definition of "
                   "CalcElasticEnergyDensityImpl.. to be correct.",
                   NiceTypeName::Get(model)));
 
-  std::array<Matrix3d, DummyData<double, kNumLocations>::num_locations> P;
+  Matrix3d P;
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.CalcFirstPiolaStress(data, &P),
       fmt::format("The derived class {} must provide a shadow definition of "
                   "CalcFirstPiolaStressImpl.. to be correct.",
                   NiceTypeName::Get(model)));
 
-  std::array<Eigen::Matrix<double, 9, 9>,
-             DummyData<double, kNumLocations>::num_locations>
-      dPdF;
+  Eigen::Matrix<double, 9, 9> dPdF;
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.CalcFirstPiolaStressDerivative(data, &dPdF),
       fmt::format("The derived class {} must provide a shadow definition of "

--- a/multibody/fem/test/constitutive_model_test_utilities.h
+++ b/multibody/fem/test/constitutive_model_test_utilities.h
@@ -15,8 +15,7 @@ namespace internal {
 namespace test {
 
 /* Creates an array of arbitrary autodiff deformation gradients. */
-template <int num_locations>
-std::array<Matrix3<AutoDiffXd>, num_locations> MakeDeformationGradients();
+Matrix3<AutoDiffXd> MakeDeformationGradients();
 
 /* Tests the constructor and the accessors for St.Venant-Kirchhoff like
 constitutive models.

--- a/multibody/fem/test/corotated_model_data_test.cc
+++ b/multibody/fem/test/corotated_model_data_test.cc
@@ -12,36 +12,26 @@ namespace fem {
 namespace internal {
 namespace {
 
-constexpr int kNumLocations = 1;
 constexpr double kTol = 1e-14;
-
-void VerifySizes(const CorotatedModelData<double, kNumLocations>& data) {
-  ASSERT_EQ(data.deformation_gradient().size(), kNumLocations);
-  ASSERT_EQ(data.R().size(), kNumLocations);
-  ASSERT_EQ(data.S().size(), kNumLocations);
-  ASSERT_EQ(data.Jm1().size(), kNumLocations);
-  ASSERT_EQ(data.JFinvT().size(), kNumLocations);
-}
 
 /* Tests that the deformation gradient is initialized to the identity matrix and
  the deformation gradient dependent data are initialized to be consistent with
  the initial deformation gradient. */
 GTEST_TEST(CorotatedModelDataTest, Initialization) {
-  const CorotatedModelData<double, kNumLocations> corotated_model_data;
-  VerifySizes(corotated_model_data);
-  EXPECT_TRUE(CompareMatrices(corotated_model_data.deformation_gradient()[0],
+  const CorotatedModelData<double> corotated_model_data;
+  EXPECT_TRUE(CompareMatrices(corotated_model_data.deformation_gradient(),
                               Matrix3<double>::Identity()));
-  EXPECT_TRUE(CompareMatrices(corotated_model_data.R()[0],
-                              Matrix3<double>::Identity()));
-  EXPECT_TRUE(CompareMatrices(corotated_model_data.S()[0],
-                              Matrix3<double>::Identity()));
-  EXPECT_EQ(corotated_model_data.Jm1()[0], 0.0);
-  EXPECT_TRUE(CompareMatrices(corotated_model_data.JFinvT()[0],
+  EXPECT_TRUE(
+      CompareMatrices(corotated_model_data.R(), Matrix3<double>::Identity()));
+  EXPECT_TRUE(
+      CompareMatrices(corotated_model_data.S(), Matrix3<double>::Identity()));
+  EXPECT_EQ(corotated_model_data.Jm1(), 0.0);
+  EXPECT_TRUE(CompareMatrices(corotated_model_data.JFinvT(),
                               Matrix3<double>::Identity()));
 }
 
 GTEST_TEST(CorotatedModelDataTest, UpdateData) {
-  CorotatedModelData<double, kNumLocations> corotated_model_data;
+  CorotatedModelData<double> corotated_model_data;
   /* We set deformation gradient as F = R*S where R is an arbitrary rotation
    matrix and S is an arbitrary sysmmetric positive definite matrix. */
   const Matrix3<double> R =
@@ -57,13 +47,12 @@ GTEST_TEST(CorotatedModelDataTest, UpdateData) {
   const Matrix3<double> F = R * S;
   const Matrix3<double> F0 = F;
 
-  corotated_model_data.UpdateData({F}, {F0});
-  EXPECT_TRUE(
-      CompareMatrices(corotated_model_data.deformation_gradient()[0], F));
-  EXPECT_TRUE(CompareMatrices(corotated_model_data.R()[0], R, kTol));
-  EXPECT_TRUE(CompareMatrices(corotated_model_data.S()[0], S, kTol));
-  EXPECT_NEAR(corotated_model_data.Jm1()[0], S.determinant() - 1.0, 10 * kTol);
-  EXPECT_TRUE(CompareMatrices(corotated_model_data.JFinvT()[0],
+  corotated_model_data.UpdateData(F, F0);
+  EXPECT_TRUE(CompareMatrices(corotated_model_data.deformation_gradient(), F));
+  EXPECT_TRUE(CompareMatrices(corotated_model_data.R(), R, kTol));
+  EXPECT_TRUE(CompareMatrices(corotated_model_data.S(), S, kTol));
+  EXPECT_NEAR(corotated_model_data.Jm1(), S.determinant() - 1.0, 10 * kTol);
+  EXPECT_TRUE(CompareMatrices(corotated_model_data.JFinvT(),
                               F.determinant() * F.inverse().transpose(), kTol));
 }
 

--- a/multibody/fem/test/corotated_model_test.cc
+++ b/multibody/fem/test/corotated_model_test.cc
@@ -10,26 +10,24 @@ namespace fem {
 namespace internal {
 namespace test {
 
-constexpr int kNumLocations = 1;
-
 GTEST_TEST(CorotatedModelTest, Parameters) {
-  TestParameters<CorotatedModel<double, kNumLocations>>();
-  TestParameters<CorotatedModel<AutoDiffXd, kNumLocations>>();
-  CorotatedModel<double, kNumLocations> model(100, 0.4);
+  TestParameters<CorotatedModel<double>>();
+  TestParameters<CorotatedModel<AutoDiffXd>>();
+  CorotatedModel<double> model(100, 0.4);
   EXPECT_FALSE(model.is_linear);
 }
 
 GTEST_TEST(CorotatedModelTest, UndeformedState) {
-  TestUndeformedState<CorotatedModel<double, kNumLocations>>();
-  TestUndeformedState<CorotatedModel<AutoDiffXd, kNumLocations>>();
+  TestUndeformedState<CorotatedModel<double>>();
+  TestUndeformedState<CorotatedModel<AutoDiffXd>>();
 }
 
 GTEST_TEST(CorotatedModelTest, PIsDerivativeOfPsi) {
-  TestPIsDerivativeOfPsi<CorotatedModel<AutoDiffXd, kNumLocations>>();
+  TestPIsDerivativeOfPsi<CorotatedModel<AutoDiffXd>>();
 }
 
 GTEST_TEST(CorotatedModelTest, dPdFIsDerivativeOfP) {
-  TestdPdFIsDerivativeOfP<CorotatedModel<AutoDiffXd, kNumLocations>>();
+  TestdPdFIsDerivativeOfP<CorotatedModel<AutoDiffXd>>();
 }
 
 }  // namespace test

--- a/multibody/fem/test/dummy_element.h
+++ b/multibody/fem/test/dummy_element.h
@@ -40,9 +40,8 @@ struct FemElementTraits<DummyElement<is_linear>> {
   static constexpr int num_dofs = Data::num_dofs;
 
   using ConstitutiveModel =
-      std::conditional_t<is_linear,
-                         LinearConstitutiveModel<T, num_quadrature_points>,
-                         CorotatedModel<T, num_quadrature_points>>;
+      std::conditional_t<is_linear, LinearConstitutiveModel<T>,
+                         CorotatedModel<T>>;
 };
 
 /* A simple FemElement implementation. The calculation methods are implemented

--- a/multibody/fem/test/fem_model_test.cc
+++ b/multibody/fem/test/fem_model_test.cc
@@ -223,8 +223,7 @@ GTEST_TEST(FemModelTest, CalcTangentMatrixNoAutoDiff) {
   using IsoparametricElementType =
       fem::internal::LinearSimplexElement<T, kNaturalDimension,
                                           kSpatialDimension, kNumQuads>;
-  using ConstitutiveModelType =
-      fem::internal::LinearCorotatedModel<T, kNumQuads>;
+  using ConstitutiveModelType = fem::internal::LinearCorotatedModel<T>;
   using FemElementType =
       fem::internal::VolumetricElement<IsoparametricElementType, QuadratureType,
                                        ConstitutiveModelType>;

--- a/multibody/fem/test/linear_constitutive_model_data_test.cc
+++ b/multibody/fem/test/linear_constitutive_model_data_test.cc
@@ -10,30 +10,20 @@ namespace fem {
 namespace internal {
 namespace {
 
-constexpr int kNumLocations = 1;
-
-void VerifySizes(
-    const LinearConstitutiveModelData<double, kNumLocations>& data) {
-  ASSERT_EQ(data.deformation_gradient().size(), kNumLocations);
-  ASSERT_EQ(data.strain().size(), kNumLocations);
-  ASSERT_EQ(data.trace_strain().size(), kNumLocations);
-}
-
 /* Tests that the deformation gradient is initialized to the identity matrix and
  the deformation gradient dependent data are initialized to be consistent with
  the initial deformation gradient. */
 GTEST_TEST(LinearConstitutiveModelDataTest, Initialization) {
-  LinearConstitutiveModelData<double, kNumLocations> linear_elasticity_data;
-  VerifySizes(linear_elasticity_data);
-  EXPECT_TRUE(CompareMatrices(linear_elasticity_data.deformation_gradient()[0],
+  LinearConstitutiveModelData<double> linear_elasticity_data;
+  EXPECT_TRUE(CompareMatrices(linear_elasticity_data.deformation_gradient(),
                               Matrix3<double>::Identity()));
-  EXPECT_TRUE(CompareMatrices(linear_elasticity_data.strain()[0],
+  EXPECT_TRUE(CompareMatrices(linear_elasticity_data.strain(),
                               Matrix3<double>::Zero()));
-  EXPECT_EQ(linear_elasticity_data.trace_strain()[0], 0.0);
+  EXPECT_EQ(linear_elasticity_data.trace_strain(), 0.0);
 }
 
 GTEST_TEST(LinearConstitutiveModelDataTest, UpdateData) {
-  LinearConstitutiveModelData<double, kNumLocations> linear_elasticity_data;
+  LinearConstitutiveModelData<double> linear_elasticity_data;
 
   Matrix3<double> F;
   // clang-format off
@@ -50,13 +40,12 @@ GTEST_TEST(LinearConstitutiveModelDataTest, UpdateData) {
   const double expected_trace_strain = 12.0;
   const auto F0 = F;
 
-  linear_elasticity_data.UpdateData({F}, {F0});
+  linear_elasticity_data.UpdateData(F, F0);
   EXPECT_TRUE(
-      CompareMatrices(linear_elasticity_data.deformation_gradient()[0], F));
-  EXPECT_TRUE(CompareMatrices(linear_elasticity_data.strain()[0],
-                              expected_strain,
+      CompareMatrices(linear_elasticity_data.deformation_gradient(), F));
+  EXPECT_TRUE(CompareMatrices(linear_elasticity_data.strain(), expected_strain,
                               std::numeric_limits<double>::epsilon()));
-  EXPECT_DOUBLE_EQ(linear_elasticity_data.trace_strain()[0],
+  EXPECT_DOUBLE_EQ(linear_elasticity_data.trace_strain(),
                    expected_trace_strain);
 }
 

--- a/multibody/fem/test/linear_constitutive_model_test.cc
+++ b/multibody/fem/test/linear_constitutive_model_test.cc
@@ -10,26 +10,24 @@ namespace fem {
 namespace internal {
 namespace test {
 
-constexpr int kNumLocations = 1;
-
 GTEST_TEST(LinearConstitutiveModelTest, Parameters) {
-  TestParameters<LinearConstitutiveModel<double, kNumLocations>>();
-  TestParameters<LinearConstitutiveModel<AutoDiffXd, kNumLocations>>();
-  LinearConstitutiveModel<double, kNumLocations> model(100, 0.4);
+  TestParameters<LinearConstitutiveModel<double>>();
+  TestParameters<LinearConstitutiveModel<AutoDiffXd>>();
+  LinearConstitutiveModel<double> model(100, 0.4);
   EXPECT_TRUE(model.is_linear);
 }
 
 GTEST_TEST(LinearConstitutiveModelTest, UndeformedState) {
-  TestUndeformedState<LinearConstitutiveModel<double, kNumLocations>>();
-  TestUndeformedState<LinearConstitutiveModel<AutoDiffXd, kNumLocations>>();
+  TestUndeformedState<LinearConstitutiveModel<double>>();
+  TestUndeformedState<LinearConstitutiveModel<AutoDiffXd>>();
 }
 
 GTEST_TEST(LinearConstitutiveModelTest, PIsDerivativeOfPsi) {
-  TestPIsDerivativeOfPsi<LinearConstitutiveModel<AutoDiffXd, kNumLocations>>();
+  TestPIsDerivativeOfPsi<LinearConstitutiveModel<AutoDiffXd>>();
 }
 
 GTEST_TEST(LinearConstitutiveModelTest, dPdFIsDerivativeOfP) {
-  TestdPdFIsDerivativeOfP<LinearConstitutiveModel<AutoDiffXd, kNumLocations>>();
+  TestdPdFIsDerivativeOfP<LinearConstitutiveModel<AutoDiffXd>>();
 }
 
 }  // namespace test

--- a/multibody/fem/test/linear_corotated_model_data_test.cc
+++ b/multibody/fem/test/linear_corotated_model_data_test.cc
@@ -12,38 +12,27 @@ namespace fem {
 namespace internal {
 namespace {
 
-constexpr int kNumLocations = 1;
 constexpr double kTol = 1e-14;
-
-void VerifySizes(const LinearCorotatedModelData<double, kNumLocations>& data) {
-  ASSERT_EQ(data.deformation_gradient().size(), kNumLocations);
-  ASSERT_EQ(data.previous_step_deformation_gradient().size(), kNumLocations);
-  ASSERT_EQ(data.R0().size(), kNumLocations);
-  ASSERT_EQ(data.strain().size(), kNumLocations);
-  ASSERT_EQ(data.trace_strain().size(), kNumLocations);
-}
 
 /* Tests that the deformation gradient is initialized to the identity matrix and
  the deformation gradient dependent data are initialized to be consistent with
  the initial deformation gradient. */
 GTEST_TEST(LinearCorotatedModelDataTest, Initialization) {
-  const LinearCorotatedModelData<double, kNumLocations>
-      linear_corotated_model_data;
-  VerifySizes(linear_corotated_model_data);
+  const LinearCorotatedModelData<double> linear_corotated_model_data;
   EXPECT_TRUE(
-      CompareMatrices(linear_corotated_model_data.deformation_gradient()[0],
+      CompareMatrices(linear_corotated_model_data.deformation_gradient(),
                       Matrix3<double>::Identity()));
-  EXPECT_EQ(linear_corotated_model_data.previous_step_deformation_gradient()[0],
+  EXPECT_EQ(linear_corotated_model_data.previous_step_deformation_gradient(),
             Matrix3<double>::Identity());
-  EXPECT_TRUE(CompareMatrices(linear_corotated_model_data.R0()[0],
+  EXPECT_TRUE(CompareMatrices(linear_corotated_model_data.R0(),
                               Matrix3<double>::Identity()));
-  EXPECT_TRUE(CompareMatrices(linear_corotated_model_data.strain()[0],
+  EXPECT_TRUE(CompareMatrices(linear_corotated_model_data.strain(),
                               Matrix3<double>::Zero()));
-  EXPECT_EQ(linear_corotated_model_data.trace_strain()[0], 0.0);
+  EXPECT_EQ(linear_corotated_model_data.trace_strain(), 0.0);
 }
 
 GTEST_TEST(LinearCorotatedModelDataTest, UpdateData) {
-  LinearCorotatedModelData<double, kNumLocations> linear_corotated_model_data;
+  LinearCorotatedModelData<double> linear_corotated_model_data;
   /* We set deformation gradient as F0 = R0*S0 where R0 is an arbitrary rotation
    matrix and S0 is an arbitrary symmetric positive definite matrix. */
   const Matrix3<double> R0 =
@@ -63,16 +52,16 @@ GTEST_TEST(LinearCorotatedModelDataTest, UpdateData) {
   // clang-format on
   const Matrix3<double> F0 = R0 * S0;
 
-  linear_corotated_model_data.UpdateData({F}, {F0});
-  EXPECT_TRUE(CompareMatrices(
-      linear_corotated_model_data.deformation_gradient()[0], F));
-  EXPECT_EQ(linear_corotated_model_data.previous_step_deformation_gradient()[0],
+  linear_corotated_model_data.UpdateData(F, F0);
+  EXPECT_TRUE(
+      CompareMatrices(linear_corotated_model_data.deformation_gradient(), F));
+  EXPECT_EQ(linear_corotated_model_data.previous_step_deformation_gradient(),
             F0);
-  EXPECT_TRUE(CompareMatrices(linear_corotated_model_data.R0()[0], R0, kTol));
+  EXPECT_TRUE(CompareMatrices(linear_corotated_model_data.R0(), R0, kTol));
   const Matrix3<double> expected_strain =
       0.5 * (R0.transpose() * F + F.transpose() * R0) -
       Matrix3<double>::Identity();
-  EXPECT_NEAR(linear_corotated_model_data.trace_strain()[0],
+  EXPECT_NEAR(linear_corotated_model_data.trace_strain(),
               expected_strain.trace(), kTol);
 }
 

--- a/multibody/fem/test/linear_corotated_model_test.cc
+++ b/multibody/fem/test/linear_corotated_model_test.cc
@@ -10,26 +10,24 @@ namespace fem {
 namespace internal {
 namespace test {
 
-constexpr int kNumLocations = 1;
-
 GTEST_TEST(LinearLinearCorotatedModelTest, Parameters) {
-  TestParameters<LinearCorotatedModel<double, kNumLocations>>();
-  TestParameters<LinearCorotatedModel<AutoDiffXd, kNumLocations>>();
-  LinearCorotatedModel<double, kNumLocations> model(100, 0.4);
+  TestParameters<LinearCorotatedModel<double>>();
+  TestParameters<LinearCorotatedModel<AutoDiffXd>>();
+  LinearCorotatedModel<double> model(100, 0.4);
   EXPECT_TRUE(model.is_linear);
 }
 
 GTEST_TEST(LinearLinearCorotatedModelTest, UndeformedState) {
-  TestUndeformedState<LinearCorotatedModel<double, kNumLocations>>();
-  TestUndeformedState<LinearCorotatedModel<AutoDiffXd, kNumLocations>>();
+  TestUndeformedState<LinearCorotatedModel<double>>();
+  TestUndeformedState<LinearCorotatedModel<AutoDiffXd>>();
 }
 
 GTEST_TEST(LinearLinearCorotatedModelTest, PIsDerivativeOfPsi) {
-  TestPIsDerivativeOfPsi<LinearCorotatedModel<AutoDiffXd, kNumLocations>>();
+  TestPIsDerivativeOfPsi<LinearCorotatedModel<AutoDiffXd>>();
 }
 
 GTEST_TEST(LinearLinearCorotatedModelTest, dPdFIsDerivativeOfP) {
-  TestdPdFIsDerivativeOfP<LinearCorotatedModel<AutoDiffXd, kNumLocations>>();
+  TestdPdFIsDerivativeOfP<LinearCorotatedModel<AutoDiffXd>>();
 }
 
 }  // namespace test

--- a/multibody/fem/test/volumetric_model_test.cc
+++ b/multibody/fem/test/volumetric_model_test.cc
@@ -31,8 +31,7 @@ constexpr int kNumQuads = QuadratureType::num_quadrature_points;
 using AutoDiffIsoparametricElement =
     internal::LinearSimplexElement<AutoDiffXd, kNaturalDimension,
                                    kSpatialDimension, kNumQuads>;
-using AutoDiffConstitutiveModel =
-    internal::LinearConstitutiveModel<AutoDiffXd, kNumQuads>;
+using AutoDiffConstitutiveModel = internal::LinearConstitutiveModel<AutoDiffXd>;
 using AutoDiffElement =
     VolumetricElement<AutoDiffIsoparametricElement, QuadratureType,
                       AutoDiffConstitutiveModel>;
@@ -40,8 +39,7 @@ using AutoDiffElement =
 using DoubleIsoparametricElement =
     internal::LinearSimplexElement<double, kNaturalDimension, kSpatialDimension,
                                    kNumQuads>;
-using DoubleConstitutiveModel =
-    internal::LinearConstitutiveModel<double, kNumQuads>;
+using DoubleConstitutiveModel = internal::LinearConstitutiveModel<double>;
 using DoubleElement =
     VolumetricElement<DoubleIsoparametricElement, QuadratureType,
                       DoubleConstitutiveModel>;

--- a/multibody/fem/volumetric_element.h
+++ b/multibody/fem/volumetric_element.h
@@ -63,7 +63,10 @@ struct VolumetricElementData {
   Vector<T, num_dofs> element_a;
   /* The current locations of the quadrature points in the world frame. */
   std::array<Vector<T, 3>, num_quadrature_points> quadrature_positions;
-  typename ConstitutiveModelType::Data deformation_gradient_data;
+
+  using DeformationGradientData = typename ConstitutiveModelType::Data;
+  std::array<DeformationGradientData, num_quadrature_points>
+      deformation_gradient_data;
   /* The elastic energy density evaluated at quadrature points. Note that this
    is energy per unit of "reference" volume. */
   std::array<T, num_quadrature_points> Psi;
@@ -109,11 +112,6 @@ struct FemElementTraits<VolumetricElement<
           IsoparametricElementType::num_sample_locations,
       "The number of quadrature points of the quadrature rule must be the same "
       "as the number of evaluation locations in the isoparametric element.");
-  static_assert(
-      QuadratureType::num_quadrature_points ==
-          ConstitutiveModelType::num_locations,
-      "The number of quadrature points must be the same as the number of "
-      "locations at which the constitutive model is evaluated.");
   /* Check that the natural dimensions are compatible. */
   static_assert(IsoparametricElementType::natural_dimension ==
                     QuadratureType::natural_dimension,
@@ -409,15 +407,20 @@ class VolumetricElement
         isoparametric_element_.template InterpolateNodalValues<3>(
             element_q_reshaped);
 
-    data.deformation_gradient_data.UpdateData(
-        CalcDeformationGradient(data.element_q),
-        CalcDeformationGradient(data.element_q0));
-    this->constitutive_model().CalcElasticEnergyDensity(
-        data.deformation_gradient_data, &data.Psi);
-    this->constitutive_model().CalcFirstPiolaStress(
-        data.deformation_gradient_data, &data.P);
-    this->constitutive_model().CalcFirstPiolaStressDerivative(
-        data.deformation_gradient_data, &data.dPdF);
+    std::array<Matrix3<T>, num_quadrature_points> F =
+        CalcDeformationGradient(data.element_q);
+    std::array<Matrix3<T>, num_quadrature_points> F0 =
+        CalcDeformationGradient(data.element_q0);
+
+    for (int q = 0; q < num_quadrature_points; ++q) {
+      data.deformation_gradient_data[q].UpdateData(F[q], F0[q]);
+      this->constitutive_model().CalcElasticEnergyDensity(
+          data.deformation_gradient_data[q], &(data.Psi[q]));
+      this->constitutive_model().CalcFirstPiolaStress(
+          data.deformation_gradient_data[q], &(data.P[q]));
+      this->constitutive_model().CalcFirstPiolaStressDerivative(
+          data.deformation_gradient_data[q], &(data.dPdF[q]));
+    }
     return data;
   }
 
@@ -429,9 +432,9 @@ class VolumetricElement
         quadrature_positions = data.quadrature_positions;
     const std::array<Vector<T, num_nodes>, num_quadrature_points>& S =
         isoparametric_element_.GetShapeFunctions();
-    const std::array<Matrix3<T>, num_quadrature_points>& deformation_gradients =
-        data.deformation_gradient_data.deformation_gradient();
     for (int q = 0; q < num_quadrature_points; ++q) {
+      const Matrix3<T>& deformation_gradient =
+          data.deformation_gradient_data[q].deformation_gradient();
       Vector3<T> scaled_force = Vector3<T>::Zero();
       for (const multibody::ForceDensityField<T>* force_density :
            plant_data.force_density_fields) {
@@ -440,7 +443,7 @@ class VolumetricElement
             force_density->density_type() ==
                     multibody::ForceDensityType::kPerReferenceVolume
                 ? 1.0
-                : deformation_gradients[q].determinant();
+                : deformation_gradient.determinant();
         scaled_force += scale *
                         force_density->EvaluateAt(plant_data.plant_context,
                                                   quadrature_positions[q]) *

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -340,7 +340,7 @@ DeformableModel<T>::BuildLinearVolumetricModel(
 }
 
 template <typename T>
-template <template <typename, int> class Model, typename T1>
+template <template <typename> class Model, typename T1>
 typename std::enable_if_t<std::is_same_v<T1, double>, void>
 DeformableModel<T>::BuildLinearVolumetricModelHelper(
     DeformableBodyId id, const geometry::VolumeMesh<double>& mesh,
@@ -355,7 +355,7 @@ DeformableModel<T>::BuildLinearVolumetricModelHelper(
   using IsoparametricElementType =
       fem::internal::LinearSimplexElement<T, kNaturalDimension,
                                           kSpatialDimension, kNumQuads>;
-  using ConstitutiveModelType = Model<T, kNumQuads>;
+  using ConstitutiveModelType = Model<T>;
   static_assert(
       std::is_base_of_v<
           fem::internal::ConstitutiveModel<

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -298,7 +298,7 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
                              const geometry::VolumeMesh<double>& mesh,
                              const fem::DeformableBodyConfig<T>& config);
 
-  template <template <class, int> class Model, typename T1 = T>
+  template <template <class> class Model, typename T1 = T>
   typename std::enable_if_t<std::is_same_v<T1, double>, void>
   BuildLinearVolumetricModelHelper(DeformableBodyId id,
                                    const geometry::VolumeMesh<double>& mesh,


### PR DESCRIPTION
This template parameter is unnecessarily cumbersome and restrictive. With this PR, constitutive models now process deformation gradient data one by one (instead of in batches of a fixed size). This adds no appreciable overhead (except for more function calls), but gives us more flexibility to reuse the class for outside of FEM (e.g. MPM).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21790)
<!-- Reviewable:end -->
