### PR TITLE
[trajopt] Add missing bounds checks

### DIFF
--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -246,8 +246,8 @@ Subgraph::Subgraph(
     maybe_edge_offsets->reserve(edges_between_regions.size());
     for (const auto& [i, j] : edges_between_regions) {
       maybe_edge_offsets->push_back(ComputeOffsetContinuousRevoluteJoints(
-          num_positions(), continuous_revolute_joints(), continuous_bboxes[i],
-          continuous_bboxes[j]));
+          num_positions(), continuous_revolute_joints(),
+          continuous_bboxes.at(i), continuous_bboxes.at(j)));
     }
     edge_offsets = &(maybe_edge_offsets.value());
   }


### PR DESCRIPTION
Hotfix for #21946.

The prior code on master relied on `vector::at()` to validate its input indices, but #21946 changed that to `vector::operator[]`.  Here we just switch it back to `vector::at()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21980)
<!-- Reviewable:end -->
