### PR TITLE
Mesh and Convex now uses MeshSource as storage

### DIFF
--- a/bindings/pydrake/geometry/_geometry_extra.py
+++ b/bindings/pydrake/geometry/_geometry_extra.py
@@ -100,5 +100,16 @@ def _add_extraneous_repr_functions():
         )
     MeshSource.__repr__ = mesh_source_repr
 
+    def mesh_or_convex_repr(mesh, type_name):
+        if mesh.source().is_path():
+            data_param = f"filename={repr(str(mesh.source().path()))}"
+        else:
+            data_param = f"mesh_data={repr(mesh.source().in_memory())}"
+        return (
+            f"{type_name}({data_param}, scale={repr(mesh.scale())})"
+        )
+    Mesh.__repr__ = lambda x: mesh_or_convex_repr(x, "Mesh")
+    Convex.__repr__ = lambda x: mesh_or_convex_repr(x, "Convex")
+
 
 _add_extraneous_repr_functions()

--- a/bindings/pydrake/geometry/test/common_test.py
+++ b/bindings/pydrake/geometry/test/common_test.py
@@ -521,7 +521,11 @@ class TestGeometryCore(unittest.TestCase):
             mut.Ellipsoid(a=1.0, b=2.0, c=3.0),
             mut.HalfSpace(),
             mut.Mesh(filename="arbitrary/path", scale=1.0),
+            mut.Mesh(mesh_data=mut.InMemoryMesh(
+                mesh_file=MemoryFile("# ", ".obj", "junk")), scale=1.0),
             mut.Convex(filename="arbitrary/path", scale=1.0),
+            mut.Convex(mesh_data=mut.InMemoryMesh(
+                mesh_file=MemoryFile("# ", ".obj", "junk")), scale=1.0),
             mut.MeshcatCone(height=1.23, a=3.45, b=6.78)
         ]
         for shape in shapes:
@@ -537,7 +541,10 @@ class TestGeometryCore(unittest.TestCase):
             self.assertIsInstance(shape_copy, shape_cls)
             self.assertIsNot(shape_copy, shape)
 
-            new_shape = eval(repr(shape), dict([(shape_cls_name, shape_cls)]))
+            # Representation of Mesh/Convex requires additional types.
+            new_shape = eval(repr(shape), {shape_cls_name: shape_cls,
+                                           'InMemoryMesh': mut.InMemoryMesh,
+                                           'MemoryFile': MemoryFile})
             self.assertIsInstance(new_shape, shape_cls)
             self.assertEqual(repr(new_shape), repr(shape))
 
@@ -559,9 +566,7 @@ class TestGeometryCore(unittest.TestCase):
         self.assertEqual(box.width(), 1.0)
         self.assertEqual(box.depth(), 2.0)
         self.assertEqual(box.height(), 3.0)
-        assert_pickle(
-            self, box,
-            lambda shape: [shape.width(), shape.depth(), shape.height()])
+        assert_pickle(self, box, repr)
         numpy_compare.assert_float_equal(box.size(), np.array([1.0, 2.0, 3.0]))
         self.assertAlmostEqual(mut.CalcVolume(box), 6.0, 1e-14)
 
@@ -570,30 +575,17 @@ class TestGeometryCore(unittest.TestCase):
         capsule = mut.Capsule(measures=(1.0, 2.0))
         self.assertEqual(capsule.radius(), 1.0)
         self.assertEqual(capsule.length(), 2.0)
-        assert_pickle(
-            self, capsule, lambda shape: [shape.radius(), shape.length()])
+        assert_pickle(self, capsule, repr)
 
-        junk_path = "arbitrary/path.ext"
-        convex = mut.Convex(filename=junk_path, scale=1.0)
-        assert_shape_api(convex)
-        self.assertIn(junk_path, convex.filename())
-        self.assertEqual(".ext", convex.extension())
-        self.assertEqual(convex.scale(), 1.0)
-        with self.assertRaisesRegex(RuntimeError,
-                                    "MakeConvexHull only applies to"):
-            # We just need evidence that it invokes convex hull machinery; the
-            # exception for a bad extension suffices.
-            convex.GetConvexHull()
-        assert_pickle(
-            self, convex, lambda shape: [shape.filename(), shape.scale()])
+        # Note: Convex has been rolled in with Mesh because of their common
+        # APIs. See below.
 
         cylinder = mut.Cylinder(radius=1.0, length=2.0)
         assert_shape_api(cylinder)
         cylinder = mut.Cylinder(measures=(1.0, 2.0))
         self.assertEqual(cylinder.radius(), 1.0)
         self.assertEqual(cylinder.length(), 2.0)
-        assert_pickle(
-            self, cylinder, lambda shape: [shape.radius(), shape.length()])
+        assert_pickle(self, cylinder, repr)
 
         ellipsoid = mut.Ellipsoid(a=1.0, b=2.0, c=3.0)
         assert_shape_api(ellipsoid)
@@ -601,29 +593,42 @@ class TestGeometryCore(unittest.TestCase):
         self.assertEqual(ellipsoid.a(), 1.0)
         self.assertEqual(ellipsoid.b(), 2.0)
         self.assertEqual(ellipsoid.c(), 3.0)
-        assert_pickle(
-            self, ellipsoid, lambda shape: [shape.a(), shape.b(), shape.c()])
+        assert_pickle(self, ellipsoid, repr)
 
         X_FH = mut.HalfSpace.MakePose(Hz_dir_F=[0, 1, 0], p_FB=[1, 1, 1])
         self.assertIsInstance(X_FH, RigidTransform)
 
-        mesh = mut.Mesh(filename=junk_path, scale=1.0)
-        assert_shape_api(mesh)
-        self.assertIn(junk_path, mesh.filename())
-        self.assertEqual(".ext", mesh.extension())
-        self.assertEqual(mesh.scale(), 1.0)
-        with self.assertRaisesRegex(RuntimeError,
-                                    "MakeConvexHull only applies to"):
-            # We just need evidence that it invokes convex hull machinery; the
-            # exception for a bad extension suffices.
-            mesh.GetConvexHull()
-        assert_pickle(
-            self, mesh, lambda shape: [shape.filename(), shape.scale()])
+        junk_path = "arbitrary/path.ext"
+        for dut_mesh in [mut.Mesh(filename=junk_path, scale=1.5),
+                         mut.Mesh(mesh_data=mut.InMemoryMesh(
+                                      mesh_file=MemoryFile("#junk", ".ext",
+                                                           "test")),
+                                  scale=1.5),
+                         mut.Mesh(source=mut.MeshSource(path=junk_path),
+                                  scale=1.5),
+                         mut.Convex(filename=junk_path, scale=1.5),
+                         mut.Convex(mesh_data=mut.InMemoryMesh(
+                            mesh_file=MemoryFile("#junk", ".ext", "test")),
+                            scale=1.5),
+                         mut.Convex(source=mut.MeshSource(path=junk_path),
+                                    scale=1.5)]:
+            assert_shape_api(dut_mesh)
+            self.assertEqual(".ext", dut_mesh.extension())
+            self.assertEqual(dut_mesh.scale(), 1.5)
+            self.assertIsInstance(dut_mesh.source(), mut.MeshSource)
+            if dut_mesh.source().is_path():
+                self.assertIn(junk_path, dut_mesh.filename())
+                with self.assertRaisesRegex(RuntimeError,
+                                            "MakeConvexHull only applies to"):
+                    # We just need evidence that it invokes convex hull
+                    # machinery; the exception for a bad extension suffices.
+                    dut_mesh.GetConvexHull()
+            assert_pickle(self, dut_mesh, repr)
 
         sphere = mut.Sphere(radius=1.0)
         assert_shape_api(sphere)
         self.assertEqual(sphere.radius(), 1.0)
-        assert_pickle(self, sphere, mut.Sphere.radius)
+        assert_pickle(self, sphere, repr)
 
         cone = mut.MeshcatCone(height=1.2, a=3.4, b=5.6)
         assert_shape_api(cone)
@@ -631,5 +636,19 @@ class TestGeometryCore(unittest.TestCase):
         self.assertEqual(cone.height(), 1.2)
         self.assertEqual(cone.a(), 3.4)
         self.assertEqual(cone.b(), 5.6)
-        assert_pickle(self, cone, lambda shape: [
-                      shape.height(), shape.a(), shape.b()])
+        assert_pickle(self, cone, repr)
+
+    def test_mesh_pickle_compatibility(self):
+        """Changing the underlying storage for Mesh/Convex changed their pickle
+        functions. This confirms that pickled byte string of the previous
+        implementation works in the new code."""
+        # Check that data pickled as Mesh in Drake v1.33.0 can be unpickled in
+        # newer versions. The data should produce a Mesh equivalent to the
+        # instantiated mesh.
+        legacy_data = b"\x80\x04\x95@\x00\x00\x00\x00\x00\x00\x00\x8c\x10pydrake.geometry\x94\x8c\x04Mesh\x94\x93\x94)\x81\x94\x8c\x11/path/to/file.obj\x94G@\x00\x00\x00\x00\x00\x00\x00\x86\x94b."  # noqa
+        obj = pickle.loads(legacy_data)
+        self.assertIsInstance(obj, mut.Mesh)
+        self.assertTrue(obj.source().is_path())
+        ref_mesh = mut.Mesh(filename="/path/to/file.obj", scale=2)
+        self.assertEqual(obj.source().path(), ref_mesh.source().path())
+        self.assertEqual(obj.scale(), ref_mesh.scale())

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -418,6 +418,7 @@ drake_cc_library(
     srcs = ["shape_specification.cc"],
     hdrs = ["shape_specification.h"],
     deps = [
+        ":mesh_source",
         "//common:essential",
         "//geometry/proximity:polygon_surface_mesh",
         "//math:geometric_transform",

--- a/geometry/in_memory_mesh.h
+++ b/geometry/in_memory_mesh.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "drake/common/file_source.h"
+#include "drake/common/fmt.h"
 #include "drake/common/memory_file.h"
 #include "drake/common/string_map.h"
 
@@ -33,3 +34,5 @@ struct InMemoryMesh final {
 
 }  // namespace geometry
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake::geometry, InMemoryMesh, x, x.to_string())

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -348,8 +348,14 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 
   const std::string extension = mesh_spec.extension();
   if (extension == ".obj") {
-    mesh = make_unique<TriangleSurfaceMesh<double>>(
-        ReadObjToTriangleSurfaceMesh(mesh_spec.filename(), mesh_spec.scale()));
+    if (!mesh_spec.source().is_path()) {
+      throw std::runtime_error(
+          "In-memory meshes are still in development. Rigid hydroelastic "
+          "meshes from .obj must still be named with a file path.");
+    }
+    mesh =
+        make_unique<TriangleSurfaceMesh<double>>(ReadObjToTriangleSurfaceMesh(
+            mesh_spec.source().path(), mesh_spec.scale()));
   } else if (extension == ".vtk") {
     mesh = make_unique<TriangleSurfaceMesh<double>>(
         ConvertVolumeToSurfaceMesh(MakeVolumeMeshFromVtk<double>(mesh_spec)));
@@ -357,7 +363,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
     throw(std::runtime_error(fmt::format(
         "hydroelastic::MakeRigidRepresentation(): for rigid hydroelastic Mesh "
         "shapes can only use .obj or .vtk files; given: {}",
-        mesh_spec.filename())));
+        mesh_spec.source().description())));
   }
 
   return RigidGeometry(RigidMesh(std::move(mesh)));

--- a/geometry/proximity/make_mesh_from_vtk.cc
+++ b/geometry/proximity/make_mesh_from_vtk.cc
@@ -13,9 +13,17 @@ namespace geometry {
 namespace internal {
 
 template <typename T>
-VolumeMesh<T> MakeVolumeMeshFromVtk(const std::filesystem::path& filename,
-                                    double scale) {
-  VolumeMesh<double> read_mesh = ReadVtkToVolumeMesh(filename, scale);
+VolumeMesh<T> MakeVolumeMeshFromVtk(const Mesh& mesh) {
+  if (mesh.extension() != ".vtk") {
+    throw std::runtime_error(fmt::format(
+        "MakeVolumeMeshFromVtk() called on a Mesh specification with the wrong "
+        "extension type. Requires '.vtk', got '{}' for mesh data {}.",
+        mesh.extension(), mesh.source().description()));
+  }
+
+  const double scale = mesh.scale();
+
+  VolumeMesh<double> read_mesh = ReadVtkToVolumeMesh(mesh.source(), scale);
 
   for (int e = 0; e < read_mesh.num_elements(); ++e) {
     if (read_mesh.CalcTetrahedronVolume(e) <= 0.) {
@@ -24,7 +32,7 @@ VolumeMesh<T> MakeVolumeMeshFromVtk(const std::filesystem::path& filename,
           "The {}-th tetrahedron (index start at 0) with "
           "vertices {}, {}, {}, {} has non-positive volume, "
           "so you might want to switch two consecutive vertices.",
-          filename.string(), scale, e, read_mesh.element(e).vertex(0),
+          mesh.source().description(), scale, e, read_mesh.element(e).vertex(0),
           read_mesh.element(e).vertex(1), read_mesh.element(e).vertex(2),
           read_mesh.element(e).vertex(3)));
     }

--- a/geometry/proximity/make_mesh_from_vtk.h
+++ b/geometry/proximity/make_mesh_from_vtk.h
@@ -13,12 +13,12 @@ namespace internal {
 /* Creates a VolumeMesh of a possibly non-convex object from a VTK file
  containing its tetrahedral mesh. It complements MakeConvexVolumeMesh().
 
- @param[in] filename  VTK file name.
- @param[in] scale  scale parameter.
+ @param[in] mesh  The mesh specifying the VTK data to use.
  @retval  volume_mesh
  @tparam_nonsymbolic_scalar
 
- @throw std::exception if a tetrahedral element has non-positive volume.
+ @throw std::exception if `mesh` doesn't specify a .vtk extension.
+        std::exception if a tetrahedral element has non-positive volume.
         std::exception if the `mesh` specification refers to non-VTK file.
         std::exception if the VTK file does not contain a tetrahedral mesh.
         For example, it will throw if `mesh` refers to Obj file instead of
@@ -26,16 +26,7 @@ namespace internal {
         instead of a tetrahedral mesh.
  */
 template <typename T>
-VolumeMesh<T> MakeVolumeMeshFromVtk(const std::filesystem::path& filename,
-                                    double scale);
-
-/* Overload the 2-argument MakeVolumeMeshFromVtk() to take filename and scale
-   from either Mesh or Convex shape specifications.
- */
-template <typename T, typename Shape>
-VolumeMesh<T> MakeVolumeMeshFromVtk(const Shape& shape) {
-  return MakeVolumeMeshFromVtk<T>(shape.filename(), shape.scale());
-}
+VolumeMesh<T> MakeVolumeMeshFromVtk(const Mesh& mesh);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -4,6 +4,8 @@
 #include <filesystem>
 #include <limits>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -19,15 +21,6 @@
 namespace drake {
 namespace geometry {
 namespace {
-
-std::string GetExtensionLower(const std::string& filename) {
-  std::filesystem::path file_path(filename);
-  std::string ext = file_path.extension();
-  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
-    return std::tolower(c);
-  });
-  return ext;
-}
 
 // Computes a convex hull and assigns it to the given shared pointer in a
 // thread-safe manner. Only does work if the shared_ptr is null (i.e., there is
@@ -45,6 +38,28 @@ void ComputeConvexHullAsNecessary(
     auto new_hull = std::make_shared<PolygonSurfaceMesh<double>>(
         internal::MakeConvexHull(filename, scale));
     std::atomic_compare_exchange_strong(hull_ptr, &check, new_hull);
+  }
+}
+
+// Support for Mesh and Convex do_to_string(). It does the hard work of
+// converting the MeshSource into the appropriate parameter name and value
+// representation and then packages it into the full Mesh string representation.
+std::string MeshToString(std::string_view class_name, const MeshSource& source,
+                         double scale) {
+  const std::string mesh_parameter = [&source]() {
+    if (source.is_path()) {
+      return fmt::format("filename='{}'", source.path().string());
+    } else {
+      return fmt::format("mesh_data={}", source.in_memory());
+    }
+  }();
+  return fmt::format("{}({}, scale={})", class_name, mesh_parameter, scale);
+}
+
+void ThrowForBadScale(double scale, std::string_view source) {
+  if (std::abs(scale) < 1e-8) {
+    throw std::logic_error(
+        fmt::format("{} |scale| cannot be < 1e-8, given {}.", source, scale));
   }
 }
 
@@ -104,22 +119,42 @@ std::string Capsule::do_to_string() const {
   return fmt::format("Capsule(radius={}, length={})", radius(), length());
 }
 
-Convex::Convex(const std::string& filename, double scale)
-    : filename_(std::filesystem::absolute(filename)),
-      extension_(GetExtensionLower(filename_)),
-      scale_(scale) {
-  if (std::abs(scale) < 1e-8) {
-    throw std::logic_error("Convex |scale| cannot be < 1e-8.");
+Convex::Convex(const std::filesystem::path& filename, double scale)
+    : Convex(MeshSource(std::filesystem::absolute(filename)), scale) {}
+
+Convex::Convex(InMemoryMesh mesh_data, double scale)
+    : Convex(MeshSource(std::move(mesh_data)), scale) {}
+
+Convex::Convex(MeshSource source, double scale)
+    : source_(std::move(source)), scale_(scale) {
+  // Note: We don't validate extensions because there's a possibility that a
+  // mesh of unsupported type is used, but only processed by client code.
+  ThrowForBadScale(scale, "Convex");
+}
+
+std::string Convex::filename() const {
+  if (source_.is_path()) {
+    return source_.path().string();
   }
+  throw std::runtime_error(
+      fmt::format("Convex::filename() cannot be called when constructed on "
+                  "in-memory mesh data: '{}'. Call Convex::source().path() "
+                  "instead.",
+                  source_.in_memory().mesh_file.filename_hint()));
 }
 
 const PolygonSurfaceMesh<double>& Convex::GetConvexHull() const {
-  ComputeConvexHullAsNecessary(&hull_, filename_, scale_);
+  if (source_.is_in_memory()) {
+    throw std::runtime_error(
+        "In-memory meshes are still being implemented. Convex::GetConvexHull() "
+        "still requires a filesystem path specification.");
+  }
+  ComputeConvexHullAsNecessary(&hull_, source_.path().string(), scale_);
   return *hull_;
 }
 
 std::string Convex::do_to_string() const {
-  return fmt::format("Convex(filename='{}', scale={})", filename(), scale());
+  return MeshToString(type_name(), source(), scale());
 }
 
 Cylinder::Cylinder(double radius, double length)
@@ -192,22 +227,42 @@ std::string HalfSpace::do_to_string() const {
   return "HalfSpace()";
 }
 
-Mesh::Mesh(const std::string& filename, double scale)
-    : filename_(std::filesystem::absolute(filename)),
-      extension_(GetExtensionLower(filename_)),
-      scale_(scale) {
-  if (std::abs(scale) < 1e-8) {
-    throw std::logic_error("Mesh |scale| cannot be < 1e-8.");
+Mesh::Mesh(const std::filesystem::path& filename, double scale)
+    : Mesh(MeshSource(std::filesystem::absolute(filename)), scale) {}
+
+Mesh::Mesh(InMemoryMesh mesh_data, double scale)
+    : Mesh(MeshSource(std::move(mesh_data)), scale) {}
+
+Mesh::Mesh(MeshSource source, double scale)
+    : source_(std::move(source)), scale_(scale) {
+  // Note: We don't validate extensions because there's a possibility that a
+  // mesh of unsupported type is used, but only processed by client code.
+  ThrowForBadScale(scale, "Mesh");
+}
+
+std::string Mesh::filename() const {
+  if (source_.is_path()) {
+    return source_.path().string();
   }
+  throw std::runtime_error(
+      fmt::format("Mesh::filename() cannot be called when constructed on "
+                  "in-memory mesh data: '{}'. Call Mesh::source().path() "
+                  "instead.",
+                  source_.in_memory().mesh_file.filename_hint()));
 }
 
 const PolygonSurfaceMesh<double>& Mesh::GetConvexHull() const {
-  ComputeConvexHullAsNecessary(&hull_, filename_, scale_);
+  if (source_.is_in_memory()) {
+    throw std::runtime_error(
+        "In-memory meshes are still being implemented. Mesh::GetConvexHull() "
+        "still requires a filesystem path specification.");
+  }
+  ComputeConvexHullAsNecessary(&hull_, source_.path().string(), scale_);
   return *hull_;
 }
 
 std::string Mesh::do_to_string() const {
-  return fmt::format("Mesh(filename='{}', scale={})", filename(), scale());
+  return MeshToString(type_name(), source(), scale());
 }
 
 MeshcatCone::MeshcatCone(double height, double a, double b)

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <variant>
@@ -7,6 +8,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_ostream.h"
+#include "drake/geometry/mesh_source.h"
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/math/rigid_transform.h"
 
@@ -261,16 +263,46 @@ class Convex final : public Shape {
                                 convenience tool for "tweaking" models. 8 orders
                                 of magnitude should be plenty without
                                 considering revisiting the model itself. */
-  explicit Convex(const std::string& filename, double scale = 1.0);
+  explicit Convex(const std::filesystem::path& filename, double scale = 1.0);
+
+  /** (Internal use only) Constructs a convex shape specification from the
+   contents of a Drake-supported mesh file type.
+
+   The mesh is defined by the contents of a @ref supported_file_types
+   "mesh file format supported by Drake". Those contents are passed in as
+   `mesh_data`. For %Convex, the only supporting files required are those
+   necessary to define vertex positions (e.g., a glTF's .bin file); material
+   and texture files, if provided, are ignored and are therefore unnecessary.
+
+   @param mesh_data   The in-memory file contents that define the vertex data
+                      for this shape.
+   @param scale       An optional scale to coordinates. */
+  explicit Convex(InMemoryMesh mesh_data, double scale = 1.0);
+
+  /** (Internal use only) Constructs a convex shape specification from the given
+   `source`.
+
+   @param source   The source for the mesh data.
+   @param scale    An optional scale to coordinates. */
+  explicit Convex(MeshSource source, double scale = 1.0);
 
   ~Convex() final;
 
-  const std::string& filename() const { return filename_; }
+  /** (Internal use only) Returns the source for this specification's mesh data.
+   When working with %Convex, this API should only be used for introspection.
+   The contract for %Convex is that the convex hull is always used in place of
+   whatever underlying mesh declaration is provided. For all functional
+   geometric usage, exclusively use the convex hull returned by GetConvexHull().
+   */
+  const MeshSource& source() const { return source_; }
+
+  std::string filename() const;
+
   /** Returns the extension of the mesh filename -- all lower case and including
    the dot. In other words /foo/bar/mesh.obj and /foo/bar/mesh.OBJ would both
    report the ".obj" extension. The "extension" portion of the filename is
    defined as in std::filesystem::path::extension(). */
-  const std::string& extension() const { return extension_; }
+  const std::string& extension() const { return source_.extension(); }
   double scale() const { return scale_; }
 
   /** Reports the convex hull of the named mesh.
@@ -291,8 +323,7 @@ class Convex final : public Shape {
   std::string do_to_string() const final;
   VariantShapeConstPtr get_variant_this() const final;
 
-  std::string filename_;
-  std::string extension_;
+  MeshSource source_;
   double scale_{};
   // Allows the deferred computation of the hull on an otherwise const Convex.
   mutable std::shared_ptr<PolygonSurfaceMesh<double>> hull_{nullptr};
@@ -459,16 +490,42 @@ class Mesh final : public Shape {
                                 convenience tool for "tweaking" models. 8 orders
                                 of magnitude should be plenty without
                                 considering revisiting the model itself. */
-  explicit Mesh(const std::string& filename, double scale = 1.0);
+  explicit Mesh(const std::filesystem::path& filename, double scale = 1.0);
+
+  /** (Internal use only) Constructs a mesh shape specification from the
+   contents of a Drake-supported mesh file type.
+
+   The mesh is defined by the contents of a @ref supported_file_types
+   "mesh file format supported by Drake". Those contents are passed in as
+   `mesh_data`. The mesh data should include the main mesh file's contents as
+   well as any supporting file contents as needed. See InMemoryMesh.
+
+   @param mesh_data   The in-memory file contents that define the mesh data for
+                      this shape.
+   @param scale       An optional scale to coordinates. */
+  explicit Mesh(InMemoryMesh mesh_data, double scale = 1.0);
+
+  /** (Internal use only) Constructs a mesh shape specification from the given
+   `source`.
+
+   @param source   The source for the mesh data.
+   @param scale    An optional scale to coordinates. */
+  explicit Mesh(MeshSource source, double scale = 1.0);
 
   ~Mesh() final;
 
-  const std::string& filename() const { return filename_; }
+  /** (Internal use only) Returns the source for this specification's mesh data.
+   */
+  const MeshSource& source() const { return source_; }
+
+  std::string filename() const;
+
   /** Returns the extension of the mesh filename -- all lower case and including
    the dot. In other words /foo/bar/mesh.obj and /foo/bar/mesh.OBJ would both
    report the ".obj" extension. The "extension" portion of the filename is
    defined as in std::filesystem::path::extension(). */
-  const std::string& extension() const { return extension_; }
+  const std::string& extension() const { return source_.extension(); }
+
   double scale() const { return scale_; }
 
   /** Reports the convex hull of the named mesh.
@@ -490,8 +547,7 @@ class Mesh final : public Shape {
   VariantShapeConstPtr get_variant_this() const final;
 
   // NOTE: Cannot be const to support default copy/move semantics.
-  std::string filename_;
-  std::string extension_;
+  MeshSource source_;
   double scale_{};
   // Allows the deferred computation of the hull on an otherwise const Mesh.
   mutable std::shared_ptr<PolygonSurfaceMesh<double>> hull_{nullptr};

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -18,6 +18,8 @@ namespace drake {
 namespace geometry {
 namespace {
 
+namespace fs = std::filesystem;
+
 using math::RigidTransformd;
 using std::unique_ptr;
 
@@ -472,8 +474,10 @@ GTEST_TEST(ShapeTest, Constructors) {
   EXPECT_EQ(capsule2.length(), 5);
 
   const Convex convex{kFilename, 1.5};
-  EXPECT_EQ(convex.filename(), kFilename);
+  EXPECT_EQ(convex.source().description(), kFilename);
+  EXPECT_EQ(convex.extension(), ".obj");
   EXPECT_EQ(convex.scale(), 1.5);
+  EXPECT_EQ(convex.filename(), kFilename);
 
   const Cylinder cylinder{1, 2};
   EXPECT_EQ(cylinder.radius(), 1);
@@ -497,8 +501,10 @@ GTEST_TEST(ShapeTest, Constructors) {
   unused(hs);
 
   const Mesh mesh{kFilename, 1.4};
-  EXPECT_EQ(mesh.filename(), kFilename);
+  EXPECT_EQ(mesh.source().description(), kFilename);
+  EXPECT_EQ(mesh.extension(), ".obj");
   EXPECT_EQ(mesh.scale(), 1.4);
+  EXPECT_EQ(mesh.filename(), kFilename);
 
   const MeshcatCone cone{1.2, 3.4, 5.6};
   EXPECT_EQ(cone.height(), 1.2);
@@ -537,8 +543,13 @@ GTEST_TEST(ShapeTest, NumericalValidation) {
                               "Capsule radius and length should both be > 0.+");
 
   DRAKE_EXPECT_THROWS_MESSAGE(Convex("bar", 0),
-                              "Convex .scale. cannot be < 1e-8.");
-  DRAKE_EXPECT_NO_THROW(Convex("foo", -1));  // Special case for negative scale.
+                              "Convex .scale. cannot be < 1e-8.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Convex(InMemoryMesh{MemoryFile("a", ".a", "a")}, 0),
+      "Convex .scale. cannot be < 1e-8.*");
+  // Special case for negative scale.
+  DRAKE_EXPECT_NO_THROW(Convex("foo", -1));
+  DRAKE_EXPECT_NO_THROW(Convex(InMemoryMesh{MemoryFile("a", ".a", "a")}, -1));
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       Cylinder(0, 1), "Cylinder radius and length should both be > 0.+");
@@ -562,8 +573,12 @@ GTEST_TEST(ShapeTest, NumericalValidation) {
                               "and c should all be > 0.+");
 
   DRAKE_EXPECT_THROWS_MESSAGE(Mesh("foo", 1e-9),
-                              "Mesh .scale. cannot be < 1e-8.");
-  DRAKE_EXPECT_NO_THROW(Mesh("foo", -1));  // Special case for negative scale.
+                              "Mesh .scale. cannot be < 1e-8.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(Mesh(InMemoryMesh{MemoryFile("a", ".a", "a")}, 0),
+                              "Mesh .scale. cannot be < 1e-8.*");
+  // Special case for negative scale.
+  DRAKE_EXPECT_NO_THROW(Mesh("foo", -1));
+  DRAKE_EXPECT_NO_THROW(Mesh(InMemoryMesh{MemoryFile("a", ".a", "a")}, -1));
 
   DRAKE_EXPECT_THROWS_MESSAGE(MeshcatCone(0, 1, 1),
                               "MeshcatCone parameters .+ should all be > 0.*");
@@ -597,6 +612,69 @@ GTEST_TEST(ShapeTest, ConvexHull) {
   };
   expect_convex_hull(Mesh(cube_path));
   expect_convex_hull(Convex(cube_path));
+}
+
+GTEST_TEST(ShapeTest, ConvexFromMemory) {
+  // This will get normalized to ".obj".
+  const std::string mesh_name = "a_mesh.OBJ";
+  const std::string obj_contents = R"""(
+    v 0 0 0
+    v 1 0 0
+    v 1 1 0
+    v 0 1 0
+    v 0 0 1
+    v 1 0 1
+    v 1 1 1
+    v 0 1 1
+    # intentionally omit faces.
+  )""";
+  InMemoryMesh mesh_data{MemoryFile(obj_contents, ".OBJ", mesh_name)};
+  const Convex convex(std::move(mesh_data), 2.0);
+  EXPECT_EQ(convex.scale(), 2.0);
+  EXPECT_EQ(convex.extension(), ".obj");
+  const MeshSource& source = convex.source();
+  ASSERT_TRUE(source.is_in_memory());
+  EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
+
+  EXPECT_THROW(convex.filename(), std::exception);
+
+  const Convex from_source(source, 3.0);
+  ASSERT_TRUE(from_source.source().is_in_memory());
+  EXPECT_EQ(from_source.source().in_memory().mesh_file.filename_hint(),
+            mesh_name);
+  EXPECT_EQ(from_source.scale(), 3);
+}
+
+GTEST_TEST(ShapeTest, MeshFromMemory) {
+  // This will get normalized to ".obj".
+  const std::string mesh_name = "a_mesh.OBJ";
+  const std::string obj_contents = R"""(
+    v 0 0 0
+    v 1 0 0
+    v 1 1 0
+    v 0 1 0
+    v 0 0 1
+    v 1 0 1
+    v 1 1 1
+    v 0 1 1
+    f 1 2 3 4
+    f 5 6 7 8
+  )""";
+  InMemoryMesh mesh_data{MemoryFile(obj_contents, ".OBJ", mesh_name)};
+  const Mesh mesh(std::move(mesh_data), 2.0);
+  EXPECT_EQ(mesh.scale(), 2.0);
+  EXPECT_EQ(mesh.extension(), ".obj");
+  const MeshSource& source = mesh.source();
+  ASSERT_TRUE(source.is_in_memory());
+  EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
+
+  EXPECT_THROW(mesh.filename(), std::exception);
+
+  const Mesh from_source(source, 3.0);
+  ASSERT_TRUE(from_source.source().is_in_memory());
+  EXPECT_EQ(from_source.source().in_memory().mesh_file.filename_hint(),
+            mesh_name);
+  EXPECT_EQ(from_source.scale(), 3);
 }
 
 class DefaultReifierTest : public ShapeReifier, public ::testing::Test {};
@@ -654,44 +732,65 @@ TEST_F(OverrideDefaultGeometryTest, UnsupportedGeometry) {
   EXPECT_NO_THROW(this->ImplementGeometry(Sphere(0.5), nullptr));
 }
 
+
 GTEST_TEST(ShapeTest, TypeNameAndToString) {
+  // In-memory mesh we'll use on Convex and Mesh.
+  const InMemoryMesh in_memory{
+      MemoryFile("a", ".a", "A"),
+      {{"bb", MemoryFile("b", ".b", "B")}, {"cc", fs::path("path/to/c")}}};
+  // Mesh and Convex both defer to InMemoryMesh to format the member, so we
+  // simply need to prove that it calls the right method based on the type of
+  // the source (we don't have to worry about *how* InMemoryMesh is written as
+  // a string.
+  static constexpr const char* mem_fmt = "{}(mesh_data={}, scale=1.5)";
+
   const Box box(1.5, 2.5, 3.5);
   const Capsule capsule(1.25, 2.5);
   const Convex convex("/some/file", 1.5);
+  const Convex mem_convex(in_memory, 1.5);
   const Cylinder cylinder(1.25, 2.5);
   const Ellipsoid ellipsoid(1.25, 2.5, 0.5);
   const HalfSpace half_space;
   const Mesh mesh("/some/file", 1.5);
+  const Mesh mem_mesh(in_memory, 1.5);
   const MeshcatCone cone(1.5, 0.25, 0.5);
   const Sphere sphere(1.25);
 
   EXPECT_EQ(box.type_name(), "Box");
   EXPECT_EQ(capsule.type_name(), "Capsule");
   EXPECT_EQ(convex.type_name(), "Convex");
+  EXPECT_EQ(mem_convex.type_name(), "Convex");
   EXPECT_EQ(cylinder.type_name(), "Cylinder");
   EXPECT_EQ(ellipsoid.type_name(), "Ellipsoid");
   EXPECT_EQ(half_space.type_name(), "HalfSpace");
   EXPECT_EQ(mesh.type_name(), "Mesh");
+  EXPECT_EQ(mem_mesh.type_name(), "Mesh");
   EXPECT_EQ(cone.type_name(), "MeshcatCone");
   EXPECT_EQ(sphere.type_name(), "Sphere");
 
   EXPECT_EQ(box.to_string(), "Box(width=1.5, depth=2.5, height=3.5)");
   EXPECT_EQ(capsule.to_string(), "Capsule(radius=1.25, length=2.5)");
   EXPECT_EQ(convex.to_string(), "Convex(filename='/some/file', scale=1.5)");
+  EXPECT_EQ(mem_convex.to_string(),
+            fmt::format(mem_fmt, "Convex", in_memory.to_string()));
   EXPECT_EQ(cylinder.to_string(), "Cylinder(radius=1.25, length=2.5)");
   EXPECT_EQ(ellipsoid.to_string(), "Ellipsoid(a=1.25, b=2.5, c=0.5)");
   EXPECT_EQ(half_space.to_string(), "HalfSpace()");
   EXPECT_EQ(mesh.to_string(), "Mesh(filename='/some/file', scale=1.5)");
+  EXPECT_EQ(mem_mesh.to_string(),
+            fmt::format(mem_fmt, "Mesh", in_memory.to_string()));
   EXPECT_EQ(cone.to_string(), "MeshcatCone(height=1.5, a=0.25, b=0.5)");
   EXPECT_EQ(sphere.to_string(), "Sphere(radius=1.25)");
 
   EXPECT_EQ(fmt::to_string(box), "Box(width=1.5, depth=2.5, height=3.5)");
   EXPECT_EQ(fmt::to_string(capsule), "Capsule(radius=1.25, length=2.5)");
   EXPECT_EQ(fmt::to_string(convex), "Convex(filename='/some/file', scale=1.5)");
+  EXPECT_EQ(fmt::to_string(mem_convex), mem_convex.to_string());
   EXPECT_EQ(fmt::to_string(cylinder), "Cylinder(radius=1.25, length=2.5)");
   EXPECT_EQ(fmt::to_string(ellipsoid), "Ellipsoid(a=1.25, b=2.5, c=0.5)");
   EXPECT_EQ(fmt::to_string(half_space), "HalfSpace()");
   EXPECT_EQ(fmt::to_string(mesh), "Mesh(filename='/some/file', scale=1.5)");
+  EXPECT_EQ(fmt::to_string(mem_mesh), mem_mesh.to_string());
   EXPECT_EQ(fmt::to_string(cone), "MeshcatCone(height=1.5, a=0.25, b=0.5)");
   EXPECT_EQ(fmt::to_string(sphere), "Sphere(radius=1.25)");
 
@@ -700,6 +799,7 @@ GTEST_TEST(ShapeTest, TypeNameAndToString) {
   EXPECT_EQ(base.to_string(), "Box(width=1.5, depth=2.5, height=3.5)");
   EXPECT_EQ(fmt::to_string(base), "Box(width=1.5, depth=2.5, height=3.5)");
 }
+
 
 GTEST_TEST(ShapeTest, Volume) {
   EXPECT_NEAR(CalcVolume(Box(1, 2, 3)), 6.0, 1e-14);
@@ -748,14 +848,14 @@ GTEST_TEST(ShapeTest, Pathname) {
   EXPECT_EQ(abspath_convex.filename(), "/absolute_path.obj");
 
   const Mesh relpath_mesh("relative_path.obj");
-  EXPECT_TRUE(std::filesystem::path(relpath_mesh.filename()).is_absolute());
-  EXPECT_EQ(relpath_mesh.filename(),
-            std::filesystem::current_path() / "relative_path.obj");
+  EXPECT_TRUE(relpath_mesh.source().path().is_absolute());
+  EXPECT_EQ(relpath_mesh.source().path(),
+            fs::current_path() / "relative_path.obj");
 
   const Convex relpath_convex("relative_path.obj");
-  EXPECT_TRUE(std::filesystem::path(relpath_convex.filename()).is_absolute());
-  EXPECT_EQ(relpath_convex.filename(),
-            std::filesystem::current_path() / "relative_path.obj");
+  EXPECT_TRUE(relpath_convex.source().path().is_absolute());
+  EXPECT_EQ(relpath_convex.source().path(),
+            fs::current_path() / "relative_path.obj");
 }
 
 GTEST_TEST(ShapeTest, MeshExtensions) {
@@ -788,8 +888,9 @@ GTEST_TEST(ShapeTest, MoveConstructor) {
   EXPECT_EQ(next.filename(), orig_filename);
   EXPECT_EQ(next.extension(), ".obj");
 
-  // The moved-from mesh is in a valid by indeterminate state.
-  EXPECT_EQ(orig.filename().empty(), orig.extension().empty());
+  // The moved-from mesh has its source revert to an empty in-memory mesh.
+  ASSERT_TRUE(orig.source().is_in_memory());
+  EXPECT_TRUE(orig.source().in_memory().mesh_file.contents().empty());
 }
 
 }  // namespace


### PR DESCRIPTION
MeshSource replaces the "filename" and "extension" members. For now, the InMemoryMesh-valued constructors are hidden from documentation and filename() semantics is changed to throw if someone attempts to call filename on an in-memory mesh. This throwing behavior is equivalent to placing a `DRAKE_DEMAND(mesh.source().IsPath())` *everywhere* a mesh.filename() is currently used. As support for MeshSource spreads, errors will evaporate.

We exercise the new storage in a limited case: creating a rigid hydro mesh from a MeshSource.

Furthermore, we update MakeVolumeMeshFromVtk:
 - That function should not be used on Convex -- we should be computing a VolumeMesh from its convex hull.
 - Rather than taking a path, it takes a Mesh and passes the mesh's source to ReadVtkToVolumeMesh().

relates #15263

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21922)
<!-- Reviewable:end -->
