### PR TITLE
[multibody topology] Adds misc algorithms over graph and forest

### DIFF
--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -152,6 +152,55 @@ class SpanningForest {
   using Link = LinkJointGraph::Link;
   using Joint = LinkJointGraph::Joint;
 
+  /** Returns the sequence of mobilized bodies from World to the given mobod B,
+  inclusive of both. The 0th element is always present in the result and is
+  the World (at level 0) with each entry being the Mobod at the next-higher
+  level along the path to B. Cost is O(ℓ) where ℓ is B's level in its tree. */
+  std::vector<MobodIndex> FindPathFromWorld(MobodIndex index) const;
+
+  /** Finds the highest-numbered mobilized body that is common to the paths
+  from each of the given ones to World. Returns World immediately if the bodies
+  are on different trees; otherwise the cost is O(ℓ) where ℓ is the length
+  of the longer path from one of the bodies to the ancestor.
+  @note Because the forest uses depth-first numbering for the Mobods, the
+  highest-numbered Mobod is also the ancestor with the highest level (i.e.,
+  the one farthest from World).
+  @see FindPathsToFirstCommonAncestor() */
+  MobodIndex FindFirstCommonAncestor(MobodIndex mobod1_index,
+                                     MobodIndex mobod2_index) const;
+
+  /** Finds the highest numbered common ancestor to two mobilized bodies and
+  returns the paths to the ancestor from each of them. The mobilizers along
+  the returned paths are the only ones that can affect the _relative_ pose
+  between the given mobilized bodies. The returned paths do not include the
+  ancestor but end with the Mobod whose inboard body is the ancestor. The
+  ancestor Mobod is returned separately as the function return value.
+  Complexity is O(ℓ) where ℓ is the length of the longer path from one of the
+  bodies to the ancestor. Each of the given Mobods will be included in its
+  returned path (as the first entry) except when it is the ancestor, in which
+  case its path will be empty.
+  @note Because the forest uses depth-first numbering for the Mobods, the
+  highest-numbered Mobod is also the ancestor with the highest level (i.e.,
+  the one farthest from World).
+  @param mobod1_index The index of Mobod 1
+  @param mobod2_index The index of Mobod 2
+  @param path1 path to ancestor from Mobod 1, not including the ancestor
+  @param path2 path to ancestor from Mobod 2, not including the ancestor
+  @retval ancestor_index the ancestor mobilized body's index
+  @see FindFirstCommonAncestor() if you don't need the paths
+  @pre indices are valid, path pointers are non-null */
+  MobodIndex FindPathsToFirstCommonAncestor(
+      MobodIndex mobod1_index, MobodIndex mobod2_index,
+      std::vector<MobodIndex>* path1, std::vector<MobodIndex>* path2) const;
+
+  /** Finds all the Links following the Forest subtree whose root mobilized body
+  B is given. That is, we return all the Links that follow B or any other Mobod
+  in the subtree rooted at B. The Links following B come first, and the rest
+  follow the depth-first ordering of the Mobods. In particular, the result is
+  _not_ sorted by LinkIndex. Computational cost is O(ℓ) where ℓ is the number of
+  Links following the subtree. */
+  std::vector<LinkIndex> FindSubtreeLinks(MobodIndex root_mobod_index) const;
+
   /** Returns a reference to the graph that owns this forest (as set during
   construction). */
   const LinkJointGraph& graph() const {
@@ -348,6 +397,12 @@ class SpanningForest {
   // FYI Debugging APIs (including Graphviz-related) are defined in
   // spanning_forest_debug.cc.
 
+  /** Generate a graphviz representation of this %SpanningForest, with the
+  given label at the top. The result is in the "dot" language, see
+  https://graphviz.org. If you write it to some file foo.dot, you can
+  generate a viewable png (for example) using the command
+  `dot -Tpng foo.dot >foo.png`.
+  @see LinkJointGraph::GenerateGraphvizString() */
   std::string GenerateGraphvizString(std::string_view label) const;
 
  private:

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -64,9 +64,9 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_EQ(world_mobod_index, MobodIndex(0));
   EXPECT_EQ(graph.link_to_mobod(world_link_index), MobodIndex(0));
   EXPECT_EQ(ssize(graph.link_composites()), 1);
-  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0)).links), 1);
-  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links[0],
-            world_link_index);
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
+            std::vector{world_link_index});
+  EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(0)).is_massless);
 
   // Check that the World-only forest makes sense.
   EXPECT_EQ(ssize(forest.mobods()), 1);
@@ -78,12 +78,18 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_EQ(forest.welded_mobods()[0][0], world_mobod_index);
   EXPECT_EQ(forest.mobod_to_link_ordinal(world_mobod_index),
             world_link_ordinal);
-  EXPECT_EQ(ssize(forest.mobod_to_link_ordinals(world_mobod_index)), 1);
-  EXPECT_EQ(forest.mobod_to_link_ordinals(world_mobod_index)[0],
-            world_link_ordinal);
+  EXPECT_EQ(forest.mobod_to_link_ordinals(world_mobod_index),
+            std::vector{world_link_ordinal});
   EXPECT_EQ(forest.num_positions(), 0);
   EXPECT_EQ(forest.num_velocities(), 0);
   EXPECT_TRUE(forest.quaternion_starts().empty());
+  EXPECT_EQ(forest.FindPathFromWorld(world_mobod_index),
+            std::vector{world_mobod_index});  // Just World.
+  EXPECT_EQ(forest.FindSubtreeLinks(world_mobod_index),
+            std::vector{world_link_index});
+  EXPECT_EQ(
+      forest.FindFirstCommonAncestor(world_mobod_index, world_mobod_index),
+      world_mobod_index);
 
   // Exercise the Mobod API to check the World Mobod for reasonableness.
   EXPECT_TRUE(world.is_world());
@@ -95,8 +101,7 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_FALSE(world.inboard().is_valid());
   EXPECT_TRUE(world.outboards().empty());
   EXPECT_EQ(world.link_ordinal(), world_link_ordinal);
-  EXPECT_EQ(ssize(world.follower_link_ordinals()), 1);
-  EXPECT_EQ(world.follower_link_ordinals()[0], world_link_ordinal);
+  EXPECT_EQ(world.follower_link_ordinals(), std::vector{world_link_ordinal});
   EXPECT_FALSE(world.joint_ordinal().is_valid());
   EXPECT_FALSE(world.tree().is_valid());
   EXPECT_EQ(world.welded_mobods_group(), WeldedMobodsIndex(0));
@@ -331,10 +336,8 @@ GTEST_TEST(SpanningForest, MultipleBranchesDefaultOptions) {
     EXPECT_EQ(forest.mobod_to_link_ordinal(MobodIndex(mobod_link.first)),
               LinkOrdinal(mobod_link.second));
     // Each Mobod has only a single Link that follows it.
-    EXPECT_EQ(
-        ssize(forest.mobod_to_link_ordinals(MobodIndex(mobod_link.first))), 1);
-    EXPECT_EQ(forest.mobod_to_link_ordinals(MobodIndex(mobod_link.first))[0],
-              LinkOrdinal(mobod_link.second));
+    EXPECT_EQ(forest.mobod_to_link_ordinals(MobodIndex(mobod_link.first)),
+              std::vector{LinkOrdinal(mobod_link.second)});
   }
   EXPECT_EQ(forest.height(), 7);
 
@@ -410,6 +413,27 @@ GTEST_TEST(SpanningForest, MultipleBranchesDefaultOptions) {
   EXPECT_EQ(find_outv(8), pair(18, 6));   // tree1 nonterminal
   EXPECT_EQ(find_outv(10), pair(20, 3));
   EXPECT_EQ(find_outv(14), pair(24, 0));  // tree1 terminal
+
+  const std::vector<MobodIndex> expected_path_from_14{
+      {MobodIndex(0)}, {MobodIndex{7}}, {MobodIndex(8)}, {MobodIndex(14)}};
+  EXPECT_EQ(forest.FindPathFromWorld(MobodIndex(14)), expected_path_from_14);
+
+  // Mobods on different trees have only World as a common ancestor.
+  EXPECT_EQ(forest.FindFirstCommonAncestor(MobodIndex(5), MobodIndex(14)),
+            MobodIndex(0));
+
+  // Check that long/short and short/long branch ordering both work since
+  // they are handled by different code.
+  EXPECT_EQ(forest.FindFirstCommonAncestor(MobodIndex(13), MobodIndex(14)),
+            MobodIndex(8));  // See right hand drawing above.
+  EXPECT_EQ(forest.FindFirstCommonAncestor(MobodIndex(14), MobodIndex(13)),
+            MobodIndex(8));
+
+  // Check special case: if either body is World the answer is World.
+  EXPECT_EQ(forest.FindFirstCommonAncestor(MobodIndex(0), MobodIndex(13)),
+            MobodIndex(0));
+  EXPECT_EQ(forest.FindFirstCommonAncestor(MobodIndex(14), MobodIndex(0)),
+            MobodIndex(0));
 }
 
 /* Starting with the same graph as the previous test, change the tree1
@@ -466,19 +490,16 @@ GTEST_TEST(SpanningForest, MultipleBranchesBaseJointOptions) {
 
   // There is only the World composite, but now tree1's base link is included.
   EXPECT_EQ(ssize(graph.link_composites()), 1);  // just World
-  EXPECT_EQ(ssize(graph.link_composites(LinkCompositeIndex(0)).links), 2);
-  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links[0],
-            graph.world_link().index());
-  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links[1],
-            graph.links(tree1.front().link_ordinal()).index());
+  EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
+            (std::vector{graph.world_link().index(),
+                         graph.links(tree1.front().link_ordinal()).index()}));
+  EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(0)).is_massless);
 
   // Similarly, there is only one WeldedMobods group, containing just World
-  // and tree1's base
-  EXPECT_EQ(ssize(forest.welded_mobods()), 1);
-  EXPECT_EQ(ssize(forest.welded_mobods(WeldedMobodsIndex(0))), 2);
-  EXPECT_EQ(forest.welded_mobods(WeldedMobodsIndex(0))[0],
-            forest.world_mobod().index());
-  EXPECT_EQ(forest.welded_mobods(WeldedMobodsIndex(0))[1], tree1.base_mobod());
+  // and tree1's base.
+  EXPECT_EQ(forest.welded_mobods(),
+            (std::vector<std::vector<MobodIndex>>{
+                {forest.world_mobod().index(), tree1.base_mobod()}}));
 }
 
 /* Verify that our base body choice policy works as intended. The policy
@@ -718,6 +739,12 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_EQ(forest.world_mobod().nv_outboard(), forest.num_velocities());
   EXPECT_EQ(forest.world_mobod().num_subtree_mobods(), ssize(forest.mobods()));
 
+  EXPECT_EQ(
+      graph.FindSubtreeLinks(graph.world_link().index()),
+      (std::vector{LinkIndex(0), LinkIndex(1), LinkIndex(2), LinkIndex(3),
+                   LinkIndex(4), LinkIndex(5), LinkIndex(7), LinkIndex(6),
+                   LinkIndex(8), LinkIndex(11), LinkIndex(10), LinkIndex(9)}));
+
   // Counts for generic middle Mobod.
   const SpanningForest::Mobod& mobod_for_link3 =
       forest.mobods(graph.link_by_index(LinkIndex(3)).mobod_index());
@@ -731,6 +758,8 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_EQ(mobod_for_link3.nq_outboard(), 2);
   EXPECT_EQ(mobod_for_link3.nv_outboard(), 2);
   EXPECT_EQ(mobod_for_link3.num_subtree_mobods(), 3);
+  EXPECT_EQ(graph.FindSubtreeLinks(LinkIndex(3)),
+            (std::vector{LinkIndex(3), LinkIndex(4), LinkIndex(5)}));
 
   // Counts for a Mobod with nq != nv.
   const SpanningForest::Mobod& mobod_for_base11 =
@@ -744,6 +773,8 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_EQ(mobod_for_base11.nq_outboard(), 0);
   EXPECT_EQ(mobod_for_base11.nv_outboard(), 0);
   EXPECT_EQ(mobod_for_base11.num_subtree_mobods(), 2);
+  EXPECT_EQ(graph.FindSubtreeLinks(LinkIndex(11)),
+            (std::vector{LinkIndex(11), LinkIndex(10)}));
 
   const std::vector<MobodIndex> welded_mobods0{MobodIndex(0), MobodIndex(6),
                                                MobodIndex(7), MobodIndex(8)};
@@ -797,6 +828,16 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_EQ(ssize(forest.mobods()), 8);
   EXPECT_EQ(ssize(forest.trees()), 3);
   EXPECT_EQ(ssize(forest.welded_mobods()), 1);  // Just World.
+
+  // Starting with a Link somewhere in a composite, we should get all the
+  // Links on that composite followed by anything outboard.
+  EXPECT_EQ(graph.FindSubtreeLinks(LinkIndex(10)),
+            (std::vector{LinkIndex(11), LinkIndex(10)}));
+  EXPECT_EQ(
+      graph.FindSubtreeLinks(LinkIndex(6)),
+      (std::vector{LinkIndex(0), LinkIndex(7), LinkIndex(6), LinkIndex(8),
+                   LinkIndex(1), LinkIndex(2), LinkIndex(3), LinkIndex(4),
+                   LinkIndex(5), LinkIndex(11), LinkIndex(10), LinkIndex(9)}));
 
   /* SerialChain 3 (merge composites except for 10 & 11)
   ------------------------------------------------------
@@ -996,6 +1037,23 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
   EXPECT_EQ(ssize(graph.links()), 14);  // Includes World.
   EXPECT_EQ(ssize(graph.joints()), 14);
 
+  // We can calculate the subgraphs without first building a Forest. This
+  // function should only consider user Links, not shadow links even if they
+  // have already been created.
+  // {0 5 7 12} {1 4 13} {6 8 10} {2} {3} {9} {11}  (see first drawing above)
+  const std::vector<std::set<LinkIndex>> expected_before_subgraphs{
+      {LinkIndex(0), LinkIndex(5), LinkIndex(7), LinkIndex(12)},
+      {LinkIndex(1), LinkIndex(4), LinkIndex(13)},
+      {LinkIndex(6), LinkIndex(8), LinkIndex(10)},
+      {LinkIndex(2)},
+      {LinkIndex(3)},
+      {LinkIndex(9)},
+      {LinkIndex(11)}};
+  const std::vector<std::set<LinkIndex>> before_subgraphs =
+      graph.CalcSubgraphsOfWeldedLinks();
+  EXPECT_EQ(before_subgraphs.size(), 7);
+  EXPECT_EQ(before_subgraphs, expected_before_subgraphs);
+
   EXPECT_TRUE(graph.BuildForest());
   const SpanningForest& forest = graph.forest();
 
@@ -1026,10 +1084,107 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
       EXPECT_EQ(graph.link_composites(c).links[link], expected_links[c][link]);
   }
 
+  // After building the Forest and adding shadow bodies, the non-Forest-using
+  // subgraph method should not change its result. The Forest-using fast one
+  // will include Shadow Links as well as the user's.
+  EXPECT_EQ(graph.CalcSubgraphsOfWeldedLinks(),
+            expected_before_subgraphs);  // no change
+
+  const std::vector<std::set<LinkIndex>> welded_subgraphs =
+      graph.GetSubgraphsOfWeldedLinks();
+
+  // Verify number of expected subgraphs.
+  EXPECT_EQ(welded_subgraphs.size(), 8);
+
+  // The first subgraph must contain the world.
+  const std::set<LinkIndex> world_subgraph = welded_subgraphs[0];
+  EXPECT_EQ(world_subgraph.count(world_index()), 1);
+
+  // Build the expected set of subgraphs (see above).
+  std::set<std::set<LinkIndex>> expected_subgraphs;
+  // {0, 5, 7, 12}, {1, 4, 13, 15}, {6, 8, 10, 16}, {3}, {9}, {2}, {11}, {14}
+  const std::set<LinkIndex>& expected_world_subgraph =
+      *expected_subgraphs
+           .insert({LinkIndex(0), LinkIndex(5), LinkIndex(7), LinkIndex(12)})
+           .first;
+  const std::set<LinkIndex>& expected_subgraphA =
+      *expected_subgraphs
+           .insert({LinkIndex(1), LinkIndex(4), LinkIndex(13), LinkIndex(15)})
+           .first;
+  const std::set<LinkIndex>& expected_subgraphB =
+      *expected_subgraphs
+           .insert({LinkIndex(6), LinkIndex(8), LinkIndex(10), LinkIndex(16)})
+           .first;
+  expected_subgraphs.insert({LinkIndex(3)});
+  expected_subgraphs.insert({LinkIndex(9)});
+  expected_subgraphs.insert({LinkIndex(2)});
+  expected_subgraphs.insert({LinkIndex(11)});
+  expected_subgraphs.insert({LinkIndex(14)});
+
+  // We do expect the first subgraph to correspond to the set of bodies welded
+  // to the world.
+  EXPECT_EQ(world_subgraph, expected_world_subgraph);
+
+  // In order to compare the computed list of welded bodies against the expected
+  // list, irrespective of the ordering in the computed list, we first convert
+  // the computed subgraphs to a set.
+  const std::set<std::set<LinkIndex>> welded_subgraphs_set(
+      welded_subgraphs.begin(), welded_subgraphs.end());
+  EXPECT_EQ(welded_subgraphs_set, expected_subgraphs);
+
+  // Verify we can query the list of bodies welded to a particular Link.
+  EXPECT_EQ(graph.GetLinksWeldedTo(LinkIndex(9)).size(), 1);
+  EXPECT_EQ(graph.GetLinksWeldedTo(LinkIndex(11)).size(), 1);
+  EXPECT_EQ(graph.GetLinksWeldedTo(LinkIndex(4)), expected_subgraphA);
+  EXPECT_EQ(graph.GetLinksWeldedTo(LinkIndex(13)), expected_subgraphA);
+  EXPECT_EQ(graph.GetLinksWeldedTo(LinkIndex(10)), expected_subgraphB);
+  EXPECT_EQ(graph.GetLinksWeldedTo(LinkIndex(6)), expected_subgraphB);
+
   // Now let's verify that we got the expected SpanningForest. To understand,
   // refer to the 6-level forest diagram above.
   EXPECT_EQ(ssize(forest.mobods()), 17);
   EXPECT_EQ(ssize(forest.loop_constraints()), 3);
+
+  // Note that this is a question about how these Links got modeled, not
+  // about the original graph.
+  EXPECT_EQ(graph.FindFirstCommonAncestor(LinkIndex(11), LinkIndex(12)),
+            LinkIndex(5));
+  EXPECT_EQ(graph.FindFirstCommonAncestor(LinkIndex(16), LinkIndex(15)),
+            LinkIndex(13));
+  EXPECT_EQ(graph.FindFirstCommonAncestor(LinkIndex(10), LinkIndex(2)),
+            LinkIndex(0));
+
+  // Repeat but this time collect the paths to the ancestor.
+  std::vector<MobodIndex> path1, path2;
+
+  // Check with path1 longer.
+  EXPECT_EQ(
+      forest.FindPathsToFirstCommonAncestor(
+          graph.link_by_index(LinkIndex(11)).mobod_index(),
+          graph.link_by_index(LinkIndex(12)).mobod_index(), &path1, &path2),
+      graph.link_by_index(LinkIndex(5)).mobod_index());
+  EXPECT_EQ(path1, (std::vector<MobodIndex>{MobodIndex(5), MobodIndex(2)}));
+  EXPECT_EQ(path2, (std::vector<MobodIndex>{MobodIndex(6)}));
+
+  // Check with path2 longer.
+  EXPECT_EQ(
+      forest.FindPathsToFirstCommonAncestor(
+          graph.link_by_index(LinkIndex(15)).mobod_index(),
+          graph.link_by_index(LinkIndex(16)).mobod_index(), &path1, &path2),
+      graph.link_by_index(LinkIndex(13)).mobod_index());
+  EXPECT_EQ(path1, (std::vector<MobodIndex>{MobodIndex(15), MobodIndex(14)}));
+  EXPECT_EQ(path2, (std::vector<MobodIndex>{MobodIndex(12), MobodIndex(11),
+                                            MobodIndex(10), MobodIndex(9)}));
+
+  EXPECT_EQ(
+      forest.FindPathsToFirstCommonAncestor(
+          graph.link_by_index(LinkIndex(10)).mobod_index(),
+          graph.link_by_index(LinkIndex(2)).mobod_index(), &path1, &path2),
+      graph.link_by_index(LinkIndex(0)).mobod_index());
+  EXPECT_EQ(path1, (std::vector<MobodIndex>{MobodIndex(10), MobodIndex(9),
+                                            MobodIndex(8), MobodIndex(7)}));
+  EXPECT_EQ(path2, (std::vector<MobodIndex>{MobodIndex(3), MobodIndex(2),
+                                            MobodIndex(1)}));
 
   // Expected level for each mobod in forest (index by MobodIndex).
   std::array<int, 17> expected_level{0, 1, 2, 3, 4, 3, 2, 1, 2,
@@ -1999,8 +2154,7 @@ GTEST_TEST(SpanningForest, MasslessMergedComposites) {
   EXPECT_EQ(shadow_link.index(), LinkIndex(9));
   EXPECT_EQ(shadow_link.primary_link(), LinkIndex(3));
   EXPECT_EQ(shadow_link.mobod_index(), MobodIndex(6));
-  ASSERT_EQ(ssize(shadow_link.joints()), 1);
-  EXPECT_EQ(shadow_link.joints()[0], JointIndex(5));
+  EXPECT_EQ(shadow_link.joints(), std::vector{JointIndex(5)});
 
   ASSERT_EQ(ssize(graph.link_composites()), 1);  // just the world composite
   EXPECT_EQ(


### PR DESCRIPTION
This is the 10th installment in the PR train for #20225, following #21800.

Adds simple algorithms that act on LinkJointGraphs or SpanningForests. These are needed by MultibodyPlant for the switchover to the new topology code. The current signatures are chosen for compatibility with existing MbP functions that are being replaced. These will likely be improved later (they are all internal). For example, some of them use sets unnecessarily or define ordering expectations ("sorted by BodyIndex", e.g.) that may not be necessary.

### What's here

```
LinkJointGraph::
   // Fast functions that depend on the forest having been built.
 - FindPathFromWorld(link) -> vector<link>
 - FindFirstCommonAncestor(link1, link2) -> link
 - FindSubtreeLinks(link) -> vector<link>
 - GetSubgraphsOfWeldedLinks() -> vector<set<link>>
 - GetLinksWeldedTo(link) -> set<link>

   // Slow functions that can be used before the forest is built, i.e. pre-finalize.
 - CalcSubgraphsOfWeldedLinks() -> vector<set<link>>
 - CalcLinksWeldedTo(link) -> set<link>

SpanningForest::
 - FindPathFromWorld(mobod) -> vector<mobod>
 - FindFirstCommonAncestor(mobod1, mobod2) -> mobod
 - FindPathsToFirstCommonAncestor(mobod1, mobod2, &path1, &path2) -> mobod
 - FindSubtreeLinks(mobod) -> vector<link>
```

Unit tests are in `link_joint_graph_test.cc` and `spanning_forest_test.cc`, resp. I added them to existing tests since they need graphs and forests to work on.

There are no user-visible changes here; everything is internal. MultibodyPlant continues to use the old topology code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21806)
<!-- Reviewable:end -->
