### PR TITLE
Correct MultibodyPlant free body documentation to reflect current implementations

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -435,11 +435,31 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("SetFreeBodyPose",
             overload_cast_explicit<void, Context<T>*, const RigidBody<T>&,
                 const RigidTransform<T>&>(&Class::SetFreeBodyPose),
+            py::arg("context"), py::arg("body"), py::arg("X_PB"),
+            cls_doc.SetFreeBodyPose.doc_3args)
+        .def("SetFreeBodyPose",
+            WrapDeprecated(
+                "\nDRAKE_DEPRECATED: a free body pose is defined in the parent "
+                "frame P which might not be the world. Use the parameter X_PB "
+                "instead.\nThe deprecated code will be removed from Drake on "
+                "or after 2024-12-01.",
+                overload_cast_explicit<void, Context<T>*, const RigidBody<T>&,
+                    const RigidTransform<T>&>(&Class::SetFreeBodyPose)),
             py::arg("context"), py::arg("body"), py::arg("X_WB"),
             cls_doc.SetFreeBodyPose.doc_3args)
         .def("SetDefaultFreeBodyPose", &Class::SetDefaultFreeBodyPose,
-            py::arg("body"), py::arg("X_WB"),
+            py::arg("body"), py::arg("X_PB"),
             cls_doc.SetDefaultFreeBodyPose.doc)
+        .def("SetDefaultFreeBodyPose",
+            WrapDeprecated(
+                "\nDRAKE_DEPRECATED: a free body pose is defined in the parent "
+                "frame P which might not be the world. Use the parameter X_PB "
+                "instead.\nThe deprecated code will be removed from Drake on "
+                "or after 2024-12-01.",
+                overload_cast_explicit<void, const RigidBody<T>&,
+                    const RigidTransform<double>&>(
+                    &Class::SetDefaultFreeBodyPose)),
+            py::arg("body"), py::arg("X_WB"), cls_doc.SetFreeBodyPose.doc_3args)
         .def("GetDefaultFreeBodyPose", &Class::GetDefaultFreeBodyPose,
             py::arg("body"), cls_doc.GetDefaultFreeBodyPose.doc)
         .def("SetActuationInArray", &Class::SetActuationInArray,
@@ -508,6 +528,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 const SpatialVelocity<T>& V_WB, Context<T>* context) {
               self->SetFreeBodySpatialVelocity(context, body, V_WB);
             },
+            py::arg("body"), py::arg("V_PB"), py::arg("context"),
+            cls_doc.SetFreeBodySpatialVelocity.doc_3args)
+        .def("SetFreeBodySpatialVelocity",
+            WrapDeprecated(
+                "\nDRAKE_DEPRECATED: a free body pose is defined in the parent "
+                "frame P which might not be the world. Use the parameter V_PB "
+                "instead.\nThe deprecated code will be removed from Drake on "
+                "or after 2024-12-01.",
+                [](const Class* self, const RigidBody<T>& body,
+                    const SpatialVelocity<T>& V_WB, Context<T>* context) {
+                  self->SetFreeBodySpatialVelocity(context, body, V_WB);
+                }),
             py::arg("body"), py::arg("V_WB"), py::arg("context"),
             cls_doc.SetFreeBodySpatialVelocity.doc_3args)
         .def("HasUniqueFreeBaseBody", &Class::HasUniqueFreeBaseBody,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1346,8 +1346,16 @@ class TestPlant(unittest.TestCase):
         # Set pose for the base.
         X_WB_desired = RigidTransform.Identity()
         X_WB = plant.CalcRelativeTransform(context, world_frame, base_frame)
+
+        # After 2024-12-01 deprecation is complete, we can remove this because
+        # we don't have to confirm which overload gets defaulted without
+        # parameters.
+        plant.SetFreeBodyPose(context, base, X_WB_desired)
         plant.SetFreeBodyPose(
-            context=context, body=base, X_WB=X_WB_desired)
+            context=context, body=base, X_PB=X_WB_desired)
+        with catch_drake_warnings(expected_count=1):
+            plant.SetFreeBodyPose(
+                context=context, body=base, X_WB=X_WB_desired)
         numpy_compare.assert_float_equal(
             X_WB.GetAsMatrix4(),
             numpy_compare.to_float(X_WB_desired.GetAsMatrix4()))
@@ -1369,14 +1377,31 @@ class TestPlant(unittest.TestCase):
 
         # Set a spatial velocity for the base.
         v_WB = SpatialVelocity(w=[1, 2, 3], v=[4, 5, 6])
+        v_I = SpatialVelocity(w=[0, 0, 0], v=[0, 0, 0])
+
+        def validate_spatial_velocity(context, body, v_WB_ref):
+            v_body = plant.EvalBodySpatialVelocityInWorld(context, body)
+            numpy_compare.assert_float_equal(
+                v_body.rotational(),
+                numpy_compare.to_float(v_WB_ref.rotational()))
+            numpy_compare.assert_float_equal(
+                v_body.translational(),
+                numpy_compare.to_float(v_WB_ref.translational()))
+
+        # After 2024-12-01 deprecation is complete, we can remove this because
+        # we don't have to confirm which overload gets defaulted without
+        # parameters.
+        plant.SetFreeBodySpatialVelocity(base, v_WB, context)
+        validate_spatial_velocity(context, base, v_WB)
+
         plant.SetFreeBodySpatialVelocity(
-            context=context, body=base, V_WB=v_WB)
-        v_base = plant.EvalBodySpatialVelocityInWorld(context, base)
-        numpy_compare.assert_float_equal(
-                v_base.rotational(), numpy_compare.to_float(v_WB.rotational()))
-        numpy_compare.assert_float_equal(
-                v_base.translational(),
-                numpy_compare.to_float(v_WB.translational()))
+            context=context, body=base, V_PB=v_I)
+        validate_spatial_velocity(context, base, v_I)
+
+        with catch_drake_warnings(expected_count=1):
+            plant.SetFreeBodySpatialVelocity(
+                context=context, body=base, V_WB=v_WB)
+            validate_spatial_velocity(context, base, v_WB)
 
         # Compute accelerations.
         vdot = np.zeros(nv)
@@ -1513,8 +1538,24 @@ class TestPlant(unittest.TestCase):
         body = plant.AddRigidBody("body")
         plant.Finalize()
         # Test existence of default free body pose setting.
-        X_WB_default = RigidTransform_[float]()
-        plant.SetDefaultFreeBodyPose(body=body, X_WB=X_WB_default)
+        X_WB_default = RigidTransform_[float]([1, 2, 3])
+        Identity = RigidTransform_[float]()
+
+        # After 2024-12-01 deprecation is complete, we can remove this because
+        # we don't have to confirm which overload gets defaulted without
+        # parameters.
+        plant.SetDefaultFreeBodyPose(body, X_WB_default)
+        numpy_compare.assert_float_equal(
+            plant.GetDefaultFreeBodyPose(body=body).GetAsMatrix4(),
+            X_WB_default.GetAsMatrix4())
+
+        plant.SetDefaultFreeBodyPose(body=body, X_PB=Identity)
+        numpy_compare.assert_float_equal(
+            plant.GetDefaultFreeBodyPose(body=body).GetAsMatrix4(),
+            Identity.GetAsMatrix4())
+
+        with catch_drake_warnings(expected_count=1):
+            plant.SetDefaultFreeBodyPose(body=body, X_WB=X_WB_default)
         numpy_compare.assert_float_equal(
             plant.GetDefaultFreeBodyPose(body=body).GetAsMatrix4(),
             X_WB_default.GetAsMatrix4())

--- a/multibody/parsing/model_directives.h
+++ b/multibody/parsing/model_directives.h
@@ -117,17 +117,27 @@ struct AddModel {
   /// or including this declaration.  The named frame must *always* be a scoped
   /// name, even if its part of the model added by this directive.
   ///
-  /// @warning if the transform's `base_frame` is not the world (explicitly or
-  /// implicitly by omission), the body associated with the named frame will
-  /// *not* be considered a free body (`body.is_floating()` returns `false`) and
-  /// calls to MultibodyPlant::SetDefaultFreeBodyPose() will have no effect on
-  /// an allocated context. If you want to change its default pose after adding
-  /// the model, you need to acquire the body's joint and set the new
-  /// default pose on the joint directly. Note: what you will *actually* be
-  /// posing is the *named* frame. If it's the name of the body, you will be
-  /// posing the body. If it's a frame affixed to the body frame, you will be
-  /// posing the fixed frame (with the body offset based on the relationship
-  /// between the two frames).
+  /// @warning there are two important implications for the named frame if the
+  /// transform's `base_frame` is not the world (explicitly or implicitly by
+  /// omission):
+  ///
+  ///  1. The named body will *not* be considered a "floating base" body (see
+  ///     @ref mbp_working_with_free_bodies "Working with free bodies"). Calls
+  ///     to MultibodyPlant::SetDefaultFreeBodyPose() will have no effect on an
+  ///     allocated context. If you want to change its default pose after
+  ///     adding the model, you need to acquire the body's joint and set the
+  ///     new default pose on the joint directly. Note: what you will
+  ///     *actually* be posing is the *named* frame. If it's the name of the
+  ///     body, you will be posing the body. If it's a frame affixed to the
+  ///     body frame, you will be posing the fixed frame (with the body offset
+  ///     based on the relationship between the two frames).
+  ///  2. The body associated with the named frame will have a six-dof joint
+  ///     between itself and the body associated with the transform's
+  ///     `base_frame`. When interpreting the qs for the "named" body, it is the
+  ///     six-dof pose of the body measured and expressed in the parent frame
+  ///     (transform's `base_frame`). This is true whether setting the position
+  ///     values in the resulting joint directly or using the
+  ///     @ref mbp_working_with_free_bodies "MultibodyPlant free body APIs".
   ///
   /// @warning There should not already be a joint in the model between the two
   /// bodies implied by the named frames.

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1152,6 +1152,7 @@ void MultibodyPlant<T>::SetFreeBodyPoseInWorldFrame(
     systems::Context<T>* context, const RigidBody<T>& body,
     const math::RigidTransform<T>& X_WB) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_THROW_UNLESS(body.is_floating());
   this->ValidateContext(context);
   internal_tree().SetFreeBodyPoseOrThrow(body, X_WB, context);
 }

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3638,6 +3638,146 @@ GTEST_TEST(StateSelection, KukaWithSimpleGripper) {
   unused(plant.MakeActuatorSelectorMatrix(std::vector<JointActuatorIndex>()));
 }
 
+// Confirms the free body APIs w.r.t. bodies that have a floating mobilizer
+// but whose parent frame is not the world. They are still free and the
+// various APIs should interpret poses as documented.
+//
+// We load a table and mug. The table is given a prismatic joint to the world
+// (to facilitate testing spatial velocities), the mug is free. In some cases,
+// it is a "floating base body" (its parent is the world) and sometimes only a
+// "free body" (its parent is the table).
+//
+// This test explicitly omits some APIs because they are tested elsewhere:
+//   - GTEST_TEST(StateSelection, FloatingBodies) tests
+//     SetFreeBodyPoseInAnchoredFrame.
+//   - GTEST_TEST(SetRandomTest, FloatingBodies) the random distribution of
+//     of free body poses, as that is dealt with below in
+//   - multibody_plant_introspection_test.cc covers the "UniqueFreeBody" APIs.
+GTEST_TEST(StateSelection, FreeBodiesVsFloatingBaseBodies) {
+  const std::string table_sdf_url =
+      "package://drake/examples/kuka_iiwa_arm/models/table/"
+      "extra_heavy_duty_table_surface_only_collision.sdf";
+  const std::string mug_sdf_url =
+      "package://drake/examples/simple_gripper/simple_mug.sdf";
+
+  for (bool mug_in_world : {true, false}) {
+    SCOPED_TRACE(mug_in_world ? "Mug joined to world" : "Mug joined to table");
+    MultibodyPlant<double> plant(0.0);
+
+    Parser parser(&plant, "test");
+    const ModelInstanceIndex table_model =
+        parser.AddModelsFromUrl(table_sdf_url).at(0);
+    const RigidBody<double>& table = plant.GetBodyByName("link", table_model);
+    plant.AddJoint(std::make_unique<PrismaticJoint<double>>(
+        "table", plant.world_frame(), table.body_frame(), Vector3d(1, 1, 1)));
+
+    // Add a mug with no joint. This will become a floating base body at
+    // finalization unless we add a joint.
+    parser.AddModelsFromUrl(mug_sdf_url);
+    const RigidBody<double>& mug = plant.GetBodyByName("simple_mug");
+    if (!mug_in_world) {
+      // Explicitly put a 6-dof joint between mug and table, making this a
+      // "free" body, but _not_ a floating base body.
+      plant.AddJoint<QuaternionFloatingJoint>("sixdof", table, {}, mug, {});
+    }
+
+    plant.Finalize();
+    auto context = plant.CreateDefaultContext();
+
+    // Table has non-identity position and velocity w.r.t. world.
+    VectorX<double> table_q =
+        plant.GetPositionsAndVelocities(*context, table.model_instance());
+    DRAKE_DEMAND(table_q.size() == 2);
+    table_q << 3, 3;
+    plant.SetPositionsAndVelocities(context.get(), table.model_instance(),
+                                    table_q);
+
+    const RigidTransformd I = RigidTransformd::Identity();
+
+    const RigidTransformd X_WT = plant.EvalBodyPoseInWorld(*context, table);
+    const RigidTransformd X_PM(Vector3d(-3, 2, -1));
+    const RigidTransformd X_WM = mug_in_world ? X_PM : X_WT * X_PM;
+    // Mug is in the world, or its world and transform poses are different.
+    DRAKE_DEMAND(mug_in_world || !CompareMatrices(X_PM.GetAsMatrix34(),
+                                                  X_WM.GetAsMatrix34(), 1));
+    // Whether the mug is a "floating base" body depends on its parent frame.
+    ASSERT_EQ(mug.is_floating(), mug_in_world);
+    ASSERT_EQ(plant.GetFloatingBaseBodies().contains(mug.index()),
+              mug_in_world);
+
+    plant.SetFreeBodyPose(context.get(), mug, X_PM);
+
+    // The value we set for free body pose should always come right back -- it's
+    // the literal configuration of the joint.
+    EXPECT_TRUE(
+        CompareMatrices(plant.GetFreeBodyPose(*context, mug).GetAsMatrix34(),
+                        X_PM.GetAsMatrix34()));
+
+    // The world pose is as expected.
+    EXPECT_TRUE(CompareMatrices(
+        plant.EvalBodyPoseInWorld(*context, mug).GetAsMatrix34(),
+        X_WM.GetAsMatrix34()));
+
+    // Reset the pose.
+    plant.SetFreeBodyPose(context.get(), mug, I);
+    EXPECT_FALSE(CompareMatrices(
+        plant.EvalBodyPoseInWorld(*context, mug).GetAsMatrix34(),
+        X_WM.GetAsMatrix34(), 1));
+
+    // Note: We're not explicitly testing
+    // MultibodyPlant::SetFreeBodyPose(context, state, body, X_PB) because the
+    // non-state variant ultimately just forwards to the same API. MbP's
+    // implementation is a tiny wrapper around the code that is ultimately
+    // tested by the call to SetFreeBodyPose(context, body, X_PB).
+
+    // Explicitly setting things in the world frame produces the expected pose
+    // in world for floating free bodies, but not for "internal" free bodies.
+    if (mug_in_world) {
+      plant.SetFreeBodyPoseInWorldFrame(context.get(), mug, X_WM);
+      EXPECT_TRUE(CompareMatrices(
+          plant.EvalBodyPoseInWorld(*context, mug).GetAsMatrix34(),
+          X_WM.GetAsMatrix34()));
+    } else {
+      EXPECT_THROW(plant.SetFreeBodyPoseInWorldFrame(context.get(), mug, X_WM),
+                   std::exception);
+    }
+
+    // Although the mug has a quaternion floating joint, that is insufficient
+    // for setting a *default* floating pose -- the parent must be world.
+    plant.SetDefaultFreeBodyPose(mug, X_PM);
+
+    // As promised, the value set is regurgitated back.
+    EXPECT_TRUE(
+        CompareMatrices(plant.GetDefaultFreeBodyPose(mug).GetAsMatrix34(),
+                        X_PM.GetAsMatrix34()));
+
+    // The default pose takes affect iff the world is the parent frame.
+    auto alt_context = plant.CreateDefaultContext();
+    EXPECT_EQ(CompareMatrices(
+                  plant.GetFreeBodyPose(*alt_context, mug).GetAsMatrix34(),
+                  X_PM.GetAsMatrix34()),
+              mug_in_world);
+
+    const SpatialVelocity<double> V_PB(Vector3d(1.0, 2.0, 3.0),
+                                       Vector3d(-1.0, 4.0, -0.5));
+    plant.SetFreeBodySpatialVelocity(context.get(), mug, V_PB);
+    if (mug_in_world) {
+      EXPECT_TRUE(CompareMatrices(
+          plant.EvalBodySpatialVelocityInWorld(*context, mug).get_coeffs(),
+          V_PB.get_coeffs()));
+    } else {
+      EXPECT_FALSE(CompareMatrices(
+          plant.EvalBodySpatialVelocityInWorld(*context, mug).get_coeffs(),
+          V_PB.get_coeffs(), 1.0));
+    }
+
+    // We omit the SetFreeBodySpatialVelocity() that takes state for the same
+    // reason as omitting SetFreeBodyPose(): the thing wrapper can be validated
+    // by inspection, the the overload called here tests the shared, underlying
+    // implementation.
+  }
+}
+
 // This unit test verifies the workings of
 // MBP::SetFreeBodyPoseInAnchoredFrame(). To that end we build a model
 // representative of a real setup consisting of a robot arm mounted on a robot

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -236,29 +236,31 @@ class RigidBody : public MultibodyElement<T> {
     return body_frame_;
   }
 
-  /// For a floating %RigidBody, lock its inboard joint. Its generalized
+  /// For a floating base %RigidBody, lock its inboard joint. Its generalized
   /// velocities will be 0 until it is unlocked.
-  /// @throws std::exception if this body is not a floating body.
+  /// @throws std::exception if this body is not a floating base body.
   void Lock(systems::Context<T>* context) const {
     // TODO(rpoyner-tri): consider extending the design to allow locking on
     //  non-floating bodies.
     if (!is_floating()) {
       throw std::logic_error(fmt::format(
-          "Attempted to call Lock() on non-floating rigid body {}", name()));
+          "Attempted to call Lock() on non-floating-base rigid body {}",
+          name()));
     }
     this->get_parent_tree()
         .get_mobilizer(topology_.inboard_mobilizer)
         .Lock(context);
   }
 
-  /// For a floating %RigidBody, unlock its inboard joint.
-  /// @throws std::exception if this body is not a floating body.
+  /// For a floating base %RigidBody, unlock its inboard joint.
+  /// @throws std::exception if this body is not a floating base body.
   void Unlock(systems::Context<T>* context) const {
     // TODO(rpoyner-tri): consider extending the design to allow locking on
     //  non-floating bodies.
     if (!is_floating()) {
       throw std::logic_error(fmt::format(
-          "Attempted to call Unlock() on non-floating rigid body {}", name()));
+          "Attempted to call Unlock() on non-floating-base rigid body {}",
+          name()));
     }
     this->get_parent_tree()
         .get_mobilizer(topology_.inboard_mobilizer)
@@ -266,8 +268,8 @@ class RigidBody : public MultibodyElement<T> {
   }
 
   /// Determines whether this %RigidBody is currently locked to its inboard
-  /// (parent) %RigidBody. This is not limited to floating bodies but generally
-  /// Joint::is_locked() is preferable otherwise.
+  /// (parent) %RigidBody. This is not limited to floating base bodies but
+  /// generally Joint::is_locked() is preferable otherwise.
   /// @returns true if the body is locked, false otherwise.
   bool is_locked(const systems::Context<T>& context) const {
     return this->get_parent_tree()
@@ -285,7 +287,7 @@ class RigidBody : public MultibodyElement<T> {
 
   /// (Advanced) Returns `true` if this body is granted 6-dofs by a Mobilizer
   /// and the parent body of this body's associated 6-dof joint is `world`.
-  /// @note A floating body is not necessarily modeled with a quaternion
+  /// @note A floating base body is not necessarily modeled with a quaternion
   /// mobilizer, see has_quaternion_dofs(). Alternative options include a
   /// roll-pitch-yaw (rpy) parametrization of rotations, see
   /// RpyFloatingMobilizer.
@@ -298,8 +300,9 @@ class RigidBody : public MultibodyElement<T> {
 
   /// (Advanced) If `true`, this body's generalized position coordinates q
   /// include a quaternion, which occupies the first four elements of q. Note
-  /// that this does not imply that the body is floating since it may have
-  /// fewer than 6 dofs or its inboard body could be something other than World.
+  /// that this does not imply that the body is floating base body since it may
+  /// have fewer than 6 dofs or its inboard body could be something other than
+  /// World.
   /// @throws std::exception if called pre-finalize
   /// @see is_floating(), MultibodyPlant::Finalize()
   bool has_quaternion_dofs() const {
@@ -307,16 +310,16 @@ class RigidBody : public MultibodyElement<T> {
     return topology_.has_quaternion_dofs;
   }
 
-  /// (Advanced) For floating bodies (see is_floating()) this method returns the
-  /// index of this %RigidBody's first generalized position in the vector q of
-  /// generalized position coordinates for a MultibodyPlant model. Positions q
-  /// for this %RigidBody are then contiguous starting at this index.
-  /// When a floating %RigidBody is modeled with quaternion coordinates (see
-  /// has_quaternion_dofs()), the four consecutive entries in the state starting
-  /// at this index correspond to the quaternion that parametrizes this
+  /// (Advanced) For floating base bodies (see is_floating()) this method
+  /// returns the index of this %RigidBody's first generalized position in the
+  /// vector q of generalized position coordinates for a MultibodyPlant model.
+  /// Positions q for this %RigidBody are then contiguous starting at this
+  /// index. When a floating %RigidBody is modeled with quaternion coordinates
+  /// (see has_quaternion_dofs()), the four consecutive entries in the state
+  /// starting at this index correspond to the quaternion that parametrizes this
   /// %RigidBody's orientation.
   /// @throws std::exception if called pre-finalize
-  /// @pre this is a floating body
+  /// @pre this is a floating base body
   /// @see is_floating(), has_quaternion_dofs(), MultibodyPlant::Finalize()
   int floating_positions_start() const {
     ThrowIfNotFinalized(__func__);
@@ -324,12 +327,12 @@ class RigidBody : public MultibodyElement<T> {
     return topology_.floating_positions_start;
   }
 
-  /// (Advanced) For floating bodies (see is_floating()) this method returns the
-  /// index of this %RigidBody's first generalized velocity in the vector v of
-  /// generalized velocities for a MultibodyPlant model. Velocities v for this
-  /// %RigidBody are then contiguous starting at this index.
+  /// (Advanced) For floating base bodies (see is_floating()) this method
+  /// returns the index of this %RigidBody's first generalized velocity in the
+  /// vector v of generalized velocities for a MultibodyPlant model. Velocities
+  /// v for this %RigidBody are then contiguous starting at this index.
   /// @throws std::exception if called pre-finalize
-  /// @pre this is a floating body
+  /// @pre this is a floating base body
   /// @see is_floating(), MultibodyPlant::Finalize()
   int floating_velocities_start_in_v() const {
     ThrowIfNotFinalized(__func__);
@@ -341,7 +344,7 @@ class RigidBody : public MultibodyElement<T> {
   /// the `k`th position in the floating base. `position_index_in_body` must
   /// be in [0, 7) if `has_quaternion_dofs()` is true, otherwise in [0, 6).
   /// @throws std::exception if called pre-finalize
-  /// @pre this is a floating body
+  /// @pre this is a floating base body
   /// @see is_floating(), has_quaternion_dofs(), MultibodyPlant::Finalize()
   std::string floating_position_suffix(int position_index_in_body) const {
     ThrowIfNotFinalized(__func__);
@@ -359,7 +362,7 @@ class RigidBody : public MultibodyElement<T> {
   /// the `k`th velocity in the floating base. `velocity_index_in_body` must
   /// be in [0,6).
   /// @throws std::exception if called pre-finalize
-  /// @pre this is a floating body
+  /// @pre this is a floating base body
   /// @see is_floating(), MultibodyPlant::Finalize()
   std::string floating_velocity_suffix(int velocity_index_in_body) const {
     ThrowIfNotFinalized(__func__);


### PR DESCRIPTION
Much of the free body documentation still assumes that all free bodies have the world as parent. That's not generally true. In fact, we advocate simulating things like suction by putting a floating joint between end effector and manipuland and simply locking the joint when the end effector is "holding" the manipuland. The configuration of the joint is always relative to the inboard frame which, in this case, is not the world.

Furthermore, the API Mbp::SetFreeBodyPoseInWorldFrame() doesn't serve its documented purpose anymore because it doesn't perform the necessary kinematics.

This addresses this in several ways:

1. Update the documentation on the methods that work for floating/non-floating free bodies.
2. SetFreeBodyPoseInWorldFrame() has updated documentation and now explicitly throws if body isn't floating (the circumstances under which the API is broken).
3. Modify python bindings.

Closes #21802 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21808)
<!-- Reviewable:end -->
