### PR TITLE
[setup] Satisfy bazel_tools implicit zip dependency

### DIFF
--- a/setup/ubuntu/source_distribution/packages-jammy-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy-test-only.txt
@@ -16,3 +16,4 @@ python3-uritemplate
 python3-websockets
 valgrind
 valgrind-dbg
+zip

--- a/setup/ubuntu/source_distribution/packages-noble-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-noble-test-only.txt
@@ -14,3 +14,4 @@ python3-u-msgpack
 python3-uritemplate
 python3-websockets
 valgrind
+zip


### PR DESCRIPTION
Lack of zip has been breaking our coverage reporting in CI, probably for months. Add it to Drake setup to stop the bleeding.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21863)
<!-- Reviewable:end -->
