### PR TITLE
Convex hull computation uses MeshSource

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -533,6 +533,7 @@ drake_cc_library(
     internal = True,
     visibility = ["//geometry:__subpackages__"],
     deps = [
+        "//geometry:mesh_source",
         "//geometry/proximity:polygon_surface_mesh",
     ],
     implementation_deps = [
@@ -1396,6 +1397,7 @@ drake_cc_googletest(
     deps = [
         ":make_convex_hull_mesh_impl",
         "//common:find_resource",
+        "//common:memory_file",
         "//common:temp_directory",
         "//common/test_utilities:expect_throws_message",
         "@nlohmann_internal//:nlohmann",

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -520,8 +520,8 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   // For zero margin, use the pre-computed convex hull for the shape.
   const TriangleSurfaceMesh<double> inflated_surface_mesh =
       MakeTriangleFromPolygonMesh(
-          margin > 0 ? MakeConvexHull(convex_spec.filename(),
-                                      convex_spec.scale(), margin)
+          margin > 0 ? MakeConvexHull(convex_spec.source(), convex_spec.scale(),
+                                      margin)
                      : convex_spec.GetConvexHull());
   auto inflated_mesh = make_unique<VolumeMesh<double>>(
       MakeConvexVolumeMesh<double>(inflated_surface_mesh));

--- a/geometry/proximity/make_convex_hull_mesh.cc
+++ b/geometry/proximity/make_convex_hull_mesh.cc
@@ -27,11 +27,11 @@ class Hullifier final : public ShapeReifier {
   using ShapeReifier::ImplementGeometry;
 
   void ImplementGeometry(const Mesh& mesh, void*) final {
-    hull_ = MakeConvexHull(mesh.filename(), mesh.scale());
+    hull_ = MakeConvexHull(mesh.source(), mesh.scale());
   }
 
   void ImplementGeometry(const Convex& convex, void*) final {
-    hull_ = MakeConvexHull(convex.filename(), convex.scale());
+    hull_ = MakeConvexHull(convex.source(), convex.scale());
   }
 
   PolygonSurfaceMesh<double> hull_;

--- a/geometry/proximity/make_convex_hull_mesh_impl.cc
+++ b/geometry/proximity/make_convex_hull_mesh_impl.cc
@@ -37,8 +37,6 @@ using Eigen::Vector4d;
 using math::RigidTransformd;
 using math::RotationMatrixd;
 
-namespace fs = std::filesystem;
-
 /* Used for ordering polygon vertices according to their angular distance from
  a reference direction. See OrderPolyVertices(). */
 struct VertexScore {
@@ -112,23 +110,25 @@ struct VertexCloud {
   Vector3d interior_point;
 };
 
-/* Returns the scaled vertices from the named obj file.
- @pre `filename` references an obj file. */
-void ReadObjVertices(const fs::path& filename, double scale,
-                     std::vector<Vector3d>* vertices) {
-  const auto [tinyobj_vertices, _1, _2] = geometry::internal::ReadObj(
-      filename, scale, /* triangulate = */ false, /* vertices_only = */ true);
-  *vertices = std::move(*tinyobj_vertices);
+/* Returns the scaled vertices from the contents of an obj file.
+ @pre `obj_source` contains obj geometry data. */
+std::vector<Vector3d> ReadObjVertices(const MeshSource& obj_source,
+                                      double scale) {
+  const auto [tinyobj_vertices_ptr, _1, _2] =
+      geometry::internal::ReadObj(obj_source, scale,
+                                  /* triangulate = */ false,
+                                  /* vertices_only = */ true);
+  return std::move(*tinyobj_vertices_ptr);
 }
 
-/* Returns the scaled vertices from the named vtk file.
- @pre `filename` references a vtk file (with a volume mesh). */
-void ReadVtkVertices(const fs::path& filename, double scale,
-                     std::vector<Vector3d>* vertices) {
-  const VolumeMesh<double> volume_mesh = ReadVtkToVolumeMesh(filename, scale);
+/* Returns the scaled vertices from the contents of a vtk file.
+ @pre `vtk_source` contains vtk geometry data. */
+std::vector<Vector3d> ReadVtkVertices(const MeshSource& vtk_source,
+                                      double scale) {
+  const VolumeMesh<double> volume_mesh = ReadVtkToVolumeMesh(vtk_source, scale);
 
   // It would be nice if we could simply steal the vertices rather than copy.
-  *vertices = volume_mesh.vertices();
+  return volume_mesh.vertices();
 }
 
 /* Multiplies the position vector p_AQ by the transform T_BA, returning p_BQ. */
@@ -139,12 +139,14 @@ Vector3d VtkMultiply(vtkMatrix4x4* T_BA, const Vector3d& p_AQ) {
   return Vector3d(p_out);
 }
 
-/* Returns the scaled vertices from the named glTF file.
- @pre `filename` references a glTF file. */
-void ReadGltfVertices(const fs::path& filename, double scale,
-                      std::vector<Vector3d>* vertices) {
+/* Returns the scaled vertices from the contents of a glTF file.
+ @pre `gltf_source` contains glTF geometry data.
+ @pre `gltf_source.is_path()` is `true`. */
+std::vector<Vector3d> ReadGltfVertices(const MeshSource& gltf_source,
+                                       double scale) {
+  DRAKE_DEMAND(gltf_source.is_path());
   vtkNew<vtkGLTFImporter> importer;
-  importer->SetFileName(filename.c_str());
+  importer->SetFileName(gltf_source.path().c_str());
   importer->Update();
 
   auto* renderer = importer->GetRenderer();
@@ -153,13 +155,14 @@ void ReadGltfVertices(const fs::path& filename, double scale,
   if (renderer->VisibleActorCount() == 0) {
     throw std::runtime_error(
         fmt::format("MakeConvexHull() found no vertices in the file '{}'.",
-                    filename.string()));
+                    gltf_source.description()));
   }
 
   // The relative transform from the file's frame F to the geometry's frame G.
   // (rotation from y-up to z-up). The scale is handled separately.
   const RigidTransformd X_GF(RotationMatrixd::MakeXRotation(M_PI / 2));
 
+  std::vector<Vector3d> vertices;
   auto* actors = renderer->GetActors();
   actors->InitTraversal();
   while (vtkActor* actor = actors->GetNextActor()) {
@@ -174,9 +177,10 @@ void ReadGltfVertices(const fs::path& filename, double scale,
     for (vtkIdType vi = 0; vi < poly_data->GetNumberOfPoints(); ++vi) {
       const Vector3d p_AV(poly_data->GetPoint(vi));
       const Vector3d p_FV = VtkMultiply(T_FA, p_AV);
-      vertices->emplace_back((X_GF * p_FV) * scale);
+      vertices.emplace_back((X_GF * p_FV) * scale);
     }
   }
+  return vertices;
 }
 
 /* Given a set of vertices, attempts to find a plane that reliably spans three
@@ -186,7 +190,7 @@ void ReadGltfVertices(const fs::path& filename, double scale,
  @throws if the vertices span a severely degenerate space in R3 (e.g.,
          co-linear or coincident). */
 Vector3d FindNormal(const std::vector<Vector3d>& vertices,
-                    const fs::path& filename) {
+                    const std::string_view description) {
   // Note: this isn't an exhaustive search. We assign i = 0 and then
   // sequentially search for j and k. This may fail but possibly succeed for
   // a different value of i. That risk seems small. Any mesh that depends on
@@ -204,9 +208,8 @@ Vector3d FindNormal(const std::vector<Vector3d>& vertices,
   if (v == ssize(vertices)) {
     throw std::runtime_error(
         fmt::format("MakeConvexHull failed because all vertices in the mesh "
-                    "were within a "
-                    "sphere with radius 1e-12 for file: {}.",
-                    filename.string()));
+                    "were within a sphere with radius 1e-12 for geometry: {}.",
+                    description));
   }
   a.normalize();
 
@@ -224,43 +227,37 @@ Vector3d FindNormal(const std::vector<Vector3d>& vertices,
     throw std::runtime_error(fmt::format(
         "MakeConvexHull failed because all vertices in the mesh appear to be "
         "co-linear for file: {}.",
-        filename.string()));
+        description));
   }
   return n_candidate.normalized();
 }
 
-/* Simply reads the vertices from an OBJ, VTK or glTF file referred to by name.
- */
-VertexCloud ReadVertices(const fs::path& filename, double scale) {
-  std::string extension = filename.extension();
-  std::transform(extension.begin(), extension.end(), extension.begin(),
-                 [](unsigned char c) {
-                   return std::tolower(c);
-                 });
-
+/* Simply reads the vertices from an OBJ, VTK or glTF file indicated by the
+ given `mesh_source`. */
+VertexCloud ReadVertices(const MeshSource& mesh_source, double scale) {
   VertexCloud cloud;
-  if (extension == ".obj") {
-    ReadObjVertices(filename, scale, &cloud.vertices);
-  } else if (extension == ".vtk") {
-    ReadVtkVertices(filename, scale, &cloud.vertices);
-  } else if (extension == ".gltf") {
-    ReadGltfVertices(filename, scale, &cloud.vertices);
+  if (mesh_source.extension() == ".obj") {
+    cloud.vertices = ReadObjVertices(mesh_source, scale);
+  } else if (mesh_source.extension() == ".vtk") {
+    cloud.vertices = ReadVtkVertices(mesh_source, scale);
+  } else if (mesh_source.extension() == ".gltf") {
+    cloud.vertices = ReadGltfVertices(mesh_source, scale);
   } else {
     throw std::runtime_error(
-        fmt::format("MakeConvexHull only applies to obj, vtk, and gltf "
-                    "meshes; given file: {}.",
-                    filename.string()));
+        fmt::format("MakeConvexHull only applies to .obj, .vtk, and .gltf "
+                    "meshes; unsupported extension '{}' for geometry data: {}.",
+                    mesh_source.extension(), mesh_source.description()));
   }
 
   if (cloud.vertices.size() < 3) {
-    throw std::runtime_error(
-        fmt::format("MakeConvexHull() cannot be used on a mesh with fewer "
-                    "than three vertices; found {} vertices in file: {}.",
-                    cloud.vertices.size(), filename.string()));
+    throw std::runtime_error(fmt::format(
+        "MakeConvexHull() cannot be used on a mesh with fewer "
+        "than three vertices; found {} vertices in geometry data: {}.",
+        cloud.vertices.size(), mesh_source.description()));
   }
 
   /* Characterizes planarity. */
-  cloud.n = FindNormal(cloud.vertices, filename);
+  cloud.n = FindNormal(cloud.vertices, mesh_source.description());
   double d = cloud.n.dot(cloud.vertices[0]);
   cloud.interior_point = cloud.vertices[0];
   /* Assume planarity and look for evidence to the contrary. */
@@ -495,11 +492,11 @@ class ConvexHull {
 
 }  // namespace
 
-PolygonSurfaceMesh<double> MakeConvexHull(const fs::path& mesh_file,
+PolygonSurfaceMesh<double> MakeConvexHull(const MeshSource& mesh_source,
                                           double scale, double margin) {
   DRAKE_THROW_UNLESS(scale > 0);
   DRAKE_THROW_UNLESS(margin >= 0);
-  VertexCloud cloud = ReadVertices(mesh_file, scale);
+  VertexCloud cloud = ReadVertices(mesh_source, scale);
 
   // Hull of the input cloud of vertices.
   const ConvexHull hull(std::move(cloud));

--- a/geometry/proximity/make_convex_hull_mesh_impl.h
+++ b/geometry/proximity/make_convex_hull_mesh_impl.h
@@ -1,45 +1,55 @@
 #pragma once
 
-#include <filesystem>
-
+#include "drake/geometry/mesh_source.h"
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
-/* Creates a polygonal mesh representing the convex hull of the vertices
- contained in the named `mesh_file` (scaled with the given `scale` value). The
- mesh is also "inflated" a given margin amount δ. If margin is zero, no
- inflation is applied and the convex hull of the original set of vertices is
+/* Creates a convex hull (represented by a PolygonSurfaceMesh) for the provided
+ mesh data. The mesh data can come from on-disk files or in-memory files -- but
+ the content must be that of a supported Drake mesh type.
+
+ The convex hull is built upon *all* of the vertex values in the mesh data
+ (regardless of how the mesh is organized or even if it includes vertices that
+ are not otherwise incorporated in faces).
+
+ The vertex positions can be scaled uniformly around the origin of the mesh
+ data's canonical frame.
+
+ The mesh can also be "inflated" by a given margin amount δ. If margin is zero,
+ no inflation is applied and the convex hull of the original set of vertices is
  computed.
 
  With "inflation", we mean the process of moving each of the faces in the convex
- hull an amount δ along the (outwards) normal. This effectively increases or
+ hull an amount δ along its (outwards) normal. This effectively grows or
  "inflates" the convex hull, producing an additional layer of thickness δ all
  around the convex hull of the original set of vertices.
 
  @note Geometry inflation by a margin δ is meant to support speculative
- constraints (contact constraints before contact actually happens) for
- "compliant" hydroelastic. Since the hydroelastic model is not meant for thin
+ contact constraints (contact constraints before contact actually happens) for
+ "compliant" hydroelastics. Since the hydroelastic model is not meant for thin
  objects, inflation of planar (zero thickness) meshes is not implemented. Margin
  is ignored for planar meshes.
 
- @param mesh_file   A path to a valid mesh file to bound.
- @param scale       All vertices will be multiplied by this value prior to
-                    computation.
- @param margin      The margin amount δ, see @ref hydro_margin.
+ @param mesh_source  The source of the mesh data.
+ @param scale        The scale to apply to the vertex data -- the vertex
+                     position vectors are scaled relative to the mesh data's
+                     canonical frame's origin.
+ @param margin       The margin amount δ, see @ref hydro_margin.
 
- @throws if `mesh_file` references anything but an .obj, .vtk volume mesh, or
-         .gltf.
- @throws if the referenced mesh data is degenerate (insufficient number of
-            vertices, co-linear or coincident vertices, etc.) All of the
-            vertices lying on a plane is *not* degenerate.
- @throws if there is an unforeseen error in computing the convex hull.
- @throws if `scale` is negative or zero.
- @throws if `margin` is negative. */
-PolygonSurfaceMesh<double> MakeConvexHull(
-    const std::filesystem::path& mesh_file, double scale, double margin = 0);
+ @throws std::exception if the mesh data is in an unsupported format.
+ @throws std::exception if the mesh data is ill formed.
+ @throws std::exception if the mesh data is degenerate (insufficient numer of
+                           vertices, co-linear or coincident vertices, etc.) All
+                           of the vertices lying on a plane is *not* degenerate.
+ @throws std::exception if there is an unforeseen error in computing the convex
+                           hull.
+ @throws std::exception if `scale` is not strictly positive.
+ @throws std::exception if `margin` is negative. */
+PolygonSurfaceMesh<double> MakeConvexHull(const MeshSource& mesh_source,
+                                          double scale, double margin = 0);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/test/make_convex_hull_mesh_impl_test.cc
+++ b/geometry/proximity/test/make_convex_hull_mesh_impl_test.cc
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -10,6 +12,7 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/fmt_eigen.h"
+#include "drake/common/memory_file.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
@@ -24,6 +27,10 @@ using PolyMesh = PolygonSurfaceMesh<double>;
 using std::vector;
 
 namespace fs = std::filesystem;
+
+fs::path FindPathOrThrow(const std::string& resource_file) {
+  return FindResourceOrThrow(resource_file);
+}
 
 /* To compare polygon meshes we will produce "canonical" representations. The
  canonical mesh is the same manifold as the input mesh but has the following
@@ -286,7 +293,7 @@ GTEST_TEST(MakeConvexHullMeshTest, MeshIsHull) {
   const PolyMesh expected = MakeCube(scale);
 
   const PolyMesh dut = MakeConvexHull(
-      FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj"), scale);
+      FindPathOrThrow("drake/geometry/render/test/meshes/box.obj"), scale);
 
   MeshesAreEquivalent(dut, expected, 1e-14);
 }
@@ -297,7 +304,7 @@ GTEST_TEST(MakeConvexHullMeshTest, HullIsSubset) {
   const PolyMesh expected = MakeCube(scale);
 
   const PolyMesh dut = MakeConvexHull(
-      FindResourceOrThrow("drake/geometry/test/cube_with_hole.obj"), scale);
+      FindPathOrThrow("drake/geometry/test/cube_with_hole.obj"), scale);
 
   MeshesAreEquivalent(dut, expected, 1e-14);
 }
@@ -308,7 +315,7 @@ GTEST_TEST(MakeConvexHullMeshTest, DisjointMesh) {
   const PolyMesh expected = MakeCube(scale);
 
   const PolyMesh dut = MakeConvexHull(
-      FindResourceOrThrow("drake/geometry/test/cube_corners.obj"), scale);
+      FindPathOrThrow("drake/geometry/test/cube_corners.obj"), scale);
 
   MeshesAreEquivalent(dut, expected, 1e-14);
 }
@@ -332,7 +339,7 @@ GTEST_TEST(MakeConvexHullMeshTest, VolumeMesh) {
   // clang-format on
 
   const PolyMesh dut = MakeConvexHull(
-      FindResourceOrThrow("drake/geometry/test/one_tetrahedron.vtk"), scale);
+      FindPathOrThrow("drake/geometry/test/one_tetrahedron.vtk"), scale);
 
   MeshesAreEquivalent(dut, expected, 1e-14);
 }
@@ -361,12 +368,12 @@ GTEST_TEST(MakeConvexHullMeshTest, GltfMesh) {
   const fs::path dir_path(temp_directory());
 
   const fs::path bin_source =
-      FindResourceOrThrow("drake/geometry/test/cube_with_hole.bin");
+      FindPathOrThrow("drake/geometry/test/cube_with_hole.bin");
   const fs::path bin_target = dir_path / bin_source.filename();
   fs::copy_file(bin_source, bin_target);
 
   const fs::path gltf_source =
-      FindResourceOrThrow("drake/geometry/test/cube_with_hole.gltf");
+      FindPathOrThrow("drake/geometry/test/cube_with_hole.gltf");
   const fs::path gltf_target = dir_path / gltf_source.filename();
   {
     std::ifstream in_gltf(gltf_source);
@@ -452,7 +459,7 @@ GTEST_TEST(MakeConvexHullMeshTest, DegenerateMeshes) {
   };
 
   // Too few vertices
-  const std::string too_few_obj = make_obj("too_few.obj", R"""(# Generated
+  const fs::path too_few_obj = make_obj("too_few.obj", R"""(# Generated
   v 0 0 0
   v 0 1 1
   f 1 1 2
@@ -462,7 +469,7 @@ GTEST_TEST(MakeConvexHullMeshTest, DegenerateMeshes) {
       ".*fewer than three vertices; found 2 .*too_few.obj.");
 
   // Coincident points
-  const std::string coincident_obj = make_obj("coincident.obj", R"""(# Generated
+  const fs::path coincident_obj = make_obj("coincident.obj", R"""(# Generated
   v 0 0 0
   v 9e-13 0 0
   v 0 9e-13 0
@@ -475,7 +482,7 @@ GTEST_TEST(MakeConvexHullMeshTest, DegenerateMeshes) {
   EXPECT_NO_THROW(MakeConvexHull(coincident_obj, 2));
 
   // Colinear points.
-  const std::string colinear_obj = make_obj("colinear.obj", R"""(# Generated
+  const fs::path colinear_obj = make_obj("colinear.obj", R"""(# Generated
   v 0 0 0
   v -1 0 0
   v 1 0 0
@@ -501,18 +508,14 @@ GTEST_TEST(MakeConvexHullMeshTest, NonZeroMargin) {
   const PolyMesh expected = MakeCube(scale + margin);
 
   const PolyMesh dut = MakeConvexHull(
-      FindResourceOrThrow("drake/geometry/test/cube_with_hole.obj"), scale,
-      margin);
+      FindPathOrThrow("drake/geometry/test/cube_with_hole.obj"), scale, margin);
 
   MeshesAreEquivalent(dut, expected, 1e-14);
 }
 
-// This test is sensitive to the OrderPolyVertices() function in ways the
-// previous tests are not, therefore providing greater test coverage.
-GTEST_TEST(MakeConvexHullMeshTest, TetrahedronWithMargin) {
-  const double margin = 0.01;
-  const double scale = 2.0;
-
+// Create a polygon mesh which is the equivalent of the tet defined in
+// one_tetrahedron.vtk, but with the faces offset by the given margin.
+PolyMesh GetTetrahedronWithMargin(double scale, double margin) {
   // We look at the one tilted face on the original mesh.
   Vector3d c(scale / 3.0, scale / 3.0, scale / 3.0);  // Face's centroid.
   const double d = c.norm();                          // Distance to the origin.
@@ -530,7 +533,7 @@ GTEST_TEST(MakeConvexHullMeshTest, TetrahedronWithMargin) {
   // one_tetrahedron.vtk.
 
   // clang-format off
-  const PolyMesh expected({
+  return PolyMesh({
       3, 0, 1, 3,
       3, 0, 2, 1,
       3, 0, 3, 2,
@@ -542,12 +545,68 @@ GTEST_TEST(MakeConvexHullMeshTest, TetrahedronWithMargin) {
       Vector3d(-margin, -margin,  length)
     });
   // clang-format on
+}
 
-  const PolyMesh dut = MakeConvexHull(
-      FindResourceOrThrow("drake/geometry/test/one_tetrahedron.vtk"), scale,
-      margin);
+// This test is sensitive to the OrderPolyVertices() function in ways the
+// previous tests are not, therefore providing greater test coverage.
+GTEST_TEST(MakeConvexHullMeshTest, TetrahedronWithMargin) {
+  const double kMargin = 0.01;
+  const double kScale = 2.0;
+
+  // Create an inflated surface mesh corresponding to the tet in
+  // one_tetrahedron.vtk.
+  const PolyMesh expected = GetTetrahedronWithMargin(kScale, kMargin);
+
+  const PolyMesh dut =
+      MakeConvexHull(FindPathOrThrow("drake/geometry/test/one_tetrahedron.vtk"),
+                     kScale, kMargin);
 
   MeshesAreEquivalent(dut, expected, 1e-14);
+}
+
+/* Simple regression test against passing a MeshSource to MakeConvexHull
+ directly. The core functionality has already been tested above. */
+GTEST_TEST(MakeConvexHullMeshTest, MakeFromMeshSource) {
+  const double kScale = 2.0;
+  const double kMargin = 1.0;
+  // The box in box.obj has edge length of 2 m. We'll scale it by s = kScale and
+  // then inflate it δ = kMargin. The effective size will be 2s + 2δ. The cube
+  // is a scaled unit cube; so we need to scale by (2s + 2δ) / 2 = s + δ.
+  const fs::path box_path =
+      FindPathOrThrow("drake/geometry/render/test/meshes/box.obj");
+  const MeshSource obj_source(InMemoryMesh{MemoryFile::Make(box_path)});
+  const PolyMesh expected_box = MakeCube(kScale + kMargin);
+
+  // The tet in one_tetrahedron.vtk has vertices at origin and unit positions
+  // along all axes.
+  const fs::path tet_path =
+      FindPathOrThrow("drake/geometry/test/one_tetrahedron.vtk");
+  const MeshSource vtk_source(InMemoryMesh{MemoryFile::Make(tet_path)});
+  const PolyMesh expected_tet = GetTetrahedronWithMargin(kScale, kMargin);
+
+  struct TestCase {
+    const MeshSource* mesh_source{};
+    const PolyMesh* expected_mesh{};
+    std::string_view description;
+  };
+
+  std::vector<TestCase> test_cases{{&obj_source, &expected_box, "Valid obj"},
+                                   {&vtk_source, &expected_tet, "Valid vtk"}};
+  for (const TestCase& test_case : test_cases) {
+    SCOPED_TRACE(test_case.description);
+    const PolyMesh dut =
+        MakeConvexHull(*test_case.mesh_source, kScale, kMargin);
+    MeshesAreEquivalent(dut, *test_case.expected_mesh, 1e-14);
+  }
+
+  // Unsupported extension.
+  {
+    SCOPED_TRACE("Unsupported extension");
+    const MeshSource bad_source(InMemoryMesh{MemoryFile::Make(
+        FindPathOrThrow("drake/geometry/render/test/meshes/box.obj.mtl"))});
+    DRAKE_EXPECT_THROWS_MESSAGE(MakeConvexHull(bad_source, kScale, kMargin),
+                                ".*unsupported extension '.mtl'.*");
+  }
 }
 
 }  // namespace

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -643,6 +643,14 @@ GTEST_TEST(ShapeTest, ConvexFromMemory) {
   EXPECT_EQ(from_source.source().in_memory().mesh_file.filename_hint(),
             mesh_name);
   EXPECT_EQ(from_source.scale(), 3);
+
+  // Also confirm that we can compute the convex hull from the in-memory
+  // representation. We don't test all file formats; we trust that visual
+  // inspection of the code under test shows that it doesn't depend on file
+  // format.
+  const PolygonSurfaceMesh<double>& hull = convex.GetConvexHull();
+  EXPECT_EQ(hull.num_vertices(), 8);
+  EXPECT_EQ(hull.num_elements(), 6);
 }
 
 GTEST_TEST(ShapeTest, MeshFromMemory) {
@@ -675,6 +683,14 @@ GTEST_TEST(ShapeTest, MeshFromMemory) {
   EXPECT_EQ(from_source.source().in_memory().mesh_file.filename_hint(),
             mesh_name);
   EXPECT_EQ(from_source.scale(), 3);
+
+  // Also confirm that we can compute the convex hull from the in-memory
+  // representation. We don't test all file formats; we trust that visual
+  // inspection of the code under test shows that it doesn't depend on file
+  // format.
+  const PolygonSurfaceMesh<double>& hull = mesh.GetConvexHull();
+  EXPECT_EQ(hull.num_vertices(), 8);
+  EXPECT_EQ(hull.num_elements(), 6);
 }
 
 class DefaultReifierTest : public ShapeReifier, public ::testing::Test {};
@@ -832,7 +848,7 @@ GTEST_TEST(ShapeTest, Volume) {
 
   const std::string non_obj = "only_extension_matters.not_obj";
   DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Convex(non_obj)),
-                              ".*only applies to obj, vtk.*");
+                              ".*only applies to .obj, .vtk.*");
   // We only support obj but should eventually support vtk.
   DRAKE_EXPECT_THROWS_MESSAGE(CalcVolume(Mesh(non_obj)),
                               ".*only supports .obj files.*");


### PR DESCRIPTION
Implementation of making the convex hull mesh updates based on mesh file extension:
  - .obj: Make use of ReadObj based on MeshSource.
  - .vtk: Make use of ReadVtkToVolumeMesh based on MeshSource.
  - .gltf: deferred to next PR.

The soft hydro Convex shape makes use of this to inflate the convex shape.

Relates #15263.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21945)
<!-- Reviewable:end -->
