### PR TITLE
[multibody] Move almost all code from BodyNode to templatized BodyNodeImpl

### DIFF
--- a/multibody/tree/body_node.cc
+++ b/multibody/tree/body_node.cc
@@ -11,6 +11,55 @@ template <typename T>
 BodyNode<T>::~BodyNode() = default;
 
 template <typename T>
+void BodyNode<T>::CalcAcrossMobilizerBodyPoses_BaseToTip(
+    const FrameBodyPoseCache<T>& frame_body_pose_cache,
+    PositionKinematicsCache<T>* pc) const {
+  // RigidBody for this node.
+  const RigidBody<T>& body_B = body();
+
+  // RigidBody for this node's parent, or the parent body P.
+  const RigidBody<T>& body_P = parent_body();
+
+  // Inboard/Outboard frames of this node's mobilizer.
+  const Frame<T>& frame_F = inboard_frame();
+  DRAKE_ASSERT(frame_F.body().index() == body_P.index());
+  const Frame<T>& frame_M = outboard_frame();
+  DRAKE_ASSERT(frame_M.body().index() == body_B.index());
+
+  // Input (const):
+  // - X_PF
+  // - X_MB
+  // - X_FM(q_B)
+  // - X_WP(q(W:P)), where q(W:P) includes all positions in the kinematics
+  //                 path from parent body P to the world W.
+  const math::RigidTransform<T>& X_MB =
+      frame_M.get_X_FB(frame_body_pose_cache);  // F==M
+  const math::RigidTransform<T>& X_PF =
+      frame_F.get_X_BF(frame_body_pose_cache);  // B==P
+  const math::RigidTransform<T>& X_FM = pc->get_X_FM(mobod_index());
+  const math::RigidTransform<T>& X_WP = pc->get_X_WB(inboard_mobod_index());
+
+  // Output (updating a cache entry):
+  // - X_PB(q_B)
+  // - X_WB(q(W:P), q_B)
+  math::RigidTransform<T>& X_PB = pc->get_mutable_X_PB(mobod_index());
+  math::RigidTransform<T>& X_WB = pc->get_mutable_X_WB(mobod_index());
+  Vector3<T>& p_PoBo_W = pc->get_mutable_p_PoBo_W(mobod_index());
+
+  // TODO(amcastro-tri): Consider logic for the common case B = M.
+  //  In that case X_FB = X_FM as suggested by setting X_MB = Identity.
+  const math::RigidTransform<T> X_FB = X_FM * X_MB;
+
+  X_PB = X_PF * X_FB;
+  X_WB = X_WP * X_PB;
+
+  // Compute shift vector p_PoBo_W from the parent origin to the body origin.
+  const Vector3<T>& p_PoBo_P = X_PB.translation();
+  const math::RotationMatrix<T>& R_WP = X_WP.rotation();
+  p_PoBo_W = R_WP * p_PoBo_P;
+}
+
+template <typename T>
 void BodyNode<T>::CalcArticulatedBodyHingeInertiaMatrixFactorization(
     const MatrixUpTo6<T>& D_B,
     math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>* llt_D_B) const {
@@ -53,7 +102,7 @@ void BodyNode<T>::CalcArticulatedBodyHingeInertiaMatrixFactorization(
   //  positive definite, we _know_ D_B is near singular.
   if (llt_D_B->eigen_linear_solver().info() != Eigen::Success) {
     // Create a meaningful message that helps the user as much as possible.
-    const Mobilizer<T>& mobilizer = get_mobilizer();
+    const Mobilizer<T>& mobilizer = *mobilizer_;
     const RigidBody<T>& inboard_body = mobilizer.inboard_body();
     const RigidBody<T>& outboard_body = mobilizer.outboard_body();
     const std::string& inboard_body_name = inboard_body.name();
@@ -78,55 +127,6 @@ void BodyNode<T>::CalcArticulatedBodyHingeInertiaMatrixFactorization(
     }
     throw std::runtime_error(message.str());
   }
-}
-
-template <typename T>
-void BodyNode<T>::CalcAcrossMobilizerBodyPoses_BaseToTip(
-    const FrameBodyPoseCache<T>& frame_body_pose_cache,
-    PositionKinematicsCache<T>* pc) const {
-  // RigidBody for this node.
-  const RigidBody<T>& body_B = body();
-
-  // RigidBody for this node's parent, or the parent body P.
-  const RigidBody<T>& body_P = parent_body();
-
-  // Inboard/Outboard frames of this node's mobilizer.
-  const Frame<T>& frame_F = inboard_frame();
-  DRAKE_ASSERT(frame_F.body().index() == body_P.index());
-  const Frame<T>& frame_M = outboard_frame();
-  DRAKE_ASSERT(frame_M.body().index() == body_B.index());
-
-  // Input (const):
-  // - X_PF
-  // - X_MB
-  // - X_FM(q_B)
-  // - X_WP(q(W:P)), where q(W:P) includes all positions in the kinematics
-  //                 path from parent body P to the world W.
-  const math::RigidTransform<T>& X_MB =
-      frame_M.get_X_FB(frame_body_pose_cache);  // F==M
-  const math::RigidTransform<T>& X_PF =
-      frame_F.get_X_BF(frame_body_pose_cache);  // B==P
-  const math::RigidTransform<T>& X_FM = get_X_FM(*pc);
-  const math::RigidTransform<T>& X_WP = get_X_WP(*pc);
-
-  // Output (updating a cache entry):
-  // - X_PB(q_B)
-  // - X_WB(q(W:P), q_B)
-  math::RigidTransform<T>& X_PB = get_mutable_X_PB(pc);
-  math::RigidTransform<T>& X_WB = get_mutable_X_WB(pc);
-  Vector3<T>& p_PoBo_W = get_mutable_p_PoBo_W(pc);
-
-  // TODO(amcastro-tri): Consider logic for the common case B = M.
-  //  In that case X_FB = X_FM as suggested by setting X_MB = Identity.
-  const math::RigidTransform<T> X_FB = X_FM * X_MB;
-
-  X_PB = X_PF * X_FB;
-  X_WB = X_WP * X_PB;
-
-  // Compute shift vector p_PoBo_W from the parent origin to the body origin.
-  const Vector3<T>& p_PoBo_P = X_PB.translation();
-  const math::RotationMatrix<T>& R_WP = X_WP.rotation();
-  p_PoBo_W = R_WP * p_PoBo_P;
 }
 
 }  // namespace internal

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -100,7 +100,6 @@ class BodyNode : public MultibodyElement<T> {
         body_(body),
         mobilizer_(mobilizer) {
     DRAKE_DEMAND(!(parent_node == nullptr && body->index() != world_index()));
-    DRAKE_DEMAND(!(mobilizer == nullptr && body->index() != world_index()));
   }
 
   ~BodyNode() override;
@@ -114,8 +113,16 @@ class BodyNode : public MultibodyElement<T> {
   // MultibodyTree::Finalize() method call.
   void add_child_node(const BodyNode<T>* child) { children_.push_back(child); }
 
-  // Returns this element's unique index.
-  MobodIndex index() const { return this->template index_impl<MobodIndex>(); }
+  MobodIndex mobod_index() const {
+    const MobodIndex mobod = get_mobilizer().mobod().index();
+    // TODO(sherm1) BodyNode shouldn't be a MultibodyElement, but is for now.
+    DRAKE_ASSERT(this->template index_impl<MobodIndex>() == mobod);
+    return mobod;
+  }
+
+  MobodIndex inboard_mobod_index() const {
+    return get_mobilizer().mobod().inboard();
+  }
 
   // Returns a constant reference to the body B associated with this node.
   const RigidBody<T>& body() const {
@@ -134,6 +141,12 @@ class BodyNode : public MultibodyElement<T> {
   // Returns a const pointer to the parent (inboard) body node or nullptr if
   // `this` is the world node, which has no inboard parent node.
   const BodyNode<T>* parent_body_node() const { return parent_node_; }
+
+  // Returns a vector of pointers to the BodyNodes for which this is the
+  // inboard node.
+  const std::vector<const BodyNode<T>*>& child_nodes() const {
+    return children_;
+  }
 
   // Returns a constant reference to the mobilizer associated with this node.
   // Aborts if called on the root node corresponding to the _world_ body, for
@@ -165,6 +178,55 @@ class BodyNode : public MultibodyElement<T> {
     return topology_.mobilizer_velocities_start_in_v;
   }
   //@}
+
+  // Returns the topology information for this body node.
+  const BodyNodeTopology& get_topology() const { return topology_; }
+
+  // Helper method to retrieve a Jacobian matrix with respect to generalized
+  // velocities v for `this` node from an array storing the columns of a set of
+  // Jacobian matrices for each node.  This method is used by MultibodyTree
+  // implementations to retrieve per-node Jacobian matrices from a
+  // `std::vector` that would usually live in the cache.
+  // @param[in] H_array
+  //   This array stores a Jacobian matrix `H` for each node in the tree. Each
+  //   matrix has size `6 x nm` with `nm` the number of mobilities of the node.
+  //   `H_array` stores the columns of these matrices and therefore it consists
+  //   of a `std::vector` of vectors in ℝ⁶ with as many entries as the number
+  //   of generalized velocities v in the model.
+  //   `H_array` must be of size MultibodyTree::num_velocities().
+  // @retval H
+  //   An Eigen::Map to a matrix of size `6 x nm` corresponding to the Jacobian
+  //   matrix for this node.
+  Eigen::Map<const MatrixUpTo6<T>> GetJacobianFromArray(
+      const std::vector<Vector6<T>>& H_array) const {
+    DRAKE_DEMAND(static_cast<int>(H_array.size()) ==
+                 this->get_parent_tree().num_velocities());
+    const int start_index_in_v = get_topology().mobilizer_velocities_start_in_v;
+    const int num_velocities = get_topology().num_mobilizer_velocities;
+    DRAKE_DEMAND(num_velocities == 0 ||
+                 start_index_in_v < this->get_parent_tree().num_velocities());
+    // The first column of this node's hinge matrix H_PB_W:
+    const T* H_col0 =
+        num_velocities == 0 ? nullptr : H_array[start_index_in_v].data();
+    // Create an Eigen map to the full H_PB_W for this node:
+    return Eigen::Map<const MatrixUpTo6<T>>(H_col0, 6, num_velocities);
+  }
+
+  // Mutable version of GetJacobianFromArray().
+  Eigen::Map<MatrixUpTo6<T>> GetMutableJacobianFromArray(
+      std::vector<Vector6<T>>* H_array) const {
+    DRAKE_DEMAND(static_cast<int>(H_array->size()) ==
+                 this->get_parent_tree().num_velocities());
+    const int start_index_in_v = get_topology().mobilizer_velocities_start_in_v;
+    const int num_velocities = get_topology().num_mobilizer_velocities;
+    DRAKE_DEMAND(num_velocities == 0 ||
+                 start_index_in_v < this->get_parent_tree().num_velocities());
+    // The first column of this node's hinge matrix H_PB_W:
+    T* H_col0 =
+        num_velocities == 0 ? nullptr : (*H_array)[start_index_in_v].data();
+    // Create an Eigen map to the full H_PB_W for this node:
+    return Eigen::Map<MatrixUpTo6<T>>(H_col0, 6, num_velocities);
+  }
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
   // this node's kinematics that only depend on generalized positions.
@@ -278,150 +340,12 @@ class BodyNode : public MultibodyElement<T> {
   // MultibodyTree::CalcAccelerationKinematicsCache().
 
   // TODO(sherm1) This function should not take a context.
-  void CalcSpatialAcceleration_BaseToTip(
+  virtual void CalcSpatialAcceleration_BaseToTip(
       const systems::Context<T>& context,
       const FrameBodyPoseCache<T>& frame_body_poses_cache,
       const PositionKinematicsCache<T>& pc,
       const VelocityKinematicsCache<T>* vc, const VectorX<T>& mbt_vdot,
-      std::vector<SpatialAcceleration<T>>* A_WB_array_ptr) const {
-    // This method must not be called for the "world" body node.
-    DRAKE_DEMAND(topology_.rigid_body != world_index());
-    DRAKE_DEMAND(A_WB_array_ptr != nullptr);
-    std::vector<SpatialAcceleration<T>>& A_WB_array = *A_WB_array_ptr;
-
-    // As a guideline for developers, a summary of the computations performed in
-    // this method is provided:
-    // Notation:
-    //  - B body frame associated with this node.
-    //  - P ("parent") body frame associated with this node's parent.
-    //  - F mobilizer inboard frame attached to body P.
-    //  - M mobilizer outboard frame attached to body B.
-    // The goal is computing the spatial acceleration A_WB of body B measured in
-    // the world frame W. The calculation is recursive and assumes the spatial
-    // acceleration A_WP of the inboard body P is already computed.
-    // The spatial velocities of P and B are related by the recursive relation
-    // (computation is performed by CalcVelocityKinematicsCache_BaseToTip():
-    //   V_WB = V_WPb + V_PB_W (Eq. 5.6 in Jain (2010), p. 77)
-    //        = V_WP.ComposeWithMovingFrameVelocity(p_PB_W, V_PB_W)         (1)
-    // where Pb is a frame aligned with P but with its origin shifted from Po
-    // to B's origin Bo. Then V_WPb is the spatial velocity of frame Pb,
-    // measured and expressed in the world frame W.
-    //
-    // In the same way the parent body P velocity V_WP can be composed with body
-    // B's velocity V_PB in P, the acceleration A_WB can be obtained by
-    // composing A_WP with A_PB:
-    //  A_WB = A_WP.ComposeWithMovingFrameAcceleration(
-    //      p_PB_W, w_WP, V_PB_W, A_PB_W);                                  (2)
-    // which includes both centrifugal and coriolis terms. For details on this
-    // operation refer to the documentation for
-    // SpatialAcceleration::ComposeWithMovingFrameAcceleration().
-    //
-    // By recursive precondition, this method was already called on all
-    // predecessor nodes in the tree and therefore the acceleration A_WP is
-    // already available.
-    // V_WP (i.e. w_WP) and V_PB_W were computed in the velocity kinematics pass
-    // and are therefore available in the VelocityKinematicsCache vc.
-    //
-    // Therefore, all that is left is computing A_PB_W = DtP(V_PB)_W.
-    // The acceleration of B in P is:
-    //   A_PB = DtP(V_PB) = DtF(V_FMb) = A_FM.Shift(p_MB, w_FM)             (3)
-    // which expressed in the world frame leads to (see note below):
-    //   A_PB_W = R_WF * A_FM.Shift(p_MB_F, w_FM)                           (4)
-    // where R_WF is the rotation matrix from F to W and A_FM expressed in the
-    // inboard frame F is the direct result from
-    // Mobilizer::CalcAcrossMobilizerAcceleration().
-    //
-    // * Note:
-    //     The rigid body assumption is made in Eq. (3) in two places:
-    //       1. DtP() = DtF() since V_PF = 0.
-    //       2. V_PB = V_FMb since V_PB = V_PFb + V_FMb + V_MB but since P is
-    //          assumed rigid V_PF = 0 and since B is assumed rigid V_MB = 0.
-
-    // RigidBody for this node. Its BodyFrame is also referred to as B whenever
-    // no ambiguity can arise.
-    const RigidBody<T>& body_B = body();
-
-    // RigidBody for this node's parent, or the parent body P. Its BodyFrame
-    // is also referred to as P whenever no ambiguity can arise.
-    const RigidBody<T>& body_P = parent_body();
-
-    // Inboard frame F of this node's mobilizer.
-    const Frame<T>& frame_F = inboard_frame();
-    DRAKE_ASSERT(frame_F.body().index() == body_P.index());
-    // Outboard frame M of this node's mobilizer.
-    const Frame<T>& frame_M = outboard_frame();
-    DRAKE_ASSERT(frame_M.body().index() == body_B.index());
-
-    // =========================================================================
-    // Computation of A_PB = DtP(V_PB), Eq. (4).
-
-    const math::RigidTransform<T>& X_PF =
-        frame_F.get_X_BF(frame_body_poses_cache);  // B==P
-    const math::RotationMatrix<T>& R_PF = X_PF.rotation();
-    const math::RigidTransform<T>& X_MB =
-        frame_M.get_X_FB(frame_body_poses_cache);  // F==M
-
-    // Form the rotation matrix relating the world frame W and parent body P.
-    // Available since we are called within a base-to-tip recursion.
-    const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
-
-    // Orientation (rotation) of frame F with respect to the world frame W.
-    // TODO(amcastro-tri): consider caching X_WF since it is also used to
-    //  compute H_PB_W.
-    const math::RotationMatrix<T> R_WF = R_WP * R_PF;
-
-    // Vector from Mo to Bo expressed in frame F as needed below:
-    // TODO(amcastro-tri): consider caching this since it is also used to
-    //  compute H_PB_W.
-    const math::RotationMatrix<T>& R_FM = get_X_FM(pc).rotation();
-    const Vector3<T>& p_MB_M = X_MB.translation();
-    const Vector3<T> p_MB_F = R_FM * p_MB_M;
-
-    // Generalized velocities' time derivatives local to this node's mobilizer.
-    const auto& vmdot = this->get_mobilizer_velocities(mbt_vdot);
-
-    // Operator A_FM = H_FM * vmdot + Hdot_FM * vm
-    SpatialAcceleration<T> A_FM =
-        get_mobilizer().CalcAcrossMobilizerSpatialAcceleration(context, vmdot);
-
-    // =========================================================================
-    // Compose acceleration A_WP of P in W with acceleration A_PB of B in P,
-    // Eq. (2)
-
-    // Obtains a const reference to the parent acceleration from A_WB_array.
-    const SpatialAcceleration<T>& A_WP = get_A_WP_from_array(A_WB_array);
-
-    // Shift vector between the parent body P and this node's body B,
-    // expressed in the world frame W.
-    const Vector3<T>& p_PB_W = get_p_PoBo_W(pc);
-
-    if (vc != nullptr) {
-      // Since we are in a base-to-tip recursion the parent body P's spatial
-      // velocity is already available in the cache.
-      const SpatialVelocity<T>& V_WP = get_V_WP(*vc);
-
-      // For body B, only the spatial velocity V_PB_W is already available in
-      // the cache. The acceleration A_PB_W was computed above.
-      const SpatialVelocity<T>& V_PB_W = get_V_PB_W(*vc);
-
-      // Across mobilizer velocity is available from the velocity kinematics.
-      const SpatialVelocity<T>& V_FM = get_V_FM(*vc);
-
-      const SpatialAcceleration<T> A_PB_W =
-          R_WF * A_FM.Shift(p_MB_F, V_FM.rotational());  // Eq. (4)
-
-      // Velocities are non-zero.
-      get_mutable_A_WB_from_array(&A_WB_array) =
-          A_WP.ComposeWithMovingFrameAcceleration(p_PB_W, V_WP.rotational(),
-                                                  V_PB_W, A_PB_W);
-    } else {
-      const SpatialAcceleration<T> A_PB_W =  // Eq. (4), with w_FM = 0.
-          R_WF * A_FM.ShiftWithZeroAngularVelocity(p_MB_F);
-      // Velocities are zero. No need to compute terms that become zero.
-      get_mutable_A_WB_from_array(&A_WB_array) =
-          A_WP.ShiftWithZeroAngularVelocity(p_PB_W) + A_PB_W;
-    }
-  }
+      std::vector<SpatialAcceleration<T>>* A_WB_array_ptr) const = 0;
 
   // Computes the generalized forces `tau` for a single BodyNode.
   // This method is used by MultibodyTree within a tip-to-base loop to compute
@@ -493,7 +417,7 @@ class BodyNode : public MultibodyElement<T> {
   // MultibodyTree::CalcInverseDynamics().
 
   // TODO(sherm1) This function should not take a context.
-  void CalcInverseDynamics_TipToBase(
+  virtual void CalcInverseDynamics_TipToBase(
       const systems::Context<T>& context,
       const FrameBodyPoseCache<T>& frame_body_pose_cache,
       const PositionKinematicsCache<T>& pc,
@@ -503,208 +427,7 @@ class BodyNode : public MultibodyElement<T> {
       const SpatialForce<T>& Fapplied_Bo_W,
       const Eigen::Ref<const VectorX<T>>& tau_applied,
       std::vector<SpatialForce<T>>* F_BMo_W_array_ptr,
-      EigenPtr<VectorX<T>> tau_array) const {
-    DRAKE_DEMAND(F_BMo_W_array_ptr != nullptr);
-    std::vector<SpatialForce<T>>& F_BMo_W_array = *F_BMo_W_array_ptr;
-    DRAKE_DEMAND(tau_applied.size() == get_num_mobilizer_velocities() ||
-                 tau_applied.size() == 0);
-    DRAKE_DEMAND(tau_array != nullptr);
-    DRAKE_DEMAND(tau_array->size() == this->get_parent_tree().num_velocities());
-
-    // As a guideline for developers, a summary of the computations performed in
-    // this method is provided:
-    // Notation:
-    //  - B body frame associated with this node.
-    //  - P ("parent") body frame associated with this node's parent.
-    //  - F mobilizer inboard frame attached to body P.
-    //  - M mobilizer outboard frame attached to body B.
-    //  - Mo The origin of the outboard (or mobilized) frame of the mobilizer
-    //       attached to body B.
-    //  - C within a loop over children, one of body B's children.
-    //  - Mc The origin of the outboard (or mobilized) frame of the mobilizer
-    //       attached to body C.
-    // The goal is computing the spatial force F_BMo_W (on body B applied at its
-    // mobilized frame origin Mo) exerted by its inboard mobilizer that is
-    // required to produce the spatial acceleration A_WB. The generalized forces
-    // are then obtained as the projection of the spatial force F_BMo in the
-    // direction of this node's mobilizer motion. That is, the generalized
-    // forces correspond to the working components of the spatial force living
-    // in the motion sub-space of this node's mobilizer.
-    // The calculation is recursive (from tip-to-base) and assumes the spatial
-    // force F_CMc on body C at Mc is already computed in F_BMo_W_array_ptr.
-    //
-    // The spatial force through body B's inboard mobilizer is obtained from a
-    // force balance (essentially the F = m * a for rigid bodies, see
-    // [Jain 2010, Eq. 2.26, p. 27] for a derivation):
-    //   Ftot_BBo_W = M_Bo_W * A_WB + Fb_Bo_W                                (1)
-    // where Fb_Bo_W contains the velocity dependent gyroscopic terms,
-    // Ftot_BBo_W is the total spatial force on body B, applied at its origin Bo
-    // and quantities are expressed in the world frame W (though the
-    // expressed-in frame is not needed in a coordinate-free form.)
-    //
-    // The total spatial force on body B is the combined effect of externally
-    // applied spatial forces Fapp_BMo on body B at Mo and spatial forces
-    // induced by its inboard and outboard mobilizers. On its mobilized frame M,
-    // in coordinate-free form:
-    //   Ftot_BMo = Fapp_BMo + F_BMo - Σᵢ(F_CiMo)                           (2)
-    // where F_CiMo is the spatial force on the i-th child body Ci due to its
-    // inboard mobilizer which, by action/reaction, applies to body B as
-    // -F_CiMo, hence the negative sign in the summation above. The applied
-    // spatial force Fapp_BMo at Mo is obtained by shifting the applied force
-    // Fapp_Bo from Bo to Mo as Fapp_BMo.Shift(p_BoMo).
-    // Therefore, spatial force F_BMo due to body B's mobilizer is:
-    //   F_BMo = Ftot_BMo + Σᵢ(F_CiMo) - Fapp_BMo                           (3)
-    // The projection of this force on the motion sub-space of this node's
-    // mobilizer corresponds to the generalized force tau:
-    //  tau = H_FMᵀ * F_BMo_F                                               (4)
-    // where the spatial force F_BMo must be re-expressed in the inboard frame F
-    // before the projection can be performed.
-
-    // This node's body B.
-    const RigidBody<T>& body_B = body();
-
-    // Input spatial acceleration for this node's body B.
-    const SpatialAcceleration<T>& A_WB = get_A_WB_from_array(A_WB_array);
-
-    // Total spatial force on body B producing acceleration A_WB.
-    SpatialForce<T> Ftot_BBo_W;
-    CalcBodySpatialForceGivenItsSpatialAcceleration(M_B_W_cache, Fb_Bo_W_cache,
-                                                    A_WB, &Ftot_BBo_W);
-
-    // Compute shift vector from Bo to Mo expressed in the world frame W.
-    const Frame<T>& frame_M = outboard_frame();
-    DRAKE_DEMAND(frame_M.body().index() == body_B.index());
-    const math::RigidTransform<T>& X_BM =
-        frame_M.get_X_BF(frame_body_pose_cache);  // F==M
-    const Vector3<T>& p_BoMo_B = X_BM.translation();
-    const math::RigidTransform<T>& X_WB = get_X_WB(pc);
-    const math::RotationMatrix<T>& R_WB = X_WB.rotation();
-    const Vector3<T> p_BoMo_W = R_WB * p_BoMo_B;
-
-    // Output spatial force that would need to be exerted by this node's
-    // mobilizer in order to attain the prescribed acceleration A_WB.
-    SpatialForce<T>& F_BMo_W = F_BMo_W_array[this->index()];
-
-    // Ensure this method was not called with an Fapplied_Bo_W being an entry
-    // into F_BMo_W_array, otherwise we would be overwriting Fapplied_Bo_W.
-    DRAKE_DEMAND(&F_BMo_W != &Fapplied_Bo_W);
-
-    // Shift spatial force on B to Mo.
-    F_BMo_W = Ftot_BBo_W.Shift(p_BoMo_W);
-    for (const BodyNode<T>* child_node : children_) {
-      MobodIndex child_node_index = child_node->index();
-
-      // Shift vector from Bo to Co, expressed in the world frame W.
-      const Vector3<T>& p_BoCo_W = child_node->get_p_PoBo_W(pc);
-
-      // p_CoMc_W:
-      const Frame<T>& frame_Mc = child_node->outboard_frame();
-      const math::RotationMatrix<T>& R_WC = child_node->get_X_WB(pc).rotation();
-      const math::RigidTransform<T>& X_CMc =
-          frame_Mc.get_X_BF(frame_body_pose_cache);  // B==C, F==Mc
-      const Vector3<T>& p_CoMc_W = R_WC * X_CMc.translation();
-
-      // Shift position vector from child C outboard mobilizer frame Mc to body
-      // B outboard mobilizer Mc. p_MoMc_W:
-      // Since p_BoMo = p_BoCo + p_CoMc + p_McMo, we have:
-      const Vector3<T> p_McMo_W = p_BoMo_W - p_BoCo_W - p_CoMc_W;
-
-      // Spatial force on the child body C at the origin Mc of the outboard
-      // mobilizer frame for the child body.
-      // A little note for how to read the next line: the frames for
-      // F_BMo_W_array are:
-      //  - B this node's body.
-      //  - Mo body B's inboard frame origin.
-      // However, when indexing by child_node_index:
-      //  - B becomes C, the child node's body.
-      //  - Mo becomes Mc, body C's inboard frame origin.
-      const SpatialForce<T>& F_CMc_W = F_BMo_W_array[child_node_index];
-
-      // Shift to this node's mobilizer origin Mo (still, F_CMo is the force
-      // acting on the child body C):
-      const SpatialForce<T>& F_CMo_W = F_CMc_W.Shift(p_McMo_W);
-      // From Eq. (3), this force is added (with positive sign) to the force
-      // applied by this body's mobilizer:
-      F_BMo_W += F_CMo_W;
-    }
-    // Add applied forces contribution.
-    F_BMo_W -= Fapplied_Bo_W.Shift(p_BoMo_W);
-
-    // Re-express F_BMo_W in the inboard frame F before projecting it onto the
-    // sub-space generated by H_FM(q).
-    const math::RotationMatrix<T> R_PF =
-        inboard_frame().CalcRotationMatrixInBodyFrame(context);
-    const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
-    // TODO(amcastro-tri): consider caching R_WF since also used in position and
-    //  velocity kinematics.
-    const math::RotationMatrix<T> R_WF = R_WP * R_PF;
-    const SpatialForce<T> F_BMo_F = R_WF.inverse() * F_BMo_W;
-
-    // Generalized velocities and forces use the same indexing.
-    auto tau = get_mutable_generalized_forces_from_array(tau_array);
-
-    // Demand that tau_applied is not an entry of tau. It would otherwise get
-    // overwritten.
-    DRAKE_DEMAND(tau.data() != tau_applied.data());
-
-    // The generalized forces on the mobilizer correspond to the active
-    // components of the spatial force performing work. Therefore we need to
-    // project F_BMo along the directions of motion.
-    // Project as: tau = H_FMᵀ(q) * F_BMo_F, Eq. (4).
-    get_mobilizer().ProjectSpatialForce(context, F_BMo_F, tau);
-
-    // Include the contribution of applied generalized forces.
-    if (tau_applied.size() != 0) tau -= tau_applied;
-  }
-
-  // Returns the topology information for this body node.
-  const BodyNodeTopology& get_topology() const { return topology_; }
-
-  // Helper method to retrieve a Jacobian matrix with respect to generalized
-  // velocities v for `this` node from an array storing the columns of a set of
-  // Jacobian matrices for each node.  This method is used by MultibodyTree
-  // implementations to retrieve per-node Jacobian matrices from a
-  // `std::vector` that would usually live in the cache.
-  // @param[in] H_array
-  //   This array stores a Jacobian matrix `H` for each node in the tree. Each
-  //   matrix has size `6 x nm` with `nm` the number of mobilities of the node.
-  //   `H_array` stores the columns of these matrices and therefore it consists
-  //   of a `std::vector` of vectors in ℝ⁶ with as many entries as the number
-  //   of generalized velocities v in the model.
-  //   `H_array` must be of size MultibodyTree::num_velocities().
-  // @retval H
-  //   An Eigen::Map to a matrix of size `6 x nm` corresponding to the Jacobian
-  //   matrix for this node.
-  Eigen::Map<const MatrixUpTo6<T>> GetJacobianFromArray(
-      const std::vector<Vector6<T>>& H_array) const {
-    DRAKE_DEMAND(static_cast<int>(H_array.size()) ==
-                 this->get_parent_tree().num_velocities());
-    const int start_index_in_v = get_topology().mobilizer_velocities_start_in_v;
-    const int num_velocities = get_topology().num_mobilizer_velocities;
-    DRAKE_DEMAND(num_velocities == 0 ||
-                 start_index_in_v < this->get_parent_tree().num_velocities());
-    // The first column of this node's hinge matrix H_PB_W:
-    const T* H_col0 =
-        num_velocities == 0 ? nullptr : H_array[start_index_in_v].data();
-    // Create an Eigen map to the full H_PB_W for this node:
-    return Eigen::Map<const MatrixUpTo6<T>>(H_col0, 6, num_velocities);
-  }
-
-  // Mutable version of GetJacobianFromArray().
-  Eigen::Map<MatrixUpTo6<T>> GetMutableJacobianFromArray(
-      std::vector<Vector6<T>>* H_array) const {
-    DRAKE_DEMAND(static_cast<int>(H_array->size()) ==
-                 this->get_parent_tree().num_velocities());
-    const int start_index_in_v = get_topology().mobilizer_velocities_start_in_v;
-    const int num_velocities = get_topology().num_mobilizer_velocities;
-    DRAKE_DEMAND(num_velocities == 0 ||
-                 start_index_in_v < this->get_parent_tree().num_velocities());
-    // The first column of this node's hinge matrix H_PB_W:
-    T* H_col0 =
-        num_velocities == 0 ? nullptr : (*H_array)[start_index_in_v].data();
-    // Create an Eigen map to the full H_PB_W for this node:
-    return Eigen::Map<MatrixUpTo6<T>>(H_col0, 6, num_velocities);
-  }
+      EigenPtr<VectorX<T>> tau_array) const = 0;
 
   // This method is used by MultibodyTree within a tip-to-base loop to compute
   // this node's articulated body inertia quantities that depend only on the
@@ -741,155 +464,11 @@ class BodyNode : public MultibodyElement<T> {
   //  - Ball: 3x3 blocks of zeroes.
 
   // TODO(sherm1) This function should not take a context.
-  void CalcArticulatedBodyInertiaCache_TipToBase(
+  virtual void CalcArticulatedBodyInertiaCache_TipToBase(
       const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
       const SpatialInertia<T>& M_B_W, const VectorX<T>& diagonal_inertias,
-      ArticulatedBodyInertiaCache<T>* abic) const {
-    DRAKE_THROW_UNLESS(topology_.rigid_body != world_index());
-    DRAKE_THROW_UNLESS(abic != nullptr);
-    DRAKE_THROW_UNLESS(diagonal_inertias.size() ==
-                       this->get_parent_tree().num_velocities());
-
-    // As a guideline for developers, a summary of the computations performed in
-    // this method is provided:
-    // Notation:
-    //  - B body frame associated with this node.
-    //  - P ("parent") body frame associated with this node's parent. This is
-    //    not to be confused with the articulated body inertia, which is also
-    //    named P.
-    //  - C within a loop over children, one of body B's children.
-    //  - P_B_W for the articulated body inertia of body B, about Bo, and
-    //    expressed in world frame W.
-    //  - Pplus_PB_W for the same articulated body inertia P_B_W but projected
-    //    across B's inboard mobilizer to frame P so that instead of
-    //    F_Bo_W = P_B_W A_WB + Z_Bo_W, we can write
-    //    F_Bo_W = Pplus_PB_W Aplus_WB + Zplus_Bo_W where Aplus_WB is defined
-    //    in Section 6.2.2, Page 101 of [Jain 2010] and Zplus_Bo_W is defined
-    //    in Section 6.3, Page 108 of [Jain 2010].
-    //  - Φ(p_PQ) for Jain's rigid body transformation operator. In code,
-    //    V_MQ = Φᵀ(p_PQ) V_MP is equivalent to V_MP.Shift(p_PQ).
-    //
-    // The goal is to populate the articulated body cache with values necessary
-    // for computing generalized accelerations in the second pass of the
-    // articulated body algorithm. This computation is recursive, and assumes
-    // that required articulated body quantities are already computed for all
-    // children.
-    //
-    // We compute the articulated inertia of the current body by summing
-    // contributions from all its children with its own spatial inertia. Note
-    // that Φ is the is the rigid body shift operator as defined in [Jain 2010]
-    // (Φ(P, Q) in Jain's book corresponds to Φ(p_PQ) in the notation used
-    // here).
-    //   P_B_W = Σᵢ(Φ(p_BCᵢ_W) Pplus_BCᵢ_W Φ(p_BCᵢ_W)ᵀ) + M_B_W
-    //         = Σᵢ(Pplus_BCᵢb_W) + M_B_W                                   (1)
-    // where Pplus_BCᵢb_W is the articulated body inertia P_Cᵢ_W of the child
-    // body Cᵢ, projected across its inboard mobilizer to frame B, shifted to
-    // frame B, and expressed in the world frame W.
-    //
-    // From P_B_W, we can obtain Pplus_PB_W by projecting the articulated body
-    // inertia for this node across its mobilizer.
-    //   Pplus_PB_W = (I - P_B_W H_PB_W (H_PB_Wᵀ P_B_W H_PB_W)⁻¹ H_PB_Wᵀ)
-    //                  P_B_W                                               (2)
-    // where H_PB_W is the hinge mapping matrix.
-    //
-    // A few quantities are required in the second pass. We write them out
-    // explicitly so we can cache them and simplify the expression for P_PB_W.
-    //   D_B = H_PB_Wᵀ P_B_W H_PB_W                                        (3)
-    //   g_PB_W = P_B_W H_PB_W D_B⁻¹                                       (4)
-    // where D_B is the articulated body hinge inertia and g_PB_W is the
-    // Kalman gain.
-    //
-    // With D_B, it is possible to view equation (2) in another manner. D_B
-    // relates mobility-space forces to mobility-space accelerations. We can
-    // view Pplus_PB_W as subtracting the mobilizer space inertia that
-    // results from expanding D_B into an articulated body inertia from B's
-    // articulated body inertia.
-    //
-    // In order to reduce the number of computations, we can save the common
-    // factor U_B_W = H_PB_Wᵀ P_B_W. We then can write:
-    //   D_B = U_B_W H_PB_W                                                  (5)
-    // and for g,
-    //   g_PB_Wᵀ = (D_B⁻¹)ᵀ H_PB_Wᵀ P_B_Wᵀ
-    //           = (D_Bᵀ)⁻¹ H_PB_Wᵀ P_B_W
-    //           = D_B⁻¹ U_B_W                                               (6)
-    // where we used the fact that both D and P are symmetric. Notice in the
-    // last expression for g_PB_Wᵀ we are reusing the common factor U_B_W.
-    //
-    // Given the articulated body hinge inertia and Kalman gain, we can simplify
-    // the equation in (2).
-    //   Pplus_PB_W = (I - g_PB_W H_PB_Wᵀ) P_B_W
-    //              = P_B_W - g_PB_W H_PB_Wᵀ P_B_W
-    //              = P_B_W - g_PB_W * U_B_W                                 (7)
-
-    // Compute articulated body inertia for body using (1).
-    ArticulatedBodyInertia<T>& P_B_W = get_mutable_P_B_W(abic);
-    P_B_W = ArticulatedBodyInertia<T>(M_B_W);
-
-    // Add articulated body inertia contributions from all children.
-    for (const BodyNode<T>* child : children_) {
-      // Shift vector p_CoBo_W.
-      const Vector3<T>& p_BoCo_W = child->get_p_PoBo_W(pc);
-      const Vector3<T> p_CoBo_W = -p_BoCo_W;
-
-      // Pull Pplus_BC_W from cache (which is Pplus_PB_W for child).
-      const ArticulatedBodyInertia<T>& Pplus_BC_W =
-          child->get_Pplus_PB_W(*abic);
-
-      // Shift Pplus_BC_W to Pplus_BCb_W.
-      // This is known to be one of the most expensive operations of ABA and
-      // must not be overlooked. Refer to #12435 for details.
-      const ArticulatedBodyInertia<T> Pplus_BCb_W = Pplus_BC_W.Shift(p_CoBo_W);
-
-      // Add Pplus_BCb_W contribution to articulated body inertia.
-      P_B_W += Pplus_BCb_W;
-    }
-
-    // Get the number of mobilizer velocities (number of columns of H_PB_W).
-    const int nv = get_num_mobilizer_velocities();
-
-    ArticulatedBodyInertia<T>& Pplus_PB_W = get_mutable_Pplus_PB_W(abic);
-    Pplus_PB_W = P_B_W;
-
-    // We now proceed to compute Pplus_PB_W using Eq. (7):
-    //   Pplus_PB_W = P_B_W - g_PB_W * U_B_W
-    // For weld joints (with nv = 0) or locked joints, terms involving the hinge
-    // matrix H_PB_W go away and therefore Pplus_PB_W = P_B_W. We check this
-    // below.
-    if (nv != 0 && !this->mobilizer_->is_locked(context)) {
-      // Compute common term U_B_W.
-      const MatrixUpTo6<T> U_B_W = H_PB_W.transpose() * P_B_W;
-
-      // Compute the articulated body hinge inertia, D_B, using (5).
-      MatrixUpTo6<T> D_B(nv, nv);
-      D_B.template triangularView<Eigen::Lower>() = U_B_W * H_PB_W;
-
-      // Include the effect of additional diagonal inertias. See @ref
-      // additional_diagonal_inertias.
-      D_B.diagonal() +=
-          diagonal_inertias.segment(this->velocity_start_in_v(), nv);
-
-      // Compute the LLT factorization of D_B as llt_D_B.
-      math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& llt_D_B =
-          get_mutable_llt_D_B(abic);
-      CalcArticulatedBodyHingeInertiaMatrixFactorization(D_B, &llt_D_B);
-
-      // Compute the Kalman gain, g_PB_W, using (6).
-      Matrix6xUpTo6<T>& g_PB_W = get_mutable_g_PB_W(abic);
-      g_PB_W = llt_D_B.Solve(U_B_W).transpose();
-
-      // Project P_B_W using (7) to obtain Pplus_PB_W, the articulated body
-      // inertia of this body B as felt by body P and expressed in frame W.
-      // Symmetrize the computation to reduce floating point errors.
-      // TODO(amcastro-tri): Notice that the line below makes the implicit
-      //  assumption that g_PB_W * U_B_W is SPD and only the lower triangular
-      //  portion is used, see the documentation for ArticulatedBodyInertia's
-      //  constructor (checked only during Debug builds). This
-      //  *might* result in the accumulation of floating point round off errors
-      //  for long kinematic chains. Further investigation is required.
-      Pplus_PB_W -= ArticulatedBodyInertia<T>(g_PB_W * U_B_W);
-    }
-  }
+      ArticulatedBodyInertiaCache<T>* abic) const = 0;
 
   // This method is used by MultibodyTree within a tip-to-base loop to compute
   // the force bias terms in the articulated body algorithm. Please refer to
@@ -935,59 +514,14 @@ class BodyNode : public MultibodyElement<T> {
   // nullptr.
 
   // TODO(sherm1) This function should not take a context.
-  void CalcArticulatedBodyForceCache_TipToBase(
+  virtual void CalcArticulatedBodyForceCache_TipToBase(
       const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
       const VelocityKinematicsCache<T>*, const SpatialForce<T>& Fb_Bo_W,
       const ArticulatedBodyInertiaCache<T>& abic,
       const SpatialForce<T>& Zb_Bo_W, const SpatialForce<T>& Fapplied_Bo_W,
       const Eigen::Ref<const VectorX<T>>& tau_applied,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
-      ArticulatedBodyForceCache<T>* aba_force_cache) const {
-    DRAKE_THROW_UNLESS(topology_.rigid_body != world_index());
-    DRAKE_THROW_UNLESS(aba_force_cache != nullptr);
-
-    // As a guideline for developers, please refer to @ref
-    // internal_forward_dynamics for a detailed description of the algorithm and
-    // notation inuse.
-
-    // Compute the residual spatial force, Z_Bo_W, according to (1).
-    SpatialForce<T> Z_Bo_W = Fb_Bo_W - Fapplied_Bo_W;
-
-    // Add residual spatial force contributions from all children.
-    for (const BodyNode<T>* child : children_) {
-      // Shift vector from Co to Bo.
-      const Vector3<T>& p_BoCo_W = child->get_p_PoBo_W(pc);
-      const Vector3<T> p_CoBo_W = -p_BoCo_W;
-
-      // Pull Zplus_BC_W from cache (which is Zplus_PB_W for child).
-      const SpatialForce<T>& Zplus_BC_W =
-          child->get_Zplus_PB_W(*aba_force_cache);
-
-      // Shift Zplus_BC_W to Zplus_BCb_W.
-      const SpatialForce<T> Zplus_BCb_W = Zplus_BC_W.Shift(p_CoBo_W);
-
-      // Add Zplus_BCb_W contribution to residual spatial force.
-      Z_Bo_W += Zplus_BCb_W;
-    }
-
-    get_mutable_Zplus_PB_W(aba_force_cache) = Z_Bo_W + Zb_Bo_W;
-
-    const int nv = get_num_mobilizer_velocities();
-
-    // These terms do not show up for zero mobilities (weld or locked).
-    if (nv != 0 && !this->mobilizer_->is_locked(context)) {
-      // Compute the articulated body inertia innovations generalized force,
-      // e_B, according to (4).
-      VectorUpTo6<T>& e_B = get_mutable_e_B(aba_force_cache);
-      e_B.noalias() = tau_applied - H_PB_W.transpose() * Z_Bo_W.get_coeffs();
-
-      // Get the Kalman gain from cache.
-      const Matrix6xUpTo6<T>& g_PB_W = get_g_PB_W(abic);
-
-      // Compute the projected articulated body force bias Zplus_PB_W.
-      get_mutable_Zplus_PB_W(aba_force_cache) += SpatialForce<T>(g_PB_W * e_B);
-    }
-  }
+      ArticulatedBodyForceCache<T>* aba_force_cache) const = 0;
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
   // the generalized accelerations `vdot` and the spatial accelerations `A_WB`.
@@ -1025,56 +559,13 @@ class BodyNode : public MultibodyElement<T> {
   // @throws when called on the _root_ node of `ac` or `vdot` is nullptr.
 
   // TODO(sherm1) This function should not take a context.
-  void CalcArticulatedBodyAccelerations_BaseToTip(
+  virtual void CalcArticulatedBodyAccelerations_BaseToTip(
       const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
       const ArticulatedBodyInertiaCache<T>& abic,
       const ArticulatedBodyForceCache<T>& aba_force_cache,
       const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
       const SpatialAcceleration<T>& Ab_WB,
-      AccelerationKinematicsCache<T>* ac) const {
-    DRAKE_THROW_UNLESS(ac != nullptr);
-
-    // As a guideline for developers, please refer to @ref
-    // abi_computing_accelerations for a detailed description of the algorithm
-    // and the notation in use.
-
-    // Get the spatial acceleration of the parent.
-    const SpatialAcceleration<T>& A_WP = parent_node_->get_A_WB(*ac);
-
-    // Shift vector p_PoBo_W from the parent origin to the body origin.
-    const Vector3<T>& p_PoBo_W = get_p_PoBo_W(pc);
-
-    const int nv = get_num_mobilizer_velocities();
-
-    // Rigidly shift the acceleration of the parent node.
-    const SpatialAcceleration<T> Aplus_WB = SpatialAcceleration<T>(
-        A_WP.rotational(),
-        A_WP.translational() + A_WP.rotational().cross(p_PoBo_W));
-
-    SpatialAcceleration<T>& A_WB = get_mutable_A_WB(ac);
-    A_WB = Aplus_WB + Ab_WB;
-
-    // These quantities do not contribute when nv = 0 (weld or locked joint). We
-    // skip them since Eigen does not allow certain operations on zero-sized
-    // objects. It is important to set the generalized accelerations to zero for
-    // locked mobilizers.
-    if (this->mobilizer_->is_locked(context)) {
-      get_mutable_accelerations(ac).setZero();
-    } else if (nv != 0) {
-      // Compute nu_B, the articulated body inertia innovations generalized
-      // acceleration.
-      const VectorUpTo6<T> nu_B =
-          get_llt_D_B(abic).Solve(get_e_B(aba_force_cache));
-
-      // Mutable reference to the generalized acceleration.
-      auto vmdot = get_mutable_accelerations(ac);
-      const Matrix6xUpTo6<T>& g_PB_W = get_g_PB_W(abic);
-      vmdot = nu_B - g_PB_W.transpose() * A_WB.get_coeffs();
-
-      // Update with vmdot term the spatial acceleration of the current body.
-      A_WB += SpatialAcceleration<T>(H_PB_W * vmdot);
-    }
-  }
+      AccelerationKinematicsCache<T>* ac) const = 0;
 
   // This method is used by MultibodyTree within a tip-to-base loop to compute
   // the composite body inertia of each body in the system.
@@ -1090,31 +581,10 @@ class BodyNode : public MultibodyElement<T> {
   // @pre CalcCompositeBodyInertia_TipToBase() must have already been called
   // for the children nodes (and, by recursive precondition, all outboard nodes
   // in the tree.)
-  void CalcCompositeBodyInertia_TipToBase(
+  virtual void CalcCompositeBodyInertia_TipToBase(
       const SpatialInertia<T>& M_B_W, const PositionKinematicsCache<T>& pc,
       const std::vector<SpatialInertia<T>>& Mc_B_W_all,
-      SpatialInertia<T>* Mc_B_W) const {
-    DRAKE_THROW_UNLESS(topology_.rigid_body != world_index());
-    DRAKE_THROW_UNLESS(Mc_B_W != nullptr);
-
-    // Composite body inertia R_B_W for this node B, about its frame's origin
-    // Bo, and expressed in the world frame W. Here we adopt the notation used
-    // in Jain's book.
-    *Mc_B_W = M_B_W;
-    // Add composite body inertia contributions from all children.
-    for (const BodyNode<T>* child : children_) {
-      // Shift vector p_CoBo_W.
-      const Vector3<T>& p_BoCo_W = child->get_p_PoBo_W(pc);
-      const Vector3<T> p_CoBo_W = -p_BoCo_W;
-
-      // Composite body inertia for outboard child body C, about Co, expressed
-      // in W.
-      const SpatialInertia<T>& Mc_CCo_W = Mc_B_W_all[child->index()];
-
-      // Shift to Bo and add it to the composite body inertia of B.
-      *Mc_B_W += Mc_CCo_W.Shift(p_CoBo_W);
-    }
-  }
+      SpatialInertia<T>* Mc_B_W) const = 0;
 
   // Computes the spatial acceleration bias `Ab_WB(q, v)` for `this` node, a
   // function of both configuration q and velocities v. This term appears in
@@ -1135,109 +605,52 @@ class BodyNode : public MultibodyElement<T> {
   // @throws when `Ab_WB` is nullptr.
 
   // TODO(sherm1) This function should not take a context.
-  void CalcSpatialAccelerationBias(
+  virtual void CalcSpatialAccelerationBias(
       const systems::Context<T>& context,
       const FrameBodyPoseCache<T>& frame_body_pose_cache,
       const PositionKinematicsCache<T>& pc,
       const VelocityKinematicsCache<T>& vc,
-      SpatialAcceleration<T>* Ab_WB) const {
-    DRAKE_THROW_UNLESS(Ab_WB != nullptr);
-    // As a guideline for developers, please refer to @ref
-    // abi_computing_accelerations for a detailed description and derivation of
-    // Ab_WB.
+      SpatialAcceleration<T>* Ab_WB) const = 0;
 
-    Ab_WB->SetZero();
-    // Inboard frame F and outboard frame M of this node's mobilizer.
-    const Frame<T>& frame_F = inboard_frame();
-    const Frame<T>& frame_M = outboard_frame();
+  // Helper method to be called within a base-to-tip recursion that computes
+  // into the PositionKinematicsCache:
+  // - X_PB(q_B)
+  // - X_WB(q(W:P), q_B)
+  // - p_PoBo_W(q_B)
+  // where q_B is the generalized coordinates associated with this node's
+  // mobilizer. q(W:P) denotes all generalized positions in the kinematics path
+  // between the world and the parent body P. It assumes we are in a base-to-tip
+  // recursion and therefore `X_WP` has already been updated.
+  //
+  // This function doesn't depend on the particular Mobilizer type so we
+  // implement once here in the base class rather than in the templatized
+  // derived class.
+  void CalcAcrossMobilizerBodyPoses_BaseToTip(
+      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      PositionKinematicsCache<T>* pc) const;
 
-    // Compute R_PF and X_MB.
-    const math::RigidTransform<T>& X_PF =
-        frame_F.get_X_BF(frame_body_pose_cache);  // B==P
-    const math::RotationMatrix<T>& R_PF = X_PF.rotation();
-    const math::RigidTransform<T>& X_MB =
-        frame_M.get_X_FB(frame_body_pose_cache);  // F==M
+  // Forms LLT factorization of articulated rigid body's hinge inertia matrix.
+  // @param[in] D_B Articulated rigid body hinge matrix.
+  // @param[out] llt_D_B Stores the LLT factorization of D_B.
+  // @throws an exception if D_B is not positive definite or is near-singular.
+  // @pre llt_D_B is not nullptr.
+  // TODO(sherm1) This should be in BodyNodeImpl (templatized for particular
+  //  mobilizers) but is required by the existing body_node_test.cc.
+  void CalcArticulatedBodyHingeInertiaMatrixFactorization(
+      const MatrixUpTo6<T>& D_B,
+      math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>* llt_D_B) const;
 
-    // Parent position in the world is available from the position kinematics.
-    const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
-
-    // TODO(amcastro-tri): consider caching R_WF.
-    const math::RotationMatrix<T> R_WF = R_WP * R_PF;
-
-    // Compute shift vector p_MoBo_F.
-    const Vector3<T> p_MoBo_F = get_X_FM(pc).rotation() * X_MB.translation();
-
-    // The goal is to compute Ab_WB = Ac_WB + Ab_PB_W, see @ref
-    // abi_computing_accelerations.
-    // We first compute Ab_PB_W and add Ac_WB at the end.
-
-    // We are ultimately trying to compute Ab_WB = Ac_WB + Ab_PB_W, of which
-    // Ab_PB (that we're computing here) is a component. See @ref
-    // abi_computing_accelerations. Now, Ab_PB_W is the bias term for the
-    // acceleration A_PB_W. That is, it is the acceleration A_PB_W when vmdot is
-    // zero. We get Ab_PB_W by shifting and re-expressing Ab_FM, the across
-    // mobilizer spatial acceleration bias term.
-
-    // We first compute the acceleration bias Ab_FM = Hdot * vm.
-    // Note, A_FM = H_FM(qm) * vmdot + Ab_FM(qm, vm).
-    const VectorUpTo6<T> vmdot_zero =
-        VectorUpTo6<T>::Zero(get_num_mobilizer_velocities());
-    const SpatialAcceleration<T> Ab_FM =
-        get_mobilizer().CalcAcrossMobilizerSpatialAcceleration(context,
-                                                               vmdot_zero);
-
-    // Due to the fact that frames P and F are on the same rigid body, we have
-    // that V_PF = 0. Therefore, DtP(V_PB) = DtF(V_PB). Since M and B are also
-    // on the same rigid body, V_MB = 0. We then recognize that V_PB = V_PFb +
-    // V_FMb + V_MB = V_FMb. Together, we get that A_PB = DtF(V_FMb) =
-    // A_FM.Shift(p_MoBo, w_FM).
-    const Vector3<T> w_FM = get_V_FM(vc).rotational();
-    const SpatialAcceleration<T> Ab_PB_W = R_WF * Ab_FM.Shift(p_MoBo_F, w_FM);
-
-    // Spatial velocity of parent is available from the velocity kinematics.
-    const SpatialVelocity<T>& V_WP = get_V_WP(vc);
-    const Vector3<T>& w_WP = V_WP.rotational();
-    const Vector3<T>& v_WP = V_WP.translational();
-
-    // Velocity of this mobilized body in its parent is available from the
-    // velocity kinematics.
-    const SpatialVelocity<T>& V_PB_W = get_V_PB_W(vc);
-    const Vector3<T>& w_PB_W = V_PB_W.rotational();
-    const Vector3<T>& v_PB_W = V_PB_W.translational();
-
-    // Mobilized body spatial velocity in W.
-    const SpatialVelocity<T>& V_WB = get_V_WB(vc);
-    const Vector3<T>& w_WB = V_WB.rotational();
-    const Vector3<T>& v_WB = V_WB.translational();
-
-    // Compute Ab_WB according to:
-    // Ab_WB =  | w_WB x w_PB_W                 | + Ab_PB_W
-    //          | w_WP x (v_WB - v_WP + v_PB_W) |
-    // N.B: It is NOT true that v_PB_W = v_WB - v_WP, since you would otherwise
-    // be forgetting to shift v_WP to B. We prefer the expression used here
-    // since it is cheaper to compute, requiring only a single cross product,
-    // see @note in SpatialAcceleration::ComposeWithMovingFrameAcceleration()
-    // for a complete derivation.
-    *Ab_WB = SpatialAcceleration<T>(
-        w_WB.cross(w_PB_W) + Ab_PB_W.rotational(),
-        w_WP.cross(v_WB - v_WP + v_PB_W) + Ab_PB_W.translational());
-  }
-
- protected:
   // Returns the inboard frame F of this node's mobilizer.
-  // @throws std::exception if called on the root node corresponding to
-  // the _world_ body.
   const Frame<T>& inboard_frame() const {
     return get_mobilizer().inboard_frame();
   }
 
   // Returns the outboard frame M of this node's mobilizer.
-  // @throws std::exception if called on the root node corresponding to
-  // the _world_ body.
   const Frame<T>& outboard_frame() const {
     return get_mobilizer().outboard_frame();
   }
 
+ protected:
   // Returns the index to the parent RigidBody of the RigidBody associated with
   // this node. For the root node, corresponding to the world RigidBody, this
   // method returns an invalid BodyIndex. Attempts to using invalid indexes
@@ -1269,350 +682,16 @@ class BodyNode : public MultibodyElement<T> {
                      topology_.num_mobilizer_velocities);
   }
 
-  // =========================================================================
-  // PositionKinematicsCache Accessors and Mutators.
-
-  // Returns a const reference to the pose of the body B associated with this
-  // node as measured and expressed in the world frame W.
-  const math::RigidTransform<T>& get_X_WB(
-      const PositionKinematicsCache<T>& pc) const {
-    return pc.get_X_WB(topology_.index);
-  }
-
-  // Mutable version of get_X_WB().
-  math::RigidTransform<T>& get_mutable_X_WB(
-      PositionKinematicsCache<T>* pc) const {
-    return pc->get_mutable_X_WB(topology_.index);
-  }
-
-  // Returns a const reference to the pose of the parent body P measured and
-  // expressed in the world frame W.
-  const math::RigidTransform<T>& get_X_WP(
-      const PositionKinematicsCache<T>& pc) const {
-    return pc.get_X_WB(topology_.parent_body_node);
-  }
-
-  // Returns a const reference to the rotation matrix `R_WP` that relates the
-  // orientation of the world frame W to the parent frame P.
-  const math::RotationMatrix<T>& get_R_WP(
-      const PositionKinematicsCache<T>& pc) const {
-    return pc.get_R_WB(topology_.parent_body_node);
-  }
-
-  // Returns a constant reference to the across-mobilizer pose of the outboard
-  // frame M as measured and expressed in the inboard frame F.
-  const math::RigidTransform<T>& get_X_FM(
-      const PositionKinematicsCache<T>& pc) const {
-    return pc.get_X_FM(topology_.index);
-  }
-
-  // Returns a mutable reference to the across-mobilizer pose of the outboard
-  // frame M as measured and expressed in the inboard frame F.
-  math::RigidTransform<T>& get_mutable_X_FM(
-      PositionKinematicsCache<T>* pc) const {
-    return pc->get_mutable_X_FM(topology_.index);
-  }
-
-  // Returns a const reference to the pose of body B as measured and expressed
-  // in the frame of the parent body P.
-  const math::RigidTransform<T>& get_X_PB(
-      const PositionKinematicsCache<T>& pc) const {
-    return pc.get_X_PB(topology_.index);
-  }
-
-  // Returns a mutable reference to the pose of body B as measured and expressed
-  // in the frame of the parent body P.
-  math::RigidTransform<T>& get_mutable_X_PB(
-      PositionKinematicsCache<T>* pc) const {
-    return pc->get_mutable_X_PB(topology_.index);
-  }
-
-  const Vector3<T>& get_p_PoBo_W(const PositionKinematicsCache<T>& pc) const {
-    return pc.get_p_PoBo_W(topology_.index);
-  }
-
-  Vector3<T>& get_mutable_p_PoBo_W(PositionKinematicsCache<T>* pc) const {
-    return pc->get_mutable_p_PoBo_W(topology_.index);
-  }
-
-  // Helper method to be called within a base-to-tip recursion that computes
-  // into the PositionKinematicsCache:
-  // - X_PB(q_B)
-  // - X_WB(q(W:P), q_B)
-  // - p_PoBo_W(q_B)
-  // where q_B is the generalized coordinates associated with this node's
-  // mobilizer. q(W:P) denotes all generalized positions in the kinematics path
-  // between the world and the parent body P. It assumes we are in a base-to-tip
-  // recursion and therefore `X_WP` has already been updated.
-  //
-  // This function doesn't depend on the particular Mobilizer type so we
-  // implement once here in the base class rather than in the templatized
-  // derived class.
-  void CalcAcrossMobilizerBodyPoses_BaseToTip(
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
-      PositionKinematicsCache<T>* pc) const;
-
-  // For the body B associated with this node, return V_WB, B's spatial velocity
-  // in the world frame W, expressed in W (for Bo, the body frame's origin).
-  const SpatialVelocity<T>& get_V_WB(
-      const VelocityKinematicsCache<T>& vc) const {
-    return vc.get_V_WB(topology_.index);
-  }
-
-  // Returns the spatial velocity `V_WP` of the body frame P in the parent node
-  // as measured and expressed in the world frame.
-  const SpatialVelocity<T>& get_V_WP(
-      const VelocityKinematicsCache<T>& vc) const {
-    return vc.get_V_WB(topology_.parent_body_node);
-  }
-
-  // Returns a const reference to the across-mobilizer spatial velocity `V_FM`
-  // of the outboard frame M in the inboard frame F, expressed in the F frame.
-  const SpatialVelocity<T>& get_V_FM(
-      const VelocityKinematicsCache<T>& vc) const {
-    return vc.get_V_FM(topology_.index);
-  }
-
-  // Returns a const reference to the spatial velocity `V_PB_W` of `this`
-  // node's body B in the parent node's body P, expressed in the world frame W.
-  const SpatialVelocity<T>& get_V_PB_W(
-      const VelocityKinematicsCache<T>& vc) const {
-    return vc.get_V_PB_W(topology_.index);
-  }
-
  private:
   friend class BodyNodeTester;
-
-  // =========================================================================
-  // AccelerationKinematicsCache Accessors and Mutators.
-
-  // For the body B associated with `this` node, returns A_WB, body B's
-  // spatial acceleration in the world frame W, expressed in W
-  // (for point Bo, the body's origin).
-  const SpatialAcceleration<T>& get_A_WB(
-      const AccelerationKinematicsCache<T>& ac) const {
-    return ac.get_A_WB(topology_.index);
-  }
-
-  // Mutable version of get_A_WB().
-  SpatialAcceleration<T>& get_mutable_A_WB(
-      AccelerationKinematicsCache<T>* ac) const {
-    return ac->get_mutable_A_WB(topology_.index);
-  }
-
-  // Returns a const reference to the spatial acceleration `A_WP` of the body
-  // frame P in the parent node as measured and expressed in the world frame.
-  const SpatialAcceleration<T>& get_A_WP(
-      const AccelerationKinematicsCache<T>& ac) const {
-    return ac.get_A_WB(topology_.parent_body_node);
-  }
-
-  // Returns an Eigen expression of the vector of generalized accelerations
-  // for this node's inboard mobilizer from the vector of generalized
-  // accelerations for the entire model.
-  Eigen::Ref<VectorX<T>> get_mutable_accelerations(
-      AccelerationKinematicsCache<T>* ac) const {
-    VectorX<T>& vdot = ac->get_mutable_vdot();
-    return get_mutable_velocities_from_array(&vdot);
-  }
-
-  // =========================================================================
-  // ArticulatedBodyInertiaCache Accessors and Mutators.
-
-  // Returns a const reference to the articulated body inertia `P_B_W` of the
-  // body taken about Bo and expressed in W.
-  const ArticulatedBodyInertia<T>& get_P_B_W(
-      const ArticulatedBodyInertiaCache<T>& abic) const {
-    return abic.get_P_B_W(topology_.index);
-  }
-
-  // Mutable version of get_P_B_W().
-  ArticulatedBodyInertia<T>& get_mutable_P_B_W(
-      ArticulatedBodyInertiaCache<T>* abic) const {
-    return abic->get_mutable_P_B_W(topology_.index);
-  }
-
-  // Returns a const reference to the articulated body inertia `Pplus_PB_W`,
-  // which can be thought of as the articulated body inertia of parent body P
-  // as though it were inertialess, but taken about Bo and expressed in W.
-  const ArticulatedBodyInertia<T>& get_Pplus_PB_W(
-      const ArticulatedBodyInertiaCache<T>& abic) const {
-    return abic.get_Pplus_PB_W(topology_.index);
-  }
-
-  // Mutable version of get_Pplus_PB_W().
-  ArticulatedBodyInertia<T>& get_mutable_Pplus_PB_W(
-      ArticulatedBodyInertiaCache<T>* abic) const {
-    return abic->get_mutable_Pplus_PB_W(topology_.index);
-  }
-
-  // Returns a const reference to the LLT factorization `llt_D_B` of the
-  // articulated body hinge inertia.
-  const math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& get_llt_D_B(
-      const ArticulatedBodyInertiaCache<T>& abic) const {
-    return abic.get_llt_D_B(topology_.index);
-  }
-
-  // Mutable version of get_llt_D_B().
-  math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& get_mutable_llt_D_B(
-      ArticulatedBodyInertiaCache<T>* abic) const {
-    return abic->get_mutable_llt_D_B(topology_.index);
-  }
-
-  // Forms LLT factorization of articulated rigid body's hinge inertia matrix.
-  // @param[in] D_B Articulated rigid body hinge matrix.
-  // @param[out] llt_D_B Stores the LLT factorization of D_B.
-  // @throws an exception if D_B is not positive definite or is near-singular.
-  // @pre llt_D_B is not nullptr.
-  void CalcArticulatedBodyHingeInertiaMatrixFactorization(
-      const MatrixUpTo6<T>& D_B,
-      math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>* llt_D_B) const;
-
-  // Returns a const reference to the Kalman gain `g_PB_W` of the body.
-  const Matrix6xUpTo6<T>& get_g_PB_W(
-      const ArticulatedBodyInertiaCache<T>& abic) const {
-    return abic.get_g_PB_W(topology_.index);
-  }
-
-  // Mutable version of get_g_PB_W().
-  Matrix6xUpTo6<T>& get_mutable_g_PB_W(
-      ArticulatedBodyInertiaCache<T>* abic) const {
-    return abic->get_mutable_g_PB_W(topology_.index);
-  }
-
-  // =========================================================================
-  // ArticulatedBodyForceCache Accessors and Mutators.
-
-  // Returns a const reference to the articulated body inertia residual force
-  // `Zplus_PB_W` for this body projected across its inboard mobilizer to
-  // frame P.
-  const SpatialForce<T>& get_Zplus_PB_W(
-      const ArticulatedBodyForceCache<T>& aba_force_cache) const {
-    return aba_force_cache.get_Zplus_PB_W(topology_.index);
-  }
-
-  // Mutable version of get_Zplus_PB_W().
-  SpatialForce<T>& get_mutable_Zplus_PB_W(
-      ArticulatedBodyForceCache<T>* aba_force_cache) const {
-    return aba_force_cache->get_mutable_Zplus_PB_W(topology_.index);
-  }
-
-  // Returns a const reference to the Coriolis spatial acceleration `Ab_WB`
-  // for this body due to the relative velocities of body B and body P.
-  const VectorUpTo6<T>& get_e_B(
-      const ArticulatedBodyForceCache<T>& aba_force_cache) const {
-    return aba_force_cache.get_e_B(topology_.index);
-  }
-
-  // Mutable version of get_e_B().
-  VectorUpTo6<T>& get_mutable_e_B(
-      ArticulatedBodyForceCache<T>* aba_force_cache) const {
-    return aba_force_cache->get_mutable_e_B(topology_.index);
-  }
-
-  // =========================================================================
-  // Per Node Array Accessors.
-  // Quantities are ordered by MobodIndex unless otherwise specified.
-
-  // Returns a const reference to the spatial acceleration of the body B
-  // associated with this node as measured and expressed in the world frame W,
-  // given an array of spatial accelerations for the entire MultibodyTree model.
-  const SpatialAcceleration<T>& get_A_WB_from_array(
-      const std::vector<SpatialAcceleration<T>>& A_WB_array) const {
-    return A_WB_array[topology_.index];
-  }
-
-  // Mutable version of get_A_WB_from_array().
-  SpatialAcceleration<T>& get_mutable_A_WB_from_array(
-      std::vector<SpatialAcceleration<T>>* A_WB_array) const {
-    DRAKE_ASSERT(A_WB_array != nullptr);
-    return (*A_WB_array)[topology_.index];
-  }
-
-  // Returns a const reference to the spatial acceleration `A_WP` of the body
-  // frame P in the parent node as measured and expressed in the world frame,
-  // given an array of spatial accelerations for the entire MultibodyTree model.
-  const SpatialAcceleration<T>& get_A_WP_from_array(
-      const std::vector<SpatialAcceleration<T>>& A_WB_array) const {
-    return A_WB_array[topology_.parent_body_node];
-  }
-
-  // Mutable version of get_A_WP_from_array().
-  SpatialAcceleration<T>& get_mutable_A_WP_from_array(
-      std::vector<SpatialAcceleration<T>>* A_WB_array) const {
-    DRAKE_ASSERT(A_WB_array != nullptr);
-    return (*A_WB_array)[topology_.parent_body_node];
-  }
-
-  // Helper to get an Eigen expression of the vector of generalized velocities
-  // from a vector of generalized velocities for the entire parent multibody
-  // tree. Useful for the implementation of operator forms where the generalized
-  // velocity (or time derivatives of the generalized velocities) is an argument
-  // to the operator.
-  Eigen::Ref<VectorX<T>> get_mutable_velocities_from_array(
-      EigenPtr<VectorX<T>> v) const {
-    DRAKE_ASSERT(v != nullptr);
-    return v->segment(topology_.mobilizer_velocities_start_in_v,
-                      topology_.num_mobilizer_velocities);
-  }
-
-  // Helper to get an Eigen expression of the vector of generalized forces
-  // from a vector of generalized forces for the entire parent multibody
-  // tree.
-  Eigen::Ref<VectorX<T>> get_mutable_generalized_forces_from_array(
-      EigenPtr<VectorX<T>> tau) const {
-    DRAKE_ASSERT(tau != nullptr);
-    return get_mutable_velocities_from_array(tau);
-  }
-
-  // This method computes the total force Ftot_BBo on body B that must be
-  // applied for it to incur in a spatial acceleration A_WB. Mathematically:
-  //   Ftot_BBo = M_B_W * A_WB + b_Bo
-  // where b_Bo contains the velocity dependent gyroscopic terms (see Eq. 2.26,
-  // p. 27, in A. Jain's book). The above balance is performed at the origin
-  // Bo of the body frame B, which does not necessarily need to coincide with
-  // the body center of mass.
-  // Notes:
-  //   1. Ftot_BBo = b_Bo when A_WB = 0.
-  //   2. b_Bo = 0 when w_WB = 0.
-  //   3. b_Bo.translational() = 0 when Bo = Bcm (p_BoBcm = 0).
-  //      When Fb_Bo_W_cache is nullptr velocities are considered to be zero.
-  //      Therefore, from (2), the bias term is assumed to be zero and is not
-  //      computed.
-  void CalcBodySpatialForceGivenItsSpatialAcceleration(
-      const std::vector<SpatialInertia<T>>& M_B_W_cache,
-      const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
-      const SpatialAcceleration<T>& A_WB,
-      SpatialForce<T>* Ftot_BBo_W_ptr) const {
-    DRAKE_DEMAND(Ftot_BBo_W_ptr != nullptr);
-
-    // Output spatial force applied on mobilized body B, at Bo, measured in W.
-    SpatialForce<T>& Ftot_BBo_W = *Ftot_BBo_W_ptr;
-
-    // RigidBody for this node.
-    const RigidBody<T>& body_B = body();
-
-    // Mobilized body B spatial inertia about Bo expressed in world W.
-    const SpatialInertia<T>& M_B_W = M_B_W_cache[body_B.mobod_index()];
-
-    // Equations of motion for a rigid body written at a generic point Bo not
-    // necessarily coincident with the body's center of mass. This corresponds
-    // to Eq. 2.26 (p. 27) in A. Jain's book.
-    Ftot_BBo_W = M_B_W * A_WB;
-
-    // If velocities are zero, then Fb_Bo_W is zero and does not contribute.
-    if (Fb_Bo_W_cache != nullptr) {
-      // Dynamic bias for body B.
-      const SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_cache)[body_B.mobod_index()];
-      Ftot_BBo_W += Fb_Bo_W;
-    }
-  }
 
   // Implementation for MultibodyElement::DoSetTopology().
   // At MultibodyTree::Finalize() time, each body retrieves its topology
   // from the parent MultibodyTree.
+  // TODO(sherm1) Get rid of this.
   void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
-    topology_ = tree_topology.get_body_node(this->index());
+    DRAKE_DEMAND(mobilizer_ != nullptr);  // Should have been set already.
+    topology_ = tree_topology.get_body_node(mobod_index());
   }
 
   BodyNodeTopology topology_;

--- a/multibody/tree/body_node_impl.cc
+++ b/multibody/tree/body_node_impl.cc
@@ -17,9 +17,9 @@ namespace internal {
 
 template <typename T, template <typename> class ConcreteMobilizer>
 BodyNodeImpl<T, ConcreteMobilizer>::BodyNodeImpl(
-    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+    const internal::BodyNode<T>* parent_node, const RigidBody<T>* rigid_body,
     const Mobilizer<T>* mobilizer)
-    : BodyNode<T>(parent_node, body, mobilizer),
+    : BodyNode<T>(parent_node, rigid_body, mobilizer),
       mobilizer_(dynamic_cast<const ConcreteMobilizer<T>*>(mobilizer)) {
   DRAKE_DEMAND(mobilizer_ != nullptr);
 }
@@ -32,14 +32,14 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcPositionKinematicsCache_BaseToTip(
     const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
     PositionKinematicsCache<T>* pc) const {
   // This method must not be called for the "world" body node.
-  DRAKE_ASSERT(this->index() != world_mobod_index());
+  DRAKE_ASSERT(mobod_index() != world_mobod_index());
   DRAKE_ASSERT(pc != nullptr);
 
   // TODO(sherm1) This should be an update rather than generating a whole
   //  new transform.
 
   // Update mobilizer-specific position dependent kinematics.
-  math::RigidTransform<T>& X_FM = this->get_mutable_X_FM(pc);
+  math::RigidTransform<T>& X_FM = get_mutable_X_FM(pc);
   X_FM = mobilizer_->calc_X_FM(get_q(positions));
 
   // Given X_FM that we just put into PositionKinematicsCache (pc), and
@@ -60,14 +60,14 @@ void BodyNodeImpl<T, ConcreteMobilizer>::
         const PositionKinematicsCache<T>& pc,
         std::vector<Vector6<T>>* H_PB_W_cache) const {
   DRAKE_ASSERT(H_PB_W_cache != nullptr);
-  DRAKE_ASSERT(this->index() != world_mobod_index());
+  DRAKE_ASSERT(mobod_index() != world_mobod_index());
 
   // Nothing to do for a weld mobilizer.
   if constexpr (kNv > 0) {
     // Inboard frame F of this node's mobilizer.
-    const Frame<T>& frame_F = this->inboard_frame();
+    const Frame<T>& frame_F = inboard_frame();
     // Outboard frame M of this node's mobilizer.
-    const Frame<T>& frame_M = this->outboard_frame();
+    const Frame<T>& frame_M = outboard_frame();
 
     const math::RigidTransform<T>& X_PF =
         frame_F.get_X_BF(frame_body_pose_cache);  // B==P
@@ -76,13 +76,13 @@ void BodyNodeImpl<T, ConcreteMobilizer>::
         frame_M.get_X_FB(frame_body_pose_cache);  // F==M
 
     // Form the rotation matrix relating the world frame W and parent body P.
-    const math::RotationMatrix<T>& R_WP = this->get_R_WP(pc);
+    const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
 
     // Orientation (rotation) of frame F with respect to the world frame W.
     const math::RotationMatrix<T> R_WF = R_WP * R_PF;
 
     // Vector from Mo to Bo expressed in frame F as needed below:
-    const math::RotationMatrix<T>& R_FM = this->get_X_FM(pc).rotation();
+    const math::RotationMatrix<T>& R_FM = get_X_FM(pc).rotation();
     const Vector3<T>& p_MB_M = X_MB.translation();
     const Vector3<T> p_MB_F = R_FM * p_MB_M;
 
@@ -110,7 +110,7 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcVelocityKinematicsCache_BaseToTip(
     const std::vector<Vector6<T>>& H_PB_W_cache, const T* velocities,
     VelocityKinematicsCache<T>* vc) const {
   // This method must not be called for the "world" body node.
-  DRAKE_ASSERT(this->index() != world_mobod_index());
+  DRAKE_ASSERT(mobod_index() != world_mobod_index());
   DRAKE_ASSERT(vc != nullptr);
 
   // Hinge matrix for this node. H_PB_W ∈ ℝ⁶ˣⁿᵐ with nm ∈ [0; 6] the
@@ -122,7 +122,7 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcVelocityKinematicsCache_BaseToTip(
   //  Eigen::Map<const MatrixUpTo6<T>> H_PB_W =
   //      this->GetJacobianFromArray(H_PB_W_cache);
   //  DRAKE_ASSERT(H_PB_W.rows() == 6);
-  //  DRAKE_ASSERT(H_PB_W.cols() == this->get_num_mobilizer_velocities());
+  //  DRAKE_ASSERT(H_PB_W.cols() == mobilizer_->num_velocities();
 
   // As a guideline for developers, a summary of the computations performed in
   // this method is provided:
@@ -199,17 +199,746 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcVelocityKinematicsCache_BaseToTip(
 
   // Shift vector between the parent body P and this node's body B,
   // expressed in the world frame W.
-  const Vector3<T>& p_PB_W = this->get_p_PoBo_W(pc);
+  const Vector3<T>& p_PB_W = get_p_PoBo_W(pc);
 
   // Since we are in a base-to-tip recursion the parent body P's spatial
   // velocity is already available in the cache.
-  const SpatialVelocity<T>& V_WP = this->get_V_WP(*vc);
+  const SpatialVelocity<T>& V_WP = get_V_WP(*vc);
 
   // =========================================================================
   // Update velocity V_WB of this node's body B in the world frame. Using the
   // recursive Eq. (1). See summary at the top of this method.
-  this->get_mutable_V_WB(vc) =
-      V_WP.ComposeWithMovingFrameVelocity(p_PB_W, V_PB_W);
+  get_mutable_V_WB(vc) = V_WP.ComposeWithMovingFrameVelocity(p_PB_W, V_PB_W);
+}
+
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::CalcSpatialAcceleration_BaseToTip(
+    const systems::Context<T>& context,
+    const FrameBodyPoseCache<T>& frame_body_poses_cache,
+    const PositionKinematicsCache<T>& pc, const VelocityKinematicsCache<T>* vc,
+    const VectorX<T>& mbt_vdot,
+    std::vector<SpatialAcceleration<T>>* A_WB_array_ptr) const {
+  // This method must not be called for the "world" body node.
+  DRAKE_DEMAND(mobod_index() != world_mobod_index());
+  DRAKE_DEMAND(A_WB_array_ptr != nullptr);
+  std::vector<SpatialAcceleration<T>>& A_WB_array = *A_WB_array_ptr;
+
+  // As a guideline for developers, a summary of the computations performed in
+  // this method is provided:
+  // Notation:
+  //  - B body frame associated with this node.
+  //  - P ("parent") body frame associated with this node's parent.
+  //  - F mobilizer inboard frame attached to body P.
+  //  - M mobilizer outboard frame attached to body B.
+  // The goal is computing the spatial acceleration A_WB of body B measured in
+  // the world frame W. The calculation is recursive and assumes the spatial
+  // acceleration A_WP of the inboard body P is already computed.
+  // The spatial velocities of P and B are related by the recursive relation
+  // (computation is performed by CalcVelocityKinematicsCache_BaseToTip():
+  //   V_WB = V_WPb + V_PB_W (Eq. 5.6 in Jain (2010), p. 77)
+  //        = V_WP.ComposeWithMovingFrameVelocity(p_PB_W, V_PB_W)         (1)
+  // where Pb is a frame aligned with P but with its origin shifted from Po
+  // to B's origin Bo. Then V_WPb is the spatial velocity of frame Pb,
+  // measured and expressed in the world frame W.
+  //
+  // In the same way the parent body P velocity V_WP can be composed with body
+  // B's velocity V_PB in P, the acceleration A_WB can be obtained by
+  // composing A_WP with A_PB:
+  //  A_WB = A_WP.ComposeWithMovingFrameAcceleration(
+  //      p_PB_W, w_WP, V_PB_W, A_PB_W);                                  (2)
+  // which includes both centrifugal and coriolis terms. For details on this
+  // operation refer to the documentation for
+  // SpatialAcceleration::ComposeWithMovingFrameAcceleration().
+  //
+  // By recursive precondition, this method was already called on all
+  // predecessor nodes in the tree and therefore the acceleration A_WP is
+  // already available.
+  // V_WP (i.e. w_WP) and V_PB_W were computed in the velocity kinematics pass
+  // and are therefore available in the VelocityKinematicsCache vc.
+  //
+  // Therefore, all that is left is computing A_PB_W = DtP(V_PB)_W.
+  // The acceleration of B in P is:
+  //   A_PB = DtP(V_PB) = DtF(V_FMb) = A_FM.Shift(p_MB, w_FM)             (3)
+  // which expressed in the world frame leads to (see note below):
+  //   A_PB_W = R_WF * A_FM.Shift(p_MB_F, w_FM)                           (4)
+  // where R_WF is the rotation matrix from F to W and A_FM expressed in the
+  // inboard frame F is the direct result from
+  // Mobilizer::CalcAcrossMobilizerAcceleration().
+  //
+  // * Note:
+  //     The rigid body assumption is made in Eq. (3) in two places:
+  //       1. DtP() = DtF() since V_PF = 0.
+  //       2. V_PB = V_FMb since V_PB = V_PFb + V_FMb + V_MB but since P is
+  //          assumed rigid V_PF = 0 and since B is assumed rigid V_MB = 0.
+
+  // RigidBody for this node. Its BodyFrame is also referred to as B whenever
+  // no ambiguity can arise.
+  const RigidBody<T>& body_B = body();
+
+  // RigidBody for this node's parent, or the parent body P. Its BodyFrame
+  // is also referred to as P whenever no ambiguity can arise.
+  const RigidBody<T>& body_P = parent_body();
+
+  // Inboard frame F of this node's mobilizer.
+  const Frame<T>& frame_F = inboard_frame();
+  DRAKE_ASSERT(frame_F.body().index() == body_P.index());
+  // Outboard frame M of this node's mobilizer.
+  const Frame<T>& frame_M = outboard_frame();
+  DRAKE_ASSERT(frame_M.body().index() == body_B.index());
+
+  // =========================================================================
+  // Computation of A_PB = DtP(V_PB), Eq. (4).
+
+  const math::RigidTransform<T>& X_PF =
+      frame_F.get_X_BF(frame_body_poses_cache);  // B==P
+  const math::RotationMatrix<T>& R_PF = X_PF.rotation();
+  const math::RigidTransform<T>& X_MB =
+      frame_M.get_X_FB(frame_body_poses_cache);  // F==M
+
+  // Form the rotation matrix relating the world frame W and parent body P.
+  // Available since we are called within a base-to-tip recursion.
+  const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
+
+  // Orientation (rotation) of frame F with respect to the world frame W.
+  // TODO(amcastro-tri): consider caching X_WF since it is also used to
+  //  compute H_PB_W.
+  const math::RotationMatrix<T> R_WF = R_WP * R_PF;
+
+  // Vector from Mo to Bo expressed in frame F as needed below:
+  // TODO(amcastro-tri): consider caching this since it is also used to
+  //  compute H_PB_W.
+  const math::RotationMatrix<T>& R_FM = get_X_FM(pc).rotation();
+  const Vector3<T>& p_MB_M = X_MB.translation();
+  const Vector3<T> p_MB_F = R_FM * p_MB_M;
+
+  // Generalized velocities' time derivatives local to this node's mobilizer.
+  const Eigen::Map<const VVector> vmdot = get_vvector(mbt_vdot.data());
+
+  // Operator A_FM = H_FM * vmdot + Hdot_FM * vm
+  SpatialAcceleration<T> A_FM =
+      mobilizer_->CalcAcrossMobilizerSpatialAcceleration(context, vmdot);
+
+  // =========================================================================
+  // Compose acceleration A_WP of P in W with acceleration A_PB of B in P,
+  // Eq. (2)
+
+  // Obtains a const reference to the parent acceleration from A_WB_array.
+  const SpatialAcceleration<T>& A_WP = get_A_WP_from_array(A_WB_array);
+
+  // Shift vector between the parent body P and this node's body B,
+  // expressed in the world frame W.
+  const Vector3<T>& p_PB_W = get_p_PoBo_W(pc);
+
+  if (vc != nullptr) {
+    // Since we are in a base-to-tip recursion the parent body P's spatial
+    // velocity is already available in the cache.
+    const SpatialVelocity<T>& V_WP = get_V_WP(*vc);
+
+    // For body B, only the spatial velocity V_PB_W is already available in
+    // the cache. The acceleration A_PB_W was computed above.
+    const SpatialVelocity<T>& V_PB_W = get_V_PB_W(*vc);
+
+    // Across mobilizer velocity is available from the velocity kinematics.
+    const SpatialVelocity<T>& V_FM = get_V_FM(*vc);
+
+    const SpatialAcceleration<T> A_PB_W =
+        R_WF * A_FM.Shift(p_MB_F, V_FM.rotational());  // Eq. (4)
+
+    // Velocities are non-zero.
+    get_mutable_A_WB_from_array(&A_WB_array) =
+        A_WP.ComposeWithMovingFrameAcceleration(p_PB_W, V_WP.rotational(),
+                                                V_PB_W, A_PB_W);
+  } else {
+    const SpatialAcceleration<T> A_PB_W =  // Eq. (4), with w_FM = 0.
+        R_WF * A_FM.ShiftWithZeroAngularVelocity(p_MB_F);
+    // Velocities are zero. No need to compute terms that become zero.
+    get_mutable_A_WB_from_array(&A_WB_array) =
+        A_WP.ShiftWithZeroAngularVelocity(p_PB_W) + A_PB_W;
+  }
+}
+
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::CalcInverseDynamics_TipToBase(
+    const systems::Context<T>& context,
+    const FrameBodyPoseCache<T>& frame_body_pose_cache,
+    const PositionKinematicsCache<T>& pc,
+    const std::vector<SpatialInertia<T>>& M_B_W_cache,
+    const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
+    const std::vector<SpatialAcceleration<T>>& A_WB_array,
+    const SpatialForce<T>& Fapplied_Bo_W,
+    const Eigen::Ref<const VectorX<T>>& tau_applied,
+    std::vector<SpatialForce<T>>* F_BMo_W_array_ptr,
+    EigenPtr<VectorX<T>> tau_array) const {
+  DRAKE_DEMAND(F_BMo_W_array_ptr != nullptr);
+  std::vector<SpatialForce<T>>& F_BMo_W_array = *F_BMo_W_array_ptr;
+  DRAKE_DEMAND(tau_applied.size() == kNv || tau_applied.size() == 0);
+  DRAKE_DEMAND(tau_array != nullptr);
+  DRAKE_DEMAND(tau_array->size() == this->get_parent_tree().num_velocities());
+
+  // As a guideline for developers, a summary of the computations performed in
+  // this method is provided:
+  // Notation:
+  //  - B body frame associated with this node.
+  //  - P ("parent") body frame associated with this node's parent.
+  //  - F mobilizer inboard frame attached to body P.
+  //  - M mobilizer outboard frame attached to body B.
+  //  - Mo The origin of the outboard (or mobilized) frame of the mobilizer
+  //       attached to body B.
+  //  - C within a loop over children, one of body B's children.
+  //  - Mc The origin of the outboard (or mobilized) frame of the mobilizer
+  //       attached to body C.
+  // The goal is computing the spatial force F_BMo_W (on body B applied at its
+  // mobilized frame origin Mo) exerted by its inboard mobilizer that is
+  // required to produce the spatial acceleration A_WB. The generalized forces
+  // are then obtained as the projection of the spatial force F_BMo in the
+  // direction of this node's mobilizer motion. That is, the generalized
+  // forces correspond to the working components of the spatial force living
+  // in the motion sub-space of this node's mobilizer.
+  // The calculation is recursive (from tip-to-base) and assumes the spatial
+  // force F_CMc on body C at Mc is already computed in F_BMo_W_array_ptr.
+  //
+  // The spatial force through body B's inboard mobilizer is obtained from a
+  // force balance (essentially the F = m * a for rigid bodies, see
+  // [Jain 2010, Eq. 2.26, p. 27] for a derivation):
+  //   Ftot_BBo_W = M_Bo_W * A_WB + Fb_Bo_W                                (1)
+  // where Fb_Bo_W contains the velocity dependent gyroscopic terms,
+  // Ftot_BBo_W is the total spatial force on body B, applied at its origin Bo
+  // and quantities are expressed in the world frame W (though the
+  // expressed-in frame is not needed in a coordinate-free form.)
+  //
+  // The total spatial force on body B is the combined effect of externally
+  // applied spatial forces Fapp_BMo on body B at Mo and spatial forces
+  // induced by its inboard and outboard mobilizers. On its mobilized frame M,
+  // in coordinate-free form:
+  //   Ftot_BMo = Fapp_BMo + F_BMo - Σᵢ(F_CiMo)                           (2)
+  // where F_CiMo is the spatial force on the i-th child body Ci due to its
+  // inboard mobilizer which, by action/reaction, applies to body B as
+  // -F_CiMo, hence the negative sign in the summation above. The applied
+  // spatial force Fapp_BMo at Mo is obtained by shifting the applied force
+  // Fapp_Bo from Bo to Mo as Fapp_BMo.Shift(p_BoMo).
+  // Therefore, spatial force F_BMo due to body B's mobilizer is:
+  //   F_BMo = Ftot_BMo + Σᵢ(F_CiMo) - Fapp_BMo                           (3)
+  // The projection of this force on the motion sub-space of this node's
+  // mobilizer corresponds to the generalized force tau:
+  //  tau = H_FMᵀ * F_BMo_F                                               (4)
+  // where the spatial force F_BMo must be re-expressed in the inboard frame F
+  // before the projection can be performed.
+
+  // This node's body B.
+  const RigidBody<T>& body_B = body();
+
+  // Input spatial acceleration for this node's body B.
+  const SpatialAcceleration<T>& A_WB = get_A_WB_from_array(A_WB_array);
+
+  // Total spatial force on body B producing acceleration A_WB.
+  SpatialForce<T> Ftot_BBo_W;
+  CalcBodySpatialForceGivenItsSpatialAcceleration(M_B_W_cache, Fb_Bo_W_cache,
+                                                  A_WB, &Ftot_BBo_W);
+
+  // Compute shift vector from Bo to Mo expressed in the world frame W.
+  const Frame<T>& frame_M = outboard_frame();
+  DRAKE_DEMAND(frame_M.body().index() == body_B.index());
+  const math::RigidTransform<T>& X_BM =
+      frame_M.get_X_BF(frame_body_pose_cache);  // F==M
+  const Vector3<T>& p_BoMo_B = X_BM.translation();
+  const math::RigidTransform<T>& X_WB = get_X_WB(pc);
+  const math::RotationMatrix<T>& R_WB = X_WB.rotation();
+  const Vector3<T> p_BoMo_W = R_WB * p_BoMo_B;
+
+  // Output spatial force that would need to be exerted by this node's
+  // mobilizer in order to attain the prescribed acceleration A_WB.
+  SpatialForce<T>& F_BMo_W = F_BMo_W_array[mobod_index()];
+
+  // Ensure this method was not called with an Fapplied_Bo_W being an entry
+  // into F_BMo_W_array, otherwise we would be overwriting Fapplied_Bo_W.
+  DRAKE_DEMAND(&F_BMo_W != &Fapplied_Bo_W);
+
+  // Shift spatial force on B to Mo.
+  F_BMo_W = Ftot_BBo_W.Shift(p_BoMo_W);
+  for (const BodyNode<T>* child_node : this->child_nodes()) {
+    const MobodIndex child_node_index = child_node->mobod_index();
+
+    // Shift vector from Bo to Co, expressed in the world frame W.
+    const Vector3<T>& p_BoCo_W = pc.get_p_PoBo_W(child_node_index);
+
+    // p_CoMc_W:
+    const Frame<T>& frame_Mc = child_node->outboard_frame();
+    const math::RotationMatrix<T>& R_WC =
+        pc.get_X_WB(child_node_index).rotation();
+    const math::RigidTransform<T>& X_CMc =
+        frame_Mc.get_X_BF(frame_body_pose_cache);  // B==C, F==Mc
+    const Vector3<T>& p_CoMc_W = R_WC * X_CMc.translation();
+
+    // Shift position vector from child C outboard mobilizer frame Mc to body
+    // B outboard mobilizer Mc. p_MoMc_W:
+    // Since p_BoMo = p_BoCo + p_CoMc + p_McMo, we have:
+    const Vector3<T> p_McMo_W = p_BoMo_W - p_BoCo_W - p_CoMc_W;
+
+    // Spatial force on the child body C at the origin Mc of the outboard
+    // mobilizer frame for the child body.
+    // A little note for how to read the next line: the frames for
+    // F_BMo_W_array are:
+    //  - B this node's body.
+    //  - Mo body B's inboard frame origin.
+    // However, when indexing by child_node_index:
+    //  - B becomes C, the child node's body.
+    //  - Mo becomes Mc, body C's inboard frame origin.
+    const SpatialForce<T>& F_CMc_W = F_BMo_W_array[child_node_index];
+
+    // Shift to this node's mobilizer origin Mo (still, F_CMo is the force
+    // acting on the child body C):
+    const SpatialForce<T>& F_CMo_W = F_CMc_W.Shift(p_McMo_W);
+    // From Eq. (3), this force is added (with positive sign) to the force
+    // applied by this body's mobilizer:
+    F_BMo_W += F_CMo_W;
+  }
+  // Add applied forces contribution.
+  F_BMo_W -= Fapplied_Bo_W.Shift(p_BoMo_W);
+
+  // Re-express F_BMo_W in the inboard frame F before projecting it onto the
+  // sub-space generated by H_FM(q).
+  const math::RotationMatrix<T>& R_PF =
+      inboard_frame().EvalPoseInBodyFrame(context).rotation();
+  const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
+  // TODO(amcastro-tri): consider caching R_WF since also used in position and
+  //  velocity kinematics.
+  const math::RotationMatrix<T> R_WF = R_WP * R_PF;
+  const SpatialForce<T> F_BMo_F = R_WF.inverse() * F_BMo_W;
+
+  // Generalized velocities and forces use the same indexing.
+  auto tau = mobilizer_->get_mutable_generalized_forces_from_array(tau_array);
+
+  // Demand that tau_applied is not an entry of tau. It would otherwise get
+  // overwritten.
+  DRAKE_DEMAND(tau.data() != tau_applied.data());
+
+  // The generalized forces on the mobilizer correspond to the active
+  // components of the spatial force performing work. Therefore we need to
+  // project F_BMo along the directions of motion.
+  // Project as: tau = H_FMᵀ(q) * F_BMo_F, Eq. (4).
+  mobilizer_->ProjectSpatialForce(context, F_BMo_F, tau);
+
+  // Include the contribution of applied generalized forces.
+  if (tau_applied.size() != 0) tau -= tau_applied;
+}
+
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::
+    CalcArticulatedBodyInertiaCache_TipToBase(
+        const systems::Context<T>& context,
+        const PositionKinematicsCache<T>& pc,
+        const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
+        const SpatialInertia<T>& M_B_W, const VectorX<T>& diagonal_inertias,
+        ArticulatedBodyInertiaCache<T>* abic) const {
+  DRAKE_DEMAND(mobod_index() != world_mobod_index());
+  DRAKE_DEMAND(abic != nullptr);
+  DRAKE_DEMAND(diagonal_inertias.size() ==
+               this->get_parent_tree().num_velocities());
+
+  // As a guideline for developers, a summary of the computations performed in
+  // this method is provided:
+  // Notation:
+  //  - B body frame associated with this node.
+  //  - P ("parent") body frame associated with this node's parent. This is
+  //    not to be confused with the articulated body inertia, which is also
+  //    named P.
+  //  - C within a loop over children, one of body B's children.
+  //  - P_B_W for the articulated body inertia of body B, about Bo, and
+  //    expressed in world frame W.
+  //  - Pplus_PB_W for the same articulated body inertia P_B_W but projected
+  //    across B's inboard mobilizer to frame P so that instead of
+  //    F_Bo_W = P_B_W A_WB + Z_Bo_W, we can write
+  //    F_Bo_W = Pplus_PB_W Aplus_WB + Zplus_Bo_W where Aplus_WB is defined
+  //    in Section 6.2.2, Page 101 of [Jain 2010] and Zplus_Bo_W is defined
+  //    in Section 6.3, Page 108 of [Jain 2010].
+  //  - Φ(p_PQ) for Jain's rigid body transformation operator. In code,
+  //    V_MQ = Φᵀ(p_PQ) V_MP is equivalent to V_MP.Shift(p_PQ).
+  //
+  // The goal is to populate the articulated body cache with values necessary
+  // for computing generalized accelerations in the second pass of the
+  // articulated body algorithm. This computation is recursive, and assumes
+  // that required articulated body quantities are already computed for all
+  // children.
+  //
+  // We compute the articulated inertia of the current body by summing
+  // contributions from all its children with its own spatial inertia. Note
+  // that Φ is the is the rigid body shift operator as defined in [Jain 2010]
+  // (Φ(P, Q) in Jain's book corresponds to Φ(p_PQ) in the notation used
+  // here).
+  //   P_B_W = Σᵢ(Φ(p_BCᵢ_W) Pplus_BCᵢ_W Φ(p_BCᵢ_W)ᵀ) + M_B_W
+  //         = Σᵢ(Pplus_BCᵢb_W) + M_B_W                                   (1)
+  // where Pplus_BCᵢb_W is the articulated body inertia P_Cᵢ_W of the child
+  // body Cᵢ, projected across its inboard mobilizer to frame B, shifted to
+  // frame B, and expressed in the world frame W.
+  //
+  // From P_B_W, we can obtain Pplus_PB_W by projecting the articulated body
+  // inertia for this node across its mobilizer.
+  //   Pplus_PB_W = (I - P_B_W H_PB_W (H_PB_Wᵀ P_B_W H_PB_W)⁻¹ H_PB_Wᵀ)
+  //                  P_B_W                                               (2)
+  // where H_PB_W is the hinge mapping matrix.
+  //
+  // A few quantities are required in the second pass. We write them out
+  // explicitly so we can cache them and simplify the expression for P_PB_W.
+  //   D_B = H_PB_Wᵀ P_B_W H_PB_W                                        (3)
+  //   g_PB_W = P_B_W H_PB_W D_B⁻¹                                       (4)
+  // where D_B is the articulated body hinge inertia and g_PB_W is the
+  // Kalman gain.
+  //
+  // With D_B, it is possible to view equation (2) in another manner. D_B
+  // relates mobility-space forces to mobility-space accelerations. We can
+  // view Pplus_PB_W as subtracting the mobilizer space inertia that
+  // results from expanding D_B into an articulated body inertia from B's
+  // articulated body inertia.
+  //
+  // In order to reduce the number of computations, we can save the common
+  // factor U_B_W = H_PB_Wᵀ P_B_W. We then can write:
+  //   D_B = U_B_W H_PB_W                                                  (5)
+  // and for g,
+  //   g_PB_Wᵀ = (D_B⁻¹)ᵀ H_PB_Wᵀ P_B_Wᵀ
+  //           = (D_Bᵀ)⁻¹ H_PB_Wᵀ P_B_W
+  //           = D_B⁻¹ U_B_W                                               (6)
+  // where we used the fact that both D and P are symmetric. Notice in the
+  // last expression for g_PB_Wᵀ we are reusing the common factor U_B_W.
+  //
+  // Given the articulated body hinge inertia and Kalman gain, we can simplify
+  // the equation in (2).
+  //   Pplus_PB_W = (I - g_PB_W H_PB_Wᵀ) P_B_W
+  //              = P_B_W - g_PB_W H_PB_Wᵀ P_B_W
+  //              = P_B_W - g_PB_W * U_B_W                                 (7)
+
+  // Compute articulated body inertia for body using (1).
+  ArticulatedBodyInertia<T>& P_B_W = get_mutable_P_B_W(abic);
+  P_B_W = ArticulatedBodyInertia<T>(M_B_W);
+
+  // Add articulated body inertia contributions from all children.
+  for (const BodyNode<T>* child : this->child_nodes()) {
+    const MobodIndex child_node_index = child->mobod_index();
+    // Shift vector p_CoBo_W.
+    const Vector3<T>& p_BoCo_W = pc.get_p_PoBo_W(child_node_index);
+    const Vector3<T> p_CoBo_W = -p_BoCo_W;
+
+    // Pull Pplus_BC_W from cache (which is Pplus_PB_W for child).
+    const ArticulatedBodyInertia<T>& Pplus_BC_W =
+        abic->get_Pplus_PB_W(child_node_index);
+
+    // Shift Pplus_BC_W to Pplus_BCb_W.
+    // This is known to be one of the most expensive operations of ABA and
+    // must not be overlooked. Refer to #12435 for details.
+    const ArticulatedBodyInertia<T> Pplus_BCb_W = Pplus_BC_W.Shift(p_CoBo_W);
+
+    // Add Pplus_BCb_W contribution to articulated body inertia.
+    P_B_W += Pplus_BCb_W;
+  }
+
+  ArticulatedBodyInertia<T>& Pplus_PB_W = get_mutable_Pplus_PB_W(abic);
+  Pplus_PB_W = P_B_W;
+
+  // We now proceed to compute Pplus_PB_W using Eq. (7):
+  //   Pplus_PB_W = P_B_W - g_PB_W * U_B_W
+  // For weld joints (with kNv = 0) or locked joints, terms involving the hinge
+  // matrix H_PB_W go away and therefore Pplus_PB_W = P_B_W. We check this
+  // below.
+  if (kNv != 0 && !mobilizer_->is_locked(context)) {
+    // Compute common term U_B_W.
+    const MatrixUpTo6<T> U_B_W = H_PB_W.transpose() * P_B_W;
+
+    // Compute the articulated body hinge inertia, D_B, using (5).
+    MatrixUpTo6<T> D_B(kNv, kNv);
+    D_B.template triangularView<Eigen::Lower>() = U_B_W * H_PB_W;
+
+    // Include the effect of additional diagonal inertias. See @ref
+    // additional_diagonal_inertias.
+    D_B.diagonal() +=
+        diagonal_inertias.segment(mobilizer_->velocity_start_in_v(), kNv);
+
+    // Compute the LLT factorization of D_B as llt_D_B.
+    math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& llt_D_B =
+        get_mutable_llt_D_B(abic);
+    this->CalcArticulatedBodyHingeInertiaMatrixFactorization(D_B, &llt_D_B);
+
+    // Compute the Kalman gain, g_PB_W, using (6).
+    Matrix6xUpTo6<T>& g_PB_W = get_mutable_g_PB_W(abic);
+    g_PB_W = llt_D_B.Solve(U_B_W).transpose();
+
+    // Project P_B_W using (7) to obtain Pplus_PB_W, the articulated body
+    // inertia of this body B as felt by body P and expressed in frame W.
+    // Symmetrize the computation to reduce floating point errors.
+    // TODO(amcastro-tri): Notice that the line below makes the implicit
+    //  assumption that g_PB_W * U_B_W is SPD and only the lower triangular
+    //  portion is used, see the documentation for ArticulatedBodyInertia's
+    //  constructor (checked only during Debug builds). This
+    //  *might* result in the accumulation of floating point round off errors
+    //  for long kinematic chains. Further investigation is required.
+    Pplus_PB_W -= ArticulatedBodyInertia<T>(g_PB_W * U_B_W);
+  }
+}
+
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::
+    CalcArticulatedBodyForceCache_TipToBase(
+        const systems::Context<T>& context,
+        const PositionKinematicsCache<T>& pc, const VelocityKinematicsCache<T>*,
+        const SpatialForce<T>& Fb_Bo_W,
+        const ArticulatedBodyInertiaCache<T>& abic,
+        const SpatialForce<T>& Zb_Bo_W, const SpatialForce<T>& Fapplied_Bo_W,
+        const Eigen::Ref<const VectorX<T>>& tau_applied,
+        const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
+        ArticulatedBodyForceCache<T>* aba_force_cache) const {
+  DRAKE_DEMAND(mobod_index() != world_mobod_index());
+  DRAKE_DEMAND(aba_force_cache != nullptr);
+
+  // As a guideline for developers, please refer to @ref
+  // internal_forward_dynamics for a detailed description of the algorithm and
+  // notation in use.
+
+  // Compute the residual spatial force, Z_Bo_W, according to (1).
+  SpatialForce<T> Z_Bo_W = Fb_Bo_W - Fapplied_Bo_W;
+
+  // Add residual spatial force contributions from all children.
+  for (const BodyNode<T>* child : this->child_nodes()) {
+    const MobodIndex child_node_index = child->mobod_index();
+    // Shift vector from Co to Bo.
+    const Vector3<T>& p_BoCo_W = pc.get_p_PoBo_W(child_node_index);
+    const Vector3<T> p_CoBo_W = -p_BoCo_W;
+
+    // Pull Zplus_BC_W from cache (which is Zplus_PB_W for child).
+    const SpatialForce<T>& Zplus_BC_W =
+        aba_force_cache->get_Zplus_PB_W(child_node_index);
+
+    // Shift Zplus_BC_W to Zplus_BCb_W.
+    const SpatialForce<T> Zplus_BCb_W = Zplus_BC_W.Shift(p_CoBo_W);
+
+    // Add Zplus_BCb_W contribution to residual spatial force.
+    Z_Bo_W += Zplus_BCb_W;
+  }
+
+  get_mutable_Zplus_PB_W(aba_force_cache) = Z_Bo_W + Zb_Bo_W;
+
+  // These terms do not show up for zero mobilities (weld or locked).
+  if (kNv != 0 && !mobilizer_->is_locked(context)) {
+    // Compute the articulated body inertia innovations generalized force,
+    // e_B, according to (4).
+    VectorUpTo6<T>& e_B = get_mutable_e_B(aba_force_cache);
+    e_B.noalias() = tau_applied - H_PB_W.transpose() * Z_Bo_W.get_coeffs();
+
+    // Get the Kalman gain from cache.
+    const Matrix6xUpTo6<T>& g_PB_W = get_g_PB_W(abic);
+
+    // Compute the projected articulated body force bias Zplus_PB_W.
+    get_mutable_Zplus_PB_W(aba_force_cache) += SpatialForce<T>(g_PB_W * e_B);
+  }
+}
+
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::
+    CalcArticulatedBodyAccelerations_BaseToTip(
+        const systems::Context<T>& context,
+        const PositionKinematicsCache<T>& pc,
+        const ArticulatedBodyInertiaCache<T>& abic,
+        const ArticulatedBodyForceCache<T>& aba_force_cache,
+        const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
+        const SpatialAcceleration<T>& Ab_WB,
+        AccelerationKinematicsCache<T>* ac) const {
+  DRAKE_THROW_UNLESS(ac != nullptr);
+
+  // As a guideline for developers, please refer to @ref
+  // abi_computing_accelerations for a detailed description of the algorithm
+  // and the notation in use.
+
+  // Get the spatial acceleration of the parent.
+  const SpatialAcceleration<T>& A_WP =
+      ac->get_A_WB(mobilizer_->mobod().inboard());
+
+  // Shift vector p_PoBo_W from the parent origin to the body origin.
+  const Vector3<T>& p_PoBo_W = get_p_PoBo_W(pc);
+
+  // Rigidly shift the acceleration of the parent node.
+  const SpatialAcceleration<T> Aplus_WB = SpatialAcceleration<T>(
+      A_WP.rotational(),
+      A_WP.translational() + A_WP.rotational().cross(p_PoBo_W));
+
+  SpatialAcceleration<T>& A_WB = get_mutable_A_WB(ac);
+  A_WB = Aplus_WB + Ab_WB;
+
+  // These quantities do not contribute when nv = 0 (weld or locked joint). We
+  // skip them since Eigen does not allow certain operations on zero-sized
+  // objects. It is important to set the generalized accelerations to zero for
+  // locked mobilizers.
+  if (mobilizer_->is_locked(context)) {
+    get_mutable_accelerations(ac).setZero();
+  } else if (kNv != 0) {
+    // Compute nu_B, the articulated body inertia innovations generalized
+    // acceleration.
+    const VectorUpTo6<T> nu_B =
+        get_llt_D_B(abic).Solve(get_e_B(aba_force_cache));
+
+    // Mutable reference to the generalized acceleration.
+    auto vmdot = get_mutable_accelerations(ac);
+    const Matrix6xUpTo6<T>& g_PB_W = get_g_PB_W(abic);
+    vmdot = nu_B - g_PB_W.transpose() * A_WB.get_coeffs();
+
+    // Update with vmdot term the spatial acceleration of the current body.
+    A_WB += SpatialAcceleration<T>(H_PB_W * vmdot);
+  }
+}
+
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::CalcCompositeBodyInertia_TipToBase(
+    const SpatialInertia<T>& M_B_W, const PositionKinematicsCache<T>& pc,
+    const std::vector<SpatialInertia<T>>& Mc_B_W_all,
+    SpatialInertia<T>* Mc_B_W) const {
+  DRAKE_DEMAND(mobod_index() != world_mobod_index());
+  DRAKE_DEMAND(Mc_B_W != nullptr);
+
+  // Composite body inertia R_B_W for this node B, about its frame's origin
+  // Bo, and expressed in the world frame W. Here we adopt the notation used
+  // in Jain's book.
+  *Mc_B_W = M_B_W;
+  // Add composite body inertia contributions from all children.
+  for (const BodyNode<T>* child : this->child_nodes()) {
+    const MobodIndex child_node_index = child->mobod_index();
+    // Shift vector p_CoBo_W.
+    const Vector3<T>& p_BoCo_W = pc.get_p_PoBo_W(child_node_index);
+    const Vector3<T> p_CoBo_W = -p_BoCo_W;
+
+    // Composite body inertia for outboard child body C, about Co, expressed
+    // in W.
+    const SpatialInertia<T>& Mc_CCo_W = Mc_B_W_all[child_node_index];
+
+    // Shift to Bo and add it to the composite body inertia of B.
+    *Mc_B_W += Mc_CCo_W.Shift(p_CoBo_W);
+  }
+}
+
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::CalcSpatialAccelerationBias(
+    const systems::Context<T>& context,
+    const FrameBodyPoseCache<T>& frame_body_pose_cache,
+    const PositionKinematicsCache<T>& pc, const VelocityKinematicsCache<T>& vc,
+    SpatialAcceleration<T>* Ab_WB) const {
+  DRAKE_THROW_UNLESS(Ab_WB != nullptr);
+  // As a guideline for developers, please refer to @ref
+  // abi_computing_accelerations for a detailed description and derivation of
+  // Ab_WB.
+
+  Ab_WB->SetZero();
+  // Inboard frame F and outboard frame M of this node's mobilizer.
+  const Frame<T>& frame_F = inboard_frame();
+  const Frame<T>& frame_M = outboard_frame();
+
+  // Compute R_PF and X_MB.
+  const math::RigidTransform<T>& X_PF =
+      frame_F.get_X_BF(frame_body_pose_cache);  // B==P
+  const math::RotationMatrix<T>& R_PF = X_PF.rotation();
+  const math::RigidTransform<T>& X_MB =
+      frame_M.get_X_FB(frame_body_pose_cache);  // F==M
+
+  // Parent position in the world is available from the position kinematics.
+  const math::RotationMatrix<T>& R_WP = get_R_WP(pc);
+
+  // TODO(amcastro-tri): consider caching R_WF.
+  const math::RotationMatrix<T> R_WF = R_WP * R_PF;
+
+  // Compute shift vector p_MoBo_F.
+  const Vector3<T> p_MoBo_F = get_X_FM(pc).rotation() * X_MB.translation();
+
+  // The goal is to compute Ab_WB = Ac_WB + Ab_PB_W, see @ref
+  // abi_computing_accelerations.
+  // We first compute Ab_PB_W and add Ac_WB at the end.
+
+  // We are ultimately trying to compute Ab_WB = Ac_WB + Ab_PB_W, of which
+  // Ab_PB (that we're computing here) is a component. See @ref
+  // abi_computing_accelerations. Now, Ab_PB_W is the bias term for the
+  // acceleration A_PB_W. That is, it is the acceleration A_PB_W when vmdot is
+  // zero. We get Ab_PB_W by shifting and re-expressing Ab_FM, the across
+  // mobilizer spatial acceleration bias term.
+
+  // We first compute the acceleration bias Ab_FM = Hdot * vm.
+  // Note, A_FM = H_FM(qm) * vmdot + Ab_FM(qm, vm).
+  const VectorUpTo6<T> vmdot_zero = VectorUpTo6<T>::Zero(kNv);
+  const SpatialAcceleration<T> Ab_FM =
+      mobilizer_->CalcAcrossMobilizerSpatialAcceleration(context, vmdot_zero);
+
+  // Due to the fact that frames P and F are on the same rigid body, we have
+  // that V_PF = 0. Therefore, DtP(V_PB) = DtF(V_PB). Since M and B are also
+  // on the same rigid body, V_MB = 0. We then recognize that V_PB = V_PFb +
+  // V_FMb + V_MB = V_FMb. Together, we get that A_PB = DtF(V_FMb) =
+  // A_FM.Shift(p_MoBo, w_FM).
+  const Vector3<T> w_FM = get_V_FM(vc).rotational();
+  const SpatialAcceleration<T> Ab_PB_W = R_WF * Ab_FM.Shift(p_MoBo_F, w_FM);
+
+  // Spatial velocity of parent is available from the velocity kinematics.
+  const SpatialVelocity<T>& V_WP = get_V_WP(vc);
+  const Vector3<T>& w_WP = V_WP.rotational();
+  const Vector3<T>& v_WP = V_WP.translational();
+
+  // Velocity of this mobilized body in its parent is available from the
+  // velocity kinematics.
+  const SpatialVelocity<T>& V_PB_W = get_V_PB_W(vc);
+  const Vector3<T>& w_PB_W = V_PB_W.rotational();
+  const Vector3<T>& v_PB_W = V_PB_W.translational();
+
+  // Mobilized body spatial velocity in W.
+  const SpatialVelocity<T>& V_WB = get_V_WB(vc);
+  const Vector3<T>& w_WB = V_WB.rotational();
+  const Vector3<T>& v_WB = V_WB.translational();
+
+  // Compute Ab_WB according to:
+  // Ab_WB =  | w_WB x w_PB_W                 | + Ab_PB_W
+  //          | w_WP x (v_WB - v_WP + v_PB_W) |
+  // N.B: It is NOT true that v_PB_W = v_WB - v_WP, since you would otherwise
+  // be forgetting to shift v_WP to B. We prefer the expression used here
+  // since it is cheaper to compute, requiring only a single cross product,
+  // see @note in SpatialAcceleration::ComposeWithMovingFrameAcceleration()
+  // for a complete derivation.
+  *Ab_WB = SpatialAcceleration<T>(
+      w_WB.cross(w_PB_W) + Ab_PB_W.rotational(),
+      w_WP.cross(v_WB - v_WP + v_PB_W) + Ab_PB_W.translational());
+}
+
+// This method computes the total force Ftot_BBo on body B that must be
+// applied for it to incur in a spatial acceleration A_WB. Mathematically:
+//   Ftot_BBo = M_B_W * A_WB + b_Bo
+// where b_Bo contains the velocity dependent gyroscopic terms (see Eq. 2.26,
+// p. 27, in A. Jain's book). The above balance is performed at the origin
+// Bo of the body frame B, which does not necessarily need to coincide with
+// the body center of mass.
+// Notes:
+//   1. Ftot_BBo = b_Bo when A_WB = 0.
+//   2. b_Bo = 0 when w_WB = 0.
+//   3. b_Bo.translational() = 0 when Bo = Bcm (p_BoBcm = 0).
+//      When Fb_Bo_W_cache is nullptr velocities are considered to be zero.
+//      Therefore, from (2), the bias term is assumed to be zero and is not
+//      computed.
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::
+    CalcBodySpatialForceGivenItsSpatialAcceleration(
+        const std::vector<SpatialInertia<T>>& M_B_W_cache,
+        const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
+        const SpatialAcceleration<T>& A_WB,
+        SpatialForce<T>* Ftot_BBo_W_ptr) const {
+  DRAKE_DEMAND(Ftot_BBo_W_ptr != nullptr);
+
+  // Output spatial force applied on mobilized body B, at Bo, measured in W.
+  SpatialForce<T>& Ftot_BBo_W = *Ftot_BBo_W_ptr;
+
+  // RigidBody for this node.
+  const RigidBody<T>& body_B = body();
+
+  // Mobilized body B spatial inertia about Bo expressed in world W.
+  const SpatialInertia<T>& M_B_W = M_B_W_cache[body_B.mobod_index()];
+
+  // Equations of motion for a rigid body written at a generic point Bo not
+  // necessarily coincident with the body's center of mass. This corresponds
+  // to Eq. 2.26 (p. 27) in A. Jain's book.
+  Ftot_BBo_W = M_B_W * A_WB;
+
+  // If velocities are zero, then Fb_Bo_W is zero and does not contribute.
+  if (Fb_Bo_W_cache != nullptr) {
+    // Dynamic bias for body B.
+    const SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_cache)[body_B.mobod_index()];
+    Ftot_BBo_W += Fb_Bo_W;
+  }
 }
 
 // Macro used to explicitly instantiate implementations for every mobilizer.

--- a/multibody/tree/body_node_impl.h
+++ b/multibody/tree/body_node_impl.h
@@ -13,11 +13,6 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// TODO(sherm1) Most of the across-mobilizer code for kinematics and
-//  dynamics should live in this class since the hinge matrices
-//  and related downstream calculations have a compile-time fixed size.
-//  Kinematics are here now; move the rest.
-
 // For internal use only of the MultibodyTree implementation.
 // While all code that is common to any node _could_ be placed in the BodyNode
 // class, BodyNodeImpl is templatized on the concrete Mobilizer type so
@@ -39,6 +34,13 @@ class BodyNodeImpl final : public BodyNode<T> {
   using QVector = typename ConcreteMobilizer<T>::QVector;
   using VVector = typename ConcreteMobilizer<T>::VVector;
   using HMatrix = typename ConcreteMobilizer<T>::HMatrix;
+
+  using BodyNode<T>::mobod_index;
+  using BodyNode<T>::inboard_mobod_index;
+  using BodyNode<T>::inboard_frame;
+  using BodyNode<T>::outboard_frame;
+  using BodyNode<T>::body;
+  using BodyNode<T>::parent_body;
 
   // Given a body and its inboard mobilizer in a MultibodyTree this constructor
   // creates the corresponding %BodyNode. See the BodyNode class documentation
@@ -76,19 +78,83 @@ class BodyNodeImpl final : public BodyNode<T> {
       const std::vector<Vector6<T>>& H_PB_W_cache, const T* velocities,
       VelocityKinematicsCache<T>* vc) const final;
 
+  void CalcSpatialAcceleration_BaseToTip(
+      const systems::Context<T>& context,
+      const FrameBodyPoseCache<T>& frame_body_poses_cache,
+      const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>* vc, const VectorX<T>& mbt_vdot,
+      std::vector<SpatialAcceleration<T>>* A_WB_array_ptr) const final;
+
+  void CalcInverseDynamics_TipToBase(
+      const systems::Context<T>& context,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      const PositionKinematicsCache<T>& pc,
+      const std::vector<SpatialInertia<T>>& M_B_W_cache,
+      const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
+      const std::vector<SpatialAcceleration<T>>& A_WB_array,
+      const SpatialForce<T>& Fapplied_Bo_W,
+      const Eigen::Ref<const VectorX<T>>& tau_applied,
+      std::vector<SpatialForce<T>>* F_BMo_W_array_ptr,
+      EigenPtr<VectorX<T>> tau_array) const final;
+
+  void CalcArticulatedBodyInertiaCache_TipToBase(
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
+      const SpatialInertia<T>& M_B_W, const VectorX<T>& diagonal_inertias,
+      ArticulatedBodyInertiaCache<T>* abic) const final;
+
+  void CalcArticulatedBodyForceCache_TipToBase(
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>*, const SpatialForce<T>& Fb_Bo_W,
+      const ArticulatedBodyInertiaCache<T>& abic,
+      const SpatialForce<T>& Zb_Bo_W, const SpatialForce<T>& Fapplied_Bo_W,
+      const Eigen::Ref<const VectorX<T>>& tau_applied,
+      const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
+      ArticulatedBodyForceCache<T>* aba_force_cache) const final;
+
+  void CalcArticulatedBodyAccelerations_BaseToTip(
+      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const ArticulatedBodyInertiaCache<T>& abic,
+      const ArticulatedBodyForceCache<T>& aba_force_cache,
+      const Eigen::Ref<const MatrixUpTo6<T>>& H_PB_W,
+      const SpatialAcceleration<T>& Ab_WB,
+      AccelerationKinematicsCache<T>* ac) const final;
+
+  void CalcCompositeBodyInertia_TipToBase(
+      const SpatialInertia<T>& M_B_W, const PositionKinematicsCache<T>& pc,
+      const std::vector<SpatialInertia<T>>& Mc_B_W_all,
+      SpatialInertia<T>* Mc_B_W) const final;
+
+  void CalcSpatialAccelerationBias(
+      const systems::Context<T>& context,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>& vc,
+      SpatialAcceleration<T>* Ab_WB) const final;
+
  private:
   // Given a pointer to the contiguous array of all q's in this system, returns
   // a pointer to the ones for this mobilizer.
   // @pre `positions` is the full set of q's for this system
   const T* get_q(const T* positions) const {
-    return &positions[mobilizer_->position_start_in_q()];
+    return &positions[mobilizer().position_start_in_q()];
+  }
+
+  // Returns this mobilizer's qs as a fixed-size QVector.
+  Eigen::Map<const QVector> get_qvector(const T* positions) const {
+    return Eigen::Map<const QVector>(get_q(positions));
   }
 
   // Given a pointer to the contiguous array of all v's in this system, returns
   // a pointer to the ones for this mobilizer.
   // @pre `velocities` is the full set of v's for this system
   const T* get_v(const T* velocities) const {
-    return &velocities[mobilizer_->velocity_start_in_v()];
+    return &velocities[mobilizer().velocity_start_in_v()];
+  }
+
+  // Returns this mobilizer's vs as a fixed-size VVector.
+  Eigen::Map<const VVector> get_vvector(const T* velocities) const {
+    return Eigen::Map<const VVector>(get_v(velocities));
   }
 
   // Given a complete array of hinge matrices H stored by contiguous columns,
@@ -98,7 +164,7 @@ class BodyNodeImpl final : public BodyNode<T> {
   Eigen::Map<const HMatrix, Eigen::Aligned16> get_H(
       const std::vector<Vector6<T>>& H_cache) const {
     return Eigen::Map<const HMatrix, Eigen::Aligned16>(
-        H_cache[mobilizer_->velocity_start_in_v()].data());
+        H_cache[mobilizer().velocity_start_in_v()].data());
   }
 
   // Given a pointer to a mutable complete array of hinge matrices H stored by
@@ -109,20 +175,251 @@ class BodyNodeImpl final : public BodyNode<T> {
       std::vector<Vector6<T>>* H_cache) const {
     DRAKE_ASSERT(H_cache != nullptr);
     return Eigen::Map<HMatrix, Eigen::Aligned16>(
-        (*H_cache)[mobilizer_->velocity_start_in_v()].data());
+        (*H_cache)[mobilizer().velocity_start_in_v()].data());
+  }
+
+  const ConcreteMobilizer<T>& mobilizer() const {
+    DRAKE_ASSERT(mobilizer_ != nullptr);
+    return *mobilizer_;
+  }
+
+  // =========================================================================
+  // PositionKinematicsCache Accessors and Mutators.
+
+  // Returns a const reference to the pose of the body B associated with this
+  // node as measured and expressed in the world frame W.
+  const math::RigidTransform<T>& get_X_WB(
+      const PositionKinematicsCache<T>& pc) const {
+    return pc.get_X_WB(mobod_index());
+  }
+
+  // Mutable version of get_X_WB().
+  math::RigidTransform<T>& get_mutable_X_WB(
+      PositionKinematicsCache<T>* pc) const {
+    return pc->get_mutable_X_WB(mobod_index());
+  }
+
+  // Returns a const reference to the pose of the parent body P measured and
+  // expressed in the world frame W.
+  const math::RigidTransform<T>& get_X_WP(
+      const PositionKinematicsCache<T>& pc) const {
+    return pc.get_X_WB(inboard_mobod_index());
+  }
+
+  // Returns a const reference to the rotation matrix `R_WP` that relates the
+  // orientation of the world frame W to the parent frame P.
+  const math::RotationMatrix<T>& get_R_WP(
+      const PositionKinematicsCache<T>& pc) const {
+    return pc.get_R_WB(inboard_mobod_index());
+  }
+
+  // Returns a constant reference to the across-mobilizer pose of the outboard
+  // frame M as measured and expressed in the inboard frame F.
+  const math::RigidTransform<T>& get_X_FM(
+      const PositionKinematicsCache<T>& pc) const {
+    return pc.get_X_FM(mobod_index());
+  }
+
+  // Returns a mutable reference to the across-mobilizer pose of the outboard
+  // frame M as measured and expressed in the inboard frame F.
+  math::RigidTransform<T>& get_mutable_X_FM(
+      PositionKinematicsCache<T>* pc) const {
+    return pc->get_mutable_X_FM(mobod_index());
+  }
+
+  // Returns a mutable reference to the pose of body B as measured and expressed
+  // in the frame of the parent body P.
+  math::RigidTransform<T>& get_mutable_X_PB(
+      PositionKinematicsCache<T>* pc) const {
+    return pc->get_mutable_X_PB(mobod_index());
+  }
+
+  const Vector3<T>& get_p_PoBo_W(const PositionKinematicsCache<T>& pc) const {
+    return pc.get_p_PoBo_W(mobod_index());
+  }
+
+  Vector3<T>& get_mutable_p_PoBo_W(PositionKinematicsCache<T>* pc) const {
+    return pc->get_mutable_p_PoBo_W(mobod_index());
   }
 
   SpatialVelocity<T>& get_mutable_V_WB(VelocityKinematicsCache<T>* vc) const {
-    return vc->get_mutable_V_WB(this->index());
+    return vc->get_mutable_V_WB(mobod_index());
   }
 
   SpatialVelocity<T>& get_mutable_V_FM(VelocityKinematicsCache<T>* vc) const {
-    return vc->get_mutable_V_FM(this->index());
+    return vc->get_mutable_V_FM(mobod_index());
   }
 
   SpatialVelocity<T>& get_mutable_V_PB_W(VelocityKinematicsCache<T>* vc) const {
-    return vc->get_mutable_V_PB_W(this->index());
+    return vc->get_mutable_V_PB_W(mobod_index());
   }
+
+  // For the body B associated with this node, return V_WB, B's spatial velocity
+  // in the world frame W, expressed in W (for Bo, the body frame's origin).
+  const SpatialVelocity<T>& get_V_WB(
+      const VelocityKinematicsCache<T>& vc) const {
+    return vc.get_V_WB(mobod_index());
+  }
+
+  // Returns the spatial velocity `V_WP` of the body frame P in the parent node
+  // as measured and expressed in the world frame.
+  const SpatialVelocity<T>& get_V_WP(
+      const VelocityKinematicsCache<T>& vc) const {
+    return vc.get_V_WB(inboard_mobod_index());
+  }
+
+  // Returns a const reference to the across-mobilizer spatial velocity `V_FM`
+  // of the outboard frame M in the inboard frame F, expressed in the F frame.
+  const SpatialVelocity<T>& get_V_FM(
+      const VelocityKinematicsCache<T>& vc) const {
+    return vc.get_V_FM(mobod_index());
+  }
+
+  // Returns a const reference to the spatial velocity `V_PB_W` of `this`
+  // node's body B in the parent node's body P, expressed in the world frame W.
+  const SpatialVelocity<T>& get_V_PB_W(
+      const VelocityKinematicsCache<T>& vc) const {
+    return vc.get_V_PB_W(mobod_index());
+  }
+
+  // =========================================================================
+  // AccelerationKinematicsCache Accessors and Mutators.
+
+  // For the body B associated with `this` node, returns A_WB, body B's
+  // spatial acceleration in the world frame W, expressed in W
+  // (for point Bo, the body's origin).
+  const SpatialAcceleration<T>& get_A_WB(
+      const AccelerationKinematicsCache<T>& ac) const {
+    return ac.get_A_WB(mobod_index());
+  }
+
+  // Mutable version of get_A_WB().
+  SpatialAcceleration<T>& get_mutable_A_WB(
+      AccelerationKinematicsCache<T>* ac) const {
+    return ac->get_mutable_A_WB(mobod_index());
+  }
+
+  // Helper to get an Eigen expression of the vector of generalized velocities
+  // from a vector of generalized velocities for the entire parent multibody
+  // tree. Useful for the implementation of operator forms where the generalized
+  // velocity (or time derivatives of the generalized velocities) is an argument
+  // to the operator.
+  Eigen::Ref<VectorX<T>> get_mutable_velocities_from_array(
+      EigenPtr<VectorX<T>> v) const {
+    DRAKE_ASSERT(v != nullptr);
+    return v->segment(mobilizer().velocity_start_in_v(), kNv);
+  }
+
+  // Returns an Eigen expression of the vector of generalized accelerations
+  // for this node's inboard mobilizer from the vector of generalized
+  // accelerations for the entire model.
+  Eigen::Ref<VectorX<T>> get_mutable_accelerations(
+      AccelerationKinematicsCache<T>* ac) const {
+    VectorX<T>& vdot = ac->get_mutable_vdot();
+    return get_mutable_velocities_from_array(&vdot);
+  }
+
+  // =========================================================================
+  // ArticulatedBodyInertiaCache Accessors and Mutators.
+
+  // Returns a reference to the articulated body inertia `P_B_W` of the
+  // body taken about Bo and expressed in W.
+  ArticulatedBodyInertia<T>& get_mutable_P_B_W(
+      ArticulatedBodyInertiaCache<T>* abic) const {
+    return abic->get_mutable_P_B_W(mobod_index());
+  }
+
+  // Returns a reference to the articulated body inertia `Pplus_PB_W`,
+  // which can be thought of as the articulated body inertia of parent body P
+  // as though it were inertialess, but taken about Bo and expressed in W.
+  ArticulatedBodyInertia<T>& get_mutable_Pplus_PB_W(
+      ArticulatedBodyInertiaCache<T>* abic) const {
+    return abic->get_mutable_Pplus_PB_W(mobod_index());
+  }
+
+  // =========================================================================
+  // Per Node Array Accessors.
+  // Quantities are ordered by MobodIndex unless otherwise specified.
+
+  // Returns a const reference to the spatial acceleration of the body B
+  // associated with this node as measured and expressed in the world frame W,
+  // given an array of spatial accelerations for the entire MultibodyTree model.
+  const SpatialAcceleration<T>& get_A_WB_from_array(
+      const std::vector<SpatialAcceleration<T>>& A_WB_array) const {
+    return A_WB_array[mobod_index()];
+  }
+
+  // Mutable version of get_A_WB_from_array().
+  SpatialAcceleration<T>& get_mutable_A_WB_from_array(
+      std::vector<SpatialAcceleration<T>>* A_WB_array) const {
+    DRAKE_ASSERT(A_WB_array != nullptr);
+    return (*A_WB_array)[mobod_index()];
+  }
+
+  // Returns a const reference to the spatial acceleration `A_WP` of the body
+  // frame P in the parent node as measured and expressed in the world frame,
+  // given an array of spatial accelerations for the entire MultibodyTree model.
+  const SpatialAcceleration<T>& get_A_WP_from_array(
+      const std::vector<SpatialAcceleration<T>>& A_WB_array) const {
+    return A_WB_array[inboard_mobod_index()];
+  }
+
+  // Returns a const reference to the LLT factorization `llt_D_B` of the
+  // articulated body hinge inertia.
+  const math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& get_llt_D_B(
+      const ArticulatedBodyInertiaCache<T>& abic) const {
+    return abic.get_llt_D_B(mobod_index());
+  }
+
+  // Mutable version of get_llt_D_B().
+  math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>& get_mutable_llt_D_B(
+      ArticulatedBodyInertiaCache<T>* abic) const {
+    return abic->get_mutable_llt_D_B(mobod_index());
+  }
+
+  // Returns a const reference to the Kalman gain `g_PB_W` of the body.
+  const Matrix6xUpTo6<T>& get_g_PB_W(
+      const ArticulatedBodyInertiaCache<T>& abic) const {
+    return abic.get_g_PB_W(mobod_index());
+  }
+
+  // Mutable version of get_g_PB_W().
+  Matrix6xUpTo6<T>& get_mutable_g_PB_W(
+      ArticulatedBodyInertiaCache<T>* abic) const {
+    return abic->get_mutable_g_PB_W(mobod_index());
+  }
+
+  // =========================================================================
+  // ArticulatedBodyForceCache Accessors and Mutators.
+
+  // Returns a const reference to the articulated body inertia residual force
+  // `Zplus_PB_W` for this body projected across its inboard mobilizer to
+  // frame P.
+  SpatialForce<T>& get_mutable_Zplus_PB_W(
+      ArticulatedBodyForceCache<T>* aba_force_cache) const {
+    return aba_force_cache->get_mutable_Zplus_PB_W(mobod_index());
+  }
+
+  // Returns a const reference to the Coriolis spatial acceleration `Ab_WB`
+  // for this body due to the relative velocities of body B and body P.
+  const VectorUpTo6<T>& get_e_B(
+      const ArticulatedBodyForceCache<T>& aba_force_cache) const {
+    return aba_force_cache.get_e_B(mobod_index());
+  }
+
+  // Mutable version of get_e_B().
+  VectorUpTo6<T>& get_mutable_e_B(
+      ArticulatedBodyForceCache<T>* aba_force_cache) const {
+    return aba_force_cache->get_mutable_e_B(mobod_index());
+  }
+
+  // Computes the total force Ftot_BBo on body B that must be applied for it to
+  // incur in a spatial acceleration A_WB.
+  void CalcBodySpatialForceGivenItsSpatialAcceleration(
+      const std::vector<SpatialInertia<T>>& M_B_W_cache,
+      const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
+      const SpatialAcceleration<T>& A_WB,
+      SpatialForce<T>* Ftot_BBo_W_ptr) const;
 
   const ConcreteMobilizer<T>* const mobilizer_;
 };

--- a/multibody/tree/body_node_world.h
+++ b/multibody/tree/body_node_world.h
@@ -19,30 +19,86 @@ class BodyNodeWorld final : public BodyNode<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BodyNodeWorld);
 
-  explicit BodyNodeWorld(const RigidBody<T>* body)
-      : BodyNode<T>(nullptr, body, nullptr) {}
+  explicit BodyNodeWorld(const RigidBody<T>* rigid_body,
+                         const Mobilizer<T>* mobilizer)
+      : BodyNode<T>(nullptr, rigid_body, mobilizer) {
+    DRAKE_DEMAND(rigid_body != nullptr && mobilizer != nullptr);
+  }
 
   void CalcPositionKinematicsCache_BaseToTip(
-      const FrameBodyPoseCache<T>& /* frame_body_pose_cache */,
-      const T* /* positions */,
-      PositionKinematicsCache<T>* /* pc */) const override {
+      const FrameBodyPoseCache<T>&, const T*,
+      PositionKinematicsCache<T>*) const final {
     DRAKE_UNREACHABLE();
   }
 
   void CalcAcrossNodeJacobianWrtVExpressedInWorld(
-      const systems::Context<T>& /* context */,
-      const FrameBodyPoseCache<T>& /* frame_body_pose_cache */,
-      const PositionKinematicsCache<T>& /* pc */,
-      std::vector<Vector6<T>>* /* H_PB_W_cache */) const override {
+      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
+      const PositionKinematicsCache<T>&, std::vector<Vector6<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 
   void CalcVelocityKinematicsCache_BaseToTip(
-      const systems::Context<T>& /* context */,
-      const PositionKinematicsCache<T>& /* pc */,
-      const std::vector<Vector6<T>>& /* H_PB_W_cache */,
-      const T* /* velocities */,
-      VelocityKinematicsCache<T>* /* vc */) const override {
+      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const std::vector<Vector6<T>>&, const T*,
+      VelocityKinematicsCache<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcSpatialAcceleration_BaseToTip(
+      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
+      const PositionKinematicsCache<T>&, const VelocityKinematicsCache<T>*,
+      const VectorX<T>&, std::vector<SpatialAcceleration<T>>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcInverseDynamics_TipToBase(
+      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
+      const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
+      const std::vector<SpatialForce<T>>*,
+      const std::vector<SpatialAcceleration<T>>&, const SpatialForce<T>&,
+      const Eigen::Ref<const VectorX<T>>&, std::vector<SpatialForce<T>>*,
+      EigenPtr<VectorX<T>>) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcArticulatedBodyInertiaCache_TipToBase(
+      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const Eigen::Ref<const MatrixUpTo6<T>>&, const SpatialInertia<T>&,
+      const VectorX<T>&, ArticulatedBodyInertiaCache<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcArticulatedBodyForceCache_TipToBase(
+      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const VelocityKinematicsCache<T>*, const SpatialForce<T>&,
+      const ArticulatedBodyInertiaCache<T>&, const SpatialForce<T>&,
+      const SpatialForce<T>&, const Eigen::Ref<const VectorX<T>>&,
+      const Eigen::Ref<const MatrixUpTo6<T>>&,
+      ArticulatedBodyForceCache<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcArticulatedBodyAccelerations_BaseToTip(
+      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const ArticulatedBodyInertiaCache<T>&,
+      const ArticulatedBodyForceCache<T>&,
+      const Eigen::Ref<const MatrixUpTo6<T>>&, const SpatialAcceleration<T>&,
+      AccelerationKinematicsCache<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcCompositeBodyInertia_TipToBase(const SpatialInertia<T>&,
+                                          const PositionKinematicsCache<T>&,
+                                          const std::vector<SpatialInertia<T>>&,
+                                          SpatialInertia<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcSpatialAccelerationBias(const systems::Context<T>&,
+                                   const FrameBodyPoseCache<T>&,
+                                   const PositionKinematicsCache<T>&,
+                                   const VelocityKinematicsCache<T>&,
+                                   SpatialAcceleration<T>*) const final {
     DRAKE_UNREACHABLE();
   }
 };

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -68,26 +68,79 @@ class DummyBodyNode : public BodyNode<double> {
   using BodyNode::BodyNode;
 
   void CalcPositionKinematicsCache_BaseToTip(
-      const FrameBodyPoseCache<T>& /* frame_body_pose_cache */,
-      const T* /* positions */,
-      PositionKinematicsCache<T>* /* pc */) const override {
+      const FrameBodyPoseCache<T>&, const T*,
+      PositionKinematicsCache<T>*) const final {
     DRAKE_UNREACHABLE();
   }
 
   void CalcAcrossNodeJacobianWrtVExpressedInWorld(
-      const systems::Context<T>& /* context */,
-      const FrameBodyPoseCache<T>& /* frame_body_pose_cache */,
-      const PositionKinematicsCache<T>& /* pc */,
-      std::vector<Vector6<T>>* /* H_PB_W_cache */) const override {
+      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
+      const PositionKinematicsCache<T>&, std::vector<Vector6<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 
   void CalcVelocityKinematicsCache_BaseToTip(
-      const systems::Context<T>& /* context */,
-      const PositionKinematicsCache<T>& /* pc */,
-      const std::vector<Vector6<T>>& /* H_PB_W_cache */,
-      const T* /* velocities */,
-      VelocityKinematicsCache<T>* /* vc */) const override {
+      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const std::vector<Vector6<T>>&, const T*,
+      VelocityKinematicsCache<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcSpatialAcceleration_BaseToTip(
+      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
+      const PositionKinematicsCache<T>&, const VelocityKinematicsCache<T>*,
+      const VectorX<T>&, std::vector<SpatialAcceleration<T>>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcInverseDynamics_TipToBase(
+      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
+      const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
+      const std::vector<SpatialForce<T>>*,
+      const std::vector<SpatialAcceleration<T>>&, const SpatialForce<T>&,
+      const Eigen::Ref<const VectorX<T>>&, std::vector<SpatialForce<T>>*,
+      EigenPtr<VectorX<T>>) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcArticulatedBodyInertiaCache_TipToBase(
+      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const Eigen::Ref<const MatrixUpTo6<T>>&, const SpatialInertia<T>&,
+      const VectorX<T>&, ArticulatedBodyInertiaCache<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcArticulatedBodyForceCache_TipToBase(
+      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const VelocityKinematicsCache<T>*, const SpatialForce<T>&,
+      const ArticulatedBodyInertiaCache<T>&, const SpatialForce<T>&,
+      const SpatialForce<T>&, const Eigen::Ref<const VectorX<T>>&,
+      const Eigen::Ref<const MatrixUpTo6<T>>&,
+      ArticulatedBodyForceCache<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcArticulatedBodyAccelerations_BaseToTip(
+      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const ArticulatedBodyInertiaCache<T>&,
+      const ArticulatedBodyForceCache<T>&,
+      const Eigen::Ref<const MatrixUpTo6<T>>&, const SpatialAcceleration<T>&,
+      AccelerationKinematicsCache<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcCompositeBodyInertia_TipToBase(const SpatialInertia<T>&,
+                                          const PositionKinematicsCache<T>&,
+                                          const std::vector<SpatialInertia<T>>&,
+                                          SpatialInertia<T>*) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+  void CalcSpatialAccelerationBias(const systems::Context<T>&,
+                                   const FrameBodyPoseCache<T>&,
+                                   const PositionKinematicsCache<T>&,
+                                   const VelocityKinematicsCache<T>&,
+                                   SpatialAcceleration<T>*) const final {
     DRAKE_UNREACHABLE();
   }
 };


### PR DESCRIPTION
This PR just relocates a bunch of multibody algorithms from the generic BodyNode class to the templatized BodyNodeImpl class (which derives from BodyNode) in preparation for taking advantage of the template arguments for speed. A bunch of private helper methods were moved over also. In most cases there were no changes at all but in a few places I had to make minor changes to get things to compile, e.g. add `this->` to call the few BodyNode functions that remain.

Also, these sizeable algorithms were in the body_node.h header; they are now in body_node_impl.cc so many compilation units are somewhat faster to compile now.

There is small performance cost (~5%) of this change, likely due to (a) making these functions virtual, and (b) using more code memory due to per-mobilizer instantiation, without taking advantage of those changes. Subsequent PRs will eliminate all the "VectorUpTo6" uses, simplify the argument passing, and replace all the many internal virtual function calls with inlines. At that point I'll publish a decent performance comparison against an earlier master.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21960)
<!-- Reviewable:end -->
