### PR TITLE
FIX: Create a new mapper per actor

### DIFF
--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -514,6 +514,9 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
       for (const auto& source_part : source_prop.parts) {
         vtkNew<vtkActor> target_actor;
         target_actor->ShallowCopy(source_part.actor);
+        vtkNew<vtkOpenGLPolyDataMapper> target_mapper;
+        target_mapper->ShallowCopy(source_part.actor->GetMapper());
+        target_actor->SetMapper(target_mapper);
         renderer.AddActor(target_actor);
         target_prop.parts.push_back(
             Part{.actor = std::move(target_actor), .T_GA = source_part.T_GA});


### PR DESCRIPTION
The vtkMapper is responsible for creating and uploading graphics resources per OpenGL context. Re-using vtkMapper instances across clones would cause unintentional side-effects like the ones described in #20002 and https://github.com/RobotLocomotion/drake/issues/21700#issuecomment-2330613816