### PR TITLE
[schunk_wsg] Fix trajectory bug with initial zero target

### DIFF
--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -88,8 +88,8 @@ EventStatus SchunkWsgTrajectoryGenerator::CalcDiscreteUpdate(
   const double max_force = get_force_limit_input_port().Eval(context)[0];
   new_traj_state->set_max_force(max_force);
 
-  if (std::abs(last_traj_state->last_target_position() - target_position) >
-      kTargetEpsilon) {
+  if (!trajectory_ || std::abs(last_traj_state->last_target_position() -
+                               target_position) > kTargetEpsilon) {
     UpdateTrajectory(cur_position, target_position);
     new_traj_state->set_last_target_position(target_position);
     new_traj_state->set_trajectory_start_time(context.get_time());


### PR DESCRIPTION
Update trajectory when trajectory_ is empty, so that the gripper can close its fingers at the beginning of the simulation.

resolves #21920

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21925)
<!-- Reviewable:end -->
