### PR TITLE
Create a Single Entrypoint for the Various IRIS Algorithms

### DIFF
--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -13,7 +13,29 @@ drake_cc_package_library(
     name = "iris",
     visibility = ["//visibility:public"],
     deps = [
+        ":iris_entrypoint",
         ":iris_from_clique_cover",
+    ],
+)
+
+drake_cc_library(
+    name = "iris_entrypoint",
+    srcs = ["iris_entrypoint.cc"],
+    hdrs = ["iris_entrypoint.h"],
+    deps = [
+        "//geometry/optimization:iris",
+        "//planning:scene_graph_collision_checker",
+    ],
+)
+
+drake_cc_googletest(
+    name = "iris_entrypoint_test",
+    timeout = "moderate",
+    deps = [
+        ":iris_entrypoint",
+        "//common/test_utilities:expect_throws_message",
+        "//planning:robot_diagram_builder",
+        "//planning:scene_graph_collision_checker",
     ],
 )
 

--- a/planning/iris/iris_entrypoint.cc
+++ b/planning/iris/iris_entrypoint.cc
@@ -18,9 +18,6 @@ HPolyhedron GrowIrisRegion(const CollisionChecker& checker,
   if (options.algorithm == IrisAlgorithm::Convex) {
     throw std::runtime_error("IrisAlgorithm::Convex is not supported yet.");
   }
-  if (options.algorithm == IrisAlgorithm::NP) {
-    throw std::runtime_error("IrisAlgorithm::NP is not supported yet.");
-  }
   if (options.algorithm == IrisAlgorithm::NP2) {
     throw std::runtime_error("IrisAlgorithm::NP2 is not supported yet.");
   }
@@ -29,6 +26,16 @@ HPolyhedron GrowIrisRegion(const CollisionChecker& checker,
   }
   if (options.algorithm == IrisAlgorithm::Certified) {
     throw std::runtime_error("IrisAlgorithm::Certified is not supported yet.");
+  }
+
+  if (options.algorithm == IrisAlgorithm::NP) {
+    if (options.region_space == IrisRegionSpace::TaskSpace2d || options.region_space == IrisRegionSpace::TaskSpace3d || options.region_space == IrisRegionSpace::AbstractSpaceNd || options.region_space == IrisRegionSpace::RationalConfigurationSpace) {
+      throw std::runtime_error("IrisAlgorithm::NP only supports options.region_space == IrisRegionSpace::ConfigurationSpace.");
+    }
+    const SceneGraphCollisionChecker* maybe_scene_graph_collision_checker = dynamic_cast<const SceneGraphCollisionChecker*>(&checker);
+    if (!maybe_scene_graph_collision_checker) {
+      throw std::runtime_error("IrisAlgorithm::NP only supports SceneGraphCollisionChecker.");
+    }
   }
 
   unused(checker);

--- a/planning/iris/iris_entrypoint.cc
+++ b/planning/iris/iris_entrypoint.cc
@@ -1,6 +1,7 @@
 #include "drake/planning/iris/iris_entrypoint.h"
 
 #include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/geometry/optimization/iris.h"
 #include "drake/planning/collision_checker.h"
 #include "drake/planning/scene_graph_collision_checker.h"
 
@@ -12,8 +13,8 @@ using geometry::optimization::HPolyhedron;
 HPolyhedron GrowIrisRegion(const CollisionChecker& checker,
                            const IrisOptions& options,
                            const Eigen::VectorXd seed) {
-  DRAKE_DEMAND(options.algorithm != IrisAlgorithm::Unset);
-  DRAKE_DEMAND(options.region_space != IrisRegionSpace::Unset);
+  DRAKE_THROW_UNLESS(options.algorithm != IrisAlgorithm::Unset);
+  DRAKE_THROW_UNLESS(options.region_space != IrisRegionSpace::Unset);
 
   if (options.algorithm == IrisAlgorithm::Convex) {
     throw std::runtime_error("IrisAlgorithm::Convex is not supported yet.");
@@ -29,16 +30,69 @@ HPolyhedron GrowIrisRegion(const CollisionChecker& checker,
   }
 
   if (options.algorithm == IrisAlgorithm::NP) {
-    if (options.region_space == IrisRegionSpace::TaskSpace2d || options.region_space == IrisRegionSpace::TaskSpace3d || options.region_space == IrisRegionSpace::AbstractSpaceNd || options.region_space == IrisRegionSpace::RationalConfigurationSpace) {
-      throw std::runtime_error("IrisAlgorithm::NP only supports options.region_space == IrisRegionSpace::ConfigurationSpace.");
+    if (options.region_space == IrisRegionSpace::TaskSpace2d ||
+        options.region_space == IrisRegionSpace::TaskSpace3d ||
+        options.region_space == IrisRegionSpace::AbstractSpaceNd ||
+        options.region_space == IrisRegionSpace::RationalConfigurationSpace) {
+      throw std::runtime_error(
+          "IrisAlgorithm::NP only supports options.region_space == "
+          "IrisRegionSpace::ConfigurationSpace.");
     }
-    const SceneGraphCollisionChecker* maybe_scene_graph_collision_checker = dynamic_cast<const SceneGraphCollisionChecker*>(&checker);
+    const SceneGraphCollisionChecker* maybe_scene_graph_collision_checker =
+        dynamic_cast<const SceneGraphCollisionChecker*>(&checker);
     if (!maybe_scene_graph_collision_checker) {
-      throw std::runtime_error("IrisAlgorithm::NP only supports SceneGraphCollisionChecker.");
+      throw std::runtime_error(
+          "IrisAlgorithm::NP only supports SceneGraphCollisionChecker.");
     }
-  }
+    // Check the dimension of the seed point.
+    const int num_positions =
+        maybe_scene_graph_collision_checker->plant().num_positions();
+    if (seed.size() != num_positions) {
+      throw std::runtime_error(fmt::format(
+          "Seed point has dimension {}, but the collision checker's underlying "
+          "plant has a configuration space of dimension {}",
+          seed.size(), num_positions));
+    }
 
-  unused(checker);
+    // Copy over the settings to the old IRIS-NP options struct.
+    geometry::optimization::IrisOptions iris_np_options;
+    iris_np_options.require_sample_point_is_contained =
+        options.require_sample_point_is_contained;
+    iris_np_options.iteration_limit = options.iteration_limit;
+    iris_np_options.termination_threshold =
+        options.absolute_termination_threshold;
+    iris_np_options.relative_termination_threshold =
+        options.relative_termination_threshold;
+    iris_np_options.configuration_space_margin =
+        options.configuration_space_margin;
+    iris_np_options.num_collision_infeasible_samples =
+        options.num_collision_infeasible_samples;
+    iris_np_options.configuration_obstacles = options.configuration_obstacles;
+    iris_np_options.starting_ellipse = options.starting_ellipse;
+    iris_np_options.bounding_region = options.bounding_region;
+    iris_np_options.prog_with_additional_constraints =
+        options.prog_with_additional_constraints;
+    iris_np_options.num_additional_constraint_infeasible_samples =
+        options.num_additional_constraint_infeasible_samples;
+    iris_np_options.random_seed = options.random_seed;
+    iris_np_options.meshcat = options.meshcat;
+    iris_np_options.termination_func = options.termination_function;
+    iris_np_options.mixing_steps = options.mixing_steps;
+    iris_np_options.solver_options = options.solver_options;
+
+    // Get the plant and context for IrisInConfigurationSpace.
+    const RobotDiagram<double>& diagram =
+        maybe_scene_graph_collision_checker->model();
+    const multibody::MultibodyPlant<double>& plant =
+        maybe_scene_graph_collision_checker->plant();
+    std::unique_ptr<systems::Context<double>> diagram_context_ptr =
+        diagram.CreateDefaultContext();
+    systems::Context<double>& plant_context =
+        plant.GetMyMutableContextFromRoot(diagram_context_ptr.get());
+    plant.SetPositions(&plant_context, seed);
+    return geometry::optimization::IrisInConfigurationSpace(
+        plant, plant_context, iris_np_options);
+  }
 
   return HPolyhedron::MakeUnitBox(seed.size());
 }

--- a/planning/iris/iris_entrypoint.cc
+++ b/planning/iris/iris_entrypoint.cc
@@ -1,0 +1,40 @@
+#include "drake/planning/iris/iris_entrypoint.h"
+
+#include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/planning/collision_checker.h"
+#include "drake/planning/scene_graph_collision_checker.h"
+
+namespace drake {
+namespace planning {
+
+using geometry::optimization::HPolyhedron;
+
+HPolyhedron GrowIrisRegion(const CollisionChecker& checker,
+                           const IrisOptions& options,
+                           const Eigen::VectorXd seed) {
+  DRAKE_DEMAND(options.algorithm != IrisAlgorithm::Unset);
+  DRAKE_DEMAND(options.region_space != IrisRegionSpace::Unset);
+
+  if (options.algorithm == IrisAlgorithm::Convex) {
+    throw std::runtime_error("IrisAlgorithm::Convex is not supported yet.");
+  }
+  if (options.algorithm == IrisAlgorithm::NP) {
+    throw std::runtime_error("IrisAlgorithm::NP is not supported yet.");
+  }
+  if (options.algorithm == IrisAlgorithm::NP2) {
+    throw std::runtime_error("IrisAlgorithm::NP2 is not supported yet.");
+  }
+  if (options.algorithm == IrisAlgorithm::ZO) {
+    throw std::runtime_error("IrisAlgorithm::ZO is not supported yet.");
+  }
+  if (options.algorithm == IrisAlgorithm::Certified) {
+    throw std::runtime_error("IrisAlgorithm::Certified is not supported yet.");
+  }
+
+  unused(checker);
+
+  return HPolyhedron::MakeUnitBox(seed.size());
+}
+
+}  // namespace planning
+}  // namespace drake

--- a/planning/iris/iris_entrypoint.cc
+++ b/planning/iris/iris_entrypoint.cc
@@ -18,18 +18,13 @@ HPolyhedron GrowIrisRegion(const CollisionChecker& checker,
 
   if (options.algorithm == IrisAlgorithm::Convex) {
     throw std::runtime_error("IrisAlgorithm::Convex is not supported yet.");
-  }
-  if (options.algorithm == IrisAlgorithm::NP2) {
+  } else if (options.algorithm == IrisAlgorithm::NP2) {
     throw std::runtime_error("IrisAlgorithm::NP2 is not supported yet.");
-  }
-  if (options.algorithm == IrisAlgorithm::ZO) {
+  } else if (options.algorithm == IrisAlgorithm::ZO) {
     throw std::runtime_error("IrisAlgorithm::ZO is not supported yet.");
-  }
-  if (options.algorithm == IrisAlgorithm::Certified) {
+  } else if (options.algorithm == IrisAlgorithm::Certified) {
     throw std::runtime_error("IrisAlgorithm::Certified is not supported yet.");
-  }
-
-  if (options.algorithm == IrisAlgorithm::NP) {
+  } else if (options.algorithm == IrisAlgorithm::NP) {
     if (options.region_space == IrisRegionSpace::TaskSpace2d ||
         options.region_space == IrisRegionSpace::TaskSpace3d ||
         options.region_space == IrisRegionSpace::AbstractSpaceNd ||
@@ -94,6 +89,8 @@ HPolyhedron GrowIrisRegion(const CollisionChecker& checker,
         plant, plant_context, iris_np_options);
   }
 
+  // Code should never reach this point, since we throw if the algorithm is
+  // unset, and every algorithm will return an HPolyhedron or throw.
   return HPolyhedron::MakeUnitBox(seed.size());
 }
 

--- a/planning/iris/iris_entrypoint.h
+++ b/planning/iris/iris_entrypoint.h
@@ -1,39 +1,42 @@
 #pragma once
 
+#include <memory>
+#include <optional>
+
+#include "drake/geometry/meshcat.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
 #include "drake/planning/collision_checker.h"
-#include "drake/geometry/meshcat.h"
 
 namespace drake {
 namespace planning {
 
 enum class IrisAlgorithm {
-  Unset,      ///< Default value -- must be changed by the user.
-  Convex,     ///< The original IRIS algorithm for convex obstacles in task space.
-  NP,         ///< The IRIS-NP algorithm, which uses nonlinear programming to grow
-              ///< regions in configuration space.
-  NP2,        ///< The IRIS-NP2 algorithm, an improved version of IRIS-NP.
-  ZO,         ///< The IRIS-ZO algorithm, which uses a gradient-free (zero-order)
-              ///< optimization to grow regions in configuration space.
+  Unset,   ///< Default value -- must be changed by the user.
+  Convex,  ///< The original IRIS algorithm for convex obstacles in task space.
+  NP,      ///< The IRIS-NP algorithm, which uses nonlinear programming to grow
+           ///< regions in configuration space.
+  NP2,     ///< The IRIS-NP2 algorithm, an improved version of IRIS-NP.
+  ZO,      ///< The IRIS-ZO algorithm, which uses a gradient-free (zero-order)
+           ///< optimization to grow regions in configuration space.
   Certified,  ///< The sums-of-squares certified version of the IRIS algorithm,
               ///< for growing regions in the rational parametrization of
               ///< configuration space.
 };
 
 enum class IrisRegionSpace {
-  Unset,                      ///< Default value -- must be changed by the user.
-  TaskSpace2d,                ///< Regions are grown in task space along the horizontal (xz)
-                              ///< plane.
-  TaskSpace3d,                ///< Regions are grown in task space.
-  AbstractSpaceNd,            ///< Regions are grown in an abstract n-dimensional
-                              ///< space. The CollisionChecker is ignored, and only
-                              ///< the convex obstacles specified in the options are
-                              ///< used. TODO(cohnt): Clean this explanation up.
-  ConfigurationSpace,         ///< Regions are grown in configuration space.
-  RationalConfigurationSpace, ///< Regions are grown in the rational
-                              ///< parametrization of configuration space.
+  Unset,        ///< Default value -- must be changed by the user.
+  TaskSpace2d,  ///< Regions are grown in task space along the horizontal (xz)
+                ///< plane.
+  TaskSpace3d,  ///< Regions are grown in task space.
+  AbstractSpaceNd,     ///< Regions are grown in an abstract n-dimensional
+                       ///< space. The CollisionChecker is ignored, and only
+                       ///< the convex obstacles specified in the options are
+                       ///< used. TODO(cohnt): Clean this explanation up.
+  ConfigurationSpace,  ///< Regions are grown in configuration space.
+  RationalConfigurationSpace,  ///< Regions are grown in the rational
+                               ///< parametrization of configuration space.
 };
 
 // TODO(cohnt): Annotate each option with which algorithms and spaces they are
@@ -46,13 +49,17 @@ See @ref IrisAlgorithm for a list of algorithms, and @ref IrisRegionSpace for a
 list of spaces where regions can be grown. The below table describes which
 algorithms can be used with which spaces.
 
-|           |   %TaskSpace2d  | %TaskSpace3d | %AbstractSpaceNd | %ConfigruationSpace | %RationalConfigurationSpace |
-| --------: | :-------------: | :----------: | :--------------: | :-----------------: | :-------------------------: |
-| Convex    |  Planned        |  Planned     |  Planned         |  Unsupported        |  Unsupported                |
-| NP        |  Unsupported    |  Unsupported |  Unsupported     |  Supported          |  Planned                    |
-| NP2       |  Unsupported    |  Unsupported |  Unsupported     |  Planned            |  Planned                    |
-| ZO        |  Unsupported    |  Unsupported |  Unsupported     |  Planned            |  Planned                    |
-| Certified |  Unsupported    |  Unsupported |  Unsupported     |  Unsupported        |  Planned                    |
+|           |   %TaskSpace2d  | %TaskSpace3d | %AbstractSpaceNd |
+%ConfigruationSpace | %RationalConfigurationSpace | | --------: |
+:-------------: | :----------: | :--------------: | :-----------------: |
+:-------------------------: | | Convex    |  Planned        |  Planned     |
+Planned         |  Unsupported        |  Unsupported                | | NP |
+Unsupported    |  Unsupported |  Unsupported     |  Supported          | Planned
+| | NP2       |  Unsupported    |  Unsupported |  Unsupported     |  Planned |
+Planned                    | | ZO        |  Unsupported    |  Unsupported |
+Unsupported     |  Planned            |  Planned                    | |
+Certified |  Unsupported    |  Unsupported |  Unsupported     |  Unsupported |
+Planned                    |
 __*Table 1*__: Algorithm/space compatibility matrix.
 
 */
@@ -71,10 +78,12 @@ struct IrisOptions {
   // TODO(wernerpe): Add IRIS-ZO options.
   // TODO(alexandreamice): Add C-IRIS options.
 
-  /** The polytope produced by the first iteration of each algorithm is guaranteed to contain the seed point, as long as that point is
-  collision-free. However, subsequent iterations do not make this guarantee, so the IRIS paper recommends that if containment is a
-  requirement, then the algorithm should simply terminate early if alternations
-  would ever cause the set to not contain the point. 
+  /** The polytope produced by the first iteration of each algorithm is
+  guaranteed to contain the seed point, as long as that point is collision-free.
+  However, subsequent iterations do not make this guarantee, so the IRIS paper
+  recommends that if containment is a requirement, then the algorithm should
+  simply terminate early if alternations would ever cause the set to not contain
+  the point.
 
   \b Algorithms: All */
   bool require_sample_point_is_contained{false};
@@ -173,7 +182,7 @@ struct IrisOptions {
   int num_additional_constraint_infeasible_samples{5};
 
   /** Set the initial seed for any random number generation.
-  
+
   \b Algorithms: NP, NP2, ZO */
   int random_seed{1234};
 
@@ -208,7 +217,8 @@ struct IrisOptions {
   require_sample_point_is_contained is enforced.
 
   \b Algorithms: All */
-  std::function<bool(const geometry::optimization::HPolyhedron&)> termination_func{};
+  std::function<bool(const geometry::optimization::HPolyhedron&)>
+      termination_function{};
 
   /* The `mixing_steps` parameters is passed to HPolyhedron::UniformSample to
   control the total number of hit-and-run steps taken for each new random
@@ -217,7 +227,10 @@ struct IrisOptions {
   \b Algorithms: NP, NP2, ZO */
   int mixing_steps{10};
 
-  /* SolverOptions passed into the optimization programs. For IRIS-NP and IRIS-NP2, this is sent to the nonlinear optimizer solving the counterexample search programs. For C-IRIS, these options are used for solving the SOS program.
+  /* SolverOptions passed into the optimization programs. For IRIS-NP and
+  IRIS-NP2, this is sent to the nonlinear optimizer solving the counterexample
+  search programs. For C-IRIS, these options are used for solving the SOS
+  program.
 
   \b Algorithms: NP, NP2, Certified*/
   std::optional<solvers::SolverOptions> solver_options;
@@ -236,7 +249,7 @@ geometry::optimization::HPolyhedron GrowIrisRegion(
 // TODO(cohnt): Add an algorithm/region_space compatibility matrix.
 // TODO(cohnt): Add IRIS-NP support.
 // TODO(cohnt): Add (original) IRIS support.
-// TODO(rhjiang): Add IRIS-NP2 support.
+// TODO(rhjiang/cohnt): Add IRIS-NP2 support.
 // TODO(wernerpe): Add IRIS-ZO support.
 // TODO(alexandreamice): Add C-IRIS support.
 

--- a/planning/iris/iris_entrypoint.h
+++ b/planning/iris/iris_entrypoint.h
@@ -1,53 +1,226 @@
 #pragma once
 
+#include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/geometry/optimization/hyperellipsoid.h"
 #include "drake/planning/collision_checker.h"
+#include "drake/geometry/meshcat.h"
 
 namespace drake {
 namespace planning {
 
 enum class IrisAlgorithm {
-  Unset,   ///< Default value -- must be changed by the user.
-  Convex,  ///< The original IRIS algorithm for convex obstacles in task space.
-  NP,      ///< The IRIS-NP algorithm, which uses nonlinear programming to grow
-           ///< regions in configuration space.
-  NP2,     ///< The IRIS-NP2 algorithm, an improved version of IRIS-NP.
-  ZO,      ///< The IRIS-ZO algorithm, which uses a gradient-free (zero-order)
-           ///< optimization to grow regions in configuration space.
+  Unset,      ///< Default value -- must be changed by the user.
+  Convex,     ///< The original IRIS algorithm for convex obstacles in task space.
+  NP,         ///< The IRIS-NP algorithm, which uses nonlinear programming to grow
+              ///< regions in configuration space.
+  NP2,        ///< The IRIS-NP2 algorithm, an improved version of IRIS-NP.
+  ZO,         ///< The IRIS-ZO algorithm, which uses a gradient-free (zero-order)
+              ///< optimization to grow regions in configuration space.
   Certified,  ///< The sums-of-squares certified version of the IRIS algorithm,
               ///< for growing regions in the rational parametrization of
               ///< configuration space.
 };
 
 enum class IrisRegionSpace {
-  Unset,        ///< Default value -- must be changed by the user.
-  TaskSpace2d,  ///< Regions are grown in task space along the horizontal (xz)
-                ///< plane.
-  TaskSpace3d,  ///< Regions are grown in task space.
-  TaskSpaceAbstractNd,  ///< Regions are grown in an abstract n-dimensional
-                        ///< space. The CollisionChecker is ignored, and only
-                        ///< the convex obstacles specified in the options are
-                        ///< used. TODO(cohnt): Clean this explanation up.
-  ConfigurationSpace,   ///< Regions are grown in configuration space.
-  RationalConfigurationSpace,  ///< Regions are grown in the rational
-                               ///< parametrization of configuration space.
+  Unset,                      ///< Default value -- must be changed by the user.
+  TaskSpace2d,                ///< Regions are grown in task space along the horizontal (xz)
+                              ///< plane.
+  TaskSpace3d,                ///< Regions are grown in task space.
+  AbstractSpaceNd,            ///< Regions are grown in an abstract n-dimensional
+                              ///< space. The CollisionChecker is ignored, and only
+                              ///< the convex obstacles specified in the options are
+                              ///< used. TODO(cohnt): Clean this explanation up.
+  ConfigurationSpace,         ///< Regions are grown in configuration space.
+  RationalConfigurationSpace, ///< Regions are grown in the rational
+                              ///< parametrization of configuration space.
 };
 
 // TODO(cohnt): Annotate each option with which algorithms and spaces they are
 // used for.
 // TODO(cohnt): Support serialization.
+/** Stores the options and parameters a user can set for the various IRIS
+algorithms.
+
+See @ref IrisAlgorithm for a list of algorithms, and @ref IrisRegionSpace for a
+list of spaces where regions can be grown. The below table describes which
+algorithms can be used with which spaces.
+
+|           |   %TaskSpace2d  | %TaskSpace3d | %AbstractSpaceNd | %ConfigruationSpace | %RationalConfigurationSpace |
+| --------: | :-------------: | :----------: | :--------------: | :-----------------: | :-------------------------: |
+| Convex    |  Planned        |  Planned     |  Planned         |  Unsupported        |  Unsupported                |
+| NP        |  Unsupported    |  Unsupported |  Unsupported     |  Supported          |  Planned                    |
+| NP2       |  Unsupported    |  Unsupported |  Unsupported     |  Planned            |  Planned                    |
+| ZO        |  Unsupported    |  Unsupported |  Unsupported     |  Planned            |  Planned                    |
+| Certified |  Unsupported    |  Unsupported |  Unsupported     |  Unsupported        |  Planned                    |
+__*Table 1*__: Algorithm/space compatibility matrix.
+
+*/
 struct IrisOptions {
   /** TODO(cohnt): Document */
-  IrisAlgorithm algorithm = IrisAlgorithm::Unset;
+  IrisAlgorithm algorithm{IrisAlgorithm::Unset};
 
   /** TODO(cohnt): Document */
-  IrisRegionSpace region_space = IrisRegionSpace::Unset;
+  IrisRegionSpace region_space{IrisRegionSpace::Unset};
 
   // TODO(cohnt): Add IRIS-NP options.
+  // TODO(cohnt): Verify which IRIS-NP options are also used by C-IRIS.
+  // TODO(cohnt): Clean up documentation so it's not just talking about IRIS-NP.
   // TODO(cohnt): Add (original) IRIS options.
   // TODO(rhjiang): Add IRIS-NP2 options.
   // TODO(wernerpe): Add IRIS-ZO options.
   // TODO(alexandreamice): Add C-IRIS options.
+
+  /** The polytope produced by the first iteration of each algorithm is guaranteed to contain the seed point, as long as that point is
+  collision-free. However, subsequent iterations do not make this guarantee, so the IRIS paper recommends that if containment is a
+  requirement, then the algorithm should simply terminate early if alternations
+  would ever cause the set to not contain the point. 
+
+  \b Algorithms: All */
+  bool require_sample_point_is_contained{false};
+
+  /** Maximum number of alternations.
+
+  \b Algorithms: All */
+  int iteration_limit{100};
+
+  /** IRIS will terminate if the change in the *volume* of the hyperellipsoid
+  between iterations is less that this threshold. This termination condition can
+  be disabled by setting to a negative value.
+
+  \b Algorithms: All */
+  double absolute_termination_threshold{2e-2};  // from rdeits/iris-distro.
+
+  /** IRIS will terminate if the change in the *volume* of the hyperellipsoid
+  between iterations is less that this percent of the previous best volume.
+  This termination condition can be disabled by setting to a negative value.
+
+  \b Algorithms: All */
+  double relative_termination_threshold{1e-3};  // from rdeits/iris-distro.
+
+  // TODO(russt): Improve the implementation so that we can clearly document the
+  // units for this margin.
+  /** When adding hyperplanes, we retreat by this margin from each
+  C-space obstacle in order to avoid the possibility of requiring an infinite
+  number of faces to approximate a curved boundary.
+
+  \b Algorithms: NP, NP2, and ZO */
+  double configuration_space_margin{1e-2};
+
+  /** For each possible collision, IRIS will search for a counter-example by
+  formulating a (likely nonconvex) optimization problem. The initial guess for
+  this optimization is taken by sampling uniformly inside the current IRIS
+  region. This option controls the termination condition for that
+  counter-example search, defining the number of consecutive failures to find a
+  counter-example requested before moving on to the next constraint.
+
+  \b Algorithms: NP */
+  int num_collision_infeasible_samples{5};
+
+  /** For IRIS in configuration space, it can be beneficial to not only specify
+  task-space obstacles (passed in through the plant) but also obstacles that are
+  defined by convex sets in the configuration space. This option can be used to
+  pass in such configuration space obstacles.
+
+  \b Algorithms: All */
+  geometry::optimization::ConvexSets configuration_obstacles{};
+
+  /** The initial hyperellipsoid used for calculating hyperplanes
+  in the first iteration. If no hyperellipsoid is provided, a small hypershpere
+  centered at the given sample will be used.
+
+  \b Algorithms: All */
+  std::optional<geometry::optimization::Hyperellipsoid> starting_ellipse{};
+
+  // TODO(cohnt): Update this documentation.
+  /** Optionally allows the caller to restrict the space within which IRIS
+  regions are allowed to grow. By default, IRIS regions are bounded by the
+  `domain` argument in the case of `Iris` or the joint limits of the input
+  `plant` in the case of `IrisInConfigurationSpace`. If this option is
+  specified, IRIS regions will be confined to the intersection between the
+  domain and `bounding_region`.
+
+  \b Algorithms: All */
+  std::optional<geometry::optimization::HPolyhedron> bounding_region{};
+
+  /** By default, IRIS in configuration space certifies regions for collision
+  avoidance constraints and joint limits. This option can be used to pass
+  additional constraints that should be satisfied by the IRIS region. We accept
+  these in the form of a MathematicalProgram:
+
+    find q subject to g(q) ≤ 0.
+
+  The decision_variables() for the program are taken to define `q`. IRIS will
+  silently ignore any costs in `prog_with_additional_constraints`, and will
+  throw std::runtime_error if it contains any unsupported constraints.
+
+  For example, one could create an InverseKinematics problem with rich
+  kinematic constraints, and then pass `InverseKinematics::prog()` into this
+  option.
+
+  \b Algorithms: NP */
+  const solvers::MathematicalProgram* prog_with_additional_constraints{};
+
+  /** For each constraint in `prog_with_additional_constraints`, IRIS will
+  search for a counter-example by formulating a (likely nonconvex) optimization
+  problem. The initial guess for this optimization is taken by sampling
+  uniformly inside the current IRIS region. This option controls the
+  termination condition for that counter-example search, defining the number of
+  consecutive failures to find a counter-example requested before moving on to
+  the next constraint.
+
+  \b Algorithms: NP */
+  int num_additional_constraint_infeasible_samples{5};
+
+  /** Set the initial seed for any random number generation.
+  
+  \b Algorithms: NP, NP2, ZO */
+  int random_seed{1234};
+
+  /** Passing a meshcat instance may enable debugging visualizations; this
+  currently only happens for IrisRegionSpace::ConfigurationSpace and when the
+  configuration space is <= 3 dimensional.
+
+  \b Algorithms: NP, NP2, ZO */
+  std::shared_ptr<geometry::Meshcat> meshcat{};
+
+  /** A user-defined termination function to
+  determine whether the iterations should stop. This function is called after
+  computing each hyperplane at every IRIS iteration. If the function returns
+  true, then the computations will stop and the last step region will be
+  returned. Therefore, it is highly recommended that the termination function
+  possesses a monotonic property such that for any two HPolyhedrons A and B such
+  that B ⊆ A, we have if termination(A) -> termination(B). For example, a valid
+  termination function is to check whether if the region does not contain any of
+  a set of desired points.
+  ```
+  auto termination_func = [](const HPolyhedron& set) {
+    for (const VectorXd& point : desired_points) {
+      if (!set.PointInSet(point)) {
+        return true;
+      }
+    }
+    return false;
+  };
+  ```
+  The algorithm will stop when as soon as the region leaves one
+  of the desired points, in a similar way to how @p
+  require_sample_point_is_contained is enforced.
+
+  \b Algorithms: All */
+  std::function<bool(const geometry::optimization::HPolyhedron&)> termination_func{};
+
+  /* The `mixing_steps` parameters is passed to HPolyhedron::UniformSample to
+  control the total number of hit-and-run steps taken for each new random
+  sample.
+
+  \b Algorithms: NP, NP2, ZO */
+  int mixing_steps{10};
+
+  /* SolverOptions passed into the optimization programs. For IRIS-NP and IRIS-NP2, this is sent to the nonlinear optimizer solving the counterexample search programs. For C-IRIS, these options are used for solving the SOS program.
+
+  \b Algorithms: NP, NP2, Certified*/
+  std::optional<solvers::SolverOptions> solver_options;
 };
 
 /** General entry point for the IRIS algorithm and its variants, used for

--- a/planning/iris/iris_entrypoint.h
+++ b/planning/iris/iris_entrypoint.h
@@ -49,20 +49,22 @@ See @ref IrisAlgorithm for a list of algorithms, and @ref IrisRegionSpace for a
 list of spaces where regions can be grown. The below table describes which
 algorithms can be used with which spaces.
 
-|           |   %TaskSpace2d  | %TaskSpace3d | %AbstractSpaceNd |
-%ConfigruationSpace | %RationalConfigurationSpace | | --------: |
-:-------------: | :----------: | :--------------: | :-----------------: |
-:-------------------------: | | Convex    |  Planned        |  Planned     |
-Planned         |  Unsupported        |  Unsupported                | | NP |
-Unsupported    |  Unsupported |  Unsupported     |  Supported          | Planned
-| | NP2       |  Unsupported    |  Unsupported |  Unsupported     |  Planned |
-Planned                    | | ZO        |  Unsupported    |  Unsupported |
-Unsupported     |  Planned            |  Planned                    | |
-Certified |  Unsupported    |  Unsupported |  Unsupported     |  Unsupported |
-Planned                    |
-__*Table 1*__: Algorithm/space compatibility matrix.
-
 */
+// TODO(cohnt): Figure out how to get clang not to complain about this.
+// clang-format off
+/**
+|           |   %TaskSpace2d  | %TaskSpace3d | %AbstractSpaceNd | %ConfigruationSpace | %RationalConfigurationSpace |
+| --------: | :-------------: | :----------: | :--------------: | :-----------------: | :-------------------------: |
+| Convex    |  Planned        |  Planned     |  Planned         |  Unsupported        |  Unsupported                |
+| NP        |  Unsupported    |  Unsupported |  Unsupported     |  Supported          |  Planned                    |
+| NP2       |  Unsupported    |  Unsupported |  Unsupported     |  Planned            |  Planned                    |
+| ZO        |  Unsupported    |  Unsupported |  Unsupported     |  Planned            |  Planned                    |
+| Certified |  Unsupported    |  Unsupported |  Unsupported     |  Unsupported        |  Planned                    |
+__*Table 1*__: Algorithm/space compatibility matrix.
+*/
+// clang-format on
+/**
+ */
 struct IrisOptions {
   /** TODO(cohnt): Document */
   IrisAlgorithm algorithm{IrisAlgorithm::Unset};

--- a/planning/iris/iris_entrypoint.h
+++ b/planning/iris/iris_entrypoint.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/planning/collision_checker.h"
+
+namespace drake {
+namespace planning {
+
+enum class IrisAlgorithm {
+  Unset,   ///< Default value -- must be changed by the user.
+  Convex,  ///< The original IRIS algorithm for convex obstacles in task space.
+  NP,      ///< The IRIS-NP algorithm, which uses nonlinear programming to grow
+           ///< regions in configuration space.
+  NP2,     ///< The IRIS-NP2 algorithm, an improved version of IRIS-NP.
+  ZO,      ///< The IRIS-ZO algorithm, which uses a gradient-free (zero-order)
+           ///< optimization to grow regions in configuration space.
+  Certified,  ///< The sums-of-squares certified version of the IRIS algorithm,
+              ///< for growing regions in the rational parametrization of
+              ///< configuration space.
+};
+
+enum class IrisRegionSpace {
+  Unset,        ///< Default value -- must be changed by the user.
+  TaskSpace2d,  ///< Regions are grown in task space along the horizontal (xz)
+                ///< plane.
+  TaskSpace3d,  ///< Regions are grown in task space.
+  TaskSpaceAbstractNd,  ///< Regions are grown in an abstract n-dimensional
+                        ///< space. The CollisionChecker is ignored, and only
+                        ///< the convex obstacles specified in the options are
+                        ///< used. TODO(cohnt): Clean this explanation up.
+  ConfigurationSpace,   ///< Regions are grown in configuration space.
+  RationalConfigurationSpace,  ///< Regions are grown in the rational
+                               ///< parametrization of configuration space.
+};
+
+// TODO(cohnt): Annotate each option with which algorithms and spaces they are
+// used for.
+// TODO(cohnt): Support serialization.
+struct IrisOptions {
+  /** TODO(cohnt): Document */
+  IrisAlgorithm algorithm = IrisAlgorithm::Unset;
+
+  /** TODO(cohnt): Document */
+  IrisRegionSpace region_space = IrisRegionSpace::Unset;
+
+  // TODO(cohnt): Add IRIS-NP options.
+  // TODO(cohnt): Add (original) IRIS options.
+  // TODO(rhjiang): Add IRIS-NP2 options.
+  // TODO(wernerpe): Add IRIS-ZO options.
+  // TODO(alexandreamice): Add C-IRIS options.
+};
+
+/** General entry point for the IRIS algorithm and its variants, used for
+generating convex collision-free subsets in task and configuration space.
+
+@pre options.algorithm != IrisAlgorithm::Unset
+@pre options.region_space != IrisRegionSpace::Unset
+*/
+geometry::optimization::HPolyhedron GrowIrisRegion(
+    const CollisionChecker& checker, const IrisOptions& options,
+    const Eigen::VectorXd seed);
+
+// TODO(cohnt): Add an algorithm/region_space compatibility matrix.
+// TODO(cohnt): Add IRIS-NP support.
+// TODO(cohnt): Add (original) IRIS support.
+// TODO(rhjiang): Add IRIS-NP2 support.
+// TODO(wernerpe): Add IRIS-ZO support.
+// TODO(alexandreamice): Add C-IRIS support.
+
+}  // namespace planning
+}  // namespace drake

--- a/planning/iris/test/iris_entrypoint_test.cc
+++ b/planning/iris/test/iris_entrypoint_test.cc
@@ -48,12 +48,13 @@ const char free_box[] = R"""(
 </robot>
 )""";
 
-std::unique_ptr<CollisionChecker> MakeSphereInCollisionChecker() {
+std::unique_ptr<SceneGraphCollisionChecker> SceneGraphCollisionCheckerFromUrdf(
+    const std::string urdf) {
   CollisionCheckerParams params;
 
   RobotDiagramBuilder<double> builder(0.0);
   params.robot_model_instances =
-      builder.parser().AddModelsFromString(free_box, "urdf");
+      builder.parser().AddModelsFromString(urdf, "urdf");
   params.edge_step_size = 0.01;
 
   params.model = builder.Build();
@@ -92,17 +93,14 @@ GTEST_TEST(IrisEntrypointTest, NotImplemented) {
     }
   }
 
-  std::unique_ptr<CollisionChecker> checker = MakeSphereInCollisionChecker();
+  std::unique_ptr<CollisionChecker> checker =
+      SceneGraphCollisionCheckerFromUrdf(free_box);
   for (const auto& invalid_option : not_implemented_option) {
     DRAKE_EXPECT_THROWS_MESSAGE(
         GrowIrisRegion(*checker, invalid_option, VectorXd::Zero(2)),
         ".*not supported yet.*");
   }
 }
-
-// GTEST_TEST(IrisEntrypointTest, UnsupportedOptionsNP) {
-//   std::vector<IrisAlgorithm>
-// }
 
 }  // namespace
 }  // namespace planning

--- a/planning/iris/test/iris_entrypoint_test.cc
+++ b/planning/iris/test/iris_entrypoint_test.cc
@@ -63,24 +63,33 @@ std::unique_ptr<CollisionChecker> MakeSphereInCollisionChecker() {
   return checker;
 }
 
-GTEST_TEST(IrisEntrypointTest, NotImplemented) {
-  std::vector<IrisAlgorithm> all_algorithms;
-  all_algorithms.push_back(IrisAlgorithm::Convex);
-  all_algorithms.push_back(IrisAlgorithm::NP);
-  all_algorithms.push_back(IrisAlgorithm::NP2);
-  all_algorithms.push_back(IrisAlgorithm::ZO);
-  all_algorithms.push_back(IrisAlgorithm::Certified);
+std::vector<IrisAlgorithm> all_algorithms = {
+  IrisAlgorithm::Convex,
+  IrisAlgorithm::NP,
+  IrisAlgorithm::NP2,
+  IrisAlgorithm::ZO,
+  IrisAlgorithm::Certified,
+};
 
-  std::vector<IrisOptions> not_implemented_option(5, IrisOptions());
+std::vector<IrisRegionSpace> all_region_spaces = {
+  IrisRegionSpace::TaskSpace2d,
+  IrisRegionSpace::TaskSpace3d,
+  IrisRegionSpace::AbstractSpaceNd,
+  IrisRegionSpace::ConfigurationSpace,
+  IrisRegionSpace::RationalConfigurationSpace,
+};
+
+GTEST_TEST(IrisEntrypointTest, NotImplemented) {
+  std::vector<IrisOptions> not_implemented_option();
 
   // Not yet implemented.
-  not_implemented_option[0].algorithm = IrisAlgorithm::Convex;
-  not_implemented_option[1].algorithm = IrisAlgorithm::NP;
-  not_implemented_option[2].algorithm = IrisAlgorithm::NP2;
-  not_implemented_option[3].algorithm = IrisAlgorithm::ZO;
-  not_implemented_option[4].algorithm = IrisAlgorithm::Certified;
-  for (int i = 0; i < 5; ++i) {
-    not_implemented_option[i].region_space = IrisRegionSpace::TaskSpace2d;
+  for (const auto& algorithm : all_algorithms) {
+    if (algorithm != IrisAlgorithm::NP) {
+      IrisOptions options;
+      options.algorithm = algorithm;
+      options.region_space = IrisRegionSpace::TaskSpace2d;
+      not_implemented_option.push_back(options);
+    }
   }
 
   std::unique_ptr<CollisionChecker> checker = MakeSphereInCollisionChecker();
@@ -90,6 +99,10 @@ GTEST_TEST(IrisEntrypointTest, NotImplemented) {
         ".*not supported yet.*");
   }
 }
+
+// GTEST_TEST(IrisEntrypointTest, UnsupportedOptionsNP) {
+//   std::vector<IrisAlgorithm>
+// }
 
 }  // namespace
 }  // namespace planning

--- a/planning/iris/test/iris_entrypoint_test.cc
+++ b/planning/iris/test/iris_entrypoint_test.cc
@@ -64,23 +64,20 @@ std::unique_ptr<CollisionChecker> MakeSphereInCollisionChecker() {
 }
 
 std::vector<IrisAlgorithm> all_algorithms = {
-  IrisAlgorithm::Convex,
-  IrisAlgorithm::NP,
-  IrisAlgorithm::NP2,
-  IrisAlgorithm::ZO,
-  IrisAlgorithm::Certified,
+    IrisAlgorithm::Convex, IrisAlgorithm::NP,        IrisAlgorithm::NP2,
+    IrisAlgorithm::ZO,     IrisAlgorithm::Certified,
 };
 
 std::vector<IrisRegionSpace> all_region_spaces = {
-  IrisRegionSpace::TaskSpace2d,
-  IrisRegionSpace::TaskSpace3d,
-  IrisRegionSpace::AbstractSpaceNd,
-  IrisRegionSpace::ConfigurationSpace,
-  IrisRegionSpace::RationalConfigurationSpace,
+    IrisRegionSpace::TaskSpace2d,
+    IrisRegionSpace::TaskSpace3d,
+    IrisRegionSpace::AbstractSpaceNd,
+    IrisRegionSpace::ConfigurationSpace,
+    IrisRegionSpace::RationalConfigurationSpace,
 };
 
 GTEST_TEST(IrisEntrypointTest, NotImplemented) {
-  std::vector<IrisOptions> not_implemented_option();
+  std::vector<IrisOptions> not_implemented_option;
 
   // Not yet implemented.
   for (const auto& algorithm : all_algorithms) {

--- a/planning/iris/test/iris_entrypoint_test.cc
+++ b/planning/iris/test/iris_entrypoint_test.cc
@@ -84,6 +84,9 @@ GTEST_TEST(IrisEntrypointTest, NotImplemented) {
     if (algorithm != IrisAlgorithm::NP) {
       IrisOptions options;
       options.algorithm = algorithm;
+      // We can use anything for options.region_space besides
+      // IrisRegionSpace::Unset, since the region space is checked after the
+      // algorithm.
       options.region_space = IrisRegionSpace::TaskSpace2d;
       not_implemented_option.push_back(options);
     }

--- a/planning/iris/test/iris_entrypoint_test.cc
+++ b/planning/iris/test/iris_entrypoint_test.cc
@@ -1,0 +1,96 @@
+#include "drake/planning/iris/iris_entrypoint.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/planning/collision_checker.h"
+#include "drake/planning/robot_diagram_builder.h"
+#include "drake/planning/scene_graph_collision_checker.h"
+
+namespace drake {
+namespace planning {
+namespace {
+
+using Eigen::VectorXd;
+
+/* A movable sphere in a box.
+┌───────────────┐
+│               │
+│               │
+│               │
+│       o       │
+│               │
+│               │
+│               │
+└───────────────┘ */
+const char free_box[] = R"""(
+<robot name="boxes">
+  <link name="movable">
+    <collision name="sphere">
+      <geometry><sphere radius="0.1"/></geometry>
+    </collision>
+  </link>
+  <link name="for_joint"/>
+
+  <joint name="x" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit lower="-2" upper="2"/>
+    <parent link="world"/>
+    <child link="for_joint"/>
+  </joint>
+  <joint name="y" type="prismatic">
+    <axis xyz="0 1 0"/>
+    <limit lower="-2" upper="2"/>
+    <parent link="for_joint"/>
+    <child link="movable"/>
+  </joint>
+</robot>
+)""";
+
+std::unique_ptr<CollisionChecker> MakeSphereInCollisionChecker() {
+  CollisionCheckerParams params;
+
+  RobotDiagramBuilder<double> builder(0.0);
+  params.robot_model_instances =
+      builder.parser().AddModelsFromString(free_box, "urdf");
+  params.edge_step_size = 0.01;
+
+  params.model = builder.Build();
+  auto checker =
+      std::make_unique<SceneGraphCollisionChecker>(std::move(params));
+
+  return checker;
+}
+
+GTEST_TEST(IrisEntrypointTest, NotImplemented) {
+  std::vector<IrisAlgorithm> all_algorithms;
+  all_algorithms.push_back(IrisAlgorithm::Convex);
+  all_algorithms.push_back(IrisAlgorithm::NP);
+  all_algorithms.push_back(IrisAlgorithm::NP2);
+  all_algorithms.push_back(IrisAlgorithm::ZO);
+  all_algorithms.push_back(IrisAlgorithm::Certified);
+
+  std::vector<IrisOptions> not_implemented_option(5, IrisOptions());
+
+  // Not yet implemented.
+  not_implemented_option[0].algorithm = IrisAlgorithm::Convex;
+  not_implemented_option[1].algorithm = IrisAlgorithm::NP;
+  not_implemented_option[2].algorithm = IrisAlgorithm::NP2;
+  not_implemented_option[3].algorithm = IrisAlgorithm::ZO;
+  not_implemented_option[4].algorithm = IrisAlgorithm::Certified;
+  for (int i = 0; i < 5; ++i) {
+    not_implemented_option[i].region_space = IrisRegionSpace::TaskSpace2d;
+  }
+
+  std::unique_ptr<CollisionChecker> checker = MakeSphereInCollisionChecker();
+  for (const auto& invalid_option : not_implemented_option) {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        GrowIrisRegion(*checker, invalid_option, VectorXd::Zero(2)),
+        ".*not supported yet.*");
+  }
+}
+
+}  // namespace
+}  // namespace planning
+}  // namespace drake


### PR DESCRIPTION
This is the beginning of a collective effort to resolve #21821.

For now, we're just creating that single entrypoint function, and showing that it can call IrisInConfigurationSpace properly. This isn't really close to being ready to merge into Drake in its current state, but hopefully I can start getting comments and suggestions from anyone who's involved with the various IRIS variants, and/or is a potential user. CC @rhjiang @wernerpe @RussTedrake @AlexandreAmice @sadraddini

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21852)
<!-- Reviewable:end -->
