### PR TITLE
[setup] Adjust macOS pip dependencies

### DIFF
--- a/setup/mac/binary_distribution/requirements.txt
+++ b/setup/mac/binary_distribution/requirements.txt
@@ -1,7 +1,6 @@
 ipywidgets
 matplotlib
 notebook
-numpy < 2.1
 Pillow
 pydot
 PyYAML

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -9,7 +9,7 @@ DRAKE_VERSION = os.environ.get('DRAKE_VERSION', '0.0.0')
 # Required python packages that will be pip installed along with pydrake
 python_required = [
     'matplotlib',
-    'numpy < 2.1',
+    'numpy',
     'pydot',
     'PyYAML',
 ]

--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -21,7 +21,9 @@ _files_to_remove = []
 # default, all targets are built, but the user may down-select from this set.
 # On macOS (unlike Linux), this is just the set of Python versions targeted.
 python_targets = (
-    PythonTarget(3, 11),
+    # TODO(jwnimmer-tri) Python 3.11 is disabled until NumPy ships PyPI wheels
+    # for that Python version that are installable on macOS 13.
+    # PythonTarget(3, 11),
     PythonTarget(3, 12),
 )
 


### PR DESCRIPTION
Reverts RobotLocomotion/drake#21829.  Towards #21830.

The root cause of the failure is that NumPy 2.1.0 did not ship any wheels that are compatible with Ventura (macOS 13).  Upstream issue: https://github.com/numpy/numpy/issues/27283.  That means for now, we can't ship Drake wheels for Ventura, either.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21845)
<!-- Reviewable:end -->
