### PR TITLE
Deprecate Mesh and Convex::filename() method (in favor of source())

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -5,6 +5,7 @@
  the pydrake.geometry module. */
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/identifier_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
@@ -500,7 +501,6 @@ void DefineShapes(py::module m) {
         .def(py::init<MeshSource, double>(), py::arg("source"),
             py::arg("scale") = 1.0, doc.Convex.ctor.doc_2args_source_scale)
         .def("source", &Convex::source, doc.Convex.source.doc)
-        .def("filename", &Convex::filename, doc.Convex.filename.doc)
         .def("extension", &Convex::extension, doc.Convex.extension.doc)
         .def("scale", &Convex::scale, doc.Convex.scale.doc)
         .def("GetConvexHull", &Convex::GetConvexHull,
@@ -514,6 +514,13 @@ void DefineShapes(py::module m) {
             }));
     // Note: Convex.__repr__ is redefined in _geometry_extra.py;
     // Shape::to_string() does not properly condition strings for python.
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    convex_cls.def("filename",
+        WrapDeprecated(doc.Convex.filename.doc_deprecated, &Convex::filename),
+        doc.Convex.filename.doc_deprecated);
+#pragma GCC diagnostic pop
 
     py::class_<Cylinder, Shape>(m, "Cylinder", doc.Cylinder.doc)
         .def(py::init<double, double>(), py::arg("radius"), py::arg("length"),
@@ -561,7 +568,6 @@ void DefineShapes(py::module m) {
         .def(py::init<MeshSource, double>(), py::arg("source"),
             py::arg("scale") = 1.0, doc.Mesh.ctor.doc_2args_source_scale)
         .def("source", &Mesh::source, doc.Mesh.source.doc)
-        .def("filename", &Mesh::filename, doc.Mesh.filename.doc)
         .def("extension", &Mesh::extension, doc.Mesh.extension.doc)
         .def("scale", &Mesh::scale, doc.Mesh.scale.doc)
         .def("GetConvexHull", &Mesh::GetConvexHull, doc.Mesh.GetConvexHull.doc)
@@ -574,6 +580,13 @@ void DefineShapes(py::module m) {
             }));
     // Note: Convex.__repr__ is redefined in _geometry_extra.py;
     // Shape::to_string() does not properly condition strings for python.
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    mesh_cls.def("filename",
+        WrapDeprecated(doc.Mesh.filename.doc_deprecated, &Mesh::filename),
+        doc.Mesh.filename.doc_deprecated);
+#pragma GCC diagnostic pop
 
     py::class_<Sphere, Shape>(m, "Sphere", doc.Sphere.doc)
         .def(py::init<double>(), py::arg("radius"), doc.Sphere.ctor.doc)

--- a/bindings/pydrake/geometry/test/common_test.py
+++ b/bindings/pydrake/geometry/test/common_test.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from pydrake.common import MemoryFile
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.common.value import AbstractValue, Value
 from pydrake.common.yaml import yaml_load_typed
@@ -616,14 +617,15 @@ class TestGeometryCore(unittest.TestCase):
             self.assertEqual(".ext", dut_mesh.extension())
             self.assertEqual(dut_mesh.scale(), 1.5)
             self.assertIsInstance(dut_mesh.source(), mut.MeshSource)
-            if dut_mesh.source().is_path():
-                self.assertIn(junk_path, dut_mesh.filename())
-                with self.assertRaisesRegex(RuntimeError,
-                                            "MakeConvexHull only applies to"):
-                    # We just need evidence that it invokes convex hull
-                    # machinery; the exception for a bad extension suffices.
-                    dut_mesh.GetConvexHull()
+            with self.assertRaisesRegex(RuntimeError,
+                                        "MakeConvexHull only applies to"):
+                # We just need evidence that it invokes convex hull
+                # machinery; the exception for a bad extension suffices.
+                dut_mesh.GetConvexHull()
             assert_pickle(self, dut_mesh, repr)
+            if dut_mesh.source().is_path():
+                with catch_drake_warnings(expected_count=1):
+                    self.assertIn(junk_path, dut_mesh.filename())
 
         sphere = mut.Sphere(radius=1.0)
         assert_shape_api(sphere)

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -6,6 +6,7 @@
 #include <variant>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/geometry/mesh_source.h"
@@ -265,8 +266,8 @@ class Convex final : public Shape {
                                 considering revisiting the model itself. */
   explicit Convex(const std::filesystem::path& filename, double scale = 1.0);
 
-  /** (Internal use only) Constructs a convex shape specification from the
-   contents of a Drake-supported mesh file type.
+  /** Constructs a convex shape specification from the contents of a
+   Drake-supported mesh file type.
 
    The mesh is defined by the contents of a @ref supported_file_types
    "mesh file format supported by Drake". Those contents are passed in as
@@ -279,8 +280,7 @@ class Convex final : public Shape {
    @param scale       An optional scale to coordinates. */
   explicit Convex(InMemoryMesh mesh_data, double scale = 1.0);
 
-  /** (Internal use only) Constructs a convex shape specification from the given
-   `source`.
+  /** Constructs a convex shape specification from the given `source`.
 
    @param source   The source for the mesh data.
    @param scale    An optional scale to coordinates. */
@@ -288,21 +288,33 @@ class Convex final : public Shape {
 
   ~Convex() final;
 
-  /** (Internal use only) Returns the source for this specification's mesh data.
-   When working with %Convex, this API should only be used for introspection.
-   The contract for %Convex is that the convex hull is always used in place of
-   whatever underlying mesh declaration is provided. For all functional
-   geometric usage, exclusively use the convex hull returned by GetConvexHull().
-   */
+  /** Returns the source for this specification's mesh data. When working with
+   %Convex, this API should only be used for introspection. The contract for
+   %Convex is that the convex hull is always used in place of whatever
+   underlying mesh declaration is provided. For all functional geometric
+   usage, exclusively use the convex hull returned by GetConvexHull(). */
   const MeshSource& source() const { return source_; }
 
+  /** Returns the filename passed to the constructor.
+   @throws std::exception if `this` %Convex was constructed using in-memory file
+                          contents.
+   @see source().is_path(). */
+  DRAKE_DEPRECATED(
+      "2025-04-01",
+      "Convex shapes can be defined from a file path or in memory data. Use "
+      "Convex::source() to determine if a filename is available.")
   std::string filename() const;
 
-  /** Returns the extension of the mesh filename -- all lower case and including
-   the dot. In other words /foo/bar/mesh.obj and /foo/bar/mesh.OBJ would both
-   report the ".obj" extension. The "extension" portion of the filename is
-   defined as in std::filesystem::path::extension(). */
+  /** Returns the extension of the underlying input mesh -- all lower case and
+   including the dot. If `this` is constructed from a file path, the extension
+   is extracted from the path. I.e., /foo/bar/mesh.obj and /foo/bar/mesh.OBJ
+   would both report the ".obj" extension. The "extension" portion of the
+   filename is defined as in std::filesystem::path::extension().
+
+   If `this` is constructed using in-memory file contents, it is the extension
+   of the MemoryFile passed to the constructor. */
   const std::string& extension() const { return source_.extension(); }
+
   double scale() const { return scale_; }
 
   /** Reports the convex hull of the named mesh.
@@ -492,8 +504,8 @@ class Mesh final : public Shape {
                                 considering revisiting the model itself. */
   explicit Mesh(const std::filesystem::path& filename, double scale = 1.0);
 
-  /** (Internal use only) Constructs a mesh shape specification from the
-   contents of a Drake-supported mesh file type.
+  /** Constructs a mesh shape specification from the contents of a
+   Drake-supported mesh file type.
 
    The mesh is defined by the contents of a @ref supported_file_types
    "mesh file format supported by Drake". Those contents are passed in as
@@ -505,8 +517,7 @@ class Mesh final : public Shape {
    @param scale       An optional scale to coordinates. */
   explicit Mesh(InMemoryMesh mesh_data, double scale = 1.0);
 
-  /** (Internal use only) Constructs a mesh shape specification from the given
-   `source`.
+  /** Constructs a mesh shape specification from the given `source`.
 
    @param source   The source for the mesh data.
    @param scale    An optional scale to coordinates. */
@@ -514,16 +525,27 @@ class Mesh final : public Shape {
 
   ~Mesh() final;
 
-  /** (Internal use only) Returns the source for this specification's mesh data.
-   */
+  /** Returns the source for this specification's mesh data. */
   const MeshSource& source() const { return source_; }
 
+  /** Returns the filename passed to the constructor.
+   @throws std::exception if `this` %Mesh was constructed using in-memory file
+                          contents.
+   @see source().is_path(). */
+  DRAKE_DEPRECATED(
+      "2025-04-01",
+      "Meshes can be defined from a file path or in memory data. Use "
+      "Mesh::source() to determine if a filename is available.")
   std::string filename() const;
 
-  /** Returns the extension of the mesh filename -- all lower case and including
-   the dot. In other words /foo/bar/mesh.obj and /foo/bar/mesh.OBJ would both
-   report the ".obj" extension. The "extension" portion of the filename is
-   defined as in std::filesystem::path::extension(). */
+  /** Returns the extension of the mesh type -- all lower case and including
+   the dot. If `this` is constructed from a file path, the extension is
+   extracted from the path. I.e., /foo/bar/mesh.obj and /foo/bar/mesh.OBJ would
+   both report the ".obj" extension. The "extension" portion of the filename is
+   defined as in std::filesystem::path::extension().
+
+   If `this` is constructed using in-memory file contents, it is the extension
+   of the MemoryFile passed to the constructor. */
   const std::string& extension() const { return source_.extension(); }
 
   double scale() const { return scale_; }

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -404,9 +404,9 @@ void ShapeMatcher<Capsule>::TestShapeParameters(const Capsule& test) {
 template <>
 template <>
 void ShapeMatcher<Mesh>::TestShapeParameters(const Mesh& test) {
-  if (test.filename() != expected_.filename()) {
-    error() << "\nExpected mesh filename " << expected_.filename() << ", "
-            << "received mesh filename " << test.filename();
+  if (test.source().description() != expected_.source().description()) {
+    error() << "\nExpected description " << expected_.source().description()
+            << ", received description " << test.source().description();
   }
   if (test.scale() != expected_.scale()) {
     error() << "\nExpected mesh scale " << expected_.scale()
@@ -417,9 +417,9 @@ void ShapeMatcher<Mesh>::TestShapeParameters(const Mesh& test) {
 template <>
 template <>
 void ShapeMatcher<Convex>::TestShapeParameters(const Convex& test) {
-  if (test.filename() != expected_.filename()) {
-    error() << "\nExpected convex filename " << expected_.filename() << ", "
-            << "received convex filename " << test.filename();
+  if (test.source().description() != expected_.source().description()) {
+    error() << "\nExpected description " << expected_.source().description()
+            << ", received description " << test.source().description();
   }
   if (test.scale() != expected_.scale()) {
     error() << "\nExpected convex scale " << expected_.scale()

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -329,7 +329,7 @@ GTEST_TEST(ProximityEngineTests, HydroelasticAabbInflation) {
   const Box box(1, 1, 1);
 
   const Mesh mesh{FindResourceOrThrow("drake/geometry/test/octahedron.obj")};
-  const Convex convex(mesh.filename());
+  const Convex convex(mesh.source());
   const Vector3d mesh_min(-1, -1, -1.414213562373);
   const Vector3d mesh_max = -mesh_min;
 

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -477,7 +477,10 @@ GTEST_TEST(ShapeTest, Constructors) {
   EXPECT_EQ(convex.source().description(), kFilename);
   EXPECT_EQ(convex.extension(), ".obj");
   EXPECT_EQ(convex.scale(), 1.5);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_EQ(convex.filename(), kFilename);
+#pragma GCC diagnostic pop
 
   const Cylinder cylinder{1, 2};
   EXPECT_EQ(cylinder.radius(), 1);
@@ -504,7 +507,10 @@ GTEST_TEST(ShapeTest, Constructors) {
   EXPECT_EQ(mesh.source().description(), kFilename);
   EXPECT_EQ(mesh.extension(), ".obj");
   EXPECT_EQ(mesh.scale(), 1.4);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_EQ(mesh.filename(), kFilename);
+#pragma GCC diagnostic pop
 
   const MeshcatCone cone{1.2, 3.4, 5.6};
   EXPECT_EQ(cone.height(), 1.2);
@@ -636,7 +642,10 @@ GTEST_TEST(ShapeTest, ConvexFromMemory) {
   ASSERT_TRUE(source.is_in_memory());
   EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_THROW(convex.filename(), std::exception);
+#pragma GCC diagnostic pop
 
   const Convex from_source(source, 3.0);
   ASSERT_TRUE(from_source.source().is_in_memory());
@@ -676,7 +685,10 @@ GTEST_TEST(ShapeTest, MeshFromMemory) {
   ASSERT_TRUE(source.is_in_memory());
   EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_THROW(mesh.filename(), std::exception);
+#pragma GCC diagnostic pop
 
   const Mesh from_source(source, 3.0);
   ASSERT_TRUE(from_source.source().is_in_memory());
@@ -856,12 +868,12 @@ GTEST_TEST(ShapeTest, Volume) {
 
 GTEST_TEST(ShapeTest, Pathname) {
   const Mesh abspath_mesh("/absolute_path.obj");
-  EXPECT_TRUE(std::filesystem::path(abspath_mesh.filename()).is_absolute());
-  EXPECT_EQ(abspath_mesh.filename(), "/absolute_path.obj");
+  EXPECT_TRUE(abspath_mesh.source().path().is_absolute());
+  EXPECT_EQ(abspath_mesh.source().path(), "/absolute_path.obj");
 
   const Convex abspath_convex("/absolute_path.obj");
-  EXPECT_TRUE(std::filesystem::path(abspath_convex.filename()).is_absolute());
-  EXPECT_EQ(abspath_convex.filename(), "/absolute_path.obj");
+  EXPECT_TRUE(abspath_convex.source().path().is_absolute());
+  EXPECT_EQ(abspath_convex.source().path(), "/absolute_path.obj");
 
   const Mesh relpath_mesh("relative_path.obj");
   EXPECT_TRUE(relpath_mesh.source().path().is_absolute());
@@ -896,12 +908,12 @@ GTEST_TEST(ShapeTest, MeshExtensions) {
 GTEST_TEST(ShapeTest, MoveConstructor) {
   // Create an original mesh.
   Mesh orig("foo.obj");
-  const std::string orig_filename = orig.filename();
+  const std::string orig_filename = orig.source().description();
   EXPECT_EQ(orig.extension(), ".obj");
 
   // Move it into a different mesh.
   Mesh next(std::move(orig));
-  EXPECT_EQ(next.filename(), orig_filename);
+  EXPECT_EQ(next.source().description(), orig_filename);
   EXPECT_EQ(next.extension(), ".obj");
 
   // The moved-from mesh has its source revert to an empty in-memory mesh.

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -516,10 +516,13 @@ class MujocoParser {
         try {  // TODO(21666), remove the try-catch.
           M_GGo_G_unitDensity = CalcSpatialInertia(mesh, 1.0 /* density */);
         } catch (const std::exception& e) {
+          // As this calculator is only used for Mesh shapes that are specified
+          // in a mujoco file, the mesh *must* be on-disk.
+          DRAKE_DEMAND(mesh.source().is_path());
           // As with mujoco, failure leads to using the convex hull.
           // https://github.com/google-deepmind/mujoco/blob/df7ea3ed3350164d0f111c12870e46bc59439a96/src/user/user_mesh.cc#L1379-L1382
           M_GGo_G_unitDensity = CalcSpatialInertia(
-              geometry::Convex(mesh.filename(), mesh.scale()),
+              geometry::Convex(mesh.source().path(), mesh.scale()),
               1.0 /* density */);
           used_convex_hull_fallback_ = true;
         }

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -690,7 +690,8 @@ class BoxMeshTest : public MujocoParserTest {
     auto* mesh =
         dynamic_cast<const geometry::Mesh*>(&inspector.GetShape(geom_id));
     EXPECT_NE(mesh, nullptr);
-    EXPECT_EQ(mesh->filename(), expected_filename);
+    DRAKE_DEMAND(mesh->source().is_path());
+    EXPECT_EQ(mesh->source().path(), expected_filename);
     EXPECT_EQ(mesh->scale(), expected_scale);
   }
 };
@@ -837,7 +838,8 @@ TEST_F(MujocoParserTest, MeshFileRelativePathFromFile) {
       dynamic_cast<const geometry::Mesh*>(&inspector.GetShape(geom_id));
 
   EXPECT_NE(mesh, nullptr);
-  EXPECT_EQ(mesh->filename(), box_obj_);
+  ASSERT_TRUE(mesh->source().is_path());
+  EXPECT_EQ(mesh->source().path(), box_obj_);
   EXPECT_EQ(mesh->scale(), 1.0);
 }
 

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -443,7 +443,8 @@ TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometry) {
       MakeShapeFromSdfGeometry(*sdf_geometry);
   const Mesh* mesh = dynamic_cast<const Mesh*>(shape->get());
   ASSERT_NE(mesh, nullptr);
-  EXPECT_EQ(mesh->filename(), absolute_file_path);
+  ASSERT_TRUE(mesh->source().is_path());
+  EXPECT_EQ(mesh->source().path(), absolute_file_path);
   EXPECT_EQ(mesh->scale(), 3);
 }
 
@@ -478,7 +479,8 @@ TEST_F(SceneGraphParserDetail, MakeConvexFromSdfGeometry) {
       MakeShapeFromSdfGeometry(*sdf_geometry);
   const Convex* convex = dynamic_cast<const Convex*>(shape->get());
   ASSERT_NE(convex, nullptr);
-  EXPECT_EQ(convex->filename(), absolute_file_path);
+  EXPECT_TRUE(convex->source().is_path());
+  EXPECT_EQ(convex->source().path(), absolute_file_path);
   EXPECT_EQ(convex->scale(), 3);
 }
 

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -523,7 +523,8 @@ TEST_F(UrdfGeometryTest, TestParseMaterial2) {
       dynamic_cast<const geometry::Mesh*>(&mesh_visual.shape());
   ASSERT_TRUE(mesh);
 
-  const std::string& mesh_filename = mesh->filename();
+  ASSERT_TRUE(mesh->source().is_path());
+  const std::string& mesh_filename = mesh->source().path().string();
   std::string obj_name = "tri_cube.obj";
   EXPECT_EQ(mesh_filename.rfind(obj_name),
             mesh_filename.size() - obj_name.size());

--- a/multibody/tree/geometry_spatial_inertia.cc
+++ b/multibody/tree/geometry_spatial_inertia.cc
@@ -27,7 +27,7 @@ SpatialInertia<double> CalcMeshSpatialInertia(const Mesh& mesh,
   const auto& extension = mesh.extension();
   if (extension == ".obj") {
     return CalcSpatialInertia(
-        geometry::ReadObjToTriangleSurfaceMesh(mesh.filename(), mesh.scale()),
+        geometry::ReadObjToTriangleSurfaceMesh(mesh.source(), mesh.scale()),
         density);
   }
   if (extension == ".vtk") {
@@ -39,7 +39,7 @@ SpatialInertia<double> CalcMeshSpatialInertia(const Mesh& mesh,
   throw std::runtime_error(fmt::format(
       "CalcSpatialInertia currently only supports .obj or tetrahedral-mesh"
       " .vtk files for Mesh shapes but was given '{}'.",
-      mesh.filename()));
+      mesh.source().description()));
 }
 
 }  // namespace


### PR DESCRIPTION
This represents the scope and coarse sequence of PRs to fully implement in-memory meshes in Drake.

Closes #15263

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21881)
<!-- Reviewable:end -->
