### PR TITLE
[abseil_cpp_internal] Fix static linking patch commands

### DIFF
--- a/tools/workspace/abseil_cpp_internal/patches/civil_time_linkopts.patch
+++ b/tools/workspace/abseil_cpp_internal/patches/civil_time_linkopts.patch
@@ -1,0 +1,17 @@
+Add a missing linkopts setting to a library, so the subsequent patch
+command to set all libraries to static linking will indeed find all
+libraries.
+
+This patch is sufficient for Drake's purposes. A patch suitable for
+upstreaming would likely import default link flags and use them.
+
+--- absl/time/internal/cctz/BUILD.bazel
++++ absl/time/internal/cctz/BUILD.bazel
+@@ -34,6 +34,7 @@ cc_library(
+     hdrs = [
+         "include/cctz/civil_time.h",
+     ],
++    linkopts = [],
+     textual_hdrs = ["include/cctz/civil_time_detail.h"],
+     visibility = ["//visibility:public"],
+     deps = ["//absl/base:config"],

--- a/tools/workspace/abseil_cpp_internal/repository.bzl
+++ b/tools/workspace/abseil_cpp_internal/repository.bzl
@@ -9,6 +9,7 @@ def abseil_cpp_internal_repository(
         commit = "67d126083c1584dd7dc584d700f853afaec365ca",
         sha256 = "8652366395b2f20628281fd98c4413e9947d989fcb214f8bdc56351e8cd7e7d4",  # noqa
         patches = [
+            ":patches/civil_time_linkopts.patch",
             ":patches/disable_int128_on_clang.patch",
             ":patches/hidden_visibility.patch",
             ":patches/inline_namespace.patch",
@@ -17,7 +18,7 @@ def abseil_cpp_internal_repository(
             # Force linkstatic = 1 everywhere. First, remove the few existing
             # uses so that we don't get "duplicate kwarg" errors. Then, add it
             # anywhere that linkopts already appears.
-            "sed -i -e 's|linkstatic = 1,||; s|linkopts = |linkstatic = 1, linkopts =|' absl/*/BUILD.bazel",  # noqa
+            "sed -i -e 's|linkstatic = 1,||; s|linkopts = |linkstatic = 1, linkopts = |' $(find absl -name BUILD.bazel)",  # noqa
         ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
Amend the patch commands to convert all of the cc_library() rules in the upstream's bazel files to use "linkstatic = 1". This prevents generation of "accidental" shared libraries, which in turn were causing link failures with more modern linkers (.i.e., ld.mold).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21961)
<!-- Reviewable:end -->
