### PR TITLE
[multibody topology] Added Graphviz visualization

### DIFF
--- a/multibody/topology/BUILD.bazel
+++ b/multibody/topology/BUILD.bazel
@@ -36,7 +36,9 @@ drake_cc_library(
     name = "multibody_topology",
     srcs = [
         "link_joint_graph.cc",
+        "link_joint_graph_debug.cc",
         "spanning_forest.cc",
+        "spanning_forest_debug.cc",
         "spanning_forest_mobod.cc",
     ],
     hdrs = [
@@ -73,6 +75,7 @@ drake_cc_googletest(
     name = "spanning_forest_test",
     deps = [
         ":multibody_topology",
+        "//common:temp_directory",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/multibody/topology/link_joint_graph.h
+++ b/multibody/topology/link_joint_graph.h
@@ -4,6 +4,7 @@
 #error Do not include this file. Use "drake/multibody/topology/graph.h".
 #endif
 
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <optional>
@@ -497,6 +498,39 @@ class LinkJointGraph {
     predefined joint type. */
   void ChangeJointType(JointIndex existing_joint_index,
                        const std::string& name_of_new_type);
+
+  // FYI Debugging APIs (including Graphviz-related) are defined in
+  // link_joint_graph_debug.cc.
+
+  /** Generate a graphviz representation of this %LinkJointGraph, with the
+  given label at the top. Will include ephemeral elements if they are
+  available (that is, if the forest is valid)  unless suppressed explicitly.
+  The result is in the "dot" language, see https://graphviz.org. If you
+  write it to some file foo.dot, you can generate a viewable png (for
+  example) using the command `dot -Tpng foo.dot >foo.png`.
+  @see MakeGraphvizFiles() for an easier way to get pngs. */
+  std::string GenerateGraphvizString(
+      std::string_view label, bool include_ephemeral_elements = true) const;
+
+  // TODO(sherm1) This function should be removed or reworked before upgrading
+  //  to Drake public API.
+
+  /** This is a useful debugging and presentation utility for getting
+  viewable "dot diagrams" of the graph and forest. You provide a directory
+  and a base name for the results. This function will generate
+  `basename_graph.png` showing the graph as the user defined it. If the
+  forest has been built, it will also produce `basename_graph+.png` showing
+  the augmented graph with its ephemeral elements, and `basename_forest.png`
+  showing the spanning forest.
+  @param where The directory in which to put the files. If empty, the
+    current directory is used.
+  @param basename The base of the file names to be produced, see above.
+  @returns the absolute path of the directory into which the files were
+    created.
+  @throws std::exception if files can't be created, or the `dot` command
+    fails or isn't in /usr/bin, /usr/local/bin, /opt/homebrew/bin, or /bin. */
+  std::filesystem::path MakeGraphvizFiles(std::filesystem::path where,
+                                          std::string_view basename) const;
 
   // Forest building requires these joint types so they are predefined.
 

--- a/multibody/topology/link_joint_graph_debug.cc
+++ b/multibody/topology/link_joint_graph_debug.cc
@@ -1,0 +1,209 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+
+#include <fmt/format.h>
+
+#include "drake/multibody/topology/forest.h"
+#include "drake/multibody/topology/graph.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// TODO(sherm1) Consider accommodation for colorblind people. Avoid red/green
+//  and/or use line styles. Update the legend.
+
+std::string LinkJointGraph::GenerateGraphvizString(
+    std::string_view label, bool include_ephemeral_elements) const {
+  const bool show_as_modeled = include_ephemeral_elements && forest_is_valid();
+  std::string graphviz = "digraph LinkJointGraph {\n";
+  graphviz += "rankdir=BT;\n";
+  graphviz += "labelloc=t;\n";
+  graphviz += fmt::format("label=\"{}\nLinkJointGraph{}\";\n", label,
+                          show_as_modeled ? "+" : "");
+
+  // Generate a legend.
+  graphviz += "legend [shape=none]\n";
+  graphviz +=
+      "[label=\""
+      "* = massless"
+      "\nL/J(i) link/joint(ordinal)"
+      "\nname:index";
+  if (show_as_modeled) graphviz += "\nred = ephemeral";
+  graphviz += "\"]\n";
+
+  // Link composites are discovered during forest building. If there
+  // is no forest, there will be no composites. But if there are composites
+  // we'd like to draw boxes around them so we'll process composited links
+  // first and then pick up the leftovers below.
+  for (LinkCompositeIndex index{0}; index < ssize(link_composites()); ++index) {
+    const LinkComposite& composite = link_composites(index);
+    // Oddly, in order to get the box and label for a subgraph, the _name_
+    // of the subgraph must begin with "cluster"!
+    graphviz += fmt::format("subgraph cluster{}", index) + " {\n";
+    graphviz += fmt::format("label=\"LinkComposite({}){}\";\n", index,
+                            composite.is_massless ? "*" : "");
+    for (const BodyIndex& link_index : composite.links) {
+      const Link& link = link_by_index(link_index);
+      const bool ephemeral = link_is_ephemeral(link.index());
+      if (ephemeral && !include_ephemeral_elements) continue;
+      graphviz += fmt::format("link{} [label=\"L({}){} {}:{}\"]{};\n",
+                              link.ordinal(), link.ordinal(),
+                              link.is_massless() ? "*" : "", link.name(),
+                              link.index(), ephemeral ? "[color=red]" : "");
+    }
+    graphviz += "}\n";
+  }
+
+  // Now pick up the links that aren't in a composite.
+  for (const Link& link : links()) {
+    if (link.composite().has_value()) continue;
+    const bool ephemeral = link_is_ephemeral(link.index());
+    if (ephemeral && !include_ephemeral_elements) continue;
+    graphviz +=
+        fmt::format("link{} [label=\"L({}){} {}:{}\"]{};\n", link.ordinal(),
+                    link.ordinal(), link.is_massless() ? "*" : "", link.name(),
+                    link.index(), ephemeral ? "[color=red]" : "");
+  }
+
+  // Draw the joints as edges, with various representations. Note that a
+  // loop joint gets retargeted to a shadow body; we show that and also
+  // the original parent/child connection (as a dashed gray edge).
+  for (const Joint& joint : joints()) {
+    const JointTraits& traits = joint_traits(joint.traits_index());
+    const bool ephemeral = joint_is_ephemeral(joint.index());
+    if (ephemeral && !include_ephemeral_elements) continue;
+    const std::string color = ephemeral               ? "red"
+                              : traits.name == "weld" ? "black"
+                                                      : "green";
+
+    const std::string arrow_type = ephemeral               ? "empty"
+                                   : traits.name == "weld" ? "box"
+                                                           : "normal";
+    const std::string style = traits.name == "weld" ? "bold" : "solid";
+
+    const LinkOrdinal parent_ordinal =
+        link_by_index(joint.parent_link_index()).ordinal();
+    const LinkOrdinal child_ordinal =
+        link_by_index(joint.child_link_index()).ordinal();
+
+    // If this is a loop joint one of these links will be revised to
+    // be the shadow link (if we're generating the "as modeled" graph).
+    LinkOrdinal revised_parent_ordinal = parent_ordinal;
+    LinkOrdinal revised_child_ordinal = child_ordinal;
+    if (show_as_modeled && joint.mobod_index().is_valid()) {
+      const SpanningForest::Mobod& mobod = forest().mobods(joint.mobod_index());
+      if (mobod.is_reversed())
+        revised_parent_ordinal = mobod.link_ordinal();
+      else
+        revised_child_ordinal = mobod.link_ordinal();
+    }
+
+    // Draw the effective joint connection.
+    graphviz += fmt::format(
+        "link{} -> link{} [arrowhead={}] [style={}] [fontsize=10] "
+        "[label=\"J({}) {}:{}\n{}\"] [color={}];\n",
+        revised_parent_ordinal, revised_child_ordinal, arrow_type, style,
+        joint.ordinal(), joint.name(), joint.index(),
+        joint_traits(joint.traits_index()).name, color);
+
+    // Draw the original joint connection if we retargeted it to a shadow.
+    if (revised_parent_ordinal != parent_ordinal ||
+        revised_child_ordinal != child_ordinal) {
+      graphviz += fmt::format(
+          "link{} -> link{} [arrowhead={}] [color=gray] [style=dashed] "
+          "[label=\"loop\nJ({})\"] [fontsize=10];\n",
+          parent_ordinal, child_ordinal, arrow_type, joint.ordinal());
+    }
+  }
+
+  // Draw the ephemeral weld constraints added to connect shadow to primary.
+  if (show_as_modeled) {
+    for (const LoopConstraint& constraint : loop_constraints()) {
+      graphviz += fmt::format(
+          "link{} -> link{} [dir=both] [arrowhead=obox] [arrowtail=obox] "
+          "[style=bold] [fontsize=10] [label=\"WELD({})\n{}\"] [color=red]\n",
+          link_by_index(constraint.primary_link()).ordinal(),
+          link_by_index(constraint.shadow_link()).ordinal(), constraint.index(),
+          constraint.name());
+    }
+  }
+
+  graphviz += "}\n";
+  return graphviz;
+}
+
+std::filesystem::path LinkJointGraph::MakeGraphvizFiles(
+    std::filesystem::path where, const std::string_view basename) const {
+  // Find the "dot" command.
+  const std::array<std::string, 4> search{"/usr/bin/dot", "/usr/local/bin/dot",
+                                          "/opt/homebrew/bin/dot", "/bin/dot"};
+  std::string dot_command;
+  for (const auto& command : search) {
+    if (std::filesystem::exists(command)) {
+      dot_command = command;
+      break;
+    }
+  }
+  if (dot_command.empty()) {
+    throw std::runtime_error(fmt::format(
+        "{}(): Graphviz 'dot' is required but missing. It must be in "
+        "{}, {}, {}, or {}. Install it in one of those places if you want to "
+        "use this function. See https://graphviz.org.",
+        __func__, search[0], search[1], search[2], search[3]));
+  }
+
+  // Default to the current directory if none specified.
+  if (where.empty()) where = std::filesystem::current_path();
+
+  // This lambda creates one png given a name and generator. The dot file
+  // is removed after use.
+  auto MakePng = [&dot_command, &where, &basename](
+                     std::string_view suffix,
+                     std::function<std::string()> generate) {
+    // Create the dot file.
+    std::filesystem::path dotname(
+        std::filesystem::absolute(std::filesystem::path(where).append(
+            fmt::format("{}_{}.dot", basename, suffix))));
+    std::ofstream dotfile(dotname);
+    if (!dotfile.good()) {
+      throw std::runtime_error(fmt::format(
+          "MakeGraphvizFiles(): can't create file {}.", dotname.string()));
+    }
+    dotfile << generate();
+    dotfile.close();
+
+    // Convert the dot file to a png.
+    const std::string cmd = fmt::format(
+        "{} -Tpng {} >{}", dot_command, dotname.string(),
+        std::filesystem::path(dotname).replace_extension("png").string());
+    int status = system(cmd.c_str());
+    if (status != 0) {
+      throw std::runtime_error(
+          fmt::format("{}(): failed to execute command\n{}", __func__, cmd));
+    }
+
+    std::filesystem::remove(dotname);
+  };
+
+  MakePng("graph", [this, &basename]() {
+    return GenerateGraphvizString(basename, false);
+  });
+
+  if (forest_is_valid()) {
+    MakePng("graph+", [this, &basename]() {
+      return GenerateGraphvizString(basename, true);
+    });
+
+    MakePng("forest", [this, &basename]() {
+      return forest().GenerateGraphvizString(basename);
+    });
+  }
+
+  return std::filesystem::absolute(where);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -144,9 +144,10 @@ bool SpanningForest::BuildForest() {
   /* Model the World (Link 0) with mobilized body 0. This also starts the 0th
   LinkComposite in the graph and the 0th Welded Mobods group in the Forest.
   (1.1) */
-  data_.mobods.emplace_back(MobodIndex(0), LinkOrdinal(0));
+  Mobod& world = data_.mobods.emplace_back(MobodIndex(0), LinkOrdinal(0));
+  world.has_massful_follower_link_ = true;  // World is heavy!
   data_.welded_mobods.emplace_back(std::vector{MobodIndex(0)});
-  data_.mobods[MobodIndex(0)].welded_mobods_index_ = WeldedMobodsIndex(0);
+  world.welded_mobods_index_ = WeldedMobodsIndex(0);
   mutable_graph().set_primary_mobod_for_link(LinkOrdinal(0), MobodIndex(0),
                                              JointIndex{});
   mutable_graph().CreateWorldLinkComposite();

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -345,6 +345,11 @@ class SpanningForest {
   @pre v_index is in range [0, num_velocities) */
   inline TreeIndex v_to_tree(int v_index) const;
 
+  // FYI Debugging APIs (including Graphviz-related) are defined in
+  // spanning_forest_debug.cc.
+
+  std::string GenerateGraphvizString(std::string_view label) const;
+
   // TODO(sherm1) Remove this.
   // (Testing stub only) Add enough fake elements to the forest to allow
   // testing of the Tree and LoopConstraint APIs.

--- a/multibody/topology/spanning_forest_debug.cc
+++ b/multibody/topology/spanning_forest_debug.cc
@@ -1,0 +1,69 @@
+#include "drake/multibody/topology/forest.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// TODO(sherm1) Consider accommodation for colorblind people. Avoid red/green
+//  and/or use line styles. Update the legend.
+
+std::string SpanningForest::GenerateGraphvizString(
+    std::string_view label) const {
+  std::string graphviz = "digraph SpanningForest {\n";
+  graphviz += "rankdir=BT;\n";
+  graphviz += "labelloc=t;\n";
+  graphviz += fmt::format("label=\"{}\nSpanningForest\";\n", label);
+
+  // Generate a legend.
+  graphviz += "legend [shape=none]\n";
+  graphviz +=
+      "[label=\""
+      "* = massless"
+      "\nred = shadow"
+      "\npurple = reversed"
+      "\"]\n";
+
+  // For each Mobod, draw the body (as a node) and the mobilizer (as an edge).
+  for (const Mobod& mobod : mobods()) {
+    std::string followers;
+    for (LinkOrdinal ordinal : mobod.follower_link_ordinals())
+      followers += fmt::format("L({}) ", ordinal);
+    graphviz += fmt::format(
+        "mobod{} [color={}] [label=\"mobod({}){}\n{}\"];\n", mobod.index(),
+        links(mobod.link_ordinal()).is_shadow() ? "red" : "black",
+        mobod.index(), mobod.has_massful_follower_link() ? "" : "*", followers);
+    if (mobod.is_world()) continue;
+    const Mobod& inboard = mobods(mobod.inboard());
+
+    const std::string color = mobod.is_reversed() ? "purple"
+                              : mobod.is_weld()   ? "black"
+                                                  : "blue";
+    const std::string arrow_type = mobod.is_weld() ? "box" : "normal";
+    const std::string style = mobod.is_weld() ? "bold" : "solid";
+
+    const LinkJointGraph::Joint& joint = joints(mobod.joint_ordinal());
+    graphviz += fmt::format(
+        "mobod{} -> mobod{} [arrowhead={}] [fontsize=10] [style={}]"
+        "[label=\"mobilizer({})\nJ({}) {}{}\nq{} v{}\"] [color={}];\n",
+        inboard.index(), mobod.index(), arrow_type, style, mobod.index(),
+        joint.ordinal(), graph().joint_traits(joint.traits_index()).name,
+        mobod.is_reversed() ? "-R" : "", mobod.q_start(), mobod.v_start(),
+        color);
+  }
+
+  // Draw weld constraints that were added to close loops.
+  for (const LoopConstraint& constraint : loop_constraints()) {
+    graphviz += fmt::format(
+        "mobod{} -> mobod{} [dir=both] [arrowhead=box] [arrowtail=box] "
+        "[style=bold] [fontsize=10] [label=\"WELD({})\n\"] [color=red]\n",
+        constraint.primary_mobod(), constraint.shadow_mobod(),
+        constraint.index());
+  }
+
+  graphviz += "}\n";
+  return graphviz;
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/topology/spanning_forest_mobod.h
+++ b/multibody/topology/spanning_forest_mobod.h
@@ -89,7 +89,7 @@ class SpanningForest::Mobod {
 
   /** Returns all the Links that are mobilized by this %Mobod. If this %Mobod
   represents a LinkComposite, the first Link returned is the "active" Link as
-  returned by link(). There is always at least one Link. */
+  returned by link_ordinal(). There is always at least one Link. */
   const std::vector<LinkOrdinal>& follower_link_ordinals() const {
     DRAKE_ASSERT(!follower_link_ordinals_.empty());
     return follower_link_ordinals_;

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -9,6 +9,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 
 // Tests here are those that require definition of SpanningForest, including
@@ -50,6 +51,7 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_EQ(world_link_index, BodyIndex(0));
   const LinkOrdinal world_link_ordinal = graph.world_link().ordinal();
   EXPECT_EQ(world_link_ordinal, LinkOrdinal(0));
+  EXPECT_FALSE(graph.world_link().is_massless());
 
   // Now build a forest representing the World-only graph.
   EXPECT_TRUE(graph.BuildForest());
@@ -68,6 +70,7 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
 
   // Check that the World-only forest makes sense.
   EXPECT_EQ(ssize(forest.mobods()), 1);
+  EXPECT_TRUE(forest.mobods(world_mobod_index).has_massful_follower_link());
   EXPECT_TRUE(forest.trees().empty());  // World isn't part of a tree.
   EXPECT_TRUE(forest.loop_constraints().empty());
   EXPECT_EQ(forest.height(), 1);
@@ -108,8 +111,8 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_EQ(world.nv_outboard(), 0);
   EXPECT_FALSE(world.has_quaternion());
   EXPECT_EQ(world.num_subtree_mobods(), 1);
-  EXPECT_EQ(world.subtree_velocities(), (std::pair{0, 0}));
-  EXPECT_EQ(world.outboard_velocities(), (std::pair{0, 0}));
+  EXPECT_EQ(world.subtree_velocities(), (pair{0, 0}));
+  EXPECT_EQ(world.outboard_velocities(), (pair{0, 0}));
 
   // Check that if we clear the graph, the forest returns to its invalid
   // condition as above.
@@ -223,7 +226,7 @@ LinkJointGraph MakeMultiBranchGraph(ModelInstanceIndex left,
     graph.AddLink("link" + std::to_string(i), link_to_instance[i]);
 
   // Joints: (Check against left-hand diagram above.)
-  const std::vector<std::pair<int, int>> joints{
+  const std::vector<pair<int, int>> joints{
       {1, 4},  {4, 5}, {4, 6}, {6, 9},  {6, 10},                        // left
       {12, 3}, {3, 8}, {3, 7}, {8, 11}, {11, 13}, {11, 14}, {14, 15}};  // right
   for (int i = 0; i < ssize(joints); ++i) {
@@ -496,8 +499,8 @@ GTEST_TEST(SpanningForest, BaseBodyChoicePolicy) {
   graph.RegisterJointType("revolute", 1, 1);
   for (int i = 1; i <= 10; ++i)
     graph.AddLink("link" + std::to_string(i), default_model_instance());
-  const std::vector<std::pair<int, int>> joints{{2, 1}, {2, 3}, {4, 5}, {6, 5},
-                                                {6, 7}, {8, 9}, {10, 9}};
+  const std::vector<pair<int, int>> joints{{2, 1}, {2, 3}, {4, 5}, {6, 5},
+                                           {6, 7}, {8, 9}, {10, 9}};
   for (int i = 0; i < ssize(joints); ++i) {
     const auto joint = joints[i];
     graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
@@ -505,6 +508,7 @@ GTEST_TEST(SpanningForest, BaseBodyChoicePolicy) {
   }
 
   EXPECT_TRUE(graph.BuildForest());
+
   const SpanningForest& forest = graph.forest();
   EXPECT_EQ(graph.num_user_joints(), 7);
   EXPECT_EQ(ssize(graph.joints()), 10);  // 3 ephemeral base joints
@@ -1106,8 +1110,8 @@ GTEST_TEST(SpanningForest, SimpleTrees) {
         "link" + std::to_string(i), model_instance,
         massless.contains(i) ? LinkFlags::kMassless : LinkFlags::kDefault);
   }
-  const std::vector<std::pair<int, int>> joints{
-      {3, 1}, {3, 2}, {8, 3}, {10, 8}, {10, 9}, {9, 4}, {9, 7}};
+  const std::vector<pair<int, int>> joints{{3, 1},  {3, 2}, {8, 3}, {10, 8},
+                                           {10, 9}, {9, 4}, {9, 7}};
   for (int i = 0; i < 7; ++i) {
     graph.AddJoint("joint" + std::to_string(i), model_instance, "revolute",
                    BodyIndex(joints[i].first), BodyIndex(joints[i].second));
@@ -1190,8 +1194,8 @@ GTEST_TEST(SpanningForest, MasslessLinksChangeLoopBreaking) {
   for (int i = 1; i <= 6; ++i) {
     graph.AddLink("link" + std::to_string(i), model_instance);
   }
-  const std::vector<std::pair<int, int>> joints{{0, 1}, {1, 2}, {2, 3}, {3, 4},
-                                                {0, 5}, {5, 6}, {6, 4}};
+  const std::vector<pair<int, int>> joints{{0, 1}, {1, 2}, {2, 3}, {3, 4},
+                                           {0, 5}, {5, 6}, {6, 4}};
   for (int i = 0; i < 7; ++i) {
     graph.AddJoint("joint" + std::to_string(i), model_instance, "revolute",
                    BodyIndex(joints[i].first), BodyIndex(joints[i].second));
@@ -1379,8 +1383,8 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
   for (int i = 1; i <= 7; ++i)
     graph.AddLink("link" + std::to_string(i), model_instance);
 
-  const std::vector<std::pair<int, int>> joints{{1, 2}, {1, 4}, {1, 3}, {2, 5},
-                                                {4, 7}, {3, 6}, {5, 6}, {7, 6}};
+  const std::vector<pair<int, int>> joints{{1, 2}, {1, 4}, {1, 3}, {2, 5},
+                                           {4, 7}, {3, 6}, {5, 6}, {7, 6}};
   for (int i = 0; i < 8; ++i) {
     graph.AddJoint("joint" + std::to_string(i), model_instance, "revolute",
                    BodyIndex(joints[i].first), BodyIndex(joints[i].second));
@@ -1582,7 +1586,7 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
   graph.AddLink("link3$1", default_model_instance());  // Awkward name!
   graph.AddLink("link2", default_model_instance());
   graph.AddLink("link3", default_model_instance());
-  const std::vector<std::pair<int, int>> joints{{0, 1}, {0, 2}, {1, 3}, {3, 2}};
+  const std::vector<pair<int, int>> joints{{0, 1}, {0, 2}, {1, 3}, {3, 2}};
   for (int i = 0; i < ssize(joints); ++i) {
     const auto joint = joints[i];
     graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
@@ -1590,6 +1594,7 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
   }
 
   EXPECT_TRUE(graph.BuildForest());
+
   const SpanningForest& forest = graph.forest();
   EXPECT_EQ(graph.num_user_joints(), 4);
   EXPECT_EQ(ssize(graph.joints()), 4);
@@ -1696,7 +1701,7 @@ GTEST_TEST(SpanningForest, MasslessLoopAreDetected) {
                   LinkFlags::kMassless);
   }
 
-  const std::vector<std::pair<int, int>> joints{{4, 1}, {4, 3}, {1, 2}, {2, 3}};
+  const std::vector<pair<int, int>> joints{{4, 1}, {4, 3}, {1, 2}, {2, 3}};
   for (int i = 0; i < ssize(joints); ++i) {
     graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
                    "revolute", BodyIndex(joints[i].first),
@@ -1726,7 +1731,7 @@ GTEST_TEST(SpanningForest, MasslessLoopAreDetected) {
                         LinkFlags::kMassless);
   }
 
-  const std::vector<std::pair<int, int>> world_graph_joints{
+  const std::vector<pair<int, int>> world_graph_joints{
       {0, 1}, {0, 3}, {1, 2}, {2, 3}};
   for (int i = 0; i < ssize(world_graph_joints); ++i) {
     world_graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
@@ -1783,8 +1788,8 @@ GTEST_TEST(SpanningForest, LoopWithComposites) {
         massless.contains(i) ? LinkFlags::kMassless : LinkFlags::kDefault);
   }
 
-  const std::vector<std::pair<int, int>> weld_joints{{1, 2}, {3, 4}, {5, 6}};
-  const std::vector<std::pair<int, int>> revolute_joints{
+  const std::vector<pair<int, int>> weld_joints{{1, 2}, {3, 4}, {5, 6}};
+  const std::vector<pair<int, int>> revolute_joints{
       {0, 1}, {2, 3}, {4, 5}, {0, 7}, {7, 8}, {8, 9}, {9, 10}, {6, 10}};
   for (int i = 0; i < ssize(weld_joints); ++i) {
     graph.AddJoint("weld_joint_" + std::to_string(i), model_instance, "weld",
@@ -1802,6 +1807,8 @@ GTEST_TEST(SpanningForest, LoopWithComposites) {
   EXPECT_EQ(ssize(graph.links()), 11);  // counting World
   EXPECT_EQ(ssize(graph.joints()), 11);
   EXPECT_EQ(ssize(graph.loop_constraints()), 0);
+
+  EXPECT_TRUE(graph.BuildForest());
 
   graph.SetGlobalForestBuildingOptions(
       ForestBuildingOptions::kMergeLinkComposites);
@@ -1930,9 +1937,9 @@ GTEST_TEST(SpanningForest, MasslessMergedComposites) {
         massless.contains(i) ? LinkFlags::kMassless : LinkFlags::kDefault);
   }
 
-  const std::vector<std::pair<int, int>> revolute_joints{
-      {0, 1}, {1, 2}, {2, 3}, {5, 7}, {7, 8}, {3, 8}};
-  const std::vector<std::pair<int, int>> weld_joints{{0, 4}, {4, 5}, {4, 6}};
+  const std::vector<pair<int, int>> revolute_joints{{0, 1}, {1, 2}, {2, 3},
+                                                    {5, 7}, {7, 8}, {3, 8}};
+  const std::vector<pair<int, int>> weld_joints{{0, 4}, {4, 5}, {4, 6}};
 
   for (int i = 0; i < ssize(revolute_joints); ++i) {
     graph.AddJoint("joint_" + std::to_string(i), model_instance, "revolute",
@@ -2106,6 +2113,142 @@ GTEST_TEST(SpanningForest, CheckMergingPolicy) {
   graph.ChangeJointFlags(JointIndex(1), JointFlags::kMustBeModeled);
   EXPECT_TRUE(graph.BuildForest());
   EXPECT_EQ(ssize(forest.mobods()), 3);
+}
+
+/* Check just some basic functioning of the Graphviz utilities for visualizing
+the graph and forest. We'll test that we get the expected dot strings for
+a very simple graph, but won't attempt to conjure up complete dot
+strings for every visualization quirk. Those will have to be validated by a
+human looking at the results. We'll also verify that the expected .png files
+are created, but won't look at their contents. */
+GTEST_TEST(SpanningForest, VisualizationWithGraphviz) {
+  const std::string tmpdir = temp_directory();
+  LinkJointGraph graph;
+  graph.RegisterJointType("revolute", 1, 1);
+  const SpanningForest& forest = graph.forest();
+
+  // Input graph:
+  //   {0} {1} -> {2}
+  // Will get an ephemeral floating joint between {0} and {1}.
+  const BodyIndex link1 = graph.AddLink("link1", default_model_instance());
+  const BodyIndex link2 = graph.AddLink("link2", default_model_instance());
+  graph.AddJoint("joint0", default_model_instance(), "revolute", link1, link2);
+  EXPECT_TRUE(graph.BuildForest());
+
+  // This is what we get if only the user elements are to be shown.
+  const char expected_graph[] = R"""(digraph LinkJointGraph {
+rankdir=BT;
+labelloc=t;
+label="GraphvizTest
+LinkJointGraph";
+legend [shape=none]
+[label="* = massless
+L/J(i) link/joint(ordinal)
+name:index"]
+subgraph cluster0 {
+label="LinkComposite(0)";
+link0 [label="L(0) world:0"];
+}
+link1 [label="L(1) link1:1"];
+link2 [label="L(2) link2:2"];
+link1 -> link2 [arrowhead=normal] [style=solid] [fontsize=10] [label="J(0) joint0:0
+revolute"] [color=green];
+}
+)""";
+
+  // This is what we should get if ephemeral elements are shown (the
+  // default behavior).
+  const char expected_augmented_graph[] = R"""(digraph LinkJointGraph {
+rankdir=BT;
+labelloc=t;
+label="GraphvizTest
+LinkJointGraph+";
+legend [shape=none]
+[label="* = massless
+L/J(i) link/joint(ordinal)
+name:index
+red = ephemeral"]
+subgraph cluster0 {
+label="LinkComposite(0)";
+link0 [label="L(0) world:0"];
+}
+link1 [label="L(1) link1:1"];
+link2 [label="L(2) link2:2"];
+link1 -> link2 [arrowhead=normal] [style=solid] [fontsize=10] [label="J(0) joint0:0
+revolute"] [color=green];
+link0 -> link1 [arrowhead=empty] [style=solid] [fontsize=10] [label="J(1) link1:1
+quaternion_floating"] [color=red];
+}
+)""";
+
+  const char expected_forest[] = R"""(digraph SpanningForest {
+rankdir=BT;
+labelloc=t;
+label="GraphvizTest
+SpanningForest";
+legend [shape=none]
+[label="* = massless
+red = shadow
+purple = reversed"]
+mobod0 [color=black] [label="mobod(0)
+L(0) "];
+mobod1 [color=black] [label="mobod(1)
+L(1) "];
+mobod0 -> mobod1 [arrowhead=normal] [fontsize=10] [style=solid][label="mobilizer(1)
+J(1) quaternion_floating
+q0 v0"] [color=blue];
+mobod2 [color=black] [label="mobod(2)
+L(2) "];
+mobod1 -> mobod2 [arrowhead=normal] [fontsize=10] [style=solid][label="mobilizer(2)
+J(0) revolute
+q7 v6"] [color=blue];
+}
+)""";
+
+  EXPECT_EQ(graph.GenerateGraphvizString("GraphvizTest", false),
+            expected_graph);
+  EXPECT_EQ(graph.GenerateGraphvizString("GraphvizTest"),
+            expected_augmented_graph);
+  EXPECT_EQ(forest.GenerateGraphvizString("GraphvizTest"), expected_forest);
+
+  // Returns true if file {tmpdir}/GraphvizTest_{suffix}.{extension} exists.
+  auto exists = [&tmpdir](const char* suffix, const char* extension) {
+    std::filesystem::path name =
+        std::filesystem::path(tmpdir).append("GraphvizTest_");
+    name.concat(suffix);
+    name.replace_extension(extension);
+    return std::filesystem::exists(name);
+  };
+
+  // Make sure we don't already have the .png files.
+  for (const char* suffix : {"graph", "graph+", "forest"})
+    EXPECT_FALSE(exists(suffix, "png"));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      graph.MakeGraphvizFiles("////bad_dir", "bad_file"),
+      "MakeGraphvizFiles.*can't create.*bad_dir/bad_file.*");
+
+  // We can't test running dot if it's not there. This is the documented
+  // search path for MakeGraphvizFiles().
+  if (!std::filesystem::exists("/usr/bin/dot") &&
+      !std::filesystem::exists("/usr/local/bin/dot") &&
+      !std::filesystem::exists("/opt/homebrew/bin/dot") &&
+      !std::filesystem::exists("/bin/dot")) {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        graph.MakeGraphvizFiles(tmpdir, "Anything"),
+        "MakeGraphvizFiles.*dot.*required but missing.*");
+  } else {
+    const std::filesystem::path directory =
+        graph.MakeGraphvizFiles(tmpdir, "GraphvizTest");
+
+    EXPECT_EQ(directory.string(), std::filesystem::absolute(tmpdir).string());
+
+    // Now check that (a) we have .pngs, and (b) we didn't leave any .dot files.
+    for (const char* suffix : {"graph", "graph+", "forest"}) {
+      EXPECT_TRUE(exists(suffix, "png"));
+      EXPECT_FALSE(exists(suffix, "dot"));
+    }
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
This is the 9th installment in the PR train for #20225, following #21755.

For debugging and presentations it is very useful to see the multibody graph and generated spanning forest drawn out with boxes and lines. This PR adds generators for graphviz strings, and a helper function for generating .png files from those. 

This code is still internal so there are no user-visible changes here.

For example, this input graph with two loops:
![DoubleLoop_graph](https://github.com/user-attachments/assets/7d08645e-ea88-49a4-907b-374c3091eae5)

Generates this spanning forest plus welds:
![DoubleLoop_forest](https://github.com/user-attachments/assets/4ad87bbc-6a7c-44ca-b2c9-bef91326b0fc)

A third visualization shows the "augmented graph" including ephemeral elements added as a result of modeling. This shows what had to be done to the input graph in order to model it, in the original link/joint terminology.
![DoubleLoop_graph+](https://github.com/user-attachments/assets/22f65d13-826a-4b3b-b9e2-ee61bbb542e5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21800)
<!-- Reviewable:end -->
