### PR TITLE
RenderMesh and RenderMaterial parse .obj files from MeshSource

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/geometry_state.h"
 
 #include <algorithm>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <string>
@@ -2057,8 +2058,9 @@ void GeometryState<T>::RegisterDrivenMesh(GeometryId geometry_id, Role role) {
   if (role == Role::kPerception) {
     // TODO(xuchenhan-tri): consider allowing embedded mesh for illustration
     // similar to the driven perception mesh.
-    const string render_meshes_file = properties.GetPropertyOrDefault(
-        "deformable", "embedded_mesh", string{});
+    const std::filesystem::path render_meshes_file =
+        properties.GetPropertyOrDefault("deformable", "embedded_mesh",
+                                        string{});
     if (!render_meshes_file.empty()) {
       render_meshes =
           internal::LoadRenderMeshesFromObj(render_meshes_file, properties, {});

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -83,6 +83,7 @@ drake_cc_library(
     deps = [
         "//common:diagnostic_policy",
         "//common:essential",
+        "//common:overloaded",
         "//geometry:geometry_properties",
         "//geometry:rgba",
     ],
@@ -99,7 +100,9 @@ drake_cc_library(
         ":render_material",
         "//common:diagnostic_policy",
         "//common:essential",
+        "//common:find_resource",
         "//geometry:geometry_properties",
+        "//geometry:mesh_source",
         "//geometry:rgba",
         "//geometry/proximity:triangle_surface_mesh",
     ],

--- a/geometry/render/render_material.h
+++ b/geometry/render/render_material.h
@@ -3,14 +3,48 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <utility>
+#include <variant>
 
 #include "drake/common/diagnostic_policy.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/memory_file.h"
 #include "drake/geometry/geometry_properties.h"
 #include "drake/geometry/rgba.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
+
+/* The key value for a texture source when it references an entry into an
+ internal image database. */
+struct TextureKey {
+  std::string value;
+};
+
+/* A texture can be specified for a RenderMaterial in several ways:
+
+  - No image at all (aka an "empty" texture source).
+  - A file path to an image on the disk.
+  - A special key for access in some coordinated image database.
+  - Contents of a known image file format.
+
+ Note: when assigning to a %TextureSource, take *extra* care to distinguish
+ between a TextureKey and a path. Simply assigning a string (or string-like
+ type) will successfully compile, but the implicit conversion from those types
+ to std::filesystem::path will mean you're setting a *path*. When setting a
+ texture key, explicitly declare it as such. E.g.,:
+
+ TextureSource source = TextureKey{"looks/like/a/path/but/is/not.png"};
+
+ This can be particularly surprising if the right-hand side is a
+ std::string_view. There *is* an implicit conversion from std::string_view to
+ std::filesystem::path, but not to std::string. */
+using TextureSource =
+    std::variant<std::monostate, std::filesystem::path, TextureKey, MemoryFile>;
+
+/* Reports if the texture source specifies no texture -- i.e., it's empty. */
+bool IsEmpty(const TextureSource& source);
 
 /* Reports how UVs have been assigned to the mesh receiving a material. Textures
  should only be applied to meshes with *fully* assigned UVs. */
@@ -25,16 +59,15 @@ struct RenderMaterial {
    `diffuse_map` is empty, it acts as the multiplicative identity. */
   Rgba diffuse;
 
-  /* The optional texture to use as diffuse map. For universal compatibility,
-   it is an image file path. However, in RenderEngine implementations that
-   construct and consume their own %RenderMaterial instances, the file path
-   can be replaced with an arbitrary string which the RenderEngine
-   implementation knows how to map to an actual texture. Such %RenderMaterial
-   instances should be kept hidden within those implementations.
-
-   Regardless of how a non-empty string is interpreted, an empty string always
-   means no diffuse map. */
-  std::string diffuse_map;
+  /* The optional texture to use as diffuse map. If no diffuse texture is
+   defined, it will be "empty". Otherwise, the texture can be specified by a
+   path to an on-disk image, in-memory image file contents, or a database key.
+   Some RenderEngine implementations construct and consume their own
+   %RenderMaterial may store images in a local database. When
+   `diffuse_map.is_key()` returns true, it is a key into that database. Such
+   %RenderMaterial instances should be kept hidden within those RenderEngine
+   implementations. */
+  TextureSource diffuse_map;
 
   /* OpenGL defines image origin at the bottom-left corner of the texture. Some
    geometry formats (e.g., glTF), define the origin at the top-left corner.
@@ -75,8 +108,11 @@ void MaybeWarnForRedundantMaterial(
      purely from the properties (e.g., ("phong", "diffuse_map") and
      ("phong", "diffuse").
    - Otherwise, if an image can be located with a "compatible name" (e.g.,
-     foo.png for a mesh foo.obj), a material with an unmodulated texture is
-     created.
+     foo.png for the mesh foo.obj), a material with an unmodulated texture is
+     created. An existing foo.png that can't be read or an empty `mesh_path`
+     are both treated as "no compatible png could be found" and will fall
+     through to the next condition. If the mesh is in-memory, there is, by
+     definition, no compatible png.
    - Otherwise, if a default_diffuse value is provided, a material is created
      with the given default_diffuse color value.
    - Finally, if no material is defined, std::nullopt is returned. In such a

--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -12,6 +12,8 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/find_resource.h"
+#include "drake/common/overloaded.h"
 #include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"
 
@@ -19,6 +21,8 @@ namespace drake {
 namespace geometry {
 namespace internal {
 namespace {
+
+namespace fs = std::filesystem;
 
 using drake::internal::DiagnosticPolicy;
 using Eigen::Vector2d;
@@ -30,7 +34,7 @@ using std::vector;
 
 /* Constructs a RenderMaterial from a single tinyobj material specification. */
 RenderMaterial MakeMaterialFromMtl(const tinyobj::material_t& mat,
-                                   const std::filesystem::path& obj_path,
+                                   const MeshSource& mesh_source,
                                    const GeometryProperties& properties,
                                    const DiagnosticPolicy& policy,
                                    UvState uv_state) {
@@ -39,53 +43,173 @@ RenderMaterial MakeMaterialFromMtl(const tinyobj::material_t& mat,
   result.from_mesh_file = true;
   result.diffuse.set(mat.diffuse[0], mat.diffuse[1], mat.diffuse[2],
                      mat.dissolve);
-  result.diffuse_map = [&mat, &obj_path]() -> std::string {
-    if (mat.diffuse_texname.empty()) {
-      return mat.diffuse_texname;
-    }
-    std::filesystem::path tex_path(mat.diffuse_texname);
-    if (tex_path.is_absolute()) {
-      return mat.diffuse_texname;
-    }
-    // There are three potential paths: path to obj, path to mtl, and path to
-    // texture image (png). We have the path to obj. The mtl is defined relative
-    // to the obj (inside the obj) and the png is defined relative to the
-    // mtl (defined in the mtl). However, tinyobj doesn't give us access to
-    // the mtl path to resolve image paths. For now, we're making the
-    // simplifying assumption that obj and mtl are in the same directory.
-    //
-    // What if the OBJ references multiple mtl files in disparate locations?
-    // Ideally, `material_t` should  come with a string indicating either the
-    // the mtl file it came from or the directory of that mtl file. Then
-    // relative paths of the referenced images can be properly interpreted.
-    // Or what is stored in material_t should be relative to the obj.
-    std::filesystem::path obj_dir = obj_path.parent_path();
-    return (obj_dir / tex_path).lexically_normal().string();
-  }();
+  if (!mat.diffuse_texname.empty()) {
+    if (mesh_source.is_path()) {
+      fs::path tex_path(mat.diffuse_texname);
+      // There are three potential paths: path to obj, path to mtl, and path to
+      // texture image (png). We have the path to obj. The mtl is defined
+      // relative to the obj (inside the obj) and the png is defined relative to
+      // the mtl (defined in the mtl). However, tinyobj doesn't give us access
+      // to the mtl path to resolve image paths. For now, we're making the
+      // simplifying assumption that obj and mtl are in the same directory.
+      //
+      // What if the OBJ references multiple mtl files in disparate locations?
+      // Ideally, `material_t` should  come with a string indicating either the
+      // the mtl file it came from or the directory of that mtl file. Then
+      // relative paths of the referenced images can be properly interpreted.
+      // Alternatively, tinyobj could reconcile paths and what is stored in
+      // material_t should be relative to the obj.
+      const fs::path obj_dir = mesh_source.path().parent_path();
+      result.diffuse_map = tex_path.is_absolute()
+                               ? tex_path
+                               : (obj_dir / tex_path).lexically_normal();
+    } else {
+      DRAKE_DEMAND(mesh_source.is_in_memory());
+      const InMemoryMesh& data = mesh_source.in_memory();
+      const auto file_source_iter =
+          data.supporting_files.find(mat.diffuse_texname);
 
-  // If texture is specified, it must be available and applicable.
-  if (!result.diffuse_map.empty()) {
-    std::ifstream tex_file(result.diffuse_map);
-    if (!tex_file.is_open()) {
-      policy.Warning(fmt::format(
-          "The OBJ file's material requested an unavailable diffuse texture "
-          "image: {}. The image will be omitted.",
-          result.diffuse_map));
-      result.diffuse_map.clear();
-    } else if (uv_state != UvState::kFull) {
-      policy.Warning(fmt::format(
-          "The OBJ file's material requested a diffuse texture image: {}. "
-          "However the mesh doesn't define {} texture coordinates. The image "
-          "will be omitted.",
-          result.diffuse_map,
-          uv_state == UvState::kNone ? "any" : "a complete set of"));
-      result.diffuse_map.clear();
+      if (file_source_iter != data.supporting_files.end()) {
+        result.diffuse_map = std::visit<TextureSource>(
+            [](auto source) {
+              return TextureSource{source};
+            },
+            file_source_iter->second);
+      } else {
+        policy.Warning(fmt::format(
+            "The OBJ file's material requested an unavailable diffuse texture "
+            "image: {}. The image will be omitted.",
+            mat.diffuse_texname));
+      }
     }
   }
 
-  MaybeWarnForRedundantMaterial(properties, obj_path.string(), policy);
+  // If texture path is specified, it must be available and applicable.
+  const bool clear_map = std::visit(
+      overloaded{
+          [&policy, uv_state](const fs::path& path) {
+            // Confirm it is available.
+            if (!std::ifstream(path).is_open()) {
+              // TODO(SeanCurtis-TRI): It would be good to be able to tie this
+              // into some reference to the geometry under question. Ideally,
+              // the caller would provide a custom policy that would
+              // automatically decorate this message with the additional
+              // context.
+              policy.Warning(fmt::format(
+                  "The OBJ file's material requested an unavailable diffuse "
+                  "texture image: {}. The image will be omitted.",
+                  path.string()));
+              return true;
+            } else if (uv_state != UvState::kFull) {
+              policy.Warning(fmt::format(
+                  "The OBJ file's material requested a diffuse texture image: "
+                  "{}. However the mesh doesn't define {} texture coordinates. "
+                  "The image will be omitted.",
+                  path.string(),
+                  uv_state == UvState::kNone ? "any" : "a complete set of"));
+              return true;
+            }
+            return false;
+          },
+          [](const auto&) {
+            return false;
+          }},
+      result.diffuse_map);
+  if (clear_map) result.diffuse_map = std::monostate{};
+
+  MaybeWarnForRedundantMaterial(properties, mesh_source.description(), policy);
   return result;
 }
+
+// This provides a string buffer for std::istream that doesn't copy the input
+// string. Instead, it aliases the string's character array. This is only
+// safe as long as the parsing never calls std::istream::putback() with a
+// *different* character than read -- as that would mutate the string.
+// Obviously, the input string must remain valid at least as long as `this`.
+struct AliasingStringReadBuf : public std::streambuf {
+ public:
+  explicit AliasingStringReadBuf(const std::string* str) {
+    char* s = const_cast<char*>(str->c_str());
+    setg(s, s, s + str->size());
+  }
+};
+
+// Serves as a material library reader based on the mesh source. If the source
+// is a file path, the named material libraries are treated as on-disk,
+// otherwise they must be in the in-memory mesh's supporting files.
+class MaterialLibraryServer final : public tinyobj::MaterialReader {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MaterialLibraryServer);
+
+  // Constructs the server for the given `mesh_source`. The parameters will be
+  // aliased and must remain valid for at least as long as `this`.
+  MaterialLibraryServer(const MeshSource* mesh_source,
+                        const DiagnosticPolicy* policy)
+      : source_(*mesh_source), policy_(*policy) {
+    DRAKE_DEMAND(mesh_source != nullptr);
+    DRAKE_DEMAND(policy != nullptr);
+  }
+
+  // The virtual interface for loading .mtl data; note the parameter names
+  // reflect those used in tinyobjloader itself.
+  bool operator()(const std::string& matId,
+                  std::vector<tinyobj::material_t>* materials,
+                  std::map<std::string, int>* matMap, std::string* warn,
+                  std::string* err) final {
+    if (source_.is_path()) {
+      return LoadFileMtl(matId, materials, matMap, warn, err);
+    } else {
+      return LoadMemoryMtl(matId, materials, matMap, warn, err);
+    }
+  }
+
+ private:
+  bool LoadFileMtl(const std::string& matId,
+                   std::vector<tinyobj::material_t>* materials,
+                   std::map<std::string, int>* matMap, std::string* warn,
+                   std::string* err) const {
+    DRAKE_DEMAND(source_.is_path());
+    tinyobj::MaterialFileReader reader(source_.path().parent_path());
+    return reader(matId, materials, matMap, warn, err);
+  }
+
+  bool LoadMemoryMtl(const std::string& matId,
+                     std::vector<tinyobj::material_t>* materials,
+                     std::map<std::string, int>* matMap, std::string* warn,
+                     std::string* err) const {
+    DRAKE_DEMAND(source_.is_in_memory());
+    const auto file_source_iter =
+        source_.in_memory().supporting_files.find(matId);
+    // matId is the filename that appears after mtllib. There may be multiple
+    // such files named.
+    if (file_source_iter == source_.in_memory().supporting_files.end()) {
+      policy_.Warning(fmt::format(
+          "An in-memory OBJ ('{}') references a mtllib called '{}' which was "
+          "not in its supporting files. The declaration will be ignored which "
+          "may lead to missing materials.",
+          source_.description(), matId));
+      return false;
+    }
+    std::visit(overloaded{[&](const fs::path& path) {
+                            std::ifstream mtl_stream(path);
+                            tinyobj::LoadMtl(matMap, materials, &mtl_stream,
+                                             warn, err);
+                          },
+                          [&](const MemoryFile& file) {
+                            AliasingStringReadBuf mat_buf(&file.contents());
+                            std::istream mtl_stream(&mat_buf);
+                            tinyobj::LoadMtl(matMap, materials, &mtl_stream,
+                                             warn, err);
+                          }},
+               file_source_iter->second);
+    // Note: in tinyobjloader, every time tinyobj::LoadMtl is called, it is
+    // *always* followed blindly by `return true;`. We'll mirror that behavior.
+    return true;
+  }
+
+  const MeshSource& source_;
+  const DiagnosticPolicy& policy_;
+};
 
 }  // namespace
 
@@ -93,18 +217,29 @@ RenderMaterial MakeMaterialFromMtl(const tinyobj::material_t& mat,
 // reference it in these errors/warnings.
 
 vector<RenderMesh> LoadRenderMeshesFromObj(
-    const std::filesystem::path& obj_path, const GeometryProperties& properties,
+    const MeshSource& mesh_source, const GeometryProperties& properties,
     const std::optional<Rgba>& default_diffuse,
     const DiagnosticPolicy& policy) {
+  const std::string& obj_contents =
+      mesh_source.is_path() ? ReadFile(mesh_source.path()).value_or("")
+                            : mesh_source.in_memory().mesh_file.contents();
+  if (obj_contents.empty()) {
+    throw std::runtime_error(
+        fmt::format("Failed parsing obj data; no data given: {}.",
+                    mesh_source.description()));
+  }
   tinyobj::ObjReaderConfig config;
   config.triangulate = true;
   config.vertex_color = false;
   tinyobj::ObjReader reader;
-  const bool valid_parse = reader.ParseFromFile(obj_path.string(), config);
+  MaterialLibraryServer mat_server(&mesh_source, &policy);
+  const bool valid_parse =
+      reader.ParseFromString(obj_contents, &mat_server, config);
 
   if (!valid_parse) {
-    throw std::runtime_error(fmt::format("Failed parsing the obj file: {}: {}",
-                                         obj_path.string(), reader.Error()));
+    throw std::runtime_error(
+        fmt::format("Failed parsing the obj data: '{}': {}",
+                    mesh_source.description(), reader.Error()));
   }
 
   // We better not get any errors if we have a valid parse.
@@ -121,7 +256,7 @@ vector<RenderMesh> LoadRenderMeshesFromObj(
     throw std::runtime_error(fmt::format(
         "The OBJ data appears to have no faces; it could be missing faces or "
         "might not be an OBJ file: {}",
-        obj_path.string()));
+        mesh_source.description()));
   }
 
   if (!reader.Warning().empty()) {
@@ -182,7 +317,7 @@ vector<RenderMesh> LoadRenderMeshesFromObj(
   //   2. Make use of smoothing groups.
   if (attrib.normals.size() == 0) {
     throw std::runtime_error(
-        fmt::format("OBJ has no normals: {}", obj_path.string()));
+        fmt::format("OBJ has no normals: {}", mesh_source.description()));
   }
 
   /* Each triangle consists of three vertices. Any of those vertices may be
@@ -222,8 +357,9 @@ vector<RenderMesh> LoadRenderMeshesFromObj(
         const int norm_index = shape_mesh.indices[v_index].normal_index;
         const int uv_index = shape_mesh.indices[v_index].texcoord_index;
         if (norm_index < 0) {
-          throw std::runtime_error(fmt::format(
-              "Not all faces reference normals: {}", obj_path.string()));
+          throw std::runtime_error(
+              fmt::format("Not all faces reference normals: {}",
+                          mesh_source.description()));
         }
         const auto obj_indices =
             make_tuple(position_index, norm_index, uv_index);
@@ -279,12 +415,16 @@ vector<RenderMesh> LoadRenderMeshesFromObj(
                              : UvState::kPartial;
     if (mat_index == -1) {
       /* This is the default material. No material was assigned to the faces.
-       We'll apply the fallback logic. */
+       We'll apply the fallback logic.
+       Note: an in-memory mesh creates an empty path. This means the fallback
+       material logic will _not_ look for a foo.png image on disk. */
+      fs::path obj_path =
+          mesh_source.is_path() ? mesh_source.path() : fs::path();
       mesh_data.material = MaybeMakeMeshFallbackMaterial(
           properties, obj_path, default_diffuse, policy, mesh_data.uv_state);
     } else {
       mesh_data.material =
-          MakeMaterialFromMtl(reader.GetMaterials().at(mat_index), obj_path,
+          MakeMaterialFromMtl(reader.GetMaterials().at(mat_index), mesh_source,
                               properties, policy, mesh_data.uv_state);
     }
 

--- a/geometry/render/render_mesh.h
+++ b/geometry/render/render_mesh.h
@@ -8,6 +8,7 @@
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/geometry_properties.h"
+#include "drake/geometry/mesh_source.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/render/render_material.h"
 #include "drake/geometry/rgba.h"
@@ -104,7 +105,7 @@ struct RenderMesh {
                            faces fail to reference the texture coordinates if
                            they are present. */
 std::vector<RenderMesh> LoadRenderMeshesFromObj(
-    const std::filesystem::path& obj_path, const GeometryProperties& properties,
+    const MeshSource& mesh_source, const GeometryProperties& properties,
     const std::optional<Rgba>& default_diffuse,
     const drake::internal::DiagnosticPolicy& policy = {});
 

--- a/geometry/render/test/render_material_test.cc
+++ b/geometry/render/test/render_material_test.cc
@@ -19,6 +19,56 @@ namespace {
 
 namespace fs = std::filesystem;
 
+// Support the document about what happens if you assign a string.
+GTEST_TEST(TextureSourceTest, StringAssignent) {
+  TextureSource source;
+
+  auto is_path = [](const TextureSource& s) {
+    return std::get_if<fs::path>(&s) != nullptr;
+  };
+
+  auto is_key = [](const TextureSource& s) {
+    return std::get_if<TextureKey>(&s) != nullptr;
+  };
+
+  source = "cstr";
+  EXPECT_TRUE(is_path(source));
+  source = TextureKey{"cstr"};
+  EXPECT_TRUE(is_key(source));
+
+  source = std::string("str");
+  EXPECT_TRUE(is_path(source));
+  source = TextureKey{std::string("str")};
+  EXPECT_TRUE(is_key(source));
+
+  // Note: there is *implicit* conversion from string view to fs::path but no
+  // such conversion to std::string.
+  source = std::string_view("str");
+  EXPECT_TRUE(is_path(source));
+}
+
+GTEST_TEST(TextureSourceTest, Empty) {
+  EXPECT_TRUE(IsEmpty(TextureSource()));
+  EXPECT_TRUE(IsEmpty(TextureSource(fs::path(""))));
+  EXPECT_TRUE(IsEmpty(TextureSource("")));
+  EXPECT_TRUE(IsEmpty(TextureSource(std::string())));
+  EXPECT_TRUE(IsEmpty(TextureSource(std::string_view())));
+  EXPECT_TRUE(IsEmpty(TextureSource(MemoryFile("", ".ext", "hint"))));
+
+  TextureSource source;
+  EXPECT_TRUE(IsEmpty(source));
+  source = fs::path("");
+  EXPECT_TRUE(IsEmpty(source));
+  source = TextureKey{""};
+  EXPECT_TRUE(IsEmpty(source));
+  source = std::string();
+  EXPECT_TRUE(IsEmpty(source));
+  source = std::string_view();
+  EXPECT_TRUE(IsEmpty(source));
+  source = MemoryFile("", ".ext", "hint");
+  EXPECT_TRUE(IsEmpty(source));
+}
+
 /* Confirms the expected diagnostic warnings in the presence of material
  properties. */
 class MaybeWarnForRedundantMaterialTest
@@ -58,7 +108,7 @@ TEST_F(DefineMaterialTest, DefaultFallback) {
   const RenderMaterial mat =
       DefineMaterial(props_, default_diffuse(), diagnostic_policy_);
 
-  EXPECT_TRUE(mat.diffuse_map.empty());
+  EXPECT_TRUE(IsEmpty(mat.diffuse_map));
   EXPECT_EQ(mat.diffuse, default_diffuse());
 }
 
@@ -71,7 +121,7 @@ TEST_F(DefineMaterialTest, PhongDiffuseOnly) {
   const RenderMaterial mat =
       DefineMaterial(props_, default_diffuse(), diagnostic_policy_);
 
-  EXPECT_TRUE(mat.diffuse_map.empty());
+  EXPECT_TRUE(IsEmpty(mat.diffuse_map));
   EXPECT_EQ(mat.diffuse, diffuse);
 }
 
@@ -85,7 +135,8 @@ TEST_F(DefineMaterialTest, PhongDiffuseMapOnly) {
   const RenderMaterial mat =
       DefineMaterial(props_, default_diffuse(), diagnostic_policy_);
 
-  EXPECT_EQ(mat.diffuse_map, tex_name);
+  ASSERT_TRUE(std::holds_alternative<fs::path>(mat.diffuse_map));
+  EXPECT_EQ(std::get<fs::path>(mat.diffuse_map), tex_name);
   EXPECT_EQ(mat.diffuse, Rgba(1, 1, 1));
 }
 
@@ -101,7 +152,8 @@ TEST_F(DefineMaterialTest, PhongDiffuseAll) {
   const RenderMaterial mat =
       DefineMaterial(props_, default_diffuse(), diagnostic_policy_);
 
-  EXPECT_EQ(mat.diffuse_map, tex_name);
+  ASSERT_TRUE(std::holds_alternative<fs::path>(mat.diffuse_map));
+  EXPECT_EQ(std::get<fs::path>(mat.diffuse_map), tex_name);
   EXPECT_EQ(mat.diffuse, diffuse);
 }
 
@@ -115,7 +167,7 @@ TEST_F(DefineMaterialTest, DiffuseMapError) {
   const RenderMaterial mat = DefineMaterial(props_, default_diffuse(),
                                             diagnostic_policy_, UvState::kNone);
 
-  EXPECT_TRUE(mat.diffuse_map.empty());
+  EXPECT_TRUE(IsEmpty(mat.diffuse_map));
   EXPECT_EQ(mat.diffuse, Rgba(1, 1, 1));
   EXPECT_THAT(
       TakeWarning(),
@@ -137,7 +189,7 @@ TEST_F(DefineMaterialTest, DiffuseMapUvCoverageError) {
     const RenderMaterial mat = DefineMaterial(
         props_, default_diffuse(), diagnostic_policy_, UvState::kNone);
 
-    EXPECT_TRUE(mat.diffuse_map.empty());
+    EXPECT_TRUE(IsEmpty(mat.diffuse_map));
     EXPECT_EQ(mat.diffuse, Rgba(1, 1, 1));
     EXPECT_THAT(TakeWarning(),
                 testing::MatchesRegex(
@@ -149,7 +201,7 @@ TEST_F(DefineMaterialTest, DiffuseMapUvCoverageError) {
     const RenderMaterial mat = DefineMaterial(
         props_, default_diffuse(), diagnostic_policy_, UvState::kPartial);
 
-    EXPECT_TRUE(mat.diffuse_map.empty());
+    EXPECT_TRUE(IsEmpty(mat.diffuse_map));
     EXPECT_EQ(mat.diffuse, Rgba(1, 1, 1));
     EXPECT_THAT(TakeWarning(),
                 testing::MatchesRegex(".*referenced a map, .* doesn't define a "
@@ -188,7 +240,7 @@ TEST_F(MaybeMakeMeshFallbackMaterialTest, DefaultDiffuseMaterial) {
       props, "no_png_for_this.obj", default_diffuse(), diagnostic_policy_,
       UvState::kFull);
   ASSERT_TRUE(mat.has_value());
-  EXPECT_TRUE(mat->diffuse_map.empty());
+  EXPECT_TRUE(IsEmpty(mat->diffuse_map));
   EXPECT_EQ(mat->diffuse, default_diffuse());
 }
 
@@ -204,7 +256,10 @@ TEST_F(MaybeMakeMeshFallbackMaterialTest, NoMaterial) {
   EXPECT_FALSE(mat.has_value());
 }
 
-/* No material defined in the properties, but foo.png exists and is available.*/
+/* No material defined in the properties, but foo.png exists and is available.
+ Also covers the special case where the mesh path is empty -- it is treated as
+ if there is no compatible foo.png and it falls through to apply the default
+ diffuse. */
 TEST_F(MaybeMakeMeshFallbackMaterialTest, ValidFooPngMaterial) {
   PerceptionProperties props;
   const std::string tex_name =
@@ -217,26 +272,41 @@ TEST_F(MaybeMakeMeshFallbackMaterialTest, ValidFooPngMaterial) {
     UvState uv_state;
     std::string expected_texture;
     std::string error;
+    fs::path path;
+    Rgba rgba = Rgba(1, 1, 1);  // Default rgb for auto-loaded texture.
     std::string description;
   };
 
   const std::vector<TestCase> cases{
       {.uv_state = UvState::kFull,
        .expected_texture = tex_name,
+       .path = obj_path,
        .description = "Full UVs"},
       {.uv_state = UvState::kPartial,
        .error = "a complete set of",
+       .path = obj_path,
        .description = "Partial UVs"},
-      {.uv_state = UvState::kNone, .error = "any", .description = "No UVs"}};
+      {.uv_state = UvState::kNone,
+       .error = "any",
+       .path = obj_path,
+       .description = "No UVs"},
+      {.uv_state = UvState::kFull,
+       .path = fs::path(),
+       .rgba = default_diffuse(),
+       .description = "Empty path produces default diffuse"}};
   for (const TestCase& test_case : cases) {
     SCOPED_TRACE(test_case.description);
 
-    const std::optional<RenderMaterial> mat = MaybeMakeMeshFallbackMaterial(
-        props, obj_path.string(), default_diffuse(), diagnostic_policy_,
-        test_case.uv_state);
+    const std::optional<RenderMaterial> mat =
+        MaybeMakeMeshFallbackMaterial(props, test_case.path, default_diffuse(),
+                                      diagnostic_policy_, test_case.uv_state);
     ASSERT_TRUE(mat.has_value());
-    EXPECT_EQ(mat->diffuse_map, test_case.expected_texture);
-    EXPECT_EQ(mat->diffuse, Rgba(1, 1, 1));
+    ASSERT_EQ(IsEmpty(mat->diffuse_map), test_case.expected_texture.empty());
+    if (!test_case.expected_texture.empty()) {
+      EXPECT_EQ(std::get<fs::path>(mat->diffuse_map),
+                test_case.expected_texture);
+    }
+    EXPECT_EQ(mat->diffuse, test_case.rgba);
     if (!test_case.error.empty()) {
       EXPECT_THAT(
           TakeWarning(),
@@ -268,7 +338,7 @@ TEST_F(MaybeMakeMeshFallbackMaterialTest, PropertiesHaveDiffuseColor) {
       UvState::kFull);
 
   ASSERT_TRUE(mat.has_value());
-  EXPECT_TRUE(mat->diffuse_map.empty());
+  EXPECT_TRUE(IsEmpty(mat->diffuse_map));
   EXPECT_EQ(mat->diffuse, props.GetProperty<Rgba>("phong", "diffuse"));
 }
 
@@ -282,7 +352,8 @@ TEST_F(MaybeMakeMeshFallbackMaterialTest, PropertiesHaveDiffuseMap) {
       UvState::kFull);
 
   ASSERT_TRUE(mat.has_value());
-  EXPECT_EQ(mat->diffuse_map, tex_name);
+  ASSERT_TRUE(std::holds_alternative<fs::path>(mat->diffuse_map));
+  EXPECT_EQ(std::get<fs::path>(mat->diffuse_map), tex_name);
   EXPECT_EQ(mat->diffuse, Rgba(1, 1, 1));
 }
 
@@ -297,7 +368,8 @@ TEST_F(MaybeMakeMeshFallbackMaterialTest, PropertiesHaveEverything) {
       UvState::kFull);
 
   ASSERT_TRUE(mat.has_value());
-  EXPECT_EQ(mat->diffuse_map, tex_name);
+  ASSERT_TRUE(std::holds_alternative<fs::path>(mat->diffuse_map));
+  EXPECT_EQ(std::get<fs::path>(mat->diffuse_map), tex_name);
   EXPECT_EQ(mat->diffuse, props.GetProperty<Rgba>("phong", "diffuse"));
 }
 

--- a/geometry/render/test/render_mesh_test.cc
+++ b/geometry/render/test/render_mesh_test.cc
@@ -127,9 +127,10 @@ TEST_F(LoadRenderMeshFromObjTest, GeometryErrorModes) {
     // is simply for the file to not exist. Any other conditions that tinyobj
     // considers a parse failure will get treated the same.
     DRAKE_EXPECT_THROWS_MESSAGE(
-        LoadRenderMeshesFromObj("__garbage_doesn't_exist__.obj", empty_props(),
-                                kDefaultDiffuse, diagnostic_policy_),
-        "Failed parsing the obj file[^]*");
+        LoadRenderMeshesFromObj(fs::path("__garbage_doesn't_exist__.obj"),
+                                empty_props(), kDefaultDiffuse,
+                                diagnostic_policy_),
+        "Failed parsing obj data[^]*");
   }
   {
     // Case: Vertices only reports no faces found.
@@ -385,7 +386,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorOnly) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(0.5, 1, 1));
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
 }
 
 /* The OBJ has a single intrinsic material which only defines diffuse texture.
@@ -409,7 +410,8 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureOnly) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(1, 1, 1));
-  EXPECT_THAT(mesh.material->diffuse_map,
+  ASSERT_TRUE(std::holds_alternative<fs::path>(mesh.material->diffuse_map));
+  EXPECT_THAT(std::get<fs::path>(mesh.material->diffuse_map).string(),
               testing::EndsWith("diag_gradient.png"));
 }
 
@@ -433,7 +435,8 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorAndTexture) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(1, 1, 0));
-  EXPECT_THAT(mesh.material->diffuse_map,
+  ASSERT_TRUE(std::holds_alternative<fs::path>(mesh.material->diffuse_map));
+  EXPECT_THAT(std::get<fs::path>(mesh.material->diffuse_map).string(),
               testing::EndsWith("diag_gradient.png"));
 }
 
@@ -467,7 +470,9 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryDislocatedTexture) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(1, 1, 1));
-  EXPECT_EQ(mesh.material->diffuse_map, (temp_dir() / "diag_gradient.png"));
+  ASSERT_TRUE(std::holds_alternative<fs::path>(mesh.material->diffuse_map));
+  EXPECT_EQ(std::get<fs::path>(mesh.material->diffuse_map),
+            (temp_dir() / "diag_gradient.png"));
 }
 
 /* The OBJ has multiple intrinsic materials *defined* in the .mtl file. But only
@@ -490,7 +495,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryMultipleDefinedIntrinsic) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(1, 0, 1));
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
 }
 
 /* The OBJ has a single intrinsic material which defines a bad texture. The
@@ -514,7 +519,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryColorAndBadTexture) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(1, 0.5, 1));
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
   EXPECT_THAT(
       TakeWarning(),
       testing::HasSubstr("requested an unavailable diffuse texture image"));
@@ -542,7 +547,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureButNoUvs) {
                                     "define any texture coordinates.*"));
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(1, 1, 0));
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
 }
 
 /* The OBJ has a single intrinsic material with a texture but no uvs. The
@@ -569,7 +574,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryTextureButPartialUvs) {
                             "complete set of texture coordinates.*"));
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(1, 1, 0));
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
 }
 
 /* This test merely exposes a known flaw in the code. Images are defined
@@ -598,7 +603,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialLibraryObjMtlDislocation) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(1, 1, 0));
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
   // Because of our limited access to parsing information, this will look like
   // the image is unavailable.
   EXPECT_THAT(
@@ -633,11 +638,11 @@ TEST_F(LoadRenderMeshFromObjTest, MultipleValidIntrinsicMaterials) {
     if (mesh.indices.rows() == 1) {
       // test_material_1 applied to a single triangle.
       EXPECT_EQ(mesh.material->diffuse, Rgba(1, 0, 1));
-      EXPECT_EQ(mesh.material->diffuse_map, "");
+      EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
     } else if (mesh.indices.rows() == 2) {
       // test_material_2 applied to two triangles.
       EXPECT_EQ(mesh.material->diffuse, Rgba(1, 0, 0));
-      EXPECT_EQ(mesh.material->diffuse_map, "");
+      EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
     } else {
       DRAKE_UNREACHABLE();
     }
@@ -669,7 +674,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackObjMtlDislocationAbsolute) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, kDefaultDiffuse);
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
   // The tinyobj warning that the material library can't be found.
   EXPECT_THAT(TakeWarning(), testing::HasSubstr("not found in a path"));
 }
@@ -698,11 +703,11 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackDefaultedFaces) {
     if (mesh.indices.rows() == 1) {
       // default material applied to a single triangle.
       EXPECT_EQ(mesh.material->diffuse, kDefaultDiffuse);
-      EXPECT_EQ(mesh.material->diffuse_map, "");
+      EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
     } else if (mesh.indices.rows() == 2) {
       // test_material applied to two triangles.
       EXPECT_EQ(mesh.material->diffuse, Rgba(0.5, 1, 1));
-      EXPECT_EQ(mesh.material->diffuse_map, "");
+      EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
     } else {
       DRAKE_UNREACHABLE();
     }
@@ -728,7 +733,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackBadMaterialName) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, kDefaultDiffuse);
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
   EXPECT_THAT(TakeWarning(),
               testing::HasSubstr("material [ 'bad_material' ] not found"));
 }
@@ -751,7 +756,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackMissingMtl) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, kDefaultDiffuse);
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
   EXPECT_THAT(
       TakeWarning(),
       testing::HasSubstr("Material file [ not_really_a.mtl ] not found"));
@@ -775,7 +780,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackNoAppliedMaterial) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, kDefaultDiffuse);
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
 }
 
 /* The OBJ references no material library. The material should be the fallback
@@ -794,7 +799,7 @@ TEST_F(LoadRenderMeshFromObjTest, MaterialFallbackNoMaterialLibrary) {
   const RenderMesh& mesh = result[0];
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, kDefaultDiffuse);
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
 }
 
 /* The OBJ references no material library. The material should be the fallback
@@ -850,7 +855,7 @@ TEST_F(LoadRenderMeshFromObjTest, RedundantMaterialWarnings) {
   // We still get the intrinsic material.
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(0.5, 1, 1));
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
   EXPECT_THAT(
       TakeWarning(),
       testing::MatchesRegex(".*has its own materials.*'phong', 'diffuse'.*"));
@@ -881,7 +886,7 @@ TEST_F(LoadRenderMeshFromObjTest, UvStatePassedToFallback) {
   // Inability to apply a valid texture leaves the material flat white.
   ASSERT_TRUE(mesh.material.has_value());
   EXPECT_EQ(mesh.material->diffuse, Rgba(1, 1, 1));
-  EXPECT_EQ(mesh.material->diffuse_map, "");
+  EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
   EXPECT_THAT(TakeWarning(),
               testing::MatchesRegex(
                   ".*'diffuse_map'.* doesn't define a complete set of.*"));
@@ -890,9 +895,10 @@ TEST_F(LoadRenderMeshFromObjTest, UvStatePassedToFallback) {
 /* Tests if the `from_mesh_file` flag is correctly propagated. */
 TEST_F(LoadRenderMeshFromObjTest, PropagateFromMeshFileFlag) {
   for (const bool from_mesh_file : {false, true}) {
-    // N.B. box_no_mtl.obj doesn't exist in the source tree and is generated
-    // from box.obj by stripping out material data by the build system.
-    const std::string filename =
+    // N.B. box_no_mtl.obj doesn't exist in the mesh_source tree and is
+    // generated from box.obj by stripping out material data by the build
+    // system.
+    const fs::path filename =
         from_mesh_file
             ? FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj")
             : FindResourceOrThrow(
@@ -902,6 +908,179 @@ TEST_F(LoadRenderMeshFromObjTest, PropagateFromMeshFileFlag) {
         filename, empty_props(), kDefaultDiffuse, diagnostic_policy_)[0];
     ASSERT_TRUE(mesh_data.material.has_value());
     EXPECT_EQ(from_mesh_file, mesh_data.material->from_mesh_file);
+  }
+}
+
+/* Tests parsing of in-memory obj. This isn't exhaustive. This largely tests the
+ use of supporting files. What happens when a supporting file is referenced but
+ is or isn't present in the set of supporting files. The rest of the parsing
+ is assumed to be identical to the on-disk parsing. */
+TEST_F(LoadRenderMeshFromObjTest, InMemoryMesh) {
+  const PerceptionProperties props;
+
+  /* Obj references no mtl file. */
+  {
+    const MeshSource mesh_source(InMemoryMesh{MemoryFile(
+        R"""(v 0 0 0
+             v 1 0 0
+             v 0 1 0
+             vn 0 0 1
+             f 1//1 2//1 3//1
+          )""",
+        ".obj", "obj1")});
+    const RenderMesh mesh = LoadRenderMeshesFromObj(
+        mesh_source, props, kDefaultDiffuse, diagnostic_policy_)[0];
+    EXPECT_EQ(mesh.positions.rows(), 3);
+    EXPECT_EQ(mesh.normals.rows(), 3);
+    EXPECT_EQ(mesh.uvs.rows(), 3);
+    EXPECT_EQ(mesh.indices.rows(), 1);
+    ASSERT_TRUE(mesh.material.has_value());
+    EXPECT_EQ(mesh.material->diffuse, kDefaultDiffuse);
+    EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
+  }
+
+  /* Obj references available mtl, no textures. */
+  {
+    const MeshSource mesh_source(
+        InMemoryMesh{MemoryFile(
+                         R"""(mtllib mem.mtl
+                              v 0 0 0
+                              v 1 0 0
+                              v 0 1 0
+                              vn 0 0 1
+                              usemtl test
+                              f 1//1 2//1 3//1
+                            )""",
+                         ".obj", "obj2"),
+                     {{"mem.mtl", MemoryFile(
+                                      R"""(newmtl test
+                                           Kd 1 0 0)""",
+                                      ".mtl", "mem.mtl")}}});
+    const RenderMesh mesh = LoadRenderMeshesFromObj(
+        mesh_source, props, kDefaultDiffuse, diagnostic_policy_)[0];
+    EXPECT_EQ(mesh.positions.rows(), 3);
+    EXPECT_EQ(mesh.normals.rows(), 3);
+    EXPECT_EQ(mesh.uvs.rows(), 3);
+    EXPECT_EQ(mesh.indices.rows(), 1);
+    ASSERT_TRUE(mesh.material.has_value());
+    EXPECT_EQ(mesh.material->diffuse, Rgba(1, 0, 0));
+    EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
+  }
+
+  /* Obj references available in-memory mtl, with available in-memory image. */
+  {
+    const MeshSource mesh_source(
+        InMemoryMesh{MemoryFile(
+                         R"""(mtllib mem.mtl
+                              v 0 0 0
+                              v 1 0 0
+                              v 0 1 0
+                              vn 0 0 1
+                              usemtl test
+                              f 1//1 2//1 3//1
+                            )""",
+                         ".obj", "obj3"),
+                     {{"mem.mtl", MemoryFile(
+                                      R"""(newmtl test
+                                           map_Kd fake.png)""",
+                                      ".mtl", "mem.mtl")},
+                      {"fake.png", MemoryFile("abc", ".png", "png")}}});
+    const RenderMesh mesh = LoadRenderMeshesFromObj(
+        mesh_source, props, kDefaultDiffuse, diagnostic_policy_)[0];
+    EXPECT_EQ(mesh.positions.rows(), 3);
+    EXPECT_EQ(mesh.normals.rows(), 3);
+    EXPECT_EQ(mesh.uvs.rows(), 3);
+    EXPECT_EQ(mesh.indices.rows(), 1);
+    ASSERT_TRUE(mesh.material.has_value());
+    EXPECT_TRUE(std::holds_alternative<MemoryFile>(mesh.material->diffuse_map));
+  }
+
+  /* Obj references available on-disk mtl, with available in-memory image. */
+  {
+    /* We reference an existing .mtl file and use the material name and texture
+     names found in that file (box.obj.mtl). */
+    const MeshSource mesh_source(InMemoryMesh{
+        MemoryFile(
+            R"""(mtllib mem.mtl
+                 v 0 0 0
+                 v 1 0 0
+                 v 0 1 0
+                 vn 0 0 1
+                 usemtl material_0
+                 f 1//1 2//1 3//1
+               )""",
+            ".obj", "obj3"),
+        {{"mem.mtl", fs::path(FindResourceOrThrow(
+                         "drake/geometry/render/test/meshes/box.obj.mtl"))},
+         {"box.png", MemoryFile("abc", ".png", "png")}}});
+    const RenderMesh mesh = LoadRenderMeshesFromObj(
+        mesh_source, props, kDefaultDiffuse, diagnostic_policy_)[0];
+    EXPECT_EQ(mesh.positions.rows(), 3);
+    EXPECT_EQ(mesh.normals.rows(), 3);
+    EXPECT_EQ(mesh.uvs.rows(), 3);
+    EXPECT_EQ(mesh.indices.rows(), 1);
+    ASSERT_TRUE(mesh.material.has_value());
+    EXPECT_TRUE(std::holds_alternative<MemoryFile>(mesh.material->diffuse_map));
+  }
+
+  /* Obj references unavailable mtl. */
+  {
+    ASSERT_EQ(this->NumWarnings(), 0);
+    ASSERT_EQ(this->NumErrors(), 0);
+    const MeshSource mesh_source(InMemoryMesh{MemoryFile(
+        R"""(mtllib missing.mtl
+             v 0 0 0
+             v 1 0 0
+             v 0 1 0
+             vn 0 0 1
+             f 1//1 2//1 3//1
+           )""",
+        ".obj", "obj4")});
+    const RenderMesh mesh = LoadRenderMeshesFromObj(
+        mesh_source, props, kDefaultDiffuse, diagnostic_policy_)[0];
+    EXPECT_EQ(mesh.positions.rows(), 3);
+    EXPECT_EQ(mesh.normals.rows(), 3);
+    EXPECT_EQ(mesh.uvs.rows(), 3);
+    EXPECT_EQ(mesh.indices.rows(), 1);
+    ASSERT_TRUE(mesh.material.has_value());
+    EXPECT_EQ(mesh.material->diffuse, kDefaultDiffuse);
+    EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
+    ASSERT_EQ(this->NumWarnings(), 2);  // One from Drake, one from tinyobj.
+    EXPECT_THAT(this->TakeWarning(),
+                testing::HasSubstr("not in its supporting files"));
+    EXPECT_THAT(this->TakeWarning(),
+                testing::HasSubstr("Failed to load material file"));
+  }
+
+  /* Obj references unavailable texture image. */
+  {
+    ASSERT_EQ(this->NumWarnings(), 0);
+    ASSERT_EQ(this->NumErrors(), 0);
+    const MeshSource mesh_source(
+        InMemoryMesh{MemoryFile(
+                         R"""(mtllib mem.mtl
+                              v 0 0 0
+                              v 1 0 0
+                              v 0 1 0
+                              vn 0 0 1
+                              usemtl test
+                              f 1//1 2//1 3//1
+                            )""",
+                         ".obj", "obj5"),
+                     {{"mem.mtl", MemoryFile(R"""(newmtl test
+                                                  map_Kd fake.png)""",
+                                             ".mtl", "mem.mtl")}}});
+    const RenderMesh mesh = LoadRenderMeshesFromObj(
+        mesh_source, props, kDefaultDiffuse, diagnostic_policy_)[0];
+    EXPECT_EQ(mesh.positions.rows(), 3);
+    EXPECT_EQ(mesh.normals.rows(), 3);
+    EXPECT_EQ(mesh.uvs.rows(), 3);
+    EXPECT_EQ(mesh.indices.rows(), 1);
+    ASSERT_TRUE(mesh.material.has_value());
+    EXPECT_TRUE(IsEmpty(mesh.material->diffuse_map));
+    ASSERT_EQ(this->NumWarnings(), 1);
+    EXPECT_THAT(this->TakeWarning(),
+                testing::HasSubstr("image will be omitted"));
   }
 }
 
@@ -1002,7 +1181,7 @@ GTEST_TEST(MakeRenderMeshFromTriangleSurfaceMeshTest, AreaWeightedNormals) {
 }
 
 GTEST_TEST(MakeRenderMeshFromTriangleSurfaceMeshTest, RoundTrip) {
-  const std::string filename =
+  const fs::path filename =
       FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj");
   PerceptionProperties empty_props;
   const RenderMesh render_mesh =

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstring>
+#include <filesystem>
 #include <optional>
 #include <unordered_map>
 
@@ -903,7 +904,7 @@ TEST_F(RenderEngineGlTest, DeformableTest) {
 
     // N.B. box_no_mtl.obj doesn't exist in the source tree and is generated
     // from box.obj by stripping out material data in the build system.
-    auto filename =
+    const std::filesystem::path filename =
         use_texture
             ? FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj")
             : FindResourceOrThrow(

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
@@ -546,7 +546,7 @@ void RenderEngineGltfClient::ImplementMesh(
   auto& data = *static_cast<RegistrationData*>(user_data);
   const std::string extension = Mesh(mesh_path.string()).extension();
   if (extension == ".obj") {
-    data.accepted = ImplementObj(mesh_path.string(), scale, data);
+    data.accepted = ImplementObj(mesh_path, scale, data);
   } else if (extension == ".gltf") {
     data.accepted = ImplementGltf(mesh_path, scale, data);
   } else {

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -199,7 +200,7 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
 
   // Adds an .obj to the scene for the id currently being reified (data->id).
   // Returns true if added, false if ignored (for whatever reason).
-  bool ImplementObj(const std::string& file_name, double scale,
+  bool ImplementObj(const std::filesystem::path& file_name, double scale,
                     const RegistrationData& data);
 
   // Adds a .gltf to the scene for the id currently being reified (data->id).


### PR DESCRIPTION
This builds on the addition of MeshSource having supporting files (as material definitions require .mtl and possibly texture images).

The RenderMesh infrastructure includes a custom tinyobj::MaterialReader in order to host .mtl file data from disk or memory.

This introduces a new internal class: TextureSource. This is akin to a FileSource, but where FileSource has two modes, TextureSource has four to span a greater number of definitions for glTFs embedded textures.

Relates #15263.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21944)
<!-- Reviewable:end -->
