### PR TITLE
Introduce sdformat semantics for Drake's visual roles

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -138,6 +138,7 @@ filegroup(
     ] + glob([
         "test/meshes/*",
         "test/box.sdf",
+        "test/configure_visual_roles.sdf",
         "test/*.png",
     ]),
 )

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -12,6 +12,7 @@
 #include <sdf/Cylinder.hh>
 #include <sdf/Element.hh>
 #include <sdf/Ellipsoid.hh>
+#include <sdf/Param.hh>
 #include <sdf/Plane.hh>
 #include <sdf/Sphere.hh>
 
@@ -34,6 +35,7 @@ using std::string;
 
 using drake::internal::DiagnosticPolicy;
 using geometry::GeometryInstance;
+using geometry::GeometryProperties;
 using geometry::IllustrationProperties;
 using geometry::PerceptionProperties;
 using geometry::ProximityProperties;
@@ -219,6 +221,8 @@ std::unique_ptr<GeometryInstance> MakeGeometryInstanceFromSdfVisual(
     const SDFormatDiagnostic& diagnostic, const sdf::Visual& sdf_visual,
     ResolveFilename resolve_filename, const math::RigidTransformd& X_LG) {
   const std::set<std::string> supported_visual_elements{
+    "drake:perception_properties",
+    "drake:illustration_properties",
     "geometry",
     "material",
     "pose",
@@ -290,25 +294,54 @@ std::unique_ptr<GeometryInstance> MakeGeometryInstanceFromSdfVisual(
 
   auto instance =
       make_unique<GeometryInstance>(X_LC, std::move(*shape), sdf_visual.Name());
-  std::optional<IllustrationProperties> illustration_properties =
-      MakeVisualPropertiesFromSdfVisual(
-          diagnostic, sdf_visual, resolve_filename);
-  if (!illustration_properties.has_value()) return nullptr;
-  instance->set_perception_properties(
-      PerceptionProperties(*illustration_properties));
-  if (illustration_properties->HasProperty("renderer", "accepting")) {
-    // We stashed the perception property in the illustration properties. It has
-    // been copied into the perception properties, so we can remove it from here
-    // now.
-    illustration_properties->RemoveProperty("renderer", "accepting");
+  VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(
+      diagnostic, sdf_visual, resolve_filename);
+  if (!(vis_props.illustration.has_value() ||
+        vis_props.perception.has_value())) {
+    // No properties of any kind were returned.
+    return nullptr;
   }
-  instance->set_illustration_properties(*std::move(illustration_properties));
+  if (vis_props.illustration.has_value()) {
+    instance->set_illustration_properties(*std::move(vis_props.illustration));
+  }
+  if (vis_props.perception.has_value()) {
+    instance->set_perception_properties(*std::move(vis_props.perception));
+  }
   return instance;
 }
 
-std::optional<IllustrationProperties> MakeVisualPropertiesFromSdfVisual(
-    const SDFormatDiagnostic& diagnostic,
-    const sdf::Visual& sdf_visual, ResolveFilename resolve_filename) {
+namespace {
+
+// The element is only disabled iff:
+//  - it is defined and
+//  - it has the attribute "enabled" and
+//  - the attribute's value is false.
+// In all other cases, the element is considered enabled.
+bool ElementIsEnabled(const sdf::ElementConstPtr e,
+                      const SDFormatDiagnostic& diagnostic) {
+  if (e == nullptr) {
+    return true;
+  }
+  sdf::ParamPtr attr = e->GetAttribute("enabled");
+  if (attr == nullptr) {
+    return true;
+  }
+  bool enabled;
+  const bool valid = attr->Get(enabled);
+  if (!valid) {
+    diagnostic.Error(e, fmt::format(
+        "The `{}` element has an 'enabled' attribute with the wrong value "
+        "type; it should be a boolean value.", e->GetName()));
+    return false;
+  }
+  return enabled;
+}
+
+}  // namespace
+
+VisualProperties MakeVisualPropertiesFromSdfVisual(
+    const SDFormatDiagnostic& diagnostic, const sdf::Visual& sdf_visual,
+    ResolveFilename resolve_filename) {
   // This doesn't directly use the sdf::Material API on purpose. In the current
   // version, if a parameter (e.g., diffuse) is missing it will *not* be
   // included in the geometry properties. Using the sdf::Material, it is
@@ -319,12 +352,49 @@ std::optional<IllustrationProperties> MakeVisualPropertiesFromSdfVisual(
   // distinguish between a value that was specified by the user and one that was
   // provided by sdformat's default value).
 
-  // The existence of a visual element will *always* require an
-  // IllustrationProperties instance. How we populate it depends on the material
-  // values.
-  IllustrationProperties properties;
-
   const sdf::ElementPtr visual_element = sdf_visual.Element();
+  // TODO(SeanCurtis-TRI): These elements will be more fully utilized when these
+  // tags contain child tags that configure properties.
+  const sdf::ElementConstPtr percep =
+      visual_element->FindElement("drake:perception_properties");
+  const sdf::ElementConstPtr illus =
+      visual_element->FindElement("drake:illustration_properties");
+  const bool gets_percep = ElementIsEnabled(percep, diagnostic);
+  const bool gets_illus = ElementIsEnabled(illus, diagnostic);
+
+  if (!(gets_percep || gets_illus)) {
+    // The <visual> tag has had both illustration and perception roles disabled.
+
+    // If true, this visual was a <visual> and not a <drake:visual>.
+    const bool is_sdf_visual =
+        sdf_visual.Element()->GetAttribute(kIsDrakeNamespaceAttr) == nullptr;
+    if (is_sdf_visual) {
+      diagnostic.Warning(
+          visual_element,
+          fmt::format("The <visual name=\"{}\"> tag had all visual roles "
+                      "turned off for Drake; this model may appear very "
+                      "different in Drake from other sdformat loaders.",
+                      sdf_visual.Name()));
+    }
+
+    return {std::nullopt, std::nullopt};
+  }
+
+  // At the point, we know at least one visual role has been specified. If
+  // illustration is defined, we'll set the properties on illustration
+  // properties and (maybe) copy them over to perception when we're done.
+  // Otherwise, we write directly to the perception_properties.
+  std::optional<IllustrationProperties> illus_props;
+  std::optional<PerceptionProperties> percep_props;
+  GeometryProperties* properties = nullptr;
+  if (gets_illus) {
+    illus_props = IllustrationProperties();
+    properties = &*illus_props;
+  } else {
+    percep_props = PerceptionProperties();
+    properties = &*percep_props;
+  }
+
   // Element pointers can only be nullptr if Load() was not called on the sdf::
   // object. Only a bug could cause this.
   DRAKE_DEMAND(visual_element != nullptr);
@@ -352,14 +422,14 @@ std::optional<IllustrationProperties> MakeVisualPropertiesFromSdfVisual(
           std::string message = std::string(fmt::format(
               "Unable to locate the texture file: {}", texture_name));
           diagnostic.Error(visual_element, std::move(message));
-          return std::nullopt;
+          return {std::nullopt, std::nullopt};
         }
-        properties.AddProperty("phong", "diffuse_map", resolved_path);
+        properties->AddProperty("phong", "diffuse_map", resolved_path);
       }
     }
 
     auto add_property = [material_element](const char* property,
-                                           IllustrationProperties* props) {
+                                           GeometryProperties* props) {
       if (!material_element->HasElement(property)) return;
       using gz::math::Color;
       const std::pair<Color, bool> value_pair =
@@ -372,35 +442,49 @@ std::optional<IllustrationProperties> MakeVisualPropertiesFromSdfVisual(
       props->AddProperty("phong", property, color);
     };
 
-    add_property("diffuse", &properties);
-    add_property("ambient", &properties);
-    add_property("specular", &properties);
-    add_property("emissive", &properties);
+    add_property("diffuse", properties);
+    add_property("ambient", properties);
+    add_property("specular", properties);
+    add_property("emissive", properties);
   }
 
-  // We're putting this perception property into the illustration properties.
-  // We'll create the PerceptionProperties from these illustration properties
-  // and simply remove this property from the illustration properties as clean
-  // up.
+  if (gets_percep && gets_illus) {
+    percep_props = PerceptionProperties(*illus_props);
+  }
+
+  // TODO(SeanCurtis-TRI): As we allow customization of properties within the
+  // drake::foo_properties tags, refine the illustration and perception
+  // properties as appropriate.
+
+  // Perception-only properties.
   if (visual_element->HasElement(kAcceptingTag)) {
-    set<string> accepting_names;
     sdf::ElementPtr accepting = visual_element->GetElement(kAcceptingTag);
-    while (accepting != nullptr) {
-      const string& name = accepting->Get<string>();
-      if (name.empty()) {
-        std::string message = fmt::format("<{}> tag given without any name",
-                                          kAcceptingTag);
-        diagnostic.Error(accepting, std::move(message));
-        return std::nullopt;
+    if (gets_percep) {
+      set<string> accepting_names;
+      while (accepting != nullptr) {
+        const string& name = accepting->Get<string>();
+        if (name.empty()) {
+          std::string message =
+              fmt::format("<{}> tag given without any name", kAcceptingTag);
+          diagnostic.Error(accepting, std::move(message));
+          return {std::nullopt, std::nullopt};
+        }
+        accepting_names.insert(name);
+        accepting = accepting->GetNextElement(kAcceptingTag);
       }
-      accepting_names.insert(name);
-      accepting = accepting->GetNextElement(kAcceptingTag);
+      DRAKE_DEMAND(accepting_names.size() > 0);
+      percep_props->AddProperty("renderer", "accepting",
+                                std::move(accepting_names));
+    } else {
+      diagnostic.Warning(
+          visual_element,
+          fmt::format(
+              "<{}> specified for a <visual> with a disabled perception role.",
+              kAcceptingTag));
     }
-    DRAKE_DEMAND(accepting_names.size() > 0);
-    properties.AddProperty("renderer", "accepting", std::move(accepting_names));
   }
 
-  return properties;
+  return {illus_props, percep_props};
 }
 
 RigidTransformd MakeGeometryPoseFromSdfCollision(

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1012,6 +1012,75 @@ struct LinkInfo {
   RigidTransformd X_WL;
 };
 
+// If `element`'s name has a "drake:" prefix, strip the prefix and then explore
+// `element`'s children, performing the same operation. Returns `true` upon
+// success.
+bool DrakeVisualToSdfVisualRecurse(const SDFormatDiagnostic& diagnostic,
+                                   sdf::ElementPtr element) {
+  const std::string& tag_name = element->GetName();
+  if (!tag_name.starts_with("drake:")) {
+    diagnostic.Error(element,
+                     "All tags under a drake-namespaced tag must likewise be "
+                     "drake-namespaced.");
+    return false;
+  }
+  if (tag_name == "drake:perception_properties" ||
+      tag_name == "drake:illustration_properties") {
+    // These drake-only tags should remain untouched to be processed later.
+    // Doing nothing is success.
+    return true;
+  }
+  element->SetName(tag_name.substr(6));
+  for (sdf::ElementPtr child = element->GetFirstElement(); child != nullptr;
+       child = child->GetNextElement()) {
+    const bool success = DrakeVisualToSdfVisualRecurse(diagnostic, child);
+    if (!success) return success;
+  }
+  return true;
+}
+
+// Search for all _element_ trees rooted at <drake:visual> tags and convert them
+// to <visual> tags, inserting them into `link`.
+void DrakeVisualToSdfVisual(const SDFormatDiagnostic& diagnostic,
+                            const sdf::ParserConfig& parser_config,
+                            sdf::Link* link) {
+  sdf::ElementPtr link_element = link->Element();
+  sdf::ElementPtr drake_visual = link_element->GetElement("drake:visual");
+  while (drake_visual != nullptr) {
+    if (DrakeVisualToSdfVisualRecurse(diagnostic, drake_visual)) {
+      // Stash an attribute into the element that we can use later to recognize
+      // the new <visual> came from <drake:visual>.
+      drake_visual->AddAttribute(kIsDrakeNamespaceAttr, "bool", "true",
+                                 /* required */ false);
+      sdf::Visual visual;
+      visual.Load(drake_visual, parser_config);
+      sdf::ElementPtr next_visual =
+          drake_visual->GetNextElement("drake:visual");
+      link_element->RemoveChild(drake_visual);
+      link->AddVisual(visual);
+      drake_visual = next_visual;
+    } else {
+      // Generally, if we return `false`, it's because there's an error in the
+      // conversion and the parsing should stop. But we'll pretend to proceed
+      // for diagnostics that don't throw on error.
+      drake_visual = drake_visual->GetNextElement("drake:visual");
+    }
+  }
+}
+
+// Immediately after parsing the .sdf file, this gives Drake a chance to
+// massage the intermediate representation. This is used to account for
+// Drake-specific artifacts in the file in a way that facilitates translation
+// into Drake constructs.
+void DrakifyModel(const SDFormatDiagnostic& diagnostic,
+                  const sdf::ParserConfig& parser_config, sdf::Model* model) {
+  // Translate <drake:visual> into a tweaked <visual>.
+  for (uint64_t link_index = 0; link_index < model->LinkCount(); ++link_index) {
+    sdf::Link* link = model->LinkByIndex(link_index);
+    DrakeVisualToSdfVisual(diagnostic, parser_config, link);
+  }
+}
+
 // Helper method to add a model to a MultibodyPlant given an sdf::Model
 // specification object.
 std::optional<std::vector<LinkInfo>> AddLinksFromSpecification(
@@ -1025,6 +1094,7 @@ std::optional<std::vector<LinkInfo>> AddLinksFromSpecification(
   std::vector<LinkInfo> link_infos;
 
   const std::set<std::string> supported_link_elements{
+    "drake:visual",
     "collision",
     "gravity",
     "inertial",
@@ -1107,9 +1177,9 @@ std::optional<std::vector<LinkInfo>> AddLinksFromSpecification(
         // was reported to diagnostic (and it responds appropriately).
         if (geometry_instance == nullptr) continue;
 
-        // The instance should be pre-configured to have both illustration and
-        // perception properties.
-        DRAKE_DEMAND(geometry_instance->illustration_properties() != nullptr &&
+        // If we have a geometry instance, it has at least one set of visual
+        // properties.
+        DRAKE_DEMAND(geometry_instance->illustration_properties() != nullptr ||
                      geometry_instance->perception_properties() != nullptr);
 
         plant->RegisterVisualGeometry(body, std::move(geometry_instance));
@@ -1614,14 +1684,20 @@ class InterfaceModelHelper {
 // specification object.
 std::vector<ModelInstanceIndex> AddModelsFromSpecification(
     const SDFormatDiagnostic& diagnostic,
-    const sdf::Model& model,
+    sdf::Model* model_ptr,
     const std::string& model_name,
     const RigidTransformd& X_WP,
     MultibodyPlant<double>* plant,
     CollisionFilterGroupResolver* resolver,
     const PackageMap& package_map,
     const std::string& root_dir,
-    const ModelInstanceIndexRange &reusable_model_instance_range) {
+    const ModelInstanceIndexRange &reusable_model_instance_range,
+    const sdf::ParserConfig& parser_config) {
+  DRAKE_DEMAND(model_ptr != nullptr);
+
+  DrakifyModel(diagnostic, parser_config, model_ptr);
+
+  const sdf::Model& model = *model_ptr;
   const ModelInstanceIndex model_instance = AddModelInstanceIfReusable(
       plant, model_name, reusable_model_instance_range);
 
@@ -1655,12 +1731,13 @@ std::vector<ModelInstanceIndex> AddModelsFromSpecification(
   drake::log()->trace("sdf_parser: Add nested models");
   for (uint64_t model_index = 0; model_index < model.ModelCount();
        ++model_index) {
-    const sdf::Model& nested_model = *model.ModelByIndex(model_index);
+    sdf::Model* nested_model = model_ptr->ModelByIndex(model_index);
     std::vector<ModelInstanceIndex> nested_model_instances =
         AddModelsFromSpecification(
             diagnostic, nested_model,
-            sdf::JoinName(model_name, nested_model.Name()), X_WM, plant,
-            resolver, package_map, root_dir, reusable_model_instance_range);
+            sdf::JoinName(model_name, nested_model->Name()), X_WM, plant,
+            resolver, package_map, root_dir, reusable_model_instance_range,
+            parser_config);
 
     added_model_instances.insert(added_model_instances.end(),
                                  nested_model_instances.begin(),
@@ -2100,22 +2177,23 @@ sdf::ParserConfig MakeSdfParserConfig(const ParsingWorkspace& workspace) {
   return parser_config;
 }
 
-const sdf::Model* get_only_model(const sdf::Root& root) {
-  const sdf::Model* maybe_model = root.Model();
+sdf::Model* get_only_model(sdf::Root* root) {
+  sdf::Model* maybe_model = root->Model();
   if (maybe_model != nullptr) {
     return maybe_model;
   }
   // If Model() is null, there still may be a single world with a single model
   // (ignoring nested models). Try to find that.
-  if (root.WorldCount() != 1) {
+  if (root->WorldCount() != 1) {
     return nullptr;
   }
-  const sdf::World* world0 = root.WorldByIndex(0);
+  sdf::World* world0 = root->WorldByIndex(0);
   if (world0->ModelCount() != 1) {
     return nullptr;
   }
   return world0->ModelByIndex(0);
 }
+
 }  // namespace
 
 std::optional<ModelInstanceIndex> AddModelFromSdf(
@@ -2143,26 +2221,25 @@ std::optional<ModelInstanceIndex> AddModelFromSdf(
   ModelInstanceIndexRange reusable_model_instance_range =
       std::make_pair(model_index_begin, model_index_end);
 
-  const sdf::Model* maybe_model = get_only_model(root);
-  if (maybe_model == nullptr) {
+  sdf::Model* model_ptr = get_only_model(&root);
+  if (model_ptr == nullptr) {
     std::string message = "File must have a single <model> element.";
     diagnostic.Error(root.Element(), std::move(message));
     return std::nullopt;
   }
-  // Get the only model in the file.
-  const sdf::Model& model = *maybe_model;
 
   const std::string local_model_name =
-      model_name_in.empty() ? model.Name() : model_name_in;
+      model_name_in.empty() ? model_ptr->Name() : model_name_in;
 
   std::string model_name =
       MakeModelName(local_model_name, parent_model_name, workspace);
 
   std::vector<ModelInstanceIndex> added_model_instances =
-      AddModelsFromSpecification(
-          diagnostic, model, model_name, {}, workspace.plant,
-          workspace.collision_resolver, workspace.package_map,
-          data_source.GetRootDir(), reusable_model_instance_range);
+      AddModelsFromSpecification(diagnostic, model_ptr, model_name, {},
+                                 workspace.plant, workspace.collision_resolver,
+                                 workspace.package_map,
+                                 data_source.GetRootDir(),
+                                 reusable_model_instance_range, parser_config);
 
   DRAKE_DEMAND(!added_model_instances.empty());
   return added_model_instances.front();
@@ -2217,16 +2294,18 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
     DRAKE_DEMAND(model_count == 1);
     DRAKE_DEMAND(world_count == 0);
     DRAKE_DEMAND(root.Model() != nullptr);
-    const sdf::Model& model = *root.Model();
+    sdf::Model* model_ptr = root.Model();
+    DRAKE_DEMAND(model_ptr != nullptr);
 
     std::string model_name =
-        MakeModelName(model.Name(), parent_model_name, workspace);
+        MakeModelName(model_ptr->Name(), parent_model_name, workspace);
 
     std::vector<ModelInstanceIndex> added_model_instances =
         AddModelsFromSpecification(
-            diagnostic, model, model_name, {}, workspace.plant,
+            diagnostic, model_ptr, model_name, {}, workspace.plant,
             workspace.collision_resolver, workspace.package_map,
-            data_source.GetRootDir(), reusable_model_instance_range);
+            data_source.GetRootDir(), reusable_model_instance_range,
+            parser_config);
     model_instances.insert(model_instances.end(),
                            added_model_instances.begin(),
                            added_model_instances.end());
@@ -2234,7 +2313,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
     DRAKE_DEMAND(model_count == 0);
     DRAKE_DEMAND(world_count == 1);
     DRAKE_DEMAND(root.WorldByIndex(0) != nullptr);
-    const sdf::World& world = *root.WorldByIndex(0);
+    sdf::World& world = *root.WorldByIndex(0);
 
     const std::set<std::string> supported_world_elements{
       "frame",
@@ -2250,15 +2329,18 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
     for (uint64_t model_index = 0; model_index < world.ModelCount();
         ++model_index) {
       // Get the model.
-      const sdf::Model& model = *world.ModelByIndex(model_index);
+      sdf::Model* model_ptr = world.ModelByIndex(model_index);
+      DRAKE_DEMAND(model_ptr != nullptr);
+
       std::string model_name =
-          MakeModelName(model.Name(), parent_model_name, workspace);
+          MakeModelName(model_ptr->Name(), parent_model_name, workspace);
 
       std::vector<ModelInstanceIndex> added_model_instances =
           AddModelsFromSpecification(
-              diagnostic, model, model_name, {}, workspace.plant,
+              diagnostic, model_ptr, model_name, {}, workspace.plant,
               workspace.collision_resolver, workspace.package_map,
-              data_source.GetRootDir(), reusable_model_instance_range);
+              data_source.GetRootDir(), reusable_model_instance_range,
+              parser_config);
       model_instances.insert(model_instances.end(),
                              added_model_instances.begin(),
                              added_model_instances.end());

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -175,6 +175,7 @@ Here is the full list of custom elements:
 - @ref tag_drake_hydroelastic_margin
 - @ref tag_drake_hydroelastic_modulus
 - @ref tag_drake_ignored_collision_filter_group
+- @ref tag_drake_illustration_properties
 - @ref tag_drake_joint
 - @ref tag_drake_linear_bushing_rpy
 - @ref tag_drake_member
@@ -184,12 +185,14 @@ Here is the full list of custom elements:
 - @ref tag_drake_mu_dynamic
 - @ref tag_drake_mu_static
 - @ref tag_drake_parent
+- @ref tag_drake_perception_properties
 - @ref tag_drake_point_contact_stiffness
 - @ref tag_drake_proximity_properties
 - @ref tag_drake_relaxation_time
 - @ref tag_drake_rigid_hydroelastic
 - @ref tag_drake_rotor_inertia
 - @ref tag_drake_screw_thread_pitch
+- @ref tag_drake_visual
 
 @subsection tag_drake_acceleration drake:acceleration
 
@@ -222,6 +225,11 @@ The tag serves as a list of renderers for which this visual is targeted.
     the list of targeted renderers.
 
 This feature is one way to provide multiple visual representations of a body.
+
+Specifying this tag for a visual whose perception role has been disabled will
+emit a warning.
+
+@see @ref tag_drake_perception_properties
 
 @subsection tag_drake_ball_constraint drake:ball_constraint
 
@@ -622,6 +630,32 @@ In SDFormat files only, the name may refer to a group within a nested model
 
 @see @ref tag_drake_collision_filter_group, @ref scoped_names
 
+@subsection tag_drake_illustration_properties drake:illustration_properties
+
+- SDFormat path: `//model/link/visual/drake:illustration_properties`
+- URDF path: n/a
+- Syntax: Single attribute: `enabled` (bool).
+
+@subsubsection tag_drake_illustration_properties_semantics Semantics
+
+`<visual>` geometries are assigned illustration roles by default. Their
+appearance in visualizers reflect the materials associated with the `<visual>`
+tag (or, as for meshes, the materials associated with the mesh). If no materials
+are defined, then they pick up whatever default materials the visualizers
+define. A `<visual>` tag can _opt out_ of the illustration role by setting the
+`enabled` attribute to `false`. Setting it to `true` is equivalent to omitting
+the tag completely.
+
+Note: if a `<visual>` tag has disabled both illustration properties _and_
+perception properties, a warning will be emitted. Essentially, the model
+defines a geometry that would be consumed by typical loaders, but it has been
+completely disabled for Drake. The definition for Drake should _refine_ the more
+generic model, but it shouldn't consist of an arbitrarily different set of
+visuals.
+
+@see @ref tag_drake_perception_properties
+@see @ref tag_drake_visual
+
 @subsection tag_drake_joint drake:joint
 
 - SDFormat path: `//model/drake:joint`
@@ -767,6 +801,32 @@ MultibodyPlant's constructor documentation for details.
 - URDF path: N/A
 - Syntax: String.
 
+@subsection tag_drake_perception_properties drake:perception_properties
+
+- SDFormat path: `//model/link/visual/drake:perception_properties`
+- URDF path: n/a
+- Syntax: Single attribute: `enabled` (bool).
+
+@subsubsection tag_drake_perception_properties_semantics Semantics
+
+`<visual>` geometries are assigned perception roles by default. Their appearance
+in renderers reflect the materials associated with the `<visual>` tag (or, as
+for meshes, the materials associated with the mesh). If no materials are
+defined, then they pick up whatever default materials the renderers define. A
+`<visual>` tag can _opt out_ of the perception role by setting the `enabled`
+attribute to `false`. Setting it to `true` is equivalent to omitting the tag
+completely.
+
+Note: if a `<visual>` tag has disabled both perception properties _and_
+illustration properties, a warning will be emitted. Essentially, the model
+defines a geometry that would be consumed by typical loaders, but it has been
+completely disabled for Drake. The definition for Drake should _refine_ the more
+generic model, but it shouldn't consist of an arbitrarily different set of
+visuals.
+
+@see @ref tag_drake_illustration_properties
+@see @ref tag_drake_visual
+
 @subsubsection tag_drake_parent_semantics Semantics
 
 The string names a frame (defined elsewhere in the model) that is associated
@@ -876,5 +936,48 @@ revolution of the joint. Units are m/revolution, with a positive value
 corresponding to a right-handed thread.
 
 @see drake::multibody::ScrewJoint
+
+@subsection tag_drake_visual drake:visual
+
+- SDFormat path: `//model/link`
+- URDF path: n/a
+- Syntax: Identical to SDFormat's `<visual>` tag, but with the `drake` namespace
+  prepended. All tags that can be found under the `<visual>` tag (e.g.,
+  `<pose>`, `<geometry>`, `<sphere>`, etc.) can be included under the
+  `<drake:visual>` tag, provided they have the `drake` namespace affixed (e.g.,
+  `<drake:pose>`, `<drake:geometry>`, `<drake:sphere>`, etc.).
+
+@subsubsection tag_drake_visual_semantics Semantics
+
+The `<drake:visual>` tag is provided for the purpose of defining visual elements
+that only Drake will consume. This could be used to do Drake-specific
+augmentation of a model. But the main intended use case is for associating
+_different_ geometries with a link based on its role. Use one geometry for the
+illustration role and another for the perception role. To use different
+geometries per role:
+
+  1. Choose the illustration and perception geometries.
+  2. Decide which geometry you want to serve as the default geometry in other
+     SDFormat loaders.
+  3. Use the SDFormat `<visual>` tag for that default geometry (including all
+     typical descendant tags).
+  4. In the `<visual>` tag, include the `<drake:??_properties>` tag of the
+     role this visual should *not* serve. Set its `enabled` attribute to
+     `false`. Remember, by default the visual would get both roles, so you have
+     to opt out of the role you don't want the geometry to have.
+  5. As a sibling to that main `<visual>`, add a `<drake:visual>` tag and define
+     its subtree as you normally would (making sure to prefix everything with
+     the `drake:` namespace).
+  6. Under the `<drake:visual>` tag, include the _other_ `<drake:??_properties>`
+     tag and set its `enabled` tag to `false`.
+
+This will allow Drake to use different visual representations for each visual
+role but still keep a more general SDFormat definition for other loaders.
+
+Note: disabling both visual roles on a `<drake:visual>` element will _not_
+emit a warning as it would for doing the same to a `<visual>` tag.
+
+@see @ref tag_drake_perception_properties
+@see @ref tag_drake_illustration_properties
 
 */

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -19,6 +19,7 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/rgba.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
@@ -45,6 +46,7 @@ using geometry::HalfSpace;
 using geometry::IllustrationProperties;
 using geometry::Mesh;
 using geometry::ProximityProperties;
+using geometry::Rgba;
 using geometry::SceneGraph;
 using geometry::Shape;
 using geometry::Sphere;
@@ -204,10 +206,9 @@ class SceneGraphParserDetail : public test::DiagnosticPolicyTestBase {
   }
 
   // Wraps a function under test with helpful defaults.
-  std::optional<geometry::IllustrationProperties>
-      MakeVisualPropertiesFromSdfVisual(
-          const sdf::Visual& sdf_visual,
-          const ResolveFilename& resolve_filename = &NoopResolveFilename) {
+  VisualProperties MakeVisualPropertiesFromSdfVisual(
+      const sdf::Visual& sdf_visual,
+      const ResolveFilename& resolve_filename = &NoopResolveFilename) {
     return internal::MakeVisualPropertiesFromSdfVisual(
         sdf_diagnostic_, sdf_visual, resolve_filename);
   }
@@ -558,6 +559,74 @@ TEST_F(SceneGraphParserDetail,
   EXPECT_TRUE(names.contains("renderer1"));
 }
 
+// Verify MakeGeometryInstanceFromSdfVisual()'s GeometryInstance reflects the
+// enabled visual roles. All we care about is the presence/absence of geometry
+// properties based on what was enabled.
+TEST_F(SceneGraphParserDetail, MakeGeometryInstanceFromSdfVisualPartialRoles) {
+  constexpr std::string_view sdf_format_str = R"""(
+    <visual name = 'some_link_visual'>
+      <geometry><sphere><radius>1</radius></sphere></geometry>
+      <drake:perception_properties enabled="{p_on}"/>
+      <drake:illustration_properties enabled="{i_on}"/>
+    </visual>)""";
+
+  // Case: Both roles enabled --> both sets of properties.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(fmt::format(
+        sdf_format_str, fmt::arg("p_on", true), fmt::arg("i_on", true)));
+    unique_ptr<GeometryInstance> instance =
+        MakeGeometryInstanceFromSdfVisual(
+            sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
+            ToRigidTransform(sdf_visual->RawPose()));
+    ASSERT_NE(instance, nullptr);
+    ASSERT_NE(instance->perception_properties(), nullptr);
+    ASSERT_NE(instance->illustration_properties(), nullptr);
+  }
+
+  // Case: Illustration disabled --> only perception properties.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(fmt::format(
+        sdf_format_str, fmt::arg("p_on", true), fmt::arg("i_on", false)));
+    unique_ptr<GeometryInstance> instance =
+        MakeGeometryInstanceFromSdfVisual(
+            sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
+            ToRigidTransform(sdf_visual->RawPose()));
+    ASSERT_NE(instance, nullptr);
+    ASSERT_NE(instance->perception_properties(), nullptr);
+    ASSERT_EQ(instance->illustration_properties(), nullptr);
+  }
+
+  // Case: Perception disabled --> only illustration properties.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(fmt::format(
+        sdf_format_str, fmt::arg("p_on", false), fmt::arg("i_on", true)));
+    unique_ptr<GeometryInstance> instance =
+        MakeGeometryInstanceFromSdfVisual(
+            sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
+            ToRigidTransform(sdf_visual->RawPose()));
+    ASSERT_NE(instance, nullptr);
+    ASSERT_EQ(instance->perception_properties(), nullptr);
+    ASSERT_NE(instance->illustration_properties(), nullptr);
+  }
+
+  // Case: Both roles disabled --> no instance returned (but we do get a warning
+  // as tested below in DisablingVisualRoles).
+  // We don't test the case where we've got both roles disabled for
+  // <drake:visual>. The only difference is whether a warning gets emitted, and
+  // that's tested in DisablingVisualRoles.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(fmt::format(
+        sdf_format_str, fmt::arg("p_on", false), fmt::arg("i_on", false)));
+    unique_ptr<GeometryInstance> instance =
+        MakeGeometryInstanceFromSdfVisual(
+            sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
+            ToRigidTransform(sdf_visual->RawPose()));
+    ASSERT_EQ(instance, nullptr);
+    EXPECT_THAT(TakeWarning(),
+                ::testing::HasSubstr("all visual roles turned off for Drake"));
+  }
+}
+
 // Confirms the failure conditions for SDFormat. SceneGraph requirements on
 // geometry names are supposed to mirror the SDFormat behavior. If these tests
 // no longer fail, the requirements in SceneGraph should become more relaxed.
@@ -903,9 +972,10 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(false, nullptr, nullptr, nullptr, nullptr, ""));
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(*material, false, {}, {}, {}, {}, {}));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_TRUE(
+        expect_phong(*vis_props.illustration, false, {}, {}, {}, {}, {}));
   }
 
   // Case: Material tag defined, but no material properties -- empty
@@ -913,9 +983,10 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, nullptr, nullptr, nullptr, nullptr, ""));
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(*material, false, {}, {}, {}, {}, {}));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_TRUE(
+        expect_phong(*vis_props.illustration, false, {}, {}, {}, {}, {}));
   }
 
   Vector4<double> diffuse{0.25, 0.5, 0.75, 1.0};
@@ -927,45 +998,49 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, &diffuse, nullptr, nullptr, nullptr, ""));
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(*material, true, diffuse, {}, {}, {}, {}));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_TRUE(
+        expect_phong(*vis_props.illustration, true, diffuse, {}, {}, {}, {}));
   }
 
   // Case: Only valid specular defined.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, nullptr, &specular, nullptr, nullptr, ""));
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(*material, true, {}, specular, {}, {}, {}));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_TRUE(
+        expect_phong(*vis_props.illustration, true, {}, specular, {}, {}, {}));
   }
 
   // Case: Only valid ambient defined.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, nullptr, nullptr, &ambient, nullptr, ""));
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(*material, true, {}, {}, ambient, {}, {}));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_TRUE(
+        expect_phong(*vis_props.illustration, true, {}, {}, ambient, {}, {}));
   }
 
   // Case: Only valid emissive defined.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, nullptr, nullptr, nullptr, &emissive, ""));
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(*material, true, {}, {}, {}, emissive, {}));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_TRUE(
+        expect_phong(*vis_props.illustration, true, {}, {}, {}, emissive, {}));
   }
 
   // Case: All four.
   {
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, &diffuse, &specular, &ambient, &emissive, ""));
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(*material, true, diffuse,
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_TRUE(expect_phong(*vis_props.illustration, true, diffuse,
                 specular, ambient, emissive, {}));
   }
 
@@ -978,11 +1053,11 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
         make_xml(true, &diffuse, &specular, &ambient, &emissive, kLocalMap);
     unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
         make_xml(true, &diffuse, &specular, &ambient, &emissive, kLocalMap));
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
     // Note: The "no-op" filename resolver will just return kLocalMap as the
     // property name.
-    EXPECT_TRUE(expect_phong(*material, true, diffuse, specular,
+    EXPECT_TRUE(expect_phong(*vis_props.illustration, true, diffuse, specular,
                              ambient, emissive, kLocalMap));
   }
 
@@ -999,6 +1074,48 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
     EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
         ".*Unable to locate the texture file: empty.png"));
     ClearDiagnostics();
+  }
+
+  // Case: drake:{illustration|perception}_properties is missing the enabled
+  // attribute. The result has the named property.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+      "<visual name='v'>"
+      " <geometry><sphere><radius>1</radius></sphere></geometry>"
+      " <drake:illustration_properties/>"
+      "</visual>");
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+  }
+
+  // Case: drake:{illustration|perception}_properties explicitly says true for
+  // enabled attribute. The result has the named property.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+      "<visual name='v'>"
+      " <geometry><sphere><radius>1</radius></sphere></geometry>"
+      " <drake:illustration_properties enabled='true'/>"
+      "</visual>");
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+  }
+
+  // Case: drake:{illustration|perception}_properties have the wrong value
+  // type for the "enabled" attribute.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+      "<visual name='v'>"
+      " <geometry><sphere><radius>1</radius></sphere></geometry>"
+      " <drake:illustration_properties enabled=\"bob\"/>"
+      "</visual>");
+    internal::MakeVisualPropertiesFromSdfVisual(
+        sdf_diagnostic_, *sdf_visual,
+        [](const SDFormatDiagnostic&, std::string) -> std::string {
+          return {};
+        });
+    EXPECT_THAT(TakeError(),
+                ::testing::MatchesRegex(
+                    ".*'enabled' attribute with the wrong value type.*"));
   }
 
   // Note: As of https://github.com/osrf/sdformat/pull/519, sdformat is doing
@@ -1021,13 +1138,15 @@ TEST_F(SceneGraphParserDetail, ParseVisualMaterial) {
         "  <material>" + bad_diffuse +
         "  </material>"
         "</visual>");
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(expect_phong(*material, false, {}, {}, {}, {}, {}));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_TRUE(
+        expect_phong(*vis_props.illustration, false, {}, {}, {}, {}, {}));
   }
 }
 
-// Confirms that the <drake:accepting_renderer> tag gets properly parsed.
+// Confirms that the <drake:accepting_renderer> tag gets properly parsed. The
+// property gets assigned to perception properties but not illustration.
 TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
   const std::string group = "renderer";
   const std::string property = "accepting";
@@ -1046,9 +1165,11 @@ TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
         "    <diffuse>0.25 1 0.5 0.25</diffuse>"
         "  </material>"
         "</visual>");
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_FALSE(material->HasProperty(group, property));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.perception.has_value());
+    EXPECT_FALSE(vis_props.perception->HasProperty(group, property));
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_FALSE(vis_props.illustration->HasProperty(group, property));
   }
 
   // Case: single <drake:accepting_renderer> tag.
@@ -1066,13 +1187,16 @@ TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
         "  </material>"
         "  <drake:accepting_renderer>renderer1</drake:accepting_renderer>"
         "</visual>");
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(material->HasProperty(group, property));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.perception.has_value());
+    EXPECT_TRUE(vis_props.perception->HasProperty(group, property));
     const auto& names =
-        material->GetProperty<std::set<std::string>>(group, property);
+        vis_props.perception->GetProperty<std::set<std::string>>(group,
+                                                                 property);
     EXPECT_EQ(names.size(), 1);
     EXPECT_TRUE(names.contains("renderer1"));
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_FALSE(vis_props.illustration->HasProperty(group, property));
   }
 
   // Case: Multiple <drake:accepting_renderer> tag.
@@ -1091,34 +1215,159 @@ TEST_F(SceneGraphParserDetail, AcceptingRenderers) {
         "  <drake:accepting_renderer>renderer1</drake:accepting_renderer>"
         "  <drake:accepting_renderer>renderer2</drake:accepting_renderer>"
         "</visual>");
-    std::optional<IllustrationProperties> material =
-        MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-    EXPECT_TRUE(material->HasProperty(group, property));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.perception.has_value());
+    EXPECT_TRUE(vis_props.perception->HasProperty(group, property));
     const auto& names =
-        material->GetProperty<std::set<std::string>>(group, property);
+        vis_props.perception->GetProperty<std::set<std::string>>(group,
+                                                                 property);
     EXPECT_EQ(names.size(), 2);
     EXPECT_TRUE(names.contains("renderer1"));
     EXPECT_TRUE(names.contains("renderer2"));
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_FALSE(vis_props.illustration->HasProperty(group, property));
   }
 
   // Case: Missing names throws exception.
-  unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
-        "<visual name='some_link_visual'>"
-        "  <pose>0 0 0 0 0 0</pose>"
-        "  <geometry>"
-        "    <sphere>"
-        "      <radius>1</radius>"
-        "    </sphere>"
-        "  </geometry>"
-        "  <material>"
-        "    <diffuse>0.25 1 0.5 0.25</diffuse>"
-        "  </material>"
-        "  <drake:accepting_renderer> </drake:accepting_renderer>"
-        "</visual>");
-  MakeVisualPropertiesFromSdfVisual(*sdf_visual);
-  EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
-      ".*<drake:accepting_renderer> tag given without any name"));
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+          "<visual name='some_link_visual'>"
+          "  <pose>0 0 0 0 0 0</pose>"
+          "  <geometry>"
+          "    <sphere>"
+          "      <radius>1</radius>"
+          "    </sphere>"
+          "  </geometry>"
+          "  <material>"
+          "    <diffuse>0.25 1 0.5 0.25</diffuse>"
+          "  </material>"
+          "  <drake:accepting_renderer> </drake:accepting_renderer>"
+          "</visual>");
+    MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
+        ".*<drake:accepting_renderer> tag given without any name"));
+  }
+
+  // Case: specifying accepting renderers with disabled perception role warns.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+          "<visual name='some_link_visual'>"
+          "  <geometry><sphere><radius>1</radius></sphere></geometry>"
+          "  <drake:perception_properties enabled=\"false\"/>"
+          "  <drake:accepting_renderer> </drake:accepting_renderer>"
+          "</visual>");
+    MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    EXPECT_THAT(TakeWarning(), ::testing::MatchesRegex(
+        ".*<drake:accepting_renderer> specified .* disabled perception role."));
+  }
+
   ClearDiagnostics();
+}
+
+// Verify that the <drake:*_properties> are accounted for in disabling sets of
+// visual properties.
+TEST_F(SceneGraphParserDetail, DisablingVisualRoles) {
+  const Rgba expected_diffuse(0.25, 1, 0.5, 0.25);
+
+  static constexpr char visual_format[] = R"""(
+  <visual name='visual'>
+    <geometry><sphere><radius>1</radius></sphere></geometry>
+    <material><diffuse>0.25, 1 0.5 0.25</diffuse></material>
+    {}
+  </visual>)""";
+
+  // Case: Saying nothing produces both illustration and perception properties
+  // with the same material properties.
+  {
+    unique_ptr<sdf::Visual> sdf_visual =
+        MakeSdfVisualFromString(fmt::format(visual_format, ""));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_EQ(vis_props.illustration->GetPropertyOrDefault("phong", "diffuse",
+                                                           Rgba(0, 0, 0)),
+              expected_diffuse);
+    ASSERT_TRUE(vis_props.perception.has_value());
+    EXPECT_EQ(vis_props.perception->GetPropertyOrDefault("phong", "diffuse",
+                                                         Rgba(0, 0, 0)),
+              expected_diffuse);
+  }
+
+  // Case: Saying enabled is the same as saying nothing.
+  {
+    unique_ptr<sdf::Visual> sdf_visual =
+        MakeSdfVisualFromString(fmt::format(visual_format, R"""(
+        <drake:perception_properties enabled="true"/>
+        <drake:illustration_properties enabled="true"/>)"""));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_EQ(vis_props.illustration->GetPropertyOrDefault("phong", "diffuse",
+                                                           Rgba(0, 0, 0)),
+              expected_diffuse);
+    ASSERT_TRUE(vis_props.perception.has_value());
+    EXPECT_EQ(vis_props.perception->GetPropertyOrDefault("phong", "diffuse",
+                                                         Rgba(0, 0, 0)),
+              expected_diffuse);
+  }
+
+  // Case: Disabling perception leaves only illustration.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+        fmt::format(visual_format,
+                    R"""(<drake:perception_properties enabled="false"/>)"""));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_TRUE(vis_props.illustration.has_value());
+    EXPECT_EQ(vis_props.illustration->GetPropertyOrDefault("phong", "diffuse",
+                                                           Rgba(0, 0, 0)),
+              expected_diffuse);
+    ASSERT_FALSE(vis_props.perception.has_value());
+  }
+
+  // Case: Disabling illustration leaves only perception.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+        fmt::format(visual_format,
+                    R"""(<drake:illustration_properties enabled="false"/>)"""));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_FALSE(vis_props.illustration.has_value());
+    ASSERT_TRUE(vis_props.perception.has_value());
+    EXPECT_EQ(vis_props.perception->GetPropertyOrDefault("phong", "diffuse",
+                                                         Rgba(0, 0, 0)),
+              expected_diffuse);
+  }
+
+  // Case: Disabling both reports no geometry properties, but does spew a
+  // warning.
+  {
+    unique_ptr<sdf::Visual> sdf_visual =
+        MakeSdfVisualFromString(fmt::format(visual_format, R"""(
+        <drake:perception_properties enabled="false"/>
+        <drake:illustration_properties enabled="false"/>)"""));
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_FALSE(vis_props.illustration.has_value());
+    ASSERT_FALSE(vis_props.perception.has_value());
+    EXPECT_THAT(TakeWarning(),
+                ::testing::HasSubstr("all visual roles turned off for Drake"));
+  }
+
+  // Case: Disabling both reports no geometry properties. If the visual came
+  // from a <drake:visual> originally, there's no warning.
+  {
+    unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(R"""(
+        <visual name='visual'>
+          <geometry><sphere><radius>1</radius></sphere></geometry>
+          <drake:perception_properties enabled="false"/>
+          <drake:illustration_properties enabled="false"/>
+        </visual>)""");
+    // This is the attribute that gets added in detail_sdf_parser.cc when a
+    // <drake:visual> gets converted to <visual>.
+    sdf_visual->Element()->AddAttribute(kIsDrakeNamespaceAttr, "bool", "true",
+                                        /* required */ false);
+    VisualProperties vis_props = MakeVisualPropertiesFromSdfVisual(*sdf_visual);
+    ASSERT_FALSE(vis_props.illustration.has_value());
+    ASSERT_FALSE(vis_props.perception.has_value());
+    // Because it ostensibly came from <drake:visual>, there is no warning.
+    ASSERT_EQ(NumWarnings(), 0);
+  }
 }
 
 // Verify MakeGeometryPoseFromSdfCollision() makes the pose X_LG of geometry

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -3872,6 +3872,109 @@ TEST_F(SdfParserTest, MergeIncludeIntoWorld) {
   TestMergeIncludeWithInterfaceApi(plant_, scene_graph_, "top");
   TestMergeIncludeWithInterfaceApi(plant_, scene_graph_, "another_top");
 }
+
+TEST_F(SdfParserTest, VisualRoleConfiguration) {
+  AddSceneGraph();
+  // Test that point masses don't get sent through the massless body branch.
+  ParseTestString(R"""(
+  <model name="visual_model">
+    <link name="unused_default_geometry">
+      <visual name="general_visual">
+        <pose>-1 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>1 1 1</size>
+          </box>
+        </geometry>
+        <!-- Both roles disabled for <visual> generates a warning. -->
+        <drake:perception_properties enabled="false"/>
+        <drake:illustration_properties enabled="false"/>
+      </visual>
+
+      <drake:visual name="non-existent">
+        <drake:geometry>
+          <drake:sphere>
+            <drake:radius>10</drake:radius>
+          </drake:sphere>
+        </drake:geometry>
+        <!-- Both roles diabled for <drake:visual> does *not* generate a
+             warning. -->
+        <drake:perception_properties enabled="false"/>
+        <drake:illustration_properties enabled="false"/>
+      </drake:visual>
+
+      <drake:visual name="illustration">
+        <drake:pose>1 0 0 0 0 0</drake:pose>
+        <drake:geometry>
+          <drake:cylinder>
+            <drake:radius>0.8</drake:radius>
+            <drake:length>0.02</drake:length>
+          </drake:cylinder>
+        </drake:geometry>
+        <!-- perception disabled; illustration only. -->
+        <drake:perception_properties enabled="false"/>
+      </drake:visual>
+
+      <drake:visual name="perception">
+        <drake:pose>0 0 0 0 0 0</drake:pose>
+        <drake:geometry>
+          <drake:sphere>
+            <drake:radius>2</drake:radius>
+          </drake:sphere>
+        </drake:geometry>
+        <!-- illustration disabled; perception only. -->
+        <drake:illustration_properties enabled="false"/>
+      </drake:visual>
+
+      <drake:visual name="bad_nesting">
+        <!-- Non drake: child element should emit diagnostic error. -->
+        <pose>0 0 0 0 0 0</pose>
+      </drake:visual>
+
+    </link>
+  </model>)""");
+
+  struct ExpectedGeometry {
+    std::string name;
+    std::string shape_string;
+    bool operator<(const ExpectedGeometry& other) const {
+      if (name < other.name) return true;
+      if (name > other.name) return false;
+      return shape_string < other.shape_string;
+    }
+  };
+
+  const std::set<ExpectedGeometry> expected_geometries{
+      {"visual_model::illustration", "Cylinder(radius=0.8, length=0.02)"},
+      {"visual_model::perception", "Sphere(radius=2)"}};
+
+  const auto& inspector = scene_graph_.model_inspector();
+  EXPECT_EQ(inspector.num_geometries(), expected_geometries.size());
+  for (const auto id : inspector.GetAllGeometryIds()) {
+    EXPECT_TRUE(expected_geometries.contains(ExpectedGeometry{
+        inspector.GetName(id), inspector.GetShape(id).to_string()}));
+  }
+
+  EXPECT_THAT(TakeWarning(),
+              ::testing::HasSubstr("<visual name=\"general_visual\"> tag had "
+                                   "all visual roles turned off"));
+
+  EXPECT_THAT(TakeError(),
+              ::testing::HasSubstr("under a drake-namespaced tag must likewise "
+                                   "be drake-namespaced"));
+
+  // Note: we haven't done anything explicit to test the <drake:pose>
+  // conversion. Given that the other elements of the <drake:visualizer> tree
+  // have processed, we assume the <drake:pose> has processed as well. The only
+  // concern we'd have if the "relative-to" plumbing weren't set up correctly.
+  // However, in that case, this test would fail because each of the
+  // <drake:visual> elements with a <drake:pose> tag would generate an error
+  // in the diagnostics:
+  //    "SemanticPose has invalid pointer to PoseRelativeToGraph."
+  // If those errors were emitted, this test would fail on completion.
+  EXPECT_THAT(NumErrors(), 0);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/tools/workspace/sdformat_internal/patches/upstream/support_drake_visual.patch
+++ b/tools/workspace/sdformat_internal/patches/upstream/support_drake_visual.patch
@@ -1,0 +1,71 @@
+We convert <drake:visual> to <visual> after SDF parsing. This means we're
+going to modify the sdf::Link instances in place, adding new sdf::Visual
+instances. To support this change, we needed the following:
+
+  1. sdf::Root did not give mutable access to its sdf::Model (only const). Now
+     it does.
+  2. The new <visual> elements need to have their "PoseRelativeToGraph" property
+     set. We've modified Link::AddVisual() to automatically update added
+     visual's graphs to the link's graph (this is what happens when we call
+     Link::SetPoseRelativeToGraph()). This should be otherwise benign.
+
+The mutable access to sdf::Model seems more consistent with how the other types
+work and should probably be upstreamed.
+
+The assignment of the pose-relative-to-graph to Visual seems benign and could
+be upstreamed. However, it's not clear if sdformat wants to encourage this kind
+of post-parse modification. If it does, then the same logic should be applied
+to the sdf::Link's other child elements: Collision, Light, Sensor, Emitter,
+and Projector.
+
+diff --git a/include/sdf/Root.hh b/include/sdf/Root.hh
+index 9ad5f163..197fd3e2 100644
+--- include/sdf/Root.hh
++++ include/sdf/Root.hh
+@@ -170,6 +170,11 @@ namespace sdf
+     /// \return A pointer to the model, nullptr if it doesn't exist
+     public: const sdf::Model *Model() const;
+ 
++    /// \brief Get the mutable model object if it exists.
++    ///
++    /// \return A pointer to the model; nullptr if it doesn't exist.
++    public: sdf::Model *Model();
++
+     /// \brief Set the model object. This will override any existing model,
+     /// actor, and light object.
+     /// \param[in] _model The model to use.
+diff --git a/src/Link.cc b/src/Link.cc
+index 19c3569f..610e5d40 100644
+--- src/Link.cc
++++ src/Link.cc
+@@ -940,6 +940,13 @@ bool Link::AddVisual(const Visual &_visual)
+   if (this->VisualNameExists(_visual.Name()))
+     return false;
+   this->dataPtr->visuals.push_back(_visual);
++
++  // Configure the visual's pose-relative-to graph in case the visual gets
++  // added *after* the Link has been configured.
++  auto& visual = this->dataPtr->visuals.back();
++  visual.SetXmlParentName(this->dataPtr->name);
++  visual.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
++
+   return true;
+ }
+ 
+diff --git a/src/Root.cc b/src/Root.cc
+index 03349d2a..c15cf8d5 100644
+--- src/Root.cc
++++ src/Root.cc
+@@ -475,6 +475,12 @@ const Model *Root::Model() const
+   return std::get_if<sdf::Model>(&this->dataPtr->modelLightOrActor);
+ }
+ 
++/////////////////////////////////////////////////
++Model *Root::Model()
++{
++  return std::get_if<sdf::Model>(&this->dataPtr->modelLightOrActor);
++}
++
+ /////////////////////////////////////////////////
+ void Root::SetModel(const sdf::Model &_model)
+ {

--- a/tools/workspace/sdformat_internal/repository.bzl
+++ b/tools/workspace/sdformat_internal/repository.bzl
@@ -19,6 +19,7 @@ def sdformat_internal_repository(
             ":patches/no_global_config.patch",
             ":patches/no_share_path.patch",
             ":patches/no_urdf.patch",
+            ":patches/upstream/support_drake_visual.patch",
         ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
This introduces a working example of an sdf file.

Closes: #13689

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22013)
<!-- Reviewable:end -->
