### PR TITLE
[common] Adjust non-spdlog stub to be more generous

### DIFF
--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -70,9 +70,10 @@ GTEST_TEST(TextLoggingTest, ConstantTest) {
 }
 
 // Check that the "warn once" idiom compiles and doesn't crash at runtime.
+// We use a pattern substitution to cover both arguments of the Warn's ctor.
 GTEST_TEST(TextLoggingTest, WarnOnceTest) {
   static const drake::logging::Warn log_once(
-      "The log_once happened as expected.");
+      "The {} happened as expected.", "log_once");
 }
 
 // Abuse gtest internals to verify that logging actually prints when enabled,

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -123,30 +123,17 @@ class logger {
   logger();
 
   template <typename... Args>
-  void trace(const char*, const Args&...) {}
+  void trace(const Args&...) {}
   template <typename... Args>
-  void debug(const char*, const Args&...) {}
+  void debug(const Args&...) {}
   template <typename... Args>
-  void info(const char*, const Args&...) {}
+  void info(const Args&...) {}
   template <typename... Args>
-  void warn(const char*, const Args&...) {}
+  void warn(const Args&...) {}
   template <typename... Args>
-  void error(const char*, const Args&...) {}
+  void error(const Args&...) {}
   template <typename... Args>
-  void critical(const char*, const Args&...) {}
-
-  template <typename T>
-  void trace(const T&) {}
-  template <typename T>
-  void debug(const T&) {}
-  template <typename T>
-  void info(const T&) {}
-  template <typename T>
-  void warn(const T&) {}
-  template <typename T>
-  void error(const T&) {}
-  template <typename T>
-  void critical(const T&) {}
+  void critical(const Args&...) {}
 };
 
 // A stubbed-out version of `spdlog::sinks::sink`.


### PR DESCRIPTION
Calls that used fmt_runtime with substitution arguments were not being stubbed correctly (there was no matching overload).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21864)
<!-- Reviewable:end -->
