### PR TITLE
Compute maximum distance via sampling

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -141,6 +141,10 @@ void DefineGeometryOptimization(py::module m) {
         .def("CalcVolumeViaSampling", &ConvexSet::CalcVolumeViaSampling,
             py::arg("generator"), py::arg("desired_rel_accuracy") = 1e-2,
             py::arg("max_num_samples") = 1e4, cls_doc.CalcVolumeViaSampling.doc)
+        .def("CalcMaximumDistanceViaSampling",
+            &ConvexSet::CalcMaximumDistanceViaSampling, py::arg("generator"),
+            py::arg("num_samples") = 1000,
+            cls_doc.CalcMaximumDistanceViaSampling.doc)
         .def("Projection", &ConvexSet::Projection, py::arg("points"),
             cls_doc.Projection.doc);
   }

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -55,6 +55,8 @@ class TestGeometryOptimization(unittest.TestCase):
         np.testing.assert_array_equal(point.x(), 2*p)
         point.set_x(x=p)
         assert_pickle(self, point, lambda S: S.x())
+        self.assertAlmostEqual(point.CalcMaximumDistanceViaSampling(
+            generator=RandomGenerator(), num_samples=1000), 0.0, delta=1e-6)
 
         # TODO(SeanCurtis-TRI): This doesn't test the constructor that
         # builds from shape.
@@ -84,6 +86,8 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertTrue(E.IsBounded())
         self.assertTrue(E.PointInSet(E.MaybeGetFeasiblePoint()))
         self.assertTrue(E.IntersectsWith(E))
+        self.assertAlmostEqual(E.CalcMaximumDistanceViaSampling(
+            generator=RandomGenerator(), num_samples=1000), 2.0, delta=1e-6)
 
         mut.AffineBall.MakeAxisAligned(
             radius=np.ones(3), center=np.zeros(3))
@@ -197,6 +201,9 @@ class TestGeometryOptimization(unittest.TestCase):
         h_unit_box = mut.HPolyhedron.MakeUnitBox(dim=3)
         np.testing.assert_array_equal(h_box.A(), h_unit_box.A())
         np.testing.assert_array_equal(h_box.b(), h_unit_box.b())
+        self.assertAlmostEqual(h_unit_box.CalcMaximumDistanceViaSampling(
+            generator=RandomGenerator(), num_samples=1000), 2 * 3 ** 0.5,
+        delta=1e-6)
         A_l1 = np.array([[1, 1, 1],
                          [-1, 1, 1],
                          [1, -1, 1],

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -276,6 +276,16 @@ class ConvexSet {
                                       const double desired_rel_accuracy = 1e-2,
                                       const int max_num_samples = 1e4) const;
 
+  /** Calculates an estimate of the largest distance in the convex set using
+    sampling.
+    @param generator a random number generator.
+    @param num_samples the number of samples to use.
+    @return a pair the estimated volume of the set and an upper bound for the
+    relative accuracy
+    @throws if ambient_dimension() == 0. */
+  double CalcMaximumDistanceViaSampling(RandomGenerator* generator,
+                                        const int num_samples = 1e3) const;
+
   /** Computes in the L₂ norm the distance and the nearest point in this convex
    set to every column of @p points. If this set is empty, we return nullopt.
    @pre points.rows() == ambient_dimension().

--- a/geometry/optimization/test/convex_set_test.cc
+++ b/geometry/optimization/test/convex_set_test.cc
@@ -235,6 +235,37 @@ GTEST_TEST(ConvexSetTest, CalcVolumeViaSampling) {
   EXPECT_LT(good_result.num_samples, max_num_samples_high);
 };
 
+
+GTEST_TEST(ConvexSetTest, CalcMaximumDistanceViaSampling) {
+  RandomGenerator generator(1234);
+  const int max_num_samples = 1e3;
+
+  // Test for a set with ambient dimension 0.
+  const HPolyhedron zero_order_set = HPolyhedron::MakeUnitBox(0);
+  DRAKE_EXPECT_THROWS_MESSAGE(zero_order_set.CalcMaximumDistanceViaSampling(&generator, max_num_samples),
+               ".*zero-dimensional.*");
+
+  // Test with a unit circle.
+  const Hyperellipsoid unit_circle = Hyperellipsoid::MakeUnitBall(2);
+  double maximum_distance = unit_circle.CalcMaximumDistanceViaSampling(&generator, max_num_samples);
+  EXPECT_NEAR(maximum_distance, 2.0, 1e-6);
+
+  // Test with a unit sphere.
+  const Hyperellipsoid unit_sphere = Hyperellipsoid::MakeUnitBall(3);
+  maximum_distance = unit_sphere.CalcMaximumDistanceViaSampling(&generator, max_num_samples);
+  EXPECT_NEAR(maximum_distance, 2.0, 1e-6);
+
+  // Test with a unit square.
+  const HPolyhedron unit_square = HPolyhedron::MakeUnitBox(2);
+  maximum_distance = unit_square.CalcMaximumDistanceViaSampling(&generator, max_num_samples);
+  EXPECT_NEAR(maximum_distance, 2 * std::sqrt(2.0), 1e-6);
+
+  // Test with a unit square.
+  const HPolyhedron unit_box = HPolyhedron::MakeUnitBox(3);
+  maximum_distance = unit_box.CalcMaximumDistanceViaSampling(&generator, max_num_samples);
+  EXPECT_NEAR(maximum_distance, 2 * std::sqrt(3.0), 1e-6);
+};
+
 // Compute the projection of a point onto a set that has no point in set
 // shortcut and no projection shortcut.
 GTEST_TEST(ConvexSetTest, GenericProjection) {


### PR DESCRIPTION
Computes the maximum distance of a convex set via sampling. This is especially useful for hpolytopes generated via IRIS where we often can't (or don't want to) compute all the vertices to then compute the maximum distance.