### PR TITLE
Add supporting files to InMemoryMesh

### DIFF
--- a/bindings/pydrake/geometry/_geometry_extra.py
+++ b/bindings/pydrake/geometry/_geometry_extra.py
@@ -78,8 +78,15 @@ def _add_extraneous_repr_functions():
     in python is simply more convenient.
     """
     def in_memory_mesh_repr(mesh):
+        # If defined, the supporting string has to provide the preceding comma,
+        # and space, along with the parameter name and its value.
+        supporting_string = ""
+        if mesh.supporting_files:
+            supporting_string = (f", supporting_files="
+                                 f"{repr(mesh.supporting_files)}")
         return (
-            f"InMemoryMesh(mesh_file={repr(mesh.mesh_file())})"
+            f"InMemoryMesh(mesh_file={repr(mesh.mesh_file)}"
+            f"{supporting_string})"
         )
     InMemoryMesh.__repr__ = in_memory_mesh_repr
 

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -299,16 +299,14 @@ void DefineInMemoryMesh(py::module m) {
     py::class_<Class> cls(m, "InMemoryMesh", cls_doc.doc);
     py::object ctor = m.attr("InMemoryMesh");
     cls  // BR
-        .def(py::init<>(), cls_doc.ctor.doc_0args)
-        .def(py::init<MemoryFile>(), py::arg("mesh_file"),
-            cls_doc.ctor.doc_1args)
-        .def(py::init<const InMemoryMesh&>(), py::arg("other"))
-        .def("mesh_file", &Class::mesh_file, py_rvp::reference_internal,
-            cls_doc.mesh_file.doc)
-        .def("empty", &Class::empty, cls_doc.empty.doc)
+        .def(ParamInit<Class>())
+        .def_readwrite("mesh_file", &Class::mesh_file, cls_doc.mesh_file.doc)
+        .def_readwrite("supporting_files", &Class::supporting_files,
+            cls_doc.supporting_files.doc)
         .def(py::pickle(
             [](const InMemoryMesh& self) {
-              return py::dict(py::arg("mesh_file") = self.mesh_file());
+              return py::dict(py::arg("mesh_file") = self.mesh_file,
+                  py::arg("supporting_files") = self.supporting_files);
             },
             [ctor](const py::dict& kwargs) {
               return ctor(**kwargs).cast<InMemoryMesh>();

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -33,6 +33,7 @@ drake_cc_package_library(
         ":dummy_value",
         ":essential",
         ":extract_double",
+        ":file_source",
         ":find_resource",
         ":find_runfiles",
         ":fmt",
@@ -180,6 +181,16 @@ drake_cc_library(
     hdrs = ["extract_double.h"],
     deps = [
         ":essential",
+    ],
+)
+
+drake_cc_library(
+    name = "file_source",
+    srcs = ["file_source.cc"],
+    hdrs = ["file_source.h"],
+    deps = [
+        ":memory_file",
+        ":overloaded",
     ],
 )
 
@@ -960,6 +971,13 @@ drake_cc_googletest(
         ":essential",
         ":extract_double",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "file_source_test",
+    deps = [
+        ":file_source",
     ],
 )
 

--- a/common/file_source.cc
+++ b/common/file_source.cc
@@ -1,0 +1,23 @@
+#include "drake/common/file_source.h"
+
+#include <fmt/format.h>
+
+#include "drake/common/fmt_ostream.h"
+#include "drake/common/overloaded.h"
+
+namespace drake {
+std::string to_string(const FileSource& source) {
+  // TODO(jwnimmer-tri) Once we have a new enough fmt with `std.h`, a
+  // simple `return fmt::to_string(source)` here will suffice.
+  return std::visit(overloaded{[](const std::filesystem::path& path) {
+                                 // We'll delegate to the built-in operator<<,
+                                 // which properly quotes the path.
+                                 return fmt::to_string(fmt_streamed(path));
+                               },
+                               [](const MemoryFile& file) {
+                                 return fmt::to_string(file);
+                               }},
+                    source);
+}
+
+}  // namespace drake

--- a/common/file_source.h
+++ b/common/file_source.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <variant>
+
+#include "drake/common/fmt.h"
+#include "drake/common/memory_file.h"
+
+namespace drake {
+
+/** Represents a file. The file can be on-disk or in-memory. */
+using FileSource = std::variant<std::filesystem::path, MemoryFile>;
+
+/** Returns a string representation. */
+std::string to_string(const FileSource& source);
+
+}  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake, FileSource, x, drake::to_string(x))

--- a/common/memory_file.cc
+++ b/common/memory_file.cc
@@ -46,4 +46,15 @@ MemoryFile::MemoryFile(std::string contents, std::string extension,
 
 MemoryFile::~MemoryFile() = default;
 
+std::string MemoryFile::to_string(int contents_limit) const {
+  const std::string contents_str =
+      contents_limit <= 0 || contents_limit >= ssize(contents_.value())
+          ? contents_.value()
+          : fmt::format("<{}...>", contents_.value().substr(0, contents_limit));
+
+  return fmt::format(
+      "MemoryFile(filename_hint=\"{}\", contents=\"{}\", extension=\"{}\")",
+      filename_hint_.value(), contents_str, extension_.value());
+}
+
 }  // namespace drake

--- a/common/memory_file.h
+++ b/common/memory_file.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt.h"
 #include "drake/common/reset_after_move.h"
 #include "drake/common/sha256.h"
 
@@ -61,6 +62,11 @@ class MemoryFile final {
   /** Returns the notional "filename" for this file`. */
   const std::string& filename_hint() const { return filename_hint_; }
 
+  /** Returns a string representation. Note: the file contents will be limited
+   to `contents_limit` number of characters. To include the full contents, pass
+   any number less than or equal to zero. */
+  std::string to_string(int contents_limit = 100) const;
+
  private:
   reset_after_move<std::string> contents_;
 
@@ -78,3 +84,5 @@ class MemoryFile final {
 };
 
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake, MemoryFile, x, x.to_string())

--- a/common/test/file_source_test.cc
+++ b/common/test/file_source_test.cc
@@ -1,0 +1,17 @@
+#include "drake/common/file_source.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace {
+
+GTEST_TEST(FileSourceTest, ToString) {
+  EXPECT_EQ(to_string(FileSource("a/b/c")), "\"a/b/c\"");
+  EXPECT_EQ(fmt::to_string(FileSource("a/b/c")), "\"a/b/c\"");
+
+  const MemoryFile file("012345789", ".ext", "hint");
+  EXPECT_EQ(to_string(FileSource(file)), file.to_string());
+  EXPECT_EQ(fmt::to_string(FileSource(file)), file.to_string());
+}
+}  // namespace
+}  // namespace drake

--- a/common/test/memory_file_test.cc
+++ b/common/test/memory_file_test.cc
@@ -2,6 +2,7 @@
 
 #include <fstream>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
@@ -94,6 +95,18 @@ GTEST_TEST(MemoryFileTest, MoveSemantics) {
   EXPECT_EQ(moved_from.sha256(), empty.sha256());
   EXPECT_EQ(moved_from.filename_hint(), empty.filename_hint());
   EXPECT_NE(moved_from.sha256(), original.sha256());
+}
+
+GTEST_TEST(MemoryFileTest, ToString) {
+  const MemoryFile file("0123456789", ".ext", "hint");
+
+  EXPECT_THAT(file.to_string(), testing::HasSubstr("\"0123456789\""));
+  EXPECT_THAT(file.to_string(10), testing::HasSubstr("\"0123456789\""));
+  EXPECT_THAT(file.to_string(0), testing::HasSubstr("\"0123456789\""));
+  EXPECT_THAT(file.to_string(-10), testing::HasSubstr("\"0123456789\""));
+  EXPECT_THAT(file.to_string(5), testing::HasSubstr("\"<01234...>\""));
+
+  EXPECT_THAT(fmt::to_string(file), testing::HasSubstr("\"0123456789\""));
 }
 
 }  // namespace

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -278,7 +278,9 @@ drake_cc_library(
     srcs = ["in_memory_mesh.cc"],
     hdrs = ["in_memory_mesh.h"],
     deps = [
+        "//common:file_source",
         "//common:memory_file",
+        "//common:string_container",
     ],
 )
 
@@ -867,13 +869,6 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "in_memory_mesh_test",
-    deps = [
-        ":in_memory_mesh",
-    ],
-)
-
-drake_cc_googletest(
     name = "mesh_source_test",
     deps = [
         ":in_memory_mesh",
@@ -961,6 +956,13 @@ drake_cc_googletest(
         "//common/test_utilities",
         "//geometry/proximity:make_sphere_mesh",
         "//geometry/test_utilities:dummy_render_engine",
+    ],
+)
+
+drake_cc_googletest(
+    name = "in_memory_mesh_test",
+    deps = [
+        ":in_memory_mesh",
     ],
 )
 

--- a/geometry/in_memory_mesh.cc
+++ b/geometry/in_memory_mesh.cc
@@ -1,20 +1,64 @@
 #include "drake/geometry/in_memory_mesh.h"
 
-#include <utility>
+#include <algorithm>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include "drake/common/drake_assert.h"
+
+// Drake currently supports a wide range of fmt versions (8..11), which vary
+// heavily in terms of how they format maps (i.e., range-of-pairs) and variant.
+// When formatting the supported_files, we can't use fmt's built-in std::map
+// formatter because as of fmt 11 it forces the "debug presentation format"
+// which when combined with our DRAKE_FORMATTER_AS on FileSource ends up
+// re-quoting the formatted FileSource as if it were a string. Instead, we'll
+// use a helper struct that more directly controls the format of a map entry.
+// Once we drop Jammy and fmt8, we can clean this up even further by removing
+// DRAKE_FORMATTER_AS on FileSource since variant<> will be natively formattable
+// in that version.
+namespace drake {
+namespace {
+struct FormattableSupportingFileMapEntry {
+  std::string to_string() const {
+    DRAKE_DEMAND(key != nullptr && value != nullptr);
+    return fmt::format(
+#if FMT_VERSION >= 90000
+        "{:?}: {}",  // Use '?' specifier to format the key as a string literal.
+#else
+        // TODO(jwnimmer-tri) On Ubuntu Jammy we use fmt8 which does not offer
+        // the capability to represent strings as literals, so we'll just toss
+        // quotes around and call it a day. Most filenames won't have quotes in
+        // them anyway.
+        "\"{}\": {}",
+#endif
+        *key, *value);
+  }
+  const std::string* key{};
+  const FileSource* value{};
+};
+}  // namespace
+}  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake, FormattableSupportingFileMapEntry, x, x.to_string())
 
 namespace drake {
 namespace geometry {
 
-InMemoryMesh::InMemoryMesh() = default;
-
-InMemoryMesh::InMemoryMesh(MemoryFile mesh_file)
-    : mesh_file_(std::move(mesh_file)) {}
-
-InMemoryMesh::~InMemoryMesh() = default;
-
-bool InMemoryMesh::empty() const {
-  return mesh_file_.contents().empty();
+std::string InMemoryMesh::to_string() const {
+  std::vector<FormattableSupportingFileMapEntry> supporting_encoded;
+  std::transform(supporting_files.cbegin(), supporting_files.cend(),
+                 std::back_inserter(supporting_encoded),
+                 [](const auto& key_value) {
+                   return FormattableSupportingFileMapEntry{&key_value.first,
+                                                            &key_value.second};
+                 });
+  return fmt::format("InMemoryMesh(mesh_file={}{})", mesh_file,
+                     supporting_files.empty()
+                         ? std::string{}
+                         : fmt::format(", supporting_files={{{}}}",
+                                       fmt::join(supporting_encoded, ", ")));
 }
-
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/in_memory_mesh.h
+++ b/geometry/in_memory_mesh.h
@@ -1,36 +1,34 @@
 #pragma once
 
-#include "drake/common/drake_copyable.h"
+#include <string>
+
+#include "drake/common/file_source.h"
 #include "drake/common/memory_file.h"
+#include "drake/common/string_map.h"
 
 namespace drake {
 namespace geometry {
 
-/** Representation of a mesh file stored in memory. Eventually, this will also
- include a family of supporting files (e.g., material files, image files, etc.)
-*/
-class InMemoryMesh final {
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InMemoryMesh);
-
-  /** Constructs an empty file. */
-  InMemoryMesh();
-
-  /** Constructs a file from the given mesh file. */
-  explicit InMemoryMesh(MemoryFile mesh_file);
-
-  ~InMemoryMesh();
-
-  /** Returns the base mesh file. */
-  const MemoryFile& mesh_file() const { return mesh_file_; }
-
-  /** Reports if the mesh is empty. */
-  bool empty() const;
-
- private:
-  /* The main mesh file's contents (e.g., a .obj or .gltf file, but not a .mtl
+/** Representation of a mesh file stored in memory. At a minimum it includes the
+ contents of a mesh file. If that mesh file makes reference to additional files
+ (e.g., a .obj file can reference a .mtl which in turn references a .png file),
+ then those files _can_ be included in `this` %InMemoryMesh's supporting files.
+ Each supporting file is represented by a key-value pair. The key is the
+ file-referencing string as it appears in the referencing file and the value is
+ a FileSource. All supporting files can be located on disk; only the main mesh
+ file is strictly required to be in memory. Failure to provide the supporting
+ files may or may not lead to errors; it depends on the context in which the
+ mesh data is used. */
+struct InMemoryMesh final {
+  /** The main mesh file's contents (e.g., a .obj or .gltf file, but not a .mtl
    or .bin). */
-  MemoryFile mesh_file_;
+  MemoryFile mesh_file;
+
+  /** The optional collection of supporting files. */
+  string_map<FileSource> supporting_files;
+
+  /** Returns a string representation. */
+  std::string to_string() const;
 };
 
 }  // namespace geometry

--- a/geometry/mesh_source.cc
+++ b/geometry/mesh_source.cc
@@ -21,12 +21,12 @@ MeshSource::MeshSource(std::filesystem::path path)
 
 MeshSource::MeshSource(InMemoryMesh&& mesh)
     : source_(std::move(mesh)),
-      extension_(in_memory().mesh_file().extension()) {}
+      extension_(in_memory().mesh_file.extension()) {}
 
 MeshSource::~MeshSource() = default;
 
 std::string MeshSource::description() const {
-  return is_path() ? path().string() : in_memory().mesh_file().filename_hint();
+  return is_path() ? path().string() : in_memory().mesh_file.filename_hint();
 }
 
 }  // namespace geometry

--- a/geometry/proximity/obj_to_surface_mesh.cc
+++ b/geometry/proximity/obj_to_surface_mesh.cc
@@ -68,8 +68,8 @@ TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
 
   // We will either throw or return a mesh here (courtesy of ReadObj).
   return ReadObjToTriangleSurfaceMesh(
-      InMemoryMesh(MemoryFile(std::move(content).str(), ".obj",
-                              std::string(description))),
+      InMemoryMesh{MemoryFile(std::move(content).str(), ".obj",
+                              std::string(description))},
       scale, on_warning);
 }
 

--- a/geometry/proximity/test/obj_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/obj_to_surface_mesh_test.cc
@@ -98,7 +98,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, MeshSource) {
   const std::string filename =
       FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
   MeshSource disk_source(filename);
-  MeshSource memory_source(InMemoryMesh(MemoryFile::Make(filename)));
+  MeshSource memory_source(InMemoryMesh{MemoryFile::Make(filename)});
   const TriangleSurfaceMesh<double> disk_surface =
       ReadObjToTriangleSurfaceMesh(disk_source, kUnitScale);
   const TriangleSurfaceMesh<double> memory_surface =
@@ -115,7 +115,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionInvalidFilePath) {
 }
 
 GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionForEmptyFile) {
-  const MeshSource empty(InMemoryMesh(MemoryFile("", ".obj", "empty")));
+  const MeshSource empty(InMemoryMesh{MemoryFile("", ".obj", "empty")});
   DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToTriangleSurfaceMesh(empty),
                               ".*OBJ data parsed contains no objects.*");
 }
@@ -128,14 +128,14 @@ GTEST_TEST(ObjToSurfaceMeshTest, WarningCallback) {
   // *One* source of a warning is a degenerate face (fewer than three vertices).
   // We'll show that the warning callback gets invoked for this one warning and
   // consider that as representative for all tinyobj warnings.
-  const MeshSource obj(InMemoryMesh(MemoryFile(R"""(
+  const MeshSource obj(InMemoryMesh{MemoryFile(R"""(
   v 1 0 0
   v 0 1 0
   v 0 0 1
   f 1 2 3
   f 2 3
   )""",
-                                               ".obj", "trigger warning")));
+                                               ".obj", "trigger warning")});
 
   // By not setting the callback, the default warning behavior won't throw.
   EXPECT_NO_THROW(ReadObjToTriangleSurfaceMesh(obj));
@@ -148,12 +148,12 @@ GTEST_TEST(ObjToSurfaceMeshTest, WarningCallback) {
 
 GTEST_TEST(ObjToSurfaceMeshTest, ThrowExceptionFileHasNoFaces) {
   const MeshSource no_faces(
-      InMemoryMesh(MemoryFile(R"""(
+      InMemoryMesh{MemoryFile(R"""(
 v 1.0 0.0 0.0
 v 0.0 1.0 0.0
 v 0.0 0.0 1.0
 )""",
-                              ".obj", "Obj with no faces")));
+                              ".obj", "Obj with no faces")});
   DRAKE_EXPECT_THROWS_MESSAGE(ReadObjToTriangleSurfaceMesh(no_faces),
                               ".*OBJ data parsed contains no objects.*");
 }
@@ -162,13 +162,13 @@ v 0.0 0.0 1.0
 // objects (o lines).
 GTEST_TEST(ObjToSurfaceMeshTest, AcceptFacesWithoutObject) {
   const MeshSource faces_without_objects(
-      InMemoryMesh(MemoryFile(R"""(
+      InMemoryMesh{MemoryFile(R"""(
 v 1.0 0.0 0.0
 v 0.0 1.0 0.0
 v 0.0 0.0 1.0
 f 1 2 3
 )""",
-                              ".obj", "faces without objects")));
+                              ".obj", "faces without objects")});
   TriangleSurfaceMesh<double> surface =
       ReadObjToTriangleSurfaceMesh(faces_without_objects);
   ASSERT_EQ(3, surface.num_vertices());
@@ -186,7 +186,7 @@ f 1 2 3
 
 // Confirms that we can accept multiple objects in one obj file.
 GTEST_TEST(ObjToSurfaceMeshTest, AcceptMultipleObjects) {
-  const MeshSource two_objects(InMemoryMesh(MemoryFile(R"""(
+  const MeshSource two_objects(InMemoryMesh{MemoryFile(R"""(
 o first_object
 v 1.0 0.0 0.0
 v 0.0 1.0 0.0
@@ -199,7 +199,7 @@ v 0.0 2.0 0.0
 v 0.0 0.0 2.0
 f 4 5 6
 )""",
-                                                       ".obj", "two objects")));
+                                                       ".obj", "two objects")});
   TriangleSurfaceMesh<double> surface =
       ReadObjToTriangleSurfaceMesh(two_objects);
   ASSERT_EQ(6, surface.num_vertices());
@@ -231,7 +231,7 @@ TEST_F(ObjToMeshDiagnosticsTest, ErrorModes) {
   v 1 1 0
   )""";
   const MeshSource source(
-      InMemoryMesh(MemoryFile(no_face_obj, ".obj", "no_faces")));
+      InMemoryMesh{MemoryFile(no_face_obj, ".obj", "no_faces")});
   auto maybe_mesh =
       internal::DoReadObjToSurfaceMesh(source, 1.0, diagnostic_policy_);
   ASSERT_FALSE(maybe_mesh.has_value());

--- a/geometry/proximity/test/vtk_to_volume_mesh_test.cc
+++ b/geometry/proximity/test/vtk_to_volume_mesh_test.cc
@@ -61,7 +61,7 @@ GTEST_TEST(VtkToVolumeMeshTest, FromMemory) {
   const fs::path test_file =
       FindResourceOrThrow("drake/geometry/test/one_tetrahedron.vtk");
   VolumeMesh<double> volume_mesh = internal::ReadVtkToVolumeMesh(
-      InMemoryMesh(MemoryFile::Make(test_file)), kScale);
+      InMemoryMesh{MemoryFile::Make(test_file)}, kScale);
 
   const VolumeMesh<double> expected_mesh{
       {{0, 1, 2, 3}},

--- a/geometry/proximity/vtk_to_volume_mesh.cc
+++ b/geometry/proximity/vtk_to_volume_mesh.cc
@@ -32,7 +32,7 @@ VolumeMesh<double> ReadVtkToVolumeMesh(const MeshSource& mesh_source,
     reader->SetFileName(mesh_source.path().c_str());
   } else {
     DRAKE_DEMAND(mesh_source.is_in_memory());
-    const MemoryFile& file = mesh_source.in_memory().mesh_file();
+    const MemoryFile& file = mesh_source.in_memory().mesh_file;
     // Note: The contents will be copied by VTK.
     reader->SetInputString(file.contents().c_str(), file.contents().size());
     reader->SetReadFromInputString(true);

--- a/geometry/read_obj.cc
+++ b/geometry/read_obj.cc
@@ -189,7 +189,7 @@ ReadObj(const MeshSource& mesh_source, double scale, bool triangulate,
                        vertices_only, diagnostic);
   } else {
     DRAKE_DEMAND(mesh_source.is_in_memory());
-    return ReadObjContents(mesh_source.in_memory().mesh_file(), scale,
+    return ReadObjContents(mesh_source.in_memory().mesh_file, scale,
                            triangulate, vertices_only, diagnostic);
   }
 }

--- a/geometry/test/in_memory_mesh_test.cc
+++ b/geometry/test/in_memory_mesh_test.cc
@@ -1,38 +1,33 @@
 #include "drake/geometry/in_memory_mesh.h"
 
+#include <fmt/format.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace drake {
 namespace geometry {
 namespace {
 
-GTEST_TEST(InMemoryMeshTest, BasicApi) {
-  const InMemoryMesh empty;
-  EXPECT_TRUE(empty.empty());
+GTEST_TEST(InMemoryMeshTest, ToString) {
+  const MemoryFile file("a", ".a", "aa");
+  const std::string file_str = fmt::to_string(file);
+  InMemoryMesh mesh{file};
 
-  const InMemoryMesh just_mesh(MemoryFile("body", ".ext", "hint"));
-  ASSERT_FALSE(just_mesh.empty());
-  EXPECT_EQ(just_mesh.mesh_file().contents(), "body");
-}
+  EXPECT_EQ(mesh.to_string(),
+            fmt::format("InMemoryMesh(mesh_file={})", file_str));
 
-GTEST_TEST(InMemorymeshTest, CopySemantics) {
-  const InMemoryMesh source(MemoryFile("body", ".ext", "hint"));
-  ASSERT_FALSE(source.empty());
-  EXPECT_EQ(source.mesh_file().contents(), "body");
+  mesh.supporting_files.emplace("name", file);
+  EXPECT_EQ(mesh.to_string(),
+            fmt::format("InMemoryMesh(mesh_file={file}, "
+                        "supporting_files={{\"name\": {file}}})",
+                        fmt::arg("file", file_str)));
 
-  const InMemoryMesh copy_ctor(source);
-  ASSERT_FALSE(copy_ctor.empty());
-  EXPECT_EQ(copy_ctor.mesh_file().contents(), "body");
-  ASSERT_FALSE(source.empty());
-  EXPECT_EQ(source.mesh_file().contents(), "body");
-
-  InMemoryMesh copy_assign;
-  EXPECT_TRUE(copy_assign.empty());
-  copy_assign = source;
-  ASSERT_FALSE(copy_assign.empty());
-  EXPECT_EQ(copy_assign.mesh_file().contents(), "body");
-  ASSERT_FALSE(source.empty());
-  EXPECT_EQ(source.mesh_file().contents(), "body");
+  mesh.supporting_files.emplace("name2", file);
+  EXPECT_EQ(mesh.to_string(),
+            fmt::format("InMemoryMesh(mesh_file={file}, "
+                        "supporting_files={{\"name\": {file}, "
+                        "\"name2\": {file}}})",
+                        fmt::arg("file", file_str)));
 }
 
 }  // namespace

--- a/geometry/test/mesh_source_test.cc
+++ b/geometry/test/mesh_source_test.cc
@@ -17,15 +17,15 @@ GTEST_TEST(MeshSourceTest, PathConstructor) {
 }
 
 GTEST_TEST(MeshSourceTest, InMemoryMeshConstructor) {
-  const MeshSource s(InMemoryMesh(MemoryFile("contents", ".ext", "hint")));
+  const MeshSource s(InMemoryMesh{MemoryFile("contents", ".ext", "hint")});
   EXPECT_EQ(s.description(), "hint");
   EXPECT_FALSE(s.is_path());
   ASSERT_TRUE(s.is_in_memory());
-  EXPECT_EQ(s.in_memory().mesh_file().contents(), "contents");
+  EXPECT_EQ(s.in_memory().mesh_file.contents(), "contents");
 }
 
 GTEST_TEST(MeshSourceTest, CopySemantics) {
-  const MeshSource source(InMemoryMesh(MemoryFile("body", ".ext", "hint")));
+  const MeshSource source(InMemoryMesh{MemoryFile("body", ".ext", "hint")});
   EXPECT_TRUE(source.is_in_memory());
   EXPECT_EQ(source.description(), "hint");
 
@@ -55,7 +55,7 @@ GTEST_TEST(MeshSourceTest, MovedFrom) {
 
   // The moved-from source now reports as an empty in-memory mesh.
   ASSERT_TRUE(s.is_in_memory());
-  EXPECT_TRUE(s.in_memory().empty());
+  EXPECT_TRUE(s.in_memory().mesh_file.contents().empty());
   EXPECT_EQ(s.extension(), "");
 }
 
@@ -66,7 +66,7 @@ void ConsumeMeshSource(const MeshSource&) {}
 Successful compilation implies test success. */
 GTEST_TEST(MeshSourceTest, ImplicitConversion) {
   ConsumeMeshSource(std::filesystem::path("path"));
-  ConsumeMeshSource(InMemoryMesh(MemoryFile("contents", ".ext", "hint")));
+  ConsumeMeshSource(InMemoryMesh{MemoryFile("contents", ".ext", "hint")});
 }
 }  // namespace
 }  // namespace geometry

--- a/geometry/test/read_obj_test.cc
+++ b/geometry/test/read_obj_test.cc
@@ -176,13 +176,13 @@ GTEST_TEST(ReadObjTest, MultipleObjects) {
 GTEST_TEST(ReadObjTest, MeshSourceRegression) {
   // In-memory source.
   {
-    const MeshSource source(InMemoryMesh(MemoryFile(R"""(v 0 0 0
+    const MeshSource source(InMemoryMesh{MemoryFile(R"""(v 0 0 0
                                                          v 0 1 0
                                                          v 1 0 0
                                                          v 1 1 0
                                                          f 1 2 3 4
                                                        )""",
-                                                    ".obj", "test")));
+                                                    ".obj", "test")});
     const auto [vertices, faces, num_faces] =
         ReadObj(source, 2.0, /* triangulate= */ true);
     EXPECT_EQ(vertices->size(), 4);
@@ -204,12 +204,12 @@ GTEST_TEST(ReadObjTest, MeshSourceRegression) {
 // vertices from an obj that would ordinarily throw if we asked for the face
 // data (see ErrorModes, below).
 GTEST_TEST(ReadObjTest, VertexOnly) {
-  const MeshSource source(InMemoryMesh(MemoryFile(R"""(v 0 0 0
+  const MeshSource source(InMemoryMesh{MemoryFile(R"""(v 0 0 0
                                                        v 0 1 0
                                                        v 1 0 0
                                                        v 1 1 0
                                                      )""",
-                                                  ".obj", "no_faces")));
+                                                  ".obj", "no_faces")});
   const auto [vertices, faces, num_faces] =
       ReadObj(source, 2.0, /* triangulate= */ true, /* vertices_only= */ true);
   EXPECT_EQ(vertices->size(), 4);
@@ -232,7 +232,7 @@ TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
     f 0 1 2
     )""";
     const MeshSource source(
-        InMemoryMesh(MemoryFile(bad_index_obj, ".obj", "bad indices")));
+        InMemoryMesh{MemoryFile(bad_index_obj, ".obj", "bad indices")});
     auto [verts, _1, _2] =
         ReadObj(source, 2.0, /* triangulate= */ false,
                 /* vertices_only= */ true, diagnostic_policy_);
@@ -254,7 +254,7 @@ TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
     f 1 2 4
     )""";
     const MeshSource source(
-        InMemoryMesh(MemoryFile(bad_index_obj, ".obj", "group")));
+        InMemoryMesh{MemoryFile(bad_index_obj, ".obj", "group")});
     auto [verts, _1, _2] =
         ReadObj(source, 2.0, /* triangulate= */ false,
                 /* vertices_only= */ true, diagnostic_policy_);
@@ -275,7 +275,7 @@ TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
   )""";
   {
     const MeshSource source(
-        InMemoryMesh(MemoryFile(no_face_obj, ".obj", "no_faces")));
+        InMemoryMesh{MemoryFile(no_face_obj, ".obj", "no_faces")});
     auto [verts, _1, _2] =
         ReadObj(source, 2.0, /* triangulate= */ false,
                 /* vertices_only= */ false, diagnostic_policy_);
@@ -289,7 +289,7 @@ TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
   // Not an .obj - from memory.
   {
     const MeshSource source(
-        InMemoryMesh(MemoryFile(no_face_obj, ".bad", "wrong_extension")));
+        InMemoryMesh{MemoryFile(no_face_obj, ".bad", "wrong_extension")});
     auto [verts, _1, _2] =
         ReadObj(source, 2.0, /* triangulate= */ false,
                 /* vertices_only= */ true, diagnostic_policy_);

--- a/multibody/parsing/detail_mesh_parser.cc
+++ b/multibody/parsing/detail_mesh_parser.cc
@@ -70,7 +70,7 @@ NamedMesh DoGetObjMesh(const DiagnosticPolicy& diagnostic,
     // expect this to be exercised, because there's no simple mechanism for
     // exercising this function with an in-memory mesh source.
     input_stream = std::make_unique<std::istringstream>(
-        obj_source.in_memory().mesh_file().contents());
+        obj_source.in_memory().mesh_file.contents());
   }
 
   const bool result =


### PR DESCRIPTION
This requires a new basic file: FileSource which allows a file specification to be either a path or a MemoryFile. This allows an in-memory mesh's supporting files to reference resources on disk as well as other in-memory files.

Relates #15263

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21923)
<!-- Reviewable:end -->
