### PR TITLE
[multibody] Templatize body node

### DIFF
--- a/multibody/tree/body_node.cc
+++ b/multibody/tree/body_node.cc
@@ -77,6 +77,55 @@ void BodyNode<T>::CalcArticulatedBodyHingeInertiaMatrixFactorization(
   }
 }
 
+template <typename T>
+void BodyNode<T>::CalcAcrossMobilizerBodyPoses_BaseToTip(
+    const FrameBodyPoseCache<T>& frame_body_pose_cache,
+    PositionKinematicsCache<T>* pc) const {
+  // RigidBody for this node.
+  const RigidBody<T>& body_B = body();
+
+  // RigidBody for this node's parent, or the parent body P.
+  const RigidBody<T>& body_P = parent_body();
+
+  // Inboard/Outboard frames of this node's mobilizer.
+  const Frame<T>& frame_F = inboard_frame();
+  DRAKE_ASSERT(frame_F.body().index() == body_P.index());
+  const Frame<T>& frame_M = outboard_frame();
+  DRAKE_ASSERT(frame_M.body().index() == body_B.index());
+
+  // Input (const):
+  // - X_PF
+  // - X_MB
+  // - X_FM(q_B)
+  // - X_WP(q(W:P)), where q(W:P) includes all positions in the kinematics
+  //                 path from parent body P to the world W.
+  const math::RigidTransform<T>& X_MB =
+      frame_M.get_X_FB(frame_body_pose_cache);  // F==M
+  const math::RigidTransform<T>& X_PF =
+      frame_F.get_X_BF(frame_body_pose_cache);  // B==P
+  const math::RigidTransform<T>& X_FM = get_X_FM(*pc);
+  const math::RigidTransform<T>& X_WP = get_X_WP(*pc);
+
+  // Output (updating a cache entry):
+  // - X_PB(q_B)
+  // - X_WB(q(W:P), q_B)
+  math::RigidTransform<T>& X_PB = get_mutable_X_PB(pc);
+  math::RigidTransform<T>& X_WB = get_mutable_X_WB(pc);
+  Vector3<T>& p_PoBo_W = get_mutable_p_PoBo_W(pc);
+
+  // TODO(amcastro-tri): Consider logic for the common case B = M.
+  //  In that case X_FB = X_FM as suggested by setting X_MB = Identity.
+  const math::RigidTransform<T> X_FB = X_FM * X_MB;
+
+  X_PB = X_PF * X_FB;
+  X_WB = X_WP * X_PB;
+
+  // Compute shift vector p_PoBo_W from the parent origin to the body origin.
+  const Vector3<T>& p_PoBo_P = X_PB.translation();
+  const math::RotationMatrix<T>& R_WP = X_WP.rotation();
+  p_PoBo_W = R_WP * p_PoBo_P;
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -93,14 +93,13 @@ class BodyNode : public MultibodyElement<T> {
   // Reference used below:
   // - [Jain 2010]  Jain, A., 2010. Robot and multibody dynamics: analysis and
   //                algorithms. Springer Science & Business Media.
-  BodyNode(const BodyNode<T>* parent_node,
-           const RigidBody<T>* body, const Mobilizer<T>* mobilizer)
+  BodyNode(const BodyNode<T>* parent_node, const RigidBody<T>* body,
+           const Mobilizer<T>* mobilizer)
       : MultibodyElement<T>(body->model_instance()),
         parent_node_(parent_node),
         body_(body),
         mobilizer_(mobilizer) {
-    DRAKE_DEMAND(!(parent_node == nullptr &&
-        body->index() != world_index()));
+    DRAKE_DEMAND(!(parent_node == nullptr && body->index() != world_index()));
     DRAKE_DEMAND(!(mobilizer == nullptr && body->index() != world_index()));
   }
 
@@ -185,41 +184,31 @@ class BodyNode : public MultibodyElement<T> {
   // @pre CalcPositionKinematicsCache_BaseToTip() must have already been called
   // for the parent node (and, by recursive precondition, all predecessor nodes
   // in the tree.)
+  virtual void CalcPositionKinematicsCache_BaseToTip(
+      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      const T* positions,
+      PositionKinematicsCache<T>* pc) const = 0;
+
+  // Calculates the hinge matrix H_PB_W.
+  // @param[in] context
+  //   The context with the state of the MultibodyTree model.
+  // @param[in] pc
+  //   An already updated position kinematics cache in sync with `context`.
+  // @param[out] H_PB_W
+  //   The `6 x nm` hinge matrix that relates `V_PB_W` (body B's spatial
+  //   velocity in its parent body P, expressed in world W) to this node's `nm`
+  //   generalized velocities (or mobilities) `v_B` as `V_PB_W = H_PB_W * v_B`.
+  // @note `H_PB_W` is only a function of the model's generalized positions q.
+  //
+  // @pre The position kinematics cache `pc` was already updated to be in sync
+  // with `context` by MultibodyTree::CalcPositionKinematicsCache().
 
   // TODO(sherm1) This function should not take a context.
-  void CalcPositionKinematicsCache_BaseToTip(
+  virtual void CalcAcrossNodeJacobianWrtVExpressedInWorld(
       const systems::Context<T>& context,
       const FrameBodyPoseCache<T>& frame_body_pose_cache,
-      PositionKinematicsCache<T>* pc) const {
-    // This method must not be called for the "world" body node.
-    DRAKE_ASSERT(topology_.rigid_body != world_index());
-
-    DRAKE_ASSERT(pc != nullptr);
-
-    // Update mobilizer' position dependent kinematics.
-    CalcAcrossMobilizerPositionKinematicsCache(context, pc);
-
-    // This computes into the PositionKinematicsCache:
-    // - X_PB(q_B)
-    // - X_WB(q(W:P), q_B)
-    // where q_B is the generalized coordinates associated with this node's
-    // mobilizer. q(W:P) denotes all generalized positions in the kinematics
-    // path between World and the parent body P. It assumes we are in a
-    // base-to-tip recursion and therefore `X_WP` has already been updated.
-    CalcAcrossMobilizerBodyPoses_BaseToTip(frame_body_pose_cache, pc);
-
-    // TODO(amcastro-tri):
-    // Update Body specific kinematics. These include:
-    // - p_PB_W: vector from P to B to perform shift operations.
-    // - com_W: center of mass.
-    // - M_Bo_W: Spatial inertia.
-
-    // TODO(amcastro-tri):
-    // With H_FM(q) already in the cache (computed by
-    // Mobilizer::UpdatePositionKinematicsCache()) update the cache entries for
-    // H_PB_W, the hinge matrix for the SpatialVelocity jump between body B and
-    // its parent body P expressed in the world frame W.
-  }
+      const PositionKinematicsCache<T>& pc,
+      std::vector<Vector6<T>>* H_PB_W_cache) const = 0;
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
   // this node's kinematics that depend on the generalized velocities.
@@ -246,100 +235,12 @@ class BodyNode : public MultibodyElement<T> {
   // MultibodyTree::CalcVelocityKinematicsCache().
 
   // TODO(sherm1) This function should not take a context.
-  void CalcVelocityKinematicsCache_BaseToTip(
+  virtual void CalcVelocityKinematicsCache_BaseToTip(
       const systems::Context<T>& context,
       const PositionKinematicsCache<T>& pc,
-      const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
-      VelocityKinematicsCache<T>* vc) const {
-    // This method must not be called for the "world" body node.
-    DRAKE_ASSERT(topology_.rigid_body != world_index());
-
-    DRAKE_ASSERT(vc != nullptr);
-    DRAKE_DEMAND(H_PB_W.rows() == 6);
-    DRAKE_DEMAND(H_PB_W.cols() == get_num_mobilizer_velocities());
-
-    // As a guideline for developers, a summary of the computations performed in
-    // this method is provided:
-    // Notation:
-    //  - B body frame associated with this node.
-    //  - P ("parent") body frame associated with this node's parent.
-    //  - F mobilizer inboard frame attached to body P.
-    //  - M mobilizer outboard frame attached to body B.
-    // The goal is computing the spatial velocity V_WB of body B measured in the
-    // world frame W. The calculation is recursive and assumes the spatial
-    // velocity V_WP of the inboard body P is already computed. These spatial
-    // velocities are related by the recursive relation:
-    //   V_WB = V_WPb + V_PB_W (Eq. 5.6 in Jain (2010), p. 77)              (1)
-    // where Pb is a frame aligned with P but with its origin shifted from Po
-    // to B's origin Bo. Then V_WPb is the spatial velocity of frame Pb,
-    // measured and expressed in the world frame W. Then since V_PB's
-    // translational component is also for the point Bo, we can add these
-    // spatial velocities. Therefore we need to develop expressions for the two
-    // terms (V_WPb and V_PB_W) in Eq. (1).
-    //
-    // Computation of V_PB_W:
-    // Let Mb be a frame aligned rigidly with M but with its origin at Bo.
-    // For rigid bodies (which we always have here)
-    //   V_PB_W = V_FMb_W                                                   (2)
-    // which can be computed from the spatial velocity measured in frame F (as
-    // provided by mobilizer's methods)
-    //   V_FMb_W = R_WF * V_FMb = R_WF * V_FM.Shift(p_MoBo_F)               (3)
-    // arriving to the desired result:
-    //   V_PB_W = R_WF * V_FM.Shift(p_MoBo_F)                               (4)
-    //
-    // V_FM is immediately available from this node's mobilizer with the method
-    // CalcAcrossMobilizerSpatialVelocity() which computes M's spatial velocity
-    // in F by V_FM = H_FM * vm, where H_FM is the mobilizer's hinge matrix.
-    //
-    // Computation of V_WPb:
-    // This can be computed by a simple shift operation from V_WP:
-    //   V_WPb = V_WP.Shift(p_PoBo_W)                                       (5)
-    //
-    // Note:
-    // It is very common to find treatments in which the body frame B is
-    // coincident with the outboard frame M, that is B ≡ M, leading to slightly
-    // simpler recursive relations (for instance, see Section 3.3.2 in
-    // Jain (2010)) where p_MoBo_F = 0 and thus V_PB_W = V_FM_W.
-
-    // Generalized velocities local to this node's mobilizer.
-    const auto& vm = this->get_mobilizer_velocities(context);
-
-    // =========================================================================
-    // Computation of V_PB_W in Eq. (1). See summary at the top of this method.
-
-    // Update V_FM using the operator V_FM = H_FM * vm:
-    SpatialVelocity<T>& V_FM = get_mutable_V_FM(vc);
-    V_FM = get_mobilizer().CalcAcrossMobilizerSpatialVelocity(context, vm);
-
-    // Compute V_PB_W = R_WF * V_FM.Shift(p_MoBo_F), Eq. (4).
-    // Side note to developers: in operator form for rigid bodies this would be
-    //   V_PB_W = R_WF * phiT_MB_F * V_FM
-    //          = R_WF * phiT_MB_F * H_FM * vm
-    //          = H_PB_W * vm
-    // where H_PB_W = R_WF * phiT_MB_F * H_FM.
-    SpatialVelocity<T>& V_PB_W = get_mutable_V_PB_W(vc);
-    if (get_num_mobilizer_velocities() > 0) {
-      V_PB_W.get_coeffs() = H_PB_W * vm;
-    } else {
-      V_PB_W.get_coeffs().setZero();
-    }
-
-    // =========================================================================
-    // Computation of V_WPb in Eq. (1). See summary at the top of this method.
-
-    // Shift vector between the parent body P and this node's body B,
-    // expressed in the world frame W.
-    const Vector3<T>& p_PB_W = get_p_PoBo_W(pc);
-
-    // Since we are in a base-to-tip recursion the parent body P's spatial
-    // velocity is already available in the cache.
-    const SpatialVelocity<T>& V_WP = get_V_WP(*vc);
-
-    // =========================================================================
-    // Update velocity V_WB of this node's body B in the world frame. Using the
-    // recursive Eq. (1). See summary at the top of this method.
-    get_mutable_V_WB(vc) = V_WP.ComposeWithMovingFrameVelocity(p_PB_W, V_PB_W);
-  }
+      const std::vector<Vector6<T>>& H_PB_W_cache,
+      const T* velocities,
+      VelocityKinematicsCache<T>* vc) const = 0;
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
   // this node's kinematics that depend on the generalized accelerations, i.e.
@@ -770,71 +671,6 @@ class BodyNode : public MultibodyElement<T> {
 
   // Returns the topology information for this body node.
   const BodyNodeTopology& get_topology() const { return topology_; }
-
-  // Calculates the hinge matrix H_PB_W.
-  // @param[in] context
-  //   The context with the state of the MultibodyTree model.
-  // @param[in] pc
-  //   An already updated position kinematics cache in sync with `context`.
-  // @param[out] H_PB_W
-  //   The `6 x nm` hinge matrix that relates `V_PB_W` (body B's spatial
-  //   velocity in its parent body P, expressed in world W) to this node's `nm`
-  //   generalized velocities (or mobilities) `v_B` as `V_PB_W = H_PB_W * v_B`.
-  // @note `H_PB_W` is only a function of the model's generalized positions q.
-  //
-  // @pre The position kinematics cache `pc` was already updated to be in sync
-  // with `context` by MultibodyTree::CalcPositionKinematicsCache().
-
-  // TODO(sherm1) This function should not take a context.
-  void CalcAcrossNodeJacobianWrtVExpressedInWorld(
-      const systems::Context<T>& context,
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
-      const PositionKinematicsCache<T>& pc,
-      EigenPtr<MatrixX<T>> H_PB_W) const {
-    // Checks on the input arguments.
-    DRAKE_DEMAND(topology_.rigid_body != world_index());
-    DRAKE_DEMAND(H_PB_W != nullptr);
-    DRAKE_DEMAND(H_PB_W->rows() == 6);
-    DRAKE_DEMAND(H_PB_W->cols() == get_num_mobilizer_velocities());
-
-    // Inboard frame F of this node's mobilizer.
-    const Frame<T>& frame_F = inboard_frame();
-    // Outboard frame M of this node's mobilizer.
-    const Frame<T>& frame_M = outboard_frame();
-
-    const math::RigidTransform<T>& X_PF =
-        frame_F.get_X_BF(frame_body_pose_cache);  // B==P
-    const math::RotationMatrix<T>& R_PF = X_PF.rotation();
-    const math::RigidTransform<T>& X_MB =
-        frame_M.get_X_FB(frame_body_pose_cache);  // F==M
-
-    // Form the rotation matrix relating the world frame W and parent body P.
-    const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
-
-    // Orientation (rotation) of frame F with respect to the world frame W.
-    const math::RotationMatrix<T> R_WF = R_WP * R_PF;
-
-    // Vector from Mo to Bo expressed in frame F as needed below:
-    const math::RotationMatrix<T>& R_FM = get_X_FM(pc).rotation();
-    const Vector3<T>& p_MB_M = X_MB.translation();
-    const Vector3<T> p_MB_F = R_FM * p_MB_M;
-
-    // Compute the imob-th column in J_PB_W:
-    VectorUpTo6<T> v = VectorUpTo6<T>::Zero(get_num_mobilizer_velocities());
-    // We compute H_FM(q) one column at a time by calling the multiplication by
-    // H_FM operation on a vector of generalized velocities which is zero except
-    // for its imob-th component, which is one.
-    for (int imob = 0; imob < get_num_mobilizer_velocities(); ++imob) {
-      v(imob) = 1.0;
-      // Compute the imob-th column of H_FM:
-      const SpatialVelocity<T> Himob_FM =
-          get_mobilizer().CalcAcrossMobilizerSpatialVelocity(context, v);
-      v(imob) = 0.0;
-      // V_PB_W = V_PFb_W + V_FMb_W + V_MB_W = V_FMb_W =
-      //         = R_WF * V_FM.Shift(p_MoBo_F)
-      H_PB_W->col(imob) = (R_WF * Himob_FM.Shift(p_MB_F)).get_coeffs();
-    }
-  }
 
   // Helper method to retrieve a Jacobian matrix with respect to generalized
   // velocities v for `this` node from an array storing the columns of a set of
@@ -1422,9 +1258,6 @@ class BodyNode : public MultibodyElement<T> {
     return get_mobilizer().outboard_frame();
   }
 
- private:
-  friend class BodyNodeTester;
-
   // Returns the index to the parent RigidBody of the RigidBody associated with
   // this node. For the root node, corresponding to the world RigidBody, this
   // method returns an invalid BodyIndex. Attempts to using invalid indexes
@@ -1520,19 +1353,28 @@ class BodyNode : public MultibodyElement<T> {
     return pc->get_mutable_p_PoBo_W(topology_.index);
   }
 
-  // =========================================================================
-  // VelocityKinematicsCache Accessors and Mutators.
+  // Helper method to be called within a base-to-tip recursion that computes
+  // into the PositionKinematicsCache:
+  // - X_PB(q_B)
+  // - X_WB(q(W:P), q_B)
+  // - p_PoBo_W(q_B)
+  // where q_B is the generalized coordinates associated with this node's
+  // mobilizer. q(W:P) denotes all generalized positions in the kinematics path
+  // between the world and the parent body P. It assumes we are in a base-to-tip
+  // recursion and therefore `X_WP` has already been updated.
+  //
+  // This function doesn't depend on the particular Mobilizer type so we
+  // implement once here in the base class rather than in the templatized
+  // derived class.
+  void CalcAcrossMobilizerBodyPoses_BaseToTip(
+      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      PositionKinematicsCache<T>* pc) const;
 
   // For the body B associated with this node, return V_WB, B's spatial velocity
   // in the world frame W, expressed in W (for Bo, the body frame's origin).
   const SpatialVelocity<T>& get_V_WB(
       const VelocityKinematicsCache<T>& vc) const {
     return vc.get_V_WB(topology_.index);
-  }
-
-  // Mutable version of get_V_WB().
-  SpatialVelocity<T>& get_mutable_V_WB(VelocityKinematicsCache<T>* vc) const {
-    return vc->get_mutable_V_WB(topology_.index);
   }
 
   // Returns the spatial velocity `V_WP` of the body frame P in the parent node
@@ -1549,12 +1391,6 @@ class BodyNode : public MultibodyElement<T> {
     return vc.get_V_FM(topology_.index);
   }
 
-  // Mutable version of get_V_FM().
-  SpatialVelocity<T>& get_mutable_V_FM(
-      VelocityKinematicsCache<T>* vc) const {
-    return vc->get_mutable_V_FM(topology_.index);
-  }
-
   // Returns a const reference to the spatial velocity `V_PB_W` of `this`
   // node's body B in the parent node's body P, expressed in the world frame W.
   const SpatialVelocity<T>& get_V_PB_W(
@@ -1562,11 +1398,8 @@ class BodyNode : public MultibodyElement<T> {
     return vc.get_V_PB_W(topology_.index);
   }
 
-  // Mutable version of get_V_PB_W().
-  SpatialVelocity<T>& get_mutable_V_PB_W(
-      VelocityKinematicsCache<T>* vc) const {
-    return vc->get_mutable_V_PB_W(topology_.index);
-  }
+ private:
+  friend class BodyNodeTester;
 
   // =========================================================================
   // AccelerationKinematicsCache Accessors and Mutators.
@@ -1748,92 +1581,6 @@ class BodyNode : public MultibodyElement<T> {
       EigenPtr<VectorX<T>> tau) const {
     DRAKE_ASSERT(tau != nullptr);
     return get_mutable_velocities_from_array(tau);
-  }
-
-  // Helper method to be called within a base-to-tip recursion that computes
-  // into the PositionKinematicsCache:
-  // - X_PB(q_B)
-  // - X_WB(q(W:P), q_B)
-  // where q_B is the generalized coordinates associated with this node's
-  // mobilizer. q(W:P) denotes all generalized positions in the kinematics path
-  // between the world and the parent body P. It assumes we are in a base-to-tip
-  // recursion and therefore `X_WP` has already been updated.
-  void CalcAcrossMobilizerBodyPoses_BaseToTip(
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
-      PositionKinematicsCache<T>* pc) const {
-    // RigidBody for this node.
-    const RigidBody<T>& body_B = body();
-
-    // RigidBody for this node's parent, or the parent body P.
-    const RigidBody<T>& body_P = parent_body();
-
-    // Inboard/Outboard frames of this node's mobilizer.
-    const Frame<T>& frame_F = get_mobilizer().inboard_frame();
-    DRAKE_ASSERT(frame_F.body().index() == body_P.index());
-    const Frame<T>& frame_M = get_mobilizer().outboard_frame();
-    DRAKE_ASSERT(frame_M.body().index() == body_B.index());
-
-    // Input (const):
-    // - X_PF
-    // - X_MB
-    // - X_FM(q_B)
-    // - X_WP(q(W:B)), where q(W:B) includes all positions in the kinematics
-    //                 path from body B to the world W.
-    const math::RigidTransform<T>& X_MB =
-        frame_M.get_X_FB(frame_body_pose_cache);  // F==M
-    const math::RigidTransform<T>& X_PF =
-        frame_F.get_X_BF(frame_body_pose_cache);  // B==P
-    const math::RigidTransform<T>& X_FM =
-        get_X_FM(*pc);  // mobilizer.Eval_X_FM(ctx)
-    const math::RigidTransform<T>& X_WP =
-        get_X_WP(*pc);  // body_P.EvalPoseInWorld(ctx)
-
-    // Output (updating a cache entry):
-    // - X_PB(q_B)
-    // - X_WB(q(W:P), q_B)
-    math::RigidTransform<T>& X_PB = get_mutable_X_PB(pc);
-    math::RigidTransform<T>& X_WB =
-        get_mutable_X_WB(pc);  // body_B.EvalPoseInWorld(ctx)
-
-    // TODO(amcastro-tri): Consider logic for the common case B = M.
-    //  In that case X_FB = X_FM as suggested by setting X_MB = Identity.
-    const math::RigidTransform<T> X_FB = X_FM * X_MB;
-
-    X_PB = X_PF * X_FB;
-    X_WB = X_WP * X_PB;
-
-    // Compute shift vector p_PoBo_W from the parent origin to the body origin.
-    const Vector3<T>& p_PoBo_P = X_PB.translation();
-    const math::RotationMatrix<T>& R_WP = X_WP.rotation();
-    get_mutable_p_PoBo_W(pc) = R_WP * p_PoBo_P;
-  }
-
-  // Computes position dependent kinematics associated with `this` mobilizer
-  // which includes:
-  // - X_FM(q): The pose of the outboard frame M as measured and expressed in
-  //            the inboard frame F.
-  // - H_FM(q): the mobilizer hinge matrix that relates the mobilizer's
-  //            generalized velocities v to the spatial velocity `V_FM` by
-  //            `V_FM(q, v) = H_FM(q) * v`.
-  // - Hdot_FM(q): The time derivative of H_FM which is used to computing the
-  //               M's spatial acceleration in frame F, expressed in F as:
-  //               `A_FM(q, v, v̇) = H_FM(q) * v̇ + Hdot_FM(q) * v`
-  // - N(q): The kinematic coupling matrix describing the relationship between
-  //         the rate of change of generalized coordinates and the generalized
-  //         velocities by `q̇ = N(q) * v`.
-  //
-  // This method is used by MultibodyTree to update the position kinematics
-  // quantities associated with `this` mobilizer. MultibodyTree will always
-  // provide a valid PositionKinematicsCache pointer, otherwise this method
-  // aborts in Debug builds.
-
-  // TODO(sherm1) This function should not take a context.
-  void CalcAcrossMobilizerPositionKinematicsCache(
-      const systems::Context<T>& context,
-      PositionKinematicsCache<T>* pc) const {
-    DRAKE_ASSERT(pc != nullptr);
-    math::RigidTransform<T>& X_FM = get_mutable_X_FM(pc);
-    X_FM = get_mobilizer().CalcAcrossMobilizerTransform(context);
   }
 
   // This method computes the total force Ftot_BBo on body B that must be

--- a/multibody/tree/body_node_impl.cc
+++ b/multibody/tree/body_node_impl.cc
@@ -1,24 +1,233 @@
 #include "drake/multibody/tree/body_node_impl.h"
 
 #include "drake/common/default_scalars.h"
+#include "drake/multibody/tree/planar_mobilizer.h"
+#include "drake/multibody/tree/prismatic_mobilizer.h"
+#include "drake/multibody/tree/quaternion_floating_mobilizer.h"
+#include "drake/multibody/tree/revolute_mobilizer.h"
+#include "drake/multibody/tree/rpy_ball_mobilizer.h"
+#include "drake/multibody/tree/rpy_floating_mobilizer.h"
+#include "drake/multibody/tree/screw_mobilizer.h"
+#include "drake/multibody/tree/universal_mobilizer.h"
+#include "drake/multibody/tree/weld_mobilizer.h"
 
 namespace drake {
 namespace multibody {
 namespace internal {
 
-template <typename T, int num_positions, int num_velocities>
-BodyNodeImpl<T, num_positions, num_velocities>::~BodyNodeImpl() = default;
+template <typename T, template <typename> class ConcreteMobilizer>
+BodyNodeImpl<T, ConcreteMobilizer>::BodyNodeImpl(
+    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+    const Mobilizer<T>* mobilizer)
+    : BodyNode<T>(parent_node, body, mobilizer),
+      mobilizer_(dynamic_cast<const ConcreteMobilizer<T>*>(mobilizer)) {
+  DRAKE_DEMAND(mobilizer_ != nullptr);
+}
 
-// Macro used to explicitly instantiate implementations on all sizes needed.
-#define EXPLICITLY_INSTANTIATE_IMPLS(T) \
-template class BodyNodeImpl<T, 0, 0>; \
-template class BodyNodeImpl<T, 1, 1>; \
-template class BodyNodeImpl<T, 2, 2>; \
-template class BodyNodeImpl<T, 3, 3>; \
-template class BodyNodeImpl<T, 6, 6>; \
-template class BodyNodeImpl<T, 7, 6>;
+template <typename T, template <typename> class ConcreteMobilizer>
+BodyNodeImpl<T, ConcreteMobilizer>::~BodyNodeImpl() = default;
 
-// Explicitly instantiates on the most common scalar types.
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::CalcPositionKinematicsCache_BaseToTip(
+    const FrameBodyPoseCache<T>& frame_body_pose_cache,
+    const T* positions,
+    PositionKinematicsCache<T>* pc) const {
+  // This method must not be called for the "world" body node.
+  DRAKE_ASSERT(this->index() != world_mobod_index());
+  DRAKE_ASSERT(pc != nullptr);
+
+  // TODO(sherm1) This should be an update rather than generating a whole
+  //  new transform.
+
+  // Update mobilizer-specific position dependent kinematics.
+  math::RigidTransform<T>& X_FM = this->get_mutable_X_FM(pc);
+  X_FM = mobilizer_->calc_X_FM(get_q(positions));
+
+  // Given X_FM that we just put into PositionKinematicsCache (pc), and
+  // calculations already done through the parent mobilizer, this
+  // calculates into pc: X_PB, X_WB, p_PoBo_W
+  // These don't depend on Mobilizer details.
+  this->CalcAcrossMobilizerBodyPoses_BaseToTip(frame_body_pose_cache, pc);
+}
+
+// TODO(sherm1) Consider combining this with VelocityCache computation
+//  so that we don't have to make a separate pass. Or better, get rid of this
+//  computation altogether by working in better frames.
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::
+    CalcAcrossNodeJacobianWrtVExpressedInWorld(
+        const systems::Context<T>& context,
+        const FrameBodyPoseCache<T>& frame_body_pose_cache,
+        const PositionKinematicsCache<T>& pc,
+        std::vector<Vector6<T>>* H_PB_W_cache) const {
+  DRAKE_ASSERT(H_PB_W_cache != nullptr);
+  DRAKE_ASSERT(this->index() != world_mobod_index());
+
+  // Nothing to do for a weld mobilizer.
+  if constexpr (kNv > 0) {
+    // Inboard frame F of this node's mobilizer.
+    const Frame<T>& frame_F = this->inboard_frame();
+    // Outboard frame M of this node's mobilizer.
+    const Frame<T>& frame_M = this->outboard_frame();
+
+    const math::RigidTransform<T>& X_PF =
+        frame_F.get_X_BF(frame_body_pose_cache);  // B==P
+    const math::RotationMatrix<T>& R_PF = X_PF.rotation();
+    const math::RigidTransform<T>& X_MB =
+        frame_M.get_X_FB(frame_body_pose_cache);  // F==M
+
+    // Form the rotation matrix relating the world frame W and parent body P.
+    const math::RotationMatrix<T>& R_WP = this->get_R_WP(pc);
+
+    // Orientation (rotation) of frame F with respect to the world frame W.
+    const math::RotationMatrix<T> R_WF = R_WP * R_PF;
+
+    // Vector from Mo to Bo expressed in frame F as needed below:
+    const math::RotationMatrix<T>& R_FM = this->get_X_FM(pc).rotation();
+    const Vector3<T>& p_MB_M = X_MB.translation();
+    const Vector3<T> p_MB_F = R_FM * p_MB_M;
+
+    VVector v = VVector::Zero();
+    auto H_PB_W = get_mutable_H(H_PB_W_cache);
+    // We compute H_FM(q) one column at a time by calling the multiplication by
+    // H_FM operation on a vector of generalized velocities which is zero except
+    // for its imob-th component, which is one.
+    for (int imob = 0; imob < kNv; ++imob) {
+      v(imob) = 1.0;
+      // Compute the imob-th column of H_FM:
+      const SpatialVelocity<T> Himob_FM =
+          mobilizer_->calc_V_FM(context, v.data());
+      v(imob) = 0.0;
+      // V_PB_W = V_PFb_W + V_FMb_W + V_MB_W = V_FMb_W =
+      //         = R_WF * V_FM.Shift(p_MoBo_F)
+      H_PB_W.col(imob) = (R_WF * Himob_FM.Shift(p_MB_F)).get_coeffs();
+    }
+  }
+}
+
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::CalcVelocityKinematicsCache_BaseToTip(
+    const systems::Context<T>& context,
+    const PositionKinematicsCache<T>& pc,
+    const std::vector<Vector6<T>>& H_PB_W_cache,
+    const T* velocities,
+    VelocityKinematicsCache<T>* vc) const {
+  // This method must not be called for the "world" body node.
+  DRAKE_ASSERT(this->index() != world_mobod_index());
+  DRAKE_ASSERT(vc != nullptr);
+
+  // Hinge matrix for this node. H_PB_W ∈ ℝ⁶ˣⁿᵐ with nm ∈ [0; 6] the
+  // number of mobilities for this node. Therefore, the return is a
+  // MatrixUpTo6 since the number of columns generally changes with the
+  // node.  It is returned as an Eigen::Map to the memory allocated in the
+  // std::vector H_PB_W_cache so that we can work with H_PB_W as with any
+  // other Eigen matrix object.
+  //  Eigen::Map<const MatrixUpTo6<T>> H_PB_W =
+  //      this->GetJacobianFromArray(H_PB_W_cache);
+  //  DRAKE_ASSERT(H_PB_W.rows() == 6);
+  //  DRAKE_ASSERT(H_PB_W.cols() == this->get_num_mobilizer_velocities());
+
+  // As a guideline for developers, a summary of the computations performed in
+  // this method is provided:
+  // Notation:
+  //  - B body frame associated with this node.
+  //  - P ("parent") body frame associated with this node's parent.
+  //  - F mobilizer inboard frame attached to body P.
+  //  - M mobilizer outboard frame attached to body B.
+  // The goal is computing the spatial velocity V_WB of body B measured in the
+  // world frame W. The calculation is recursive and assumes the spatial
+  // velocity V_WP of the inboard body P is already computed. These spatial
+  // velocities are related by the recursive relation:
+  //   V_WB = V_WPb + V_PB_W (Eq. 5.6 in Jain (2010), p. 77)              (1)
+  // where Pb is a frame aligned with P but with its origin shifted from Po
+  // to B's origin Bo. Then V_WPb is the spatial velocity of frame Pb,
+  // measured and expressed in the world frame W. Then since V_PB's
+  // translational component is also for the point Bo, we can add these
+  // spatial velocities. Therefore we need to develop expressions for the two
+  // terms (V_WPb and V_PB_W) in Eq. (1).
+  //
+  // Computation of V_PB_W:
+  // Let Mb be a frame aligned rigidly with M but with its origin at Bo.
+  // For rigid bodies (which we always have here)
+  //   V_PB_W = V_FMb_W                                                   (2)
+  // which can be computed from the spatial velocity measured in frame F (as
+  // provided by mobilizer's methods)
+  //   V_FMb_W = R_WF * V_FMb = R_WF * V_FM.Shift(p_MoBo_F)               (3)
+  // arriving to the desired result:
+  //   V_PB_W = R_WF * V_FM.Shift(p_MoBo_F)                               (4)
+  //
+  // V_FM is immediately available from this node's mobilizer with the method
+  // CalcAcrossMobilizerSpatialVelocity() which computes M's spatial velocity
+  // in F by V_FM = H_FM * vm, where H_FM is the mobilizer's hinge matrix.
+  //
+  // Computation of V_WPb:
+  // This can be computed by a simple shift operation from V_WP:
+  //   V_WPb = V_WP.Shift(p_PoBo_W)                                       (5)
+  //
+  // Note:
+  // It is very common to find treatments in which the body frame B is
+  // coincident with the outboard frame M, that is B ≡ M, leading to slightly
+  // simpler recursive relations (for instance, see Section 3.3.2 in
+  // Jain (2010)) where p_MoBo_F = 0 and thus V_PB_W = V_FM_W.
+
+  // Generalized velocities local to this node's mobilizer.
+  const T* v_ptr = get_v(velocities);
+  const Eigen::Map<const VVector> v(v_ptr);
+
+  // =========================================================================
+  // Computation of V_PB_W in Eq. (1). See summary at the top of this method.
+
+  // Update V_FM using the operator V_FM = H_FM * vm:
+  SpatialVelocity<T>& V_FM = get_mutable_V_FM(vc);
+  V_FM = mobilizer_->calc_V_FM(context, v_ptr);
+
+  // Compute V_PB_W = R_WF * V_FM.Shift(p_MoBo_F), Eq. (4).
+  // Side note to developers: in operator form for rigid bodies this would be
+  //   V_PB_W = R_WF * phiT_MB_F * V_FM
+  //          = R_WF * phiT_MB_F * H_FM * v
+  //          = H_PB_W * v
+  // where H_PB_W = R_WF * phiT_MB_F * H_FM.
+  SpatialVelocity<T>& V_PB_W = get_mutable_V_PB_W(vc);
+  if constexpr (kNv > 0) {
+    // Hinge matrix for this node. H_PB_W ∈ ℝ⁶ˣⁿᵛ with nv ∈ [0; 6] the
+    // number of mobilities for this node.
+    const auto H_PB_W = get_H(H_PB_W_cache);
+    V_PB_W.get_coeffs() = H_PB_W * v;
+  } else {
+    V_PB_W.get_coeffs().setZero();
+  }
+
+  // =========================================================================
+  // Computation of V_WPb in Eq. (1). See summary at the top of this method.
+
+  // Shift vector between the parent body P and this node's body B,
+  // expressed in the world frame W.
+  const Vector3<T>& p_PB_W = this->get_p_PoBo_W(pc);
+
+  // Since we are in a base-to-tip recursion the parent body P's spatial
+  // velocity is already available in the cache.
+  const SpatialVelocity<T>& V_WP = this->get_V_WP(*vc);
+
+  // =========================================================================
+  // Update velocity V_WB of this node's body B in the world frame. Using the
+  // recursive Eq. (1). See summary at the top of this method.
+  this->get_mutable_V_WB(vc) =
+      V_WP.ComposeWithMovingFrameVelocity(p_PB_W, V_PB_W);
+}
+
+// Macro used to explicitly instantiate implementations for every mobilizer.
+#define EXPLICITLY_INSTANTIATE_IMPLS(T)                        \
+  template class BodyNodeImpl<T, PlanarMobilizer>;             \
+  template class BodyNodeImpl<T, PrismaticMobilizer>;          \
+  template class BodyNodeImpl<T, QuaternionFloatingMobilizer>; \
+  template class BodyNodeImpl<T, RevoluteMobilizer>;           \
+  template class BodyNodeImpl<T, RpyBallMobilizer>;            \
+  template class BodyNodeImpl<T, RpyFloatingMobilizer>;        \
+  template class BodyNodeImpl<T, ScrewMobilizer>;              \
+  template class BodyNodeImpl<T, UniversalMobilizer>;          \
+  template class BodyNodeImpl<T, WeldMobilizer>
+
+// Explicitly instantiates on the supported scalar types.
 // These should be kept in sync with the list in default_scalars.h.
 EXPLICITLY_INSTANTIATE_IMPLS(double);
 EXPLICITLY_INSTANTIATE_IMPLS(AutoDiffXd);

--- a/multibody/tree/body_node_impl.h
+++ b/multibody/tree/body_node_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
@@ -15,39 +16,120 @@ namespace internal {
 // TODO(sherm1) Most of the across-mobilizer code for kinematics and
 //  dynamics should live in this class since the hinge matrices
 //  and related downstream calculations have a compile-time fixed size.
+//  Kinematics are here now; move the rest.
 
 // For internal use only of the MultibodyTree implementation.
-// While all code that is common to any node can be placed in the BodyNode
-// class, %BodyNodeImpl provides compile-time fixed-size BodyNode
-// implementations so that all operations can be performed with fixed-size
-// stack-allocated Eigen variables. For a more detailed discussion of the role
-// of a BodyNode in a MultibodyTree refer to the class documentation for
-// BodyNode.
-template <typename T, int  num_positions, int num_velocities>
-class BodyNodeImpl : public BodyNode<T> {
+// While all code that is common to any node _could_ be placed in the BodyNode
+// class, BodyNodeImpl is templatized on the concrete Mobilizer type so
+// implementations here can use fixed-size objects and mobilizer-specific
+// inline implementations for maximum speed. For a more detailed discussion of
+// the role of a BodyNode in a MultibodyTree refer to the class documentation
+// for BodyNode.
+template <typename T, template <typename> class ConcreteMobilizer>
+class BodyNodeImpl final : public BodyNode<T> {
  public:
-  // static constexpr int i = 42; discouraged.  See answer in:
-  // http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
-  enum : int {nq = num_positions, nv = num_velocities};
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BodyNodeImpl);
+
+  // Inherit sizes from the concrete mobilizer.
+  enum : int {
+    kNq = ConcreteMobilizer<T>::kNq,
+    kNv = ConcreteMobilizer<T>::kNv,
+    kNx = ConcreteMobilizer<T>::kNx
+  };
+  using QVector = typename ConcreteMobilizer<T>::QVector;
+  using VVector = typename ConcreteMobilizer<T>::VVector;
+  using HMatrix = typename ConcreteMobilizer<T>::HMatrix;
 
   // Given a body and its inboard mobilizer in a MultibodyTree this constructor
   // creates the corresponding %BodyNode. See the BodyNode class documentation
   // for details on how a BodyNode is defined.
   // @param[in] parent_node
   //   A const pointer to the parent BodyNode object in the tree structure of
-  //   the owning MultibodyTree. It can be a `nullptr` only when `body` **is**
-  //   the **world** body, otherwise the parent class constructor will abort.
-  // @param[in] body The body B associated with `this` node.
-  // @param[in] mobilizer The mobilizer associated with this `node`. It can
-  //                      only be a `nullptr` for the **world** body.
+  //   the owning MultibodyTree.
+  // @param[in] body The body B associated with `this` node. Can't be World.
+  // @param[in] mobilizer The mobilizer associated with this `node`.
+  //
+  // @note World is handled specially and does not go through this path. There
+  //   is a world BodyNode and dummy world Mobilizer 0; see MultibodyTree
+  //   CreateJointImplementations() and CreateBodyNode(). The BodyNode
+  //   constructor used here will abort if we try this with World.
   BodyNodeImpl(const internal::BodyNode<T>* parent_node,
-               const RigidBody<T>* body, const Mobilizer<T>* mobilizer) :
-      BodyNode<T>(parent_node, body, mobilizer) {}
+               const RigidBody<T>* body, const Mobilizer<T>* mobilizer);
 
-  ~BodyNodeImpl() override;
+  ~BodyNodeImpl() final;
 
-  // TODO(amcastro-tri): Implement methods for computing velocity kinematics
-  //  using fixed-size Eigen matrices.
+  // TODO(sherm1) Just a warm up -- move the rest of the kernel computations
+  //  here also.
+
+  void CalcPositionKinematicsCache_BaseToTip(
+      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      const T* positions,
+      PositionKinematicsCache<T>* pc) const final;
+
+  void CalcAcrossNodeJacobianWrtVExpressedInWorld(
+      const systems::Context<T>& context,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      const PositionKinematicsCache<T>& pc,
+      std::vector<Vector6<T>>* H_PB_W_cache) const final;
+
+  void CalcVelocityKinematicsCache_BaseToTip(
+      const systems::Context<T>& context,
+      const PositionKinematicsCache<T>& pc,
+      const std::vector<Vector6<T>>& H_PB_W_cache,
+      const T* velocities,
+      VelocityKinematicsCache<T>* vc) const final;
+
+ private:
+  // Given a pointer to the contiguous array of all q's in this system, returns
+  // a pointer to the ones for this mobilizer.
+  // @pre `positions` is the full set of q's for this system
+  const T* get_q(const T* positions) const {
+    return &positions[mobilizer_->position_start_in_q()];
+  }
+
+  // Given a pointer to the contiguous array of all v's in this system, returns
+  // a pointer to the ones for this mobilizer.
+  // @pre `velocities` is the full set of v's for this system
+  const T* get_v(const T* velocities) const {
+    return &velocities[mobilizer_->velocity_start_in_v()];
+  }
+
+  // Given a complete array of hinge matrices H stored by contiguous columns,
+  // returns a const reference to H for this mobilizer, as a 6xnv fixed-size
+  // matrix. This matrix is 16-byte aligned because it is composed of
+  // columns of Eigen::Vector6 objects which Eigen aligns.
+  Eigen::Map<const HMatrix, Eigen::Aligned16> get_H(
+      const std::vector<Vector6<T>>& H_cache) const {
+    return Eigen::Map<const HMatrix, Eigen::Aligned16>(
+        H_cache[mobilizer_->velocity_start_in_v()].data());
+  }
+
+  // Given a pointer to a mutable complete array of hinge matrices H stored by
+  // contiguous columns, returns a mutable reference to H for this mobilizer,
+  // as a 6xnv fixed-size matrix. This matrix is 16-byte aligned because it is
+  // composed of columns of Eigen::Vector6 objects which Eigen aligns.
+  Eigen::Map<HMatrix, Eigen::Aligned16> get_mutable_H(
+      std::vector<Vector6<T>>* H_cache) const {
+    DRAKE_ASSERT(H_cache != nullptr);
+    return Eigen::Map<HMatrix, Eigen::Aligned16>(
+        (*H_cache)[mobilizer_->velocity_start_in_v()].data());
+  }
+
+  SpatialVelocity<T>& get_mutable_V_WB(VelocityKinematicsCache<T>* vc) const {
+    return vc->get_mutable_V_WB(this->index());
+  }
+
+  SpatialVelocity<T>& get_mutable_V_FM(
+      VelocityKinematicsCache<T>* vc) const {
+    return vc->get_mutable_V_FM(this->index());
+  }
+
+  SpatialVelocity<T>& get_mutable_V_PB_W(
+      VelocityKinematicsCache<T>* vc) const {
+    return vc->get_mutable_V_PB_W(this->index());
+  }
+
+  const ConcreteMobilizer<T>* const mobilizer_;
 };
 
 }  // namespace internal

--- a/multibody/tree/body_node_world.h
+++ b/multibody/tree/body_node_world.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <vector>
+
+#include "drake/common/drake_assert.h"
 #include "drake/multibody/tree/body_node.h"
 
 namespace drake {
@@ -12,10 +15,36 @@ namespace internal {
 // This class represents a BodyNode for the world body.
 // Base class BodyNode methods are sufficient for this zero-dof node.
 template <typename T>
-class BodyNodeWorld : public BodyNode<T> {
+class BodyNodeWorld final : public BodyNode<T> {
  public:
-  explicit BodyNodeWorld(const RigidBody<T>* body) :
-      BodyNode<T>(nullptr, body, nullptr) {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BodyNodeWorld);
+
+  explicit BodyNodeWorld(const RigidBody<T>* body)
+      : BodyNode<T>(nullptr, body, nullptr) {}
+
+  void CalcPositionKinematicsCache_BaseToTip(
+      const FrameBodyPoseCache<T>& /* frame_body_pose_cache */,
+      const T* /* positions */,
+      PositionKinematicsCache<T>* /* pc */) const override {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcAcrossNodeJacobianWrtVExpressedInWorld(
+      const systems::Context<T>& /* context */,
+      const FrameBodyPoseCache<T>& /* frame_body_pose_cache */,
+      const PositionKinematicsCache<T>& /* pc */,
+      std::vector<Vector6<T>>* /* H_PB_W_cache */) const override {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcVelocityKinematicsCache_BaseToTip(
+      const systems::Context<T>& /* context */,
+      const PositionKinematicsCache<T>& /* pc */,
+      const std::vector<Vector6<T>>& /* H_PB_W_cache */,
+      const T* /* velocities */,
+      VelocityKinematicsCache<T>* /* vc */) const override {
+    DRAKE_UNREACHABLE();
+  }
 };
 
 }  // namespace internal

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -431,6 +431,9 @@ class Mobilizer : public MultibodyElement<T> {
   //
   // Additionally, `context` can provide any other parameters the mobilizer
   // could depend on.
+
+  // TODO(sherm1) Consider getting rid of this function altogether and
+  //  making use only of the concrete mobilizer's calc_X_FM() method.
   virtual math::RigidTransform<T> CalcAcrossMobilizerTransform(
       const systems::Context<T>& context) const = 0;
 

--- a/multibody/tree/mobilizer_impl.cc
+++ b/multibody/tree/mobilizer_impl.cc
@@ -1,23 +1,11 @@
 #include "drake/multibody/tree/mobilizer_impl.h"
 
-#include <memory>
-
-#include "drake/multibody/tree/body_node_impl.h"
-
 namespace drake {
 namespace multibody {
 namespace internal {
 
 template <typename T, int nq, int nv>
 MobilizerImpl<T, nq, nv>::~MobilizerImpl() = default;
-
-template <typename T, int nq, int nv>
-std::unique_ptr<internal::BodyNode<T>> MobilizerImpl<T, nq, nv>::CreateBodyNode(
-    const internal::BodyNode<T>* parent_node,
-    const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const {
-  return std::make_unique<internal::BodyNodeImpl<T, nq, nv>>(parent_node,
-                                                             body, mobilizer);
-}
 
 // Macro used to explicitly instantiate implementations on all sizes needed.
 #define EXPLICITLY_INSTANTIATE_IMPLS(T) \
@@ -28,7 +16,7 @@ template class MobilizerImpl<T, 3, 3>; \
 template class MobilizerImpl<T, 6, 6>; \
 template class MobilizerImpl<T, 7, 6>;
 
-// Explicitly instantiates on the most common scalar types.
+// Explicitly instantiates on the supported scalar types.
 // These should be kept in sync with the list in default_scalars.h.
 EXPLICITLY_INSTANTIATE_IMPLS(double);
 EXPLICITLY_INSTANTIATE_IMPLS(AutoDiffXd);

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -20,25 +20,55 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// Base class for specific Mobilizer implementations with the number of
-// generalized positions and velocities resolved at compile time as template
-// parameters. This allows specific mobilizer implementations to only work on
-// fixed-size Eigen expressions therefore allowing for optimized operations on
-// fixed-size matrices. In addition, this layer discourages the proliferation
-// of dynamic-sized Eigen matrices that would otherwise lead to run-time
-// dynamic memory allocations.
-// %MobilizerImpl also provides a number of size specific methods to retrieve
-// multibody quantities of interest from caching structures. These are common
-// to all mobilizer implementations and therefore they live in this class.
-// Users should not need to interact with this class directly unless they need
-// to implement a custom Mobilizer class.
-//
-// @tparam_default_scalar
+/* Base class for specific Mobilizer implementations with the number of
+generalized positions and velocities resolved at compile time as template
+parameters. This allows specific mobilizer implementations to only work on
+fixed-size Eigen expressions therefore allowing for optimized operations on
+fixed-size matrices. In addition, this layer discourages the proliferation
+of dynamic-sized Eigen matrices that would otherwise lead to run-time
+dynamic memory allocations.
+
+Every concrete Mobilizer derived from MobilizerImpl must implement the
+following (ideally inline) methods:
+
+  math::RigidTransform<T> calc_X_FM(const T* q) const;
+
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
+                               const T* v) const;
+
+The coordinate pointers are guaranteed to point to the kNq or kNv state
+variables for the particular mobilizer. They are only 8-byte aligned so
+be careful when interpreting them as Eigen vectors for computation purposes.
+
+TODO(sherm1) The above signatures should _not_ include a Context; all the
+ low-level methods should be purely numerical. Anything needed from the
+ Context should be extracted once prior to the tree recursion and passed
+ directly to the low-level methods.
+
+%MobilizerImpl also provides a number of size specific methods to retrieve
+multibody quantities of interest from caching structures. These are common
+to all mobilizer implementations and therefore they live in this class.
+Users should not need to interact with this class directly unless they need
+to implement a custom Mobilizer class.
+
+@tparam_default_scalar */
 template <typename T,
     int compile_time_num_positions, int compile_time_num_velocities>
 class MobilizerImpl : public Mobilizer<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MobilizerImpl);
+
+  // Handy enum to grant specific implementations compile time sizes.
+  // static constexpr int i = 42; discouraged.  See answer in:
+  // http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
+  enum : int {
+    kNq = compile_time_num_positions,
+    kNv = compile_time_num_velocities,
+    kNx = compile_time_num_positions + compile_time_num_velocities
+  };
+  using QVector = Eigen::Matrix<T, kNq, 1>;
+  using VVector = Eigen::Matrix<T, kNv, 1>;
+  using HMatrix = Eigen::Matrix<T, 6, kNv>;
 
   // As with Mobilizer this the only constructor available for this base class.
   // The minimum amount of information that we need to define a mobilizer is
@@ -123,21 +153,7 @@ class MobilizerImpl : public Mobilizer<T> {
     random_state_distribution_->template tail<kNv>() = velocity;
   }
 
-  // For MultibodyTree internal use only.
-  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
-
  protected:
-  // Handy enum to grant specific implementations compile time sizes.
-  // static constexpr int i = 42; discouraged.  See answer in:
-  // http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
-  enum : int {
-    kNq = compile_time_num_positions,
-    kNv = compile_time_num_velocities,
-    kNx = compile_time_num_positions + compile_time_num_velocities
-  };
-
   // Returns the zero configuration for the mobilizer.
   virtual Vector<double, kNq> get_zero_position() const {
     return Vector<double, kNq>::Zero();

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -15,7 +15,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
@@ -1259,6 +1258,9 @@ void MultibodyTree<T>::CalcPositionKinematicsCache(
   const FrameBodyPoseCache<T>& frame_body_pose_cache =
       EvalFrameBodyPoses(context);
 
+  const Eigen::VectorBlock<const VectorX<T>> q_block = get_positions(context);
+  const T* q = q_block.data();
+
   // With the kinematics information across mobilizers and the kinematics
   // information for each body, we are now in position to perform a base-to-tip
   // recursion to update world positions and parent to child body transforms.
@@ -1271,8 +1273,7 @@ void MultibodyTree<T>::CalcPositionKinematicsCache(
       DRAKE_ASSERT(node.index() == mobod_index);
 
       // Update per-node kinematics.
-      node.CalcPositionKinematicsCache_BaseToTip(context, frame_body_pose_cache,
-                                                 pc);
+      node.CalcPositionKinematicsCache_BaseToTip(frame_body_pose_cache, q, pc);
     }
   }
 }
@@ -1294,6 +1295,9 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
   const std::vector<Vector6<T>>& H_PB_W_cache =
       EvalAcrossNodeJacobianWrtVExpressedInWorld(context);
 
+  const Eigen::VectorBlock<const VectorX<T>> v_block = get_velocities(context);
+  const T* v = v_block.data();
+
   // Performs a base-to-tip recursion computing body velocities.
   // This skips the world, level = 0.
   for (int level = 1; level < forest_height(); ++level) {
@@ -1303,17 +1307,9 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
       DRAKE_ASSERT(node.get_topology().level == level);
       DRAKE_ASSERT(node.index() == mobod_index);
 
-      // Hinge matrix for this node. H_PB_W ∈ ℝ⁶ˣⁿᵐ with nm ∈ [0; 6] the
-      // number of mobilities for this node. Therefore, the return is a
-      // MatrixUpTo6 since the number of columns generally changes with the
-      // node.  It is returned as an Eigen::Map to the memory allocated in the
-      // std::vector H_PB_W_cache so that we can work with H_PB_W as with any
-      // other Eigen matrix object.
-      Eigen::Map<const MatrixUpTo6<T>> H_PB_W =
-          node.GetJacobianFromArray(H_PB_W_cache);
-
-      // Update per-node kinematics.
-      node.CalcVelocityKinematicsCache_BaseToTip(context, pc, H_PB_W, vc);
+      // Update per-mobod kinematics.
+      node.CalcVelocityKinematicsCache_BaseToTip(context, pc, H_PB_W_cache,
+                                                 v, vc);
     }
   }
 }
@@ -2631,17 +2627,8 @@ void MultibodyTree<T>::CalcAcrossNodeJacobianWrtVExpressedInWorld(
        mobod_index < topology_.num_mobods(); ++mobod_index) {
     const BodyNode<T>& node = *body_nodes_[mobod_index];
 
-    // The body-node hinge matrix is H_PB_W ∈ ℝ⁶ˣⁿᵐ, with nm ∈ [0; 6] the number
-    // of mobilities for this node.
-    // Therefore, the return is a MatrixUpTo6 since the number of columns
-    // generally changes with the node.  It is returned as an Eigen::Map to the
-    // memory allocated in the std::vector H_PB_W_cache so that we can work
-    // with H_PB_W as with any other Eigen matrix object.
-    Eigen::Map<MatrixUpTo6<T>> H_PB_W =
-        node.GetMutableJacobianFromArray(H_PB_W_cache);
-
     node.CalcAcrossNodeJacobianWrtVExpressedInWorld(
-        context, frame_body_pose_cache, pc, &H_PB_W);
+        context, frame_body_pose_cache, pc, H_PB_W_cache);
   }
 }
 

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -5,6 +5,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/tree/body_node_impl.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -13,6 +14,14 @@ namespace internal {
 
 template <typename T>
 PlanarMobilizer<T>::~PlanarMobilizer() = default;
+
+template <typename T>
+std::unique_ptr<internal::BodyNode<T>> PlanarMobilizer<T>::CreateBodyNode(
+    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+    const Mobilizer<T>* mobilizer) const {
+  return std::make_unique<internal::BodyNodeImpl<T, PlanarMobilizer>>(
+      parent_node, body, mobilizer);
+}
 
 template <typename T>
 std::string PlanarMobilizer<T>::position_suffix(
@@ -117,19 +126,15 @@ math::RigidTransform<T> PlanarMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>& context) const {
   const auto& q = this->get_positions(context);
   DRAKE_ASSERT(q.size() == kNq);
-  Vector3<T> X_FM_translation;
-  X_FM_translation << q[0], q[1], 0.0;
-  return math::RigidTransform<T>(math::RotationMatrix<T>::MakeZRotation(q[2]),
-                                 X_FM_translation);
+  return calc_X_FM(q.data());
 }
 
 template <typename T>
 SpatialVelocity<T> PlanarMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
+    const systems::Context<T>& context,
+    const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  Vector6<T> V_FM_vector;
-  V_FM_vector << 0.0, 0.0, v[2], v[0], v[1], 0.0;
-  return SpatialVelocity<T>(V_FM_vector);
+  return calc_V_FM(context, v.data());
 }
 
 template <typename T>

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -36,6 +36,10 @@ template <typename T>
 class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PlanarMobilizer);
+  using MobilizerBase = MobilizerImpl<T, 3, 3>;
+  using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
+  using typename MobilizerBase::HMatrix;
 
   /* Constructor for a %PlanarMobilizer between an inboard frame F
    `inboard_frame_F` and an outboard frame M `outboard_frame_M` granting two
@@ -47,6 +51,10 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
       : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {}
 
   ~PlanarMobilizer() final;
+
+  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
+      const internal::BodyNode<T>* parent_node,
+      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
@@ -127,19 +135,27 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
                                             const T& theta_dot) const;
 
   /* Computes the across-mobilizer transform `X_FM(q)` between the inboard
-   frame F and the outboard frame M as a function of the configuration q stored
-   in `context`. */
-  math::RigidTransform<T> CalcAcrossMobilizerTransform(
-      const systems::Context<T>& context) const override;
+  frame F and the outboard frame M as a function of the configuration q stored
+  in `context`. */
+  math::RigidTransform<T> calc_X_FM(const T* q) const {
+    return math::RigidTransform<T>(math::RotationMatrix<T>::MakeZRotation(q[2]),
+                                   Vector3<T>(q[0], q[1], 0.0));
+  }
 
-  /* Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame
-   M measured and expressed in frame F as a function of the configuration q
-   stored in `context` and of the input velocity v, formatted as described in
-   the class documentation.
-   This method aborts in Debug builds if `v.size()` is not three. */
+  /* Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame
+   M measured and expressed in frame F as a function of the input velocity v. */
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
+                               const T* v) const {
+    return SpatialVelocity<T>(Vector3<T>(0.0, 0.0, v[2]),
+                              Vector3<T>(v[0], v[1], 0.0));
+  }
+
+  math::RigidTransform<T> CalcAcrossMobilizerTransform(
+      const systems::Context<T>& context) const final;
+
   SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(
       const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v) const override;
+      const Eigen::Ref<const VectorX<T>>& v) const final;
 
   /* Computes the across-mobilizer acceleration `A_FM(q, v, v̇)` of the outboard
    frame M in the inboard frame F.
@@ -198,16 +214,6 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
       const MultibodyTree<symbolic::Expression>& tree_clone) const override;
 
  private:
-  typedef MobilizerImpl<T, 3, 3> MobilizerBase;
-  /* Bring the handy number of position and velocities MobilizerImpl enums into
-   this class' scope. This is useful when writing mathematical expressions with
-   fixed-sized vectors since we can do things like Vector<T, nq>.
-   Operations with fixed-sized quantities can be optimized at compile time and
-   therefore they are highly preferred compared to the very slow dynamic sized
-   quantities. */
-  using MobilizerBase::kNq;
-  using MobilizerBase::kNv;
-
   /* Helper method to make a clone templated on ToScalar. */
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -6,6 +6,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/math/quaternion.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/multibody/tree/body_node_impl.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -14,6 +15,16 @@ namespace internal {
 
 template <typename T>
 QuaternionFloatingMobilizer<T>::~QuaternionFloatingMobilizer() = default;
+
+template <typename T>
+std::unique_ptr<internal::BodyNode<T>>
+QuaternionFloatingMobilizer<T>::CreateBodyNode(
+    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+    const Mobilizer<T>* mobilizer) const {
+  return std::make_unique<
+      internal::BodyNodeImpl<T, QuaternionFloatingMobilizer>>(parent_node, body,
+                                                              mobilizer);
+}
 
 template <typename T>
 std::string QuaternionFloatingMobilizer<T>::position_suffix(
@@ -228,24 +239,16 @@ QuaternionFloatingMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>& context) const {
   const auto& q = this->get_positions(context);
   DRAKE_ASSERT(q.size() == kNq);
-
-  // The first 4 elements in q contain a quaternion, ordered as w, x, y, z.
-  // The last 3 elements in q contain position from Fo to Mo.
-  const Vector4<T> wxyz(q.template head<4>());
-  const Vector3<T> p_FM = q.template tail<3>();  // position from Fo to Mo.
-  const Eigen::Quaternion<T> quaternion_FM(wxyz(0), wxyz(1), wxyz(2), wxyz(3));
-  const math::RigidTransform<T> X_FM(quaternion_FM, p_FM);
-  return X_FM;
+  return calc_X_FM(q.data());
 }
 
 template <typename T>
 SpatialVelocity<T>
 QuaternionFloatingMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>&,
+    const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return SpatialVelocity<T>(v.template head<3>(),   // w_FM
-                            v.template tail<3>());  // v_FM
+  return calc_V_FM(context, v.data());
 }
 
 template <typename T>

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -7,6 +7,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/tree/body_node_impl.h"
 #include "drake/multibody/tree/multibody_tree.h"
 #include "drake/multibody/tree/rigid_body.h"
 
@@ -16,6 +17,14 @@ namespace internal {
 
 template <typename T>
 RpyBallMobilizer<T>::~RpyBallMobilizer() = default;
+
+template <typename T>
+std::unique_ptr<internal::BodyNode<T>> RpyBallMobilizer<T>::CreateBodyNode(
+    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+    const Mobilizer<T>* mobilizer) const {
+  return std::make_unique<internal::BodyNodeImpl<T, RpyBallMobilizer>>(
+      parent_node, body, mobilizer);
+}
 
 template <typename T>
 std::string RpyBallMobilizer<T>::position_suffix(
@@ -94,19 +103,17 @@ const RpyBallMobilizer<T>& RpyBallMobilizer<T>::SetAngularVelocity(
 template <typename T>
 math::RigidTransform<T> RpyBallMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>& context) const {
-  const Eigen::Matrix<T, 3, 1>& rpy = this->get_positions(context);
-  DRAKE_ASSERT(rpy.size() == kNq);
-  const math::RollPitchYaw<T> roll_pitch_yaw(rpy(0), rpy(1), rpy(2));
-  math::RigidTransform<T> X_FM(roll_pitch_yaw, Vector3<T>::Zero());
-  return X_FM;
+  const auto& q = this->get_positions(context);
+  DRAKE_ASSERT(q.size() == kNq);
+  return calc_X_FM(q.data());
 }
 
 template <typename T>
 SpatialVelocity<T> RpyBallMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>&,
+    const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return SpatialVelocity<T>(v, Vector3<T>::Zero());
+  return calc_V_FM(context, v.data());
 }
 
 template <typename T>

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -246,7 +246,7 @@ class ScrewJoint final : public Joint<T> {
   /// Gets the default position for `this` joint.
   /// @retval z The default position of `this` joint.
   double get_default_translation() const {
-    return internal::get_screw_translation_from_rotation(
+    return internal::GetScrewTranslationFromRotation(
         this->default_positions()[0], screw_pitch());
   }
 
@@ -255,8 +255,8 @@ class ScrewJoint final : public Joint<T> {
   /// @param[in] z The desired default translation of the joint
   /// @throws std::exception if pitch is very near zero.
   void set_default_translation(const double& z) {
-    Vector1<double> state(internal::get_screw_rotation_from_translation(
-        z, screw_pitch()));
+    Vector1<double> state(
+        internal::GetScrewRotationFromTranslation(z, screw_pitch()));
     this->set_default_positions(state);
   }
 

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -3,12 +3,22 @@
 #include <cmath>
 #include <limits>
 
+#include "drake/multibody/tree/body_node_impl.h"
+
 namespace drake {
 namespace multibody {
 namespace internal {
 
 template <typename T>
 ScrewMobilizer<T>::~ScrewMobilizer() = default;
+
+template <typename T>
+std::unique_ptr<internal::BodyNode<T>> ScrewMobilizer<T>::CreateBodyNode(
+    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+    const Mobilizer<T>* mobilizer) const {
+  return std::make_unique<internal::BodyNodeImpl<T, ScrewMobilizer>>(
+      parent_node, body, mobilizer);
+}
 
 template <typename T>
 std::string ScrewMobilizer<T>::position_suffix(
@@ -37,7 +47,7 @@ template <typename T>
 T ScrewMobilizer<T>::get_translation(const systems::Context<T>& context) const {
   auto q = this->get_positions(context);
   DRAKE_ASSERT(q.size() == kNq);
-  return get_screw_translation_from_rotation(q[0], screw_pitch_);
+  return GetScrewTranslationFromRotation(q[0], screw_pitch_);
 }
 
 template <typename T>
@@ -50,7 +60,7 @@ const ScrewMobilizer<T>& ScrewMobilizer<T>::SetTranslation(
                      abs(translation) < kEpsilon);
   auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);
-  q[0] = get_screw_rotation_from_translation(translation, screw_pitch_);
+  q[0] = GetScrewRotationFromTranslation(translation, screw_pitch_);
   return *this;
 }
 
@@ -76,7 +86,7 @@ T ScrewMobilizer<T>::get_translation_rate(
     const systems::Context<T>& context) const {
   auto v = this->get_velocities(context);
   DRAKE_ASSERT(v.size() == kNv);
-  return get_screw_translation_from_rotation(v[0], screw_pitch_);
+  return GetScrewTranslationFromRotation(v[0], screw_pitch_);
 }
 
 template <typename T>
@@ -89,7 +99,7 @@ const ScrewMobilizer<T>& ScrewMobilizer<T>::SetTranslationRate(
 
   auto v = this->GetMutableVelocities(context);
   DRAKE_ASSERT(v.size() == kNv);
-  v[0] = get_screw_rotation_from_translation(vz, screw_pitch_);
+  v[0] = GetScrewRotationFromTranslation(vz, screw_pitch_);
   return *this;
 }
 
@@ -113,22 +123,17 @@ const ScrewMobilizer<T>& ScrewMobilizer<T>::SetAngularRate(
 template <typename T>
 math::RigidTransform<T> ScrewMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>& context) const {
-  const auto& q = this->get_positions(context);
-  DRAKE_ASSERT(q.size() == kNq);
-  const Vector3<T> p_FM(axis_ *
-      get_screw_translation_from_rotation(q[0], screw_pitch_));
-  return math::RigidTransform<T>(Eigen::AngleAxis<T>(q[0], axis_), p_FM);
+const auto& q = this->get_positions(context);
+DRAKE_ASSERT(q.size() == kNq);
+return calc_X_FM(q.data());
 }
 
 template <typename T>
 SpatialVelocity<T> ScrewMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  Vector6<T> V_FM_vector;
-  V_FM_vector <<
-    (axis_ * v[0]),
-    (axis_ * get_screw_translation_from_rotation(v[0], screw_pitch_));
-  return SpatialVelocity<T>(V_FM_vector);
+    const systems::Context<T>& context,
+    const Eigen::Ref<const VectorX<T>>& v) const {
+DRAKE_ASSERT(v.size() == kNv);
+return calc_V_FM(context, v.data());
 }
 
 template <typename T>
@@ -140,7 +145,7 @@ ScrewMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
   Vector6<T> A_FM_vector;
   A_FM_vector <<
     (axis_ * vdot[0]),
-    (axis_ * get_screw_translation_from_rotation(vdot[0], screw_pitch_));
+    (axis_ * GetScrewTranslationFromRotation(vdot[0], screw_pitch_));
   return SpatialAcceleration<T>(A_FM_vector);
 }
 

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -17,6 +17,24 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
+/* These two functions are suitable for position, velocity, and acceleration
+conversions. All of these are governed by the same relation, depended on the
+`screw_pitch`. These are available for internal use here and also in the
+ScrewJoint for which this is the implementation. */
+
+template <typename T>
+T GetScrewTranslationFromRotation(const T& theta,
+                                             double screw_pitch) {
+  const T revolution_amount{theta / (2 * M_PI)};
+  return screw_pitch * revolution_amount;
+}
+
+template <typename T>
+T GetScrewRotationFromTranslation(const T& z, double screw_pitch) {
+  const T revolution_amount{z / screw_pitch};
+  return revolution_amount * 2 * M_PI;
+}
+
 /* This mobilizer models a screw joint between an inboard frame F and an
  outboard frame M that enables translation along an axis while
  rotating about it, such that the axis is constant when measured
@@ -40,6 +58,10 @@ template <typename T>
 class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ScrewMobilizer);
+  using MobilizerBase = MobilizerImpl<T, 1, 1>;
+  using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
+  using typename MobilizerBase::HMatrix;
 
   /* Constructor for a %ScrewMobilizer between an inboard frame F and
      an outboard frame M  granting one translational and one rotational degrees
@@ -69,6 +91,10 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   }
 
   ~ScrewMobilizer() final;
+
+  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
+      const internal::BodyNode<T>* parent_node,
+      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
@@ -163,15 +189,27 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   /* Computes the across-mobilizer transform `X_FM(q)` between the inboard
    frame F and the outboard frame M as a function of the configuration q stored
    in `context`. */
+  math::RigidTransform<T> calc_X_FM(const T* q) const {
+    const Vector3<T> p_FM(
+        axis_ * GetScrewTranslationFromRotation(q[0], screw_pitch_));
+    return math::RigidTransform<T>(Eigen::AngleAxis<T>(q[0], axis_), p_FM);
+  }
+
+  /* Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame
+   M measured and expressed in frame F as a function of the input velocity v,
+   which is the angular velocity. We scale that by the pitch to find the
+   related translational velocity. */
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
+                               const T* v) const {
+    const SpatialVelocity<T> V_FM(
+        axis_ * v[0],
+        axis_ * GetScrewTranslationFromRotation(v[0], screw_pitch_));
+    return V_FM;
+  }
+
   math::RigidTransform<T> CalcAcrossMobilizerTransform(
       const systems::Context<T>& context) const final;
 
-  /* Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame
-   M measured and expressed in frame F as a function of the configuration q
-   stored in `context` and of the input velocity v, formatted as described in
-   the class documentation.
-   This method aborts in Debug builds if `v.size()` is not one.
-   @pre v.size() == 1 */
   SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& v) const final;
@@ -237,38 +275,11 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(
       const MultibodyTree<ToScalar>& tree_clone) const;
 
-  typedef MobilizerImpl<T, 1, 1> MobilizerBase;
-  /* Bring the handy number of position and velocities MobilizerImpl enums into
-   this class' scope. This is useful when writing mathematical expressions with
-   fixed-sized vectors since we can do things like Vector<T, nq>.
-   Operations with fixed-sized quantities can be optimized at compile time and
-   therefore they are highly preferred compared to the very slow dynamic sized
-   quantities. */
-  using MobilizerBase::kNq;
-  using MobilizerBase::kNv;
-
   // Default joint axis expressed in the inboard frame F.
   Vector3<double> axis_;
 
   const double screw_pitch_;
 };
-
-/* `get_screw_translation_from_rotation`,
- `get_screw_rotation_from_translation` are used for position, velocity,
- and acceleration conversions.  All of these are governed by
- the same relation, depended on the `screw_pitch` of a screw mobilizer. */
-template <typename T>
-inline T get_screw_translation_from_rotation(const T& theta,
-                                             double screw_pitch) {
-  T revolution_amount{theta / (2 * M_PI)};
-  return screw_pitch * revolution_amount;
-}
-
-template <typename T>
-inline T get_screw_rotation_from_translation(const T& z, double screw_pitch) {
-  T revolution_amount{z / screw_pitch};
-  return revolution_amount * 2 * M_PI;
-}
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -60,6 +60,38 @@ class DummyBody : public RigidBody<double> {
   }
 };
 
+// Non-abstract definition of a BodyNode.
+class DummyBodyNode : public BodyNode<double> {
+ public:
+  using T = double;
+
+  using BodyNode::BodyNode;
+
+  void CalcPositionKinematicsCache_BaseToTip(
+      const FrameBodyPoseCache<T>& /* frame_body_pose_cache */,
+      const T* /* positions */,
+      PositionKinematicsCache<T>* /* pc */) const override {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcAcrossNodeJacobianWrtVExpressedInWorld(
+      const systems::Context<T>& /* context */,
+      const FrameBodyPoseCache<T>& /* frame_body_pose_cache */,
+      const PositionKinematicsCache<T>& /* pc */,
+      std::vector<Vector6<T>>* /* H_PB_W_cache */) const override {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcVelocityKinematicsCache_BaseToTip(
+      const systems::Context<T>& /* context */,
+      const PositionKinematicsCache<T>& /* pc */,
+      const std::vector<Vector6<T>>& /* H_PB_W_cache */,
+      const T* /* velocities */,
+      VelocityKinematicsCache<T>* /* vc */) const override {
+    DRAKE_UNREACHABLE();
+  }
+};
+
 // This test validates the exception message thrown in
 // BodyNode::CalcArticulatedBodyHingeInertiaMatrixFactorization(). There are two
 // aspects of the message that are not simply *literal*:
@@ -75,7 +107,7 @@ GTEST_TEST(BodyNodeTest, FactorArticulatedBodyHingeInertiaMatrixErrorMessages) {
   // Construct enough of a node so we can invoke the dut with known body names.
   const DummyBody parent("parent", world_index());
   const DummyBody child("child", BodyIndex(1));
-  const BodyNode<double> parent_node(nullptr, &parent, nullptr);
+  const DummyBodyNode parent_node(nullptr, &parent, nullptr);
 
   // A 1x1 articulated body hinge inertia matrix.
   MatrixUpTo6<double> one_by_one(1, 1);
@@ -87,7 +119,7 @@ GTEST_TEST(BodyNodeTest, FactorArticulatedBodyHingeInertiaMatrixErrorMessages) {
     const RevoluteMobilizer<double> mobilizer(dummy_mobod, parent.body_frame(),
                                               child.body_frame(),
                                               Vector3d{0, 0, 1});
-    const BodyNode<double> body_node(&parent_node, &child, &mobilizer);
+    const DummyBodyNode body_node(&parent_node, &child, &mobilizer);
     DRAKE_EXPECT_THROWS_MESSAGE(
         BodyNodeTester::CallLltFactorization(body_node, one_by_one),
         "An internal mass matrix associated with the joint that connects body "
@@ -102,7 +134,7 @@ GTEST_TEST(BodyNodeTest, FactorArticulatedBodyHingeInertiaMatrixErrorMessages) {
     const PrismaticMobilizer<double> mobilizer(dummy_mobod, parent.body_frame(),
                                                child.body_frame(),
                                                Vector3d{0, 0, 1});
-    const BodyNode<double> body_node(&parent_node, &child, &mobilizer);
+    const DummyBodyNode body_node(&parent_node, &child, &mobilizer);
     DRAKE_EXPECT_THROWS_MESSAGE(
         BodyNodeTester::CallLltFactorization(body_node, one_by_one),
         "An internal mass matrix associated with the joint that connects body "
@@ -118,7 +150,7 @@ GTEST_TEST(BodyNodeTest, FactorArticulatedBodyHingeInertiaMatrixErrorMessages) {
     // space is irrelevant.
     const PlanarMobilizer<double> mobilizer(dummy_mobod, parent.body_frame(),
                                             child.body_frame());
-    const BodyNode<double> body_node(&parent_node, &child, &mobilizer);
+    const DummyBodyNode body_node(&parent_node, &child, &mobilizer);
     // In this case, we don't need to examine the full exception message since
     // the message is a concatenation of the text in the previous messages. We
     // look for evidence of concatenation with "rotation" and "translation".
@@ -146,8 +178,8 @@ GTEST_TEST(BodyNodeTest, FactorHingeMatrixThrows) {
   const SpanningForest::Mobod dummy_mobod(MobodIndex(0), LinkOrdinal(0));
   const RevoluteMobilizer<double> mobilizer(
       dummy_mobod, world.body_frame(), body.body_frame(), Vector3d{0, 0, 1});
-  const BodyNode<double> world_node(nullptr, &world, nullptr);
-  const BodyNode<double> body_node(&world_node, &body, &mobilizer);
+  const DummyBodyNode world_node(nullptr, &world, nullptr);
+  const DummyBodyNode body_node(&world_node, &body, &mobilizer);
 
   // 1x1 hinge matrix.
   Matrix one_by_one(1, 1);

--- a/multibody/tree/universal_mobilizer.cc
+++ b/multibody/tree/universal_mobilizer.cc
@@ -6,7 +6,8 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/rotation_matrix.h"
-#include "drake/multibody/tree/multibody_tree.h"
+#include "drake/multibody/tree/body_node_impl.h"
+// #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
 namespace multibody {
@@ -17,6 +18,14 @@ using std::sin;
 
 template <typename T>
 UniversalMobilizer<T>::~UniversalMobilizer() = default;
+
+template <typename T>
+std::unique_ptr<internal::BodyNode<T>> UniversalMobilizer<T>::CreateBodyNode(
+    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+    const Mobilizer<T>* mobilizer) const {
+  return std::make_unique<internal::BodyNodeImpl<T, UniversalMobilizer>>(
+      parent_node, body, mobilizer);
+}
 
 template <typename T>
 std::string UniversalMobilizer<T>::position_suffix(
@@ -78,24 +87,6 @@ const UniversalMobilizer<T>& UniversalMobilizer<T>::SetAngularRates(
 }
 
 template <typename T>
-math::RigidTransform<T> UniversalMobilizer<T>::CalcAcrossMobilizerTransform(
-    const systems::Context<T>& context) const {
-  const auto& q = this->get_positions(context);
-  DRAKE_ASSERT(q.size() == kNq);
-  const T s1 = sin(q[0]);
-  const T c1 = cos(q[0]);
-  const T s2 = sin(q[1]);
-  const T c2 = cos(q[1]);
-  Matrix3<T> R_FM_matrix;
-  R_FM_matrix << c2,     0.0, s2,
-                 s1*s2,  c1,  -s1*c2,
-                 -c1*s2, s1,  c1*c2;
-  const math::RotationMatrix<T> R_FM = math::RotationMatrix<T>(R_FM_matrix);
-  const math::RigidTransform<T> X_FM(R_FM);
-  return X_FM;
-}
-
-template <typename T>
 Eigen::Matrix<T, 3, 2> UniversalMobilizer<T>::CalcHwMatrix(
     const systems::Context<T>& context, Vector3<T>* Hw_dot) const {
   const Vector2<T>& q = this->get_positions(context);
@@ -118,12 +109,19 @@ Eigen::Matrix<T, 3, 2> UniversalMobilizer<T>::CalcHwMatrix(
 }
 
 template <typename T>
+math::RigidTransform<T> UniversalMobilizer<T>::CalcAcrossMobilizerTransform(
+    const systems::Context<T>& context) const {
+  const auto& q = this->get_positions(context);
+  DRAKE_ASSERT(q.size() == kNq);
+  return calc_X_FM(q.data());
+}
+
+template <typename T>
 SpatialVelocity<T> UniversalMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  const Eigen::Matrix<T, 3, 2> Hw = this->CalcHwMatrix(context);
-  return SpatialVelocity<T>(Hw * v, Vector3<T>::Zero());
+  return calc_V_FM(context, v.data());
 }
 
 template <typename T>

--- a/multibody/tree/universal_mobilizer.h
+++ b/multibody/tree/universal_mobilizer.h
@@ -48,6 +48,10 @@ template <typename T>
 class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UniversalMobilizer);
+  using MobilizerBase = MobilizerImpl<T, 2, 2>;
+  using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
+  using typename MobilizerBase::HMatrix;
 
   // Constructor for a %UniversalMobilizer between an inboard frame F
   // `inboard_frame_F` and an outboard frame M `outboard_frame_M` granting
@@ -59,6 +63,10 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
       : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {}
 
   ~UniversalMobilizer() final;
+
+  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
+      const internal::BodyNode<T>* parent_node,
+      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
@@ -107,17 +115,36 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
   // Computes the across-mobilizer transform `X_FM(q)` between the inboard
   // frame F and the outboard frame M as a function of the angles (θ₁, θ₂)
   // stored in `context`.
-  math::RigidTransform<T> CalcAcrossMobilizerTransform(
-      const systems::Context<T>& context) const override;
+  math::RigidTransform<T> calc_X_FM(const T* q) const {
+    const T s1 = sin(q[0]), c1 = cos(q[0]);
+    const T s2 = sin(q[1]), c2 = cos(q[1]);
+    Matrix3<T> R_FM_matrix;
+    R_FM_matrix <<   c2,    0.0,  s2,
+                   s1 * s2, c1,  -s1 * c2,
+                  -c1 * s2, s1,   c1 * c2;
+    return math::RigidTransform<T>(
+        math::RotationMatrix<T>::MakeUnchecked(R_FM_matrix),
+        Vector3<T>::Zero());
+  }
 
-  // Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame
+  // Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame
   // M measured and expressed in frame F as a function of the angles (θ₁, θ₂)
-  // stored in `context` and of the input angular rates v, formatted as
+  // stored in context and of the input angular rates v, formatted as
   // in get_angular_rates().
-  // This method aborts in Debug builds if `v.size()` is not two.
+  // TODO(sherm1) Should not have to recalculate H_FM(q) here.
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>& context,
+                               const T* v) const {
+    const Eigen::Map<const VVector> w(v);
+    const Eigen::Matrix<T, 3, 2> Hw = this->CalcHwMatrix(context);
+    return SpatialVelocity<T>(Hw * w, Vector3<T>::Zero());
+  }
+
+  math::RigidTransform<T> CalcAcrossMobilizerTransform(
+      const systems::Context<T>& context) const final;
+
   SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(
       const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v) const override;
+      const Eigen::Ref<const VectorX<T>>& v) const final;
 
   // Computes the across-mobilizer acceleration `A_FM(q, v, v̇)` of the
   // outboard frame M in the inboard frame F.
@@ -179,16 +206,6 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
       const MultibodyTree<symbolic::Expression>& tree_clone) const override;
 
  private:
-  typedef MobilizerImpl<T, 2, 2> MobilizerBase;
-  // Bring the handy number of position and velocities MobilizerImpl enums into
-  // this class' scope. This is useful when writing mathematical expressions
-  // with fixed-sized vectors since we can do things like Vector<T, nq>.
-  // Operations with fixed-sized quantities can be optimized at compile time
-  // and therefore they are highly preferred compared to the very slow dynamic
-  // sized quantities.
-  using MobilizerBase::kNq;
-  using MobilizerBase::kNv;
-
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/multibody/tree/body_node_impl.h"
 #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
@@ -12,15 +13,24 @@ template <typename T>
 WeldMobilizer<T>::~WeldMobilizer() = default;
 
 template <typename T>
+std::unique_ptr<internal::BodyNode<T>> WeldMobilizer<T>::CreateBodyNode(
+    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+    const Mobilizer<T>* mobilizer) const {
+  return std::make_unique<internal::BodyNodeImpl<T, WeldMobilizer>>(
+      parent_node, body, mobilizer);
+}
+
+template <typename T>
 math::RigidTransform<T> WeldMobilizer<T>::CalcAcrossMobilizerTransform(
-    const systems::Context<T>&) const { return X_FM_.cast<T>(); }
+    const systems::Context<T>&) const {
+return X_FM_.cast<T>();
+}
 
 template <typename T>
 SpatialVelocity<T> WeldMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
     const systems::Context<T>&,
-    const Eigen::Ref<const VectorX<T>>& v) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  return SpatialVelocity<T>::Zero();
+    const Eigen::Ref<const VectorX<T>>&) const {
+return SpatialVelocity<T>::Zero();
 }
 
 template <typename T>

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -25,6 +25,10 @@ template <typename T>
 class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(WeldMobilizer);
+  using MobilizerBase = MobilizerImpl<T, 0, 0>;
+  using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
+  using typename MobilizerBase::HMatrix;
 
   // Constructor for a %WeldMobilizer between the `inboard_frame_F` and
   // `outboard_frame_M`.
@@ -37,19 +41,32 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
 
   ~WeldMobilizer() final;
 
+  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
+      const internal::BodyNode<T>* parent_node,
+      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+
   // @retval X_FM The pose of the outboard frame M in the inboard frame F.
   const math::RigidTransform<double>& get_X_FM() const { return X_FM_; }
 
   // Computes the across-mobilizer transform `X_FM`, which for this mobilizer
   // is independent of the state stored in `context`.
-  math::RigidTransform<T> CalcAcrossMobilizerTransform(
-      const systems::Context<T>& context) const final;
+  math::RigidTransform<T> calc_X_FM(const T*) const {
+    return X_FM_.cast<T>();
+  }
 
-  // Computes the across-mobilizer velocity `V_FM` which for this mobilizer is
+  // Computes the across-mobilizer velocity V_FM which for this mobilizer is
   // always zero since the outboard frame M is fixed to the inboard frame F.
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
+                               const T*) const {
+    return SpatialVelocity<T>::Zero();
+  }
+
+  math::RigidTransform<T> CalcAcrossMobilizerTransform(
+      const systems::Context<T>&) const final;
+
   SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v) const final;
+      const systems::Context<T>&,
+      const Eigen::Ref<const VectorX<T>>&) const final;
 
   // Computes the across-mobilizer acceleration `A_FM` which for this mobilizer
   // is always zero since the outboard frame M is fixed to the inboard frame F.
@@ -101,16 +118,6 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
       const MultibodyTree<symbolic::Expression>& tree_clone) const final;
 
  private:
-  typedef MobilizerImpl<T, 0, 0> MobilizerBase;
-  // Bring the handy number of position and velocities MobilizerImpl enums into
-  // this class' scope. This is useful when writing mathematical expressions
-  // with fixed-sized vectors since we can do things like Vector<T, nq>.
-  // Operations with fixed-sized quantities can be optimized at compile time
-  // and therefore they are highly preferred compared to the very slow dynamic
-  // sized quantities.
-  using MobilizerBase::kNq;
-  using MobilizerBase::kNv;
-
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(


### PR DESCRIPTION
Templatizes BodyNodeImpl on concrete Mobilizer type to permit inlines rather than virtuals. This is part of the MbP performance epic #18442.

This PR doesn't change how we compute anything or attempt to reduce flop count. It just rearranges what's there to allow the compiler to generate better code. There are many further changes to come but I want to merge this now since the shuffling around would make it hard to review with substantive changes. This is a step towards a templatized kernel using only fixed-size objects, and reduces the amount of context-digging being done (but doesn't yet eliminate it all).

As a proof of concept, in addition to the newly-templatized BodyNodeImpl, I moved the position and velocity kinematics methods to take advantage of that. Everything else is unchanged. I measured 4% and 21% speedup for those with gcc, 11% and 32% with clang. Combined with the similar hacks to Frames in last week's #21853, position and velocity speedup is 28%/41% and 28%/44% resp. (See table below)
Note that these are the simplest computations with very few "up to 6" vectors and virtual function calls -- the dynamics computations have a lot more potential for speedup.

### What's here
- BodyNodeImpl (which was unused before) is now templated by concrete Mobilizer type, and partially filled in.
- Every mobilizer gains two new inline, non-virtual methods `calc_X_FM()` and `calc_V_FM()`. The existing virtual methods are reimplemented as calls to the non-virtuals.
- The per-node position & velocity kinematics functions are moved from the generic BodyNode to the templatized BodyNodeImpl where they can invoke the new inline methods directly.
- The corresponding tree-walking algorithms in MultibodyTree are fixed to extract numerical info from the context outside the loop, and to allow the individual nodes to grab what they need (which they can do very efficiently).

### What's not here
- no algorithmic changes
- no modifications to most of the existing computations (they are still stuck in BodyNode)
- not every Context extraction at low levels has been removed yet, so the existing "kernel" is not yet purely numerical
- other than modest speedups, there are no user-visible changes here (all code is `internal::`)

### Notes for reviewers
- I suggest starting with body_node_impl.h to see how it is templatized now, and the three virtual kinematics functions it implements. This is not CRTP -- it is very straightforward.
- Then body_node_impl.cc has the implementations which are able to call directly into concrete mobilizer's inlines. These functions were moved over directly from BodyNode and then lightly modified to replace virtuals with inline calls.
- Every mobilizer was changed in the same boilerplate manner to add the new inlines.

### Benchmarking
CassieBench measures only multibody kernel time, in microseconds. (I did nothing to speed up Mass Matrix calculation here but clang sped it up anyway so I included those times.)

|    Test (gcc)        |   Master    |  Master* | This PR | Speedup |  Speedup* |
| ------------------ | ----------- | ---------- | ------- | ------------ | ----------|
| Position only       |     2.68      |    3.58       |   2.58    |     4%       |     28%    |
| Position&Velocity|    5.55     |    7.52     |   4.41    |     21%        |    41%    |
| Mass Matrix         |   12.5     |    14.5     |   12.2    |     2%        |    16%    |

|    Test (clang)      |   Master    |  Master* | This PR | Speedup |  Speedup* |
| ------------------ | ----------- | ---------- | ------- | ------------ | ----------|
| Position only       |     2.52      |    3.12       |   2.25    |    11%       |     28%    |
| Position&Velocity|    5.19     |    6.3     |   3.55    |     32%        |    44%    |
| Mass Matrix        |    9.55     |    10.7     |  8.88    |     7%        |   17%    |

   `*` times from pre-#21853 which applied similar changes to Frames.

- Puget Xeon E5-2699 v4 @2.2GHz
- gcc 11.4.0
- clang 15.0.7

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21862)
<!-- Reviewable:end -->
