### PR TITLE
[meshcat] when .mtl files are missing, render colors instead

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -586,6 +586,7 @@ drake_cc_googletest(
     ],
     deps = [
         ":meshcat",
+        "//common:temp_directory",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "@msgpack_internal//:msgpack",

--- a/geometry/geometry_file_formats_doxygen.h
+++ b/geometry/geometry_file_formats_doxygen.h
@@ -340,7 +340,7 @@ namespace geometry {
      specified in that material will be applied. Note: cases where an .obj
      references a material name, but the material is not defined in the .mtl
      file, or the .mtl file is missing, will be treated as if no material is
-     specified and the next step will be applied.
+     specified and we proceed to step 2.
      - If diffuse properties are *also* defined in the mesh's
        GeometryProperties, a warning will be written to the console.
      - If the material specifies a texture, but the mesh doesn't have texture

--- a/geometry/geometry_file_formats_doxygen.h
+++ b/geometry/geometry_file_formats_doxygen.h
@@ -337,7 +337,10 @@ namespace geometry {
  definition.
 
   1. If the mesh file specifies materials, then the diffuse color or texture
-     specified in that material will be applied.
+     specified in that material will be applied. Note: cases where an .obj
+     references a material name, but the material is not defined in the .mtl
+     file, or the .mtl file is missing, will be treated as if no material is
+     specified and the next step will be applied.
      - If diffuse properties are *also* defined in the mesh's
        GeometryProperties, a warning will be written to the console.
      - If the material specifies a texture, but the mesh doesn't have texture

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -353,7 +353,7 @@ class MeshcatShapeReifier : public ShapeReifier {
     // TODO(russt): Make this mtllib parsing more robust (right now commented
     // mtllib lines will match, too, etc).
     size_t mtllib_pos;
-    bool replace_with_meshfile_geometry = false;
+    bool use_meshfile_geometry = false;
     if (format == "obj" &&
         (mtllib_pos = mesh_data.find("mtllib ")) != std::string::npos) {
       mtllib_pos += 7;  // Advance to after the actual "mtllib " string.
@@ -430,7 +430,7 @@ class MeshcatShapeReifier : public ShapeReifier {
         // If we can't load the mtl file, we'll just send the obj file as if it
         // did not specify the mtl. MuJoCo often ships obj files that reference
         // missing mtl files (see #20444).
-        replace_with_meshfile_geometry = true;
+        use_meshfile_geometry = true;
         // Move the data back.
         format = std::move(meshfile_object.format);
         mesh_data = std::move(meshfile_object.data);
@@ -448,10 +448,10 @@ class MeshcatShapeReifier : public ShapeReifier {
       // mesh file *geometry* instead of mesh file *object*. This will most
       // typically be a Collada .dae file, an .stl, or simply an .obj that
       // doesn't reference an .mtl.
-      replace_with_meshfile_geometry = true;
+      use_meshfile_geometry = true;
     }
 
-    if (replace_with_meshfile_geometry) {
+    if (use_meshfile_geometry) {
       // TODO(SeanCurtis-TRI): This doesn't work for STL even though meshcat
       // supports STL. Meshcat treats STL differently from obj or dae.
       // https://github.com/meshcat-dev/meshcat/blob/4b4f8ffbaa5f609352ea6227bd5ae8207b579c70/src/index.js#L130-L146.


### PR DESCRIPTION
Towards #20444. Like many mujoco assets, the
`mujoco_menagerie/boston_dynamics_spot/spot.xml` has obj files that reference missing `.mtl` files. For `spot.xml`, the mujoco parser correctly reads the rgba texture, but the meshcat parser did not publish it (because it went down the branch expecting the mtl).

This change makes meshcat slightly more robust... if the mtl file is missing, it publishes the file in the format that will accept the color property instead.

Example code:
```
from pydrake.all import ModelVisualizer, StartMeshcat, PackageMap

visualizer = ModelVisualizer(meshcat=meshcat)
visualizer.parser().package_map().AddRemote(
    package_name="mujoco_menagerie",
    params=PackageMap.RemoteParams(
        # This repository doesn't have up-to-date tags/releases; the scary
        # hash in the url is the most recent commit sha at the time of my
        # writing.
        urls=[
            f"https://github.com/google-deepmind/mujoco_menagerie/archive/bf110a75a56e5bd146c7ed76965737c71d48425d.tar.gz"
        ],
        sha256=("2562301c38ac82b593b31e523004b94c263b20952f99d2bcbb9939fa5c6bebd2"),
        strip_prefix="mujoco_menagerie-bf110a75a56e5bd146c7ed76965737c71d48425d/",
    ),
)
visualizer.AddModels(url="package://mujoco_menagerie/boston_dynamics_spot/spot.xml")
visualizer.Run(loop_once=True)
```

Before:
<img width="285" alt="image" src="https://github.com/user-attachments/assets/b715ab48-a87c-4d0f-9f7d-0ee6c6c39d26">


After:
<img width="433" alt="image" src="https://github.com/user-attachments/assets/6d9a4f8c-73e7-4bc7-a139-037db08f39f5">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21889)
<!-- Reviewable:end -->
