### PR TITLE
Reformat multibody/tree files and require clang-format idempotence

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -706,4 +706,4 @@ drake_cc_googletest(
     ],
 )
 
-add_lint_tests(enable_clang_format_lint = False)
+add_lint_tests()

--- a/multibody/tree/acceleration_kinematics_cache.h
+++ b/multibody/tree/acceleration_kinematics_cache.h
@@ -80,14 +80,10 @@ class AccelerationKinematicsCache {
 
   // Returns a constant reference to the generalized accelerations `vdot` for
   // the entire model.
-  const VectorX<T>& get_vdot() const {
-    return vdot_;
-  }
+  const VectorX<T>& get_vdot() const { return vdot_; }
 
   // Mutable version of get_vdot().
-  VectorX<T>& get_mutable_vdot() {
-    return vdot_;
-  }
+  VectorX<T>& get_mutable_vdot() { return vdot_; }
 
  private:
   // Pools store entries in the same order as the mobilized bodies (BodyNodes)
@@ -96,9 +92,7 @@ class AccelerationKinematicsCache {
   // `get_A_WB()` for instance.
 
   // Return the number of mobilized bodies in this multibody tree cache.
-  int get_num_mobods() const {
-    return static_cast<int>(A_WB_pool_.size());
-  }
+  int get_num_mobods() const { return static_cast<int>(A_WB_pool_.size()); }
 
   // Allocates resources for this acceleration kinematics cache.
   void Allocate(const MultibodyTreeTopology& topology) {

--- a/multibody/tree/articulated_body_force_cache.h
+++ b/multibody/tree/articulated_body_force_cache.h
@@ -22,16 +22,15 @@ namespace internal {
 // the force bias terms.
 //
 // @tparam_default_scalar
-template<typename T>
+template <typename T>
 class ArticulatedBodyForceCache {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ArticulatedBodyForceCache);
 
   // Constructs an %ArticulatedBodyForceCache object properly sized to
   // store the force bias terms for a model with the given `topology`.
-  explicit ArticulatedBodyForceCache(
-      const MultibodyTreeTopology& topology) :
-      num_mobods_(topology.num_mobods()) {
+  explicit ArticulatedBodyForceCache(const MultibodyTreeTopology& topology)
+      : num_mobods_(topology.num_mobods()) {
     Allocate();
   }
 

--- a/multibody/tree/articulated_body_inertia.h
+++ b/multibody/tree/articulated_body_inertia.h
@@ -90,7 +90,7 @@ namespace multibody {
 ///     Springer Science & Business Media.
 ///
 /// @tparam_default_scalar
-template<typename T>
+template <typename T>
 class ArticulatedBodyInertia {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ArticulatedBodyInertia);
@@ -188,7 +188,8 @@ class ArticulatedBodyInertia {
   IsPhysicallyValid() const {
     throw std::logic_error(
         "IsPhysicallyValid() is only supported for numeric types. It is not "
-        "supported for type '" + NiceTypeName::Get<T>() + "'.");
+        "supported for type '" +
+        NiceTypeName::Get<T>() + "'.");
     return false;  // Return something so that the compiler doesn't complain.
   }
 
@@ -252,7 +253,7 @@ class ArticulatedBodyInertia {
         matrix_.template block<3, 3>(3, 0).transpose();
     Eigen::Block<Matrix6<T>, 3, 3> Fp = matrix_.template block<3, 3>(0, 3);
     Matrix3<T> M = matrix_.template block<3, 3>(3, 3)
-        .template selfadjointView<Eigen::Lower>();
+                       .template selfadjointView<Eigen::Lower>();
 
     // Compute common term Fp = F + (p×)M.
     // The minus on p× is needed because we are doing each column times p×, in
@@ -308,8 +309,8 @@ class ArticulatedBodyInertia {
   /// @warning This operation is only valid if both articulated body inertias
   ///          are computed about the same point Q and expressed in the same
   ///          frame E.
-  ArticulatedBodyInertia<T>&
-  operator+=(const ArticulatedBodyInertia<T>& P_BQ_E) {
+  ArticulatedBodyInertia<T>& operator+=(
+      const ArticulatedBodyInertia<T>& P_BQ_E) {
     matrix_.template triangularView<Eigen::Lower>() = matrix_ + P_BQ_E.matrix_;
     return *this;
   }
@@ -318,8 +319,8 @@ class ArticulatedBodyInertia {
   /// for the same articulated body B as this ABI (about the same point Q and
   /// expressed in the same frame E). The resulting inertia will have the same
   /// properties.
-  ArticulatedBodyInertia<T>&
-  operator-=(const ArticulatedBodyInertia<T>& P_BQ_E) {
+  ArticulatedBodyInertia<T>& operator-=(
+      const ArticulatedBodyInertia<T>& P_BQ_E) {
     matrix_.template triangularView<Eigen::Lower>() = matrix_ - P_BQ_E.matrix_;
     return *this;
   }
@@ -330,7 +331,7 @@ class ArticulatedBodyInertia {
   /// @note This method does not evaluate the product immediately. Instead, it
   /// returns an intermediate Eigen quantity that can be optimized automatically
   /// during compile time.
-  template<typename OtherDerived>
+  template <typename OtherDerived>
   const Eigen::Product<Eigen::SelfAdjointView<const Matrix6<T>, Eigen::Lower>,
                        OtherDerived>
   operator*(const Eigen::MatrixBase<OtherDerived>& rhs) const {
@@ -349,9 +350,9 @@ class ArticulatedBodyInertia {
   /// @note This method does not evaluate the product immediately. Instead, it
   /// returns an intermediate Eigen quantity that can be optimized automatically
   /// during compile time.
-  template<typename OtherDerived> friend
-  const Eigen::Product<OtherDerived,
-                       Eigen::SelfAdjointView<const Matrix6<T>, Eigen::Lower>>
+  template <typename OtherDerived>
+  friend const Eigen::Product<
+      OtherDerived, Eigen::SelfAdjointView<const Matrix6<T>, Eigen::Lower>>
   operator*(const Eigen::MatrixBase<OtherDerived>& lhs,
             const ArticulatedBodyInertia& rhs) {
     return lhs * rhs.matrix_.template selfadjointView<Eigen::Lower>();
@@ -361,7 +362,8 @@ class ArticulatedBodyInertia {
   // Make ArticulatedBodyInertia templated on every other scalar type a friend
   // of ArticulatedBodyInertia<T> so that cast<Scalar>() can access private
   // members of ArticulatedBodyInertia<T>.
-  template <typename> friend class ArticulatedBodyInertia;
+  template <typename>
+  friend class ArticulatedBodyInertia;
 
   // Helper method for NaN initialization.
   static constexpr T nan() {

--- a/multibody/tree/articulated_body_inertia_cache.h
+++ b/multibody/tree/articulated_body_inertia_cache.h
@@ -30,29 +30,27 @@ namespace internal {
 // - The Kalman gain `g_PB_W = P_B_W * H_PB_W * D_B⁻¹`.
 //
 // @tparam_default_scalar
-template<typename T>
+template <typename T>
 class ArticulatedBodyInertiaCache {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ArticulatedBodyInertiaCache);
 
   // Constructs an articulated body cache entry for the given
   // MultibodyTreeTopology.
-  explicit ArticulatedBodyInertiaCache(const MultibodyTreeTopology& topology) :
-      num_mobods_(topology.num_mobods()) {
+  explicit ArticulatedBodyInertiaCache(const MultibodyTreeTopology& topology)
+      : num_mobods_(topology.num_mobods()) {
     Allocate();
   }
 
   // Articulated body inertia `P_B_W` of the body taken about Bo and expressed
   // in W.
-  const ArticulatedBodyInertia<T>& get_P_B_W(
-      MobodIndex mobod_index) const {
+  const ArticulatedBodyInertia<T>& get_P_B_W(MobodIndex mobod_index) const {
     DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
     return P_B_W_[mobod_index];
   }
 
   // Mutable version of get_P_B_W().
-  ArticulatedBodyInertia<T>& get_mutable_P_B_W(
-      MobodIndex mobod_index) {
+  ArticulatedBodyInertia<T>& get_mutable_P_B_W(MobodIndex mobod_index) {
     DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
     return P_B_W_[mobod_index];
   }
@@ -67,8 +65,7 @@ class ArticulatedBodyInertiaCache {
   }
 
   // Mutable version of get_Pplus_PB_W().
-  ArticulatedBodyInertia<T>& get_mutable_Pplus_PB_W(
-      MobodIndex mobod_index) {
+  ArticulatedBodyInertia<T>& get_mutable_Pplus_PB_W(MobodIndex mobod_index) {
     DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
     return Pplus_PB_W_[mobod_index];
   }
@@ -88,15 +85,13 @@ class ArticulatedBodyInertiaCache {
   }
 
   // The Kalman gain `g_PB_W` of the body.
-  const Matrix6xUpTo6<T>& get_g_PB_W(
-      MobodIndex mobod_index) const {
+  const Matrix6xUpTo6<T>& get_g_PB_W(MobodIndex mobod_index) const {
     DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
     return g_PB_W_[mobod_index];
   }
 
   // Mutable version of get_g_PB_W().
-  Matrix6xUpTo6<T>& get_mutable_g_PB_W(
-      MobodIndex mobod_index) {
+  Matrix6xUpTo6<T>& get_mutable_g_PB_W(MobodIndex mobod_index) {
     DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
     return g_PB_W_[mobod_index];
   }

--- a/multibody/tree/body_node.cc
+++ b/multibody/tree/body_node.cc
@@ -60,17 +60,20 @@ void BodyNode<T>::CalcArticulatedBodyHingeInertiaMatrixFactorization(
     const std::string& outboard_body_name = outboard_body.name();
     std::stringstream message;
     message << "An internal mass matrix associated with the joint that "
-               "connects body " << inboard_body_name << " to body "
-               << outboard_body_name << " is not positive-definite.";
+               "connects body "
+            << inboard_body_name << " to body " << outboard_body_name
+            << " is not positive-definite.";
     if (mobilizer.can_rotate()) {
       message << " Since the joint allows rotation, ensure body "
-              << outboard_body_name << " (combined with other outboard bodies) "
+              << outboard_body_name
+              << " (combined with other outboard bodies) "
                  "has reasonable non-zero moments of inertia about the joint "
                  "rotation axes.";
     }
     if (mobilizer.can_translate()) {
       message << " Since the joint allows translation, ensure body "
-              << outboard_body_name << " (combined with other outboard bodies) "
+              << outboard_body_name
+              << " (combined with other outboard bodies) "
                  "has a reasonable non-zero mass.";
     }
     throw std::runtime_error(message.str());

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -112,14 +112,10 @@ class BodyNode : public MultibodyElement<T> {
   // via calls to this method.
   // Used by MultibodyTree at creation of a BodyNode during the
   // MultibodyTree::Finalize() method call.
-  void add_child_node(const BodyNode<T>* child) {
-    children_.push_back(child);
-  }
+  void add_child_node(const BodyNode<T>* child) { children_.push_back(child); }
 
   // Returns this element's unique index.
-  MobodIndex index() const {
-    return this->template index_impl<MobodIndex>();
-  }
+  MobodIndex index() const { return this->template index_impl<MobodIndex>(); }
 
   // Returns a constant reference to the body B associated with this node.
   const RigidBody<T>& body() const {
@@ -137,9 +133,7 @@ class BodyNode : public MultibodyElement<T> {
 
   // Returns a const pointer to the parent (inboard) body node or nullptr if
   // `this` is the world node, which has no inboard parent node.
-  const BodyNode<T>* parent_body_node() const {
-    return parent_node_;
-  }
+  const BodyNode<T>* parent_body_node() const { return parent_node_; }
 
   // Returns a constant reference to the mobilizer associated with this node.
   // Aborts if called on the root node corresponding to the _world_ body, for
@@ -185,8 +179,7 @@ class BodyNode : public MultibodyElement<T> {
   // for the parent node (and, by recursive precondition, all predecessor nodes
   // in the tree.)
   virtual void CalcPositionKinematicsCache_BaseToTip(
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
-      const T* positions,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
       PositionKinematicsCache<T>* pc) const = 0;
 
   // Calculates the hinge matrix H_PB_W.
@@ -236,10 +229,8 @@ class BodyNode : public MultibodyElement<T> {
 
   // TODO(sherm1) This function should not take a context.
   virtual void CalcVelocityKinematicsCache_BaseToTip(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      const std::vector<Vector6<T>>& H_PB_W_cache,
-      const T* velocities,
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const std::vector<Vector6<T>>& H_PB_W_cache, const T* velocities,
       VelocityKinematicsCache<T>* vc) const = 0;
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
@@ -291,8 +282,7 @@ class BodyNode : public MultibodyElement<T> {
       const systems::Context<T>& context,
       const FrameBodyPoseCache<T>& frame_body_poses_cache,
       const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>* vc,
-      const VectorX<T>& mbt_vdot,
+      const VelocityKinematicsCache<T>* vc, const VectorX<T>& mbt_vdot,
       std::vector<SpatialAcceleration<T>>* A_WB_array_ptr) const {
     // This method must not be called for the "world" body node.
     DRAKE_DEMAND(topology_.rigid_body != world_index());
@@ -425,7 +415,7 @@ class BodyNode : public MultibodyElement<T> {
           A_WP.ComposeWithMovingFrameAcceleration(p_PB_W, V_WP.rotational(),
                                                   V_PB_W, A_PB_W);
     } else {
-      const SpatialAcceleration<T> A_PB_W =   // Eq. (4), with w_FM = 0.
+      const SpatialAcceleration<T> A_PB_W =  // Eq. (4), with w_FM = 0.
           R_WF * A_FM.ShiftWithZeroAngularVelocity(p_MB_F);
       // Velocities are zero. No need to compute terms that become zero.
       get_mutable_A_WB_from_array(&A_WB_array) =
@@ -516,12 +506,10 @@ class BodyNode : public MultibodyElement<T> {
       EigenPtr<VectorX<T>> tau_array) const {
     DRAKE_DEMAND(F_BMo_W_array_ptr != nullptr);
     std::vector<SpatialForce<T>>& F_BMo_W_array = *F_BMo_W_array_ptr;
-    DRAKE_DEMAND(
-        tau_applied.size() == get_num_mobilizer_velocities() ||
-        tau_applied.size() == 0);
+    DRAKE_DEMAND(tau_applied.size() == get_num_mobilizer_velocities() ||
+                 tau_applied.size() == 0);
     DRAKE_DEMAND(tau_array != nullptr);
-    DRAKE_DEMAND(tau_array->size() ==
-        this->get_parent_tree().num_velocities());
+    DRAKE_DEMAND(tau_array->size() == this->get_parent_tree().num_velocities());
 
     // As a guideline for developers, a summary of the computations performed in
     // this method is provided:
@@ -690,7 +678,7 @@ class BodyNode : public MultibodyElement<T> {
   Eigen::Map<const MatrixUpTo6<T>> GetJacobianFromArray(
       const std::vector<Vector6<T>>& H_array) const {
     DRAKE_DEMAND(static_cast<int>(H_array.size()) ==
-        this->get_parent_tree().num_velocities());
+                 this->get_parent_tree().num_velocities());
     const int start_index_in_v = get_topology().mobilizer_velocities_start_in_v;
     const int num_velocities = get_topology().num_mobilizer_velocities;
     DRAKE_DEMAND(num_velocities == 0 ||
@@ -754,11 +742,9 @@ class BodyNode : public MultibodyElement<T> {
 
   // TODO(sherm1) This function should not take a context.
   void CalcArticulatedBodyInertiaCache_TipToBase(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
-      const SpatialInertia<T>& M_B_W,
-      const VectorX<T>& diagonal_inertias,
+      const SpatialInertia<T>& M_B_W, const VectorX<T>& diagonal_inertias,
       ArticulatedBodyInertiaCache<T>* abic) const {
     DRAKE_THROW_UNLESS(topology_.rigid_body != world_index());
     DRAKE_THROW_UNLESS(abic != nullptr);
@@ -847,8 +833,8 @@ class BodyNode : public MultibodyElement<T> {
       const Vector3<T> p_CoBo_W = -p_BoCo_W;
 
       // Pull Pplus_BC_W from cache (which is Pplus_PB_W for child).
-      const ArticulatedBodyInertia<T>& Pplus_BC_W
-          = child->get_Pplus_PB_W(*abic);
+      const ArticulatedBodyInertia<T>& Pplus_BC_W =
+          child->get_Pplus_PB_W(*abic);
 
       // Shift Pplus_BC_W to Pplus_BCb_W.
       // This is known to be one of the most expensive operations of ABA and
@@ -885,7 +871,7 @@ class BodyNode : public MultibodyElement<T> {
 
       // Compute the LLT factorization of D_B as llt_D_B.
       math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& llt_D_B =
-        get_mutable_llt_D_B(abic);
+          get_mutable_llt_D_B(abic);
       CalcArticulatedBodyHingeInertiaMatrixFactorization(D_B, &llt_D_B);
 
       // Compute the Kalman gain, g_PB_W, using (6).
@@ -950,13 +936,10 @@ class BodyNode : public MultibodyElement<T> {
 
   // TODO(sherm1) This function should not take a context.
   void CalcArticulatedBodyForceCache_TipToBase(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>*,
-      const SpatialForce<T>& Fb_Bo_W,
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>*, const SpatialForce<T>& Fb_Bo_W,
       const ArticulatedBodyInertiaCache<T>& abic,
-      const SpatialForce<T>& Zb_Bo_W,
-      const SpatialForce<T>& Fapplied_Bo_W,
+      const SpatialForce<T>& Zb_Bo_W, const SpatialForce<T>& Fapplied_Bo_W,
       const Eigen::Ref<const VectorX<T>>& tau_applied,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
       ArticulatedBodyForceCache<T>* aba_force_cache) const {
@@ -1002,8 +985,7 @@ class BodyNode : public MultibodyElement<T> {
       const Matrix6xUpTo6<T>& g_PB_W = get_g_PB_W(abic);
 
       // Compute the projected articulated body force bias Zplus_PB_W.
-      get_mutable_Zplus_PB_W(aba_force_cache) +=
-          SpatialForce<T>(g_PB_W * e_B);
+      get_mutable_Zplus_PB_W(aba_force_cache) += SpatialForce<T>(g_PB_W * e_B);
     }
   }
 
@@ -1044,8 +1026,7 @@ class BodyNode : public MultibodyElement<T> {
 
   // TODO(sherm1) This function should not take a context.
   void CalcArticulatedBodyAccelerations_BaseToTip(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
       const ArticulatedBodyInertiaCache<T>& abic,
       const ArticulatedBodyForceCache<T>& aba_force_cache,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
@@ -1110,8 +1091,7 @@ class BodyNode : public MultibodyElement<T> {
   // for the children nodes (and, by recursive precondition, all outboard nodes
   // in the tree.)
   void CalcCompositeBodyInertia_TipToBase(
-      const SpatialInertia<T>& M_B_W,
-      const PositionKinematicsCache<T>& pc,
+      const SpatialInertia<T>& M_B_W, const PositionKinematicsCache<T>& pc,
       const std::vector<SpatialInertia<T>>& Mc_B_W_all,
       SpatialInertia<T>* Mc_B_W) const {
     DRAKE_THROW_UNLESS(topology_.rigid_body != world_index());
@@ -1262,7 +1242,9 @@ class BodyNode : public MultibodyElement<T> {
   // this node. For the root node, corresponding to the world RigidBody, this
   // method returns an invalid BodyIndex. Attempts to using invalid indexes
   // leads to an exception being thrown in Debug builds.
-  BodyIndex get_parent_body_index() const { return topology_.parent_rigid_body;}
+  BodyIndex get_parent_body_index() const {
+    return topology_.parent_rigid_body;
+  }
 
   // =========================================================================
   // Helpers to access the state.
@@ -1600,8 +1582,8 @@ class BodyNode : public MultibodyElement<T> {
   void CalcBodySpatialForceGivenItsSpatialAcceleration(
       const std::vector<SpatialInertia<T>>& M_B_W_cache,
       const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
-      const SpatialAcceleration<T>& A_WB, SpatialForce<T>* Ftot_BBo_W_ptr)
-  const {
+      const SpatialAcceleration<T>& A_WB,
+      SpatialForce<T>* Ftot_BBo_W_ptr) const {
     DRAKE_DEMAND(Ftot_BBo_W_ptr != nullptr);
 
     // Output spatial force applied on mobilized body B, at Bo, measured in W.

--- a/multibody/tree/body_node_impl.cc
+++ b/multibody/tree/body_node_impl.cc
@@ -29,8 +29,7 @@ BodyNodeImpl<T, ConcreteMobilizer>::~BodyNodeImpl() = default;
 
 template <typename T, template <typename> class ConcreteMobilizer>
 void BodyNodeImpl<T, ConcreteMobilizer>::CalcPositionKinematicsCache_BaseToTip(
-    const FrameBodyPoseCache<T>& frame_body_pose_cache,
-    const T* positions,
+    const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
     PositionKinematicsCache<T>* pc) const {
   // This method must not be called for the "world" body node.
   DRAKE_ASSERT(this->index() != world_mobod_index());
@@ -107,10 +106,8 @@ void BodyNodeImpl<T, ConcreteMobilizer>::
 
 template <typename T, template <typename> class ConcreteMobilizer>
 void BodyNodeImpl<T, ConcreteMobilizer>::CalcVelocityKinematicsCache_BaseToTip(
-    const systems::Context<T>& context,
-    const PositionKinematicsCache<T>& pc,
-    const std::vector<Vector6<T>>& H_PB_W_cache,
-    const T* velocities,
+    const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+    const std::vector<Vector6<T>>& H_PB_W_cache, const T* velocities,
     VelocityKinematicsCache<T>* vc) const {
   // This method must not be called for the "world" body node.
   DRAKE_ASSERT(this->index() != world_mobod_index());

--- a/multibody/tree/body_node_impl.h
+++ b/multibody/tree/body_node_impl.h
@@ -62,8 +62,7 @@ class BodyNodeImpl final : public BodyNode<T> {
   //  here also.
 
   void CalcPositionKinematicsCache_BaseToTip(
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
-      const T* positions,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
       PositionKinematicsCache<T>* pc) const final;
 
   void CalcAcrossNodeJacobianWrtVExpressedInWorld(
@@ -73,10 +72,8 @@ class BodyNodeImpl final : public BodyNode<T> {
       std::vector<Vector6<T>>* H_PB_W_cache) const final;
 
   void CalcVelocityKinematicsCache_BaseToTip(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      const std::vector<Vector6<T>>& H_PB_W_cache,
-      const T* velocities,
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const std::vector<Vector6<T>>& H_PB_W_cache, const T* velocities,
       VelocityKinematicsCache<T>* vc) const final;
 
  private:
@@ -119,13 +116,11 @@ class BodyNodeImpl final : public BodyNode<T> {
     return vc->get_mutable_V_WB(this->index());
   }
 
-  SpatialVelocity<T>& get_mutable_V_FM(
-      VelocityKinematicsCache<T>* vc) const {
+  SpatialVelocity<T>& get_mutable_V_FM(VelocityKinematicsCache<T>* vc) const {
     return vc->get_mutable_V_FM(this->index());
   }
 
-  SpatialVelocity<T>& get_mutable_V_PB_W(
-      VelocityKinematicsCache<T>* vc) const {
+  SpatialVelocity<T>& get_mutable_V_PB_W(VelocityKinematicsCache<T>* vc) const {
     return vc->get_mutable_V_PB_W(this->index());
   }
 

--- a/multibody/tree/door_hinge.cc
+++ b/multibody/tree/door_hinge.cc
@@ -119,10 +119,8 @@ T DoorHinge<T>::CalcHingeSpringTorque(const T& angle) const {
 }
 
 template <typename T>
-T DoorHinge<T>::CalcHingeTorque(const T& angle,
-                                const T& angular_rate) const {
-  return CalcHingeFrictionalTorque(angular_rate) +
-         CalcHingeSpringTorque(angle);
+T DoorHinge<T>::CalcHingeTorque(const T& angle, const T& angular_rate) const {
+  return CalcHingeFrictionalTorque(angular_rate) + CalcHingeSpringTorque(angle);
 }
 
 template <typename T>

--- a/multibody/tree/fixed_offset_frame.cc
+++ b/multibody/tree/fixed_offset_frame.cc
@@ -15,9 +15,10 @@ template <typename T>
 FixedOffsetFrame<T>::FixedOffsetFrame(
     const std::string& name, const Frame<T>& P,
     const math::RigidTransform<double>& X_PF,
-    std::optional<ModelInstanceIndex> model_instance) :
-    Frame<T>(name, P.body(), model_instance.value_or(P.model_instance())),
-    parent_frame_(P), X_PF_(X_PF) {}
+    std::optional<ModelInstanceIndex> model_instance)
+    : Frame<T>(name, P.body(), model_instance.value_or(P.model_instance())),
+      parent_frame_(P),
+      X_PF_(X_PF) {}
 
 template <typename T>
 FixedOffsetFrame<T>::FixedOffsetFrame(const std::string& name,
@@ -27,7 +28,6 @@ FixedOffsetFrame<T>::FixedOffsetFrame(const std::string& name,
 
 template <typename T>
 FixedOffsetFrame<T>::~FixedOffsetFrame() = default;
-
 
 template <typename T>
 void FixedOffsetFrame<T>::SetPoseInParentFrame(

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -13,8 +13,10 @@ namespace drake {
 namespace multibody {
 
 // Forward declarations.
-template <class T> class RigidBodyFrame;
-template <class T> class RigidBody;
+template <class T>
+class RigidBodyFrame;
+template <class T>
+class RigidBody;
 
 /// %FixedOffsetFrame represents a material frame F whose pose is fixed with
 /// respect to a _parent_ material frame P. The pose offset is given by a
@@ -49,10 +51,9 @@ class FixedOffsetFrame final : public Frame<T> {
   /// @param[in] model_instance
   ///   The model instance to which this frame belongs to. If unspecified, will
   ///   use P.body().model_instance().
-  FixedOffsetFrame(
-      const std::string& name, const Frame<T>& P,
-      const math::RigidTransform<double>& X_PF,
-      std::optional<ModelInstanceIndex> model_instance = {});
+  FixedOffsetFrame(const std::string& name, const Frame<T>& P,
+                   const math::RigidTransform<double>& X_PF,
+                   std::optional<ModelInstanceIndex> model_instance = {});
 
   /// Creates a material Frame F whose pose is fixed with respect to the
   /// RigidBodyFrame B of the given RigidBody, which serves as F's parent frame.
@@ -63,9 +64,8 @@ class FixedOffsetFrame final : public Frame<T> {
   /// @param[in] bodyB The body whose RigidBodyFrame B is to be F's parent
   ///                  frame.
   /// @param[in] X_BF  The transform giving the pose of F in B.
-  FixedOffsetFrame(
-      const std::string& name, const RigidBody<T>& bodyB,
-      const math::RigidTransform<double>& X_BF);
+  FixedOffsetFrame(const std::string& name, const RigidBody<T>& bodyB,
+                   const math::RigidTransform<double>& X_BF);
 
   ~FixedOffsetFrame() override;
 

--- a/multibody/tree/force_element.h
+++ b/multibody/tree/force_element.h
@@ -161,7 +161,7 @@ class ForceElement : public MultibodyElement<T> {
   // MultibodyTree::CloneToScalar().
   template <typename ToScalar>
   std::unique_ptr<ForceElement<ToScalar>> CloneToScalar(
-  const internal::MultibodyTree<ToScalar>& cloned_tree) const {
+      const internal::MultibodyTree<ToScalar>& cloned_tree) const {
     return DoCloneToScalar(cloned_tree);
   }
   /// @endcond

--- a/multibody/tree/frame.cc
+++ b/multibody/tree/frame.cc
@@ -32,8 +32,7 @@ ScopedName Frame<T>::scoped_name() const {
 //  rigid body (not a soft body). Modify if soft bodies are possible.
 template <typename T>
 Vector3<T> Frame<T>::CalcAngularVelocity(
-    const systems::Context<T>& context,
-    const Frame<T>& measured_in_frame,
+    const systems::Context<T>& context, const Frame<T>& measured_in_frame,
     const Frame<T>& expressed_in_frame) const {
   const Frame<T>& frame_M = measured_in_frame;
   const Frame<T>& frame_E = expressed_in_frame;
@@ -67,8 +66,7 @@ SpatialVelocity<T> Frame<T>::CalcSpatialVelocityInWorld(
 
 template <typename T>
 SpatialVelocity<T> Frame<T>::CalcSpatialVelocity(
-    const systems::Context<T>& context,
-    const Frame<T>& frame_M,
+    const systems::Context<T>& context, const Frame<T>& frame_M,
     const Frame<T>& frame_E) const {
   const math::RotationMatrix<T> R_WM =
       frame_M.CalcRotationMatrixInWorld(context);
@@ -185,14 +183,13 @@ SpatialAcceleration<T> Frame<T>::CalcSpatialAcceleration(
 // Ideally, we'd be instantiating the entire class here, instead of just one
 // member function. However, the MultibodyTree physical design is so contrary to
 // GSG best practices that trying to do the entire class here doesn't work.
-DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
-    &drake::multibody::Frame<T>::scoped_name,
-    &drake::multibody::Frame<T>::CalcAngularVelocity,
-    &drake::multibody::Frame<T>::CalcSpatialVelocityInWorld,
-    &drake::multibody::Frame<T>::CalcSpatialVelocity,
-    &drake::multibody::Frame<T>::CalcSpatialAccelerationInWorld,
-    &drake::multibody::Frame<T>::CalcSpatialAcceleration
-));
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    (&drake::multibody::Frame<T>::scoped_name,
+     &drake::multibody::Frame<T>::CalcAngularVelocity,
+     &drake::multibody::Frame<T>::CalcSpatialVelocityInWorld,
+     &drake::multibody::Frame<T>::CalcSpatialVelocity,
+     &drake::multibody::Frame<T>::CalcSpatialAccelerationInWorld,
+     &drake::multibody::Frame<T>::CalcSpatialAcceleration));
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::Frame);

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -21,7 +21,8 @@ std::string DeprecateWhenEmptyName(std::string name, std::string_view type);
 }  // namespace internal
 
 // Forward declarations.
-template<typename T> class RigidBody;
+template <typename T>
+class RigidBody;
 
 /// %Frame is an abstract class representing a _material frame_ (also called a
 /// _physical frame_) of its underlying RigidBody. The %Frame's origin is a
@@ -57,14 +58,10 @@ class Frame : public FrameBase<T> {
   ~Frame() override;
 
   /// Returns a const reference to the body associated to this %Frame.
-  const RigidBody<T>& body() const {
-    return body_;
-  }
+  const RigidBody<T>& body() const { return body_; }
 
   /// Returns true if `this` is the world frame.
-  bool is_world_frame() const {
-    return this->index() == world_frame_index();
-  }
+  bool is_world_frame() const { return this->index() == world_frame_index(); }
 
   /// Returns true if `this` is the body frame.
   bool is_body_frame() const {
@@ -72,9 +69,7 @@ class Frame : public FrameBase<T> {
   }
 
   /// Returns the name of this frame. The name will never be empty.
-  const std::string& name() const {
-    return name_;
-  }
+  const std::string& name() const { return name_; }
 
   /// Returns scoped name of this frame. Neither of the two pieces of the name
   /// will be empty (the scope name and the element name).
@@ -126,8 +121,8 @@ class Frame : public FrameBase<T> {
   virtual math::RigidTransform<T> GetFixedPoseInBodyFrame() const {
     throw std::logic_error(
         "Attempting to retrieve a fixed pose from a frame of type '" +
-            drake::NiceTypeName::Get(*this) +
-            "', which does not support this operation.");
+        drake::NiceTypeName::Get(*this) +
+        "', which does not support this operation.");
   }
 
   /// Returns the rotation matrix `R_BF` that relates body frame B to `this`
@@ -141,8 +136,8 @@ class Frame : public FrameBase<T> {
   virtual math::RotationMatrix<T> GetFixedRotationMatrixInBodyFrame() const {
     throw std::logic_error(
         "Unable to retrieve a fixed rotation matrix from a frame of type '" +
-            drake::NiceTypeName::Get(*this) +
-            "', which does not support this method.");
+        drake::NiceTypeName::Get(*this) +
+        "', which does not support this method.");
   }
 
   // TODO(jwnimmer-tri) These next four functions only exist so that BodyFrame
@@ -228,18 +223,18 @@ class Frame : public FrameBase<T> {
   /// Computes and returns the pose `X_MF` of `this` frame F in measured in
   /// `frame_M` as a function of the state of the model stored in `context`.
   /// @see CalcPoseInWorld().
-  math::RigidTransform<T> CalcPose(
-      const systems::Context<T>& context, const Frame<T>& frame_M) const {
-    return this->get_parent_tree().CalcRelativeTransform(
-        context, frame_M, *this);
+  math::RigidTransform<T> CalcPose(const systems::Context<T>& context,
+                                   const Frame<T>& frame_M) const {
+    return this->get_parent_tree().CalcRelativeTransform(context, frame_M,
+                                                         *this);
   }
 
   /// Calculates and returns the rotation matrix `R_MF` that relates `frame_M`
   /// and `this` frame F as a function of the state stored in `context`.
-  math::RotationMatrix<T> CalcRotationMatrix(
-      const systems::Context<T>& context, const Frame<T>& frame_M) const {
-    return this->get_parent_tree().CalcRelativeRotationMatrix(
-        context, frame_M, *this);
+  math::RotationMatrix<T> CalcRotationMatrix(const systems::Context<T>& context,
+                                             const Frame<T>& frame_M) const {
+    return this->get_parent_tree().CalcRelativeRotationMatrix(context, frame_M,
+                                                              *this);
   }
 
   /// Calculates and returns the rotation matrix `R_WF` that relates the world
@@ -277,10 +272,9 @@ class Frame : public FrameBase<T> {
   /// expressed in frame E.
   /// @see EvalAngularVelocityInWorld() to evaluate ω_WF_W (`this` frame F's
   /// angular velocity ω measured and expressed in the world frame W).
-  Vector3<T> CalcAngularVelocity(
-      const systems::Context<T>& context,
-      const Frame<T>& measured_in_frame,
-      const Frame<T>& expressed_in_frame) const;
+  Vector3<T> CalcAngularVelocity(const systems::Context<T>& context,
+                                 const Frame<T>& measured_in_frame,
+                                 const Frame<T>& expressed_in_frame) const;
 
   /// Calculates `this` frame F's spatial velocity measured and expressed in
   /// the world frame W.
@@ -309,10 +303,9 @@ class Frame : public FrameBase<T> {
   /// frame F's origin point Fo, measured in frame M, expressed in frame E).
   /// @see CalcSpatialVelocityInWorld(), CalcRelativeSpatialVelocity(), and
   /// CalcSpatialAcceleration().
-  SpatialVelocity<T> CalcSpatialVelocity(
-      const systems::Context<T>& context,
-      const Frame<T>& frame_M,
-      const Frame<T>& frame_E) const;
+  SpatialVelocity<T> CalcSpatialVelocity(const systems::Context<T>& context,
+                                         const Frame<T>& frame_M,
+                                         const Frame<T>& frame_E) const;
 
   /// Calculates `this` frame C's spatial velocity relative to another frame B,
   /// measured and expressed in the world frame W.
@@ -332,8 +325,7 @@ class Frame : public FrameBase<T> {
   /// coherent if any of `this`, other_frame, or the world frame W are the same.
   /// @see CalcSpatialVelocityInWorld() and CalcRelativeSpatialVelocity().
   SpatialVelocity<T> CalcRelativeSpatialVelocityInWorld(
-      const systems::Context<T>& context,
-      const Frame<T>& other_frame) const {
+      const systems::Context<T>& context, const Frame<T>& other_frame) const {
     const Frame<T>& frame_B = other_frame;
     const SpatialVelocity<T> V_WB_W =
         frame_B.CalcSpatialVelocityInWorld(context);
@@ -368,8 +360,7 @@ class Frame : public FrameBase<T> {
   /// @see CalcSpatialVelocityInWorld(), CalcSpatialVelocity(), and
   /// CalcRelativeSpatialVelocityInWorld().
   SpatialVelocity<T> CalcRelativeSpatialVelocity(
-      const systems::Context<T>& context,
-      const Frame<T>& other_frame,
+      const systems::Context<T>& context, const Frame<T>& other_frame,
       const Frame<T>& measured_in_frame,
       const Frame<T>& expressed_in_frame) const {
     const Frame<T>& frame_B = other_frame;
@@ -419,8 +410,7 @@ class Frame : public FrameBase<T> {
   /// </pre>
   /// @see CalcSpatialAccelerationInWorld() and CalcSpatialVelocity().
   SpatialAcceleration<T> CalcSpatialAcceleration(
-      const systems::Context<T>& context,
-      const Frame<T>& measured_in_frame,
+      const systems::Context<T>& context, const Frame<T>& measured_in_frame,
       const Frame<T>& expressed_in_frame) const;
 
   /// Calculates `this` frame C's spatial acceleration relative to another
@@ -445,8 +435,7 @@ class Frame : public FrameBase<T> {
   /// coherent if any of `this`, other_frame, or the world frame W are the same.
   /// @see CalcSpatialAccelerationInWorld(), CalcRelativeSpatialAcceleration().
   SpatialAcceleration<T> CalcRelativeSpatialAccelerationInWorld(
-      const systems::Context<T>& context,
-      const Frame<T>& other_frame) const {
+      const systems::Context<T>& context, const Frame<T>& other_frame) const {
     const Frame<T>& frame_B = other_frame;
     const SpatialAcceleration<T> A_WB_W =
         frame_B.CalcSpatialAccelerationInWorld(context);
@@ -482,8 +471,7 @@ class Frame : public FrameBase<T> {
   /// @see CalcSpatialAccelerationInWorld(), CalcSpatialAcceleration(), and
   /// CalcRelativeSpatialAccelerationInWorld().
   SpatialAcceleration<T> CalcRelativeSpatialAcceleration(
-      const systems::Context<T>& context,
-      const Frame<T>& other_frame,
+      const systems::Context<T>& context, const Frame<T>& other_frame,
       const Frame<T>& measured_in_frame,
       const Frame<T>& expressed_in_frame) const {
     const Frame<T>& frame_B = other_frame;
@@ -531,9 +519,7 @@ class Frame : public FrameBase<T> {
   }
 
   /// (Internal use only) Retrieve this %Frame's body pose index in the cache.
-  int get_body_pose_index_in_cache() const {
-    return body_pose_index_in_cache_;
-  }
+  int get_body_pose_index_in_cache() const { return body_pose_index_in_cache_; }
 
   /// (Internal use only) Given an already up-to-date frame body pose cache,
   /// extract X_BF for this %Frame from it.
@@ -560,9 +546,8 @@ class Frame : public FrameBase<T> {
   /// Only derived classes can use this constructor. It creates a %Frame
   /// object attached to `body` and puts the frame in the body's model
   /// instance.
-  explicit Frame(
-      const std::string& name, const RigidBody<T>& body,
-      std::optional<ModelInstanceIndex> model_instance = {})
+  explicit Frame(const std::string& name, const RigidBody<T>& body,
+                 std::optional<ModelInstanceIndex> model_instance = {})
       : FrameBase<T>(model_instance.value_or(body.model_instance())),
         name_(internal::DeprecateWhenEmptyName(name, "Frame")),
         body_(body) {}
@@ -623,8 +608,8 @@ class Frame : public FrameBase<T> {
 
  private:
   // Implementation for MultibodyElement::DoSetTopology().
-  void DoSetTopology(const internal::MultibodyTreeTopology& tree_topology)
-  final {
+  void DoSetTopology(
+      const internal::MultibodyTreeTopology& tree_topology) final {
     topology_ = tree_topology.get_frame(this->index());
     DRAKE_ASSERT(topology_.index == this->index());
   }

--- a/multibody/tree/frame_body_pose_cache.h
+++ b/multibody/tree/frame_body_pose_cache.h
@@ -32,8 +32,8 @@ class FrameBodyPoseCache {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FrameBodyPoseCache);
 
   explicit FrameBodyPoseCache(int num_frame_body_pose_slots_needed)
-  : X_BF_pool_(num_frame_body_pose_slots_needed),
-    X_FB_pool_(num_frame_body_pose_slots_needed) {
+      : X_BF_pool_(num_frame_body_pose_slots_needed),
+        X_FB_pool_(num_frame_body_pose_slots_needed) {
     DRAKE_DEMAND(num_frame_body_pose_slots_needed > 0);
 
     // All RigidBodyFrames share this body pose.

--- a/multibody/tree/geometry_spatial_inertia.h
+++ b/multibody/tree/geometry_spatial_inertia.h
@@ -11,7 +11,7 @@ namespace multibody {
 /** Computes the SpatialInertia of a body made up of a homogeneous material
  (of given `density` in kg/m³) uniformly distributed in the volume of the given
  `shape`.
- 
+
  The `shape` is defined in its canonical frame S and the body in frame B. The
  two frames are coincident and aligned (i.e., X_SB = I).
 
@@ -34,7 +34,7 @@ SpatialInertia<double> CalcSpatialInertia(const geometry::Shape& shape,
 /** Computes the SpatialInertia of a body made up of a homogeneous material
  (of given `density` in kg/m³) uniformly distributed in the volume of the given
  `mesh`.
- 
+
  The `mesh` is defined in its canonical frame M and the body in frame B. The two
  frames are coincident and aligned (i.e., X_MB = I).
 

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -195,24 +195,16 @@ class Joint : public MultibodyElement<T> {
   const std::string& name() const { return name_; }
 
   /// Returns a const reference to the parent body P.
-  const RigidBody<T>& parent_body() const {
-    return frame_on_parent_.body();
-  }
+  const RigidBody<T>& parent_body() const { return frame_on_parent_.body(); }
 
   /// Returns a const reference to the child body B.
-  const RigidBody<T>& child_body() const {
-    return frame_on_child_.body();
-  }
+  const RigidBody<T>& child_body() const { return frame_on_child_.body(); }
 
   /// Returns a const reference to the frame F attached on the parent body P.
-  const Frame<T>& frame_on_parent() const {
-    return frame_on_parent_;
-  }
+  const Frame<T>& frame_on_parent() const { return frame_on_parent_; }
 
   /// Returns a const reference to the frame M attached on the child body B.
-  const Frame<T>& frame_on_child() const {
-    return frame_on_child_;
-  }
+  const Frame<T>& frame_on_child() const { return frame_on_child_; }
 
   /// Returns a string identifying the type of `this` joint, such as "revolute"
   /// or "prismatic".
@@ -221,9 +213,7 @@ class Joint : public MultibodyElement<T> {
   /// Returns the index to the first generalized velocity for this joint
   /// within the vector v of generalized velocities for the full multibody
   /// system.
-  int velocity_start() const {
-    return do_get_velocity_start();
-  }
+  int velocity_start() const { return do_get_velocity_start(); }
 
   /// Returns the number of generalized velocities describing this joint.
   int num_velocities() const {
@@ -234,9 +224,7 @@ class Joint : public MultibodyElement<T> {
   /// Returns the index to the first generalized position for this joint
   /// within the vector q of generalized positions for the full multibody
   /// system.
-  int position_start() const {
-    return do_get_position_start();
-  }
+  int position_start() const { return do_get_position_start(); }
 
   /// Returns the number of generalized positions describing this joint.
   int num_positions() const {
@@ -322,11 +310,8 @@ class Joint : public MultibodyElement<T> {
   ///   `forces` is `nullptr` or if `forces` doest not have the right sizes to
   ///   accommodate a set of forces for the model to which this joint belongs.
   // NVI to DoAddInOneForce().
-  void AddInOneForce(
-      const systems::Context<T>& context,
-      int joint_dof,
-      const T& joint_tau,
-      MultibodyForces<T>* forces) const {
+  void AddInOneForce(const systems::Context<T>& context, int joint_dof,
+                     const T& joint_tau, MultibodyForces<T>* forces) const {
     DRAKE_DEMAND(forces != nullptr);
     DRAKE_DEMAND(0 <= joint_dof && joint_dof < num_velocities());
     DRAKE_DEMAND(forces->CheckHasRightSizeForModel(this->get_parent_tree()));
@@ -344,8 +329,8 @@ class Joint : public MultibodyElement<T> {
   ///   not have the right sizes to accommodate a set of forces for the model
   ///   to which this joint belongs.
   // NVI to DoAddInOneForce().
-  void AddInDamping(
-      const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  void AddInDamping(const systems::Context<T>& context,
+                    MultibodyForces<T>* forces) const {
     DRAKE_DEMAND(forces != nullptr);
     DRAKE_DEMAND(forces->CheckHasRightSizeForModel(this->get_parent_tree()));
     DoAddInDamping(context, forces);
@@ -590,7 +575,8 @@ class Joint : public MultibodyElement<T> {
 
     std::unique_ptr<typename Joint<ToScalar>::JointImplementation>
         implementation_clone =
-        this->get_implementation().template CloneToScalar<ToScalar>(tree_clone);
+            this->get_implementation().template CloneToScalar<ToScalar>(
+                tree_clone);
     joint_clone->OwnImplementation(std::move(implementation_clone));
 
     return joint_clone;
@@ -634,9 +620,7 @@ class Joint : public MultibodyElement<T> {
     }
 
     /// Returns `true` if the implementation of this Joint uses a Mobilizer.
-    bool has_mobilizer() const {
-      return mobilizer != nullptr;
-    }
+    bool has_mobilizer() const { return mobilizer != nullptr; }
 
     // Hide the following section from Doxygen.
 #ifndef DRAKE_DOXYGEN_CXX
@@ -767,11 +751,9 @@ class Joint : public MultibodyElement<T> {
   /// This method is only called by the public NVI AddInOneForce() and therefore
   /// input arguments were checked to be valid.
   /// @see The public NVI AddInOneForce() for details.
-  virtual void DoAddInOneForce(
-      const systems::Context<T>& context,
-      int joint_dof,
-      const T& joint_tau,
-      MultibodyForces<T>* forces) const = 0;
+  virtual void DoAddInOneForce(const systems::Context<T>& context,
+                               int joint_dof, const T& joint_tau,
+                               MultibodyForces<T>* forces) const = 0;
 
   /// Adds into MultibodyForces the forces due to damping within `this` joint.
   /// How forces are added to a MultibodyTree model depends on the underlying
@@ -779,8 +761,8 @@ class Joint : public MultibodyElement<T> {
   /// constraint) and therefore specific %Joint subclasses must provide a
   /// definition for this method.
   /// The default implementation is a no-op for joints with no damping.
-  virtual void DoAddInDamping(
-      const systems::Context<T>&, MultibodyForces<T>*) const {}
+  virtual void DoAddInDamping(const systems::Context<T>&,
+                              MultibodyForces<T>*) const {}
 
   // Implements MultibodyElement::DoSetTopology(). Joints have no topology
   // though we could require them to have one in the future.

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -41,11 +41,9 @@ const Joint<T>& JointActuator<T>::joint() const {
 }
 
 template <typename T>
-void JointActuator<T>::AddInOneForce(
-    const systems::Context<T>& context,
-    int joint_dof,
-    const T& joint_tau,
-    MultibodyForces<T>* forces) const {
+void JointActuator<T>::AddInOneForce(const systems::Context<T>& context,
+                                     int joint_dof, const T& joint_tau,
+                                     MultibodyForces<T>* forces) const {
   DRAKE_DEMAND(forces != nullptr);
   DRAKE_DEMAND(0 <= joint_dof && joint_dof < num_inputs());
   DRAKE_DEMAND(forces->CheckHasRightSizeForModel(this->get_parent_tree()));
@@ -59,8 +57,7 @@ void JointActuator<T>::set_actuation_vector(
   DRAKE_THROW_UNLESS(u != nullptr);
   DRAKE_THROW_UNLESS(u->size() == this->get_parent_tree().num_actuated_dofs());
   DRAKE_THROW_UNLESS(u_actuator.size() == num_inputs());
-  u->segment(topology_.actuator_index_start, num_inputs()) =
-      u_actuator;
+  u->segment(topology_.actuator_index_start, num_inputs()) = u_actuator;
 }
 
 template <typename T>

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -18,7 +18,8 @@ namespace drake {
 namespace multibody {
 
 // Forward declaration for JointActuator<T>.
-template<typename T> class Joint;
+template <typename T>
+class Joint;
 
 /// PD controller gains. This enables the modeling of a simple low level PD
 /// controllers, see JointActuator::set_controller_gains().
@@ -99,11 +100,8 @@ class JointActuator final : public MultibodyElement<T> {
   ///   `forces` is `nullptr` or if `forces` doest not have the right sizes to
   ///   accommodate a set of forces for the model to which this actuator
   ///   belongs.
-  void AddInOneForce(
-      const systems::Context<T>& context,
-      int joint_dof,
-      const T& tau,
-      MultibodyForces<T>* forces) const;
+  void AddInOneForce(const systems::Context<T>& context, int joint_dof,
+                     const T& tau, MultibodyForces<T>* forces) const;
 
   /// Gets the actuation values for `this` actuator from the actuation vector u
   /// for the entire plant model.
@@ -132,9 +130,8 @@ class JointActuator final : public MultibodyElement<T> {
   /// @throws std::exception if u is nullptr.
   /// @throws std::exception if
   ///   `u.size() != this->GetParentPlant().num_actuated_dofs()`.
-  void set_actuation_vector(
-      const Eigen::Ref<const VectorX<T>>& u_actuator,
-      EigenPtr<VectorX<T>> u) const;
+  void set_actuation_vector(const Eigen::Ref<const VectorX<T>>& u_actuator,
+                            EigenPtr<VectorX<T>> u) const;
 
   /// Returns the index to the first element for this joint actuator / within
   /// the vector of actuation inputs for the full multibody / system.
@@ -150,6 +147,8 @@ class JointActuator final : public MultibodyElement<T> {
   /// Returns the actuator effort limit.
   double effort_limit() const { return effort_limit_; }
 
+  // Don't let clang-format wrap long @image lines.
+  // clang-format off
   /// @anchor reflected_inertia
   /// @name                 Reflected Inertia
   ///
@@ -197,6 +196,7 @@ class JointActuator final : public MultibodyElement<T> {
   /// The gear ratio is defined ρ ≝ wR / vB (units of 1/m). Typically, ρ >> 1.
   /// For the gear-motor here, reflected inertia Iᵣᵢ = ρ² ⋅ Iᵣ (units of kg).
   ///@{
+  // clang-format on
 
   /// Gets the default value for this actuator's rotor inertia.
   /// See @ref reflected_inertia.
@@ -321,7 +321,7 @@ class JointActuator final : public MultibodyElement<T> {
   // MultibodyTree::CloneToScalar().
   template <typename ToScalar>
   std::unique_ptr<JointActuator<ToScalar>> CloneToScalar(
-  const internal::MultibodyTree<ToScalar>& cloned_tree) const {
+      const internal::MultibodyTree<ToScalar>& cloned_tree) const {
     return DoCloneToScalar(cloned_tree);
   }
   /// @endcond
@@ -329,7 +329,8 @@ class JointActuator final : public MultibodyElement<T> {
  private:
   // Allow different specializations to access each other's private constructor
   // for scalar conversion.
-  template <typename U> friend class JointActuator;
+  template <typename U>
+  friend class JointActuator;
 
   // Private constructor used for cloning.
   JointActuator(const std::string& name, JointIndex joint_index,

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.cc
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.cc
@@ -21,18 +21,15 @@ LinearBushingRollPitchYaw<T>::LinearBushingRollPitchYaw(
     const Vector3<double>& torque_damping_constants,
     const Vector3<double>& force_stiffness_constants,
     const Vector3<double>& force_damping_constants)
-    : LinearBushingRollPitchYaw(frameC.model_instance(),
-                                frameA.index(), frameC.index(),
-                                torque_stiffness_constants,
-                                torque_damping_constants,
-                                force_stiffness_constants,
-                                force_damping_constants) {}
+    : LinearBushingRollPitchYaw(
+          frameC.model_instance(), frameA.index(), frameC.index(),
+          torque_stiffness_constants, torque_damping_constants,
+          force_stiffness_constants, force_damping_constants) {}
 
 template <typename T>
 LinearBushingRollPitchYaw<T>::LinearBushingRollPitchYaw(
-    ModelInstanceIndex model_instance,
-    FrameIndex frameA_index, FrameIndex frameC_index,
-    const Vector3<double>& torque_stiffness_constants,
+    ModelInstanceIndex model_instance, FrameIndex frameA_index,
+    FrameIndex frameC_index, const Vector3<double>& torque_stiffness_constants,
     const Vector3<double>& torque_damping_constants,
     const Vector3<double>& force_stiffness_constants,
     const Vector3<double>& force_damping_constants)
@@ -103,7 +100,6 @@ void LinearBushingRollPitchYaw<T>::DoCalcAndAddForceContribution(
     const internal::PositionKinematicsCache<T>& /* pc */,
     const internal::VelocityKinematicsCache<T>& /* vc */,
     MultibodyForces<T>* forces) const {
-
   // Form F_Ao_A, the spatial force at point Ao of frame A due to the bushing.
   const SpatialForce<T> F_Ao_A = CalcBushingSpatialForceOnFrameA(context);
 
@@ -179,7 +175,7 @@ math::RotationMatrix<T> LinearBushingRollPitchYaw<T>::CalcR_AB(
   // e3 = λz sin(θ/4) = q3 / (2 cos(θ/4) ).
   // ----------------------------------------------------------------------
   using std::sqrt;
-  const T e0 = sqrt(0.5 *(q0 + 1));
+  const T e0 = sqrt(0.5 * (q0 + 1));
   // If q0 = −1 the e0 = 0 and the next line has a divide-by-zero error.
   // However, R_AC.ToQuaternion() guarantees q0 >= 0, so sqrt(0.5) <= e0 <= 1
   // which means the angle θₑ in e0 = cos(θₑ/2) has range  0 <= θₑ <= π/2.
@@ -218,8 +214,8 @@ template <typename T>
 Vector3<T> LinearBushingRollPitchYaw<T>::CalcBushing_xyzDt(
     const systems::Context<T>& context) const {
   // Calculate V_AC_A, frame C's spatial velocity in frame A, expressed in A.
-  const SpatialVelocity<T> V_AC_A = frameC().CalcSpatialVelocity(context,
-      frameA(), frameA());
+  const SpatialVelocity<T> V_AC_A =
+      frameC().CalcSpatialVelocity(context, frameA(), frameA());
   const Vector3<T>& w_AC_A = V_AC_A.rotational();
   const Vector3<T>& v_ACo_A = V_AC_A.translational();
   const Vector3<T> w_AB_A = 0.5 * w_AC_A;
@@ -286,20 +282,21 @@ Vector3<T> LinearBushingRollPitchYaw<T>::CalcBushingTorqueOnCExpressedInA(
 template <typename T>
 void LinearBushingRollPitchYaw<T>::ThrowPitchAngleViolatesGimbalLockTolerance(
     const T& pitch_angle, const char* function_name) {
-    const double pitch_radians = ExtractDoubleOrThrow(pitch_angle);
-    const double pitch_tolerance =
-        math::RollPitchYaw<double>::GimbalLockPitchAngleTolerance();
-    std::string message = fmt::format("LinearBushingRollPitchYaw::{}():"
-        " Pitch angle p = {:G} degrees is within {:G} degrees of gimbal-lock"
-        " which means p ≈ (n*π ± π/2) where n = 0, 1, 2, ..."
-        " There is a divide-by-zero error (singularity) at gimbal-lock due to"
-        " this bushing's mathematical dependence on roll-pitch-yaw angles."
-        " A pitch angle near gimbal-lock cause numerical inaccuracies.  To"
-        " avoid this pitch angle problem, use a reasonable default alignment of"
-        " the frames associated with this bushing and/or choose stiffness and"
-        " damping properties that help avoid pitch angles near gimbal lock.",
-        function_name, pitch_radians * 180 / M_PI, pitch_tolerance);
-    throw std::runtime_error(message);
+  const double pitch_radians = ExtractDoubleOrThrow(pitch_angle);
+  const double pitch_tolerance =
+      math::RollPitchYaw<double>::GimbalLockPitchAngleTolerance();
+  std::string message = fmt::format(
+      "LinearBushingRollPitchYaw::{}():"
+      " Pitch angle p = {:G} degrees is within {:G} degrees of gimbal-lock"
+      " which means p ≈ (n*π ± π/2) where n = 0, 1, 2, ..."
+      " There is a divide-by-zero error (singularity) at gimbal-lock due to"
+      " this bushing's mathematical dependence on roll-pitch-yaw angles."
+      " A pitch angle near gimbal-lock cause numerical inaccuracies.  To"
+      " avoid this pitch angle problem, use a reasonable default alignment of"
+      " the frames associated with this bushing and/or choose stiffness and"
+      " damping properties that help avoid pitch angles near gimbal lock.",
+      function_name, pitch_radians * 180 / M_PI, pitch_tolerance);
+  throw std::runtime_error(message);
 }
 
 template <typename T>
@@ -351,7 +348,8 @@ LinearBushingRollPitchYaw<T>::TemplatedDoCloneToScalar(
   // is needed to facilitate the _private_ use of constructor below.
   std::unique_ptr<LinearBushingRollPitchYaw<ToScalar>> bushing_clone(
       new LinearBushingRollPitchYaw<ToScalar>(this->model_instance(),
-          frameA_index_, frameC_index_, k012, d012, kxyz, dxyz));
+                                              frameA_index_, frameC_index_,
+                                              k012, d012, kxyz, dxyz));
 
   return bushing_clone;
 }

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.h
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.h
@@ -14,8 +14,11 @@
 namespace drake {
 namespace multibody {
 
-template <typename T> class RigidBody;
+template <typename T>
+class RigidBody;
 
+// Don't let clang-format wrap long @image lines.
+// clang-format off
 /// This ForceElement models a massless flexible bushing that connects a frame A
 /// of a link (body) L0 to a frame C of a link (body) L1.  The bushing can apply
 /// a torque and force due to stiffness (spring) and dissipation (damper)
@@ -316,6 +319,7 @@ template <typename T> class RigidBody;
 /// @note Per issue #12982, do not directly or indirectly call the following
 /// methods as they have not yet been implemented and throw an exception:
 /// CalcPotentialEnergy(), CalcConservativePower(), CalcNonConservativePower().
+// clang-format on
 template <typename T>
 class LinearBushingRollPitchYaw final : public ForceElement<T> {
   // TODO(Mitiguy) Add gimbal picture at "Relationship of 𝐭 to τ".
@@ -626,7 +630,7 @@ class LinearBushingRollPitchYaw final : public ForceElement<T> {
   // @throws std::exception if pitch angle is near gimbal-lock.  For more info,
   // @see RollPitchYaw::DoesCosPitchAngleViolateGimbalLockTolerance().
   static void ThrowPitchAngleViolatesGimbalLockTolerance(
-    const T& pitch_angle, const char* function_name);
+      const T& pitch_angle, const char* function_name);
 
   // The efficient algorithm CalcR_AB() above is verified in debug builds by
   // calculating the `θ λ` AngleAxis from R_AC and then forming R_AB_expected
@@ -705,7 +709,8 @@ class LinearBushingRollPitchYaw final : public ForceElement<T> {
   // @note `w_AC_A ≠ [q̇₀ q̇₁ q̇₂]`
   // @see CalcBushingRollPitchYawAngleRates() for `[q̇₀ q̇₁ q̇₂]`.
   Vector3<T> Calcw_AC_A(const systems::Context<T>& context) const {
-    return frameC().CalcSpatialVelocity(context, frameA(), frameA())
+    return frameC()
+        .CalcSpatialVelocity(context, frameA(), frameA())
         .rotational();
   }
 
@@ -799,7 +804,6 @@ class LinearBushingRollPitchYaw final : public ForceElement<T> {
   systems::NumericParameterIndex force_stiffness_parameter_index_;
   systems::NumericParameterIndex force_damping_parameter_index_;
 };
-
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/linear_spring_damper.cc
+++ b/multibody/tree/linear_spring_damper.cc
@@ -11,17 +11,20 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
-LinearSpringDamper<T>::LinearSpringDamper(
-    const RigidBody<T>& bodyA, const Vector3<double>& p_AP,
-    const RigidBody<T>& bodyB, const Vector3<double>& p_BQ,
-    double free_length, double stiffness, double damping) :
-    ForceElement<T>(bodyA.model_instance()),
-    bodyA_(bodyA),
-    p_AP_(p_AP),
-    bodyB_(bodyB),
-    p_BQ_(p_BQ),
-    free_length_(free_length),
-    stiffness_(stiffness), damping_(damping) {
+LinearSpringDamper<T>::LinearSpringDamper(const RigidBody<T>& bodyA,
+                                          const Vector3<double>& p_AP,
+                                          const RigidBody<T>& bodyB,
+                                          const Vector3<double>& p_BQ,
+                                          double free_length, double stiffness,
+                                          double damping)
+    : ForceElement<T>(bodyA.model_instance()),
+      bodyA_(bodyA),
+      p_AP_(p_AP),
+      bodyB_(bodyB),
+      p_BQ_(p_BQ),
+      free_length_(free_length),
+      stiffness_(stiffness),
+      damping_(damping) {
   DRAKE_THROW_UNLESS(free_length > 0);
   DRAKE_THROW_UNLESS(stiffness >= 0);
   DRAKE_THROW_UNLESS(damping >= 0);
@@ -32,8 +35,7 @@ LinearSpringDamper<T>::~LinearSpringDamper() = default;
 
 template <typename T>
 void LinearSpringDamper<T>::DoCalcAndAddForceContribution(
-    const systems::Context<T>&,
-    const internal::PositionKinematicsCache<T>& pc,
+    const systems::Context<T>&, const internal::PositionKinematicsCache<T>& pc,
     const internal::VelocityKinematicsCache<T>& vc,
     MultibodyForces<T>* forces) const {
   using std::sqrt;
@@ -53,8 +55,7 @@ void LinearSpringDamper<T>::DoCalcAndAddForceContribution(
   const Vector3<T> r_PQ_W = p_PQ_W / length_soft;
 
   // Force on A, applied at P, expressed in the world frame.
-  Vector3<T> f_AP_W =
-      stiffness() * (length_soft - free_length()) * r_PQ_W;
+  Vector3<T> f_AP_W = stiffness() * (length_soft - free_length()) * r_PQ_W;
 
   // The rate at which the length of the spring changes.
   const T length_dot = CalcLengthTimeDerivative(pc, vc);
@@ -99,8 +100,7 @@ T LinearSpringDamper<T>::CalcPotentialEnergy(
 
 template <typename T>
 T LinearSpringDamper<T>::CalcConservativePower(
-    const systems::Context<T>&,
-    const internal::PositionKinematicsCache<T>& pc,
+    const systems::Context<T>&, const internal::PositionKinematicsCache<T>& pc,
     const internal::VelocityKinematicsCache<T>& vc) const {
   // Since the potential energy is:
   //  V = 1/2⋅k⋅(ℓ-ℓ₀)²
@@ -131,8 +131,7 @@ T LinearSpringDamper<T>::CalcConservativePower(
 
 template <typename T>
 T LinearSpringDamper<T>::CalcNonConservativePower(
-    const systems::Context<T>&,
-    const internal::PositionKinematicsCache<T>& pc,
+    const systems::Context<T>&, const internal::PositionKinematicsCache<T>& pc,
     const internal::VelocityKinematicsCache<T>& vc) const {
   // The rate at which the length of the spring changes.
   const T length_dot = CalcLengthTimeDerivative(pc, vc);
@@ -145,22 +144,19 @@ template <typename ToScalar>
 std::unique_ptr<ForceElement<ToScalar>>
 LinearSpringDamper<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {
-  const RigidBody<ToScalar>& bodyA_clone =
-      tree_clone.get_body(bodyA().index());
-  const RigidBody<ToScalar>& bodyB_clone =
-      tree_clone.get_body(bodyB().index());
+  const RigidBody<ToScalar>& bodyA_clone = tree_clone.get_body(bodyA().index());
+  const RigidBody<ToScalar>& bodyB_clone = tree_clone.get_body(bodyB().index());
 
   // Make the LinearSpringDamper<T> clone.
   auto spring_damper_clone = std::make_unique<LinearSpringDamper<ToScalar>>(
-      bodyA_clone, p_AP(), bodyB_clone, p_BQ(),
-      free_length(), stiffness(), damping());
+      bodyA_clone, p_AP(), bodyB_clone, p_BQ(), free_length(), stiffness(),
+      damping());
 
   return spring_damper_clone;
 }
 
 template <typename T>
-std::unique_ptr<ForceElement<double>>
-LinearSpringDamper<T>::DoCloneToScalar(
+std::unique_ptr<ForceElement<double>> LinearSpringDamper<T>::DoCloneToScalar(
     const internal::MultibodyTree<double>& tree_clone) const {
   return TemplatedDoCloneToScalar(tree_clone);
 }
@@ -180,15 +176,16 @@ LinearSpringDamper<T>::DoCloneToScalar(
 }
 
 template <typename T>
-T LinearSpringDamper<T>::SafeSoftNorm(const Vector3<T> &x) const {
+T LinearSpringDamper<T>::SafeSoftNorm(const Vector3<T>& x) const {
   using std::sqrt;
   const double epsilon_length =
       std::numeric_limits<double>::epsilon() * free_length();
   const double epsilon_length_squared = epsilon_length * epsilon_length;
   const T x2 = x.squaredNorm();
   if (scalar_predicate<T>::is_bool && (x2 < epsilon_length_squared)) {
-    throw std::runtime_error("The length of the spring became nearly zero. "
-                                 "Revisit your model to avoid this situation.");
+    throw std::runtime_error(
+        "The length of the spring became nearly zero. "
+        "Revisit your model to avoid this situation.");
   }
   return sqrt(x2 + epsilon_length_squared);
 }

--- a/multibody/tree/linear_spring_damper.h
+++ b/multibody/tree/linear_spring_damper.h
@@ -10,7 +10,8 @@
 namespace drake {
 namespace multibody {
 
-template <typename T> class RigidBody;
+template <typename T>
+class RigidBody;
 
 /// This %ForceElement models a spring-damper attached between two points on
 /// two different bodies.
@@ -61,10 +62,9 @@ class LinearSpringDamper final : public ForceElement<T> {
   /// @throws std::exception if `free_length` is negative or zero.
   /// @throws std::exception if `stiffness` is negative.
   /// @throws std::exception if `damping` is negative.
-  LinearSpringDamper(
-      const RigidBody<T>& bodyA, const Vector3<double>& p_AP,
-      const RigidBody<T>& bodyB, const Vector3<double>& p_BQ,
-      double free_length, double stiffness, double damping);
+  LinearSpringDamper(const RigidBody<T>& bodyA, const Vector3<double>& p_AP,
+                     const RigidBody<T>& bodyB, const Vector3<double>& p_BQ,
+                     double free_length, double stiffness, double damping);
 
   ~LinearSpringDamper() override;
 
@@ -131,7 +131,7 @@ class LinearSpringDamper final : public ForceElement<T> {
   // This spring model does not allow the length of the spring to approach zero
   // since that would incur in a non-physical situation. Therefore this "safe"
   // norm will throw a std::exception when ‖x‖ < δ.
-  T SafeSoftNorm(const Vector3<T> &x) const;
+  T SafeSoftNorm(const Vector3<T>& x) const;
 
   // Helper method to compute the rate of change of the separation length
   // between the two endpoints for this spring-damper.

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -19,11 +19,13 @@ namespace drake {
 namespace multibody {
 
 // Forward declarations.
-template<typename T> class RigidBody;
+template <typename T>
+class RigidBody;
 
 namespace internal {
 
-template<typename T> class BodyNode;
+template <typename T>
+class BodyNode;
 
 // %Mobilizer is a fundamental object within Drake's multibody engine used to
 // specify the allowed motions between two Frame objects within a
@@ -265,9 +267,7 @@ class Mobilizer : public MultibodyElement<T> {
   ~Mobilizer() override;
 
   /// Returns this element's unique index.
-  MobodIndex index() const {
-    return this->template index_impl<MobodIndex>();
-  }
+  MobodIndex index() const { return this->template index_impl<MobodIndex>(); }
 
   // Returns the number of generalized coordinates granted by this mobilizer.
   // As an example, consider RevoluteMobilizer, for which
@@ -337,33 +337,24 @@ class Mobilizer : public MultibodyElement<T> {
   const SpanningForest::Mobod& mobod() const { return mobod_; }
 
   // Returns a constant reference to the inboard frame.
-  const Frame<T>& inboard_frame() const {
-    return inboard_frame_;
-  }
+  const Frame<T>& inboard_frame() const { return inboard_frame_; }
 
   // Returns a constant reference to the outboard frame.
-  const Frame<T>& outboard_frame() const {
-    return outboard_frame_;
-  }
+  const Frame<T>& outboard_frame() const { return outboard_frame_; }
 
   // Returns a constant reference to the body associated with `this`
   // mobilizer's inboard frame.
-  const RigidBody<T>& inboard_body() const {
-    return inboard_frame().body();
-  }
+  const RigidBody<T>& inboard_body() const { return inboard_frame().body(); }
 
   // Returns a constant reference to the body associated with `this`
   // mobilizer's outboard frame.
-  const RigidBody<T>& outboard_body() const {
-    return outboard_frame().body();
-  }
+  const RigidBody<T>& outboard_body() const { return outboard_frame().body(); }
 
   // Returns `true` if `this` mobilizer grants 6-dofs to the outboard frame.
   virtual bool is_floating() const { return false; }
 
   // Returns `true` if `this` uses a quaternion parametrization of rotations.
   virtual bool has_quaternion_dofs() const { return false; }
-
 
   // @name Methods that define a %Mobilizer
   // @{
@@ -514,10 +505,9 @@ class Mobilizer : public MultibodyElement<T> {
   //   expressed in the inboard frame F.
   // @retval tau
   //   The vector of generalized forces. It must live in ℝⁿᵛ.
-  virtual void ProjectSpatialForce(
-      const systems::Context<T>& context,
-      const SpatialForce<T>& F_Mo_F,
-      Eigen::Ref<VectorX<T>> tau) const = 0;
+  virtual void ProjectSpatialForce(const systems::Context<T>& context,
+                                   const SpatialForce<T>& F_Mo_F,
+                                   Eigen::Ref<VectorX<T>> tau) const = 0;
 
   // Computes the kinematic mapping matrix `N(q)` that maps generalized
   // velocities for this mobilizer to time derivatives of the generalized
@@ -530,8 +520,8 @@ class Mobilizer : public MultibodyElement<T> {
   //   `nq x nv` with nq and nv the number of generalized positions and the
   //   number of generalized velocities for this mobilizer, respectively.
   // @see MapVelocityToQDot().
-  void CalcNMatrix(
-      const systems::Context<T>& context, EigenPtr<MatrixX<T>> N) const {
+  void CalcNMatrix(const systems::Context<T>& context,
+                   EigenPtr<MatrixX<T>> N) const {
     DRAKE_DEMAND(N != nullptr);
     DRAKE_DEMAND(N->rows() == num_positions());
     DRAKE_DEMAND(N->cols() == num_velocities());
@@ -550,9 +540,8 @@ class Mobilizer : public MultibodyElement<T> {
   //   `nv x nq` with nq the number of generalized positions and nv the
   //   number of generalized velocities.
   // @see MapVelocityToQDot().
-  void CalcNplusMatrix(
-      const systems::Context<T>& context,
-      EigenPtr<MatrixX<T>> Nplus) const {
+  void CalcNplusMatrix(const systems::Context<T>& context,
+                       EigenPtr<MatrixX<T>> Nplus) const {
     DRAKE_DEMAND(Nplus != nullptr);
     DRAKE_DEMAND(Nplus->rows() == num_velocities());
     DRAKE_DEMAND(Nplus->cols() == num_positions());
@@ -564,19 +553,17 @@ class Mobilizer : public MultibodyElement<T> {
   // Computes the kinematic mapping `q̇ = N(q)⋅v` between generalized
   // velocities v and time derivatives of the generalized positions `qdot`.
   // The generalized positions vector is stored in `context`.
-  virtual void MapVelocityToQDot(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> qdot) const = 0;
+  virtual void MapVelocityToQDot(const systems::Context<T>& context,
+                                 const Eigen::Ref<const VectorX<T>>& v,
+                                 EigenPtr<VectorX<T>> qdot) const = 0;
 
   // Computes the mapping `v = N⁺(q)⋅q̇` from time derivatives of the
   // generalized positions `qdot` to generalized velocities v, where `N⁺(q)` is
   // the left pseudo-inverse of `N(q)` defined by MapVelocityToQDot().
   // The generalized positions vector is stored in `context`.
-  virtual void MapQDotToVelocity(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& qdot,
-      EigenPtr<VectorX<T>> v) const = 0;
+  virtual void MapQDotToVelocity(const systems::Context<T>& context,
+                                 const Eigen::Ref<const VectorX<T>>& qdot,
+                                 EigenPtr<VectorX<T>> v) const = 0;
   // @}
 
   // Returns a const Eigen expression of the vector of generalized positions
@@ -585,8 +572,7 @@ class Mobilizer : public MultibodyElement<T> {
   // @pre @p q_array is of size MultibodyTree::num_positions().
   Eigen::Ref<const VectorX<T>> get_positions_from_array(
       const Eigen::Ref<const VectorX<T>>& q_array) const {
-    DRAKE_DEMAND(
-        q_array.size() == this->get_parent_tree().num_positions());
+    DRAKE_DEMAND(q_array.size() == this->get_parent_tree().num_positions());
     return q_array.segment(position_start_in_q(), num_positions());
   }
 
@@ -594,8 +580,7 @@ class Mobilizer : public MultibodyElement<T> {
   Eigen::Ref<VectorX<T>> get_mutable_positions_from_array(
       EigenPtr<VectorX<T>> q_array) const {
     DRAKE_DEMAND(q_array != nullptr);
-    DRAKE_DEMAND(
-        q_array->size() == this->get_parent_tree().num_positions());
+    DRAKE_DEMAND(q_array->size() == this->get_parent_tree().num_positions());
     return q_array->segment(position_start_in_q(), num_positions());
   }
 
@@ -603,10 +588,9 @@ class Mobilizer : public MultibodyElement<T> {
   // for `this` mobilizer from a vector `v_array` of generalized velocities for
   // the entire MultibodyTree model.
   // @pre @p v_array is of size MultibodyTree::num_velocities().
-  Eigen::Ref<const VectorX<T>>
-  get_velocities_from_array(const Eigen::Ref<const VectorX<T>>& v_array) const {
-    DRAKE_DEMAND(
-        v_array.size() == this->get_parent_tree().num_velocities());
+  Eigen::Ref<const VectorX<T>> get_velocities_from_array(
+      const Eigen::Ref<const VectorX<T>>& v_array) const {
+    DRAKE_DEMAND(v_array.size() == this->get_parent_tree().num_velocities());
     return v_array.segment(velocity_start_in_v(), num_velocities());
   }
 
@@ -614,8 +598,7 @@ class Mobilizer : public MultibodyElement<T> {
   Eigen::Ref<VectorX<T>> get_mutable_velocities_from_array(
       EigenPtr<VectorX<T>> v_array) const {
     DRAKE_DEMAND(v_array != nullptr);
-    DRAKE_DEMAND(
-        v_array->size() == this->get_parent_tree().num_velocities());
+    DRAKE_DEMAND(v_array->size() == this->get_parent_tree().num_velocities());
     return v_array->segment(velocity_start_in_v(), num_velocities());
   }
 
@@ -665,8 +648,8 @@ class Mobilizer : public MultibodyElement<T> {
 
   // For MultibodyTree internal use only.
   virtual std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const = 0;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const = 0;
 
   // Lock the mobilizer. Its generalized velocities will be 0 until it is
   // unlocked.
@@ -696,14 +679,13 @@ class Mobilizer : public MultibodyElement<T> {
  protected:
   // NVI to CalcNMatrix(). Implementations can safely assume that N is not the
   // nullptr and that N has the proper size.
-  virtual void DoCalcNMatrix(
-      const systems::Context<T>& context, EigenPtr<MatrixX<T>> N) const = 0;
+  virtual void DoCalcNMatrix(const systems::Context<T>& context,
+                             EigenPtr<MatrixX<T>> N) const = 0;
 
   // NVI to CalcNplusMatrix(). Implementations can safely assume that Nplus is
   // not the nullptr and that Nplus has the proper size.
-  virtual void DoCalcNplusMatrix(
-      const systems::Context<T>& context,
-      EigenPtr<MatrixX<T>> Nplus) const = 0;
+  virtual void DoCalcNplusMatrix(const systems::Context<T>& context,
+                                 EigenPtr<MatrixX<T>> Nplus) const = 0;
 
   // @name Methods to make a clone templated on different scalar types.
   //

--- a/multibody/tree/mobilizer_impl.cc
+++ b/multibody/tree/mobilizer_impl.cc
@@ -8,13 +8,13 @@ template <typename T, int nq, int nv>
 MobilizerImpl<T, nq, nv>::~MobilizerImpl() = default;
 
 // Macro used to explicitly instantiate implementations on all sizes needed.
-#define EXPLICITLY_INSTANTIATE_IMPLS(T) \
-template class MobilizerImpl<T, 0, 0>; \
-template class MobilizerImpl<T, 1, 1>; \
-template class MobilizerImpl<T, 2, 2>; \
-template class MobilizerImpl<T, 3, 3>; \
-template class MobilizerImpl<T, 6, 6>; \
-template class MobilizerImpl<T, 7, 6>;
+#define EXPLICITLY_INSTANTIATE_IMPLS(T)  \
+  template class MobilizerImpl<T, 0, 0>; \
+  template class MobilizerImpl<T, 1, 1>; \
+  template class MobilizerImpl<T, 2, 2>; \
+  template class MobilizerImpl<T, 3, 3>; \
+  template class MobilizerImpl<T, 6, 6>; \
+  template class MobilizerImpl<T, 7, 6>;
 
 // Explicitly instantiates on the supported scalar types.
 // These should be kept in sync with the list in default_scalars.h.

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -52,8 +52,8 @@ Users should not need to interact with this class directly unless they need
 to implement a custom Mobilizer class.
 
 @tparam_default_scalar */
-template <typename T,
-    int compile_time_num_positions, int compile_time_num_velocities>
+template <typename T, int compile_time_num_positions,
+          int compile_time_num_velocities>
 class MobilizerImpl : public Mobilizer<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MobilizerImpl);
@@ -100,8 +100,9 @@ class MobilizerImpl : public Mobilizer<T> {
 
   // Sets the default position of this Mobilizer to be used in subsequent
   // calls to set_default_state().
-  void set_default_position(const Eigen::Ref<const Vector<double,
-      compile_time_num_positions>>& position) {
+  void set_default_position(
+      const Eigen::Ref<const Vector<double, compile_time_num_positions>>&
+          position) {
     default_position_.emplace(position);
   }
 
@@ -144,8 +145,7 @@ class MobilizerImpl : public Mobilizer<T> {
       const Eigen::Ref<const Vector<symbolic::Expression,
                                     compile_time_num_velocities>>& velocity) {
     if (!random_state_distribution_) {
-      random_state_distribution_.emplace(
-          Vector<symbolic::Expression, kNx>());
+      random_state_distribution_.emplace(Vector<symbolic::Expression, kNx>());
       // Maintain the default behavior for position.
       random_state_distribution_->template head<kNq>() = get_zero_position();
     }
@@ -212,8 +212,8 @@ class MobilizerImpl : public Mobilizer<T> {
   // @pre `context` is a valid multibody system Context.
   Eigen::VectorBlock<const VectorX<T>, kNv> get_velocities(
       const systems::Context<T>& context) const {
-    return this->get_parent_tree().template get_state_segment<kNv>(context,
-        num_qs_in_state() + this->velocity_start_in_v());
+    return this->get_parent_tree().template get_state_segment<kNv>(
+        context, num_qs_in_state() + this->velocity_start_in_v());
   }
 
   // Helper to return a mutable fixed-size Eigen::VectorBlock referencing the

--- a/multibody/tree/model_instance.cc
+++ b/multibody/tree/model_instance.cc
@@ -55,7 +55,7 @@ VectorX<T> ModelInstance<T>::GetActuationFromArray(
   for (const JointActuator<T>* actuator : joint_actuators_) {
     const int num_dofs = actuator->joint().num_velocities();
     u_instance.segment(u_instance_offset, num_dofs) =
-       actuator->get_actuation_vector(u);
+        actuator->get_actuation_vector(u);
     u_instance_offset += num_dofs;
     DRAKE_DEMAND(u_instance_offset <= u.size());
   }
@@ -94,8 +94,7 @@ VectorX<T> ModelInstance<T>::GetPositionsFromArray(
 
 template <typename T>
 void ModelInstance<T>::GetPositionsFromArray(
-    const Eigen::Ref<const VectorX<T>>& q,
-    EigenPtr<VectorX<T>> q_out) const {
+    const Eigen::Ref<const VectorX<T>>& q, EigenPtr<VectorX<T>> q_out) const {
   DRAKE_DEMAND(q_out != nullptr);
   if (q.size() != this->get_parent_tree().num_positions())
     throw std::logic_error("Passed in array is not properly sized.");
@@ -141,8 +140,7 @@ VectorX<T> ModelInstance<T>::GetVelocitiesFromArray(
 
 template <typename T>
 void ModelInstance<T>::GetVelocitiesFromArray(
-    const Eigen::Ref<const VectorX<T>>& v,
-    EigenPtr<VectorX<T>> v_out) const {
+    const Eigen::Ref<const VectorX<T>>& v, EigenPtr<VectorX<T>> v_out) const {
   DRAKE_DEMAND(v_out != nullptr);
   if (v.size() != this->get_parent_tree().num_velocities())
     throw std::logic_error("Passed in array is not properly sized.");

--- a/multibody/tree/model_instance.h
+++ b/multibody/tree/model_instance.h
@@ -116,8 +116,7 @@ class ModelInstance final : public MultibodyElement<T> {
   // increasing JointActuatorIndex within this model instance.
   // @throws std::exception if `u` is not of size
   //         MultibodyTree::num_actuators().
-  VectorX<T> GetActuationFromArray(
-      const Eigen::Ref<const VectorX<T>>& u) const;
+  VectorX<T> GetActuationFromArray(const Eigen::Ref<const VectorX<T>>& u) const;
 
   // Given the actuation values `u_instance` for all actuators in `this` model
   // instance, updates the portion of the actuation vector `u` corresponding to
@@ -137,26 +136,23 @@ class ModelInstance final : public MultibodyElement<T> {
   //   is not of size equal to the number of degrees of freedom of all of the
   //   actuated joints in the entire MultibodyTree model to which `this`
   //   actuator belongs to.
-  void SetActuationInArray(
-      const Eigen::Ref<const VectorX<T>>& u_instance,
-      EigenPtr<VectorX<T>> u) const;
+  void SetActuationInArray(const Eigen::Ref<const VectorX<T>>& u_instance,
+                           EigenPtr<VectorX<T>> u) const;
 
   // Returns an Eigen vector of the generalized positions
   // for `this` model instance from a vector `q` of generalized
   // positions for the entire MultibodyTree model.
   // @throws std::exception if `q` is not of size
   //         MultibodyTree::num_positions().
-  VectorX<T> GetPositionsFromArray(
-      const Eigen::Ref<const VectorX<T>>& q) const;
+  VectorX<T> GetPositionsFromArray(const Eigen::Ref<const VectorX<T>>& q) const;
 
   // (Advanced) Takes an output vector q_out and populates it with the
   // generalized positions for `this` model instance from a vector `q` of
   // generalized positions for the entire MultibodyTree model.
   // @throws std::exception if `q` is not of size
   //         MultibodyTree::num_positions().
-  void GetPositionsFromArray(
-      const Eigen::Ref<const VectorX<T>>& q,
-      EigenPtr<VectorX<T>> q_out) const;
+  void GetPositionsFromArray(const Eigen::Ref<const VectorX<T>>& q,
+                             EigenPtr<VectorX<T>> q_out) const;
 
   // Sets the vector of generalized positions for `this` model instance in
   // the relevant locations of an array that corresponds to the positions for
@@ -167,9 +163,8 @@ class ModelInstance final : public MultibodyElement<T> {
   // @throws std::exception if `q` is not of size
   //         MultibodyTree::num_positions() or `q_instance` is not of size
   //         num_positions().
-  void SetPositionsInArray(
-      const Eigen::Ref<const VectorX <T>>& q_instance,
-      EigenPtr<VectorX<T>> q) const;
+  void SetPositionsInArray(const Eigen::Ref<const VectorX<T>>& q_instance,
+                           EigenPtr<VectorX<T>> q) const;
 
   // Returns an Eigen vector of the generalized velocities
   // for `this` mobilizer from a vector `v` of generalized velocities for
@@ -184,9 +179,8 @@ class ModelInstance final : public MultibodyElement<T> {
   // generalized velocities for the entire MultibodyTree model.
   // @throws std::exception if `v` is not of size
   //         MultibodyTree::num_velocities().
-  void GetVelocitiesFromArray(
-      const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> v_out) const;
+  void GetVelocitiesFromArray(const Eigen::Ref<const VectorX<T>>& v,
+                              EigenPtr<VectorX<T>> v_out) const;
 
   // Sets the vector of generalized velocities for `this` model instance in
   // the relevant locations of an array corresponding to the velocities for the
@@ -197,9 +191,8 @@ class ModelInstance final : public MultibodyElement<T> {
   // @throws std::exception if `v` is not of size
   //         MultibodyTree::num_velocities() or `v_instance` is not of size
   //         num_velocities().
-  void SetVelocitiesInArray(
-      const Eigen::Ref<const VectorX<T>>& v_instance,
-      EigenPtr<VectorX<T>> v) const;
+  void SetVelocitiesInArray(const Eigen::Ref<const VectorX<T>>& v_instance,
+                            EigenPtr<VectorX<T>> v) const;
 
  private:
   void DoSetTopology(const MultibodyTreeTopology&) final {}

--- a/multibody/tree/multibody_element.cc
+++ b/multibody/tree/multibody_element.cc
@@ -52,16 +52,15 @@ template <typename T>
 systems::NumericParameterIndex MultibodyElement<T>::DeclareNumericParameter(
     MultibodyTreeSystem<T>* tree_system,
     const systems::BasicVector<T>& model_vector) {
-  return internal::MultibodyTreeSystemElementAttorney<T>
-      ::DeclareNumericParameter(tree_system, model_vector);
+  return internal::MultibodyTreeSystemElementAttorney<
+      T>::DeclareNumericParameter(tree_system, model_vector);
 }
 
 template <typename T>
 systems::AbstractParameterIndex MultibodyElement<T>::DeclareAbstractParameter(
-    MultibodyTreeSystem<T>* tree_system,
-    const AbstractValue& model_value) {
-  return internal::MultibodyTreeSystemElementAttorney<T>
-      ::DeclareAbstractParameter(tree_system, model_value);
+    MultibodyTreeSystem<T>* tree_system, const AbstractValue& model_value) {
+  return internal::MultibodyTreeSystemElementAttorney<
+      T>::DeclareAbstractParameter(tree_system, model_value);
 }
 
 template <typename T>
@@ -77,8 +76,9 @@ void MultibodyElement<T>::HasThisParentTreeOrThrow(
     const internal::MultibodyTree<T>* tree) const {
   DRAKE_ASSERT(tree != nullptr);
   if (parent_tree_ != tree) {
-    throw std::logic_error("This multibody element does not belong to the "
-                           "supplied MultibodyTree.");
+    throw std::logic_error(
+        "This multibody element does not belong to the "
+        "supplied MultibodyTree.");
   }
 }
 

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -153,8 +153,7 @@ class MultibodyElement {
   // Give unit tests access to the tree.
   friend class MultibodyElementTester;
 
-  void set_parent_tree(
-      const internal::MultibodyTree<T>* tree, int64_t index) {
+  void set_parent_tree(const internal::MultibodyTree<T>* tree, int64_t index) {
     index_ = index;
     parent_tree_ = tree;
   }

--- a/multibody/tree/multibody_forces.h
+++ b/multibody/tree/multibody_forces.h
@@ -11,8 +11,10 @@ namespace drake {
 namespace multibody {
 
 namespace internal {
-template <typename T> class MultibodyTree;
-template <typename T> class MultibodyTreeSystem;
+template <typename T>
+class MultibodyTree;
+template <typename T>
+class MultibodyTreeSystem;
 }  // namespace internal
 
 /// A class to hold a set of forces applied to a MultibodyTree system. Forces

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -46,9 +46,8 @@ const FrameType<T>& MultibodyTree<T>::AddFrame(
                 "FrameType must be a sub-class of Frame<T>.");
   if (topology_is_valid()) {
     throw std::logic_error(
-        "This MultibodyTree is finalized already. "
-        "Therefore adding more frames is not allowed. "
-        "See documentation for Finalize() for details.");
+        "This MultibodyTree is finalized already. Therefore adding more frames "
+        "is not allowed. See documentation for Finalize() for details.");
   }
   if (frame == nullptr) {
     throw std::logic_error("Input frame is a nullptr.");
@@ -74,24 +73,24 @@ const FrameType<T>& MultibodyTree<T>::AddFrame(
 }
 
 template <typename T>
-template<template<typename Scalar> class FrameType, typename... Args>
+template <template <typename Scalar> class FrameType, typename... Args>
 const FrameType<T>& MultibodyTree<T>::AddFrame(Args&&... args) {
   static_assert(std::is_convertible_v<FrameType<T>*, Frame<T>*>,
                 "FrameType must be a sub-class of Frame<T>.");
-  return AddFrame(
-      std::make_unique<FrameType<T>>(std::forward<Args>(args)...));
+  return AddFrame(std::make_unique<FrameType<T>>(std::forward<Args>(args)...));
 }
 
 template <typename T>
-template <template<typename Scalar> class MobilizerType>
+template <template <typename Scalar> class MobilizerType>
 const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
     std::unique_ptr<MobilizerType<T>> mobilizer) {
   static_assert(std::is_convertible_v<MobilizerType<T>*, Mobilizer<T>*>,
                 "MobilizerType must be a sub-class of mobilizer<T>.");
   if (topology_is_valid()) {
-    throw std::logic_error("This MultibodyTree is finalized already. "
-                           "Therefore adding more mobilizers is not allowed. "
-                           "See documentation for Finalize() for details.");
+    throw std::logic_error(
+        "This MultibodyTree is finalized already. Therefore adding more "
+        "mobilizers is not allowed. See documentation for Finalize() for "
+        "details.");
   }
   if (mobilizer == nullptr) {
     throw std::logic_error("Input mobilizer is a nullptr.");
@@ -103,8 +102,7 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
   mobilizer->inboard_frame().HasThisParentTreeOrThrow(this);
   mobilizer->outboard_frame().HasThisParentTreeOrThrow(this);
   MobodIndex mobilizer_index = topology_.add_mobilizer(
-      mobilizer->mobod(),
-      mobilizer->inboard_frame().index(),
+      mobilizer->mobod(), mobilizer->inboard_frame().index(),
       mobilizer->outboard_frame().index());
 
   // This DRAKE_DEMAND MUST be performed BEFORE mobilizers_.push_back()
@@ -140,7 +138,7 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
 }
 
 template <typename T>
-template<template<typename Scalar> class MobilizerType, typename... Args>
+template <template <typename Scalar> class MobilizerType, typename... Args>
 const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(Args&&... args) {
   static_assert(std::is_base_of_v<Mobilizer<T>, MobilizerType<T>>,
                 "MobilizerType must be a sub-class of Mobilizer<T>.");
@@ -149,24 +147,23 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(Args&&... args) {
 }
 
 template <typename T>
-template <template<typename Scalar> class ForceElementType>
+template <template <typename Scalar> class ForceElementType>
 const ForceElementType<T>& MultibodyTree<T>::AddForceElement(
     std::unique_ptr<ForceElementType<T>> force_element) {
-  static_assert(
-      std::is_convertible_v<ForceElementType<T>*, ForceElement<T>*>,
-      "ForceElementType<T> must be a sub-class of ForceElement<T>.");
+  static_assert(std::is_convertible_v<ForceElementType<T>*, ForceElement<T>*>,
+                "ForceElementType<T> must be a sub-class of ForceElement<T>.");
   if (topology_is_valid()) {
     throw std::logic_error(
-        "This MultibodyTree is finalized already. Therefore adding more "
-        "force elements is not allowed. "
-        "See documentation for Finalize() for details.");
+        "This MultibodyTree is finalized already. Therefore adding more force "
+        "elements is not allowed. See documentation for Finalize() for "
+        "details.");
   }
   if (force_element == nullptr) {
     throw std::logic_error("Input force element is a nullptr.");
   }
 
-  auto gravity_element = dynamic_cast<UniformGravityFieldElement<T>*>(
-      force_element.get());
+  auto gravity_element =
+      dynamic_cast<UniformGravityFieldElement<T>*>(force_element.get());
   if (gravity_element) {
     if (gravity_field_) {
       throw std::runtime_error(
@@ -186,9 +183,8 @@ const ForceElementType<T>& MultibodyTree<T>::AddForceElement(
 }
 
 template <typename T>
-template<template<typename Scalar> class ForceElementType, typename... Args>
-const ForceElementType<T>&
-MultibodyTree<T>::AddForceElement(Args&&... args) {
+template <template <typename Scalar> class ForceElementType, typename... Args>
+const ForceElementType<T>& MultibodyTree<T>::AddForceElement(Args&&... args) {
   static_assert(std::is_base_of_v<ForceElement<T>, ForceElementType<T>>,
                 "ForceElementType<T> must be a sub-class of "
                 "ForceElement<T>.");
@@ -197,7 +193,7 @@ MultibodyTree<T>::AddForceElement(Args&&... args) {
 }
 
 template <typename T>
-template <template<typename Scalar> class JointType>
+template <template <typename Scalar> class JointType>
 const JointType<T>& MultibodyTree<T>::AddJoint(
     std::unique_ptr<JointType<T>> joint, bool is_ephemeral_joint) {
   static_assert(std::is_convertible_v<JointType<T>*, Joint<T>*>,
@@ -212,9 +208,9 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
   }
 
   if (topology_is_valid()) {
-    throw std::logic_error("This MultibodyTree is finalized already. "
-                           "Therefore adding more joints is not allowed. "
-                           "See documentation for Finalize() for details.");
+    throw std::logic_error(
+        "This MultibodyTree is finalized already. Therefore adding more joints "
+        "is not allowed. See documentation for Finalize() for details.");
   }
   if (joint == nullptr) {
     throw std::logic_error("Input joint is a nullptr.");
@@ -237,8 +233,7 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
 
   // User joints need to be registered with the LinkJointGraph but joints added
   // during modeling are already in the graph.
-  if (!is_ephemeral_joint)
-    RegisterJointAndMaybeJointTypeInGraph(*joint.get());
+  if (!is_ephemeral_joint) RegisterJointAndMaybeJointTypeInGraph(*joint.get());
 
   joint->set_parent_tree(this, joints_.next_index());
   joint->set_ordinal(joints_.num_elements());
@@ -248,14 +243,12 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
 }
 
 template <typename T>
-template<template<typename> class JointType, typename... Args>
+template <template <typename> class JointType, typename... Args>
 const JointType<T>& MultibodyTree<T>::AddJoint(
-    const std::string& name,
-    const RigidBody<T>& parent,
+    const std::string& name, const RigidBody<T>& parent,
     const std::optional<math::RigidTransform<double>>& X_PF,
     const RigidBody<T>& child,
-    const std::optional<math::RigidTransform<double>>& X_BM,
-    Args&&... args) {
+    const std::optional<math::RigidTransform<double>>& X_BM, Args&&... args) {
   static_assert(std::is_base_of_v<Joint<T>, JointType<T>>,
                 "JointType<T> must be a sub-class of Joint<T>.");
 
@@ -285,16 +278,15 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
 // This is internal use only so doesn't need the error checking provided
 // by the AddJoint() signature.
 template <typename T>
-template<template<typename> class JointType, typename... Args>
+template <template <typename> class JointType, typename... Args>
 const JointType<T>& MultibodyTree<T>::AddEphemeralJoint(
-    const std::string& name,
-    const RigidBody<T>& parent,
-    const RigidBody<T>& child,
-    Args&&... args) {
-
-  const JointType<T>& result = AddJoint(std::make_unique<JointType<T>>(
-  name, parent.body_frame(), child.body_frame(), std::forward<Args>(args)...),
-                                        true /*ephemeral joint*/);
+    const std::string& name, const RigidBody<T>& parent,
+    const RigidBody<T>& child, Args&&... args) {
+  const JointType<T>& result =
+      AddJoint(std::make_unique<JointType<T>>(name, parent.body_frame(),
+                                              child.body_frame(),
+                                              std::forward<Args>(args)...),
+               true /*ephemeral joint*/);
   return result;
 }
 
@@ -309,9 +301,10 @@ const JointActuator<T>& MultibodyTree<T>::AddJointActuator(
   }
 
   if (topology_is_valid()) {
-    throw std::logic_error("This MultibodyTree is finalized already. "
-                           "Therefore adding more actuators is not allowed. "
-                           "See documentation for Finalize() for details.");
+    throw std::logic_error(
+        "This MultibodyTree is finalized already. Therefore adding more "
+        "actuators is not allowed. See documentation for Finalize() for "
+        "details.");
   }
 
   // Create the JointActuator before making any changes to our member fields, so
@@ -328,14 +321,14 @@ ModelInstanceIndex MultibodyTree<T>::AddModelInstance(const std::string& name) {
   if (HasModelInstanceNamed(name)) {
     throw std::logic_error(
         "This model already contains a model instance named '" + name +
-            "'. Model instance names must be unique within a given model.");
+        "'. Model instance names must be unique within a given model.");
   }
 
   if (topology_is_valid()) {
-    throw std::logic_error("This MultibodyTree is finalized already. "
-                           "Therefore adding more model instances is not "
-                           "allowed. See documentation for Finalize() for "
-                           "details.");
+    throw std::logic_error(
+        "This MultibodyTree is finalized already. Therefore adding more model "
+        "instances is not allowed. See documentation for Finalize() for "
+        "details.");
   }
   const ModelInstanceIndex index = model_instances_.next_index();
   auto element = std::make_unique<internal::ModelInstance<T>>(index, name);
@@ -348,18 +341,20 @@ template <typename T>
 void MultibodyTree<T>::RenameModelInstance(ModelInstanceIndex model_instance,
                                            const std::string& name) {
   const auto old_name = this->GetModelInstanceName(model_instance);
-  if (old_name == name) { return; }
+  if (old_name == name) {
+    return;
+  }
   if (HasModelInstanceNamed(name)) {
     throw std::logic_error(
         "This model already contains a model instance named '" + name +
-            "'. Model instance names must be unique within a given model.");
+        "'. Model instance names must be unique within a given model.");
   }
 
   if (topology_is_valid()) {
-    throw std::logic_error("This MultibodyTree is finalized already. "
-                           "Therefore renaming model instances is not "
-                           "allowed. See documentation for Finalize() for "
-                           "details.");
+    throw std::logic_error(
+        "This MultibodyTree is finalized already. Therefore renaming model "
+        "instances is not allowed. See documentation for Finalize() for "
+        "details.");
   }
 
   model_instances_.Rename(model_instance, name);
@@ -454,7 +449,6 @@ template <typename T>
 Eigen::VectorBlock<const VectorX<T>>
 MultibodyTree<T>::get_positions_and_velocities(
     const systems::Context<T>& context) const {
-
   // Note that we can't currently count on MultibodyPlant's API to have
   // validated this Context. The extract_qv_from_continuous() call
   // below depends on this being a LeafContext. We'll just verify that this
@@ -606,7 +600,7 @@ MultibodyTree<T>::get_mutable_discrete_state_vector(
   systems::BasicVector<T>& discrete_state_vector =
       state->get_mutable_discrete_state(discrete_state_index_);
   DRAKE_ASSERT(discrete_state_vector.size() ==
-      num_positions() + num_velocities());
+               num_positions() + num_velocities());
   return discrete_state_vector.get_mutable_value();
 }
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -236,9 +236,8 @@ std::string_view GetElementClassname() {
 
 // Given a tree and element index, returns the corresponding `const Element&`.
 template <typename T, typename ElementIndex>
-const auto& GetElementByIndex(
-    const MultibodyTree<T>& tree,
-    const ElementIndex index) {
+const auto& GetElementByIndex(const MultibodyTree<T>& tree,
+                              const ElementIndex index) {
   if constexpr (std::is_same_v<ElementIndex, BodyIndex>) {
     return tree.get_body(index);
   }
@@ -285,10 +284,9 @@ std::string GetElementModelInstancesByName(
 
 // Common implementation for HasBodyNamed, HasFrameNamed, etc.
 template <typename T, typename ElementIndex>
-bool HasElementNamed(
-    const MultibodyTree<T>& tree, std::string_view name,
-    std::optional<ModelInstanceIndex> model_instance,
-    const NameToIndex<ElementIndex>& name_to_index) {
+bool HasElementNamed(const MultibodyTree<T>& tree, std::string_view name,
+                     std::optional<ModelInstanceIndex> model_instance,
+                     const NameToIndex<ElementIndex>& name_to_index) {
   // Find all elements with a matching name.
   const auto [lower, upper] = name_to_index.equal_range(name);
 
@@ -332,17 +330,16 @@ bool HasElementNamed(
 
 // Common implementation for GetRigidBodyByName, GetFrameByName, etc.
 template <typename T, typename ElementIndex>
-const auto& GetElementByName(
-    const MultibodyTree<T>& tree, std::string_view name,
-    std::optional<ModelInstanceIndex> model_instance,
-    const NameToIndex<ElementIndex>& name_to_index) {
+const auto& GetElementByName(const MultibodyTree<T>& tree,
+                             std::string_view name,
+                             std::optional<ModelInstanceIndex> model_instance,
+                             const NameToIndex<ElementIndex>& name_to_index) {
   // We fetch the model instance name as the first operation in this function
   // (even though we'll only need it for error messages) because it throws an
   // exception when the model_instance index is invalid.
   const std::string empty_name;
   const std::string& model_instance_name =
-      model_instance ? tree.GetModelInstanceName(*model_instance)
-                     : empty_name;
+      model_instance ? tree.GetModelInstanceName(*model_instance) : empty_name;
   const std::string_view element_classname =
       GetElementClassname<ElementIndex>();
 
@@ -441,8 +438,8 @@ bool MultibodyTree<T>::HasFrameNamed(std::string_view name) const {
 }
 
 template <typename T>
-bool MultibodyTree<T>::HasFrameNamed(
-    std::string_view name, ModelInstanceIndex model_instance) const {
+bool MultibodyTree<T>::HasFrameNamed(std::string_view name,
+                                     ModelInstanceIndex model_instance) const {
   return HasElementNamed(*this, name, model_instance, frames_.names_map());
 }
 
@@ -452,8 +449,8 @@ bool MultibodyTree<T>::HasJointNamed(std::string_view name) const {
 }
 
 template <typename T>
-bool MultibodyTree<T>::HasJointNamed(
-    std::string_view name, ModelInstanceIndex model_instance) const {
+bool MultibodyTree<T>::HasJointNamed(std::string_view name,
+                                     ModelInstanceIndex model_instance) const {
   return HasElementNamed(*this, name, model_instance, joints_.names_map());
 }
 
@@ -711,8 +708,7 @@ VectorX<T> MultibodyTree<T>::GetPositionsFromArray(
 
 template <typename T>
 void MultibodyTree<T>::GetPositionsFromArray(
-    ModelInstanceIndex model_instance,
-    const Eigen::Ref<const VectorX<T>>& q,
+    ModelInstanceIndex model_instance, const Eigen::Ref<const VectorX<T>>& q,
     drake::EigenPtr<VectorX<T>> q_out) const {
   model_instances_.get_element(model_instance).GetPositionsFromArray(q, q_out);
 }
@@ -735,8 +731,7 @@ VectorX<T> MultibodyTree<T>::GetVelocitiesFromArray(
 
 template <typename T>
 void MultibodyTree<T>::GetVelocitiesFromArray(
-    ModelInstanceIndex model_instance,
-    const Eigen::Ref<const VectorX<T>>& v,
+    ModelInstanceIndex model_instance, const Eigen::Ref<const VectorX<T>>& v,
     drake::EigenPtr<VectorX<T>> v_out) const {
   model_instances_.get_element(model_instance).GetVelocitiesFromArray(v, v_out);
 }
@@ -803,8 +798,7 @@ void MultibodyTree<T>::CreateJointImplementations() {
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-MultibodyTree<T>::GetFreeBodyMobilizerOrThrow(
-    const RigidBody<T>& body) const {
+MultibodyTree<T>::GetFreeBodyMobilizerOrThrow(const RigidBody<T>& body) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   DRAKE_DEMAND(body.index() != world_index());
   const RigidBodyTopology& rigid_body_topology =
@@ -813,8 +807,8 @@ MultibodyTree<T>::GetFreeBodyMobilizerOrThrow(
       dynamic_cast<const QuaternionFloatingMobilizer<T>*>(
           &get_mobilizer(rigid_body_topology.inboard_mobilizer));
   if (mobilizer == nullptr) {
-    throw std::logic_error(
-        "Body '" + body.name() + "' is not a free floating body.");
+    throw std::logic_error("Body '" + body.name() +
+                           "' is not a free floating body.");
   }
   return *mobilizer;
 }
@@ -881,8 +875,8 @@ void MultibodyTree<T>::FinalizeInternals() {
   }
 
   body_node_levels_.resize(topology_.forest_height());
-  for (MobodIndex mobod_index(1);
-       mobod_index < topology_.num_mobods(); ++mobod_index) {
+  for (MobodIndex mobod_index(1); mobod_index < topology_.num_mobods();
+       ++mobod_index) {
     const BodyNodeTopology& node_topology =
         topology_.get_body_node(mobod_index);
     body_node_levels_[node_topology.level].push_back(mobod_index);
@@ -891,8 +885,8 @@ void MultibodyTree<T>::FinalizeInternals() {
   // Creates BodyNodes:
   // This recursion order ensures that a BodyNode's parent is created before the
   // node itself, since BodyNode objects are in Depth First Traversal order.
-  for (MobodIndex mobod_index(0);
-       mobod_index < topology_.num_mobods(); ++mobod_index) {
+  for (MobodIndex mobod_index(0); mobod_index < topology_.num_mobods();
+       ++mobod_index) {
     CreateBodyNode(mobod_index);
   }
 
@@ -969,8 +963,7 @@ void MultibodyTree<T>::Finalize() {
 
 template <typename T>
 void MultibodyTree<T>::CreateBodyNode(MobodIndex mobod_index) {
-  const BodyNodeTopology& node_topology =
-      topology_.get_body_node(mobod_index);
+  const BodyNodeTopology& node_topology = topology_.get_body_node(mobod_index);
   const BodyIndex body_index = node_topology.rigid_body;
 
   const RigidBody<T>& body =
@@ -1062,25 +1055,24 @@ VectorX<T> MultibodyTree<T>::GetPositionsAndVelocities(
 
 template <typename T>
 void MultibodyTree<T>::GetPositionsAndVelocities(
-    const systems::Context<T>& context,
-    ModelInstanceIndex model_instance,
+    const systems::Context<T>& context, ModelInstanceIndex model_instance,
     EigenPtr<VectorX<T>> qv_out) const {
   DRAKE_DEMAND(qv_out != nullptr);
 
   Eigen::VectorBlock<const VectorX<T>> state_vector =
       get_positions_and_velocities(context);
 
-  if (qv_out->size() != num_positions(model_instance) +
-      num_velocities(model_instance))
+  if (qv_out->size() !=
+      num_positions(model_instance) + num_velocities(model_instance))
     throw std::logic_error("Output array is not properly sized.");
 
   auto qv_out_head = qv_out->head(num_positions(model_instance));
   auto qv_out_tail = qv_out->tail(num_velocities(model_instance));
 
-  GetPositionsFromArray(
-      model_instance, state_vector.head(num_positions()), &qv_out_head);
-  GetVelocitiesFromArray(
-      model_instance, state_vector.tail(num_velocities()), &qv_out_tail);
+  GetPositionsFromArray(model_instance, state_vector.head(num_positions()),
+                        &qv_out_head);
+  GetVelocitiesFromArray(model_instance, state_vector.tail(num_velocities()),
+                         &qv_out_tail);
 }
 
 template <typename T>
@@ -1090,10 +1082,10 @@ void MultibodyTree<T>::SetPositionsAndVelocities(
     systems::Context<T>* context) const {
   Eigen::VectorBlock<VectorX<T>> state_vector =
       GetMutablePositionsAndVelocities(context);
-  Eigen::VectorBlock<VectorX<T>> q = make_mutable_block_segment(&state_vector,
-      0, num_positions());
-  Eigen::VectorBlock<VectorX<T>> v = make_mutable_block_segment(&state_vector,
-      num_positions(), num_velocities());
+  Eigen::VectorBlock<VectorX<T>> q =
+      make_mutable_block_segment(&state_vector, 0, num_positions());
+  Eigen::VectorBlock<VectorX<T>> v = make_mutable_block_segment(
+      &state_vector, num_positions(), num_velocities());
   SetPositionsInArray(model_instance,
                       instance_state.head(num_positions(model_instance)), &q);
   SetVelocitiesInArray(model_instance,
@@ -1170,8 +1162,8 @@ void MultibodyTree<T>::SetFreeBodySpatialVelocityOrThrow(
     const RigidBody<T>& body, const SpatialVelocity<T>& V_WB,
     systems::Context<T>* context) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
-  SetFreeBodySpatialVelocityOrThrow(
-      body, V_WB, *context, &context->get_mutable_state());
+  SetFreeBodySpatialVelocityOrThrow(body, V_WB, *context,
+                                    &context->get_mutable_state());
 }
 
 template <typename T>
@@ -1251,8 +1243,7 @@ void MultibodyTree<T>::CalcAllBodySpatialVelocitiesInWorld(
 
 template <typename T>
 void MultibodyTree<T>::CalcPositionKinematicsCache(
-    const systems::Context<T>& context,
-    PositionKinematicsCache<T>* pc) const {
+    const systems::Context<T>& context, PositionKinematicsCache<T>* pc) const {
   DRAKE_DEMAND(pc != nullptr);
 
   const FrameBodyPoseCache<T>& frame_body_pose_cache =
@@ -1280,8 +1271,7 @@ void MultibodyTree<T>::CalcPositionKinematicsCache(
 
 template <typename T>
 void MultibodyTree<T>::CalcVelocityKinematicsCache(
-    const systems::Context<T>& context,
-    const PositionKinematicsCache<T>& pc,
+    const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
     VelocityKinematicsCache<T>* vc) const {
   DRAKE_DEMAND(vc != nullptr);
 
@@ -1308,8 +1298,8 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
       DRAKE_ASSERT(node.index() == mobod_index);
 
       // Update per-mobod kinematics.
-      node.CalcVelocityKinematicsCache_BaseToTip(context, pc, H_PB_W_cache,
-                                                 v, vc);
+      node.CalcVelocityKinematicsCache_BaseToTip(context, pc, H_PB_W_cache, v,
+                                                 vc);
     }
   }
 }
@@ -1383,8 +1373,7 @@ void MultibodyTree<T>::CalcFrameBodyPoses(
   DRAKE_ASSERT(frame_body_poses->get_X_FB(0).IsExactlyIdentity());
 
   for (const Frame<T>* frame : frames_.elements()) {
-    const int body_pose_index_in_cache =
-        frame->get_body_pose_index_in_cache();
+    const int body_pose_index_in_cache = frame->get_body_pose_index_in_cache();
     if (frame->is_body_frame()) {
       DRAKE_DEMAND(body_pose_index_in_cache == 0);
       continue;
@@ -1469,8 +1458,8 @@ void MultibodyTree<T>::CalcArticulatedBodyForceBias(
   // TODO(joemasterjohn): Consider an optimization to avoid computing `Zb_Bo_W`
   //  for locked floating bodies.
   (*Zb_Bo_W_all)[world_mobod_index()].SetNaN();
-  for (MobodIndex mobod_index(1);
-       mobod_index < topology_.num_mobods(); ++mobod_index) {
+  for (MobodIndex mobod_index(1); mobod_index < topology_.num_mobods();
+       ++mobod_index) {
     const ArticulatedBodyInertia<T>& Pplus_PB_W =
         abic.get_Pplus_PB_W(mobod_index);
     const SpatialAcceleration<T>& Ab_WB = Ab_WB_cache[mobod_index];
@@ -1523,17 +1512,15 @@ void MultibodyTree<T>::CalcDynamicBiasForces(
     const Vector3<T>& w_WB = V_WB.rotational();
     SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_all)[body.mobod_index()];
     Fb_Bo_W = mass * SpatialForce<T>(
-                        w_WB.cross(G_B_W * w_WB), /* rotational */
-                        w_WB.cross(w_WB.cross(p_BoBcm_W)) /* translational */);
+                         w_WB.cross(G_B_W * w_WB), /* rotational */
+                         w_WB.cross(w_WB.cross(p_BoBcm_W)) /* translational */);
   }
 }
 
 template <typename T>
 void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
-    const systems::Context<T>& context,
-    const PositionKinematicsCache<T>&,
-    const VelocityKinematicsCache<T>&,
-    const VectorX<T>& known_vdot,
+    const systems::Context<T>& context, const PositionKinematicsCache<T>&,
+    const VelocityKinematicsCache<T>&, const VectorX<T>& known_vdot,
     std::vector<SpatialAcceleration<T>>* A_WB_array) const {
   const bool ignore_velocities = false;
   CalcSpatialAccelerationsFromVdot(context, known_vdot, ignore_velocities,
@@ -1542,8 +1529,7 @@ void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
 
 template <typename T>
 void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
-    const systems::Context<T>& context,
-    const VectorX<T>& known_vdot,
+    const systems::Context<T>& context, const VectorX<T>& known_vdot,
     bool ignore_velocities,
     std::vector<SpatialAcceleration<T>>* A_WB_array) const {
   DRAKE_DEMAND(A_WB_array != nullptr);
@@ -1569,18 +1555,16 @@ void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
       DRAKE_ASSERT(node.index() == mobod_index);
 
       // Update per-node kinematics.
-      node.CalcSpatialAcceleration_BaseToTip(
-          context, frame_body_pose_cache, pc, vc, known_vdot, A_WB_array);
+      node.CalcSpatialAcceleration_BaseToTip(context, frame_body_pose_cache, pc,
+                                             vc, known_vdot, A_WB_array);
     }
   }
 }
 
 template <typename T>
 void MultibodyTree<T>::CalcAccelerationKinematicsCache(
-    const systems::Context<T>& context,
-    const PositionKinematicsCache<T>& pc,
-    const VelocityKinematicsCache<T>& vc,
-    const VectorX<T>& known_vdot,
+    const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+    const VelocityKinematicsCache<T>& vc, const VectorX<T>& known_vdot,
     AccelerationKinematicsCache<T>* ac) const {
   DRAKE_DEMAND(ac != nullptr);
   DRAKE_DEMAND(known_vdot.size() == topology_.num_velocities());
@@ -1592,8 +1576,7 @@ void MultibodyTree<T>::CalcAccelerationKinematicsCache(
 
 template <typename T>
 VectorX<T> MultibodyTree<T>::CalcInverseDynamics(
-    const systems::Context<T>& context,
-    const VectorX<T>& known_vdot,
+    const systems::Context<T>& context, const VectorX<T>& known_vdot,
     const MultibodyForces<T>& external_forces) const {
   // Temporary storage used in the computation of inverse dynamics.
   std::vector<SpatialAcceleration<T>> A_WB(num_bodies());
@@ -1623,28 +1606,24 @@ void MultibodyTree<T>::CalcInverseDynamics(
 // All argument vectors are indexed by MobodIndex.
 template <typename T>
 void MultibodyTree<T>::CalcInverseDynamics(
-    const systems::Context<T>& context,
-    const VectorX<T>& known_vdot,
+    const systems::Context<T>& context, const VectorX<T>& known_vdot,
     const std::vector<SpatialForce<T>>& Fapplied_Bo_W_array,
     const Eigen::Ref<const VectorX<T>>& tau_applied_array,
-    bool ignore_velocities,
-    std::vector<SpatialAcceleration<T>>* A_WB_array,
+    bool ignore_velocities, std::vector<SpatialAcceleration<T>>* A_WB_array,
     std::vector<SpatialForce<T>>* F_BMo_W_array,
     EigenPtr<VectorX<T>> tau_array) const {
   DRAKE_DEMAND(known_vdot.size() == num_velocities());
   const int Fapplied_size = static_cast<int>(Fapplied_Bo_W_array.size());
-  DRAKE_DEMAND(Fapplied_size == topology_.num_mobods() ||
-               Fapplied_size == 0);
+  DRAKE_DEMAND(Fapplied_size == topology_.num_mobods() || Fapplied_size == 0);
   const int tau_applied_size = tau_applied_array.size();
   DRAKE_DEMAND(tau_applied_size == num_velocities() || tau_applied_size == 0);
 
   DRAKE_DEMAND(A_WB_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(A_WB_array->size()) ==
-      topology_.num_mobods());
+  DRAKE_DEMAND(static_cast<int>(A_WB_array->size()) == topology_.num_mobods());
 
   DRAKE_DEMAND(F_BMo_W_array != nullptr);
   DRAKE_DEMAND(static_cast<int>(F_BMo_W_array->size()) ==
-      topology_.num_mobods());
+               topology_.num_mobods());
 
   DRAKE_DEMAND(tau_array->size() == num_velocities());
 
@@ -1722,10 +1701,8 @@ void MultibodyTree<T>::CalcInverseDynamics(
 
 template <typename T>
 void MultibodyTree<T>::CalcForceElementsContribution(
-    const systems::Context<T>& context,
-    const PositionKinematicsCache<T>& pc,
-    const VelocityKinematicsCache<T>& vc,
-    MultibodyForces<T>* forces) const {
+    const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+    const VelocityKinematicsCache<T>& vc, MultibodyForces<T>* forces) const {
   DRAKE_DEMAND(forces != nullptr);
   DRAKE_DEMAND(forces->CheckHasRightSizeForModel(*this));
 
@@ -1740,9 +1717,9 @@ void MultibodyTree<T>::CalcForceElementsContribution(
   AddJointDampingForces(context, forces);
 }
 
-template<typename T>
-void MultibodyTree<T>::AddJointDampingForces(
-    const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+template <typename T>
+void MultibodyTree<T>::AddJointDampingForces(const systems::Context<T>& context,
+                                             MultibodyForces<T>* forces) const {
   DRAKE_DEMAND(forces != nullptr);
   for (const Joint<T>* joint : joints_.elements()) {
     joint->AddInDamping(context, forces);
@@ -1765,8 +1742,7 @@ bool MultibodyTree<T>::IsVelocityEqualToQDot() const {
 template <typename T>
 void MultibodyTree<T>::MapQDotToVelocity(
     const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& qdot,
-    EigenPtr<VectorX<T>> v) const {
+    const Eigen::Ref<const VectorX<T>>& qdot, EigenPtr<VectorX<T>> v) const {
   DRAKE_DEMAND(qdot.size() == num_positions());
   DRAKE_DEMAND(v != nullptr);
   DRAKE_DEMAND(v->size() == num_velocities());
@@ -1781,10 +1757,9 @@ void MultibodyTree<T>::MapQDotToVelocity(
 }
 
 template <typename T>
-void MultibodyTree<T>::MapVelocityToQDot(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v,
-    EigenPtr<VectorX<T>> qdot) const {
+void MultibodyTree<T>::MapVelocityToQDot(const systems::Context<T>& context,
+                                         const Eigen::Ref<const VectorX<T>>& v,
+                                         EigenPtr<VectorX<T>> qdot) const {
   DRAKE_DEMAND(v.size() == num_velocities());
   DRAKE_DEMAND(qdot != nullptr);
   DRAKE_DEMAND(qdot->size() == num_positions());
@@ -1838,7 +1813,7 @@ Eigen::SparseMatrix<T> MultibodyTree<T>::MakeVelocityToQDotMap(
 
 template <typename T>
 Eigen::SparseMatrix<T> MultibodyTree<T>::MakeQDotToVelocityMap(
-      const systems::Context<T>& context) const {
+    const systems::Context<T>& context) const {
   Eigen::SparseMatrix<T> Nplus(num_velocities(), num_positions());
   if (IsVelocityEqualToQDot()) {
     Nplus.setIdentity();
@@ -2024,8 +1999,8 @@ void MultibodyTree<T>::CalcMassMatrix(const systems::Context<T>& context,
 }
 
 template <typename T>
-void MultibodyTree<T>::CalcBiasTerm(
-    const systems::Context<T>& context, EigenPtr<VectorX<T>> Cv) const {
+void MultibodyTree<T>::CalcBiasTerm(const systems::Context<T>& context,
+                                    EigenPtr<VectorX<T>> Cv) const {
   DRAKE_DEMAND(Cv != nullptr);
   DRAKE_DEMAND(Cv->rows() == num_velocities());
   DRAKE_DEMAND(Cv->cols() == 1);
@@ -2035,8 +2010,8 @@ void MultibodyTree<T>::CalcBiasTerm(
   std::vector<SpatialAcceleration<T>> A_WB_array(topology_.num_mobods());
   std::vector<SpatialForce<T>> F_BMo_W_array(topology_.num_mobods());
   // TODO(amcastro-tri): provide specific API for when vdot = 0.
-  CalcInverseDynamics(context, vdot, {}, VectorX<T>(),
-                      &A_WB_array, &F_BMo_W_array, Cv);
+  CalcInverseDynamics(context, vdot, {}, VectorX<T>(), &A_WB_array,
+                      &F_BMo_W_array, Cv);
 }
 
 template <typename T>
@@ -2051,8 +2026,7 @@ VectorX<T> MultibodyTree<T>::CalcGravityGeneralizedForces(
 
 template <typename T>
 RigidTransform<T> MultibodyTree<T>::CalcRelativeTransform(
-    const systems::Context<T>& context,
-    const Frame<T>& frame_F,
+    const systems::Context<T>& context, const Frame<T>& frame_F,
     const Frame<T>& frame_G) const {
   // Shortcut: Efficiently return identity transform if frame_F == frame_G.
   if (frame_F.index() == frame_G.index()) return RigidTransform<T>::Identity();
@@ -2080,8 +2054,7 @@ RigidTransform<T> MultibodyTree<T>::CalcRelativeTransform(
 
 template <typename T>
 RotationMatrix<T> MultibodyTree<T>::CalcRelativeRotationMatrix(
-    const systems::Context<T>& context,
-    const Frame<T>& frame_F,
+    const systems::Context<T>& context, const Frame<T>& frame_F,
     const Frame<T>& frame_G) const {
   // Shortcut: Efficiently return identity matrix if frame_F == frame_G.
   if (frame_F.index() == frame_G.index()) return RotationMatrix<T>::Identity();
@@ -2100,10 +2073,8 @@ RotationMatrix<T> MultibodyTree<T>::CalcRelativeRotationMatrix(
 
 template <typename T>
 void MultibodyTree<T>::CalcPointsPositions(
-    const systems::Context<T>& context,
-    const Frame<T>& frame_B,
-    const Eigen::Ref<const MatrixX<T>>& p_BQi,
-    const Frame<T>& frame_A,
+    const systems::Context<T>& context, const Frame<T>& frame_B,
+    const Eigen::Ref<const MatrixX<T>>& p_BQi, const Frame<T>& frame_A,
     EigenPtr<MatrixX<T>> p_AQi) const {
   DRAKE_THROW_UNLESS(p_BQi.rows() == 3);
   DRAKE_THROW_UNLESS(p_AQi != nullptr);
@@ -2145,8 +2116,10 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
     const systems::Context<T>& context) const {
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -2168,8 +2141,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2183,8 +2156,10 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   // Reminder: MultibodyTree always declares a world body and 2 model instances
   // "world" and "default" so num_model_instances() should always be >= 2.
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -2217,14 +2192,16 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
 
   // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
-    std::string message = fmt::format("{}(): There must be at least one "
-        "non-world body contained in model_instances.", __func__);
+    std::string message = fmt::format(
+        "{}(): There must be at least one "
+        "non-world body contained in model_instances.",
+        __func__);
     throw std::logic_error(message);
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2233,17 +2210,15 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
 
 template <typename T>
 SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
-    const systems::Context<T>& context,
-    const Frame<T>& frame_F,
+    const systems::Context<T>& context, const Frame<T>& frame_F,
     const std::vector<BodyIndex>& body_indexes) const {
-
   // Check if there are repeated BodyIndex in body_indexes by converting the
   // vector to a set (to eliminate duplicates) and see if their sizes differ.
-  const std::set<BodyIndex> without_duplicate_bodies(
-      body_indexes.begin(), body_indexes.end());
+  const std::set<BodyIndex> without_duplicate_bodies(body_indexes.begin(),
+                                                     body_indexes.end());
   if (body_indexes.size() != without_duplicate_bodies.size()) {
-      throw std::logic_error(
-          "CalcSpatialInertia(): contains a repeated BodyIndex.");
+    throw std::logic_error(
+        "CalcSpatialInertia(): contains a repeated BodyIndex.");
   }
 
   // For the set S of bodies contained in body_indexes, return S's
@@ -2257,7 +2232,7 @@ SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
   // S's spatial inertia in W about Wo (the origin of W), expressed in W.
   // TODO(Mitiguy) Create SpatialInertia<T>::Zero() and use it below.
   SpatialInertia<T> M_SWo_W(0., Vector3<T>::Zero(),
-      UnitInertia<T>::TriaxiallySymmetric(0));
+                            UnitInertia<T>::TriaxiallySymmetric(0));
 
   for (BodyIndex body_index : body_indexes) {
     if (body_index == 0) continue;  // No contribution from the world body.
@@ -2296,8 +2271,10 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
     const systems::Context<T>& context) const {
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -2319,8 +2296,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2338,8 +2315,10 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   // Reminder: MultibodyTree always declares a world body and 2 model instances
   // "world" and "default" so num_model_instances() should always be >= 2.
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -2365,21 +2344,23 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
 
       // sum_mi_vi = ∑ mᵢ * vi_WBcm_W.
       const Vector3<T> vi_WBcm_W =
-        body.CalcCenterOfMassTranslationalVelocityInWorld(context);
+          body.CalcCenterOfMassTranslationalVelocityInWorld(context);
       sum_mi_vi += body_mass * vi_WBcm_W;
     }
   }
 
   // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
-    std::string message = fmt::format("{}(): There must be at least one "
-        "non-world body contained in model_instances.", __func__);
+    std::string message = fmt::format(
+        "{}(): There must be at least one "
+        "non-world body contained in model_instances.",
+        __func__);
     throw std::logic_error(message);
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2390,8 +2371,10 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
     const systems::Context<T>& context) const {
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -2408,8 +2391,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2435,8 +2418,10 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances) const {
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -2461,14 +2446,16 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
 
   // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
-    std::string message = fmt::format("{}(): There must be at least one "
-        "non-world body contained in model_instances.", __func__);
+    std::string message = fmt::format(
+        "{}(): There must be at least one "
+        "non-world body contained in model_instances.",
+        __func__);
     throw std::logic_error(message);
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -2497,8 +2484,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
 
 template <typename T>
 SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
-    const systems::Context<T>& context,
-    const Vector3<T>& p_WoP_W) const {
+    const systems::Context<T>& context, const Vector3<T>& p_WoP_W) const {
   // Assemble a list of ModelInstanceIndex.
   // Skip model_instance_index(0) which always contains the "world" body -- the
   // spatial momentum of the world body measured in the world is always zero.
@@ -2508,7 +2494,7 @@ SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
     model_instances.push_back(model_instance_index);
 
   return CalcSpatialMomentumInWorldAboutPoint(context, model_instances,
-      p_WoP_W);
+                                              p_WoP_W);
 }
 
 template <typename T>
@@ -2544,7 +2530,6 @@ template <typename T>
 SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
     const systems::Context<T>& context,
     const std::vector<BodyIndex>& body_indexes) const {
-
   // For efficiency, evaluate all bodies' spatial inertia, velocities, and pose.
   const std::vector<SpatialInertia<T>>& M_Bi_W =
       EvalSpatialInertiaInWorldCache(context);
@@ -2574,7 +2559,7 @@ SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
     // After ShiftInPlace, L_WBo_W is changed to L_WBWo_W, which is B's
     // spatial momentum about point Wo, measured and expressed in frame W.
     L_WBo_W.ShiftInPlace(-p_WoBo_W);  // After this, L_WBo_W is now L_WBWo_W.
-    L_WS_W += L_WBo_W;  // Actually is `L_WS_W += L_WBWo_W`.
+    L_WS_W += L_WBo_W;                // Actually is `L_WS_W += L_WBWo_W`.
   }
 
   return L_WS_W;
@@ -2582,8 +2567,7 @@ SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
 
 template <typename T>
 const RigidTransform<T>& MultibodyTree<T>::EvalBodyPoseInWorld(
-    const systems::Context<T>& context,
-    const RigidBody<T>& body_B) const {
+    const systems::Context<T>& context, const RigidBody<T>& body_B) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   body_B.HasThisParentTreeOrThrow(this);
   return EvalPositionKinematics(context).get_X_WB(body_B.mobod_index());
@@ -2591,8 +2575,7 @@ const RigidTransform<T>& MultibodyTree<T>::EvalBodyPoseInWorld(
 
 template <typename T>
 const SpatialVelocity<T>& MultibodyTree<T>::EvalBodySpatialVelocityInWorld(
-    const systems::Context<T>& context,
-    const RigidBody<T>& body_B) const {
+    const systems::Context<T>& context, const RigidBody<T>& body_B) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   body_B.HasThisParentTreeOrThrow(this);
   return EvalVelocityKinematics(context).get_V_WB(body_B.mobod_index());
@@ -2609,8 +2592,7 @@ MultibodyTree<T>::EvalBodySpatialAccelerationInWorld(
 
 template <typename T>
 void MultibodyTree<T>::CalcAcrossNodeJacobianWrtVExpressedInWorld(
-    const systems::Context<T>& context,
-    const PositionKinematicsCache<T>& pc,
+    const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
     std::vector<Vector6<T>>* H_PB_W_cache) const {
   DRAKE_DEMAND(H_PB_W_cache != nullptr);
   DRAKE_DEMAND(static_cast<int>(H_PB_W_cache->size()) == num_velocities());
@@ -2623,8 +2605,8 @@ void MultibodyTree<T>::CalcAcrossNodeJacobianWrtVExpressedInWorld(
 
   // TODO(joemasterjohn): Consider and optimization where we avoid computing
   //  `H_PB_W` for locked floating bodies.
-  for (MobodIndex mobod_index(1);
-       mobod_index < topology_.num_mobods(); ++mobod_index) {
+  for (MobodIndex mobod_index(1); mobod_index < topology_.num_mobods();
+       ++mobod_index) {
     const BodyNode<T>& node = *body_nodes_[mobod_index];
 
     node.CalcAcrossNodeJacobianWrtVExpressedInWorld(
@@ -2634,8 +2616,7 @@ void MultibodyTree<T>::CalcAcrossNodeJacobianWrtVExpressedInWorld(
 
 template <typename T>
 void MultibodyTree<T>::CalcAllBodyBiasSpatialAccelerationsInWorld(
-    const systems::Context<T>& context,
-    JacobianWrtVariable with_respect_to,
+    const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
     std::vector<SpatialAcceleration<T>>* AsBias_WB_all) const {
   // TODO(mitiguy) Allow with_respect_to be JacobianWrtVariable::kQDot.
   // TODO(mitiguy) Per issue #13560, cache bias acceleration computation.
@@ -2662,12 +2643,9 @@ void MultibodyTree<T>::CalcAllBodyBiasSpatialAccelerationsInWorld(
 
 template <typename T>
 SpatialAcceleration<T> MultibodyTree<T>::CalcBiasSpatialAcceleration(
-    const systems::Context<T>& context,
-    JacobianWrtVariable with_respect_to,
-    const Frame<T>& frame_B,
-    const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
-    const Frame<T>& frame_A,
-    const Frame<T>& frame_E) const {
+    const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
+    const Frame<T>& frame_B, const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
+    const Frame<T>& frame_A, const Frame<T>& frame_E) const {
   // TODO(mitiguy) Allow with_respect_to be JacobianWrtVariable::kQDot.
   DRAKE_THROW_UNLESS(with_respect_to == JacobianWrtVariable::kV);
 
@@ -2691,17 +2669,15 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcBiasSpatialAcceleration(
 
   // Calculate Bp's spatial acceleration bias in body_A, expressed in frame_E.
   return CalcSpatialAccelerationHelper(context, frame_B, p_BoBp_B, body_A,
-      frame_E, AsBias_WBodyB_W, AsBias_WBodyA_W);
+                                       frame_E, AsBias_WBodyB_W,
+                                       AsBias_WBodyA_W);
 }
 
 template <typename T>
 SpatialAcceleration<T> MultibodyTree<T>::CalcSpatialAccelerationHelper(
-    const systems::Context<T>& context,
-    const Frame<T>& frame_F,
-    const Eigen::Ref<const Vector3<T>>& p_FoFp_F,
-    const RigidBody<T>& body_A,
-    const Frame<T>& frame_E,
-    const SpatialAcceleration<T>& A_WB_W,
+    const systems::Context<T>& context, const Frame<T>& frame_F,
+    const Eigen::Ref<const Vector3<T>>& p_FoFp_F, const RigidBody<T>& body_A,
+    const Frame<T>& frame_E, const SpatialAcceleration<T>& A_WB_W,
     const SpatialAcceleration<T>& A_WA_W) const {
   // For a frame Fp that is fixed/welded to a frame_F, one way to calculate
   // A_AFp (Fp's spatial acceleration in body_A) is by rearranging formulas
@@ -2749,8 +2725,8 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcSpatialAccelerationHelper(
   // Shift spatial acceleration from body_B's origin to point Fp of frame_F.
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
-  const SpatialAcceleration<T> A_WFp_W = ShiftSpatialAccelerationInWorld(
-      frame_F, p_FoFp_F, A_WB_W, pc, vc);
+  const SpatialAcceleration<T> A_WFp_W =
+      ShiftSpatialAccelerationInWorld(frame_F, p_FoFp_F, A_WB_W, pc, vc);
 
   // Calculations are simpler if body_A (the "measured-in" frame) is the world
   // frame W.  Otherwise, extra calculations are needed.
@@ -2771,8 +2747,8 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcSpatialAccelerationHelper(
     //   a_WAp = a_WAo + α_WA x p_AoAp + w_WA x (w_WA x p_AoAp)
     // Reminder: p_AoAp is an "instantaneous" position vector, so differentation
     // of p_AoAp or a_WAp may produce a result different than you might expect.
-    const SpatialAcceleration<T> A_WAp_W = ShiftSpatialAccelerationInWorld(
-        frame_A, p_AoAp_A, A_WA_W, pc, vc);
+    const SpatialAcceleration<T> A_WAp_W =
+        ShiftSpatialAccelerationInWorld(frame_A, p_AoAp_A, A_WA_W, pc, vc);
 
     // Implement part of the formula from equations (5) and (6) above.
     // TODO(Mitiguy) Investigate whether it is more accurate and/or efficient
@@ -2822,10 +2798,8 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcSpatialAccelerationHelper(
 
 template <typename T>
 SpatialAcceleration<T> MultibodyTree<T>::ShiftSpatialAccelerationInWorld(
-    const Frame<T>& frame_B,
-    const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
-    const SpatialAcceleration<T>& A_WA_W,
-    const PositionKinematicsCache<T>& pc,
+    const Frame<T>& frame_B, const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
+    const SpatialAcceleration<T>& A_WA_W, const PositionKinematicsCache<T>& pc,
     const VelocityKinematicsCache<T>& vc) const {
   // frame_B is fixed/welded to body_A.
   const RigidBody<T>& body_A = frame_B.body();
@@ -2853,12 +2827,9 @@ SpatialAcceleration<T> MultibodyTree<T>::ShiftSpatialAccelerationInWorld(
 
 template <typename T>
 Matrix3X<T> MultibodyTree<T>::CalcBiasTranslationalAcceleration(
-    const systems::Context<T>& context,
-    JacobianWrtVariable with_respect_to,
-    const Frame<T>& frame_B,
-    const Eigen::Ref<const Matrix3X<T>>& p_BoBi_B,
-    const Frame<T>& frame_A,
-    const Frame<T>& frame_E) const {
+    const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
+    const Frame<T>& frame_B, const Eigen::Ref<const Matrix3X<T>>& p_BoBi_B,
+    const Frame<T>& frame_A, const Frame<T>& frame_E) const {
   // TODO(mitiguy) Allow with_respect_to be JacobianWrtVariable::kQDot.
   DRAKE_THROW_UNLESS(with_respect_to == JacobianWrtVariable::kV);
 
@@ -2897,17 +2868,15 @@ Matrix3X<T> MultibodyTree<T>::CalcBiasTranslationalAcceleration(
 template <typename T>
 void MultibodyTree<T>::CalcJacobianSpatialVelocity(
     const systems::Context<T>& context,
-    const JacobianWrtVariable with_respect_to,
-    const Frame<T>& frame_B,
-    const Eigen::Ref<const Vector3<T>>& p_BP,
-    const Frame<T>& frame_A,
-    const Frame<T>& frame_E,
-    EigenPtr<MatrixX<T>> Js_V_ABp_E) const {
+    const JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
+    const Eigen::Ref<const Vector3<T>>& p_BP, const Frame<T>& frame_A,
+    const Frame<T>& frame_E, EigenPtr<MatrixX<T>> Js_V_ABp_E) const {
   DRAKE_THROW_UNLESS(Js_V_ABp_E != nullptr);
   DRAKE_THROW_UNLESS(Js_V_ABp_E->rows() == 6);
 
-  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot) ?
-                           num_positions() : num_velocities();
+  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot)
+                              ? num_positions()
+                              : num_velocities();
   DRAKE_THROW_UNLESS(Js_V_ABp_E->cols() == num_columns);
 
   // The spatial velocity V_WBp can be obtained by composing the spatial
@@ -2934,14 +2903,14 @@ void MultibodyTree<T>::CalcJacobianSpatialVelocity(
   Matrix6X<T> Js_V_WAp(6, num_columns);
   auto Js_w_WAp = Js_V_WAp.template topRows<3>();     // rotational part.
   auto Js_v_WAp = Js_V_WAp.template bottomRows<3>();  // translational part.
-  CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
-      with_respect_to, frame_A,  p_WP,  &Js_w_WAp, &Js_v_WAp);
+  CalcJacobianAngularAndOrTranslationalVelocityInWorld(
+      context, with_respect_to, frame_A, p_WP, &Js_w_WAp, &Js_v_WAp);
 
   Matrix6X<T> Js_V_WBp(6, num_columns);
   auto Js_w_WBp = Js_V_WBp.template topRows<3>();     // rotational part.
   auto Js_v_WBp = Js_V_WBp.template bottomRows<3>();  // translational part.
-  CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
-      with_respect_to, frame_B,  p_WP,  &Js_w_WBp, &Js_v_WBp);
+  CalcJacobianAngularAndOrTranslationalVelocityInWorld(
+      context, with_respect_to, frame_B, p_WP, &Js_w_WBp, &Js_v_WBp);
 
   // Jacobian Js_V_ABp_W when E is the world frame W.
   Js_V_ABp_E->template topRows<3>() = Js_w_WBp - Js_w_WAp;
@@ -2962,15 +2931,14 @@ void MultibodyTree<T>::CalcJacobianSpatialVelocity(
 template <typename T>
 void MultibodyTree<T>::CalcJacobianAngularVelocity(
     const systems::Context<T>& context,
-    const JacobianWrtVariable with_respect_to,
-    const Frame<T>& frame_B,
-    const Frame<T>& frame_A,
-    const Frame<T>& frame_E,
+    const JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
+    const Frame<T>& frame_A, const Frame<T>& frame_E,
     EigenPtr<Matrix3X<T>> Js_w_AB_E) const {
   DRAKE_THROW_UNLESS(Js_w_AB_E != nullptr);
   DRAKE_THROW_UNLESS(Js_w_AB_E->rows() == 3);
-  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot) ?
-                          num_positions() : num_velocities();
+  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot)
+                              ? num_positions()
+                              : num_velocities();
   DRAKE_THROW_UNLESS(Js_w_AB_E->cols() == num_columns);
 
   // The angular velocity addition theorem, gives w_WB = w_WA + w_AB, where
@@ -2993,12 +2961,14 @@ void MultibodyTree<T>::CalcJacobianAngularVelocity(
   //  Also modify CalcJacobianAngularAndOrTranslationalVelocityInWorld() so
   //  it can add or subtract to the Jacobian that is passed to it.
   Matrix3X<T> Js_w_WA_W(3, num_columns);
-  CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
-      with_respect_to, frame_A, empty_position_list, &Js_w_WA_W, nullptr);
+  CalcJacobianAngularAndOrTranslationalVelocityInWorld(
+      context, with_respect_to, frame_A, empty_position_list, &Js_w_WA_W,
+      nullptr);
 
   Matrix3X<T> Js_w_WB_W(3, num_columns);
-  CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
-      with_respect_to, frame_B, empty_position_list, &Js_w_WB_W, nullptr);
+  CalcJacobianAngularAndOrTranslationalVelocityInWorld(
+      context, with_respect_to, frame_B, empty_position_list, &Js_w_WB_W,
+      nullptr);
 
   const Frame<T>& frame_W = world_frame();
   if (frame_E.index() == frame_W.index()) {
@@ -3017,13 +2987,12 @@ void MultibodyTree<T>::CalcJacobianAngularVelocity(
 template <typename T>
 void MultibodyTree<T>::CalcJacobianTranslationalVelocityHelper(
     const systems::Context<T>& context,
-    const JacobianWrtVariable with_respect_to,
-    const Frame<T>& frame_B,
-    const Eigen::Ref<const Matrix3X<T>>& p_WoBi_W,
-    const Frame<T>& frame_A,
+    const JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
+    const Eigen::Ref<const Matrix3X<T>>& p_WoBi_W, const Frame<T>& frame_A,
     EigenPtr<MatrixX<T>> Js_v_ABi_W) const {
-  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot) ?
-                          num_positions() : num_velocities();
+  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot)
+                              ? num_positions()
+                              : num_velocities();
   const int num_points = p_WoBi_W.cols();
   DRAKE_THROW_UNLESS(num_points > 0);
   DRAKE_THROW_UNLESS(Js_v_ABi_W != nullptr);
@@ -3042,8 +3011,8 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocityHelper(
 
   // Calculate each point Bi's translational velocity Jacobian in world W.
   // The result is Js_v_WBi_W, but we store into Js_v_ABi_W for performance.
-  CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
-    with_respect_to, frame_B, p_WoBi_W, nullptr, Js_v_ABi_W);
+  CalcJacobianAngularAndOrTranslationalVelocityInWorld(
+      context, with_respect_to, frame_B, p_WoBi_W, nullptr, Js_v_ABi_W);
 
   // For the common special case in which frame A is the world W, optimize as
   // Js_v_ABi_W = Js_v_WBi_W
@@ -3051,8 +3020,8 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocityHelper(
 
   // Calculate each point Ai's translational velocity Jacobian in world W.
   MatrixX<T> Js_v_WAi_W(3 * num_points, num_columns);
-  CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
-    with_respect_to, frame_A, p_WoBi_W, nullptr, &Js_v_WAi_W);
+  CalcJacobianAngularAndOrTranslationalVelocityInWorld(
+      context, with_respect_to, frame_A, p_WoBi_W, nullptr, &Js_v_WAi_W);
 
   // Calculate each point Bi's translational velocity Jacobian in frame A,
   // expressed in world W. Note, again, that before this line Js_v_ABi_W
@@ -3063,15 +3032,13 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocityHelper(
 template <typename T>
 void MultibodyTree<T>::CalcJacobianTranslationalVelocity(
     const systems::Context<T>& context,
-    const JacobianWrtVariable with_respect_to,
-    const Frame<T>& frame_B,
-    const Frame<T>& frame_F,
-    const Eigen::Ref<const Matrix3X<T>>& p_FoBi_F,
-    const Frame<T>& frame_A,
-    const Frame<T>& frame_E,
+    const JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
+    const Frame<T>& frame_F, const Eigen::Ref<const Matrix3X<T>>& p_FoBi_F,
+    const Frame<T>& frame_A, const Frame<T>& frame_E,
     EigenPtr<MatrixX<T>> Js_v_ABi_E) const {
-  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot) ?
-                          num_positions() : num_velocities();
+  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot)
+                              ? num_positions()
+                              : num_velocities();
   const int num_points = p_FoBi_F.cols();
   DRAKE_THROW_UNLESS(num_points > 0);
   DRAKE_THROW_UNLESS(p_FoBi_F.rows() == 3);
@@ -3090,8 +3057,8 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocity(
     // If frame_F != frame_W, then for each point Bi, determine Bi's position
     // from Wo (World origin), expressed in world W and call helper method.
     Matrix3X<T> p_WoBi_W(3, num_points);
-    CalcPointsPositions(context, frame_F, p_FoBi_F,  /* From frame F */
-                        world_frame(), &p_WoBi_W);   /* To world frame W */
+    CalcPointsPositions(context, frame_F, p_FoBi_F, /* From frame F */
+                        world_frame(), &p_WoBi_W);  /* To world frame W */
     CalcJacobianTranslationalVelocityHelper(context, with_respect_to, frame_B,
                                             p_WoBi_W, frame_A, Js_v_ABi_E);
   }
@@ -3104,20 +3071,17 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocity(
     // Extract the 3 x num_columns block that starts at row = 3 * i, column = 0.
     for (int i = 0; i < num_points; ++i) {
       Js_v_ABi_E->template block<3, Eigen::Dynamic>(3 * i, 0, 3, num_columns) =
-      R_EW *
-      Js_v_ABi_E->template block<3, Eigen::Dynamic>(3 * i, 0, 3, num_columns);
+          R_EW * Js_v_ABi_E->template block<3, Eigen::Dynamic>(3 * i, 0, 3,
+                                                               num_columns);
     }
   }
 }
 
 template <typename T>
 void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
-    const systems::Context<T>& context,
-    JacobianWrtVariable with_respect_to,
-    const Frame<T>& frame_F,
-    const Eigen::Ref<const Matrix3X<T>>& p_WoFpi_W,
-    EigenPtr<Matrix3X<T>> Js_w_WF_W,
-    EigenPtr<MatrixX<T>> Js_v_WFpi_W) const {
+    const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
+    const Frame<T>& frame_F, const Eigen::Ref<const Matrix3X<T>>& p_WoFpi_W,
+    EigenPtr<Matrix3X<T>> Js_w_WF_W, EigenPtr<MatrixX<T>> Js_v_WFpi_W) const {
   // At least one of the Jacobian output terms must be nullptr.
   DRAKE_THROW_UNLESS(Js_w_WF_W != nullptr || Js_v_WFpi_W != nullptr);
 
@@ -3166,10 +3130,8 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
     const Mobilizer<T>& mobilizer = node.get_mobilizer();
     const int start_index_in_v = node_topology.mobilizer_velocities_start_in_v;
     const int start_index_in_q = node_topology.mobilizer_positions_start;
-    const int mobilizer_num_velocities =
-        node_topology.num_mobilizer_velocities;
-    const int mobilizer_num_positions =
-        node_topology.num_mobilizer_positions;
+    const int mobilizer_num_velocities = node_topology.num_mobilizer_velocities;
+    const int mobilizer_num_positions = node_topology.num_mobilizer_positions;
 
     const int start_index = is_wrt_qdot ? start_index_in_q : start_index_in_v;
     const int mobilizer_jacobian_ncols =
@@ -3204,8 +3166,8 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
     if (Js_w_WF_W) {
       // Get memory address in the output Jacobian angular velocity Js_w_WF_W
       // corresponding to the contribution of the mobilities in level ilevel.
-      auto Js_w_PB_W = Js_w_WF_W->block(0, start_index, 3,
-                                        mobilizer_jacobian_ncols);
+      auto Js_w_PB_W =
+          Js_w_WF_W->block(0, start_index, 3, mobilizer_jacobian_ncols);
       if (is_wrt_qdot) {
         Js_w_PB_W = Hw_PB_W * Nplus;
       } else {
@@ -3260,16 +3222,18 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
     const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
     const Frame<T>& frame_A, const Frame<T>& frame_E,
     EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const {
-
-  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot) ?
-                          num_positions() : num_velocities();
+  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot)
+                              ? num_positions()
+                              : num_velocities();
   DRAKE_THROW_UNLESS(Js_v_ACcm_E != nullptr);
   DRAKE_THROW_UNLESS(Js_v_ACcm_E->cols() == num_columns);
 
   // Reminder: MultibodyTree always declares a world body (0ᵗʰ body).
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -3280,16 +3244,16 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
     const Vector3<T> pi_BoBcm = body.CalcCenterOfMassInBodyFrame(context);
     MatrixX<T> Jsi_v_ABcm_E(3, num_columns);
     CalcJacobianTranslationalVelocity(
-        context, with_respect_to, body.body_frame(),
-        body.body_frame(), pi_BoBcm, frame_A, frame_E, &Jsi_v_ABcm_E);
+        context, with_respect_to, body.body_frame(), body.body_frame(),
+        pi_BoBcm, frame_A, frame_E, &Jsi_v_ABcm_E);
     const T& body_mass = body.get_mass(context);
     *Js_v_ACcm_E += body_mass * Jsi_v_ABcm_E;
     composite_mass += body_mass;
   }
 
   if (composite_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -3300,19 +3264,20 @@ template <typename T>
 void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances,
-    JacobianWrtVariable with_respect_to,
-    const Frame<T>& frame_A,
-    const Frame<T>& frame_E,
-    EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const {
-  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot) ?
-                          num_positions() : num_velocities();
+    JacobianWrtVariable with_respect_to, const Frame<T>& frame_A,
+    const Frame<T>& frame_E, EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const {
+  const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot)
+                              ? num_positions()
+                              : num_velocities();
   DRAKE_THROW_UNLESS(Js_v_ACcm_E != nullptr);
   DRAKE_THROW_UNLESS(Js_v_ACcm_E->cols() == num_columns);
 
   // Reminder: MultibodyTree always declares a world body.
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -3341,28 +3306,25 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
       // frame E (Bᵢcm is the center of mass of the iᵗʰ body).
       const Vector3<T> pi_BoBcm = body.CalcCenterOfMassInBodyFrame(context);
       MatrixX<T> Jsi_v_ABcm_E(3, num_columns);
-      CalcJacobianTranslationalVelocity(context,
-                                        with_respect_to,
-                                        body.body_frame(),
-                                        body.body_frame(),
-                                        pi_BoBcm,
-                                        frame_A,
-                                        frame_E,
-                                        &Jsi_v_ABcm_E);
+      CalcJacobianTranslationalVelocity(
+          context, with_respect_to, body.body_frame(), body.body_frame(),
+          pi_BoBcm, frame_A, frame_E, &Jsi_v_ABcm_E);
       *Js_v_ACcm_E += body_mass * Jsi_v_ABcm_E;
     }
   }
 
   // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
-    std::string message = fmt::format("{}(): There must be at least one "
-        "non-world body contained in model_instances.", __func__);
+    std::string message = fmt::format(
+        "{}(): There must be at least one "
+        "non-world body contained in model_instances.",
+        __func__);
     throw std::logic_error(message);
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -3376,8 +3338,10 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
     const Frame<T>& frame_A, const Frame<T>& frame_E) const {
   // Reminder: MultibodyTree always declares a world body (0ᵗʰ body).
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -3388,15 +3352,15 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
     const Vector3<T> pi_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
     const Frame<T>& frame_B = body.body_frame();
     const SpatialAcceleration<T> AsBiasi_ACcm_E = CalcBiasSpatialAcceleration(
-       context, with_respect_to, frame_B, pi_BoBcm_B, frame_A, frame_E);
+        context, with_respect_to, frame_B, pi_BoBcm_B, frame_A, frame_E);
     const T& body_mass = body.get_mass(context);
     asBias_ACcm_E += body_mass * AsBiasi_ACcm_E.translational();
     composite_mass += body_mass;
   }
 
   if (composite_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
   asBias_ACcm_E /= composite_mass;
@@ -3404,17 +3368,17 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
 }
 
 template <typename T>
-Vector3<T>
-MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
+Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances,
-    JacobianWrtVariable with_respect_to,
-    const Frame<T>& frame_A,
+    JacobianWrtVariable with_respect_to, const Frame<T>& frame_A,
     const Frame<T>& frame_E) const {
   // Reminder: MultibodyTree always declares a world body (0ᵗʰ body).
   if (num_bodies() <= 1) {
-    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
-        "the world_body() so its center of mass is undefined.", __func__);
+    std::string message = fmt::format(
+        "{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.",
+        __func__);
     throw std::logic_error(message);
   }
 
@@ -3443,26 +3407,23 @@ MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
       const Frame<T>& frame_B = body.body_frame();
       const Vector3<T> pi_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
       const Vector3<T> aBiasi_ABcm_E = CalcBiasTranslationalAcceleration(
-                                        context,
-                                        with_respect_to,
-                                        frame_B,
-                                        pi_BoBcm_B,
-                                        frame_A,
-                                        frame_E);
+          context, with_respect_to, frame_B, pi_BoBcm_B, frame_A, frame_E);
       sum_mi_aBiasi += body_mass * aBiasi_ABcm_E;
     }
   }
 
   // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
-    std::string message = fmt::format("{}(): There must be at least one "
-        "non-world body contained in model_instances.", __func__);
+    std::string message = fmt::format(
+        "{}(): There must be at least one "
+        "non-world body contained in model_instances.",
+        __func__);
     throw std::logic_error(message);
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's total mass must "
-                                      "be greater than zero.", __func__);
+    std::string message = fmt::format(
+        "{}(): The system's total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -3547,7 +3508,8 @@ template <typename T>
 void MultibodyTree<T>::ThrowIfFinalized(const char* source_method) const {
   if (topology_is_valid()) {
     throw std::logic_error(
-        "Post-finalize calls to '" + std::string(source_method) + "()' are "
+        "Post-finalize calls to '" + std::string(source_method) +
+        "()' are "
         "not allowed; calls to this method must happen before Finalize().");
   }
 }
@@ -3555,9 +3517,10 @@ void MultibodyTree<T>::ThrowIfFinalized(const char* source_method) const {
 template <typename T>
 void MultibodyTree<T>::ThrowIfNotFinalized(const char* source_method) const {
   if (!topology_is_valid()) {
-    throw std::logic_error(
-        "Pre-finalize calls to '" + std::string(source_method) + "()' are "
-        "not allowed; you must call Finalize() first.");
+    throw std::logic_error("Pre-finalize calls to '" +
+                           std::string(source_method) +
+                           "()' are "
+                           "not allowed; you must call Finalize() first.");
   }
 }
 
@@ -3683,8 +3646,7 @@ void MultibodyTree<T>::CalcArticulatedBodyInertiaCache(
 
 template <typename T>
 void MultibodyTree<T>::CalcArticulatedBodyInertiaCache(
-    const systems::Context<T>& context,
-    const VectorX<T>& diagonal_inertias,
+    const systems::Context<T>& context, const VectorX<T>& diagonal_inertias,
     ArticulatedBodyInertiaCache<T>* abic) const {
   DRAKE_DEMAND(abic != nullptr);
 
@@ -3707,8 +3669,8 @@ void MultibodyTree<T>::CalcArticulatedBodyInertiaCache(
       const SpatialInertia<T>& M_B_W =
           spatial_inertia_in_world_cache[mobod_index];
 
-      node.CalcArticulatedBodyInertiaCache_TipToBase(
-          context, pc, H_PB_W, M_B_W, diagonal_inertias, abic);
+      node.CalcArticulatedBodyInertiaCache_TipToBase(context, pc, H_PB_W, M_B_W,
+                                                     diagonal_inertias, abic);
     }
   }
 }
@@ -3830,9 +3792,8 @@ MatrixX<double> MultibodyTree<T>::MakeStateSelectorMatrix(
   for (const auto& joint_index : user_to_joint_index_map) {
     const bool inserted = already_selected_joints.insert(joint_index).second;
     if (!inserted) {
-      throw std::logic_error(
-          "Joint named '" + get_joint(joint_index).name() +
-              "' is repeated multiple times.");
+      throw std::logic_error("Joint named '" + get_joint(joint_index).name() +
+                             "' is repeated multiple times.");
     }
   }
 
@@ -3848,8 +3809,7 @@ MatrixX<double> MultibodyTree<T>::MakeStateSelectorMatrix(
 
   // With state x of size n and selected state xₛ of size nₛ, Sx has size
   // nₛ x n so that xₛ = Sx⋅x.
-  MatrixX<double> Sx =
-      MatrixX<double>::Zero(num_selected_states, num_states());
+  MatrixX<double> Sx = MatrixX<double>::Zero(num_selected_states, num_states());
 
   const int nq = num_positions();
   // We place all selected positions first, followed by all the selected

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -36,13 +36,20 @@
 namespace drake {
 namespace multibody {
 
-template <typename T> class RigidBodyFrame;
-template <typename T> class Frame;
-template <typename T> class RigidBody;
-template <typename T> class Joint;
-template <typename T> class JointActuator;
-template <typename T> class ForceElement;
-template <typename T> class UniformGravityFieldElement;
+template <typename T>
+class RigidBodyFrame;
+template <typename T>
+class Frame;
+template <typename T>
+class RigidBody;
+template <typename T>
+class Joint;
+template <typename T>
+class JointActuator;
+template <typename T>
+class ForceElement;
+template <typename T>
+class UniformGravityFieldElement;
 
 /// Enumeration that indicates whether the Jacobian is partial differentiation
 /// with respect to q̇ (time-derivatives of generalized positions) or
@@ -68,10 +75,14 @@ enum class JacobianWrtVariable {
 
 namespace internal {
 
-template <typename T> class BodyNode;
-template <typename T> class ModelInstance;
-template <typename T> class Mobilizer;
-template <typename T> class QuaternionFloatingMobilizer;
+template <typename T>
+class BodyNode;
+template <typename T>
+class ModelInstance;
+template <typename T>
+class Mobilizer;
+template <typename T>
+class QuaternionFloatingMobilizer;
 
 // %MultibodyTree provides a representation for a physical system consisting of
 // a collection of interconnected rigid and deformable bodies. As such, it owns
@@ -132,9 +143,9 @@ class MultibodyTree {
   // @throws std::exception if a body named `name` already exists in this
   //         model instance.
   // @throws std::exception if the model instance does not exist.
-  const RigidBody<T>& AddRigidBody(
-      const std::string& name, ModelInstanceIndex model_instance,
-      const SpatialInertia<double>& M_BBo_B);
+  const RigidBody<T>& AddRigidBody(const std::string& name,
+                                   ModelInstanceIndex model_instance,
+                                   const SpatialInertia<double>& M_BBo_B);
 
   // Creates a rigid body with the provided name, model instance, and spatial
   // inertia.  The newly created body will be placed in the default model
@@ -163,8 +174,8 @@ class MultibodyTree {
   // @throws std::exception if a body named `name` already exists.
   // @throws std::exception if additional model instances have been created
   //                        beyond the world and default instances.
-  const RigidBody<T>& AddRigidBody(
-      const std::string& name, const SpatialInertia<double>& M_BBo_B);
+  const RigidBody<T>& AddRigidBody(const std::string& name,
+                                   const SpatialInertia<double>& M_BBo_B);
 
   // Takes ownership of `frame` and adds it to `this` %MultibodyTree. Returns
   // a constant reference to the frame just added, which will remain valid for
@@ -191,7 +202,7 @@ class MultibodyTree {
   // @tparam FrameType The type of the specific sub-class of Frame to add. The
   //                   template needs to be specialized on the same scalar type
   //                   T of this %MultibodyTree.
-  template <template<typename Scalar> class FrameType>
+  template <template <typename Scalar> class FrameType>
   const FrameType<T>& AddFrame(std::unique_ptr<FrameType<T>> frame);
 
   // Constructs a new frame with type `FrameType` with the given `args`, and
@@ -229,7 +240,7 @@ class MultibodyTree {
   // @tparam FrameType A template for the type of Frame to construct. The
   //                   template will be specialized on the scalar type T of
   //                   this %MultibodyTree.
-  template<template<typename Scalar> class FrameType, typename... Args>
+  template <template <typename Scalar> class FrameType, typename... Args>
   const FrameType<T>& AddFrame(Args&&... args);
 
   // Takes ownership of `mobilizer` and adds it to `this` %MultibodyTree.
@@ -271,7 +282,7 @@ class MultibodyTree {
   // @tparam MobilizerType The type of the specific sub-class of Mobilizer to
   //                       add. The template needs to be specialized on the
   //                       same scalar type T of this %MultibodyTree.
-  template <template<typename Scalar> class MobilizerType>
+  template <template <typename Scalar> class MobilizerType>
   const MobilizerType<T>& AddMobilizer(
       std::unique_ptr<MobilizerType<T>> mobilizer);
 
@@ -312,7 +323,7 @@ class MultibodyTree {
   // @tparam MobilizerType A template for the type of Mobilizer to construct.
   //                       The template will be specialized on the scalar type
   //                       T of `this` %MultibodyTree.
-  template<template<typename Scalar> class MobilizerType, typename... Args>
+  template <template <typename Scalar> class MobilizerType, typename... Args>
   const MobilizerType<T>& AddMobilizer(Args&&... args);
 
   // Creates and adds to `this` %MultibodyTree (which retains ownership) a new
@@ -327,7 +338,7 @@ class MultibodyTree {
   //
   // The newly created `ForceElementType` object will be specialized on the
   // scalar type T of this %MultibodyTree.
-  template <template<typename Scalar> class ForceElementType>
+  template <template <typename Scalar> class ForceElementType>
   const ForceElementType<T>& AddForceElement(
       std::unique_ptr<ForceElementType<T>> force_element);
 
@@ -351,15 +362,14 @@ class MultibodyTree {
   // @see The ForceElement class's documentation for further details on how a
   // force element is defined.
   // @throws std::exception if gravity was already added to the model.
-  template<template<typename Scalar> class ForceElementType, typename... Args>
+  template <template <typename Scalar> class ForceElementType, typename... Args>
   const ForceElementType<T>& AddForceElement(Args&&... args);
 
   // See MultibodyPlant documentation. In addition internally we distinguish
   // user Joints from Joints added during modeling (called "ephemeral joints").
-  template <template<typename Scalar> class JointType>
-  const JointType<T>& AddJoint(
-      std::unique_ptr<JointType<T>> joint,
-      bool is_ephemeral_joint = false);
+  template <template <typename Scalar> class JointType>
+  const JointType<T>& AddJoint(std::unique_ptr<JointType<T>> joint,
+                               bool is_ephemeral_joint = false);
 
   // This method adds a Joint of type `JointType` between two bodies.
   // The two bodies connected by this Joint object are referred to as _parent_
@@ -431,14 +441,12 @@ class MultibodyTree {
   //
   // @see The Joint class's documentation for further details on how a Joint
   // is defined.
-  template<template<typename> class JointType, typename... Args>
+  template <template <typename> class JointType, typename... Args>
   const JointType<T>& AddJoint(
-      const std::string& name,
-      const RigidBody<T>& parent,
+      const std::string& name, const RigidBody<T>& parent,
       const std::optional<math::RigidTransform<double>>& X_PF,
       const RigidBody<T>& child,
-      const std::optional<math::RigidTransform<double>>& X_BM,
-      Args&&... args);
+      const std::optional<math::RigidTransform<double>>& X_BM, Args&&... args);
 
   // See MultibodyPlant documentation.
   void RemoveJoint(const Joint<T>& joint);
@@ -563,9 +571,7 @@ class MultibodyTree {
   }
 
   // See MultibodyPlant method.
-  int num_actuated_dofs() const {
-    return topology_.num_actuated_dofs();
-  }
+  int num_actuated_dofs() const { return topology_.num_actuated_dofs(); }
 
   // See MultibodyPlant method.
   int num_actuators(ModelInstanceIndex model_instance) const {
@@ -586,9 +592,7 @@ class MultibodyTree {
   // Kinematic paths are created by Mobilizer objects connecting a chain of
   // frames. Therefore, this method does not count kinematic cycles, which
   // could only be considered in the model using constraints.
-  int forest_height() const {
-    return topology_.forest_height();
-  }
+  int forest_height() const { return topology_.forest_height(); }
 
   // Returns a constant reference to the *world* body.
   const RigidBody<T>& world_body() const {
@@ -773,8 +777,8 @@ class MultibodyTree {
   // @}
 
   // Returns a list of body indices associated with `model_instance`.
-  std::vector<BodyIndex> GetBodyIndices(ModelInstanceIndex model_instance)
-  const;
+  std::vector<BodyIndex> GetBodyIndices(
+      ModelInstanceIndex model_instance) const;
 
   // See MultibodyPlant method.
   const std::vector<JointIndex>& GetJointIndices() const {
@@ -782,8 +786,8 @@ class MultibodyTree {
   }
 
   // Returns a list of joint indices associated with `model_instance`.
-  std::vector<JointIndex> GetJointIndices(ModelInstanceIndex model_instance)
-  const;
+  std::vector<JointIndex> GetJointIndices(
+      ModelInstanceIndex model_instance) const;
 
   // See MultibodyPlant method.
   const std::vector<JointActuatorIndex>& GetJointActuatorIndices() const {
@@ -799,15 +803,15 @@ class MultibodyTree {
       ModelInstanceIndex model_instance) const;
 
   // Returns a list of frame indices associated with `model_instance`
-  std::vector<FrameIndex> GetFrameIndices(ModelInstanceIndex model_instance)
-  const;
+  std::vector<FrameIndex> GetFrameIndices(
+      ModelInstanceIndex model_instance) const;
 
   // See MultibodyPlant method.
   const Frame<T>& GetFrameByName(std::string_view name) const;
 
   // See MultibodyPlant method.
-  const Frame<T>& GetFrameByName(
-      std::string_view name, ModelInstanceIndex model_instance) const;
+  const Frame<T>& GetFrameByName(std::string_view name,
+                                 ModelInstanceIndex model_instance) const;
 
   // See MultibodyPlant method.
   const RigidBody<T>& GetRigidBodyByName(std::string_view name) const;
@@ -848,8 +852,7 @@ class MultibodyTree {
   }
 
   // See MultibodyPlant method.
-  const JointActuator<T>& GetJointActuatorByName(
-      std::string_view name) const;
+  const JointActuator<T>& GetJointActuatorByName(std::string_view name) const;
 
   // See MultibodyPlant method.
   const JointActuator<T>& GetJointActuatorByName(
@@ -901,32 +904,27 @@ class MultibodyTree {
   // @{
 
   // See MultibodyPlant method.
-  VectorX<T> GetActuationFromArray(
-      ModelInstanceIndex model_instance,
-      const Eigen::Ref<const VectorX<T>>& u) const;
+  VectorX<T> GetActuationFromArray(ModelInstanceIndex model_instance,
+                                   const Eigen::Ref<const VectorX<T>>& u) const;
 
   // See MultibodyPlant method.
-  void SetActuationInArray(
-      ModelInstanceIndex model_instance,
-      const Eigen::Ref<const VectorX<T>>& u_instance,
-      EigenPtr<VectorX<T>> u) const;
+  void SetActuationInArray(ModelInstanceIndex model_instance,
+                           const Eigen::Ref<const VectorX<T>>& u_instance,
+                           EigenPtr<VectorX<T>> u) const;
 
   // See MultibodyPlant method.
-  VectorX<T> GetPositionsFromArray(
-      ModelInstanceIndex model_instance,
-      const Eigen::Ref<const VectorX<T>>& q) const;
+  VectorX<T> GetPositionsFromArray(ModelInstanceIndex model_instance,
+                                   const Eigen::Ref<const VectorX<T>>& q) const;
 
   // See MultibodyPlant method.
-  void GetPositionsFromArray(
-      ModelInstanceIndex model_instance,
-      const Eigen::Ref<const VectorX<T>>& q,
-      EigenPtr<VectorX<T>> q_out) const;
+  void GetPositionsFromArray(ModelInstanceIndex model_instance,
+                             const Eigen::Ref<const VectorX<T>>& q,
+                             EigenPtr<VectorX<T>> q_out) const;
 
   // See MultibodyPlant method.
-  void SetPositionsInArray(
-      ModelInstanceIndex model_instance,
-      const Eigen::Ref<const VectorX<T>>& q_instance,
-      EigenPtr<VectorX<T>> q) const;
+  void SetPositionsInArray(ModelInstanceIndex model_instance,
+                           const Eigen::Ref<const VectorX<T>>& q_instance,
+                           EigenPtr<VectorX<T>> q) const;
 
   // See MultibodyPlant method.
   VectorX<T> GetVelocitiesFromArray(
@@ -934,20 +932,18 @@ class MultibodyTree {
       const Eigen::Ref<const VectorX<T>>& v) const;
 
   // See MultibodyPlant method.
-  void GetVelocitiesFromArray(
-      ModelInstanceIndex model_instance,
-      const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> v_out) const;
+  void GetVelocitiesFromArray(ModelInstanceIndex model_instance,
+                              const Eigen::Ref<const VectorX<T>>& v,
+                              EigenPtr<VectorX<T>> v_out) const;
 
   // Sets the vector of generalized velocities for `model_instance` in
   // `v` using `v_instance`, leaving all other elements in the array
   // untouched. This method throws an exception if `v` is not of size
   // MultibodyTree::num_velocities() or `v_instance` is not of size
   // `MultibodyTree::num_positions(model_instance)`.
-  void SetVelocitiesInArray(
-      ModelInstanceIndex model_instance,
-      const Eigen::Ref<const VectorX<T>>& v_instance,
-      EigenPtr<VectorX<T>> v) const;
+  void SetVelocitiesInArray(ModelInstanceIndex model_instance,
+                            const Eigen::Ref<const VectorX<T>>& v_instance,
+                            EigenPtr<VectorX<T>> v) const;
 
   // @}
   // End of "Model instance accessors" section.
@@ -1021,9 +1017,8 @@ class MultibodyTree {
   // @note returns a dense vector of dimension `q.size() + v.size()` associated
   //          with `model_instance` in O(`q.size()`) time.
   // @pre `context` is a valid multibody system Context.
-  VectorX<T> GetPositionsAndVelocities(
-      const systems::Context<T>& context,
-      ModelInstanceIndex model_instance) const;
+  VectorX<T> GetPositionsAndVelocities(const systems::Context<T>& context,
+                                       ModelInstanceIndex model_instance) const;
 
   // Takes output vector qv_out and populates it with the multibody
   // state `x = [q; v]` of the model with `q` the vector of generalized
@@ -1034,10 +1029,9 @@ class MultibodyTree {
   // @throws std::exception if the size of `qv_out` is not equal to
   //         'num_postions(model_instance)' + 'num_velocities(model_instance)'
   // @pre `context` is a valid multibody system Context.
-  void GetPositionsAndVelocities(
-      const systems::Context<T>& context,
-      ModelInstanceIndex model_instance,
-      EigenPtr<VectorX<T>> qv_out) const;
+  void GetPositionsAndVelocities(const systems::Context<T>& context,
+                                 ModelInstanceIndex model_instance,
+                                 EigenPtr<VectorX<T>> qv_out) const;
 
   // From a mutable State, returns a mutable Eigen vector containing the vector
   // `[q; v]` of the model with `q` the vector of generalized positions and `v`
@@ -1082,24 +1076,26 @@ class MultibodyTree {
       const RigidBody<T>& body) const;
 
   // See MultibodyPlant::SetFreeBodyPose.
-  void SetFreeBodyPoseOrThrow(
-      const RigidBody<T>& body, const math::RigidTransform<T>& X_WB,
-      systems::Context<T>* context) const;
+  void SetFreeBodyPoseOrThrow(const RigidBody<T>& body,
+                              const math::RigidTransform<T>& X_WB,
+                              systems::Context<T>* context) const;
 
   // See MultibodyPlant::SetFreeBodySpatialVelocity.
-  void SetFreeBodySpatialVelocityOrThrow(
-      const RigidBody<T>& body, const SpatialVelocity<T>& V_WB,
-      systems::Context<T>* context) const;
+  void SetFreeBodySpatialVelocityOrThrow(const RigidBody<T>& body,
+                                         const SpatialVelocity<T>& V_WB,
+                                         systems::Context<T>* context) const;
 
   // See MultibodyPlant::SetFreeBodyPose.
-  void SetFreeBodyPoseOrThrow(
-      const RigidBody<T>& body, const math::RigidTransform<T>& X_WB,
-      const systems::Context<T>& context, systems::State<T>* state) const;
+  void SetFreeBodyPoseOrThrow(const RigidBody<T>& body,
+                              const math::RigidTransform<T>& X_WB,
+                              const systems::Context<T>& context,
+                              systems::State<T>* state) const;
 
   // See MultibodyPlant::SetFreeBodySpatialVelocity.
-  void SetFreeBodySpatialVelocityOrThrow(
-      const RigidBody<T>& body, const SpatialVelocity<T>& V_WB,
-      const systems::Context<T>& context, systems::State<T>* state) const;
+  void SetFreeBodySpatialVelocityOrThrow(const RigidBody<T>& body,
+                                         const SpatialVelocity<T>& V_WB,
+                                         const systems::Context<T>& context,
+                                         systems::State<T>* state) const;
 
   // See MultibodyPlant::SetFreeBodyRandomTranslationDistribution.
   void SetFreeBodyRandomTranslationDistributionOrThrow(
@@ -1130,23 +1126,20 @@ class MultibodyTree {
 
   // See MultibodyPlant method.
   math::RigidTransform<T> CalcRelativeTransform(
-      const systems::Context<T>& context,
-      const Frame<T>& frame_F,
+      const systems::Context<T>& context, const Frame<T>& frame_F,
       const Frame<T>& frame_G) const;
 
   // See MultibodyPlant method.
   math::RotationMatrix<T> CalcRelativeRotationMatrix(
-      const systems::Context<T>& context,
-      const Frame<T>& frame_F,
+      const systems::Context<T>& context, const Frame<T>& frame_F,
       const Frame<T>& frame_G) const;
 
   // See MultibodyPlant method.
-  void CalcPointsPositions(
-      const systems::Context<T>& context,
-      const Frame<T>& frame_B,
-      const Eigen::Ref<const MatrixX<T>>& p_BQi,
-      const Frame<T>& frame_A,
-      EigenPtr<MatrixX<T>> p_AQi) const;
+  void CalcPointsPositions(const systems::Context<T>& context,
+                           const Frame<T>& frame_B,
+                           const Eigen::Ref<const MatrixX<T>>& p_BQi,
+                           const Frame<T>& frame_A,
+                           EigenPtr<MatrixX<T>> p_AQi) const;
 
   // See MultibodyPlant method.
   T CalcTotalMass(const systems::Context<T>& context) const;
@@ -1166,8 +1159,7 @@ class MultibodyTree {
 
   // See MultibodyPlant method.
   SpatialInertia<T> CalcSpatialInertia(
-      const systems::Context<T>& context,
-      const Frame<T>& frame_F,
+      const systems::Context<T>& context, const Frame<T>& frame_F,
       const std::vector<BodyIndex>& body_indexes) const;
 
   // See MultibodyPlant method.
@@ -1200,18 +1192,15 @@ class MultibodyTree {
 
   // See MultibodyPlant method.
   const math::RigidTransform<T>& EvalBodyPoseInWorld(
-      const systems::Context<T>& context,
-      const RigidBody<T>& body_B) const;
+      const systems::Context<T>& context, const RigidBody<T>& body_B) const;
 
   // See MultibodyPlantMethod.
   const SpatialVelocity<T>& EvalBodySpatialVelocityInWorld(
-      const systems::Context<T>& context,
-      const RigidBody<T>& body_B) const;
+      const systems::Context<T>& context, const RigidBody<T>& body_B) const;
 
   // See MultibodyPlantMethod.
   const SpatialAcceleration<T>& EvalBodySpatialAccelerationInWorld(
-      const systems::Context<T>& context,
-      const RigidBody<T>& body_B) const;
+      const systems::Context<T>& context, const RigidBody<T>& body_B) const;
 
   // @}
   // End of "Kinematic computations" section.
@@ -1220,12 +1209,13 @@ class MultibodyTree {
   // @{
 
   // See MultibodyPlant method.
-  void CalcJacobianSpatialVelocity(
-      const systems::Context<T>& context,
-      JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_B, const Eigen::Ref<const Vector3<T>>& p_BP,
-      const Frame<T>& frame_A, const Frame<T>& frame_E,
-      EigenPtr<MatrixX<T>> Js_V_ABp_E) const;
+  void CalcJacobianSpatialVelocity(const systems::Context<T>& context,
+                                   JacobianWrtVariable with_respect_to,
+                                   const Frame<T>& frame_B,
+                                   const Eigen::Ref<const Vector3<T>>& p_BP,
+                                   const Frame<T>& frame_A,
+                                   const Frame<T>& frame_E,
+                                   EigenPtr<MatrixX<T>> Js_V_ABp_E) const;
 
   // See MultibodyPlant method.
   void CalcJacobianAngularVelocity(const systems::Context<T>& context,
@@ -1271,31 +1261,23 @@ class MultibodyTree {
   // Note: This method is more general than the corresponding MultibodyPlant
   // method as it also contains the argument `frame_F`.
   void CalcJacobianTranslationalVelocity(
-      const systems::Context<T>& context,
-      JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_B,
-      const Frame<T>& frame_F,
-      const Eigen::Ref<const Matrix3X<T>>& p_FoBi_F,
-      const Frame<T>& frame_A,
-      const Frame<T>& frame_E,
-      EigenPtr<MatrixX<T>> Js_v_ABi_E) const;
+      const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_B, const Frame<T>& frame_F,
+      const Eigen::Ref<const Matrix3X<T>>& p_FoBi_F, const Frame<T>& frame_A,
+      const Frame<T>& frame_E, EigenPtr<MatrixX<T>> Js_v_ABi_E) const;
 
   // See MultibodyPlant method.
   void CalcJacobianCenterOfMassTranslationalVelocity(
-      const systems::Context<T>& context,
-      JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_A,
-      const Frame<T>& frame_E,
+      const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_A, const Frame<T>& frame_E,
       EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const;
 
   // See MultibodyPlant method.
   void CalcJacobianCenterOfMassTranslationalVelocity(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances,
-      JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_A,
-      const Frame<T>& frame_E,
-      EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const;
+      JacobianWrtVariable with_respect_to, const Frame<T>& frame_A,
+      const Frame<T>& frame_E, EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const;
 
   // See MultibodyPlant method.
   Vector3<T> CalcBiasCenterOfMassTranslationalAcceleration(
@@ -1306,26 +1288,20 @@ class MultibodyTree {
   Vector3<T> CalcBiasCenterOfMassTranslationalAcceleration(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances,
-      JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_A, const Frame<T>& frame_E) const;
+      JacobianWrtVariable with_respect_to, const Frame<T>& frame_A,
+      const Frame<T>& frame_E) const;
 
   // See MultibodyPlant method.
   Matrix3X<T> CalcBiasTranslationalAcceleration(
-      const systems::Context<T>& context,
-      JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_B,
-      const Eigen::Ref<const Matrix3X<T>>& p_BoBi_B,
-      const Frame<T>& frame_A,
-      const Frame<T>& frame_E) const;
+      const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_B, const Eigen::Ref<const Matrix3X<T>>& p_BoBi_B,
+      const Frame<T>& frame_A, const Frame<T>& frame_E) const;
 
   // See MultibodyPlant method.
   SpatialAcceleration<T> CalcBiasSpatialAcceleration(
-      const systems::Context<T>& context,
-      JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_B,
-      const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
-      const Frame<T>& frame_A,
-      const Frame<T>& frame_E) const;
+      const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_B, const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
+      const Frame<T>& frame_A, const Frame<T>& frame_E) const;
   // @}
   // End of multibody Jacobian methods section.
 
@@ -1351,9 +1327,8 @@ class MultibodyTree {
   // - Body specific quantities such as `com_W` and `M_Bo_W`.
   //
   // Aborts if `pc` is nullptr.
-  void CalcPositionKinematicsCache(
-      const systems::Context<T>& context,
-      PositionKinematicsCache<T>* pc) const;
+  void CalcPositionKinematicsCache(const systems::Context<T>& context,
+                                   PositionKinematicsCache<T>* pc) const;
 
   // Computes all the kinematic quantities that depend on the generalized
   // velocities and stores them in the velocity kinematics cache `vc`.
@@ -1367,10 +1342,9 @@ class MultibodyTree {
   // call to CalcPositionKinematicsCache().
   //
   // Aborts if `vc` is nullptr.
-  void CalcVelocityKinematicsCache(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      VelocityKinematicsCache<T>* vc) const;
+  void CalcVelocityKinematicsCache(const systems::Context<T>& context,
+                                   const PositionKinematicsCache<T>& pc,
+                                   VelocityKinematicsCache<T>* vc) const;
 
   // Computes the spatial inertia M_B_W(q) for each body B in the model about
   // its frame origin Bo and expressed in the world frame W.
@@ -1395,7 +1369,7 @@ class MultibodyTree {
   // @throws std::exception if reflected_inertia is nullptr or if its size is
   // not num_velocities().
   void CalcReflectedInertia(const systems::Context<T>& context,
-      VectorX<T>* reflected_inertia) const;
+                            VectorX<T>* reflected_inertia) const;
 
   // Computes the joint damping for each velocity index.
   // @param[in] context
@@ -1470,26 +1444,21 @@ class MultibodyTree {
   // @pre The velocity kinematics `vc` must have been previously updated with a
   // call to CalcVelocityKinematicsCache().
   void CalcAccelerationKinematicsCache(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>& vc,
-      const VectorX<T>& known_vdot,
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>& vc, const VectorX<T>& known_vdot,
       AccelerationKinematicsCache<T>* ac) const;
 
   // See MultibodyPlant method.
   // @warning The output parameter `A_WB_array` is indexed by MobodIndex,
   // while MultibodyPlant's method returns accelerations indexed by BodyIndex.
   void CalcSpatialAccelerationsFromVdot(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>& vc,
-      const VectorX<T>& known_vdot,
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>& vc, const VectorX<T>& known_vdot,
       std::vector<SpatialAcceleration<T>>* A_WB_array) const;
 
   // See MultibodyPlant method.
   VectorX<T> CalcInverseDynamics(
-      const systems::Context<T>& context,
-      const VectorX<T>& known_vdot,
+      const systems::Context<T>& context, const VectorX<T>& known_vdot,
       const MultibodyForces<T>& external_forces) const;
 
   // (Advanced) Given the state of `this` %MultibodyTree in `context` and a
@@ -1618,11 +1587,10 @@ class MultibodyTree {
       EigenPtr<VectorX<T>> tau_array) const;
 
   // See MultibodyPlant method.
-  void CalcForceElementsContribution(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>& vc,
-      MultibodyForces<T>* forces) const;
+  void CalcForceElementsContribution(const systems::Context<T>& context,
+                                     const PositionKinematicsCache<T>& pc,
+                                     const VelocityKinematicsCache<T>& vc,
+                                     MultibodyForces<T>* forces) const;
 
   // TODO(sherm1) Revise the comments below as #12942 is addressed.
 
@@ -1646,16 +1614,16 @@ class MultibodyTree {
   T CalcNonConservativePower(const systems::Context<T>& context) const;
 
   // See MultibodyPlant method.
-  void CalcMassMatrixViaInverseDynamics(
-      const systems::Context<T>& context, EigenPtr<MatrixX<T>> M) const;
+  void CalcMassMatrixViaInverseDynamics(const systems::Context<T>& context,
+                                        EigenPtr<MatrixX<T>> M) const;
 
   // See MultibodyPlant method.
   void CalcMassMatrix(const systems::Context<T>& context,
                       EigenPtr<MatrixX<T>> M) const;
 
   // See MultibodyPlant method.
-  void CalcBiasTerm(
-      const systems::Context<T>& context, EigenPtr<VectorX<T>> Cv) const;
+  void CalcBiasTerm(const systems::Context<T>& context,
+                    EigenPtr<VectorX<T>> Cv) const;
 
   // See MultibodyPlant method.
   VectorX<T> CalcGravityGeneralizedForces(
@@ -1665,16 +1633,14 @@ class MultibodyTree {
   bool IsVelocityEqualToQDot() const;
 
   // See MultibodyPlant method.
-  void MapVelocityToQDot(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> qdot) const;
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const;
 
   // See MultibodyPlant method.
-  void MapQDotToVelocity(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& qdot,
-      EigenPtr<VectorX<T>> v) const;
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const;
 
   // See MultibodyPlant method.
   Eigen::SparseMatrix<T> MakeVelocityToQDotMap(
@@ -1939,8 +1905,10 @@ class MultibodyTree {
   described in @ref multibody_notation, here we present a table that compares
   the different symbols across these three different sources. This is
   especially useful when studying the particulars of ABA as introduced in
-  [Jain, 2010] and [Featherstone 2008] or as implemented in Drake.
+  [Jain, 2010] and [Featherstone 2008] or as implemented in Drake. */
 
+  // clang-format off
+  /*
   Quantity                            |    Featherstone 2008 †    |              Jain 2010 ††              | Drake monogram †††
   ------------------------------------|:-------------------------:|:--------------------------------------:|:-------------------
   Body spatial acceleration           |  𝒂ᵢ                       |  α(k)                                  | A_WB
@@ -1952,7 +1920,10 @@ class MultibodyTree {
   ABI across the mobilizer            |  𝑰ᵃᵢ                (7.23) | P⁺(k)  (6.24)                         | Pplus_B_W
   ABA force bias                      |  𝒑ᴬᵢ                (7.2)  | 𝔷(k)   (6.6)                           | Z_B_W
   ABA force bias across the mobilizer |  𝒑ᵃᵢ                (7.24) | 𝔷⁺(k)  (6.33)                          | Zplus_B_W
+  */
+  // clang-format on
 
+  /*
   † Featherstone's spatial vectors are Plücker vectors, see §2.
 
   †† Jain's spatial vectors are the concatenation of two ordinary
@@ -1991,9 +1962,9 @@ class MultibodyTree {
   // Refer to @ref abi_computing_accelerations "Computing Accelerations" for
   // further details.
   void CalcArticulatedBodyAccelerations(
-    const systems::Context<T>& context,
-    const ArticulatedBodyForceCache<T>& aba_force_cache,
-    AccelerationKinematicsCache<T>* ac) const;
+      const systems::Context<T>& context,
+      const ArticulatedBodyForceCache<T>& aba_force_cache,
+      AccelerationKinematicsCache<T>* ac) const;
 
   // For a body B, computes the spatial acceleration bias term `Ab_WB` as it
   // appears in the acceleration level motion constraint imposed by body B's
@@ -2145,49 +2116,47 @@ class MultibodyTree {
   // SFINAE overload for Frame<T> elements.
   template <template <typename> class MultibodyElement, typename Scalar>
   std::enable_if_t<std::is_base_of_v<Frame<T>, MultibodyElement<T>>,
-                   const MultibodyElement<T>&> get_variant(
-      const MultibodyElement<Scalar>& element) const {
+                   const MultibodyElement<T>&>
+  get_variant(const MultibodyElement<Scalar>& element) const {
     return get_frame_variant(element);
   }
 
   // SFINAE overload for RigidBody<T> elements.
   template <template <typename> class MultibodyElement, typename Scalar>
   std::enable_if_t<std::is_base_of_v<RigidBody<T>, MultibodyElement<T>>,
-                   const MultibodyElement<T>&> get_variant(
-      const MultibodyElement<Scalar>& element) const {
+                   const MultibodyElement<T>&>
+  get_variant(const MultibodyElement<Scalar>& element) const {
     return get_body_variant(element);
   }
 
   // SFINAE overload for Mobilizer<T> elements.
   template <template <typename> class MultibodyElement, typename Scalar>
   std::enable_if_t<std::is_base_of_v<Mobilizer<T>, MultibodyElement<T>>,
-                   const MultibodyElement<T>&> get_variant(
-      const MultibodyElement<Scalar>& element) const {
+                   const MultibodyElement<T>&>
+  get_variant(const MultibodyElement<Scalar>& element) const {
     return get_mobilizer_variant(element);
   }
 
   // SFINAE overload for Mobilizer<T> elements.
   template <template <typename> class MultibodyElement, typename Scalar>
   std::enable_if_t<std::is_base_of_v<Mobilizer<T>, MultibodyElement<T>>,
-                   MultibodyElement<T>&> get_mutable_variant(
-      const MultibodyElement<Scalar>& element) {
+                   MultibodyElement<T>&>
+  get_mutable_variant(const MultibodyElement<Scalar>& element) {
     return get_mutable_mobilizer_variant(element);
   }
 
   // SFINAE overload for Joint<T> elements.
   template <template <typename> class MultibodyElement, typename Scalar>
   std::enable_if_t<std::is_base_of_v<Joint<T>, MultibodyElement<T>>,
-                   const MultibodyElement<T>&> get_variant(
-      const MultibodyElement<Scalar>& element) const {
+                   const MultibodyElement<T>&>
+  get_variant(const MultibodyElement<Scalar>& element) const {
     return get_joint_variant(element);
   }
   // @}
 
   // Creates a deep copy of `this` %MultibodyTree templated on the same
   // scalar type T as `this` tree.
-  std::unique_ptr<MultibodyTree<T>> Clone() const {
-    return CloneToScalar<T>();
-  }
+  std::unique_ptr<MultibodyTree<T>> Clone() const { return CloneToScalar<T>(); }
 
   // Creates a deep copy of `this` %MultibodyTree templated on AutoDiffXd.
   std::unique_ptr<MultibodyTree<AutoDiffXd>> ToAutoDiffXd() const {
@@ -2523,8 +2492,7 @@ class MultibodyTree {
   // a vector of the columns of these matrices. Therefore `H_PB_W_cache` has
   // as many entries as number of generalized velocities in the tree.
   void CalcAcrossNodeJacobianWrtVExpressedInWorld(
-      const systems::Context<T>& context,
-      const PositionKinematicsCache<T>& pc,
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
       std::vector<Vector6<T>>* H_PB_W_cache) const;
 
   // (Internal use only) Sets the discrete state index for the multibody
@@ -2568,7 +2536,8 @@ class MultibodyTree {
   // Make MultibodyTree templated on every other scalar type a friend of
   // MultibodyTree<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private methods from MultibodyTree<T>.
-  template <typename> friend class MultibodyTree;
+  template <typename>
+  friend class MultibodyTree;
 
   // Friend class to facilitate testing.
   friend class MultibodyTreeTester;
@@ -2577,12 +2546,11 @@ class MultibodyTree {
   // joints that were added to the LinkJointGraph during modeling (elements
   // added during modeling are called "ephemeral"). The joint connects the body
   // frames.
-  template<template<typename> class JointType, typename... Args>
-  const JointType<T>& AddEphemeralJoint(
-      const std::string& name,
-      const RigidBody<T>& parent,
-      const RigidBody<T>& child,
-      Args&&... args);
+  template <template <typename> class JointType, typename... Args>
+  const JointType<T>& AddEphemeralJoint(const std::string& name,
+                                        const RigidBody<T>& parent,
+                                        const RigidBody<T>& child,
+                                        Args&&... args);
 
   // Helpers for getting the full qv discrete state once we know we are using
   // discrete state.
@@ -2655,11 +2623,11 @@ class MultibodyTree {
   // lifetime of this MultibodyTree. Public members AddRigidBody() end up here.
   const RigidBody<T>& AddRigidBodyImpl(std::unique_ptr<RigidBody<T>> body);
 
-  const Joint<T>& GetJointByNameImpl(
-      std::string_view, std::optional<ModelInstanceIndex>) const;
+  const Joint<T>& GetJointByNameImpl(std::string_view,
+                                     std::optional<ModelInstanceIndex>) const;
 
-  [[noreturn]] void ThrowJointSubtypeMismatch(
-      const Joint<T>&, std::string_view) const;
+  [[noreturn]] void ThrowJointSubtypeMismatch(const Joint<T>&,
+                                              std::string_view) const;
 
   // If X_BF is nullopt, returns the body frame of `body`. Otherwise, adds a
   // FixedOffsetFrame (named based on the joint_name and frame_suffix) to `body`
@@ -2709,12 +2677,9 @@ class MultibodyTree {
   // in which case the method returns A𝑠Bias_AFp_E (Fp's bias spatial
   // acceleration in body_A, expressed in frame_E, with respect to speeds 𝑠.
   SpatialAcceleration<T> CalcSpatialAccelerationHelper(
-      const systems::Context<T>& context,
-      const Frame<T>& frame_F,
-      const Eigen::Ref<const Vector3<T>>& p_FoFp_F,
-      const RigidBody<T>& body_A,
-      const Frame<T>& frame_E,
-      const SpatialAcceleration<T>& A_WB_W,
+      const systems::Context<T>& context, const Frame<T>& frame_F,
+      const Eigen::Ref<const Vector3<T>>& p_FoFp_F, const RigidBody<T>& body_A,
+      const Frame<T>& frame_E, const SpatialAcceleration<T>& A_WB_W,
       const SpatialAcceleration<T>& A_WA_W) const;
 
   // For a frame Bp fixed/welded to both a frame_B and a body_A, this method
@@ -2732,8 +2697,7 @@ class MultibodyTree {
   // respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v)). It then returns A𝑠Bias_WBp_W (point
   // Bp's bias spatial acceleration in W, expressed in W with respect to 𝑠).
   SpatialAcceleration<T> ShiftSpatialAccelerationInWorld(
-      const Frame<T>& frame_B,
-      const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
+      const Frame<T>& frame_B, const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
       const SpatialAcceleration<T>& A_WA_W,
       const PositionKinematicsCache<T>& pc,
       const VelocityKinematicsCache<T>& vc) const;
@@ -2749,8 +2713,7 @@ class MultibodyTree {
   // @throws std::exception if AsBias_WB_all is nullptr.
   // @throws std::exception if AsBias_WB_all.size() is not num_bodies().
   void CalcAllBodyBiasSpatialAccelerationsInWorld(
-      const systems::Context<T>& context,
-      JacobianWrtVariable with_respect_to,
+      const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
       std::vector<SpatialAcceleration<T>>* AsBias_WB_all) const;
 
   // This method returns the spatial momentum of a list of bodies in the
@@ -2893,12 +2856,9 @@ class MultibodyTree {
   // - `Js_w_WF_W` is not nullptr and its size differs from `3 x n`.
   // - `Js_v_WFpi_W` is not nullptr and its size differs from `3*p x n`.
   void CalcJacobianAngularAndOrTranslationalVelocityInWorld(
-      const systems::Context<T>& context,
-      JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_F,
-      const Eigen::Ref<const Matrix3X<T>>& p_WoFpi_W,
-      EigenPtr<Matrix3X<T>> Js_w_WF_W,
-      EigenPtr<MatrixX<T>> Js_v_WFpi_W) const;
+      const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_F, const Eigen::Ref<const Matrix3X<T>>& p_WoFpi_W,
+      EigenPtr<Matrix3X<T>> Js_w_WF_W, EigenPtr<MatrixX<T>> Js_v_WFpi_W) const;
 
   // Helper method for CalcJacobianTranslationalVelocity().
   // @param[in] context The state of the multibody system.
@@ -2917,12 +2877,9 @@ class MultibodyTree {
   // n is the number of elements in 𝑠.
   // @throws std::exception if `Js_v_ABi_W` is nullptr or not sized `3*p x n`.
   void CalcJacobianTranslationalVelocityHelper(
-      const systems::Context<T>& context,
-      JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_B,
-      const Eigen::Ref<const Matrix3X<T>>& p_WoBi_W,
-      const Frame<T>& frame_A,
-      EigenPtr<MatrixX<T>> Js_v_ABi_W) const;
+      const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_B, const Eigen::Ref<const Matrix3X<T>>& p_WoBi_W,
+      const Frame<T>& frame_A, EigenPtr<MatrixX<T>> Js_v_ABi_W) const;
 
   // Helper method to apply forces due to damping at the joints.
   // MultibodyTree treats damping forces separately from other ForceElement
@@ -2932,8 +2889,8 @@ class MultibodyTree {
   //  Jacobian for general force models. That would allow us to implement
   //  implicit schemes for any forces using a more general infrastructure rather
   //  than having to deal with damping in a special way.
-  void AddJointDampingForces(
-      const systems::Context<T>& context, MultibodyForces<T>* forces) const;
+  void AddJointDampingForces(const systems::Context<T>& context,
+                             MultibodyForces<T>* forces) const;
 
   void CreateBodyNode(MobodIndex mobod_index);
 
@@ -2958,8 +2915,7 @@ class MultibodyTree {
   // Helper method to create a clone of `force_element` and add it to `this`
   // tree.
   template <typename FromScalar>
-  void CloneForceElementAndAdd(
-      const ForceElement<FromScalar>& force_element);
+  void CloneForceElementAndAdd(const ForceElement<FromScalar>& force_element);
 
   // Helper method to create a clone of `joint` and add it to `this` tree.
   template <typename FromScalar>
@@ -2968,8 +2924,7 @@ class MultibodyTree {
   // Helper method to create a clone of `actuator` (which is templated on
   // FromScalar) and add it to `this` tree (templated on T).
   template <typename FromScalar>
-  void CloneActuatorAndAdd(
-      const JointActuator<FromScalar>& actuator);
+  void CloneActuatorAndAdd(const JointActuator<FromScalar>& actuator);
 
   // Helper method to retrieve the corresponding Frame<T> variant to a Frame in
   // a MultibodyTree variant templated on Scalar.
@@ -3035,8 +2990,8 @@ class MultibodyTree {
     //   MultibodyTree. That will require the tree to have some sort of id.
     MobodIndex mobilizer_index = mobilizer.index();
     DRAKE_DEMAND(mobilizer_index < num_mobilizers());
-    MobilizerType<T>* mobilizer_variant = dynamic_cast<MobilizerType<T>*>(
-        mobilizers_[mobilizer_index].get());
+    MobilizerType<T>* mobilizer_variant =
+        dynamic_cast<MobilizerType<T>*>(mobilizers_[mobilizer_index].get());
     DRAKE_DEMAND(mobilizer_variant != nullptr);
     return *mobilizer_variant;
   }

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -20,38 +20,32 @@ namespace internal {
 
 template <typename T>
 MultibodyTreeSystem<T>::MultibodyTreeSystem(
-    std::unique_ptr<MultibodyTree<T>> tree,
-    bool is_discrete)
-    : MultibodyTreeSystem(
-          systems::SystemTypeTag<MultibodyTreeSystem>{},
-          false,  // Null tree is not allowed here.
-          std::move(tree), is_discrete) {}
+    std::unique_ptr<MultibodyTree<T>> tree, bool is_discrete)
+    : MultibodyTreeSystem(systems::SystemTypeTag<MultibodyTreeSystem>{},
+                          false,  // Null tree is not allowed here.
+                          std::move(tree), is_discrete) {}
 
 template <typename T>
 MultibodyTreeSystem<T>::MultibodyTreeSystem(bool is_discrete)
-    : MultibodyTreeSystem(
-          systems::SystemTypeTag<MultibodyTreeSystem>{},
-          true,  // Null tree is OK.
-          nullptr, is_discrete) {}
+    : MultibodyTreeSystem(systems::SystemTypeTag<MultibodyTreeSystem>{},
+                          true,  // Null tree is OK.
+                          nullptr, is_discrete) {}
 
 template <typename T>
 MultibodyTreeSystem<T>::MultibodyTreeSystem(
     systems::SystemScalarConverter converter,
-    std::unique_ptr<MultibodyTree<T>> tree,
-    bool is_discrete)
-    : MultibodyTreeSystem(
-          std::move(converter),
-          true,  // Null tree is OK.
-          std::move(tree), is_discrete) {}
+    std::unique_ptr<MultibodyTree<T>> tree, bool is_discrete)
+    : MultibodyTreeSystem(std::move(converter),
+                          true,  // Null tree is OK.
+                          std::move(tree), is_discrete) {}
 
 template <typename T>
 template <typename U>
 MultibodyTreeSystem<T>::MultibodyTreeSystem(const MultibodyTreeSystem<U>& other)
-    : MultibodyTreeSystem(
-          systems::SystemTypeTag<MultibodyTreeSystem>{},
-          false,  // Null tree isn't allowed (or possible).
-          other.internal_tree().template CloneToScalar<T>(),
-          other.is_discrete()) {}
+    : MultibodyTreeSystem(systems::SystemTypeTag<MultibodyTreeSystem>{},
+                          false,  // Null tree isn't allowed (or possible).
+                          other.internal_tree().template CloneToScalar<T>(),
+                          other.is_discrete()) {}
 
 // This is the one true constructor.
 template <typename T>
@@ -82,8 +76,8 @@ void MultibodyTreeSystem<T>::SetDefaultParameters(
   LeafSystem<T>::SetDefaultParameters(context, parameters);
 
   // Mobilizers.
-  for (MobodIndex mobilizer_index(0);
-       mobilizer_index < tree_->num_mobilizers(); ++mobilizer_index) {
+  for (MobodIndex mobilizer_index(0); mobilizer_index < tree_->num_mobilizers();
+       ++mobilizer_index) {
     internal_tree()
         .get_mobilizer(mobilizer_index)
         .SetDefaultParameters(parameters);
@@ -102,16 +96,12 @@ void MultibodyTreeSystem<T>::SetDefaultParameters(
   // Bodies.
   for (BodyIndex body_index(0); body_index < tree_->num_bodies();
        ++body_index) {
-    internal_tree()
-        .get_body(body_index)
-        .SetDefaultParameters(parameters);
+    internal_tree().get_body(body_index).SetDefaultParameters(parameters);
   }
   // Frames.
   for (FrameIndex frame_index(0); frame_index < tree_->num_frames();
        ++frame_index) {
-    internal_tree()
-        .get_frame(frame_index)
-        .SetDefaultParameters(parameters);
+    internal_tree().get_frame(frame_index).SetDefaultParameters(parameters);
   }
   // Force Elements.
   for (ForceElementIndex force_element_index(0);
@@ -143,8 +133,8 @@ template <typename T>
 void MultibodyTreeSystem<T>::DeclareMultibodyElementParameters(
     int* num_frame_body_pose_slots_needed) {
   // Mobilizers.
-  for (MobodIndex mobilizer_index(0);
-       mobilizer_index < tree_->num_mobilizers(); ++mobilizer_index) {
+  for (MobodIndex mobilizer_index(0); mobilizer_index < tree_->num_mobilizers();
+       ++mobilizer_index) {
     mutable_tree()
         .get_mutable_mobilizer(mobilizer_index)
         .DeclareParameters(this);
@@ -207,8 +197,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   } else {
     this->DeclareContinuousState(BasicVector<T>(tree_->num_states()),
                                  tree_->num_positions(),
-                                 tree_->num_velocities(),
-                                 0 /* num_z */);
+                                 tree_->num_velocities(), 0 /* num_z */);
   }
 
   // Declare cache entries dependent only on parameters.
@@ -232,11 +221,11 @@ void MultibodyTreeSystem<T>::Finalize() {
           .cache_index();
 
   cache_indexes_.frame_body_poses =
-      this->DeclareCacheEntry(std::string("frame pose in body frame"),
-                              FrameBodyPoseCache<T>(
-                                  num_frame_body_poses_needed),
-                              &MultibodyTreeSystem<T>::CalcFrameBodyPoses,
-                              {this->all_parameters_ticket()})
+      this->DeclareCacheEntry(
+              std::string("frame pose in body frame"),
+              FrameBodyPoseCache<T>(num_frame_body_poses_needed),
+              &MultibodyTreeSystem<T>::CalcFrameBodyPoses,
+              {this->all_parameters_ticket()})
           .cache_index();
 
   const DependencyTicket position_ticket =
@@ -376,7 +365,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   already_finalized_ = true;
 }
 
-template<typename T>
+template <typename T>
 void MultibodyTreeSystem<T>::DoCalcTimeDerivatives(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
@@ -388,7 +377,8 @@ void MultibodyTreeSystem<T>::DoCalcTimeDerivatives(
   if (internal_tree().num_states() == 0) return;
 
   const VectorX<T>& x = dynamic_cast<const systems::BasicVector<T>&>(
-      context.get_continuous_state_vector()).value();
+                            context.get_continuous_state_vector())
+                            .value();
   const auto v = x.bottomRows(internal_tree().num_velocities());
 
   const VectorX<T>& vdot = this->EvalForwardDynamics(context).get_vdot();
@@ -401,7 +391,7 @@ void MultibodyTreeSystem<T>::DoCalcTimeDerivatives(
   derivatives->SetFromVector(xdot);
 }
 
-template<typename T>
+template <typename T>
 void MultibodyTreeSystem<T>::DoMapQDotToVelocity(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& qdot,
@@ -419,7 +409,7 @@ void MultibodyTreeSystem<T>::DoMapQDotToVelocity(
   generalized_velocity->SetFromVector(v);
 }
 
-template<typename T>
+template <typename T>
 void MultibodyTreeSystem<T>::DoMapVelocityToQDot(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& generalized_velocity,
@@ -468,8 +458,9 @@ void MultibodyTreeSystem<T>::DoCalcImplicitTimeDerivativesResidual(
   //              static_cast in Release builds.
   const VectorX<T>& qvdot_proposed =
       dynamic_cast<const systems::BasicVector<T>&>(
-          proposed_derivatives.get_vector()).value();
-  DRAKE_ASSERT(qvdot_proposed.size() == nq+nv);
+          proposed_derivatives.get_vector())
+          .value();
+  DRAKE_ASSERT(qvdot_proposed.size() == nq + nv);
 
   auto qdot_residual = residual->head(nq);
   // N(q)⋅v
@@ -518,8 +509,8 @@ void MultibodyTreeSystem<T>::CalcForwardDynamicsContinuous(
 
   // Perform the last base-to-tip pass to compute accelerations using the O(n)
   // ABA.
-  internal_tree().CalcArticulatedBodyAccelerations(context,
-                                                   aba_force_cache, ac);
+  internal_tree().CalcArticulatedBodyAccelerations(context, aba_force_cache,
+                                                   ac);
 }
 
 }  // namespace internal

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -98,8 +98,8 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   const FrameBodyPoseCache<T>& EvalFrameBodyPoses(
       const systems::Context<T>& context) const {
     this->ValidateContext(context);
-    return frame_body_poses_cache_entry()
-        .template Eval<FrameBodyPoseCache<T>>(context);
+    return frame_body_poses_cache_entry().template Eval<FrameBodyPoseCache<T>>(
+        context);
   }
 
   /* Returns a reference to the up-to-date PositionKinematicsCache in the
@@ -214,8 +214,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   particularly expensive when performing O(n) forward dynamics with different
   applied forces but with the same multibody state x = [q, v] and therefore it
   is worth caching. */
-  const std::vector<SpatialForce<T>>&
-  EvalArticulatedBodyForceBiasCache(
+  const std::vector<SpatialForce<T>>& EvalArticulatedBodyForceBiasCache(
       const systems::Context<T>& context) const {
     this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.articulated_body_force_bias)
@@ -225,8 +224,8 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   /* When using the articulated body algorithm, this cache entry holds the
   per-body and per-dof propagated forces. These include the effects of both
   the velocity-dependent bias forces and applied forces. */
-  const ArticulatedBodyForceCache<T>&
-  EvalArticulatedBodyForceCache(const systems::Context<T>& context) const {
+  const ArticulatedBodyForceCache<T>& EvalArticulatedBodyForceCache(
+      const systems::Context<T>& context) const {
     this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.articulated_body_forces)
         .template Eval<ArticulatedBodyForceCache<T>>(context);
@@ -243,8 +242,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   all the body-node hinge matrices in the tree as a vector of the columns of
   these matrices. Therefore the returned `std::vector` of columns has as many
   entries as number of generalized velocities in the tree. */
-  const std::vector<Vector6<T>>&
-  EvalAcrossNodeJacobianWrtVExpressedInWorld(
+  const std::vector<Vector6<T>>& EvalAcrossNodeJacobianWrtVExpressedInWorld(
       const systems::Context<T>& context) const {
     this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.across_node_jacobians)
@@ -312,8 +310,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
                       bool is_discrete = false);
 
   template <typename U>
-  friend const MultibodyTree<U>& GetInternalTree(
-      const MultibodyTreeSystem<U>&);
+  friend const MultibodyTree<U>& GetInternalTree(const MultibodyTreeSystem<U>&);
 
   /* Returns a const reference to the MultibodyTree owned by this class. */
   const MultibodyTree<T>& internal_tree() const {
@@ -395,8 +392,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
     return internal_tree().CalcConservativePower(context);
   }
 
-  T DoCalcNonConservativePower(
-      const systems::Context<T>& context) const final {
+  T DoCalcNonConservativePower(const systems::Context<T>& context) const final {
     return internal_tree().CalcNonConservativePower(context);
   }
 
@@ -424,9 +420,8 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
     internal_tree().CalcJointDamping(context, joint_damping);
   }
 
-  void CalcFrameBodyPoses(
-      const systems::Context<T>& context,
-      FrameBodyPoseCache<T>* frame_body_poses) const {
+  void CalcFrameBodyPoses(const systems::Context<T>& context,
+                          FrameBodyPoseCache<T>* frame_body_poses) const {
     internal_tree().CalcFrameBodyPoses(context, frame_body_poses);
   }
 
@@ -456,8 +451,8 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   void CalcVelocityKinematicsCache(
       const systems::Context<T>& context,
       VelocityKinematicsCache<T>* velocity_cache) const {
-    internal_tree().CalcVelocityKinematicsCache(context,
-        EvalPositionKinematics(context), velocity_cache);
+    internal_tree().CalcVelocityKinematicsCache(
+        context, EvalPositionKinematics(context), velocity_cache);
   }
 
   void CalcDynamicBiasForces(
@@ -512,9 +507,8 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
 
   // Discrete mode forward dynamics must be implemented by a derived class
   // (likely MultibodyPlant).
-  void CalcForwardDynamicsDiscrete(
-      const systems::Context<T>& context,
-      AccelerationKinematicsCache<T>* ac) const {
+  void CalcForwardDynamicsDiscrete(const systems::Context<T>& context,
+                                   AccelerationKinematicsCache<T>* ac) const {
     DRAKE_DEMAND(ac != nullptr);
     DRAKE_DEMAND(is_discrete());
     DoCalcForwardDynamicsDiscrete(context, ac);
@@ -565,8 +559,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   // already been finalized.
   MultibodyTreeSystem(systems::SystemScalarConverter converter,
                       bool null_tree_is_ok,
-                      std::unique_ptr<MultibodyTree<T>> tree,
-                      bool is_discrete);
+                      std::unique_ptr<MultibodyTree<T>> tree, bool is_discrete);
 
   const bool is_discrete_;
 

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -136,17 +136,18 @@ struct MobilizerTopology {
   // Constructs a MobilizerTopology from the corresponding Mobod, plus the
   // connected RigidBodies and the Frame geometric information from the
   // modeled Joint.
-  MobilizerTopology(
-      MobodIndex mobilizer_index,
-      FrameIndex in_frame, FrameIndex out_frame,
-      BodyIndex in_body, BodyIndex out_body,
-      const SpanningForest::Mobod& mobod) :
-      index(mobilizer_index),
-      inboard_frame(in_frame), outboard_frame(out_frame),
-      inboard_body(in_body), outboard_body(out_body),
-      num_positions(mobod.nq()),
-      positions_start(mobod.q_start()),
-      num_velocities(mobod.nv()), velocities_start_in_v(mobod.v_start()) {}
+  MobilizerTopology(MobodIndex mobilizer_index, FrameIndex in_frame,
+                    FrameIndex out_frame, BodyIndex in_body, BodyIndex out_body,
+                    const SpanningForest::Mobod& mobod)
+      : index(mobilizer_index),
+        inboard_frame(in_frame),
+        outboard_frame(out_frame),
+        inboard_body(in_body),
+        outboard_body(out_body),
+        num_positions(mobod.nq()),
+        positions_start(mobod.q_start()),
+        num_velocities(mobod.nv()),
+        velocities_start_in_v(mobod.v_start()) {}
 
   // Returns `true` if all members of `this` topology are exactly equal to the
   // members of `other`.
@@ -235,20 +236,20 @@ struct BodyNodeTopology {
   // @param parent_rigid_body_in The parent body, in a tree structure sense, to
   //     `rigid_body_in`. In other words, `parent_rigid_body_in` is the body
   //     associated with node `parent_node_in`.
-  BodyNodeTopology(
-      MobodIndex index_in, int level_in,
-      MobodIndex parent_node_in,
-      BodyIndex rigid_body_in, BodyIndex parent_rigid_body_in)
-      : index(index_in), level(level_in),
+  BodyNodeTopology(MobodIndex index_in, int level_in, MobodIndex parent_node_in,
+                   BodyIndex rigid_body_in, BodyIndex parent_rigid_body_in)
+      : index(index_in),
+        level(level_in),
         parent_body_node(parent_node_in),
-        rigid_body(rigid_body_in), parent_rigid_body(parent_rigid_body_in) {}
+        rigid_body(rigid_body_in),
+        parent_rigid_body(parent_rigid_body_in) {}
 
   // Returns `true` if all members of `this` topology are exactly equal to the
   // members of `other`.
   bool operator==(const BodyNodeTopology& other) const;
 
   // Returns the number of children to this node.
-  int get_num_children() const { return ssize(child_nodes);}
+  int get_num_children() const { return ssize(child_nodes); }
 
   // Index of this node in the SpanningForest (0 for World). There
   // is an associated Mobilizer with the same index.
@@ -312,9 +313,7 @@ class MultibodyTreeTopology {
   int num_mobods() const { return ssize(body_nodes_); }
 
   // Returns the number of joint actuators in the topology.
-  int num_joint_actuators() const {
-    return ssize(joint_actuators_);
-  }
+  int num_joint_actuators() const { return ssize(joint_actuators_); }
 
   // Returns the number of levels in the forest topology.
   int forest_height() const { return forest_height_; }

--- a/multibody/tree/parameter_conversion.h
+++ b/multibody/tree/parameter_conversion.h
@@ -33,15 +33,14 @@ systems::BasicVector<T> ToBasicVector(
     const SpatialInertia<T>& spatial_inertia) {
   const Vector3<T>& com = spatial_inertia.get_com();
   const UnitInertia<T>& unit_inertia = spatial_inertia.get_unit_inertia();
-  return systems::BasicVector<T>(
-      {
-      // mass
-      spatial_inertia.get_mass(),
-      // center of mass
-      com(0), com(1), com(2),
-      // unit inertia
-      unit_inertia(0, 0), unit_inertia(1, 1), unit_inertia(2, 2),
-      unit_inertia(0, 1), unit_inertia(0, 2), unit_inertia(1, 2)});
+  return systems::BasicVector<T>({// mass
+                                  spatial_inertia.get_mass(),
+                                  // center of mass
+                                  com(0), com(1), com(2),
+                                  // unit inertia
+                                  unit_inertia(0, 0), unit_inertia(1, 1),
+                                  unit_inertia(2, 2), unit_inertia(0, 1),
+                                  unit_inertia(0, 2), unit_inertia(1, 2)});
 }
 
 // Extracts the mass from the BasicVector<T> representing a SpatialInertia<T> as
@@ -60,10 +59,9 @@ Vector3<T> GetCenterOfMass(
     const systems::BasicVector<T>& spatial_inertia_vector) {
   DRAKE_DEMAND(spatial_inertia_vector.size() ==
                SpatialInertiaIndex::k_num_coordinates);
-  return Vector3<T>(
-      spatial_inertia_vector[SpatialInertiaIndex::k_com_x],
-      spatial_inertia_vector[SpatialInertiaIndex::k_com_y],
-      spatial_inertia_vector[SpatialInertiaIndex::k_com_z]);
+  return Vector3<T>(spatial_inertia_vector[SpatialInertiaIndex::k_com_x],
+                    spatial_inertia_vector[SpatialInertiaIndex::k_com_y],
+                    spatial_inertia_vector[SpatialInertiaIndex::k_com_z]);
 }
 
 // Converts a BasicVector<T> to a SpatialInertia<T>

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -25,7 +25,7 @@ std::unique_ptr<internal::BodyNode<T>> PlanarMobilizer<T>::CreateBodyNode(
 
 template <typename T>
 std::string PlanarMobilizer<T>::position_suffix(
-  int position_index_in_mobilizer) const {
+    int position_index_in_mobilizer) const {
   switch (position_index_in_mobilizer) {
     case 0:
       return "x";
@@ -39,7 +39,7 @@ std::string PlanarMobilizer<T>::position_suffix(
 
 template <typename T>
 std::string PlanarMobilizer<T>::velocity_suffix(
-  int velocity_index_in_mobilizer) const {
+    int velocity_index_in_mobilizer) const {
   switch (velocity_index_in_mobilizer) {
     case 0:
       return "vx";

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -38,8 +38,8 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PlanarMobilizer);
   using MobilizerBase = MobilizerImpl<T, 3, 3>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
-  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
   using typename MobilizerBase::HMatrix;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
 
   /* Constructor for a %PlanarMobilizer between an inboard frame F
    `inboard_frame_F` and an outboard frame M `outboard_frame_M` granting two
@@ -53,15 +53,15 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
   ~PlanarMobilizer() final;
 
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
   std::string position_suffix(int position_index_in_mobilizer) const final;
   std::string velocity_suffix(int velocity_index_in_mobilizer) const final;
 
-  bool can_rotate() const final    { return true; }
+  bool can_rotate() const final { return true; }
   bool can_translate() const final { return true; }
 
   /* Retrieves from `context` the two translations (x, y) which describe the
@@ -132,7 +132,7 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
                         in radians per second.
    @returns A constant reference to `this` mobilizer. */
   const PlanarMobilizer<T>& SetAngularRate(systems::Context<T>* context,
-                                            const T& theta_dot) const;
+                                           const T& theta_dot) const;
 
   /* Computes the across-mobilizer transform `X_FM(q)` between the inboard
   frame F and the outboard frame M as a function of the configuration q stored
@@ -144,8 +144,7 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   /* Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame
    M measured and expressed in frame F as a function of the input velocity v. */
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
-                               const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
     return SpatialVelocity<T>(Vector3<T>(0.0, 0.0, v[2]),
                               Vector3<T>(v[0], v[1], 0.0));
   }

--- a/multibody/tree/position_kinematics_cache.h
+++ b/multibody/tree/position_kinematics_cache.h
@@ -160,7 +160,8 @@ class PositionKinematicsCache {
   static RigidTransform<T> NaNPose() {
     // Note: RotationMatrix will throw in Debug builds if values are NaN. For
     // our purposes, it is enough the translation has NaN values.
-    return RigidTransform<T>(math::RotationMatrix<T>::Identity(),
+    return RigidTransform<T>(
+        math::RotationMatrix<T>::Identity(),
         Vector3<T>::Constant(Eigen::NumTraits<double>::quiet_NaN()));
   }
 

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -9,26 +9,29 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
-PrismaticJoint<T>::PrismaticJoint(
-    const std::string& name, const Frame<T>& frame_on_parent,
-    const Frame<T>& frame_on_child, const Vector3<double>& axis,
-    double pos_lower_limit, double pos_upper_limit, double damping)
-    : Joint<T>(name, frame_on_parent, frame_on_child,
-               VectorX<double>::Constant(1, damping),
-               VectorX<double>::Constant(1, pos_lower_limit),
-               VectorX<double>::Constant(1, pos_upper_limit),
-               VectorX<double>::Constant(
-                   1, -std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, -std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, std::numeric_limits<double>::infinity())) {
+PrismaticJoint<T>::PrismaticJoint(const std::string& name,
+                                  const Frame<T>& frame_on_parent,
+                                  const Frame<T>& frame_on_child,
+                                  const Vector3<double>& axis,
+                                  double pos_lower_limit,
+                                  double pos_upper_limit, double damping)
+    : Joint<T>(
+          name, frame_on_parent, frame_on_child,
+          VectorX<double>::Constant(1, damping),
+          VectorX<double>::Constant(1, pos_lower_limit),
+          VectorX<double>::Constant(1, pos_upper_limit),
+          VectorX<double>::Constant(1,
+                                    -std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1, std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1,
+                                    -std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1,
+                                    std::numeric_limits<double>::infinity())) {
   const double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
   if (axis.isZero(kEpsilon)) {
-    throw std::logic_error("Prismatic joint axis vector must have nonzero "
-                           "length.");
+    throw std::logic_error(
+        "Prismatic joint axis vector must have nonzero "
+        "length.");
   }
   if (damping < 0) {
     throw std::logic_error("Prismatic joint damping must be nonnegative.");

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -79,9 +79,7 @@ class PrismaticJoint final : public Joint<T> {
   /// Since the measures of this axis in either frame F or M are the same (see
   /// this class's documentation for frame definitions) then,
   /// `axis = axis_F = axis_M`.
-  const Vector3<double>& translation_axis() const {
-    return axis_;
-  }
+  const Vector3<double>& translation_axis() const { return axis_; }
 
   /// Returns `this` joint's default damping constant in N⋅s/m.
   double default_damping() const { return this->default_damping_vector()[0]; }
@@ -145,8 +143,8 @@ class PrismaticJoint final : public Joint<T> {
   /// @param[in] translation
   ///   The desired translation in meters to be stored in `context`.
   /// @returns a constant reference to `this` joint.
-  const PrismaticJoint<T>& set_translation(
-      Context<T>* context, const T& translation) const {
+  const PrismaticJoint<T>& set_translation(Context<T>* context,
+                                           const T& translation) const {
     get_mobilizer()->SetTranslation(context, translation);
     return *this;
   }
@@ -223,10 +221,8 @@ class PrismaticJoint final : public Joint<T> {
   /// positive in the direction along this joint's axis.
   /// That is, a positive force causes a positive translational acceleration
   /// along the joint's axis.
-  void AddInForce(
-      const systems::Context<T>& context,
-      const T& force,
-      MultibodyForces<T>* multibody_forces) const {
+  void AddInForce(const systems::Context<T>& context, const T& force,
+                  MultibodyForces<T>* multibody_forces) const {
     DRAKE_DEMAND(multibody_forces != nullptr);
     DRAKE_DEMAND(
         multibody_forces->CheckHasRightSizeForModel(this->get_parent_tree()));
@@ -242,11 +238,9 @@ class PrismaticJoint final : public Joint<T> {
   /// child (according to the prismatic joint's constructor) at the origin of
   /// the child frame (which is coincident with the origin of the parent frame
   /// at all times).
-  void DoAddInOneForce(
-      const systems::Context<T>&,
-      int joint_dof,
-      const T& joint_tau,
-      MultibodyForces<T>* forces) const final {
+  void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
+                       const T& joint_tau,
+                       MultibodyForces<T>* forces) const final {
     // Right now we assume all the forces in joint_tau go into a single
     // mobilizer.
     Eigen::Ref<VectorX<T>> tau_mob =
@@ -330,7 +324,8 @@ class PrismaticJoint final : public Joint<T> {
   // Make PrismaticJoint templated on every other scalar type a friend of
   // PrismaticJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of PrismaticJoint<T>.
-  template <typename> friend class PrismaticJoint;
+  template <typename>
+  friend class PrismaticJoint;
 
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
@@ -364,7 +359,8 @@ class PrismaticJoint final : public Joint<T> {
   Vector3<double> axis_;
 };
 
-template <typename T> const char PrismaticJoint<T>::kTypeName[] = "prismatic";
+template <typename T>
+const char PrismaticJoint<T>::kTypeName[] = "prismatic";
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -24,7 +24,7 @@ std::unique_ptr<internal::BodyNode<T>> PrismaticMobilizer<T>::CreateBodyNode(
 
 template <typename T>
 std::string PrismaticMobilizer<T>::position_suffix(
-  int position_index_in_mobilizer) const {
+    int position_index_in_mobilizer) const {
   if (position_index_in_mobilizer == 0) {
     return "x";
   }
@@ -33,7 +33,7 @@ std::string PrismaticMobilizer<T>::position_suffix(
 
 template <typename T>
 std::string PrismaticMobilizer<T>::velocity_suffix(
-  int velocity_index_in_mobilizer) const {
+    int velocity_index_in_mobilizer) const {
   if (velocity_index_in_mobilizer == 0) {
     return "v";
   }
@@ -102,8 +102,7 @@ PrismaticMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
 
 template <typename T>
 void PrismaticMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>&,
-    const SpatialForce<T>& F_Mo_F,
+    const systems::Context<T>&, const SpatialForce<T>& F_Mo_F,
     Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
   // Computes tau = H_FMᵀ * F_Mo_F where H_FM ∈ ℝ⁶ is:
@@ -113,8 +112,8 @@ void PrismaticMobilizer<T>::ProjectSpatialForce(
 }
 
 template <typename T>
-void PrismaticMobilizer<T>::DoCalcNMatrix(
-    const systems::Context<T>&, EigenPtr<MatrixX<T>> N) const {
+void PrismaticMobilizer<T>::DoCalcNMatrix(const systems::Context<T>&,
+                                          EigenPtr<MatrixX<T>> N) const {
   (*N)(0, 0) = 1.0;
 }
 
@@ -126,8 +125,7 @@ void PrismaticMobilizer<T>::DoCalcNplusMatrix(
 
 template <typename T>
 void PrismaticMobilizer<T>::MapVelocityToQDot(
-    const systems::Context<T>&,
-    const Eigen::Ref<const VectorX<T>>& v,
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
   DRAKE_ASSERT(v.size() == kNv);
   DRAKE_ASSERT(qdot != nullptr);
@@ -137,8 +135,7 @@ void PrismaticMobilizer<T>::MapVelocityToQDot(
 
 template <typename T>
 void PrismaticMobilizer<T>::MapQDotToVelocity(
-    const systems::Context<T>&,
-    const Eigen::Ref<const VectorX<T>>& qdot,
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
     EigenPtr<VectorX<T>> v) const {
   DRAKE_ASSERT(qdot.size() == kNq);
   DRAKE_ASSERT(v != nullptr);

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -37,8 +37,8 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PrismaticMobilizer);
   using MobilizerBase = MobilizerImpl<T, 1, 1>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
-  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
   using typename MobilizerBase::HMatrix;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
 
   // Constructor for a %PrismaticMobilizer between the `inboard_frame_F` and
   // `outboard_frame_M` granting a single translational degree of freedom along
@@ -51,8 +51,9 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   PrismaticMobilizer(const SpanningForest::Mobod& mobod,
                      const Frame<T>& inboard_frame_F,
                      const Frame<T>& outboard_frame_M,
-                     const Vector3<double>& axis_F) :
-      MobilizerBase(mobod, inboard_frame_F, outboard_frame_M), axis_F_(axis_F) {
+                     const Vector3<double>& axis_F)
+      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M),
+        axis_F_(axis_F) {
     double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
     DRAKE_DEMAND(!axis_F.isZero(kEpsilon));
     axis_F_.normalize();
@@ -61,15 +62,15 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   ~PrismaticMobilizer() final;
 
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
   std::string position_suffix(int position_index_in_mobilizer) const final;
   std::string velocity_suffix(int velocity_index_in_mobilizer) const final;
 
-  bool can_rotate() const final    { return false; }
+  bool can_rotate() const final { return false; }
   bool can_translate() const final { return true; }
 
   // @retval axis_F The translation axis as a unit vector expressed in the
@@ -89,8 +90,8 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   //                    belongs to.
   // @param[in] translation The desired translation in meters.
   // @returns a constant reference to `this` mobilizer.
-  const PrismaticMobilizer<T>& SetTranslation(
-      systems::Context<T>* context, const T& translation) const;
+  const PrismaticMobilizer<T>& SetTranslation(systems::Context<T>* context,
+                                              const T& translation) const;
 
   // Gets the rate of change, in meters per second, of `this` mobilizer's
   // translation (see get_translation()) from `context`. See class
@@ -99,7 +100,7 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   //                    belongs to.
   // @returns The rate of change of `this` mobilizer's translation in the
   // `context`.
-  const T& get_translation_rate(const systems::Context<T> &context) const;
+  const T& get_translation_rate(const systems::Context<T>& context) const;
 
   // Sets the rate of change, in meters per second, of `this` mobilizer's
   // translation to `translation_dot`. The new rate of change `translation_dot`
@@ -111,7 +112,7 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   // mobilizer's translation in meters per second.
   // @returns a constant reference to `this` mobilizer.
   const PrismaticMobilizer<T>& SetTranslationRate(
-      systems::Context<T> *context, const T& translation_dot) const;
+      systems::Context<T>* context, const T& translation_dot) const;
 
   // Computes the across-mobilizer transform `X_FM(q)` between the inboard
   // frame F and the outboard frame M as a function of the translation distance
@@ -126,8 +127,7 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   // M measured and expressed in frame F as a function of the input
   // translational velocity v along this mobilizer's axis (see
   // translation_axis()).
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
-                               const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
     return SpatialVelocity<T>(Vector3<T>::Zero(), v[0] * translation_axis());
   }
 
@@ -158,34 +158,30 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   // Therefore, the result of this method is the scalar value of the linear
   // force along the axis of `this` mobilizer.
   // This method aborts in Debug builds if `tau.size()` is not one.
-  void ProjectSpatialForce(
-      const systems::Context<T>& context,
-      const SpatialForce<T>& F_Mo_F,
-      Eigen::Ref<VectorX<T>> tau) const final;
+  void ProjectSpatialForce(const systems::Context<T>& context,
+                           const SpatialForce<T>& F_Mo_F,
+                           Eigen::Ref<VectorX<T>> tau) const final;
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
   // Computes the kinematic mapping from generalized velocities v to time
   // derivatives of the generalized positions `q̇`. For this mobilizer `q̇ = v`.
-  void MapVelocityToQDot(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> qdot) const final;
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const final;
 
   // Computes the kinematic mapping from time derivatives of the generalized
   // positions `q̇` to generalized velocities v. For this mobilizer `v = q̇`.
-  void MapQDotToVelocity(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& qdot,
-      EigenPtr<VectorX<T>> v) const final;
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const final;
 
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
 
-  void DoCalcNplusMatrix(
-      const systems::Context<T>& context,
-      EigenPtr<MatrixX<T>> Nplus) const final;
+  void DoCalcNplusMatrix(const systems::Context<T>& context,
+                         EigenPtr<MatrixX<T>> Nplus) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/prismatic_spring.cc
+++ b/multibody/tree/prismatic_spring.cc
@@ -90,7 +90,7 @@ PrismaticSpring<T>::TemplatedDoCloneToScalar(
   // reference, which might not be available during cloning.
   std::unique_ptr<PrismaticSpring<ToScalar>> spring_clone(
       new PrismaticSpring<ToScalar>(this->model_instance(), joint_index_,
-                                   nominal_position(), stiffness()));
+                                    nominal_position(), stiffness()));
   return spring_clone;
 }
 

--- a/multibody/tree/prismatic_spring.h
+++ b/multibody/tree/prismatic_spring.h
@@ -38,10 +38,8 @@ class PrismaticSpring final : public ForceElement<T> {
   /// @param[in] stiffness
   /// The stiffness k of the spring in N/m.
   /// @throws std::exception if `stiffness` is (strictly) negative.
-  PrismaticSpring(
-      const PrismaticJoint<T>& joint,
-      double nominal_position,
-      double stiffness);
+  PrismaticSpring(const PrismaticJoint<T>& joint, double nominal_position,
+                  double stiffness);
 
   ~PrismaticSpring() override;
 
@@ -83,11 +81,12 @@ class PrismaticSpring final : public ForceElement<T> {
 
   // Allow different specializations to access each other's private data for
   // scalar conversion.
-  template <typename U> friend class PrismaticSpring;
+  template <typename U>
+  friend class PrismaticSpring;
 
   // Private constructor for internal use in TemplatedDoCloneToScalar()
   PrismaticSpring(ModelInstanceIndex model_instance, JointIndex joint_index,
-                 double nominal_position, double stiffness);
+                  double nominal_position, double stiffness);
 
   // Helper method to make a clone templated on ToScalar().
   template <typename ToScalar>

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -409,8 +409,8 @@ class QuaternionFloatingJoint final : public Joint<T> {
     this->set_default_positions(q);
   }
 
-  std::pair<Eigen::Quaternion<double>, Vector3<double>>
-  DoGetDefaultPosePair() const final {
+  std::pair<Eigen::Quaternion<double>, Vector3<double>> DoGetDefaultPosePair()
+      const final {
     const VectorX<double>& q = this->default_positions();
     return std::make_pair(Eigen::Quaternion<double>(q[0], q[1], q[2], q[3]),
                           q.tail<3>());

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -28,7 +28,7 @@ QuaternionFloatingMobilizer<T>::CreateBodyNode(
 
 template <typename T>
 std::string QuaternionFloatingMobilizer<T>::position_suffix(
-  int position_index_in_mobilizer) const {
+    int position_index_in_mobilizer) const {
   // Note: The order of variables here is documented in get_quaternion().
   switch (position_index_in_mobilizer) {
     case 0:
@@ -46,13 +46,12 @@ std::string QuaternionFloatingMobilizer<T>::position_suffix(
     case 6:
       return "z";
   }
-  throw std::runtime_error(
-    "QuaternionFloatingMobilizer has only 7 positions.");
+  throw std::runtime_error("QuaternionFloatingMobilizer has only 7 positions.");
 }
 
 template <typename T>
 std::string QuaternionFloatingMobilizer<T>::velocity_suffix(
-  int velocity_index_in_mobilizer) const {
+    int velocity_index_in_mobilizer) const {
   switch (velocity_index_in_mobilizer) {
     case 0:
       return "wx";
@@ -68,7 +67,7 @@ std::string QuaternionFloatingMobilizer<T>::velocity_suffix(
       return "vz";
   }
   throw std::runtime_error(
-    "QuaternionFloatingMobilizer has only 6 velocities.");
+      "QuaternionFloatingMobilizer has only 6 velocities.");
 }
 
 template <typename T>
@@ -98,8 +97,8 @@ Vector3<T> QuaternionFloatingMobilizer<T>::get_translation(
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-QuaternionFloatingMobilizer<T>::SetQuaternion(
-    systems::Context<T>* context, const Quaternion<T>& q_FM) const {
+QuaternionFloatingMobilizer<T>::SetQuaternion(systems::Context<T>* context,
+                                              const Quaternion<T>& q_FM) const {
   DRAKE_DEMAND(context != nullptr);
   SetQuaternion(*context, q_FM, &context->get_mutable_state());
   return *this;
@@ -107,9 +106,9 @@ QuaternionFloatingMobilizer<T>::SetQuaternion(
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-QuaternionFloatingMobilizer<T>::SetQuaternion(
-    const systems::Context<T>&, const Quaternion<T>& q_FM,
-    systems::State<T>* state) const {
+QuaternionFloatingMobilizer<T>::SetQuaternion(const systems::Context<T>&,
+                                              const Quaternion<T>& q_FM,
+                                              systems::State<T>* state) const {
   DRAKE_DEMAND(state != nullptr);
   auto q = this->get_mutable_positions(state);
   DRAKE_ASSERT(q.size() == kNq);
@@ -130,9 +129,9 @@ QuaternionFloatingMobilizer<T>::SetTranslation(systems::Context<T>* context,
 
 template <typename T>
 const QuaternionFloatingMobilizer<T>&
-QuaternionFloatingMobilizer<T>::SetTranslation(
-    const systems::Context<T>&, const Vector3<T>& p_FM,
-    systems::State<T>* state) const {
+QuaternionFloatingMobilizer<T>::SetTranslation(const systems::Context<T>&,
+                                               const Vector3<T>& p_FM,
+                                               systems::State<T>* state) const {
   DRAKE_DEMAND(state != nullptr);
   auto q = this->get_mutable_positions(&*state);
   DRAKE_ASSERT(q.size() == kNq);
@@ -156,7 +155,7 @@ void QuaternionFloatingMobilizer<T>::set_random_translation_distribution(
 
 template <typename T>
 void QuaternionFloatingMobilizer<T>::set_random_quaternion_distribution(
-        const Eigen::Quaternion<symbolic::Expression>& q_FM) {
+    const Eigen::Quaternion<symbolic::Expression>& q_FM) {
   Vector<symbolic::Expression, kNq> positions;
   if (this->get_random_state_distribution()) {
     positions = this->get_random_state_distribution()->template head<kNq>();
@@ -224,8 +223,7 @@ QuaternionFloatingMobilizer<T>::SetTranslationalVelocity(
 }
 
 template <typename T>
-Vector<double, 7> QuaternionFloatingMobilizer<T>::get_zero_position()
-    const {
+Vector<double, 7> QuaternionFloatingMobilizer<T>::get_zero_position() const {
   Vector<double, 7> q = Vector<double, 7>::Zero();
   const Quaternion<double> quaternion = Quaternion<double>::Identity();
   q[0] = quaternion.w();
@@ -345,7 +343,8 @@ QuaternionFloatingMobilizer<T>::QuaternionRateToAngularVelocityMatrix(
   // N⁺(q_tilde) = L(2 q_FM_tilde)ᵀ
   return CalcLMatrix({2.0 * q_FM_tilde[0], 2.0 * q_FM_tilde[1],
                       2.0 * q_FM_tilde[2], 2.0 * q_FM_tilde[3]})
-      .transpose() * dqnorm_dq;
+             .transpose() *
+         dqnorm_dq;
 }
 
 template <typename T>
@@ -378,8 +377,8 @@ void QuaternionFloatingMobilizer<T>::DoCalcNplusMatrix(
 
 template <typename T>
 void QuaternionFloatingMobilizer<T>::MapVelocityToQDot(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v, EigenPtr<VectorX<T>> qdot) const {
+    const systems::Context<T>& context, const Eigen::Ref<const VectorX<T>>& v,
+    EigenPtr<VectorX<T>> qdot) const {
   DRAKE_ASSERT(v.size() == kNv);
   DRAKE_ASSERT(qdot != nullptr);
   DRAKE_ASSERT(qdot->size() == kNq);

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -36,8 +36,8 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(QuaternionFloatingMobilizer);
   using MobilizerBase = MobilizerImpl<T, 7, 6>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
-  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
   using typename MobilizerBase::HMatrix;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
 
   // Constructor for a %QuaternionFloatingMobilizer granting six degrees of
   // freedom to an outboard frame M with respect to an inboard frame F. The
@@ -50,14 +50,14 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   //   the outboard frame M which can move freely with respect to frame F.
   QuaternionFloatingMobilizer(const SpanningForest::Mobod& mobod,
                               const Frame<T>& inboard_frame_F,
-                              const Frame<T>& outboard_frame_M) :
-      MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {}
+                              const Frame<T>& outboard_frame_M)
+      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {}
 
   ~QuaternionFloatingMobilizer() final;
 
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   bool is_floating() const final { return true; }
 
@@ -68,7 +68,7 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   std::string position_suffix(int position_index_in_mobilizer) const final;
   std::string velocity_suffix(int velocity_index_in_mobilizer) const final;
 
-  bool can_rotate() const final    { return true; }
+  bool can_rotate() const final { return true; }
   bool can_translate() const final { return true; }
 
   // @name Methods to get and set the state for a QuaternionFloatingMobilizer
@@ -108,8 +108,8 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   // Alternative signature to SetQuaternion(context, q_FM) to set `state` to
   // store the orientation of M in F given by the quaternion `q_FM`.
   const QuaternionFloatingMobilizer<T>& SetQuaternion(
-      const systems::Context<T>& context,
-      const Quaternion<T>& q_FM, systems::State<T>* state) const;
+      const systems::Context<T>& context, const Quaternion<T>& q_FM,
+      systems::State<T>* state) const;
 
   // Sets the distribution governing the random samples of the rotation
   // component of the mobilizer state.
@@ -135,8 +135,8 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
 
   // Sets the distribution governing the random samples of the position
   // component of the mobilizer state.
-  void set_random_translation_distribution(const Vector3<symbolic::Expression>&
-      position);
+  void set_random_translation_distribution(
+      const Vector3<symbolic::Expression>& position);
 
   // Sets `context` so this mobilizer's generalized coordinates (its quaternion
   // q_FM) are consistent with the given `R_FM` rotation matrix.
@@ -213,8 +213,7 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
                                    Vector3<T>(q[4], q[5], q[6]));
   }
 
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
-                               const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
     const Eigen::Map<const VVector> V_FM(v);
     return SpatialVelocity<T>(V_FM);  // w_FM, v_FM
   }
@@ -230,22 +229,19 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& vdot) const final;
 
-  void ProjectSpatialForce(
-      const systems::Context<T>& context,
-      const SpatialForce<T>& F_Mo_F,
-      Eigen::Ref<VectorX<T>> tau) const final;
+  void ProjectSpatialForce(const systems::Context<T>& context,
+                           const SpatialForce<T>& F_Mo_F,
+                           Eigen::Ref<VectorX<T>> tau) const final;
 
   bool is_velocity_equal_to_qdot() const final { return false; }
 
-  void MapVelocityToQDot(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> qdot) const final;
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const final;
 
-  void MapQDotToVelocity(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& qdot,
-      EigenPtr<VectorX<T>> v) const final;
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const final;
   // @}
 
  protected:

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -10,25 +10,28 @@ namespace multibody {
 
 template <typename T>
 RevoluteJoint<T>::RevoluteJoint(const std::string& name,
-              const Frame<T>& frame_on_parent, const Frame<T>& frame_on_child,
-              const Vector3<double>& axis, double pos_lower_limit,
-              double pos_upper_limit, double damping)
-    : Joint<T>(name, frame_on_parent, frame_on_child,
-               VectorX<double>::Constant(1, damping),
-               VectorX<double>::Constant(1, pos_lower_limit),
-               VectorX<double>::Constant(1, pos_upper_limit),
-               VectorX<double>::Constant(
-                   1, -std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, -std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, std::numeric_limits<double>::infinity())) {
+                                const Frame<T>& frame_on_parent,
+                                const Frame<T>& frame_on_child,
+                                const Vector3<double>& axis,
+                                double pos_lower_limit, double pos_upper_limit,
+                                double damping)
+    : Joint<T>(
+          name, frame_on_parent, frame_on_child,
+          VectorX<double>::Constant(1, damping),
+          VectorX<double>::Constant(1, pos_lower_limit),
+          VectorX<double>::Constant(1, pos_upper_limit),
+          VectorX<double>::Constant(1,
+                                    -std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1, std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1,
+                                    -std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1,
+                                    std::numeric_limits<double>::infinity())) {
   const double kEpsilon = std::numeric_limits<double>::epsilon();
   if (axis.isZero(kEpsilon)) {
-    throw std::logic_error("Revolute joint axis vector must have nonzero "
-                           "length.");
+    throw std::logic_error(
+        "Revolute joint axis vector must have nonzero "
+        "length.");
   }
   if (damping < 0) {
     throw std::logic_error("Revolute joint damping must be nonnegative.");

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -61,13 +61,12 @@ class RevoluteJoint final : public Joint<T> {
   ///   opposing motion, with ω the angular rate for `this` joint (see
   ///   get_angular_rate()).
   /// @throws std::exception if damping is negative.
-  RevoluteJoint(const std::string& name,
-                const Frame<T>& frame_on_parent, const Frame<T>& frame_on_child,
-                const Vector3<double>& axis,
-                double damping = 0) :
-      RevoluteJoint<T>(name, frame_on_parent, frame_on_child, axis,
-                       -std::numeric_limits<double>::infinity(),
-                       std::numeric_limits<double>::infinity(), damping) {}
+  RevoluteJoint(const std::string& name, const Frame<T>& frame_on_parent,
+                const Frame<T>& frame_on_child, const Vector3<double>& axis,
+                double damping = 0)
+      : RevoluteJoint<T>(name, frame_on_parent, frame_on_child, axis,
+                         -std::numeric_limits<double>::infinity(),
+                         std::numeric_limits<double>::infinity(), damping) {}
 
   /// Constructor to create a revolute joint between two bodies so that
   /// frame F attached to the parent body P and frame M attached to the child
@@ -113,9 +112,7 @@ class RevoluteJoint final : public Joint<T> {
   /// Since the measures of this axis in either frame F or M are the same (see
   /// this class's documentation for frame definitions) then,
   /// `axis = axis_F = axis_M`.
-  const Vector3<double>& revolute_axis() const {
-    return axis_;
-  }
+  const Vector3<double>& revolute_axis() const { return axis_; }
 
   /// Returns `this` joint's default damping constant in N⋅m⋅s.
   double default_damping() const { return this->default_damping_vector()[0]; }
@@ -177,8 +174,7 @@ class RevoluteJoint final : public Joint<T> {
   /// @param[in] angle
   ///   The desired angle in radians to be stored in `context`.
   /// @returns a constant reference to `this` joint.
-  const RevoluteJoint<T>& set_angle(
-      Context<T>* context, const T& angle) const {
+  const RevoluteJoint<T>& set_angle(Context<T>* context, const T& angle) const {
     get_mobilizer()->SetAngle(context, angle);
     return *this;
   }
@@ -207,8 +203,8 @@ class RevoluteJoint final : public Joint<T> {
   ///   The desired rate of change of `this` joints's angle in radians per
   ///   second.
   /// @returns a constant reference to `this` joint.
-  const RevoluteJoint<T>& set_angular_rate(
-      Context<T>* context, const T& angle) const {
+  const RevoluteJoint<T>& set_angular_rate(Context<T>* context,
+                                           const T& angle) const {
     get_mobilizer()->SetAngularRate(context, angle);
     return *this;
   }
@@ -253,10 +249,8 @@ class RevoluteJoint final : public Joint<T> {
   /// acceleration according to the right-hand-rule around the joint's axis.
   ///
   /// @note A torque is the moment of a set of forces whose resultant is zero.
-  void AddInTorque(
-      const systems::Context<T>& context,
-      const T& torque,
-      MultibodyForces<T>* forces) const {
+  void AddInTorque(const systems::Context<T>& context, const T& torque,
+                   MultibodyForces<T>* forces) const {
     DRAKE_DEMAND(forces != nullptr);
     DRAKE_DEMAND(forces->CheckHasRightSizeForModel(this->get_parent_tree()));
     this->AddInOneForce(context, 0, torque, forces);
@@ -275,11 +269,9 @@ class RevoluteJoint final : public Joint<T> {
   /// joint's axis. That is, a positive torque causes a positive rotational
   /// acceleration (of the child body frame) according to the right-hand-rule
   /// around the joint's axis.
-  void DoAddInOneForce(
-      const systems::Context<T>&,
-      int joint_dof,
-      const T& joint_tau,
-      MultibodyForces<T>* forces) const override {
+  void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
+                       const T& joint_tau,
+                       MultibodyForces<T>* forces) const override {
     // Right now we assume all the forces in joint_tau go into a single
     // mobilizer.
     DRAKE_DEMAND(joint_dof == 0);
@@ -306,17 +298,13 @@ class RevoluteJoint final : public Joint<T> {
     return get_mobilizer()->velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override {
-    return 1;
-  }
+  int do_get_num_velocities() const override { return 1; }
 
   int do_get_position_start() const override {
     return get_mobilizer()->position_start_in_q();
   }
 
-  int do_get_num_positions() const override {
-    return 1;
-  }
+  int do_get_num_positions() const override { return 1; }
 
   std::string do_get_position_suffix(int index) const override {
     return get_mobilizer()->position_suffix(index);
@@ -357,7 +345,8 @@ class RevoluteJoint final : public Joint<T> {
   // Make RevoluteJoint templated on every other scalar type a friend of
   // RevoluteJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of RevoluteJoint<T>.
-  template <typename> friend class RevoluteJoint;
+  template <typename>
+  friend class RevoluteJoint;
 
   // Friend class to facilitate testing.
   friend class JointTester;
@@ -393,7 +382,8 @@ class RevoluteJoint final : public Joint<T> {
   Vector3<double> axis_;
 };
 
-template <typename T> const char RevoluteJoint<T>::kTypeName[] = "revolute";
+template <typename T>
+const char RevoluteJoint<T>::kTypeName[] = "revolute";
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -23,7 +23,7 @@ std::unique_ptr<internal::BodyNode<T>> RevoluteMobilizer<T>::CreateBodyNode(
 
 template <typename T>
 std::string RevoluteMobilizer<T>::position_suffix(
-  int position_index_in_mobilizer) const {
+    int position_index_in_mobilizer) const {
   if (position_index_in_mobilizer == 0) {
     return "q";
   }
@@ -32,7 +32,7 @@ std::string RevoluteMobilizer<T>::position_suffix(
 
 template <typename T>
 std::string RevoluteMobilizer<T>::velocity_suffix(
-  int velocity_index_in_mobilizer) const {
+    int velocity_index_in_mobilizer) const {
   if (velocity_index_in_mobilizer == 0) {
     return "w";
   }
@@ -100,8 +100,7 @@ RevoluteMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
 
 template <typename T>
 void RevoluteMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>&,
-    const SpatialForce<T>& F_Mo_F,
+    const systems::Context<T>&, const SpatialForce<T>& F_Mo_F,
     Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
   // Computes tau = H_FMᵀ * F_Mo_F where H_FM ∈ ℝ⁶ is:
@@ -111,21 +110,20 @@ void RevoluteMobilizer<T>::ProjectSpatialForce(
 }
 
 template <typename T>
-void RevoluteMobilizer<T>::DoCalcNMatrix(
-    const systems::Context<T>&, EigenPtr<MatrixX<T>> N) const {
+void RevoluteMobilizer<T>::DoCalcNMatrix(const systems::Context<T>&,
+                                         EigenPtr<MatrixX<T>> N) const {
   (*N)(0, 0) = 1.0;
 }
 
 template <typename T>
-void RevoluteMobilizer<T>::DoCalcNplusMatrix(
-      const systems::Context<T>&, EigenPtr<MatrixX<T>> Nplus) const {
+void RevoluteMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>&,
+                                             EigenPtr<MatrixX<T>> Nplus) const {
   (*Nplus)(0, 0) = 1.0;
 }
 
 template <typename T>
 void RevoluteMobilizer<T>::MapVelocityToQDot(
-    const systems::Context<T>&,
-    const Eigen::Ref<const VectorX<T>>& v,
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
   DRAKE_ASSERT(v.size() == kNv);
   DRAKE_ASSERT(qdot != nullptr);
@@ -135,8 +133,7 @@ void RevoluteMobilizer<T>::MapVelocityToQDot(
 
 template <typename T>
 void RevoluteMobilizer<T>::MapQDotToVelocity(
-    const systems::Context<T>&,
-    const Eigen::Ref<const VectorX<T>>& qdot,
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
     EigenPtr<VectorX<T>> v) const {
   DRAKE_ASSERT(qdot.size() == kNq);
   DRAKE_ASSERT(v != nullptr);

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -39,8 +39,8 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RevoluteMobilizer);
   using MobilizerBase = MobilizerImpl<T, 1, 1>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
-  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
   using typename MobilizerBase::HMatrix;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
 
   // Constructor for a %RevoluteMobilizer between the inboard frame F
   // `inboard_frame_F` and the outboard frame M `outboard_frame_F` granting a
@@ -52,8 +52,9 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   RevoluteMobilizer(const SpanningForest::Mobod& mobod,
                     const Frame<T>& inboard_frame_F,
                     const Frame<T>& outboard_frame_M,
-                    const Vector3<double>& axis_F) :
-      MobilizerBase(mobod, inboard_frame_F, outboard_frame_M), axis_F_(axis_F) {
+                    const Vector3<double>& axis_F)
+      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M),
+        axis_F_(axis_F) {
     double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
     DRAKE_DEMAND(!axis_F_.isZero(kEpsilon));
     axis_F_.normalize();
@@ -62,15 +63,15 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   ~RevoluteMobilizer() final;
 
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
   std::string position_suffix(int position_index_in_mobilizer) const final;
   std::string velocity_suffix(int velocity_index_in_mobilizer) const final;
 
-  bool can_rotate() const final    { return true; }
+  bool can_rotate() const final { return true; }
   bool can_translate() const final { return false; }
 
   // @retval axis_F The rotation axis as a unit vector expressed in the inboard
@@ -90,8 +91,8 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   //                    belongs to.
   // @param[in] angle The desired angle in radians.
   // @returns a constant reference to `this` mobilizer.
-  const RevoluteMobilizer<T>& SetAngle(
-      systems::Context<T>* context, const T& angle) const;
+  const RevoluteMobilizer<T>& SetAngle(systems::Context<T>* context,
+                                       const T& angle) const;
 
   // Gets the rate of change, in radians per second, of `this` mobilizer's
   // angle (see get_angle()) from `context`. See class documentation for the
@@ -99,7 +100,7 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   // @param[in] context The context of the MultibodyTree this mobilizer
   //                    belongs to.
   // @returns The rate of change of `this` mobilizer's angle in the `context`.
-  const T& get_angular_rate(const systems::Context<T> &context) const;
+  const T& get_angular_rate(const systems::Context<T>& context) const;
 
   // Sets the rate of change, in radians per second, of this `this` mobilizer's
   // angle to `theta_dot`. The new rate of change `theta_dot` gets stored in
@@ -110,8 +111,8 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   // @param[in] theta_dot The desired rate of change of `this` mobilizer's
   // angle in radians per second.
   // @returns a constant reference to `this` mobilizer.
-  const RevoluteMobilizer<T>& SetAngularRate(
-      systems::Context<T> *context, const T& theta_dot) const;
+  const RevoluteMobilizer<T>& SetAngularRate(systems::Context<T>* context,
+                                             const T& theta_dot) const;
 
   // Computes the across-mobilizer transform `X_FM(q)` between the inboard
   // frame F and the outboard frame M as a function of the rotation angle
@@ -127,8 +128,7 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   // Computes the across-mobilizer spatial velocity V_FM(q, v) of the outboard
   // frame M measured and expressed in frame F as a function of the input
   // angular velocity `v` about this mobilizer's axis (@see revolute_axis()).
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
-                               const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
     return SpatialVelocity<T>(v[0] * axis_F_, Vector3<T>::Zero());
   }
 
@@ -159,30 +159,26 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   // Therefore, the result of this method is the scalar value of the torque at
   // the axis of `this` mobilizer.
   // This method aborts in Debug builds if `tau.size()` is not one.
-  void ProjectSpatialForce(
-      const systems::Context<T>& context,
-      const SpatialForce<T>& F_Mo_F,
-      Eigen::Ref<VectorX<T>> tau) const override;
+  void ProjectSpatialForce(const systems::Context<T>& context,
+                           const SpatialForce<T>& F_Mo_F,
+                           Eigen::Ref<VectorX<T>> tau) const override;
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  void MapVelocityToQDot(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> qdot) const override;
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const override;
 
-  void MapQDotToVelocity(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& qdot,
-      EigenPtr<VectorX<T>> v) const override;
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const override;
 
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
 
-  void DoCalcNplusMatrix(
-      const systems::Context<T>& context,
-      EigenPtr<MatrixX<T>> Nplus) const final;
+  void DoCalcNplusMatrix(const systems::Context<T>& context,
+                         EigenPtr<MatrixX<T>> Nplus) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;

--- a/multibody/tree/revolute_spring.h
+++ b/multibody/tree/revolute_spring.h
@@ -76,7 +76,8 @@ class RevoluteSpring final : public ForceElement<T> {
  private:
   // Allow different specializations to access each other's private data for
   // scalar conversion.
-  template <typename U> friend class RevoluteSpring;
+  template <typename U>
+  friend class RevoluteSpring;
 
   RevoluteSpring(ModelInstanceIndex model_instance, JointIndex joint_index,
                  double nominal_angle, double stiffness);

--- a/multibody/tree/rigid_body.cc
+++ b/multibody/tree/rigid_body.cc
@@ -59,7 +59,8 @@ RigidBody<T>::RigidBody(const std::string& body_name,
                         const SpatialInertia<double>& M)
     : MultibodyElement<T>(default_model_instance()),
       name_(internal::DeprecateWhenEmptyName(body_name, "RigidBody")),
-      body_frame_(*this), default_spatial_inertia_(M) {}
+      body_frame_(*this),
+      default_spatial_inertia_(M) {}
 
 template <typename T>
 RigidBody<T>::RigidBody(const std::string& body_name,
@@ -67,7 +68,8 @@ RigidBody<T>::RigidBody(const std::string& body_name,
                         const SpatialInertia<double>& M)
     : MultibodyElement<T>(model_instance),
       name_(internal::DeprecateWhenEmptyName(body_name, "RigidBody")),
-      body_frame_(*this), default_spatial_inertia_(M) {}
+      body_frame_(*this),
+      default_spatial_inertia_(M) {}
 
 template <typename T>
 void RigidBody<T>::SetCenterOfMassInBodyFrameNoModifyInertia(
@@ -89,8 +91,7 @@ void RigidBody<T>::SetCenterOfMassInBodyFrameNoModifyInertia(
 
 template <typename T>
 void RigidBody<T>::SetUnitInertiaAboutBodyOrigin(
-    systems::Context<T>* context,
-    const UnitInertia<T>& G_BBo_B) const {
+    systems::Context<T>* context, const UnitInertia<T>& G_BBo_B) const {
   DRAKE_THROW_UNLESS(context != nullptr);
   const T& Gxx = G_BBo_B(0, 0);
   const T& Gyy = G_BBo_B(1, 1);
@@ -123,8 +124,7 @@ void RigidBody<T>::SetCenterOfMassInBodyFrameAndPreserveCentralInertia(
   // Get B's initial spatial inertia about Bo (before Bcm changes location).
   // Get pi_BoBcm_B position from Bo to Bcm before Bcm changes location.
   // Get Gi_BBo_B (B's initial unit inertia about Bo, before Bcm changes).
-  const SpatialInertia<T> Mi_BBo_B =
-      CalcSpatialInertiaInBodyFrame(*context);
+  const SpatialInertia<T> Mi_BBo_B = CalcSpatialInertiaInBodyFrame(*context);
   const Vector3<T>& pi_BoBcm_B = Mi_BBo_B.get_com();
   const UnitInertia<T>& Gi_BBo_B = Mi_BBo_B.get_unit_inertia();
 

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -27,7 +27,8 @@ namespace drake {
 namespace multibody {
 
 // Forward declaration for RigidBodyFrame<T>.
-template<typename T> class RigidBody;
+template <typename T>
+class RigidBody;
 
 /// A %RigidBodyFrame is a material Frame that serves as the unique reference
 /// frame for a RigidBody.
@@ -121,7 +122,8 @@ class RigidBodyFrame final : public Frame<T> {
   // Make RigidBodyFrame templated on any other scalar type a friend of
   // RigidBodyFrame<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private methods from RigidBodyFrame<T>.
-  template <typename> friend class RigidBodyFrame;
+  template <typename>
+  friend class RigidBodyFrame;
 
   // Only RigidBody objects can create RigidBodyFrame objects since RigidBody is
   // a friend of RigidBodyFrame.
@@ -232,9 +234,7 @@ class RigidBody : public MultibodyElement<T> {
   ScopedName scoped_name() const;
 
   /// Returns a const reference to the associated BodyFrame.
-  const RigidBodyFrame<T>& body_frame() const {
-    return body_frame_;
-  }
+  const RigidBodyFrame<T>& body_frame() const { return body_frame_; }
 
   /// For a floating base %RigidBody, lock its inboard joint. Its generalized
   /// velocities will be 0 until it is unlocked.
@@ -281,9 +281,7 @@ class RigidBody : public MultibodyElement<T> {
   /// computational directed forest structure of the owning MultibodyTree to
   /// which this %RigidBody belongs. This serves as the BodyNode index and the
   /// index into all associated quantities.
-  internal::MobodIndex mobod_index() const {
-    return topology_.mobod_index;
-  }
+  internal::MobodIndex mobod_index() const { return topology_.mobod_index; }
 
   /// (Advanced) Returns `true` if this body is granted 6-dofs by a Mobilizer
   /// and the parent body of this body's associated 6-dof joint is `world`.
@@ -354,8 +352,9 @@ class RigidBody : public MultibodyElement<T> {
     } else {
       DRAKE_DEMAND(0 <= position_index_in_body && position_index_in_body < 6);
     }
-    return this->get_parent_tree().get_mobilizer(
-        topology_.inboard_mobilizer).position_suffix(position_index_in_body);
+    return this->get_parent_tree()
+        .get_mobilizer(topology_.inboard_mobilizer)
+        .position_suffix(position_index_in_body);
   }
 
   /// Returns a string suffix (e.g. to be appended to the name()) to identify
@@ -368,8 +367,9 @@ class RigidBody : public MultibodyElement<T> {
     ThrowIfNotFinalized(__func__);
     DRAKE_DEMAND(is_floating());
     DRAKE_DEMAND(0 <= velocity_index_in_body && velocity_index_in_body < 6);
-    return this->get_parent_tree().get_mobilizer(
-        topology_.inboard_mobilizer).velocity_suffix(velocity_index_in_body);
+    return this->get_parent_tree()
+        .get_mobilizer(topology_.inboard_mobilizer)
+        .velocity_suffix(velocity_index_in_body);
   }
 
   /// Returns this %RigidBody's default mass, which is initially supplied at
@@ -378,9 +378,7 @@ class RigidBody : public MultibodyElement<T> {
   /// this rigid body's %SpatialInertia or a parameter that is stored in a
   /// Context. The default constant mass value is used to initialize the mass
   /// parameter in the Context.
-  double default_mass() const {
-    return default_spatial_inertia_.get_mass();
-  }
+  double default_mass() const { return default_spatial_inertia_.get_mass(); }
 
   /// Returns the default value of this %RigidBody's center of mass as measured
   /// and expressed in its body frame. This value is initially supplied at
@@ -436,8 +434,8 @@ class RigidBody : public MultibodyElement<T> {
   /// expressed in W (for point Bo, the body frame's origin).
   const SpatialVelocity<T>& EvalSpatialVelocityInWorld(
       const systems::Context<T>& context) const {
-    return this->get_parent_tree().EvalBodySpatialVelocityInWorld(
-        context, *this);
+    return this->get_parent_tree().EvalBodySpatialVelocityInWorld(context,
+                                                                  *this);
   }
 
   /// Evaluates A_WB, this body B's SpatialAcceleration in the world frame W.
@@ -449,8 +447,8 @@ class RigidBody : public MultibodyElement<T> {
   /// once evaluated, successive calls to this method are inexpensive.
   const SpatialAcceleration<T>& EvalSpatialAccelerationInWorld(
       const systems::Context<T>& context) const {
-    return this->get_parent_tree().EvalBodySpatialAccelerationInWorld(
-        context, *this);
+    return this->get_parent_tree().EvalBodySpatialAccelerationInWorld(context,
+                                                                      *this);
   }
 
   /// Gets the SpatialForce on this %RigidBody B from `forces` as F_BBo_W:
@@ -488,10 +486,9 @@ class RigidBody : public MultibodyElement<T> {
   ///   A multibody forces objects that on output will have `F_Bp_E` added.
   /// @throws std::exception if `forces` is nullptr or if it is not consistent
   /// with the model to which this body belongs.
-  void AddInForce(
-      const systems::Context<T>& context,
-      const Vector3<T>& p_BP_E, const SpatialForce<T>& F_Bp_E,
-      const Frame<T>& frame_E, MultibodyForces<T>* forces) const;
+  void AddInForce(const systems::Context<T>& context, const Vector3<T>& p_BP_E,
+                  const SpatialForce<T>& F_Bp_E, const Frame<T>& frame_E,
+                  MultibodyForces<T>* forces) const;
 
   /// Gets this body's center of mass position from the given context.
   /// @param[in] context contains the state of the multibody system.
@@ -800,24 +797,21 @@ class RigidBody : public MultibodyElement<T> {
   // checked via CalcSpatialInertiaInBodyFrame().IsPhysicallyValid().
   // @pre the context makes sense for use by this %RigidBody.
   // @throws std::exception if context is null.
-  void SetUnitInertiaAboutBodyOrigin(
-      systems::Context<T>* context,
-      const UnitInertia<T>& G_BBo_B) const;
+  void SetUnitInertiaAboutBodyOrigin(systems::Context<T>* context,
+                                     const UnitInertia<T>& G_BBo_B) const;
 
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
   std::unique_ptr<RigidBody<ToScalar>> TemplatedDoCloneToScalar(
       const internal::MultibodyTree<ToScalar>& tree_clone) const {
     unused(tree_clone);
-    return std::make_unique<RigidBody<ToScalar>>(
-        this->name(), default_spatial_inertia_);
+    return std::make_unique<RigidBody<ToScalar>>(this->name(),
+                                                 default_spatial_inertia_);
   }
 
   // MultibodyTree has access to the mutable RigidBodyFrame through
   // RigidBodyAttorney.
-  RigidBodyFrame<T>& get_mutable_body_frame() {
-    return body_frame_;
-  }
+  RigidBodyFrame<T>& get_mutable_body_frame() { return body_frame_; }
 
   // A string identifying the body in its model.
   // Within a MultibodyPlant model instance this string is guaranteed to be

--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -35,8 +35,7 @@ namespace {
 //  principal moment of inertia is distinct.
 math::RotationMatrix<double> CalcCanonicalPrincipalDirections(
     const Vector3<double>& principal_moments_inertia,
-    const math::RotationMatrix<double>& R_EA,
-    const double& inertia_tolerance) {
+    const math::RotationMatrix<double>& R_EA, const double& inertia_tolerance) {
   const double& Imin = principal_moments_inertia(0);
   const double& Imax = principal_moments_inertia(2);
   math::RotationMatrix<double> canonical_principal_directions = R_EA;
@@ -72,7 +71,7 @@ math::RotationMatrix<double> CalcCanonicalPrincipalDirections(
 
 template <typename T>
 Vector3<double> RotationalInertia<T>::CalcPrincipalMomentsAndMaybeAxesOfInertia(
-      math::RotationMatrix<double>* principal_directions) const {
+    math::RotationMatrix<double>* principal_directions) const {
   Vector3<double> principal_moments;
 
   // 1. Eigen's SelfAdjointEigenSolver does not compile for AutoDiffXd.
@@ -93,7 +92,8 @@ Vector3<double> RotationalInertia<T>::CalcPrincipalMomentsAndMaybeAxesOfInertia(
   // Note: It seems reasonable to surmise that an inertia tolerance based on
   // known properties of moments and products of inertia is generally better
   // than generic matrix tolerances used in Eigen's eigenvalue solver.
-  const double inertia_tolerance = 4 * std::numeric_limits<double>::epsilon() *
+  const double inertia_tolerance =
+      4 * std::numeric_limits<double>::epsilon() *
       ExtractDoubleOrThrow(CalcMaximumPossibleMomentOfInertia());
   const bool is_diagonal = (std::abs(I_double(1, 0)) <= inertia_tolerance &&
                             std::abs(I_double(2, 0)) <= inertia_tolerance &&
@@ -102,11 +102,11 @@ Vector3<double> RotationalInertia<T>::CalcPrincipalMomentsAndMaybeAxesOfInertia(
     // Sort the principal moments of inertia (eigenvalues) and corresponding
     // principal directions (eigenvectors) in ascending order.
     using Pair = std::pair<double, int>;
-    std::array I{Pair{I_double(0, 0), 0},
-                 Pair{I_double(1, 1), 1},
+    std::array I{Pair{I_double(0, 0), 0}, Pair{I_double(1, 1), 1},
                  Pair{I_double(2, 2), 2}};
     std::sort(I.begin(), I.end(), [](const Pair& l, const Pair& r) {
-      return l < r;});
+      return l < r;
+    });
     const double Imin = I[0].first;  // Minimum principal moment of inertia.
     const double Imed = I[1].first;  // Intermediate principal moment of inertia
     const double Imax = I[2].first;  // Maximum principal moment of inertia.
@@ -140,13 +140,15 @@ Vector3<double> RotationalInertia<T>::CalcPrincipalMomentsAndMaybeAxesOfInertia(
     // is usually signficantly faster than the QR iterative algorithm but may
     // be less accurate (e.g., for 3x3 matrix of doubles, accuracy ≈ 1.0E-8).
     Eigen::SelfAdjointEigenSolver<Matrix3<double>> eig_solve;
-    const int compute_eigenvectors = principal_directions != nullptr ?
-        Eigen::ComputeEigenvectors : Eigen::EigenvaluesOnly;
+    const int compute_eigenvectors = principal_directions != nullptr
+                                         ? Eigen::ComputeEigenvectors
+                                         : Eigen::EigenvaluesOnly;
     eig_solve.compute(I_double, compute_eigenvectors);
     if (eig_solve.info() != Eigen::Success) {
       const std::string error_message = fmt::format(
           "{}(): Unable to calculate the eigenvalues or eigenvectors of the "
-          "3x3 matrix associated with a RotationalInertia.", __func__);
+          "3x3 matrix associated with a RotationalInertia.",
+          __func__);
       throw std::logic_error(error_message);
     }
 
@@ -180,8 +182,8 @@ Vector3<double> RotationalInertia<T>::CalcPrincipalMomentsAndMaybeAxesOfInertia(
 }
 
 template <typename T>
-void RotationalInertia<T>::ThrowNotPhysicallyValid(const char* func_name)
-    const {
+void RotationalInertia<T>::ThrowNotPhysicallyValid(
+    const char* func_name) const {
   std::string error_message = fmt::format(
       "{}(): The rotational inertia\n"
       "{}did not pass the test CouldBePhysicallyValid().",
@@ -195,7 +197,8 @@ void RotationalInertia<T>::ThrowNotPhysicallyValid(const char* func_name)
               p(0), p(1), p(2), /* epsilon = */ 0.0)) {
         error_message += fmt::format(
             "\nThe associated principal moments of inertia:"
-            "\n{}  {}  {}", p(0), p(1), p(2));
+            "\n{}  {}  {}",
+            p(0), p(1), p(2));
         if (p(0) < 0 || p(1) < 0 || p(2) < 0) {
           error_message += "\nare invalid since at least one is negative.";
         } else {
@@ -241,10 +244,12 @@ std::ostream& operator<<(std::ostream& out, const RotationalInertia<T>& I) {
   return out;
 }
 
-DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
-    static_cast<std::ostream&(*)(std::ostream&, const RotationalInertia<T>&)>(
-        &operator<< )
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    (static_cast<std::ostream& (*)(std::ostream&, const RotationalInertia<T>&)>(
+        &operator<< )  // clang-format would remove space lint requires
 ));
+// clang-format on
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -186,10 +186,9 @@ class RotationalInertia {
   /// Creates a rotational inertia with moments of inertia `Ixx`, `Iyy`, `Izz`,
   /// and with products of inertia `Ixy`, `Ixz`, `Iyz`.
   /// @throws std::exception for Debug builds if not CouldBePhysicallyValid().
-  RotationalInertia(const T& Ixx, const T& Iyy, const T& Izz,
-                    const T& Ixy, const T& Ixz, const T& Iyz) {
-    set_moments_and_products_no_validity_check(Ixx, Iyy, Izz,
-                                               Ixy, Ixz, Iyz);
+  RotationalInertia(const T& Ixx, const T& Iyy, const T& Izz, const T& Ixy,
+                    const T& Ixz, const T& Iyz) {
+    set_moments_and_products_no_validity_check(Ixx, Iyy, Izz, Ixy, Ixz, Iyz);
     DRAKE_ASSERT_VOID(ThrowIfNotPhysicallyValid(__func__));
   }
 
@@ -224,12 +223,10 @@ class RotationalInertia {
   /// @throws std::exception if skip_validity_check is false and
   /// CouldBePhysicallyValid() fails.
   static RotationalInertia<T> MakeFromMomentsAndProductsOfInertia(
-      const T& Ixx, const T& Iyy, const T& Izz,
-      const T& Ixy, const T& Ixz, const T& Iyz,
-      bool skip_validity_check = false) {
+      const T& Ixx, const T& Iyy, const T& Izz, const T& Ixy, const T& Ixz,
+      const T& Iyz, bool skip_validity_check = false) {
     RotationalInertia<T> I;
-    I.set_moments_and_products_no_validity_check(Ixx, Iyy, Izz,
-                                                 Ixy, Ixz, Iyz);
+    I.set_moments_and_products_no_validity_check(Ixx, Iyy, Izz, Ixy, Ixz, Iyz);
     if (!skip_validity_check) I.ThrowIfNotPhysicallyValid(__func__);
     return I;
   }
@@ -465,7 +462,7 @@ class RotationalInertia {
   /// This helps quickly detect uninitialized moments/products of inertia.
   void SetToNaN() {
     I_SP_E_.setConstant(std::numeric_limits<
-        typename Eigen::NumTraits<T>::Literal>::quiet_NaN());
+                        typename Eigen::NumTraits<T>::Literal>::quiet_NaN());
   }
 
   /// Sets `this` rotational inertia so all its moments/products of inertia
@@ -490,9 +487,9 @@ class RotationalInertia {
     static_assert(is_lower_triangular_order(1, 1), "Invalid indices");
     static_assert(is_lower_triangular_order(2, 1), "Invalid indices");
     static_assert(is_lower_triangular_order(2, 2), "Invalid indices");
-    return isnan(I_SP_E_(0, 0)) ||
-        isnan(I_SP_E_(1, 0)) || isnan(I_SP_E_(1, 1)) ||
-        isnan(I_SP_E_(2, 0)) || isnan(I_SP_E_(2, 1)) || isnan(I_SP_E_(2, 2));
+    return isnan(I_SP_E_(0, 0)) || isnan(I_SP_E_(1, 0)) ||
+           isnan(I_SP_E_(1, 1)) || isnan(I_SP_E_(2, 0)) ||
+           isnan(I_SP_E_(2, 1)) || isnan(I_SP_E_(2, 2));
   }
 
   /// Returns `true` if all moments and products of inertia are exactly zero.
@@ -505,9 +502,9 @@ class RotationalInertia {
     static_assert(is_lower_triangular_order(1, 1), "Invalid indices");
     static_assert(is_lower_triangular_order(2, 1), "Invalid indices");
     static_assert(is_lower_triangular_order(2, 2), "Invalid indices");
-    return I_SP_E_(0, 0) == 0.0 &&
-    I_SP_E_(1, 0) == 0.0 && I_SP_E_(1, 1) == 0.0 &&
-    I_SP_E_(2, 0) == 0.0 && I_SP_E_(2, 1) == 0.0 && I_SP_E_(2, 2) == 0.0;
+    return I_SP_E_(0, 0) == 0.0 && I_SP_E_(1, 0) == 0.0 &&
+           I_SP_E_(1, 1) == 0.0 && I_SP_E_(2, 0) == 0.0 &&
+           I_SP_E_(2, 1) == 0.0 && I_SP_E_(2, 2) == 0.0;
   }
 
   /// Returns a new %RotationalInertia object templated on `Scalar` initialized
@@ -607,8 +604,8 @@ class RotationalInertia {
     const Vector3<double> p = CalcPrincipalMomentsOfInertia();
 
     return !IsNaN() &&
-        AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
-            p(0), p(1), p(2), epsilon);
+           AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
+               p(0), p(1), p(2), epsilon);
   }
 
   /// Re-expresses `this` rotational inertia `I_BP_E` in place to `I_BP_A`.
@@ -730,8 +727,8 @@ class RotationalInertia {
   void ShiftToThenAwayFromCenterOfMassInPlace(const T& mass,
                                               const Vector3<T>& p_PBcm_E,
                                               const Vector3<T>& p_QBcm_E) {
-    *this += mass * ShiftUnitMassBodyToThenAwayFromCenterOfMass(p_PBcm_E,
-                                                                p_QBcm_E);
+    *this +=
+        mass * ShiftUnitMassBodyToThenAwayFromCenterOfMass(p_PBcm_E, p_QBcm_E);
   }
 
   /// Calculates the rotational inertia that results from shifting `this`
@@ -788,7 +785,8 @@ class RotationalInertia {
   // RotationalInertia<T>::cast<Scalar>() can make use of the private
   // constructor RotationalInertia<Scalar>(const Eigen::MatrixBase&) for an
   // Eigen expression templated on Scalar.
-  template <typename> friend class RotationalInertia;
+  template <typename>
+  friend class RotationalInertia;
 
   // Constructs a rotational inertia for a particle Q whose position vector
   // from about-point P is p_PQ_E = xx̂ + yŷ + zẑ = [x, y, z]_E, where E is the
@@ -807,11 +805,11 @@ class RotationalInertia {
     const T& x = p_PQ_E(0);
     const T& y = p_PQ_E(1);
     const T& z = p_PQ_E(2);
-    const T mxx = mx*x;
-    const T myy = my*y;
-    const T mzz = mz*z;
+    const T mxx = mx * x;
+    const T myy = my * y;
+    const T mzz = mz * z;
     set_moments_and_products_no_validity_check(myy + mzz, mxx + mzz, mxx + myy,
-                                               -mx * y,   -mx * z,   -my * z);
+                                               -mx * y, -mx * z, -my * z);
     DRAKE_ASSERT_VOID(ThrowIfNotPhysicallyValid(__func__));
   }
 
@@ -839,15 +837,19 @@ class RotationalInertia {
   // intentionally avoids testing CouldBePhysicallyValid().  Some methods need
   // to be able to form non-physical rotational inertias (which are to be
   // subtracted or added to other rotational inertias to form valid ones).
-  void set_moments_and_products_no_validity_check(
-      const T& Ixx, const T& Iyy, const T& Izz,
-      const T& Ixy, const T& Ixz, const T& Iyz) {
+  void set_moments_and_products_no_validity_check(const T& Ixx, const T& Iyy,
+                                                  const T& Izz, const T& Ixy,
+                                                  const T& Ixz, const T& Iyz) {
     // Note: The three upper off-diagonal matrix elements remain equal to NaN.
     static_assert(is_lower_triangular_order(1, 0), "Invalid indices");
     static_assert(is_lower_triangular_order(2, 0), "Invalid indices");
     static_assert(is_lower_triangular_order(2, 1), "Invalid indices");
-    I_SP_E_(0, 0) = Ixx;  I_SP_E_(1, 1) = Iyy;  I_SP_E_(2, 2) = Izz;
-    I_SP_E_(1, 0) = Ixy;  I_SP_E_(2, 0) = Ixz;  I_SP_E_(2, 1) = Iyz;
+    I_SP_E_(0, 0) = Ixx;
+    I_SP_E_(1, 1) = Iyy;
+    I_SP_E_(2, 2) = Izz;
+    I_SP_E_(1, 0) = Ixy;
+    I_SP_E_(2, 0) = Ixz;
+    I_SP_E_(2, 1) = Iyz;
   }
 
   // Calculates the rotational inertia that must be added to account for
@@ -969,11 +971,10 @@ class RotationalInertia {
   //       rotational inertia (e.g., Ixx + Iyy + Izz), one can prove:
   //       0 <= Imin <= tr/3,   tr/3 <= Imed <= tr/2,   tr/3 <= Imax <= tr/2.
   //       If Imin == 0, then Imed == Imax == tr / 2.
-  static boolean<T>
-  AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
+  static boolean<T> AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
       const T& Ixx, const T& Iyy, const T& Izz, const T& epsilon) {
-    const auto are_moments_near_positive = AreMomentsOfInertiaNearPositive(
-        Ixx, Iyy, Izz, epsilon);
+    const auto are_moments_near_positive =
+        AreMomentsOfInertiaNearPositive(Ixx, Iyy, Izz, epsilon);
     const auto is_triangle_inequality_satisified = Ixx + Iyy + epsilon >= Izz &&
                                                    Ixx + Iyy + epsilon >= Iyy &&
                                                    Iyy + Izz + epsilon >= Ixx;
@@ -988,9 +989,10 @@ class RotationalInertia {
   // @param epsilon Real positive number that is significantly smaller than the
   //        largest possible element in a valid rotational inertia.
   //        Heuristically, `epsilon` is a small multiplier of Trace() / 2.
-  static boolean<T> AreMomentsOfInertiaNearPositive(
-      const T& Ixx, const T& Iyy, const T& Izz, const T& epsilon) {
-    return Ixx + epsilon >= 0  &&  Iyy + epsilon >= 0  &&  Izz + epsilon >= 0;
+  static boolean<T> AreMomentsOfInertiaNearPositive(const T& Ixx, const T& Iyy,
+                                                    const T& Izz,
+                                                    const T& epsilon) {
+    return Ixx + epsilon >= 0 && Iyy + epsilon >= 0 && Izz + epsilon >= 0;
   }
 
   // ==========================================================================
@@ -1009,10 +1011,8 @@ class RotationalInertia {
   typename std::enable_if_t<scalar_predicate<T1>::is_bool>
   ThrowIfNotPhysicallyValid(const char* func_name) {
     DRAKE_DEMAND(func_name != nullptr);
-    if (!CouldBePhysicallyValid())
-      ThrowNotPhysicallyValid(func_name);
+    if (!CouldBePhysicallyValid()) ThrowNotPhysicallyValid(func_name);
   }
-
 
   // SFINAE for non-numeric types. See documentation in the implementation for
   // numeric types.
@@ -1028,8 +1028,9 @@ class RotationalInertia {
   static typename std::enable_if_t<scalar_predicate<T1>::is_bool>
   ThrowIfMultiplyByNegativeScalar(const T& nonnegative_scalar) {
     if (nonnegative_scalar < 0) {
-      throw std::logic_error("Error: Rotational inertia is multiplied by a "
-                             "negative number.");
+      throw std::logic_error(
+          "Error: Rotational inertia is multiplied by a "
+          "negative number.");
     }
   }
 
@@ -1047,8 +1048,9 @@ class RotationalInertia {
     if (positive_scalar == 0)
       throw std::logic_error("Error: Rotational inertia is divided by 0.");
     if (positive_scalar < 0) {
-      throw std::logic_error("Error: Rotational inertia is divided by a "
-                             "negative number");
+      throw std::logic_error(
+          "Error: Rotational inertia is divided by a "
+          "negative number");
     }
   }
 
@@ -1067,8 +1069,8 @@ class RotationalInertia {
   // Since the inertia matrix is symmetric, only the lower-triangular part of
   // the matrix is used.  All elements of the inertia matrix are initially set
   // to NaN which helps ensure the upper-triangular part is not used.
-  Matrix3<T> I_SP_E_{Matrix3<T>::Constant(std::numeric_limits<
-      typename Eigen::NumTraits<T>::Literal>::quiet_NaN())};
+  Matrix3<T> I_SP_E_{Matrix3<T>::Constant(
+      std::numeric_limits<typename Eigen::NumTraits<T>::Literal>::quiet_NaN())};
 };
 
 /// Writes an instance of RotationalInertia into a std::ostream.
@@ -1143,26 +1145,38 @@ void RotationalInertia<T>::ReExpressInPlace(
 
   // We're going to write back into this lower triangle.
   T& a = I_SP_E_(0, 0);
-  T& d = I_SP_E_(1, 0); T& b = I_SP_E_(1, 1);
-  T& e = I_SP_E_(2, 0); T& f = I_SP_E_(2, 1); T& c = I_SP_E_(2, 2);
+  T& d = I_SP_E_(1, 0);
+  T& b = I_SP_E_(1, 1);
+  T& e = I_SP_E_(2, 0);
+  T& f = I_SP_E_(2, 1);
+  T& c = I_SP_E_(2, 2);
 
   // Avoid use of Eigen's comma initializer since the compilers don't
   // reliably inline it.
   Eigen::Matrix<T, 3, 2> L;
-  L(0, 0) = a-c; L(0, 1) = d;
-  L(1, 0) = d;   L(1, 1) = b-c;
-  L(2, 0) = 2*e; L(2, 1) = 2*f;
+  L(0, 0) = a - c;
+  L(0, 1) = d;
+  L(1, 0) = d;
+  L(1, 1) = b - c;
+  L(2, 0) = 2 * e;
+  L(2, 1) = 2 * f;
 
   // For convenience below, the first two rows of Rᵀ.
   Eigen::Matrix<T, 2, 3> Rt;
-  Rt(0, 0) = R(0, 0); Rt(0, 1) = R(1, 0); Rt(0, 2) = R(2, 0);
-  Rt(1, 0) = R(0, 1); Rt(1, 1) = R(1, 1); Rt(1, 2) = R(2, 1);
+  Rt(0, 0) = R(0, 0);
+  Rt(0, 1) = R(1, 0);
+  Rt(0, 2) = R(2, 0);
+  Rt(1, 0) = R(0, 1);
+  Rt(1, 1) = R(1, 1);
+  Rt(1, 2) = R(2, 1);
 
   const Vector3<T> Rv(e * Rt.row(1) - f * Rt.row(0));
 
   Matrix2<T> Y;
-  Y(0, 0) = R.row(1).dot(L.col(0)); Y(0, 1) = R.row(1).dot(L.col(1));
-  Y(1, 0) = R.row(2).dot(L.col(0)); Y(1, 1) = R.row(2).dot(L.col(1));
+  Y(0, 0) = R.row(1).dot(L.col(0));
+  Y(0, 1) = R.row(1).dot(L.col(1));
+  Y(1, 0) = R.row(2).dot(L.col(0));
+  Y(1, 1) = R.row(2).dot(L.col(1));
 
   // We'll do Z elementwise due to element interdependence.
   const T Z11 = Y.row(0) * Rt.col(1);
@@ -1175,8 +1189,11 @@ void RotationalInertia<T>::ReExpressInPlace(
   // Assign result back into lower triangle. Don't set c until we're done
   // with the previous value!
   a = Z00 + c;
-  d = Z10 + Rv[2]; b = Z11 + c;
-  e = Z20 - Rv[1]; f = Z21 + Rv[0]; c += Z22;
+  d = Z10 + Rv[2];
+  b = Z11 + c;
+  e = Z20 - Rv[1];
+  f = Z21 + Rv[0];
+  c += Z22;
 
   // If both `this` and `R_AE` were valid upon entry to this method, the
   // returned rotational inertia should be valid.  Otherwise, it may not be.

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -28,7 +28,7 @@ std::unique_ptr<internal::BodyNode<T>> RpyBallMobilizer<T>::CreateBodyNode(
 
 template <typename T>
 std::string RpyBallMobilizer<T>::position_suffix(
-  int position_index_in_mobilizer) const {
+    int position_index_in_mobilizer) const {
   switch (position_index_in_mobilizer) {
     case 0:
       return "qx";
@@ -42,7 +42,7 @@ std::string RpyBallMobilizer<T>::position_suffix(
 
 template <typename T>
 std::string RpyBallMobilizer<T>::velocity_suffix(
-  int velocity_index_in_mobilizer) const {
+    int velocity_index_in_mobilizer) const {
   switch (velocity_index_in_mobilizer) {
     case 0:
       return "wx";
@@ -51,8 +51,7 @@ std::string RpyBallMobilizer<T>::velocity_suffix(
     case 2:
       return "wz";
   }
-  throw std::runtime_error(
-    "RpyBallMobilizer has only 3 velocities.");
+  throw std::runtime_error("RpyBallMobilizer has only 3 velocities.");
 }
 
 template <typename T>
@@ -127,19 +126,18 @@ RpyBallMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
 
 template <typename T>
 void RpyBallMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>&,
-    const SpatialForce<T>& F_Mo_F,
+    const systems::Context<T>&, const SpatialForce<T>& F_Mo_F,
     Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
   tau = F_Mo_F.rotational();
 }
 
 template <typename T>
-void RpyBallMobilizer<T>::DoCalcNMatrix(
-    const systems::Context<T>& context, EigenPtr<MatrixX<T>> N) const {
-  using std::sin;
-  using std::cos;
+void RpyBallMobilizer<T>::DoCalcNMatrix(const systems::Context<T>& context,
+                                        EigenPtr<MatrixX<T>> N) const {
   using std::abs;
+  using std::cos;
+  using std::sin;
 
   // The linear map E_F(q) allows computing v from q̇ as:
   // w_FM = E_F(q) * q̇; q̇ = [ṙ, ṗ, ẏ]ᵀ
@@ -189,8 +187,8 @@ void RpyBallMobilizer<T>::DoCalcNMatrix(
 }
 
 template <typename T>
-void RpyBallMobilizer<T>::DoCalcNplusMatrix(
-    const systems::Context<T>& context, EigenPtr<MatrixX<T>> Nplus) const {
+void RpyBallMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>& context,
+                                            EigenPtr<MatrixX<T>> Nplus) const {
   // The linear map between q̇ and v is given by matrix E_F(q) defined by:
   //          [ cos(y) * cos(p), -sin(y), 0]
   // E_F(q) = [ sin(y) * cos(p),  cos(y), 0]
@@ -211,24 +209,20 @@ void RpyBallMobilizer<T>::DoCalcNplusMatrix(
   const T sy = sin(angles[2]);
   const T cy = cos(angles[2]);
 
-  *Nplus <<
-        cy * cp, -sy, 0.0,
-        sy * cp,  cy, 0.0,
-            -sp, 0.0, 1.0;
+  *Nplus << cy * cp, -sy, 0.0, sy * cp, cy, 0.0, -sp, 0.0, 1.0;
 }
 
 template <typename T>
 void RpyBallMobilizer<T>::MapVelocityToQDot(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v,
+    const systems::Context<T>& context, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
   DRAKE_ASSERT(v.size() == kNv);
   DRAKE_ASSERT(qdot != nullptr);
   DRAKE_ASSERT(qdot->size() == kNq);
 
-  using std::sin;
-  using std::cos;
   using std::abs;
+  using std::cos;
+  using std::sin;
 
   // The linear map E_F(q) allows computing v from q̇ as:
   // w_FM = E_F(q) * q̇; q̇ = [ṙ, ṗ, ẏ]ᵀ
@@ -309,19 +303,18 @@ void RpyBallMobilizer<T>::MapVelocityToQDot(
   // ṗ = -sin(y) * w0 + cos(y) * w1
   // ẏ = sin(p) * ṙ + w2
   const T t = (cy * w0 + sy * w1) * cpi;  // Common factor.
-  *qdot =  Vector3<T>(t, -sy * w0 + cy * w1, sp *  t + w2);
+  *qdot = Vector3<T>(t, -sy * w0 + cy * w1, sp * t + w2);
 }
 
 template <typename T>
 void RpyBallMobilizer<T>::MapQDotToVelocity(
     const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& qdot,
-    EigenPtr<VectorX<T>> v) const {
+    const Eigen::Ref<const VectorX<T>>& qdot, EigenPtr<VectorX<T>> v) const {
   DRAKE_ASSERT(qdot.size() == kNq);
   DRAKE_ASSERT(v != nullptr);
   DRAKE_ASSERT(v->size() == kNv);
-  using std::sin;
   using std::cos;
+  using std::sin;
 
   // The linear map between q̇ and v is given by matrix E_F(q) defined by:
   //          [ cos(y) * cos(p), -sin(y), 0]
@@ -371,10 +364,9 @@ void RpyBallMobilizer<T>::MapQDotToVelocity(
 
   // Compute the product w_FM = E_W * q̇ directly since it's cheaper than
   // explicitly forming E_F and then multiplying with q̇.
-  *v = Vector3<T>(
-      cy * cp_x_rdot  -  sy * pdot, /*+ 0 * ydot*/
-      sy * cp_x_rdot  +  cy * pdot, /*+ 0 * ydot*/
-          -sp * rdot/*+   0 * pdot */ +     ydot);
+  *v = Vector3<T>(cy * cp_x_rdot - sy * pdot, /*+ 0 * ydot*/
+                  sy * cp_x_rdot + cy * pdot, /*+ 0 * ydot*/
+                  -sp * rdot /*+   0 * pdot */ + ydot);
 }
 
 template <typename T>
@@ -398,8 +390,7 @@ std::unique_ptr<Mobilizer<double>> RpyBallMobilizer<T>::DoCloneToScalar(
 }
 
 template <typename T>
-std::unique_ptr<Mobilizer<AutoDiffXd>>
-RpyBallMobilizer<T>::DoCloneToScalar(
+std::unique_ptr<Mobilizer<AutoDiffXd>> RpyBallMobilizer<T>::DoCloneToScalar(
     const MultibodyTree<AutoDiffXd>& tree_clone) const {
   return TemplatedDoCloneToScalar(tree_clone);
 }

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -64,8 +64,8 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RpyBallMobilizer);
   using MobilizerBase = MobilizerImpl<T, 3, 3>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
-  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
   using typename MobilizerBase::HMatrix;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
 
   // Constructor for an RpyBallMobilizer between an inboard frame F
   // inboard_frame_F and an outboard frame M outboard_frame_M granting
@@ -73,14 +73,14 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   // described in this class's documentation.
   RpyBallMobilizer(const SpanningForest::Mobod& mobod,
                    const Frame<T>& inboard_frame_F,
-                   const Frame<T>& outboard_frame_M) :
-      MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {}
+                   const Frame<T>& outboard_frame_M)
+      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {}
 
   ~RpyBallMobilizer() final;
 
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   bool has_quaternion_dofs() const final { return false; }
 
@@ -89,7 +89,7 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   std::string position_suffix(int position_index_in_mobilizer) const final;
   std::string velocity_suffix(int velocity_index_in_mobilizer) const final;
 
-  bool can_rotate() const final    { return true; }
+  bool can_rotate() const final { return true; }
   bool can_translate() const final { return false; }
 
   // Retrieves from context the three roll-pitch-yaw angles θ₀, θ₁, θ₂ which
@@ -116,9 +116,8 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   //   θ₂, described in this class's documentation, at entries angles(0),
   //   angles(1) and angles(2), respectively.
   // @returns a constant reference to this mobilizer.
-  const RpyBallMobilizer<T>& SetAngles(
-      systems::Context<T>* context,
-      const Vector3<T>& angles) const;
+  const RpyBallMobilizer<T>& SetAngles(systems::Context<T>* context,
+                                       const Vector3<T>& angles) const;
 
   // Sets context so this mobilizer's generalized coordinates (roll-pitch-yaw
   // angles θ₀, θ₁, θ₂) are consistent with the given R_FM rotation matrix.
@@ -152,8 +151,8 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   //   A vector in ℝ³ with the desired angular velocity of the outboard frame M
   //   in the inboard frame F, expressed in F.
   // @returns a constant reference to this mobilizer.
-  const RpyBallMobilizer<T>& SetAngularVelocity(
-      systems::Context<T>* context, const Vector3<T>& w_FM) const;
+  const RpyBallMobilizer<T>& SetAngularVelocity(systems::Context<T>* context,
+                                                const Vector3<T>& w_FM) const;
 
   // Stores in state the angular velocity w_FM of the outboard frame
   // M in the inboard frame F corresponding to this mobilizer.
@@ -183,8 +182,7 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   // M measured and expressed in frame F as a function of the input generalized
   // velocity v which contains the components of the angular velocity w_FM
   // expressed in frame F. The translational velocity is always zero.
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
-                               const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
     const Eigen::Map<const Vector3<T>> w_FM(v);
     return SpatialVelocity<T>(w_FM, Vector3<T>::Zero());
   }
@@ -209,10 +207,9 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& vdot) const override;
 
-  void ProjectSpatialForce(
-      const systems::Context<T>& context,
-      const SpatialForce<T>& F_Mo_F,
-      Eigen::Ref<VectorX<T>> tau) const override;
+  void ProjectSpatialForce(const systems::Context<T>& context,
+                           const SpatialForce<T>& F_Mo_F,
+                           Eigen::Ref<VectorX<T>> tau) const override;
 
   bool is_velocity_equal_to_qdot() const override { return false; }
 
@@ -234,10 +231,9 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   // in large errors for qdot), this method aborts when the absolute value of
   // the cosine of θ₁ is smaller than 10⁻³, a number arbitrarily chosen to this
   // end.
-  void MapVelocityToQDot(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> qdot) const override;
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const override;
 
   // Maps time derivatives of the roll-pitch-yaw angles θ₀, θ₁, θ₂ in qdot to
   // the generalized velocity v, which corresponds to the angular velocity
@@ -251,19 +247,16 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   // @param[out] v
   //   A vector of generalized velocities for this Mobilizer which should
   //   correspond to a vector in ℝ³ for an angular velocity w_FM of M in F.
-  void MapQDotToVelocity(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& qdot,
-      EigenPtr<VectorX<T>> v) const override;
-
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const override;
 
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
 
-  void DoCalcNplusMatrix(
-      const systems::Context<T>& context,
-      EigenPtr<MatrixX<T>> Nplus) const final;
+  void DoCalcNplusMatrix(const systems::Context<T>& context,
+                         EigenPtr<MatrixX<T>> Nplus) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;

--- a/multibody/tree/rpy_floating_mobilizer.cc
+++ b/multibody/tree/rpy_floating_mobilizer.cc
@@ -44,8 +44,7 @@ std::string RpyFloatingMobilizer<T>::position_suffix(
     case 5:
       return "z";
   }
-  throw std::runtime_error(
-      "RpyFloatingMobilizer has only 6 positions.");
+  throw std::runtime_error("RpyFloatingMobilizer has only 6 positions.");
 }
 
 template <typename T>
@@ -65,8 +64,7 @@ std::string RpyFloatingMobilizer<T>::velocity_suffix(
     case 5:
       return "vz";
   }
-  throw std::runtime_error(
-      "RpyFloatingMobilizer has only 6 velocities.");
+  throw std::runtime_error("RpyFloatingMobilizer has only 6 velocities.");
 }
 
 template <typename T>
@@ -114,17 +112,15 @@ const RpyFloatingMobilizer<T>& RpyFloatingMobilizer<T>::SetAngles(
 }
 
 template <typename T>
-const RpyFloatingMobilizer<T>&
-RpyFloatingMobilizer<T>::SetTranslation(systems::Context<T>* context,
-                                        const Vector3<T>& p_FM) const {
+const RpyFloatingMobilizer<T>& RpyFloatingMobilizer<T>::SetTranslation(
+    systems::Context<T>* context, const Vector3<T>& p_FM) const {
   auto q = this->GetMutablePositions(context).template tail<3>();
   q = p_FM;
   return *this;
 }
 
 template <typename T>
-const RpyFloatingMobilizer<T>&
-RpyFloatingMobilizer<T>::SetAngularVelocity(
+const RpyFloatingMobilizer<T>& RpyFloatingMobilizer<T>::SetAngularVelocity(
     systems::Context<T>* context, const Vector3<T>& w_FM) const {
   auto v = this->GetMutableVelocities(context).template head<3>();
   v = w_FM;
@@ -141,8 +137,7 @@ RpyFloatingMobilizer<T>::SetTranslationalVelocity(
 }
 
 template <typename T>
-const RpyFloatingMobilizer<T>&
-RpyFloatingMobilizer<T>::SetFromRigidTransform(
+const RpyFloatingMobilizer<T>& RpyFloatingMobilizer<T>::SetFromRigidTransform(
     systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const {
   SetAngles(context, math::RollPitchYaw<T>(X_FM.rotation()).vector());
   SetTranslation(context, X_FM.translation());
@@ -209,8 +204,8 @@ void RpyFloatingMobilizer<T>::ProjectSpatialForce(
 }
 
 template <typename T>
-void RpyFloatingMobilizer<T>::DoCalcNMatrix(
-    const systems::Context<T>& context, EigenPtr<MatrixX<T>> N) const {
+void RpyFloatingMobilizer<T>::DoCalcNMatrix(const systems::Context<T>& context,
+                                            EigenPtr<MatrixX<T>> N) const {
   using std::abs;
   using std::cos;
   using std::sin;
@@ -474,15 +469,13 @@ RpyFloatingMobilizer<T>::TemplatedDoCloneToScalar(
 }
 
 template <typename T>
-std::unique_ptr<Mobilizer<double>>
-RpyFloatingMobilizer<T>::DoCloneToScalar(
+std::unique_ptr<Mobilizer<double>> RpyFloatingMobilizer<T>::DoCloneToScalar(
     const MultibodyTree<double>& tree_clone) const {
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
 template <typename T>
-std::unique_ptr<Mobilizer<AutoDiffXd>>
-RpyFloatingMobilizer<T>::DoCloneToScalar(
+std::unique_ptr<Mobilizer<AutoDiffXd>> RpyFloatingMobilizer<T>::DoCloneToScalar(
     const MultibodyTree<AutoDiffXd>& tree_clone) const {
   return TemplatedDoCloneToScalar(tree_clone);
 }

--- a/multibody/tree/rpy_floating_mobilizer.h
+++ b/multibody/tree/rpy_floating_mobilizer.h
@@ -65,8 +65,8 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RpyFloatingMobilizer);
   using MobilizerBase = MobilizerImpl<T, 6, 6>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
-  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
   using typename MobilizerBase::HMatrix;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
 
   // Constructor for an RpyFloatingMobilizer between an inboard frame F
   // inboard_frame_F and an outboard frame M outboard_frame_M.
@@ -78,8 +78,8 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   ~RpyFloatingMobilizer() final;
 
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   bool is_floating() const final { return true; }
 
@@ -90,7 +90,7 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   std::string position_suffix(int position_index_in_mobilizer) const final;
   std::string velocity_suffix(int velocity_index_in_mobilizer) const final;
 
-  bool can_rotate() const final    { return true; }
+  bool can_rotate() const final { return true; }
   bool can_translate() const final { return true; }
 
   // Returns the generalized positions for this mobilizer stored in context.
@@ -163,8 +163,8 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   //   θ₀, θ₁, θ₂, described in this class's documentation, at entries
   //   angles(0), angles(1) and angles(2), respectively.
   // @returns a constant reference to this mobilizer.
-  const RpyFloatingMobilizer<T>& SetAngles(
-      systems::Context<T>* context, const Vector3<T>& angles) const;
+  const RpyFloatingMobilizer<T>& SetAngles(systems::Context<T>* context,
+                                           const Vector3<T>& angles) const;
 
   // Stores in context the position p_FM of M in F.
   //
@@ -173,8 +173,8 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   // @param[in] p_FM
   //   Position of F in M.
   // @returns a constant reference to this mobilizer.
-  const RpyFloatingMobilizer<T>& SetTranslation(
-      systems::Context<T>* context, const Vector3<T>& p_FM) const;
+  const RpyFloatingMobilizer<T>& SetTranslation(systems::Context<T>* context,
+                                                const Vector3<T>& p_FM) const;
 
   // Sets the distribution governing the random samples of the rpy angles
   // component of the mobilizer state.
@@ -233,8 +233,7 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   // measured and expressed in frame F as a function of the input generalized
   // velocity v, packed as documented in get_generalized_velocities(). (That's
   // conveniently just V_FM already.)
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
-                               const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
     const Eigen::Map<const VVector> V_FM(v);
     return SpatialVelocity<T>(V_FM);  // w_FM, v_FM
   }

--- a/multibody/tree/scoped_name.h
+++ b/multibody/tree/scoped_name.h
@@ -54,8 +54,8 @@ class ScopedName final {
   Returns nullopt if `namespace_name` starts or ends with "::", or if
   `element_name` contains "::" or is empty.
   @see ScopedName::Join() for automatic coalescing of "::" tokens. */
-  static std::optional<ScopedName> Make(
-      std::string_view namespace_name, std::string_view element_name);
+  static std::optional<ScopedName> Make(std::string_view namespace_name,
+                                        std::string_view element_name);
 
   /** Creates a %ScopedName for the given `name1::name2`. Unlike the constructor
   or ScopedName::Make(), this function allows "::" in either name. Any leading

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -10,23 +10,24 @@ namespace multibody {
 
 template <typename T>
 ScrewJoint<T>::ScrewJoint(const std::string& name,
-            const Frame<T>& frame_on_parent, const Frame<T>& frame_on_child,
-            const Vector3<double>& axis, double screw_pitch, double damping)
-    : Joint<T>(name, frame_on_parent, frame_on_child,
-               VectorX<double>::Constant(1, damping),
-               VectorX<double>::Constant(
-                   1, -std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, -std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, -std::numeric_limits<double>::infinity()),
-               VectorX<double>::Constant(
-                   1, std::numeric_limits<double>::infinity()))
-    , screw_pitch_{screw_pitch} {
+                          const Frame<T>& frame_on_parent,
+                          const Frame<T>& frame_on_child,
+                          const Vector3<double>& axis, double screw_pitch,
+                          double damping)
+    : Joint<T>(
+          name, frame_on_parent, frame_on_child,
+          VectorX<double>::Constant(1, damping),
+          VectorX<double>::Constant(1,
+                                    -std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1, std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1,
+                                    -std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1, std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1,
+                                    -std::numeric_limits<double>::infinity()),
+          VectorX<double>::Constant(1,
+                                    std::numeric_limits<double>::infinity())),
+      screw_pitch_{screw_pitch} {
   const double kEpsilon = std::numeric_limits<double>::epsilon();
   if (axis.isZero(kEpsilon)) {
     throw std::logic_error("Screw joint axis vector must have nonzero length.");
@@ -58,9 +59,7 @@ std::unique_ptr<Joint<ToScalar>> ScrewJoint<T>::TemplatedDoCloneToScalar(
   // Make the Joint<T> clone.
   auto joint_clone = std::make_unique<ScrewJoint<ToScalar>>(
       this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
-      this->screw_axis(),
-      this->screw_pitch(),
-      this->default_damping());
+      this->screw_axis(), this->screw_pitch(), this->default_damping());
   joint_clone->set_position_limits(this->position_lower_limits(),
                                    this->position_upper_limits());
   joint_clone->set_velocity_limits(this->velocity_lower_limits(),

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -66,10 +66,9 @@ class ScrewJoint final : public Joint<T> {
   ///   default_damping() for details on modelling of the damping torque.
   /// @throws std::exception if damping is negative.
   ScrewJoint(const std::string& name, const Frame<T>& frame_on_parent,
-             const Frame<T>& frame_on_child, double screw_pitch,
-             double damping) :
-      ScrewJoint<T>(name, frame_on_parent, frame_on_child,
-                    Vector3<double>::UnitZ(), screw_pitch, damping) {}
+             const Frame<T>& frame_on_child, double screw_pitch, double damping)
+      : ScrewJoint<T>(name, frame_on_parent, frame_on_child,
+                      Vector3<double>::UnitZ(), screw_pitch, damping) {}
 
   /// Constructor to create a screw joint between two bodies so that frame F
   /// attached to the parent body P and frame M attached to the child body B
@@ -115,9 +114,7 @@ class ScrewJoint final : public Joint<T> {
   /// Since the measures of this axis in either frame F or M are the same (see
   /// this class's documentation for frame definitions) then,
   /// `axis = axis_F = axis_M`.
-  const Vector3<double>& screw_axis() const {
-    return axis_;
-  }
+  const Vector3<double>& screw_axis() const { return axis_; }
 
   /// Returns `this` joint's amount of translation in meters
   /// occurring over a one full revolution.
@@ -148,8 +145,7 @@ class ScrewJoint final : public Joint<T> {
   /// @param[in] z The desired translation in meters to be stored in `context`
   ///              as (z). See class documentation for details.
   /// @returns a constant reference to `this` joint.
-  const ScrewJoint<T>& set_translation(Context<T>* context,
-                                       const T& z) const {
+  const ScrewJoint<T>& set_translation(Context<T>* context, const T& z) const {
     get_mobilizer()->SetTranslation(context, z);
     return *this;
   }
@@ -170,7 +166,7 @@ class ScrewJoint final : public Joint<T> {
   ///                  See class documentation for details.
   /// @returns a constant reference to `this` joint.
   const ScrewJoint<T>& set_rotation(systems::Context<T>* context,
-                                     const T& theta) const {
+                                    const T& theta) const {
     get_mobilizer()->SetAngle(context, theta);
     return *this;
   }
@@ -191,8 +187,8 @@ class ScrewJoint final : public Joint<T> {
   /// @param[in] vz The desired translational velocity of `this` joint in meters
   ///               per second along F frame's â-axis.
   /// @returns a constant reference to `this` joint.
-  const ScrewJoint<T>& set_translational_velocity(
-      systems::Context<T>* context, const T& vz) const {
+  const ScrewJoint<T>& set_translational_velocity(systems::Context<T>* context,
+                                                  const T& vz) const {
     get_mobilizer()->SetTranslationRate(context, vz);
     return *this;
   }
@@ -217,7 +213,7 @@ class ScrewJoint final : public Joint<T> {
   ///                      angle in radians per second.
   /// @returns a constant reference to `this` joint.
   const ScrewJoint<T>& set_angular_velocity(systems::Context<T>* context,
-                                             const T& theta_dot) const {
+                                            const T& theta_dot) const {
     get_mobilizer()->SetAngularRate(context, theta_dot);
     return *this;
   }

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -22,7 +22,7 @@ std::unique_ptr<internal::BodyNode<T>> ScrewMobilizer<T>::CreateBodyNode(
 
 template <typename T>
 std::string ScrewMobilizer<T>::position_suffix(
-  int position_index_in_mobilizer) const {
+    int position_index_in_mobilizer) const {
   if (position_index_in_mobilizer == 0) {
     return "q";
   }
@@ -31,7 +31,7 @@ std::string ScrewMobilizer<T>::position_suffix(
 
 template <typename T>
 std::string ScrewMobilizer<T>::velocity_suffix(
-  int velocity_index_in_mobilizer) const {
+    int velocity_index_in_mobilizer) const {
   if (velocity_index_in_mobilizer == 0) {
     return "w";
   }
@@ -52,8 +52,7 @@ T ScrewMobilizer<T>::get_translation(const systems::Context<T>& context) const {
 
 template <typename T>
 const ScrewMobilizer<T>& ScrewMobilizer<T>::SetTranslation(
-    systems::Context<T>* context,
-    const T& translation) const {
+    systems::Context<T>* context, const T& translation) const {
   const double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
   using std::abs;
   DRAKE_THROW_UNLESS(abs(screw_pitch_) > kEpsilon ||
@@ -91,8 +90,7 @@ T ScrewMobilizer<T>::get_translation_rate(
 
 template <typename T>
 const ScrewMobilizer<T>& ScrewMobilizer<T>::SetTranslationRate(
-    systems::Context<T>* context,
-    const T& vz) const {
+    systems::Context<T>* context, const T& vz) const {
   const double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
   using std::abs;
   DRAKE_THROW_UNLESS(abs(screw_pitch_) > kEpsilon || abs(vz) < kEpsilon);
@@ -123,17 +121,17 @@ const ScrewMobilizer<T>& ScrewMobilizer<T>::SetAngularRate(
 template <typename T>
 math::RigidTransform<T> ScrewMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>& context) const {
-const auto& q = this->get_positions(context);
-DRAKE_ASSERT(q.size() == kNq);
-return calc_X_FM(q.data());
+  const auto& q = this->get_positions(context);
+  DRAKE_ASSERT(q.size() == kNq);
+  return calc_X_FM(q.data());
 }
 
 template <typename T>
 SpatialVelocity<T> ScrewMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& v) const {
-DRAKE_ASSERT(v.size() == kNv);
-return calc_V_FM(context, v.data());
+  DRAKE_ASSERT(v.size() == kNv);
+  return calc_V_FM(context, v.data());
 }
 
 template <typename T>
@@ -143,16 +141,15 @@ ScrewMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
   Vector6<T> A_FM_vector;
-  A_FM_vector <<
-    (axis_ * vdot[0]),
-    (axis_ * GetScrewTranslationFromRotation(vdot[0], screw_pitch_));
+  A_FM_vector << (axis_ * vdot[0]),
+      (axis_ * GetScrewTranslationFromRotation(vdot[0], screw_pitch_));
   return SpatialAcceleration<T>(A_FM_vector);
 }
 
 template <typename T>
 void ScrewMobilizer<T>::ProjectSpatialForce(const systems::Context<T>&,
-                                             const SpatialForce<T>& F_Mo_F,
-                                             Eigen::Ref<VectorX<T>> tau) const {
+                                            const SpatialForce<T>& F_Mo_F,
+                                            Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
   tau[0] = F_Mo_F.rotational().dot(axis_) +
            F_Mo_F.translational().dot(axis_) / (2 * M_PI) * screw_pitch_;
@@ -160,20 +157,20 @@ void ScrewMobilizer<T>::ProjectSpatialForce(const systems::Context<T>&,
 
 template <typename T>
 void ScrewMobilizer<T>::DoCalcNMatrix(const systems::Context<T>&,
-                                       EigenPtr<MatrixX<T>> N) const {
+                                      EigenPtr<MatrixX<T>> N) const {
   *N = Eigen::Matrix<T, 1, 1>::Identity();
 }
 
 template <typename T>
 void ScrewMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>&,
-                                           EigenPtr<MatrixX<T>> Nplus) const {
+                                          EigenPtr<MatrixX<T>> Nplus) const {
   *Nplus = Eigen::Matrix<T, 1, 1>::Identity();
 }
 
 template <typename T>
-void ScrewMobilizer<T>::MapVelocityToQDot(
-    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
-    EigenPtr<VectorX<T>> qdot) const {
+void ScrewMobilizer<T>::MapVelocityToQDot(const systems::Context<T>&,
+                                          const Eigen::Ref<const VectorX<T>>& v,
+                                          EigenPtr<VectorX<T>> qdot) const {
   DRAKE_ASSERT(v.size() == kNv);
   DRAKE_ASSERT(qdot != nullptr);
   DRAKE_ASSERT(qdot->size() == kNq);

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -23,8 +23,7 @@ conversions. All of these are governed by the same relation, depended on the
 ScrewJoint for which this is the implementation. */
 
 template <typename T>
-T GetScrewTranslationFromRotation(const T& theta,
-                                             double screw_pitch) {
+T GetScrewTranslationFromRotation(const T& theta, double screw_pitch) {
   const T revolution_amount{theta / (2 * M_PI)};
   return screw_pitch * revolution_amount;
 }
@@ -60,8 +59,8 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ScrewMobilizer);
   using MobilizerBase = MobilizerImpl<T, 1, 1>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
-  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
   using typename MobilizerBase::HMatrix;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
 
   /* Constructor for a %ScrewMobilizer between an inboard frame F and
      an outboard frame M  granting one translational and one rotational degrees
@@ -81,8 +80,8 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
    machine epsilon. */
   ScrewMobilizer(const SpanningForest::Mobod& mobod,
                  const Frame<T>& inboard_frame_F,
-                 const Frame<T>& outboard_frame_M,
-                 const Vector3<double>& axis, double screw_pitch)
+                 const Frame<T>& outboard_frame_M, const Vector3<double>& axis,
+                 double screw_pitch)
       : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M),
         screw_pitch_(screw_pitch) {
     const double kEpsilon = std::numeric_limits<double>::epsilon();
@@ -93,8 +92,8 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   ~ScrewMobilizer() final;
 
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
@@ -190,8 +189,8 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
    frame F and the outboard frame M as a function of the configuration q stored
    in `context`. */
   math::RigidTransform<T> calc_X_FM(const T* q) const {
-    const Vector3<T> p_FM(
-        axis_ * GetScrewTranslationFromRotation(q[0], screw_pitch_));
+    const Vector3<T> p_FM(axis_ *
+                          GetScrewTranslationFromRotation(q[0], screw_pitch_));
     return math::RigidTransform<T>(Eigen::AngleAxis<T>(q[0], axis_), p_FM);
   }
 
@@ -199,8 +198,7 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
    M measured and expressed in frame F as a function of the input velocity v,
    which is the angular velocity. We scale that by the pitch to find the
    related translational velocity. */
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
-                               const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
     const SpatialVelocity<T> V_FM(
         axis_ * v[0],
         axis_ * GetScrewTranslationFromRotation(v[0], screw_pitch_));

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -22,24 +22,26 @@ const boolean<T> is_nonnegative_finite(const T& value) {
   return isfinite(value) && value >= 0;
 }
 
-template<typename T>
+template <typename T>
 void ThrowUnlessValueIsPositiveFinite(const T& value,
-    std::string_view value_name, std::string_view function_name) {
+                                      std::string_view value_name,
+                                      std::string_view function_name) {
   if (!is_positive_finite(value)) {
     DRAKE_DEMAND(!value_name.empty());
     DRAKE_DEMAND(!function_name.empty());
-    const std::string error_message = fmt::format(
-    "{}(): {} is not positive and finite: {}.",
-    function_name, value_name, value);
-  throw std::logic_error(error_message);
+    const std::string error_message =
+        fmt::format("{}(): {} is not positive and finite: {}.", function_name,
+                    value_name, value);
+    throw std::logic_error(error_message);
   }
 }
 
 }  // namespace
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::MakeFromCentralInertia(const T& mass,
-    const Vector3<T>& p_PScm_E, const RotationalInertia<T>& I_SScm_E) {
+SpatialInertia<T> SpatialInertia<T>::MakeFromCentralInertia(
+    const T& mass, const Vector3<T>& p_PScm_E,
+    const RotationalInertia<T>& I_SScm_E) {
   UnitInertia<T> G_SScm_E;
   G_SScm_E.SetFromRotationalInertia(I_SScm_E, mass);
   // The next line checks that M_SScm_E is physically valid.
@@ -56,8 +58,8 @@ SpatialInertia<T> SpatialInertia<T>::MakeUnitary() {
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::PointMass(
-    const T& mass, const Vector3<T>& position) {
+SpatialInertia<T> SpatialInertia<T>::PointMass(const T& mass,
+                                               const Vector3<T>& position) {
   ThrowUnlessValueIsPositiveFinite(mass, "mass", __func__);
 
   // Upgrade to monogram notation: position is the position vector from
@@ -72,8 +74,10 @@ SpatialInertia<T> SpatialInertia<T>::PointMass(
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(
-    const T& density, const T& lx, const T& ly, const T& lz) {
+SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(const T& density,
+                                                         const T& lx,
+                                                         const T& ly,
+                                                         const T& lz) {
   ThrowUnlessValueIsPositiveFinite(density, "density", __func__);
   ThrowUnlessValueIsPositiveFinite(lx, "x-length", __func__);
   ThrowUnlessValueIsPositiveFinite(ly, "y-length", __func__);
@@ -84,8 +88,9 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithDensity(
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(
-    const T& mass, const T& lx, const T& ly, const T& lz) {
+SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(const T& mass,
+                                                      const T& lx, const T& ly,
+                                                      const T& lz) {
   ThrowUnlessValueIsPositiveFinite(mass, "mass", __func__);
   ThrowUnlessValueIsPositiveFinite(lx, "x-length", __func__);
   ThrowUnlessValueIsPositiveFinite(ly, "y-length", __func__);
@@ -96,8 +101,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidBoxWithMass(
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(
-    const T& density, const T& length) {
+SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(const T& density,
+                                                          const T& length) {
   ThrowUnlessValueIsPositiveFinite(density, "density", __func__);
   ThrowUnlessValueIsPositiveFinite(length, "length", __func__);
   const T volume = length * length * length;
@@ -106,8 +111,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidCubeWithDensity(
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::SolidCubeWithMass(
-    const T& mass, const T& length) {
+SpatialInertia<T> SpatialInertia<T>::SolidCubeWithMass(const T& mass,
+                                                       const T& length) {
   ThrowUnlessValueIsPositiveFinite(mass, "mass", __func__);
   ThrowUnlessValueIsPositiveFinite(length, "length", __func__);
   const Vector3<T> p_BoBcm_B = Vector3<T>::Zero();
@@ -205,8 +210,7 @@ SpatialInertia<T> SpatialInertia<T>::ThinRodWithMass(
   ThrowUnlessValueIsPositiveFinite(mass, "mass", __func__);
   ThrowUnlessValueIsPositiveFinite(length, "length", __func__);
   math::internal::ThrowIfNotUnitVector(unit_vector, __func__);
-  const UnitInertia<T> G_BBcm_B =
-      UnitInertia<T>::ThinRod(length, unit_vector);
+  const UnitInertia<T> G_BBcm_B = UnitInertia<T>::ThinRod(length, unit_vector);
   const Vector3<T> p_BoBcm_B = Vector3<T>::Zero();
   return SpatialInertia<T>(mass, p_BoBcm_B, G_BBcm_B);
 }
@@ -225,8 +229,10 @@ SpatialInertia<T> SpatialInertia<T>::ThinRodWithMassAboutEnd(
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(
-    const T& density, const T& a, const T& b, const T& c) {
+SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(const T& density,
+                                                               const T& a,
+                                                               const T& b,
+                                                               const T& c) {
   ThrowUnlessValueIsPositiveFinite(density, "density", __func__);
   ThrowUnlessValueIsPositiveFinite(a, "semi-axis a", __func__);
   ThrowUnlessValueIsPositiveFinite(b, "semi-axis b", __func__);
@@ -237,8 +243,10 @@ SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithDensity(
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithMass(
-    const T& mass, const T& a, const T& b, const T& c) {
+SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithMass(const T& mass,
+                                                            const T& a,
+                                                            const T& b,
+                                                            const T& c) {
   ThrowUnlessValueIsPositiveFinite(mass, "mass", __func__);
   ThrowUnlessValueIsPositiveFinite(a, "semi-axis a", __func__);
   ThrowUnlessValueIsPositiveFinite(b, "semi-axis b", __func__);
@@ -249,8 +257,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidEllipsoidWithMass(
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(
-    const T& density, const T& radius) {
+SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(const T& density,
+                                                            const T& radius) {
   ThrowUnlessValueIsPositiveFinite(density, "density", __func__);
   ThrowUnlessValueIsPositiveFinite(radius, "radius", __func__);
   const T volume = (4.0 / 3.0) * M_PI * radius * radius * radius;  // 4/3 π r³
@@ -259,8 +267,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidSphereWithDensity(
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::SolidSphereWithMass(
-    const T& mass, const T& radius) {
+SpatialInertia<T> SpatialInertia<T>::SolidSphereWithMass(const T& mass,
+                                                         const T& radius) {
   ThrowUnlessValueIsPositiveFinite(mass, "mass", __func__);
   ThrowUnlessValueIsPositiveFinite(radius, "radius", __func__);
   const Vector3<T> p_BoBcm_B = Vector3<T>::Zero();
@@ -279,8 +287,8 @@ SpatialInertia<T> SpatialInertia<T>::HollowSphereWithDensity(
 }
 
 template <typename T>
-SpatialInertia<T> SpatialInertia<T>::HollowSphereWithMass(
-    const T& mass, const T& radius) {
+SpatialInertia<T> SpatialInertia<T>::HollowSphereWithMass(const T& mass,
+                                                          const T& radius) {
   ThrowUnlessValueIsPositiveFinite(mass, "mass", __func__);
   ThrowUnlessValueIsPositiveFinite(radius, "radius", __func__);
   const Vector3<T> p_BoBcm_B = Vector3<T>::Zero();
@@ -303,8 +311,8 @@ SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutPointWithDensity(
 
   // Form B's spatial inertia about vertex B0 and then shifts to point A.
   SpatialInertia<T> M_BB0 =
-      SpatialInertia<T>::SolidTetrahedronAboutVertexWithDensity(
-          density, p_B0B1, p_B0B2, p_B0B3);
+      SpatialInertia<T>::SolidTetrahedronAboutVertexWithDensity(density, p_B0B1,
+                                                                p_B0B2, p_B0B3);
   const Vector3<T>& p_AB0 = p0;  // Alias for position from point A to B0.
   M_BB0.ShiftInPlace(-p_AB0);
   return M_BB0;  // Since M_BB0 was shifted, this actually returns M_BA.
@@ -345,12 +353,12 @@ boolean<T> SpatialInertia<T>::IsPhysicallyValid() const {
 
 template <typename T>
 void SpatialInertia<T>::ThrowNotPhysicallyValid() const {
-  std::string error_message = fmt::format(
-          "Spatial inertia fails SpatialInertia::IsPhysicallyValid().");
+  std::string error_message =
+      fmt::format("Spatial inertia fails SpatialInertia::IsPhysicallyValid().");
   const T& mass = get_mass();
   if (!is_positive_finite(mass)) {
-      error_message += fmt::format(
-          "\nmass = {} is not positive and finite.\n", mass);
+    error_message +=
+        fmt::format("\nmass = {} is not positive and finite.\n", mass);
   } else {
     error_message += fmt::format("{}", *this);
     WriteExtraCentralInertiaProperties(&error_message);
@@ -531,8 +539,8 @@ void SpatialInertia<T>::WriteExtraCentralInertiaProperties(
   const Vector3<T>& p_PBcm = get_com();
   const boolean<T> is_position_zero = (p_PBcm == Vector3<T>::Zero());
   if (!is_position_zero) {
-    *message += fmt::format(
-        " Inertia about center of mass, I_BBcm =\n{}", I_BBcm);
+    *message +=
+        fmt::format(" Inertia about center of mass, I_BBcm =\n{}", I_BBcm);
   }
 
   // Write B's principal moments of inertia about Bcm.
@@ -541,7 +549,8 @@ void SpatialInertia<T>::WriteExtraCentralInertiaProperties(
     const double Imin = eig(0), Imed = eig(1), Imax = eig(2);
     *message += fmt::format(
         " Principal moments of inertia about Bcm (center of mass) ="
-        "\n[{}  {}  {}]\n", Imin, Imed, Imax);
+        "\n[{}  {}  {}]\n",
+        Imin, Imed, Imax);
   }
 }
 
@@ -582,10 +591,12 @@ std::ostream& operator<<(std::ostream& out, const SpatialInertia<T>& M) {
   return out;
 }
 
-DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
-    static_cast<std::ostream&(*)(std::ostream&, const SpatialInertia<T>&)>(
-        &operator<< )
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    (static_cast<std::ostream& (*)(std::ostream&, const SpatialInertia<T>&)>(
+        &operator<< )  // clang-format would remove space lint requires
 ));
+// clang-format on
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -97,7 +97,8 @@ namespace multibody {
 /// @see https://en.cppreference.com/w/cpp/language/exceptions
 ///
 /// @see To create a spatial inertia of a mesh, see
-/// @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>& mesh, double density). <!--# NOLINT-->
+/// @ref CalcSpatialInertia(const geometry::TriangleSurfaceMesh<double>& mesh,
+/// double density). <!--# NOLINT-->
 ///
 /// @see To create spatial inertia from most of geometry::Shape, see
 /// @ref CalcSpatialInertia(const geometry::Shape& shape, double density).
@@ -130,8 +131,9 @@ class SpatialInertia {
   ///                     (S's center of mass), expressed in a frame E.
   /// @param[in] I_SScm_E S's RotationalInertia about Scm, expressed in frame E.
   /// @retval M_SP_E S's spatial inertia about point P, expressed in frame E.
-  static SpatialInertia<T> MakeFromCentralInertia(const T& mass,
-      const Vector3<T>& p_PScm_E, const RotationalInertia<T>& I_SScm_E);
+  static SpatialInertia<T> MakeFromCentralInertia(
+      const T& mass, const Vector3<T>& p_PScm_E,
+      const RotationalInertia<T>& I_SScm_E);
 
   /// (Internal use only) Creates a spatial inertia whose mass is 1, position
   /// vector to center of mass is zero, and whose rotational inertia has
@@ -154,8 +156,8 @@ class SpatialInertia {
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
   /// @throws std::exception if density, lx, ly, or lz is not positive and
   /// finite.
-  static SpatialInertia<T> SolidBoxWithDensity(
-      const T& density, const T& lx, const T& ly, const T& lz);
+  static SpatialInertia<T> SolidBoxWithDensity(const T& density, const T& lx,
+                                               const T& ly, const T& lz);
 
   /// Creates a spatial inertia for a uniform density solid box B about its
   /// geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -165,8 +167,8 @@ class SpatialInertia {
   /// @param[in] lz length of the box in the Bz direction (meters).
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
   /// @throws std::exception if mass, lx, ly, or lz is not positive and finite.
-  static SpatialInertia<T> SolidBoxWithMass(
-      const T& mass, const T& lx, const T& ly, const T& lz);
+  static SpatialInertia<T> SolidBoxWithMass(const T& mass, const T& lx,
+                                            const T& ly, const T& lz);
 
   /// Creates a spatial inertia for a uniform density solid cube B about its
   /// geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -178,8 +180,8 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
   /// @throws std::exception if density or length is not positive and finite.
-  static SpatialInertia<T> SolidCubeWithDensity(
-      const T& density, const T& length);
+  static SpatialInertia<T> SolidCubeWithDensity(const T& density,
+                                                const T& length);
 
   /// Creates a spatial inertia for a uniform density solid cube B about its
   /// geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -191,8 +193,7 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
   /// @throws std::exception if mass or length is not positive and finite.
-  static SpatialInertia<T> SolidCubeWithMass(
-      const T& mass, const T& length);
+  static SpatialInertia<T> SolidCubeWithMass(const T& mass, const T& length);
 
   /// Creates a spatial inertia for a uniform density solid capsule B about
   /// its geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -224,9 +225,9 @@ class SpatialInertia {
   /// and is perpendicular to unit_vector.
   /// @throws std::exception if mass, radius, or length is not positive and
   /// finite or if ‖unit_vector‖ is not within 1.0E-14 of 1.0.
-  static SpatialInertia<T> SolidCapsuleWithMass(
-      const T& mass, const T& radius, const T& length,
-      const Vector3<T>& unit_vector);
+  static SpatialInertia<T> SolidCapsuleWithMass(const T& mass, const T& radius,
+                                                const T& length,
+                                                const Vector3<T>& unit_vector);
 
   /// Creates a spatial inertia for a uniform density solid cylinder B about
   /// its geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -262,9 +263,9 @@ class SpatialInertia {
   /// finite or if ‖unit_vector‖ is not within 1.0E-14 of 1.0.
   /// @see SolidCylinderWithMassAboutEnd() to calculate M_BBp_B, B's spatial
   /// inertia about Bp (at the center of one of the cylinder's circular ends).
-  static SpatialInertia<T> SolidCylinderWithMass(
-      const T& mass, const T& radius, const T& length,
-      const Vector3<T>& unit_vector);
+  static SpatialInertia<T> SolidCylinderWithMass(const T& mass, const T& radius,
+                                                 const T& length,
+                                                 const Vector3<T>& unit_vector);
 
   /// Creates a spatial inertia for a uniform-density solid cylinder B about an
   /// end-point Bp of the cylinder's axis (see below for more about Bp).
@@ -321,8 +322,8 @@ class SpatialInertia {
   /// if ‖unit_vector‖ is not within 1.0E-14 of 1.0.
   /// @see ThinRodWithMassAboutEnd() to calculate M_BBp_B, B's spatial inertia
   /// about Bp (one of the ends of rod B).
-  static SpatialInertia<T> ThinRodWithMass(
-      const T& mass, const T& length, const Vector3<T>& unit_vector);
+  static SpatialInertia<T> ThinRodWithMass(const T& mass, const T& length,
+                                           const Vector3<T>& unit_vector);
 
   /// Creates a spatial inertia for a uniform-density thin rod B about one of
   /// its ends.
@@ -351,8 +352,9 @@ class SpatialInertia {
   /// @param[in] c length of ellipsoid semi-axis in the ellipsoid Bz direction.
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
   /// @throws std::exception if density, a, b, or c is not positive and finite.
-  static SpatialInertia<T> SolidEllipsoidWithDensity(
-      const T& density, const T& a, const T& b, const T& c);
+  static SpatialInertia<T> SolidEllipsoidWithDensity(const T& density,
+                                                     const T& a, const T& b,
+                                                     const T& c);
 
   /// Creates a spatial inertia for a uniform density solid ellipsoid B about
   /// its geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -362,8 +364,8 @@ class SpatialInertia {
   /// @param[in] c length of ellipsoid semi-axis in the ellipsoid Bz direction.
   /// @retval M_BBo_B B's spatial inertia about Bo, expressed in B.
   /// @throws std::exception if mass, a, b, or c is not positive and finite.
-  static SpatialInertia<T> SolidEllipsoidWithMass(
-      const T& mass, const T& a, const T& b, const T& c);
+  static SpatialInertia<T> SolidEllipsoidWithMass(const T& mass, const T& a,
+                                                  const T& b, const T& c);
 
   /// Creates a spatial inertia for a uniform density solid sphere B about its
   /// geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -375,8 +377,8 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
   /// @throws std::exception if density or radius is not positive and finite.
-  static SpatialInertia<T> SolidSphereWithDensity(
-      const T& density, const T& radius);
+  static SpatialInertia<T> SolidSphereWithDensity(const T& density,
+                                                  const T& radius);
 
   /// Creates a spatial inertia for a uniform density solid sphere B about its
   /// geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -388,8 +390,7 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
   /// @throws std::exception if mass or radius is not positive and finite.
-  static SpatialInertia<T> SolidSphereWithMass(
-      const T& mass, const T& radius);
+  static SpatialInertia<T> SolidSphereWithMass(const T& mass, const T& radius);
 
   /// Creates a spatial inertia for a uniform density thin hollow sphere B about
   /// its geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -403,8 +404,8 @@ class SpatialInertia {
   /// B has an equal moment of inertia about any line passing through Bo.
   /// @throws std::exception if area_density or radius is not positive and
   /// finite.
-  static SpatialInertia<T> HollowSphereWithDensity(
-      const T& area_density, const T& radius);
+  static SpatialInertia<T> HollowSphereWithDensity(const T& area_density,
+                                                   const T& radius);
 
   /// Creates a spatial inertia for a uniform density hollow sphere B about its
   /// geometric center Bo (which is coincident with B's center of mass Bcm).
@@ -417,8 +418,7 @@ class SpatialInertia {
   /// @note B's rotational inertia about Bo is triaxially symmetric, meaning
   /// B has an equal moment of inertia about any line passing through Bo.
   /// @throws std::exception if mass or radius is not positive and finite.
-  static SpatialInertia<T> HollowSphereWithMass(
-      const T& mass, const T& radius);
+  static SpatialInertia<T> HollowSphereWithMass(const T& mass, const T& radius);
 
   /// Creates a spatial inertia for a uniform density solid tetrahedron B about
   /// a point A, from which position vectors to B's 4 vertices B0, B1, B2, B3
@@ -513,10 +513,10 @@ class SpatialInertia {
   ///                   about origin point P and expressed in frame E.
   /// @param[in] skip_validity_check If true, skips the validity check described
   ///                                above. Defaults to false.
-  SpatialInertia(
-      const T& mass, const Vector3<T>& p_PScm_E, const UnitInertia<T>& G_SP_E,
-      const bool skip_validity_check = false) :
-      mass_(mass), p_PScm_E_(p_PScm_E), G_SP_E_(G_SP_E) {
+  SpatialInertia(const T& mass, const Vector3<T>& p_PScm_E,
+                 const UnitInertia<T>& G_SP_E,
+                 const bool skip_validity_check = false)
+      : mass_(mass), p_PScm_E_(p_PScm_E), G_SP_E_(G_SP_E) {
     if (!skip_validity_check) {
       CheckInvariants();
     }
@@ -537,35 +537,34 @@ class SpatialInertia {
   template <typename Scalar>
   SpatialInertia<Scalar> cast() const {
     return SpatialInertia<Scalar>(
-        get_mass(),
-        get_com().template cast<Scalar>(),
+        get_mass(), get_com().template cast<Scalar>(),
         get_unit_inertia().template cast<Scalar>(),
         true);  // Skip validity check since this inertia is already valid.
   }
 
   /// Get a constant reference to the mass of this spatial inertia.
-  const T& get_mass() const { return mass_;}
+  const T& get_mass() const { return mass_; }
 
   /// Get a constant reference to the position vector `p_PScm_E` from the
   /// _about point_ P to the center of mass `Scm` of the body or composite body
   /// S, expressed in frame E. See the documentation of this class for details.
-  const Vector3<T>& get_com() const { return p_PScm_E_;}
+  const Vector3<T>& get_com() const { return p_PScm_E_; }
 
   /// Computes the center of mass moment vector `mass * p_PScm_E` given the
   /// position vector `p_PScm_E` from the _about point_ P to the center of mass
   /// `Scm` of the body or composite body S, expressed in frame E. See the
   /// documentation of this class for details.
-  Vector3<T> CalcComMoment() const { return mass_ * p_PScm_E_;}
+  Vector3<T> CalcComMoment() const { return mass_ * p_PScm_E_; }
 
   /// Get a constant reference to the unit inertia `G_SP_E` of this
   /// spatial inertia, computed about point P and expressed in frame E. See the
   /// documentation of this class for details.
-  const UnitInertia<T>& get_unit_inertia() const { return G_SP_E_;}
+  const UnitInertia<T>& get_unit_inertia() const { return G_SP_E_; }
 
   /// Computes the rotational inertia `I_SP_E = mass * G_SP_E` of this
   /// spatial inertia, computed about point P and expressed in frame E. See the
   /// documentation of this class for details.
-  RotationalInertia<T> CalcRotationalInertia() const { return mass_ * G_SP_E_;}
+  RotationalInertia<T> CalcRotationalInertia() const { return mass_ * G_SP_E_; }
 
   /// Returns `true` if any of the elements in this spatial inertia is NaN
   /// and `false` otherwise.
@@ -915,8 +914,7 @@ class SpatialInertia {
   template <typename T1 = T>
   typename std::enable_if_t<scalar_predicate<T1>::is_bool> CheckInvariants()
       const {
-    if (!IsPhysicallyValid())
-      ThrowNotPhysicallyValid();
+    if (!IsPhysicallyValid()) ThrowNotPhysicallyValid();
   }
 
   // SFINAE for non-numeric types. See documentation in the implementation for

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -51,40 +51,20 @@ template <typename T>
 void VerifyModelBasics(const MultibodyTree<T>& model) {
   const std::string kInvalidName = "InvalidName";
   const std::vector<std::string> kLinkNames = {
-      "iiwa_link_1",
-      "iiwa_link_2",
-      "iiwa_link_3",
-      "iiwa_link_4",
-      "iiwa_link_5",
-      "iiwa_link_6",
-      "iiwa_link_7"};
+      "iiwa_link_1", "iiwa_link_2", "iiwa_link_3", "iiwa_link_4",
+      "iiwa_link_5", "iiwa_link_6", "iiwa_link_7"};
 
   const std::vector<std::string> kFrameNames = {
-      "iiwa_link_1",
-      "iiwa_link_2",
-      "iiwa_link_3",
-      "iiwa_link_4",
-      "iiwa_link_5",
-      "iiwa_link_6",
-      "iiwa_link_7",
-      "tool_arbitrary"};
+      "iiwa_link_1", "iiwa_link_2", "iiwa_link_3", "iiwa_link_4",
+      "iiwa_link_5", "iiwa_link_6", "iiwa_link_7", "tool_arbitrary"};
 
   const std::vector<std::string> kJointNames = {
-      "iiwa_joint_1",
-      "iiwa_joint_2",
-      "iiwa_joint_3",
-      "iiwa_joint_4",
-      "iiwa_joint_5",
-      "iiwa_joint_6",
-      "iiwa_joint_7"};
+      "iiwa_joint_1", "iiwa_joint_2", "iiwa_joint_3", "iiwa_joint_4",
+      "iiwa_joint_5", "iiwa_joint_6", "iiwa_joint_7"};
 
   const std::vector<std::string> kActuatorNames = {
-      "iiwa_actuator_1",
-      "iiwa_actuator_2",
-      "iiwa_actuator_3",
-      "iiwa_actuator_4",
-      "iiwa_actuator_5",
-      "iiwa_actuator_6",
+      "iiwa_actuator_1", "iiwa_actuator_2", "iiwa_actuator_3",
+      "iiwa_actuator_4", "iiwa_actuator_5", "iiwa_actuator_6",
       "iiwa_actuator_7"};
 
   // Model Size. Counting the world body, there should be eight bodies.
@@ -143,7 +123,7 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
 
   // Test that calling GetRigidBodyByName() with an invalid ModelInstanceIndex
   // throws.
-  const ModelInstanceIndex kInvalidIndex(1<<30);
+  const ModelInstanceIndex kInvalidIndex(1 << 30);
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetRigidBodyByName(kLinkNames[0], kInvalidIndex),
       ".*There is no model instance.*in the model.*");
@@ -153,8 +133,8 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
     drake::test::LimitMalloc guard;
     const Frame<T>& frame = model.GetFrameByName(frame_name);
     EXPECT_EQ(frame.name(), frame_name);
-    EXPECT_EQ(
-        &frame, &model.GetFrameByName(frame_name, default_model_instance()));
+    EXPECT_EQ(&frame,
+              &model.GetFrameByName(frame_name, default_model_instance()));
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetFrameByName(kInvalidName),
@@ -247,22 +227,20 @@ GTEST_TEST(MultibodyTree, VerifyModelBasics) {
   // Attempt to add a joint having the same name as a joint already part of the
   // model. This is not allowed and an exception should be thrown.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model->AddJoint<RevoluteJoint>(
-          "iiwa_joint_4",
-          model->world_body(), std::nullopt,
-          model->GetRigidBodyByName("iiwa_link_5"), std::nullopt,
-          Vector3<double>::UnitZ()),
+      model->AddJoint<RevoluteJoint>("iiwa_joint_4", model->world_body(),
+                                     std::nullopt,
+                                     model->GetRigidBodyByName("iiwa_link_5"),
+                                     std::nullopt, Vector3<double>::UnitZ()),
       ".* already contains a joint named 'iiwa_joint_4'. "
       "Joint names must be unique within a given model.");
 
   // Attempt to add an actuator having the same name as an actuator already part
   // of the model. This is not allowed and an exception should be thrown.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model->AddJointActuator(
-          "iiwa_actuator_4",
-          model->GetJointByName("iiwa_joint_4")),
+      model->AddJointActuator("iiwa_actuator_4",
+                              model->GetJointByName("iiwa_joint_4")),
       ".* already contains a joint actuator named 'iiwa_actuator_4'. "
-          "Joint actuator names must be unique within a given model.");
+      "Joint actuator names must be unique within a given model.");
 
   // Now we tested we cannot add body or joints with an existing name, finalize
   // the model.
@@ -289,9 +267,8 @@ GTEST_TEST(MultibodyTree, EmptyGetElementByName) {
       model.GetFrameByName(kInvalidName),
       ".*There is no Frame named .*valid names in model instance "
       "'WorldModelInstance' are.* world.*");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      model.GetJointByName(kInvalidName),
-      ".*There are no Joints defined in the model");
+  DRAKE_EXPECT_THROWS_MESSAGE(model.GetJointByName(kInvalidName),
+                              ".*There are no Joints defined in the model");
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.template GetJointByName<RevoluteJoint>(kInvalidName),
       ".*There are no Joints defined in the model");
@@ -312,9 +289,8 @@ GTEST_TEST(MultibodyTree, RetrievingAmbiguousNames) {
   const ModelInstanceIndex other_model_instance =
       model->AddModelInstance("other");
   const std::string link_name = "iiwa_link_5";
-  EXPECT_NO_THROW(
-      model->AddRigidBody(link_name, other_model_instance,
-                          SpatialInertia<double>::NaN()));
+  EXPECT_NO_THROW(model->AddRigidBody(link_name, other_model_instance,
+                                      SpatialInertia<double>::NaN()));
   EXPECT_NO_THROW(model->Finalize());
 
   // Link name is ambiguous, there are more than one bodies that use the name.
@@ -404,12 +380,11 @@ class KukaIiwaModelTests : public ::testing::Test {
 
       // Add a frame H with a fixed pose X_GH in the end effector frame G.
       // Note: frame names are documented in MakeKukaIiwaModel().
-      frame_H_ = &tree->AddFrame<FixedOffsetFrame>(
-          "H", *end_effector_link_, X_GH_);
+      frame_H_ =
+          &tree->AddFrame<FixedOffsetFrame>("H", *end_effector_link_, X_GH_);
 
       // Create a system to manage context resources.
-      system_ =
-          std::make_unique<MultibodyTreeSystem<double>>(std::move(tree));
+      system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(tree));
     }
 
     context_ = system_->CreateDefaultContext();
@@ -424,8 +399,8 @@ class KukaIiwaModelTests : public ::testing::Test {
 
   // Get an arm state associated with an arbitrary configuration that avoids
   // in-plane motion and in which joint angles and rates are non-zero.
-  void GetArbitraryNonZeroJointAnglesAndRates(
-      VectorX<double>* q, VectorX<double>* v) {
+  void GetArbitraryNonZeroJointAnglesAndRates(VectorX<double>* q,
+                                              VectorX<double>* v) {
     const int kNumPositions = tree().num_positions();
     q->resize(kNumPositions);
     v->resize(kNumPositions);  // q and v have the same dimension for kuka.
@@ -455,9 +430,8 @@ class KukaIiwaModelTests : public ::testing::Test {
   // Computes the translational velocity `v_WE` of the end effector frame E in
   // the world frame W.
   template <typename T>
-  Vector3<T> CalcEndEffectorVelocity(
-      const MultibodyTree<T>& model_on_T,
-      const Context<T>& context_on_T) const {
+  Vector3<T> CalcEndEffectorVelocity(const MultibodyTree<T>& model_on_T,
+                                     const Context<T>& context_on_T) const {
     std::vector<SpatialVelocity<T>> V_WB_array;
     model_on_T.CalcAllBodySpatialVelocitiesInWorld(context_on_T, &V_WB_array);
     return V_WB_array[end_effector_link_->index()].translational();
@@ -476,16 +450,14 @@ class KukaIiwaModelTests : public ::testing::Test {
 
   // Computes p_WEo, the position of the end effector frame's origin Eo.
   template <typename T>
-  Vector3<T> CalcEndEffectorPosition(
-      const MultibodyTree<T>& model_on_T,
-      const Context<T>& context_on_T) const {
+  Vector3<T> CalcEndEffectorPosition(const MultibodyTree<T>& model_on_T,
+                                     const Context<T>& context_on_T) const {
     const RigidBody<T>& linkG_on_T =
         model_on_T.get_variant(*end_effector_link_);
     Vector3<T> p_WE;
-    model_on_T.CalcPointsPositions(
-        context_on_T, linkG_on_T.body_frame(),
-        Vector3<T>::Zero(),  // position in frame G
-        model_on_T.world_body().body_frame(), &p_WE);
+    model_on_T.CalcPointsPositions(context_on_T, linkG_on_T.body_frame(),
+                                   Vector3<T>::Zero(),  // position in frame G
+                                   model_on_T.world_body().body_frame(), &p_WE);
     return p_WE;
   }
 
@@ -494,28 +466,21 @@ class KukaIiwaModelTests : public ::testing::Test {
   // See MultibodyTree::CalcJacobianTranslationalVelocity() for details.
   template <typename T>
   void CalcPointsOnEndEffectorTranslationalVelocityJacobianWrtV(
-      const MultibodyTree<T>& model_on_T,
-      const Context<T>& context_on_T,
-      const MatrixX<T>& p_EoEi_E,
-      MatrixX<T>* p_WoEi_W,
+      const MultibodyTree<T>& model_on_T, const Context<T>& context_on_T,
+      const MatrixX<T>& p_EoEi_E, MatrixX<T>* p_WoEi_W,
       MatrixX<T>* Jv_WEi_W) const {
     const RigidBody<T>& linkG_on_T =
         model_on_T.get_variant(*end_effector_link_);
     const Frame<T>& frame_E = linkG_on_T.body_frame();
     const Frame<T>& frame_W = model_on_T.world_frame();
-    model_on_T.CalcJacobianTranslationalVelocity(context_on_T,
-                                                 JacobianWrtVariable::kV,
-                                                 frame_E,
-                                                 frame_E,
-                                                 p_EoEi_E,
-                                                 frame_W,
-                                                 frame_W,
-                                                 Jv_WEi_W);
+    model_on_T.CalcJacobianTranslationalVelocity(
+        context_on_T, JacobianWrtVariable::kV, frame_E, frame_E, p_EoEi_E,
+        frame_W, frame_W, Jv_WEi_W);
 
     // For each point Ei, calculate Ei's position from Wo (World origin),
     // expressed in world W.
-    model_on_T.CalcPointsPositions(context_on_T, frame_E, p_EoEi_E,   // From E
-                                                 frame_W, p_WoEi_W);  // to W.
+    model_on_T.CalcPointsPositions(context_on_T, frame_E, p_EoEi_E,  // From E
+                                   frame_W, p_WoEi_W);               // to W.
   }
 
   // For each point Hi fixed (welded) to frame H, calculates Jv_WHi_W,
@@ -523,26 +488,19 @@ class KukaIiwaModelTests : public ::testing::Test {
   // See MultibodyTree::CalcJacobianTranslationalVelocity() for details.
   template <typename T>
   void CalcPointsOnFrameHTranslationalVelocityJacobianWrtV(
-      const MultibodyTree<T>& model_on_T,
-      const Context<T>& context_on_T,
-      const MatrixX<T>& p_HoHi_H,
-      MatrixX<T>* p_WoHi_W,
+      const MultibodyTree<T>& model_on_T, const Context<T>& context_on_T,
+      const MatrixX<T>& p_HoHi_H, MatrixX<T>* p_WoHi_W,
       MatrixX<T>* Jv_WHi_W) const {
     const Frame<T>& frameH_on_T = model_on_T.get_variant(*frame_H_);
     const Frame<T>& frame_W = model_on_T.world_frame();
-    model_on_T.CalcJacobianTranslationalVelocity(context_on_T,
-                                                 JacobianWrtVariable::kV,
-                                                 frameH_on_T,
-                                                 frameH_on_T,
-                                                 p_HoHi_H,
-                                                 frame_W,
-                                                 frame_W,
-                                                 Jv_WHi_W);
+    model_on_T.CalcJacobianTranslationalVelocity(
+        context_on_T, JacobianWrtVariable::kV, frameH_on_T, frameH_on_T,
+        p_HoHi_H, frame_W, frame_W, Jv_WHi_W);
 
     // Calculate p_WoHi_W (Hi's position from World origin Wo, expressed in W)
     // from p_HoHi_H (Hi's position from Ho, expressed in H).
-    model_on_T.CalcPointsPositions(context_on_T, frameH_on_T, p_HoHi_H,
-                                                 frame_W, p_WoHi_W);
+    model_on_T.CalcPointsPositions(context_on_T, frameH_on_T, p_HoHi_H, frame_W,
+                                   p_WoHi_W);
   }
 
   // For a point Hp fixed/welded to frame H (attached to the end effector, see
@@ -551,19 +509,13 @@ class KukaIiwaModelTests : public ::testing::Test {
   // AutoDiffXd, this method can also calculate its time derivative J̇v_V_WHp.
   template <typename T>
   void CalcFrameHpJacobianSpatialVelocityInWorld(
-      const MultibodyTree<T>& model_on_T,
-      const Context<T>& context_on_T,
-      const Vector3<T>& p_HoHp_H,
-      MatrixX<T>* Jv_V_WHp) const {
+      const MultibodyTree<T>& model_on_T, const Context<T>& context_on_T,
+      const Vector3<T>& p_HoHp_H, MatrixX<T>* Jv_V_WHp) const {
     const Frame<T>& frameH_on_T = model_on_T.get_variant(*frame_H_);
     const Frame<T>& frame_W = model_on_T.world_frame();
-    model_on_T.CalcJacobianSpatialVelocity(context_on_T,
-                                           JacobianWrtVariable::kV,
-                                           frameH_on_T,
-                                           p_HoHp_H,
-                                           frame_W,
-                                           frame_W,
-                                           Jv_V_WHp);
+    model_on_T.CalcJacobianSpatialVelocity(
+        context_on_T, JacobianWrtVariable::kV, frameH_on_T, p_HoHp_H, frame_W,
+        frame_W, Jv_V_WHp);
   }
 
   const MultibodyTree<double>& tree() const {
@@ -617,8 +569,9 @@ TEST_F(KukaIiwaModelTests, StateAccess) {
   ASSERT_EQ(tree().num_velocities(), 7);
   ASSERT_EQ(tree().num_states(), 14);
 
-  const Eigen::VectorXd qv_values = (Eigen::VectorXd(14)
-      << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).finished();
+  const Eigen::VectorXd qv_values =
+      (Eigen::VectorXd(14) << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+          .finished();
 
   // Check whole-state access.
   tree().GetMutablePositionsAndVelocities(context_.get()) = qv_values;
@@ -656,10 +609,8 @@ TEST_F(KukaIiwaModelTests, StateAccess) {
 
   // Test that the state segment methods work.
   tree().GetMutablePositionsAndVelocities(context_.get()) = qv_values;
-  EXPECT_EQ(tree().get_state_segment<3>(*context_, 5),
-      qv_values.segment(5, 3));
-  EXPECT_EQ(tree().get_state_segment(*context_, 5, 4),
-      qv_values.segment(5, 4));
+  EXPECT_EQ(tree().get_state_segment<3>(*context_, 5), qv_values.segment(5, 3));
+  EXPECT_EQ(tree().get_state_segment(*context_, 5, 4), qv_values.segment(5, 4));
 
   // There are four segment-mutating methods. We'll use each
   // to make the same change, then verify with this lambda.
@@ -750,8 +701,9 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityA) {
   // variable of the problem.
   VectorX<AutoDiffXd> v_autodiff(kNumPositions);
   math::InitializeAutoDiff(v, &v_autodiff);
-  context_autodiff_->get_mutable_continuous_state().
-      get_mutable_generalized_velocity().SetFromVector(v_autodiff);
+  context_autodiff_->get_mutable_continuous_state()
+      .get_mutable_generalized_velocity()
+      .SetFromVector(v_autodiff);
 
   const Vector3<AutoDiffXd> v_WE_autodiff =
       CalcEndEffectorVelocity(tree_autodiff(), *context_autodiff_);
@@ -761,8 +713,8 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityA) {
 
   // Values obtained with <AutoDiffXd> should match those computed with
   // <double>.
-  EXPECT_TRUE(CompareMatrices(v_WE_value, v_WE,
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(v_WE_value, v_WE, kTolerance,
+                              MatrixCompareType::relative));
 
   // Some sanity checks on the expected sizes of the derivatives.
   EXPECT_EQ(v_WE_derivs.rows(), 3);
@@ -775,36 +727,30 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityA) {
   const Frame<double>& frame_E = end_effector_link_->body_frame();
   const Frame<double>& frame_W = tree().world_frame();
   const Vector3<double> p_EoGo_E = Vector3<double>::Zero();
-  tree().CalcJacobianTranslationalVelocity(*context_,
-                                           JacobianWrtVariable::kV,
-                                           frame_E,
-                                           frame_E,
-                                           p_EoGo_E,
-                                           frame_W,
-                                           frame_W,
-                                           &Jv_WE);
+  tree().CalcJacobianTranslationalVelocity(*context_, JacobianWrtVariable::kV,
+                                           frame_E, frame_E, p_EoGo_E, frame_W,
+                                           frame_W, &Jv_WE);
 
   // Calculate p_WoEo_W (Eo's position from World origin Wo expressed in W)
   // from p_EoGo_E (Go's position from Eo expressed in E -- zero vector).
-  tree().CalcPointsPositions(*context_, frame_E, p_EoGo_E,
-                                        frame_W, &p_WE);
+  tree().CalcPointsPositions(*context_, frame_E, p_EoGo_E, frame_W, &p_WE);
 
   // Verify the computed Jacobian matches the one obtained using automatic
   // differentiation.
-  EXPECT_TRUE(CompareMatrices(Jv_WE, v_WE_derivs,
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(Jv_WE, v_WE_derivs, kTolerance,
+                              MatrixCompareType::relative));
 
   // Verify that v_WE = Jv_WE * v:
   const Vector3<double> Jv_WE_times_v = Jv_WE * v;
-  EXPECT_TRUE(CompareMatrices(Jv_WE_times_v, v_WE,
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(Jv_WE_times_v, v_WE, kTolerance,
+                              MatrixCompareType::relative));
 
   // Verify that MultibodyTree::CalcPointsPositions() computes the same value
   // of p_WE. Even both code paths resolve to CalcPointsPositions(), here we
   // call this method explicitly to provide unit testing for this API.
   Vector3<double> p2_WE = CalcEndEffectorPosition(tree(), *context_);
-  EXPECT_TRUE(CompareMatrices(p2_WE, p_WE,
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(
+      CompareMatrices(p2_WE, p_WE, kTolerance, MatrixCompareType::relative));
 
   // The derivative with respect to time should equal v_WE.
   const VectorX<AutoDiffXd> q_autodiff =
@@ -812,19 +758,20 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityA) {
       // gradient for math::InitializeAutoDiff(). Eigen complains otherwise.
       math::InitializeAutoDiff(q, MatrixXd(v));
   v_autodiff = v.cast<AutoDiffXd>();
-  context_autodiff_->get_mutable_continuous_state().
-      get_mutable_generalized_position().SetFromVector(q_autodiff);
-  context_autodiff_->get_mutable_continuous_state().
-      get_mutable_generalized_velocity().SetFromVector(v_autodiff);
+  context_autodiff_->get_mutable_continuous_state()
+      .get_mutable_generalized_position()
+      .SetFromVector(q_autodiff);
+  context_autodiff_->get_mutable_continuous_state()
+      .get_mutable_generalized_velocity()
+      .SetFromVector(v_autodiff);
 
-  Vector3<AutoDiffXd> p_WE_autodiff = CalcEndEffectorPosition(
-      tree_autodiff(), *context_autodiff_);
-  Vector3<double> p_WE_derivs(
-      p_WE_autodiff[0].derivatives()[0],
-      p_WE_autodiff[1].derivatives()[0],
-      p_WE_autodiff[2].derivatives()[0]);
-  EXPECT_TRUE(CompareMatrices(p_WE_derivs, v_WE,
-                              kTolerance, MatrixCompareType::relative));
+  Vector3<AutoDiffXd> p_WE_autodiff =
+      CalcEndEffectorPosition(tree_autodiff(), *context_autodiff_);
+  Vector3<double> p_WE_derivs(p_WE_autodiff[0].derivatives()[0],
+                              p_WE_autodiff[1].derivatives()[0],
+                              p_WE_autodiff[2].derivatives()[0]);
+  EXPECT_TRUE(CompareMatrices(p_WE_derivs, v_WE, kTolerance,
+                              MatrixCompareType::relative));
 }
 
 // This test is used to verify the correctness of the method
@@ -893,14 +840,10 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityB) {
   // point P with position p_GP = 0 in the G frame.
   const Frame<double>& end_effector_frame = end_effector_link_->body_frame();
   const Frame<double>& world_frame = tree().world_frame();
-  tree().CalcJacobianTranslationalVelocity(*context_,
-                                           JacobianWrtVariable::kV,
-                                           end_effector_frame,
-                                           end_effector_frame,
-                                           Vector3<double>::Zero(),
-                                           world_frame,
-                                           world_frame,
-                                           &Jv_WE);
+  tree().CalcJacobianTranslationalVelocity(
+      *context_, JacobianWrtVariable::kV, end_effector_frame,
+      end_effector_frame, Vector3<double>::Zero(), world_frame, world_frame,
+      &Jv_WE);
 
   // Verify the computed Jacobian matches the one from auto-differentiation.
   EXPECT_TRUE(CompareMatrices(Jv_WE, v_WE_derivs, kTolerance,
@@ -914,14 +857,9 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityB) {
   // Use different frame arguments to again calculate the Jacobian.
   // Again verify the computed Jacobian matches that from auto-differentiation.
   const Vector3<double> p_WE = CalcEndEffectorPosition(tree(), *context_);
-  tree().CalcJacobianTranslationalVelocity(*context_,
-                                           JacobianWrtVariable::kV,
-                                           end_effector_frame,
-                                           world_frame,
-                                           p_WE,
-                                           world_frame,
-                                           world_frame,
-                                           &Jv_WE);
+  tree().CalcJacobianTranslationalVelocity(
+      *context_, JacobianWrtVariable::kV, end_effector_frame, world_frame, p_WE,
+      world_frame, world_frame, &Jv_WE);
   EXPECT_TRUE(CompareMatrices(Jv_WE, v_WE_derivs, kTolerance,
                               MatrixCompareType::relative));
 
@@ -930,7 +868,8 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityB) {
       math::InitializeAutoDiff(q, MatrixXd(v));
   v_autodiff = v.cast<AutoDiffXd>();
   tree_autodiff().GetMutablePositionsAndVelocities(context_autodiff_.get())
-      << q_autodiff, v_autodiff;
+      << q_autodiff,
+      v_autodiff;
 
   Vector3<AutoDiffXd> p_WE_autodiff =
       CalcEndEffectorPosition(tree_autodiff(), *context_autodiff_);
@@ -962,8 +901,9 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityC) {
   VectorX<double> q0, v0;  // v0 will not be used in this test.
   GetArbitraryNonZeroJointAnglesAndRates(&q0, &v0);
 
-  context_->get_mutable_continuous_state().
-      get_mutable_generalized_position().SetFromVector(q0);
+  context_->get_mutable_continuous_state()
+      .get_mutable_generalized_position()
+      .SetFromVector(q0);
 
   // A set of points Pi attached to the end effector, thus we a fixed position
   // in its frame G.
@@ -990,16 +930,17 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityC) {
   // variable of the problem.
   VectorX<AutoDiffXd> q_autodiff(kNumPositions);
   math::InitializeAutoDiff(q0, &q_autodiff);
-  context_autodiff_->get_mutable_continuous_state().
-      get_mutable_generalized_position().SetFromVector(q_autodiff);
+  context_autodiff_->get_mutable_continuous_state()
+      .get_mutable_generalized_position()
+      .SetFromVector(q_autodiff);
 
   const MatrixX<AutoDiffXd> p_EPi_autodiff = p_EPi;
   MatrixX<AutoDiffXd> p_WPi_autodiff(3, kNumPoints);
   MatrixX<AutoDiffXd> Jq_WPi_autodiff(3 * kNumPoints, kNumPositions);
 
   CalcPointsOnEndEffectorTranslationalVelocityJacobianWrtV(
-      tree_autodiff(), *context_autodiff_,
-      p_EPi_autodiff, &p_WPi_autodiff, &Jq_WPi_autodiff);
+      tree_autodiff(), *context_autodiff_, p_EPi_autodiff, &p_WPi_autodiff,
+      &Jq_WPi_autodiff);
 
   // Extract values and derivatives:
   const Matrix3X<double> p_WPi_value = math::ExtractValue(p_WPi_autodiff);
@@ -1008,8 +949,8 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityC) {
   // Some sanity checks:
   // Values obtained with <AutoDiffXd> should match those computed with
   // <double>.
-  EXPECT_TRUE(CompareMatrices(p_WPi_value, p_WPi,
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(p_WPi_value, p_WPi, kTolerance,
+                              MatrixCompareType::relative));
   // Sizes of the derivatives.
   EXPECT_EQ(p_WPi_derivs.rows(), 3 * kNumPoints);
   EXPECT_EQ(p_WPi_derivs.cols(), kNumPositions);
@@ -1017,8 +958,8 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityC) {
   // Verify the computed Jacobian Jq_WPi matches the one obtained using
   // automatic differentiation.  In this Kuka iiwa arm example, q̇ = v, so
   // these two Jacobian calculations should be nearly equal.
-  EXPECT_TRUE(CompareMatrices(Jq_WPi, p_WPi_derivs,
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(Jq_WPi, p_WPi_derivs, kTolerance,
+                              MatrixCompareType::relative));
 }
 
 TEST_F(KukaIiwaModelTests, EvalPoseAndSpatialVelocity) {
@@ -1047,8 +988,8 @@ TEST_F(KukaIiwaModelTests, EvalPoseAndSpatialVelocity) {
 
   // Independent benchmark solution.
   const SpatialKinematicsPVA<double> MG_kinematics =
-      benchmark_.CalcEndEffectorKinematics(
-          q, v, VectorX<double>::Zero(7) /* vdot */);
+      benchmark_.CalcEndEffectorKinematics(q, v,
+                                           VectorX<double>::Zero(7) /* vdot */);
   const SpatialVelocity<double>& V_WE_benchmark =
       MG_kinematics.spatial_velocity();
   const RigidTransform<double> X_WE_benchmark(MG_kinematics.transform());
@@ -1056,8 +997,8 @@ TEST_F(KukaIiwaModelTests, EvalPoseAndSpatialVelocity) {
   // Compare against benchmark.
   EXPECT_TRUE(V_WE.IsApprox(V_WE_benchmark, kTolerance));
   EXPECT_TRUE(CompareMatrices(X_WE.GetAsMatrix34(),
-                              X_WE_benchmark.GetAsMatrix34(),
-                              kTolerance, MatrixCompareType::relative));
+                              X_WE_benchmark.GetAsMatrix34(), kTolerance,
+                              MatrixCompareType::relative));
 }
 
 TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityA) {
@@ -1111,11 +1052,9 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityA) {
   // Compute the Jacobian Jv_WF for that relate the generalized velocities with
   // the spatial velocity of frame F.
   const Frame<double>& frame_W = tree().world_frame();
-  tree().CalcJacobianSpatialVelocity(*context_,
-                                     JacobianWrtVariable::kV,
+  tree().CalcJacobianSpatialVelocity(*context_, JacobianWrtVariable::kV,
                                      end_effector_link_->body_frame(), p_EoFo_E,
-                                     frame_W, frame_W,
-                                     &Jv_WF);
+                                     frame_W, frame_W, &Jv_WF);
 
   // Verify that V_WEf = Jv_WF * v:
   const SpatialVelocity<double> Jv_WF_times_v(Jv_WF * v);
@@ -1145,19 +1084,13 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityD) {
   // For each point P, calculate Jv_v_WP (P's translational velocity Jacobian
   // in world W, expressed in W).  Note: This test case is somewhat degenerate.
   const Frame<double>& frame_W = tree().world_frame();
-  tree().CalcJacobianTranslationalVelocity(*context_,
-                                           JacobianWrtVariable::kV,
-                                           frame_W,
-                                           frame_W,
-                                           p_WP_set,
-                                           frame_W,
-                                           frame_W,
-                                           &Jv_WP);
+  tree().CalcJacobianTranslationalVelocity(*context_, JacobianWrtVariable::kV,
+                                           frame_W, frame_W, p_WP_set, frame_W,
+                                           frame_W, &Jv_WP);
 
   // For each point P, calculate p_WoP_W (P's position from World origin Wo,
   // expressed in world W).  Note: This test case is somewhat degenerate.
-  tree().CalcPointsPositions(*context_, frame_W, p_WP_set,
-                                        frame_W, &p_WP_out);
+  tree().CalcPointsPositions(*context_, frame_W, p_WP_set, frame_W, &p_WP_out);
 
   // Since in this case we are querying for the world frame:
   //   a) the output set should match the input set exactly and,
@@ -1184,13 +1117,9 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityB) {
   // The state stored in the context should not affect the result of this test.
   // Therefore we do not set it.
   const Frame<double>& frame_W = tree().world_frame();
-  tree().CalcJacobianSpatialVelocity(*context_,
-                                     JacobianWrtVariable::kV,
-                                     tree().world_body().body_frame(),
-                                     p_WoWp_W,
-                                     frame_W,
-                                     frame_W,
-                                     &Jv_WWp);
+  tree().CalcJacobianSpatialVelocity(*context_, JacobianWrtVariable::kV,
+                                     tree().world_body().body_frame(), p_WoWp_W,
+                                     frame_W, frame_W, &Jv_WWp);
 
   // Since in this case we are querying for the world frame, the Jacobian should
   // be exactly zero.
@@ -1360,13 +1289,13 @@ class WeldMobilizerTest : public ::testing::Test {
     context_ = system_->CreateDefaultContext();
 
     // Expected pose of body 2 in the world.
-    X_WB2_.set_translation(
-        Vector3d(M_SQRT2 / 4, -M_SQRT2 / 4, 0.0) - Vector3d::UnitY() / M_SQRT2);
+    X_WB2_.set_translation(Vector3d(M_SQRT2 / 4, -M_SQRT2 / 4, 0.0) -
+                           Vector3d::UnitY() / M_SQRT2);
     X_WB2_.set_rotation(math::RotationMatrixd::MakeZRotation(-3 * M_PI_4));
   }
 
   const MultibodyTree<double>& tree() const {
-      return internal::GetInternalTree(*system_);
+    return internal::GetInternalTree(*system_);
   }
 
  protected:

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -52,7 +52,7 @@ class ScrewJointTest : public ::testing::Test {
         Vector1d::Constant(kAccelerationUpperLimit));
 
     system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
-        std::move(model), true/* is_discrete */);
+        std::move(model), true /* is_discrete */);
     context_ = system_->CreateDefaultContext();
   }
 

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -94,25 +94,24 @@ GTEST_TEST(SpatialInertia, PointMass) {
   const double ly = 2.0;
   const double lz = 3.0;
   const Vector3<double> p_BpBcm_B = Vector3<double>(lx, ly, lz);
-  const UnitInertia<double>G_BBp_B = UnitInertia<double>::PointMass(p_BpBcm_B);
+  const UnitInertia<double> G_BBp_B = UnitInertia<double>::PointMass(p_BpBcm_B);
   const SpatialInertia<double> M_expected(mass, p_BpBcm_B, G_BBp_B);
   const SpatialInertia<double> M_BBp_B =
       SpatialInertia<double>::PointMass(mass, p_BpBcm_B);
-  EXPECT_TRUE(CompareMatrices(
-      M_expected.CopyToFullMatrix6(), M_BBp_B.CopyToFullMatrix6()));
+  EXPECT_TRUE(CompareMatrices(M_expected.CopyToFullMatrix6(),
+                              M_BBp_B.CopyToFullMatrix6()));
 
   // Verify PointMass() with a zero position vector produces the same spatial
   // inertia as shifting the spatial inertia from M_BBp_B to M_BBcm_B.
   const SpatialInertia<double> M_BBcm_B_expected = M_BBp_B.Shift(p_BpBcm_B);
   const SpatialInertia<double> M_BBcm_B =
-       SpatialInertia<double>::PointMass(mass, Vector3<double>::Zero());
-  EXPECT_TRUE(CompareMatrices(
-      M_BBcm_B_expected.CopyToFullMatrix6(), M_BBcm_B.CopyToFullMatrix6()));
+      SpatialInertia<double>::PointMass(mass, Vector3<double>::Zero());
+  EXPECT_TRUE(CompareMatrices(M_BBcm_B_expected.CopyToFullMatrix6(),
+                              M_BBcm_B.CopyToFullMatrix6()));
 
   // Ensure a negative mass throws an exception.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::PointMass(-1, p_BpBcm_B),
-      "[^]* mass is not positive and finite: .*");
+  DRAKE_EXPECT_THROWS_MESSAGE(SpatialInertia<double>::PointMass(-1, p_BpBcm_B),
+                              "[^]* mass is not positive and finite: .*");
 }
 
 // Tests the static method for the spatial inertia of a solid box.
@@ -124,7 +123,7 @@ GTEST_TEST(SpatialInertia, SolidBoxWithDensityOrMass) {
   const double volume = lx * ly * lz;
   const double mass = density * volume;
   const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
-  const UnitInertia<double>G_BBo_B = UnitInertia<double>::SolidBox(lx, ly, lz);
+  const UnitInertia<double> G_BBo_B = UnitInertia<double>::SolidBox(lx, ly, lz);
   const SpatialInertia<double> M_expected(mass, p_BoBcm_B, G_BBo_B);
   const SpatialInertia<double> M_with_density =
       SpatialInertia<double>::SolidBoxWithDensity(density, lx, ly, lz);
@@ -151,22 +150,22 @@ GTEST_TEST(SpatialInertia, SolidBoxWithDensityOrMass) {
   // single value sufficiently tests the full domain of invalid values.
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithDensity(density, 0, ly, lz),
-       "[^]* x-length is not positive and finite: .*.");
+      "[^]* x-length is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithMass(mass, 0, ly, lz),
-       "[^]* x-length is not positive and finite: .*.");
+      "[^]* x-length is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithDensity(density, lx, -0.1, lz),
-       "[^]* y-length is not positive and finite: .*.");
+      "[^]* y-length is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithMass(mass, lx, -0.1, lz),
-        "[^]* y-length is not positive and finite: .*.");
+      "[^]* y-length is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithDensity(density, lx, ly, -1E-15),
-        "[^]* z-length is not positive and finite: .*.");
+      "[^]* z-length is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       SpatialInertia<double>::SolidBoxWithMass(mass, lx, ly, -1E-15),
-        "[^]* z-length is not positive and finite: .*.");
+      "[^]* z-length is not positive and finite: .*.");
 }
 
 // Tests the static method for the spatial inertia of a solid cube.
@@ -176,25 +175,25 @@ GTEST_TEST(SpatialInertia, SolidCubeWithDensity) {
   const double volume = length * length * length;
   const double mass = density * volume;
   const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
-  const UnitInertia<double>G_BBo_B = UnitInertia<double>::SolidCube(length);
+  const UnitInertia<double> G_BBo_B = UnitInertia<double>::SolidCube(length);
   const SpatialInertia<double> M_expected(mass, p_BoBcm_B, G_BBo_B);
   const SpatialInertia<double> M_with_density =
       SpatialInertia<double>::SolidCubeWithDensity(density, length);
   EXPECT_TRUE(CompareMatrices(M_expected.CopyToFullMatrix6(),
-      M_with_density.CopyToFullMatrix6()));
+                              M_with_density.CopyToFullMatrix6()));
 
   // Also test against a solid box with length = width = height.
   const SpatialInertia<double> Mbox =
-      SpatialInertia<double>::SolidBoxWithDensity(
-          density, length, length, length);
+      SpatialInertia<double>::SolidBoxWithDensity(density, length, length,
+                                                  length);
   EXPECT_TRUE(CompareMatrices(Mbox.CopyToFullMatrix6(),
-      M_with_density.CopyToFullMatrix6()));
+                              M_with_density.CopyToFullMatrix6()));
 
   // Ensure SolidCubeWithDensity() matches SolidCubeWithMass().
   const SpatialInertia<double> M_with_mass =
       SpatialInertia<double>::SolidCubeWithMass(mass, length);
   EXPECT_TRUE(CompareMatrices(M_with_mass.CopyToFullMatrix6(),
-      M_with_density.CopyToFullMatrix6()));
+                              M_with_density.CopyToFullMatrix6()));
 
   // Ensure a negative density or mass throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -224,13 +223,13 @@ GTEST_TEST(SpatialInertia, SolidCapsuleWithDensityOrMass) {
   const double density = 1000;  // Water is 1 g/ml = 1000 kg/m³.
   const double r = 1.0;
   const double l = 2.0;
-  const double volume = 4.0/3.0 * M_PI * std::pow(r, 3) + M_PI * r * r * l;
+  const double volume = 4.0 / 3.0 * M_PI * std::pow(r, 3) + M_PI * r * r * l;
   const double mass = density * volume;
   const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
 
   // Test a solid capsule B whose unit_vector is in the z-direction.
   Vector3<double> unit_vec(0, 0, 1);
-  UnitInertia<double>G_BBo_B =
+  UnitInertia<double> G_BBo_B =
       UnitInertia<double>::SolidCapsule(r, l, unit_vec);
   SpatialInertia<double> M_expected(mass, p_BoBcm_B, G_BBo_B);
   SpatialInertia<double> M_with_density =
@@ -251,7 +250,7 @@ GTEST_TEST(SpatialInertia, SolidCapsuleWithDensityOrMass) {
   const SpatialInertia<double> M_with_mass =
       SpatialInertia<double>::SolidCapsuleWithMass(mass, r, l, unit_vec);
   EXPECT_TRUE(CompareMatrices(M_with_mass.CopyToFullMatrix6(),
-      M_with_density.CopyToFullMatrix6()));
+                              M_with_density.CopyToFullMatrix6()));
 
   // Ensure a negative density or mass throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -282,15 +281,15 @@ GTEST_TEST(SpatialInertia, SolidCapsuleWithDensityOrMass) {
 // Tests the static method for the spatial inertia of a solid cylinder.
 GTEST_TEST(SpatialInertia, SolidCylinderWithDensityOrMass) {
   const double density = 1000;  // Water is 1 g/ml = 1000 kg/m³.
-  const double r = 1.0;  // radius
-  const double l = 2.0;  // length
+  const double r = 1.0;         // radius
+  const double l = 2.0;         // length
   const double volume = M_PI * r * r * l;
   const double mass = density * volume;
   const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
 
   // Test a solid cylinder B about Bcm whose axis is aligned with unit_vec.
-  const Vector3<double>unit_vec(0.5, -0.5, 1.0 / std::sqrt(2));
-  UnitInertia<double>G_BBo_B =
+  const Vector3<double> unit_vec(0.5, -0.5, 1.0 / std::sqrt(2));
+  UnitInertia<double> G_BBo_B =
       UnitInertia<double>::SolidCylinder(r, l, unit_vec);
   SpatialInertia<double> M_expected(mass, p_BoBcm_B, G_BBo_B);
   SpatialInertia<double> M_with_density =
@@ -302,12 +301,12 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensityOrMass) {
   SpatialInertia<double> M_with_mass =
       SpatialInertia<double>::SolidCylinderWithMass(mass, r, l, unit_vec);
   EXPECT_TRUE(CompareMatrices(M_with_mass.CopyToFullMatrix6(),
-      M_with_density.CopyToFullMatrix6()));
+                              M_with_density.CopyToFullMatrix6()));
 
   // Test a solid cylinder B about the point Bp, where Bp is at the center of a
   // circular end of the cylinder with the following position from Bp to Bcm.
   const Vector3<double> p_BpBcm_B = 0.5 * l * unit_vec;
-  const UnitInertia<double>G_BBp_B =
+  const UnitInertia<double> G_BBp_B =
       UnitInertia<double>::SolidCylinderAboutEnd(r, l, unit_vec);
   M_expected = SpatialInertia<double>(mass, p_BpBcm_B, G_BBp_B);
   M_with_density = SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(
@@ -331,8 +330,8 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensityOrMass) {
   // use an empirical tolerance of two bits = 2^2 times machine epsilon.
   const double kTolerance = 4 * std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(CompareMatrices(M_expected.CopyToFullMatrix6(),
-                              M_with_density.CopyToFullMatrix6(),
-                              kTolerance, MatrixCompareType::relative));
+                              M_with_density.CopyToFullMatrix6(), kTolerance,
+                              MatrixCompareType::relative));
 
   // Ensure a negative density or mass throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -342,12 +341,12 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensityOrMass) {
       SpatialInertia<double>::SolidCylinderWithMass(-9.3, r, l, unit_vec),
       "[^]* mass is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(
-          -9.3, r, l, unit_vec),
+      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(-9.3, r, l,
+                                                               unit_vec),
       "[^]* density is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidCylinderWithMassAboutEnd(
-          -9.3, r, l, unit_vec),
+      SpatialInertia<double>::SolidCylinderWithMassAboutEnd(-9.3, r, l,
+                                                            unit_vec),
       "[^]* mass is not positive and finite: .*.");
 
   // Ensure a negative or zero radius throws an exception.
@@ -358,12 +357,12 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensityOrMass) {
       SpatialInertia<double>::SolidCylinderWithMass(mass, 0, l, unit_vec),
       "[^]* radius is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(
-          density, -0.1, l, unit_vec),
+      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(density, -0.1, l,
+                                                               unit_vec),
       "[^]* radius is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidCylinderWithMassAboutEnd(
-          mass, -0.1, l, unit_vec),
+      SpatialInertia<double>::SolidCylinderWithMassAboutEnd(mass, -0.1, l,
+                                                            unit_vec),
       "[^]* radius is not positive and finite: .*.");
 
   // Ensure a negative or zero length throws an exception.
@@ -374,12 +373,12 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensityOrMass) {
       SpatialInertia<double>::SolidCylinderWithMass(mass, r, 0, unit_vec),
       "[^]* length is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(
-          density, r, -0.1, unit_vec),
+      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(density, r, -0.1,
+                                                               unit_vec),
       "[^]* length is not positive and finite: .*.");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidCylinderWithMassAboutEnd(
-          density, r, -0.1, unit_vec),
+      SpatialInertia<double>::SolidCylinderWithMassAboutEnd(density, r, -0.1,
+                                                            unit_vec),
       "[^]* length is not positive and finite: .*.");
 
   // Ensure a bad unit vector throws an exception.
@@ -391,12 +390,12 @@ GTEST_TEST(SpatialInertia, SolidCylinderWithDensityOrMass) {
       SpatialInertia<double>::SolidCylinderWithMass(mass, r, l, bad_vec),
       "[^]* The unit_vector argument .* is not a unit vector.[^]*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(
-          density, r, l, bad_vec),
+      SpatialInertia<double>::SolidCylinderWithDensityAboutEnd(density, r, l,
+                                                               bad_vec),
       "[^]* The unit_vector argument .* is not a unit vector.[^]*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidCylinderWithMassAboutEnd(
-          mass, r, l, bad_vec),
+      SpatialInertia<double>::SolidCylinderWithMassAboutEnd(mass, r, l,
+                                                            bad_vec),
       "[^]* The unit_vector argument .* is not a unit vector.[^]*");
 }
 
@@ -408,37 +407,37 @@ GTEST_TEST(SpatialInertia, ThinRodWithMass) {
 
   // Test a thin rod B whose unit_vector is in the z-direction.
   Vector3<double> unit_vec(0, 0, 1);
-  UnitInertia<double>G_BBcm_B = UnitInertia<double>::ThinRod(length, unit_vec);
+  UnitInertia<double> G_BBcm_B = UnitInertia<double>::ThinRod(length, unit_vec);
   SpatialInertia<double> M_expected(mass, p_BoBcm_B, G_BBcm_B);
   SpatialInertia<double> M =
       SpatialInertia<double>::ThinRodWithMass(mass, length, unit_vec);
   // Use an empirical tolerance of two bits = 2^2 times machine epsilon.
   const double kTolerance = 4 * std::numeric_limits<double>::epsilon();
-  EXPECT_TRUE(CompareMatrices(
-      M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6(), kTolerance));
+  EXPECT_TRUE(CompareMatrices(M_expected.CopyToFullMatrix6(),
+                              M.CopyToFullMatrix6(), kTolerance));
 
   // Test a thin rod B with a different and less simple unit vector direction.
   unit_vec = Vector3<double>(0.5, -0.5, 1.0 / std::sqrt(2));
   G_BBcm_B = UnitInertia<double>::ThinRod(length, unit_vec);
   M_expected = SpatialInertia<double>(mass, p_BoBcm_B, G_BBcm_B);
   M = SpatialInertia<double>::ThinRodWithMass(mass, length, unit_vec);
-  EXPECT_TRUE(CompareMatrices(
-      M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6(), kTolerance));
+  EXPECT_TRUE(CompareMatrices(M_expected.CopyToFullMatrix6(),
+                              M.CopyToFullMatrix6(), kTolerance));
 
   // Test a thin rod B about Bp, where Bp is at an end of the rod.
   const Vector3<double> p_BpBcm_B = 0.5 * length * unit_vec;
   UnitInertia<double> G_BBp_B = G_BBcm_B.ShiftFromCenterOfMass(-p_BpBcm_B);
   M_expected = SpatialInertia<double>(mass, p_BpBcm_B, G_BBp_B);
   M = SpatialInertia<double>::ThinRodWithMassAboutEnd(mass, length, unit_vec);
-  EXPECT_TRUE(CompareMatrices(
-      M_expected.CopyToFullMatrix6(), M.CopyToFullMatrix6(), kTolerance));
+  EXPECT_TRUE(CompareMatrices(M_expected.CopyToFullMatrix6(),
+                              M.CopyToFullMatrix6(), kTolerance));
 
   // Another way to perform the previous calculation and test.
   const SpatialInertia<double> M_BBp_B =
-        SpatialInertia<double>::MakeFromCentralInertia(
-            mass, p_BpBcm_B, mass * G_BBcm_B);
-  EXPECT_TRUE(CompareMatrices(
-      M_BBp_B.CopyToFullMatrix6(), M.CopyToFullMatrix6(), kTolerance));
+      SpatialInertia<double>::MakeFromCentralInertia(mass, p_BpBcm_B,
+                                                     mass * G_BBcm_B);
+  EXPECT_TRUE(CompareMatrices(M_BBp_B.CopyToFullMatrix6(),
+                              M.CopyToFullMatrix6(), kTolerance));
 
   // Ensure a negative or zero mass throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -472,7 +471,7 @@ GTEST_TEST(SpatialInertia, SolidEllipsoidWithDensityOrMass) {
   const double volume = 4.0 / 3.0 * M_PI * a * b * c;
   const double mass = density * volume;
   const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
-  UnitInertia<double>G_BBo_B = UnitInertia<double>::SolidEllipsoid(a, b, c);
+  UnitInertia<double> G_BBo_B = UnitInertia<double>::SolidEllipsoid(a, b, c);
   SpatialInertia<double> M_expected(mass, p_BoBcm_B, G_BBo_B);
   SpatialInertia<double> M_with_density =
       SpatialInertia<double>::SolidEllipsoidWithDensity(density, a, b, c);
@@ -524,7 +523,7 @@ GTEST_TEST(SpatialInertia, SolidSphereWithDensityOrMass) {
   const double volume = 4.0 / 3.0 * M_PI * std::pow(radius, 3);  // 4/3 π r³
   const double mass = density * volume;
   const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
-  const UnitInertia<double>G_BBo_B = UnitInertia<double>::SolidSphere(radius);
+  const UnitInertia<double> G_BBo_B = UnitInertia<double>::SolidSphere(radius);
   const SpatialInertia<double> M_expected(mass, p_BoBcm_B, G_BBo_B);
   const SpatialInertia<double> M_with_density =
       SpatialInertia<double>::SolidSphereWithDensity(density, radius);
@@ -567,7 +566,7 @@ GTEST_TEST(SpatialInertia, HollowSphereWithDensityOrMass) {
   const double surface_area = 4.0 * M_PI * std::pow(radius, 2);  // 4 π r²
   const double mass = area_density * surface_area;
   const Vector3<double> p_BoBcm_B = Vector3<double>::Zero();
-  const UnitInertia<double>G_BBo_B = UnitInertia<double>::HollowSphere(radius);
+  const UnitInertia<double> G_BBo_B = UnitInertia<double>::HollowSphere(radius);
   const SpatialInertia<double> M_expected(mass, p_BoBcm_B, G_BBo_B);
   const SpatialInertia<double> M_with_density =
       SpatialInertia<double>::HollowSphereWithDensity(area_density, radius);
@@ -627,14 +626,14 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutVertex) {
 
   // Ensure nothing changes if two arguments are switched (e.g., p1 and p2).
   M_BB0 = SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
-          density, p2, p1, p3);
+      density, p2, p1, p3);
   EXPECT_TRUE(CompareMatrices(M_BB0_expected.CopyToFullMatrix6(),
                               M_BB0.CopyToFullMatrix6(), kTolerance));
 
   // Ensure a negative density throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
-          -9.3, p1, p2, p3),
+      SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(-9.3, p1,
+                                                                     p2, p3),
       "[^]* density is not positive and finite: .*.");
 }
 
@@ -649,7 +648,7 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutPoint) {
   // Do a sanity check that SolidTetrahedronAboutPointWithDensity() simplifies
   // to SolidTetrahedronAboutVertexWithDensity() when p_AB0 is the zero vector.
   SpatialInertia<double> M_BA_expected =
-     SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
+      SpatialInertia<double>::SolidTetrahedronAboutVertexWithDensity(
           density, p_AB1, p_AB2, p_AB3);
   SpatialInertia<double> M_BA =
       SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(
@@ -667,7 +666,7 @@ GTEST_TEST(SpatialInertia, SolidTetrahedronAboutPoint) {
   p_AB3 += p_AB0;
   M_BA_expected.ShiftInPlace(-p_AB0);
   M_BA = SpatialInertia<double>::SolidTetrahedronAboutPointWithDensity(
-          density, p_AB0, p_AB1, p_AB2, p_AB3);
+      density, p_AB0, p_AB1, p_AB2, p_AB3);
   EXPECT_TRUE(CompareMatrices(M_BA_expected.CopyToFullMatrix6(),
                               M_BA.CopyToFullMatrix6(), kTolerance));
 
@@ -1053,10 +1052,11 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidThrowsNiceExceptionMessage) {
 // Tests that by setting skip_validity_check = true, it is possible to create
 // invalid spatial inertias with negative mass and malformed COM.
 GTEST_TEST(SpatialInertia, SkipValidityCheck) {
-  DRAKE_EXPECT_NO_THROW(SpatialInertia<double>(-1.0, Vector3d::Zero(),
-                           UnitInertia<double>::SolidSphere(1.0), true));
-  DRAKE_EXPECT_NO_THROW(SpatialInertia<double>(1.0, Vector3d(2.0, 0.0, 0.0),
-                           UnitInertia<double>::SolidSphere(1.0), true));
+  DRAKE_EXPECT_NO_THROW(SpatialInertia<double>(
+      -1.0, Vector3d::Zero(), UnitInertia<double>::SolidSphere(1.0), true));
+  DRAKE_EXPECT_NO_THROW(
+      SpatialInertia<double>(1.0, Vector3d(2.0, 0.0, 0.0),
+                             UnitInertia<double>::SolidSphere(1.0), true));
 }
 
 // Tests the method SpatialInertia::MakeFromCentralInertia(...).
@@ -1108,7 +1108,7 @@ GTEST_TEST(SpatialInertia, IsMakeFromCentralInertiaTestValidityImmediately) {
   // Create a spatial inertia for a thin rod B about its center of mass Bcm.
   // The allowable violation for rotational inertia triangle inequality test is
   // ≈ 16 * std::numeric_limits<double>::epsilon() * 20.833 ≈ 7.4E-14.
-  const double mass = 10.0,  length = 5.0;
+  const double mass = 10.0, length = 5.0;
   const SpatialInertia<double> M_BBcm_B =
       SpatialInertia<double>::ThinRodWithMass(mass, length, Vector3d(0, 0, 1));
   RotationalInertia<double> I_BBcm_B = M_BBcm_B.CalcRotationalInertia();
@@ -1124,30 +1124,34 @@ GTEST_TEST(SpatialInertia, IsMakeFromCentralInertiaTestValidityImmediately) {
   // Bo (for storage) and a later shift from Bo to Bcm (for triangle inequalty
   // test) caused the inertia triangle inequality to be violated by ≈ 1.1E-12.
   Vector3<double> p_BoBcm_B(10, 20, 30);
-  DRAKE_EXPECT_NO_THROW(  /* M_BBo_B = */
-    SpatialInertia<double>::MakeFromCentralInertia(mass, p_BoBcm_B, I_BBcm_B));
+  DRAKE_EXPECT_NO_THROW(/* M_BBo_B = */
+                        SpatialInertia<double>::MakeFromCentralInertia(
+                            mass, p_BoBcm_B, I_BBcm_B));
 
   // Scale the position vector by a factor of 10.
   // Before June 2023, the following caused the inertia triangle inequality test
   // to be violated by ≈ 1.5E-10. Note the ratio 1.5E-10 / 1.1E-12 ≈ 10² = 100.
   // In other words, error scaled as ≈ mass * distance² to center of mass.
   p_BoBcm_B *= 10;
-  DRAKE_EXPECT_NO_THROW(  /* M_BBo_B = */
-     SpatialInertia<double>::MakeFromCentralInertia(mass, p_BoBcm_B, I_BBcm_B));
+  DRAKE_EXPECT_NO_THROW(/* M_BBo_B = */
+                        SpatialInertia<double>::MakeFromCentralInertia(
+                            mass, p_BoBcm_B, I_BBcm_B));
 
   // Before June 2023, the following caused the inertia triangle inequality test
   // to be violated by ≈ 1.2E-06. Note the ratio 1.2E-06 / 1.1E-12 ≈ 1000² = 1E6
   // which reinforces that lost signficiant digits scale with distance².
   p_BoBcm_B *= 100;
-  DRAKE_EXPECT_NO_THROW(  /* M_BBo_B = */
-     SpatialInertia<double>::MakeFromCentralInertia(mass, p_BoBcm_B, I_BBcm_B));
+  DRAKE_EXPECT_NO_THROW(/* M_BBo_B = */
+                        SpatialInertia<double>::MakeFromCentralInertia(
+                            mass, p_BoBcm_B, I_BBcm_B));
 
   // Test for a small spatial inertia with somewhat disorderly digits.
   // Before June 2023, the test below threw an exception (similarly as above).
-  I_BBcm_B = RotationalInertia<double>(0.01/M_PI, 0.01/M_PI, 0.02/M_PI);
+  I_BBcm_B = RotationalInertia<double>(0.01 / M_PI, 0.01 / M_PI, 0.02 / M_PI);
   p_BoBcm_B = Vector3<double>(10, 20, 30);
-  DRAKE_EXPECT_NO_THROW(  /* M_BBo_B = */
-    SpatialInertia<double>::MakeFromCentralInertia(mass, p_BoBcm_B, I_BBcm_B));
+  DRAKE_EXPECT_NO_THROW(/* M_BBo_B = */
+                        SpatialInertia<double>::MakeFromCentralInertia(
+                            mass, p_BoBcm_B, I_BBcm_B));
 
   // Test a spatial inertia constructor that STILL throws an exception due to
   // the inertia triangle inequality test being violated by ≈ 1.1E-12.
@@ -1155,8 +1159,8 @@ GTEST_TEST(SpatialInertia, IsMakeFromCentralInertiaTestValidityImmediately) {
   // significant digits lost in a relatively large shift to the center of mass.
   const UnitInertia<double> G_BBcm_B = M_BBcm_B.get_unit_inertia();
   UnitInertia<double> G_BBo_B = G_BBcm_B.ShiftFromCenterOfMass(p_BoBcm_B);
-  EXPECT_THROW(  /* M_BBo_B = */
-     SpatialInertia(mass, p_BoBcm_B, G_BBo_B),  std::exception);
+  EXPECT_THROW(/* M_BBo_B = */
+               SpatialInertia(mass, p_BoBcm_B, G_BBo_B), std::exception);
 }
 
 // Verifies the operator*(const SpatialVelocity&) by computing the kinetic
@@ -1341,7 +1345,7 @@ GTEST_TEST(SpatialInertia, CalcPrincipalHalfLengthsAndPoseForEquivalentShape) {
   // Verify principal directions Ax, Ay, Az (R_BA is an identity matrix).
   // Verify p_BcmAo_B is zero (since Ao should be located at Bcm).
   M_BBcm_B =
-      SpatialInertia<double>::SolidBoxWithDensity(density, 2*a, 2*b, 2*c);
+      SpatialInertia<double>::SolidBoxWithDensity(density, 2 * a, 2 * b, 2 * c);
   std::tie(abc, X_BA) = M_BBcm_B.CalcPrincipalHalfLengthsAndPoseForSolidBox();
   EXPECT_TRUE(CompareMatrices(Vector3<double>(a, b, c), abc, kTolerance));
   EXPECT_TRUE(X_BA.rotation().IsExactlyEqualTo(R_identity));

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -16,8 +16,7 @@ UniformGravityFieldElement<T>::UniformGravityFieldElement()
 
 template <typename T>
 UniformGravityFieldElement<T>::UniformGravityFieldElement(Vector3<double> g_W)
-    : ForceElement<T>(world_model_instance()),
-      g_W_(g_W) {}
+    : ForceElement<T>(world_model_instance()), g_W_(g_W) {}
 
 template <typename T>
 UniformGravityFieldElement<T>::~UniformGravityFieldElement() = default;
@@ -198,8 +197,7 @@ T UniformGravityFieldElement<T>::CalcConservativePower(
 
 template <typename T>
 T UniformGravityFieldElement<T>::CalcNonConservativePower(
-    const systems::Context<T>&,
-    const internal::PositionKinematicsCache<T>&,
+    const systems::Context<T>&, const internal::PositionKinematicsCache<T>&,
     const internal::VelocityKinematicsCache<T>&) const {
   // A uniform gravity field is conservative. Therefore return zero power.
   return 0.0;

--- a/multibody/tree/uniform_gravity_field_element.h
+++ b/multibody/tree/uniform_gravity_field_element.h
@@ -51,9 +51,7 @@ class UniformGravityFieldElement : public ForceElement<T> {
 
   /// Sets the acceleration of gravity vector, expressed in the world frame
   /// W in m/s².
-  void set_gravity_vector(const Vector3<double>& g_W) {
-    g_W_ = g_W;
-  }
+  void set_gravity_vector(const Vector3<double>& g_W) { g_W_ = g_W; }
 
   /// @returns `true` iff gravity is enabled for `model_instance`.
   /// @see enable(), disable().

--- a/multibody/tree/unit_inertia.cc
+++ b/multibody/tree/unit_inertia.cc
@@ -19,8 +19,8 @@ template <typename T>
 UnitInertia<T> UnitInertia<T>::PointMass(const Vector3<T>& p_FQ) {
   // Square each coefficient in p_FQ, perhaps better with p_FQ.array().square()?
   const Vector3<T> p2m = p_FQ.cwiseAbs2();  // [x²  y²  z²].
-  const T mp0 = -p_FQ(0);  // -x
-  const T mp1 = -p_FQ(1);  // -y
+  const T mp0 = -p_FQ(0);                   // -x
+  const T mp1 = -p_FQ(1);                   // -y
   return UnitInertia<T>(
       // Gxx = y² + z²,  Gyy = x² + z²,  Gzz = x² + y²
       p2m[1] + p2m[2], p2m[0] + p2m[2], p2m[0] + p2m[1],
@@ -29,8 +29,8 @@ UnitInertia<T> UnitInertia<T>::PointMass(const Vector3<T>& p_FQ) {
 }
 
 template <typename T>
-UnitInertia<T> UnitInertia<T>::SolidEllipsoid(
-    const T& a, const T& b, const T& c) {
+UnitInertia<T> UnitInertia<T>::SolidEllipsoid(const T& a, const T& b,
+                                              const T& c) {
   const T a2 = a * a;
   const T b2 = b * b;
   const T c2 = c * c;
@@ -38,8 +38,8 @@ UnitInertia<T> UnitInertia<T>::SolidEllipsoid(
 }
 
 template <typename T>
-UnitInertia<T> UnitInertia<T>::SolidCylinder(
-    const T& radius, const T& length, const Vector3<T>& unit_vector) {
+UnitInertia<T> UnitInertia<T>::SolidCylinder(const T& radius, const T& length,
+                                             const Vector3<T>& unit_vector) {
   DRAKE_THROW_UNLESS(radius >= 0);
   DRAKE_THROW_UNLESS(length >= 0);
   math::internal::ThrowIfNotUnitVector(unit_vector, __func__);
@@ -58,14 +58,15 @@ UnitInertia<T> UnitInertia<T>::SolidCylinderAboutEnd(
   math::internal::ThrowIfNotUnitVector(unit_vector, __func__);
   const T rsq = radius * radius;
   const T lsq = length * length;
-  const T J = 0.5 * rsq;                // Axial moment of inertia J = ½ r².
-  const T K = 0.25 * rsq  + lsq / 3.0;  // Transverse moment K = ¼ r² + ⅓ l².
+  const T J = 0.5 * rsq;               // Axial moment of inertia J = ½ r².
+  const T K = 0.25 * rsq + lsq / 3.0;  // Transverse moment K = ¼ r² + ⅓ l².
   return AxiallySymmetric(J, K, unit_vector);
 }
 
 template <typename T>
 UnitInertia<T> UnitInertia<T>::AxiallySymmetric(const T& moment_parallel,
-    const T& moment_perpendicular, const Vector3<T>& unit_vector) {
+                                                const T& moment_perpendicular,
+                                                const Vector3<T>& unit_vector) {
   const T& J = moment_parallel;
   const T& K = moment_perpendicular;
   DRAKE_THROW_UNLESS(moment_parallel >= 0.0);       // Ensure J ≥ 0.
@@ -99,7 +100,7 @@ UnitInertia<T> UnitInertia<T>::AxiallySymmetric(const T& moment_parallel,
 
 template <typename T>
 UnitInertia<T> UnitInertia<T>::StraightLine(const T& moment_perpendicular,
-    const Vector3<T>& unit_vector) {
+                                            const Vector3<T>& unit_vector) {
   DRAKE_THROW_UNLESS(moment_perpendicular > 0.0);
   math::internal::ThrowIfNotUnitVector(unit_vector, __func__);
   return AxiallySymmetric(0.0, moment_perpendicular, unit_vector);
@@ -107,7 +108,7 @@ UnitInertia<T> UnitInertia<T>::StraightLine(const T& moment_perpendicular,
 
 template <typename T>
 UnitInertia<T> UnitInertia<T>::ThinRod(const T& length,
-    const Vector3<T>& unit_vector) {
+                                       const Vector3<T>& unit_vector) {
   DRAKE_THROW_UNLESS(length > 0.0);
   math::internal::ThrowIfNotUnitVector(unit_vector, __func__);
   return StraightLine(length * length / 12.0, unit_vector);
@@ -126,7 +127,7 @@ UnitInertia<T> UnitInertia<T>::SolidBox(const T& Lx, const T& Ly, const T& Lz) {
 
 template <typename T>
 UnitInertia<T> UnitInertia<T>::SolidCapsule(const T& radius, const T& length,
-    const Vector3<T>& unit_vector) {
+                                            const Vector3<T>& unit_vector) {
   DRAKE_THROW_UNLESS(radius >= 0);
   DRAKE_THROW_UNLESS(length >= 0);
   math::internal::ThrowIfNotUnitVector(unit_vector, __func__);
@@ -156,9 +157,9 @@ UnitInertia<T> UnitInertia<T>::SolidCapsule(const T& radius, const T& length,
   // Denoting mc as the mass of cylinder C and mh as the mass of half-sphere H,
   // and knowing the capsule has a uniform density and the capsule's mass is 1
   // (for unit inertia), calculate mc and mh.
-  const T v = vc + 2 * vh;    // Volume of capsule.
-  const T mc = vc / v;        // Mass in the cylinder (relates to volume).
-  const T mh = vh / v;        // Mass in each half-sphere (relates to volume).
+  const T v = vc + 2 * vh;  // Volume of capsule.
+  const T mc = vc / v;      // Mass in the cylinder (relates to volume).
+  const T mh = vh / v;      // Mass in each half-sphere (relates to volume).
 
   // The distance dH between Hcm (half-sphere H's center of mass) and Ccm
   // (cylinder C's center of mass) is given in [Kane, Figure A23, pg. 369] as
@@ -187,8 +188,9 @@ UnitInertia<T> UnitInertia<T>::SolidCapsule(const T& radius, const T& length,
   // The previous algorithm for Ixx and Izz is algebraically manipulated to a
   // more efficient result by factoring on mh and mc and computing numbers as
   const T lsq = length * length;
-  const T Ixx = mc * (lsq/12.0 + 0.25*rsq) + mh * (0.51875*rsq + 2*dH*dH);
-  const T Izz = (0.5*mc + 0.8*mh) * rsq;  // Axial moment of inertia.
+  const T Ixx =
+      mc * (lsq / 12.0 + 0.25 * rsq) + mh * (0.51875 * rsq + 2 * dH * dH);
+  const T Izz = (0.5 * mc + 0.8 * mh) * rsq;  // Axial moment of inertia.
   return UnitInertia<T>::AxiallySymmetric(Izz, Ixx, unit_vector);
 }
 
@@ -201,13 +203,15 @@ namespace {
 // @note This function is an efficient way to calculate outer-products that
 //   contribute via a sum to a symmetric matrix.
 template <typename T>
-Matrix3<T> UpperTriangularOuterProduct(
-    const Eigen::Ref<const Vector3<T>>& a,
-    const Eigen::Ref<const Vector3<T>>& b) {
+Matrix3<T> UpperTriangularOuterProduct(const Eigen::Ref<const Vector3<T>>& a,
+                                       const Eigen::Ref<const Vector3<T>>& b) {
   Matrix3<T> M;
-  M(0, 0) = a(0) * b(0);  M(0, 1) = a(0) * b(1);  M(0, 2) = a(0) * b(2);
-                          M(1, 1) = a(1) * b(1);  M(1, 2) = a(1) * b(2);
-                                                  M(2, 2) = a(2) * b(2);
+  M(0, 0) = a(0) * b(0);
+  M(0, 1) = a(0) * b(1);
+  M(0, 2) = a(0) * b(2);
+  M(1, 1) = a(1) * b(1);
+  M(1, 2) = a(1) * b(2);
+  M(2, 2) = a(2) * b(2);
   return M;
 }
 }  // namespace
@@ -249,15 +253,15 @@ UnitInertia<T> UnitInertia<T>::SolidTetrahedronAboutVertex(
   const Vector3<T>& r = p3;  // Position from vertex B0 to vertex R.
   const Vector3<T> q_plus_r = q + r;
   const T p_dot_pqr = p.dot(p + q_plus_r);
-  const T q_dot_qr  = q.dot(q_plus_r);
-  const T r_dot_r   = r.dot(r);
+  const T q_dot_qr = q.dot(q_plus_r);
+  const T r_dot_r = r.dot(r);
   const T scalar = 0.1 * (p_dot_pqr + q_dot_qr + r_dot_r);
   const Vector3<T> p_half = 0.5 * p;
   const Vector3<T> q_half = 0.5 * q;
   const Vector3<T> r_half = 0.5 * r;
-  const Matrix3<T> G = UpperTriangularOuterProduct<T>(p, p + q_half + r_half)
-                     + UpperTriangularOuterProduct<T>(q, p_half + q + r_half)
-                     + UpperTriangularOuterProduct<T>(r, p_half + q_half + r);
+  const Matrix3<T> G = UpperTriangularOuterProduct<T>(p, p + q_half + r_half) +
+                       UpperTriangularOuterProduct<T>(q, p_half + q + r_half) +
+                       UpperTriangularOuterProduct<T>(r, p_half + q_half + r);
   const T Ixx = scalar - 0.1 * G(0, 0);
   const T Iyy = scalar - 0.1 * G(1, 1);
   const T Izz = scalar - 0.1 * G(2, 2);

--- a/multibody/tree/unit_inertia.h
+++ b/multibody/tree/unit_inertia.h
@@ -65,8 +65,8 @@ class UnitInertia : public RotationalInertia<T> {
   /// and with products of inertia `Ixy`, `Ixz`, `Iyz`.
   /// In debug builds, throws std::exception if unit inertia constructed from
   /// these arguments violates RotationalInertia::CouldBePhysicallyValid().
-  UnitInertia(const T& Ixx, const T& Iyy, const T& Izz,
-              const T& Ixy, const T& Ixz, const T& Iyz)
+  UnitInertia(const T& Ixx, const T& Iyy, const T& Izz, const T& Ixy,
+              const T& Ixz, const T& Iyz)
       : RotationalInertia<T>(Ixx, Iyy, Izz, Ixy, Ixz, Iyz) {}
 
   /// Constructs a %UnitInertia from a RotationalInertia. This constructor has
@@ -99,8 +99,8 @@ class UnitInertia : public RotationalInertia<T> {
   /// to a body with a given `mass`.
   /// @note In Debug builds, this operation aborts if the provided `mass` is
   ///       not strictly positive.
-  UnitInertia<T>& SetFromRotationalInertia(
-      const RotationalInertia<T>& I, const T& mass);
+  UnitInertia<T>& SetFromRotationalInertia(const RotationalInertia<T>& I,
+                                           const T& mass);
 
   /// Re-express a unit inertia in a different frame, performing the operation
   /// in place and modifying the original object. @see ReExpress() for details.
@@ -238,7 +238,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// consisting of an infinitesimally thin shell of uniform density.
   /// The unit inertia is taken about the center of the sphere.
   static UnitInertia<T> HollowSphere(const T& r) {
-    return UnitInertia<T>::TriaxiallySymmetric(2.0/3.0 * r * r);
+    return UnitInertia<T>::TriaxiallySymmetric(2.0 / 3.0 * r * r);
   }
 
   /// Computes the unit inertia for a unit-mass solid box of uniform density
@@ -254,9 +254,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// Computes the unit inertia for a unit-mass solid cube (a box with
   /// equal-sized sides) of uniform density taken about its geometric center.
   /// @param[in] L The length of each of the cube's sides.
-  static UnitInertia<T> SolidCube(const T& L) {
-    return SolidBox(L, L, L);
-  }
+  static UnitInertia<T> SolidCube(const T& L) { return SolidBox(L, L, L); }
 
   /// Creates a unit inertia for a uniform density solid cylinder B about
   /// its center of mass Bcm (which is coincident with B's geometric center Bo).
@@ -273,8 +271,8 @@ class UnitInertia : public RotationalInertia<T> {
   /// ‖unit_vector‖ is not within 1.0E-14 of 1.0.
   /// @see SolidCylinderAboutEnd() to calculate G_BBp_E, B's unit inertia about
   /// point Bp (Bp is at the center of one of the cylinder's circular ends).
-  static UnitInertia<T> SolidCylinder(
-      const T& radius, const T& length, const Vector3<T>& unit_vector);
+  static UnitInertia<T> SolidCylinder(const T& radius, const T& length,
+                                      const Vector3<T>& unit_vector);
 
   /// Creates a unit inertia for a uniform density solid capsule B about
   /// its center of mass Bcm (which is coincident with B's geometric center Bo).
@@ -290,7 +288,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// @throws std::exception if radius or length is negative or if
   /// ‖unit_vector‖ is not within 1.0E-14 of 1.0.
   static UnitInertia<T> SolidCapsule(const T& radius, const T& length,
-      const Vector3<T>& unit_vector);
+                                     const Vector3<T>& unit_vector);
 
   /// Creates a unit inertia for a uniform-density solid cylinder B about an
   /// end-point Bp of the cylinder's axis (see below for more about Bp).
@@ -306,8 +304,8 @@ class UnitInertia : public RotationalInertia<T> {
   /// is perpendicular to unit_vector.
   /// @throws std::exception if radius or length is negative or if
   /// ‖unit_vector‖ is not within 1.0E-14 of 1.0.
-  static UnitInertia<T> SolidCylinderAboutEnd(
-      const T& radius, const T& length, const Vector3<T>& unit_vector);
+  static UnitInertia<T> SolidCylinderAboutEnd(const T& radius, const T& length,
+                                              const Vector3<T>& unit_vector);
 
   /// Creates a unit inertia for a unit-mass uniform density solid tetrahedron B
   /// about a point A, from which position vectors to B's 4 vertices B0, B1, B2,
@@ -370,7 +368,8 @@ class UnitInertia : public RotationalInertia<T> {
   /// is negative or if J > 2 K (violates the triangle inequality, see
   /// CouldBePhysicallyValid()) or ‖unit_vector‖ is not within 1.0E-14 of 1.0.
   static UnitInertia<T> AxiallySymmetric(const T& moment_parallel,
-      const T& moment_perpendicular, const Vector3<T>& unit_vector);
+                                         const T& moment_perpendicular,
+                                         const Vector3<T>& unit_vector);
 
   /// Creates a unit inertia for a straight line segment B about a point Bp on
   /// the line segment.
@@ -389,7 +388,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// @see ThinRod() is an example of an object that is axially symmetric and
   /// that has a zero moment of inertia about Bp in the unit_vector direction.
   static UnitInertia<T> StraightLine(const T& moment_perpendicular,
-      const Vector3<T>& unit_vector);
+                                     const Vector3<T>& unit_vector);
 
   /// Creates a unit inertia for a uniform density thin rod B about its
   /// center of mass Bcm (which is coincident with B's geometric center Bo).

--- a/multibody/tree/universal_mobilizer.cc
+++ b/multibody/tree/universal_mobilizer.cc
@@ -29,7 +29,7 @@ std::unique_ptr<internal::BodyNode<T>> UniversalMobilizer<T>::CreateBodyNode(
 
 template <typename T>
 std::string UniversalMobilizer<T>::position_suffix(
-  int position_index_in_mobilizer) const {
+    int position_index_in_mobilizer) const {
   switch (position_index_in_mobilizer) {
     case 0:
       return "qx";
@@ -41,15 +41,14 @@ std::string UniversalMobilizer<T>::position_suffix(
 
 template <typename T>
 std::string UniversalMobilizer<T>::velocity_suffix(
-  int velocity_index_in_mobilizer) const {
+    int velocity_index_in_mobilizer) const {
   switch (velocity_index_in_mobilizer) {
     case 0:
       return "wx";
     case 1:
       return "wy";
   }
-  throw std::runtime_error(
-    "UniversalMobilizer has only 2 velocities.");
+  throw std::runtime_error("UniversalMobilizer has only 2 velocities.");
 }
 
 template <typename T>
@@ -103,7 +102,7 @@ Eigen::Matrix<T, 3, 2> UniversalMobilizer<T>::CalcHwMatrix(
     // Since only the second column of Hw evolves with time, we only return that
     // column as a vector. The vector is the time derivative of My_F.
     const Vector2<T>& v = this->get_velocities(context);
-    *Hw_dot =  Vector3<T>(0, -s * v[0], c * v[0]);
+    *Hw_dot = Vector3<T>(0, -s * v[0], c * v[0]);
   }
   return H;
 }

--- a/multibody/tree/universal_mobilizer.h
+++ b/multibody/tree/universal_mobilizer.h
@@ -50,8 +50,8 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UniversalMobilizer);
   using MobilizerBase = MobilizerImpl<T, 2, 2>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
-  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
   using typename MobilizerBase::HMatrix;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
 
   // Constructor for a %UniversalMobilizer between an inboard frame F
   // `inboard_frame_F` and an outboard frame M `outboard_frame_M` granting
@@ -65,15 +65,15 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
   ~UniversalMobilizer() final;
 
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
   std::string position_suffix(int position_index_in_mobilizer) const final;
   std::string velocity_suffix(int velocity_index_in_mobilizer) const final;
 
-  bool can_rotate() const final    { return true; }
+  bool can_rotate() const final { return true; }
   bool can_translate() const final { return false; }
 
   // Retrieves from `context` the two angles, (θ₁, θ₂) which describe the state
@@ -119,9 +119,11 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
     const T s1 = sin(q[0]), c1 = cos(q[0]);
     const T s2 = sin(q[1]), c2 = cos(q[1]);
     Matrix3<T> R_FM_matrix;
+    // clang-format off
     R_FM_matrix <<   c2,    0.0,  s2,
                    s1 * s2, c1,  -s1 * c2,
                   -c1 * s2, s1,   c1 * c2;
+    // clang-format on
     return math::RigidTransform<T>(
         math::RotationMatrix<T>::MakeUnchecked(R_FM_matrix),
         Vector3<T>::Zero());

--- a/multibody/tree/velocity_kinematics_cache.h
+++ b/multibody/tree/velocity_kinematics_cache.h
@@ -55,8 +55,7 @@ class VelocityKinematicsCache {
   // Initializes `this` %VelocityKinematicsCache as if all generalized
   // velocities of the corresponding MultibodyTree model were zero.
   void InitializeToZero() {
-    for (MobodIndex mobod_index(0); mobod_index < num_mobods_;
-         ++mobod_index) {
+    for (MobodIndex mobod_index(0); mobod_index < num_mobods_; ++mobod_index) {
       V_WB_pool_[mobod_index].SetZero();
       V_FM_pool_[mobod_index].SetZero();
       V_PB_W_pool_[mobod_index].SetZero();
@@ -126,8 +125,7 @@ class VelocityKinematicsCache {
   // Initializes all pools to have NaN values to ease bug detection when entries
   // are accidentally left uninitialized.
   void InitializeToNaN() {
-    for (MobodIndex mobod_index(0); mobod_index < num_mobods_;
-         ++mobod_index) {
+    for (MobodIndex mobod_index(0); mobod_index < num_mobods_; ++mobod_index) {
       V_WB_pool_[mobod_index].SetNaN();
       V_FM_pool_[mobod_index].SetNaN();
       V_PB_W_pool_[mobod_index].SetNaN();

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -18,8 +18,7 @@ const std::string& WeldJoint<T>::type_name() const {
 
 template <typename T>
 template <typename ToScalar>
-std::unique_ptr<Joint<ToScalar>>
-WeldJoint<T>::TemplatedDoCloneToScalar(
+std::unique_ptr<Joint<ToScalar>> WeldJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {
   const Frame<ToScalar>& frame_on_parent_body_clone =
       tree_clone.get_variant(this->frame_on_parent());
@@ -28,8 +27,8 @@ WeldJoint<T>::TemplatedDoCloneToScalar(
 
   // Make the Joint<T> clone.
   auto joint_clone = std::make_unique<WeldJoint<ToScalar>>(
-      this->name(),
-      frame_on_parent_body_clone, frame_on_child_body_clone, X_FM());
+      this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
+      X_FM());
 
   return joint_clone;
 }

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -23,7 +23,7 @@ class WeldJoint final : public Joint<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(WeldJoint);
 
-  template<typename Scalar>
+  template <typename Scalar>
   using Context = systems::Context<Scalar>;
 
   static const char kTypeName[];
@@ -55,9 +55,8 @@ class WeldJoint final : public Joint<T> {
   /// Since frame F and M are welded together, it is physically not possible to
   /// apply forces between them. Therefore this method throws an exception if
   /// invoked.
-  void DoAddInOneForce(
-      const systems::Context<T>&, int, const T&,
-      MultibodyForces<T>*) const override {
+  void DoAddInOneForce(const systems::Context<T>&, int, const T&,
+                       MultibodyForces<T>*) const override {
     throw std::logic_error("Weld joints do not allow applying forces.");
   }
 
@@ -69,9 +68,7 @@ class WeldJoint final : public Joint<T> {
     return get_mobilizer()->velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override {
-    return 0;
-  }
+  int do_get_num_velocities() const override { return 0; }
 
   int do_get_position_start() const override {
     // Since WeldJoint has no state, the start index has no meaning. However,
@@ -80,9 +77,7 @@ class WeldJoint final : public Joint<T> {
     return get_mobilizer()->position_start_in_q();
   }
 
-  int do_get_num_positions() const override {
-    return 0;
-  }
+  int do_get_num_positions() const override { return 0; }
 
   std::string do_get_position_suffix(int index) const override {
     return get_mobilizer()->position_suffix(index);
@@ -105,12 +100,13 @@ class WeldJoint final : public Joint<T> {
       const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&x) const override;
+      const internal::MultibodyTree<symbolic::Expression>& x) const override;
 
   // Make WeldJoint templated on every other scalar type a friend of
   // WeldJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of WeldJoint<T>.
-  template <typename> friend class WeldJoint;
+  template <typename>
+  friend class WeldJoint;
 
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
@@ -141,7 +137,8 @@ class WeldJoint final : public Joint<T> {
   const math::RigidTransform<double> X_FM_;
 };
 
-template <typename T> const char WeldJoint<T>::kTypeName[] = "weld";
+template <typename T>
+const char WeldJoint<T>::kTypeName[] = "weld";
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -23,19 +23,17 @@ std::unique_ptr<internal::BodyNode<T>> WeldMobilizer<T>::CreateBodyNode(
 template <typename T>
 math::RigidTransform<T> WeldMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>&) const {
-return X_FM_.cast<T>();
+  return X_FM_.cast<T>();
 }
 
 template <typename T>
 SpatialVelocity<T> WeldMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>&,
-    const Eigen::Ref<const VectorX<T>>&) const {
-return SpatialVelocity<T>::Zero();
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>&) const {
+  return SpatialVelocity<T>::Zero();
 }
 
 template <typename T>
-SpatialAcceleration<T>
-WeldMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
+SpatialAcceleration<T> WeldMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>&,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
@@ -43,26 +41,24 @@ WeldMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
 }
 
 template <typename T>
-void WeldMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>&,
-    const SpatialForce<T>&,
-    Eigen::Ref<VectorX<T>> tau) const {
+void WeldMobilizer<T>::ProjectSpatialForce(const systems::Context<T>&,
+                                           const SpatialForce<T>&,
+                                           Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
 }
 
 template <typename T>
-void WeldMobilizer<T>::DoCalcNMatrix(
-    const systems::Context<T>&, EigenPtr<MatrixX<T>>) const {}
+void WeldMobilizer<T>::DoCalcNMatrix(const systems::Context<T>&,
+                                     EigenPtr<MatrixX<T>>) const {}
 
 template <typename T>
-void WeldMobilizer<T>::DoCalcNplusMatrix(
-    const systems::Context<T>&, EigenPtr<MatrixX<T>>) const {}
+void WeldMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>&,
+                                         EigenPtr<MatrixX<T>>) const {}
 
 template <typename T>
-void WeldMobilizer<T>::MapVelocityToQDot(
-    const systems::Context<T>&,
-    const Eigen::Ref<const VectorX<T>>& v,
-    EigenPtr<VectorX<T>> qdot) const {
+void WeldMobilizer<T>::MapVelocityToQDot(const systems::Context<T>&,
+                                         const Eigen::Ref<const VectorX<T>>& v,
+                                         EigenPtr<VectorX<T>> qdot) const {
   DRAKE_ASSERT(v.size() == kNv);
   DRAKE_ASSERT(qdot != nullptr);
   DRAKE_ASSERT(qdot->size() == kNq);
@@ -70,8 +66,7 @@ void WeldMobilizer<T>::MapVelocityToQDot(
 
 template <typename T>
 void WeldMobilizer<T>::MapQDotToVelocity(
-    const systems::Context<T>&,
-    const Eigen::Ref<const VectorX<T>>& qdot,
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
     EigenPtr<VectorX<T>> v) const {
   DRAKE_ASSERT(qdot.size() == kNq);
   DRAKE_ASSERT(v != nullptr);

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -27,8 +27,8 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(WeldMobilizer);
   using MobilizerBase = MobilizerImpl<T, 0, 0>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
-  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
   using typename MobilizerBase::HMatrix;
+  using typename MobilizerBase::QVector, typename MobilizerBase::VVector;
 
   // Constructor for a %WeldMobilizer between the `inboard_frame_F` and
   // `outboard_frame_M`.
@@ -36,28 +36,25 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   WeldMobilizer(const SpanningForest::Mobod& mobod,
                 const Frame<T>& inboard_frame_F,
                 const Frame<T>& outboard_frame_M,
-                const math::RigidTransform<double>& X_FM) :
-      MobilizerBase(mobod, inboard_frame_F, outboard_frame_M), X_FM_(X_FM) {}
+                const math::RigidTransform<double>& X_FM)
+      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M), X_FM_(X_FM) {}
 
   ~WeldMobilizer() final;
 
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node,
-      const RigidBody<T>* body, const Mobilizer<T>* mobilizer) const final;
+      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   // @retval X_FM The pose of the outboard frame M in the inboard frame F.
   const math::RigidTransform<double>& get_X_FM() const { return X_FM_; }
 
   // Computes the across-mobilizer transform `X_FM`, which for this mobilizer
   // is independent of the state stored in `context`.
-  math::RigidTransform<T> calc_X_FM(const T*) const {
-    return X_FM_.cast<T>();
-  }
+  math::RigidTransform<T> calc_X_FM(const T*) const { return X_FM_.cast<T>(); }
 
   // Computes the across-mobilizer velocity V_FM which for this mobilizer is
   // always zero since the outboard frame M is fixed to the inboard frame F.
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
-                               const T*) const {
+  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T*) const {
     return SpatialVelocity<T>::Zero();
   }
 
@@ -76,37 +73,33 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
 
   // Since this mobilizer has no generalized velocities associated with it,
   // this override is a no-op.
-  void ProjectSpatialForce(
-      const systems::Context<T>& context,
-      const SpatialForce<T>& F_Mo_F,
-      Eigen::Ref<VectorX<T>> tau) const final;
+  void ProjectSpatialForce(const systems::Context<T>& context,
+                           const SpatialForce<T>& F_Mo_F,
+                           Eigen::Ref<VectorX<T>> tau) const final;
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
   // This override is a no-op since this mobilizer has no generalized
   // velocities associated with it.
-  void MapVelocityToQDot(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v,
-      EigenPtr<VectorX<T>> qdot) const final;
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const final;
 
   // This override is a no-op since this mobilizer has no generalized
   // velocities associated with it.
-  void MapQDotToVelocity(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& qdot,
-      EigenPtr<VectorX<T>> v) const final;
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const final;
 
-  bool can_rotate() const final    { return false; }
+  bool can_rotate() const final { return false; }
   bool can_translate() const final { return false; }
 
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
 
-  void DoCalcNplusMatrix(
-      const systems::Context<T>& context,
-      EigenPtr<MatrixX<T>> Nplus) const final;
+  void DoCalcNplusMatrix(const systems::Context<T>& context,
+                         EigenPtr<MatrixX<T>> Nplus) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;


### PR DESCRIPTION
Following #21928, this completes reformatting of all the remaining multibody/tree files and turns on the requirement that none of these files change at all when clang-format is run on them.

There are no changes here besides reformatting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21932)
<!-- Reviewable:end -->
