### PR TITLE
Consolidate .obj parsing

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_meshes.cc
+++ b/bindings/pydrake/geometry/geometry_py_meshes.cc
@@ -191,7 +191,7 @@ void DoMeshDependentDefinitions(py::module m) {
       },
       py::arg("filename"), py::arg("scale") = 1.0,
       // N.B. We have not bound the optional "on_warning" argument.
-      doc.ReadObjToTriangleSurfaceMesh.doc_3args_filename_scale_on_warning);
+      doc.ReadObjToTriangleSurfaceMesh.doc_3args);
 }
 
 }  // namespace

--- a/bindings/pydrake/multibody/test/mesh_to_model_test.py
+++ b/bindings/pydrake/multibody/test/mesh_to_model_test.py
@@ -120,7 +120,8 @@ class TestModelMaker(unittest.TestCase):
         not_an_obj = self._temp_dir / "not_an_obj.txt"
         with open(not_an_obj, 'w') as f:
             f.write("Just some text\n")
-        with self.assertRaisesRegex(RuntimeError, ".+obj data has no.+"):
+        with self.assertRaisesRegex(RuntimeError,
+                                    ".+file parsed contains no objects.+"):
             dut.mesh_path = not_an_obj
             dut.make_model()
         self.assertFalse(self._sdf_path.exists())

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -379,6 +379,7 @@ drake_cc_library(
     srcs = ["read_obj.cc"],
     hdrs = ["read_obj.h"],
     deps = [
+        "//common:diagnostic_policy",
         "@eigen",
     ],
     implementation_deps = [

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -780,8 +780,8 @@ drake_cc_library(
     ],
     implementation_deps = [
         "//common:essential",
+        "//geometry:read_obj",
         "@fmt",
-        "@tinyobjloader_internal//:tinyobjloader",
     ],
 )
 

--- a/geometry/proximity/obj_to_surface_mesh.cc
+++ b/geometry/proximity/obj_to_surface_mesh.cc
@@ -1,185 +1,50 @@
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
 
-#include <filesystem>
 #include <fstream>
-#include <istream>
 #include <memory>
-#include <numeric>
-#include <optional>
+#include <sstream>
 #include <stdexcept>
-#include <string>
 #include <utility>
-#include <vector>
-
-#include <fmt/format.h>
-#include <tiny_obj_loader.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/text_logging.h"
-#include "drake/geometry/proximity/triangle_surface_mesh.h"
+#include "drake/geometry/read_obj.h"
 
 namespace drake {
 namespace geometry {
-namespace {
 
 using drake::internal::DiagnosticDetail;
 using drake::internal::DiagnosticPolicy;
 using Eigen::Vector3d;
 
-// TODO(DamrongGuoy): Refactor the tinyobj usage between here and
-//  ProximityEngine.
-
-/*
- Converts vertices of tinyobj to vertices of TriangleSurfaceMesh.
- @param tinyobj_vertices
-     Vertices from tinyobj represented as `std::vector` of floating-point
-     numbers.
- @param scale
-     A scale to coordinates.
- @return
-     Vertices for TriangleSurfaceMesh.
- @pre
-     The size of `tinyobj_vertices` is divisible by three.
- */
-std::vector<Vector3d> TinyObjToSurfaceVertices(
-    const std::vector<tinyobj::real_t>& tinyobj_vertices, const double scale) {
-  // Vertices from tinyobj are in a vector of floating-point numbers like this:
-  //     tinyobj_vertices = {c₀,c₁,c₂, c₃,c₄,c₅, c₆,c₇,c₈,...}
-  //                      = {x, y, z,  x, y, z,  x, y, z,...}
-  // We will convert to a vector of Vector3<double> like this:
-  //     vertices = {{c₀,c₁,c₂}, {c₃,c₄,c₅}, {c₆,c₇,c₈},...}
-  //              = {    v0,         v1,         v2,...}
-  const int num_coords = tinyobj_vertices.size();
-  DRAKE_DEMAND(num_coords % 3 == 0);
-  std::vector<Vector3d> vertices;
-  vertices.reserve(num_coords / 3);
-
-  auto iter = tinyobj_vertices.begin();
-  while (iter != tinyobj_vertices.end()) {
-    double x = *(iter++) * scale;
-    double y = *(iter++) * scale;
-    double z = *(iter++) * scale;
-    vertices.emplace_back(Vector3<double>(x, y, z));
-  }
-  return vertices;
-}
-
-/*
- Converts faces of tinyobj::mesh_t to faces of TriangleSurfaceMesh.
- @param[in] mesh
-     The mesh from tinyobj.
- @param[out] faces
-     Triangles from previous meshes plus new triangles from this `mesh` on
-     return.
- @pre
-     Every face is a triangle.
- */
-void TinyObjToSurfaceFaces(const tinyobj::mesh_t& mesh,
-                           std::vector<SurfaceTriangle>* faces) {
-  //
-  // In general, tinyobj::mesh_t::num_face_vertices is a list of number
-  // of vertices of each polygonal face like this:
-  //     mesh.num_face_vertices = {n₀, n₁, n₂,...},
-  // where faceᵢ has nᵢ vertices. In this function, we require every face to
-  // be a triangle, so every nᵢ is 3 like this:
-  //     mesh.num_face_vertices = {3, 3, 3,...}.
-  //
-  // In general, tinyobj::mesh_t::indices concatenates tinyobj::index_t of
-  // vertices of each face like this:
-  //     mesh.indices = {v0₀,v0₁,...,v0ₙ₀₋₁, v1₀,v1₁,...,v1ₙ₁₋₁, ...}.
-  //                     -------face0------  -------face1------
-  // Because this function requires the faces to be triangles, it must look
-  // like this:
-  //     mesh.indices = {v0₀,v0₁,v0₂, v1₀,v1₁,v1₂, ...}.
-  //                     ---face0---  ---face1---
-  //
-  // Each tinyobj::index_t consists of vertex_index, normal_index, and
-  // texcoord_index. In this function, we use only vertex_index.
-  //
-  const int num_faces = mesh.num_face_vertices.size();
-  const int num_indices = mesh.indices.size();
-  // Although we will validate each face as a triangle individually, we make
-  // sure that there are enough vertices for that to be true as an initial
-  // check.
-  DRAKE_DEMAND(3 * num_faces == num_indices);
-  for (int face = 0; face < num_faces; ++face) {
-    DRAKE_DEMAND(mesh.num_face_vertices[face] == 3);
-    const int vertex_indices[3] = {mesh.indices[3 * face].vertex_index,
-                                   mesh.indices[3 * face + 1].vertex_index,
-                                   mesh.indices[3 * face + 2].vertex_index};
-    faces->emplace_back(vertex_indices);
-  }
-}
-
-}  // namespace
-
 namespace internal {
 std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
     std::istream* input_stream, const double scale,
-    const std::optional<std::string>& mtl_basedir,
-    const ObjParseConfig& config) {
-  tinyobj::attrib_t attrib;                    // Used for vertices.
-  std::vector<tinyobj::shape_t> shapes;        // Used for triangles.
-  std::vector<tinyobj::material_t> materials;  // Not used.
-  std::string warn;
-  std::string err;
-  std::unique_ptr<tinyobj::MaterialReader> readMatFn;
-  if (mtl_basedir) {
-    readMatFn = std::make_unique<tinyobj::MaterialFileReader>(*mtl_basedir);
-  }
-  // triangulate non-triangle faces.
-  bool triangulate = true;
-
-  bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err,
-                              input_stream, readMatFn.get(), triangulate);
-  if (!ret || !err.empty()) {
-    const std::string err_message =
-        fmt::format("Error parsing Wavefront obj data : {}", err);
-    config.diagnostic.Error(err_message);
-    return std::nullopt;
-  }
-  if (!warn.empty()) {
-    warn = "Warning parsing Wavefront obj data : " + warn;
-    if (warn.back() == '\n') {
-      warn.pop_back();
-    }
-    config.diagnostic.Warning(warn);
-  }
-  if (shapes.size() == 0) {
-    const char* err_message = "The Wavefront obj data has no faces.";
-    config.diagnostic.Error(err_message);
+    const drake::internal::DiagnosticPolicy& diagnostic,
+    std::string_view description) {
+  std::shared_ptr<std::vector<Eigen::Vector3d>> vertices;
+  std::shared_ptr<std::vector<int>> face_data;
+  int num_tris{};
+  std::tie(vertices, face_data, num_tris) = ReadObjStream(
+      input_stream, scale, /* triangulate = */ true, description, diagnostic);
+  if (vertices == nullptr) {
+    // ReadObjStream() reported errors to diagnostic; we can simply return no
+    // mesh.
     return std::nullopt;
   }
 
-  if (config.allowed_shape_count > 0 &&
-      static_cast<int>(shapes.size()) > config.allowed_shape_count) {
-    const std::string err_message = fmt::format(
-        "The Wavefront obj data defines {} unique shapes; only {} allowed.",
-        shapes.size(), config.allowed_shape_count);
-    config.diagnostic.Error(err_message);
-    return std::nullopt;
+  DRAKE_DEMAND(ssize(*face_data) == num_tris * 4);
+  std::vector<SurfaceTriangle> triangles;
+  triangles.reserve(num_tris);
+  int i = 0;
+  for (int f = 0; f < num_tris; ++f) {
+    DRAKE_DEMAND((*face_data)[i] == 3);  // Each face has three vertices.
+    triangles.emplace_back((*face_data)[i + 1], (*face_data)[i + 2],
+                           (*face_data)[i + 3]);
+    i += 4;
   }
 
-  std::vector<Vector3d> vertices =
-      TinyObjToSurfaceVertices(attrib.vertices, scale);
-
-  // tinyobj stores vertices from all objects in attrib.vertices but stores
-  // faces from each object separately. We will keep all faces together in
-  // the return TriangleSurfaceMesh. First we calculate the total number of
-  // faces of all objects, so we can pre-allocate memory for all faces of
-  // TriangleSurfaceMesh.
-  int total_num_faces =
-      std::accumulate(shapes.begin(), shapes.end(), 0,
-                      [](int sum, const tinyobj::shape_t& shape) {
-                        return sum + shape.mesh.num_face_vertices.size();
-                      });
-  std::vector<SurfaceTriangle> faces;
-  faces.reserve(total_num_faces);
-  for (const tinyobj::shape_t& shape : shapes) {
-    TinyObjToSurfaceFaces(shape.mesh, &faces);
-  }
-
-  return TriangleSurfaceMesh<double>(std::move(faces), std::move(vertices));
+  return TriangleSurfaceMesh<double>(std::move(triangles),
+                                     std::move(*vertices));
 }
 
 }  // namespace internal
@@ -191,8 +56,6 @@ TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
   if (!input_stream.is_open()) {
     throw std::runtime_error("Cannot open file '" + filename + "'");
   }
-  const std::string mtl_basedir =
-      std::filesystem::path(filename).parent_path().string() + "/";
 
   DiagnosticPolicy policy;
   if (on_warning != nullptr) {
@@ -202,13 +65,14 @@ TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
   }
 
   // We will either throw or return a mesh here.
-  return *internal::DoReadObjToSurfaceMesh(&input_stream, scale, mtl_basedir,
-                                           {.diagnostic = policy});
+  return *internal::DoReadObjToSurfaceMesh(&input_stream, scale, policy,
+                                           filename);
 }
 
 TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
     std::istream* input_stream, const double scale,
-    std::function<void(std::string_view)> on_warning) {
+    std::function<void(std::string_view)> on_warning,
+    std::string_view description) {
   DRAKE_THROW_UNLESS(input_stream != nullptr);
 
   DiagnosticPolicy policy;
@@ -219,9 +83,8 @@ TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
   }
 
   // We will either throw or return a mesh here.
-  return *internal::DoReadObjToSurfaceMesh(input_stream, scale,
-                                           std::nullopt /* mtl_basedir */,
-                                           {.diagnostic = policy});
+  return *internal::DoReadObjToSurfaceMesh(input_stream, scale, policy,
+                                           description);
 }
 
 }  // namespace geometry

--- a/geometry/proximity/obj_to_surface_mesh.h
+++ b/geometry/proximity/obj_to_surface_mesh.h
@@ -10,33 +10,26 @@
 #include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 
+// TODO(SeanCurtis-TRI): This should distill further and combine with
+// geometry/proximity/read_obj.* to further constrain the amount of ad hoc
+// obj parsing we do.
+
 namespace drake {
 namespace geometry {
 namespace internal {
 
-/* Configures the obj->mesh parsing operation. */
-struct ObjParseConfig {
-  /* The policy for handling warnings and errors. */
-  drake::internal::DiagnosticPolicy diagnostic;
-  /* Defines the maximum number of unique shapes in the file for a strictly
-   positive value. For any non-positive value, there is no limit. */
-  int allowed_shape_count{-1};
-};
-
 /* Creates a triangle mesh from the obj data contained in the `input_stream`.
- Parsing will continue through warnings, but stop for errors. If the given
- diagnostic policy (as defined in `config`) doesn't throw for errors,
- std::nullopt is returned.
- @pre `config` has both warning and error handlers defined. */
+ Parsing will continue through warnings. If the given diagnostic policy isn't
+ configured to stop for errors, std::nullopt is returned.
+ @pre `diagnostic` has both warning and error handlers defined. */
 std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
     std::istream* input_stream, double scale,
-    const std::optional<std::string>& mtl_basedir,
-    const ObjParseConfig& config);
+    const drake::internal::DiagnosticPolicy& diagnostic,
+    std::string_view description);
 
 }  // namespace internal
 
-/**
- Constructs a surface mesh from a Wavefront .obj file and optionally scales
+/** Constructs a surface mesh from a Wavefront .obj file and optionally scales
  coordinates by the given scale factor. Polygons will be triangulated if they
  are not triangles already. All objects in the .obj file will be merged into
  the surface mesh. See https://en.wikipedia.org/wiki/Wavefront_.obj_file for
@@ -50,19 +43,17 @@ std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
      while reading the mesh.  When not provided, drake::log() will be used.
  @throws std::exception if `filename` doesn't have a valid file path, or the
      file has no faces.
- @return surface mesh
- */
+ @return surface mesh */
 TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
     const std::string& filename, double scale = 1.0,
     std::function<void(std::string_view)> on_warning = {});
 
-/**
- Overload of @ref ReadObjToTriangleSurfaceMesh(const std::string&, double) with
- the Wavefront .obj file given in std::istream.
- */
+/** Overload of @ref ReadObjToTriangleSurfaceMesh(const std::string&, double)
+ with the Wavefront .obj file given in std::istream. */
 TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
     std::istream* input_stream, double scale = 1.0,
-    std::function<void(std::string_view)> on_warning = {});
+    std::function<void(std::string_view)> on_warning = {},
+    std::string_view description = "from_stream");
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/test/obj_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/obj_to_surface_mesh_test.cc
@@ -156,7 +156,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionInvalidFilePath) {
 GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionForEmptyFile) {
   std::istringstream empty("");
   DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToTriangleSurfaceMesh(&empty),
-                              ".*The Wavefront obj data has no faces.");
+                              ".*The file parsed contains no objects.*");
 }
 
 void FailOnWarning(std::string_view message) {
@@ -176,16 +176,6 @@ GTEST_TEST(ObjToSurfaceMeshTest, WarningCallback) {
     EXPECT_NO_THROW(ReadObjToTriangleSurfaceMesh(&input, 1.0));
   }
 
-  // When loaded as a stream (such that the *.mtl file is missing), the user-
-  // provided callback may choose to throw, and our test stub callback does so.
-  {
-    std::ifstream input(filename);
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        ReadObjToTriangleSurfaceMesh(&input, 1.0, &FailOnWarning),
-        "FailOnWarning: .*Warning parsing Wavefront obj data : "
-        ".*CubeMaterial.*not found.*");
-  }
-
   // When parsing using a filename, we are able to locate the *.mtl file with
   // no warnings.
   EXPECT_NO_THROW(ReadObjToTriangleSurfaceMesh(filename, 1.0, &FailOnWarning));
@@ -198,7 +188,7 @@ v 0.0 1.0 0.0
 v 0.0 0.0 1.0
 )"};
   DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToTriangleSurfaceMesh(&no_faces),
-                              ".*The Wavefront obj data has no faces.");
+                              ".*The file parsed contains no objects.*");
 }
 
 GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionObjectHasNoFaces) {
@@ -209,7 +199,7 @@ v 0.0 1.0 0.0
 v 0.0 0.0 1.0
 )"};
   DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToTriangleSurfaceMesh(&no_faces),
-                              ".*The Wavefront obj data has no faces.");
+                              ".*The file parsed contains no objects.*");
 }
 
 // Confirms that we can accept an obj file with faces (f lines) without

--- a/geometry/read_obj.cc
+++ b/geometry/read_obj.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/read_obj.h"
 
+#include <fstream>
+
 #include <fmt/format.h>
 #include <tiny_obj_loader.h>
 
@@ -13,6 +15,8 @@ namespace drake {
 namespace geometry {
 namespace internal {
 namespace {
+
+using drake::internal::DiagnosticPolicy;
 
 // TODO(SeanCurtis-TRI) Move this tinyobj->fcl code into its own library that
 //  can be built and tested separately.
@@ -106,34 +110,44 @@ std::vector<int> TinyObjToFclFaces(
 
 std::tuple<std::shared_ptr<std::vector<Eigen::Vector3d>>,
            std::shared_ptr<std::vector<int>>, int>
-ReadObjFile(const std::string& filename, double scale, bool triangulate) {
+ReadObjFile(const std::string& filename, double scale, bool triangulate,
+            const DiagnosticPolicy& diagnostic) {
+  std::ifstream f(filename);
+  return ReadObjStream(&f, scale, triangulate, filename, diagnostic);
+}
+
+std::tuple<std::shared_ptr<std::vector<Eigen::Vector3d>>,
+           std::shared_ptr<std::vector<int>>, int>
+ReadObjStream(std::istream* input_stream, double scale, bool triangulate,
+              std::string_view filename_hint,
+              const DiagnosticPolicy& diagnostic) {
   tinyobj::attrib_t attrib;
   std::vector<tinyobj::shape_t> shapes;
   std::vector<tinyobj::material_t> materials;
   std::string warn;
   std::string err;
 
-  // Tinyobj doesn't infer the search directory from the directory containing
-  // the obj file. We have to provide that directory; of course, this assumes
-  // that the material library reference is relative to the obj directory.
-  const size_t pos = filename.find_last_of('/');
-  const std::string obj_folder = filename.substr(0, pos + 1);
-  const char* mtl_basedir = obj_folder.c_str();
+  // We don't need materials, so we won't bother reading them.
+  tinyobj::MaterialReader* mat_reader = nullptr;
 
   bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err,
-                              filename.c_str(), mtl_basedir, triangulate);
+                              input_stream, mat_reader, triangulate);
   if (!ret || !err.empty()) {
-    throw std::runtime_error("Error parsing file '" + filename + "' : " + err);
+    diagnostic.Error(
+        fmt::format("Error parsing file '{}' : {}", filename_hint, err));
+    return {nullptr, nullptr, 0};
   }
   if (!warn.empty()) {
-    drake::log()->warn("Warning parsing file '{}' : {}", filename, warn);
+    diagnostic.Warning(
+        fmt::format("Warning parsing file '{}' : {}", filename_hint, warn));
   }
 
   if (shapes.size() == 0) {
-    throw std::runtime_error(
-        fmt::format("The file parsed contains no objects;. The file could be "
-                    "corrupt, empty, or not an OBJ file. File name: '{}'",
-                    filename));
+    diagnostic.Error(
+        fmt::format("The file parsed contains no objects; the file could be "
+                    "corrupt, empty, or not an OBJ file. File: '{}'",
+                    filename_hint));
+    return {nullptr, nullptr, 0};
   }
 
   auto vertices = std::make_shared<std::vector<Eigen::Vector3d>>(
@@ -155,6 +169,7 @@ ReadObjFile(const std::string& filename, double scale, bool triangulate) {
       std::make_shared<std::vector<int>>(TinyObjToFclFaces(shapes));
   return {vertices, faces, num_faces};
 }
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/read_obj.h
+++ b/geometry/read_obj.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <istream>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -7,10 +8,12 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/diagnostic_policy.h"
+
 namespace drake {
 namespace geometry {
 namespace internal {
-/** Reads the OBJ file with the given `filename` into a collection of data. It
+/* Reads the OBJ file with the given `filename` into a collection of data. It
  includes the vertex positions, face encodings (see TinyObjToFclFaces), and
  number of faces.
 
@@ -26,10 +29,20 @@ namespace internal {
             ...}
   where n_i is the number of vertices of face_i, vi_j is the index in
  `vertices` for a vertex on face i. Note that the size of faces is larger than
- num_faces. */
+ num_faces.
+
+ In the case of an error, the pointers will be null. */
 std::tuple<std::shared_ptr<std::vector<Eigen::Vector3d>>,
            std::shared_ptr<std::vector<int>>, int>
-ReadObjFile(const std::string& filename, double scale, bool triangulate);
+ReadObjFile(const std::string& filename, double scale, bool triangulate,
+            const drake::internal::DiagnosticPolicy& diagnostic = {});
+
+/* Variant that takes a stream. */
+std::tuple<std::shared_ptr<std::vector<Eigen::Vector3d>>,
+           std::shared_ptr<std::vector<int>>, int>
+ReadObjStream(std::istream* input_stream, double scale, bool triangulate,
+              std::string_view filename_hint,
+              const drake::internal::DiagnosticPolicy& diagnostic = {});
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -802,7 +802,7 @@ GTEST_TEST(ProximityEngineTests, FailedParsing) {
     Convex convex{file.string(), 1.0};
     DRAKE_EXPECT_THROWS_MESSAGE(
         engine.AddDynamicGeometry(convex, {}, GeometryId::get_new_id()),
-        "The file parsed contains no objects;.+");
+        ".*The file parsed contains no objects;.+");
   }
 
   // The file does not have OBJ contents..
@@ -813,7 +813,7 @@ GTEST_TEST(ProximityEngineTests, FailedParsing) {
     Convex convex{file.string(), 1.0};
     DRAKE_EXPECT_THROWS_MESSAGE(
         engine.AddDynamicGeometry(convex, {}, GeometryId::get_new_id()),
-        "The file parsed contains no objects;.+");}
+        ".*The file parsed contains no objects;.+");}
 }
 
 // Tests for copy/move semantics.  ---------------------------------------------

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -725,7 +725,7 @@ GTEST_TEST(ShapeTest, Volume) {
   // error along -- those terminate in new lines and has to be handled in the
   // matching expression explicitly.
   DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex("fakename.obj")),
-                              ".*Cannot open file[^]*");
+                              ".*file parsed contains no objects[^]*");
   // Error thrown in ReadObjToTriangleSurfaceMesh() (obj_to_surface_mesh.cc).
   DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh("fakename.obj")),
                               "Cannot open file.*");

--- a/multibody/parsing/detail_mesh_parser.cc
+++ b/multibody/parsing/detail_mesh_parser.cc
@@ -42,12 +42,10 @@ void CaptureName(void* storage, const char* parsed_name) {
 // parsing failure, the return value contains a null mesh.
 NamedMesh DoGetObjMesh(const DiagnosticPolicy& diagnostic,
                        std::istream* input_stream,
-                       const std::string& mtl_basedir) {
+                       std::string_view description) {
   std::optional<TriangleSurfaceMesh<double>> mesh =
-      geometry::internal::DoReadObjToSurfaceMesh(input_stream, 1.0,
-                                                 mtl_basedir,
-                                                 {.diagnostic = diagnostic,
-                                                  .allowed_shape_count = 1});
+      geometry::internal::DoReadObjToSurfaceMesh(input_stream, 1.0, diagnostic,
+                                                 description);
 
   if (!mesh.has_value()) {
     return {};
@@ -81,12 +79,7 @@ NamedMesh GetMeshFromFile(const DiagnosticPolicy& diagnostic,
     diagnostic.Error(fmt::format("Cannot open file '{}'", filename));
     return {};
   }
-  // Failure to provide the directory of the obj file as the base material
-  // library directory will cause OBJs with MTL files referenced by relative
-  // paths to spew warnings.
-  const std::string mtl_basedir =
-      std::filesystem::path(filename).parent_path().string() + "/";
-  return DoGetObjMesh(diagnostic, &input_stream, mtl_basedir);
+  return DoGetObjMesh(diagnostic, &input_stream, filename);
 }
 
 }  // namespace

--- a/tools/workspace/tinyobjloader_internal/patches/silence_materials.patch
+++ b/tools/workspace/tinyobjloader_internal/patches/silence_materials.patch
@@ -1,0 +1,18 @@
+tinyobj gives us the option to parse an obj file _without_ specifying a material
+reader. However, even if no material reader has been provided, usages of
+"usemtl" will bark at the lack of material. In the case where we're clearly not
+reading materials, we shouldn't bother processing the usemtl directives either.
+
+This should be upstreamed into tinyobjloader.
+
+--- tiny_obj_loader.h
++++ tiny_obj_loader.h
+@@ -2848,6 +2848,8 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+ 
+     // use mtl
+     if ((0 == strncmp(token, "usemtl", 6))) {
++      // Skip materials if we don't have a material reader.
++      if (readMatFn == nullptr) continue;
+       token += 6;
+       std::string namebuf = parseString(&token);
+ 

--- a/tools/workspace/tinyobjloader_internal/repository.bzl
+++ b/tools/workspace/tinyobjloader_internal/repository.bzl
@@ -13,5 +13,6 @@ def tinyobjloader_internal_repository(
         patches = [
             ":patches/faster_float_parsing.patch",
             ":patches/default_texture_color.patch",
+            ":patches/silence_materials.patch",
         ],
     )


### PR DESCRIPTION
We had two different sets of functions that would parse *just* the geometry out of an .obj file. They also had slightly different semantics. There was no value in the separation.

In this case, we maintain the two APIs, but we have one API simply call into the other API, limiting the spread of tinyobjloader.

There is a slight implication to the mesh parser. It previously enforced that parsed meshes *must* have a single object. This has now been relaxed. As the parsed geometry was only used to compute mass properties, this relaxation seems harmless, and makes it more compatible with a larger set of valid .obj files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21842)
<!-- Reviewable:end -->
