### PR TITLE
Planar scene graph visualizer updated

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -502,6 +502,7 @@ drake_py_unittest(
     name = "planar_scenegraph_visualizer_test",
     data = [
         "//examples/multibody/cart_pole:models",
+        "//geometry:test_obj_files",
         "@drake_models//:iiwa_description",
     ],
     deps = [


### PR DESCRIPTION
All "mesh"-type objects (Mesh and Convex) ultimately are represented by their convex hulls. This clarifies this fact. Furthermore, the logic for searching for an alternative mesh file has been updated to respect the MeshSource for the Mesh/Convex (we only search if the source was a path and not in-memory).

Relates #15263.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21950)
<!-- Reviewable:end -->
