### PR TITLE
[tools] Clarify cpplint_unittest spelling

### DIFF
--- a/tools/workspace/styleguide/BUILD.bazel
+++ b/tools/workspace/styleguide/BUILD.bazel
@@ -4,7 +4,9 @@ load("//tools/skylark:py.bzl", "py_test")
 py_test(
     name = "cpplint_unittest",
     size = "small",
-    srcs = ["@styleguide//:cpplint_unittest"],
+    srcs = ["@styleguide//:test_files"],
+    data = ["@styleguide//:test_files"],
+    main = "@styleguide//:cpplint/cpplint_unittest.py",
     tags = ["no_kcov"],
 )
 

--- a/tools/workspace/styleguide/package.BUILD.bazel
+++ b/tools/workspace/styleguide/package.BUILD.bazel
@@ -29,18 +29,12 @@ alias(
     actual = ":cpplint_binary",
 )
 
-# We use py_binary here because externals' tests are not run by
-# default during `bazel test //...`, so `py_test` here would be
-# misleading.  We can't even `alias()` the test into Drake due to
-# https://github.com/bazelbuild/bazel/issues/10893
-py_binary(
-    name = "cpplint_unittest",
-    srcs = ["cpplint/cpplint_unittest.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
-    data = [
+filegroup(
+    name = "test_files",
+    testonly = True,
+    srcs = [
+        "cpplint/cpplint.py",
         "cpplint/cpplint_test_header.h",
+        "cpplint/cpplint_unittest.py",
     ],
-    deps = ["cpplint_binary"],
-    testonly = 1,
 )


### PR DESCRIPTION
Having both `py_binary` and `py_test` targets is brittle and confusing for maintainers. Remove the `py_binary` and use a filegroup instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21877)
<!-- Reviewable:end -->
