### PR TITLE
Use tiny_gltf instead of vtk for parsing gltf vertices

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -523,12 +523,9 @@ drake_cc_library(
         "//common:essential",
         "//common:find_resource",
         "//geometry:read_obj",
-        "//geometry:vtk_opengl_init",
         "//math:geometric_transform",
         "@qhull_internal//:qhull",
-        "@vtk_internal//:vtkCommonCore",
-        "@vtk_internal//:vtkIOImport",
-        "@vtk_internal//:vtkRenderingCore",
+        "@tinygltf_internal//:tinygltf",
     ],
 )
 


### PR DESCRIPTION
I found that MultibodyPlant pulls quite a bit of the rendering pipeline just parse vertices of a gltf and VTK files. Recently, we added tinygltf_internal as a dependency enabling us to get around vtk to import gltfs.
Further, this would allow us to parse .glb files in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21869)
<!-- Reviewable:end -->
