### PR TITLE
[workspace] Upgrade libtiff_internal to latest release v4.7.0

### DIFF
--- a/tools/workspace/libtiff_internal/package.BUILD.bazel
+++ b/tools/workspace/libtiff_internal/package.BUILD.bazel
@@ -96,6 +96,13 @@ cmake_configure_files(
         "CHUNKY_STRIP_READ_SUPPORT",
         "JPEG_DUAL_MODE_8_12",
         "JPEG_SUPPORT",
+        # We don't build the tiffgt viewer.
+        "HAVE_GLUT_GLUT_H",
+        "HAVE_GL_GLUT_H",
+        "HAVE_GL_GLU_H",
+        "HAVE_GL_GL_H",
+        "HAVE_OPENGL_GLU_H",
+        "HAVE_OPENGL_GL_H",
         # Match the upstream defaults.
         "DEFER_STRILE_LOAD",
         # Dead code (unused).

--- a/tools/workspace/libtiff_internal/repository.bzl
+++ b/tools/workspace/libtiff_internal/repository.bzl
@@ -12,8 +12,8 @@ def libtiff_internal_repository(
         The package.BUILD.bazel file hard-codes the version number and release
         date; be sure to update those to match the new commit.
         """,
-        commit = "v4.6.0",
-        sha256 = "c760de148e0b2ceec115dd5afa660e91617aac4a94da997aa8a8fc2a58f1d378",  # noqa
+        commit = "v4.7.0",
+        sha256 = "8f568a0dfac2e514074b04d7368c22e8afc1009af29780762a2536fd4d111e16",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Toward #21979.

When merging, we should squash this (nixing the irrelevant subject line of the second commit).  The release note we want is just the version bump.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/21994)
<!-- Reviewable:end -->
