### PR TITLE
CartesianProduct Getters for A and b Properties

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -235,7 +235,9 @@ void DefineGeometryOptimization(py::module m) {
         .def("num_factors", &CartesianProduct::num_factors,
             cls_doc.num_factors.doc)
         .def("factor", &CartesianProduct::factor, py_rvp::reference_internal,
-            py::arg("index"), cls_doc.factor.doc);
+            py::arg("index"), cls_doc.factor.doc)
+        .def("A", &CartesianProduct::A, cls_doc.A.doc)
+        .def("b", &CartesianProduct::b, cls_doc.b.doc);
   }
 
   // HPolyhedron

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -547,6 +547,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertTrue(sum.PointInSet(sum.MaybeGetFeasiblePoint()))
         self.assertEqual(sum.ambient_dimension(), 6)
         self.assertEqual(sum.num_factors(), 2)
+        self.assertIsNone(sum.A())
+        self.assertIsNone(sum.b())
         sum2 = mut.CartesianProduct(sets=[point, h_box])
         self.assertEqual(sum2.ambient_dimension(), 6)
         self.assertEqual(sum2.num_factors(), 2)
@@ -556,6 +558,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(sum2.ambient_dimension(), 3)
         self.assertEqual(sum2.num_factors(), 2)
         self.assertIsInstance(sum2.factor(1), mut.HPolyhedron)
+        self.assertIsInstance(sum2.A(), np.ndarray)
+        self.assertIsInstance(sum2.b(), np.ndarray)
 
     def test_intersection(self):
         mut.Intersection()

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -73,6 +73,14 @@ class CartesianProduct final : public ConvexSet {
   product. */
   const ConvexSet& factor(int i) const;
 
+  /** Returns a pointer to the matrix A if it has been set, or nullptr
+  otherwise. */
+  std::optional<Eigen::MatrixXd> A() const { return A_; }
+
+  /** Returns a pointer to the vector b if it has been set, or nullptr
+  otherwise. */
+  std::optional<Eigen::VectorXd> b() const { return b_; }
+
   /** Returns true if each subvector is in its corresponding set with tolerance
   `tol`.  Note: Tolerance support for this query varies in the different convex
   set implementations. */

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -73,12 +73,12 @@ class CartesianProduct final : public ConvexSet {
   product. */
   const ConvexSet& factor(int i) const;
 
-  /** Returns a pointer to the matrix A if it has been set, or nullptr
-  otherwise. */
+  /** Returns a copy of the matrix A if it has been set, or nullopt otherwise.
+   */
   std::optional<Eigen::MatrixXd> A() const { return A_; }
 
-  /** Returns a pointer to the vector b if it has been set, or nullptr
-  otherwise. */
+  /** Returns a copy of the vector b if it has been set, or nullopt otherwise.
+   */
   std::optional<Eigen::VectorXd> b() const { return b_; }
 
   /** Returns true if each subvector is in its corresponding set with tolerance

--- a/geometry/optimization/test/cartesian_product_test.cc
+++ b/geometry/optimization/test/cartesian_product_test.cc
@@ -84,6 +84,10 @@ GTEST_TEST(CartesianProductTest, BasicTest) {
   // Test MaybeGetFeasiblePoint.
   ASSERT_TRUE(S2.MaybeGetFeasiblePoint().has_value());
   EXPECT_TRUE(S2.PointInSet(S2.MaybeGetFeasiblePoint().value()));
+
+  // Test the A and b getters (since not specified, they should be nullopt).
+  EXPECT_EQ(S2.A(), std::nullopt);
+  EXPECT_EQ(S2.b(), std::nullopt);
 }
 
 GTEST_TEST(CartesianProductTest, DefaultCtor) {
@@ -239,6 +243,12 @@ GTEST_TEST(CartesianProductTest, ScaledPoints) {
   const CartesianProduct S(MakeConvexSets(P1, P2), A, b);
 
   const double kTol = 1e-15;
+
+  ASSERT_TRUE(S.A().has_value());
+  ASSERT_TRUE(S.b().has_value());
+  EXPECT_TRUE(CompareMatrices(S.A().value(), A, kTol));
+  EXPECT_TRUE(CompareMatrices(S.b().value(), b, kTol));
+
   const Vector2d in{-0.6, 0.08};
   EXPECT_TRUE(S.PointInSet(in, kTol));
   ASSERT_TRUE(S.MaybeGetPoint().has_value());


### PR DESCRIPTION
`CartesianProduct` has optional members `A_` and `b_`, which are essential to the properties of the set, but can only be accessed indirectly (i.e., via checking if a point is in the set, or calculating its volume). Currently, we can't even determine if these values have been set, let alone what the values actually are. This PR adds methods to get the values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21827)
<!-- Reviewable:end -->
