### PR TITLE
More Reasonable Behavior for IRIS Boundedness Check when an Initial Region is Provided

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -580,6 +580,9 @@ void DefineIris(py::module m) {
             cls_doc.starting_ellipse.doc)
         .def_readwrite("bounding_region", &IrisOptions::bounding_region,
             cls_doc.bounding_region.doc)
+        .def_readwrite("verify_domain_boundedness",
+            &IrisOptions::verify_domain_boundedness,
+            cls_doc.verify_domain_boundedness.doc)
         .def_readwrite("num_additional_constraint_infeasible_samples",
             &IrisOptions::num_additional_constraint_infeasible_samples,
             cls_doc.num_additional_constraint_infeasible_samples.doc)

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -683,6 +683,7 @@ class TestGeometryOptimization(unittest.TestCase):
         options.starting_ellipse = mut.Hyperellipsoid.MakeUnitBall(3)
         options.bounding_region = mut.HPolyhedron.MakeBox(
             lb=[-6, -6, -6], ub=[6, 6, 6])
+        options.verify_domain_boundedness = True
         options.solver_options = SolverOptions()
         self.assertNotIn("object at 0x", repr(options))
         region = mut.Iris(

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -54,7 +54,6 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
   for (int i = 0; i < N; ++i) {
     DRAKE_DEMAND(obstacles[i]->ambient_dimension() == dim);
   }
-  DRAKE_DEMAND(domain.IsBounded());
   const double kEpsilonEllipsoid = 1e-2;
   Hyperellipsoid E = options.starting_ellipse.value_or(
       Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample));
@@ -69,6 +68,10 @@ HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
   if (options.bounding_region) {
     DRAKE_DEMAND(options.bounding_region->ambient_dimension() == dim);
     P = P.Intersection(*options.bounding_region);
+  }
+
+  if (options.verify_domain_boundedness) {
+    DRAKE_DEMAND(P.IsBounded());
   }
 
   const int num_initial_constraints = P.A().rows();
@@ -552,14 +555,6 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
     }
   }
 
-  if (lower_limits.array().isInf().any() ||
-      upper_limits.array().isInf().any()) {
-    throw std::runtime_error(
-        "IrisInConfigurationSpace requires that all joints have position "
-        "limits (unless that joint is a RevoluteJoint or the revolute "
-        "component of a PlanarJoint or RpyFloatingJoint.");
-  }
-
   DRAKE_DEMAND(options.num_collision_infeasible_samples >= 0);
   for (int i = 0; i < nc; ++i) {
     DRAKE_DEMAND(options.configuration_obstacles[i]->ambient_dimension() == nq);
@@ -575,12 +570,48 @@ HPolyhedron IrisInConfigurationSpace(const MultibodyPlant<double>& plant,
   }
 
   // Make the polytope and ellipsoid.
-  HPolyhedron P = HPolyhedron::MakeBox(lower_limits, upper_limits);
-  DRAKE_DEMAND(P.A().rows() == 2 * nq);
+  MatrixXd A_init = MatrixXd::Zero(2 * ssize(lower_limits), nq);
+  VectorXd b_init = VectorXd::Zero(2 * ssize(lower_limits));
+  int row_count = 0;
+  for (int i = 0; i < ssize(upper_limits); ++i) {
+    if (std::isfinite(upper_limits[i])) {
+      A_init(row_count, i) = 1;
+      b_init(row_count) = upper_limits[i];
+      ++row_count;
+    }
+    if (std::isfinite(lower_limits[i])) {
+      A_init(row_count, i) = -1;
+      b_init(row_count) = -lower_limits[i];
+      ++row_count;
+    }
+  }
+  A_init.conservativeResize(row_count, nq);
+  b_init.conservativeResize(row_count);
+  HPolyhedron P(A_init, b_init);
 
+  bool boundedness_error = false;
   if (options.bounding_region) {
     DRAKE_DEMAND(options.bounding_region->ambient_dimension() == nq);
     P = P.Intersection(*options.bounding_region);
+    if (options.verify_domain_boundedness) {
+      if (!P.IsBounded()) {
+        boundedness_error = true;
+      }
+    }
+  } else {
+    if (lower_limits.array().isInf().any() ||
+        upper_limits.array().isInf().any()) {
+      boundedness_error = true;
+    }
+  }
+
+  if (boundedness_error) {
+    throw std::runtime_error(
+        "IrisInConfigurationSpace requires that the initial domain be bounded. "
+        "Make sure all joints have position limits (unless that joint is a "
+        "RevoluteJoint or the revolute component of a PlanarJoint or "
+        "RpyFloatingJoint), or ensure that the intersection of the joint "
+        "limits and options.bounding_region is bounded.");
   }
 
   const double kEpsilonEllipsoid = 1e-2;

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -36,6 +36,7 @@ struct IrisOptions {
     a->Visit(DRAKE_NVP(random_seed));
     a->Visit(DRAKE_NVP(mixing_steps));
     a->Visit(DRAKE_NVP(convexity_radius_stepback));
+    a->Visit(DRAKE_NVP(verify_domain_boundedness));
   }
 
   /** The initial polytope is guaranteed to contain the point if that point is
@@ -93,6 +94,14 @@ struct IrisOptions {
   specified, IRIS regions will be confined to the intersection between the
   domain and `bounding_region` */
   std::optional<HPolyhedron> bounding_region{};
+
+  /** If the user knows the intersection of bounding_region and the domain (for
+  IRIS) or plant joint limits (for IrisInConfigurationSpace) is bounded,
+  setting this flag to `false` will skip the boundedness check that IRIS and
+  IrisInConfigurationSpace perform (leading to a small speedup, as checking
+  boundedness requires solving optimization problems). If the intersection turns
+  out to be unbounded, this will lead to undefined behavior. */
+  bool verify_domain_boundedness{true};
 
   /** By default, IRIS in configuration space certifies regions for collision
   avoidance constraints and joint limits. This option can be used to pass

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -209,6 +209,35 @@ GTEST_TEST(IrisInConfigurationSpaceTest, PlanarJoint) {
   // the prismatic components of the planar joint are unbounded.
   DRAKE_EXPECT_THROWS_MESSAGE(IrisFromUrdf(planar_urdf, sample, options),
                               ".*position limits.*");
+
+  // If we add an initial bounding region that bounds the planar degrees of
+  // freedom, it shouldn't error.
+  Eigen::MatrixXd A(4, 3);
+  Eigen::VectorXd b(4);
+  // clang-format off
+  A <<  1,  0, 0,
+       -1,  0, 0,
+        0,  1, 0,
+        0, -1, 0;
+  // clang-format on
+  b << 1, 1, 1, 1;
+  options.bounding_region = HPolyhedron{A, b};
+  EXPECT_NO_THROW(IrisFromUrdf(planar_urdf, sample, options));
+
+  // It still shouldn't error if we disable the boundedness check.
+  options.verify_domain_boundedness = false;
+  EXPECT_NO_THROW(IrisFromUrdf(planar_urdf, sample, options));
+
+  // If the initial bounding region doesn't actually bound the planar degrees of
+  // freedom, it should error.
+  Eigen::MatrixXd A2(1, 3);
+  Eigen::VectorXd b2(1);
+  A2 << 1, 0, 0;
+  b2 << 1;
+  options.bounding_region = HPolyhedron{A2, b2};
+  options.verify_domain_boundedness = true;
+  DRAKE_EXPECT_THROWS_MESSAGE(IrisFromUrdf(planar_urdf, sample, options),
+                              ".*position limits.*");
 }
 
 // Check that IRIS correctly handles the continuous revolute component(s) of a


### PR DESCRIPTION
We allow the user to pass in a bounding region for IRIS (and IrisInConfigurationSpace, but I'll use IRIS as a catchall here), such that the region the algorithm produces will be properly contained within that set. As long as the intersection of that bounding region with the underlying domain (the user-specified HPolyhedron in IRIS, or the joint limits in IrisInConfigurationSpace) is bounded, then the algorithm can function properly. However, we currently throw an error if the domain (or the joint limits) are unbounded, no matter what is specified for the bounding region. This PR modifies the check to occur after the two have been intersected, making it much more user-friendly to grow IRIS regions when there are unbounded joints.

This PR also adds a flag `skip_domain_boundedness_check` to `IrisOptions`, to skip this boundedness check when the user is sure that the bounding region they're providing is valid. (This can lead to time savings, since checking boundedness requires solving a MathematicalProgram).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21942)
<!-- Reviewable:end -->
