### PR TITLE
Introduce ComputePairwiseIntersections with New Return Type, Towards Replacing CalcPairwiseIntersections

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -4,6 +4,7 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/identifier_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/sorted_pair_pybind.h"
@@ -1346,59 +1347,133 @@ void DefineGeometryOptimization(py::module m) {
       doc.PartitionConvexSet
           .doc_3args_convex_sets_continuous_revolute_joints_epsilon);
   m.def(
-      "CalcPairwiseIntersections",
+      "ComputePairwiseIntersections",
       [](const std::vector<ConvexSet*>& convex_sets_A,
           const std::vector<ConvexSet*>& convex_sets_B,
           const std::vector<int>& continuous_revolute_joints,
           bool preprocess_bbox) {
-        return CalcPairwiseIntersections(CloneConvexSets(convex_sets_A),
+        return ComputePairwiseIntersections(CloneConvexSets(convex_sets_A),
             CloneConvexSets(convex_sets_B), continuous_revolute_joints,
             preprocess_bbox);
       },
       py::arg("convex_sets_A"), py::arg("convex_sets_B"),
       py::arg("continuous_revolute_joints"), py::arg("preprocess_bbox") = true,
-      doc.CalcPairwiseIntersections
+      doc.ComputePairwiseIntersections
           .doc_4args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  m.def("CalcPairwiseIntersections",
+      WrapDeprecated(
+          doc.CalcPairwiseIntersections
+              .doc_deprecated_deprecated_4args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox,
+          [](const std::vector<ConvexSet*>& convex_sets_A,
+              const std::vector<ConvexSet*>& convex_sets_B,
+              const std::vector<int>& continuous_revolute_joints,
+              bool preprocess_bbox) {
+            return CalcPairwiseIntersections(CloneConvexSets(convex_sets_A),
+                CloneConvexSets(convex_sets_B), continuous_revolute_joints,
+                preprocess_bbox);
+          }),
+      py::arg("convex_sets_A"), py::arg("convex_sets_B"),
+      py::arg("continuous_revolute_joints"), py::arg("preprocess_bbox") = true,
+      doc.CalcPairwiseIntersections
+          .doc_deprecated_deprecated_4args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox);
+#pragma GCC diagnostic pop
   m.def(
-      "CalcPairwiseIntersections",
+      "ComputePairwiseIntersections",
       [](const std::vector<ConvexSet*>& convex_sets_A,
           const std::vector<ConvexSet*>& convex_sets_B,
           const std::vector<int>& continuous_revolute_joints,
           const std::vector<Hyperrectangle>& bboxes_A,
           const std::vector<Hyperrectangle>& bboxes_B) {
-        return CalcPairwiseIntersections(CloneConvexSets(convex_sets_A),
+        return ComputePairwiseIntersections(CloneConvexSets(convex_sets_A),
             CloneConvexSets(convex_sets_B), continuous_revolute_joints,
             bboxes_A, bboxes_B);
       },
       py::arg("convex_sets_A"), py::arg("convex_sets_B"),
       py::arg("continuous_revolute_joints"), py::arg("bboxes_A"),
       py::arg("bboxes_B"),
-      doc.CalcPairwiseIntersections
+      doc.ComputePairwiseIntersections
           .doc_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  m.def("CalcPairwiseIntersections",
+      WrapDeprecated(
+          doc.CalcPairwiseIntersections
+              .doc_deprecated_deprecated_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B,
+          [](const std::vector<ConvexSet*>& convex_sets_A,
+              const std::vector<ConvexSet*>& convex_sets_B,
+              const std::vector<int>& continuous_revolute_joints,
+              const std::vector<Hyperrectangle>& bboxes_A,
+              const std::vector<Hyperrectangle>& bboxes_B) {
+            return CalcPairwiseIntersections(CloneConvexSets(convex_sets_A),
+                CloneConvexSets(convex_sets_B), continuous_revolute_joints,
+                bboxes_A, bboxes_B);
+          }),
+      py::arg("convex_sets_A"), py::arg("convex_sets_B"),
+      py::arg("continuous_revolute_joints"), py::arg("bboxes_A"),
+      py::arg("bboxes_B"),
+      doc.CalcPairwiseIntersections
+          .doc_deprecated_deprecated_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B);
+#pragma GCC diagnostic pop
   m.def(
-      "CalcPairwiseIntersections",
+      "ComputePairwiseIntersections",
       [](const std::vector<ConvexSet*>& convex_sets,
           const std::vector<int>& continuous_revolute_joints,
           bool preprocess_bbox) {
-        return CalcPairwiseIntersections(CloneConvexSets(convex_sets),
+        return ComputePairwiseIntersections(CloneConvexSets(convex_sets),
             continuous_revolute_joints, preprocess_bbox);
       },
       py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
       py::arg("preprocess_bbox") = true,
-      doc.CalcPairwiseIntersections
+      doc.ComputePairwiseIntersections
           .doc_3args_convex_sets_continuous_revolute_joints_preprocess_bbox);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  m.def("CalcPairwiseIntersections",
+      WrapDeprecated(
+          doc.CalcPairwiseIntersections
+              .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_preprocess_bbox,
+          [](const std::vector<ConvexSet*>& convex_sets,
+              const std::vector<int>& continuous_revolute_joints,
+              bool preprocess_bbox) {
+            return CalcPairwiseIntersections(CloneConvexSets(convex_sets),
+                continuous_revolute_joints, preprocess_bbox);
+          }),
+      py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
+      py::arg("preprocess_bbox") = true,
+      doc.CalcPairwiseIntersections
+          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_preprocess_bbox);
+#pragma GCC diagnostic pop
   m.def(
-      "CalcPairwiseIntersections",
+      "ComputePairwiseIntersections",
       [](const std::vector<ConvexSet*>& convex_sets,
           const std::vector<int>& continuous_revolute_joints,
           const std::vector<Hyperrectangle>& bboxes) {
-        return CalcPairwiseIntersections(
+        return ComputePairwiseIntersections(
             CloneConvexSets(convex_sets), continuous_revolute_joints, bboxes);
       },
       py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
       py::arg("bboxes") = std::vector<Hyperrectangle>{},
-      doc.CalcPairwiseIntersections
+      doc.ComputePairwiseIntersections
           .doc_3args_convex_sets_continuous_revolute_joints_bboxes);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  m.def("CalcPairwiseIntersections",
+      WrapDeprecated(
+          doc.CalcPairwiseIntersections
+              .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_bboxes,
+          [](const std::vector<ConvexSet*>& convex_sets,
+              const std::vector<int>& continuous_revolute_joints,
+              const std::vector<Hyperrectangle>& bboxes) {
+            return CalcPairwiseIntersections(CloneConvexSets(convex_sets),
+                continuous_revolute_joints, bboxes);
+          }),
+      py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
+      py::arg("bboxes") = std::vector<Hyperrectangle>{},
+      doc.CalcPairwiseIntersections
+          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_bboxes);
+#pragma GCC diagnostic pop
   // NOLINTNEXTLINE(readability/fn_size)
 }
 

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -7,6 +7,7 @@ import copy
 import numpy as np
 
 from pydrake.common import RandomGenerator, temp_directory
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.geometry import (
     Box, Capsule, Cylinder, Convex, Ellipsoid, FramePoseVector, GeometryFrame,
@@ -1429,30 +1430,72 @@ class TestCspaceFreePolytope(unittest.TestCase):
             self.assertTrue(bbox_B is not None)
         outputs = []
         outputs.append(
-                mut.CalcPairwiseIntersections(convex_sets_A=sets_A,
-                                              convex_sets_B=sets_B,
-                                              continuous_revolute_joints=[0],
-                                              preprocess_bbox=True))
+                mut.ComputePairwiseIntersections(
+                        convex_sets_A=sets_A,
+                        convex_sets_B=sets_B,
+                        continuous_revolute_joints=[0],
+                        preprocess_bbox=True))
         outputs.append(
-                mut.CalcPairwiseIntersections(convex_sets_A=sets_A,
-                                              convex_sets_B=sets_B,
-                                              continuous_revolute_joints=[0],
-                                              bboxes_A=bboxes_A,
-                                              bboxes_B=bboxes_B))
+                mut.ComputePairwiseIntersections(
+                        convex_sets_A=sets_A,
+                        convex_sets_B=sets_B,
+                        continuous_revolute_joints=[0],
+                        bboxes_A=bboxes_A,
+                        bboxes_B=bboxes_B))
+        outputs.append(
+                mut.ComputePairwiseIntersections(
+                        convex_sets=sets_A,
+                        continuous_revolute_joints=[0],
+                        preprocess_bbox=True))
+        outputs.append(
+                mut.ComputePairwiseIntersections(
+                        convex_sets=sets_A,
+                        continuous_revolute_joints=[0],
+                        bboxes=bboxes_A))
         for out in outputs:
+            self.assertIsInstance(out, tuple)
+            self.assertIsInstance(out[0], list)
+            self.assertTrue(len(out[0]) > 0)
+            self.assertEqual(len(out[0]), 2)
+            self.assertIsInstance(out[0][0][0], int)
+            self.assertIsInstance(out[0][0][1], int)
+            self.assertTrue(len(out[1]) > 0)
+            self.assertIsInstance(out[1][0], np.ndarray)
+
+        outputs = []
+        with catch_drake_warnings(expected_count=1):
+            outputs.append(
+                    mut.CalcPairwiseIntersections(
+                            convex_sets_A=sets_A,
+                            convex_sets_B=sets_B,
+                            continuous_revolute_joints=[0],
+                            preprocess_bbox=True))
+        with catch_drake_warnings(expected_count=1):
+            outputs.append(
+                    mut.CalcPairwiseIntersections(
+                            convex_sets_A=sets_A,
+                            convex_sets_B=sets_B,
+                            continuous_revolute_joints=[0],
+                            bboxes_A=bboxes_A,
+                            bboxes_B=bboxes_B))
+        with catch_drake_warnings(expected_count=1):
+            outputs.append(
+                    mut.CalcPairwiseIntersections(
+                            convex_sets=sets_A,
+                            continuous_revolute_joints=[0],
+                            preprocess_bbox=True))
+        with catch_drake_warnings(expected_count=1):
+            outputs.append(
+                    mut.CalcPairwiseIntersections(
+                            convex_sets=sets_A,
+                            continuous_revolute_joints=[0],
+                            bboxes=bboxes_A))
+        for out in outputs:
+            print(out)
             self.assertIsInstance(out, list)
-            self.assertEqual(len(out), 2)
-            self.assertIsInstance(out[0], tuple)
-        outputs2 = []
-        outputs2.append(
-                mut.CalcPairwiseIntersections(convex_sets=sets_A,
-                                              continuous_revolute_joints=[0],
-                                              preprocess_bbox=True))
-        outputs2.append(
-                mut.CalcPairwiseIntersections(convex_sets=sets_A,
-                                              continuous_revolute_joints=[0],
-                                              bboxes=bboxes_A))
-        for out in outputs2:
-            self.assertIsInstance(out, list)
-            self.assertEqual(len(out), 2)
-            self.assertIsInstance(out[0], tuple)
+            for elt in out:
+                self.assertIsInstance(elt, tuple)
+                self.assertEqual(len(elt), 3)
+                self.assertIsInstance(elt[0], int)
+                self.assertIsInstance(elt[1], int)
+                self.assertIsInstance(elt[2], np.ndarray)

--- a/geometry/optimization/geodesic_convexity.cc
+++ b/geometry/optimization/geodesic_convexity.cc
@@ -283,11 +283,39 @@ std::vector<Hyperrectangle> BoundingBoxesForListOfSetsSomeDimensions(
   }
   return bboxes;
 }
+
+/* Convenience function to change the new type standard for edges and their
+offsets to the old standard, simplifying the deprecated versions of the
+functions. */
+std::vector<std::tuple<int, int, Eigen::VectorXd>> ReorganizeEdgesAndOffsets(
+    std::vector<std::pair<int, int>> edges,
+    std::vector<Eigen::VectorXd> edge_offsets) {
+  // TODO(cohnt): This entire function can be removed when
+  // CalcPairwiseIntersections is removed.
+  DRAKE_DEMAND(edges.size() == edge_offsets.size());
+  std::vector<std::tuple<int, int, Eigen::VectorXd>> reorganized_edges;
+  for (int i = 0; i < ssize(edges); ++i) {
+    reorganized_edges.emplace_back(edges[i].first, edges[i].second,
+                                   edge_offsets[i]);
+  }
+  return reorganized_edges;
+}
 }  // namespace
 
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets_A, const ConvexSets& convex_sets_B,
     const std::vector<int>& continuous_revolute_joints, bool preprocess_bbox) {
+  auto [edges, edge_offsets] =
+      ComputePairwiseIntersections(convex_sets_A, convex_sets_B,
+                                   continuous_revolute_joints, preprocess_bbox);
+  return ReorganizeEdgesAndOffsets(edges, edge_offsets);
+}
+
+std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
+ComputePairwiseIntersections(const ConvexSets& convex_sets_A,
+                             const ConvexSets& convex_sets_B,
+                             const std::vector<int>& continuous_revolute_joints,
+                             bool preprocess_bbox) {
   DRAKE_THROW_UNLESS(convex_sets_A.size() > 0);
   DRAKE_THROW_UNLESS(convex_sets_B.size() > 0);
   const int dimension = convex_sets_A[0]->ambient_dimension();
@@ -327,7 +355,7 @@ std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     }
   }
 
-  return CalcPairwiseIntersections(
+  return ComputePairwiseIntersections(
       convex_sets_A, convex_sets_B, continuous_revolute_joints, bboxes_A,
       convex_sets_A_and_B_are_identical ? bboxes_A : bboxes_B);
 }
@@ -337,6 +365,18 @@ std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const std::vector<int>& continuous_revolute_joints,
     const std::vector<Hyperrectangle>& bboxes_A,
     const std::vector<Hyperrectangle>& bboxes_B) {
+  auto [edges, edge_offsets] = ComputePairwiseIntersections(
+      convex_sets_A, convex_sets_B, continuous_revolute_joints, bboxes_A,
+      bboxes_B);
+  return ReorganizeEdgesAndOffsets(edges, edge_offsets);
+}
+
+std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
+ComputePairwiseIntersections(const ConvexSets& convex_sets_A,
+                             const ConvexSets& convex_sets_B,
+                             const std::vector<int>& continuous_revolute_joints,
+                             const std::vector<Hyperrectangle>& bboxes_A,
+                             const std::vector<Hyperrectangle>& bboxes_B) {
   DRAKE_THROW_UNLESS(convex_sets_A.size() > 0);
   DRAKE_THROW_UNLESS(convex_sets_B.size() > 0);
   DRAKE_THROW_UNLESS(convex_sets_A.size() == bboxes_A.size());
@@ -359,8 +399,10 @@ std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     }
   }
 
-  std::vector<std::tuple<int, int, Eigen::VectorXd>> edges;
+  std::vector<std::pair<int, int>> edges;
+  std::vector<Eigen::VectorXd> edge_offsets;
 
+  // TODO(wrangelvid): This is O(n^2) and can be improved.
   VectorXd offset = Eigen::VectorXd::Zero(dimension);
   for (int i = 0; i < ssize(convex_sets_A); ++i) {
     for (int j = 0; j < ssize(convex_sets_B); ++j) {
@@ -444,30 +486,50 @@ std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
         // Regions are overlapping, add edge (i, j). If we're adding edges
         // within convex_sets_A, also add edge (j, i), since edges are
         // considered bidirectional in that context.
-        edges.emplace_back(i, j, offset);
+        edges.emplace_back(i, j);
+        edge_offsets.emplace_back(offset);
         if (convex_sets_A_and_B_are_identical) {
-          edges.emplace_back(j, i, -offset);
+          edges.emplace_back(j, i);
+          edge_offsets.emplace_back(-offset);
         }
       }
     }
   }
 
-  return edges;
+  return {edges, edge_offsets};
 }
 
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets,
     const std::vector<int>& continuous_revolute_joints, bool preprocess_bbox) {
-  return CalcPairwiseIntersections(convex_sets, convex_sets,
-                                   continuous_revolute_joints, preprocess_bbox);
+  auto [edges, edge_offsets] = ComputePairwiseIntersections(
+      convex_sets, continuous_revolute_joints, preprocess_bbox);
+  return ReorganizeEdgesAndOffsets(edges, edge_offsets);
+}
+
+std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
+ComputePairwiseIntersections(const ConvexSets& convex_sets,
+                             const std::vector<int>& continuous_revolute_joints,
+                             bool preprocess_bbox) {
+  return ComputePairwiseIntersections(
+      convex_sets, convex_sets, continuous_revolute_joints, preprocess_bbox);
 }
 
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets,
     const std::vector<int>& continuous_revolute_joints,
     const std::vector<Hyperrectangle>& bboxes) {
-  return CalcPairwiseIntersections(convex_sets, convex_sets,
-                                   continuous_revolute_joints, bboxes, bboxes);
+  auto [edges, edge_offsets] = ComputePairwiseIntersections(
+      convex_sets, continuous_revolute_joints, bboxes);
+  return ReorganizeEdgesAndOffsets(edges, edge_offsets);
+}
+
+std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
+ComputePairwiseIntersections(const ConvexSets& convex_sets,
+                             const std::vector<int>& continuous_revolute_joints,
+                             const std::vector<Hyperrectangle>& bboxes) {
+  return ComputePairwiseIntersections(
+      convex_sets, convex_sets, continuous_revolute_joints, bboxes, bboxes);
 }
 
 }  // namespace optimization

--- a/geometry/optimization/geodesic_convexity.h
+++ b/geometry/optimization/geodesic_convexity.h
@@ -15,6 +15,7 @@ of robots. */
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/hyperrectangle.h"
 #include "drake/geometry/optimization/intersection.h"
@@ -130,16 +131,49 @@ geometry::optimization::ConvexSets PartitionConvexSet(
     const std::vector<int>& continuous_revolute_joints,
     const double epsilon = 1e-5);
 
-/** Computes the pairwise intersections edges between two lists of convex sets.
-Each edge is a tuple in the form [index_A, index_B, offset_A_to_B], where
-Each is a tuple in the form [index_A, index_B, offset_A_to_B],
-where index_A is the index of the list in `convex_sets_A`, index_B is the
-index of the list in `convex_sets_B`, and offset_A_to_B is is the translation
-to applied to all the points in the index_A'th set in `convex_sets_A` to align
-them with the index_B'th set in `convex_sets_B`. This translation may only have
-non-zero entries along the dimensions corresponding to @p
-continuous_revolute_joints. All non-zero entries are integer multiples of 2π as
-the translation of the sets still represents the same configurations for the
+/** Computes the pairwise intersections between two lists of convex sets,
+returning a list of edges, and a list of their corresponding offsets. Each edge
+is a tuple in the form [index_A, index_B], where index_A is the index of the set
+in `convex_sets_A` and index_B is the index of the set in `convex_sets_B`. The
+corresponding entry in the list of offsets (i.e., the entry at the same index)
+is the translation that is applied to all the points in the index_A'th set in
+`convex_sets_A` to align them with the index_B'th set in `convex_sets_B`. This
+translation may only have non-zero entries along the dimensions corresponding to
+`continuous_revolute_joints`. All non-zero entries are integer multiples of 2π
+as the translation of the sets still represents the same configurations for the
+indices in `continuous_revolute_joints`.
+
+@param convex_sets_A is a vector of convex sets. Pairwise intersections will be
+computed between `convex_sets_A` and `convex_sets_B`.
+@param convex_sets_B is the other vector of convex sets.
+@param continuous_revolute_joints is a list of joint indices corresponding to
+continuous revolute joints.
+@param preprocess_bbox is a flag for whether the function should precompute
+axis-aligned bounding boxes (AABBs) for every set. This can speed up the
+pairwise intersection checks, by determining some sets to be disjoint without
+needing to solve an optimization problem. However, it does require some overhead
+to compute those bounding boxes.
+
+@throws if `continuous_revolute_joints` has repeated entries, or if any entry
+is outside the interval [0, ambient_dimension), where ambient_dimension is the
+ambient dimension of the convex sets in `convex_sets_A` and `convex_sets_B`.
+@throws if `convex_sets_A` or `convex_sets_B` are empty.
+*/
+std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
+ComputePairwiseIntersections(const ConvexSets& convex_sets_A,
+                             const ConvexSets& convex_sets_B,
+                             const std::vector<int>& continuous_revolute_joints,
+                             bool preprocess_bbox = true);
+
+/** Computes the pairwise intersections between two lists of convex sets,
+returning a list of edges. Each edge is a tuple in the form [index_A, index_B,
+offset_A_to_B], where index_A is the index of the list in `convex_sets_A`,
+index_B is the index of the list in `convex_sets_B`, and offset_A_to_B is is the
+translation to applied to all the points in the index_A'th set in
+`convex_sets_A` to align them with the index_B'th set in `convex_sets_B`. This
+translation may only have non-zero entries along the dimensions corresponding to
+`continuous_revolute_joints`. All non-zero entries are integer multiples of 2π
+as the translation of the sets still represents the same configurations for the
 indices in `continuous_revolute_joints`.
 
 @param convex_sets_A is a vector of convex sets. Pairwise intersections will be
@@ -157,10 +191,36 @@ to compute those bounding boxes.
 is outside the interval [0, ambient_dimension), where ambient_dimension is the
 ambient dimension of the convex sets in `convex_sets_A` and `convex_sets_B`.
 @throws if `convex_sets_A` or `convex_sets_B` are empty. */
+DRAKE_DEPRECATED("2024-12-01",
+                 "Instead use ComputePairwiseIntersections, with return type "
+                 "std::pair<std::vector<std::pair<int, int>>, "
+                 "std::vector<Eigen::VectorXd>>.")
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets_A, const ConvexSets& convex_sets_B,
     const std::vector<int>& continuous_revolute_joints,
     bool preprocess_bbox = true);
+
+/** Overload of `ComputePairwiseIntersections` allowing the user to supply axis-
+aligned bounding boxes if they're known a priori, to save on computation time.
+
+@param bboxes_A is a vector of Hyperrectangles, allowing the user to manually
+pass in the AABBs of each set in `convex_sets_A` to avoid recomputation.
+@param bboxes_B serves the same role to `convex_sets_B` as `bboxes_A` does to
+`convex_sets_A`.
+
+@warning The function does not check that the entries of bboxes_A are indeed the
+AABBs corresponding to the sets in `convex_sets_A` (and likewise for bboxes_B).
+
+@throws if `convex_sets_A.size() != bboxes_A.size()`
+@throws if `convex_sets_B.size() != bboxes_B.size()`
+@throws if not all entries of `convex_sets_A`, `convex_sets_B`, `bboxes_A`, and
+`bboxes_B` have the same ambient dimension. */
+std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
+ComputePairwiseIntersections(
+    const ConvexSets& convex_sets_A, const ConvexSets& convex_sets_B,
+    const std::vector<int>& continuous_revolute_joints,
+    const std::vector<geometry::optimization::Hyperrectangle>& bboxes_A,
+    const std::vector<geometry::optimization::Hyperrectangle>& bboxes_B);
 
 /** Overload of `CalcPairwiseIntersections` allowing the user to supply axis-
 aligned bounding boxes if they're known a priori, to save on computation time.
@@ -177,11 +237,38 @@ AABBs corresponding to the sets in `convex_sets_A` (and likewise for bboxes_B).
 @throws if `convex_sets_B.size() != bboxes_B.size()`
 @throws if not all entries of `convex_sets_A`, `convex_sets_B`, `bboxes_A`, and
 `bboxes_B` have the same ambient dimension. */
+DRAKE_DEPRECATED("2024-12-01",
+                 "Instead use ComputePairwiseIntersections, with return type "
+                 "std::pair<std::vector<std::pair<int, int>>, "
+                 "std::vector<Eigen::VectorXd>>.")
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets_A, const ConvexSets& convex_sets_B,
     const std::vector<int>& continuous_revolute_joints,
     const std::vector<geometry::optimization::Hyperrectangle>& bboxes_A,
     const std::vector<geometry::optimization::Hyperrectangle>& bboxes_B);
+
+/** Convenience overload to compute pairwise intersections within a list of
+convex sets. Equivalent to calling ComputePairwiseIntersections(convex_sets,
+convex_sets, continuous_revolute_joints).
+
+@param convex_sets is a vector of convex sets. Pairwise intersections will be
+computed within `convex_sets`.
+@param continuous_revolute_joints is a list of joint indices corresponding to
+continuous revolute joints.
+@param preprocess_bbox is a flag for whether the function should precompute
+axis-aligned bounding boxes for every set. This can speed up the pairwise
+intersection checks, by determining some sets to be disjoint without needing
+to solve an optimization problem.
+
+@throws if `continuous_revolute_joints` has repeated entries, or if any entry
+is outside the interval [0, ambient_dimension), where ambient_dimension is the
+ambient dimension of the convex sets in `convex_sets`.
+@throws if `convex_sets` is empty.
+*/
+std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
+ComputePairwiseIntersections(const ConvexSets& convex_sets,
+                             const std::vector<int>& continuous_revolute_joints,
+                             bool preprocess_bbox = true);
 
 /** Convenience overload to compute pairwise intersections within a list of
 convex sets. Equivalent to calling CalcPairwiseIntersections(convex_sets,
@@ -200,10 +287,32 @@ to solve an optimization problem.
 is outside the interval [0, ambient_dimension), where ambient_dimension is the
 ambient dimension of the convex sets in `convex_sets`.
 @throws if `convex_sets` is empty. */
+DRAKE_DEPRECATED("2024-12-01",
+                 "Instead use ComputePairwiseIntersections, with return type "
+                 "std::pair<std::vector<std::pair<int, int>>, "
+                 "std::vector<Eigen::VectorXd>>.")
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets,
     const std::vector<int>& continuous_revolute_joints,
     bool preprocess_bbox = true);
+
+/** Overload of `ComputePairwiseIntersections` allowing the user to supply axis-
+aligned bounding boxes if they're known a priori, to save on computation time.
+
+@param bboxes is a vector of Hyperrectangles, allowing the user to manually pass
+in the AABBs of each set in `convex_sets` to avoid recomputation.
+
+@warning The function does not check that the entries are indeed the AABBs
+corresponding to the sets in `convex_sets`.
+
+@throws if `convex_sets.size() != bboxes.size()`
+@throws if not all entries of `convex_sets` and `bboxes` have the same
+ambient dimension.*/
+std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
+ComputePairwiseIntersections(
+    const ConvexSets& convex_sets,
+    const std::vector<int>& continuous_revolute_joints,
+    const std::vector<geometry::optimization::Hyperrectangle>& bboxes);
 
 /** Overload of `CalcPairwiseIntersections` allowing the user to supply axis-
 aligned bounding boxes if they're known a priori, to save on computation time.
@@ -217,6 +326,10 @@ corresponding to the sets in `convex_sets`.
 @throws if `convex_sets.size() != bboxes.size()`
 @throws if not all entries of `convex_sets` and `bboxes` have the same
 ambient dimension. */
+DRAKE_DEPRECATED("2024-12-01",
+                 "Instead use ComputePairwiseIntersections, with return type "
+                 "std::pair<std::vector<std::pair<int, int>>, "
+                 "std::vector<Eigen::VectorXd>>.")
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets,
     const std::vector<int>& continuous_revolute_joints,

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -34,9 +34,9 @@ using drake::solvers::VectorXDecisionVariable;
 using Eigen::MatrixXd;
 using Eigen::SparseMatrix;
 using Eigen::VectorXd;
-using geometry::optimization::CalcPairwiseIntersections;
 using geometry::optimization::CartesianProduct;
 using geometry::optimization::CheckIfSatisfiesConvexityRadius;
+using geometry::optimization::ComputePairwiseIntersections;
 using geometry::optimization::ConvexSet;
 using geometry::optimization::ConvexSets;
 using geometry::optimization::GraphOfConvexSets;
@@ -783,30 +783,35 @@ EdgesBetweenSubgraphs::EdgesBetweenSubgraphs(
     }
   }
 
-  std::vector<std::tuple<int, int, Eigen::VectorXd>> edge_data;
+  // These will hold the edge data if they weren't given as arguments.
+  std::vector<std::pair<int, int>> maybe_edges_between_regions;
+  std::vector<Eigen::VectorXd> maybe_edge_offsets;
+
   if (edges_between_regions) {
-    edge_data.reserve(edges_between_regions->size());
-    for (int edge_idx = 0; edge_idx < ssize(*edges_between_regions);
-         ++edge_idx) {
-      int i = std::get<0>((*edges_between_regions)[edge_idx]);
-      int j = std::get<1>((*edges_between_regions)[edge_idx]);
+    for (const auto& [i, j] : *edges_between_regions) {
       DRAKE_THROW_UNLESS(0 <= i && 0 <= j && i < from_subgraph_.size() &&
                          j < to_subgraph_.size());
-      edge_data.emplace_back(i, j,
-                             edge_offsets ? edge_offsets->at(edge_idx)
-                                          : VectorXd::Zero(num_positions()));
     }
   } else {
-    // TODO(cohnt): Make the return type of CalcPairwiseIntersections match the
-    // argument to this function, so this block of code can be simplified.
-    edge_data = CalcPairwiseIntersections(from_subgraph.regions(),
-                                          to_subgraph.regions(),
-                                          continuous_revolute_joints());
+    std::tie(maybe_edges_between_regions, maybe_edge_offsets) =
+        ComputePairwiseIntersections(from_subgraph.regions(),
+                                     to_subgraph.regions(),
+                                     continuous_revolute_joints());
+    DRAKE_DEMAND(maybe_edges_between_regions.size() ==
+                 maybe_edge_offsets.size());
+    edges_between_regions = &maybe_edges_between_regions;
+    edge_offsets = &maybe_edge_offsets;
   }
-  for (const auto& edge : edge_data) {
-    int i = std::get<0>(edge);
-    int j = std::get<1>(edge);
-    Eigen::VectorXd edge_offset = std::get<2>(edge);
+
+  for (int edge_idx = 0; edge_idx < ssize(*edges_between_regions); ++edge_idx) {
+    int i = (*edges_between_regions)[edge_idx].first;
+    int j = (*edges_between_regions)[edge_idx].second;
+    // If the user specified edges_between_regions but not edge_offsets, then
+    // edge_offsets are implicitly assumed to be zero. That is indicated here by
+    // edge_offsets being nullptr.
+    const Eigen::VectorXd& edge_offset =
+        edge_offsets ? (*edge_offsets)[edge_idx]
+                     : Eigen::VectorXd::Zero(num_positions());
 
     // Check if the overlap between the sets is contained in the subspace.
     if (subspace != nullptr) {
@@ -1463,22 +1468,9 @@ Subgraph& GcsTrajectoryOptimization::AddRegions(const ConvexSets& regions,
                                                 int order, double h_min,
                                                 double h_max,
                                                 std::string name) {
-  // TODO(wrangelvid): This is O(n^2) and can be improved.
   DRAKE_DEMAND(regions.size() > 0);
-
-  const std::vector<std::tuple<int, int, Eigen::VectorXd>> edge_data =
-      CalcPairwiseIntersections(regions, continuous_revolute_joints());
-
-  std::vector<std::pair<int, int>> edges_between_regions;
-  std::vector<Eigen::VectorXd> edge_offsets;
-  edges_between_regions.reserve(edge_data.size());
-  edge_offsets.reserve(edge_data.size());
-  for (int i = 0; i < ssize(edge_data); ++i) {
-    edges_between_regions.emplace_back(std::get<0>(edge_data[i]),
-                                       std::get<1>(edge_data[i]));
-    edge_offsets.emplace_back(std::get<2>(edge_data[i]));
-  }
-
+  auto [edges_between_regions, edge_offsets] =
+      ComputePairwiseIntersections(regions, continuous_revolute_joints());
   return GcsTrajectoryOptimization::AddRegions(regions, edges_between_regions,
                                                order, h_min, h_max,
                                                std::move(name), &edge_offsets);


### PR DESCRIPTION
Per a discussion with @sadraddini in #21723, it makes much more sense for the `CalcPairwiseIntersections` method to have return type `std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>` instead of `std::vector<std::tuple<int, int, Eigen::VectorXd>>`. There are many use cases where one only needs the data stored in the `int` fields, and the `Eigen::VectorXd` fields will be uniformly zero, so changing the return type makes things easier for the user. This also removes a lot of boilerplate code in `gcs_trajectory_optimization.cc`, switching back and forth between these two representations of the data.

[Per a discussion in Drake developers](https://drakedevelopers.slack.com/archives/C3YB3EV5W/p1723490834845309), we determined the best way to accomplish this change is to introduce a new function, `ComputePairwiseIntersections`, which has the proper return type, and deprecate (and eventually remove) the obsolete `CalcPairwiseIntersections`. This pull request implements that change, via the following specific steps:

- Create the new `ComputePairwiseIntersections` function, with all corresponding overloads to match `CalcPairwiseIntersections`.
- Rewrite `CalcPairwiseIntersections` to call `ComputePairwiseIntersections`, and add a deprecation notice. This included the creation of a new function with internal linkage, `ReorganizeEdgesAndOffsets`, that can be removed together with `CalcPairwiseIntersections`.
- Update all relevant tests in `geodesic_convexity_test.cc` to use `ComputePairwiseIntersections`, and add deprecation tests for `CalcPairwiseIntersections`.
- Update code in `gcs_trajectory_optimization.cc` to use `ComputePairwiseIntersections`.
- Add python bindings for `ComputePairwiseIntersections`, and deprecate python bindings for `CalcPairwiseIntersections`.

Gonna go ahead and assign +@sadraddini for feature review, but feel free to reassign if you don't have time or don't feel sufficiently familiar with Drake's deprecation practices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21807)
<!-- Reviewable:end -->
