### PR TITLE
Implement AffineSubspace::DoAddPointInNonnegativeScalingConstraints

### DIFF
--- a/geometry/optimization/affine_subspace.cc
+++ b/geometry/optimization/affine_subspace.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/optimization/affine_subspace.h"
 
 #include "drake/common/is_approx_equal_abstol.h"
+#include "drake/geometry/optimization/point.h"
 #include "drake/solvers/solve.h"
 
 namespace drake {
@@ -39,7 +40,7 @@ AffineSubspace::AffineSubspace(const ConvexSet& set, double tol)
   const auto singleton_maybe = set.MaybeGetPoint();
   if (singleton_maybe.has_value()) {
     // Fall back to the basis and translation constructor.
-    *this = AffineSubspace(Eigen::MatrixXd::Zero(set.ambient_dimension(), 0),
+    *this = AffineSubspace(MatrixXd::Zero(set.ambient_dimension(), 0),
                            singleton_maybe.value());
     return;
   }
@@ -190,15 +191,15 @@ std::optional<bool> AffineSubspace::DoPointInSetShortcut(
     return is_approx_equal_abstol(x, translation_, tol);
   }
   // Otherwise, project onto the flat, and compare to the input.
-  Eigen::VectorXd projected_points(x.rows());
+  VectorXd projected_points(x.rows());
   DoProjectionShortcut(x, &projected_points);
   return is_approx_equal_abstol(x, projected_points, tol);
 }
 
 std::pair<VectorX<Variable>, std::vector<Binding<Constraint>>>
 AffineSubspace::DoAddPointInSetConstraints(
-    solvers::MathematicalProgram* prog,
-    const Eigen::Ref<const solvers::VectorXDecisionVariable>& x) const {
+    MathematicalProgram* prog,
+    const Eigen::Ref<const VectorXDecisionVariable>& x) const {
   // We require that (x - translation) can be written as a linear
   // combination of the basis vectors
   std::vector<Binding<Constraint>> new_constraints;
@@ -216,30 +217,65 @@ AffineSubspace::DoAddPointInSetConstraints(
 
 std::vector<Binding<Constraint>>
 AffineSubspace::DoAddPointInNonnegativeScalingConstraints(
-    solvers::MathematicalProgram*,
-    const Eigen::Ref<const solvers::VectorXDecisionVariable>&,
-    const Variable&) const {
-  // This method of ConvexSet is currently only used in GraphOfConvexSets,
-  // and it's bad practice to include unbounded sets in such optimizations.
-  // "For GCS the boundedness of the sets is required because you want to
-  // be sure that if the perspective coefficient is zero, then the vector
-  // variable is constrained to be zero. If the set is unbounded, then the
-  // vector variables is only constrained in the recession cone of the set."
-  // -Tobia Marcucci
-  throw std::runtime_error(
-      "AffineSubspace::DoAddPointInNonnegativeScalingConstraints() is not "
-      "implemented yet.");
+    MathematicalProgram* prog,
+    const Eigen::Ref<const VectorXDecisionVariable>& x,
+    const Variable& t) const {
+  // If the affine dimension is zero, then we have a point, so we just use the
+  // method from the Point class.
+  std::vector<Binding<Constraint>> new_constraints;
+  const int n = ambient_dimension();
+  const int m = basis_.cols();
+  if (m == 0) {
+    Point p(translation_);
+    new_constraints = p.AddPointInNonnegativeScalingConstraints(prog, x, t);
+  } else {
+    // Suppose the ambient dimension is n and the affine dimension is m. We add
+    // the new variable y∈Rᵐ and impose the constraint x∈tS⊕rec(S), via
+    // x=basis*y + translation*t This is explicitly written as
+    // [-I, basis, translation][x; y; t] = 0.
+    VectorXDecisionVariable y = prog->NewContinuousVariables(m, "y");
+    MatrixXd A(n, n + m + 1);
+    A.leftCols(n) = -MatrixXd::Identity(n, n);
+    A.block(0, n, n, m) = basis_;
+    A.rightCols(1) = translation_;
+    new_constraints.push_back(prog->AddLinearEqualityConstraint(
+        A, VectorXd::Zero(n), {x, y, Vector1<Variable>(t)}));
+  }
+  return new_constraints;
 }
 
 std::vector<Binding<Constraint>>
 AffineSubspace::DoAddPointInNonnegativeScalingConstraints(
-    solvers::MathematicalProgram*, const Eigen::Ref<const MatrixXd>&,
-    const Eigen::Ref<const VectorXd>&, const Eigen::Ref<const VectorXd>&,
-    double, const Eigen::Ref<const VectorXDecisionVariable>&,
-    const Eigen::Ref<const VectorXDecisionVariable>&) const {
-  throw std::runtime_error(
-      "AffineSubspace::DoAddPointInNonnegativeScalingConstraints() is not "
-      "implemented yet.");
+    MathematicalProgram* prog, const Eigen::Ref<const MatrixXd>& A,
+    const Eigen::Ref<const VectorXd>& b, const Eigen::Ref<const VectorXd>& c,
+    double d, const Eigen::Ref<const VectorXDecisionVariable>& x,
+    const Eigen::Ref<const VectorXDecisionVariable>& t) const {
+  // If the affine dimension is zero, then we have a point, so we just use the
+  // method from the Point class.
+  std::vector<Binding<Constraint>> new_constraints;
+  const int n = ambient_dimension();
+  const int m = basis_.cols();
+  if (m == 0) {
+    Point p(translation_);
+    new_constraints =
+        p.AddPointInNonnegativeScalingConstraints(prog, A, b, c, d, x, t);
+  } else {
+    // Suppose the ambient dimension is n and the affine dimension is m. We add
+    // the new variable y∈Rᵐ and impose the constraint Ax+b∈(c'*t+d)S⊕rec(S),
+    // via Ax+b=basis*y + translation*(c'*t+d). This is explicitly written as
+    // [-A, basis, translation*c'][x; y; t] = b - translation*d.
+    const int k = x.size();
+    const int p = t.size();
+    VectorXDecisionVariable y = prog->NewContinuousVariables(m, "y");
+    MatrixXd constraint_A(n, k + m + p);
+    constraint_A.leftCols(k) = -A;
+    constraint_A.block(0, k, n, m) = basis_;
+    constraint_A.rightCols(p) = translation_ * c.transpose();
+    VectorXd constraint_b = b - d * translation_;
+    new_constraints.push_back(prog->AddLinearEqualityConstraint(
+        constraint_A, constraint_b, {x, y, t}));
+  }
+  return new_constraints;
 }
 
 std::pair<std::unique_ptr<Shape>, math::RigidTransformd>
@@ -259,13 +295,13 @@ double AffineSubspace::DoCalcVolume() const {
 }
 
 std::vector<std::optional<double>> AffineSubspace::DoProjectionShortcut(
-    const Eigen::Ref<const Eigen::MatrixXd>& points,
-    EigenPtr<Eigen::MatrixXd> projected_points) const {
+    const Eigen::Ref<const MatrixXd>& points,
+    EigenPtr<MatrixXd> projected_points) const {
   // If the set is a point, the projection is just that point. This also
   // directly handles the zero-dimensional case.
   const auto maybe_point = DoMaybeGetPoint();
   if (maybe_point) {
-    const Eigen::VectorXd eigen_dists =
+    const VectorXd eigen_dists =
         (points - maybe_point.value()).colwise().norm();
     std::vector<std::optional<double>> distances(
         eigen_dists.data(), eigen_dists.data() + eigen_dists.size());
@@ -276,35 +312,34 @@ std::vector<std::optional<double>> AffineSubspace::DoProjectionShortcut(
       // Outer product, which will return x.cols() copies of the feasible
       // point.
       *projected_points =
-          maybe_point.value() * Eigen::RowVectorXd::Ones(points.cols());
+          maybe_point.value() * RowVectorXd::Ones(points.cols());
       return distances;
     }
   }
-  const Eigen::MatrixXd least_squares =
+  const MatrixXd least_squares =
       basis_decomp_->solve(points.colwise() - translation_);
   *projected_points = (basis_ * least_squares).colwise() + translation_;
-  const Eigen::VectorXd eigen_dists =
-      (points - *projected_points).colwise().norm();
+  const VectorXd eigen_dists = (points - *projected_points).colwise().norm();
   std::vector<std::optional<double>> distances(
       eigen_dists.data(), eigen_dists.data() + eigen_dists.size());
   return distances;
 }
 
-Eigen::MatrixXd AffineSubspace::ToLocalCoordinates(
-    const Eigen::Ref<const Eigen::MatrixXd>& x) const {
+MatrixXd AffineSubspace::ToLocalCoordinates(
+    const Eigen::Ref<const MatrixXd>& x) const {
   DRAKE_THROW_UNLESS(x.rows() == ambient_dimension());
   // If the set is a point, then the basis is empty, so there are no local
   // coordinates. This behavior is handled by returning a length-zero vector.
   // This also directly handles the zero-dimensional case.
   auto maybe_point = DoMaybeGetPoint();
   if (maybe_point) {
-    return Eigen::MatrixXd::Zero(0, x.cols());
+    return MatrixXd::Zero(0, x.cols());
   }
   return basis_decomp_->solve(x.colwise() - translation_);
 }
 
-Eigen::MatrixXd AffineSubspace::ToGlobalCoordinates(
-    const Eigen::Ref<const Eigen::MatrixXd>& y) const {
+MatrixXd AffineSubspace::ToGlobalCoordinates(
+    const Eigen::Ref<const MatrixXd>& y) const {
   DRAKE_THROW_UNLESS(y.rows() == AffineDimension());
   return (basis_ * y).colwise() + translation_;
 }
@@ -335,7 +370,7 @@ bool AffineSubspace::IsNearlyEqualTo(const AffineSubspace& other,
   return ContainedIn(other, tol) && other.ContainedIn(*this, tol);
 }
 
-Eigen::MatrixXd AffineSubspace::OrthogonalComplementBasis() const {
+MatrixXd AffineSubspace::OrthogonalComplementBasis() const {
   // If we have a zero-dimensional AffineSubspace (i.e. a point), the
   // basis_decomp_ isn't constructed, and we just return a basis of the whole
   // space.

--- a/geometry/optimization/test/affine_subspace_test.cc
+++ b/geometry/optimization/test/affine_subspace_test.cc
@@ -19,8 +19,19 @@ namespace drake {
 namespace geometry {
 namespace optimization {
 
+using Eigen::MatrixXd;
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using solvers::Binding;
+using solvers::Constraint;
+using solvers::MathematicalProgram;
+using solvers::Solve;
+using solvers::VectorXDecisionVariable;
+using symbolic::Variable;
+
 void CheckOrthogonalComplementBasis(const AffineSubspace& as) {
-  Eigen::MatrixXd perpendicular_basis = as.OrthogonalComplementBasis();
+  MatrixXd perpendicular_basis = as.OrthogonalComplementBasis();
   EXPECT_EQ(perpendicular_basis.cols(),
             as.ambient_dimension() - as.AffineDimension());
   EXPECT_EQ(perpendicular_basis.rows(), as.ambient_dimension());
@@ -47,10 +58,10 @@ GTEST_TEST(AffineSubspaceTest, DefaultCtor) {
   EXPECT_TRUE(dut.MaybeGetPoint().has_value());
   ASSERT_TRUE(dut.MaybeGetFeasiblePoint().has_value());
   EXPECT_TRUE(dut.PointInSet(dut.MaybeGetFeasiblePoint().value()));
-  EXPECT_TRUE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
+  EXPECT_TRUE(dut.PointInSet(VectorXd::Zero(0)));
   EXPECT_TRUE(dut.IntersectsWith(dut));
   EXPECT_EQ(dut.AffineDimension(), 0);
-  Eigen::VectorXd test_point(0);
+  VectorXd test_point(0);
   EXPECT_EQ(dut.ToLocalCoordinates(test_point).size(), 0);
   EXPECT_TRUE(CompareMatrices(dut.ToLocalCoordinates(test_point), test_point));
   const auto projection_result = dut.Projection(test_point);
@@ -67,7 +78,7 @@ GTEST_TEST(AffineSubspaceTest, DefaultCtor) {
 
 GTEST_TEST(AffineSubspaceTest, Point) {
   Eigen::Matrix<double, 3, 0> basis;
-  Eigen::VectorXd translation(3);
+  VectorXd translation(3);
   translation << 1, 2, 3;
   const AffineSubspace as(basis, translation);
 
@@ -82,36 +93,36 @@ GTEST_TEST(AffineSubspaceTest, Point) {
   ASSERT_TRUE(as.MaybeGetFeasiblePoint().has_value());
   EXPECT_TRUE(as.PointInSet(as.MaybeGetFeasiblePoint().value()));
   EXPECT_TRUE(as.PointInSet(translation));
-  EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3)));
+  EXPECT_FALSE(as.PointInSet(VectorXd::Zero(3)));
   EXPECT_TRUE(as.IntersectsWith(as));
-  auto projection_result = as.Projection(Eigen::VectorXd::Zero(3));
+  auto projection_result = as.Projection(VectorXd::Zero(3));
   EXPECT_TRUE(as.PointInSet(std::get<1>(projection_result.value())));
   CheckOrthogonalComplementBasis(as);
   EXPECT_EQ(as.CalcVolume(), 0);
 
   // Should throw because the ambient dimension is wrong.
-  EXPECT_THROW(as.Projection(Eigen::VectorXd::Zero(1)), std::exception);
+  EXPECT_THROW(as.Projection(VectorXd::Zero(1)), std::exception);
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 0);
-  Eigen::VectorXd test_point(3);
+  VectorXd test_point(3);
   test_point << 42, 27, 0;
   EXPECT_EQ(as.ToLocalCoordinates(test_point).size(), 0);
-  EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point),
-                              Eigen::VectorXd::Zero(0)));
+  EXPECT_TRUE(
+      CompareMatrices(as.ToLocalCoordinates(test_point), VectorXd::Zero(0)));
   projection_result = as.Projection(test_point);
   const auto& [distances, projections] = projection_result.value();
   EXPECT_TRUE(CompareMatrices(
       as.ToGlobalCoordinates(as.ToLocalCoordinates(test_point)), projections));
   EXPECT_TRUE(CompareMatrices(
-      as.ToLocalCoordinates(as.ToGlobalCoordinates(Eigen::VectorXd::Zero(0))),
-      Eigen::VectorXd::Zero(0)));
+      as.ToLocalCoordinates(as.ToGlobalCoordinates(VectorXd::Zero(0))),
+      VectorXd::Zero(0)));
 }
 
 GTEST_TEST(AffineSubspaceTest, Line) {
   Eigen::Matrix<double, 3, 1> basis;
   basis << 1, 1, 0;
-  Eigen::VectorXd translation(3);
+  VectorXd translation(3);
   translation << 1, 0, 0;
   const AffineSubspace as(basis, translation);
 
@@ -128,12 +139,12 @@ GTEST_TEST(AffineSubspaceTest, Line) {
   ASSERT_TRUE(as.MaybeGetFeasiblePoint().has_value());
   EXPECT_TRUE(as.PointInSet(as.MaybeGetFeasiblePoint().value()));
   EXPECT_TRUE(as.PointInSet(translation));
-  Eigen::VectorXd test_point(3);
+  VectorXd test_point(3);
   test_point << 2, 1, 0;
   EXPECT_TRUE(as.PointInSet(test_point, kTol));
-  EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3), kTol));
+  EXPECT_FALSE(as.PointInSet(VectorXd::Zero(3), kTol));
   EXPECT_TRUE(as.IntersectsWith(as));
-  const auto projection_result = as.Projection(Eigen::VectorXd::Zero(3));
+  const auto projection_result = as.Projection(VectorXd::Zero(3));
   ASSERT_TRUE(projection_result.has_value());
   const auto& [distances, projections] = projection_result.value();
   EXPECT_TRUE(as.PointInSet(projections, kTol));
@@ -142,11 +153,11 @@ GTEST_TEST(AffineSubspaceTest, Line) {
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 1);
-  Eigen::VectorXd test_point2(3);
+  VectorXd test_point2(3);
   test_point2 << 2, 1, 1;
-  Eigen::VectorXd expected_project(3);
+  VectorXd expected_project(3);
   expected_project << 2, 1, 0;
-  Eigen::VectorXd expected_local_coords(1);
+  VectorXd expected_local_coords(1);
   expected_local_coords << 1;
   EXPECT_EQ(as.ToLocalCoordinates(test_point2).size(), 1);
   EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point2),
@@ -171,7 +182,7 @@ GTEST_TEST(AffineSubspaceTest, Plane) {
            0, 1,
            0, 0;
   // clang-format on
-  Eigen::VectorXd translation(3);
+  VectorXd translation(3);
   translation << 0, 0, 1;
   const AffineSubspace as(basis, translation);
 
@@ -188,12 +199,12 @@ GTEST_TEST(AffineSubspaceTest, Plane) {
   ASSERT_TRUE(as.MaybeGetFeasiblePoint().has_value());
   EXPECT_TRUE(as.PointInSet(as.MaybeGetFeasiblePoint().value()));
   EXPECT_TRUE(as.PointInSet(translation));
-  Eigen::VectorXd test_point(3);
+  VectorXd test_point(3);
   test_point << 43, -7, 1;
   EXPECT_TRUE(as.PointInSet(test_point));
-  EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(3)));
+  EXPECT_FALSE(as.PointInSet(VectorXd::Zero(3)));
   EXPECT_TRUE(as.IntersectsWith(as));
-  const auto projection_result = as.Projection(Eigen::VectorXd::Zero(3));
+  const auto projection_result = as.Projection(VectorXd::Zero(3));
   ASSERT_TRUE(projection_result.has_value());
   EXPECT_TRUE(as.PointInSet(std::get<1>(projection_result.value())));
   CheckOrthogonalComplementBasis(as);
@@ -201,11 +212,11 @@ GTEST_TEST(AffineSubspaceTest, Plane) {
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 2);
-  Eigen::VectorXd test_point2(3);
+  VectorXd test_point2(3);
   test_point2 << 42, 27, 0;
-  Eigen::VectorXd expected_project(3);
+  VectorXd expected_project(3);
   expected_project << 42, 27, 1;
-  Eigen::VectorXd expected_local_coords(2);
+  VectorXd expected_local_coords(2);
   expected_local_coords << 42, 27;
   EXPECT_EQ(as.ToLocalCoordinates(test_point2).size(), 2);
   EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point2),
@@ -228,7 +239,7 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR3) {
            0, 1, 0,
            0, 0, 1;
   // clang-format on
-  Eigen::VectorXd translation(3);
+  VectorXd translation(3);
   translation << 0, 0, 1;
   const AffineSubspace as(basis, translation);
 
@@ -245,12 +256,12 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR3) {
   ASSERT_TRUE(as.MaybeGetFeasiblePoint().has_value());
   EXPECT_TRUE(as.PointInSet(as.MaybeGetFeasiblePoint().value()));
   EXPECT_TRUE(as.PointInSet(translation));
-  Eigen::VectorXd test_point(3);
+  VectorXd test_point(3);
   test_point << 43, -7, 1;
   EXPECT_TRUE(as.PointInSet(test_point));
-  EXPECT_TRUE(as.PointInSet(Eigen::VectorXd::Zero(3)));
+  EXPECT_TRUE(as.PointInSet(VectorXd::Zero(3)));
   EXPECT_TRUE(as.IntersectsWith(as));
-  const auto projection_result = as.Projection(Eigen::VectorXd::Zero(3));
+  const auto projection_result = as.Projection(VectorXd::Zero(3));
   ASSERT_TRUE(projection_result.has_value());
   EXPECT_TRUE(as.PointInSet(std::get<1>(projection_result.value())));
   CheckOrthogonalComplementBasis(as);
@@ -258,11 +269,11 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR3) {
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 3);
-  Eigen::VectorXd test_point2(3);
+  VectorXd test_point2(3);
   test_point2 << 42, 27, 1;
-  Eigen::VectorXd expected_project(3);
+  VectorXd expected_project(3);
   expected_project << 42, 27, 1;
-  Eigen::VectorXd expected_local_coords(3);
+  VectorXd expected_local_coords(3);
   expected_local_coords << 42, 27, 0;
   EXPECT_EQ(as.ToLocalCoordinates(test_point2).size(), 3);
   EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point2),
@@ -284,7 +295,7 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR4) {
            0, 0, 1,
            0, 0, 0;
   // clang-format on
-  Eigen::VectorXd translation(4);
+  VectorXd translation(4);
   translation << 0, 0, 0, 1;
   const AffineSubspace as(basis, translation);
 
@@ -301,12 +312,12 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR4) {
   ASSERT_TRUE(as.MaybeGetFeasiblePoint().has_value());
   EXPECT_TRUE(as.PointInSet(as.MaybeGetFeasiblePoint().value()));
   EXPECT_TRUE(as.PointInSet(translation));
-  Eigen::VectorXd test_point(4);
+  VectorXd test_point(4);
   test_point << 43, -7, 1, 1;
   EXPECT_TRUE(as.PointInSet(test_point));
-  EXPECT_FALSE(as.PointInSet(Eigen::VectorXd::Zero(4)));
+  EXPECT_FALSE(as.PointInSet(VectorXd::Zero(4)));
   EXPECT_TRUE(as.IntersectsWith(as));
-  const auto projection_result = as.Projection(Eigen::VectorXd::Zero(4));
+  const auto projection_result = as.Projection(VectorXd::Zero(4));
   ASSERT_TRUE(projection_result.has_value());
   EXPECT_TRUE(as.PointInSet(std::get<1>(projection_result.value())));
   CheckOrthogonalComplementBasis(as);
@@ -314,11 +325,11 @@ GTEST_TEST(AffineSubspaceTest, VolumeInR4) {
 
   // Test local coordinates
   EXPECT_EQ(as.AffineDimension(), 3);
-  Eigen::VectorXd test_point2(4);
+  VectorXd test_point2(4);
   test_point2 << 42, 27, -7, 0;
-  Eigen::VectorXd expected_project(4);
+  VectorXd expected_project(4);
   expected_project << 42, 27, -7, 1;
-  Eigen::VectorXd expected_local_coords(3);
+  VectorXd expected_local_coords(3);
   expected_local_coords << 42, 27, -7;
   EXPECT_EQ(as.ToLocalCoordinates(test_point2).size(), 3);
   EXPECT_TRUE(CompareMatrices(as.ToLocalCoordinates(test_point2),
@@ -342,7 +353,7 @@ GTEST_TEST(AffineSubspaceTest, NotABasis1) {
            0, 1, 1;
   // clang-format on
 
-  Eigen::VectorXd translation(2);
+  VectorXd translation(2);
   translation << 0, 1;
   EXPECT_THROW(AffineSubspace(basis, translation), std::exception);
 }
@@ -357,7 +368,7 @@ GTEST_TEST(AffineSubspaceTest, NotABasis2) {
            0, 0;
   // clang-format on
 
-  Eigen::VectorXd translation(2);
+  VectorXd translation(2);
   translation << 0, 1;
   EXPECT_THROW(AffineSubspace(basis, translation), std::exception);
 }
@@ -369,7 +380,7 @@ GTEST_TEST(AffineSubspaceTest, Serialize) {
            0, 1,
            0, 0;
   // clang-format on
-  Eigen::VectorXd translation(3);
+  VectorXd translation(3);
   translation << 0, 0, 1;
   const AffineSubspace as(basis, translation);
   const std::string yaml = yaml::SaveYamlString(as);
@@ -386,7 +397,7 @@ GTEST_TEST(AffineSubspaceTest, Move) {
            0, 1,
            0, 0;
   // clang-format on
-  Eigen::VectorXd translation(3);
+  VectorXd translation(3);
   translation << 0, 0, 1;
   const AffineSubspace orig(basis, translation);
 
@@ -408,7 +419,7 @@ GTEST_TEST(AffineSubspaceTest, CloneTest) {
            0, 1,
            0, 0;
   // clang-format on
-  Eigen::VectorXd translation(3);
+  VectorXd translation(3);
   translation << 0, 0, 1;
   const AffineSubspace as(basis, translation);
 
@@ -427,13 +438,13 @@ GTEST_TEST(AffineSubspaceTest, PointInSetConstraints) {
            0, 1,
            0, 0;
   // clang-format on
-  Eigen::VectorXd translation(3);
+  VectorXd translation(3);
   translation << 0, 0, 1;
   const AffineSubspace as(basis, translation);
 
   const double kTol = 1e-11;
 
-  solvers::MathematicalProgram prog;
+  MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>();
   auto [new_vars, new_constraints] = as.AddPointInSetConstraints(&prog, x);
 
@@ -442,13 +453,112 @@ GTEST_TEST(AffineSubspaceTest, PointInSetConstraints) {
   EXPECT_EQ(new_constraints.size(), 1);
   EXPECT_EQ(new_vars.rows(), as.basis().cols());
 
-  auto result = solvers::Solve(prog);
+  auto result = Solve(prog);
   ASSERT_TRUE(result.is_success());
   const auto new_vars_val = result.GetSolution(new_vars);
-  const Eigen::Vector3d x_val = result.GetSolution(x);
+  const Vector3d x_val = result.GetSolution(x);
   EXPECT_TRUE(as.PointInSet(x_val, kTol));
   EXPECT_TRUE(
       CompareMatrices(x_val, as.basis() * new_vars_val + translation, kTol));
+}
+
+GTEST_TEST(AffineSubspaceTest, PointInNonnegativeScalingConstraints) {
+  Eigen::Matrix<double, 3, 2> basis;
+  // clang-format off
+  basis << 1, 0,
+           0, 1,
+           0, 0;
+  // clang-format on
+  VectorXd translation(3);
+  translation << 0, 0, 1;
+  const AffineSubspace as(basis, translation);
+
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables(3, "x");
+  auto t = prog.NewContinuousVariables(1, "t")[0];
+
+  std::vector<Binding<Constraint>> constraints =
+      as.AddPointInNonnegativeScalingConstraints(&prog, x, t);
+
+  EXPECT_EQ(constraints.size(), 2);
+
+  // Because the nonnegative scaling constraints rely on an additional (hidden)
+  // variable y, to check the constraint, we solve an optimization problem,
+  // fixing the values of x and t. Success implies a feasible value was found
+  // for the unconstrained variable y.
+
+  Vector3d x_test_value = Vector3d::Zero();
+  double t_test_value = 0;
+  auto x_constraint = prog.AddLinearEqualityConstraint(MatrixXd::Identity(3, 3),
+                                                       x_test_value, x);
+  auto t_constraint = prog.AddLinearEqualityConstraint(
+      MatrixXd::Identity(1, 1), Vector1d(t_test_value), Vector1<Variable>(t));
+
+  // Test values for x, t, and whether the constraint is satisfied.
+  const std::vector<std::tuple<Vector3d, double, bool>> test_x_t{
+      {Vector3d(-43.0, 43.0, 0.0), 0.0, true},
+      {Vector3d(-43.0, 43.0, 0.5), 0.5, true},
+      {Vector3d(-43.0, 43.0, 3.0), 3.0, true},
+      {Vector3d(-43.0, 43.0, -1.0), 0.0, false},
+      {Vector3d(-43.0, 43.0, -1.0), 1.0, false},
+      {Vector3d(-43.0, 43.0, 0.0), -1.0, false},
+      {Vector3d(-43.0, 43.0, 5.0), 0.0, false},
+      {Vector3d(-43.0, 43.0, 1.0), 0.5, false}};
+
+  for (const auto& [x_val, t_val, expect_success] : test_x_t) {
+    x_constraint.evaluator()->UpdateCoefficients(MatrixXd::Identity(3, 3),
+                                                 x_val);
+    t_constraint.evaluator()->UpdateCoefficients(MatrixXd::Identity(1, 1),
+                                                 Vector1d(t_val));
+    auto result = Solve(prog);
+    EXPECT_EQ(result.is_success(), expect_success);
+  }
+
+  MatrixXd A(3, 2);
+  // clang-format off
+  A << 1, 0,
+       0, 1,
+       2, 0;
+  // clang-format on
+  Vector3d b = Vector3d::Zero();
+  Vector2d c(1, -1);
+  double d = 0;
+
+  MathematicalProgram prog2;
+  auto x2 = prog2.NewContinuousVariables(2, "x");
+  auto t2 = prog2.NewContinuousVariables(2, "t");
+
+  std::vector<Binding<Constraint>> constraints2 =
+      as.AddPointInNonnegativeScalingConstraints(&prog2, A, b, c, d, x2, t2);
+
+  EXPECT_EQ(constraints2.size(), 2);
+
+  Vector2d x2_test_value = Vector2d::Zero();
+  Vector2d t2_test_value = Vector2d::Zero();
+  auto x2_constraint = prog2.AddLinearEqualityConstraint(
+      MatrixXd::Identity(2, 2), x2_test_value, x2);
+  auto t2_constraint = prog2.AddLinearEqualityConstraint(
+      MatrixXd::Identity(2, 2), t2_test_value, t2);
+
+  const std::vector<std::tuple<Vector2d, Vector2d, bool>> test_x2_t2{
+      {Vector2d{1.0, 1.0}, Vector2d{2.0, 0.0}, true},
+      {Vector2d(2.0, 1.0), Vector2d(4.0, 0.0), true},
+      {Vector2d(0.0, 1.0), Vector2d(0.0, 0.0), true},
+      {Vector2d(0.0, 1.0), Vector2d(1.0, 1.0), true},
+      {Vector2d(2.0, 1.0), Vector2d(0.0, -4.0), true},
+      {Vector2d{1.0, 1.0}, Vector2d{0.0, 0.0}, false},
+      {Vector2d{1.0, 1.0}, Vector2d{1.0, 0.0}, false},
+      {Vector2d{-1.0, 1.0}, Vector2d{0.0, 2.0}, false},
+      {Vector2d{-1.0, 1.0}, Vector2d{-2.0, 0.0}, false}};
+
+  for (const auto& [x2_val, t2_val, expect_success] : test_x2_t2) {
+    x2_constraint.evaluator()->UpdateCoefficients(MatrixXd::Identity(2, 2),
+                                                  x2_val);
+    t2_constraint.evaluator()->UpdateCoefficients(MatrixXd::Identity(2, 2),
+                                                  t2_val);
+    auto result2 = Solve(prog2);
+    EXPECT_EQ(result2.is_success(), expect_success);
+  }
 }
 
 // Check that the ConvexSet is contained in an AffineSubspace
@@ -458,22 +568,22 @@ bool CheckAffineSubspaceSetContainment(const AffineSubspace& as,
     // The empty set is contained in every affine subspace.
     return true;
   }
-  Eigen::VectorXd feasible_point = set.MaybeGetFeasiblePoint().value();
+  VectorXd feasible_point = set.MaybeGetFeasiblePoint().value();
   if (!as.PointInSet(feasible_point, tol)) {
     return false;
   }
 
-  solvers::MathematicalProgram prog;
+  MathematicalProgram prog;
 
   // x represents the offset relative to the feasible point. We add a bounding
   // box constraint to ensure the problem is not unbounded.
-  solvers::VectorXDecisionVariable x =
+  VectorXDecisionVariable x =
       prog.NewContinuousVariables(set.ambient_dimension(), "x");
   prog.AddBoundingBoxConstraint(-1, 1, x);
 
   // y represents the actual point we are finding, so as to constrain it
   // to lie within the convex set.
-  solvers::VectorXDecisionVariable y =
+  VectorXDecisionVariable y =
       prog.NewContinuousVariables(set.ambient_dimension(), "y");
   prog.AddLinearConstraint(y == x + feasible_point);
   set.AddPointInSetConstraints(&prog, y);
@@ -481,9 +591,8 @@ bool CheckAffineSubspaceSetContainment(const AffineSubspace& as,
   // This is the objective we use. We will iteratively try to minimize and
   // maximize the ith component of x for each dimension to find a feasible point
   // along that axis, and then check that it's contained in the affine hull.
-  Eigen::VectorXd new_objective_vector =
-      Eigen::VectorXd::Zero(set.ambient_dimension());
-  solvers::Binding<solvers::LinearCost> objective =
+  VectorXd new_objective_vector = VectorXd::Zero(set.ambient_dimension());
+  Binding<solvers::LinearCost> objective =
       prog.AddLinearCost(new_objective_vector, x);
 
   for (int i = 0; i < set.ambient_dimension(); ++i) {
@@ -491,7 +600,7 @@ bool CheckAffineSubspaceSetContainment(const AffineSubspace& as,
     new_objective_vector[i] = 1;
     objective.evaluator()->UpdateCoefficients(new_objective_vector);
 
-    auto result = solvers::Solve(prog);
+    auto result = Solve(prog);
     DRAKE_DEMAND(result.is_success());
     if (!as.PointInSet(result.GetSolution(y), tol)) {
       return false;
@@ -500,7 +609,7 @@ bool CheckAffineSubspaceSetContainment(const AffineSubspace& as,
     new_objective_vector[i] = -1;
     objective.evaluator()->UpdateCoefficients(new_objective_vector);
 
-    result = solvers::Solve(prog);
+    result = Solve(prog);
     DRAKE_DEMAND(result.is_success());
     if (!as.PointInSet(result.GetSolution(y), tol)) {
       return false;
@@ -523,12 +632,12 @@ void CheckAffineHullTightness(const AffineSubspace& as, const ConvexSet& set,
   ASSERT_TRUE(as.ambient_dimension() == set.ambient_dimension());
   ASSERT_FALSE(set.IsEmpty());
 
-  const Eigen::VectorXd translation = as.translation();
-  const Eigen::MatrixXd basis = as.basis();
+  const VectorXd translation = as.translation();
+  const MatrixXd basis = as.basis();
 
   for (int i = 0; i < basis.cols(); ++i) {
     const int right_cols_num = basis.cols() - i - 1;
-    Eigen::MatrixXd new_basis(basis.rows(), basis.cols() - 1);
+    MatrixXd new_basis(basis.rows(), basis.cols() - 1);
     new_basis << basis.leftCols(i), basis.rightCols(right_cols_num);
     const AffineSubspace new_as(new_basis, translation);
     EXPECT_FALSE(CheckAffineSubspaceSetContainment(new_as, set, tol));
@@ -537,7 +646,7 @@ void CheckAffineHullTightness(const AffineSubspace& as, const ConvexSet& set,
 
 GTEST_TEST(AffineSubspaceTest, AffineHullCartesianProduct) {
   // Point VPolytope
-  VPolytope point(Eigen::Vector2d(2, -1));
+  VPolytope point(Vector2d(2, -1));
 
   // Line segment VPolytope
   Eigen::Matrix<double, 3, 2> line_segment_points;
@@ -558,7 +667,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullCartesianProduct) {
 
   const double kTol = 1e-15;
 
-  Eigen::VectorXd test_point(5);
+  VectorXd test_point(5);
   test_point << 2, -1, 2, 2, 2;
   EXPECT_TRUE(as.PointInSet(test_point, kTol));
 
@@ -582,8 +691,8 @@ GTEST_TEST(AffineSubspaceTest, AffineHullHPolyhedron) {
   CheckAffineHullTightness(as1, h1, kTol);
 
   // Test a not-full-dimensional HPolyhedron.
-  Eigen::MatrixXd A2(6, 3);
-  Eigen::VectorXd b2(6);
+  MatrixXd A2(6, 3);
+  VectorXd b2(6);
 
   // clang-format off
   A2 <<  1,  0,  0,
@@ -638,7 +747,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullHyperellipsoid) {
   const math::RotationMatrixd R =
       math::RotationMatrixd::MakeZRotation(M_PI / 2.0);
   const Eigen::Matrix3d A = D * R.matrix();
-  const Eigen::Vector3d center{4.0, 5.0, 6.0};
+  const Vector3d center{4.0, 5.0, 6.0};
 
   Hyperellipsoid E(A, center);
   AffineSubspace as(E);
@@ -656,7 +765,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   // Point-Line intersection
 
   // Point VPolytope
-  VPolytope point(Eigen::Vector3d(0.5, 0.5, 0.5));
+  VPolytope point(Vector3d(0.5, 0.5, 0.5));
 
   // Line segment VPolytope
   Eigen::Matrix<double, 3, 2> line_segment_points;
@@ -671,8 +780,8 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   AffineSubspace as1(i1);
 
   const double kTol1 = 1e-6;
-  EXPECT_TRUE(i1.PointInSet(Eigen::Vector3d(0.5, 0.5, 0.5), kTol1));
-  EXPECT_TRUE(as1.PointInSet(Eigen::Vector3d(0.5, 0.5, 0.5), kTol1));
+  EXPECT_TRUE(i1.PointInSet(Vector3d(0.5, 0.5, 0.5), kTol1));
+  EXPECT_TRUE(as1.PointInSet(Vector3d(0.5, 0.5, 0.5), kTol1));
 
   EXPECT_EQ(as1.basis().cols(), 0);
   EXPECT_EQ(as1.basis().rows(), 3);
@@ -692,7 +801,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   AffineSubspace as2(i2);
 
   const double kTol2 = 1e-6;
-  const Eigen::Vector3d one_third(1. / 3., 1. / 3., 1. / 3.);
+  const Vector3d one_third(1. / 3., 1. / 3., 1. / 3.);
   EXPECT_TRUE(i2.PointInSet(one_third, kTol2));
   EXPECT_TRUE(as2.PointInSet(one_third, kTol2));
 
@@ -714,11 +823,11 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   AffineSubspace as3(i3);
 
   const double kTol3 = 1e-6;
-  EXPECT_TRUE(i3.PointInSet(Eigen::Vector3d(0, 0, 0), kTol3));
-  EXPECT_TRUE(i3.PointInSet(Eigen::Vector3d(1, 1, 1), kTol3));
+  EXPECT_TRUE(i3.PointInSet(Vector3d(0, 0, 0), kTol3));
+  EXPECT_TRUE(i3.PointInSet(Vector3d(1, 1, 1), kTol3));
 
-  EXPECT_TRUE(as3.PointInSet(Eigen::Vector3d(0, 0, 0), kTol3));
-  EXPECT_TRUE(as3.PointInSet(Eigen::Vector3d(1, 1, 1), kTol3));
+  EXPECT_TRUE(as3.PointInSet(Vector3d(0, 0, 0), kTol3));
+  EXPECT_TRUE(as3.PointInSet(Vector3d(1, 1, 1), kTol3));
 
   EXPECT_EQ(as3.basis().cols(), 1);
   EXPECT_EQ(as3.basis().rows(), 3);
@@ -742,11 +851,11 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
 
   // The numerics are much better with commerical solvers.
   const double kTol4 = 1e-6;
-  EXPECT_TRUE(i4.PointInSet(Eigen::Vector3d(0, 0, 0), kTol4));
-  EXPECT_TRUE(i4.PointInSet(Eigen::Vector3d(1, 1, 0), kTol4));
+  EXPECT_TRUE(i4.PointInSet(Vector3d(0, 0, 0), kTol4));
+  EXPECT_TRUE(i4.PointInSet(Vector3d(1, 1, 0), kTol4));
 
-  EXPECT_TRUE(as4.PointInSet(Eigen::Vector3d(0, 0, 0), kTol4));
-  EXPECT_TRUE(as4.PointInSet(Eigen::Vector3d(1, 1, 0), kTol4));
+  EXPECT_TRUE(as4.PointInSet(Vector3d(0, 0, 0), kTol4));
+  EXPECT_TRUE(as4.PointInSet(Vector3d(1, 1, 0), kTol4));
 
   EXPECT_EQ(as4.basis().cols(), 1);
   EXPECT_EQ(as4.basis().rows(), 3);
@@ -771,13 +880,13 @@ GTEST_TEST(AffineSubspaceTest, AffineHullIntersection) {
   EXPECT_EQ(as5.basis().cols(), 2);
 
   const double kTol5 = 1e-6;
-  EXPECT_TRUE(i5.PointInSet(Eigen::Vector3d(0, 0, 0), kTol5));
-  EXPECT_TRUE(i5.PointInSet(Eigen::Vector3d(1, 1, 0), kTol5));
-  EXPECT_TRUE(i5.PointInSet(Eigen::Vector3d(1, 1, 1), kTol5));
+  EXPECT_TRUE(i5.PointInSet(Vector3d(0, 0, 0), kTol5));
+  EXPECT_TRUE(i5.PointInSet(Vector3d(1, 1, 0), kTol5));
+  EXPECT_TRUE(i5.PointInSet(Vector3d(1, 1, 1), kTol5));
 
-  EXPECT_TRUE(as5.PointInSet(Eigen::Vector3d(0, 0, 0), kTol5));
-  EXPECT_TRUE(as5.PointInSet(Eigen::Vector3d(1, 1, 0), kTol5));
-  EXPECT_TRUE(as5.PointInSet(Eigen::Vector3d(1, 1, 1), kTol5));
+  EXPECT_TRUE(as5.PointInSet(Vector3d(0, 0, 0), kTol5));
+  EXPECT_TRUE(as5.PointInSet(Vector3d(1, 1, 0), kTol5));
+  EXPECT_TRUE(as5.PointInSet(Vector3d(1, 1, 1), kTol5));
 
   EXPECT_EQ(as5.basis().cols(), 2);
   EXPECT_EQ(as5.basis().rows(), 3);
@@ -815,11 +924,11 @@ GTEST_TEST(AffineSubspaceTest, AffineHullMinkowskiSum) {
   AffineSubspace as1(ms1);
 
   const double kTol = 1e-12;
-  EXPECT_TRUE(ms1.PointInSet(Eigen::Vector3d(2, 2, 2), kTol));
-  EXPECT_TRUE(ms1.PointInSet(Eigen::Vector3d(4, 4, 4), kTol));
+  EXPECT_TRUE(ms1.PointInSet(Vector3d(2, 2, 2), kTol));
+  EXPECT_TRUE(ms1.PointInSet(Vector3d(4, 4, 4), kTol));
 
-  EXPECT_TRUE(as1.PointInSet(Eigen::Vector3d(2, 2, 2), kTol));
-  EXPECT_TRUE(as1.PointInSet(Eigen::Vector3d(4, 4, 4), kTol));
+  EXPECT_TRUE(as1.PointInSet(Vector3d(2, 2, 2), kTol));
+  EXPECT_TRUE(as1.PointInSet(Vector3d(4, 4, 4), kTol));
 
   EXPECT_EQ(as1.basis().cols(), 1);
   EXPECT_EQ(as1.basis().rows(), 3);
@@ -841,13 +950,13 @@ GTEST_TEST(AffineSubspaceTest, AffineHullMinkowskiSum) {
   MinkowskiSum ms2(line_segment1, line_segment3);
   AffineSubspace as2(ms2);
 
-  EXPECT_TRUE(ms2.PointInSet(Eigen::Vector3d(0, 0, 0), kTol));
-  EXPECT_TRUE(ms2.PointInSet(Eigen::Vector3d(1, 0, 0), kTol));
-  EXPECT_TRUE(ms2.PointInSet(Eigen::Vector3d(1, 1, 1), kTol));
+  EXPECT_TRUE(ms2.PointInSet(Vector3d(0, 0, 0), kTol));
+  EXPECT_TRUE(ms2.PointInSet(Vector3d(1, 0, 0), kTol));
+  EXPECT_TRUE(ms2.PointInSet(Vector3d(1, 1, 1), kTol));
 
-  EXPECT_TRUE(as2.PointInSet(Eigen::Vector3d(0, 0, 0), kTol));
-  EXPECT_TRUE(as2.PointInSet(Eigen::Vector3d(1, 0, 0), kTol));
-  EXPECT_TRUE(as2.PointInSet(Eigen::Vector3d(1, 1, 1), kTol));
+  EXPECT_TRUE(as2.PointInSet(Vector3d(0, 0, 0), kTol));
+  EXPECT_TRUE(as2.PointInSet(Vector3d(1, 0, 0), kTol));
+  EXPECT_TRUE(as2.PointInSet(Vector3d(1, 1, 1), kTol));
 
   EXPECT_EQ(as2.basis().cols(), 2);
   EXPECT_EQ(as2.basis().rows(), 3);
@@ -869,15 +978,15 @@ GTEST_TEST(AffineSubspaceTest, AffineHullMinkowskiSum) {
   MinkowskiSum ms3(line_segment3, triangle);
   AffineSubspace as3(ms3);
 
-  EXPECT_TRUE(ms3.PointInSet(Eigen::Vector3d(0, 1, 0), kTol));
-  EXPECT_TRUE(ms3.PointInSet(Eigen::Vector3d(0, 0, 1), kTol));
-  EXPECT_TRUE(ms3.PointInSet(Eigen::Vector3d(0, 1, 1), kTol));
-  EXPECT_TRUE(ms3.PointInSet(Eigen::Vector3d(1, 1, 1), kTol));
+  EXPECT_TRUE(ms3.PointInSet(Vector3d(0, 1, 0), kTol));
+  EXPECT_TRUE(ms3.PointInSet(Vector3d(0, 0, 1), kTol));
+  EXPECT_TRUE(ms3.PointInSet(Vector3d(0, 1, 1), kTol));
+  EXPECT_TRUE(ms3.PointInSet(Vector3d(1, 1, 1), kTol));
 
-  EXPECT_TRUE(as3.PointInSet(Eigen::Vector3d(0, 1, 0), kTol));
-  EXPECT_TRUE(as3.PointInSet(Eigen::Vector3d(0, 0, 1), kTol));
-  EXPECT_TRUE(as3.PointInSet(Eigen::Vector3d(0, 1, 1), kTol));
-  EXPECT_TRUE(as3.PointInSet(Eigen::Vector3d(1, 1, 1), kTol));
+  EXPECT_TRUE(as3.PointInSet(Vector3d(0, 1, 0), kTol));
+  EXPECT_TRUE(as3.PointInSet(Vector3d(0, 0, 1), kTol));
+  EXPECT_TRUE(as3.PointInSet(Vector3d(0, 1, 1), kTol));
+  EXPECT_TRUE(as3.PointInSet(Vector3d(1, 1, 1), kTol));
 
   EXPECT_EQ(as3.basis().cols(), 3);
   EXPECT_EQ(as3.basis().rows(), 3);
@@ -889,7 +998,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullMinkowskiSum) {
 }
 
 GTEST_TEST(AffineSubspaceTest, AffineHullPoint) {
-  const Eigen::Vector3d p_value{4.2, 2.7, 0.0};
+  const Vector3d p_value{4.2, 2.7, 0.0};
   Point p(p_value);
   AffineSubspace as(p);
 
@@ -927,7 +1036,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullSpectrahedron) {
   // matrix has 6 unique entries, and the remaining 3 are not considered part
   // of the ambient space.) This spectrahedron has 1 additional equality
   // constraint, so its affine dimension should be 5.
-  solvers::MathematicalProgram prog;
+  MathematicalProgram prog;
   auto X1 = prog.NewSymmetricContinuousVariables<3>();
   prog.AddLinearCost(-(X1(0, 1) + X1(1, 2)));
   prog.AddPositiveSemidefiniteConstraint(X1);
@@ -958,7 +1067,7 @@ GTEST_TEST(AffineSubspaceTest, AffineHullVPolytope) {
   EXPECT_THROW(AffineSubspace{dut}, std::exception);
 
   // Check a point as a VPolytope
-  Eigen::Vector3d point(2, -1, 0);
+  Vector3d point(2, -1, 0);
   VPolytope v(point);
   AffineSubspace as1(v);
 
@@ -967,8 +1076,8 @@ GTEST_TEST(AffineSubspaceTest, AffineHullVPolytope) {
   EXPECT_EQ(as1.translation().size(), 3);
   EXPECT_EQ(as1.ambient_dimension(), 3);
 
-  EXPECT_TRUE(as1.PointInSet(Eigen::Vector3d(2, -1, 0), kTol));
-  EXPECT_FALSE(as1.PointInSet(Eigen::Vector3d(2, -1, 1), kTol));
+  EXPECT_TRUE(as1.PointInSet(Vector3d(2, -1, 0), kTol));
+  EXPECT_FALSE(as1.PointInSet(Vector3d(2, -1, 1), kTol));
   EXPECT_TRUE(CheckAffineSubspaceSetContainment(as1, v));
   CheckAffineHullTightness(as1, v);
 
@@ -987,8 +1096,8 @@ GTEST_TEST(AffineSubspaceTest, AffineHullVPolytope) {
   EXPECT_EQ(as2.translation().size(), 3);
   EXPECT_EQ(as2.ambient_dimension(), 3);
 
-  EXPECT_TRUE(as2.PointInSet(Eigen::Vector3d(2, 2, 2), kTol));
-  EXPECT_FALSE(as2.PointInSet(Eigen::Vector3d(2, 2, 0), kTol));
+  EXPECT_TRUE(as2.PointInSet(Vector3d(2, 2, 2), kTol));
+  EXPECT_FALSE(as2.PointInSet(Vector3d(2, 2, 0), kTol));
   EXPECT_TRUE(CheckAffineSubspaceSetContainment(as2, line_segment, kTol));
   CheckAffineHullTightness(as2, line_segment);
 
@@ -1007,8 +1116,8 @@ GTEST_TEST(AffineSubspaceTest, AffineHullVPolytope) {
   EXPECT_EQ(as3.translation().size(), 3);
   EXPECT_EQ(as3.ambient_dimension(), 3);
 
-  EXPECT_TRUE(as3.PointInSet(Eigen::Vector3d(42, 27, 0), kTol));
-  EXPECT_FALSE(as3.PointInSet(Eigen::Vector3d(42, 27, 1), kTol));
+  EXPECT_TRUE(as3.PointInSet(Vector3d(42, 27, 0), kTol));
+  EXPECT_FALSE(as3.PointInSet(Vector3d(42, 27, 1), kTol));
   EXPECT_TRUE(CheckAffineSubspaceSetContainment(as3, triangle));
   CheckAffineHullTightness(as3, triangle);
 }
@@ -1022,7 +1131,7 @@ GTEST_TEST(AffineSubspaceTest, BatchChangeOfCoordinates) {
            0, 1,
            0, 0;
   // clang-format on
-  Eigen::VectorXd translation(3);
+  VectorXd translation(3);
   translation << 0, 0, 1;
   const AffineSubspace as(basis, translation);
 
@@ -1040,7 +1149,7 @@ GTEST_TEST(AffineSubspaceTest, BatchChangeOfCoordinates) {
         projections.col(i), std::get<1>(as.Projection(points.col(i)).value())));
   }
 
-  Eigen::MatrixXd local = as.ToLocalCoordinates(points);
+  MatrixXd local = as.ToLocalCoordinates(points);
   EXPECT_EQ(local.rows(), 2);
   EXPECT_EQ(local.cols(), 5);
   for (int i = 0; i < points.cols(); ++i) {
@@ -1048,7 +1157,7 @@ GTEST_TEST(AffineSubspaceTest, BatchChangeOfCoordinates) {
         CompareMatrices(local.col(i), as.ToLocalCoordinates(points.col(i))));
   }
 
-  Eigen::MatrixXd global = as.ToGlobalCoordinates(local);
+  MatrixXd global = as.ToGlobalCoordinates(local);
   EXPECT_EQ(global.rows(), 3);
   EXPECT_EQ(global.cols(), 5);
   for (int i = 0; i < local.cols(); ++i) {
@@ -1064,7 +1173,7 @@ GTEST_TEST(AffineSubspaceTest, ContainmentTest) {
             1,
             0;
   // clang-format on
-  Eigen::VectorXd translation1(3);
+  VectorXd translation1(3);
   translation1 << 0, 0, 1;
   const AffineSubspace as1(basis1, translation1);
 
@@ -1074,7 +1183,7 @@ GTEST_TEST(AffineSubspaceTest, ContainmentTest) {
             0, 1,
             0, 0;
   // clang-format on
-  Eigen::VectorXd translation2(3);
+  VectorXd translation2(3);
   translation2 << 1, 1, 1;
   const AffineSubspace as2(basis2, translation2);
 
@@ -1092,7 +1201,7 @@ GTEST_TEST(AffineSubspaceTest, CompareDifferentDimensions) {
   basis1 << 1,
             0;
   // clang-format on
-  Eigen::VectorXd translation1(2);
+  VectorXd translation1(2);
   translation1 << 0, 1;
   const AffineSubspace as1(basis1, translation1);
 
@@ -1102,7 +1211,7 @@ GTEST_TEST(AffineSubspaceTest, CompareDifferentDimensions) {
             0, 1,
             0, 0;
   // clang-format on
-  Eigen::VectorXd translation2(3);
+  VectorXd translation2(3);
   translation2 << 0, 0, 1;
   const AffineSubspace as2(basis2, translation2);
 
@@ -1121,7 +1230,7 @@ GTEST_TEST(AffineSubspaceTest, EqualityTest) {
             0, 1,
             0, 0;
   // clang-format on
-  Eigen::VectorXd translation1(3);
+  VectorXd translation1(3);
   translation1 << 0, 0, 1;
 
   Eigen::Matrix<double, 3, 2> basis2;
@@ -1130,7 +1239,7 @@ GTEST_TEST(AffineSubspaceTest, EqualityTest) {
             1, -1,
             0, 0;
   // clang-format on
-  Eigen::VectorXd translation2(3);
+  VectorXd translation2(3);
   translation2 << 1, 1, 1;
 
   const AffineSubspace as1(basis1, translation1);
@@ -1166,9 +1275,9 @@ GTEST_TEST(AffineSubspaceTest, EqualityTest2) {
             -1, 1,
             0, -1;
   // clang-format on
-  Eigen::VectorXd translation1(3);
+  VectorXd translation1(3);
   translation1 << 0, 0, 1;
-  Eigen::VectorXd translation2(3);
+  VectorXd translation2(3);
   translation2 << 0, 1, 0;
 
   const AffineSubspace as1(basis1, translation1);
@@ -1190,7 +1299,7 @@ GTEST_TEST(AffineSubspaceTest, DeliberatelyLooseTolerance) {
   basis1 << 1, 0;
   Eigen::Matrix<double, 2, 1> basis2;
   basis2 << 0, 1;
-  Eigen::VectorXd translation(2);
+  VectorXd translation(2);
   translation << 0, 0;
 
   const AffineSubspace as1(basis1, translation);


### PR DESCRIPTION
Previously, this method had not been implemented, since it's only used in `GraphOfConvexSets`, where one generally doesn't want to deal with unbounded sets. However, if a user creates an `Intersection` of a bounded set with an `AffineSubspace`, the resulting set will also be bounded.

One may want to do this, for example, to restrict motion along an affine subspace in GcsTrajectoryOptimization. (We did this for our bimanual manipulation paper to fix the grasp distance, whereas our regions allowed varying grasp distance. Having this feature implemented would have simplified our code.)

cc @lujieyang @hjsuh94 

Not sure who makes the most sense for feature review. Maybe +@hongkai-dai? @TobiaMarcucci, it would be great if you could give my math a sanity check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21874)
<!-- Reviewable:end -->
