### PR TITLE
[multibody] Allow Rpy floating joints for free bodies

### DIFF
--- a/multibody/plant/test/floating_body_test.cc
+++ b/multibody/plant/test/floating_body_test.cc
@@ -17,9 +17,17 @@ namespace internal {
 class MultibodyTreeTester {
  public:
   MultibodyTreeTester() = delete;
+
   static const QuaternionFloatingMobilizer<double>& get_floating_mobilizer(
       const MultibodyTree<double>& model, const RigidBody<double>& body) {
-    return model.GetFreeBodyMobilizerOrThrow(body);
+    const Mobilizer<double>& mobilizer =
+        model.GetFreeBodyMobilizerOrThrow(body);
+    const QuaternionFloatingMobilizer<double>* const
+        quaternion_floating_mobilizer =
+            dynamic_cast<const QuaternionFloatingMobilizer<double>*>(
+                &mobilizer);
+    DRAKE_DEMAND(quaternion_floating_mobilizer != nullptr);
+    return *quaternion_floating_mobilizer;
   }
 };
 }  // namespace internal

--- a/multibody/tree/joint.cc
+++ b/multibody/tree/joint.cc
@@ -18,6 +18,109 @@ bool Joint<T>::can_translate() const {
   return get_implementation().mobilizer->can_translate();
 }
 
+template <typename T>
+void Joint<T>::set_default_positions(const VectorX<double>& default_positions) {
+  DRAKE_THROW_UNLESS(default_positions.size() == num_positions());
+  default_positions_ = default_positions;
+  do_set_default_positions(default_positions);
+}
+
+template <typename T>
+void Joint<T>::SetPositions(
+    systems::Context<T>* context,
+    const Eigen::Ref<const VectorX<T>>& positions) const {
+  DRAKE_THROW_UNLESS(context != nullptr);
+  DRAKE_THROW_UNLESS(positions.size() == num_positions());
+  this->get_parent_tree().ThrowIfNotFinalized("Joint::SetPositions");
+  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  const Eigen::VectorBlock<VectorX<T>> all_q =
+      this->get_parent_tree().GetMutablePositions(&*context);
+  get_implementation().mobilizer->get_mutable_positions_from_array(&all_q) =
+      positions;
+}
+
+template <typename T>
+Eigen::Ref<const VectorX<T>> Joint<T>::GetPositions(
+    const systems::Context<T>& context) const {
+  this->get_parent_tree().ThrowIfNotFinalized("Joint::GetPositions");
+  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  const Eigen::VectorBlock<const VectorX<T>> all_q =
+      this->get_parent_tree().get_positions(context);
+  return get_implementation().mobilizer->get_positions_from_array(all_q);
+}
+
+template <typename T>
+void Joint<T>::SetVelocities(
+    systems::Context<T>* context,
+    const Eigen::Ref<const VectorX<T>>& velocities) const {
+  DRAKE_THROW_UNLESS(context != nullptr);
+  DRAKE_THROW_UNLESS(velocities.size() == num_velocities());
+  this->get_parent_tree().ThrowIfNotFinalized("Joint::SetVelocities");
+  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  const Eigen::VectorBlock<VectorX<T>> all_v =
+      this->get_parent_tree().GetMutableVelocities(&*context);
+  get_implementation().mobilizer->get_mutable_velocities_from_array(&all_v) =
+      velocities;
+}
+
+template <typename T>
+Eigen::Ref<const VectorX<T>> Joint<T>::GetVelocities(
+    const systems::Context<T>& context) const {
+  this->get_parent_tree().ThrowIfNotFinalized("Joint::GetVelocities");
+  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  const Eigen::VectorBlock<const VectorX<T>> all_v =
+      this->get_parent_tree().get_velocities(context);
+  return get_implementation().mobilizer->get_velocities_from_array(all_v);
+}
+
+template <typename T>
+void Joint<T>::SetSpatialVelocityImpl(systems::Context<T>* context,
+                                      const SpatialVelocity<T>& V_FM,
+                                      const char* func) const {
+  DRAKE_THROW_UNLESS(context != nullptr);
+  this->get_parent_tree().ThrowIfNotFinalized("Joint::SetSpatialVelocity");
+  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  if (!get_implementation().mobilizer->SetSpatialVelocity(
+          *context, V_FM, &context->get_mutable_state())) {
+    throw std::logic_error(
+        fmt::format("{}(): {} joint does not implement this function "
+                    "(joint '{}')",
+                    func, type_name(), name()));
+  }
+}
+
+template <typename T>
+SpatialVelocity<T> Joint<T>::GetSpatialVelocity(
+    const systems::Context<T>& context) const {
+  this->get_parent_tree().ThrowIfNotFinalized("Joint::GetSpatialVelocity");
+  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  return get_implementation().mobilizer->GetSpatialVelocity(context);
+}
+
+template <typename T>
+void Joint<T>::SetPosePairImpl(systems::Context<T>* context,
+                               const Quaternion<T>& q_FM,
+                               const Vector3<T>& p_FM, const char* func) const {
+  DRAKE_THROW_UNLESS(context != nullptr);
+  this->get_parent_tree().ThrowIfNotFinalized("Joint::SetPosePair");
+  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  if (!get_implementation().mobilizer->SetPosePair(
+          *context, q_FM, p_FM, &context->get_mutable_state())) {
+    throw std::logic_error(
+        fmt::format("{}(): {} joint does not implement this function "
+                    "(joint '{}')",
+                    func, type_name(), name()));
+  }
+}
+
+template <typename T>
+std::pair<Eigen::Quaternion<T>, Vector3<T>> Joint<T>::GetPosePair(
+    const systems::Context<T>& context) const {
+  this->get_parent_tree().ThrowIfNotFinalized("Joint::GetPosePair");
+  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  return get_implementation().mobilizer->GetPosePair(context);
+}
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -79,9 +79,11 @@ class Joint : public MultibodyElement<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Joint);
 
+  // TODO(sherm1) Shouldn't these constructors be in protected?
+
   /// Creates a joint between two Frame objects which imposes a given kinematic
   /// relation between frame F attached on the parent body P and frame M
-  /// attached on the child body B. The joint will be initialized to the model
+  /// attached on the child body B. The joint will be assigned to the model
   /// instance from @p frame_on_child (this is the typical convention for joints
   /// between the world and a model, or between two models (e.g. an arm to a
   /// gripper)).  See this class's documentation for further details.
@@ -355,12 +357,13 @@ class Joint : public MultibodyElement<T> {
     return implementation_->mobilizer->is_locked(context);
   }
 
-  /// @name Methods to get and set the limits of `this` joint. For position
-  /// limits, the layout is the same as the generalized position's. For
-  /// velocity and acceleration limits, the layout is the same as the
-  /// generalized velocity's. A limit with value +/- ∞ implies no upper or
+  /// @name            Methods to get and set limits
+  /// For position limits, the layout is the same as the generalized positions
+  /// q. For velocity and acceleration limits, the layout is the same as the
+  /// generalized velocities v. A limit with value +/- ∞ implies no upper or
   /// lower limit.
   /// @{
+
   /// Returns the position lower limits.
   const VectorX<double>& position_lower_limits() const {
     return pos_lower_limits_;
@@ -389,11 +392,6 @@ class Joint : public MultibodyElement<T> {
   /// Returns the acceleration upper limits.
   const VectorX<double>& acceleration_upper_limits() const {
     return acc_upper_limits_;
-  }
-
-  /// Returns the default positions.
-  const VectorX<double>& default_positions() const {
-    return default_positions_;
   }
 
   /// Sets the position limits to @p lower_limits and @p upper_limits.
@@ -441,49 +439,186 @@ class Joint : public MultibodyElement<T> {
     acc_upper_limits_ = upper_limits;
   }
 
-  /// Sets the default positions to @p default_positions. Joint subclasses are
-  /// expected to implement the do_set_default_positions().
-  /// @throws std::exception if the dimension of @p default_positions does not
-  /// match num_positions().
-  /// @note The values in @p default_positions are NOT constrained to be within
-  /// `position_lower_limits()` and `position_upper_limits()`.
-  void set_default_positions(const VectorX<double>& default_positions) {
-    DRAKE_THROW_UNLESS(default_positions.size() == num_positions());
-    default_positions_ = default_positions;
-    do_set_default_positions(default_positions);
+  /// @}
+
+  // TODO(sherm1) Consider implementing SetPose/SetDefaultPose() for every joint
+  //  type, with the joint responsible for making a "best effort" to match the
+  //  pose if it can't do so exactly. Simbody has that feature and it has proven
+  //  very useful in practice.
+
+  /// @name       Methods to set and get pose and velocity
+  ///
+  /// Joints have both a default state q₀, v₀ (stored here) and a runtime state
+  /// q, v (stored in a systems::Context). The default state is the value that
+  /// is used to initialize the runtime state when a Context is first created.
+  /// (The default velocity v₀ for a joint is always zero so is not settable
+  /// here.) There are several ways to set these values:
+  ///  - If you understand a joint's state representation q and v, you can
+  ///    directly set them using methods below. The specific choice of
+  ///    generalized coordinates q and generalized velocities v is defined by
+  ///    the particular joint type; see documentation for the joint type.
+  ///  - Alternatively you can provide a generic pose X_FM and spatial velocity
+  ///    V_FM in which case the joint will set q and v to match or approximate
+  ///    those quantities. In particular, Drake's "floating" (6 degree of
+  ///    freedom) joints can represent any pose and spatial velocity.
+  ///  - Particular joint types may provide additional joint-specific functions
+  ///    for setting pose and velocity; see their documentation.
+  /// @{
+
+  /// Sets the default generalized position coordinates q₀ to
+  /// `default_positions`.
+  /// @note The values in `default_positions` are NOT constrained to be within
+  ///   position_lower_limits() and position_upper_limits().
+  /// @note The default generalized velocities v₀ are zero for every joint.
+  /// @throws std::exception if the dimension of `default_positions` does not
+  ///   match num_positions().
+  void set_default_positions(const VectorX<double>& default_positions);
+
+  /// Returns the default generalized position coordinates q₀. These will be
+  /// the values set with set_default_positions() if any; otherwise, they will
+  /// be the "zero configuration" for this joint type (as defined by the
+  /// particular joint type).
+  /// @note The default generalized velocities v₀ are zero for every joint.
+  const VectorX<double>& default_positions() const {
+    return default_positions_;
   }
 
-  // TODO(sherm1) Consider implementing SetDefaultPose() for every joint type,
-  //  with the joint responsible for making a "best effort" to match the pose if
-  //  it can't do so exactly. Simbody has that feature and it has proven very
-  //  useful in practice.
+  /// Sets in the given `context` the generalized position coordinates q for
+  /// this joint to `positions`.
+  /// @note The values in `positions` are NOT constrained to be within
+  ///   position_lower_limits() and position_upper_limits().
+  /// @throws std::exception if the dimension of `positions` does not match
+  ///   num_positions().
+  /// @throws std::exception if the containing MultibodyPlant has not yet been
+  ///   finalized.
+  /// @pre `context` is not null.
+  void SetPositions(systems::Context<T>* context,
+                    const Eigen::Ref<const VectorX<T>>& positions) const;
 
-  /// Sets this %Joint's default generalized positions q₀ such that the pose
+  /// Returns the current value in the given `context` of the generalized
+  /// coordinates q for this joint.
+  /// @throws std::exception if the containing MultibodyPlant has not yet been
+  ///   finalized.
+  Eigen::Ref<const VectorX<T>> GetPositions(
+      const systems::Context<T>& context) const;
+
+  /// Sets in the given `context` the generalized velocity coordinates v for
+  /// this joint to `velocities`.
+  /// @note The values in `velocities` are NOT constrained to be within
+  ///   velocity_lower_limits() and velocity_upper_limits().
+  /// @throws std::exception if the dimension of `velocities` does not match
+  ///   num_velocities().
+  /// @throws std::exception if the containing MultibodyPlant has not yet been
+  ///   finalized.
+  /// @pre `context` is not null.
+  void SetVelocities(systems::Context<T>* context,
+                     const Eigen::Ref<const VectorX<T>>& velocities) const;
+
+  /// Returns the current value in the given `context` of the generalized
+  /// velocities v for this joint.
+  /// @throws std::exception if the containing MultibodyPlant has not yet been
+  /// finalized.
+  Eigen::Ref<const VectorX<T>> GetVelocities(
+      const systems::Context<T>& context) const;
+
+  /// Sets this joint's default generalized positions q₀ such that the pose
   /// of the child frame M in the parent frame F best matches the given pose.
-  /// The pose is given by a RigidTransform `X_FM`, but a %Joint will
+  /// The pose is given by a RigidTransform `X_FM`, but a joint will
   /// represent pose differently.
   /// @note Currently this is implemented only for floating (6 dof) joints
   /// which can represent any pose.
-  /// @throws std::exception if called for any %Joint type that does not
+  /// @throws std::exception if called for any joint type that does not
   /// implement this function.
-  /// @see get_default_positions() to see the resulting q₀ after this call.
+  /// @see default_positions() to see the resulting q₀ after this call.
   /// @see SetDefaultPosePair() for an alternative using a quaternion
   void SetDefaultPose(const math::RigidTransform<double>& X_FM) {
     SetDefaultPosePair(X_FM.rotation().ToQuaternion(), X_FM.translation());
   }
 
-  /// Returns this %Joint's default pose as a RigidTransform X_FM.
+  /// Returns this joint's default pose as a RigidTransform X_FM.
   /// @note Currently this is implemented only for floating (6 dof) joints
-  /// which can represent any pose.
-  /// @throws std::exception if called for any %Joint type that does not
-  /// implement this function.
+  ///   which can represent any pose.
+  /// @throws std::exception if called for any joint type that does not
+  ///   implement this function.
   /// @retval X_FM The default pose as a rigid transform.
-  /// @see get_default_positions() to see the generalized positions q₀ that this
-  ///      joint used to generate the returned transform.
+  /// @see default_positions() to see the generalized positions q₀ that this
+  ///   joint used to generate the returned transform.
+  /// @see GetDefaultPosePair() for an alternative using a quaternion
   math::RigidTransform<double> GetDefaultPose() const {
     auto pose_pair = GetDefaultPosePair();
     return math::RigidTransform(pose_pair.first, pose_pair.second);
   }
+
+  /// Sets in the given `context` this joint's generalized positions q such
+  /// that the pose of the child frame M in the parent frame F best matches the
+  /// given pose. The pose is given by a RigidTransform X_FM, but a joint
+  /// will represent pose differently. Drake's "floating" (6 dof) joints can
+  /// represent any pose, but other joints may only be able to approximate
+  /// X_FM. See the individual joint descriptions for specifics.
+  ///
+  /// @note Currently this is implemented only for floating (6 dof) joints
+  ///   which can represent any pose.
+  /// @throws std::exception if called for any joint type that does not
+  ///   implement this function.
+  /// @throws std::exception if the containing MultibodyPlant has not yet been
+  ///   finalized.
+  /// @pre `context` is not null.
+  /// @see GetPositions() to see the resulting q after this call.
+  /// @see SetPosePair() for an alternative using a quaternion.
+  void SetPose(systems::Context<T>* context,
+               const math::RigidTransform<T>& X_FM) const {
+    SetPosePairImpl(context, X_FM.rotation().ToQuaternion(), X_FM.translation(),
+                    __func__);
+  }
+
+  /// Returns this joint's current pose using its position coordinates q taken
+  /// from the given `context` and converting that to a RigidTransform X_FM(q).
+  ///
+  /// @note The returned pose may not match the transform that was supplied to
+  ///   SetPose() since in general joints (other than 6 dof joints) cannot
+  ///   represent arbitrary poses.
+  /// @note All joint types support this function.
+  /// @throws std::exception if called for any joint type that does not
+  ///   implement this function.
+  /// @retval X_FM The current pose as a rigid transform.
+  /// @see GetPositions() to see the generalized positions q that this
+  ///   joint used to generate the returned transform.
+  math::RigidTransform<T> GetPose(const systems::Context<T>& context) const {
+    const auto& [q_FM, p_FM] = GetPosePair(context);
+    return math::RigidTransform(q_FM, p_FM);
+  }
+
+  /// Sets in the given `context` this joint's generalized velocities v such
+  /// that the spatial velocity of the child frame M in the parent frame F best
+  /// matches the given spatial velocity. The velocity is provided as a spatial
+  /// velocity V_FM, but a joint may represent velocity differently. Drake's
+  /// "floating" (6 dof) joints can represent any spatial velocity, but other
+  /// joints may only be able to approximate V_FM. See the individual joint
+  /// descriptions for specifics.
+  /// @note Currently this is implemented only for floating (6 dof) joints
+  ///   which can represent any spatial velocity.
+  /// @throws std::exception if called for any joint type that does not
+  ///   implement this function.
+  /// @throws std::exception if the containing MultibodyPlant has not yet been
+  ///   finalized.
+  /// @pre `context` is not null.
+  /// @see GetVelocities() to see the resulting v after this call.
+  void SetSpatialVelocity(systems::Context<T>* context,
+                          const SpatialVelocity<T>& V_FM) const {
+    SetSpatialVelocityImpl(&*context, V_FM, __func__);
+  }
+
+  /// Given the generalized positions q and generalized velocities v for this
+  /// joint in the given `context`, returns the cross-joint spatial velocity
+  /// V_FM.
+  /// @note All joint types support this function.
+  /// @retval V_FM the spatial velocity across this joint.
+  /// @throws std::exception if the containing MultibodyPlant has not yet been
+  ///   finalized.
+  /// @see GetVelocities() to see the generalized velocities v that this
+  ///   joint used to generate the returned spatial velocity.
+  SpatialVelocity<T> GetSpatialVelocity(
+      const systems::Context<T>& context) const;
 
   // BTW These are implemented with a (quaternion,vector) pair rather than a
   // rigid transform so that we can guarantee to preserve bit-perfect results
@@ -491,21 +626,67 @@ class Joint : public MultibodyElement<T> {
   // inboard quaternion floating joint. Users should prefer the above versions.
 
   /// (Advanced) This is the same as SetDefaultPose() except it takes the
-  /// pose as a (quaternion, translation vector) pair.
-  /// @see SetDefaultPose() for more information
+  /// pose as a (quaternion, translation vector) pair. A QuaternionFloatingJoint
+  /// will store this pose bit-identically; an RpyFloatingJoint will store it
+  /// to within floating point precision; any other joint will approximate it
+  /// consistent with that joint's mobility.
+  /// @note Currently this is implemented only for floating (6 dof) joints
+  ///   which can represent any pose.
+  /// @throws std::exception if called for any joint type that does not
+  ///   implement this function.
+  /// @see SetDefaultPose()
   void SetDefaultPosePair(const Quaternion<double>& q_FM,
                           const Vector3<double>& p_FM) {
     DoSetDefaultPosePair(q_FM, p_FM);
   }
 
   /// (Advanced) This is the same as GetDefaultPose() except it returns this
-  /// %Joint's default pose as a (quaternion, translation vector) pair.
+  /// joint's default pose as a (quaternion, translation vector) pair.
+  /// @note Currently this is implemented only for floating (6 dof) joints
+  ///   which can represent any pose.
+  /// @note For a QuaternionFloatingJoint the return will be bit-identical to
+  ///   the pose provided to SetDefaultPosePair(). For any other floating
+  ///   (6 dof) joint the pose will be numerically equivalent (i.e. within
+  ///   roundoff) but not identical. For other joint types it will be some
+  ///   approximation.
   /// @retval q_FM,p_FM The default pose as a (quaternion, translation) pair.
-  /// @see GetDefaultPose() for more information
+  /// @throws std::exception if called for any joint type that does not
+  ///   implement this function.
+  /// @see GetDefaultPose()
   std::pair<Eigen::Quaternion<double>, Vector3<double>> GetDefaultPosePair()
       const {
     return DoGetDefaultPosePair();
   }
+
+  /// (Advanced) This is the same as SetPose() except it takes the
+  /// pose as a (quaternion, translation vector) pair. A QuaternionFloatingJoint
+  /// will store this pose bit-identically; any other joint will approximate it.
+  /// @note Currently this is implemented only for floating (6 dof) joints
+  ///   which can represent any pose.
+  /// @throws std::exception if called for any joint type that does not
+  ///   implement this function.
+  /// @throws std::exception if the containing MultibodyPlant has not yet been
+  ///   finalized.
+  /// @pre `context` is not null.
+  /// @see SetPose()
+  void SetPosePair(systems::Context<T>* context, const Quaternion<T>& q_FM,
+                   const Vector3<T>& p_FM) const {
+    SetPosePairImpl(&*context, q_FM, p_FM, __func__);
+  }
+
+  /// (Advanced) This is the same as GetPose() except it returns this joint's
+  /// pose in the given `context` as a (quaternion, translation vector) pair.
+  /// @note All joint types support this function.
+  /// @note For a QuaternionFloatingJoint the return will be bit-identical to
+  ///   the pose provided to SetPosePair(). For any other floating (6 dof)
+  ///   joint the pose will be numerically equivalent (i.e. within roundoff) but
+  ///   not identical. For other joint types it will be some approximation.
+  /// @retval q_FM,p_FM The pose as a (quaternion, translation) pair.
+  /// @throws std::exception if the containing MultibodyPlant has not yet been
+  ///   finalized.
+  /// @see GetPose()
+  std::pair<Eigen::Quaternion<T>, Vector3<T>> GetPosePair(
+      const systems::Context<T>& context) const;
 
   /// @}
 
@@ -593,8 +774,8 @@ class Joint : public MultibodyElement<T> {
  protected:
   /// (Advanced) Structure containing all the information needed to build the
   /// MultibodyTree implementation for a %Joint. At MultibodyTree::Finalize() a
-  /// %Joint creates a BluePrint of its implementation with MakeModelBlueprint()
-  /// so that MultibodyTree can build an implementation for it.
+  /// %Joint creates a BluePrint of its implementation so that MultibodyTree can
+  /// build an implementation for it.
   struct BluePrint {
     std::unique_ptr<internal::Mobilizer<T>> mobilizer;
     // TODO(sherm1): add constraints and force elements as needed.
@@ -846,6 +1027,13 @@ class Joint : public MultibodyElement<T> {
         parameters->get_mutable_numeric_parameter(damping_parameter_index_);
     damping_parameter.set_value(VectorX<T>(damping_));
   }
+
+  void SetPosePairImpl(systems::Context<T>* context, const Quaternion<T>& q_FM,
+                       const Vector3<T>& p_FM, const char* func) const;
+
+  void SetSpatialVelocityImpl(systems::Context<T>* context,
+                              const SpatialVelocity<T>& V_FM,
+                              const char* func) const;
 
   std::string name_;
   const Frame<T>& frame_on_parent_;

--- a/multibody/tree/mobilizer.cc
+++ b/multibody/tree/mobilizer.cc
@@ -10,6 +10,13 @@ namespace internal {
 template <typename T>
 Mobilizer<T>::~Mobilizer() = default;
 
+template <typename T>
+std::pair<Eigen::Quaternion<T>, Vector3<T>> Mobilizer<T>::GetPosePair(
+    const systems::Context<T>& context) const {
+  const math::RigidTransform<T> X_FM = CalcAcrossMobilizerTransform(context);
+  return std::pair(X_FM.rotation().ToQuaternion(), X_FM.translation());
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "drake/common/autodiff.h"
@@ -129,9 +130,10 @@ class BodyNode;
 // describe rotations plus a position vector to describe translations. However,
 // we might choose the angular velocity `w_FM` and the linear velocity `v_FM`
 // as the generalized velocities (or more generally, the spatial velocity
-// `V_FM`.) In such a case `nq = 7` (4 dofs for a quaternion plus 3 dofs for a
-// position vector) and `nv = 6` (3 dofs for an angular velocity and 3 dofs for
-// a linear velocity).
+// `V_FM`.) In such a case `nq = 7` (4 generalized coordinates for a quaternion
+// plus 3 generalized coordinates for a position vector) and `nv = 6` (3
+// generalized speeds for an angular velocity and 3 generalized speeds for a
+// linear velocity).
 //
 // For a detailed discussion on the concept of a mobilizer please refer to
 // [Seth 2010]. The mobilizer "hinge" matrix `H_FM(q)` is introduced in
@@ -266,7 +268,7 @@ class Mobilizer : public MultibodyElement<T> {
 
   ~Mobilizer() override;
 
-  /// Returns this element's unique index.
+  // Returns this element's unique index.
   MobodIndex index() const { return this->template index_impl<MobodIndex>(); }
 
   // Returns the number of generalized coordinates granted by this mobilizer.
@@ -302,8 +304,8 @@ class Mobilizer : public MultibodyElement<T> {
   // system.
   int velocity_start_in_v() const { return mobod_.v_start(); }
 
-  /// Returns a string suffix (e.g. to be appended to the name()) to identify
-  /// the `k`th position in this mobilizer. Mobilizers with more than one
+  // Returns a string suffix (e.g. to be appended to the name()) to identify
+  // the `k`th position in this mobilizer. Mobilizers with more than one
   // position or that don't want to use the default `q`, must override this
   // method.
   virtual std::string position_suffix(int position_index_in_mobilizer) const {
@@ -314,8 +316,8 @@ class Mobilizer : public MultibodyElement<T> {
     return "q";
   }
 
-  /// Returns a string suffix (e.g. to be appended to the name()) to identify
-  /// the `k`th velocity in this mobilizer. Mobilizers with more than one
+  // Returns a string suffix (e.g. to be appended to the name()) to identify
+  // the `k`th velocity in this mobilizer. Mobilizers with more than one
   // velocity or that don't want to use the default 'v' must override this
   // method.
   virtual std::string velocity_suffix(int velocity_index_in_mobilizer) const {
@@ -351,12 +353,16 @@ class Mobilizer : public MultibodyElement<T> {
   const RigidBody<T>& outboard_body() const { return outboard_frame().body(); }
 
   // Returns `true` if `this` mobilizer grants 6-dofs to the outboard frame.
-  virtual bool is_floating() const { return false; }
+  // Ignoring joint limits, this means this mobilizer can represent any pose
+  // and any spatial velocity to machine precision.
+  bool has_six_dofs() const { return num_velocities() == 6; }
 
-  // Returns `true` if `this` uses a quaternion parametrization of rotations.
+  // Returns `true` if `this` uses a quaternion parameterization of rotations.
   virtual bool has_quaternion_dofs() const { return false; }
 
-  // @name Methods that define a %Mobilizer
+  // @name         Methods that define the Mobilizer abstraction
+  // For inner-loop computations, don't use this API. Use the templatized
+  // APIs of the concrete mobilizers.
   // @{
 
   // Sets the `state` to what will be considered to be the _zero_ state
@@ -382,10 +388,54 @@ class Mobilizer : public MultibodyElement<T> {
   // [1, 0, 0, 0].
   //
   // Note that the zero state may fall outside of the limits for any joints
-  // associated with this mobilizer.
+  // associated with this type of mobilizer.
   // @see set_default_state().
   virtual void SetZeroState(const systems::Context<T>& context,
                             systems::State<T>* state) const = 0;
+
+  // Sets the state for this mobilizer in the given State to some
+  // approximation of this pose. It's up to the concrete mobilizer to figure out
+  // what to do. (Only QuaternionFloatingMobilizer can represent this pose
+  // bit-exactly.)
+  // Returns false if this mobilizer doesn't implement this feature.
+  // TODO(sherm1) Currently this is only implemented for 6dof mobilizers.
+  //  It's still useful for other joints; broaden support.
+  virtual bool SetPosePair(const systems::Context<T>& context,
+                           const Eigen::Quaternion<T> q_FM,
+                           const Vector3<T>& p_FM,
+                           systems::State<T>* state) const = 0;
+
+  // Given the generalized positions q for this Mobilizer in the given
+  // `context`, returns the cross-mobilizer pose X_FM as a (quaternion, vec3)
+  // pair. Most mobilizers can use the default implementation here, but
+  // quaternion floating mobilizer is required to return bit-identical data
+  // so must override.
+  // @returns (q_FM, p_FM)
+  virtual std::pair<Eigen::Quaternion<T>, Vector3<T>> GetPosePair(
+      const systems::Context<T>& context) const;
+
+  // Sets the velocity state v for this mobilizer in the given State to some
+  // approximation of the given spatial velocity. It's up to the concrete
+  // mobilizer to figure out what to do. 6-dof mobilizers can represent this
+  // velocity exactly; others must project.
+  // Note: there is no SetDefaultSpatialVelocity() because that is always zero.
+  // Returns false if this mobilizer doesn't implement this feature.
+  // TODO(sherm1) Currently this is only implemented for 6dof mobilizers.
+  //  It's still useful for other joints; broaden support.
+  virtual bool SetSpatialVelocity(const systems::Context<T>& context,
+                                  const SpatialVelocity<T>& V_FM,
+                                  systems::State<T>* state) const = 0;
+
+  // Given the generalized positions q and generalized velocities v for this
+  // Mobilizer in the given `context`, returns the cross-mobilizer spatial
+  // velocity V_FM. (Not virtual)
+  SpatialVelocity<T> GetSpatialVelocity(
+      const systems::Context<T>& context) const {
+    const Eigen::VectorBlock<const VectorX<T>> all_v =
+        this->get_parent_tree().get_velocities(context);
+    const Eigen::Ref<const VectorX<T>> my_v = get_velocities_from_array(all_v);
+    return CalcAcrossMobilizerSpatialVelocity(context, my_v);
+  }
 
   // Sets the `state` to the _default_ state (position and velocity) for
   // `this` mobilizer.  For example, the zero state for our standard IIWA

--- a/multibody/tree/mobilizer_impl.cc
+++ b/multibody/tree/mobilizer_impl.cc
@@ -7,6 +7,68 @@ namespace internal {
 template <typename T, int nq, int nv>
 MobilizerImpl<T, nq, nv>::~MobilizerImpl() = default;
 
+template <typename T, int nq, int nv>
+void MobilizerImpl<T, nq, nv>::SetZeroState(const systems::Context<T>&,
+                                            systems::State<T>* state) const {
+  get_mutable_positions(state) = get_zero_position();
+  get_mutable_velocities(state).setZero();
+}
+
+template <typename T, int nq, int nv>
+bool MobilizerImpl<T, nq, nv>::SetPosePair(const systems::Context<T>&,
+                                           const Eigen::Quaternion<T> q_FM,
+                                           const Vector3<T>& p_FM,
+                                           systems::State<T>* state) const {
+  const std::optional<QVector<T>> q = DoPoseToPositions(q_FM, p_FM);
+  if (q.has_value()) get_mutable_positions(&*state) = *q;
+  return q.has_value();
+}
+
+template <typename T, int nq, int nv>
+bool MobilizerImpl<T, nq, nv>::SetSpatialVelocity(
+    const systems::Context<T>&, const SpatialVelocity<T>& V_FM,
+    systems::State<T>* state) const {
+  const std::optional<VVector<T>> v = DoSpatialVelocityToVelocities(V_FM);
+  if (v.has_value()) get_mutable_velocities(&*state) = *v;
+  return v.has_value();
+}
+
+template <typename T, int nq, int nv>
+void MobilizerImpl<T, nq, nv>::set_default_state(
+    const systems::Context<T>&, systems::State<T>* state) const {
+  get_mutable_positions(&*state) = get_default_position();
+  get_mutable_velocities(&*state).setZero();
+}
+
+template <typename T, int nq, int nv>
+void MobilizerImpl<T, nq, nv>::set_random_state(
+    const systems::Context<T>& context, systems::State<T>* state,
+    RandomGenerator* generator) const {
+  if (random_state_distribution_) {
+    const Vector<double, kNx> sample = Evaluate(
+        *random_state_distribution_, symbolic::Environment{}, generator);
+    get_mutable_positions(state) = sample.template head<kNq>();
+    get_mutable_velocities(state) = sample.template tail<kNv>();
+  } else {
+    set_default_state(context, state);
+  }
+}
+
+template <typename T, int nq, int nv>
+auto MobilizerImpl<T, nq, nv>::DoPoseToPositions(
+    const Eigen::Quaternion<T> orientation, const Vector3<T>& translation) const
+    -> std::optional<QVector<T>> {
+  unused(orientation, translation);
+  return {};
+}
+
+template <typename T, int nq, int nv>
+auto MobilizerImpl<T, nq, nv>::DoSpatialVelocityToVelocities(
+    const SpatialVelocity<T>& velocity) const -> std::optional<VVector<T>> {
+  unused(velocity);
+  return {};
+}
+
 // Macro used to explicitly instantiate implementations on all sizes needed.
 #define EXPLICITLY_INSTANTIATE_IMPLS(T)  \
   template class MobilizerImpl<T, 0, 0>; \

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -123,12 +123,12 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
 
   // Mark free bodies as needed.
   const BodyIndex outboard_body_index = mobilizer->outboard_body().index();
-  bool is_body_floating =
-      mobilizer->is_floating() &&
+  bool is_floating_base_body =
+      mobilizer->has_six_dofs() &&
       mobilizer->inboard_frame().body().index() == world_body().index();
 
-  topology_.get_mutable_rigid_body(outboard_body_index).is_floating =
-      is_body_floating;
+  topology_.get_mutable_rigid_body(outboard_body_index).is_floating_base =
+      is_floating_base_body;
   topology_.get_mutable_rigid_body(outboard_body_index).has_quaternion_dofs =
       mobilizer->has_quaternion_dofs();
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -961,6 +961,8 @@ class MultibodyTree {
     return link_joint_graph_;
   }
 
+  [[nodiscard]] LinkJointGraph& mutable_graph() { return link_joint_graph_; }
+
   [[nodiscard]] const SpanningForest& forest() const {
     DRAKE_ASSERT(graph().forest_is_valid());
     return graph().forest();
@@ -983,7 +985,7 @@ class MultibodyTree {
   //
   // @throws std::exception if called post-finalize.
   // TODO(amcastro-tri): Consider making this method private and calling it
-  // automatically when CreateDefaultContext() is called.
+  //  automatically when CreateDefaultContext() is called.
   void Finalize();
 
   // (Advanced) Allocates a new context for this %MultibodyTree uniquely
@@ -1108,6 +1110,11 @@ class MultibodyTree {
   void SetFreeBodyRandomRotationDistributionOrThrow(
       const RigidBody<T>& body,
       const Eigen::Quaternion<symbolic::Expression>& rotation);
+
+  // See MultibodyPlant::SetFreeBodyRandomRotationDistribution.
+  void SetFreeBodyRandomAnglesDistributionOrThrow(
+      const RigidBody<T>& body,
+      const math::RollPitchYaw<symbolic::Expression>& angles);
 
   // @name Kinematic computations
   // Kinematics computations are concerned with the motion of bodies in the
@@ -2516,6 +2523,16 @@ class MultibodyTree {
   // properties will cause subsequent numerical problems.
   void ThrowDefaultMassInertiaError() const;
 
+  // Helper method for throwing an exception within public methods that should
+  // not be called post-finalize. The invoking method should pass its name so
+  // that the error message can include that detail.
+  void ThrowIfFinalized(const char* source_method) const;
+
+  // Helper method for throwing an exception within public methods that should
+  // not be called pre-finalize. The invoking method should pass its name so
+  // that the error message can include that detail.
+  void ThrowIfNotFinalized(const char* source_method) const;
+
  private:
   // Make MultibodyTree templated on every other scalar type a friend of
   // MultibodyTree<T> so that CloneToScalar<ToAnyOtherScalar>() can access
@@ -2713,32 +2730,19 @@ class MultibodyTree {
       const systems::Context<T>& context,
       const std::vector<BodyIndex>& body_indexes) const;
 
-  // Helper method to access the mobilizer of a free body.
-  // If `body` is a free body in the model, this method will return the
-  // QuaternionFloatingMobilizer for the body. If the body is not free but it
-  // is connected to the model by a Joint, this method will throw a
-  // std::exception.
-  // The returned mobilizer provides a user-facing API to set the state for
-  // this body including both pose and spatial velocity.
-  // @note In general setting the pose and/or velocity of a body in the model
-  // would involve a complex inverse kinematics problem. It is possible however
-  // to do this directly for free bodies and the QuaternionFloatingMobilizer
-  // user-facing API allows us to do exactly that.
-  // @throws std::exception if `body` is not free in the model.
+  // Helper method to access the mobilizer of a free body (that is, a
+  // body connected to its parent by a 6-dof joint). If `body` is free, this
+  // method will return the Mobilizer for the body, which will
+  // be one of the 6-dof mobilizers. Otherwise this method will throw
+  // std::exception. The Mobilizer API supports the ability to set the
+  // mobilizer's state including both pose and spatial velocity; 6-dof
+  // mobilizers have the unique property of being able to represent _any_ pose
+  // and spatial velocity.
+  // @throws std::exception if `body` is not a free body.
   // @throws std::exception if called pre-finalize.
-  // @throws std::exception if called on the world body.
-  const QuaternionFloatingMobilizer<T>& GetFreeBodyMobilizerOrThrow(
+  // @pre `body` is not World
+  const Mobilizer<T>& GetFreeBodyMobilizerOrThrow(
       const RigidBody<T>& body) const;
-
-  // Helper method for throwing an exception within public methods that should
-  // not be called post-finalize. The invoking method should pass its name so
-  // that the error message can include that detail.
-  void ThrowIfFinalized(const char* source_method) const;
-
-  // Helper method for throwing an exception within public methods that should
-  // not be called pre-finalize. The invoking method should pass its name so
-  // that the error message can include that detail.
-  void ThrowIfNotFinalized(const char* source_method) const;
 
   // Helper for ThrowDefaultMassInertiaError(): takes a terminal Link or a set
   // of Links forming a terminal composite, and complains if its default

--- a/multibody/tree/multibody_tree_topology.cc
+++ b/multibody/tree/multibody_tree_topology.cc
@@ -48,7 +48,7 @@ bool RigidBodyTopology::operator==(const RigidBodyTopology& other) const {
   if (body_frame != other.body_frame) return false;
   if (level != other.level) return false;
   if (mobod_index != other.mobod_index) return false;
-  if (is_floating != other.is_floating) return false;
+  if (is_floating_base != other.is_floating_base) return false;
   if (has_quaternion_dofs != other.has_quaternion_dofs) return false;
   if (floating_positions_start != other.floating_positions_start) return false;
   if (floating_velocities_start_in_v != other.floating_velocities_start_in_v)
@@ -308,7 +308,7 @@ void MultibodyTreeTopology::Finalize(const LinkJointGraph& graph) {
   // Update position/velocity indexes for free rigid bodies so that they are
   // easily accessible.
   for (RigidBodyTopology& rigid_body : rigid_bodies_) {
-    if (rigid_body.is_floating) {
+    if (rigid_body.is_floating_base) {
       DRAKE_DEMAND(rigid_body.inboard_mobilizer.is_valid());
       const MobilizerTopology& mobilizer =
           get_mobilizer(rigid_body.inboard_mobilizer);

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -85,8 +85,9 @@ struct RigidBodyTopology {
   // SpanningForest.
   MobodIndex mobod_index;
 
-  // `true` if this topology corresponds to a floating RigidBody.
-  bool is_floating{false};
+  // `true` if this topology corresponds to a floating base RigidBody, meaning
+  // it has a 6 dof mobilizer connecting it to World.
+  bool is_floating_base{false};
 
   // `true` if this topology corresponds to a floating RigidBody with rotations
   // parametrized by a quaternion.

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -123,8 +123,6 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   // Computes the across-mobilizer transform `X_FM(q)` between the inboard
   // frame F and the outboard frame M as a function of the translation distance
   // along this mobilizer's axis (see translation_axis().)
-  // The generalized coordinate q for `this` mobilizer (the translation
-  // distance) is read from in `context`.
   math::RigidTransform<T> calc_X_FM(const T* q) const {
     return math::RigidTransform<T>(q[0] * translation_axis());
   }

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
+#include <utility>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
@@ -64,8 +66,6 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
       const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
-
-  bool is_floating() const final { return true; }
 
   bool has_quaternion_dofs() const final { return true; }
 
@@ -265,12 +265,26 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
   void MapQDotToVelocity(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;
+
+  // This mobilizer can't use the default implementaion because it is
+  // required to preserve bit-identical state.
+  std::pair<Eigen::Quaternion<T>, Vector3<T>> GetPosePair(
+      const systems::Context<T>& context) const final;
   // @}
 
  protected:
   // Sets `state` to store a configuration in which M coincides with F (i.e.
   // q_FM is the identity quaternion).
   QVector<double> get_zero_position() const final;
+
+  std::optional<QVector<T>> DoPoseToPositions(
+      const Eigen::Quaternion<T> orientation,
+      const Vector3<T>& translation) const final;
+
+  std::optional<VVector<T>> DoSpatialVelocityToVelocities(
+      const SpatialVelocity<T>& velocity) const final {
+    return velocity.get_coeffs();
+  }
 
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -293,7 +293,7 @@ class RigidBody : public MultibodyElement<T> {
   /// @see MultibodyPlant::Finalize()
   bool is_floating() const {
     ThrowIfNotFinalized(__func__);
-    return topology_.is_floating;
+    return topology_.is_floating_base;
   }
 
   /// (Advanced) If `true`, this body's generalized position coordinates q

--- a/multibody/tree/rpy_floating_mobilizer.cc
+++ b/multibody/tree/rpy_floating_mobilizer.cc
@@ -203,6 +203,17 @@ void RpyFloatingMobilizer<T>::ProjectSpatialForce(
 }
 
 template <typename T>
+auto RpyFloatingMobilizer<T>::DoPoseToPositions(
+    const Eigen::Quaternion<T> orientation, const Vector3<T>& translation) const
+    -> std::optional<QVector<T>> {
+  const math::RollPitchYaw rpy(orientation);
+  QVector<T> q;
+  q.template head<3>() = rpy.vector();
+  q.template tail<3>() = translation;
+  return q;
+}
+
+template <typename T>
 void RpyFloatingMobilizer<T>::DoCalcNMatrix(const systems::Context<T>& context,
                                             EigenPtr<MatrixX<T>> N) const {
   using std::abs;

--- a/multibody/tree/rpy_floating_mobilizer.h
+++ b/multibody/tree/rpy_floating_mobilizer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "drake/common/default_scalars.h"
@@ -86,8 +87,6 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
       const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
-
-  bool is_floating() const final { return true; }
 
   bool has_quaternion_dofs() const final { return false; }
 
@@ -324,6 +323,15 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
                          EigenPtr<VectorX<T>> v) const final;
 
  protected:
+  std::optional<QVector<T>> DoPoseToPositions(
+      const Eigen::Quaternion<T> orientation,
+      const Vector3<T>& translation) const final;
+
+  std::optional<VVector<T>> DoSpatialVelocityToVelocities(
+      const SpatialVelocity<T>& velocity) const final {
+    return velocity.get_coeffs();
+  }
+
   // Implements Mobilizer's NVI, see Mobilizer::CalcNMatrix() for details.
   // @warning The mapping from angular velocity to Euler angle's rates is
   // singular for angle θ₁ such that θ₁ = π/2 + kπ, ∀ k ∈ ℤ. To avoid

--- a/multibody/tree/test/mobilizer_tester.h
+++ b/multibody/tree/test/mobilizer_tester.h
@@ -59,24 +59,6 @@ class MobilizerTester : public ::testing::Test {
     return *typed_mobilizer;
   }
 
-  // TODO(sherm1) Remove this as soon as space_xyz_floating_mobilizer_test.cc
-  //  is converted to use the corresponding Joint (when that exists).
-  template <template <typename> class MobilizerType>
-  const MobilizerType<double>& AddMobilizerAndFinalize(
-      std::unique_ptr<MobilizerType<double>> mobilizer) {
-    // Add a mobilizer between the world and the body:
-    const MobilizerType<double>& mobilizer_ref =
-        owned_tree_->AddMobilizer(std::move(mobilizer));
-
-    // We are done adding modeling elements. Transfer tree to system and get
-    // a Context.
-    system_ =
-        std::make_unique<MultibodyTreeSystem<double>>(std::move(owned_tree_));
-    context_ = system_->CreateDefaultContext();
-
-    return mobilizer_ref;
-  }
-
   const MultibodyTree<double>& tree() const { return *tree_; }
   MultibodyTree<double>& mutable_tree() { return *tree_; }
 


### PR DESCRIPTION
### What's here

Removes MbP's assumption that floating bodies use quaternion floating joints, allowing rpy floating joints instead. The setting can be global or model instance-specific. Weld joints may also be selected (the new topology code already supports these three types). The following MultibodyPlant method is added to convey the desired base-body joint type pre-finalize:
```c++
MultibodyPlant::SetBaseBodyJointType(BaseBodyJointType, optional<ModelInstance>)
```
where BaseBodyJointType is an enum selecting quaternion/rpy floating, or weld (fixed) joint.

The existing `SetFreeBodyRandomRotationDistribution()` methods remain restricted to free bodies that use a QuaternionFloatingJoint because the rotation is expressed as a quaternion. I added
```c++
MultibodyPlant::SetFreeBodyRandomAnglesDistribution(body, RollPitchYaw angles)
```
that works with free bodies that use an RpyFloatingJoint. `SetFreeBodyRandomTranslationDistribution()` now works with either floating joint.

Rather than creating a new "floating" abstraction layer, I have chosen instead to permit more operations on the Joint (or internally, Mobilizer) base class that can deal with pose and velocity (already nice abstractions!) without having to know the underlying joint type. This PR adds several public methods to the base `Joint` class that permit setting/getting joint pose without knowing what kind of joint is there. There were a few existing `Joint::` methods which are now extended to provide a complete set of default & context-taking methods. "Advanced" methods for quaternion/translation pairs are provided for consistency with the existing promise that pre-finalize setting of floating bodies results in the bit-identical pose post-finalize (only when using quaternion floating joints). _Italics_ indicates a pre-existing method:

|              Joint:: Setter                        |                  Joint:: Getter                        |
| -------------------------------------- | ----------------------------------------- |
| _set_default_positions(q)_                |  q = _default_positions()_                     |
| _SetDefaultPose(X_FM)_                   | _X_FM = GetDefaultPose()_                  |
| _SetDefaultPosePair(q_FM, p_FM)_  | _q_FM, p_FM = GetDefaultPosePair()_  |
|                                                          |                                                              |
| SetPositions(&context, q)                 |  q = GetPositions(context )                   |
| SetVelocities(&context, v)                 | v = GetVelocities(context)                    |
| SetPose(&context, X_FM)                  | X_FM = GetPose(context)                     |
| SetSpatialVelocity(&context, V_FM)  | V_FM = GetSpatialVelocity(context)     |
| SetPosePair(&context, q_FM, p_FM) | q_FM, p_FM = GetPosePair(context)     |

APIs SetPose(), SetPosePair(), and SetSpatialVelocity() are currently implemented only for floating joints, which can represent any value of their arguments. (There is good reason to implement them for other joints also, but that is only a TODO here.)
The Get methods work for all joint types.

Multibody code that was previously tied to QuaternionFloatingJoints is rewritten here in terms of the generic setters and getters so that it is floating-joint agnostic.

### What's not here
Access to the new base joint controls from parsing, configuration, or Python; only the C++ API is included.
Subsequent PRs should use the new API to provide higher-level access to this control.

### Unit testing
Tests are in multibody_plant_test.cc unless otherwise stated:
- Base body joint type selection API is tested for global & model instance settings for quaternion, rpy, and weld.
- The new random angles API gets a test that parallels the existing random rotation API test.
- The new Joint:: APIs are all tested for floating and one non-floating case.
- A test checks for one non-floating joint type that a reasonable "not implemented" error is issued for the unimplemented APIs. 
- The mobilizer abstraction is extended a little to support the new PosePair and SpatialVelocity APIs. Only the floating joints support those. Low-level mobilizer tests are added for the implemented cases (in quaternion/rpy_floating_joint_test.cc).

I'm not testing the new API x all joint types because (except for the floating cases) the implementation is the same for all of them and just uses pre-existing, well tested code.

Addresses #20943

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21973)
<!-- Reviewable:end -->
