### PR TITLE
[py rational] Fix signatures to use Python types (not C++)

### DIFF
--- a/bindings/pydrake/multibody/rational_py.cc
+++ b/bindings/pydrake/multibody/rational_py.cc
@@ -27,6 +27,10 @@ PYBIND11_MODULE(rational, m) {
   m.doc() = "RationalForwardKinematics module";
   py::module::import("pydrake.math");
   py::module::import("pydrake.multibody.plant");
+
+  type_pack<symbolic::Polynomial, symbolic::RationalFunction> sym_pack;
+  type_visit([m](auto dummy) { DoPoseDeclaration(m, dummy); }, sym_pack);
+
   {
     using Class = drake::multibody::RationalForwardKinematics;
     constexpr auto& cls_doc = doc.RationalForwardKinematics;
@@ -91,9 +95,6 @@ PYBIND11_MODULE(rational, m) {
             },
             py::arg("s_val"), py::arg("q_star_val"), cls_doc.ComputeQValue.doc);
   }
-
-  type_pack<symbolic::Polynomial, symbolic::RationalFunction> sym_pack;
-  type_visit([m](auto dummy) { DoPoseDeclaration(m, dummy); }, sym_pack);
 }
 }  // namespace
 }  // namespace pydrake


### PR DESCRIPTION
Towards #17520.

The best place to see the resulting effects is the docs. Here's one example of broken docs / types: [RationalForwardKinematics](https://drake.mit.edu/pydrake/pydrake.multibody.rational.html#pydrake.multibody.rational.RationalForwardKinematics).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21917)
<!-- Reviewable:end -->
