### PR TITLE
More Efficient Affine Hull Computation for Certain Subclasses of ConvexSet

### DIFF
--- a/geometry/optimization/affine_ball.cc
+++ b/geometry/optimization/affine_ball.cc
@@ -188,6 +188,17 @@ AffineBall::DoToShapeWithPose() const {
       "ToShapeWithPose is not yet supported by AffineBall.");
 }
 
+std::unique_ptr<ConvexSet> AffineBall::DoAffineHullShortcut(
+    std::optional<double> tol) const {
+  Eigen::FullPivHouseholderQR<MatrixXd> qr(B_);
+  if (tol) {
+    qr.setThreshold(tol.value());
+  }
+  MatrixXd basis =
+      qr.matrixQ() * MatrixXd::Identity(ambient_dimension(), qr.rank());
+  return std::make_unique<AffineSubspace>(std::move(basis), center_);
+}
+
 std::pair<VectorX<Variable>, std::vector<Binding<Constraint>>>
 AffineBall::DoAddPointInSetConstraints(
     MathematicalProgram* prog,

--- a/geometry/optimization/affine_ball.h
+++ b/geometry/optimization/affine_ball.h
@@ -163,6 +163,9 @@ class AffineBall final : public ConvexSet {
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 
+  std::unique_ptr<ConvexSet> DoAffineHullShortcut(
+      std::optional<double> tol) const final;
+
   void CheckInvariants() const;
 
   double DoCalcVolume() const final;

--- a/geometry/optimization/affine_subspace.h
+++ b/geometry/optimization/affine_subspace.h
@@ -43,19 +43,41 @@ class AffineSubspace final : public ConvexSet {
                           const Eigen::Ref<const Eigen::VectorXd>& translation);
 
   /** Constructs an affine subspace as the affine hull of another convex set.
-  This is done by finding a feasible point in the set, and then iteratively
-  computing feasible vectors until we have a basis that spans the set. If you
-  pass in a convex set whose points are matrix-valued (e.g. a Spectrahedron),
-  then the affine subspace will work over a flattened representation of those
-  coordinates. (So a Spectrahedron with n-by-n matrices will output an
-  AffineSubspace with ambient dimension (n * (n+1)) / 2.)
+  The generic approach is to find a feasible point in the set, and then
+  iteratively compute feasible vectors until we have a basis that spans the set.
+  If you pass in a convex set whose points are matrix-valued (e.g. a
+  Spectrahedron), then the affine subspace will work over a flattened
+  representation of those coordinates. (So a Spectrahedron with n-by-n matrices
+  will output an AffineSubspace with ambient dimension (n * (n+1)) / 2.)
 
   `tol` sets the numerical precision of the computation. For each dimension, a
   pair of feasible points are constructed, so as to maximize the displacement in
   that dimension. If their displacement along that dimension is larger than tol,
   then the vector connecting the points is added as a basis vector.
-  @pre !set.IsEmpty() */
-  explicit AffineSubspace(const ConvexSet& set, double tol = 1e-12);
+
+  @throws std::exception if `set` is empty.
+  @throws std::exception if `tol < 0`.
+
+  For several subclasses of ConvexSet, there is a closed-form computation (or
+  more efficient numerical computation) that is preferred.
+  - AffineBall: Can be computed via a rank-revealing decomposition; `tol` is
+  used as the numerical tolerance for the rank of the matrix. Pass
+  `std::nullopt` for `tol` to use Eigen's automatic tolerance computation.
+  - AffineSubspace: Equivalent to the copy-constructor; `tol` is ignored.
+  - CartesianProduct: Can compute the affine hull of each factor individually;
+  `tol` is propagated to the constituent calls. (This is not done if the
+  Cartesian product has an associated affine transformation.)
+  - Hyperellipsoid: Always equal to the whole ambient space; `tol` is ignored.
+  - Hyperrectangle: Can be computed in closed-form; `tol` has the same meaning
+  as in the generic affine hull computation.
+  - Point: Can be computed in closed-form; `tol` is ignored. This also
+  encompasses sets which are obviously a singleton point, as determined via
+  MaybeGetPoint.
+  - VPolytope: Can be computed via a singular value decomposition; `tol` is
+  used as the numerical tolerance for the rank of the matrix. Pass
+  `std::nullopt` for `tol` to use Eigen's automatic tolerance computation. */
+  explicit AffineSubspace(const ConvexSet& set,
+                          std::optional<double> tol = std::nullopt);
 
   ~AffineSubspace() final;
 
@@ -159,6 +181,9 @@ class AffineSubspace final : public ConvexSet {
 
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
+
+  std::unique_ptr<ConvexSet> DoAffineHullShortcut(
+      std::optional<double>) const final;
 
   double DoCalcVolume() const final;
 

--- a/geometry/optimization/cartesian_product.cc
+++ b/geometry/optimization/cartesian_product.cc
@@ -4,6 +4,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/geometry/optimization/affine_subspace.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
 #include "drake/solvers/solve.h"
@@ -360,6 +361,38 @@ CartesianProduct::DoToShapeWithPose() const {
   // TODO(russt): Consider handling Cylinder as a (very) special case.
   throw std::runtime_error(
       "ToShapeWithPose is not implemented yet for CartesianProduct.");
+}
+
+std::unique_ptr<ConvexSet> CartesianProduct::DoAffineHullShortcut(
+    std::optional<double> tol) const {
+  // TODO(cohnt): Support affine transformations of Cartesian products. For now,
+  // we just return std::nullopt and use the generic affine hull computation.
+  if (A_ != std::nullopt || b_ != std::nullopt) {
+    return nullptr;
+  }
+
+  // The basis will be a block diagonal matrix, whose blocks correspond to the
+  // bases of the affine subspace of each factor. Not all blocks will be square,
+  // and some of the columns on the right will be skipped, since the affine hull
+  // may be a proper subspace.
+  MatrixXd basis = MatrixXd::Zero(ambient_dimension(), ambient_dimension());
+  // The translation will be a vector, concatenating all of the translations of
+  // each factor. Zero-initialization is not needed, since all entries will be
+  // overwritten in the following loop.
+  VectorXd translation(ambient_dimension());
+  int current_dimension = 0;
+  int num_basis_vectors = 0;
+  for (int i = 0; i < num_factors(); ++i) {
+    AffineSubspace a(factor(i), tol);
+    basis.block(current_dimension, num_basis_vectors, a.ambient_dimension(),
+                a.AffineDimension()) = a.basis();
+    translation.segment(current_dimension, a.ambient_dimension()) =
+        a.translation();
+    current_dimension += a.ambient_dimension();
+    num_basis_vectors += a.AffineDimension();
+  }
+  return std::make_unique<AffineSubspace>(basis.leftCols(num_basis_vectors),
+                                          std::move(translation));
 }
 
 double CartesianProduct::DoCalcVolume() const {

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -135,6 +135,9 @@ class CartesianProduct final : public ConvexSet {
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 
+  std::unique_ptr<ConvexSet> DoAffineHullShortcut(
+      std::optional<double> tol) const final;
+
   // The member variables are not const in order to support move semantics.
   ConvexSets sets_{};
 

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -444,6 +444,16 @@ double ConvexSet::DoCalcVolume() const {
                   NiceTypeName::Get(*this)));
 }
 
+std::unique_ptr<ConvexSet> ConvexSet::AffineHullShortcut(
+    const ConvexSet& self, std::optional<double> tol) {
+  return self.DoAffineHullShortcut(tol);
+}
+
+std::unique_ptr<ConvexSet> ConvexSet::DoAffineHullShortcut(
+    std::optional<double>) const {
+  return nullptr;
+}
+
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -453,6 +453,22 @@ class ConvexSet {
       solvers::MathematicalProgram* prog, const ConvexSet& set,
       std::vector<solvers::Binding<solvers::Constraint>>* constraints) const;
 
+  /** When there is a more efficient strategy to compute the affine hull of this
+  set, returns affine hull as an AffineSubspace. When no efficient conversion
+  exists, returns null. The default base class implementation returns null. This
+  method is used by the AffineSubspace constructor to short-circuit the generic
+  iterative approach. (This function is static to allow calling it from the
+  AffineSubspace constructor, but is conceptially a normal member function.)
+  The return type is ConvexSet to avoid a forward declaration; any non-null
+  result must always have the AffineSubspace as its runtime type. */
+  static std::unique_ptr<ConvexSet> AffineHullShortcut(
+      const ConvexSet& self, std::optional<double> tol);
+
+  /** NVI implementation of DoAffineHullShortcut, which trivially returns null.
+  Derived classes that have efficient algorithms should override this method. */
+  virtual std::unique_ptr<ConvexSet> DoAffineHullShortcut(
+      std::optional<double> tol) const;
+
  private:
   /** Generic implementation for IsBounded() -- applicable for all convex sets.
   @pre ambient_dimension() >= 0 */

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -6,6 +6,7 @@
 #include <Eigen/Eigenvalues>
 #include <fmt/format.h>
 
+#include "drake/geometry/optimization/affine_subspace.h"
 #include "drake/math/matrix_util.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/solvers/choose_best_solver.h"
@@ -394,6 +395,16 @@ void Hyperellipsoid::ImplementGeometry(const Ellipsoid& ellipsoid, void* data) {
 void Hyperellipsoid::ImplementGeometry(const Sphere& sphere, void* data) {
   auto* A = static_cast<Eigen::Matrix3d*>(data);
   *A = Eigen::Matrix3d::Identity() / sphere.radius();
+}
+
+std::unique_ptr<ConvexSet> Hyperellipsoid::DoAffineHullShortcut(
+    std::optional<double> tol) const {
+  // Hyperellipsoids are always positive volume, so we can trivially construct
+  // their affine hull as the whole vector space.
+  unused(tol);
+  const int n = ambient_dimension();
+  return std::make_unique<AffineSubspace>(Eigen::MatrixXd::Identity(n, n),
+                                          Eigen::VectorXd::Zero(n));
 }
 
 }  // namespace optimization

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -177,6 +177,9 @@ class Hyperellipsoid final : public ConvexSet, private ShapeReifier {
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 
+  std::unique_ptr<ConvexSet> DoAffineHullShortcut(
+      std::optional<double> tol) const final;
+
   double DoCalcVolume() const final;
 
   void CheckInvariants() const;

--- a/geometry/optimization/hyperrectangle.h
+++ b/geometry/optimization/hyperrectangle.h
@@ -111,6 +111,9 @@ class Hyperrectangle final : public ConvexSet {
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 
+  std::unique_ptr<ConvexSet> DoAffineHullShortcut(
+      std::optional<double> tol) const final;
+
   // TODO(Alexandre.Amice) Implement DoProjectionShortcut.
 
   double DoCalcVolume() const final;

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -137,6 +137,9 @@ class VPolytope final : public ConvexSet, private ShapeReifier {
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;
 
+  std::unique_ptr<ConvexSet> DoAffineHullShortcut(
+      std::optional<double> tol) const final;
+
   double DoCalcVolume() const final;
 
   // Implement support shapes for the ShapeReifier interface.


### PR DESCRIPTION
`AffineSubspace` provides a generic method to compute the affine hull of an arbitrary convex set, by repeatedly solving convex optimization problems. However, for certain subclasses of `ConvexSet`, it's possible to compute the affine hull with a simpler numerical procedure, or even in closed-form. For example, we can compute the affine hull of a `VPolytope` with a singular value decomposition, and the affine hull of a `Hyperellipsoid` is always the whole space.

Holding off on looking for a reviewer until #21827 lands, since this PR builds off its functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21828)
<!-- Reviewable:end -->
