### PR TITLE
Implements fail fast in DoPointInSet for VPolytopes

### DIFF
--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -167,6 +167,19 @@ GTEST_TEST(VPolytopeTest, UnitBoxTest) {
   EXPECT_FALSE(V.PointInSet(out_W, kTol));
 }
 
+// Tests correct handling of the edge case for the "fail fast heuristic" in
+// PointInSet where the query point is exactly the mean of the vertices. In this
+// case, the heuristic generates a degenerate hyperplane but does not falsely
+// claim a that the mean of the vertices lies outside of the set.
+GTEST_TEST(VPolytopeTest, PointInSetFailFastEdgeCase) {
+  VPolytope V = VPolytope::MakeUnitBox(3);
+  Eigen::VectorXd vertex_mean = V.vertices().rowwise().mean();
+  const double kTol = 1e-11;
+  EXPECT_TRUE(V.PointInSet(vertex_mean, kTol));
+  const double kZeroTol = 0;
+  EXPECT_TRUE(V.PointInSet(vertex_mean, kZeroTol));
+}
+
 GTEST_TEST(VPolytopeTest, ArbitraryBoxTest) {
   const RigidTransformd X_WG(math::RollPitchYawd(.1, .2, 3),
                              Vector3d(-4.0, -5.0, -6.0));

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -176,8 +176,6 @@ GTEST_TEST(VPolytopeTest, PointInSetFailFastEdgeCase) {
   Eigen::VectorXd vertex_mean = V.vertices().rowwise().mean();
   const double kTol = 1e-11;
   EXPECT_TRUE(V.PointInSet(vertex_mean, kTol));
-  const double kZeroTol = 0;
-  EXPECT_TRUE(V.PointInSet(vertex_mean, kZeroTol));
 }
 
 GTEST_TEST(VPolytopeTest, ArbitraryBoxTest) {

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -499,7 +499,10 @@ bool VPolytope::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
 
   // Attempt to "fail fast": Check if a hyperplane through x, with a normal
   // vector colinear to (x - mean(vertices)), separates the point from the
-  // VPolytope avoid the point containment LP.
+  // VPolytope avoid the point containment LP. This is a heuristic, sufficient
+  // condition which can falsify that the point is in the set which
+  // works better as the point in question gets farther away.
+
   Eigen::VectorXd vertex_mean = vertices_.rowwise().mean();
   Eigen::VectorXd a = (x - vertex_mean).normalized();
   double b = a.dot(x);

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -508,7 +508,10 @@ bool VPolytope::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
   double b = a.dot(x);
   Eigen::VectorXd vals = a.transpose() * vertices_;
   vals = vals.array() - b;
-  if ((vals.array() < -tol).all()) {
+
+  // Explicitly require tolerance to be bigger than zero for the check to be
+  // valid.
+  if ((vals.array() < -tol).all() && tol > 0) {
     return false;
   }
 

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -511,7 +511,7 @@ bool VPolytope::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
 
   // Only allow early return if query point x is sufficiently far away from the
   // vertex mean.
-  if ((vals.array() < -tol).all() && (x - vertex_mean).norm() > tol) {
+  if ((vals.array() < -tol).all() && (x - vertex_mean).norm() > 1e-13) {
     return false;
   }
 

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -498,12 +498,12 @@ bool VPolytope::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
   }
 
   // Attempt to "fail fast": Check if a hyperplane through x, with a normal
-  // vector colinear to (x - vertex_mean), separates the point from the
+  // vector colinear to (x - mean(vertices)), separates the point from the
   // VPolytope avoid the point containment LP.
   Eigen::VectorXd vertex_mean = vertices_.rowwise().mean();
   Eigen::VectorXd a = (x - vertex_mean).normalized();
   double b = a.dot(x);
-  Eigen::VectorXd vals = a.transpose() * vertices_;  // -  b;
+  Eigen::VectorXd vals = a.transpose() * vertices_;
   vals = vals.array() - b;
   if ((vals.array() < -tol).all()) {
     return false;

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -497,10 +497,10 @@ bool VPolytope::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
     return false;
   }
 
-  // Attempt to "fail fast": Check if a hyperplane through x, with a normal
+  // Attempt to "fail fast": Checks if a hyperplane through x, with a normal
   // vector colinear to (x - mean(vertices)), separates the point from the
-  // VPolytope avoid the point containment LP. This is a heuristic, sufficient
-  // condition which can falsify that the point is in the set which
+  // VPolytope avoid solving the point containment LP. This is a heuristic,
+  // sufficient condition which can falsify that the point is in the set which
   // works better as the point in question gets farther away.
 
   Eigen::VectorXd vertex_mean = vertices_.rowwise().mean();

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -509,9 +509,9 @@ bool VPolytope::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
   Eigen::VectorXd vals = a.transpose() * vertices_;
   vals = vals.array() - b;
 
-  // Explicitly require tolerance to be bigger than zero for the check to be
-  // valid.
-  if ((vals.array() < -tol).all() && tol > 0) {
+  // Only allow early return if query point x is sufficiently far away from the
+  // vertex mean.
+  if ((vals.array() < -tol).all() && (x - vertex_mean).norm() > tol) {
     return false;
   }
 


### PR DESCRIPTION
Implements a "fail fast check" that attempts to guess a separating hyperplane to avoid having to solve the point containment LP for PointInSet for VPolytopes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21988)
<!-- Reviewable:end -->
