### PR TITLE
[py geometry] Fix signatures to use Python types (not C++)

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -27,12 +27,14 @@ namespace drake {
 namespace pydrake {
 namespace {
 
-void DoScalarIndependentDefinitions(py::module m) {
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::geometry;
-  constexpr auto& doc = pydrake_doc.drake.geometry;
+// NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+using namespace drake::geometry;
+constexpr auto& doc = pydrake_doc.drake.geometry;
 
-  // CollisionFilterDeclaration.
+// TODO(jwnimmer-tri) Reformat this entire file to remove the unnecessary
+// indentation.
+
+void DefineCollisionFilterDeclaration(py::module m) {
   {
     using Class = CollisionFilterDeclaration;
     constexpr auto& cls_doc = doc.CollisionFilterDeclaration;
@@ -48,8 +50,9 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("ExcludeWithin", &Class::ExcludeWithin, py::arg("geometry_set"),
             py_rvp::reference, cls_doc.ExcludeWithin.doc);
   }
+}
 
-  // CollisionFilterManager
+void DefineCollisionFilterManager(py::module m) {
   {
     using Class = CollisionFilterManager;
     constexpr auto& cls_doc = doc.CollisionFilterManager;
@@ -64,8 +67,9 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("IsActive", &Class::IsActive, py::arg("filter_id"),
             cls_doc.IsActive.doc);
   }
+}
 
-  // GeometryFrame
+void DefineGeometryFrame(py::module m) {
   {
     using Class = GeometryFrame;
     constexpr auto& cls_doc = doc.GeometryFrame;
@@ -78,8 +82,9 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("frame_group", &Class::frame_group, cls_doc.frame_group.doc);
     DefCopyAndDeepCopy(&cls);
   }
+}
 
-  // GeometryInstance
+void DefineGeometryInstance(py::module m) {
   {
     using Class = GeometryInstance;
     constexpr auto& cls_doc = doc.GeometryInstance;
@@ -120,8 +125,9 @@ void DoScalarIndependentDefinitions(py::module m) {
             py_rvp::reference_internal, cls_doc.perception_properties.doc);
     DefCopyAndDeepCopy(&cls);
   }
+}
 
-  // GeometryProperties
+void DefineGeometryProperties(py::module m) {
   {
     using Class = GeometryProperties;
     constexpr auto& cls_doc = doc.GeometryProperties;
@@ -205,8 +211,9 @@ void DoScalarIndependentDefinitions(py::module m) {
             },
             "Returns formatted string.");
   }
+}
 
-  // GeometrySet
+void DefineGeometrySet(py::module m) {
   {
     using Class = GeometrySet;
     constexpr auto& cls_doc = doc.GeometrySet;
@@ -260,8 +267,9 @@ void DoScalarIndependentDefinitions(py::module m) {
             },
             py::arg("geometry_ids"), py::arg("frame_ids"), extra_ctor_doc);
   }
+}
 
-  // GeometryVersion
+void DefineGeometryVersion(py::module m) {
   {
     using Class = GeometryVersion;
     constexpr auto& cls_doc = doc.GeometryVersion;
@@ -273,16 +281,18 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.IsSameAs.doc);
     DefCopyAndDeepCopy(&cls);
   }
+}
 
-  // Identifiers.
+void DefineIdentifiers(py::module m) {
   {
     BindIdentifier<FilterId>(m, "FilterId", doc.FilterId.doc);
     BindIdentifier<SourceId>(m, "SourceId", doc.SourceId.doc);
     BindIdentifier<FrameId>(m, "FrameId", doc.FrameId.doc);
     BindIdentifier<GeometryId>(m, "GeometryId", doc.GeometryId.doc);
   }
+}
 
-  // InMemoryMesh
+void DefineInMemoryMesh(py::module m) {
   {
     using Class = InMemoryMesh;
     constexpr auto& cls_doc = doc.InMemoryMesh;
@@ -306,8 +316,9 @@ void DoScalarIndependentDefinitions(py::module m) {
     // Note: __repr__ is defined in _geometry_extra.py.
     DefCopyAndDeepCopy(&cls);
   }
+}
 
-  // IllustrationProperties
+void DefineGeometryPropertiesSubclasses(py::module m) {
   {
     py::class_<IllustrationProperties, GeometryProperties> cls(
         m, "IllustrationProperties", doc.IllustrationProperties.doc);
@@ -316,8 +327,25 @@ void DoScalarIndependentDefinitions(py::module m) {
             "Creates a copy of the properties");
     DefCopyAndDeepCopy(&cls);
   }
+  {
+    py::class_<PerceptionProperties, GeometryProperties> cls(
+        m, "PerceptionProperties", doc.PerceptionProperties.doc);
+    cls.def(py::init(), doc.PerceptionProperties.ctor.doc)
+        .def(py::init<const PerceptionProperties&>(), py::arg("other"),
+            "Creates a copy of the properties");
+    DefCopyAndDeepCopy(&cls);
+  }
+  {
+    py::class_<ProximityProperties, GeometryProperties> cls(
+        m, "ProximityProperties", doc.ProximityProperties.doc);
+    cls.def(py::init(), doc.ProximityProperties.ctor.doc)
+        .def(py::init<const ProximityProperties&>(), py::arg("other"),
+            "Creates a copy of the properties");
+    DefCopyAndDeepCopy(&cls);
+  }
+}
 
-  // MeshSource
+void DefineMeshSource(py::module m) {
   {
     using Class = MeshSource;
     constexpr auto& cls_doc = doc.MeshSource;
@@ -350,28 +378,9 @@ void DoScalarIndependentDefinitions(py::module m) {
     // Note: __repr__ is defined in _geometry_extra.py.
     DefCopyAndDeepCopy(&cls);
   }
+}
 
-  // PerceptionProperties
-  {
-    py::class_<PerceptionProperties, GeometryProperties> cls(
-        m, "PerceptionProperties", doc.PerceptionProperties.doc);
-    cls.def(py::init(), doc.PerceptionProperties.ctor.doc)
-        .def(py::init<const PerceptionProperties&>(), py::arg("other"),
-            "Creates a copy of the properties");
-    DefCopyAndDeepCopy(&cls);
-  }
-
-  // ProximityProperties
-  {
-    py::class_<ProximityProperties, GeometryProperties> cls(
-        m, "ProximityProperties", doc.ProximityProperties.doc);
-    cls.def(py::init(), doc.ProximityProperties.ctor.doc)
-        .def(py::init<const ProximityProperties&>(), py::arg("other"),
-            "Creates a copy of the properties");
-    DefCopyAndDeepCopy(&cls);
-  }
-
-  // Rgba
+void DefineRgba(py::module m) {
   {
     using Class = Rgba;
     constexpr auto& cls_doc = doc.Rgba;
@@ -416,8 +425,9 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefCopyAndDeepCopy(&cls);
     AddValueInstantiation<Rgba>(m);
   }
+}
 
-  // Role enumeration
+void DefineRole(py::module m) {
   {
     constexpr auto& cls_doc = doc.Role;
     py::enum_<Role>(m, "Role", py::arithmetic(), cls_doc.doc)
@@ -426,8 +436,9 @@ void DoScalarIndependentDefinitions(py::module m) {
         .value("kIllustration", Role::kIllustration, cls_doc.kIllustration.doc)
         .value("kPerception", Role::kPerception, cls_doc.kPerception.doc);
   }
+}
 
-  // RoleAssign enumeration
+void DefineRoleAssign(py::module m) {
   {
     constexpr auto& cls_doc = doc.RoleAssign;
     using Class = RoleAssign;
@@ -435,7 +446,9 @@ void DoScalarIndependentDefinitions(py::module m) {
         .value("kNew", Class::kNew, cls_doc.kNew.doc)
         .value("kReplace", Class::kReplace, cls_doc.kReplace.doc);
   }
+}
 
+void DefineShapes(py::module m) {
   // Shape constructors - ordered alphabetically and not in the order given in
   // shape_specification.h
   {
@@ -571,7 +584,9 @@ void DoScalarIndependentDefinitions(py::module m) {
                   std::get<2>(params));
             }));
   }
+}
 
+void DefineMiscFunctions(py::module m) {
   m.def("CalcVolume", &CalcVolume, py::arg("shape"), doc.CalcVolume.doc);
 
   m.def("MakePhongIllustrationProperties", &MakePhongIllustrationProperties,
@@ -653,7 +668,24 @@ void def_testing_module(py::module m) {
 void DefineGeometryCommon(py::module m) {
   m.doc() = "Bindings for `drake::geometry`";
 
-  DoScalarIndependentDefinitions(m);
+  // This list must remain in topological order.
+  DefineIdentifiers(m);
+  DefineRole(m);
+  DefineRoleAssign(m);
+  DefineRgba(m);
+  DefineGeometryFrame(m);
+  DefineGeometryProperties(m);
+  DefineGeometryPropertiesSubclasses(m);
+  DefineInMemoryMesh(m);
+  DefineMeshSource(m);
+  DefineShapes(m);
+  DefineGeometrySet(m);
+  DefineCollisionFilterDeclaration(m);
+  DefineCollisionFilterManager(m);
+  DefineGeometryInstance(m);
+  DefineGeometryVersion(m);
+  DefineMiscFunctions(m);
+
   testing::def_testing_module(m.def_submodule("_testing"));
 }
 

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -146,10 +146,16 @@ void DefineGeometryOptimization(py::module m) {
         .def("Projection", &ConvexSet::Projection, py::arg("points"),
             cls_doc.Projection.doc);
   }
-  // There is a dependency cycle between Hyperellipsoid and AffineBall, so we
+
+  // There is a dependency cycle between Hyperellipsoid <=> AffineBall, so we
   // need to "forward declare" the Hyperellipsoid class here.
   py::class_<Hyperellipsoid, ConvexSet> hyperellipsoid_cls(
       m, "Hyperellipsoid", doc.Hyperellipsoid.doc);
+
+  // There is a dependency cycle between VPolytope <=> HPolyhedron, so we
+  // need to "forward declare" the VPolytope class here.
+  py::class_<VPolytope, ConvexSet> vpolytope_cls(
+      m, "VPolytope", doc.VPolytope.doc);
 
   // AffineBall
   {
@@ -502,7 +508,7 @@ void DefineGeometryOptimization(py::module m) {
   // VPolytope
   {
     const auto& cls_doc = doc.VPolytope;
-    py::class_<VPolytope, ConvexSet>(m, "VPolytope", cls_doc.doc)
+    vpolytope_cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&>(),
             py::arg("vertices"), cls_doc.ctor.doc_vertices)

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -124,6 +124,34 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.near.doc);
   }
   {
+    using Class = RenderCameraCore;
+    const auto& cls_doc = doc.RenderCameraCore;
+    py::class_<Class> cls(m, "RenderCameraCore");
+    cls  // BR
+        .def(py::init<Class const&>(), py::arg("other"), "Copy constructor")
+        .def(
+            py::init<std::string, CameraInfo, ClippingRange, RigidTransformd>(),
+            py::arg("renderer_name"), py::arg("intrinsics"),
+            py::arg("clipping"), py::arg("X_BS"), cls_doc.ctor.doc)
+        .def("clipping",
+            static_cast<ClippingRange const& (Class::*)() const>(
+                &Class::clipping),
+            cls_doc.clipping.doc)
+        .def("intrinsics",
+            static_cast<CameraInfo const& (Class::*)() const>(
+                &Class::intrinsics),
+            cls_doc.intrinsics.doc)
+        .def("renderer_name",
+            static_cast<::std::string const& (Class::*)() const>(
+                &Class::renderer_name),
+            cls_doc.renderer_name.doc)
+        .def("sensor_pose_in_camera_body",
+            static_cast<RigidTransformd const& (Class::*)() const>(
+                &Class::sensor_pose_in_camera_body),
+            cls_doc.sensor_pose_in_camera_body.doc);
+    DefCopyAndDeepCopy(&cls);
+  }
+  {
     using Class = ColorRenderCamera;
     const auto& cls_doc = doc.ColorRenderCamera;
     py::class_<Class> cls(m, "ColorRenderCamera", cls_doc.doc);
@@ -174,33 +202,45 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.depth_range.doc);
     DefCopyAndDeepCopy(&cls);
   }
+
   {
-    using Class = RenderCameraCore;
-    const auto& cls_doc = doc.RenderCameraCore;
-    py::class_<Class> cls(m, "RenderCameraCore");
-    cls  // BR
-        .def(py::init<Class const&>(), py::arg("other"), "Copy constructor")
-        .def(
-            py::init<std::string, CameraInfo, ClippingRange, RigidTransformd>(),
-            py::arg("renderer_name"), py::arg("intrinsics"),
-            py::arg("clipping"), py::arg("X_BS"), cls_doc.ctor.doc)
-        .def("clipping",
-            static_cast<ClippingRange const& (Class::*)() const>(
-                &Class::clipping),
-            cls_doc.clipping.doc)
-        .def("intrinsics",
-            static_cast<CameraInfo const& (Class::*)() const>(
-                &Class::intrinsics),
-            cls_doc.intrinsics.doc)
-        .def("renderer_name",
-            static_cast<::std::string const& (Class::*)() const>(
-                &Class::renderer_name),
-            cls_doc.renderer_name.doc)
-        .def("sensor_pose_in_camera_body",
-            static_cast<RigidTransformd const& (Class::*)() const>(
-                &Class::sensor_pose_in_camera_body),
-            cls_doc.sensor_pose_in_camera_body.doc);
-    DefCopyAndDeepCopy(&cls);
+    py::class_<RenderLabel> render_label(m, "RenderLabel", doc.RenderLabel.doc);
+    render_label
+        .def(py::init<int>(), py::arg("value"), doc.RenderLabel.ctor.doc_1args)
+        .def("is_reserved", &RenderLabel::is_reserved)
+        .def("__int__", [](const RenderLabel& self) -> int { return self; })
+        .def("__repr__",
+            [](const RenderLabel& self) -> std::string {
+              if (self == RenderLabel::kEmpty) {
+                return "RenderLabel.kEmpty";
+              }
+              if (self == RenderLabel::kDoNotRender) {
+                return "RenderLabel.kDoNotRender";
+              }
+              if (self == RenderLabel::kDontCare) {
+                return "RenderLabel.kDontCare";
+              }
+              if (self == RenderLabel::kUnspecified) {
+                return "RenderLabel.kUnspecified";
+              }
+              if (self == RenderLabel::kMaxUnreserved) {
+                return "RenderLabel.kMaxUnreserved";
+              }
+              return fmt::format("RenderLabel({})", int{self});
+            })
+        // EQ(==).
+        .def(py::self == py::self)
+        .def(py::self == int{})
+        .def(int{} == py::self)
+        // NE(!=).
+        .def(py::self != py::self)
+        .def(py::self != int{})
+        .def(int{} != py::self);
+    render_label.attr("kEmpty") = RenderLabel::kEmpty;
+    render_label.attr("kDoNotRender") = RenderLabel::kDoNotRender;
+    render_label.attr("kDontCare") = RenderLabel::kDontCare;
+    render_label.attr("kUnspecified") = RenderLabel::kUnspecified;
+    render_label.attr("kMaxUnreserved") = RenderLabel::kMaxUnreserved;
   }
 
   {
@@ -283,46 +323,6 @@ void DoScalarIndependentDefinitions(py::module m) {
     // Note that we do not bind MakeRgbFromLabel nor MakeLabelFromRgb, because
     // crossing the C++ <=> Python boundary one pixel at a time would be
     // extraordinarily inefficient.
-  }
-
-  {
-    py::class_<RenderLabel> render_label(m, "RenderLabel", doc.RenderLabel.doc);
-    render_label
-        .def(py::init<int>(), py::arg("value"), doc.RenderLabel.ctor.doc_1args)
-        .def("is_reserved", &RenderLabel::is_reserved)
-        .def("__int__", [](const RenderLabel& self) -> int { return self; })
-        .def("__repr__",
-            [](const RenderLabel& self) -> std::string {
-              if (self == RenderLabel::kEmpty) {
-                return "RenderLabel.kEmpty";
-              }
-              if (self == RenderLabel::kDoNotRender) {
-                return "RenderLabel.kDoNotRender";
-              }
-              if (self == RenderLabel::kDontCare) {
-                return "RenderLabel.kDontCare";
-              }
-              if (self == RenderLabel::kUnspecified) {
-                return "RenderLabel.kUnspecified";
-              }
-              if (self == RenderLabel::kMaxUnreserved) {
-                return "RenderLabel.kMaxUnreserved";
-              }
-              return fmt::format("RenderLabel({})", int{self});
-            })
-        // EQ(==).
-        .def(py::self == py::self)
-        .def(py::self == int{})
-        .def(int{} == py::self)
-        // NE(!=).
-        .def(py::self != py::self)
-        .def(py::self != int{})
-        .def(int{} != py::self);
-    render_label.attr("kEmpty") = RenderLabel::kEmpty;
-    render_label.attr("kDoNotRender") = RenderLabel::kDoNotRender;
-    render_label.attr("kDontCare") = RenderLabel::kDontCare;
-    render_label.attr("kUnspecified") = RenderLabel::kUnspecified;
-    render_label.attr("kMaxUnreserved") = RenderLabel::kMaxUnreserved;
   }
 
   {

--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -20,12 +20,14 @@ namespace {
 using systems::Context;
 using systems::LeafSystem;
 
+// NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+using namespace drake::geometry;
+constexpr auto& doc = pydrake_doc.drake.geometry;
+
+// TODO(jwnimmer-tri) Reformat this entire file to remove the unnecessary
+// indentation.
+
 void DoScalarIndependentDefinitions(py::module m) {
-  constexpr auto& doc = pydrake_doc.drake.geometry;
-
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::geometry;
-
   // HydroelasticContactRepresentation enumeration
   {
     using Class = HydroelasticContactRepresentation;
@@ -59,13 +61,8 @@ void DoScalarIndependentDefinitions(py::module m) {
 }
 
 template <typename T>
-void DoScalarDependentDefinitions(py::module m, T) {
+void DefineSceneGraphInspector(py::module m, T) {
   py::tuple param = GetPyParam<T>();
-  constexpr auto& doc = pydrake_doc.drake.geometry;
-
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::geometry;
-
   //  SceneGraphInspector
   {
     using Class = SceneGraphInspector<T>;
@@ -181,7 +178,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("geometry_version", &Class::geometry_version,
             py_rvp::reference_internal, cls_doc.geometry_version.doc);
   }
+}
 
+template <typename T>
+void DefineSceneGraph(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
   //  SceneGraph
   {
     using Class = SceneGraph<T>;
@@ -422,8 +423,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def_static("world_frame_id", &Class::world_frame_id,
             cls_doc.world_frame_id.doc);
   }
+}
 
-  //  FramePoseVector
+template <typename T>
+void DefineFramePoseVector(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
   {
     using Class = FramePoseVector<T>;
     auto cls = DefineTemplateClassWithDefault<Class>(
@@ -448,8 +452,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("ids", &FramePoseVector<T>::ids, doc.KinematicsVector.ids.doc);
     AddValueInstantiation<FramePoseVector<T>>(m);
   }
+}
 
-  //  QueryObject
+template <typename T>
+void DefineQueryObject(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
   {
     using Class = QueryObject<T>;
     constexpr auto& cls_doc = doc.QueryObject;
@@ -552,8 +559,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
 
     AddValueInstantiation<QueryObject<T>>(m);
   }
+}
 
-  // SignedDistancePair
+template <typename T>
+void DefineSignedDistancePair(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
   {
     using Class = SignedDistancePair<T>;
     auto cls = DefineTemplateClassWithDefault<Class>(
@@ -576,8 +586,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
             return_value_policy_for_scalar_type<T>(),
             doc.SignedDistancePair.nhat_BA_W.doc);
   }
+}
 
-  // SignedDistanceToPoint
+template <typename T>
+void DefineSignedDistanceToPoint(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
   {
     using Class = SignedDistanceToPoint<T>;
     auto cls = DefineTemplateClassWithDefault<Class>(
@@ -595,8 +608,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
             return_value_policy_for_scalar_type<T>(),
             doc.SignedDistanceToPoint.grad_W.doc);
   }
+}
 
-  // PenetrationAsPointPair
+template <typename T>
+void DefinePenetrationAsPointPair(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
   {
     using Class = PenetrationAsPointPair<T>;
     auto cls = DefineTemplateClassWithDefault<Class>(
@@ -616,8 +632,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def_readwrite("depth", &PenetrationAsPointPair<T>::depth,
             doc.PenetrationAsPointPair.depth.doc);
   }
+}
 
-  // ContactSurface
+template <typename T>
+void DefineContactSurface(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
   // Currently we do not bind the constructor because users do not need to
   // construct it directly yet. We can get it from ComputeContactSurface*().
   if constexpr (scalar_predicate<T>::is_bool) {
@@ -661,13 +680,24 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("Equal", &Class::Equal, py::arg("surface"), cls_doc.Equal.doc);
     DefCopyAndDeepCopy(&cls);
   }
-}  // NOLINT(readability/fn_size)
+}
 }  // namespace
 
 void DefineGeometrySceneGraph(py::module m) {
   py::module::import("pydrake.systems.framework");
   DoScalarIndependentDefinitions(m);
-  type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
+  type_visit(
+      [m](auto dummy) {
+        // This list must remain in topological order.
+        DefineFramePoseVector(m, dummy);
+        DefineContactSurface(m, dummy);
+        DefinePenetrationAsPointPair(m, dummy);
+        DefineSignedDistancePair(m, dummy);
+        DefineSignedDistanceToPoint(m, dummy);
+        DefineSceneGraphInspector(m, dummy);
+        DefineQueryObject(m, dummy);
+        DefineSceneGraph(m, dummy);
+      },
       CommonScalarPack{});
 }
 }  // namespace pydrake

--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -22,17 +22,16 @@ using math::RigidTransformd;
 using systems::Context;
 using systems::LeafSystem;
 
+// NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+using namespace drake::geometry;
+constexpr auto& doc = pydrake_doc.drake.geometry;
+
+// TODO(jwnimmer-tri) Reformat this entire file to remove the unnecessary
+// indentation.
+
 template <typename T>
-void DoScalarDependentDefinitions(py::module m, T) {
+void DefineDrakeVisualizer(py::module m, T) {
   py::tuple param = GetPyParam<T>();
-  constexpr auto& doc = pydrake_doc.drake.geometry;
-
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::geometry;
-  py::module::import("pydrake.systems.framework");
-  py::module::import("pydrake.systems.lcm");
-
-  // DrakeVisualizer
   {
     using Class = DrakeVisualizer<T>;
     constexpr auto& cls_doc = doc.DrakeVisualizer;
@@ -76,8 +75,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("lcm"), py::arg("params") = DrakeVisualizerParams{},
             cls_doc.DispatchLoadMessage.doc);
   }
+}
 
-  // MeshcatPointCloudVisualizer
+template <typename T>
+void DefineMeshcatPointCloudVisualizer(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
   {
     using Class = MeshcatPointCloudVisualizer<T>;
     constexpr auto& cls_doc = doc.MeshcatPointCloudVisualizer;
@@ -99,8 +101,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("pose_input_port", &Class::pose_input_port,
             py_rvp::reference_internal, cls_doc.pose_input_port.doc);
   }
+}
 
-  // MeshcatVisualizer
+template <typename T>
+void DefineMeshcatVisualizer(py::module m, T) {
+  py::tuple param = GetPyParam<T>();
   {
     using Class = MeshcatVisualizer<T>;
     constexpr auto& cls_doc = doc.MeshcatVisualizer;
@@ -147,7 +152,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py_rvp::reference,
             cls_doc.AddToBuilder
                 .doc_4args_builder_query_object_port_meshcat_params);
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls  // BR
@@ -159,12 +163,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
   }
 }
 
-void DoScalarIndependentDefinitions(py::module m) {
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::geometry;
-  constexpr auto& doc = pydrake_doc.drake.geometry;
-
-  // DrakeVisualizerParams
+void DefineDrakeVisualizerParams(py::module m) {
   {
     using Class = DrakeVisualizerParams;
     constexpr auto& cls_doc = doc.DrakeVisualizerParams;
@@ -176,8 +175,9 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefReprUsingSerialize(&cls);
     DefCopyAndDeepCopy(&cls);
   }
+}
 
-  // MeshcatParams
+void DefineMeshcatParams(py::module m) {
   {
     using Class = MeshcatParams;
     constexpr auto& cls_doc = doc.MeshcatParams;
@@ -198,8 +198,9 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefReprUsingSerialize(&cls);
     DefCopyAndDeepCopy(&cls);
   }
+}
 
-  // Meshcat
+void DefineMeshcat(py::module m) {
   {
     using Class = Meshcat;
     constexpr auto& cls_doc = doc.Meshcat;
@@ -216,6 +217,35 @@ void DoScalarIndependentDefinitions(py::module m) {
             side_doc.kBackSide.doc)
         .value("kDoubleSide", Meshcat::SideOfFaceToRender::kDoubleSide,
             side_doc.kDoubleSide.doc);
+
+    const auto& perspective_camera_doc = doc.Meshcat.PerspectiveCamera;
+    py::class_<Meshcat::PerspectiveCamera> perspective_camera_cls(
+        meshcat, "PerspectiveCamera", perspective_camera_doc.doc);
+    perspective_camera_cls  // BR
+        .def(ParamInit<Meshcat::PerspectiveCamera>());
+    DefAttributesUsingSerialize(
+        &perspective_camera_cls, perspective_camera_doc);
+    DefReprUsingSerialize(&perspective_camera_cls);
+    DefCopyAndDeepCopy(&perspective_camera_cls);
+
+    const auto& orthographic_camera_doc = doc.Meshcat.OrthographicCamera;
+    py::class_<Meshcat::OrthographicCamera> orthographic_camera_cls(
+        meshcat, "OrthographicCamera", orthographic_camera_doc.doc);
+    orthographic_camera_cls  // BR
+        .def(ParamInit<Meshcat::OrthographicCamera>());
+    DefAttributesUsingSerialize(
+        &orthographic_camera_cls, orthographic_camera_doc);
+    DefReprUsingSerialize(&orthographic_camera_cls);
+    DefCopyAndDeepCopy(&orthographic_camera_cls);
+
+    const auto& gamepad_doc = doc.Meshcat.Gamepad;
+    py::class_<Meshcat::Gamepad> gamepad_cls(
+        meshcat, "Gamepad", gamepad_doc.doc);
+    gamepad_cls  // BR
+        .def(ParamInit<Meshcat::Gamepad>());
+    DefAttributesUsingSerialize(&gamepad_cls, gamepad_doc);
+    DefReprUsingSerialize(&gamepad_cls);
+    DefCopyAndDeepCopy(&gamepad_cls);
 
     meshcat  // BR
         .def(py::init<std::optional<int>>(), py::arg("port") = std::nullopt,
@@ -412,42 +442,25 @@ void DoScalarIndependentDefinitions(py::module m) {
               self.InjectWebsocketMessage(message_view);
             },
             py::arg("message"));
-
-    const auto& perspective_camera_doc = doc.Meshcat.PerspectiveCamera;
-    py::class_<Meshcat::PerspectiveCamera> perspective_camera_cls(
-        meshcat, "PerspectiveCamera", perspective_camera_doc.doc);
-    perspective_camera_cls  // BR
-        .def(ParamInit<Meshcat::PerspectiveCamera>());
-    DefAttributesUsingSerialize(
-        &perspective_camera_cls, perspective_camera_doc);
-    DefReprUsingSerialize(&perspective_camera_cls);
-    DefCopyAndDeepCopy(&perspective_camera_cls);
-
-    const auto& orthographic_camera_doc = doc.Meshcat.OrthographicCamera;
-    py::class_<Meshcat::OrthographicCamera> orthographic_camera_cls(
-        meshcat, "OrthographicCamera", orthographic_camera_doc.doc);
-    orthographic_camera_cls  // BR
-        .def(ParamInit<Meshcat::OrthographicCamera>());
-    DefAttributesUsingSerialize(
-        &orthographic_camera_cls, orthographic_camera_doc);
-    DefReprUsingSerialize(&orthographic_camera_cls);
-    DefCopyAndDeepCopy(&orthographic_camera_cls);
-
-    const auto& gamepad_doc = doc.Meshcat.Gamepad;
-    py::class_<Meshcat::Gamepad> gamepad_cls(
-        meshcat, "Gamepad", gamepad_doc.doc);
-    gamepad_cls  // BR
-        .def(ParamInit<Meshcat::Gamepad>());
-    DefAttributesUsingSerialize(&gamepad_cls, gamepad_doc);
-    DefReprUsingSerialize(&gamepad_cls);
-    DefCopyAndDeepCopy(&gamepad_cls);
   }
+}
 
-  // MeshcatAnimation
+void DefineMeshcatAnimation(py::module m) {
   {
     using Class = MeshcatAnimation;
     constexpr auto& cls_doc = doc.MeshcatAnimation;
     py::class_<Class> cls(m, "MeshcatAnimation", cls_doc.doc);
+
+    // MeshcatAnimation::LoopMode enumeration
+    constexpr auto& loop_doc = doc.MeshcatAnimation.LoopMode;
+    py::enum_<MeshcatAnimation::LoopMode>(cls, "LoopMode", loop_doc.doc)
+        .value("kLoopOnce", MeshcatAnimation::LoopMode::kLoopOnce,
+            loop_doc.kLoopOnce.doc)
+        .value("kLoopRepeat", MeshcatAnimation::LoopMode::kLoopRepeat,
+            loop_doc.kLoopRepeat.doc)
+        .value("kLoopPingPong", MeshcatAnimation::LoopMode::kLoopPingPong,
+            loop_doc.kLoopPingPong.doc);
+
     cls  // BR
         .def(py::init<double>(), py::arg("frames_per_second") = 64.0,
             cls_doc.ctor.doc)
@@ -488,19 +501,10 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("value"), cls_doc.SetProperty.doc_vector_double);
     // Note: We don't bind get_key_frame and get_javascript_type (at least
     // not yet); they are meant primarily for testing.
-
-    // MeshcatAnimation::LoopMode enumeration
-    constexpr auto& loop_doc = doc.MeshcatAnimation.LoopMode;
-    py::enum_<MeshcatAnimation::LoopMode>(cls, "LoopMode", loop_doc.doc)
-        .value("kLoopOnce", MeshcatAnimation::LoopMode::kLoopOnce,
-            loop_doc.kLoopOnce.doc)
-        .value("kLoopRepeat", MeshcatAnimation::LoopMode::kLoopRepeat,
-            loop_doc.kLoopRepeat.doc)
-        .value("kLoopPingPong", MeshcatAnimation::LoopMode::kLoopPingPong,
-            loop_doc.kLoopPingPong.doc);
   }
+}
 
-  // MeshcatVisualizerParams
+void DefineMeshcatVisualizerParams(py::module m) {
   {
     using Class = MeshcatVisualizerParams;
     constexpr auto& cls_doc = doc.MeshcatVisualizerParams;
@@ -517,9 +521,23 @@ void DoScalarIndependentDefinitions(py::module m) {
 }  // namespace
 
 void DefineGeometryVisualizers(py::module m) {
-  DoScalarIndependentDefinitions(m);
-  type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
+  py::module::import("pydrake.systems.framework");
+  py::module::import("pydrake.systems.lcm");
+
+  // This list must remain in topological order.
+  DefineMeshcatParams(m);
+  DefineDrakeVisualizerParams(m);
+  DefineMeshcatVisualizerParams(m);
+  DefineMeshcatAnimation(m);
+  DefineMeshcat(m);
+  type_visit(
+      [m](auto dummy) {
+        DefineDrakeVisualizer(m, dummy);
+        DefineMeshcatPointCloudVisualizer(m, dummy);
+        DefineMeshcatVisualizer(m, dummy);
+      },
       NonSymbolicScalarPack{});
 }
+
 }  // namespace pydrake
 }  // namespace drake


### PR DESCRIPTION
Adjust bindings to follow topological order, so that function signatures can look up their requisite python types.

This is not a 100% fix -- dependencies on other modules (`perception` and `multibody.math`) still show up as dangling due to module cycles.

Here's one example of broken docs / types: [`QueryObject.ComputeContactSurfaces`](https://drake.mit.edu/pydrake/pydrake.geometry.html#pydrake.geometry.QueryObject.ComputeContactSurfaces).

Towards #17520.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21907)
<!-- Reviewable:end -->
