### PR TITLE
[py solvers] Fix signatures to use Python types (not C++)

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -268,7 +268,7 @@ class PySolverInterface : public py::wrapper<solvers::SolverInterface> {
   }
 };
 
-void BindSolverInterfaceAndFlags(py::module m) {
+void BindSolverInterface(py::module m) {
   constexpr auto& doc = pydrake_doc.drake.solvers;
   py::class_<SolverInterface, PySolverInterface>(
       m, "SolverInterface", doc.SolverInterface.doc)
@@ -329,7 +329,10 @@ void BindSolverInterfaceAndFlags(py::module m) {
           })
       .def("SolverName",
           [](const SolverInterface& self) { return self.solver_id().name(); });
+}
 
+void BindSolverIdAndType(py::module m) {
+  constexpr auto& doc = pydrake_doc.drake.solvers;
   py::class_<SolverId>(m, "SolverId", doc.SolverId.doc)
       .def(py::init<std::string>(), py::arg("name"), doc.SolverId.ctor.doc)
       .def("name", &SolverId::name, doc.SolverId.name.doc)
@@ -366,6 +369,20 @@ void BindSolverInterfaceAndFlags(py::module m) {
       .value("kSnopt", SolverType::kSnopt, doc.SolverType.kSnopt.doc)
       .value("kUnrevisedLemke", SolverType::kUnrevisedLemke,
           doc.SolverType.kUnrevisedLemke.doc);
+}
+
+void BindSolverOptions(py::module m) {
+  constexpr auto& doc = pydrake_doc.drake.solvers;
+
+  py::enum_<CommonSolverOption>(
+      m, "CommonSolverOption", doc.CommonSolverOption.doc)
+      .value("kPrintFileName", CommonSolverOption::kPrintFileName,
+          doc.CommonSolverOption.kPrintFileName.doc)
+      .value("kPrintToConsole", CommonSolverOption::kPrintToConsole,
+          doc.CommonSolverOption.kPrintToConsole.doc)
+      .value("kStandaloneReproductionFileName",
+          CommonSolverOption::kStandaloneReproductionFileName,
+          doc.CommonSolverOption.kStandaloneReproductionFileName.doc);
 
   // TODO(jwnimmer-tri) Bind the accessors for SolverOptions.
   py::class_<SolverOptions>(m, "SolverOptions", doc.SolverOptions.doc)
@@ -417,19 +434,9 @@ void BindSolverInterfaceAndFlags(py::module m) {
         // we should enhance this to provide more details.
         return "<SolverOptions>";
       });
-
-  py::enum_<CommonSolverOption>(
-      m, "CommonSolverOption", doc.CommonSolverOption.doc)
-      .value("kPrintFileName", CommonSolverOption::kPrintFileName,
-          doc.CommonSolverOption.kPrintFileName.doc)
-      .value("kPrintToConsole", CommonSolverOption::kPrintToConsole,
-          doc.CommonSolverOption.kPrintToConsole.doc)
-      .value("kStandaloneReproductionFileName",
-          CommonSolverOption::kStandaloneReproductionFileName,
-          doc.CommonSolverOption.kStandaloneReproductionFileName.doc);
 }
 
-void BindMathematicalProgram(py::module m) {
+void BindMathematicalProgramResult(py::module m) {
   constexpr auto& doc = pydrake_doc.drake.solvers;
   py::class_<MathematicalProgramResult>(
       m, "MathematicalProgramResult", doc.MathematicalProgramResult.doc)
@@ -559,7 +566,10 @@ void BindMathematicalProgram(py::module m) {
           &MathematicalProgramResult::GetInfeasibleConstraintNames,
           py::arg("prog"), py::arg("tol") = std::nullopt,
           doc.MathematicalProgramResult.GetInfeasibleConstraintNames.doc);
+}
 
+void BindMathematicalProgram(py::module m) {
+  constexpr auto& doc = pydrake_doc.drake.solvers;
   py::class_<MathematicalProgram> prog_cls(
       m, "MathematicalProgram", doc.MathematicalProgram.doc);
   prog_cls.def(py::init<>(), doc.MathematicalProgram.ctor.doc);
@@ -1607,7 +1617,10 @@ for every column of ``prog_var_vals``. )""")
           &MathematicalProgram::RemoveVisualizationCallback,
           py::arg("callback"),
           doc.MathematicalProgram.RemoveVisualizationCallback.doc);
+}  // NOLINT(readability/fn_size)
 
+void BindSolutionResult(py::module m) {
+  constexpr auto& doc = pydrake_doc.drake.solvers;
   py::enum_<SolutionResult> solution_result_enum(
       m, "SolutionResult", doc.SolutionResult.doc);
   solution_result_enum
@@ -1629,7 +1642,7 @@ for every column of ``prog_var_vals``. )""")
           doc.SolutionResult.kDualInfeasible.doc)
       .value("kSolutionResultNotSet", SolutionResult::kSolutionResultNotSet,
           doc.SolutionResult.kSolutionResultNotSet.doc);
-}  // NOLINT(readability/fn_size)
+}
 
 void BindPyFunctionConstraint(py::module m) {
   py::class_<PyFunctionConstraint, Constraint,
@@ -1670,9 +1683,14 @@ void BindFreeFunctions(py::module m) {
 
 namespace internal {
 void DefineSolversMathematicalProgram(py::module m) {
+  // This list must remain in topological order.
   BindPyFunctionConstraint(m);
-  BindSolverInterfaceAndFlags(m);
+  BindSolverIdAndType(m);
+  BindSolverOptions(m);
   BindMathematicalProgram(m);
+  BindSolutionResult(m);
+  BindMathematicalProgramResult(m);
+  BindSolverInterface(m);
   BindFreeFunctions(m);
 }
 }  // namespace internal


### PR DESCRIPTION
Adjust bindings to follow topological order, so that function signatures can look up their requisite python types.

Here's one example of broken docs / types: [`MathematicalProgramResult.get_solution_result`](https://drake.mit.edu/pydrake/pydrake.solvers.html#pydrake.solvers.MathematicalProgramResult.get_solution_result).

Towards #17520.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21909)
<!-- Reviewable:end -->
