### PR TITLE
[wheel] Re-enable macOS Python 3.11 builds

### DIFF
--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -21,9 +21,7 @@ _files_to_remove = []
 # default, all targets are built, but the user may down-select from this set.
 # On macOS (unlike Linux), this is just the set of Python versions targeted.
 python_targets = (
-    # TODO(jwnimmer-tri) Python 3.11 is disabled until NumPy ships PyPI wheels
-    # for that Python version that are installable on macOS 13.
-    # PythonTarget(3, 11),
+    PythonTarget(3, 11),
     PythonTarget(3, 12),
 )
 


### PR DESCRIPTION
This is safe now that NumPy has published a new fixed version (2.1.1).

Closes #21830.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21883)
<!-- Reviewable:end -->
