### PR TITLE
Avoid duplicate warnings in multibody XML parsers

### DIFF
--- a/multibody/parsing/detail_tinyxml2_diagnostic.cc
+++ b/multibody/parsing/detail_tinyxml2_diagnostic.cc
@@ -36,7 +36,10 @@ DiagnosticDetail TinyXml2Diagnostic::MakeDetail(
 
 void TinyXml2Diagnostic::Warning(
     const XMLNode& location, const std::string& message) const {
-  diagnostic_->Warning(MakeDetail(location, message));
+  // Avoid warnings with exactly the same message string.
+  if (warnings_.insert(message).second) {
+    diagnostic_->Warning(MakeDetail(location, message));
+  }
 }
 
 void TinyXml2Diagnostic::Error(

--- a/multibody/parsing/detail_tinyxml2_diagnostic.h
+++ b/multibody/parsing/detail_tinyxml2_diagnostic.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_set>
 
 #include <tinyxml2.h>
 
@@ -56,6 +57,8 @@ class TinyXml2Diagnostic {
   const drake::internal::DiagnosticPolicy* diagnostic_{};
   const DataSource* data_source_{};
   const std::string file_extension_;
+  // Keep a history to avoid duplicate warnings.
+  mutable std::unordered_set<std::string> warnings_;
 };
 
 }  // namespace internal

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -1798,12 +1798,8 @@ TEST_F(MujocoParserTest, ContactWarnings) {
 
   EXPECT_THAT(TakeWarning(), MatchesRegex(
       ".*pair.*not have.*geom1.*geom2.*ignored.*"));
-  EXPECT_THAT(TakeWarning(), MatchesRegex(
-      ".*pair.*not have.*geom1.*geom2.*ignored.*"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*pair.*unknown geom1.*ignored.*"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*pair.*unknown geom2.*ignored.*"));
-  EXPECT_THAT(TakeWarning(), MatchesRegex(
-      ".*exclude.*not have.*body1.*body2.*ignored.*"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(
       ".*exclude.*not have.*body1.*body2.*ignored.*"));
 }

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -764,9 +764,7 @@ TEST_F(UrdfParserTest, TestAtlasMinimalContact) {
   const std::string full_name = FindRunfile(
       "drake_models/atlas/atlas_minimal_contact.urdf").abspath;
   AddModelFromUrdfFile(full_name, "");
-  for (int k = 0; k < 30; k++) {
-    EXPECT_THAT(TakeWarning(), MatchesRegex(".*safety_controller.*ignored.*"));
-  }
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*safety_controller.*ignored.*"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*attached to a fixed joint.*"));
   plant_.Finalize();
 
@@ -798,7 +796,7 @@ TEST_F(UrdfParserTest, TestRegisteredSceneGraph) {
   // Test that registration with scene graph results in visual geometries.
   AddModelFromUrdfFile(full_name, "");
   // Mostly ignore warnings here; they are tested in detail elsewhere.
-  EXPECT_GT(warning_records_.size(), 30);
+  EXPECT_GT(warning_records_.size(), 1);
   warning_records_.clear();
   plant_.Finalize();
   EXPECT_NE(plant_.num_visual_geometries(), 0);


### PR DESCRIPTION
The multibody parsers, in particular, had a habit of being very noisy, since if an unsupported element or attribute is used once it is likely used many times. This actually made it hard to visually inspect the output to see the unique set of unsupported tags. This change significantly improves the output for examples like in #20444.

+@rpoyner-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21966)
<!-- Reviewable:end -->
