### PR TITLE
[py framework] Fix signatures to use Python types (not C++)

### DIFF
--- a/bindings/pydrake/systems/framework_py.cc
+++ b/bindings/pydrake/systems/framework_py.cc
@@ -15,10 +15,11 @@ PYBIND11_MODULE(framework, m) {
   py::module::import("pydrake.autodiffutils");
   py::module::import("pydrake.symbolic");
 
-  // Incorporate definitions as pieces (to speed up compilation).
+  // This list of calls to helpers must remain in topological dependency order.
   DefineFrameworkPyValues(m);
   DefineFrameworkPySemantics(m);
   DefineFrameworkPySystems(m);
+  DefineFrameworkDiagramBuilder(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -25,6 +25,10 @@ namespace {
 
 using AbstractValuePtrList = vector<unique_ptr<AbstractValue>>;
 
+// NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+using namespace drake::systems;
+constexpr auto& doc = pydrake_doc.drake.systems;
+
 // Given an InputPort or OutputPort as self, return self.Eval(context).  In
 // python, always returns either a numpy.ndarray (when vector-valued) or the
 // unwrapped T in a Value<T> (when abstract-valued).
@@ -53,10 +57,6 @@ py::object DoEval(const SomeObject* self, const systems::Context<T>& context) {
 }
 
 void DoScalarIndependentDefinitions(py::module m) {
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::systems;
-  constexpr auto& doc = pydrake_doc.drake.systems;
-
   {
     using Class = UseDefaultName;
     py::class_<Class>(m, "UseDefaultName", doc.UseDefaultName.doc)
@@ -282,11 +282,7 @@ void DoScalarIndependentDefinitions(py::module m) {
 }
 
 template <typename T>
-void DoScalarDependentDefinitions(py::module m) {
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::systems;
-  constexpr auto& doc = pydrake_doc.drake.systems;
-
+py::class_<Context<T>, ContextBase> DefineContext(py::module m) {
   auto context_cls = DefineTemplateClassWithDefault<Context<T>, ContextBase>(
       m, "Context", GetPyParam<T>(), doc.Context.doc);
   context_cls
@@ -448,11 +444,16 @@ void DoScalarDependentDefinitions(py::module m) {
       .def("__deepcopy__", [](const Context<T>* self,
                                py::dict /* memo */) { return self->Clone(); })
       .def("__str__", &Context<T>::to_string, doc.Context.to_string.doc);
+  return context_cls;
+}
 
-  auto bind_context_methods_templated_on_a_secondary_scalar =
-      [m, &doc, &context_cls](auto dummy_u) {
+template <typename T, typename PyClass>
+void DefineContextMethodsTemplatedOnASecondaryScalar(PyClass* context_cls) {
+  PyClass& cls = *context_cls;
+  type_visit(
+      [&cls](auto dummy_u) {
         using U = decltype(dummy_u);
-        context_cls  // BR
+        cls  // BR
             .def(
                 "SetStateAndParametersFrom",
                 [](Context<T>* self, const Context<U>& source) {
@@ -466,13 +467,18 @@ void DoScalarDependentDefinitions(py::module m) {
                 },
                 py::arg("source"),
                 doc.Context.SetTimeStateAndParametersFrom.doc);
-      };
-  type_visit(
-      bind_context_methods_templated_on_a_secondary_scalar, CommonScalarPack{});
+      },
+      CommonScalarPack{});
+}
 
+template <typename T>
+void DefineLeafContext(py::module m) {
   DefineTemplateClassWithDefault<LeafContext<T>, Context<T>>(
       m, "LeafContext", GetPyParam<T>(), doc.LeafContext.doc);
+}
 
+template <typename T>
+void DefineEventAndEventSubclasses(py::module m) {
   // Event mechanisms.
   DefineTemplateClassWithDefault<Event<T>>(
       m, "Event", GetPyParam<T>(), doc.Event.doc)
@@ -580,8 +586,10 @@ void DoScalarDependentDefinitions(py::module m) {
             "Constructs an UnrestrictedUpdateEvent with the given callback "
             "function.");
   }
+}
 
-  // Glue mechanisms.
+template <typename T>
+void DoDefineFrameworkDiagramBuilder(py::module m) {
   DefineTemplateClassWithDefault<DiagramBuilder<T>>(
       m, "DiagramBuilder", GetPyParam<T>(), doc.DiagramBuilder.doc)
       .def(py::init<>(), doc.DiagramBuilder.ctor.doc)
@@ -698,7 +706,12 @@ void DoScalarDependentDefinitions(py::module m) {
           doc.DiagramBuilder.num_input_ports.doc)
       .def("num_output_ports", &DiagramBuilder<T>::num_output_ports,
           doc.DiagramBuilder.num_output_ports.doc);
+}
 
+// TODO(jwnimmer-tri) This function is just a grab-bag of several classes. We
+// should split it up into smaller pieces.
+template <typename T>
+void DefineRemainingScalarDependentDefinitions(py::module m) {
   DefineTemplateClassWithDefault<OutputPort<T>>(
       m, "OutputPort", GetPyParam<T>(), doc.OutputPort.doc)
       .def("size", &OutputPort<T>::size, doc.PortBase.size.doc)
@@ -833,8 +846,10 @@ void DoScalarDependentDefinitions(py::module m) {
   // minimal binding required to support DeclareWitnessFunction.
   DefineTemplateClassWithDefault<WitnessFunction<T>>(
       m, "WitnessFunction", GetPyParam<T>(), doc.WitnessFunction.doc);
+}  // NOLINT(readability/fn_size)
 
-  // Parameters.
+template <typename T>
+void DefineParameters(py::module m) {
   auto parameters = DefineTemplateClassWithDefault<Parameters<T>>(
       m, "Parameters", GetPyParam<T>(), doc.Parameters.doc);
   DefClone(&parameters);
@@ -907,8 +922,10 @@ void DoScalarDependentDefinitions(py::module m) {
             self->SetFrom(other);
           },
           doc.Parameters.SetFrom.doc);
+}
 
-  // State.
+template <typename T>
+void DefineState(py::module m) {
   DefineTemplateClassWithDefault<State<T>>(
       m, "State", GetPyParam<T>(), doc.State.doc)
       .def(py::init<>(), doc.State.ctor.doc)
@@ -955,8 +972,10 @@ void DoScalarDependentDefinitions(py::module m) {
           },
           py::arg("index"), py_rvp::reference_internal,
           doc.State.get_mutable_abstract_state.doc_1args);
+}
 
-  // - Constituents.
+template <typename T>
+void DefineContinuousState(py::module m) {
   auto continuous_state = DefineTemplateClassWithDefault<ContinuousState<T>>(
       m, "ContinuousState", GetPyParam<T>(), doc.ContinuousState.doc);
   DefClone(&continuous_state);
@@ -1021,7 +1040,10 @@ void DoScalarDependentDefinitions(py::module m) {
           py::arg("value"), doc.ContinuousState.SetFromVector.doc)
       .def("CopyToVector", &ContinuousState<T>::CopyToVector,
           doc.ContinuousState.CopyToVector.doc);
+}
 
+template <typename T>
+void DefineDiscreteValues(py::module m) {
   auto discrete_values = DefineTemplateClassWithDefault<DiscreteValues<T>>(
       m, "DiscreteValues", GetPyParam<T>(), doc.DiscreteValues.doc);
   DefClone(&discrete_values);
@@ -1093,18 +1115,51 @@ void DoScalarDependentDefinitions(py::module m) {
             self[index] = value;
           },
           doc.DiscreteValues.operator_array.doc_1args_idx_nonconst);
-}  // NOLINT(readability/fn_size)
+}
 }  // namespace
 
-void DefineFrameworkPySemantics(py::module m) {
-  DoScalarIndependentDefinitions(m);
+void DefineFrameworkDiagramBuilder(py::module m) {
+  type_visit(
+      [m](auto dummy) {
+        using T = decltype(dummy);
+        DoDefineFrameworkDiagramBuilder<T>(m);
+      },
+      CommonScalarPack{});
+}
 
-  // Do templated instantiations.
-  auto bind_common_scalar_types = [m](auto dummy) {
-    using T = decltype(dummy);
-    DoScalarDependentDefinitions<T>(m);
-  };
-  type_visit(bind_common_scalar_types, CommonScalarPack{});
+void DefineFrameworkPySemantics(py::module m) {
+  // This list of calls to helpers must remain in topological dependency order.
+  DoScalarIndependentDefinitions(m);
+  type_visit(
+      [m](auto dummy) {
+        using T = decltype(dummy);
+        DefineContinuousState<T>(m);
+        DefineDiscreteValues<T>(m);
+        DefineState<T>(m);
+        DefineParameters<T>(m);
+      },
+      CommonScalarPack{});
+  {
+    // The Context classes form a dependency cycle due to built-in scalar
+    // conversion, so we must declare all of them prior to defining any of them.
+    auto cls_context_double = DefineContext<double>(m);
+    auto cls_context_autodiff = DefineContext<AutoDiffXd>(m);
+    auto cls_context_expression = DefineContext<symbolic::Expression>(m);
+    DefineContextMethodsTemplatedOnASecondaryScalar<double>(
+        &cls_context_double);
+    DefineContextMethodsTemplatedOnASecondaryScalar<AutoDiffXd>(
+        &cls_context_autodiff);
+    DefineContextMethodsTemplatedOnASecondaryScalar<symbolic::Expression>(
+        &cls_context_expression);
+  }
+  type_visit(
+      [m](auto dummy) {
+        using T = decltype(dummy);
+        DefineLeafContext<T>(m);
+        DefineEventAndEventSubclasses<T>(m);
+        DefineRemainingScalarDependentDefinitions<T>(m);
+      },
+      CommonScalarPack{});
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/framework_py_semantics.h
+++ b/bindings/pydrake/systems/framework_py_semantics.h
@@ -11,5 +11,10 @@ namespace pydrake {
 
 void DefineFrameworkPySemantics(py::module m);
 
+// The DiagramBuilder really should be part of framework_py_systems.cc but for
+// historical reasons is part of framework_py_semantics.cc. We'll provide a
+// standalone function to bind it so framework_py.cc can sequence it properly.
+void DefineFrameworkDiagramBuilder(py::module m);
+
 }  // namespace pydrake
 }  // namespace drake

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -45,6 +45,13 @@ using systems::UnrestrictedUpdateEvent;
 using systems::VectorSystem;
 using systems::WitnessFunction;
 
+// NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+using namespace drake::systems;
+constexpr auto& doc = pydrake_doc.drake.systems;
+
+// TODO(jwnimmer-tri) Reformat this entire file to remove the unnecessary
+// indentation.
+
 class SystemBasePublic : public SystemBase {
  public:
   // This class is only used to expose some protected types.
@@ -290,21 +297,14 @@ struct Impl {
   template <typename... Args>
   using EventCallback = std::function<std::optional<EventStatus>(Args...)>;
 
-  static void DoScalarDependentDefinitions(py::module m) {
-    // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-    using namespace drake::systems;
-    constexpr auto& doc = pydrake_doc.drake.systems;
-
+  static py::class_<System<T>, SystemBase, PySystem> DefineSystem(
+      py::module m) {
     // TODO(eric.cousineau): Show constructor, but somehow make sure `pybind11`
     // knows this is abstract?
     auto system_cls =
         DefineTemplateClassWithDefault<System<T>, SystemBase, PySystem>(
             m, "System", GetPyParam<T>(), doc.System.doc);
-    system_cls  // BR
-        .def(
-            "Accept",
-            [](const System<T>* self, PySystemVisitor* v) { self->Accept(v); },
-            py::arg("v"), doc.System.Accept.doc)
+    system_cls
         // Resource allocation and initialization.
         .def("AllocateContext", &System<T>::AllocateContext,
             doc.System.AllocateContext.doc)
@@ -489,24 +489,6 @@ Note: The above is for the C++ documentation. For Python, use
             doc.System.GetOutputPort.doc)
         .def("HasOutputPort", &System<T>::HasOutputPort, py::arg("port_name"),
             doc.System.HasOutputPort.doc)
-        // Automatic differentiation.
-        .def(
-            "ToAutoDiffXd",
-            [](const System<T>& self) { return self.ToAutoDiffXd(); },
-            doc.System.ToAutoDiffXd.doc_0args)
-        .def("ToAutoDiffXdMaybe", &System<T>::ToAutoDiffXdMaybe,
-            doc.System.ToAutoDiffXdMaybe.doc)
-        // Symbolics
-        .def(
-            "ToSymbolic",
-            [](const System<T>& self) { return self.ToSymbolic(); },
-            doc.System.ToSymbolic.doc_0args)
-        .def("ToSymbolicMaybe", &System<T>::ToSymbolicMaybe,
-            doc.System.ToSymbolicMaybe.doc)
-        // Scalar type conversion utilities.
-        .def("FixInputPortsFrom", &System<T>::FixInputPortsFrom,
-            py::arg("other_system"), py::arg("other_context"),
-            py::arg("target_context"), doc.System.FixInputPortsFrom.doc)
         // Witness functions.
         .def(
             "GetWitnessFunctions",
@@ -546,30 +528,50 @@ Note: The above is for the C++ documentation. For Python, use
         .def("__deepcopy__", [](const System<T>* self, py::dict /* memo */) {
           return self->Clone();
         });
+    return system_cls;
+  }
 
-    // Out-of-order binding for Scalar type conversion by template parameter
-    // group.
-    auto def_to_scalar_type = [&system_cls, doc](auto dummy) {
+  template <typename PyClass>
+  static void DefineSystemScalarConversions(PyClass* system_cls) {
+    PyClass& cls = *system_cls;
+    cls  // BR
+        .def(
+            "ToAutoDiffXd",
+            [](const System<T>& self) { return self.ToAutoDiffXd(); },
+            doc.System.ToAutoDiffXd.doc_0args)
+        .def("ToAutoDiffXdMaybe", &System<T>::ToAutoDiffXdMaybe,
+            doc.System.ToAutoDiffXdMaybe.doc)
+        .def(
+            "ToSymbolic",
+            [](const System<T>& self) { return self.ToSymbolic(); },
+            doc.System.ToSymbolic.doc_0args)
+        .def("ToSymbolicMaybe", &System<T>::ToSymbolicMaybe,
+            doc.System.ToSymbolicMaybe.doc)
+        .def("FixInputPortsFrom", &System<T>::FixInputPortsFrom,
+            py::arg("other_system"), py::arg("other_context"),
+            py::arg("target_context"), doc.System.FixInputPortsFrom.doc);
+    auto def_to_scalar_type = [&cls](auto dummy) {
       using U = decltype(dummy);
       AddTemplateMethod(
-          system_cls, "ToScalarType",
+          cls, "ToScalarType",
           [](const System<T>& self) { return self.template ToScalarType<U>(); },
           GetPyParam<U>(), doc.System.ToScalarType.doc_0args);
     };
     type_visit(def_to_scalar_type, CommonScalarPack{});
 
-    auto def_to_scalar_type_maybe = [&system_cls, doc](auto dummy) {
+    auto def_to_scalar_type_maybe = [&cls](auto dummy) {
       using U = decltype(dummy);
-      AddTemplateMethod(system_cls, "ToScalarTypeMaybe",
+      AddTemplateMethod(cls, "ToScalarTypeMaybe",
           &System<T>::template ToScalarTypeMaybe<U>, GetPyParam<U>(),
           doc.System.ToScalarTypeMaybe.doc);
     };
     type_visit(def_to_scalar_type_maybe, CommonScalarPack{});
+  }
 
+  static void DefineLeafSystem(py::module m) {
     using AllocCallback = typename LeafOutputPort<T>::AllocCallback;
     using CalcCallback = typename LeafOutputPort<T>::CalcCallback;
     using CalcVectorCallback = typename LeafOutputPort<T>::CalcVectorCallback;
-
     auto leaf_system_cls =
         DefineTemplateClassWithDefault<LeafSystem<T>, PyLeafSystem, System<T>>(
             m, "LeafSystem", GetPyParam<T>(), doc.LeafSystem.doc);
@@ -943,7 +945,9 @@ Note: The above is for the C++ documentation. For Python, use
             py::overload_cast<const AbstractValue&>(
                 &LeafSystemPublic::DeclareAbstractState),
             py::arg("model_value"), doc.LeafSystem.DeclareAbstractState.doc);
+  }
 
+  static void DefineDiagram(py::module m) {
     DefineTemplateClassWithDefault<Diagram<T>, PyDiagram, System<T>>(
         m, "Diagram", GetPyParam<T>(), doc.Diagram.doc)
         .def(py::init<>(), doc.Diagram.ctor.doc_0args)
@@ -1031,7 +1035,9 @@ Note: The above is for the C++ documentation. For Python, use
             doc.Diagram.GetSubsystemByName.doc)
         .def("GetSystems", &Diagram<T>::GetSystems, py_rvp::reference_internal,
             doc.Diagram.GetSystems.doc);
+  }
 
+  static void DefineVectorSystem(py::module m) {
     {
       // N.B. This will effectively allow derived classes of `VectorSystem` to
       // override `LeafSystem` methods, disrespecting `final`-ity.
@@ -1057,7 +1063,10 @@ Note: The above is for the C++ documentation. For Python, use
               py::arg("input_size"), py::arg("output_size"),
               doc.VectorSystem.ctor.doc_deprecated_2args);
     }
+  }
 
+  template <typename PyClass>
+  static void DefineSystemVisitor(py::module m, PyClass* system_cls) {
     // TODO(eric.cousineau): Bind virtual methods once we provide a function
     // wrapper to convert `Map<Derived>*` arguments.
     // N.B. This could be mitigated by using `EigenPtr` in public interfaces in
@@ -1070,6 +1079,11 @@ Note: The above is for the C++ documentation. For Python, use
             doc.SystemVisitor.VisitSystem.doc)
         .def("VisitDiagram", &SystemVisitor<T>::VisitDiagram,
             py::arg("diagram"), doc.SystemVisitor.VisitDiagram.doc);
+
+    system_cls->def(
+        "Accept",
+        [](const System<T>* self, SystemVisitor<T>* v) { self->Accept(v); },
+        py::arg("v"), doc.System.Accept.doc);
   }
 };
 
@@ -1079,10 +1093,6 @@ py::tuple GetPyParamList(type_pack<Packs...> = {}) {
 }
 
 void DoScalarIndependentDefinitions(py::module m) {
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::systems;
-  constexpr auto& doc = pydrake_doc.drake.systems;
-
   {
     using Class = SystemBase;
     constexpr auto& cls_doc = doc.SystemBase;
@@ -1220,10 +1230,12 @@ void DoScalarIndependentDefinitions(py::module m) {
             doc.SystemBase.DeclareCacheEntry
                 .doc_3args_description_value_producer_prerequisites_of_calc);
   }
+}
 
+template <typename PyClass>
+void DefineSystemScalarConverter(PyClass* cls) {
+  auto& converter = *cls;
   {
-    // System scalar conversion.
-    py::class_<SystemScalarConverter> converter(m, "SystemScalarConverter");
     converter  // BR
         .def(py::init())
         .def("__copy__",
@@ -1277,12 +1289,34 @@ void DoScalarIndependentDefinitions(py::module m) {
 void DefineFrameworkPySystems(py::module m) {
   DoScalarIndependentDefinitions(m);
 
+  // Declare (but don't define) to resolve a dependency cycle.
+  py::class_<SystemScalarConverter> cls_system_scalar_converter(
+      m, "SystemScalarConverter");
+  auto cls_system_double = Impl<double>::DefineSystem(m);
+  auto cls_system_autodiff = Impl<AutoDiffXd>::DefineSystem(m);
+  auto cls_system_expression = Impl<Expression>::DefineSystem(m);
+
   // Do templated instantiations of system types.
-  auto bind_common_scalar_types = [m](auto dummy) {
+  auto bind_common_scalar_types = [&](auto dummy) {
     using T = decltype(dummy);
-    Impl<T>::DoScalarDependentDefinitions(m);
+    py::class_<System<T>, SystemBase, typename Impl<T>::PySystem>* cls_system{};
+    if constexpr (std::is_same_v<T, double>) {
+      cls_system = &cls_system_double;
+    } else if constexpr (std::is_same_v<T, AutoDiffXd>) {
+      cls_system = &cls_system_autodiff;
+    } else {
+      static_assert(std::is_same_v<T, Expression>);
+      cls_system = &cls_system_expression;
+    }
+    Impl<T>::DefineSystemScalarConversions(cls_system);
+    Impl<T>::DefineLeafSystem(m);
+    Impl<T>::DefineDiagram(m);
+    Impl<T>::DefineVectorSystem(m);
+    Impl<T>::DefineSystemVisitor(m, cls_system);
   };
   type_visit(bind_common_scalar_types, CommonScalarPack{});
+
+  DefineSystemScalarConverter(&cls_system_scalar_converter);
 }
 
 }  // namespace pydrake


### PR DESCRIPTION
The best place to see the resulting effects is the docs. Here's an example of broken docs / types: [Context.get_mutable_state](https://drake.mit.edu/pydrake/pydrake.systems.framework.html#pydrake.systems.framework.Context.get_mutable_state).

Towards #17520.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21921)
<!-- Reviewable:end -->
