### PR TITLE
[GCS] Resolve inconsistencies in results from shortest path vs convex restriction

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -800,8 +800,18 @@ void DefineGeometryOptimization(py::module m) {
         .def("GetConstraints", &GraphOfConvexSets::Vertex::GetConstraints,
             py::arg("used_in_transcription") = all_transcriptions,
             vertex_doc.GetConstraints.doc)
-        .def("GetSolutionCost", &GraphOfConvexSets::Vertex::GetSolutionCost,
-            py::arg("result"), vertex_doc.GetSolutionCost.doc)
+        .def("GetSolutionCost",
+            overload_cast_explicit<double,
+                const solvers::MathematicalProgramResult&>(
+                &GraphOfConvexSets::Vertex::GetSolutionCost),
+            py::arg("result"), vertex_doc.GetSolutionCost.doc_1args)
+        .def("GetSolutionCost",
+            overload_cast_explicit<double,
+                const solvers::MathematicalProgramResult&,
+                const solvers::Binding<solvers::Cost>&>(
+                &GraphOfConvexSets::Vertex::GetSolutionCost),
+            py::arg("result"), py::arg("cost"),
+            vertex_doc.GetSolutionCost.doc_2args)
         .def("GetSolution", &GraphOfConvexSets::Vertex::GetSolution,
             py::arg("result"), vertex_doc.GetSolution.doc)
         .def("incoming_edges", &GraphOfConvexSets::Vertex::incoming_edges,
@@ -874,8 +884,18 @@ void DefineGeometryOptimization(py::module m) {
         .def("GetConstraints", &GraphOfConvexSets::Edge::GetConstraints,
             py::arg("used_in_transcription") = all_transcriptions,
             edge_doc.GetConstraints.doc)
-        .def("GetSolutionCost", &GraphOfConvexSets::Edge::GetSolutionCost,
-            py::arg("result"), edge_doc.GetSolutionCost.doc)
+        .def("GetSolutionCost",
+            overload_cast_explicit<double,
+                const solvers::MathematicalProgramResult&>(
+                &GraphOfConvexSets::Edge::GetSolutionCost),
+            py::arg("result"), edge_doc.GetSolutionCost.doc_1args)
+        .def("GetSolutionCost",
+            overload_cast_explicit<double,
+                const solvers::MathematicalProgramResult&,
+                const solvers::Binding<solvers::Cost>&>(
+                &GraphOfConvexSets::Edge::GetSolutionCost),
+            py::arg("result"), py::arg("cost"),
+            edge_doc.GetSolutionCost.doc_2args)
         .def("GetSolutionPhiXu", &GraphOfConvexSets::Edge::GetSolutionPhiXu,
             py::arg("result"), edge_doc.GetSolutionPhiXu.doc)
         .def("GetSolutionPhiXv", &GraphOfConvexSets::Edge::GetSolutionPhiXv,

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -773,9 +773,12 @@ class TestGeometryOptimization(unittest.TestCase):
 
         spp = mut.GraphOfConvexSets()
         source = spp.AddVertex(set=mut.Point([0.1]), name="source")
+        source_cost = source.AddCost(1.23)
         target = spp.AddVertex(set=mut.Point([0.2]), name="target")
         edge0 = spp.AddEdge(u=source, v=target, name="edge0")
+        edge0_cost = edge0.AddCost(2.34)
         edge1 = spp.AddEdge(u=source, v=target, name="edge1")
+        edge1.AddCost(3.45)
         self.assertEqual(len(spp.Vertices()), 2)
         self.assertEqual(len(spp.Edges()), 2)
         result = spp.SolveShortestPath(
@@ -859,8 +862,9 @@ class TestGeometryOptimization(unittest.TestCase):
         )
 
         # Vertex
-        self.assertAlmostEqual(
-            source.GetSolutionCost(result=result), 0.0, 1e-6)
+        self.assertAlmostEqual(source.GetSolutionCost(result=result), 1.23)
+        self.assertAlmostEqual(source.GetSolutionCost(
+            result=result, cost=source_cost), 1.23)
         np.testing.assert_array_almost_equal(
             source.GetSolution(result), [0.1], 1e-6)
         self.assertIsInstance(source.id(), mut.GraphOfConvexSets.VertexId)
@@ -868,18 +872,16 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(source.name(), "source")
         self.assertIsInstance(source.x()[0], Variable)
         self.assertIsInstance(source.set(), mut.Point)
-        var, binding = source.AddCost(
+        binding = source.AddCost(
             e=1.0+source.x()[0],
             use_in_transcription={kMIP, kRelaxation, kRestriction})
-        self.assertIsInstance(var, Variable)
         self.assertIsInstance(binding, Binding[Cost])
-        var, binding = source.AddCost(
+        binding = source.AddCost(
             binding=binding,
             use_in_transcription={kMIP, kRelaxation, kRestriction})
-        self.assertIsInstance(var, Variable)
         self.assertIsInstance(binding, Binding[Cost])
         self.assertEqual(len(source.GetCosts(
-            used_in_transcription={kMIP, kRelaxation, kRestriction})), 2)
+            used_in_transcription={kMIP, kRelaxation, kRestriction})), 3)
         binding = source.AddConstraint(f=(source.x()[0] <= 1.0))
         self.assertIsInstance(binding, Binding[Constraint])
         binding = source.AddConstraint(
@@ -928,7 +930,9 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertEqual(len(target.outgoing_edges()), 0)
 
         # Edge
-        self.assertAlmostEqual(edge0.GetSolutionCost(result=result), 0.0, 1e-6)
+        self.assertAlmostEqual(edge0.GetSolutionCost(result=result), 2.34)
+        self.assertAlmostEqual(edge0.GetSolutionCost(
+            result=result, cost=edge0_cost), 2.34)
         np.testing.assert_array_almost_equal(
             edge0.GetSolutionPhiXu(result=result), [0.1], 1e-6)
         np.testing.assert_array_almost_equal(
@@ -940,19 +944,17 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertIsInstance(edge0.phi(), Variable)
         self.assertIsInstance(edge0.xu()[0], Variable)
         self.assertIsInstance(edge0.xv()[0], Variable)
-        var, binding = edge0.AddCost(
+        binding = edge0.AddCost(
             e=1.0+edge0.xu()[0],
             use_in_transcription={kMIP, kRelaxation, kRestriction})
-        self.assertIsInstance(var, Variable)
         self.assertIsInstance(binding, Binding[Cost])
-        var, binding = edge0.AddCost(
+        binding = edge0.AddCost(
             binding=binding,
             use_in_transcription={kMIP, kRelaxation, kRestriction})
-        self.assertIsInstance(var, Variable)
         self.assertIsInstance(binding, Binding[Cost])
         self.assertEqual(len(edge0.GetCosts(
             used_in_transcription={kMIP, kRelaxation, kRestriction}
-            )), 2)
+            )), 3)
         binding = edge0.AddConstraint(f=(edge0.xu()[0] == edge0.xv()[0]))
         self.assertIsInstance(binding, Binding[Constraint])
         binding = edge0.AddConstraint(

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -590,7 +590,6 @@ class TestTrajectoryOptimization(unittest.TestCase):
         self.assertTrue(traj.end_time() - traj.start_time() >= 10)
 
         graphviz_options = GcsGraphvizOptions()
-        graphviz_options.show_costs = False
         self.assertIsInstance(
             gcs.GetGraphvizString(result=result, options=graphviz_options),
             str

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -137,13 +137,13 @@ Vertex::Vertex(VertexId id, const ConvexSet& set, std::string name)
 
 Vertex::~Vertex() = default;
 
-std::pair<Variable, Binding<Cost>> Vertex::AddCost(
+Binding<Cost> Vertex::AddCost(
     const symbolic::Expression& e,
     const std::unordered_set<Transcription>& use_in_transcription) {
   return AddCost(solvers::internal::ParseCost(e), use_in_transcription);
 }
 
-std::pair<Variable, Binding<Cost>> Vertex::AddCost(
+Binding<Cost> Vertex::AddCost(
     const Binding<Cost>& binding,
     const std::unordered_set<Transcription>& use_in_transcription) {
   DRAKE_THROW_UNLESS(
@@ -153,7 +153,12 @@ std::pair<Variable, Binding<Cost>> Vertex::AddCost(
   ell_.conservativeResize(n + 1);
   ell_[n] = Variable(fmt::format("v_ell{}", n), Variable::Type::CONTINUOUS);
   costs_.push_back({binding, use_in_transcription});
-  return std::pair<Variable, Binding<Cost>>(ell_[n], binding);
+  // Note: The ell_ variable is a slack variable used e.g. SolveShortestPath,
+  // but not e.g. SolveConvexRestriction. It is an implementation detail, and
+  // should not leak into the public interface, otherwise people could expect
+  // to call e.g. prog.GetSolution(ell_), and get different answers based on
+  // which solution method they used.
+  return binding;
 }
 
 Binding<Constraint> Vertex::AddConstraint(
@@ -211,11 +216,40 @@ std::vector<solvers::Binding<solvers::Constraint>> Vertex::GetConstraints(
 }
 
 double Vertex::GetSolutionCost(const MathematicalProgramResult& result) const {
-  return result.GetSolution(ell_).sum();
+  double sum = 0.0;
+  for (int i = 0; i < ssize(ell_); ++i) {
+    if (result.get_decision_variable_index()->contains(ell_[i].get_id())) {
+      sum += result.GetSolution(ell_[i]);
+    }
+  }
+  return sum;
+}
+
+double Vertex::GetSolutionCost(
+    const MathematicalProgramResult& result,
+    const solvers::Binding<solvers::Cost>& cost) const {
+  for (int i = 0; i < ssize(costs_); ++i) {
+    if (costs_[i].first == cost) {
+      if (result.get_decision_variable_index()->contains(ell_[i].get_id())) {
+        return result.GetSolution(ell_[i]);
+      } else {
+        return 0.0;
+      }
+    }
+  }
+  throw std::runtime_error(fmt::format(
+      "Vertex::GetSolutionCost: cost {} was not registered with this vertex.",
+      cost.to_string()));
 }
 
 VectorXd Vertex::GetSolution(const MathematicalProgramResult& result) const {
-  return result.GetSolution(placeholder_x_);
+  if (result.get_decision_variable_index()->contains(
+          placeholder_x_[0].get_id())) {
+    return result.GetSolution(placeholder_x_);
+  } else {
+    return VectorXd::Constant(ambient_dimension(),
+                              std::numeric_limits<double>::quiet_NaN());
+  }
 }
 
 void Vertex::AddIncomingEdge(Edge* e) {
@@ -284,13 +318,13 @@ VectorXDecisionVariable Edge::NewSlackVariables(int rows,
   return s;
 }
 
-std::pair<Variable, Binding<Cost>> Edge::AddCost(
+Binding<Cost> Edge::AddCost(
     const symbolic::Expression& e,
     const std::unordered_set<Transcription>& use_in_transcription) {
   return AddCost(solvers::internal::ParseCost(e), use_in_transcription);
 }
 
-std::pair<Variable, Binding<Cost>> Edge::AddCost(
+Binding<Cost> Edge::AddCost(
     const Binding<Cost>& binding,
     const std::unordered_set<Transcription>& use_in_transcription) {
   DRAKE_THROW_UNLESS(Variables(binding.variables()).IsSubsetOf(allowed_vars_));
@@ -300,7 +334,12 @@ std::pair<Variable, Binding<Cost>> Edge::AddCost(
   ell_[n] =
       Variable(fmt::format("{}ell{}", name_, n), Variable::Type::CONTINUOUS);
   costs_.push_back({binding, use_in_transcription});
-  return std::pair<Variable, Binding<Cost>>(ell_[n], binding);
+  // Note: The ell_ variable is a slack variable used e.g. SolveShortestPath,
+  // but not e.g. SolveConvexRestriction. It is an implementation detail, and
+  // should not leak into the public interface, otherwise people could expect
+  // to call e.g. prog.GetSolution(ell_), and get different answers based on
+  // which solution method they used.
+  return binding;
 }
 
 Binding<Constraint> Edge::AddConstraint(
@@ -366,17 +405,50 @@ void Edge::ClearPhiConstraints() {
 }
 
 double Edge::GetSolutionCost(const MathematicalProgramResult& result) const {
-  return result.GetSolution(ell_).sum();
+  double sum = 0.0;
+  for (int i = 0; i < ssize(ell_); ++i) {
+    if (result.get_decision_variable_index()->contains(ell_[i].get_id())) {
+      sum += result.GetSolution(ell_[i]);
+    }
+  }
+  return sum;
+}
+
+double Edge::GetSolutionCost(
+    const MathematicalProgramResult& result,
+    const solvers::Binding<solvers::Cost>& cost) const {
+  for (int i = 0; i < ssize(costs_); ++i) {
+    if (costs_[i].first == cost) {
+      if (result.get_decision_variable_index()->contains(ell_[i].get_id())) {
+        return result.GetSolution(ell_[i]);
+      } else {
+        return 0.0;
+      }
+    }
+  }
+  throw std::runtime_error(fmt::format(
+      "Edge::GetSolutionCost: cost {} was not registered with this edge.",
+      cost.to_string()));
 }
 
 Eigen::VectorXd Edge::GetSolutionPhiXu(
     const solvers::MathematicalProgramResult& result) const {
-  return result.GetSolution(y_);
+  if (result.get_decision_variable_index()->contains(y_[0].get_id())) {
+    return result.GetSolution(y_);
+  } else {
+    return VectorXd::Constant(u_->ambient_dimension(),
+                              std::numeric_limits<double>::quiet_NaN());
+  }
 }
 
 Eigen::VectorXd Edge::GetSolutionPhiXv(
     const solvers::MathematicalProgramResult& result) const {
-  return result.GetSolution(z_);
+  if (result.get_decision_variable_index()->contains(z_[0].get_id())) {
+    return result.GetSolution(z_);
+  } else {
+    return VectorXd::Constant(v_->ambient_dimension(),
+                              std::numeric_limits<double>::quiet_NaN());
+  }
 }
 
 Vertex* GraphOfConvexSets::AddVertex(const ConvexSet& set, std::string name) {
@@ -499,7 +571,7 @@ std::string GraphOfConvexSets::GetGraphvizString(
     graphviz << "v" << v_id << " [label=\"" << v->name();
     if (result) {
       if (options.show_vars) {
-        graphviz << "\nx = [" << result->GetSolution(v->x()).transpose() << "]";
+        graphviz << "\nx = [" << v->GetSolution(*result).transpose() << "]";
       }
       if (options.show_costs) {
         graphviz << "\ncost = " << v->GetSolutionCost(*result);
@@ -513,16 +585,7 @@ std::string GraphOfConvexSets::GetGraphvizString(
     graphviz << " [label=\"" << e->name();
     if (result) {
       if (options.show_costs) {
-        graphviz << "\n";
-        if (e->ell_.size() > 0) {
-          // SolveConvexRestriction does not yet return the rewritten costs.
-          if (result->get_decision_variable_index()->contains(
-                  e->ell_[0].get_id())) {
-            graphviz << "cost = " << e->GetSolutionCost(*result);
-          }
-        } else {
-          graphviz << "cost = 0";
-        }
+        graphviz << "\ncost = " << e->GetSolutionCost(*result);
       }
       if (options.show_slacks) {
         graphviz << "\n";
@@ -1316,11 +1379,17 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     int num_placeholder_vars = relaxed_phi.size();
     for (const std::pair<const VertexId, std::unique_ptr<Vertex>>& vpair :
          vertices_) {
-      num_placeholder_vars += vpair.second->ambient_dimension();
-      num_placeholder_vars += vpair.second->ell_.size();
+      const Vertex* v = vpair.second.get();
+      num_placeholder_vars += v->ambient_dimension();
+      for (int i = 0; i < v->ell_.size(); ++i) {
+        const auto& [b, transcriptions] = v->costs_[i];
+        if (IncludesCurrentTranscription(transcriptions)) {
+          num_placeholder_vars += 1;
+        }
+      }
     }
     for (const Edge* e : excluded_edges) {
-      num_placeholder_vars += e->y_.size() + e->z_.size() + e->ell_.size() + 1;
+      num_placeholder_vars += e->y_.size() + e->z_.size() + 1;
     }
     num_placeholder_vars += excluded_phi.size();
     std::unordered_map<symbolic::Variable::Id, int> decision_variable_index =
@@ -1329,16 +1398,14 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     Eigen::VectorXd x_val(count + num_placeholder_vars);
     x_val.head(count) = result.get_x_val();
     for (const Edge* e : excluded_edges) {
+      // TODO(russt): Consider not adding y_ and z_ for the excluded edges;
+      // GetSolutionPhiXu() and GetSolutionPhiXv() should handle this.
       for (int i = 0; i < e->y_.size(); ++i) {
         decision_variable_index.emplace(e->y_[i].get_id(), count);
         x_val[count++] = 0;
       }
       for (int i = 0; i < e->z_.size(); ++i) {
         decision_variable_index.emplace(e->z_[i].get_id(), count);
-        x_val[count++] = 0;
-      }
-      for (int i = 0; i < e->ell_.size(); ++i) {
-        decision_variable_index.emplace(e->ell_[i].get_id(), count);
         x_val[count++] = 0;
       }
       decision_variable_index.emplace(e->phi_.get_id(), count);
@@ -1382,14 +1449,12 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
       }
       int active_ell = 0;
       for (int i = 0; i < v->ell_.size(); ++i) {
-        decision_variable_index.emplace(v->ell_[i].get_id(), count);
         const auto& [b, transcriptions] = v->costs_[i];
         if (IncludesCurrentTranscription(transcriptions)) {
+          decision_variable_index.emplace(v->ell_[i].get_id(), count);
           x_val[count++] =
               result.GetSolution(vertex_edge_ell.at(v->id())[active_ell++])
                   .sum();
-        } else {
-          x_val[count++] = 0.0;
         }
       }
     }
@@ -1826,15 +1891,31 @@ MathematicalProgramResult GraphOfConvexSets::SolveConvexRestriction(
 
   // TODO(russt): Add the dual variables back in for the rewritten costs.
 
-  // Add phi vars.
+  // In order to access to the results that is comparable with the other GCS
+  // transcriptions, we add a few extra values to the result:
+  // - flow variables (phi) for all of the edges,
+  // - slack variables corresponding the (active) vertex and edge costs: they
+  //   are not used in the restriction, but are the only way to retrieve the
+  //   cost from the MIP and/or its convex relaxation.
+
+  // Add phi vars for all edges.
   int num_excluded_vars = edges_.size();
-  // Add any excluded vertices to the result.
-  std::vector<const Vertex*> excluded_vertices;
-  for (const auto& pair : vertices_) {
-    const Vertex* v = pair.second.get();
-    if (!vertices.contains(v)) {
-      num_excluded_vars += v->x().size();
-      excluded_vertices.emplace_back(v);
+  // Add edge cost slack variables for active_edges.
+  for (const Edge* e : active_edges) {
+    for (int i = 0; i < e->ell_.size(); ++i) {
+      const auto& [b, transcriptions] = e->costs_[i];
+      if (transcriptions.contains(Transcription::kRestriction)) {
+        num_excluded_vars += 1;
+      }
+    }
+  }
+  for (const auto* v : vertices) {
+    // Add the vertex cost slack variables.
+    for (int i = 0; i < v->ell_.size(); ++i) {
+      const auto& [b, transcriptions] = v->costs_[i];
+      if (transcriptions.contains(Transcription::kRestriction)) {
+        num_excluded_vars += 1;
+      }
     }
   }
   int count = result.get_x_val().size();
@@ -1844,16 +1925,33 @@ MathematicalProgramResult GraphOfConvexSets::SolveConvexRestriction(
       prog.decision_variable_index();
   for (const auto& pair : edges_) {
     const Edge* e = pair.second.get();
-    decision_variable_index.emplace(e->phi_.get_id(), count);
-    x_val[count++] = std::find(active_edges.begin(), active_edges.end(), e) !=
-                             active_edges.end()
-                         ? 1.0
-                         : 0.0;
+    if (std::find(active_edges.begin(), active_edges.end(), e) !=
+        active_edges.end()) {
+      // phi.
+      decision_variable_index.emplace(e->phi_.get_id(), count);
+      x_val[count++] = 1.0;
+      // edge cost slack variables.
+      for (int i = 0; i < e->ell_.size(); ++i) {
+        const auto& [b, transcriptions] = e->costs_[i];
+        if (transcriptions.contains(Transcription::kRestriction)) {
+          decision_variable_index.emplace(e->ell_[i].get_id(), count);
+          x_val[count++] = result.EvalBinding(b)[0];
+        }
+      }
+    } else {
+      // phi.
+      decision_variable_index.emplace(e->phi_.get_id(), count);
+      x_val[count++] = 0.0;
+    }
   }
-  for (const Vertex* v : excluded_vertices) {
-    for (int i = 0; i < v->x().size(); ++i) {
-      decision_variable_index.emplace(v->x()[i].get_id(), count);
-      x_val[count++] = std::numeric_limits<double>::quiet_NaN();
+  for (const auto* v : vertices) {
+    // vertex cost slack variables.
+    for (int i = 0; i < v->ell_.size(); ++i) {
+      const auto& [b, transcriptions] = v->costs_[i];
+      if (transcriptions.contains(Transcription::kRestriction)) {
+        decision_variable_index.emplace(v->ell_[i].get_id(), count);
+        x_val[count++] = result.EvalBinding(b)[0];
+      }
     }
   }
   result.set_decision_variable_index(decision_variable_index);

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -272,19 +272,22 @@ class GraphOfConvexSets {
     relating to being able to "turn-off" the cost on inactive vertices, all
     costs are eventually implemented with a slack variable and a constraint:
     @verbatim
-    min g(x) ⇒ min ℓ, s.t. ℓ ≥ g(x)
+    min g(x) ⇒ min ℓ, s.t. ℓ ≥ g(x).
     @endverbatim
+    You must use GetSolutionCost() to retrieve the cost of the solution, rather
+    than evaluating the cost directly, in order to get consistent behavior when
+    solving with the different GCS transcriptions.
     @param use_in_transcription specifies the components of the problem to
     which the constraint should be added.
     @note Linear costs lead to negative costs if decision variables are not
     properly constrained. Users may want to check that the solution does not
     contain negative costs.
-    @returns the pair <ℓ, g(x)>.
+    @returns the added cost, g(x).
     @throws std::exception if e.GetVariables() is not a subset of x().
     @throws std::exception if no transcription is specified.
-     @pydrake_mkdoc_identifier{expression}
+    @pydrake_mkdoc_identifier{expression}
     */
-    std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
+    solvers::Binding<solvers::Cost> AddCost(
         const symbolic::Expression& e,
         const std::unordered_set<Transcription>& use_in_transcription = {
             Transcription::kMIP, Transcription::kRelaxation,
@@ -295,19 +298,22 @@ class GraphOfConvexSets {
     the cost on inactive vertices, all costs are eventually implemented with a
     slack variable and a constraint:
     @verbatim
-    min g(x) ⇒ min ℓ, s.t. ℓ ≥ g(x)
+    min g(x) ⇒ min ℓ, s.t. ℓ ≥ g(x).
     @endverbatim
+    You must use GetSolutionCost() to retrieve the cost of the solution, rather
+    than evaluating the cost directly, in order to get consistent behavior when
+    solving with the different GCS transcriptions.
     @param use_in_transcription specifies the components of the problem to
     which the constraint should be added.
     @note Linear costs lead to negative costs if decision variables are not
     properly constrained. Users may want to check that the solution does not
     contain negative costs.
-    @returns the pair <ℓ, g(x)>.
+    @returns the added cost, g(x).
     @throws std::exception if binding.variables() is not a subset of x().
     @throws std::exception if no transcription is specified.
     @pydrake_mkdoc_identifier{binding}
     */
-    std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
+    solvers::Binding<solvers::Cost> AddCost(
         const solvers::Binding<solvers::Cost>& binding,
         const std::unordered_set<Transcription>& use_in_transcription = {
             Transcription::kMIP, Transcription::kRelaxation,
@@ -367,6 +373,12 @@ class GraphOfConvexSets {
     solvers::MathematicalProgramResult. */
     double GetSolutionCost(
         const solvers::MathematicalProgramResult& result) const;
+
+    /** Returns the cost associated with the `cost` binding on this vertex in a
+    solvers::MathematicalProgramResult.
+    @throws std::exception if cost is not associated with this vertex. */
+    double GetSolutionCost(const solvers::MathematicalProgramResult& result,
+                           const solvers::Binding<solvers::Cost>& cost) const;
 
     /** Returns the solution of x() in a MathematicalProgramResult.  This
     solution is NaN if the vertex is not in the shortest path (or if we are
@@ -480,17 +492,20 @@ class GraphOfConvexSets {
     @verbatim
     min g(xu, xv) ⇒ min ℓ, s.t. ℓ ≥ g(xu,xv)
     @endverbatim
+    You must use GetSolutionCost() to retrieve the cost of the solution, rather
+    than evaluating the cost directly, in order to get consistent behavior when
+    solving with the different GCS transcriptions.
     @param use_in_transcription specifies the components of the problem to
     which the constraint should be added.
     @note Linear costs lead to negative costs if decision variables are not
     properly constrained. Users may want to check that the solution does not
     contain negative costs.
-    @returns the pair <ℓ, g(xu, xv)>.
+    @returns the added cost, g(xu, xv).
     @throws std::exception if e.GetVariables() is not a subset of xu() ∪ xv().
     @throws std::exception if no transcription is specified.
     @pydrake_mkdoc_identifier{expression}
     */
-    std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
+    solvers::Binding<solvers::Cost> AddCost(
         const symbolic::Expression& e,
         const std::unordered_set<Transcription>& use_in_transcription = {
             Transcription::kMIP, Transcription::kRelaxation,
@@ -503,18 +518,21 @@ class GraphOfConvexSets {
     @verbatim
     min g(xu, xv) ⇒ min ℓ, s.t. ℓ ≥ g(xu,xv)
     @endverbatim
+    You must use GetSolutionCost() to retrieve the cost of the solution, rather
+    than evaluating the cost directly, in order to get consistent behavior when
+    solving with the different GCS transcriptions.
     @param use_in_transcription specifies the components of the problem to
     which the constraint should be added.
     @note Linear costs lead to negative costs if decision variables are not
     properly constrained. Users may want to check that the solution does not
     contain negative costs.
-    @returns the pair <ℓ, g(xu, xv)>.
+    @returns the added cost, g(xu, xv).
     @throws std::exception if binding.variables() is not a subset of xu() ∪
     xv().
     @throws std::exception if no transcription is specified.
     @pydrake_mkdoc_identifier{binding}
     */
-    std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
+    solvers::Binding<solvers::Cost> AddCost(
         const solvers::Binding<solvers::Cost>& binding,
         const std::unordered_set<Transcription>& use_in_transcription = {
             Transcription::kMIP, Transcription::kRelaxation,
@@ -589,6 +607,12 @@ class GraphOfConvexSets {
     solvers::MathematicalProgramResult. */
     double GetSolutionCost(
         const solvers::MathematicalProgramResult& result) const;
+
+    /** Returns the cost associated with the `cost` binding on this edge in a
+    solvers::MathematicalProgramResult.
+    @throws std::exception if cost is not associated with this edge. */
+    double GetSolutionCost(const solvers::MathematicalProgramResult& result,
+                           const solvers::Binding<solvers::Cost>& cost) const;
 
     /** Returns the vector value of the slack variables associated with ϕxᵤ in
     a solvers::MathematicalProgramResult. This can obtain a different value

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -268,11 +268,11 @@ TEST_F(TwoPoints, Basic) {
 // Confirms that we can add costs (both ways) and get the solution.
 // The correctness of the added costs will be established by the solution tests.
 TEST_F(TwoPoints, AddCost) {
-  auto [ell0, b0] = e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
+  auto b0 = e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
   auto cost = std::make_shared<LinearCost>(Vector2d::Zero(), 0.1);
-  auto [ell1, b1] = e_->AddCost(Binding(cost, e_->xu()));
-  auto [v_ell0, v_b0] = v_->AddCost((v_->x() + Vector3d::Ones()).squaredNorm());
-  auto [v_ell1, v_b1] = v_->AddCost(Binding(cost, v_->x().head<2>()));
+  auto b1 = e_->AddCost(Binding(cost, e_->xu()));
+  auto v_b0 = v_->AddCost((v_->x() + Vector3d::Ones()).squaredNorm());
+  auto v_b1 = v_->AddCost(Binding(cost, v_->x().head<2>()));
 
   // Confirm that they are down-castable.
   auto quadratic = dynamic_cast<QuadraticCost*>(b0.evaluator().get());
@@ -291,19 +291,6 @@ TEST_F(TwoPoints, AddCost) {
   const auto& vertex_costs = v_->GetCosts();
   EXPECT_EQ(vertex_costs[0], v_b0);
   EXPECT_EQ(vertex_costs[1], v_b1);
-
-  MathematicalProgramResult result;
-  std::unordered_map<symbolic::Variable::Id, int> map;
-  map.emplace(ell0.get_id(), 0);
-  map.emplace(ell1.get_id(), 1);
-  map.emplace(v_ell0.get_id(), 2);
-  map.emplace(v_ell1.get_id(), 3);
-  const Vector4d ell{1.2, 3.4, 5.6, 7.8};
-  result.set_decision_variable_index(map);
-  result.set_x_val(ell);
-
-  EXPECT_NEAR(e_->GetSolutionCost(result), ell.head<2>().sum(), 1e-16);
-  EXPECT_NEAR(v_->GetSolutionCost(result), ell.tail<2>().sum(), 1e-16);
 
   symbolic::Variable other_var("x");
   DRAKE_EXPECT_THROWS_MESSAGE(e_->AddCost(other_var), ".*IsSubsetOf.*");
@@ -483,9 +470,9 @@ TEST_F(TwoPoints, VerifyCostTranscriptionAssignment) {
                                          kCostRelaxation},
         std::pair<Transcription, double>{Transcription::kRestriction,
                                          kCostRestriction}}) {
-    auto [ell, e_b] = e_->AddCost(cost, {transcription});
+    auto e_b = e_->AddCost(cost, {transcription});
     e_->AddCost(e_b, {transcription});
-    auto [v_ell, v_b] = v_->AddCost(cost, {transcription});
+    auto v_b = v_->AddCost(cost, {transcription});
     v_->AddCost(v_b, {transcription});
   }
   GraphOfConvexSetsOptions options;
@@ -744,9 +731,8 @@ class ThreePoints : public ::testing::Test {
     EXPECT_NEAR(result.get_optimal_cost(),
                 restriction_result.get_optimal_cost(), 1e-4);
     for (const auto* v : {source_, target_, sink_}) {
-      EXPECT_TRUE(CompareMatrices(result.GetSolution(v->x()),
-                                  restriction_result.GetSolution(v->x()),
-                                  1e-6));
+      EXPECT_TRUE(CompareMatrices(v->GetSolution(result),
+                                  v->GetSolution(restriction_result), 1e-6));
     }
   }
 
@@ -790,9 +776,9 @@ TEST_F(ThreePoints, NoMixedIntegerSolverAvailable) {
 }
 
 TEST_F(ThreePoints, LinearCost1) {
-  e_on_->AddCost(1.0);
-  e_off_->AddCost(1.0);
-  source_->AddCost(1.0);
+  auto e_on_cost = e_on_->AddCost(1.0);
+  auto e_off_cost = e_off_->AddCost(1.0);
+  auto source_cost = source_->AddCost(1.0);
   auto result = g_.SolveShortestPath(*source_, *target_, options_);
   ASSERT_TRUE(result.is_success());
   EXPECT_NEAR(e_on_->GetSolutionCost(result), 1.0, 1e-6);
@@ -800,6 +786,15 @@ TEST_F(ThreePoints, LinearCost1) {
   EXPECT_NEAR(source_->GetSolutionCost(result), 1.0, 1e-6);
   EXPECT_NEAR(target_->GetSolutionCost(result), 0.0, 1e-6);
   EXPECT_NEAR(sink_->GetSolutionCost(result), 0.0, 1e-6);
+
+  // Check GetSolutionCost overloads which take the binding.
+  EXPECT_NEAR(e_on_->GetSolutionCost(result, e_on_cost), 1.0, 1e-6);
+  EXPECT_NEAR(e_off_->GetSolutionCost(result, e_off_cost), 0.0, 1e-6);
+  EXPECT_NEAR(source_->GetSolutionCost(result, source_cost), 1.0, 1e-6);
+  DRAKE_EXPECT_THROWS_MESSAGE(e_on_->GetSolutionCost(result, e_off_cost),
+                              ".*not registered with this edge.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(target_->GetSolutionCost(result, source_cost),
+                              ".*not registered with this vertex.*");
 
   EXPECT_TRUE(
       CompareMatrices(e_on_->GetSolutionPhiXu(result), p_source_.x(), 1e-6));
@@ -1324,9 +1319,8 @@ class ThreeBoxes : public ::testing::Test {
     EXPECT_NEAR(result.get_optimal_cost(),
                 restriction_result.get_optimal_cost(), 1e-6);
     for (const auto* v : {source_, target_, sink_}) {
-      EXPECT_TRUE(CompareMatrices(result.GetSolution(v->x()),
-                                  restriction_result.GetSolution(v->x()),
-                                  1e-6));
+      EXPECT_TRUE(CompareMatrices(v->GetSolution(result),
+                                  v->GetSolution(restriction_result), 1e-6));
     }
   }
 
@@ -1983,8 +1977,8 @@ TEST_F(ThreeBoxes, SolveConvexRestriction) {
   EXPECT_NEAR(result.get_optimal_cost(), restriction_result.get_optimal_cost(),
               1e-6);
   for (const auto* v : g_.Vertices()) {
-    EXPECT_TRUE(CompareMatrices(result.GetSolution(v->x()),
-                                restriction_result.GetSolution(v->x()), 1e-6));
+    EXPECT_TRUE(CompareMatrices(v->GetSolution(result),
+                                v->GetSolution(restriction_result), 1e-6));
   }
 }
 


### PR DESCRIPTION
**This is a breaking change** (Note that GCS is still marked experimental)

During the review of #21530, we realized that cost slack variables were not being written to the MathematicalProgramResult in a consistent way between SolveShortestPath and SolveConvexRestriction. This PR addresses this by:

1) The "ell" slack variables associated with the AddCost methods are not returned to the user. Users should call vertex->GetSolutionCost() or edge->GetSolutionCost() to retrieve them. SolveConvexRestriction doesn't use ell, and it's an implementation detail that shouldn't have ever been exposed to the user.

2) GetSolutionCost and GetSolution are now more robust... if the placeholder variables are not in the MathematicalProgramResult, they return the implied values.

3) SolveConvexRestriction no longer tries to write NaN values for the unused vertices on every solve. The more robust GetSolution methods make this reasonable, and now that we've been generating large graphs this has become more important. Users may need to change calls from e.g. `result->GetSolution(v->x())` to `v->GetSolution(result)`.

4) The artificial `graphviz_options.show_costs = False` that was needed in `trajectory_optimization_test.py` to cover up this issue is now safely removed.

Resolves #20443.


+@cohnt for feature review, please?
cc @shaoyuancc @sadraddini @bernhardpg as heavy users of SolveConvexRestriction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21833)
<!-- Reviewable:end -->
