### PR TITLE
[workspace] Bump CRU and VGT 2024-08-14

### DIFF
--- a/tools/workspace/common_robotics_utilities/repository.bzl
+++ b/tools/workspace/common_robotics_utilities/repository.bzl
@@ -12,8 +12,8 @@ def common_robotics_utilities_repository(
         updated in ToyotaResearchInstitute/common_robotics_utilities/test/ or
         ToyotaResearchInstitute/common_robotics_utilities/CMakeLists.txt.ros2
         """,
-        commit = "366ac8a9d9c9c8d1dd2ae8c93d243906b7657598",
-        sha256 = "9247e5652c55824940b2ea9c5b9c113f2676efa8c372731f541987647c1546e9",  # noqa
+        commit = "80a6ce74b1d7c26101164d3cefa476320e552ea0",
+        sha256 = "1e0fa7afb941ef6e66c22d3cef36e94eecebaf27d17a345f16b6e85076a80587",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             ":patches/vendor.patch",

--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -10,8 +10,8 @@ def voxelized_geometry_tools_repository(
         When updating, ensure that any new unit tests are reflected in
         package.BUILD.bazel and BUILD.bazel in drake.
         """,
-        commit = "b466fbc96db4145a61c8eebb9071bb48660d174d",
-        sha256 = "5590cd8668a6fde093ceaf87618ac866dccf3d547422b86c0e7eb2ecd0d3706a",  # noqa
+        commit = "1925e129778d9c8b74818c72dfa1314a1ccf5737",
+        sha256 = "bf3389a7d61dddce7eb327baad0f4ac4e34da6e57857572ddcce762c08e70920",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             ":patches/vendor.patch",


### PR DESCRIPTION
Bumps CRU and VGT to latest, upstream changes address new warnings on 24.04 and `-Wmissing-declarations`.

+@ggould-tri for review, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21812)
<!-- Reviewable:end -->
