### PR TITLE
Add utility for working with glTF files

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -46,6 +46,7 @@ drake_cc_package_library(
         ":meshcat_visualizer_params",
         ":proximity_engine",
         ":proximity_properties",
+        ":read_gltf_to_memory",
         ":read_obj",
         ":rgba",
         ":scene_graph",
@@ -281,6 +282,21 @@ drake_cc_library(
         "//common:file_source",
         "//common:memory_file",
         "//common:string_container",
+    ],
+)
+
+drake_cc_library(
+    name = "read_gltf_to_memory",
+    srcs = ["read_gltf_to_memory.cc"],
+    hdrs = ["read_gltf_to_memory.h"],
+    deps = [
+        ":in_memory_mesh",
+    ],
+    implementation_deps = [
+        "//common:file_source",
+        "//common:memory_file",
+        "//common:string_container",
+        "@nlohmann_internal//:nlohmann",
     ],
 )
 
@@ -964,6 +980,20 @@ drake_cc_googletest(
     name = "in_memory_mesh_test",
     deps = [
         ":in_memory_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "read_gltf_to_memory_test",
+    data = [
+        "//geometry:test_gltf_files",
+        "//geometry/render:test_models",
+    ],
+    deps = [
+        ":read_gltf_to_memory",
+        "//common:find_resource",
+        "//common:temp_directory",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/read_gltf_to_memory.cc
+++ b/geometry/read_gltf_to_memory.cc
@@ -1,0 +1,57 @@
+#include "drake/geometry/read_gltf_to_memory.h"
+
+#include <string>
+#include <utility>
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include "drake/common/file_source.h"
+#include "drake/common/string_map.h"
+
+namespace drake {
+namespace geometry {
+
+using nlohmann::json;
+
+namespace {
+
+void AddFilesFromUris(const std::filesystem::path& gltf_path, const json& gltf,
+                      std::string_view array_name,
+                      string_map<FileSource>* supporting_files) {
+  if (!gltf.contains(array_name)) return;
+  auto& array = gltf[array_name];
+  for (size_t i = 0; i < array.size(); ++i) {
+    auto& item = array[i];
+    if (item.contains("uri") && item["uri"].is_string()) {
+      const std::string_view uri = item["uri"].template get<std::string_view>();
+      if (uri.substr(0, 5) == "data:") {
+        continue;
+      }
+      supporting_files->emplace(uri, gltf_path.parent_path() / uri);
+    }
+  }
+}
+
+}  // namespace
+
+InMemoryMesh ReadGltfToMemory(const std::filesystem::path& gltf_path) {
+  auto gltf_file = MemoryFile::Make(gltf_path);
+
+  string_map<FileSource> supporting_files;
+  json gltf;
+  try {
+    gltf = json::parse(gltf_file.contents());
+  } catch (const json::exception& e) {
+    throw std::runtime_error(
+        fmt::format("Error parsing the glTF file '{}': {}.",
+                    gltf_path.string(), e.what()));
+  }
+  AddFilesFromUris(gltf_path, gltf, "buffers", &supporting_files);
+  AddFilesFromUris(gltf_path, gltf, "images", &supporting_files);
+
+  return InMemoryMesh{std::move(gltf_file), std::move(supporting_files)};
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/read_gltf_to_memory.h
+++ b/geometry/read_gltf_to_memory.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <filesystem>
+
+#include "drake/geometry/in_memory_mesh.h"
+
+namespace drake {
+namespace geometry {
+
+/** Given a file path to a .gltf file, loads the .gltf file contents into
+ memory. All named .bin and image files are loaded into its supporting files as
+ path-valued FileSource instances (i.e., absolute paths for the external files
+ are included).
+
+Note: the path-valued supporting files are not validated with respect to their
+accessibility or even their existence. */
+InMemoryMesh ReadGltfToMemory(const std::filesystem::path& gltf_path);
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/read_gltf_to_memory_test.cc
+++ b/geometry/test/read_gltf_to_memory_test.cc
@@ -1,0 +1,67 @@
+#include "drake/geometry/read_gltf_to_memory.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+namespace fs = std::filesystem;
+
+GTEST_TEST(PreParseGltfTest, WithImages) {
+  const fs::path gltf_path = FindResourceOrThrow(
+      "drake/geometry/render/test/meshes/fully_textured_pyramid.gltf");
+
+  const InMemoryMesh mesh = ReadGltfToMemory(gltf_path);
+  EXPECT_EQ(mesh.supporting_files.size(), 9);
+  for (const auto& file :
+       {"fully_textured_pyramid_emissive.png",
+        "fully_textured_pyramid_normal.png", "fully_textured_pyramid_omr.png",
+        "fully_textured_pyramid_base_color.png",
+        "fully_textured_pyramid_emissive.ktx2",
+        "fully_textured_pyramid_normal.ktx2", "fully_textured_pyramid_omr.ktx2",
+        "fully_textured_pyramid_base_color.ktx2",
+        "fully_textured_pyramid.bin"}) {
+    ASSERT_TRUE(mesh.supporting_files.contains(file));
+    // It's a path-valued FileSource.
+    const FileSource& source = mesh.supporting_files.at(std::string(file));
+    const auto* path = std::get_if<fs::path>(&source);
+    ASSERT_NE(path, nullptr);
+    EXPECT_EQ(*path, gltf_path.parent_path() / file);
+  }
+}
+
+// This glTF has no images (and no "images" array). Confirm it still works.
+GTEST_TEST(PreParseGltfTest, NoImageArray) {
+  const fs::path gltf_path =
+      FindResourceOrThrow("drake/geometry/test/cube_with_hole.gltf");
+
+  const InMemoryMesh mesh = ReadGltfToMemory(gltf_path);
+
+  EXPECT_EQ(mesh.supporting_files.size(), 1);
+  ASSERT_TRUE(mesh.supporting_files.contains("cube_with_hole.bin"));
+}
+
+GTEST_TEST(PreParseGltfTest, BadGltf) {
+  const fs::path dir = temp_directory();
+  const fs::path gltf_path = dir / "invalid.gltf";
+  {
+    std::ofstream file(gltf_path);
+    DRAKE_DEMAND(file.is_open());
+    file << "not valid json\n";
+  }
+
+  DRAKE_EXPECT_THROWS_MESSAGE(ReadGltfToMemory(gltf_path),
+                              ".*Error parsing the glTF file.*");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This converts a path to a glTF file into a fully-specified `InMemoryMesh` of same by chasing down the buffer and image references to external files and packing them into the in-memory mesh's supporting files.

Relates #15263.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21949)
<!-- Reviewable:end -->
