### PR TITLE
Added method to set x(n) in the context for vector-valued ZeroOrderHold

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -588,7 +588,9 @@ PYBIND11_MODULE(primitives, m) {
             doc.ZeroOrderHold.ctor
                 .doc_3args_period_sec_abstract_model_value_offset_sec)
         .def("period", &ZeroOrderHold<T>::period, doc.ZeroOrderHold.period.doc)
-        .def("offset", &ZeroOrderHold<T>::offset, doc.ZeroOrderHold.offset.doc);
+        .def("offset", &ZeroOrderHold<T>::offset, doc.ZeroOrderHold.offset.doc)
+        .def("SetVectorState", &ZeroOrderHold<T>::SetVectorState,
+            doc.ZeroOrderHold.SetVectorState.doc);
 
     DefineTemplateClassWithDefault<TrajectorySource<T>, LeafSystem<T>>(
         m, "TrajectorySource", GetPyParam<T>(), doc.TrajectorySource.doc)

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -152,6 +152,13 @@ TEST_P(ZeroOrderHoldTest, InitialState) {
     value = state_value.value();
   }
   EXPECT_EQ(value_expected, value);
+
+  if (!is_abstract_) {
+    const Eigen::Vector3d updated_value_expected{1.0, 2.0, 3.0};
+    hold_->SetVectorState(context_.get(), updated_value_expected);
+    EXPECT_EQ(updated_value_expected,
+              context_->get_discrete_state(0).CopyToVector());
+  }
 }
 
 // Tests that the output is the state.

--- a/systems/primitives/zero_order_hold.cc
+++ b/systems/primitives/zero_order_hold.cc
@@ -46,6 +46,17 @@ ZeroOrderHold<T>::ZeroOrderHold(const ZeroOrderHold<U>& other)
                                         : nullptr) {}
 
 template <typename T>
+void ZeroOrderHold<T>::SetVectorState(
+    Context<T>* context, const Eigen::Ref<const VectorX<T>>& value) const {
+  DRAKE_ASSERT(!is_abstract());
+  this->ValidateContext(context);
+  BasicVector<T>& state_vector = context->get_mutable_discrete_state_vector();
+  // Asserts that the input value is a column vector of the appropriate size.
+  DRAKE_THROW_UNLESS(value.rows() == state_vector.size());
+  state_vector.SetFromVector(value);
+}
+
+template <typename T>
 void ZeroOrderHold<T>::LatchInputVectorToState(
     const Context<T>& context, DiscreteValues<T>* discrete_state) const {
   DRAKE_ASSERT(!is_abstract());

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -29,6 +29,8 @@ namespace systems {
 /// ```
 /// where xᵢₙᵢₜ = 0 for vector-valued %ZeroOrderHold, and xᵢₙᵢₜ is a given
 /// value for abstract-valued %ZeroOrderHold.
+/// Use SetVectorState() to set xₙ in the context for vector-valued
+/// %ZeroOrderHold.
 ///
 /// See @ref discrete_systems "Discrete Systems" for general information about
 /// discrete systems in Drake, including how they interact with continuous
@@ -78,6 +80,12 @@ class ZeroOrderHold final : public LeafSystem<T> {
 
   /// Reports the first update time of this hold (in seconds).
   double offset() const { return offset_sec_; }
+
+  /// Sets the value of the state by modifying it in the context.
+  /// @p value must be a column vector of the appropriate size. This can only be
+  /// used to initialize a vector-valued state.
+  void SetVectorState(Context<T>* context,
+                      const Eigen::Ref<const VectorX<T>>& value) const;
 
   /// (Advanced) Manually sample the input port and copy ("latch") the value
   /// into the state. This emulates an update event and is mostly useful for


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22005)
<!-- Reviewable:end -->
