### PR TITLE
Python binding for Body::CalcCenterOfMassTranslationalVelocityInWorld().

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -625,6 +625,13 @@ class TestPlant(unittest.TestCase):
             dut.CalcCenterOfMassInBodyFrame(context=context),
             np.ndarray)
         self.assertIsInstance(
+            dut.CalcCenterOfMassTranslationalVelocityInWorld(context=context),
+            np.ndarray)
+        self.assertIsInstance(
+            dut.CalcCenterOfMassTranslationalAccelerationInWorld(
+                context=context),
+            np.ndarray)
+        self.assertIsInstance(
             dut.CalcSpatialInertiaInBodyFrame(context=context),
             SpatialInertia_[T])
         self.assertIsInstance(

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -350,6 +350,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.get_mass.doc)
         .def("CalcCenterOfMassInBodyFrame", &Class::CalcCenterOfMassInBodyFrame,
             py::arg("context"), cls_doc.CalcCenterOfMassInBodyFrame.doc)
+        .def("CalcCenterOfMassTranslationalVelocityInWorld",
+            &Class::CalcCenterOfMassTranslationalVelocityInWorld,
+            py::arg("context"),
+            cls_doc.CalcCenterOfMassTranslationalVelocityInWorld.doc)
+        .def("CalcCenterOfMassTranslationalAccelerationInWorld",
+            &Class::CalcCenterOfMassTranslationalAccelerationInWorld,
+            py::arg("context"),
+            cls_doc.CalcCenterOfMassTranslationalAccelerationInWorld.doc)
         .def("CalcSpatialInertiaInBodyFrame",
             &Class::CalcSpatialInertiaInBodyFrame, py::arg("context"),
             cls_doc.CalcSpatialInertiaInBodyFrame.doc)

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -498,7 +498,7 @@ class RigidBody : public MultibodyElement<T> {
   /// @returns p_BoBcm_B position vector from Bo (this rigid body B's origin)
   /// to Bcm (B's center of mass), expressed in B.
   /// @pre the context makes sense for use by this %RigidBody.
-  const Vector3<T> CalcCenterOfMassInBodyFrame(
+  Vector3<T> CalcCenterOfMassInBodyFrame(
       const systems::Context<T>& context) const {
     const systems::BasicVector<T>& spatial_inertia_parameter =
         context.get_numeric_parameter(spatial_inertia_parameter_index_);


### PR DESCRIPTION
Python bindings for C++ public functions RigidBody::CalcCenterOfMassTranslationalVelocityInWorld() 
and RigidBody::CalcCenterOfMassTranslationalAccelerationInWorld() .

Perhaps these Python bindings could have been done as part of issue #14269. However, binding RigidBody::CalcCenterOfMassTranslationalVelocityInWorld() was overlooked a while ago and binding RigidBody::CalcCenterOfMassTranslationalAccelerationInWorld() was delayed to this PR.  

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21926)
<!-- Reviewable:end -->
