### PR TITLE
[py optimization] Fix signatures to use Python types (not C++)

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -668,7 +668,7 @@ void def_testing_module(py::module m) {
 void DefineGeometryCommon(py::module m) {
   m.doc() = "Bindings for `drake::geometry`";
 
-  // This list must remain in topological order.
+  // This list must remain in topological dependency order.
   DefineIdentifiers(m);
   DefineRole(m);
   DefineRoleAssign(m);

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -38,21 +38,34 @@
 
 namespace drake {
 namespace pydrake {
+namespace {
 
-// CSpaceSeparatingPlane, CIrisSeparatingPlane
-template <typename T>
-void DoSeparatingPlaneDeclaration(py::module m, T) {
-  constexpr auto& doc = pydrake_doc.drake.geometry.optimization;
-  py::tuple param = GetPyParam<T>();
-  using Class = geometry::optimization::CSpaceSeparatingPlane<T>;
-  constexpr auto& base_cls_doc = doc.CSpaceSeparatingPlane;
-  {
-    auto cls =
-        DefineTemplateClassWithDefault<Class>(
-            m, "CSpaceSeparatingPlane", param, base_cls_doc.doc)
-            // Use py_rvp::copy here because numpy.ndarray with dtype=object
-            // arrays must be copied, and cannot be referenced.
-            .def_readonly("a", &Class::a, py_rvp::copy, base_cls_doc.a.doc)
+// NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+using namespace drake::geometry;
+// NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+using namespace drake::geometry::optimization;
+constexpr auto& doc = pydrake_doc.drake.geometry.optimization;
+
+// Definitions for cspace_separating_plane.h.
+void DefineCspaceSeparatingPlane(py::module m) {
+  py::enum_<SeparatingPlaneOrder>(
+      m, "SeparatingPlaneOrder", doc.SeparatingPlaneOrder.doc)
+      .value("kAffine", SeparatingPlaneOrder::kAffine,
+          doc.SeparatingPlaneOrder.kAffine.doc);
+
+  type_visit(
+      [m]<typename T>(const T& /* unused */) {
+        py::tuple param = GetPyParam<T>();
+        using Class = geometry::optimization::CSpaceSeparatingPlane<T>;
+        constexpr auto& base_cls_doc = doc.CSpaceSeparatingPlane;
+        auto cls = DefineTemplateClassWithDefault<Class>(
+            m, "CSpaceSeparatingPlane", param, base_cls_doc.doc);
+        cls  // BR
+            .def_readonly("a", &Class::a,
+                // Use py_rvp::copy here because numpy.ndarray with
+                // dtype=object arrays must be copied, and cannot be
+                // referenced.
+                py_rvp::copy, base_cls_doc.a.doc)
             .def_readonly("b", &Class::b, base_cls_doc.b.doc)
             .def_readonly("positive_side_geometry",
                 &Class::positive_side_geometry,
@@ -63,27 +76,18 @@ void DoSeparatingPlaneDeclaration(py::module m, T) {
             .def_readonly("expressed_body", &Class::expressed_body,
                 base_cls_doc.expressed_body.doc)
             .def_readonly("plane_degree", &Class::plane_degree)
-            // Use py_rvp::copy here because numpy.ndarray with dtype=object
-            // arrays must be copied, and cannot be referenced.
             .def_readonly("decision_variables", &Class::decision_variables,
+                // Use py_rvp::copy here because numpy.ndarray with
+                // dtype=object arrays must be copied, and cannot be
+                // referenced.
                 py_rvp::copy, base_cls_doc.a.doc);
-    DefCopyAndDeepCopy(&cls);
-    AddValueInstantiation<Class>(m);
-  }
+        DefCopyAndDeepCopy(&cls);
+        AddValueInstantiation<Class>(m);
+      },
+      type_pack<double, symbolic::Variable>());
 }
 
-void DefineGeometryOptimization(py::module m) {
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake;
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::geometry;
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::geometry::optimization;
-  m.doc() = "Local bindings for `drake::geometry::optimization`";
-  constexpr auto& doc = pydrake_doc.drake.geometry.optimization;
-
-  py::module::import("pydrake.solvers");
-
+void DefineConvexSetBaseClassAndSubclasses(py::module m) {
   // SampledVolume. This struct must be declared before ConvexSet as methods in
   // ConvexSet depend on this struct.
   {
@@ -531,7 +535,9 @@ void DefineGeometryOptimization(py::module m) {
         .def(py::pickle([](const VPolytope& self) { return self.vertices(); },
             [](Eigen::MatrixXd arg) { return VPolytope(arg); }));
   }
+}
 
+void DefineIris(py::module m) {
   {
     const auto& cls_doc = doc.IrisOptions;
     py::class_<IrisOptions> iris_options(m, "IrisOptions", cls_doc.doc);
@@ -666,7 +672,9 @@ void DefineGeometryOptimization(py::module m) {
       },
       py::arg("filename"), py::arg("child_name") = std::nullopt,
       "Calls LoadYamlFile() to deserialize an IrisRegions object.");
+}
 
+void DefineGraphOfConvexSetsAndRelated(py::module m) {
   // GraphOfConvexSetsOptions
   {
     const auto& cls_doc = doc.GraphOfConvexSetsOptions;
@@ -1061,8 +1069,11 @@ void DefineGeometryOptimization(py::module m) {
             py::arg("initial_guess") = nullptr,
             cls_doc.SolveConvexRestriction.doc);
   }
+}
+
+// Definitions for c_iris_collision_geometry.h.
+void DefineCIrisCollisionGeometry(py::module m) {
   {
-    // Definitions for c_iris_collision_geometry.h/cc
     py::enum_<PlaneSide>(m, "PlaneSide", doc.PlaneSide.doc)
         .value("kPositive", PlaneSide::kPositive)
         .value("kNegative", PlaneSide::kNegative);
@@ -1093,16 +1104,11 @@ void DefineGeometryOptimization(py::module m) {
         .def("num_rationals", &CIrisCollisionGeometry::num_rationals,
             doc.CIrisCollisionGeometry.num_rationals.doc);
   }
+}
+
+// Definitions for cpsace_free_structs.h.
+void DefineCspaceFreeStructs(py::module m) {
   {
-    py::enum_<SeparatingPlaneOrder>(
-        m, "SeparatingPlaneOrder", doc.SeparatingPlaneOrder.doc)
-        .value("kAffine", SeparatingPlaneOrder::kAffine,
-            doc.SeparatingPlaneOrder.kAffine.doc);
-    type_visit([m](auto dummy) { DoSeparatingPlaneDeclaration(m, dummy); },
-        type_pack<double, symbolic::Variable>());
-  }
-  {
-    // Definitions for cpsace_free_structs.h/cc
     constexpr auto& prog_doc = doc.SeparationCertificateProgramBase;
     auto prog_cls = py::class_<SeparationCertificateProgramBase>(
         m, "SeparationCertificateProgramBase", prog_doc.doc)
@@ -1141,6 +1147,9 @@ void DefineGeometryOptimization(py::module m) {
             .def_readwrite("solver_options",
                 &FindSeparationCertificateOptions::solver_options);
   }
+}
+
+void DefineCspaceFreePolytopeAndRelated(py::module m) {
   {
     using BaseClass = CspaceFreePolytopeBase;
     const auto& base_cls_doc = doc.CspaceFreePolytopeBase;
@@ -1360,8 +1369,9 @@ void DefineGeometryOptimization(py::module m) {
             py::call_guard<py::gil_scoped_release>(),
             cls_doc.SolveSeparationCertificateProgram.doc);
   }
+}
 
-  using drake::geometry::optimization::ConvexSet;
+void DefineGeodesicConvexity(py::module m) {
   m.def("CheckIfSatisfiesConvexityRadius", &CheckIfSatisfiesConvexityRadius,
       py::arg("convex_set"), py::arg("continuous_revolute_joints"),
       doc.CheckIfSatisfiesConvexityRadius.doc);
@@ -1526,7 +1536,24 @@ void DefineGeometryOptimization(py::module m) {
       doc.CalcPairwiseIntersections
           .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_bboxes);
 #pragma GCC diagnostic pop
-  // NOLINTNEXTLINE(readability/fn_size)
+}
+
+}  // namespace
+
+void DefineGeometryOptimization(py::module m) {
+  m.doc() = "Local bindings for `drake::geometry::optimization`";
+
+  py::module::import("pydrake.solvers");
+
+  // This list must remain in topological dependency order.
+  DefineConvexSetBaseClassAndSubclasses(m);
+  DefineGeodesicConvexity(m);
+  DefineGraphOfConvexSetsAndRelated(m);
+  DefineIris(m);
+  DefineCIrisCollisionGeometry(m);
+  DefineCspaceSeparatingPlane(m);
+  DefineCspaceFreeStructs(m);
+  DefineCspaceFreePolytopeAndRelated(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -688,7 +688,7 @@ void DefineGeometrySceneGraph(py::module m) {
   DoScalarIndependentDefinitions(m);
   type_visit(
       [m](auto dummy) {
-        // This list must remain in topological order.
+        // This list must remain in topological dependency order.
         DefineFramePoseVector(m, dummy);
         DefineContactSurface(m, dummy);
         DefinePenetrationAsPointPair(m, dummy);

--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -524,7 +524,7 @@ void DefineGeometryVisualizers(py::module m) {
   py::module::import("pydrake.systems.framework");
   py::module::import("pydrake.systems.lcm");
 
-  // This list must remain in topological order.
+  // This list must remain in topological dependency order.
   DefineMeshcatParams(m);
   DefineDrakeVisualizerParams(m);
   DefineMeshcatVisualizerParams(m);

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1683,7 +1683,7 @@ void BindFreeFunctions(py::module m) {
 
 namespace internal {
 void DefineSolversMathematicalProgram(py::module m) {
-  // This list must remain in topological order.
+  // This list must remain in topological dependency order.
   BindPyFunctionConstraint(m);
   BindSolverIdAndType(m);
   BindSolverOptions(m);


### PR DESCRIPTION
Towards #17520.

(The prior fix to this module at #21913 only cleaned up the `ConvexSet` items; this PR tackles the IRIS stuff.)

Here's one example of broken docs / types: [CspaceFreePolytope.BinarySearch](https://drake.mit.edu/pydrake/pydrake.geometry.optimization.html#pydrake.geometry.optimization.CspaceFreePolytope.BinarySearch).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21919)
<!-- Reviewable:end -->
