### PR TITLE
Usages of fmt::join made compatible with fmt v11

### DIFF
--- a/common/yaml/test/yaml_doxygen_test.cc
+++ b/common/yaml/test/yaml_doxygen_test.cc
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <sstream>
 
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -5,6 +5,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <yaml-cpp/yaml.h>
 
 #include "drake/common/nice_type_name.h"

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "drake/common/autodiff.h"
 #include "drake/common/default_scalars.h"

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -20,6 +20,7 @@
 #include <App.h>
 #include <common_robotics_utilities/base64_helpers.hpp>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <msgpack.hpp>
 
 #include "drake/common/drake_export.h"

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -10,6 +10,7 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <libqhullcpp/Qhull.h>
 #include <libqhullcpp/QhullVertexSet.h>
 

--- a/geometry/render/render_material.cc
+++ b/geometry/render/render_material.cc
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/fmt_eigen.h"

--- a/geometry/render_gltf_client/internal_http_service.cc
+++ b/geometry/render_gltf_client/internal_http_service.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace drake {
 namespace geometry {

--- a/multibody/plant/internal_geometry_names.cc
+++ b/multibody/plant/internal_geometry_names.cc
@@ -2,6 +2,8 @@
 
 #include <stdexcept>
 
+#include <fmt/ranges.h>
+
 #include "drake/common/default_scalars.h"
 
 namespace drake {

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -8,6 +8,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include <fmt/ranges.h>
+
 #include "drake/common/drake_throw.h"
 #include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -10,6 +10,8 @@
 #include <unordered_set>
 #include <utility>
 
+#include <fmt/ranges.h>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"

--- a/solvers/clarabel_solver.cc
+++ b/solvers/clarabel_solver.cc
@@ -7,6 +7,7 @@
 
 #include <Clarabel>
 #include <Eigen/Eigen>
+#include <fmt/ranges.h>
 
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/name_value.h"

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include <unordered_set>
 
+#include <fmt/ranges.h>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/string_unordered_set.h"
 #include "drake/common/text_logging.h"

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "drake/common/unused.h"
 #include "drake/systems/framework/system_visitor.h"

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -9,6 +9,7 @@
 #include <unordered_set>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "drake/common/hash.h"
 #include "drake/common/unused.h"

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/framework/diagram.h"
 
 #include <Eigen/Dense>
+#include <fmt/ranges.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/systems/lcm/test/lcm_system_graphviz_test.cc
+++ b/systems/lcm/test/lcm_system_graphviz_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/lcm/lcm_system_graphviz.h"
 
 #include "absl/strings/str_split.h"
+#include <fmt/ranges.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
For v11, fmt moved the "range and iterator overloads" of fmt::join into the fmt/ranges.h header file. This mindlessly adds that header to all of the compilation units that make use of fmt::join to offer v10->v11 compatibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21856)
<!-- Reviewable:end -->
