### PR TITLE
[MuJoCo parser] Support "gear", "armature", and "position"

### DIFF
--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -1576,6 +1576,18 @@ TEST_F(MujocoParserTest, Motor) {
     <body>
       <joint type="hinge" name="hinge3" axis="0 1 0"/>
     </body>
+    <body>
+      <joint type="hinge" name="hinge4" axis="0 1 0" armature="12"/>
+    </body>
+    <body>
+      <joint type="hinge" name="hinge5" axis="0 1 0"/>
+    </body>
+    <body>
+      <joint type="hinge" name="hinge6" axis="0 1 0"/>
+    </body>
+    <body>
+      <joint type="hinge" name="hinge7" axis="0 1 0"/>
+    </body>
   </worldbody>
   <actuator>
     <motor joint="hinge0"/>
@@ -1586,6 +1598,13 @@ TEST_F(MujocoParserTest, Motor) {
     <!-- malformed limits will be ignored -->
     <motor name="motor3" joint="hinge3" ctrllimited="true" ctrlrange="2 1"
            forcelimited="true" forcerange="2 1"/>
+    <!-- gear ratio -->
+    <motor joint="hinge4" gear="2 0 0 0 0 0"/>
+    <!-- gear ratios with the wrong number of entries still work, but emit a warning -->
+    <motor joint="hinge5" gear="3 0 0"/>
+    <position name="position0" joint="hinge6"/>
+    <position name="position1" joint="hinge7" ctrllimited="true" ctrlrange="-2 2"
+           forcelimited="true" forcerange="-.4 .4" kp="4" kd="1"/>
   </actuator>
 </mujoco>
 )""";
@@ -1596,16 +1615,20 @@ TEST_F(MujocoParserTest, Motor) {
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*motor2.*forcerange.*"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*motor3.*ctrlrange.*"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*motor3.*forcerange.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*1 value or 6 values.*gear.*"));
 
   plant_.Finalize();
 
-  EXPECT_EQ(plant_.get_actuation_input_port().size(), 4);
+  EXPECT_EQ(plant_.get_actuation_input_port().size(), 8);
 
   const JointActuator<double>& motor0 =
       plant_.get_joint_actuator(JointActuatorIndex(0));
   EXPECT_EQ(motor0.name(), "motor0");
   EXPECT_EQ(motor0.joint().name(), "hinge0");
   EXPECT_EQ(motor0.effort_limit(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(motor0.default_gear_ratio(), 1);
+  EXPECT_EQ(motor0.default_rotor_inertia(), 0);
+  EXPECT_FALSE(motor0.has_controller());
 
   const JointActuator<double>& motor1 =
       plant_.get_joint_actuator(JointActuatorIndex(1));
@@ -1624,6 +1647,43 @@ TEST_F(MujocoParserTest, Motor) {
   EXPECT_EQ(motor3.name(), "motor3");
   EXPECT_EQ(motor3.joint().name(), "hinge3");
   EXPECT_EQ(motor3.effort_limit(), std::numeric_limits<double>::infinity());
+
+  const JointActuator<double>& motor4 =
+      plant_.get_joint_actuator(JointActuatorIndex(4));
+  EXPECT_EQ(motor4.name(), "motor4");
+  EXPECT_EQ(motor4.joint().name(), "hinge4");
+  EXPECT_EQ(motor4.effort_limit(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(motor4.default_gear_ratio(), 2);
+  EXPECT_NEAR(motor4.default_reflected_inertia(), 12, 1e-14);
+
+  const JointActuator<double>& motor5 =
+      plant_.get_joint_actuator(JointActuatorIndex(5));
+  EXPECT_EQ(motor5.name(), "motor5");
+  EXPECT_EQ(motor5.joint().name(), "hinge5");
+  EXPECT_EQ(motor5.effort_limit(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(motor5.default_gear_ratio(), 3);
+  EXPECT_EQ(motor5.default_rotor_inertia(), 0);
+
+  // Verify that omiting kp and kd for position tag results in the MuJoCo
+  // default controller gains.
+  const JointActuator<double>& position0 =
+      plant_.get_joint_actuator(JointActuatorIndex(6));
+  EXPECT_EQ(position0.name(), "position0");
+  EXPECT_EQ(position0.joint().name(), "hinge6");
+  EXPECT_EQ(position0.effort_limit(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(position0.get_controller_gains().p, 1);
+  EXPECT_EQ(position0.get_controller_gains().d, 0);
+
+  // Verify that the supported tags are parsed correctly (the effort limit is
+  // the mininum of the absolute value of the control range and the force
+  // range).
+  const JointActuator<double>& position1 =
+      plant_.get_joint_actuator(JointActuatorIndex(7));
+  EXPECT_EQ(position1.name(), "position1");
+  EXPECT_EQ(position1.joint().name(), "hinge7");
+  EXPECT_EQ(position1.effort_limit(), 0.4);
+  EXPECT_EQ(position1.get_controller_gains().p, 4);
+  EXPECT_EQ(position1.get_controller_gains().d, 1);
 }
 
 class ContactTest : public MujocoParserTest,


### PR DESCRIPTION
+@joemasterjohn for feature review, please.

fyi @yuvaltassa: the [xml spec](https://mujoco.readthedocs.io/en/stable/XMLreference.html#actuator) indicates that gear must be specified with 6 numbers, but [clearly](https://github.com/search?q=repo%3Agoogle-deepmind%2Fdm_control%20gear&type=code) specifying only a single number works, too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21967)
<!-- Reviewable:end -->
