### PR TITLE
[multibody] Move mass matrix computation to body_node_impl for speed

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -86,6 +86,7 @@ drake_cc_library(
         "ball_rpy_joint.cc",
         "body_node.cc",
         "body_node_impl.cc",
+        "body_node_impl_mass_matrix.cc",
         "door_hinge.cc",
         "element_collection.cc",
         "fixed_offset_frame.cc",

--- a/multibody/tree/body_node.cc
+++ b/multibody/tree/body_node.cc
@@ -60,6 +60,76 @@ void BodyNode<T>::CalcAcrossMobilizerBodyPoses_BaseToTip(
 }
 
 template <typename T>
+void BodyNode<T>::CalcCompositeBodyInertia_TipToBase(
+    const PositionKinematicsCache<T>& pc,
+    const std::vector<SpatialInertia<T>>& M_B_W_all,
+    std::vector<SpatialInertia<T>>* Mc_B_W_all) const {
+  DRAKE_ASSERT(mobod_index() != world_mobod_index());
+  DRAKE_ASSERT(Mc_B_W_all != nullptr);
+
+  // This mobod's spatial inertia (given).
+  const SpatialInertia<T>& M_B_W = M_B_W_all[mobod_index()];
+  // This mobod's composite body inertia (to be calculated).
+  SpatialInertia<T>& Mc_BBo_W = (*Mc_B_W_all)[mobod_index()];
+
+  // Composite body inertia for this node B, about its frame's origin Bo, and
+  // expressed in the world frame W. Add composite body inertia contributions
+  // from all children (already calculated).
+  Mc_BBo_W = M_B_W;
+  for (const BodyNode<T>* child : child_nodes()) {
+    const MobodIndex child_node_index = child->mobod_index();
+    // Composite body inertia for child body C, about Co, expressed in W.
+    const SpatialInertia<T>& Mc_CCo_W = (*Mc_B_W_all)[child_node_index];
+    // Shift to Bo and add it to the composite body inertia of B.
+    const Vector3<T>& p_BoCo_W = pc.get_p_PoBo_W(child_node_index);
+    Mc_BBo_W += Mc_CCo_W.Shift(-p_BoCo_W);  // i.e., by p_CoBo
+  }
+}
+
+// This method computes the total force Ftot_BBo on body B that must be
+// applied for it to incur in a spatial acceleration A_WB. Mathematically:
+//   Ftot_BBo = M_B_W * A_WB + b_Bo
+// where b_Bo contains the velocity dependent gyroscopic terms (see Eq. 2.26,
+// p. 27, in A. Jain's book). The above balance is performed at the origin
+// Bo of the body frame B, which does not necessarily need to coincide with
+// the body center of mass.
+// Notes:
+//   1. Ftot_BBo = b_Bo when A_WB = 0.
+//   2. b_Bo = 0 when w_WB = 0.
+//   3. b_Bo.translational() = 0 when Bo = Bcm (p_BoBcm = 0).
+//      When Fb_Bo_W_cache is nullptr velocities are considered to be zero.
+//      Therefore, from (2), the bias term is assumed to be zero and is not
+//      computed.
+template <typename T>
+void BodyNode<T>::CalcBodySpatialForceGivenItsSpatialAcceleration(
+    const std::vector<SpatialInertia<T>>& M_B_W_cache,
+    const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
+    const SpatialAcceleration<T>& A_WB, SpatialForce<T>* Ftot_BBo_W_ptr) const {
+  DRAKE_DEMAND(Ftot_BBo_W_ptr != nullptr);
+
+  // Output spatial force applied on mobilized body B, at Bo, measured in W.
+  SpatialForce<T>& Ftot_BBo_W = *Ftot_BBo_W_ptr;
+
+  // RigidBody for this node.
+  const RigidBody<T>& body_B = body();
+
+  // Mobilized body B spatial inertia about Bo expressed in world W.
+  const SpatialInertia<T>& M_B_W = M_B_W_cache[body_B.mobod_index()];
+
+  // Equations of motion for a rigid body written at a generic point Bo not
+  // necessarily coincident with the body's center of mass. This corresponds
+  // to Eq. 2.26 (p. 27) in A. Jain's book.
+  Ftot_BBo_W = M_B_W * A_WB;
+
+  // If velocities are zero, then Fb_Bo_W is zero and does not contribute.
+  if (Fb_Bo_W_cache != nullptr) {
+    // Dynamic bias for body B.
+    const SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_cache)[body_B.mobod_index()];
+    Ftot_BBo_W += Fb_Bo_W;
+  }
+}
+
+template <typename T>
 void BodyNode<T>::CalcArticulatedBodyHingeInertiaMatrixFactorization(
     const MatrixUpTo6<T>& D_B,
     math::LinearSolver<Eigen::LLT, MatrixUpTo6<T>>* llt_D_B) const {

--- a/multibody/tree/body_node_impl_mass_matrix.cc
+++ b/multibody/tree/body_node_impl_mass_matrix.cc
@@ -1,0 +1,160 @@
+/* clang-format off */
+// NOLINTNEXTLINE(build/include)
+#include "drake/multibody/tree/body_node_impl.h"
+/* clang-format on */
+
+#include "drake/common/default_scalars.h"
+#include "drake/multibody/tree/planar_mobilizer.h"
+#include "drake/multibody/tree/prismatic_mobilizer.h"
+#include "drake/multibody/tree/quaternion_floating_mobilizer.h"
+#include "drake/multibody/tree/revolute_mobilizer.h"
+#include "drake/multibody/tree/rpy_ball_mobilizer.h"
+#include "drake/multibody/tree/rpy_floating_mobilizer.h"
+#include "drake/multibody/tree/screw_mobilizer.h"
+#include "drake/multibody/tree/universal_mobilizer.h"
+#include "drake/multibody/tree/weld_mobilizer.h"
+
+/* This is a continuation of body_node_impl.cc, split in order to balance
+compilation times. The many template instantiations take a long time to
+compile. */
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T, template <typename> class ConcreteMobilizer>
+void BodyNodeImpl<T, ConcreteMobilizer>::CalcMassMatrixContribution_TipToBase(
+    const PositionKinematicsCache<T>& pc,
+    const std::vector<SpatialInertia<T>>& Mc_B_W_cache,
+    const std::vector<Vector6<T>>& H_PB_W_cache, EigenPtr<MatrixX<T>> M) const {
+  // Welds only contribute to composite mass properties. Their effect on the
+  // mass matrix gets included when we get to the composite's non-weld inboard
+  // mobilizer.
+  if constexpr (kNv != 0) {
+    // This node's 6x6 composite body inertia.
+    const SpatialInertia<T>& Mc_C_W = Mc_B_W_cache[mobod_index()];
+
+    // Across-mobilizer 6 x cnv hinge matrix, from C's parent Cp to C.
+    const auto H_CpC_W = get_H(H_PB_W_cache);  // 6 x kNv fixed size Map.
+
+    // The composite body algorithm considers the system at rest, when
+    // generalized velocities are zero.
+    // Now if we consider this node's generalized accelerations as the matrix
+    // vm_dot = Iₘ, the identity matrix in ℝᵐˣᵐ, the spatial acceleration A_WC
+    // is in ℝ⁶ˣᵐ. That is, we are considering each case in which all
+    // generalized accelerations are zero but the m-th generalized
+    // acceleration for this node equals one.
+    // This node's spatial acceleration can be written as:
+    //   A_WC = Φᵀ(p_CpC) * A_WCp + Ac_WC + Ab_CpC_W + H_CpC_W * vm_dot
+    // where A_WCp is the spatial acceleration of the parent node's body Cp,
+    // Ac_WC include the centrifugal and Coriolis terms, and Ab_CpC_W is the
+    // spatial acceleration bias of the hinge Jacobian matrix H_CpC_W.
+    // Now, since all generalized accelerations but vm_dot are zero, then
+    // A_WCp is zero.  Since the system is at rest, Ac_WC and Ab_CpC_W are
+    // zero.
+    // Therefore, for vm_dot = Iₘ, we have that A_WC = H_CpC_W.
+    const auto& A_WC = H_CpC_W;  // 6 x cnv, fixed-size Map.
+
+    // If we consider the closed system composed of the composite body held by
+    // its mobilizer, the Newton-Euler equations state:
+    //   Fm_CCo_W = Mc_C_W * A_WC + Fb_C_W
+    // where Fm_CCo_W is the spatial force at this node's mobilizer.
+    // Since the system is at rest, we have Fb_C_W = 0 and thus:
+    const Eigen::Matrix<T, 6, kNv> Fm_CCo_W = Mc_C_W * A_WC;  // 6 x cnv.
+
+    const int composite_start_in_v = mobilizer().velocity_start_in_v();
+
+    // Diagonal block corresponding to current node (mobod_index).
+    M->template block<kNv, kNv>(composite_start_in_v, composite_start_in_v) +=
+        H_CpC_W.transpose() * Fm_CCo_W;
+
+    // We recurse the tree inwards from C all the way to the root. We define
+    // the frames:
+    //  - B:  the frame for the current node, body_node.
+    //  - Bc: B's child node frame, child_node.
+    //  - P:  B's parent node frame.
+    const BodyNode<T>* child_node = this;  // Child starts at frame C.
+    const BodyNode<T>* body_node = this->parent_body_node();  // Inboard body.
+    Eigen::Matrix<T, 6, kNv> Fm_CBo_W = Fm_CCo_W;             // 6 x cnv
+
+    while (body_node->mobod_index() != world_mobod_index()) {
+      const Vector3<T>& p_BoBc_W = pc.get_p_PoBo_W(child_node->mobod_index());
+      // In place rigid shift of the spatial force in each column of
+      // Fm_CBo_W, from Bc to Bo. Before this computation, Fm_CBo_W actually
+      // stores Fm_CBc_W from the previous recursion. At the end of this
+      // computation, Fm_CBo_W stores the spatial force on composite body C,
+      // shifted to Bo, and expressed in the world W. That is, we are doing
+      // Fm_CBo_W = Fm_CBc_W.Shift(p_BcB_W).
+
+      // This is SpatialForce<T>::ShiftInPlace(&Fm_CBo_W, -p_BoBc_W) but
+      // done with fixed sizes (no loop if kNv==1).
+      // TODO(sherm1) Consider moving this to a templatized ShiftInPlace
+      //  API in SpatialForce (and other spatial vector classes?).
+      for (int col = 0; col < kNv; ++col) {
+        // Ugly Eigen intermediate types; don't look!
+        auto torque = Fm_CBo_W.template block<3, 1>(0, col);
+        const auto force = Fm_CBo_W.template block<3, 1>(3, col);
+        torque += p_BoBc_W.cross(force);  // + because we're negating p_BoBc
+      }
+
+      CalcMassMatrixOffDiagonalDispatcher<T, kNv>::Dispatch(
+          *body_node, composite_start_in_v, H_PB_W_cache, Fm_CBo_W, M);
+
+      child_node = body_node;                      // Update child node Bc.
+      body_node = child_node->parent_body_node();  // Update node B.
+    }
+  }
+}
+
+// This is the inner loop of the CalcMassMatrix() algorithm. Rnv is the
+// size of the outer-loop body node R's mobilizer, kNv is the size of the
+// current body B's ConcreteMobilizer encountered on R's inboard sweep.
+#define DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(Rnv)                             \
+  template <typename T, template <typename> class ConcreteMobilizer>           \
+  void                                                                         \
+      BodyNodeImpl<T, ConcreteMobilizer>::CalcMassMatrixOffDiagonalBlock##Rnv( \
+          int R_start_in_v, const std::vector<Vector6<T>>& H_PB_W_cache,       \
+          const Eigen::Matrix<T, 6, Rnv>& Fm_CBo_W, EigenPtr<MatrixX<T>> M)    \
+          const {                                                              \
+    if constexpr (kNv != 0) {                                                  \
+      const auto H_PB_W = get_H(H_PB_W_cache); /* 6 x kNv fixed-size Map */    \
+      const Eigen::Matrix<T, kNv, Rnv> HtFm = H_PB_W.transpose() * Fm_CBo_W;   \
+      const int body_start_in_v = mobilizer().velocity_start_in_v();           \
+      /* Update the appropriate block and its symmetric partner. */            \
+      auto block = M->template block<kNv, Rnv>(body_start_in_v, R_start_in_v); \
+      block += HtFm;                                                           \
+      M->template block<Rnv, kNv>(R_start_in_v, body_start_in_v) =             \
+          block.transpose();                                                   \
+    }                                                                          \
+  }
+
+DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(1)
+DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(2)
+DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(3)
+DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(4)
+DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(5)
+DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(6)
+
+#undef DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK
+
+// Macro used to explicitly instantiate implementations for every mobilizer.
+#define EXPLICITLY_INSTANTIATE_IMPLS(T)                        \
+  template class BodyNodeImpl<T, PlanarMobilizer>;             \
+  template class BodyNodeImpl<T, PrismaticMobilizer>;          \
+  template class BodyNodeImpl<T, QuaternionFloatingMobilizer>; \
+  template class BodyNodeImpl<T, RevoluteMobilizer>;           \
+  template class BodyNodeImpl<T, RpyBallMobilizer>;            \
+  template class BodyNodeImpl<T, RpyFloatingMobilizer>;        \
+  template class BodyNodeImpl<T, ScrewMobilizer>;              \
+  template class BodyNodeImpl<T, UniversalMobilizer>;          \
+  template class BodyNodeImpl<T, WeldMobilizer>
+
+// Explicitly instantiates on the supported scalar types.
+// These should be kept in sync with the list in default_scalars.h.
+EXPLICITLY_INSTANTIATE_IMPLS(double);
+EXPLICITLY_INSTANTIATE_IMPLS(AutoDiffXd);
+EXPLICITLY_INSTANTIATE_IMPLS(symbolic::Expression);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/body_node_world.h
+++ b/multibody/tree/body_node_world.h
@@ -44,6 +44,28 @@ class BodyNodeWorld final : public BodyNode<T> {
     DRAKE_UNREACHABLE();
   }
 
+  void CalcMassMatrixContribution_TipToBase(
+      const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
+      const std::vector<Vector6<T>>&, EigenPtr<MatrixX<T>>) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+#define DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(Rnv)                                \
+  void CalcMassMatrixOffDiagonalBlock##Rnv(                                 \
+      int, const std::vector<Vector6<T>>&, const Eigen::Matrix<T, 6, Rnv>&, \
+      EigenPtr<MatrixX<T>>) const final {                                   \
+    DRAKE_UNREACHABLE();                                                    \
+  }
+
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(1)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(2)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(3)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(4)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(5)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(6)
+
+#undef DEFINE_DUMMY_OFF_DIAGONAL_BLOCK
+
   void CalcSpatialAcceleration_BaseToTip(
       const systems::Context<T>&, const FrameBodyPoseCache<T>&,
       const PositionKinematicsCache<T>&, const VelocityKinematicsCache<T>*,
@@ -87,10 +109,9 @@ class BodyNodeWorld final : public BodyNode<T> {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcCompositeBodyInertia_TipToBase(const SpatialInertia<T>&,
-                                          const PositionKinematicsCache<T>&,
-                                          const std::vector<SpatialInertia<T>>&,
-                                          SpatialInertia<T>*) const final {
+  void CalcCompositeBodyInertia_TipToBase(
+      const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
+      std::vector<SpatialInertia<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -86,6 +86,28 @@ class DummyBodyNode : public BodyNode<double> {
     DRAKE_UNREACHABLE();
   }
 
+  void CalcMassMatrixContribution_TipToBase(
+      const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
+      const std::vector<Vector6<T>>&, EigenPtr<MatrixX<T>>) const final {
+    DRAKE_UNREACHABLE();
+  }
+
+#define DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(Rnv)                                \
+  void CalcMassMatrixOffDiagonalBlock##Rnv(                                 \
+      int, const std::vector<Vector6<T>>&, const Eigen::Matrix<T, 6, Rnv>&, \
+      EigenPtr<MatrixX<T>>) const final {                                   \
+    DRAKE_UNREACHABLE();                                                    \
+  }
+
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(1)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(2)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(3)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(4)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(5)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(6)
+
+#undef DEFINE_DUMMY_OFF_DIAGONAL_BLOCK
+
   void CalcSpatialAcceleration_BaseToTip(
       const systems::Context<T>&, const FrameBodyPoseCache<T>&,
       const PositionKinematicsCache<T>&, const VelocityKinematicsCache<T>*,
@@ -129,10 +151,9 @@ class DummyBodyNode : public BodyNode<double> {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcCompositeBodyInertia_TipToBase(const SpatialInertia<T>&,
-                                          const PositionKinematicsCache<T>&,
-                                          const std::vector<SpatialInertia<T>>&,
-                                          SpatialInertia<T>*) const final {
+  void CalcCompositeBodyInertia_TipToBase(
+      const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
+      std::vector<SpatialInertia<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 


### PR DESCRIPTION
Moves CalcMassMatrix() from high-level multibody tree code to low level templatized body node code where it can use its mobilizer-specific knowledge to work with fixed-size matrices.

This is an O(n²) algorithm so requires an awkward double-dispatch so that we always know both dimensions of the current mass matrix block being computed.

This provides a modest performance improvement to CalcMassMatrix(): 10% with gcc 11.4.0, 24% with clang 14.0.0 and sets us up for more gains with internal changes.

Minor:
- added body_node_impl_mass_matrix.cc with mass matrix inertia functions defined there to keep compile times balanced
- made some minor changes to the composite body inertia function
- moved composite body inertia and an unrelated function back from the templatized class to the base class since they weren't mobilizer-dependent (generates less code this way)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22003)
<!-- Reviewable:end -->
