### PR TITLE
Illustration supports in-memory meshes

### DIFF
--- a/bindings/pydrake/visualization/_meldis.py
+++ b/bindings/pydrake/visualization/_meldis.py
@@ -1,6 +1,7 @@
 # Remove once we have Python >= 3.10.
 from __future__ import annotations
 
+import base64
 import copy
 import hashlib
 import json
@@ -22,6 +23,7 @@ from drake import (
 )
 from pydrake.common import (
     configure_logging,
+    MemoryFile,
 )
 from pydrake.common.eigen_geometry import (
     Quaternion,
@@ -31,9 +33,11 @@ from pydrake.geometry import (
     Capsule,
     Cylinder,
     Ellipsoid,
+    InMemoryMesh,
     Mesh,
     Meshcat,
     MeshcatParams,
+    MeshSource,
     Rgba,
     Sphere,
     SurfaceTriangle,
@@ -103,6 +107,48 @@ class _Slider:
         return value, value_changed
 
 
+def _json_to_memory_file(json):
+    """Converts a json representation of a MemoryFile to an instance of
+    same."""
+    return MemoryFile(contents=base64.b64decode(json["contents"]),
+                      extension=json["extension"],
+                      filename_hint=json["filename_hint"])
+
+
+def _json_to_file_source(json):
+    """Converts the json representation of a file source to an instance of
+    same."""
+    if "path" in json:
+        return json["path"]
+    else:
+        return _json_to_memory_file(json)
+
+
+def _make_mesh_source_from_json(json_str):
+    """Given the json representation of a mesh, create a mesh source for it."""
+    # Generally, we assume that if it is legitimate json, then it is an
+    # an in-memory representation.
+    try:
+        payload = json.loads(json_str)
+    except json.JSONDecodeError as e:
+        _logger.warning(f"Received message with malformed json: {e}")
+        return None
+
+    if ("in_memory_mesh" not in payload
+            or "mesh_file" not in payload["in_memory_mesh"]):
+        _logger.warning("Received Mesh with unexpected json content")
+        return None
+
+    mesh_data = payload["in_memory_mesh"]
+    supporting_files = {}
+    for name, coded in mesh_data.get("supporting_files", {}).items():
+        supporting_files[name] = _json_to_file_source(coded)
+
+    return MeshSource(
+        InMemoryMesh(mesh_file=_json_to_memory_file(mesh_data["mesh_file"]),
+                     supporting_files=supporting_files))
+
+
 class _GeometryFileHasher:
     """Calculates a checksum of external file(s) referenced by geometry
     messages such as lcmt_viewer_load_robot or similar.
@@ -144,51 +190,76 @@ class _GeometryFileHasher:
         assert isinstance(message, lcmt_viewer_geometry_data)
         if (message.type == lcmt_viewer_geometry_data.MESH
                 and message.string_data):
-            self.on_mesh(Path(message.string_data))
+            self.on_mesh(message.string_data)
 
-    def on_mesh(self, path: Path):
-        assert isinstance(path, Path)
+    def on_mesh(self, string_data: str):
+        if string_data[0] == '{':
+            self.on_mesh_in_memory(string_data)
+        else:
+            self.on_mesh_from_disk(Path(string_data))
+
+    def on_mesh_in_memory(self, string_data: str):
+        json_str = string_data.encode()
+        source = _make_mesh_source_from_json(json_str)
+        if source is None:
+            # While the json won't produce a source that will instantiate
+            # geometry in the _ViewerApplet, we'll hash the contents of the
+            # json so that if it's corrected, we'll redraw on it.
+            self._hasher.update(json_str)
+            return
+
+        assert source.is_in_memory()
+
+        # Note: we only need to hash *supporting* files that are defined by
+        # their path. The main mesh file and all in-memory supporting files
+        # appear in the message body itself, and, as such, changes to that data
+        # gets detected *outside* of the hasher.
+        for file_source in source.in_memory().supporting_files.values():
+            if isinstance(file_source, Path):
+                self._read_file(file_source)
+
+    def on_mesh_from_disk(self, path: Path):
         # Hash the file contents, even if we don't know how to interpret it.
         content = self._read_file(path)
         if path.suffix.lower() == ".obj":
-            self.on_obj(path, content)
+            self.on_obj_from_disk(path, content)
         elif path.suffix.lower() == ".gltf":
-            self.on_gltf(path, content)
+            self.on_gltf_from_disk(path, content)
         else:
-            _logger.warn(f"Unsupported mesh file: '{path}'\n"
-                         "Update Meldis's hasher to trigger reloads on this "
-                         "kind of file.")
+            _logger.warning(f"Unsupported mesh file: '{path}'\n"
+                            "Update Meldis's hasher to trigger reloads on "
+                            "this kind of file.")
 
-    def on_obj(self, path: Path, content: bytes):
+    def on_obj_from_disk(self, path: Path, content: bytes):
         assert isinstance(path, Path)
         for mtl_names in re.findall(rb"^\s*mtllib\s+(.*?)\s*$", content,
                                     re.MULTILINE):
             for mtl_name in mtl_names.decode("utf-8").split():
-                self.on_mtl(path.parent / mtl_name)
+                self.on_mtl_from_disk(path.parent / mtl_name)
 
-    def on_mtl(self, path: Path):
+    def on_mtl_from_disk(self, path: Path):
         assert isinstance(path, Path)
         content = self._read_file(path)
         for tex_name in re.findall(rb"^\s*map_.*?\s+(\S+)\s*$", content,
                                    re.MULTILINE):
-            self.on_texture(path.parent / tex_name.decode("utf-8"))
+            self.on_texture_from_disk(path.parent / tex_name.decode("utf-8"))
 
-    def on_texture(self, path: Path):
+    def on_texture_from_disk(self, path: Path):
         assert isinstance(path, Path)
         self._read_file(path)
 
-    def on_gltf(self, path: Path, content: bytes):
+    def on_gltf_from_disk(self, path: Path, content: bytes):
         assert isinstance(path, Path)
         try:
             document = json.loads(content.decode(encoding="utf-8"))
         except json.JSONDecodeError:
-            _logger.warn(f"glTF file is not valid JSON: {path}")
+            _logger.warning(f"glTF file is not valid JSON: {path}")
             return
 
         # Handle the images
         for image in document.get("images", []):
             if not image.get("uri", "").startswith("data:"):
-                self.on_texture(path.parent / image["uri"])
+                self.on_texture_from_disk(path.parent / image["uri"])
 
         # Handle the .bin files.
         for buffer in document.get("buffers", []):
@@ -379,11 +450,18 @@ class _ViewerApplet:
             (a, b, c) = geom.float_data
             shape = Ellipsoid(a=a, b=b, c=c)
         elif geom.type == lcmt_viewer_geometry_data.MESH and geom.string_data:
-            # A mesh to be loaded from a file.
             (scale_x, scale_y, scale_z) = geom.float_data
-            filename = geom.string_data
             assert scale_x == scale_y and scale_y == scale_z
-            shape = Mesh(filename=filename, scale=scale_x)
+            if geom.string_data[0] == "{":
+                mesh_source = _make_mesh_source_from_json(geom.string_data)
+                if mesh_source is None:
+                    # Warning has already been emitted by _make_mesh_source...
+                    return (None, None, None)
+                shape = Mesh(source=mesh_source, scale=scale_x)
+            else:
+                # A mesh to be loaded from a file.
+                filename = geom.string_data
+                shape = Mesh(filename=filename, scale=scale_x)
         elif geom.type == lcmt_viewer_geometry_data.MESH:
             assert not geom.string_data
             shape = self._make_triangle_mesh(geom.float_data)
@@ -597,7 +675,8 @@ class _PointCloudApplet:
             # Throttle warning messages to one per channel.
             if channel not in self._already_warned_channel_names:
                 self._already_warned_channel_names.add(channel)
-                _logger.warn(f"Unsupported point cloud data from {channel}.")
+                _logger.warning(
+                    f"Unsupported point cloud data from {channel}.")
             return
 
         # Transform the raw data into an N x num_fields array.

--- a/examples/scene_graph/BUILD.bazel
+++ b/examples/scene_graph/BUILD.bazel
@@ -123,6 +123,7 @@ drake_cc_binary(
     deps = [
         ":solar_system",
         "//geometry:drake_visualizer",
+        "//geometry:meshcat_visualizer",
         "//geometry:scene_graph",
         "//lcm",
         "//systems/analysis:simulator",

--- a/examples/scene_graph/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/solar_system_run_dynamics.cc
@@ -1,7 +1,11 @@
+#include <memory>
+
 #include <gflags/gflags.h>
 
 #include "drake/examples/scene_graph/solar_system.h"
 #include "drake/geometry/drake_visualizer.h"
+#include "drake/geometry/meshcat.h"
+#include "drake/geometry/meshcat_visualizer.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
@@ -31,7 +35,12 @@ int do_main() {
   builder.Connect(solar_system->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(solar_system->source_id()));
 
+  // Note: we can't use AddDefaultVisualization() because we don't have a plant
+  // in the Diagram.
   geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph);
+  auto meshcat = std::make_shared<geometry::Meshcat>();
+  geometry::MeshcatVisualizer<double>::AddToBuilder(&builder, *scene_graph,
+                                                    meshcat);
 
   auto diagram = builder.Build();
 

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -147,6 +147,8 @@ drake_cc_library(
         "//lcm:drake_lcm",
         "//lcmtypes:viewer",
         "//systems/lcm:lcm_system_graphviz",
+        "@common_robotics_utilities",
+        "@nlohmann_internal//:nlohmann",
     ],
 )
 
@@ -558,6 +560,7 @@ drake_cc_library(
         ":scene_graph_inspector",
         ":shape_specification",
         "//common:essential",
+        "//common:memory_file",
         "//common:name_value",
         "//common:timer",
         "//geometry/proximity:triangle_surface_mesh",
@@ -882,12 +885,15 @@ drake_cc_googletest(
     data = ["//geometry/render:test_models"],
     deps = [
         ":drake_visualizer",
+        ":read_gltf_to_memory",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//lcm",
         "//lcmtypes:viewer",
         "//systems/analysis:simulator",
+        "@common_robotics_utilities",
+        "@nlohmann_internal//:nlohmann",
     ],
 )
 

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -7,8 +7,12 @@
 #include <utility>
 #include <vector>
 
+#include <common_robotics_utilities/base64_helpers.hpp>
+#include <nlohmann/json.hpp>
+
 #include "drake/common/default_scalars.h"
 #include "drake/common/extract_double.h"
+#include "drake/common/overloaded.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/value.h"
 #include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
@@ -80,16 +84,8 @@ lcmt_viewer_geometry_data MakeFacetedMeshDataForLcm(
 
   EigenMapView(geometry_data.color) = in_color.rgba().cast<float>();
 
-  // There are *two* ways to use the MESH geometry type. One is to set the
-  // string value with a path to a parseable mesh file (see
-  // ImplementGeometry(Mesh) below). The other is to leave the string empty and
-  // define the mesh in the float data as:
-  // V | T | v0 | v1 | ... vN | t0 | t1 | ... | tM
-  // where
-  //   V: The number of vertices.
-  //   T: The number of triangles.
-  //   N: 3V, the number of floating point values for the V vertices.
-  //   M: 3T, the number of vertex indices for the T triangles.
+  // Setting the mesh payload as an in-message triangle mesh (see
+  // lcmt_viewer_geometry_data.lcm for details).
   geometry_data.type = geometry_data.MESH;
 
   // TODO(SeanCurtis-TRI): It would be better if we could simply broadcast the
@@ -378,7 +374,44 @@ class ShapeToLcm : public ShapeReifier {
     geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
     geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
     geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
-    geometry_data_.string_data = mesh.filename();
+    const MeshSource& mesh_source = mesh.source();
+    if (mesh_source.is_path()) {
+      geometry_data_.string_data = mesh_source.path().string();
+    } else {
+      using nlohmann::json;
+      // Note: See lcmt_viewer_geometry_data.lcm for the explanation of this
+      // json encoding.
+      auto json_memory_file = [](const MemoryFile& file) {
+        json mesh_file_j;
+        mesh_file_j["filename_hint"] = file.filename_hint();
+        mesh_file_j["extension"] = file.extension();
+        std::vector<uint8_t> bytes(file.contents().begin(),
+                                   file.contents().end());
+        mesh_file_j["contents"] =
+            common_robotics_utilities::base64_helpers::Encode(bytes);
+        return mesh_file_j;
+      };
+
+      DRAKE_DEMAND(mesh_source.is_in_memory());
+      const InMemoryMesh& mem_mesh = mesh_source.in_memory();
+      json in_memory;
+      in_memory["in_memory_mesh"]["mesh_file"] =
+          json_memory_file(mem_mesh.mesh_file);
+
+      for (const auto& [name, file_source] : mem_mesh.supporting_files) {
+        in_memory["in_memory_mesh"]["supporting_files"][name] = std::visit(
+            overloaded{[](const std::filesystem::path& path) {
+                         json json_filesystem_file;
+                         json_filesystem_file["path"] = path.string();
+                         return json_filesystem_file;
+                       },
+                       [&json_memory_file](const MemoryFile& file) {
+                         return json_memory_file(file);
+                       }},
+            file_source);
+      }
+      geometry_data_.string_data = in_memory.dump();
+    }
   }
 
   void ImplementGeometry(const Sphere& sphere, void*) override {

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -325,10 +325,9 @@ class MeshcatShapeReifier : public ShapeReifier {
 
   using ShapeReifier::ImplementGeometry;
 
-  // Helper for ImplementGeometry, common to both Mesh and Convex shapes.
-  // The `extension` is lowercase and includes the leading dot (e.g., ".obj").
-  void ImplementMesh(const std::string& filename, const std::string& extension,
-                     double scale, void* data) {
+  // TODO(SeanCurtis-TRI): In follow up commit, move this down in alphabetical
+  // order.
+  void ImplementGeometry(const Mesh& mesh, void* data) override {
     DRAKE_DEMAND(data != nullptr);
     auto& output = *static_cast<Output*>(data);
     auto& lumped = output.lumped;
@@ -336,17 +335,31 @@ class MeshcatShapeReifier : public ShapeReifier {
     // meshes unless necessary.  Using the filename is tempting, but that leads
     // to problems when the file contents change on disk.
 
-    std::string format = extension;
+    std::string format = mesh.extension();
     format.erase(0, 1);  // remove the . from the extension
-    std::optional<std::string> maybe_mesh_data = ReadFile(filename);
-    if (!maybe_mesh_data) {
-      drake::log()->warn("Meshcat: Could not open mesh filename {}", filename);
-      return;
-    }
+
+    const MeshSource& mesh_source = mesh.source();
+
+    // Precompute the basedir which we'll only use if source.is_path().
+    const fs::path basedir_if_path =
+        mesh_source.is_path() ? mesh_source.path().parent_path() : fs::path();
 
     // We simply dump the binary contents of the file into the data field of the
-    // message.  The javascript meshcat takes care of the rest.
-    std::string mesh_data = std::move(*maybe_mesh_data);
+    // message. The javascript meshcat takes care of the rest, but first we
+    // need to acquire a copy -- either from a file or from an in-memory string.
+    std::string mesh_data;
+    if (mesh_source.is_path()) {
+      std::optional<std::string> maybe_mesh_data = ReadFile(mesh_source.path());
+      if (!maybe_mesh_data) {
+        drake::log()->warn("Meshcat: Could not open mesh filename {}",
+                           mesh_source.path().string());
+        return;
+      }
+      mesh_data = std::move(*maybe_mesh_data);
+    } else {
+      DRAKE_DEMAND(mesh_source.is_in_memory());
+      mesh_data = mesh_source.in_memory().mesh_file.contents();
+    }
 
     // TODO(russt): MeshCat.jl/src/mesh_files.jl loads dae with textures, also.
 
@@ -373,26 +386,40 @@ class MeshcatShapeReifier : public ShapeReifier {
       meshfile_object.format = std::move(format);
       meshfile_object.data = std::move(mesh_data);
 
-      std::string mtllib = matches.str(1);
+      const std::string mtllib = matches.str(1);
 
-      // Use filename path as the base directory for textures.
-      const std::filesystem::path basedir =
-          std::filesystem::path(filename).parent_path();
+      std::optional<std::string> maybe_mtl_data;
+      if (mesh_source.is_path()) {
+        DRAKE_DEMAND(!basedir_if_path.empty());
+        maybe_mtl_data = ReadFile(basedir_if_path / mtllib);
+      } else {
+        const auto mtl_iter =
+            mesh_source.in_memory().supporting_files.find(mtllib);
+        if (mtl_iter != mesh_source.in_memory().supporting_files.end()) {
+          maybe_mtl_data = std::visit<std::optional<std::string>>(
+              overloaded{[](const fs::path& path) {
+                           return ReadFile(path);
+                         },
+                         [](const MemoryFile& file) {
+                           return file.contents();
+                         }},
+              mtl_iter->second);
+        }
+      }
 
       // Read .mtl file into geometry.mtl_library.
-      if (std::optional<std::string> maybe_mtl_data =
-              ReadFile(basedir / mtllib)) {
+      if (maybe_mtl_data.has_value()) {
         meshfile_object.mtl_library = std::move(*maybe_mtl_data);
 
         // Scan .mtl file for map_ lines.  For each, load the file and add
         // the contents to geometry.resources.
         // The syntax (http://paulbourke.net/dataformats/mtl/) is e.g.
-        //   map_Ka -options args filename
-        // Here we ignore the options and only extract the filename (by
+        //   map_Ka -options args image_name
+        // Here we ignore the options and only extract the image_name (by
         // extracting the last word before the end of line/string).
         //  - "map_.+" matches the map_ plus any options,
-        //  - "\s" matches one whitespace (before the filename),
-        //  - "[^\s]+" matches the filename, and
+        //  - "\s" matches one whitespace (before the image_name),
+        //  - "[^\s]+" matches the image_name, and
         //  - "[$\r\n]" matches the end of string or end of line.
         // TODO(russt): This parsing could still be more robust.
         std::regex map_regex(R"""(map_.+\s([^\s]+)\s*[$\r\n])""");
@@ -400,32 +427,71 @@ class MeshcatShapeReifier : public ShapeReifier {
                                        meshfile_object.mtl_library.end(),
                                        map_regex);
              iter != std::sregex_iterator(); ++iter) {
-          std::string map = iter->str(1);
-          std::ifstream map_stream(basedir / map,
-                                   std::ios::binary | std::ios::ate);
-          if (map_stream.is_open()) {
-            int map_size = map_stream.tellg();
-            map_stream.seekg(0, std::ios::beg);
-            std::vector<uint8_t> map_data;
-            map_data.reserve(map_size);
-            map_data.assign(std::istreambuf_iterator<char>(map_stream),
-                            std::istreambuf_iterator<char>());
+          const std::string map = iter->str(1);
+          // The *possible* path to the texture image; non-empty if we need to
+          // read the image from disk.
+          fs::path maybe_map_path;
+          // We'll put the bytes of the available image in here.
+          std::vector<uint8_t> map_data;
+          if (mesh_source.is_in_memory()) {
+            const auto map_file_iter =
+                mesh_source.in_memory().supporting_files.find(map);
+            if (map_file_iter !=
+                mesh_source.in_memory().supporting_files.end()) {
+              // Load it.
+              std::visit(
+                  overloaded{
+                      [&maybe_map_path](const fs::path& path) {
+                        // Note: paths to supporting files in an in-memory mesh
+                        // have no "base directory". The path must be
+                        // sufficiently well defined so that it can be read
+                        // directly.
+                        maybe_map_path = path;
+                      },
+                      [&map_data](const MemoryFile& file) {
+                        map_data = std::vector<uint8_t>(file.contents().begin(),
+                                                        file.contents().end());
+                      }},
+                  map_file_iter->second);
+            }
+          } else {
+            DRAKE_DEMAND(mesh_source.is_path());
+            maybe_map_path = basedir_if_path / map;
+          }
+
+          // maybe_map_path is non-empty only if one of the paths above
+          // indicated the image is on disk.
+          if (!maybe_map_path.empty()) {
+            std::ifstream map_stream(maybe_map_path,
+                                     std::ios::binary | std::ios::ate);
+            if (map_stream.is_open()) {
+              int map_size = map_stream.tellg();
+              map_stream.seekg(0, std::ios::beg);
+              map_data.reserve(map_size);
+              map_data.assign(std::istreambuf_iterator<char>(map_stream),
+                              std::istreambuf_iterator<char>());
+            }
+          }
+
+          // Either we now have bytes for the map, or we had a look-up error.
+          if (map_data.size() > 0) {
             meshfile_object.resources.try_emplace(
                 map, std::string("data:image/png;base64,") +
                          common_robotics_utilities::base64_helpers::Encode(
                              map_data));
           } else {
             drake::log()->warn(
-                "Meshcat: Failed to load texture. \"{}\" references {}, but "
+                "Meshcat: Failed to load texture. \"{}\" references '{}', but "
                 "Meshcat could not open filename \"{}\"",
-                (basedir / mtllib).string(), map, (basedir / map).string());
+                (basedir_if_path / mtllib).string(), map,
+                maybe_map_path.string());
           }
         }
-      } else {
+      } else if (!mtllib.empty()) {
         drake::log()->warn(
-            "Meshcat: Failed to load texture. {} references {}, but Meshcat "
-            "could not open filename \"{}\"",
-            filename, mtllib, (basedir / mtllib).string());
+            "Meshcat: An obj referenced a material library '{}' that Meshcat "
+            "could not open; no materials will be included. Obj: '{}'.",
+            mtllib, mesh_source.description());
 
         // If we can't load the mtl file, we'll just send the obj file as if it
         // did not specify the mtl. MuJoCo often ships obj files that reference
@@ -437,7 +503,7 @@ class MeshcatShapeReifier : public ShapeReifier {
       }
     } else if (format == "gltf") {
       output.assets =
-          internal::UnbundleGltfAssets(filename, &mesh_data, &file_storage_);
+          internal::UnbundleGltfAssets(mesh_source, &mesh_data, &file_storage_);
       auto& meshfile_object =
           lumped.object.emplace<internal::MeshfileObjectData>();
       meshfile_object.uuid = uuid_generator_.GenerateRandom();
@@ -482,6 +548,7 @@ class MeshcatShapeReifier : public ShapeReifier {
     }
 
     // Set the scale.
+    const double scale = mesh.scale();
     std::visit<void>(
         overloaded{[](std::monostate) {},
                    [scale](auto& lumped_object) {
@@ -592,10 +659,6 @@ class MeshcatShapeReifier : public ShapeReifier {
     // TODO(russt): Use PlaneGeometry with fields width, height,
     // widthSegments, heightSegments
     drake::log()->warn("Meshcat does not display HalfSpace geometry (yet).");
-  }
-
-  void ImplementGeometry(const Mesh& mesh, void* data) override {
-    ImplementMesh(mesh.filename(), mesh.extension(), mesh.scale(), data);
   }
 
   void ImplementGeometry(const MeshcatCone& cone, void* data) override {
@@ -2661,7 +2724,7 @@ void Meshcat::SetProperty(std::string_view path, std::string property,
   }
 }
 
-void Meshcat::SetEnvironmentMap(const std::filesystem::path& image_path) {
+void Meshcat::SetEnvironmentMap(const fs::path& image_path) {
   const std::string_view property_path = "/Background/<object>";
   const std::string property_name = "environment_map";
   if (image_path.empty()) {

--- a/geometry/meshcat_internal.cc
+++ b/geometry/meshcat_internal.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/meshcat_internal.h"
 
+#include <functional>
 #include <stdexcept>
 #include <utility>
 
@@ -12,6 +13,7 @@
 #include "drake/common/drake_export.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/never_destroyed.h"
+#include "drake/common/overloaded.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {
@@ -79,14 +81,33 @@ std::string UuidGenerator::GenerateRandom() {
 
 namespace {
 
+// The result of loading a URI: the URI's contents (maybe) and a description.
+struct UriLoadResult{
+  // The contents of a requested Uri. May be null if the URI could not be
+  // successfully read.
+  std::optional<std::string> contents;
+
+  // A uri-loader-dependent description of the URI to use in messaging to the
+  // user.
+  std::string description;
+};
+
+// The function that attempts to load a URI.
+using UriLoader = std::function<UriLoadResult(std::string_view)>;
+
 // Load the given `uri` into `storage` and returns the storage handle.
 // On error, returns nullptr.
-// @param gltf_filename Only used for debugging and error messages.
 // @param array_hint The place where this URI occurred, e.g., "buffers[1]".
 //  Only used for debugging and error messages.
-std::shared_ptr<const MemoryFile> LoadGltfUri(
-    const fs::path& gltf_filename, std::string_view array_hint,
-    std::string_view uri, FileStorage* storage) {
+// @param uri_loader The function that attempts to read the file contents
+//  associated with the given `uri`.
+// @param description User-friendly string describing the glTF file the URI
+//  comes from. Only used for debugging and error messages.
+std::shared_ptr<const MemoryFile> LoadGltfUri(std::string_view array_hint,
+                                              std::string_view uri,
+                                              FileStorage* storage,
+                                              const UriLoader& uri_loader,
+                                              const std::string& description) {
   DRAKE_DEMAND(storage != nullptr);
   if (uri.substr(0, 5) == "data:") {
     constexpr std::string_view needle = ";base64,";
@@ -94,11 +115,13 @@ std::shared_ptr<const MemoryFile> LoadGltfUri(
     if (pos == std::string_view::npos) {
       log()->warn(
           "Meshcat ignoring malformed data URI while loading {} from '{}'",
-          array_hint, gltf_filename.string());
+          array_hint, description);
       return nullptr;
     }
     // TODO(jwnimmer-tri) Save the media type to http-serve later on.
-    // For now, we'll just skip ahead to the actual content.
+    // For now, we'll just skip ahead to the actual content. Note: for a data
+    // URI, glTF requires the mime type be specified. It's optional for a file
+    // URI and, if absent, we'd have to rely on the file URI's extension.
     std::string_view base64_content = uri.substr(pos + needle.size());
     // TODO(jwnimmer-tri) Use a decoder with a better types, to avoid all of
     // these extra copies.
@@ -108,38 +131,76 @@ std::shared_ptr<const MemoryFile> LoadGltfUri(
     std::string decoded(reinterpret_cast<const char*>(decoded_vec.data()),
                         decoded_vec.size());
     std::string filename_hint =
-        fmt::format("{} from {}", array_hint, gltf_filename.string());
+        fmt::format("{} from {}", array_hint, description);
     return storage->Insert(std::move(decoded), std::move(filename_hint));
   } else {
     // Not a data URI, so it must be a relative path.
-    fs::path asset_filename = gltf_filename.parent_path() / uri;
-    std::optional<std::string> asset_data = ReadFile(asset_filename);
-    if (!asset_data) {
+    UriLoadResult asset_data = uri_loader(uri);
+    if (!asset_data.contents.has_value()) {
       log()->warn(
-          "Meshcat could not open '{}' while loading {} from '{}'",
-          asset_filename.string(), array_hint, gltf_filename.string());
+          "Meshcat could not get data for the named uri '{}' while loading {} "
+          "from '{}'",
+          uri, array_hint, description);
       return nullptr;
     }
-    return storage->Insert(std::move(*asset_data), asset_filename.string());
+    return storage->Insert(std::move(*asset_data.contents),
+                           std::move(asset_data.description));
   }
 }
 
 }  // namespace
 
 std::vector<std::shared_ptr<const MemoryFile>> UnbundleGltfAssets(
-    const fs::path& gltf_filename, std::string* gltf_contents,
+    const MeshSource& mesh_source, std::string* gltf_contents,
     FileStorage* storage) {
   DRAKE_DEMAND(gltf_contents != nullptr);
   DRAKE_DEMAND(storage != nullptr);
   std::vector<std::shared_ptr<const MemoryFile>> assets;
+
   json gltf;
   try {
     gltf = json::parse(*gltf_contents);
   } catch (const json::exception& e) {
     log()->warn("Meshcat could not unbundle '{}': glTF parse error: {}",
-                gltf_filename.string(), e.what());
+                mesh_source.description(), e.what());
     return assets;
   }
+
+  // Resolving URIs depends on where the glTF specification resides.
+  UriLoader uri_loader;
+  if (mesh_source.is_path()) {
+    uri_loader = [gltf_dir =
+                      mesh_source.path().parent_path()](std::string_view uri) {
+      const fs::path uri_path = gltf_dir / uri;
+      return UriLoadResult{ReadFile(uri_path), uri_path.string()};
+    };
+  } else {
+    DRAKE_DEMAND(mesh_source.is_in_memory());
+    uri_loader = [&memory_mesh = mesh_source.in_memory()](
+                     std::string_view uri) -> UriLoadResult {
+      const std::string description =
+          fmt::format("glTF '{}' supporting file with uri '{}'",
+                      memory_mesh.mesh_file.filename_hint(), uri);
+      std::optional<std::string> contents;
+
+      const auto file_source_iter = memory_mesh.supporting_files.find(uri);
+      if (file_source_iter != memory_mesh.supporting_files.end()) {
+        contents = std::visit<std::optional<std::string>>(overloaded{
+          [](const fs::path& path) {
+            // Either uri is absolute or meaningful w.r.t. cwd, otherwise, we'll
+            // respond appropriately to an otherwise unavailable uri.
+            return ReadFile(path);
+          },
+          [](const MemoryFile& file) {
+            return file.contents();
+          }},
+          file_source_iter->second);
+      }
+
+      return {std::move(contents), description};
+    };
+  }
+
   // In glTF 2.0, URIs can only appear in two places:
   //  "images": [ { "uri": "some.png" } ]
   //  "buffers": [ { "uri": "some.bin", "byteLength": 1024 } ]
@@ -152,8 +213,8 @@ std::vector<std::shared_ptr<const MemoryFile>> UnbundleGltfAssets(
         const std::string_view uri =
             item["uri"].template get<std::string_view>();
         const std::string array_hint = fmt::format("{}[{}]", array_name, i);
-        std::shared_ptr<const MemoryFile> asset =
-            LoadGltfUri(gltf_filename, array_hint, uri, storage);
+        std::shared_ptr<const MemoryFile> asset = LoadGltfUri(
+            array_hint, uri, storage, uri_loader, mesh_source.description());
         if (asset != nullptr) {
           item["uri"] = FileStorage::GetCasUrl(*asset);
           assets.push_back(std::move(asset));
@@ -169,8 +230,8 @@ std::vector<std::shared_ptr<const MemoryFile>> UnbundleGltfAssets(
 }
 
 template <typename T>
-std::string TransformGeometryName(
-    GeometryId geom_id, const SceneGraphInspector<T>& inspector) {
+std::string TransformGeometryName(GeometryId geom_id,
+                                  const SceneGraphInspector<T>& inspector) {
   std::string geometry_name = inspector.GetName(geom_id);
   size_t pos = 0;
   while ((pos = geometry_name.find("::", pos)) != std::string::npos) {

--- a/geometry/meshcat_internal.h
+++ b/geometry/meshcat_internal.h
@@ -61,19 +61,24 @@ When a glTF file has relative path URIs (i.e., unbundled files on disk), this
 loads the files into FileStorage so that we can serve them later, even if the
 original file has disappeared in the meantime.
 
-@param[in] gltf_filename The glTF filename, used to calculate relative paths.
+@param[in] mesh_source The MeshSource for the given glTF, used to resolve file
+  URIs used in the `gltf_contents`. The actual contents of
+  `source.in_memory().mesh_file` will _not_ be used; `gltf_contents` takes
+  precedence, but is expected to be a copy of the source's glTF file contents.
 
-@param[in,out] gltf_contents The contents of `gltf_filename`. It will be edited
-  in place to replace the URIs. (We assume that the caller has already read the
-  file into a string, so here we can just operate on that string as an [in,out]
-  parameter instead of re-reading the file and using an output-only parameter.)
+@param[in,out] gltf_contents The glTF data named in `mesh_source`. It will be
+  edited in place to replace the URIs. (We assume that the caller has created
+  this as a unique, editable copy of the glTF data, whether from on-disk or
+  in-memory, so here we can just operate on that string as an [in,out]
+  parameter.)
 
 @param[in,out] storage The database where assets should be stored.
 
 @returns The handles for all assets cited by `gltf_contents`. */
 [[nodiscard]] std::vector<std::shared_ptr<const MemoryFile>>
-UnbundleGltfAssets(const std::filesystem::path& gltf_filename,
-                   std::string* gltf_contents, FileStorage* storage);
+UnbundleGltfAssets(
+    const MeshSource& mesh_source, std::string* gltf_contents,
+    FileStorage* storage);
 
 /* Converts a geometry name into a meshcat path. So, a geometry named
 `my_scope::Mesh` becomes my_scope/Mesh.

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -1,22 +1,27 @@
 #include "drake/geometry/drake_visualizer.h"
 
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include <common_robotics_utilities/base64_helpers.hpp>
 #include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/unused.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/kinematics_vector.h"
 #include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/read_gltf_to_memory.h"
 #include "drake/geometry/rgba.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
@@ -76,6 +81,9 @@ class DrakeVisualizerTester {
 };
 
 namespace {
+
+namespace fs = std::filesystem;
+
 /* Collection of data for reporting what is waiting in the LCM queue.  */
 struct MessageResults {
   int num_load{};
@@ -366,13 +374,35 @@ class DrakeVisualizerTest : public ::testing::Test {
    @param role         The role to assign to the test geometry -- should be
                        either kIllustrated or kProximity.
    @param expect_hull  If true, we expect the MeshType with the given `role`
-                       to be represented by its convex hull. */
+                       to be represented by its convex hull.
+   @param in_memory    If true, the mesh will be specified using in-memory
+                       resources. */
   template <typename MeshType>
-  void ExpectMeshInMessage(Role role, bool expect_hull) {
-    auto mesh = make_unique<MeshType>(
-        FindResourceOrThrow("drake/geometry/render/test/meshes/"
-                            "fully_textured_pyramid.gltf"));
-    SCOPED_TRACE(fmt::format("{} shape with {} role", mesh->type_name(), role));
+  void ExpectMeshInMessage(Role role, bool expect_hull,
+                           bool in_memory = false) {
+    std::unique_ptr<MeshType> mesh;
+    const std::string gltf_path = FindResourceOrThrow(
+        "drake/geometry/render/test/meshes/fully_textured_pyramid.gltf");
+
+    // The names of two supporting files. We'll poke the results by examining
+    // each of these two files when the Mesh is defined in memory.
+    const std::string kSupportingPngAsPath("fully_textured_pyramid_omr.png");
+    const std::string kSupportingPngAsMemory(
+        "fully_textured_pyramid_normal.png");
+
+    if (in_memory) {
+      InMemoryMesh mesh_data = ReadGltfToMemory(fs::path(gltf_path));
+      mesh_data.supporting_files[kSupportingPngAsMemory] =
+          MemoryFile::Make(std::get<fs::path>(
+              mesh_data.supporting_files[kSupportingPngAsMemory]));
+      mesh = make_unique<MeshType>(std::move(mesh_data));
+    } else {
+      mesh = make_unique<MeshType>(gltf_path);
+    }
+
+    SCOPED_TRACE(fmt::format("{} {} shape with {} role",
+                             in_memory ? "in-memory" : "on-disk",
+                             mesh->type_name(), role));
     this->ConfigureDiagram({.role = role});
 
     const FrameId f_id = this->scene_graph_->RegisterFrame(
@@ -381,7 +411,7 @@ class DrakeVisualizerTest : public ::testing::Test {
     const RigidTransformd X_PC(Vector3d(-1, 2, -3));
     const GeometryId g_id = this->scene_graph_->RegisterGeometry(
         this->pose_source_id_, f_id,
-        make_unique<GeometryInstance>(X_PC, std::move(mesh), "test"));
+        make_unique<GeometryInstance>(X_PC, mesh->Clone(), "test"));
 
     // We assign a diffuse color, because we expect it to come through when
     // `expect_hull` is true.
@@ -450,8 +480,64 @@ class DrakeVisualizerTest : public ::testing::Test {
       EXPECT_TRUE(CompareMatrices(X_PC.GetAsMatrix34(),
                                   X_PG_test.GetAsMatrix34(), 1e-7));
     } else {
-      EXPECT_THAT(geo_message.string_data,
-                  ::testing::HasSubstr("fully_textured_pyramid.gltf"));
+      if (in_memory) {
+        EXPECT_FALSE(geo_message.string_data.empty());
+        nlohmann::json json_root =
+            nlohmann::json::parse(geo_message.string_data);
+        ASSERT_TRUE(json_root.contains("in_memory_mesh"));
+        const auto& json_mesh = json_root["in_memory_mesh"];
+        ASSERT_TRUE(json_mesh.contains("mesh_file"));
+        ASSERT_TRUE(json_mesh["mesh_file"].contains("contents"));
+        ASSERT_TRUE(json_mesh["mesh_file"].contains("extension"));
+        ASSERT_TRUE(json_mesh["mesh_file"].contains("filename_hint"));
+        // Contents is a valid base64-encoded glTF file.
+        auto gltf_base64 =
+            json_mesh["mesh_file"]["contents"].get<std::string_view>();
+        const std::vector<uint8_t> decoded_gltf =
+            common_robotics_utilities::base64_helpers::Decode(
+                std::string{gltf_base64});
+        std::string gltf_content(
+            reinterpret_cast<const char*>(decoded_gltf.data()),
+            decoded_gltf.size());
+        EXPECT_FALSE(gltf_content.empty());
+        EXPECT_NO_THROW(unused(nlohmann::json::parse(gltf_content)));
+        EXPECT_EQ(json_mesh["mesh_file"]["extension"].get<std::string_view>(),
+                  mesh->source().extension());
+        EXPECT_EQ(
+            json_mesh["mesh_file"]["filename_hint"].get<std::string_view>(),
+            mesh->source().in_memory().mesh_file.filename_hint());
+
+        ASSERT_TRUE(json_mesh.contains("supporting_files"));
+        const nlohmann::json& files = json_mesh["supporting_files"];
+
+        // We won't explore *all* of the supporting files. We'll poke one that
+        // should be encoded as a path, and the other as a MemoryFile.
+        ASSERT_TRUE(files.contains(kSupportingPngAsPath));
+        ASSERT_TRUE(files[kSupportingPngAsPath].contains("path"));
+        EXPECT_EQ(
+            files[kSupportingPngAsPath]["path"].get<std::string_view>(),
+            std::get<fs::path>(mesh->source().in_memory().supporting_files.at(
+                kSupportingPngAsPath)));
+
+        ASSERT_TRUE(files.contains(kSupportingPngAsMemory));
+        const nlohmann::json& mem_file = files[kSupportingPngAsMemory];
+        EXPECT_EQ(mem_file["extension"].get<std::string_view>(), ".png");
+        EXPECT_TRUE(mem_file["filename_hint"].get<std::string_view>().ends_with(
+            kSupportingPngAsMemory));
+        const auto emissive_64 = mem_file["contents"].get<std::string_view>();
+        // We'll confirm that the contents indicate an encoded png.
+        const std::vector<uint8_t> decoded_png =
+            common_robotics_utilities::base64_helpers::Decode(
+                std::string{emissive_64});
+        // See http://www.libpng.org/pub/png/spec/1.2/PNG-Structure.html.
+        uint8_t kPngHeader[] = {137, 80, 78, 71, 13, 10, 26, 10};
+        for (int i = 0; i < 8; ++i) {
+          ASSERT_EQ(decoded_png[i], kPngHeader[i]);
+        }
+      } else {
+        EXPECT_THAT(geo_message.string_data,
+                    ::testing::HasSubstr("fully_textured_pyramid.gltf"));
+      }
     }
     /* We don't care about the draw message. */
   }
@@ -1191,6 +1277,12 @@ TYPED_TEST(DrakeVisualizerTest, ConvexIsHullAlways) {
                                              /* expect_hull = */ true);
   this->template ExpectMeshInMessage<Convex>(Role::kIllustration,
                                              /* expect_hull = */ true);
+  this->template ExpectMeshInMessage<Convex>(Role::kProximity,
+                                             /* expect_hull = */ true,
+                                             /* in_memory = */ true);
+  this->template ExpectMeshInMessage<Convex>(Role::kIllustration,
+                                             /* expect_hull = */ true,
+                                             /* in_memory = */ true);
 }
 
 /* This confirms that DrakeVisualizer dispatches a faceted convex hull for
@@ -1200,6 +1292,18 @@ TYPED_TEST(DrakeVisualizerTest, MeshIsHullForProximity) {
                                            /* expect_hull = */ true);
   this->template ExpectMeshInMessage<Mesh>(Role::kIllustration,
                                            /* expect_hull = */ false);
+}
+
+/* When a Mesh contains an in-memory representations, confirm that it encodes
+ as the expected json. */
+TYPED_TEST(DrakeVisualizerTest, InMemoryMesh) {
+  this->template ExpectMeshInMessage<Mesh>(Role::kProximity,
+                                           /* expect_hull = */ true,
+                                           /* in_memory = */ true);
+
+  this->template ExpectMeshInMessage<Mesh>(Role::kIllustration,
+                                           /* expect_hull = */ false,
+                                           /* in_memory = */ true);
 }
 
 /* Tests the AddToBuilder method that connects directly to a provided SceneGraph

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <thread>
@@ -35,12 +36,65 @@ using Eigen::Vector3d;
 using math::RigidTransformd;
 using math::RotationMatrixd;
 
+namespace fs = std::filesystem;
+
 // Returns an offset pointer inside message that skips over leading newlines.
 const char* ltrim(const char* message) {
   while (*message == '\n') {
     ++message;
   }
   return message;
+}
+
+// Loads the textured cuboctahedron with hole into an in-memory Mesh.
+Mesh GetCuboctahedronInMemory(double scale) {
+  const fs::path obj_path = FindResourceOrThrow(
+      "drake/examples/scene_graph/cuboctahedron_with_hole.obj");
+  const fs::path obj_dir = obj_path.parent_path();
+  string_map<FileSource> supporting_files;
+  for (const auto* f : {"cuboctahedron_with_hole.mtl", "rainbow_checker.png"}) {
+    supporting_files.emplace(f, MemoryFile::Make(std::move(obj_dir / f)));
+  }
+  return Mesh(
+      InMemoryMesh{MemoryFile::Make(obj_path), std::move(supporting_files)},
+      scale);
+}
+
+// Loads the fully_textured_pyramid.gltf file as an in-memory mesh.
+Mesh GetPyramidInMemory(double scale = 1.0) {
+  const fs::path gltf_path = FindResourceOrThrow(
+      "drake/geometry/render/test/meshes/fully_textured_pyramid.gltf");
+  const fs::path gltf_dir = gltf_path.parent_path();
+  string_map<FileSource> supporting_files;
+  // These are _all_ the files referenced in fully_textured_pyramid.gltf. Only
+  // the ktx2 images will render, but the console will complain about not being
+  // able to find the .png images if we don't include them as supporting files.
+  // We'll add the ktx2 files as path FileSources to test both representations
+  // (MemoryFile and path).
+  bool have_paths = false;
+  for (const auto* f :
+       {"fully_textured_pyramid_emissive.png",
+        "fully_textured_pyramid_normal.png", "fully_textured_pyramid_omr.png",
+        "fully_textured_pyramid_base_color.png",
+        "fully_textured_pyramid_emissive.ktx2",
+        "fully_textured_pyramid_normal.ktx2", "fully_textured_pyramid_omr.ktx2",
+        "fully_textured_pyramid_base_color.ktx2",
+        "fully_textured_pyramid.bin"}) {
+    const std::string f_name(f);
+    if (f_name.ends_with(".ktx2")) {
+      supporting_files.emplace(f, gltf_dir / f);
+      have_paths = true;
+    } else {
+      supporting_files.emplace(f, MemoryFile::Make(std::move(gltf_dir / f)));
+    }
+  }
+  // Make sure there's not some erroneous logic in putting the ktx2 files in as
+  // path FileSource.
+  DRAKE_DEMAND(have_paths);
+
+  return Mesh(
+      InMemoryMesh{MemoryFile::Make(gltf_path), std::move(supporting_files)},
+      scale);
 }
 
 int do_main() {
@@ -101,10 +155,15 @@ int do_main() {
   // The color and shininess properties come from PBR materials.
   meshcat->SetObject(
       "gltf",
-      Mesh(FindResourceOrThrow("drake/geometry/render/test/meshes/cube1.gltf"),
-           0.25));
+      Mesh(FindResourceOrThrow(
+               "drake/geometry/render/test/meshes/fully_textured_pyramid.gltf"),
+           0.5));
   const Vector3d gltf_pose{++x, 0, 0};
   meshcat->SetTransform("gltf", RigidTransformd(gltf_pose));
+
+  meshcat->SetObject("gltf_in_memory", GetPyramidInMemory(0.5));
+  meshcat->SetTransform("gltf_in_memory",
+                        RigidTransformd(gltf_pose + Vector3d(0, 1.5, 0)));
 
   auto mustard_obj =
       FindRunfile("drake_models/ycb/meshes/006_mustard_bottle_textured.obj")
@@ -262,7 +321,8 @@ Ignore those for now; we'll need to circle back and fix them later.
     hull.
   - a teal capsule (long axis in z)
   - a red cone (expanding in +z, twice as wide in y than in x)
-  - a shiny, green, dented cube (created with a PBR material)
+  - two shiny, textured pyramids (created with PBR materials); one read from
+    disk, the other loaded from memory.
   - a yellow mustard bottle w/ label
   - a dense rainbow point cloud in a box (long axis in z)
   - a blue line coiling up (in z).
@@ -368,9 +428,9 @@ Ignore those for now; we'll need to circle back and fix them later.
 
   std::cout << "- An environment map has been loaded from a png -- the Cornell "
             << "box.\n"
-            << "  The dented green box should reflect it (the camera has moved "
-            << "to focus on the box). This may not be apparent until after you "
-            << "move the mouse.\n";
+            << "  The shiny pyramids should reflect it (the camera has moved "
+            << "to focus on the pyramids). This may not be apparent until "
+            << "after you move the mouse.\n";
   MaybePauseForUser();
 
   meshcat->SetEnvironmentMap(
@@ -508,12 +568,24 @@ Ignore those for now; we'll need to circle back and fix them later.
     MaybePauseForUser();
   }
 
-  std::cout << "Now we'll add back an environment map and move the camera, in\n"
-               "preparation for testing the standalone HTML download ...\n\n";
+  std::cout << "Now we'll add back some elements in preparation for testing\n"
+               "the standalone HTML download:\n"
+               "  - an environment map\n"
+               "  - reposition the camera\n"
+               "  - add an in-memory glTF file (textured pyramid)\n"
+               "  - add an in-memory obj file (textured cuboctahedron)\n"
+               "\n";
 
   meshcat->SetEnvironmentMap(
       FindResourceOrThrow("drake/geometry/test/env_256_cornell_box.png"));
   meshcat->SetCameraTarget(Vector3d{-0.4, 0, 0});
+
+  meshcat->SetObject("gltf_in_memory", GetPyramidInMemory(0.1));
+  meshcat->SetTransform("gltf_in_memory",
+                        RigidTransformd(Vector3d(0.25, 0.3, 0.1)));
+  meshcat->SetObject("obj_in_memory", GetCuboctahedronInMemory(0.1));
+  meshcat->SetTransform("obj_in_memory",
+                        RigidTransformd(Vector3d(-0.25, 0.3, 0.1)));
 
   std::cout
       << "Now we'll check the standalone HTML file capturing this scene.\n"
@@ -647,7 +719,7 @@ Ignore those for now; we'll need to circle back and fix them later.
 
   std::cout << "Exiting..." << std::endl;
   return 0;
-}
+}  // NOLINT(readability/fn_size)
 
 }  // namespace
 }  // namespace geometry

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -21,6 +21,8 @@ namespace drake {
 namespace geometry {
 namespace {
 
+namespace fs = std::filesystem;
+
 using Eigen::Vector3d;
 using math::RigidTransformd;
 using math::RollPitchYawd;
@@ -342,8 +344,107 @@ GTEST_TEST(MeshcatTest, NumActive) {
   EXPECT_EQ(meshcat.GetNumActiveConnections(), 0);
 }
 
+// Note: The Mesh shape is special. It can reference on-disk or in-memory data
+// and they all need to be handled. This test runs through the various
+// permutations.
+GTEST_TEST(MeshcatTest, SetObjectWithMesh) {
+  Meshcat meshcat;
+
+  using testing::HasSubstr;
+  using testing::Not;
+
+  // A .obj file with material library and image. The packed message should
+  // encode the .obj, the .mtl file, and the image.
+  const fs::path obj_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/rainbow_box.obj");
+  const Mesh disk_obj(obj_path, 0.25);
+  const auto obj_file = MemoryFile::Make(obj_path);
+  const auto mtl_file = MemoryFile::Make(
+      FindResourceOrThrow("drake/geometry/render/test/meshes/rainbow_box.mtl"));
+  const auto png_file = MemoryFile::Make(FindResourceOrThrow(
+      "drake/geometry/render/test/meshes/rainbow_stripes.png"));
+  const Mesh memory_obj(InMemoryMesh{
+      MemoryFile(obj_file.contents(), obj_file.extension(),
+                 "a hint; *not* a path"),
+      {{"rainbow_box.mtl", MemoryFile(mtl_file)},
+       {"rainbow_stripes.png", MemoryFile(png_file)}}});
+  // The "hetero" objs mix up the supporting files so that, in turn, one is
+  // in memory, and one is on-disk.
+  const Mesh hetero_obj1(InMemoryMesh{
+      MemoryFile(obj_file.contents(), obj_file.extension(), "hetero1_obj"),
+      {{"rainbow_box.mtl", fs::path(mtl_file.filename_hint())},
+       {"rainbow_stripes.png", MemoryFile(png_file)}}});
+  const Mesh hetero_obj2(InMemoryMesh{
+      MemoryFile(obj_file.contents(), obj_file.extension(), "hetero2_obj"),
+      {{"rainbow_box.mtl", MemoryFile(mtl_file)},
+       {"rainbow_stripes.png", fs::path(png_file.filename_hint())}}});
+  for (const auto* mesh_ptr :
+       {&disk_obj, &memory_obj, &hetero_obj1, &hetero_obj2}) {
+    const MeshSource& source = mesh_ptr->source();
+    const bool is_disk = source.is_path();
+    SCOPED_TRACE(fmt::format("Full obj from {} - {}",
+                             is_disk ? "disk" : "memory",
+                             is_disk ? std::string() : source.description()));
+    DRAKE_DEMAND(meshcat.GetPackedObject("obj_path").empty());
+
+    meshcat.SetObject("obj_path", *mesh_ptr);
+    const std::string packed_obj = meshcat.GetPackedObject("obj_path");
+    EXPECT_FALSE(packed_obj.empty());
+    // Evidence that the image got loaded.
+    EXPECT_THAT(packed_obj, testing::HasSubstr("data:image/png;base64"));
+    // Evidence that the material library got loaded.
+    EXPECT_THAT(packed_obj, testing::HasSubstr("newmtl Rainbow_Stripes"));
+    meshcat.Delete("obj_path");
+    ASSERT_TRUE(meshcat.GetPackedObject("obj_path").empty());
+  }
+
+  // Missing elements from the in-memory mesh should proceed (but with missing
+  // resources). Warnings are also spewed, but we can't test for those.
+
+  // Missing the mtl file (whether the png is present or not), means no mtl and
+  // no png.
+  for (const InMemoryMesh& mem_mesh :
+       {InMemoryMesh{obj_file},
+        InMemoryMesh{obj_file,
+                     {{"rainbow_stripes.png", MemoryFile(png_file)}}}}) {
+    SCOPED_TRACE(fmt::format("Partial OBJ with {} supporting files",
+                             mem_mesh.supporting_files.size()));
+    DRAKE_DEMAND(meshcat.GetPackedObject("obj_path").empty());
+    meshcat.SetObject("obj_path", Mesh(mem_mesh));
+    const std::string packed_obj = meshcat.GetPackedObject("obj_path");
+    EXPECT_FALSE(packed_obj.empty());
+    EXPECT_THAT(packed_obj, Not(HasSubstr("data:image/png;base64")));
+    EXPECT_THAT(packed_obj, Not(HasSubstr("newmtl Rainbow_Stripes")));
+    meshcat.Delete("obj_path");
+  }
+
+  // If only the texture is missing, we still have "success" - materials are
+  // loaded but the image is not.
+  {
+    DRAKE_DEMAND(meshcat.GetPackedObject("obj_path").empty());
+    meshcat.SetObject("obj_path",
+                      Mesh(InMemoryMesh{obj_file, {{"rainbow_box.mtl",
+                                                    MemoryFile(mtl_file)}}}));
+    const std::string packed_obj = meshcat.GetPackedObject("obj_path");
+    EXPECT_FALSE(packed_obj.empty());
+    EXPECT_THAT(packed_obj, Not(HasSubstr("data:image/png;base64")));
+    EXPECT_THAT(packed_obj, HasSubstr("newmtl Rainbow_Stripes"));
+    meshcat.Delete("obj_path");
+  }
+
+  // Meshcat defers to `meshcat_internal` logic for handling glTF files so
+  // it's enough to show that good things happen. Tests on the internal
+  // implementations are responsible for confirming it's the *right* thing.
+  meshcat.SetObject(
+      "gltf",
+      Mesh(FindResourceOrThrow("drake/geometry/render/test/meshes/cube1.gltf"),
+           0.25));
+  EXPECT_FALSE(meshcat.GetPackedObject("gltf").empty());
+}
+
 // The correctness of this is established with meshcat_manual_test.  Here we
 // simply aim to provide code coverage for CI (e.g., no segfaults).
+// Meshes are treated in SetObjectWithMesh.
 GTEST_TEST(MeshcatTest, SetObjectWithShape) {
   Meshcat meshcat;
   EXPECT_TRUE(meshcat.GetPackedObject("sphere").empty());
@@ -361,16 +462,6 @@ GTEST_TEST(MeshcatTest, SetObjectWithShape) {
   EXPECT_FALSE(meshcat.GetPackedObject("ellipsoid").empty());
   meshcat.SetObject("capsule", Capsule(0.25, 0.5));
   EXPECT_FALSE(meshcat.GetPackedObject("capsule").empty());
-  meshcat.SetObject(
-      "mesh",
-      Mesh(FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj"),
-           0.25));
-  EXPECT_FALSE(meshcat.GetPackedObject("mesh").empty());
-  meshcat.SetObject(
-      "gltf",
-      Mesh(FindResourceOrThrow("drake/geometry/render/test/meshes/cube1.gltf"),
-           0.25));
-  EXPECT_FALSE(meshcat.GetPackedObject("gltf").empty());
   meshcat.SetObject(
       "convex",
       Convex(FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj"),
@@ -398,9 +489,9 @@ GTEST_TEST(MeshcatTest, ObjWithMissingMtl) {
   EXPECT_THAT(with_mtl_packed, testing::HasSubstr("mtl_library"));
 
   // Copy the .obj into a directory, without its .mtl file.
-  const std::filesystem::path dir = temp_directory();
-  const std::filesystem::path missing_mtl_path = dir / "box.obj";
-  std::filesystem::copy_file(obj_source, missing_mtl_path);
+  const fs::path dir = temp_directory();
+  const fs::path missing_mtl_path = dir / "box.obj";
+  fs::copy_file(obj_source, missing_mtl_path);
   meshcat.SetObject("missing_mtl", Mesh(missing_mtl_path.string()),
                     Rgba(1, 0.75, 0.5));
 
@@ -680,7 +771,7 @@ GTEST_TEST(MeshcatTest, SetEnvironmentMap) {
   EXPECT_EQ(actual_value, "");
 
   // Set the map to a valid image.
-  const std::filesystem::path env_map(
+  const fs::path env_map(
       FindResourceOrThrow("drake/geometry/test/env_256_cornell_box.png"));
   EXPECT_NO_THROW(meshcat.SetEnvironmentMap(env_map));
   EXPECT_TRUE(meshcat.HasPath(path));

--- a/lcmtypes/lcmt_viewer_geometry_data.lcm
+++ b/lcmtypes/lcmt_viewer_geometry_data.lcm
@@ -16,6 +16,60 @@ struct lcmt_viewer_geometry_data {
   float quaternion[4];  // w, x, y, z
   float color[4];  // r, g, b, a
 
+  // If type == MESH there are different ways of encoding the mesh:
+  //
+  //  - By path: string_data contains a file path to a mesh file.
+  //
+  //  - Raw triangle mesh: a triangle mesh is wholly contained within the
+  //    message. string_data will remain empty and the mesh is defined in
+  //    float data as:
+  //
+  //        V | T | v0 | v1 | ... vN | t0 | t1 | ... | tM
+  //
+  //    where
+  //
+  //      V: The number of vertices.
+  //      T: The number of triangles.
+  //      N: 3V, the number of floating point values for the V vertices.
+  //      M: 3T, the number of vertex indices for the T triangles.
+  //
+  //  - In-memory mesh: A json string stored in string_data which represents a
+  //    C++ InMemoryMesh instance with only a single mesh file of the form:
+  //
+  //        {
+  //          "in_memory_mesh": {
+  //            "mesh_file": {
+  //              "contents": "VGhpcyBpcyBhIHRlc3Q=,
+  //              "extension": ".txt",
+  //              "filename_hint": "not_a_real.mesh"
+  //            }
+  //          }
+  //        }
+  //
+  //    or an in-memory mesh with supporting files of the form:
+  //
+  //        {
+  //          "in_memory_mesh": {
+  //            "mesh_file": {
+  //              "contents": "VGhpcyBpcyBhIHRlc3Q=,
+  //              "extension": ".txt",
+  //              "filename_hint": "not_a_real.mesh"
+  //            },
+  //            "supporting_files": [
+  //              "in_memory.png": {
+  //                "contents": "VGhpcyBpcyBhIHRlc3Q=,
+  //                "extension": ".png",
+  //                "filename_hint": "not_a_real.png"
+  //              },
+  //              "on_disk.png": {
+  //                "path": "/file/to/image.png"
+  //              },
+  //            ]
+  //          }
+  //        }
+  //
+  //    Note: Where file contents are provided, they are base64-encoded.
+  //
   string string_data;
 
   int32_t num_float_data;


### PR DESCRIPTION
 - Meshcat operates on MeshSource
 - DrakeVisualizer serializes a FileSource into javascript that subsequently gets decoded by meldis (and then passed to its own Meshcat as in-memory Mesh).
 - To evaluate the result:
   - meshcat_manual_test has been updated to include both on-disk and in-memory representations. (Doesn't support meldis.)
   - The solar system example has been updated to perform a similar role and now supports both meshcat and meldis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21952)
<!-- Reviewable:end -->
