### PR TITLE
Allow better content access in string_map

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -1152,6 +1152,7 @@ drake_cc_googletest(
     name = "string_container_test",
     deps = [
         ":string_container",
+        "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:limit_malloc",
     ],
 )

--- a/common/string_map.h
+++ b/common/string_map.h
@@ -11,7 +11,26 @@ namespace drake {
 function so that `std::string_view` and `const char*` can be used as lookup keys
 without copying them to a `std::string`. */
 template <typename T>
-using string_map = std::map<std::string, T, std::less<void>>;
+class string_map : public std::map<std::string, T, std::less<void>> {
+ public:
+  template <class K>
+  T& operator[](K&& x) {
+    auto iter = this->find(x);
+    if (iter != this->end()) {
+        return iter->second;
+    }
+    return this->emplace(std::move(x), T{}).first->second;
+  }
+
+  template <class K>
+  const T& at(const K& x) const {
+    auto iter = this->find(x);
+    if (iter != this->end()) {
+        return iter->second;
+    }
+    throw std::out_of_range("string_map::at");
+  }
+};
 
 /** Like `std::multimap<std::string, T>`, but with better defaults than the
 plain `std::multimap<std::string, T>` spelling. We need `std::less<void>` as the

--- a/common/test/string_container_test.cc
+++ b/common/test/string_container_test.cc
@@ -4,6 +4,7 @@
 #include "drake/common/string_set.h"
 #include "drake/common/string_unordered_map.h"
 #include "drake/common/string_unordered_set.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/limit_malloc.h"
 
 namespace drake {
@@ -61,6 +62,27 @@ GTEST_TEST(StringContainerTest, string_map) {
   EXPECT_EQ(dut.count("hello"), count);
   EXPECT_EQ(dut.count(std::string{"hello"}), count);
   EXPECT_EQ(dut.count(std::string_view{"hello"}), count);
+
+  // Implicit addition.
+  EXPECT_EQ(dut["missing_cstr"], 0);
+  EXPECT_EQ(dut[std::string_view("missing_view")], 0);
+  EXPECT_EQ(dut[std::string("missing_str")], 0);
+
+  // Using non std::string to look up present values.
+  EXPECT_EQ(dut["hello"], 1);
+  EXPECT_EQ(dut[std::string_view("hello")], 1);
+
+  // Using look up constant values.
+  EXPECT_EQ(dut.at("hello"), 1);
+  EXPECT_EQ(dut.at(std::string{"hello"}), 1);
+  EXPECT_EQ(dut.at(std::string_view{"hello"}), 1);
+
+  // Using look up failed.
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.at("nope"), ".*string_map::at.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.at(std::string("nope")),
+                              ".*string_map::at.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.at(std::string_view("nope")),
+                              ".*string_map::at.*");
 }
 
 GTEST_TEST(StringContainerTest, string_multimap) {


### PR DESCRIPTION
This allows the following operations:

```c++
string_map<int> values;
values.emplace("bob", 10);

values["mary"] = 30;
if (values.at("mary") == 20) {
  ...
}
```

(Similarly for std::string_view in place of const char* -- anything that is comparable to a string.)

It comes at a cost that if a `string_map` is passed in where a std::map<std::string, T> is expected, we lose operator[] and at().

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21927)
<!-- Reviewable:end -->
