### PR TITLE
[trajectories] Add GSG-required out-of-line destructors

### DIFF
--- a/common/trajectories/bezier_curve.cc
+++ b/common/trajectories/bezier_curve.cc
@@ -23,6 +23,9 @@ BezierCurve<T>::BezierCurve(double start_time, double end_time,
 }
 
 template <typename T>
+BezierCurve<T>::~BezierCurve() = default;
+
+template <typename T>
 T BezierCurve<T>::BernsteinBasis(int i, const T& time,
                                  std::optional<int> order) const {
   using std::pow;

--- a/common/trajectories/bezier_curve.h
+++ b/common/trajectories/bezier_curve.h
@@ -41,7 +41,7 @@ class BezierCurve final : public trajectories::Trajectory<T> {
   // TODO(russt): Add support for MatrixX control points, but only if we have a
   // use case for it.
 
-  virtual ~BezierCurve() = default;
+  ~BezierCurve() override;
 
   /** Returns the order of the curve (1 for linear, 2 for quadratic, etc.). */
   int order() const { return control_points_.cols() - 1; }

--- a/common/trajectories/bspline_trajectory.cc
+++ b/common/trajectories/bspline_trajectory.cc
@@ -27,6 +27,9 @@ BsplineTrajectory<T>::BsplineTrajectory(BsplineBasis<T> basis,
 }
 
 template <typename T>
+BsplineTrajectory<T>::~BsplineTrajectory() = default;
+
+template <typename T>
 std::unique_ptr<Trajectory<T>> BsplineTrajectory<T>::Clone() const {
   return std::make_unique<BsplineTrajectory<T>>(*this);
 }

--- a/common/trajectories/bspline_trajectory.h
+++ b/common/trajectories/bspline_trajectory.h
@@ -45,7 +45,7 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
       : BsplineTrajectory(math::BsplineBasis<T>(basis), control_points) {}
 #endif
 
-  virtual ~BsplineTrajectory() = default;
+  ~BsplineTrajectory() override;
 
   // Required methods for trajectories::Trajectory interface.
   std::unique_ptr<trajectories::Trajectory<T>> Clone() const override;

--- a/common/trajectories/composite_trajectory.cc
+++ b/common/trajectories/composite_trajectory.cc
@@ -48,6 +48,9 @@ CompositeTrajectory<T>::CompositeTrajectory(
 }
 
 template <typename T>
+CompositeTrajectory<T>::~CompositeTrajectory() = default;
+
+template <typename T>
 std::unique_ptr<Trajectory<T>> CompositeTrajectory<T>::Clone() const {
   return std::make_unique<CompositeTrajectory<T>>(segments_);
 }

--- a/common/trajectories/composite_trajectory.h
+++ b/common/trajectories/composite_trajectory.h
@@ -31,7 +31,7 @@ class CompositeTrajectory final : public trajectories::PiecewiseTrajectory<T> {
   explicit CompositeTrajectory(
       std::vector<copyable_unique_ptr<Trajectory<T>>> segments);
 
-  virtual ~CompositeTrajectory() = default;
+  ~CompositeTrajectory() final;
 
   std::unique_ptr<trajectories::Trajectory<T>> Clone() const final;
 

--- a/common/trajectories/discrete_time_trajectory.cc
+++ b/common/trajectories/discrete_time_trajectory.cc
@@ -44,6 +44,9 @@ DiscreteTimeTrajectory<T>::DiscreteTimeTrajectory(
 }
 
 template <typename T>
+DiscreteTimeTrajectory<T>::~DiscreteTimeTrajectory() = default;
+
+template <typename T>
 PiecewisePolynomial<T> DiscreteTimeTrajectory<T>::ToZeroOrderHold() const {
   return PiecewisePolynomial<T>::ZeroOrderHold(times_, values_);
 }

--- a/common/trajectories/discrete_time_trajectory.h
+++ b/common/trajectories/discrete_time_trajectory.h
@@ -86,6 +86,8 @@ class DiscreteTimeTrajectory final : public Trajectory<T> {
                          double time_comparison_tolerance =
                              std::numeric_limits<double>::epsilon());
 
+  ~DiscreteTimeTrajectory() override;
+
   /** Converts the discrete-time trajectory using
   PiecewisePolynomial<T>::ZeroOrderHold(). */
   PiecewisePolynomial<T> ToZeroOrderHold() const;

--- a/common/trajectories/exponential_plus_piecewise_polynomial.cc
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.cc
@@ -24,6 +24,10 @@ ExponentialPlusPiecewisePolynomial<T>::ExponentialPlusPiecewisePolynomial(
 }
 
 template <typename T>
+ExponentialPlusPiecewisePolynomial<T>::~ExponentialPlusPiecewisePolynomial() =
+    default;
+
+template <typename T>
 std::unique_ptr<Trajectory<T>> ExponentialPlusPiecewisePolynomial<T>::Clone()
     const {
   return std::make_unique<ExponentialPlusPiecewisePolynomial<T>>(*this);

--- a/common/trajectories/exponential_plus_piecewise_polynomial.h
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.h
@@ -69,7 +69,7 @@ class ExponentialPlusPiecewisePolynomial final : public PiecewiseTrajectory<T> {
   ExponentialPlusPiecewisePolynomial(
       const PiecewisePolynomial<T>& piecewise_polynomial_part);
 
-  ~ExponentialPlusPiecewisePolynomial() override = default;
+  ~ExponentialPlusPiecewisePolynomial() override;
 
   std::unique_ptr<Trajectory<T>> Clone() const override;
 

--- a/common/trajectories/path_parameterized_trajectory.cc
+++ b/common/trajectories/path_parameterized_trajectory.cc
@@ -19,6 +19,9 @@ PathParameterizedTrajectory<T>::PathParameterizedTrajectory(
 }
 
 template <typename T>
+PathParameterizedTrajectory<T>::~PathParameterizedTrajectory() = default;
+
+template <typename T>
 std::unique_ptr<Trajectory<T>> PathParameterizedTrajectory<T>::Clone() const {
   return std::make_unique<PathParameterizedTrajectory<T>>(*this);
 }

--- a/common/trajectories/path_parameterized_trajectory.h
+++ b/common/trajectories/path_parameterized_trajectory.h
@@ -30,7 +30,7 @@ class PathParameterizedTrajectory final : public Trajectory<T> {
   PathParameterizedTrajectory(const Trajectory<T>& path,
                               const Trajectory<T>& time_scaling);
 
-  ~PathParameterizedTrajectory() final = default;
+  ~PathParameterizedTrajectory() final;
 
   // Required methods for trajectories::Trajectory interface.
   std::unique_ptr<trajectories::Trajectory<T>> Clone() const override;

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -57,6 +57,9 @@ PiecewisePolynomial<T>::PiecewisePolynomial(
 }
 
 template <typename T>
+PiecewisePolynomial<T>::~PiecewisePolynomial() = default;
+
+template <typename T>
 std::unique_ptr<Trajectory<T>> PiecewisePolynomial<T>::Clone() const {
   return std::make_unique<PiecewisePolynomial<T>>(*this);
 }

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -181,7 +181,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
                       const std::vector<T>& breaks);
   // @}
 
-  ~PiecewisePolynomial() override = default;
+  ~PiecewisePolynomial() override;
 
   std::unique_ptr<Trajectory<T>> Clone() const override;
 

--- a/common/trajectories/piecewise_pose.cc
+++ b/common/trajectories/piecewise_pose.cc
@@ -22,6 +22,9 @@ PiecewisePose<T>::PiecewisePose(
 }
 
 template <typename T>
+PiecewisePose<T>::~PiecewisePose() = default;
+
+template <typename T>
 PiecewisePose<T> PiecewisePose<T>::MakeLinear(
     const std::vector<T>& times,
     const std::vector<math::RigidTransform<T>>& poses) {

--- a/common/trajectories/piecewise_pose.h
+++ b/common/trajectories/piecewise_pose.h
@@ -37,6 +37,8 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
   PiecewisePose(const PiecewisePolynomial<T>& position_trajectory,
                 const PiecewiseQuaternionSlerp<T>& orientation_trajectory);
 
+  ~PiecewisePose() override;
+
   /**
    * Constructs a PiecewisePose from given @p times and @p poses. The positions
    * trajectory is constructed as a first-order hold. The orientation is

--- a/common/trajectories/piecewise_quaternion.cc
+++ b/common/trajectories/piecewise_quaternion.cc
@@ -122,6 +122,9 @@ PiecewiseQuaternionSlerp<T>::PiecewiseQuaternionSlerp(
 }
 
 template <typename T>
+PiecewiseQuaternionSlerp<T>::~PiecewiseQuaternionSlerp() = default;
+
+template <typename T>
 std::unique_ptr<Trajectory<T>> PiecewiseQuaternionSlerp<T>::Clone() const {
   return std::make_unique<PiecewiseQuaternionSlerp>(*this);
 }

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -74,7 +74,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
   PiecewiseQuaternionSlerp(const std::vector<T>& breaks,
                            const std::vector<AngleAxis<T>>& angle_axes);
 
-  ~PiecewiseQuaternionSlerp() override = default;
+  ~PiecewiseQuaternionSlerp() override;
 
   std::unique_ptr<Trajectory<T>> Clone() const override;
 

--- a/common/trajectories/piecewise_trajectory.cc
+++ b/common/trajectories/piecewise_trajectory.cc
@@ -21,6 +21,9 @@ PiecewiseTrajectory<T>::PiecewiseTrajectory(const std::vector<T>& breaks)
 }
 
 template <typename T>
+PiecewiseTrajectory<T>::~PiecewiseTrajectory() = default;
+
+template <typename T>
 boolean<T> PiecewiseTrajectory<T>::is_time_in_range(const T& time) const {
   return (time >= start_time() && time <= end_time());
 }

--- a/common/trajectories/piecewise_trajectory.h
+++ b/common/trajectories/piecewise_trajectory.h
@@ -24,7 +24,7 @@ class PiecewiseTrajectory : public Trajectory<T> {
   /// Minimum delta quantity used for comparing time.
   static constexpr double kEpsilonTime = std::numeric_limits<double>::epsilon();
 
-  ~PiecewiseTrajectory() override = default;
+  ~PiecewiseTrajectory() override;
 
   int get_number_of_segments() const;
 

--- a/common/trajectories/trajectory.cc
+++ b/common/trajectories/trajectory.cc
@@ -6,6 +6,9 @@ namespace drake {
 namespace trajectories {
 
 template <typename T>
+Trajectory<T>::~Trajectory() = default;
+
+template <typename T>
 MatrixX<T> Trajectory<T>::vector_values(const std::vector<T>& t) const {
   return vector_values(Eigen::Map<const VectorX<T>>(t.data(), t.size()));
 }

--- a/common/trajectories/trajectory.h
+++ b/common/trajectories/trajectory.h
@@ -21,7 +21,7 @@ namespace trajectories {
 template <typename T>
 class Trajectory {
  public:
-  virtual ~Trajectory() = default;
+  virtual ~Trajectory();
 
   /**
    * @return A deep copy of this Trajectory.


### PR DESCRIPTION
+@sherm1 for both reviews per schedule, please.

We noticed this problem in an `#onramp` slack thread from yesterday.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22010)
<!-- Reviewable:end -->
