### PR TITLE
[py math] Fix signatures to use Python types (not C++)

### DIFF
--- a/bindings/pydrake/symbolic/symbolic_py_monolith.cc
+++ b/bindings/pydrake/symbolic/symbolic_py_monolith.cc
@@ -29,6 +29,13 @@ void DefineSymbolicMonolith(py::module m) {
   using namespace drake::symbolic;
   constexpr auto& doc = pydrake_doc.drake.symbolic;
 
+  // These declarations must be first, because low-level operators return them.
+  py::class_<Expression> expr_cls(m, "Expression", doc.Expression.doc);
+  py::class_<Formula> formula_cls(m, "Formula", doc.Formula.doc);
+  py::class_<Polynomial> polynomial_cls(m, "Polynomial", doc.Polynomial.doc);
+  py::class_<RationalFunction> rat_fun_cls(
+      m, "RationalFunction", doc.RationalFunction.doc);
+
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
   py::class_<Variable> var_cls(m, "Variable", doc.Variable.doc);
   constexpr auto& var_doc = doc.Variable;
@@ -304,7 +311,6 @@ void DefineSymbolicMonolith(py::module m) {
   }
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
-  py::class_<Expression> expr_cls(m, "Expression", doc.Expression.doc);
   expr_cls.def(py::init<>(), doc.Expression.ctor.doc_0args)
       .def(py::init<double>(), py::arg("constant"),
           doc.Expression.ctor.doc_1args_constant)
@@ -562,7 +568,6 @@ void DefineSymbolicMonolith(py::module m) {
             cls_doc.PositiveSemidefinite.doc);
   }
 
-  py::class_<Formula> formula_cls(m, "Formula", doc.Formula.doc);
   formula_cls.def(py::init<>(), doc.Formula.ctor.doc_0args)
       .def(py::init<bool>(), py::arg("value").noconvert(),
           doc.Formula.ctor.doc_1args_value)
@@ -761,10 +766,16 @@ void DefineSymbolicMonolith(py::module m) {
           py::arg("sort_monomial") = false,
           doc.CalcMonomialBasisOrderUpToOne.doc);
 
+  py::class_<Polynomial::SubstituteAndExpandCacheData>(m,
+      "SubstituteAndExpandCacheData",
+      doc.Polynomial.SubstituteAndExpandCacheData.doc)
+      .def(py::init<>())
+      .def("get_data", &Polynomial::SubstituteAndExpandCacheData::get_data,
+          py_rvp::reference);
+
   using symbolic::Polynomial;
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
-  py::class_<Polynomial> polynomial_cls(m, "Polynomial", doc.Polynomial.doc);
   polynomial_cls.def(py::init<>(), doc.Polynomial.ctor.doc_0args)
       .def(py::init<Polynomial::MapType>(), py::arg("map"),
           doc.Polynomial.ctor.doc_1args_map)
@@ -927,13 +938,6 @@ void DefineSymbolicMonolith(py::module m) {
           },
           py::arg("vars"), doc.Polynomial.Jacobian.doc);
 
-  py::class_<Polynomial::SubstituteAndExpandCacheData>(m,
-      "SubstituteAndExpandCacheData",
-      doc.Polynomial.SubstituteAndExpandCacheData.doc)
-      .def(py::init<>())
-      .def("get_data", &Polynomial::SubstituteAndExpandCacheData::get_data,
-          py_rvp::reference);
-
   // Bind CalcPolynomialWLowerTriangularPart
   m.def(
        "CalcPolynomialWLowerTriangularPart",
@@ -965,8 +969,6 @@ void DefineSymbolicMonolith(py::module m) {
           py::arg("monomial_basis"), py::arg("gram_lower"),
           doc.CalcPolynomialWLowerTriangularPart.doc);
 
-  py::class_<RationalFunction> rat_fun_cls(
-      m, "RationalFunction", doc.RationalFunction.doc);
   rat_fun_cls.def(py::init<>(), doc.RationalFunction.ctor.doc_0args)
       .def(py::init<Polynomial, Polynomial>(), py::arg("numerator"),
           py::arg("denominator"),


### PR DESCRIPTION
Adjust bindings to follow topological order, so that function signatures can look up their requisite python types.

Here's one example of broken docs / types: [`RigidTransform.__init__`](https://drake.mit.edu/pydrake/pydrake.math.html#pydrake.math.RigidTransform.__init__).

Towards #17520.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21908)
<!-- Reviewable:end -->
