### PR TITLE
Run clang-format on multibody tree tests

### DIFF
--- a/multibody/tree/multibody_tree_indexes.h
+++ b/multibody/tree/multibody_tree_indexes.h
@@ -19,7 +19,9 @@ using MobodIndex = TypeSafeIndex<class MobodTag>;
 using TreeIndex = TypeSafeIndex<class TreeTag>;
 
 // World is always modeled as the 0th mobilized body.
-inline MobodIndex world_mobod_index() { return MobodIndex(0); }
+inline MobodIndex world_mobod_index() {
+  return MobodIndex(0);
+}
 
 }  // namespace internal
 
@@ -56,11 +58,15 @@ using ModelInstanceIndex = TypeSafeIndex<class ModelInstanceTag>;
 
 /// For every MultibodyPlant the **world** body _always_ has this unique index
 /// and it is always zero.
-inline BodyIndex world_index() { return BodyIndex(0); }
+inline BodyIndex world_index() {
+  return BodyIndex(0);
+}
 
 /// For every MultibodyPlant the **world** frame _always_ has this unique index
 /// and it is always zero.
-inline FrameIndex world_frame_index() { return FrameIndex(0); }
+inline FrameIndex world_frame_index() {
+  return FrameIndex(0);
+}
 
 /// Returns the model instance containing the *world* body.  For
 /// every MultibodyPlant the **world** body _always_ has this unique

--- a/multibody/tree/test/articulated_body_inertia_test.cc
+++ b/multibody/tree/test/articulated_body_inertia_test.cc
@@ -14,8 +14,8 @@ namespace multibody {
 namespace internal {
 namespace {
 
-using Eigen::Vector3d;
 using Eigen::MatrixXd;
+using Eigen::Vector3d;
 
 constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
 
@@ -24,10 +24,9 @@ constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
 GTEST_TEST(ArticulatedBodyInertia, DefaultConstructor) {
   ArticulatedBodyInertia<double> P;
   const Matrix6<double> P_matrix = P.CopyToFullMatrix6();
-  ASSERT_TRUE(std::all_of(
-      P_matrix.data(),
-      P_matrix.data() + 36,
-      [](double x) { return std::isnan(x); }));
+  ASSERT_TRUE(std::all_of(P_matrix.data(), P_matrix.data() + 36, [](double x) {
+    return std::isnan(x);
+  }));
 }
 
 // Construct a non-trivial articulated body inertia from a spatial inertia,
@@ -35,8 +34,8 @@ GTEST_TEST(ArticulatedBodyInertia, DefaultConstructor) {
 GTEST_TEST(ArticulatedBodyInertia, ConstructionNonTrivial) {
   const double mass = 2.5;
   const Vector3d com(0.1, -0.2, 0.3);
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
-  const Vector3d p(0.1, -0.1, 0.2);  // p for products.
+  const Vector3d m(2.0, 2.3, 2.4);               // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);              // p for products.
   const UnitInertia<double> G(m(0), m(1), m(2),  /* moments of inertia */
                               p(0), p(1), p(2)); /* products of inertia */
   const SpatialInertia<double> M(mass, com, G);
@@ -57,11 +56,11 @@ GTEST_TEST(ArticulatedBodyInertia, ConstructionNonTrivial) {
 GTEST_TEST(ArticulatedBodyInertia, CastToAutoDiff) {
   const double mass_double = 2.5;
   const Vector3d com_double(0.1, -0.2, 0.3);
-  const Vector3d m_double(2.0,  2.3, 2.4);  // m for moments.
+  const Vector3d m_double(2.0, 2.3, 2.4);   // m for moments.
   const Vector3d p_double(0.1, -0.1, 0.2);  // p for products.
   const UnitInertia<double> G_double(
-      m_double(0), m_double(1), m_double(2), /* moments of inertia */
-      p_double(0), p_double(1), p_double(2));/* products of inertia */
+      m_double(0), m_double(1), m_double(2),  /* moments of inertia */
+      p_double(0), p_double(1), p_double(2)); /* products of inertia */
   const SpatialInertia<double> M_double(mass_double, com_double, G_double);
   ASSERT_TRUE(M_double.IsPhysicallyValid());
 
@@ -87,8 +86,8 @@ GTEST_TEST(ArticulatedBodyInertia, CastToAutoDiff) {
 GTEST_TEST(ArticulatedBodyInertia, Shift) {
   const double mass = 2.5;
   const Vector3d com(0.1, -0.2, 0.3);
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
-  const Vector3d p(0.1, -0.1, 0.2);  // p for products.
+  const Vector3d m(2.0, 2.3, 2.4);               // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);              // p for products.
   const UnitInertia<double> G(m(0), m(1), m(2),  /* moments of inertia */
                               p(0), p(1), p(2)); /* products of inertia */
   const SpatialInertia<double> M(mass, com, G);
@@ -106,8 +105,9 @@ GTEST_TEST(ArticulatedBodyInertia, Shift) {
 
   // Shift the articulated body inertia back and ensure that it is close to the
   // original articulated body inertia.
-  EXPECT_TRUE(P_shifted.Shift(-shift_vector).CopyToFullMatrix6().isApprox(
-      P.CopyToFullMatrix6(), kEpsilon));
+  EXPECT_TRUE(P_shifted.Shift(-shift_vector)
+                  .CopyToFullMatrix6()
+                  .isApprox(P.CopyToFullMatrix6(), kEpsilon));
 }
 
 // Test the plus equal operator for adding articulated body inertias.
@@ -140,8 +140,8 @@ GTEST_TEST(ArticulatedBodyInertia, PlusEqualOperator) {
   P_SP_E += P_DP_E;
 
   // Ensure both inertias are the same.
-  EXPECT_TRUE(P_SP_E.CopyToFullMatrix6().isApprox(
-      M_SP_E.CopyToFullMatrix6(), kEpsilon));
+  EXPECT_TRUE(P_SP_E.CopyToFullMatrix6().isApprox(M_SP_E.CopyToFullMatrix6(),
+                                                  kEpsilon));
 }
 
 // Test the times equal for operator for multiplying on the left and right
@@ -162,12 +162,14 @@ GTEST_TEST(ArticulatedBodyInertia, TimesOperator) {
   // Verify that multiplying by a matrix on the left and right works as
   // expected.
   Matrix6<double> H1;
+  // clang-format off
   H1 << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6,
         1.1, 1.2, 1.3, 1.4, 1.5, 1.6,
         1.7, 1.8, 1.9, 2.1, 2.2, 2.3,
         -2.4, -2.5, -2.6, -2.7, -2.8, -2.9,
         -3.1, -3.2, -3.3, -3.4, -3.5, -3.6,
         -3.7, -3.8, -3.9, -4.1, -4.2, -4.3;
+  // clang-format on
   EXPECT_TRUE((H1 * P_matrix).isApprox(H1 * P, kEpsilon));
   EXPECT_TRUE((P_matrix * H1).isApprox(P * H1, kEpsilon));
 
@@ -178,8 +180,8 @@ GTEST_TEST(ArticulatedBodyInertia, TimesOperator) {
 
   // Ensure that the results of multiplying by H transpose and H on the left and
   // right are the same as operating directly on the matrix.
-  EXPECT_TRUE((H2.transpose() * P_matrix * H2).isApprox(
-      H2.transpose() * P * H2, kEpsilon));
+  EXPECT_TRUE((H2.transpose() * P_matrix * H2)
+                  .isApprox(H2.transpose() * P * H2, kEpsilon));
 }
 
 // Tests support (though limited) for symbolic::Expression.

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -60,7 +60,7 @@ class BallRpyJointTest : public ::testing::Test {
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
     system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
-        std::move(model), true/* is_discrete */);
+        std::move(model), true /* is_discrete */);
     context_ = system_->CreateDefaultContext();
   }
 
@@ -271,8 +271,7 @@ TEST_F(BallRpyJointTest, DefaultAngles) {
 
   // Setting the default angle out of the bounds of the position limits
   // should NOT throw an exception
-  EXPECT_NO_THROW(
-      mutable_joint_->set_default_angles(out_of_bounds_low_angles));
+  EXPECT_NO_THROW(mutable_joint_->set_default_angles(out_of_bounds_low_angles));
   EXPECT_NO_THROW(
       mutable_joint_->set_default_angles(out_of_bounds_high_angles));
 }

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -26,8 +26,8 @@ class MultibodyElementTester {
 namespace internal {
 
 using Eigen::AngleAxisd;
-using Eigen::MatrixXd;
 using Eigen::Matrix3d;
+using Eigen::MatrixXd;
 using Eigen::Vector3d;
 using math::RotationMatrix;
 using systems::Context;
@@ -84,9 +84,9 @@ GTEST_TEST(BodyNodeTest, FactorArticulatedBodyHingeInertiaMatrixErrorMessages) {
   const SpanningForest::Mobod dummy_mobod(MobodIndex(0), LinkOrdinal(0));
   {
     // Rotation only.
-    const RevoluteMobilizer<double> mobilizer(
-        dummy_mobod, parent.body_frame(), child.body_frame(),
-        Vector3d{0, 0, 1});
+    const RevoluteMobilizer<double> mobilizer(dummy_mobod, parent.body_frame(),
+                                              child.body_frame(),
+                                              Vector3d{0, 0, 1});
     const BodyNode<double> body_node(&parent_node, &child, &mobilizer);
     DRAKE_EXPECT_THROWS_MESSAGE(
         BodyNodeTester::CallLltFactorization(body_node, one_by_one),
@@ -99,9 +99,9 @@ GTEST_TEST(BodyNodeTest, FactorArticulatedBodyHingeInertiaMatrixErrorMessages) {
 
   {
     // Translation only.
-    const PrismaticMobilizer<double> mobilizer(
-        dummy_mobod, parent.body_frame(), child.body_frame(),
-        Vector3d{0, 0, 1});
+    const PrismaticMobilizer<double> mobilizer(dummy_mobod, parent.body_frame(),
+                                               child.body_frame(),
+                                               Vector3d{0, 0, 1});
     const BodyNode<double> body_node(&parent_node, &child, &mobilizer);
     DRAKE_EXPECT_THROWS_MESSAGE(
         BodyNodeTester::CallLltFactorization(body_node, one_by_one),

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -23,9 +23,9 @@ namespace internal {
 namespace {
 
 using Eigen::AngleAxisd;
-using math::RigidTransformd;
 using Eigen::Translation3d;
 using Eigen::Vector3d;
+using math::RigidTransformd;
 using std::unique_ptr;
 using systems::Context;
 
@@ -52,9 +52,8 @@ class FrameTests : public ::testing::Test {
     frameB_ = &bodyB_->body_frame();
 
     // Joint connecting bodyB to the world.
-    model->AddJoint<RevoluteJoint>("joint0",
-        model->world_body(), {}, *bodyB_, {},
-        Vector3d::UnitZ() /*revolute axis*/);
+    model->AddJoint<RevoluteJoint>("joint0", model->world_body(), {}, *bodyB_,
+                                   {}, Vector3d::UnitZ() /*revolute axis*/);
 
     // Some arbitrary pose of frame P in the body frame B.
     X_BP_ = RigidTransformd(AngleAxisd(M_PI / 6.0, Vector3d::UnitZ()) *
@@ -69,8 +68,7 @@ class FrameTests : public ::testing::Test {
                             AngleAxisd(M_PI / 7.0, Vector3d::UnitX()) *
                             Translation3d(0.5, 1.0, -2.0));
     // Frame Q is rigidly attached to P with pose X_PQ.
-    frameQ_ =
-        &model->AddFrame<FixedOffsetFrame>("Q", *frameP_, X_PQ_);
+    frameQ_ = &model->AddFrame<FixedOffsetFrame>("Q", *frameP_, X_PQ_);
 
     // Frame R is arbitrary, but named.
     frameR_ = &model->AddFrame<FixedOffsetFrame>(
@@ -85,13 +83,12 @@ class FrameTests : public ::testing::Test {
     // Ensure that the model instance propagates implicitly.
     frameSChild_ = &model->AddFrame<FixedOffsetFrame>(
         "SChild", *frameS_, math::RigidTransformd::Identity());
-    EXPECT_EQ(frameSChild_->scoped_name().get_full(),
-              "extra_instance::SChild");
+    EXPECT_EQ(frameSChild_->scoped_name().get_full(), "extra_instance::SChild");
 
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
-    system_ = std::make_unique<
-        internal::MultibodyTreeSystem<double>>(std::move(model));
+    system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
+        std::move(model));
     context_ = system_->CreateDefaultContext();
 
     // An arbitrary pose of an arbitrary frame G in an arbitrary frame F.
@@ -336,8 +333,7 @@ TEST_F(FrameTests, ModelInstanceOverride) {
 TEST_F(FrameTests, HasFrameNamed) {
   for (FrameIndex i{0}; i < tree().num_frames(); ++i) {
     auto& frame = tree().get_frame(i);
-    EXPECT_TRUE(
-        tree().HasFrameNamed(frame.name(), frame.model_instance()))
+    EXPECT_TRUE(tree().HasFrameNamed(frame.name(), frame.model_instance()))
         << frame.name();
   }
 }

--- a/multibody/tree/test/free_rotating_body_plant.cc
+++ b/multibody/tree/test/free_rotating_body_plant.cc
@@ -12,19 +12,20 @@ namespace test {
 
 using Eigen::Vector3d;
 
-template<typename T>
-FreeRotatingBodyPlant<T>::FreeRotatingBodyPlant(double I, double J) :
-    internal::MultibodyTreeSystem<T>(), I_(I), J_(J) {
+template <typename T>
+FreeRotatingBodyPlant<T>::FreeRotatingBodyPlant(double I, double J)
+    : internal::MultibodyTreeSystem<T>(), I_(I), J_(J) {
   BuildMultibodyTreeModel();
   DRAKE_DEMAND(tree().num_positions() == 3);
   DRAKE_DEMAND(tree().num_velocities() == 3);
   DRAKE_DEMAND(tree().num_states() == 6);
 }
 
-template<typename T>
-template<typename U>
+template <typename T>
+template <typename U>
 FreeRotatingBodyPlant<T>::FreeRotatingBodyPlant(
-    const FreeRotatingBodyPlant<U> &other) : FreeRotatingBodyPlant<T>(I_, J_) {}
+    const FreeRotatingBodyPlant<U>& other)
+    : FreeRotatingBodyPlant<T>(I_, J_) {}
 
 template <typename T>
 void FreeRotatingBodyPlant<T>::BuildMultibodyTreeModel() {
@@ -35,14 +36,14 @@ void FreeRotatingBodyPlant<T>::BuildMultibodyTreeModel() {
 
   body_ = &this->mutable_tree().AddRigidBody("B", M_Bcm);
   joint_ = &this->mutable_tree().template AddJoint<BallRpyJoint>(
-          "ball_rpy_joint", tree().world_body(), {}, *body_, {});
+      "ball_rpy_joint", tree().world_body(), {}, *body_, {});
 
   internal::MultibodyTreeSystem<T>::Finalize();
 }
 
-template<typename T>
-Vector3<double>
-FreeRotatingBodyPlant<T>::get_default_initial_angular_velocity() const {
+template <typename T>
+Vector3<double> FreeRotatingBodyPlant<T>::get_default_initial_angular_velocity()
+    const {
   return Vector3d::UnitX() + Vector3d::UnitY() + Vector3d::UnitZ();
 }
 
@@ -61,26 +62,26 @@ void FreeRotatingBodyPlant<T>::SetDefaultState(
       context, get_default_initial_angular_velocity(), state);
 }
 
-template<typename T>
+template <typename T>
 Vector3<T> FreeRotatingBodyPlant<T>::get_angular_velocity(
     const systems::Context<T>& context) const {
   return joint_->get_angular_velocity(context);
 }
 
-template<typename T>
+template <typename T>
 void FreeRotatingBodyPlant<T>::set_angular_velocity(
     systems::Context<T>* context, const Vector3<T>& w_WB) const {
   joint_->set_angular_velocity(context, w_WB);
 }
 
-template<typename T>
+template <typename T>
 math::RigidTransform<T> FreeRotatingBodyPlant<T>::CalcPoseInWorldFrame(
     const systems::Context<T>& context) const {
   auto& pc = this->EvalPositionKinematics(context);
   return math::RigidTransform<T>(pc.get_X_WB(body_->mobod_index()));
 }
 
-template<typename T>
+template <typename T>
 SpatialVelocity<T> FreeRotatingBodyPlant<T>::CalcSpatialVelocityInWorldFrame(
     const systems::Context<T>& context) const {
   auto& vc = this->EvalVelocityKinematics(context);

--- a/multibody/tree/test/free_rotating_body_plant.h
+++ b/multibody/tree/test/free_rotating_body_plant.h
@@ -21,7 +21,7 @@ namespace test {
 /// its axis of revolution.
 ///
 /// @tparam_default_scalar
-template<typename T>
+template <typename T>
 class FreeRotatingBodyPlant final : public internal::MultibodyTreeSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FreeRotatingBodyPlant);
@@ -52,8 +52,8 @@ class FreeRotatingBodyPlant final : public internal::MultibodyTreeSystem<T> {
 
   /// Stores in `context` the value of the angular velocity `w_WB` of the body
   /// in the world frame W.
-  void set_angular_velocity(
-      systems::Context<T>* context, const Vector3<T>& w_WB) const;
+  void set_angular_velocity(systems::Context<T>* context,
+                            const Vector3<T>& w_WB) const;
 
   /// Computes the pose `X_WB` of the body in the world frame.
   math::RigidTransform<T> CalcPoseInWorldFrame(

--- a/multibody/tree/test/free_rotating_body_test.cc
+++ b/multibody/tree/test/free_rotating_body_test.cc
@@ -40,9 +40,8 @@ GTEST_TEST(RollPitchYawTest, TimeDerivatives) {
 
   // Instantiate a benchmark object with analytical solution for comparison with
   // our numerical solution.
-  FreeBody benchmark_(
-      Quaterniond::Identity(), Vector3d::Zero(),
-      p0_WBcm, v0_WBcm, gravity_W);
+  FreeBody benchmark_(Quaterniond::Identity(), Vector3d::Zero(), p0_WBcm,
+                      v0_WBcm, gravity_W);
 
   // Instantiate the model for the free body in space.
   FreeRotatingBodyPlant<double> free_body_plant(benchmark_.get_I(),
@@ -81,7 +80,7 @@ GTEST_TEST(RollPitchYawTest, TimeDerivatives) {
 
   simulator.Initialize();
   RungeKutta3Integrator<double>& integrator =
-          simulator.reset_integrator<RungeKutta3Integrator<double>>();
+      simulator.reset_integrator<RungeKutta3Integrator<double>>();
   integrator.set_maximum_step_size(kMaxDt);
   EXPECT_FALSE(integrator.get_fixed_step_mode());
   EXPECT_TRUE(integrator.supports_error_estimation());

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -32,8 +32,7 @@ constexpr double kTol = std::numeric_limits<double>::epsilon();
 // Asserts that the given spatial inertia is equivalent to the given mass
 // properties, i.e., mass, position vector, and unit inertia.
 ::testing::AssertionResult SpatialInertiasEqual(
-    const SpatialInertia<double>& dut,
-    const SpatialInertia<double>& M_expected,
+    const SpatialInertia<double>& dut, const SpatialInertia<double>& M_expected,
     double tolerance = 0.0) {
   const double mass = M_expected.get_mass();
   const Vector3<double> p_BoBcm_B = M_expected.get_com();
@@ -64,7 +63,6 @@ constexpr double kTol = std::numeric_limits<double>::epsilon();
   return ::testing::AssertionSuccess();
 }
 
-
 // Note: Some tests below validate using SpatialInertia::SolidFooWithDensity()
 // or UnitInertia::SolidFoo(). The *implementations* use similar logic, so,
 // these tests would seem to be a tautology. This is intentional. The goal is
@@ -79,8 +77,8 @@ GTEST_TEST(GeometrySpatialInertiaTest, Box) {
   const geometry::Box box(Lx, Ly, Lz);
   const SpatialInertia<double> M_BBo_B =
       SpatialInertia<double>::SolidBoxWithDensity(kDensity, Lx, Ly, Lz);
-  EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(box, kDensity),
-                                   M_BBo_B, /* tolerance = */ 0.0));
+  EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(box, kDensity), M_BBo_B,
+                                   /* tolerance = */ 0.0));
 }
 
 GTEST_TEST(GeometrySpatialInertiaTest, Capsule) {
@@ -88,8 +86,8 @@ GTEST_TEST(GeometrySpatialInertiaTest, Capsule) {
   const double L = 2;
   const geometry::Capsule capsule(r, L);
   const SpatialInertia<double> M_BBo_B =
-      SpatialInertia<double>::SolidCapsuleWithDensity(
-          kDensity, r, L, Vector3<double>::UnitZ());
+      SpatialInertia<double>::SolidCapsuleWithDensity(kDensity, r, L,
+                                                      Vector3<double>::UnitZ());
   EXPECT_TRUE(SpatialInertiasEqual(CalcSpatialInertia(capsule, kDensity),
                                    M_BBo_B, /* tolerance = */ 0.0));
 }
@@ -181,8 +179,8 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
 
   const std::string valid_obj_path = FindResourceOrThrow(
       "drake/multibody/parsing/test/box_package/meshes/box.obj");
-  const std::string valid_vtk_path = FindResourceOrThrow(
-      "drake/geometry/test/one_tetrahedron.vtk");
+  const std::string valid_vtk_path =
+      FindResourceOrThrow("drake/geometry/test/one_tetrahedron.vtk");
   const MeshType unit_scale_obj(valid_obj_path, 1.0);
   const MeshType double_scale_obj(valid_obj_path, 2.0);
   const MeshType unit_scale_vtk(valid_vtk_path, 1.0);
@@ -206,7 +204,7 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
       DRAKE_EXPECT_THROWS_MESSAGE(
           CalcSpatialInertia(nonexistent, kDensity),
           ".*only supports .obj or .*.vtk .* given '.*nonexistent.stl'.*");
-      }
+    }
   }
 
   {
@@ -260,7 +258,7 @@ GTEST_TEST(TriangleSurfaceMassPropertiesTest, ExactPolyhedron) {
   const double Lz = 3;
   const geometry::Box box(Lx, Ly, Lz);
   const SpatialInertia<double> M_BBo_B =
-    SpatialInertia<double>::SolidBoxWithDensity(kDensity, Lx, Ly, Lz);
+      SpatialInertia<double>::SolidBoxWithDensity(kDensity, Lx, Ly, Lz);
 
   {
     // Mesh posed in its frame the same as the solid box is in its own frame.
@@ -297,8 +295,7 @@ GTEST_TEST(TriangleSurfaceMassPropertiesTest, ExactPolyhedron) {
     const double mass = M_BBo_B.get_mass();
     const UnitInertia<double> G_BBo_B = M_BBo_B.get_unit_inertia();
     const UnitInertia<double> G_BBo_M = G_BBo_B.ReExpress(R_MB);
-    const UnitInertia<double> G_MMo_M =
-        G_BBo_M.ShiftFromCenterOfMass(p_BcmMcm);
+    const UnitInertia<double> G_MMo_M = G_BBo_M.ShiftFromCenterOfMass(p_BcmMcm);
 
     // The vertex transformation introduces precision loss, requiring a larger
     // tolerance.

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -35,21 +35,21 @@ class BushingTester {
 
     RotationMatrixd R_AB_expected(Eigen::AngleAxis<double>(angle / 2, axis));
     DRAKE_EXPECT_NO_THROW(
-      LinearBushingRollPitchYaw<double>::ThrowIfInvalidHalfAngleAxis(
-              R_AC, R_AB_expected));
+        LinearBushingRollPitchYaw<double>::ThrowIfInvalidHalfAngleAxis(
+            R_AC, R_AB_expected));
 
     // Ensure calculated R_AB is nearly equal to R_AB_expected.
     DRAKE_ASSERT(R_AB.IsNearlyEqualTo(R_AB_expected, 32 * kEpsilon));
 
     double bad_half_angle = angle / 2 + 128 * kEpsilon;
     RotationMatrixd R_AB_bad(Eigen::AngleAxis<double>(bad_half_angle, axis));
-    DRAKE_EXPECT_THROWS_MESSAGE(LinearBushingRollPitchYaw<double>::
-          ThrowIfInvalidHalfAngleAxis(R_AC, R_AB_bad),
-          "Error: Calculation of R_AB from quaternion differs from the "
-          "R_AB_expected formed via a half-angle axis calculation.");
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        LinearBushingRollPitchYaw<double>::ThrowIfInvalidHalfAngleAxis(
+            R_AC, R_AB_bad),
+        "Error: Calculation of R_AB from quaternion differs from the "
+        "R_AB_expected formed via a half-angle axis calculation.");
   }
 };
-
 
 namespace internal {
 namespace {
@@ -64,8 +64,8 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
     // Before adding a rigid link C to the model, form a spatial inertia that
     // contains C's mass and inertia properties about Ccm, expressed in C.
     // Note: Point Co (C's origin) is coincident with CCm (C's center of mass).
-    const RotationalInertia<double> I_CCcm_C(Ixx_, Iyy_, Izz_,
-                                             Ixy_, Ixz_, Iyz_);
+    const RotationalInertia<double> I_CCcm_C(Ixx_, Iyy_, Izz_, Ixy_, Ixz_,
+                                             Iyz_);
     const SpatialInertia<double> M_CCo_C =
         SpatialInertia<double>::MakeFromCentralInertia(mC_, p_CoCcm_, I_CCcm_C);
 
@@ -79,9 +79,8 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
 
     // Allow relative motion between bodies A and C by adding a 6-DOF mobilizer
     // between frameA of bodyA (world) and frameC of bodyC.
-    joint_ = &model->AddJoint(
-        std::make_unique<QuaternionFloatingJoint<double>>("joint0",
-            frameA, frameC));
+    joint_ = &model->AddJoint(std::make_unique<QuaternionFloatingJoint<double>>(
+        "joint0", frameA, frameC));
 
     // Calculate "reasonable" torque and force stiffness/damping constants,
     // where "reasonable" means a critical damping ratio ζ = 0.1 for each of the
@@ -90,18 +89,14 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
     Vector3<double> torque_damping_constants;
     Vector3<double> force_stiffness_constants;
     Vector3<double> force_damping_constants;
-    CalcReasonableStiffnessAndDampingConstants(&torque_stiffness_constants,
-                                               &torque_damping_constants,
-                                               &force_stiffness_constants,
-                                               &force_damping_constants);
+    CalcReasonableStiffnessAndDampingConstants(
+        &torque_stiffness_constants, &torque_damping_constants,
+        &force_stiffness_constants, &force_damping_constants);
 
     // Add a bushing force element between frame A and frame C.
     bushing_ = &(model->AddForceElement<LinearBushingRollPitchYaw>(
-                              frameA, frameC,
-                              torque_stiffness_constants,
-                              torque_damping_constants,
-                              force_stiffness_constants,
-                              force_damping_constants));
+        frameA, frameC, torque_stiffness_constants, torque_damping_constants,
+        force_stiffness_constants, force_damping_constants));
 
     // By default, this model has no uniform gravitational force.
     const Vector3<double> gravity(0, 0, 0);
@@ -128,10 +123,8 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
   //   results that can be passed to this method as a non nullptr and used as a
   //   secondary check on the Drake results.
   void CompareToMotionGenesisResult(
-      const math::RollPitchYaw<double>& rpy,
-      const Vector3<double>& p_AoCo_A,
-      const Vector3<double>& w_AC_A,
-      const Vector3<double>& v_ACo_A,
+      const math::RollPitchYaw<double>& rpy, const Vector3<double>& p_AoCo_A,
+      const Vector3<double>& w_AC_A, const Vector3<double>& v_ACo_A,
       const Vector3<double>* f_C_C_expected_simple = nullptr,
       const Vector3<double>* t_Co_C_expected_simple = nullptr) const {
     const RotationMatrixd R_AC(rpy);
@@ -152,9 +145,9 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
 
     // ---------- Start of alternate calculations ---------
     // Get the roll-pitch-yaw angles relating orientation of frames A and C.
-    const double q0 = rpy.roll_angle();    // rad
-    const double q1 = rpy.pitch_angle();   // rad
-    const double q2 = rpy.yaw_angle();     // rad
+    const double q0 = rpy.roll_angle();   // rad
+    const double q1 = rpy.pitch_angle();  // rad
+    const double q2 = rpy.yaw_angle();    // rad
 
     // Form kinematical ODEs that relate [q̇₀ q̇₁ q̇₂] to w_AC_A.
     const Vector3<double> qDt =
@@ -229,13 +222,13 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
 
     // Calculate the moment on frame A about Ao, expressed in A.
     const Vector3<double> p_AoBo_B = 0.5 * p_AoCo_B;
-    const Vector3<double> t_Ao_A_expected = -txyz +
-        R_AB * p_AoBo_B.cross(f_A_B_expected);
+    const Vector3<double> t_Ao_A_expected =
+        -txyz + R_AB * p_AoBo_B.cross(f_A_B_expected);
 
     // Calculate the moment on frame C about Co, expressed in A.
     const Vector3<double> p_CoBo_B = -p_AoBo_B;
-    const Vector3<double> t_Co_C_expected = R_CA * txyz
-        + R_CB * p_CoBo_B.cross(f_C_B_expected);
+    const Vector3<double> t_Co_C_expected =
+        R_CA * txyz + R_CB * p_CoBo_B.cross(f_C_B_expected);
 
     // Verify F_A_A,, the bushing's spatial force calculation on frame A.
     double torque_epsilon = 32 * kEpsilon * t_Ao_A_expected.norm();
@@ -252,10 +245,10 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
         bushing_->CalcBushingSpatialForceOnFrameC(context);
     const Vector3<double>& t_Co_C = F_C_C.rotational();
     const Vector3<double>& f_C_C = F_C_C.translational();
-    EXPECT_TRUE(CompareMatrices(t_Co_C, t_Co_C_expected,
-                                torque_epsilon, MatrixCompareType::relative));
-    EXPECT_TRUE(CompareMatrices(f_C_C, f_C_C_expected,
-                                force_epsilon, MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(t_Co_C, t_Co_C_expected, torque_epsilon,
+                                MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(f_C_C, f_C_C_expected, force_epsilon,
+                                MatrixCompareType::relative));
 
     // If available, also verify the previous results with by-hand calculations.
     if (t_Co_C_expected_simple != nullptr) {
@@ -263,8 +256,8 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
                                   torque_epsilon, MatrixCompareType::relative));
     }
     if (f_C_C_expected_simple != nullptr) {
-      EXPECT_TRUE(CompareMatrices(f_C_C, *f_C_C_expected_simple,
-                                  force_epsilon, MatrixCompareType::relative));
+      EXPECT_TRUE(CompareMatrices(f_C_C, *f_C_C_expected_simple, force_epsilon,
+                                  MatrixCompareType::relative));
     }
 
     // Verify potential energy and power methods throw exceptions.
@@ -275,7 +268,7 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
         mbt.EvalVelocityKinematics(context);
 
     // Verify CalcPotentialEnergy() throws an exception (see issue #12982).
-    const ForceElement<double> *bushing_force_element = bushing_;
+    const ForceElement<double>* bushing_force_element = bushing_;
     DRAKE_EXPECT_THROWS_MESSAGE(
         bushing_force_element->CalcPotentialEnergy(context, pc),
         "Error: LinearBushingRollPitchYaw::CalcPotentialEnergy().*");
@@ -296,10 +289,10 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
   // natural periods of a few seconds.  This method returns output via its
   // arguments, which are defined in the LinearBushingRollPitchYaw constructor.
   void CalcReasonableStiffnessAndDampingConstants(
-      Vector3<double>* torque_stiffness_constants,         /* [k₀, k₁, k₂] */
-      Vector3<double>* torque_damping_constants,           /* [d₀, d₁, d₂] */
-      Vector3<double>* force_stiffness_constants,          /* [kx, ky, kz] */
-      Vector3<double>* force_damping_constants) const {    /* [dx, dy, dz] */
+      Vector3<double>* torque_stiffness_constants,      /* [k₀, k₁, k₂] */
+      Vector3<double>* torque_damping_constants,        /* [d₀, d₁, d₂] */
+      Vector3<double>* force_stiffness_constants,       /* [kx, ky, kz] */
+      Vector3<double>* force_damping_constants) const { /* [dx, dy, dz] */
     DRAKE_ASSERT(torque_stiffness_constants != nullptr);
     DRAKE_ASSERT(torque_damping_constants != nullptr);
     DRAKE_ASSERT(force_stiffness_constants != nullptr);
@@ -317,30 +310,30 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
     // Use τᴅᴀᴍᴩ = 2π/ωᴅᴀᴍᴩ, ωᴅᴀᴍᴩ = ωₙ√(1−ζ²) to find ωₙ = ωᴅᴀᴍᴩ / √(1−ζ²).
     // Since ζ = b /(2 √(m k)), the associated damping constant b = 2 ζ √(m k).
     // ------------ Calculate torque stiffness/damping constants --------------
-    const double tau_rotate = 1;                                 // seconds
-    const double wDamped_rotate = 2 * M_PI / tau_rotate;         // rad/s
-    const double zeta = 0.1;                                     // No units
+    const double tau_rotate = 1;                          // seconds
+    const double wDamped_rotate = 2 * M_PI / tau_rotate;  // rad/s
+    const double zeta = 0.1;                              // No units
     const double wn_rotate = wDamped_rotate / std::sqrt(1 - zeta * zeta);
-    const double k0 = Ixx_ * wn_rotate * wn_rotate;              // N*m/rad
-    const double k1 = Iyy_ * wn_rotate * wn_rotate;              // N*m/rad
-    const double k2 = Izz_ * wn_rotate * wn_rotate;              // N*m/rad
-    const double d0 = 2 * zeta * std::sqrt(Ixx_ * k0);           // N*m*s/rad
-    const double d1 = 2 * zeta * std::sqrt(Iyy_ * k1);           // N*m*s/rad
-    const double d2 = 2 * zeta * std::sqrt(Izz_ * k2);           // N*m*s/rad
+    const double k0 = Ixx_ * wn_rotate * wn_rotate;     // N*m/rad
+    const double k1 = Iyy_ * wn_rotate * wn_rotate;     // N*m/rad
+    const double k2 = Izz_ * wn_rotate * wn_rotate;     // N*m/rad
+    const double d0 = 2 * zeta * std::sqrt(Ixx_ * k0);  // N*m*s/rad
+    const double d1 = 2 * zeta * std::sqrt(Iyy_ * k1);  // N*m*s/rad
+    const double d2 = 2 * zeta * std::sqrt(Izz_ * k2);  // N*m*s/rad
     *torque_stiffness_constants = Vector3<double>(k0, k1, k2);
     *torque_damping_constants = Vector3<double>(d0, d1, d2);
 
     // ------------ Calculate force stiffness/damping constants ---------------
-    const double tauX = 2, tauY = 3, tauZ = 3;                   // seconds
-    const double wDampedX = 2 * M_PI / tauX;                     // rad/s
-    const double wDampedY = 2 * M_PI / tauY;                     // rad/s
-    const double wDampedZ = 2 * M_PI / tauZ;                     // rad/s
-    const double wnX = wDampedX / std::sqrt(1 - zeta * zeta);    // rad/s
-    const double wnY = wDampedY / std::sqrt(1 - zeta * zeta);    // rad/s
-    const double wnZ = wDampedZ / std::sqrt(1 - zeta * zeta);    // rad/s
-    const double kx = mC_ * wnX * wnX;                           // N/m
-    const double ky = mC_ * wnY * wnY;                           // N/m
-    const double kz = mC_ * wnZ * wnZ;                           // N/m
+    const double tauX = 2, tauY = 3, tauZ = 3;                 // seconds
+    const double wDampedX = 2 * M_PI / tauX;                   // rad/s
+    const double wDampedY = 2 * M_PI / tauY;                   // rad/s
+    const double wDampedZ = 2 * M_PI / tauZ;                   // rad/s
+    const double wnX = wDampedX / std::sqrt(1 - zeta * zeta);  // rad/s
+    const double wnY = wDampedY / std::sqrt(1 - zeta * zeta);  // rad/s
+    const double wnZ = wDampedZ / std::sqrt(1 - zeta * zeta);  // rad/s
+    const double kx = mC_ * wnX * wnX;                         // N/m
+    const double ky = mC_ * wnY * wnY;                         // N/m
+    const double kz = mC_ * wnZ * wnZ;                         // N/m
     const Vector3<double> Kxyz(kx, ky, kz);
     const Vector3<double> Dxyz = 2 * zeta * (mC_ * Kxyz).cwiseSqrt();
     *force_stiffness_constants = Vector3<double>(kx, ky, kz);
@@ -387,23 +380,22 @@ TEST_F(LinearBushingRollPitchYawTester, ConstructionAndAccessors) {
   Vector3<double> torque_damping_constants;
   Vector3<double> force_stiffness_constants;
   Vector3<double> force_damping_constants;
-  CalcReasonableStiffnessAndDampingConstants(&torque_stiffness_constants,
-                                             &torque_damping_constants,
-                                             &force_stiffness_constants,
-                                             &force_damping_constants);
+  CalcReasonableStiffnessAndDampingConstants(
+      &torque_stiffness_constants, &torque_damping_constants,
+      &force_stiffness_constants, &force_damping_constants);
   const double tolerance = 32 * kEpsilon;
   EXPECT_TRUE(CompareMatrices(torque_stiffness_constants,
-                              bushing_->torque_stiffness_constants(),
-                              tolerance, MatrixCompareType::relative));
+                              bushing_->torque_stiffness_constants(), tolerance,
+                              MatrixCompareType::relative));
   EXPECT_TRUE(CompareMatrices(torque_damping_constants,
-                              bushing_->torque_damping_constants(),
-                              tolerance, MatrixCompareType::relative));
+                              bushing_->torque_damping_constants(), tolerance,
+                              MatrixCompareType::relative));
   EXPECT_TRUE(CompareMatrices(force_stiffness_constants,
-                              bushing_->force_stiffness_constants(),
-                              tolerance, MatrixCompareType::relative));
+                              bushing_->force_stiffness_constants(), tolerance,
+                              MatrixCompareType::relative));
   EXPECT_TRUE(CompareMatrices(force_damping_constants,
-                              bushing_->force_damping_constants(),
-                              tolerance, MatrixCompareType::relative));
+                              bushing_->force_damping_constants(), tolerance,
+                              MatrixCompareType::relative));
 }
 
 // Verify results when body C has given orientation, but no motion in world.
@@ -424,26 +416,26 @@ TEST_F(LinearBushingRollPitchYawTester, VariousOrientationsAtRest) {
   math::RollPitchYaw<double> rpy(0, 0, 0);
   Vector3<double> f_C_C_expected = Vector3<double>(0, 0, 0);
   Vector3<double> t_Co_C_expected = Vector3<double>(0, 0, 0);
-  CompareToMotionGenesisResult(rpy, p_zero, w_zero, v_zero,
-                               &f_C_C_expected, &t_Co_C_expected);
+  CompareToMotionGenesisResult(rpy, p_zero, w_zero, v_zero, &f_C_C_expected,
+                               &t_Co_C_expected);
 
   // Test for non-zero roll only.
   rpy.set(roll_angle, 0, 0);
   t_Co_C_expected = Vector3<double>(k0_roll, 0, 0);
-  CompareToMotionGenesisResult(rpy, p_zero, w_zero, v_zero,
-                               &f_C_C_expected, &t_Co_C_expected);
+  CompareToMotionGenesisResult(rpy, p_zero, w_zero, v_zero, &f_C_C_expected,
+                               &t_Co_C_expected);
 
   // Test for non-zero pitch only.
   rpy.set(0, pitch_angle, 0);
   t_Co_C_expected = Vector3<double>(0, k1_pitch, 0);
-  CompareToMotionGenesisResult(rpy, p_zero, w_zero, v_zero,
-                               &f_C_C_expected, &t_Co_C_expected);
+  CompareToMotionGenesisResult(rpy, p_zero, w_zero, v_zero, &f_C_C_expected,
+                               &t_Co_C_expected);
 
   // Test for non-zero yaw only.
   rpy.set(0, 0, yaw_angle);
   t_Co_C_expected = Vector3<double>(0, 0, k2_yaw);
-  CompareToMotionGenesisResult(rpy, p_zero, w_zero, v_zero,
-                               &f_C_C_expected, &t_Co_C_expected);
+  CompareToMotionGenesisResult(rpy, p_zero, w_zero, v_zero, &f_C_C_expected,
+                               &t_Co_C_expected);
 
   // Test with roll ≠ 0, pitch ≠ 0, yaw = 0.
   rpy.set(roll_angle, pitch_angle, 0);
@@ -649,6 +641,7 @@ TEST_F(LinearBushingRollPitchYawTester, VariousPosesAndMotion) {
   const Vector3<double> w_AC_A(0.7, 0.8, 0.9);
   const Vector3<double> v_zero(0, 0, 0);
   const Vector3<double> v_ACo_A(1.1, 1.2, 1.3);
+  // clang-format off
   CompareToMotionGenesisResult(rpy_zero, p_zero,   w_zero, v_zero);
   CompareToMotionGenesisResult(rpy_zero, p_zero,   w_zero, v_ACo_A);
   CompareToMotionGenesisResult(rpy_zero, p_zero,   w_AC_A, v_zero);
@@ -665,11 +658,12 @@ TEST_F(LinearBushingRollPitchYawTester, VariousPosesAndMotion) {
   CompareToMotionGenesisResult(rpy,      p_AoCo_A, w_zero, v_ACo_A);
   CompareToMotionGenesisResult(rpy,      p_AoCo_A, w_AC_A, v_zero);
   CompareToMotionGenesisResult(rpy,      p_AoCo_A, w_AC_A, v_ACo_A);
+  // clang-format on
 }
 
 // Test that an exception is thrown near gimbal lock singularity.
 TEST_F(LinearBushingRollPitchYawTester, TestGimbalLock) {
-  const math::RollPitchYaw<double> rpy_gimbal_lock(0, M_PI/2, 0);
+  const math::RollPitchYaw<double> rpy_gimbal_lock(0, M_PI / 2, 0);
   const Vector3<double> p_zero(0, 0, 0);
   const Vector3<double> w_zero(0, 0, 0);
   const Vector3<double> v_zero(0, 0, 0);
@@ -688,20 +682,18 @@ TEST_F(LinearBushingRollPitchYawTester, TestGimbalLock) {
 
   // Check that CalcBushingSpatialForceOnFrameA() throws near gimbal lock.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      bushing_->CalcBushingSpatialForceOnFrameA(context),
-      expected_message);
+      bushing_->CalcBushingSpatialForceOnFrameA(context), expected_message);
 
   // Check that CalcBushingSpatialForceOnFrameC() throws near gimbal lock.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      bushing_->CalcBushingSpatialForceOnFrameC(context),
-      expected_message);
+      bushing_->CalcBushingSpatialForceOnFrameC(context), expected_message);
 }
 
 // Verify algorithm that calculates rotation matrix R_AB.
 TEST_F(LinearBushingRollPitchYawTester, HalfAngleAxisAlgorithm) {
   // This test uses a generic unit vector for the "axis" part of AngleAxis.
   const Vector3<double> unit_vector = Vector3<double>(1, 2, 3).normalized();
-  for (double angle = 0; angle <= 0.99 * M_PI;  angle += M_PI / 32) {;
+  for (double angle = 0; angle <= 0.99 * M_PI; angle += M_PI / 32) {
     BushingTester::VerifyHalfAngleAxisAlgorithm(angle, unit_vector);
   }
 }
@@ -713,10 +705,12 @@ GTEST_TEST(LinearBushingRollPitchYawTest, BushingParameters) {
   const double sphere_radius = 1.0;
   const double sphere_mass = 2.5;
 
-  const RigidBody<double>& sphere1 = plant.AddRigidBody("sphere1",
+  const RigidBody<double>& sphere1 = plant.AddRigidBody(
+      "sphere1",
       SpatialInertia<double>::SolidSphereWithMass(sphere_mass, sphere_radius));
 
-  const RigidBody<double>& sphere2 = plant.AddRigidBody("sphere2",
+  const RigidBody<double>& sphere2 = plant.AddRigidBody(
+      "sphere2",
       SpatialInertia<double>::SolidSphereWithMass(sphere_mass, sphere_radius));
 
   const Vector3<double> torque_stiffness(100, 100, 100);

--- a/multibody/tree/test/linear_spring_damper_test.cc
+++ b/multibody/tree/test/linear_spring_damper_test.cc
@@ -6,12 +6,9 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/plant/multibody_plant.h"
-#include "drake/multibody/tree/position_kinematics_cache.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/spatial_inertia.h"
-#include "drake/multibody/tree/velocity_kinematics_cache.h"
-#include "drake/multibody/tree/weld_joint.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
@@ -36,8 +33,8 @@ class SpringDamperTester : public ::testing::Test {
     bodyB_ = &plant_.AddRigidBody("BodyB", point_mass);
 
     plant_.AddJoint<WeldJoint>("WeldBodyAToWorld", plant_.world_body(),
-                              std::nullopt, *bodyA_, std::nullopt,
-                              math::RigidTransform<double>::Identity());
+                               std::nullopt, *bodyA_, std::nullopt,
+                               math::RigidTransform<double>::Identity());
 
     // Allow body B to slide along the x axis.
     slider_ = &plant_.AddJoint<PrismaticJoint>(
@@ -283,8 +280,7 @@ TEST_F(SpringDamperTester, Power) {
 
   // System power should reflect only the spring.
   EXPECT_EQ(plant_.EvalConservativePower(*context_), conservative_power);
-  EXPECT_EQ(plant_.EvalNonConservativePower(*context_),
-            non_conservative_power);
+  EXPECT_EQ(plant_.EvalNonConservativePower(*context_), non_conservative_power);
 }
 
 }  // namespace

--- a/multibody/tree/test/mobilizer_tester.h
+++ b/multibody/tree/test/mobilizer_tester.h
@@ -48,13 +48,13 @@ class MobilizerTester : public ::testing::Test {
 
     // We are done adding modeling elements. Transfer tree to system,
     // finalize, and get a Context.
-    system_ = std::make_unique<MultibodyTreeSystem<double>>(
-        std::move(owned_tree_));
+    system_ =
+        std::make_unique<MultibodyTreeSystem<double>>(std::move(owned_tree_));
     context_ = system_->CreateDefaultContext();
 
     const Mobilizer<double>& mobilizer = joint_ref.GetMobilizerInUse();
     const auto* typed_mobilizer =
-      dynamic_cast<const MobilizerType<double>*>(&mobilizer);
+        dynamic_cast<const MobilizerType<double>*>(&mobilizer);
     DRAKE_DEMAND(typed_mobilizer != nullptr);
     return *typed_mobilizer;
   }
@@ -70,8 +70,8 @@ class MobilizerTester : public ::testing::Test {
 
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
-    system_ = std::make_unique<MultibodyTreeSystem<double>>(
-        std::move(owned_tree_));
+    system_ =
+        std::make_unique<MultibodyTreeSystem<double>>(std::move(owned_tree_));
     context_ = system_->CreateDefaultContext();
 
     return mobilizer_ref;

--- a/multibody/tree/test/model_instance_test.cc
+++ b/multibody/tree/test/model_instance_test.cc
@@ -35,23 +35,20 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
       tree.AddRigidBody("Body3", instance1, SpatialInertia<double>::NaN());
 
   const auto& weld1 = tree.AddJoint<WeldJoint>(
-      "weld1", tree.world_body(), math::RigidTransformd::Identity(),
-      body1, math::RigidTransformd::Identity(),
-      math::RigidTransformd::Identity());
+      "weld1", tree.world_body(), math::RigidTransformd::Identity(), body1,
+      math::RigidTransformd::Identity(), math::RigidTransformd::Identity());
   EXPECT_EQ(weld1.frame_on_parent().model_instance(), instance1);
   EXPECT_EQ(weld1.frame_on_child().model_instance(), instance1);
   // Test minimal `AddJoint` overload.
   const Joint<double>& body1_body2 =
-      tree.AddJoint(
-          std::make_unique<PrismaticJoint<double>>(
-              "prism1", body1.body_frame(), body2.body_frame(),
-              Eigen::Vector3d(0, 0, 1)));
+      tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
+          "prism1", body1.body_frame(), body2.body_frame(),
+          Eigen::Vector3d(0, 0, 1)));
   tree.AddJointActuator("act1", body1_body2);
 
-  const Joint<double>& body2_body3 =
-      tree.AddJoint<PrismaticJoint>(
-          "prism2", body2, math::RigidTransformd::Identity(),
-          body3, math::RigidTransformd::Identity(), Eigen::Vector3d(0, 0, 1));
+  const Joint<double>& body2_body3 = tree.AddJoint<PrismaticJoint>(
+      "prism2", body2, math::RigidTransformd::Identity(), body3,
+      math::RigidTransformd::Identity(), Eigen::Vector3d(0, 0, 1));
   tree.AddJointActuator("act2", body2_body3);
 
   const ModelInstanceIndex instance2 = tree.AddModelInstance("instance2");
@@ -61,10 +58,9 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
   const RigidBody<double>& body5 =
       tree.AddRigidBody("Body5", instance2, SpatialInertia<double>::NaN());
 
-  const Joint<double>& body4_body5 =
-      tree.AddJoint<PrismaticJoint>(
-          "prism3", body4, math::RigidTransformd::Identity(),
-          body5, math::RigidTransformd::Identity(), Eigen::Vector3d(0, 0, 1));
+  const Joint<double>& body4_body5 = tree.AddJoint<PrismaticJoint>(
+      "prism3", body4, math::RigidTransformd::Identity(), body5,
+      math::RigidTransformd::Identity(), Eigen::Vector3d(0, 0, 1));
   tree.AddJointActuator("act3", body4_body5);
 
   tree.Finalize();
@@ -134,8 +130,8 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
 
   // Create a MultibodyTreeSystem so that we can get a context.
   internal::MultibodyTreeSystem<double> mb_system(std::move(tree_pointer));
-  std::unique_ptr<systems::Context<double>> context = mb_system.
-      CreateDefaultContext();
+  std::unique_ptr<systems::Context<double>> context =
+      mb_system.CreateDefaultContext();
 
   // Clear the entire multibody state vector so that we can check the effect
   // of setting one instance at a time.
@@ -145,14 +141,14 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
   // Validate setting the position and velocity through the multibody state
   // vector for an instance.
   Eigen::VectorXd instance1_x(tree.num_positions(instance1) +
-      tree.num_velocities(instance1));
+                              tree.num_velocities(instance1));
   instance1_x << instance1_pos, instance1_vel;
   tree.SetPositionsAndVelocities(instance1, instance1_x, context.get());
   EXPECT_EQ(tree.GetPositionsAndVelocities(*context, instance2).norm(), 0);
-  const Eigen::VectorXd instance1_pos_from_array = tree.GetPositionsFromArray(
-      instance1, pos_vector);
-  const Eigen::VectorXd instance1_vel_from_array = tree.GetVelocitiesFromArray(
-      instance1, vel_vector);
+  const Eigen::VectorXd instance1_pos_from_array =
+      tree.GetPositionsFromArray(instance1, pos_vector);
+  const Eigen::VectorXd instance1_vel_from_array =
+      tree.GetVelocitiesFromArray(instance1, vel_vector);
   EXPECT_TRUE(CompareMatrices(instance1_pos, instance1_pos_from_array));
   EXPECT_TRUE(CompareMatrices(instance1_vel, instance1_vel_from_array));
 
@@ -187,15 +183,13 @@ GTEST_TEST(ModelInstance, ModelInstanceRenameTest) {
   tree.RenameModelInstance(model0, "after");  // to same name is not an error.
 
   const ModelInstanceIndex model1 = tree.AddModelInstance("another");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      tree.RenameModelInstance(model1, "after"),
-      ".*names must be unique.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(tree.RenameModelInstance(model1, "after"),
+                              ".*names must be unique.*");
 
   tree.Finalize();
 
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      tree.RenameModelInstance(model0, "too_late"),
-      ".*is finalized already.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(tree.RenameModelInstance(model0, "too_late"),
+                              ".*is finalized already.*");
 }
 
 }  // namespace

--- a/multibody/tree/test/multibody_forces_test.cc
+++ b/multibody/tree/test/multibody_forces_test.cc
@@ -37,6 +37,7 @@ class MultibodyForcesTests : public ::testing::Test {
                                    std::nullopt, Vector3d::UnitZ());
     model_.Finalize();
   }
+
  protected:
   internal::MultibodyTree<double> model_;
 };
@@ -48,7 +49,7 @@ TEST_F(MultibodyForcesTests, Construction) {
   // forces would not be zero if the constructor had not explicitly zeroed them.
   std::array<char, sizeof(MultibodyForces<double>)> mem;  // memory buffer.
   mem.fill(1);  // fill in with garbage.
-  auto forces = new(&mem) MultibodyForces<double>(model_);  // placement new.
+  auto forces = new (&mem) MultibodyForces<double>(model_);  // placement new.
   ASSERT_NE(forces, nullptr);
 
   // Forces object should be compatible with the original model.
@@ -99,18 +100,18 @@ TEST_F(MultibodyForcesTests, NonZeroForces) {
 
   // Check the results:
   EXPECT_EQ(generalized_forces, Vector2d(4, 6));
-  EXPECT_TRUE(CompareMatrices(
-      spatial_forces[0].get_coeffs(),
-      (Vector6<double>() << 6, 7, 8, 9, 10, 11).finished(),
-      kEpsilon, MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(
-      spatial_forces[1].get_coeffs(),
-      (Vector6<double>() << 0, 1, 2, 3, 4, 5).finished(),
-      kEpsilon, MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(
-      spatial_forces[2].get_coeffs(),
-      (Vector6<double>() << 6, 8, 10, 12, 14, 16).finished(),
-      kEpsilon, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(spatial_forces[0].get_coeffs(),
+                      (Vector6<double>() << 6, 7, 8, 9, 10, 11).finished(),
+                      kEpsilon, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(spatial_forces[1].get_coeffs(),
+                      (Vector6<double>() << 0, 1, 2, 3, 4, 5).finished(),
+                      kEpsilon, MatrixCompareType::absolute));
+  EXPECT_TRUE(
+      CompareMatrices(spatial_forces[2].get_coeffs(),
+                      (Vector6<double>() << 6, 8, 10, 12, 14, 16).finished(),
+                      kEpsilon, MatrixCompareType::absolute));
 
   // Set to zero and assess the result:
   forces1.SetZero();

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -81,8 +81,7 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
   const auto M_Bo_B = SpatialInertia<double>::NaN();
 
   // Adds a new body to the world.
-  const RigidBody<double>& pendulum =
-      model->AddRigidBody("pendulum", M_Bo_B);
+  const RigidBody<double>& pendulum = model->AddRigidBody("pendulum", M_Bo_B);
   EXPECT_EQ(pendulum.scoped_name().get_full(),
             "DefaultModelInstance::pendulum");
   EXPECT_EQ(pendulum.body_frame().scoped_name().get_full(),
@@ -104,13 +103,12 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
 
   // Verify we cannot add a joint between a body and itself.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      (model->AddJoint<RevoluteJoint>("joint1", pendulum, {}, pendulum,
-                                               {}, Vector3d::UnitZ())),
+      (model->AddJoint<RevoluteJoint>("joint1", pendulum, {}, pendulum, {},
+                                      Vector3d::UnitZ())),
       "AddJoint.*joint1 would connect body pendulum to itself.*");
 
   // Adds a second pendulum.
-  const RigidBody<double>& pendulum2 =
-      model->AddRigidBody("pendulum2", M_Bo_B);
+  const RigidBody<double>& pendulum2 = model->AddRigidBody("pendulum2", M_Bo_B);
   model->AddJoint<RevoluteJoint>("joint1", world_body, {}, pendulum2, {},
                                  Vector3d::UnitZ());
 
@@ -147,12 +145,10 @@ GTEST_TEST(MultibodyTree, TopologicalLoopDisallowed) {
   auto model = std::make_unique<MultibodyTree<double>>();
   const RigidBody<double>& world_body = model->world_body();
   const auto M_Bo_B = SpatialInertia<double>::NaN();
-  const RigidBody<double>& pendulum =
-      model->AddRigidBody("pendulum", M_Bo_B);
-  model->AddJoint<RevoluteJoint>(
-      "joint0", world_body, {}, pendulum, {}, Vector3d::UnitZ());
-  const RigidBody<double>& pendulum2 =
-      model->AddRigidBody("pendulum2", M_Bo_B);
+  const RigidBody<double>& pendulum = model->AddRigidBody("pendulum", M_Bo_B);
+  model->AddJoint<RevoluteJoint>("joint0", world_body, {}, pendulum, {},
+                                 Vector3d::UnitZ());
+  const RigidBody<double>& pendulum2 = model->AddRigidBody("pendulum2", M_Bo_B);
   model->AddJoint<RevoluteJoint>("joint1", world_body, {}, pendulum2, {},
                                  Vector3d::UnitZ());
 
@@ -160,8 +156,8 @@ GTEST_TEST(MultibodyTree, TopologicalLoopDisallowed) {
   EXPECT_EQ(model->num_joints(), 2);
 
   // Attempts to create a loop. Verify we gen an exception at Finalize().
-  model->AddJoint<RevoluteJoint>(
-      "joint2", pendulum, {}, pendulum2, {}, Vector3d::UnitZ());
+  model->AddJoint<RevoluteJoint>("joint2", pendulum, {}, pendulum2, {},
+                                 Vector3d::UnitZ());
 
   EXPECT_EQ(model->num_bodies(), 3);
   EXPECT_EQ(model->num_joints(), 3);
@@ -190,16 +186,14 @@ GTEST_TEST(MultibodyTree, MultibodyElementChecks) {
   const RigidBody<double>& body2 = model2->AddRigidBody("body2", M_Bo_B);
 
   // Verify we can add a joint between body1 and the world of model1.
-  const RevoluteJoint<double>& pin1 =
-      model1->AddJoint<RevoluteJoint>("pin1",
-          model1->world_body(), std::nullopt /*inboard frame*/,
-          body1, std::nullopt /*outboard frame*/,
-          Vector3d::UnitZ() /*axis of rotation*/);
+  const RevoluteJoint<double>& pin1 = model1->AddJoint<RevoluteJoint>(
+      "pin1", model1->world_body(), std::nullopt /*inboard frame*/, body1,
+      std::nullopt /*outboard frame*/, Vector3d::UnitZ() /*axis of rotation*/);
 
   // Verify we can't add a joint between bodies that belong to another plant.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      (model1->AddJoint<RevoluteJoint>("nogood",
-          model1->world_body(), std::nullopt,
+      (model1->AddJoint<RevoluteJoint>(
+          "nogood", model1->world_body(), std::nullopt,
           body2 /*body2 belongs to model2, not model1!!!*/, std::nullopt,
           Vector3d::UnitZ() /*axis of rotation*/)),
       "AddJoint.*can't add joint nogood.*world.*body2.*different.*Plant.*");
@@ -283,8 +277,7 @@ class TreeTopologyTests : public ::testing::Test {
 
     const int kNumRigidBodies = 10;
     bodies_.push_back(&model_->world_body());
-    for (int i = 1; i < kNumRigidBodies; ++i)
-      AddTestBody(i);
+    for (int i = 1; i < kNumRigidBodies; ++i) AddTestBody(i);
 
     // Adds Joints to connect bodies according to the following diagram:
     ConnectBodies(*bodies_[1], *bodies_[6]);  // joint 0
@@ -302,14 +295,14 @@ class TreeTopologyTests : public ::testing::Test {
     // NaN SpatialInertia to instantiate the RigidBody objects.
     // It is safe here since this tests only focus on topological information.
     const auto M_Bo_B = SpatialInertia<double>::NaN();
-    const RigidBody<double>* body = &model_->AddRigidBody(
-       fmt::format("TestBody_{}", i), M_Bo_B);
+    const RigidBody<double>* body =
+        &model_->AddRigidBody(fmt::format("TestBody_{}", i), M_Bo_B);
     bodies_.push_back(body);
     return body;
   }
 
-  void ConnectBodies(
-      const RigidBody<double>& inboard, const RigidBody<double>& outboard) {
+  void ConnectBodies(const RigidBody<double>& inboard,
+                     const RigidBody<double>& outboard) {
     // Just for fun, here we explicitly state that the frame on body
     // "inboard" (frame P) IS the joint frame F, done by passing the empty
     // curly braces {}.
@@ -332,9 +325,7 @@ class TreeTopologyTests : public ::testing::Test {
     joints_.push_back(joint);
   }
 
-  void FinalizeModel() {
-    model_->Finalize();
-  }
+  void FinalizeModel() { model_->Finalize(); }
 
   // Performs a number of tests on the BodyNodeTopology corresponding to the
   // body indexed by `body`.
@@ -378,8 +369,8 @@ class TreeTopologyTests : public ::testing::Test {
       // "parent_node".
       auto is_child_of_parent = [&]() {
         const auto& children = topology.get_body_node(parent_node).child_nodes;
-        return
-            std::find(children.begin(), children.end(), node) != children.end();
+        return std::find(children.begin(), children.end(), node) !=
+               children.end();
       };
       EXPECT_TRUE(is_child_of_parent());
     }
@@ -693,8 +684,7 @@ TEST_F(TreeTopologyTests, GetTransitiveOutboardBodies) {
   const std::vector<BodyIndex> body4{body4_index};
   std::set<BodyIndex> expected_outboard_bodies{body1_index, body2_index,
                                                body4_index, body6_index};
-  EXPECT_EQ(model_->GetBodiesOutboardOfBodies(body4),
-            expected_outboard_bodies);
+  EXPECT_EQ(model_->GetBodiesOutboardOfBodies(body4), expected_outboard_bodies);
 
   const std::vector<BodyIndex> body14{body1_index, body4_index};
   EXPECT_EQ(model_->GetBodiesOutboardOfBodies(body14),
@@ -709,8 +699,7 @@ TEST_F(TreeTopologyTests, GetTransitiveOutboardBodies) {
   const std::vector<BodyIndex> body6{body6_index};
   expected_outboard_bodies.clear();
   expected_outboard_bodies.insert(body6_index);
-  EXPECT_EQ(model_->GetBodiesOutboardOfBodies(body6),
-            expected_outboard_bodies);
+  EXPECT_EQ(model_->GetBodiesOutboardOfBodies(body6), expected_outboard_bodies);
 }
 
 // Unit test to verify that LinkJointGraph::GetSubgraphsOfWeldedLinks()
@@ -853,21 +842,20 @@ GTEST_TEST(WeldedBodies, CreateSubgraphsOfWeldedLinks) {
   // In order to compare the computed list of welded bodies against the expected
   // list, irrespective of the ordering in the computed list, we first convert
   // the computed list to a set.
-  std::set<std::set<BodyIndex>> welded_bodies_set(
-      welded_bodies.begin(), welded_bodies.end());
+  std::set<std::set<BodyIndex>> welded_bodies_set(welded_bodies.begin(),
+                                                  welded_bodies.end());
 
   // Verify the computed list has the expected entries.
   EXPECT_EQ(welded_bodies_set, expected_welded_bodies);
 
   // All bodies in welded_bodies[0] are, by definition, anchored to the world.
   // Verify this by checking the LinkJointGraph (after building the Forest).
-  for (size_t welded_body_index = 0;
-       welded_body_index < welded_bodies.size(); ++welded_body_index) {
+  for (size_t welded_body_index = 0; welded_body_index < welded_bodies.size();
+       ++welded_body_index) {
     const std::set<BodyIndex>& welded_body = welded_bodies[welded_body_index];
     for (BodyIndex body_index : welded_body) {
-        EXPECT_EQ(
-            graph.link_by_index(body_index).is_anchored(),
-            welded_body_index == 0 /* 'true' for anchored bodies. */);
+      EXPECT_EQ(graph.link_by_index(body_index).is_anchored(),
+                welded_body_index == 0 /* 'true' for anchored bodies. */);
     }
   }
 }
@@ -882,11 +870,11 @@ GTEST_TEST(WeldedBodies, CreateSubgraphsOfWeldedLinks) {
 // cube whose outward normal is -Bx. Hence, the position vector from Bo to Bcm
 // (B's center of mass) is p_BoBcm_B = Lx/2 Bx.
 UnitInertia<double> MakeTestCubeUnitInertia(const double length = 1.0) {
-    const UnitInertia<double> G_BBcm_B = UnitInertia<double>::SolidCube(length);
-    const Vector3<double> p_BoBcm_B(length / 2, 0, 0);
-    const UnitInertia<double> G_BBo_B =
-        G_BBcm_B.ShiftFromCenterOfMass(-p_BoBcm_B);
-    return G_BBo_B;
+  const UnitInertia<double> G_BBcm_B = UnitInertia<double>::SolidCube(length);
+  const Vector3<double> p_BoBcm_B(length / 2, 0, 0);
+  const UnitInertia<double> G_BBo_B =
+      G_BBcm_B.ShiftFromCenterOfMass(-p_BoBcm_B);
+  return G_BBo_B;
 }
 
 // Helper function to create a cube-shaped rigid body B and add it to a model.
@@ -899,10 +887,8 @@ UnitInertia<double> MakeTestCubeUnitInertia(const double length = 1.0) {
 //  mass or link_length is NaN). Avoiding this early exception allows for a
 //  later exception to be thrown in a subsequent function and tested below.
 const RigidBody<double>& AddCubicalLink(
-    MultibodyTree<double>* model,
-    const std::string& body_name,
-    const double mass,
-    const double link_length = 1.0,
+    MultibodyTree<double>* model, const std::string& body_name,
+    const double mass, const double link_length = 1.0,
     const bool skip_validity_check = false) {
   DRAKE_DEMAND(model != nullptr);
   const Vector3<double> p_BoBcm_B(link_length / 2, 0, 0);
@@ -918,7 +904,7 @@ GTEST_TEST(DefaultInertia, VerifyDefaultRotationalInertia) {
   // Create a model and add three rigid bodies, namely A, B, C.
   MultibodyTree<double> model;
   const double mA = 0, mB = 1, mC = 3;  // Mass of links A, B, C.
-  const double length = 3;         // Length of each thin uniform-density link.
+  const double length = 3;  // Length of each thin uniform-density link.
   const RigidBody<double>& body_A = AddCubicalLink(&model, "bodyA", mA, length);
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
   const RigidBody<double>& body_C = AddCubicalLink(&model, "bodyC", mC, length);
@@ -1018,7 +1004,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithZeroMass) {
       "Body bodyA is the active body for a terminal composite body that "
       "is massless, but its joint has a translational degree of freedom.";
   DRAKE_EXPECT_THROWS_MESSAGE(model.ThrowDefaultMassInertiaError(),
-      expected_message);
+                              expected_message);
 }
 
 // Verify MultibodyTree::ThrowDefaultMassInertiaError() throws an exception
@@ -1046,7 +1032,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithZeroInertia) {
       "has zero rotational inertia, but its joint has a rotational degree "
       "of freedom.";
   DRAKE_EXPECT_THROWS_MESSAGE(model.ThrowDefaultMassInertiaError(),
-      expected_message);
+                              expected_message);
 }
 
 // Verify MultibodyTree::ThrowDefaultMassInertiaError() throws an exception
@@ -1077,7 +1063,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithNaNInertia) {
       "has a NaN rotational inertia, but its joint has a rotational degree "
       "of freedom.";
   DRAKE_EXPECT_THROWS_MESSAGE(model.ThrowDefaultMassInertiaError(),
-      expected_message);
+                              expected_message);
 }
 
 // Verify MultibodyTree::ThrowDefaultMassInertiaError() does not throw an
@@ -1143,11 +1129,11 @@ GTEST_TEST(TestDistalBody, NoThrowErrorIfZeroMassBodyIsNotDistal) {
 
   // Add bodyA to bodyB Y-prismatic joint (bodyB has zero mass and inertia).
   model.AddJoint<PrismaticJoint>("AB_prismatic_jointY", body_A, {}, body_B, {},
-        Vector3<double>::UnitY());
+                                 Vector3<double>::UnitY());
 
   // Add bodyB to bodyC Z-prismatic joint (bodyC has zero mass and inertia).
   model.AddJoint<PrismaticJoint>("BC_prismatic_jointZ", body_B, {}, body_C, {},
-        Vector3<double>::UnitZ());
+                                 Vector3<double>::UnitZ());
 
   // Add bodyC to bodyD Z-revolute joint (bodyD has non-zero mass and inertia).
   AddRevoluteJointZ(&model, "CD_revolute_joint", body_C, body_D);

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -62,7 +62,7 @@ class PlanarJointTest : public ::testing::Test {
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
     system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
-        std::move(model), true/* is_discrete */);
+        std::move(model), true /* is_discrete */);
     context_ = system_->CreateDefaultContext();
   }
 

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -34,7 +34,7 @@ class PrismaticJointTest : public ::testing::Test {
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
     system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
-        std::move(model), true/* is_discrete */);
+        std::move(model), true /* is_discrete */);
     context_ = system_->CreateDefaultContext();
   }
 

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -49,9 +49,8 @@ TEST_F(PrismaticMobilizerTest, CanRotateOrTranslate) {
 
 // Verify that PrismaticMobilizer normalizes its axis on construction.
 TEST_F(PrismaticMobilizerTest, AxisIsNormalizedAtConstruction) {
-  EXPECT_TRUE(CompareMatrices(
-      slider_->translation_axis(), axis_F_.normalized(),
-      kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(slider_->translation_axis(), axis_F_.normalized(),
+                              kTolerance, MatrixCompareType::relative));
 }
 
 // Verifies method to mutate and access the context.
@@ -101,15 +100,15 @@ TEST_F(PrismaticMobilizerTest, CalcAcrossMobilizerTransform) {
   // introduce no rotations at all.
   EXPECT_EQ(X_FM.rotation().matrix(), Matrix3d::Identity());
   EXPECT_TRUE(CompareMatrices(X_FM.GetAsMatrix34(),
-                              X_FM_expected.GetAsMatrix34(),
-                              kTolerance, MatrixCompareType::relative));
+                              X_FM_expected.GetAsMatrix34(), kTolerance,
+                              MatrixCompareType::relative));
 }
 
 TEST_F(PrismaticMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
   const double translation_rate = 1.5;
   const SpatialVelocity<double> V_FM =
-      slider_->CalcAcrossMobilizerSpatialVelocity(
-          *context_, Vector1d(translation_rate));
+      slider_->CalcAcrossMobilizerSpatialVelocity(*context_,
+                                                  Vector1d(translation_rate));
 
   const SpatialVelocity<double> V_FM_expected(
       Vector3d::Zero(), axis_F_.normalized() * translation_rate);
@@ -163,8 +162,9 @@ TEST_F(PrismaticMobilizerTest, MapVelocityToQDotAndBack) {
 TEST_F(PrismaticMobilizerTest, KinematicMapping) {
   // For this joint, Nplus = 1 independently of the state. We therefore set the
   // state to NaN in order to verify this.
-  tree().GetMutablePositionsAndVelocities(context_.get()).
-      setConstant(std::numeric_limits<double>::quiet_NaN());
+  tree()
+      .GetMutablePositionsAndVelocities(context_.get())
+      .setConstant(std::numeric_limits<double>::quiet_NaN());
 
   // Compute N.
   MatrixX<double> N(1, 1);

--- a/multibody/tree/test/prismatic_spring_test.cc
+++ b/multibody/tree/test/prismatic_spring_test.cc
@@ -7,11 +7,9 @@
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
-#include "drake/multibody/tree/position_kinematics_cache.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/spatial_inertia.h"
-#include "drake/multibody/tree/velocity_kinematics_cache.h"
 #include "drake/multibody/tree/weld_joint.h"
 #include "drake/systems/framework/context.h"
 
@@ -39,15 +37,13 @@ class SpringTester : public ::testing::Test {
                                math::RigidTransform<double>::Identity());
 
     // Allow body B to translate along the z axis.
-    joint_ = &model->AddJoint<PrismaticJoint>("joint_AB", *bodyA_,
-                                              std::nullopt, *bodyB_,
-                                              std::nullopt,
+    joint_ = &model->AddJoint<PrismaticJoint>("joint_AB", *bodyA_, std::nullopt,
+                                              *bodyB_, std::nullopt,
                                               Vector3<double>::UnitZ());
 
     // Add spring
-    spring_ = &model->AddForceElement<PrismaticSpring>(*joint_,
-                                                      nominal_position_,
-                                                      stiffness_);
+    spring_ = &model->AddForceElement<PrismaticSpring>(
+        *joint_, nominal_position_, stiffness_);
 
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
@@ -102,7 +98,7 @@ TEST_F(SpringTester, NominalPosition) {
   CalcSpringForces();
   const VectorX<double>& generalized_forces = forces_->generalized_forces();
   EXPECT_TRUE(CompareMatrices(generalized_forces, VectorX<double>::Zero(1),
-      kTolerance, MatrixCompareType::relative));
+                              kTolerance, MatrixCompareType::relative));
 
   // Verify the potential energy is zero.
   const double potential_energy = spring_->CalcPotentialEnergy(
@@ -125,9 +121,9 @@ TEST_F(SpringTester, DeltaPosition) {
                               kTolerance, MatrixCompareType::relative));
 
   // Verify the value of the potential energy.
-  const double potential_energy_expected =
-      0.5 * stiffness_ * (position - nominal_position_) *
-      (position - nominal_position_);
+  const double potential_energy_expected = 0.5 * stiffness_ *
+                                           (position - nominal_position_) *
+                                           (position - nominal_position_);
   const double potential_energy = spring_->CalcPotentialEnergy(
       *context_, tree().EvalPositionKinematics(*context_));
   EXPECT_NEAR(potential_energy, potential_energy_expected, kTolerance);

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -349,8 +349,7 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
   std::uniform_real_distribution<symbolic::Expression> uniform;
 
   // Default behavior is to set to zero.
-  tree().SetRandomState(*context_, &context_->get_mutable_state(),
-                           &generator);
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
   EXPECT_TRUE(joint_->GetPose(*context_).IsExactlyIdentity());
 
   // Set the position distribution to arbitrary values.
@@ -362,8 +361,7 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
   mutable_joint_->set_random_quaternion_distribution(
       math::UniformlyRandomQuaternion<symbolic::Expression>(&generator));
   mutable_joint_->set_random_translation_distribution(position_distribution);
-  tree().SetRandomState(*context_, &context_->get_mutable_state(),
-                           &generator);
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
   // We expect arbitrary non-zero values for the random state.
   EXPECT_FALSE(joint_->GetPose(*context_).IsExactlyIdentity());
 
@@ -372,15 +370,13 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
       Eigen::Quaternion<symbolic::Expression>::Identity());
   mutable_joint_->set_random_translation_distribution(
       Eigen::Matrix<symbolic::Expression, 3, 1>::Zero());
-  tree().SetRandomState(*context_, &context_->get_mutable_state(),
-                           &generator);
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
   // We expect zero values for pose.
   EXPECT_TRUE(joint_->GetPose(*context_).IsExactlyIdentity());
 
   // Set the quaternion distribution using built in uniform sampling.
   mutable_joint_->set_random_quaternion_distribution_to_uniform();
-  tree().SetRandomState(*context_, &context_->get_mutable_state(),
-                           &generator);
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
   // We expect arbitrary non-zero pose.
   EXPECT_FALSE(joint_->GetPose(*context_).IsExactlyIdentity());
 }

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -6,7 +6,6 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/random_rotation.h"
-#include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/quaternion_floating_joint.h"
@@ -63,8 +62,8 @@ TEST_F(QuaternionFloatingMobilizerTest, StateAccess) {
   const Quaterniond Q_WB = R_WB.ToQuaternion();
   mobilizer_->SetOrientation(context_.get(), R_WB);
   EXPECT_TRUE(CompareMatrices(mobilizer_->get_quaternion(*context_).coeffs(),
-                              Q_WB.coeffs(),
-                              kTolerance, MatrixCompareType::relative));
+                              Q_WB.coeffs(), kTolerance,
+                              MatrixCompareType::relative));
 }
 
 TEST_F(QuaternionFloatingMobilizerTest, ZeroState) {
@@ -135,7 +134,6 @@ TEST_F(QuaternionFloatingMobilizerTest, RandomState) {
   EXPECT_FALSE(mobilizer_->get_translational_velocity(*context_).isZero());
 }
 
-
 // For an arbitrary state verify that the computed Nplus(q) matrix is the
 // left pseudoinverse of N(q).
 TEST_F(QuaternionFloatingMobilizerTest, KinematicMapping) {
@@ -160,9 +158,8 @@ TEST_F(QuaternionFloatingMobilizerTest, KinematicMapping) {
   // Verify that Nplus is the left pseudoinverse of N.
   MatrixX<double> Nplus_x_N = Nplus * N;
 
-  EXPECT_TRUE(CompareMatrices(
-      Nplus_x_N, MatrixX<double>::Identity(6, 6),
-      kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(Nplus_x_N, MatrixX<double>::Identity(6, 6),
+                              kTolerance, MatrixCompareType::relative));
 }
 
 TEST_F(QuaternionFloatingMobilizerTest, CheckExceptionMessage) {
@@ -200,8 +197,8 @@ TEST_F(QuaternionFloatingMobilizerTest, MapUsesN) {
   mobilizer_->CalcNMatrix(*context_, &N);
 
   // Ensure N(q) is used in `q̇ = N(q)⋅v`
-  EXPECT_TRUE(CompareMatrices(qdot, N * v, kTolerance,
-                              MatrixCompareType::relative));
+  EXPECT_TRUE(
+      CompareMatrices(qdot, N * v, kTolerance, MatrixCompareType::relative));
 }
 
 TEST_F(QuaternionFloatingMobilizerTest, MapUsesNplus) {

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -172,7 +172,6 @@ TEST_F(RevoluteJointTest, AddInTorques) {
   joint1_->AddInTorque(*context_, some_value, &forces1);
   joint1_->AddInTorque(*context_, some_value, &forces1);
 
-
   MultibodyForces<double> forces2(tree());
   // Add value only once:
   joint1_->AddInTorque(*context_, some_value, &forces2);

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -48,9 +48,8 @@ TEST_F(RevoluteMobilizerTest, CanRotateOrTranslate) {
 
 // Verify that RevoluteMobilizer normalizes its axis on construction.
 TEST_F(RevoluteMobilizerTest, AxisIsNormalizedAtConstruction) {
-  EXPECT_TRUE(CompareMatrices(
-      mobilizer_->revolute_axis(), axis_F_.normalized(),
-      kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(mobilizer_->revolute_axis(), axis_F_.normalized(),
+                              kTolerance, MatrixCompareType::relative));
 }
 
 // Verifies method to mutate and access the context.
@@ -150,15 +149,15 @@ TEST_F(RevoluteMobilizerTest, CalcAcrossMobilizerTransform) {
   // introduce no translations at all.
   EXPECT_EQ(X_FM.translation(), Vector3d::Zero());
   EXPECT_TRUE(CompareMatrices(X_FM.GetAsMatrix34(),
-                              X_FM_expected.GetAsMatrix34(),
-                              kTolerance, MatrixCompareType::relative));
+                              X_FM_expected.GetAsMatrix34(), kTolerance,
+                              MatrixCompareType::relative));
 }
 
 TEST_F(RevoluteMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
   const double angular_rate = 1.5;
   const SpatialVelocity<double> V_FM =
-      mobilizer_->CalcAcrossMobilizerSpatialVelocity(
-          *context_, Vector1d(angular_rate));
+      mobilizer_->CalcAcrossMobilizerSpatialVelocity(*context_,
+                                                     Vector1d(angular_rate));
 
   const SpatialVelocity<double> V_FM_expected(
       axis_F_.normalized() * angular_rate, Vector3d::Zero());
@@ -212,8 +211,9 @@ TEST_F(RevoluteMobilizerTest, MapVelocityToQDotAndBack) {
 TEST_F(RevoluteMobilizerTest, KinematicMapping) {
   // For this joint, Nplus = 1 independently of the state. We therefore set the
   // state to NaN in order to verify this.
-  tree().GetMutablePositionsAndVelocities(context_.get()).
-      setConstant(std::numeric_limits<double>::quiet_NaN());
+  tree()
+      .GetMutablePositionsAndVelocities(context_.get())
+      .setConstant(std::numeric_limits<double>::quiet_NaN());
 
   // Compute N.
   MatrixX<double> N(1, 1);

--- a/multibody/tree/test/revolute_spring_test.cc
+++ b/multibody/tree/test/revolute_spring_test.cc
@@ -39,10 +39,9 @@ class SpringTester : public ::testing::Test {
                                math::RigidTransform<double>::Identity());
 
     // Allow body B to rotate about the z axis.
-    joint_ =
-        &model->AddJoint<RevoluteJoint>("joint_AB", *bodyA_, std::nullopt,
-                                        *bodyB_, std::nullopt,
-                                        Vector3<double>::UnitZ());
+    joint_ = &model->AddJoint<RevoluteJoint>("joint_AB", *bodyA_, std::nullopt,
+                                             *bodyB_, std::nullopt,
+                                             Vector3<double>::UnitZ());
 
     model->AddJoint<RevoluteJoint>("joint_BC", *bodyB_, std::nullopt, *bodyC_,
                                    std::nullopt, Vector3<double>::UnitX());

--- a/multibody/tree/test/rigid_body_test.cc
+++ b/multibody/tree/test/rigid_body_test.cc
@@ -46,7 +46,7 @@ GTEST_TEST(RigidBody, RigidBodyConstructor2) {
   // Test that RigidBody class properly calculates rotational inertia.
   const RotationalInertia<double> I_BBo_B_expected = mass * G_BBo_B;
   const RotationalInertia<double> I_BBo_B = B.default_rotational_inertia();
-  EXPECT_TRUE(I_BBo_B.IsNearlyEqualTo(I_BBo_B_expected, 4.0*kEpsilon));
+  EXPECT_TRUE(I_BBo_B.IsNearlyEqualTo(I_BBo_B_expected, 4.0 * kEpsilon));
 }
 
 // Test rigid body 1-argument constructor.
@@ -94,7 +94,7 @@ TEST_F(RigidBodyTest, SetCenterOfMassInBodyFrame) {
   double mass = 3;     // mass of body B in kilograms.
   const double L = 2;  // x-measure of Bcm's position from Bo in meters.
   Vector3d p_BoBcm_B(L, 0, 0);  // Position from Bo to Bcm, expressed in B.
-  const UnitInertia<double> G_BBo_B(0, L*L, L*L);
+  const UnitInertia<double> G_BBo_B(0, L * L, L * L);
   SpatialInertia<double> M_BBo_B(mass, p_BoBcm_B, G_BBo_B);
   systems::Context<double>* context_ptr = context_.get();
   rigid_body_->SetSpatialInertiaInBodyFrame(context_ptr, M_BBo_B);
@@ -104,13 +104,14 @@ TEST_F(RigidBodyTest, SetCenterOfMassInBodyFrame) {
   const SpatialInertia<double> M_BBo_B_test =
       rigid_body_->CalcSpatialInertiaInBodyFrame(*context_);
   EXPECT_TRUE(CompareMatrices(M_BBo_B_test.CopyToFullMatrix6(),
-      M_BBo_B.CopyToFullMatrix6(), kTolerance));
+                              M_BBo_B.CopyToFullMatrix6(), kTolerance));
 
   // Verify rotational inertia is of a single particle at B's center of mass.
   RotationalInertia<double> I_BBo_B_expected(mass, p_BoBcm_B);
   RotationalInertia<double> I_BBo_B = M_BBo_B.CalcRotationalInertia();
   EXPECT_TRUE(CompareMatrices(I_BBo_B.CopyToFullMatrix3(),
-      I_BBo_B_expected.CopyToFullMatrix3(), kTolerance));
+                              I_BBo_B_expected.CopyToFullMatrix3(),
+                              kTolerance));
 
   // Verify B's unit inertia about Bcm is zero.
   SpatialInertia<double> M_BBcm_B = M_BBo_B.Shift(p_BoBcm_B);
@@ -126,40 +127,44 @@ TEST_F(RigidBodyTest, SetCenterOfMassInBodyFrame) {
   M_BBo_B = rigid_body_->CalcSpatialInertiaInBodyFrame(*context_);
   SpatialInertia<double> M_BBo_B_expected(mass, p_BoBcm_B, G_BBo_B);
   EXPECT_TRUE(CompareMatrices(M_BBo_B.CopyToFullMatrix6(),
-      M_BBo_B_expected.CopyToFullMatrix6(), kTolerance));
+                              M_BBo_B_expected.CopyToFullMatrix6(),
+                              kTolerance));
   M_BBcm_B = M_BBo_B.Shift(p_BoBcm_B);
   G_BBcm_B = M_BBcm_B.get_unit_inertia();
   EXPECT_TRUE(G_BBcm_B.IsNearlyEqualTo(G_BBcm_B_expected, kTolerance));
 
   // Change p_BoBcm_B and ensure it propagates albeit in a weird way, with
   // unchanged mass, changed p_Bo_Bcm_B, unchanged G_BBo_B, changed G_BBcm_B.
-  p_BoBcm_B = Vector3d(L/2, 0, 0);  // Now p_BoBcm_B = (1, 0, 0).
+  p_BoBcm_B = Vector3d(L / 2, 0, 0);  // Now p_BoBcm_B = (1, 0, 0).
   rigid_body_->SetCenterOfMassInBodyFrame(context_ptr, p_BoBcm_B);
   const Vector3d p_BoBcm_B_calculated =
       rigid_body_->CalcCenterOfMassInBodyFrame(*context_);
-  EXPECT_EQ(p_BoBcm_B_calculated, p_BoBcm_B);      // Position vector changes.
+  EXPECT_EQ(p_BoBcm_B_calculated, p_BoBcm_B);  // Position vector changes.
   EXPECT_EQ(rigid_body_->get_mass(*context_), mass);  // Mass is unchanged.
   M_BBo_B = rigid_body_->CalcSpatialInertiaInBodyFrame(*context_);
   const UnitInertia<double> G_BBo_B_test = M_BBo_B.get_unit_inertia();
   EXPECT_TRUE(CompareMatrices(G_BBo_B_test.CopyToFullMatrix3(),
-      G_BBo_B.CopyToFullMatrix3(), kTolerance));  // G_BBo_B is unchanged.
+                              G_BBo_B.CopyToFullMatrix3(),
+                              kTolerance));  // G_BBo_B is unchanged.
 
   // Ensure M_BBo_B has proper mass, proper p_BoBcm_B, and unchanged G_BBo_B.
   M_BBo_B_expected = SpatialInertia<double>(mass, p_BoBcm_B, G_BBo_B);
   EXPECT_TRUE(CompareMatrices(M_BBo_B.CopyToFullMatrix6(),
-      M_BBo_B_expected.CopyToFullMatrix6(), kTolerance));
+                              M_BBo_B_expected.CopyToFullMatrix6(),
+                              kTolerance));
 
   // Verify G_BBcm_B changes in a strange way if p_BBcm_B is changed!
   // G_BBcm_B is _not_ the unit inertia of a particle at B's center of mass.
   G_BBcm_B = G_BBo_B.ShiftToCenterOfMass(p_BoBcm_B);
   G_BBcm_B_expected = UnitInertia<double>(0, 3, 3);  // By-hand calculation.
   EXPECT_TRUE(CompareMatrices(G_BBcm_B.CopyToFullMatrix3(),
-    G_BBcm_B_expected.CopyToFullMatrix3(), kTolerance));
+                              G_BBcm_B_expected.CopyToFullMatrix3(),
+                              kTolerance));
 
   // Show that calling SetCenterOfMassInBodyFrame() can cause an exception to
   // be thrown due to non-physical mass/inertia properties.
 #ifdef DRAKE_ASSERT_IS_ARMED
-  p_BoBcm_B = Vector3d(3*L, 0, 0);  // Now p_BoBcm_B = (6, 0, 0).
+  p_BoBcm_B = Vector3d(3 * L, 0, 0);  // Now p_BoBcm_B = (6, 0, 0).
   rigid_body_->SetCenterOfMassInBodyFrame(context_ptr, p_BoBcm_B);
 
   // CalcSpatialInertiaInBodyFrame() does not check whether B's inertia
@@ -169,7 +174,8 @@ TEST_F(RigidBodyTest, SetCenterOfMassInBodyFrame) {
   const Vector3d com = M_BBo_B.get_com();
   const UnitInertia<double> G = M_BBo_B.get_unit_inertia();
   // Ensure M_BBcm_B is invalid via the spatial inertia constructor.
-  DRAKE_EXPECT_THROWS_MESSAGE(SpatialInertia<double>(m, com, G),
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>(m, com, G),
       "Spatial inertia fails SpatialInertia::IsPhysicallyValid[^]*");
 #endif
 }
@@ -180,7 +186,7 @@ TEST_F(RigidBodyTest, SetCenterOfMassInBodyFrameAndPreserveCentralInertia) {
   double mass = 3;     // mass of body B in kilograms.
   const double L = 2;  // x-measure of Bcm's position from Bo in meters.
   Vector3d p_BoBcm_B(L, 0, 0);  // Position from Bo to Bcm, expressed in B.
-  const UnitInertia<double> G_BBo_B(0, L*L, L*L);  // By-hand calculation.
+  const UnitInertia<double> G_BBo_B(0, L * L, L * L);  // By-hand calculation.
   SpatialInertia<double> M_BBo_B(mass, p_BoBcm_B, G_BBo_B);
   systems::Context<double>* context_ptr = context_.get();
   rigid_body_->SetSpatialInertiaInBodyFrame(context_ptr, M_BBo_B);
@@ -190,13 +196,14 @@ TEST_F(RigidBodyTest, SetCenterOfMassInBodyFrameAndPreserveCentralInertia) {
   const SpatialInertia<double> M_BBo_B_test =
       rigid_body_->CalcSpatialInertiaInBodyFrame(*context_);
   EXPECT_TRUE(CompareMatrices(M_BBo_B_test.CopyToFullMatrix6(),
-      M_BBo_B.CopyToFullMatrix6(), kTolerance));
+                              M_BBo_B.CopyToFullMatrix6(), kTolerance));
 
   // Verify rotational inertia is of a single particle at B's center of mass.
   RotationalInertia<double> I_BBo_B_expected(mass, p_BoBcm_B);
   RotationalInertia<double> I_BBo_B = M_BBo_B.CalcRotationalInertia();
   EXPECT_TRUE(CompareMatrices(I_BBo_B.CopyToFullMatrix3(),
-      I_BBo_B_expected.CopyToFullMatrix3(), kTolerance));
+                              I_BBo_B_expected.CopyToFullMatrix3(),
+                              kTolerance));
 
   // Verify B's unit inertia about Bcm is zero.
   SpatialInertia<double> M_BBcm_B = M_BBo_B.Shift(p_BoBcm_B);
@@ -212,16 +219,17 @@ TEST_F(RigidBodyTest, SetCenterOfMassInBodyFrameAndPreserveCentralInertia) {
   M_BBo_B = rigid_body_->CalcSpatialInertiaInBodyFrame(*context_);
   SpatialInertia<double> M_BBo_B_expected(mass, p_BoBcm_B, G_BBo_B);
   EXPECT_TRUE(CompareMatrices(M_BBo_B.CopyToFullMatrix6(),
-      M_BBo_B_expected.CopyToFullMatrix6(), kTolerance));
+                              M_BBo_B_expected.CopyToFullMatrix6(),
+                              kTolerance));
   M_BBcm_B = M_BBo_B.Shift(p_BoBcm_B);
   G_BBcm_B = M_BBcm_B.get_unit_inertia();
   EXPECT_TRUE(G_BBcm_B.IsNearlyEqualTo(G_BBcm_B_expected_zero, kTolerance));
 
   // Change p_BoBcm_B and ensure it propagates properly.
   // First, ensure p_BoBcm_B properly changes.
-  p_BoBcm_B = Vector3d(L/2, 0, 0);  // Now p_BoBcm_B = (1, 0, 0).
-  rigid_body_->SetCenterOfMassInBodyFrameAndPreserveCentralInertia(
-      context_ptr, p_BoBcm_B);
+  p_BoBcm_B = Vector3d(L / 2, 0, 0);  // Now p_BoBcm_B = (1, 0, 0).
+  rigid_body_->SetCenterOfMassInBodyFrameAndPreserveCentralInertia(context_ptr,
+                                                                   p_BoBcm_B);
   const Vector3d p_BoBcm_B_calculated =
       rigid_body_->CalcCenterOfMassInBodyFrame(*context_);
   EXPECT_EQ(p_BoBcm_B_calculated, p_BoBcm_B);
@@ -234,7 +242,8 @@ TEST_F(RigidBodyTest, SetCenterOfMassInBodyFrameAndPreserveCentralInertia) {
   I_BBo_B = M_BBo_B.CalcRotationalInertia();
   I_BBo_B_expected = RotationalInertia<double>(mass, p_BoBcm_B);
   EXPECT_TRUE(CompareMatrices(I_BBo_B.CopyToFullMatrix3(),
-      I_BBo_B_expected.CopyToFullMatrix3(), kTolerance));
+                              I_BBo_B_expected.CopyToFullMatrix3(),
+                              kTolerance));
 
   // Verify B's unit inertia about Bcm is still zero.
   M_BBcm_B = M_BBo_B.Shift(p_BoBcm_B);
@@ -242,10 +251,12 @@ TEST_F(RigidBodyTest, SetCenterOfMassInBodyFrameAndPreserveCentralInertia) {
   EXPECT_TRUE(G_BBcm_B.IsNearlyEqualTo(G_BBcm_B_expected_zero, kTolerance));
 
   // Ensure M_BBo_B has proper mass, proper p_BoBcm_B, and proper G_BBo_B.
-  UnitInertia<double> G_BBo_B_expected = UnitInertia<double>(0, L*L/4, L*L/4);
+  UnitInertia<double> G_BBo_B_expected =
+      UnitInertia<double>(0, L * L / 4, L * L / 4);
   M_BBo_B_expected = SpatialInertia<double>(mass, p_BoBcm_B, G_BBo_B_expected);
   EXPECT_TRUE(CompareMatrices(M_BBo_B.CopyToFullMatrix6(),
-      M_BBo_B_expected.CopyToFullMatrix6(), kTolerance));
+                              M_BBo_B_expected.CopyToFullMatrix6(),
+                              kTolerance));
 }
 
 }  // namespace

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -60,8 +60,8 @@ GTEST_TEST(RotationalInertia, TestIsZeroAndIsNanFunctions) {
 // Test constructor for a diagonal rotational inertia with all elements equal.
 GTEST_TEST(RotationalInertia, DiagonalInertiaConstructor) {
   const double I_diagonal = 3.14;
-  RotationalInertia<double> I = RotationalInertia<double>::
-                                            TriaxiallySymmetric(I_diagonal);
+  RotationalInertia<double> I =
+      RotationalInertia<double>::TriaxiallySymmetric(I_diagonal);
   Vector3d moments_expected;
   moments_expected.setConstant(I_diagonal);
   Vector3d products_expected = Vector3d::Zero();
@@ -69,78 +69,78 @@ GTEST_TEST(RotationalInertia, DiagonalInertiaConstructor) {
   EXPECT_EQ(I.get_products(), products_expected);
 }
 
-
 // Test rotational inertia factory method set via a 3x3 matrix.
 GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
-    // Form an arbitrary (but valid) rotational inertia.
-    const double Ixx = 17, Iyy = 13, Izz = 10;
-    const double Ixy = -3, Ixz = -3, Iyz = -6;
+  // Form an arbitrary (but valid) rotational inertia.
+  const double Ixx = 17, Iyy = 13, Izz = 10;
+  const double Ixy = -3, Ixz = -3, Iyz = -6;
 
-    RotationalInertia<double> I =
-        RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-            Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false);
-    EXPECT_TRUE(I.CouldBePhysicallyValid());
+  RotationalInertia<double> I =
+      RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false);
+  EXPECT_TRUE(I.CouldBePhysicallyValid());
 
-    // Ensure an invalid rotational inertia always throws an exception if the
-    // 2nd argument of MakeFromMomentsAndProductsOfInertia is false or missing.
-    EXPECT_THROW(RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-        2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false),
-        std::exception);
-    EXPECT_THROW(RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-        2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz),
-        std::exception);
-
-    // Ensure an invalid rotational inertia does not throw an exception if the
-    // 2nd argument of MakeFromMomentsAndProductsOfInertia is true.
-    EXPECT_NO_THROW(
-        I = RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-            2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz,
-            /* skip_validity_check = */ true));
-    EXPECT_FALSE(I.CouldBePhysicallyValid());
-
-    // Check for a thrown exception with proper error message when creating an
-    // invalid rotational inertia (a principal moment of inertia is negative).
-    std::string expected_message =
-        "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
-        "\\[ 1  -3  -3\\]\n"
-        "\\[-3  13  -6\\]\n"
-        "\\[-3  -6  10\\]\n"
-        "did not pass the test CouldBePhysicallyValid\\(\\)\\.";
-    expected_message += fmt::format(
-        "\nThe associated principal moments of inertia:"
-        "\n-1.583957883\\d+  7.881702629\\d+  17.702255254\\d+"
-        "\nare invalid since at least one is negative.");
-    // Note: The principal moments of inertia (with more significant digits)
-    // are: -1.583957883490135  7.881702629192435  17.702255254297697.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-          1.0, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false),
-          expected_message);
-
-    // Check for a thrown exception with proper error message when creating a
-    // rotational inertia that violates the triangle inequality.
-    expected_message =
-      "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
-        "\\[34  -3  -3\\]\n"
-        "\\[-3  13  -6\\]\n"
-        "\\[-3  -6  10\\]\n"
-        "did not pass the test CouldBePhysicallyValid\\(\\)\\.";
-    expected_message += fmt::format(
-        "\nThe associated principal moments of inertia:"
-        "\n4.70955263953\\d+  17.66953281\\d+  34.6209145475\\d+"
-        "\ndo not satisfy the triangle inequality.");
-    // Note: The principal moments of inertia (with more significant digits)
-    // are:  4.709552639531104  17.66953281292159  34.620914547547315.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+  // Ensure an invalid rotational inertia always throws an exception if the
+  // 2nd argument of MakeFromMomentsAndProductsOfInertia is false or missing.
+  EXPECT_THROW(
+      RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
           2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false),
-          expected_message);
+      std::exception);
+  EXPECT_THROW(RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+                   2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz),
+               std::exception);
+
+  // Ensure an invalid rotational inertia does not throw an exception if the
+  // 2nd argument of MakeFromMomentsAndProductsOfInertia is true.
+  EXPECT_NO_THROW(
+      I = RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz,
+          /* skip_validity_check = */ true));
+  EXPECT_FALSE(I.CouldBePhysicallyValid());
+
+  // Check for a thrown exception with proper error message when creating an
+  // invalid rotational inertia (a principal moment of inertia is negative).
+  std::string expected_message =
+      "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
+      "\\[ 1  -3  -3\\]\n"
+      "\\[-3  13  -6\\]\n"
+      "\\[-3  -6  10\\]\n"
+      "did not pass the test CouldBePhysicallyValid\\(\\)\\.";
+  expected_message += fmt::format(
+      "\nThe associated principal moments of inertia:"
+      "\n-1.583957883\\d+  7.881702629\\d+  17.702255254\\d+"
+      "\nare invalid since at least one is negative.");
+  // Note: The principal moments of inertia (with more significant digits)
+  // are: -1.583957883490135  7.881702629192435  17.702255254297697.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          1.0, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false),
+      expected_message);
+
+  // Check for a thrown exception with proper error message when creating a
+  // rotational inertia that violates the triangle inequality.
+  expected_message =
+      "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
+      "\\[34  -3  -3\\]\n"
+      "\\[-3  13  -6\\]\n"
+      "\\[-3  -6  10\\]\n"
+      "did not pass the test CouldBePhysicallyValid\\(\\)\\.";
+  expected_message += fmt::format(
+      "\nThe associated principal moments of inertia:"
+      "\n4.70955263953\\d+  17.66953281\\d+  34.6209145475\\d+"
+      "\ndo not satisfy the triangle inequality.");
+  // Note: The principal moments of inertia (with more significant digits)
+  // are:  4.709552639531104  17.66953281292159  34.620914547547315.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false),
+      expected_message);
 }
 
 // Test constructor for a principal axes rotational inertia matrix (products
 // of inertia are zero).
 GTEST_TEST(RotationalInertia, PrincipalAxesConstructor) {
-  const Vector3d moments(2.0,  2.3, 2.4);
+  const Vector3d moments(2.0, 2.3, 2.4);
   RotationalInertia<double> I(moments(0), moments(1), moments(2));
   EXPECT_EQ(I.get_moments(), moments);
   EXPECT_EQ(I.get_products(), Vector3d::Zero());
@@ -150,10 +150,10 @@ GTEST_TEST(RotationalInertia, PrincipalAxesConstructor) {
 // off-diagonal elements for which the six entries need to be specified.
 // Also test SetZero() and SetNaN() methods.
 GTEST_TEST(RotationalInertia, GeneralConstructor) {
-  const Vector3d moments(2.0,  2.3, 2.4);
+  const Vector3d moments(2.0, 2.3, 2.4);
   const Vector3d product(0.1, -0.1, 0.2);
-  RotationalInertia<double> I(moments(0), moments(1), moments(2),
-                              product(0), product(1), product(2));
+  RotationalInertia<double> I(moments(0), moments(1), moments(2), product(0),
+                              product(1), product(2));
   EXPECT_EQ(I.get_moments(), moments);
   EXPECT_EQ(I.get_products(), product);
 
@@ -168,7 +168,7 @@ GTEST_TEST(RotationalInertia, GeneralConstructor) {
 
 // Test calculation of trace of rotational inertia (sum of diagonal elements).
 GTEST_TEST(RotationalInertia, TraceIsSumOfDiagonalElements) {
-  const Vector3d moments(2.0,  2.3, 2.4);
+  const Vector3d moments(2.0, 2.3, 2.4);
   const Vector3d product(0.1, -0.1, 0.2);
   const RotationalInertia<double> I(moments(0), moments(1), moments(2),
                                     product(0), product(1), product(2));
@@ -178,8 +178,8 @@ GTEST_TEST(RotationalInertia, TraceIsSumOfDiagonalElements) {
 
 // Test access by (i, j) indexes.
 GTEST_TEST(RotationalInertia, AccessByIndexes) {
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
-  const Vector3d p(0.1, -0.1, 0.2);  // p for products.
+  const Vector3d m(2.0, 2.3, 2.4);                     // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);                    // p for products.
   const RotationalInertia<double> I(m(0), m(1), m(2),  /* moments of inertia */
                                     p(0), p(1), p(2)); /* products of inertia */
 
@@ -202,8 +202,8 @@ GTEST_TEST(RotationalInertia, AccessByIndexes) {
 // Tests that even when the underlying dense Eigen representation holds NaN
 // entries for unused entries, RotationalInertia behaves as a symmetric matrix.
 GTEST_TEST(RotationalInertia, Symmetry) {
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
-  const Vector3d p(0.1, -0.1, 0.2);  // p for products.
+  const Vector3d m(2.0, 2.3, 2.4);                     // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);                    // p for products.
   const RotationalInertia<double> I(m(0), m(1), m(2),  /* moments of inertia */
                                     p(0), p(1), p(2)); /* products of inertia */
 
@@ -236,17 +236,16 @@ GTEST_TEST(RotationalInertia, IsNearlyEqualTo) {
   const double Iyz = -6.539290790868233;
   const double trace = Ixx + Iyy + Izz;
   const double epsilonI = kEpsilon * trace / 2;
-  const RotationalInertia<double> I1(Ixx, Iyy, Izz,
-                                     Ixy, Ixz, Iyz);
-  const RotationalInertia<double> I2(Ixx, Iyy, Izz,
-                                     Ixy, Ixz, Iyz + 3*epsilonI);
-  const RotationalInertia<double> I3(Ixx, Iyy, Izz,
-                                     Ixy, Ixz, Iyz + 8*epsilonI);
+  const RotationalInertia<double> I1(Ixx, Iyy, Izz, Ixy, Ixz, Iyz);
+  const RotationalInertia<double> I2(Ixx, Iyy, Izz, Ixy, Ixz,
+                                     Iyz + 3 * epsilonI);
+  const RotationalInertia<double> I3(Ixx, Iyy, Izz, Ixy, Ixz,
+                                     Iyz + 8 * epsilonI);
 
   // Ensure rotational inertias I1 and I2 are nearly equal.
   // Ensure rotational inertias I1 and I3 are not equal.
-  EXPECT_TRUE(I1.IsNearlyEqualTo(I2, 4*kEpsilon));
-  EXPECT_FALSE(I1.IsNearlyEqualTo(I3, 7*kEpsilon));
+  EXPECT_TRUE(I1.IsNearlyEqualTo(I2, 4 * kEpsilon));
+  EXPECT_FALSE(I1.IsNearlyEqualTo(I3, 7 * kEpsilon));
 }
 
 // TestA: Rotational inertia expressed in frame R then re-expressed in frame E.
@@ -285,8 +284,9 @@ GTEST_TEST(RotationalInertia, ReExpressInAnotherFrameA) {
 GTEST_TEST(RotationalInertia, ReExpressInAnotherFrameB) {
   // Rotate rigid-body B from frame A by a Euler body-fixed sequence
   // characterized by BodyXYZ q1, q2, q3.  Calculations from MotionGenesis.
-  const double deg_to_rad = M_PI/180;
-  const double q1 = 30*deg_to_rad,  q2 = 70*deg_to_rad,  q3 = -70*deg_to_rad;
+  const double deg_to_rad = M_PI / 180;
+  const double q1 = 30 * deg_to_rad, q2 = 70 * deg_to_rad,
+               q3 = -70 * deg_to_rad;
   const double R_BAxx = cos(q2) * cos(q3);
   const double R_BAxy = sin(q3) * cos(q1) + sin(q1) * sin(q2) * cos(q3);
   const double R_BAxz = sin(q1) * sin(q3) - sin(q2) * cos(q1) * cos(q3);
@@ -297,8 +297,7 @@ GTEST_TEST(RotationalInertia, ReExpressInAnotherFrameB) {
   const double R_BAzy = -sin(q1) * cos(q2);
   const double R_BAzz = cos(q1) * cos(q2);
   const RotationMatrixd R_BA = RotationMatrixd::MakeFromOrthonormalRows(
-      Vector3d(R_BAxx, R_BAxy, R_BAxz),
-      Vector3d(R_BAyx, R_BAyy, R_BAyz),
+      Vector3d(R_BAxx, R_BAxy, R_BAxz), Vector3d(R_BAyx, R_BAyy, R_BAyz),
       Vector3d(R_BAzx, R_BAzy, R_BAzz));
 
   // Form an arbitrary (but valid) rotational inertia for B about-point Bo,
@@ -327,9 +326,8 @@ GTEST_TEST(RotationalInertia, ReExpressInAnotherFrameB) {
   const double I_BBo_Bxy = 1.134877977228511;
   const double I_BBo_Bxz = 6.018249975302059;
   const double I_BBo_Byz = -0.6136491084717202;
-  const RotationalInertia<double>
-      expected_I_BBo_B(I_BBo_Bxx, I_BBo_Byy, I_BBo_Bzz,
-                       I_BBo_Bxy, I_BBo_Bxz, I_BBo_Byz);
+  const RotationalInertia<double> expected_I_BBo_B(
+      I_BBo_Bxx, I_BBo_Byy, I_BBo_Bzz, I_BBo_Bxy, I_BBo_Bxz, I_BBo_Byz);
 
   // Compare Drake results versus MotionGenesis results using a comparison
   // that tests moments/products of inertia to within kEpsilon multiplied
@@ -340,8 +338,8 @@ GTEST_TEST(RotationalInertia, ReExpressInAnotherFrameB) {
 // Test the method ShiftFromCenterOfMass for a body B's rotational inertia
 // about-point Bcm (B's center of mass) to about-point Q.
 GTEST_TEST(RotationalInertia, ShiftFromCenterOfMass) {
-  const double I_BBcm_Bxx = 2,  I_BBcm_Byy = 3,  I_BBcm_Bzz = 4;
-  const double I_BBcm_Bxy = 0,  I_BBcm_Bxz = 0,  I_BBcm_Byz = 0;
+  const double I_BBcm_Bxx = 2, I_BBcm_Byy = 3, I_BBcm_Bzz = 4;
+  const double I_BBcm_Bxy = 0, I_BBcm_Bxz = 0, I_BBcm_Byz = 0;
   const RotationalInertia<double> I_BBcm_B(I_BBcm_Bxx, I_BBcm_Byy, I_BBcm_Bzz,
                                            I_BBcm_Bxy, I_BBcm_Bxz, I_BBcm_Byz);
   const double mass = 1.1, xQ = 2.234, yQ = 3.14, zQ = 0.56;
@@ -350,47 +348,47 @@ GTEST_TEST(RotationalInertia, ShiftFromCenterOfMass) {
       I_BBcm_B.ShiftFromCenterOfMass(mass, p_BcmQ_B);
 
   // Compare Drake results versus by-hand results.
-  const double Ixx = I_BBcm_Bxx + mass * (yQ*yQ + zQ*zQ);
-  const double Iyy = I_BBcm_Byy + mass * (xQ*xQ + zQ*zQ);
-  const double Izz = I_BBcm_Bzz + mass * (xQ*xQ + yQ*yQ);
-  const double Ixy = I_BBcm_Bxy - mass * xQ*yQ;
-  const double Ixz = I_BBcm_Bxz - mass * xQ*zQ;
-  const double Iyz = I_BBcm_Byz - mass * yQ*zQ;
+  const double Ixx = I_BBcm_Bxx + mass * (yQ * yQ + zQ * zQ);
+  const double Iyy = I_BBcm_Byy + mass * (xQ * xQ + zQ * zQ);
+  const double Izz = I_BBcm_Bzz + mass * (xQ * xQ + yQ * yQ);
+  const double Ixy = I_BBcm_Bxy - mass * xQ * yQ;
+  const double Ixz = I_BBcm_Bxz - mass * xQ * zQ;
+  const double Iyz = I_BBcm_Byz - mass * yQ * zQ;
   const RotationalInertia<double> expected_I_BQ_B(Ixx, Iyy, Izz, Ixy, Ixz, Iyz);
-  EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(expected_I_BQ_B, 2*kEpsilon));
+  EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(expected_I_BQ_B, 2 * kEpsilon));
 }
 
 // Test the method ShiftToCenterOfMass for a body B's rotational inertia
 // about-point P to about-point Bcm (B's center of mass).
 GTEST_TEST(RotationalInertia, ShiftToCenterOfMass) {
-  const double I_BP_Bxx = 13.2,  I_BP_Byy = 8.8,   I_BP_Bzz = 20.3;
-  const double I_BP_Bxy = -7.7,  I_BP_Bxz = -1.3,  I_BP_Byz = -1.9;
-  const RotationalInertia<double> I_BP_B(I_BP_Bxx, I_BP_Byy, I_BP_Bzz,
-                                         I_BP_Bxy, I_BP_Bxz, I_BP_Byz);
+  const double I_BP_Bxx = 13.2, I_BP_Byy = 8.8, I_BP_Bzz = 20.3;
+  const double I_BP_Bxy = -7.7, I_BP_Bxz = -1.3, I_BP_Byz = -1.9;
+  const RotationalInertia<double> I_BP_B(I_BP_Bxx, I_BP_Byy, I_BP_Bzz, I_BP_Bxy,
+                                         I_BP_Bxz, I_BP_Byz);
   const double mass = 1.1, xBcm = 2.234, yBcm = 3.14, zBcm = 0.56;
   const Vector3d p_PBcm_B(xBcm, yBcm, zBcm);
   const RotationalInertia<double> I_BBcm_B =
       I_BP_B.ShiftToCenterOfMass(mass, p_PBcm_B);
 
   // Compare Drake results versus by-hand results.
-  const double Ixx = I_BP_Bxx - mass * (yBcm*yBcm + zBcm*zBcm);
-  const double Iyy = I_BP_Byy - mass * (xBcm*xBcm + zBcm*zBcm);
-  const double Izz = I_BP_Bzz - mass * (xBcm*xBcm + yBcm*yBcm);
-  const double Ixy = I_BP_Bxy + mass * xBcm*yBcm;
-  const double Ixz = I_BP_Bxz + mass * xBcm*zBcm;
-  const double Iyz = I_BP_Byz + mass * yBcm*zBcm;
-  const RotationalInertia<double> expected_I_BBcm_B(
-      Ixx, Iyy, Izz, Ixy, Ixz, Iyz);
-  EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(expected_I_BBcm_B, 4*kEpsilon));
+  const double Ixx = I_BP_Bxx - mass * (yBcm * yBcm + zBcm * zBcm);
+  const double Iyy = I_BP_Byy - mass * (xBcm * xBcm + zBcm * zBcm);
+  const double Izz = I_BP_Bzz - mass * (xBcm * xBcm + yBcm * yBcm);
+  const double Ixy = I_BP_Bxy + mass * xBcm * yBcm;
+  const double Ixz = I_BP_Bxz + mass * xBcm * zBcm;
+  const double Iyz = I_BP_Byz + mass * yBcm * zBcm;
+  const RotationalInertia<double> expected_I_BBcm_B(Ixx, Iyy, Izz, Ixy, Ixz,
+                                                    Iyz);
+  EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(expected_I_BBcm_B, 4 * kEpsilon));
 }
 
 // Test the method ShiftToThenAwayFromCenterOfMass for a body B's
 // rotational inertia from about-point P to about-point Q.
 GTEST_TEST(RotationalInertia, ShiftToThenAwayFromCenterOfMass) {
-  const double I_BP_xx = 13.2,  I_BP_yy = 8.8,   I_BP_zz = 20.3;
-  const double I_BP_xy = -7.7,  I_BP_xz = -1.3,  I_BP_yz = -1.9;
-  const RotationalInertia<double> I_BP_B(I_BP_xx, I_BP_yy, I_BP_zz,
-                                         I_BP_xy, I_BP_xz, I_BP_yz);
+  const double I_BP_xx = 13.2, I_BP_yy = 8.8, I_BP_zz = 20.3;
+  const double I_BP_xy = -7.7, I_BP_xz = -1.3, I_BP_yz = -1.9;
+  const RotationalInertia<double> I_BP_B(I_BP_xx, I_BP_yy, I_BP_zz, I_BP_xy,
+                                         I_BP_xz, I_BP_yz);
   const double mass = 1.1, xBcm = 2.234, yBcm = 3.14, zBcm = 0.56;
   const double xP = -1.234, yP = -2.11, zP = 1.98;
   const Vector3d p_PBcm(xBcm, yBcm, zBcm);
@@ -408,26 +406,25 @@ GTEST_TEST(RotationalInertia, ShiftToThenAwayFromCenterOfMass) {
   // Calculate with single method that does it slightly more efficiently.
   const RotationalInertia<double> I_BQ_B =
       I_BP_B.ShiftToThenAwayFromCenterOfMass(mass, p_PBcm, p_QBcm);
-  EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(expected_I_BQ_B, 2*kEpsilon));
+  EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(expected_I_BQ_B, 2 * kEpsilon));
 
   // Test that negating position vectors have no affect on results.
   EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(
-              I_BP_B.ShiftToCenterOfMass(mass, -p_PBcm), 2*kEpsilon));
+      I_BP_B.ShiftToCenterOfMass(mass, -p_PBcm), 2 * kEpsilon));
   EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(
-              I_BBcm_B.ShiftFromCenterOfMass(mass, -p_QBcm),
-              2*kEpsilon));
+      I_BBcm_B.ShiftFromCenterOfMass(mass, -p_QBcm), 2 * kEpsilon));
   EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(
-              I_BP_B.ShiftToThenAwayFromCenterOfMass(mass, -p_PBcm, -p_QBcm),
-              2*kEpsilon));
+      I_BP_B.ShiftToThenAwayFromCenterOfMass(mass, -p_PBcm, -p_QBcm),
+      2 * kEpsilon));
 }
 
 // Test the method CouldBePhysicallyValid after a body B's rotational inertia
 // is shifted from about-point P to about-point Bcm (B's center of mass).
 GTEST_TEST(RotationalInertia, CouldBePhysicallyValidA) {
-  const double I_BP_xx = 2,   I_BP_yy = 3,   I_BP_zz = 4;
-  const double I_BP_xy = 0,   I_BP_xz = 0,   I_BP_yz = 0;
-  const RotationalInertia<double> I_BP(I_BP_xx, I_BP_yy, I_BP_zz,
-                                       I_BP_xy, I_BP_xz, I_BP_yz);
+  const double I_BP_xx = 2, I_BP_yy = 3, I_BP_zz = 4;
+  const double I_BP_xy = 0, I_BP_xz = 0, I_BP_yz = 0;
+  const RotationalInertia<double> I_BP(I_BP_xx, I_BP_yy, I_BP_zz, I_BP_xy,
+                                       I_BP_xz, I_BP_yz);
   const double mass = 1.1, xBcm = 2.234, yBcm = 3.14, zBcm = 0.56;
   const Vector3d p_PBcm(xBcm, yBcm, zBcm);
 
@@ -455,7 +452,7 @@ GTEST_TEST(RotationalInertia, CouldBePhysicallyValidB) {
 // Test the method CouldBePhysicallyValid to violate triangle inequality.
 GTEST_TEST(RotationalInertia, CouldBePhysicallyValidC) {
   EXPECT_THROW_IF_ARMED(RotationalInertia<double> bad_inertia(10, 10, 30),
-                std::logic_error);
+                        std::logic_error);
 }
 
 // Test the method CouldBePhysicallyValid for bad product of inertia
@@ -469,8 +466,9 @@ GTEST_TEST(RotationalInertia, CouldBePhysicallyValidD) {
 // (i.e., eigenvalues of the inertia matrix) that violate triangle inequality.
 // This test is courtesy of Steve Peters via Michael Sherman.
 GTEST_TEST(RotationalInertia, CouldBePhysicallyValidE) {
-  EXPECT_THROW_IF_ARMED(RotationalInertia<double>
-                       bad_inertia(2, 2, 2, -0.8, 0, -0.8), std::logic_error);
+  EXPECT_THROW_IF_ARMED(
+      RotationalInertia<double> bad_inertia(2, 2, 2, -0.8, 0, -0.8),
+      std::logic_error);
 }
 
 // Test the method RotationalInertia::CalcPrincipalMomentsOfInertia() that
@@ -483,17 +481,17 @@ GTEST_TEST(RotationalInertia, PrincipalMomentsOfInertiaEtc) {
   const double Lz = 5.0;
 
   // Rotational inertia of a box B computed about Bcm (B's center of mass).
-  const double Imed = mass * (Ly*Ly + Lz*Lz) / 12.0;  // Ixx is medium.
-  const double Imax = mass * (Lx*Lx + Lz*Lz) / 12.0;  // Iyy is largest.
-  const double Imin = mass * (Lx*Lx + Ly*Ly) / 12.0;  // Izz is smallest.
+  const double Imed = mass * (Ly * Ly + Lz * Lz) / 12.0;  // Ixx is medium.
+  const double Imax = mass * (Lx * Lx + Lz * Lz) / 12.0;  // Iyy is largest.
+  const double Imin = mass * (Lx * Lx + Ly * Ly) / 12.0;  // Izz is smallest.
   double Ixx = Imed, Iyy = Imax, Izz = Imin;
   RotationalInertia<double> I_BBcm_Q(Ixx, Iyy, Izz);
 
   // Orient a frame Q relative to a frame W by subjecting frame Q to a SpaceXYZ
   // rotation sequence of 20, 25, 30 degrees (i.e., BodyZYX by 30, 25, 20).
   const double deg_to_rad = M_PI / 180.0;
-  const drake::math::RollPitchYaw<double>
-      rpy(20 * deg_to_rad, 25 * deg_to_rad, 30 * deg_to_rad);
+  const drake::math::RollPitchYaw<double> rpy(20 * deg_to_rad, 25 * deg_to_rad,
+                                              30 * deg_to_rad);
   const drake::math::RotationMatrix<double> R_WQ(rpy);
 
   // Compute B's rotational inertia about-point Bcm, expressed-in frame W.
@@ -510,12 +508,13 @@ GTEST_TEST(RotationalInertia, PrincipalMomentsOfInertiaEtc) {
   // return from RotationalInertia::CalcPrincipalMomentsOfInertia() is sorted
   // in ascending order. Therefore reorder before performing the comparison.
   Vector3d expected_principal_moments = I_BBcm_Q.get_moments();
-  std::sort(expected_principal_moments.data(),
-            expected_principal_moments.data() +
-                expected_principal_moments.size());
+  std::sort(
+      expected_principal_moments.data(),
+      expected_principal_moments.data() + expected_principal_moments.size());
 
   // Verify principal moments against their expected value.
-  const double inertia_tolerance = 4 * std::numeric_limits<double>::epsilon() *
+  const double inertia_tolerance =
+      4 * std::numeric_limits<double>::epsilon() *
       I_BBcm_W.CalcMaximumPossibleMomentOfInertia();
   EXPECT_TRUE(CompareMatrices(expected_principal_moments, principal_moments,
                               inertia_tolerance, MatrixCompareType::absolute));
@@ -547,11 +546,13 @@ GTEST_TEST(RotationalInertia, PrincipalMomentsOfInertiaEtc) {
   // due to tiny numbers instead of zeroes and reordering of columns.
   drake::math::RotationMatrix<double> R_QP = I_BBcm_P.second;
   Matrix3<double> m_expected;
+  // clang-format off
   m_expected << 0, 1, 0,  // Izz is smallest moment of inertia (1st column).
                 0, 0, 1,  // Ixx is intermediate moment of inertia (2nd column).
                 1, 0, 0;  // Iyy is largest moment of inertia (3rd column).
-  EXPECT_TRUE(CompareMatrices(R_QP.matrix(), m_expected,
-                              0.0, MatrixCompareType::absolute));
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(R_QP.matrix(), m_expected, 0.0,
+                              MatrixCompareType::absolute));
 
   // Create a test that makes a rotation matrix whose 3rd column is [0 0 -1].
   Ixx = Imed, Iyy = Imin, Izz = Imax;
@@ -563,11 +564,13 @@ GTEST_TEST(RotationalInertia, PrincipalMomentsOfInertiaEtc) {
   EXPECT_TRUE(CompareMatrices(expected_principal_moments, principal_moments,
                               inertia_tolerance, MatrixCompareType::absolute));
   R_QP = I_BBcm_P.second;
-  m_expected << 0, 1,  0,  // Iyy is smallest moment of inertia (1st column).
-                1, 0,  0,  // Ixx is intermediate moment of inertia (2nd column)
+  // clang-format off
+  m_expected << 0, 1, 0,   // Iyy is smallest moment of inertia (1st column).
+                1, 0, 0,   // Ixx is intermediate moment of inertia (2nd column)
                 0, 0, -1;  // Izz is largest moment of inertia (3rd column).
-  EXPECT_TRUE(CompareMatrices(R_QP.matrix(), m_expected,
-                              0.0, MatrixCompareType::absolute));
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(R_QP.matrix(), m_expected, 0.0,
+                              MatrixCompareType::absolute));
 
   // Create a test that ideally makes an identity rotation matrix.
   Ixx = Imax + 0.5 * inertia_tolerance;  // Intermediate moment of inertia.
@@ -580,11 +583,13 @@ GTEST_TEST(RotationalInertia, PrincipalMomentsOfInertiaEtc) {
   EXPECT_TRUE(CompareMatrices(Vector3<double>(Iyy, Ixx, Izz), principal_moments,
                               inertia_tolerance, MatrixCompareType::absolute));
   R_QP = I_BBcm_P.second;
+  // clang-format off
   m_expected << 1, 0, 0,  // Since Ixx ≈ Iyy ≈ Izz (triaxially symmetric), it is
                 0, 1, 0,  // ideal ("canonical") if the rotation matrix for
                 0, 0, 1;  // principal axes is the identity matrix..
-  EXPECT_TRUE(CompareMatrices(R_QP.matrix(), m_expected,
-                              0.0, MatrixCompareType::absolute));
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(R_QP.matrix(), m_expected, 0.0,
+                              MatrixCompareType::absolute));
 
   // TODO(Mitiguy) Add more tests after adding canonical calculations for
   //  principal directions associated with axially symmetric shapes and shapes
@@ -597,9 +602,12 @@ GTEST_TEST(RotationalInertia, CalcPrincipalMomentsAndAxesOfInertia) {
   // of mass) for principal directions Bx, By, Bz.
   const double a = 5.0, b = 4.0, c = 3.0;
   const double mass = 3.0;
-  const double Imin = 0.2 * mass * (b*b + c*c);  // Ixx = 1/5 m (b² + c²) small
-  const double Imed = 0.2 * mass * (a*a + c*c);  // Iyy = 1/5 m (a² + c²) medium
-  const double Imax = 0.2 * mass * (a*a + b*b);  // Izz = 1/5 m (a² + b²) large
+  const double Imin =
+      0.2 * mass * (b * b + c * c);  // Ixx = 1/5 m (b² + c²) small
+  const double Imed =
+      0.2 * mass * (a * a + c * c);  // Iyy = 1/5 m (a² + c²) medium
+  const double Imax =
+      0.2 * mass * (a * a + b * b);  // Izz = 1/5 m (a² + b²) large
   constexpr double kTolerance = 64 * std::numeric_limits<double>::epsilon();
 
   // Verify a special case of a RotationalInertia with zero products of inertia,
@@ -610,8 +618,8 @@ GTEST_TEST(RotationalInertia, CalcPrincipalMomentsAndAxesOfInertia) {
       RotationalInertia<double>(Imed, Imed, Imed);
   std::pair<Vector3<double>, drake::math::RotationMatrix<double>> I_BBcm_P =
       I_BBcm_B.CalcPrincipalMomentsAndAxesOfInertia();
-  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imed, Imed, Imed),
-                              I_BBcm_P.first, kTolerance));
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imed, Imed, Imed), I_BBcm_P.first,
+                              kTolerance));
   drake::math::RotationMatrix<double> R_BP = I_BBcm_P.second;
   drake::math::RotationMatrix<double> R_BP_expected =
       drake::math::RotationMatrix<double>::Identity();
@@ -622,8 +630,8 @@ GTEST_TEST(RotationalInertia, CalcPrincipalMomentsAndAxesOfInertia) {
   // Calculate I_BBcm_P, which contains B's principal inertia moments and axes.
   I_BBcm_B = RotationalInertia<double>(Imin, Imed, Imax);
   I_BBcm_P = I_BBcm_B.CalcPrincipalMomentsAndAxesOfInertia();
-  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imin, Imed, Imax),
-                              I_BBcm_P.first, kTolerance));
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imin, Imed, Imax), I_BBcm_P.first,
+                              kTolerance));
   R_BP = I_BBcm_P.second;  // Columns of R_BP are eigenvectors (principal axes).
   R_BP_expected = drake::math::RotationMatrix<double>::Identity();
   EXPECT_TRUE(R_BP.IsExactlyEqualTo(R_BP_expected));
@@ -632,8 +640,8 @@ GTEST_TEST(RotationalInertia, CalcPrincipalMomentsAndAxesOfInertia) {
   // with principal moments of inertia having Imed < Imin (must reorder).
   I_BBcm_B = RotationalInertia<double>(Imed, Imin, Imax);
   I_BBcm_P = I_BBcm_B.CalcPrincipalMomentsAndAxesOfInertia();
-  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imin, Imed, Imax),
-                              I_BBcm_P.first, kTolerance));
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imin, Imed, Imax), I_BBcm_P.first,
+                              kTolerance));
   R_BP = I_BBcm_P.second;  // Columns of R_BP are eigenvectors (principal axes).
   Vector3<double> col_min(0.0, 1.0, 0.0);  // Direction for minimum axis.
   Vector3<double> col_med(1.0, 0.0, 0.0);  // Direction for intermediate axis.
@@ -647,8 +655,8 @@ GTEST_TEST(RotationalInertia, CalcPrincipalMomentsAndAxesOfInertia) {
   // with principal moments of inertia having Imax < Imin (must reorder).
   I_BBcm_B = RotationalInertia<double>(Imax, Imin, Imed);
   I_BBcm_P = I_BBcm_B.CalcPrincipalMomentsAndAxesOfInertia();
-  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imin, Imed, Imax),
-                              I_BBcm_P.first, kTolerance));
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imin, Imed, Imax), I_BBcm_P.first,
+                              kTolerance));
   R_BP = I_BBcm_P.second;  // Columns of R_BP are eigenvectors (principal axes).
   col_min = Vector3<double>(0.0, 1.0, 0.0);  // Direction for minimum axis.
   col_med = Vector3<double>(0.0, 0.0, 1.0);  // Direction for intermediate axis.
@@ -665,8 +673,8 @@ GTEST_TEST(RotationalInertia, CalcPrincipalMomentsAndAxesOfInertia) {
       drake::math::RotationMatrix<double>::MakeZRotation(M_PI / 6.0);
   RotationalInertia<double> I_BBcm_C = I_BBcm_B.ReExpress(R_BC);
   I_BBcm_P = I_BBcm_C.CalcPrincipalMomentsAndAxesOfInertia();
-  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imin, Imed, Imax),
-                              I_BBcm_P.first, kTolerance));
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(Imin, Imed, Imax), I_BBcm_P.first,
+                              kTolerance));
   // The orthogonal unit length eigenvectors Px_B, Py_B, Pz_B stored in the
   // columns of R_BP are parallel to the principal axes (lines). Since lines
   // do not have a fully-qualified direction (they lack sense), all we can check
@@ -695,8 +703,8 @@ GTEST_TEST(RotationalInertia, CalcPrincipalMomentsAndAxesOfInertia) {
 // and has eigenvalues lambda = [2 - sqrt(2), 2, 2 + sqrt(2)] which do not
 // satisfy the triangle inequality.
 GTEST_TEST(RotationalInertia, PrincipalMomentsOfInertiaLaplacianTest) {
-  const double Idiag =  2.0;  // The diagonal entries.
-  const double Ioff  = -1.0;  // The off-diagonal entries.
+  const double Idiag = 2.0;  // The diagonal entries.
+  const double Ioff = -1.0;  // The off-diagonal entries.
 
   // Although the inertia matrix is symmetric and positive definite, it does not
   // satisfy the triangle inequality. Hence the constructor throws an exception.
@@ -707,8 +715,8 @@ GTEST_TEST(RotationalInertia, PrincipalMomentsOfInertiaLaplacianTest) {
 
 // Test the correctness of multiplication with a scalar from the left.
 GTEST_TEST(RotationalInertia, MultiplicationWithScalarFromTheLeft) {
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
-  const Vector3d p(0.1, -0.1, 0.2);  // p for products.
+  const Vector3d m(2.0, 2.3, 2.4);                     // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);                    // p for products.
   const RotationalInertia<double> I(m(0), m(1), m(2),  /* moments of inertia */
                                     p(0), p(1), p(2)); /* products of inertia */
   const double scalar = 3.0;
@@ -737,8 +745,8 @@ GTEST_TEST(RotationalInertia, MultiplicationWithScalarFromTheLeft) {
 //  - operator*=(const T&)
 //  - operator/=(const T&)
 GTEST_TEST(RotationalInertia, OperatorPlusEqual) {
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
-  const Vector3d p(0.1, -0.1, 0.2);  // p for products.
+  const Vector3d m(2.0, 2.3, 2.4);                // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);               // p for products.
   RotationalInertia<double> Ia(m(0), m(1), m(2),  /* moments of inertia */
                                p(0), p(1), p(2)); /* products of inertia */
   // A second inertia.
@@ -801,9 +809,9 @@ GTEST_TEST(RotationalInertia, ShiftOperator) {
   RotationalInertia<double> I(1, 2.718, 3.14);
   stream << std::fixed << std::setprecision(4) << I;
   std::string expected_string =
-                  "[1.0000  0.0000  0.0000]\n"
-                  "[0.0000  2.7180  0.0000]\n"
-                  "[0.0000  0.0000  3.1400]\n";
+      "[1.0000  0.0000  0.0000]\n"
+      "[0.0000  2.7180  0.0000]\n"
+      "[0.0000  0.0000  3.1400]\n";
   EXPECT_EQ(expected_string, stream.str());
 }
 
@@ -836,8 +844,8 @@ GTEST_TEST(RotationalInertia, CastToAutoDiff) {
 GTEST_TEST(RotationalInertia, AutoDiff) {
   // Helper lambda to extract from a matrix of auto-diff scalar's the matrix of
   // values and the matrix of derivatives.
-  auto extract_derivatives = [](
-      const Matrix3<AutoDiffXd>& M, Matrix3d& Mvalue, Matrix3d& Mdot) {
+  auto extract_derivatives = [](const Matrix3<AutoDiffXd>& M, Matrix3d& Mvalue,
+                                Matrix3d& Mdot) {
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
         Mvalue(i, j) = M(i, j).value();
@@ -876,9 +884,11 @@ GTEST_TEST(RotationalInertia, AutoDiff) {
   // Therefore we have [w] = Rdot * R.transpose().
   Matrix3<double> wcross = Rdot_WB * Rvalue_WB.transpose();
   Matrix3<double> wcross_expected;
+  // clang-format off
   wcross_expected << 0.0,  -wz, 0.0,
                       wz,  0.0, 0.0,
                      0.0,  0.0, 0.0;
+  // clang-format on
   EXPECT_TRUE(wcross.isApprox(wcross_expected, kEpsilon));
 
   // Re-express inertia into another frame.

--- a/multibody/tree/test/rpy_ball_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_ball_mobilizer_test.cc
@@ -29,14 +29,14 @@ using systems::Context;
 constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 
 // Fixture to setup a simple MBT model containing a space xyz mobilizer.
-class RpyBallMobilizerTest :  public MobilizerTester {
+class RpyBallMobilizerTest : public MobilizerTester {
  public:
   // Creates a simple model consisting of a single body with a space xyz
   // mobilizer connecting it to the world.
   void SetUp() override {
     mobilizer_ = &AddJointAndFinalize<BallRpyJoint, RpyBallMobilizer>(
-        std::make_unique<BallRpyJoint<double>>("joint0",
-            tree().world_body().body_frame(), body_->body_frame()));
+        std::make_unique<BallRpyJoint<double>>(
+            "joint0", tree().world_body().body_frame(), body_->body_frame()));
   }
 
  protected:
@@ -58,9 +58,8 @@ TEST_F(RpyBallMobilizerTest, StateAccess) {
   const RollPitchYawd rpy(M_PI / 5, -M_PI / 7, M_PI / 3);
   const RotationMatrixd R_WB(rpy);
   mobilizer_->SetFromRotationMatrix(context_.get(), R_WB);
-  EXPECT_TRUE(CompareMatrices(
-    mobilizer_->get_angles(*context_), rpy.vector(),
-    kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(mobilizer_->get_angles(*context_), rpy.vector(),
+                              kTolerance, MatrixCompareType::relative));
 }
 
 TEST_F(RpyBallMobilizerTest, ZeroState) {
@@ -98,12 +97,10 @@ TEST_F(RpyBallMobilizerTest, KinematicMapping) {
   MatrixX<double> N_x_Nplus = N * Nplus;
   MatrixX<double> Nplus_x_N = Nplus * N;
 
-  EXPECT_TRUE(CompareMatrices(
-      N_x_Nplus, Matrix3d::Identity(),
-      kTolerance, MatrixCompareType::relative));
-  EXPECT_TRUE(CompareMatrices(
-      Nplus_x_N, Matrix3d::Identity(),
-      kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(N_x_Nplus, Matrix3d::Identity(), kTolerance,
+                              MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(Nplus_x_N, Matrix3d::Identity(), kTolerance,
+                              MatrixCompareType::relative));
 }
 
 TEST_F(RpyBallMobilizerTest, MapUsesN) {

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -64,8 +64,8 @@ TEST_F(ScrewMobilizerTest, ExceptionRaisingWhenZeroPitch) {
   EXPECT_THROW(
       zero_pitch_screw_mobilizer.SetTranslation(context_.get(), translation_z),
       std::exception);
-  EXPECT_THROW(zero_pitch_screw_mobilizer.SetTranslationRate(
-          context_.get(), velocity_z),
+  EXPECT_THROW(
+      zero_pitch_screw_mobilizer.SetTranslationRate(context_.get(), velocity_z),
       std::exception);
 }
 
@@ -74,7 +74,7 @@ TEST_F(ScrewMobilizerTest, StateAccess) {
   // context.
   const double translation_z_first{1.0};
   const double translation_z_second{2.0};
-  const double angle_z_second{translation_z_second  * 2 * M_PI / kScrewPitch};
+  const double angle_z_second{translation_z_second * 2 * M_PI / kScrewPitch};
 
   mobilizer_->SetTranslation(context_.get(), translation_z_first);
   EXPECT_EQ(mobilizer_->get_translation(*context_), translation_z_first);
@@ -93,8 +93,8 @@ TEST_F(ScrewMobilizerTest, StateAccess) {
 
   const double velocity_z_first{1.0};
   const double velocity_z_second{2.0};
-  const double angular_velocity_z_second{
-    velocity_z_second * 2 * M_PI / kScrewPitch};
+  const double angular_velocity_z_second{velocity_z_second * 2 * M_PI /
+                                         kScrewPitch};
 
   // Verify we can set a screw mobilizer velocities given the model's context.
   mobilizer_->SetTranslationRate(context_.get(), velocity_z_first);
@@ -163,7 +163,7 @@ TEST_F(ScrewMobilizerTest, RandomState) {
 
   // Default behavior is to set to zero.
   mobilizer_->set_random_state(*context_, &context_->get_mutable_state(),
-                                      &generator);
+                               &generator);
   EXPECT_EQ(mobilizer_->get_angle(*context_), 0.0);
   EXPECT_EQ(mobilizer_->get_angular_rate(*context_), 0.0);
 
@@ -171,7 +171,7 @@ TEST_F(ScrewMobilizerTest, RandomState) {
   mutable_mobilizer->set_random_position_distribution(
       Vector1<symbolic::Expression>(uniform(generator) + 1.0));
   mobilizer_->set_random_state(*context_, &context_->get_mutable_state(),
-      &generator);
+                               &generator);
   EXPECT_GE(mobilizer_->get_angle(*context_), 1.0);
   EXPECT_EQ(mobilizer_->get_angular_rate(*context_), 0.0);
 
@@ -179,21 +179,21 @@ TEST_F(ScrewMobilizerTest, RandomState) {
   mutable_mobilizer->set_random_velocity_distribution(
       Vector1<symbolic::Expression>(uniform(generator) - 1.0));
   mobilizer_->set_random_state(*context_, &context_->get_mutable_state(),
-      &generator);
+                               &generator);
   EXPECT_GE(mobilizer_->get_angle(*context_), 1.0);
   EXPECT_GE(mobilizer_->get_angular_rate(*context_), -1.0);
 
   // Check that they change on a second draw from the distribution.
   const double last_translation = mobilizer_->get_translation(*context_);
-  const double last_translational_rate = mobilizer_->get_translation_rate(
-      *context_);
+  const double last_translational_rate =
+      mobilizer_->get_translation_rate(*context_);
   const double last_angle = mobilizer_->get_angle(*context_);
   const double last_angular_rate = mobilizer_->get_angular_rate(*context_);
   mobilizer_->set_random_state(*context_, &context_->get_mutable_state(),
-                                      &generator);
+                               &generator);
   EXPECT_NE(mobilizer_->get_translation(*context_), last_translation);
   EXPECT_NE(mobilizer_->get_translation_rate(*context_),
-    last_translational_rate);
+            last_translational_rate);
   EXPECT_NE(mobilizer_->get_angle(*context_), last_angle);
   EXPECT_NE(mobilizer_->get_angular_rate(*context_), last_angular_rate);
 }
@@ -207,8 +207,7 @@ TEST_F(ScrewMobilizerTest, CalcAcrossMobilizerTransform) {
   Vector3d X_FM_translation;
   X_FM_translation << kScrewAxis * angle / (2 * M_PI) * kScrewPitch;
   const RigidTransformd X_FM_expected(
-      Eigen::AngleAxis<double>(angle, kScrewAxis),
-      X_FM_translation);
+      Eigen::AngleAxis<double>(angle, kScrewAxis), X_FM_translation);
 
   EXPECT_TRUE(CompareMatrices(X_FM.GetAsMatrix34(),
                               X_FM_expected.GetAsMatrix34(), kTolerance,
@@ -225,7 +224,7 @@ TEST_F(ScrewMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
 
   VectorXd v_expected(6);
   v_expected << kScrewAxis * angular_velocity[0],
-                kScrewAxis * angular_velocity[0] / (2 * M_PI) * kScrewPitch;
+      kScrewAxis * angular_velocity[0] / (2 * M_PI) * kScrewPitch;
   const SpatialVelocity<double> V_FM_expected(v_expected);
 
   EXPECT_TRUE(V_FM.IsApprox(V_FM_expected, kTolerance));
@@ -244,7 +243,7 @@ TEST_F(ScrewMobilizerTest, CalcAcrossMobilizerSpatialAcceleration) {
 
   VectorXd a_expected(6);
   a_expected << kScrewAxis * angle_acceleration[0],
-                kScrewAxis * angle_acceleration[0] / (2 * M_PI) * kScrewPitch;
+      kScrewAxis * angle_acceleration[0] / (2 * M_PI) * kScrewPitch;
   const SpatialAcceleration<double> A_FM_expected(a_expected);
 
   EXPECT_TRUE(A_FM.IsApprox(A_FM_expected, kTolerance));
@@ -262,9 +261,9 @@ TEST_F(ScrewMobilizerTest, ProjectSpatialForce) {
   Vector1d tau;
   mobilizer_->ProjectSpatialForce(*context_, F_Mo_F, tau);
 
-  const Vector1d tau_expected(
-      torque_Mo_F.dot(kScrewAxis) +
-      force_Mo_F.dot(kScrewAxis) / (2 * M_PI) * kScrewPitch);
+  const Vector1d tau_expected(torque_Mo_F.dot(kScrewAxis) +
+                              force_Mo_F.dot(kScrewAxis) / (2 * M_PI) *
+                                  kScrewPitch);
   EXPECT_TRUE(CompareMatrices(tau, tau_expected, kTolerance,
                               MatrixCompareType::relative));
 

--- a/multibody/tree/test/tree_from_joints_test.cc
+++ b/multibody/tree/test/tree_from_joints_test.cc
@@ -96,7 +96,7 @@ using systems::Context;
 //      |        |
 //      |        |
 //      +--------+
-template<typename T>
+template <typename T>
 class DoublePendulumModel {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DoublePendulumModel);
@@ -139,12 +139,9 @@ class DoublePendulumModel {
     const math::RigidTransformd X_L1So{Vector3d(0.0, half_length1_, 0.0)};
 
     shoulder_ = &model->template AddJoint<RevoluteJoint>(
-        "ShoulderJoint",
-        *world_body_,
-        {},      /* Default to Identity; frame Si IS the world frame W. */
-        *link1_,
-        X_L1So,  /* Pose of So in link 1's frame L1. */
-        Vector3d::UnitZ()  /* revolute axis */);
+        "ShoulderJoint", *world_body_, {},  // Default to Identity; frame Si==W.
+        *link1_, X_L1So,                    // Pose of So in link 1's frame L1.
+        Vector3d::UnitZ());                 // Revolute axis.
 
     // The elbow is the joint that connects links 1 and 2.
     // An inboard frame Ei is rigidly attached to link 1. It is located
@@ -157,12 +154,9 @@ class DoublePendulumModel {
     const math::RigidTransformd X_L1Ei{Vector3d(0.0, -half_length1_, 0.0)};
 
     elbow_ = &model->template AddJoint<RevoluteJoint>(
-        "ElbowJoint",
-        *link1_,
-        X_L1Ei,  /* Pose of Ei in L1. */
-        *link2_,
-        {},      /* Default to Identity; frame Eo IS frame L2. */
-        Vector3d::UnitZ() /* revolute axis */);
+        "ElbowJoint", *link1_, X_L1Ei,  // Pose of Ei in L1.
+        *link2_, {},                    // Default to Identity; frame Eo==L2.
+        Vector3d::UnitZ());             // Revolute axis.
 
     // Add force element for a constant gravity pointing downwards, that is, in
     // the minus y-axis direction.
@@ -235,17 +229,14 @@ class DoublePendulumModel {
 // of a double pendulum.
 class PendulumTests : public ::testing::Test {
  public:
-  void SetUp() override {
-      context_ = pendulum_.CreateDefaultContext();
-  }
+  void SetUp() override { context_ = pendulum_.CreateDefaultContext(); }
 
   // For the double pendulum system it turns out that the mass matrix is only a
   // function of the elbow angle, theta2, independent of the shoulder angle,
   // theta1. This fact can be verified by calling this method with
   // arbitrary values of theta1, given that our benchmark does have this
   // property. This is done in the unit test below.
-  void VerifyCalcMassMatrixViaInverseDynamics(
-      double theta1, double theta2) {
+  void VerifyCalcMassMatrixViaInverseDynamics(double theta1, double theta2) {
     const double kTolerance = 10 * kEpsilon;
     pendulum_.shoulder().set_angle(context_.get(), theta1);
     pendulum_.elbow().set_angle(context_.get(), theta2);
@@ -257,8 +248,8 @@ class PendulumTests : public ::testing::Test {
     // Benchmark mass matrix:
     Matrix2d H_expected = acrobot_benchmark_.CalcMassMatrix(theta2);
 
-    EXPECT_TRUE(CompareMatrices(
-        H, H_expected, kTolerance, MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(H, H_expected, kTolerance,
+                                MatrixCompareType::relative));
   }
 
   // For the double pendulum model under test, it verifies the result returned
@@ -274,14 +265,13 @@ class PendulumTests : public ::testing::Test {
     const UniformGravityFieldElement<double>& gravity_element =
         pendulum_.gravity_element();
 
-    Vector2d tau_g =
-        gravity_element.CalcGravityGeneralizedForces(*context_);
+    Vector2d tau_g = gravity_element.CalcGravityGeneralizedForces(*context_);
 
     Vector2d tau_g_expected =
         acrobot_benchmark_.CalcGravityVector(theta1, theta2);
 
-    EXPECT_TRUE(CompareMatrices(
-        tau_g, tau_g_expected, kTolerance, MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(tau_g, tau_g_expected, kTolerance,
+                                MatrixCompareType::relative));
   }
 
   // This test verifies the API to set joint forces and compute inverse dynamics
@@ -291,10 +281,10 @@ class PendulumTests : public ::testing::Test {
   // described by the joints' angles `theta1` and `theta2` and the joints' angle
   // rates `theta1dot` and `theta2dot`. Input torques `tau1` and `tau2` are
   // applied to the shoulder and elbow joints respectively.
-  void VerifyInverseDynamicsWithAppliedForces(
-      double theta1, double theta2,
-      double theta1dot, double theta2dot,
-      double tau1, double tau2) {
+  void VerifyInverseDynamicsWithAppliedForces(double theta1, double theta2,
+                                              double theta1dot,
+                                              double theta2dot, double tau1,
+                                              double tau2) {
     const double kTolerance = 10 * kEpsilon;
 
     // Set up workspace:
@@ -302,8 +292,7 @@ class PendulumTests : public ::testing::Test {
     // External forces:
     MultibodyForces<double> forces(pendulum_.tree());
     // Accelerations of the bodies:
-    std::vector<SpatialAcceleration<double>> A_WB_array(
-        tree().num_bodies());
+    std::vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
     // Generalized accelerations:
     VectorX<double> vdot = VectorX<double>::Zero(nv);
 
@@ -339,11 +328,8 @@ class PendulumTests : public ::testing::Test {
 
     // With vdot = 0, this computes:
     //   rhs = C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W.
-    tree().CalcInverseDynamics(
-        *context_, vdot,
-        F_BBo_W_array, tau_array,
-        &A_WB_array,
-        &F_BMo_W, &tau  /* Output forces */);
+    tree().CalcInverseDynamics(*context_, vdot, F_BBo_W_array, tau_array,
+                               &A_WB_array, &F_BMo_W, &tau /* Output forces */);
 
     // Now compute inverse dynamics using our benchmark:
     Vector2d tau_expected(tau1, tau2);
@@ -353,14 +339,14 @@ class PendulumTests : public ::testing::Test {
         acrobot_benchmark_.CalcGravityVector(theta1, theta2);
     Vector2d rhs = C_expected - tau_g_expected - tau_expected;
 
-    EXPECT_TRUE(CompareMatrices(
-        tau, rhs, kTolerance, MatrixCompareType::relative));
+    EXPECT_TRUE(
+        CompareMatrices(tau, rhs, kTolerance, MatrixCompareType::relative));
 
     // Verify alternative APIs for inverse dynamics.
     const VectorX<double> tau_id2 =
         tree().CalcInverseDynamics(*context_, vdot, forces);
-    EXPECT_TRUE(CompareMatrices(
-        tau_id2, rhs, kTolerance, MatrixCompareType::relative));
+    EXPECT_TRUE(
+        CompareMatrices(tau_id2, rhs, kTolerance, MatrixCompareType::relative));
   }
 
   const internal::MultibodyTree<double>& tree() const {
@@ -373,13 +359,19 @@ class PendulumTests : public ::testing::Test {
   std::unique_ptr<Context<double>> context_;
 
   // Reference benchmark for verification.
-  Acrobot<double> acrobot_benchmark_{
-      Vector3d::UnitZ() /* Plane normal */, Vector3d::UnitY() /* Up vector */,
-      pendulum_.mass1(), pendulum_.mass2(),
-      pendulum_.length1(), pendulum_.length2(),
-      pendulum_.half_length1(), pendulum_.half_length2(),
-      pendulum_.Ic1(), pendulum_.Ic2(), 0.0, 0.0,
-      pendulum_.gravity()};
+  Acrobot<double> acrobot_benchmark_{Vector3d::UnitZ() /* Plane normal */,
+                                     Vector3d::UnitY() /* Up vector */,
+                                     pendulum_.mass1(),
+                                     pendulum_.mass2(),
+                                     pendulum_.length1(),
+                                     pendulum_.length2(),
+                                     pendulum_.half_length1(),
+                                     pendulum_.half_length2(),
+                                     pendulum_.Ic1(),
+                                     pendulum_.Ic2(),
+                                     0.0,
+                                     0.0,
+                                     pendulum_.gravity()};
 };
 
 // Compute the mass matrix using the inverse dynamics method.
@@ -428,75 +420,70 @@ TEST_F(PendulumTests, VerifyGravityGeneralizedForces) {
 // Compute forward dynamics by explicitly forming the mass matrix.
 TEST_F(PendulumTests, CalcForwardDynamicsViaExplicitMassMatrixSolve) {
   // With zero velocity and zero input torques.
-  VerifyInverseDynamicsWithAppliedForces(
-      0.0, 0.0,   /* joint's angles */
-      0.0, 0.0,   /* joint's angular rates */
-      0.0, 0.0);  /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      0.0, M_PI / 2.0,  /* joint's angles */
-      0.0, 0.0,         /* joint's angular rates */
-      0.0, 0.0);        /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      0.0, M_PI / 3.0,  /* joint's angles */
-      0.0, 0.0,         /* joint's angular rates */
-      0.0, 0.0);        /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      0.0, M_PI / 4.0,  /* joint's angles */
-      0.0, 0.0,         /* joint's angular rates */
-      0.0, 0.0);        /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(0.0, 0.0,  /* joint's angles */
+                                         0.0, 0.0,  /* joint's angular rates */
+                                         0.0, 0.0); /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(0.0, M_PI / 2.0, /* joint's angles */
+                                         0.0, 0.0,  /* joint's angular rates */
+                                         0.0, 0.0); /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(0.0, M_PI / 3.0, /* joint's angles */
+                                         0.0, 0.0,  /* joint's angular rates */
+                                         0.0, 0.0); /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(0.0, M_PI / 4.0, /* joint's angles */
+                                         0.0, 0.0,  /* joint's angular rates */
+                                         0.0, 0.0); /* joint's torques */
 
-  VerifyInverseDynamicsWithAppliedForces(
-      M_PI / 3.0, 0.0,   /* joint's angles */
-      0.0, 0.0,          /* joint's angular rates */
-      0.0, 0.0);         /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      M_PI / 3.0, M_PI / 2.0,  /* joint's angles */
-      0.0, 0.0,                /* joint's angular rates */
-      0.0, 0.0);               /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      M_PI / 3.0, M_PI / 3.0,  /* joint's angles */
-      0.0, 0.0,                /* joint's angular rates */
-      0.0, 0.0);               /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      M_PI / 3.0, M_PI / 4.0,  /* joint's angles */
-      0.0, 0.0,                /* joint's angular rates */
-      0.0, 0.0);               /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(M_PI / 3.0, 0.0, /* joint's angles */
+                                         0.0, 0.0,  /* joint's angular rates */
+                                         0.0, 0.0); /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(M_PI / 3.0,
+                                         M_PI / 2.0, /* joint's angles */
+                                         0.0, 0.0,   /* joint's angular rates */
+                                         0.0, 0.0);  /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(M_PI / 3.0,
+                                         M_PI / 3.0, /* joint's angles */
+                                         0.0, 0.0,   /* joint's angular rates */
+                                         0.0, 0.0);  /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(M_PI / 3.0,
+                                         M_PI / 4.0, /* joint's angles */
+                                         0.0, 0.0,   /* joint's angular rates */
+                                         0.0, 0.0);  /* joint's torques */
 
   // With non-zero velocities and zero torques:
-  VerifyInverseDynamicsWithAppliedForces(
-      -M_PI / 5.0, M_PI / 2.0,  /* joint's angles */
-      0.5, 1.0,                 /* joint's angular rates */
-      0.0, 0.0);                /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      -M_PI / 5.0, M_PI / 3.0,  /* joint's angles */
-      0.5, 1.0,                 /* joint's angular rates */
-      0.0, 0.0);                /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      -M_PI / 5.0, M_PI / 2.0,  /* joint's angles */
-      -1.5, 0.5,                /* joint's angular rates */
-      0.0, 0.0);                /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      -M_PI / 5.0, M_PI / 3.0,  /* joint's angles */
-      -1.5, 0.5,                /* joint's angular rates */
-      0.0, 0.0);                /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(-M_PI / 5.0,
+                                         M_PI / 2.0, /* joint's angles */
+                                         0.5, 1.0,   /* joint's angular rates */
+                                         0.0, 0.0);  /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(-M_PI / 5.0,
+                                         M_PI / 3.0, /* joint's angles */
+                                         0.5, 1.0,   /* joint's angular rates */
+                                         0.0, 0.0);  /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(-M_PI / 5.0,
+                                         M_PI / 2.0, /* joint's angles */
+                                         -1.5, 0.5,  /* joint's angular rates */
+                                         0.0, 0.0);  /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(-M_PI / 5.0,
+                                         M_PI / 3.0, /* joint's angles */
+                                         -1.5, 0.5,  /* joint's angular rates */
+                                         0.0, 0.0);  /* joint's torques */
 
   // With non-zero velocities and non-zero torques:
-  VerifyInverseDynamicsWithAppliedForces(
-      -M_PI / 5.0, M_PI / 2.0,  /* joint's angles */
-      0.5, 1.0,                 /* joint's angular rates */
-      0.5, 1.0);                /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      -M_PI / 5.0, M_PI / 2.0,  /* joint's angles */
-      0.5, 1.0,                 /* joint's angular rates */
-      0.5, -1.0);               /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      -M_PI / 5.0, M_PI / 2.0,  /* joint's angles */
-      0.5, 1.0,                 /* joint's angular rates */
-      -0.5, 1.0);               /* joint's torques */
-  VerifyInverseDynamicsWithAppliedForces(
-      -M_PI / 5.0, M_PI / 2.0,  /* joint's angles */
-      0.5, 1.0,                 /* joint's angular rates */
-      -0.5, -1.0);              /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(-M_PI / 5.0,
+                                         M_PI / 2.0, /* joint's angles */
+                                         0.5, 1.0,   /* joint's angular rates */
+                                         0.5, 1.0);  /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(-M_PI / 5.0,
+                                         M_PI / 2.0, /* joint's angles */
+                                         0.5, 1.0,   /* joint's angular rates */
+                                         0.5, -1.0); /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(-M_PI / 5.0,
+                                         M_PI / 2.0, /* joint's angles */
+                                         0.5, 1.0,   /* joint's angular rates */
+                                         -0.5, 1.0); /* joint's torques */
+  VerifyInverseDynamicsWithAppliedForces(-M_PI / 5.0,
+                                         M_PI / 2.0, /* joint's angles */
+                                         0.5, 1.0,   /* joint's angular rates */
+                                         -0.5, -1.0); /* joint's torques */
 }
 
 }  // namespace

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -173,18 +173,15 @@ class PendulumTests : public ::testing::Test {
     // frame U of the upper link.
     // In this case the frame is created explicitly from the body frame of
     // upper_link.
-    shoulder_outboard_frame_ =
-        &model_->AddFrame<FixedOffsetFrame>(
-            "So", upper_link_->body_frame(), X_USo_);
+    shoulder_outboard_frame_ = &model_->AddFrame<FixedOffsetFrame>(
+        "So", upper_link_->body_frame(), X_USo_);
 
     // Adds the shoulder and elbow mobilizers of the pendulum.
     // Using:
     //  const Mobilizer& AddMobilizer(std::unique_ptr<MobilizerType> mobilizer).
-    shoulder_joint_ =
-        &model_->AddJoint(
-            make_unique<RevoluteJoint<double>>("shoulder",
-                *shoulder_inboard_frame_, *shoulder_outboard_frame_,
-                Vector3d::UnitZ() /*revolute axis*/));
+    shoulder_joint_ = &model_->AddJoint(make_unique<RevoluteJoint<double>>(
+        "shoulder", *shoulder_inboard_frame_, *shoulder_outboard_frame_,
+        Vector3d::UnitZ() /*revolute axis*/));
 
     // The elbow is the mobilizer that connects upper and lower links.
     // Below we will create inboard and outboard frames associated with the
@@ -204,10 +201,9 @@ class PendulumTests : public ::testing::Test {
     // frame (Eo) and connecting them with a Joint, we'll let the
     // MultibodyTree::AddJoint() method do that for us:
     elbow_joint_ = &model_->AddJoint<RevoluteJoint>(
-        "ElbowJoint",
-        *upper_link_, X_UEi_, /* Pose of Ei in U. */
-        *lower_link_, {},     /* No pose provided, frame Eo IS frame L. */
-        Vector3d::UnitZ()     /* revolute axis */);
+        "ElbowJoint", *upper_link_, X_UEi_, /* Pose of Ei in U. */
+        *lower_link_, {}, /* No pose provided, frame Eo IS frame L. */
+        Vector3d::UnitZ() /* revolute axis */);
     elbow_inboard_frame_ = &elbow_joint_->frame_on_parent();
     elbow_outboard_frame_ = &elbow_joint_->frame_on_child();
     EXPECT_EQ(elbow_joint_->name(), "ElbowJoint");
@@ -226,8 +222,7 @@ class PendulumTests : public ::testing::Test {
   // Helper method to extract a pose from the position kinematics.
   template <typename T>
   static const RigidTransform<T> get_body_pose_in_world(
-      const MultibodyTree<T>& tree,
-      const PositionKinematicsCache<T>& pc,
+      const MultibodyTree<T>& tree, const PositionKinematicsCache<T>& pc,
       const RigidBody<T>& body) {
     const MultibodyTreeTopology& topology = tree.get_topology();
     // Cache entries are accessed by MobodIndex for fast traversals.
@@ -326,12 +321,8 @@ TEST_F(PendulumTests, CreateModelBasics) {
   EXPECT_EQ(model_->num_mobilizers(), 0);
 
   // Check that frames are associated with the correct bodies.
-  EXPECT_EQ(
-      shoulder_inboard_frame_->body().index(),
-      world_body_->index());
-  EXPECT_EQ(
-      shoulder_outboard_frame_->body().index(),
-      upper_link_->index());
+  EXPECT_EQ(shoulder_inboard_frame_->body().index(), world_body_->index());
+  EXPECT_EQ(shoulder_outboard_frame_->body().index(), upper_link_->index());
 
   // Checks we can retrieve the body associated with a frame.
   EXPECT_EQ(&shoulder_inboard_frame_->body(), world_body_);
@@ -353,10 +344,8 @@ TEST_F(PendulumTests, CreateModelBasics) {
             shoulder_outboard_frame_->index());
 
   // Checks that mobilizers connect the right bodies.
-  EXPECT_EQ(shoulder_mobilizer_->inboard_body().index(),
-            world_body_->index());
-  EXPECT_EQ(shoulder_mobilizer_->outboard_body().index(),
-            upper_link_->index());
+  EXPECT_EQ(shoulder_mobilizer_->inboard_body().index(), world_body_->index());
+  EXPECT_EQ(shoulder_mobilizer_->outboard_body().index(), upper_link_->index());
 
   // Checks we can request inboard/outboard bodies to a mobilizer.
   EXPECT_EQ(&shoulder_mobilizer_->inboard_body(), world_body_);
@@ -367,20 +356,16 @@ TEST_F(PendulumTests, CreateModelBasics) {
 
   EXPECT_EQ(model_->num_mobilizers(), 3);
   // Check that frames are associated with the correct bodies.
-  EXPECT_EQ(
-      elbow_inboard_frame_->body().index(), upper_link_->index());
-  EXPECT_EQ(
-      elbow_outboard_frame_->body().index(), lower_link_->index());
+  EXPECT_EQ(elbow_inboard_frame_->body().index(), upper_link_->index());
+  EXPECT_EQ(elbow_outboard_frame_->body().index(), lower_link_->index());
   // Checks that mobilizers connect the right frames.
   EXPECT_EQ(elbow_mobilizer_->inboard_frame().index(),
             elbow_inboard_frame_->index());
   EXPECT_EQ(elbow_mobilizer_->outboard_frame().index(),
             elbow_outboard_frame_->index());
   // Checks that mobilizers connect the right bodies.
-  EXPECT_EQ(elbow_mobilizer_->inboard_body().index(),
-            upper_link_->index());
-  EXPECT_EQ(elbow_mobilizer_->outboard_body().index(),
-            lower_link_->index());
+  EXPECT_EQ(elbow_mobilizer_->inboard_body().index(), upper_link_->index());
+  EXPECT_EQ(elbow_mobilizer_->outboard_body().index(), lower_link_->index());
   // Checks we can retrieve the body associated with a frame.
   EXPECT_EQ(&elbow_inboard_frame_->body(), upper_link_);
   EXPECT_EQ(&elbow_outboard_frame_->body(), lower_link_);
@@ -408,8 +393,7 @@ TEST_F(PendulumTests, Indexes) {
   EXPECT_EQ(elbow_inboard_frame_->index(), FrameIndex(4));
   EXPECT_EQ(elbow_outboard_frame_->index(), FrameIndex(2));
   // Verifies the elbow's outboard frame IS the lower link's frame.
-  EXPECT_EQ(elbow_outboard_frame_->index(),
-            lower_link_->body_frame().index());
+  EXPECT_EQ(elbow_outboard_frame_->index(), lower_link_->body_frame().index());
 }
 
 // Asserts that the Finalize() stage is successful and that re-finalization is
@@ -424,12 +408,12 @@ TEST_F(PendulumTests, Finalize) {
   // Asserts that no more multibody elements can be added after finalize.
   const auto M_Bo_B = SpatialInertia<double>::NaN();
   EXPECT_THROW(model_->AddRigidBody("B", M_Bo_B), std::logic_error);
-  EXPECT_THROW(
-      model_->AddFrame<FixedOffsetFrame>("F", *lower_link_, X_LEo_),
-      std::logic_error);
+  EXPECT_THROW(model_->AddFrame<FixedOffsetFrame>("F", *lower_link_, X_LEo_),
+               std::logic_error);
   EXPECT_THROW(model_->AddJoint(make_unique<RevoluteJoint<double>>(
-      "joint_name", *shoulder_inboard_frame_, *shoulder_outboard_frame_,
-      Vector3d::UnitZ())), std::logic_error);
+                   "joint_name", *shoulder_inboard_frame_,
+                   *shoulder_outboard_frame_, Vector3d::UnitZ())),
+               std::logic_error);
 
   // Asserts re-finalization is not allowed.
   EXPECT_THROW(model_->Finalize(), std::logic_error);
@@ -500,10 +484,8 @@ TEST_F(PendulumTests, CreateContext) {
   SetPendulumPoses(&pc);
 
   // Retrieve body poses from position kinematics cache.
-  const RigidTransformd X_WW =
-      get_body_pose_in_world(tree, pc, *world_body_);
-  const RigidTransformd X_WLu =
-      get_body_pose_in_world(tree, pc, *upper_link_);
+  const RigidTransformd X_WW = get_body_pose_in_world(tree, pc, *world_body_);
+  const RigidTransformd X_WLu = get_body_pose_in_world(tree, pc, *upper_link_);
 
   // Asserts that the retrieved poses match with the ones specified by the unit
   // test method SetPendulumPoses().
@@ -542,8 +524,8 @@ class PendulumKinematicTests : public PendulumTests {
   ///
   /// The solution is verified against the independent benchmark from
   /// drake::multibody::benchmarks::Acrobot.
-  void VerifyMassMatrixViaInverseDynamics(
-      double shoulder_angle, double elbow_angle) {
+  void VerifyMassMatrixViaInverseDynamics(double shoulder_angle,
+                                          double elbow_angle) {
     shoulder_mobilizer_->SetAngle(context_.get(), shoulder_angle);
     elbow_mobilizer_->SetAngle(context_.get(), elbow_angle);
 
@@ -557,8 +539,8 @@ class PendulumKinematicTests : public PendulumTests {
   /// Verifies the results from MultibodyTree::CalcInverseDynamics() for a
   /// number of state configurations against the independently coded
   /// implementation in drake::multibody::benchmarks::Acrobot.
-  void VerifyCoriolisTermViaInverseDynamics(
-      double shoulder_angle, double elbow_angle) {
+  void VerifyCoriolisTermViaInverseDynamics(double shoulder_angle,
+                                            double elbow_angle) {
     const double kTolerance = 5 * kEpsilon;
 
     shoulder_mobilizer_->SetAngle(context_.get(), shoulder_angle);
@@ -575,9 +557,9 @@ class PendulumKinematicTests : public PendulumTests {
     elbow_mobilizer_->SetAngularRate(context_.get(), elbow_rate);
     tree().CalcBiasTerm(*context_, &C);
     C_expected = acrobot_benchmark_.CalcCoriolisVector(
-            shoulder_angle, elbow_angle, shoulder_rate, elbow_rate);
-    EXPECT_TRUE(CompareMatrices(
-        C, C_expected, kTolerance, MatrixCompareType::relative));
+        shoulder_angle, elbow_angle, shoulder_rate, elbow_rate);
+    EXPECT_TRUE(CompareMatrices(C, C_expected, kTolerance,
+                                MatrixCompareType::relative));
 
     // First column of C(q, e_1) times e_1.
     shoulder_rate = 1.0;
@@ -587,8 +569,8 @@ class PendulumKinematicTests : public PendulumTests {
     tree().CalcBiasTerm(*context_, &C);
     C_expected = acrobot_benchmark_.CalcCoriolisVector(
         shoulder_angle, elbow_angle, shoulder_rate, elbow_rate);
-    EXPECT_TRUE(CompareMatrices(
-        C, C_expected, kTolerance, MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(C, C_expected, kTolerance,
+                                MatrixCompareType::relative));
 
     // Second column of C(q, e_2) times e_2.
     shoulder_rate = 0.0;
@@ -598,8 +580,8 @@ class PendulumKinematicTests : public PendulumTests {
     tree().CalcBiasTerm(*context_, &C);
     C_expected = acrobot_benchmark_.CalcCoriolisVector(
         shoulder_angle, elbow_angle, shoulder_rate, elbow_rate);
-    EXPECT_TRUE(CompareMatrices(
-        C, C_expected, kTolerance, MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(C, C_expected, kTolerance,
+                                MatrixCompareType::relative));
 
     // Both velocities are non-zero.
     shoulder_rate = 1.0;
@@ -609,8 +591,8 @@ class PendulumKinematicTests : public PendulumTests {
     tree().CalcBiasTerm(*context_, &C);
     C_expected = acrobot_benchmark_.CalcCoriolisVector(
         shoulder_angle, elbow_angle, shoulder_rate, elbow_rate);
-    EXPECT_TRUE(CompareMatrices(
-        C, C_expected, kTolerance, MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(C, C_expected, kTolerance,
+                                MatrixCompareType::relative));
   }
 
   /// This method verifies the correctness of
@@ -620,8 +602,7 @@ class PendulumKinematicTests : public PendulumTests {
   /// denoted by tau_g(q).
   /// The solution is verified against the independent benchmark from
   /// drake::multibody::benchmarks::Acrobot.
-  Vector2d VerifyGravityTerm(
-      const Eigen::Ref<const VectorXd>& q) const {
+  Vector2d VerifyGravityTerm(const Eigen::Ref<const VectorXd>& q) const {
     DRAKE_DEMAND(q.size() == tree().num_positions());
 
     // This is the minimum factor of the machine precision within which these
@@ -630,8 +611,8 @@ class PendulumKinematicTests : public PendulumTests {
     const int kEpsilonFactor = 20;
     const double kTolerance = kEpsilonFactor * kEpsilon;
 
-    const double shoulder_angle =  q(0);
-    const double elbow_angle =  q(1);
+    const double shoulder_angle = q(0);
+    const double elbow_angle = q(1);
 
     PositionKinematicsCache<double> pc(tree().get_topology());
     VelocityKinematicsCache<double> vc(tree().get_topology());
@@ -668,8 +649,8 @@ class PendulumKinematicTests : public PendulumTests {
 
     // ======================================================================
     // Compute expected values using the acrobot benchmark.
-    const Vector2d tau_g_expected = acrobot_benchmark_.CalcGravityVector(
-        shoulder_angle, elbow_angle);
+    const Vector2d tau_g_expected =
+        acrobot_benchmark_.CalcGravityVector(shoulder_angle, elbow_angle);
 
     // ======================================================================
     // Notice that we do not need to allocate extra memory since both
@@ -689,18 +670,17 @@ class PendulumKinematicTests : public PendulumTests {
     // Initialize output to garbage, it should not affect the results.
     tau.setConstant(std::numeric_limits<double>::quiet_NaN());
     tau_applied.setZero();
-    tree().CalcInverseDynamics(
-        *context_, vdot, Fapplied_Bo_W_array, tau_applied,
-        &A_WB_array, &F_BMo_W_array, &tau);
+    tree().CalcInverseDynamics(*context_, vdot, Fapplied_Bo_W_array,
+                               tau_applied, &A_WB_array, &F_BMo_W_array, &tau);
     // The result from inverse dynamics must be tau = -tau_g(q).
     EXPECT_TRUE(tau.isApprox(-tau_g_expected, kTolerance));
 
     // Now try using the same arrays for input/output (input data
     // Fapplied_Bo_W_array will get overwritten through the output argument).
     tau_applied.setZero();  // This will now get overwritten.
-    tree().CalcInverseDynamics(
-        *context_, vdot, Fapplied_Bo_W_array, tau_applied,
-        &A_WB_array, &Fapplied_Bo_W_array, &tau_applied);
+    tree().CalcInverseDynamics(*context_, vdot, Fapplied_Bo_W_array,
+                               tau_applied, &A_WB_array, &Fapplied_Bo_W_array,
+                               &tau_applied);
     // The result from inverse dynamics must be tau = -tau_g(q).
     EXPECT_TRUE(tau.isApprox(-tau_g_expected, kTolerance));
 
@@ -739,11 +719,19 @@ class PendulumKinematicTests : public PendulumTests {
   std::unique_ptr<MultibodyTreeSystem<double>> system_;
   std::unique_ptr<Context<double>> context_;
   // Reference benchmark for verification.
-  Acrobot<double> acrobot_benchmark_{
-      Vector3d::UnitZ() /* Plane normal */, Vector3d::UnitY() /* Up vector */,
-      link1_mass_, link2_mass_,
-      link1_length_, link2_length_, half_link1_length_, half_link2_length_,
-      link1_Ic_, link2_Ic_, 0.0, 0.0, acceleration_of_gravity_};
+  Acrobot<double> acrobot_benchmark_{Vector3d::UnitZ() /* Plane normal */,
+                                     Vector3d::UnitY() /* Up vector */,
+                                     link1_mass_,
+                                     link2_mass_,
+                                     link1_length_,
+                                     link2_length_,
+                                     half_link1_length_,
+                                     half_link2_length_,
+                                     link1_Ic_,
+                                     link2_Ic_,
+                                     0.0,
+                                     0.0,
+                                     acceleration_of_gravity_};
 
  private:
   // This method verifies the correctness of
@@ -757,10 +745,9 @@ class PendulumKinematicTests : public PendulumTests {
   // method.
   // The solution is verified against the independent benchmark from
   // drake::multibody::benchmarks::Acrobot.
-  Vector2d VerifyInverseDynamics(
-      const Eigen::Ref<const VectorXd>& q,
-      const Eigen::Ref<const VectorXd>& v,
-      const Eigen::Ref<const VectorXd>& vdot) const {
+  Vector2d VerifyInverseDynamics(const Eigen::Ref<const VectorXd>& q,
+                                 const Eigen::Ref<const VectorXd>& v,
+                                 const Eigen::Ref<const VectorXd>& vdot) const {
     DRAKE_DEMAND(q.size() == tree().num_positions());
     DRAKE_DEMAND(v.size() == tree().num_velocities());
     DRAKE_DEMAND(vdot.size() == tree().num_velocities());
@@ -771,8 +758,8 @@ class PendulumKinematicTests : public PendulumTests {
     const int kEpsilonFactor = 30;
     const double kTolerance = kEpsilonFactor * kEpsilon;
 
-    const double shoulder_angle =  q(0);
-    const double elbow_angle =  q(1);
+    const double shoulder_angle = q(0);
+    const double elbow_angle = q(1);
 
     const double shoulder_angle_rate = v(0);
     const double elbow_angle_rate = v(1);
@@ -797,8 +784,8 @@ class PendulumKinematicTests : public PendulumTests {
     VectorXd tau(tree().num_velocities());
     vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
     vector<SpatialForce<double>> F_BMo_W_array(tree().num_bodies());
-    tree().CalcInverseDynamics(*context_, vdot, {}, VectorXd(),
-                                &A_WB_array, &F_BMo_W_array, &tau);
+    tree().CalcInverseDynamics(*context_, vdot, {}, VectorXd(), &A_WB_array,
+                               &F_BMo_W_array, &tau);
 
     // ======================================================================
     // Compute acceleration kinematics.
@@ -848,8 +835,7 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
   // Test mobilizer's setter/getters.
   shoulder_mobilizer_->SetAngle(context_.get(), M_PI);
   EXPECT_EQ(shoulder_mobilizer_->get_angle(*context_), M_PI);
-  shoulder_mobilizer_->SetZeroState(*context_,
-                                    &context_->get_mutable_state());
+  shoulder_mobilizer_->SetZeroState(*context_, &context_->get_mutable_state());
   EXPECT_EQ(shoulder_mobilizer_->get_angle(*context_), 0.0);
 
   PositionKinematicsCache<double> pc(tree().get_topology());
@@ -889,8 +875,7 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
       // Verify that both, const and mutable versions point to the same address.
       EXPECT_EQ(&pc.get_X_FM(shoulder_node),
                 &pc.get_mutable_X_FM(shoulder_node));
-      EXPECT_EQ(&pc.get_X_FM(elbow_node),
-                &pc.get_mutable_X_FM(elbow_node));
+      EXPECT_EQ(&pc.get_X_FM(elbow_node), &pc.get_mutable_X_FM(elbow_node));
 
       // Retrieve body poses from position kinematics cache.
       const RigidTransformd X_WW =
@@ -909,15 +894,14 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
 
       // Asserts that the retrieved poses match with the ones specified by the
       // unit test method SetPendulumPoses().
-      EXPECT_TRUE(CompareMatrices(X_WW.GetAsMatrix4(),
-                                  Matrix4d::Identity(),
+      EXPECT_TRUE(CompareMatrices(X_WW.GetAsMatrix4(), Matrix4d::Identity(),
                                   kTolerance, MatrixCompareType::relative));
       EXPECT_TRUE(CompareMatrices(X_WU.GetAsMatrix34(),
-                                  X_WU_expected.GetAsMatrix34(),
-                                  kTolerance, MatrixCompareType::relative));
+                                  X_WU_expected.GetAsMatrix34(), kTolerance,
+                                  MatrixCompareType::relative));
       EXPECT_TRUE(CompareMatrices(X_WL.GetAsMatrix34(),
-                                  X_WL_expected.GetAsMatrix34(),
-                                  kTolerance, MatrixCompareType::relative));
+                                  X_WL_expected.GetAsMatrix34(), kTolerance,
+                                  MatrixCompareType::relative));
     }
   }
 }
@@ -960,8 +944,7 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
 
       // Set the shoulder's angular velocity.
       const double shoulder_angle_rate = 1.0;
-      shoulder_mobilizer_->SetAngularRate(context_.get(),
-                                          shoulder_angle_rate);
+      shoulder_mobilizer_->SetAngularRate(context_.get(), shoulder_angle_rate);
       EXPECT_EQ(shoulder_mobilizer_->get_angular_rate(*context_),
                 shoulder_angle_rate);
 
@@ -985,8 +968,8 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
               shoulder_angle, shoulder_angle_rate));
       const SpatialVelocity<double> V_WLcm_expected(
           acrobot_benchmark_.CalcLink2SpatialVelocityInWorldFrame(
-              shoulder_angle, elbow_angle,
-              shoulder_angle_rate, elbow_angle_rate));
+              shoulder_angle, elbow_angle, shoulder_angle_rate,
+              elbow_angle_rate));
 
       EXPECT_TRUE(V_WUcm.IsApprox(V_WUcm_expected, kTolerance));
       EXPECT_TRUE(V_WLcm.IsApprox(V_WLcm_expected, kTolerance));
@@ -1016,25 +999,22 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
 
       SpatialAcceleration<double> A_WLcm_expected(
           acrobot_benchmark_.CalcLink2SpatialAccelerationInWorldFrame(
-              shoulder_angle, elbow_angle,
-              shoulder_angle_rate, elbow_angle_rate,
-              vdot(0), vdot(1)));
+              shoulder_angle, elbow_angle, shoulder_angle_rate,
+              elbow_angle_rate, vdot(0), vdot(1)));
 
       EXPECT_TRUE(A_WUcm.IsApprox(A_WUcm_expected, kTolerance));
       EXPECT_TRUE(A_WLcm.IsApprox(A_WLcm_expected, kTolerance));
 
       // For a non-zero vdot [rad/sec^2]:
-      shoulder_mobilizer_->get_mutable_accelerations_from_array(
-          &vdot)(0) = -1.0;
-      elbow_mobilizer_->get_mutable_accelerations_from_array(&vdot)(0) = 2.0;
-      EXPECT_EQ(
-          shoulder_mobilizer_->get_accelerations_from_array(vdot).size(), 1);
-      EXPECT_EQ(
-          shoulder_mobilizer_->get_accelerations_from_array(vdot)(0), -1.0);
-      EXPECT_EQ(
-          elbow_mobilizer_->get_accelerations_from_array(vdot).size(), 1);
-      EXPECT_EQ(
-          elbow_mobilizer_->get_accelerations_from_array(vdot)(0), 2.0);
+      shoulder_mobilizer_->get_mutable_accelerations_from_array (&vdot)(0) =
+          -1.0;
+      elbow_mobilizer_->get_mutable_accelerations_from_array (&vdot)(0) = 2.0;
+      EXPECT_EQ(shoulder_mobilizer_->get_accelerations_from_array(vdot).size(),
+                1);
+      EXPECT_EQ(shoulder_mobilizer_->get_accelerations_from_array(vdot)(0),
+                -1.0);
+      EXPECT_EQ(elbow_mobilizer_->get_accelerations_from_array(vdot).size(), 1);
+      EXPECT_EQ(elbow_mobilizer_->get_accelerations_from_array(vdot)(0), 2.0);
 
       tree().CalcAccelerationKinematicsCache(*context_, pc, vc, vdot, &ac);
 
@@ -1049,9 +1029,8 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
 
       A_WLcm_expected = SpatialAcceleration<double>(
           acrobot_benchmark_.CalcLink2SpatialAccelerationInWorldFrame(
-              shoulder_angle, elbow_angle,
-              shoulder_angle_rate, elbow_angle_rate,
-              vdot(0), vdot(1)));
+              shoulder_angle, elbow_angle, shoulder_angle_rate,
+              elbow_angle_rate, vdot(0), vdot(1)));
 
       EXPECT_TRUE(A_WUcm.IsApprox(A_WUcm_expected, kTolerance));
       EXPECT_TRUE(A_WLcm.IsApprox(A_WLcm_expected, kTolerance));
@@ -1179,10 +1158,10 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
       for (double iq_shoulder = 0; iq_shoulder < num_angles; ++iq_shoulder) {
         const AutoDiffXd shoulder_angle(
             -M_PI + iq_shoulder * kDeltaAngle, /* angle value */
-            Vector1<double>::Constant(w_WU)  /* angular velocity */);
+            Vector1<double>::Constant(w_WU) /* angular velocity */);
         for (double iq_elbow = 0; iq_elbow < num_angles; ++iq_elbow) {
           const AutoDiffXd elbow_angle(
-              -M_PI + iq_elbow * kDeltaAngle,   /* angle value */
+              -M_PI + iq_elbow * kDeltaAngle, /* angle value */
               Vector1<double>::Constant(w_UL) /* angular velocity */);
 
           // Update position kinematics.
@@ -1252,31 +1231,28 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
           const AutoDiffXd V =
               tree_autodiff.CalcPotentialEnergy(*context_autodiff);
           const double V_value = V.value();
-          const double V_expected =
-              acrobot_benchmark_.CalcPotentialEnergy(
-                  shoulder_angle.value(), elbow_angle.value());
+          const double V_expected = acrobot_benchmark_.CalcPotentialEnergy(
+              shoulder_angle.value(), elbow_angle.value());
           EXPECT_NEAR(V_value, V_expected, kTolerance);
 
           // Since in this case the only force is that of gravity, the time
           // derivative of the total potential energy must equal the total
           // conservative power.
-          shoulder_mobilizer_->SetAngle(
-              context_.get(), shoulder_angle.value());
-          shoulder_mobilizer_->SetAngularRate(
-              context_.get(), shoulder_angle.derivatives()[0]);
-          elbow_mobilizer_->SetAngle(
-              context_.get(), elbow_angle.value());
-          elbow_mobilizer_->SetAngularRate(
-              context_.get(), elbow_angle.derivatives()[0]);
+          shoulder_mobilizer_->SetAngle(context_.get(), shoulder_angle.value());
+          shoulder_mobilizer_->SetAngularRate(context_.get(),
+                                              shoulder_angle.derivatives()[0]);
+          elbow_mobilizer_->SetAngle(context_.get(), elbow_angle.value());
+          elbow_mobilizer_->SetAngularRate(context_.get(),
+                                           elbow_angle.derivatives()[0]);
           const double Pc = tree().CalcConservativePower(*context_);
 
           // Notice we define Pc = -d(Pc)/dt.
           const double Pc_from_autodiff = -V.derivatives()[0];
           EXPECT_NEAR(Pc, Pc_from_autodiff, kTolerance);
         }  // ielbow
-      }  // ishoulder
-    }  // iw_elbow
-  }  // iw_shoulder
+      }    // ishoulder
+    }      // iw_elbow
+  }        // iw_shoulder
 }
 
 TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
@@ -1292,44 +1268,40 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
   Matrix3X<double> p_LQi_set(3, 3);
   p_LQi_set.col(0) << 0.0, -2.0, 0.0;  // At the end effector.
   p_LQi_set.col(1) << 0.0, -1.0, 0.0;  // In the middle of the lower link.
-  p_LQi_set.col(2) << 0.0,  0.0, 0.0;  // At the elbow.
+  p_LQi_set.col(2) << 0.0, 0.0, 0.0;   // At the elbow.
 
   // World positions of the set of points Qi:
   Matrix3X<double> p_WQi_set(3, 3);
-  tree().CalcPointsPositions(
-      *context_,
-      lower_link_->body_frame(), p_LQi_set,
-      tree().world_frame(), &p_WQi_set);
+  tree().CalcPointsPositions(*context_, lower_link_->body_frame(), p_LQi_set,
+                             tree().world_frame(), &p_WQi_set);
 
   Matrix3X<double> p_WQi_set_expected(3, 3);
   p_WQi_set_expected.col(0) << 2.0 + M_SQRT1_2, -M_SQRT1_2, 0.0;
   p_WQi_set_expected.col(1) << 1.0 + M_SQRT1_2, -M_SQRT1_2, 0.0;
   p_WQi_set_expected.col(2) << M_SQRT1_2, -M_SQRT1_2, 0.0;
 
-  EXPECT_TRUE(CompareMatrices(
-      p_WQi_set, p_WQi_set_expected, kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(p_WQi_set, p_WQi_set_expected, kTolerance,
+                              MatrixCompareType::relative));
 
   // A scond set of points Pi but measured and expressed in the upper link's
   // frame U.
   Matrix3X<double> p_UPi_set(3, 3);
-  p_UPi_set.col(0) << 0.0,  1.0, 0.0;  // Projecting 0.5 out from the shoulder.
-  p_UPi_set.col(1) << 0.0,  0.0, 0.0;  // In the middle of the upper link.
+  p_UPi_set.col(0) << 0.0, 1.0, 0.0;   // Projecting 0.5 out from the shoulder.
+  p_UPi_set.col(1) << 0.0, 0.0, 0.0;   // In the middle of the upper link.
   p_UPi_set.col(2) << 0.0, -1.0, 0.0;  // Projecting 0.5 out from the elbow.
 
   // World positions of the set of points Qi:
   Matrix3X<double> p_WPi_set(3, 3);
-  tree().CalcPointsPositions(
-      *context_,
-      upper_link_->body_frame(), p_UPi_set,
-      tree().world_frame(), &p_WPi_set);
+  tree().CalcPointsPositions(*context_, upper_link_->body_frame(), p_UPi_set,
+                             tree().world_frame(), &p_WPi_set);
 
   Matrix3X<double> p_WPi_set_expected(3, 3);
   p_WPi_set_expected.col(0) = 0.5 * Vector3d(-M_SQRT1_2, M_SQRT1_2, 0.0);
   p_WPi_set_expected.col(1) = -0.5 * Vector3d(-M_SQRT1_2, M_SQRT1_2, 0.0);
   p_WPi_set_expected.col(2) = -1.5 * Vector3d(-M_SQRT1_2, M_SQRT1_2, 0.0);
 
-  EXPECT_TRUE(CompareMatrices(
-      p_WPi_set, p_WPi_set_expected, kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(p_WPi_set, p_WPi_set_expected, kTolerance,
+                              MatrixCompareType::relative));
 
   const Vector3d p_UL_expected(0.0, -0.5, 0.0);
   const Matrix3d R_UL_expected(Eigen::AngleAxisd(M_PI_4, Vector3d::UnitZ()));
@@ -1339,14 +1311,14 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
       *context_, upper_link_->body_frame(), lower_link_->body_frame()));
   EXPECT_TRUE(CompareMatrices(X_UL.rotation().matrix(), R_UL_expected,
                               kTolerance, MatrixCompareType::relative));
-  EXPECT_TRUE(CompareMatrices(X_UL.translation(), p_UL_expected,
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(X_UL.translation(), p_UL_expected, kTolerance,
+                              MatrixCompareType::relative));
 
   // Verify the RotationMatrix returned by CalcRelativeRotationMatrix().
   const RotationMatrixd R_UL = tree().CalcRelativeRotationMatrix(
       *context_, upper_link_->body_frame(), lower_link_->body_frame());
-  EXPECT_TRUE(CompareMatrices(R_UL.matrix(), R_UL_expected,
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(R_UL.matrix(), R_UL_expected, kTolerance,
+                              MatrixCompareType::relative));
 }
 
 TEST_F(PendulumKinematicTests, PointsHaveTheWrongSize) {
@@ -1359,10 +1331,10 @@ TEST_F(PendulumKinematicTests, PointsHaveTheWrongSize) {
 
   // World positions of the set of points Qi:
   Matrix3X<double> p_WQi_set(3, 3);
-  EXPECT_THROW(tree().CalcPointsPositions(
-      *context_,
-      lower_link_->body_frame(), p_LQi_set,
-      tree().world_frame(), &p_WQi_set), std::runtime_error);
+  EXPECT_THROW(
+      tree().CalcPointsPositions(*context_, lower_link_->body_frame(),
+                                 p_LQi_set, tree().world_frame(), &p_WQi_set),
+      std::runtime_error);
 }
 
 }  // namespace

--- a/multibody/tree/test/unit_inertia_test.cc
+++ b/multibody/tree/test/unit_inertia_test.cc
@@ -61,10 +61,10 @@ GTEST_TEST(UnitInertia, PrincipalAxesConstructor) {
 // off-diagonal elements for which the six entries need to be specified.
 // Also test SetZero() and SetNaN methods.
 GTEST_TEST(UnitInertia, GeneralConstructor) {
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
-  const Vector3d p(0.1, -0.1, 0.2);  // p for products.
-  UnitInertia<double> I(m(0), m(1), m(2), /* moments of inertia */
-                        p(0), p(1), p(2));/* products of inertia */
+  const Vector3d m(2.0, 2.3, 2.4);         // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);        // p for products.
+  UnitInertia<double> I(m(0), m(1), m(2),  /* moments of inertia */
+                        p(0), p(1), p(2)); /* products of inertia */
   Vector3d moments_expected = m;
   Vector3d products_expected = p;
   EXPECT_EQ(I.get_moments(), moments_expected);
@@ -81,7 +81,7 @@ GTEST_TEST(UnitInertia, GeneralConstructor) {
 
 // Test constructor from a RotationalInertia.
 GTEST_TEST(UnitInertia, ConstructorFromRotationalInertia) {
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
+  const Vector3d m(2.0, 2.3, 2.4);  // m for moments.
   RotationalInertia<double> I(m(0), m(1), m(2));
   UnitInertia<double> G(I);
   EXPECT_EQ(G.get_moments(), I.get_moments());
@@ -161,8 +161,8 @@ GTEST_TEST(UnitInertia, SolidEllipsoid) {
 GTEST_TEST(UnitInertia, SolidSphere) {
   const double radius = 3.5;
   const double sphere_I = 4.9;
-  const UnitInertia<double> G_expected = UnitInertia<double>::
-                                         TriaxiallySymmetric(sphere_I);
+  const UnitInertia<double> G_expected =
+      UnitInertia<double>::TriaxiallySymmetric(sphere_I);
   UnitInertia<double> G = UnitInertia<double>::SolidSphere(radius);
   EXPECT_TRUE(G_expected.get_moments() == G.get_moments());
   EXPECT_TRUE(G_expected.get_products() == G.get_products());
@@ -171,9 +171,9 @@ GTEST_TEST(UnitInertia, SolidSphere) {
 // Tests the static method to obtain the unit inertia of a hollow sphere.
 GTEST_TEST(UnitInertia, HollowSphere) {
   const double radius = 3.5;
-  const double sphere_I = 2.0 *radius * radius / 3.0;
-  const UnitInertia<double> G_expected = UnitInertia<double>::
-                                         TriaxiallySymmetric(sphere_I);
+  const double sphere_I = 2.0 * radius * radius / 3.0;
+  const UnitInertia<double> G_expected =
+      UnitInertia<double>::TriaxiallySymmetric(sphere_I);
   UnitInertia<double> G = UnitInertia<double>::HollowSphere(radius);
   EXPECT_TRUE(G_expected.get_moments() == G.get_moments());
   EXPECT_TRUE(G_expected.get_products() == G.get_products());
@@ -190,19 +190,19 @@ GTEST_TEST(UnitInertia, SolidBox) {
   const double Izz = (Lx2 + Ly2) / 12.0;
   const UnitInertia<double> G_expected(Ixx, Iyy, Izz);
   UnitInertia<double> G = UnitInertia<double>::SolidBox(Lx, Ly, Lz);
-  EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
-      G_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(
+      G.CopyToFullMatrix3().isApprox(G_expected.CopyToFullMatrix3(), kEpsilon));
 }
 
 // Tests the static method to obtain the unit inertia of a solid cube.
 GTEST_TEST(UnitInertia, SolidCube) {
   const double L = 1.5;
   const double I = L * L / 6.0;
-  const UnitInertia<double> G_expected = UnitInertia<double>::
-                                         TriaxiallySymmetric(I);
-    UnitInertia<double> G = UnitInertia<double>::SolidCube(L);
-  EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
-      G_expected.CopyToFullMatrix3(), kEpsilon));
+  const UnitInertia<double> G_expected =
+      UnitInertia<double>::TriaxiallySymmetric(I);
+  UnitInertia<double> G = UnitInertia<double>::SolidCube(L);
+  EXPECT_TRUE(
+      G.CopyToFullMatrix3().isApprox(G_expected.CopyToFullMatrix3(), kEpsilon));
 }
 
 // Tests the static method to obtain the unit inertia of a solid cylinder.
@@ -215,27 +215,26 @@ GTEST_TEST(UnitInertia, SolidCylinder) {
   // Compute the unit inertia for a cylinder oriented along the z-axis.
   UnitInertia<double> Gz =
       UnitInertia<double>::SolidCylinder(r, L, Vector3d::UnitZ());
-  EXPECT_TRUE(Gz.CopyToFullMatrix3().isApprox(
-      Gz_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(Gz.CopyToFullMatrix3().isApprox(Gz_expected.CopyToFullMatrix3(),
+                                              kEpsilon));
 
   // Compute the unit inertia for a cylinder oriented along the x-axis.
   const UnitInertia<double> Gx =
       UnitInertia<double>::SolidCylinder(r, L, Vector3d::UnitX());
   const UnitInertia<double> Gx_expected(I_axial, I_perp, I_perp);
-  EXPECT_TRUE(Gx.CopyToFullMatrix3().isApprox(
-      Gx_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(Gx.CopyToFullMatrix3().isApprox(Gx_expected.CopyToFullMatrix3(),
+                                              kEpsilon));
 
   // Compute the unit inertia for a cylinder oriented along the y-axis.
   const UnitInertia<double> Gy =
       UnitInertia<double>::SolidCylinder(r, L, Vector3d::UnitY());
   const UnitInertia<double> Gy_expected(I_perp, I_axial, I_perp);
-  EXPECT_TRUE(Gy.CopyToFullMatrix3().isApprox(
-      Gy_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(Gy.CopyToFullMatrix3().isApprox(Gy_expected.CopyToFullMatrix3(),
+                                              kEpsilon));
 
   // Compute the unit inertia for a cylinder oriented along a non-axial vector.
   const Vector3d v = Vector3d(1.0, 2.0, 3.0).normalized();
-  const UnitInertia<double> Gv =
-      UnitInertia<double>::SolidCylinder(r, L, v);
+  const UnitInertia<double> Gv = UnitInertia<double>::SolidCylinder(r, L, v);
   // Generate a rotation matrix from a Frame V in which Vz = v to frame Z where
   // Zz = zhat.
   const drake::math::RotationMatrix<double> R_ZV(
@@ -243,8 +242,8 @@ GTEST_TEST(UnitInertia, SolidCylinder) {
   // Generate expected solution by computing it in the V frame and re-expressing
   // in the Z frame.
   const UnitInertia<double> Gv_expected = Gz.ReExpress(R_ZV);
-  EXPECT_TRUE(Gv.CopyToFullMatrix3().isApprox(
-      Gv_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(Gv.CopyToFullMatrix3().isApprox(Gv_expected.CopyToFullMatrix3(),
+                                              kEpsilon));
 }
 
 // Tests the static method to obtain the unit inertia of a solid cylinder B
@@ -252,7 +251,7 @@ GTEST_TEST(UnitInertia, SolidCylinder) {
 GTEST_TEST(UnitInertia, SolidCylinderAboutEnd) {
   const double r = 2.5;
   const double L = 1.5;
-  const double I_perp = (3.0 * r * r + L * L) / 12.0 + L * L /4.0;
+  const double I_perp = (3.0 * r * r + L * L) / 12.0 + L * L / 4.0;
   const double I_axial = r * r / 2.0;
 
   // Create G_BBp_A, body B's unit inertia about point Bp expressed in terms of
@@ -353,7 +352,8 @@ GTEST_TEST(UnitInertia, SolidCapsule) {
   Ih.ShiftToThenAwayFromCenterOfMassInPlace(mh, p_HoHcm_C, p_HcmCcm_C);
 
   // Form the cylinder's inertia about its center of mass and verify results.
-  const RotationalInertia<double> I_cylinder = mass_cylinder *
+  const RotationalInertia<double> I_cylinder =
+      mass_cylinder *
       UnitInertia<double>::SolidCylinder(r, L, Vector3d::UnitZ());
   I_capsule = I_cylinder + 2 * Ih;
   EXPECT_TRUE(CompareMatrices(I_capsule.get_moments(),
@@ -442,8 +442,8 @@ GTEST_TEST(UnitInertia, AxiallySymmetric) {
   UnitInertia<double> G_E_expected = G_Z.ReExpress(R_EZ);
 
   // Verify the computed values.
-  EXPECT_TRUE(G_E.CopyToFullMatrix3().isApprox(
-      G_E_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(G_E.CopyToFullMatrix3().isApprox(G_E_expected.CopyToFullMatrix3(),
+                                               kEpsilon));
 
   // Verify the principal moments indeed are I_perp and I_axial:
   Vector3d moments = G_E.CalcPrincipalMomentsOfInertia();
@@ -481,8 +481,7 @@ GTEST_TEST(UnitInertia, ThinRod) {
       drake::math::RotationMatrix<double>::MakeXRotation(-M_PI_4);
 
   // Unit inertia computed with StraightLine().
-  UnitInertia<double> G_E =
-      UnitInertia<double>::StraightLine(I_rod, b_E);
+  UnitInertia<double> G_E = UnitInertia<double>::StraightLine(I_rod, b_E);
 
   // The expected inertia is that of a cylinder of zero radius and height L with
   // its longitudinal axis aligned with b.
@@ -491,8 +490,8 @@ GTEST_TEST(UnitInertia, ThinRod) {
   UnitInertia<double> G_E_expected = G_Z.ReExpress(R_EZ);
 
   // Verify the computed values.
-  EXPECT_TRUE(G_E.CopyToFullMatrix3().isApprox(
-      G_E_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(G_E.CopyToFullMatrix3().isApprox(G_E_expected.CopyToFullMatrix3(),
+                                               kEpsilon));
 
   // Verify the result from ThinRod():
   UnitInertia<double> G_rod = UnitInertia<double>::ThinRod(L, b_E);
@@ -588,8 +587,8 @@ GTEST_TEST(UnitInertia, SolidTetrahedronAboutPoint) {
   p_AB1 += p_AB0;
   p_AB2 += p_AB0;
   p_AB3 += p_AB0;
-  G_BA = UnitInertia<double>::SolidTetrahedronAboutPoint(
-      p_AB0, p_AB1, p_AB2, p_AB3);
+  G_BA = UnitInertia<double>::SolidTetrahedronAboutPoint(p_AB0, p_AB1, p_AB2,
+                                                         p_AB3);
 
   // Shift G_BA_expected from about-point B0 to about-point A.
   const Vector3<double> p_ABcm = p_AB0 + p_B0Bcm;
@@ -599,8 +598,8 @@ GTEST_TEST(UnitInertia, SolidTetrahedronAboutPoint) {
                               G_BA.CopyToFullMatrix3(), kTolerance));
 
   // Show no change if shuffle last 2 arguments to SolidTetrahedronAboutPoint().
-  G_BA = UnitInertia<double>::SolidTetrahedronAboutPoint(
-      p_AB0, p_AB1, p_AB3, p_AB2);
+  G_BA = UnitInertia<double>::SolidTetrahedronAboutPoint(p_AB0, p_AB1, p_AB3,
+                                                         p_AB2);
   EXPECT_TRUE(CompareMatrices(G_BA_expected.CopyToFullMatrix3(),
                               G_BA.CopyToFullMatrix3(), kTolerance));
 }
@@ -618,8 +617,8 @@ GTEST_TEST(UnitInertia, ShiftFromCenterOfMassInPlace) {
                                                  Vector3<double>::UnitZ());
   UnitInertia<double> G =
       UnitInertia<double>::SolidCylinder(r, L, Vector3<double>::UnitZ());
-  EXPECT_FALSE(G.CopyToFullMatrix3().isApprox(
-      G_expected.CopyToFullMatrix3(), kEpsilon));  // Not equal yet.
+  EXPECT_FALSE(G.CopyToFullMatrix3().isApprox(G_expected.CopyToFullMatrix3(),
+                                              kEpsilon));  // Not equal yet.
   G.ShiftFromCenterOfMassInPlace({0.0, 0.0, L / 2.0});
   EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
       G_expected.CopyToFullMatrix3(), kEpsilon));  // Equal after shifting.
@@ -633,16 +632,16 @@ GTEST_TEST(UnitInertia, ShiftFromCenterOfMassInPlace) {
   G.ShiftToCenterOfMassInPlace({0.0, 0.0, -L / 2.0});
   const UnitInertia<double> G_cylinder =
       UnitInertia<double>::SolidCylinder(r, L, Vector3<double>::UnitZ());
-  EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
-      G_cylinder.CopyToFullMatrix3(), kEpsilon));
-  EXPECT_TRUE(G2.CopyToFullMatrix3().isApprox(
-      G_cylinder.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(
+      G.CopyToFullMatrix3().isApprox(G_cylinder.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(G2.CopyToFullMatrix3().isApprox(G_cylinder.CopyToFullMatrix3(),
+                                              kEpsilon));
 
   // Create a new object.
   const UnitInertia<double> G3 =
       G_cylinder.ShiftFromCenterOfMass({0.0, 0.0, L / 2.0});
-  EXPECT_TRUE(G3.CopyToFullMatrix3().isApprox(
-      G_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(G3.CopyToFullMatrix3().isApprox(G_expected.CopyToFullMatrix3(),
+                                              kEpsilon));
   EXPECT_TRUE(G3.CouldBePhysicallyValid());
 }
 
@@ -659,13 +658,15 @@ GTEST_TEST(UnitInertia, CalcPrincipalHalfLengthsAndAxesForEquivalentShape) {
   // under test reproduces semi-diameters lmax = a, lmed = b, lmin = c.
   // Verify principal directions Ax, Ay, Az (R_BA is an identity matrix).
   const double shape_factor_solid_ellipsoid = 0.2;  // Inertia shape factor.
-  double Gmin = shape_factor_solid_ellipsoid * (b*b + c*c);  // 1/5 (b² + c²)
-  double Gmed = shape_factor_solid_ellipsoid * (a*a + c*c);  // 1/5 (a² + c²)
-  double Gmax = shape_factor_solid_ellipsoid * (a*a + b*b);  // 1/5 (a² + b²)
+  double Gmin =
+      shape_factor_solid_ellipsoid * (b * b + c * c);  // 1/5 (b² + c²)
+  double Gmed =
+      shape_factor_solid_ellipsoid * (a * a + c * c);  // 1/5 (a² + c²)
+  double Gmax =
+      shape_factor_solid_ellipsoid * (a * a + b * b);  // 1/5 (a² + b²)
   UnitInertia<double> G_BBcm_B = UnitInertia<double>(Gmin, Gmed, Gmax);
-  auto [abc, R_BA] =
-      G_BBcm_B.CalcPrincipalHalfLengthsAndAxesForEquivalentShape(
-          shape_factor_solid_ellipsoid);
+  auto [abc, R_BA] = G_BBcm_B.CalcPrincipalHalfLengthsAndAxesForEquivalentShape(
+      shape_factor_solid_ellipsoid);
   EXPECT_TRUE(CompareMatrices(Vector3<double>(a, b, c), abc, kTolerance));
   EXPECT_TRUE(R_BA.IsExactlyEqualTo(R_identity));
 
@@ -673,9 +674,10 @@ GTEST_TEST(UnitInertia, CalcPrincipalHalfLengthsAndAxesForEquivalentShape) {
   // under test reproduces half-lengths lmax = a, lmed = b, lmin = c.
   // Verify principal directions Ax, Ay, Az (R_BA is an identity matrix).
   const double shape_factor_solid_box = 1.0 / 3.0;  // Inertia shape factor.
-  Gmin = shape_factor_solid_box * (b*b + c*c);  // Gxx = 1/3 (b² + c²)  small
-  Gmed = shape_factor_solid_box * (a*a + c*c);  // Gyy = 1/3 (a² + c²)  medium
-  Gmax = shape_factor_solid_box * (a*a + b*b);  // Gzz = 1/3 (a² + b²)  large
+  Gmin = shape_factor_solid_box * (b * b + c * c);  // Gxx = 1/3 (b² + c²) small
+  Gmed =
+      shape_factor_solid_box * (a * a + c * c);  // Gyy = 1/3 (a² + c²)  medium
+  Gmax = shape_factor_solid_box * (a * a + b * b);  // Gzz = 1/3 (a² + b²) large
   G_BBcm_B = UnitInertia<double>(Gmin, Gmed, Gmax);
   std::tie(abc, R_BA) =
       G_BBcm_B.CalcPrincipalHalfLengthsAndAxesForEquivalentShape(
@@ -709,15 +711,15 @@ GTEST_TEST(UnitInertia, CalcPrincipalHalfLengthsAndAxesForEquivalentShape) {
           shape_factor_solid_ellipsoid);
   const double ratio =
       std::sqrt(shape_factor_solid_box / shape_factor_solid_ellipsoid);
-  EXPECT_NEAR(std::abs(ratio), std::sqrt(1.0/0.6), kTolerance);
-  EXPECT_TRUE(CompareMatrices(ratio * Vector3<double>(a, b, c),
-                              abc, kTolerance));
+  EXPECT_NEAR(std::abs(ratio), std::sqrt(1.0 / 0.6), kTolerance);
+  EXPECT_TRUE(
+      CompareMatrices(ratio * Vector3<double>(a, b, c), abc, kTolerance));
 
   // For a hollow sphere B, verify the function under test produces
   // semi-diameters lmax = a, lmed = a, lmin = a.
   // Verify principal directions Ax, Ay, Az (R_BA is an identity matrix).
   // For a hollow sphere with radius a, Gmin = Gmed = Gmax = 2/3 a².
-  const double shape_factor_hollow_ellipsoid = 1.0 /3.0;
+  const double shape_factor_hollow_ellipsoid = 1.0 / 3.0;
   const double G_hollow_sphere = 2.0 / 3.0 * a * a;
   G_BBcm_B =
       UnitInertia<double>(G_hollow_sphere, G_hollow_sphere, G_hollow_sphere);
@@ -750,8 +752,8 @@ GTEST_TEST(UnitInertia, CalcPrincipalHalfLengthsAndAxesForEquivalentShape) {
   // For a thin solid flat plate B, verify the function under test produces
   // lmax = a, lmed = b, lmin = 0 (plate dimensions).
   // Verify principal directions Ax, Ay, Az (R_BA is an identity matrix).
-  const double Imin_plate = 1.0 / 3.0 * b*b;          // Gxx = 1/12 (2*b)²
-  const double Imed_plate = 1.0 / 3.0 * a*a;          // Gyy = 1/12 (2*a)²
+  const double Imin_plate = 1.0 / 3.0 * b * b;        // Gxx = 1/12 (2*b)²
+  const double Imed_plate = 1.0 / 3.0 * a * a;        // Gyy = 1/12 (2*a)²
   const double Imax_plate = Imin_plate + Imed_plate;  // Gzz = 1/3 (a² + b²)
   G_BBcm_B = UnitInertia<double>(Imin_plate, Imed_plate, Imax_plate);
   std::tie(abc, R_BA) =
@@ -819,8 +821,8 @@ GTEST_TEST(UnitInertia, CastToAutoDiff) {
 GTEST_TEST(UnitInertia, AutoDiff) {
   // Helper lambda to extract from a matrix of auto-diff scalar's the matrix of
   // values and the matrix of derivatives.
-  auto extract_derivatives = [](
-      const Matrix3<AutoDiffXd>& M, Matrix3d& Mvalue, Matrix3d& Mdot) {
+  auto extract_derivatives = [](const Matrix3<AutoDiffXd>& M, Matrix3d& Mvalue,
+                                Matrix3d& Mdot) {
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
         Mvalue(i, j) = M(i, j).value();
@@ -859,11 +861,12 @@ GTEST_TEST(UnitInertia, AutoDiff) {
   // Therefore we have w× = Rdot * R.transpose().
   Matrix3<double> wcross = Rdot_WB * Rvalue_WB.transpose();
   Matrix3<double> wcross_expected;
+  // clang-format off
   wcross_expected << 0.0,  -wz, 0.0,
                       wz,  0.0, 0.0,
                      0.0,  0.0, 0.0;
-  EXPECT_TRUE(wcross.isApprox(
-      wcross_expected, kEpsilon));
+  // clang-format on
+  EXPECT_TRUE(wcross.isApprox(wcross_expected, kEpsilon));
 
   // Re-express inertia into another frame.
   const UnitInertia<AutoDiffXd> I_W = G_B.ReExpress(R_WB);
@@ -890,8 +893,7 @@ GTEST_TEST(UnitInertia, AutoDiff) {
 
   const Matrix3d Idot_W_expected = Ix * Rdot_x + Iy * Rdot_y + Iz * Rdot_z;
 
-  EXPECT_TRUE(Idot_W.isApprox(
-      Idot_W_expected, kEpsilon));
+  EXPECT_TRUE(Idot_W.isApprox(Idot_W_expected, kEpsilon));
 }
 
 // The code below is in support of the goal to use a unit-test to confirm that
@@ -903,20 +905,25 @@ GTEST_TEST(UnitInertia, AutoDiff) {
 // operator.
 
 // This overload gets chosen if the *= double would compile.
-template <typename T,
-    typename = decltype(std::declval<T&>() *= 1.)>
-bool has_times_equal_helper(int) { return true; }
+template <typename T, typename = decltype(std::declval<T&>() *= 1.)>
+bool has_times_equal_helper(int) {
+  return true;
+}
 
 // This overload gets chosen if the above can't compile.
 // It is made to take any other argument but the above is a better match to an
 // int argument if it got compiled, and therefore gets selected for a class with
 // an operator*=() defined.
 template <typename T>
-bool has_times_equal_helper(...) { return false; }
+bool has_times_equal_helper(...) {
+  return false;
+}
 
 // This method returns true at runtime if type T has an operator*=().
 template <typename T>
-bool has_times_equal() { return has_times_equal_helper<T>(1); }
+bool has_times_equal() {
+  return has_times_equal_helper<T>(1);
+}
 
 // Tests that operator*=() is indeed not available for a UnitInertia while it is
 // available for a general RotationalInertia.
@@ -930,13 +937,18 @@ GTEST_TEST(UnitInertia, TimesEqualScalar) {
 
 // See the explanation for these template helpers in the analogous
 // implementation for has_times_equal() above.
-template <typename T,
-    typename = decltype(std::declval<T&>() /= 1.)>
-bool has_divide_equal_helper(int) { return true; }
+template <typename T, typename = decltype(std::declval<T&>() /= 1.)>
+bool has_divide_equal_helper(int) {
+  return true;
+}
 template <typename T>
-bool has_divide_equal_helper(...) { return false; }
+bool has_divide_equal_helper(...) {
+  return false;
+}
 template <typename T>
-bool has_divide_equal() { return has_divide_equal_helper<T>(1); }
+bool has_divide_equal() {
+  return has_divide_equal_helper<T>(1);
+}
 
 // Tests that operator/=() is indeed not available for a UnitInertia while it is
 // available for a general RotationalInertia.
@@ -950,13 +962,18 @@ GTEST_TEST(UnitInertia, DivideEqualScalar) {
 
 // See the explanation for this template helpers in the analogous implementation
 // for has_times_equal() above.
-template <typename T,
-    typename = decltype(std::declval<T&>() += T())>
-bool has_plus_equal_helper(int) { return true; }
+template <typename T, typename = decltype(std::declval<T&>() += T())>
+bool has_plus_equal_helper(int) {
+  return true;
+}
 template <typename T>
-bool has_plus_equal_helper(...) { return false; }
+bool has_plus_equal_helper(...) {
+  return false;
+}
 template <typename T>
-bool has_plus_equal() { return has_plus_equal_helper<T>(1); }
+bool has_plus_equal() {
+  return has_plus_equal_helper<T>(1);
+}
 
 // Tests that operator+=() is indeed not available for a UnitInertia while it is
 // available for a general RotationalInertia.

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -60,7 +60,7 @@ class UniversalJointTest : public ::testing::Test {
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
     system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
-        std::move(model), true/* is_discrete */);
+        std::move(model), true /* is_discrete */);
     context_ = system_->CreateDefaultContext();
   }
 
@@ -288,8 +288,7 @@ TEST_F(UniversalJointTest, DefaultAngles) {
 
   // Setting the default angle out of the bounds of the position limits
   // should NOT throw an exception.
-  EXPECT_NO_THROW(
-      mutable_joint_->set_default_angles(out_of_bounds_low_angles));
+  EXPECT_NO_THROW(mutable_joint_->set_default_angles(out_of_bounds_low_angles));
   EXPECT_NO_THROW(
       mutable_joint_->set_default_angles(out_of_bounds_high_angles));
 }

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -12,9 +12,9 @@ namespace drake {
 namespace multibody {
 namespace {
 
-using math::RigidTransformd;
 using Eigen::Translation3d;
 using Eigen::Vector3d;
+using math::RigidTransformd;
 using systems::Context;
 
 class WeldJointTest : public ::testing::Test {
@@ -38,7 +38,7 @@ class WeldJointTest : public ::testing::Test {
     // We are done adding modeling elements. Transfer tree to system for
     // computation.
     system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
-        std::move(model), true/* is_discrete */);
+        std::move(model), true /* is_discrete */);
   }
 
   const internal::MultibodyTree<double>& tree() const {

--- a/multibody/tree/test/weld_mobilizer_test.cc
+++ b/multibody/tree/test/weld_mobilizer_test.cc
@@ -25,12 +25,13 @@ using systems::Context;
 constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 
 // Fixture to setup a simple MBT model containing a weld mobilizer.
-class WeldMobilizerTest :  public MobilizerTester {
+class WeldMobilizerTest : public MobilizerTester {
  public:
   void SetUp() override {
     weld_body_to_world_ = &AddJointAndFinalize<WeldJoint, WeldMobilizer>(
         std::make_unique<WeldJoint<double>>("joint0",
-            tree().world_body().body_frame(), body_->body_frame(), X_WB_));
+                                            tree().world_body().body_frame(),
+                                            body_->body_frame(), X_WB_));
   }
 
  protected:
@@ -52,8 +53,7 @@ TEST_F(WeldMobilizerTest, ZeroSizedState) {
 TEST_F(WeldMobilizerTest, CalcAcrossMobilizerTransform) {
   const math::RigidTransformd X_FM(
       weld_body_to_world_->CalcAcrossMobilizerTransform(*context_));
-  EXPECT_TRUE(CompareMatrices(X_FM.GetAsMatrix34(),
-                              X_WB_.GetAsMatrix34(),
+  EXPECT_TRUE(CompareMatrices(X_FM.GetAsMatrix34(), X_WB_.GetAsMatrix34(),
                               kTolerance, MatrixCompareType::relative));
 }
 
@@ -78,8 +78,8 @@ TEST_F(WeldMobilizerTest, ProjectSpatialForce) {
   // Value not important for this test.
   const SpatialForce<double> F_Mo_F(Vector6d::Zero());
   // No-op, just tests we can call it with a zero sized vector.
-  weld_body_to_world_->ProjectSpatialForce(
-      *context_, F_Mo_F, zero_sized_vector);
+  weld_body_to_world_->ProjectSpatialForce(*context_, F_Mo_F,
+                                           zero_sized_vector);
 }
 
 TEST_F(WeldMobilizerTest, MapVelocityToQDotAndBack) {
@@ -88,10 +88,10 @@ TEST_F(WeldMobilizerTest, MapVelocityToQDotAndBack) {
   VectorXd zero_sized_vector(0);
   // These methods are no-ops, just test we can call them with zero sized
   // vectors.
-  weld_body_to_world_->MapVelocityToQDot(*context_,
-                                         zero_sized_vector, &zero_sized_vector);
-  weld_body_to_world_->MapQDotToVelocity(*context_,
-                                         zero_sized_vector, &zero_sized_vector);
+  weld_body_to_world_->MapVelocityToQDot(*context_, zero_sized_vector,
+                                         &zero_sized_vector);
+  weld_body_to_world_->MapQDotToVelocity(*context_, zero_sized_vector,
+                                         &zero_sized_vector);
 }
 
 TEST_F(WeldMobilizerTest, KinematicMapping) {


### PR DESCRIPTION
Towards making multibody tree clang-format idempotent, this PR reformats all the multibody/tree test code.
There are many other files that need formatting, but I'm holding off to avoid merge nightmares with WIPs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21928)
<!-- Reviewable:end -->
