### PR TITLE
[multibody topology] Replace Doxygen /** with /* for internal API

### DIFF
--- a/multibody/topology/forest.h
+++ b/multibody/topology/forest.h
@@ -1,6 +1,6 @@
 #pragma once
 
-/** @file
+/* @file
 This is the file to #include to use SpanningForest. It includes
 subsidiary headers for nested class definitions to keep file sizes
 reasonable. */

--- a/multibody/topology/graph.h
+++ b/multibody/topology/graph.h
@@ -1,6 +1,6 @@
 #pragma once
 
-/** @file
+/* @file
 This is the file to #include to use LinkJointGraph. It includes
 subsidiary headers for nested class definitions to keep file sizes
 reasonable. */

--- a/multibody/topology/link_joint_graph.h
+++ b/multibody/topology/link_joint_graph.h
@@ -26,13 +26,7 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-// TODO(sherm1) During the PR train leading up to MbP using this code in Drake
-//  master, I'm using Doxygen comments /** despite the fact that this is
-//  currently just internal. That allows me to validate Doxygen syntax in
-//  anticipation of the API becoming public later. Change these to /* in the
-//  final PR in this train to satisfy the styleguide.
-
-/** Represents a graph consisting of Links (user-defined rigid bodies)
+/* Represents a graph consisting of Links (user-defined rigid bodies)
 interconnected by Joints.
 
 Terminology notes:
@@ -106,7 +100,7 @@ class LinkJointGraph {
   class Joint;
   class LoopConstraint;
 
-  /** This is all we need to know about joint types for topological purposes. */
+  /* This is all we need to know about joint types for topological purposes. */
   struct JointTraits {
     std::string name;
     int nq{-1};
@@ -114,27 +108,27 @@ class LinkJointGraph {
     bool has_quaternion{false};  // If so, the first 4 qs are wxyz.
   };
 
-  /** A LinkComposite is a set of Links that are mutually connected by weld
+  /* A LinkComposite is a set of Links that are mutually connected by weld
   joints. It is massless only if _all_ its constituent Links are massless. */
   struct LinkComposite {
     std::vector<LinkIndex> links;
     bool is_massless{false};
   };
 
-  /** Default construction defines well-known joint types and World. */
+  /* Default construction defines well-known joint types and World. */
   LinkJointGraph();
 
-  /** Restores this graph to its default-constructed state. The contained
+  /* Restores this graph to its default-constructed state. The contained
   SpanningForest object is preserved but now invalid. */
   void Clear();
 
-  /** Sets the forest building options to be used for elements of any model
+  /* Sets the forest building options to be used for elements of any model
   instance that does not have its own forest building options set. Invalidates
   the current forest.
   @see SetForestBuildingOptions() */
   void SetGlobalForestBuildingOptions(ForestBuildingOptions global_options);
 
-  /** Gets the forest building options to be used for elements of any model
+  /* Gets the forest building options to be used for elements of any model
   instance that does not have its own forest building options set. If no call
   has yet been made to SetGlobalForestBuildingOptions(), returns
   ForestBuildingOptions::kDefault. */
@@ -143,7 +137,7 @@ class LinkJointGraph {
     return data_.global_forest_building_options;
   }
 
-  /** Sets the forest building options to be used for elements of the given
+  /* Sets the forest building options to be used for elements of the given
   `model_instance`, completely overriding (not blending with) global options.
   Invalidates the current forest. Model instances do not have to
   be pre-declared; we will simply record the given `options` with the given
@@ -154,7 +148,7 @@ class LinkJointGraph {
   void SetForestBuildingOptions(ModelInstanceIndex model_instance,
                                 ForestBuildingOptions options);
 
-  /** Gets the forest building options to be used for elements of the given
+  /* Gets the forest building options to be used for elements of the given
   model instance. Returns the options set explicitly for this model instance,
   if any. Otherwise, returns what get_global_forest_building_options() returns.
   @pre `instance_index` is any valid index */
@@ -164,11 +158,11 @@ class LinkJointGraph {
         .value_or(get_global_forest_building_options());
   }
 
-  /** Resets the global forest building options to kDefault and removes any
+  /* Resets the global forest building options to kDefault and removes any
   per-model instance options that were set. */
   void ResetForestBuildingOptions();
 
-  /** Models this LinkJointGraph as a spanning forest, records the result
+  /* Models this LinkJointGraph as a spanning forest, records the result
   into this graph's SpanningForest object, and marks it valid. The currently-set
   forest building options are used. This is done unconditionally; if there
   was already a valid forest it is cleared and then rebuilt. If you don't want
@@ -191,7 +185,7 @@ class LinkJointGraph {
   @see InvalidateForest() */
   bool BuildForest();
 
-  /** Invalidates this LinkJointGraph's SpanningForest and removes ephemeral
+  /* Invalidates this LinkJointGraph's SpanningForest and removes ephemeral
   "as-built" Link, Joint, and Constraint elements that were added to the graph
   during forest building. After this call the graph will contain only
   user-provided elements and forest_is_valid() will return `false`. A
@@ -200,13 +194,13 @@ class LinkJointGraph {
     invalidate the forest as a side effect. */
   void InvalidateForest();
 
-  /** Has the SpanningForest been rebuilt with BuildForest() since the most
+  /* Has the SpanningForest been rebuilt with BuildForest() since the most
   recent change to this LinkJointGraph or to the forest building options? If
   this returns `false` then a call to BuildForest() is required before you can
   make use of the SpanningForest. */
   [[nodiscard]] bool forest_is_valid() const { return data_.forest_is_valid; }
 
-  /** Returns a reference to this LinkJointGraph's SpanningForest
+  /* Returns a reference to this LinkJointGraph's SpanningForest
   object (without rebuilding). The forest is a data member of LinkJointGraph and
   the _reference_ remains unchanged across repeated graph modifications and
   calls to BuildForest(), though the _contents_ will change. You can call the
@@ -218,7 +212,7 @@ class LinkJointGraph {
     anything about the contents otherwise. */
   [[nodiscard]] const SpanningForest& forest() const { return *data_.forest; }
 
-  /** Adds a new Link to the graph. Invalidates the SpanningForest; call
+  /* Adds a new Link to the graph. Invalidates the SpanningForest; call
   BuildForest() to rebuild.
   @param[in] name
     A unique name for the new Link (rigid body) in the given `model_instance`.
@@ -243,14 +237,14 @@ class LinkJointGraph {
   // TODO(sherm1) Add this method;
   //  void RemoveLink(LinkIndex doomed_link_index);
 
-  /** Returns true if the given `link_index` is in range and the corresponding
+  /* Returns true if the given `link_index` is in range and the corresponding
   Link hasn't been removed. Can be a user or ephemeral Link. */
   [[nodiscard]] bool has_link(LinkIndex link_index) const {
     return link_index < num_link_indexes() &&
            data_.link_index_to_ordinal[link_index].has_value();
   }
 
-  /** Returns true if the given Link exists and is ephemeral. Ephemeral links
+  /* Returns true if the given Link exists and is ephemeral. Ephemeral links
   are present only if the SpanningForest is valid. */
   [[nodiscard]] bool link_is_ephemeral(LinkIndex link_index) const {
     if (has_link(link_index) && link_index > data_.max_user_link_index) {
@@ -260,7 +254,7 @@ class LinkJointGraph {
     return false;
   }
 
-  /** Adds a new Joint to the graph.
+  /* Adds a new Joint to the graph.
   @param[in] name
     A unique name for the new Joint in the given `model_instance`. Several
     Joints can have the same name within a %LinkJointGraph as long as they are
@@ -295,7 +289,7 @@ class LinkJointGraph {
                       LinkIndex child_link_index,
                       JointFlags flags = JointFlags::kDefault);
 
-  /** Removes a previously-added Joint and any references to it in the graph.
+  /* Removes a previously-added Joint and any references to it in the graph.
   Invalidates the SpanningForest. Will repack and change ordinals for the
   remaining Joints in the joints() vector, though all JointIndexes are
   preserved. The `doomed_joint_index` given here will never be re-used.
@@ -304,14 +298,14 @@ class LinkJointGraph {
     an already-removed Joint, or refers to an ephemeral Joint. */
   void RemoveJoint(JointIndex doomed_joint_index);
 
-  /** Returns true if the given `joint_index` is in range and the corresponding
+  /* Returns true if the given `joint_index` is in range and the corresponding
   Joint hasn't been removed. Can be a user or ephemeral Joint. */
   [[nodiscard]] bool has_joint(JointIndex joint_index) const {
     return joint_index < num_joint_indexes() &&
            data_.joint_index_to_ordinal[joint_index].has_value();
   }
 
-  /** Returns true if the given Joint exists and is ephemeral. Ephemeral joints
+  /* Returns true if the given Joint exists and is ephemeral. Ephemeral joints
   are present only if the SpanningForest is valid. */
   [[nodiscard]] bool joint_is_ephemeral(JointIndex joint_index) const {
     if (has_joint(joint_index) && joint_index > data_.max_user_joint_index) {
@@ -321,10 +315,10 @@ class LinkJointGraph {
     return false;
   }
 
-  /** Returns the Link that corresponds to World (always predefined). */
+  /* Returns the Link that corresponds to World (always predefined). */
   [[nodiscard]] const Link& world_link() const;
 
-  /** Registers a joint type by name and provides the joint traits for it.
+  /* Registers a joint type by name and provides the joint traits for it.
   @param[in] joint_type_name
     A unique string identifying a joint type, such as "revolute" or
     "prismatic". Should match the MultibodyPlant name for the Joint it
@@ -349,25 +343,25 @@ class LinkJointGraph {
   JointTraitsIndex RegisterJointType(const std::string& joint_type_name, int nq,
                                      int nv, bool has_quaternion = false);
 
-  /** Returns `true` if the given `joint_type_name` was previously registered
+  /* Returns `true` if the given `joint_type_name` was previously registered
   via a call to RegisterJointType(), or is one of the pre-registered names. */
   [[nodiscard]] bool IsJointTypeRegistered(
       const std::string& joint_type_name) const;
 
-  /** Returns a reference to the vector of traits for the known and registered
+  /* Returns a reference to the vector of traits for the known and registered
   Joint types. */
   [[nodiscard]] const std::vector<JointTraits>& joint_traits() const {
     return data_.joint_traits;
   }
 
-  /** Returns a reference to a particular JointTraits object using one of the
+  /* Returns a reference to a particular JointTraits object using one of the
   predefined indices or an index returned by RegisterJointType(). Requires a
   JointTraitsIndex, not a plain integer.*/
   [[nodiscard]] const JointTraits& joint_traits(JointTraitsIndex index) const {
     return joint_traits().at(index);
   }
 
-  /** Returns a reference to the vector of Link objects, contiguous and ordered
+  /* Returns a reference to the vector of Link objects, contiguous and ordered
   by ordinal (not by LinkIndex). World is always the first entry and is always
   present. `ssize(links())` is the number of Links currently in this graph. */
   [[nodiscard]] const std::vector<Link>& links() const { return data_.links; }
@@ -375,29 +369,29 @@ class LinkJointGraph {
   // TODO(sherm1) Re-think this naming strategy to use either link() or
   //  link_by_ordinal(), and similar for the other APIs.
 
-  /** Returns a reference to a particular Link using its current ordinal
+  /* Returns a reference to a particular Link using its current ordinal
   within the links() vector. Requires a LinkOrdinal, not a plain integer. */
   [[nodiscard]] inline const Link& links(LinkOrdinal link_ordinal) const;
 
-  /** Returns a reference to a particular Link using the index returned by
+  /* Returns a reference to a particular Link using the index returned by
   AddLink(). The World Link is LinkIndex(0). Ephemeral links added by
   BuildForest() are indexed last. Requires a LinkIndex, not a plain integer.
   @throws std::exception if the index is out of range or if the selected Link
     was removed. */
   [[nodiscard]] inline const Link& link_by_index(LinkIndex link_index) const;
 
-  /** Returns a reference to the vector of Joint objects, contiguous and ordered
+  /* Returns a reference to the vector of Joint objects, contiguous and ordered
   by ordinal (not by JointIndex). `ssize(joints())` is the number of Joints
   currently in this graph. */
   [[nodiscard]] const std::vector<Joint>& joints() const {
     return data_.joints;
   }
 
-  /** Returns a reference to a particular Joint using its current ordinal
+  /* Returns a reference to a particular Joint using its current ordinal
   within the joints() vector. Requires a JointOrdinal, not a plain integer. */
   [[nodiscard]] inline const Joint& joints(JointOrdinal joint_ordinal) const;
 
-  /** Returns a reference to a particular Joint using the index returned by
+  /* Returns a reference to a particular Joint using the index returned by
   AddJoint(). Ephemeral joints added by BuildForest() are indexed last. Requires
   a JointIndex, not a plain integer.
   @throws std::exception if the index is out of range or if the selected Joint
@@ -405,34 +399,34 @@ class LinkJointGraph {
   [[nodiscard]] inline const Joint& joint_by_index(
       JointIndex joint_index) const;
 
-  /** Returns a reference to the vector of LoopConstraint objects. These are
+  /* Returns a reference to the vector of LoopConstraint objects. These are
   always "ephemeral" (added during forest-building) so this will return empty
   if there is no valid Forest. See the class comment for more information. */
   [[nodiscard]] const std::vector<LoopConstraint>& loop_constraints() const {
     return data_.loop_constraints;
   }
 
-  /** Returns a reference to a particular LoopConstraint. Requires a
+  /* Returns a reference to a particular LoopConstraint. Requires a
   LoopConstraintIndex, not a plain integer.*/
   [[nodiscard]] inline const LoopConstraint& loop_constraints(
       LoopConstraintIndex constraint_index) const;
 
-  /** Links with this ordinal or higher are "ephemeral" (added during
+  /* Links with this ordinal or higher are "ephemeral" (added during
   forest-building). See the class comment for more information. */
   [[nodiscard]] int num_user_links() const { return data_.num_user_links; }
 
-  /** Joints with this ordinal or higher are "ephemeral" (added during
+  /* Joints with this ordinal or higher are "ephemeral" (added during
   forest-building). See the class comment for more information. */
   [[nodiscard]] int num_user_joints() const { return data_.num_user_joints; }
 
-  /** After the SpanningForest has been built, returns the mobilized body
+  /* After the SpanningForest has been built, returns the mobilized body
   (Mobod) followed by this Link. If the Link is part of a merged composite, this
   will be the mobilized body for the whole composite. If the Link was split into
   a primary and shadows, this is the mobilized body followed by the primary. If
   there is no valid Forest, the returned index will be invalid. */
   [[nodiscard]] MobodIndex link_to_mobod(LinkIndex index) const;
 
-  /** After the SpanningForest has been built, returns groups of Links that are
+  /* After the SpanningForest has been built, returns groups of Links that are
   welded together, which we call "LinkComposites". Each composite may be modeled
   in the Forest with a single mobilized body (a "merged composite") or multiple
   mobilized bodies depending on modeling options, but that doesn't change
@@ -457,7 +451,7 @@ class LinkJointGraph {
     return data_.link_composites;
   }
 
-  /** Returns a reference to a particular LinkComposite. Requires a
+  /* Returns a reference to a particular LinkComposite. Requires a
   LinkCompositeIndex, not a plain integer.
   @pre `link_composite_index` is valid and in range. */
   [[nodiscard]] const LinkComposite& link_composites(
@@ -465,19 +459,19 @@ class LinkJointGraph {
     return link_composites().at(link_composite_index);
   }
 
-  /** @returns `true` if a Link named `name` was added to `model_instance`.
+  /* @returns `true` if a Link named `name` was added to `model_instance`.
   @see AddLink().
   @throws std::exception if `model_instance_index` is not a valid index. */
   [[nodiscard]] bool HasLinkNamed(
       std::string_view name, ModelInstanceIndex model_instance_index) const;
 
-  /** @returns `true` if a Joint named `name` was added to `model_instance`.
+  /* @returns `true` if a Joint named `name` was added to `model_instance`.
   @see AddJoint().
   @throws std::exception if `model_instance_index` is not a valid index. */
   [[nodiscard]] bool HasJointNamed(
       std::string_view name, ModelInstanceIndex model_instance_index) const;
 
-  /** If there is a Joint connecting the given Links, returns its index. You can
+  /* If there is a Joint connecting the given Links, returns its index. You can
   call this any time and it will work with whatever Joints have been defined.
   But note that Links may be split and additional Joints added during Forest
   building, so you may get a different answer before and after modeling. Cost is
@@ -485,20 +479,20 @@ class LinkJointGraph {
   [[nodiscard]] std::optional<JointIndex> MaybeGetJointBetween(
       LinkIndex link1_index, LinkIndex link2_index) const;
 
-  /** Returns true if the given Link should be treated as massless. That
+  /* Returns true if the given Link should be treated as massless. That
   requires that the Link was flagged kMassless and is not connected by
   a Weld Joint to a massful Composite. If this Link is not part of a
   LinkComposite then the result is the same as Link::is_massless(). */
   [[nodiscard]] bool link_and_its_composite_are_massless(
       LinkOrdinal link_ordinal) const;
 
-  /** (Internal use only) For testing -- invalidates the Forest. */
+  /* (Internal use only) For testing -- invalidates the Forest. */
   void ChangeLinkFlags(LinkIndex link_index, LinkFlags flags);
 
-  /** (Internal use only) For testing -- invalidates the Forest. */
+  /* (Internal use only) For testing -- invalidates the Forest. */
   void ChangeJointFlags(JointIndex joint_index, JointFlags flags);
 
-  /** (Internal use only) Changes the type of an existing user-defined Joint
+  /* (Internal use only) Changes the type of an existing user-defined Joint
   without making any other changes. Invalidates the Forest, even if the new
   type is the same as the current type.
   @throws std::exception if called on an ephemeral (added) joint.
@@ -509,7 +503,7 @@ class LinkJointGraph {
   void ChangeJointType(JointIndex existing_joint_index,
                        const std::string& name_of_new_type);
 
-  /** After the Forest is built, returns the sequence of Links from World to the
+  /* After the Forest is built, returns the sequence of Links from World to the
   given Link L in the Forest. In case the Forest was built with a single Mobod
   for each Link Composite (Links connected by Weld joints), we only report the
   "active Link" for each Link Composite so that there is only one Link returned
@@ -522,7 +516,7 @@ class LinkJointGraph {
   @see link_composites(), SpanningForest::FindPathFromWorld() */
   std::vector<LinkIndex> FindPathFromWorld(LinkIndex link_index) const;
 
-  /** After the Forest is built, finds the first Link common to the paths
+  /* After the Forest is built, finds the first Link common to the paths
   towards World from each of two Links in the SpanningForest. Returns World
   immediately if the Links are on different trees of the forest. Otherwise the
   cost is O(ℓ) where ℓ is the length of the longer path from one of the Links
@@ -533,7 +527,7 @@ class LinkJointGraph {
   LinkIndex FindFirstCommonAncestor(LinkIndex link1_index,
                                     LinkIndex link2_index) const;
 
-  /** After the Forest is built, finds all the Links following the Forest
+  /* After the Forest is built, finds all the Links following the Forest
   subtree whose root mobilized body is the one followed by the given Link. That
   is, we look up the given Link's Mobod B and return all the Links that follow
   B or any other Mobod in the subtree rooted at B. The Links following B
@@ -544,7 +538,7 @@ class LinkJointGraph {
   @see SpanningForest::FindSubtreeLinks() */
   std::vector<LinkIndex> FindSubtreeLinks(LinkIndex link_index) const;
 
-  /** After the Forest is built, this method can be called to return a
+  /* After the Forest is built, this method can be called to return a
   partitioning of the LinkJointGraph into subgraphs such that (a) every Link is
   in one and only one subgraph, and (b) two Links are in the same subgraph iff
   there is a path between them which consists only of Weld joints.
@@ -563,12 +557,12 @@ class LinkJointGraph {
   @see CalcSubgraphsOfWeldedLinks() if you haven't built a Forest yet */
   std::vector<std::set<LinkIndex>> GetSubgraphsOfWeldedLinks() const;
 
-  /** This much-slower method does not depend on the SpanningForest having
+  /* This much-slower method does not depend on the SpanningForest having
   already been built. It is a fallback for when there is no Forest.
   @see GetSubgraphsOfWeldedLinks() if you already have a Forest built */
   std::vector<std::set<LinkIndex>> CalcSubgraphsOfWeldedLinks() const;
 
-  /** After the Forest is built, returns all Links that are transitively welded,
+  /* After the Forest is built, returns all Links that are transitively welded,
   or rigidly affixed, to `link_index`, per these two definitions:
     1. A Link is always considered welded to itself.
     2. Two unique Links are considered welded together exclusively by the
@@ -584,7 +578,7 @@ class LinkJointGraph {
   @see CalcLinksWeldedTo() if you haven't built a Forest yet */
   std::set<LinkIndex> GetLinksWeldedTo(LinkIndex link_index) const;
 
-  /** This slower method does not depend on the SpanningForest having
+  /* This slower method does not depend on the SpanningForest having
   already been built. It is a fallback for when there is no Forest.
   @see GetLinksWeldedTo() if you already have a Forest built */
   std::set<LinkIndex> CalcLinksWeldedTo(LinkIndex link_index) const;
@@ -592,7 +586,7 @@ class LinkJointGraph {
   // FYI Debugging APIs (including Graphviz-related) are defined in
   // link_joint_graph_debug.cc.
 
-  /** Generate a graphviz representation of this %LinkJointGraph, with the
+  /* Generate a graphviz representation of this %LinkJointGraph, with the
   given label at the top. Will include ephemeral elements if they are
   available (that is, if the forest is valid)  unless suppressed explicitly.
   The result is in the "dot" language, see https://graphviz.org. If you
@@ -606,7 +600,7 @@ class LinkJointGraph {
   // TODO(sherm1) This function should be removed or reworked before upgrading
   //  to Drake public API.
 
-  /** This is a useful debugging and presentation utility for getting
+  /* This is a useful debugging and presentation utility for getting
   viewable "dot diagrams" of the graph and forest. You provide a directory
   and a base name for the results. This function will generate
   `basename_graph.png` showing the graph as the user defined it. If the
@@ -625,18 +619,18 @@ class LinkJointGraph {
 
   // Forest building requires these joint types so they are predefined.
 
-  /** The predefined index for the "weld" joint type's traits. */
+  /* The predefined index for the "weld" joint type's traits. */
   [[nodiscard]] static JointTraitsIndex weld_joint_traits_index() {
     return JointTraitsIndex(0);
   }
 
-  /** The predefined index for the "quaternion_floating" joint type's traits. */
+  /* The predefined index for the "quaternion_floating" joint type's traits. */
   [[nodiscard]] static JointTraitsIndex
   quaternion_floating_joint_traits_index() {
     return JointTraitsIndex(1);
   }
 
-  /** The predefined index for the "rpy_floating" joint type's traits. */
+  /* The predefined index for the "rpy_floating" joint type's traits. */
   [[nodiscard]] static JointTraitsIndex rpy_floating_joint_traits_index() {
     return JointTraitsIndex(2);
   }

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -24,7 +24,7 @@ using JointTraitsIndex = TypeSafeIndex<class JointTraitsTag>;
 using LinkCompositeIndex = TypeSafeIndex<class LinkCompositeTag>;
 using LoopConstraintIndex = TypeSafeIndex<class LoopConstraintTag>;
 
-/** Link properties that can affect how the forest model gets built. Or-ing
+/* Link properties that can affect how the forest model gets built. Or-ing
 these also produces a LinkFlags object. */
 enum class LinkFlags : uint32_t {
   kDefault = 0,
@@ -34,14 +34,14 @@ enum class LinkFlags : uint32_t {
   kShadow = 1 << 3           ///< Link is a shadow (internal use only).
 };
 
-/** Joint properties that can affect how the SpanningForest gets built. Or-ing
+/* Joint properties that can affect how the SpanningForest gets built. Or-ing
 these also produces a JointFlags object. */
 enum class JointFlags : uint32_t {
   kDefault = 0,
   kMustBeModeled = 1 << 0  ///< Model explicitly even if ignorable weld.
 };
 
-/** Options for how to build the SpanningForest. Or-ing these also produces a
+/* Options for how to build the SpanningForest. Or-ing these also produces a
 ForestBuildingOptions object. These can be provided as per-model instance
 options to locally override global options. */
 enum class ForestBuildingOptions : uint32_t {

--- a/multibody/topology/link_joint_graph_joint.h
+++ b/multibody/topology/link_joint_graph_joint.h
@@ -18,39 +18,39 @@ class LinkJointGraph::Joint {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Joint);
 
-  /** Returns this %Joint's unique index in the graph. This is persistent after
+  /* Returns this %Joint's unique index in the graph. This is persistent after
   the %Joint has been allocated. */
   JointIndex index() const { return index_; }
 
-  /** Returns the current value of this %Joint's ordinal (position in the
+  /* Returns the current value of this %Joint's ordinal (position in the
   joints() vector). This can change as %Joints are removed. */
   JointOrdinal ordinal() const { return ordinal_; }
 
-  /** Returns this %Joint's model instance. */
+  /* Returns this %Joint's model instance. */
   ModelInstanceIndex model_instance() const { return model_instance_; }
 
-  /** Returns this %Joint's name, unique within model_instance(). */
+  /* Returns this %Joint's name, unique within model_instance(). */
   const std::string& name() const { return name_; }
 
-  /** Returns the index of this %Joint's parent Link. */
+  /* Returns the index of this %Joint's parent Link. */
   LinkIndex parent_link_index() const { return parent_link_index_; }
 
-  /** Returns the index of this %Joint's child Link. */
+  /* Returns the index of this %Joint's child Link. */
   LinkIndex child_link_index() const { return child_link_index_; }
 
-  /** Returns `true` if this is a Weld %Joint. */
+  /* Returns `true` if this is a Weld %Joint. */
   bool is_weld() const { return traits_index() == weld_joint_traits_index(); }
 
-  /** Returns the index of this %Joint's traits. */
+  /* Returns the index of this %Joint's traits. */
   JointTraitsIndex traits_index() const { return traits_index_; }
 
-  /** Returns `true` if either the parent or child Link of this %Joint is
+  /* Returns `true` if either the parent or child Link of this %Joint is
   the specified `link`. */
   bool connects(LinkIndex link) const {
     return link == parent_link_index() || link == child_link_index();
   }
 
-  /** Returns `true` if this %Joint connects the two given Links. That is, if
+  /* Returns `true` if this %Joint connects the two given Links. That is, if
   one of these is the parent Link and the other is the child Link, in either
   order. */
   bool connects(LinkIndex link1, LinkIndex link2) const {
@@ -62,7 +62,7 @@ class LinkJointGraph::Joint {
   //  return link_index ^ (parent_link_index ^ child_link_index);
   //  with the second term precalculated. Consider that if performance warrants.
 
-  /** Given one of the Links connected by this %Joint, returns the other one.
+  /* Given one of the Links connected by this %Joint, returns the other one.
   @pre `link_index` is either the parent or child */
   LinkIndex other_link_index(LinkIndex link_index) const {
     DRAKE_DEMAND((parent_link_index() == link_index) ||
@@ -71,13 +71,13 @@ class LinkJointGraph::Joint {
                                              : parent_link_index();
   }
 
-  /** Returns `true` if this %Joint was added with
+  /* Returns `true` if this %Joint was added with
   JointFlags::kMustBeModeled. */
   bool must_be_modeled() const {
     return static_cast<bool>(flags_ & JointFlags::kMustBeModeled);
   }
 
-  /** Returns the index of the Mobod whose inboard mobilizer models this
+  /* Returns the index of the Mobod whose inboard mobilizer models this
   %Joint, if any. If this %Joint is unmodeled then the returned index is
   invalid. */
   MobodIndex mobod_index() const {
@@ -85,7 +85,7 @@ class LinkJointGraph::Joint {
     return std::get<MobodIndex>(how_modeled_);
   }
 
-  /** (Internal use only) During construction of the forest, this is used
+  /* (Internal use only) During construction of the forest, this is used
   to check whether this %Joint has already been modeled. */
   bool has_been_processed() const {
     return !std::holds_alternative<std::monostate>(how_modeled_);

--- a/multibody/topology/link_joint_graph_link.h
+++ b/multibody/topology/link_joint_graph_link.h
@@ -14,7 +14,7 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-/** Represents a %Link in the LinkJointGraph. This includes Links provided via
+/* Represents a %Link in the LinkJointGraph. This includes Links provided via
 user input and also those added during forest building as Shadow links created
 when we cut a user %Link in order to break a kinematic loop. Links may be
 modeled individually or can be combined into LinkComposites comprising groups
@@ -23,47 +23,47 @@ class LinkJointGraph::Link {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Link);
 
-  /** Returns this %Link's unique index in the graph. This is persistent after
+  /* Returns this %Link's unique index in the graph. This is persistent after
   the %Link has been allocated. */
   LinkIndex index() const { return index_; }
 
-  /** Returns the current value of this %Link's ordinal (position in the
+  /* Returns the current value of this %Link's ordinal (position in the
   links() vector). This can change as %Links are removed. */
   LinkOrdinal ordinal() const { return ordinal_; }
 
-  /** Returns this %Link's model instance. */
+  /* Returns this %Link's model instance. */
   ModelInstanceIndex model_instance() const { return model_instance_; }
 
-  /** Returns this %Link's name, unique within model_instance(). */
+  /* Returns this %Link's name, unique within model_instance(). */
   const std::string& name() const { return name_; }
 
-  /** Returns indexes of all the Joints that connect to this %Link. This is
+  /* Returns indexes of all the Joints that connect to this %Link. This is
   the union of joints_as_parent() and joints_as_child(). */
   const std::vector<JointIndex>& joints() const { return joints_; }
 
-  /** Returns indexes of all the Joints that connect to this %Link in which
+  /* Returns indexes of all the Joints that connect to this %Link in which
   this is the parent %Link. */
   const std::vector<JointIndex>& joints_as_parent() const {
     return joints_as_parent_;
   }
 
-  /** Returns indexes of all the joints that connect to this %Link in which
+  /* Returns indexes of all the joints that connect to this %Link in which
   this is the child %Link. */
   const std::vector<JointIndex>& joints_as_child() const {
     return joints_as_child_;
   }
 
-  /** Returns indexes of all the LoopConstraints that connect to this %Link. */
+  /* Returns indexes of all the LoopConstraints that connect to this %Link. */
   const std::vector<LoopConstraintIndex>& loop_constraints() const {
     return loop_constraints_;
   }
 
-  /** Returns `true` only if this is the World %Link. Static Links and Links
+  /* Returns `true` only if this is the World %Link. Static Links and Links
   in the World Composite are not included; see is_anchored() if you want to
   include everything that is fixed with respect to World. */
   bool is_world() const { return index_ == LinkIndex(0); }
 
-  /** After modeling, returns `true` if this %Link is fixed with respect to
+  /* After modeling, returns `true` if this %Link is fixed with respect to
   World. That includes World itself, static Links, and any Link that is part
   of the World Composite (that is, it is directly or indirectly welded to
   World). */
@@ -72,17 +72,17 @@ class LinkJointGraph::Link {
            (composite() == LinkCompositeIndex(0));
   }
 
-  /** Returns `true` if this %Link was added with LinkFlags::kStatic. */
+  /* Returns `true` if this %Link was added with LinkFlags::kStatic. */
   bool is_static_flag_set() const {
     return static_cast<bool>(flags_ & LinkFlags::kStatic);
   }
 
-  /** Returns `true` if this %Link was added with LinkFlags::kMustBeBaseBody. */
+  /* Returns `true` if this %Link was added with LinkFlags::kMustBeBaseBody. */
   bool must_be_base_body() const {
     return static_cast<bool>(flags_ & LinkFlags::kMustBeBaseBody);
   }
 
-  /** Returns `true` if this %Link was added with LinkFlags::kMassless.
+  /* Returns `true` if this %Link was added with LinkFlags::kMassless.
   However, this %Link may still be _effectively_ massful if it is welded
   into a massful composite. See
   LinkJointGraph::link_and_its_composite_are_massless() for the full story. */
@@ -90,20 +90,20 @@ class LinkJointGraph::Link {
     return static_cast<bool>(flags_ & LinkFlags::kMassless);
   }
 
-  /** Returns `true` if this is a shadow Link added by BuildForest(). */
+  /* Returns `true` if this is a shadow Link added by BuildForest(). */
   bool is_shadow() const {
     return static_cast<bool>(flags_ & LinkFlags::kShadow);
   }
 
-  /** If this %Link is a shadow, returns the primary %Link it shadows. If
+  /* If this %Link is a shadow, returns the primary %Link it shadows. If
   not a shadow then it is its own primary %Link so returns index(). */
   LinkIndex primary_link() const { return primary_link_; }
 
-  /** If this is a primary %Link (not a shadow) returns the number of Shadow
+  /* If this is a primary %Link (not a shadow) returns the number of Shadow
   Links that were added due to loop breaking. */
   int num_shadows() const { return ssize(shadow_links_); }
 
-  /** Returns the index of the mobilized body (Mobod) that mobilizes this %Link.
+  /* Returns the index of the mobilized body (Mobod) that mobilizes this %Link.
   If this %Link is part of a LinkComposite, this is the Mobod that mobilizes the
   LinkComposite as a whole via the composite's active %Link. If you ask
   this Mobod what Joint it represents, it will report the Joint that was used
@@ -112,13 +112,13 @@ class LinkJointGraph::Link {
   %Link to its LinkComposite. */
   MobodIndex mobod_index() const { return mobod_; }
 
-  /** Returns the Joint that was used to associate this %Link with its
+  /* Returns the Joint that was used to associate this %Link with its
   mobilized body. If this %Link is part of a LinkComposite, returns the Joint
   that connects this %Link to the Composite, not necessarily the Joint that is
   modeled by the Mobod returned by mobod_index(). */
   JointIndex inboard_joint_index() const { return joint_; }
 
-  /** Returns the index of the LinkComposite this %Link is part of, if any.
+  /* Returns the index of the LinkComposite this %Link is part of, if any.
   World is always in LinkComposite 0; any other link is in a Composite only if
   it is connected by a weld joint to another link. */
   std::optional<LinkCompositeIndex> composite() const {

--- a/multibody/topology/link_joint_graph_loop_constraint.h
+++ b/multibody/topology/link_joint_graph_loop_constraint.h
@@ -11,7 +11,7 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-/** A weld constraint used to close a topological loop (cycle) in the input
+/* A weld constraint used to close a topological loop (cycle) in the input
 graph after modeling as a forest. The parent/child ordering sets the sign
 convention for the constraint multipliers. Added welds between a primary %Link
 and one of its shadow Links always make the primary %Link the parent. */

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -22,15 +22,9 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-// TODO(sherm1) During the PR train leading up to MbP using this code in Drake
-//  master, I'm using Doxygen comments /** despite the fact that this is
-//  currently just internal. That allows me to validate Doxygen syntax in
-//  anticipation of the API becoming public later. Change these to /* in the
-//  final PR in this train to satisfy the styleguide.
-
 using WeldedMobodsIndex = TypeSafeIndex<class WeldedMobodsTag>;
 
-/** SpanningForest models a LinkJointGraph via a set of spanning trees and
+/* SpanningForest models a LinkJointGraph via a set of spanning trees and
 loop-closing constraints. This is a directed forest, with edges ordered from
 inboard (closer to World) to outboard. The nodes are mobilized bodies (Mobods)
 representing a body and its inboard mobilizer. While building the Forest we also
@@ -152,13 +146,13 @@ class SpanningForest {
   using Link = LinkJointGraph::Link;
   using Joint = LinkJointGraph::Joint;
 
-  /** Returns the sequence of mobilized bodies from World to the given mobod B,
+  /* Returns the sequence of mobilized bodies from World to the given mobod B,
   inclusive of both. The 0th element is always present in the result and is
   the World (at level 0) with each entry being the Mobod at the next-higher
   level along the path to B. Cost is O(ℓ) where ℓ is B's level in its tree. */
   std::vector<MobodIndex> FindPathFromWorld(MobodIndex index) const;
 
-  /** Finds the highest-numbered mobilized body that is common to the paths
+  /* Finds the highest-numbered mobilized body that is common to the paths
   from each of the given ones to World. Returns World immediately if the bodies
   are on different trees; otherwise the cost is O(ℓ) where ℓ is the length
   of the longer path from one of the bodies to the ancestor.
@@ -169,7 +163,7 @@ class SpanningForest {
   MobodIndex FindFirstCommonAncestor(MobodIndex mobod1_index,
                                      MobodIndex mobod2_index) const;
 
-  /** Finds the highest numbered common ancestor to two mobilized bodies and
+  /* Finds the highest numbered common ancestor to two mobilized bodies and
   returns the paths to the ancestor from each of them. The mobilizers along
   the returned paths are the only ones that can affect the _relative_ pose
   between the given mobilized bodies. The returned paths do not include the
@@ -193,7 +187,7 @@ class SpanningForest {
       MobodIndex mobod1_index, MobodIndex mobod2_index,
       std::vector<MobodIndex>* path1, std::vector<MobodIndex>* path2) const;
 
-  /** Finds all the Links following the Forest subtree whose root mobilized body
+  /* Finds all the Links following the Forest subtree whose root mobilized body
   B is given. That is, we return all the Links that follow B or any other Mobod
   in the subtree rooted at B. The Links following B come first, and the rest
   follow the depth-first ordering of the Mobods. In particular, the result is
@@ -201,31 +195,31 @@ class SpanningForest {
   Links following the subtree. */
   std::vector<LinkIndex> FindSubtreeLinks(MobodIndex root_mobod_index) const;
 
-  /** Returns a reference to the graph that owns this forest (as set during
+  /* Returns a reference to the graph that owns this forest (as set during
   construction). */
   const LinkJointGraph& graph() const {
     DRAKE_ASSERT(data_.graph != nullptr);
     return *data_.graph;
   }
 
-  /** Returns `true` if this forest is up to date with respect to its owning
+  /* Returns `true` if this forest is up to date with respect to its owning
   graph. */
   bool is_valid() const { return graph().forest_is_valid(); }
 
-  /** Returns `true` if this forest can be used for dynamics (the usual case).
+  /* Returns `true` if this forest can be used for dynamics (the usual case).
   Otherwise, the presence of a terminal massless body will make the resulting
   mass matrix singular, restricting use to kinematic operations. */
   bool dynamics_ok() const { return data_.dynamics_ok; }
 
-  /** If dynamics_ok() returns `false`, returns a human-readable message
+  /* If dynamics_ok() returns `false`, returns a human-readable message
   explaining why. Otherwise returns the empty string. */
   const std::string& why_no_dynamics() const { return data_.why_no_dynamics; }
 
-  /** Provides convenient access to the owning graph's links, contiguous
+  /* Provides convenient access to the owning graph's links, contiguous
   and accessed by LinkOrdinal. */
   const std::vector<Link>& links() const { return graph().links(); }
 
-  /** Provides convenient access to one of the owning graph's links. Requires
+  /* Provides convenient access to one of the owning graph's links. Requires
   a LinkOrdinal, not a plain integer.
   @pre link_ordinal is in range */
   const Link& links(LinkOrdinal link_ordinal) const {
@@ -237,11 +231,11 @@ class SpanningForest {
     return graph().link_by_index(link_index);
   }
 
-  /** Provides convenient access to the owning graph's joints, contiguous
+  /* Provides convenient access to the owning graph's joints, contiguous
   and accessed by JointOrdinal. */
   const std::vector<Joint>& joints() const { return graph().joints(); }
 
-  /** Provides convenient access to one of the owning graph's joints. Requires
+  /* Provides convenient access to one of the owning graph's joints. Requires
   a JointOrdinal, not a plain integer.
   @pre joint_ordinal is in range */
   const Joint& joints(JointOrdinal joint_ordinal) const {
@@ -253,50 +247,50 @@ class SpanningForest {
     return graph().joint_by_index(joint_index);
   }
 
-  /** All the mobilized bodies, in depth-first order. World comes first,
+  /* All the mobilized bodies, in depth-first order. World comes first,
   then every Mobod in tree 0, then every Mobod in tree 1, etc. Free bodies
   that weren't explicitly connected to World by a Joint come last. */
   const std::vector<Mobod>& mobods() const { return data_.mobods; }
 
-  /** Provides convenient access to a particular Mobod. Requires a MobodIndex,
+  /* Provides convenient access to a particular Mobod. Requires a MobodIndex,
   not a plain integer.
   @pre mobod_index is in range */
   inline const Mobod& mobods(MobodIndex mobod_index) const;
 
-  /** The mobilized body (Mobod) corresponding to the World Link.
+  /* The mobilized body (Mobod) corresponding to the World Link.
   @pre The forest is valid. */
   // Internal use only: this is valid during BuildForest() also.
   const Mobod& world_mobod() const { return mobods(MobodIndex(0)); }
 
-  /** Constraints we added to close loops we had to cut. */
+  /* Constraints we added to close loops we had to cut. */
   const std::vector<LoopConstraint>& loop_constraints() const {
     return data_.loop_constraints;
   }
 
-  /** Provides convenient access to a particular LoopConstraint. Requires a
+  /* Provides convenient access to a particular LoopConstraint. Requires a
   LoopConstraintIndex, not a plain integer. */
   inline const LoopConstraint& loop_constraints(
       LoopConstraintIndex index) const;
 
-  /** The partitioning of the forest of mobilized bodies into trees. Each Tree
+  /* The partitioning of the forest of mobilized bodies into trees. Each Tree
   has a base (root) mobilized body that is connected directly to the World
   Mobod (which may represent a LinkComposite). World is not considered to
   be part of any Tree; it is the root of the Forest. */
   const std::vector<Tree>& trees() const { return data_.trees; }
 
-  /** Provides convenient access to a particular Tree. Requires a TreeIndex,
+  /* Provides convenient access to a particular Tree. Requires a TreeIndex,
   not a plain integer.
   @pre tree_index is in range */
   inline const Tree& trees(TreeIndex tree_index) const;
 
-  /** When this %SpanningForest is valid (i.e., after BuildForest() returns)
+  /* When this %SpanningForest is valid (i.e., after BuildForest() returns)
   this is the height of the forest, defined as the height of the tallest
   Tree, plus 1 for World. Returns zero for an invalid forest. */
   // Internal use only: During BuildForest() this will track the largest
   // height seen so far.
   int height() const { return data_.forest_height; }
 
-  /** Returns precalculated groups of mobilized bodies that are mutually
+  /* Returns precalculated groups of mobilized bodies that are mutually
   interconnected by Weld mobilizers so have no relative degrees of freedom.
   Note that if you have chosen the modeling option to combine welded-together
   Links into single bodies, then each LinkComposite gets only a single Mobod
@@ -318,19 +312,19 @@ class SpanningForest {
     return data_.welded_mobods;
   }
 
-  /** Provides convenient access to a particular WeldedMobods group. Requires a
+  /* Provides convenient access to a particular WeldedMobods group. Requires a
   WeldedMobodsIndex, not a plain integer.
   @pre index is in range */
   const std::vector<MobodIndex>& welded_mobods(WeldedMobodsIndex index) const {
     return welded_mobods().at(index);
   }
 
-  /** Returns the global ForestBuildingOptions in effect in the owning graph. */
+  /* Returns the global ForestBuildingOptions in effect in the owning graph. */
   ForestBuildingOptions options() const {
     return graph().get_global_forest_building_options();
   }
 
-  /** Returns the ForestBuildingOptions in effect for elements of the given
+  /* Returns the ForestBuildingOptions in effect for elements of the given
   ModelInstance. If we don't have specific options for this instance, we
   return the global ForestBuildingOptions as returned by options().
   @pre index is valid (but not necessarily one we've seen before) */
@@ -338,7 +332,7 @@ class SpanningForest {
     return graph().get_forest_building_options_in_use(index);
   }
 
-  /** Returns the Link that is represented by the given Mobod. This could be
+  /* Returns the Link that is represented by the given Mobod. This could be
   one of the Links from the original graph or an added shadow Link. If this
   Mobod represents a LinkComposite, the Link returned here is the
   "active" Link, that is, the one whose mobilizer is used to move the whole
@@ -346,29 +340,29 @@ class SpanningForest {
   @pre mobod_index is in range */
   inline LinkOrdinal mobod_to_link_ordinal(MobodIndex mobod_index) const;
 
-  /** Returns all the Links mobilized by this Mobod. The "active" Link returned
+  /* Returns all the Links mobilized by this Mobod. The "active" Link returned
   by mobod_to_link() comes first, then any other Links in the same Composite.
   O(1), very fast.
   @pre mobod_index is in range  */
   inline const std::vector<LinkOrdinal>& mobod_to_link_ordinals(
       MobodIndex mobod_index) const;
 
-  /** Returns the total number of generalized position coordinates q used by
+  /* Returns the total number of generalized position coordinates q used by
   this model. O(1), very fast. */
   int num_positions() const { return ssize(data_.q_to_mobod); }
 
-  /** Returns the total number of generalized velocity coordinates v used by
+  /* Returns the total number of generalized velocity coordinates v used by
   this model. O(1), very fast. */
   int num_velocities() const { return ssize(data_.v_to_mobod); }
 
-  /** Returns the indexes of all quaternions within the generalized position
+  /* Returns the indexes of all quaternions within the generalized position
   coordinates q. Each quaternion begins at the given index with its scalar
   element w, followed immediately by its vector part xyz. */
   const std::vector<int>& quaternion_starts() const {
     return data_.quaternion_starts;
   }
 
-  /** Returns the Mobod to which a given position coordinate q belongs.
+  /* Returns the Mobod to which a given position coordinate q belongs.
   O(1), very fast.
   @pre q_index is in range [0, num_positions) */
   MobodIndex q_to_mobod(int q_index) const {
@@ -376,7 +370,7 @@ class SpanningForest {
     return data_.q_to_mobod[q_index];
   }
 
-  /** Returns the Mobod to which a given velocity coordinate v belongs.
+  /* Returns the Mobod to which a given velocity coordinate v belongs.
   O(1), very fast.
   @pre v_index is in range [0, num_velocities) */
   MobodIndex v_to_mobod(int v_index) const {
@@ -384,12 +378,12 @@ class SpanningForest {
     return data_.v_to_mobod[v_index];
   }
 
-  /** Returns the Tree to which a given position coordinate q belongs.
+  /* Returns the Tree to which a given position coordinate q belongs.
   O(1), very fast.
   @pre q_index is in range [0, num_positions) */
   inline TreeIndex q_to_tree(int q_index) const;
 
-  /** Returns the Tree to which a given velocity coordinate v belongs.
+  /* Returns the Tree to which a given velocity coordinate v belongs.
   O(1), very fast.
   @pre v_index is in range [0, num_velocities) */
   inline TreeIndex v_to_tree(int v_index) const;
@@ -397,7 +391,7 @@ class SpanningForest {
   // FYI Debugging APIs (including Graphviz-related) are defined in
   // spanning_forest_debug.cc.
 
-  /** Generate a graphviz representation of this %SpanningForest, with the
+  /* Generate a graphviz representation of this %SpanningForest, with the
   given label at the top. The result is in the "dot" language, see
   https://graphviz.org. If you write it to some file foo.dot, you can
   generate a viewable png (for example) using the command
@@ -405,7 +399,7 @@ class SpanningForest {
   @see LinkJointGraph::GenerateGraphvizString() */
   std::string GenerateGraphvizString(std::string_view label) const;
 
-  /** (Debugging, Testing) Runs a series of expensive tests to see that the
+  /* (Debugging, Testing) Runs a series of expensive tests to see that the
   Graph and Forest are internally consistent and throws if not. Does nothing
   if no Forest has been built. */
   void SanityCheckForest() const;

--- a/multibody/topology/spanning_forest_loop_constraint.h
+++ b/multibody/topology/spanning_forest_loop_constraint.h
@@ -11,13 +11,13 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-/** Weld constraints added during modeling to close loops. */
+/* Weld constraints added during modeling to close loops. */
 class SpanningForest::LoopConstraint {
  public:
-  /** (Internal use only) Copy/Move constructor & assignment. */
+  /* (Internal use only) Copy/Move constructor & assignment. */
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LoopConstraint);
 
-  /** (Internal use only) Created in SpanningForest::BuildForest() when loops
+  /* (Internal use only) Created in SpanningForest::BuildForest() when loops
   are cut. */
   LoopConstraint(LoopConstraintIndex loop_constraint_index,
                  MobodIndex primary_mobod_index, MobodIndex shadow_mobod_index)
@@ -30,14 +30,14 @@ class SpanningForest::LoopConstraint {
     DRAKE_DEMAND(primary_mobod_index != shadow_mobod_index);
   }
 
-  /** Returns the index assigned to this LoopConstraint. */
+  /* Returns the index assigned to this LoopConstraint. */
   LoopConstraintIndex index() const { return loop_constraint_index_; }
 
-  /** Returns the primary Mobod associated with the cut Link. This will
+  /* Returns the primary Mobod associated with the cut Link. This will
   be the parent of the implementing weld constraint. */
   MobodIndex primary_mobod() const { return primary_mobod_index_; }
 
-  /** Returns the shadow Mobod associated with the cut Link. This will
+  /* Returns the shadow Mobod associated with the cut Link. This will
   be the child of the implementing weld constraint. */
   MobodIndex shadow_mobod() const { return shadow_mobod_index_; }
 

--- a/multibody/topology/spanning_forest_mobod.h
+++ b/multibody/topology/spanning_forest_mobod.h
@@ -14,38 +14,38 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-/** Everything you might want to know about a mobilized body. */
+/* Everything you might want to know about a mobilized body. */
 class SpanningForest::Mobod {
  public:
-  /** (Internal use only) Copy/Move constructor & assignment. */
+  /* (Internal use only) Copy/Move constructor & assignment. */
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Mobod);
 
-  /** (Internal use only) This constructor is just for World, the only %Mobod
+  /* (Internal use only) This constructor is just for World, the only %Mobod
   with no mobilizer. (Or you can consider it welded to the universe at the
   World origin.) */
   Mobod(MobodIndex mobod_index, LinkOrdinal world_link_ordinal);
 
-  /** (Internal use only) The general constructor for any non-World %Mobod. */
+  /* (Internal use only) The general constructor for any non-World %Mobod. */
   Mobod(MobodIndex mobod_index, LinkOrdinal link_ordinal,
         JointOrdinal joint_ordinal, int level, bool is_reversed);
 
-  /** Returns `true` if this %Mobod is the World body, that is, the one with
+  /* Returns `true` if this %Mobod is the World body, that is, the one with
   MobodIndex 0. Returns `false` for anything else, even if this %Mobod is
   welded to World. */
   bool is_world() const { return level_ == 0; }
 
-  /** A %Mobod is a "base body" if its inboard mobilizer connects it directly to
+  /* A %Mobod is a "base body" if its inboard mobilizer connects it directly to
   World. That means it is at level 1 in the Forest. */
   bool is_base_body() const { return level_ == 1; }
 
-  /** A %Mobod is "anchored" if it is the World %Mobod or if it is a %Mobod
+  /* A %Mobod is "anchored" if it is the World %Mobod or if it is a %Mobod
   directly or indirectly connected to the World %Mobod by Weld mobilizers.
   All such %Mobods are part of the 0th WeldedMobods group. */
   bool is_anchored() const {
     return welded_mobods_index_ == WeldedMobodsIndex(0);
   }
 
-  /** Returns true if there is no %Mobod that claims this one as its
+  /* Returns true if there is no %Mobod that claims this one as its
   inboard %Mobod.
   @note Even if this %Mobod is not a leaf of its tree, it could still
   be the case that there are no outboard degrees of freedom if all the
@@ -54,40 +54,40 @@ class SpanningForest::Mobod {
   @see nq_outboard() */
   bool is_leaf_mobod() const { return outboard_mobods_.empty(); }
 
-  /** Returns true if the inboard/outboard relation here is opposite the
+  /* Returns true if the inboard/outboard relation here is opposite the
   parent/child relation of the Joint that this Mobod is modeling. */
   bool is_reversed() const { return use_reverse_mobilizer_; }
 
-  /** Returns true if this %Mobod's inboard mobilizer has no degrees of
+  /* Returns true if this %Mobod's inboard mobilizer has no degrees of
   freedom (or if this is World). */
   bool is_weld() const { return nq() == 0; }
 
-  /** Returns the index of this %Mobod within the SpanningForest. World has
+  /* Returns the index of this %Mobod within the SpanningForest. World has
   index 0 and the rest are in depth-first order. */
   MobodIndex index() const { return index_; }
 
-  /** Returns the index of this %Mobod's unique inboard %Mobod. The index is
+  /* Returns the index of this %Mobod's unique inboard %Mobod. The index is
   invalid if this is the World %Mobod. The inboard %Mobod's level()
   is one less that this %Mobod's level(). */
   MobodIndex inboard() const { return inboard_mobod_; }
 
-  /** Returns the indices of all %Mobods for which this %Mobod serves as the
+  /* Returns the indices of all %Mobods for which this %Mobod serves as the
   inboard body. Each of the outboard %Mobods has a level() one higher than this
   %Mobod's level(). */
   const std::vector<MobodIndex>& outboards() const { return outboard_mobods_; }
 
-  /** Returns the ordinal of the Link mobilized by this %Mobod. If this %Mobod
+  /* Returns the ordinal of the Link mobilized by this %Mobod. If this %Mobod
   models a LinkComposite (collection of welded-together Links), this is the
   "active" Link of that composite, the one whose (non-Weld) Joint connects
   the whole LinkComposite to its inboard %Mobod.
   @see joint() */
   LinkOrdinal link_ordinal() const { return follower_link_ordinals()[0]; }
 
-  /** Returns true if _any_ of the follower links is massful, in which case
+  /* Returns true if _any_ of the follower links is massful, in which case
   this Mobod is also massful. */
   bool has_massful_follower_link() const { return has_massful_follower_link_; }
 
-  /** Returns all the Links that are mobilized by this %Mobod. If this %Mobod
+  /* Returns all the Links that are mobilized by this %Mobod. If this %Mobod
   represents a LinkComposite, the first Link returned is the "active" Link as
   returned by link_ordinal(). There is always at least one Link. */
   const std::vector<LinkOrdinal>& follower_link_ordinals() const {
@@ -102,18 +102,18 @@ class SpanningForest::Mobod {
                      link_ordinal) != follower_link_ordinals_.cend();
   }
 
-  /** Returns the ordinal of the Joint represented by this %Mobod. If this
+  /* Returns the ordinal of the Joint represented by this %Mobod. If this
   %Mobod represents a LinkComposite (which has internal weld Joints), the Joint
   returned here is the "active" Joint that connects the Composite's active Link
   to a Link that follows this %Mobod's inboard %Mobod in the forest. The
   returned ordinal is invalid only if this is the World %Mobod. */
   JointOrdinal joint_ordinal() const { return joint_ordinal_; }
 
-  /** Returns the index of the Tree of which this %Mobod is a member. The
+  /* Returns the index of the Tree of which this %Mobod is a member. The
   index is invalid if and only if this is the World %Mobod. */
   TreeIndex tree() const { return tree_index_; }
 
-  /** Returns the index of the WeldedMobods group of which this %Mobod is a
+  /* Returns the index of the WeldedMobods group of which this %Mobod is a
   part, if any. If this is the World %Mobod, we always return
   WeldedMobodIndex(0). Otherwise, an index is returned only if there is
   another %Mobod connected by a weld mobilizer to this %Mobod. */
@@ -121,52 +121,52 @@ class SpanningForest::Mobod {
     return welded_mobods_index_;
   }
 
-  /** Returns the level of this %Mobod within the SpanningForest. World is
+  /* Returns the level of this %Mobod within the SpanningForest. World is
   level 0, the root (base body) of each Tree is level 1, %Mobods connected to
   the base body are level 2, etc. */
   int level() const { return level_; }
 
-  /** Starting offset within the contiguous q vector. */
+  /* Starting offset within the contiguous q vector. */
   int q_start() const { return q_start_; }
 
-  /** The number of position coordinates q used by this %Mobod's mobilizer. */
+  /* The number of position coordinates q used by this %Mobod's mobilizer. */
   int nq() const { return nq_; }
 
-  /** True if the first four entries in q (beginning at q_start()) for this
+  /* True if the first four entries in q (beginning at q_start()) for this
   %Mobod are a quaternion. If so, it is stored in wxyz order -- that is, the
   scalar followed by the vector part. */
   bool has_quaternion() const { return has_quaternion_; }
 
-  /** Starting offset within the contiguous v vector. */
+  /* Starting offset within the contiguous v vector. */
   int v_start() const { return v_start_; }
 
-  /** The number of velocity coordinates v used by this %Mobod's mobilizer. */
+  /* The number of velocity coordinates v used by this %Mobod's mobilizer. */
   int nv() const { return nv_; }
 
-  /** The count of generalized position coordinates q on the path between this
+  /* The count of generalized position coordinates q on the path between this
   and World. Includes this %Mobod's qs. */
   int nq_inboard() const { return nq_inboard_; }
 
-  /** The count of generalized velocity coordinates v on the path between this
+  /* The count of generalized velocity coordinates v on the path between this
   and World. Includes this %Mobod's vs. */
   int nv_inboard() const { return nv_inboard_; }
 
-  /** The count of generalized position coordinates q in the outboard subtree
+  /* The count of generalized position coordinates q in the outboard subtree
   that has this %Mobod as its root. Does _not_ include this %Mobod's qs. */
   int nq_outboard() const { return nq_outboard_; }
 
-  /** The count of generalized velocity coordinates v in the outboard subtree
+  /* The count of generalized velocity coordinates v in the outboard subtree
   that has this %Mobod as its root. Does _not_ include this %Mobod's vs. */
   int nv_outboard() const { return nv_outboard_; }
 
-  /** The number of %Mobods in the subtree with this %Mobod as its root,
+  /* The number of %Mobods in the subtree with this %Mobod as its root,
   including this %Mobod in the count. These are numbered consecutively starting
   with this %Mobod's index, so the indices of the subtree %Mobods are [i, i+n)
   where i is this %Mobod's index and n is the return value of this method. When
   applied to World this returns the total number of %Mobods in the forest.*/
   int num_subtree_mobods() const { return num_subtree_mobods_; }
 
-  /** Returns the velocity coordinates for the subtree rooted at this %Mobod,
+  /* Returns the velocity coordinates for the subtree rooted at this %Mobod,
   _including_ this %Mobod's velocities. Because velocities are assigned
   depth-first, all the velocities in a subtree are consecutive so we need only
   return the index of the first one and the number of velocities. We return the
@@ -179,7 +179,7 @@ class SpanningForest::Mobod {
     return std::make_pair(v_start(), nv() + nv_outboard());
   }
 
-  /** Returns the velocity coordinates v that are outboard of this %Mobod,
+  /* Returns the velocity coordinates v that are outboard of this %Mobod,
   _not including_ its own velocities. This is the same as subtree_velocities()
   but with this Mobod's velocities removed. When applied to World, returns all
   the velocities in the forest.

--- a/multibody/topology/spanning_forest_tree.h
+++ b/multibody/topology/spanning_forest_tree.h
@@ -11,7 +11,7 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-/** Everything you might want to know about an individual tree in the forest.
+/* Everything you might want to know about an individual tree in the forest.
 A Tree consists of consecutively numbered Mobod nodes in depth-first order.
 The first node is its base Mobod (root node) and the last node is its
 "rightmost" terminal Mobod (assuming you draw the tree with the root at the
@@ -19,65 +19,65 @@ bottom, and children consistently left-to-right). Duplication is avoided by
 keeping a back pointer to the owning SpanningForest. */
 class SpanningForest::Tree {
  public:
-  /** (Internal use only) Copy/Move constructor & assignment. Back pointer
+  /* (Internal use only) Copy/Move constructor & assignment. Back pointer
   requires fixup afterwards. */
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Tree);
 
-  /** (Internal use only) Trees are constructed during BuildForest(). Note
+  /* (Internal use only) Trees are constructed during BuildForest(). Note
   that we know the base_mobod at construction but can't know the last_mobod
   until much later. */
   Tree(const SpanningForest* forest, TreeIndex index, MobodIndex base_mobod)
       : forest_(forest), index_(index), base_mobod_(base_mobod), height_(1) {}
 
-  /** The TreeIndex of this Tree within the SpanningForest. */
+  /* The TreeIndex of this Tree within the SpanningForest. */
   TreeIndex index() const { return index_; }
 
-  /** The length of the longest branch of this %Tree, counting the base (root)
+  /* The length of the longest branch of this %Tree, counting the base (root)
   body of the %Tree but not counting World. */
   int height() const { return height_; }
 
-  /** The level-1 Mobod that is the base (root) Mobod of this %Tree. This is
+  /* The level-1 Mobod that is the base (root) Mobod of this %Tree. This is
   the lowest-numbered Mobod in this %Tree. */
   MobodIndex base_mobod() const { return base_mobod_; }
 
-  /** The highest-numbered Mobod that is part of this %Tree. The Mobods in
+  /* The highest-numbered Mobod that is part of this %Tree. The Mobods in
   this tree are numbered consecutively from base_mobod() to last_mobod(). */
   MobodIndex last_mobod() const { return last_mobod_; }
 
-  /** An iterator pointing to the base_mobod(), suitable for range iteration. */
+  /* An iterator pointing to the base_mobod(), suitable for range iteration. */
   const SpanningForest::Mobod* begin() const {
     return &forest_->mobods()[base_mobod_];
   }
 
-  /** An iterator pointing one entry past the last_mobod(), suitable for range
+  /* An iterator pointing one entry past the last_mobod(), suitable for range
   iteration. Don't dereference this! */
   const SpanningForest::Mobod* end() const {
     return &forest_->mobods()[last_mobod_] + 1;
   }
 
-  /** The Mobod whose index is returned by base_mobod(). */
+  /* The Mobod whose index is returned by base_mobod(). */
   const SpanningForest::Mobod& front() const {
     return forest_->mobods()[base_mobod_];
   }
 
-  /** The Mobod whose index is returned by last_mobod(). */
+  /* The Mobod whose index is returned by last_mobod(). */
   const SpanningForest::Mobod& back() const {
     return forest_->mobods()[last_mobod_];
   }
 
-  /** The number of Mobods in this %Tree, counting the base (root) body.
+  /* The number of Mobods in this %Tree, counting the base (root) body.
   (World is not considered to be part of any %Tree.) */
   int num_mobods() const { return last_mobod_ - base_mobod_ + 1; }
 
-  /** The lowest numbered generalized position coordinate q assigned to
+  /* The lowest numbered generalized position coordinate q assigned to
   this %Tree. */
   int q_start() const { return front().q_start(); }
 
-  /** The lowest numbered generalized velocity coordinate v assigned to
+  /* The lowest numbered generalized velocity coordinate v assigned to
   this %Tree. */
   int v_start() const { return front().v_start(); }
 
-  /** The number of generalized position coordinates q assigned to
+  /* The number of generalized position coordinates q assigned to
   this %Tree. They are numbered sequentially from q_start() to
   q_start() + nq() - 1. */
   int nq() const {
@@ -87,7 +87,7 @@ class SpanningForest::Tree {
     return last_q_plus_1 - q_start();
   }
 
-  /** The number of generalized velocity coordinates v assigned to
+  /* The number of generalized velocity coordinates v assigned to
   this %Tree. They are numbered sequentially from v_start() to
   v_start() + nv() - 1. */
   int nv() const {


### PR DESCRIPTION
Currently the LinkJointGraph and SpanningForest topology classes are internal. Per agreement with @jwnimmer-tri I used full `/**` doxygen comments during development for syntax checking in anticipation of these being promoted eventually to public. Now that is done, this PR puts the comments back to internal-appropriate `/*`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21840)
<!-- Reviewable:end -->
