### PR TITLE
Introduce InMemoryMesh and MeshSource

### DIFF
--- a/bindings/pydrake/common/_common_extra.py
+++ b/bindings/pydrake/common/_common_extra.py
@@ -298,10 +298,10 @@ def _add_extraneous_repr_functions():
         else:
             repr_contents = repr(file.contents())
         return (
-            f"MemoryFile(\n"
-            f"  contents={repr_contents},\n"
-            f"  extension={repr(file.extension())},\n"
-            f"  filename_hint={repr(file.filename_hint())})"
+            f"MemoryFile("
+            f"contents={repr_contents}, "
+            f"extension={repr(file.extension())}, "
+            f"filename_hint={repr(file.filename_hint())})"
         )
     MemoryFile.__repr__ = mem_file_repr
 

--- a/bindings/pydrake/geometry/_geometry_extra.py
+++ b/bindings/pydrake/geometry/_geometry_extra.py
@@ -71,3 +71,27 @@ def StartMeshcat():
     if "DEEPNOTE_PROJECT_ID" in os.environ:
         return _start_meshcat_deepnote()
     return Meshcat()
+
+
+def _add_extraneous_repr_functions():
+    """Defines repr functions for various classes in common where defining it
+    in python is simply more convenient.
+    """
+    def in_memory_mesh_repr(mesh):
+        return (
+            f"InMemoryMesh(mesh_file={repr(mesh.mesh_file())})"
+        )
+    InMemoryMesh.__repr__ = in_memory_mesh_repr
+
+    def mesh_source_repr(source):
+        if source.is_path():
+            param_str = f"path={repr(str(source.path()))}"
+        else:
+            param_str = f"mesh={repr(source.in_memory())}"
+        return (
+            f"MeshSource({param_str})"
+        )
+    MeshSource.__repr__ = mesh_source_repr
+
+
+_add_extraneous_repr_functions()

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -18,6 +18,8 @@
 #include "drake/geometry/geometry_properties.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_version.h"
+#include "drake/geometry/in_memory_mesh.h"
+#include "drake/geometry/mesh_source.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/shape_specification.h"
 
@@ -280,6 +282,31 @@ void DoScalarIndependentDefinitions(py::module m) {
     BindIdentifier<GeometryId>(m, "GeometryId", doc.GeometryId.doc);
   }
 
+  // InMemoryMesh
+  {
+    using Class = InMemoryMesh;
+    constexpr auto& cls_doc = doc.InMemoryMesh;
+    py::class_<Class> cls(m, "InMemoryMesh", cls_doc.doc);
+    py::object ctor = m.attr("InMemoryMesh");
+    cls  // BR
+        .def(py::init<>(), cls_doc.ctor.doc_0args)
+        .def(py::init<MemoryFile>(), py::arg("mesh_file"),
+            cls_doc.ctor.doc_1args)
+        .def(py::init<const InMemoryMesh&>(), py::arg("other"))
+        .def("mesh_file", &Class::mesh_file, py_rvp::reference_internal,
+            cls_doc.mesh_file.doc)
+        .def("empty", &Class::empty, cls_doc.empty.doc)
+        .def(py::pickle(
+            [](const InMemoryMesh& self) {
+              return py::dict(py::arg("mesh_file") = self.mesh_file());
+            },
+            [ctor](const py::dict& kwargs) {
+              return ctor(**kwargs).cast<InMemoryMesh>();
+            }));
+    // Note: __repr__ is defined in _geometry_extra.py.
+    DefCopyAndDeepCopy(&cls);
+  }
+
   // IllustrationProperties
   {
     py::class_<IllustrationProperties, GeometryProperties> cls(
@@ -287,6 +314,40 @@ void DoScalarIndependentDefinitions(py::module m) {
     cls.def(py::init(), doc.IllustrationProperties.ctor.doc)
         .def(py::init<const IllustrationProperties&>(), py::arg("other"),
             "Creates a copy of the properties");
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  // MeshSource
+  {
+    using Class = MeshSource;
+    constexpr auto& cls_doc = doc.MeshSource;
+    py::class_<Class> cls(m, "MeshSource", cls_doc.doc);
+    py::object ctor = m.attr("MeshSource");
+    cls  // BR
+        .def(py::init<std::filesystem::path>(), py::arg("path"),
+            cls_doc.ctor.doc_1args_path)
+        .def(py::init<InMemoryMesh>(), py::arg("mesh"),
+            cls_doc.ctor.doc_1args_mesh)
+        .def(py::init<const MeshSource&>(), py::arg("other"))
+        .def("is_path", &Class::is_path, cls_doc.is_path.doc)
+        .def("is_in_memory", &Class::is_in_memory, cls_doc.is_in_memory.doc)
+        .def("description", &Class::description, cls_doc.description.doc)
+        .def("extension", &Class::extension, cls_doc.extension.doc)
+        .def("path", &Class::path, cls_doc.path.doc)
+        .def("in_memory", &Class::in_memory, py_rvp::reference_internal,
+            cls_doc.in_memory.doc)
+        .def(py::pickle(
+            [](const MeshSource& self) {
+              if (self.is_path()) {
+                return py::dict(py::arg("path") = self.path());
+              }
+              DRAKE_DEMAND(self.is_in_memory());
+              return py::dict(py::arg("mesh") = self.in_memory());
+            },
+            [ctor](const py::dict& kwargs) {
+              return ctor(**kwargs).cast<MeshSource>();
+            }));
+    // Note: __repr__ is defined in _geometry_extra.py.
     DefCopyAndDeepCopy(&cls);
   }
 
@@ -536,6 +597,9 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::arg("properties"), py::arg("dissipation") = std::nullopt,
       py::arg("point_stiffness") = std::nullopt,
       py::arg("friction") = std::nullopt, doc.AddContactMaterial.doc);
+
+  // TODO(SeanCurtis-TRI): Decompose this in some meaningful way.
+  // NOLINTNEXTLINE(readability/fn_size)
 }
 
 // Test-only code.

--- a/common/memory_file.cc
+++ b/common/memory_file.cc
@@ -44,4 +44,6 @@ MemoryFile::MemoryFile(std::string contents, std::string extension,
                      std::string::npos);
 }
 
+MemoryFile::~MemoryFile() = default;
+
 }  // namespace drake

--- a/common/memory_file.h
+++ b/common/memory_file.h
@@ -10,7 +10,7 @@
 namespace drake {
 
 /** A virtual file, stored in memory. */
-class MemoryFile {
+class MemoryFile final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MemoryFile);
 
@@ -44,6 +44,8 @@ class MemoryFile {
                           isn't '.'. */
   MemoryFile(std::string contents, std::string extension,
              std::string filename_hint);
+
+  ~MemoryFile();
 
   /** Returns the file's contents. */
   const std::string& contents() const { return contents_; }

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -31,11 +31,13 @@ drake_cc_package_library(
         ":geometry_set",
         ":geometry_state",
         ":geometry_version",
+        ":in_memory_mesh",
         ":internal_frame",
         ":internal_geometry",
         ":kinematics_vector",
         ":make_mesh_for_deformable",
         ":mesh_deformation_interpolator",
+        ":mesh_source",
         ":meshcat",
         ":meshcat_animation",
         ":meshcat_graphviz",
@@ -272,6 +274,15 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "in_memory_mesh",
+    srcs = ["in_memory_mesh.cc"],
+    hdrs = ["in_memory_mesh.h"],
+    deps = [
+        "//common:memory_file",
+    ],
+)
+
+drake_cc_library(
     name = "make_mesh_for_deformable",
     srcs = ["make_mesh_for_deformable.cc"],
     hdrs = ["make_mesh_for_deformable.h"],
@@ -292,6 +303,15 @@ drake_cc_library(
         "//geometry/proximity:triangle_surface_mesh",
         "//geometry/proximity:volume_mesh",
         "//geometry/proximity:volume_to_surface_mesh",
+    ],
+)
+
+drake_cc_library(
+    name = "mesh_source",
+    srcs = ["mesh_source.cc"],
+    hdrs = ["mesh_source.h"],
+    deps = [
+        ":in_memory_mesh",
     ],
 )
 
@@ -841,6 +861,21 @@ drake_cc_googletest(
         "//lcm",
         "//lcmtypes:viewer",
         "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "in_memory_mesh_test",
+    deps = [
+        ":in_memory_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_source_test",
+    deps = [
+        ":in_memory_mesh",
+        ":mesh_source",
     ],
 )
 

--- a/geometry/in_memory_mesh.cc
+++ b/geometry/in_memory_mesh.cc
@@ -1,0 +1,20 @@
+#include "drake/geometry/in_memory_mesh.h"
+
+#include <utility>
+
+namespace drake {
+namespace geometry {
+
+InMemoryMesh::InMemoryMesh() = default;
+
+InMemoryMesh::InMemoryMesh(MemoryFile mesh_file)
+    : mesh_file_(std::move(mesh_file)) {}
+
+InMemoryMesh::~InMemoryMesh() = default;
+
+bool InMemoryMesh::empty() const {
+  return mesh_file_.contents().empty();
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/in_memory_mesh.h
+++ b/geometry/in_memory_mesh.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/memory_file.h"
+
+namespace drake {
+namespace geometry {
+
+/** Representation of a mesh file stored in memory. Eventually, this will also
+ include a family of supporting files (e.g., material files, image files, etc.)
+*/
+class InMemoryMesh final {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InMemoryMesh);
+
+  /** Constructs an empty file. */
+  InMemoryMesh();
+
+  /** Constructs a file from the given mesh file. */
+  explicit InMemoryMesh(MemoryFile mesh_file);
+
+  ~InMemoryMesh();
+
+  /** Returns the base mesh file. */
+  const MemoryFile& mesh_file() const { return mesh_file_; }
+
+  /** Reports if the mesh is empty. */
+  bool empty() const;
+
+ private:
+  /* The main mesh file's contents (e.g., a .obj or .gltf file, but not a .mtl
+   or .bin). */
+  MemoryFile mesh_file_;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/mesh_source.cc
+++ b/geometry/mesh_source.cc
@@ -1,0 +1,33 @@
+#include "drake/geometry/mesh_source.h"
+
+#include <algorithm>
+
+namespace drake {
+namespace geometry {
+namespace {
+
+std::string GetExtensionLower(const std::filesystem::path& file_path) {
+  std::string ext = file_path.extension();
+  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
+    return std::tolower(c);
+  });
+  return ext;
+}
+
+}  // namespace
+
+MeshSource::MeshSource(std::filesystem::path path)
+    : source_(std::move(path)), extension_(GetExtensionLower(this->path())) {}
+
+MeshSource::MeshSource(InMemoryMesh&& mesh)
+    : source_(std::move(mesh)),
+      extension_(in_memory().mesh_file().extension()) {}
+
+MeshSource::~MeshSource() = default;
+
+std::string MeshSource::description() const {
+  return is_path() ? path().string() : in_memory().mesh_file().filename_hint();
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/mesh_source.h
+++ b/geometry/mesh_source.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/reset_after_move.h"
+#include "drake/geometry/in_memory_mesh.h"
+
+namespace drake {
+namespace geometry {
+
+/** Provides a general abstraction to the definition of a mesh. A mesh
+ definition can come from disk or memory. APIs that support both can take as
+ specification an instance of %MeshSource to communicate that ability. */
+class MeshSource final {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MeshSource);
+
+  /** Constructs from a file path.
+   Note: the path will not be validated in any way (existence, availability,
+   naming an actual mesh file, etc.). Validation occurs where the %MeshSource's
+   path is *used*. */
+  // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.
+  MeshSource(std::filesystem::path path);
+
+  /** Constructs from an in-memory mesh. */
+  // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.
+  MeshSource(InMemoryMesh&& mesh);
+
+  ~MeshSource();
+
+  /** Reports `true` if this source is a filesystem path. */
+  bool is_path() const {
+    return std::holds_alternative<std::filesystem::path>(source_.value());
+  }
+
+  /** Reports `true` if this source contains an in-memory mesh definition. */
+  bool is_in_memory() const {
+    return std::holds_alternative<InMemoryMesh>(source_.value());
+  }
+
+  /** Provides a source-agnostic description of the mesh. If is_path() is true,
+   it is the path. If is_in_memory() is true, it is the filename_hint for the
+   in-memory mesh file. */
+  std::string description() const;
+
+  /** Returns the extension of the mesh type -- all lower case and including
+   the dot. If is_path() is `true`, the extension is extracted from the path.
+   I.e., /foo/bar/mesh.obj and /foo/bar/mesh.OBJ would both report the ".obj"
+   extension. The "extension" portion of the filename is defined as in
+   std::filesystem::path::extension().
+
+   If is_in_memory() is `true`, it is the extension reported by the MemoryFile.
+   */
+  const std::string& extension() const { return extension_.value(); }
+
+  /** Returns the source's file path.
+   @pre is_path() returns `true`. */
+  const std::filesystem::path& path() const {
+    return std::get<std::filesystem::path>(source_.value());
+  }
+
+  /** Returns the source's in-memory mesh data.
+   @pre is_in_memory() returns `true`. */
+  const InMemoryMesh& in_memory() const {
+    return std::get<InMemoryMesh>(source_.value());
+  }
+
+ private:
+  reset_after_move<std::variant<InMemoryMesh, std::filesystem::path>> source_;
+  // We cache the extension so that we don't have recompute it each time.
+  reset_after_move<std::string> extension_;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -981,6 +981,7 @@ drake_cc_library(
     deps = [
         ":volume_mesh",
         "//common:essential",
+        "//geometry:mesh_source",
     ],
     implementation_deps = [
         "@fmt",

--- a/geometry/proximity/make_convex_hull_mesh_impl.cc
+++ b/geometry/proximity/make_convex_hull_mesh_impl.cc
@@ -114,7 +114,7 @@ struct VertexCloud {
 
 /* Returns the scaled vertices from the named obj file.
  @pre `filename` references an obj file. */
-void ReadObjVertices(const fs::path filename, double scale,
+void ReadObjVertices(const fs::path& filename, double scale,
                      std::vector<Vector3d>* vertices) {
   const auto [tinyobj_vertices, _1, _2] = geometry::internal::ReadObjFile(
       std::string(filename), scale, /* triangulate = */ false);
@@ -123,10 +123,9 @@ void ReadObjVertices(const fs::path filename, double scale,
 
 /* Returns the scaled vertices from the named vtk file.
  @pre `filename` references a vtk file (with a volume mesh). */
-void ReadVtkVertices(const fs::path filename, double scale,
+void ReadVtkVertices(const fs::path& filename, double scale,
                      std::vector<Vector3d>* vertices) {
-  const VolumeMesh<double> volume_mesh =
-      ReadVtkToVolumeMesh(std::string(filename), scale);
+  const VolumeMesh<double> volume_mesh = ReadVtkToVolumeMesh(filename, scale);
 
   // It would be nice if we could simply steal the vertices rather than copy.
   *vertices = volume_mesh.vertices();
@@ -142,7 +141,7 @@ Vector3d VtkMultiply(vtkMatrix4x4* T_BA, const Vector3d& p_AQ) {
 
 /* Returns the scaled vertices from the named glTF file.
  @pre `filename` references a glTF file. */
-void ReadGltfVertices(const fs::path filename, double scale,
+void ReadGltfVertices(const fs::path& filename, double scale,
                       std::vector<Vector3d>* vertices) {
   vtkNew<vtkGLTFImporter> importer;
   importer->SetFileName(filename.c_str());
@@ -187,7 +186,7 @@ void ReadGltfVertices(const fs::path filename, double scale,
  @throws if the vertices span a severely degenerate space in R3 (e.g.,
          co-linear or coincident). */
 Vector3d FindNormal(const std::vector<Vector3d>& vertices,
-                    const fs::path filename) {
+                    const fs::path& filename) {
   // Note: this isn't an exhaustive search. We assign i = 0 and then
   // sequentially search for j and k. This may fail but possibly succeed for
   // a different value of i. That risk seems small. Any mesh that depends on
@@ -232,7 +231,7 @@ Vector3d FindNormal(const std::vector<Vector3d>& vertices,
 
 /* Simply reads the vertices from an OBJ, VTK or glTF file referred to by name.
  */
-VertexCloud ReadVertices(const fs::path filename, double scale) {
+VertexCloud ReadVertices(const fs::path& filename, double scale) {
   std::string extension = filename.extension();
   std::transform(extension.begin(), extension.end(), extension.begin(),
                  [](unsigned char c) {
@@ -496,7 +495,7 @@ class ConvexHull {
 
 }  // namespace
 
-PolygonSurfaceMesh<double> MakeConvexHull(const std::filesystem::path mesh_file,
+PolygonSurfaceMesh<double> MakeConvexHull(const fs::path& mesh_file,
                                           double scale, double margin) {
   DRAKE_THROW_UNLESS(scale > 0);
   DRAKE_THROW_UNLESS(margin >= 0);

--- a/geometry/proximity/make_convex_hull_mesh_impl.h
+++ b/geometry/proximity/make_convex_hull_mesh_impl.h
@@ -38,8 +38,8 @@ namespace internal {
  @throws if there is an unforeseen error in computing the convex hull.
  @throws if `scale` is negative or zero.
  @throws if `margin` is negative. */
-PolygonSurfaceMesh<double> MakeConvexHull(const std::filesystem::path mesh_file,
-                                          double scale, double margin = 0);
+PolygonSurfaceMesh<double> MakeConvexHull(
+    const std::filesystem::path& mesh_file, double scale, double margin = 0);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/refine_mesh.cc
+++ b/geometry/proximity/refine_mesh.cc
@@ -39,7 +39,8 @@ int do_main(int argc, char* argv[]) {
     return 1;
   }
 
-  VolumeMesh<double> mesh = internal::ReadVtkToVolumeMesh(argv[1]);
+  VolumeMesh<double> mesh =
+      internal::ReadVtkToVolumeMesh(std::filesystem::path(argv[1]));
   std::vector<int> bad_tets =
       internal::DetectTetrahedronWithAllBoundaryVertices(mesh);
   std::vector<internal::SortedTriplet<int>> bad_triangles =

--- a/geometry/proximity/test/vtk_to_volume_mesh_test.cc
+++ b/geometry/proximity/test/vtk_to_volume_mesh_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/vtk_to_volume_mesh.h"
 
+#include <filesystem>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
@@ -9,10 +11,12 @@ namespace drake {
 namespace geometry {
 namespace {
 
+namespace fs = std::filesystem;
+
 using Eigen::Vector3d;
 
 GTEST_TEST(VtkToVolumeMeshTest, OneTetrahedronFile) {
-  const std::string test_file =
+  const fs::path test_file =
       FindResourceOrThrow("drake/geometry/test/one_tetrahedron.vtk");
   VolumeMesh<double> volume_mesh = internal::ReadVtkToVolumeMesh(test_file);
 
@@ -25,7 +29,7 @@ GTEST_TEST(VtkToVolumeMeshTest, OneTetrahedronFile) {
 
 // With an additional field variable, we can still read the mesh.
 GTEST_TEST(VtkToVolumeMeshTest, KeepMeshIgnoreFieldVariables) {
-  const std::string test_file = FindResourceOrThrow(
+  const fs::path test_file = FindResourceOrThrow(
       "drake/geometry/test/two_tetrahedra_with_field_variable.vtk");
   VolumeMesh<double> volume_mesh = internal::ReadVtkToVolumeMesh(test_file);
 
@@ -37,7 +41,7 @@ GTEST_TEST(VtkToVolumeMeshTest, KeepMeshIgnoreFieldVariables) {
 }
 
 GTEST_TEST(VtkToVolumeMeshTest, Scale) {
-  const std::string test_file =
+  const fs::path test_file =
       FindResourceOrThrow("drake/geometry/test/one_tetrahedron.vtk");
   // Scale from a one-meter object to a one-centimeter object.
   const double kScale = 0.01;
@@ -51,29 +55,43 @@ GTEST_TEST(VtkToVolumeMeshTest, Scale) {
   EXPECT_TRUE(volume_mesh.Equal(expected_mesh));
 }
 
+GTEST_TEST(VtkToVolumeMeshTest, FromMemory) {
+  // Scale from a one-meter object to a one-centimeter object.
+  const double kScale = 0.01;
+  const fs::path test_file =
+      FindResourceOrThrow("drake/geometry/test/one_tetrahedron.vtk");
+  VolumeMesh<double> volume_mesh = internal::ReadVtkToVolumeMesh(
+      InMemoryMesh(MemoryFile::Make(test_file)), kScale);
+
+  const VolumeMesh<double> expected_mesh{
+      {{0, 1, 2, 3}},
+      {kScale * Vector3d::Zero(), kScale * Vector3d::UnitX(),
+       kScale * Vector3d::UnitY(), kScale * Vector3d::UnitZ()}};
+  EXPECT_TRUE(volume_mesh.Equal(expected_mesh));
+}
+
 GTEST_TEST(VtkToVolumeMeshTest, BadScale) {
-  const std::string test_file =
+  const fs::path test_file =
       FindResourceOrThrow("drake/geometry/test/one_tetrahedron.vtk");
 
   const double kNegativeScale = -0.01;
   DRAKE_EXPECT_THROWS_MESSAGE(
       internal::ReadVtkToVolumeMesh(test_file, kNegativeScale),
-      "ReadVtkToVolumeMesh.*: scale=.* is not a positive number.*");
+      "ReadVtkToVolumeMesh.* requires a positive scale.*");
 
   const double kZeroScale = 0.0;
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      internal::ReadVtkToVolumeMesh(test_file, kZeroScale),
-      "ReadVtkToVolumeMesh.*: scale=.* is not a positive number.*");
+  EXPECT_THROW(internal::ReadVtkToVolumeMesh(test_file, kZeroScale),
+               std::exception);
 }
 
 GTEST_TEST(VtkToVolumeMeshTest, BogusFileName) {
-  const std::string bogus_filename = "bogus_filename";
+  const fs::path bogus_filename = "bogus_filename";
   DRAKE_EXPECT_THROWS_MESSAGE(internal::ReadVtkToVolumeMesh(bogus_filename),
                               ".*at least one tetra.*");
 }
 
 GTEST_TEST(VtkToVolumeMeshTest, WrongFileType) {
-  const std::string require_vtk_but_this_is_obj =
+  const fs::path require_vtk_but_this_is_obj =
       FindResourceOrThrow("drake/geometry/test/non_convex_mesh.obj");
   DRAKE_EXPECT_THROWS_MESSAGE(
       internal::ReadVtkToVolumeMesh(require_vtk_but_this_is_obj),
@@ -81,24 +99,24 @@ GTEST_TEST(VtkToVolumeMeshTest, WrongFileType) {
 }
 
 GTEST_TEST(VtkToVolumeMeshTest, WrongFileContentsCube) {
-  const std::string cube_vtk =
+  const fs::path cube_vtk =
       FindResourceOrThrow("drake/geometry/test/cube_as_6_squares.vtk");
   DRAKE_EXPECT_THROWS_MESSAGE(internal::ReadVtkToVolumeMesh(cube_vtk),
                               ".*at least one tetra.*");
 }
 
 GTEST_TEST(VtkToVolumeMeshTest, WrongFileContentsVolume) {
-  const std::string volume_vtk =
+  const fs::path volume_vtk =
       FindResourceOrThrow("drake/geometry/test/some_volume.vtk");
   DRAKE_EXPECT_THROWS_MESSAGE(internal::ReadVtkToVolumeMesh(volume_vtk),
                               ".*at least one tetra.*");
 }
 
 GTEST_TEST(VtkToVolumeMeshTest, WrongFileContentsUnstructured) {
-  const std::string unstructured_vtk =
+  const fs::path unstructured_vtk =
       FindResourceOrThrow("drake/geometry/test/unstructured.vtk");
   DRAKE_EXPECT_THROWS_MESSAGE(internal::ReadVtkToVolumeMesh(unstructured_vtk),
-                              ".*non-tetra.*");
+                              ".*should only contain tetrahedra.*");
 }
 
 }  // namespace

--- a/geometry/proximity/test/zero_simplex_manual_test.cc
+++ b/geometry/proximity/test/zero_simplex_manual_test.cc
@@ -1,3 +1,5 @@
+#include <filesystem>
+
 #include <gflags/gflags.h>
 
 #include "drake/common/text_logging.h"
@@ -23,7 +25,7 @@ int do_main(int argc, char* argv[]) {
     return 1;
   }
 
-  auto mesh = ReadVtkToVolumeMesh(argv[1]);
+  auto mesh = ReadVtkToVolumeMesh(std::filesystem::path(argv[1]));
   auto bad_tets = DetectTetrahedronWithAllBoundaryVertices(mesh);
   auto bad_triangles = DetectInteriorTriangleWithAllBoundaryVertices(mesh);
   auto bad_edges = DetectInteriorEdgeWithAllBoundaryVertices(mesh);

--- a/geometry/proximity/vtk_to_volume_mesh.cc
+++ b/geometry/proximity/vtk_to_volume_mesh.cc
@@ -7,6 +7,7 @@
 
 // To ease build system upkeep, we annotate VTK includes with their deps.
 #include <vtkCellIterator.h>            // vtkCommonDataModel
+#include <vtkCharArray.h>               // vtkCommonCore
 #include <vtkNew.h>                     // vtkCommonCore
 #include <vtkUnstructuredGrid.h>        // vtkCommonDataModel
 #include <vtkUnstructuredGridReader.h>  // vtkIOLegacy
@@ -15,21 +16,29 @@
 
 namespace drake {
 namespace geometry {
+namespace internal {
 
 using Eigen::Vector3d;
 
-namespace internal {
-
-VolumeMesh<double> ReadVtkToVolumeMesh(const std::string& filename,
+VolumeMesh<double> ReadVtkToVolumeMesh(const MeshSource& mesh_source,
                                        double scale) {
-  if (scale <= 0.0) {
+  if (!(scale > 0.0)) {
     throw std::runtime_error(fmt::format(
-        "ReadVtkToVolumeMesh('{}', {}): scale={} is not a positive number",
-        filename, scale, scale));
+        "ReadVtkToVolumeMesh() requires a positive scale. Given {} for '{}'.",
+        scale, mesh_source.description()));
   }
   vtkNew<vtkUnstructuredGridReader> reader;
-  reader->SetFileName(filename.c_str());
+  if (mesh_source.is_path()) {
+    reader->SetFileName(mesh_source.path().c_str());
+  } else {
+    DRAKE_DEMAND(mesh_source.is_in_memory());
+    const MemoryFile& file = mesh_source.in_memory().mesh_file();
+    // Note: The contents will be copied by VTK.
+    reader->SetInputString(file.contents().c_str(), file.contents().size());
+    reader->SetReadFromInputString(true);
+  }
   reader->Update();
+
   vtkUnstructuredGrid* vtk_mesh = reader->GetOutput();
 
   const vtkIdType num_vertices = vtk_mesh->GetNumberOfPoints();
@@ -51,13 +60,13 @@ VolumeMesh<double> ReadVtkToVolumeMesh(const std::string& filename,
     if (iter->GetCellType() != VTK_TETRA) {
       vtkNew<vtkGenericCell> bad_cell;
       iter->GetCell(bad_cell);
-      auto msg = fmt::format(
-          "ReadVtkToVolumeMesh('{}', {}): file contains a"
-          " non-tetrahedron(type id={}) cell with type id {}, dimension {},"
-          " and number of points {}",
-          filename, scale, static_cast<int>(VTK_TETRA), bad_cell->GetCellType(),
-          bad_cell->GetCellDimension(), bad_cell->GetNumberOfPoints());
-      throw std::runtime_error(msg);
+      throw std::runtime_error(fmt::format(
+          "ReadVtkToVolumeMesh(): mesh data should only contain tetrahedra "
+          "(type id={}). Read cell with type id={}, dimension {}, and number "
+          "of points {} in '{}'.",
+          static_cast<int>(VTK_TETRA), bad_cell->GetCellType(),
+          bad_cell->GetCellDimension(), bad_cell->GetNumberOfPoints(),
+          mesh_source.description()));
     }
     vtkIdList* vtk_vertex_ids = iter->GetPointIds();
     // clang-format off

--- a/geometry/proximity/vtk_to_volume_mesh.h
+++ b/geometry/proximity/vtk_to_volume_mesh.h
@@ -2,21 +2,20 @@
 
 #include <string>
 
+#include "drake/geometry/mesh_source.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
-/* @name Import tetrahedral volume meshes from VTK files for deformable
- geometries. These internal functions import VolumeMesh from a subset of VTK
- files (legacy, serial, ASCII, UNSTRUCTURED_GRID). They only support a limited
- number of tags and ignore the rest. The file format is described in:
- https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf
- */
-//@{
+/* Instantiates a VolumeMesh from VTK file data.
 
-/* Reads VolumeMesh from VTK file.
+ The VTK file data is a subset of VTK files (legacy, serial, ASCII,
+ UNSTRUCTURED_GRID). A limited number of tags are supported; the rest ignored.
+ The file format is described in:
+ https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf
+
  It looks for lines like these to describe positions of vertices and the four
  vertices of each tetrahedron.
 
@@ -35,19 +34,16 @@ namespace internal {
  Other sections like POINT_DATA and CELL_DATA, e.g. per-vertex pressure value
  or per-tetrahedron velocity field are ignored.
 
- @param filename    A file name with absolute path or relative path.
- @param scale       An optional scale to coordinates.
+ @param mesh_source      The source of mesh data to parse.
+ @param scale            An optional scale to coordinates.
  @return tetrahedral volume mesh
 
  @note Error handling from parsing the file is performed by VTK library.
 
  @throw  std::exception if the file does not exist or unsupported.
-         std::exceptoin for non-positive scale factors.
- */
-VolumeMesh<double> ReadVtkToVolumeMesh(const std::string& filename,
+         std::exception for non-positive scale factors. */
+VolumeMesh<double> ReadVtkToVolumeMesh(const MeshSource& mesh_source,
                                        double scale = 1.0);
-
-//@}
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/test/in_memory_mesh_test.cc
+++ b/geometry/test/in_memory_mesh_test.cc
@@ -1,0 +1,40 @@
+#include "drake/geometry/in_memory_mesh.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace {
+
+GTEST_TEST(InMemoryMeshTest, BasicApi) {
+  const InMemoryMesh empty;
+  EXPECT_TRUE(empty.empty());
+
+  const InMemoryMesh just_mesh(MemoryFile("body", ".ext", "hint"));
+  ASSERT_FALSE(just_mesh.empty());
+  EXPECT_EQ(just_mesh.mesh_file().contents(), "body");
+}
+
+GTEST_TEST(InMemorymeshTest, CopySemantics) {
+  const InMemoryMesh source(MemoryFile("body", ".ext", "hint"));
+  ASSERT_FALSE(source.empty());
+  EXPECT_EQ(source.mesh_file().contents(), "body");
+
+  const InMemoryMesh copy_ctor(source);
+  ASSERT_FALSE(copy_ctor.empty());
+  EXPECT_EQ(copy_ctor.mesh_file().contents(), "body");
+  ASSERT_FALSE(source.empty());
+  EXPECT_EQ(source.mesh_file().contents(), "body");
+
+  InMemoryMesh copy_assign;
+  EXPECT_TRUE(copy_assign.empty());
+  copy_assign = source;
+  ASSERT_FALSE(copy_assign.empty());
+  EXPECT_EQ(copy_assign.mesh_file().contents(), "body");
+  ASSERT_FALSE(source.empty());
+  EXPECT_EQ(source.mesh_file().contents(), "body");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/mesh_source_test.cc
+++ b/geometry/test/mesh_source_test.cc
@@ -1,0 +1,73 @@
+#include "drake/geometry/mesh_source.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/in_memory_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+GTEST_TEST(MeshSourceTest, PathConstructor) {
+  const MeshSource s(std::filesystem::path("path"));
+  EXPECT_EQ(s.description(), "path");
+  ASSERT_TRUE(s.is_path());
+  EXPECT_FALSE(s.is_in_memory());
+  EXPECT_EQ(s.path(), "path");
+}
+
+GTEST_TEST(MeshSourceTest, InMemoryMeshConstructor) {
+  const MeshSource s(InMemoryMesh(MemoryFile("contents", ".ext", "hint")));
+  EXPECT_EQ(s.description(), "hint");
+  EXPECT_FALSE(s.is_path());
+  ASSERT_TRUE(s.is_in_memory());
+  EXPECT_EQ(s.in_memory().mesh_file().contents(), "contents");
+}
+
+GTEST_TEST(MeshSourceTest, CopySemantics) {
+  const MeshSource source(InMemoryMesh(MemoryFile("body", ".ext", "hint")));
+  EXPECT_TRUE(source.is_in_memory());
+  EXPECT_EQ(source.description(), "hint");
+
+  const MeshSource copy_ctor(source);
+  EXPECT_TRUE(copy_ctor.is_in_memory());
+  EXPECT_EQ(copy_ctor.description(), "hint");
+  EXPECT_TRUE(source.is_in_memory());
+  EXPECT_EQ(source.description(), "hint");
+
+  MeshSource copy_assign(std::filesystem::path("path"));
+  EXPECT_TRUE(copy_assign.is_path());
+  copy_assign = source;
+  EXPECT_TRUE(copy_assign.is_in_memory());
+  EXPECT_EQ(copy_assign.description(), "hint");
+  EXPECT_TRUE(source.is_in_memory());
+  EXPECT_EQ(source.description(), "hint");
+}
+
+GTEST_TEST(MeshSourceTest, MovedFrom) {
+  MeshSource s(std::filesystem::path("path"));
+  ASSERT_TRUE(s.is_path());
+  EXPECT_EQ(s.path(), "path");
+
+  const MeshSource d(std::move(s));
+  ASSERT_TRUE(d.is_path());
+  EXPECT_EQ(d.path(), "path");
+
+  // The moved-from source now reports as an empty in-memory mesh.
+  ASSERT_TRUE(s.is_in_memory());
+  EXPECT_TRUE(s.in_memory().empty());
+  EXPECT_EQ(s.extension(), "");
+}
+
+/* Dummy function for testing implicit construction. */
+void ConsumeMeshSource(const MeshSource&) {}
+
+/* We allow implicit conversions from paths and in-memory meshes to MeshSource.
+Successful compilation implies test success. */
+GTEST_TEST(MeshSourceTest, ImplicitConversion) {
+  ConsumeMeshSource(std::filesystem::path("path"));
+  ConsumeMeshSource(InMemoryMesh(MemoryFile("contents", ".ext", "hint")));
+}
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
These provide the foundation of in-memory mesh specification. `InMemoryMesh` tracks a `MemoryFile` for a mesh file (and an optional set of supporting files in the near future).

`MeshSource` acts as a sugared-up variant between a `filesystem::path` and an `InMemoryMesh`. This will, ultimately, serve as the storage for `Mesh` and `Convex` specifications.

While it is not integrated with `Mesh` or `Convex` yet, we exercise the new APIs in `vtk_to_volume_mesh` -- which consumes the `MeshSource` and creates the `VolumeMesh` from both in-memory as well as on-disk .vtk files.

Relates #15263.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21890)
<!-- Reviewable:end -->
