### PR TITLE
[multibody topology] Replace BodyIndex with LinkIndex alias

### DIFF
--- a/multibody/topology/link_joint_graph_debug.cc
+++ b/multibody/topology/link_joint_graph_debug.cc
@@ -44,7 +44,7 @@ std::string LinkJointGraph::GenerateGraphvizString(
     graphviz += fmt::format("subgraph cluster{}", index) + " {\n";
     graphviz += fmt::format("label=\"LinkComposite({}){}\";\n", index,
                             composite.is_massless ? "*" : "");
-    for (const BodyIndex& link_index : composite.links) {
+    for (const LinkIndex& link_index : composite.links) {
       const Link& link = link_by_index(link_index);
       const bool ephemeral = link_is_ephemeral(link.index());
       if (ephemeral && !include_ephemeral_elements) continue;

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -13,6 +13,8 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
+using LinkIndex = BodyIndex;
+
 class SpanningForest;
 
 using LinkOrdinal = TypeSafeIndex<class LinkOrdinalTag>;

--- a/multibody/topology/link_joint_graph_inlines.h
+++ b/multibody/topology/link_joint_graph_inlines.h
@@ -20,7 +20,7 @@ inline const LinkJointGraph::Link& LinkJointGraph::links(
 }
 
 inline const LinkJointGraph::Link& LinkJointGraph::link_by_index(
-    BodyIndex link_index) const {
+    LinkIndex link_index) const {
   const std::optional<LinkOrdinal>& ordinal =
       data_.link_index_to_ordinal.at(link_index);
   if (!ordinal.has_value()) ThrowLinkWasRemoved(__func__, link_index);
@@ -34,7 +34,7 @@ inline LinkJointGraph::Link& LinkJointGraph::mutable_link(
   return data_.links[link_ordinal];
 }
 
-inline MobodIndex LinkJointGraph::link_to_mobod(BodyIndex index) const {
+inline MobodIndex LinkJointGraph::link_to_mobod(LinkIndex index) const {
   return link_by_index(index).mobod_;
 }
 

--- a/multibody/topology/link_joint_graph_joint.h
+++ b/multibody/topology/link_joint_graph_joint.h
@@ -33,10 +33,10 @@ class LinkJointGraph::Joint {
   const std::string& name() const { return name_; }
 
   /** Returns the index of this %Joint's parent Link. */
-  BodyIndex parent_link_index() const { return parent_link_index_; }
+  LinkIndex parent_link_index() const { return parent_link_index_; }
 
   /** Returns the index of this %Joint's child Link. */
-  BodyIndex child_link_index() const { return child_link_index_; }
+  LinkIndex child_link_index() const { return child_link_index_; }
 
   /** Returns `true` if this is a Weld %Joint. */
   bool is_weld() const { return traits_index() == weld_joint_traits_index(); }
@@ -46,14 +46,14 @@ class LinkJointGraph::Joint {
 
   /** Returns `true` if either the parent or child Link of this %Joint is
   the specified `link`. */
-  bool connects(BodyIndex link) const {
+  bool connects(LinkIndex link) const {
     return link == parent_link_index() || link == child_link_index();
   }
 
   /** Returns `true` if this %Joint connects the two given Links. That is, if
   one of these is the parent Link and the other is the child Link, in either
   order. */
-  bool connects(BodyIndex link1, BodyIndex link2) const {
+  bool connects(LinkIndex link1, LinkIndex link2) const {
     return (parent_link_index() == link1 && child_link_index() == link2) ||
            (parent_link_index() == link2 && child_link_index() == link1);
   }
@@ -64,7 +64,7 @@ class LinkJointGraph::Joint {
 
   /** Given one of the Links connected by this %Joint, returns the other one.
   @pre `link_index` is either the parent or child */
-  BodyIndex other_link_index(BodyIndex link_index) const {
+  LinkIndex other_link_index(LinkIndex link_index) const {
     DRAKE_DEMAND((parent_link_index() == link_index) ||
                  (child_link_index() == link_index));
     return parent_link_index() == link_index ? child_link_index()
@@ -97,7 +97,7 @@ class LinkJointGraph::Joint {
 
   Joint(JointIndex index, JointOrdinal ordinal, std::string name,
         ModelInstanceIndex model_instance, JointTraitsIndex joint_traits_index,
-        BodyIndex parent_link_index, BodyIndex child_link_index,
+        LinkIndex parent_link_index, LinkIndex child_link_index,
         JointFlags flags);
 
   void ClearModel() { how_modeled_ = std::monostate{}; }
@@ -125,8 +125,8 @@ class LinkJointGraph::Joint {
   JointFlags flags_{JointFlags::kDefault};
 
   JointTraitsIndex traits_index_;
-  BodyIndex parent_link_index_;
-  BodyIndex child_link_index_;
+  LinkIndex parent_link_index_;
+  LinkIndex child_link_index_;
 
   // Below here is the as-built information; must be flushed when the forest is
   // cleared or rebuilt.

--- a/multibody/topology/link_joint_graph_link.h
+++ b/multibody/topology/link_joint_graph_link.h
@@ -25,7 +25,7 @@ class LinkJointGraph::Link {
 
   /** Returns this %Link's unique index in the graph. This is persistent after
   the %Link has been allocated. */
-  BodyIndex index() const { return index_; }
+  LinkIndex index() const { return index_; }
 
   /** Returns the current value of this %Link's ordinal (position in the
   links() vector). This can change as %Links are removed. */
@@ -61,7 +61,7 @@ class LinkJointGraph::Link {
   /** Returns `true` only if this is the World %Link. Static Links and Links
   in the World Composite are not included; see is_anchored() if you want to
   include everything that is fixed with respect to World. */
-  bool is_world() const { return index_ == BodyIndex(0); }
+  bool is_world() const { return index_ == LinkIndex(0); }
 
   /** After modeling, returns `true` if this %Link is fixed with respect to
   World. That includes World itself, static Links, and any Link that is part
@@ -97,7 +97,7 @@ class LinkJointGraph::Link {
 
   /** If this %Link is a shadow, returns the primary %Link it shadows. If
   not a shadow then it is its own primary %Link so returns index(). */
-  BodyIndex primary_link() const { return primary_link_; }
+  LinkIndex primary_link() const { return primary_link_; }
 
   /** If this is a primary %Link (not a shadow) returns the number of Shadow
   Links that were added due to loop breaking. */
@@ -129,7 +129,7 @@ class LinkJointGraph::Link {
   friend class LinkJointGraph;
   friend class LinkJointGraphTester;
 
-  Link(BodyIndex index, LinkOrdinal ordinal, std::string name,
+  Link(LinkIndex index, LinkOrdinal ordinal, std::string name,
        ModelInstanceIndex model_instance, LinkFlags flags);
 
   // (For testing) If `to_set` is LinkFlags::kDefault sets the flags to
@@ -173,12 +173,12 @@ class LinkJointGraph::Link {
   // @pre this is a user link, not a shadow.
   void ClearModel(JointIndex max_user_joint_index);
 
-  BodyIndex index_;      // persistent
+  LinkIndex index_;      // persistent
   LinkOrdinal ordinal_;  // can change
   std::string name_;
   ModelInstanceIndex model_instance_;
   LinkFlags flags_{LinkFlags::kDefault};
-  BodyIndex primary_link_;  // Same as index_ unless this is a shadow link.
+  LinkIndex primary_link_;  // Same as index_ unless this is a shadow link.
 
   // Members below here may contain as-modeled information that has to be
   // removed when the SpanningForest is cleared or rebuilt. The joint
@@ -194,7 +194,7 @@ class LinkJointGraph::Link {
   MobodIndex mobod_;  // Mobod that mobilizes this Link.
   JointIndex joint_;  // Joint that connects us to the Mobod (invalid if World).
 
-  std::vector<BodyIndex> shadow_links_;
+  std::vector<LinkIndex> shadow_links_;
 
   // World is always in a composite; other links are in a composite only
   // if they are welded to another link.

--- a/multibody/topology/link_joint_graph_loop_constraint.h
+++ b/multibody/topology/link_joint_graph_loop_constraint.h
@@ -21,7 +21,7 @@ class LinkJointGraph::LoopConstraint {
 
   LoopConstraint(LoopConstraintIndex index, std::string name,
                  ModelInstanceIndex model_instance,
-                 BodyIndex primary_link_index, BodyIndex shadow_link_index)
+                 LinkIndex primary_link_index, LinkIndex shadow_link_index)
       : index_(index),
         name_(name),
         model_instance_(model_instance),
@@ -34,15 +34,15 @@ class LinkJointGraph::LoopConstraint {
 
   const std::string& name() const { return name_; }
 
-  BodyIndex primary_link() const { return primary_link_index_; }
-  BodyIndex shadow_link() const { return shadow_link_index_; }
+  LinkIndex primary_link() const { return primary_link_index_; }
+  LinkIndex shadow_link() const { return shadow_link_index_; }
 
  private:
   LoopConstraintIndex index_;
   std::string name_;
   ModelInstanceIndex model_instance_;
-  BodyIndex primary_link_index_;
-  BodyIndex shadow_link_index_;
+  LinkIndex primary_link_index_;
+  LinkIndex shadow_link_index_;
 
   // TODO(sherm1) Record the ephemeral MultibodyPlant Constraint here, e.g.:
   //  MultibodyConstraintId plant_constraint_id_;

--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -689,7 +689,7 @@ void SpanningForest::FindNextLevelJoints(MobodIndex inboard_mobod_index,
     same merged LinkComposite. We must grow the composite in the outboard
     direction of the joint, which is the end that is _not_ already following
     the inboard Mobod. */
-    const BodyIndex outboard_link_index =
+    const LinkIndex outboard_link_index =
         FindOutboardLink(inboard_mobod_index, j_in);
 
     /* Adds the outboard link O to the inboard composite and keeps collecting
@@ -700,7 +700,7 @@ void SpanningForest::FindNextLevelJoints(MobodIndex inboard_mobod_index,
   }
 }
 
-BodyIndex SpanningForest::FindOutboardLink(MobodIndex inboard_mobod_index,
+LinkIndex SpanningForest::FindOutboardLink(MobodIndex inboard_mobod_index,
                                            const Joint& joint) const {
   const Link& parent_link = link_by_index(joint.parent_link_index());
   const Link& child_link = link_by_index(joint.child_link_index());
@@ -718,7 +718,7 @@ bool SpanningForest::HasMassfulOutboardLink(
     const std::vector<JointIndex>& joints) const {
   for (JointIndex joint_index : joints) {
     const Joint& joint = joint_by_index(joint_index);
-    const BodyIndex outboard_link_index =
+    const LinkIndex outboard_link_index =
         FindOutboardLink(inboard_mobod_index, joint);
     if (!link_by_index(outboard_link_index).is_massless()) return true;
   }
@@ -787,7 +787,7 @@ const SpanningForest::Mobod& SpanningForest::AddNewMobod(
 }
 
 void SpanningForest::ConnectLinksToWorld(
-    const std::vector<BodyIndex>& links_to_connect, bool use_weld) {
+    const std::vector<LinkIndex>& links_to_connect, bool use_weld) {
   for (const auto& link_index : links_to_connect) {
     const LinkOrdinal link_ordinal = graph().index_to_ordinal(link_index);
     DRAKE_DEMAND(!link_is_already_in_forest(link_ordinal));
@@ -903,7 +903,7 @@ const SpanningForest::Mobod& SpanningForest::AddShadowMobod(
   const Link& primary_link = links(primary_link_ordinal);
   Joint& shadow_joint = mutable_graph().mutable_joint(shadow_joint_ordinal);
   DRAKE_DEMAND(shadow_joint.connects(primary_link.index()));
-  const BodyIndex inboard_link_index =
+  const LinkIndex inboard_link_index =
       shadow_joint.other_link_index(primary_link.index());
 
   /* The Joint was written to connect inboard_link to primary_link but is
@@ -958,7 +958,7 @@ const SpanningForest::Mobod& SpanningForest::JoinExistingMobod(
 }
 
 void SpanningForest::GrowCompositeMobod(
-    Mobod* mobod, BodyIndex outboard_link_index,
+    Mobod* mobod, LinkIndex outboard_link_index,
     JointOrdinal weld_joint_ordinal,
     std::vector<JointIndex>* open_joint_indexes, int* num_unprocessed_links) {
   /* If the outboard_link has already been processed we're looking at a loop
@@ -999,7 +999,7 @@ void SpanningForest::GrowCompositeMobod(
     /* We've found another unprocessed joint that needs merging onto this
     composite. One of its links is the outboard_link (already in the forest
     at this point). Find the other link. */
-    const BodyIndex other_link_index =
+    const LinkIndex other_link_index =
         joint.other_link_index(outboard_link_index);
 
     /* Recursively extend the Composite along the new merge-weld joint. */

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -184,7 +184,7 @@ class SpanningForest {
   }
 
   // TODO(sherm1) Make this unchecked; maybe private?
-  const Link& link_by_index(BodyIndex link_index) const {
+  const Link& link_by_index(LinkIndex link_index) const {
     return graph().link_by_index(link_index);
   }
 
@@ -450,7 +450,7 @@ class SpanningForest {
 
   // Given a Mobod and a Joint known to have one of its links already following
   // that Mobod, find the other (outboard) link. */
-  BodyIndex FindOutboardLink(MobodIndex inboard_mobod_index,
+  LinkIndex FindOutboardLink(MobodIndex inboard_mobod_index,
                              const Joint& joint) const;
 
   // Helper for ExtendTreesOneLevel(). Given a Mobod and a set of joints known
@@ -479,7 +479,7 @@ class SpanningForest {
 
   // Given a list of Static or MustBeBaseBody Links, adds a weld or floating
   // Joint to World for each Link that doesn't already have one.
-  void ConnectLinksToWorld(const std::vector<BodyIndex>& links, bool use_weld);
+  void ConnectLinksToWorld(const std::vector<LinkIndex>& links, bool use_weld);
 
   // Sets the comparison function to be used in making the "best" choice.
   void SetBaseBodyChoicePolicy();
@@ -576,7 +576,7 @@ class SpanningForest {
   // link. As we encounter non-merge joints attached to this composite we append
   // them to `open_joint_indexes` for processing next. Those constitute the
   // "next level" outboard of this merged composite.
-  void GrowCompositeMobod(Mobod* inboard_mobod, BodyIndex outboard_link_index,
+  void GrowCompositeMobod(Mobod* inboard_mobod, LinkIndex outboard_link_index,
                           JointOrdinal weld_joint_ordinal,
                           std::vector<JointIndex>* open_joint_indexes,
                           int* num_unprocessed_links);

--- a/multibody/topology/test/link_joint_graph_test.cc
+++ b/multibody/topology/test/link_joint_graph_test.cc
@@ -28,7 +28,7 @@ using std::pair;
 // member functions so that we can test those APIs standalone.
 class LinkJointGraphTester {
  public:
-  static LinkJointGraph::Link MakeLink(BodyIndex index, LinkOrdinal ordinal,
+  static LinkJointGraph::Link MakeLink(LinkIndex index, LinkOrdinal ordinal,
                                        std::string name,
                                        ModelInstanceIndex model_instance,
                                        LinkFlags flags) {
@@ -40,8 +40,8 @@ class LinkJointGraphTester {
                                          std::string name,
                                          ModelInstanceIndex model_instance,
                                          JointTraitsIndex joint_traits_index,
-                                         BodyIndex parent_link_index,
-                                         BodyIndex child_link_index,
+                                         LinkIndex parent_link_index,
+                                         LinkIndex child_link_index,
                                          JointFlags flags) {
     return LinkJointGraph::Joint(index, ordinal, std::move(name),
                                  model_instance, joint_traits_index,
@@ -65,12 +65,12 @@ class LinkJointGraphTester {
                                                shadow_link_ordinal);
   }
 
-  static std::vector<BodyIndex> static_link_indexes(
+  static std::vector<LinkIndex> static_link_indexes(
       const LinkJointGraph& graph) {
     return graph.static_link_indexes();
   }
 
-  static std::vector<BodyIndex> non_static_must_be_base_body_link_indexes(
+  static std::vector<LinkIndex> non_static_must_be_base_body_link_indexes(
       const LinkJointGraph& graph) {
     return graph.non_static_must_be_base_body_link_indexes();
   }
@@ -245,8 +245,8 @@ GTEST_TEST(LinkJointGraph, WorldOnlyTest) {
   EXPECT_TRUE(graph.joints().empty());
   EXPECT_EQ(graph.world_link().name(), "world");
   EXPECT_EQ(graph.world_link().model_instance(), world_model_instance());
-  const BodyIndex world_link_index = graph.world_link().index();
-  EXPECT_EQ(world_link_index, BodyIndex(0));
+  const LinkIndex world_link_index = graph.world_link().index();
+  EXPECT_EQ(world_link_index, LinkIndex(0));
 
   // Topologically important joint types are predefined.
   EXPECT_EQ(ssize(graph.joint_traits()), 3);
@@ -291,12 +291,12 @@ GTEST_TEST(LinkJointGraph, WorldOnlyTest) {
   // Check that Clear() puts the graph back to default-constructed condition.
   // First add some junk to the graph.
   graph.RegisterJointType("revolute", 1, 1);
-  const BodyIndex dummy_index =
+  const LinkIndex dummy_index =
       graph.AddLink("dummy", default_model_instance());
   graph.AddJoint("joint0", default_model_instance(), "revolute", world_index(),
                  dummy_index);
   EXPECT_TRUE(graph.HasLinkNamed("dummy", default_model_instance()));
-  EXPECT_EQ(dummy_index, BodyIndex(1));
+  EXPECT_EQ(dummy_index, LinkIndex(1));
   EXPECT_EQ(ssize(graph.links()), 2);
   EXPECT_EQ(ssize(graph.joints()), 1);
   EXPECT_EQ(ssize(graph.joint_traits()), 4);
@@ -331,7 +331,7 @@ GTEST_TEST(LinkJointGraph, AddLinkErrors) {
       "AddLink.*already a link named.*link1.*model instance.*3.*");
 
   // Addlink accepts flags, but not Shadow which is set internally only.
-  const BodyIndex link2_index =
+  const LinkIndex link2_index =
       graph.AddLink("link2", ModelInstanceIndex(3),
                     LinkFlags::kMassless | LinkFlags::kMustBeBaseBody);
   const LinkJointGraph::Link& link2 = graph.link_by_index(link2_index);
@@ -348,29 +348,29 @@ GTEST_TEST(LinkJointGraph, AddLinkErrors) {
 GTEST_TEST(LinkJointGraph, InternalListsAreBuiltCorrectly) {
   LinkJointGraph graph;
 
-  const BodyIndex link1_index =
+  const LinkIndex link1_index =
       graph.AddLink("link1", default_model_instance(), LinkFlags::kStatic);
-  const BodyIndex link2_index = graph.AddLink("link2", default_model_instance(),
+  const LinkIndex link2_index = graph.AddLink("link2", default_model_instance(),
                                               LinkFlags::kMustBeBaseBody);
-  const BodyIndex link3_index =
+  const LinkIndex link3_index =
       graph.AddLink("link3", default_model_instance(),
                     LinkFlags::kStatic | LinkFlags::kMustBeBaseBody);
 
   // Links 1 and 3 are static.
   EXPECT_EQ(LinkJointGraphTester::static_link_indexes(graph),
-            (std::vector<BodyIndex>{link1_index, link3_index}));
+            (std::vector<LinkIndex>{link1_index, link3_index}));
   // But only link 2 should be on the non-static must be base body list.
   EXPECT_EQ(
       LinkJointGraphTester::non_static_must_be_base_body_link_indexes(graph),
-      std::vector<BodyIndex>{link2_index});
+      std::vector<LinkIndex>{link2_index});
 }
 
 // Check operation of the public members of the Link subclass.
 GTEST_TEST(LinkJoinGraph, LinkAPITest) {
   LinkJointGraph::Link link5 = LinkJointGraphTester::MakeLink(
-      BodyIndex(5), LinkOrdinal(0), "link5", ModelInstanceIndex(7),
+      LinkIndex(5), LinkOrdinal(0), "link5", ModelInstanceIndex(7),
       LinkFlags::kMustBeBaseBody);
-  EXPECT_EQ(link5.index(), BodyIndex(5));
+  EXPECT_EQ(link5.index(), LinkIndex(5));
   EXPECT_EQ(link5.model_instance(), ModelInstanceIndex(7));
   EXPECT_EQ(link5.name(), "link5");
 
@@ -400,9 +400,9 @@ GTEST_TEST(LinkJoinGraph, LinkAPITest) {
 
 // Check operation of the public members of the Joint subclass.
 GTEST_TEST(LinkJointGraph, JointAPITest) {
-  const BodyIndex parent_index(1);
-  const BodyIndex child_index(2);
-  const BodyIndex other_body_index(3);  // Not connected by joint3.
+  const LinkIndex parent_index(1);
+  const LinkIndex child_index(2);
+  const LinkIndex other_body_index(3);  // Not connected by joint3.
   LinkJointGraph::Joint joint3 = LinkJointGraphTester::MakeJoint(
       JointIndex(3), JointOrdinal(0), "joint3", ModelInstanceIndex(9),
       LinkJointGraph::rpy_floating_joint_traits_index(), parent_index,
@@ -465,10 +465,10 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
       fmt::format("AddLink\\(\\): Model instance index {} is reserved.*",
                   world_model_instance()));
 
-  BodyIndex parent = graph.AddLink("link1", model_instance);
+  LinkIndex parent = graph.AddLink("link1", model_instance);
   graph.AddJoint("pin1", model_instance, "revolute", world_index(), parent);
   for (int i = 2; i <= 5; ++i) {
-    BodyIndex child = graph.AddLink("link" + std::to_string(i), model_instance);
+    LinkIndex child = graph.AddLink("link" + std::to_string(i), model_instance);
     graph.AddJoint("pin" + std::to_string(i), model_instance, "revolute",
                    parent, child);
     parent = child;
@@ -480,7 +480,7 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   EXPECT_EQ(graph.num_user_joints(), 5);
 
   // Check that the links see their joints.
-  const LinkJointGraph::Link& link4 = graph.link_by_index(BodyIndex(4));
+  const LinkJointGraph::Link& link4 = graph.link_by_index(LinkIndex(4));
   EXPECT_EQ(link4.joints(),
             (std::vector<JointIndex>{JointIndex(3), JointIndex(4)}));
   EXPECT_EQ(link4.joints_as_parent(), std::vector<JointIndex>{JointIndex(4)});
@@ -490,7 +490,7 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   // weld constraint, and check that it properly updates the relevant links.
   // (This is a private function normally used only by SpanningForest as it
   // breaks loops; users can't add constraints to the graph.)
-  const LinkJointGraph::Link& link5 = graph.link_by_index(BodyIndex(5));
+  const LinkJointGraph::Link& link5 = graph.link_by_index(LinkIndex(5));
   const LoopConstraintIndex constraint0_index =
       LinkJointGraphTester::AddLoopClosingWeldConstraint(
           link4.ordinal(),  // primary link
@@ -521,44 +521,44 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
       "AddLink.*already a link named.*link3.*model instance.*5.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      graph.AddJoint("pin3", model_instance, "revolute", BodyIndex(1),
-                     BodyIndex(2)),
+      graph.AddJoint("pin3", model_instance, "revolute", LinkIndex(1),
+                     LinkIndex(2)),
       "AddJoint.*already a joint named.*pin3.*model instance.*5.*");
 
   // We cannot add a redundant joint.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      graph.AddJoint("other", model_instance, "revolute", BodyIndex(1),
-                     BodyIndex(2)),
+      graph.AddJoint("other", model_instance, "revolute", LinkIndex(1),
+                     LinkIndex(2)),
       "AddJoint\\(\\):.*already has joint.*pin2.*instance 5.*"
       " connecting.*link1.*link2.*adding joint.*other.*instance 5.*"
       " connecting.*link1.*link2.*is not allowed.");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      graph.AddJoint("reverse", model_instance, "revolute", BodyIndex(2),
-                     BodyIndex(1)),
+      graph.AddJoint("reverse", model_instance, "revolute", LinkIndex(2),
+                     LinkIndex(1)),
       "AddJoint\\(\\):.*already has joint.*pin2.*instance 5.*"
       " connecting.*link1.*link2.*adding joint.*reverse.*instance 5.*"
       " connecting.*link2.*link1.*is not allowed.");
 
   // We cannot add an unregistered joint type.
   DRAKE_EXPECT_THROWS_MESSAGE(graph.AddJoint("screw1", model_instance, "screw",
-                                             BodyIndex(1), BodyIndex(2)),
+                                             LinkIndex(1), LinkIndex(2)),
                               "AddJoint\\(\\): Unrecognized type.*");
 
   // Invalid parent/child Link throws.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      graph.AddJoint("another_pin", model_instance, "revolute", BodyIndex(1),
-                     BodyIndex(9)),
+      graph.AddJoint("another_pin", model_instance, "revolute", LinkIndex(1),
+                     LinkIndex(9)),
       "AddJoint\\(\\): child link index 9 for joint '.*' refers.*"
       "non-existent or ephemeral.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      graph.AddJoint("another_pin", model_instance, "revolute", BodyIndex(9),
-                     BodyIndex(1)),
+      graph.AddJoint("another_pin", model_instance, "revolute", LinkIndex(9),
+                     LinkIndex(1)),
       "AddJoint\\(\\): parent link index 9 for joint '.*' refers.*"
       "non-existent or ephemeral.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      graph.AddJoint("joint_to_self", model_instance, "revolute", BodyIndex(5),
-                     BodyIndex(5)),
+      graph.AddJoint("joint_to_self", model_instance, "revolute", LinkIndex(5),
+                     LinkIndex(5)),
       "AddJoint\\(\\): Joint.*joint_to_self.*instance 5.*would connect.*link5.*"
       "to itself.");
 
@@ -567,9 +567,9 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   EXPECT_EQ(ssize(graph.joints()), 5);
 
   // Verify we can get bodies/joints.
-  EXPECT_EQ(graph.link_by_index(BodyIndex(3)).name(), "link3");
+  EXPECT_EQ(graph.link_by_index(LinkIndex(3)).name(), "link3");
   EXPECT_EQ(graph.joint_by_index(JointIndex(3)).name(), "pin4");
-  EXPECT_THROW((void)graph.link_by_index(BodyIndex(9)), std::exception);
+  EXPECT_THROW((void)graph.link_by_index(LinkIndex(9)), std::exception);
   EXPECT_THROW((void)graph.joint_by_index(JointIndex(9)), std::exception);
 
   // Verify we can query if a Link/Joint is in the graph.
@@ -584,9 +584,9 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   // We can add a Static Link with no Joint, or attach it to World with an
   // explicit Weld, but we can't use any other kind of Joint to World.
   graph.AddLink("static6", static_model_instance);
-  const BodyIndex static7_index =
+  const LinkIndex static7_index =
       graph.AddLink("static7", static_model_instance);
-  const BodyIndex static8_index =
+  const LinkIndex static8_index =
       graph.AddLink("static8", model_instance, LinkFlags::kStatic);
   graph.AddJoint("static7_weld", model_instance,  // OK
                  "weld", graph.world_link().index(), static7_index);
@@ -599,8 +599,8 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
   // Now add a free link and a free-floating pair.
   graph.AddLink("free9", model_instance);
 
-  const BodyIndex link10_index = graph.AddLink("link10", model_instance);
-  const BodyIndex base11_index =
+  const LinkIndex link10_index = graph.AddLink("link10", model_instance);
+  const LinkIndex base11_index =
       graph.AddLink("base11", model_instance, LinkFlags::kMustBeBaseBody);
   const JointIndex joint_10_11_index = graph.AddJoint(
       "weld", model_instance, "weld", link10_index, base11_index);
@@ -626,7 +626,7 @@ GTEST_TEST(LinkJointGraph, RemoveJoint) {
     graph.AddLink("link" + std::to_string(i), model_instance);
   for (int j = 0; j <= 2; ++j) {
     graph.AddJoint("joint" + std::to_string(j), model_instance, "revolute",
-                   BodyIndex(j + 1), BodyIndex(j + 2));
+                   LinkIndex(j + 1), LinkIndex(j + 2));
   }
 
   for (int j = 0; j < 3; ++j)
@@ -637,8 +637,8 @@ GTEST_TEST(LinkJointGraph, RemoveJoint) {
   EXPECT_TRUE(graph.has_joint(JointIndex(1)));
   EXPECT_TRUE(graph.HasJointNamed("joint1", model_instance));
 
-  const LinkJointGraph::Link& link2 = graph.link_by_index(BodyIndex(2));
-  const LinkJointGraph::Link& link3 = graph.link_by_index(BodyIndex(3));
+  const LinkJointGraph::Link& link2 = graph.link_by_index(LinkIndex(2));
+  const LinkJointGraph::Link& link3 = graph.link_by_index(LinkIndex(3));
 
   EXPECT_EQ(ssize(link2.joints()), 2);
   EXPECT_EQ(ssize(link3.joints()), 2);
@@ -686,7 +686,7 @@ GTEST_TEST(LinkJointGraph, RemoveJoint) {
   // Adding a new joint should wipe the ephemeral elements, whose indices
   // are then available for reassignment (unlike user element indices).
   const JointIndex replaced_index = graph.AddJoint(
-      "joint3", model_instance, "revolute", BodyIndex(2), BodyIndex(3));
+      "joint3", model_instance, "revolute", LinkIndex(2), LinkIndex(3));
   EXPECT_EQ(replaced_index, JointIndex(3));
 
   // At this point we should have

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -47,8 +47,8 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
   EXPECT_TRUE(graph.joints().empty());
   EXPECT_EQ(graph.world_link().name(), "world");
   EXPECT_EQ(graph.world_link().model_instance(), world_model_instance());
-  const BodyIndex world_link_index = graph.world_link().index();
-  EXPECT_EQ(world_link_index, BodyIndex(0));
+  const LinkIndex world_link_index = graph.world_link().index();
+  EXPECT_EQ(world_link_index, LinkIndex(0));
   const LinkOrdinal world_link_ordinal = graph.world_link().ordinal();
   EXPECT_EQ(world_link_ordinal, LinkOrdinal(0));
   EXPECT_FALSE(graph.world_link().is_massless());
@@ -139,12 +139,12 @@ GTEST_TEST(SpanningForest, TreeAndLoopConstraintAPIs) {
 
   graph.AddLink("link1", default_model_instance());
   graph.AddLink("link2", default_model_instance());
-  graph.AddJoint("joint0", default_model_instance(), "revolute", BodyIndex(0),
-                 BodyIndex(1));
-  graph.AddJoint("joint1", default_model_instance(), "revolute", BodyIndex(0),
-                 BodyIndex(2));
-  graph.AddJoint("joint2", default_model_instance(), "revolute", BodyIndex(1),
-                 BodyIndex(2));
+  graph.AddJoint("joint0", default_model_instance(), "revolute", LinkIndex(0),
+                 LinkIndex(1));
+  graph.AddJoint("joint1", default_model_instance(), "revolute", LinkIndex(0),
+                 LinkIndex(2));
+  graph.AddJoint("joint2", default_model_instance(), "revolute", LinkIndex(1),
+                 LinkIndex(2));
 
   EXPECT_TRUE(graph.BuildForest());
 
@@ -247,7 +247,7 @@ LinkJointGraph MakeMultiBranchGraph(ModelInstanceIndex left,
   for (int i = 0; i < ssize(joints); ++i) {
     const auto joint = joints[i];
     graph.AddJoint("joint" + std::to_string(i), link_to_instance[joint.second],
-                   "revolute", BodyIndex(joint.first), BodyIndex(joint.second));
+                   "revolute", LinkIndex(joint.first), LinkIndex(joint.second));
   }
 
   // Remove and re-add a joint to mess up the numbering. It will now have
@@ -256,7 +256,7 @@ LinkJointGraph MakeMultiBranchGraph(ModelInstanceIndex left,
   EXPECT_TRUE(graph.HasJointNamed("joint7", link_to_instance[7]));
   graph.RemoveJoint(JointIndex(7));  // The joint between 3 & 8.
   graph.AddJoint("joint7replaced", link_to_instance[7], "revolute",
-                 BodyIndex(3), BodyIndex(7));
+                 LinkIndex(3), LinkIndex(7));
   EXPECT_FALSE(graph.has_joint(JointIndex(7)));
   EXPECT_FALSE(graph.HasJointNamed("joint7", link_to_instance[7]));
   EXPECT_TRUE(graph.has_joint(JointIndex(12)));
@@ -326,7 +326,7 @@ GTEST_TEST(SpanningForest, MultipleBranchesDefaultOptions) {
       {0, 0}, {1, 1}, {2, 4},   {3, 5},   {4, 6},   {5, 9},   {6, 10}, {7, 12},
       {8, 3}, {9, 8}, {10, 11}, {11, 13}, {12, 14}, {13, 15}, {14, 7}, {15, 2}};
   for (auto mobod_link : mobod_link_map) {
-    EXPECT_EQ(graph.link_to_mobod(BodyIndex(mobod_link.second)),
+    EXPECT_EQ(graph.link_to_mobod(LinkIndex(mobod_link.second)),
               MobodIndex(mobod_link.first));
     EXPECT_EQ(forest.mobod_to_link_ordinal(MobodIndex(mobod_link.first)),
               LinkOrdinal(mobod_link.second));
@@ -519,7 +519,7 @@ GTEST_TEST(SpanningForest, BaseBodyChoicePolicy) {
   for (int i = 0; i < ssize(joints); ++i) {
     const auto joint = joints[i];
     graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
-                   "revolute", BodyIndex(joint.first), BodyIndex(joint.second));
+                   "revolute", LinkIndex(joint.first), LinkIndex(joint.second));
   }
 
   EXPECT_TRUE(graph.BuildForest());
@@ -623,19 +623,19 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   // Put static bodies in this model instance.
   const ModelInstanceIndex static_model_instance(100);
 
-  BodyIndex parent = graph.AddLink("link1", model_instance);
+  LinkIndex parent = graph.AddLink("link1", model_instance);
   graph.AddJoint("pin1", model_instance, "revolute", world_index(), parent);
   for (int i = 2; i <= 5; ++i) {
-    BodyIndex child = graph.AddLink("link" + std::to_string(i), model_instance);
+    LinkIndex child = graph.AddLink("link" + std::to_string(i), model_instance);
     graph.AddJoint("pin" + std::to_string(i), model_instance, "revolute",
                    parent, child);
     parent = child;
   }
 
   graph.AddLink("static6", static_model_instance);
-  const BodyIndex static7_index =
+  const LinkIndex static7_index =
       graph.AddLink("static7", static_model_instance);
-  const BodyIndex static8_index =
+  const LinkIndex static8_index =
       graph.AddLink("static8", model_instance, LinkFlags::kStatic);
   // Manually adding a weld to World is allowable for a static Link.
   const JointIndex static7_joint_index =
@@ -644,8 +644,8 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   // Now add a free link and a free-floating pair.
   graph.AddLink("free9", model_instance);
 
-  const BodyIndex link10_index = graph.AddLink("link10", model_instance);
-  const BodyIndex base11_index =
+  const LinkIndex link10_index = graph.AddLink("link10", model_instance);
+  const LinkIndex base11_index =
       graph.AddLink("base11", model_instance, LinkFlags::kMustBeBaseBody);
   const JointIndex joint_10_11_index = graph.AddJoint(
       "weld", model_instance, "weld", link10_index, base11_index);
@@ -691,9 +691,9 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_EQ(graph.joint_by_index(free9_joint_index).traits_index(),
             LinkJointGraph::quaternion_floating_joint_traits_index());
 
-  const std::vector<BodyIndex> link_composites0{BodyIndex(0), BodyIndex(7),
-                                                BodyIndex(6), BodyIndex(8)};
-  const std::vector<BodyIndex> link_composites1{BodyIndex(11), BodyIndex(10)};
+  const std::vector<LinkIndex> link_composites0{LinkIndex(0), LinkIndex(7),
+                                                LinkIndex(6), LinkIndex(8)};
+  const std::vector<LinkIndex> link_composites1{LinkIndex(11), LinkIndex(10)};
 
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
             link_composites0);
@@ -720,8 +720,8 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
 
   // Counts for generic middle Mobod.
   const SpanningForest::Mobod& mobod_for_link3 =
-      forest.mobods(graph.link_by_index(BodyIndex(3)).mobod_index());
-  EXPECT_EQ(graph.links(mobod_for_link3.link_ordinal()).index(), BodyIndex(3));
+      forest.mobods(graph.link_by_index(LinkIndex(3)).mobod_index());
+  EXPECT_EQ(graph.links(mobod_for_link3.link_ordinal()).index(), LinkIndex(3));
   EXPECT_EQ(mobod_for_link3.q_start(), 2);
   EXPECT_EQ(mobod_for_link3.v_start(), 2);
   EXPECT_EQ(mobod_for_link3.nq(), 1);
@@ -734,7 +734,7 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
 
   // Counts for a Mobod with nq != nv.
   const SpanningForest::Mobod& mobod_for_base11 =
-      forest.mobods(graph.link_by_index(BodyIndex(11)).mobod_index());
+      forest.mobods(graph.link_by_index(LinkIndex(11)).mobod_index());
   EXPECT_EQ(mobod_for_base11.q_start(), 5);
   EXPECT_EQ(mobod_for_base11.v_start(), 5);
   EXPECT_EQ(mobod_for_base11.nq(), 7);
@@ -858,9 +858,9 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_EQ(ssize(forest.mobods()), 6);
   EXPECT_EQ(ssize(forest.trees()), 1);
   EXPECT_EQ(ssize(forest.welded_mobods()), 1);  // Just World.
-  const std::vector<BodyIndex> expected_link_composite{
-      BodyIndex(0),  BodyIndex(7),  BodyIndex(6), BodyIndex(8),
-      BodyIndex(11), BodyIndex(10), BodyIndex(9)};
+  const std::vector<LinkIndex> expected_link_composite{
+      LinkIndex(0),  LinkIndex(7),  LinkIndex(6), LinkIndex(8),
+      LinkIndex(11), LinkIndex(10), LinkIndex(9)};
   EXPECT_EQ(ssize(graph.link_composites()), 1);
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
             expected_link_composite);
@@ -989,8 +989,8 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
   for (int i = 0; i < ssize(joints); ++i) {
     const auto& joint = joints[i];
     graph.AddJoint("joint" + std::to_string(i), model_instance,
-                   std::get<0>(joint), BodyIndex(std::get<1>(joint)),
-                   BodyIndex(std::get<2>(joint)));
+                   std::get<0>(joint), LinkIndex(std::get<1>(joint)),
+                   LinkIndex(std::get<2>(joint)));
   }
 
   EXPECT_EQ(ssize(graph.links()), 14);  // Includes World.
@@ -1007,14 +1007,14 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
 
   // Check that the shadows are connected up properly. See the test comment
   // above for why we expect these particular links to get split.
-  for (BodyIndex link(14); link <= 16; ++link)
+  for (LinkIndex link(14); link <= 16; ++link)
     EXPECT_TRUE(graph.link_by_index(link).is_shadow());
-  EXPECT_EQ(graph.link_by_index(BodyIndex(14)).primary_link(), 11);
-  EXPECT_EQ(graph.link_by_index(BodyIndex(11)).num_shadows(), 1);
-  EXPECT_EQ(graph.link_by_index(BodyIndex(15)).primary_link(), 1);
-  EXPECT_EQ(graph.link_by_index(BodyIndex(1)).num_shadows(), 1);
-  EXPECT_EQ(graph.link_by_index(BodyIndex(16)).primary_link(), 8);
-  EXPECT_EQ(graph.link_by_index(BodyIndex(8)).num_shadows(), 1);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(14)).primary_link(), 11);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(11)).num_shadows(), 1);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(15)).primary_link(), 1);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(1)).num_shadows(), 1);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(16)).primary_link(), 8);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(8)).num_shadows(), 1);
 
   // Check that we built the LinkComposites properly (see above).
   EXPECT_EQ(ssize(graph.link_composites()), 3);
@@ -1044,14 +1044,14 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
                                0,  7,  4,  6, 5, 2,  1,  15};
   for (const SpanningForest::Mobod& mobod : forest.mobods()) {
     EXPECT_EQ(graph.links(mobod.link_ordinal()).index(),
-              BodyIndex(mobod2link[mobod.index()]));
+              LinkIndex(mobod2link[mobod.index()]));
     if (mobod.is_world()) continue;  // No joint for World mobod.
     EXPECT_EQ(graph.joints(mobod.joint_ordinal()).index(),
               JointIndex(mobod2joint[mobod.index()]));
   }
 
   // Should get the same information from the graph.
-  for (BodyIndex link{0}; link < ssize(graph.links()); ++link) {
+  for (LinkIndex link{0}; link < ssize(graph.links()); ++link) {
     EXPECT_EQ(mobod2link[graph.link_to_mobod(link)], link);
   }
 
@@ -1072,14 +1072,14 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
   EXPECT_EQ(ssize(graph.links()), 15);  // Only one added shadow.
   EXPECT_EQ(ssize(graph.link_composites()), 3);
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
-            (std::vector<BodyIndex>{BodyIndex(0), BodyIndex(5), BodyIndex(7),
-                                    BodyIndex(12)}));
+            (std::vector<LinkIndex>{LinkIndex(0), LinkIndex(5), LinkIndex(7),
+                                    LinkIndex(12)}));
   EXPECT_EQ(
       graph.link_composites(LinkCompositeIndex(1)).links,
-      (std::vector<BodyIndex>{BodyIndex(13), BodyIndex(1), BodyIndex(4)}));
+      (std::vector<LinkIndex>{LinkIndex(13), LinkIndex(1), LinkIndex(4)}));
   EXPECT_EQ(
       graph.link_composites(LinkCompositeIndex(2)).links,
-      (std::vector<BodyIndex>{BodyIndex(10), BodyIndex(6), BodyIndex(8)}));
+      (std::vector<LinkIndex>{LinkIndex(10), LinkIndex(6), LinkIndex(8)}));
   for (LinkCompositeIndex i(0); i < 3; ++i) {
     EXPECT_FALSE(graph.link_composites(i).is_massless);
   }
@@ -1129,7 +1129,7 @@ GTEST_TEST(SpanningForest, SimpleTrees) {
                                            {10, 9}, {9, 4}, {9, 7}};
   for (int i = 0; i < 7; ++i) {
     graph.AddJoint("joint" + std::to_string(i), model_instance, "revolute",
-                   BodyIndex(joints[i].first), BodyIndex(joints[i].second));
+                   LinkIndex(joints[i].first), LinkIndex(joints[i].second));
   }
 
   EXPECT_EQ(ssize(graph.links()), 11);  // this includes the world Link.
@@ -1159,15 +1159,15 @@ GTEST_TEST(SpanningForest, SimpleTrees) {
       testing::MatchesRegex("Link link2 on revolute joint joint1.*terminal.*"
                             "singular.*cannot be used for dynamics.*"));
   EXPECT_EQ(ssize(graph.link_composites()), 2);
-  const std::vector<BodyIndex>& composite94 =
+  const std::vector<LinkIndex>& composite94 =
       graph.link_composites(LinkCompositeIndex(1)).links;
-  EXPECT_EQ(composite94, (std::vector<BodyIndex>{BodyIndex(9), BodyIndex(4)}));
+  EXPECT_EQ(composite94, (std::vector<LinkIndex>{LinkIndex(9), LinkIndex(4)}));
   EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(1)).is_massless);
 
   // Finally if we connect link 2 to a massful link forming a loop, we should
   // get a dynamics-ready forest by splitting the massful link.
-  graph.AddJoint("loop_2_to_7", model_instance, "revolute", BodyIndex(2),
-                 BodyIndex(7));
+  graph.AddJoint("loop_2_to_7", model_instance, "revolute", LinkIndex(2),
+                 LinkIndex(7));
   EXPECT_TRUE(graph.BuildForest());
   EXPECT_TRUE(forest.dynamics_ok());
   EXPECT_TRUE(forest.why_no_dynamics().empty());
@@ -1213,7 +1213,7 @@ GTEST_TEST(SpanningForest, MasslessLinksChangeLoopBreaking) {
                                            {0, 5}, {5, 6}, {6, 4}};
   for (int i = 0; i < 7; ++i) {
     graph.AddJoint("joint" + std::to_string(i), model_instance, "revolute",
-                   BodyIndex(joints[i].first), BodyIndex(joints[i].second));
+                   LinkIndex(joints[i].first), LinkIndex(joints[i].second));
   }
 
   EXPECT_EQ(ssize(graph.links()), 7);  // this includes the world Link.
@@ -1224,18 +1224,18 @@ GTEST_TEST(SpanningForest, MasslessLinksChangeLoopBreaking) {
 
   EXPECT_EQ(ssize(graph.links()), 8);  // Added a shadow.
   EXPECT_EQ(ssize(graph.joints()), 7);
-  EXPECT_TRUE(graph.link_by_index(BodyIndex(7)).is_shadow());
-  EXPECT_EQ(graph.link_by_index(BodyIndex(7)).primary_link(), BodyIndex(4));
+  EXPECT_TRUE(graph.link_by_index(LinkIndex(7)).is_shadow());
+  EXPECT_EQ(graph.link_by_index(LinkIndex(7)).primary_link(), LinkIndex(4));
 
   EXPECT_EQ(ssize(forest.trees()), 2);
   EXPECT_EQ(forest.trees()[0].num_mobods(), 4);
   EXPECT_EQ(forest.trees()[1].num_mobods(), 3);
   EXPECT_EQ(graph.links(forest.mobods(MobodIndex(4)).link_ordinal()).index(),
-            BodyIndex(7));
+            LinkIndex(7));
 
   // Changing just 3 to massless results in the same forest.
   // (Tests Case 2 in ExtendTreesOneLevel())
-  graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kMassless);
+  graph.ChangeLinkFlags(LinkIndex(3), LinkFlags::kMassless);
   EXPECT_TRUE(graph.BuildForest());
 
   // Check that links not in a composite still respond correctly.
@@ -1243,30 +1243,30 @@ GTEST_TEST(SpanningForest, MasslessLinksChangeLoopBreaking) {
 
   EXPECT_EQ(ssize(graph.links()), 8);
   EXPECT_EQ(ssize(graph.joints()), 7);
-  EXPECT_TRUE(graph.link_by_index(BodyIndex(7)).is_shadow());
-  EXPECT_EQ(graph.link_by_index(BodyIndex(7)).primary_link(), BodyIndex(4));
+  EXPECT_TRUE(graph.link_by_index(LinkIndex(7)).is_shadow());
+  EXPECT_EQ(graph.link_by_index(LinkIndex(7)).primary_link(), LinkIndex(4));
 
   EXPECT_EQ(ssize(forest.trees()), 2);
   EXPECT_EQ(forest.trees()[0].num_mobods(), 4);
   EXPECT_EQ(forest.trees()[1].num_mobods(), 3);
   EXPECT_EQ(graph.links(forest.mobods(MobodIndex(4)).link_ordinal()).index(),
-            BodyIndex(7));
+            LinkIndex(7));
 
   // Changing both 3 and 4 to massless breaks the loop at 6 instead of 4.
   // (Tests Case 3 in ExtendTreesOneLevel())
-  graph.ChangeLinkFlags(BodyIndex(4), LinkFlags::kMassless);
+  graph.ChangeLinkFlags(LinkIndex(4), LinkFlags::kMassless);
   EXPECT_TRUE(graph.BuildForest());
 
   EXPECT_EQ(ssize(graph.links()), 8);
   EXPECT_EQ(ssize(graph.joints()), 7);
-  EXPECT_TRUE(graph.link_by_index(BodyIndex(7)).is_shadow());
-  EXPECT_EQ(graph.link_by_index(BodyIndex(7)).primary_link(), BodyIndex(6));
+  EXPECT_TRUE(graph.link_by_index(LinkIndex(7)).is_shadow());
+  EXPECT_EQ(graph.link_by_index(LinkIndex(7)).primary_link(), LinkIndex(6));
 
   EXPECT_EQ(ssize(forest.trees()), 2);
   EXPECT_EQ(forest.trees()[0].num_mobods(), 5);
   EXPECT_EQ(forest.trees()[1].num_mobods(), 2);
   EXPECT_EQ(graph.links(forest.mobods(MobodIndex(5)).link_ordinal()).index(),
-            BodyIndex(7));
+            LinkIndex(7));
 }
 
 /* Here is a tricky case that should be handled correctly and without warnings.
@@ -1310,13 +1310,13 @@ GTEST_TEST(SpanningForest, MasslessBodiesShareSplitLink) {
   graph.AddLink("link_3", model_instance);
 
   graph.AddJoint("prismatic_0", model_instance, "prismatic", world_index(),
-                 BodyIndex(1));
+                 LinkIndex(1));
   graph.AddJoint("prismatic_1", model_instance, "prismatic", world_index(),
-                 BodyIndex(2));
-  graph.AddJoint("revolute_2", model_instance, "revolute", BodyIndex(1),
-                 BodyIndex(3));
-  graph.AddJoint("revolute_3", model_instance, "revolute", BodyIndex(2),
-                 BodyIndex(3));
+                 LinkIndex(2));
+  graph.AddJoint("revolute_2", model_instance, "revolute", LinkIndex(1),
+                 LinkIndex(3));
+  graph.AddJoint("revolute_3", model_instance, "revolute", LinkIndex(2),
+                 LinkIndex(3));
 
   EXPECT_EQ(ssize(graph.links()), 4);  // Before modeling (includes World).
   EXPECT_EQ(graph.num_user_links(), 4);
@@ -1328,9 +1328,9 @@ GTEST_TEST(SpanningForest, MasslessBodiesShareSplitLink) {
   EXPECT_EQ(graph.num_user_links(), 4);
   EXPECT_EQ(ssize(graph.loop_constraints()), 1);
 
-  const auto& shadow_link = graph.link_by_index(BodyIndex(4));
+  const auto& shadow_link = graph.link_by_index(LinkIndex(4));
   EXPECT_TRUE(shadow_link.is_shadow());
-  EXPECT_EQ(shadow_link.primary_link(), BodyIndex(3));
+  EXPECT_EQ(shadow_link.primary_link(), LinkIndex(3));
   EXPECT_EQ(shadow_link.mobod_index(), MobodIndex(4));
   EXPECT_EQ(shadow_link.inboard_joint_index(), JointIndex(3));
   EXPECT_EQ(ssize(shadow_link.joints()), 1);
@@ -1338,9 +1338,9 @@ GTEST_TEST(SpanningForest, MasslessBodiesShareSplitLink) {
   EXPECT_EQ(shadow_link.joints_as_child()[0], JointIndex(3));
   EXPECT_EQ(shadow_link.joints()[0], JointIndex(3));
 
-  EXPECT_EQ(graph.link_by_index(BodyIndex(3)).num_shadows(), 1);
-  EXPECT_EQ(graph.link_by_index(BodyIndex(2)).num_shadows(), 0);
-  EXPECT_EQ(graph.link_by_index(BodyIndex(4)).num_shadows(), 0);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(3)).num_shadows(), 1);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(2)).num_shadows(), 0);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(4)).num_shadows(), 0);
 
   EXPECT_EQ(ssize(forest.mobods()), 5);
   EXPECT_EQ(ssize(forest.trees()), 2);
@@ -1402,7 +1402,7 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
                                            {4, 7}, {3, 6}, {5, 6}, {7, 6}};
   for (int i = 0; i < 8; ++i) {
     graph.AddJoint("joint" + std::to_string(i), model_instance, "revolute",
-                   BodyIndex(joints[i].first), BodyIndex(joints[i].second));
+                   LinkIndex(joints[i].first), LinkIndex(joints[i].second));
   }
 
   EXPECT_EQ(ssize(graph.links()), 8);  // Before modeling (includes World).
@@ -1418,9 +1418,9 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
   EXPECT_EQ(graph.num_user_links(), 8);
   EXPECT_EQ(graph.num_user_joints(), 8);
 
-  const LinkJointGraph::Link& primary_link = graph.link_by_index(BodyIndex(6));
-  const LinkJointGraph::Link& shadow_link_1 = graph.link_by_index(BodyIndex(8));
-  const LinkJointGraph::Link& shadow_link_2 = graph.link_by_index(BodyIndex(9));
+  const LinkJointGraph::Link& primary_link = graph.link_by_index(LinkIndex(6));
+  const LinkJointGraph::Link& shadow_link_1 = graph.link_by_index(LinkIndex(8));
+  const LinkJointGraph::Link& shadow_link_2 = graph.link_by_index(LinkIndex(9));
 
   EXPECT_EQ(primary_link.name(), "link6");
   EXPECT_EQ(shadow_link_1.name(), "link6$1");
@@ -1430,8 +1430,8 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
   EXPECT_TRUE(shadow_link_1.is_shadow());
   EXPECT_TRUE(shadow_link_2.is_shadow());
 
-  EXPECT_EQ(graph.link_by_index(BodyIndex(5)).num_shadows(), 0);
-  EXPECT_EQ(graph.link_by_index(BodyIndex(7)).num_shadows(), 0);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(5)).num_shadows(), 0);
+  EXPECT_EQ(graph.link_by_index(LinkIndex(7)).num_shadows(), 0);
 
   EXPECT_EQ(ssize(forest.mobods()), 10);
   EXPECT_EQ(ssize(forest.trees()), 1);
@@ -1446,7 +1446,7 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
   const std::array mobod2joint{-1, 8, 0, 3, 6, 1, 4, 7, 2, 5};
   for (const SpanningForest::Mobod& mobod : forest.mobods()) {
     EXPECT_EQ(graph.links(mobod.link_ordinal()).index(),
-              BodyIndex(mobod2link[mobod.index()]));
+              LinkIndex(mobod2link[mobod.index()]));
     if (mobod.is_world()) continue;  // No joint for World mobod.
     EXPECT_EQ(graph.joints(mobod.joint_ordinal()).index(),
               JointIndex(mobod2joint[mobod.index()]));
@@ -1460,10 +1460,10 @@ GTEST_TEST(SpanningForest, DoubleLoop) {
   EXPECT_EQ(loop1.index(), 1);
   EXPECT_EQ(loop0.model_instance(), model_instance);
   EXPECT_EQ(loop1.model_instance(), model_instance);
-  EXPECT_EQ(loop0.primary_link(), BodyIndex(6));
-  EXPECT_EQ(loop0.shadow_link(), BodyIndex(8));
-  EXPECT_EQ(loop1.primary_link(), BodyIndex(6));
-  EXPECT_EQ(loop1.shadow_link(), BodyIndex(9));
+  EXPECT_EQ(loop0.primary_link(), LinkIndex(6));
+  EXPECT_EQ(loop0.shadow_link(), LinkIndex(8));
+  EXPECT_EQ(loop1.primary_link(), LinkIndex(6));
+  EXPECT_EQ(loop1.shadow_link(), LinkIndex(9));
 
   // Added loop constraints should be named the same as their shadow Link.
   EXPECT_EQ(loop0.name(), shadow_link_1.name());
@@ -1496,11 +1496,11 @@ GTEST_TEST(SpanningForest, WorldCompositeComesFirst) {
   graph.AddLink("link3", model_instance);
   graph.AddLink("link4", model_instance);
 
-  const auto& world = graph.link_by_index(BodyIndex(0));
-  const auto& massless_link = graph.link_by_index(BodyIndex(1));
-  const auto& link2 = graph.link_by_index(BodyIndex(2));
-  const auto& link3 = graph.link_by_index(BodyIndex(3));
-  const auto& link4 = graph.link_by_index(BodyIndex(4));
+  const auto& world = graph.link_by_index(LinkIndex(0));
+  const auto& massless_link = graph.link_by_index(LinkIndex(1));
+  const auto& link2 = graph.link_by_index(LinkIndex(2));
+  const auto& link3 = graph.link_by_index(LinkIndex(3));
+  const auto& link4 = graph.link_by_index(LinkIndex(4));
 
   graph.AddJoint("joint0", model_instance, "revolute", world.index(),
                  massless_link.index());
@@ -1526,9 +1526,9 @@ GTEST_TEST(SpanningForest, WorldCompositeComesFirst) {
 
   EXPECT_EQ(ssize(graph.link_composites()), 2);
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links,
-            (std::vector<BodyIndex>{BodyIndex(0), BodyIndex(3)}));
+            (std::vector<LinkIndex>{LinkIndex(0), LinkIndex(3)}));
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(1)).links,
-            (std::vector<BodyIndex>{BodyIndex(1), BodyIndex(2)}));
+            (std::vector<LinkIndex>{LinkIndex(1), LinkIndex(2)}));
   EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(0)).is_massless);
   EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(1)).is_massless);
 
@@ -1605,7 +1605,7 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
   for (int i = 0; i < ssize(joints); ++i) {
     const auto joint = joints[i];
     graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
-                   "revolute", BodyIndex(joint.first), BodyIndex(joint.second));
+                   "revolute", LinkIndex(joint.first), LinkIndex(joint.second));
   }
 
   EXPECT_TRUE(graph.BuildForest());
@@ -1618,7 +1618,7 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
 
   // See right-hand graph above. We're expecting to split link 3 since that
   // will produce equal-length branches.
-  const LinkJointGraph::Link& primary_link = graph.link_by_index(BodyIndex(3));
+  const LinkJointGraph::Link& primary_link = graph.link_by_index(LinkIndex(3));
   EXPECT_FALSE(primary_link.is_shadow());
   EXPECT_EQ(primary_link.num_shadows(), 1);
   EXPECT_EQ(primary_link.mobod_index(), MobodIndex(2));
@@ -1631,7 +1631,7 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
   EXPECT_EQ(primary_link.joints_as_child(), (std::vector{JointIndex(2)}));
   EXPECT_EQ(primary_link.joints_as_parent(), (std::vector{JointIndex(3)}));
 
-  const LinkJointGraph::Link& shadow_link = graph.link_by_index(BodyIndex(4));
+  const LinkJointGraph::Link& shadow_link = graph.link_by_index(LinkIndex(4));
   EXPECT_TRUE(shadow_link.is_shadow());
   // Shadow 1 of link 3 should be "link3$1", but that name conflicts with a
   // nutty user name so we have to disambiguate with underscores.
@@ -1664,12 +1664,12 @@ GTEST_TEST(SpanningForest, ShadowLinkPreservesJointOrder) {
   }
 
   // Now make link3 massless, rebuild, and check a few things.
-  graph.ChangeLinkFlags(BodyIndex(3), LinkFlags::kMassless);
+  graph.ChangeLinkFlags(LinkIndex(3), LinkFlags::kMassless);
   EXPECT_TRUE(graph.BuildForest());
   const LinkJointGraph::Link& new_primary_link =
-      graph.link_by_index(BodyIndex(2));
+      graph.link_by_index(LinkIndex(2));
   const LinkJointGraph::Link& new_shadow_link =
-      graph.link_by_index(BodyIndex(4));
+      graph.link_by_index(LinkIndex(4));
 
   EXPECT_EQ(ssize(forest.mobods()), 5);
   EXPECT_EQ(ssize(forest.trees()), 2);
@@ -1719,8 +1719,8 @@ GTEST_TEST(SpanningForest, MasslessLoopAreDetected) {
   const std::vector<pair<int, int>> joints{{4, 1}, {4, 3}, {1, 2}, {2, 3}};
   for (int i = 0; i < ssize(joints); ++i) {
     graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
-                   "revolute", BodyIndex(joints[i].first),
-                   BodyIndex(joints[i].second));
+                   "revolute", LinkIndex(joints[i].first),
+                   LinkIndex(joints[i].second));
   }
 
   EXPECT_FALSE(graph.BuildForest());
@@ -1729,7 +1729,7 @@ GTEST_TEST(SpanningForest, MasslessLoopAreDetected) {
       testing::MatchesRegex("Loop breaks.*joint1.*between two massless links.*"
                             "link4.*link3.*cannot be used for dynamics.*"));
 
-  graph.ChangeLinkFlags(BodyIndex(1), LinkFlags::kDefault);  // Massful now.
+  graph.ChangeLinkFlags(LinkIndex(1), LinkFlags::kDefault);  // Massful now.
   EXPECT_TRUE(graph.BuildForest());
 
   /* Make a new graph where World replaces body 4.
@@ -1750,8 +1750,8 @@ GTEST_TEST(SpanningForest, MasslessLoopAreDetected) {
       {0, 1}, {0, 3}, {1, 2}, {2, 3}};
   for (int i = 0; i < ssize(world_graph_joints); ++i) {
     world_graph.AddJoint("joint" + std::to_string(i), default_model_instance(),
-                         "revolute", BodyIndex(world_graph_joints[i].first),
-                         BodyIndex(world_graph_joints[i].second));
+                         "revolute", LinkIndex(world_graph_joints[i].first),
+                         LinkIndex(world_graph_joints[i].second));
   }
 
   /* Check that we split World as expected. */
@@ -1760,9 +1760,9 @@ GTEST_TEST(SpanningForest, MasslessLoopAreDetected) {
   EXPECT_EQ(ssize(world_graph.links()), 5);
   EXPECT_EQ(ssize(world_graph.forest().mobods()), 5);
   EXPECT_EQ(world_graph.world_link().num_shadows(), 1);
-  EXPECT_TRUE(world_graph.link_by_index(BodyIndex(4)).is_shadow());
-  EXPECT_EQ(world_graph.link_by_index(BodyIndex(4)).primary_link(),
-            BodyIndex(0));
+  EXPECT_TRUE(world_graph.link_by_index(LinkIndex(4)).is_shadow());
+  EXPECT_EQ(world_graph.link_by_index(LinkIndex(4)).primary_link(),
+            LinkIndex(0));
 }
 
 /* Composite bodies should be treated the same as single bodies while
@@ -1808,14 +1808,14 @@ GTEST_TEST(SpanningForest, LoopWithComposites) {
       {0, 1}, {2, 3}, {4, 5}, {0, 7}, {7, 8}, {8, 9}, {9, 10}, {6, 10}};
   for (int i = 0; i < ssize(weld_joints); ++i) {
     graph.AddJoint("weld_joint_" + std::to_string(i), model_instance, "weld",
-                   BodyIndex(weld_joints[i].first),
-                   BodyIndex(weld_joints[i].second));
+                   LinkIndex(weld_joints[i].first),
+                   LinkIndex(weld_joints[i].second));
   }
   for (int i = 0; i < ssize(revolute_joints); ++i) {
     const int j = ssize(weld_joints) + i;  // joint number
     graph.AddJoint("revolute_joint_" + std::to_string(j), model_instance,
-                   "revolute", BodyIndex(revolute_joints[i].first),
-                   BodyIndex(revolute_joints[i].second));
+                   "revolute", LinkIndex(revolute_joints[i].first),
+                   LinkIndex(revolute_joints[i].second));
   }
 
   // Before modeling
@@ -1958,14 +1958,14 @@ GTEST_TEST(SpanningForest, MasslessMergedComposites) {
 
   for (int i = 0; i < ssize(revolute_joints); ++i) {
     graph.AddJoint("joint_" + std::to_string(i), model_instance, "revolute",
-                   BodyIndex(revolute_joints[i].first),
-                   BodyIndex(revolute_joints[i].second));
+                   LinkIndex(revolute_joints[i].first),
+                   LinkIndex(revolute_joints[i].second));
   }
   for (int i = 0; i < ssize(weld_joints); ++i) {
     const int j = ssize(revolute_joints) + i;  // joint number
     graph.AddJoint("joint_" + std::to_string(j), model_instance, "weld",
-                   BodyIndex(weld_joints[i].first),
-                   BodyIndex(weld_joints[i].second));
+                   LinkIndex(weld_joints[i].first),
+                   LinkIndex(weld_joints[i].second));
   }
 
   // Before modeling
@@ -1993,11 +1993,11 @@ GTEST_TEST(SpanningForest, MasslessMergedComposites) {
   EXPECT_EQ(forest.trees(TreeIndex(0)).height(), 3);
   EXPECT_EQ(forest.trees(TreeIndex(1)).height(), 3);
 
-  const auto& shadow_link = graph.link_by_index(BodyIndex(9));
+  const auto& shadow_link = graph.link_by_index(LinkIndex(9));
   EXPECT_TRUE(shadow_link.is_shadow());
   EXPECT_EQ(shadow_link.name(), "link3$1");
-  EXPECT_EQ(shadow_link.index(), BodyIndex(9));
-  EXPECT_EQ(shadow_link.primary_link(), BodyIndex(3));
+  EXPECT_EQ(shadow_link.index(), LinkIndex(9));
+  EXPECT_EQ(shadow_link.primary_link(), LinkIndex(3));
   EXPECT_EQ(shadow_link.mobod_index(), MobodIndex(6));
   ASSERT_EQ(ssize(shadow_link.joints()), 1);
   EXPECT_EQ(shadow_link.joints()[0], JointIndex(5));
@@ -2005,7 +2005,7 @@ GTEST_TEST(SpanningForest, MasslessMergedComposites) {
   ASSERT_EQ(ssize(graph.link_composites()), 1);  // just the world composite
   EXPECT_EQ(
       graph.link_composites(LinkCompositeIndex(0)).links,
-      (std::vector{BodyIndex(0), BodyIndex(4), BodyIndex(5), BodyIndex(6)}));
+      (std::vector{LinkIndex(0), LinkIndex(4), LinkIndex(5), LinkIndex(6)}));
 
   /* (Test 2) Change the type of joint 6 (connects {4} to World) from weld
   to revolute. That should move massless composite {4:5:6} onto its own Mobod.
@@ -2022,26 +2022,26 @@ GTEST_TEST(SpanningForest, MasslessMergedComposites) {
 
   EXPECT_EQ(forest.trees(TreeIndex(0)).height(), 4);
   EXPECT_EQ(forest.trees(TreeIndex(1)).height(), 3);
-  const auto& new_shadow_link = graph.link_by_index(BodyIndex(9));
+  const auto& new_shadow_link = graph.link_by_index(LinkIndex(9));
   EXPECT_TRUE(new_shadow_link.is_shadow());
   EXPECT_EQ(new_shadow_link.name(), "link8$1");
 
-  for (BodyIndex i(4); i <= 6; ++i)
+  for (LinkIndex i(4); i <= 6; ++i)
     EXPECT_EQ(graph.link_by_index(i).mobod_index(), 5);  // Merged to one Mobod.
 
   ASSERT_EQ(ssize(graph.link_composites()), 2);  // world and {4:5:6}
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(1)).links,
-            (std::vector{BodyIndex(4), BodyIndex(5), BodyIndex(6)}));
+            (std::vector{LinkIndex(4), LinkIndex(5), LinkIndex(6)}));
 
   /* (Test 3) Change links 7 and 8 to be massless so that we have to continue
   extending the branch after the massless composite to hunt down something
   massful with which to end the branch in Tree 1. This should affect when we see
   the loop so Tree 0 will have height 3 and Tree 1 height 4, with link 3
   split. */
-  graph.ChangeLinkFlags(BodyIndex(7), LinkFlags::kMassless);
-  graph.ChangeLinkFlags(BodyIndex(8), LinkFlags::kMassless);
+  graph.ChangeLinkFlags(LinkIndex(7), LinkFlags::kMassless);
+  graph.ChangeLinkFlags(LinkIndex(8), LinkFlags::kMassless);
   EXPECT_TRUE(graph.BuildForest());
-  const auto& newer_shadow_link = graph.link_by_index(BodyIndex(9));
+  const auto& newer_shadow_link = graph.link_by_index(LinkIndex(9));
   EXPECT_TRUE(newer_shadow_link.is_shadow());
   EXPECT_EQ(newer_shadow_link.name(), "link3$1");
 
@@ -2085,10 +2085,10 @@ GTEST_TEST(SpanningForest, CheckMergingPolicy) {
   graph.RegisterJointType("revolute", 1, 1);
   for (int i = 1; i <= 3; ++i)
     graph.AddLink("link" + std::to_string(i), ModelInstanceIndex(i));
-  graph.AddJoint("revolute_0", ModelInstanceIndex(4), "revolute", BodyIndex(0),
-                 BodyIndex(1));
-  graph.AddJoint("weld_1", ModelInstanceIndex(5), "weld", BodyIndex(1),
-                 BodyIndex(2));
+  graph.AddJoint("revolute_0", ModelInstanceIndex(4), "revolute", LinkIndex(0),
+                 LinkIndex(1));
+  graph.AddJoint("weld_1", ModelInstanceIndex(5), "weld", LinkIndex(1),
+                 LinkIndex(2));
 
   graph.SetForestBuildingOptions(ModelInstanceIndex(3),
                                  ForestBuildingOptions::kStatic);
@@ -2145,8 +2145,8 @@ GTEST_TEST(SpanningForest, VisualizationWithGraphviz) {
   // Input graph:
   //   {0} {1} -> {2}
   // Will get an ephemeral floating joint between {0} and {1}.
-  const BodyIndex link1 = graph.AddLink("link1", default_model_instance());
-  const BodyIndex link2 = graph.AddLink("link2", default_model_instance());
+  const LinkIndex link1 = graph.AddLink("link1", default_model_instance());
+  const LinkIndex link2 = graph.AddLink("link2", default_model_instance());
   graph.AddJoint("joint0", default_model_instance(), "revolute", link1, link2);
   EXPECT_TRUE(graph.BuildForest());
 

--- a/multibody/tree/multibody_tree_indexes.h
+++ b/multibody/tree/multibody_tree_indexes.h
@@ -34,7 +34,8 @@ inline MobodIndex world_mobod_index() { return MobodIndex(0); }
 /// Type used to identify frames by index in a multibody tree system.
 using FrameIndex = TypeSafeIndex<class FrameTag>;
 
-/// Type used to identify bodies by index in a multibody tree system.
+/// Type used to identify RigidBodies (a.k.a. Links) by index in a multibody
+/// system. Interchangeable with LinkIndex.
 using BodyIndex = TypeSafeIndex<class BodyTag>;
 
 /// Type used to identify force elements by index within a multibody tree


### PR DESCRIPTION
This defines an alias LinkIndex for BodyIndex and uses it exclusively in the new topology code where we use the term "Link" exclusively. I should have done this much earlier, sorry for the pain previous reviewers! The code is much more readable like this.

The symbol `drake::multibody::LinkIndex` is defined as an alias for `drake::multibody::BodyIndex`. I'm not sure whether we need to mention that in release notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21811)
<!-- Reviewable:end -->
