### PR TITLE
[Mujoco Parser] Support equality "connect" constraints.

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -293,7 +293,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("damping") = 0.0, py_rvp::reference_internal,
             cls_doc.AddDistanceConstraint.doc)
         .def("AddBallConstraint", &Class::AddBallConstraint, py::arg("body_A"),
-            py::arg("p_AP"), py::arg("body_B"), py::arg("p_BQ"),
+            py::arg("p_AP"), py::arg("body_B"), py::arg("p_BQ") = std::nullopt,
             py_rvp::reference_internal, cls_doc.AddBallConstraint.doc)
         .def("AddWeldConstraint", &Class::AddWeldConstraint, py::arg("body_A"),
             py::arg("X_AP"), py::arg("body_B"), py::arg("X_BQ"),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2681,6 +2681,9 @@ class TestPlant(unittest.TestCase):
             body_A=body_A, p_AP=p_AP, body_B=body_B, p_BQ=p_BQ, distance=0.01)
         ball_id = plant.AddBallConstraint(
             body_A=body_A, p_AP=p_AP, body_B=body_B, p_BQ=p_BQ)
+        # Add a second ball constraint using the default (unspecified) p_BQ.
+        ball_id2 = plant.AddBallConstraint(
+            body_A=body_A, p_AP=p_AP, body_B=body_B)
         weld_id = plant.AddWeldConstraint(
             body_A=body_A, X_AP=X_AP, body_B=body_B, X_BQ=X_BQ)
 
@@ -2704,7 +2707,7 @@ class TestPlant(unittest.TestCase):
         # are the same up to a permutation.
         self.assertTrue(
             collections.Counter(ids) == collections.Counter(
-                [distance_id, ball_id, weld_id, coupler_id]))
+                [distance_id, ball_id, ball_id2, weld_id, coupler_id]))
 
         # Default context.
         context = plant.CreateDefaultContext()
@@ -2717,6 +2720,8 @@ class TestPlant(unittest.TestCase):
         self.assertTrue(
             plant.GetConstraintActiveStatus(context=context, id=ball_id))
         self.assertTrue(
+            plant.GetConstraintActiveStatus(context=context, id=ball_id2))
+        self.assertTrue(
             plant.GetConstraintActiveStatus(context=context, id=weld_id))
 
         # Set all constraints to inactive.
@@ -2726,6 +2731,8 @@ class TestPlant(unittest.TestCase):
             context=context, id=distance_id, status=False)
         plant.SetConstraintActiveStatus(
             context=context, id=ball_id, status=False)
+        plant.SetConstraintActiveStatus(
+            context=context, id=ball_id2, status=False)
         plant.SetConstraintActiveStatus(
             context=context, id=weld_id, status=False)
 
@@ -2737,6 +2744,8 @@ class TestPlant(unittest.TestCase):
         self.assertFalse(
             plant.GetConstraintActiveStatus(context=context, id=ball_id))
         self.assertFalse(
+            plant.GetConstraintActiveStatus(context=context, id=ball_id2))
+        self.assertFalse(
             plant.GetConstraintActiveStatus(context=context, id=weld_id))
 
         # Set all constraints to back to active.
@@ -2747,6 +2756,8 @@ class TestPlant(unittest.TestCase):
         plant.SetConstraintActiveStatus(
             context=context, id=ball_id, status=True)
         plant.SetConstraintActiveStatus(
+            context=context, id=ball_id2, status=True)
+        plant.SetConstraintActiveStatus(
             context=context, id=weld_id, status=True)
 
         # Verify all constraints are active in the context.
@@ -2756,6 +2767,8 @@ class TestPlant(unittest.TestCase):
             plant.GetConstraintActiveStatus(context=context, id=distance_id))
         self.assertTrue(
             plant.GetConstraintActiveStatus(context=context, id=ball_id))
+        self.assertTrue(
+            plant.GetConstraintActiveStatus(context=context, id=ball_id2))
         self.assertTrue(
             plant.GetConstraintActiveStatus(context=context, id=weld_id))
 

--- a/examples/multibody/strandbeest/run_with_motor.cc
+++ b/examples/multibody/strandbeest/run_with_motor.cc
@@ -212,7 +212,8 @@ int do_main() {
     for (const auto& [id, spec] : strandbeest.get_ball_constraint_specs()) {
       ik.AddPointToPointDistanceConstraint(
           strandbeest.get_body(spec.body_A).body_frame(), spec.p_AP,
-          strandbeest.get_body(spec.body_B).body_frame(), spec.p_BQ, 0, 0);
+          strandbeest.get_body(spec.body_B).body_frame(), spec.p_BQ.value(), 0,
+          0);
     }
   } else {
     // Add a position constraint for each bushing element. The origins of the

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -1051,6 +1051,7 @@ class MujocoParser {
     parse_class_defaults("geom", &default_geometry_);
     parse_class_defaults("joint", &default_joint_);
     parse_class_defaults("mesh", &default_mesh_);
+    parse_class_defaults("equality", &default_equality_);
 
     // Parse child defaults.
     for (XMLElement* default_node = node->FirstChildElement("default");
@@ -1064,7 +1065,6 @@ class MujocoParser {
     WarnUnsupportedElement(*node, "camera");
     WarnUnsupportedElement(*node, "light");
     WarnUnsupportedElement(*node, "pair");
-    WarnUnsupportedElement(*node, "equality");
     WarnUnsupportedElement(*node, "tendon");
     WarnUnsupportedElement(*node, "general");
     WarnUnsupportedElement(*node, "motor");
@@ -1472,6 +1472,104 @@ class MujocoParser {
     }
   }
 
+  void ParseEquality(XMLElement* node) {
+    // Per the mujoco docs: "The actual equality constraints have types
+    // depending on the sub-element used to define them. However here we are
+    // setting attributes common to all equality constraint types, which is why
+    // we do not make a distinction between types." This helper method applies
+    // the default_equality to each sub-element.
+    auto apply_defaults = [&](XMLElement* node_on_which_to_apply) {
+      std::string class_name;
+      if (!ParseStringAttribute(node_on_which_to_apply, "class", &class_name)) {
+        class_name = "main";
+      }
+      if (default_equality_.contains(class_name)) {
+        ApplyDefaultAttributes(*default_equality_.at(class_name),
+                               node_on_which_to_apply);
+      }
+    };
+
+    for (XMLElement* connect_node = node->FirstChildElement("connect");
+         connect_node;
+         connect_node = connect_node->NextSiblingElement("connect")) {
+      apply_defaults(connect_node);
+
+      // Per the mujoco docs: connect can be specified with either "body1",
+      // "anchor", (both required) and optionally "body2" OR "site1" and
+      // "site2" (both required).
+      if (connect_node->Attribute("body1") &&
+          connect_node->Attribute("site1")) {
+        Error(*connect_node,
+              "connect node must specify either body1 and anchor OR site1 and "
+              "site2, but not both.");
+        continue;
+      }
+
+      std::string body1;
+      if (ParseStringAttribute(connect_node, "body1", &body1)) {
+        // Then "body1", "anchor", and optionally "body2".
+        Vector3d p_AP;
+        if (!ParseVectorAttribute(connect_node, "anchor", &p_AP)) {
+          Error(*node,
+                "connect specified body1 but does not have the required anchor "
+                "attribute.");
+          continue;
+        }
+        if (!plant_->HasBodyNamed(body1, model_instance_)) {
+          Error(*node,
+                fmt::format("connect specified body1: {} but no body with that "
+                            "name exists in model instance: {}",
+                            body1,
+                            plant_->GetModelInstanceName(model_instance_)));
+          continue;
+        }
+        const RigidBody<double>& body_A =
+            plant_->GetBodyByName(body1, model_instance_);
+        const RigidBody<double>* body_B = &plant_->world_body();
+        std::string body2;
+        if (ParseStringAttribute(connect_node, "body2", &body2)) {
+          if (!plant_->HasBodyNamed(body2, model_instance_)) {
+            Error(*node,
+                  fmt::format(
+                      "connect specified body2: {} but no body with that "
+                      "name exists in model instance: {}",
+                      body2, plant_->GetModelInstanceName(model_instance_)));
+            continue;
+          }
+          body_B = &plant_->GetBodyByName(body2, model_instance_);
+        }
+        plant_->AddBallConstraint(body_A, p_AP, *body_B);
+      } else {
+        std::string site1, site2;
+        if (!ParseStringAttribute(connect_node, "site1", &site1) ||
+            !ParseStringAttribute(connect_node, "site2", &site2)) {
+          Error(*connect_node,
+                "connect must specify body1 and anchor OR site1 and site2.");
+          continue;
+        } else {
+          Warning(*connect_node,
+                  "connect node uses the site1 and site2 specification, which "
+                  "is not supported yet. This constraint will be ignored.");
+          continue;
+        }
+      }
+
+      WarnUnsupportedAttribute(*connect_node, "active");
+      WarnUnsupportedAttribute(*connect_node, "solref");
+      WarnUnsupportedAttribute(*connect_node, "solimp");
+    }
+
+    // TODO(russt): "weld" and "distance" constraints are already supported by
+    // MultibodyPlant and should be easy to add. But note that "distance"
+    // constraints were removed in MuJoCo version 2.2.2.
+    WarnUnsupportedElement(*node, "weld");
+    WarnUnsupportedElement(*node, "distance");
+
+    WarnUnsupportedElement(*node, "joint");
+    WarnUnsupportedElement(*node, "tendon");
+    WarnUnsupportedElement(*node, "flex");
+  }
+
   // Updates node by recursively replacing any <include> elements under it with
   // the children of the named file's root element.
   void ExpandIncludeTags(XMLElement* node,
@@ -1627,11 +1725,17 @@ class MujocoParser {
       ParseContact(contact_node);
     }
 
+    // Parses the model's equality elements.
+    for (XMLElement* equality_node = node->FirstChildElement("equality");
+         equality_node;
+         equality_node = equality_node->NextSiblingElement("equality")) {
+      ParseEquality(equality_node);
+    }
+
     WarnUnsupportedElement(*node, "size");
     WarnUnsupportedElement(*node, "visual");
     WarnUnsupportedElement(*node, "statistic");
     WarnUnsupportedElement(*node, "custom");
-    WarnUnsupportedElement(*node, "equality");
     WarnUnsupportedElement(*node, "tendon");
     WarnUnsupportedElement(*node, "sensor");
     WarnUnsupportedElement(*node, "keyframe");
@@ -1670,6 +1774,7 @@ class MujocoParser {
   std::map<std::string, XMLElement*> default_geometry_{};
   std::map<std::string, XMLElement*> default_joint_{};
   std::map<std::string, XMLElement*> default_mesh_{};
+  std::map<std::string, XMLElement*> default_equality_{};
   enum InertiaFromGeometry { kFalse, kTrue, kAuto };
   InertiaFromGeometry inertia_from_geom_{kAuto};
   std::map<std::string, XMLElement*> material_{};

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -1775,6 +1775,92 @@ TEST_F(MujocoParserTest, ContactThrows) {
       ".*no RigidBody named 'QQQ' anywhere.*");
 }
 
+TEST_F(MujocoParserTest, EqualityTest) {
+  std::string xml = R"""(
+<mujoco model="test">
+  <worldbody>
+    <body name="body1" pos="-1 0 0">
+      <geom type="box" size="0.1 0.2 0.3"/>
+      <joint type="hinge"/>
+    </body>
+    <body name="body2" pos="1 0 0">
+      <geom type="box" size="0.1 0.2 0.3"/>
+      <joint type="hinge"/>
+    </body>
+  </worldbody>
+  <equality>
+    <connect body1="body1" anchor="1 2 3" body2="body2"/>
+    <connect body1="body1" anchor="4 5 6"/>
+  </equality>
+</mujoco>
+)""";
+
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  AddModelFromString(xml, "test");
+  const auto constraint_ids = plant_.GetConstraintIds();
+  const auto& spec1 = plant_.get_ball_constraint_specs(constraint_ids[0]);
+  const auto& spec2 = plant_.get_ball_constraint_specs(constraint_ids[1]);
+  EXPECT_EQ(constraint_ids.size(), 2);
+  EXPECT_FALSE(spec1.p_BQ.has_value());
+  EXPECT_FALSE(spec2.p_BQ.has_value());
+
+  plant_.Finalize();
+
+  EXPECT_EQ(spec1.body_A, plant_.GetBodyByName("body1").index());
+  EXPECT_EQ(spec1.body_B, plant_.GetBodyByName("body2").index());
+  Vector3d p_AP(1, 2, 3);
+  EXPECT_TRUE(CompareMatrices(spec1.p_AP, p_AP));
+  RigidTransformd X_WA(Vector3d(-1, 0, 0)), X_WB(Vector3d(1, 0, 0));
+  Vector3d p_BQ = X_WB.inverse() * X_WA * p_AP;  // since Q == P.
+  ASSERT_TRUE(spec1.p_BQ.has_value());
+  EXPECT_TRUE(CompareMatrices(spec1.p_BQ.value(), p_BQ, 1e-14));
+
+  auto context = plant_.CreateDefaultContext();
+  EXPECT_EQ(spec2.body_A, plant_.GetBodyByName("body1").index());
+  EXPECT_EQ(spec2.body_B, plant_.world_body().index());
+  p_AP = Vector3d(4, 5, 6);
+  EXPECT_TRUE(CompareMatrices(spec2.p_AP, p_AP));
+  Vector3d p_WQ = X_WA * p_AP;
+  ASSERT_TRUE(spec2.p_BQ.has_value());
+  EXPECT_TRUE(CompareMatrices(spec2.p_BQ.value(), p_WQ, 1e-14));
+}
+
+TEST_F(MujocoParserTest, BadEqualityTest) {
+  std::string xml = R"""(
+<mujoco model="test">
+  <worldbody>
+    <body name="body1">
+      <geom type="box" size="0.1 0.2 0.3"/>
+      <joint type="hinge" pos="-1 0 0"/>
+    </body>
+    <body name="body2">
+      <geom type="box" size="0.1 0.2 0.3"/>
+      <joint type="hinge" pos="1 0 0"/>
+    </body>
+  </worldbody>
+  <equality>
+    <connect body1="body1" body2="body2"/>
+    <connect/>
+    <connect site1="site1" site2="site2"/>
+    <connect body1="body1" site1="site1"/>
+    <connect body1="nonsense" anchor="1 2 3"/>
+    <connect body1="body1" anchor="1 2 3" body2="nonsense"/>
+  </equality>
+</mujoco>
+)""";
+
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  AddModelFromString(xml, "test");
+  EXPECT_THAT(TakeError(), MatchesRegex(".*anchor.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*body1.*anchor.*site1.*site2.*"));
+  EXPECT_THAT(TakeWarning(), MatchesRegex(".*site1.*site2.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*body1.*site1.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*body1.*nonsense.*"));
+  EXPECT_THAT(TakeError(), MatchesRegex(".*body2.*nonsense.*"));
+  const auto constraint_ids = plant_.GetConstraintIds();
+  EXPECT_EQ(constraint_ids.size(), 0);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/constraint_specs.h
+++ b/multibody/plant/constraint_specs.h
@@ -6,6 +6,7 @@
 /// are later on used by our discrete solvers to build a model.
 
 #include <limits>
+#include <optional>
 #include <vector>
 
 #include "drake/math/rigid_transform.h"
@@ -89,10 +90,15 @@ struct BallConstraintSpec {
   //   body_A != body_B.
   bool IsValid() const { return body_A != body_B; }
 
-  BodyIndex body_A;          // Index of body A.
-  Vector3<double> p_AP;      // Position of point P in body frame A.
-  BodyIndex body_B;          // Index of body B.
-  Vector3<double> p_BQ;      // Position of point Q in body frame B.
+  BodyIndex body_A;      // Index of body A.
+  Vector3<double> p_AP;  // Position of point P in body frame A.
+  BodyIndex body_B;      // Index of body B.
+
+  // Position of point Q in body frame B. Pre-finalize this may be
+  // std::nullopt; if so, then during Finalize() it will be set so that the
+  // constraint is satisfied in the default context.
+  std::optional<Vector3<double>> p_BQ;
+
   MultibodyConstraintId id;  // Id of this constraint in the plant.
 };
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1927,7 +1927,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] body_A RigidBody to which point P is rigidly attached.
   /// @param[in] p_AP Position of point P in body A's frame.
   /// @param[in] body_B RigidBody to which point Q is rigidly attached.
-  /// @param[in] p_BQ Position of point Q in body B's frame.
+  /// @param[in] p_BQ (optional) Position of point Q in body B's frame. If p_BQ
+  /// is std::nullopt, then p_BQ will be computed so that the constraint is
+  /// satisfied for the default configuration at Finalize() time; subsequent
+  /// changes to the default configuration will not change the computed p_BQ.
   /// @returns the id of the newly added constraint.
   ///
   /// @throws std::exception if bodies A and B are the same body.
@@ -1937,10 +1940,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if `this` %MultibodyPlant's underlying contact
   /// solver is not SAP. (i.e. get_discrete_contact_solver() !=
   /// DiscreteContactSolver::kSap)
-  MultibodyConstraintId AddBallConstraint(const RigidBody<T>& body_A,
-                                          const Vector3<double>& p_AP,
-                                          const RigidBody<T>& body_B,
-                                          const Vector3<double>& p_BQ);
+  MultibodyConstraintId AddBallConstraint(
+      const RigidBody<T>& body_A, const Vector3<double>& p_AP,
+      const RigidBody<T>& body_B,
+      const std::optional<Vector3<double>>& p_BQ = {});
 
   /// Defines a constraint such that frame P affixed to body A is coincident at
   /// all times with frame Q affixed to body B, effectively modeling a weld
@@ -5508,6 +5511,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // corresponds to the largest penalty parameter (smaller violation errors)
   // that still guarantees stability.
   void SetUpJointLimitsParameters();
+
+  // Some constraints support std::optional specs, which implies that the
+  // kinematics should be used to compute values such that the constraint is
+  // satisfied by the default context at the moment Finalize() is called. This
+  // method computes those values and stores them in the constraint specs.
+  void FinalizeConstraints();
 
   // Declares any input ports that haven't yet been declared.
   // This happens during Finalize().

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -538,6 +538,7 @@ void SapDriver<T>::AddBallConstraints(
 
     const RigidBody<T>& body_A = plant().get_body(spec.body_A);
     const RigidBody<T>& body_B = plant().get_body(spec.body_B);
+    DRAKE_DEMAND(spec.p_BQ.has_value());
 
     const math::RigidTransform<T>& X_WA =
         plant().EvalBodyPoseInWorld(context, body_A);
@@ -545,8 +546,9 @@ void SapDriver<T>::AddBallConstraints(
         plant().EvalBodyPoseInWorld(context, body_B);
     const Vector3<T> p_WP = X_WA * spec.p_AP.template cast<T>();
     const Vector3<T> p_AP_W = X_WA.rotation() * spec.p_AP.template cast<T>();
-    const Vector3<T> p_WQ = X_WB * spec.p_BQ.template cast<T>();
-    const Vector3<T> p_BQ_W = X_WB.rotation() * spec.p_BQ.template cast<T>();
+    const Vector3<T> p_WQ = X_WB * spec.p_BQ.value().template cast<T>();
+    const Vector3<T> p_BQ_W =
+        X_WB.rotation() * spec.p_BQ.value().template cast<T>();
 
     // Dense Jacobian.
     // d(p_PQ_W)/dt = Jv_ApBq_W * v.

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -4503,6 +4503,35 @@ GTEST_TEST(MultibodyPlantTests, RemoveConstraint) {
       ".*Post-finalize calls to .*RemoveConstraint.* are not allowed.*");
 }
 
+GTEST_TEST(MultibodyPlantTests, FinalizeConstraints) {
+  // Set up a plant with partially specified constraints that must be finalized.
+  MultibodyPlant<double> plant(0.01);
+  // N.B. This feature is only supported by the SAP solver. Therefore we
+  // arbitrarily choose one model approximation that uses the SAP solver.
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  const Body<double>& body_A =
+      plant.AddRigidBody("body_A", SpatialInertia<double>::NaN());
+  const Body<double>& body_B =
+      plant.AddRigidBody("body_B", SpatialInertia<double>::NaN());
+  RigidTransformd X_WA(Vector3d(-1.0, -2.0, -3.0));
+  plant.AddJoint<RevoluteJoint>("world_A", plant.world_body(), X_WA, body_A,
+                                std::nullopt, Vector3d::UnitZ());
+  RigidTransformd X_WB(Vector3d(1.2, 3.4, 5.6));
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("body_B"), X_WB);
+
+  Vector3d p_AP = Vector3d(4.0, 5.0, 6.0);
+  MultibodyConstraintId ball_id = plant.AddBallConstraint(
+      body_A, p_AP, body_B, std::nullopt /* p_BQ is left unspecified */);
+  EXPECT_FALSE(plant.get_ball_constraint_specs(ball_id).p_BQ.has_value());
+
+  plant.Finalize();
+
+  Vector3d p_BQ = X_WB.inverse() * X_WA * p_AP;  // since Q == P.
+  ASSERT_TRUE(plant.get_ball_constraint_specs(ball_id).p_BQ.has_value());
+  EXPECT_TRUE(CompareMatrices(
+      plant.get_ball_constraint_specs(ball_id).p_BQ.value(), p_BQ, 1e-14));
+}
+
 GTEST_TEST(MultibodyPlantTests, FixedOffsetFrameFunctions) {
   MultibodyPlant<double> plant(0.0);
   const RigidBody<double>& body_B =

--- a/multibody/plant/test/sap_driver_ball_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_ball_constraints_test.cc
@@ -278,6 +278,24 @@ GTEST_TEST(BallConstraintsTests, VerifyIdMapping) {
   EXPECT_THROW(plant.get_weld_constraint_specs(ball_id), std::exception);
 }
 
+// Ensure that SAP runs on a constraint specified with p_BQ = std::nullopt.
+GTEST_TEST(BallConstraintTests, FinalizedConstraint) {
+  MultibodyPlant<double> plant{0.1};
+  plant.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  const RigidBody<double>& bodyA =
+      plant.AddRigidBody("A", SpatialInertia<double>::MakeUnitary());
+  const RigidBody<double>& bodyB =
+      plant.AddRigidBody("B", SpatialInertia<double>::MakeUnitary());
+  plant.AddBallConstraint(bodyA, Vector3d{0, 0, 0}, bodyB,
+                          /* p_BQ = */ std::nullopt);
+  plant.Finalize();
+  auto context = plant.CreateDefaultContext();
+
+  EXPECT_NO_THROW(
+      plant.get_contact_results_output_port().Eval<ContactResults<double>>(
+          *context));
+}
+
 GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
   MultibodyPlant<double> plant{0.1};
   plant.set_discrete_contact_approximation(


### PR DESCRIPTION
Implements initial support for equality constraints in the MuJoCo parser.

As discussed in #21943, this generalizes
`MultibodyPlant::AddBallConstraint()` to take a partial specification of constraint, which uses the kinematics during FinalizePlantOnly() to compute the point on body B which satisfies the constraints.

+@joemasterjohn for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21970)
<!-- Reviewable:end -->
